### PR TITLE
fix: diffデコレーションのカテゴリを追加/削除の2種に統一 (#580)

### DIFF
--- a/src/hooks/useMonacoDiffEditor.ts
+++ b/src/hooks/useMonacoDiffEditor.ts
@@ -8,7 +8,7 @@ import {
 import type { ChangeGroup } from "@/lib/computeHunks";
 import {
 	DIFF_ADDED_COLOR,
-	DIFF_MODIFIED_COLOR,
+	DIFF_DELETED_COLOR,
 	defaultDiffEditorOptions,
 	disableBuiltinDiagnostics,
 	getMonacoThemeName,
@@ -363,10 +363,22 @@ export function useMonacoDiffEditor(
 							),
 							options: {
 								overviewRuler: {
-									color:
-										change.originalEndLineNumber === 0
-											? DIFF_ADDED_COLOR
-											: DIFF_MODIFIED_COLOR,
+									color: DIFF_ADDED_COLOR,
+									position: monaco.editor.OverviewRulerLane.Full,
+								},
+							},
+						});
+					} else if (change.modifiedEndLineNumber === 0) {
+						decorations.push({
+							range: new monaco.Range(
+								change.modifiedStartLineNumber,
+								1,
+								change.modifiedStartLineNumber,
+								1,
+							),
+							options: {
+								overviewRuler: {
+									color: DIFF_DELETED_COLOR,
 									position: monaco.editor.OverviewRulerLane.Full,
 								},
 							},

--- a/src/hooks/useMonacoGutterEditor.test.ts
+++ b/src/hooks/useMonacoGutterEditor.test.ts
@@ -1,58 +1,146 @@
 import { loader } from "@monaco-editor/react";
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { computeDiff, useMonacoGutterEditor } from "./useMonacoGutterEditor";
+import {
+	computeDiff,
+	createDiffDecorations,
+	useMonacoGutterEditor,
+} from "./useMonacoGutterEditor";
 
 describe("computeDiff", () => {
 	it("should return empty arrays when texts are identical", () => {
 		const result = computeDiff("line1\nline2\n", "line1\nline2\n");
 		expect(result.added).toEqual([]);
-		expect(result.modified).toEqual([]);
+		expect(result.deleted).toEqual([]);
 	});
 
 	it("should detect added lines", () => {
 		const result = computeDiff("line1\nline2\n", "line1\nline2\nline3\n");
 		expect(result.added).toEqual([3]);
-		expect(result.modified).toEqual([]);
+		expect(result.deleted).toEqual([]);
 	});
 
-	it("should detect modified lines", () => {
+	it("should detect replacement as added lines", () => {
 		const result = computeDiff(
 			"line1\nline2\nline3\n",
 			"line1\nmodified\nline3\n",
 		);
 		expect(result.added).toEqual([2]);
-		expect(result.modified).toEqual([2]);
+		expect(result.deleted).toEqual([]);
 	});
 
 	it("should not add out-of-range line numbers when deleting trailing lines", () => {
 		const result = computeDiff("line1\nline2\nline3\n", "line1\nline2\n");
 		expect(result.added).toEqual([]);
-		expect(result.modified).toEqual([]);
+		expect(result.deleted).toEqual([2]);
 	});
 
-	it("should mark modified when deleting middle lines", () => {
+	it("should mark deleted when deleting middle lines", () => {
 		const result = computeDiff("line1\nline2\nline3\n", "line1\nline3\n");
 		expect(result.added).toEqual([]);
-		expect(result.modified).toEqual([2]);
+		expect(result.deleted).toEqual([2]);
 	});
 
 	it("should handle empty modified text", () => {
 		const result = computeDiff("line1\nline2\n", "");
 		expect(result.added).toEqual([]);
-		expect(result.modified).toEqual([]);
+		expect(result.deleted).toEqual([]);
 	});
 
 	it("should handle empty original text", () => {
 		const result = computeDiff("", "line1\nline2\n");
 		expect(result.added).toEqual([1, 2]);
-		expect(result.modified).toEqual([]);
+		expect(result.deleted).toEqual([]);
 	});
 
 	it("should handle deleting all lines except first", () => {
 		const result = computeDiff("line1\nline2\nline3\n", "line1\n");
 		expect(result.added).toEqual([]);
-		expect(result.modified).toEqual([]);
+		expect(result.deleted).toEqual([1]);
+	});
+
+	it("should detect deleted lines at end of file", () => {
+		const result = computeDiff(
+			"line1\nline2\nline3\nline4\n",
+			"line1\nline2\n",
+		);
+		expect(result.added).toEqual([]);
+		expect(result.deleted).toEqual([2]);
+	});
+
+	it("should detect replacement with deletion as added only", () => {
+		const result = computeDiff("line1\nline2\nline3\n", "line1\nchanged\n");
+		expect(result.added).toContain(2);
+		expect(result.deleted).toEqual([]);
+	});
+
+	it("should handle multi-line replacement as added only", () => {
+		const result = computeDiff("aaa\nbbb\nccc\n", "aaa\nxxx\nyyy\nccc\n");
+		expect(result.added.length).toBeGreaterThan(0);
+		expect(result.deleted).toEqual([]);
+	});
+
+	it("pure deletion produces deleted only", () => {
+		const result = computeDiff("line1\nline2\nline3\n", "line1\nline3\n");
+		expect(result.deleted).toEqual([2]);
+		expect(result.added).toEqual([]);
+	});
+
+	it("should detect both added and deleted lines in mixed diff", () => {
+		const result = computeDiff("a\nb\nc\nd\ne\n", "a\nX\nd\n");
+		expect(result.added).toContain(2);
+		expect(result.deleted.length).toBeGreaterThan(0);
+	});
+});
+
+describe("createDiffDecorations", () => {
+	let mockMonaco: Awaited<ReturnType<typeof loader.init>>;
+
+	beforeEach(async () => {
+		mockMonaco = await loader.init();
+		(mockMonaco.editor as Record<string, unknown>).OverviewRulerLane = {
+			Full: 7,
+		};
+	});
+
+	it("should create gutter-added decorations for added lines", () => {
+		const diff = { added: [1, 3], deleted: [] };
+		const result = createDiffDecorations(diff, mockMonaco);
+
+		expect(result).toHaveLength(2);
+		for (const d of result) {
+			expect(d.options.glyphMarginClassName).toBe("gutter-added");
+			expect(d.options.overviewRuler?.color).toBe("#9ccc2c");
+			expect(d.options.overviewRuler?.position).toBe(7);
+		}
+	});
+
+	it("should create gutter-deleted decorations for deleted lines", () => {
+		const diff = { added: [], deleted: [2, 4] };
+		const result = createDiffDecorations(diff, mockMonaco);
+
+		expect(result).toHaveLength(2);
+		for (const d of result) {
+			expect(d.options.glyphMarginClassName).toBe("gutter-deleted");
+			expect(d.options.overviewRuler?.color).toBe("#ff0000");
+			expect(d.options.overviewRuler?.position).toBe(7);
+		}
+	});
+
+	it("should return empty array for empty diff", () => {
+		const diff = { added: [], deleted: [] };
+		const result = createDiffDecorations(diff, mockMonaco);
+
+		expect(result).toEqual([]);
+	});
+
+	it("should create both added and deleted decorations for mixed diff", () => {
+		const diff = { added: [2], deleted: [5] };
+		const result = createDiffDecorations(diff, mockMonaco);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].options.glyphMarginClassName).toBe("gutter-added");
+		expect(result[1].options.glyphMarginClassName).toBe("gutter-deleted");
 	});
 });
 

--- a/src/hooks/useMonacoGutterEditor.ts
+++ b/src/hooks/useMonacoGutterEditor.ts
@@ -9,7 +9,7 @@ import {
 import type { ChangeGroup } from "@/lib/computeHunks";
 import {
 	DIFF_ADDED_COLOR,
-	DIFF_MODIFIED_COLOR,
+	DIFF_DELETED_COLOR,
 	defaultEditorOptions,
 	disableBuiltinDiagnostics,
 	getMonacoThemeName,
@@ -63,13 +63,13 @@ interface UseMonacoGutterEditorOptions {
 
 interface DiffResult {
 	added: number[];
-	modified: number[];
+	deleted: number[];
 }
 
 export function computeDiff(original: string, modified: string): DiffResult {
 	const changes = diffLines(original, modified);
 	const added: number[] = [];
-	const modified_lines: number[] = [];
+	const deletedLines: number[] = [];
 
 	const modifiedLineCount =
 		modified === ""
@@ -87,15 +87,54 @@ export function computeDiff(original: string, modified: string): DiffResult {
 			}
 			lineNumber += lines;
 		} else if (change.removed) {
-			if (lines > 0 && lineNumber <= modifiedLineCount) {
-				modified_lines.push(lineNumber);
+			const deletedMarkerLine =
+				lineNumber <= modifiedLineCount ? lineNumber : modifiedLineCount;
+			if (deletedMarkerLine > 0) {
+				deletedLines.push(deletedMarkerLine);
 			}
 		} else {
 			lineNumber += lines;
 		}
 	}
 
-	return { added, modified: modified_lines };
+	const addedSet = new Set(added);
+	const filteredDeleted = deletedLines.filter((l) => !addedSet.has(l));
+
+	return { added, deleted: filteredDeleted };
+}
+
+export function createDiffDecorations(
+	diff: DiffResult,
+	monaco: typeof Monaco,
+): Monaco.editor.IModelDeltaDecoration[] {
+	const decorations: Monaco.editor.IModelDeltaDecoration[] = [];
+	for (const line of diff.added) {
+		decorations.push({
+			range: new monaco.Range(line, 1, line, 1),
+			options: {
+				isWholeLine: true,
+				glyphMarginClassName: "gutter-added",
+				overviewRuler: {
+					color: DIFF_ADDED_COLOR,
+					position: monaco.editor.OverviewRulerLane.Full,
+				},
+			},
+		});
+	}
+	for (const line of diff.deleted) {
+		decorations.push({
+			range: new monaco.Range(line, 1, line, 1),
+			options: {
+				isWholeLine: true,
+				glyphMarginClassName: "gutter-deleted",
+				overviewRuler: {
+					color: DIFF_DELETED_COLOR,
+					position: monaco.editor.OverviewRulerLane.Full,
+				},
+			},
+		});
+	}
+	return decorations;
 }
 
 export function useMonacoGutterEditor(
@@ -257,36 +296,7 @@ export function useMonacoGutterEditor(
 			const updateDecorations = () => {
 				const currentValue = editor.getValue();
 				const diff = computeDiff(originalValueRef.current, currentValue);
-				const decorations: Monaco.editor.IModelDeltaDecoration[] = [];
-
-				for (const line of diff.added) {
-					decorations.push({
-						range: new monaco.Range(line, 1, line, 1),
-						options: {
-							isWholeLine: true,
-							glyphMarginClassName: "gutter-added",
-							overviewRuler: {
-								color: DIFF_ADDED_COLOR,
-								position: monaco.editor.OverviewRulerLane.Full,
-							},
-						},
-					});
-				}
-
-				for (const line of diff.modified) {
-					decorations.push({
-						range: new monaco.Range(line, 1, line, 1),
-						options: {
-							isWholeLine: true,
-							glyphMarginClassName: "gutter-modified",
-							overviewRuler: {
-								color: DIFF_MODIFIED_COLOR,
-								position: monaco.editor.OverviewRulerLane.Full,
-							},
-						},
-					});
-				}
-
+				const decorations = createDiffDecorations(diff, monaco);
 				decorationsRef.current = editor.deltaDecorations(
 					decorationsRef.current,
 					decorations,
@@ -565,36 +575,7 @@ export function useMonacoGutterEditor(
 
 		const currentValue = editor.getValue();
 		const diff = computeDiff(originalValue, currentValue);
-		const decorations: Monaco.editor.IModelDeltaDecoration[] = [];
-
-		for (const line of diff.added) {
-			decorations.push({
-				range: new monaco.Range(line, 1, line, 1),
-				options: {
-					isWholeLine: true,
-					glyphMarginClassName: "gutter-added",
-					overviewRuler: {
-						color: "rgba(80, 200, 80, 0.8)",
-						position: monaco.editor.OverviewRulerLane.Full,
-					},
-				},
-			});
-		}
-
-		for (const line of diff.modified) {
-			decorations.push({
-				range: new monaco.Range(line, 1, line, 1),
-				options: {
-					isWholeLine: true,
-					glyphMarginClassName: "gutter-modified",
-					overviewRuler: {
-						color: "rgba(80, 160, 240, 0.8)",
-						position: monaco.editor.OverviewRulerLane.Full,
-					},
-				},
-			});
-		}
-
+		const decorations = createDiffDecorations(diff, monaco);
 		decorationsRef.current = editor.deltaDecorations(
 			decorationsRef.current,
 			decorations,

--- a/src/index.css
+++ b/src/index.css
@@ -248,12 +248,6 @@
 	margin-left: 3px;
 }
 
-.gutter-modified {
-	background-color: var(--status-modified);
-	width: 4px !important;
-	margin-left: 3px;
-}
-
 .gutter-deleted {
 	background-color: var(--status-deleted);
 	width: 4px !important;
@@ -262,10 +256,6 @@
 
 .line-added {
 	background-color: color-mix(in oklch, var(--status-added) 15%, transparent);
-}
-
-.line-modified {
-	background-color: color-mix(in oklch, var(--status-modified) 15%, transparent);
 }
 
 .line-deleted {

--- a/src/lib/monaco-config.ts
+++ b/src/lib/monaco-config.ts
@@ -32,7 +32,7 @@ export const monacoTheme: Monaco.editor.IStandaloneThemeData = {
 };
 
 export const DIFF_ADDED_COLOR = "#9ccc2c";
-export const DIFF_MODIFIED_COLOR = "#9ccc2c";
+export const DIFF_DELETED_COLOR = "#ff0000";
 
 export const monacoLightTheme: Monaco.editor.IStandaloneThemeData = {
 	base: "vs",


### PR DESCRIPTION
## Summary
- diffカテゴリから死コード（modified）を除去し、added/deletedの2種に統一
- ガターとスクロールバーの両方に追加行（緑）・削除行（赤）のデコレーションマーカーを正しく表示するよう修正
- `DIFF_MODIFIED_COLOR`, `.gutter-modified`, `.line-modified` の死コードを除去

## Test plan
- [x] `computeDiff` の単体テスト（13ケース）が全て通過
- [x] `createDiffDecorations` の単体テスト（4ケース）が全て通過
- [x] 全978テスト通過を確認
- [ ] 行追加のあるファイルでガター・スクロールバーに緑マーカーが表示されることを確認
- [ ] 行削除のあるファイルでガター・スクロールバーに赤マーカーが表示されることを確認
- [ ] 行の内容変更（置換）が追加（緑）として表示されることを確認

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 差分表示ロジックを刷新しました。変更行の追加と削除を明確に区別するようになり、視覚的な表現がより直感的になります。削除行は赤色で、追加行は独立したスタイルで表示されます。

* **スタイル**
  * 変更行に関連するスタイルを削除し、追加・削除専用のスタイルに統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->