### PR TITLE
feat: ISSUEパネルにマイルストーン表示・フィルタを追加

### DIFF
--- a/src-tauri/src/git_host/github.rs
+++ b/src-tauri/src/git_host/github.rs
@@ -79,20 +79,37 @@ impl GitHostProvider for GitHubProvider {
             repo_path,
         );
         match output {
-            Some(stdout) => parse_gh_issue_list_output(&stdout),
-            None => Vec::new(),
+            Some(stdout) => {
+                let issues = parse_gh_issue_list_output(&stdout);
+                if issues.is_empty() && stdout.trim() != "[]" && !stdout.trim().is_empty() {
+                    eprintln!(
+                        "[list_issues] parse returned 0 issues from non-empty output: {stdout}"
+                    );
+                }
+                issues
+            }
+            None => {
+                eprintln!("[list_issues] gh command returned no output for {repo_path}");
+                Vec::new()
+            }
         }
     }
 }
 
 fn run_gh_with_timeout(args: &[&str], repo_path: &str) -> Option<String> {
-    let mut child = Command::new("gh")
+    let mut child = match Command::new("gh")
         .args(args)
         .current_dir(repo_path)
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
-        .ok()?;
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[run_gh] spawn failed: {e}");
+            return None;
+        }
+    };
 
     let mut stdout = child.stdout.take()?;
     let reader = std::thread::spawn(move || {
@@ -107,6 +124,19 @@ fn run_gh_with_timeout(args: &[&str], repo_path: &str) -> Option<String> {
         match child.try_wait() {
             Ok(Some(status)) => {
                 if !status.success() {
+                    let stderr = child
+                        .stderr
+                        .take()
+                        .and_then(|mut s| {
+                            let mut buf = String::new();
+                            std::io::Read::read_to_string(&mut s, &mut buf).ok()?;
+                            Some(buf)
+                        })
+                        .unwrap_or_default();
+                    eprintln!(
+                        "[run_gh] exit {status} for `gh {}` in {repo_path}: {stderr}",
+                        args.join(" ")
+                    );
                     return None;
                 }
                 break;
@@ -115,11 +145,18 @@ fn run_gh_with_timeout(args: &[&str], repo_path: &str) -> Option<String> {
                 if start.elapsed() > GH_TIMEOUT {
                     let _ = child.kill();
                     let _ = child.wait();
+                    eprintln!(
+                        "[run_gh] timeout for `gh {}` in {repo_path}",
+                        args.join(" ")
+                    );
                     return None;
                 }
                 std::thread::sleep(Duration::from_millis(100));
             }
-            Err(_) => return None,
+            Err(e) => {
+                eprintln!("[run_gh] try_wait error: {e}");
+                return None;
+            }
         }
     }
 

--- a/src/components/panels/IssuePanel.test.tsx
+++ b/src/components/panels/IssuePanel.test.tsx
@@ -16,7 +16,7 @@ const mockIssues: IssueInfo[] = [
 		labels: [{ name: "enhancement", color: "a2eeef" }],
 		assignees: [{ login: "user1" }],
 		body: "Issue body",
-		milestone: null,
+		milestone: { title: "v1.0" },
 	},
 	{
 		number: 100,
@@ -206,6 +206,60 @@ describe("IssuePanel", () => {
 		await user.type(filterInput, "zzz");
 
 		expect(screen.getByText("No matching issues")).toBeInTheDocument();
+	});
+
+	it("should display milestone badge", async () => {
+		const { invoke } = await import("@tauri-apps/api/core");
+		vi.mocked(invoke).mockResolvedValue(mockIssues);
+
+		render(<IssuePanel {...defaultProps} />);
+		await waitFor(() => {
+			const elements = screen.getAllByText("v1.0");
+			const badge = elements.find(
+				(el) => el.tagName === "SPAN" && el.closest(".bg-card"),
+			);
+			expect(badge).toBeDefined();
+		});
+	});
+
+	it("should filter issues by milestone", async () => {
+		const { invoke } = await import("@tauri-apps/api/core");
+		vi.mocked(invoke).mockResolvedValue(mockIssues);
+		const user = userEvent.setup();
+
+		render(<IssuePanel {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("#305")).toBeInTheDocument();
+		});
+
+		const milestoneSelect = screen.getByDisplayValue("All milestones");
+		await user.selectOptions(milestoneSelect, "v1.0");
+
+		expect(
+			screen.getByText("Kanban画面にIssue管理パネルを追加"),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Bug fix")).not.toBeInTheDocument();
+	});
+
+	it("should filter issues with no milestone", async () => {
+		const { invoke } = await import("@tauri-apps/api/core");
+		vi.mocked(invoke).mockResolvedValue(mockIssues);
+		const user = userEvent.setup();
+
+		render(<IssuePanel {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("#305")).toBeInTheDocument();
+		});
+
+		const milestoneSelect = screen.getByDisplayValue("All milestones");
+		await user.selectOptions(milestoneSelect, "__none__");
+
+		expect(screen.getByText("Bug fix")).toBeInTheDocument();
+		expect(
+			screen.queryByText("Kanban画面にIssue管理パネルを追加"),
+		).not.toBeInTheDocument();
 	});
 
 	it("should filter issues by label", async () => {

--- a/src/components/panels/IssuePanel.tsx
+++ b/src/components/panels/IssuePanel.tsx
@@ -77,6 +77,7 @@ function RepoIssueSection({
 	const [expanded, setExpanded] = useState(defaultExpanded);
 	const [titleFilter, setTitleFilter] = useState("");
 	const [labelFilter, setLabelFilter] = useState("");
+	const [milestoneFilter, setMilestoneFilter] = useState("");
 	const { issues, loading, refresh } = useIssues(repoPath);
 	const repoName = repoPath.split("/").filter(Boolean).pop() ?? "repo";
 
@@ -90,6 +91,20 @@ function RepoIssueSection({
 			}
 		}
 		return Array.from(set).sort();
+	}, [issues]);
+
+	const allMilestones = useMemo(() => {
+		const set = new Set<string>();
+		let hasNone = false;
+		for (const issue of issues) {
+			if (issue.milestone) {
+				set.add(issue.milestone.title);
+			} else {
+				hasNone = true;
+			}
+		}
+		const sorted = Array.from(set).sort();
+		return { titles: sorted, hasNone };
 	}, [issues]);
 
 	const filteredIssues = useMemo(() => {
@@ -108,10 +123,20 @@ function RepoIssueSection({
 			);
 		}
 
+		if (milestoneFilter) {
+			if (milestoneFilter === "__none__") {
+				result = result.filter((issue) => issue.milestone === null);
+			} else {
+				result = result.filter(
+					(issue) => issue.milestone?.title === milestoneFilter,
+				);
+			}
+		}
+
 		result.sort((a, b) => b.number - a.number);
 
 		return result;
-	}, [issues, titleFilter, labelFilter]);
+	}, [issues, titleFilter, labelFilter, milestoneFilter]);
 
 	return (
 		<div className="border-b border-border">
@@ -157,6 +182,23 @@ function RepoIssueSection({
 									{allLabels.map((label) => (
 										<option key={label} value={label}>
 											{label}
+										</option>
+									))}
+								</select>
+							)}
+							{allMilestones.titles.length > 0 && (
+								<select
+									value={milestoneFilter}
+									onChange={(e) => setMilestoneFilter(e.target.value)}
+									className="w-full bg-muted border border-border rounded px-2 py-1 text-[10px] focus:outline-none focus:ring-1 focus:ring-primary"
+								>
+									<option value="">All milestones</option>
+									{allMilestones.hasNone && (
+										<option value="__none__">未設定</option>
+									)}
+									{allMilestones.titles.map((title) => (
+										<option key={title} value={title}>
+											{title}
 										</option>
 									))}
 								</select>
@@ -278,7 +320,7 @@ function IssueCard({
 				</a>
 			</div>
 
-			{issue.labels.length > 0 && (
+			{(issue.labels.length > 0 || issue.milestone) && (
 				<div className="flex flex-wrap gap-1 mt-1.5">
 					{issue.labels.map((label) => {
 						const hasColor = /^[0-9a-fA-F]{6}$/.test(label.color);
@@ -304,6 +346,11 @@ function IssueCard({
 							</span>
 						);
 					})}
+					{issue.milestone && (
+						<span className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[9px] font-medium leading-none bg-muted text-muted-foreground border border-border">
+							{issue.milestone.title}
+						</span>
+					)}
 				</div>
 			)}
 

--- a/src/hooks/useIssues.ts
+++ b/src/hooks/useIssues.ts
@@ -21,7 +21,8 @@ export function useIssues(repoPath: string) {
 					repoPath,
 				});
 				setIssues(result);
-			} catch {
+			} catch (e) {
+				console.error(`[useIssues] ${command} failed for ${repoPath}:`, e);
 				setIssues([]);
 			} finally {
 				hasFetched.current = true;


### PR DESCRIPTION
## Summary
- Issueカードにマイルストーンバッジを表示
- マイルストーンによるフィルタ機能を追加（「未設定」フィルタ含む）
- `gh` コマンドのエラーハンドリング改善（stderr キャプチャ、タイムアウト・spawn失敗時のログ出力）

Closes #317

## Test plan
- [x] マイルストーン付きIssueにバッジが表示される
- [x] マイルストーンフィルタで絞り込みできる
- [x] 「未設定」フィルタでマイルストーンなしのIssueを絞り込める
- [x] `pnpm test` 498 passed
- [x] `cargo test` 279 passed
- [x] `pnpm lint` / `cargo fmt` / `cargo clippy` all pass
- [x] `pnpm build` success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * イシューのマイルストーン機能を追加。マイルストーン別フィルタリングとイシューカード内でのマイルストーン表示に対応しました。マイルストーン未設定のイシューも個別にフィルタリング可能です。

* **バグ修正**
  * イシュー取得時のエラーハンドリングを強化。タイムアウトやコマンド実行エラー発生時のログ出力を改善し、デバッグが容易になりました。

* **テスト**
  * マイルストーン関連のテストケースを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->