### PR TITLE
fix: エージェント状態遷移バグを修正

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -210,12 +210,32 @@ pub fn generate_hooks_config(state: tauri::State<'_, Arc<AppConfig>>) -> Result<
                     )
                 }]
             }],
-            "Notification": [{
+            "Notification": [
+                {
+                    "matcher": "permission_prompt",
+                    "hooks": [{
+                        "type": "command",
+                        "command": format!(
+                            "printf '{{\"worktree_path\":\"%s\",\"event\":\"%s\"}}' \"$(pwd)\" \"notification\" | curl -s -X POST http://localhost:{port}/hooks/agent -H 'Authorization: Bearer {token}' -H 'Content-Type: application/json' -d @- || true"
+                        )
+                    }]
+                },
+                {
+                    "matcher": "elicitation_dialog",
+                    "hooks": [{
+                        "type": "command",
+                        "command": format!(
+                            "printf '{{\"worktree_path\":\"%s\",\"event\":\"%s\"}}' \"$(pwd)\" \"notification\" | curl -s -X POST http://localhost:{port}/hooks/agent -H 'Authorization: Bearer {token}' -H 'Content-Type: application/json' -d @- || true"
+                        )
+                    }]
+                }
+            ],
+            "PostToolUse": [{
                 "matcher": "",
                 "hooks": [{
                     "type": "command",
                     "command": format!(
-                        "printf '{{\"worktree_path\":\"%s\",\"event\":\"%s\"}}' \"$(pwd)\" \"notification\" | curl -s -X POST http://localhost:{port}/hooks/agent -H 'Authorization: Bearer {token}' -H 'Content-Type: application/json' -d @- || true"
+                        "printf '{{\"worktree_path\":\"%s\",\"event\":\"%s\"}}' \"$(pwd)\" \"post_tool_use\" | curl -s -X POST http://localhost:{port}/hooks/agent -H 'Authorization: Bearer {token}' -H 'Content-Type: application/json' -d @- || true"
                     )
                 }]
             }]

--- a/src-tauri/src/hook_listener.rs
+++ b/src-tauri/src/hook_listener.rs
@@ -132,19 +132,27 @@ async fn handle_agent_hook(
 
     let sync = AgentStateSync::from_payload(&payload);
 
-    {
+    let changed = {
         let mut states = state.agent_states.lock();
-        states.insert(sync.worktree_path.clone(), sync.clone());
-    }
+        let should_update = states
+            .get(&sync.worktree_path)
+            .is_none_or(|prev| prev.state != sync.state);
+        if should_update {
+            states.insert(sync.worktree_path.clone(), sync.clone());
+        }
+        should_update
+    };
 
-    {
-        use tauri::Emitter;
-        let _ = state.app_handle.emit("agent-state-changed", &sync);
-    }
+    if changed {
+        {
+            use tauri::Emitter;
+            let _ = state.app_handle.emit("agent-state-changed", &sync);
+        }
 
-    state
-        .broadcaster
-        .try_send(WsMessage::AgentStateSync(sync.clone()));
+        state
+            .broadcaster
+            .try_send(WsMessage::AgentStateSync(sync.clone()));
+    }
 
     if let Ok(cfg) = state.app_config.get_config() {
         let url = cfg.server.notify.webhook_url.clone();
@@ -187,5 +195,95 @@ mod tests {
     #[test]
     fn extract_bearer_token_wrong_scheme() {
         assert_eq!(parse_bearer(Some("Basic abc123")), None);
+    }
+
+    use super::*;
+    use crate::protocol::{AgentState, AgentStateSync};
+
+    #[test]
+    fn same_state_transition_is_skipped() {
+        let states: AgentStatesMap = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let existing = AgentStateSync {
+            worktree_path: "/repo".to_string(),
+            state: AgentState::Running,
+            exit_code: None,
+            timestamp: 1000.0,
+            session_id: None,
+        };
+        states.lock().insert("/repo".to_string(), existing.clone());
+
+        let incoming = AgentStateSync {
+            worktree_path: "/repo".to_string(),
+            state: AgentState::Running,
+            exit_code: None,
+            timestamp: 2000.0,
+            session_id: None,
+        };
+
+        let map = states.lock();
+        let should_update = map
+            .get(&incoming.worktree_path)
+            .is_none_or(|prev| prev.state != incoming.state);
+        assert!(!should_update);
+
+        // timestamp は更新されない
+        let stored = map.get("/repo").unwrap();
+        assert_eq!(stored.timestamp, 1000.0);
+        drop(map);
+    }
+
+    #[test]
+    fn different_state_transition_is_applied() {
+        let states: AgentStatesMap = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let existing = AgentStateSync {
+            worktree_path: "/repo".to_string(),
+            state: AgentState::Waiting,
+            exit_code: None,
+            timestamp: 1000.0,
+            session_id: None,
+        };
+        states.lock().insert("/repo".to_string(), existing.clone());
+
+        let incoming = AgentStateSync {
+            worktree_path: "/repo".to_string(),
+            state: AgentState::Running,
+            exit_code: None,
+            timestamp: 2000.0,
+            session_id: None,
+        };
+
+        let mut map = states.lock();
+        let should_update = map
+            .get(&incoming.worktree_path)
+            .is_none_or(|prev| prev.state != incoming.state);
+        assert!(should_update);
+        if should_update {
+            map.insert(incoming.worktree_path.clone(), incoming.clone());
+        }
+
+        let stored = map.get("/repo").unwrap();
+        assert_eq!(stored.state, AgentState::Running);
+        assert_eq!(stored.timestamp, 2000.0);
+        drop(map);
+    }
+
+    #[test]
+    fn first_event_for_worktree_is_always_applied() {
+        let states: AgentStatesMap = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+
+        let incoming = AgentStateSync {
+            worktree_path: "/new-repo".to_string(),
+            state: AgentState::Running,
+            exit_code: None,
+            timestamp: 1000.0,
+            session_id: None,
+        };
+
+        let map = states.lock();
+        let should_update = map
+            .get(&incoming.worktree_path)
+            .is_none_or(|prev| prev.state != incoming.state);
+        assert!(should_update);
+        drop(map);
     }
 }

--- a/src-tauri/src/protocol/agent.rs
+++ b/src-tauri/src/protocol/agent.rs
@@ -29,7 +29,7 @@ pub struct AgentStateSync {
 impl AgentStateSync {
     pub fn from_payload(payload: &AgentHookPayload) -> Self {
         let state = match payload.event.as_str() {
-            "prompt_submit" => AgentState::Running,
+            "prompt_submit" | "post_tool_use" => AgentState::Running,
             "stop" => match payload.exit_code {
                 Some(code) if code != 0 => AgentState::Error,
                 _ => AgentState::Done,
@@ -105,6 +105,18 @@ mod tests {
         let sync = AgentStateSync::from_payload(&payload);
         assert_eq!(sync.state, AgentState::Error);
         assert_eq!(sync.exit_code, Some(1));
+    }
+
+    #[test]
+    fn post_tool_use_maps_to_running() {
+        let payload = AgentHookPayload {
+            worktree_path: "/repo".to_string(),
+            event: "post_tool_use".to_string(),
+            exit_code: None,
+            session_id: None,
+        };
+        let sync = AgentStateSync::from_payload(&payload);
+        assert_eq!(sync.state, AgentState::Running);
     }
 
     #[test]

--- a/src/screens/WorktreeView.tsx
+++ b/src/screens/WorktreeView.tsx
@@ -23,6 +23,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useLineComments } from "@/hooks/useLineComments";
 import { formatCommentsForTerminal } from "@/lib/formatCommentsForTerminal";
 import { registerDefinitionProviders } from "@/lib/monaco-definition-provider";
+import { normalizePath } from "@/lib/normalizePath";
 import type { LineComment } from "@/types/comment";
 import type { AgentState, AgentStateSync } from "@/types/protocol";
 import {
@@ -76,7 +77,9 @@ export function WorktreeView({
 
 	useEffect(() => {
 		const unlisten = listen<AgentStateSync>("agent-state-changed", (event) => {
-			if (event.payload.worktree_path === rootPath) {
+			if (
+				normalizePath(event.payload.worktree_path) === normalizePath(rootPath)
+			) {
 				setAgentState(event.payload.state);
 			}
 		});


### PR DESCRIPTION
## Summary
- Notificationフックのmatcherを`permission_prompt`と`elicitation_dialog`に限定し、`idle_prompt`によるDone→Waiting上書きを防止
- `PostToolUse`フックを追加し、ツール承認後にWaiting→Runningへ遷移するように修正
- 同一状態への遷移をスキップする防御ロジックを追加（PostToolUseによるRunning→Runningの不要イベント抑制）
- WorktreeViewのパス比較を`normalizePath`で統一

Closes #179

## Test plan
- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` 207件全パス
- [x] `pnpm lint` パス
- [x] `pnpm test` 337件全パス
- [x] `pnpm build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 通知フックシステムを拡張し、複数のイベントタイプに対応しました。
  * エージェント状態の更新時に変更検出ロジックを追加し、不要なブロードキャストをスキップするよう最適化しました。
  * ファイルパス比較の正規化により、パス処理の信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->