### PR TITLE
fix: ソース管理ビューの自動更新を修正 (#172)

### DIFF
--- a/src/hooks/useGitStatus.test.ts
+++ b/src/hooks/useGitStatus.test.ts
@@ -228,6 +228,40 @@ describe("useGitStatus", () => {
 		vi.useRealTimers();
 	});
 
+	it("should ignore file-change events from a path that shares the same prefix but is a different directory", async () => {
+		vi.useFakeTimers();
+		mockInvoke.mockResolvedValue([]);
+
+		type ListenCallback = (event: { payload: { path: string } }) => void;
+		let fileChangeCallback: ListenCallback | null = null;
+		mockListen.mockImplementation((event: string, cb: ListenCallback) => {
+			if (event === "file-change") {
+				fileChangeCallback = cb;
+			}
+			return Promise.resolve(vi.fn());
+		});
+
+		renderHook(() => useGitStatus("/test/repo"));
+
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledTimes(1);
+		});
+
+		act(() => {
+			fileChangeCallback?.({
+				payload: { path: "/test/repo-other/src/file.ts" },
+			});
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(300);
+		});
+
+		expect(mockInvoke).toHaveBeenCalledTimes(1);
+
+		vi.useRealTimers();
+	});
+
 	it("should cancel pending debounce when externalRefreshKey changes", async () => {
 		vi.useFakeTimers();
 		mockInvoke.mockResolvedValue([]);

--- a/src/hooks/useGitStatus.ts
+++ b/src/hooks/useGitStatus.ts
@@ -93,7 +93,12 @@ export function useGitStatus(
 
 		const setup = async () => {
 			unlisten = await listen<FileChangeEvent>("file-change", (event) => {
-				if (mounted && rootPath && event.payload.path.startsWith(rootPath)) {
+				if (
+					mounted &&
+					rootPath &&
+					(event.payload.path === rootPath ||
+						event.payload.path.startsWith(`${rootPath}/`))
+				) {
 					debouncedRefresh();
 				}
 			});


### PR DESCRIPTION
## Summary
- ソース管理ビューの自動更新が効かない問題を修正（`useFileWatcher` の接続漏れ）
- `useGitStatus` の `file-change` イベントを `rootPath` でフィルタリングし、他ワークツリーの変更による不要な Git ステータス取得を防止
- `externalRefreshKey` による即時リフレッシュ時にデバウンスタイマーをキャンセルし、二重発火を防止

Closes #172

## Test plan
- [x] `npx biome check src/` — 154ファイル OK
- [x] `npm test -- --run` — 47ファイル / 372テスト全パス
- [x] `npx tsc --noEmit` — 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファイル変更イベントのパス検証を改善し、関連のないディレクトリからのイベントを無視するようになりました。
  * 外部リフレッシュキー変更時のデバウンス処理をクリアし、確実に新しいフェッチが実行されるようになりました。
  * ステータス更新のタイミングをより安定させました。

* **テスト**
  * エッジケース対応のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->