### PR TITLE
docs: READMEにロゴ追加とv0.1.0リリース対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<!-- TODO: ロゴ画像 -->
-<!-- <p align="center"><img src="docs/assets/logo.svg" alt="Releash" width="200" /></p> -->
+<p align="center"><img src="src-tauri/icons/icon.png" alt="Releash" width="120" /></p>
 
 # Releash
 
@@ -67,13 +66,15 @@ A real PTY terminal, not a toy. Shell integration (Bash, Zsh) detects when comma
 
 ## Getting Started
 
-> **Early development** — pre-built binaries are not available yet. Build from source for now.
+**Platforms:** macOS (Linux and Windows are not yet supported)
 
-**Platforms:** macOS (Linux and Windows are not supported yet)
-
-**Prerequisites:** [Node.js](https://nodejs.org/) (v18+), [pnpm](https://pnpm.io/), [Rust](https://www.rust-lang.org/tools/install), [Tauri v2 prerequisites](https://v2.tauri.app/start/prerequisites/)
+Download the latest installer from the [Releases page](https://github.com/siro33950/releash/releases/latest).
 
 **Optional:** [GitHub CLI](https://cli.github.com/) (`gh`) — enables PR detection for Kanban board
+
+### Build from source
+
+**Prerequisites:** [Node.js](https://nodejs.org/) (v18+), [pnpm](https://pnpm.io/), [Rust](https://www.rust-lang.org/tools/install), [Tauri v2 prerequisites](https://v2.tauri.app/start/prerequisites/)
 
 ```sh
 pnpm install


### PR DESCRIPTION
## Summary
- READMEにアプリアイコンをロゴとして配置（TODOコメント解消）
- Getting Startedをv0.1.0リリースに合わせて更新（Releasesページからのダウンロードを案内、ビルド手順をサブセクションに移動）

## Test plan
- [ ] GitHubでREADMEのロゴ画像が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

- ロゴイメージを更新し、中央揃えで表示
- プラットフォーム対応状況（初期段階ではmacOSのみ）を明記し、最新リリースインストーラーへのリンクを追加
- 「ソースからビルド」セクションを新規追加し、前提条件とコマンド例を記載
- Getting Startedセクションのフォーマットと順序を改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->