### PR TITLE
fix: ターミナル背景色を他パネルと統一 (#152)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,7 @@
 	--sidebar-ring: oklch(0.65 0.18 220);
 
 	/* ターミナル */
-	--terminal-bg: oklch(0.14 0 0);
+	--terminal-bg: var(--background);
 	--terminal-foreground: oklch(0.85 0 0);
 	--terminal-green: oklch(0.7 0.2 145);
 	--terminal-yellow: oklch(0.8 0.15 85);
@@ -82,7 +82,7 @@
 	--sidebar-border: oklch(0.85 0.005 260);
 	--sidebar-ring: oklch(0.55 0.18 220);
 
-	--terminal-bg: oklch(0.98 0 0);
+	--terminal-bg: var(--background);
 	--terminal-foreground: oklch(0.2 0 0);
 	--terminal-green: oklch(0.5 0.2 145);
 	--terminal-yellow: oklch(0.6 0.15 85);


### PR DESCRIPTION
## Summary
- ターミナルの背景色がエディタ等の他パネルと異なっていた問題を修正
- `--terminal-bg` CSS変数をハードコード値から `var(--background)` に変更し、ダーク・ライト両テーマで自動同期
- xterm.jsの描画領域もコンテナのCSS値を読み取るため自動的に統一される

## Test plan
- [ ] `npm run dev`でダークテーマのターミナル背景色がエディタ領域と一致することを確認
- [ ] ライトテーマに切り替えて同様に確認
- [ ] xterm.js描画領域とコンテナのパディング部分(p-2)の色が一致していることを確認

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)