### PR TITLE
fix: Monaco EditorをローカルバンドルしCSP違反を解消

### DIFF
--- a/src/lib/monaco-setup.ts
+++ b/src/lib/monaco-setup.ts
@@ -1,0 +1,22 @@
+import { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
+
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+self.MonacoEnvironment = {
+	getWorker(_, label) {
+		if (label === "json") return new jsonWorker();
+		if (label === "css" || label === "scss" || label === "less")
+			return new cssWorker();
+		if (label === "html" || label === "handlebars" || label === "razor")
+			return new htmlWorker();
+		if (label === "typescript" || label === "javascript") return new tsWorker();
+		return new editorWorker();
+	},
+};
+
+loader.config({ monaco });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "./lib/monaco-setup";
 import App from "./App";
 import "./index.css";
 


### PR DESCRIPTION
## Summary
- CSP有効化(bca86a0)により`script-src 'self'`が設定され、`@monaco-editor/react`のデフォルトCDN(jsDelivr)ロードがブロックされエディタが表示不能になっていた
- `monaco-editor`をViteのworkerインポートでローカルバンドルし、CDN依存を完全に排除
- `src/lib/monaco-setup.ts`を新規作成し、`src/main.tsx`で副作用インポートすることで`loader.init()`より前にローカル設定を適用

## Test plan
- [ ] `pnpm tauri dev` でアプリ起動 → エディタが表示されることを確認
- [ ] DevToolsのConsoleにCSP違反エラーがないことを確認
- [ ] DevToolsのNetworkタブでjsDelivr等への外部リクエストがないことを確認
- [ ] `npx tsc --noEmit` — 型チェック通過 ✅
- [ ] `npx vitest run` — 全247テスト通過 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Monaco Editorの統合設定を追加しました。JSON、CSS、HTML、TypeScript、JavaScriptなど複数の言語に対応した動的なワーカーロード機能が実装されています。これにより、コードエディター機能が初期化時に適切に構成されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->