### PR TITLE
fix: UIの空白部分ドラッグ時のテキスト範囲選択を無効化

### DIFF
--- a/src/components/panels/MarkdownDiffViewer.tsx
+++ b/src/components/panels/MarkdownDiffViewer.tsx
@@ -31,7 +31,7 @@ export function MarkdownDiffViewer({
 	return (
 		<div
 			data-testid="markdown-diff-viewer"
-			className="markdown-preview h-full overflow-auto p-6 scrollbar-thin"
+			className="markdown-preview h-full overflow-auto p-6 scrollbar-thin select-text"
 		>
 			<Markdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
 				{deferredModified}

--- a/src/components/panels/MarkdownPreview.tsx
+++ b/src/components/panels/MarkdownPreview.tsx
@@ -33,7 +33,7 @@ export function MarkdownPreview({ content, className }: MarkdownPreviewProps) {
 		<div
 			data-testid="markdown-preview"
 			className={cn(
-				"markdown-preview h-full overflow-auto p-6 scrollbar-thin",
+				"markdown-preview h-full overflow-auto p-6 scrollbar-thin select-text",
 				className,
 			)}
 		>

--- a/src/index.css
+++ b/src/index.css
@@ -153,7 +153,11 @@
 		@apply border-border outline-ring/50;
 	}
 	body {
-		@apply bg-background text-foreground;
+		@apply bg-background text-foreground select-none;
+	}
+	input,
+	textarea {
+		user-select: text;
 	}
 	html,
 	body,


### PR DESCRIPTION
## Summary
- `body`に`user-select: none`を設定し、空白部分のドラッグによるテキスト範囲選択を無効化
- `input`/`textarea`には`user-select: text`を明示設定し、入力フィールドの選択を保証
- MarkdownPreview/MarkdownDiffViewerに`select-text`を追加し、コンテンツのコピーを維持

Close #306

## Test plan
- [ ] 空白部分をドラッグしてテキスト選択が発生しないことを確認
- [ ] Monaco Editor / ターミナル / input / textarea でテキスト選択が正常に動作することを確認
- [ ] MarkdownPreview / MarkdownDiffViewer でテキスト選択・コピーできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **UI改善**
  * Markdownプレビューと差分表示パネルでテキスト選択が可能になりました。
  * テキスト入力フィールドとテキストエリアでテキスト選択を明示的に有効化しました。
  * ページ全体のテキスト選択動作を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->