### PR TITLE
refactor: SDKターンライフサイクルのRust一元管理・UI改善・エラー表示修正

### DIFF
--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -13,7 +13,7 @@ use tokio::sync::Mutex;
 
 use crate::session::{
     add_message_internal, create_session_internal, now_timestamp, resolve_data_dir, ChatMessage,
-    ChatSession, GetSessionResponse, MessagePart, MessageRole, SessionSummary, SessionStore,
+    ChatSession, GetSessionResponse, MessagePart, MessageRole, SessionStore, SessionSummary,
 };
 
 const PERSIST_INTERVAL_MS: u64 = 1000;
@@ -907,12 +907,7 @@ async fn spawn_bridge_process(
             })
         };
         if was_streaming {
-            emit_session_state_changed(
-                &app_stdout,
-                &csid_stdout,
-                TurnPhase::Idle,
-                Some(-1),
-            );
+            emit_session_state_changed(&app_stdout, &csid_stdout, TurnPhase::Idle, Some(-1));
         }
         {
             let mut map = handles_stdout.lock().await;
@@ -1230,9 +1225,7 @@ async fn consume_pending_message(
                 return;
             }
         } else {
-            log::error!(
-                "consume_pending_message: no agent process for session {chat_session_id}"
-            );
+            log::error!("consume_pending_message: no agent process for session {chat_session_id}");
             return;
         }
     }
