### PR TITLE
feat: AgentChatで画像をD&D/ペーストして送信できるようにする

### DIFF
--- a/docs/spec/issues-698.md
+++ b/docs/spec/issues-698.md
@@ -1,0 +1,107 @@
+## 要求
+
+**種別**: 新機能
+**ゴール**: AgentChatのメッセージ入力エリアで、画像をドラッグ&ドロップまたはクリップボードからペースト（Ctrl+V / Cmd+V）して、コンテキストとして送信できるようにする
+**背景**: Cursor、Claude Code等の主要AIコーディングツールが採用しているパターンであり、スクリーンショットやUI画像を直接共有してAIとの対話に活用するUXを実現する
+**制約**:
+- 対応画像形式: Claude Codeが認識できる形式に準拠
+- サイズ上限: Claude Code側の制限に従う（Releash側では制限しない）
+**送信方式**: テキスト+画像の同時送信、画像単体送信の両方に対応
+
+## 振る舞い定義
+
+```gherkin
+Feature: AgentChat 画像添付
+  AgentChatのメッセージ入力エリアで画像をドラッグ&ドロップまたはペーストして、
+  コンテキストとしてAIに送信する。
+
+  Rule: 画像はドラッグ&ドロップで添付できる
+    Scenario: 画像ファイルをドロップして添付する
+      Given メッセージ入力エリアが表示されている
+      When ユーザーが画像ファイルをメッセージ入力エリアにドロップする
+      Then 画像が添付リストに追加される
+
+  Rule: 画像はクリップボードからペーストで添付できる
+    Scenario: クリップボードの画像をペーストして添付する
+      Given メッセージ入力エリアにフォーカスがある
+      When ユーザーがクリップボードから画像をペーストする
+      Then 画像が添付リストに追加される
+
+  Rule: 添付された画像はプレビュー表示される
+    Scenario: 添付済み画像のプレビューを表示する
+      Given 画像が添付リストに追加されている
+      When ユーザーがメッセージ入力エリアを見る
+      Then 添付画像のサムネイルプレビューが表示される
+
+  Rule: 添付された画像は削除できる
+    Scenario: 添付済み画像を削除する
+      Given 画像が添付リストに追加されている
+      When ユーザーが添付画像を削除する
+      Then 画像が添付リストから除去される
+
+  Rule: テキストと画像を同時に送信できる
+    Scenario: テキストと画像を一緒に送信する
+      Given メッセージ入力エリアにテキストが入力されている
+      And 画像が添付リストに追加されている
+      When ユーザーがメッセージを送信する
+      Then テキストと画像がAIに送信される
+      And 添付リストがクリアされる
+
+  Rule: 画像のみでも送信できる
+    Scenario: 画像だけを送信する
+      Given メッセージ入力エリアにテキストが入力されていない
+      And 画像が添付リストに追加されている
+      When ユーザーがメッセージを送信する
+      Then 画像がAIに送信される
+      And 添付リストがクリアされる
+
+  Rule: 複数画像を添付できる
+    Scenario: 複数の画像を添付する
+      Given 画像が添付リストに追加されている
+      When ユーザーが別の画像を追加する
+      Then 両方の画像が添付リストに含まれる
+
+  Rule: 送信済み画像はチャット履歴に表示される
+    Scenario: 送信したメッセージに画像が表示される
+      Given ユーザーが画像付きメッセージを送信した
+      When ユーザーがチャット履歴を見る
+      Then 送信メッセージ内に画像が表示される
+
+  Rule: 非対応形式のファイルは添付できない
+    Scenario: 非画像ファイルをドロップする
+      Given メッセージ入力エリアが表示されている
+      When ユーザーが画像以外のファイルをドロップする
+      Then ファイルは添付されない
+```
+
+## 実装仕様
+
+**対応方針**: 振る舞い定義（D&D・ペースト・プレビュー・削除・送信・チャット履歴表示）を実現するために、Rust（agent_sdk / session）に画像処理ロジックを集約し、フロントエンド（MessageInput / StreamMessage）はUI表示とinvoke呼び出しのみ行う。Bridgeは `content` 配列に画像ブロックを追加する拡張を行う。
+
+**対象コンポーネント**:
+- `src-tauri/src/agent_sdk.rs`: `prepare_image_attachment` コマンド新設（バイナリ受取→バリデーション→Base64エンコード→返却）、`send_agent_message` 拡張（画像データを受取→セッション保存→Bridgeへ送信）
+- `src-tauri/src/session/mod.rs`: `MessagePart` に `Image` バリアントを追加、Humanメッセージを `parts` 付きで保存
+- `src-tauri/resources/claude-sdk-bridge.mjs`: `toUserMessage(text, images)` に拡張し、`content` 配列に `{ type: "image", source: { type: "base64", ... } }` を含める
+- `src/components/panels/AgentChatPanel/MessageInput.tsx`: D&D/ペーストイベント受付→`invoke("prepare_image_attachment")` 呼出→プレビューUI表示→削除UI
+- `src/components/panels/AgentChatPanel/StreamMessage.tsx`: Humanメッセージのpartsに画像バリアントがある場合 `<img>` で表示
+- `src/hooks/useSessionStore.ts`: `sendAgentMessage` のシグネチャ拡張（テキスト+画像配列をinvokeに渡す）
+- `src/types/session.ts`: `MessagePart` に `image` バリアントの型定義を追加
+
+**ロジック配置（Rust-first原則）**:
+- バリデーション（画像形式判定、非対応形式の拒否）: Rust
+- Base64エンコード: Rust
+- MIMEタイプ判定: Rust
+- UI状態管理（添付リスト）: フロントエンド（UIの責務）
+- プレビューURL組立て（`data:${mime};base64,...`）: フロントエンド（表示フォーマットの責務）
+- D&D/ペーストイベントの受付: フロントエンド（入力受付の責務）
+
+**検討した代替案**:
+- `@tauri-apps/plugin-clipboard-manager` 導入: Webview標準の `ClipboardEvent` で画像取得可能なため新規プラグイン導入のコストに見合わない → 却下
+- 画像を一時ファイルとして保存→パスで渡す: メモリ上で完結する方がシンプル。Claude APIもBase64を期待している → 却下
+
+**リスク**:
+- 大きな画像のinvoke通信コスト: Uint8ArrayをRustに渡す際のシリアライゼーション。Claude Code SDK側のサイズ制限に委ねるため、Releash側では制限しない（要求の制約通り）
+
+**影響するテスト**:
+- Rust（cargo test）: `prepare_image_attachment` のバリデーション・エンコードテスト、`MessagePart::Image` のserdeテスト
+- フロントエンド（Vitest）: MessageInput のD&D/ペースト/プレビュー/削除UIテスト、StreamMessage の画像パート表示テスト

