### PR TITLE
fix: ブランチ削除後にDeleting状態で抜け出せなくなるバグを修正

### DIFF
--- a/src/components/workspace/DeleteWorktreeDialog.test.tsx
+++ b/src/components/workspace/DeleteWorktreeDialog.test.tsx
@@ -107,6 +107,59 @@ describe("DeleteWorktreeDialog", () => {
 		expect(onCancel).not.toHaveBeenCalled();
 	});
 
+	it("should reset deleting state after successful deletion so next delete works", async () => {
+		const user = userEvent.setup();
+		const onConfirm = vi.fn(() => Promise.resolve());
+		const onCancel = vi.fn();
+
+		const { rerender } = render(
+			<DeleteWorktreeDialog
+				open={true}
+				branch={baseBranch}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		// First deletion
+		const deleteButton = screen.getByRole("button", { name: "Delete" });
+		await user.click(deleteButton);
+
+		await waitFor(() => {
+			expect(onConfirm).toHaveBeenCalledTimes(1);
+		});
+
+		// After success, button should not be stuck in "Deleting..." state
+		expect(screen.queryByText("Deleting...")).not.toBeInTheDocument();
+
+		// Simulate opening dialog for a different branch
+		const anotherBranch: BranchCard = {
+			...baseBranch,
+			name: "feature/other",
+		};
+
+		rerender(
+			<DeleteWorktreeDialog
+				open={true}
+				branch={anotherBranch}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		// The delete button should be enabled and show "Delete", not "Deleting..."
+		const nextDeleteButton = screen.getByRole("button", { name: "Delete" });
+		expect(nextDeleteButton).not.toBeDisabled();
+		expect(screen.queryByText("Deleting...")).not.toBeInTheDocument();
+
+		// Second deletion should work
+		await user.click(nextDeleteButton);
+
+		await waitFor(() => {
+			expect(onConfirm).toHaveBeenCalledTimes(2);
+		});
+	});
+
 	it("should hide spinner and show error on failure", async () => {
 		const user = userEvent.setup();
 		const onConfirm = vi.fn(() => Promise.reject(new Error("Delete failed")));

--- a/src/components/workspace/DeleteWorktreeDialog.tsx
+++ b/src/components/workspace/DeleteWorktreeDialog.tsx
@@ -41,6 +41,7 @@ export function DeleteWorktreeDialog({
 				await onConfirm(branch, force);
 			} catch (e) {
 				setError(String(e));
+			} finally {
 				setDeleting(false);
 				deletingRef.current = false;
 			}


### PR DESCRIPTION
## Summary
- `DeleteWorktreeDialog` の `handleDelete` で、削除成功時に `deleting` 状態がリセットされず、次回の削除操作が「Deleting...」のまま操作不能になるバグを修正
- `try/catch` に `finally` ブロックを追加し、成功・失敗問わず必ず状態をリセット
- 削除成功後に別ブランチの削除が正常に動作することを確認する再現テストを追加

Closes #332

## Test plan
- [x] 既存テスト全545件が合格
- [x] 削除成功後の状態リセットを確認する再現テストを追加・合格
- [x] Biome lint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)