### PR TITLE
feat: Diffビューから外部エディタでファイルを開く機能を追加

### DIFF
--- a/docs/spec/issues-796.md
+++ b/docs/spec/issues-796.md
@@ -1,0 +1,64 @@
+## 要求
+
+**種別**: 新機能
+**ゴール**: Diffビューに「エディタで開く」ボタンを追加し、Diffビューからエディタへスムーズに遷移できるようにする
+**背景**: Diffビューとエディタ間のナビゲーションを改善し、変更確認から編集へのワークフローをスムーズにする
+
+## 振る舞い定義
+
+```gherkin
+Feature: Diffビューから外部エディタで開く
+  Diffビューで確認中のファイルを外部エディタで開き、変更確認から編集へスムーズに遷移する
+
+  Rule: Diffビューで選択中のファイルを外部エディタで開くことができる
+    Scenario: Diffビューから外部エディタで開く
+      Given Diffビューでファイルが選択されている
+      When ユーザーが「エディタで開く」を実行する
+      Then 選択中のファイルが設定された外部エディタで開かれる
+
+  Rule: デフォルトではシステムデフォルトのアプリケーションでファイルを開く
+    Scenario: エディタ未変更時はシステムデフォルトで開く
+      Given 外部エディタの設定がデフォルトのままである
+      When ファイルを外部エディタで開く
+      Then システムデフォルトのアプリケーションでファイルが開かれる
+
+  Rule: 設定画面でデフォルトエディタを変更できる
+    Scenario: デフォルトエディタの変更
+      Given 利用可能なエディタが検出されている
+      When ユーザーが設定画面でエディタを選択する
+      Then 選択されたエディタがデフォルトとして保存される
+
+    Scenario: 変更後のエディタで開く
+      Given デフォルトエディタが変更されている
+      When ファイルを外部エディタで開く
+      Then 変更後のエディタでファイルが開かれる
+
+  Rule: 利用可能な外部エディタを検出できる
+    Scenario: インストール済みエディタの検出
+      Given システムにエディタアプリがインストールされている
+      When 利用可能なエディタを検出する
+      Then インストール済みのエディタが一覧として返される
+```
+
+## 実装仕様
+
+**対応方針**: Diffビューから外部エディタでファイルを開く機能を実現するために、Rust側に外部エディタ検出・設定管理のロジックを実装し、フロントエンドのReviewPanelにボタンを追加する。ファイルオープンには既存の`tauri_plugin_opener`の`open_path`を使用する。
+
+**対象コンポーネント**:
+- `src-tauri/src/external_editor.rs`（新規）: エディタ検出ロジック（macOS: `/Applications`のアプリバンドル検索）、`open_in_editor` Tauriコマンド（`tauri_plugin_opener::open_path`で`with`にエディタパスを渡す）
+- `src-tauri/src/config.rs`: `AppSection`に`external_editor: String`フィールド追加（デフォルト空=システムデフォルト）
+- `src-tauri/src/lib.rs`: 新規コマンド登録（`detect_editors`, `open_in_editor`）
+- `src/types/settings.ts`: `AppSettings`に`externalEditor: string`追加
+- `src/components/panels/ReviewPanel.tsx`: ヘッダー部にDiffBaseToggle横に「エディタで開く」ボタン追加
+- `src/components/panels/SettingsModal.tsx`: Editorタブに外部エディタ選択ドロップダウン追加
+
+**技術選定**:
+- `tauri_plugin_opener::open_path(with)`: 既にプロジェクトに導入済み。`with`パラメータでエディタ実行パスを指定可能。新規依存なし
+
+**検討した代替案**:
+- `std::process::Command`で直接エディタを起動: エディタごとの起動引数の差異を吸収する必要がありメンテコストが高い。`open_path`は各OSのデフォルトオープン機構を利用するため安定性が高い → 却下
+
+**影響するテスト**:
+- Rust単体テスト: `external_editor.rs`のエディタ検出ロジック（`/Applications`スキャンのモック）
+- フロントエンドテスト: ReviewPanelのボタン表示・クリック時のinvoke呼び出し確認
+- 設定テスト: `AppSettings`のexternalEditorフィールドの永続化テスト（既存`app_section_roundtrip`テストの拡張）

--- a/docs/spec/issues-796.md
+++ b/docs/spec/issues-796.md
@@ -45,7 +45,7 @@ Feature: Diffビューから外部エディタで開く
 **対応方針**: Diffビューから外部エディタでファイルを開く機能を実現するために、Rust側に外部エディタ検出・設定管理のロジックを実装し、フロントエンドのReviewPanelにボタンを追加する。ファイルオープンには既存の`tauri_plugin_opener`の`open_path`を使用する。
 
 **対象コンポーネント**:
