### PR TITLE
feat: ドラッグ&ドロップでターミナルにファイルパスを挿入

### DIFF
--- a/src/components/panels/FileTree.tsx
+++ b/src/components/panels/FileTree.tsx
@@ -115,6 +115,11 @@ function FileTreeItem({
 	const itemButton = (
 		<button
 			type="button"
+			draggable
+			onDragStart={(e) => {
+				e.dataTransfer.setData("application/x-releash-file-path", node.path);
+				e.dataTransfer.effectAllowed = "copy";
+			}}
 			onClick={handleClick}
 			className={cn(
 				"flex w-full items-center gap-1 px-2 py-1 text-sm hover:bg-sidebar-accent transition-colors",

--- a/src/components/panels/TerminalPanel.test.tsx
+++ b/src/components/panels/TerminalPanel.test.tsx
@@ -2,10 +2,12 @@ import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalPanel } from "./TerminalPanel";
 
+const mockWriteToTerminal = vi.fn();
 const mockTerminalRef = { current: null };
-const mockUseTerminal = vi
-	.fn()
-	.mockReturnValue({ terminalRef: mockTerminalRef });
+const mockUseTerminal = vi.fn().mockReturnValue({
+	terminalRef: mockTerminalRef,
+	writeToTerminal: mockWriteToTerminal,
+});
 
 vi.mock("@/hooks/useTerminal", () => ({
 	useTerminal: (...args: unknown[]) => mockUseTerminal(...args),

--- a/src/components/panels/TerminalPanel.tsx
+++ b/src/components/panels/TerminalPanel.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useRef,
+	useState,
+} from "react";
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -7,6 +15,7 @@ import {
 	ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { useTerminal } from "@/hooks/useTerminal";
+import { quotePathForShell, quotePathsForShell } from "@/lib/quotePathForShell";
 import type { Theme } from "@/types/settings";
 import "@xterm/xterm/css/xterm.css";
 
@@ -29,12 +38,81 @@ export const TerminalPanel = forwardRef<
 		cwd,
 		theme,
 	);
+	const [isDragOver, setIsDragOver] = useState(false);
 
 	useImperativeHandle(
 		ref,
 		() => ({
 			writeToTerminal,
 		}),
+		[writeToTerminal],
+	);
+
+	// Tauri OS drag & drop (Finder等からのドラッグ)
+	useEffect(() => {
+		const unlisten = getCurrentWebview().onDragDropEvent((event) => {
+			const container = containerRef.current;
+			if (!container) return;
+
+			const payload = event.payload;
+
+			if (payload.type === "enter" || payload.type === "over") {
+				const rect = container.getBoundingClientRect();
+				const { x, y } = payload.position;
+				const isInside =
+					x >= rect.left &&
+					x <= rect.right &&
+					y >= rect.top &&
+					y <= rect.bottom;
+				setIsDragOver(isInside);
+			} else if (payload.type === "drop") {
+				const rect = container.getBoundingClientRect();
+				const { x, y } = payload.position;
+				const isInside =
+					x >= rect.left &&
+					x <= rect.right &&
+					y >= rect.top &&
+					y <= rect.bottom;
+				if (isInside && payload.paths.length > 0) {
+					writeToTerminal(quotePathsForShell(payload.paths));
+				}
+				setIsDragOver(false);
+			} else if (payload.type === "leave") {
+				setIsDragOver(false);
+			}
+		});
+
+		return () => {
+			unlisten.then((fn) => fn());
+		};
+	}, [writeToTerminal]);
+
+	// アプリ内 HTML5 drag & drop (FileTreeからのドラッグ)
+	const handleDragOver = useCallback((e: React.DragEvent) => {
+		if (e.dataTransfer.types.includes("application/x-releash-file-path")) {
+			e.preventDefault();
+			e.dataTransfer.dropEffect = "copy";
+			setIsDragOver(true);
+		}
+	}, []);
+
+	const handleDragLeave = useCallback((e: React.DragEvent) => {
+		if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+			setIsDragOver(false);
+		}
+	}, []);
+
+	const handleDrop = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault();
+			setIsDragOver(false);
+			const filePath = e.dataTransfer.getData(
+				"application/x-releash-file-path",
+			);
+			if (filePath) {
+				writeToTerminal(quotePathForShell(filePath));
+			}
+		},
 		[writeToTerminal],
 	);
 
@@ -61,7 +139,25 @@ export const TerminalPanel = forwardRef<
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
-				<div ref={containerRef} className="h-full w-full p-2 bg-terminal-bg" />
+				<div
+					role="application"
+					className="relative h-full w-full"
+					onDragOver={handleDragOver}
+					onDragLeave={handleDragLeave}
+					onDrop={handleDrop}
+				>
+					<div
+						ref={containerRef}
+						className="h-full w-full p-2 bg-terminal-bg"
+					/>
+					{isDragOver && (
+						<div className="absolute inset-0 flex items-center justify-center bg-primary/10 border-2 border-dashed border-primary rounded pointer-events-none">
+							<span className="text-sm font-medium text-primary bg-background/80 px-3 py-1.5 rounded">
+								ドロップしてパスを入力
+							</span>
+						</div>
+					)}
+				</div>
 			</ContextMenuTrigger>
 			<ContextMenuContent className="w-56">
 				<ContextMenuItem onClick={handleCopy}>コピー</ContextMenuItem>

--- a/src/lib/quotePathForShell.test.ts
+++ b/src/lib/quotePathForShell.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { quotePathForShell, quotePathsForShell } from "./quotePathForShell";
+
+describe("quotePathForShell", () => {
+	it("should return plain path as-is", () => {
+		expect(quotePathForShell("/usr/local/bin/node")).toBe(
+			"/usr/local/bin/node",
+		);
+	});
+
+	it("should quote path with spaces", () => {
+		expect(quotePathForShell("/Users/me/My Documents/file.txt")).toBe(
+			"'/Users/me/My Documents/file.txt'",
+		);
+	});
+
+	it("should escape single quotes in path", () => {
+		expect(quotePathForShell("/tmp/it's a file")).toBe(
+			"'/tmp/it'\\''s a file'",
+		);
+	});
+
+	it("should quote path with special characters", () => {
+		expect(quotePathForShell("/tmp/file(1).txt")).toBe("'/tmp/file(1).txt'");
+		expect(quotePathForShell("/tmp/$HOME")).toBe("'/tmp/$HOME'");
+		expect(quotePathForShell("/tmp/a&b")).toBe("'/tmp/a&b'");
+		expect(quotePathForShell("/tmp/a*")).toBe("'/tmp/a*'");
+	});
+
+	it("should not quote simple paths", () => {
+		expect(quotePathForShell("/home/user/project/src/main.rs")).toBe(
+			"/home/user/project/src/main.rs",
+		);
+		expect(quotePathForShell("relative/path.txt")).toBe("relative/path.txt");
+	});
+});
+
+describe("quotePathsForShell", () => {
+	it("should join multiple paths with spaces", () => {
+		expect(
+			quotePathsForShell(["/tmp/a.txt", "/tmp/my file.txt", "/tmp/b.txt"]),
+		).toBe("/tmp/a.txt '/tmp/my file.txt' /tmp/b.txt");
+	});
+
+	it("should return empty string for empty array", () => {
+		expect(quotePathsForShell([])).toBe("");
+	});
+});

--- a/src/lib/quotePathForShell.ts
+++ b/src/lib/quotePathForShell.ts
@@ -1,0 +1,10 @@
+export function quotePathForShell(path: string): string {
+	if (/[ \t'"\\!$`(){}[\]<>|;&*?#~]/.test(path)) {
+		return `'${path.replace(/'/g, "'\\''")}'`;
+	}
+	return path;
+}
+
+export function quotePathsForShell(paths: string[]): string {
+	return paths.map(quotePathForShell).join(" ");
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -29,6 +29,12 @@ vi.mock("@tauri-apps/api/event", () => ({
 	listen: vi.fn().mockResolvedValue(() => {}),
 }));
 
+vi.mock("@tauri-apps/api/webview", () => ({
+	getCurrentWebview: vi.fn().mockReturnValue({
+		onDragDropEvent: vi.fn().mockResolvedValue(() => {}),
+	}),
+}));
+
 vi.mock("@xterm/xterm", () => {
 	return {
 		Terminal: class MockTerminal {


### PR DESCRIPTION
## Summary
- FileTreeからターミナルへのドラッグ&ドロップでファイルパスを挿入する機能を実装
- アプリ内ドラッグ (HTML5 D&D) と OS外部からのドラッグ (Tauri `onDragDropEvent`) の両方に対応
- スペースや特殊文字を含むパスはシングルクォートで安全にエスケープ

## Changes
| ファイル | 内容 |
|---|---|
| `src/lib/quotePathForShell.ts` | パスクォートユーティリティ（新規） |
| `src/lib/quotePathForShell.test.ts` | ユーティリティの7テスト（新規） |
| `src/components/panels/FileTree.tsx` | FileTreeItemに`draggable`/`onDragStart`追加 |
| `src/components/panels/TerminalPanel.tsx` | ドロップ受け取り + ビジュアルフィードバック |
| `src/components/panels/TerminalPanel.test.tsx` | テストのモック修正 |
| `src/test/setup.ts` | `@tauri-apps/api/webview` グローバルモック追加 |

## Test plan
- [x] `pnpm test` 全295テスト通過
- [x] `pnpm lint` biome lint通過
- [ ] FileTreeからファイルをターミナルにドラッグ → パスが入力される
- [ ] スペース含むファイル名でクォートされる
- [ ] Finderからターミナルにドラッグ → パスが入力される
- [ ] ドラッグ中のオーバーレイ表示・ドロップ後の消去を確認

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)