### PR TITLE
fix: bump-version CIのインデント破壊とバージョン入力方式を改善

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Calculate new version
         run: |
-          CURRENT=$(jq -r '.version' package.json)
+          CURRENT=$(jq -r '.version' src-tauri/tauri.conf.json)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
           case "${{ inputs.bump }}" in
             major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;


### PR DESCRIPTION
## Summary
- `jq` による `package.json` 書き換え時にタブインデントがスペースに変わる問題を `--tab` オプションで修正
- バージョン入力を自由入力から patch / minor / major の選択式に変更し、現在のバージョンから自動計算するように改善

## Test plan
- [ ] GitHub Actions の workflow_dispatch で patch / minor / major それぞれ選択できることを確認
- [ ] 生成される PR の `package.json` がタブインデントを維持していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリースプロセスの改善：バージョンバンプワークフローを最適化し、より堅牢なバージョン管理を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->