### PR TITLE
feat: diffOnlyMode（差分のみ表示モード）を追加

### DIFF
--- a/docs/spec/issues-795.md
+++ b/docs/spec/issues-795.md
@@ -1,0 +1,122 @@
+## 要求
+
+**種別**: 改善
+**ゴール**: 差分ファイルビューで、変更のあるHunk周辺のみを表示し、変更のない行を折りたたむ（省略する）「差分のみ表示」モードを追加する。全文表示と差分のみ表示を切り替え可能にする。
+**背景**: 現在のgutterモードではファイル全文を表示しつつ変更箇所にマーカーを付けるが、大きなファイルでは変更箇所を見つけにくい。差分のみ表示にすることで、レビュー時に変更箇所に集中できる。
+**影響範囲**: 右パネルの差分表示（CodeDiffViewer / GutterDiffViewer）、DiffToolbar（切り替えUI）
+
+## 振る舞い定義
+
+```gherkin
+Feature: 差分のみ表示モード
+  差分ファイルビューで、変更のあるHunk周辺のみを表示し、
+  変更のない行を折りたたむ（省略する）モードを提供する。
+  全文表示と差分のみ表示を切り替え可能にする。
+
+  Rule: 差分のみ表示モードの切り替え
+    Scenario: 全文表示から差分のみ表示に切り替える
+      Given 差分ファイルビューでファイルが表示されている
+      And 全文表示モードである
+      When ユーザーが差分のみ表示モードに切り替える
+      Then 変更のあるHunk周辺の行のみが表示される
+      And 変更のない行は折りたたまれる
+
+    Scenario: 差分のみ表示から全文表示に切り替える
+      Given 差分ファイルビューでファイルが表示されている
+      And 差分のみ表示モードである
+      When ユーザーが全文表示モードに切り替える
+      Then ファイルの全行が表示される
+
+  Rule: 差分のみ表示における折りたたみ表示
+    Scenario: 変更がないファイルを差分のみ表示で見る
+      Given ファイルに変更がない
+      When 差分のみ表示モードで表示する
+      Then 全ての行が折りたたまれる
+      And 変更がないことがわかる表示になる
+
+    Scenario: 複数のHunkがあるファイルを差分のみ表示で見る
+      Given ファイルに離れた位置に複数のHunkがある
+      When 差分のみ表示モードで表示する
+      Then 各Hunkの変更行と周辺のコンテキスト行が表示される
+      And Hunk間の変更のない行は折りたたまれる
+      And 折りたたまれた箇所には省略されている行数が表示される
+
+  Rule: 折りたたまれた行の展開
+    Scenario: 折りたたまれた箇所を個別に展開する
+      Given 差分のみ表示モードで折りたたまれた箇所がある
+      When ユーザーが折りたたまれた箇所をクリックする
+      Then その箇所の省略されていた行が展開される
+      And 他の折りたたまれた箇所はそのまま維持される
+
+    Scenario: 全ての折りたたみを一括展開する
+      Given 差分のみ表示モードで折りたたまれた箇所がある
+      When ユーザーが全展開ボタンを押す
+      Then 全ての折りたたまれた箇所が展開される
+
+  Rule: 差分のみ表示モードの適用範囲
+    Scenario: 全ての差分表示モード（gutter/inline/split）で差分のみ表示を使う
+      Given いずれかの差分表示モード（gutter, inline, split）が選択されている
+      When 差分のみ表示を有効にする
+      Then 選択中の差分表示モードに関わらず差分のみ表示が適用される
+
+  Rule: デフォルト設定と保持
+    Scenario: 初回起動時のデフォルト
+      Given ユーザーが差分のみ表示の設定を変更したことがない
+      When 差分ファイルビューを開く
+      Then 全文表示モードで表示される
+
+    Scenario: 設定画面からデフォルトを変更する
+      Given 設定画面を開いている
+      When デフォルトの差分表示を「差分のみ表示」に変更する
+      Then 以降新しく開く差分ファイルビューは差分のみ表示モードで表示される
+
+    Scenario: 差分のみ表示の設定がWorkspaceごとに保持される
+      Given Workspace Aで差分のみ表示モードに切り替えた
+      When Workspace Bに移動する
+      Then Workspace Bでは独自の設定が適用される
+
+    Scenario: 同一Workspace内でファイルを切り替えても設定が維持される
+      Given 差分のみ表示モードに切り替えた
+      When 別のファイルを選択する
+      Then 差分のみ表示モードが維持される
+```
+
+## 実装仕様
+
+**対応方針**: 振る舞い定義（差分のみ表示モード）を実現するために、Monaco DiffEditorのビルトイン `hideUnchangedRegions` APIを活用し（inline/split）、GutterモードにはHunkデータベースの独自折りたたみ（setHiddenAreas + ViewZone）を実装する。
+
+**対象コンポーネント**:
+
+Rust（ロジック）:
+- `src-tauri/src/git/hunk.rs`: `compute_hidden_ranges(hunks: Vec<Hunk>, total_lines: u32, context_lines: u32) -> Vec<HiddenRange>` を追加。Hunkデータからコンテキスト行（前後N行）外の非表示範囲を算出する
+- `src-tauri/src/git/hunk.rs`: `compute_visible_markdown_blocks(original: &str, modified: &str, context_lines: u32) -> Vec<VisibleBlock>` を追加。Markdown差分で変更のあるブロックとコンテキスト行のみを抽出する
+- `src-tauri/src/git/types.rs`: `HiddenRange { start_line: u32, end_line: u32, hidden_count: u32 }` と `VisibleBlock { start_line: u32, end_line: u32, content: String }` を追加
+- `src-tauri/src/git/commands.rs`: 上記をTauriコマンドとして公開
+
+フロントエンド（UI）:
+- `src/types/settings.ts`: `AppSettings`に`defaultDiffOnlyMode: boolean`を追加（デフォルト: `false`）
+- `src/hooks/useSettings.ts`: `updateDefaultDiffOnlyMode`アクセサを追加
+- `src/hooks/useReviewPanel.ts`: `diffOnlyMode: boolean`状態と`setDiffOnlyMode`を管理
+- `src/components/panels/DiffToolbar.tsx`: 差分のみ表示トグルボタンを追加（diff mode切り替えの左隣）
+- `src/components/panels/CodeDiffViewer.tsx`:
+  - **MonacoDiffViewer**: `hideUnchangedRegions`オプションを`diffOnlyMode`連動で`updateOptions`切り替え（`contextLineCount: 3`, `minimumLineCount: 3`, `revealLineCount: 20`）
+  - **GutterDiffViewer**: `invoke("compute_hidden_ranges")`で取得した結果を`editor.setHiddenAreas()`に渡して非表示化 + ViewZoneで「… N lines hidden」バナーを表示。バナークリックで個別展開
+- `src/components/panels/MarkdownDiffViewer.tsx`: `invoke("compute_visible_markdown_blocks")`で取得した可視ブロックのみを表示
+- `src/components/panels/ReviewPanel.tsx`: `diffOnlyMode`状態を`DiffToolbar`・`DiffViewerSection`に伝搬
+
+**技術選定**:
+- inline/splitモード: Monaco DiffEditor `hideUnchangedRegions` API（ビルトイン機能。折りたたみ表示・個別展開・省略行数表示を標準提供）
+- gutterモード: Rust側で非表示範囲を算出 → フロントは`ICodeEditor.setHiddenAreas()` + `ViewZone`で表示制御のみ（StandaloneEditorにはDiffEditor機能がないため独自実装が必要）
+- markdownモード: Rust側で可視ブロックを算出 → フロントは受け取ったブロックを描画するのみ
+
+**検討した代替案**:
+- GutterモードでもDiffEditorに切り替える案: Gutterモード固有機能（コメントスレッド、Stage overlay、glyphMargin装飾）がDiffEditorでは動作しないため却下
+- 全モード共通でHunk計算ベースの独自折りたたみ: inline/splitはMonaco DiffEditorのビルトインの方がUX（アニメーション、省略行数表示、展開UI）が優れるため却下
+
+**リスク**:
+- `setHiddenAreas`はMonaco公式APIとして`ICodeEditor`に存在するが、ドキュメントが薄い → 実際にVSCodeで広く使われているため低リスク
+
+**影響するテスト**:
+- Rust: `hunk.rs`内に`compute_hidden_ranges`・`compute_visible_markdown_blocks`の単体テスト（正常系・境界値・変更なし・全行変更）
+- フロントエンド単体テスト: `CodeDiffViewer.test.tsx`（diffOnlyMode propsの受け渡し）、`DiffToolbar.test.tsx`（トグルボタンのクリックイベント）
+- フック: `useReviewPanel`のdiffOnlyMode状態管理テスト

