### PR TITLE
fix: Rebase時にWorktreeビューが消失する問題を修正

### DIFF
--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -53,12 +53,26 @@ pub fn get_worktree_dirty_count(worktree_path: String) -> Result<u32, GitError> 
     Ok(count)
 }
 
+fn get_rebasing_branch_name(repo: &Repository) -> Option<String> {
+    let git_dir = repo.path();
+    for subdir in &["rebase-merge", "rebase-apply"] {
+        let head_name = git_dir.join(subdir).join("head-name");
+        if let Ok(content) = std::fs::read_to_string(&head_name) {
+            return content.trim().strip_prefix("refs/heads/").map(String::from);
+        }
+    }
+    None
+}
+
 fn get_branch_name_for_repo(repo: &Repository) -> String {
     match repo.head() {
         Ok(head) => {
             if head.is_branch() {
                 head.shorthand().unwrap_or("HEAD").to_string()
             } else {
+                if let Some(name) = get_rebasing_branch_name(repo) {
+                    return name;
+                }
                 let oid = head.target().map(|o| o.to_string());
                 match oid {
                     Some(h) => format!("({})", &h[..7.min(h.len())]),
@@ -138,11 +152,36 @@ pub fn list_worktrees(repo_path: String) -> Result<Vec<WorktreeEntry>, GitError>
             Err(_) => continue,
         };
 
+        let wt_path = wt.path();
+
         if wt.validate().is_err() {
+            if wt_path.exists() {
+                let (branch, dirty_count) = match Repository::open(wt_path) {
+                    Ok(wt_repo) => (
+                        get_branch_name_for_repo(&wt_repo),
+                        get_dirty_count_for_path(wt_path),
+                    ),
+                    Err(_) => ("(rebasing...)".to_string(), 0),
+                };
+                entries.push(WorktreeEntry {
+                    name: wt_name,
+                    path: wt_path
+                        .to_str()
+                        .ok_or_else(|| {
+                            GitError::Custom("invalid path encoding".to_string())
+                        })?
+                        .trim_end_matches('/')
+                        .to_string(),
+                    branch,
+                    is_main: false,
+                    is_locked: false,
+                    dirty_count,
+                    base_branch: None,
+                });
+            }
             continue;
         }
 
-        let wt_path = wt.path();
         let is_locked =
             matches!(wt.is_locked(), Ok(s) if !matches!(s, git2::WorktreeLockStatus::Unlocked));
 
@@ -212,10 +251,11 @@ pub fn list_branches_with_status(repo_path: String) -> Result<Vec<BranchCard>, G
                 Ok(wt) => wt,
                 Err(_) => continue,
             };
-            if wt.validate().is_err() {
+            let wt_path = wt.path();
+            let is_invalid = wt.validate().is_err();
+            if is_invalid && !wt_path.exists() {
                 continue;
             }
-            let wt_path = wt.path();
             if let Ok(wt_repo) = Repository::open(wt_path) {
                 let branch = get_branch_name_for_repo(&wt_repo);
                 wt_map.insert(
@@ -947,6 +987,80 @@ mod tests {
         assert!(
             card.is_merged,
             "with releash.base=develop, should be merged"
+        );
+    }
+
+    #[test]
+    fn test_get_rebasing_branch_name_from_rebase_merge() {
+        let (_dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+
+        let git_dir = repo.path();
+        let rebase_dir = git_dir.join("rebase-merge");
+        fs::create_dir_all(&rebase_dir).unwrap();
+        fs::write(
+            rebase_dir.join("head-name"),
+            "refs/heads/feat-rebase\n",
+        )
+        .unwrap();
+
+        let result = get_rebasing_branch_name(&repo);
+        assert_eq!(result, Some("feat-rebase".to_string()));
+
+        fs::remove_dir_all(&rebase_dir).unwrap();
+    }
+
+    #[test]
+    fn test_get_rebasing_branch_name_from_rebase_apply() {
+        let (_dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+
+        let git_dir = repo.path();
+        let rebase_dir = git_dir.join("rebase-apply");
+        fs::create_dir_all(&rebase_dir).unwrap();
+        fs::write(
+            rebase_dir.join("head-name"),
+            "refs/heads/feat-apply\n",
+        )
+        .unwrap();
+
+        let result = get_rebasing_branch_name(&repo);
+        assert_eq!(result, Some("feat-apply".to_string()));
+
+        fs::remove_dir_all(&rebase_dir).unwrap();
+    }
+
+    #[test]
+    fn test_get_rebasing_branch_name_none_when_not_rebasing() {
+        let (_dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+
+        let result = get_rebasing_branch_name(&repo);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_list_worktrees_with_invalid_but_existing_worktree() {
+        let (_parent, repo_dir, repo) = create_test_repo_with_parent();
+        create_initial_commit(&repo);
+
+        let wt_path = create_worktree_helper(&repo, _parent.path(), "wt-rebase", "feat-rebase");
+        assert!(wt_path.exists());
+
+        // Simulate a broken worktree by removing the .git file (makes validate fail)
+        let dot_git = wt_path.join(".git");
+        if dot_git.exists() {
+            fs::remove_file(&dot_git).unwrap();
+            // Write an invalid .git file so the directory still exists but worktree is invalid
+            fs::write(&dot_git, "invalid content").unwrap();
+        }
+
+        let entries = list_worktrees(repo_dir.to_str().unwrap().to_string()).unwrap();
+        // The invalid worktree should still appear if the path exists
+        let wt_entry = entries.iter().find(|e| e.name == "wt-rebase");
+        assert!(
+            wt_entry.is_some(),
+            "worktree with existing path should be listed even if validate fails"
         );
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { WorkspaceTabBar } from "@/components/layout/WorkspaceTabBar";
 import { useSettings } from "@/hooks/useSettings";
 import { useWorkspaceTabs } from "@/hooks/useWorkspaceTabs";
 import { WorkspaceManagerScreen } from "@/screens/WorkspaceManagerScreen";
+import { WorktreeErrorBoundary } from "@/components/ErrorBoundary";
 import { WorktreeView } from "@/screens/WorktreeView";
 import type { ProviderStatus, WorktreeEntry } from "@/types/git";
 
@@ -115,12 +116,14 @@ function App() {
 						}}
 						className="h-full"
 					>
-						<WorktreeView
-							rootPath={tab.rootPath}
-							settings={settings}
-							onSettingsSave={updateSettings}
-							onSwitchToKanban={switchToKanban}
-						/>
+						<WorktreeErrorBoundary>
+							<WorktreeView
+								rootPath={tab.rootPath}
+								settings={settings}
+								onSettingsSave={updateSettings}
+								onSwitchToKanban={switchToKanban}
+							/>
+						</WorktreeErrorBoundary>
 					</div>
 				))}
 			</div>

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { WorktreeErrorBoundary } from "./ErrorBoundary";
+
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
+	if (shouldThrow) {
+		throw new Error("test render error");
+	}
+	return <div>normal content</div>;
+}
+
+describe("WorktreeErrorBoundary", () => {
+	it("renders children when no error occurs", () => {
+		render(
+			<WorktreeErrorBoundary>
+				<ThrowingChild shouldThrow={false} />
+			</WorktreeErrorBoundary>,
+		);
+		expect(screen.getByText("normal content")).toBeInTheDocument();
+	});
+
+	it("renders fallback UI when child throws", () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		render(
+			<WorktreeErrorBoundary>
+				<ThrowingChild shouldThrow={true} />
+			</WorktreeErrorBoundary>,
+		);
+
+		expect(
+			screen.getByText("ビューの描画中にエラーが発生しました"),
+		).toBeInTheDocument();
+		expect(screen.getByText("test render error")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "再試行" })).toBeInTheDocument();
+
+		consoleSpy.mockRestore();
+	});
+
+	it("calls onRetry and resets state when retry button is clicked", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const onRetry = vi.fn();
+		const user = userEvent.setup();
+
+		const { rerender } = render(
+			<WorktreeErrorBoundary onRetry={onRetry}>
+				<ThrowingChild shouldThrow={true} />
+			</WorktreeErrorBoundary>,
+		);
+
+		expect(
+			screen.getByText("ビューの描画中にエラーが発生しました"),
+		).toBeInTheDocument();
+
+		rerender(
+			<WorktreeErrorBoundary onRetry={onRetry}>
+				<ThrowingChild shouldThrow={false} />
+			</WorktreeErrorBoundary>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "再試行" }));
+
+		expect(onRetry).toHaveBeenCalledOnce();
+		expect(screen.getByText("normal content")).toBeInTheDocument();
+
+		consoleSpy.mockRestore();
+	});
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+	children: ReactNode;
+	onRetry?: () => void;
+}
+
+interface State {
+	hasError: boolean;
+	error: Error | null;
+}
+
+export class WorktreeErrorBoundary extends Component<Props, State> {
+	constructor(props: Props) {
+		super(props);
+		this.state = { hasError: false, error: null };
+	}
+
+	static getDerivedStateFromError(error: Error): State {
+		return { hasError: true, error };
+	}
+
+	componentDidCatch(error: Error, info: ErrorInfo) {
+		console.error("WorktreeErrorBoundary caught error:", error, info);
+	}
+
+	private handleRetry = () => {
+		this.props.onRetry?.();
+		this.setState({ hasError: false, error: null });
+	};
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<div className="flex flex-col items-center justify-center h-full gap-4 p-8 text-muted-foreground">
+					<p className="text-sm">
+						ビューの描画中にエラーが発生しました
+					</p>
+					<p className="text-xs text-muted-foreground/60 max-w-md text-center">
+						{this.state.error?.message}
+					</p>
+					<button
+						type="button"
+						onClick={this.handleRetry}
+						className="px-3 py-1.5 text-xs rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+					>
+						再試行
+					</button>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -1,5 +1,5 @@
 import { readDir } from "@tauri-apps/plugin-fs";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type FileChangeEvent, useFileWatcher } from "@/hooks/useFileWatcher";
 import { normalizePath } from "@/lib/normalizePath";
 import type { FileNode } from "@/types/file-tree";
@@ -80,39 +80,64 @@ export function useFileTree(options: UseFileTreeOptions): UseFileTreeReturn {
 	const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const handleFileChange = useCallback(
-		async (event: FileChangeEvent) => {
+		(event: FileChangeEvent) => {
 			onFileChangeExternal?.(event);
 
-			const changedPath = normalizePath(event.path);
-			const lastSlashIndex = changedPath.lastIndexOf("/");
-			if (lastSlashIndex === -1) return;
-			const parentDir = changedPath.substring(0, lastSlashIndex);
-
-			const normalizedRootPath = rootPath ? normalizePath(rootPath) : null;
-
-			if (parentDir === normalizedRootPath) {
-				try {
-					const children = await loadChildren(normalizedRootPath, showHidden);
-					setTree(children);
-				} catch (e) {
-					console.error("Failed to reload root tree:", e);
-				}
-				return;
+			if (refreshTimerRef.current) {
+				clearTimeout(refreshTimerRef.current);
 			}
 
-			if (expandedPaths.has(parentDir)) {
-				try {
-					const children = await loadChildren(parentDir, showHidden);
-					setTree((prev) => updateNodeChildren(prev, parentDir, children));
-				} catch (e) {
-					console.error("Failed to reload directory:", e);
+			refreshTimerRef.current = setTimeout(async () => {
+				const changedPath = normalizePath(event.path);
+				const lastSlashIndex = changedPath.lastIndexOf("/");
+				if (lastSlashIndex === -1) return;
+				const parentDir = changedPath.substring(0, lastSlashIndex);
+
+				const normalizedRootPath = rootPath
+					? normalizePath(rootPath)
+					: null;
+
+				if (parentDir === normalizedRootPath) {
+					try {
+						const children = await loadChildren(
+							normalizedRootPath,
+							showHidden,
+						);
+						setTree(children);
+					} catch (e) {
+						console.error("Failed to reload root tree:", e);
+					}
+					return;
 				}
-			}
+
+				if (expandedPaths.has(parentDir)) {
+					try {
+						const children = await loadChildren(
+							parentDir,
+							showHidden,
+						);
+						setTree((prev) =>
+							updateNodeChildren(prev, parentDir, children),
+						);
+					} catch (e) {
+						console.error("Failed to reload directory:", e);
+					}
+				}
+			}, 200);
 		},
 		[rootPath, showHidden, expandedPaths, onFileChangeExternal],
 	);
+
+	useEffect(() => {
+		return () => {
+			if (refreshTimerRef.current) {
+				clearTimeout(refreshTimerRef.current);
+			}
+		};
+	}, []);
 
 	useFileWatcher({
 		rootPath,


### PR DESCRIPTION
## Summary
- Rebase中にWorktreeViewがクラッシュ→タブ消失する問題を3層で防御
- ErrorBoundary追加でReactツリーのクラッシュ伝播を防止
- useFileTreeにデバウンス追加でrebase中のイベント洪水を抑制
- Rust側でrebase中(validate失敗)のworktreeもリストに返却し、detached HEADから元ブランチ名を復元

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `src/components/ErrorBoundary.tsx` | **新規** WorktreeErrorBoundary (エラーキャッチ + フォールバックUI + 再試行) |
| `src/components/ErrorBoundary.test.tsx` | **新規** テスト3件 |
| `src/App.tsx` | WorktreeViewをErrorBoundaryでラップ |
| `src/hooks/useFileTree.ts` | handleFileChangeに200msデバウンス追加 |
| `src-tauri/src/git/worktree.rs` | validate失敗worktreeの返却、`get_rebasing_branch_name`追加、テスト4件追加 |

## Test plan
- [x] `cargo test` — 207テスト全通過
- [x] `pnpm test` — 326テスト全通過
- [x] `cargo clippy -- -D warnings` — 警告なし
- [ ] worktreeで外部ターミナルから `git rebase` を実行し、タブが維持されることを確認
- [ ] Rebase完了後にビューが正常に使えることを確認
- [ ] ErrorBoundary発動時に再試行ボタンが機能することを確認

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * リベース中のGitワークツリー状態をより正確に検出・表示するよう改善
  * 無効なワークツリーでもブランチ情報を取得できるよう対応

* **パフォーマンス改善**
  * ファイルツリー更新のデバウンス処理を追加し、レスポンス性を向上

* **機能改善**
  * ビュー描画エラー時の自動回復機能を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->