### PR TITLE
fix: Hooks設定UIのスピナー永続バグを修正

### DIFF
--- a/src/components/panels/SettingsModal.test.tsx
+++ b/src/components/panels/SettingsModal.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppSettings } from "@/types/settings";
@@ -32,6 +38,10 @@ describe("SettingsModal", () => {
 						auto_start: false,
 						auto_start_on_lan: false,
 					});
+				case "generate_hooks_config":
+					return Promise.resolve('{"hooks":{}}');
+				case "get_hooks_status":
+					return Promise.resolve("not_configured");
 				case "update_remote_config":
 				case "update_notify_config":
 					return Promise.resolve(null);
@@ -324,6 +334,58 @@ describe("SettingsModal", () => {
 		expect(screen.getByText("Repositories")).toBeInTheDocument();
 		fireEvent.click(screen.getByText("Repositories"));
 		expect(await screen.findByText("Base branch")).toBeInTheDocument();
+	});
+
+	it("should resolve hooks loading spinner when agent is claude", async () => {
+		const claudeSettings = { ...defaultSettings, agent: "claude" as const };
+		render(<SettingsModal {...defaultProps} settings={claudeSettings} />);
+		const nav = screen.getByRole("navigation");
+		fireEvent.click(within(nav).getByText("Agent"));
+		await waitFor(() => {
+			expect(screen.getByText("Not configured")).toBeInTheDocument();
+		});
+	});
+
+	it("should not show permanent spinner when dialog is re-opened with claude agent", async () => {
+		const claudeSettings = { ...defaultSettings, agent: "claude" as const };
+		const onOpenChange = vi.fn();
+
+		const { rerender } = render(
+			<SettingsModal
+				{...defaultProps}
+				settings={claudeSettings}
+				onOpenChange={onOpenChange}
+			/>,
+		);
+		const nav = screen.getByRole("navigation");
+		fireEvent.click(within(nav).getByText("Agent"));
+		await waitFor(() => {
+			expect(screen.getByText("Not configured")).toBeInTheDocument();
+		});
+
+		// Close dialog
+		rerender(
+			<SettingsModal
+				{...defaultProps}
+				open={false}
+				settings={claudeSettings}
+				onOpenChange={onOpenChange}
+			/>,
+		);
+
+		// Re-open dialog
+		rerender(
+			<SettingsModal
+				{...defaultProps}
+				open={true}
+				settings={claudeSettings}
+				onOpenChange={onOpenChange}
+			/>,
+		);
+		fireEvent.click(within(nav).getByText("Agent"));
+		await waitFor(() => {
+			expect(screen.getByText("Not configured")).toBeInTheDocument();
+		});
 	});
 
 	it("should save base branch via Apply button", async () => {

--- a/src/components/panels/SettingsModal.tsx
+++ b/src/components/panels/SettingsModal.tsx
@@ -1092,9 +1092,6 @@ export function SettingsModal({
 		dispatchSettings({ type: "SYNC_OPEN", open, settings });
 		if (open) {
 			repos.reset();
-			if (settings.agent === "claude") {
-				dispatchHooks({ type: "LOAD_START" });
-			}
 		}
 	}
 
@@ -1105,9 +1102,10 @@ export function SettingsModal({
 		[],
 	);
 
-	// Load hooks config when agent is claude
+	// Load hooks config when agent is claude and dialog is open
 	useEffect(() => {
-		if (draft.agent !== "claude") return;
+		if (!open || draft.agent !== "claude") return;
+		let cancelled = false;
 		dispatchHooks({ type: "LOAD_START" });
 
 		Promise.all([
@@ -1115,16 +1113,23 @@ export function SettingsModal({
 			invoke<string>("get_hooks_status"),
 		])
 			.then(([json, status]) => {
-				dispatchHooks({
-					type: "LOAD_SUCCESS",
-					config: json,
-					status: status as HooksState["status"],
-				});
+				if (!cancelled) {
+					dispatchHooks({
+						type: "LOAD_SUCCESS",
+						config: json,
+						status: status as HooksState["status"],
+					});
+				}
 			})
 			.catch((e) => {
-				dispatchHooks({ type: "LOAD_ERROR", error: String(e) });
+				if (!cancelled) {
+					dispatchHooks({ type: "LOAD_ERROR", error: String(e) });
+				}
 			});
-	}, [draft.agent]);
+		return () => {
+			cancelled = true;
+		};
+	}, [open, draft.agent]);
 
 	const handleApplyHooks = useCallback(async () => {
 		dispatchHooks({ type: "APPLY_START" });


### PR DESCRIPTION
## Summary
- Hooks設定UIでダイアログを開くとスピナーが永続し、設定画面が表示されないバグを修正
- レンダー時の`LOAD_START`ディスパッチを削除し、`useEffect`の依存配列に`open`を追加
- 非同期処理のクリーンアップ（`cancelled`フラグ）を追加

## Test plan
- [x] `pnpm test` — 777 tests passed
- [x] `pnpm lint` — No errors
- [x] `pnpm build` — Success
- [x] `cargo fmt --check` / `cargo clippy` / `cargo test` — All passed
- [ ] `agent: "claude"` でダイアログを開き、スピナーが解除されHooks設定が表示されることを確認
- [ ] ダイアログを閉じて再度開いた際にスピナーが永続しないことを確認

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* Claude エージェント使用時にフックの読み込みスピナーが正常に解決されるようになりました
* 設定パネルを再度開く際の読み込み状態管理が改善されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->