### PR TITLE
feat: Diffのbaseにブランチのmerge-baseを追加

### DIFF
--- a/src-tauri/src/git/commands.rs
+++ b/src-tauri/src/git/commands.rs
@@ -221,3 +221,13 @@ pub async fn get_binary_file_at_ref(
 pub async fn get_binary_staged_content(file_path: String) -> Result<String, GitError> {
     blocking(move || super::diff::get_binary_staged_content(file_path)).await
 }
+
+#[tauri::command]
+pub async fn get_file_at_branch_base(file_path: String) -> Result<String, GitError> {
+    blocking(move || super::diff::get_file_at_branch_base(file_path)).await
+}
+
+#[tauri::command]
+pub async fn get_binary_file_at_branch_base(file_path: String) -> Result<String, GitError> {
+    blocking(move || super::diff::get_binary_file_at_branch_base(file_path)).await
+}

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -3,6 +3,97 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use git2::Repository;
 use std::path::Path;
 
+/// merge-base コミットのファイル内容を取得する（テキスト）
+pub fn get_file_at_branch_base(file_path: String) -> Result<String, GitError> {
+    let path = Path::new(&file_path);
+    let repo = Repository::discover(path)?;
+
+    let repo_workdir = repo
+        .workdir()
+        .ok_or_else(|| GitError::Custom("bare repository".to_string()))?;
+
+    let relative_path = path.strip_prefix(repo_workdir)?;
+
+    let merge_base_commit = find_merge_base_commit(&repo)?;
+    let tree = merge_base_commit.tree()?;
+    let entry = tree.get_path(relative_path)?;
+    let blob = repo.find_blob(entry.id())?;
+
+    let content = std::str::from_utf8(blob.content())?.to_string();
+    Ok(content)
+}
+
+/// merge-base コミットのファイル内容を取得する（バイナリ → Base64）
+pub fn get_binary_file_at_branch_base(file_path: String) -> Result<String, GitError> {
+    let path = Path::new(&file_path);
+    let repo = Repository::discover(path)?;
+
+    let repo_workdir = repo
+        .workdir()
+        .ok_or_else(|| GitError::Custom("bare repository".to_string()))?;
+
+    let relative_path = path.strip_prefix(repo_workdir)?;
+
+    let merge_base_commit = find_merge_base_commit(&repo)?;
+    let tree = merge_base_commit.tree()?;
+    let entry = tree.get_path(relative_path)?;
+    let blob = repo.find_blob(entry.id())?;
+
+    Ok(STANDARD.encode(blob.content()))
+}
+
+/// 現在のブランチと設定された base ブランチの merge-base コミットを返す。
+/// Detached HEAD の場合は HEAD コミットにフォールバック。
+fn find_merge_base_commit(repo: &Repository) -> Result<git2::Commit<'_>, GitError> {
+    let head = repo.head().map_err(|e| {
+        if e.code() == git2::ErrorCode::UnbornBranch {
+            GitError::Custom("unborn branch: no commits yet".to_string())
+        } else {
+            GitError::from(e)
+        }
+    })?;
+
+    let current_oid = head
+        .target()
+        .ok_or_else(|| GitError::Custom("HEAD has no target".to_string()))?;
+
+    // Detached HEAD → HEAD コミットにフォールバック
+    if !head.is_branch() {
+        return Ok(repo.find_commit(current_oid)?);
+    }
+
+    let branch_name = head
+        .shorthand()
+        .ok_or_else(|| GitError::Custom("HEAD has no shorthand".to_string()))?;
+
+    let config = repo.config().ok();
+    let base_branch_name =
+        match super::config::resolve_branch_base(repo, config.as_ref(), branch_name) {
+            Some(name) => name,
+            None => return Ok(repo.find_commit(current_oid)?),
+        };
+
+    // base ブランチの OID を取得
+    let base_ref = format!("refs/heads/{base_branch_name}");
+    let base_oid = match repo.revparse_single(&base_ref) {
+        Ok(obj) => obj.peel_to_commit().map(|c| c.id()),
+        Err(_) => {
+            // ローカルにない場合 origin/<name> を試す
+            let remote_ref = format!("refs/remotes/origin/{base_branch_name}");
+            repo.revparse_single(&remote_ref)
+                .map_err(|_| {
+                    GitError::Custom(format!("base branch '{base_branch_name}' not found"))
+                })?
+                .peel_to_commit()
+                .map(|c| c.id())
+        }
+    }
+    .map_err(|e| GitError::Custom(format!("failed to resolve base branch: {e}")))?;
+
+    let merge_base_oid = repo.merge_base(current_oid, base_oid)?;
+    Ok(repo.find_commit(merge_base_oid)?)
+}
+
 pub fn get_file_at_ref(file_path: String, git_ref: String) -> Result<String, GitError> {
     let path = Path::new(&file_path);
     let repo = Repository::discover(path)?;
@@ -91,4 +182,82 @@ pub fn get_binary_staged_content(file_path: String) -> Result<String, GitError> 
     let blob = repo.find_blob(entry.id)?;
 
     Ok(STANDARD.encode(blob.content()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::test_helpers::*;
+    use git2::build::CheckoutBuilder;
+
+    /// macOS では TempDir::path() が /var/... を返すが workdir() は /private/var/... を返す
+    /// strip_prefix の不一致を防ぐため workdir() ベースでファイルパスを構築する
+    fn workdir_file(repo: &Repository, name: &str) -> String {
+        repo.workdir()
+            .unwrap()
+            .join(name)
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn test_get_file_at_branch_base_returns_base_content() {
+        let (_dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        add_and_commit(&repo, "hello.txt", "base content", "add hello.txt");
+
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("feature", &head, false).unwrap();
+        repo.set_head("refs/heads/feature").unwrap();
+        repo.checkout_head(Some(CheckoutBuilder::new().force()))
+            .unwrap();
+        add_and_commit(&repo, "hello.txt", "modified content", "modify hello.txt");
+
+        let result = get_file_at_branch_base(workdir_file(&repo, "hello.txt")).unwrap();
+        assert_eq!(result, "base content");
+    }
+
+    #[test]
+    fn test_get_file_at_branch_base_detached_head() {
+        let (_dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        let oid = add_and_commit(&repo, "hello.txt", "content", "add");
+        repo.set_head_detached(oid).unwrap();
+
+        let result = get_file_at_branch_base(workdir_file(&repo, "hello.txt")).unwrap();
+        assert_eq!(result, "content");
+    }
+
+    #[test]
+    fn test_get_file_at_branch_base_unborn_branch() {
+        let (_dir, repo) = create_test_repo();
+        // unborn branch でもファイルは存在する必要がある（discover がパスを解決するため）
+        let file_path = workdir_file(&repo, "hello.txt");
+        std::fs::write(&file_path, "new file").unwrap();
+        let result = get_file_at_branch_base(file_path);
+        assert!(result.is_err(), "expected error, got: {:?}", result);
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("unborn branch"),
+            "expected 'unborn branch' in error message, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_get_binary_file_at_branch_base() {
+        let (_dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        add_and_commit(&repo, "img.bin", "binary data", "add binary");
+
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("feature", &head, false).unwrap();
+        repo.set_head("refs/heads/feature").unwrap();
+        repo.checkout_head(Some(CheckoutBuilder::new().force()))
+            .unwrap();
+        add_and_commit(&repo, "img.bin", "new binary", "modify binary");
+
+        let result = get_binary_file_at_branch_base(workdir_file(&repo, "img.bin")).unwrap();
+        assert_eq!(result, STANDARD.encode(b"binary data"));
+    }
 }

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod worktree;
 
 pub(crate) use branch::get_current_branch;
 pub(crate) use commit::{git_commit, git_push};
-pub(crate) use diff::{get_file_at_ref, get_staged_content};
+pub(crate) use diff::{get_file_at_branch_base, get_staged_content};
 pub(crate) use stage::{git_stage, git_stage_hunk, git_unstage};
 pub(crate) use status::get_git_status;
 pub(crate) use worktree::{get_main_repo_path, list_branches_with_status, list_worktrees};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -189,6 +189,8 @@ pub fn run() {
             git::commands::get_staged_content,
             git::commands::get_binary_file_at_ref,
             git::commands::get_binary_staged_content,
+            git::commands::get_file_at_branch_base,
+            git::commands::get_binary_file_at_branch_base,
             // Git: ブランチ
             git::commands::list_branches,
             git::commands::get_current_branch,

--- a/src-tauri/src/ws_server/handlers.rs
+++ b/src-tauri/src/ws_server/handlers.rs
@@ -88,10 +88,10 @@ fn handle_file_content_request(req: &FileContentRequest, repo_path: &str) -> WsM
     let original = if req.diff_base == "staged" {
         crate::git::get_staged_content(absolute_path.clone()).unwrap_or_default()
     } else {
-        crate::git::get_file_at_ref(absolute_path.clone(), "HEAD".to_string()).unwrap_or_default()
+        crate::git::get_file_at_branch_base(absolute_path.clone()).unwrap_or_default()
     };
     let modified = std::fs::read_to_string(&validated_path).unwrap_or_default();
-    let staged = if req.diff_base == "HEAD" {
+    let staged = if req.diff_base != "staged" {
         Some(crate::git::get_staged_content(absolute_path).unwrap_or_default())
     } else {
         None

--- a/src/components/panels/DiffToolbar.tsx
+++ b/src/components/panels/DiffToolbar.tsx
@@ -54,7 +54,7 @@ export function DiffToolbar({
 						<SelectValue />
 					</SelectTrigger>
 					<SelectContent>
-						<SelectItem value="HEAD">HEAD</SelectItem>
+						<SelectItem value="branch-base">Branch Base</SelectItem>
 						<SelectItem value="staged">Staged</SelectItem>
 					</SelectContent>
 				</Select>
@@ -69,7 +69,7 @@ export function DiffToolbar({
 								>
 									Stage All
 								</button>
-								{diffBase === "HEAD" && (
+								{diffBase === "branch-base" && (
 									<button
 										type="button"
 										onClick={onUnstageAll}

--- a/src/components/panels/EditorTabContent.tsx
+++ b/src/components/panels/EditorTabContent.tsx
@@ -65,7 +65,7 @@ export function EditorTabContent({
 	);
 
 	const stagedContent = useGitOriginalContent(
-		!isImage && diffBase === "HEAD" ? filePath : null,
+		!isImage && diffBase === "branch-base" ? filePath : null,
 		"staged",
 		"",
 		gitRefreshKey,
@@ -87,7 +87,7 @@ export function EditorTabContent({
 	} = useHunks(originalContent, modifiedContent, filePath);
 
 	const changeGroups = useMemo(() => {
-		if (diffBase !== "HEAD") return rawChangeGroups;
+		if (diffBase !== "branch-base") return rawChangeGroups;
 		const hunks = computeHunks(originalContent, modifiedContent, filePath);
 		const stagedHunks = computeHunks(originalContent, stagedContent, filePath);
 		const stagedGroups = computeChangeGroups(stagedHunks);
@@ -225,7 +225,9 @@ export function EditorTabContent({
 					commentRanges={commentRanges}
 					onContentChange={handleContentChange}
 					onStageHunk={handleStageGroup}
-					onUnstageHunk={diffBase === "HEAD" ? handleUnstageGroup : undefined}
+					onUnstageHunk={
+						diffBase === "branch-base" ? handleUnstageGroup : undefined
+					}
 					onAddComment={handleAddComment}
 					getCommentsForLine={getCommentsForLine}
 					revealLine={revealLine}

--- a/src/components/panels/SettingsModal.test.tsx
+++ b/src/components/panels/SettingsModal.test.tsx
@@ -145,12 +145,12 @@ describe("SettingsModal", () => {
 		fireEvent.click(screen.getByText("Editor"));
 		const trigger = screen.getByRole("combobox", { name: "Default Base" });
 		await user.click(trigger);
-		const option = screen.getByRole("option", { name: "HEAD" });
+		const option = screen.getByRole("option", { name: "Branch Base" });
 		await user.click(option);
 		await user.click(screen.getByRole("button", { name: "Save" }));
 		expect(onSave).toHaveBeenCalledWith({
 			...defaultSettings,
-			defaultDiffBase: "HEAD",
+			defaultDiffBase: "branch-base",
 		});
 	});
 

--- a/src/components/panels/SettingsModal.tsx
+++ b/src/components/panels/SettingsModal.tsx
@@ -230,7 +230,7 @@ function EditorSection({
 					</SelectTrigger>
 					<SelectContent>
 						<SelectItem value="staged">Staged</SelectItem>
-						<SelectItem value="HEAD">HEAD</SelectItem>
+						<SelectItem value="branch-base">Branch Base</SelectItem>
 					</SelectContent>
 				</Select>
 			</div>

--- a/src/components/panels/useDiffOperations.ts
+++ b/src/components/panels/useDiffOperations.ts
@@ -90,7 +90,7 @@ export function useDiffOperations({
 			let patchHunk = hunk;
 			let patchGroup = group;
 
-			if (diffBase === "HEAD") {
+			if (diffBase === "branch-base") {
 				const targetLines = hunk.lines.slice(
 					group.lineOffsetStart,
 					group.lineOffsetEnd + 1,
@@ -181,7 +181,7 @@ export function useDiffOperations({
 	const handleStageAll = useCallback(async () => {
 		const relativePath = getRelativePath(rootPath, filePath);
 		if (!relativePath || !rootPath) return;
-		const base = diffBase === "HEAD" ? stagedContent : originalContent;
+		const base = diffBase === "branch-base" ? stagedContent : originalContent;
 		const allHunks = computeHunks(base, modifiedContent, relativePath);
 		const allIndices = allHunks.map((h) => h.index);
 		const patch = generatePatch(relativePath, allHunks, allIndices);

--- a/src/hooks/__tests__/useImageDiff.test.ts
+++ b/src/hooks/__tests__/useImageDiff.test.ts
@@ -21,19 +21,19 @@ describe("useImageDiff", () => {
 	});
 
 	it("returns null URLs when filePath is null", () => {
-		const { result } = renderHook(() => useImageDiff(null, "HEAD"));
+		const { result } = renderHook(() => useImageDiff(null, "branch-base"));
 		expect(result.current.originalUrl).toBeNull();
 		expect(result.current.modifiedUrl).toBeNull();
 		expect(result.current.loading).toBe(false);
 	});
 
-	it("fetches modified from readFile and original from get_binary_file_at_ref", async () => {
+	it("fetches modified from readFile and original from get_binary_file_at_branch_base", async () => {
 		const pngBytes = new Uint8Array([137, 80, 78, 71]);
 		mockReadFile.mockResolvedValue(pngBytes);
 		mockInvoke.mockResolvedValue("iVBORw0KGgo=");
 
 		const { result } = renderHook(() =>
-			useImageDiff("/repo/image.png", "HEAD"),
+			useImageDiff("/repo/image.png", "branch-base"),
 		);
 
 		await waitFor(() => {
@@ -41,9 +41,8 @@ describe("useImageDiff", () => {
 		});
 
 		expect(mockReadFile).toHaveBeenCalledWith("/repo/image.png");
-		expect(mockInvoke).toHaveBeenCalledWith("get_binary_file_at_ref", {
+		expect(mockInvoke).toHaveBeenCalledWith("get_binary_file_at_branch_base", {
 			filePath: "/repo/image.png",
-			gitRef: "HEAD",
 		});
 
 		expect(result.current.modifiedUrl).toMatch(/^data:image\/png;base64,/);
@@ -76,7 +75,7 @@ describe("useImageDiff", () => {
 		mockInvoke.mockRejectedValue(new Error("not found"));
 
 		const { result } = renderHook(() =>
-			useImageDiff("/repo/new-image.png", "HEAD"),
+			useImageDiff("/repo/new-image.png", "branch-base"),
 		);
 
 		await waitFor(() => {
@@ -92,7 +91,7 @@ describe("useImageDiff", () => {
 		mockInvoke.mockResolvedValue("AQID");
 
 		const { result } = renderHook(() =>
-			useImageDiff("/repo/deleted.png", "HEAD"),
+			useImageDiff("/repo/deleted.png", "branch-base"),
 		);
 
 		await waitFor(() => {

--- a/src/hooks/useGitOriginalContent.test.ts
+++ b/src/hooks/useGitOriginalContent.test.ts
@@ -23,15 +23,16 @@ describe("useGitOriginalContent", () => {
 		mockListen.mockResolvedValue(vi.fn());
 	});
 
-	it("should return content from get_file_at_ref on success", async () => {
+	it("should return content from get_file_at_branch_base on success", async () => {
 		mockInvoke.mockImplementation((cmd: string) => {
 			if (cmd === "get_repo_git_dir") return Promise.resolve("/repo/.git");
-			if (cmd === "get_file_at_ref") return Promise.resolve("original content");
+			if (cmd === "get_file_at_branch_base")
+				return Promise.resolve("original content");
 			return Promise.resolve("");
 		});
 
 		const { result } = renderHook(() =>
-			useGitOriginalContent("/repo/file.ts", "HEAD", "fallback"),
+			useGitOriginalContent("/repo/file.ts", "branch-base", "fallback"),
 		);
 
 		await waitFor(() => {
@@ -63,7 +64,11 @@ describe("useGitOriginalContent", () => {
 		});
 
 		const { result } = renderHook(() =>
-			useGitOriginalContent("/repo/untracked.ts", "HEAD", "current content"),
+			useGitOriginalContent(
+				"/repo/untracked.ts",
+				"branch-base",
+				"current content",
+			),
 		);
 
 		await waitFor(() => {
@@ -75,7 +80,7 @@ describe("useGitOriginalContent", () => {
 		mockInvoke.mockResolvedValue("");
 
 		const { result } = renderHook(() =>
-			useGitOriginalContent(null, "HEAD", "fallback"),
+			useGitOriginalContent(null, "branch-base", "fallback"),
 		);
 
 		expect(result.current).toBe("fallback");

--- a/src/hooks/useGitOriginalContent.ts
+++ b/src/hooks/useGitOriginalContent.ts
@@ -92,9 +92,8 @@ export function useGitOriginalContent(
 						filePath,
 					});
 				} else {
-					content = await invoke<string>("get_file_at_ref", {
+					content = await invoke<string>("get_file_at_branch_base", {
 						filePath,
-						gitRef: diffBase,
 					});
 				}
 				if (!cancelled) {

--- a/src/hooks/useImageDiff.ts
+++ b/src/hooks/useImageDiff.ts
@@ -60,9 +60,8 @@ export function useImageDiff(
 						filePath,
 					});
 				} else {
-					base64 = await invoke<string>("get_binary_file_at_ref", {
+					base64 = await invoke<string>("get_binary_file_at_branch_base", {
 						filePath,
-						gitRef: diffBase,
 					});
 				}
 				if (!cancelled) {

--- a/src/remote/components/DiffTabContent.tsx
+++ b/src/remote/components/DiffTabContent.tsx
@@ -49,7 +49,7 @@ export function DiffTabContent({
 							onChange={(e) => onDiffBaseChange(e.target.value as DiffBase)}
 							className="text-xs bg-input text-secondary-foreground border border-border rounded px-1.5 py-0.5"
 						>
-							<option value="HEAD">HEAD</option>
+							<option value="branch-base">Branch Base</option>
 							<option value="staged">Staged</option>
 						</select>
 						{hasDiffChanges && (
@@ -61,7 +61,7 @@ export function DiffTabContent({
 								Stage All
 							</button>
 						)}
-						{diffBase === "HEAD" &&
+						{diffBase === "branch-base" &&
 							stagedFiles.some((f) => f.path === selectedPath) && (
 								<button
 									type="button"

--- a/src/remote/components/RemoteDiffPanel.tsx
+++ b/src/remote/components/RemoteDiffPanel.tsx
@@ -86,13 +86,13 @@ export function RemoteDiffPanel({
 	);
 
 	const stagedHunks = useMemo(() => {
-		if (!path || staged == null || diffBase !== "HEAD") return [];
+		if (!path || staged == null || diffBase !== "branch-base") return [];
 		return computeHunks(original, staged, path);
 	}, [original, staged, diffBase, path]);
 
 	const changeGroups = useMemo(() => {
 		const groups = computeChangeGroups(hunks);
-		if (diffBase !== "HEAD" || stagedHunks.length === 0) return groups;
+		if (diffBase !== "branch-base" || stagedHunks.length === 0) return groups;
 		const sGroups = computeChangeGroups(stagedHunks);
 		return markStagedGroups(groups, sGroups, hunks, stagedHunks);
 	}, [hunks, stagedHunks, diffBase]);
@@ -108,7 +108,7 @@ export function RemoteDiffPanel({
 			let patchHunk = hunk;
 			let patchGroup = group;
 
-			if (diffBase === "HEAD" && staged != null) {
+			if (diffBase === "branch-base" && staged != null) {
 				const targetLines = hunk.lines.slice(
 					group.lineOffsetStart,
 					group.lineOffsetEnd + 1,
@@ -239,7 +239,9 @@ export function RemoteDiffPanel({
 					changeGroups={changeGroups}
 					onStageGroup={onStageHunk ? handleStageGroup : undefined}
 					onUnstageGroup={
-						onStageHunk && diffBase === "HEAD" ? handleUnstageGroup : undefined
+						onStageHunk && diffBase === "branch-base"
+							? handleUnstageGroup
+							: undefined
 					}
 				/>
 			</div>

--- a/src/remote/hooks/useRemoteAppActions.ts
+++ b/src/remote/hooks/useRemoteAppActions.ts
@@ -189,7 +189,7 @@ export function useRemoteAppActions({
 	const handleStageAll = useCallback(() => {
 		if (!selectedPath || !content) return;
 		const base =
-			diffBase === "HEAD" && content.staged != null
+			diffBase === "branch-base" && content.staged != null
 				? content.staged
 				: content.original;
 		const allHunks = computeHunks(base, content.modified, selectedPath);

--- a/src/remote/hooks/useRemoteFileContent.ts
+++ b/src/remote/hooks/useRemoteFileContent.ts
@@ -9,7 +9,7 @@ interface FileContent {
 	staged: string | null;
 }
 
-export type DiffBase = "HEAD" | "staged";
+export type DiffBase = "branch-base" | "staged";
 
 interface UseRemoteFileContentOptions {
 	subscribe: Subscribe;
@@ -23,7 +23,7 @@ export function useRemoteFileContent({
 	const [content, setContent] = useState<FileContent | null>(null);
 	const [loading, setLoading] = useState(false);
 	const currentPathRef = useRef<string | null>(null);
-	const currentDiffBaseRef = useRef<DiffBase>("HEAD");
+	const currentDiffBaseRef = useRef<DiffBase>("branch-base");
 
 	const requestContent = useCallback(
 		(path: string, diffBase?: DiffBase) => {
@@ -78,7 +78,7 @@ export function useRemoteFileContent({
 
 	const clear = useCallback(() => {
 		currentPathRef.current = null;
-		currentDiffBaseRef.current = "HEAD";
+		currentDiffBaseRef.current = "branch-base";
 		setContent(null);
 		setLoading(false);
 	}, []);

--- a/src/remote/hooks/useRemoteNavigation.ts
+++ b/src/remote/hooks/useRemoteNavigation.ts
@@ -12,7 +12,7 @@ export function useRemoteNavigation({ subscribe }: UseRemoteNavigationOptions) {
 	const [selectedPath, setSelectedPath] = useState<string | null>(null);
 	const [selectedWorktree, setSelectedWorktree] = useState<string | null>(null);
 	const [activeTab, setActiveTab] = useState<Tab>("terminal");
-	const [diffBase, setDiffBase] = useState<DiffBase>("HEAD");
+	const [diffBase, setDiffBase] = useState<DiffBase>("branch-base");
 	const [worktreeLoading, setWorktreeLoading] = useState(false);
 
 	const selectWorktreeOptimistic = useCallback((path: string) => {

--- a/src/screens/useWorktreeGitActions.test.ts
+++ b/src/screens/useWorktreeGitActions.test.ts
@@ -93,9 +93,9 @@ describe("gitReducer", () => {
 	it("SET_DIFF_BASE updates diffBase", () => {
 		const state = gitReducer(initialGitState, {
 			type: "SET_DIFF_BASE",
-			value: "HEAD",
+			value: "branch-base",
 		});
-		expect(state.diffBase).toBe("HEAD");
+		expect(state.diffBase).toBe("branch-base");
 	});
 
 	it("SET_DIFF_MODE updates diffMode", () => {

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -80,7 +80,7 @@ export interface GitStatusSync {
 
 export interface FileContentRequest {
 	path: string;
-	diff_base?: "HEAD" | "staged";
+	diff_base?: "branch-base" | "staged";
 }
 
 interface FileContentResponse {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,5 +1,5 @@
 export type Theme = "dark" | "light";
-export type DiffBase = "HEAD" | "staged";
+export type DiffBase = "branch-base" | "staged";
 export type DiffMode = "gutter" | "inline" | "split";
 
 export type AgentType =


### PR DESCRIPTION
## Summary
- DiffBase を `"HEAD"` から `"branch-base"` に変更し、ブランチの分岐元（merge-base）コミットとの差分を表示できるようにした
- Rust 側に `find_merge_base_commit()` を追加し、`resolve_branch_base()` フォールバックチェーン（`branch.<name>.releash-base` → `releash.base` → `detect_default_branch()`）を活用
- フロントエンド・WebSocket ハンドラー・テストを全て `branch-base` に移行

## Test plan
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` パス (429 tests)
- [x] `pnpm lint` パス
- [x] `pnpm test` パス (775 tests)
- [x] `pnpm build` パス

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブランチベースでのファイルコンテンツ取得機能を追加しました。テキストおよびバイナリファイルの両方をサポートしています。

* **変更**
  * デフォルトの比較ベースを変更しました。より正確なファイル差分比較が可能になり、ステージング操作の条件も改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->