### PR TITLE
feat: AgentChatにSDKシステムメッセージ通知を表示 (#746)

### DIFF
--- a/docs/spec/issues-746.md
+++ b/docs/spec/issues-746.md
@@ -1,0 +1,144 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: Claude CodeでCompaction（会話圧縮）が発生しても、ReleashのAgentChat上に通知や表示がなく、ユーザーが気づけない
+**期待する挙動**: Compaction発生時にAgentChat上で表示し、ユーザーがAgentの作業状況を把握できるようにする
+**再現手順**:
+1. ReleashのAgentChatからClaude Codeセッションを実行する
+2. コンテキストウィンドウが上限に達しCompactionが発生する
+3. AgentChat上にCompactionの発生を示す通知や表示がない
+**背景**: Compactionが発生するとAgentのコンテキストが圧縮され、以降の動作に影響する可能性があるが、現状ではReleash上でその発生を確認する手段がなく、Agentの作業状況の把握が困難になる
+
+## 振る舞い定義
+
+```gherkin
+Feature: SDKシステムメッセージ通知
+  AgentChatセッション中にClaude Code SDKからシステムメッセージを受信した場合、
+  ユーザーがAgentの作業状況を把握できるようAgentChat上にシステムメッセージを表示する
+
+  Background:
+    Given AgentChatセッションが実行中である
+
+  Rule: Compactionの開始と完了を1つのシステムメッセージとして表示する
+    Scenario: Compaction開始
+      When SDKがstatus=compactingメッセージを送信する
+      Then AgentChatにCompaction進行中のシステムメッセージが追加される
+
+    Scenario: Compaction完了
+      Given AgentChatにCompaction進行中のシステムメッセージがある
+      When SDKがcompact_boundaryメッセージを送信する
+      Then そのシステムメッセージがCompaction完了の表示に更新される
+
+  Rule: Hookの開始と完了を1つのシステムメッセージとして表示する
+    Scenario: Hook開始
+      When SDKがhook_startedメッセージを送信する
+      Then AgentChatにHook名とイベント名を含む進行中のシステムメッセージが追加される
+
+    Scenario: Hook完了
+      Given AgentChatにHook進行中のシステムメッセージがある
+      When SDKが同じhook_idのhook_responseメッセージを送信する
+      Then そのシステムメッセージがHook名と実行結果を含む完了表示に更新される
+
+  Rule: ファイル永続化をシステムメッセージとして表示する
+    Scenario: ファイル永続化の通知
+      When SDKがfiles_persistedメッセージを送信する
+      Then AgentChatに永続化されたファイル名を含むシステムメッセージが表示される
+
+  Rule: ローカルコマンド出力をシステムメッセージとして表示する
+    Scenario: ローカルコマンド出力の通知
+      When SDKがlocal_command_outputメッセージを送信する
+      Then AgentChatにコマンド出力内容のシステムメッセージが表示される
+
+  Rule: initとtask関連とpermissionMode同期は表示しない
+    Scenario: セッション初期化メッセージは表示しない
+      When SDKがinitメッセージを送信する
+      Then AgentChatにシステムメッセージは追加されない
+
+    Scenario: タスク関連メッセージは既存のTaskStatusとして処理する
+      When SDKがtask_started/task_progress/task_notificationメッセージを送信する
+      Then 既存のTaskStatusパートとして処理される
+
+    Scenario: permissionMode同期は表示しない
+      When SDKがstatus=nullかつpermissionMode付きのstatusメッセージを送信する
+      Then AgentChatにシステムメッセージは追加されない
+```
+
+## 実装仕様
+
+**対応方針**: 振る舞い定義のSDKシステムメッセージ通知を実現するために、Rust側の `accumulate_sdk_message()` に新しいシステムsubtype（compacting/compact_boundary/hook_started/hook_response/files_persisted/local_command_output）の処理を追加し、新しいMessagePartバリアント `SystemNotification` で蓄積・永続化する。フロントエンドは受け取ったpartをインライン表示するのみ。
+
+**対象コンポーネント**:
+- `src-tauri/src/session/mod.rs`: `MessagePart` enumに `SystemNotification` バリアント追加
+- `src-tauri/src/agent_sdk.rs`: `accumulate_sdk_message()` にsubtype分岐を追加。Compaction/Hookは同一partを更新するパターン
+- `src/types/session.ts`: TypeScript側 `MessagePart` に `system_notification` を追加
+- `src/components/panels/AgentChatPanel/AgentChatPanel.tsx`: `AgentMessageParts` 内で `system_notification` partをインライン表示
+
+**SystemNotificationのフィールド設計**:
+
+Rust:
+```rust
+SystemNotification {
+    notification_type: String,  // "compaction" | "hook" | "files_persisted" | "local_command_output"
+    status: String,             // "in_progress" | "completed" | "error"
+    label: String,              // 表示用テキスト
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,     // 追加情報
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hook_id: Option<String>,    // Hook開始→完了の紐付け用
+}
+```
+
+TypeScript:
+```typescript
+| {
+    type: "system_notification";
+    notificationType: "compaction" | "hook" | "files_persisted" | "local_command_output";
+    status: "in_progress" | "completed" | "error";
+    label: string;
+    detail?: string;
+    hookId?: string;
+  }
+```
+
+**各SDKメッセージの変換ロジック**:
+
+| SDKメッセージ | notificationType | 初期status | label | detail |
+|---|---|---|---|---|
+| `status=compacting` | compaction | in_progress | "Compacting conversation..." | None |
+| `compact_boundary` | compaction | completed | "Conversation compacted" | `"trigger={trigger}, {pre_tokens} tokens"` |
+| `hook_started` | hook | in_progress | `"{hook_name} ({hook_event})"` | None |
+| `hook_response` | hook | completed/error | `"{hook_name} ({hook_event})"` | `"outcome={outcome}, exit_code={exit_code}"` |
+| `files_persisted` | files_persisted | completed | "Files persisted" | ファイル名のカンマ区切りリスト |
+| `local_command_output` | local_command_output | completed | "Command output" | content（200文字でtruncate） |
+
+**開始→完了の同一part更新メカニズム**:
+
+Compaction:
+- `status=compacting` 受信時: `SystemNotification { notification_type: "compaction", status: "in_progress", ... }` をpushし、streaming_parts内のインデックスを `compaction_part_index: Option<usize>` として `AgentProcess` 構造体に記録
+- `compact_boundary` 受信時: 記録したインデックスの既存partを `status: "completed"` に更新（新しいpartは追加しない）。deltaとして更新後のpartを送信
+
+Hook:
+- `hook_started` 受信時: `hook_id` をキーにpushし、`hook_part_indices: HashMap<String, usize>` に `AgentProcess` 構造体で記録
+- `hook_response` 受信時: `hook_id` で既存partを検索し、status/label/detailを更新。deltaとして更新後のpartを送信
+
+**非表示メッセージ（既存処理を維持）**:
+- `init`: `accumulate_sdk_message` で `false` を返す（既存）
+- `task_started/task_progress/task_notification`: 既存の `TaskStatus` 処理を維持（既存）
+- `status` で `permissionMode` 付き: フロントエンドでpermissionMode同期として処理（既存の `agent-sdk-message` フォワード）
+
+**検討した代替案**:
+- フロントエンド側のみで処理: Rust変更なしだが永続化されず、セッション再読み込み時に消失。全ロジックをRustに寄せる方針に反する
+
+**OSSプロジェクト調査結果**:
+- VS Code/Genie/claude-view/OpenCow/GSD/BotVa/ACP の7プロジェクトを調査
+- 全プロジェクトが `type` → `subtype` の2段階分岐を使用
+- `compact_boundary` はほぼ全プロジェクトで処理対象
+- `files_persisted`/`local_command_output` は多くのプロジェクトで未実装またはno-op
+- Hook系は対応が分かれる（トレーシング/監査ログ/スキップ）
+
+**影響するテスト**:
+- Rust単体テスト: `session/mod.rs` — `SystemNotification` のserde roundtrip、後方互換性
+- Rust単体テスト: `agent_sdk.rs` — `accumulate_sdk_message()` の各subtypeの変換テスト（compacting, compact_boundary, hook_started, hook_response, files_persisted, local_command_output）
+- Rust単体テスト: `agent_sdk.rs` — Compaction/Hookの開始→完了で同一partが更新されるテスト
+- フロントエンドテスト: `AgentChatPanel` — `system_notification` partの表示テスト
+- フロントエンドテスト: `session.ts` — `system_notification` が無い古いJSONのデシリアライズ後方互換性

--- a/docs/spec/issues-746.md
+++ b/docs/spec/issues-746.md
@@ -114,12 +114,12 @@ TypeScript:
 **開始→完了の同一part更新メカニズム**:
 
 Compaction:
-- `status=compacting` 受信時: `SystemNotification { notification_type: "compaction", status: "in_progress", ... }` をpushし、streaming_parts内のインデックスを `compaction_part_index: Option<usize>` として `AgentProcess` 構造体に記録
-- `compact_boundary` 受信時: 記録したインデックスの既存partを `status: "completed"` に更新（新しいpartは追加しない）。deltaとして更新後のpartを送信
+- `status=compacting` 受信時: `SystemNotification { notification_type: "compaction", status: "in_progress", ... }` を `streaming_parts` にpush
+- `compact_boundary` 受信時: `streaming_parts` を逆走査し、`notification_type == "compaction" && status == "in_progress"` に一致する最新のpartを `status: "completed"` に更新。deltaとして更新後のpartを送信。該当partがなければcompleted状態で新規push
 
 Hook:
-- `hook_started` 受信時: `hook_id` をキーにpushし、`hook_part_indices: HashMap<String, usize>` に `AgentProcess` 構造体で記録
-- `hook_response` 受信時: `hook_id` で既存partを検索し、status/label/detailを更新。deltaとして更新後のpartを送信
+- `hook_started` 受信時: `hook_id` 付きの `SystemNotification` を `streaming_parts` にpush（`hook_id` が空文字または未設定の場合は `None` として保存）
+- `hook_response` 受信時: `streaming_parts` を逆走査し、`notification_type == "hook" && status == "in_progress" && hook_id` が一致するpartを検索してstatus/detailを更新。deltaとして更新後のpartを送信。該当partがなければ新規push
 
 **非表示メッセージ（既存処理を維持）**:
 - `init`: `accumulate_sdk_message` で `false` を返す（既存）

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -508,19 +508,22 @@ fn accumulate_sdk_message(
                     let hook_id = msg
                         .get("hook_id")
                         .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
+                        .filter(|id| !id.is_empty())
+                        .map(|id| id.to_string());
                     parts.push(MessagePart::SystemNotification {
                         notification_type: "hook".to_string(),
                         status: "in_progress".to_string(),
                         label: format!("{hook_name} ({hook_event})"),
                         detail: None,
-                        hook_id: Some(hook_id),
+                        hook_id: hook_id.clone(),
                     });
                     (true, None)
                 }
                 "hook_response" => {
-                    let hook_id = msg.get("hook_id").and_then(|v| v.as_str()).unwrap_or("");
+                    let hook_id = msg
+                        .get("hook_id")
+                        .and_then(|v| v.as_str())
+                        .filter(|id| !id.is_empty());
                     let outcome = msg
                         .get("outcome")
                         .and_then(|v| v.as_str())
@@ -550,7 +553,7 @@ fn accumulate_sdk_message(
                         {
                             if notification_type == "hook"
                                 && status == "in_progress"
-                                && hid.as_deref() == Some(hook_id)
+                                && hid.as_deref() == hook_id
                             {
                                 *status = new_status.to_string();
                                 *d = Some(detail.clone());
@@ -576,7 +579,7 @@ fn accumulate_sdk_message(
                             status: new_status.to_string(),
                             label: format!("{hook_name} ({hook_event})"),
                             detail: Some(detail),
-                            hook_id: Some(hook_id.to_string()),
+                            hook_id: hook_id.map(|id| id.to_string()),
                         });
                         (true, None)
                     }

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -287,12 +287,15 @@ fn extract_agent_id(content: &str) -> Option<&str> {
 }
 
 /// Parse SDK message and accumulate into streaming_parts.
-/// Returns true if the message was handled (accumulated) and should NOT be forwarded as agent-sdk-message.
+/// Returns (accumulated, updated_parts):
+/// - accumulated: true if the message was handled and should NOT be forwarded as agent-sdk-message.
+/// - updated_parts: Some(parts) when an existing part was updated in-place (e.g. compaction/hook completion).
+///   These must be emitted as delta since they are not captured by the `parts[prev_len..]` diff.
 fn accumulate_sdk_message(
     msg: &serde_json::Value,
     parts: &mut Vec<MessagePart>,
     task_id_map: &mut HashMap<String, String>,
-) -> bool {
+) -> (bool, Option<Vec<MessagePart>>) {
     let msg_type = msg.get("type").and_then(|v| v.as_str()).unwrap_or("");
     let parent_tool_use_id = msg
         .get("parent_tool_use_id")
@@ -309,18 +312,18 @@ fn accumulate_sdk_message(
                         if delta_type == "text_delta" {
                             if let Some(text) = delta.get("text").and_then(|v| v.as_str()) {
                                 append_to_parts(parts, "text", text, parent_tool_use_id);
-                                return true;
+                                return (true, None);
                             }
                         } else if delta_type == "thinking_delta" {
                             if let Some(thinking) = delta.get("thinking").and_then(|v| v.as_str()) {
                                 append_to_parts(parts, "thinking", thinking, parent_tool_use_id);
-                                return true;
+                                return (true, None);
                             }
                         }
                     }
                 }
             }
-            false
+            (false, None)
         }
         "assistant" => {
             if let Some(message) = msg.get("message") {
@@ -352,7 +355,7 @@ fn accumulate_sdk_message(
                     }
                 }
             }
-            true
+            (true, None)
         }
         "user" => {
             if let Some(message) = msg.get("message") {
@@ -389,7 +392,7 @@ fn accumulate_sdk_message(
                     }
                 }
             }
