### PR TITLE
fix: AskQuestion選択肢をカード型縦リスト表示に変更

### DIFF
--- a/docs/spec/issues-747.md
+++ b/docs/spec/issues-747.md
@@ -1,0 +1,64 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: AskQuestion UIで選択肢がボタン形式で横一列に並び、各ボタンの幅が不均等。descriptionテキストがボタンの下に長い1行として表示され、どのボタンに対応するか判別しにくい。
+**期待する挙動**: Claude Code本体のAskQuestion UIのように、選択肢が縦にリスト表示される形式にする。各選択肢がラベル付きで縦に並び、視認性・操作性が向上する。
+**再現手順**:
+1. ReleashアプリでAgent機能を使用
+2. AgentがAskQuestion（複数選択肢付き）を発行
+3. 選択肢がボタン形式で横並びに表示され、幅が不正
+**背景**: 選択肢のdescriptionが長い場合にボタンレイアウトが破綻し、ユーザーが内容を把握しづらい。リスト形式にすることでClaude Code本体と一貫したUXを提供する。
+
+## 振る舞い定義
+
+```gherkin
+Feature: AskQuestion選択肢のリスト表示
+  AgentがAskQuestionを発行した際、選択肢を縦リスト形式で表示し、
+  各選択肢のラベルとdescriptionの対応関係を明確にする。
+
+  Rule: 選択肢は縦リスト形式で表示される
+    Scenario: 複数の選択肢が縦に並んで表示される
+      Given Agentが3つの選択肢付きAskQuestionを発行している
+      When ユーザーが選択肢を確認する
+      Then 各選択肢がラベルとdescriptionのペアとして縦に一覧表示される
+
+    Scenario: Otherオプションもリスト内に表示される
+      Given Agentが単一選択のAskQuestionを発行している
+      When ユーザーが選択肢を確認する
+      Then 定義済み選択肢の後にOtherオプションが同じリスト形式で表示される
+
+  Rule: 選択肢の選択状態が視覚的に区別される
+    Scenario: 単一選択で選択肢を選ぶ
+      Given 単一選択のAskQuestionが表示されている
+      When ユーザーが1つの選択肢を選択する
+      Then 選択された選択肢が選択状態として視覚的に区別される
+
+    Scenario: 複数選択で複数の選択肢を選ぶ
+      Given 複数選択のAskQuestionが表示されている
+      When ユーザーが複数の選択肢を選択する
+      Then 選択された各選択肢が選択状態として視覚的に区別される
+
+  Rule: Otherを選択すると自由入力欄が表示される
+    Scenario: Otherを選択してテキストを入力する
+      Given 単一選択のAskQuestionが表示されている
+      When ユーザーがOtherを選択する
+      Then テキスト入力欄が表示される
+```
+
+## 実装仕様
+
+**対応方針**: AskQuestion選択肢の縦リスト表示を実現するために、`PermissionDialog.tsx` の選択肢レンダリング部分を `flex flex-wrap`（横並びボタン）から、既存の `RadioGroup` / `Checkbox` コンポーネントを使った縦リスト形式に変更する。
+
+**対象コンポーネント**:
+- `src/components/panels/AgentChatPanel/PermissionDialog.tsx`: 選択肢のレイアウトを縦リスト形式に変更。単一選択は `RadioGroup` + `RadioGroupItem`、複数選択は `Checkbox` を使用。各アイテムの右にラベル + description を配置。"Other" オプションも同じリスト内にアイテムとして表示。
+
+**技術選定**:
+- `src/components/ui/radio-group.tsx`（既存）: 単一選択の UI
+- `src/components/ui/checkbox.tsx`（既存）: 複数選択の UI
+- 新規ライブラリの導入なし
+
+**検討した代替案**:
+- カード型リスト: 各選択肢をボーダー付きカードとして縦に積む方式。よりリッチだが実装量が多く、既存のshadcn/uiコンポーネントを活用できない
+
+**影響するテスト**:
+- `PermissionDialog.test.tsx`: 既存テストのUI要素セレクタ（ボタンからラジオ/チェックボックスへ）を更新。複数選択（`multiSelect: true`）のテストケースを新規追加

