### PR TITLE
ci: Apple署名・公証を1Password経由でCI自動化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,18 @@ jobs:
           workspaces: src-tauri
           key: macos-universal
 
+      - uses: 1password/load-secrets-action@v3
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          APPLE_CERTIFICATE: op://releash/apple-signing/certificate
+          APPLE_CERTIFICATE_PASSWORD: op://releash/apple-signing/certificate-password
+          APPLE_SIGNING_IDENTITY: op://releash/apple-signing/signing-identity
+          APPLE_ID: op://releash/apple-signing/apple-id
+          APPLE_PASSWORD: op://releash/apple-signing/app-password
+          APPLE_TEAM_ID: op://releash/apple-signing/team-id
+        with:
+          export-env: true
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- リリースワークフローに1Password load-secrets-action v3を導入
- Apple署名・公証に必要な6つのシークレットを1Password経由で注入
- GitHub Secretsは `OP_SERVICE_ACCOUNT_TOKEN` の1つのみに集約

## Test plan
- [ ] タグpushでリリースワークフローを実行
- [ ] リリースページの.dmgをダウンロードしてGatekeeper警告なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)