-            true
+            (true, None)
         }
         "permission_request" => {
             let request = msg.clone();
@@ -399,7 +402,7 @@ fn accumulate_sdk_message(
                 answers: None,
                 parent_tool_use_id,
             });
-            true
+            (true, None)
         }
         "system" => {
             let subtype = msg.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
@@ -441,9 +444,207 @@ fn accumulate_sdk_message(
                         description,
                         summary,
                     });
-                    true
+                    (true, None)
                 }
-                _ => false, // permissionMode sync, other system messages → forward
+                "init" => (false, None), // init message → forward (not accumulated)
+                "compact_boundary" => {
+                    // Compaction completed: find the in-progress compaction part and update it
+                    let trigger = msg
+                        .get("compact_metadata")
+                        .and_then(|m| m.get("trigger"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let pre_tokens = msg
+                        .get("compact_metadata")
+                        .and_then(|m| m.get("pre_summary_token_count"))
+                        .and_then(|v| v.as_u64())
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "?".to_string());
+                    let detail = format!("trigger={trigger}, {pre_tokens} tokens");
+
+                    // Walk parts in reverse to find the in-progress compaction notification
+                    let mut updated_part = None;
+                    for part in parts.iter_mut().rev() {
+                        if let MessagePart::SystemNotification {
+                            notification_type,
+                            status,
+                            label,
+                            detail: d,
+                            ..
+                        } = part
+                        {
+                            if notification_type == "compaction" && status == "in_progress" {
+                                *status = "completed".to_string();
+                                *label = "Conversation compacted".to_string();
+                                *d = Some(detail.clone());
+                                updated_part = Some(part.clone());
+                                break;
+                            }
+                        }
+                    }
+                    if let Some(p) = updated_part {
+                        (true, Some(vec![p]))
+                    } else {
+                        // No in-progress compaction found, add a completed one directly
+                        parts.push(MessagePart::SystemNotification {
+                            notification_type: "compaction".to_string(),
+                            status: "completed".to_string(),
+                            label: "Conversation compacted".to_string(),
+                            detail: Some(detail),
+                            hook_id: None,
+                        });
+                        (true, None)
+                    }
+                }
+                "hook_started" => {
+                    let hook_name = msg
+                        .get("hook_name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let hook_event = msg
+                        .get("hook_event")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let hook_id = msg
+                        .get("hook_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    parts.push(MessagePart::SystemNotification {
+                        notification_type: "hook".to_string(),
+                        status: "in_progress".to_string(),
+                        label: format!("{hook_name} ({hook_event})"),
+                        detail: None,
+                        hook_id: Some(hook_id),
+                    });
+                    (true, None)
+                }
+                "hook_response" => {
+                    let hook_id = msg.get("hook_id").and_then(|v| v.as_str()).unwrap_or("");
+                    let outcome = msg
+                        .get("outcome")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let exit_code = msg
+                        .get("exit_code")
+                        .and_then(|v| v.as_i64())
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "?".to_string());
+                    let new_status = if outcome == "error" {
+                        "error"
+                    } else {
+                        "completed"
+                    };
+                    let detail = format!("outcome={outcome}, exit_code={exit_code}");
+
+                    // Walk parts in reverse to find the matching hook_started notification
+                    let mut updated_part = None;
+                    for part in parts.iter_mut().rev() {
+                        if let MessagePart::SystemNotification {
+                            notification_type,
+                            status,
+                            detail: d,
+                            hook_id: hid,
+                            ..
+                        } = part
+                        {
+                            if notification_type == "hook"
+                                && status == "in_progress"
+                                && hid.as_deref() == Some(hook_id)
+                            {
+                                *status = new_status.to_string();
+                                *d = Some(detail.clone());
+                                updated_part = Some(part.clone());
+                                break;
+                            }
+                        }
+                    }
+                    if let Some(p) = updated_part {
+                        (true, Some(vec![p]))
+                    } else {
+                        // No matching hook_started found, add a standalone completed entry
+                        let hook_name = msg
+                            .get("hook_name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown");
+                        let hook_event = msg
+                            .get("hook_event")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown");
+                        parts.push(MessagePart::SystemNotification {
+                            notification_type: "hook".to_string(),
+                            status: new_status.to_string(),
+                            label: format!("{hook_name} ({hook_event})"),
+                            detail: Some(detail),
+                            hook_id: Some(hook_id.to_string()),
+                        });
+                        (true, None)
+                    }
+                }
+                "files_persisted" => {
+                    let file_paths = msg
+                        .get("filePaths")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        })
+                        .unwrap_or_default();
+                    parts.push(MessagePart::SystemNotification {
+                        notification_type: "files_persisted".to_string(),
+                        status: "completed".to_string(),
+                        label: "Files persisted".to_string(),
+                        detail: if file_paths.is_empty() {
+                            None
+                        } else {
+                            Some(file_paths)
+                        },
+                        hook_id: None,
+                    });
+                    (true, None)
+                }
+                "local_command_output" => {
+                    let content = msg.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                    let truncated = if content.chars().count() > 200 {
+                        // Truncate at char boundary
+                        match content.char_indices().nth(200) {
+                            Some((byte_pos, _)) => format!("{}…", &content[..byte_pos]),
+                            None => content.to_string(),
+                        }
+                    } else {
+                        content.to_string()
+                    };
+                    parts.push(MessagePart::SystemNotification {
+                        notification_type: "local_command_output".to_string(),
+                        status: "completed".to_string(),
+                        label: "Command output".to_string(),
+                        detail: if truncated.is_empty() {
+                            None
+                        } else {
+                            Some(truncated)
+                        },
+                        hook_id: None,
+                    });
+                    (true, None)
+                }
+                _ => {
+                    // Check for status=compacting (subtype may be empty/"" for status messages)
+                    let status = msg.get("status").and_then(|v| v.as_str()).unwrap_or("");
+                    if status == "compacting" {
+                        parts.push(MessagePart::SystemNotification {
+                            notification_type: "compaction".to_string(),
+                            status: "in_progress".to_string(),
+                            label: "Compacting conversation...".to_string(),
+                            detail: None,
+                            hook_id: None,
+                        });
+                        (true, None)
+                    } else {
+                        (false, None) // permissionMode sync, other system messages → forward
+                    }
+                }
             }
         }
         "error" => {
@@ -455,9 +656,9 @@ fn accumulate_sdk_message(
                 content: format!("Error: {}", error_text),
                 parent_tool_use_id,
             });
