### PR TITLE
fix: Reviewパネルのスクロールバーをカスタムスクロールバーに統一

### DIFF
--- a/docs/spec/issues-800.md
+++ b/docs/spec/issues-800.md
@@ -1,0 +1,51 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: Reviewパネルでブラウザデフォルトのスクロールバーが表示される
+**期待する挙動**: デフォルトではなくアプリのデザインに合ったカスタムスクロールバーが表示される
+**背景**: デフォルトのスクロールバーがアプリのUIデザインと統一されておらず、見た目を損なっている
+
+## 振る舞い定義
+
+```gherkin
+Feature: Reviewパネルのスクロールバー表示
+  Reviewパネル内のスクロール可能な領域で、アプリのデザインに統一されたカスタムスクロールバーが表示される
+
+  Rule: Reviewパネルのスクロールバーはアプリ内の他パネルと統一されたデザインで表示される
+    Scenario: Reviewパネルのファイルツリー領域にカスタムスクロールバーが表示される
+      Given Reviewパネルが表示されている
+      When ファイルツリー領域の内容がスクロール可能な量である
+      Then アプリのデザインに統一された細いスクロールバーが表示される
+
+    Scenario: Reviewパネルのdiff表示領域にカスタムスクロールバーが表示される
+      Given Reviewパネルが表示されている
+      When diff表示領域の内容がスクロール可能な量である
+      Then アプリのデザインに統一された細いスクロールバーが表示される
+```
+
+## 実装仕様
+
+**対応方針**: Reviewパネル内のすべてのスクロール可能領域を、`overflow-auto` / `overflow-y-auto` のdivから shadcn/ui の `ScrollArea` コンポーネントに置き換えることで、アプリ全体で統一されたカスタムスクロールバーを実現する。
+
+**対象コンポーネント**:
+- **DiffFileTree.tsx**: 3箇所
+  - Unstagedセクションのツリー領域（`overflow-y-auto` → `ScrollArea`）
+  - Stagedセクションのツリー領域（`overflow-y-auto` → `ScrollArea`）
+  - BranchBaseTreeの全体（`overflow-y-auto` → `ScrollArea`）
+- **ReviewPanel.tsx**: 1箇所
+  - diff表示領域（`overflow-auto` → `ScrollArea`）
+- **MarkdownDiffViewer.tsx**: 2箇所
+  - GutterView（`overflow-auto scrollbar-thin` → `ScrollArea`、`scrollbar-thin`クラス除去）
+  - InlineView（`overflow-auto scrollbar-thin` → `ScrollArea`、`scrollbar-thin`クラス除去）
+- **ImageDiffViewer.tsx**: 1箇所
+  - 各ImagePaneの画像コンテナ（`overflow-auto` → `ScrollArea`）
+
+**技術選定**:
+- `ScrollArea`（shadcn/ui / Radix UI）: 既にプロジェクト内に `src/components/ui/scroll-area.tsx` として存在。追加インストール不要
+
+**リスク**:
+- ScrollAreaのViewportが `size-full` のため、親要素に明示的な高さ制約が必要。現在の `flex-1 min-h-0` 構造で各箇所確認が必要
+- MarkdownDiffViewerのSplitView（`md-split-container scrollbar-thin`）はCSS Grid/Flexレイアウト上の `scrollbar-thin` であり、ScrollArea置き換え時にレイアウトとの相互作用を検証する必要がある
+
+**影響するテスト**:
+- 既存テストでScrollAreaのモックが必要になる可能性あり（Radix UIのResizeObserver等がjsdomで動作しない場合）

--- a/src/components/panels/DiffFileTree.tsx
+++ b/src/components/panels/DiffFileTree.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
 	Tooltip,
 	TooltipContent,
