### PR TITLE
feat: Agent状態管理を再設計し、Hook定義を4→7に拡張

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -238,6 +238,24 @@ pub fn generate_hooks_config(state: tauri::State<'_, Arc<AppConfig>>) -> Result<
                         "printf '{{\"worktree_path\":\"%s\",\"event\":\"%s\"}}' \"$(pwd)\" \"post_tool_use\" | curl -s -X POST http://localhost:{port}/hooks/agent -H 'Authorization: Bearer {token}' -H 'Content-Type: application/json' -d @- || true"
                     )
                 }]
+            }],
+            "PostToolUseFailure": [{
+                "matcher": "",
+                "hooks": [{
+                    "type": "command",
+                    "command": format!(
+                        "printf '{{\"worktree_path\":\"%s\",\"event\":\"%s\"}}' \"$(pwd)\" \"post_tool_use_failure\" | curl -s -X POST http://localhost:{port}/hooks/agent -H 'Authorization: Bearer {token}' -H 'Content-Type: application/json' -d @- || true"
+                    )
+                }]
+            }],
+            "SessionStart": [{
+                "matcher": "",
+                "hooks": [{
+                    "type": "command",
+                    "command": format!(
+                        "printf '{{\"worktree_path\":\"%s\",\"event\":\"%s\"}}' \"$(pwd)\" \"session_start\" | curl -s -X POST http://localhost:{port}/hooks/agent -H 'Authorization: Bearer {token}' -H 'Content-Type: application/json' -d @- || true"
+                    )
+                }]
             }]
         }
     });

--- a/src-tauri/src/protocol/agent.rs
+++ b/src-tauri/src/protocol/agent.rs
@@ -29,11 +29,12 @@ pub struct AgentStateSync {
 impl AgentStateSync {
     pub fn from_payload(payload: &AgentHookPayload) -> Self {
         let state = match payload.event.as_str() {
-            "prompt_submit" | "post_tool_use" => AgentState::Running,
+            "prompt_submit" | "post_tool_use" | "post_tool_use_failure" => AgentState::Running,
             "stop" => match payload.exit_code {
                 Some(code) if code != 0 => AgentState::Error,
                 _ => AgentState::Done,
             },
+            "session_start" => AgentState::Done,
             "notification" => AgentState::Waiting,
             _ => AgentState::Done,
         };
@@ -117,6 +118,31 @@ mod tests {
         };
         let sync = AgentStateSync::from_payload(&payload);
         assert_eq!(sync.state, AgentState::Running);
+    }
+
+    #[test]
+    fn post_tool_use_failure_maps_to_running() {
+        let payload = AgentHookPayload {
+            worktree_path: "/repo".to_string(),
+            event: "post_tool_use_failure".to_string(),
+            exit_code: None,
+            session_id: None,
+        };
+        let sync = AgentStateSync::from_payload(&payload);
+        assert_eq!(sync.state, AgentState::Running);
+    }
+
+    #[test]
+    fn session_start_maps_to_done() {
+        let payload = AgentHookPayload {
+            worktree_path: "/repo".to_string(),
+            event: "session_start".to_string(),
+            exit_code: None,
+            session_id: Some("sess-456".to_string()),
+        };
+        let sync = AgentStateSync::from_payload(&payload);
+        assert_eq!(sync.state, AgentState::Done);
+        assert_eq!(sync.session_id, Some("sess-456".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `post_tool_use_failure` → `Running` と `session_start` → `Done` の状態遷移マッピングを追加
- Hook生成ロジックに `PostToolUseFailure` と `SessionStart` の定義を追加（4→7定義）
- 対応するユニットテスト2件を追加（全211件通過）

## Background
Issue #215「ClaudeCodeの質問に答えたあとRunningに戻らない」の根本対策。
PR #213 で `PostToolUse` hook追加による直接的な修正は行ったが、今回は全14 Hookを評価した上で、状態遷移の網羅性を改善する再設計。

### 採用したHook（7定義）
| Hook | event名 | → AgentState |
|------|---------|-------------|
| UserPromptSubmit | `prompt_submit` | Running |
| PostToolUse | `post_tool_use` | Running |
| **PostToolUseFailure** | `post_tool_use_failure` | **Running** (新規) |
| Stop | `stop` | Done/Error |
| **SessionStart** | `session_start` | **Done** (新規) |
| Notification(`permission_prompt`) | `notification` | Waiting |
| Notification(`elicitation_dialog`) | `notification` | Waiting |

### 不採用としたHook/matcher
- `PreToolUse`: PostToolUseと同じRunningへの遷移で冗長
- `Notification(idle_prompt)`: Stop後に到達→Done状態の上書きは誤り
- `Notification(auth_success)`: 状態変化ではない
- その他7つ: 重複または無関係

Closes #215

## Test plan
- [x] `cargo test` — 211件全通過
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット問題なし
- [ ] 手動検証: Hook設定を再適用後、質問回答→Running復帰を確認
- [ ] 手動検証: ツール失敗→Running維持を確認
- [ ] 手動検証: セッション再開→Done状態リセットを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セッション開始とツール使用失敗イベントの新しいハンドリング機能を追加しました。

* **改善**
  * イベント処理とシステム状態管理の信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->