### PR TITLE
feat: レビューコメントのターミナル送信フォーマット改善

### DIFF
--- a/src/lib/formatCommentsForTerminal.test.ts
+++ b/src/lib/formatCommentsForTerminal.test.ts
@@ -17,82 +17,137 @@ function makeComment(
 	};
 }
 
+const ROOT = "/Users/me/workspace/my-project";
+
 describe("formatCommentsForTerminal", () => {
 	it("should return empty string for no comments", () => {
 		expect(formatCommentsForTerminal([])).toBe("");
 	});
 
-	it("should format a single comment", () => {
-		const result = formatCommentsForTerminal([
-			makeComment({
-				filePath: "/src/App.tsx",
-				lineNumber: 42,
-				content: "変数名を改善してください",
-			}),
-		]);
-		expect(result).toContain("## Review Comments");
-		expect(result).toContain("### App.tsx");
-		expect(result).toContain("- L42: 変数名を改善してください");
+	it("should strip rootPath to produce relative paths", () => {
+		const result = formatCommentsForTerminal(
+			[
+				makeComment({
+					filePath: `${ROOT}/src/App.tsx`,
+					lineNumber: 42,
+					content: "変数名を改善してください",
+				}),
+			],
+			ROOT,
+		);
+		expect(result).toBe(
+			"## Review Comments\nsrc/App.tsx:L42\n変数名を改善してください",
+		);
 	});
 
-	it("should group comments by file", () => {
-		const result = formatCommentsForTerminal([
-			makeComment({
-				id: "c-1",
-				filePath: "/src/App.tsx",
-				lineNumber: 10,
-				content: "comment A",
-			}),
-			makeComment({
-				id: "c-2",
-				filePath: "/src/hooks/useAuth.ts",
-				lineNumber: 5,
-				content: "comment B",
-			}),
-			makeComment({
-				id: "c-3",
-				filePath: "/src/App.tsx",
-				lineNumber: 20,
-				content: "comment C",
-			}),
-		]);
-		expect(result).toContain("### App.tsx");
-		expect(result).toContain("### useAuth.ts");
-		expect(result).toContain("- L10: comment A");
-		expect(result).toContain("- L20: comment C");
-		expect(result).toContain("- L5: comment B");
+	it("should group comments by file and separate with =====", () => {
+		const result = formatCommentsForTerminal(
+			[
+				makeComment({
+					id: "c-1",
+					filePath: `${ROOT}/src/App.tsx`,
+					lineNumber: 10,
+					content: "comment A",
+				}),
+				makeComment({
+					id: "c-2",
+					filePath: `${ROOT}/src/hooks/useAuth.ts`,
+					lineNumber: 5,
+					content: "comment B",
+				}),
+				makeComment({
+					id: "c-3",
+					filePath: `${ROOT}/src/App.tsx`,
+					lineNumber: 20,
+					content: "comment C",
+				}),
+			],
+			ROOT,
+		);
+		expect(result).toBe(
+			[
+				"## Review Comments",
+				"src/App.tsx:L10",
+				"comment A",
+				"=====",
+				"src/App.tsx:L20",
+				"comment C",
+				"=====",
+				"src/hooks/useAuth.ts:L5",
+				"comment B",
+			].join("\n"),
+		);
 	});
 
 	it("should format range comment as L5-12", () => {
-		const result = formatCommentsForTerminal([
-			makeComment({
-				filePath: "/src/App.tsx",
-				lineNumber: 5,
-				content: "range comment",
-				endLine: 12,
-			}),
-		]);
-		expect(result).toContain("- L5-12: range comment");
+		const result = formatCommentsForTerminal(
+			[
+				makeComment({
+					filePath: `${ROOT}/src/App.tsx`,
+					lineNumber: 5,
+					content: "range comment",
+					endLine: 12,
+				}),
+			],
+			ROOT,
+		);
+		expect(result).toBe("## Review Comments\nsrc/App.tsx:L5-12\nrange comment");
 	});
 
 	it("should sort comments by line number within a file", () => {
+		const result = formatCommentsForTerminal(
+			[
+				makeComment({
+					id: "c-1",
+					filePath: `${ROOT}/src/App.tsx`,
+					lineNumber: 50,
+					content: "later",
+				}),
+				makeComment({
+					id: "c-2",
+					filePath: `${ROOT}/src/App.tsx`,
+					lineNumber: 10,
+					content: "earlier",
+				}),
+			],
+			ROOT,
+		);
+		expect(result).toBe(
+			[
+				"## Review Comments",
+				"src/App.tsx:L10",
+				"earlier",
+				"=====",
+				"src/App.tsx:L50",
+				"later",
+			].join("\n"),
+		);
+	});
+
+	it("should not append separator after the last comment", () => {
+		const result = formatCommentsForTerminal(
+			[
+				makeComment({
+					filePath: `${ROOT}/src/App.tsx`,
+					lineNumber: 1,
+					content: "only one",
+				}),
+			],
+			ROOT,
+		);
+		expect(result.endsWith("=====")).toBe(false);
+	});
+
+	it("should keep filePath as-is when rootPath is not provided", () => {
 		const result = formatCommentsForTerminal([
 			makeComment({
-				id: "c-1",
-				filePath: "/src/App.tsx",
-				lineNumber: 50,
-				content: "later",
-			}),
-			makeComment({
-				id: "c-2",
-				filePath: "/src/App.tsx",
-				lineNumber: 10,
-				content: "earlier",
+				filePath: "src/App.tsx",
+				lineNumber: 1,
+				content: "relative path comment",
 			}),
 		]);
-		const lines = result.split("\n");
-		const earlierIdx = lines.findIndex((l) => l.includes("L10"));
-		const laterIdx = lines.findIndex((l) => l.includes("L50"));
-		expect(earlierIdx).toBeLessThan(laterIdx);
+		expect(result).toBe(
+			"## Review Comments\nsrc/App.tsx:L1\nrelative path comment",
+		);
 	});
 });

--- a/src/lib/formatCommentsForTerminal.ts
+++ b/src/lib/formatCommentsForTerminal.ts
@@ -1,6 +1,9 @@
 import type { LineComment } from "@/types/comment";
 
-export function formatCommentsForTerminal(comments: LineComment[]): string {
+export function formatCommentsForTerminal(
+	comments: LineComment[],
+	rootPath?: string,
+): string {
 	if (comments.length === 0) return "";
 
 	const grouped = new Map<string, LineComment[]>();
@@ -13,10 +16,12 @@ export function formatCommentsForTerminal(comments: LineComment[]): string {
 		}
 	}
 
-	const lines: string[] = ["## Review Comments"];
+	const blocks: string[] = [];
 	for (const [filePath, fileComments] of grouped) {
-		const name = filePath.split("/").pop() ?? filePath;
-		lines.push(`### ${name}`);
+		const prefix = rootPath ? `${rootPath}/` : "";
+		const relativePath = filePath.startsWith(prefix)
+			? filePath.slice(prefix.length)
+			: filePath;
 		const sorted = [...fileComments].sort(
 			(a, b) => a.lineNumber - b.lineNumber,
 		);
@@ -25,9 +30,9 @@ export function formatCommentsForTerminal(comments: LineComment[]): string {
 				c.endLine != null
 					? `L${c.lineNumber}-${c.endLine}`
 					: `L${c.lineNumber}`;
-			lines.push(`- ${lineLabel}: ${c.content}`);
+			blocks.push(`${relativePath}:${lineLabel}\n${c.content}`);
 		}
 	}
 
-	return lines.join("\n");
+	return `## Review Comments\n${blocks.join("\n=====\n")}`;
 }

--- a/src/screens/WorktreeView.tsx
+++ b/src/screens/WorktreeView.tsx
@@ -537,14 +537,14 @@ export function WorktreeView({
 
 	const handleSendToTerminal = useCallback(
 		(unsent: LineComment[]) => {
-			const text = formatCommentsForTerminal(unsent);
+			const text = formatCommentsForTerminal(unsent, rootPath);
 			if (text && terminalRef.current) {
 				terminalRef.current.writeToTerminal(`${text}\n`);
 				markAsSent(unsent.map((c) => c.id));
 				trackEvent("comment_sent", { count: unsent.length });
 			}
 		},
-		[markAsSent],
+		[markAsSent, rootPath],
 	);
 
 	const handleCommentClick = useCallback(


### PR DESCRIPTION
## Summary
- レビューコメントのターミナル送信フォーマットを `ファイルパス:L行番号\nコメント内容` 形式に変更
- `rootPath` を使って絶対パスからプロジェクト相対パスへ変換し、AIエージェントがファイルを正確に特定可能に
- コメントブロック間を `=====` セパレータで区切り、パースしやすい構造に

## Test plan
- [x] 全414テスト通過
- [x] biome lint 通過
- [ ] ローカルでレビューコメントをターミナル送信し、相対パス形式で出力されることを確認
- [ ] リモート側でも正常に動作することを確認

closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  - ターミナル出力でのコメント表示形式を改善し、プロジェクトルートパスに基づいて相対パスを正しく表示するようになりました
  - ファイルごとにコメントをグループ化し、セパレーターで区切ることでコメントの区別が明確になりました
  - 行番号の表示形式を最適化し、ターミナルでのコメント確認がより効率的になりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->