### PR TITLE
fix: ファイル名・フォルダ名入力時にフォーカスが自動で当たらない問題を修正

### DIFF
--- a/src/components/panels/InlineInput.tsx
+++ b/src/components/panels/InlineInput.tsx
@@ -22,15 +22,20 @@ export function InlineInput({
 	const committedRef = useRef(false);
 
 	useEffect(() => {
-		inputRef.current?.focus();
-		if (defaultValue) {
-			const dotIndex = defaultValue.lastIndexOf(".");
-			if (dotIndex > 0) {
-				inputRef.current?.setSelectionRange(0, dotIndex);
-			} else {
-				inputRef.current?.select();
+		// Radix UIのContextMenuが閉じる際にフォーカスをトリガー要素に戻すため、
+		// その復元処理の後にフォーカスを当てる必要がある
+		const timerId = setTimeout(() => {
+			inputRef.current?.focus();
+			if (defaultValue) {
+				const dotIndex = defaultValue.lastIndexOf(".");
+				if (dotIndex > 0) {
+					inputRef.current?.setSelectionRange(0, dotIndex);
+				} else {
+					inputRef.current?.select();
+				}
 			}
-		}
+		}, 0);
+		return () => clearTimeout(timerId);
 	}, [defaultValue]);
 
 	const handleCommit = () => {


### PR DESCRIPTION
## Summary
- Radix UIのContextMenuが閉じる際にフォーカスをトリガー要素に復元する挙動により、InlineInputのフォーカスが奪われていた問題を修正
- `useEffect`内の`focus()`呼び出しを`setTimeout`で遅延させ、ContextMenuのフォーカス復元後に確実にフォーカスを当てるように変更

## Test plan
- [ ] ファイルツリーで右クリック→「新規ファイル」を選択し、入力フィールドに自動でフォーカスが当たることを確認
- [ ] ファイルツリーで右クリック→「新規フォルダ」を選択し、入力フィールドに自動でフォーカスが当たることを確認
- [ ] ファイルツリーで右クリック→「名前の変更」を選択し、入力フィールドに自動でフォーカスが当たることを確認
- [ ] 名前変更時にファイル拡張子を除いた部分が選択されていることを確認

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * インライン入力フィールドのフォーカスとテキスト選択動作を改善しました。コンテキストメニュー使用後のフォーカス復帰処理が適切に機能するようになっています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->