-- `src-tauri/src/external_editor.rs`（新規）: エディタ検出ロジック（macOS: `/Applications`のアプリバンドル検索）、`open_in_editor` Tauriコマンド（`tauri_plugin_opener::open_path`で`with`にエディタパスを渡す）
+- `src-tauri/src/external_editor.rs`（新規）: エディタ検出ロジック（macOS: `/Applications`および`~/Applications`のアプリバンドル検索、スキャンディレクトリは注入可能）、`open_in_editor` Tauriコマンド（`tauri_plugin_opener::open_path`で`with`にエディタパスを渡す）
 - `src-tauri/src/config.rs`: `AppSection`に`external_editor: String`フィールド追加（デフォルト空=システムデフォルト）
 - `src-tauri/src/lib.rs`: 新規コマンド登録（`detect_editors`, `open_in_editor`）
 - `src/types/settings.ts`: `AppSettings`に`externalEditor: string`追加
@@ -59,6 +59,6 @@ Feature: Diffビューから外部エディタで開く
 - `std::process::Command`で直接エディタを起動: エディタごとの起動引数の差異を吸収する必要がありメンテコストが高い。`open_path`は各OSのデフォルトオープン機構を利用するため安定性が高い → 却下
 
 **影響するテスト**:
-- Rust単体テスト: `external_editor.rs`のエディタ検出ロジック（`/Applications`スキャンのモック）
+- Rust単体テスト: `external_editor.rs`のエディタ検出ロジック（`scan_applications_in`にTempDirを注入した決定的テスト）
 - フロントエンドテスト: ReviewPanelのボタン表示・クリック時のinvoke呼び出し確認
 - 設定テスト: `AppSettings`のexternalEditorフィールドの永続化テスト（既存`app_section_roundtrip`テストの拡張）

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -52,6 +52,8 @@ pub struct AppSection {
     pub last_repo_paths: Vec<String>,
     #[serde(default)]
     pub last_bind_ip: String,
+    #[serde(default)]
+    pub external_editor: String,
 }
 
 impl Default for AppSection {
@@ -63,6 +65,7 @@ impl Default for AppSection {
             last_root_path: String::new(),
             last_repo_paths: Vec::new(),
             last_bind_ip: String::new(),
+            external_editor: String::new(),
         }
     }
 }
@@ -805,6 +808,34 @@ pub async fn update_crash_reporting(
     .map_err(|e| format!("task join error: {e}"))?
 }
 
+#[tauri::command]
+pub fn get_external_editor(state: tauri::State<'_, Arc<AppConfig>>) -> Result<String, String> {
+    let config = state
+        .config
+        .lock()
+        .map_err(|e| format!("ロック取得失敗: {e}"))?;
+    Ok(config.app.external_editor.clone())
+}
+
+#[tauri::command]
+pub async fn update_external_editor(
+    state: tauri::State<'_, Arc<AppConfig>>,
+    editor: String,
+) -> Result<(), String> {
+    let app_config = state.inner().clone();
+    tokio::task::spawn_blocking(move || {
+        let mut config = app_config
+            .config
+            .lock()
+            .map_err(|e| format!("ロック取得失敗: {e}"))?;
+        config.app.external_editor = editor;
+        write_config(&app_config.config_path, &config)?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1268,6 +1299,7 @@ token = "existing_token_value_here_with_enough_length_!!"
         assert!(app.last_root_path.is_empty());
         assert!(app.last_repo_paths.is_empty());
         assert!(app.last_bind_ip.is_empty());
+        assert!(app.external_editor.is_empty());
     }
 
     #[test]
@@ -1283,6 +1315,7 @@ token = "existing_token_value_here_with_enough_length_!!"
         config.app.last_root_path = "/repo/path".to_string();
         config.app.last_repo_paths = vec!["/repo/path".to_string(), "/repo/path2".to_string()];
         config.app.last_bind_ip = "10.0.0.1".to_string();
+        config.app.external_editor = "/Applications/Cursor.app".to_string();
         write_config(&path, &config).unwrap();
 
         let reloaded = fs::read_to_string(&path).unwrap();
@@ -1296,6 +1329,7 @@ token = "existing_token_value_here_with_enough_length_!!"
             vec!["/repo/path", "/repo/path2"]
         );
         assert_eq!(reloaded.app.last_bind_ip, "10.0.0.1");
+        assert_eq!(reloaded.app.external_editor, "/Applications/Cursor.app");
     }
 
     #[test]