--- a/docs/spec/issues-795.md
+++ b/docs/spec/issues-795.md
@@ -96,11 +96,11 @@ Rust（ロジック）:
 フロントエンド（UI）:
 - `src/types/settings.ts`: `AppSettings`に`defaultDiffOnlyMode: boolean`を追加（デフォルト: `false`）
 - `src/hooks/useSettings.ts`: `updateDefaultDiffOnlyMode`アクセサを追加
-- `src/hooks/useReviewPanel.ts`: `diffOnlyMode: boolean`状態と`setDiffOnlyMode`を管理
+- `src/screens/useWorktreeState.tsx`: Workspaceごとの`diffOnlyMode: boolean`状態と`setDiffOnlyMode`を管理
 - `src/components/panels/DiffToolbar.tsx`: 差分のみ表示トグルボタンを追加（diff mode切り替えの左隣）
 - `src/components/panels/CodeDiffViewer.tsx`:
   - **MonacoDiffViewer**: `hideUnchangedRegions`オプションを`diffOnlyMode`連動で`updateOptions`切り替え（`contextLineCount: 3`, `minimumLineCount: 3`, `revealLineCount: 20`）
-  - **GutterDiffViewer**: `invoke("compute_hidden_ranges")`で取得した結果を`editor.setHiddenAreas()`に渡して非表示化 + ViewZoneで「… N lines hidden」バナーを表示。バナークリックで個別展開
+  - **GutterDiffViewer**: `invoke("compute_hidden_ranges_from_content")`で取得した結果を`editor.setHiddenAreas()`に渡して非表示化 + ViewZoneで「… N lines hidden」バナーを表示。バナークリックで個別展開
 - `src/components/panels/MarkdownDiffViewer.tsx`: `invoke("compute_visible_markdown_blocks")`で取得した可視ブロックのみを表示
 - `src/components/panels/ReviewPanel.tsx`: `diffOnlyMode`状態を`DiffToolbar`・`DiffViewerSection`に伝搬
 

--- a/src-tauri/src/git/commands.rs
+++ b/src-tauri/src/git/commands.rs
@@ -262,6 +262,54 @@ pub async fn generate_group_patch(
 }
 
 #[tauri::command]
