### PR TITLE
fix: 接続/再接続時の自動Enter送信を削除

### DIFF
--- a/src/pwa/hooks/useRemoteTerminal.ts
+++ b/src/pwa/hooks/useRemoteTerminal.ts
@@ -153,7 +153,6 @@ export function useRemoteTerminal({
 					type: "pty_output_request",
 					payload: { pty_id: ptyId },
 				});
-				send({ type: "pty_input", payload: { pty_id: ptyId, data: "\r" } });
 			}
 		});
 


### PR DESCRIPTION
## Summary
- PWAリモートターミナルで接続/再接続時に自動送信していた `\r`（Enter）を削除
- ターミナル上の実行中プロセス（確認プロンプト等）に意図しないEnterが送られる副作用を修正
- `pty_output_request` によるバッファ同期のみ残す

## Test plan
- [ ] `npx tsc --noEmit` パス確認済み
- [ ] `npx vitest run` 全247テストパス確認済み
- [ ] モバイルからPWAに接続し、確認プロンプト表示中に再接続しても自動Enterが送られないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * リモートターミナルの初期化処理を改善し、不要な自動入力動作を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->