### PR TITLE
fix: ビルド時のMonaco Editor行番号消失とSidebar重なりを修正

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss: http: https:; worker-src 'self' blob:"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss: http: https:; worker-src 'self' blob:"
     }
   },
   "bundle": {

--- a/src/components/panels/EditorPanel.tsx
+++ b/src/components/panels/EditorPanel.tsx
@@ -443,7 +443,10 @@ export function EditorPanel({
 			<Group orientation="vertical" className="flex-1">
 				<Panel id="editor-main" defaultSize={70} minSize={30}>
 					<div className="flex flex-col h-full">
-						<div className="flex-1 overflow-hidden">
+						<div
+							className="flex-1"
+							style={{ position: "relative", overflow: "hidden" }}
+						>
 							{activeTab ? (
 								<MonacoDiffViewer
 									key={activeTab.path}

--- a/src/components/panels/MonacoDiffViewer.test.tsx
+++ b/src/components/panels/MonacoDiffViewer.test.tsx
@@ -15,11 +15,10 @@ describe("MonacoDiffViewer", () => {
 			/>,
 		);
 
-		expect(container.firstChild).toHaveClass(
-			"h-full",
-			"w-full",
-			"bg-background",
-		);
+		const el = container.firstChild as HTMLElement;
+		expect(el).toHaveClass("bg-background");
+		expect(el.style.position).toBe("absolute");
+		expect(el.style.inset).toBe("0");
 	});
 
 	it("should apply custom className", () => {
@@ -42,7 +41,10 @@ describe("MonacoDiffViewer", () => {
 			/>,
 		);
 
-		expect(container.querySelector(".h-full.w-full")).toBeInTheDocument();
+		const editors = container.querySelectorAll<HTMLElement>(
+			"[style*='height: 100%']",
+		);
+		expect(editors.length).toBeGreaterThan(0);
 	});
 
 	it("should render gutter mode when diffMode is gutter", () => {
@@ -54,7 +56,10 @@ describe("MonacoDiffViewer", () => {
 			/>,
 		);
 
-		expect(container.querySelector(".h-full.w-full")).toBeInTheDocument();
+		const editors = container.querySelectorAll<HTMLElement>(
+			"[style*='height: 100%']",
+		);
+		expect(editors.length).toBeGreaterThan(0);
 	});
 
 	it("should render inline mode when diffMode is inline", () => {
@@ -66,6 +71,9 @@ describe("MonacoDiffViewer", () => {
 			/>,
 		);
 
-		expect(container.querySelector(".h-full.w-full")).toBeInTheDocument();
+		const editors = container.querySelectorAll<HTMLElement>(
+			"[style*='height: 100%']",
+		);
+		expect(editors.length).toBeGreaterThan(0);
 	});
 });

--- a/src/components/panels/MonacoDiffViewer.tsx
+++ b/src/components/panels/MonacoDiffViewer.tsx
@@ -236,7 +236,7 @@ function GutterEditor({
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
-				<div ref={containerRef} className="h-full w-full" />
+				<div ref={containerRef} style={{ height: "100%", width: "100%" }} />
 			</ContextMenuTrigger>
 			<EditorContextMenuContent actions={actions} />
 		</ContextMenu>
@@ -309,7 +309,7 @@ function DiffEditor({
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
-				<div ref={containerRef} className="h-full w-full" />
+				<div ref={containerRef} style={{ height: "100%", width: "100%" }} />
 			</ContextMenuTrigger>
 			<EditorContextMenuContent actions={actions} />
 		</ContextMenu>
@@ -377,7 +377,10 @@ export function MonacoDiffViewer({
 		: undefined;
 
 	return (
-		<div className={cn("h-full w-full bg-background", className)}>
+		<div
+			style={{ position: "absolute", inset: 0 }}
+			className={cn("bg-background", className)}
+		>
 			{diffMode === "gutter" && (
 				<GutterEditor
 					originalContent={originalContent}

--- a/src/index.css
+++ b/src/index.css
@@ -163,6 +163,16 @@
 	}
 }
 
+/*
+ * Isolate each resizable panel into its own stacking context.
+ * Without this, Monaco Editor's high z-index elements paint on top of
+ * adjacent panels (e.g. Sidebar) in production builds.
+ * Must be outside @layer to avoid being overridden by Monaco's runtime CSS.
+ */
+[data-panel] {
+	isolation: isolate;
+}
+
 /* Monaco Editor Gutter Decorations */
 .gutter-added {
 	background-color: var(--status-added);


### PR DESCRIPTION
## Summary
- CSPの`style-src`に`https://cdn.jsdelivr.net`が未許可で、MonacoのCDN CSSがブロックされ行番号が表示されなかった
- エディタ領域に`position: absolute; inset: 0`の絶対配置を適用し、Sidebar重なりを防止
- `[data-panel] { isolation: isolate }` でパネル間のz-index汚染を分離

## Test plan
- [x] `pnpm test` 全250件通過
- [x] `pnpm lint` 通過
- [ ] `pnpm tauri build` でビルドしたアプリで行番号が表示されることを確認
- [ ] gutter / inline / split の3モード全てで正常表示
- [ ] Sidebar領域にエディタが重ならないことを確認
- [ ] DevToolsのConsoleにCSP違反エラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 複数パネル環境での差分エディタの表示が改善されました。

* **Chores**
  * セキュリティ設定が更新されました。
  * テストとエディタのレイアウト処理が最適化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->