+pub async fn compute_hidden_ranges(
+    hunks: Vec<super::types::Hunk>,
+    total_lines: u32,
+    context_lines: u32,
+) -> Result<Vec<super::types::HiddenRange>, GitError> {
+    blocking(move || {
+        Ok(super::hunk::compute_hidden_ranges(
+            &hunks,
+            total_lines,
+            context_lines,
+        ))
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn compute_hidden_ranges_from_content(
+    original: String,
+    modified: String,
+    context_lines: u32,
+) -> Result<Vec<super::types::HiddenRange>, GitError> {
+    blocking(move || {
+        Ok(super::hunk::compute_hidden_ranges_from_content(
+            &original,
+            &modified,
+            context_lines,
+        ))
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn compute_visible_markdown_blocks(
+    original: String,
+    modified: String,
+    context_lines: u32,
+) -> Result<Vec<super::types::VisibleBlock>, GitError> {
+    blocking(move || {
+        Ok(super::hunk::compute_visible_markdown_blocks(
+            &original,
+            &modified,
+            context_lines,
+        ))
+    })
+    .await
+}
+
+#[tauri::command]
 pub async fn get_language_from_path(file_path: String) -> Result<String, GitError> {
     blocking(move || Ok(super::lang::get_language_from_path(&file_path))).await
 }

--- a/src-tauri/src/git/hunk.rs
+++ b/src-tauri/src/git/hunk.rs
@@ -396,6 +396,7 @@ pub fn compute_visible_markdown_blocks(
 ) -> Vec<VisibleBlock> {
     let hunks_result = compute_diff_hunks(original, modified, None);
     let mod_lines: Vec<&str> = modified.lines().collect();
+    let orig_lines: Vec<&str> = original.lines().collect();
     let total_lines = mod_lines.len() as u32;
 
     if hunks_result.hunks.is_empty() {
@@ -404,17 +405,48 @@ pub fn compute_visible_markdown_blocks(
 
     let merged = compute_visible_ranges(&hunks_result.hunks, total_lines, context_lines);
 
-    // Build visible blocks from merged ranges
+    // Build visible blocks from merged ranges, including deleted content
     merged
         .iter()
         .map(|(start, end)| {
             let s = (*start as usize).saturating_sub(1);
             let e = (*end as usize).min(mod_lines.len());
             let content = mod_lines[s..e].join("\n");
+
+            // Collect deleted lines from hunks that overlap this visible range
+            let mut deleted: Vec<&str> = Vec::new();
+            for hunk in &hunks_result.hunks {
+                let hunk_mod_start = hunk.new_start;
+                let hunk_mod_end = hunk.new_start + hunk.new_lines.max(1) - 1;
+                // Check if hunk overlaps with this visible range
+                if hunk_mod_end >= *start && hunk_mod_start <= *end {
+                    // Extract deleted lines (lines starting with '-') from original
+                    let mut orig_line = hunk.old_start as usize;
+                    for line in &hunk.lines {
+                        let prefix = line.as_bytes().first().copied().unwrap_or(b' ');
+                        if prefix == b'-' {
+                            if orig_line >= 1 && orig_line <= orig_lines.len() {
+                                deleted.push(orig_lines[orig_line - 1]);
+                            }
+                            orig_line += 1;
+                        } else if prefix == b' ' {
+                            orig_line += 1;
+                        }
+                    }
+                }
+            }
+
+            let deleted_content = if deleted.is_empty() {
+                None
+            } else {
+                Some(deleted.join("\n"))
+            };
+
             VisibleBlock {
                 start_line: *start,
                 end_line: *end,
                 content,
+                deleted_content,
             }
         })
         .collect()

--- a/src-tauri/src/git/hunk.rs
+++ b/src-tauri/src/git/hunk.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use super::types::{ChangeGroup, DiffHunksResult, Hunk};
+use super::types::{ChangeGroup, DiffHunksResult, HiddenRange, Hunk, VisibleBlock};
 
 /// Compute diff hunks and change groups from two text buffers.
 ///
@@ -292,6 +292,132 @@ pub fn generate_patch(file_path: &str, hunks: &[Hunk], selected_indices: &[u32])
     }
 
     format!("{}\n", lines.join("\n"))
+}
+
+/// Compute hidden (foldable) line ranges for diff-only mode in the Gutter viewer.
+///
+/// Given a list of hunks and the total line count of the modified file,
+/// Compute merged visible line ranges around each hunk with context.
+fn compute_visible_ranges(hunks: &[Hunk], total_lines: u32, context_lines: u32) -> Vec<(u32, u32)> {
+    let mut visible_ranges: Vec<(u32, u32)> = Vec::new();
+    for hunk in hunks {
+        let hunk_start = hunk.new_start;
+        let hunk_end = hunk.new_start + hunk.new_lines.max(1) - 1;
+
+        let visible_start = if hunk_start > context_lines {
+            hunk_start - context_lines
+        } else {
+            1
+        };
+        let visible_end = (hunk_end + context_lines).min(total_lines);
+        visible_ranges.push((visible_start, visible_end));
+    }
+
+    visible_ranges.sort_by_key(|r| r.0);
+    let mut merged: Vec<(u32, u32)> = Vec::new();
+    for range in &visible_ranges {
+        if let Some(last) = merged.last_mut() {
+            if range.0 <= last.1 + 1 {
+                last.1 = last.1.max(range.1);
+            } else {
+                merged.push(*range);
+            }
+        } else {
+            merged.push(*range);
+        }
+    }
+    merged
+}
+
+/// returns the ranges of lines that should be hidden (folded) because they
+/// contain no changes. Each hunk is surrounded by `context_lines` of visible
+/// context.
+pub fn compute_hidden_ranges(
+    hunks: &[Hunk],
+    total_lines: u32,
+    context_lines: u32,
+) -> Vec<HiddenRange> {
+    if total_lines == 0 {
+        return Vec::new();
+    }
+
+    let merged = compute_visible_ranges(hunks, total_lines, context_lines);
+
+    // Compute hidden ranges (gaps between visible ranges)
+    let mut hidden: Vec<HiddenRange> = Vec::new();
+    let mut current = 1u32;
+
+    for (vis_start, vis_end) in &merged {
+        if current < *vis_start {
+            let count = vis_start - current;
+            hidden.push(HiddenRange {
+                start_line: current,
+                end_line: vis_start - 1,
+                hidden_count: count,
+            });
+        }
+        current = vis_end + 1;
+    }
+
+    // Trailing hidden range after last visible block
+    if current <= total_lines {
+        let count = total_lines - current + 1;
+        hidden.push(HiddenRange {
+            start_line: current,
+            end_line: total_lines,
+            hidden_count: count,
+        });
+    }
+
+    hidden
+}
+
+/// Compute hidden ranges directly from content strings.
+///
+/// Internally diffs `original` against `modified` and then computes hidden ranges.
+pub fn compute_hidden_ranges_from_content(
+    original: &str,
+    modified: &str,
+    context_lines: u32,
+) -> Vec<HiddenRange> {
+    let hunks_result = compute_diff_hunks(original, modified, None);
+    let total_lines = modified.lines().count() as u32;
+    compute_hidden_ranges(&hunks_result.hunks, total_lines, context_lines)
+}
+
+/// Compute visible blocks for Markdown diff-only mode.
+///
+/// Diffs `original` against `modified` and returns only the blocks
+/// (with surrounding context lines) that contain changes.
+pub fn compute_visible_markdown_blocks(
+    original: &str,
+    modified: &str,
+    context_lines: u32,
+) -> Vec<VisibleBlock> {
+    let hunks_result = compute_diff_hunks(original, modified, None);
+    let mod_lines: Vec<&str> = modified.lines().collect();
+    let total_lines = mod_lines.len() as u32;
+
+    if hunks_result.hunks.is_empty() {
+        return Vec::new();
+    }
+
+    let merged = compute_visible_ranges(&hunks_result.hunks, total_lines, context_lines);
+
+    // Build visible blocks from merged ranges
+    merged
+        .iter()
+        .map(|(start, end)| {
+            let s = (*start as usize).saturating_sub(1);
+            let e = (*end as usize).min(mod_lines.len());
+            let content = mod_lines[s..e].join("\n");
+            VisibleBlock {
+                start_line: *start,
+                end_line: *end,
+                content,
+            }
+        })
+        .collect()
 }
 
 /// Convert an absolute file path to a repository-relative path.
@@ -600,5 +726,234 @@ mod tests {
     fn relative_path_no_prefix() {
         let result = get_relative_path("/Users/foo/project", "other/path.ts");
         assert_eq!(result, Some("other/path.ts".to_string()));
+    }
+
+    // ── compute_hidden_ranges ──
+
+    #[test]
+    fn hidden_ranges_no_hunks() {
+        let result = compute_hidden_ranges(&[], 100, 3);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start_line, 1);
+        assert_eq!(result[0].end_line, 100);
+        assert_eq!(result[0].hidden_count, 100);
+    }
+
+    #[test]
+    fn hidden_ranges_zero_total_lines() {
+        let result = compute_hidden_ranges(&[], 0, 3);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn hidden_ranges_single_hunk_at_start() {
+        let hunks = vec![Hunk {
+            index: 0,
+            old_start: 1,
+            old_lines: 2,
+            new_start: 1,
+            new_lines: 3,
+            lines: vec![
+                "-old".to_string(),
+                "+new1".to_string(),
+                "+new2".to_string(),
+                " ctx".to_string(),
+            ],
+        }];
+        let result = compute_hidden_ranges(&hunks, 20, 3);
+        // Hunk covers lines 1-3, context extends to 6
+        // Hidden: 7-20
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start_line, 7);
+        assert_eq!(result[0].end_line, 20);
+    }
+
+    #[test]
+    fn hidden_ranges_single_hunk_in_middle() {
+        let hunks = vec![Hunk {
+            index: 0,
+            old_start: 10,
+            old_lines: 2,
+            new_start: 10,
+            new_lines: 2,
+            lines: vec!["-old".to_string(), "+new".to_string()],
+        }];
+        let result = compute_hidden_ranges(&hunks, 20, 3);
+        // Hunk covers lines 10-11, context extends to 7-14
+        // Hidden: 1-6, 15-20
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].start_line, 1);
+        assert_eq!(result[0].end_line, 6);
+        assert_eq!(result[1].start_line, 15);
+        assert_eq!(result[1].end_line, 20);
+    }
+
+    #[test]
+    fn hidden_ranges_adjacent_hunks_merge() {
+        let hunks = vec![
+            Hunk {
+                index: 0,
+                old_start: 5,
+                old_lines: 1,
+                new_start: 5,
+                new_lines: 1,
+                lines: vec!["-a".to_string(), "+b".to_string()],
+            },
+            Hunk {
+                index: 1,
+                old_start: 8,
+                old_lines: 1,
+                new_start: 8,
+                new_lines: 1,
+                lines: vec!["-c".to_string(), "+d".to_string()],
+            },
+        ];
+        // context=3: hunk0 visible 2-8, hunk1 visible 5-11 → merged 2-11
+        let result = compute_hidden_ranges(&hunks, 20, 3);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].start_line, 1);
+        assert_eq!(result[0].end_line, 1);
+        assert_eq!(result[1].start_line, 12);
+        assert_eq!(result[1].end_line, 20);
+    }
+
+    #[test]
+    fn hidden_ranges_all_lines_changed() {
+        let hunks = vec![Hunk {
+            index: 0,
+            old_start: 1,
+            old_lines: 5,
+            new_start: 1,
+            new_lines: 5,
+            lines: vec![
+                "-a".to_string(),
+                "-b".to_string(),
+                "-c".to_string(),
+                "-d".to_string(),
+                "-e".to_string(),
+                "+A".to_string(),
+                "+B".to_string(),
+                "+C".to_string(),
+                "+D".to_string(),
+                "+E".to_string(),
+            ],
+        }];
+        let result = compute_hidden_ranges(&hunks, 5, 3);
+        assert!(result.is_empty());
+    }
+
+    // ── compute_visible_ranges (shared helper) ──
+
+    #[test]
+    fn visible_ranges_empty_hunks() {
+        let result = compute_visible_ranges(&[], 100, 3);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn visible_ranges_single_hunk() {
+        let hunks = vec![Hunk {
+            index: 0,
+            old_start: 10,
+            old_lines: 2,
+            new_start: 10,
+            new_lines: 2,
+            lines: vec!["-old".to_string(), "+new".to_string()],
+        }];
+        let result = compute_visible_ranges(&hunks, 20, 3);
+        assert_eq!(result, vec![(7, 14)]);
+    }
+
+    #[test]
+    fn visible_ranges_delete_only_hunk() {
+        let hunks = vec![Hunk {
+            index: 0,
+            old_start: 5,
+            old_lines: 3,
+            new_start: 5,
+            new_lines: 0,
+            lines: vec!["-a".to_string(), "-b".to_string(), "-c".to_string()],
+        }];
+        let result = compute_visible_ranges(&hunks, 20, 3);
+        assert_eq!(result, vec![(2, 8)]);
+    }
+
+    #[test]
+    fn visible_ranges_overlapping_merge() {
+        let hunks = vec![
+            Hunk {
+                index: 0,
+                old_start: 5,
+                old_lines: 1,
+                new_start: 5,
+                new_lines: 1,
+                lines: vec!["-a".to_string(), "+b".to_string()],
+            },
+            Hunk {
+                index: 1,
+                old_start: 8,
+                old_lines: 1,
+                new_start: 8,
+                new_lines: 1,
+                lines: vec!["-c".to_string(), "+d".to_string()],
+            },
+        ];
+        let result = compute_visible_ranges(&hunks, 20, 3);
+        assert_eq!(result, vec![(2, 11)]);
+    }
+
+    // ── compute_hidden_ranges_from_content ──
+
+    #[test]
+    fn hidden_ranges_from_content_no_changes() {
+        let text = "line1\nline2\nline3\n";
+        let result = compute_hidden_ranges_from_content(text, text, 3);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start_line, 1);
+    }
+
+    #[test]
+    fn hidden_ranges_from_content_with_change() {
+        // Use a large file so hidden ranges exist outside the hunk + context
+        let lines: Vec<String> = (1..=30).map(|i| format!("line{i}")).collect();
+        let original = lines.join("\n");
+        let mut modified_lines = lines.clone();
+        modified_lines[14] = "CHANGED15".to_string(); // Change line 15
+        let modified = modified_lines.join("\n");
+        let result = compute_hidden_ranges_from_content(&original, &modified, 3);
+        // With 30 lines and a change around line 15, there should be hidden ranges
+        // before and after the visible context around the hunk
+        assert!(
+            !result.is_empty(),
+            "expected hidden ranges for a 30-line file with change at line 15"
+        );
+    }
+
+    // ── compute_visible_markdown_blocks ──
+
+    #[test]
+    fn visible_blocks_no_changes() {
+        let text = "line1\nline2\nline3\n";
+        let result = compute_visible_markdown_blocks(text, text, 3);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn visible_blocks_single_change() {
+        let original = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n";
+        let modified = "a\nb\nc\nd\nE\nf\ng\nh\ni\nj\n";
+        let result = compute_visible_markdown_blocks(original, modified, 2);
+        assert_eq!(result.len(), 1);
+        assert!(result[0].content.contains("E"));
+        assert!(result[0].start_line <= 5);
+        assert!(result[0].end_line >= 5);
+    }
+
+    #[test]
+    fn visible_blocks_multiple_changes() {
+        let original = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\n";
+        let modified = original.replace("b\n", "B\n").replace("s\n", "S\n");
+        let result = compute_visible_markdown_blocks(original, &modified, 2);
+        assert_eq!(result.len(), 2);
     }
 }

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -92,6 +92,8 @@ pub struct VisibleBlock {
     pub start_line: u32,
     pub end_line: u32,
     pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_content: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -76,6 +76,24 @@ pub struct DiffHunksResult {
     pub change_groups: Vec<ChangeGroup>,
 }
 
+// ── HiddenRange / VisibleBlock (diff-only mode) ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HiddenRange {
+    pub start_line: u32,
+    pub end_line: u32,
+    pub hidden_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VisibleBlock {
+    pub start_line: u32,
+    pub end_line: u32,
+    pub content: String,
+}
+
 #[derive(Serialize)]
 pub struct WorktreeBranch {
     pub name: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -222,6 +222,9 @@ pub fn run() {
             git::commands::get_file_navigation,
             // Git: hunk/patch
             git::commands::compute_diff_hunks,
+            git::commands::compute_hidden_ranges,
+            git::commands::compute_hidden_ranges_from_content,
+            git::commands::compute_visible_markdown_blocks,
             git::commands::generate_group_patch,
             git::commands::get_language_from_path,
             git::commands::get_relative_path,

--- a/src/components/panels/CodeDiffViewer.tsx
+++ b/src/components/panels/CodeDiffViewer.tsx
@@ -1,7 +1,7 @@
 import { loader } from "@monaco-editor/react";
 import { invoke } from "@tauri-apps/api/core";
 import type * as Monaco from "monaco-editor";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	computeDiff,
 	createDiffDecorations,
@@ -17,10 +17,17 @@ import {
 } from "@/lib/monaco-config";
 import type { DiffMode } from "@/types/settings";
 
+interface HiddenRange {
+	startLine: number;
+	endLine: number;
+	hiddenCount: number;
+}
+
 export interface CodeDiffViewerProps {
 	originalContent: string;
 	modifiedContent: string;
 	diffMode: DiffMode;
+	diffOnlyMode?: boolean;
 	language?: string;
 	filePath?: string;
 	changeGroups?: ChangeGroup[];
@@ -72,6 +79,7 @@ function GutterDiffViewer({
 	originalContent,
 	modifiedContent,
 	language,
+	diffOnlyMode,
 	changeGroups,
 	onStageGroup,
 	groupActionLabel,
@@ -79,6 +87,7 @@ function GutterDiffViewer({
 	originalContent: string;
 	modifiedContent: string;
 	language: string;
+	diffOnlyMode?: boolean;
 	changeGroups?: ChangeGroup[];
 	onStageGroup?: (groupIndex: number) => void;
 	groupActionLabel?: string;
@@ -88,6 +97,10 @@ function GutterDiffViewer({
 	const monacoRef = useRef<typeof Monaco | null>(null);
 	const decorationsRef = useRef<string[]>([]);
 	const overlayRef = useRef<HTMLDivElement>(null);
+	const viewZoneIdsRef = useRef<string[]>([]);
+	const [hiddenRanges, setHiddenRanges] = useState<HiddenRange[]>([]);
+	const hiddenRangesRef = useRef<HiddenRange[]>([]);
+	const [editorReady, setEditorReady] = useState(false);
 
 	// Always-latest refs so the async init callback sees current values
 	const latestOriginalRef = useRef(originalContent);
@@ -152,6 +165,7 @@ function GutterDiffViewer({
 			requestAnimationFrame(refreshOverlay);
 
 			editorRef.current = editor;
+			setEditorReady(true);
 		});
 
 		return () => {
@@ -162,27 +176,48 @@ function GutterDiffViewer({
 				editor.dispose();
 				editorRef.current = null;
 			}
+			setEditorReady(false);
 		};
 	}, []);
 
-	// Update content + decorations
+	// Helper: apply content + decorations to editor
+	const applyContentAndDecorations = useCallback(
+		(
+			editor: Monaco.editor.IStandaloneCodeEditor,
+			monaco: typeof Monaco,
+			original: string,
+			modified: string,
+		) => {
+			const model = editor.getModel();
+			if (model && model.getValue() !== modified) {
+				model.setValue(modified);
+			}
+			const diff = computeDiff(original, modified);
+			const newDecorations = createDiffDecorations(diff, monaco);
+			decorationsRef.current = editor.deltaDecorations(
+				decorationsRef.current,
+				newDecorations,
+			);
+		},
+		[],
+	);
+
+	// Update content + decorations (only when diffOnlyMode is OFF)
+	// When diffOnlyMode is ON, updates are deferred to the combined effect below
+	// to avoid showing stale decorations while hidden ranges are being recomputed.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: diffOnlyMode controls which branch handles content updates
 	useEffect(() => {
+		if (diffOnlyMode) return;
 		const editor = editorRef.current;
 		const monaco = monacoRef.current;
 		if (!editor || !monaco) return;
-
-		const model = editor.getModel();
-		if (model && model.getValue() !== modifiedContent) {
-			model.setValue(modifiedContent);
-		}
-
-		const diff = computeDiff(originalContent, modifiedContent);
-		const newDecorations = createDiffDecorations(diff, monaco);
-		decorationsRef.current = editor.deltaDecorations(
-			decorationsRef.current,
-			newDecorations,
+		applyContentAndDecorations(
+			editor,
+			monaco,
+			originalContent,
+			modifiedContent,
 		);
-	}, [originalContent, modifiedContent]);
+	}, [originalContent, modifiedContent, diffOnlyMode]);
 
 	// Update stage overlay when changeGroups change
 	useEffect(() => {
@@ -209,12 +244,142 @@ function GutterDiffViewer({
 		}
 	}, [language]);
 
+	// Compute hidden ranges + update content/decorations atomically.
+	// When diffOnlyMode is ON, content and decoration updates are batched
+	// with hidden range computation to prevent the flash of full content
+	// that occurs when decorations update before hidden ranges are ready.
+	useEffect(() => {
+		if (!diffOnlyMode) {
+			hiddenRangesRef.current = [];
+			setHiddenRanges([]);
+			return;
+		}
+
+		let cancelled = false;
+
+		invoke<HiddenRange[]>("compute_hidden_ranges_from_content", {
+			original: originalContent,
+			modified: modifiedContent,
+			contextLines: 3,
+		})
+			.then((ranges) => {
+				if (cancelled) return;
+				// Apply content + decorations + hidden ranges together
+				const editor = editorRef.current;
+				const monaco = monacoRef.current;
+				if (editor && monaco) {
+					applyContentAndDecorations(
+						editor,
+						monaco,
+						originalContent,
+						modifiedContent,
+					);
+				}
+				hiddenRangesRef.current = ranges;
+				setHiddenRanges(ranges);
+			})
+			.catch(() => {
+				if (cancelled) return;
+				const editor = editorRef.current;
+				const monaco = monacoRef.current;
+				if (editor && monaco) {
+					applyContentAndDecorations(
+						editor,
+						monaco,
+						originalContent,
+						modifiedContent,
+					);
+				}
+				hiddenRangesRef.current = [];
+				setHiddenRanges([]);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		diffOnlyMode,
+		originalContent,
+		modifiedContent,
+		applyContentAndDecorations,
+	]);
+
+	// Apply/remove hidden areas + view zones
+	useEffect(() => {
+		if (!editorReady) return;
+		const editor = editorRef.current;
+		const monaco = monacoRef.current;
+		if (!editor || !monaco) return;
+
+		// Remove old view zones
+		editor.changeViewZones((accessor) => {
+			for (const id of viewZoneIdsRef.current) {
+				accessor.removeZone(id);
+			}
+		});
+		viewZoneIdsRef.current = [];
+
+		if (!diffOnlyMode || hiddenRanges.length === 0) {
+			// Clear hidden areas
+			// biome-ignore lint/suspicious/noExplicitAny: setHiddenAreas is internal Monaco API
+			(editor as any).setHiddenAreas?.([]);
+			return;
+		}
+
+		// Set hidden areas
+		const areas = hiddenRanges.map(
+			(r) => new monaco.Range(r.startLine, 1, r.endLine, 1),
+		);
+		// biome-ignore lint/suspicious/noExplicitAny: setHiddenAreas is internal Monaco API
+		(editor as any).setHiddenAreas?.(areas);
+
+		// Add view zones (banners) before each hidden area
+		const newZoneIds: string[] = [];
+		editor.changeViewZones((accessor) => {
+			for (const range of hiddenRanges) {
+				const domNode = document.createElement("div");
+				domNode.className =
+					"hidden-lines-banner flex items-center justify-center text-xs text-muted-foreground cursor-pointer hover:bg-muted/50 border-y border-border";
+				domNode.style.height = "22px";
+				domNode.textContent = `··· ${range.hiddenCount} lines hidden ···`;
+				domNode.addEventListener("click", () => {
+					// Expand this specific range
+					setHiddenRanges((prev) => {
+						const next = prev.filter(
+							(r) =>
+								r.startLine !== range.startLine || r.endLine !== range.endLine,
+						);
+						hiddenRangesRef.current = next;
+						return next;
+					});
+				});
+
+				const id = accessor.addZone({
+					afterLineNumber: range.startLine - 1,
+					heightInPx: 22,
+					domNode,
+				});
+				newZoneIds.push(id);
+			}
+		});
+		viewZoneIdsRef.current = newZoneIds;
+	}, [editorReady, diffOnlyMode, hiddenRanges]);
+
 	return (
 		<div className="h-full w-full relative" data-testid="code-diff-viewer">
 			<div ref={containerRef} className="h-full w-full" />
 			<div ref={overlayRef} className="hunk-overlay-container" />
 		</div>
 	);
+}
+
+function buildHideUnchangedRegionsOption(enabled: boolean) {
+	return {
+		enabled,
+		contextLineCount: 3,
+		minimumLineCount: 3,
+		revealLineCount: 20,
+	};
 }
 
 /**
@@ -224,6 +389,7 @@ function MonacoDiffViewer({
 	originalContent,
 	modifiedContent,
 	diffMode,
+	diffOnlyMode,
 	language,
 	changeGroups,
 	onStageGroup,
@@ -232,6 +398,7 @@ function MonacoDiffViewer({
 	originalContent: string;
 	modifiedContent: string;
 	diffMode: DiffMode;
+	diffOnlyMode?: boolean;
 	language: string;
 	changeGroups?: ChangeGroup[];
 	onStageGroup?: (groupIndex: number) => void;
@@ -241,12 +408,14 @@ function MonacoDiffViewer({
 	const editorRef = useRef<Monaco.editor.IDiffEditor | null>(null);
 	const monacoRef = useRef<typeof Monaco | null>(null);
 	const overlayRef = useRef<HTMLDivElement>(null);
+	const [editorReady, setEditorReady] = useState(false);
 
 	// Always-latest refs so the async init callback sees current values
 	const latestOriginalRef = useRef(originalContent);
 	const latestModifiedRef = useRef(modifiedContent);
 	const latestLanguageRef = useRef(language);
 	const latestDiffModeRef = useRef(diffMode);
+	const latestDiffOnlyModeRef = useRef(diffOnlyMode);
 	const changeGroupsRef = useRef(changeGroups);
 	const onStageGroupRef = useRef(onStageGroup);
 	const groupActionLabelRef = useRef(groupActionLabel);
@@ -254,6 +423,7 @@ function MonacoDiffViewer({
 	latestModifiedRef.current = modifiedContent;
 	latestLanguageRef.current = language;
 	latestDiffModeRef.current = diffMode;
+	latestDiffOnlyModeRef.current = diffOnlyMode;
 	changeGroupsRef.current = changeGroups;
 	onStageGroupRef.current = onStageGroup;
 	groupActionLabelRef.current = groupActionLabel;
@@ -277,6 +447,9 @@ function MonacoDiffViewer({
 				useInlineViewWhenSpaceIsLimited: false,
 				glyphMargin: true,
 				theme: MONACO_DARK_THEME_NAME,
+				hideUnchangedRegions: buildHideUnchangedRegionsOption(
+					!!latestDiffOnlyModeRef.current,
+				),
 			});
 
 			const originalModel = monaco.editor.createModel(
@@ -308,6 +481,7 @@ function MonacoDiffViewer({
 			requestAnimationFrame(refreshOverlay);
 
 			editorRef.current = editor;
+			setEditorReady(true);
 		});
 
 		return () => {
@@ -320,22 +494,43 @@ function MonacoDiffViewer({
 				editor.dispose();
 				editorRef.current = null;
 			}
+			setEditorReady(false);
 		};
 	}, []);
 
 	// Update content
 	useEffect(() => {
 		const editor = editorRef.current;
-		if (!editor) return;
+		const monaco = monacoRef.current;
+		if (!editor || !monaco) return;
 
-		const model = editor.getModel();
-		if (model) {
-			if (model.original.getValue() !== originalContent) {
-				model.original.setValue(originalContent);
-			}
-			if (model.modified.getValue() !== modifiedContent) {
-				model.modified.setValue(modifiedContent);
-			}
+		const currentModel = editor.getModel();
+		if (!currentModel) return;
+
+		const origChanged = currentModel.original.getValue() !== originalContent;
+		const modChanged = currentModel.modified.getValue() !== modifiedContent;
+
+		if (!origChanged && !modChanged) return;
+
+		if (latestDiffOnlyModeRef.current) {
+			// When diffOnlyMode is on, recreate models instead of using setValue.
+			// setValue causes Monaco to expand collapsed hideUnchangedRegions
+			// during async diff recomputation. Recreating models forces Monaco
+			// to compute a fresh diff with hideUnchangedRegions applied correctly.
+			const newOriginal = monaco.editor.createModel(
+				originalContent,
+				latestLanguageRef.current,
+			);
+			const newModified = monaco.editor.createModel(
+				modifiedContent,
+				latestLanguageRef.current,
+			);
+			editor.setModel({ original: newOriginal, modified: newModified });
+			currentModel.original.dispose();
+			currentModel.modified.dispose();
+		} else {
+			if (origChanged) currentModel.original.setValue(originalContent);
+			if (modChanged) currentModel.modified.setValue(modifiedContent);
 		}
 	}, [originalContent, modifiedContent]);
 
@@ -374,6 +569,17 @@ function MonacoDiffViewer({
 		editor.updateOptions({ renderSideBySide: diffMode === "split" });
 	}, [diffMode]);
 
+	// Update hideUnchangedRegions based on diffOnlyMode
+	useEffect(() => {
+		if (!editorReady) return;
+		const editor = editorRef.current;
+		if (!editor) return;
+
+		editor.updateOptions({
+			hideUnchangedRegions: buildHideUnchangedRegionsOption(!!diffOnlyMode),
+		});
+	}, [editorReady, diffOnlyMode]);
+
 	return (
 		<div className="h-full w-full relative" data-testid="code-diff-viewer">
 			<div ref={containerRef} className="h-full w-full" />
@@ -386,6 +592,7 @@ export function CodeDiffViewer({
 	originalContent,
 	modifiedContent,
 	diffMode,
+	diffOnlyMode,
 	language,
 	filePath,
 	changeGroups,
@@ -419,6 +626,7 @@ export function CodeDiffViewer({
 				originalContent={originalContent}
 				modifiedContent={modifiedContent}
 				language={resolvedLanguage}
+				diffOnlyMode={diffOnlyMode}
 				changeGroups={changeGroups}
 				onStageGroup={onStageGroup}
 				groupActionLabel={groupActionLabel}
@@ -432,6 +640,7 @@ export function CodeDiffViewer({
 			originalContent={originalContent}
 			modifiedContent={modifiedContent}
 			diffMode={diffMode}
+			diffOnlyMode={diffOnlyMode}
 			language={resolvedLanguage}
 			changeGroups={changeGroups}
 			onStageGroup={onStageGroup}

--- a/src/components/panels/DiffToolbar.test.tsx
+++ b/src/components/panels/DiffToolbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { DiffToolbarProps } from "./DiffToolbar";
@@ -17,7 +17,9 @@ if (typeof Element.prototype.releasePointerCapture !== "function") {
 
 const defaultProps: DiffToolbarProps = {
 	diffMode: "inline",
+	diffOnlyMode: false,
 	onDiffModeChange: vi.fn(),
+	onDiffOnlyModeChange: vi.fn(),
 };
 
 function renderToolbar(props: Partial<DiffToolbarProps> = {}) {
@@ -63,6 +65,41 @@ describe("DiffToolbar", () => {
 				"aria-pressed",
 				"false",
 			);
+		});
+	});
+
+	describe("diff only mode toggle", () => {
+		it("should render Diff only button", () => {
+			renderToolbar();
+
+			expect(
+				screen.getByRole("button", { name: "Diff only" }),
+			).toBeInTheDocument();
+		});
+
+		it("should mark diff only button as pressed when enabled", () => {
+			renderToolbar({ diffOnlyMode: true });
+
+			expect(screen.getByRole("button", { name: "Diff only" })).toHaveAttribute(
+				"aria-pressed",
+				"true",
+			);
+		});
+
+		it("should call onDiffOnlyModeChange(true) when clicking Diff only while disabled", () => {
+			const onChange = vi.fn();
+			renderToolbar({ diffOnlyMode: false, onDiffOnlyModeChange: onChange });
+
+			fireEvent.click(screen.getByRole("button", { name: "Diff only" }));
+			expect(onChange).toHaveBeenCalledWith(true);
+		});
+
+		it("should call onDiffOnlyModeChange(false) when clicking Diff only while enabled", () => {
+			const onChange = vi.fn();
+			renderToolbar({ diffOnlyMode: true, onDiffOnlyModeChange: onChange });
+
+			fireEvent.click(screen.getByRole("button", { name: "Diff only" }));
+			expect(onChange).toHaveBeenCalledWith(false);
 		});
 	});
 

--- a/src/components/panels/DiffToolbar.tsx
+++ b/src/components/panels/DiffToolbar.tsx
@@ -2,6 +2,7 @@ import {
 	AlignJustify,
 	ChevronLeft,
 	ChevronRight,
+	Diff,
 	Minus,
 	SplitSquareHorizontal,
 } from "lucide-react";
@@ -17,7 +18,9 @@ import type { DiffMode } from "@/types/settings";
 
 export interface DiffToolbarProps {
 	diffMode: DiffMode;
+	diffOnlyMode: boolean;
 	onDiffModeChange: (mode: DiffMode) => void;
+	onDiffOnlyModeChange: (enabled: boolean) => void;
 	fileNavigation?: FileNavigationResult;
 	onGoToPrevFile?: () => void;
 	onGoToNextFile?: () => void;
@@ -31,7 +34,9 @@ const diffModes: { mode: DiffMode; icon: typeof Minus; label: string }[] = [
 
 export function DiffToolbar({
 	diffMode,
+	diffOnlyMode,
 	onDiffModeChange,
+	onDiffOnlyModeChange,
 	fileNavigation,
 	onGoToPrevFile,
 	onGoToNextFile,
@@ -74,8 +79,31 @@ export function DiffToolbar({
 				</div>
 			)}
 
-			{/* Right: Diff mode icons */}
+			{/* Right: Diff-only toggle + Diff mode icons */}
 			<div className="flex items-center gap-1">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon-xs"
+							aria-label="Diff only"
+							aria-pressed={diffOnlyMode}
+							onClick={() => onDiffOnlyModeChange(!diffOnlyMode)}
+							className={cn(
+								"w-6 h-5",
+								diffOnlyMode
+									? "bg-primary/20 text-primary"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+						>
+							<Diff className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="top" className="text-xs">
+						{diffOnlyMode ? "Show full file" : "Show diff only"}
+					</TooltipContent>
+				</Tooltip>
+
 				<div className="flex items-center gap-0.5 bg-muted rounded p-0.5">
 					{diffModes.map(({ mode, icon: Icon, label }) => (
 						<Tooltip key={mode}>

--- a/src/components/panels/DiffViewerSection.tsx
+++ b/src/components/panels/DiffViewerSection.tsx
@@ -16,6 +16,7 @@ export interface DiffViewerSectionProps {
 	originalContent: string;
 	modifiedContent: string;
 	diffMode: DiffMode;
+	diffOnlyMode?: boolean;
 	filePath?: string;
 	changeGroups?: ChangeGroup[];
 	onStageGroup?: (groupIndex: number) => void;
@@ -39,6 +40,7 @@ export function DiffViewerSection(props: DiffViewerSectionProps) {
 				originalContent={props.originalContent}
 				modifiedContent={props.modifiedContent}
 				diffMode={props.diffMode}
+				diffOnlyMode={props.diffOnlyMode}
 			/>
 		);
 	}
@@ -49,6 +51,7 @@ export function DiffViewerSection(props: DiffViewerSectionProps) {
 			originalContent={props.originalContent}
 			modifiedContent={props.modifiedContent}
 			diffMode={props.diffMode}
+			diffOnlyMode={props.diffOnlyMode}
 			filePath={props.filePath}
 			changeGroups={props.changeGroups}
 			onStageGroup={props.onStageGroup}

--- a/src/components/panels/MarkdownDiffViewer.tsx
+++ b/src/components/panels/MarkdownDiffViewer.tsx
@@ -1,4 +1,11 @@
-import { useDeferredValue, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+	useCallback,
+	useDeferredValue,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 import Markdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
@@ -12,10 +19,17 @@ import {
 import { rehypeSourceLines } from "@/lib/rehypeSourceLines";
 import type { DiffMode } from "@/types/settings";
 
+interface VisibleBlock {
+	startLine: number;
+	endLine: number;
+	content: string;
+}
+
 export interface MarkdownDiffViewerProps {
 	originalContent: string;
 	modifiedContent: string;
 	diffMode?: DiffMode;
+	diffOnlyMode?: boolean;
 }
 
 const remarkPlugins = [remarkGfm];
@@ -160,13 +174,110 @@ function InlineView({
 	);
 }
 
+function DiffOnlyMarkdownView({
+	originalContent,
+	modifiedContent,
+}: {
+	originalContent: string;
+	modifiedContent: string;
+}) {
+	const [visibleBlocks, setVisibleBlocks] = useState<VisibleBlock[]>([]);
+	const [expandedGaps, setExpandedGaps] = useState<Set<number>>(new Set());
+	const rehypePlugins = useMemo(() => [rehypeHighlight], []);
+
+	useEffect(() => {
+		setExpandedGaps(new Set());
+		invoke<VisibleBlock[]>("compute_visible_markdown_blocks", {
+			original: originalContent,
+			modified: modifiedContent,
+			contextLines: 3,
+		})
+			.then(setVisibleBlocks)
+			.catch(() => setVisibleBlocks([]));
+	}, [originalContent, modifiedContent]);
+
+	const expandGap = useCallback((gapIndex: number) => {
+		setExpandedGaps((prev) => {
+			const next = new Set(prev);
+			next.add(gapIndex);
+			return next;
+		});
+	}, []);
+
+	const modLines = useMemo(
+		() => modifiedContent.split("\n"),
+		[modifiedContent],
+	);
+
+	if (visibleBlocks.length === 0) {
+		return (
+			<div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+				No changes
+			</div>
+		);
+	}
+
+	return (
+		<div className="markdown-preview h-full overflow-auto p-6 scrollbar-thin">
+			{visibleBlocks.map((block, i) => {
+				const prevEnd = visibleBlocks[i - 1]?.endLine ?? 0;
+				const gapLines = block.startLine - prevEnd - 1;
+
+				return (
+					// biome-ignore lint/suspicious/noArrayIndexKey: blocks are positional, order is fixed
+					<div key={i}>
+						{i > 0 &&
+							gapLines > 0 &&
+							(expandedGaps.has(i) ? (
+								<div className="border-y border-border my-4 py-2 opacity-60">
+									<Markdown
+										remarkPlugins={remarkPlugins}
+										rehypePlugins={rehypePlugins}
+									>
+										{modLines.slice(prevEnd, block.startLine - 1).join("\n")}
+									</Markdown>
+								</div>
+							) : (
+								<button
+									type="button"
+									onClick={() => expandGap(i)}
+									className="flex w-full items-center justify-center text-xs text-muted-foreground py-2 border-y border-border my-4 cursor-pointer hover:bg-muted/50"
+								>
+									··· {gapLines} lines hidden ···
+								</button>
+							))}
+						<Markdown
+							remarkPlugins={remarkPlugins}
+							rehypePlugins={rehypePlugins}
+						>
+							{block.content}
+						</Markdown>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
 export function MarkdownDiffViewer({
 	originalContent,
 	modifiedContent,
 	diffMode = "gutter",
+	diffOnlyMode,
 }: MarkdownDiffViewerProps) {
 	const deferredOriginal = useDeferredValue(originalContent);
 	const deferredModified = useDeferredValue(modifiedContent);
+
+	if (diffOnlyMode) {
+		return (
+			<div data-testid="markdown-diff-viewer" className="h-full">
+				<DiffOnlyMarkdownView
+					originalContent={deferredOriginal}
+					modifiedContent={deferredModified}
+				/>
+			</div>
+		);
+	}
 
 	return (
 		<div data-testid="markdown-diff-viewer" className="h-full">

--- a/src/components/panels/MarkdownDiffViewer.tsx
+++ b/src/components/panels/MarkdownDiffViewer.tsx
@@ -23,6 +23,7 @@ interface VisibleBlock {
 	startLine: number;
 	endLine: number;
 	content: string;
+	deletedContent?: string;
 }
 
 export interface MarkdownDiffViewerProps {
@@ -186,14 +187,23 @@ function DiffOnlyMarkdownView({
 	const rehypePlugins = useMemo(() => [rehypeHighlight], []);
 
 	useEffect(() => {
+		let cancelled = false;
 		setExpandedGaps(new Set());
 		invoke<VisibleBlock[]>("compute_visible_markdown_blocks", {
 			original: originalContent,
 			modified: modifiedContent,
 			contextLines: 3,
 		})
-			.then(setVisibleBlocks)
-			.catch(() => setVisibleBlocks([]));
+			.then((blocks) => {
+				if (!cancelled) setVisibleBlocks(blocks);
+			})
+			.catch(() => {
+				if (!cancelled) setVisibleBlocks([]);
+			});
+
+		return () => {
+			cancelled = true;
+		};
 	}, [originalContent, modifiedContent]);
 
 	const expandGap = useCallback((gapIndex: number) => {
@@ -217,6 +227,10 @@ function DiffOnlyMarkdownView({
 		);
 	}
 
+	const lastBlock = visibleBlocks[visibleBlocks.length - 1];
+	const trailingGapLines = lastBlock ? modLines.length - lastBlock.endLine : 0;
+	const trailingGapIndex = visibleBlocks.length;
+
 	return (
 		<div className="markdown-preview h-full overflow-auto p-6 scrollbar-thin">
 			{visibleBlocks.map((block, i) => {
@@ -226,8 +240,7 @@ function DiffOnlyMarkdownView({
 				return (
 					// biome-ignore lint/suspicious/noArrayIndexKey: blocks are positional, order is fixed
 					<div key={i}>
-						{i > 0 &&
-							gapLines > 0 &&
+						{gapLines > 0 &&
 							(expandedGaps.has(i) ? (
 								<div className="border-y border-border my-4 py-2 opacity-60">
 									<Markdown
@@ -246,6 +259,19 @@ function DiffOnlyMarkdownView({
 									··· {gapLines} lines hidden ···
 								</button>
 							))}
+						{block.deletedContent && (
+							<div className="border-l-2 border-red-500/50 pl-3 my-2 opacity-70">
+								<div className="text-xs text-red-400 mb-1">Deleted:</div>
+								<div className="line-through text-muted-foreground">
+									<Markdown
+										remarkPlugins={remarkPlugins}
+										rehypePlugins={rehypePlugins}
+									>
+										{block.deletedContent}
+									</Markdown>
+								</div>
+							</div>
+						)}
 						<Markdown
 							remarkPlugins={remarkPlugins}
 							rehypePlugins={rehypePlugins}
@@ -255,6 +281,25 @@ function DiffOnlyMarkdownView({
 					</div>
 				);
 			})}
+			{trailingGapLines > 0 &&
+				(expandedGaps.has(trailingGapIndex) ? (
+					<div className="border-y border-border my-4 py-2 opacity-60">
+						<Markdown
+							remarkPlugins={remarkPlugins}
+							rehypePlugins={rehypePlugins}
+						>
+							{modLines.slice(lastBlock.endLine).join("\n")}
+						</Markdown>
+					</div>
+				) : (
+					<button
+						type="button"
+						onClick={() => expandGap(trailingGapIndex)}
+						className="flex w-full items-center justify-center text-xs text-muted-foreground py-2 border-y border-border my-4 cursor-pointer hover:bg-muted/50"
+					>
+						··· {trailingGapLines} lines hidden ···
+					</button>
+				))}
 		</div>
 	);
 }

--- a/src/components/panels/ReviewPanel.test.tsx
+++ b/src/components/panels/ReviewPanel.test.tsx
@@ -231,7 +231,12 @@ describe("ReviewPanel", () => {
 
 		render(
 			<TooltipProvider>
-				<ReviewPanel rootPath="/repo" baseBranch="main" diffOnlyMode={false} onDiffOnlyModeChange={() => {}} />
+				<ReviewPanel
+					rootPath="/repo"
+					baseBranch="main"
+					diffOnlyMode={false}
+					onDiffOnlyModeChange={() => {}}
+				/>
 			</TooltipProvider>,
 		);
 
@@ -275,7 +280,12 @@ describe("ReviewPanel", () => {
 
 		render(
 			<TooltipProvider>
-				<ReviewPanel rootPath="/repo" baseBranch="main" diffOnlyMode={false} onDiffOnlyModeChange={() => {}} />
+				<ReviewPanel
+					rootPath="/repo"
+					baseBranch="main"
+					diffOnlyMode={false}
+					onDiffOnlyModeChange={() => {}}
+				/>
 			</TooltipProvider>,
 		);
 

--- a/src/components/panels/ReviewPanel.test.tsx
+++ b/src/components/panels/ReviewPanel.test.tsx
@@ -112,7 +112,12 @@ describe("ReviewPanel", () => {
 	it("should show 'No changes' when totalFileCount is 0", () => {
 		render(
 			<TooltipProvider>
-				<ReviewPanel rootPath="/repo" baseBranch="main" />
+				<ReviewPanel
+					rootPath="/repo"
+					baseBranch="main"
+					diffOnlyMode={false}
+					onDiffOnlyModeChange={vi.fn()}
+				/>
 			</TooltipProvider>,
 		);
 
@@ -143,7 +148,12 @@ describe("ReviewPanel", () => {
 
 		render(
 			<TooltipProvider>
-				<ReviewPanel rootPath="/repo" baseBranch="main" />
+				<ReviewPanel
+					rootPath="/repo"
+					baseBranch="main"
+					diffOnlyMode={false}
+					onDiffOnlyModeChange={vi.fn()}
+				/>
 			</TooltipProvider>,
 		);
 
@@ -174,7 +184,12 @@ describe("ReviewPanel", () => {
 
 		render(
 			<TooltipProvider>
-				<ReviewPanel rootPath="/repo" baseBranch="main" />
+				<ReviewPanel
+					rootPath="/repo"
+					baseBranch="main"
+					diffOnlyMode={false}
+					onDiffOnlyModeChange={vi.fn()}
+				/>
 			</TooltipProvider>,
 		);
 

--- a/src/components/panels/ReviewPanel.test.tsx
+++ b/src/components/panels/ReviewPanel.test.tsx
@@ -231,7 +231,7 @@ describe("ReviewPanel", () => {
 
 		render(
 			<TooltipProvider>
-				<ReviewPanel rootPath="/repo" baseBranch="main" />
+				<ReviewPanel rootPath="/repo" baseBranch="main" diffOnlyMode={false} onDiffOnlyModeChange={() => {}} />
 			</TooltipProvider>,
 		);
 
@@ -275,7 +275,7 @@ describe("ReviewPanel", () => {
 
 		render(
 			<TooltipProvider>
-				<ReviewPanel rootPath="/repo" baseBranch="main" />
+				<ReviewPanel rootPath="/repo" baseBranch="main" diffOnlyMode={false} onDiffOnlyModeChange={() => {}} />
 			</TooltipProvider>,
 		);
 

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -43,6 +43,8 @@ interface ReviewPanelProps {
 	baseBranch: string | null;
 	defaultDiffBase?: DiffBase;
 	defaultDiffMode?: DiffMode;
+	diffOnlyMode: boolean;
+	onDiffOnlyModeChange: (enabled: boolean) => void;
 }
 
 function DiffBaseToggle({
@@ -107,6 +109,8 @@ export function ReviewPanel({
 	baseBranch,
 	defaultDiffBase,
 	defaultDiffMode,
+	diffOnlyMode,
+	onDiffOnlyModeChange,
 }: ReviewPanelProps) {
 	const {
 		diffBase,
@@ -493,6 +497,7 @@ export function ReviewPanel({
 											originalContent={originalContent}
 											modifiedContent={modifiedContent}
 											diffMode={diffMode}
+											diffOnlyMode={diffOnlyMode}
 											filePath={selectedFile}
 											changeGroups={isBranchBase ? undefined : changeGroups}
 											onStageGroup={
@@ -505,7 +510,9 @@ export function ReviewPanel({
 									</div>
 									<DiffToolbar
 										diffMode={diffMode}
+										diffOnlyMode={diffOnlyMode}
 										onDiffModeChange={setDiffMode}
+										onDiffOnlyModeChange={onDiffOnlyModeChange}
 										fileNavigation={fileNavigation}
 										onGoToPrevFile={handleGoToPrevFile}
 										onGoToNextFile={handleGoToNextFile}

--- a/src/components/panels/SettingsModal.tsx
+++ b/src/components/panels/SettingsModal.tsx
@@ -267,6 +267,22 @@ function EditorSection({
 					</SelectContent>
 				</Select>
 			</div>
+
+			<div className="flex items-center gap-2">
+				<Checkbox
+					id="diff-only-mode"
+					checked={draft.defaultDiffOnlyMode}
+					onCheckedChange={(checked) =>
+						updateDraft((d) => ({
+							...d,
+							defaultDiffOnlyMode: checked === true,
+						}))
+					}
+				/>
+				<label htmlFor="diff-only-mode" className={labelClass}>
+					Show diff only by default
+				</label>
+			</div>
 		</div>
 	);
 }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -77,6 +77,13 @@ export function useSettings() {
 		setSettings((prev) => ({ ...prev, defaultDiffMode }));
 	}, []);
 
+	const updateDefaultDiffOnlyMode = useCallback(
+		(defaultDiffOnlyMode: boolean) => {
+			setSettings((prev) => ({ ...prev, defaultDiffOnlyMode }));
+		},
+		[],
+	);
+
 	const updateTerminalStartupCommand = useCallback(
 		(terminalStartupCommand: string) => {
 			setSettings((prev) => ({ ...prev, terminalStartupCommand }));
@@ -115,6 +122,7 @@ export function useSettings() {
 		updateFontSize,
 		updateDefaultDiffBase,
 		updateDefaultDiffMode,
+		updateDefaultDiffOnlyMode,
 		updateTerminalStartupCommand,
 		updateAgent,
 		updateAgentAutoApprove,

--- a/src/hooks/useWorkspacePersistence.test.ts
+++ b/src/hooks/useWorkspacePersistence.test.ts
@@ -58,6 +58,7 @@ function makeInternalState(
 		activeView: "git",
 		rightBottomCollapsed: false,
 		reviewCollapsed: false,
+		diffOnlyMode: false,
 		...overrides,
 	};
 }

--- a/src/screens/MainLayout.tsx
+++ b/src/screens/MainLayout.tsx
@@ -160,6 +160,8 @@ function WorktreeContent({
 										baseBranch={baseBranch}
 										defaultDiffBase={settings.defaultDiffBase}
 										defaultDiffMode={settings.defaultDiffMode}
+										diffOnlyMode={s.diffOnlyMode}
+										onDiffOnlyModeChange={s.setDiffOnlyMode}
 									/>
 								</div>
 							</Panel>

--- a/src/screens/useWorktreeState.tsx
+++ b/src/screens/useWorktreeState.tsx
@@ -131,10 +131,11 @@ export function useWorktreeState({
 	// --- Sync internal state for workspace state persistence ---
 	useEffect(() => {
 		if (!internalStateMapRef) return;
+		const current = internalStateMapRef.current.get(rootPath);
 		internalStateMapRef.current.set(rootPath, {
-			tabs: [],
-			activeEditorPath: null,
-			activeView: "agent",
+			tabs: current?.tabs ?? [],
+			activeEditorPath: current?.activeEditorPath ?? null,
+			activeView: current?.activeView ?? "agent",
 			rightBottomCollapsed,
 			reviewCollapsed,
 			diffOnlyMode,

--- a/src/screens/useWorktreeState.tsx
+++ b/src/screens/useWorktreeState.tsx
@@ -49,6 +49,12 @@ export function useWorktreeState({
 		initialWorkspaceState?.layout.reviewCollapsed ?? false,
 	);
 
+	const [diffOnlyMode, setDiffOnlyMode] = useState(
+		initialWorkspaceState?.layout.diffOnlyMode ??
+			settings.defaultDiffOnlyMode ??
+			false,
+	);
+
 	const { branch } = useCurrentBranch(rootPath);
 	const [ready, setReady] = useState(false);
 	const {
@@ -131,8 +137,15 @@ export function useWorktreeState({
 			activeView: "agent",
 			rightBottomCollapsed,
 			reviewCollapsed,
+			diffOnlyMode,
 		});
-	}, [internalStateMapRef, rootPath, rightBottomCollapsed, reviewCollapsed]);
+	}, [
+		internalStateMapRef,
+		rootPath,
+		rightBottomCollapsed,
+		reviewCollapsed,
+		diffOnlyMode,
+	]);
 
 	return {
 		ready,
@@ -163,5 +176,7 @@ export function useWorktreeState({
 		setRightBottomCollapsed,
 		reviewCollapsed,
 		setReviewCollapsed,
+		diffOnlyMode,
+		setDiffOnlyMode,
 	};
 }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -106,6 +106,7 @@ export interface AppSettings {
 	autoUpdate: boolean;
 	telemetryEnabled: boolean;
 	enableCrashReporting: boolean;
+	defaultDiffOnlyMode: boolean;
 	agentMaxConcurrent: number;
 }
 
@@ -114,6 +115,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	fontSize: 14,
 	defaultDiffBase: "head",
 	defaultDiffMode: "inline",
+	defaultDiffOnlyMode: false,
 	agent: "none",
 	agentAutoApprove: false,
 	terminalStartupCommand: "",

--- a/src/types/workspace-state.test.ts
+++ b/src/types/workspace-state.test.ts
@@ -30,6 +30,7 @@ describe("buildWorkspaceState", () => {
 			activeView: "git",
 			rightBottomCollapsed: false,
 			reviewCollapsed: false,
+			diffOnlyMode: false,
 		};
 
 		const result = buildWorkspaceState(internal, "editor", true, true);
@@ -47,6 +48,7 @@ describe("buildWorkspaceState", () => {
 				rightCollapsed: false,
 				rightBottomCollapsed: false,
 				reviewCollapsed: false,
+				diffOnlyMode: false,
 			},
 		});
 	});
@@ -58,6 +60,7 @@ describe("buildWorkspaceState", () => {
 			activeView: "git",
 			rightBottomCollapsed: false,
 			reviewCollapsed: false,
+			diffOnlyMode: false,
 		};
 
 		const result = buildWorkspaceState(internal, "editor", true, true);
@@ -71,6 +74,7 @@ describe("buildWorkspaceState", () => {
 			activeView: "git",
 			rightBottomCollapsed: false,
 			reviewCollapsed: false,
+			diffOnlyMode: false,
 		};
 
 		const result = buildWorkspaceState(internal, "editor", false, true);
@@ -84,6 +88,7 @@ describe("buildWorkspaceState", () => {
 			activeView: "git",
 			rightBottomCollapsed: false,
 			reviewCollapsed: false,
+			diffOnlyMode: false,
 		};
 
 		const result = buildWorkspaceState(internal, "editor", true, false);
@@ -97,10 +102,25 @@ describe("buildWorkspaceState", () => {
 			activeView: "git",
 			rightBottomCollapsed: true,
 			reviewCollapsed: false,
+			diffOnlyMode: false,
 		};
 
 		const result = buildWorkspaceState(internal, "agent", true, true);
 		expect(result.layout.rightBottomCollapsed).toBe(true);
 		expect(result.layout.centerTab).toBe("agent");
+	});
+
+	it("diffOnlyMode=trueが保持される", () => {
+		const internal = {
+			tabs: [],
+			activeEditorPath: null,
+			activeView: "git",
+			rightBottomCollapsed: false,
+			reviewCollapsed: false,
+			diffOnlyMode: true,
+		};
+
+		const result = buildWorkspaceState(internal, "editor", true, true);
+		expect(result.layout.diffOnlyMode).toBe(true);
 	});
 });

--- a/src/types/workspace-state.ts
+++ b/src/types/workspace-state.ts
@@ -15,6 +15,7 @@ export interface WorkspaceState {
 		rightCollapsed: boolean;
 		rightBottomCollapsed: boolean;
 		reviewCollapsed?: boolean;
+		diffOnlyMode?: boolean;
 	};
 }
 
@@ -24,6 +25,7 @@ export interface InternalWorktreeState {
 	activeView: string;
 	rightBottomCollapsed: boolean;
 	reviewCollapsed: boolean;
+	diffOnlyMode: boolean;
 }
 
 export function buildWorkspaceState(
@@ -45,6 +47,7 @@ export function buildWorkspaceState(
 			rightCollapsed: !rightVisible,
 			rightBottomCollapsed: internal.rightBottomCollapsed,
 			reviewCollapsed: internal.reviewCollapsed,
+			diffOnlyMode: internal.diffOnlyMode,
 		},
 	};
 }


### PR DESCRIPTION
## Summary
- Reviewパネルに差分箇所のみ表示するdiffOnlyModeを追加（未変更行を折りたたみ、変更箇所+前後コンテキスト行のみ表示）
- Gutter/Inline/Split全モード、Markdown diffにも対応
- hunkステージ時に表示が崩れないよう、コンテンツ更新とhidden range計算をアトミックに実行
- Rust側に`compute_hidden_ranges_from_content`コマンドを追加し、2段階IPCを1回に統合

## Test plan
- [x] pnpm lint / pnpm test (1325 passed) / pnpm build 全PASS
- [x] cargo fmt / cargo clippy / cargo test 全PASS
- [ ] diffOnlyModeトグルON/OFFで差分のみ/全文表示が切り替わることを確認
- [ ] diffOnlyMode中にhunkをstageしても表示が崩れないことを確認
- [ ] Markdownプレビューモードで折りたたみ箇所をクリックして展開できることを確認

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * diff ビューアツールバーに「差分のみを表示」トグルを追加しました。有効化時、変更されていない領域を折りたたんで表示します。
  * 設定画面に「Show diff only by default」オプションを追加し、このモードをワークスペースのデフォルトとして設定できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->