### PR TITLE
fix: ターミナルパネル横幅リサイズ時のPTYカラム数同期を修正

### DIFF
--- a/src/hooks/useTerminal.test.ts
+++ b/src/hooks/useTerminal.test.ts
@@ -297,4 +297,161 @@ describe("useTerminal", () => {
 			);
 		});
 	});
+
+	describe("リサイズデバウンス", () => {
+		it("連続リサイズ時に resize_pty がデバウンスされ1回だけ呼ばれる", async () => {
+			renderHook(() => useTerminal(containerRef));
+
+			await waitFor(() => {
+				expect(mockInvoke).toHaveBeenCalledWith(
+					"get_or_spawn_pty",
+					expect.any(Object),
+				);
+			});
+
+			Object.defineProperty(containerRef.current, "clientWidth", {
+				value: 800,
+				configurable: true,
+			});
+			Object.defineProperty(containerRef.current, "clientHeight", {
+				value: 600,
+				configurable: true,
+			});
+
+			mockInvoke.mockClear();
+
+			resizeObserverCallback();
+			resizeObserverCallback();
+			resizeObserverCallback();
+
+			// デバウンス中なので即座には呼ばれない
+			expect(mockInvoke).not.toHaveBeenCalledWith(
+				"resize_pty",
+				expect.any(Object),
+			);
+
+			// デバウンス後に1回だけ呼ばれることを検証
+			await waitFor(() => {
+				expect(mockInvoke).toHaveBeenCalledWith("resize_pty", {
+					ptyId: 1,
+					rows: 24,
+					cols: 80,
+				});
+			});
+
+			const resizeCalls = mockInvoke.mock.calls.filter(
+				(call) => call[0] === "resize_pty",
+			);
+			expect(resizeCalls).toHaveLength(1);
+		});
+
+		it("非表示復帰時はデバウンスなしで即座に resize_pty が呼ばれる", async () => {
+			renderHook(() => useTerminal(containerRef));
+
+			await waitFor(() => {
+				expect(mockInvoke).toHaveBeenCalledWith(
+					"get_or_spawn_pty",
+					expect.any(Object),
+				);
+			});
+
+			Object.defineProperty(containerRef.current, "clientWidth", {
+				value: 0,
+				configurable: true,
+			});
+			Object.defineProperty(containerRef.current, "clientHeight", {
+				value: 0,
+				configurable: true,
+			});
+			resizeObserverCallback();
+
+			mockInvoke.mockClear();
+
+			Object.defineProperty(containerRef.current, "clientWidth", {
+				value: 800,
+				configurable: true,
+			});
+			Object.defineProperty(containerRef.current, "clientHeight", {
+				value: 600,
+				configurable: true,
+			});
+			resizeObserverCallback();
+
+			// 非表示復帰は即座にリサイズ（デバウンスなし）
+			expect(mockInvoke).toHaveBeenCalledWith("resize_pty", {
+				ptyId: 1,
+				rows: 24,
+				cols: 80,
+			});
+		});
+
+		it("デバウンス保留中にアンマウントしてもエラーが発生しない", async () => {
+			const { unmount } = renderHook(() => useTerminal(containerRef));
+
+			await waitFor(() => {
+				expect(mockInvoke).toHaveBeenCalledWith(
+					"get_or_spawn_pty",
+					expect.any(Object),
+				);
+			});
+
+			Object.defineProperty(containerRef.current, "clientWidth", {
+				value: 800,
+				configurable: true,
+			});
+			Object.defineProperty(containerRef.current, "clientHeight", {
+				value: 600,
+				configurable: true,
+			});
+
+			resizeObserverCallback();
+			mockInvoke.mockClear();
+			unmount();
+
+			// デバウンスタイムアウト(100ms)より長く待つ
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			expect(mockInvoke).not.toHaveBeenCalledWith(
+				"resize_pty",
+				expect.any(Object),
+			);
+		});
+	});
+
+	describe("初回fit()の再実行", () => {
+		it("マウント時に fitAddon.fit() が同期呼び出し後にRAFで再実行される", async () => {
+			renderHook(() => useTerminal(containerRef));
+
+			// 同期的な初回fit()は即座に呼ばれる
+			expect(mockFitAddonInstance.fit).toHaveBeenCalledTimes(1);
+
+			// RAFでの再実行 + PTYスポーン後のRAFで追加呼び出しが発生する
+			await vi.waitFor(() => {
+				expect(
+					mockFitAddonInstance.fit.mock.calls.length,
+				).toBeGreaterThanOrEqual(2);
+			});
+		});
+	});
+
+	describe("PTYスポーン後のリサイズ再同期", () => {
+		it("get_or_spawn_pty の後に resize_pty が requestAnimationFrame で呼ばれる", async () => {
+			renderHook(() => useTerminal(containerRef));
+
+			await waitFor(() => {
+				expect(mockInvoke).toHaveBeenCalledWith(
+					"get_or_spawn_pty",
+					expect.any(Object),
+				);
+			});
+
+			await waitFor(() => {
+				expect(mockInvoke).toHaveBeenCalledWith("resize_pty", {
+					ptyId: 1,
+					rows: 24,
+					cols: 80,
+				});
+			});
+		});
+	});
 });

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -127,6 +127,13 @@ export function useTerminal(
 		terminal.open(container);
 		fitAddon.fit();
 
+		// レンダラー初期化後に再度fitして正確なサイズを確定
+		requestAnimationFrame(() => {
+			if (isMounted) {
+				fitAddon.fit();
+			}
+		});
+
 		terminalRef.current = terminal;
 		fitAddonRef.current = fitAddon;
 
@@ -182,6 +189,23 @@ export function useTerminal(
 			// 5. Set ptyId (from here, real-time output starts flowing)
 			ptyIdRef.current = result.pty_id;
 
+			// 初回fit()が不正確だった場合のセーフティネット:
+			// PTYスポーン後に最新のサイズで再同期する
+			requestAnimationFrame(() => {
+				if (!isMounted || !fitAddonRef.current || !terminalRef.current) return;
+				fitAddonRef.current.fit();
+				const { rows, cols } = terminalRef.current;
+				if (rows > 0 && cols > 0) {
+					invoke("resize_pty", {
+						ptyId: result.pty_id,
+						rows,
+						cols,
+					}).catch((error) => {
+						console.error("Failed to resize PTY:", error);
+					});
+				}
+			});
+
 			// 6. Send startup command for newly created PTY
 			if (result.is_new && startupCommandRef.current) {
 				const cmd = startupCommandRef.current.trim();
@@ -213,28 +237,18 @@ export function useTerminal(
 			}
 		});
 
+		const RESIZE_DEBOUNCE_MS = 100;
+		let resizeTimer: ReturnType<typeof setTimeout> | null = null;
 		let wasHidden = false;
 
-		const resizeObserver = new ResizeObserver(() => {
+		const performResize = () => {
 			const el = containerRef.current;
-			if (!el || !fitAddonRef.current) return;
-
-			const isHidden = el.clientWidth === 0 || el.clientHeight === 0;
-			if (isHidden) {
-				wasHidden = true;
-				return;
-			}
+			if (!el || !fitAddonRef.current || !terminalRef.current) return;
+			if (el.clientWidth === 0 || el.clientHeight === 0) return;
 
 			fitAddonRef.current.fit();
 
-			if (wasHidden && terminalRef.current) {
-				wasHidden = false;
-				requestAnimationFrame(() => {
-					terminalRef.current?.refresh(0, (terminalRef.current?.rows ?? 1) - 1);
-				});
-			}
-
-			if (ptyIdRef.current !== null && terminalRef.current) {
+			if (ptyIdRef.current !== null) {
 				const { rows, cols } = terminalRef.current;
 				if (rows > 0 && cols > 0) {
 					invoke("resize_pty", {
@@ -246,12 +260,43 @@ export function useTerminal(
 					});
 				}
 			}
+		};
+
+		const resizeObserver = new ResizeObserver(() => {
+			const el = containerRef.current;
+			if (!el || !fitAddonRef.current) return;
+
+			const isHidden = el.clientWidth === 0 || el.clientHeight === 0;
+			if (isHidden) {
+				wasHidden = true;
+				return;
+			}
+
+			if (wasHidden) {
+				wasHidden = false;
+				performResize();
+				requestAnimationFrame(() => {
+					terminalRef.current?.refresh(0, (terminalRef.current?.rows ?? 1) - 1);
+				});
+				return;
+			}
+
+			if (resizeTimer !== null) {
+				clearTimeout(resizeTimer);
+			}
+			resizeTimer = setTimeout(() => {
+				resizeTimer = null;
+				performResize();
+			}, RESIZE_DEBOUNCE_MS);
 		});
 		resizeObserver.observe(container);
 		resizeObserverRef.current = resizeObserver;
 
 		return () => {
 			isMounted = false;
+			if (resizeTimer !== null) {
+				clearTimeout(resizeTimer);
+			}
 			resizeObserver.disconnect();
 			unlistenOutput?.();
 			unlistenExit?.();


### PR DESCRIPTION
## Summary
- ResizeObserverコールバックに100msデバウンスを導入し、パネルドラッグ中の大量リサイズ呼び出しを抑制
- 初回`fitAddon.fit()`とPTYスポーン後に`requestAnimationFrame`で再同期し、ワークスペース切替時のサイズ不整合を解消
- 非表示タブからの復帰時は即時リサイズ（デバウンスなし）で瞬時に反映

## Test plan
- [ ] アプリ起動 → ターミナルパネルの左右境界をドラッグ → コンテンツが正しくリフローされること
- [ ] "editor" タブでパネル幅を変更 → "agent" タブに切り替え → ターミナルが正しい幅で表示されること
- [ ] ターミナルタブを複数開き → タブ切替 → 各タブが正しい幅で表示されること
- [ ] サイドバーサイズを変更 → 別ワークスペースに切替 → ターミナルが正しい幅で表示されること

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ターミナルのリサイズイベント処理を改善し、過度なリサイズ呼び出しを削減しました
  * 初期読み込み後のサイズ計算精度を向上させました
  * PTYプロセス生成後のサイズ同期を安定化させました

* **テスト**
  * リサイズデバウンス動作の検証テストを追加しました
  * PTY生成関連のリサイズ同期テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->