### PR TITLE
feat: ソース管理パネルに ahead/behind 表示を追加

### DIFF
--- a/src-tauri/src/git/branch.rs
+++ b/src-tauri/src/git/branch.rs
@@ -1,5 +1,5 @@
 use super::error::GitError;
-use super::types::BranchInfo;
+use super::types::{AheadBehind, BranchInfo};
 use super::worktree::{get_branch_name_for_repo, remove_worktree};
 use git2::{build::CheckoutBuilder, BranchType, Repository, WorktreePruneOptions};
 use std::path::Path;
@@ -65,6 +65,52 @@ pub fn get_current_branch(repo_path: String) -> Result<String, GitError> {
         let short = &oid.to_string()[..7];
         Ok(format!("({short})"))
     }
+}
+
+pub fn get_current_branch_ahead_behind(repo_path: String) -> Result<AheadBehind, GitError> {
+    let no_upstream = AheadBehind {
+        ahead: 0,
+        behind: 0,
+        has_upstream: false,
+    };
+
+    let repo = Repository::open(&repo_path)?;
+
+    let head = match repo.head() {
+        Ok(h) => h,
+        Err(e) if e.code() == git2::ErrorCode::UnbornBranch => return Ok(no_upstream),
+        Err(e) => return Err(e.into()),
+    };
+
+    if !head.is_branch() {
+        return Ok(no_upstream);
+    }
+
+    let branch_name = head
+        .shorthand()
+        .ok_or_else(|| GitError::Custom("HEAD has no shorthand".to_string()))?;
+    let branch = repo.find_branch(branch_name, BranchType::Local)?;
+
+    let upstream = match branch.upstream() {
+        Ok(u) => u,
+        Err(_) => return Ok(no_upstream),
+    };
+
+    let local_oid = head
+        .target()
+        .ok_or_else(|| GitError::Custom("HEAD has no target".to_string()))?;
+    let remote_oid = upstream
+        .get()
+        .target()
+        .ok_or_else(|| GitError::Custom("upstream has no target".to_string()))?;
+
+    let (ahead, behind) = repo.graph_ahead_behind(local_oid, remote_oid)?;
+
+    Ok(AheadBehind {
+        ahead,
+        behind,
+        has_upstream: true,
+    })
 }
 
 pub fn git_create_branch(repo_path: String, branch_name: String) -> Result<(), GitError> {
@@ -185,6 +231,53 @@ mod tests {
     use crate::git::test_helpers::*;
     use git2::WorktreeAddOptions;
     use std::path::{Path, PathBuf};
+
+    // ── ahead/behind tests ──
+
+    #[test]
+    fn test_ahead_behind_no_upstream() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+
+        let result =
+            get_current_branch_ahead_behind(dir.path().to_str().unwrap().to_string()).unwrap();
+        assert!(!result.has_upstream);
+        assert_eq!(result.ahead, 0);
+        assert_eq!(result.behind, 0);
+    }
+
+    #[test]
+    fn test_ahead_behind_empty_repo() {
+        let (dir, _repo) = create_test_repo();
+
+        let result =
+            get_current_branch_ahead_behind(dir.path().to_str().unwrap().to_string()).unwrap();
+        assert!(!result.has_upstream);
+    }
+
+    #[test]
+    fn test_ahead_behind_detached_head() {
+        let (dir, repo) = create_test_repo();
+        let oid = create_initial_commit(&repo);
+        repo.set_head_detached(oid).unwrap();
+
+        let result =
+            get_current_branch_ahead_behind(dir.path().to_str().unwrap().to_string()).unwrap();
+        assert!(!result.has_upstream);
+    }
+
+    #[test]
+    fn test_ahead_behind_with_upstream() {
+        let (_parent, clone_dir, repo) = setup_remote_repo();
+
+        add_and_commit(&repo, "local.txt", "local", "local commit");
+
+        let result =
+            get_current_branch_ahead_behind(clone_dir.to_str().unwrap().to_string()).unwrap();
+        assert!(result.has_upstream);
+        assert_eq!(result.ahead, 1);
+        assert_eq!(result.behind, 0);
+    }
 
     #[test]
     fn test_get_current_branch() {

--- a/src-tauri/src/git/commands.rs
+++ b/src-tauri/src/git/commands.rs
@@ -1,5 +1,5 @@
 use super::error::GitError;
-use super::types::{BranchCard, BranchInfo, WorktreeEntry};
+use super::types::{AheadBehind, BranchCard, BranchInfo, WorktreeEntry};
 
 async fn blocking<T, F>(f: F) -> Result<T, GitError>
 where
@@ -21,6 +21,11 @@ pub async fn list_branches(repo_path: String) -> Result<Vec<BranchInfo>, GitErro
 #[tauri::command]
 pub async fn get_current_branch(repo_path: String) -> Result<String, GitError> {
     blocking(move || super::branch::get_current_branch(repo_path)).await
+}
+
+#[tauri::command]
+pub async fn get_current_branch_ahead_behind(repo_path: String) -> Result<AheadBehind, GitError> {
+    blocking(move || super::branch::get_current_branch_ahead_behind(repo_path)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -65,4 +65,29 @@ pub(crate) mod test_helpers {
         repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])
             .unwrap()
     }
+
+    pub fn setup_remote_repo() -> (TempDir, std::path::PathBuf, Repository) {
+        let parent = TempDir::new().unwrap();
+
+        let bare_dir = parent.path().join("bare.git");
+        let bare = Repository::init_bare(&bare_dir).unwrap();
+        {
+            let sig = Signature::now("Test", "test@example.com").unwrap();
+            let tree_id = bare.treebuilder(None).unwrap().write().unwrap();
+            let tree = bare.find_tree(tree_id).unwrap();
+            bare.commit(Some("refs/heads/main"), &sig, &sig, "init", &tree, &[])
+                .unwrap();
+            bare.set_head("refs/heads/main").unwrap();
+        }
+
+        let clone_dir = parent.path().join("clone");
+        let repo = Repository::clone(bare_dir.to_str().unwrap(), &clone_dir).unwrap();
+        {
+            let mut config = repo.config().unwrap();
+            config.set_str("user.name", "Test").unwrap();
+            config.set_str("user.email", "test@example.com").unwrap();
+        }
+
+        (parent, clone_dir, repo)
+    }
 }

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -23,6 +23,13 @@ pub struct CommitInfo {
     pub timestamp: i64,
 }
 
+#[derive(Serialize)]
+pub struct AheadBehind {
+    pub ahead: usize,
+    pub behind: usize,
+    pub has_upstream: bool,
+}
+
 #[derive(Serialize, Debug, Clone)]
 pub struct WorktreeEntry {
     pub name: String,

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -1138,31 +1138,6 @@ mod tests {
         );
     }
 
-    fn setup_remote_repo() -> (tempfile::TempDir, PathBuf, Repository) {
-        let parent = tempfile::TempDir::new().unwrap();
-
-        let bare_dir = parent.path().join("bare.git");
-        let bare = Repository::init_bare(&bare_dir).unwrap();
-        {
-            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
-            let tree_id = bare.treebuilder(None).unwrap().write().unwrap();
-            let tree = bare.find_tree(tree_id).unwrap();
-            bare.commit(Some("refs/heads/main"), &sig, &sig, "init", &tree, &[])
-                .unwrap();
-            bare.set_head("refs/heads/main").unwrap();
-        }
-
-        let clone_dir = parent.path().join("clone");
-        let repo = Repository::clone(bare_dir.to_str().unwrap(), &clone_dir).unwrap();
-        {
-            let mut config = repo.config().unwrap();
-            config.set_str("user.name", "Test").unwrap();
-            config.set_str("user.email", "test@example.com").unwrap();
-        }
-
-        (parent, clone_dir, repo)
-    }
-
     #[test]
     fn test_list_branches_with_status_ahead_behind() {
         let (_parent, clone_dir, repo) = setup_remote_repo();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -139,6 +139,7 @@ pub fn run() {
             // Git: ブランチ
             git::commands::list_branches,
             git::commands::get_current_branch,
+            git::commands::get_current_branch_ahead_behind,
             git::commands::get_default_branch,
             git::commands::git_create_branch,
             git::commands::delete_branch,

--- a/src/components/panels/SourceControlCommitForm.tsx
+++ b/src/components/panels/SourceControlCommitForm.tsx
@@ -19,6 +19,9 @@ interface CommitFormProps {
 	loading: boolean;
 	error: string | null;
 	stagedFilesCount: number;
+	ahead: number;
+	behind: number;
+	hasUpstream: boolean;
 	onSummaryChange: (value: string) => void;
 	onDescriptionChange: (value: string) => void;
 	onCommit: () => void;
@@ -32,6 +35,9 @@ export function CommitForm({
 	loading,
 	error,
 	stagedFilesCount,
+	ahead,
+	behind,
+	hasUpstream,
 	onSummaryChange,
 	onDescriptionChange,
 	onCommit,
@@ -78,7 +84,7 @@ export function CommitForm({
 				onChange={(e) => onDescriptionChange(e.target.value)}
 				rows={2}
 			/>
-			<div className="flex gap-1.5">
+			<div className="flex items-center gap-1.5">
 				<button
 					type="button"
 					className="flex-1 flex items-center justify-center gap-1 bg-accent text-accent-foreground rounded px-2 py-1 text-xs font-medium hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -96,6 +102,13 @@ export function CommitForm({
 					Push
 					<ArrowUp className="h-3 w-3" />
 				</button>
+				{hasUpstream && (ahead > 0 || behind > 0) && (
+					<span className="shrink-0 text-[10px] text-muted-foreground">
+						{ahead > 0 && `↑${ahead}`}
+						{ahead > 0 && behind > 0 && " "}
+						{behind > 0 && `↓${behind}`}
+					</span>
+				)}
 			</div>
 			{error && <Message message={error} onDismiss={onDismissError} />}
 		</div>

--- a/src/components/panels/SourceControlPanel.tsx
+++ b/src/components/panels/SourceControlPanel.tsx
@@ -5,6 +5,7 @@ import { FileStatusItem } from "@/components/panels/FileStatusItem";
 import { SourceControlContextMenu } from "@/components/panels/SourceControlContextMenu";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useAheadBehind } from "@/hooks/useAheadBehind";
 import { useGitActions } from "@/hooks/useGitActions";
 import { useGitStatus } from "@/hooks/useGitStatus";
 import { formatGitError } from "@/lib/errorHandler";
@@ -89,6 +90,7 @@ export function SourceControlPanel({
 		refresh: refreshStatus,
 	} = useGitStatus(rootPath, gitRefreshKey);
 	const { stage, unstage, discard, commit, push } = useGitActions();
+	const aheadBehind = useAheadBehind(rootPath, gitRefreshKey);
 
 	const [form, dispatch] = useReducer(commitFormReducer, initialCommitForm);
 	const {
@@ -333,6 +335,9 @@ export function SourceControlPanel({
 				loading={loading}
 				error={error}
 				stagedFilesCount={stagedFiles.length}
+				ahead={aheadBehind?.ahead ?? 0}
+				behind={aheadBehind?.behind ?? 0}
+				hasUpstream={aheadBehind?.has_upstream ?? false}
 				onSummaryChange={(value) => dispatch({ type: "SET_SUMMARY", value })}
 				onDescriptionChange={(value) =>
 					dispatch({ type: "SET_DESCRIPTION", value })

--- a/src/hooks/useAheadBehind.test.ts
+++ b/src/hooks/useAheadBehind.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AheadBehind } from "@/types/git";
+import { useAheadBehind } from "./useAheadBehind";
+
+const mockInvoke = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+describe("useAheadBehind", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should return null when rootPath is null", () => {
+		const { result } = renderHook(() => useAheadBehind(null));
+		expect(result.current).toBeNull();
+		expect(mockInvoke).not.toHaveBeenCalled();
+	});
+
+	it("should fetch ahead/behind data", async () => {
+		const mockData: AheadBehind = {
+			ahead: 3,
+			behind: 1,
+			has_upstream: true,
+		};
+		mockInvoke.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useAheadBehind("/test/repo"));
+
+		await waitFor(() => {
+			expect(result.current).toEqual(mockData);
+		});
+
+		expect(mockInvoke).toHaveBeenCalledWith("get_current_branch_ahead_behind", {
+			repoPath: "/test/repo",
+		});
+	});
+
+	it("should return null on invoke error", async () => {
+		mockInvoke.mockRejectedValue(new Error("fail"));
+
+		const { result } = renderHook(() => useAheadBehind("/test/repo"));
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalled();
+		});
+
+		expect(result.current).toBeNull();
+	});
+
+	it("should refetch when externalRefreshKey changes", async () => {
+		const mockData: AheadBehind = {
+			ahead: 1,
+			behind: 0,
+			has_upstream: true,
+		};
+		mockInvoke.mockResolvedValue(mockData);
+
+		const { result, rerender } = renderHook(
+			({ key }: { key: number }) => useAheadBehind("/test/repo", key),
+			{ initialProps: { key: 0 } },
+		);
+
+		await waitFor(() => {
+			expect(result.current).toEqual(mockData);
+		});
+
+		const updatedData: AheadBehind = {
+			ahead: 2,
+			behind: 0,
+			has_upstream: true,
+		};
+		mockInvoke.mockResolvedValue(updatedData);
+
+		rerender({ key: 1 });
+
+		await waitFor(() => {
+			expect(result.current).toEqual(updatedData);
+		});
+
+		expect(mockInvoke).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/hooks/useAheadBehind.ts
+++ b/src/hooks/useAheadBehind.ts
@@ -1,0 +1,38 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useState } from "react";
+import type { AheadBehind } from "@/types/git";
+
+export function useAheadBehind(
+	rootPath: string | null,
+	externalRefreshKey?: number,
+): AheadBehind | null {
+	const [data, setData] = useState<AheadBehind | null>(null);
+
+	const fetch = useCallback(async () => {
+		if (!rootPath) {
+			setData(null);
+			return;
+		}
+		try {
+			const result = await invoke<AheadBehind>(
+				"get_current_branch_ahead_behind",
+				{ repoPath: rootPath },
+			);
+			setData(result);
+		} catch {
+			setData(null);
+		}
+	}, [rootPath]);
+
+	useEffect(() => {
+		fetch();
+	}, [fetch]);
+
+	useEffect(() => {
+		if (externalRefreshKey != null && externalRefreshKey > 0) {
+			fetch();
+		}
+	}, [externalRefreshKey, fetch]);
+
+	return data;
+}

--- a/src/types/git.ts
+++ b/src/types/git.ts
@@ -111,6 +111,12 @@ export interface IssueInfo {
 	milestone: Milestone | null;
 }
 
+export interface AheadBehind {
+	ahead: number;
+	behind: number;
+	has_upstream: boolean;
+}
+
 export interface CommitInfo {
 	hash: string;
 	short_hash: string;


### PR DESCRIPTION
## Summary
- 現在ブランチの upstream との ahead/behind を軽量に取得する専用 Tauri コマンド `get_current_branch_ahead_behind` を新設
- ソース管理パネルの Commit/Push ボタン横に `↑N ↓M` を表示し、リモートとの差分を可視化
- `setup_remote_repo` テストヘルパーを共通化し、branch / worktree 両テストから利用可能に

Closes #389

## Test plan
- [x] `cargo test` — Rust テスト通過（branch 4件追加: upstream なし / 空リポ / detached HEAD / upstream あり）
- [x] `cargo clippy -- -D warnings` + `cargo fmt --check` — lint 通過
- [x] `pnpm test` — フロントエンドテスト 798件通過（useAheadBehind 4件追加）
- [x] `pnpm lint` — Biome lint 通過
- [ ] 手動確認: upstream ありのブランチでソース管理パネルに ↑N ↓M が表示されること
- [ ] 手動確認: commit 後に ahead が増加、push 後に非表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブランチの上流との同期状況（先行・遅延コミット数）を表示する機能を追加しました。ソースコントロールパネルで、現在のブランチが上流ブランチより何コミット先行または遅延しているかを確認できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->