### PR TITLE
feat: コメントの個別送信・クリップボードコピー機能を追加

### DIFF
--- a/src/components/panels/CommentList.test.tsx
+++ b/src/components/panels/CommentList.test.tsx
@@ -154,4 +154,59 @@ describe("CommentList", () => {
 			screen.queryByTestId("toggle-sent-comments"),
 		).not.toBeInTheDocument();
 	});
+
+	it("should show send button for unsent comment when onSendComment is provided", () => {
+		render(
+			<CommentList
+				comments={[makeComment({ status: "unsent" })]}
+				onSendComment={vi.fn()}
+			/>,
+		);
+		expect(screen.getByTitle("送信")).toBeInTheDocument();
+	});
+
+	it("should not show send button for sent comment", () => {
+		render(
+			<CommentList
+				comments={[makeComment({ status: "sent" })]}
+				onSendComment={vi.fn()}
+				showSentComments={true}
+			/>,
+		);
+		expect(screen.queryByTitle("送信")).not.toBeInTheDocument();
+	});
+
+	it("should not show send button when onSendComment is not provided", () => {
+		render(<CommentList comments={[makeComment({ status: "unsent" })]} />);
+		expect(screen.queryByTitle("送信")).not.toBeInTheDocument();
+	});
+
+	it("should call onSendComment when send button is clicked", async () => {
+		const user = userEvent.setup();
+		const onSend = vi.fn();
+		const comment = makeComment({ status: "unsent" });
+		render(<CommentList comments={[comment]} onSendComment={onSend} />);
+		await user.click(screen.getByTitle("送信"));
+		expect(onSend).toHaveBeenCalledWith(comment);
+	});
+
+	it("should show copy button when onCopyComment is provided", () => {
+		render(
+			<CommentList
+				comments={[makeComment({ status: "sent" })]}
+				onCopyComment={vi.fn()}
+				showSentComments={true}
+			/>,
+		);
+		expect(screen.getByTitle("コピー")).toBeInTheDocument();
+	});
+
+	it("should call onCopyComment when copy button is clicked", async () => {
+		const user = userEvent.setup();
+		const onCopy = vi.fn();
+		const comment = makeComment();
+		render(<CommentList comments={[comment]} onCopyComment={onCopy} />);
+		await user.click(screen.getByTitle("コピー"));
+		expect(onCopy).toHaveBeenCalledWith(comment);
+	});
 });

--- a/src/components/panels/CommentList.tsx
+++ b/src/components/panels/CommentList.tsx
@@ -1,9 +1,11 @@
 import {
 	Check,
+	Copy,
 	Eye,
 	EyeOff,
 	MessageSquare,
 	Pencil,
+	Send,
 	Trash2,
 	X,
 } from "lucide-react";
@@ -17,6 +19,8 @@ export interface CommentListProps {
 	onCommentClick?: (filePath: string, lineNumber: number) => void;
 	onDeleteComment?: (id: string) => void;
 	onUpdateComment?: (id: string, content: string) => void;
+	onSendComment?: (comment: LineComment) => void;
+	onCopyComment?: (comment: LineComment) => void;
 	showSentComments?: boolean;
 	onToggleShowSent?: () => void;
 }