--- a/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
@@ -251,7 +251,7 @@ const askRequest = {
 };
 
 describe("PermissionDialog — AskUserQuestion", () => {
-	it("displays question text and options", () => {
+	it("displays question text and options as vertical list with radio buttons", () => {
 		render(
 			<PermissionDialog
 				request={askRequest}
@@ -266,6 +266,23 @@ describe("PermissionDialog — AskUserQuestion", () => {
 		expect(screen.getByText("Library")).toBeInTheDocument();
 		expect(screen.getByText("React")).toBeInTheDocument();
 		expect(screen.getByText("Vue")).toBeInTheDocument();
+		// Radio buttons are rendered for single-select
+		const radios = screen.getAllByRole("radio");
+		// 2 options + 1 Other = 3 radio items
+		expect(radios).toHaveLength(3);
+	});
+
+	it("displays each option with label and description as a pair", () => {
+		render(
+			<PermissionDialog
+				request={askRequest}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+				onAnswer={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("Popular UI framework")).toBeInTheDocument();
+		expect(screen.getByText("Progressive framework")).toBeInTheDocument();
 	});
 
 	it("hides Allow/Deny buttons for AskUserQuestion", () => {
@@ -311,6 +328,28 @@ describe("PermissionDialog — AskUserQuestion", () => {
 		expect(onAnswer).toHaveBeenCalledWith("req-ask-001", {
 			"Which library should we use?": "React",
 		});
+	});
+
+	it("visually distinguishes the selected option (single select)", async () => {
+		render(
+			<PermissionDialog
+				request={askRequest}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+				onAnswer={vi.fn()}
+			/>,
+		);
+
+		const radios = screen.getAllByRole("radio");
+		// Initially no radio is checked
+		for (const radio of radios) {
+			expect(radio).not.toBeChecked();
+		}
+
+		await userEvent.click(screen.getByText("React"));
+		// The first radio (React) should now be checked
+		expect(radios[0]).toBeChecked();
+		expect(radios[1]).not.toBeChecked();
 	});
 
 	it("handles multiple questions", async () => {
@@ -376,7 +415,7 @@ describe("PermissionDialog — AskUserQuestion", () => {
 		expect(screen.getByText("Deny")).toBeInTheDocument();
 	});
 
-	it("displays an Other button for each question", () => {
+	it("displays Other option in the same radio list", () => {
 		render(
 			<PermissionDialog
 				request={askRequest}
@@ -386,6 +425,9 @@ describe("PermissionDialog — AskUserQuestion", () => {
 			/>,
 		);
 		expect(screen.getByText("Other")).toBeInTheDocument();
+		// Other is a radio item in the same group
+		const radios = screen.getAllByRole("radio");
+		expect(radios).toHaveLength(3);
 	});
 
 	it("shows text input when Other is clicked", async () => {
@@ -461,6 +503,129 @@ describe("PermissionDialog — AskUserQuestion", () => {
 		expect(
 			screen.queryByLabelText("Other input for Which library should we use?"),
 		).not.toBeInTheDocument();
+	});
+});
+
+describe("AskUserQuestion — multiSelect", () => {
+	const multiSelectRequest = {
+		request_id: "req-ask-multi-001",
+		tool_name: "AskUserQuestion",
+		input: {
+			questions: [
+				{
+					question: "Which features do you want?",
+					header: "Features",
+					options: [
+						{ label: "Auth", description: "Authentication" },
+						{ label: "DB", description: "Database" },
+						{ label: "API", description: "REST API" },
+					],
+					multiSelect: true,
+				},
+			],
+		},
+		tool_use_id: "toolu_ask_multi_001",
+	};
+
+	it("renders checkboxes for multi-select questions", () => {
+		render(
+			<PermissionDialog
+				request={multiSelectRequest}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+				onAnswer={vi.fn()}
+			/>,
+		);
+		const checkboxes = screen.getAllByRole("checkbox");
+		expect(checkboxes).toHaveLength(3);
+	});
+
+	it("displays each option with label and description", () => {
+		render(
+			<PermissionDialog
+				request={multiSelectRequest}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+				onAnswer={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("Auth")).toBeInTheDocument();
+		expect(screen.getByText("Authentication")).toBeInTheDocument();
+		expect(screen.getByText("DB")).toBeInTheDocument();
+		expect(screen.getByText("Database")).toBeInTheDocument();
+		expect(screen.getByText("API")).toBeInTheDocument();
+		expect(screen.getByText("REST API")).toBeInTheDocument();
+	});
+
+	it("allows selecting multiple checkboxes and visually distinguishes them", async () => {
+		render(
+			<PermissionDialog
+				request={multiSelectRequest}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+				onAnswer={vi.fn()}
+			/>,
+		);
+
+		const checkboxes = screen.getAllByRole("checkbox");
+
+		await userEvent.click(screen.getByText("Auth"));
+		await userEvent.click(screen.getByText("API"));
+
+		expect(checkboxes[0]).toBeChecked();
+		expect(checkboxes[1]).not.toBeChecked();
+		expect(checkboxes[2]).toBeChecked();
+	});
+
+	it("submits comma-separated values for multi-select", async () => {
+		const onAnswer = vi.fn();
+		render(
+			<PermissionDialog
+				request={multiSelectRequest}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+				onAnswer={onAnswer}
+			/>,
+		);
+
+		await userEvent.click(screen.getByText("Auth"));
+		await userEvent.click(screen.getByText("DB"));
+		expect(screen.getByText("Submit")).not.toBeDisabled();
+
+		await userEvent.click(screen.getByText("Submit"));
+		expect(onAnswer).toHaveBeenCalledWith("req-ask-multi-001", {
+			"Which features do you want?": "Auth, DB",
+		});
+	});
+
+	it("can toggle checkbox off", async () => {
+		render(
+			<PermissionDialog
+				request={multiSelectRequest}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+				onAnswer={vi.fn()}
+			/>,
+		);
+
+		await userEvent.click(screen.getByText("Auth"));
+		const checkboxes = screen.getAllByRole("checkbox");
+		expect(checkboxes[0]).toBeChecked();
+
+		await userEvent.click(screen.getByText("Auth"));
+		expect(checkboxes[0]).not.toBeChecked();
+	});
+
+	it("does not show Other option for multi-select", () => {
+		render(
+			<PermissionDialog
+				request={multiSelectRequest}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+				onAnswer={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByText("Other")).not.toBeInTheDocument();
 	});
 });
 

--- a/src/components/panels/AgentChatPanel/PermissionDialog.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.tsx
@@ -1,8 +1,9 @@
 import { ChevronRight } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import Markdown from "react-markdown";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { rehypePluginList, remarkPluginList } from "@/lib/markdownConfig";
 import { cn } from "@/lib/utils";
@@ -41,14 +42,17 @@ function parseAskQuestions(input: Record<string, unknown>): AskQuestion[] {
 function InlineMarkdown({
 	children,
 	className,
+	id,
 	"data-testid": dataTestId,
 }: {
 	children: string;
 	className?: string;
+	id?: string;
 	"data-testid"?: string;
 }) {
 	return (
 		<div
+			id={id}
 			data-testid={dataTestId}
 			className={cn(
 				"markdown-preview prose prose-sm dark:prose-invert max-w-none",
@@ -178,6 +182,7 @@ export function PermissionDialog({
 	const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
 	const [otherTexts, setOtherTexts] = useState<Record<string, string>>({});
 	const [isExpanded, setIsExpanded] = useState(false);
+	const questionIdBase = useId();
 	if (status !== "pending") {
 		const isAllowed = status === "allowed";
 		let label: string;
@@ -284,36 +289,75 @@ export function PermissionDialog({
 				data-testid="permission-dialog"
 				className="mx-3 my-1.5 rounded-md border border-border bg-muted/50 p-3"
 			>
-				{questions.map((q) => (
-					<div key={q.question} className="mb-2">
-						<InlineMarkdown className="text-xs text-muted-foreground mb-0.5">
-							{q.header}
-						</InlineMarkdown>
-						<InlineMarkdown className="text-sm font-medium mb-1.5">
-							{q.question}
-						</InlineMarkdown>
-						{q.multiSelect ? (
-							<fieldset
-								className="space-y-2 border-0 p-0 m-0"
-								aria-label={q.header}
+				{questions.map((q, qIndex) => {
+					const questionId = `${questionIdBase}-q-${qIndex}`;
+					return (
+						<div key={q.question} className="mb-2">
+							<InlineMarkdown className="text-xs text-muted-foreground mb-0.5">
+								{q.header}
+							</InlineMarkdown>
+							<InlineMarkdown
+								id={questionId}
+								className="text-sm font-medium mb-1.5"
 							>
-								{q.options.map((opt) => {
-									const isChecked =
-										Array.isArray(answers[q.question]) &&
-										(answers[q.question] as string[]).includes(opt.label);
-									return (
-										// biome-ignore lint/a11y/noLabelWithoutControl: Radix Checkbox renders an internal button element
+								{q.question}
+							</InlineMarkdown>
+							{q.multiSelect ? (
+								<fieldset
+									className="space-y-2 border-0 p-0 m-0"
+									aria-labelledby={questionId}
+								>
+									{q.options.map((opt) => {
+										const isChecked =
+											Array.isArray(answers[q.question]) &&
+											(answers[q.question] as string[]).includes(opt.label);
+										return (
+											// biome-ignore lint/a11y/noLabelWithoutControl: Radix Checkbox renders an internal button element
+											<label
+												key={opt.label}
+												className="flex items-start gap-2.5 cursor-pointer rounded-md border border-border px-3 py-2 hover:bg-accent/50"
+											>
+												<Checkbox
+													checked={isChecked}
+													onCheckedChange={() =>
+														handleSelect(q.question, opt.label, true)
+													}
+													className="mt-0.5"
+												/>
+												<div className="flex flex-col">
+													<span className="text-sm font-medium">
+														{opt.label}
+													</span>
+													{opt.description && (
+														<InlineMarkdown className="text-xs text-muted-foreground">
+															{opt.description}
+														</InlineMarkdown>
+													)}
+												</div>
+											</label>
+										);
+									})}
+								</fieldset>
+							) : (
+								<RadioGroup
+									value={
+										typeof answers[q.question] === "string"
+											? (answers[q.question] as string)
+											: undefined
+									}
+									onValueChange={(value) =>
+										handleSelect(q.question, value, false)
+									}
+									className="space-y-2"
+									aria-labelledby={questionId}
+								>
+									{q.options.map((opt) => (
+										// biome-ignore lint/a11y/noLabelWithoutControl: Radix RadioGroupItem renders an internal button element
 										<label
 											key={opt.label}
 											className="flex items-start gap-2.5 cursor-pointer rounded-md border border-border px-3 py-2 hover:bg-accent/50"
 										>
-											<Checkbox
-												checked={isChecked}
-												onCheckedChange={() =>
-													handleSelect(q.question, opt.label, true)
-												}
-												className="mt-0.5"
-											/>
+											<RadioGroupItem value={opt.label} className="mt-0.5" />
 											<div className="flex flex-col">
 												<span className="text-sm font-medium">{opt.label}</span>
 												{opt.description && (
@@ -323,65 +367,35 @@ export function PermissionDialog({
 												)}
 											</div>
 										</label>
-									);
-								})}
-							</fieldset>
-						) : (
-							<RadioGroup
-								value={
-									typeof answers[q.question] === "string"
-										? (answers[q.question] as string)
-										: undefined
-								}
-								onValueChange={(value) =>
-									handleSelect(q.question, value, false)
-								}
-								className="space-y-2"
-							>
-								{q.options.map((opt) => (
-									// biome-ignore lint/a11y/noLabelWithoutControl: Radix RadioGroupItem renders an internal button element
-									<label
-										key={opt.label}
-										className="flex items-start gap-2.5 cursor-pointer rounded-md border border-border px-3 py-2 hover:bg-accent/50"
-									>
-										<RadioGroupItem value={opt.label} className="mt-0.5" />
-										<div className="flex flex-col">
-											<span className="text-sm font-medium">{opt.label}</span>
-											{opt.description && (
-												<InlineMarkdown className="text-xs text-muted-foreground">
-													{opt.description}
-												</InlineMarkdown>
+									))}
+									{/* biome-ignore lint/a11y/noLabelWithoutControl: Radix RadioGroupItem renders an internal button element */}
+									<label className="flex items-start gap-2.5 cursor-pointer rounded-md border border-border px-3 py-2 hover:bg-accent/50">
+										<RadioGroupItem value={OTHER_LABEL} className="mt-0.5" />
+										<div className="flex flex-col flex-1">
+											<span className="text-sm font-medium">Other</span>
+											{answers[q.question] === OTHER_LABEL && (
+												<Input
+													type="text"
+													aria-label={`Other input for ${q.question}`}
+													value={otherTexts[q.question] ?? ""}
+													onClick={(e) => e.stopPropagation()}
+													onChange={(e) =>
+														setOtherTexts((prev) => ({
+															...prev,
+															[q.question]: e.target.value,
+														}))
+													}
+													className="mt-1 h-auto text-sm"
+													placeholder="Type your answer..."
+												/>
 											)}
 										</div>
 									</label>
-								))}
-								{/* biome-ignore lint/a11y/noLabelWithoutControl: Radix RadioGroupItem renders an internal button element */}
-								<label className="flex items-start gap-2.5 cursor-pointer rounded-md border border-border px-3 py-2 hover:bg-accent/50">
-									<RadioGroupItem value={OTHER_LABEL} className="mt-0.5" />
-									<div className="flex flex-col flex-1">
-										<span className="text-sm font-medium">Other</span>
-										{answers[q.question] === OTHER_LABEL && (
-											<input
-												type="text"
-												aria-label={`Other input for ${q.question}`}
-												value={otherTexts[q.question] ?? ""}
-												onClick={(e) => e.stopPropagation()}
-												onChange={(e) =>
-													setOtherTexts((prev) => ({
-														...prev,
-														[q.question]: e.target.value,
-													}))
-												}
-												className="mt-1 w-full rounded-md border border-border bg-background px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-ring"
-												placeholder="Type your answer..."
-											/>
-										)}
-									</div>
-								</label>
-							</RadioGroup>
-						)}
-					</div>
-				))}
+								</RadioGroup>
+							)}
+						</div>
+					);
+				})}
 				<Button
 					size="xs"
 					onClick={handleSubmit}

--- a/src/components/panels/AgentChatPanel/PermissionDialog.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.tsx
@@ -2,6 +2,8 @@ import { ChevronRight } from "lucide-react";
 import { useState } from "react";
 import Markdown from "react-markdown";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { rehypePluginList, remarkPluginList } from "@/lib/markdownConfig";
 import { cn } from "@/lib/utils";
 import type { PermissionRequest } from "@/types/session";
@@ -290,64 +292,93 @@ export function PermissionDialog({
 						<InlineMarkdown className="text-sm font-medium mb-1.5">
 							{q.question}
 						</InlineMarkdown>
-						<div className="flex flex-wrap gap-1.5">
-							{q.options.map((opt) => {
-								const isSelected = q.multiSelect
-									? Array.isArray(answers[q.question]) &&
-										(answers[q.question] as string[]).includes(opt.label)
-									: answers[q.question] === opt.label;
-								return (
-									<div key={opt.label} className="flex flex-col gap-0.5">
-										<Button
-											size="xs"
-											variant={isSelected ? "default" : "outline"}
-											onClick={() =>
-												handleSelect(q.question, opt.label, q.multiSelect)
-											}
-											className={cn(
-												!q.multiSelect && isSelected && "pointer-events-none",
-											)}
+						{q.multiSelect ? (
+							<fieldset
+								className="space-y-2 border-0 p-0 m-0"
+								aria-label={q.header}
+							>
+								{q.options.map((opt) => {
+									const isChecked =
+										Array.isArray(answers[q.question]) &&
+										(answers[q.question] as string[]).includes(opt.label);
+									return (
+										// biome-ignore lint/a11y/noLabelWithoutControl: Radix Checkbox renders an internal button element
+										<label
+											key={opt.label}
+											className="flex items-start gap-2.5 cursor-pointer rounded-md border border-border px-3 py-2 hover:bg-accent/50"
 										>
-											{opt.label}
-										</Button>
-										{opt.description && (
-											<InlineMarkdown className="text-[11px] text-muted-foreground">
-												{opt.description}
-											</InlineMarkdown>
+											<Checkbox
+												checked={isChecked}
+												onCheckedChange={() =>
+													handleSelect(q.question, opt.label, true)
+												}
+												className="mt-0.5"
+											/>
+											<div className="flex flex-col">
+												<span className="text-sm font-medium">{opt.label}</span>
+												{opt.description && (
+													<InlineMarkdown className="text-xs text-muted-foreground">
+														{opt.description}
+													</InlineMarkdown>
+												)}
+											</div>
+										</label>
+									);
+								})}
+							</fieldset>
+						) : (
+							<RadioGroup
+								value={
+									typeof answers[q.question] === "string"
+										? (answers[q.question] as string)
+										: undefined
+								}
+								onValueChange={(value) =>
+									handleSelect(q.question, value, false)
+								}
+								className="space-y-2"
+							>
+								{q.options.map((opt) => (
+									// biome-ignore lint/a11y/noLabelWithoutControl: Radix RadioGroupItem renders an internal button element
+									<label
+										key={opt.label}
+										className="flex items-start gap-2.5 cursor-pointer rounded-md border border-border px-3 py-2 hover:bg-accent/50"
+									>
+										<RadioGroupItem value={opt.label} className="mt-0.5" />
+										<div className="flex flex-col">
+											<span className="text-sm font-medium">{opt.label}</span>
+											{opt.description && (
+												<InlineMarkdown className="text-xs text-muted-foreground">
+													{opt.description}
+												</InlineMarkdown>
+											)}
+										</div>
+									</label>
+								))}
+								{/* biome-ignore lint/a11y/noLabelWithoutControl: Radix RadioGroupItem renders an internal button element */}
+								<label className="flex items-start gap-2.5 cursor-pointer rounded-md border border-border px-3 py-2 hover:bg-accent/50">
+									<RadioGroupItem value={OTHER_LABEL} className="mt-0.5" />
+									<div className="flex flex-col flex-1">
+										<span className="text-sm font-medium">Other</span>
+										{answers[q.question] === OTHER_LABEL && (
+											<input
+												type="text"
+												aria-label={`Other input for ${q.question}`}
+												value={otherTexts[q.question] ?? ""}
+												onClick={(e) => e.stopPropagation()}
+												onChange={(e) =>
+													setOtherTexts((prev) => ({
+														...prev,
+														[q.question]: e.target.value,
+													}))
+												}
+												className="mt-1 w-full rounded-md border border-border bg-background px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-ring"
+												placeholder="Type your answer..."
+											/>
 										)}
 									</div>
-								);
-							})}
-							{!q.multiSelect && (
-								<Button
-									size="xs"
-									variant={
-										answers[q.question] === OTHER_LABEL ? "default" : "outline"
-									}
-									onClick={() => handleSelect(q.question, OTHER_LABEL, false)}
-									className={cn(
-										answers[q.question] === OTHER_LABEL &&
-											"pointer-events-none",
-									)}
-								>
-									Other
-								</Button>
-							)}
-						</div>
-						{answers[q.question] === OTHER_LABEL && (
-							<input
-								type="text"
-								aria-label={`Other input for ${q.question}`}
-								value={otherTexts[q.question] ?? ""}
-								onChange={(e) =>
-									setOtherTexts((prev) => ({
-										...prev,
-										[q.question]: e.target.value,
-									}))
-								}
-								className="mt-1.5 w-full rounded-md border border-border bg-background px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-ring"
-								placeholder="Type your answer..."
-							/>
+								</label>
+							</RadioGroup>
 						)}
 					</div>
 				))}


### PR DESCRIPTION
## Summary
- AskQuestion UIの選択肢を横並びボタン形式からRadioGroup/Checkboxを使ったカード型縦リストに変更
- 各選択肢をボーダー付きカードで囲み、ラベル太字化・description拡大・ホバー効果で視認性向上
- Otherのテキスト入力をカード内に配置し、multiSelectのテストケースを新規追加

## Test plan
- [x] `pnpm lint` PASS
- [x] `pnpm test` 全1419件 PASS
- [ ] 単一選択の縦リスト表示・選択状態の視覚的区別を目視確認
- [ ] 複数選択のチェックボックス表示・トグル動作を目視確認
- [ ] Other選択時のテキスト入力がカード内に表示されることを目視確認

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AskQuestion UI を改善し、選択肢を垂直リストで表示するように変更しました。単一選択ではラジオボタン、複数選択ではチェックボックスを使用します。

* **バグ修正**
  * "その他"オプションを同じリスト内に統合し、選択状態の視認性を向上させました。

* **テスト**
  * 単一選択と複数選択の両モードに対応したテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->