### PR TITLE
fix: セキュリティ監査指摘のCRITICAL/HIGH修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"diff": "^8.0.3",
+		"dompurify": "^3.3.1",
 		"html5-qrcode": "^2.3.8",
 		"lucide-react": "^0.563.0",
 		"monaco-editor": "^0.55.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       diff:
         specifier: ^8.0.3
         version: 8.0.3
+      dompurify:
+        specifier: ^3.3.1
+        version: 3.3.1
       html5-qrcode:
         specifier: ^2.3.8
         version: 2.3.8
@@ -1769,6 +1772,9 @@ packages:
 
   dompurify@3.2.7:
     resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
@@ -3838,6 +3844,10 @@ snapshots:
   dom-accessibility-api@0.6.3: {}
 
   dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  dompurify@3.3.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -114,6 +114,13 @@ pub fn write_config(path: &Path, config: &ReleashConfig) -> Result<(), String> {
     fs::write(&tmp_path, &content).map_err(|e| format!("一時ファイル書き込み失敗: {e}"))?;
     fs::rename(&tmp_path, path).map_err(|e| format!("ファイルのリネーム失敗: {e}"))?;
 
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("パーミッション設定失敗: {e}"))?;
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -90,6 +90,7 @@ pub struct WsServerState {
     repo_path: Option<String>,
     app_config: Arc<AppConfig>,
     app_handle: Option<tauri::AppHandle>,
+    tls_enabled: bool,
 }
 
 impl WsServerState {
@@ -100,6 +101,7 @@ impl WsServerState {
         repo_path: Option<String>,
         app_config: Arc<AppConfig>,
         app_handle: Option<tauri::AppHandle>,
+        tls_enabled: bool,
     ) -> Self {
         Self {
             active_connection: Arc::new(Mutex::new(false)),
@@ -110,6 +112,7 @@ impl WsServerState {
             repo_path,
             app_config,
             app_handle,
+            tls_enabled,
         }
     }
 
@@ -525,6 +528,21 @@ fn join_error_msg(e: tokio::task::JoinError) -> WsMessage {
     })
 }
 