-            false // Still forward for handleBridgeError
+            (false, None) // Still forward for handleBridgeError
         }
-        _ => false,
+        _ => (false, None),
     }
 }
 
@@ -790,7 +991,7 @@ async fn spawn_bridge_process(
                                     && proc.streaming_message_id.is_some()
                                 {
                                     let prev_len = proc.streaming_parts.len();
-                                    let acc = accumulate_sdk_message(
+                                    let (acc, updated_parts) = accumulate_sdk_message(
                                         &msg,
                                         &mut proc.streaming_parts,
                                         &mut proc.task_id_map,
@@ -799,8 +1000,12 @@ async fn spawn_bridge_process(
                                         (false, Vec::new(), None, false, Vec::new())
                                     } else {
                                         // Extract only newly added parts as delta
-                                        let delta: Vec<MessagePart> =
+                                        let mut delta: Vec<MessagePart> =
                                             proc.streaming_parts[prev_len..].to_vec();
+                                        // Include in-place updated parts in the delta
+                                        if let Some(up) = updated_parts {
+                                            delta.extend(up);
+                                        }
                                         let mid = proc.streaming_message_id.clone();
 
                                         let now = std::time::Instant::now();
@@ -821,7 +1026,7 @@ async fn spawn_bridge_process(
                                     // (task_notification, task_progress, etc.)
                                     // Accumulate and emit immediately (no throttle needed).
                                     let prev_len = proc.streaming_parts.len();
-                                    let acc = accumulate_sdk_message(
+                                    let (acc, updated_parts) = accumulate_sdk_message(
                                         &msg,
                                         &mut proc.streaming_parts,
                                         &mut proc.task_id_map,
@@ -829,8 +1034,11 @@ async fn spawn_bridge_process(
                                     if !acc {
                                         (false, Vec::new(), None, false, Vec::new())
                                     } else {
-                                        let delta: Vec<MessagePart> =
+                                        let mut delta: Vec<MessagePart> =
                                             proc.streaming_parts[prev_len..].to_vec();
+                                        if let Some(up) = updated_parts {
+                                            delta.extend(up);
+                                        }
                                         let mid = proc.last_message_id.clone();
 
                                         // Always persist post-turn events immediately
@@ -2468,7 +2676,7 @@ mod tests {
             }
         });
         let mut parts = vec![];
-        let handled = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
         assert!(handled);
         assert_eq!(parts.len(), 1);
         match &parts[0] {
@@ -2487,7 +2695,7 @@ mod tests {
             }
         });
         let mut parts = vec![];
-        let handled = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
         assert!(handled);
         assert_eq!(parts.len(), 1);
         match &parts[0] {
@@ -2510,7 +2718,7 @@ mod tests {
             }
         });
         let mut parts = vec![];
-        let handled = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
         assert!(handled);
         assert_eq!(parts.len(), 1);
         match &parts[0] {
@@ -2536,7 +2744,7 @@ mod tests {
             }
         });
         let mut parts = vec![];
-        let handled = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
         assert!(handled);
         assert_eq!(parts.len(), 1);
         match &parts[0] {
@@ -2562,7 +2770,7 @@ mod tests {
             "tool_name": "Edit"
         });
         let mut parts = vec![];
-        let handled = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
         assert!(handled);
         assert_eq!(parts.len(), 1);
         assert!(matches!(&parts[0], MessagePart::Permission { status, .. } if status == "pending"));
@@ -2587,7 +2795,7 @@ mod tests {
             "message": "Something went wrong"
         });
         let mut parts = vec![];
-        let handled = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
         assert!(!handled);
         assert_eq!(parts.len(), 1);
         match &parts[0] {
@@ -2607,7 +2815,7 @@ mod tests {
             "description": "Searching"
         });
         let mut parts = vec![];
-        let handled = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
         assert!(handled);
         assert_eq!(parts.len(), 1);
         match &parts[0] {
@@ -2716,6 +2924,334 @@ mod tests {
             }
             _ => panic!("expected TaskStatus"),
         }
+    }
+
+    // --- SystemNotification accumulate tests ---
+
+    #[test]
+    fn test_accumulate_compaction_start() {
+        let msg = serde_json::json!({
+            "type": "system",
+            "status": "compacting"
+        });
+        let mut parts = vec![];
+        let (handled, updated) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        assert!(updated.is_none());
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            MessagePart::SystemNotification {
+                notification_type,
+                status,
+                label,
+                detail,
+                hook_id,
+            } => {
+                assert_eq!(notification_type, "compaction");
+                assert_eq!(status, "in_progress");
+                assert_eq!(label, "Compacting conversation...");
+                assert_eq!(*detail, None);
+                assert_eq!(*hook_id, None);
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_compaction_complete_updates_existing() {
+        let mut parts = vec![MessagePart::SystemNotification {
+            notification_type: "compaction".to_string(),
+            status: "in_progress".to_string(),
+            label: "Compacting conversation...".to_string(),
+            detail: None,
+            hook_id: None,
+        }];
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "compact_metadata": {
+                "trigger": "auto",
+                "pre_summary_token_count": 50000
+            }
+        });
+        let (handled, updated) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        assert!(updated.is_some());
+        let updated_parts = updated.unwrap();
+        assert_eq!(updated_parts.len(), 1);
+        // Verify the part was updated in-place
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            MessagePart::SystemNotification {
+                notification_type,
+                status,
+                label,
+                detail,
+                ..
+            } => {
+                assert_eq!(notification_type, "compaction");
+                assert_eq!(status, "completed");
+                assert_eq!(label, "Conversation compacted");
+                assert!(detail.as_ref().unwrap().contains("trigger=auto"));
+                assert!(detail.as_ref().unwrap().contains("50000 tokens"));
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_compaction_complete_without_start() {
+        let mut parts = vec![];
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "compact_metadata": {
+                "trigger": "manual",
+                "pre_summary_token_count": 10000
+            }
+        });
+        let (handled, updated) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        assert!(updated.is_none()); // No existing part to update, new one pushed
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            MessagePart::SystemNotification { status, label, .. } => {
+                assert_eq!(status, "completed");
+                assert_eq!(label, "Conversation compacted");
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_hook_started() {
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "hook_started",
+            "hook_name": "SessionEnd",
+            "hook_event": "StopSession",
+            "hook_id": "hook-001"
+        });
+        let mut parts = vec![];
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            MessagePart::SystemNotification {
+                notification_type,
+                status,
+                label,
+                hook_id,
+                ..
+            } => {
+                assert_eq!(notification_type, "hook");
+                assert_eq!(status, "in_progress");
+                assert_eq!(label, "SessionEnd (StopSession)");
+                assert_eq!(hook_id.as_deref(), Some("hook-001"));
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_hook_response_updates_existing() {
+        let mut parts = vec![MessagePart::SystemNotification {
+            notification_type: "hook".to_string(),
+            status: "in_progress".to_string(),
+            label: "SessionEnd (StopSession)".to_string(),
+            detail: None,
+            hook_id: Some("hook-001".to_string()),
+        }];
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "hook_response",
+            "hook_id": "hook-001",
+            "outcome": "success",
+            "exit_code": 0
+        });
+        let (handled, updated) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        assert!(updated.is_some());
+        assert_eq!(parts.len(), 1); // Updated in-place
+        match &parts[0] {
+            MessagePart::SystemNotification { status, detail, .. } => {
+                assert_eq!(status, "completed");
+                assert!(detail.as_ref().unwrap().contains("outcome=success"));
+                assert!(detail.as_ref().unwrap().contains("exit_code=0"));
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_hook_response_error_status() {
+        let mut parts = vec![MessagePart::SystemNotification {
+            notification_type: "hook".to_string(),
+            status: "in_progress".to_string(),
+            label: "PreCompact (Compact)".to_string(),
+            detail: None,
+            hook_id: Some("hook-err".to_string()),
+        }];
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "hook_response",
+            "hook_id": "hook-err",
+            "outcome": "error",
+            "exit_code": 1
+        });
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        match &parts[0] {
+            MessagePart::SystemNotification { status, .. } => {
+                assert_eq!(status, "error");
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_files_persisted() {
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "files_persisted",
+            "filePaths": ["CLAUDE.md", "src/main.rs"]
+        });
+        let mut parts = vec![];
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            MessagePart::SystemNotification {
+                notification_type,
+                status,
+                label,
+                detail,
+                ..
+            } => {
+                assert_eq!(notification_type, "files_persisted");
+                assert_eq!(status, "completed");
+                assert_eq!(label, "Files persisted");
+                assert_eq!(detail.as_deref(), Some("CLAUDE.md, src/main.rs"));
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_local_command_output() {
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "local_command_output",
+            "content": "npm test output here"
+        });
+        let mut parts = vec![];
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            MessagePart::SystemNotification {
+                notification_type,
+                status,
+                label,
+                detail,
+                ..
+            } => {
+                assert_eq!(notification_type, "local_command_output");
+                assert_eq!(status, "completed");
+                assert_eq!(label, "Command output");
+                assert_eq!(detail.as_deref(), Some("npm test output here"));
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_local_command_output_truncates_long_content() {
+        let long_content = "a".repeat(300);
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "local_command_output",
+            "content": long_content
+        });
+        let mut parts = vec![];
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        match &parts[0] {
+            MessagePart::SystemNotification { detail, .. } => {
+                let d = detail.as_ref().unwrap();
+                assert!(d.len() <= 200 + "…".len());
+                assert!(d.ends_with('…'));
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_local_command_output_truncates_multibyte() {
+        let long_content = "あ".repeat(201);
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "local_command_output",
+            "content": long_content
+        });
+        let mut parts = vec![];
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        match &parts[0] {
+            MessagePart::SystemNotification { detail, .. } => {
+                let d = detail.as_ref().unwrap();
+                assert!(d.ends_with('…'));
+                let without_ellipsis = d.trim_end_matches('…');
+                assert_eq!(without_ellipsis.chars().count(), 200);
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_local_command_output_no_truncate_short_multibyte() {
+        let content = "あ".repeat(100);
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "local_command_output",
+            "content": content
+        });
+        let mut parts = vec![];
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(handled);
+        match &parts[0] {
+            MessagePart::SystemNotification { detail, .. } => {
+                let d = detail.as_ref().unwrap();
+                assert!(!d.ends_with('…'));
+                assert_eq!(d.chars().count(), 100);
+            }
+            _ => panic!("expected SystemNotification"),
+        }
+    }
+
+    #[test]
+    fn test_accumulate_init_not_handled() {
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "init",
+            "session_id": "sess-123"
+        });
+        let mut parts = vec![];
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(!handled);
+        assert!(parts.is_empty());
+    }
+
+    #[test]
+    fn test_accumulate_permission_mode_status_not_handled() {
+        let msg = serde_json::json!({
+            "type": "system",
+            "permissionMode": "acceptEdits"
+        });
+        let mut parts = vec![];
+        let (handled, _) = accumulate_sdk_message(&msg, &mut parts, &mut HashMap::new());
+        assert!(!handled);
+        assert!(parts.is_empty());
     }
 
     // --- consolidate_parts tests ---

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -81,6 +81,16 @@ pub enum MessagePart {
         #[serde(skip_serializing_if = "Option::is_none", default)]
         summary: Option<String>,
     },
+    SystemNotification {
+        #[serde(rename = "notificationType")]
+        notification_type: String,
+        status: String,
+        label: String,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        detail: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", default, rename = "hookId")]
+        hook_id: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -276,6 +286,7 @@ pub fn parts_to_legacy(
                 }
             }
             MessagePart::TaskStatus { .. } => {}
+            MessagePart::SystemNotification { .. } => {}
         }
     }
     let thinking = if thinking.is_empty() {
@@ -928,6 +939,54 @@ mod tests {
         } else {
             panic!("Expected Text variant");
         }
+    }
+
+    #[test]
+    fn system_notification_serde_roundtrip() {
+        let part = MessagePart::SystemNotification {
+            notification_type: "compaction".to_string(),
+            status: "completed".to_string(),
+            label: "Conversation compacted".to_string(),
+            detail: Some("trigger=auto, 50000 tokens".to_string()),
+            hook_id: None,
+        };
+        let json = serde_json::to_string(&part).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "system_notification");
+        assert_eq!(v["notificationType"], "compaction");
+        assert_eq!(v["status"], "completed");
+        assert_eq!(v["label"], "Conversation compacted");
+        assert_eq!(v["detail"], "trigger=auto, 50000 tokens");
+        assert!(v.get("hookId").is_none());
+        let back: MessagePart = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, part);
+    }
+
+    #[test]
+    fn system_notification_with_hook_id_serde_roundtrip() {
+        let part = MessagePart::SystemNotification {
+            notification_type: "hook".to_string(),
+            status: "in_progress".to_string(),
+            label: "SessionEnd (StopSession)".to_string(),
+            detail: None,
+            hook_id: Some("hook-001".to_string()),
+        };
+        let json = serde_json::to_string(&part).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["hookId"], "hook-001");
+        assert!(v.get("detail").is_none());
+        let back: MessagePart = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, part);
+    }
+
+    #[test]
+    fn old_json_without_system_notification_deserializes() {
+        // Backward compat: old session JSON without system_notification parts
+        let json = r#"[{"type":"text","content":"hello"},{"type":"task_status","taskToolUseId":"t1","status":"started"}]"#;
+        let parts: Vec<MessagePart> = serde_json::from_str(json).unwrap();
+        assert_eq!(parts.len(), 2);
+        assert!(matches!(&parts[0], MessagePart::Text { .. }));
+        assert!(matches!(&parts[1], MessagePart::TaskStatus { .. }));
     }
 
     #[test]

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
@@ -874,6 +874,164 @@ describe("AgentChatPanel Task tool rendering", () => {
 	});
 });
 