@@ -1471,12 +1464,7 @@ pub async fn respond_agent_permission(
 
     // Emit state change only if we actually transitioned: WaitingPermission → Streaming
     if did_transition_to_streaming {
-        emit_session_state_changed(
-            &app,
-            &chat_session_id,
-            TurnPhase::Streaming,
-            None,
-        );
+        emit_session_state_changed(&app, &chat_session_id, TurnPhase::Streaming, None);
     }
 
     Ok(())
@@ -1512,29 +1500,18 @@ pub async fn send_agent_message(
             .get_session(&data_dir, sid)?
             .ok_or_else(|| format!("Session not found: {sid}"))?
     } else {
-        let s = create_session_internal(&session_store, &data_dir, &worktree_path)?;
-        // Prewarm: start agent process in background
-        let app_c = app.clone();
-        let h_c = Arc::clone(handles.inner());
-        let ss_c = Arc::clone(session_store.inner());
-        let sid_c = s.id.clone();
-        let cwd_c = worktree_path.clone();
-        let pm_c = pm.clone();
-        tokio::spawn(async move {
-            if let Err(e) =
-                start_agent_session_internal(&app_c, &h_c, &ss_c, &sid_c, &cwd_c, Some(pm_c))
-                    .await
-            {
-                log::error!("Failed to prewarm agent session {sid_c}: {e}");
-            }
-        });
-        s
+        create_session_internal(&session_store, &data_dir, &worktree_path)?
     };
     let sid = session.id.clone();
 
     // 2. Add human message
-    let human_message =
-        add_message_internal(&session_store, &data_dir, &sid, MessageRole::Human, &content)?;
+    let human_message = add_message_internal(
+        &session_store,
+        &data_dir,
+        &sid,
+        MessageRole::Human,
+        &content,
+    )?;
 
     // 3. Check turn phase
     let current_phase = {
@@ -1544,45 +1521,44 @@ pub async fn send_agent_message(
             .unwrap_or(TurnPhase::Idle)
     };
 
-    let agent_message = if current_phase == TurnPhase::Streaming
-        || current_phase == TurnPhase::WaitingPermission
-    {
-        // 4a. Queue pending message + interrupt
-        {
-            let mut map = handles.lock().await;
-            if let Some(proc) = map.get_mut(&sid) {
-                proc.pending_message = Some(PendingMessage {
-                    content: content.clone(),
-                    permission_mode: pm.clone(),
-                });
-                proc.stdin
-                    .write_all(b"{\"type\":\"interrupt\"}\n")
-                    .await
-                    .map_err(|e| format!("Failed to write interrupt: {e}"))?;
-                proc.stdin
-                    .flush()
-                    .await
-                    .map_err(|e| format!("Failed to flush: {e}"))?;
+    let agent_message =
+        if current_phase == TurnPhase::Streaming || current_phase == TurnPhase::WaitingPermission {
+            // 4a. Queue pending message + interrupt
+            {
+                let mut map = handles.lock().await;
+                if let Some(proc) = map.get_mut(&sid) {
+                    proc.pending_message = Some(PendingMessage {
+                        content: content.clone(),
+                        permission_mode: pm.clone(),
+                    });
+                    proc.stdin
+                        .write_all(b"{\"type\":\"interrupt\"}\n")
+                        .await
+                        .map_err(|e| format!("Failed to write interrupt: {e}"))?;
+                    proc.stdin
+                        .flush()
+                        .await
+                        .map_err(|e| format!("Failed to flush: {e}"))?;
+                }
             }
-        }
-        None
-    } else {
-        // 4b. Create agent message + start turn
-        let agent_msg =
-            add_message_internal(&session_store, &data_dir, &sid, MessageRole::Agent, "")?;
-        start_agent_turn(
-            &app,
-            handles.inner(),
-            session_store.inner(),
-            &sid,
-            &worktree_path,
-            &pm,
-            &content,
-            &agent_msg.id,
-        )
-        .await?;
-        Some(agent_msg)
-    };
+            None
+        } else {
+            // 4b. Create agent message + start turn
+            let agent_msg =
+                add_message_internal(&session_store, &data_dir, &sid, MessageRole::Agent, "")?;
+            start_agent_turn(
+                &app,
+                handles.inner(),
+                session_store.inner(),
+                &sid,
+                &worktree_path,
+                &pm,
+                &content,
+                &agent_msg.id,
+            )
+            .await?;
+            Some(agent_msg)
+        };
 
     // 5. Get updated session and list
     let updated_session = session_store
@@ -1656,8 +1632,7 @@ pub async fn init_agent_sessions(
             let pm_c = pm.clone();
             tokio::spawn(async move {
                 if let Err(e) =
-                    start_agent_session_internal(&app_c, &h_c, &ss_c, &sid, &cwd, Some(pm_c))
-                        .await
+                    start_agent_session_internal(&app_c, &h_c, &ss_c, &sid, &cwd, Some(pm_c)).await
                 {
                     log::error!("Failed to start agent session {sid}: {e}");
                 }

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -12,7 +12,8 @@ use tokio::process::Command;
 use tokio::sync::Mutex;
 
 use crate::session::{
-    now_timestamp, resolve_data_dir, GetSessionResponse, MessagePart, SessionStore,
+    add_message_internal, create_session_internal, now_timestamp, resolve_data_dir, ChatMessage,
+    ChatSession, GetSessionResponse, MessagePart, MessageRole, SessionSummary, SessionStore,
 };
 
 const PERSIST_INTERVAL_MS: u64 = 1000;
@@ -37,6 +38,12 @@ pub enum TurnPhase {
     WaitingPermission,
 }
 
+/// A message queued while the agent is streaming, consumed on turn_complete.
+pub struct PendingMessage {
+    pub content: String,
+    pub permission_mode: String,
+}
+
 pub struct AgentProcess {
     pub stdin: tokio::process::ChildStdin,
     pub state: BridgeState,
@@ -53,6 +60,9 @@ pub struct AgentProcess {
     /// Populated from ToolResult content ("agentId: XXX"), used to fill
     /// missing tool_use_id in task_notification messages from the SDK.
     pub task_id_map: HashMap<String, String>,
+    /// Pending message queued by send_agent_message during streaming.
+    /// Auto-consumed on turn_complete by the stdout reader.
+    pub pending_message: Option<PendingMessage>,
 }
 
 /// Per-session agent process map: chat_session_id → AgentProcess
@@ -532,6 +542,7 @@ async fn spawn_bridge_process(
                 streaming_parts: Vec::new(),
                 last_message_id: None,
                 task_id_map: HashMap::new(),
+                pending_message: None,
             },
         );
     }
@@ -660,6 +671,23 @@ async fn spawn_bridge_process(
                                 TurnPhase::Idle,
                                 Some(exit_code),
                             );
+
+                            // Auto-consume pending message queued by send_agent_message.
+                            // Spawn a separate task to avoid oversized async state machine in stdout reader.
+                            let has_pending = {
+                                let map = handles_stdout.lock().await;
+                                map.get(&csid_stdout)
+                                    .is_some_and(|p| p.pending_message.is_some())
+                            };
+                            if has_pending {
+                                let app_p = app_stdout.clone();
+                                let h_p = Arc::clone(&handles_stdout);
+                                let ss_p = Arc::clone(&session_store_clone);
+                                let csid_p = csid_stdout.clone();
+                                tokio::spawn(async move {
+                                    consume_pending_message(&app_p, &h_p, &ss_p, &csid_p).await;
+                                });
+                            }
                         }
                     }
                     "error" => {
@@ -912,22 +940,20 @@ async fn spawn_bridge_process(
     Ok(())
 }
 
-#[tauri::command]
-pub async fn get_session(
-    state: tauri::State<'_, Arc<SessionStore>>,
-    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
-    app: tauri::AppHandle,
-    session_id: String,
+async fn get_session_internal(
+    session_store: &Arc<SessionStore>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    app: &tauri::AppHandle,
+    session_id: &str,
 ) -> Result<Option<GetSessionResponse>, String> {
-    let data_dir = resolve_data_dir(&app)?;
-    let session = state.get_session(&data_dir, &session_id)?;
+    let data_dir = resolve_data_dir(app)?;
+    let session = session_store.get_session(&data_dir, session_id)?;
     match session {
         None => Ok(None),
         Some(mut session) => {
-            // Acquire lock briefly to read turn_phase and clone streaming parts
             let (turn_phase, raw_parts, streaming_mid) = {
                 let map = handles.lock().await;
-                if let Some(proc) = map.get(&session_id) {
+                if let Some(proc) = map.get(session_id) {
                     let phase = proc.turn_phase;
                     if proc.state == BridgeState::Streaming {
                         (
@@ -943,7 +969,6 @@ pub async fn get_session(
                 }
             };
 
-            // Consolidate outside lock to avoid blocking other sessions
             if turn_phase == TurnPhase::Streaming || turn_phase == TurnPhase::WaitingPermission {
                 if let Some(ref mid) = streaming_mid {
                     let parts = consolidate_parts(raw_parts);
@@ -964,6 +989,48 @@ pub async fn get_session(
 }
 
 #[tauri::command]
+pub async fn get_session(
+    state: tauri::State<'_, Arc<SessionStore>>,
+    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
+    app: tauri::AppHandle,
+    session_id: String,
+) -> Result<Option<GetSessionResponse>, String> {
+    get_session_internal(state.inner(), handles.inner(), &app, &session_id).await
+}
+
+async fn start_agent_session_internal(
+    app: &tauri::AppHandle,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    chat_session_id: &str,
+    cwd: &str,
+    permission_mode: Option<String>,
+) -> Result<(), String> {
+    {
+        let mut map = handles.lock().await;
+        if let Some(proc) = map.get(chat_session_id) {
+            if proc.state != BridgeState::Crashed {
+                return Ok(());
+            }
+        }
+        map.remove(chat_session_id);
+    }
+
+    let resume_sid = get_resume_session_id(app, session_store, chat_session_id);
+
+    spawn_bridge_process(
+        app,
+        handles,
+        session_store,
+        chat_session_id,
+        resume_sid,
+        cwd,
+        permission_mode,
+    )
+    .await
+}
+
+#[tauri::command]
 pub async fn start_agent_session(
     app: tauri::AppHandle,
     handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
@@ -972,59 +1039,38 @@ pub async fn start_agent_session(
     cwd: String,
     permission_mode: Option<String>,
 ) -> Result<(), String> {
-    // If process already exists and is not crashed, do nothing; otherwise remove crashed entry
-    {
-        let mut map = handles.lock().await;
-        if let Some(proc) = map.get(&chat_session_id) {
-            if proc.state != BridgeState::Crashed {
-                return Ok(());
-            }
-        }
-        map.remove(&chat_session_id);
-    }
-
-    let resume_sid = get_resume_session_id(&app, session_store.inner(), &chat_session_id);
-
-    spawn_bridge_process(
+    start_agent_session_internal(
         &app,
         handles.inner(),
         session_store.inner(),
         &chat_session_id,
-        resume_sid,
         &cwd,
         permission_mode,
     )
     .await
 }
 
+/// Core logic for starting a new agent turn: spawn Bridge if needed, send prompt.
+/// Used by execute_agent_query (Tauri command), send_agent_message, and pending message consumption.
 #[allow(clippy::too_many_arguments)]
-#[tauri::command]
-pub async fn execute_agent_query(
-    app: tauri::AppHandle,
-    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
-    session_store: tauri::State<'_, Arc<SessionStore>>,
-    prompt: String,
-    chat_session_id: String,
-    cwd: String,
-    permission_mode: Option<String>,
-    streaming_message_id: String,
+async fn start_agent_turn(
+    app: &tauri::AppHandle,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    chat_session_id: &str,
+    cwd: &str,
+    permission_mode: &str,
+    prompt: &str,
+    streaming_message_id: &str,
 ) -> Result<(), String> {
     // Check if we need to spawn a new process (single lock to avoid TOCTOU)
     let spawn_info = {
         let mut map = handles.lock().await;
-        match map.get(&chat_session_id) {
-            None => Some(get_resume_session_id(
-                &app,
-                session_store.inner(),
-                &chat_session_id,
-            )),
+        match map.get(chat_session_id) {
+            None => Some(get_resume_session_id(app, session_store, chat_session_id)),
             Some(proc) if proc.state == BridgeState::Crashed => {
-                map.remove(&chat_session_id);
-                Some(get_resume_session_id(
-                    &app,
-                    session_store.inner(),
-                    &chat_session_id,
-                ))
+                map.remove(chat_session_id);
+                Some(get_resume_session_id(app, session_store, chat_session_id))
             }
             _ => None,
         }
@@ -1032,19 +1078,19 @@ pub async fn execute_agent_query(
 
     if let Some(resume_sid) = spawn_info {
         spawn_bridge_process(
-            &app,
-            handles.inner(),
-            session_store.inner(),
-            &chat_session_id,
+            app,
+            handles,
+            session_store,
+            chat_session_id,
             resume_sid,
-            &cwd,
-            permission_mode.clone(),
+            cwd,
+            Some(permission_mode.to_string()),
         )
         .await?;
     }
 
     // Sync permissionMode to Bridge before sending message
-    let mode_data = build_set_mode_command(permission_mode.as_deref().unwrap_or("acceptEdits"));
+    let mode_data = build_set_mode_command(permission_mode);
 
     // Send message command.
     // Even if a message is sent while the SDK is still processing an interrupt,
@@ -1058,7 +1104,7 @@ pub async fn execute_agent_query(
 
     {
         let mut map = handles.lock().await;
-        if let Some(proc) = map.get_mut(&chat_session_id) {
+        if let Some(proc) = map.get_mut(chat_session_id) {
             // Sync permissionMode to Bridge
             proc.stdin
                 .write_all(mode_data.as_bytes())
@@ -1071,7 +1117,7 @@ pub async fn execute_agent_query(
 
             proc.state = BridgeState::Streaming;
             proc.turn_phase = TurnPhase::Streaming;
-            proc.streaming_message_id = Some(streaming_message_id.clone());
+            proc.streaming_message_id = Some(streaming_message_id.to_string());
             proc.streaming_parts.clear();
             proc.last_message_id = None;
             proc.task_id_map.clear();
@@ -1089,14 +1135,135 @@ pub async fn execute_agent_query(
     }
 
     // Emit state change so frontend can track turn phase
-    emit_session_state_changed(
-        &app,
-        &chat_session_id,
-        TurnPhase::Streaming,
-        None,
-    );
+    emit_session_state_changed(app, chat_session_id, TurnPhase::Streaming, None);
 
     Ok(())
+}
+
+/// Consume a pending message that was queued by `send_agent_message` during streaming.
+/// Called from the stdout reader after `turn_complete` via `tokio::spawn`.
+///
+/// Unlike `start_agent_turn`, this skips the spawn-if-needed check because the Bridge
+/// process is guaranteed to be running (it just emitted `turn_complete`).
+async fn consume_pending_message(
+    app: &tauri::AppHandle,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    chat_session_id: &str,
+) {
+    // 1. Take pending message from process
+    let pending = {
+        let mut map = handles.lock().await;
+        map.get_mut(chat_session_id)
+            .and_then(|p| p.pending_message.take())
+    };
+    let Some(pending) = pending else {
+        return;
+    };
+
+    // 2. Add empty agent message
+    let data_dir = match resolve_data_dir(app) {
+        Ok(d) => d,
+        Err(e) => {
+            log::error!("consume_pending_message: failed to resolve data dir: {e}");
+            return;
+        }
+    };
+    let agent_msg = match add_message_internal(
+        session_store,
+        &data_dir,
+        chat_session_id,
+        MessageRole::Agent,
+        "",
+    ) {
+        Ok(msg) => msg,
+        Err(e) => {
+            log::error!("consume_pending_message: failed to add agent message: {e}");
+            return;
+        }
+    };
+
+    // 3. Emit event so UI can update with the new agent message
+    {
+        use tauri::Emitter;
+        let _ = app.emit(
+            "agent-pending-message-consumed",
+            serde_json::json!({
+                "chat_session_id": chat_session_id,
+                "agent_message": agent_msg,
+            }),
+        );
+    }
+
+    // 4. Sync permissionMode + send message directly to the running Bridge.
+    //    The process is guaranteed running since it just emitted turn_complete.
+    let mode_data = build_set_mode_command(&pending.permission_mode);
+    let msg_cmd = serde_json::json!({
+        "type": "message",
+        "prompt": pending.content,
+    });
+    let data = format!("{}\n", msg_cmd);
+
+    {
+        let mut map = handles.lock().await;
+        if let Some(proc) = map.get_mut(chat_session_id) {
+            if let Err(e) = proc.stdin.write_all(mode_data.as_bytes()).await {
+                log::error!("consume_pending_message: failed to write setMode: {e}");
+                return;
+            }
+            if let Err(e) = proc.stdin.flush().await {
+                log::error!("consume_pending_message: failed to flush setMode: {e}");
+                return;
+            }
+            proc.state = BridgeState::Streaming;
+            proc.turn_phase = TurnPhase::Streaming;
+            proc.streaming_message_id = Some(agent_msg.id.clone());
+            proc.streaming_parts.clear();
+            proc.last_message_id = None;
+            proc.task_id_map.clear();
+            if let Err(e) = proc.stdin.write_all(data.as_bytes()).await {
+                log::error!("consume_pending_message: failed to write message: {e}");
+                return;
+            }
+            if let Err(e) = proc.stdin.flush().await {
+                log::error!("consume_pending_message: failed to flush message: {e}");
+                return;
+            }
+        } else {
+            log::error!(
+                "consume_pending_message: no agent process for session {chat_session_id}"
+            );
+            return;
+        }
+    }
+
+    // 5. Emit state change
+    emit_session_state_changed(app, chat_session_id, TurnPhase::Streaming, None);
+}
+
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub async fn execute_agent_query(
+    app: tauri::AppHandle,
+    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
+    session_store: tauri::State<'_, Arc<SessionStore>>,
+    prompt: String,
+    chat_session_id: String,
+    cwd: String,
+    permission_mode: Option<String>,
+    streaming_message_id: String,
+) -> Result<(), String> {
+    start_agent_turn(
+        &app,
+        handles.inner(),
+        session_store.inner(),
+        &chat_session_id,
+        &cwd,
+        permission_mode.as_deref().unwrap_or("acceptEdits"),
+        &prompt,
+        &streaming_message_id,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -1313,6 +1480,204 @@ pub async fn respond_agent_permission(
     }
 
     Ok(())
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendMessageResponse {
+    pub session: ChatSession,
+    pub human_message: ChatMessage,
+    pub agent_message: Option<ChatMessage>,
+    pub sessions: Vec<SessionSummary>,
+}
+
+/// Unified command to send a message: handles session creation, message persistence,
+/// turn phase check (interrupt if streaming, start query if idle), and pending message queuing.
+#[tauri::command]
+pub async fn send_agent_message(
+    app: tauri::AppHandle,
+    session_store: tauri::State<'_, Arc<SessionStore>>,
+    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
+    chat_session_id: Option<String>,
+    worktree_path: String,
+    content: String,
+    permission_mode: Option<String>,
+) -> Result<SendMessageResponse, String> {
+    let data_dir = resolve_data_dir(&app)?;
+    let pm = permission_mode.unwrap_or_else(|| "acceptEdits".to_string());
+
+    // 1. Create or get session
+    let session = if let Some(ref sid) = chat_session_id {
+        session_store
+            .get_session(&data_dir, sid)?
+            .ok_or_else(|| format!("Session not found: {sid}"))?
+    } else {
+        let s = create_session_internal(&session_store, &data_dir, &worktree_path)?;
+        // Prewarm: start agent process in background
+        let app_c = app.clone();
+        let h_c = Arc::clone(handles.inner());
+        let ss_c = Arc::clone(session_store.inner());
+        let sid_c = s.id.clone();
+        let cwd_c = worktree_path.clone();
+        let pm_c = pm.clone();
+        tokio::spawn(async move {
+            if let Err(e) =
+                start_agent_session_internal(&app_c, &h_c, &ss_c, &sid_c, &cwd_c, Some(pm_c))
+                    .await
+            {
+                log::error!("Failed to prewarm agent session {sid_c}: {e}");
+            }
+        });
+        s
+    };
+    let sid = session.id.clone();
+
+    // 2. Add human message
+    let human_message =
+        add_message_internal(&session_store, &data_dir, &sid, MessageRole::Human, &content)?;
+
+    // 3. Check turn phase
+    let current_phase = {
+        let map = handles.lock().await;
+        map.get(&sid)
+            .map(|p| p.turn_phase)
+            .unwrap_or(TurnPhase::Idle)
+    };
+
+    let agent_message = if current_phase == TurnPhase::Streaming
+        || current_phase == TurnPhase::WaitingPermission
+    {
+        // 4a. Queue pending message + interrupt
+        {
+            let mut map = handles.lock().await;
+            if let Some(proc) = map.get_mut(&sid) {
+                proc.pending_message = Some(PendingMessage {
+                    content: content.clone(),
+                    permission_mode: pm.clone(),
+                });
+                proc.stdin
+                    .write_all(b"{\"type\":\"interrupt\"}\n")
+                    .await
+                    .map_err(|e| format!("Failed to write interrupt: {e}"))?;
+                proc.stdin
+                    .flush()
+                    .await
+                    .map_err(|e| format!("Failed to flush: {e}"))?;
+            }
+        }
+        None
+    } else {
+        // 4b. Create agent message + start turn
+        let agent_msg =
+            add_message_internal(&session_store, &data_dir, &sid, MessageRole::Agent, "")?;
+        start_agent_turn(
+            &app,
+            handles.inner(),
+            session_store.inner(),
+            &sid,
+            &worktree_path,
+            &pm,
+            &content,
+            &agent_msg.id,
+        )
+        .await?;
+        Some(agent_msg)
+    };
+
+    // 5. Get updated session and list
+    let updated_session = session_store
+        .get_session(&data_dir, &sid)?
+        .ok_or_else(|| format!("Session not found: {sid}"))?;
+    let sessions = session_store.list_sessions(&data_dir, &worktree_path)?;
+
+    Ok(SendMessageResponse {
+        session: updated_session,
+        human_message,
+        agent_message,
+        sessions,
+    })
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitSessionsResponse {
+    pub sessions: Vec<SessionSummary>,
+    pub active_session: Option<GetSessionResponse>,
+}
+
+/// Unified command for session initialization: lists sessions, starts Bridge processes,
+/// creates a new session if empty, returns sessions + active session.
+#[tauri::command]
+pub async fn init_agent_sessions(
+    app: tauri::AppHandle,
+    session_store: tauri::State<'_, Arc<SessionStore>>,
+    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
+    worktree_path: String,
+    permission_mode: Option<String>,
+) -> Result<InitSessionsResponse, String> {
+    let data_dir = resolve_data_dir(&app)?;
+    let pm = permission_mode.unwrap_or_else(|| "acceptEdits".to_string());
+
+    let mut sessions = session_store.list_sessions(&data_dir, &worktree_path)?;
+
+    if sessions.is_empty() {
+        // Create new session + start agent process
+        let session = create_session_internal(&session_store, &data_dir, &worktree_path)?;
+        start_agent_session_internal(
+            &app,
+            handles.inner(),
+            session_store.inner(),
+            &session.id,
+            &worktree_path,
+            Some(pm),
+        )
+        .await
+        .unwrap_or_else(|e| {
+            log::error!("Failed to start new agent session: {e}");
+        });
+
+        sessions = session_store.list_sessions(&data_dir, &worktree_path)?;
+        let response = GetSessionResponse {
+            session,
+            turn_phase: TurnPhase::Idle,
+        };
+        Ok(InitSessionsResponse {
+            sessions,
+            active_session: Some(response),
+        })
+    } else {
+        // Start agent processes for all sessions (fire-and-forget)
+        for s in &sessions {
+            let app_c = app.clone();
+            let h_c = Arc::clone(handles.inner());
+            let ss_c = Arc::clone(session_store.inner());
+            let sid = s.id.clone();
+            let cwd = worktree_path.clone();
+            let pm_c = pm.clone();
+            tokio::spawn(async move {
+                if let Err(e) =
+                    start_agent_session_internal(&app_c, &h_c, &ss_c, &sid, &cwd, Some(pm_c))
+                        .await
+                {
+                    log::error!("Failed to start agent session {sid}: {e}");
+                }
+            });
+        }
+
+        // Get first session as active
+        let active = get_session_internal(
+            session_store.inner(),
+            handles.inner(),
+            &app,
+            &sessions[0].id,
+        )
+        .await?;
+
+        Ok(InitSessionsResponse {
+            sessions,
+            active_session: active,
+        })
+    }
 }
 
 #[derive(serde::Serialize, Clone, Debug, PartialEq)]

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -669,17 +669,40 @@ async fn spawn_bridge_process(
                             .unwrap_or("Unknown bridge error");
                         log::error!("Bridge error [{}]: {}", csid_stdout, error_msg);
 
-                        // Accumulate error into streaming parts
-                        {
+                        // Accumulate error into streaming parts and extract delta
+                        let (error_delta, error_emit_msg_id) = {
                             let mut map = handles_stdout.lock().await;
                             if let Some(proc) = map.get_mut(&csid_stdout) {
                                 if proc.state == BridgeState::Streaming {
+                                    let prev_len = proc.streaming_parts.len();
                                     accumulate_sdk_message(
                                         &msg,
                                         &mut proc.streaming_parts,
                                         &mut proc.task_id_map,
                                     );
+                                    let delta = proc.streaming_parts[prev_len..].to_vec();
+                                    let mid = proc.streaming_message_id.clone();
+                                    (delta, mid)
+                                } else {
+                                    (Vec::new(), None)
                                 }
+                            } else {
+                                (Vec::new(), None)
+                            }
+                        };
+
+                        // Emit error delta so UI can display the error message
+                        if !error_delta.is_empty() {
+                            if let Some(ref mid) = error_emit_msg_id {
+                                use tauri::Emitter;
+                                let _ = app_stdout.emit(
+                                    "agent-streaming-updated",
+                                    serde_json::json!({
+                                        "chat_session_id": csid_stdout,
+                                        "message_id": mid,
+                                        "parts": error_delta,
+                                    }),
+                                );
                             }
                         }
 

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 static GENERATION_COUNTER: AtomicU64 = AtomicU64::new(1);
 
+use serde::Serialize;
 use tauri::Manager;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
@@ -24,9 +25,22 @@ pub enum BridgeState {
     Crashed,
 }
 
+/// SDK's turn lifecycle phase, exposed to the frontend as the single source of truth.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnPhase {
+    /// Waiting for user input / turn completed
+    Idle,
+    /// Actively processing a user prompt (SDK iterator yielding before `result`)
+    Streaming,
+    /// SDK blocked on `canUseTool` promise — waiting for permission response
+    WaitingPermission,
+}
+
 pub struct AgentProcess {
     pub stdin: tokio::process::ChildStdin,
     pub state: BridgeState,
+    pub turn_phase: TurnPhase,
     pub sdk_session_id: Option<String>,
     pub child: tokio::process::Child,
     pub generation_id: u64,
@@ -125,19 +139,19 @@ fn persist_streaming_parts(
     }
 }
 
-fn emit_agent_query_completed(
+fn emit_session_state_changed(
     app: &tauri::AppHandle,
-    exit_code: i64,
-    stderr: &str,
     chat_session_id: &str,
+    turn_phase: TurnPhase,
+    exit_code: Option<i64>,
 ) {
     use tauri::Emitter;
     let _ = app.emit(
-        "agent-query-completed",
+        "agent-session-state-changed",
         serde_json::json!({
-            "exit_code": exit_code,
-            "stderr": stderr,
             "chat_session_id": chat_session_id,
+            "turn_phase": turn_phase,
+            "exit_code": exit_code,
         }),
     );
 }
@@ -510,6 +524,7 @@ async fn spawn_bridge_process(
             AgentProcess {
                 stdin,
                 state: BridgeState::Initializing,
+                turn_phase: TurnPhase::Idle,
                 sdk_session_id: session_id,
                 child,
                 generation_id: gen_id,
@@ -565,6 +580,7 @@ async fn spawn_bridge_process(
                             if let Some(proc) = map.get_mut(&csid_stdout) {
                                 was_streaming = proc.state == BridgeState::Streaming;
                                 proc.state = BridgeState::Ready;
+                                proc.turn_phase = TurnPhase::Idle;
 
                                 // Capture streaming buffer for consolidation outside lock.
                                 // Keep parts in buffer so post-turn_complete background task
@@ -636,15 +652,13 @@ async fn spawn_bridge_process(
                             }
                         }
 
-                        // Emit agent-query-completed only for user turns (was Streaming)
+                        // Emit state change only for user turns (was Streaming)
                         if was_streaming {
-                            let stderr_text =
-                                msg.get("stderr").and_then(|v| v.as_str()).unwrap_or("");
-                            emit_agent_query_completed(
+                            emit_session_state_changed(
                                 &app_stdout,
-                                exit_code,
-                                stderr_text,
                                 &csid_stdout,
+                                TurnPhase::Idle,
+                                Some(exit_code),
                             );
                         }
                     }
@@ -679,6 +693,7 @@ async fn spawn_bridge_process(
                                 let wi = proc.state == BridgeState::Initializing;
                                 if ws || wi {
                                     proc.state = BridgeState::Crashed;
+                                    proc.turn_phase = TurnPhase::Idle;
                                 }
                                 (ws, wi)
                             } else {
@@ -686,7 +701,12 @@ async fn spawn_bridge_process(
                             }
                         };
                         if was_streaming {
-                            emit_agent_query_completed(&app_stdout, 1, error_msg, &csid_stdout);
+                            emit_session_state_changed(
+                                &app_stdout,
+                                &csid_stdout,
+                                TurnPhase::Idle,
+                                Some(1),
+                            );
                         }
                         // Init error → clear stale agent_session_id to prevent infinite resume loop
                         if was_initializing {
@@ -808,6 +828,22 @@ async fn spawn_bridge_process(
                         if should_forward_sdk_message(accumulated, msg_type) {
                             let _ = app_stdout.emit("agent-sdk-message", &msg);
                         }
+
+                        // Transition to WaitingPermission when permission_request arrives
+                        if msg_type == "permission_request" {
+                            let mut map = handles_stdout.lock().await;
+                            if let Some(proc) = map.get_mut(&csid_stdout) {
+                                if proc.state == BridgeState::Streaming {
+                                    proc.turn_phase = TurnPhase::WaitingPermission;
+                                    emit_session_state_changed(
+                                        &app_stdout,
+                                        &csid_stdout,
+                                        TurnPhase::WaitingPermission,
+                                        None,
+                                    );
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -820,11 +856,11 @@ async fn spawn_bridge_process(
             })
         };
         if was_streaming {
-            emit_agent_query_completed(
+            emit_session_state_changed(
                 &app_stdout,
-                -1,
-                "Bridge process exited unexpectedly",
                 &csid_stdout,
+                TurnPhase::Idle,
+                Some(-1),
             );
         }
         {
@@ -832,6 +868,7 @@ async fn spawn_bridge_process(
             if let Some(proc) = map.get_mut(&csid_stdout) {
                 if proc.generation_id == captured_gen_id {
                     proc.state = BridgeState::Crashed;
+                    proc.turn_phase = TurnPhase::Idle;
                 }
             }
         }
@@ -864,27 +901,27 @@ pub async fn get_session(
     match session {
         None => Ok(None),
         Some(mut session) => {
-            // Acquire lock briefly to read state and clone streaming parts
-            let (is_streaming, raw_parts, streaming_mid) = {
+            // Acquire lock briefly to read turn_phase and clone streaming parts
+            let (turn_phase, raw_parts, streaming_mid) = {
                 let map = handles.lock().await;
                 if let Some(proc) = map.get(&session_id) {
-                    let streaming = proc.state == BridgeState::Streaming;
-                    if streaming {
+                    let phase = proc.turn_phase;
+                    if proc.state == BridgeState::Streaming {
                         (
-                            true,
+                            phase,
                             proc.streaming_parts.clone(),
                             proc.streaming_message_id.clone(),
                         )
                     } else {
-                        (false, Vec::new(), None)
+                        (phase, Vec::new(), None)
                     }
                 } else {
-                    (false, Vec::new(), None)
+                    (TurnPhase::Idle, Vec::new(), None)
                 }
             };
 
             // Consolidate outside lock to avoid blocking other sessions
-            if is_streaming {
+            if turn_phase == TurnPhase::Streaming || turn_phase == TurnPhase::WaitingPermission {
                 if let Some(ref mid) = streaming_mid {
                     let parts = consolidate_parts(raw_parts);
                     if !parts.is_empty() {
@@ -897,7 +934,7 @@ pub async fn get_session(
 
             Ok(Some(GetSessionResponse {
                 session,
-                is_streaming,
+                turn_phase,
             }))
         }
     }
@@ -1010,6 +1047,7 @@ pub async fn execute_agent_query(
                 .map_err(|e| format!("Failed to flush setMode: {e}"))?;
 
             proc.state = BridgeState::Streaming;
+            proc.turn_phase = TurnPhase::Streaming;
             proc.streaming_message_id = Some(streaming_message_id.clone());
             proc.streaming_parts.clear();
             proc.last_message_id = None;
@@ -1027,14 +1065,12 @@ pub async fn execute_agent_query(
         }
     }
 
-    // Emit agent-streaming-started so frontend can track streaming state
-    use tauri::Emitter;
-    let _ = app.emit(
-        "agent-streaming-started",
-        serde_json::json!({
-            "chat_session_id": chat_session_id,
-            "message_id": streaming_message_id,
-        }),
+    // Emit state change so frontend can track turn phase
+    emit_session_state_changed(
+        &app,
+        &chat_session_id,
+        TurnPhase::Streaming,
+        None,
     );
 
     Ok(())
@@ -1177,6 +1213,7 @@ pub async fn respond_agent_permission(
 
     let updated_permission_part: Option<MessagePart>;
     let emit_msg_id;
+    let did_transition_to_streaming;
     {
         let mut map = handles.lock().await;
         if let Some(proc) = map.get_mut(&chat_session_id) {
@@ -1188,6 +1225,12 @@ pub async fn respond_agent_permission(
                 .flush()
                 .await
                 .map_err(|e| format!("Failed to flush: {e}"))?;
+
+            // Transition back to Streaming after permission response
+            did_transition_to_streaming = proc.turn_phase == TurnPhase::WaitingPermission;
+            if did_transition_to_streaming {
+                proc.turn_phase = TurnPhase::Streaming;
+            }
 
             // Update Permission part status in streaming buffer
             let new_status = if behavior == "allow" {
@@ -1233,6 +1276,16 @@ pub async fn respond_agent_permission(
                 "message_id": mid,
                 "parts": [part],
             }),
+        );
+    }
+
+    // Emit state change only if we actually transitioned: WaitingPermission → Streaming
+    if did_transition_to_streaming {
+        emit_session_state_changed(
+            &app,
+            &chat_session_id,
+            TurnPhase::Streaming,
+            None,
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod protocol;
 mod pty;
 mod qr_code;
 mod repo_registry;
+mod review;
 mod review_prompt;
 mod search;
 mod sentry_integration;
@@ -88,6 +89,8 @@ pub fn run() {
             app.manage(Arc::new(pty::oneshot::OneShotPtyManager::new(Arc::clone(
                 pty_mgr.inner(),
             ))));
+            app.manage(Arc::new(review::ReviewOrchestrator::new()));
+            review::ReviewOrchestrator::register_listeners(app.handle());
 
             let data_dir = app.path().app_data_dir()?;
             let config_path = data_dir.join("releash.toml");
@@ -367,6 +370,11 @@ pub fn run() {
             // Review prompt
             review_prompt::get_review_prompt,
             review_prompt::get_per_file_review_tasks,
+            // Review orchestration
+            review::commands::start_review,
+            review::commands::cancel_review,
+            review::commands::get_review_status,
+            review::commands::reset_review,
             // Thread AI
             thread_ai::build_thread_ai_prompt,
             thread_ai::build_thread_summarize_prompt,
@@ -394,6 +402,8 @@ pub fn run() {
             agent_sdk::close_agent_session,
             agent_sdk::set_agent_permission_mode,
             agent_sdk::respond_agent_permission,
+            agent_sdk::send_agent_message,
+            agent_sdk::init_agent_sessions,
             agent_sdk::scan_slash_commands,
             // Session
             session::list_sessions,

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -222,6 +222,7 @@ pub struct ExploreSymbolParams {
 #[derive(Clone)]
 pub struct ReleashMcpServer {
     state: Arc<McpSharedState>,
+    #[allow(dead_code)]
     tool_router: ToolRouter<ReleashMcpServer>,
 }
 

--- a/src-tauri/src/pty/oneshot.rs
+++ b/src-tauri/src/pty/oneshot.rs
@@ -259,9 +259,48 @@ impl OneShotPtyManager {
         let entries = self.entries.lock();
         entries.get(&pty_id).and_then(|e| {
             if e.output.is_empty() {
-                None
+                self.pty_manager
+                    .find_session(&e.info.session_key)
+                    .map(|s| s.buffered_output)
+                    .filter(|o| !o.is_empty())
             } else {
                 Some(e.output.clone())
+            }
+        })
+    }
+
+    /// Returns the current length of the accumulated output for a given pty_id.
+    /// Used by the orchestrator to take a snapshot offset before registering
+    /// the pty-to-session mapping, so that the backfill replay only covers
+    /// output that arrived *before* the mapping was registered.
+    pub fn get_output_len(&self, pty_id: u64) -> usize {
+        self.entries
+            .lock()
+            .get(&pty_id)
+            .map(|e| e.output.len())
+            .unwrap_or(0)
+    }
+
+    /// Returns buffered output starting from `offset` bytes.
+    /// If the entry output is shorter than `offset` (e.g. due to truncation),
+    /// returns `None`.
+    pub fn get_buffered_output_from(&self, pty_id: u64, offset: usize) -> Option<String> {
+        let entries = self.entries.lock();
+        entries.get(&pty_id).and_then(|e| {
+            if offset == 0 {
+                // Same as get_buffered_output: fallback to PtyManager buffer
+                if e.output.is_empty() {
+                    self.pty_manager
+                        .find_session(&e.info.session_key)
+                        .map(|s| s.buffered_output)
+                        .filter(|o| !o.is_empty())
+                } else {
+                    Some(e.output.clone())
+                }
+            } else if offset < e.output.len() {
+                Some(e.output[offset..].to_string())
+            } else {
+                None
             }
         })
     }

--- a/src-tauri/src/pty/oneshot.rs
+++ b/src-tauri/src/pty/oneshot.rs
@@ -255,6 +255,17 @@ impl OneShotPtyManager {
         self.entries.lock().get(&pty_id).map(|e| e.info.clone())
     }
 
+    pub fn get_buffered_output(&self, pty_id: u64) -> Option<String> {
+        let entries = self.entries.lock();
+        entries.get(&pty_id).and_then(|e| {
+            if e.output.is_empty() {
+                None
+            } else {
+                Some(e.output.clone())
+            }
+        })
+    }
+
     pub fn list_active_for_worktree(&self, worktree_path: &str) -> Vec<FindOneShotPtyResult> {
         self.entries
             .lock()

--- a/src-tauri/src/review/commands.rs
+++ b/src-tauri/src/review/commands.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use tauri::{AppHandle, State};
+
+use crate::review_prompt::get_per_file_review_tasks_internal;
+use crate::thread_store::ThreadStore;
+
+use super::orchestrator::{ReviewOrchestrator, ReviewSessionStatus};
+
+#[tauri::command]
+pub fn start_review(
+    app: AppHandle,
+    orchestrator: State<'_, Arc<ReviewOrchestrator>>,
+    thread_store: State<'_, Arc<ThreadStore>>,
+    worktree_path: String,
+    command_template: String,
+    concurrency: usize,
+) -> Result<Option<String>, String> {
+    let tasks = get_per_file_review_tasks_internal(&worktree_path, &thread_store)?;
+
+    if tasks.is_empty() {
+        return Ok(None);
+    }
+
+    let session_id =
+        orchestrator.start_review(&app, &worktree_path, &command_template, concurrency, tasks);
+    Ok(Some(session_id))
+}
+
+#[tauri::command]
+pub fn cancel_review(
+    app: AppHandle,
+    orchestrator: State<'_, Arc<ReviewOrchestrator>>,
+    review_session_id: String,
+) -> Result<(), String> {
+    orchestrator.cancel_review(&app, &review_session_id)
+}
+
+#[tauri::command]
+pub fn get_review_status(
+    orchestrator: State<'_, Arc<ReviewOrchestrator>>,
+    review_session_id: String,
+) -> Option<ReviewSessionStatus> {
+    orchestrator.get_status(&review_session_id)
+}
+
+#[tauri::command]
+pub fn reset_review(
+    orchestrator: State<'_, Arc<ReviewOrchestrator>>,
+    review_session_id: String,
+) {
+    orchestrator.reset(&review_session_id);
+}

--- a/src-tauri/src/review/commands.rs
+++ b/src-tauri/src/review/commands.rs
@@ -33,7 +33,9 @@ pub fn cancel_review(
     orchestrator: State<'_, Arc<ReviewOrchestrator>>,
     review_session_id: String,
 ) -> Result<(), String> {
-    orchestrator.cancel_review(&app, &review_session_id)
+    orchestrator
+        .cancel_review(&app, &review_session_id)
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -46,8 +48,9 @@ pub fn get_review_status(
 
 #[tauri::command]
 pub fn reset_review(
+    app: AppHandle,
     orchestrator: State<'_, Arc<ReviewOrchestrator>>,
     review_session_id: String,
 ) {
-    orchestrator.reset(&review_session_id);
+    orchestrator.reset(&app, &review_session_id);
 }

--- a/src-tauri/src/review/mod.rs
+++ b/src-tauri/src/review/mod.rs
@@ -1,0 +1,4 @@
+pub mod commands;
+mod orchestrator;
+
+pub use orchestrator::ReviewOrchestrator;

--- a/src-tauri/src/review/orchestrator.rs
+++ b/src-tauri/src/review/orchestrator.rs
@@ -1,0 +1,664 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Listener, Manager};
+
+use crate::pty::oneshot::{OneShotPtyManager, OneShotStatus};
+use crate::pty::PtyOutput;
+use crate::review_prompt::PerFileReviewTask;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewStatus {
+    #[allow(dead_code)]
+    Idle,
+    Running,
+    Completed,
+    Error,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FileReviewStatus {
+    Pending,
+    Running,
+    Done,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileReviewState {
+    pub file_path: String,
+    pub status: FileReviewStatus,
+    pub pty_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReviewProgress {
+    pub done: usize,
+    pub total: usize,
+    pub error_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReviewSessionStatus {
+    pub status: ReviewStatus,
+    pub file_states: Vec<FileReviewState>,
+    pub progress: ReviewProgress,
+}
+
+struct ReviewSession {
+    worktree_path: String,
+    command_template: String,
+    task_queue: VecDeque<PerFileReviewTask>,
+    file_states: Vec<FileReviewState>,
+    concurrency: usize,
+    pty_to_file: HashMap<u64, usize>,
+    active_count: usize,
+    done_count: usize,
+    total_count: usize,
+    error_count: usize,
+    cancelled: bool,
+}
+
+struct OrchestratorState {
+    sessions: HashMap<String, ReviewSession>,
+    pty_to_session: HashMap<u64, String>,
+}
+
+pub struct ReviewOrchestrator {
+    state: Mutex<OrchestratorState>,
+}
+
+impl ReviewOrchestrator {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(OrchestratorState {
+                sessions: HashMap::new(),
+                pty_to_session: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Register Tauri event listeners for PTY status changes and output.
+    /// Must be called once during app setup.
+    pub fn register_listeners(app: &AppHandle) {
+        let app_status = app.clone();
+        app.listen("oneshot-pty-status-changed", move |event| {
+            if let Ok(info) =
+                serde_json::from_str::<crate::pty::oneshot::OneShotPtyInfo>(event.payload())
+            {
+                let is_terminal = matches!(
+                    info.status,
+                    OneShotStatus::Completed
+                        | OneShotStatus::Error
+                        | OneShotStatus::Timeout
+                        | OneShotStatus::Cancelled
+                );
+                if !is_terminal {
+                    return;
+                }
+                if let Some(orchestrator) = app_status.try_state::<Arc<ReviewOrchestrator>>() {
+                    orchestrator.handle_pty_completed(&app_status, info.pty_id, &info.status);
+                }
+            }
+        });
+
+        let app_output = app.clone();
+        app.listen("pty-output", move |event| {
+            if let Ok(payload) = serde_json::from_str::<PtyOutput>(event.payload()) {
+                if let Some(orchestrator) = app_output.try_state::<Arc<ReviewOrchestrator>>() {
+                    orchestrator.handle_pty_output(&app_output, payload.pty_id, &payload.data);
+                }
+            }
+        });
+    }
+
+    pub fn start_review(
+        &self,
+        app: &AppHandle,
+        worktree_path: &str,
+        command_template: &str,
+        concurrency: usize,
+        tasks: Vec<PerFileReviewTask>,
+    ) -> String {
+        let session_id = worktree_path.to_string();
+        let concurrency = concurrency.max(1);
+
+        // Cancel existing review for this worktree if any
+        let existing_ptys: Vec<u64> = {
+            let mut state = self.state.lock();
+            if let Some(existing) = state.sessions.remove(&session_id) {
+                let ptys: Vec<u64> = existing.pty_to_file.keys().copied().collect();
+                for &pty_id in &ptys {
+                    state.pty_to_session.remove(&pty_id);
+                }
+                ptys
+            } else {
+                Vec::new()
+            }
+        };
+
+        if !existing_ptys.is_empty() {
+            if let Some(pty_mgr) = app.try_state::<Arc<OneShotPtyManager>>() {
+                for pty_id in existing_ptys {
+                    let _ = pty_mgr.cancel(app, pty_id);
+                }
+            }
+        }
+
+        let file_states: Vec<FileReviewState> = tasks
+            .iter()
+            .map(|t| FileReviewState {
+                file_path: t.file_path.clone(),
+                status: FileReviewStatus::Pending,
+                pty_id: None,
+            })
+            .collect();
+
+        let total = tasks.len();
+        let session = ReviewSession {
+            worktree_path: worktree_path.to_string(),
+            command_template: command_template.to_string(),
+            task_queue: VecDeque::from(tasks),
+            file_states,
+            concurrency,
+            pty_to_file: HashMap::new(),
+            active_count: 0,
+            done_count: 0,
+            total_count: total,
+            error_count: 0,
+            cancelled: false,
+        };
+
+        {
+            let mut state = self.state.lock();
+            state.sessions.insert(session_id.clone(), session);
+        }
+
+        self.emit_state_changed(app, &session_id);
+        self.spawn_next_batch(app, &session_id, concurrency);
+
+        session_id
+    }
+
+    pub fn cancel_review(&self, app: &AppHandle, session_id: &str) -> Result<(), String> {
+        let pty_ids: Vec<u64> = {
+            let mut state = self.state.lock();
+            let ptys = {
+                let session = state
+                    .sessions
+                    .get_mut(session_id)
+                    .ok_or("Review session not found")?;
+                session.cancelled = true;
+                session.task_queue.clear();
+                let ptys: Vec<u64> = session.pty_to_file.keys().copied().collect();
+                session.pty_to_file.clear();
+                session.active_count = 0;
+                ptys
+            };
+            for pty_id in &ptys {
+                state.pty_to_session.remove(pty_id);
+            }
+            ptys
+        };
+
+        if let Some(pty_mgr) = app.try_state::<Arc<OneShotPtyManager>>() {
+            for pty_id in pty_ids {
+                let _ = pty_mgr.cancel(app, pty_id);
+            }
+        }
+
+        self.emit_state_changed(app, session_id);
+        Ok(())
+    }
+
+    pub fn get_status(&self, session_id: &str) -> Option<ReviewSessionStatus> {
+        let state = self.state.lock();
+        let session = state.sessions.get(session_id)?;
+        Some(build_status(session))
+    }
+
+    pub fn reset(&self, session_id: &str) {
+        let mut state = self.state.lock();
+        if let Some(session) = state.sessions.remove(session_id) {
+            for pty_id in session.pty_to_file.keys() {
+                state.pty_to_session.remove(pty_id);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal event handlers
+    // -----------------------------------------------------------------------
+
+    fn handle_pty_completed(&self, app: &AppHandle, pty_id: u64, status: &OneShotStatus) {
+        let is_error = matches!(
+            status,
+            OneShotStatus::Error | OneShotStatus::Timeout | OneShotStatus::Cancelled
+        );
+
+        let (session_id, should_spawn_next) = {
+            let mut state = self.state.lock();
+
+            let session_id = match state.pty_to_session.remove(&pty_id) {
+                Some(id) => id,
+                None => return, // Not tracked by any review session
+            };
+
+            let session = match state.sessions.get_mut(&session_id) {
+                Some(s) => s,
+                None => return,
+            };
+
+            if session.cancelled {
+                return;
+            }
+
+            if let Some(&file_idx) = session.pty_to_file.get(&pty_id) {
+                session.file_states[file_idx].status = if is_error {
+                    FileReviewStatus::Error
+                } else {
+                    FileReviewStatus::Done
+                };
+            }
+            session.pty_to_file.remove(&pty_id);
+            session.active_count = session.active_count.saturating_sub(1);
+            session.done_count += 1;
+            if is_error {
+                session.error_count += 1;
+            }
+
+            let should_spawn =
+                session.done_count < session.total_count && !session.task_queue.is_empty();
+
+            (session_id, should_spawn)
+        };
+
+        self.emit_state_changed(app, &session_id);
+
+        if should_spawn_next {
+            self.spawn_next_batch(app, &session_id, 1);
+        }
+    }
+
+    fn handle_pty_output(&self, app: &AppHandle, pty_id: u64, data: &str) {
+        let emit_info = {
+            let state = self.state.lock();
+            state.pty_to_session.get(&pty_id).and_then(|session_id| {
+                state.sessions.get(session_id).and_then(|session| {
+                    session.pty_to_file.get(&pty_id).map(|&file_idx| {
+                        (
+                            session_id.clone(),
+                            session.file_states[file_idx].file_path.clone(),
+                        )
+                    })
+                })
+            })
+        };
+
+        if let Some((session_id, file_path)) = emit_info {
+            let _ = app.emit(
+                "review-file-output",
+                serde_json::json!({
+                    "review_session_id": session_id,
+                    "file_path": file_path,
+                    "data": data,
+                }),
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    fn spawn_next_batch(&self, app: &AppHandle, session_id: &str, count: usize) {
+        for _ in 0..count {
+            if !self.spawn_single_task(app, session_id) {
+                break;
+            }
+        }
+    }
+
+    /// Spawn a single task from the queue. Returns `true` if a task was popped
+    /// (even if spawn failed), `false` if no task was available.
+    fn spawn_single_task(&self, app: &AppHandle, session_id: &str) -> bool {
+        // 1. Pop task from queue (lock held briefly)
+        let spawn_info = {
+            let mut state = self.state.lock();
+            let session = match state.sessions.get_mut(session_id) {
+                Some(s) if !s.cancelled && s.active_count < s.concurrency => s,
+                _ => return false,
+            };
+            session.task_queue.pop_front().map(|task| {
+                (
+                    task,
+                    session.command_template.clone(),
+                    session.worktree_path.clone(),
+                )
+            })
+        };
+
+        let (task, command_template, worktree_path) = match spawn_info {
+            Some(info) => info,
+            None => return false,
+        };
+
+        // 2. Build command and spawn PTY (NO LOCK HELD — spawn_oneshot emits events)
+        let command = build_command(&command_template, &task.prompt);
+        let label = format!("review:{}", task.file_path);
+        let pty_mgr = match app.try_state::<Arc<OneShotPtyManager>>() {
+            Some(m) => m,
+            None => {
+                self.mark_file_error(app, session_id, &task.file_path);
+                return true;
+            }
+        };
+
+        match pty_mgr.spawn_oneshot(app, &command, &worktree_path, &label, None) {
+            Ok(info) => {
+                // 3. Register pty_id mapping (re-acquire lock)
+                {
+                    let mut state = self.state.lock();
+                    if let Some(session) = state.sessions.get_mut(session_id) {
+                        if session.cancelled {
+                            let _ = pty_mgr.cancel(app, info.pty_id);
+                            return false;
+                        }
+                        if let Some(idx) = session
+                            .file_states
+                            .iter()
+                            .position(|f| f.file_path == task.file_path)
+                        {
+                            session.file_states[idx].status = FileReviewStatus::Running;
+                            session.file_states[idx].pty_id = Some(info.pty_id);
+                            session.pty_to_file.insert(info.pty_id, idx);
+                            session.active_count += 1;
+                            state
+                                .pty_to_session
+                                .insert(info.pty_id, session_id.to_string());
+                        }
+                    }
+                }
+
+                // 4. Handle race condition: PTY may have completed during spawn
+                if let Some(current) = pty_mgr.get_status(info.pty_id) {
+                    if matches!(
+                        current.status,
+                        OneShotStatus::Completed
+                            | OneShotStatus::Error
+                            | OneShotStatus::Timeout
+                            | OneShotStatus::Cancelled
+                    ) {
+                        self.handle_pty_completed(app, info.pty_id, &current.status);
+                    }
+                }
+
+                self.emit_state_changed(app, session_id);
+                true
+            }
+            Err(_) => {
+                self.mark_file_error(app, session_id, &task.file_path);
+                true
+            }
+        }
+    }
+
+    fn mark_file_error(&self, app: &AppHandle, session_id: &str, file_path: &str) {
+        {
+            let mut state = self.state.lock();
+            if let Some(session) = state.sessions.get_mut(session_id) {
+                if let Some(idx) = session
+                    .file_states
+                    .iter()
+                    .position(|f| f.file_path == file_path)
+                {
+                    session.file_states[idx].status = FileReviewStatus::Error;
+                }
+                session.done_count += 1;
+                session.error_count += 1;
+            }
+        }
+        self.emit_state_changed(app, session_id);
+    }
+
+    fn emit_state_changed(&self, app: &AppHandle, session_id: &str) {
+        let status = {
+            let state = self.state.lock();
+            state.sessions.get(session_id).map(build_status)
+        };
+        if let Some(status) = status {
+            let _ = app.emit("review-state-changed", &status);
+        }
+    }
+}
+
+fn build_status(session: &ReviewSession) -> ReviewSessionStatus {
+    let status = if session.cancelled {
+        ReviewStatus::Cancelled
+    } else if session.total_count == 0 {
+        ReviewStatus::Completed
+    } else if session.done_count >= session.total_count {
+        if session.error_count > 0 {
+            ReviewStatus::Error
+        } else {
+            ReviewStatus::Completed
+        }
+    } else {
+        ReviewStatus::Running
+    };
+
+    ReviewSessionStatus {
+        status,
+        file_states: session.file_states.clone(),
+        progress: ReviewProgress {
+            done: session.done_count,
+            total: session.total_count,
+            error_count: session.error_count,
+        },
+    }
+}
+
+fn shell_escape_prompt(prompt: &str) -> String {
+    prompt
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "\\$")
+        .replace('`', "\\`")
+}
+
+fn build_command(template: &str, prompt: &str) -> String {
+    let escaped = shell_escape_prompt(prompt);
+    template.replace("{prompt}", &escaped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_escape_handles_special_chars() {
+        let input = r#"Hello "world" $HOME `echo`\n"#;
+        let escaped = shell_escape_prompt(input);
+        assert_eq!(escaped, r#"Hello \"world\" \$HOME \`echo\`\\n"#);
+    }
+
+    #[test]
+    fn build_command_replaces_prompt() {
+        let template = r#"echo "{prompt}" | claude -p"#;
+        let prompt = "Review this file";
+        let result = build_command(template, prompt);
+        assert_eq!(result, r#"echo "Review this file" | claude -p"#);
+    }
+
+    #[test]
+    fn build_command_escapes_prompt() {
+        let template = r#"echo "{prompt}" | claude"#;
+        let prompt = r#"say "hello""#;
+        let result = build_command(template, prompt);
+        assert_eq!(result, r#"echo "say \"hello\"" | claude"#);
+    }
+
+    #[test]
+    fn build_status_idle_when_empty() {
+        let session = ReviewSession {
+            worktree_path: "/repo".to_string(),
+            command_template: "echo {prompt}".to_string(),
+            task_queue: VecDeque::new(),
+            file_states: vec![],
+            concurrency: 5,
+            pty_to_file: HashMap::new(),
+            active_count: 0,
+            done_count: 0,
+            total_count: 0,
+            error_count: 0,
+            cancelled: false,
+        };
+        let status = build_status(&session);
+        assert_eq!(status.status, ReviewStatus::Completed);
+        assert_eq!(status.progress.total, 0);
+    }
+
+    #[test]
+    fn build_status_running() {
+        let session = ReviewSession {
+            worktree_path: "/repo".to_string(),
+            command_template: "echo {prompt}".to_string(),
+            task_queue: VecDeque::new(),
+            file_states: vec![
+                FileReviewState {
+                    file_path: "a.ts".to_string(),
+                    status: FileReviewStatus::Running,
+                    pty_id: Some(1),
+                },
+                FileReviewState {
+                    file_path: "b.ts".to_string(),
+                    status: FileReviewStatus::Pending,
+                    pty_id: None,
+                },
+            ],
+            concurrency: 1,
+            pty_to_file: HashMap::from([(1, 0)]),
+            active_count: 1,
+            done_count: 0,
+            total_count: 2,
+            error_count: 0,
+            cancelled: false,
+        };
+        let status = build_status(&session);
+        assert_eq!(status.status, ReviewStatus::Running);
+        assert_eq!(status.progress.done, 0);
+        assert_eq!(status.progress.total, 2);
+    }
+
+    #[test]
+    fn build_status_completed() {
+        let session = ReviewSession {
+            worktree_path: "/repo".to_string(),
+            command_template: "echo {prompt}".to_string(),
+            task_queue: VecDeque::new(),
+            file_states: vec![FileReviewState {
+                file_path: "a.ts".to_string(),
+                status: FileReviewStatus::Done,
+                pty_id: Some(1),
+            }],
+            concurrency: 1,
+            pty_to_file: HashMap::new(),
+            active_count: 0,
+            done_count: 1,
+            total_count: 1,
+            error_count: 0,
+            cancelled: false,
+        };
+        let status = build_status(&session);
+        assert_eq!(status.status, ReviewStatus::Completed);
+    }
+
+    #[test]
+    fn build_status_error() {
+        let session = ReviewSession {
+            worktree_path: "/repo".to_string(),
+            command_template: "echo {prompt}".to_string(),
+            task_queue: VecDeque::new(),
+            file_states: vec![
+                FileReviewState {
+                    file_path: "a.ts".to_string(),
+                    status: FileReviewStatus::Done,
+                    pty_id: Some(1),
+                },
+                FileReviewState {
+                    file_path: "b.ts".to_string(),
+                    status: FileReviewStatus::Error,
+                    pty_id: Some(2),
+                },
+            ],
+            concurrency: 1,
+            pty_to_file: HashMap::new(),
+            active_count: 0,
+            done_count: 2,
+            total_count: 2,
+            error_count: 1,
+            cancelled: false,
+        };
+        let status = build_status(&session);
+        assert_eq!(status.status, ReviewStatus::Error);
+        assert_eq!(status.progress.error_count, 1);
+    }
+
+    #[test]
+    fn build_status_cancelled() {
+        let session = ReviewSession {
+            worktree_path: "/repo".to_string(),
+            command_template: "echo {prompt}".to_string(),
+            task_queue: VecDeque::new(),
+            file_states: vec![],
+            concurrency: 1,
+            pty_to_file: HashMap::new(),
+            active_count: 0,
+            done_count: 0,
+            total_count: 2,
+            error_count: 0,
+            cancelled: true,
+        };
+        let status = build_status(&session);
+        assert_eq!(status.status, ReviewStatus::Cancelled);
+    }
+
+    #[test]
+    fn orchestrator_new() {
+        let orchestrator = ReviewOrchestrator::new();
+        assert!(orchestrator.get_status("/repo").is_none());
+    }
+
+    #[test]
+    fn orchestrator_reset_clears_session() {
+        let orchestrator = ReviewOrchestrator::new();
+        // Manually insert a session
+        {
+            let mut state = orchestrator.state.lock();
+            state.sessions.insert(
+                "/repo".to_string(),
+                ReviewSession {
+                    worktree_path: "/repo".to_string(),
+                    command_template: "echo {prompt}".to_string(),
+                    task_queue: VecDeque::new(),
+                    file_states: vec![],
+                    concurrency: 1,
+                    pty_to_file: HashMap::new(),
+                    active_count: 0,
+                    done_count: 0,
+                    total_count: 0,
+                    error_count: 0,
+                    cancelled: false,
+                },
+            );
+        }
+        assert!(orchestrator.get_status("/repo").is_some());
+        orchestrator.reset("/repo");
+        assert!(orchestrator.get_status("/repo").is_none());
+    }
+}

--- a/src-tauri/src/review/orchestrator.rs
+++ b/src-tauri/src/review/orchestrator.rs
@@ -24,6 +24,16 @@ impl std::fmt::Display for ReviewOrchestratorError {
 
 impl std::error::Error for ReviewOrchestratorError {}
 
+/// Result of attempting to spawn a single review task.
+enum SpawnResult {
+    /// PTY was successfully started.
+    Spawned,
+    /// Task was popped but spawn failed; contains the file path for error marking.
+    Failed(String),
+    /// No task available or session not in spawnable state.
+    QueueEmpty,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ReviewStatus {
@@ -352,22 +362,34 @@ impl ReviewOrchestrator {
     // -----------------------------------------------------------------------
 
     fn spawn_next_batch(&self, app: &AppHandle, session_id: &str, count: usize) {
-        for _ in 0..count {
-            if !self.spawn_single_task(app, session_id) {
-                break;
+        let mut remaining = count;
+        while remaining > 0 {
+            match self.spawn_single_task(app, session_id) {
+                SpawnResult::Spawned => {
+                    remaining -= 1;
+                }
+                SpawnResult::Failed(file_path) => {
+                    // Mark error and continue iteratively (no recursion)
+                    self.mark_file_error(app, session_id, &file_path);
+                    // Don't decrement remaining — the failed task didn't consume a slot
+                }
+                SpawnResult::QueueEmpty => {
+                    break;
+                }
             }
         }
     }
 
-    /// Spawn a single task from the queue. Returns `true` if a task was popped
-    /// (even if spawn failed), `false` if no task was available.
-    fn spawn_single_task(&self, app: &AppHandle, session_id: &str) -> bool {
+    /// Spawn a single task from the queue.
+    /// Returns `Spawned` if PTY was started, `Failed(file_path)` if spawn failed,
+    /// or `QueueEmpty` if no task was available.
+    fn spawn_single_task(&self, app: &AppHandle, session_id: &str) -> SpawnResult {
         // 1. Pop task from queue (lock held briefly)
         let spawn_info = {
             let mut state = self.state.lock();
             let session = match state.sessions.get_mut(session_id) {
                 Some(s) if !s.cancelled && s.active_count < s.concurrency => s,
-                _ => return false,
+                _ => return SpawnResult::QueueEmpty,
             };
             session.task_queue.pop_front().map(|task| {
                 (
@@ -380,7 +402,7 @@ impl ReviewOrchestrator {
 
         let (task, command_template, worktree_path) = match spawn_info {
             Some(info) => info,
-            None => return false,
+            None => return SpawnResult::QueueEmpty,
         };
 
         // 2. Build command and spawn PTY (NO LOCK HELD — spawn_oneshot emits events)
@@ -389,8 +411,7 @@ impl ReviewOrchestrator {
         let pty_mgr = match app.try_state::<Arc<OneShotPtyManager>>() {
             Some(m) => m,
             None => {
-                self.mark_file_error(app, session_id, &task.file_path);
-                return true;
+                return SpawnResult::Failed(task.file_path);
             }
         };
 
@@ -426,7 +447,7 @@ impl ReviewOrchestrator {
 
                 if !mapped {
                     let _ = pty_mgr.cancel(app, info.pty_id);
-                    return false;
+                    return SpawnResult::QueueEmpty;
                 }
 
                 // 4. Flush buffered output that arrived before mapping was registered
@@ -455,17 +476,14 @@ impl ReviewOrchestrator {
                 }
 
                 self.emit_state_changed(app, session_id);
-                true
+                SpawnResult::Spawned
             }
-            Err(_) => {
-                self.mark_file_error(app, session_id, &task.file_path);
-                true
-            }
+            Err(_) => SpawnResult::Failed(task.file_path),
         }
     }
 
     fn mark_file_error(&self, app: &AppHandle, session_id: &str, file_path: &str) {
-        let should_spawn_next = {
+        {
             let mut state = self.state.lock();
             if let Some(session) = state.sessions.get_mut(session_id) {
                 if let Some(idx) = session
@@ -477,16 +495,9 @@ impl ReviewOrchestrator {
                 }
                 session.done_count += 1;
                 session.error_count += 1;
-                session.done_count < session.total_count && !session.task_queue.is_empty()
-            } else {
-                false
             }
-        };
-        self.emit_state_changed(app, session_id);
-
-        if should_spawn_next {
-            self.spawn_next_batch(app, session_id, 1);
         }
+        self.emit_state_changed(app, session_id);
     }
 
     fn emit_state_changed(&self, app: &AppHandle, session_id: &str) {

--- a/src-tauri/src/review/orchestrator.rs
+++ b/src-tauri/src/review/orchestrator.rs
@@ -396,15 +396,14 @@ impl ReviewOrchestrator {
 
         match pty_mgr.spawn_oneshot(app, &command, &worktree_path, &label, None) {
             Ok(info) => {
-                // 3. Register pty_id mapping (re-acquire lock)
-                {
+                // 3. Snapshot output offset, then register pty_id mapping (re-acquire lock)
+                let output_snapshot_offset = pty_mgr.get_output_len(info.pty_id);
+                let mapped = {
                     let mut state = self.state.lock();
                     if let Some(session) = state.sessions.get_mut(session_id) {
                         if session.cancelled {
-                            let _ = pty_mgr.cancel(app, info.pty_id);
-                            return false;
-                        }
-                        if let Some(idx) = session
+                            false
+                        } else if let Some(idx) = session
                             .file_states
                             .iter()
                             .position(|f| f.file_path == task.file_path)
@@ -416,12 +415,29 @@ impl ReviewOrchestrator {
                             state
                                 .pty_to_session
                                 .insert(info.pty_id, session_id.to_string());
+                            true
+                        } else {
+                            false
                         }
+                    } else {
+                        false
                     }
+                };
+
+                if !mapped {
+                    let _ = pty_mgr.cancel(app, info.pty_id);
+                    return false;
                 }
 
                 // 4. Flush buffered output that arrived before mapping was registered
-                if let Some(buffered) = pty_mgr.get_buffered_output(info.pty_id) {
+                //    Use snapshot offset to avoid replaying data already sent via live listener
+                if output_snapshot_offset == 0 {
+                    if let Some(buffered) = pty_mgr.get_buffered_output(info.pty_id) {
+                        self.handle_pty_output(app, info.pty_id, &buffered);
+                    }
+                } else if let Some(buffered) =
+                    pty_mgr.get_buffered_output_from(info.pty_id, output_snapshot_offset)
+                {
                     self.handle_pty_output(app, info.pty_id, &buffered);
                 }
 

--- a/src-tauri/src/review/orchestrator.rs
+++ b/src-tauri/src/review/orchestrator.rs
@@ -9,6 +9,21 @@ use crate::pty::oneshot::{OneShotPtyManager, OneShotStatus};
 use crate::pty::PtyOutput;
 use crate::review_prompt::PerFileReviewTask;
 
+#[derive(Debug)]
+pub enum ReviewOrchestratorError {
+    NotFound,
+}
+
+impl std::fmt::Display for ReviewOrchestratorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "Review session not found"),
+        }
+    }
+}
+
+impl std::error::Error for ReviewOrchestratorError {}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ReviewStatus {
@@ -185,14 +200,18 @@ impl ReviewOrchestrator {
         session_id
     }
 
-    pub fn cancel_review(&self, app: &AppHandle, session_id: &str) -> Result<(), String> {
+    pub fn cancel_review(
+        &self,
+        app: &AppHandle,
+        session_id: &str,
+    ) -> Result<(), ReviewOrchestratorError> {
         let pty_ids: Vec<u64> = {
             let mut state = self.state.lock();
             let ptys = {
                 let session = state
                     .sessions
                     .get_mut(session_id)
-                    .ok_or("Review session not found")?;
+                    .ok_or(ReviewOrchestratorError::NotFound)?;
                 session.cancelled = true;
                 session.task_queue.clear();
                 let ptys: Vec<u64> = session.pty_to_file.keys().copied().collect();
@@ -222,12 +241,28 @@ impl ReviewOrchestrator {
         Some(build_status(session))
     }
 
-    pub fn reset(&self, session_id: &str) {
+    pub fn reset(&self, app: &AppHandle, session_id: &str) {
+        let pty_ids = self.reset_internal(session_id);
+
+        if !pty_ids.is_empty() {
+            if let Some(pty_mgr) = app.try_state::<Arc<OneShotPtyManager>>() {
+                for pty_id in pty_ids {
+                    let _ = pty_mgr.cancel(app, pty_id);
+                }
+            }
+        }
+    }
+
+    fn reset_internal(&self, session_id: &str) -> Vec<u64> {
         let mut state = self.state.lock();
         if let Some(session) = state.sessions.remove(session_id) {
-            for pty_id in session.pty_to_file.keys() {
-                state.pty_to_session.remove(pty_id);
+            let ptys: Vec<u64> = session.pty_to_file.keys().copied().collect();
+            for &pty_id in &ptys {
+                state.pty_to_session.remove(&pty_id);
             }
+            ptys
+        } else {
+            Vec::new()
         }
     }
 
@@ -385,7 +420,12 @@ impl ReviewOrchestrator {
                     }
                 }
 
-                // 4. Handle race condition: PTY may have completed during spawn
+                // 4. Flush buffered output that arrived before mapping was registered
+                if let Some(buffered) = pty_mgr.get_buffered_output(info.pty_id) {
+                    self.handle_pty_output(app, info.pty_id, &buffered);
+                }
+
+                // 5. Handle race condition: PTY may have completed during spawn
                 if let Some(current) = pty_mgr.get_status(info.pty_id) {
                     if matches!(
                         current.status,
@@ -409,7 +449,7 @@ impl ReviewOrchestrator {
     }
 
     fn mark_file_error(&self, app: &AppHandle, session_id: &str, file_path: &str) {
-        {
+        let should_spawn_next = {
             let mut state = self.state.lock();
             if let Some(session) = state.sessions.get_mut(session_id) {
                 if let Some(idx) = session
@@ -421,9 +461,16 @@ impl ReviewOrchestrator {
                 }
                 session.done_count += 1;
                 session.error_count += 1;
+                session.done_count < session.total_count && !session.task_queue.is_empty()
+            } else {
+                false
             }
-        }
+        };
         self.emit_state_changed(app, session_id);
+
+        if should_spawn_next {
+            self.spawn_next_batch(app, session_id, 1);
+        }
     }
 
     fn emit_state_changed(&self, app: &AppHandle, session_id: &str) {
@@ -658,7 +705,7 @@ mod tests {
             );
         }
         assert!(orchestrator.get_status("/repo").is_some());
-        orchestrator.reset("/repo");
+        orchestrator.reset_internal("/repo");
         assert!(orchestrator.get_status("/repo").is_none());
     }
 }

--- a/src-tauri/src/review_prompt.rs
+++ b/src-tauri/src/review_prompt.rs
@@ -14,18 +14,17 @@ pub fn get_review_prompt() -> String {
     DEFAULT_REVIEW_PROMPT.to_string()
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct PerFileReviewTask {
     pub file_path: String,
     pub prompt: String,
 }
 
-#[tauri::command]
-pub fn get_per_file_review_tasks(
-    worktree_path: String,
-    thread_store: State<'_, Arc<ThreadStore>>,
+pub fn get_per_file_review_tasks_internal(
+    worktree_path: &str,
+    thread_store: &ThreadStore,
 ) -> Result<Vec<PerFileReviewTask>, String> {
-    let diff = get_review_diff(&worktree_path, None, None, None)
+    let diff = get_review_diff(worktree_path, None, None, None)
         .map_err(|e| format!("failed to get review diff: {e}"))?;
 
     if diff.changed_files.is_empty() {
@@ -61,7 +60,7 @@ pub fn get_per_file_review_tasks(
         .map(|file| {
             // Get existing threads for this file
             let file_threads =
-                thread_store.get_filtered(&worktree_path, Some(&file.path), None, None);
+                thread_store.get_filtered(worktree_path, Some(&file.path), None, None);
             let existing_comments = if file_threads.is_empty() {
                 "None".to_string()
             } else {
@@ -87,7 +86,7 @@ pub fn get_per_file_review_tasks(
             };
 
             let prompt = PER_FILE_REVIEW_TEMPLATE
-                .replace("{{WORKTREE}}", &worktree_path)
+                .replace("{{WORKTREE}}", worktree_path)
                 .replace("{{FILE_PATH}}", &file.path)
                 .replace("{{CHANGE_SUMMARY}}", &change_summary)
                 .replace("{{EXISTING_COMMENTS}}", &existing_comments);
@@ -100,6 +99,14 @@ pub fn get_per_file_review_tasks(
         .collect();
 
     Ok(tasks)
+}
+
+#[tauri::command]
+pub fn get_per_file_review_tasks(
+    worktree_path: String,
+    thread_store: State<'_, Arc<ThreadStore>>,
+) -> Result<Vec<PerFileReviewTask>, String> {
+    get_per_file_review_tasks_internal(&worktree_path, &thread_store)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -152,12 +152,12 @@ pub struct ChatSession {
     pub agent_session_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSessionResponse {
     #[serde(flatten)]
     pub session: ChatSession,
-    pub is_streaming: bool,
+    pub turn_phase: crate::agent_sdk::TurnPhase,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -301,6 +301,53 @@ pub fn list_sessions(
     state.list_sessions(&data_dir, &worktree_path)
 }
 
+/// Internal (non-command) version of create_session, callable from agent_sdk.
+pub fn create_session_internal(
+    session_store: &SessionStore,
+    data_dir: &std::path::Path,
+    worktree_path: &str,
+) -> Result<ChatSession, String> {
+    let now = now_timestamp();
+    let session = ChatSession {
+        id: uuid::Uuid::new_v4().to_string(),
+        worktree_path: worktree_path.to_string(),
+        messages: Vec::new(),
+        state: SessionState::Active,
+        created_at: now,
+        updated_at: now,
+        agent_session_id: None,
+    };
+    session_store.save_session(data_dir, &session)?;
+    Ok(session)
+}
+
+/// Internal (non-command) version of add_message, callable from agent_sdk.
+pub fn add_message_internal(
+    session_store: &SessionStore,
+    data_dir: &std::path::Path,
+    session_id: &str,
+    role: MessageRole,
+    content: &str,
+) -> Result<ChatMessage, String> {
+    let mut session = session_store
+        .get_session(data_dir, session_id)?
+        .ok_or_else(|| format!("Session not found: {session_id}"))?;
+    let now = now_timestamp();
+    let message = ChatMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        role,
+        content: content.to_string(),
+        thinking: None,
+        activities: None,
+        parts: None,
+        timestamp: now,
+    };
+    session.messages.push(message.clone());
+    session.updated_at = now;
+    session_store.save_session(data_dir, &session)?;
+    Ok(message)
+}
+
 #[tauri::command]
 pub fn create_session(
     state: State<'_, Arc<SessionStore>>,
@@ -308,18 +355,7 @@ pub fn create_session(
     worktree_path: String,
 ) -> Result<ChatSession, String> {
     let data_dir = resolve_data_dir(&app)?;
-    let now = now_timestamp();
-    let session = ChatSession {
-        id: uuid::Uuid::new_v4().to_string(),
-        worktree_path,
-        messages: Vec::new(),
-        state: SessionState::Active,
-        created_at: now,
-        updated_at: now,
-        agent_session_id: None,
-    };
-    state.save_session(&data_dir, &session)?;
-    Ok(session)
+    create_session_internal(&state, &data_dir, &worktree_path)
 }
 
 #[tauri::command]
@@ -331,23 +367,7 @@ pub fn add_message(
     content: String,
 ) -> Result<ChatMessage, String> {
     let data_dir = resolve_data_dir(&app)?;
-    let mut session = state
-        .get_session(&data_dir, &session_id)?
-        .ok_or_else(|| format!("Session not found: {session_id}"))?;
-    let now = now_timestamp();
-    let message = ChatMessage {
-        id: uuid::Uuid::new_v4().to_string(),
-        role,
-        content,
-        thinking: None,
-        activities: None,
-        parts: None,
-        timestamp: now,
-    };
-    session.messages.push(message.clone());
-    session.updated_at = now;
-    state.save_session(&data_dir, &session)?;
-    Ok(message)
+    add_message_internal(&state, &data_dir, &session_id, role, &content)
 }
 
 #[tauri::command]

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
@@ -209,6 +209,7 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 		closedSessions,
 		activeSession,
 		isStreaming,
+		activityStatus,
 		error,
 		permissionMode,
 		sessionAgentStates,
@@ -293,8 +294,6 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 		lastAgentPartsLen,
 		shimmerLineCount,
 	]);
-
-	const isInputDisabled = isStreaming;
 
 	const cycleMode = useCallback(() => {
 		const currentIndex = MODES.findIndex((m) => m.value === permissionMode);
@@ -496,6 +495,11 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 						)}
 					</div>
 					<div className="shrink-0">
+						{activityStatus && (
+							<div className="px-4 pb-1 text-xs text-muted-foreground animate-pulse truncate">
+								{activityStatus.label}
+							</div>
+						)}
 						{error && (
 							<div className="px-2 pb-2">
 								<div className="bg-destructive/10 text-destructive rounded-lg px-3 py-2 text-sm">
@@ -506,7 +510,6 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 						<MessageInput
 							onSend={sendMessage}
 							onInterrupt={interrupt}
-							disabled={isInputDisabled}
 							isStreaming={isStreaming}
 							onCycleMode={cycleMode}
 							mode={permissionMode}

--- a/src/components/panels/AgentChatPanel/MessageInput.test.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.test.tsx
@@ -6,7 +6,6 @@ import { MessageInput } from "./MessageInput";
 const defaultProps = {
 	onSend: vi.fn(),
 	onInterrupt: vi.fn(),
-	disabled: false,
 	isStreaming: false,
 	mode: "acceptEdits" as const,
 	onModeChange: vi.fn(),
@@ -89,10 +88,18 @@ describe("MessageInput", () => {
 		expect(onInterrupt).toHaveBeenCalled();
 	});
 
-	it("disables textarea when disabled prop is true", () => {
-		render(<MessageInput {...defaultProps} disabled={true} />);
+	it("shows send button when streaming with text input", () => {
+		render(<MessageInput {...defaultProps} isStreaming={true} />);
 		const textarea = screen.getByPlaceholderText("Send a message...");
-		expect(textarea.hasAttribute("disabled")).toBe(true);
+		fireEvent.change(textarea, { target: { value: "Hello" } });
+		expect(screen.getByLabelText("Send message")).toBeDefined();
+		expect(screen.queryByLabelText("Interrupt agent")).toBeNull();
+	});
+
+	it("textarea is always enabled even during streaming", () => {
+		render(<MessageInput {...defaultProps} isStreaming={true} />);
+		const textarea = screen.getByPlaceholderText("Send a message...");
+		expect(textarea.hasAttribute("disabled")).toBe(false);
 	});
 
 	it("calls onCycleMode on Shift+Tab", () => {

--- a/src/components/panels/AgentChatPanel/MessageInput.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.tsx
@@ -10,7 +10,6 @@ import { SlashCommandPopup } from "./SlashCommandPopup";
 interface MessageInputProps {
 	onSend: (content: string) => void;
 	onInterrupt: () => void;
-	disabled: boolean;
 	isStreaming: boolean;
 	onCycleMode?: () => void;
 	mode: PermissionMode;
@@ -20,7 +19,6 @@ interface MessageInputProps {
 export function MessageInput({
 	onSend,
 	onInterrupt,
-	disabled,
 	isStreaming,
 	onCycleMode,
 	mode,
@@ -58,7 +56,7 @@ export function MessageInput({
 
 	const handleSubmit = useCallback(() => {
 		const trimmed = value.trim();
-		if (!trimmed || disabled) return;
+		if (!trimmed) return;
 		onSend(trimmed);
 		setValue("");
 		setSlashPopupDismissed(false);
@@ -66,7 +64,7 @@ export function MessageInput({
 		if (textareaRef.current) {
 			textareaRef.current.style.height = "auto";
 		}
-	}, [value, disabled, onSend]);
+	}, [value, onSend]);
 
 	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -139,7 +137,7 @@ export function MessageInput({
 		[],
 	);
 
-	const canSend = value.trim().length > 0 && !disabled;
+	const canSend = value.trim().length > 0;
 
 	return (
 		<SlashCommandPopup
@@ -159,9 +157,8 @@ export function MessageInput({
 					onChange={handleChange}
 					onKeyDown={handleKeyDown}
 					placeholder="Send a message..."
-					disabled={disabled}
 					rows={1}
-					className="w-full resize-none bg-transparent border-none px-3 pt-3 pb-1 text-sm focus:outline-none disabled:opacity-50 min-h-[36px] max-h-[200px]"
+					className="w-full resize-none bg-transparent border-none px-3 pt-3 pb-1 text-sm focus:outline-none min-h-[36px] max-h-[200px]"
 				/>
 				<div className="flex items-center justify-between px-2 pb-2">
 					<ModeSelector
@@ -169,7 +166,7 @@ export function MessageInput({
 						onModeChange={onModeChange}
 						disabled={false}
 					/>
-					{isStreaming ? (
+					{isStreaming && !canSend ? (
 						<Button
 							size="icon"
 							variant="destructive"

--- a/src/components/panels/ReviewModal.tsx
+++ b/src/components/panels/ReviewModal.tsx
@@ -34,16 +34,13 @@ export function StatusIndicator({
 	progress?: { done: number; total: number } | null;
 }) {
 	switch (status) {
-		case "starting":
 		case "running":
 			return (
 				<span className="flex items-center gap-1.5 text-xs text-blue-400">
 					<Loader2 className="h-3.5 w-3.5 animate-spin" />
 					{progress
 						? `Reviewing (${progress.done}/${progress.total})`
-						: status === "starting"
-							? "Starting..."
-							: "Reviewing..."}
+						: "Reviewing..."}
 				</span>
 			);
 		case "completed":
@@ -129,7 +126,7 @@ export function ReviewModal({
 	onCancel,
 	onRetry,
 }: ReviewModalProps) {
-	const isRunning = status === "starting" || status === "running";
+	const isRunning = status === "running";
 	const hasFiles = fileStates.length > 0;
 
 	const [selectedFile, setSelectedFile] = useState<string | null>(null);

--- a/src/components/panels/RightSidebarBottom.tsx
+++ b/src/components/panels/RightSidebarBottom.tsx
@@ -75,7 +75,7 @@ export function RightSidebarBottom({
 		reset,
 	} = useReviewExecution(rootPath, threads, settings);
 
-	const isRunning = status === "starting" || status === "running";
+	const isRunning = status === "running";
 	const isFinished =
 		status === "completed" || status === "error" || status === "cancelled";
 	const reviewDisabled = settings.reviewAgent === "none";

--- a/src/hooks/agentChatReducer.test.ts
+++ b/src/hooks/agentChatReducer.test.ts
@@ -32,8 +32,7 @@ describe("agentChatReducer", () => {
 			sessionOrder: [],
 			closedSessions: [],
 			activeSession: null,
-			streamingSessionIds: [],
-			sessionFinalStates: {},
+			turnPhases: {},
 			error: null,
 			permissionMode: "acceptEdits",
 			userPermissionMode: "acceptEdits",
@@ -221,61 +220,44 @@ describe("agentChatReducer", () => {
 		});
 	});
 
-	describe("START_STREAMING / STOP_STREAMING", () => {
-		it("adds sessionId to streamingSessionIds", () => {
+	describe("SET_TURN_PHASE", () => {
+		it("sets turn phase for a session", () => {
 			const next = reducer(INITIAL_STATE, {
-				type: "START_STREAMING",
+				type: "SET_TURN_PHASE",
 				sessionId: "s1",
+				turnPhase: "streaming",
 			});
-			expect(next.streamingSessionIds).toEqual(["s1"]);
+			expect(next.turnPhases).toEqual({ s1: "streaming" });
 		});
 
-		it("does not duplicate sessionId", () => {
+		it("overwrites existing turn phase", () => {
 			const state: AgentChatState = {
 				...INITIAL_STATE,
-				streamingSessionIds: ["s1"],
+				turnPhases: { s1: "streaming" },
 			};
 			const next = reducer(state, {
-				type: "START_STREAMING",
+				type: "SET_TURN_PHASE",
 				sessionId: "s1",
+				turnPhase: "idle",
 			});
-			expect(next.streamingSessionIds).toEqual(["s1"]);
+			expect(next.turnPhases).toEqual({ s1: "idle" });
 		});
 
 		it("supports multiple concurrent sessions", () => {
 			const step1 = reducer(INITIAL_STATE, {
-				type: "START_STREAMING",
+				type: "SET_TURN_PHASE",
 				sessionId: "s1",
+				turnPhase: "streaming",
 			});
 			const step2 = reducer(step1, {
-				type: "START_STREAMING",
+				type: "SET_TURN_PHASE",
 				sessionId: "s2",
+				turnPhase: "waiting_permission",
 			});
-			expect(step2.streamingSessionIds).toEqual(["s1", "s2"]);
-		});
-
-		it("removes sessionId from streamingSessionIds", () => {
-			const state: AgentChatState = {
-				...INITIAL_STATE,
-				streamingSessionIds: ["s1", "s2"],
-			};
-			const next = reducer(state, {
-				type: "STOP_STREAMING",
-				sessionId: "s1",
+			expect(step2.turnPhases).toEqual({
+				s1: "streaming",
+				s2: "waiting_permission",
 			});
-			expect(next.streamingSessionIds).toEqual(["s2"]);
-		});
-
-		it("does nothing when stopping non-streaming session", () => {
-			const state: AgentChatState = {
-				...INITIAL_STATE,
-				streamingSessionIds: ["s1"],
-			};
-			const next = reducer(state, {
-				type: "STOP_STREAMING",
-				sessionId: "s2",
-			});
-			expect(next.streamingSessionIds).toEqual(["s1"]);
 		});
 	});
 

--- a/src/hooks/agentChatReducer.ts
+++ b/src/hooks/agentChatReducer.ts
@@ -6,6 +6,7 @@ import type {
 	PermissionRequest,
 	SessionState,
 	SessionSummary,
+	TurnPhase,
 } from "@/types/session";
 
 export function resolvePermissionMode(mode: PermissionMode): PermissionMode {
@@ -17,8 +18,7 @@ export interface AgentChatState {
 	sessionOrder: string[];
 	closedSessions: SessionSummary[];
 	activeSession: ChatSession | null;
-	streamingSessionIds: string[];
-	sessionFinalStates: Record<string, "done" | "error">;
+	turnPhases: Record<string, TurnPhase>;
 	error: string | null;
 	permissionMode: PermissionMode;
 	userPermissionMode: PermissionMode;
@@ -30,8 +30,11 @@ export type AgentChatAction =
 	| { type: "SET_CLOSED_SESSIONS"; sessions: SessionSummary[] }
 	| { type: "SET_ACTIVE_SESSION"; session: ChatSession | null }
 	| { type: "ADD_MESSAGE"; message: ChatMessage }
-	| { type: "START_STREAMING"; sessionId: string }
-	| { type: "STOP_STREAMING"; sessionId: string }
+	| {
+			type: "SET_TURN_PHASE";
+			sessionId: string;
+			turnPhase: TurnPhase;
+	  }
 	| { type: "SET_ERROR"; error: string | null }
 	| { type: "UPDATE_SESSION_STATE"; state: SessionState }
 	| { type: "SET_PERMISSION_MODE"; mode: PermissionMode }
@@ -43,11 +46,6 @@ export type AgentChatAction =
 			request: PermissionRequest | null;
 	  }
 	| { type: "REORDER_SESSIONS"; sessionOrder: string[] }
-	| {
-			type: "SET_SESSION_FINAL_STATE";
-			sessionId: string;
-			state: "done" | "error";
-	  }
 	| {
 			type: "SET_STREAMING_MESSAGE";
 			sessionId: string;
@@ -151,24 +149,13 @@ export function reducer(
 				},
 			};
 		}
-		case "START_STREAMING": {
-			const { [action.sessionId]: _, ...restFinal } = state.sessionFinalStates;
+		case "SET_TURN_PHASE":
 			return {
 				...state,
-				streamingSessionIds: state.streamingSessionIds.includes(
-					action.sessionId,
-				)
-					? state.streamingSessionIds
-					: [...state.streamingSessionIds, action.sessionId],
-				sessionFinalStates: restFinal,
-			};
-		}
-		case "STOP_STREAMING":
-			return {
-				...state,
-				streamingSessionIds: state.streamingSessionIds.filter(
-					(id) => id !== action.sessionId,
-				),
+				turnPhases: {
+					...state.turnPhases,
+					[action.sessionId]: action.turnPhase,
+				},
 			};
 		case "SET_ERROR":
 			return { ...state, error: action.error };
@@ -208,14 +195,6 @@ export function reducer(
 		}
 		case "REORDER_SESSIONS":
 			return { ...state, sessionOrder: action.sessionOrder };
-		case "SET_SESSION_FINAL_STATE":
-			return {
-				...state,
-				sessionFinalStates: {
-					...state.sessionFinalStates,
-					[action.sessionId]: action.state,
-				},
-			};
 		case "SET_STREAMING_MESSAGE": {
 			if (!state.activeSession || state.activeSession.id !== action.sessionId)
 				return state;
@@ -232,8 +211,7 @@ export const INITIAL_STATE: AgentChatState = {
 	sessionOrder: [],
 	closedSessions: [],
 	activeSession: null,
-	streamingSessionIds: [],
-	sessionFinalStates: {},
+	turnPhases: {},
 	error: null,
 	permissionMode: "acceptEdits",
 	userPermissionMode: "acceptEdits",

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -35,26 +35,51 @@ vi.mock("./useSessionStore", () => ({
 	closeSession: vi.fn().mockResolvedValue(undefined),
 	restoreSession: vi.fn().mockResolvedValue(undefined),
 	listClosedSessions: vi.fn().mockResolvedValue([]),
+	sendAgentMessage: vi.fn().mockResolvedValue({
+		session: {
+			id: "s1",
+			worktreePath: "/repo",
+			messages: [],
+			state: "active",
+			createdAt: 1000,
+			updatedAt: 1000,
+		},
+		humanMessage: {
+			id: "msg-1",
+			role: "human",
+			parts: [{ type: "text", content: "hello" }],
+			timestamp: 1001,
+		},
+		agentMessage: {
+			id: "msg-2",
+			role: "agent",
+			parts: [],
+			timestamp: 1002,
+		},
+		sessions: [],
+	}),
+	initAgentSessions: vi.fn().mockResolvedValue({
+		sessions: [],
+		activeSession: {
+			session: {
+				id: "s1",
+				worktreePath: "/repo",
+				messages: [],
+				state: "active",
+				createdAt: 1000,
+				updatedAt: 1000,
+			},
+			turnPhase: "idle",
+		},
+	}),
 }));
-
-let addMessageCounter = 0;
 
 describe("useAgentChat", () => {
 	beforeEach(async () => {
 		mockInvoke.mockClear();
-		addMessageCounter = 0;
 		const sessionStore = await import("./useSessionStore");
-		vi.mocked(sessionStore.addMessage).mockImplementation(
-			(_sid, role, content) => {
-				addMessageCounter++;
-				return Promise.resolve({
-					id: `msg-${addMessageCounter}`,
-					role,
-					parts: [{ type: "text", content }],
-					timestamp: 1000 + addMessageCounter,
-				});
-			},
-		);
+		vi.mocked(sessionStore.sendAgentMessage).mockClear();
+		vi.mocked(sessionStore.initAgentSessions).mockClear();
 	});
 
 	it("should define the hook", async () => {
@@ -68,9 +93,10 @@ describe("useAgentChat", () => {
 		expect((mod as Record<string, unknown>).buildClaudeCommand).toBeUndefined();
 	});
 
-	it("sendMessage passes permissionMode to invoke", async () => {
+	it("sendMessage calls sendAgentMessage with permissionMode", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
@@ -78,13 +104,11 @@ describe("useAgentChat", () => {
 			await result.current.sendMessage("hello");
 		});
 
-		expect(mockInvoke).toHaveBeenCalledWith(
-			"execute_agent_query",
-			expect.objectContaining({
-				chatSessionId: "s1",
-				permissionMode: "acceptEdits",
-				streamingMessageId: "msg-2",
-			}),
+		expect(sessionStore.sendAgentMessage).toHaveBeenCalledWith(
+			null,
+			"/repo",
+			"hello",
+			"acceptEdits",
 		);
 	});
 
@@ -137,7 +161,7 @@ describe("useAgentChat", () => {
 		});
 	});
 
-	it("sendMessage calls createSession when no active session", async () => {
+	it("sendMessage creates session via Rust when no active session", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");
 		const sessionStore = await import("./useSessionStore");
@@ -148,10 +172,16 @@ describe("useAgentChat", () => {
 			await result.current.sendMessage("hello");
 		});
 
-		expect(sessionStore.createSession).toHaveBeenCalledWith("/repo");
+		// sendAgentMessage is called with null chatSessionId (Rust creates session)
+		expect(sessionStore.sendAgentMessage).toHaveBeenCalledWith(
+			null,
+			"/repo",
+			"hello",
+			"acceptEdits",
+		);
 	});
 
-	it("sendMessage does not call createSession on second message", async () => {
+	it("sendMessage passes existing session id on second message", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");
 		const sessionStore = await import("./useSessionStore");
@@ -162,13 +192,18 @@ describe("useAgentChat", () => {
 			await result.current.sendMessage("first");
 		});
 
-		vi.mocked(sessionStore.createSession).mockClear();
+		vi.mocked(sessionStore.sendAgentMessage).mockClear();
 
 		await act(async () => {
 			await result.current.sendMessage("second");
 		});
 
-		expect(sessionStore.createSession).not.toHaveBeenCalled();
+		expect(sessionStore.sendAgentMessage).toHaveBeenCalledWith(
+			"s1",
+			"/repo",
+			"second",
+			"acceptEdits",
+		);
 	});
 
 	it("interrupt invokes interrupt_agent_query with chatSessionId", async () => {
@@ -199,7 +234,7 @@ describe("useAgentChat", () => {
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
-		// Wait for mount effect (auto-creates session when no sessions exist)
+		// Wait for mount effect
 		await act(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
@@ -292,6 +327,7 @@ describe("useAgentChat", () => {
 	it("setPermissionMode changes mode used in next sendMessage", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
@@ -303,12 +339,11 @@ describe("useAgentChat", () => {
 			await result.current.sendMessage("hello");
 		});
 
-		expect(mockInvoke).toHaveBeenCalledWith(
-			"execute_agent_query",
-			expect.objectContaining({
-				chatSessionId: "s1",
-				permissionMode: "plan",
-			}),
+		expect(sessionStore.sendAgentMessage).toHaveBeenCalledWith(
+			null,
+			"/repo",
+			"hello",
+			"plan",
 		);
 	});
 
@@ -396,7 +431,7 @@ describe("useAgentChat", () => {
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
-		// Wait for mount effect (auto-creates session when no sessions exist)
+		// Wait for mount effect
 		await act(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
@@ -451,7 +486,7 @@ describe("useAgentChat", () => {
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
-		// Wait for mount effect (auto-creates session when no sessions exist)
+		// Wait for mount effect
 		await act(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
@@ -575,7 +610,7 @@ describe("useAgentChat", () => {
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
-		// Wait for mount effect (auto-creates session when no sessions exist)
+		// Wait for mount effect
 		await act(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
@@ -598,7 +633,7 @@ describe("useAgentChat", () => {
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
-		// Wait for mount effect (auto-creates session when no sessions exist)
+		// Wait for mount effect
 		await act(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
@@ -678,7 +713,7 @@ describe("useAgentChat", () => {
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
-		// Wait for mount effect (auto-creates session when no sessions exist)
+		// Wait for mount effect
 		await act(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
@@ -694,47 +729,44 @@ describe("useAgentChat", () => {
 		expect(result.current.error).toContain("セッション復元に失敗");
 	});
 
-	it("initSessions starts agent process for each existing session", async () => {
+	it("initSessions calls initAgentSessions on mount", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");
 		const sessionStore = await import("./useSessionStore");
 
-		// listSessions returns multiple sessions
-		vi.mocked(sessionStore.listSessions).mockResolvedValueOnce([
-			{
-				id: "s1",
-				worktreePath: "/repo",
-				updatedAt: 1000,
-				state: "active",
-				firstMessage: "hi",
-				messageCount: 1,
-				createdAt: 1000,
+		vi.mocked(sessionStore.initAgentSessions).mockResolvedValueOnce({
+			sessions: [
+				{
+					id: "s1",
+					worktreePath: "/repo",
+					updatedAt: 1000,
+					state: "active",
+					firstMessage: "hi",
+					messageCount: 1,
+					createdAt: 1000,
+				},
+				{
+					id: "s2",
+					worktreePath: "/repo",
+					updatedAt: 900,
+					state: "active",
+					firstMessage: "hello",
+					messageCount: 1,
+					createdAt: 900,
+				},
+			],
+			activeSession: {
+				session: {
+					id: "s1",
+					worktreePath: "/repo",
+					messages: [],
+					state: "active",
+					createdAt: 1000,
+					updatedAt: 1000,
+				},
+				turnPhase: "idle",
 			},
-			{
-				id: "s2",
-				worktreePath: "/repo",
-				updatedAt: 900,
-				state: "active",
-				firstMessage: "hello",
-				messageCount: 1,
-				createdAt: 900,
-			},
-		] as never);
-
-		// getSession for the first session (selectSession(sessions[0].id))
-		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
-			session: {
-				id: "s1",
-				worktreePath: "/repo",
-				messages: [],
-				state: "active",
-				createdAt: 1000,
-				updatedAt: 1000,
-			},
-			turnPhase: "idle",
 		} as never);
-
-		mockInvoke.mockClear();
 
 		renderHook(() => useAgentChat("/repo"));
 
@@ -743,15 +775,9 @@ describe("useAgentChat", () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 
-		const startCalls = mockInvoke.mock.calls.filter(
-			(call: unknown[]) => call[0] === "start_agent_session",
-		);
-		expect(startCalls).toHaveLength(2);
-		expect(startCalls[0][1]).toEqual(
-			expect.objectContaining({ chatSessionId: "s1" }),
-		);
-		expect(startCalls[1][1]).toEqual(
-			expect.objectContaining({ chatSessionId: "s2" }),
+		expect(sessionStore.initAgentSessions).toHaveBeenCalledWith(
+			"/repo",
+			"acceptEdits",
 		);
 	});
 });
@@ -876,25 +902,17 @@ describe("useSessionStore", () => {
 		expect(mod.closeSession).toBeDefined();
 		expect(mod.restoreSession).toBeDefined();
 		expect(mod.listClosedSessions).toBeDefined();
+		expect(mod.sendAgentMessage).toBeDefined();
+		expect(mod.initAgentSessions).toBeDefined();
 	});
 });
 
 describe("Worktree switch (unmount/remount) streaming persistence via Rust backend", () => {
 	beforeEach(async () => {
 		mockInvoke.mockClear();
-		addMessageCounter = 0;
 		const sessionStore = await import("./useSessionStore");
-		vi.mocked(sessionStore.addMessage).mockImplementation(
-			(_sid, role, content) => {
-				addMessageCounter++;
-				return Promise.resolve({
-					id: `msg-${addMessageCounter}`,
-					role,
-					parts: [{ type: "text", content }],
-					timestamp: 1000 + addMessageCounter,
-				});
-			},
-		);
+		vi.mocked(sessionStore.sendAgentMessage).mockClear();
+		vi.mocked(sessionStore.initAgentSessions).mockClear();
 	});
 
 	it("getSession with isStreaming restores streaming state on remount", async () => {
@@ -912,42 +930,43 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 		// Unmount (simulates Worktree switch)
 		unmount();
 
-		// Remount (simulates returning to original Worktree)
-		// Rust backend returns session with streaming parts already merged
-		vi.mocked(sessionStore.listSessions).mockResolvedValueOnce([
-			{
-				id: "s1",
-				worktreePath: "/repo",
-				updatedAt: 1000,
-				state: "active",
-				firstMessage: "hello",
-				messageCount: 2,
-				createdAt: 1000,
+		// Remount: Rust backend returns session with streaming parts already merged
+		vi.mocked(sessionStore.initAgentSessions).mockResolvedValueOnce({
+			sessions: [
+				{
+					id: "s1",
+					worktreePath: "/repo",
+					updatedAt: 1000,
+					state: "active",
+					firstMessage: "hello",
+					messageCount: 2,
+					createdAt: 1000,
+				},
+			],
+			activeSession: {
+				session: {
+					id: "s1",
+					worktreePath: "/repo",
+					messages: [
+						{
+							id: "msg-1",
+							role: "human",
+							parts: [{ type: "text", content: "hello" }],
+							timestamp: 1001,
+						},
+						{
+							id: "msg-2",
+							role: "agent",
+							parts: [{ type: "text", content: "streaming response" }],
+							timestamp: 1002,
+						},
+					],
+					state: "active",
+					createdAt: 1000,
+					updatedAt: 1000,
+				},
+				turnPhase: "streaming",
 			},
-		] as never);
-		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
-			session: {
-				id: "s1",
-				worktreePath: "/repo",
-				messages: [
-					{
-						id: "msg-1",
-						role: "human",
-						parts: [{ type: "text", content: "hello" }],
-						timestamp: 1001,
-					},
-					{
-						id: "msg-2",
-						role: "agent",
-						parts: [{ type: "text", content: "streaming response" }],
-						timestamp: 1002,
-					},
-				],
-				state: "active",
-				createdAt: 1000,
-				updatedAt: 1000,
-			},
-			turnPhase: "streaming",
 		} as never);
 
 		const { result: result2 } = renderHook(() => useAgentChat("/repo"));
@@ -985,41 +1004,43 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 		// Unmount
 		unmount();
 
-		// After completion + unmount, getSession returns Rust-persisted data
-		vi.mocked(sessionStore.listSessions).mockResolvedValueOnce([
-			{
-				id: "s1",
-				worktreePath: "/repo",
-				updatedAt: 1000,
-				state: "idle",
-				firstMessage: "hello",
-				messageCount: 2,
-				createdAt: 1000,
+		// After completion + unmount, initAgentSessions returns Rust-persisted data
+		vi.mocked(sessionStore.initAgentSessions).mockResolvedValueOnce({
+			sessions: [
+				{
+					id: "s1",
+					worktreePath: "/repo",
+					updatedAt: 1000,
+					state: "idle",
+					firstMessage: "hello",
+					messageCount: 2,
+					createdAt: 1000,
+				},
+			],
+			activeSession: {
+				session: {
+					id: "s1",
+					worktreePath: "/repo",
+					messages: [
+						{
+							id: "msg-1",
+							role: "human",
+							parts: [{ type: "text", content: "hello" }],
+							timestamp: 1001,
+						},
+						{
+							id: "msg-2",
+							role: "agent",
+							parts: [{ type: "text", content: "final response" }],
+							timestamp: 1002,
+						},
+					],
+					state: "idle",
+					createdAt: 1000,
+					updatedAt: 1000,
+				},
+				turnPhase: "idle",
 			},
-		] as never);
-		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
-			session: {
-				id: "s1",
-				worktreePath: "/repo",
-				messages: [
-					{
-						id: "msg-1",
-						role: "human",
-						parts: [{ type: "text", content: "hello" }],
-						timestamp: 1001,
-					},
-					{
-						id: "msg-2",
-						role: "agent",
-						parts: [{ type: "text", content: "final response" }],
-						timestamp: 1002,
-					},
-				],
-				state: "idle",
-				createdAt: 1000,
-				updatedAt: 1000,
-			},
-			turnPhase: "idle",
 		} as never);
 
 		const { result: result2 } = renderHook(() => useAgentChat("/repo"));

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -221,7 +221,7 @@ describe("useAgentChat", () => {
 		};
 		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
 			session: mockSession,
-			isStreaming: false,
+			turnPhase: "idle",
 		} as never);
 
 		await act(async () => {
@@ -269,7 +269,7 @@ describe("useAgentChat", () => {
 		// getSession returns merged data from Rust backend (including streaming parts)
 		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
 			session: mockSession,
-			isStreaming: true,
+			turnPhase: "streaming",
 		} as never);
 
 		await act(async () => {
@@ -554,7 +554,7 @@ describe("useAgentChat", () => {
 		};
 		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
 			session: s2Full,
-			isStreaming: false,
+			turnPhase: "idle",
 		} as never);
 
 		await act(async () => {
@@ -620,7 +620,7 @@ describe("useAgentChat", () => {
 		};
 		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
 			session: restoredSession,
-			isStreaming: false,
+			turnPhase: "idle",
 		} as never);
 
 		await act(async () => {
@@ -653,7 +653,7 @@ describe("useAgentChat", () => {
 		};
 		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
 			session: restoredSession,
-			isStreaming: false,
+			turnPhase: "idle",
 		} as never);
 		mockInvoke.mockClear();
 
@@ -731,7 +731,7 @@ describe("useAgentChat", () => {
 				createdAt: 1000,
 				updatedAt: 1000,
 			},
-			isStreaming: false,
+			turnPhase: "idle",
 		} as never);
 
 		mockInvoke.mockClear();
@@ -947,7 +947,7 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 				createdAt: 1000,
 				updatedAt: 1000,
 			},
-			isStreaming: true,
+			turnPhase: "streaming",
 		} as never);
 
 		const { result: result2 } = renderHook(() => useAgentChat("/repo"));
@@ -1019,7 +1019,7 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 				createdAt: 1000,
 				updatedAt: 1000,
 			},
-			isStreaming: false,
+			turnPhase: "idle",
 		} as never);
 
 		const { result: result2 } = renderHook(() => useAgentChat("/repo"));
@@ -1046,12 +1046,42 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
-		// Send a message to start streaming
+		// Wait for mount effect
 		await act(async () => {
-			await result.current.sendMessage("hello");
+			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 
-		// Simulate streaming started
+		// Select session s1 with streaming turnPhase (simulates ongoing streaming)
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
+			session: {
+				id: "s1",
+				worktreePath: "/repo",
+				messages: [
+					{
+						id: "msg-1",
+						role: "human",
+						parts: [{ type: "text", content: "hello" }],
+						timestamp: 1001,
+					},
+					{
+						id: "msg-2",
+						role: "agent",
+						parts: [{ type: "text", content: "partial" }],
+						timestamp: 1002,
+					},
+				],
+				state: "active",
+				createdAt: 1000,
+				updatedAt: 1000,
+			},
+			turnPhase: "streaming",
+		} as never);
+
+		await act(async () => {
+			await result.current.selectSession("s1");
+		});
+
+		// Streaming state should be restored from backend
 		expect(result.current.isStreaming).toBe(true);
 
 		// Switch to another session: getSession for session s2
@@ -1071,7 +1101,7 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 				createdAt: 2000,
 				updatedAt: 2000,
 			},
-			isStreaming: false,
+			turnPhase: "idle",
 		} as never);
 
 		await act(async () => {
@@ -1101,7 +1131,7 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 				createdAt: 1000,
 				updatedAt: 1000,
 			},
-			isStreaming: false,
+			turnPhase: "idle",
 		} as never);
 
 		await act(async () => {

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -12,13 +12,14 @@ import type {
 import { INITIAL_STATE, reducer } from "./agentChatReducer";
 import { useAgentSdkListeners } from "./useAgentSdkListeners";
 import {
-	addMessage,
 	closeSession as closeSessionApi,
 	createSession,
 	getSession,
+	initAgentSessions,
 	listClosedSessions,
 	listSessions,
 	restoreSession as restoreSessionApi,
+	sendAgentMessage,
 } from "./useSessionStore";
 
 export type ActivityStatus = { label: string } | null;
@@ -157,10 +158,6 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 	userPermissionModeRef.current = state.userPermissionMode;
 	const turnPhasesRef = useRef(state.turnPhases);
 	turnPhasesRef.current = state.turnPhases;
-	const pendingMessageRef = useRef<{
-		sessionId: string;
-		content: string;
-	} | null>(null);
 
 	const refreshSessions = useCallback(async (): Promise<SessionSummary[]> => {
 		try {
@@ -198,25 +195,6 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		}
 	}, []);
 
-	const startQuery = useCallback(async (sessionId: string, prompt: string) => {
-		const agentMsg = await addMessage(sessionId, "agent", "");
-		dispatch({ type: "ADD_MESSAGE", message: agentMsg });
-
-		invoke("execute_agent_query", {
-			prompt,
-			chatSessionId: sessionId,
-			cwd: worktreePathRef.current,
-			permissionMode: permissionModeRef.current,
-			streamingMessageId: agentMsg.id,
-		}).catch((e) => {
-			console.error("execute_agent_query failed:", e);
-			dispatch({
-				type: "SET_ERROR",
-				error: `エージェント実行に失敗: ${e}`,
-			});
-		});
-	}, []);
-
 	const interrupt = useCallback(() => {
 		const sessionId = activeSessionRef.current?.id;
 		if (!sessionId) return;
@@ -225,46 +203,33 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		});
 	}, []);
 
-	const sendMessage = useCallback(
-		async (content: string) => {
-			const trimmed = content.trim();
-			if (!trimmed) return;
+	const sendMessage = useCallback(async (content: string) => {
+		const trimmed = content.trim();
+		if (!trimmed) return;
 
-			try {
-				let session = activeSessionRef.current;
-				if (!session) {
-					session = await createSession(worktreePathRef.current);
-					dispatch({ type: "SET_ACTIVE_SESSION", session });
-				}
-
-				const message = await addMessage(session.id, "human", trimmed);
-				dispatch({ type: "ADD_MESSAGE", message });
-
-				const currentPhase = turnPhasesRef.current[session.id] ?? "idle";
-				if (
-					currentPhase === "streaming" ||
-					currentPhase === "waiting_permission"
-				) {
-					// Streaming: interrupt and queue pending message
-					pendingMessageRef.current = {
-						sessionId: session.id,
-						content: trimmed,
-					};
-					interrupt();
-				} else {
-					await startQuery(session.id, trimmed);
-				}
-
-				await refreshSessions();
-			} catch (e) {
-				dispatch({
-					type: "SET_ERROR",
-					error: `メッセージ送信に失敗: ${e}`,
-				});
+		try {
+			const isNewSession = !activeSessionRef.current;
+			const response = await sendAgentMessage(
+				activeSessionRef.current?.id ?? null,
+				worktreePathRef.current,
+				trimmed,
+				permissionModeRef.current,
+			);
+			if (isNewSession) {
+				dispatch({ type: "SET_ACTIVE_SESSION", session: response.session });
 			}
-		},
-		[refreshSessions, startQuery, interrupt],
-	);
+			dispatch({ type: "ADD_MESSAGE", message: response.humanMessage });
+			if (response.agentMessage) {
+				dispatch({ type: "ADD_MESSAGE", message: response.agentMessage });
+			}
+			dispatch({ type: "SET_SESSIONS", sessions: response.sessions });
+		} catch (e) {
+			dispatch({
+				type: "SET_ERROR",
+				error: `メッセージ送信に失敗: ${e}`,
+			});
+		}
+	}, []);
 
 	const refreshClosedSessions = useCallback(async () => {
 		try {
@@ -425,26 +390,33 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		activeSessionRef,
 		userPermissionModeRef,
 		refreshSessions,
-		pendingMessageRef,
-		startQuery,
 	});
 
 	const initSessions = useCallback(async () => {
-		const sessions = await refreshSessions();
-		// Start Bridge processes for all existing sessions
-		for (const session of sessions) {
-			startAgentProcess(
-				session.id,
+		try {
+			const response = await initAgentSessions(
 				worktreePathRef.current,
 				permissionModeRef.current,
 			);
+			dispatch({ type: "SET_SESSIONS", sessions: response.sessions });
+			if (response.activeSession) {
+				dispatch({
+					type: "SET_ACTIVE_SESSION",
+					session: response.activeSession.session,
+				});
+				dispatch({
+					type: "SET_TURN_PHASE",
+					sessionId: response.activeSession.session.id,
+					turnPhase: response.activeSession.turnPhase,
+				});
+			}
+		} catch (e) {
+			dispatch({
+				type: "SET_ERROR",
+				error: `セッション初期化に失敗: ${e}`,
+			});
 		}
-		if (sessions.length > 0) {
-			await selectSession(sessions[0].id);
-		} else {
-			await createNewSession();
-		}
-	}, [refreshSessions, selectSession, createNewSession]);
+	}, []);
 
 	// Load sessions on mount
 	useEffect(() => {

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -4,8 +4,8 @@ import type { AgentState } from "@/types/protocol";
 import type {
 	ChatSession,
 	PermissionMode,
-	PermissionRequest,
 	SessionSummary,
+	TurnPhase,
 } from "@/types/session";
 import { INITIAL_STATE, reducer } from "./agentChatReducer";
 import { useAgentSdkListeners } from "./useAgentSdkListeners";
@@ -59,16 +59,15 @@ function startAgentProcess(
 	});
 }
 
-function deriveAgentState(
-	sessionId: string,
-	streamingSessionIds: string[],
-	pendingPermissions: Record<string, PermissionRequest>,
-	sessionFinalStates: Record<string, "done" | "error">,
-): AgentState {
-	if (streamingSessionIds.includes(sessionId)) {
-		return sessionId in pendingPermissions ? "waiting" : "running";
+function deriveAgentState(turnPhase: TurnPhase): AgentState {
+	switch (turnPhase) {
+		case "streaming":
+			return "running";
+		case "waiting_permission":
+			return "waiting";
+		case "idle":
+			return "done";
 	}
-	return sessionFinalStates[sessionId] ?? "done";
 }
 
 export function useAgentChat(worktreePath: string): UseAgentChatResult {
@@ -103,12 +102,12 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 			const response = await getSession(sessionId);
 			if (response) {
 				dispatch({ type: "SET_ACTIVE_SESSION", session: response.session });
-				// Sync streaming state from backend
-				if (response.isStreaming) {
-					dispatch({ type: "START_STREAMING", sessionId });
-				} else {
-					dispatch({ type: "STOP_STREAMING", sessionId });
-				}
+				// Sync turn phase from backend
+				dispatch({
+					type: "SET_TURN_PHASE",
+					sessionId,
+					turnPhase: response.turnPhase,
+				});
 			} else {
 				dispatch({ type: "SET_ACTIVE_SESSION", session: null });
 			}
@@ -123,7 +122,6 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 	const startQuery = useCallback(async (sessionId: string, prompt: string) => {
 		const agentMsg = await addMessage(sessionId, "agent", "");
 		dispatch({ type: "ADD_MESSAGE", message: agentMsg });
-		dispatch({ type: "START_STREAMING", sessionId });
 
 		invoke("execute_agent_query", {
 			prompt,
@@ -133,7 +131,6 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 			streamingMessageId: agentMsg.id,
 		}).catch((e) => {
 			console.error("execute_agent_query failed:", e);
-			dispatch({ type: "STOP_STREAMING", sessionId });
 			dispatch({
 				type: "SET_ERROR",
 				error: `エージェント実行に失敗: ${e}`,
@@ -160,10 +157,6 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 
 				await refreshSessions();
 			} catch (e) {
-				const sessionId = activeSessionRef.current?.id;
-				if (sessionId) {
-					dispatch({ type: "STOP_STREAMING", sessionId });
-				}
 				dispatch({
 					type: "SET_ERROR",
 					error: `メッセージ送信に失敗: ${e}`,
@@ -375,9 +368,11 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		}
 	}, [worktreePath, initSessions, refreshClosedSessions]);
 
-	const isStreaming = state.streamingSessionIds.includes(
-		state.activeSession?.id ?? "",
-	);
+	const activeTurnPhase: TurnPhase =
+		state.turnPhases[state.activeSession?.id ?? ""] ?? "idle";
+	const isStreaming =
+		activeTurnPhase === "streaming" || activeTurnPhase === "waiting_permission";
+
 	const orderedSessions = useMemo(() => {
 		const sessionMap = new Map(state.sessions.map((s) => [s.id, s]));
 		return state.sessionOrder
@@ -388,23 +383,11 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 	const sessionAgentStates = useMemo(() => {
 		const map = new Map<string, AgentState>();
 		for (const s of state.sessions) {
-			map.set(
-				s.id,
-				deriveAgentState(
-					s.id,
-					state.streamingSessionIds,
-					state.pendingPermissions,
-					state.sessionFinalStates,
-				),
-			);
+			const phase: TurnPhase = state.turnPhases[s.id] ?? "idle";
+			map.set(s.id, deriveAgentState(phase));
 		}
 		return map;
-	}, [
-		state.sessions,
-		state.streamingSessionIds,
-		state.pendingPermissions,
-		state.sessionFinalStates,
-	]);
+	}, [state.sessions, state.turnPhases]);
 
 	return {
 		sessions: state.sessions,

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -2,8 +2,10 @@ import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import type { AgentState } from "@/types/protocol";
 import type {
+	ChatMessage,
 	ChatSession,
 	PermissionMode,
+	SessionState,
 	SessionSummary,
 	TurnPhase,
 } from "@/types/session";
@@ -19,12 +21,15 @@ import {
 	restoreSession as restoreSessionApi,
 } from "./useSessionStore";
 
+export type ActivityStatus = { label: string } | null;
+
 export interface UseAgentChatResult {
 	sessions: SessionSummary[];
 	orderedSessions: SessionSummary[];
 	closedSessions: SessionSummary[];
 	activeSession: ChatSession | null;
 	isStreaming: boolean;
+	activityStatus: ActivityStatus;
 	error: string | null;
 	permissionMode: PermissionMode;
 	sessionAgentStates: Map<string, AgentState>;
@@ -59,14 +64,82 @@ function startAgentProcess(
 	});
 }
 
-function deriveAgentState(turnPhase: TurnPhase): AgentState {
+function deriveAgentState(
+	turnPhase: TurnPhase,
+	sessionState?: SessionState,
+): AgentState {
 	switch (turnPhase) {
 		case "streaming":
 			return "running";
 		case "waiting_permission":
 			return "waiting";
 		case "idle":
-			return "done";
+			return sessionState === "error" ? "error" : "done";
+	}
+}
+
+function deriveActivityStatus(
+	messages: ChatMessage[] | undefined,
+	turnPhase: TurnPhase,
+): ActivityStatus {
+	if (turnPhase === "idle") return null;
+	if (!messages || messages.length === 0) return null;
+	const lastMsg = messages[messages.length - 1];
+	if (lastMsg.role !== "agent") return null;
+	if (lastMsg.parts.length === 0) return { label: "Thinking..." };
+
+	const lastPart = lastMsg.parts[lastMsg.parts.length - 1];
+	switch (lastPart.type) {
+		case "thinking":
+			return { label: "Thinking..." };
+		case "text":
+			return { label: "Writing..." };
+		case "tool_use": {
+			const tool = (
+				lastPart as { tool: string; input?: Record<string, unknown> }
+			).tool;
+			const filePath = (lastPart as { input?: Record<string, unknown> }).input
+				?.file_path as string | undefined;
+			const fileName = filePath?.split("/").pop();
+			switch (tool) {
+				case "Read":
+					return {
+						label: fileName ? `Reading ${fileName}` : "Reading file...",
+					};
+				case "Write":
+					return {
+						label: fileName ? `Writing ${fileName}` : "Writing file...",
+					};
+				case "Edit":
+					return {
+						label: fileName ? `Editing ${fileName}` : "Editing file...",
+					};
+				case "Bash":
+					return { label: "Running command..." };
+				case "Grep":
+					return { label: "Searching..." };
+				case "Glob":
+					return { label: "Finding files..." };
+				case "Task":
+					return { label: "Running background task..." };
+				case "WebFetch":
+					return { label: "Fetching web content..." };
+				case "WebSearch":
+					return { label: "Searching the web..." };
+				default:
+					return { label: `Using ${tool}...` };
+			}
+		}
+		case "tool_result":
+			return { label: "Processing result..." };
+		case "permission":
+			return { label: "Waiting for permission..." };
+		case "task_status":
+			return { label: "Running background task..." };
+		case "error":
+			return null;
+		default:
+			return { label: "Working..." };
 	}
 }
 
@@ -82,6 +155,12 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 	permissionModeRef.current = state.permissionMode;
 	const userPermissionModeRef = useRef(state.userPermissionMode);
 	userPermissionModeRef.current = state.userPermissionMode;
+	const turnPhasesRef = useRef(state.turnPhases);
+	turnPhasesRef.current = state.turnPhases;
+	const pendingMessageRef = useRef<{
+		sessionId: string;
+		content: string;
+	} | null>(null);
 
 	const refreshSessions = useCallback(async (): Promise<SessionSummary[]> => {
 		try {
@@ -138,6 +217,14 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		});
 	}, []);
 
+	const interrupt = useCallback(() => {
+		const sessionId = activeSessionRef.current?.id;
+		if (!sessionId) return;
+		invoke("interrupt_agent_query", { chatSessionId: sessionId }).catch((e) => {
+			console.error("Failed to interrupt agent query:", e);
+		});
+	}, []);
+
 	const sendMessage = useCallback(
 		async (content: string) => {
 			const trimmed = content.trim();
@@ -153,7 +240,20 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 				const message = await addMessage(session.id, "human", trimmed);
 				dispatch({ type: "ADD_MESSAGE", message });
 
-				await startQuery(session.id, trimmed);
+				const currentPhase = turnPhasesRef.current[session.id] ?? "idle";
+				if (
+					currentPhase === "streaming" ||
+					currentPhase === "waiting_permission"
+				) {
+					// Streaming: interrupt and queue pending message
+					pendingMessageRef.current = {
+						sessionId: session.id,
+						content: trimmed,
+					};
+					interrupt();
+				} else {
+					await startQuery(session.id, trimmed);
+				}
 
 				await refreshSessions();
 			} catch (e) {
@@ -163,7 +263,7 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 				});
 			}
 		},
-		[refreshSessions, startQuery],
+		[refreshSessions, startQuery, interrupt],
 	);
 
 	const refreshClosedSessions = useCallback(async () => {
@@ -272,14 +372,6 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		}
 	}, [refreshSessions]);
 
-	const interrupt = useCallback(() => {
-		const sessionId = activeSessionRef.current?.id;
-		if (!sessionId) return;
-		invoke("interrupt_agent_query", { chatSessionId: sessionId }).catch((e) => {
-			console.error("Failed to interrupt agent query:", e);
-		});
-	}, []);
-
 	const reorderSessions = useCallback((sessionOrder: string[]) => {
 		dispatch({ type: "REORDER_SESSIONS", sessionOrder });
 	}, []);
@@ -333,6 +425,8 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		activeSessionRef,
 		userPermissionModeRef,
 		refreshSessions,
+		pendingMessageRef,
+		startQuery,
 	});
 
 	const initSessions = useCallback(async () => {
@@ -384,10 +478,15 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		const map = new Map<string, AgentState>();
 		for (const s of state.sessions) {
 			const phase: TurnPhase = state.turnPhases[s.id] ?? "idle";
-			map.set(s.id, deriveAgentState(phase));
+			map.set(s.id, deriveAgentState(phase, s.state));
 		}
 		return map;
 	}, [state.sessions, state.turnPhases]);
+
+	const activityStatus = useMemo(
+		() => deriveActivityStatus(state.activeSession?.messages, activeTurnPhase),
+		[state.activeSession?.messages, activeTurnPhase],
+	);
 
 	return {
 		sessions: state.sessions,
@@ -395,6 +494,7 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		closedSessions: state.closedSessions,
 		activeSession: state.activeSession,
 		isStreaming,
+		activityStatus,
 		error: state.error,
 		permissionMode: state.permissionMode,
 		sessionAgentStates,

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -217,10 +217,11 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 			);
 			if (isNewSession) {
 				dispatch({ type: "SET_ACTIVE_SESSION", session: response.session });
-			}
-			dispatch({ type: "ADD_MESSAGE", message: response.humanMessage });
-			if (response.agentMessage) {
-				dispatch({ type: "ADD_MESSAGE", message: response.agentMessage });
+			} else {
+				dispatch({ type: "ADD_MESSAGE", message: response.humanMessage });
+				if (response.agentMessage) {
+					dispatch({ type: "ADD_MESSAGE", message: response.agentMessage });
+				}
 			}
 			dispatch({ type: "SET_SESSIONS", sessions: response.sessions });
 		} catch (e) {
@@ -271,6 +272,13 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 							type: "SET_ACTIVE_SESSION",
 							session: response?.session ?? null,
 						});
+						if (response) {
+							dispatch({
+								type: "SET_TURN_PHASE",
+								sessionId: nextSession.id,
+								turnPhase: response.turnPhase,
+							});
+						}
 					} else {
 						dispatch({
 							type: "SET_ACTIVE_SESSION",
@@ -300,6 +308,13 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 					type: "SET_ACTIVE_SESSION",
 					session: response?.session ?? null,
 				});
+				if (response) {
+					dispatch({
+						type: "SET_TURN_PHASE",
+						sessionId,
+						turnPhase: response.turnPhase,
+					});
+				}
 				// Start Bridge process for the restored session
 				startAgentProcess(
 					sessionId,

--- a/src/hooks/useAgentSdkListeners.test.ts
+++ b/src/hooks/useAgentSdkListeners.test.ts
@@ -102,7 +102,7 @@ describe("useAgentSdkListeners cancelled flag", () => {
 		}
 	});
 
-	it("registers listeners for agent-sdk-message, agent-query-completed, streaming-message-updated, agent-streaming-started", () => {
+	it("registers listeners for agent-sdk-message, agent-session-state-changed, agent-streaming-updated", () => {
 		listenResolvers = [];
 		const refs = makeRefs();
 
@@ -110,10 +110,10 @@ describe("useAgentSdkListeners cancelled flag", () => {
 
 		const eventNames = listenResolvers.map((r) => r.eventName);
 		expect(eventNames).toContain("agent-sdk-message");
-		expect(eventNames).toContain("agent-query-completed");
+		expect(eventNames).toContain("agent-session-state-changed");
 		expect(eventNames).toContain("agent-streaming-updated");
-		expect(eventNames).toContain("agent-streaming-started");
-		expect(eventNames).not.toContain("agent-state-changed");
+		expect(eventNames).not.toContain("agent-streaming-started");
+		expect(eventNames).not.toContain("agent-query-completed");
 	});
 });
 
@@ -151,8 +151,8 @@ describe("agent-streaming-updated event", () => {
 	});
 });
 
-describe("agent-streaming-started event", () => {
-	it("dispatches START_STREAMING when agent-streaming-started is received", () => {
+describe("agent-session-state-changed event", () => {
+	it("dispatches SET_TURN_PHASE when streaming phase is received", () => {
 		listenResolvers = [];
 		listenCallbacks.clear();
 		const refs = makeRefs();
@@ -160,25 +160,25 @@ describe("agent-streaming-started event", () => {
 		renderHook(() => useAgentSdkListeners(refs));
 		for (const { resolve } of listenResolvers) resolve(vi.fn());
 
-		const cb = listenCallbacks.get("agent-streaming-started");
+		const cb = listenCallbacks.get("agent-session-state-changed");
 		expect(cb).toBeDefined();
 
 		cb?.({
 			payload: {
 				chat_session_id: "session-1",
-				message_id: "msg-001",
+				turn_phase: "streaming",
+				exit_code: null,
 			},
 		});
 
 		expect(refs.dispatch).toHaveBeenCalledWith({
-			type: "START_STREAMING",
+			type: "SET_TURN_PHASE",
 			sessionId: "session-1",
+			turnPhase: "streaming",
 		});
 	});
-});
 
-describe("useAgentSdkListeners callback behavior", () => {
-	it("dispatches STOP_STREAMING when agent-query-completed is received", () => {
+	it("dispatches SET_TURN_PHASE and UPDATE_SESSION_STATE on idle with exit_code", () => {
 		listenResolvers = [];
 		listenCallbacks.clear();
 		const refs = makeRefs();
@@ -197,20 +197,21 @@ describe("useAgentSdkListeners callback behavior", () => {
 			resolve(vi.fn());
 		}
 
-		const cb = listenCallbacks.get("agent-query-completed");
+		const cb = listenCallbacks.get("agent-session-state-changed");
 		expect(cb).toBeDefined();
 
 		cb?.({
 			payload: {
-				exit_code: 0,
-				stderr: "",
 				chat_session_id: "session-1",
+				turn_phase: "idle",
+				exit_code: 0,
 			},
 		});
 
 		expect(refs.dispatch).toHaveBeenCalledWith({
-			type: "STOP_STREAMING",
+			type: "SET_TURN_PHASE",
 			sessionId: "session-1",
+			turnPhase: "idle",
 		});
 		expect(refs.dispatch).toHaveBeenCalledWith({
 			type: "UPDATE_SESSION_STATE",
@@ -260,7 +261,7 @@ describe("useAgentSdkListeners callback behavior", () => {
 		});
 	});
 
-	it("dispatches SET_PENDING_PERMISSION null on agent-query-completed", () => {
+	it("dispatches SET_PENDING_PERMISSION null on idle state change", () => {
 		listenResolvers = [];
 		listenCallbacks.clear();
 		const refs = makeRefs();
@@ -279,11 +280,15 @@ describe("useAgentSdkListeners callback behavior", () => {
 			resolve(vi.fn());
 		}
 
-		const cb = listenCallbacks.get("agent-query-completed");
+		const cb = listenCallbacks.get("agent-session-state-changed");
 		expect(cb).toBeDefined();
 
 		cb?.({
-			payload: { exit_code: 0, stderr: "", chat_session_id: "session-1" },
+			payload: {
+				chat_session_id: "session-1",
+				turn_phase: "idle",
+				exit_code: 0,
+			},
 		});
 
 		expect(refs.dispatch).toHaveBeenCalledWith({

--- a/src/hooks/useAgentSdkListeners.test.ts
+++ b/src/hooks/useAgentSdkListeners.test.ts
@@ -47,6 +47,10 @@ function makeRefs() {
 			current: "acceptEdits" as import("@/types/session").PermissionMode,
 		},
 		refreshSessions: vi.fn().mockResolvedValue(undefined),
+		pendingMessageRef: { current: null } as {
+			current: { sessionId: string; content: string } | null;
+		},
+		startQuery: vi.fn().mockResolvedValue(undefined),
 	};
 }
 

--- a/src/hooks/useAgentSdkListeners.test.ts
+++ b/src/hooks/useAgentSdkListeners.test.ts
@@ -47,10 +47,6 @@ function makeRefs() {
 			current: "acceptEdits" as import("@/types/session").PermissionMode,
 		},
 		refreshSessions: vi.fn().mockResolvedValue(undefined),
-		pendingMessageRef: { current: null } as {
-			current: { sessionId: string; content: string } | null;
-		},
-		startQuery: vi.fn().mockResolvedValue(undefined),
 	};
 }
 
@@ -106,7 +102,7 @@ describe("useAgentSdkListeners cancelled flag", () => {
 		}
 	});
 
-	it("registers listeners for agent-sdk-message, agent-session-state-changed, agent-streaming-updated", () => {
+	it("registers listeners for agent-sdk-message, agent-session-state-changed, agent-streaming-updated, agent-pending-message-consumed", () => {
 		listenResolvers = [];
 		const refs = makeRefs();
 
@@ -116,6 +112,7 @@ describe("useAgentSdkListeners cancelled flag", () => {
 		expect(eventNames).toContain("agent-sdk-message");
 		expect(eventNames).toContain("agent-session-state-changed");
 		expect(eventNames).toContain("agent-streaming-updated");
+		expect(eventNames).toContain("agent-pending-message-consumed");
 		expect(eventNames).not.toContain("agent-streaming-started");
 		expect(eventNames).not.toContain("agent-query-completed");
 	});
@@ -778,5 +775,70 @@ describe("supported_commands handling", () => {
 		});
 
 		expect(setSlashCommands).not.toHaveBeenCalled();
+	});
+});
+
+describe("agent-pending-message-consumed event", () => {
+	it("dispatches ADD_MESSAGE when pending message is consumed for active session", () => {
+		listenResolvers = [];
+		listenCallbacks.clear();
+		const refs = makeRefs();
+		refs.activeSessionRef.current = { id: "session-1" } as never;
+
+		renderHook(() => useAgentSdkListeners(refs));
+		for (const { resolve } of listenResolvers) resolve(vi.fn());
+
+		const cb = listenCallbacks.get("agent-pending-message-consumed");
+		expect(cb).toBeDefined();
+
+		cb?.({
+			payload: {
+				chat_session_id: "session-1",
+				agent_message: {
+					id: "msg-agent-001",
+					role: "agent",
+					timestamp: 1234567,
+				},
+			},
+		});
+
+		expect(refs.dispatch).toHaveBeenCalledWith({
+			type: "ADD_MESSAGE",
+			message: {
+				id: "msg-agent-001",
+				role: "agent",
+				parts: [],
+				timestamp: 1234567,
+			},
+		});
+	});
+
+	it("does not dispatch ADD_MESSAGE when pending message is consumed for non-active session", () => {
+		listenResolvers = [];
+		listenCallbacks.clear();
+		const refs = makeRefs();
+		refs.activeSessionRef.current = { id: "session-2" } as never;
+
+		renderHook(() => useAgentSdkListeners(refs));
+		for (const { resolve } of listenResolvers) resolve(vi.fn());
+
+		const cb = listenCallbacks.get("agent-pending-message-consumed");
+		expect(cb).toBeDefined();
+
+		cb?.({
+			payload: {
+				chat_session_id: "session-1",
+				agent_message: {
+					id: "msg-agent-001",
+					role: "agent",
+					timestamp: 1234567,
+				},
+			},
+		});
+
+		const addMsgCalls = refs.dispatch.mock.calls.filter(
+			(call: unknown[]) => (call[0] as { type: string }).type === "ADD_MESSAGE",
+		);
+		expect(addMsgCalls).toHaveLength(0);
 	});
 });

--- a/src/hooks/useAgentSdkListeners.ts
+++ b/src/hooks/useAgentSdkListeners.ts
@@ -8,6 +8,7 @@ import type {
 	PermissionMode,
 	PermissionRequest,
 	SessionState,
+	TurnPhase,
 } from "@/types/session";
 import {
 	type AgentChatAction,
@@ -40,20 +41,16 @@ type SdkMessage =
 			[key: string]: unknown;
 	  };
 
-interface QueryCompleted {
-	exit_code: number;
-	stderr: string;
-	chat_session_id?: string;
+interface SessionStateChanged {
+	chat_session_id: string;
+	turn_phase: TurnPhase;
+	exit_code: number | null;
 }
 
 interface StreamingMessageUpdated {
 	chat_session_id: string;
 	message_id: string;
 	parts: MessagePart[];
-}
-
-interface StreamingStarted {
-	chat_session_id: string;
 }
 
 export interface AgentSdkListenerRefs {
@@ -261,70 +258,42 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 		};
 	}, [dispatch]);
 
-	// Listen to agent-streaming-started from Rust backend
+	// Listen to agent-session-state-changed (unified state event from Rust)
 	useEffect(() => {
 		let unlisten: UnlistenFn | null = null;
 		let cancelled = false;
 
-		listen<StreamingStarted>("agent-streaming-started", (event) => {
-			const { chat_session_id } = event.payload;
-			dispatch({ type: "START_STREAMING", sessionId: chat_session_id });
-		}).then((fn) => {
-			if (cancelled) {
-				fn();
-			} else {
-				unlisten = fn;
-			}
-		});
+		listen<SessionStateChanged>("agent-session-state-changed", (event) => {
+			const { chat_session_id, turn_phase, exit_code } = event.payload;
 
-		return () => {
-			cancelled = true;
-			unlisten?.();
-		};
-	}, [dispatch]);
+			dispatch({
+				type: "SET_TURN_PHASE",
+				sessionId: chat_session_id,
+				turnPhase: turn_phase,
+			});
 
-	// Listen to agent-query-completed for completion/error handling
-	useEffect(() => {
-		let unlisten: UnlistenFn | null = null;
-		let cancelled = false;
-
-		listen<QueryCompleted>("agent-query-completed", (event) => {
-			const info = event.payload;
-			const chatSessionId = info.chat_session_id;
-
-			if (chatSessionId) {
-				dispatch({
-					type: "STOP_STREAMING",
-					sessionId: chatSessionId,
-				});
-				dispatch({
-					type: "SET_SESSION_FINAL_STATE",
-					sessionId: chatSessionId,
-					state: info.exit_code === 0 ? "done" : "error",
-				});
+			// Turn completed (idle with exit_code): update session state and clear permissions
+			if (turn_phase === "idle" && exit_code != null) {
 				dispatch({
 					type: "SET_PENDING_PERMISSION",
-					sessionId: chatSessionId,
+					sessionId: chat_session_id,
 					request: null,
 				});
-			}
 
-			// Update session state
-			const session = activeSessionRef.current;
-			const newState: SessionState = info.exit_code === 0 ? "idle" : "error";
-			if (chatSessionId && session && session.id === chatSessionId) {
-				dispatch({ type: "UPDATE_SESSION_STATE", state: newState });
-			}
+				const session = activeSessionRef.current;
+				const newState: SessionState = exit_code === 0 ? "idle" : "error";
+				if (session && session.id === chat_session_id) {
+					dispatch({ type: "UPDATE_SESSION_STATE", state: newState });
+				}
 
-			if (chatSessionId) {
-				updateSessionState(chatSessionId, newState).catch((e) =>
+				updateSessionState(chat_session_id, newState).catch((e) =>
 					console.error("Failed to update session state:", e),
 				);
-			}
 
-			refreshSessions().catch((e) =>
-				console.error("Failed to refresh sessions:", e),
-			);
+				refreshSessions().catch((e) =>
+					console.error("Failed to refresh sessions:", e),
+				);
+			}
 		}).then((fn) => {
 			if (cancelled) {
 				fn();

--- a/src/hooks/useAgentSdkListeners.ts
+++ b/src/hooks/useAgentSdkListeners.ts
@@ -58,6 +58,11 @@ export interface AgentSdkListenerRefs {
 	activeSessionRef: MutableRefObject<ChatSession | null>;
 	userPermissionModeRef: MutableRefObject<PermissionMode>;
 	refreshSessions: () => Promise<unknown>;
+	pendingMessageRef: MutableRefObject<{
+		sessionId: string;
+		content: string;
+	} | null>;
+	startQuery: (sessionId: string, prompt: string) => Promise<void>;
 }
 
 function handleSupportedCommands(msg: SdkMessage): void {
@@ -195,8 +200,14 @@ function handleResultErrors(
 }
 
 export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
-	const { dispatch, activeSessionRef, userPermissionModeRef, refreshSessions } =
-		refs;
+	const {
+		dispatch,
+		activeSessionRef,
+		userPermissionModeRef,
+		refreshSessions,
+		pendingMessageRef,
+		startQuery,
+	} = refs;
 
 	// Listen to SDK messages for meta events (permissions, commands, system messages)
 	useEffect(() => {
@@ -293,6 +304,15 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 				refreshSessions().catch((e) =>
 					console.error("Failed to refresh sessions:", e),
 				);
+
+				// Consume pending message if queued (interrupt + new message flow)
+				const pending = pendingMessageRef.current;
+				if (pending && pending.sessionId === chat_session_id) {
+					pendingMessageRef.current = null;
+					startQuery(pending.sessionId, pending.content).catch((e) =>
+						console.error("Failed to start pending query:", e),
+					);
+				}
 			}
 		}).then((fn) => {
 			if (cancelled) {
@@ -306,5 +326,11 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 			cancelled = true;
 			unlisten?.();
 		};
-	}, [dispatch, activeSessionRef, refreshSessions]);
+	}, [
+		dispatch,
+		activeSessionRef,
+		refreshSessions,
+		pendingMessageRef,
+		startQuery,
+	]);
 }

--- a/src/hooks/useAgentSdkListeners.ts
+++ b/src/hooks/useAgentSdkListeners.ts
@@ -53,16 +53,20 @@ interface StreamingMessageUpdated {
 	parts: MessagePart[];
 }
 
+interface PendingMessageConsumed {
+	chat_session_id: string;
+	agent_message: {
+		id: string;
+		role: "agent";
+		timestamp: number;
+	};
+}
+
 export interface AgentSdkListenerRefs {
 	dispatch: Dispatch<AgentChatAction>;
 	activeSessionRef: MutableRefObject<ChatSession | null>;
 	userPermissionModeRef: MutableRefObject<PermissionMode>;
 	refreshSessions: () => Promise<unknown>;
-	pendingMessageRef: MutableRefObject<{
-		sessionId: string;
-		content: string;
-	} | null>;
-	startQuery: (sessionId: string, prompt: string) => Promise<void>;
 }
 
 function handleSupportedCommands(msg: SdkMessage): void {
@@ -200,14 +204,8 @@ function handleResultErrors(
 }
 
 export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
-	const {
-		dispatch,
-		activeSessionRef,
-		userPermissionModeRef,
-		refreshSessions,
-		pendingMessageRef,
-		startQuery,
-	} = refs;
+	const { dispatch, activeSessionRef, userPermissionModeRef, refreshSessions } =
+		refs;
 
 	// Listen to SDK messages for meta events (permissions, commands, system messages)
 	useEffect(() => {
@@ -304,15 +302,6 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 				refreshSessions().catch((e) =>
 					console.error("Failed to refresh sessions:", e),
 				);
-
-				// Consume pending message if queued (interrupt + new message flow)
-				const pending = pendingMessageRef.current;
-				if (pending && pending.sessionId === chat_session_id) {
-					pendingMessageRef.current = null;
-					startQuery(pending.sessionId, pending.content).catch((e) =>
-						console.error("Failed to start pending query:", e),
-					);
-				}
 			}
 		}).then((fn) => {
 			if (cancelled) {
@@ -326,11 +315,39 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 			cancelled = true;
 			unlisten?.();
 		};
-	}, [
-		dispatch,
-		activeSessionRef,
-		refreshSessions,
-		pendingMessageRef,
-		startQuery,
-	]);
+	}, [dispatch, activeSessionRef, refreshSessions]);
+
+	// Listen to agent-pending-message-consumed (Rust auto-consumed pending message after turn_complete)
+	useEffect(() => {
+		let unlisten: UnlistenFn | null = null;
+		let cancelled = false;
+
+		listen<PendingMessageConsumed>(
+			"agent-pending-message-consumed",
+			(event) => {
+				const { chat_session_id, agent_message } = event.payload;
+				if (activeSessionRef.current?.id !== chat_session_id) return;
+				dispatch({
+					type: "ADD_MESSAGE",
+					message: {
+						id: agent_message.id,
+						role: agent_message.role,
+						parts: [],
+						timestamp: agent_message.timestamp,
+					},
+				});
+			},
+		).then((fn) => {
+			if (cancelled) {
+				fn();
+			} else {
+				unlisten = fn;
+			}
+		});
+
+		return () => {
+			cancelled = true;
+			unlisten?.();
+		};
+	}, [dispatch, activeSessionRef]);
 }

--- a/src/hooks/useReviewExecution.test.ts
+++ b/src/hooks/useReviewExecution.test.ts
@@ -51,24 +51,20 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
 	};
 }
 
-function makeTask(filePath: string) {
-	return { file_path: filePath, prompt: `Review ${filePath}` };
+/** Emit a review-state-changed event via the captured listener */
+function emitReviewStateChanged(payload: {
+	status: string;
+	file_states: { file_path: string; status: string; pty_id: number | null }[];
+	progress: { done: number; total: number; error_count: number };
+}) {
+	const listener = capturedListeners.get("review-state-changed");
+	listener?.({ payload: payload as unknown as Record<string, unknown> });
 }
 
-/** Emit a pty-output event via the captured listener */
-function emitPtyOutput(pty_id: number, data: string) {
-	const listener = capturedListeners.get("pty-output");
-	listener?.({ payload: { pty_id, data } });
-}
-
-/** Emit a oneshot-pty-status-changed event via the captured listener */
-function emitPtyStatus(
-	pty_id: number,
-	status: string,
-	exit_code: number | null = null,
-) {
-	const listener = capturedListeners.get("oneshot-pty-status-changed");
-	listener?.({ payload: { pty_id, status, exit_code } });
+/** Emit a review-file-output event via the captured listener */
+function emitReviewFileOutput(file_path: string, data: string) {
+	const listener = capturedListeners.get("review-file-output");
+	listener?.({ payload: { file_path, data } });
 }
 
 // ---------------------------------------------------------------------------
@@ -79,8 +75,8 @@ describe("useReviewExecution", () => {
 	beforeEach(() => {
 		mockInvoke.mockReset();
 		capturedListeners = new Map();
-		// list_oneshot_ptys on mount (returns empty array = no recovery)
-		mockInvoke.mockResolvedValueOnce([]);
+		// get_review_status on mount (returns null = no active session)
+		mockInvoke.mockResolvedValueOnce(null);
 		mockInvoke.mockResolvedValue(undefined);
 	});
 
@@ -107,40 +103,50 @@ describe("useReviewExecution", () => {
 		expect(result.current.fileStates).toEqual([]);
 	});
 
-	it("should transition to running on successful startReview", async () => {
-		const tasks = [makeTask("src/a.ts")];
-		mockInvoke
-			.mockResolvedValueOnce(tasks) // get_per_file_review_tasks
-			.mockResolvedValueOnce({
-				// spawn_oneshot_pty
-				pty_id: 42,
-				session_key: "sess-1",
-				status: "running",
-			});
+	it("should call start_review on startReview", async () => {
+		// start_review returns session id
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result } = await renderReviewHook();
 
 		await act(async () => {
 			await result.current.startReview();
+		});
+
+		expect(mockInvoke).toHaveBeenCalledWith(
+			"start_review",
+			expect.objectContaining({
+				worktreePath: WORKTREE,
+				commandTemplate: expect.any(String),
+				concurrency: 5,
+			}),
+		);
+	});
+
+	it("should transition to running when Rust emits running state", async () => {
+		mockInvoke.mockResolvedValueOnce("session-1");
+
+		const { result } = await renderReviewHook();
+
+		await act(async () => {
+			await result.current.startReview();
+		});
+
+		act(() => {
+			emitReviewStateChanged({
+				status: "running",
+				file_states: [{ file_path: "src/a.ts", status: "running", pty_id: 42 }],
+				progress: { done: 0, total: 1, error_count: 0 },
+			});
 		});
 
 		expect(result.current.status).toBe("running");
 		expect(result.current.fileStates.length).toBe(1);
 		expect(result.current.fileStates[0].filePath).toBe("src/a.ts");
-		expect(mockInvoke).toHaveBeenCalledWith("get_per_file_review_tasks", {
-			worktreePath: WORKTREE,
-		});
-		expect(mockInvoke).toHaveBeenCalledWith(
-			"spawn_oneshot_pty",
-			expect.objectContaining({
-				worktreePath: WORKTREE,
-				label: "review:src/a.ts",
-			}),
-		);
 	});
 
-	it("should set error status when get_per_file_review_tasks fails", async () => {
-		mockInvoke.mockRejectedValueOnce(new Error("task fail"));
+	it("should set error status when start_review invoke fails", async () => {
+		mockInvoke.mockRejectedValueOnce(new Error("start fail"));
 
 		const { result } = await renderReviewHook();
 
@@ -148,24 +154,6 @@ describe("useReviewExecution", () => {
 			await result.current.startReview();
 		});
 
-		expect(result.current.status).toBe("error");
-	});
-
-	it("should set error status when spawn_oneshot_pty fails", async () => {
-		mockInvoke
-			.mockResolvedValueOnce([makeTask("src/a.ts")]) // get_per_file_review_tasks
-			.mockRejectedValueOnce(new Error("spawn fail")); // spawn_oneshot_pty
-
-		const { result } = await renderReviewHook();
-
-		await act(async () => {
-			await result.current.startReview();
-		});
-
-		// spawnNextTask is async, wait for it to complete
-		await act(async () => {});
-
-		// Single file failed → all done → error
 		expect(result.current.status).toBe("error");
 	});
 
@@ -177,17 +165,15 @@ describe("useReviewExecution", () => {
 		});
 
 		expect(result.current.status).toBe("idle");
-		// Only the mount-time list_oneshot_ptys (which didn't fire for null path)
+		// start_review should not have been called
+		const startCalls = mockInvoke.mock.calls.filter(
+			(c) => c[0] === "start_review",
+		);
+		expect(startCalls).toHaveLength(0);
 	});
 
-	it("should accumulate pty output per file", async () => {
-		mockInvoke
-			.mockResolvedValueOnce([makeTask("src/a.ts")])
-			.mockResolvedValueOnce({
-				pty_id: 10,
-				session_key: "s",
-				status: "running",
-			});
+	it("should accumulate file output per file", async () => {
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result } = await renderReviewHook();
 
@@ -195,11 +181,20 @@ describe("useReviewExecution", () => {
 			await result.current.startReview();
 		});
 
+		// Rust emits running state with file
 		act(() => {
-			emitPtyOutput(10, "hello ");
+			emitReviewStateChanged({
+				status: "running",
+				file_states: [{ file_path: "src/a.ts", status: "running", pty_id: 10 }],
+				progress: { done: 0, total: 1, error_count: 0 },
+			});
+		});
+
+		act(() => {
+			emitReviewFileOutput("src/a.ts", "hello ");
 		});
 		act(() => {
-			emitPtyOutput(10, "world");
+			emitReviewFileOutput("src/a.ts", "world");
 		});
 
 		const fileState = result.current.fileStates.find(
@@ -208,14 +203,8 @@ describe("useReviewExecution", () => {
 		expect(fileState?.output).toBe("hello world");
 	});
 
-	it("should transition to completed when all files done", async () => {
-		mockInvoke
-			.mockResolvedValueOnce([makeTask("src/a.ts")])
-			.mockResolvedValueOnce({
-				pty_id: 10,
-				session_key: "s",
-				status: "running",
-			});
+	it("should transition to completed via event", async () => {
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result } = await renderReviewHook();
 
@@ -224,21 +213,27 @@ describe("useReviewExecution", () => {
 		});
 
 		act(() => {
-			emitPtyStatus(10, "completed", 0);
+			emitReviewStateChanged({
+				status: "running",
+				file_states: [{ file_path: "src/a.ts", status: "running", pty_id: 10 }],
+				progress: { done: 0, total: 1, error_count: 0 },
+			});
+		});
+
+		act(() => {
+			emitReviewStateChanged({
+				status: "completed",
+				file_states: [{ file_path: "src/a.ts", status: "done", pty_id: 10 }],
+				progress: { done: 1, total: 1, error_count: 0 },
+			});
 		});
 
 		expect(result.current.status).toBe("completed");
 		expect(result.current.progress).toEqual({ done: 1, total: 1 });
 	});
 
-	it("should transition to error on timeout status", async () => {
-		mockInvoke
-			.mockResolvedValueOnce([makeTask("src/a.ts")])
-			.mockResolvedValueOnce({
-				pty_id: 10,
-				session_key: "s",
-				status: "running",
-			});
+	it("should transition to error via event when error_count > 0", async () => {
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result } = await renderReviewHook();
 
@@ -247,20 +242,18 @@ describe("useReviewExecution", () => {
 		});
 
 		act(() => {
-			emitPtyStatus(10, "timeout");
+			emitReviewStateChanged({
+				status: "error",
+				file_states: [{ file_path: "src/a.ts", status: "error", pty_id: 10 }],
+				progress: { done: 1, total: 1, error_count: 1 },
+			});
 		});
 
 		expect(result.current.status).toBe("error");
 	});
 
-	it("should cancel all running PTYs on cancelReview", async () => {
-		mockInvoke
-			.mockResolvedValueOnce([makeTask("src/a.ts")])
-			.mockResolvedValueOnce({
-				pty_id: 10,
-				session_key: "s",
-				status: "running",
-			});
+	it("should call cancel_review on cancelReview", async () => {
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result } = await renderReviewHook();
 
@@ -272,25 +265,58 @@ describe("useReviewExecution", () => {
 			await result.current.cancelReview();
 		});
 
-		expect(mockInvoke).toHaveBeenCalledWith("cancel_oneshot_pty", {
-			ptyId: 10,
+		expect(mockInvoke).toHaveBeenCalledWith("cancel_review", {
+			reviewSessionId: WORKTREE,
 		});
-		expect(result.current.status).toBe("cancelled");
 	});
 
-	it("should reset to idle", async () => {
-		mockInvoke
-			.mockResolvedValueOnce([makeTask("src/a.ts")])
-			.mockResolvedValueOnce({
-				pty_id: 10,
-				session_key: "s",
-				status: "running",
-			});
+	it("should transition to cancelled via event after cancel", async () => {
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result } = await renderReviewHook();
 
 		await act(async () => {
 			await result.current.startReview();
+		});
+
+		act(() => {
+			emitReviewStateChanged({
+				status: "running",
+				file_states: [{ file_path: "src/a.ts", status: "running", pty_id: 10 }],
+				progress: { done: 0, total: 1, error_count: 0 },
+			});
+		});
+
+		await act(async () => {
+			await result.current.cancelReview();
+		});
+
+		act(() => {
+			emitReviewStateChanged({
+				status: "cancelled",
+				file_states: [{ file_path: "src/a.ts", status: "error", pty_id: 10 }],
+				progress: { done: 0, total: 1, error_count: 0 },
+			});
+		});
+
+		expect(result.current.status).toBe("cancelled");
+	});
+
+	it("should reset to idle", async () => {
+		mockInvoke.mockResolvedValueOnce("session-1");
+
+		const { result } = await renderReviewHook();
+
+		await act(async () => {
+			await result.current.startReview();
+		});
+
+		act(() => {
+			emitReviewStateChanged({
+				status: "running",
+				file_states: [{ file_path: "src/a.ts", status: "running", pty_id: 10 }],
+				progress: { done: 0, total: 1, error_count: 0 },
+			});
 		});
 
 		expect(result.current.status).toBe("running");
@@ -301,22 +327,13 @@ describe("useReviewExecution", () => {
 
 		expect(result.current.status).toBe("idle");
 		expect(result.current.fileStates).toEqual([]);
+		expect(mockInvoke).toHaveBeenCalledWith("reset_review", {
+			reviewSessionId: WORKTREE,
+		});
 	});
 
 	it("should track progress across multiple files", async () => {
-		const tasks = [makeTask("src/a.ts"), makeTask("src/b.ts")];
-		mockInvoke
-			.mockResolvedValueOnce(tasks)
-			.mockResolvedValueOnce({
-				pty_id: 10,
-				session_key: "s1",
-				status: "running",
-			})
-			.mockResolvedValueOnce({
-				pty_id: 11,
-				session_key: "s2",
-				status: "running",
-			});
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result } = await renderReviewHook();
 
@@ -324,17 +341,42 @@ describe("useReviewExecution", () => {
 			await result.current.startReview();
 		});
 
+		act(() => {
+			emitReviewStateChanged({
+				status: "running",
+				file_states: [
+					{ file_path: "src/a.ts", status: "running", pty_id: 10 },
+					{ file_path: "src/b.ts", status: "pending", pty_id: null },
+				],
+				progress: { done: 0, total: 2, error_count: 0 },
+			});
+		});
+
 		expect(result.current.progress).toEqual({ done: 0, total: 2 });
 
 		act(() => {
-			emitPtyStatus(10, "completed", 0);
+			emitReviewStateChanged({
+				status: "running",
+				file_states: [
+					{ file_path: "src/a.ts", status: "done", pty_id: 10 },
+					{ file_path: "src/b.ts", status: "running", pty_id: 11 },
+				],
+				progress: { done: 1, total: 2, error_count: 0 },
+			});
 		});
 
 		expect(result.current.progress?.done).toBe(1);
 		expect(result.current.status).toBe("running");
 
 		act(() => {
-			emitPtyStatus(11, "completed", 0);
+			emitReviewStateChanged({
+				status: "completed",
+				file_states: [
+					{ file_path: "src/a.ts", status: "done", pty_id: 10 },
+					{ file_path: "src/b.ts", status: "done", pty_id: 11 },
+				],
+				progress: { done: 2, total: 2, error_count: 0 },
+			});
 		});
 
 		expect(result.current.progress).toEqual({ done: 2, total: 2 });
@@ -342,19 +384,7 @@ describe("useReviewExecution", () => {
 	});
 
 	it("should complete with error if any file fails", async () => {
-		const tasks = [makeTask("src/a.ts"), makeTask("src/b.ts")];
-		mockInvoke
-			.mockResolvedValueOnce(tasks)
-			.mockResolvedValueOnce({
-				pty_id: 10,
-				session_key: "s1",
-				status: "running",
-			})
-			.mockResolvedValueOnce({
-				pty_id: 11,
-				session_key: "s2",
-				status: "running",
-			});
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result } = await renderReviewHook();
 
@@ -363,10 +393,14 @@ describe("useReviewExecution", () => {
 		});
 
 		act(() => {
-			emitPtyStatus(10, "completed", 0);
-		});
-		act(() => {
-			emitPtyStatus(11, "error");
+			emitReviewStateChanged({
+				status: "error",
+				file_states: [
+					{ file_path: "src/a.ts", status: "done", pty_id: 10 },
+					{ file_path: "src/b.ts", status: "error", pty_id: 11 },
+				],
+				progress: { done: 2, total: 2, error_count: 1 },
+			});
 		});
 
 		expect(result.current.status).toBe("error");
@@ -382,8 +416,9 @@ describe("useReviewExecution", () => {
 		expect(bState?.status).toBe("error");
 	});
 
-	it("should handle empty task list as completed", async () => {
-		mockInvoke.mockResolvedValueOnce([]); // no changed files
+	it("should handle no-tasks as completed with empty summary", async () => {
+		// start_review returns null (no tasks to review)
+		mockInvoke.mockResolvedValueOnce(null);
 
 		const { result } = await renderReviewHook();
 
@@ -424,13 +459,7 @@ describe("useReviewExecution", () => {
 			}),
 		];
 
-		mockInvoke
-			.mockResolvedValueOnce([makeTask("src/a.ts")])
-			.mockResolvedValueOnce({
-				pty_id: 10,
-				session_key: "s",
-				status: "running",
-			});
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result, rerender } = await renderReviewHook(WORKTREE, []);
 
@@ -438,11 +467,15 @@ describe("useReviewExecution", () => {
 			await result.current.startReview();
 		});
 
-		// Provide threads and complete
+		// Provide threads and complete via event
 		rerender({ wt: WORKTREE, threads });
 
 		act(() => {
-			emitPtyStatus(10, "completed", 0);
+			emitReviewStateChanged({
+				status: "completed",
+				file_states: [{ file_path: "src/a.ts", status: "done", pty_id: 10 }],
+				progress: { done: 1, total: 1, error_count: 0 },
+			});
 		});
 
 		// Wait for summary computation useEffect
@@ -465,18 +498,17 @@ describe("useReviewExecution", () => {
 		);
 		await act(async () => {});
 
-		// get_per_file_review_tasks returns tasks but buildReviewCommand returns null
-		mockInvoke.mockResolvedValueOnce([makeTask("src/a.ts")]);
-
 		await act(async () => {
 			await result.current.startReview();
 		});
 
-		// spawnNextTask is async (uses ref), wait for it to complete
-		await act(async () => {});
-
-		// All tasks fail (buildReviewCommand returns null for "none") → error
+		// buildReviewCommandTemplate returns null for "none" → error
 		expect(result.current.status).toBe("error");
+		// start_review should not have been called
+		const startCalls = mockInvoke.mock.calls.filter(
+			(c) => c[0] === "start_review",
+		);
+		expect(startCalls).toHaveLength(0);
 	});
 
 	// -----------------------------------------------------------------------
@@ -485,15 +517,11 @@ describe("useReviewExecution", () => {
 
 	it("should restore running review on mount", async () => {
 		mockInvoke.mockReset();
-		mockInvoke.mockResolvedValueOnce([
-			{
-				pty_id: 100,
-				label: "review:src/a.ts",
-				status: "running",
-				started_at: 1000,
-				buffered_output: "partial output",
-			},
-		]);
+		mockInvoke.mockResolvedValueOnce({
+			status: "running",
+			file_states: [{ file_path: "src/a.ts", status: "running", pty_id: 100 }],
+			progress: { done: 0, total: 1, error_count: 0 },
+		});
 		mockInvoke.mockResolvedValue(undefined);
 
 		const { result } = await renderReviewHook();
@@ -501,135 +529,56 @@ describe("useReviewExecution", () => {
 		expect(result.current.status).toBe("running");
 		expect(result.current.fileStates.length).toBe(1);
 		expect(result.current.fileStates[0].filePath).toBe("src/a.ts");
-		expect(result.current.fileStates[0].output).toBe("partial output");
+		expect(result.current.fileStates[0].status).toBe("running");
 	});
 
 	it("should restore completed review on mount", async () => {
 		mockInvoke.mockReset();
-		mockInvoke.mockResolvedValueOnce([
-			{
-				pty_id: 200,
-				label: "review:src/b.ts",
-				status: "completed",
-				started_at: 2000,
-				buffered_output: "done output",
-			},
-		]);
+		mockInvoke.mockResolvedValueOnce({
+			status: "completed",
+			file_states: [{ file_path: "src/b.ts", status: "done", pty_id: 200 }],
+			progress: { done: 1, total: 1, error_count: 0 },
+		});
 		mockInvoke.mockResolvedValue(undefined);
 
 		const { result } = await renderReviewHook();
 
 		expect(result.current.status).toBe("completed");
 		expect(result.current.fileStates[0].status).toBe("done");
-		expect(result.current.fileStates[0].output).toBe("done output");
 	});
 
 	it("should stay idle when no review found on mount", async () => {
-		// Default beforeEach already returns [] for list_oneshot_ptys
+		// Default beforeEach already returns null for get_review_status
 		const { result } = await renderReviewHook();
 
 		expect(result.current.status).toBe("idle");
 		expect(result.current.fileStates).toEqual([]);
 	});
 
-	it("should prevent double start", async () => {
-		let resolveTasks = (_v: unknown) => {};
-		mockInvoke.mockReturnValueOnce(
-			new Promise((r) => {
-				resolveTasks = r;
-			}),
-		);
+	it("should stay idle when get_review_status returns idle status", async () => {
+		mockInvoke.mockReset();
+		mockInvoke.mockResolvedValueOnce({
+			status: "idle",
+			file_states: [],
+			progress: { done: 0, total: 0, error_count: 0 },
+		});
+		mockInvoke.mockResolvedValue(undefined);
 
 		const { result } = await renderReviewHook();
 
-		// Start first review (still pending)
-		act(() => {
-			result.current.startReview();
-		});
-
-		// Try to start second review while first is pending
-		act(() => {
-			result.current.startReview();
-		});
-
-		// Resolve the first
-		await act(async () => {
-			resolveTasks([]);
-		});
-
-		// get_per_file_review_tasks should only be called once
-		const taskCalls = mockInvoke.mock.calls.filter(
-			(c) => c[0] === "get_per_file_review_tasks",
-		);
-		expect(taskCalls.length).toBe(1);
+		expect(result.current.status).toBe("idle");
 	});
 
-	it("should spawn next task from queue when one completes (concurrency control)", async () => {
-		const concurrencySettings = { ...SETTINGS, reviewConcurrency: 1 };
-		const { useReviewExecution } = await import("./useReviewExecution");
+	it("should not register listeners when worktreePath is null", async () => {
+		await renderReviewHook(null);
 
-		// Reset mock for this specific test
-		mockInvoke.mockReset();
-		mockInvoke.mockResolvedValueOnce([]); // list_oneshot_ptys on mount
-		mockInvoke.mockResolvedValue(undefined); // default for cleanup/cancel calls
-
-		const tasks = [makeTask("src/a.ts"), makeTask("src/b.ts")];
-
-		mockInvoke
-			.mockResolvedValueOnce(tasks) // get_per_file_review_tasks
-			.mockResolvedValueOnce({
-				// spawn first
-				pty_id: 10,
-				session_key: "s1",
-				status: "running",
-			});
-
-		const { result } = renderHook(() =>
-			useReviewExecution(WORKTREE, [], concurrencySettings),
-		);
-		await act(async () => {});
-
-		await act(async () => {
-			await result.current.startReview();
-		});
-
-		// Only first file should be running (concurrency = 1)
-		expect(result.current.fileStates[0].status).toBe("running");
-		expect(result.current.fileStates[1].status).toBe("pending");
-
-		// Complete first → should spawn second
-		mockInvoke.mockResolvedValueOnce({
-			pty_id: 11,
-			session_key: "s2",
-			status: "running",
-		});
-
-		await act(async () => {
-			emitPtyStatus(10, "completed", 0);
-		});
-
-		// Wait for spawn
-		await act(async () => {});
-
-		expect(result.current.fileStates[0].status).toBe("done");
-		expect(
-			mockInvoke.mock.calls.filter((c) => c[0] === "spawn_oneshot_pty").length,
-		).toBe(2);
+		// No listeners should be registered for review events
+		expect(capturedListeners.has("review-state-changed")).toBe(false);
+		expect(capturedListeners.has("review-file-output")).toBe(false);
 	});
 
-	it("should not cancel PTYs on unmount (keep running for recovery)", async () => {
-		mockInvoke
-			.mockResolvedValueOnce([makeTask("src/a.ts"), makeTask("src/b.ts")])
-			.mockResolvedValueOnce({
-				pty_id: 50,
-				session_key: "s1",
-				status: "running",
-			})
-			.mockResolvedValueOnce({
-				pty_id: 51,
-				session_key: "s2",
-				status: "running",
-			});
+	it("should not update state after unmount", async () => {
+		mockInvoke.mockResolvedValueOnce("session-1");
 
 		const { result, unmount } = await renderReviewHook();
 
@@ -637,41 +586,60 @@ describe("useReviewExecution", () => {
 			await result.current.startReview();
 		});
 
-		expect(result.current.status).toBe("running");
-
-		// Clear mock to isolate unmount calls
-		mockInvoke.mockClear();
-		mockInvoke.mockResolvedValue(undefined);
-
-		unmount();
-
-		// PTYs should NOT be cancelled — they keep running for mount-time recovery
-		const cancelCalls = mockInvoke.mock.calls.filter(
-			(c) => c[0] === "cancel_oneshot_pty",
-		);
-		expect(cancelCalls).toHaveLength(0);
-	});
-
-	it("should not update state after unmount via syncState", async () => {
-		mockInvoke
-			.mockResolvedValueOnce([makeTask("src/a.ts")])
-			.mockResolvedValueOnce({
-				pty_id: 60,
-				session_key: "s",
+		act(() => {
+			emitReviewStateChanged({
 				status: "running",
+				file_states: [{ file_path: "src/a.ts", status: "running", pty_id: 60 }],
+				progress: { done: 0, total: 1, error_count: 0 },
 			});
-
-		const { result, unmount } = await renderReviewHook();
-
-		await act(async () => {
-			await result.current.startReview();
 		});
 
 		unmount();
 
 		// Emitting events after unmount should not throw
 		expect(() => {
-			emitPtyStatus(60, "completed", 0);
+			emitReviewStateChanged({
+				status: "completed",
+				file_states: [{ file_path: "src/a.ts", status: "done", pty_id: 60 }],
+				progress: { done: 1, total: 1, error_count: 0 },
+			});
 		}).not.toThrow();
+	});
+
+	it("should preserve output on state change events", async () => {
+		mockInvoke.mockResolvedValueOnce("session-1");
+
+		const { result } = await renderReviewHook();
+
+		await act(async () => {
+			await result.current.startReview();
+		});
+
+		// Rust emits running state
+		act(() => {
+			emitReviewStateChanged({
+				status: "running",
+				file_states: [{ file_path: "src/a.ts", status: "running", pty_id: 10 }],
+				progress: { done: 0, total: 1, error_count: 0 },
+			});
+		});
+
+		// Output arrives
+		act(() => {
+			emitReviewFileOutput("src/a.ts", "some output");
+		});
+
+		expect(result.current.fileStates[0].output).toBe("some output");
+
+		// State changes again (e.g., file completes) — output should be preserved
+		act(() => {
+			emitReviewStateChanged({
+				status: "completed",
+				file_states: [{ file_path: "src/a.ts", status: "done", pty_id: 10 }],
+				progress: { done: 1, total: 1, error_count: 0 },
+			});
+		});
+
+		expect(result.current.fileStates[0].output).toBe("some output");
 	});
 });

--- a/src/hooks/useReviewExecution.ts
+++ b/src/hooks/useReviewExecution.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { type AppSettings, buildReviewCommand } from "@/types/settings";
+import { type AppSettings, buildReviewCommandTemplate } from "@/types/settings";
 import type { Thread } from "@/types/thread";
 import { getThreadOrigin } from "@/types/thread";
 
@@ -15,7 +15,6 @@ export interface ReviewSummary {
 
 export type ReviewStatus =
 	| "idle"
-	| "starting"
 	| "running"
 	| "completed"
 	| "error"
@@ -30,14 +29,27 @@ export interface FileReviewState {
 	output: string;
 }
 
-interface PerFileReviewTask {
+interface ReviewStateChanged {
+	status: ReviewStatus;
+	file_states: {
+		file_path: string;
+		status: FileReviewStatus;
+		pty_id: number | null;
+	}[];
+	progress: {
+		done: number;
+		total: number;
+		error_count: number;
+	};
+}
+
+interface ReviewFileOutput {
 	file_path: string;
-	prompt: string;
+	data: string;
 }
 
 export interface ReviewExecutionState {
 	status: ReviewStatus;
-	ptyIds: Set<number>;
 	progress: { done: number; total: number } | null;
 	summary: ReviewSummary | null;
 	fileStates: FileReviewState[];
@@ -50,361 +62,95 @@ export function useReviewExecution(
 ) {
 	const [state, setState] = useState<ReviewExecutionState>({
 		status: "idle",
-		ptyIds: new Set(),
 		progress: null,
 		summary: null,
 		fileStates: [],
 	});
 
 	const reviewStartTimeRef = useRef(0);
-	const prevStatusRef = useRef<ReviewStatus>("idle");
-
-	// Mutable refs for concurrency control
-	const ptyIdSetRef = useRef<Set<number>>(new Set());
-	const fileStatesRef = useRef<FileReviewState[]>([]);
-	const taskQueueRef = useRef<PerFileReviewTask[]>([]);
-	const activeCountRef = useRef(0);
-	const doneCountRef = useRef(0);
-	const totalCountRef = useRef(0);
-	const errorCountRef = useRef(0);
-	const runTokenRef = useRef(0);
-	const startInFlightRef = useRef(false);
-	const concurrencyRef = useRef(5);
-	const mountedRef = useRef(true);
-
-	// Per-file output buffers (for PTY output arriving before ptyId is confirmed)
-	const pendingOutputRef = useRef<Map<number, string>>(new Map());
-	const pendingStatusRef = useRef<
-		Map<number, { status: string; exit_code: number | null }>
-	>(new Map());
-	// Map pty_id → runToken so events use the correct token (not the current one)
-	const ptyRunTokenMapRef = useRef<Map<number, number>>(new Map());
-
-	// Stable refs for settings to avoid circular useCallback dependencies
-	const worktreePathRef = useRef(worktreePath);
-	worktreePathRef.current = worktreePath;
 	const settingsRef = useRef(settings);
 	settingsRef.current = settings;
+	const fileOutputRef = useRef<Map<string, string>>(new Map());
 
-	// Prevent state updates after unmount (PTYs keep running for recovery)
+	// Listen for review state changes from Rust orchestrator
 	useEffect(() => {
-		return () => {
-			mountedRef.current = false;
-		};
-	}, []);
+		if (!worktreePath) return;
 
-	const syncState = useCallback(() => {
-		if (!mountedRef.current) return;
-		const allDone =
-			totalCountRef.current > 0 &&
-			doneCountRef.current >= totalCountRef.current;
-		setState((prev) => ({
-			...prev,
-			...(allDone
-				? { status: errorCountRef.current > 0 ? "error" : "completed" }
-				: {}),
-			ptyIds: new Set(ptyIdSetRef.current),
-			progress: {
-				done: doneCountRef.current,
-				total: totalCountRef.current,
-			},
-			fileStates: [...fileStatesRef.current],
-		}));
-	}, []);
-
-	// Use refs to break circular dependency between spawnNextTask and handlePtyFinished
-	const spawnNextTaskRef = useRef<(runToken: number) => void>(() => {});
-	const handlePtyFinishedRef = useRef<
-		(ptyId: number, status: string, runToken: number) => void
-	>(() => {});
-
-	const spawnNextTask = useCallback(
-		async (runToken: number) => {
-			const wt = worktreePathRef.current;
-			if (!wt) return;
-			if (runTokenRef.current !== runToken) return;
-
-			const task = taskQueueRef.current.shift();
-			if (!task) return;
-
-			activeCountRef.current++;
-
-			const fileIdx = fileStatesRef.current.findIndex(
-				(f) => f.filePath === task.file_path,
-			);
-
-			const command = buildReviewCommand(settingsRef.current, task.prompt);
-			if (!command) {
-				if (fileIdx >= 0) {
-					fileStatesRef.current[fileIdx] = {
-						...fileStatesRef.current[fileIdx],
-						status: "error",
-					};
-				}
-				activeCountRef.current--;
-				doneCountRef.current++;
-				errorCountRef.current++;
-				syncState();
-				spawnNextTaskRef.current(runToken);
-				return;
-			}
-
-			try {
-				const info = await invoke<{
-					pty_id: number;
-					session_key: string;
-					status: string;
-				}>("spawn_oneshot_pty", {
-					command,
-					worktreePath: wt,
-					label: `review:${task.file_path}`,
-					timeoutSecs: null,
-				});
-
-				if (!mountedRef.current) return;
-
-				if (runTokenRef.current !== runToken) {
-					activeCountRef.current = Math.max(0, activeCountRef.current - 1);
-					// Token changed — cancel the orphaned PTY
-					invoke("cancel_oneshot_pty", { ptyId: info.pty_id }).catch(() => {});
-					return;
-				}
-
-				ptyIdSetRef.current.add(info.pty_id);
-				ptyRunTokenMapRef.current.set(info.pty_id, runToken);
-
-				if (fileIdx >= 0) {
-					fileStatesRef.current[fileIdx] = {
-						...fileStatesRef.current[fileIdx],
-						status: "running",
-						ptyId: info.pty_id,
-					};
-				}
-
-				// Flush pending output
-				const buffered = pendingOutputRef.current.get(info.pty_id);
-				if (buffered && fileIdx >= 0) {
-					fileStatesRef.current[fileIdx] = {
-						...fileStatesRef.current[fileIdx],
-						output: fileStatesRef.current[fileIdx].output + buffered,
-					};
-				}
-				pendingOutputRef.current.delete(info.pty_id);
-
-				// Flush pending status if process already finished
-				const pendingStatus = pendingStatusRef.current.get(info.pty_id);
-				if (pendingStatus) {
-					pendingStatusRef.current.delete(info.pty_id);
-					handlePtyFinishedRef.current(
-						info.pty_id,
-						pendingStatus.status,
-						runToken,
-					);
-				}
-
-				syncState();
-			} catch {
-				if (fileIdx >= 0) {
-					fileStatesRef.current[fileIdx] = {
-						...fileStatesRef.current[fileIdx],
-						status: "error",
-					};
-				}
-				activeCountRef.current--;
-				doneCountRef.current++;
-				errorCountRef.current++;
-				syncState();
-				spawnNextTaskRef.current(runToken);
-			}
-		},
-		[syncState],
-	);
-
-	const handlePtyFinished = useCallback(
-		(ptyId: number, status: string, runToken: number) => {
-			if (runTokenRef.current !== runToken) return;
-
-			ptyIdSetRef.current.delete(ptyId);
-			ptyRunTokenMapRef.current.delete(ptyId);
-			pendingStatusRef.current.delete(ptyId);
-			pendingOutputRef.current.delete(ptyId);
-
-			const fileIdx = fileStatesRef.current.findIndex((f) => f.ptyId === ptyId);
-			if (fileIdx < 0) return;
-
-			const isError =
-				status === "error" || status === "timeout" || status === "cancelled";
-			fileStatesRef.current[fileIdx] = {
-				...fileStatesRef.current[fileIdx],
-				status: isError ? "error" : "done",
-			};
-
-			activeCountRef.current--;
-			doneCountRef.current++;
-			if (isError) errorCountRef.current++;
-
-			syncState();
-			if (doneCountRef.current < totalCountRef.current) {
-				spawnNextTaskRef.current(runToken);
-			}
-		},
-		[syncState],
-	);
-
-	// Keep refs in sync
-	spawnNextTaskRef.current = spawnNextTask;
-	handlePtyFinishedRef.current = handlePtyFinished;
-
-	// Listen for oneshot PTY status changes
-	useEffect(() => {
-		const unlisten = listen<{
-			pty_id: number;
-			status: string;
-			exit_code: number | null;
-		}>("oneshot-pty-status-changed", (event) => {
-			if (!mountedRef.current) return;
-			const { pty_id, status } = event.payload;
-
-			const isTerminal =
-				status === "completed" ||
-				status === "error" ||
-				status === "timeout" ||
-				status === "cancelled";
-
-			if (!isTerminal) return;
-
-			// Check if this pty_id belongs to our review session
-			if (ptyIdSetRef.current.has(pty_id)) {
-				const token =
-					ptyRunTokenMapRef.current.get(pty_id) ?? runTokenRef.current;
-				ptyRunTokenMapRef.current.delete(pty_id);
-				handlePtyFinishedRef.current(pty_id, status, token);
-			} else if (activeCountRef.current > 0 || startInFlightRef.current) {
-				// Buffer it - might arrive before spawn returns
-				pendingStatusRef.current.set(pty_id, {
-					status,
-					exit_code: event.payload.exit_code,
-				});
-			}
-		});
-
-		return () => {
-			unlisten.then((f) => f());
-		};
-	}, []);
-
-	// Capture PTY output per-file
-	useEffect(() => {
-		const unlisten = listen<{ pty_id: number; data: string }>(
-			"pty-output",
+		const unlisten = listen<ReviewStateChanged>(
+			"review-state-changed",
 			(event) => {
-				if (!mountedRef.current) return;
-				const { pty_id, data } = event.payload;
-
-				const fileIdx = fileStatesRef.current.findIndex(
-					(f) => f.ptyId === pty_id,
-				);
-				if (fileIdx >= 0) {
-					fileStatesRef.current[fileIdx] = {
-						...fileStatesRef.current[fileIdx],
-						output: fileStatesRef.current[fileIdx].output + data,
-					};
-					setState((prev) => ({
-						...prev,
-						fileStates: [...fileStatesRef.current],
-					}));
-				} else if (activeCountRef.current > 0 || startInFlightRef.current) {
-					// Buffer output for PTY IDs we haven't matched yet
-					const buf = pendingOutputRef.current.get(pty_id) ?? "";
-					pendingOutputRef.current.set(pty_id, buf + data);
-				}
+				const { status, file_states, progress } = event.payload;
+				setState((prev) => ({
+					...prev,
+					status,
+					progress: { done: progress.done, total: progress.total },
+					fileStates: file_states.map((f) => ({
+						filePath: f.file_path,
+						status: f.status,
+						ptyId: f.pty_id,
+						output: fileOutputRef.current.get(f.file_path) ?? "",
+					})),
+				}));
 			},
 		);
 
 		return () => {
 			unlisten.then((f) => f());
 		};
-	}, []);
+	}, [worktreePath]);
 
-	// Mount-time recovery: find running review PTYs
+	// Listen for per-file output from Rust orchestrator
 	useEffect(() => {
 		if (!worktreePath) return;
 
-		const token = runTokenRef.current;
+		const unlisten = listen<ReviewFileOutput>("review-file-output", (event) => {
+			const { file_path, data } = event.payload;
+			const current = fileOutputRef.current.get(file_path) ?? "";
+			fileOutputRef.current.set(file_path, current + data);
+
+			setState((prev) => ({
+				...prev,
+				fileStates: prev.fileStates.map((f) =>
+					f.filePath === file_path
+						? {
+								...f,
+								output: fileOutputRef.current.get(file_path) ?? "",
+							}
+						: f,
+				),
+			}));
+		});
+
+		return () => {
+			unlisten.then((f) => f());
+		};
+	}, [worktreePath]);
+
+	// Mount-time recovery: check if Rust has an active review session
+	useEffect(() => {
+		if (!worktreePath) return;
 		let active = true;
 
-		invoke<
-			{
-				pty_id: number;
-				label: string;
-				status: string;
-				started_at: number;
-				buffered_output: string;
-			}[]
-		>("list_oneshot_ptys", { worktreePath })
-			.then((sessions) => {
-				if (!active || runTokenRef.current !== token) return;
-
-				const reviewSessions = sessions.filter((s) =>
-					s.label.startsWith("review:"),
-				);
-				if (reviewSessions.length === 0) return;
-
-				const minStartedAt = Math.min(
-					...reviewSessions.map((s) => s.started_at),
-				);
-				reviewStartTimeRef.current = minStartedAt * 1000;
-
-				const fileStates: FileReviewState[] = reviewSessions.map((s) => {
-					const filePath = s.label.replace("review:", "");
-					const statusMap: Record<string, FileReviewStatus> = {
-						starting: "running",
-						running: "running",
-						completed: "done",
-						error: "error",
-						timeout: "error",
-						cancelled: "error",
-					};
-					return {
-						filePath,
-						status: statusMap[s.status] ?? "pending",
-						ptyId: s.pty_id,
-						output: s.buffered_output,
-					};
-				});
-
-				const ptyIds = new Set(reviewSessions.map((s) => s.pty_id));
-				const doneCount = fileStates.filter(
-					(f) => f.status === "done" || f.status === "error",
-				).length;
-				const hasRunning = fileStates.some((f) => f.status === "running");
-
-				ptyIdSetRef.current = ptyIds;
-				fileStatesRef.current = fileStates;
-				totalCountRef.current = fileStates.length;
-				doneCountRef.current = doneCount;
-				activeCountRef.current = fileStates.filter(
-					(f) => f.status === "running",
-				).length;
-				errorCountRef.current = fileStates.filter(
-					(f) => f.status === "error",
-				).length;
-
-				const hasError = fileStates.some((f) => f.status === "error");
-				const overallStatus: ReviewStatus = hasRunning
-					? "running"
-					: doneCount >= fileStates.length
-						? hasError
-							? "error"
-							: "completed"
-						: "running";
-
+		invoke<ReviewStateChanged | null>("get_review_status", {
+			reviewSessionId: worktreePath,
+		})
+			.then((status) => {
+				if (!active || !status) return;
+				if (status.status === "idle") return;
+				reviewStartTimeRef.current = Date.now();
 				setState({
-					status: overallStatus,
-					ptyIds,
-					progress: { done: doneCount, total: fileStates.length },
+					status: status.status,
+					progress: {
+						done: status.progress.done,
+						total: status.progress.total,
+					},
 					summary: null,
-					fileStates,
+					fileStates: status.file_states.map((f) => ({
+						filePath: f.file_path,
+						status: f.status,
+						ptyId: f.pty_id,
+						output: "",
+					})),
 				});
 			})
 			.catch(() => {});
@@ -416,43 +162,31 @@ export function useReviewExecution(
 
 	// Compute summary when status is completed
 	useEffect(() => {
-		if (state.status === "completed") {
-			const reviewThreads = threads.filter(
-				(t) =>
-					getThreadOrigin(t) === "ai-review" &&
-					t.createdAt > reviewStartTimeRef.current,
-			);
-			const summary: ReviewSummary = {
-				total: reviewThreads.length,
-				errors: reviewThreads.filter((t) => t.severity === "error").length,
-				warnings: reviewThreads.filter((t) => t.severity === "warning").length,
-				infos: reviewThreads.filter((t) => t.severity === "info").length,
-				suggestions: reviewThreads.filter((t) => t.severity === "suggestion")
-					.length,
-			};
-			setState((prev) => ({ ...prev, summary }));
-		}
-		prevStatusRef.current = state.status;
+		if (state.status !== "completed") return;
+
+		const reviewThreads = threads.filter(
+			(t) =>
+				getThreadOrigin(t) === "ai-review" &&
+				t.createdAt > reviewStartTimeRef.current,
+		);
+		const summary: ReviewSummary = {
+			total: reviewThreads.length,
+			errors: reviewThreads.filter((t) => t.severity === "error").length,
+			warnings: reviewThreads.filter((t) => t.severity === "warning").length,
+			infos: reviewThreads.filter((t) => t.severity === "info").length,
+			suggestions: reviewThreads.filter((t) => t.severity === "suggestion")
+				.length,
+		};
+		setState((prev) => ({ ...prev, summary }));
 	}, [state.status, threads]);
 
 	const startReview = useCallback(async () => {
 		if (!worktreePath) return;
-		if (startInFlightRef.current) return;
-		startInFlightRef.current = true;
-		const runToken = ++runTokenRef.current;
 
-		// Get per-file tasks from Rust
-		let tasks: PerFileReviewTask[];
-		try {
-			tasks = await invoke<PerFileReviewTask[]>("get_per_file_review_tasks", {
-				worktreePath,
-			});
-		} catch {
-			startInFlightRef.current = false;
-			if (!mountedRef.current) return;
+		const commandTemplate = buildReviewCommandTemplate(settingsRef.current);
+		if (!commandTemplate) {
 			setState({
 				status: "error",
-				ptyIds: new Set(),
 				progress: null,
 				summary: null,
 				fileStates: [],
@@ -460,116 +194,59 @@ export function useReviewExecution(
 			return;
 		}
 
-		if (!mountedRef.current) {
-			startInFlightRef.current = false;
-			return;
-		}
+		reviewStartTimeRef.current = Date.now();
+		fileOutputRef.current.clear();
 
-		if (runTokenRef.current !== runToken) {
-			startInFlightRef.current = false;
-			return;
-		}
+		try {
+			const sessionId = await invoke<string | null>("start_review", {
+				worktreePath,
+				commandTemplate,
+				concurrency: Math.max(1, settingsRef.current.reviewConcurrency ?? 5),
+			});
 
-		if (tasks.length === 0) {
-			startInFlightRef.current = false;
-			if (!mountedRef.current) return;
+			if (!sessionId) {
+				setState({
+					status: "completed",
+					progress: { done: 0, total: 0 },
+					summary: {
+						total: 0,
+						errors: 0,
+						warnings: 0,
+						infos: 0,
+						suggestions: 0,
+					},
+					fileStates: [],
+				});
+			}
+		} catch {
 			setState({
-				status: "completed",
-				ptyIds: new Set(),
-				progress: { done: 0, total: 0 },
-				summary: {
-					total: 0,
-					errors: 0,
-					warnings: 0,
-					infos: 0,
-					suggestions: 0,
-				},
+				status: "error",
+				progress: null,
+				summary: null,
 				fileStates: [],
 			});
-			return;
 		}
-
-		// Initialize state
-		const concurrency = Math.max(1, settings.reviewConcurrency ?? 5);
-		concurrencyRef.current = concurrency;
-		reviewStartTimeRef.current = Date.now();
-		ptyIdSetRef.current = new Set();
-		ptyRunTokenMapRef.current.clear();
-		totalCountRef.current = tasks.length;
-		doneCountRef.current = 0;
-		activeCountRef.current = 0;
-		errorCountRef.current = 0;
-		pendingStatusRef.current.clear();
-		pendingOutputRef.current.clear();
-
-		const fileStates: FileReviewState[] = tasks.map((t) => ({
-			filePath: t.file_path,
-			status: "pending" as FileReviewStatus,
-			ptyId: null,
-			output: "",
-		}));
-		fileStatesRef.current = fileStates;
-		taskQueueRef.current = [...tasks];
-
-		setState({
-			status: "running",
-			ptyIds: new Set(),
-			progress: { done: 0, total: tasks.length },
-			summary: null,
-			fileStates: [...fileStates],
-		});
-
-		// Spawn initial batch
-		const initialBatch = Math.min(concurrency, tasks.length);
-		for (let i = 0; i < initialBatch; i++) {
-			spawnNextTaskRef.current(runToken);
-		}
-		startInFlightRef.current = false;
-	}, [worktreePath, settings]);
+	}, [worktreePath]);
 
 	const cancelReview = useCallback(async () => {
-		// Invalidate current run token to prevent completion events from overwriting status
-		runTokenRef.current += 1;
-		// Cancel all running PTYs
-		const cancelPromises = Array.from(ptyIdSetRef.current).map((id) =>
-			invoke("cancel_oneshot_pty", { ptyId: id }).catch(() => {}),
-		);
-		// Clear the queue
-		taskQueueRef.current = [];
-		await Promise.all(cancelPromises);
-		ptyIdSetRef.current.clear();
-		ptyRunTokenMapRef.current.clear();
-		activeCountRef.current = 0;
-		pendingStatusRef.current.clear();
-		pendingOutputRef.current.clear();
-		setState((prev) => ({
-			...prev,
-			status: "cancelled",
-			ptyIds: new Set(),
-		}));
-	}, []);
+		if (!worktreePath) return;
+		await invoke("cancel_review", {
+			reviewSessionId: worktreePath,
+		}).catch(() => {});
+	}, [worktreePath]);
 
 	const reset = useCallback(() => {
-		runTokenRef.current += 1;
-		ptyIdSetRef.current = new Set();
-		ptyRunTokenMapRef.current.clear();
-		fileStatesRef.current = [];
-		taskQueueRef.current = [];
-		activeCountRef.current = 0;
-		doneCountRef.current = 0;
-		totalCountRef.current = 0;
-		errorCountRef.current = 0;
-		startInFlightRef.current = false;
-		pendingStatusRef.current.clear();
-		pendingOutputRef.current.clear();
+		if (worktreePath) {
+			invoke("reset_review", { reviewSessionId: worktreePath }).catch(() => {});
+		}
+		fileOutputRef.current.clear();
 		setState({
 			status: "idle",
-			ptyIds: new Set(),
 			progress: null,
 			summary: null,
 			fileStates: [],
 		});
-	}, []);
+	}, [worktreePath]);
 
 	return {
 		...state,

--- a/src/hooks/useSessionStore.ts
+++ b/src/hooks/useSessionStore.ts
@@ -7,6 +7,7 @@ import type {
 	MessageRole,
 	SessionState,
 	SessionSummary,
+	TurnPhase,
 } from "@/types/session";
 
 interface LegacyChatSession {
@@ -86,7 +87,7 @@ export async function listSessions(
 
 export interface GetSessionResponse {
 	session: ChatSession;
-	isStreaming: boolean;
+	turnPhase: TurnPhase;
 }
 
 interface RawGetSessionResponse {
@@ -98,7 +99,7 @@ interface RawGetSessionResponse {
 	createdAt: number;
 	updatedAt: number;
 	agentSessionId?: string | null;
-	isStreaming: boolean;
+	turnPhase: TurnPhase;
 }
 
 export async function getSession(
@@ -119,7 +120,7 @@ export async function getSession(
 	});
 	return {
 		session,
-		isStreaming: raw.isStreaming,
+		turnPhase: raw.turnPhase,
 	};
 }
 

--- a/src/hooks/useSessionStore.ts
+++ b/src/hooks/useSessionStore.ts
@@ -160,6 +160,77 @@ export async function addMessage(
 	return convertLegacyMessage(raw);
 }
 
+interface RawSendMessageResponse {
+	session: LegacyChatSession;
+	humanMessage: LegacyChatMessage & { parts?: MessagePart[] };
+	agentMessage: (LegacyChatMessage & { parts?: MessagePart[] }) | null;
+	sessions: SessionSummary[];
+}
+
+export interface SendMessageResponse {
+	session: ChatSession;
+	humanMessage: ChatMessage;
+	agentMessage: ChatMessage | null;
+	sessions: SessionSummary[];
+}
+
+export async function sendAgentMessage(
+	chatSessionId: string | null,
+	worktreePath: string,
+	content: string,
+	permissionMode: string,
+): Promise<SendMessageResponse> {
+	const raw = await invoke<RawSendMessageResponse>("send_agent_message", {
+		chatSessionId,
+		worktreePath,
+		content,
+		permissionMode,
+	});
+	return {
+		session: convertLegacySession(raw.session),
+		humanMessage: convertLegacyMessage(raw.humanMessage),
+		agentMessage: raw.agentMessage
+			? convertLegacyMessage(raw.agentMessage)
+			: null,
+		sessions: raw.sessions,
+	};
+}
+
+interface RawInitSessionsResponse {
+	sessions: SessionSummary[];
+	activeSession: RawGetSessionResponse | null;
+}
+
+export interface InitSessionsResponse {
+	sessions: SessionSummary[];
+	activeSession: GetSessionResponse | null;
+}
+
+export async function initAgentSessions(
+	worktreePath: string,
+	permissionMode: string,
+): Promise<InitSessionsResponse> {
+	const raw = await invoke<RawInitSessionsResponse>("init_agent_sessions", {
+		worktreePath,
+		permissionMode,
+	});
+	const activeSession = raw.activeSession
+		? {
+				session: convertLegacySession({
+					id: raw.activeSession.id,
+					worktreePath: raw.activeSession.worktreePath,
+					messages: raw.activeSession.messages,
+					state: raw.activeSession.state,
+					createdAt: raw.activeSession.createdAt,
+					updatedAt: raw.activeSession.updatedAt,
+					agentSessionId: raw.activeSession.agentSessionId,
+				}),
+				turnPhase: raw.activeSession.turnPhase,
+			}
+		: null;
+	return { sessions: raw.sessions, activeSession };
+}
+
 export async function updateSessionState(
 	sessionId: string,
 	newState: SessionState,

--- a/src/screens/useWorktreeGitActions.ts
+++ b/src/screens/useWorktreeGitActions.ts
@@ -1,4 +1,3 @@
-import { invoke } from "@tauri-apps/api/core";
 import { useCallback } from "react";
 import type { DiffBase, DiffMode } from "@/types/settings";
 
@@ -174,17 +173,8 @@ export function useWorktreeGitActions({
 }: UseWorktreeGitActionsParams): WorktreeGitActions {
 	const handleGitStageAll = useCallback(async () => {
 		try {
-			const status = await invoke<{ changed: Array<{ path: string }> }>(
-				"get_git_status",
-				{ repoPath: rootPath },
-			);
-			if (status.changed.length > 0) {
-				await stage(
-					rootPath,
-					status.changed.map((f) => f.path),
-				);
-				refreshGit();
-			}
+			await stage(rootPath, []);
+			refreshGit();
 		} catch (e) {
 			dispatchGit({ type: "SET_GIT_ERROR", error: String(e) });
 		}
@@ -192,17 +182,8 @@ export function useWorktreeGitActions({
 
 	const handleGitUnstageAll = useCallback(async () => {
 		try {
-			const status = await invoke<{ staged: Array<{ path: string }> }>(
-				"get_git_status",
-				{ repoPath: rootPath },
-			);
-			if (status.staged.length > 0) {
-				await unstage(
-					rootPath,
-					status.staged.map((f) => f.path),
-				);
-				refreshGit();
-			}
+			await unstage(rootPath, []);
+			refreshGit();
 		} catch (e) {
 			dispatchGit({ type: "SET_GIT_ERROR", error: String(e) });
 		}
@@ -228,17 +209,8 @@ export function useWorktreeGitActions({
 	const executeDiscardAll = useCallback(async () => {
 		dispatchUI({ type: "SET_DISCARD_CONFIRM", show: false });
 		try {
-			const status = await invoke<{ changed: Array<{ path: string }> }>(
-				"get_git_status",
-				{ repoPath: rootPath },
-			);
-			if (status.changed.length > 0) {
-				await discard(
-					rootPath,
-					status.changed.map((f) => f.path),
-				);
-				refreshGit();
-			}
+			await discard(rootPath, []);
+			refreshGit();
 		} catch (e) {
 			dispatchGit({ type: "SET_GIT_ERROR", error: String(e) });
 		}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -19,6 +19,8 @@ export type MessageRole = "human" | "agent" | "system";
 
 export type SessionState = "active" | "idle" | "done" | "error" | "closed";
 
+export type TurnPhase = "idle" | "streaming" | "waiting_permission";
+
 export type MessagePart =
 	| { type: "thinking"; content: string; parentToolUseId?: string }
 	| { type: "text"; content: string; parentToolUseId?: string }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -188,6 +188,38 @@ export function buildReviewCommand(
 		.trim();
 }
 
+/**
+ * Build a command template with {prompt} placeholder for Rust-side substitution.
+ * Returns null if no review agent is configured.
+ */
+export function buildReviewCommandTemplate(
+	settings: AppSettings,
+): string | null {
+	const { reviewAgent, reviewModel, customReviewCommand } = settings;
+
+	if (reviewAgent === "none") {
+		return null;
+	}
+
+	if (reviewAgent === "custom") {
+		return customReviewCommand || null;
+	}
+
+	const config = AGENT_CONFIGS[reviewAgent];
+	if (!config.reviewCommand) return null;
+
+	const allowedModels = AGENT_MODELS[reviewAgent].map((m) => m.value);
+	const safeModel =
+		reviewModel && allowedModels.includes(reviewModel) ? reviewModel : "";
+	const modelFlagValue =
+		safeModel && config.modelFlag ? `${config.modelFlag} ${safeModel}` : "";
+
+	return config.reviewCommand
+		.replace("{model_flag}", modelFlagValue)
+		.replace(/\s{2,}/g, " ")
+		.trim();
+}
+
 export function buildThreadCommand(
 	settings: AppSettings,
 	prompt: string,


### PR DESCRIPTION
## Summary

- **TurnPhase一元管理**: フロントエンドのoptimistic state（`streamingSessionIds`, `sessionFinalStates`）を全て削除し、Rust側 `TurnPhase`（Idle/Streaming/WaitingPermission）から統一イベント `agent-session-state-changed` で通知する構造に変更
- **メッセージ送信の常時有効化**: textarea常時有効化、ストリーミング中でもメッセージ送信可能（interrupt + pending message パターン）、SDK活動ステータス表示（Thinking/Reading/Running command等）
- **SDKエラー表示修正 (#739)**: errorハンドラで `agent-streaming-updated` を emit していなかった問題を修正

## Changes

### Rust (`src-tauri/`)
- `agent_sdk.rs`: `TurnPhase` enum 追加、統一イベント `agent-session-state-changed` 導入、errorハンドラのdelta emit追加
- `session/mod.rs`: `GetSessionResponse` の `is_streaming` → `turn_phase` に変更

### Frontend (`src/`)
- `agentChatReducer`: optimistic state 削除、`turnPhases` に統一
- `useAgentChat`: `deriveActivityStatus()`, `deriveAgentState(turnPhase, sessionState)` 追加、pending message パターン実装
- `useAgentSdkListeners`: `agent-session-state-changed` リスナー追加、pending message 消化ロジック
- `MessageInput`: `disabled` prop 削除、常時入力可能に
- `AgentChatPanel`: activity status 表示追加

## Closes

- Closes #739

## Test plan

- [x] `cargo test` (821 tests)
- [x] `cargo clippy -- -D warnings`
- [x] `pnpm test` (1408 tests)
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 並列レビュー実行を追加：レビュー開始/キャンセル、進捗・ファイルごとの出力表示と状態管理が可能に。
  * メッセージ送信ワークフローを統合：セッション初期化、サーバ経由送信、保留メッセージのキューと自動適用をサポート。

* **Improvements**
  * エージェント活動表示を強化（思考中・書き込み中・権限待機などのラベルを追加）。
  * 権限要求やストリーミング中の送信/中断挙動と状態同期を改善。 UIの入力制御とステータス表示を調整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->