### PR TITLE
feat: カード要素にシャドウとホバーエフェクトを追加

### DIFF
--- a/src/components/panels/IssuePanel.tsx
+++ b/src/components/panels/IssuePanel.tsx
@@ -343,7 +343,7 @@ function IssueCard({
 	const createdDate = new Date(issue.created_at).toLocaleDateString();
 
 	return (
-		<div className="mx-2 mb-1 rounded border border-border bg-card p-2">
+		<div className="mx-2 mb-1 rounded border border-border bg-card p-2 shadow-sm transition-[border-color,box-shadow] hover:shadow-md hover:border-primary/30">
 			<div className="flex items-start gap-1.5">
 				<span className="text-[10px] text-muted-foreground shrink-0">
 					#{issue.number}

--- a/src/components/panels/NotionPanel.tsx
+++ b/src/components/panels/NotionPanel.tsx
@@ -756,7 +756,7 @@ function NotionTaskCard({
 		: parsedDate.toLocaleDateString();
 
 	return (
-		<div className="mx-2 mb-1 rounded border border-border bg-card p-2">
+		<div className="mx-2 mb-1 rounded border border-border bg-card p-2 shadow-sm transition-[border-color,box-shadow] hover:shadow-md hover:border-primary/30">
 			<div className="flex items-start gap-1.5">
 				<span className="text-xs font-medium leading-tight flex-1 break-words">
 					{task.title}

--- a/src/components/workspace/WorktreeCard.tsx
+++ b/src/components/workspace/WorktreeCard.tsx
@@ -55,10 +55,10 @@ export function BranchCard({
 			role="button"
 			tabIndex={0}
 			data-testid={`branch-card-${branch.name}`}
-			className={`group relative flex flex-col gap-3 rounded-lg border p-3 transition-colors text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${opening ? "cursor-default" : "cursor-pointer"} ${
+			className={`group relative flex flex-col gap-3 rounded-lg border p-3 shadow-sm transition-[color,border-color,box-shadow] text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${opening ? "cursor-default" : "cursor-pointer"} ${
 				hasWorktree
-					? "border-border bg-card hover:border-primary/50"
-					: "border-border/50 bg-card/50 hover:border-border"
+					? "border-border bg-card hover:border-primary/50 hover:shadow-md"
+					: "border-border/50 bg-card/50 hover:border-border hover:shadow-md"
 			}`}
 			onClick={opening ? undefined : onOpen}
 			onKeyDown={(e) => {


### PR DESCRIPTION
## Summary
- WorktreeCard, IssueCard, NotionTaskCardに `shadow-sm` / `hover:shadow-md` を追加し、カードの奥行き感を演出
- `transition-[border-color,box-shadow]` で必要なプロパティのみスムーズにトランジション
- `hover:border-primary/30` でホバー時のボーダー色変化によりインタラクティブ感を向上

Closes #366

## Test plan
- [ ] pnpm lint パス確認済み
- [ ] pnpm test (685テスト) パス確認済み
- [ ] pnpm build パス確認済み
- [ ] 各カード（WorktreeCard, IssueCard, NotionTaskCard）のホバー時にシャドウとボーダーが変化することを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * カードコンポーネントのシャドウ効果とトランジションを改善しました
  * ホバー時の視覚的フィードバックを強化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->