+describe("SystemNotificationItem rendering", () => {
+	it("shows ⏳ with animate-pulse when status is in_progress", () => {
+		mockUseAgentChat({
+			isStreaming: true,
+			activeSession: {
+				id: "s1",
+				worktreePath: "/repo",
+				messages: [
+					{
+						id: "m1",
+						role: "human",
+						parts: [{ type: "text", content: "hello" }],
+						timestamp: 1000,
+					},
+					{
+						id: "m2",
+						role: "agent",
+						parts: [
+							{
+								type: "system_notification",
+								notificationType: "compaction",
+								status: "in_progress",
+								label: "Compacting conversation...",
+							},
+						],
+						timestamp: 1001,
+					},
+				],
+				state: "active",
+				createdAt: 1000,
+				updatedAt: 1000,
+			},
+		});
+		render(<AgentChatPanel worktreePath="/repo" />);
+		const el = screen.getByText(/Compacting conversation/);
+		expect(el).toBeDefined();
+		expect(el.textContent).toContain("⏳");
+		expect(el.className).toContain("animate-pulse");
+	});
+
+	it("shows ✓ when status is completed", () => {
+		mockUseAgentChat({
+			isStreaming: false,
+			activeSession: {
+				id: "s1",
+				worktreePath: "/repo",
+				messages: [
+					{
+						id: "m1",
+						role: "human",
+						parts: [{ type: "text", content: "hello" }],
+						timestamp: 1000,
+					},
+					{
+						id: "m2",
+						role: "agent",
+						parts: [
+							{
+								type: "system_notification",
+								notificationType: "compaction",
+								status: "completed",
+								label: "Conversation compacted",
+							},
+						],
+						timestamp: 1001,
+					},
+				],
+				state: "idle",
+				createdAt: 1000,
+				updatedAt: 1000,
+			},
+		});
+		render(<AgentChatPanel worktreePath="/repo" />);
+		const el = screen.getByText(/Conversation compacted/);
+		expect(el).toBeDefined();
+		expect(el.textContent).toContain("✓");
+		expect(el.className).not.toContain("animate-pulse");
+	});
+
+	it("shows ❌ when status is error", () => {
+		mockUseAgentChat({
+			isStreaming: false,
+			activeSession: {
+				id: "s1",
+				worktreePath: "/repo",
+				messages: [
+					{
+						id: "m1",
+						role: "human",
+						parts: [{ type: "text", content: "hello" }],
+						timestamp: 1000,
+					},
+					{
+						id: "m2",
+						role: "agent",
+						parts: [
+							{
+								type: "system_notification",
+								notificationType: "hook",
+								status: "error",
+								label: "pre-commit (PromptSubmit)",
+								hookId: "hook-1",
+							},
+						],
+						timestamp: 1001,
+					},
+				],
+				state: "idle",
+				createdAt: 1000,
+				updatedAt: 1000,
+			},
+		});
+		render(<AgentChatPanel worktreePath="/repo" />);
+		const el = screen.getByText(/pre-commit/);
+		expect(el).toBeDefined();
+		expect(el.textContent).toContain("❌");
+	});
+
+	it("shows detail in parentheses when detail is provided", () => {
+		mockUseAgentChat({
+			isStreaming: false,
+			activeSession: {
+				id: "s1",
+				worktreePath: "/repo",
+				messages: [
+					{
+						id: "m1",
+						role: "human",
+						parts: [{ type: "text", content: "hello" }],
+						timestamp: 1000,
+					},
+					{
+						id: "m2",
+						role: "agent",
+						parts: [
+							{
+								type: "system_notification",
+								notificationType: "compaction",
+								status: "completed",
+								label: "Conversation compacted",
+								detail: "trigger=auto, 50000 tokens",
+							},
+						],
+						timestamp: 1001,
+					},
+				],
+				state: "idle",
+				createdAt: 1000,
+				updatedAt: 1000,
+			},
+		});
+		render(<AgentChatPanel worktreePath="/repo" />);
+		expect(
+			screen.getByText("(trigger=auto, 50000 tokens)"),
+		).toBeDefined();
+	});
+});
+
 describe("AgentChatPanel session history", () => {
 	it("renders history button", () => {
 		mockUseAgentChat();

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
@@ -1026,9 +1026,7 @@ describe("SystemNotificationItem rendering", () => {
 			},
 		});
 		render(<AgentChatPanel worktreePath="/repo" />);
-		expect(
-			screen.getByText("(trigger=auto, 50000 tokens)"),
-		).toBeDefined();
+		expect(screen.getByText("(trigger=auto, 50000 tokens)")).toBeDefined();
 	});
 });
 

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
@@ -15,7 +15,7 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAgentChat } from "@/hooks/useAgentChat";
 import { loadSlashCommands } from "@/hooks/useSlashCommands";
