### PR TITLE
feat: CollapsibleSectionを共通コンポーネントとして抽出

### DIFF
--- a/src/components/panels/IssuePanel.tsx
+++ b/src/components/panels/IssuePanel.tsx
@@ -1,7 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
 import {
-	ChevronDown,
-	ChevronRight,
 	ExternalLink,
 	FolderOpen,
 	GitBranch,
@@ -11,6 +9,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { EmptyState } from "@/components/panels/EmptyState";
 import { Button } from "@/components/ui/button";
+import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useIssues } from "@/hooks/useIssues";
@@ -79,7 +78,6 @@ function RepoIssueSection({
 	onSelectWorktree,
 	defaultExpanded,
 }: RepoIssueSectionProps) {
-	const [expanded, setExpanded] = useState(defaultExpanded);
 	const [titleFilter, setTitleFilter] = useState("");
 	const [labelFilter, setLabelFilter] = useState("");
 	const [milestoneFilter, setMilestoneFilter] = useState("");
@@ -160,125 +158,121 @@ function RepoIssueSection({
 	}, [issues, titleFilter, labelFilter, milestoneFilter]);
 
 	return (
-		<div className="border-b border-border">
-			<button
-				type="button"
-				className="flex items-center gap-1.5 w-full px-3 py-1.5 text-xs font-medium hover:bg-accent/50"
-				onClick={() => setExpanded((v) => !v)}
-			>
-				{expanded ? (
-					<ChevronDown className="size-3 shrink-0" />
-				) : (
-					<ChevronRight className="size-3 shrink-0" />
-				)}
-				<span className="truncate">{repoName}</span>
-				{loading && <Loader2 className="size-3 animate-spin ml-auto" />}
-				{!loading && (
-					<span className="ml-auto text-muted-foreground">{issues.length}</span>
-				)}
-			</button>
-			{expanded && (
-				<div className="pb-1">
-					{!isAvailable && (
-						<div className="px-3 py-2 text-[10px] text-muted-foreground">
-							GitHub CLI (gh) が利用できません
-						</div>
+		<CollapsibleSection
+			title={repoName}
+			defaultOpen={defaultExpanded}
+			className="border-b border-border"
+			actions={
+				<>
+					{loading && <Loader2 className="size-3 animate-spin ml-auto" />}
+					{!loading && (
+						<span className="ml-auto text-muted-foreground">
+							{issues.length}
+						</span>
 					)}
-					{isAvailable && !loading && issues.length > 0 && (
-						<div className="px-2 py-1.5 flex flex-col gap-1">
-							<Input
-								type="text"
-								variant="panel"
-								size="xs"
-								placeholder="Filter by title..."
-								aria-label="Filter issues by title"
-								value={titleFilter}
-								onChange={(e) => setTitleFilter(e.target.value)}
-							/>
-							{allLabels.length > 0 && (
-								<select
-									value={labelFilter}
-									onChange={(e) => setLabelFilter(e.target.value)}
-									className="w-full bg-muted border border-border rounded px-2 py-1 text-[10px] focus:outline-none focus:ring-1 focus:ring-primary"
-								>
-									<option value="">All labels</option>
-									{allLabels.map((label) => (
-										<option key={label} value={label}>
-											{label}
-										</option>
-									))}
-								</select>
-							)}
-							{allMilestones.titles.length > 0 && (
-								<select
-									value={milestoneFilter}
-									onChange={(e) => setMilestoneFilter(e.target.value)}
-									className="w-full bg-muted border border-border rounded px-2 py-1 text-[10px] focus:outline-none focus:ring-1 focus:ring-primary"
-								>
-									<option value="">All milestones</option>
-									{allMilestones.hasNone && (
-										<option value="__none__">未設定</option>
-									)}
-									{allMilestones.titles.map((title) => (
-										<option key={title} value={title}>
-											{title}
-										</option>
-									))}
-								</select>
-							)}
-						</div>
-					)}
-					{isAvailable && !loading && issues.length === 0 && (
+				</>
+			}
+		>
+			<div className="pb-1">
+				{!isAvailable && (
+					<div className="px-3 py-2 text-[10px] text-muted-foreground">
+						GitHub CLI (gh) が利用できません
+					</div>
+				)}
+				{isAvailable && !loading && issues.length > 0 && (
+					<div className="px-2 py-1.5 flex flex-col gap-1">
+						<Input
+							type="text"
+							variant="panel"
+							size="xs"
+							placeholder="Filter by title..."
+							aria-label="Filter issues by title"
+							value={titleFilter}
+							onChange={(e) => setTitleFilter(e.target.value)}
+						/>
+						{allLabels.length > 0 && (
+							<select
+								value={labelFilter}
+								onChange={(e) => setLabelFilter(e.target.value)}
+								className="w-full bg-muted border border-border rounded px-2 py-1 text-[10px] focus:outline-none focus:ring-1 focus:ring-primary"
+							>
+								<option value="">All labels</option>
+								{allLabels.map((label) => (
+									<option key={label} value={label}>
+										{label}
+									</option>
+								))}
+							</select>
+						)}
+						{allMilestones.titles.length > 0 && (
+							<select
+								value={milestoneFilter}
+								onChange={(e) => setMilestoneFilter(e.target.value)}
+								className="w-full bg-muted border border-border rounded px-2 py-1 text-[10px] focus:outline-none focus:ring-1 focus:ring-primary"
+							>
+								<option value="">All milestones</option>
+								{allMilestones.hasNone && (
+									<option value="__none__">未設定</option>
+								)}
+								{allMilestones.titles.map((title) => (
+									<option key={title} value={title}>
+										{title}
+									</option>
+								))}
+							</select>
+						)}
+					</div>
+				)}
+				{isAvailable && !loading && issues.length === 0 && (
+					<EmptyState
+						compact
+						title="No open issues"
+						className="px-3 py-2 text-[10px]"
+					/>
+				)}
+				{isAvailable &&
+					!loading &&
+					issues.length > 0 &&
+					filteredIssues.length === 0 && (
 						<EmptyState
 							compact
-							title="No open issues"
+							title="No matching issues"
 							className="px-3 py-2 text-[10px]"
 						/>
 					)}
-					{isAvailable &&
-						!loading &&
-						issues.length > 0 &&
-						filteredIssues.length === 0 && (
-							<EmptyState
-								compact
-								title="No matching issues"
-								className="px-3 py-2 text-[10px]"
+				{isAvailable &&
+					filteredIssues.map((issue) => {
+						const branchName = generateIssueBranchName(issue.number);
+						const matchedWorktree = worktrees.find(
+							(wt) => wt.branch === branchName,
+						);
+						return (
+							<IssueCard
+								key={issue.number}
+								issue={issue}
+								repoPath={repoPath}
+								repoName={repoName}
+								onSelectWorktree={onSelectWorktree}
+								existingWorktree={matchedWorktree}
+								onWorktreeCreated={fetchWorktrees}
 							/>
-						)}
-					{isAvailable &&
-						filteredIssues.map((issue) => {
-							const branchName = generateIssueBranchName(issue.number);
-							const matchedWorktree = worktrees.find(
-								(wt) => wt.branch === branchName,
-							);
-							return (
-								<IssueCard
-									key={issue.number}
-									issue={issue}
-									repoPath={repoPath}
-									repoName={repoName}
-									onSelectWorktree={onSelectWorktree}
-									existingWorktree={matchedWorktree}
-									onWorktreeCreated={fetchWorktrees}
-								/>
-							);
-						})}
-					{isAvailable && !loading && (
-						<div className="px-3 pt-1">
-							<Button
-								variant="ghost"
-								size="sm"
-								className="h-5 px-1.5 text-[10px] text-muted-foreground"
-								onClick={refresh}
-							>
-								<RefreshCw className="size-2.5 mr-1" />
-								Refresh
-							</Button>
-						</div>
-					)}
-				</div>
-			)}
-		</div>
+						);
+					})}
+				{isAvailable && !loading && (
+					<div className="px-3 pt-1">
+						<Button
+							variant="ghost"
+							size="sm"
+							className="h-5 px-1.5 text-[10px] text-muted-foreground"
+							onClick={refresh}
+						>
+							<RefreshCw className="size-2.5 mr-1" />
+							Refresh
+						</Button>
+					</div>
+				)}
+			</div>
+		</CollapsibleSection>
 	);
 }
 

--- a/src/components/panels/NotionPanel.tsx
+++ b/src/components/panels/NotionPanel.tsx
@@ -1,7 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
 import {
-	ChevronDown,
-	ChevronRight,
 	ExternalLink,
 	GitBranch,
 	Loader2,
@@ -12,6 +10,7 @@ import {
 import { useCallback, useState } from "react";
 import { EmptyState } from "@/components/panels/EmptyState";
 import { Button } from "@/components/ui/button";
+import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useNotionConfig } from "@/hooks/useNotionConfig";
@@ -81,7 +80,6 @@ function NotionRepoSection({
 	onSelectWorktree,
 	defaultExpanded,
 }: NotionRepoSectionProps) {
-	const [expanded, setExpanded] = useState(defaultExpanded);
 	const [showConfig, setShowConfig] = useState(false);
 	const {
 		config,
@@ -94,69 +92,63 @@ function NotionRepoSection({
 	const repoName = repoPath.split("/").filter(Boolean).pop() ?? "repo";
 
 	return (
-		<div className="border-b border-border">
-			<button
-				type="button"
-				className="flex items-center gap-1.5 w-full px-3 py-1.5 text-xs font-medium hover:bg-accent/50"
-				onClick={() => setExpanded((v) => !v)}
-			>
-				{expanded ? (
-					<ChevronDown className="size-3 shrink-0" />
-				) : (
-					<ChevronRight className="size-3 shrink-0" />
-				)}
-				<span className="truncate">{repoName}</span>
-				{configLoading && <Loader2 className="size-3 animate-spin ml-auto" />}
-			</button>
-			{expanded && (
-				<div className="pb-1">
-					{!isConfigured && !configLoading && !showConfig && (
-						<div className="px-3 py-2">
-							<div className="text-[10px] text-muted-foreground mb-2">
-								Notion連携が未設定です
-							</div>
-							<Button
-								variant="outline"
-								size="sm"
-								className="w-full h-6 text-[10px]"
-								onClick={() => setShowConfig(true)}
-							>
-								<Settings className="size-3 mr-1" />
-								設定する
-							</Button>
+		<CollapsibleSection
+			title={repoName}
+			defaultOpen={defaultExpanded}
+			className="border-b border-border"
+			actions={
+				configLoading ? (
+					<Loader2 className="size-3 animate-spin ml-auto" />
+				) : undefined
+			}
+		>
+			<div className="pb-1">
+				{!isConfigured && !configLoading && !showConfig && (
+					<div className="px-3 py-2">
+						<div className="text-[10px] text-muted-foreground mb-2">
+							Notion連携が未設定です
 						</div>
-					)}
-					{showConfig && (
-						<NotionConfigForm
-							initialConfig={config}
-							onSave={async (apiToken, databaseId, mapping) => {
-								await save(apiToken, databaseId, mapping);
-								setShowConfig(false);
-							}}
-							onCancel={() => setShowConfig(false)}
-							onDelete={
-								isConfigured
-									? async () => {
-											await remove();
-											setShowConfig(false);
-										}
-									: undefined
-							}
-							validate={validate}
-						/>
-					)}
-					{isConfigured && !showConfig && (
-						<NotionTaskList
-							repoPath={repoPath}
-							repoName={repoName}
-							onSelectWorktree={onSelectWorktree}
-							onShowConfig={() => setShowConfig(true)}
-							branchPrefix={config?.property_mapping.branch_prefix ?? ""}
-						/>
-					)}
-				</div>
-			)}
-		</div>
+						<Button
+							variant="outline"
+							size="sm"
+							className="w-full h-6 text-[10px]"
+							onClick={() => setShowConfig(true)}
+						>
+							<Settings className="size-3 mr-1" />
+							設定する
+						</Button>
+					</div>
+				)}
+				{showConfig && (
+					<NotionConfigForm
+						initialConfig={config}
+						onSave={async (apiToken, databaseId, mapping) => {
+							await save(apiToken, databaseId, mapping);
+							setShowConfig(false);
+						}}
+						onCancel={() => setShowConfig(false)}
+						onDelete={
+							isConfigured
+								? async () => {
+										await remove();
+										setShowConfig(false);
+									}
+								: undefined
+						}
+						validate={validate}
+					/>
+				)}
+				{isConfigured && !showConfig && (
+					<NotionTaskList
+						repoPath={repoPath}
+						repoName={repoName}
+						onSelectWorktree={onSelectWorktree}
+						onShowConfig={() => setShowConfig(true)}
+						branchPrefix={config?.property_mapping.branch_prefix ?? ""}
+					/>
+				)}
+			</div>
+		</CollapsibleSection>
 	);
 }
 

--- a/src/components/panels/SourceControlPanel.tsx
+++ b/src/components/panels/SourceControlPanel.tsx
@@ -2,8 +2,6 @@ import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import {
 	ArrowDown,
 	ArrowUp,
-	ChevronDown,
-	ChevronRight,
 	Minus,
 	Pencil,
 	Plus,
@@ -22,6 +20,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useGitActions } from "@/hooks/useGitActions";
@@ -119,59 +118,6 @@ function FileStatusItem({
 					<Minus className="h-3.5 w-3.5" />
 				)}
 			</button>
-		</div>
-	);
-}
-
-function CollapsibleSection({
-	title,
-	count,
-	defaultOpen = true,
-	actionLabel,
-	actionIcon,
-	onAction,
-	children,
-}: {
-	title: string;
-	count?: number;
-	defaultOpen?: boolean;
-	actionLabel?: string;
-	actionIcon?: React.ReactNode;
-	onAction?: () => void;
-	children: React.ReactNode;
-}) {
-	const [open, setOpen] = useState(defaultOpen);
-
-	return (
-		<div className="overflow-hidden">
-			<div className="flex items-center gap-1 px-2 py-1 text-xs font-semibold uppercase tracking-wide hover:bg-sidebar-accent transition-colors">
-				<button
-					type="button"
-					className="flex flex-1 min-w-0 items-center gap-1"
-					onClick={() => setOpen(!open)}
-				>
-					{open ? (
-						<ChevronDown className="h-3.5 w-3.5 shrink-0" />
-					) : (
-						<ChevronRight className="h-3.5 w-3.5 shrink-0" />
-					)}
-					<span className="flex-1 text-left truncate">
-						{title}
-						{count != null ? ` (${count})` : ""}
-					</span>
-				</button>
-				{actionLabel && onAction && (
-					<button
-						type="button"
-						className="inline-flex items-center justify-center h-5 w-5 min-w-5 rounded text-muted-foreground hover:text-foreground hover:bg-sidebar-accent-foreground/10 transition-colors shrink-0"
-						onClick={onAction}
-						title={actionLabel}
-					>
-						{actionIcon}
-					</button>
-				)}
-			</div>
-			{open && children}
 		</div>
 	);
 }
@@ -321,9 +267,18 @@ export function SourceControlPanel({
 				<CollapsibleSection
 					title="Unstaged Files"
 					count={changedFiles.length}
-					actionLabel="Stage All Changes"
-					actionIcon={<ArrowDown className="h-3.5 w-3.5" />}
-					onAction={() => handleStage([])}
+					headerClassName="gap-1 px-2 py-1 font-semibold uppercase tracking-wide hover:bg-sidebar-accent"
+					chevronClassName="h-3.5 w-3.5"
+					actions={
+						<button
+							type="button"
+							className="inline-flex items-center justify-center h-5 w-5 min-w-5 rounded text-muted-foreground hover:text-foreground hover:bg-sidebar-accent-foreground/10 transition-colors shrink-0"
+							onClick={() => handleStage([])}
+							title="Stage All Changes"
+						>
+							<ArrowDown className="h-3.5 w-3.5" />
+						</button>
+					}
 				>
 					{changedFiles.length === 0 && (
 						<EmptyState
@@ -369,9 +324,18 @@ export function SourceControlPanel({
 				<CollapsibleSection
 					title="Staged Files"
 					count={stagedFiles.length}
-					actionLabel="Unstage All Changes"
-					actionIcon={<ArrowUp className="h-3.5 w-3.5" />}
-					onAction={() => handleUnstage([])}
+					headerClassName="gap-1 px-2 py-1 font-semibold uppercase tracking-wide hover:bg-sidebar-accent"
+					chevronClassName="h-3.5 w-3.5"
+					actions={
+						<button
+							type="button"
+							className="inline-flex items-center justify-center h-5 w-5 min-w-5 rounded text-muted-foreground hover:text-foreground hover:bg-sidebar-accent-foreground/10 transition-colors shrink-0"
+							onClick={() => handleUnstage([])}
+							title="Unstage All Changes"
+						>
+							<ArrowUp className="h-3.5 w-3.5" />
+						</button>
+					}
 				>
 					{stagedFiles.length === 0 && (
 						<EmptyState

--- a/src/components/ui/collapsible-section.test.tsx
+++ b/src/components/ui/collapsible-section.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CollapsibleSection } from "./collapsible-section";
+
+describe("CollapsibleSection", () => {
+	it("renders children when defaultOpen is true", () => {
+		render(
+			<CollapsibleSection title="Section">
+				<div>Content</div>
+			</CollapsibleSection>,
+		);
+		expect(screen.getByText("Content")).toBeInTheDocument();
+	});
+
+	it("hides children when defaultOpen is false", () => {
+		render(
+			<CollapsibleSection title="Section" defaultOpen={false}>
+				<div>Content</div>
+			</CollapsibleSection>,
+		);
+		expect(screen.queryByText("Content")).not.toBeInTheDocument();
+	});
+
+	it("toggles children visibility on header click", () => {
+		render(
+			<CollapsibleSection title="Section">
+				<div>Content</div>
+			</CollapsibleSection>,
+		);
+		expect(screen.getByText("Content")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /Section/ }));
+		expect(screen.queryByText("Content")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /Section/ }));
+		expect(screen.getByText("Content")).toBeInTheDocument();
+	});
+
+	it("displays count in title", () => {
+		render(
+			<CollapsibleSection title="Items" count={5}>
+				<div>Content</div>
+			</CollapsibleSection>,
+		);
+		expect(screen.getByText("Items (5)")).toBeInTheDocument();
+	});
+
+	it("does not display count when not provided", () => {
+		render(
+			<CollapsibleSection title="Items">
+				<div>Content</div>
+			</CollapsibleSection>,
+		);
+		expect(screen.getByText("Items")).toBeInTheDocument();
+	});
+
+	it("renders actions slot", () => {
+		render(
+			<CollapsibleSection
+				title="Section"
+				actions={<button type="button">Action</button>}
+			>
+				<div>Content</div>
+			</CollapsibleSection>,
+		);
+		expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
+	});
+
+	it("applies className to root", () => {
+		const { container } = render(
+			<CollapsibleSection title="Section" className="custom-root">
+				<div>Content</div>
+			</CollapsibleSection>,
+		);
+		const root = container.querySelector('[data-slot="collapsible-section"]');
+		expect(root).toHaveClass("custom-root");
+	});
+
+	it("applies headerClassName to header", () => {
+		const { container } = render(
+			<CollapsibleSection title="Section" headerClassName="custom-header">
+				<div>Content</div>
+			</CollapsibleSection>,
+		);
+		const header = container.querySelector(
+			'[data-slot="collapsible-section"] > div',
+		);
+		expect(header).toHaveClass("custom-header");
+	});
+
+	it("applies chevronClassName to chevron icon", () => {
+		const { container } = render(
+			<CollapsibleSection title="Section" chevronClassName="custom-chevron">
+				<div>Content</div>
+			</CollapsibleSection>,
+		);
+		const svg = container.querySelector(
+			'[data-slot="collapsible-section"] button svg',
+		);
+		expect(svg).toHaveClass("custom-chevron");
+	});
+});

--- a/src/components/ui/collapsible-section.tsx
+++ b/src/components/ui/collapsible-section.tsx
@@ -1,0 +1,65 @@
+import { ChevronDown } from "lucide-react";
+import type * as React from "react";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+export interface CollapsibleSectionProps {
+	title: string;
+	count?: number;
+	defaultOpen?: boolean;
+	actions?: React.ReactNode;
+	className?: string;
+	headerClassName?: string;
+	chevronClassName?: string;
+	children: React.ReactNode;
+}
+
+export function CollapsibleSection({
+	title,
+	count,
+	defaultOpen = true,
+	actions,
+	className,
+	headerClassName,
+	chevronClassName,
+	children,
+}: CollapsibleSectionProps) {
+	return (
+		<Collapsible
+			defaultOpen={defaultOpen}
+			data-slot="collapsible-section"
+			className={cn("overflow-hidden", className)}
+		>
+			<div
+				className={cn(
+					"flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium hover:bg-accent/50 transition-colors",
+					headerClassName,
+				)}
+			>
+				<CollapsibleTrigger asChild>
+					<button
+						type="button"
+						className="flex flex-1 min-w-0 items-center gap-1"
+					>
+						<ChevronDown
+							className={cn(
+								"size-3 shrink-0 transition-transform [[data-state=closed]_&]:-rotate-90",
+								chevronClassName,
+							)}
+						/>
+						<span className="flex-1 text-left truncate">
+							{title}
+							{count != null && ` (${count})`}
+						</span>
+					</button>
+				</CollapsibleTrigger>
+				{actions}
+			</div>
+			<CollapsibleContent>{children}</CollapsibleContent>
+		</Collapsible>
+	);
+}

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Collapsible as CollapsiblePrimitive } from "radix-ui";
+import type * as React from "react";
+
+function Collapsible({
+	...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+	return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+	...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
+	return (
+		<CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+	);
+}
+
+function CollapsibleContent({
+	...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Content>) {
+	return (
+		<CollapsiblePrimitive.Content data-slot="collapsible-content" {...props} />
+	);
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };


### PR DESCRIPTION
## Summary
- SourceControlPanel, IssuePanel, NotionPanelで重複していた折りたたみセクションをRadix UI Collapsibleベースの共通コンポーネント(`CollapsibleSection`)に統合
- `collapsible.tsx`(Radixラッパー) + `collapsible-section.tsx`(セクションコンポーネント)の2層構成で、shadcn/uiパターンに準拠
- 各パネルは`headerClassName`/`chevronClassName`/`actions`スロットでスタイル差異を吸収

## Test plan
- [x] `pnpm test` — 全624テスト パス（新規9テスト含む）
- [x] `pnpm lint` — エラーなし
- [x] `pnpm build` — ビルド成功

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Issue パネルにヘッダー内フィルタリング機能を追加（タイトル検索、ラベル・マイルストーン絞り込み）
  * ヘッダーに読込状態インジケータと件数表示を統合

* **UI改善**
  * パネルにコンパクトな折りたたみセクション UI を導入し、情報表示をより整理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->