### PR TITLE
feat: 送信済みコメントの表示/非表示トグルを追加

### DIFF
--- a/src/components/panels/CommentList.test.tsx
+++ b/src/components/panels/CommentList.test.tsx
@@ -46,6 +46,7 @@ describe("CommentList", () => {
 					makeComment({ id: "c-1", status: "unsent" }),
 					makeComment({ id: "c-2", status: "sent", lineNumber: 20 }),
 				]}
+				showSentComments={true}
 			/>,
 		);
 		expect(screen.getByText("unsent")).toBeInTheDocument();
@@ -70,5 +71,87 @@ describe("CommentList", () => {
 		);
 		await user.click(screen.getByText("click me"));
 		expect(onClick).toHaveBeenCalledWith("/src/App.tsx", 15);
+	});
+
+	it("should hide sent comments when showSentComments is false", () => {
+		render(
+			<CommentList
+				comments={[
+					makeComment({ id: "c-1", status: "unsent", content: "unsent one" }),
+					makeComment({
+						id: "c-2",
+						status: "sent",
+						lineNumber: 20,
+						content: "sent one",
+					}),
+				]}
+				showSentComments={false}
+				onToggleShowSent={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("unsent one")).toBeInTheDocument();
+		expect(screen.queryByText("sent one")).not.toBeInTheDocument();
+	});
+
+	it("should show sent comments when showSentComments is true", () => {
+		render(
+			<CommentList
+				comments={[
+					makeComment({ id: "c-1", status: "unsent", content: "unsent one" }),
+					makeComment({
+						id: "c-2",
+						status: "sent",
+						lineNumber: 20,
+						content: "sent one",
+					}),
+				]}
+				showSentComments={true}
+				onToggleShowSent={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("unsent one")).toBeInTheDocument();
+		expect(screen.getByText("sent one")).toBeInTheDocument();
+	});
+
+	it("should show toggle button with sent count", () => {
+		render(
+			<CommentList
+				comments={[
+					makeComment({ id: "c-1", status: "sent" }),
+					makeComment({ id: "c-2", status: "sent", lineNumber: 20 }),
+				]}
+				showSentComments={false}
+				onToggleShowSent={vi.fn()}
+			/>,
+		);
+		expect(screen.getByTestId("toggle-sent-comments")).toBeInTheDocument();
+		expect(screen.getByText(/送信済み \(2\)/)).toBeInTheDocument();
+	});
+
+	it("should call onToggleShowSent when toggle button is clicked", async () => {
+		const user = userEvent.setup();
+		const onToggle = vi.fn();
+		render(
+			<CommentList
+				comments={[makeComment({ id: "c-1", status: "sent" })]}
+				showSentComments={false}
+				onToggleShowSent={onToggle}
+			/>,
+		);
+		await user.click(screen.getByTestId("toggle-sent-comments"));
+		expect(onToggle).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not show toggle button when no sent comments", () => {
+		render(
+			<CommentList
+				comments={[makeComment({ id: "c-1", status: "unsent" })]}
+				showSentComments={false}
+				onToggleShowSent={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.queryByTestId("toggle-sent-comments"),
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/components/panels/CommentList.tsx
+++ b/src/components/panels/CommentList.tsx
@@ -1,5 +1,13 @@
-import { Check, MessageSquare, Pencil, Trash2, X } from "lucide-react";
-import { useCallback, useState } from "react";
+import {
+	Check,
+	Eye,
+	EyeOff,
+	MessageSquare,
+	Pencil,
+	Trash2,
+	X,
+} from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import type { LineComment } from "@/types/comment";
@@ -9,6 +17,8 @@ export interface CommentListProps {
 	onCommentClick?: (filePath: string, lineNumber: number) => void;
 	onDeleteComment?: (id: string) => void;
 	onUpdateComment?: (id: string, content: string) => void;
+	showSentComments?: boolean;
+	onToggleShowSent?: () => void;
 }
 
 export function CommentList({
@@ -16,6 +26,8 @@ export function CommentList({
 	onCommentClick,
 	onDeleteComment,
 	onUpdateComment,
+	showSentComments = false,
+	onToggleShowSent,
 }: CommentListProps) {
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editContent, setEditContent] = useState("");
@@ -51,7 +63,18 @@ export function CommentList({
 		[onDeleteComment],
 	);
 
-	if (comments.length === 0) {
+	const sentCount = useMemo(
+		() => comments.filter((c) => c.status === "sent").length,
+		[comments],
+	);
+
+	const visibleComments = useMemo(
+		() =>
+			showSentComments ? comments : comments.filter((c) => c.status !== "sent"),
+		[comments, showSentComments],
+	);
+
+	if (visibleComments.length === 0 && sentCount === 0) {
 		return (
 			<div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground px-4">
 				<MessageSquare className="h-6 w-6" />
@@ -70,7 +93,7 @@ export function CommentList({
 	}
 
 	const grouped = new Map<string, LineComment[]>();
-	for (const comment of comments) {
+	for (const comment of visibleComments) {
 		const existing = grouped.get(comment.filePath);
 		if (existing) {
 			existing.push(comment);
@@ -82,6 +105,21 @@ export function CommentList({
 	return (
 		<ScrollArea className="h-full">
 			<div className="p-2">
+				{sentCount > 0 && onToggleShowSent && (
+					<button
+						type="button"
+						onClick={onToggleShowSent}
+						className="flex items-center gap-1 w-full px-1.5 py-1 mb-1.5 text-[11px] text-muted-foreground rounded hover:bg-muted transition-colors"
+						data-testid="toggle-sent-comments"
+					>
+						{showSentComments ? (
+							<EyeOff className="h-3 w-3" />
+						) : (
+							<Eye className="h-3 w-3" />
+						)}
+						送信済み ({sentCount})
+					</button>
+				)}
 				{[...grouped.entries()].map(([filePath, fileComments]) => {
 					const fileName = filePath.split("/").pop() ?? filePath;
 					return (

--- a/src/components/panels/EditorTabContent.tsx
+++ b/src/components/panels/EditorTabContent.tsx
@@ -47,6 +47,7 @@ export function EditorTabContent({
 		setDiffMode,
 		comments,
 		addComment,
+		showSentComments,
 		rootPath,
 		onStageHunk,
 		onGitChanged,
@@ -109,9 +110,12 @@ export function EditorTabContent({
 
 	const commentRanges = useMemo(() => {
 		return comments
-			.filter((c) => c.filePath === filePath)
+			.filter(
+				(c) =>
+					c.filePath === filePath && (showSentComments || c.status !== "sent"),
+			)
 			.map((c) => ({ start: c.lineNumber, end: c.endLine }));
-	}, [comments, filePath]);
+	}, [comments, filePath, showSentComments]);
 
 	const handleAddComment = useCallback(
 		(lineNumber: number, content: string, endLine?: number) => {
@@ -125,13 +129,14 @@ export function EditorTabContent({
 			return comments.filter(
 				(c) =>
 					c.filePath === filePath &&
+					(showSentComments || c.status !== "sent") &&
 					(c.lineNumber === lineNumber ||
 						(c.endLine != null &&
 							lineNumber >= c.lineNumber &&
 							lineNumber <= c.endLine)),
 			);
 		},
-		[comments, filePath],
+		[comments, filePath, showSentComments],
 	);
 
 	const getRelativePath = useCallback(() => {

--- a/src/components/panels/ReviewPanel.test.tsx
+++ b/src/components/panels/ReviewPanel.test.tsx
@@ -78,4 +78,21 @@ describe("ReviewPanel", () => {
 		await user.click(screen.getByText("Send"));
 		expect(onSend).toHaveBeenCalledWith([unsent]);
 	});
+
+	it("should pass showSentComments and onToggleShowSent to CommentList", async () => {
+		const user = userEvent.setup();
+		const onToggle = vi.fn();
+		render(
+			<ReviewPanel
+				comments={[makeComment({ id: "c-1", status: "sent" })]}
+				showSentComments={false}
+				onToggleShowSent={onToggle}
+			/>,
+		);
+		await user.click(screen.getByText("Comments"));
+		const toggleBtn = screen.getByTestId("toggle-sent-comments");
+		expect(toggleBtn).toBeInTheDocument();
+		await user.click(toggleBtn);
+		expect(onToggle).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -12,6 +12,8 @@ export interface ReviewPanelProps {
 	onDeleteComment?: (id: string) => void;
 	onUpdateComment?: (id: string, content: string) => void;
 	onSendToTerminal?: (comments: LineComment[]) => void;
+	showSentComments?: boolean;
+	onToggleShowSent?: () => void;
 	cwd?: string | null;
 	theme?: Theme;
 }
@@ -24,6 +26,8 @@ export function ReviewPanel({
 	onDeleteComment,
 	onUpdateComment,
 	onSendToTerminal,
+	showSentComments,
+	onToggleShowSent,
 	cwd,
 	theme,
 }: ReviewPanelProps) {
@@ -101,6 +105,8 @@ export function ReviewPanel({
 					onCommentClick={onCommentClick}
 					onDeleteComment={onDeleteComment}
 					onUpdateComment={onUpdateComment}
+					showSentComments={showSentComments}
+					onToggleShowSent={onToggleShowSent}
 				/>
 			</div>
 		</div>

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -23,6 +23,9 @@ export interface EditorContextValue {
 	deleteComment: (id: string) => void;
 	updateComment: (id: string, content: string) => void;
 
+	showSentComments: boolean;
+	toggleShowSentComments: () => void;
+
 	rootPath: string;
 	onStageHunk?: (repoPath: string, patch: string) => Promise<void>;
 	onGitChanged?: () => void;

--- a/src/hooks/useLineComments.test.ts
+++ b/src/hooks/useLineComments.test.ts
@@ -134,4 +134,27 @@ describe("useLineComments", () => {
 		expect(aComments[0].content).toBe("comment1");
 		expect(aComments[1].content).toBe("comment3");
 	});
+
+	it("should default showSentComments to false", () => {
+		const { result } = renderHook(() => useLineComments());
+		expect(result.current.showSentComments).toBe(false);
+	});
+
+	it("should toggle showSentComments", () => {
+		const { result } = renderHook(() => useLineComments());
+
+		expect(result.current.showSentComments).toBe(false);
+
+		act(() => {
+			result.current.toggleShowSentComments();
+		});
+
+		expect(result.current.showSentComments).toBe(true);
+
+		act(() => {
+			result.current.toggleShowSentComments();
+		});
+
+		expect(result.current.showSentComments).toBe(false);
+	});
 });

--- a/src/hooks/useLineComments.ts
+++ b/src/hooks/useLineComments.ts
@@ -54,6 +54,12 @@ export function useLineComments() {
 		[comments],
 	);
 
+	const [showSentComments, setShowSentComments] = useState(false);
+
+	const toggleShowSentComments = useCallback(() => {
+		setShowSentComments((prev) => !prev);
+	}, []);
+
 	const unsentComments = comments.filter((c) => c.status === "unsent");
 
 	return {
@@ -65,5 +71,7 @@ export function useLineComments() {
 		markAsSent,
 		getCommentsForFile,
 		setComments,
+		showSentComments,
+		toggleShowSentComments,
 	};
 }

--- a/src/lib/commentPeekWidget.test.ts
+++ b/src/lib/commentPeekWidget.test.ts
@@ -356,4 +356,68 @@ describe("createCommentPeekWidget", () => {
 			preference: [1],
 		});
 	});
+
+	it("showSentComments=false で sent コメントが非表示になる", () => {
+		const comments = [
+			makeComment({ id: "c1", content: "sent comment", status: "sent" }),
+			makeComment({ id: "c2", content: "unsent comment", status: "unsent" }),
+		];
+
+		const widget = createCommentPeekWidget(mockMonaco, {
+			lineNumber: 10,
+			existingComments: comments,
+			showSentComments: false,
+			onSubmit: vi.fn(),
+			onCancel: vi.fn(),
+		});
+
+		const dom = widget.getDomNode();
+		const existing = dom.querySelector(".comment-peek-existing");
+		expect(existing).not.toBeNull();
+
+		const items = existing
+			? existing.querySelectorAll(".comment-peek-existing-item")
+			: [];
+		expect(items).toHaveLength(1);
+		expect(
+			items[0].querySelector(".comment-peek-comment-text")?.textContent,
+		).toBe("unsent comment");
+	});
+
+	it("showSentComments=true で全コメントが表示される", () => {
+		const comments = [
+			makeComment({ id: "c1", content: "sent comment", status: "sent" }),
+			makeComment({ id: "c2", content: "unsent comment", status: "unsent" }),
+		];
+
+		const widget = createCommentPeekWidget(mockMonaco, {
+			lineNumber: 10,
+			existingComments: comments,
+			showSentComments: true,
+			onSubmit: vi.fn(),
+			onCancel: vi.fn(),
+		});
+
+		const dom = widget.getDomNode();
+		const items = dom.querySelectorAll(".comment-peek-existing-item");
+		expect(items).toHaveLength(2);
+	});
+
+	it("showSentComments 未指定時はデフォルトで全コメント表示", () => {
+		const comments = [
+			makeComment({ id: "c1", content: "sent", status: "sent" }),
+			makeComment({ id: "c2", content: "unsent", status: "unsent" }),
+		];
+
+		const widget = createCommentPeekWidget(mockMonaco, {
+			lineNumber: 10,
+			existingComments: comments,
+			onSubmit: vi.fn(),
+			onCancel: vi.fn(),
+		});
+
+		const dom = widget.getDomNode();
+		const items = dom.querySelectorAll(".comment-peek-existing-item");
+		expect(items).toHaveLength(2);
+	});
 });

--- a/src/lib/commentPeekWidget.ts
+++ b/src/lib/commentPeekWidget.ts
@@ -12,6 +12,7 @@ export interface CreateCommentPeekOptions {
 	lineNumber: number;
 	endLine?: number;
 	existingComments: LineComment[];
+	showSentComments?: boolean;
 	onSubmit: (content: string) => void;
 	onCancel: () => void;
 }
@@ -20,7 +21,18 @@ export function createCommentPeekWidget(
 	monaco: typeof Monaco,
 	options: CreateCommentPeekOptions,
 ): MonacoContentWidget {
-	const { lineNumber, endLine, existingComments, onSubmit, onCancel } = options;
+	const {
+		lineNumber,
+		endLine,
+		existingComments: rawExistingComments,
+		showSentComments = true,
+		onSubmit,
+		onCancel,
+	} = options;
+
+	const existingComments = showSentComments
+		? rawExistingComments
+		: rawExistingComments.filter((c) => c.status !== "sent");
 
 	const domNode = document.createElement("div");
 	domNode.className = "comment-peek-widget";

--- a/src/remote/components/RemoteCommentList.tsx
+++ b/src/remote/components/RemoteCommentList.tsx
@@ -1,5 +1,14 @@
-import { Check, MessageSquare, Pencil, Send, Trash2, X } from "lucide-react";
-import { useCallback, useState } from "react";
+import {
+	Check,
+	Eye,
+	EyeOff,
+	MessageSquare,
+	Pencil,
+	Send,
+	Trash2,
+	X,
+} from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
 import type { LineComment } from "@/types/comment";
 
 interface RemoteCommentListProps {
@@ -15,7 +24,17 @@ export function RemoteCommentList({
 	onDeleteComment,
 	onUpdateComment,
 }: RemoteCommentListProps) {
+	const [showSentComments, setShowSentComments] = useState(false);
 	const unsentComments = comments.filter((c) => c.status === "unsent");
+	const sentCount = useMemo(
+		() => comments.filter((c) => c.status === "sent").length,
+		[comments],
+	);
+	const visibleComments = useMemo(
+		() =>
+			showSentComments ? comments : comments.filter((c) => c.status !== "sent"),
+		[comments, showSentComments],
+	);
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editContent, setEditContent] = useState("");
 
@@ -38,7 +57,7 @@ export function RemoteCommentList({
 		setEditContent("");
 	}, [editingId, editContent, onUpdateComment]);
 
-	if (comments.length === 0) {
+	if (visibleComments.length === 0 && sentCount === 0) {
 		return (
 			<div className="flex flex-col items-center justify-center h-full gap-3 text-neutral-500 px-6">
 				<MessageSquare className="h-8 w-8" />
@@ -51,7 +70,7 @@ export function RemoteCommentList({
 	}
 
 	const grouped = new Map<string, LineComment[]>();
-	for (const comment of comments) {
+	for (const comment of visibleComments) {
 		const existing = grouped.get(comment.filePath);
 		if (existing) {
 			existing.push(comment);
@@ -63,14 +82,31 @@ export function RemoteCommentList({
 	return (
 		<div className="flex flex-col h-full">
 			<div className="flex items-center justify-between px-3 py-2 border-b border-neutral-800 bg-neutral-900 shrink-0">
-				<span className="text-xs text-neutral-400">
-					Comments
-					{unsentComments.length > 0 && (
-						<span className="ml-1.5 px-1.5 py-0.5 text-[10px] bg-blue-500/20 text-blue-400 rounded">
-							{unsentComments.length}
-						</span>
+				<div className="flex items-center gap-2">
+					<span className="text-xs text-neutral-400">
+						Comments
+						{unsentComments.length > 0 && (
+							<span className="ml-1.5 px-1.5 py-0.5 text-[10px] bg-blue-500/20 text-blue-400 rounded">
+								{unsentComments.length}
+							</span>
+						)}
+					</span>
+					{sentCount > 0 && (
+						<button
+							type="button"
+							onClick={() => setShowSentComments((prev) => !prev)}
+							className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] text-neutral-500 rounded hover:bg-neutral-800 transition-colors"
+							data-testid="toggle-sent-comments"
+						>
+							{showSentComments ? (
+								<EyeOff className="h-3 w-3" />
+							) : (
+								<Eye className="h-3 w-3" />
+							)}
+							送信済み ({sentCount})
+						</button>
 					)}
-				</span>
+				</div>
 				{unsentComments.length > 0 && onSendToTerminal && (
 					<button
 						type="button"

--- a/src/screens/WorktreeView.tsx
+++ b/src/screens/WorktreeView.tsx
@@ -96,8 +96,15 @@ export function WorktreeView({
 	const { branch } = useCurrentBranch(rootPath);
 	const [ready, setReady] = useState(false);
 	const [agentState, setAgentState] = useState<AgentState | undefined>();
-	const { comments, addComment, removeComment, updateComment, markAsSent } =
-		useLineComments();
+	const {
+		comments,
+		addComment,
+		removeComment,
+		updateComment,
+		markAsSent,
+		showSentComments,
+		toggleShowSentComments,
+	} = useLineComments();
 	const { stage, unstage, push, discard, stageHunk, createBranch } =
 		useGitActions();
 	const terminalRef = useRef<TerminalPanelHandle>(null);
@@ -575,6 +582,8 @@ export function WorktreeView({
 			addComment,
 			deleteComment: removeComment,
 			updateComment,
+			showSentComments,
+			toggleShowSentComments,
 			rootPath,
 			onStageHunk: stageHunk,
 			onGitChanged: refreshGit,
@@ -593,6 +602,8 @@ export function WorktreeView({
 			addComment,
 			removeComment,
 			updateComment,
+			showSentComments,
+			toggleShowSentComments,
 			rootPath,
 			stageHunk,
 			refreshGit,
@@ -664,6 +675,8 @@ export function WorktreeView({
 							onDeleteComment={removeComment}
 							onUpdateComment={updateComment}
 							onSendToTerminal={handleSendToTerminal}
+							showSentComments={showSentComments}
+							onToggleShowSent={toggleShowSentComments}
 							cwd={rootPath}
 							theme={settings.theme}
 						/>
@@ -704,6 +717,8 @@ export function WorktreeView({
 			removeComment,
 			updateComment,
 			handleSendToTerminal,
+			showSentComments,
+			toggleShowSentComments,
 		],
 	);
 


### PR DESCRIPTION
## Summary
- 送信済みコメント（`status: "sent"`）をデフォルト非表示にし、トグルボタンで表示/非表示を切り替え可能にした
- 非表示時はコメント一覧、エディタのガターマーカー、PeekWidget 全てから隠れる
- Remote（ブラウザ）側でも同様のトグル機能をローカル state で実装

## Changes
| ファイル | 変更内容 |
|---|---|
| `useLineComments.ts` | `showSentComments` state (default: false) + `toggleShowSentComments` |
| `EditorContext.tsx` | コンテキスト型に2フィールド追加 |
| `WorktreeView.tsx` | hook → Context / ReviewPanel へのワイヤリング |
| `EditorTabContent.tsx` | `commentRanges` / `getCommentsForLine` で sent フィルタリング |
| `CommentList.tsx` | トグルボタンUI + フィルタリングロジック |
| `ReviewPanel.tsx` | props 受け渡し |
| `commentPeekWidget.ts` | `showSentComments` option で PeekWidget 内フィルタリング |
| `RemoteCommentList.tsx` | ローカル state でトグル管理 |

## Test plan
- [x] `useLineComments.test.ts`: showSentComments default / toggle テスト追加
- [x] `CommentList.test.tsx`: フィルタ・トグル表示・クリック・非表示テスト追加
- [x] `ReviewPanel.test.tsx`: props 受け渡しテスト追加
- [x] `commentPeekWidget.test.ts`: showSentComments フィルタテスト追加
- [x] 全423テストパス、biome lint / tsc --noEmit クリーン

close #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コメント一覧に「送信済みコメント」の表示/非表示を切り替えるトグルボタンを追加
  * 送信済みコメントをフィルタリングして非表示にする機能を実装
  * 送信済みコメント数を表示するカウンター機能を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->