-import type { ChatMessage } from "@/types/session";
+import type { ChatMessage, MessagePart } from "@/types/session";
 import { getTextContent } from "@/types/session";
 import {
 	ActivityItem,
@@ -29,6 +29,24 @@ import { PermissionDialog } from "./PermissionDialog";
 import { ShimmerPlaceholder } from "./ShimmerPlaceholder";
 import { StreamMessage } from "./StreamMessage";
 import { buildToolPairings, type TaskGroup } from "./toolPairing";
+
+type SystemNotificationPart = Extract<
+	MessagePart,
+	{ type: "system_notification" }
+>;
+
+function SystemNotificationItem({ part }: { part: SystemNotificationPart }) {
+	const isInProgress = part.status === "in_progress";
+	return (
+		<div className="px-5 py-0.5 text-xs text-muted-foreground">
+			<span className={isInProgress ? "animate-pulse" : ""}>
+				{isInProgress ? "⏳ " : part.status === "error" ? "❌ " : "✓ "}
+				{part.label}
+			</span>
+			{part.detail && <span className="ml-1 opacity-70">({part.detail})</span>}
+		</div>
+	);
+}
 
 interface AgentMessagePartsProps {
 	msg: ChatMessage;
@@ -178,6 +196,8 @@ const AgentMessageParts = React.memo(function AgentMessageParts({
 								}
 							/>
 						);
+					case "system_notification":
+						return <SystemNotificationItem key={key} part={part} />;
 				}
 			})}
 			{runningBackgroundTasks.map((group) => (
@@ -268,6 +288,7 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 			case "tool_use":
 			case "tool_result":
 			case "task_status":
+			case "system_notification":
 				return 2;
 			case "text":
 				return 1;

--- a/src/hooks/agentChatReducer.test.ts
+++ b/src/hooks/agentChatReducer.test.ts
@@ -632,5 +632,80 @@ describe("agentChatReducer", () => {
 			const result = mergeDeltaParts(existing, delta);
 			expect(result).toHaveLength(2);
 		});
+
+		it("updates existing compaction notification in-place", () => {
+			const existing = [
+				{
+					type: "system_notification" as const,
+					notificationType: "compaction" as const,
+					status: "in_progress" as const,
+					label: "Compacting conversation...",
+				},
+			];
+			const delta = [
+				{
+					type: "system_notification" as const,
+					notificationType: "compaction" as const,
+					status: "completed" as const,
+					label: "Conversation compacted",
+					detail: "trigger=auto, 50000 tokens",
+				},
+			];
+			const result = mergeDeltaParts(existing, delta);
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({
+				type: "system_notification",
+				notificationType: "compaction",
+				status: "completed",
+				label: "Conversation compacted",
+				detail: "trigger=auto, 50000 tokens",
+			});
+		});
+
+		it("updates existing hook notification by hookId", () => {
+			const existing = [
+				{
+					type: "system_notification" as const,
+					notificationType: "hook" as const,
+					status: "in_progress" as const,
+					label: "SessionEnd (StopSession)",
+					hookId: "hook-001",
+				},
+			];
+			const delta = [
+				{
+					type: "system_notification" as const,
+					notificationType: "hook" as const,
+					status: "completed" as const,
+					label: "SessionEnd (StopSession)",
+					detail: "outcome=success, exit_code=0",
+					hookId: "hook-001",
+				},
+			];
+			const result = mergeDeltaParts(existing, delta);
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual(
+				expect.objectContaining({
+					status: "completed",
+					detail: "outcome=success, exit_code=0",
+				}),
+			);
+		});
+
+		it("appends new system_notification when no match found", () => {
+			const existing = [{ type: "text" as const, content: "hello" }];
+			const delta = [
+				{
+					type: "system_notification" as const,
+					notificationType: "files_persisted" as const,
+					status: "completed" as const,
+					label: "Files persisted",
+					detail: "CLAUDE.md",
+				},
+			];
+			const result = mergeDeltaParts(existing, delta);
+			expect(result).toHaveLength(2);
+			expect(result[1].type).toBe("system_notification");
+		});
 	});
 });

