### PR TITLE
fix: PTY readerスレッドがEINTRで停止する問題を修正

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -256,6 +256,7 @@ impl PtyManager {
                             }
                         }
                     }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                     Err(_) => break,
                 }
             }


### PR DESCRIPTION
## Summary
- Worktree移動時にSIGCHLDが配送され、PTY readerスレッドの`read()`が`EINTR`を返した際にスレッドが終了してしまう問題を修正
- `ErrorKind::Interrupted`（EINTR）の場合は`continue`でリトライするようにした

Closes #212

## Test plan
- [ ] 複数Worktreeでターミナルを開き、Claude Code等の長時間プロセスを起動
- [ ] 別のWorktreeに切り替えた後、元のWorktreeのターミナルプロセスが正常に動作し続けることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ターミナル通信における一時的な中断エラーに対応し、エラー発生時にも処理が継続されるようになりました。これにより、一時的な割り込みによるシステム停止を防ぎます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->