### PR TITLE
fix: Kanbanタブ切り替え時にPRステータスを即座に更新

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,6 +102,7 @@ function App() {
 						settings={settings}
 						providerStatus={providerStatus}
 						initializing={initializing}
+						isActive={activeTabId === "kanban"}
 						onSettingsSave={updateSettings}
 						onSelectWorktree={openWorktreeTab}
 						onChangeRepo={handleChangeRepo}

--- a/src/screens/WorkspaceManagerScreen.test.tsx
+++ b/src/screens/WorkspaceManagerScreen.test.tsx
@@ -135,7 +135,10 @@ function setupMockInvoke(
 	});
 }
 
-function renderScreen(repoPath: string | null = "/home/user/my-repo") {
+function renderScreen(
+	repoPath: string | null = "/home/user/my-repo",
+	isActive = true,
+) {
 	const onSelectWorktree = vi.fn();
 	const onChangeRepo = vi.fn();
 	const result = render(
@@ -143,6 +146,7 @@ function renderScreen(repoPath: string | null = "/home/user/my-repo") {
 			repoPath={repoPath}
 			settings={DEFAULT_SETTINGS}
 			providerStatus="available"
+			isActive={isActive}
 			onSettingsSave={vi.fn()}
 			onSelectWorktree={onSelectWorktree}
 			onChangeRepo={onChangeRepo}
@@ -575,6 +579,91 @@ describe("WorkspaceManagerScreen", () => {
 				"branch-list-sync",
 				expect.any(Function),
 			);
+		});
+
+		it("isActive が false→true に変わった時に refresh が呼ばれる", async () => {
+			setupMockInvoke();
+			const { rerender } = render(
+				<WorkspaceManagerScreen
+					repoPath="/home/user/my-repo"
+					settings={DEFAULT_SETTINGS}
+					providerStatus="available"
+					isActive={false}
+					onSettingsSave={vi.fn()}
+					onSelectWorktree={vi.fn()}
+					onChangeRepo={vi.fn()}
+				/>,
+			);
+
+			await act(async () => {});
+
+			const callCountBeforeActivation = mockInvoke.mock.calls.filter(
+				(c) => c[0] === "list_branches_with_status",
+			).length;
+
+			rerender(
+				<WorkspaceManagerScreen
+					repoPath="/home/user/my-repo"
+					settings={DEFAULT_SETTINGS}
+					providerStatus="available"
+					isActive={true}
+					onSettingsSave={vi.fn()}
+					onSelectWorktree={vi.fn()}
+					onChangeRepo={vi.fn()}
+				/>,
+			);
+
+			await waitFor(() => {
+				const callCountAfter = mockInvoke.mock.calls.filter(
+					(c) => c[0] === "list_branches_with_status",
+				).length;
+				expect(callCountAfter).toBeGreaterThan(callCountBeforeActivation);
+			});
+		});
+
+		it("初回マウント時 isActive=true で refresh が二重に呼ばれない", async () => {
+			setupMockInvoke();
+			renderScreen("/home/user/my-repo", true);
+
+			await act(async () => {});
+
+			// 初回マウント useEffect で1回だけ呼ばれる（遷移検知では呼ばれない）
+			const callCount = mockInvoke.mock.calls.filter(
+				(c) => c[0] === "list_branches_with_status",
+			).length;
+			expect(callCount).toBe(1);
+		});
+
+		it("isActive=false の時にポーリングが実行されない", async () => {
+			vi.useFakeTimers();
+			setupMockInvoke();
+			renderScreen("/home/user/my-repo", false);
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(100);
+			});
+
+			const callCountBefore = mockInvoke.mock.calls.filter(
+				(c) => c[0] === "list_branches_with_status",
+			).length;
+
+			Object.defineProperty(document, "visibilityState", {
+				value: "visible",
+				writable: true,
+				configurable: true,
+			});
+
+			// 30秒経過してもポーリングされない
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(60_000);
+			});
+
+			const callCountAfter = mockInvoke.mock.calls.filter(
+				(c) => c[0] === "list_branches_with_status",
+			).length;
+			expect(callCountAfter).toBe(callCountBefore);
+
+			vi.useRealTimers();
 		});
 
 		it("フォールバックポーリングが 30秒間隔で設定される", async () => {

--- a/src/screens/WorkspaceManagerScreen.tsx
+++ b/src/screens/WorkspaceManagerScreen.tsx
@@ -11,7 +11,7 @@ import {
 	Plus,
 	Settings,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import {
 	ActivityBar,
@@ -40,6 +40,7 @@ interface WorkspaceManagerScreenProps {
 	settings: AppSettings;
 	providerStatus: ProviderStatus | null;
 	initializing?: boolean;
+	isActive?: boolean;
 	onSettingsSave: (settings: AppSettings) => void;
 	onSelectWorktree: (path: string, branchName?: string) => void;
 	onChangeRepo: (path: string | null) => void;
@@ -71,6 +72,7 @@ export function WorkspaceManagerScreen({
 	settings,
 	providerStatus,
 	initializing = false,
+	isActive = true,
 	onSettingsSave,
 	onSelectWorktree,
 	onChangeRepo,
@@ -84,6 +86,7 @@ export function WorkspaceManagerScreen({
 	const [openingBranch, setOpeningBranch] = useState<string | null>(null);
 	const [baseBranchLabel, setBaseBranchLabel] = useState<string>("");
 	const [folderLoading, setFolderLoading] = useState(false);
+	const prevActiveRef = useRef(isActive);
 
 	const activityBarItems: ActivityBarItem[] = useMemo(
 		() => [
@@ -251,14 +254,22 @@ export function WorkspaceManagerScreen({
 	}, []);
 
 	useEffect(() => {
-		if (!repoPath) return;
+		if (!repoPath || !isActive) return;
 		const id = setInterval(() => {
 			if (document.visibilityState === "visible") {
 				refresh();
 			}
 		}, 30000);
 		return () => clearInterval(id);
-	}, [repoPath, refresh]);
+	}, [repoPath, isActive, refresh]);
+
+	useEffect(() => {
+		const wasActive = prevActiveRef.current;
+		prevActiveRef.current = isActive;
+		if (isActive && !wasActive) {
+			refresh();
+		}
+	}, [isActive, refresh]);
 
 	const handleOpenBranch = useCallback(
 		async (branch: BranchCard) => {


### PR DESCRIPTION
## Summary
- `WorkspaceManagerScreen` に `isActive` prop を追加し、非アクティブ→アクティブ遷移時に `refresh()` を呼ぶことでPRバッジを即座に反映
- 非アクティブ時のポーリングを停止し、不要なAPIコールを削減
- `prevActiveRef` で初回マウント時の二重呼び出しを回避

Closes #175

## Test plan
- [x] `isActive` が `false→true` に変わった時に refresh が呼ばれる
- [x] 初回マウント時 `isActive=true` で refresh が二重に呼ばれない
- [x] `isActive=false` の時にポーリングが実行されない
- [x] 既存テスト27件全通過
- [x] biome lint通過
- [ ] 手動確認: Kanban→Worktree→PR作成→Kanbanに戻る → PRバッジが即座に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワークスペースマネージャーのアクティブ状態制御機能を追加しました
  * コンポーネントがアクティブに切り替わった際、自動的にデータを更新するようになりました
  * アクティブでない場合はポーリングを停止し、アプリケーションのパフォーマンスを向上させます

<!-- end of auto-generated comment: release notes by coderabbit.ai -->