### PR TITLE
feat: Push操作のプログレスインジケーター追加

### DIFF
--- a/src/components/panels/SourceControlCommitForm.tsx
+++ b/src/components/panels/SourceControlCommitForm.tsx
@@ -1,4 +1,5 @@
-import { ArrowUp } from "lucide-react";
+import { ArrowUp, Loader2 } from "lucide-react";
+import { useEffect } from "react";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -17,27 +18,38 @@ interface CommitFormProps {
 	commitSummary: string;
 	commitDescription: string;
 	loading: boolean;
+	pushing: boolean;
 	error: string | null;
+	successMessage: string | null;
 	stagedFilesCount: number;
 	onSummaryChange: (value: string) => void;
 	onDescriptionChange: (value: string) => void;
 	onCommit: () => void;
 	onPush: () => void;
 	onDismissError: () => void;
+	onDismissSuccess: () => void;
 }
 
 export function CommitForm({
 	commitSummary,
 	commitDescription,
 	loading,
+	pushing,
 	error,
+	successMessage,
 	stagedFilesCount,
 	onSummaryChange,
 	onDescriptionChange,
 	onCommit,
 	onPush,
 	onDismissError,
+	onDismissSuccess,
 }: CommitFormProps) {
+	useEffect(() => {
+		if (!successMessage) return;
+		const timer = setTimeout(onDismissSuccess, 3000);
+		return () => clearTimeout(timer);
+	}, [successMessage, onDismissSuccess]);
 	return (
 		<div className="border-t border-border px-3 py-2 shrink-0 flex flex-col gap-1.5">
 			<div className="relative">
@@ -93,10 +105,26 @@ export function CommitForm({
 					disabled={loading}
 					onClick={onPush}
 				>
-					Push
-					<ArrowUp className="h-3 w-3" />
+					{pushing ? (
+						<>
+							<Loader2 className="h-3 w-3 animate-spin" />
+							Pushing...
+						</>
+					) : (
+						<>
+							<ArrowUp className="h-3 w-3" />
+							Push
+						</>
+					)}
 				</button>
 			</div>
+			{successMessage && (
+				<Message
+					message={successMessage}
+					severity="success"
+					onDismiss={onDismissSuccess}
+				/>
+			)}
 			{error && <Message message={error} onDismiss={onDismissError} />}
 		</div>
 	);

--- a/src/components/panels/SourceControlPanel.test.tsx
+++ b/src/components/panels/SourceControlPanel.test.tsx
@@ -251,6 +251,39 @@ describe("SourceControlPanel", () => {
 		});
 	});
 
+	it("should show 'Pushing...' while push is in progress", async () => {
+		let resolvePush: ((value: unknown) => void) | undefined;
+		mockGitActions.push.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolvePush = resolve;
+				}),
+		);
+		render(<SourceControlPanel rootPath="/test/repo" />);
+
+		fireEvent.click(screen.getByText("Push"));
+
+		await waitFor(() => {
+			expect(screen.getByText("Pushing...")).toBeInTheDocument();
+		});
+
+		resolvePush?.("ok");
+
+		await waitFor(() => {
+			expect(screen.queryByText("Pushing...")).not.toBeInTheDocument();
+		});
+	});
+
+	it("should show success message after push completes", async () => {
+		render(<SourceControlPanel rootPath="/test/repo" />);
+
+		fireEvent.click(screen.getByText("Push"));
+
+		await waitFor(() => {
+			expect(screen.getByText("Pushed successfully")).toBeInTheDocument();
+		});
+	});
+
 	describe("context menu", () => {
 		it("should show context menu on right-click for unstaged file", async () => {
 			const user = userEvent.setup();

--- a/src/components/panels/SourceControlPanel.tsx
+++ b/src/components/panels/SourceControlPanel.tsx
@@ -16,6 +16,8 @@ interface CommitFormState {
 	description: string;
 	error: string | null;
 	loading: boolean;
+	pushing: boolean;
+	successMessage: string | null;
 	discardTarget: { path: string; paths: string[] } | null;
 }
 
@@ -29,6 +31,7 @@ type CommitFormAction =
 	| { type: "PUSH_START" }
 	| { type: "PUSH_END" }
 	| { type: "PUSH_ERROR"; error: string }
+	| { type: "DISMISS_SUCCESS" }
 	| { type: "SET_DISCARD_TARGET"; target: CommitFormState["discardTarget"] }
 	| { type: "CLEAR_DISCARD" };
 
@@ -37,6 +40,8 @@ const initialCommitForm: CommitFormState = {
 	description: "",
 	error: null,
 	loading: false,
+	pushing: false,
+	successMessage: null,
 	discardTarget: null,
 };
 
@@ -52,17 +57,30 @@ export function commitFormReducer(
 		case "SET_ERROR":
 			return { ...state, error: action.error };
 		case "COMMIT_START":
-			return { ...state, loading: true, error: null };
+			return { ...state, loading: true, error: null, successMessage: null };
 		case "COMMIT_SUCCESS":
 			return { ...state, loading: false, summary: "", description: "" };
 		case "COMMIT_ERROR":
 			return { ...state, loading: false, error: action.error };
 		case "PUSH_START":
-			return { ...state, loading: true, error: null };
+			return {
+				...state,
+				loading: true,
+				pushing: true,
+				error: null,
+				successMessage: null,
+			};
 		case "PUSH_END":
-			return { ...state, loading: false };
+			return {
+				...state,
+				loading: false,
+				pushing: false,
+				successMessage: "Pushed successfully",
+			};
 		case "PUSH_ERROR":
-			return { ...state, loading: false, error: action.error };
+			return { ...state, loading: false, pushing: false, error: action.error };
+		case "DISMISS_SUCCESS":
+			return { ...state, successMessage: null };
 		case "SET_DISCARD_TARGET":
 			return { ...state, discardTarget: action.target };
 		case "CLEAR_DISCARD":
@@ -96,6 +114,8 @@ export function SourceControlPanel({
 		description: commitDescription,
 		error,
 		loading,
+		pushing,
+		successMessage,
 		discardTarget,
 	} = form;
 
@@ -167,6 +187,10 @@ export function SourceControlPanel({
 		refreshStatus,
 		onGitChanged,
 	]);
+
+	const handleDismissSuccess = useCallback(() => {
+		dispatch({ type: "DISMISS_SUCCESS" });
+	}, []);
 
 	const handlePush = useCallback(async () => {
 		if (!rootPath) return;
@@ -331,7 +355,9 @@ export function SourceControlPanel({
 				commitSummary={commitSummary}
 				commitDescription={commitDescription}
 				loading={loading}
+				pushing={pushing}
 				error={error}
+				successMessage={successMessage}
 				stagedFilesCount={stagedFiles.length}
 				onSummaryChange={(value) => dispatch({ type: "SET_SUMMARY", value })}
 				onDescriptionChange={(value) =>
@@ -340,6 +366,7 @@ export function SourceControlPanel({
 				onCommit={handleCommit}
 				onPush={handlePush}
 				onDismissError={() => dispatch({ type: "SET_ERROR", error: null })}
+				onDismissSuccess={handleDismissSuccess}
 			/>
 
 			{/* Discard Confirm Dialog */}

--- a/src/components/panels/reducers.test.ts
+++ b/src/components/panels/reducers.test.ts
@@ -11,6 +11,8 @@ describe("commitFormReducer", () => {
 		description: "",
 		error: null as string | null,
 		loading: false,
+		pushing: false,
+		successMessage: null as string | null,
 		discardTarget: null as { path: string; paths: string[] } | null,
 	};
 
@@ -44,11 +46,16 @@ describe("commitFormReducer", () => {
 		expect(state.error).toBeNull();
 	});
 
-	it("COMMIT_START sets loading=true and clears error", () => {
-		const prev = { ...initial, error: "old error" };
+	it("COMMIT_START sets loading=true and clears error and successMessage", () => {
+		const prev = {
+			...initial,
+			error: "old error",
+			successMessage: "Pushed successfully",
+		};
 		const state = commitFormReducer(prev, { type: "COMMIT_START" });
 		expect(state.loading).toBe(true);
 		expect(state.error).toBeNull();
+		expect(state.successMessage).toBeNull();
 	});
 
 	it("COMMIT_SUCCESS resets loading, summary, and description", () => {
@@ -74,27 +81,42 @@ describe("commitFormReducer", () => {
 		expect(state.error).toBe("commit failed");
 	});
 
-	it("PUSH_START sets loading=true and clears error", () => {
-		const prev = { ...initial, error: "old" };
+	it("PUSH_START sets loading=true, pushing=true and clears error and successMessage", () => {
+		const prev = {
+			...initial,
+			error: "old",
+			successMessage: "Pushed successfully",
+		};
 		const state = commitFormReducer(prev, { type: "PUSH_START" });
 		expect(state.loading).toBe(true);
+		expect(state.pushing).toBe(true);
 		expect(state.error).toBeNull();
+		expect(state.successMessage).toBeNull();
 	});
 
-	it("PUSH_END clears loading", () => {
-		const prev = { ...initial, loading: true };
+	it("PUSH_END clears loading and pushing, sets successMessage", () => {
+		const prev = { ...initial, loading: true, pushing: true };
 		const state = commitFormReducer(prev, { type: "PUSH_END" });
 		expect(state.loading).toBe(false);
+		expect(state.pushing).toBe(false);
+		expect(state.successMessage).toBe("Pushed successfully");
 	});
 
-	it("PUSH_ERROR sets error and clears loading", () => {
-		const prev = { ...initial, loading: true };
+	it("PUSH_ERROR sets error and clears loading and pushing", () => {
+		const prev = { ...initial, loading: true, pushing: true };
 		const state = commitFormReducer(prev, {
 			type: "PUSH_ERROR",
 			error: "push rejected",
 		});
 		expect(state.loading).toBe(false);
+		expect(state.pushing).toBe(false);
 		expect(state.error).toBe("push rejected");
+	});
+
+	it("DISMISS_SUCCESS clears successMessage", () => {
+		const prev = { ...initial, successMessage: "Pushed successfully" };
+		const state = commitFormReducer(prev, { type: "DISMISS_SUCCESS" });
+		expect(state.successMessage).toBeNull();
 	});
 
 	it("SET_DISCARD_TARGET updates discardTarget", () => {


### PR DESCRIPTION
## Summary
- Push操作中にスピナー（Loader2）+ "Pushing..." テキストを表示するように変更
- Push成功時に "Pushed successfully" メッセージを表示（3秒後に自動消去）
- reducer に `pushing` / `successMessage` ステートと `DISMISS_SUCCESS` アクションを追加

## Test plan
- [x] `pnpm test` — 全797テストパス
- [x] `pnpm lint` — エラーなし
- [x] `pnpm build` — ビルド成功
- [ ] デスクトップアプリでPushボタン押下時にスピナーが表示されることを確認
- [ ] Push成功後に "Pushed successfully" メッセージが表示され、3秒後に消えることを確認
- [ ] Push失敗時にエラーメッセージが表示されることを確認

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ソースコントロールのプッシュ操作中に「Pushing...」ローディング表示を追加
  * プッシュ完了時に「Pushed successfully」の成功メッセージを表示
  * 成功メッセージは3秒後に自動消去される機能を実装
  * ユーザーが成功メッセージを手動で消去できるようにしました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->