### PR TITLE
fix: detached HEAD/featureブランチ上のメインリポジトリがWorkspaces一覧から消える問題を修正

### DIFF
--- a/docs/spec/issues-815.md
+++ b/docs/spec/issues-815.md
@@ -47,7 +47,7 @@ Feature: ワークツリー一覧の表示
 
 **対象コンポーネント**:
 - `src-tauri/src/git/worktree.rs` (`list_branches_with_status`): ローカルブランチイテレーション後、`wt_map` からブランチにマッチしなかったワークツリー（detached HEAD等）を検出し、`WorktreeBranch` として `cards` に追加する
-- `src/hooks/useWorktreeList.ts`: メインリポジトリの表示対応 — 現在の `!b.is_default` フィルタを見直し、メインリポジトリも一覧に含める。メインリポジトリには識別アイコンを付与
+- `src/hooks/useWorktreeList.ts`: メインリポジトリの表示対応 — `worktree_path` を持つエントリを一覧に残し、`is_main_worktree` をフロントエンドへ伝搬する
 - `src/components/workspace/WorkspaceList.tsx`: メインリポジトリのアイコン表示対応
 
 **検討した代替案**:

--- a/docs/spec/issues-815.md
+++ b/docs/spec/issues-815.md
@@ -1,0 +1,58 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: ワークツリーがRebase中にdetached HEAD状態になると、Workspaces一覧から表示が消える
+**期待する挙動**: Rebase中（detached HEAD状態）でも、ワークツリーがWorkspaces一覧に表示され続ける
+**再現手順**:
+1. ワークツリーでRebaseを開始する
+2. Rebase中にdetached HEAD状態になる
+3. Workspaces一覧を確認すると、該当ワークツリーが表示されていない
+**背景**: Rebaseは日常的なGit操作であり、その間ワークツリーが一覧から消えると、ユーザーはそのワークツリーにアクセスできなくなる
+
+## 振る舞い定義
+
+```gherkin
+Feature: ワークツリー一覧の表示
+  全てのワークツリーがWorkspaces一覧に正しく表示される
+
+  Rule: detached HEAD状態のワークツリーもワークツリー一覧に含まれる
+    Scenario: Rebase中のワークツリーが一覧に含まれる
+      Given ワークツリーでRebaseが進行中である
+      And そのワークツリーがdetached HEAD状態である
+      When ワークツリー一覧を取得する
+      Then そのワークツリーのworktree_pathが返される
+
+  Rule: メインリポジトリもWorkspaces一覧に表示される
+    Scenario: メインリポジトリが一覧に含まれる
+      Given メインリポジトリが存在する
+      When ユーザーがWorkspaces一覧を表示する
+      Then メインリポジトリが一覧に表示される
+
+  Rule: メインリポジトリはメインであることが識別できる
+    Scenario: メインリポジトリにメイン識別アイコンが表示される
+      Given メインリポジトリがWorkspaces一覧に表示されている
+      When ユーザーがWorkspaces一覧を表示する
+      Then メインリポジトリにメインであることを示すアイコンが表示される
+
+  Rule: 全てのワークツリーがWorkspaces一覧に表示される
+    Scenario: detached HEAD状態のワークツリーがWorkspaces一覧に表示される
+      Given ワークツリーがdetached HEAD状態でworktree_pathを持っている
+      When ユーザーがWorkspaces一覧を表示する
+      Then そのワークツリーが一覧に表示される
+```
+
+## 実装仕様
+
+**対応方針**: detached HEADのワークツリーが一覧から欠落するバグを修正するために、Rust側の `list_branches_with_status` で、ローカルブランチのイテレーション後に `wt_map` に残ったエントリ（ブランチにマッチしなかったワークツリー）を `WorktreeBranch` として追加する。
+
+**対象コンポーネント**:
+- `src-tauri/src/git/worktree.rs` (`list_branches_with_status`): ローカルブランチイテレーション後、`wt_map` からブランチにマッチしなかったワークツリー（detached HEAD等）を検出し、`WorktreeBranch` として `cards` に追加する
+- `src/hooks/useWorktreeList.ts`: メインリポジトリの表示対応 — 現在の `!b.is_default` フィルタを見直し、メインリポジトリも一覧に含める。メインリポジトリには識別アイコンを付与
+- `src/components/workspace/WorkspaceList.tsx`: メインリポジトリのアイコン表示対応
+
+**検討した代替案**:
+- フロントエンド側のフィルタ修正のみ: Rust側からdetached HEADワークツリーのデータが返却されないため、フロントのフィルタ修正だけでは解決不可。却下
+
+**影響するテスト**:
+- Rust: `src-tauri/src/git/worktree.rs` にdetached HEAD状態のワークツリーが `list_branches_with_status` の結果に含まれることを検証するテストを追加
+- フロントエンド: `useWorktreeList` のフィルタロジック変更に伴うテスト修正（メインリポジトリが含まれることの検証）

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -99,7 +99,7 @@ pub struct VisibleBlock {
 #[derive(Serialize)]
 pub struct WorktreeBranch {
     pub name: String,
-    pub is_default: bool,
+    pub is_main_worktree: bool,
     pub worktree_path: Option<String>,
     pub dirty_count: usize,
     pub is_merged: bool,

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -223,15 +223,12 @@ pub fn list_branches_with_status(repo_path: String) -> Result<Vec<WorktreeBranch
     let mut wt_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
     let main_branch = get_branch_name_for_repo(&repo);
-    if let Some(workdir) = repo.workdir() {
-        wt_map.insert(
-            main_branch.clone(),
-            workdir
-                .to_str()
-                .unwrap_or("")
-                .trim_end_matches('/')
-                .to_string(),
-        );
+    let main_workdir = repo
+        .workdir()
+        .and_then(|p| p.to_str())
+        .map(|s| s.trim_end_matches('/').to_string());
+    if let Some(ref workdir) = main_workdir {
+        wt_map.insert(main_branch.clone(), workdir.clone());
     }
 
     if let Ok(wt_names) = repo.worktrees() {
@@ -275,6 +272,7 @@ pub fn list_branches_with_status(repo_path: String) -> Result<Vec<WorktreeBranch
         .or(default_oid);
 
     let mut cards = Vec::new();
+    let mut matched_wt_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
     for branch in local_branches {
         let (branch, _) = branch?;
         let name = match branch.name()? {
@@ -282,10 +280,9 @@ pub fn list_branches_with_status(repo_path: String) -> Result<Vec<WorktreeBranch
             None => continue,
         };
 
-        let is_default = default_branch.as_deref() == Some(&name);
-
         let (worktree_path, dirty_count) = match wt_map.get(&name) {
             Some(path) => {
+                matched_wt_keys.insert(name.clone());
                 let dirty = get_dirty_count_for_path(Path::new(path)) as usize;
                 (Some(path.clone()), dirty)
             }
@@ -324,9 +321,10 @@ pub fn list_branches_with_status(repo_path: String) -> Result<Vec<WorktreeBranch
             })
             .unwrap_or(0);
 
+        let is_main_wt = worktree_path.as_ref() == main_workdir.as_ref();
         cards.push(WorktreeBranch {
             name,
-            is_default,
+            is_main_worktree: is_main_wt,
             worktree_path,
             dirty_count,
             is_merged,
@@ -337,6 +335,30 @@ pub fn list_branches_with_status(repo_path: String) -> Result<Vec<WorktreeBranch
             behind,
             has_upstream,
             base_ahead,
+        });
+    }
+
+    // wt_map に残ったエントリ（ローカルブランチにマッチしなかったワークツリー）を追加
+    // detached HEAD（rebase中等）のワークツリーがここに該当する
+    for (wt_branch_name, wt_path) in &wt_map {
+        if matched_wt_keys.contains(wt_branch_name) {
+            continue;
+        }
+        let dirty_count = get_dirty_count_for_path(Path::new(wt_path)) as usize;
+        let is_main_wt = main_workdir.as_deref() == Some(wt_path.as_str());
+        cards.push(WorktreeBranch {
+            name: wt_branch_name.clone(),
+            is_main_worktree: is_main_wt,
+            worktree_path: Some(wt_path.clone()),
+            dirty_count,
+            is_merged: false,
+            has_pr: false,
+            pr_number: None,
+            pr_url: None,
+            ahead: 0,
+            behind: 0,
+            has_upstream: false,
+            base_ahead: 0,
         });
     }
 
@@ -915,7 +937,7 @@ mod tests {
 
         let cards = list_branches_with_status(dir.path().to_str().unwrap().to_string()).unwrap();
         assert_eq!(cards.len(), 1);
-        assert!(cards[0].is_default);
+        assert!(cards[0].is_main_worktree);
     }
 
     #[test]
@@ -932,7 +954,7 @@ mod tests {
         let names: Vec<&str> = cards.iter().map(|c| c.name.as_str()).collect();
         assert!(names.contains(&"feature-a"));
         assert!(names.contains(&"feature-b"));
-        for card in cards.iter().filter(|c| !c.is_default) {
+        for card in cards.iter().filter(|c| !c.is_main_worktree) {
             assert!(card.worktree_path.is_none());
             assert_eq!(card.dirty_count, 0);
         }
@@ -1144,5 +1166,102 @@ mod tests {
         let card = cards.iter().find(|c| c.name == "no-upstream").unwrap();
         assert_eq!(card.ahead, 0);
         assert_eq!(card.behind, 0);
+    }
+
+    #[test]
+    fn test_list_branches_with_status_detached_head_worktree() {
+        let (_parent, repo_dir, repo) = create_test_repo_with_parent();
+        create_initial_commit(&repo);
+
+        // ワークツリーを作成
+        let wt_path = create_worktree_helper(&repo, _parent.path(), "wt-rebase", "feat-rebase");
+
+        // ワークツリーをdetached HEAD状態にする（rebase中を模擬）
+        let wt_repo = Repository::open(&wt_path).unwrap();
+        let head_commit = wt_repo.head().unwrap().peel_to_commit().unwrap();
+        wt_repo.set_head_detached(head_commit.id()).unwrap();
+
+        // list_branches_with_status を呼ぶ
+        let cards = list_branches_with_status(repo_dir.to_str().unwrap().to_string()).unwrap();
+
+        // detached HEAD のワークツリーが結果に含まれること
+        // macOSでは /var → /private/var のsymlink解決が発生するため、名前で検索する
+        let detached_card = cards.iter().find(|c| {
+            c.name != "feat-rebase"
+                && c.name != "master"
+                && c.worktree_path.is_some()
+                && c.worktree_path.as_deref().unwrap().ends_with("wt-rebase")
+        });
+        assert!(
+            detached_card.is_some(),
+            "detached HEAD worktree should be included in list_branches_with_status"
+        );
+
+        let card = detached_card.unwrap();
+        assert!(card.worktree_path.is_some());
+        // detached HEADのため、名前はOID短縮形（括弧付き）
+        assert!(
+            card.name.starts_with('('),
+            "detached HEAD card name should start with '(', got: {}",
+            card.name
+        );
+    }
+
+    #[test]
+    fn test_is_main_worktree_on_default_branch() {
+        let (_parent, repo_dir, repo) = create_test_repo_with_parent();
+        create_initial_commit(&repo);
+
+        // linked worktree を作成
+        create_worktree_helper(&repo, _parent.path(), "wt-feat", "feat-a");
+
+        let cards = list_branches_with_status(repo_dir.to_str().unwrap().to_string()).unwrap();
+
+        // メインリポジトリ（master ブランチ上）は is_main_worktree = true
+        let main_card = cards.iter().find(|c| c.name == "master").unwrap();
+        assert!(main_card.is_main_worktree);
+
+        // linked worktree は is_main_worktree = false
+        let wt_card = cards.iter().find(|c| c.name == "feat-a").unwrap();
+        assert!(!wt_card.is_main_worktree);
+    }
+
+    #[test]
+    fn test_is_main_worktree_on_feature_branch() {
+        let (_parent, repo_dir, repo) = create_test_repo_with_parent();
+        create_initial_commit(&repo);
+
+        // feature ブランチを作成し、メインリポジトリをそこにチェックアウト
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("feat-current", &head, false).unwrap();
+        repo.set_head("refs/heads/feat-current").unwrap();
+        repo.checkout_head(Some(CheckoutBuilder::new().force()))
+            .unwrap();
+
+        let cards = list_branches_with_status(repo_dir.to_str().unwrap().to_string()).unwrap();
+
+        // メインリポジトリは feat-current ブランチ上にいるが is_main_worktree = true
+        let feat_card = cards.iter().find(|c| c.name == "feat-current").unwrap();
+        assert!(feat_card.is_main_worktree);
+
+        // master ブランチは worktree_path なし、is_main_worktree = false
+        let master_card = cards.iter().find(|c| c.name == "master").unwrap();
+        assert!(!master_card.is_main_worktree);
+    }
+
+    #[test]
+    fn test_is_main_worktree_detached_head_main_repo() {
+        let (_parent, repo_dir, repo) = create_test_repo_with_parent();
+        create_initial_commit(&repo);
+
+        // メインリポジトリを detached HEAD にする
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.set_head_detached(head_commit.id()).unwrap();
+
+        let cards = list_branches_with_status(repo_dir.to_str().unwrap().to_string()).unwrap();
+
+        // detached HEAD のメインリポジトリは is_main_worktree = true
+        let detached_card = cards.iter().find(|c| c.name.starts_with('(')).unwrap();
+        assert!(detached_card.is_main_worktree);
     }
 }

--- a/src-tauri/src/protocol/branch.rs
+++ b/src-tauri/src/protocol/branch.rs
@@ -5,7 +5,8 @@ use crate::git::types::WorktreeBranch;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BranchCardMsg {
     pub name: String,
-    pub is_default: bool,
+    #[serde(default)]
+    pub is_main_worktree: bool,
     pub worktree_path: Option<String>,
     pub dirty_count: usize,
     pub is_merged: bool,
@@ -29,7 +30,7 @@ impl From<WorktreeBranch> for BranchCardMsg {
     fn from(b: WorktreeBranch) -> Self {
         Self {
             name: b.name,
-            is_default: b.is_default,
+            is_main_worktree: b.is_main_worktree,
             worktree_path: b.worktree_path,
             dirty_count: b.dirty_count,
             is_merged: b.is_merged,

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -329,7 +329,7 @@ mod tests {
             WsMessage::BranchListSync(BranchListSync {
                 branches: vec![BranchCardMsg {
                     name: "feature/test".to_string(),
-                    is_default: false,
+                    is_main_worktree: false,
                     worktree_path: Some("/repo-worktrees/feature-test".to_string()),
                     dirty_count: 2,
                     is_merged: false,

--- a/src/components/workspace/DeleteWorktreeDialog.test.tsx
+++ b/src/components/workspace/DeleteWorktreeDialog.test.tsx
@@ -6,7 +6,7 @@ import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
 
 const baseBranch: WorktreeBranch = {
 	name: "feature/test",
-	is_default: false,
+	is_main_worktree: false,
 	worktree_path: "/tmp/worktree/feature-test",
 	dirty_count: 0,
 	is_merged: false,

--- a/src/components/workspace/DeleteWorktreeDialog.tsx
+++ b/src/components/workspace/DeleteWorktreeDialog.tsx
@@ -62,15 +62,12 @@ export function DeleteWorktreeDialog({
 
 	if (!branch) return null;
 
-	const isMergedOnly = branch.is_merged && !branch.worktree_path;
 	const isMergedWithWorktree = branch.is_merged && !!branch.worktree_path;
 
 	const title = branch.is_merged ? "Delete Branch" : "Delete Workspace";
-	const description = isMergedOnly
-		? `Delete merged branch "${branch.name}"?`
-		: isMergedWithWorktree
-			? `Delete workspace and branch "${branch.name}"?`
-			: `Delete workspace for branch "${branch.name}"?`;
+	const description = isMergedWithWorktree
+		? `Delete workspace and branch "${branch.name}"?`
+		: `Delete workspace for branch "${branch.name}"?`;
 
 	return (
 		<AlertDialog open={open} onOpenChange={handleOpenChange}>

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -6,6 +6,7 @@ import {
 	ChevronRight,
 	Filter,
 	Globe,
+	Home,
 	LayoutList,
 	Loader2,
 	Plus,
@@ -189,7 +190,8 @@ function RepoWorktreeSectionView({
 	const renderItem = (branch: WorktreeBranch) => {
 		const isSelected = branch.worktree_path === selectedRootPath;
 		const hasWorktree = branch.worktree_path != null;
-		const canDelete = !branch.is_default && (hasWorktree || branch.is_merged);
+		const canDelete =
+			!branch.is_main_worktree && (hasWorktree || branch.is_merged);
 		const status = computeStatus(branch);
 
 		// 2行目テキスト部分を組み立て
@@ -233,6 +235,12 @@ function RepoWorktreeSectionView({
 						<span className="text-xs font-medium truncate flex-1">
 							{branch.name}
 						</span>
+						{branch.is_main_worktree && (
+							<Home
+								className="shrink-0 size-3 text-muted-foreground"
+								aria-label="Main repository"
+							/>
+						)}
 						{branch.ahead > 0 && (
 							<span className="shrink-0 text-[11px] font-mono text-success/70">
 								+{branch.ahead}

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -190,8 +190,7 @@ function RepoWorktreeSectionView({
 	const renderItem = (branch: WorktreeBranch) => {
 		const isSelected = branch.worktree_path === selectedRootPath;
 		const hasWorktree = branch.worktree_path != null;
-		const canDelete =
-			!branch.is_main_worktree && (hasWorktree || branch.is_merged);
+		const canDelete = !branch.is_main_worktree;
 		const status = computeStatus(branch);
 
 		// 2行目テキスト部分を組み立て

--- a/src/hooks/useWorktreeList.test.ts
+++ b/src/hooks/useWorktreeList.test.ts
@@ -19,7 +19,7 @@ const makeBranch = (
 ): WorktreeBranch => ({
 	name: "feat/test",
 	worktree_path: "/tmp/wt",
-	is_default: false,
+	is_main_worktree: false,
 	is_merged: false,
 	has_upstream: false,
 	has_pr: false,
@@ -318,9 +318,9 @@ describe("useWorktreeList", () => {
 		expect(result.current.branches).toHaveLength(2);
 	});
 
-	it("should filter out default branches and those without worktree_path", async () => {
+	it("should filter out branches without worktree_path but include default branches", async () => {
 		const branches = [
-			makeBranch({ name: "main", is_default: true }),
+			makeBranch({ name: "main", is_main_worktree: true }),
 			makeBranch({
 				name: "feat/a",
 				worktree_path: null as unknown as string,
@@ -332,10 +332,45 @@ describe("useWorktreeList", () => {
 		const { result } = renderHook(() => useWorktreeList("/test/repo"));
 
 		await waitFor(() => {
-			expect(result.current.branches).toHaveLength(1);
+			expect(result.current.branches).toHaveLength(2);
 		});
 
-		expect(result.current.branches[0].name).toBe("feat/b");
+		const names = result.current.branches.map((b) => b.name);
+		expect(names).toContain("main");
+		expect(names).toContain("feat/b");
+		expect(names).not.toContain("feat/a");
+	});
+
+	it("should pass is_main_worktree through to branches when main repo is on feature branch", async () => {
+		const branches = [
+			makeBranch({
+				name: "main",
+				is_main_worktree: false,
+				worktree_path: null as unknown as string,
+			}),
+			makeBranch({
+				name: "feat/current",
+				is_main_worktree: true,
+				worktree_path: "/repo",
+			}),
+			makeBranch({
+				name: "feat/wt",
+				is_main_worktree: false,
+				worktree_path: "/tmp/wt",
+			}),
+		];
+		setupMockInvoke(branches);
+
+		const { result } = renderHook(() => useWorktreeList("/test/repo"));
+
+		await waitFor(() => {
+			expect(result.current.branches).toHaveLength(2);
+		});
+
+		const mainWt = result.current.branches.find((b) => b.is_main_worktree);
+		expect(mainWt).toBeDefined();
+		expect(mainWt?.name).toBe("feat/current");
+		expect(mainWt?.is_main_worktree).toBe(true);
 	});
 
 	it("should update agent_state from workspace-status-changed event", async () => {

--- a/src/hooks/useWorktreeList.test.ts
+++ b/src/hooks/useWorktreeList.test.ts
@@ -318,7 +318,7 @@ describe("useWorktreeList", () => {
 		expect(result.current.branches).toHaveLength(2);
 	});
 
-	it("should filter out branches without worktree_path but include default branches", async () => {
+	it("should filter out branches without worktree_path but include main worktree branches", async () => {
 		const branches = [
 			makeBranch({ name: "main", is_main_worktree: true }),
 			makeBranch({

--- a/src/hooks/useWorktreeList.ts
+++ b/src/hooks/useWorktreeList.ts
@@ -94,9 +94,7 @@ export function useWorktreeList(repoPath: string) {
 					const ws = latestStatusMap.get(normalizePath(b.worktree_path));
 					return ws ? { ...b, agent_state: ws.aggregated_state } : b;
 				});
-				const filtered = withAgentState.filter(
-					(b) => b.worktree_path != null && !b.is_default,
-				);
+				const filtered = withAgentState.filter((b) => b.worktree_path != null);
 				if (seq === refreshSeqRef.current) {
 					const serialized = JSON.stringify(filtered);
 					if (serialized !== prevBranchesRef.current) {

--- a/src/types/git.ts
+++ b/src/types/git.ts
@@ -21,7 +21,7 @@ export interface BranchInfo {
 
 export interface WorktreeBranch {
 	name: string;
-	is_default: boolean;
+	is_main_worktree: boolean;
 	worktree_path: string | null;
 	dirty_count: number;
 	is_merged: boolean;

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -178,7 +178,7 @@ export interface WorktreeSelectResponse {
 
 interface BranchCardMsg {
 	name: string;
-	is_default: boolean;
+	is_main_worktree: boolean;
 	worktree_path: string | null;
 	dirty_count: number;
 	is_merged: boolean;


### PR DESCRIPTION
## Summary
- detached HEAD状態（Rebase中等）のワークツリーがWorkspaces一覧から消えるバグを修正
- `is_default`（デフォルトブランチ名一致判定）を`is_main_worktree`（メインリポジトリworkdir一致判定）に置き換え、メインリポジトリがどのブランチにいても正しく識別・表示されるようにした
- メインリポジトリにHomeアイコンを表示し、削除ボタンを非表示にする条件も`is_main_worktree`に統一

## Test plan
- [ ] Rust: `cargo test` — detached HEADワークツリー、メインリポジトリがfeatureブランチ上、detached HEAD状態のメインリポジトリの各テストがPASS
- [ ] フロント: `pnpm test` — `useWorktreeList`のフィルタ・伝搬テスト、`DeleteWorktreeDialog`テストがPASS
- [ ] 手動確認: Rebase中のワークツリーが一覧に表示されること
- [ ] 手動確認: メインリポジトリがfeatureブランチにいてもHomeアイコンが表示されること
- [ ] 手動確認: メインリポジトリに削除ボタンが表示されないこと

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * リベース中にdetached HEAD状態のワークツリーがワークスペースリストから消える問題を修正しました
  * Detached HEADワークツリーがリストに正常に表示されるようになりました

* **新機能**
  * メインリポジトリを視覚的に識別するアイコンをワークスペースリストに追加しました

* **UI改善**
  * ワークスペース削除時の確認ダイアログメッセージを簡潔化しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->