### PR TITLE
fix: PTY入力のEnter送信を \n から \r に修正

### DIFF
--- a/src/remote/RemoteApp.tsx
+++ b/src/remote/RemoteApp.tsx
@@ -198,7 +198,11 @@ export function RemoteApp() {
 			if (activePtyId != null) {
 				send({
 					type: "pty_input",
-					payload: { pty_id: activePtyId, data: `${text}\n` },
+					payload: { pty_id: activePtyId, data: text },
+				});
+				send({
+					type: "pty_input",
+					payload: { pty_id: activePtyId, data: "\r" },
 				});
 				setComments((prev) =>
 					prev.map((c) =>
@@ -219,7 +223,11 @@ export function RemoteApp() {
 			if (activePtyId != null) {
 				send({
 					type: "pty_input",
-					payload: { pty_id: activePtyId, data: `${text}\n` },
+					payload: { pty_id: activePtyId, data: text },
+				});
+				send({
+					type: "pty_input",
+					payload: { pty_id: activePtyId, data: "\r" },
 				});
 				setComments((prev) =>
 					prev.map((c) =>

--- a/src/screens/WorktreeView.tsx
+++ b/src/screens/WorktreeView.tsx
@@ -604,7 +604,8 @@ export function WorktreeView({
 		(unsent: LineComment[]) => {
 			const text = formatCommentsForTerminal(unsent, rootPath);
 			if (text && terminalRef.current) {
-				terminalRef.current.writeToTerminal(`${text}\n`);
+				terminalRef.current.writeToTerminal(text);
+				terminalRef.current.writeToTerminal("\r");
 				markAsSent(unsent.map((c) => c.id));
 				trackEvent("comment_sent", { count: unsent.length });
 			}
@@ -616,7 +617,8 @@ export function WorktreeView({
 		(comment: LineComment) => {
 			const text = formatCommentsForTerminal([comment], rootPath);
 			if (text && terminalRef.current) {
-				terminalRef.current.writeToTerminal(`${text}\n`);
+				terminalRef.current.writeToTerminal(text);
+				terminalRef.current.writeToTerminal("\r");
 				markAsSent([comment.id]);
 				trackEvent("comment_sent", { count: 1 });
 			}


### PR DESCRIPTION
## Summary
- PTYへのEnter送信で `\n` の代わりに `\r`（carriage return）を使用するよう修正
- raw modeではCR→NL変換（`icrnl`）が無効のため `\n` はEnterとして認識されない
- `RemoteApp.tsx`（WebSocket経由）と `WorktreeView.tsx`（ローカルターミナル）の両方を修正

## Test plan
- [ ] リモートアプリからコメントをターミナルに送信し、Enterが正しく入力されること
- [ ] デスクトップアプリからコメントをターミナルに送信し、Enterが正しく入力されること

closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ターミナル入出力における改行とキャリッジリターンの処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->