### PR TITLE
feat: Remote Appのハードコード色をセマンティックトークンに移行

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,12 @@
 	--status-deleted: oklch(0.6 0.2 25);
 	--status-untracked: oklch(0.75 0.14 155);
 	--status-ignored: oklch(0.63 0 0);
+
+	/* Diff行ハイライト */
+	--diff-added-bg: oklch(0.28 0.08 145 / 0.4);
+	--diff-deleted-bg: oklch(0.28 0.08 25 / 0.4);
+	--diff-added-fg: oklch(0.75 0.15 145);
+	--diff-deleted-fg: oklch(0.75 0.15 25);
 }
 
 :root.light {
@@ -109,6 +115,11 @@
 	--status-deleted: oklch(0.5 0.2 25);
 	--status-untracked: oklch(0.55 0.14 155);
 	--status-ignored: oklch(0.55 0 0);
+
+	--diff-added-bg: oklch(0.85 0.08 145 / 0.3);
+	--diff-deleted-bg: oklch(0.85 0.08 25 / 0.3);
+	--diff-added-fg: oklch(0.4 0.15 145);
+	--diff-deleted-fg: oklch(0.4 0.15 25);
 }
 
 @theme inline {
@@ -164,6 +175,10 @@
 	--color-status-deleted: var(--status-deleted);
 	--color-status-untracked: var(--status-untracked);
 	--color-status-ignored: var(--status-ignored);
+	--color-diff-added-bg: var(--diff-added-bg);
+	--color-diff-deleted-bg: var(--diff-deleted-bg);
+	--color-diff-added-fg: var(--diff-added-fg);
+	--color-diff-deleted-fg: var(--diff-deleted-fg);
 }
 
 @layer base {

--- a/src/remote/RemoteApp.tsx
+++ b/src/remote/RemoteApp.tsx
@@ -270,14 +270,14 @@ export function RemoteApp() {
 	}
 
 	return (
-		<div className="flex flex-col h-dvh bg-neutral-950 text-neutral-100">
-			<header className="flex items-center justify-between px-3 py-1.5 border-b border-neutral-800 bg-neutral-900 shrink-0">
+		<div className="flex flex-col h-dvh bg-background text-foreground">
+			<header className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-card shrink-0">
 				<div className="flex items-center gap-2 min-w-0">
 					{selectedWorktree && (
 						<button
 							type="button"
 							onClick={handleBackToWorktrees}
-							className="p-1 -ml-1 rounded hover:bg-neutral-800 transition-colors shrink-0"
+							className="p-1 -ml-1 rounded hover:bg-muted transition-colors shrink-0"
 							aria-label="Back"
 						>
 							<ArrowLeft className="size-4" />
@@ -285,7 +285,7 @@ export function RemoteApp() {
 					)}
 					<h1 className="text-sm font-semibold shrink-0">Releash Remote</h1>
 					{branchName && (
-						<span className="text-xs text-neutral-400 truncate font-mono">
+						<span className="text-xs text-muted-foreground truncate font-mono">
 							{branchName}
 						</span>
 					)}
@@ -295,7 +295,7 @@ export function RemoteApp() {
 					<button
 						type="button"
 						onClick={handleDisconnect}
-						className="text-xs px-2 py-0.5 rounded bg-neutral-800 hover:bg-neutral-700 transition-colors"
+						className="text-xs px-2 py-0.5 rounded bg-secondary hover:bg-secondary/80 text-secondary-foreground transition-colors"
 					>
 						切断
 					</button>
@@ -316,8 +316,8 @@ export function RemoteApp() {
 				<>
 					<main className="flex-1 overflow-hidden relative">
 						{worktreeLoading && (
-							<div className="absolute inset-0 flex items-center justify-center bg-neutral-950/80 z-10">
-								<div className="animate-spin size-6 border-2 border-neutral-500 border-t-blue-400 rounded-full" />
+							<div className="absolute inset-0 flex items-center justify-center bg-background/80 z-10">
+								<div className="animate-spin size-6 border-2 border-muted-foreground border-t-primary rounded-full" />
 							</div>
 						)}
 						<div
@@ -349,8 +349,8 @@ export function RemoteApp() {
 							style={{ display: activeTab === "diff" ? undefined : "none" }}
 						>
 							{selectedPath && (
-								<div className="flex items-center justify-between gap-2 px-3 py-1 border-b border-neutral-800 bg-neutral-900 shrink-0">
-									<span className="text-xs text-neutral-500 truncate flex-1 min-w-0">
+								<div className="flex items-center justify-between gap-2 px-3 py-1 border-b border-border bg-card shrink-0">
+									<span className="text-xs text-muted-foreground truncate flex-1 min-w-0">
 										{selectedPath}
 									</span>
 									<div className="flex items-center gap-1.5 shrink-0">
@@ -359,7 +359,7 @@ export function RemoteApp() {
 											onChange={(e) =>
 												handleDiffBaseChange(e.target.value as DiffBase)
 											}
-											className="text-xs bg-neutral-800 text-neutral-300 border border-neutral-700 rounded px-1.5 py-0.5"
+											className="text-xs bg-input text-secondary-foreground border border-border rounded px-1.5 py-0.5"
 										>
 											<option value="HEAD">HEAD</option>
 											<option value="staged">Staged</option>
@@ -368,7 +368,7 @@ export function RemoteApp() {
 											<button
 												type="button"
 												onClick={handleStageAll}
-												className="text-xs px-2 py-0.5 rounded bg-green-800 hover:bg-green-700 text-green-100 transition-colors"
+												className="text-xs px-2 py-0.5 rounded bg-success/80 hover:bg-success/70 text-success-foreground transition-colors"
 											>
 												Stage All
 											</button>
@@ -378,7 +378,7 @@ export function RemoteApp() {
 												<button
 													type="button"
 													onClick={handleUnstageAll}
-													className="text-xs px-2 py-0.5 rounded bg-amber-800 hover:bg-amber-700 text-amber-100 transition-colors"
+													className="text-xs px-2 py-0.5 rounded bg-warning/80 hover:bg-warning/70 text-warning-foreground transition-colors"
 												>
 													Unstage All
 												</button>
@@ -399,7 +399,7 @@ export function RemoteApp() {
 										onAddComment={addComment}
 									/>
 								) : (
-									<div className="flex items-center justify-center h-full text-neutral-500">
+									<div className="flex items-center justify-center h-full text-muted-foreground">
 										<p>接続中...</p>
 									</div>
 								)}
@@ -432,15 +432,15 @@ export function RemoteApp() {
 							ptySessions.length > 0 ? (
 								<>
 									{ptySessions.length > 1 && (
-										<div className="flex items-center gap-1 px-2 py-1 border-b border-neutral-800 bg-neutral-900 shrink-0 overflow-x-auto">
+										<div className="flex items-center gap-1 px-2 py-1 border-b border-border bg-card shrink-0 overflow-x-auto">
 											{ptySessions.map((s) => (
 												<button
 													key={s.ptyId}
 													type="button"
 													className={`px-2 py-0.5 text-xs rounded transition-colors shrink-0 ${
 														activePtyId === s.ptyId
-															? "bg-blue-600 text-white"
-															: "bg-neutral-800 text-neutral-400 hover:bg-neutral-700"
+															? "bg-primary text-primary-foreground"
+															: "bg-secondary text-muted-foreground hover:bg-secondary/80"
 													}`}
 													onClick={() => setActivePtyId(s.ptyId)}
 												>
@@ -468,34 +468,34 @@ export function RemoteApp() {
 							) : activeTab === "terminal" &&
 								status === "connected" &&
 								ptySessions.length === 0 ? (
-								<div className="flex flex-col items-center justify-center h-full gap-3 text-neutral-500">
+								<div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
 									<p>ターミナルセッションがありません</p>
 									<button
 										type="button"
 										onClick={spawnPty}
 										disabled={ptySpawning || !selectedWorktree}
-										className="px-4 py-2 rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm transition-colors"
+										className="px-4 py-2 rounded bg-primary hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed text-primary-foreground text-sm transition-colors"
 									>
 										{ptySpawning ? "起動中..." : "ターミナルを起動"}
 									</button>
 									{ptySpawnError && (
-										<p className="text-red-400 text-xs">{ptySpawnError}</p>
+										<p className="text-destructive text-xs">{ptySpawnError}</p>
 									)}
 									{!selectedWorktree && (
-										<p className="text-neutral-600 text-xs">
+										<p className="text-muted-foreground text-xs">
 											Worktreeを選択してください
 										</p>
 									)}
 								</div>
 							) : activeTab === "terminal" && status !== "connected" ? (
-								<div className="flex items-center justify-center h-full text-neutral-500">
+								<div className="flex items-center justify-center h-full text-muted-foreground">
 									<p>接続されていません</p>
 								</div>
 							) : null}
 						</div>
 					</main>
 
-					<nav className="flex shrink-0 border-t border-neutral-800 bg-neutral-900">
+					<nav className="flex shrink-0 border-t border-border bg-card">
 						{tabs.map((tab) => {
 							const Icon = tab.icon;
 							const isActive = activeTab === tab.id;
@@ -505,8 +505,8 @@ export function RemoteApp() {
 									type="button"
 									className={`flex-1 flex flex-col items-center justify-center h-12 gap-0.5 transition-colors ${
 										isActive
-											? "text-blue-400 border-t-2 border-blue-400"
-											: "text-neutral-500"
+											? "text-primary border-t-2 border-primary"
+											: "text-muted-foreground"
 									}`}
 									onClick={() => {
 										setActiveTab(tab.id);

--- a/src/remote/components/ConnectionForm.tsx
+++ b/src/remote/components/ConnectionForm.tsx
@@ -51,19 +51,19 @@ export function ConnectionForm({ onConnect }: ConnectionFormProps) {
 	};
 
 	return (
-		<div className="flex items-center justify-center min-h-dvh bg-neutral-950 text-neutral-100">
+		<div className="flex items-center justify-center min-h-dvh bg-background text-foreground">
 			<form
 				onSubmit={handleSubmit}
-				className="w-full max-w-md p-4 sm:p-8 space-y-6 bg-neutral-900 rounded-xl border border-neutral-800"
+				className="w-full max-w-md p-4 sm:p-8 space-y-6 bg-card rounded-xl border border-border"
 			>
 				<h1 className="text-2xl font-bold text-center">Releash Remote</h1>
-				<p className="text-sm text-neutral-400 text-center">
+				<p className="text-sm text-muted-foreground text-center">
 					Mac上のReleashに接続します
 				</p>
 
 				<div className="space-y-2">
 					<label
-						className="block text-sm font-medium text-neutral-300"
+						className="block text-sm font-medium text-secondary-foreground"
 						htmlFor="host"
 					>
 						ホスト (IP:ポート)
@@ -74,13 +74,13 @@ export function ConnectionForm({ onConnect }: ConnectionFormProps) {
 						value={host}
 						onChange={(e) => setHost(e.target.value)}
 						placeholder="192.168.1.100:9700"
-						className="w-full px-4 py-2 rounded-lg bg-neutral-800 border border-neutral-700 text-neutral-100 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+						className="w-full px-4 py-2 rounded-lg bg-input border border-border text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
 					/>
 				</div>
 
 				<div className="space-y-2">
 					<label
-						className="block text-sm font-medium text-neutral-300"
+						className="block text-sm font-medium text-secondary-foreground"
 						htmlFor="token"
 					>
 						トークン
@@ -92,12 +92,12 @@ export function ConnectionForm({ onConnect }: ConnectionFormProps) {
 							value={token}
 							onChange={(e) => setToken(e.target.value)}
 							placeholder="認証トークンを入力"
-							className="flex-1 px-4 py-2 rounded-lg bg-neutral-800 border border-neutral-700 text-neutral-100 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+							className="flex-1 px-4 py-2 rounded-lg bg-input border border-border text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
 						/>
 						<button
 							type="button"
 							onClick={() => setScanning(true)}
-							className="px-3 py-2 rounded-lg bg-neutral-700 hover:bg-neutral-600 text-sm font-medium transition-colors shrink-0"
+							className="px-3 py-2 rounded-lg bg-secondary hover:bg-secondary/80 text-secondary-foreground text-sm font-medium transition-colors shrink-0"
 						>
 							QRスキャン
 						</button>
@@ -107,7 +107,7 @@ export function ConnectionForm({ onConnect }: ConnectionFormProps) {
 				<button
 					type="submit"
 					disabled={!host || !token}
-					className="w-full py-3 rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed font-medium transition-colors"
+					className="w-full py-3 rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground disabled:opacity-40 disabled:cursor-not-allowed font-medium transition-colors"
 				>
 					接続
 				</button>

--- a/src/remote/components/DiffRenderer.test.tsx
+++ b/src/remote/components/DiffRenderer.test.tsx
@@ -33,7 +33,7 @@ describe("DiffRenderer", () => {
 				{...defaultProps}
 			/>,
 		);
-		const addedRows = container.querySelectorAll("tr.bg-green-950\\/40");
+		const addedRows = container.querySelectorAll("tr.bg-diff-added-bg");
 		expect(addedRows.length).toBeGreaterThan(0);
 	});
 
@@ -45,7 +45,7 @@ describe("DiffRenderer", () => {
 				{...defaultProps}
 			/>,
 		);
-		const deletedRows = container.querySelectorAll("tr.bg-red-950\\/40");
+		const deletedRows = container.querySelectorAll("tr.bg-diff-deleted-bg");
 		expect(deletedRows.length).toBeGreaterThan(0);
 	});
 
@@ -160,7 +160,7 @@ describe("DiffRenderer", () => {
 				selectionStart={1}
 			/>,
 		);
-		const highlighted = container.querySelectorAll("tr.ring-amber-500");
+		const highlighted = container.querySelectorAll("tr.ring-warning");
 		expect(highlighted.length).toBe(1);
 	});
 
@@ -173,7 +173,7 @@ describe("DiffRenderer", () => {
 				highlightRange={{ start: 2, end: 3 }}
 			/>,
 		);
-		const highlighted = container.querySelectorAll("tr.ring-blue-500");
+		const highlighted = container.querySelectorAll("tr.ring-primary");
 		expect(highlighted.length).toBe(2);
 	});
 });

--- a/src/remote/components/DiffRenderer.tsx
+++ b/src/remote/components/DiffRenderer.tsx
@@ -67,15 +67,15 @@ function buildDiffLines(hunk: Hunk): DiffLine[] {
 }
 
 function lineStyle(prefix: string): string {
-	if (prefix === "+") return "bg-green-950/40 text-green-300";
-	if (prefix === "-") return "bg-red-950/40 text-red-300";
-	return "bg-neutral-950 text-neutral-300";
+	if (prefix === "+") return "bg-diff-added-bg text-diff-added-fg";
+	if (prefix === "-") return "bg-diff-deleted-bg text-diff-deleted-fg";
+	return "bg-background text-foreground";
 }
 
 const LONG_PRESS_MS = 500;
 
 const lineNumberClass =
-	"w-12 text-right px-2 text-neutral-600 select-none border-r border-neutral-800 font-mono text-xs";
+	"w-12 text-right px-2 text-muted-foreground select-none border-r border-border font-mono text-xs";
 
 function isInRange(lineNum: number, range: LineRange | null): boolean {
 	if (!range) return false;
@@ -142,7 +142,7 @@ export function DiffRenderer({
 
 	if (hunks.length === 0) {
 		return (
-			<div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+			<div className="flex items-center justify-center h-full text-muted-foreground text-sm">
 				No changes
 			</div>
 		);
@@ -212,10 +212,10 @@ function HunkRows({
 
 	return (
 		<>
-			<tr className="bg-neutral-900/80">
+			<tr className="bg-card/80">
 				<td
 					colSpan={3}
-					className="px-3 py-1 text-neutral-500 text-xs select-none"
+					className="px-3 py-1 text-muted-foreground text-xs select-none"
 				>
 					@@ -{hunk.oldStart},{hunk.oldLines} +{hunk.newStart},{hunk.newLines}{" "}
 					@@
@@ -229,9 +229,9 @@ function HunkRows({
 
 				let rowHighlight = "";
 				if (isRangeHighlight) {
-					rowHighlight = "ring-1 ring-blue-500 bg-blue-950/30";
+					rowHighlight = "ring-1 ring-primary bg-primary/10";
 				} else if (isSelStart) {
-					rowHighlight = "ring-1 ring-amber-500 bg-amber-950/30";
+					rowHighlight = "ring-1 ring-warning bg-warning/10";
 				}
 
 				const group = hasGroupButtons
@@ -248,7 +248,7 @@ function HunkRows({
 						onUnstageGroup={onUnstageGroup}
 					>
 						<tr
-							className={`${lineStyle(line.prefix)} select-none ${tappable ? "active:bg-neutral-700/50" : ""} ${rowHighlight} ${isStaged ? "opacity-50" : ""}`}
+							className={`${lineStyle(line.prefix)} select-none ${tappable ? "active:bg-muted/50" : ""} ${rowHighlight} ${isStaged ? "opacity-50" : ""}`}
 							onPointerDown={
 								tappable ? () => onPointerDown(newLine) : undefined
 							}
@@ -287,11 +287,11 @@ function GroupButtonWrapper({
 
 	return (
 		<>
-			<tr className="bg-neutral-900/60">
+			<tr className="bg-card/60">
 				<td colSpan={3} className="px-3 py-0.5 select-none">
 					<div className="flex items-center gap-1.5">
 						{isStaged && (
-							<span className="text-[10px] text-green-500 font-medium">
+							<span className="text-[10px] text-success font-medium">
 								Staged
 							</span>
 						)}
@@ -299,7 +299,7 @@ function GroupButtonWrapper({
 							<button
 								type="button"
 								onClick={() => onStageGroup(group.groupIndex)}
-								className="text-[10px] px-1.5 py-0 rounded bg-green-800/80 hover:bg-green-700 text-green-100 transition-colors"
+								className="text-[10px] px-1.5 py-0 rounded bg-success/80 hover:bg-success/70 text-success-foreground transition-colors"
 							>
 								Stage
 							</button>
@@ -308,7 +308,7 @@ function GroupButtonWrapper({
 							<button
 								type="button"
 								onClick={() => onUnstageGroup(group.groupIndex)}
-								className="text-[10px] px-1.5 py-0 rounded bg-amber-800/80 hover:bg-amber-700 text-amber-100 transition-colors"
+								className="text-[10px] px-1.5 py-0 rounded bg-warning/80 hover:bg-warning/70 text-warning-foreground transition-colors"
 							>
 								Unstage
 							</button>

--- a/src/remote/components/QrTokenScanner.tsx
+++ b/src/remote/components/QrTokenScanner.tsx
@@ -42,15 +42,15 @@ export function QrTokenScanner({ onScan, onClose }: QrTokenScannerProps) {
 
 	return (
 		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
-			<div className="w-full max-w-sm mx-4 bg-neutral-900 rounded-xl border border-neutral-700 overflow-hidden">
-				<div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700">
-					<span className="text-sm font-medium text-neutral-100">
+			<div className="w-full max-w-sm mx-4 bg-card rounded-xl border border-border overflow-hidden">
+				<div className="flex items-center justify-between px-4 py-3 border-b border-border">
+					<span className="text-sm font-medium text-card-foreground">
 						トークンQRをスキャン
 					</span>
 					<button
 						type="button"
 						onClick={onClose}
-						className="text-neutral-400 hover:text-neutral-100 text-lg leading-none"
+						className="text-muted-foreground hover:text-card-foreground text-lg leading-none"
 					>
 						&times;
 					</button>

--- a/src/remote/components/RemoteCommentInput.tsx
+++ b/src/remote/components/RemoteCommentInput.tsx
@@ -23,26 +23,26 @@ export function RemoteCommentInput({
 	}, [content, onSave]);
 
 	return (
-		<div className="border-t border-neutral-700 bg-neutral-900 p-3 animate-in slide-in-from-bottom-2">
+		<div className="border-t border-border bg-card p-3 animate-in slide-in-from-bottom-2">
 			<div className="flex items-center gap-2 mb-2">
-				<span className="text-xs font-mono text-neutral-400 bg-neutral-800 px-1.5 py-0.5 rounded">
+				<span className="text-xs font-mono text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
 					L{lineNumber}
 					{endLine != null ? `-${endLine}` : ""}
 				</span>
-				<span className="text-xs text-neutral-500">コメントを追加</span>
+				<span className="text-xs text-muted-foreground">コメントを追加</span>
 			</div>
 			<textarea
 				value={content}
 				onChange={(e) => setContent(e.target.value)}
 				placeholder="コメントを入力..."
-				className="w-full bg-neutral-800 text-neutral-100 text-sm rounded px-3 py-2 resize-none border border-neutral-700 focus:border-blue-500 focus:outline-none"
+				className="w-full bg-input text-foreground text-sm rounded px-3 py-2 resize-none border border-border focus:border-primary focus:outline-none"
 				rows={3}
 			/>
 			<div className="flex justify-end gap-2 mt-2">
 				<button
 					type="button"
 					onClick={onCancel}
-					className="text-xs px-3 py-1.5 rounded bg-neutral-800 text-neutral-300 hover:bg-neutral-700 transition-colors min-h-[32px]"
+					className="text-xs px-3 py-1.5 rounded bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors min-h-[32px]"
 				>
 					キャンセル
 				</button>
@@ -50,7 +50,7 @@ export function RemoteCommentInput({
 					type="button"
 					onClick={handleSave}
 					disabled={!content.trim()}
-					className="text-xs px-3 py-1.5 rounded bg-blue-600 text-white hover:bg-blue-500 transition-colors disabled:opacity-40 disabled:cursor-not-allowed min-h-[32px]"
+					className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed min-h-[32px]"
 				>
 					保存
 				</button>

--- a/src/remote/components/RemoteCommentList.tsx
+++ b/src/remote/components/RemoteCommentList.tsx
@@ -64,7 +64,7 @@ export function RemoteCommentList({
 
 	if (visibleComments.length === 0 && sentCount === 0) {
 		return (
-			<div className="flex flex-col items-center justify-center h-full gap-3 text-neutral-500 px-6">
+			<div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground px-6">
 				<MessageSquare className="h-8 w-8" />
 				<span className="text-sm font-medium">コメントなし</span>
 				<p className="text-xs text-center leading-relaxed">
@@ -86,12 +86,12 @@ export function RemoteCommentList({
 
 	return (
 		<div className="flex flex-col h-full">
-			<div className="flex items-center justify-between px-3 py-2 border-b border-neutral-800 bg-neutral-900 shrink-0">
+			<div className="flex items-center justify-between px-3 py-2 border-b border-border bg-card shrink-0">
 				<div className="flex items-center gap-2">
-					<span className="text-xs text-neutral-400">
+					<span className="text-xs text-muted-foreground">
 						Comments
 						{unsentComments.length > 0 && (
-							<span className="ml-1.5 px-1.5 py-0.5 text-[10px] bg-blue-500/20 text-blue-400 rounded">
+							<span className="ml-1.5 px-1.5 py-0.5 text-[10px] bg-primary/20 text-primary rounded">
 								{unsentComments.length}
 							</span>
 						)}
@@ -100,7 +100,7 @@ export function RemoteCommentList({
 						<button
 							type="button"
 							onClick={() => setShowSentComments((prev) => !prev)}
-							className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] text-neutral-500 rounded hover:bg-neutral-800 transition-colors"
+							className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] text-muted-foreground rounded hover:bg-muted transition-colors"
 							data-testid="toggle-sent-comments"
 						>
 							{showSentComments ? (
@@ -116,7 +116,7 @@ export function RemoteCommentList({
 					<button
 						type="button"
 						onClick={() => onSendToTerminal(unsentComments)}
-						className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-blue-500/20 text-blue-400 rounded hover:bg-blue-500/30 transition-colors min-h-[32px]"
+						className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-primary/20 text-primary rounded hover:bg-primary/30 transition-colors min-h-[32px]"
 					>
 						<Send className="h-3.5 w-3.5" />
 						送信
@@ -128,7 +128,7 @@ export function RemoteCommentList({
 					const fileName = filePath.split("/").pop() ?? filePath;
 					return (
 						<div key={filePath} className="mb-3">
-							<div className="text-xs font-medium px-2 py-1 text-neutral-300 truncate">
+							<div className="text-xs font-medium px-2 py-1 text-secondary-foreground truncate">
 								{fileName}
 							</div>
 							{fileComments
@@ -136,20 +136,20 @@ export function RemoteCommentList({
 								.map((comment) => (
 									<div
 										key={comment.id}
-										className="group flex items-start gap-2 px-2 py-2 text-sm rounded hover:bg-neutral-800/50 transition-colors"
+										className="group flex items-start gap-2 px-2 py-2 text-sm rounded hover:bg-muted/50 transition-colors"
 									>
-										<MessageSquare className="h-4 w-4 shrink-0 mt-0.5 text-neutral-500" />
+										<MessageSquare className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" />
 										<div className="min-w-0 flex-1">
 											<div className="flex items-center gap-1.5">
-												<span className="text-neutral-500 font-mono text-xs">
+												<span className="text-muted-foreground font-mono text-xs">
 													L{comment.lineNumber}
 													{comment.endLine != null ? `-${comment.endLine}` : ""}
 												</span>
 												<span
 													className={`text-[10px] px-1 rounded ${
 														comment.status === "sent"
-															? "bg-green-500/20 text-green-400"
-															: "bg-neutral-700 text-neutral-400"
+															? "bg-success/20 text-success"
+															: "bg-muted text-muted-foreground"
 													}`}
 												>
 													{comment.status === "sent" ? "sent" : "unsent"}
@@ -170,14 +170,14 @@ export function RemoteCommentList({
 																cancelEditing();
 															}
 														}}
-														className="w-full px-2 py-1 text-sm bg-neutral-800 border border-neutral-700 rounded resize-none focus:outline-none focus:ring-1 focus:ring-blue-500 text-neutral-100"
+														className="w-full px-2 py-1 text-sm bg-input border border-border rounded resize-none focus:outline-none focus:ring-1 focus:ring-ring text-foreground"
 														rows={2}
 													/>
 													<div className="flex gap-2 mt-1">
 														<button
 															type="button"
 															onClick={submitEdit}
-															className="flex items-center gap-1 px-2 py-1 text-xs bg-blue-500/20 text-blue-400 rounded hover:bg-blue-500/30 transition-colors"
+															className="flex items-center gap-1 px-2 py-1 text-xs bg-primary/20 text-primary rounded hover:bg-primary/30 transition-colors"
 														>
 															<Check className="h-3 w-3" />
 															保存
@@ -185,7 +185,7 @@ export function RemoteCommentList({
 														<button
 															type="button"
 															onClick={cancelEditing}
-															className="flex items-center gap-1 px-2 py-1 text-xs bg-neutral-700 text-neutral-400 rounded hover:bg-neutral-600 transition-colors"
+															className="flex items-center gap-1 px-2 py-1 text-xs bg-secondary text-secondary-foreground rounded hover:bg-secondary/80 transition-colors"
 														>
 															<X className="h-3 w-3" />
 															キャンセル
@@ -193,7 +193,7 @@ export function RemoteCommentList({
 													</div>
 												</div>
 											) : (
-												<div className="text-neutral-200 mt-0.5 break-words">
+												<div className="text-foreground mt-0.5 break-words">
 													{comment.content}
 												</div>
 											)}
@@ -204,7 +204,7 @@ export function RemoteCommentList({
 													<button
 														type="button"
 														onClick={() => onSendComment(comment)}
-														className="p-1 rounded hover:bg-blue-500/20 text-neutral-500 hover:text-blue-400 transition-colors"
+														className="p-1 rounded hover:bg-primary/20 text-muted-foreground hover:text-primary transition-colors"
 														title="送信"
 													>
 														<Send className="h-3.5 w-3.5" />
@@ -214,7 +214,7 @@ export function RemoteCommentList({
 													<button
 														type="button"
 														onClick={() => onCopyComment(comment)}
-														className="p-1 rounded hover:bg-neutral-700 text-neutral-500 hover:text-neutral-300 transition-colors"
+														className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-secondary-foreground transition-colors"
 														title="コピー"
 													>
 														<Copy className="h-3.5 w-3.5" />
@@ -224,7 +224,7 @@ export function RemoteCommentList({
 													<button
 														type="button"
 														onClick={() => startEditing(comment)}
-														className="p-1 rounded hover:bg-neutral-700 text-neutral-500 hover:text-neutral-300 transition-colors"
+														className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-secondary-foreground transition-colors"
 														title="編集"
 													>
 														<Pencil className="h-3.5 w-3.5" />
@@ -234,7 +234,7 @@ export function RemoteCommentList({
 													<button
 														type="button"
 														onClick={() => onDeleteComment(comment.id)}
-														className="p-1 rounded hover:bg-red-500/20 text-neutral-500 hover:text-red-400 transition-colors"
+														className="p-1 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors"
 														title="削除"
 													>
 														<Trash2 className="h-3.5 w-3.5" />

--- a/src/remote/components/RemoteDashboard.tsx
+++ b/src/remote/components/RemoteDashboard.tsx
@@ -34,21 +34,21 @@ function WorktreeCard({
 		<button
 			key={wt.path}
 			type="button"
-			className="flex flex-col gap-3 p-4 rounded-lg border border-neutral-800 bg-neutral-900/50 hover:border-neutral-600 hover:bg-neutral-800/50 transition-colors text-left w-full"
+			className="flex flex-col gap-3 p-4 rounded-lg border border-border bg-card/50 hover:border-muted-foreground hover:bg-card transition-colors text-left w-full"
 			onClick={() => onSelect?.(wt.path)}
 		>
 			<div className="flex items-center gap-2 min-w-0">
-				<GitBranch className="size-4 shrink-0 text-neutral-500" />
+				<GitBranch className="size-4 shrink-0 text-muted-foreground" />
 				<span className="text-sm font-medium truncate">{wt.branch}</span>
-				{wt.is_locked && <Lock className="size-3 text-yellow-500 shrink-0" />}
+				{wt.is_locked && <Lock className="size-3 text-warning shrink-0" />}
 				{wt.has_pr && (
-					<span className="shrink-0 inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 font-medium">
+					<span className="shrink-0 inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-info/15 text-info font-medium">
 						<GitPullRequest className="size-2.5" />
 						{wt.pr_number && `#${wt.pr_number}`}
 					</span>
 				)}
 				{wt.is_main && (
-					<span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 font-medium">
+					<span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-primary/20 text-primary font-medium">
 						main
 					</span>
 				)}
@@ -58,11 +58,9 @@ function WorktreeCard({
 			</div>
 			<div className="text-xs">
 				{wt.dirty_count > 0 ? (
-					<span className="text-yellow-500">
-						{wt.dirty_count} files changed
-					</span>
+					<span className="text-warning">{wt.dirty_count} files changed</span>
 				) : (
-					<span className="text-green-500">clean</span>
+					<span className="text-success">clean</span>
 				)}
 			</div>
 		</button>
@@ -94,29 +92,29 @@ export function RemoteDashboard({
 
 	return (
 		<div className="flex flex-col h-full">
-			<div className="flex items-center justify-between px-3 py-2 border-b border-neutral-800">
-				<span className="text-xs font-semibold text-neutral-400 uppercase tracking-wider">
+			<div className="flex items-center justify-between px-3 py-2 border-b border-border">
+				<span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
 					Workspaces
 				</span>
 				<button
 					type="button"
 					onClick={onRefresh}
-					className="p-1 hover:bg-neutral-800 rounded transition-colors"
+					className="p-1 hover:bg-muted rounded transition-colors"
 					aria-label="Refresh"
 				>
 					<RefreshCw
-						className={`h-3.5 w-3.5 text-neutral-400 ${loading ? "animate-spin" : ""}`}
+						className={`h-3.5 w-3.5 text-muted-foreground ${loading ? "animate-spin" : ""}`}
 					/>
 				</button>
 			</div>
 			<div className="flex-1 overflow-y-auto p-3">
 				{worktrees.length === 0 && !loading && (
-					<p className="text-sm text-neutral-500 text-center py-8">
+					<p className="text-sm text-muted-foreground text-center py-8">
 						No worktrees found
 					</p>
 				)}
 				{loading && worktrees.length === 0 && (
-					<p className="text-sm text-neutral-500 text-center py-8">
+					<p className="text-sm text-muted-foreground text-center py-8">
 						Loading...
 					</p>
 				)}
@@ -125,8 +123,8 @@ export function RemoteDashboard({
 						<div key={repoPath || "__single"}>
 							{isMultiRepo && repoPath && (
 								<div className="flex items-center gap-1.5 mb-2 mt-1">
-									<FolderGit2 className="size-3.5 text-neutral-500" />
-									<span className="text-xs font-medium text-neutral-400">
+									<FolderGit2 className="size-3.5 text-muted-foreground" />
+									<span className="text-xs font-medium text-muted-foreground">
 										{repoDisplayName(repoPath)}
 									</span>
 								</div>

--- a/src/remote/components/RemoteDiffPanel.tsx
+++ b/src/remote/components/RemoteDiffPanel.tsx
@@ -196,7 +196,7 @@ export function RemoteDiffPanel({
 
 	if (!path) {
 		return (
-			<div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+			<div className="flex items-center justify-center h-full text-muted-foreground text-sm">
 				Select a file to view diff
 			</div>
 		);
@@ -204,7 +204,7 @@ export function RemoteDiffPanel({
 
 	if (loading) {
 		return (
-			<div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+			<div className="flex items-center justify-center h-full text-muted-foreground text-sm">
 				Loading...
 			</div>
 		);
@@ -213,14 +213,14 @@ export function RemoteDiffPanel({
 	return (
 		<div className="flex flex-col h-full">
 			{selectionStart != null && (
-				<div className="flex items-center px-3 py-1 border-b border-amber-800/50 bg-amber-950/30 shrink-0">
-					<span className="text-xs text-amber-400">
+				<div className="flex items-center px-3 py-1 border-b border-warning/50 bg-warning/10 shrink-0">
+					<span className="text-xs text-warning">
 						L{selectionStart} から範囲選択中 — 終了行をタップ
 					</span>
 					<button
 						type="button"
 						onClick={() => setSelectionStart(null)}
-						className="ml-auto text-xs px-2 py-0.5 rounded bg-neutral-800 text-neutral-300 hover:bg-neutral-700 transition-colors"
+						className="ml-auto text-xs px-2 py-0.5 rounded bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors"
 					>
 						キャンセル
 					</button>

--- a/src/remote/components/RemoteSourceControl.tsx
+++ b/src/remote/components/RemoteSourceControl.tsx
@@ -70,15 +70,15 @@ export function RemoteSourceControl({
 	const handleUnstageAll = useCallback(() => onUnstage([]), [onUnstage]);
 
 	return (
-		<div className="h-full flex flex-col bg-neutral-900">
-			<div className="flex items-center gap-2 h-[30px] px-3 border-b border-neutral-800 shrink-0">
-				<span className="text-xs font-semibold uppercase tracking-wide truncate text-neutral-400 flex-1">
+		<div className="h-full flex flex-col bg-card">
+			<div className="flex items-center gap-2 h-[30px] px-3 border-b border-border shrink-0">
+				<span className="text-xs font-semibold uppercase tracking-wide truncate text-muted-foreground flex-1">
 					{totalChanges} file changes
 				</span>
 				{onRefresh && (
 					<button
 						type="button"
-						className="inline-flex items-center justify-center h-5 w-5 rounded text-neutral-400 hover:text-neutral-200 hover:bg-neutral-700 transition-colors shrink-0"
+						className="inline-flex items-center justify-center h-5 w-5 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
 						onClick={onRefresh}
 						title="Refresh"
 					>
@@ -90,7 +90,7 @@ export function RemoteSourceControl({
 			<div className="flex-1 overflow-y-auto" style={{ minHeight: 0 }}>
 				<CollapsibleSection title="Unstaged" count={changedFiles.length}>
 					{changedFiles.length === 0 && (
-						<div className="px-4 py-1.5 text-xs text-neutral-500">
+						<div className="px-4 py-1.5 text-xs text-muted-foreground">
 							No unstaged changes
 						</div>
 					)}
@@ -98,7 +98,7 @@ export function RemoteSourceControl({
 						<div className="flex justify-end px-2 py-0.5">
 							<button
 								type="button"
-								className="text-[10px] text-neutral-400 hover:text-neutral-200 transition-colors"
+								className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
 								onClick={handleStageAll}
 							>
 								Stage All
@@ -121,7 +121,7 @@ export function RemoteSourceControl({
 
 				<CollapsibleSection title="Staged" count={stagedFiles.length}>
 					{stagedFiles.length === 0 && (
-						<div className="px-4 py-1.5 text-xs text-neutral-500">
+						<div className="px-4 py-1.5 text-xs text-muted-foreground">
 							No staged changes
 						</div>
 					)}
@@ -129,7 +129,7 @@ export function RemoteSourceControl({
 						<div className="flex justify-end px-2 py-0.5">
 							<button
 								type="button"
-								className="text-[10px] text-neutral-400 hover:text-neutral-200 transition-colors"
+								className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
 								onClick={handleUnstageAll}
 							>
 								Unstage All
@@ -151,17 +151,19 @@ export function RemoteSourceControl({
 				</CollapsibleSection>
 
 				{totalChanges === 0 && (
-					<div className="px-3 py-4 text-sm text-neutral-500">No changes</div>
+					<div className="px-3 py-4 text-sm text-muted-foreground">
+						No changes
+					</div>
 				)}
 			</div>
 
-			<div className="px-3 py-2 border-t border-neutral-800 shrink-0">
+			<div className="px-3 py-2 border-t border-border shrink-0">
 				<textarea
 					value={commitMessage}
 					onChange={(e) => setCommitMessage(e.target.value)}
 					placeholder="Commit message..."
 					rows={2}
-					className="w-full px-2 py-1.5 text-sm bg-neutral-800 text-neutral-200 border border-neutral-700 rounded resize-none outline-none focus:border-blue-500 placeholder:text-neutral-500"
+					className="w-full px-2 py-1.5 text-sm bg-input text-foreground border border-border rounded resize-none outline-none focus:border-primary placeholder:text-muted-foreground"
 				/>
 				<div className="flex gap-2 mt-1.5">
 					<button
@@ -169,7 +171,7 @@ export function RemoteSourceControl({
 						disabled={
 							!commitMessage.trim() || stagedFiles.length === 0 || committing
 						}
-						className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded bg-green-700 hover:bg-green-600 text-green-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+						className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded bg-success hover:bg-success/90 text-success-foreground transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
 						onClick={handleCommit}
 					>
 						{committing ? (
@@ -182,7 +184,7 @@ export function RemoteSourceControl({
 					<button
 						type="button"
 						disabled={pushing}
-						className="flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded bg-blue-700 hover:bg-blue-600 text-blue-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+						className="flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded bg-primary hover:bg-primary/90 text-primary-foreground transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
 						onClick={onPush}
 					>
 						{pushing ? (
@@ -196,7 +198,7 @@ export function RemoteSourceControl({
 			</div>
 
 			{pushResult && (
-				<div className="flex items-start gap-1 px-3 py-2 text-green-400 text-xs border-t border-neutral-800">
+				<div className="flex items-start gap-1 px-3 py-2 text-success text-xs border-t border-border">
 					<span className="flex-1 break-all">{pushResult}</span>
 					<button
 						type="button"
@@ -210,7 +212,7 @@ export function RemoteSourceControl({
 			)}
 
 			{error && (
-				<div className="flex items-start gap-1 px-3 py-2 text-red-400 text-xs border-t border-neutral-800">
+				<div className="flex items-start gap-1 px-3 py-2 text-destructive text-xs border-t border-border">
 					<span className="flex-1 break-all">{error}</span>
 					<button
 						type="button"

--- a/src/remote/components/RemoteTerminalPanel.tsx
+++ b/src/remote/components/RemoteTerminalPanel.tsx
@@ -208,19 +208,19 @@ export function RemoteTerminalPanel({
 
 	const ctrlButtonClass = modifier
 		? modifier.locked
-			? "bg-blue-600 text-white ring-2 ring-blue-400"
-			: "bg-blue-600 text-white"
-		: "bg-[#333] text-[#ccc] active:bg-[#555]";
+			? "bg-primary text-primary-foreground ring-2 ring-ring"
+			: "bg-primary text-primary-foreground"
+		: "bg-muted text-muted-foreground active:bg-muted/80";
 
 	return (
-		<div ref={rootRef} className="flex flex-col h-full bg-[#1a1a1a]">
+		<div ref={rootRef} className="flex flex-col h-full bg-terminal-bg">
 			<div
 				ref={containerRef}
-				className="flex-1 overflow-hidden bg-[#1a1a1a]"
+				className="flex-1 overflow-hidden bg-terminal-bg"
 				style={{ minHeight: 0 }}
 			/>
 
-			<div className="flex items-center px-2 py-1 bg-[#252525] border-t border-[#333] shrink-0">
+			<div className="flex items-center px-2 py-1 bg-card border-t border-border shrink-0">
 				<div className="flex gap-1 overflow-x-auto flex-1">
 					{BAR_KEYS.map((def) => {
 						const isCtrl = "modifier" in def;
@@ -231,7 +231,7 @@ export function RemoteTerminalPanel({
 								className={`px-2 py-1 text-xs rounded shrink-0 ${
 									isCtrl
 										? ctrlButtonClass
-										: "bg-[#333] text-[#ccc] active:bg-[#555]"
+										: "bg-muted text-muted-foreground active:bg-muted/80"
 								}`}
 								onPointerDown={(e) => {
 									e.preventDefault();
@@ -249,8 +249,8 @@ export function RemoteTerminalPanel({
 						type="button"
 						className={`px-2 py-1 text-xs rounded shrink-0 ${
 							menuOpen
-								? "bg-blue-600 text-white"
-								: "bg-[#333] text-[#ccc] active:bg-[#555]"
+								? "bg-primary text-primary-foreground"
+								: "bg-muted text-muted-foreground active:bg-muted/80"
 						}`}
 						onPointerDown={(e) => {
 							e.preventDefault();
@@ -263,7 +263,7 @@ export function RemoteTerminalPanel({
 
 					{menuOpen && (
 						<div
-							className="absolute bottom-full right-0 mb-1 bg-[#2d2d2d] border border-[#555] rounded p-1 grid grid-cols-4 gap-1 z-50"
+							className="absolute bottom-full right-0 mb-1 bg-input border border-border rounded p-1 grid grid-cols-4 gap-1 z-50"
 							style={{ minWidth: "180px" }}
 							onPointerDown={(e) => e.stopPropagation()}
 						>
@@ -271,7 +271,7 @@ export function RemoteTerminalPanel({
 								<button
 									key={sc.label}
 									type="button"
-									className="px-2 py-1.5 text-xs bg-[#333] text-[#ccc] rounded active:bg-[#555] whitespace-nowrap"
+									className="px-2 py-1.5 text-xs bg-muted text-muted-foreground rounded active:bg-muted/80 whitespace-nowrap"
 									onPointerDown={(e) => {
 										e.preventDefault();
 										handleShortcut(sc.key);
@@ -285,7 +285,7 @@ export function RemoteTerminalPanel({
 				</div>
 			</div>
 
-			<div className="flex gap-2 px-2 py-2 bg-[#1e1e1e] border-t border-[#333] shrink-0">
+			<div className="flex gap-2 px-2 py-2 bg-background border-t border-border shrink-0">
 				<textarea
 					ref={inputRef}
 					value={inputValue}
@@ -295,12 +295,12 @@ export function RemoteTerminalPanel({
 					autoCorrect="off"
 					autoCapitalize="off"
 					spellCheck={false}
-					className="flex-1 px-3 py-2 bg-[#2d2d2d] text-[#e0e0e0] border border-[#444] rounded text-sm outline-none focus:border-blue-500 resize-none max-h-24 leading-5"
+					className="flex-1 px-3 py-2 bg-input text-foreground border border-border rounded text-sm outline-none focus:border-primary resize-none max-h-24 leading-5"
 					placeholder="コマンドを入力..."
 				/>
 				<button
 					type="button"
-					className="px-4 py-2 bg-blue-600 text-white rounded text-sm active:bg-blue-700 shrink-0"
+					className="px-4 py-2 bg-primary text-primary-foreground rounded text-sm active:bg-primary/90 shrink-0"
 					onClick={handleSubmit}
 				>
 					送信

--- a/src/remote/components/StatusIndicator.tsx
+++ b/src/remote/components/StatusIndicator.tsx
@@ -2,10 +2,10 @@ import type { ConnectionStatus } from "../hooks/useWebSocket";
 
 const statusConfig: Record<ConnectionStatus, { label: string; color: string }> =
 	{
-		connected: { label: "接続中", color: "bg-green-500" },
-		connecting: { label: "接続試行中", color: "bg-yellow-500 animate-pulse" },
-		authenticating: { label: "認証中", color: "bg-yellow-500 animate-pulse" },
-		disconnected: { label: "切断", color: "bg-red-500" },
+		connected: { label: "接続中", color: "bg-success" },
+		connecting: { label: "接続試行中", color: "bg-warning animate-pulse" },
+		authenticating: { label: "認証中", color: "bg-warning animate-pulse" },
+		disconnected: { label: "切断", color: "bg-destructive" },
 	};
 
 interface StatusIndicatorProps {
@@ -15,9 +15,9 @@ interface StatusIndicatorProps {
 export function StatusIndicator({ status }: StatusIndicatorProps) {
 	const config = statusConfig[status];
 	return (
-		<div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-neutral-800 text-sm">
+		<div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-secondary text-sm">
 			<span className={`w-2 h-2 rounded-full ${config.color}`} />
-			<span className="text-neutral-300">{config.label}</span>
+			<span className="text-secondary-foreground">{config.label}</span>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Remote App全コンポーネントのハードコードされたneutral系カラー（`bg-neutral-950`, `text-neutral-400`等）をセマンティックトークン（`bg-background`, `text-muted-foreground`等）に置換
- Diff表示用カラートークン（`--diff-added-bg`, `--diff-deleted-fg`等）を`index.css`にダーク/ライト両テーマ分追加
- キャンセルボタンのテキスト色を`text-secondary-foreground`に統一

## Test plan
- [x] `pnpm test` 全678テスト通過
- [ ] ダークテーマでRemote App各画面の表示確認
- [ ] ライトテーマでRemote App各画面の表示確認
- [ ] Diff表示の追加/削除行ハイライト色確認

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style（スタイル）**
  * UIのカラーシステムをデザイントークンベースに統一
  * 新しい差分表示スタイリングを追加
  * テーマ色の一貫性を向上（背景、テキスト、ボーダー色など）

* **Tests（テスト）**
  * スタイル関連テストを更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->