### PR TITLE
feat: コンテキストメニューにLucideアイコンを追加 (#369)

### DIFF
--- a/src/components/panels/FileTreeContextMenu.tsx
+++ b/src/components/panels/FileTreeContextMenu.tsx
@@ -1,4 +1,15 @@
 import {
+	Clipboard,
+	ClipboardPaste,
+	Copy,
+	ExternalLink,
+	FilePlus,
+	FolderPlus,
+	Pencil,
+	Scissors,
+	Trash2,
+} from "lucide-react";
+import {
 	ContextMenu,
 	ContextMenuContent,
 	ContextMenuItem,
@@ -49,30 +60,52 @@ export function FileTreeContextMenu({
 			<ContextMenuContent className="w-56">
 				{isFolder && (
 					<>
-						<ContextMenuItem onClick={onNewFile}>新規ファイル</ContextMenuItem>
+						<ContextMenuItem onClick={onNewFile}>
+							<FilePlus />
+							新規ファイル
+						</ContextMenuItem>
 						<ContextMenuItem onClick={onNewFolder}>
+							<FolderPlus />
 							新規フォルダ
 						</ContextMenuItem>
 						<ContextMenuSeparator />
 					</>
 				)}
-				<ContextMenuItem onClick={onCut}>切り取り</ContextMenuItem>
-				<ContextMenuItem onClick={onCopy}>コピー</ContextMenuItem>
+				<ContextMenuItem onClick={onCut}>
+					<Scissors />
+					切り取り
+				</ContextMenuItem>
+				<ContextMenuItem onClick={onCopy}>
+					<Copy />
+					コピー
+				</ContextMenuItem>
 				{clipboard && (
-					<ContextMenuItem onClick={onPaste}>貼り付け</ContextMenuItem>
+					<ContextMenuItem onClick={onPaste}>
+						<ClipboardPaste />
+						貼り付け
+					</ContextMenuItem>
 				)}
 				<ContextMenuSeparator />
-				<ContextMenuItem onClick={onCopyPath}>パスをコピー</ContextMenuItem>
+				<ContextMenuItem onClick={onCopyPath}>
+					<Clipboard />
+					パスをコピー
+				</ContextMenuItem>
 				<ContextMenuItem onClick={onCopyRelativePath}>
+					<Clipboard />
 					相対パスをコピー
 				</ContextMenuItem>
 				<ContextMenuSeparator />
-				<ContextMenuItem onClick={onRename}>名前の変更</ContextMenuItem>
+				<ContextMenuItem onClick={onRename}>
+					<Pencil />
+					名前の変更
+				</ContextMenuItem>
 				<ContextMenuItem onClick={onDelete} variant="destructive">
+					<Trash2 />
 					削除
 				</ContextMenuItem>
 				<ContextMenuSeparator />
 				<ContextMenuItem onClick={onRevealInFinder}>
+					<ExternalLink />
 					Finder で表示
 				</ContextMenuItem>
 			</ContextMenuContent>

--- a/src/components/panels/SourceControlContextMenu.tsx
+++ b/src/components/panels/SourceControlContextMenu.tsx
@@ -1,4 +1,12 @@
 import {
+	Clipboard,
+	ExternalLink,
+	FilePen,
+	Minus,
+	Plus,
+	Undo2,
+} from "lucide-react";
+import {
 	ContextMenu,
 	ContextMenuContent,
 	ContextMenuItem,
@@ -36,25 +44,40 @@ export function SourceControlContextMenu({
 				<div onContextMenu={(e) => e.stopPropagation()}>{children}</div>
 			</ContextMenuTrigger>
 			<ContextMenuContent className="w-56">
-				<ContextMenuItem onClick={onOpenChanges}>変更を開く</ContextMenuItem>
+				<ContextMenuItem onClick={onOpenChanges}>
+					<FilePen />
+					変更を開く
+				</ContextMenuItem>
 				{variant === "unstaged" && onStage && (
-					<ContextMenuItem onClick={onStage}>ステージ</ContextMenuItem>
+					<ContextMenuItem onClick={onStage}>
+						<Plus />
+						ステージ
+					</ContextMenuItem>
 				)}
 				{variant === "staged" && onUnstage && (
-					<ContextMenuItem onClick={onUnstage}>アンステージ</ContextMenuItem>
+					<ContextMenuItem onClick={onUnstage}>
+						<Minus />
+						アンステージ
+					</ContextMenuItem>
 				)}
 				{variant === "unstaged" && onDiscard && (
 					<ContextMenuItem onClick={onDiscard} variant="destructive">
+						<Undo2 />
 						変更を破棄
 					</ContextMenuItem>
 				)}
 				<ContextMenuSeparator />
-				<ContextMenuItem onClick={onCopyPath}>パスをコピー</ContextMenuItem>
+				<ContextMenuItem onClick={onCopyPath}>
+					<Clipboard />
+					パスをコピー
+				</ContextMenuItem>
 				<ContextMenuItem onClick={onCopyRelativePath}>
+					<Clipboard />
 					相対パスをコピー
 				</ContextMenuItem>
 				<ContextMenuSeparator />
 				<ContextMenuItem onClick={onRevealInFinder}>
+					<ExternalLink />
 					Finder で表示
 				</ContextMenuItem>
 			</ContextMenuContent>


### PR DESCRIPTION
## Summary
- ファイルツリーとソース管理のコンテキストメニューに Lucide アイコンを追加し、操作の視認性を向上
- `FileTreeContextMenu` に 10 種、`SourceControlContextMenu` に 7 種のアイコンを配置
- `ContextMenuItem` の既存スタイリング（`gap-2`, `[&_svg]:size-4`）を活用し、子要素として追加するだけで正しく表示

## Test plan
- [x] `pnpm lint` — Biome check 通過
- [x] `pnpm test` — 73 ファイル、685 テスト全合格
- [x] `pnpm build` — ビルド成功
- [ ] スクリーンショットテストの更新（`pnpm test:update-screenshots`）

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)