### PR TITLE
fix: リモートビュー再表示時のQRコード消失を修正

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ pub fn run() {
             ws_server::commands::start_server,
             ws_server::commands::stop_server,
             ws_server::commands::get_server_status,
+            ws_server::commands::get_server_info,
             ws_server::commands::broadcast_comments,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/ws_server/commands.rs
+++ b/src-tauri/src/ws_server/commands.rs
@@ -117,6 +117,22 @@ pub fn get_server_status(handle: tauri::State<'_, WsServerHandle>) -> bool {
     *handle.running.lock()
 }
 
+#[derive(serde::Serialize)]
+pub struct ServerInfo {
+    pub running: bool,
+    pub bound_ip: Option<String>,
+    pub connection_mode: Option<String>,
+}
+
+#[tauri::command]
+pub fn get_server_info(handle: tauri::State<'_, WsServerHandle>) -> ServerInfo {
+    ServerInfo {
+        running: handle.is_running(),
+        bound_ip: handle.active_bind(),
+        connection_mode: handle.connection_mode(),
+    }
+}
+
 #[tauri::command]
 pub fn broadcast_comments(
     comments: crate::protocol::CommentSync,

--- a/src-tauri/src/ws_server/mod.rs
+++ b/src-tauri/src/ws_server/mod.rs
@@ -51,6 +51,14 @@ impl WsServerHandle {
     pub fn is_tls_enabled(&self) -> bool {
         *self.tls_enabled.lock()
     }
+
+    pub fn connection_mode(&self) -> Option<String> {
+        self.connection_mode.lock().clone()
+    }
+
+    pub fn is_running(&self) -> bool {
+        *self.running.lock()
+    }
 }
 
 pub(crate) struct WsServerState {

--- a/src/hooks/useRemoteServer.ts
+++ b/src/hooks/useRemoteServer.ts
@@ -18,6 +18,12 @@ interface DetectedInterface {
 	kind: "vpn" | "lan";
 }
 
+interface ServerInfo {
+	running: boolean;
+	bound_ip: string | null;
+	connection_mode: "vpn" | "lan" | null;
+}
+
 interface StartServerResult {
 	ip: string;
 	mode: "vpn" | "lan";
@@ -62,8 +68,12 @@ export function useRemoteServer() {
 
 	const refreshStatus = useCallback(async () => {
 		try {
-			const status = await invoke<boolean>("get_server_status");
-			setRunning(status);
+			const info = await invoke<ServerInfo>("get_server_info");
+			setRunning(info.running);
+			if (info.running) {
+				setBoundIp(info.bound_ip);
+				setConnectionMode(info.connection_mode);
+			}
 		} catch (e) {
 			setError(String(e));
 		}
@@ -84,6 +94,12 @@ export function useRemoteServer() {
 			setError(String(e));
 		}
 	}, []);
+
+	useEffect(() => {
+		if (running && !qrData) {
+			refreshQr();
+		}
+	}, [running, qrData, refreshQr]);
 
 	const doStartServer = useCallback(
 		async (rootPath: string, bindIp: string) => {


### PR DESCRIPTION
## Summary
- RemotePanelの条件付きレンダリング（`showRemote && ...`）によるアンマウント/再マウント時に、`useRemoteServer`フックの`qrData`/`boundIp`/`connectionMode`が復元されない問題を修正
- Rust側に`get_server_info`コマンドを追加し、`running`/`bound_ip`/`connection_mode`を一括取得可能に
- フロントエンド側で再マウント時にバックエンドからサーバー状態を再取得し、QRデータも自動再フェッチ

## Test plan
- [x] Rust: `cargo test` 全171件通過
- [x] Frontend: `pnpm test` 全288件通過
- [x] `pnpm lint` 通過
- [x] `cargo check` 通過

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * サーバーの実行状態、バインドIP、接続モードをクエリできる新しいサーバー情報エンドポイントを追加しました。
  * サーバー起動時にQRデータが存在しない場合、自動的にQRデータを更新する機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->