@@ -26,6 +30,8 @@ export function CommentList({
 	onCommentClick,
 	onDeleteComment,
 	onUpdateComment,
+	onSendComment,
+	onCopyComment,
 	showSentComments = false,
 	onToggleShowSent,
 }: CommentListProps) {
@@ -214,6 +220,32 @@ export function CommentList({
 										</div>
 										{editingId !== comment.id && (
 											<div className="flex gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+												{onSendComment && comment.status === "unsent" && (
+													<button
+														type="button"
+														onClick={(e) => {
+															e.stopPropagation();
+															onSendComment(comment);
+														}}
+														className="p-0.5 rounded hover:bg-primary/20 text-muted-foreground hover:text-primary"
+														title="送信"
+													>
+														<Send className="h-3 w-3" />
+													</button>
+												)}
+												{onCopyComment && (
+													<button
+														type="button"
+														onClick={(e) => {
+															e.stopPropagation();
+															onCopyComment(comment);
+														}}
+														className="p-0.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
+														title="コピー"
+													>
+														<Copy className="h-3 w-3" />
+													</button>
+												)}
 												{onUpdateComment && (
 													<button
 														type="button"

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -12,6 +12,8 @@ export interface ReviewPanelProps {
 	onDeleteComment?: (id: string) => void;
 	onUpdateComment?: (id: string, content: string) => void;
 	onSendToTerminal?: (comments: LineComment[]) => void;
+	onSendComment?: (comment: LineComment) => void;
+	onCopyComment?: (comment: LineComment) => void;
 	showSentComments?: boolean;
 	onToggleShowSent?: () => void;
 	cwd?: string | null;
@@ -26,6 +28,8 @@ export function ReviewPanel({
 	onDeleteComment,
 	onUpdateComment,
 	onSendToTerminal,
+	onSendComment,
+	onCopyComment,
 	showSentComments,
 	onToggleShowSent,
 	cwd,
@@ -105,6 +109,8 @@ export function ReviewPanel({
 					onCommentClick={onCommentClick}
 					onDeleteComment={onDeleteComment}
 					onUpdateComment={onUpdateComment}
+					onSendComment={onSendComment}
+					onCopyComment={onCopyComment}
 					showSentComments={showSentComments}
 					onToggleShowSent={onToggleShowSent}
 				/>

--- a/src/lib/formatCommentForClipboard.test.ts
+++ b/src/lib/formatCommentForClipboard.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { LineComment } from "@/types/comment";
+import { formatCommentForClipboard } from "./formatCommentForClipboard";
+
+function makeComment(
+	overrides: Partial<LineComment> & {
+		filePath: string;
+		lineNumber: number;
+		content: string;
+	},
+): LineComment {
+	return {
+		id: "c-1",
+		status: "unsent",
+		createdAt: Date.now(),
+		...overrides,
+	};
+}
+
+describe("formatCommentForClipboard", () => {
+	it("should format a single-line comment", () => {
+		const result = formatCommentForClipboard(
+			makeComment({
+				filePath: "/src/App.tsx",
+				lineNumber: 42,
+				content: "変数名を改善してください",
+			}),
+		);
+		expect(result).toBe("/src/App.tsx:L42\n変数名を改善してください");
+	});
+
+	it("should format a range comment with endLine", () => {
+		const result = formatCommentForClipboard(
+			makeComment({
+				filePath: "/src/hooks/useAuth.ts",
+				lineNumber: 5,
+				content: "この範囲をリファクタしてください",
+				endLine: 12,
+			}),
+		);
+		expect(result).toBe(
+			"/src/hooks/useAuth.ts:L5-12\nこの範囲をリファクタしてください",
+		);
+	});
+});

--- a/src/lib/formatCommentForClipboard.ts
+++ b/src/lib/formatCommentForClipboard.ts
@@ -1,0 +1,9 @@
+import type { LineComment } from "@/types/comment";
+
+export function formatCommentForClipboard(comment: LineComment): string {
+	const lineLabel =
+		comment.endLine != null
+			? `L${comment.lineNumber}-${comment.endLine}`
+			: `L${comment.lineNumber}`;
+	return `${comment.filePath}:${lineLabel}\n${comment.content}`;
+}

--- a/src/remote/RemoteApp.tsx
+++ b/src/remote/RemoteApp.tsx
@@ -7,6 +7,7 @@ import {
 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { computeHunks } from "@/lib/computeHunks";
+import { formatCommentForClipboard } from "@/lib/formatCommentForClipboard";
 import { formatCommentsForTerminal } from "@/lib/formatCommentsForTerminal";
 import { generatePatch } from "@/lib/generatePatch";
 import type { LineComment } from "@/types/comment";
@@ -211,6 +212,30 @@ export function RemoteApp() {
 		[send, activePtyId, setComments],
 	);
 
+	const handleSendComment = useCallback(
+		(comment: LineComment) => {
+			const text = formatCommentsForTerminal([comment]);
+			if (!text) return;
+			if (activePtyId != null) {
+				send({
+					type: "pty_input",
+					payload: { pty_id: activePtyId, data: `${text}\n` },
+				});
+				setComments((prev) =>
+					prev.map((c) =>
+						c.id === comment.id ? { ...c, status: "sent" as const } : c,
+					),
+				);
+			}
+		},
+		[send, activePtyId, setComments],
+	);
+
+	const handleCopyComment = useCallback((comment: LineComment) => {
+		const text = formatCommentForClipboard(comment);
+		navigator.clipboard.writeText(text).catch(() => {});
+	}, []);
+
 	const hasDiffChanges = useMemo(() => {
 		if (!content) return false;
 		return content.original !== content.modified;
@@ -390,6 +415,8 @@ export function RemoteApp() {
 								onSendToTerminal={handleSendToTerminal}
 								onDeleteComment={deleteComment}
 								onUpdateComment={updateComment}
+								onSendComment={handleSendComment}
+								onCopyComment={handleCopyComment}
 							/>
 						</div>
 

--- a/src/remote/components/RemoteCommentList.tsx
+++ b/src/remote/components/RemoteCommentList.tsx
@@ -1,5 +1,6 @@
 import {
 	Check,
+	Copy,
 	Eye,
 	EyeOff,
 	MessageSquare,
@@ -16,6 +17,8 @@ interface RemoteCommentListProps {
 	onSendToTerminal?: (comments: LineComment[]) => void;
 	onDeleteComment?: (id: string) => void;
 	onUpdateComment?: (id: string, content: string) => void;
+	onSendComment?: (comment: LineComment) => void;
+	onCopyComment?: (comment: LineComment) => void;
 }
 
 export function RemoteCommentList({
@@ -23,6 +26,8 @@ export function RemoteCommentList({
 	onSendToTerminal,
 	onDeleteComment,
 	onUpdateComment,
+	onSendComment,
+	onCopyComment,
 }: RemoteCommentListProps) {
 	const [showSentComments, setShowSentComments] = useState(false);
 	const unsentComments = comments.filter((c) => c.status === "unsent");
@@ -195,6 +200,26 @@ export function RemoteCommentList({
 										</div>
 										{editingId !== comment.id && (
 											<div className="flex gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+												{onSendComment && comment.status === "unsent" && (
+													<button
+														type="button"
+														onClick={() => onSendComment(comment)}
+														className="p-1 rounded hover:bg-blue-500/20 text-neutral-500 hover:text-blue-400 transition-colors"
+														title="送信"
+													>
+														<Send className="h-3.5 w-3.5" />
+													</button>
+												)}
+												{onCopyComment && (
+													<button
+														type="button"
+														onClick={() => onCopyComment(comment)}
+														className="p-1 rounded hover:bg-neutral-700 text-neutral-500 hover:text-neutral-300 transition-colors"
+														title="コピー"
+													>
+														<Copy className="h-3.5 w-3.5" />
+													</button>
+												)}
 												{onUpdateComment && (
 													<button
 														type="button"

--- a/src/screens/WorktreeView.tsx
+++ b/src/screens/WorktreeView.tsx
@@ -49,6 +49,7 @@ import { type FileChangeEvent, useFileWatcher } from "@/hooks/useFileWatcher";
 import { useGitActions } from "@/hooks/useGitActions";
 import { useLineComments } from "@/hooks/useLineComments";
 import { type MenuHandlers, useMenuEvents } from "@/hooks/useMenuEvents";
+import { formatCommentForClipboard } from "@/lib/formatCommentForClipboard";
 import { formatCommentsForTerminal } from "@/lib/formatCommentsForTerminal";
 import { registerDefinitionProviders } from "@/lib/monaco-definition-provider";
 import { normalizePath } from "@/lib/normalizePath";
@@ -554,6 +555,24 @@ export function WorktreeView({
 		[markAsSent, rootPath],
 	);
 
+	const handleSendComment = useCallback(
+		(comment: LineComment) => {
+			const text = formatCommentsForTerminal([comment], rootPath);
+			if (text && terminalRef.current) {
+				terminalRef.current.writeToTerminal(`${text}\n`);
+				markAsSent([comment.id]);
+				trackEvent("comment_sent", { count: 1 });
+			}
+		},
+		[markAsSent, rootPath],
+	);
+
+	const handleCopyComment = useCallback((comment: LineComment) => {
+		const text = formatCommentForClipboard(comment);
+		navigator.clipboard.writeText(text).catch(() => {});
+		trackEvent("comment_copied");
+	}, []);
+
 	const handleCommentClick = useCallback(
 		(commentFilePath: string, lineNumber: number) => {
 			if (activeTabPath === commentFilePath) {
@@ -675,6 +694,8 @@ export function WorktreeView({
 							onDeleteComment={removeComment}
 							onUpdateComment={updateComment}
 							onSendToTerminal={handleSendToTerminal}
+							onSendComment={handleSendComment}
+							onCopyComment={handleCopyComment}
 							showSentComments={showSentComments}
 							onToggleShowSent={toggleShowSentComments}
 							cwd={rootPath}
@@ -717,6 +738,8 @@ export function WorktreeView({
 			removeComment,
 			updateComment,
 			handleSendToTerminal,
+			handleSendComment,
+			handleCopyComment,
 			showSentComments,
 			toggleShowSentComments,
 		],


### PR DESCRIPTION
## Summary
- コメントリストに個別送信ボタン（Send）を追加し、unsent状態のコメントを1件ずつターミナルへ送信可能に
- コメントリストにコピーボタン（Copy）を追加し、`ファイルパス:行番号\nコメント内容` 形式でクリップボードにコピー可能に
- `formatCommentForClipboard` ユーティリティと対応するテストを新規追加
- デスクトップ（WorktreeView）とリモート（RemoteApp）の両方で動作

## Test plan
- [ ] unsent状態のコメントに送信ボタンが表示されること
- [ ] sent状態のコメントに送信ボタンが表示されないこと
- [ ] 送信ボタンクリックでコメントがターミナルに送信され、sentに変わること
- [ ] コピーボタンクリックでクリップボードにコメントがコピーされること
- [ ] 既存の一括送信機能が引き続き動作すること
- [ ] `pnpm lint` / `pnpm test` / `pnpm build` が全て通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)