### PR TITLE
fix: ターミナルUIがStatusBarに重なるレイアウトバグを修正 (#158)

### DIFF
--- a/src/components/panels/EditorPanel.tsx
+++ b/src/components/panels/EditorPanel.tsx
@@ -433,7 +433,7 @@ export function EditorPanel({
 		: undefined;
 
 	return (
-		<div className="flex flex-col h-full">
+		<div className="flex flex-col h-full overflow-hidden">
 			<EditorTabs
 				tabs={tabs}
 				activeTabPath={activeTab?.path ?? null}

--- a/src/screens/WorktreeView.tsx
+++ b/src/screens/WorktreeView.tsx
@@ -357,6 +357,7 @@ export function WorktreeView({
 				)}
 			</div>
 			<StatusBar
+				className="shrink-0"
 				branch={branch ?? undefined}
 				language={activeTab?.language}
 				encoding={activeTab ? "UTF-8" : undefined}


### PR DESCRIPTION
## Summary
- EditorPanel root divに`overflow-hidden`を追加し、内部コンテンツ(EditorTabs + ReviewPanel)がパネル境界を超えてStatusBar領域に侵食するのを防止
- StatusBarに`shrink-0`を追加し、flex-shrinkデフォルト値(1)による縮小を防止してh-6の高さを常に維持

## Test plan
- [ ] EditorPanel下部のReviewPanelでTerminalタブを表示し、StatusBarと重なっていないことを確認
- [ ] ReviewPanelのリサイズ操作時にもレイアウトが正しく保たれることを確認
- [ ] 右サイドのTerminalPanelにも影響がないことを確認

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)