### PR TITLE
feat: 右パネル下部のタブUIを左右分割レイアウトに変更

### DIFF
--- a/docs/spec/issues-786.md
+++ b/docs/spec/issues-786.md
@@ -1,0 +1,93 @@
+## 要求
+
+**種別**: 改善
+**ゴール**: 右パネル下部にコメント一覧とターミナルを並列配置し、レビュー画面からコメント・ターミナル機能にアクセスできるようにする
+**背景**: #784（旧UI廃止）でコメントとターミナルの既存配置先が廃止されるため、新しいUI配置先として右パネル下部に統合する
+**影響範囲**:
+- 既存の `CommentThread.tsx`, `CommentList.tsx` を流用
+- 既存の `TerminalPanel.tsx`, `RightSidebarBottom.tsx` を流用
+- Rust側コマンド（Thread/Comment系、PTY系）は変更なし
+
+## 振る舞い定義
+
+```gherkin
+Feature: 右パネル下部のコメント・ターミナル分割配置
+  レビュー画面の右パネル下部にコメント一覧とターミナルを左右に並列配置して同時表示し、
+  レビュー中にコメント確認とターミナル操作を切り替えなしで行えるようにする
+
+  Rule: コメント一覧とターミナルは左右に並列配置で同時表示される
+    Scenario: 右パネル下部を表示する
+      Given レビュー画面が表示されている
+      When 右パネル下部が展開される
+      Then コメント一覧とターミナルが左右に並列配置で表示される
+
+  Rule: 分割サイズはドラッグで調整可能である
+    Scenario: 分割比率を変更する
+      Given コメント一覧とターミナルが分割表示されている
+      When ユーザーが分割バーをドラッグする
+      Then コメント一覧とターミナルのサイズ比率が変更される
+
+  Rule: 右パネル下部は折りたたみ可能である
+    Scenario: パネルを折りたたむ
+      Given 右パネル下部が展開されている
+      When ユーザーが折りたたみボタンを押す
+      Then ヘッダーのみが表示される
+
+    Scenario: パネルを展開する
+      Given 右パネル下部が折りたたまれている
+      When ユーザーが展開ボタンを押す
+      Then コメント一覧とターミナルが分割表示で復元される
+
+  Rule: コメント一覧はファイルごとにグループ化して未解決コメントを表示する
+    Scenario: 未解決コメントの表示
+      Given ワークツリーに複数ファイルへのコメントがある
+      When ユーザーがコメント一覧を表示する
+      Then ファイルパスごとにグループ化された未解決コメントが表示される
+
+    Scenario: 解決済みコメントの表示切り替え
+      Given 解決済みコメントが存在する
+      When ユーザーが解決済み表示をトグルする
+      Then 解決済みコメントが一覧に含まれる
+
+  Rule: コメント一覧からターミナルにコメントを送信できる
+    Scenario: 未解決コメントをターミナルに送信する
+      Given 未解決コメントが存在する
+      When ユーザーが送信ボタンを押す
+      Then 未解決コメントがテキスト形式でターミナルに入力される
+
+    Scenario: 未解決コメントをクリップボードにコピーする
+      Given 未解決コメントが存在する
+      When ユーザーがコピーボタンを押す
+      Then 未解決コメントがテキスト形式でクリップボードにコピーされる
+```
+
+## 実装仕様
+
+**対応方針**: コメント一覧とターミナルの同時表示を実現するために、`RightSidebarBottom.tsx` のタブUIを `react-resizable-panels` による左右分割レイアウトに置き換える。
+
+**対象コンポーネント**:
+- `src/components/panels/RightSidebarBottom.tsx`: タブUI (`Tabs`) → `Group orientation="horizontal"` + 2つの `Panel`（ターミナル左・コメント右）に変更。タブ関連のprops（`initialActiveTab`, `onActiveTabChange`）を削除。Copy/Sendボタンはコメントパネル内のフッターに配置。スクロールは既存の `ScrollArea` コンポーネントを使用
+- `src/screens/MainLayout.tsx`: `RightSidebarBottom` に渡しているタブ関連propsの削除
+- `src/screens/useWorktreeState.tsx`: `rightBottomActiveTab` 状態管理の削除
+- `src/types/workspace-state.ts`: `rightBottomActiveTab` フィールドの削除、`RightBottomActiveTab` 型の削除、`normalizeRightBottomActiveTab` 関数の削除
+
+**レイアウト構造**:
+```
+Panel "right-bottom" (既存、折りたたみ可能)
+  └─ RightSidebarBottom
+       ├─ ヘッダー（折りたたみボタンのみ）
+       └─ Group orientation="horizontal"
+            ├─ Panel "terminal" (50% default)
+            │    └─ TerminalPanel
+            ├─ Separator
+            └─ Panel "comments" (50% default)
+                 └─ CommentList（ScrollArea使用）
+                      └─ フッター（Copy / Send ボタン）
+```
+
+**設計判断**:
+- `ReviewPanel` の既存パターン（ファイルツリー/Diffビューの分割）を踏襲
+- コメント・ターミナル各サブパネルは折りたたみ不可（パネル全体の折りたたみのみ対応）。Specに個別折りたたみの要求がないため
+
+**影響するテスト**:
+- `src/components/panels/RightSidebarBottom.test.tsx`: タブ切り替えテスト → 分割表示テストに書き換え。`react-resizable-panels` のモックが必要（jsdom非対応のため）