--- a/src-tauri/resources/claude-sdk-bridge.mjs
+++ b/src-tauri/resources/claude-sdk-bridge.mjs
@@ -62,12 +62,28 @@ process.stdin.on("data", (chunk) => {
  * Wrap a plain text prompt into an SDKUserMessage that the CLI's
  * `--input-format stream-json` protocol expects.
  */
-function toUserMessage(text) {
+function toUserMessage(text, images) {
+	const content = [];
+	if (images && images.length > 0) {
+		for (const img of images) {
+			content.push({
+				type: "image",
+				source: {
+					type: "base64",
+					media_type: img.mediaType,
+					data: img.data,
+				},
+			});
+		}
+	}
+	if (text) {
+		content.push({ type: "text", text });
+	}
 	return {
 		type: "user",
 		message: {
 			role: "user",
-			content: [{ type: "text", text }],
+			content,
 		},
 		parent_tool_use_id: null,
 		session_id: "",
@@ -96,7 +112,7 @@ function handleCommand(cmd) {
 			handleInit(cmd);
 			break;
 		case "message": {
-			const msg = toUserMessage(cmd.prompt);
+			const msg = toUserMessage(cmd.prompt, cmd.images);
 			if (messageResolve) {
 				messageResolve(msg);
 			} else {

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -65,6 +65,7 @@ pub enum TurnPhase {
 pub struct PendingMessage {
     pub content: String,
     pub permission_mode: String,
+    pub images: Vec<ImageAttachment>,
 }
 
 /// Model information from Agent SDK.
@@ -1628,6 +1629,7 @@ async fn start_agent_turn(
     permission_mode: &str,
     prompt: &str,
     streaming_message_id: &str,
+    images: &[ImageAttachment],
 ) -> Result<(), String> {
     // Check if we need to spawn a new process (single lock to avoid TOCTOU)
     let needs_spawn = {
@@ -1663,10 +1665,7 @@ async fn start_agent_turn(
     // Even if a message is sent while the SDK is still processing an interrupt,
     // the Bridge's promptGenerator queues it and only yields after the current turn completes.
     // The SDK calls generator.next() only when ready for the next turn, providing ordering guarantee.
-    let msg_cmd = serde_json::json!({
-        "type": "message",
-        "prompt": prompt,
-    });
+    let msg_cmd = build_message_cmd(prompt, images);
     let data = format!("{}\n", msg_cmd);
 
     {
@@ -1742,6 +1741,7 @@ async fn consume_pending_message(
         chat_session_id,
         MessageRole::Agent,
         "",
+        None,
     ) {
         Ok(msg) => msg,
         Err(e) => {
@@ -1764,10 +1764,7 @@ async fn consume_pending_message(
 
     // 4. Sync permissionMode + selected_model + send message directly to the running Bridge.
     //    The process is guaranteed running since it just emitted turn_complete.
-    let msg_cmd = serde_json::json!({
-        "type": "message",
-        "prompt": pending.content,
-    });
+    let msg_cmd = build_message_cmd(&pending.content, &pending.images);
     let data = format!("{}\n", msg_cmd);
 
     {
@@ -1830,6 +1827,7 @@ pub async fn execute_agent_query(
         permission_mode.as_deref().unwrap_or("acceptEdits"),
         &prompt,
         &streaming_message_id,
+        &[],
     )
     .await
 }
@@ -2126,6 +2124,7 @@ pub struct SendMessageResponse {
 
 /// Unified command to send a message: handles session creation, message persistence,
 /// turn phase check (interrupt if streaming, start query if idle), and pending message queuing.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn send_agent_message(
     app: tauri::AppHandle,
@@ -2135,9 +2134,11 @@ pub async fn send_agent_message(
     worktree_path: String,
     content: String,
     permission_mode: Option<String>,
+    images: Option<Vec<ImageAttachment>>,
 ) -> Result<SendMessageResponse, String> {
     let data_dir = resolve_data_dir(&app)?;
     let pm = permission_mode.unwrap_or_else(|| "acceptEdits".to_string());
+    let images = images.unwrap_or_default();
 
     // 1. Create or get session
     let session = if let Some(ref sid) = chat_session_id {
@@ -2149,14 +2150,35 @@ pub async fn send_agent_message(
     };
     let sid = session.id.clone();
 
-    // 2. Add human message
-    let human_message = add_message_internal(
-        &session_store,
-        &data_dir,
-        &sid,
-        MessageRole::Human,
-        &content,
-    )?;
+    // 2. Add human message (with image parts if present)
+    let human_message = {
+        let parts = if images.is_empty() {
+            None
+        } else {
+            let mut p: Vec<MessagePart> = Vec::new();
+            if !content.is_empty() {
+                p.push(MessagePart::Text {
+                    content: content.clone(),
+                    parent_tool_use_id: None,
+                });
+            }
+            for img in &images {
+                p.push(MessagePart::Image {
+                    data: img.data.clone(),
+                    media_type: img.media_type.clone(),
+                });
+            }
+            Some(p)
+        };
+        add_message_internal(
+            &session_store,
+            &data_dir,
+            &sid,
+            MessageRole::Human,
+            &content,
+            parts,
+        )?
+    };
 
     // 3. Check turn phase
     let current_phase = {
@@ -2175,6 +2197,7 @@ pub async fn send_agent_message(
                     proc.pending_message = Some(PendingMessage {
                         content: content.clone(),
                         permission_mode: pm.clone(),
+                        images: images.clone(),
                     });
                     proc.stdin
                         .write_all(b"{\"type\":\"interrupt\"}\n")
@@ -2189,8 +2212,14 @@ pub async fn send_agent_message(
             None
         } else {
             // 4b. Create agent message + start turn
-            let agent_msg =
-                add_message_internal(&session_store, &data_dir, &sid, MessageRole::Agent, "")?;
+            let agent_msg = add_message_internal(
+                &session_store,
+                &data_dir,
+                &sid,
+                MessageRole::Agent,
+                "",
+                None,
+            )?;
             start_agent_turn(
                 &app,
                 handles.inner(),
@@ -2200,6 +2229,7 @@ pub async fn send_agent_message(
                 &pm,
                 &content,
                 &agent_msg.id,
+                &images,
             )
             .await?;
             Some(agent_msg)
@@ -2401,6 +2431,120 @@ pub async fn scan_slash_commands(cwd: String) -> Result<Vec<SlashCommandEntry>, 
     }
 
     Ok(commands)
+}
+
+// --- Image attachment support ---
+
+/// Build a JSON command to send a user message (with optional images) to the Bridge.
+fn build_message_cmd(prompt: &str, images: &[ImageAttachment]) -> serde_json::Value {
+    if images.is_empty() {
+        serde_json::json!({
+            "type": "message",
+            "prompt": prompt,
+        })
+    } else {
+        let img_blocks: Vec<serde_json::Value> = images
+            .iter()
+            .map(|img| {
+                serde_json::json!({
+                    "data": img.data,
+                    "mediaType": img.media_type,
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "type": "message",
+            "prompt": prompt,
+            "images": img_blocks,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImageAttachment {
+    pub data: String,
+    pub media_type: String,
+}
+
+/// Validate and encode an image from raw bytes.
+/// Returns base64-encoded data and detected MIME type, or an error for unsupported formats.
+fn validate_and_encode_image(bytes: &[u8]) -> Result<ImageAttachment, String> {
+    let media_type =
+        detect_image_mime(bytes).ok_or_else(|| "Unsupported image format".to_string())?;
+
+    use base64::Engine;
+    let data = base64::engine::general_purpose::STANDARD.encode(bytes);
+
+    Ok(ImageAttachment {
+        data,
+        media_type: media_type.to_string(),
+    })
+}
+
+/// Detect MIME type from magic bytes.
+fn detect_image_mime(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    // JPEG: FF D8 FF
+    if bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF {
+        return Some("image/jpeg");
+    }
+    // PNG: 89 50 4E 47
+    if bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47 {
+        return Some("image/png");
+    }
+    // GIF: 47 49 46 38
+    if bytes[0] == 0x47 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x38 {
+        return Some("image/gif");
+    }
+    // WebP: RIFF....WEBP
+    if bytes.len() >= 12
+        && bytes[0] == 0x52
+        && bytes[1] == 0x49
+        && bytes[2] == 0x46
+        && bytes[3] == 0x46
+        && bytes[8] == 0x57
+        && bytes[9] == 0x45
+        && bytes[10] == 0x42
+        && bytes[11] == 0x50
+    {
+        return Some("image/webp");
+    }
+    None
+}
+
+/// Tauri command: Validate image bytes and return base64-encoded image attachment.
+/// Called from the frontend after D&D or paste events.
+#[tauri::command]
+pub fn prepare_image_attachment(data: Vec<u8>) -> Result<ImageAttachment, String> {
+    if data.is_empty() {
+        return Err("Empty image data".to_string());
+    }
+    validate_and_encode_image(&data)
+}
+
+/// Tauri command: Read image files from paths and return base64-encoded attachments.
+/// Called from the frontend when files are dropped via native drag-and-drop.
+/// Non-image files are silently skipped.
+#[tauri::command]
+pub async fn prepare_image_attachments_from_paths(
+    paths: Vec<String>,
+) -> Result<Vec<ImageAttachment>, String> {
+    let mut attachments = Vec::new();
+    for path in &paths {
+        let data = tokio::fs::read(path)
+            .await
+            .map_err(|e| format!("Failed to read {}: {}", path, e))?;
+        if data.is_empty() {
+            continue;
+        }
+        if let Ok(attachment) = validate_and_encode_image(&data) {
+            attachments.push(attachment);
+        }
+    }
+    Ok(attachments)
 }
 
 #[cfg(test)]
@@ -3831,5 +3975,159 @@ mod tests {
     #[test]
     fn resolve_permission_mode_default_unchanged() {
         assert_eq!(resolve_permission_mode("default"), "default");
+    }
+
+    // --- Image attachment tests ---
+
+    #[test]
+    fn detect_image_mime_jpeg() {
+        let bytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+        assert_eq!(detect_image_mime(&bytes), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn detect_image_mime_png() {
+        let bytes = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        assert_eq!(detect_image_mime(&bytes), Some("image/png"));
+    }
+
+    #[test]
+    fn detect_image_mime_gif() {
+        let bytes = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61];
+        assert_eq!(detect_image_mime(&bytes), Some("image/gif"));
+    }
+
+    #[test]
+    fn detect_image_mime_webp() {
+        let bytes = [
+            0x52, 0x49, 0x46, 0x46, // RIFF
+            0x00, 0x00, 0x00, 0x00, // size
+            0x57, 0x45, 0x42, 0x50, // WEBP
+        ];
+        assert_eq!(detect_image_mime(&bytes), Some("image/webp"));
+    }
+
+    #[test]
+    fn detect_image_mime_unknown() {
+        let bytes = [0x00, 0x01, 0x02, 0x03];
+        assert_eq!(detect_image_mime(&bytes), None);
+    }
+
+    #[test]
+    fn detect_image_mime_too_short() {
+        let bytes = [0xFF, 0xD8];
+        assert_eq!(detect_image_mime(&bytes), None);
+    }
+
+    #[test]
+    fn validate_and_encode_image_jpeg() {
+        let mut bytes = vec![0xFF, 0xD8, 0xFF, 0xE0];
+        bytes.extend_from_slice(&[0x00; 100]); // pad
+        let result = validate_and_encode_image(&bytes).unwrap();
+        assert_eq!(result.media_type, "image/jpeg");
+        assert!(!result.data.is_empty());
+    }
+
+    #[test]
+    fn validate_and_encode_image_png() {
+        let mut bytes = vec![0x89, 0x50, 0x4E, 0x47];
+        bytes.extend_from_slice(&[0x00; 100]);
+        let result = validate_and_encode_image(&bytes).unwrap();
+        assert_eq!(result.media_type, "image/png");
+    }
+
+    #[test]
+    fn validate_and_encode_image_rejects_unknown() {
+        let bytes = vec![0x00, 0x01, 0x02, 0x03, 0x04];
+        let result = validate_and_encode_image(&bytes);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unsupported"));
+    }
+
+    #[test]
+    fn prepare_image_attachment_empty_data() {
+        let result = prepare_image_attachment(vec![]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Empty"));
+    }
+
+    #[test]
+    fn prepare_image_attachment_valid_png() {
+        let mut bytes = vec![0x89, 0x50, 0x4E, 0x47];
+        bytes.extend_from_slice(&[0x00; 100]);
+        let result = prepare_image_attachment(bytes).unwrap();
+        assert_eq!(result.media_type, "image/png");
+    }
+
+    #[test]
+    fn prepare_image_attachment_rejects_text_file() {
+        let bytes = b"Hello, world!".to_vec();
+        let result = prepare_image_attachment(bytes);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn prepare_image_attachments_from_paths_valid_png() {
+        let dir = tempfile::tempdir().unwrap();
+        let png_path = dir.path().join("test.png");
+        let mut png_bytes = vec![0x89, 0x50, 0x4E, 0x47];
+        png_bytes.extend_from_slice(&[0x00; 100]);
+        tokio::fs::write(&png_path, &png_bytes).await.unwrap();
+
+        let result =
+            prepare_image_attachments_from_paths(vec![png_path.to_string_lossy().to_string()])
+                .await
+                .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].media_type, "image/png");
+    }
+
+    #[tokio::test]
+    async fn prepare_image_attachments_from_paths_skips_non_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let txt_path = dir.path().join("readme.txt");
+        tokio::fs::write(&txt_path, b"Hello, world!").await.unwrap();
+
+        let result =
+            prepare_image_attachments_from_paths(vec![txt_path.to_string_lossy().to_string()])
+                .await
+                .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn prepare_image_attachments_from_paths_skips_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let empty_path = dir.path().join("empty.png");
+        tokio::fs::write(&empty_path, b"").await.unwrap();
+
+        let result =
+            prepare_image_attachments_from_paths(vec![empty_path.to_string_lossy().to_string()])
+                .await
+                .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn build_message_cmd_text_only() {
+        let cmd = build_message_cmd("hello", &[]);
+        assert_eq!(cmd["type"], "message");
+        assert_eq!(cmd["prompt"], "hello");
+        assert!(cmd.get("images").is_none());
+    }
+
+    #[test]
+    fn build_message_cmd_with_images() {
+        let images = vec![ImageAttachment {
+            data: "base64data".to_string(),
+            media_type: "image/png".to_string(),
+        }];
+        let cmd = build_message_cmd("check this", &images);
+        assert_eq!(cmd["type"], "message");
+        assert_eq!(cmd["prompt"], "check this");
+        let imgs = cmd["images"].as_array().unwrap();
+        assert_eq!(imgs.len(), 1);
+        assert_eq!(imgs[0]["data"], "base64data");
+        assert_eq!(imgs[0]["mediaType"], "image/png");
     }
 }

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -2467,9 +2467,21 @@ pub struct ImageAttachment {
     pub media_type: String,
 }
 
+/// Maximum image size in bytes (5 MiB).
+/// Anthropic Messages API limits base64-encoded images to ~5 MB.
+const MAX_IMAGE_BYTES: usize = 5 * 1024 * 1024;
+
 /// Validate and encode an image from raw bytes.
 /// Returns base64-encoded data and detected MIME type, or an error for unsupported formats.
 fn validate_and_encode_image(bytes: &[u8]) -> Result<ImageAttachment, String> {
+    if bytes.len() > MAX_IMAGE_BYTES {
+        return Err(format!(
+            "Image too large: {} bytes (max {} bytes)",
+            bytes.len(),
+            MAX_IMAGE_BYTES
+        ));
+    }
+
     let media_type =
         detect_image_mime(bytes).ok_or_else(|| "Unsupported image format".to_string())?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -348,6 +348,8 @@ pub fn run() {
             agent_sdk::send_agent_message,
             agent_sdk::init_agent_sessions,
             agent_sdk::scan_slash_commands,
+            agent_sdk::prepare_image_attachment,
+            agent_sdk::prepare_image_attachments_from_paths,
             // Session
             session::list_sessions,
             agent_sdk::get_session,

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -207,10 +207,21 @@ impl ChatSession {
             .messages
             .first()
             .map(|m| {
-                let content = &m.content;
+                let content = if m.content.is_empty() {
+                    if m.parts
+                        .as_ref()
+                        .is_some_and(|parts| parts.iter().any(|p| matches!(p, MessagePart::Image { .. })))
+                    {
+                        "[Image]".to_string()
+                    } else {
+                        m.content.clone()
+                    }
+                } else {
+                    m.content.clone()
+                };
                 match content.char_indices().nth(100) {
                     Some((byte_pos, _)) => format!("{}…", &content[..byte_pos]),
-                    None => content.clone(),
+                    None => content,
                 }
             })
             .unwrap_or_default();

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -208,10 +208,9 @@ impl ChatSession {
             .first()
             .map(|m| {
                 let content = if m.content.is_empty() {
-                    if m.parts
-                        .as_ref()
-                        .is_some_and(|parts| parts.iter().any(|p| matches!(p, MessagePart::Image { .. })))
-                    {
+                    if m.parts.as_ref().is_some_and(|parts| {
+                        parts.iter().any(|p| matches!(p, MessagePart::Image { .. }))
+                    }) {
                         "[Image]".to_string()
                     } else {
                         m.content.clone()

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -91,6 +91,13 @@ pub enum MessagePart {
         #[serde(skip_serializing_if = "Option::is_none", default, rename = "hookId")]
         hook_id: Option<String>,
     },
+    Image {
+        /// Base64-encoded image data
+        data: String,
+        /// MIME type (e.g. "image/png", "image/jpeg")
+        #[serde(rename = "mediaType")]
+        media_type: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -298,6 +305,7 @@ pub fn parts_to_legacy(
             }
             MessagePart::TaskStatus { .. } => {}
             MessagePart::SystemNotification { .. } => {}
+            MessagePart::Image { .. } => {}
         }
     }
     let thinking = if thinking.is_empty() {
@@ -352,6 +360,7 @@ pub fn add_message_internal(
     session_id: &str,
     role: MessageRole,
     content: &str,
+    parts: Option<Vec<MessagePart>>,
 ) -> Result<ChatMessage, String> {
     let mut session = session_store
         .get_session(data_dir, session_id)?
@@ -363,7 +372,7 @@ pub fn add_message_internal(
         content: content.to_string(),
         thinking: None,
         activities: None,
-        parts: None,
+        parts,
         timestamp: now,
     };
     session.messages.push(message.clone());
@@ -391,7 +400,7 @@ pub fn add_message(
     content: String,
 ) -> Result<ChatMessage, String> {
     let data_dir = resolve_data_dir(&app)?;
-    add_message_internal(&state, &data_dir, &session_id, role, &content)
+    add_message_internal(&state, &data_dir, &session_id, role, &content, None)
 }
 
 #[tauri::command]
@@ -1051,5 +1060,67 @@ mod tests {
         } else {
             panic!("Expected Text variant");
         }
+    }
+
+    #[test]
+    fn message_part_image_serde_roundtrip() {
+        let part = MessagePart::Image {
+            data: "iVBORw0KGgoAAAA==".to_string(),
+            media_type: "image/png".to_string(),
+        };
+        let json = serde_json::to_string(&part).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "image");
+        assert_eq!(v["data"], "iVBORw0KGgoAAAA==");
+        assert_eq!(v["mediaType"], "image/png");
+        let back: MessagePart = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, part);
+    }
+
+    #[test]
+    fn chat_message_with_image_parts_roundtrip() {
+        let msg = ChatMessage {
+            id: "m1".to_string(),
+            role: MessageRole::Human,
+            content: "Check this image".to_string(),
+            thinking: None,
+            activities: None,
+            parts: Some(vec![
+                MessagePart::Text {
+                    content: "Check this image".to_string(),
+                    parent_tool_use_id: None,
+                },
+                MessagePart::Image {
+                    data: "base64data".to_string(),
+                    media_type: "image/jpeg".to_string(),
+                },
+            ]),
+            timestamp: 1000.0,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let back: ChatMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.parts.as_ref().unwrap().len(), 2);
+        assert!(matches!(
+            &back.parts.as_ref().unwrap()[1],
+            MessagePart::Image { .. }
+        ));
+    }
+
+    #[test]
+    fn parts_to_legacy_ignores_image() {
+        let parts = vec![
+            MessagePart::Text {
+                content: "hello".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::Image {
+                data: "base64".to_string(),
+                media_type: "image/png".to_string(),
+            },
+        ];
+        let (content, thinking, activities) = parts_to_legacy(&parts);
+        assert_eq!(content, "hello");
+        assert_eq!(thinking, None);
+        assert_eq!(activities, None);
     }
 }

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 // jsdom does not implement scrollIntoView
@@ -10,12 +16,22 @@ vi.mock("react-resizable-panels", () => ({
 	Separator: () => <div />,
 }));
 
+const mockInvoke = vi.fn().mockResolvedValue([]);
 vi.mock("@tauri-apps/api/core", () => ({
-	invoke: vi.fn().mockResolvedValue([]),
+	invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
+type ListenCallback = (event: { payload: unknown }) => void;
+const listenCallbacks = new Map<string, ListenCallback>();
+const mockListen = vi.fn((eventName: string, callback: ListenCallback) => {
+	listenCallbacks.set(eventName, callback);
+	return Promise.resolve(() => {
+		listenCallbacks.delete(eventName);
+	});
+});
 vi.mock("@tauri-apps/api/event", () => ({
-	listen: vi.fn().mockResolvedValue(() => {}),
+	listen: (...args: unknown[]) =>
+		mockListen(args[0] as string, args[1] as ListenCallback),
 }));
 
 const useAgentChatMock = vi.fn();
@@ -25,6 +41,18 @@ vi.mock("@/hooks/useAgentChat", () => ({
 
 // Must import after mocks
 const { AgentChatPanel } = await import("./AgentChatPanel");
+
+type DropCallback = (paths: string[]) => void;
+const agentDropCallbacks = new Map<string, DropCallback>();
+const mockRegisterDropZone = vi.fn(
+	(zone: string, _element: HTMLElement | null, onDrop?: DropCallback) => {
+		if (_element && onDrop) {
+			agentDropCallbacks.set(zone, onDrop);
+		} else if (!_element) {
+			agentDropCallbacks.delete(zone);
+		}
+	},
+);
 
 function mockUseAgentChat(overrides: Record<string, unknown> = {}) {
 	const sessions = (overrides.sessions ?? []) as Array<{ id: string }>;
@@ -60,13 +88,23 @@ function mockUseAgentChat(overrides: Record<string, unknown> = {}) {
 describe("AgentChatPanel", () => {
 	it("renders empty state when no active session", () => {
 		mockUseAgentChat();
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.getByTestId("agent-chat-panel")).toBeDefined();
 	});
 
 	it("renders message input", () => {
 		mockUseAgentChat();
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.getByTestId("message-input")).toBeDefined();
 	});
 });
@@ -95,7 +133,12 @@ describe("AgentChatPanel session tabs", () => {
 				},
 			],
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.getByText("Hello")).toBeDefined();
 		expect(screen.getByText("Fix bug")).toBeDefined();
 	});
@@ -114,7 +157,12 @@ describe("AgentChatPanel session tabs", () => {
 				},
 			],
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.getByText("New session")).toBeDefined();
 	});
 
@@ -132,7 +180,12 @@ describe("AgentChatPanel session tabs", () => {
 				},
 			],
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.queryByLabelText("Close Hello")).toBeNull();
 	});
 
@@ -159,7 +212,12 @@ describe("AgentChatPanel session tabs", () => {
 				},
 			],
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.getByLabelText("Close Hello")).toBeDefined();
 		expect(screen.getByLabelText("Close Fix bug")).toBeDefined();
 	});
@@ -189,7 +247,12 @@ describe("AgentChatPanel session tabs", () => {
 			],
 			closeSession,
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		fireEvent.click(screen.getByLabelText("Close Hello"));
 		expect(closeSession).toHaveBeenCalledWith("s1");
 	});
@@ -197,7 +260,12 @@ describe("AgentChatPanel session tabs", () => {
 	it("calls createNewSession when + button is clicked", () => {
 		const createNewSession = vi.fn();
 		mockUseAgentChat({ createNewSession });
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		fireEvent.click(screen.getByLabelText("New session"));
 		expect(createNewSession).toHaveBeenCalled();
 	});
@@ -227,7 +295,12 @@ describe("AgentChatPanel session tabs", () => {
 			],
 			selectSession,
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		fireEvent.click(screen.getByText("Fix bug"));
 		expect(selectSession).toHaveBeenCalledWith("s2");
 	});
@@ -271,7 +344,12 @@ describe("AgentChatPanel agent state reflection", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 
 		const tab = screen.getByText("Hello").closest("[role='tab']");
 		expect(tab?.querySelector("[title='running']")).not.toBeNull();
@@ -320,7 +398,12 @@ describe("AgentChatPanel agent state reflection", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 
 		const tab = screen.getByText("Hello").closest("[role='tab']");
 		expect(tab?.querySelector("[title='waiting']")).not.toBeNull();
@@ -341,7 +424,12 @@ describe("AgentChatPanel agent state reflection", () => {
 			],
 			sessionAgentStates: new Map([["s1", "done"]]),
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 
 		const tab = screen.getByText("Hello").closest("[role='tab']");
 		expect(tab?.querySelector("[title='done']")).not.toBeNull();
@@ -366,7 +454,12 @@ describe("AgentChatPanel agent state reflection", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 
 		expect(screen.getByTestId("mode-selector-trigger")).toHaveTextContent(
 			"Plan",
@@ -395,7 +488,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		const shimmer = screen.getByTestId("shimmer-placeholder");
 		expect(shimmer).toBeDefined();
 		expect(shimmer.children).toHaveLength(3);
@@ -429,7 +527,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		const shimmer = screen.getByTestId("shimmer-placeholder");
 		expect(shimmer).toBeDefined();
 		expect(shimmer.children).toHaveLength(2);
@@ -461,7 +564,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.getByTestId("stream-message-agent")).toBeDefined();
 		const shimmer = screen.getByTestId("shimmer-placeholder");
 		expect(shimmer).toBeDefined();
@@ -500,7 +608,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		const shimmer = screen.getByTestId("shimmer-placeholder");
 		expect(shimmer).toBeDefined();
 		expect(shimmer.children).toHaveLength(2);
@@ -546,7 +659,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		const shimmer = screen.getByTestId("shimmer-placeholder");
 		expect(shimmer).toBeDefined();
 		expect(shimmer.children).toHaveLength(2);
@@ -588,7 +706,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.queryByTestId("shimmer-placeholder")).toBeNull();
 	});
 
@@ -617,7 +740,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.queryByTestId("shimmer-placeholder")).toBeNull();
 	});
 
@@ -649,7 +777,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.queryByTestId("thinking-indicator")).toBeNull();
 		expect(screen.getByTestId("stream-message-agent")).toBeDefined();
 	});
@@ -679,7 +812,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.getByTestId("stream-message-agent")).toBeDefined();
 		expect(screen.queryByTestId("shimmer-placeholder")).toBeNull();
 	});
@@ -734,7 +872,12 @@ describe("AgentChatPanel shimmer placeholder", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		// Both tool_use items should be rendered, but no standalone tool_result items
 		expect(screen.getByTestId("activity-tool-use-0")).toBeDefined();
 		expect(screen.getByTestId("activity-tool-use-1")).toBeDefined();
@@ -750,7 +893,12 @@ describe("AgentChatPanel Shift+Tab mode cycle", () => {
 			permissionMode: "acceptEdits",
 			setPermissionMode,
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.keyDown(textarea, { key: "Tab", shiftKey: true });
@@ -821,7 +969,12 @@ describe("AgentChatPanel Task tool rendering", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 
 		// TaskToolActivity should be rendered
 		expect(screen.getByTestId("activity-task-0")).toBeDefined();
@@ -871,7 +1024,12 @@ describe("AgentChatPanel Task tool rendering", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		const shimmer = screen.getByTestId("shimmer-placeholder");
 		expect(shimmer.children).toHaveLength(2);
 	});
@@ -910,7 +1068,12 @@ describe("SystemNotificationItem rendering", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		const el = screen.getByText(/Compacting conversation/);
 		expect(el).toBeDefined();
 		expect(el.textContent).toContain("⏳");
@@ -949,7 +1112,12 @@ describe("SystemNotificationItem rendering", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		const el = screen.getByText(/Conversation compacted/);
 		expect(el).toBeDefined();
 		expect(el.textContent).toContain("✓");
@@ -989,7 +1157,12 @@ describe("SystemNotificationItem rendering", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		const el = screen.getByText(/pre-commit/);
 		expect(el).toBeDefined();
 		expect(el.textContent).toContain("❌");
@@ -1028,7 +1201,12 @@ describe("SystemNotificationItem rendering", () => {
 				updatedAt: 1000,
 			},
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.getByText("(trigger=auto, 50000 tokens)")).toBeDefined();
 	});
 });
@@ -1036,13 +1214,23 @@ describe("SystemNotificationItem rendering", () => {
 describe("AgentChatPanel session history", () => {
 	it("renders history button", () => {
 		mockUseAgentChat();
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		expect(screen.getByLabelText("Session history")).toBeDefined();
 	});
 
 	it("shows 'No closed sessions' when closedSessions is empty", () => {
 		mockUseAgentChat();
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		fireEvent.click(screen.getByLabelText("Session history"));
 		expect(screen.getByText("No closed sessions")).toBeDefined();
 	});
@@ -1063,10 +1251,115 @@ describe("AgentChatPanel session history", () => {
 			],
 			restoreSession,
 		});
-		render(<AgentChatPanel worktreePath="/repo" />);
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
 		fireEvent.click(screen.getByLabelText("Session history"));
 		expect(screen.getByText("Old conversation")).toBeDefined();
 		fireEvent.click(screen.getByText("Old conversation"));
 		expect(restoreSession).toHaveBeenCalledWith("closed-1");
+	});
+});
+
+describe("AgentChatPanel image drag and drop", () => {
+	it("shows drop overlay on dragover with files and hides on dragleave", () => {
+		mockUseAgentChat();
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
+
+		const dropZone = screen
+			.getByTestId("agent-chat-panel")
+			.querySelector("[class*='relative']") as HTMLElement;
+		expect(dropZone).not.toBeNull();
+
+		// Initially no overlay
+		expect(screen.queryByText("Drop image to attach")).toBeNull();
+
+		// Drag over with Files
+		fireEvent.dragOver(dropZone, {
+			dataTransfer: { types: ["Files"], dropEffect: "" },
+		});
+		expect(screen.getByText("Drop image to attach")).toBeDefined();
+
+		// Drag leave (relatedTarget outside currentTarget)
+		fireEvent.dragLeave(dropZone, {
+			relatedTarget: document.body,
+		});
+		expect(screen.queryByText("Drop image to attach")).toBeNull();
+	});
+
+	it("calls prepare_image_attachments_from_paths on native file drop", async () => {
+		mockUseAgentChat();
+		mockInvoke.mockImplementation(async (cmd: string) => {
+			if (cmd === "prepare_image_attachments_from_paths") {
+				return [{ data: "aGVsbG8=", mediaType: "image/png" }];
+			}
+			return [];
+		});
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
+
+		// registerDropZone should have been called with "agent" zone
+		const agentDropCallback = agentDropCallbacks.get("agent");
+		expect(agentDropCallback).toBeDefined();
+
+		await act(async () => {
+			await agentDropCallback?.(["/tmp/test.png"]);
+		});
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"prepare_image_attachments_from_paths",
+				{ paths: ["/tmp/test.png"] },
+			);
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("image-preview-list")).toBeDefined();
+			expect(screen.getAllByTestId("image-preview-item")).toHaveLength(1);
+		});
+	});
+
+	it("does not show preview when dropped files are not images", async () => {
+		mockUseAgentChat();
+		mockInvoke.mockImplementation(async (cmd: string) => {
+			if (cmd === "prepare_image_attachments_from_paths") {
+				return [];
+			}
+			return [];
+		});
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
+
+		const agentDropCallback = agentDropCallbacks.get("agent");
+		expect(agentDropCallback).toBeDefined();
+
+		await act(async () => {
+			await agentDropCallback?.(["/tmp/readme.txt"]);
+		});
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"prepare_image_attachments_from_paths",
+				{ paths: ["/tmp/readme.txt"] },
+			);
+		});
+
+		expect(screen.queryByTestId("image-preview-list")).toBeNull();
 	});
 });

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { History, X } from "lucide-react";
 import React, {
 	useCallback,
@@ -15,8 +16,14 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAgentChat } from "@/hooks/useAgentChat";
+import type { DropZoneType } from "@/hooks/useNativeFileDrop";
 import { loadSlashCommands } from "@/hooks/useSlashCommands";
-import type { ChatMessage, MessagePart } from "@/types/session";
+import type {
+	ChatMessage,
+	ImageAttachment,
+	ImagePart,
+	MessagePart,
+} from "@/types/session";
 import { getTextContent } from "@/types/session";
 import {
 	ActivityItem,
@@ -24,6 +31,7 @@ import {
 	TaskToolActivity,
 	ToolActivity,
 } from "./ActivityLog";
+import type { MessageInputHandle } from "./MessageInput";
 import { MessageInput } from "./MessageInput";
 import { MODES } from "./ModeSelector";
 import { PermissionDialog } from "./PermissionDialog";
@@ -199,6 +207,8 @@ const AgentMessageParts = React.memo(function AgentMessageParts({
 						);
 					case "system_notification":
 						return <SystemNotificationItem key={key} part={part} />;
+					case "image":
+						return null;
 				}
 			})}
 			{runningBackgroundTasks.map((group) => (
@@ -221,9 +231,17 @@ const AgentMessageParts = React.memo(function AgentMessageParts({
 
 interface AgentChatPanelProps {
 	worktreePath: string;
+	registerDropZone: (
+		zone: DropZoneType,
+		element: HTMLElement | null,
+		onDrop?: (paths: string[]) => void,
+	) => void;
 }
 
-export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
+export function AgentChatPanel({
+	worktreePath,
+	registerDropZone,
+}: AgentChatPanelProps) {
 	const {
 		sessions,
 		orderedSessions,
@@ -253,6 +271,10 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 	const draggedSessionIdRef = useRef<string | null>(null);
 	const isDraggingRef = useRef(false);
 
+	const messageInputRef = useRef<MessageInputHandle>(null);
+	const [isFileDragOver, setIsFileDragOver] = useState(false);
+	const isFileDragOverRef = useRef(false);
+
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const scrollAnchorRef = useRef<HTMLDivElement>(null);
 	const lastMessageCount = useRef(0);
@@ -264,6 +286,49 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 			console.error("Failed to load slash commands:", e),
 		);
 	}, [worktreePath]);
+
+	// Register agent drop zone for native file drop (image attachment)
+	const agentDropZoneRef = useRef<HTMLDivElement>(null);
+	const handleAgentDrop = useCallback(async (paths: string[]) => {
+		isFileDragOverRef.current = false;
+		setIsFileDragOver(false);
+		try {
+			const attachments = await invoke<ImageAttachment[]>(
+				"prepare_image_attachments_from_paths",
+				{ paths },
+			);
+			if (attachments.length > 0) {
+				messageInputRef.current?.addImageAttachments(attachments);
+			}
+		} catch (e) {
+			console.error("Failed to process dropped images:", e);
+		}
+	}, []);
+	useEffect(() => {
+		const el = agentDropZoneRef.current;
+		if (el) {
+			registerDropZone("agent", el, handleAgentDrop);
+		}
+		return () => {
+			registerDropZone("agent", null);
+		};
+	}, [registerDropZone, handleAgentDrop]);
+
+	const handleFileDragOver = useCallback((e: React.DragEvent) => {
+		if (e.dataTransfer.types.includes("Files")) {
+			e.preventDefault();
+			e.dataTransfer.dropEffect = "copy";
+			isFileDragOverRef.current = true;
+			setIsFileDragOver(true);
+		}
+	}, []);
+
+	const handleFileDragLeave = useCallback((e: React.DragEvent) => {
+		if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+			isFileDragOverRef.current = false;
+			setIsFileDragOver(false);
+		}
+	}, []);
 
 	// Track scroll position via onScroll handler
 	const handleScroll = useCallback(() => {
@@ -480,7 +545,20 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 						</PopoverContent>
 					</Popover>
 				</div>
-				<div className="flex flex-col flex-1 min-h-0">
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: native file drop target */}
+				<div
+					ref={agentDropZoneRef}
+					className="flex flex-col flex-1 min-h-0 relative"
+					onDragOver={handleFileDragOver}
+					onDragLeave={handleFileDragLeave}
+				>
+					{isFileDragOver && (
+						<div className="absolute inset-0 flex items-center justify-center bg-primary/10 border-2 border-dashed border-primary rounded pointer-events-none z-10">
+							<span className="text-sm font-medium text-primary bg-background/80 px-3 py-1.5 rounded">
+								Drop image to attach
+							</span>
+						</div>
+					)}
 					<ScrollArea
 						viewportRef={scrollRef}
 						onScroll={handleScroll}
@@ -491,9 +569,18 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 								{activeSession.messages.map((msg, idx) => {
 									if (msg.role !== "agent") {
 										const textContent = getTextContent(msg.parts);
+										const imageParts = msg.parts.filter(
+											(p): p is ImagePart => p.type === "image",
+										);
 										return (
 											<div key={msg.id}>
-												<StreamMessage content={textContent} role={msg.role} />
+												<StreamMessage
+													content={textContent}
+													role={msg.role}
+													images={
+														imageParts.length > 0 ? imageParts : undefined
+													}
+												/>
 											</div>
 										);
 									}
@@ -533,6 +620,7 @@ export function AgentChatPanel({ worktreePath }: AgentChatPanelProps) {
 							</div>
 						)}
 						<MessageInput
+							ref={messageInputRef}
 							onSend={sendMessage}
 							onInterrupt={interrupt}
 							isStreaming={isStreaming}

--- a/src/components/panels/AgentChatPanel/MessageInput.test.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.test.tsx
@@ -1,5 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { createRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setSlashCommands } from "@/hooks/useSlashCommands";
@@ -427,9 +433,11 @@ describe("MessageInput image attachments", () => {
 		await act(async () => {
 			fireEvent.paste(textarea, { clipboardData });
 		});
-		expect(invoke).toHaveBeenCalledWith("prepare_image_attachment", {
-			data: expect.any(Array),
+		await waitFor(() => {
+			expect(invoke).toHaveBeenCalledWith("prepare_image_attachment", {
+				data: expect.any(Array),
+			});
 		});
-		expect(screen.getByTestId("image-preview-list")).toBeDefined();
+		expect(await screen.findByTestId("image-preview-list")).toBeDefined();
 	});
 });

--- a/src/components/panels/AgentChatPanel/MessageInput.test.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.test.tsx
@@ -1,7 +1,9 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setSlashCommands } from "@/hooks/useSlashCommands";
-import { MessageInput } from "./MessageInput";
+import { MessageInput, type MessageInputHandle } from "./MessageInput";
 
 const defaultProps = {
 	onSend: vi.fn(),
@@ -300,5 +302,134 @@ describe("MessageInput slash command popup", () => {
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "/" } });
 		expect(screen.queryByTestId("slash-command-list")).toBeNull();
+	});
+});
+
+const sampleAttachment = {
+	data: "aGVsbG8=",
+	mediaType: "image/png",
+};
+
+describe("MessageInput image attachments", () => {
+	it("shows image preview when images are added via ref", () => {
+		const ref = createRef<MessageInputHandle>();
+		render(<MessageInput {...defaultProps} ref={ref} />);
+		act(() => {
+			ref.current?.addImageAttachments([sampleAttachment]);
+		});
+		expect(screen.getByTestId("image-preview-list")).toBeDefined();
+		expect(screen.getAllByTestId("image-preview-item")).toHaveLength(1);
+		const img = screen.getByAltText("Attached");
+		expect(img.getAttribute("src")).toBe("data:image/png;base64,aGVsbG8=");
+	});
+
+	it("enables send button when only images are attached (no text)", () => {
+		const ref = createRef<MessageInputHandle>();
+		render(<MessageInput {...defaultProps} ref={ref} />);
+		act(() => {
+			ref.current?.addImageAttachments([sampleAttachment]);
+		});
+		const button = screen.getByLabelText("Send message");
+		expect(button.hasAttribute("disabled")).toBe(false);
+	});
+
+	it("removes image when remove button is clicked", () => {
+		const ref = createRef<MessageInputHandle>();
+		render(<MessageInput {...defaultProps} ref={ref} />);
+		act(() => {
+			ref.current?.addImageAttachments([sampleAttachment]);
+		});
+		expect(screen.getAllByTestId("image-preview-item")).toHaveLength(1);
+		fireEvent.click(screen.getByTestId("remove-image-button"));
+		expect(screen.queryByTestId("image-preview-item")).toBeNull();
+	});
+
+	it("sends images with onSend when images are attached", () => {
+		const onSend = vi.fn();
+		const ref = createRef<MessageInputHandle>();
+		render(<MessageInput {...defaultProps} onSend={onSend} ref={ref} />);
+		act(() => {
+			ref.current?.addImageAttachments([sampleAttachment]);
+		});
+		const textarea = screen.getByPlaceholderText("Send a message...");
+		fireEvent.change(textarea, { target: { value: "Check this" } });
+		fireEvent.click(screen.getByLabelText("Send message"));
+		expect(onSend).toHaveBeenCalledWith("Check this", [sampleAttachment]);
+	});
+
+	it("sends images only (no text) when text is empty", () => {
+		const onSend = vi.fn();
+		const ref = createRef<MessageInputHandle>();
+		render(<MessageInput {...defaultProps} onSend={onSend} ref={ref} />);
+		act(() => {
+			ref.current?.addImageAttachments([sampleAttachment]);
+		});
+		fireEvent.click(screen.getByLabelText("Send message"));
+		expect(onSend).toHaveBeenCalledWith("", [sampleAttachment]);
+	});
+
+	it("clears image preview after sending", () => {
+		const ref = createRef<MessageInputHandle>();
+		render(<MessageInput {...defaultProps} ref={ref} />);
+		act(() => {
+			ref.current?.addImageAttachments([sampleAttachment]);
+		});
+		expect(screen.getByTestId("image-preview-list")).toBeDefined();
+		fireEvent.click(screen.getByLabelText("Send message"));
+		expect(screen.queryByTestId("image-preview-list")).toBeNull();
+	});
+
+	it("supports multiple image attachments", () => {
+		const ref = createRef<MessageInputHandle>();
+		render(<MessageInput {...defaultProps} ref={ref} />);
+		act(() => {
+			ref.current?.addImageAttachments([
+				sampleAttachment,
+				{ data: "aW1nMg==", mediaType: "image/jpeg" },
+			]);
+		});
+		expect(screen.getAllByTestId("image-preview-item")).toHaveLength(2);
+	});
+
+	it("ignores non-image files on paste", async () => {
+		render(<MessageInput {...defaultProps} />);
+		const textarea = screen.getByPlaceholderText("Send a message...");
+		const file = new File(["hello"], "readme.txt", { type: "text/plain" });
+		const clipboardData = {
+			items: [
+				{
+					type: "text/plain",
+					getAsFile: () => file,
+				},
+			],
+		};
+		await act(async () => {
+			fireEvent.paste(textarea, { clipboardData });
+		});
+		expect(screen.queryByTestId("image-preview-list")).toBeNull();
+	});
+
+	it("adds image from clipboard paste", async () => {
+		vi.mocked(invoke).mockResolvedValueOnce(sampleAttachment);
+		render(<MessageInput {...defaultProps} />);
+		const textarea = screen.getByPlaceholderText("Send a message...");
+		const file = new File(["fake-png-data"], "screenshot.png", {
+			type: "image/png",
+		});
+		const clipboardData = {
+			items: [
+				{
+					type: "image/png",
+					getAsFile: () => file,
+				},
+			],
+		};
+		await act(async () => {
+			fireEvent.paste(textarea, { clipboardData });
+		});
+		expect(invoke).toHaveBeenCalledWith("prepare_image_attachment", {
+			data: expect.any(Array),
+		});
+		expect(screen.getByTestId("image-preview-list")).toBeDefined();
 	});
 });

--- a/src/components/panels/AgentChatPanel/MessageInput.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.tsx
@@ -1,7 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { ArrowUp, Square, X } from "lucide-react";
 import {
-	forwardRef,
 	useCallback,
 	useImperativeHandle,
 	useMemo,
@@ -40,310 +39,307 @@ interface MessageInputProps {
 	models: ModelInfo[];
 	currentModelId: string | null;
 	onModelChange: (modelId: string | null) => void;
+	ref?: React.Ref<MessageInputHandle>;
 }
 
-export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
-	function MessageInput(
-		{
-			onSend,
-			onInterrupt,
-			isStreaming,
-			onCycleMode,
-			mode,
-			onModeChange,
-			models,
-			currentModelId,
-			onModelChange,
+export function MessageInput({
+	onSend,
+	onInterrupt,
+	isStreaming,
+	onCycleMode,
+	mode,
+	onModeChange,
+	models,
+	currentModelId,
+	onModelChange,
+	ref,
+}: MessageInputProps) {
+	const [value, setValue] = useState("");
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const [slashPopupDismissed, setSlashPopupDismissed] = useState(false);
+	const [selectedIndex, setSelectedIndex] = useState(0);
+	const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
+	const imageIdCounterRef = useRef(0);
+
+	const allCommands = useSlashCommands();
+
+	const createAttachedImage = useCallback(
+		(attachment: ImageAttachment): AttachedImage => {
+			return {
+				id: `img-${++imageIdCounterRef.current}`,
+				attachment,
+				previewUrl: `data:${attachment.mediaType};base64,${attachment.data}`,
+			};
 		},
-		ref,
-	) {
-		const [value, setValue] = useState("");
-		const textareaRef = useRef<HTMLTextAreaElement>(null);
-		const [slashPopupDismissed, setSlashPopupDismissed] = useState(false);
-		const [selectedIndex, setSelectedIndex] = useState(0);
-		const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
-		const imageIdCounterRef = useRef(0);
+		[],
+	);
 
-		const allCommands = useSlashCommands();
-
-		const createAttachedImage = useCallback(
-			(attachment: ImageAttachment): AttachedImage => {
-				return {
-					id: `img-${++imageIdCounterRef.current}`,
-					attachment,
-					previewUrl: `data:${attachment.mediaType};base64,${attachment.data}`,
-				};
-			},
-			[],
-		);
-
-		const processImageFile = useCallback(
-			async (file: File): Promise<AttachedImage | null> => {
-				const bytes = new Uint8Array(await file.arrayBuffer());
-				try {
-					const attachment = await invoke<ImageAttachment>(
-						"prepare_image_attachment",
-						{ data: Array.from(bytes) },
-					);
-					return createAttachedImage(attachment);
-				} catch {
-					return null;
-				}
-			},
-			[createAttachedImage],
-		);
-
-		useImperativeHandle(
-			ref,
-			() => ({
-				addImageAttachments: (attachments: ImageAttachment[]) => {
-					const newImages = attachments.map(createAttachedImage);
-					setAttachedImages((prev) => [...prev, ...newImages]);
-				},
-			}),
-			[createAttachedImage],
-		);
-
-		const showSlashPopup =
-			value.startsWith("/") && !value.includes(" ") && !slashPopupDismissed;
-		const slashQuery = value.slice(1).toLowerCase();
-
-		const filteredCommands = useMemo(() => {
-			if (!showSlashPopup) return [];
-			if (slashQuery === "") return allCommands;
-			return allCommands.filter((cmd) =>
-				cmd.name.toLowerCase().startsWith(slashQuery),
-			);
-		}, [showSlashPopup, slashQuery, allCommands]);
-
-		const popupOpen = showSlashPopup && filteredCommands.length > 0;
-
-		const handleSelectCommand = useCallback((cmd: SlashCommand) => {
-			setValue(`/${cmd.name} `);
-			setSlashPopupDismissed(true);
-			setSelectedIndex(0);
-			if (textareaRef.current) {
-				textareaRef.current.focus();
-			}
-		}, []);
-
-		const addImages = useCallback(
-			async (files: File[]) => {
-				const results = await Promise.all(files.map(processImageFile));
-				const valid = results.filter((r): r is AttachedImage => r !== null);
-				if (valid.length > 0) {
-					setAttachedImages((prev) => [...prev, ...valid]);
-				}
-			},
-			[processImageFile],
-		);
-
-		const removeImage = useCallback((id: string) => {
-			setAttachedImages((prev) => prev.filter((img) => img.id !== id));
-		}, []);
-
-		const handleSubmit = useCallback(() => {
-			const trimmed = value.trim();
-			const hasImages = attachedImages.length > 0;
-			if (!trimmed && !hasImages) return;
-			if (hasImages) {
-				onSend(
-					trimmed,
-					attachedImages.map((img) => img.attachment),
+	const processImageFile = useCallback(
+		async (file: File): Promise<AttachedImage | null> => {
+			const bytes = new Uint8Array(await file.arrayBuffer());
+			try {
+				const attachment = await invoke<ImageAttachment>(
+					"prepare_image_attachment",
+					{ data: Array.from(bytes) },
 				);
-			} else {
-				onSend(trimmed);
+				return createAttachedImage(attachment);
+			} catch {
+				return null;
 			}
-			setValue("");
-			setAttachedImages([]);
-			setSlashPopupDismissed(false);
-			setSelectedIndex(0);
-			if (textareaRef.current) {
-				textareaRef.current.style.height = "auto";
+		},
+		[createAttachedImage],
+	);
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			addImageAttachments: (attachments: ImageAttachment[]) => {
+				const newImages = attachments.map(createAttachedImage);
+				setAttachedImages((prev) => [...prev, ...newImages]);
+			},
+		}),
+		[createAttachedImage],
+	);
+
+	const showSlashPopup =
+		value.startsWith("/") && !value.includes(" ") && !slashPopupDismissed;
+	const slashQuery = value.slice(1).toLowerCase();
+
+	const filteredCommands = useMemo(() => {
+		if (!showSlashPopup) return [];
+		if (slashQuery === "") return allCommands;
+		return allCommands.filter((cmd) =>
+			cmd.name.toLowerCase().startsWith(slashQuery),
+		);
+	}, [showSlashPopup, slashQuery, allCommands]);
+
+	const popupOpen = showSlashPopup && filteredCommands.length > 0;
+
+	const handleSelectCommand = useCallback((cmd: SlashCommand) => {
+		setValue(`/${cmd.name} `);
+		setSlashPopupDismissed(true);
+		setSelectedIndex(0);
+		if (textareaRef.current) {
+			textareaRef.current.focus();
+		}
+	}, []);
+
+	const addImages = useCallback(
+		async (files: File[]) => {
+			const results = await Promise.all(files.map(processImageFile));
+			const valid = results.filter((r): r is AttachedImage => r !== null);
+			if (valid.length > 0) {
+				setAttachedImages((prev) => [...prev, ...valid]);
 			}
-		}, [value, onSend, attachedImages]);
+		},
+		[processImageFile],
+	);
 
-		const handleKeyDown = useCallback(
-			(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-				if (popupOpen) {
-					if (e.key === "ArrowDown") {
-						e.preventDefault();
-						setSelectedIndex((i) =>
-							i >= filteredCommands.length - 1 ? 0 : i + 1,
-						);
-						return;
-					}
-					if (e.key === "ArrowUp") {
-						e.preventDefault();
-						setSelectedIndex((i) =>
-							i <= 0 ? filteredCommands.length - 1 : i - 1,
-						);
-						return;
-					}
-					if (e.key === "Enter" && !e.metaKey && !e.ctrlKey) {
-						e.preventDefault();
-						if (filteredCommands[selectedIndex]) {
-							handleSelectCommand(filteredCommands[selectedIndex]);
-						}
-						return;
-					}
-					if (e.key === "Tab" && !e.shiftKey) {
-						e.preventDefault();
-						if (filteredCommands[selectedIndex]) {
-							handleSelectCommand(filteredCommands[selectedIndex]);
-						}
-						return;
-					}
-					if (e.key === "Escape") {
-						e.preventDefault();
-						setSlashPopupDismissed(true);
-						return;
-					}
-				}
+	const removeImage = useCallback((id: string) => {
+		setAttachedImages((prev) => prev.filter((img) => img.id !== id));
+	}, []);
 
-				if (e.key === "Tab" && e.shiftKey) {
+	const handleSubmit = useCallback(() => {
+		const trimmed = value.trim();
+		const hasImages = attachedImages.length > 0;
+		if (!trimmed && !hasImages) return;
+		if (hasImages) {
+			onSend(
+				trimmed,
+				attachedImages.map((img) => img.attachment),
+			);
+		} else {
+			onSend(trimmed);
+		}
+		setValue("");
+		setAttachedImages([]);
+		setSlashPopupDismissed(false);
+		setSelectedIndex(0);
+		if (textareaRef.current) {
+			textareaRef.current.style.height = "auto";
+		}
+	}, [value, onSend, attachedImages]);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+			if (popupOpen) {
+				if (e.key === "ArrowDown") {
 					e.preventDefault();
-					onCycleMode?.();
+					setSelectedIndex((i) =>
+						i >= filteredCommands.length - 1 ? 0 : i + 1,
+					);
 					return;
 				}
-				if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+				if (e.key === "ArrowUp") {
 					e.preventDefault();
-					handleSubmit();
+					setSelectedIndex((i) =>
+						i <= 0 ? filteredCommands.length - 1 : i - 1,
+					);
+					return;
 				}
-			},
-			[
-				handleSubmit,
-				onCycleMode,
-				popupOpen,
-				filteredCommands,
-				selectedIndex,
-				handleSelectCommand,
-			],
-		);
-
-		const handleChange = useCallback(
-			(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-				const newValue = e.target.value;
-				setValue(newValue);
-				setSlashPopupDismissed(false);
-				setSelectedIndex(0);
-				const el = e.target;
-				el.style.height = "auto";
-				el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
-			},
-			[],
-		);
-
-		const handlePaste = useCallback(
-			(e: React.ClipboardEvent) => {
-				const items = e.clipboardData?.items;
-				if (!items) return;
-				const imageFiles: File[] = [];
-				for (const item of items) {
-					if (item.type.startsWith("image/")) {
-						const file = item.getAsFile();
-						if (file) imageFiles.push(file);
+				if (e.key === "Enter" && !e.metaKey && !e.ctrlKey) {
+					e.preventDefault();
+					if (filteredCommands[selectedIndex]) {
+						handleSelectCommand(filteredCommands[selectedIndex]);
 					}
+					return;
 				}
-				if (imageFiles.length > 0) {
+				if (e.key === "Tab" && !e.shiftKey) {
 					e.preventDefault();
-					addImages(imageFiles);
+					if (filteredCommands[selectedIndex]) {
+						handleSelectCommand(filteredCommands[selectedIndex]);
+					}
+					return;
 				}
-			},
-			[addImages],
-		);
+				if (e.key === "Escape") {
+					e.preventDefault();
+					setSlashPopupDismissed(true);
+					return;
+				}
+			}
 
-		const canSend = value.trim().length > 0 || attachedImages.length > 0;
+			if (e.key === "Tab" && e.shiftKey) {
+				e.preventDefault();
+				onCycleMode?.();
+				return;
+			}
+			if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+				e.preventDefault();
+				handleSubmit();
+			}
+		},
+		[
+			handleSubmit,
+			onCycleMode,
+			popupOpen,
+			filteredCommands,
+			selectedIndex,
+			handleSelectCommand,
+		],
+	);
 
-		return (
-			<SlashCommandPopup
-				open={popupOpen}
-				commands={filteredCommands}
-				selectedIndex={selectedIndex}
-				onSelect={handleSelectCommand}
-				onClose={() => setSlashPopupDismissed(true)}
+	const handleChange = useCallback(
+		(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+			const newValue = e.target.value;
+			setValue(newValue);
+			setSlashPopupDismissed(false);
+			setSelectedIndex(0);
+			const el = e.target;
+			el.style.height = "auto";
+			el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+		},
+		[],
+	);
+
+	const handlePaste = useCallback(
+		(e: React.ClipboardEvent) => {
+			const items = e.clipboardData?.items;
+			if (!items) return;
+			const imageFiles: File[] = [];
+			for (const item of items) {
+				if (item.type.startsWith("image/")) {
+					const file = item.getAsFile();
+					if (file) imageFiles.push(file);
+				}
+			}
+			if (imageFiles.length > 0) {
+				e.preventDefault();
+				addImages(imageFiles);
+			}
+		},
+		[addImages],
+	);
+
+	const canSend = value.trim().length > 0 || attachedImages.length > 0;
+
+	return (
+		<SlashCommandPopup
+			open={popupOpen}
+			commands={filteredCommands}
+			selectedIndex={selectedIndex}
+			onSelect={handleSelectCommand}
+			onClose={() => setSlashPopupDismissed(true)}
+		>
+			<div
+				data-testid="message-input"
+				className="mx-3 my-2 border rounded-lg focus-within:ring-1 focus-within:ring-ring"
 			>
-				<div
-					data-testid="message-input"
-					className="mx-3 my-2 border rounded-lg focus-within:ring-1 focus-within:ring-ring"
-				>
-					{attachedImages.length > 0 && (
-						<div
-							data-testid="image-preview-list"
-							className="flex flex-wrap gap-2 px-3 pt-2"
-						>
-							{attachedImages.map((img) => (
-								<div
-									key={img.id}
-									className="relative group"
-									data-testid="image-preview-item"
+				{attachedImages.length > 0 && (
+					<div
+						data-testid="image-preview-list"
+						className="flex flex-wrap gap-2 px-3 pt-2"
+					>
+						{attachedImages.map((img) => (
+							<div
+								key={img.id}
+								className="relative group"
+								data-testid="image-preview-item"
+							>
+								<img
+									src={img.previewUrl}
+									alt="Attached"
+									className="h-16 w-16 object-cover rounded-md border"
+								/>
+								<button
+									type="button"
+									onClick={() => removeImage(img.id)}
+									className="absolute -top-1.5 -right-1.5 bg-destructive text-destructive-foreground rounded-full p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+									aria-label="Remove image"
+									data-testid="remove-image-button"
 								>
-									<img
-										src={img.previewUrl}
-										alt="Attached"
-										className="h-16 w-16 object-cover rounded-md border"
-									/>
-									<button
-										type="button"
-										onClick={() => removeImage(img.id)}
-										className="absolute -top-1.5 -right-1.5 bg-destructive text-destructive-foreground rounded-full p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
-										aria-label="Remove image"
-										data-testid="remove-image-button"
-									>
-										<X className="size-3" />
-									</button>
-								</div>
-							))}
-						</div>
-					)}
-					<textarea
-						ref={textareaRef}
-						value={value}
-						onChange={handleChange}
-						onKeyDown={handleKeyDown}
-						onPaste={handlePaste}
-						placeholder="Send a message..."
-						rows={1}
-						className="w-full resize-none bg-transparent border-none px-3 pt-3 pb-1 text-sm focus:outline-none min-h-[36px] max-h-[200px]"
-					/>
-					<div className="flex items-center justify-between px-2 pb-2">
-						<div className="flex items-center gap-1">
-							<ModeSelector
-								mode={mode}
-								onModeChange={onModeChange}
-								disabled={false}
-							/>
-							<ModelSelector
-								models={models}
-								currentModelId={currentModelId}
-								onModelChange={onModelChange}
-								disabled={false}
-							/>
-						</div>
-						{isStreaming && !canSend ? (
-							<Button
-								size="icon"
-								variant="destructive"
-								className="h-7 w-7 shrink-0"
-								onClick={onInterrupt}
-								aria-label="Interrupt agent"
-							>
-								<Square className="size-3.5" />
-							</Button>
-						) : (
-							<Button
-								size="icon"
-								className="h-7 w-7 shrink-0"
-								onClick={handleSubmit}
-								disabled={!canSend}
-								aria-label="Send message"
-							>
-								<ArrowUp className="size-3.5" />
-							</Button>
-						)}
+									<X className="size-3" />
+								</button>
+							</div>
+						))}
 					</div>
+				)}
+				<textarea
+					ref={textareaRef}
+					value={value}
+					onChange={handleChange}
+					onKeyDown={handleKeyDown}
+					onPaste={handlePaste}
+					placeholder="Send a message..."
+					rows={1}
+					className="w-full resize-none bg-transparent border-none px-3 pt-3 pb-1 text-sm focus:outline-none min-h-[36px] max-h-[200px]"
+				/>
+				<div className="flex items-center justify-between px-2 pb-2">
+					<div className="flex items-center gap-1">
+						<ModeSelector
+							mode={mode}
+							onModeChange={onModeChange}
+							disabled={false}
+						/>
+						<ModelSelector
+							models={models}
+							currentModelId={currentModelId}
+							onModelChange={onModelChange}
+							disabled={false}
+						/>
+					</div>
+					{isStreaming && !canSend ? (
+						<Button
+							size="icon"
+							variant="destructive"
+							className="h-7 w-7 shrink-0"
+							onClick={onInterrupt}
+							aria-label="Interrupt agent"
+						>
+							<Square className="size-3.5" />
+						</Button>
+					) : (
+						<Button
+							size="icon"
+							className="h-7 w-7 shrink-0"
+							onClick={handleSubmit}
+							disabled={!canSend}
+							aria-label="Send message"
+						>
+							<ArrowUp className="size-3.5" />
+						</Button>
+					)}
 				</div>
-			</SlashCommandPopup>
-		);
-	},
-);
+			</div>
+		</SlashCommandPopup>
+	);
+}

--- a/src/components/panels/AgentChatPanel/MessageInput.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.tsx
@@ -283,7 +283,7 @@ export function MessageInput({
 								<button
 									type="button"
 									onClick={() => removeImage(img.id)}
-									className="absolute -top-1.5 -right-1.5 bg-destructive text-destructive-foreground rounded-full p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+									className="absolute -top-1.5 -right-1.5 bg-destructive text-destructive-foreground rounded-full p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring transition-opacity"
 									aria-label="Remove image"
 									data-testid="remove-image-button"
 								>

--- a/src/components/panels/AgentChatPanel/MessageInput.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.tsx
@@ -1,15 +1,37 @@
-import { ArrowUp, Square } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { ArrowUp, Square, X } from "lucide-react";
+import {
+	forwardRef,
+	useCallback,
+	useImperativeHandle,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { Button } from "@/components/ui/button";
 import type { SlashCommand } from "@/hooks/useSlashCommands";
 import { useSlashCommands } from "@/hooks/useSlashCommands";
-import type { ModelInfo, PermissionMode } from "@/types/session";
+import type {
+	ImageAttachment,
+	ModelInfo,
+	PermissionMode,
+} from "@/types/session";
 import { ModelSelector } from "./ModelSelector";
 import { ModeSelector } from "./ModeSelector";
 import { SlashCommandPopup } from "./SlashCommandPopup";
 
+interface AttachedImage {
+	id: string;
+	attachment: ImageAttachment;
+	previewUrl: string;
+}
+
+export interface MessageInputHandle {
+	addImageAttachments: (attachments: ImageAttachment[]) => void;
+}
+
 interface MessageInputProps {
-	onSend: (content: string) => void;
+	onSend: (content: string, images?: ImageAttachment[]) => void;
 	onInterrupt: () => void;
 	isStreaming: boolean;
 	onCycleMode?: () => void;
@@ -20,190 +42,308 @@ interface MessageInputProps {
 	onModelChange: (modelId: string | null) => void;
 }
 
-export function MessageInput({
-	onSend,
-	onInterrupt,
-	isStreaming,
-	onCycleMode,
-	mode,
-	onModeChange,
-	models,
-	currentModelId,
-	onModelChange,
-}: MessageInputProps) {
-	const [value, setValue] = useState("");
-	const textareaRef = useRef<HTMLTextAreaElement>(null);
-	const [slashPopupDismissed, setSlashPopupDismissed] = useState(false);
-	const [selectedIndex, setSelectedIndex] = useState(0);
-
-	const allCommands = useSlashCommands();
-
-	const showSlashPopup =
-		value.startsWith("/") && !value.includes(" ") && !slashPopupDismissed;
-	const slashQuery = value.slice(1).toLowerCase();
-
-	const filteredCommands = useMemo(() => {
-		if (!showSlashPopup) return [];
-		if (slashQuery === "") return allCommands;
-		return allCommands.filter((cmd) =>
-			cmd.name.toLowerCase().startsWith(slashQuery),
-		);
-	}, [showSlashPopup, slashQuery, allCommands]);
-
-	const popupOpen = showSlashPopup && filteredCommands.length > 0;
-
-	const handleSelectCommand = useCallback((cmd: SlashCommand) => {
-		setValue(`/${cmd.name} `);
-		setSlashPopupDismissed(true);
-		setSelectedIndex(0);
-		if (textareaRef.current) {
-			textareaRef.current.focus();
-		}
-	}, []);
-
-	const handleSubmit = useCallback(() => {
-		const trimmed = value.trim();
-		if (!trimmed) return;
-		onSend(trimmed);
-		setValue("");
-		setSlashPopupDismissed(false);
-		setSelectedIndex(0);
-		if (textareaRef.current) {
-			textareaRef.current.style.height = "auto";
-		}
-	}, [value, onSend]);
-
-	const handleKeyDown = useCallback(
-		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-			if (popupOpen) {
-				if (e.key === "ArrowDown") {
-					e.preventDefault();
-					setSelectedIndex((i) =>
-						i >= filteredCommands.length - 1 ? 0 : i + 1,
-					);
-					return;
-				}
-				if (e.key === "ArrowUp") {
-					e.preventDefault();
-					setSelectedIndex((i) =>
-						i <= 0 ? filteredCommands.length - 1 : i - 1,
-					);
-					return;
-				}
-				if (e.key === "Enter" && !e.metaKey && !e.ctrlKey) {
-					e.preventDefault();
-					if (filteredCommands[selectedIndex]) {
-						handleSelectCommand(filteredCommands[selectedIndex]);
-					}
-					return;
-				}
-				if (e.key === "Tab" && !e.shiftKey) {
-					e.preventDefault();
-					if (filteredCommands[selectedIndex]) {
-						handleSelectCommand(filteredCommands[selectedIndex]);
-					}
-					return;
-				}
-				if (e.key === "Escape") {
-					e.preventDefault();
-					setSlashPopupDismissed(true);
-					return;
-				}
-			}
-
-			if (e.key === "Tab" && e.shiftKey) {
-				e.preventDefault();
-				onCycleMode?.();
-				return;
-			}
-			if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-				e.preventDefault();
-				handleSubmit();
-			}
-		},
-		[
-			handleSubmit,
+export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
+	function MessageInput(
+		{
+			onSend,
+			onInterrupt,
+			isStreaming,
 			onCycleMode,
-			popupOpen,
-			filteredCommands,
-			selectedIndex,
-			handleSelectCommand,
-		],
-	);
+			mode,
+			onModeChange,
+			models,
+			currentModelId,
+			onModelChange,
+		},
+		ref,
+	) {
+		const [value, setValue] = useState("");
+		const textareaRef = useRef<HTMLTextAreaElement>(null);
+		const [slashPopupDismissed, setSlashPopupDismissed] = useState(false);
+		const [selectedIndex, setSelectedIndex] = useState(0);
+		const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
+		const imageIdCounterRef = useRef(0);
 
-	const handleChange = useCallback(
-		(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-			const newValue = e.target.value;
-			setValue(newValue);
+		const allCommands = useSlashCommands();
+
+		const createAttachedImage = useCallback(
+			(attachment: ImageAttachment): AttachedImage => {
+				return {
+					id: `img-${++imageIdCounterRef.current}`,
+					attachment,
+					previewUrl: `data:${attachment.mediaType};base64,${attachment.data}`,
+				};
+			},
+			[],
+		);
+
+		const processImageFile = useCallback(
+			async (file: File): Promise<AttachedImage | null> => {
+				const bytes = new Uint8Array(await file.arrayBuffer());
+				try {
+					const attachment = await invoke<ImageAttachment>(
+						"prepare_image_attachment",
+						{ data: Array.from(bytes) },
+					);
+					return createAttachedImage(attachment);
+				} catch {
+					return null;
+				}
+			},
+			[createAttachedImage],
+		);
+
+		useImperativeHandle(
+			ref,
+			() => ({
+				addImageAttachments: (attachments: ImageAttachment[]) => {
+					const newImages = attachments.map(createAttachedImage);
+					setAttachedImages((prev) => [...prev, ...newImages]);
+				},
+			}),
+			[createAttachedImage],
+		);
+
+		const showSlashPopup =
+			value.startsWith("/") && !value.includes(" ") && !slashPopupDismissed;
+		const slashQuery = value.slice(1).toLowerCase();
+
+		const filteredCommands = useMemo(() => {
+			if (!showSlashPopup) return [];
+			if (slashQuery === "") return allCommands;
+			return allCommands.filter((cmd) =>
+				cmd.name.toLowerCase().startsWith(slashQuery),
+			);
+		}, [showSlashPopup, slashQuery, allCommands]);
+
+		const popupOpen = showSlashPopup && filteredCommands.length > 0;
+
+		const handleSelectCommand = useCallback((cmd: SlashCommand) => {
+			setValue(`/${cmd.name} `);
+			setSlashPopupDismissed(true);
+			setSelectedIndex(0);
+			if (textareaRef.current) {
+				textareaRef.current.focus();
+			}
+		}, []);
+
+		const addImages = useCallback(
+			async (files: File[]) => {
+				const results = await Promise.all(files.map(processImageFile));
+				const valid = results.filter((r): r is AttachedImage => r !== null);
+				if (valid.length > 0) {
+					setAttachedImages((prev) => [...prev, ...valid]);
+				}
+			},
+			[processImageFile],
+		);
+
+		const removeImage = useCallback((id: string) => {
+			setAttachedImages((prev) => prev.filter((img) => img.id !== id));
+		}, []);
+
+		const handleSubmit = useCallback(() => {
+			const trimmed = value.trim();
+			const hasImages = attachedImages.length > 0;
+			if (!trimmed && !hasImages) return;
+			if (hasImages) {
+				onSend(
+					trimmed,
+					attachedImages.map((img) => img.attachment),
+				);
+			} else {
+				onSend(trimmed);
+			}
+			setValue("");
+			setAttachedImages([]);
 			setSlashPopupDismissed(false);
 			setSelectedIndex(0);
-			const el = e.target;
-			el.style.height = "auto";
-			el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
-		},
-		[],
-	);
+			if (textareaRef.current) {
+				textareaRef.current.style.height = "auto";
+			}
+		}, [value, onSend, attachedImages]);
 
-	const canSend = value.trim().length > 0;
+		const handleKeyDown = useCallback(
+			(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+				if (popupOpen) {
+					if (e.key === "ArrowDown") {
+						e.preventDefault();
+						setSelectedIndex((i) =>
+							i >= filteredCommands.length - 1 ? 0 : i + 1,
+						);
+						return;
+					}
+					if (e.key === "ArrowUp") {
+						e.preventDefault();
+						setSelectedIndex((i) =>
+							i <= 0 ? filteredCommands.length - 1 : i - 1,
+						);
+						return;
+					}
+					if (e.key === "Enter" && !e.metaKey && !e.ctrlKey) {
+						e.preventDefault();
+						if (filteredCommands[selectedIndex]) {
+							handleSelectCommand(filteredCommands[selectedIndex]);
+						}
+						return;
+					}
+					if (e.key === "Tab" && !e.shiftKey) {
+						e.preventDefault();
+						if (filteredCommands[selectedIndex]) {
+							handleSelectCommand(filteredCommands[selectedIndex]);
+						}
+						return;
+					}
+					if (e.key === "Escape") {
+						e.preventDefault();
+						setSlashPopupDismissed(true);
+						return;
+					}
+				}
 
-	return (
-		<SlashCommandPopup
-			open={popupOpen}
-			commands={filteredCommands}
-			selectedIndex={selectedIndex}
-			onSelect={handleSelectCommand}
-			onClose={() => setSlashPopupDismissed(true)}
-		>
-			<div
-				data-testid="message-input"
-				className="mx-3 my-2 border rounded-lg focus-within:ring-1 focus-within:ring-ring"
+				if (e.key === "Tab" && e.shiftKey) {
+					e.preventDefault();
+					onCycleMode?.();
+					return;
+				}
+				if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+					e.preventDefault();
+					handleSubmit();
+				}
+			},
+			[
+				handleSubmit,
+				onCycleMode,
+				popupOpen,
+				filteredCommands,
+				selectedIndex,
+				handleSelectCommand,
+			],
+		);
+
+		const handleChange = useCallback(
+			(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+				const newValue = e.target.value;
+				setValue(newValue);
+				setSlashPopupDismissed(false);
+				setSelectedIndex(0);
+				const el = e.target;
+				el.style.height = "auto";
+				el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+			},
+			[],
+		);
+
+		const handlePaste = useCallback(
+			(e: React.ClipboardEvent) => {
+				const items = e.clipboardData?.items;
+				if (!items) return;
+				const imageFiles: File[] = [];
+				for (const item of items) {
+					if (item.type.startsWith("image/")) {
+						const file = item.getAsFile();
+						if (file) imageFiles.push(file);
+					}
+				}
+				if (imageFiles.length > 0) {
+					e.preventDefault();
+					addImages(imageFiles);
+				}
+			},
+			[addImages],
+		);
+
+		const canSend = value.trim().length > 0 || attachedImages.length > 0;
+
+		return (
+			<SlashCommandPopup
+				open={popupOpen}
+				commands={filteredCommands}
+				selectedIndex={selectedIndex}
+				onSelect={handleSelectCommand}
+				onClose={() => setSlashPopupDismissed(true)}
 			>
-				<textarea
-					ref={textareaRef}
-					value={value}
-					onChange={handleChange}
-					onKeyDown={handleKeyDown}
-					placeholder="Send a message..."
-					rows={1}
-					className="w-full resize-none bg-transparent border-none px-3 pt-3 pb-1 text-sm focus:outline-none min-h-[36px] max-h-[200px]"
-				/>
-				<div className="flex items-center justify-between px-2 pb-2">
-					<div className="flex items-center gap-1">
-						<ModeSelector
-							mode={mode}
-							onModeChange={onModeChange}
-							disabled={false}
-						/>
-						<ModelSelector
-							models={models}
-							currentModelId={currentModelId}
-							onModelChange={onModelChange}
-							disabled={false}
-						/>
-					</div>
-					{isStreaming && !canSend ? (
-						<Button
-							size="icon"
-							variant="destructive"
-							className="h-7 w-7 shrink-0"
-							onClick={onInterrupt}
-							aria-label="Interrupt agent"
+				<div
+					data-testid="message-input"
+					className="mx-3 my-2 border rounded-lg focus-within:ring-1 focus-within:ring-ring"
+				>
+					{attachedImages.length > 0 && (
+						<div
+							data-testid="image-preview-list"
+							className="flex flex-wrap gap-2 px-3 pt-2"
 						>
-							<Square className="size-3.5" />
-						</Button>
-					) : (
-						<Button
-							size="icon"
-							className="h-7 w-7 shrink-0"
-							onClick={handleSubmit}
-							disabled={!canSend}
-							aria-label="Send message"
-						>
-							<ArrowUp className="size-3.5" />
-						</Button>
+							{attachedImages.map((img) => (
+								<div
+									key={img.id}
+									className="relative group"
+									data-testid="image-preview-item"
+								>
+									<img
+										src={img.previewUrl}
+										alt="Attached"
+										className="h-16 w-16 object-cover rounded-md border"
+									/>
+									<button
+										type="button"
+										onClick={() => removeImage(img.id)}
+										className="absolute -top-1.5 -right-1.5 bg-destructive text-destructive-foreground rounded-full p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+										aria-label="Remove image"
+										data-testid="remove-image-button"
+									>
+										<X className="size-3" />
+									</button>
+								</div>
+							))}
+						</div>
 					)}
+					<textarea
+						ref={textareaRef}
+						value={value}
+						onChange={handleChange}
+						onKeyDown={handleKeyDown}
+						onPaste={handlePaste}
+						placeholder="Send a message..."
+						rows={1}
+						className="w-full resize-none bg-transparent border-none px-3 pt-3 pb-1 text-sm focus:outline-none min-h-[36px] max-h-[200px]"
+					/>
+					<div className="flex items-center justify-between px-2 pb-2">
+						<div className="flex items-center gap-1">
+							<ModeSelector
+								mode={mode}
+								onModeChange={onModeChange}
+								disabled={false}
+							/>
+							<ModelSelector
+								models={models}
+								currentModelId={currentModelId}
+								onModelChange={onModelChange}
+								disabled={false}
+							/>
+						</div>
+						{isStreaming && !canSend ? (
+							<Button
+								size="icon"
+								variant="destructive"
+								className="h-7 w-7 shrink-0"
+								onClick={onInterrupt}
+								aria-label="Interrupt agent"
+							>
+								<Square className="size-3.5" />
+							</Button>
+						) : (
+							<Button
+								size="icon"
+								className="h-7 w-7 shrink-0"
+								onClick={handleSubmit}
+								disabled={!canSend}
+								aria-label="Send message"
+							>
+								<ArrowUp className="size-3.5" />
+							</Button>
+						)}
+					</div>
 				</div>
-			</div>
-		</SlashCommandPopup>
-	);
-}
+			</SlashCommandPopup>
+		);
+	},
+);

--- a/src/components/panels/AgentChatPanel/StreamMessage.test.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.test.tsx
@@ -112,4 +112,51 @@ describe("StreamMessage", () => {
 		expect(notPrevented).toBe(false);
 		expect(mockOpenUrl).toHaveBeenCalledWith("https://docs.example.com");
 	});
+
+	it("renders images in human message when image parts provided", () => {
+		const images = [
+			{ type: "image" as const, data: "aGVsbG8=", mediaType: "image/png" },
+		];
+		render(<StreamMessage content="Check this" role={human} images={images} />);
+		const el = screen.getByTestId("stream-message-human");
+		const imgs = el.querySelectorAll("img");
+		expect(imgs.length).toBe(1);
+		expect(imgs[0].getAttribute("src")).toBe("data:image/png;base64,aGVsbG8=");
+		expect(el.textContent).toContain("Check this");
+	});
+
+	it("renders human message without images when no image parts", () => {
+		render(<StreamMessage content="Hello" role={human} />);
+		const el = screen.getByTestId("stream-message-human");
+		const imgs = el.querySelectorAll("img");
+		expect(imgs.length).toBe(0);
+		expect(el.textContent).toContain("Hello");
+	});
+
+	it("renders multiple images in human message", () => {
+		const images = [
+			{ type: "image" as const, data: "aW1nMQ==", mediaType: "image/png" },
+			{
+				type: "image" as const,
+				data: "aW1nMg==",
+				mediaType: "image/jpeg",
+			},
+		];
+		render(<StreamMessage content="Two images" role={human} images={images} />);
+		const el = screen.getByTestId("stream-message-human");
+		const imgs = el.querySelectorAll("img");
+		expect(imgs.length).toBe(2);
+	});
+
+	it("renders image-only human message (no text)", () => {
+		const images = [
+			{ type: "image" as const, data: "aGVsbG8=", mediaType: "image/png" },
+		];
+		render(<StreamMessage content="" role={human} images={images} />);
+		const el = screen.getByTestId("stream-message-human");
+		const imgs = el.querySelectorAll("img");
+		expect(imgs.length).toBe(1);
+		const p = el.querySelector("p");
+		expect(p).toBeNull();
+	});
 });

--- a/src/components/panels/AgentChatPanel/StreamMessage.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.tsx
@@ -3,11 +3,12 @@ import type { AnchorHTMLAttributes } from "react";
 import { useDeferredValue } from "react";
 import Markdown from "react-markdown";
 import { rehypePluginList, remarkPluginList } from "@/lib/markdownConfig";
-import type { MessageRole } from "@/types/session";
+import type { ImagePart, MessageRole } from "@/types/session";
 
 interface StreamMessageProps {
 	content: string;
 	role: MessageRole;
+	images?: ImagePart[];
 }
 
 function ExternalLink(props: AnchorHTMLAttributes<HTMLAnchorElement>) {
@@ -25,7 +26,7 @@ function ExternalLink(props: AnchorHTMLAttributes<HTMLAnchorElement>) {
 	);
 }
 
-export function StreamMessage({ content, role }: StreamMessageProps) {
+export function StreamMessage({ content, role, images }: StreamMessageProps) {
 	const isHuman = role === "human";
 	const deferredContent = useDeferredValue(content);
 
@@ -39,6 +40,18 @@ export function StreamMessage({ content, role }: StreamMessageProps) {
 		);
 	}
 
+	const imageElements =
+		isHuman && images && images.length > 0
+			? images.map((img) => (
+					<img
+						key={`${img.mediaType}-${img.data.slice(0, 20)}`}
+						src={`data:${img.mediaType};base64,${img.data}`}
+						alt="Attached"
+						className="max-h-48 max-w-full rounded-md"
+					/>
+				))
+			: null;
+
 	return (
 		<div
 			data-testid={`stream-message-${role}`}
@@ -46,7 +59,12 @@ export function StreamMessage({ content, role }: StreamMessageProps) {
 		>
 			{isHuman ? (
 				<div className="bg-muted rounded-lg px-3 py-2">
-					<p className="text-sm whitespace-pre-wrap break-words">{content}</p>
+					{imageElements && imageElements.length > 0 && (
+						<div className="flex flex-wrap gap-2 mb-2">{imageElements}</div>
+					)}
+					{content && (
+						<p className="text-sm whitespace-pre-wrap break-words">{content}</p>
+					)}
 				</div>
 			) : (
 				<div className="markdown-preview prose prose-sm dark:prose-invert max-w-none break-words">

--- a/src/components/panels/AgentChatPanel/StreamMessage.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.tsx
@@ -42,9 +42,10 @@ export function StreamMessage({ content, role, images }: StreamMessageProps) {
 
 	const imageElements =
 		isHuman && images && images.length > 0
-			? images.map((img) => (
+			? images.map((img, index) => (
 					<img
-						key={`${img.mediaType}-${img.data.slice(0, 20)}`}
+						// biome-ignore lint/suspicious/noArrayIndexKey: images are positional data, order is fixed
+						key={`${index}-${img.mediaType}-${img.data.slice(0, 20)}`}
 						src={`data:${img.mediaType};base64,${img.data}`}
 						alt="Attached"
 						className="max-h-48 max-w-full rounded-md"

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -117,6 +117,67 @@ describe("useAgentChat", () => {
 		);
 	});
 
+	it("sendMessage passes images to sendAgentMessage", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		const images = [{ data: "aGVsbG8=", mediaType: "image/png" }];
+		await act(async () => {
+			await result.current.sendMessage("check this", images);
+		});
+
+		expect(sessionStore.sendAgentMessage).toHaveBeenCalledWith(
+			null,
+			"/repo",
+			"check this",
+			"acceptEdits",
+			images,
+		);
+	});
+
+	it("sendMessage with images only (empty text) calls sendAgentMessage", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		const images = [{ data: "aGVsbG8=", mediaType: "image/png" }];
+		await act(async () => {
+			await result.current.sendMessage("", images);
+		});
+
+		expect(sessionStore.sendAgentMessage).toHaveBeenCalledWith(
+			null,
+			"/repo",
+			"",
+			"acceptEdits",
+			images,
+		);
+	});
+
+	it("sendMessage without images does not pass images arg", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		await act(async () => {
+			await result.current.sendMessage("hello");
+		});
+
+		expect(sessionStore.sendAgentMessage).toHaveBeenCalledWith(
+			null,
+			"/repo",
+			"hello",
+			"acceptEdits",
+		);
+	});
+
 	it("respondPermission invokes respond_agent_permission with chatSessionId", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -4,6 +4,7 @@ import type { AgentState } from "@/types/protocol";
 import type {
 	ChatMessage,
 	ChatSession,
+	ImageAttachment,
 	ModelInfo,
 	PermissionMode,
 	SessionSummary,
@@ -39,7 +40,7 @@ export interface UseAgentChatResult {
 	error: string | null;
 	permissionMode: PermissionMode;
 	sessionAgentStates: Map<string, AgentState>;
-	sendMessage: (content: string) => Promise<void>;
+	sendMessage: (content: string, images?: ImageAttachment[]) => Promise<void>;
 	interrupt: () => void;
 	selectSession: (sessionId: string) => Promise<void>;
 	refreshSessions: () => Promise<SessionSummary[] | undefined>;
@@ -222,34 +223,44 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 		});
 	}, []);
 
-	const sendMessage = useCallback(async (content: string) => {
-		const trimmed = content.trim();
-		if (!trimmed) return;
+	const sendMessage = useCallback(
+		async (content: string, images?: ImageAttachment[]) => {
+			const trimmed = content.trim();
+			if (!trimmed && (!images || images.length === 0)) return;
 
-		try {
-			const isNewSession = !activeSessionRef.current;
-			const response = await sendAgentMessage(
-				activeSessionRef.current?.id ?? null,
-				worktreePathRef.current,
-				trimmed,
-				permissionModeRef.current,
-			);
-			if (isNewSession) {
-				dispatch({ type: "SET_ACTIVE_SESSION", session: response.session });
-			} else {
-				dispatch({ type: "ADD_MESSAGE", message: response.humanMessage });
-				if (response.agentMessage) {
-					dispatch({ type: "ADD_MESSAGE", message: response.agentMessage });
+			try {
+				const isNewSession = !activeSessionRef.current;
+				const hasImages = images && images.length > 0;
+				const sessionId = activeSessionRef.current?.id ?? null;
+				const wPath = worktreePathRef.current;
+				const pm = permissionModeRef.current;
+				const response = hasImages
+					? await sendAgentMessage(sessionId, wPath, trimmed, pm, images)
+					: await sendAgentMessage(sessionId, wPath, trimmed, pm);
+				if (isNewSession) {
+					dispatch({
+						type: "SET_ACTIVE_SESSION",
+						session: response.session,
+					});
+				} else {
+					dispatch({ type: "ADD_MESSAGE", message: response.humanMessage });
+					if (response.agentMessage) {
+						dispatch({
+							type: "ADD_MESSAGE",
+							message: response.agentMessage,
+						});
+					}
 				}
+				dispatch({ type: "SET_SESSIONS", sessions: response.sessions });
+			} catch (e) {
+				dispatch({
+					type: "SET_ERROR",
+					error: `メッセージ送信に失敗: ${e}`,
+				});
 			}
-			dispatch({ type: "SET_SESSIONS", sessions: response.sessions });
-		} catch (e) {
-			dispatch({
-				type: "SET_ERROR",
-				error: `メッセージ送信に失敗: ${e}`,
-			});
-		}
-	}, []);
+		},
+		[],
+	);
 
 	const refreshClosedSessions = useCallback(async () => {
 		try {

--- a/src/hooks/useNativeFileDrop.ts
+++ b/src/hooks/useNativeFileDrop.ts
@@ -10,7 +10,7 @@ interface UseNativeFileDropOptions {
 	onDropToEditor: (paths: string[]) => void;
 }
 
-type DropZoneType = "editor";
+export type DropZoneType = "editor" | "agent";
 
 export function resolveZone(
 	zones: Map<DropZoneType, HTMLElement>,
@@ -37,6 +37,9 @@ export function hasVisibleZones(
 
 export function useNativeFileDrop(options: UseNativeFileDropOptions) {
 	const zonesRef = useRef<Map<DropZoneType, HTMLElement>>(new Map());
+	const callbacksRef = useRef<Map<DropZoneType, (paths: string[]) => void>>(
+		new Map(),
+	);
 	const optionsRef = useRef(options);
 	optionsRef.current = options;
 
@@ -62,8 +65,11 @@ export function useNativeFileDrop(options: UseNativeFileDropOptions) {
 				if (!hasVisibleZones(zonesRef.current)) return;
 
 				const zone = lastZoneRef.current;
+				const callback = zone ? callbacksRef.current.get(zone) : undefined;
 
-				if (zone === "editor") {
+				if (callback) {
+					callback(paths);
+				} else if (zone === "editor") {
 					optionsRef.current.onDropToEditor(paths);
 				}
 				// zone === null の場合は何もしない（TerminalPanelが自己処理する）
@@ -78,11 +84,19 @@ export function useNativeFileDrop(options: UseNativeFileDropOptions) {
 	}, []);
 
 	const registerDropZone = useCallback(
-		(zone: DropZoneType, element: HTMLElement | null) => {
+		(
+			zone: DropZoneType,
+			element: HTMLElement | null,
+			onDrop?: (paths: string[]) => void,
+		) => {
 			if (element) {
 				zonesRef.current.set(zone, element);
+				if (onDrop) {
+					callbacksRef.current.set(zone, onDrop);
+				}
 			} else {
 				zonesRef.current.delete(zone);
+				callbacksRef.current.delete(zone);
 			}
 		},
 		[],

--- a/src/hooks/useNativeFileDrop.ts
+++ b/src/hooks/useNativeFileDrop.ts
@@ -93,6 +93,8 @@ export function useNativeFileDrop(options: UseNativeFileDropOptions) {
 				zonesRef.current.set(zone, element);
 				if (onDrop) {
 					callbacksRef.current.set(zone, onDrop);
+				} else {
+					callbacksRef.current.delete(zone);
 				}
 			} else {
 				zonesRef.current.delete(zone);

--- a/src/hooks/useSessionStore.ts
+++ b/src/hooks/useSessionStore.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type {
 	ChatMessage,
 	ChatSession,
+	ImageAttachment,
 	LegacyChatMessage,
 	MessagePart,
 	MessageRole,
@@ -191,12 +192,14 @@ export async function sendAgentMessage(
 	worktreePath: string,
 	content: string,
 	permissionMode: string,
+	images?: ImageAttachment[],
 ): Promise<SendMessageResponse> {
 	const raw = await invoke<RawSendMessageResponse>("send_agent_message", {
 		chatSessionId,
 		worktreePath,
 		content,
 		permissionMode,
+		images: images && images.length > 0 ? images : undefined,
 	});
 	return {
 		session: convertLegacySession(raw.session),

--- a/src/screens/MainLayout.tsx
+++ b/src/screens/MainLayout.tsx
@@ -108,7 +108,10 @@ function WorktreeContent({
 				<div className="h-full relative overflow-hidden flex flex-col">
 					<ViewToolbar leftPanels={leftPanels} rightSlot={branchSelector} />
 					<div className="flex-1 overflow-hidden">
-						<AgentChatPanel worktreePath={rootPath} />
+						<AgentChatPanel
+							worktreePath={rootPath}
+							registerDropZone={s.registerDropZone}
+						/>
 					</div>
 				</div>
 			</Panel>

--- a/src/screens/useWorktreeState.tsx
+++ b/src/screens/useWorktreeState.tsx
@@ -4,6 +4,7 @@ import { useCurrentBranch } from "@/hooks/useCurrentBranch";
 import { useGitActions } from "@/hooks/useGitActions";
 import { useGitDirWatcher } from "@/hooks/useGitDirWatcher";
 import { useThreads } from "@/hooks/useThreads";
+import { useNativeFileDrop } from "@/hooks/useNativeFileDrop";
 import { useWorkspaceStatus } from "@/hooks/useWorkspaceStatus";
 import { useWorktreeThreads } from "@/screens/useWorktreeComments";
 import {
@@ -119,6 +120,11 @@ export function useWorktreeState({
 		rootPath,
 	});
 
+	// --- Native file drop (image D&D to AgentChat) ---
+	const { registerDropZone } = useNativeFileDrop({
+		onDropToEditor: useCallback((_paths: string[]) => {}, []),
+	});
+
 	// --- Sync internal state for workspace state persistence ---
 	useEffect(() => {
 		if (!internalStateMapRef) return;
@@ -153,6 +159,7 @@ export function useWorktreeState({
 		dispatchUI,
 		dispatchGit,
 		gitActions,
+		registerDropZone,
 		handleSendToTerminal,
 		handleThreadClick,
 		refreshGit,

--- a/src/screens/useWorktreeState.tsx
+++ b/src/screens/useWorktreeState.tsx
@@ -3,8 +3,8 @@ import type { TerminalTabPanelHandle } from "@/components/panels/TerminalTabPane
 import { useCurrentBranch } from "@/hooks/useCurrentBranch";
 import { useGitActions } from "@/hooks/useGitActions";
 import { useGitDirWatcher } from "@/hooks/useGitDirWatcher";
-import { useThreads } from "@/hooks/useThreads";
 import { useNativeFileDrop } from "@/hooks/useNativeFileDrop";
+import { useThreads } from "@/hooks/useThreads";
 import { useWorkspaceStatus } from "@/hooks/useWorkspaceStatus";
 import { useWorktreeThreads } from "@/screens/useWorktreeComments";
 import {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -71,6 +71,11 @@ export type MessagePart =
 			label: string;
 			detail?: string;
 			hookId?: string;
+	  }
+	| {
+			type: "image";
+			data: string;
+			mediaType: string;
 	  };
 
 export type ActivityEntry =
@@ -169,4 +174,11 @@ export interface WorkspaceStatus {
 	error_count: number;
 	session_count: number;
 	last_activity_at: number;
+}
+
+export type ImagePart = Extract<MessagePart, { type: "image" }>;
+
+export interface ImageAttachment {
+	data: string;
+	mediaType: string;
 }


### PR DESCRIPTION
## Summary
- AgentChatのメッセージ入力エリアで画像をドラッグ&ドロップまたはクリップボードからペーストして、コンテキストとしてAIに送信できるようにする
- Rust側で画像バリデーション（マジックバイトによるMIME判定）・Base64エンコードを行い、フロントエンドはUI表示とinvoke呼び出しに徹する
- `useNativeFileDrop`のゾーンシステムを拡張し、agentゾーンのドロップ処理を統合

## Test plan
- [ ] 画像ファイル（PNG/JPEG/GIF/WebP）をAgentChatエリアにドラッグ&ドロップしてプレビュー表示されることを確認
- [ ] クリップボードの画像をCmd+Vでペーストしてプレビュー表示されることを確認
- [ ] 添付画像の×ボタンで削除できることを確認
- [ ] テキスト+画像、画像のみの送信が正常に動作することを確認
- [ ] 非画像ファイル（.txt等）をドロップしても添付されないことを確認
- [ ] 送信済みメッセージのチャット履歴に画像が表示されることを確認
- [ ] `pnpm test` (1435テスト全PASS)
- [ ] `pnpm lint` (エラーなし)
- [ ] `pnpm build` (成功)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AgentChat のメッセージ入力でドラッグ＆ドロップおよびペースト（Ctrl/Cmd+V）で画像を添付可能に
  * 添付画像はサムネイルでプレビュー表示、個別削除ができ、テキスト付き送信／画像のみ送信に対応
  * 送信した画像は該当の発言に表示され、複数添付にも対応
  * 画像の種類・容量には利用側で定められた制限があります
* **ドキュメント**
  * 仕様書を追加して挙動を明確化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->