### PR TITLE
fix: モバイルでターミナル履歴が重複する問題を修正

### DIFF
--- a/src-tauri/src/ws_bridge.rs
+++ b/src-tauri/src/ws_bridge.rs
@@ -58,6 +58,13 @@ impl WsBroadcaster {
         }
     }
 
+    pub fn send_without_buffer(&self, msg: WsMessage) {
+        let guard = self.sender.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(sender) = guard.as_ref() {
+            let _ = sender.send(msg);
+        }
+    }
+
     pub fn set_sender(&self, sender: Option<WsSender>) {
         let mut guard = self.sender.lock().unwrap_or_else(|e| e.into_inner());
         *guard = sender;
@@ -134,5 +141,34 @@ mod tests {
         }));
         assert_eq!(broadcaster.get_pty_output_buffer(1), "aaa");
         assert_eq!(broadcaster.get_pty_output_buffer(2), "bbb");
+    }
+
+    #[test]
+    fn send_without_buffer_does_not_affect_buffer() {
+        let broadcaster = WsBroadcaster::default();
+        let (tx, mut rx) = WsBroadcaster::create_channel();
+        broadcaster.set_sender(Some(tx));
+
+        broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
+            pty_id: 1,
+            data: "original".to_string(),
+        }));
+        assert_eq!(broadcaster.get_pty_output_buffer(1), "original");
+
+        broadcaster.send_without_buffer(WsMessage::PtyOutput(PtyOutputMsg {
+            pty_id: 1,
+            data: "original".to_string(),
+        }));
+        assert_eq!(
+            broadcaster.get_pty_output_buffer(1),
+            "original",
+            "send_without_buffer must not append to buffer"
+        );
+
+        let mut received = vec![];
+        while let Ok(msg) = rx.try_recv() {
+            received.push(msg);
+        }
+        assert_eq!(received.len(), 2, "both messages should be sent to channel");
     }
 }

--- a/src-tauri/src/ws_server/handlers.rs
+++ b/src-tauri/src/ws_server/handlers.rs
@@ -327,14 +327,15 @@ pub(super) fn handle_pty_output_request(
         let sessions = pm.list_pty_sessions();
         if sessions.iter().any(|s| s.pty_id == req.pty_id) {
             let buffered = state.broadcaster.get_pty_output_buffer(req.pty_id);
-            if buffered.is_empty() {
-                None
-            } else {
-                Some(WsMessage::PtyOutput(PtyOutputMsg {
-                    pty_id: req.pty_id,
-                    data: buffered,
-                }))
+            if !buffered.is_empty() {
+                state
+                    .broadcaster
+                    .send_without_buffer(WsMessage::PtyOutput(PtyOutputMsg {
+                        pty_id: req.pty_id,
+                        data: buffered,
+                    }));
             }
+            None
         } else {
             Some(WsMessage::Error(ErrorMsg {
                 code: "PTY_NOT_FOUND".to_string(),


### PR DESCRIPTION
## Summary
- `WsBroadcaster`に`send_without_buffer`メソッドを追加し、バッファリングをスキップする送信経路を用意
- `handle_pty_output_request`のレスポンスを`send_without_buffer`で送信するよう変更し、`try_send`経由のバッファ再追加を防止
- `send_without_buffer`がバッファに影響しないことを検証するテストを追加

Closes #242

## Test plan
- [x] `cargo test` — 226テスト全通過
- [ ] モバイルUIでターミナルタブを複数回開き直し、履歴が倍増しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## チューア

* WebSocketメッセージ配信メカニズムを最適化し、端末出力データのハンドリング効率を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->