### PR TITLE
fix: Agentセッション別permissionModeの永続化・復元 (#749)

### DIFF
--- a/docs/spec/issues-749.md
+++ b/docs/spec/issues-749.md
@@ -1,0 +1,91 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: Workspaceを切り替えると、Agentのモード選択がデフォルトにリセットされる
+**期待する挙動**: 各Workspaceが独立したAgentモードを保持し、Workspace切り替え時にそのWorkspaceのモードが復元される
+**再現手順**:
+1. Agentのモードをデフォルト以外（例: Agentモード）に切り替える
+2. 別のWorkspaceに切り替える
+3. 元のWorkspaceに戻る
+4. Agentのモードがデフォルトにリセットされている
+**背景**: Workspace切り替え時にAgentのモード状態が失われるため、毎回モードを再設定する必要がありUXが悪い
+
+## 振る舞い定義
+
+```gherkin
+Feature: Agentセッション別モードの保持
+  Agentセッションのモード（Code/Ask/Plan/Bypass）がセッションごとに
+  独立して保持され、セッション切り替えやターン完了時に正しく維持される
+
+  Rule: モードはAgentセッションごとに独立して保持される
+    Scenario: セッション切り替え後にモードが復元される
+      Given Session Aでモードを"Plan"に変更している
+      And Session Bでモードを"Bypass"に変更している
+      When Session Aに切り替える
+      Then Session Aのモードが"Plan"である
+
+    Scenario: 新規セッションではデフォルトモードが適用される
+      Given 新規セッションを作成する
+      Then モードが"Code"である
+
+  Rule: モードセレクターはアクティブセッションのモードを表示する
+    Scenario: 切り替え先セッションのモードが表示に反映される
+      Given Session Aでモードを"Ask"に変更している
+      When Session Aに切り替える
+      Then モードセレクターに"Ask"と表示される
+
+  Rule: モードはターン完了後も維持される
+    Scenario: ターン完了後にPlanモードが維持される
+      Given モードを"Plan"に設定している
+      When エージェントのターンが完了する
+      Then モードが"Plan"のままである
+
+    Scenario: ターン完了後にBypassモードが維持される
+      Given モードを"Bypass"に設定している
+      When エージェントのターンが完了する
+      Then モードが"Bypass"のままである
+
+    Scenario: ターン完了後にAskモードが維持される
+      Given モードを"Ask"に設定している
+      When エージェントのターンが完了する
+      Then モードが"Ask"のままである
+
+  Rule: Plan承認後はCodeモードに切り替わる
+    Scenario: Plan承認後にCodeモードになる
+      Given モードを"Plan"に設定している
+      When エージェントの計画が承認される
+      Then モードが"Code"に切り替わる
+```
+
+## 実装仕様
+
+**対応方針**: Agentセッション別のモード保持を実現するために、Rust側のChatSessionに`permission_mode`（ユーザー設定モード）を永続化し、モード管理ロジック（保存・復元・Plan承認後の復元）を全てRust側に集約する。フロントエンドはRustから受け取ったモードを表示・送信するインターフェースに徹する。
+
+**対象コンポーネント**:
+
+Rust側:
+- `src-tauri/src/session/mod.rs`: `ChatSession`に`permission_mode: String`フィールド追加（デフォルト`"acceptEdits"`、既存JSON互換のため`#[serde(default)]`）。`SessionSummary`にも`permission_mode`を追加
+- `src-tauri/src/session/store.rs`: `update_permission_mode(session_id, mode)`メソッド追加
+- `src-tauri/src/agent_sdk.rs`:
+  - `set_agent_permission_mode`: Bridgeへの送信に加えて`SessionStore`に永続化
+  - `init_agent_sessions`: 各セッションのBridge起動時にセッション固有の`permission_mode`を使用
+  - SDK側から`permissionMode: "default"`（Plan承認後）が来た時、Rust側で`permission_mode`に基づいて`resolve_permission_mode`を実行し、Bridgeにrestoredモードを送信＋SessionStoreに保存＋フロントにイベント通知
+  - 新規Tauriイベント`agent-permission-mode-changed`を追加し、モード変更をフロントに通知
+
+フロントエンド側:
+- `src/hooks/agentChatReducer.ts`: `userPermissionMode`フィールド除去（Rust側に移行）。`permissionMode`はRust側から受け取った表示用の値のみ保持。`SET_USER_PERMISSION_MODE`/`RESTORE_USER_PERMISSION_MODE`アクション除去
+- `src/hooks/useAgentChat.ts`: `setPermissionMode`はRustコマンド呼び出しのみ（dispatchしない）。`selectSession`/`initSessions`で`GetSessionResponse`から`permissionMode`を取得してdispatch
+- `src/hooks/useAgentSdkListeners.ts`: `handlePermissionModeSync`からフロントエンドのモード復元ロジック除去。`agent-permission-mode-changed`イベントをlistenし、Rustから通知されたモードをdispatchするだけ
+- `src/types/session.ts`: `ChatSession`に`permissionMode`フィールド追加
+
+**検討した代替案**:
+- フロントエンドstateのみでモード管理（reducerに`sessionPermissionModes`マップを追加）: ロジックがフロント側に残るため却下
+
+**リスク**:
+- 既存JSONにpermission_modeフィールドがないセッションファイル: `#[serde(default = "default_permission_mode")]`で`"acceptEdits"`をデフォルト値とすることで後方互換性を確保
+
+**影響するテスト**:
+- Rust: `session/` — `permission_mode`の永続化・デフォルト値・後方互換性テスト
+- Rust: `agent_sdk` — モード変更・Plan承認後の復元ロジックテスト
+- フロントエンド: `agentChatReducer.test.ts` — 除去されたアクションの削除、新しいモード反映ロジックのテスト
+- フロントエンド: セッション切り替え時のモード表示テスト

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -63,6 +63,10 @@ pub struct AgentProcess {
     /// Pending message queued by send_agent_message during streaming.
     /// Auto-consumed on turn_complete by the stdout reader.
     pub pending_message: Option<PendingMessage>,
+    /// Runtime permission mode tracked from SDK notifications.
+    /// Unlike `ChatSession.permission_mode` (persisted, excludes transient "plan"),
+    /// this reflects the actual SDK state including "plan" mode.
+    pub current_permission_mode: String,
 }
 
 /// Per-session agent process map: chat_session_id → AgentProcess
@@ -167,6 +171,27 @@ fn emit_session_state_changed(
 }
 
 const CLOSE_TIMEOUT_SECS: u64 = 5;
+
+/// Resolve permission mode: "plan" → "default" (= acceptEdits), others unchanged.
+/// Called when SDK sends permissionMode: "default" (after Plan approval).
+fn resolve_permission_mode(mode: &str) -> &str {
+    if mode == "plan" {
+        "default"
+    } else {
+        mode
+    }
+}
+
+fn emit_permission_mode_changed(app: &tauri::AppHandle, chat_session_id: &str, mode: &str) {
+    use tauri::Emitter;
+    let _ = app.emit(
+        "agent-permission-mode-changed",
+        serde_json::json!({
+            "chat_session_id": chat_session_id,
+            "permission_mode": mode,
+        }),
+    );
+}
 
 fn build_set_mode_command(permission_mode: &str) -> String {
     let cmd = serde_json::json!({
@@ -509,10 +534,12 @@ async fn spawn_bridge_process(
         .ok_or_else(|| "Failed to capture stderr".to_string())?;
 
     // Send init command
+    let initial_permission_mode =
+        permission_mode.unwrap_or_else(|| "acceptEdits".to_string());
     let init_cmd = serde_json::json!({
         "type": "init",
         "cwd": cwd,
-        "permissionMode": permission_mode.unwrap_or_else(|| "acceptEdits".to_string()),
+        "permissionMode": initial_permission_mode,
         "sessionId": session_id,
     });
     let init_data = format!("{}\n", init_cmd);
@@ -543,6 +570,7 @@ async fn spawn_bridge_process(
                 last_message_id: None,
                 task_id_map: HashMap::new(),
                 pending_message: None,
+                current_permission_mode: initial_permission_mode.clone(),
             },
         );
     }
@@ -874,6 +902,67 @@ async fn spawn_bridge_process(
                             }
                         }
 
+                        // Handle permissionMode sync from SDK on Rust side
+                        if msg_type == "system" {
+                            if let Some(sdk_mode) =
+                                msg.get("permissionMode").and_then(|v| v.as_str())
+                            {
+                                if sdk_mode == "default" {
+                                    // Plan approval: resolve persisted permission_mode
+                                    let data_dir_result = resolve_data_dir(&app_stdout);
+                                    if let Ok(data_dir) = data_dir_result {
+                                        if let Ok(Some(session)) =
+                                            session_store_clone.get_session(&data_dir, &csid_stdout)
+                                        {
+                                            let restored =
+                                                resolve_permission_mode(&session.permission_mode);
+                                            // Send restored mode to Bridge
+                                            let mode_data = build_set_mode_command(restored);
+                                            let mut map = handles_stdout.lock().await;
+                                            if let Some(proc) = map.get_mut(&csid_stdout) {
+                                                let _ = proc
+                                                    .stdin
+                                                    .write_all(mode_data.as_bytes())
+                                                    .await;
+                                                let _ = proc.stdin.flush().await;
+                                                proc.current_permission_mode =
+                                                    restored.to_string();
+                                            }
+                                            drop(map);
+                                            // Persist resolved mode if it changed (plan → default)
+                                            if restored != session.permission_mode {
+                                                let _ = session_store_clone.update_permission_mode(
+                                                    &data_dir,
+                                                    &csid_stdout,
+                                                    restored,
+                                                );
+                                            }
+                                            // Notify frontend
+                                            emit_permission_mode_changed(
+                                                &app_stdout,
+                                                &csid_stdout,
+                                                restored,
+                                            );
+                                        }
+                                    }
+                                } else {
+                                    // SDK changed mode (e.g., to "plan") — update runtime state & notify frontend
+                                    {
+                                        let mut map = handles_stdout.lock().await;
+                                        if let Some(proc) = map.get_mut(&csid_stdout) {
+                                            proc.current_permission_mode =
+                                                sdk_mode.to_string();
+                                        }
+                                    }
+                                    emit_permission_mode_changed(
+                                        &app_stdout,
+                                        &csid_stdout,
+                                        sdk_mode,
+                                    );
+                                }
+                            }
+                        }
+
                         // Forward non-accumulated messages (meta events) as agent-sdk-message.
                         // permission_request needs both delta emit AND forwarding for SET_PENDING_PERMISSION.
                         if should_forward_sdk_message(accumulated, msg_type) {
@@ -949,6 +1038,8 @@ async fn get_session_internal(
             let (turn_phase, raw_parts, streaming_mid) = {
                 let map = handles.lock().await;
                 if let Some(proc) = map.get(session_id) {
+                    // Override persisted mode with runtime mode (includes transient "plan")
+                    session.permission_mode = proc.current_permission_mode.clone();
                     let phase = proc.turn_phase;
                     if proc.state == BridgeState::Streaming {
                         (
@@ -1110,6 +1201,7 @@ async fn start_agent_turn(
                 .await
                 .map_err(|e| format!("Failed to flush setMode: {e}"))?;
 
+            proc.current_permission_mode = permission_mode.to_string();
             proc.state = BridgeState::Streaming;
             proc.turn_phase = TurnPhase::Streaming;
             proc.streaming_message_id = Some(streaming_message_id.to_string());
@@ -1210,6 +1302,7 @@ async fn consume_pending_message(
                 log::error!("consume_pending_message: failed to flush setMode: {e}");
                 return;
             }
+            proc.current_permission_mode = pending.permission_mode.clone();
             proc.state = BridgeState::Streaming;
             proc.turn_phase = TurnPhase::Streaming;
             proc.streaming_message_id = Some(agent_msg.id.clone());
@@ -1332,11 +1425,17 @@ pub async fn close_agent_session(
 
 #[tauri::command]
 pub async fn set_agent_permission_mode(
+    app: tauri::AppHandle,
+    session_store: tauri::State<'_, Arc<SessionStore>>,
     handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
     chat_session_id: String,
     permission_mode: String,
 ) -> Result<(), String> {
     let data = build_set_mode_command(&permission_mode);
+
+    // Persist to SessionStore
+    let data_dir = resolve_data_dir(&app)?;
+    session_store.update_permission_mode(&data_dir, &chat_session_id, &permission_mode)?;
 
     {
         let mut map = handles.lock().await;
@@ -1349,6 +1448,7 @@ pub async fn set_agent_permission_mode(
                 .flush()
                 .await
                 .map_err(|e| format!("Failed to flush setMode: {e}"))?;
+            proc.current_permission_mode = permission_mode.clone();
         }
         // If no process exists, silently ignore (process not yet started)
     }
@@ -1589,23 +1689,22 @@ pub async fn init_agent_sessions(
     session_store: tauri::State<'_, Arc<SessionStore>>,
     handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
     worktree_path: String,
-    permission_mode: Option<String>,
 ) -> Result<InitSessionsResponse, String> {
     let data_dir = resolve_data_dir(&app)?;
-    let pm = permission_mode.unwrap_or_else(|| "acceptEdits".to_string());
 
     let mut sessions = session_store.list_sessions(&data_dir, &worktree_path)?;
 
     if sessions.is_empty() {
-        // Create new session + start agent process
+        // Create new session + start agent process (new session uses default permission_mode)
         let session = create_session_internal(&session_store, &data_dir, &worktree_path)?;
+        let session_pm = session.permission_mode.clone();
         start_agent_session_internal(
             &app,
             handles.inner(),
             session_store.inner(),
             &session.id,
             &worktree_path,
-            Some(pm),
+            Some(session_pm),
         )
         .await
         .unwrap_or_else(|e| {
@@ -1622,14 +1721,14 @@ pub async fn init_agent_sessions(
             active_session: Some(response),
         })
     } else {
-        // Start agent processes for all sessions (fire-and-forget)
+        // Start agent processes for all sessions with their persisted permission_mode
         for s in &sessions {
             let app_c = app.clone();
             let h_c = Arc::clone(handles.inner());
             let ss_c = Arc::clone(session_store.inner());
             let sid = s.id.clone();
             let cwd = worktree_path.clone();
-            let pm_c = pm.clone();
+            let pm_c = s.permission_mode.clone();
             tokio::spawn(async move {
                 if let Err(e) =
                     start_agent_session_internal(&app_c, &h_c, &ss_c, &sid, &cwd, Some(pm_c)).await
@@ -2819,5 +2918,25 @@ mod tests {
             MessagePart::Text { content, .. } => assert_eq!(content, "abc"),
             _ => panic!("expected Text"),
         }
+    }
+
+    #[test]
+    fn resolve_permission_mode_plan_returns_default() {
+        assert_eq!(resolve_permission_mode("plan"), "default");
+    }
+
+    #[test]
+    fn resolve_permission_mode_accept_edits_unchanged() {
+        assert_eq!(resolve_permission_mode("acceptEdits"), "acceptEdits");
+    }
+
+    #[test]
+    fn resolve_permission_mode_bypass_unchanged() {
+        assert_eq!(resolve_permission_mode("bypassPermissions"), "bypassPermissions");
+    }
+
+    #[test]
+    fn resolve_permission_mode_default_unchanged() {
+        assert_eq!(resolve_permission_mode("default"), "default");
     }
 }

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -534,8 +534,7 @@ async fn spawn_bridge_process(
         .ok_or_else(|| "Failed to capture stderr".to_string())?;
 
     // Send init command
-    let initial_permission_mode =
-        permission_mode.unwrap_or_else(|| "acceptEdits".to_string());
+    let initial_permission_mode = permission_mode.unwrap_or_else(|| "acceptEdits".to_string());
     let init_cmd = serde_json::json!({
         "type": "init",
         "cwd": cwd,
@@ -925,8 +924,7 @@ async fn spawn_bridge_process(
                                                     .write_all(mode_data.as_bytes())
                                                     .await;
                                                 let _ = proc.stdin.flush().await;
-                                                proc.current_permission_mode =
-                                                    restored.to_string();
+                                                proc.current_permission_mode = restored.to_string();
                                             }
                                             drop(map);
                                             // Persist resolved mode if it changed (plan → default)
@@ -950,8 +948,7 @@ async fn spawn_bridge_process(
                                     {
                                         let mut map = handles_stdout.lock().await;
                                         if let Some(proc) = map.get_mut(&csid_stdout) {
-                                            proc.current_permission_mode =
-                                                sdk_mode.to_string();
+                                            proc.current_permission_mode = sdk_mode.to_string();
                                         }
                                     }
                                     emit_permission_mode_changed(
@@ -2932,7 +2929,10 @@ mod tests {
 
     #[test]
     fn resolve_permission_mode_bypass_unchanged() {
-        assert_eq!(resolve_permission_mode("bypassPermissions"), "bypassPermissions");
+        assert_eq!(
+            resolve_permission_mode("bypassPermissions"),
+            "bypassPermissions"
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -150,6 +150,12 @@ pub struct ChatSession {
     pub updated_at: f64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub agent_session_id: Option<String>,
+    #[serde(default = "default_permission_mode")]
+    pub permission_mode: String,
+}
+
+fn default_permission_mode() -> String {
+    "acceptEdits".to_string()
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -172,6 +178,7 @@ pub struct SessionSummary {
     pub message_count: usize,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub agent_session_id: Option<String>,
+    pub permission_mode: String,
 }
 
 impl ChatSession {
@@ -197,6 +204,7 @@ impl ChatSession {
             first_message,
             message_count: self.messages.len(),
             agent_session_id: self.agent_session_id.clone(),
+            permission_mode: self.permission_mode.clone(),
         }
     }
 }
@@ -316,6 +324,7 @@ pub fn create_session_internal(
         created_at: now,
         updated_at: now,
         agent_session_id: None,
+        permission_mode: default_permission_mode(),
     };
     session_store.save_session(data_dir, &session)?;
     Ok(session)
@@ -468,6 +477,7 @@ mod tests {
             created_at: 1000.0,
             updated_at: 1000.0,
             agent_session_id: None,
+            permission_mode: "acceptEdits".to_string(),
         };
         let summary = session.to_summary();
         assert_eq!(summary.id, "s1");
@@ -494,6 +504,7 @@ mod tests {
             created_at: 1000.0,
             updated_at: 1000.0,
             agent_session_id: None,
+            permission_mode: "acceptEdits".to_string(),
         };
         let summary = session.to_summary();
         assert_eq!(summary.first_message.len(), 100 + "…".len());
@@ -520,6 +531,7 @@ mod tests {
             created_at: 1000.0,
             updated_at: 1000.0,
             agent_session_id: None,
+            permission_mode: "acceptEdits".to_string(),
         };
         let summary = session.to_summary();
         // 100 chars of "あ" (300 bytes) + "…" (3 bytes)
@@ -538,6 +550,7 @@ mod tests {
             created_at: 1000.0,
             updated_at: 1000.0,
             agent_session_id: None,
+            permission_mode: "acceptEdits".to_string(),
         };
         let summary = session.to_summary();
         assert_eq!(summary.first_message, "");
@@ -651,6 +664,7 @@ mod tests {
             created_at: 1000.0,
             updated_at: 1001.0,
             agent_session_id: None,
+            permission_mode: "acceptEdits".to_string(),
         };
         let json = serde_json::to_string(&session).unwrap();
         let back: ChatSession = serde_json::from_str(&json).unwrap();

--- a/src-tauri/src/session/store.rs
+++ b/src-tauri/src/session/store.rs
@@ -109,6 +109,24 @@ impl SessionStore {
         Ok(())
     }
 
+    pub fn update_permission_mode(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        permission_mode: &str,
+    ) -> Result<(), String> {
+        self.ensure_loaded(app_data_dir)?;
+        let mut session = {
+            let cache = self.cache.read();
+            cache
+                .get(session_id)
+                .cloned()
+                .ok_or_else(|| format!("Session not found: {session_id}"))?
+        };
+        session.permission_mode = permission_mode.to_string();
+        self.save_session(app_data_dir, &session)
+    }
+
     fn ensure_loaded(&self, app_data_dir: &Path) -> Result<(), String> {
         if self.loaded.load(Ordering::Acquire) {
             return Ok(());
@@ -177,6 +195,7 @@ mod tests {
             created_at: 1000.0,
             updated_at: 1000.0,
             agent_session_id: None,
+            permission_mode: "acceptEdits".to_string(),
         }
     }
 
@@ -325,6 +344,31 @@ mod tests {
         let sessions = store.list_sessions(tmp.path(), "/repo").unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id, UUID1);
+    }
+
+    #[test]
+    fn update_permission_mode_persists() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::default();
+        let session = make_session(UUID1, "/repo");
+        assert_eq!(session.permission_mode, "acceptEdits");
+
+        store.save_session(tmp.path(), &session).unwrap();
+        store
+            .update_permission_mode(tmp.path(), UUID1, "plan")
+            .unwrap();
+
+        let loaded = store.get_session(tmp.path(), UUID1).unwrap().unwrap();
+        assert_eq!(loaded.permission_mode, "plan");
+    }
+
+    #[test]
+    fn update_permission_mode_nonexistent_session_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::default();
+        let result = store.update_permission_mode(tmp.path(), UUID1, "plan");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Session not found"));
     }
 
     #[test]

--- a/src/hooks/agentChatReducer.test.ts
+++ b/src/hooks/agentChatReducer.test.ts
@@ -11,6 +11,7 @@ function makeSession(overrides?: Partial<ChatSession>): ChatSession {
 		state: "active",
 		createdAt: 1000,
 		updatedAt: 1000,
+		permissionMode: "acceptEdits" as const,
 		...overrides,
 	};
 }
@@ -34,8 +35,7 @@ describe("agentChatReducer", () => {
 			activeSession: null,
 			turnPhases: {},
 			error: null,
-			permissionMode: "acceptEdits",
-			userPermissionMode: "acceptEdits",
+			permissionMode: "acceptEdits" as const,
 			pendingPermissions: {},
 		});
 	});
@@ -51,6 +51,7 @@ describe("agentChatReducer", () => {
 					updatedAt: 1000,
 					firstMessage: "hello",
 					messageCount: 1,
+					permissionMode: "acceptEdits" as const,
 				},
 			];
 			const next = reducer(INITIAL_STATE, {
@@ -74,6 +75,7 @@ describe("agentChatReducer", () => {
 						updatedAt: 1000,
 						firstMessage: "first",
 						messageCount: 1,
+						permissionMode: "acceptEdits" as const,
 					},
 					{
 						id: "s2",
@@ -83,6 +85,7 @@ describe("agentChatReducer", () => {
 						updatedAt: 900,
 						firstMessage: "second",
 						messageCount: 1,
+						permissionMode: "acceptEdits" as const,
 					},
 				],
 			};
@@ -96,6 +99,7 @@ describe("agentChatReducer", () => {
 					updatedAt: 1100,
 					firstMessage: "third",
 					messageCount: 1,
+					permissionMode: "acceptEdits" as const,
 				},
 			];
 			const next = reducer(state, {
@@ -119,6 +123,7 @@ describe("agentChatReducer", () => {
 					updatedAt: 1000,
 					firstMessage: "first",
 					messageCount: 1,
+					permissionMode: "acceptEdits" as const,
 				},
 				{
 					id: "s3",
@@ -128,6 +133,7 @@ describe("agentChatReducer", () => {
 					updatedAt: 1100,
 					firstMessage: "third",
 					messageCount: 1,
+					permissionMode: "acceptEdits" as const,
 				},
 			];
 			const next = reducer(state, { type: "SET_SESSIONS", sessions });
@@ -160,6 +166,7 @@ describe("agentChatReducer", () => {
 					updatedAt: 1000,
 					firstMessage: "hello",
 					messageCount: 1,
+					permissionMode: "acceptEdits" as const,
 				},
 			];
 			const next = reducer(INITIAL_STATE, {
@@ -321,66 +328,6 @@ describe("agentChatReducer", () => {
 				mode: "plan",
 			});
 			expect(next.permissionMode).toBe("plan");
-		});
-	});
-
-	describe("SET_USER_PERMISSION_MODE", () => {
-		it("updates both userPermissionMode and permissionMode", () => {
-			const next = reducer(INITIAL_STATE, {
-				type: "SET_USER_PERMISSION_MODE",
-				mode: "bypassPermissions",
-			});
-			expect(next.userPermissionMode).toBe("bypassPermissions");
-			expect(next.permissionMode).toBe("bypassPermissions");
-		});
-	});
-
-	describe("RESTORE_USER_PERMISSION_MODE", () => {
-		it("restores permissionMode from userPermissionMode", () => {
-			const state: AgentChatState = {
-				...INITIAL_STATE,
-				userPermissionMode: "acceptEdits",
-				permissionMode: "plan",
-			};
-			const next = reducer(state, { type: "RESTORE_USER_PERMISSION_MODE" });
-			expect(next.permissionMode).toBe("acceptEdits");
-		});
-
-		it("falls back to default when userPermissionMode is plan", () => {
-			const state: AgentChatState = {
-				...INITIAL_STATE,
-				userPermissionMode: "plan",
-				permissionMode: "plan",
-			};
-			const next = reducer(state, { type: "RESTORE_USER_PERMISSION_MODE" });
-			expect(next.permissionMode).toBe("default");
-		});
-
-		it("restores bypassPermissions after Agent changes to plan then default", () => {
-			// Scenario: Bypass → Agent sets Plan → Agent restores default → Bypass
-			let state: AgentChatState = {
-				...INITIAL_STATE,
-			};
-			// User selects bypassPermissions
-			state = reducer(state, {
-				type: "SET_USER_PERMISSION_MODE",
-				mode: "bypassPermissions",
-			});
-			expect(state.permissionMode).toBe("bypassPermissions");
-			expect(state.userPermissionMode).toBe("bypassPermissions");
-
-			// Agent changes to plan
-			state = reducer(state, {
-				type: "SET_PERMISSION_MODE",
-				mode: "plan",
-			});
-			expect(state.permissionMode).toBe("plan");
-			expect(state.userPermissionMode).toBe("bypassPermissions");
-
-			// Agent restores default → should restore to bypassPermissions
-			state = reducer(state, { type: "RESTORE_USER_PERMISSION_MODE" });
-			expect(state.permissionMode).toBe("bypassPermissions");
-			expect(state.userPermissionMode).toBe("bypassPermissions");
 		});
 	});
 

--- a/src/hooks/agentChatReducer.ts
+++ b/src/hooks/agentChatReducer.ts
@@ -9,10 +9,6 @@ import type {
 	TurnPhase,
 } from "@/types/session";
 
-export function resolvePermissionMode(mode: PermissionMode): PermissionMode {
-	return mode === "plan" ? "default" : mode;
-}
-
 export interface AgentChatState {
 	sessions: SessionSummary[];
 	sessionOrder: string[];
@@ -21,7 +17,6 @@ export interface AgentChatState {
 	turnPhases: Record<string, TurnPhase>;
 	error: string | null;
 	permissionMode: PermissionMode;
-	userPermissionMode: PermissionMode;
 	pendingPermissions: Record<string, PermissionRequest>;
 }
 
@@ -38,8 +33,6 @@ export type AgentChatAction =
 	| { type: "SET_ERROR"; error: string | null }
 	| { type: "UPDATE_SESSION_STATE"; state: SessionState }
 	| { type: "SET_PERMISSION_MODE"; mode: PermissionMode }
-	| { type: "SET_USER_PERMISSION_MODE"; mode: PermissionMode }
-	| { type: "RESTORE_USER_PERMISSION_MODE" }
 	| {
 			type: "SET_PENDING_PERMISSION";
 			sessionId: string;
@@ -168,18 +161,6 @@ export function reducer(
 		}
 		case "SET_PERMISSION_MODE":
 			return { ...state, permissionMode: action.mode };
-		case "SET_USER_PERMISSION_MODE":
-			return {
-				...state,
-				userPermissionMode: action.mode,
-				permissionMode: action.mode,
-			};
-		case "RESTORE_USER_PERMISSION_MODE": {
-			return {
-				...state,
-				permissionMode: resolvePermissionMode(state.userPermissionMode),
-			};
-		}
 		case "SET_PENDING_PERMISSION": {
 			if (action.request === null) {
 				const { [action.sessionId]: _, ...rest } = state.pendingPermissions;
@@ -214,6 +195,5 @@ export const INITIAL_STATE: AgentChatState = {
 	turnPhases: {},
 	error: null,
 	permissionMode: "acceptEdits",
-	userPermissionMode: "acceptEdits",
 	pendingPermissions: {},
 };

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -28,6 +28,7 @@ vi.mock("./useSessionStore", () => ({
 		state: "active",
 		createdAt: 1000,
 		updatedAt: 1000,
+		permissionMode: "acceptEdits",
 	}),
 	addMessage: vi.fn(),
 	updateSessionState: vi.fn().mockResolvedValue(undefined),
@@ -43,6 +44,7 @@ vi.mock("./useSessionStore", () => ({
 			state: "active",
 			createdAt: 1000,
 			updatedAt: 1000,
+			permissionMode: "acceptEdits",
 		},
 		humanMessage: {
 			id: "msg-1",
@@ -68,6 +70,7 @@ vi.mock("./useSessionStore", () => ({
 				state: "active",
 				createdAt: 1000,
 				updatedAt: 1000,
+				permissionMode: "acceptEdits",
 			},
 			turnPhase: "idle",
 		},
@@ -253,6 +256,7 @@ describe("useAgentChat", () => {
 			state: "idle",
 			createdAt: 1000,
 			updatedAt: 1000,
+			permissionMode: "acceptEdits",
 		};
 		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
 			session: mockSession,
@@ -299,6 +303,7 @@ describe("useAgentChat", () => {
 			state: "active",
 			createdAt: 1000,
 			updatedAt: 1000,
+			permissionMode: "acceptEdits",
 		};
 
 		// getSession returns merged data from Rust backend (including streaming parts)
@@ -498,6 +503,7 @@ describe("useAgentChat", () => {
 			state: "active",
 			createdAt: 2000,
 			updatedAt: 2000,
+			permissionMode: "acceptEdits",
 		};
 		vi.mocked(sessionStore.createSession).mockResolvedValueOnce(
 			newSession as never,
@@ -586,6 +592,7 @@ describe("useAgentChat", () => {
 			state: "active",
 			createdAt: 900,
 			updatedAt: 900,
+			permissionMode: "acceptEdits",
 		};
 		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
 			session: s2Full,
@@ -652,6 +659,7 @@ describe("useAgentChat", () => {
 			state: "idle",
 			createdAt: 500,
 			updatedAt: 500,
+			permissionMode: "acceptEdits",
 		};
 		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
 			session: restoredSession,
@@ -685,6 +693,7 @@ describe("useAgentChat", () => {
 			state: "idle",
 			createdAt: 500,
 			updatedAt: 500,
+			permissionMode: "acceptEdits",
 		};
 		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
 			session: restoredSession,
@@ -763,6 +772,7 @@ describe("useAgentChat", () => {
 					state: "active",
 					createdAt: 1000,
 					updatedAt: 1000,
+					permissionMode: "acceptEdits",
 				},
 				turnPhase: "idle",
 			},
@@ -775,32 +785,306 @@ describe("useAgentChat", () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 
-		expect(sessionStore.initAgentSessions).toHaveBeenCalledWith(
-			"/repo",
-			"acceptEdits",
-		);
+		expect(sessionStore.initAgentSessions).toHaveBeenCalledWith("/repo");
 	});
 });
 
-describe("permissionMode sync from SDK system messages", () => {
-	it("syncs permissionMode when SDK system message has permissionMode: plan", async () => {
+describe("permissionMode per-session persistence", () => {
+	it("selectSession restores permissionMode from session", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		// Wait for mount effect
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		// Mock getSession returning a session with "plan" permissionMode
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
+			session: {
+				id: "s2",
+				worktreePath: "/repo",
+				messages: [],
+				state: "idle",
+				createdAt: 1000,
+				updatedAt: 1000,
+				permissionMode: "plan",
+			},
+			turnPhase: "idle",
+		} as never);
+
+		await act(async () => {
+			await result.current.selectSession("s2");
+		});
+
+		expect(result.current.permissionMode).toBe("plan");
+	});
+
+	it("switching between sessions preserves independent permissionModes", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		// Wait for mount effect
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		// Switch to Session A with "plan" mode
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
+			session: {
+				id: "session-a",
+				worktreePath: "/repo",
+				messages: [],
+				state: "idle",
+				createdAt: 1000,
+				updatedAt: 1000,
+				permissionMode: "plan",
+			},
+			turnPhase: "idle",
+		} as never);
+
+		await act(async () => {
+			await result.current.selectSession("session-a");
+		});
+
+		expect(result.current.permissionMode).toBe("plan");
+
+		// Switch to Session B with "bypassPermissions" mode
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
+			session: {
+				id: "session-b",
+				worktreePath: "/repo",
+				messages: [],
+				state: "idle",
+				createdAt: 1000,
+				updatedAt: 1000,
+				permissionMode: "bypassPermissions",
+			},
+			turnPhase: "idle",
+		} as never);
+
+		await act(async () => {
+			await result.current.selectSession("session-b");
+		});
+
+		expect(result.current.permissionMode).toBe("bypassPermissions");
+
+		// Switch back to Session A — mode should still be "plan"
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
+			session: {
+				id: "session-a",
+				worktreePath: "/repo",
+				messages: [],
+				state: "idle",
+				createdAt: 1000,
+				updatedAt: 1000,
+				permissionMode: "plan",
+			},
+			turnPhase: "idle",
+		} as never);
+
+		await act(async () => {
+			await result.current.selectSession("session-a");
+		});
+
+		expect(result.current.permissionMode).toBe("plan");
+	});
+
+	it("createNewSession resets permissionMode to default", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		// Wait for mount effect
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		// Change mode to plan via event
+		const permCb = listenCallbacks.get("agent-permission-mode-changed");
+		// First send a message to create session
+		await act(async () => {
+			await result.current.sendMessage("hello");
+		});
+		act(() => {
+			permCb?.({
+				payload: {
+					chat_session_id: "s1",
+					permission_mode: "plan",
+				},
+			});
+		});
+		expect(result.current.permissionMode).toBe("plan");
+
+		// Create new session (returns default "acceptEdits")
+		vi.mocked(sessionStore.createSession).mockResolvedValueOnce({
+			id: "new-s",
+			worktreePath: "/repo",
+			messages: [],
+			state: "active",
+			createdAt: 2000,
+			updatedAt: 2000,
+			permissionMode: "acceptEdits",
+		} as never);
+
+		await act(async () => {
+			await result.current.createNewSession();
+		});
+
+		expect(result.current.permissionMode).toBe("acceptEdits");
+	});
+
+	it("permissionMode is preserved after turn completion", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 		await act(async () => {});
 
-		const sdkCb = listenCallbacks.get("agent-sdk-message");
-		expect(sdkCb).toBeDefined();
+		// Send a message to create an active session (s1)
+		await act(async () => {
+			await result.current.sendMessage("hello");
+		});
 
-		// Simulate SDK system init with permissionMode: plan
+		// Set mode to "plan" via Rust event
+		const permCb = listenCallbacks.get("agent-permission-mode-changed");
 		act(() => {
-			sdkCb?.({
+			permCb?.({
 				payload: {
-					type: "system",
-					subtype: "init",
-					session_id: "sdk-session-abc",
-					permissionMode: "plan",
+					chat_session_id: "s1",
+					permission_mode: "plan",
+				},
+			});
+		});
+		expect(result.current.permissionMode).toBe("plan");
+
+		// Simulate turn completion via agent-session-state-changed event
+		const stateCb = listenCallbacks.get("agent-session-state-changed");
+		act(() => {
+			stateCb?.({
+				payload: {
+					chat_session_id: "s1",
+					turn_phase: "idle",
+					exit_code: 0,
+				},
+			});
+		});
+
+		// permissionMode should still be "plan" after turn completion
+		expect(result.current.permissionMode).toBe("plan");
+	});
+
+	it("permissionMode bypassPermissions is preserved after turn completion", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+		await act(async () => {});
+
+		// Send a message to create an active session (s1)
+		await act(async () => {
+			await result.current.sendMessage("hello");
+		});
+
+		// Set mode to "bypassPermissions" via Rust event
+		const permCb = listenCallbacks.get("agent-permission-mode-changed");
+		act(() => {
+			permCb?.({
+				payload: {
+					chat_session_id: "s1",
+					permission_mode: "bypassPermissions",
+				},
+			});
+		});
+		expect(result.current.permissionMode).toBe("bypassPermissions");
+
+		// Simulate turn completion via agent-session-state-changed event
+		const stateCb = listenCallbacks.get("agent-session-state-changed");
+		act(() => {
+			stateCb?.({
+				payload: {
+					chat_session_id: "s1",
+					turn_phase: "idle",
+					exit_code: 0,
+				},
+			});
+		});
+
+		// permissionMode should still be "bypassPermissions" after turn completion
+		expect(result.current.permissionMode).toBe("bypassPermissions");
+	});
+
+	it("permissionMode default (Ask) is preserved after turn completion", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+		await act(async () => {});
+
+		// Send a message to create an active session (s1)
+		await act(async () => {
+			await result.current.sendMessage("hello");
+		});
+
+		// Set mode to "default" (Ask) via Rust event
+		const permCb = listenCallbacks.get("agent-permission-mode-changed");
+		act(() => {
+			permCb?.({
+				payload: {
+					chat_session_id: "s1",
+					permission_mode: "default",
+				},
+			});
+		});
+		expect(result.current.permissionMode).toBe("default");
+
+		// Simulate turn completion via agent-session-state-changed event
+		const stateCb = listenCallbacks.get("agent-session-state-changed");
+		act(() => {
+			stateCb?.({
+				payload: {
+					chat_session_id: "s1",
+					turn_phase: "idle",
+					exit_code: 0,
+				},
+			});
+		});
+
+		// permissionMode should still be "default" after turn completion
+		expect(result.current.permissionMode).toBe("default");
+	});
+});
+
+describe("permissionMode sync from agent-permission-mode-changed event", () => {
+	it("syncs permissionMode when agent-permission-mode-changed event fires with plan", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+		await act(async () => {});
+
+		// Send a message to create an active session (s1)
+		await act(async () => {
+			await result.current.sendMessage("hello");
+		});
+
+		const permCb = listenCallbacks.get("agent-permission-mode-changed");
+		expect(permCb).toBeDefined();
+
+		// Rust sends permission mode change for the active session
+		act(() => {
+			permCb?.({
+				payload: {
+					chat_session_id: "s1",
+					permission_mode: "plan",
 				},
 			});
 		});
@@ -808,51 +1092,57 @@ describe("permissionMode sync from SDK system messages", () => {
 		expect(result.current.permissionMode).toBe("plan");
 	});
 
-	it("restores user choice when SDK returns permissionMode: default", async () => {
+	it("restores resolved mode when Rust sends agent-permission-mode-changed after ExitPlanMode", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 		await act(async () => {});
 
-		// User selects acceptEdits (initial default)
+		// Send a message to create an active session (s1)
+		await act(async () => {
+			await result.current.sendMessage("hello");
+		});
+
 		expect(result.current.permissionMode).toBe("acceptEdits");
 
-		const sdkCb = listenCallbacks.get("agent-sdk-message");
-		expect(sdkCb).toBeDefined();
+		const permCb = listenCallbacks.get("agent-permission-mode-changed");
+		expect(permCb).toBeDefined();
 
-		// SDK sends plan mode
+		// Rust sends plan mode
 		act(() => {
-			sdkCb?.({
+			permCb?.({
 				payload: {
-					type: "system",
-					subtype: "init",
-					session_id: "sdk-session-abc",
-					permissionMode: "plan",
+					chat_session_id: "s1",
+					permission_mode: "plan",
 				},
 			});
 		});
 		expect(result.current.permissionMode).toBe("plan");
 
-		// SDK sends default (ExitPlanMode approved) → should restore user's acceptEdits
+		// Rust resolves and sends the restored mode (acceptEdits)
 		act(() => {
-			sdkCb?.({
+			permCb?.({
 				payload: {
-					type: "system",
-					subtype: "status",
-					permissionMode: "default",
+					chat_session_id: "s1",
+					permission_mode: "acceptEdits",
 				},
 			});
 		});
 		expect(result.current.permissionMode).toBe("acceptEdits");
 	});
 
-	it("restores bypassPermissions when SDK returns permissionMode: default after plan override", async () => {
+	it("restores bypassPermissions when Rust sends agent-permission-mode-changed after plan override", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 		await act(async () => {});
+
+		// Send a message to create an active session (s1)
+		await act(async () => {
+			await result.current.sendMessage("hello");
+		});
 
 		// User selects bypassPermissions
 		act(() => {
@@ -860,29 +1150,26 @@ describe("permissionMode sync from SDK system messages", () => {
 		});
 		expect(result.current.permissionMode).toBe("bypassPermissions");
 
-		const sdkCb = listenCallbacks.get("agent-sdk-message");
-		expect(sdkCb).toBeDefined();
+		const permCb = listenCallbacks.get("agent-permission-mode-changed");
+		expect(permCb).toBeDefined();
 
-		// SDK sends plan mode
+		// Rust sends plan mode
 		act(() => {
-			sdkCb?.({
+			permCb?.({
 				payload: {
-					type: "system",
-					subtype: "init",
-					session_id: "sdk-session-abc",
-					permissionMode: "plan",
+					chat_session_id: "s1",
+					permission_mode: "plan",
 				},
 			});
 		});
 		expect(result.current.permissionMode).toBe("plan");
 
-		// SDK sends default → should restore to bypassPermissions
+		// Rust resolves and sends bypassPermissions back
 		act(() => {
-			sdkCb?.({
+			permCb?.({
 				payload: {
-					type: "system",
-					subtype: "status",
-					permissionMode: "default",
+					chat_session_id: "s1",
+					permission_mode: "bypassPermissions",
 				},
 			});
 		});
@@ -964,6 +1251,7 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 					state: "active",
 					createdAt: 1000,
 					updatedAt: 1000,
+					permissionMode: "acceptEdits",
 				},
 				turnPhase: "streaming",
 			},
@@ -1038,6 +1326,7 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 					state: "idle",
 					createdAt: 1000,
 					updatedAt: 1000,
+					permissionMode: "acceptEdits",
 				},
 				turnPhase: "idle",
 			},
@@ -1094,6 +1383,7 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 				state: "active",
 				createdAt: 1000,
 				updatedAt: 1000,
+				permissionMode: "acceptEdits",
 			},
 			turnPhase: "streaming",
 		} as never);
@@ -1121,6 +1411,7 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 				state: "idle",
 				createdAt: 2000,
 				updatedAt: 2000,
+				permissionMode: "acceptEdits",
 			},
 			turnPhase: "idle",
 		} as never);
@@ -1151,6 +1442,7 @@ describe("Worktree switch (unmount/remount) streaming persistence via Rust backe
 				state: "idle",
 				createdAt: 1000,
 				updatedAt: 1000,
+				permissionMode: "acceptEdits",
 			},
 			turnPhase: "idle",
 		} as never);

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -154,8 +154,6 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 	sessionsRef.current = state.sessions;
 	const permissionModeRef = useRef(state.permissionMode);
 	permissionModeRef.current = state.permissionMode;
-	const userPermissionModeRef = useRef(state.userPermissionMode);
-	userPermissionModeRef.current = state.userPermissionMode;
 	const turnPhasesRef = useRef(state.turnPhases);
 	turnPhasesRef.current = state.turnPhases;
 
@@ -183,6 +181,11 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 					type: "SET_TURN_PHASE",
 					sessionId,
 					turnPhase: response.turnPhase,
+				});
+				// Restore permission mode from session
+				dispatch({
+					type: "SET_PERMISSION_MODE",
+					mode: response.session.permissionMode,
 				});
 			} else {
 				dispatch({ type: "SET_ACTIVE_SESSION", session: null });
@@ -278,6 +281,10 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 								sessionId: nextSession.id,
 								turnPhase: response.turnPhase,
 							});
+							dispatch({
+								type: "SET_PERMISSION_MODE",
+								mode: response.session.permissionMode,
+							});
 						}
 					} else {
 						dispatch({
@@ -314,13 +321,17 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 						sessionId,
 						turnPhase: response.turnPhase,
 					});
+					dispatch({
+						type: "SET_PERMISSION_MODE",
+						mode: response.session.permissionMode,
+					});
+					// Start Bridge process for the restored session
+					startAgentProcess(
+						sessionId,
+						worktreePathRef.current,
+						response.session.permissionMode,
+					);
 				}
-				// Start Bridge process for the restored session
-				startAgentProcess(
-					sessionId,
-					worktreePathRef.current,
-					permissionModeRef.current,
-				);
 				await refreshSessions();
 				await refreshClosedSessions();
 			} catch (e) {
@@ -337,11 +348,12 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		try {
 			const session = await createSession(worktreePathRef.current);
 			dispatch({ type: "SET_ACTIVE_SESSION", session });
+			dispatch({ type: "SET_PERMISSION_MODE", mode: session.permissionMode });
 			// Prewarm: start agent process in background
 			startAgentProcess(
 				session.id,
 				worktreePathRef.current,
-				permissionModeRef.current,
+				session.permissionMode,
 			);
 			await refreshSessions();
 		} catch (e) {
@@ -357,8 +369,8 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 	}, []);
 
 	const setPermissionMode = useCallback((mode: PermissionMode) => {
-		dispatch({ type: "SET_USER_PERMISSION_MODE", mode });
-		// Immediately sync to all active Bridge processes
+		dispatch({ type: "SET_PERMISSION_MODE", mode });
+		// Persist to Rust and sync to Bridge
 		const sessionId = activeSessionRef.current?.id;
 		if (sessionId) {
 			invoke("set_agent_permission_mode", {
@@ -403,16 +415,12 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 	useAgentSdkListeners({
 		dispatch,
 		activeSessionRef,
-		userPermissionModeRef,
 		refreshSessions,
 	});
 
 	const initSessions = useCallback(async () => {
 		try {
-			const response = await initAgentSessions(
-				worktreePathRef.current,
-				permissionModeRef.current,
-			);
+			const response = await initAgentSessions(worktreePathRef.current);
 			dispatch({ type: "SET_SESSIONS", sessions: response.sessions });
 			if (response.activeSession) {
 				dispatch({
@@ -423,6 +431,11 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 					type: "SET_TURN_PHASE",
 					sessionId: response.activeSession.session.id,
 					turnPhase: response.activeSession.turnPhase,
+				});
+				// Restore permission mode from active session
+				dispatch({
+					type: "SET_PERMISSION_MODE",
+					mode: response.activeSession.session.permissionMode,
 				});
 			}
 		} catch (e) {
@@ -444,6 +457,7 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		if (prevWorktreePathRef.current !== worktreePath) {
 			prevWorktreePathRef.current = worktreePath;
 			dispatch({ type: "SET_ACTIVE_SESSION", session: null });
+			dispatch({ type: "SET_PERMISSION_MODE", mode: "acceptEdits" });
 			initSessions();
 			refreshClosedSessions();
 		}

--- a/src/hooks/useAgentSdkListeners.test.ts
+++ b/src/hooks/useAgentSdkListeners.test.ts
@@ -43,9 +43,6 @@ function makeRefs() {
 	return {
 		dispatch: vi.fn(),
 		activeSessionRef: { current: null },
-		userPermissionModeRef: {
-			current: "acceptEdits" as import("@/types/session").PermissionMode,
-		},
 		refreshSessions: vi.fn().mockResolvedValue(undefined),
 	};
 }
@@ -102,7 +99,7 @@ describe("useAgentSdkListeners cancelled flag", () => {
 		}
 	});
 
-	it("registers listeners for agent-sdk-message, agent-session-state-changed, agent-streaming-updated, agent-pending-message-consumed", () => {
+	it("registers listeners for agent-sdk-message, agent-session-state-changed, agent-streaming-updated, agent-pending-message-consumed, agent-permission-mode-changed", () => {
 		listenResolvers = [];
 		const refs = makeRefs();
 
@@ -113,6 +110,7 @@ describe("useAgentSdkListeners cancelled flag", () => {
 		expect(eventNames).toContain("agent-session-state-changed");
 		expect(eventNames).toContain("agent-streaming-updated");
 		expect(eventNames).toContain("agent-pending-message-consumed");
+		expect(eventNames).toContain("agent-permission-mode-changed");
 		expect(eventNames).not.toContain("agent-streaming-started");
 		expect(eventNames).not.toContain("agent-query-completed");
 	});
@@ -300,23 +298,23 @@ describe("agent-session-state-changed event", () => {
 	});
 });
 
-describe("SET_PERMISSION_MODE from SDK system messages", () => {
-	it("dispatches SET_PERMISSION_MODE when system init message has permissionMode", () => {
+describe("SET_PERMISSION_MODE from agent-permission-mode-changed event", () => {
+	it("dispatches SET_PERMISSION_MODE when agent-permission-mode-changed is received for active session", () => {
 		listenResolvers = [];
 		listenCallbacks.clear();
 		const refs = makeRefs();
+		refs.activeSessionRef.current = { id: "session-1" } as never;
 
 		renderHook(() => useAgentSdkListeners(refs));
 		for (const { resolve } of listenResolvers) resolve(vi.fn());
 
-		const cb = listenCallbacks.get("agent-sdk-message");
+		const cb = listenCallbacks.get("agent-permission-mode-changed");
+		expect(cb).toBeDefined();
 
 		cb?.({
 			payload: {
-				type: "system",
-				subtype: "init",
-				session_id: "sdk-session-abc",
-				permissionMode: "plan",
+				chat_session_id: "session-1",
+				permission_mode: "plan",
 			},
 		});
 
@@ -326,53 +324,30 @@ describe("SET_PERMISSION_MODE from SDK system messages", () => {
 		});
 	});
 
-	it("dispatches RESTORE_USER_PERMISSION_MODE when system message has permissionMode: default", () => {
+	it("does not dispatch SET_PERMISSION_MODE when agent-permission-mode-changed is for non-active session", () => {
 		listenResolvers = [];
 		listenCallbacks.clear();
 		const refs = makeRefs();
+		refs.activeSessionRef.current = { id: "session-2" } as never;
 
 		renderHook(() => useAgentSdkListeners(refs));
 		for (const { resolve } of listenResolvers) resolve(vi.fn());
 
-		const cb = listenCallbacks.get("agent-sdk-message");
+		const cb = listenCallbacks.get("agent-permission-mode-changed");
+		expect(cb).toBeDefined();
 
 		cb?.({
 			payload: {
-				type: "system",
-				subtype: "status",
-				permissionMode: "default",
-			},
-		});
-
-		expect(refs.dispatch).toHaveBeenCalledWith({
-			type: "RESTORE_USER_PERMISSION_MODE",
-		});
-	});
-
-	it("invokes set_agent_permission_mode to sync restored mode to Bridge on permissionMode: default", async () => {
-		listenResolvers = [];
-		listenCallbacks.clear();
-		const refs = makeRefs();
-		refs.userPermissionModeRef.current = "bypassPermissions";
-
-		renderHook(() => useAgentSdkListeners(refs));
-		for (const { resolve } of listenResolvers) resolve(vi.fn());
-
-		const cb = listenCallbacks.get("agent-sdk-message");
-
-		cb?.({
-			payload: {
-				type: "system",
 				chat_session_id: "session-1",
-				permissionMode: "default",
+				permission_mode: "plan",
 			},
 		});
 
-		const { invoke } = await import("@tauri-apps/api/core");
-		expect(invoke).toHaveBeenCalledWith("set_agent_permission_mode", {
-			chatSessionId: "session-1",
-			permissionMode: "bypassPermissions",
-		});
+		const permModeCalls = refs.dispatch.mock.calls.filter(
+			(call: unknown[]) =>
+				(call[0] as { type: string }).type === "SET_PERMISSION_MODE",
+		);
+		expect(permModeCalls).toHaveLength(0);
 	});
 
 	it("does not dispatch SET_PERMISSION_MODE when system message has no permissionMode", () => {

--- a/src/hooks/useAgentSdkListeners.ts
+++ b/src/hooks/useAgentSdkListeners.ts
@@ -1,4 +1,3 @@
-import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type { Dispatch, MutableRefObject } from "react";
 import { useEffect } from "react";
@@ -10,10 +9,7 @@ import type {
 	SessionState,
 	TurnPhase,
 } from "@/types/session";
-import {
-	type AgentChatAction,
-	resolvePermissionMode,
-} from "./agentChatReducer";
+import type { AgentChatAction } from "./agentChatReducer";
 import { updateSessionState } from "./useSessionStore";
 import { setSlashCommands } from "./useSlashCommands";
 
@@ -65,7 +61,6 @@ interface PendingMessageConsumed {
 export interface AgentSdkListenerRefs {
 	dispatch: Dispatch<AgentChatAction>;
 	activeSessionRef: MutableRefObject<ChatSession | null>;
-	userPermissionModeRef: MutableRefObject<PermissionMode>;
 	refreshSessions: () => Promise<unknown>;
 }
 
@@ -107,38 +102,6 @@ function handlePermissionRequest(
 		sessionId: chatSessionId,
 		request: req,
 	});
-}
-
-function handlePermissionModeSync(
-	msg: SdkMessage,
-	chatSessionId: string | undefined,
-	dispatch: Dispatch<AgentChatAction>,
-	userPermissionModeRef: MutableRefObject<PermissionMode>,
-): void {
-	if (
-		msg.type === "system" &&
-		"permissionMode" in msg &&
-		typeof msg.permissionMode === "string"
-	) {
-		const sdkMode = msg.permissionMode as PermissionMode;
-		if (sdkMode === "default") {
-			dispatch({ type: "RESTORE_USER_PERMISSION_MODE" });
-			// Sync restored userPermissionMode back to Bridge
-			if (chatSessionId) {
-				const restoredMode = resolvePermissionMode(
-					userPermissionModeRef.current,
-				);
-				invoke("set_agent_permission_mode", {
-					chatSessionId,
-					permissionMode: restoredMode,
-				}).catch((e) => {
-					console.error("Failed to sync restored permission mode:", e);
-				});
-			}
-		} else {
-			dispatch({ type: "SET_PERMISSION_MODE", mode: sdkMode });
-		}
-	}
 }
 
 function handleSystemMessage(
@@ -204,8 +167,7 @@ function handleResultErrors(
 }
 
 export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
-	const { dispatch, activeSessionRef, userPermissionModeRef, refreshSessions } =
-		refs;
+	const { dispatch, activeSessionRef, refreshSessions } = refs;
 
 	// Listen to SDK messages for meta events (permissions, commands, system messages)
 	useEffect(() => {
@@ -218,12 +180,6 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 
 			handleSupportedCommands(msg);
 			handlePermissionRequest(msg, chatSessionId, dispatch);
-			handlePermissionModeSync(
-				msg,
-				chatSessionId,
-				dispatch,
-				userPermissionModeRef,
-			);
 			handleSystemMessage(msg, chatSessionId, dispatch, activeSessionRef);
 			handleResultErrors(msg, chatSessionId, dispatch, activeSessionRef);
 		}).then((fn) => {
@@ -238,7 +194,38 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 			cancelled = true;
 			unlisten?.();
 		};
-	}, [dispatch, activeSessionRef, userPermissionModeRef]);
+	}, [dispatch, activeSessionRef]);
+
+	// Listen to agent-permission-mode-changed from Rust backend
+	useEffect(() => {
+		let unlisten: UnlistenFn | null = null;
+		let cancelled = false;
+
+		listen<{ chat_session_id: string; permission_mode: string }>(
+			"agent-permission-mode-changed",
+			(event) => {
+				const { chat_session_id, permission_mode } = event.payload;
+				// Only update if the event is for the active session
+				if (activeSessionRef.current?.id === chat_session_id) {
+					dispatch({
+						type: "SET_PERMISSION_MODE",
+						mode: permission_mode as PermissionMode,
+					});
+				}
+			},
+		).then((fn) => {
+			if (cancelled) {
+				fn();
+			} else {
+				unlisten = fn;
+			}
+		});
+
+		return () => {
+			cancelled = true;
+			unlisten?.();
+		};
+	}, [dispatch, activeSessionRef]);
 
 	// Listen to agent-streaming-updated from Rust backend
 	useEffect(() => {

--- a/src/hooks/useSessionStore.ts
+++ b/src/hooks/useSessionStore.ts
@@ -5,6 +5,7 @@ import type {
 	LegacyChatMessage,
 	MessagePart,
 	MessageRole,
+	PermissionMode,
 	SessionState,
 	SessionSummary,
 	TurnPhase,
@@ -18,6 +19,7 @@ interface LegacyChatSession {
 	createdAt: number;
 	updatedAt: number;
 	agentSessionId?: string | null;
+	permissionMode?: PermissionMode;
 }
 
 export function legacyToParts(msg: LegacyChatMessage): MessagePart[] {
@@ -76,6 +78,7 @@ function convertLegacySession(session: LegacyChatSession): ChatSession {
 	return {
 		...session,
 		messages: session.messages.map(convertLegacyMessage),
+		permissionMode: session.permissionMode ?? "acceptEdits",
 	};
 }
 
@@ -99,6 +102,7 @@ interface RawGetSessionResponse {
 	createdAt: number;
 	updatedAt: number;
 	agentSessionId?: string | null;
+	permissionMode?: PermissionMode;
 	turnPhase: TurnPhase;
 }
 
@@ -117,6 +121,7 @@ export async function getSession(
 		createdAt: raw.createdAt,
 		updatedAt: raw.updatedAt,
 		agentSessionId: raw.agentSessionId,
+		permissionMode: raw.permissionMode,
 	});
 	return {
 		session,
@@ -208,11 +213,9 @@ export interface InitSessionsResponse {
 
 export async function initAgentSessions(
 	worktreePath: string,
-	permissionMode: string,
 ): Promise<InitSessionsResponse> {
 	const raw = await invoke<RawInitSessionsResponse>("init_agent_sessions", {
 		worktreePath,
-		permissionMode,
 	});
 	const activeSession = raw.activeSession
 		? {
@@ -224,6 +227,7 @@ export async function initAgentSessions(
 					createdAt: raw.activeSession.createdAt,
 					updatedAt: raw.activeSession.updatedAt,
 					agentSessionId: raw.activeSession.agentSessionId,
+					permissionMode: raw.activeSession.permissionMode,
 				}),
 				turnPhase: raw.activeSession.turnPhase,
 			}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -99,6 +99,7 @@ export interface ChatSession {
 	createdAt: number;
 	updatedAt: number;
 	agentSessionId?: string | null;
+	permissionMode: PermissionMode;
 }
 
 export function getTextContent(parts: MessagePart[]): string {
@@ -117,4 +118,5 @@ export interface SessionSummary {
 	firstMessage: string;
 	messageCount: number;
 	agentSessionId?: string | null;
+	permissionMode: PermissionMode;
 }


### PR DESCRIPTION
## Summary
- Workspace切り替え時にAgentモードがデフォルトにリセットされるバグを修正
- モード管理ロジック（保存・復元・Plan承認後の復元）をRust側`SessionStore`に集約
- フロントエンドから`userPermissionMode` / `RESTORE_USER_PERMISSION_MODE` / `SET_USER_PERMISSION_MODE`を除去し、Rustイベント(`agent-permission-mode-changed`)による通知に統一

## Test plan
- [ ] Session AでPlanモード → Session Bに切替 → Session Aに戻りPlanモードが復元されること
- [ ] 新規セッション作成時にデフォルトモード(Code)が適用されること
- [ ] ターン完了後にPlan/Bypass/Askモードが維持されること
- [ ] Plan承認後にCodeモードに自動切替されること
- [ ] アプリ再起動後もセッション別モードが復元されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)