### PR TITLE
refactor: インラインエラー表示をInlineMessageコンポーネントに共通化

### DIFF
--- a/src/components/panels/InlineInput.tsx
+++ b/src/components/panels/InlineInput.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
@@ -85,7 +86,9 @@ export function InlineInput({
 				className="h-[22px] px-1 text-sm bg-input border border-primary rounded-sm shadow-none outline-none focus-visible:ring-0 w-full"
 			/>
 			{error && (
-				<span className="text-[10px] text-destructive px-1">{error}</span>
+				<InlineMessage size="xs" className="px-1">
+					{error}
+				</InlineMessage>
 			)}
 		</div>
 	);

--- a/src/components/panels/IssuePanel.tsx
+++ b/src/components/panels/IssuePanel.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { EmptyState } from "@/components/panels/EmptyState";
 import { Button } from "@/components/ui/button";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useIssues } from "@/hooks/useIssues";
@@ -403,9 +404,9 @@ function IssueCard({
 			</div>
 
 			{error && (
-				<div className="mt-1.5 text-[10px] text-destructive break-all">
+				<InlineMessage size="xs" className="mt-1.5">
 					{error}
-				</div>
+				</InlineMessage>
 			)}
 
 			{existingWorktree ? (

--- a/src/components/panels/NotionPanel.tsx
+++ b/src/components/panels/NotionPanel.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useState } from "react";
 import { EmptyState } from "@/components/panels/EmptyState";
 import { Button } from "@/components/ui/button";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useNotionConfig } from "@/hooks/useNotionConfig";
@@ -307,10 +308,12 @@ function NotionConfigForm({
 			</Button>
 
 			{validationStatus && validationStatus !== "success" && (
-				<div className="text-[10px] text-destructive">{validationStatus}</div>
+				<InlineMessage size="xs">{validationStatus}</InlineMessage>
 			)}
 			{validationStatus === "success" && (
-				<div className="text-[10px] text-success">接続成功</div>
+				<InlineMessage type="success" size="xs">
+					接続成功
+				</InlineMessage>
 			)}
 
 			{properties.length > 0 && (
@@ -389,12 +392,8 @@ function NotionConfigForm({
 					保存
 				</Button>
 			</div>
-			{saveError && (
-				<div className="text-[10px] text-destructive">{saveError}</div>
-			)}
-			{deleteError && (
-				<div className="text-[10px] text-destructive">{deleteError}</div>
-			)}
+			{saveError && <InlineMessage size="xs">{saveError}</InlineMessage>}
+			{deleteError && <InlineMessage size="xs">{deleteError}</InlineMessage>}
 		</div>
 	);
 }
@@ -791,9 +790,9 @@ function NotionTaskCard({
 			</div>
 
 			{error && (
-				<div className="mt-1.5 text-[10px] text-destructive break-all">
+				<InlineMessage size="xs" className="mt-1.5">
 					{error}
-				</div>
+				</InlineMessage>
 			)}
 
 			{existingWorktree ? (

--- a/src/components/panels/PullRequestPanel.tsx
+++ b/src/components/panels/PullRequestPanel.tsx
@@ -1,6 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ExternalLink, GitPullRequest, Loader2, RefreshCw } from "lucide-react";
 import { MarkdownPreview } from "@/components/panels/MarkdownPreview";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useBranchPr } from "@/hooks/useBranchPr";
 import { usePrDetail } from "@/hooks/usePrDetail";
@@ -113,17 +114,10 @@ export function PullRequestPanel({ rootPath, branch }: PullRequestPanelProps) {
 
 	if (error && !detail) {
 		return (
-			<div className="h-full flex flex-col items-center justify-center bg-sidebar gap-2">
-				<span className="text-sm text-destructive">
+			<div className="h-full flex items-center justify-center bg-sidebar">
+				<InlineMessage layout="block" size="default" icon onRetry={refresh}>
 					Failed to load PR details
-				</span>
-				<button
-					type="button"
-					className="text-xs text-muted-foreground hover:text-foreground underline"
-					onClick={refresh}
-				>
-					Retry
-				</button>
+				</InlineMessage>
 			</div>
 		);
 	}

--- a/src/components/panels/RemotePanel.tsx
+++ b/src/components/panels/RemotePanel.tsx
@@ -12,6 +12,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useRemoteServer } from "@/hooks/useRemoteServer";
 
@@ -131,17 +132,13 @@ export function RemotePanel({
 					</div>
 
 					{/* Error */}
-					{error && (
-						<div className="text-xs text-destructive bg-destructive/10 rounded px-2 py-1.5 break-all">
-							{error}
-						</div>
-					)}
+					{error && <InlineMessage filled>{error}</InlineMessage>}
 
 					{/* LAN Mode Warning */}
 					{running && connectionMode === "lan" && (
-						<div className="text-xs text-warning bg-warning/10 border border-warning/30 rounded px-2 py-1.5">
+						<InlineMessage type="warning" filled>
 							LAN接続モード — 同一ネットワーク上のデバイスがアクセス可能です
-						</div>
+						</InlineMessage>
 					)}
 
 					{/* Network */}

--- a/src/components/panels/SearchPanel.tsx
+++ b/src/components/panels/SearchPanel.tsx
@@ -1,5 +1,6 @@
 import { CaseSensitive, Regex, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useSearch } from "@/hooks/useSearch";
@@ -207,7 +208,7 @@ export function SearchPanel({
 				{loading && (
 					<div className="text-[10px] text-muted-foreground">Searching...</div>
 				)}
-				{error && <div className="text-[10px] text-destructive">{error}</div>}
+				{error && <InlineMessage size="xs">{error}</InlineMessage>}
 			</div>
 
 			<ScrollArea className="flex-1 min-h-0 [&>[data-slot=scroll-area-viewport]>div]:block!">

--- a/src/components/panels/SettingsPanel.tsx
+++ b/src/components/panels/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { Check, Copy, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useRemoteConfig } from "@/hooks/useRemoteConfig";
@@ -364,15 +365,13 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
 										</button>
 									</div>
 
-									{hooksError && (
-										<p className="text-xs text-destructive">{hooksError}</p>
-									)}
+									{hooksError && <InlineMessage>{hooksError}</InlineMessage>}
 
 									{hooksSuccess && (
-										<p className="text-xs text-success">
+										<InlineMessage type="success">
 											設定を適用しました。Claude
 											Codeを再起動すると反映されます。
-										</p>
+										</InlineMessage>
 									)}
 
 									<div className="flex justify-end">
@@ -443,9 +442,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
 									VPN接続時は常に自動起動します。LAN接続時の自動起動は上記で制御できます。
 								</p>
 
-								{remote.error && (
-									<p className="text-xs text-destructive">{remote.error}</p>
-								)}
+								{remote.error && <InlineMessage>{remote.error}</InlineMessage>}
 							</>
 						)}
 					</div>
@@ -572,7 +569,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
 								</div>
 
 								{webhook.error && (
-									<p className="text-xs text-destructive">{webhook.error}</p>
+									<InlineMessage>{webhook.error}</InlineMessage>
 								)}
 							</>
 						)}

--- a/src/components/panels/SidebarPanel.tsx
+++ b/src/components/panels/SidebarPanel.tsx
@@ -7,6 +7,7 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useFileOperations } from "@/hooks/useFileOperations";
 import { useFileTree } from "@/hooks/useFileTree";
@@ -290,9 +291,9 @@ export function SidebarPanel({
 							)}
 
 							{error && (
-								<div className="px-2 py-4 text-sm text-destructive">
+								<InlineMessage size="default" className="px-2 py-4">
 									{error}
-								</div>
+								</InlineMessage>
 							)}
 
 							{!loading && !error && (

--- a/src/components/panels/SourceControlPanel.tsx
+++ b/src/components/panels/SourceControlPanel.tsx
@@ -1,5 +1,5 @@
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
-import { ArrowDown, ArrowUp, RefreshCw, X } from "lucide-react";
+import { ArrowDown, ArrowUp, RefreshCw } from "lucide-react";
 import { useCallback, useState } from "react";
 import { FileStatusItem } from "@/components/panels/FileStatusItem";
 import { SourceControlContextMenu } from "@/components/panels/SourceControlContextMenu";
@@ -14,6 +14,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useGitActions } from "@/hooks/useGitActions";
@@ -339,16 +340,9 @@ export function SourceControlPanel({
 					</button>
 				</div>
 				{error && (
-					<div className="flex items-start gap-1 text-destructive text-xs">
-						<span className="flex-1 break-all">{error}</span>
-						<button
-							type="button"
-							className="shrink-0"
-							onClick={() => setError(null)}
-						>
-							<X className="h-3 w-3" />
-						</button>
-					</div>
+					<InlineMessage onDismiss={() => setError(null)}>
+						{error}
+					</InlineMessage>
 				)}
 			</div>
 

--- a/src/components/ui/inline-message.test.tsx
+++ b/src/components/ui/inline-message.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { InlineMessage } from "./inline-message";
+
+describe("InlineMessage", () => {
+	it("renders children", () => {
+		render(<InlineMessage>Something went wrong</InlineMessage>);
+		expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+	});
+
+	it("applies error type by default", () => {
+		const { container } = render(<InlineMessage>Error</InlineMessage>);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("text-destructive");
+	});
+
+	it("applies success type", () => {
+		const { container } = render(
+			<InlineMessage type="success">Done</InlineMessage>,
+		);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("text-success");
+	});
+
+	it("applies warning type", () => {
+		const { container } = render(
+			<InlineMessage type="warning">Caution</InlineMessage>,
+		);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("text-warning");
+	});
+
+	it("applies info type", () => {
+		const { container } = render(
+			<InlineMessage type="info">Info</InlineMessage>,
+		);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("text-info");
+	});
+
+	it("applies xs size", () => {
+		const { container } = render(<InlineMessage size="xs">Tiny</InlineMessage>);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("text-[10px]");
+	});
+
+	it("applies sm size by default", () => {
+		const { container } = render(<InlineMessage>Small</InlineMessage>);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("text-xs");
+	});
+
+	it("applies default size", () => {
+		const { container } = render(
+			<InlineMessage size="default">Normal</InlineMessage>,
+		);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("text-sm");
+	});
+
+	it("applies filled variant", () => {
+		const { container } = render(<InlineMessage filled>Error</InlineMessage>);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("bg-destructive/10");
+		expect(el).toHaveClass("rounded");
+		expect(el).toHaveClass("px-2");
+	});
+
+	it("applies filled warning with border", () => {
+		const { container } = render(
+			<InlineMessage type="warning" filled>
+				Warning
+			</InlineMessage>,
+		);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("bg-warning/10");
+	});
+
+	it("does not show icon by default", () => {
+		const { container } = render(<InlineMessage>Error</InlineMessage>);
+		expect(container.querySelector("svg")).toBeNull();
+	});
+
+	it("shows icon when icon prop is true", () => {
+		const { container } = render(<InlineMessage icon>Error</InlineMessage>);
+		expect(container.querySelector("svg")).not.toBeNull();
+	});
+
+	it("shows dismiss button when onDismiss is provided", () => {
+		const onDismiss = vi.fn();
+		render(<InlineMessage onDismiss={onDismiss}>Error</InlineMessage>);
+		const buttons = screen.getAllByRole("button");
+		expect(buttons).toHaveLength(1);
+		fireEvent.click(buttons[0]);
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+
+	it("shows retry button when onRetry is provided (inline)", () => {
+		const onRetry = vi.fn();
+		render(<InlineMessage onRetry={onRetry}>Error</InlineMessage>);
+		const retryBtn = screen.getByText("Retry");
+		fireEvent.click(retryBtn);
+		expect(onRetry).toHaveBeenCalledOnce();
+	});
+
+	it("renders block layout with retry", () => {
+		const onRetry = vi.fn();
+		const { container } = render(
+			<InlineMessage layout="block" onRetry={onRetry}>
+				Failed
+			</InlineMessage>,
+		);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("flex-col");
+		expect(el).toHaveClass("items-center");
+		const retryBtn = screen.getByText("Retry");
+		fireEvent.click(retryBtn);
+		expect(onRetry).toHaveBeenCalledOnce();
+	});
+
+	it("merges className", () => {
+		const { container } = render(
+			<InlineMessage className="mt-2 px-3">Error</InlineMessage>,
+		);
+		const el = container.querySelector('[data-slot="inline-message"]');
+		expect(el).toHaveClass("mt-2");
+		expect(el).toHaveClass("px-3");
+	});
+
+	it("passes through HTML attributes", () => {
+		render(<InlineMessage data-testid="msg">Error</InlineMessage>);
+		expect(screen.getByTestId("msg")).toBeInTheDocument();
+	});
+});

--- a/src/components/ui/inline-message.tsx
+++ b/src/components/ui/inline-message.tsx
@@ -1,0 +1,135 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { CircleAlert, CircleCheck, Info, TriangleAlert, X } from "lucide-react";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const iconMap = {
+	error: CircleAlert,
+	warning: TriangleAlert,
+	info: Info,
+	success: CircleCheck,
+} as const;
+
+const inlineMessageVariants = cva("", {
+	variants: {
+		type: {
+			error: "text-destructive",
+			warning: "text-warning",
+			info: "text-info",
+			success: "text-success",
+		},
+		size: {
+			xs: "text-[10px]",
+			sm: "text-xs",
+			default: "text-sm",
+		},
+		filled: {
+			true: "rounded px-2 py-1.5",
+			false: "",
+		},
+		layout: {
+			inline: "flex items-start gap-1",
+			block: "flex flex-col items-center gap-2",
+		},
+	},
+	compoundVariants: [
+		{ filled: true, type: "error", className: "bg-destructive/10" },
+		{
+			filled: true,
+			type: "warning",
+			className: "bg-warning/10 border border-warning/30",
+		},
+		{ filled: true, type: "info", className: "bg-info/10" },
+		{ filled: true, type: "success", className: "bg-success/10" },
+	],
+	defaultVariants: {
+		type: "error",
+		size: "sm",
+		filled: false,
+		layout: "inline",
+	},
+});
+
+interface InlineMessageProps
+	extends React.HTMLAttributes<HTMLDivElement>,
+		VariantProps<typeof inlineMessageVariants> {
+	icon?: boolean;
+	onDismiss?: () => void;
+	onRetry?: () => void;
+}
+
+function InlineMessage({
+	className,
+	type = "error",
+	size = "sm",
+	filled = false,
+	layout = "inline",
+	icon = false,
+	onDismiss,
+	onRetry,
+	children,
+	...props
+}: InlineMessageProps) {
+	const Icon = type ? iconMap[type] : null;
+	const iconSize =
+		size === "xs" ? "size-2.5" : size === "sm" ? "size-3" : "size-3.5";
+
+	if (layout === "block") {
+		return (
+			<div
+				data-slot="inline-message"
+				className={cn(
+					inlineMessageVariants({ type, size, filled, layout, className }),
+				)}
+				{...props}
+			>
+				{icon && Icon && <Icon className={iconSize} />}
+				<span>{children}</span>
+				{onRetry && (
+					<button
+						type="button"
+						className="text-xs text-muted-foreground hover:text-foreground underline"
+						onClick={onRetry}
+					>
+						Retry
+					</button>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<div
+			data-slot="inline-message"
+			className={cn(
+				inlineMessageVariants({ type, size, filled, layout, className }),
+			)}
+			{...props}
+		>
+			{icon && Icon && <Icon className={cn(iconSize, "shrink-0 mt-0.5")} />}
+			<span className="flex-1 break-all">{children}</span>
+			{onRetry && (
+				<button
+					type="button"
+					className="shrink-0 underline hover:no-underline"
+					onClick={onRetry}
+				>
+					Retry
+				</button>
+			)}
+			{onDismiss && (
+				<button
+					type="button"
+					className="shrink-0"
+					onClick={onDismiss}
+					aria-label="Dismiss"
+				>
+					<X className={iconSize} />
+				</button>
+			)}
+		</div>
+	);
+}
+
+export { InlineMessage, inlineMessageVariants };

--- a/src/components/workspace/BaseBranchDialog.tsx
+++ b/src/components/workspace/BaseBranchDialog.tsx
@@ -10,6 +10,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { InlineMessage } from "@/components/ui/inline-message";
 import type { BranchInfo } from "@/types/git";
 
 interface BaseBranchDialogProps {
@@ -86,7 +87,7 @@ export function BaseBranchDialog({
 							</option>
 						))}
 					</select>
-					{error && <p className="text-sm text-destructive">{error}</p>}
+					{error && <InlineMessage size="default">{error}</InlineMessage>}
 				</div>
 				<AlertDialogFooter>
 					<AlertDialogCancel onClick={onCancel} disabled={saving}>

--- a/src/components/workspace/CreateWorktreeDialog.tsx
+++ b/src/components/workspace/CreateWorktreeDialog.tsx
@@ -10,6 +10,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { InlineMessage } from "@/components/ui/inline-message";
 import { Input } from "@/components/ui/input";
 import { trackEvent } from "@/lib/telemetry";
 import { branchToDir, computeWorktreeDir } from "@/lib/worktreePath";
@@ -215,7 +216,7 @@ export function CreateWorktreeDialog({
 									</select>
 								</div>
 							)}
-							{error && <p className="text-sm text-destructive">{error}</p>}
+							{error && <InlineMessage size="default">{error}</InlineMessage>}
 						</div>
 						<AlertDialogFooter>
 							<AlertDialogCancel

--- a/src/components/workspace/DeleteWorktreeDialog.tsx
+++ b/src/components/workspace/DeleteWorktreeDialog.tsx
@@ -10,6 +10,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { InlineMessage } from "@/components/ui/inline-message";
 import type { BranchCard } from "@/types/git";
 
 interface DeleteWorktreeDialogProps {
@@ -95,7 +96,7 @@ export function DeleteWorktreeDialog({
 							Force delete is required.
 						</p>
 					)}
-					{error && <p className="text-destructive">{error}</p>}
+					{error && <InlineMessage size="default">{error}</InlineMessage>}
 				</div>
 				<AlertDialogFooter>
 					<AlertDialogCancel onClick={onCancel} disabled={deleting}>

--- a/src/components/workspace/SettingsDialog.tsx
+++ b/src/components/workspace/SettingsDialog.tsx
@@ -9,6 +9,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { InlineMessage } from "@/components/ui/inline-message";
 import type { BranchInfo } from "@/types/git";
 
 interface SettingsDialogProps {
@@ -99,7 +100,7 @@ export function SettingsDialog({
 									</option>
 								))}
 							</select>
-							{error && <p className="text-xs text-destructive">{error}</p>}
+							{error && <InlineMessage>{error}</InlineMessage>}
 						</div>
 					</div>
 				</div>

--- a/src/remote/components/RemoteSourceControl.tsx
+++ b/src/remote/components/RemoteSourceControl.tsx
@@ -1,7 +1,8 @@
-import { ArrowUpFromLine, Check, Loader2, RefreshCw, X } from "lucide-react";
+import { ArrowUpFromLine, Check, Loader2, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FileStatusItem } from "@/components/panels/FileStatusItem";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
+import { InlineMessage } from "@/components/ui/inline-message";
 import type { GitFileStatus } from "@/types/git";
 
 interface RemoteSourceControlProps {
@@ -198,31 +199,22 @@ export function RemoteSourceControl({
 			</div>
 
 			{pushResult && (
-				<div className="flex items-start gap-1 px-3 py-2 text-success text-xs border-t border-border">
-					<span className="flex-1 break-all">{pushResult}</span>
-					<button
-						type="button"
-						className="shrink-0"
-						aria-label="閉じる"
-						onClick={onClearPushResult}
-					>
-						<X className="h-3 w-3" />
-					</button>
-				</div>
+				<InlineMessage
+					type="success"
+					className="px-3 py-2 border-t border-border"
+					onDismiss={onClearPushResult}
+				>
+					{pushResult}
+				</InlineMessage>
 			)}
 
 			{error && (
-				<div className="flex items-start gap-1 px-3 py-2 text-destructive text-xs border-t border-border">
-					<span className="flex-1 break-all">{error}</span>
-					<button
-						type="button"
-						className="shrink-0"
-						aria-label="エラーを閉じる"
-						onClick={onClearError}
-					>
-						<X className="h-3 w-3" />
-					</button>
-				</div>
+				<InlineMessage
+					className="px-3 py-2 border-t border-border"
+					onDismiss={onClearError}
+				>
+					{error}
+				</InlineMessage>
 			)}
 		</div>
 	);


### PR DESCRIPTION
Closes #363

## Summary
- 散在していたエラー/警告/成功メッセージの表示パターンを`InlineMessage`コンポーネントに統一
- メッセージ種別（error / warning / info / success）に応じた色とアイコンで表現
- dismissボタンに`aria-label="Dismiss"`を追加しアクセシビリティを改善
- 16ファイルにわたる一貫したメッセージ表示の共通化

## Test plan
- [x] `pnpm test` 全702件パス
- [x] `pnpm lint` パス
- [ ] 各パネルのエラー表示が正しく動作することを目視確認
- [ ] dismissボタンがスクリーンリーダーで正しく読み上げられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)