### PR TITLE
fix: カンバンカラムの横幅を320pxに固定

### DIFF
--- a/src/components/workspace/KanbanColumn.tsx
+++ b/src/components/workspace/KanbanColumn.tsx
@@ -14,7 +14,7 @@ export function KanbanColumn({
 	children,
 }: KanbanColumnProps) {
 	return (
-		<div className="flex flex-col min-h-0 rounded-lg border border-border bg-card/30">
+		<div className="flex flex-col min-h-0 w-80 shrink-0 rounded-lg border border-border bg-card/30">
 			<div className="flex items-center gap-2 px-3 py-2 border-b border-border shrink-0">
 				{icon}
 				<span className="text-xs font-semibold">{title}</span>

--- a/src/screens/WorkspaceManagerScreen.tsx
+++ b/src/screens/WorkspaceManagerScreen.tsx
@@ -261,7 +261,7 @@ export function WorkspaceManagerScreen({
 							<p className="text-muted-foreground">Loading...</p>
 						</div>
 					) : (
-						<div className="grid grid-cols-3 gap-3 h-full">
+						<div className="flex gap-3 h-full overflow-x-auto">
 							<KanbanColumn
 								icon={<CircleDot className="size-3.5 text-muted-foreground" />}
 								title="Todo"


### PR DESCRIPTION
## Summary
- カンバンカラムの横幅を320px固定に変更（`w-80 shrink-0`）
- 親コンテナを`grid grid-cols-3`から`flex overflow-x-auto`に変更し、画面幅が狭い場合は横スクロールで対応

closes #108

## Test plan
- [ ] カンバンボードの各カラムが320px固定幅で表示されることを確認
- [ ] 画面幅を縮めた際に横スクロールが発生することを確認
- [ ] Remoteパネル表示時もレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)