--- a/src-tauri/src/external_editor.rs
+++ b/src-tauri/src/external_editor.rs
@@ -1,0 +1,98 @@
+use serde::Serialize;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::config::AppConfig;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EditorInfo {
+    pub name: String,
+    pub path: String,
+}
+
+const KNOWN_EDITORS: &[(&str, &str)] = &[
+    ("Visual Studio Code", "Visual Studio Code.app"),
+    ("Cursor", "Cursor.app"),
+    ("Zed", "Zed.app"),
+    ("Sublime Text", "Sublime Text.app"),
+    ("TextMate", "TextMate.app"),
+    ("Nova", "Nova.app"),
+    ("BBEdit", "BBEdit.app"),
+    ("CotEditor", "CotEditor.app"),
+];
+
+fn scan_applications() -> Vec<EditorInfo> {
+    let mut editors = Vec::new();
+
+    for (name, app_bundle) in KNOWN_EDITORS {
+        let app_path = format!("/Applications/{app_bundle}");
+        if Path::new(&app_path).exists() {
+            editors.push(EditorInfo {
+                name: name.to_string(),
+                path: app_path,
+            });
+        }
+    }
+
+    editors
+}
+
+#[tauri::command]
+pub fn detect_editors() -> Vec<EditorInfo> {
+    scan_applications()
+}
+
+#[tauri::command]
+pub fn open_in_editor(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<AppConfig>>,
+    file_path: String,
+) -> Result<(), String> {
+    if file_path.is_empty() {
+        return Err("ファイルパスが指定されていません".to_string());
+    }
+
+    use tauri_plugin_opener::OpenerExt;
+
+    let config = state.get_config()?;
+    let editor = &config.app.external_editor;
+
+    if editor.is_empty() {
+        app.opener()
+            .open_path(&file_path, None::<&str>)
+            .map_err(|e| format!("ファイルを開けませんでした: {e}"))
+    } else {
+        app.opener()
+            .open_path(&file_path, Some(editor.as_str()))
+            .map_err(|e| format!("エディタでファイルを開けませんでした: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_editors_list_is_not_empty() {
+        assert!(!KNOWN_EDITORS.is_empty());
+    }
+
+    #[test]
+    fn scan_applications_returns_only_existing() {
+        let editors = scan_applications();
+        for editor in &editors {
+            assert!(Path::new(&editor.path).exists());
+        }
+    }
+
+    #[test]
+    fn editor_info_serializes() {
+        let info = EditorInfo {
+            name: "Test Editor".to_string(),
+            path: "/Applications/Test.app".to_string(),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("Test Editor"));
+        assert!(json.contains("/Applications/Test.app"));
+    }
+}

--- a/src-tauri/src/external_editor.rs
+++ b/src-tauri/src/external_editor.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::config::AppConfig;
@@ -21,20 +21,35 @@ const KNOWN_EDITORS: &[(&str, &str)] = &[
     ("CotEditor", "CotEditor.app"),
 ];
 
-fn scan_applications() -> Vec<EditorInfo> {
+fn application_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![PathBuf::from("/Applications")];
+    if let Some(home) = std::env::var_os("HOME") {
+        dirs.push(PathBuf::from(home).join("Applications"));
+    }
+    dirs
+}
+
+fn scan_applications_in(dirs: &[PathBuf]) -> Vec<EditorInfo> {
     let mut editors = Vec::new();
 
     for (name, app_bundle) in KNOWN_EDITORS {
-        let app_path = format!("/Applications/{app_bundle}");
-        if Path::new(&app_path).exists() {
-            editors.push(EditorInfo {
-                name: name.to_string(),
-                path: app_path,
-            });
+        for dir in dirs {
+            let app_path = dir.join(app_bundle);
+            if app_path.exists() {
+                editors.push(EditorInfo {
+                    name: name.to_string(),
+                    path: app_path.to_string_lossy().into_owned(),
+                });
+                break;
+            }
         }
     }
 
     editors
+}
+
+fn scan_applications() -> Vec<EditorInfo> {
+    scan_applications_in(&application_dirs())
 }
 
 #[tauri::command]
@@ -71,6 +86,9 @@ pub fn open_in_editor(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
 
     #[test]
     fn known_editors_list_is_not_empty() {
@@ -78,11 +96,54 @@ mod tests {
     }
 
     #[test]
-    fn scan_applications_returns_only_existing() {
-        let editors = scan_applications();
-        for editor in &editors {
-            assert!(Path::new(&editor.path).exists());
-        }
+    fn scan_finds_existing_editors_in_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let apps_dir = tmp.path().to_path_buf();
+        fs::create_dir_all(apps_dir.join("Cursor.app")).unwrap();
+        fs::create_dir_all(apps_dir.join("Zed.app")).unwrap();
+
+        let editors = scan_applications_in(&[apps_dir]);
+        assert_eq!(editors.len(), 2);
+        assert_eq!(editors[0].name, "Cursor");
+        assert_eq!(editors[1].name, "Zed");
+    }
+
+    #[test]
+    fn scan_returns_empty_for_no_editors() {
+        let tmp = TempDir::new().unwrap();
+        let editors = scan_applications_in(&[tmp.path().to_path_buf()]);
+        assert!(editors.is_empty());
+    }
+
+    #[test]
+    fn scan_deduplicates_across_dirs() {
+        let tmp1 = TempDir::new().unwrap();
+        let tmp2 = TempDir::new().unwrap();
+        fs::create_dir_all(tmp1.path().join("Cursor.app")).unwrap();
+        fs::create_dir_all(tmp2.path().join("Cursor.app")).unwrap();
+
+        let editors = scan_applications_in(&[tmp1.path().to_path_buf(), tmp2.path().to_path_buf()]);
+        assert_eq!(editors.len(), 1);
+        assert!(editors[0].path.contains(tmp1.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn scan_prefers_first_dir() {
+        let sys_dir = TempDir::new().unwrap();
+        let user_dir = TempDir::new().unwrap();
+        fs::create_dir_all(sys_dir.path().join("Zed.app")).unwrap();
+        fs::create_dir_all(user_dir.path().join("Zed.app")).unwrap();
+
+        let editors =
+            scan_applications_in(&[sys_dir.path().to_path_buf(), user_dir.path().to_path_buf()]);
+        assert_eq!(editors.len(), 1);
+        assert!(editors[0].path.contains(sys_dir.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn application_dirs_includes_system() {
+        let dirs = application_dirs();
+        assert!(dirs.iter().any(|d| d == Path::new("/Applications")));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod agent_sdk;
 mod agent_status;
 mod comment_store;
 mod config;
+mod external_editor;
 mod file_mention;
 mod focus_tracker;
 mod git;
@@ -288,9 +289,14 @@ pub fn run() {
             config::get_crash_reporting_enabled,
             config::update_crash_reporting,
             config::update_webhook_url,
+            config::get_external_editor,
+            config::update_external_editor,
             config::get_mcp_config,
             config::update_mcp_config,
             config::regenerate_mcp_token,
+            // External Editor
+            external_editor::detect_editors,
+            external_editor::open_in_editor,
             // Agent Status (Rust 中央管理)
             agent_status::get_session_status,
             agent_status::get_workspace_status,

--- a/src/components/panels/DiffToolbar.test.tsx
+++ b/src/components/panels/DiffToolbar.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { DiffToolbarProps } from "./DiffToolbar";
@@ -15,11 +16,16 @@ if (typeof Element.prototype.releasePointerCapture !== "function") {
 	Element.prototype.releasePointerCapture = () => {};
 }
 
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: vi.fn().mockResolvedValue(null),
+}));
+
 const defaultProps: DiffToolbarProps = {
 	diffMode: "inline",
 	diffOnlyMode: false,
 	onDiffModeChange: vi.fn(),
 	onDiffOnlyModeChange: vi.fn(),
+	filePath: null,
 };
 
 function renderToolbar(props: Partial<DiffToolbarProps> = {}) {
@@ -100,6 +106,33 @@ describe("DiffToolbar", () => {
 
 			fireEvent.click(screen.getByRole("button", { name: "Diff only" }));
 			expect(onChange).toHaveBeenCalledWith(false);
+		});
+	});
+
+	describe("Open in Editor button", () => {
+		it("should not show button when filePath is null", () => {
+			renderToolbar({ filePath: null });
+			expect(
+				screen.queryByRole("button", { name: "Open in Editor" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("should show button when filePath is provided", () => {
+			renderToolbar({ filePath: "/repo/src/main.ts" });
+			expect(
+				screen.getByRole("button", { name: "Open in Editor" }),
+			).toBeInTheDocument();
+		});
+
+		it("should invoke open_in_editor with filePath when clicked", async () => {
+			const { invoke } = await import("@tauri-apps/api/core");
+			const user = userEvent.setup();
+			renderToolbar({ filePath: "/repo/src/main.ts" });
+			const button = screen.getByRole("button", { name: "Open in Editor" });
+			await user.click(button);
+			expect(vi.mocked(invoke)).toHaveBeenCalledWith("open_in_editor", {
+				filePath: "/repo/src/main.ts",
+			});
 		});
 	});
 

--- a/src/components/panels/DiffToolbar.tsx
+++ b/src/components/panels/DiffToolbar.tsx
@@ -8,6 +8,7 @@ import {
 	Minus,
 	SplitSquareHorizontal,
 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Tooltip,
@@ -46,11 +47,30 @@ export function DiffToolbar({
 	filePath,
 }: DiffToolbarProps) {
 	const hasFileNav = fileNavigation && fileNavigation.total > 0;
+	const [editorError, setEditorError] = useState<string | null>(null);
+	const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+		};
+	}, []);
+
+	const handleOpenInEditor = useCallback(() => {
+		if (!filePath) return;
+		setEditorError(null);
+		invoke("open_in_editor", { filePath }).catch((e) => {
+			console.error("Failed to open in editor:", e);
+			setEditorError(String(e));
+			if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+			errorTimerRef.current = setTimeout(() => setEditorError(null), 5000);
+		});
+	}, [filePath]);
 
 	return (
 		<div className="flex items-center justify-between px-2 h-[36px] border-t border-border bg-card shrink-0 select-none">
 			{/* Left: Open in Editor */}
-			<div className="flex items-center h-full">
+			<div className="flex items-center h-full gap-1">
 				{filePath && (
 					<Tooltip>
 						<TooltipTrigger asChild>
@@ -58,11 +78,7 @@ export function DiffToolbar({
 								variant="ghost"
 								size="icon-xs"
 								aria-label="Open in Editor"
-								onClick={() => {
-									invoke("open_in_editor", { filePath }).catch((e) => {
-										console.error("Failed to open in editor:", e);
-									});
-								}}
+								onClick={handleOpenInEditor}
 								className="h-5 w-5 text-muted-foreground hover:text-foreground"
 							>
 								<ExternalLink className="h-3.5 w-3.5" />
@@ -72,6 +88,11 @@ export function DiffToolbar({
 							Open in Editor
 						</TooltipContent>
 					</Tooltip>
+				)}
+				{editorError && (
+					<span className="text-[10px] text-destructive truncate max-w-[200px]">
+						{editorError}
+					</span>
 				)}
 			</div>
 

--- a/src/components/panels/DiffToolbar.tsx
+++ b/src/components/panels/DiffToolbar.tsx
@@ -1,8 +1,10 @@
+import { invoke } from "@tauri-apps/api/core";
 import {
 	AlignJustify,
 	ChevronLeft,
 	ChevronRight,
 	Diff,
+	ExternalLink,
 	Minus,
 	SplitSquareHorizontal,
 } from "lucide-react";
@@ -24,6 +26,7 @@ export interface DiffToolbarProps {
 	fileNavigation?: FileNavigationResult;
 	onGoToPrevFile?: () => void;
 	onGoToNextFile?: () => void;
+	filePath: string | null;
 }
 
 const diffModes: { mode: DiffMode; icon: typeof Minus; label: string }[] = [
@@ -40,13 +43,37 @@ export function DiffToolbar({
 	fileNavigation,
 	onGoToPrevFile,
 	onGoToNextFile,
+	filePath,
 }: DiffToolbarProps) {
 	const hasFileNav = fileNavigation && fileNavigation.total > 0;
 
 	return (
 		<div className="flex items-center justify-between px-2 h-[36px] border-t border-border bg-card shrink-0 select-none">
-			{/* Left: spacer */}
-			<div className="flex items-center h-full" />
+			{/* Left: Open in Editor */}
+			<div className="flex items-center h-full">
+				{filePath && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon-xs"
+								aria-label="Open in Editor"
+								onClick={() => {
+									invoke("open_in_editor", { filePath }).catch((e) => {
+										console.error("Failed to open in editor:", e);
+									});
+								}}
+								className="h-5 w-5 text-muted-foreground hover:text-foreground"
+							>
+								<ExternalLink className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="top" className="text-xs">
+							Open in Editor
+						</TooltipContent>
+					</Tooltip>
+				)}
+			</div>
 
 			{/* Center: File navigation */}
 			{hasFileNav && (

--- a/src/components/panels/ReviewPanel.test.tsx
+++ b/src/components/panels/ReviewPanel.test.tsx
@@ -330,7 +330,12 @@ describe("ReviewPanel", () => {
 
 		render(
 			<TooltipProvider>
-				<ReviewPanel rootPath="/repo" baseBranch="main" />
+				<ReviewPanel
+					rootPath="/repo"
+					baseBranch="main"
+					diffOnlyMode={false}
+					onDiffOnlyModeChange={vi.fn()}
+				/>
 			</TooltipProvider>,
 		);
 
@@ -372,7 +377,12 @@ describe("ReviewPanel", () => {
 
 		render(
 			<TooltipProvider>
-				<ReviewPanel rootPath="/repo" baseBranch="main" />
+				<ReviewPanel
+					rootPath="/repo"
+					baseBranch="main"
+					diffOnlyMode={false}
+					onDiffOnlyModeChange={vi.fn()}
+				/>
 			</TooltipProvider>,
 		);
 

--- a/src/components/panels/ReviewPanel.test.tsx
+++ b/src/components/panels/ReviewPanel.test.tsx
@@ -105,6 +105,20 @@ vi.mock("@/hooks/useGitActions", () => ({
 	}),
 }));
 
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("./DiffViewerSection", () => ({
+	DiffViewerSection: () => <div data-testid="diff-viewer-section" />,
+}));
+
+vi.mock("./DiffToolbar", () => ({
+	DiffToolbar: ({ filePath }: { filePath?: string | null }) => (
+		<div data-testid="diff-toolbar" data-file-path={filePath ?? ""} />
+	),
+}));
+
 const { useDiffFileTree } = await import("@/hooks/useDiffFileTree");
 const { useReviewPanel } = await import("@/hooks/useReviewPanel");
 
@@ -290,5 +304,79 @@ describe("ReviewPanel", () => {
 		);
 
 		expect(screen.queryByTestId("breadcrumb")).not.toBeInTheDocument();
+	});
+
+	it("should pass null filePath to DiffToolbar when no file is selected", () => {
+		vi.mocked(useDiffFileTree).mockReturnValue({
+			stagedTree: [],
+			changesTree: [
+				{
+					id: "file:file.ts",
+					name: "file.ts",
+					path: "file.ts",
+					node_type: "file",
+					status: "modified",
+					additions: 1,
+					deletions: 0,
+					children: [],
+				},
+			],
+			stagedFileCount: 0,
+			changesFileCount: 1,
+			branchBaseTree: [],
+			branchBaseFileCount: 0,
+			loading: false,
+		});
+
+		render(
+			<TooltipProvider>
+				<ReviewPanel rootPath="/repo" baseBranch="main" />
+			</TooltipProvider>,
+		);
+
+		// No file selected → DiffToolbar is not rendered (placeholder shown instead)
+		expect(screen.queryByTestId("diff-toolbar")).not.toBeInTheDocument();
+	});
+
+	it("should pass filePath to DiffToolbar when a file is selected", () => {
+		vi.mocked(useReviewPanel).mockReturnValue({
+			diffBase: "head",
+			diffMode: "gutter",
+			selectedFile: "src/main.ts",
+			selectedSection: "changes",
+			setDiffBase: vi.fn(),
+			setDiffMode: vi.fn(),
+			selectFile: vi.fn(),
+		});
+
+		vi.mocked(useDiffFileTree).mockReturnValue({
+			stagedTree: [],
+			changesTree: [
+				{
+					id: "file:src/main.ts",
+					name: "main.ts",
+					path: "src/main.ts",
+					node_type: "file",
+					status: "modified",
+					additions: 1,
+					deletions: 0,
+					children: [],
+				},
+			],
+			stagedFileCount: 0,
+			changesFileCount: 1,
+			branchBaseTree: [],
+			branchBaseFileCount: 0,
+			loading: false,
+		});
+
+		render(
+			<TooltipProvider>
+				<ReviewPanel rootPath="/repo" baseBranch="main" />
+			</TooltipProvider>,
+		);
+
+		const toolbar = screen.getByTestId("diff-toolbar");
+		expect(toolbar).toHaveAttribute("data-file-path", "/repo/src/main.ts");
 	});
 });

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -516,6 +516,7 @@ export function ReviewPanel({
 										fileNavigation={fileNavigation}
 										onGoToPrevFile={handleGoToPrevFile}
 										onGoToNextFile={handleGoToNextFile}
+										filePath={selectedFilePath}
 									/>
 								</>
 							) : (

--- a/src/components/panels/SettingsModal.test.tsx
+++ b/src/components/panels/SettingsModal.test.tsx
@@ -51,6 +51,10 @@ describe("SettingsModal", () => {
 				case "update_remote_config":
 				case "update_notify_config":
 					return Promise.resolve(null);
+				case "get_external_editor":
+					return Promise.resolve("");
+				case "detect_editors":
+					return Promise.resolve([]);
 				default:
 					return Promise.resolve(null);
 			}
@@ -392,6 +396,68 @@ describe("SettingsModal", () => {
 		fireEvent.click(within(nav).getByText("Agent"));
 		await waitFor(() => {
 			expect(screen.getByText("Not configured")).toBeInTheDocument();
+		});
+	});
+
+	it("should save external editor selection via Save button", async () => {
+		const user = userEvent.setup();
+		const { invoke } = await import("@tauri-apps/api/core");
+		vi.mocked(invoke).mockImplementation((cmd: string) => {
+			switch (cmd) {
+				case "get_external_editor":
+					return Promise.resolve("");
+				case "detect_editors":
+					return Promise.resolve([
+						{
+							name: "Visual Studio Code",
+							path: "/Applications/Visual Studio Code.app",
+						},
+						{ name: "Cursor", path: "/Applications/Cursor.app" },
+					]);
+				case "get_notify_config":
+					return Promise.resolve({
+						webhook_url: "",
+						on_running: false,
+						on_done: true,
+						on_error: true,
+						on_waiting: true,
+						desktop_mode: "always",
+						inactive_timeout_minutes: 2,
+					});
+				case "get_remote_config":
+					return Promise.resolve({
+						auto_start: false,
+						auto_start_on_lan: false,
+					});
+				case "get_mcp_config":
+					return Promise.resolve({ port: 19801, token: "test-token" });
+				case "get_configured_agents":
+					return Promise.resolve([]);
+				case "preview_agent_mcp_config":
+					return Promise.resolve("");
+				case "update_external_editor":
+					return Promise.resolve(null);
+				default:
+					return Promise.resolve(null);
+			}
+		});
+
+		render(<SettingsModal {...defaultProps} />);
+		fireEvent.click(screen.getByText("Editor"));
+
+		const trigger = await screen.findByRole("combobox", {
+			name: "External Editor",
+		});
+		await user.click(trigger);
+		const option = screen.getByRole("option", { name: "Cursor" });
+		await user.click(option);
+
+		const saveBtn = screen.getByRole("button", { name: "Save" });
+		expect(saveBtn).toBeEnabled();
+		await user.click(saveBtn);
+
+		expect(vi.mocked(invoke)).toHaveBeenCalledWith("update_external_editor", {
+			editor: "/Applications/Cursor.app",
 		});
 	});
 

--- a/src/components/panels/SettingsModal.tsx
+++ b/src/components/panels/SettingsModal.tsx
@@ -212,12 +212,52 @@ function AppearanceSection({
 	);
 }
 
+interface EditorInfo {
+	name: string;
+	path: string;
+}
+
+function useExternalEditorConfig() {
+	const [editor, setEditor] = useState("");
+	const [initialEditor, setInitialEditor] = useState("");
+	const [editors, setEditors] = useState<EditorInfo[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		setLoading(true);
+		setError(null);
+		Promise.all([
+			invoke<string>("get_external_editor"),
+			invoke<EditorInfo[]>("detect_editors"),
+		])
+			.then(([current, detected]) => {
+				setEditor(current);
+				setInitialEditor(current);
+				setEditors(detected);
+			})
+			.catch((e) => setError(String(e)))
+			.finally(() => setLoading(false));
+	}, []);
+
+	const isDirty = editor !== initialEditor;
+
+	const save = useCallback(async () => {
+		await invoke("update_external_editor", { editor });
+		setInitialEditor(editor);
+	}, [editor]);
+
+	return { editor, setEditor, editors, isDirty, loading, error, save };
+}
+
 function EditorSection({
 	draft,
 	updateDraft,
+	externalEditor,
 }: {
 	draft: AppSettings;
 	updateDraft: (updater: (d: AppSettings) => AppSettings) => void;
+	externalEditor: ReturnType<typeof useExternalEditorConfig>;
 }) {
 	return (
 		<div className="flex flex-col gap-4">
@@ -282,6 +322,44 @@ function EditorSection({
 				<label htmlFor="diff-only-mode" className={labelClass}>
 					Show diff only by default
 				</label>
+			</div>
+
+			<div className="flex flex-col gap-1.5">
+				<label htmlFor="external-editor-select" className={labelClass}>
+					External Editor
+				</label>
+				{externalEditor.loading ? (
+					<div className="flex items-center justify-center py-3">
+						<Loader2 className="size-4 animate-spin text-muted-foreground" />
+					</div>
+				) : (
+					<>
+						<Select
+							value={externalEditor.editor || "__default__"}
+							onValueChange={(value) =>
+								externalEditor.setEditor(value === "__default__" ? "" : value)
+							}
+						>
+							<SelectTrigger id="external-editor-select">
+								<SelectValue placeholder="System Default" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="__default__">System Default</SelectItem>
+								{externalEditor.editors.map((e) => (
+									<SelectItem key={e.path} value={e.path}>
+										{e.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<p className="text-[10px] text-muted-foreground">
+							Application used when opening files from the diff view.
+						</p>
+						{externalEditor.error && (
+							<p className="text-xs text-destructive">{externalEditor.error}</p>
+						)}
+					</>
+				)}
 			</div>
 		</div>
 	);
@@ -1135,6 +1213,7 @@ export function SettingsModal({
 	const repos = useRepoChanges();
 	const notion = useNotionSettings(repoPaths);
 	const mcp = useMcpConfig();
+	const externalEditor = useExternalEditorConfig();
 
 	// Hooks state
 	const [hooks, dispatchHooks] = useReducer(hooksReducer, initialHooksState);
@@ -1214,6 +1293,7 @@ export function SettingsModal({
 	const { isDirty: reposIsDirty, save: reposSave } = repos;
 	const { isDirty: notionIsDirty, save: notionSave } = notion;
 	const { isDirty: mcpIsDirty, save: mcpSave } = mcp;
+	const { isDirty: editorIsDirty, save: editorSave } = externalEditor;
 
 	const handleSave = useCallback(async () => {
 		dispatchSettings({ type: "SAVE_START" });
@@ -1236,6 +1316,9 @@ export function SettingsModal({
 			}
 			if (mcpIsDirty) {
 				await mcpSave();
+			}
+			if (editorIsDirty) {
+				await editorSave();
 			}
 			if (draft.telemetryEnabled) {
 				trackEvent("settings_saved");
@@ -1261,6 +1344,8 @@ export function SettingsModal({
 		notionSave,
 		mcpIsDirty,
 		mcpSave,
+		editorIsDirty,
+		editorSave,
 	]);
 
 	const isDirty =
@@ -1270,14 +1355,21 @@ export function SettingsModal({
 		backgroundIsDirty ||
 		reposIsDirty ||
 		notionIsDirty ||
-		mcpIsDirty;
+		mcpIsDirty ||
+		editorIsDirty;
 
 	const sectionContent = (() => {
 		switch (activeSection) {
 			case "appearance":
 				return <AppearanceSection draft={draft} updateDraft={updateDraft} />;
 			case "editor":
-				return <EditorSection draft={draft} updateDraft={updateDraft} />;
+				return (
+					<EditorSection
+						draft={draft}
+						updateDraft={updateDraft}
+						externalEditor={externalEditor}
+					/>
+				);
 			case "repositories":
 				return (
 					<RepositoriesSection

--- a/src/components/panels/SettingsModal.tsx
+++ b/src/components/panels/SettingsModal.tsx
@@ -217,7 +217,7 @@ interface EditorInfo {
 	path: string;
 }
 
-function useExternalEditorConfig() {
+function useExternalEditorConfig(open: boolean) {
 	const [editor, setEditor] = useState("");
 	const [initialEditor, setInitialEditor] = useState("");
 	const [editors, setEditors] = useState<EditorInfo[]>([]);
@@ -225,6 +225,8 @@ function useExternalEditorConfig() {
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
+		if (!open) return;
+		let cancelled = false;
 		setLoading(true);
 		setError(null);
 		Promise.all([
@@ -232,19 +234,33 @@ function useExternalEditorConfig() {
 			invoke<EditorInfo[]>("detect_editors"),
 		])
 			.then(([current, detected]) => {
+				if (cancelled) return;
 				setEditor(current);
 				setInitialEditor(current);
 				setEditors(detected);
 			})
-			.catch((e) => setError(String(e)))
-			.finally(() => setLoading(false));
-	}, []);
+			.catch((e) => {
+				if (!cancelled) setError(String(e));
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open]);
 
 	const isDirty = editor !== initialEditor;
 
 	const save = useCallback(async () => {
-		await invoke("update_external_editor", { editor });
-		setInitialEditor(editor);
+		setError(null);
+		try {
+			await invoke("update_external_editor", { editor });
+			setInitialEditor(editor);
+		} catch (e) {
+			setError(String(e));
+			throw e;
+		}
 	}, [editor]);
 
 	return { editor, setEditor, editors, isDirty, loading, error, save };
@@ -1213,7 +1229,7 @@ export function SettingsModal({
 	const repos = useRepoChanges();
 	const notion = useNotionSettings(repoPaths);
 	const mcp = useMcpConfig();
-	const externalEditor = useExternalEditorConfig();
+	const externalEditor = useExternalEditorConfig(open);
 
 	// Hooks state
 	const [hooks, dispatchHooks] = useReducer(hooksReducer, initialHooksState);

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -163,6 +163,11 @@ const baseIpcHandler: Record<string, unknown> = {
 	get_remote_config: { auto_start: false, auto_start_on_lan: false },
 	update_remote_config: null,
 
+	// External editor
+	get_external_editor: "",
+	detect_editors: [],
+	update_external_editor: null,
+
 	// Repo registry
 	get_repo_paths: ["/test/repo"],
 	add_repo_path: null,


### PR DESCRIPTION
## Summary
- Diffビューに「Open in Editor」ボタンを追加し、選択中のファイルを外部エディタで開けるようにした
- 設定画面（Editor タブ）で外部エディタを選択可能にした（デフォルトはシステムデフォルト）
- エディタ検出（macOS `/Applications` スキャン）・ファイルオープンのロジックはRust側に実装（`tauri_plugin_opener` 使用）

## Test plan
- [ ] Diffビューでファイル選択時に「Open in Editor」ボタンが表示される
- [ ] ボタンクリックでシステムデフォルトアプリケーションでファイルが開く
- [ ] 設定画面 Editor タブで外部エディタを選択・保存できる
- [ ] 選択したエディタでファイルが開く
- [ ] `pnpm test` — 1319テスト全PASS
- [ ] `pnpm lint` / `pnpm build` — PASS
- [ ] `cargo test` — 760テスト全PASS
- [ ] `cargo clippy -- -D warnings` / `cargo fmt --check` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Diff ビューに「エディタで開く」ボタンを追加しました。現在選択されているファイルを外部エディタで素早く開けます
  * 設定画面の「エディタ」タブに外部エディタ設定を追加しました。システムデフォルトまたは指定したエディタを使用できます
  * 複数のエディタを自動検出し、選択リストから簡単に切り替えられます

<!-- end of auto-generated comment: release notes by coderabbit.ai -->