### PR TITLE
fix: エクスプローラの不要な「Open Folder」ボタンを削除

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -211,7 +211,6 @@ function App() {
 							rootPath={tab.rootPath}
 							settings={settings}
 							onSettingsSave={updateSettings}
-							onSwitchToKanban={switchToKanban}
 							isActive={activeTabId === tab.id}
 						/>
 					</div>

--- a/src/components/panels/SidebarPanel.tsx
+++ b/src/components/panels/SidebarPanel.tsx
@@ -1,10 +1,4 @@
-import {
-	ChevronsDownUp,
-	FilePlus,
-	FolderOpen,
-	FolderPlus,
-	RefreshCw,
-} from "lucide-react";
+import { ChevronsDownUp, FilePlus, FolderPlus, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	ContextMenu,
@@ -43,8 +37,7 @@ function findNodeByPath(
 }
 
 export interface SidebarPanelProps {
-	rootPath: string | null;
-	onOpenFolder: () => void;
+	rootPath: string;
 	onSelectFile?: (path: string) => void;
 	onFileChange?: (path: string) => void;
 	onRename?: (oldPath: string, newPath: string) => void;
@@ -54,7 +47,6 @@ export interface SidebarPanelProps {
 
 export function SidebarPanel({
 	rootPath,
-	onOpenFolder,
 	onSelectFile,
 	onFileChange,
 	onRename,
@@ -285,15 +277,6 @@ export function SidebarPanel({
 					>
 						<ChevronsDownUp className="h-3.5 w-3.5 text-muted-foreground" />
 					</button>
-					<button
-						type="button"
-						onClick={onOpenFolder}
-						className="p-1 hover:bg-sidebar-accent rounded transition-colors"
-						title="Open Folder"
-						aria-label="Open Folder"
-					>
-						<FolderOpen className="h-3.5 w-3.5 text-muted-foreground" />
-					</button>
 				</div>
 			</div>
 			<ContextMenu>
@@ -312,20 +295,7 @@ export function SidebarPanel({
 								</div>
 							)}
 
-							{!rootPath && !loading && (
-								<div className="px-2 py-4 text-center">
-									<button
-										type="button"
-										onClick={onOpenFolder}
-										className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-sidebar-accent hover:bg-sidebar-accent/80 rounded transition-colors"
-									>
-										<FolderOpen className="h-4 w-4" />
-										Open Folder
-									</button>
-								</div>
-							)}
-
-							{rootPath && !loading && !error && (
+							{!loading && !error && (
 								<FileTree
 									rootPath={rootPath}
 									tree={treeWithStatus}

--- a/src/screens/WorktreeView.test.tsx
+++ b/src/screens/WorktreeView.test.tsx
@@ -58,7 +58,6 @@ describe("WorktreeView", () => {
 				rootPath="/test/path"
 				settings={DEFAULT_SETTINGS}
 				onSettingsSave={vi.fn()}
-				onSwitchToKanban={vi.fn()}
 				isActive
 			/>,
 		);
@@ -71,7 +70,6 @@ describe("WorktreeView", () => {
 				rootPath="/test/path"
 				settings={DEFAULT_SETTINGS}
 				onSettingsSave={vi.fn()}
-				onSwitchToKanban={vi.fn()}
 				isActive
 			/>,
 		);

--- a/src/screens/WorktreeView.tsx
+++ b/src/screens/WorktreeView.tsx
@@ -76,7 +76,6 @@ interface WorktreeViewProps {
 	rootPath: string;
 	settings: AppSettings;
 	onSettingsSave: (settings: AppSettings) => void;
-	onSwitchToKanban: () => void;
 	isActive: boolean;
 }
 
@@ -84,7 +83,6 @@ export function WorktreeView({
 	rootPath,
 	settings,
 	onSettingsSave,
-	onSwitchToKanban,
 	isActive,
 }: WorktreeViewProps) {
 	const {
@@ -693,7 +691,6 @@ export function WorktreeView({
 		return (
 			<SidebarPanel
 				rootPath={rootPath}
-				onOpenFolder={onSwitchToKanban}
 				onSelectFile={handleOpenFile}
 				onFileChange={reloadFileIfClean}
 				onRename={handleRename}
@@ -711,7 +708,6 @@ export function WorktreeView({
 		searchFocusKey,
 		settings,
 		onSettingsSave,
-		onSwitchToKanban,
 		reloadFileIfClean,
 		handleRename,
 		handleDelete,


### PR DESCRIPTION
## Summary
- SidebarPanelのヘッダーアクションと中央に残っていた「Open Folder」ボタンを削除
- 関連する`onOpenFolder`/`onSwitchToKanban` propの伝搬をSidebarPanel → WorktreeView → App.txsの全レイヤーから除去
- `rootPath`の型を`string | null`から`string`に変更（呼び出し元は常に`string`を渡すため）

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm test` 全495テストパス
- [x] `pnpm build` ビルド成功

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ファイルツリーパネルのインターフェースを簡潔に最適化しました。フォルダ管理の操作をシンプル化し、より直感的なユーザー体験を実現しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->