@@ -413,17 +414,19 @@ export function DiffFileTree({
 					onCollapseAll={changesExpand.collapseAll}
 				/>
 				{changesSectionOpen && changesFileCount > 0 && (
-					<div className="flex-1 overflow-y-auto">
-						<TreeSection
-							tree={changesTree}
-							section="changes"
-							selectedFile={selectedFile}
-							selectedSection={selectedSection}
-							onSelectFile={onSelectFile}
-							onFileAction={onStageFile}
-							fileActionIcon="plus"
-							expandState={changesExpand}
-						/>
+					<div className="flex-1 min-h-0 overflow-hidden">
+						<ScrollArea className="h-full">
+							<TreeSection
+								tree={changesTree}
+								section="changes"
+								selectedFile={selectedFile}
+								selectedSection={selectedSection}
+								onSelectFile={onSelectFile}
+								onFileAction={onStageFile}
+								fileActionIcon="plus"
+								expandState={changesExpand}
+							/>
+						</ScrollArea>
 					</div>
 				)}
 			</div>
@@ -448,17 +451,19 @@ export function DiffFileTree({
 					onCollapseAll={stagedExpand.collapseAll}
 				/>
 				{stagedSectionOpen && stagedFileCount > 0 && (
-					<div className="flex-1 overflow-y-auto">
-						<TreeSection
-							tree={stagedTree}
-							section="staged"
-							selectedFile={selectedFile}
-							selectedSection={selectedSection}
-							onSelectFile={onSelectFile}
-							onFileAction={onUnstageFile}
-							fileActionIcon="minus"
-							expandState={stagedExpand}
-						/>
+					<div className="flex-1 min-h-0 overflow-hidden">
+						<ScrollArea className="h-full">
+							<TreeSection
+								tree={stagedTree}
+								section="staged"
+								selectedFile={selectedFile}
+								selectedSection={selectedSection}
+								onSelectFile={onSelectFile}
+								onFileAction={onUnstageFile}
+								fileActionIcon="minus"
+								expandState={stagedExpand}
+							/>
+						</ScrollArea>
 					</div>
 				)}
 			</div>
@@ -480,10 +485,7 @@ function BranchBaseTree({
 		useTreeExpand(tree);
 
 	return (
-		<div
-			className="flex flex-col overflow-y-auto select-none"
-			data-testid="diff-file-tree"
-		>
+		<ScrollArea className="select-none h-full" data-testid="diff-file-tree">
 			{hasFolders && (
 				<div className="flex items-center justify-end gap-0.5 px-1 py-0.5 border-b border-border">
 					<ExpandCollapseButtons
@@ -506,6 +508,6 @@ function BranchBaseTree({
 					onToggle={handleToggle}
 				/>
 			))}
-		</div>
+		</ScrollArea>
 	);
 }

--- a/src/components/panels/ImageDiffViewer.tsx
+++ b/src/components/panels/ImageDiffViewer.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 
 interface ImageDiffViewerProps {
 	originalUrl: string | null;
@@ -12,7 +12,7 @@ function ImagePane({ url, label }: { url: string | null; label: string }) {
 			<span className="text-xs font-medium text-muted-foreground">{label}</span>
 			{url ? (
 				<ScrollArea
-					className="relative max-h-full w-full rounded border border-border"
+					className="relative flex-1 min-h-0 w-full rounded border border-border"
 					style={{
 						backgroundImage:
 							"repeating-conic-gradient(#80808020 0% 25%, transparent 0% 50%)",
@@ -26,6 +26,7 @@ function ImagePane({ url, label }: { url: string | null; label: string }) {
 							className="max-w-full max-h-[60vh] object-contain"
 						/>
 					</div>
+					<ScrollBar orientation="horizontal" />
 				</ScrollArea>
 			) : (
 				<div className="flex items-center justify-center flex-1 w-full rounded border border-dashed border-border text-muted-foreground text-sm">

--- a/src/components/panels/ImageDiffViewer.tsx
+++ b/src/components/panels/ImageDiffViewer.tsx
@@ -1,3 +1,5 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+
 interface ImageDiffViewerProps {
 	originalUrl: string | null;
 	modifiedUrl: string | null;
@@ -9,20 +11,22 @@ function ImagePane({ url, label }: { url: string | null; label: string }) {
 		<div className="flex-1 flex flex-col items-center gap-2 min-w-0 p-4">
 			<span className="text-xs font-medium text-muted-foreground">{label}</span>
 			{url ? (
-				<div
-					className="relative flex items-center justify-center overflow-auto max-h-full w-full rounded border border-border"
+				<ScrollArea
+					className="relative max-h-full w-full rounded border border-border"
 					style={{
 						backgroundImage:
 							"repeating-conic-gradient(#80808020 0% 25%, transparent 0% 50%)",
 						backgroundSize: "16px 16px",
 					}}
 				>
-					<img
-						src={url}
-						alt={label}
-						className="max-w-full max-h-[60vh] object-contain"
-					/>
-				</div>
+					<div className="flex items-center justify-center">
+						<img
+							src={url}
+							alt={label}
+							className="max-w-full max-h-[60vh] object-contain"
+						/>
+					</div>
+				</ScrollArea>
 			) : (
 				<div className="flex items-center justify-center flex-1 w-full rounded border border-dashed border-border text-muted-foreground text-sm">
 					No file

--- a/src/components/panels/MarkdownDiffViewer.tsx
+++ b/src/components/panels/MarkdownDiffViewer.tsx
@@ -2,6 +2,7 @@ import { useDeferredValue, useMemo } from "react";
 import Markdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
 	computeInlineChunks,
 	computeModifiedDiffRanges,
@@ -35,11 +36,13 @@ function GutterView({
 		[diffRanges],
 	);
 	return (
-		<div className="markdown-preview h-full overflow-auto p-6 scrollbar-thin">
-			<Markdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
-				{modifiedContent}
-			</Markdown>
-		</div>
+		<ScrollArea className="h-full">
+			<div className="markdown-preview p-6">
+				<Markdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+					{modifiedContent}
+				</Markdown>
+			</div>
+		</ScrollArea>
 	);
 }
 
@@ -131,27 +134,29 @@ function InlineView({
 	);
 	const rehypePlugins = useMemo(() => [rehypeHighlight], []);
 	return (
-		<div className="markdown-preview h-full overflow-auto p-6 scrollbar-thin">
-			{chunks.map((chunk, chunkIndex) => {
-				const className =
-					chunk.type === "added"
-						? "md-diff-inline-added"
-						: chunk.type === "removed"
-							? "md-diff-inline-removed"
-							: undefined;
-				return (
-					// biome-ignore lint/suspicious/noArrayIndexKey: chunks are positional diff output, order is fixed
-					<div key={chunkIndex} className={className}>
-						<Markdown
-							remarkPlugins={remarkPlugins}
-							rehypePlugins={rehypePlugins}
-						>
-							{chunk.content}
-						</Markdown>
-					</div>
-				);
-			})}
-		</div>
+		<ScrollArea className="h-full">
+			<div className="markdown-preview p-6">
+				{chunks.map((chunk, chunkIndex) => {
+					const className =
+						chunk.type === "added"
+							? "md-diff-inline-added"
+							: chunk.type === "removed"
+								? "md-diff-inline-removed"
+								: undefined;
+					return (
+						// biome-ignore lint/suspicious/noArrayIndexKey: chunks are positional diff output, order is fixed
+						<div key={chunkIndex} className={className}>
+							<Markdown
+								remarkPlugins={remarkPlugins}
+								rehypePlugins={rehypePlugins}
+							>
+								{chunk.content}
+							</Markdown>
+						</div>
+					);
+				})}
+			</div>
+		</ScrollArea>
 	);
 }
 

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -444,7 +444,7 @@ export function ReviewPanel({
 											</div>
 										</div>
 									)}
-									<div className="flex-1 overflow-auto">
+									<div className="flex-1 min-h-0 overflow-hidden">
 										<DiffViewerSection
 											isImage={isImage}
 											isMarkdown={isMarkdown}


### PR DESCRIPTION
## Summary
- Reviewパネル内のスクロール可能領域（DiffFileTree、ReviewPanel、MarkdownDiffViewer、ImageDiffViewer）で、ブラウザデフォルトのスクロールバーをshadcn/uiの`ScrollArea`コンポーネントに置き換え
- アプリ全体で統一されたカスタムスクロールバーデザインを実現

## Test plan
- [ ] Reviewパネルのファイルツリー（Unstaged/Staged/BranchBase）でカスタムスクロールバーが表示されること
- [ ] diff表示領域（Markdown/Image）でカスタムスクロールバーが表示されること
- [ ] CodeDiffViewer（Monaco Editor）のスクロールが正常に動作すること
- [ ] 既存テストがすべてパスすること

closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * レビューパネル内のすべてのスクロール領域で、カスタムデザインされた細いスクロールバーを使用するように改善しました。

* **ドキュメント**
  * レビューパネルのスクロールバー修正に関する実装仕様を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->