### PR TITLE
fix: Kanbanタブからテキストを削除してアイコンのみに

### DIFF
--- a/src/components/layout/WorkspaceTabBar.test.tsx
+++ b/src/components/layout/WorkspaceTabBar.test.tsx
@@ -21,8 +21,7 @@ describe("WorkspaceTabBar", () => {
 				onTabClose={vi.fn()}
 			/>,
 		);
-		const tab = screen.getByRole("tab");
-		expect(tab).toBeInTheDocument();
+		screen.getByRole("tab", { name: /Kanban/i });
 		expect(screen.queryByLabelText(/Close/)).not.toBeInTheDocument();
 	});
 

--- a/src/components/layout/WorkspaceTabBar.tsx
+++ b/src/components/layout/WorkspaceTabBar.tsx
@@ -85,6 +85,7 @@ export function WorkspaceTabBar({
 									role="tab"
 									tabIndex={0}
 									aria-selected={isActive}
+									aria-label="Kanban"
 								>
 									<LayoutGrid className="size-4 shrink-0" />
 								</div>


### PR DESCRIPTION
## Summary
- Kanbanタブから `<span>Kanban</span>` テキストを削除し、`LayoutGrid` アイコンのみの表示に変更
- テストを修正して新しいUI構造に対応

Closes #310

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm test` 全495テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * Kanbanタブの表示を変更し、テキストラベルを削除してアイコンのみを表示するようにしました。

* **テスト**
  * タブ要素の選択方法をテキスト一致からロールベース検索に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->