### PR TITLE
feat: デスクトップの初期表示をソース管理ビューに変更 (#138)

### DIFF
--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -14,13 +14,13 @@ export interface ActivityBarItem {
 }
 
 const defaultItems: ActivityBarItem[] = [
-	{ id: "explorer", icon: <Files className="size-5" />, title: "Explorer" },
-	{ id: "search", icon: <Search className="size-5" />, title: "Search" },
 	{
 		id: "git",
 		icon: <GitBranch className="size-5" />,
 		title: "Source Control",
 	},
+	{ id: "explorer", icon: <Files className="size-5" />, title: "Explorer" },
+	{ id: "search", icon: <Search className="size-5" />, title: "Search" },
 ];
 
 const defaultBottomItems: ActivityBarItem[] = [

--- a/src/screens/WorktreeView.tsx
+++ b/src/screens/WorktreeView.tsx
@@ -58,7 +58,7 @@ export function WorktreeView({
 		closeTabsByPrefix,
 	} = useEditorTabs();
 
-	const [activeView, setActiveView] = useState<string>("explorer");
+	const [activeView, setActiveView] = useState<string>("git");
 	const { branch } = useCurrentBranch(rootPath);
 	const [ready, setReady] = useState(false);
 	const [agentState, setAgentState] = useState<AgentState | undefined>();
@@ -254,11 +254,7 @@ export function WorktreeView({
 	return (
 		<div className="flex flex-col h-full w-full overflow-hidden bg-background text-foreground">
 			<div className="flex flex-1 overflow-hidden">
-				<ActivityBar
-					activeItem={activeView}
-					onItemClick={setActiveView}
-					onGoHome={onSwitchToKanban}
-				/>
+				<ActivityBar activeItem={activeView} onItemClick={setActiveView} />
 				{!ready ? (
 					<div className="flex-1 flex items-center justify-center">
 						<Loader2 className="size-6 text-muted-foreground animate-spin" />


### PR DESCRIPTION
## Summary
- ワークツリータブの初期サイドバーをExplorerからSource Controlに変更
- ActivityBarの表示順をSource Control → Explorer → Searchに並べ替え
- ActivityBarからKanban直接遷移ボタンを削除（タブバーからは引き続きアクセス可能）

## Test plan
- [x] `npx vitest run` で全323テスト通過
- [x] biome lintチェック通過
- [ ] アプリ起動時、ワークツリータブを開くとソース管理パネルが最初に表示されること
- [ ] ActivityBarの表示順が Source Control → Explorer → Search → (下部) Settings であること
- [ ] ActivityBarにKanban移動ボタンが表示されないこと

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)