### PR TITLE
feat: ReviewPanelにユーザー操作用ターミナルタブを追加

### DIFF
--- a/src/components/panels/EditorPanel.tsx
+++ b/src/components/panels/EditorPanel.tsx
@@ -585,6 +585,8 @@ export function EditorPanel({
 						comments={comments ?? []}
 						onCommentClick={handleCommentClick}
 						onSendToTerminal={onSendToTerminal}
+						cwd={rootPath}
+						theme={theme}
 					/>
 				</Panel>
 			</Group>

--- a/src/components/panels/ReviewPanel.test.tsx
+++ b/src/components/panels/ReviewPanel.test.tsx
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { LineComment } from "@/types/comment";
 import { ReviewPanel } from "./ReviewPanel";
 
+vi.mock("./TerminalPanel", () => ({
+	TerminalPanel: () => <div data-testid="terminal-panel" />,
+}));
+
 function makeComment(overrides: Partial<LineComment> = {}): LineComment {
 	return {
 		id: "c-1",
@@ -17,17 +21,29 @@ function makeComment(overrides: Partial<LineComment> = {}): LineComment {
 }
 
 describe("ReviewPanel", () => {
-	it("should render Comments header", () => {
+	it("should render Terminal and Comments tab buttons", () => {
 		render(<ReviewPanel comments={[]} />);
+		expect(screen.getByText("Terminal")).toBeInTheDocument();
 		expect(screen.getByText("Comments")).toBeInTheDocument();
 	});
 
-	it("should show empty state when no comments", () => {
+	it("should default to terminal tab", () => {
 		render(<ReviewPanel comments={[]} />);
+		expect(screen.getByRole("tab", { name: /Terminal/ })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+		expect(screen.getByTestId("terminal-panel")).toBeInTheDocument();
+	});
+
+	it("should show empty state when switching to comments tab with no comments", async () => {
+		const user = userEvent.setup();
+		render(<ReviewPanel comments={[]} />);
+		await user.click(screen.getByText("Comments"));
 		expect(screen.getByText("コメントなし")).toBeInTheDocument();
 	});
 
-	it("should show unsent count badge", () => {
+	it("should show unsent count badge on comments tab", () => {
 		render(
 			<ReviewPanel
 				comments={[
@@ -39,10 +55,12 @@ describe("ReviewPanel", () => {
 		expect(screen.getByText("1")).toBeInTheDocument();
 	});
 
-	it("should show Send button when unsent comments exist", () => {
+	it("should show Send button when comments tab is active and unsent comments exist", async () => {
+		const user = userEvent.setup();
 		render(
 			<ReviewPanel comments={[makeComment()]} onSendToTerminal={vi.fn()} />,
 		);
+		await user.click(screen.getByText("Comments"));
 		expect(screen.getByText("Send")).toBeInTheDocument();
 	});
 
@@ -56,6 +74,7 @@ describe("ReviewPanel", () => {
 				onSendToTerminal={onSend}
 			/>,
 		);
+		await user.click(screen.getByText("Comments"));
 		await user.click(screen.getByText("Send"));
 		expect(onSend).toHaveBeenCalledWith([unsent]);
 	});

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -1,44 +1,97 @@
 import { Send } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
 import type { LineComment } from "@/types/comment";
+import type { Theme } from "@/types/settings";
 import { CommentList } from "./CommentList";
+import { TerminalPanel } from "./TerminalPanel";
 
 export interface ReviewPanelProps {
 	comments: LineComment[];
 	onCommentClick?: (filePath: string, lineNumber: number) => void;
 	onSendToTerminal?: (comments: LineComment[]) => void;
+	cwd?: string | null;
+	theme?: Theme;
 }
+
+type ReviewTab = "terminal" | "comments";
 
 export function ReviewPanel({
 	comments,
 	onCommentClick,
 	onSendToTerminal,
+	cwd,
+	theme,
 }: ReviewPanelProps) {
+	const [activeTab, setActiveTab] = useState<ReviewTab>("terminal");
 	const unsentComments = comments.filter((c) => c.status === "unsent");
 
 	return (
 		<div className="flex flex-col h-full border-t border-border">
-			<div className="flex items-center justify-between px-2 py-1 border-b border-border bg-card">
-				<span className="text-xs text-muted-foreground">
-					Comments
-					{unsentComments.length > 0 && (
-						<span className="ml-1 px-1 text-[10px] bg-primary/20 text-primary rounded">
-							{unsentComments.length}
-						</span>
-					)}
-				</span>
-				{unsentComments.length > 0 && onSendToTerminal && (
+			<div className="flex items-center justify-between border-b border-border bg-card">
+				<div className="flex items-center" role="tablist">
 					<button
 						type="button"
-						onClick={() => onSendToTerminal(unsentComments)}
-						className="flex items-center gap-1 px-2 py-0.5 text-[10px] bg-primary/20 text-primary rounded hover:bg-primary/30 transition-colors"
-						title="未送信コメントをターミナルに送信"
+						role="tab"
+						aria-selected={activeTab === "terminal"}
+						onClick={() => setActiveTab("terminal")}
+						className={cn(
+							"h-[28px] px-3 text-xs transition-colors",
+							activeTab === "terminal"
+								? "bg-background text-foreground"
+								: "bg-sidebar text-muted-foreground hover:bg-sidebar-accent",
+						)}
 					>
-						<Send className="h-3 w-3" />
-						Send
+						Terminal
 					</button>
-				)}
+					<button
+						type="button"
+						role="tab"
+						aria-selected={activeTab === "comments"}
+						onClick={() => setActiveTab("comments")}
+						className={cn(
+							"h-[28px] px-3 text-xs transition-colors",
+							activeTab === "comments"
+								? "bg-background text-foreground"
+								: "bg-sidebar text-muted-foreground hover:bg-sidebar-accent",
+						)}
+					>
+						Comments
+						{unsentComments.length > 0 && (
+							<span className="ml-1 px-1 text-[10px] bg-primary/20 text-primary rounded">
+								{unsentComments.length}
+							</span>
+						)}
+					</button>
+				</div>
+				{activeTab === "comments" &&
+					unsentComments.length > 0 &&
+					onSendToTerminal && (
+						<button
+							type="button"
+							onClick={() => onSendToTerminal(unsentComments)}
+							className="flex items-center gap-1 px-2 py-0.5 mr-2 text-[10px] bg-primary/20 text-primary rounded hover:bg-primary/30 transition-colors"
+							title="未送信コメントをターミナルに送信"
+						>
+							<Send className="h-3 w-3" />
+							Send
+						</button>
+					)}
 			</div>
-			<div className="flex-1 overflow-hidden">
+			<div
+				className="flex-1 overflow-hidden"
+				style={{ display: activeTab === "terminal" ? "block" : "none" }}
+			>
+				<TerminalPanel
+					cwd={cwd}
+					theme={theme}
+					sessionKey={cwd ? `${cwd}::user` : undefined}
+				/>
+			</div>
+			<div
+				className="flex-1 overflow-hidden"
+				style={{ display: activeTab === "comments" ? "block" : "none" }}
+			>
 				<CommentList comments={comments} onCommentClick={onCommentClick} />
 			</div>
 		</div>

--- a/src/components/panels/TerminalPanel.test.tsx
+++ b/src/components/panels/TerminalPanel.test.tsx
@@ -35,6 +35,7 @@ describe("TerminalPanel", () => {
 			undefined,
 			undefined,
 			undefined,
+			undefined,
 		);
 	});
 });

--- a/src/components/panels/TerminalPanel.tsx
+++ b/src/components/panels/TerminalPanel.tsx
@@ -27,18 +27,23 @@ export interface TerminalPanelProps {
 	cwd?: string | null;
 	theme?: Theme;
 	terminalStartupCommand?: string;
+	sessionKey?: string;
 }
 
 export const TerminalPanel = forwardRef<
 	TerminalPanelHandle,
 	TerminalPanelProps
->(function TerminalPanel({ cwd, theme, terminalStartupCommand }, ref) {
+>(function TerminalPanel(
+	{ cwd, theme, terminalStartupCommand, sessionKey },
+	ref,
+) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const { terminalRef, writeToTerminal } = useTerminal(
 		containerRef,
 		cwd,
 		theme,
 		terminalStartupCommand,
+		sessionKey,
 	);
 	const [isDragOver, setIsDragOver] = useState(false);
 

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -92,6 +92,7 @@ export function useTerminal(
 	cwd?: string | null,
 	theme?: Theme,
 	terminalStartupCommand?: string,
+	sessionKey?: string,
 ) {
 	const terminalRef = useRef<Terminal | null>(null);
 	const fitAddonRef = useRef<FitAddon | null>(null);
@@ -149,11 +150,12 @@ export function useTerminal(
 			// 2. Get or spawn PTY for this worktree
 			const { rows, cols } = terminal;
 			const worktreePath = cwd ?? null;
+			const effectiveKey = sessionKey ?? worktreePath ?? "";
 			const result = await invoke<GetOrSpawnPtyResult>("get_or_spawn_pty", {
 				rows,
 				cols,
 				cwd: worktreePath,
-				worktreePath: worktreePath ?? "",
+				worktreePath: effectiveKey,
 			});
 
 			if (!isMounted) return;
@@ -225,7 +227,7 @@ export function useTerminal(
 			unlistenExit?.();
 			terminal.dispose();
 		};
-	}, [containerRef, cwd]);
+	}, [containerRef, cwd, sessionKey]);
 
 	useEffect(() => {
 		const terminal = terminalRef.current;


### PR DESCRIPTION
## Summary
- ReviewPanel（エディタ下部）にTerminal/Commentsのタブ切り替えUIを追加
- `useTerminal`に`sessionKey`パラメータを追加し、同一ワークツリーでAgent用とユーザー用の独立PTYセッションを実現
- バックエンド変更なし（`worktreePath`キーに異なる値を渡すだけ）

## Test plan
- [ ] `pnpm tauri dev`でTerminalタブでシェルコマンドが実行できることを確認
- [ ] Commentsタブでコメント一覧が表示されることを確認
- [ ] タブ切り替え後もTerminalの状態が保持されることを確認
- [ ] 右側のAgent用ターミナルと独立して動作することを確認

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)