### PR TITLE
fix: AgentChat Plan・AskUserQuestion表示の横スクロールを防止 (#775)

### DIFF
--- a/docs/spec/issues-775.md
+++ b/docs/spec/issues-775.md
@@ -1,0 +1,60 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: AgentChatでPlanモード時にAIが計画を出すと横スクロールが出現する。AskUserQuestion表示時にも同様の現象が発生する見込み。
+**期待する挙動**: Plan表示・AskUserQuestion表示ともに、コンテンツは領域幅で折り返されて表示され、横スクロールは発生しない。
+**再現手順**:
+1. AgentChatを開く
+2. Planモードに切り替えてAIに計画を出させる
+3. 計画メッセージに対して横スクロールバーが出現する
+**背景**: AgentChatでは常に横スクロールを出さない方針（Issue #750 でScrollAreaベースの折り返し対応済）だが、Plan表示とAskUserQuestion表示がこの原則から外れているバグ。
+**影響範囲**: AgentChat内のPlan表示コンポーネントとAskUserQuestion表示コンポーネント。
+
+## 振る舞い定義
+
+```gherkin
+Feature: AgentChat内のPlan・AskUserQuestion表示における横スクロール防止
+  AgentChatではすべてのコンテンツが領域幅で折り返され、
+  横スクロールが発生しない方針である（Issue #750）。
+  Plan表示とAskUserQuestion表示もこの方針に従う。
+
+  Rule: コンテンツは表示領域の幅で折り返される
+    Scenario: Plan表示のコンテンツが領域幅で折り返される
+      Given AgentChatでPlanモードのメッセージが表示されている
+      When 計画内容に領域幅を超える長さのテキストが含まれている
+      Then コンテンツは領域幅で折り返されて表示される
+
+    Scenario: AskUserQuestion表示のコンテンツが領域幅で折り返される
+      Given AgentChatでAskUserQuestionのメッセージが表示されている
+      When 質問内容に領域幅を超える長さのテキストが含まれている
+      Then コンテンツは領域幅で折り返されて表示される
+
+  Rule: 横スクロールバーは表示されない
+    Scenario: Plan表示で横スクロールバーが出現しない
+      Given AgentChatでPlanモードのメッセージが表示されている
+      When 計画内容にコードブロックや長い単語が含まれている
+      Then 横スクロールバーは表示されない
+
+    Scenario: AskUserQuestion表示で横スクロールバーが出現しない
+      Given AgentChatでAskUserQuestionのメッセージが表示されている
+      When 質問内容にコードブロックや長い単語が含まれている
+      Then 横スクロールバーは表示されない
+```
+
+## 実装仕様
+
+**対応方針**: Plan表示・AskUserQuestion表示の横スクロールを防止するために、InlineMarkdownコンポーネントにデフォルトの折り返し指定を追加し、PermissionDialogのコンテナに幅制御を追加する。Issue #750 のパターン（コンポーネント側での折り返し徹底）に準拠。
+
+**対象コンポーネント**:
+- `src/components/panels/AgentChatPanel/PermissionDialog.tsx`:
+  - `InlineMarkdown`: デフォルトクラスに `break-words` を追加（58行目）
+  - AskUserQuestionコンテナ（290行目）: `overflow-hidden` を追加
+  - ExitPlanModeコンテナ（417行目）: `overflow-hidden` を追加
+
+**検討した代替案**:
+- 各InlineMarkdown呼び出し箇所に個別に `break-words` を追加する案 → 漏れのリスクがあり、InlineMarkdown本体への追加のほうが一貫性が高いため却下
+- グローバルCSSで `.markdown-preview` に `overflow-wrap: break-word` を追加する案 → Issue #750 で `contain: inline-size` は既に適用済みだが、親コンテナの幅制御がないと効かないため、コンポーネント側の修正も必要
+
+**影響するテスト**:
+- 既存テスト: `PermissionDialog.test.tsx` が存在すれば回帰確認。スタイル変更のみのため既存テストの期待値変更は不要
+- 新規テスト: CSSクラスの変更のみで視覚的な確認が主体のため、自動テスト追加は不要。手動で横スクロールが発生しないことを確認

--- a/src/components/panels/AgentChatPanel/PermissionDialog.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.tsx
@@ -55,13 +55,20 @@ function InlineMarkdown({
 			id={id}
 			data-testid={dataTestId}
 			className={cn(
-				"markdown-preview prose prose-sm dark:prose-invert max-w-none",
+				"markdown-preview prose prose-sm dark:prose-invert max-w-none break-words",
 				className,
 			)}
 		>
 			<Markdown
 				remarkPlugins={remarkPluginList}
 				rehypePlugins={rehypePluginList}
+				components={{
+					table: ({ children: c, ...props }) => (
+						<div style={{ overflowX: "auto", maxWidth: "100%" }}>
+							<table {...props}>{c}</table>
+						</div>
+					),
+				}}
 			>
 				{children}
 			</Markdown>
@@ -79,9 +86,7 @@ function PlanContent({
 	return (
 		<>
 			{plan && (
-				<InlineMarkdown data-testid="plan-markdown" className="break-words">
-					{plan}
-				</InlineMarkdown>
+				<InlineMarkdown data-testid="plan-markdown">{plan}</InlineMarkdown>
 			)}
 			{allowedPrompts.length > 0 && (
 				<div data-testid="allowed-prompts">
@@ -287,7 +292,7 @@ export function PermissionDialog({
 		return (
 			<div
 				data-testid="permission-dialog"
-				className="mx-3 my-1.5 rounded-md border border-border bg-muted/50 p-3"
+				className="mx-3 my-1.5 rounded-md border border-border bg-muted/50 p-3 overflow-hidden"
 			>
 				{questions.map((q, qIndex) => {
 					const questionId = `${questionIdBase}-q-${qIndex}`;
@@ -414,7 +419,7 @@ export function PermissionDialog({
 		return (
 			<div
 				data-testid="permission-dialog"
-				className="mx-3 my-1.5 rounded-md border border-border bg-muted/50 p-3"
+				className="mx-3 my-1.5 rounded-md border border-border bg-muted/50 p-3 overflow-hidden"
 			>
 				<p className="text-sm font-medium mb-2">Plan Review</p>
 				<div className="space-y-2 mb-2">

--- a/src/components/panels/AgentChatPanel/StreamMessage.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.tsx
@@ -53,7 +53,14 @@ export function StreamMessage({ content, role }: StreamMessageProps) {
 					<Markdown
 						remarkPlugins={remarkPluginList}
 						rehypePlugins={rehypePluginList}
-						components={{ a: ExternalLink }}
+						components={{
+							a: ExternalLink,
+							table: ({ children: c, ...props }) => (
+								<div style={{ overflowX: "auto", maxWidth: "100%" }}>
+									<table {...props}>{c}</table>
+								</div>
+							),
+						}}
 					>
 						{deferredContent}
 					</Markdown>

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -23,7 +23,7 @@ function ScrollArea({
 				ref={viewportRef}
 				onScroll={onScroll}
 				data-slot="scroll-area-viewport"
-				className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+				className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&>div]:!block"
 			>
 				{children}
 			</ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
## Summary
- Radix ScrollArea Viewportの内部`display: table`ラッパーを`display: block !important`で上書きし、コンテンツ幅の不正拡張を防止
- Plan表示・AskUserQuestion表示のコンテナに`overflow-hidden`を追加し、横はみ出しを防止
- マークダウンテーブルはラッパーdivで個別に横スクロール可能にする（`react-markdown`の`components.table`）

## Test plan
- [x] 既存テスト全件(1447件) PASS
- [x] Biome lint PASS
- [x] ビルド PASS
- [ ] Plan表示でテーブルを含む計画が横スクロールなしで表示されることを手動確認
- [ ] テーブルのみがラッパー内で横スクロール可能であることを手動確認
- [ ] AskUserQuestion表示で横スクロールが出ないことを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)