### PR TITLE
fix: ターミナルの色表示とIME予測変換を修正

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -55,13 +55,17 @@ pub fn spawn_pty(
         })
         .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-    #[cfg(target_os = "windows")]
-    let shell = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
+    let mut cmd = CommandBuilder::new_default_prog();
 
     #[cfg(not(target_os = "windows"))]
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    {
+        cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
+        if std::env::var("LANG").is_err() {
+            cmd.env("LANG", "en_US.UTF-8");
+        }
+    }
 
-    let mut cmd = CommandBuilder::new(shell);
     if let Some(dir) = cwd {
         cmd.cwd(dir);
     }


### PR DESCRIPTION
## Summary
- PTY起動時に `CommandBuilder::new_default_prog()` を使用してログインシェルとして起動するよう変更。Finder起動時でも `.zprofile` 等が読み込まれ、`PATH`/`LANG` が正しく設定される
- `TERM=xterm-256color`, `COLORTERM=truecolor` を環境変数に設定し、CLI ツールのカラー出力を有効化
- `LANG` 未設定時のフォールバックとして `en_US.UTF-8` を設定し、IME/日本語入力の動作を保証

## Test plan
- [ ] `cargo clippy --lib` — 警告なし確認済み
- [ ] `cargo test --lib` — 33テスト全パス確認済み
- [ ] `npx vitest run` — 237テスト全パス確認済み
- [ ] アプリ起動後、ターミナルで `echo $TERM` → `xterm-256color` を確認
- [ ] `ls` でカラー出力されることを確認
- [ ] 日本語IMEで予測変換が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ターミナル環境の設定を改善しました。クロスプラットフォームで一貫性のあるシェル動作を実現し、非Windows環境では256色対応とUTF-8言語設定を自動設定するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->