--- a/src/components/panels/RightSidebarBottom.test.tsx
+++ b/src/components/panels/RightSidebarBottom.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Thread } from "@/types/thread";
+import { RightSidebarBottom } from "./RightSidebarBottom";
+
+// react-resizable-panels does not work in jsdom
+vi.mock("react-resizable-panels", () => ({
+	Group: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="resizable-group">{children}</div>
+	),
+	Panel: ({
+		children,
+		id,
+	}: {
+		children: React.ReactNode;
+		id?: string;
+		[key: string]: unknown;
+	}) => <div data-testid={`panel-${id ?? "unknown"}`}>{children}</div>,
+	Separator: () => <div data-testid="separator" />,
+}));
+
+vi.mock("@/components/panels/CommentList", () => ({
+	CommentList: (props: {
+		threads: Thread[];
+		showResolvedThreads?: boolean;
+		onToggleShowResolved?: () => void;
+	}) => (
+		<div data-testid="comment-list">
+			{props.threads.length} threads
+			{props.onToggleShowResolved && (
+				<button type="button" onClick={props.onToggleShowResolved}>
+					Toggle resolved
+				</button>
+			)}
+		</div>
+	),
+}));
+
+vi.mock("@/components/panels/TerminalPanel", () => ({
+	TerminalPanel: () => <div data-testid="terminal-panel" />,
+}));
+
+vi.mock("@/lib/formatCommentsForTerminal", () => ({
+	formatCommentsForTerminal: (threads: Thread[]) =>
+		threads.map((t) => t.entries[0]?.content).join("\n"),
+}));
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+	return {
+		id: `thread-${Math.random().toString(36).slice(2)}`,
+		filePath: "src/index.ts",
+		lineNumber: 1,
+		entries: [{ id: "e1", content: "Fix this", createdAt: 1 }],
+		resolved: false,
+		createdAt: Date.now(),
+		...overrides,
+	};
+}
+
+const defaultProps = {
+	rootPath: "/repo",
+	threads: [] as Thread[],
+};
+
+describe("RightSidebarBottom", () => {
+	it("should render terminal and comments panels side by side", () => {
+		render(<RightSidebarBottom {...defaultProps} />);
+
+		expect(screen.getByTestId("panel-terminal")).toBeInTheDocument();
+		expect(screen.getByTestId("panel-comments")).toBeInTheDocument();
+		expect(screen.getByTestId("resizable-group")).toBeInTheDocument();
+	});
+
+	it("should render a separator between panels", () => {
+		render(<RightSidebarBottom {...defaultProps} />);
+
+		expect(screen.getByTestId("separator")).toBeInTheDocument();
+	});
+
+	it("should render collapse button with correct aria-label when expanded", () => {
+		render(
+			<RightSidebarBottom
+				{...defaultProps}
+				collapsed={false}
+				onToggleCollapse={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Collapse panel" }),
+		).toBeInTheDocument();
+	});
+
+	it("should render expand button with correct aria-label when collapsed", () => {
+		render(
+			<RightSidebarBottom
+				{...defaultProps}
+				collapsed={true}
+				onToggleCollapse={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Expand panel" }),
+		).toBeInTheDocument();
+	});
+
+	it("should call onToggleCollapse when collapse button is clicked", async () => {
+		const user = userEvent.setup();
+		const onToggleCollapse = vi.fn();
+
+		render(
+			<RightSidebarBottom
+				{...defaultProps}
+				collapsed={false}
+				onToggleCollapse={onToggleCollapse}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Collapse panel" }));
+		expect(onToggleCollapse).toHaveBeenCalledOnce();
+	});
+
+	it("should copy unresolved comments to clipboard when copy button is clicked", async () => {
+		const user = userEvent.setup();
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		Object.defineProperty(navigator, "clipboard", {
+			value: { writeText },
+			writable: true,
+			configurable: true,
+		});
+
+		const threads = [
+			makeThread({ resolved: false }),
+			makeThread({ resolved: true }),
+		];
+
+		render(<RightSidebarBottom {...defaultProps} threads={threads} />);
+
+		await user.click(
+			screen.getByRole("button", { name: "Copy comments to clipboard" }),
+		);
+		expect(writeText).toHaveBeenCalledOnce();
+		expect(writeText).toHaveBeenCalledWith("Fix this");
+	});
+
+	it("should call onSendToTerminal with unresolved threads when send button is clicked", async () => {
+		const user = userEvent.setup();
+		const onSendToTerminal = vi.fn();
+
+		const unresolvedThread = makeThread({ resolved: false });
+		const resolvedThread = makeThread({ resolved: true });
+
+		render(
+			<RightSidebarBottom
+				{...defaultProps}
+				threads={[unresolvedThread, resolvedThread]}
+				onSendToTerminal={onSendToTerminal}
+			/>,
+		);
+
+		await user.click(screen.getByText("Send"));
+		expect(onSendToTerminal).toHaveBeenCalledOnce();
+		expect(onSendToTerminal).toHaveBeenCalledWith([unresolvedThread]);
+	});
+
+	it("should disable copy and send buttons when no unresolved threads exist", () => {
+		const threads = [makeThread({ resolved: true })];
+
+		render(
+			<RightSidebarBottom
+				{...defaultProps}
+				threads={threads}
+				onSendToTerminal={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Copy comments to clipboard" }),
+		).toBeDisabled();
+		expect(screen.getByText("Send").closest("button")).toBeDisabled();
+	});
+
+	it("should not render send button when onSendToTerminal is not provided", () => {
+		render(<RightSidebarBottom {...defaultProps} />);
+
+		expect(screen.queryByText("Send")).not.toBeInTheDocument();
+	});
+
+	it("should not render collapse button when onToggleCollapse is not provided", () => {
+		render(<RightSidebarBottom {...defaultProps} />);
+
+		expect(
+			screen.queryByRole("button", { name: "Collapse panel" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Expand panel" }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/src/components/panels/RightSidebarBottom.tsx
+++ b/src/components/panels/RightSidebarBottom.tsx
@@ -1,21 +1,12 @@
-import {
-	ChevronDown,
-	ChevronUp,
-	Copy,
-	MessageSquare,
-	Send,
-	Terminal,
-} from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { ChevronDown, ChevronUp, Copy, Send } from "lucide-react";
+import { useCallback, useMemo } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
 import { CommentList } from "@/components/panels/CommentList";
 import { TerminalPanel } from "@/components/panels/TerminalPanel";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { formatCommentsForTerminal } from "@/lib/formatCommentsForTerminal";
 import type { Theme } from "@/types/settings";
 import type { Thread } from "@/types/thread";
-
-export type RightBottomTab = "terminal" | "comments";
 
 interface RightSidebarBottomProps {
 	rootPath: string;
@@ -29,8 +20,6 @@ interface RightSidebarBottomProps {
 	onToggleShowResolved?: () => void;
 	onToggleCollapse?: () => void;
 	collapsed?: boolean;
-	initialActiveTab?: RightBottomTab;
-	onActiveTabChange?: (tab: RightBottomTab) => void;
 }
 
 export function RightSidebarBottom({
@@ -45,13 +34,7 @@ export function RightSidebarBottom({
 	onToggleShowResolved,
 	onToggleCollapse,
 	collapsed,
-	initialActiveTab,
-	onActiveTabChange,
 }: RightSidebarBottomProps) {
-	const [activeTab, setActiveTab] = useState<RightBottomTab>(
-		initialActiveTab ?? "terminal",
-	);
-
 	const unresolvedThreads = useMemo(
 		() => threads.filter((t) => !t.resolved),
 		[threads],
@@ -64,93 +47,68 @@ export function RightSidebarBottom({
 
 	return (
 		<div className="flex flex-col h-full">
-			<Tabs
-				value={activeTab}
-				onValueChange={(val) => {
-					const tab = val as RightBottomTab;
-					setActiveTab(tab);
-					onActiveTabChange?.(tab);
-				}}
-				className="flex flex-col h-full"
-			>
-				<div className="flex items-center gap-2 shrink-0 px-0 pt-0 bg-background">
-					{onToggleCollapse && (
-						<button
-							type="button"
-							onClick={onToggleCollapse}
-							className="shrink-0 p-1 ml-2 text-muted-foreground hover:text-foreground transition-colors"
-							aria-label={collapsed ? "Expand panel" : "Collapse panel"}
-						>
-							{collapsed ? (
-								<ChevronUp className="size-3.5" />
-							) : (
-								<ChevronDown className="size-3.5" />
-							)}
-						</button>
-					)}
-					<TabsList variant="line" aria-label="Bottom sidebar tabs">
-						<TabsTrigger value="terminal" aria-label="Terminal">
-							<span className="inline-flex items-center">
-								<Terminal className="size-3.5" />
-							</span>
-						</TabsTrigger>
-						<TabsTrigger value="comments" aria-label="Comments">
-							<span className="inline-flex items-center gap-1.5">
-								<MessageSquare className="size-3.5" />
-								{unresolvedThreads.length > 0 && (
-									<span className="px-1 text-[10px] bg-primary/20 text-primary rounded">
-										{unresolvedThreads.length}
-									</span>
-								)}
-							</span>
-						</TabsTrigger>
-					</TabsList>
-				</div>
-				<TabsContent
-					value="terminal"
-					forceMount
-					className="flex-1 overflow-hidden data-[state=inactive]:hidden"
-				>
-					<TerminalPanel cwd={rootPath} theme={theme} />
-				</TabsContent>
-				<TabsContent
-					value="comments"
-					className="flex-1 overflow-hidden flex flex-col"
-				>
-					<div className="flex-1 min-h-0 overflow-hidden">
-						<CommentList
-							threads={threads}
-							onThreadClick={onThreadClick}
-							onDeleteThread={onDeleteThread}
-							onResolveThread={onResolveThread}
-							showResolvedThreads={showResolvedThreads}
-							onToggleShowResolved={onToggleShowResolved}
-						/>
-					</div>
-					<div className="shrink-0 px-3 py-2 border-t border-border flex items-center gap-2">
-						<Button
-							variant="ghost"
-							size="icon-xs"
-							onClick={handleCopyThreads}
-							disabled={unresolvedThreads.length === 0}
-							aria-label="Copy comments to clipboard"
-						>
-							<Copy />
-						</Button>
-						{onSendToTerminal && (
-							<Button
-								variant="ghost"
-								size="xs"
-								onClick={() => onSendToTerminal(unresolvedThreads)}
-								disabled={unresolvedThreads.length === 0}
-							>
-								<Send />
-								Send
-							</Button>
+			<div className="flex items-center gap-2 shrink-0 px-0 pt-0 bg-background border-y border-border">
+				{onToggleCollapse && (
+					<button
+						type="button"
+						onClick={onToggleCollapse}
+						className="shrink-0 p-1 ml-2 text-muted-foreground hover:text-foreground transition-colors"
+						aria-label={collapsed ? "Expand panel" : "Collapse panel"}
+					>
+						{collapsed ? (
+							<ChevronUp className="size-3.5" />
+						) : (
+							<ChevronDown className="size-3.5" />
 						)}
-					</div>
-				</TabsContent>
-			</Tabs>
+					</button>
+				)}
+			</div>
+			<div className="flex-1 overflow-hidden">
+				<Group orientation="horizontal">
+					<Panel id="terminal" defaultSize="50%" minSize="20%">
+						<div className="h-full overflow-hidden border-r border-border">
+							<TerminalPanel cwd={rootPath} theme={theme} />
+						</div>
+					</Panel>
+					<Separator />
+					<Panel id="comments" defaultSize="50%" minSize="20%">
+						<div className="h-full flex flex-col overflow-hidden">
+							<div className="flex-1 min-h-0 overflow-hidden">
+								<CommentList
+									threads={threads}
+									onThreadClick={onThreadClick}
+									onDeleteThread={onDeleteThread}
+									onResolveThread={onResolveThread}
+									showResolvedThreads={showResolvedThreads}
+									onToggleShowResolved={onToggleShowResolved}
+								/>
+							</div>
+							<div className="shrink-0 px-3 py-2 border-t border-border flex items-center gap-2">
+								<Button
+									variant="ghost"
+									size="icon-xs"
+									onClick={handleCopyThreads}
+									disabled={unresolvedThreads.length === 0}
+									aria-label="Copy comments to clipboard"
+								>
+									<Copy />
+								</Button>
+								{onSendToTerminal && (
+									<Button
+										variant="ghost"
+										size="xs"
+										onClick={() => onSendToTerminal(unresolvedThreads)}
+										disabled={unresolvedThreads.length === 0}
+									>
+										<Send />
+										Send
+									</Button>
+								)}
+							</div>
+						</div>
+					</Panel>
+				</Group>
+			</div>
 		</div>
 	);
 }

--- a/src/hooks/useWorkspacePersistence.test.ts
+++ b/src/hooks/useWorkspacePersistence.test.ts
@@ -57,7 +57,6 @@ function makeInternalState(
 		activeEditorPath: "/repoA/src/main.rs",
 		activeView: "git",
 		rightBottomCollapsed: false,
-		rightBottomActiveTab: "terminal",
 		reviewCollapsed: false,
 		...overrides,
 	};
@@ -483,120 +482,5 @@ describe("useWorkspacePersistence", () => {
 		);
 
 		expect(mockLoadState).not.toHaveBeenCalled();
-	});
-
-	it("右下パネルのタブ選択が保存される", () => {
-		const setCenterTab = vi.fn();
-		const leftNavRef = makePanelRef();
-		const rightPanelRef = makePanelRef();
-
-		const { result, rerender } = renderHook(
-			({ selectedRootPath }) =>
-				useWorkspacePersistence({
-					selectedRootPath,
-					centerTab: "editor",
-					leftNavVisible: true,
-					rightVisible: true,
-					setCenterTab,
-					leftNavRef,
-					rightPanelRef,
-				}),
-			{ initialProps: { selectedRootPath: "/repoA" as string | null } },
-		);
-
-		act(() => {
-			result.current.internalStateMapRef.current.set(
-				"/repoA",
-				makeInternalState({ rightBottomActiveTab: "comments" }),
-			);
-		});
-
-		rerender({ selectedRootPath: "/repoB" });
-
-		const savedState = mockUpdateState.mock.calls[0][1] as WorkspaceState;
-		expect(savedState.layout.rightBottomActiveTab).toBe("comments");
-	});
-
-	it("右下パネルのタブ選択がWorktreeごとに独立している", () => {
-		const stateA = makeState({
-			layout: {
-				centerTab: "editor",
-				activeView: "git",
-				leftNavCollapsed: false,
-				rightCollapsed: false,
-				rightBottomCollapsed: false,
-				rightBottomActiveTab: "comments",
-			},
-		});
-		const stateB = makeState({
-			layout: {
-				centerTab: "editor",
-				activeView: "git",
-				leftNavCollapsed: false,
-				rightCollapsed: false,
-				rightBottomCollapsed: false,
-				rightBottomActiveTab: "terminal",
-			},
-		});
-
-		mockGetState.mockImplementation((path: string) => {
-			if (path === "/repoA") return stateA;
-			if (path === "/repoB") return stateB;
-			return undefined;
-		});
-
-		const setCenterTab = vi.fn();
-		const leftNavRef = makePanelRef();
-		const rightPanelRef = makePanelRef();
-
-		const { result, rerender } = renderHook(
-			({ selectedRootPath }) =>
-				useWorkspacePersistence({
-					selectedRootPath,
-					centerTab: "editor",
-					leftNavVisible: true,
-					rightVisible: true,
-					setCenterTab,
-					leftNavRef,
-					rightPanelRef,
-				}),
-			{ initialProps: { selectedRootPath: "/repoA" as string | null } },
-		);
-
-		// A → B に切り替え
-		act(() => {
-			result.current.internalStateMapRef.current.set(
-				"/repoA",
-				makeInternalState({ rightBottomActiveTab: "comments" }),
-			);
-		});
-		rerender({ selectedRootPath: "/repoB" });
-
-		const initialB = result.current.getInitialState("/repoB");
-		expect(initialB?.layout.rightBottomActiveTab).toBe("terminal");
-	});
-
-	it("保存された状態が存在しないWorktreeでは右下パネルがデフォルトタブで表示される", () => {
-		mockGetState.mockReturnValue(undefined);
-
-		const setCenterTab = vi.fn();
-		const leftNavRef = makePanelRef();
-		const rightPanelRef = makePanelRef();
-
-		const { result } = renderHook(() =>
-			useWorkspacePersistence({
-				selectedRootPath: "/newRepo",
-				centerTab: "editor",
-				leftNavVisible: true,
-				rightVisible: true,
-				setCenterTab,
-				leftNavRef,
-				rightPanelRef,
-			}),
-		);
-
-		const initialState = result.current.getInitialState("/newRepo");
-		// 保存状態がないのでundefined、useWorktreeStateでデフォルト"terminal"になる
-		expect(initialState).toBeUndefined();
 	});
 });

--- a/src/hooks/useWorkspaceStateCache.test.ts
+++ b/src/hooks/useWorkspaceStateCache.test.ts
@@ -21,7 +21,6 @@ function makeState(overrides?: Partial<WorkspaceState>): WorkspaceState {
 			leftNavCollapsed: false,
 			rightCollapsed: false,
 			rightBottomCollapsed: false,
-			rightBottomActiveTab: "terminal",
 		},
 		...overrides,
 	};

--- a/src/screens/MainLayout.tsx
+++ b/src/screens/MainLayout.tsx
@@ -175,7 +175,10 @@ function WorktreeContent({
 									s.setRightBottomCollapsed(size.inPixels <= 31)
 								}
 							>
-								<div data-testid="comments" className="h-full overflow-hidden">
+								<div
+									data-testid="right-bottom-content"
+									className="h-full overflow-hidden"
+								>
 									<RightSidebarBottom
 										rootPath={rootPath}
 										theme={settings.theme}

--- a/src/screens/MainLayout.tsx
+++ b/src/screens/MainLayout.tsx
@@ -13,10 +13,7 @@ import { RightPanelHeader } from "@/components/layout/RightPanelHeader";
 import { type TogglePanel, ViewToolbar } from "@/components/layout/ViewToolbar";
 import { AgentChatPanel } from "@/components/panels/AgentChatPanel";
 import { ReviewPanel } from "@/components/panels/ReviewPanel";
-import {
-	type RightBottomTab,
-	RightSidebarBottom,
-} from "@/components/panels/RightSidebarBottom";
+import { RightSidebarBottom } from "@/components/panels/RightSidebarBottom";
 import { SettingsModal } from "@/components/panels/SettingsModal";
 import { Button } from "@/components/ui/button";
 import {
@@ -191,8 +188,6 @@ function WorktreeContent({
 										onToggleShowResolved={s.toggleShowResolvedThreads}
 										onToggleCollapse={handleToggleRightBottom}
 										collapsed={s.rightBottomCollapsed}
-										initialActiveTab={s.rightBottomActiveTab as RightBottomTab}
-										onActiveTabChange={s.setRightBottomActiveTab}
 									/>
 								</div>
 							</Panel>

--- a/src/screens/useWorktreeState.tsx
+++ b/src/screens/useWorktreeState.tsx
@@ -15,10 +15,9 @@ import {
 } from "@/screens/useWorktreeGitActions";
 import { useWorktreeMenuHandlers } from "@/screens/useWorktreeMenuHandlers";
 import type { AppSettings } from "@/types/settings";
-import {
-	type InternalWorktreeState,
-	normalizeRightBottomActiveTab,
-	type WorkspaceState,
+import type {
+	InternalWorktreeState,
+	WorkspaceState,
 } from "@/types/workspace-state";
 
 export type { InternalWorktreeState } from "@/types/workspace-state";
@@ -44,12 +43,6 @@ export function useWorktreeState({
 }: UseWorktreeStateParams) {
 	const [rightBottomCollapsed, setRightBottomCollapsed] = useState(
 		initialWorkspaceState?.layout.rightBottomCollapsed ?? false,
-	);
-
-	const [rightBottomActiveTab, setRightBottomActiveTab] = useState<string>(
-		normalizeRightBottomActiveTab(
-			initialWorkspaceState?.layout.rightBottomActiveTab,
-		),
 	);
 
 	const [reviewCollapsed, setReviewCollapsed] = useState(
@@ -137,16 +130,9 @@ export function useWorktreeState({
 			activeEditorPath: null,
 			activeView: "agent",
 			rightBottomCollapsed,
-			rightBottomActiveTab,
 			reviewCollapsed,
 		});
-	}, [
-		internalStateMapRef,
-		rootPath,
-		rightBottomCollapsed,
-		rightBottomActiveTab,
-		reviewCollapsed,
-	]);
+	}, [internalStateMapRef, rootPath, rightBottomCollapsed, reviewCollapsed]);
 
 	return {
 		ready,
@@ -175,8 +161,6 @@ export function useWorktreeState({
 		rootPath,
 		rightBottomCollapsed,
 		setRightBottomCollapsed,
-		rightBottomActiveTab,
-		setRightBottomActiveTab,
 		reviewCollapsed,
 		setReviewCollapsed,
 	};

--- a/src/types/workspace-state.test.ts
+++ b/src/types/workspace-state.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	buildWorkspaceState,
-	normalizeRightBottomActiveTab,
-	worktreeNameFromPath,
-} from "./workspace-state";
+import { buildWorkspaceState, worktreeNameFromPath } from "./workspace-state";
 
 describe("worktreeNameFromPath", () => {
 	it("通常パスから末尾のディレクトリ名を返す", () => {
@@ -33,7 +29,6 @@ describe("buildWorkspaceState", () => {
 			activeEditorPath: "/repo/src/main.rs",
 			activeView: "git",
 			rightBottomCollapsed: false,
-			rightBottomActiveTab: "terminal",
 			reviewCollapsed: false,
 		};
 
@@ -51,7 +46,6 @@ describe("buildWorkspaceState", () => {
 				leftNavCollapsed: false,
 				rightCollapsed: false,
 				rightBottomCollapsed: false,
-				rightBottomActiveTab: "terminal",
 				reviewCollapsed: false,
 			},
 		});
@@ -63,7 +57,6 @@ describe("buildWorkspaceState", () => {
 			activeEditorPath: null,
 			activeView: "git",
 			rightBottomCollapsed: false,
-			rightBottomActiveTab: "terminal",
 			reviewCollapsed: false,
 		};
 
@@ -77,7 +70,6 @@ describe("buildWorkspaceState", () => {
 			activeEditorPath: null,
 			activeView: "git",
 			rightBottomCollapsed: false,
-			rightBottomActiveTab: "terminal",
 			reviewCollapsed: false,
 		};
 
@@ -91,7 +83,6 @@ describe("buildWorkspaceState", () => {
 			activeEditorPath: null,
 			activeView: "git",
 			rightBottomCollapsed: false,
-			rightBottomActiveTab: "terminal",
 			reviewCollapsed: false,
 		};
 
@@ -105,78 +96,11 @@ describe("buildWorkspaceState", () => {
 			activeEditorPath: null,
 			activeView: "git",
 			rightBottomCollapsed: true,
-			rightBottomActiveTab: "terminal",
 			reviewCollapsed: false,
 		};
 
 		const result = buildWorkspaceState(internal, "agent", true, true);
 		expect(result.layout.rightBottomCollapsed).toBe(true);
 		expect(result.layout.centerTab).toBe("agent");
-	});
-
-	it("rightBottomActiveTabが保持される", () => {
-		const internal = {
-			tabs: [],
-			activeEditorPath: null,
-			activeView: "git",
-			rightBottomCollapsed: false,
-			rightBottomActiveTab: "comments",
-			reviewCollapsed: false,
-		};
-
-		const result = buildWorkspaceState(internal, "editor", true, true);
-		expect(result.layout.rightBottomActiveTab).toBe("comments");
-	});
-
-	it('旧 rightBottomActiveTab="review" は "comments" にマイグレーションされる', () => {
-		const internal = {
-			tabs: [],
-			activeEditorPath: null,
-			activeView: "git",
-			rightBottomCollapsed: false,
-			rightBottomActiveTab: "review",
-			reviewCollapsed: false,
-		};
-
-		const result = buildWorkspaceState(internal, "editor", true, true);
-		expect(result.layout.rightBottomActiveTab).toBe("comments");
-	});
-
-	it('不明な rightBottomActiveTab は "terminal" にフォールバックする', () => {
-		const internal = {
-			tabs: [],
-			activeEditorPath: null,
-			activeView: "git",
-			rightBottomCollapsed: false,
-			rightBottomActiveTab: "unknown-tab",
-			reviewCollapsed: false,
-		};
-
-		const result = buildWorkspaceState(internal, "editor", true, true);
-		expect(result.layout.rightBottomActiveTab).toBe("terminal");
-	});
-});
-
-describe("normalizeRightBottomActiveTab", () => {
-	it('"terminal" はそのまま返る', () => {
-		expect(normalizeRightBottomActiveTab("terminal")).toBe("terminal");
-	});
-
-	it('"comments" はそのまま返る', () => {
-		expect(normalizeRightBottomActiveTab("comments")).toBe("comments");
-	});
-
-	it('旧値 "review" は "comments" に移行される', () => {
-		expect(normalizeRightBottomActiveTab("review")).toBe("comments");
-	});
-
-	it('undefined/null/空文字は "terminal" にフォールバックする', () => {
-		expect(normalizeRightBottomActiveTab(undefined)).toBe("terminal");
-		expect(normalizeRightBottomActiveTab(null)).toBe("terminal");
-		expect(normalizeRightBottomActiveTab("")).toBe("terminal");
-	});
-
-	it('未知の値は "terminal" にフォールバックする', () => {
-		expect(normalizeRightBottomActiveTab("xyz")).toBe("terminal");
 	});
 });

--- a/src/types/workspace-state.ts
+++ b/src/types/workspace-state.ts
@@ -2,21 +2,6 @@ export function worktreeNameFromPath(rootPath: string): string {
 	return rootPath.split("/").pop() ?? rootPath;
 }
 
-export type RightBottomActiveTab = "terminal" | "comments";
-
-/**
- * Normalizes a raw `rightBottomActiveTab` value (possibly a legacy string) into
- * the current union type. Legacy `"review"` is migrated to `"comments"`, and
- * any unknown value falls back to `"terminal"`.
- */
-export function normalizeRightBottomActiveTab(
-	value: string | null | undefined,
-): RightBottomActiveTab {
-	if (value === "comments" || value === "review") return "comments";
-	if (value === "terminal") return "terminal";
-	return "terminal";
-}
-
 export interface WorkspaceState {
 	version: 1;
 	tabs: {
@@ -29,7 +14,6 @@ export interface WorkspaceState {
 		leftNavCollapsed: boolean;
 		rightCollapsed: boolean;
 		rightBottomCollapsed: boolean;
-		rightBottomActiveTab?: RightBottomActiveTab;
 		reviewCollapsed?: boolean;
 	};
 }
@@ -39,7 +23,6 @@ export interface InternalWorktreeState {
 	activeEditorPath: string | null;
 	activeView: string;
 	rightBottomCollapsed: boolean;
-	rightBottomActiveTab: string;
 	reviewCollapsed: boolean;
 }
 
@@ -61,9 +44,6 @@ export function buildWorkspaceState(
 			leftNavCollapsed: !leftNavVisible,
 			rightCollapsed: !rightVisible,
 			rightBottomCollapsed: internal.rightBottomCollapsed,
-			rightBottomActiveTab: normalizeRightBottomActiveTab(
-				internal.rightBottomActiveTab,
-			),
 			reviewCollapsed: internal.reviewCollapsed,
 		},
 	};

--- a/tests/workspace-manager.spec.ts
+++ b/tests/workspace-manager.spec.ts
@@ -54,8 +54,8 @@ test.describe("Workspace Manager", () => {
 		// feat/wip（worktree_path あり）をクリック
 		await page.getByTestId("worktree-item-feat/wip").click();
 
-		// WorktreeView 固有の comments パネルが表示される
-		await expect(page.getByTestId("comments")).toBeVisible({
+		// WorktreeView 固有の右下パネルが表示される
+		await expect(page.getByTestId("right-bottom-content")).toBeVisible({
 			timeout: 5000,
 		});
 	});


### PR DESCRIPTION
## Summary
- 右パネル下部のコメント一覧/ターミナルのタブ切り替えUIを、`react-resizable-panels` による左右分割レイアウトに変更し、両パネルを同時表示可能にした
- 不要になった `rightBottomActiveTab` 関連の状態管理・型定義・テストを全レイヤーから削除
- 新しい分割レイアウトのテスト（`RightSidebarBottom.test.tsx`）を追加

## Test plan
- [x] `pnpm test` — 全111ファイル / 1312テスト PASS
- [x] `pnpm lint` — PASS
- [x] `pnpm build` — TSC + Vite（メイン・リモート・ブリッジ）PASS
- [ ] 実機でコメント一覧とターミナルが左右に並列表示されること
- [ ] 分割バーのドラッグでサイズ変更できること
- [ ] 折りたたみ/展開が動作すること
- [ ] Copy/Sendボタンが未解決コメント存在時のみ有効であること

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)