--- a/src/hooks/agentChatReducer.ts
+++ b/src/hooks/agentChatReducer.ts
@@ -92,6 +92,26 @@ export function mergeDeltaParts(
 			} else {
 				result.push(part);
 			}
+		} else if (part.type === "system_notification") {
+			// Update existing notification in-place (compaction/hook completion)
+			const idx = result.findIndex((p) => {
+				if (p.type !== "system_notification") return false;
+				if (p.notificationType !== part.notificationType) return false;
+				// Hook: match by hookId
+				if (part.notificationType === "hook" && part.hookId) {
+					return p.hookId === part.hookId;
+				}
+				// Compaction: match by notificationType (only one active at a time)
+				if (part.notificationType === "compaction") {
+					return p.status === "in_progress";
+				}
+				return false;
+			});
+			if (idx !== -1) {
+				result[idx] = part;
+			} else {
+				result.push(part);
+			}
 		} else {
 			result.push(part);
 		}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -52,6 +52,18 @@ export type MessagePart =
 			status: "started" | "completed" | "failed" | "stopped" | "progress";
 			description?: string;
 			summary?: string;
+	  }
+	| {
+			type: "system_notification";
+			notificationType:
+				| "compaction"
+				| "hook"
+				| "files_persisted"
+				| "local_command_output";
+			status: "in_progress" | "completed" | "error";
+			label: string;
+			detail?: string;
+			hookId?: string;
 	  };
 
 export type ActivityEntry =


### PR DESCRIPTION
## Summary
- Compaction・Hook・files_persisted・local_command_outputのSDKシステムメッセージをSystemNotification partとしてAgentChat上にインライン表示
- Compaction/Hookは開始→完了を同一partのインプレース更新で表現（status: in_progress → completed）
- init/task関連/permissionMode同期は非表示（既存処理を維持）

## Test plan
- [ ] Rust単体テスト: 各subtypeの変換テスト（compacting, compact_boundary, hook_started, hook_response, files_persisted, local_command_output）
- [ ] Rust単体テスト: Compaction/Hookの開始→完了で同一partが更新されるテスト
- [ ] フロントエンドテスト: system_notification partの表示テスト
- [ ] フロントエンドテスト: mergeDeltaPartsによるsystem_notification更新テスト
- [ ] CI全PASS確認（lint, test, build, clippy）

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AgentChatでシステム通知機能を追加。タスク実行の進捗（進行中/完了/エラー）をリアルタイムで表示し、視覚的なステータスインジケーターと詳細情報の表示に対応。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->