### PR TITLE
fix: パネル境界の視覚的区分を改善

### DIFF
--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -102,7 +102,7 @@ export function ActivityBar({
 		<div
 			className={cn(
 				"flex flex-col items-center w-12 py-1",
-				"bg-sidebar border-r border-sidebar-border",
+				"bg-activity-bar border-r border-activity-bar-border",
 				className,
 			)}
 		>
@@ -113,7 +113,7 @@ export function ActivityBar({
 						isActive={false}
 						onClick={onGoHome}
 					/>
-					<div className="w-8 border-b border-sidebar-border my-1" />
+					<div className="w-8 border-b border-activity-bar-border my-1" />
 				</>
 			)}
 			{items.map((item) => (

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -39,7 +39,7 @@ export function ReviewPanel({
 	const unsentComments = comments.filter((c) => c.status === "unsent");
 
 	return (
-		<div className="flex flex-col h-full border-t border-border">
+		<div className="flex flex-col h-full">
 			<div className="flex items-center justify-between border-b border-border bg-card">
 				<div className="flex items-center" role="tablist">
 					<button

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,10 @@
 	--ring: oklch(0.6116 0.0714 197.91);
 	--radius: 0.375rem;
 
+	/* ActivityBar */
+	--activity-bar: oklch(0.14 0.005 260);
+	--activity-bar-border: oklch(0.25 0.005 260);
+
 	/* サイドバー */
 	--sidebar: oklch(0.17 0.005 260);
 	--sidebar-foreground: oklch(0.85 0 0);
@@ -93,6 +97,9 @@
 	--border: oklch(0.85 0.005 260);
 	--input: oklch(0.93 0.005 260);
 	--ring: oklch(0.6116 0.0714 197.91);
+
+	--activity-bar: oklch(0.92 0.005 260);
+	--activity-bar-border: oklch(0.82 0.005 260);
 
 	--sidebar: oklch(0.95 0.005 260);
 	--sidebar-foreground: oklch(0.2 0 0);
@@ -156,6 +163,8 @@
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 4px);
+	--color-activity-bar: var(--activity-bar);
+	--color-activity-bar-border: var(--activity-bar-border);
 	--color-sidebar: var(--sidebar);
 	--color-sidebar-foreground: var(--sidebar-foreground);
 	--color-sidebar-primary: var(--sidebar-primary);

--- a/src/styles/flexlayout-custom.css
+++ b/src/styles/flexlayout-custom.css
@@ -115,7 +115,7 @@
 @media (hover: hover) {
   .flexlayout__splitter:hover {
     background-color: var(--primary);
-    opacity: 0.5;
+    opacity: 0.7;
     border-radius: 0;
   }
 }

--- a/src/styles/resizable-panels.css
+++ b/src/styles/resizable-panels.css
@@ -1,11 +1,12 @@
-/* Separator: transparent by default, visible on hover/drag (VSCode sash style) */
+/* Separator: border color by default, primary on hover/drag */
 [data-separator] {
-	background-color: transparent;
-	transition: background-color 0.1s ease-out;
+	background-color: var(--border);
+	transition: background-color 0.15s ease-out;
 }
 
 [data-separator="hover"] {
 	background-color: var(--primary);
+	opacity: 0.7;
 }
 
 [data-separator="active"] {


### PR DESCRIPTION
## Summary
- ActivityBarに専用背景色(`--activity-bar`)を導入し、サイドバー/メインエリアとの明度階層を明確化
- リサイズハンドル(Separator)をデフォルトで`--border`色表示にし、パネル境界を常に視認可能に
- FlexLayoutスプリッターとSeparatorのホバーopacityを0.7に統一、ReviewPanelのborder-t重複を解消

## Test plan
- [x] `pnpm lint` — Biomeチェック通過
- [x] `pnpm test` — 73ファイル 685テスト全通過
- [x] `pnpm build` — メイン + リモート両方ビルド成功
- [x] `pnpm test:integration` — Playwright 41テスト全通過

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)