### PR TITLE
fix: apply_hooks_configがユーザーの既存hooksを上書きする問題を修正

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -302,11 +302,9 @@ fn merge_hooks(
                             .unwrap_or("");
 
                         let existing_idx = existing_arr.iter().position(|e| {
-                            let matcher_matches = e
-                                .get("matcher")
-                                .and_then(|m| m.as_str())
-                                .unwrap_or("")
-                                == new_matcher;
+                            let matcher_matches =
+                                e.get("matcher").and_then(|m| m.as_str()).unwrap_or("")
+                                    == new_matcher;
                             matcher_matches && is_releash_hook_entry(e)
                         });
 
@@ -560,7 +558,8 @@ token = ""
 
     #[test]
     fn merge_hooks_preserves_user_hooks() {
-        let user_entry = user_hook_entry("permission_prompt", "notify-send 'Claude needs permission'");
+        let user_entry =
+            user_hook_entry("permission_prompt", "notify-send 'Claude needs permission'");
         let mut existing = serde_json::json!({
             "hooks": {
                 "Notification": [user_entry.clone()]


### PR DESCRIPTION
## Summary
- `apply_hooks_config`のマージロジックをイベントキー単位の`map.insert()`からエントリ単位のマージに変更
- Releashのhookエントリを`/hooks/agent`を含むコマンドで識別し、同じmatcherを持つReleashエントリのみを更新、存在しなければ追加
- ユーザーが自分で設定したhooksが保持されるようになった

## Test plan
- [x] `is_releash_hook_entry`がReleash hookとユーザーhookを正しく識別することを確認
- [x] 同じイベントキーにユーザーhookが存在する場合、Releash hooks適用後もユーザーhookが保持されることを確認
- [x] 既存のReleash hookがポート変更時に正しく更新されることを確認
- [x] 新規イベントキーが正しく追加されることを確認
- [x] hooks未設定の状態から正しく作成されることを確認
- [x] hooks以外のsettings.json設定が保持されることを確認

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * フック設定の統合処理を強化し、ユーザー定義フックの保護を改善しました。
  * システムフックとユーザーフックの共存がより堅牢になりました。

* **テスト**
  * フック設定機能の包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->