+fn apply_security_headers(
+    builder: hyper::http::response::Builder,
+    tls_enabled: bool,
+) -> hyper::http::response::Builder {
+    let builder = builder
+        .header("X-Content-Type-Options", "nosniff")
+        .header("X-Frame-Options", "DENY")
+        .header("Referrer-Policy", "strict-origin-when-cross-origin");
+    if tls_enabled {
+        builder.header("Strict-Transport-Security", "max-age=31536000")
+    } else {
+        builder
+    }
+}
+
 fn content_type_for(path: &str) -> &'static str {
     if path.ends_with(".html") {
         "text/html; charset=utf-8"
@@ -652,10 +670,11 @@ async fn handle_http(
     state: Arc<WsServerState>,
 ) -> Response<Full<Bytes>> {
     let path = req.uri().path().to_string();
+    let tls = state.tls_enabled;
     if is_ws_upgrade(&req) {
         match handle_ws_upgrade(req, peer_addr, state) {
             Ok(resp) => resp,
-            Err(e) => error_response(StatusCode::BAD_REQUEST, &e),
+            Err(e) => error_response(StatusCode::BAD_REQUEST, &e, tls),
         }
     } else {
         serve_pwa(&path, &state)
@@ -708,7 +727,13 @@ fn handle_ws_upgrade(
 fn serve_pwa(path: &str, state: &WsServerState) -> Response<Full<Bytes>> {
     let pwa_dir = match &state.pwa_dir {
         Some(d) => d,
-        None => return error_response(StatusCode::NOT_FOUND, "PWA is not available"),
+        None => {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                "PWA is not available",
+                state.tls_enabled,
+            )
+        }
     };
 
     let file_path = match path {
@@ -716,41 +741,42 @@ fn serve_pwa(path: &str, state: &WsServerState) -> Response<Full<Bytes>> {
         p => p.trim_start_matches('/'),
     };
 
+    let tls = state.tls_enabled;
     let full_path = pwa_dir.join(file_path);
     if let (Ok(canonical), Ok(pwa_canonical)) = (full_path.canonicalize(), pwa_dir.canonicalize()) {
         if !canonical.starts_with(&pwa_canonical) {
-            return error_response(StatusCode::FORBIDDEN, "Access denied");
+            return error_response(StatusCode::FORBIDDEN, "Access denied", tls);
         }
         match std::fs::read(&canonical) {
             Ok(content) => {
                 let ct = content_type_for(canonical.to_str().unwrap_or(""));
-                Response::builder()
+                apply_security_headers(Response::builder(), tls)
                     .status(StatusCode::OK)
                     .header("Content-Type", ct)
                     .header("Cache-Control", "no-cache")
                     .body(Full::new(Bytes::from(content)))
                     .unwrap()
             }
-            Err(_) => serve_pwa_fallback(pwa_dir),
+            Err(_) => serve_pwa_fallback(pwa_dir, tls),
         }
     } else {
-        serve_pwa_fallback(pwa_dir)
+        serve_pwa_fallback(pwa_dir, tls)
     }
 }
 
-fn serve_pwa_fallback(pwa_dir: &std::path::Path) -> Response<Full<Bytes>> {
+fn serve_pwa_fallback(pwa_dir: &std::path::Path, tls_enabled: bool) -> Response<Full<Bytes>> {
     match std::fs::read(pwa_dir.join("pwa.html")) {
-        Ok(content) => Response::builder()
+        Ok(content) => apply_security_headers(Response::builder(), tls_enabled)
             .status(StatusCode::OK)
             .header("Content-Type", "text/html; charset=utf-8")
             .body(Full::new(Bytes::from(content)))
             .unwrap(),
-        Err(_) => error_response(StatusCode::NOT_FOUND, "Not Found"),
+        Err(_) => error_response(StatusCode::NOT_FOUND, "Not Found", tls_enabled),
     }
 }
 
-fn error_response(status: StatusCode, msg: &str) -> Response<Full<Bytes>> {
-    Response::builder()
+fn error_response(status: StatusCode, msg: &str, tls_enabled: bool) -> Response<Full<Bytes>> {
+    apply_security_headers(Response::builder(), tls_enabled)
         .status(status)
         .body(Full::new(Bytes::from(msg.to_string())))
         .unwrap()
@@ -1063,6 +1089,7 @@ pub async fn start_server(
         Some(root_path),
         Arc::clone(config_state.inner()),
         Some(app.clone()),
+        cfg.server.tls.enabled,
     ));
 
     start_ws_server(&cfg, server_state, shutdown_rx).await?;
@@ -1206,6 +1233,7 @@ mod tests {
             None,
             app_config,
             None,
+            false,
         )
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss: http: https:; worker-src 'self' blob:"
     }
   },
   "bundle": {

--- a/src/components/panels/RemotePanel.tsx
+++ b/src/components/panels/RemotePanel.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from "dompurify";
 import { Copy, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import {
@@ -182,8 +183,12 @@ export function RemotePanel({ rootPath }: RemotePanelProps) {
 							</span>
 							<div
 								className="w-full flex justify-center"
-								// biome-ignore lint/security/noDangerouslySetInnerHtml: QR SVG from trusted backend
-								dangerouslySetInnerHTML={{ __html: qrData.svg }}
+								// biome-ignore lint/security/noDangerouslySetInnerHtml: SVG sanitized by DOMPurify
+								dangerouslySetInnerHTML={{
+									__html: DOMPurify.sanitize(qrData.svg, {
+										USE_PROFILES: { svg: true },
+									}),
+								}}
 							/>
 							<div className="flex items-center gap-1">
 								<span className="flex-1 text-[10px] text-muted-foreground font-mono truncate">
@@ -209,8 +214,12 @@ export function RemotePanel({ rootPath }: RemotePanelProps) {
 							</span>
 							<div
 								className="w-full flex justify-center"
-								// biome-ignore lint/security/noDangerouslySetInnerHtml: QR SVG from trusted backend
-								dangerouslySetInnerHTML={{ __html: qrData.token_svg }}
+								// biome-ignore lint/security/noDangerouslySetInnerHtml: SVG sanitized by DOMPurify
+								dangerouslySetInnerHTML={{
+									__html: DOMPurify.sanitize(qrData.token_svg, {
+										USE_PROFILES: { svg: true },
+									}),
+								}}
 							/>
 							<div className="flex items-center gap-1">
 								<span className="flex-1 text-[10px] text-muted-foreground font-mono truncate bg-muted border border-border rounded px-2 py-1">


### PR DESCRIPTION
## Summary
- **C-1 (CRITICAL):** CSP有効化 — `csp: null` をMonaco Editor/WebSocket対応の具体的なCSPに変更
- **H-1:** PWAセキュリティヘッダー — `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` を共通ヘルパーで付与、TLS時はHSTSも追加
- **H-2:** DOMPurifyサニタイズ — QR SVG挿入を `DOMPurify.sanitize()` で防御
- **H-3:** 設定ファイルパーミッション — `write_config` 後にUnixで `0o600` を設定

## Test plan
- [ ] アプリ起動してMonaco Editor表示・diff表示・ファイル編集・ターミナル・検索が正常に動作すること（CSP検証）
- [ ] PWAサーバー起動後 `curl -I` でセキュリティヘッダー存在確認
- [ ] QR表示が正常に動作すること（DOMPurifyでSVGが壊れないこと）
- [ ] `ls -la ~/.config/releash/releash.toml` で `-rw-------` を確認
- [ ] 全既存テスト通過確認済み（Rust 105件、Vitest 247件、tsc/biome/clippy/fmt）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ強化**
  * TLS有効時にセキュリティヘッダーを自動適用
  * コンテンツセキュリティポリシーを明示的に設定してアプリケーション保護を強化
  * リモートパネルのSVGコンテンツをサニタイズし、注入攻撃を防止

* **その他の改善**
  * ファイル権限の安全性を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->