### PR TITLE
fix: AgentChatヘッダーのウィンドウ操作を修正

### DIFF
--- a/docs/spec/issues-793.md
+++ b/docs/spec/issues-793.md
@@ -1,0 +1,55 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: AgentChatパネルのヘッダー領域でドラッグ・ダブルクリックしても反応がなく、ウィンドウの移動・最大化/復元ができない
+**期待する挙動**: AgentChatパネルのヘッダー領域でドラッグするとウィンドウが移動し、ダブルクリックするとウィンドウが最大化/復元される（他の画面と同じ挙動）
+**再現手順**:
+1. AgentChatパネルを開く
+2. ヘッダー領域をドラッグする → ウィンドウが移動しない
+3. ヘッダー領域をダブルクリックする → ウィンドウが最大化/復元されない
+**背景**: Tauriのウィンドウ操作（ドラッグ移動・ダブルクリック最大化）はヘッダー領域に `data-tauri-drag-region` 属性を付与することで実現されるが、AgentChatのヘッダーにこの属性が欠落しているか、イベントが阻害されている可能性がある
+
+## 振る舞い定義
+
+```gherkin
+Feature: AgentChatパネルのウィンドウ操作
+  AgentChatパネルのヘッダー領域からウィンドウの移動・最大化/復元ができる
+
+  Rule: ヘッダー領域のドラッグでウィンドウが移動する
+    Scenario: ヘッダーの空き領域をドラッグするとウィンドウが移動する
+      Given AgentChatパネルが表示されている
+      When ヘッダーの空き領域をドラッグする
+      Then ウィンドウが移動する
+
+    Scenario: セッションタブをドラッグしてもウィンドウは移動しない
+      Given AgentChatパネルに複数のセッションタブがある
+      When セッションタブをドラッグする
+      Then タブの並べ替えが行われる
+      And ウィンドウは移動しない
+
+  Rule: ヘッダー領域のダブルクリックでウィンドウが最大化/復元される
+    Scenario: ヘッダーの空き領域をダブルクリックするとウィンドウが最大化される
+      Given AgentChatパネルが表示されている
+      And ウィンドウが通常サイズである
+      When ヘッダーの空き領域をダブルクリックする
+      Then ウィンドウが最大化される
+
+    Scenario: 最大化状態でヘッダーの空き領域をダブルクリックするとウィンドウが復元される
+      Given AgentChatパネルが表示されている
+      And ウィンドウが最大化されている
+      When ヘッダーの空き領域をダブルクリックする
+      Then ウィンドウが通常サイズに復元される
+```
+
+## 実装仕様
+
+**対応方針**: 振る舞い定義を実現するために、AgentChatPanel のヘッダーコンテナに対して `data-tauri-drag-region` 属性の付与で対応する。ViewToolbar・RightPanelHeader の既存パターンを踏襲する。
+
+**対象コンポーネント**:
+- `src/components/panels/AgentChatPanel/AgentChatPanel.tsx`: ヘッダーのコンテナ div に `data-tauri-drag-region` 属性を追加。TabsList とボタン群の間に `data-tauri-drag-region` 付きのフレックス空き領域（`<div data-tauri-drag-region className="flex-1" />`）を挿入し、ドラッグ可能な空き領域を確保する。
+
+**検討した代替案**:
+- ヘッダーコンテナのみに属性付与（空き領域 div なし）: TabsList・ボタンがヘッダー全幅を占有するため、ドラッグ可能な空き領域が確保できない可能性があるため却下
+
+**影響するテスト**:
+- `AgentChatPanel.test.tsx`: `data-tauri-drag-region` 属性の存在を確認するテストを追加（ViewToolbar.test.tsx・RightPanelHeader.test.tsx の既存パターンに準拠）

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
@@ -97,6 +97,19 @@ describe("AgentChatPanel", () => {
 		expect(screen.getByTestId("agent-chat-panel")).toBeDefined();
 	});
 
+	it("has data-tauri-drag-region attribute for window dragging", () => {
+		mockUseAgentChat();
+		const { container } = render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
+
+		const dragRegion = container.querySelector("[data-tauri-drag-region]");
+		expect(dragRegion).toBeInTheDocument();
+	});
+
 	it("renders message input", () => {
 		mockUseAgentChat();
 		render(

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
@@ -463,7 +463,10 @@ export function AgentChatPanel({
 				onValueChange={selectSession}
 				className="flex flex-col h-full gap-0"
 			>
-				<div className="flex items-center gap-2 shrink-0 px-2 pt-2 bg-background border-b">
+				<div
+					data-tauri-drag-region
+					className="flex items-center gap-2 shrink-0 px-2 pt-2 bg-background border-b"
+				>
 					<TabsList
 						data-testid="session-tab-list"
 						className="w-auto max-w-full overflow-x-auto overflow-y-hidden justify-start [&::-webkit-scrollbar]:hidden [scrollbar-width:none]"
@@ -504,6 +507,7 @@ export function AgentChatPanel({
 							</TabsTrigger>
 						))}
 					</TabsList>
+					<div data-tauri-drag-region className="flex-1" />
 					<button
 						type="button"
 						onClick={() => createNewSession()}


### PR DESCRIPTION
## Summary
- AgentChatパネルのヘッダーに `data-tauri-drag-region` 属性を追加し、ドラッグによるウィンドウ移動・ダブルクリックによる最大化/復元を有効化

## Related Issues
- Closes #793
- Closes #792

## Test plan
- [ ] AgentChatヘッダーの空き領域をドラッグしてウィンドウが移動することを確認
- [ ] AgentChatヘッダーの空き領域をダブルクリックしてウィンドウが最大化/復元されることを確認
- [ ] セッションタブのドラッグは従来通りタブ並べ替えとして動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)