### PR TITLE
feat: エラー表示を共通Messageコンポーネントに統一

### DIFF
--- a/src/components/panels/IssuePanel.tsx
+++ b/src/components/panels/IssuePanel.tsx
@@ -11,6 +11,7 @@ import { EmptyState } from "@/components/panels/EmptyState";
 import { Button } from "@/components/ui/button";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { Input } from "@/components/ui/input";
+import { Message } from "@/components/ui/message";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useIssues } from "@/hooks/useIssues";
 import { generateIssueBranchName } from "@/lib/issueBranch";
@@ -402,11 +403,7 @@ function IssueCard({
 				<span className="ml-auto">{createdDate}</span>
 			</div>
 
-			{error && (
-				<div className="mt-1.5 text-[10px] text-destructive break-all">
-					{error}
-				</div>
-			)}
+			{error && <Message message={error} size="xs" className="mt-1.5" />}
 
 			{existingWorktree ? (
 				<Button

--- a/src/components/panels/NotionPanel.tsx
+++ b/src/components/panels/NotionPanel.tsx
@@ -13,6 +13,7 @@ import { EmptyState } from "@/components/panels/EmptyState";
 import { Button } from "@/components/ui/button";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { Input } from "@/components/ui/input";
+import { Message } from "@/components/ui/message";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useNotionConfig } from "@/hooks/useNotionConfig";
 import { useNotionLabelOptions } from "@/hooks/useNotionLabelOptions";
@@ -307,10 +308,10 @@ function NotionConfigForm({
 			</Button>
 
 			{validationStatus && validationStatus !== "success" && (
-				<div className="text-[10px] text-destructive">{validationStatus}</div>
+				<Message message={validationStatus} size="xs" />
 			)}
 			{validationStatus === "success" && (
-				<div className="text-[10px] text-success">接続成功</div>
+				<Message severity="success" message="接続成功" size="xs" />
 			)}
 
 			{properties.length > 0 && (
@@ -389,12 +390,8 @@ function NotionConfigForm({
 					保存
 				</Button>
 			</div>
-			{saveError && (
-				<div className="text-[10px] text-destructive">{saveError}</div>
-			)}
-			{deleteError && (
-				<div className="text-[10px] text-destructive">{deleteError}</div>
-			)}
+			{saveError && <Message message={saveError} size="xs" />}
+			{deleteError && <Message message={deleteError} size="xs" />}
 		</div>
 	);
 }
@@ -790,11 +787,7 @@ function NotionTaskCard({
 				<span className="ml-auto">{createdDate}</span>
 			</div>
 
-			{error && (
-				<div className="mt-1.5 text-[10px] text-destructive break-all">
-					{error}
-				</div>
-			)}
+			{error && <Message message={error} size="xs" className="mt-1.5" />}
 
 			{existingWorktree ? (
 				<Button

--- a/src/components/panels/PullRequestPanel.tsx
+++ b/src/components/panels/PullRequestPanel.tsx
@@ -1,6 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ExternalLink, GitPullRequest, Loader2, RefreshCw } from "lucide-react";
 import { MarkdownPreview } from "@/components/panels/MarkdownPreview";
+import { Message } from "@/components/ui/message";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useBranchPr } from "@/hooks/useBranchPr";
 import { usePrDetail } from "@/hooks/usePrDetail";
@@ -113,17 +114,12 @@ export function PullRequestPanel({ rootPath, branch }: PullRequestPanelProps) {
 
 	if (error && !detail) {
 		return (
-			<div className="h-full flex flex-col items-center justify-center bg-sidebar gap-2">
-				<span className="text-sm text-destructive">
-					Failed to load PR details
-				</span>
-				<button
-					type="button"
-					className="text-xs text-muted-foreground hover:text-foreground underline"
-					onClick={refresh}
-				>
-					Retry
-				</button>
+			<div className="h-full flex flex-col items-center justify-center bg-sidebar">
+				<Message
+					variant="block"
+					message="Failed to load PR details"
+					onRetry={refresh}
+				/>
 			</div>
 		);
 	}

--- a/src/components/panels/RemotePanel.tsx
+++ b/src/components/panels/RemotePanel.tsx
@@ -12,6 +12,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { Message } from "@/components/ui/message";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useRemoteServer } from "@/hooks/useRemoteServer";
 
@@ -132,16 +133,19 @@ export function RemotePanel({
 
 					{/* Error */}
 					{error && (
-						<div className="text-xs text-destructive bg-destructive/10 rounded px-2 py-1.5 break-all">
-							{error}
-						</div>
+						<Message
+							message={error}
+							className="bg-destructive/10 rounded px-2 py-1.5"
+						/>
 					)}
 
 					{/* LAN Mode Warning */}
 					{running && connectionMode === "lan" && (
-						<div className="text-xs text-warning bg-warning/10 border border-warning/30 rounded px-2 py-1.5">
-							LAN接続モード — 同一ネットワーク上のデバイスがアクセス可能です
-						</div>
+						<Message
+							severity="warning"
+							message="LAN接続モード — 同一ネットワーク上のデバイスがアクセス可能です"
+							className="bg-warning/10 border border-warning/30 rounded px-2 py-1.5"
+						/>
 					)}
 
 					{/* Network */}

--- a/src/components/panels/SourceControlPanel.tsx
+++ b/src/components/panels/SourceControlPanel.tsx
@@ -1,5 +1,5 @@
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
-import { ArrowDown, ArrowUp, RefreshCw, X } from "lucide-react";
+import { ArrowDown, ArrowUp, RefreshCw } from "lucide-react";
 import { useCallback, useState } from "react";
 import { FileStatusItem } from "@/components/panels/FileStatusItem";
 import { SourceControlContextMenu } from "@/components/panels/SourceControlContextMenu";
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { Input } from "@/components/ui/input";
+import { Message } from "@/components/ui/message";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useGitActions } from "@/hooks/useGitActions";
 import { useGitStatus } from "@/hooks/useGitStatus";
@@ -338,18 +339,7 @@ export function SourceControlPanel({
 						<ArrowUp className="h-3 w-3" />
 					</button>
 				</div>
-				{error && (
-					<div className="flex items-start gap-1 text-destructive text-xs">
-						<span className="flex-1 break-all">{error}</span>
-						<button
-							type="button"
-							className="shrink-0"
-							onClick={() => setError(null)}
-						>
-							<X className="h-3 w-3" />
-						</button>
-					</div>
-				)}
+				{error && <Message message={error} onDismiss={() => setError(null)} />}
 			</div>
 
 			{/* Discard Confirm Dialog */}

--- a/src/components/ui/message.test.tsx
+++ b/src/components/ui/message.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Message } from "./message";
+
+describe("Message", () => {
+	it("renders inline error message by default", () => {
+		render(<Message message="Something went wrong" />);
+		expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+		const root = screen
+			.getByText("Something went wrong")
+			.closest('[data-slot="message"]');
+		expect(root).toHaveClass("text-destructive");
+		expect(root).toHaveClass("text-xs");
+	});
+
+	it("renders block variant with icon", () => {
+		render(<Message variant="block" message="Failed to load" />);
+		const root = screen
+			.getByText("Failed to load")
+			.closest('[data-slot="message"]');
+		expect(root).toHaveClass("flex-col", "items-center", "text-sm");
+	});
+
+	it("applies severity classes", () => {
+		const { rerender } = render(<Message severity="warning" message="warn" />);
+		let root = screen.getByText("warn").closest('[data-slot="message"]');
+		expect(root).toHaveClass("text-warning");
+
+		rerender(<Message severity="info" message="info msg" />);
+		root = screen.getByText("info msg").closest('[data-slot="message"]');
+		expect(root).toHaveClass("text-info");
+
+		rerender(<Message severity="success" message="ok" />);
+		root = screen.getByText("ok").closest('[data-slot="message"]');
+		expect(root).toHaveClass("text-success");
+	});
+
+	it("applies xs size", () => {
+		render(<Message size="xs" message="small" />);
+		const root = screen.getByText("small").closest('[data-slot="message"]');
+		expect(root).toHaveClass("text-[10px]");
+	});
+
+	it("shows dismiss button when onDismiss provided", () => {
+		const onDismiss = vi.fn();
+		render(<Message message="err" onDismiss={onDismiss} />);
+		const buttons = screen.getAllByRole("button");
+		expect(buttons).toHaveLength(1);
+		fireEvent.click(buttons[0]);
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+
+	it("does not show dismiss button when onDismiss not provided", () => {
+		render(<Message message="err" />);
+		expect(screen.queryAllByRole("button")).toHaveLength(0);
+	});
+
+	it("shows retry button in block variant", () => {
+		const onRetry = vi.fn();
+		render(<Message variant="block" message="Failed" onRetry={onRetry} />);
+		const retryBtn = screen.getByText("Retry");
+		fireEvent.click(retryBtn);
+		expect(onRetry).toHaveBeenCalledOnce();
+	});
+
+	it("does not show retry button when onRetry not provided", () => {
+		render(<Message variant="block" message="Failed" />);
+		expect(screen.queryByText("Retry")).not.toBeInTheDocument();
+	});
+
+	it("toggles expand/collapse when expandable", () => {
+		render(<Message message="long error text here" expandable />);
+		const msgSpan = screen.getByText("long error text here");
+		expect(msgSpan).toHaveClass("truncate");
+
+		const toggleBtn = screen.getAllByRole("button")[0];
+		fireEvent.click(toggleBtn);
+		expect(msgSpan).not.toHaveClass("truncate");
+
+		fireEvent.click(toggleBtn);
+		expect(msgSpan).toHaveClass("truncate");
+	});
+
+	it("applies custom className", () => {
+		render(<Message message="test" className="bg-red-500 px-2" />);
+		const root = screen.getByText("test").closest('[data-slot="message"]');
+		expect(root).toHaveClass("bg-red-500", "px-2");
+	});
+});

--- a/src/components/ui/message.tsx
+++ b/src/components/ui/message.tsx
@@ -1,0 +1,109 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { AlertCircle, ChevronDown, RotateCcw, X } from "lucide-react";
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+const messageVariants = cva("", {
+	variants: {
+		variant: {
+			inline: "flex items-start gap-1 text-xs",
+			block: "flex flex-col items-center gap-2 text-sm",
+		},
+		severity: {
+			error: "text-destructive",
+			warning: "text-warning",
+			info: "text-info",
+			success: "text-success",
+		},
+		size: {
+			default: "",
+			xs: "text-[10px]",
+		},
+	},
+	defaultVariants: {
+		variant: "inline",
+		severity: "error",
+		size: "default",
+	},
+});
+
+interface MessageProps extends VariantProps<typeof messageVariants> {
+	message: string;
+	onDismiss?: () => void;
+	onRetry?: () => void;
+	expandable?: boolean;
+	className?: string;
+}
+
+function Message({
+	message,
+	variant = "inline",
+	severity = "error",
+	size = "default",
+	onDismiss,
+	onRetry,
+	expandable = false,
+	className,
+}: MessageProps) {
+	const [expanded, setExpanded] = useState(false);
+
+	if (variant === "block") {
+		return (
+			<div
+				data-slot="message"
+				className={cn(messageVariants({ variant, severity, size, className }))}
+			>
+				<AlertCircle className="size-5 shrink-0" />
+				<span>{message}</span>
+				{onRetry && (
+					<button
+						type="button"
+						className="text-xs text-muted-foreground hover:text-foreground underline"
+						onClick={onRetry}
+					>
+						<RotateCcw className="size-3 inline mr-0.5" />
+						Retry
+					</button>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<div
+			data-slot="message"
+			className={cn(messageVariants({ variant, severity, size, className }))}
+		>
+			{expandable && (
+				<button
+					type="button"
+					className="shrink-0 mt-0.5"
+					onClick={() => setExpanded((v) => !v)}
+				>
+					<ChevronDown
+						className={cn(
+							"size-3 transition-transform",
+							expanded && "rotate-180",
+						)}
+					/>
+				</button>
+			)}
+			<span
+				className={cn(
+					"flex-1 break-all",
+					!expanded && expandable && "truncate",
+				)}
+			>
+				{message}
+			</span>
+			{onDismiss && (
+				<button type="button" className="shrink-0" onClick={onDismiss}>
+					<X className="size-3" />
+				</button>
+			)}
+		</div>
+	);
+}
+
+export { Message, messageVariants };


### PR DESCRIPTION
## Summary
- CVAパターンで `Message` 共通コンポーネント (`src/components/ui/message.tsx`) を新規作成
- SourceControlPanel, PullRequestPanel, RemotePanel, IssuePanel, NotionPanel の計9箇所のエラー・警告・成功メッセージ表示を `Message` に置き換え
- variant (inline/block), severity (error/warning/info/success), size (default/xs) をサポート

## Test plan
- [x] `pnpm test` — 新規10テスト含む全695テスト通過
- [x] `pnpm lint` — Biome check 通過
- [x] `pnpm build` — ビルド成功

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)