### PR TITLE
feat: Worktree/Branch削除時にスピナーとクローズ防止を追加

### DIFF
--- a/src/components/workspace/DeleteWorktreeDialog.test.tsx
+++ b/src/components/workspace/DeleteWorktreeDialog.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { BranchCard } from "@/types/git";
+import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
+
+const baseBranch: BranchCard = {
+	name: "feature/test",
+	is_default: false,
+	worktree_path: "/tmp/worktree/feature-test",
+	dirty_count: 0,
+	is_merged: false,
+	has_pr: false,
+	pr_number: null,
+	pr_url: null,
+};
+
+const dirtyBranch: BranchCard = {
+	...baseBranch,
+	dirty_count: 3,
+};
+
+describe("DeleteWorktreeDialog", () => {
+	it("should show spinner and 'Deleting...' text when delete is in progress", async () => {
+		const user = userEvent.setup();
+		const onConfirm = vi.fn(
+			() => new Promise<void>(() => {}), // never resolves
+		);
+		const onCancel = vi.fn();
+
+		render(
+			<DeleteWorktreeDialog
+				open={true}
+				branch={baseBranch}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		const deleteButton = screen.getByRole("button", { name: "Delete" });
+		await user.click(deleteButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Deleting...")).toBeInTheDocument();
+		});
+		expect(deleteButton.querySelector(".animate-spin")).toBeInTheDocument();
+		expect(deleteButton).toBeDisabled();
+	});
+
+	it("should show spinner on Force Delete button for dirty worktree", async () => {
+		const user = userEvent.setup();
+		const onConfirm = vi.fn(() => new Promise<void>(() => {}));
+		const onCancel = vi.fn();
+
+		render(
+			<DeleteWorktreeDialog
+				open={true}
+				branch={dirtyBranch}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		const forceDeleteButton = screen.getByRole("button", {
+			name: "Force Delete",
+		});
+		await user.click(forceDeleteButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Deleting...")).toBeInTheDocument();
+		});
+		expect(
+			forceDeleteButton.querySelector(".animate-spin"),
+		).toBeInTheDocument();
+		expect(forceDeleteButton).toBeDisabled();
+	});
+
+	it("should not call onCancel while deleting", async () => {
+		const user = userEvent.setup();
+		const onConfirm = vi.fn(() => new Promise<void>(() => {}));
+		const onCancel = vi.fn();
+
+		render(
+			<DeleteWorktreeDialog
+				open={true}
+				branch={baseBranch}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		const deleteButton = screen.getByRole("button", { name: "Delete" });
+		await user.click(deleteButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Deleting...")).toBeInTheDocument();
+		});
+
+		// Cancel button should be disabled during deletion
+		const cancelButton = screen.getByRole("button", { name: "Cancel" });
+		expect(cancelButton).toBeDisabled();
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+
+	it("should hide spinner and show error on failure", async () => {
+		const user = userEvent.setup();
+		const onConfirm = vi.fn(() => Promise.reject(new Error("Delete failed")));
+		const onCancel = vi.fn();
+
+		render(
+			<DeleteWorktreeDialog
+				open={true}
+				branch={baseBranch}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		const deleteButton = screen.getByRole("button", { name: "Delete" });
+		await user.click(deleteButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Error: Delete failed")).toBeInTheDocument();
+		});
+
+		// Spinner should be gone, button should be re-enabled
+		expect(deleteButton.querySelector(".animate-spin")).toBeNull();
+		expect(deleteButton).not.toBeDisabled();
+	});
+});

--- a/src/components/workspace/DeleteWorktreeDialog.tsx
+++ b/src/components/workspace/DeleteWorktreeDialog.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -26,6 +27,7 @@ export function DeleteWorktreeDialog({
 }: DeleteWorktreeDialogProps) {
 	const [deleting, setDeleting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const deletingRef = useRef(false);
 
 	const hasDirty = (branch?.dirty_count ?? 0) > 0;
 
@@ -33,12 +35,14 @@ export function DeleteWorktreeDialog({
 		async (force: boolean) => {
 			if (!branch || (!branch.worktree_path && !branch.is_merged)) return;
 			setDeleting(true);
+			deletingRef.current = true;
 			setError(null);
 			try {
 				await onConfirm(branch, force);
 			} catch (e) {
 				setError(String(e));
 				setDeleting(false);
+				deletingRef.current = false;
 			}
 		},
 		[branch, onConfirm],
@@ -47,8 +51,8 @@ export function DeleteWorktreeDialog({
 	const handleOpenChange = useCallback(
 		(o: boolean) => {
 			if (!o) {
+				if (deletingRef.current) return;
 				setError(null);
-				setDeleting(false);
 				onCancel();
 			}
 		},
@@ -69,7 +73,11 @@ export function DeleteWorktreeDialog({
 
 	return (
 		<AlertDialog open={open} onOpenChange={handleOpenChange}>
-			<AlertDialogContent>
+			<AlertDialogContent
+				onEscapeKeyDown={(e) => {
+					if (deleting) e.preventDefault();
+				}}
+			>
 				<AlertDialogHeader>
 					<AlertDialogTitle>{title}</AlertDialogTitle>
 					<AlertDialogDescription>{description}</AlertDialogDescription>
@@ -98,6 +106,7 @@ export function DeleteWorktreeDialog({
 							onClick={() => handleDelete(true)}
 							disabled={deleting}
 						>
+							{deleting && <Loader2 className="size-3.5 mr-1 animate-spin" />}
 							{deleting ? "Deleting..." : "Force Delete"}
 						</AlertDialogAction>
 					) : (
@@ -106,6 +115,7 @@ export function DeleteWorktreeDialog({
 							onClick={() => handleDelete(false)}
 							disabled={deleting}
 						>
+							{deleting && <Loader2 className="size-3.5 mr-1 animate-spin" />}
 							{deleting ? "Deleting..." : "Delete"}
 						</AlertDialogAction>
 					)}


### PR DESCRIPTION
## Summary
- 削除処理中にLoader2スピナーアイコンをDelete/Force Deleteボタンに表示
- 削除中のEscape/オーバーレイクリックによるダイアログクローズを防止し、二重実行を防ぐ
- Radix UIのAlertDialogAction自動クローズによるstale closure問題をuseRefで解決

## Test plan
- [ ] Deleteボタンクリック後にスピナーが表示されることを確認
- [ ] 削除中にEscapeキー・オーバーレイクリックでダイアログが閉じないことを確認
- [ ] エラー時にスピナーが消え、エラーメッセージが表示されることを確認
- [ ] `pnpm test` / `pnpm lint` / `pnpm build` が通ること

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * DeleteWorktreeDialogコンポーネントの包括的なテストスイートを追加

* **Bug Fixes**
  * ワークツリー削除中の操作を改善し、キャンセルボタンを無効化
  * 削除処理中のダイアログ終了を防止
  * 削除失敗時のエラーハンドリングを強化
  * 削除処理中の視覚的フィードバック（ローディング表示）を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->