### PR TITLE
feat: KanbanボードにBaseブランチカードを表示

### DIFF
--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -267,9 +267,6 @@ pub fn list_branches_with_status(repo_path: String) -> Result<Vec<BranchCard>, G
         };
 
         let is_default = default_branch.as_deref() == Some(&name);
-        if is_default {
-            continue;
-        }
 
         let (worktree_path, dirty_count) = match wt_map.get(&name) {
             Some(path) => {
@@ -833,12 +830,13 @@ mod tests {
     }
 
     #[test]
-    fn test_list_branches_with_status_excludes_default() {
+    fn test_list_branches_with_status_includes_default() {
         let (dir, repo) = create_test_repo();
         create_initial_commit(&repo);
 
         let cards = list_branches_with_status(dir.path().to_str().unwrap().to_string()).unwrap();
-        assert!(cards.is_empty());
+        assert_eq!(cards.len(), 1);
+        assert!(cards[0].is_default);
     }
 
     #[test]
@@ -851,11 +849,11 @@ mod tests {
         repo.branch("feature-b", &head, false).unwrap();
 
         let cards = list_branches_with_status(dir.path().to_str().unwrap().to_string()).unwrap();
-        assert_eq!(cards.len(), 2);
+        assert_eq!(cards.len(), 3);
         let names: Vec<&str> = cards.iter().map(|c| c.name.as_str()).collect();
         assert!(names.contains(&"feature-a"));
         assert!(names.contains(&"feature-b"));
-        for card in &cards {
+        for card in cards.iter().filter(|c| !c.is_default) {
             assert!(card.worktree_path.is_none());
             assert_eq!(card.dirty_count, 0);
         }

--- a/src/components/workspace/WorktreeCard.tsx
+++ b/src/components/workspace/WorktreeCard.tsx
@@ -90,7 +90,8 @@ export function BranchCard({
 	onDelete,
 }: BranchCardProps) {
 	const hasWorktree = branch.worktree_path != null;
-	const hasStatusBadges = branch.is_merged || branch.agent_state || hasWorktree;
+	const hasStatusBadges =
+		branch.is_default || branch.is_merged || branch.agent_state || hasWorktree;
 
 	return (
 		<div
@@ -127,6 +128,11 @@ export function BranchCard({
 				</div>
 				{hasStatusBadges && (
 					<div className="flex items-center gap-1.5 ml-6 flex-wrap">
+						{branch.is_default && (
+							<span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-green-500/15 text-green-500 font-medium">
+								base
+							</span>
+						)}
 						{branch.is_merged && (
 							<span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-green-500/15 text-green-500 font-medium">
 								merged
@@ -161,7 +167,7 @@ export function BranchCard({
 				>
 					{opening ? <Loader2 className="size-4 animate-spin" /> : "Open"}
 				</Button>
-				{(hasWorktree || branch.is_merged) && (
+				{!branch.is_default && (hasWorktree || branch.is_merged) && (
 					<Button
 						size="icon-sm"
 						variant="ghost"


### PR DESCRIPTION
## Summary
- デフォルトブランチが`list_branches_with_status`でスキップされ、KanbanボードにBaseブランチのカードが表示されない問題を修正
- `base`バッジ（緑系）でデフォルトブランチを視覚的に区別
- デフォルトブランチの削除ボタンを非表示にし、誤操作を防止

## Test plan
- [x] `cargo test` — 225テスト全通過
- [ ] Kanban上にBaseブランチカードが「base」バッジ付きで表示される
- [ ] OpenボタンでBaseブランチのコードが開ける
- [ ] Baseブランチカードに削除ボタンが表示されない

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * デフォルトブランチがブランチ一覧に表示されるようになりました
  * デフォルトブランチに「base」バッジが表示されるようになりました

* **改善**
  * デフォルトブランチの削除操作を無効化し、誤削除を防止します
<!-- end of auto-generated comment: release notes by coderabbit.ai -->