### PR TITLE
fix: エクスプローラビューがスクロールに未対応 (#252)

### DIFF
--- a/src/components/panels/SidebarPanel.tsx
+++ b/src/components/panels/SidebarPanel.tsx
@@ -298,7 +298,7 @@ export function SidebarPanel({
 			</div>
 			<ContextMenu>
 				<ContextMenuTrigger asChild>
-					<ScrollArea className="flex-1">
+					<ScrollArea className="flex-1 min-h-0">
 						<div className="p-2">
 							{loading && (
 								<div className="px-2 py-4 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- エクスプローラビュー（SidebarPanel）のScrollAreaに`min-h-0`を追加し、ファイルツリーが多い場合にスクロール可能にした
- Flexboxレイアウトでは`min-h-0`がないとflex itemが内容サイズ以下に縮小できず、ScrollAreaが機能しない
- 他のパネル（SourceControl, Search, Settings）と同一のパターンに統一

## Test plan
- [ ] ファイル数の多いリポジトリでエクスプローラビューを開き、スクロールできることを確認
- [ ] スクロールバーが正しく表示されることを確認
- [ ] 他のパネル（SourceControl, Search, Settings）のスクロールが影響を受けていないことを確認

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * サイドバーパネルのコンテキストメニュー内のスクロール領域のレイアウト動作が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->