### PR TITLE
feat: Monaco DiffEditorを廃止しShikiベースの自前diff表示UIに置き換え

### DIFF
--- a/docs/spec/issues-811.md
+++ b/docs/spec/issues-811.md
@@ -1,0 +1,120 @@
+## 要求
+
+**種別**: 改善
+**ゴール**: 現在のMonaco DiffEditorおよびMonaco GutterEditorを廃止し、軽量な自前diff表示UIに置き換える。Gutter / Inline / Split の3つの表示モードを提供する
+**背景**: Monaco Editorではhunk単位のstage/unstageやコメントUIの自由な配置など、レビュー機能に必要なカスタマイズが困難なため
+
+**対応する表示モード**:
+- **Gutter**: 変更後コードの行左端に追加/削除マーカーを表示（現`useMonacoGutterEditor`の置き換え）
+- **Inline**: 追加行/削除行を1カラムで交互表示
+- **Split**: 左右2カラムでbefore/afterを並べて表示
+
+**制約**:
+- diff hunk計算はRust側（git2）で行い、フロントはレンダリングに徹する
+- シンタックスハイライトはShiki（`shiki/core` + `shiki/engine/javascript`、WASM不要）
+- 言語は動的import（`@shikijs/langs/xxx`）、テーマはGitHub Dark系
+- `codeToTokens()`で行・トークン単位の配列を取得し、自前HTMLにレンダリング
+- hunk単位・行単位のインタラクション（stage/unstage、コメント）が可能なHTML構造にする
+
+## 振る舞い定義
+
+```gherkin
+Feature: 自前Diff表示UI
+  Monaco DiffEditor/GutterEditorを廃止し、Shikiベースの軽量な自前diff表示UIで
+  Gutter / Inline / Split の3つの表示モードを提供する
+
+  Background:
+    Given ファイルにdiff（追加・削除・変更）が存在する
+
+  Rule: 表示モードの切り替え
+    Scenario: Gutterモードで表示する
+      When ユーザーがGutterモードを選択する
+      Then 変更後のコードが表示される
+      And 追加行の左端に追加マーカーが表示される
+      And 削除行の左端に削除マーカーが表示される
+
+    Scenario: Inlineモードで表示する
+      When ユーザーがInlineモードを選択する
+      Then 削除行と追加行が1カラムで交互に表示される
+
+    Scenario: Splitモードで表示する
+      When ユーザーがSplitモードを選択する
+      Then 左カラムに変更前のコードが表示される
+      And 右カラムに変更後のコードが表示される
+
+  Rule: シンタックスハイライト
+    Scenario: ファイルの言語に応じたハイライトが適用される
+      Given ファイルの拡張子から言語が判別できる
+      When diff表示が描画される
+      Then Shikiによるシンタックスハイライトが適用される
+
+    Scenario: 言語が判別できないファイル
+      Given ファイルの拡張子から言語が判別できない
+      When diff表示が描画される
+      Then プレーンテキストとして表示される
+
+  Rule: Hunk単位のステージ操作による状態変化
+    Scenario: ChangeGroupをステージする
+      Given Unstaged変更のdiffを表示している
+      When ユーザーがChangeGroupのステージ操作を行う
+      Then そのChangeGroupがステージされる
+
+    Scenario: ChangeGroupをアンステージする
+      Given Staged変更のdiffを表示している
+      When ユーザーがChangeGroupのアンステージ操作を行う
+      Then そのChangeGroupがアンステージされる
+
+  Rule: ステージ操作UIの表示
+    Scenario: Unstaged変更表示時のステージボタン
+      Given Unstaged変更のdiffを表示している
+      When 各ChangeGroupが画面に表示されている
+      Then 各ChangeGroupにステージボタンが表示される
+
+    Scenario: Staged変更表示時のアンステージボタン
+      Given Staged変更のdiffを表示している
+      When 各ChangeGroupが画面に表示されている
+      Then 各ChangeGroupにアンステージボタンが表示される
+
+  Rule: Diff-onlyモードによる表示制御
+    Scenario: Diff-onlyモードを有効にする
+      When ユーザーがDiff-onlyモードを有効にする
+      Then 変更がない領域が折りたたまれる
+      And 変更箇所の前後にコンテキスト行が表示される
+
+    Scenario: Diff-onlyモードを無効にする
+      When ユーザーがDiff-onlyモードを無効にする
+      Then ファイル全体が表示される
+```
+
+## 実装仕様
+
+**対応方針**: 振る舞い定義（Gutter / Inline / Split の3モード、Shikiハイライト、ChangeGroup単位ステージ、Diff-onlyモード）を実現するために、`CodeDiffViewer`コンポーネントをMonaco依存からShiki + 自前HTMLレンダリングに置き換える。Rust側のdiff計算ロジック（hunk.rs）は変更なくそのまま活用する。
+
+**対象コンポーネント**:
+- **新規: `src/components/panels/ShikiDiffViewer.tsx`**: Shiki `codeToTokens()` でトークン化した行データを、Hunk情報と組み合わせて自前HTMLでレンダリング。Gutter / Inline / Split の3モードを1コンポーネントで提供
+- **新規: `src/hooks/useShikiHighlighter.ts`**: Shikiハイライターインスタンスの初期化・キャッシュ管理。`createHighlighterCore` + `createJavaScriptRegexEngine`（WASM不要）で構築。言語は`@shikijs/langs/xxx`で動的import
+- **新規: `src/hooks/useDiffTokens.ts`**: originalContent / modifiedContent をShikiでトークン化し、Hunk情報と結合して行ごとの表示データ（トークン配列 + 追加/削除/コンテキスト種別）を生成するフック
+- **変更: `src/components/panels/CodeDiffViewer.tsx`**: `GutterDiffViewer` / `MonacoDiffViewer` を廃止し、`ShikiDiffViewer`に委譲。外部インターフェース（`CodeDiffViewerProps`）は維持
+- **変更: `src/components/panels/DiffViewerSection.tsx`**: コードdiff時の描画先が変わるが、`CodeDiffViewer`のpropsが維持されるため最小限の変更
+- **廃止: `src/hooks/useMonacoGutterEditor.ts`**: Monaco依存のGutter表示ロジックを廃止
+- **廃止: `src/lib/monaco-config.ts`**: diff表示用のMonacoテーマ・設定。Monaco Editorがエディタ機能で引き続き使われる場合は残す
+- **Rust側: 変更なし**: `hunk.rs`（`compute_diff_hunks`, `compute_hidden_ranges_from_content`, `generate_group_patch`）, `stage.rs`, `diff.rs`, `types.rs` はすべて現状のまま活用
+
+**技術選定**:
+- **Shiki（`shiki/core` + `shiki/engine/javascript`）**: WASM不要のJavaScript RegExpエンジンでシンタックスハイライト。`codeToTokens()`でトークン配列を取得し自前HTMLにレンダリング。Monaco Editorのビルトインハイライトからの移行先
+- **言語ロード**: `@shikijs/langs/xxx` で動的import。拡張子→言語IDマッピングは既存の`get_language_from_path` Tauriコマンドを活用
+- **テーマ**: GitHub Dark系（`github-dark`）
+
+**検討した代替案**:
+- **Monaco Editorのカスタマイズ続行**: hunk単位UIの自由度が不足、DOM直接操作によるStageボタンがMonacoレイアウト変更に脆弱。却下
+- **highlight.js（既に依存に存在）**: 行・トークン単位の配列取得APIがなく、自前HTMLレンダリングとの統合が困難。却下
+
+**リスク**:
+- **Shikiの言語対応漏れ**: `createJavaScriptRegexEngine`はNode.js 20+のRegExp `v`フラグが最適。Tauriアプリ内のWebView環境で`v`フラグ非対応の場合は`u`フラグへのフォールバックが自動的に行われる
+- **パフォーマンス**: 大ファイル（数千行）でのトークン化コスト → Diff-onlyモード時は表示範囲のみトークン化する最適化を検討
+
+**影響するテスト**:
+- **フロントエンド単体テスト**: `ShikiDiffViewer`の3モード切り替え、ステージボタン表示、Diff-onlyモードのテスト追加。`useShikiHighlighter`のモック方針定義
+- **既存テスト修正**: `CodeDiffViewer`関連のテストがMonaco依存であれば修正
+- **Rustテスト**: 変更なし（hunk.rsの既存テストはそのまま）
+- **統合テスト（Playwright）**: diff表示のスクリーンショットテストがある場合は更新

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
 		"@noble/hashes": "^2.0.1",
 		"@react-symbols/icons": "^1.3.1",
 		"@sentry/react": "^10",
+		"@shikijs/langs": "^4.0.2",
+		"@shikijs/themes": "^4.0.2",
+		"@tanstack/react-virtual": "^3.13.24",
 		"@tauri-apps/api": "^2",
 		"@tauri-apps/plugin-autostart": "^2",
 		"@tauri-apps/plugin-dialog": "^2",
@@ -60,6 +63,7 @@
 		"rehype-sanitize": "^6.0.0",
 		"remark-breaks": "^4.0.0",
 		"remark-gfm": "^4.0.1",
+		"shiki": "^4.0.2",
 		"tailwind-merge": "^3.5.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,15 @@ importers:
       '@sentry/react':
         specifier: ^10
         version: 10.45.0(react@19.2.4)
+      '@shikijs/langs':
+        specifier: ^4.0.2
+        version: 4.0.2
+      '@shikijs/themes':
+        specifier: ^4.0.2
+        version: 4.0.2
+      '@tanstack/react-virtual':
+        specifier: ^3.13.24
+        version: 3.13.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
@@ -119,6 +128,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      shiki:
+        specifier: ^4.0.2
+        version: 4.0.2
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -1685,6 +1697,37 @@ packages:
     resolution: {integrity: sha512-i6NWUDi2SDikfSUeMJvJTRdwEKYSfTd+mvBO2Ja51S1YK+hnickBuDfD+RvPerIXLuyRu3GamgNPbNqgCGUg/Q==}
     engines: {node: '>= 18'}
 
+  '@shikijs/core@4.0.2':
+    resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.0.2':
+    resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.0.2':
+    resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.0.2':
+    resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.0.2':
+    resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.0.2':
+    resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1781,6 +1824,15 @@ packages:
     resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/react-virtual@3.13.24':
+    resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.14.0':
+    resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
@@ -2310,6 +2362,9 @@ packages:
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -2714,6 +2769,12 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2856,6 +2917,15 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   rehype-highlight@7.0.2:
     resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
 
@@ -2915,6 +2985,10 @@ packages:
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+
+  shiki@4.0.2:
+    resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
+    engines: {node: '>=20'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -4630,6 +4704,46 @@ snapshots:
       - rollup
       - supports-color
 
+  '@shikijs/core@4.0.2':
+    dependencies:
+      '@shikijs/primitive': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/primitive@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/types@4.0.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.2.2':
@@ -4699,6 +4813,14 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)
+
+  '@tanstack/react-virtual@3.13.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.14.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@tanstack/virtual-core@3.14.0': {}
 
   '@tauri-apps/api@2.10.1': {}
 
@@ -5246,6 +5368,20 @@ snapshots:
       '@types/hast': 3.0.4
       '@ungap/structured-clone': 1.3.0
       unist-util-position: 5.0.0
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
@@ -5858,6 +5994,14 @@ snapshots:
 
   obug@2.1.1: {}
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -6054,6 +6198,16 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   rehype-highlight@7.0.2:
     dependencies:
       '@types/hast': 3.0.4
@@ -6163,6 +6317,17 @@ snapshots:
   semver@7.7.4: {}
 
   shell-quote@1.8.3: {}
+
+  shiki@4.0.2:
+    dependencies:
+      '@shikijs/core': 4.0.2
+      '@shikijs/engine-javascript': 4.0.2
+      '@shikijs/engine-oniguruma': 4.0.2
+      '@shikijs/langs': 4.0.2
+      '@shikijs/themes': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   siginfo@2.0.0: {}
 

--- a/src/components/panels/CodeDiffViewer.tsx
+++ b/src/components/panels/CodeDiffViewer.tsx
@@ -1,26 +1,11 @@
-import { loader } from "@monaco-editor/react";
 import { invoke } from "@tauri-apps/api/core";
-import type * as Monaco from "monaco-editor";
-import { useCallback, useEffect, useRef, useState } from "react";
-import {
-	computeDiff,
-	createDiffDecorations,
-} from "@/hooks/useMonacoGutterEditor";
-import type { ChangeGroup } from "@/lib/computeHunks";
-import {
-	defaultDiffEditorOptions,
-	defaultEditorOptions,
-	MONACO_DARK_THEME_NAME,
-	MONACO_LIGHT_THEME_NAME,
-	monacoLightTheme,
-	monacoTheme,
-} from "@/lib/monaco-config";
+import { useEffect, useRef, useState } from "react";
+import type { ChangeGroup, Hunk } from "@/lib/computeHunks";
 import type { DiffMode } from "@/types/settings";
+import { ShikiDiffViewer } from "./ShikiDiffViewer";
 
-interface HiddenRange {
-	startLine: number;
-	endLine: number;
-	hiddenCount: number;
+interface DiffHunksResult {
+	hunks: Hunk[];
 }
 
 export interface CodeDiffViewerProps {
@@ -35,559 +20,6 @@ export interface CodeDiffViewerProps {
 	groupActionLabel?: string;
 }
 
-/**
- * Overlay floating "Stage" buttons at the top-right of each change group.
- * Uses direct DOM manipulation for performance (no React re-renders on scroll).
- */
-function updateStageOverlay(
-	editor: Monaco.editor.ICodeEditor,
-	overlay: HTMLDivElement,
-	changeGroups: ChangeGroup[] | undefined,
-	onStageGroup: ((groupIndex: number) => void) | undefined,
-	label = "Stage",
-) {
-	overlay.replaceChildren();
-
-	if (!changeGroups?.length || !onStageGroup) return;
-
-	const scrollTop = editor.getScrollTop();
-	const editorHeight = editor.getLayoutInfo().height;
-
-	for (const g of changeGroups) {
-		const top = editor.getTopForLineNumber(g.newStart) - scrollTop;
-		if (top < -30 || top > editorHeight) continue;
-
-		const widget = document.createElement("div");
-		widget.className = "hunk-widget";
-		widget.style.top = `${top}px`;
-
-		const btn = document.createElement("button");
-		btn.className = "hunk-seg-btn hunk-stage";
-		btn.textContent = label;
-		btn.addEventListener("click", () => onStageGroup(g.groupIndex));
-
-		widget.appendChild(btn);
-		overlay.appendChild(widget);
-	}
-}
-
-/**
- * Gutter mode: single Monaco editor showing the modified content
- * with gutter decorations (green/red bars) for added/deleted lines.
- */
-function GutterDiffViewer({
-	originalContent,
-	modifiedContent,
-	language,
-	diffOnlyMode,
-	changeGroups,
-	onStageGroup,
-	groupActionLabel,
-}: {
-	originalContent: string;
-	modifiedContent: string;
-	language: string;
-	diffOnlyMode?: boolean;
-	changeGroups?: ChangeGroup[];
-	onStageGroup?: (groupIndex: number) => void;
-	groupActionLabel?: string;
-}) {
-	const containerRef = useRef<HTMLDivElement>(null);
-	const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
-	const monacoRef = useRef<typeof Monaco | null>(null);
-	const decorationsRef = useRef<string[]>([]);
-	const overlayRef = useRef<HTMLDivElement>(null);
-	const viewZoneIdsRef = useRef<string[]>([]);
-	const [hiddenRanges, setHiddenRanges] = useState<HiddenRange[]>([]);
-	const hiddenRangesRef = useRef<HiddenRange[]>([]);
-	const [editorReady, setEditorReady] = useState(false);
-
-	// Always-latest refs so the async init callback sees current values
-	const latestOriginalRef = useRef(originalContent);
-	const latestModifiedRef = useRef(modifiedContent);
-	const latestLanguageRef = useRef(language);
-	const changeGroupsRef = useRef(changeGroups);
-	const onStageGroupRef = useRef(onStageGroup);
-	const groupActionLabelRef = useRef(groupActionLabel);
-	latestOriginalRef.current = originalContent;
-	latestModifiedRef.current = modifiedContent;
-	latestLanguageRef.current = language;
-	changeGroupsRef.current = changeGroups;
-	onStageGroupRef.current = onStageGroup;
-	groupActionLabelRef.current = groupActionLabel;
-
-	// Create / destroy editor
-	useEffect(() => {
-		let disposed = false;
-
-		loader.init().then((monaco) => {
-			if (disposed || !containerRef.current) return;
-			monacoRef.current = monaco;
-
-			monaco.editor.defineTheme(MONACO_DARK_THEME_NAME, monacoTheme);
-			monaco.editor.defineTheme(MONACO_LIGHT_THEME_NAME, monacoLightTheme);
-
-			const model = monaco.editor.createModel(
-				latestModifiedRef.current,
-				latestLanguageRef.current,
-			);
-
-			const editor = monaco.editor.create(containerRef.current, {
-				...defaultEditorOptions,
-				model,
-				readOnly: true,
-				glyphMargin: true,
-				theme: MONACO_DARK_THEME_NAME,
-			});
-
-			// Apply initial decorations
-			const diff = computeDiff(
-				latestOriginalRef.current,
-				latestModifiedRef.current,
-			);
-			const decos = createDiffDecorations(diff, monaco);
-			decorationsRef.current = editor.deltaDecorations([], decos);
-
-			// Stage overlay
-			const refreshOverlay = () => {
-				if (overlayRef.current) {
-					updateStageOverlay(
-						editor,
-						overlayRef.current,
-						changeGroupsRef.current,
-						onStageGroupRef.current,
-						groupActionLabelRef.current,
-					);
-				}
-			};
-			editor.onDidScrollChange(refreshOverlay);
-			editor.onDidLayoutChange(refreshOverlay);
-			requestAnimationFrame(refreshOverlay);
-
-			editorRef.current = editor;
-			setEditorReady(true);
-		});
-
-		return () => {
-			disposed = true;
-			const editor = editorRef.current;
-			if (editor) {
-				editor.getModel()?.dispose();
-				editor.dispose();
-				editorRef.current = null;
-			}
-			setEditorReady(false);
-		};
-	}, []);
-
-	// Helper: apply content + decorations to editor
-	const applyContentAndDecorations = useCallback(
-		(
-			editor: Monaco.editor.IStandaloneCodeEditor,
-			monaco: typeof Monaco,
-			original: string,
-			modified: string,
-		) => {
-			const model = editor.getModel();
-			if (model && model.getValue() !== modified) {
-				model.setValue(modified);
-			}
-			const diff = computeDiff(original, modified);
-			const newDecorations = createDiffDecorations(diff, monaco);
-			decorationsRef.current = editor.deltaDecorations(
-				decorationsRef.current,
-				newDecorations,
-			);
-		},
-		[],
-	);
-
-	// Update content + decorations (only when diffOnlyMode is OFF)
-	// When diffOnlyMode is ON, updates are deferred to the combined effect below
-	// to avoid showing stale decorations while hidden ranges are being recomputed.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: diffOnlyMode controls which branch handles content updates
-	useEffect(() => {
-		if (diffOnlyMode) return;
-		const editor = editorRef.current;
-		const monaco = monacoRef.current;
-		if (!editor || !monaco) return;
-		applyContentAndDecorations(
-			editor,
-			monaco,
-			originalContent,
-			modifiedContent,
-		);
-	}, [originalContent, modifiedContent, diffOnlyMode]);
-
-	// Update stage overlay when changeGroups change
-	useEffect(() => {
-		const editor = editorRef.current;
-		if (!editor || !overlayRef.current) return;
-		updateStageOverlay(
-			editor,
-			overlayRef.current,
-			changeGroups,
-			onStageGroupRef.current,
-			groupActionLabel,
-		);
-	}, [changeGroups, groupActionLabel]);
-
-	// Update language
-	useEffect(() => {
-		const editor = editorRef.current;
-		const monaco = monacoRef.current;
-		if (!editor || !monaco) return;
-
-		const model = editor.getModel();
-		if (model) {
-			monaco.editor.setModelLanguage(model, language);
-		}
-	}, [language]);
-
-	// Compute hidden ranges + update content/decorations atomically.
-	// When diffOnlyMode is ON, content and decoration updates are batched
-	// with hidden range computation to prevent the flash of full content
-	// that occurs when decorations update before hidden ranges are ready.
-	useEffect(() => {
-		if (!diffOnlyMode) {
-			hiddenRangesRef.current = [];
-			setHiddenRanges([]);
-			return;
-		}
-
-		let cancelled = false;
-
-		invoke<HiddenRange[]>("compute_hidden_ranges_from_content", {
-			original: originalContent,
-			modified: modifiedContent,
-			contextLines: 3,
-		})
-			.then((ranges) => {
-				if (cancelled) return;
-				// Apply content + decorations + hidden ranges together
-				const editor = editorRef.current;
-				const monaco = monacoRef.current;
-				if (editor && monaco) {
-					applyContentAndDecorations(
-						editor,
-						monaco,
-						originalContent,
-						modifiedContent,
-					);
-				}
-				hiddenRangesRef.current = ranges;
-				setHiddenRanges(ranges);
-			})
-			.catch(() => {
-				if (cancelled) return;
-				const editor = editorRef.current;
-				const monaco = monacoRef.current;
-				if (editor && monaco) {
-					applyContentAndDecorations(
-						editor,
-						monaco,
-						originalContent,
-						modifiedContent,
-					);
-				}
-				hiddenRangesRef.current = [];
-				setHiddenRanges([]);
-			});
-
-		return () => {
-			cancelled = true;
-		};
-	}, [
-		diffOnlyMode,
-		originalContent,
-		modifiedContent,
-		applyContentAndDecorations,
-	]);
-
-	// Apply/remove hidden areas + view zones
-	useEffect(() => {
-		if (!editorReady) return;
-		const editor = editorRef.current;
-		const monaco = monacoRef.current;
-		if (!editor || !monaco) return;
-
-		// Remove old view zones
-		editor.changeViewZones((accessor) => {
-			for (const id of viewZoneIdsRef.current) {
-				accessor.removeZone(id);
-			}
-		});
-		viewZoneIdsRef.current = [];
-
-		if (!diffOnlyMode || hiddenRanges.length === 0) {
-			// Clear hidden areas
-			// biome-ignore lint/suspicious/noExplicitAny: setHiddenAreas is internal Monaco API
-			(editor as any).setHiddenAreas?.([]);
-			return;
-		}
-
-		// Set hidden areas
-		const areas = hiddenRanges.map(
-			(r) => new monaco.Range(r.startLine, 1, r.endLine, 1),
-		);
-		// biome-ignore lint/suspicious/noExplicitAny: setHiddenAreas is internal Monaco API
-		(editor as any).setHiddenAreas?.(areas);
-
-		// Add view zones (banners) before each hidden area
-		const newZoneIds: string[] = [];
-		editor.changeViewZones((accessor) => {
-			for (const range of hiddenRanges) {
-				const domNode = document.createElement("div");
-				domNode.className =
-					"hidden-lines-banner flex items-center justify-center text-xs text-muted-foreground cursor-pointer hover:bg-muted/50 border-y border-border";
-				domNode.style.height = "22px";
-				domNode.textContent = `··· ${range.hiddenCount} lines hidden ···`;
-				domNode.addEventListener("click", () => {
-					// Expand this specific range
-					setHiddenRanges((prev) => {
-						const next = prev.filter(
-							(r) =>
-								r.startLine !== range.startLine || r.endLine !== range.endLine,
-						);
-						hiddenRangesRef.current = next;
-						return next;
-					});
-				});
-
-				const id = accessor.addZone({
-					afterLineNumber: range.startLine - 1,
-					heightInPx: 22,
-					domNode,
-				});
-				newZoneIds.push(id);
-			}
-		});
-		viewZoneIdsRef.current = newZoneIds;
-	}, [editorReady, diffOnlyMode, hiddenRanges]);
-
-	return (
-		<div className="h-full w-full relative" data-testid="code-diff-viewer">
-			<div ref={containerRef} className="h-full w-full" />
-			<div ref={overlayRef} className="hunk-overlay-container" />
-		</div>
-	);
-}
-
-function buildHideUnchangedRegionsOption(enabled: boolean) {
-	return {
-		enabled,
-		contextLineCount: 3,
-		minimumLineCount: 3,
-		revealLineCount: 20,
-	};
-}
-
-/**
- * Inline / Split mode: Monaco DiffEditor with inline or side-by-side rendering.
- */
-function MonacoDiffViewer({
-	originalContent,
-	modifiedContent,
-	diffMode,
-	diffOnlyMode,
-	language,
-	changeGroups,
-	onStageGroup,
-	groupActionLabel,
-}: {
-	originalContent: string;
-	modifiedContent: string;
-	diffMode: DiffMode;
-	diffOnlyMode?: boolean;
-	language: string;
-	changeGroups?: ChangeGroup[];
-	onStageGroup?: (groupIndex: number) => void;
-	groupActionLabel?: string;
-}) {
-	const containerRef = useRef<HTMLDivElement>(null);
-	const editorRef = useRef<Monaco.editor.IDiffEditor | null>(null);
-	const monacoRef = useRef<typeof Monaco | null>(null);
-	const overlayRef = useRef<HTMLDivElement>(null);
-	const [editorReady, setEditorReady] = useState(false);
-
-	// Always-latest refs so the async init callback sees current values
-	const latestOriginalRef = useRef(originalContent);
-	const latestModifiedRef = useRef(modifiedContent);
-	const latestLanguageRef = useRef(language);
-	const latestDiffModeRef = useRef(diffMode);
-	const latestDiffOnlyModeRef = useRef(diffOnlyMode);
-	const changeGroupsRef = useRef(changeGroups);
-	const onStageGroupRef = useRef(onStageGroup);
-	const groupActionLabelRef = useRef(groupActionLabel);
-	latestOriginalRef.current = originalContent;
-	latestModifiedRef.current = modifiedContent;
-	latestLanguageRef.current = language;
-	latestDiffModeRef.current = diffMode;
-	latestDiffOnlyModeRef.current = diffOnlyMode;
-	changeGroupsRef.current = changeGroups;
-	onStageGroupRef.current = onStageGroup;
-	groupActionLabelRef.current = groupActionLabel;
-
-	// Create / destroy editor
-	useEffect(() => {
-		let disposed = false;
-
-		loader.init().then((monaco) => {
-			if (disposed || !containerRef.current) return;
-			monacoRef.current = monaco;
-
-			monaco.editor.defineTheme(MONACO_DARK_THEME_NAME, monacoTheme);
-			monaco.editor.defineTheme(MONACO_LIGHT_THEME_NAME, monacoLightTheme);
-
-			const editor = monaco.editor.createDiffEditor(containerRef.current, {
-				...defaultDiffEditorOptions,
-				readOnly: true,
-				originalEditable: false,
-				renderSideBySide: latestDiffModeRef.current === "split",
-				useInlineViewWhenSpaceIsLimited: false,
-				glyphMargin: true,
-				theme: MONACO_DARK_THEME_NAME,
-				hideUnchangedRegions: buildHideUnchangedRegionsOption(
-					!!latestDiffOnlyModeRef.current,
-				),
-			});
-
-			const originalModel = monaco.editor.createModel(
-				latestOriginalRef.current,
-				latestLanguageRef.current,
-			);
-			const modifiedModel = monaco.editor.createModel(
-				latestModifiedRef.current,
-				latestLanguageRef.current,
-			);
-
-			editor.setModel({ original: originalModel, modified: modifiedModel });
-
-			// Stage overlay on modified editor
-			const modifiedEditor = editor.getModifiedEditor();
-			const refreshOverlay = () => {
-				if (overlayRef.current) {
-					updateStageOverlay(
-						modifiedEditor,
-						overlayRef.current,
-						changeGroupsRef.current,
-						onStageGroupRef.current,
-						groupActionLabelRef.current,
-					);
-				}
-			};
-			modifiedEditor.onDidScrollChange(refreshOverlay);
-			modifiedEditor.onDidLayoutChange(refreshOverlay);
-			requestAnimationFrame(refreshOverlay);
-
-			editorRef.current = editor;
-			setEditorReady(true);
-		});
-
-		return () => {
-			disposed = true;
-			const editor = editorRef.current;
-			if (editor) {
-				const model = editor.getModel();
-				model?.original?.dispose();
-				model?.modified?.dispose();
-				editor.dispose();
-				editorRef.current = null;
-			}
-			setEditorReady(false);
-		};
-	}, []);
-
-	// Update content
-	useEffect(() => {
-		const editor = editorRef.current;
-		const monaco = monacoRef.current;
-		if (!editor || !monaco) return;
-
-		const currentModel = editor.getModel();
-		if (!currentModel) return;
-
-		const origChanged = currentModel.original.getValue() !== originalContent;
-		const modChanged = currentModel.modified.getValue() !== modifiedContent;
-
-		if (!origChanged && !modChanged) return;
-
-		if (latestDiffOnlyModeRef.current) {
-			// When diffOnlyMode is on, recreate models instead of using setValue.
-			// setValue causes Monaco to expand collapsed hideUnchangedRegions
-			// during async diff recomputation. Recreating models forces Monaco
-			// to compute a fresh diff with hideUnchangedRegions applied correctly.
-			const newOriginal = monaco.editor.createModel(
-				originalContent,
-				latestLanguageRef.current,
-			);
-			const newModified = monaco.editor.createModel(
-				modifiedContent,
-				latestLanguageRef.current,
-			);
-			editor.setModel({ original: newOriginal, modified: newModified });
-			currentModel.original.dispose();
-			currentModel.modified.dispose();
-		} else {
-			if (origChanged) currentModel.original.setValue(originalContent);
-			if (modChanged) currentModel.modified.setValue(modifiedContent);
-		}
-	}, [originalContent, modifiedContent]);
-
-	// Update stage overlay when changeGroups change
-	useEffect(() => {
-		const editor = editorRef.current;
-		if (!editor || !overlayRef.current) return;
-		const modifiedEditor = editor.getModifiedEditor();
-		updateStageOverlay(
-			modifiedEditor,
-			overlayRef.current,
-			changeGroups,
-			onStageGroupRef.current,
-			groupActionLabel,
-		);
-	}, [changeGroups, groupActionLabel]);
-
-	// Update language
-	useEffect(() => {
-		const editor = editorRef.current;
-		const monaco = monacoRef.current;
-		if (!editor || !monaco) return;
-
-		const model = editor.getModel();
-		if (model) {
-			monaco.editor.setModelLanguage(model.original, language);
-			monaco.editor.setModelLanguage(model.modified, language);
-		}
-	}, [language]);
-
-	// Update diff mode (side-by-side vs inline)
-	useEffect(() => {
-		const editor = editorRef.current;
-		if (!editor) return;
-
-		editor.updateOptions({ renderSideBySide: diffMode === "split" });
-	}, [diffMode]);
-
-	// Update hideUnchangedRegions based on diffOnlyMode
-	useEffect(() => {
-		if (!editorReady) return;
-		const editor = editorRef.current;
-		if (!editor) return;
-
-		editor.updateOptions({
-			hideUnchangedRegions: buildHideUnchangedRegionsOption(!!diffOnlyMode),
-		});
-	}, [editorReady, diffOnlyMode]);
-
-	return (
-		<div className="h-full w-full relative" data-testid="code-diff-viewer">
-			<div ref={containerRef} className="h-full w-full" />
-			<div ref={overlayRef} className="hunk-overlay-container" />
-		</div>
-	);
-}
-
 export function CodeDiffViewer({
 	originalContent,
 	modifiedContent,
@@ -600,48 +32,54 @@ export function CodeDiffViewer({
 	groupActionLabel,
 }: CodeDiffViewerProps) {
 	const [detectedLanguage, setDetectedLanguage] = useState("plaintext");
+	const [hunks, setHunks] = useState<Hunk[] | null>(null);
+	const requestIdRef = useRef(0);
 
 	useEffect(() => {
-		if (language || !filePath) return;
-		let cancelled = false;
-		invoke<string>("get_language_from_path", { filePath }).then(
-			(detected) => {
-				if (!cancelled) setDetectedLanguage(detected);
-			},
-			() => {
-				if (!cancelled) setDetectedLanguage("plaintext");
-			},
-		);
-		return () => {
-			cancelled = true;
-		};
-	}, [language, filePath]);
+		const id = ++requestIdRef.current;
+		setHunks(null);
+		if (!language) setDetectedLanguage("plaintext");
+
+		const langPromise =
+			!language && filePath
+				? invoke<string>("get_language_from_path", { filePath }).catch(
+						() => "plaintext",
+					)
+				: Promise.resolve(language ?? "plaintext");
+
+		const hunksPromise = invoke<DiffHunksResult>("compute_diff_hunks", {
+			original: originalContent,
+			modified: modifiedContent,
+			filePath: filePath ?? null,
+		});
+
+		Promise.all([langPromise, hunksPromise])
+			.then(([detectedLang, hunksResult]) => {
+				if (requestIdRef.current !== id) return;
+				setDetectedLanguage(detectedLang);
+				setHunks(hunksResult.hunks);
+			})
+			.catch(() => {
+				if (requestIdRef.current !== id) return;
+				setHunks([]);
+			});
+	}, [originalContent, modifiedContent, filePath, language]);
 
 	const resolvedLanguage = language ?? detectedLanguage;
 
-	if (diffMode === "gutter") {
-		return (
-			<GutterDiffViewer
-				key="gutter"
-				originalContent={originalContent}
-				modifiedContent={modifiedContent}
-				language={resolvedLanguage}
-				diffOnlyMode={diffOnlyMode}
-				changeGroups={changeGroups}
-				onStageGroup={onStageGroup}
-				groupActionLabel={groupActionLabel}
-			/>
-		);
+	if (hunks === null) {
+		return null;
 	}
 
 	return (
-		<MonacoDiffViewer
-			key={diffMode}
+		<ShikiDiffViewer
 			originalContent={originalContent}
 			modifiedContent={modifiedContent}
 			diffMode={diffMode}
 			diffOnlyMode={diffOnlyMode}
 			language={resolvedLanguage}
+			hunks={hunks}
+			filePath={filePath}
 			changeGroups={changeGroups}
 			onStageGroup={onStageGroup}
 			groupActionLabel={groupActionLabel}

--- a/src/components/panels/CodeDiffViewer.tsx
+++ b/src/components/panels/CodeDiffViewer.tsx
@@ -34,10 +34,14 @@ export function CodeDiffViewer({
 	const [detectedLanguage, setDetectedLanguage] = useState("plaintext");
 	const [hunks, setHunks] = useState<Hunk[] | null>(null);
 	const requestIdRef = useRef(0);
+	const prevFilePathRef = useRef(filePath);
 
 	useEffect(() => {
 		const id = ++requestIdRef.current;
-		setHunks(null);
+		if (prevFilePathRef.current !== filePath) {
+			setHunks(null);
+			prevFilePathRef.current = filePath;
+		}
 		if (!language) setDetectedLanguage("plaintext");
 
 		const langPromise =

--- a/src/components/panels/DiffViewerSection.tsx
+++ b/src/components/panels/DiffViewerSection.tsx
@@ -47,7 +47,6 @@ export function DiffViewerSection(props: DiffViewerSectionProps) {
 
 	return (
 		<CodeDiffViewer
-			key={props.filePath ?? "__no-file__"}
 			originalContent={props.originalContent}
 			modifiedContent={props.modifiedContent}
 			diffMode={props.diffMode}

--- a/src/components/panels/ShikiDiffViewer.test.tsx
+++ b/src/components/panels/ShikiDiffViewer.test.tsx
@@ -1,0 +1,383 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ShikiDiffViewer } from "./ShikiDiffViewer";
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/hooks/useShikiHighlighter", () => ({
+	useShikiHighlighter: () => null,
+}));
+
+vi.mock("@tanstack/react-virtual", () => ({
+	useVirtualizer: ({
+		count,
+		estimateSize,
+	}: {
+		count: number;
+		estimateSize: (index: number) => number;
+	}) => ({
+		getVirtualItems: () =>
+			Array.from({ length: count }, (_, i) => {
+				const size = estimateSize(i);
+				return {
+					index: i,
+					key: i,
+					start: i * size,
+					size,
+					end: (i + 1) * size,
+				};
+			}),
+		getTotalSize: () => {
+			let total = 0;
+			for (let i = 0; i < count; i++) {
+				total += estimateSize(i);
+			}
+			return total;
+		},
+		measureElement: () => {},
+	}),
+}));
+
+const baseProps = {
+	originalContent: "line1\nline2\nline3\n",
+	modifiedContent: "line1\nmodified\nline3\n",
+	language: "typescript",
+	hunks: [
+		{
+			index: 0,
+			oldStart: 1,
+			oldLines: 3,
+			newStart: 1,
+			newLines: 3,
+			lines: [" line1", "-line2", "+modified", " line3"],
+		},
+	],
+};
+
+describe("ShikiDiffViewer", () => {
+	it("renders with data-testid code-diff-viewer", () => {
+		render(<ShikiDiffViewer {...baseProps} diffMode="gutter" />);
+		expect(screen.getByTestId("code-diff-viewer")).toBeDefined();
+	});
+
+	it("renders Gutter mode with new line numbers only", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="gutter" />,
+		);
+		const diffViewer = container.querySelector(
+			"[data-testid='code-diff-viewer']",
+		);
+		expect(diffViewer).toBeDefined();
+		// Gutter mode only shows new line numbers (column count = 1 number column)
+		expect(diffViewer?.textContent).toContain("2");
+		expect(diffViewer?.textContent).toContain("+");
+	});
+
+	it("renders Inline mode showing both old and new line numbers", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="inline" />,
+		);
+		const diffViewer = container.querySelector(
+			"[data-testid='code-diff-viewer']",
+		);
+		expect(diffViewer).toBeDefined();
+		// Inline mode: deleted and added lines are interleaved
+		expect(diffViewer?.textContent).toContain("+");
+		expect(diffViewer?.textContent).toContain("-");
+	});
+
+	it("renders Split mode with two columns", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="split" />,
+		);
+		const splitColumns = container.querySelectorAll(".flex-1");
+		expect(splitColumns.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("displays + marker for added lines and - marker for deleted lines", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="inline" />,
+		);
+		const text = container.textContent ?? "";
+		expect(text).toContain("+");
+		expect(text).toContain("-");
+	});
+
+	it("shows stage button when changeGroups and onStageGroup are provided", () => {
+		const onStage = vi.fn();
+		const { container } = render(
+			<ShikiDiffViewer
+				{...baseProps}
+				diffMode="inline"
+				changeGroups={[
+					{
+						groupIndex: 0,
+						hunkIndex: 0,
+						newStart: 2,
+						newEnd: 2,
+						lineOffsetStart: 1,
+						lineOffsetEnd: 3,
+					},
+				]}
+				onStageGroup={onStage}
+				groupActionLabel="Stage"
+			/>,
+		);
+		const stageButtons = container.querySelectorAll(".hunk-stage");
+		expect(stageButtons.length).toBeGreaterThan(0);
+	});
+
+	it("shows Unstage label when groupActionLabel is Unstage", () => {
+		const onStage = vi.fn();
+		const { container } = render(
+			<ShikiDiffViewer
+				{...baseProps}
+				diffMode="inline"
+				changeGroups={[
+					{
+						groupIndex: 0,
+						hunkIndex: 0,
+						newStart: 2,
+						newEnd: 2,
+						lineOffsetStart: 1,
+						lineOffsetEnd: 3,
+					},
+				]}
+				onStageGroup={onStage}
+				groupActionLabel="Unstage"
+			/>,
+		);
+		const stageButtons = container.querySelectorAll(".hunk-stage");
+		expect(stageButtons.length).toBeGreaterThan(0);
+		expect(stageButtons[0].textContent).toBe("Unstage");
+	});
+
+	it("renders with plaintext when language is plaintext", () => {
+		render(
+			<ShikiDiffViewer {...baseProps} diffMode="gutter" language="plaintext" />,
+		);
+		expect(screen.getByTestId("code-diff-viewer")).toBeDefined();
+	});
+
+	it("Gutter mode does not display deleted line content", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="gutter" />,
+		);
+		const text = container.textContent ?? "";
+		expect(text).toContain("modified");
+		expect(text).not.toContain("line2");
+	});
+
+	it("Gutter mode shows + marker for added lines", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="gutter" />,
+		);
+		const text = container.textContent ?? "";
+		expect(text).toContain("+");
+	});
+
+	it("Gutter mode shows - marker for pure deletion", () => {
+		const deletionOnlyProps = {
+			originalContent: "line1\nremoved\nline2\n",
+			modifiedContent: "line1\nline2\n",
+			language: "typescript",
+			hunks: [
+				{
+					index: 0,
+					oldStart: 1,
+					oldLines: 3,
+					newStart: 1,
+					newLines: 2,
+					lines: [" line1", "-removed", " line2"],
+				},
+			],
+		};
+		const { container } = render(
+			<ShikiDiffViewer {...deletionOnlyProps} diffMode="gutter" />,
+		);
+		const text = container.textContent ?? "";
+		expect(text).toContain("-");
+	});
+
+	it("Gutter mode shows only modified content with pure deletion", () => {
+		const deletionProps = {
+			originalContent: "line1\nremoved\nline2\n",
+			modifiedContent: "line1\nline2\n",
+			language: "typescript",
+			hunks: [
+				{
+					index: 0,
+					oldStart: 1,
+					oldLines: 3,
+					newStart: 1,
+					newLines: 2,
+					lines: [" line1", "-removed", " line2"],
+				},
+			],
+		};
+		const { container } = render(
+			<ShikiDiffViewer {...deletionProps} diffMode="gutter" />,
+		);
+		const text = container.textContent ?? "";
+		expect(text).not.toContain("removed");
+		expect(text).toContain("-");
+	});
+
+	it("Inline mode displays both added and deleted line content", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="inline" />,
+		);
+		const text = container.textContent ?? "";
+		expect(text).toContain("modified");
+		expect(text).toContain("line2");
+	});
+
+	it("Gutter mode shows colored bar instead of full-line background", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="gutter" />,
+		);
+		const bars = container.querySelectorAll(".w-\\[4px\\]");
+		expect(bars.length).toBeGreaterThan(0);
+		const addedBars = container.querySelectorAll(
+			".w-\\[4px\\].bg-\\[var\\(--status-added\\)\\]",
+		);
+		expect(addedBars.length).toBeGreaterThan(0);
+	});
+
+	it("Gutter mode deletion shows red bar", () => {
+		const deletionProps = {
+			originalContent: "line1\nremoved\nline2\n",
+			modifiedContent: "line1\nline2\n",
+			language: "typescript",
+			hunks: [
+				{
+					index: 0,
+					oldStart: 1,
+					oldLines: 3,
+					newStart: 1,
+					newLines: 2,
+					lines: [" line1", "-removed", " line2"],
+				},
+			],
+		};
+		const { container } = render(
+			<ShikiDiffViewer {...deletionProps} diffMode="gutter" />,
+		);
+		const deletedBars = container.querySelectorAll(
+			".w-\\[4px\\].bg-\\[var\\(--status-deleted\\)\\]",
+		);
+		expect(deletedBars.length).toBeGreaterThan(0);
+	});
+
+	it("renders scrollbar markers for diff blocks", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="inline" />,
+		);
+		const markersContainer = container.querySelector(
+			"[data-testid='scrollbar-markers']",
+		);
+		expect(markersContainer).toBeDefined();
+		expect(markersContainer?.getAttribute("aria-hidden")).toBe("true");
+		const markers = markersContainer?.querySelectorAll("[class*='absolute']");
+		expect(markers?.length).toBeGreaterThan(0);
+	});
+
+	it("does not render scrollbar markers when no diff blocks exist", () => {
+		const noDiffProps = {
+			originalContent: "same\n",
+			modifiedContent: "same\n",
+			language: "typescript",
+			hunks: [] as typeof baseProps.hunks,
+		};
+		const { container } = render(
+			<ShikiDiffViewer {...noDiffProps} diffMode="inline" />,
+		);
+		const markersContainer = container.querySelector(
+			"[data-testid='scrollbar-markers']",
+		);
+		expect(markersContainer).toBeNull();
+	});
+
+	it("scrollbar markers rendered for all three modes", () => {
+		for (const mode of ["gutter", "inline", "split"] as const) {
+			const { container } = render(
+				<ShikiDiffViewer {...baseProps} diffMode={mode} />,
+			);
+			const markersContainer = container.querySelector(
+				"[data-testid='scrollbar-markers']",
+			);
+			expect(markersContainer).not.toBeNull();
+		}
+	});
+
+	it("calls onStageGroup with correct groupIndex when stage button is clicked", () => {
+		const onStage = vi.fn();
+		const { container } = render(
+			<ShikiDiffViewer
+				{...baseProps}
+				diffMode="inline"
+				changeGroups={[
+					{
+						groupIndex: 2,
+						hunkIndex: 0,
+						newStart: 2,
+						newEnd: 2,
+						lineOffsetStart: 1,
+						lineOffsetEnd: 3,
+					},
+				]}
+				onStageGroup={onStage}
+				groupActionLabel="Stage"
+			/>,
+		);
+		const stageButton = container.querySelector(".hunk-stage") as HTMLElement;
+		expect(stageButton).not.toBeNull();
+		fireEvent.click(stageButton);
+		expect(onStage).toHaveBeenCalledWith(2);
+	});
+
+	it("shows hidden lines banner when diffOnlyMode is true", async () => {
+		const longOriginal =
+			"line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n";
+		const longModified =
+			"line1\nline2\nline3\nline4\nchanged\nline6\nline7\nline8\nline9\nline10\n";
+		const longHunks = [
+			{
+				index: 0,
+				oldStart: 5,
+				oldLines: 1,
+				newStart: 5,
+				newLines: 1,
+				lines: ["-line5", "+changed"],
+			},
+		];
+		const { invoke } = await import("@tauri-apps/api/core");
+		vi.mocked(invoke).mockResolvedValue([
+			{ startLine: 1, endLine: 2, hiddenCount: 2 },
+		]);
+		const { container } = render(
+			<ShikiDiffViewer
+				originalContent={longOriginal}
+				modifiedContent={longModified}
+				language="typescript"
+				hunks={longHunks}
+				diffMode="inline"
+				diffOnlyMode={true}
+			/>,
+		);
+		await waitFor(() => {
+			expect(container.textContent).toContain("lines hidden");
+		});
+	});
+
+	it("shows all lines without hidden banner when diffOnlyMode is false", () => {
+		const { container } = render(
+			<ShikiDiffViewer {...baseProps} diffMode="inline" diffOnlyMode={false} />,
+		);
+		expect(container.textContent).not.toContain("lines hidden");
+		expect(container.textContent).toContain("line1");
+		expect(container.textContent).toContain("line3");
+	});
+});

--- a/src/components/panels/ShikiDiffViewer.tsx
+++ b/src/components/panels/ShikiDiffViewer.tsx
@@ -337,7 +337,11 @@ function useDelegatedClick(
 				const startLine = Number(expandBtn.dataset.expandStart);
 				const endLine = Number(expandBtn.dataset.expandEnd);
 				const hiddenCount = Number(expandBtn.dataset.expandCount);
-				if (!Number.isNaN(startLine)) {
+				if (
+					Number.isFinite(startLine) &&
+					Number.isFinite(endLine) &&
+					Number.isFinite(hiddenCount)
+				) {
 					onExpandRange({ startLine, endLine, hiddenCount });
 				}
 			}
@@ -907,7 +911,7 @@ export function ShikiDiffViewer({
 				containerRef.current.scrollTo(0, 0);
 			}
 		}
-	});
+	}, [filePath]);
 
 	const handleDelegatedClick = useDelegatedClick(onStageGroup, expandRange);
 

--- a/src/components/panels/ShikiDiffViewer.tsx
+++ b/src/components/panels/ShikiDiffViewer.tsx
@@ -1,0 +1,951 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { invoke } from "@tauri-apps/api/core";
+import React, {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import {
+	assignChangeGroupsToBlocks,
+	computeDiffBlocks,
+	type DiffBlock,
+	type DiffLine,
+} from "@/hooks/useDiffTokens";
+import { useShikiHighlighter } from "@/hooks/useShikiHighlighter";
+import type { ChangeGroup, Hunk } from "@/lib/computeHunks";
+import type { DiffMode } from "@/types/settings";
+
+interface HiddenRange {
+	startLine: number;
+	endLine: number;
+	hiddenCount: number;
+}
+
+function findHiddenRange(
+	lineNum: number,
+	ranges: HiddenRange[],
+): HiddenRange | undefined {
+	let lo = 0;
+	let hi = ranges.length - 1;
+	while (lo <= hi) {
+		const mid = (lo + hi) >>> 1;
+		const r = ranges[mid];
+		if (lineNum < r.startLine) {
+			hi = mid - 1;
+		} else if (lineNum > r.endLine) {
+			lo = mid + 1;
+		} else {
+			return r;
+		}
+	}
+	return undefined;
+}
+
+export interface ShikiDiffViewerProps {
+	originalContent: string;
+	modifiedContent: string;
+	diffMode: DiffMode;
+	diffOnlyMode?: boolean;
+	language: string;
+	hunks: Hunk[];
+	filePath?: string;
+	changeGroups?: ChangeGroup[];
+	onStageGroup?: (groupIndex: number) => void;
+	groupActionLabel?: string;
+}
+
+type VisibleItem = DiffBlock | { type: "hidden"; range: HiddenRange };
+
+function lineBgClass(type: string): string {
+	if (type === "added")
+		return "bg-[color-mix(in_oklch,var(--status-added)_15%,transparent)]";
+	if (type === "deleted")
+		return "bg-[color-mix(in_oklch,var(--status-deleted)_15%,transparent)]";
+	return "";
+}
+
+function lineMarkerClass(type: string): string {
+	if (type === "added") return "text-[var(--status-added)]";
+	if (type === "deleted") return "text-[var(--status-deleted)]";
+	return "text-transparent";
+}
+
+function lineMarker(type: string): string {
+	if (type === "added") return "+";
+	if (type === "deleted") return "-";
+	return " ";
+}
+
+function renderTokens(tokens: DiffLine["tokens"]): React.ReactNode {
+	if (tokens.length === 0) return "\u00A0";
+	let offset = 0;
+	return tokens.map((token) => {
+		const key = `${offset}-${token.content.length}`;
+		offset += token.content.length;
+		return (
+			<span key={key} style={{ color: token.color }}>
+				{token.content}
+			</span>
+		);
+	});
+}
+
+const DiffLineRow = React.memo(function DiffLineRow({
+	line,
+	showOldLineNumber,
+	showNewLineNumber,
+}: {
+	line: DiffLine;
+	showOldLineNumber: boolean;
+	showNewLineNumber: boolean;
+}) {
+	return (
+		<div
+			className={`flex ${lineBgClass(line.type)} hover:brightness-110 min-h-[20px]`}
+		>
+			{showOldLineNumber && (
+				<span className="shrink-0 w-[50px] text-right pr-2 text-[var(--muted-foreground)] text-xs select-none opacity-60 leading-[20px]">
+					{line.oldLineNumber ?? ""}
+				</span>
+			)}
+			{showNewLineNumber && (
+				<span className="shrink-0 w-[50px] text-right pr-2 text-[var(--muted-foreground)] text-xs select-none opacity-60 leading-[20px]">
+					{line.newLineNumber ?? ""}
+				</span>
+			)}
+			<span
+				className={`shrink-0 w-[20px] text-center text-xs select-none leading-[20px] font-mono ${lineMarkerClass(line.type)}`}
+			>
+				{lineMarker(line.type)}
+			</span>
+			<span className="flex-1 whitespace-pre-wrap break-all font-mono text-sm leading-[20px] pr-4">
+				{renderTokens(line.tokens)}
+			</span>
+		</div>
+	);
+});
+
+interface GutterDiffLine extends DiffLine {
+	hasDeleteMarker?: boolean;
+	changeGroupIndex?: number;
+	isGroupStart?: boolean;
+}
+
+function buildGutterLines(blocks: DiffBlock[]): GutterDiffLine[] {
+	const result: GutterDiffLine[] = [];
+
+	for (const block of blocks) {
+		if (block.type === "context") {
+			for (const line of block.lines) {
+				result.push({ ...line });
+			}
+			continue;
+		}
+
+		let pendingDeleteMarker = false;
+		const nonDeletedLines: GutterDiffLine[] = [];
+		let isFirst = true;
+
+		for (const line of block.lines) {
+			if (line.type === "deleted") {
+				pendingDeleteMarker = true;
+			} else {
+				const gutterLine: GutterDiffLine = {
+					...line,
+					changeGroupIndex: block.changeGroupIndex,
+				};
+				if (pendingDeleteMarker) {
+					gutterLine.hasDeleteMarker = true;
+					pendingDeleteMarker = false;
+				}
+				if (isFirst) {
+					gutterLine.isGroupStart = true;
+					isFirst = false;
+				}
+				nonDeletedLines.push(gutterLine);
+			}
+		}
+
+		if (pendingDeleteMarker && nonDeletedLines.length > 0) {
+			nonDeletedLines[nonDeletedLines.length - 1].hasDeleteMarker = true;
+		}
+
+		if (nonDeletedLines.length === 0) {
+			nonDeletedLines.push({
+				type: "context",
+				oldLineNumber: null,
+				newLineNumber: null,
+				tokens: [],
+				content: "",
+				hasDeleteMarker: true,
+				changeGroupIndex: block.changeGroupIndex,
+				isGroupStart: true,
+			});
+		}
+
+		result.push(...nonDeletedLines);
+	}
+
+	return result;
+}
+
+const GutterLineRow = React.memo(function GutterLineRow({
+	line,
+}: {
+	line: GutterDiffLine;
+}) {
+	const isAdded = line.type === "added";
+	const hasDelete = line.hasDeleteMarker === true;
+
+	const barClass = isAdded
+		? "bg-[var(--status-added)]"
+		: hasDelete
+			? "bg-[var(--status-deleted)]"
+			: "bg-transparent";
+
+	const marker = isAdded ? "+" : hasDelete ? "-" : " ";
+	const markerClass = isAdded
+		? "text-[var(--status-added)]"
+		: hasDelete
+			? "text-[var(--status-deleted)]"
+			: "text-transparent";
+
+	return (
+		<div className="flex hover:brightness-110 min-h-[20px]">
+			<span className={`shrink-0 w-[4px] ml-[3px] ${barClass}`} />
+			<span className="shrink-0 w-[50px] text-right pr-2 text-[var(--muted-foreground)] text-xs select-none opacity-60 leading-[20px]">
+				{line.newLineNumber ?? ""}
+			</span>
+			<span
+				className={`shrink-0 w-[20px] text-center text-xs select-none leading-[20px] font-mono ${markerClass}`}
+			>
+				{marker}
+			</span>
+			<span className="flex-1 whitespace-pre-wrap break-all font-mono text-sm leading-[20px] pr-4">
+				{renderTokens(line.tokens)}
+			</span>
+		</div>
+	);
+});
+
+function renderHalfLine(line: DiffLine | null): React.ReactNode {
+	if (!line) return <div className="min-h-[20px] bg-[var(--muted)]/20" />;
+	return (
+		<div
+			className={`flex ${lineBgClass(line.type)} hover:brightness-110 min-h-[20px]`}
+		>
+			<span className="shrink-0 w-[50px] text-right pr-2 text-[var(--muted-foreground)] text-xs select-none opacity-60 leading-[20px]">
+				{(line.type === "deleted" ? line.oldLineNumber : line.newLineNumber) ??
+					""}
+			</span>
+			<span
+				className={`shrink-0 w-[20px] text-center text-xs select-none leading-[20px] font-mono ${lineMarkerClass(line.type)}`}
+			>
+				{lineMarker(line.type)}
+			</span>
+			<span className="flex-1 whitespace-pre-wrap break-all font-mono text-sm leading-[20px] pr-4">
+				{renderTokens(line.tokens)}
+			</span>
+		</div>
+	);
+}
+
+const SplitDiffLineRow = React.memo(function SplitDiffLineRow({
+	left,
+	right,
+}: {
+	left: DiffLine | null;
+	right: DiffLine | null;
+}) {
+	return (
+		<div className="flex">
+			<div className="flex-1 border-r border-border overflow-hidden">
+				{renderHalfLine(left)}
+			</div>
+			<div className="flex-1 overflow-hidden">{renderHalfLine(right)}</div>
+		</div>
+	);
+});
+
+type FlatGutterItem =
+	| { kind: "gutter-line"; line: GutterDiffLine }
+	| { kind: "hidden"; range: HiddenRange };
+
+type FlatInlineItem =
+	| {
+			kind: "line";
+			line: DiffLine;
+			showStageButton: boolean;
+			changeGroupIndex?: number;
+	  }
+	| { kind: "hidden"; range: HiddenRange };
+
+interface FlatSplitRow {
+	left: DiffLine | null;
+	right: DiffLine | null;
+	showStageButton: boolean;
+	changeGroupIndex?: number;
+}
+
+type FlatSplitItem =
+	| { kind: "split-row"; row: FlatSplitRow }
+	| { kind: "hidden"; range: HiddenRange };
+
+interface VirtualViewProps {
+	visibleBlocks: VisibleItem[];
+	changeGroups?: ChangeGroup[];
+	onStageGroup?: (groupIndex: number) => void;
+	groupActionLabel?: string;
+	containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+function flattenWithGroups(
+	visibleBlocks: VisibleItem[],
+	changeGroups: ChangeGroup[],
+): { blocksWithGroups: DiffBlock[]; blockOrder: VisibleItem[] } {
+	const diffBlocks: DiffBlock[] = [];
+	for (const item of visibleBlocks) {
+		if (item.type !== "hidden") {
+			diffBlocks.push(item as DiffBlock);
+		}
+	}
+	const blocksWithGroups = assignChangeGroupsToBlocks(diffBlocks, changeGroups);
+	return { blocksWithGroups, blockOrder: visibleBlocks };
+}
+
+function useDelegatedClick(
+	onStageGroup: ((groupIndex: number) => void) | undefined,
+	onExpandRange: (range: HiddenRange) => void,
+): (e: React.MouseEvent<HTMLDivElement>) => void {
+	return useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			const target = e.target as HTMLElement;
+
+			const stageBtn = target.closest<HTMLElement>("[data-group-index]");
+			if (stageBtn && onStageGroup) {
+				const idx = Number(stageBtn.dataset.groupIndex);
+				if (!Number.isNaN(idx)) {
+					onStageGroup(idx);
+				}
+				return;
+			}
+
+			const expandBtn = target.closest<HTMLElement>("[data-expand-start]");
+			if (expandBtn) {
+				const startLine = Number(expandBtn.dataset.expandStart);
+				const endLine = Number(expandBtn.dataset.expandEnd);
+				const hiddenCount = Number(expandBtn.dataset.expandCount);
+				if (!Number.isNaN(startLine)) {
+					onExpandRange({ startLine, endLine, hiddenCount });
+				}
+			}
+		},
+		[onStageGroup, onExpandRange],
+	);
+}
+
+function HiddenBanner({ range }: { range: HiddenRange }) {
+	return (
+		<button
+			type="button"
+			className="flex w-full items-center justify-center text-xs text-muted-foreground cursor-pointer hover:bg-muted/50 border-y border-border h-[22px] bg-transparent"
+			data-expand-start={range.startLine}
+			data-expand-end={range.endLine}
+			data-expand-count={range.hiddenCount}
+		>
+			··· {range.hiddenCount} lines hidden ···
+		</button>
+	);
+}
+
+function GroupStageButton({
+	groupIndex,
+	label,
+}: {
+	groupIndex: number;
+	label: string;
+}) {
+	return (
+		<button
+			type="button"
+			className="hunk-seg-btn hunk-stage absolute right-2 top-0 z-10"
+			data-group-index={groupIndex}
+		>
+			{label}
+		</button>
+	);
+}
+
+function GutterView({
+	visibleBlocks,
+	changeGroups,
+	onStageGroup,
+	groupActionLabel,
+	containerRef,
+}: VirtualViewProps) {
+	const flatItems = useMemo(() => {
+		const { blocksWithGroups, blockOrder } = flattenWithGroups(
+			visibleBlocks,
+			changeGroups ?? [],
+		);
+		const result: FlatGutterItem[] = [];
+		let blockIdx = 0;
+
+		for (const item of blockOrder) {
+			if (item.type === "hidden") {
+				result.push({ kind: "hidden", range: item.range });
+			} else {
+				const block = blocksWithGroups[blockIdx++];
+				const gutterLines = buildGutterLines([block]);
+				for (const line of gutterLines) {
+					result.push({ kind: "gutter-line", line });
+				}
+			}
+		}
+
+		return result;
+	}, [visibleBlocks, changeGroups]);
+
+	const virtualizer = useVirtualizer({
+		count: flatItems.length,
+		getScrollElement: () => containerRef.current,
+		estimateSize: (i) => (flatItems[i].kind === "hidden" ? 22 : 20),
+		overscan: 15,
+	});
+
+	return (
+		<div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+			{virtualizer.getVirtualItems().map((vItem) => {
+				const item = flatItems[vItem.index];
+				return (
+					<div
+						key={vItem.index}
+						data-index={vItem.index}
+						ref={virtualizer.measureElement}
+						style={{
+							position: "absolute",
+							top: 0,
+							left: 0,
+							width: "100%",
+							transform: `translateY(${vItem.start}px)`,
+						}}
+					>
+						{item.kind === "hidden" ? (
+							<HiddenBanner range={item.range} />
+						) : (
+							<>
+								{item.line.isGroupStart &&
+									item.line.changeGroupIndex != null &&
+									onStageGroup && (
+										<GroupStageButton
+											groupIndex={item.line.changeGroupIndex}
+											label={groupActionLabel ?? "Stage"}
+										/>
+									)}
+								<GutterLineRow line={item.line} />
+							</>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function InlineView({
+	visibleBlocks,
+	changeGroups,
+	onStageGroup,
+	groupActionLabel,
+	containerRef,
+}: VirtualViewProps) {
+	const flatItems = useMemo(() => {
+		const { blocksWithGroups, blockOrder } = flattenWithGroups(
+			visibleBlocks,
+			changeGroups ?? [],
+		);
+		const result: FlatInlineItem[] = [];
+		let blockIdx = 0;
+
+		for (const item of blockOrder) {
+			if (item.type === "hidden") {
+				result.push({ kind: "hidden", range: item.range });
+			} else {
+				const block = blocksWithGroups[blockIdx++];
+				let isFirst = true;
+				for (const line of block.lines) {
+					result.push({
+						kind: "line",
+						line,
+						showStageButton: isFirst && block.changeGroupIndex != null,
+						changeGroupIndex: block.changeGroupIndex,
+					});
+					isFirst = false;
+				}
+			}
+		}
+
+		return result;
+	}, [visibleBlocks, changeGroups]);
+
+	const virtualizer = useVirtualizer({
+		count: flatItems.length,
+		getScrollElement: () => containerRef.current,
+		estimateSize: (i) => (flatItems[i].kind === "hidden" ? 22 : 20),
+		overscan: 15,
+	});
+
+	return (
+		<div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+			{virtualizer.getVirtualItems().map((vItem) => {
+				const item = flatItems[vItem.index];
+				return (
+					<div
+						key={vItem.index}
+						data-index={vItem.index}
+						ref={virtualizer.measureElement}
+						style={{
+							position: "absolute",
+							top: 0,
+							left: 0,
+							width: "100%",
+							transform: `translateY(${vItem.start}px)`,
+						}}
+					>
+						{item.kind === "hidden" ? (
+							<HiddenBanner range={item.range} />
+						) : (
+							<>
+								{item.showStageButton &&
+									item.changeGroupIndex != null &&
+									onStageGroup && (
+										<GroupStageButton
+											groupIndex={item.changeGroupIndex}
+											label={groupActionLabel ?? "Stage"}
+										/>
+									)}
+								<DiffLineRow
+									line={item.line}
+									showOldLineNumber={true}
+									showNewLineNumber={true}
+								/>
+							</>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function SplitView({
+	visibleBlocks,
+	changeGroups,
+	onStageGroup,
+	groupActionLabel,
+	containerRef,
+}: VirtualViewProps) {
+	const flatItems = useMemo(() => {
+		const { blocksWithGroups, blockOrder } = flattenWithGroups(
+			visibleBlocks,
+			changeGroups ?? [],
+		);
+		const result: FlatSplitItem[] = [];
+		let blockIdx = 0;
+
+		for (const item of blockOrder) {
+			if (item.type === "hidden") {
+				result.push({ kind: "hidden", range: item.range });
+			} else {
+				const block = blocksWithGroups[blockIdx++];
+
+				if (block.type === "context") {
+					for (const line of block.lines) {
+						result.push({
+							kind: "split-row",
+							row: {
+								left: line,
+								right: line,
+								showStageButton: false,
+							},
+						});
+					}
+				} else {
+					const deleted = block.lines.filter((l) => l.type === "deleted");
+					const added = block.lines.filter((l) => l.type === "added");
+					const contextInBlock = block.lines.filter(
+						(l) => l.type === "context",
+					);
+
+					const maxLen = Math.max(deleted.length, added.length);
+					for (let i = 0; i < maxLen; i++) {
+						result.push({
+							kind: "split-row",
+							row: {
+								left: deleted[i] ?? null,
+								right: added[i] ?? null,
+								showStageButton: i === 0 && block.changeGroupIndex != null,
+								changeGroupIndex: block.changeGroupIndex,
+							},
+						});
+					}
+
+					for (const line of contextInBlock) {
+						result.push({
+							kind: "split-row",
+							row: {
+								left: line,
+								right: line,
+								showStageButton: false,
+							},
+						});
+					}
+				}
+			}
+		}
+
+		return result;
+	}, [visibleBlocks, changeGroups]);
+
+	const virtualizer = useVirtualizer({
+		count: flatItems.length,
+		getScrollElement: () => containerRef.current,
+		estimateSize: (i) => (flatItems[i].kind === "hidden" ? 22 : 20),
+		overscan: 15,
+	});
+
+	return (
+		<div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+			{virtualizer.getVirtualItems().map((vItem) => {
+				const item = flatItems[vItem.index];
+				return (
+					<div
+						key={vItem.index}
+						data-index={vItem.index}
+						ref={virtualizer.measureElement}
+						style={{
+							position: "absolute",
+							top: 0,
+							left: 0,
+							width: "100%",
+							transform: `translateY(${vItem.start}px)`,
+						}}
+					>
+						{item.kind === "hidden" ? (
+							<HiddenBanner range={item.range} />
+						) : (
+							<>
+								{item.row.showStageButton &&
+									item.row.changeGroupIndex != null &&
+									onStageGroup && (
+										<GroupStageButton
+											groupIndex={item.row.changeGroupIndex}
+											label={groupActionLabel ?? "Stage"}
+										/>
+									)}
+								<SplitDiffLineRow left={item.row.left} right={item.row.right} />
+							</>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+interface DiffMarker {
+	position: number;
+	height: number;
+	type: "added" | "deleted";
+}
+
+function computeBlockLineCount(block: DiffBlock, mode: DiffMode): number {
+	if (block.type === "context") return block.lines.length;
+	if (mode === "gutter") return buildGutterLines([block]).length;
+	if (mode === "split") {
+		const deleted = block.lines.filter((l) => l.type === "deleted").length;
+		const added = block.lines.filter((l) => l.type === "added").length;
+		const ctx = block.lines.filter((l) => l.type === "context").length;
+		return Math.max(deleted, added) + ctx;
+	}
+	return block.lines.length;
+}
+
+function flushRun(
+	markers: DiffMarker[],
+	runStart: number,
+	runLen: number,
+	totalLines: number,
+	runType: "added" | "deleted",
+): void {
+	if (runLen <= 0) return;
+	markers.push({
+		position: runStart / totalLines,
+		height: runLen / totalLines,
+		type: runType,
+	});
+}
+
+function computeDiffMarkers(
+	visibleBlocks: VisibleItem[],
+	diffMode: DiffMode,
+): DiffMarker[] {
+	let totalLines = 0;
+	for (const item of visibleBlocks) {
+		if (item.type === "hidden") {
+			totalLines += 1;
+		} else {
+			totalLines += computeBlockLineCount(item as DiffBlock, diffMode);
+		}
+	}
+	if (totalLines === 0) return [];
+
+	const markers: DiffMarker[] = [];
+	let currentLine = 0;
+
+	for (const item of visibleBlocks) {
+		if (item.type === "hidden") {
+			currentLine += 1;
+			continue;
+		}
+		const block = item as DiffBlock;
+
+		if (block.type === "change") {
+			let runStart = currentLine;
+			let runLen = 0;
+			let runType: "added" | "deleted" | null = null;
+
+			for (const line of block.lines) {
+				if (line.type === "context") {
+					flushRun(markers, runStart, runLen, totalLines, runType ?? "added");
+					runLen = 0;
+					runType = null;
+					currentLine += 1;
+					runStart = currentLine;
+				} else if (diffMode === "gutter" && line.type === "deleted") {
+					// Gutter mode: deleted lines are collapsed, skip
+				} else {
+					if (runType !== null && runType !== line.type) {
+						flushRun(markers, runStart, runLen, totalLines, runType);
+						runLen = 0;
+						runStart = currentLine;
+					}
+					runType = line.type as "added" | "deleted";
+					runLen += 1;
+					currentLine += 1;
+				}
+			}
+
+			if (runLen > 0 && runType !== null) {
+				flushRun(markers, runStart, runLen, totalLines, runType);
+			}
+		} else {
+			currentLine += block.lines.length;
+		}
+	}
+
+	return markers;
+}
+
+const MARKER_COLORS: Record<DiffMarker["type"], string> = {
+	added: "color-mix(in oklch, var(--status-added) 55%, transparent)",
+	deleted: "color-mix(in oklch, var(--status-deleted) 55%, transparent)",
+};
+
+const ScrollbarMarkers = React.memo(function ScrollbarMarkers({
+	markers,
+}: {
+	markers: DiffMarker[];
+}) {
+	if (markers.length === 0) return null;
+
+	return (
+		<div
+			className="absolute top-0 right-0 h-full pointer-events-none"
+			style={{ width: "10px" }}
+			aria-hidden="true"
+			data-testid="scrollbar-markers"
+		>
+			{markers.map((marker) => {
+				const key = `${marker.position}-${marker.type}`;
+				return (
+					<div
+						key={key}
+						className="absolute"
+						style={{
+							top: `${marker.position * 100}%`,
+							height: `${Math.max(marker.height * 100, 0.4)}%`,
+							minHeight: "2px",
+							width: "8px",
+							right: "1px",
+							backgroundColor: MARKER_COLORS[marker.type],
+						}}
+					/>
+				);
+			})}
+		</div>
+	);
+});
+
+export function ShikiDiffViewer({
+	originalContent,
+	modifiedContent,
+	diffMode,
+	diffOnlyMode,
+	language,
+	hunks,
+	filePath,
+	changeGroups,
+	onStageGroup,
+	groupActionLabel,
+}: ShikiDiffViewerProps) {
+	const originalTokens = useShikiHighlighter(originalContent, language);
+	const modifiedTokens = useShikiHighlighter(modifiedContent, language);
+
+	const { blocks } = useMemo(
+		() =>
+			computeDiffBlocks(
+				hunks,
+				originalTokens,
+				modifiedTokens,
+				originalContent,
+				modifiedContent,
+			),
+		[hunks, originalTokens, modifiedTokens, originalContent, modifiedContent],
+	);
+
+	const [hiddenRanges, setHiddenRanges] = useState<HiddenRange[]>([]);
+
+	useEffect(() => {
+		if (!diffOnlyMode) {
+			setHiddenRanges([]);
+			return;
+		}
+
+		let cancelled = false;
+		invoke<HiddenRange[]>("compute_hidden_ranges_from_content", {
+			original: originalContent,
+			modified: modifiedContent,
+			contextLines: 3,
+		})
+			.then((ranges) => {
+				if (!cancelled) setHiddenRanges(ranges);
+			})
+			.catch(() => {
+				if (!cancelled) setHiddenRanges([]);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [diffOnlyMode, originalContent, modifiedContent]);
+
+	const expandRange = useCallback((range: HiddenRange) => {
+		setHiddenRanges((prev) =>
+			prev.filter(
+				(r) => r.startLine !== range.startLine || r.endLine !== range.endLine,
+			),
+		);
+	}, []);
+
+	const visibleBlocks = useMemo(() => {
+		if (!diffOnlyMode || hiddenRanges.length === 0) return blocks;
+
+		const result: VisibleItem[] = [];
+
+		for (const block of blocks) {
+			if (block.type === "change") {
+				result.push(block);
+				continue;
+			}
+
+			const visibleLines: DiffLine[] = [];
+			let currentHiddenRange: HiddenRange | null = null;
+
+			for (const line of block.lines) {
+				const lineNum = line.newLineNumber ?? line.oldLineNumber ?? 0;
+				const hidden = findHiddenRange(lineNum, hiddenRanges);
+
+				if (hidden) {
+					if (visibleLines.length > 0) {
+						result.push({ type: "context", lines: [...visibleLines] });
+						visibleLines.length = 0;
+					}
+					if (
+						!currentHiddenRange ||
+						currentHiddenRange.startLine !== hidden.startLine
+					) {
+						currentHiddenRange = hidden;
+						result.push({ type: "hidden", range: hidden });
+					}
+				} else {
+					currentHiddenRange = null;
+					visibleLines.push(line);
+				}
+			}
+
+			if (visibleLines.length > 0) {
+				result.push({ type: "context", lines: visibleLines });
+			}
+		}
+
+		return result;
+	}, [blocks, diffOnlyMode, hiddenRanges]);
+
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	const prevFilePathRef = useRef(filePath);
+	useEffect(() => {
+		if (prevFilePathRef.current !== filePath) {
+			prevFilePathRef.current = filePath;
+			if (
+				containerRef.current &&
+				typeof containerRef.current.scrollTo === "function"
+			) {
+				containerRef.current.scrollTo(0, 0);
+			}
+		}
+	});
+
+	const handleDelegatedClick = useDelegatedClick(onStageGroup, expandRange);
+
+	const diffMarkers = useMemo(
+		() => computeDiffMarkers(visibleBlocks, diffMode),
+		[visibleBlocks, diffMode],
+	);
+
+	const ViewComponent =
+		diffMode === "gutter"
+			? GutterView
+			: diffMode === "split"
+				? SplitView
+				: InlineView;
+
+	return (
+		<div className="relative h-full w-full">
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: event delegation for stage buttons and expand banners */}
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: interactive elements inside handle keyboard events */}
+			<div
+				ref={containerRef}
+				className="h-full w-full overflow-auto font-mono text-sm"
+				style={{
+					backgroundColor: "var(--editor-background, #1a1a1a)",
+					color: "var(--editor-foreground, #e0e0e0)",
+				}}
+				data-testid="code-diff-viewer"
+				onClick={handleDelegatedClick}
+			>
+				<ViewComponent
+					visibleBlocks={visibleBlocks}
+					changeGroups={changeGroups}
+					onStageGroup={onStageGroup}
+					groupActionLabel={groupActionLabel}
+					containerRef={containerRef}
+				/>
+			</div>
+			<ScrollbarMarkers markers={diffMarkers} />
+		</div>
+	);
+}

--- a/src/hooks/useDiffTokens.test.ts
+++ b/src/hooks/useDiffTokens.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { assignChangeGroupsToBlocks, computeDiffBlocks } from "./useDiffTokens";
+
+describe("computeDiffBlocks", () => {
+	it("returns context block for identical content", () => {
+		const result = computeDiffBlocks(
+			[],
+			null,
+			null,
+			"line1\nline2\n",
+			"line1\nline2\n",
+		);
+		expect(result.blocks).toHaveLength(1);
+		expect(result.blocks[0].type).toBe("context");
+		expect(result.blocks[0].lines).toHaveLength(2);
+		expect(result.blocks[0].lines[0].type).toBe("context");
+		expect(result.blocks[0].lines[0].content).toBe("line1");
+		expect(result.blocks[0].lines[0].oldLineNumber).toBe(1);
+		expect(result.blocks[0].lines[0].newLineNumber).toBe(1);
+	});
+
+	it("returns empty blocks for empty content", () => {
+		const result = computeDiffBlocks([], null, null, "", "");
+		expect(result.blocks).toHaveLength(0);
+	});
+
+	it("processes hunks with added lines", () => {
+		const hunks = [
+			{
+				index: 0,
+				oldStart: 1,
+				oldLines: 2,
+				newStart: 1,
+				newLines: 3,
+				lines: [" line1", "+added", " line2"],
+			},
+		];
+		const result = computeDiffBlocks(
+			hunks,
+			null,
+			null,
+			"line1\nline2\n",
+			"line1\nadded\nline2\n",
+		);
+
+		const changeBlock = result.blocks.find((b) => b.type === "change");
+		if (changeBlock == null) throw new Error("change block not found");
+
+		const addedLines = changeBlock.lines.filter((l) => l.type === "added");
+		expect(addedLines).toHaveLength(1);
+		expect(addedLines[0].content).toBe("added");
+		expect(addedLines[0].newLineNumber).toBe(2);
+		expect(addedLines[0].oldLineNumber).toBeNull();
+	});
+
+	it("processes hunks with deleted lines", () => {
+		const hunks = [
+			{
+				index: 0,
+				oldStart: 1,
+				oldLines: 3,
+				newStart: 1,
+				newLines: 2,
+				lines: [" line1", "-deleted", " line2"],
+			},
+		];
+		const result = computeDiffBlocks(
+			hunks,
+			null,
+			null,
+			"line1\ndeleted\nline2\n",
+			"line1\nline2\n",
+		);
+
+		const changeBlock = result.blocks.find((b) => b.type === "change");
+		if (changeBlock == null) throw new Error("change block not found");
+
+		const deletedLines = changeBlock.lines.filter((l) => l.type === "deleted");
+		expect(deletedLines).toHaveLength(1);
+		expect(deletedLines[0].content).toBe("deleted");
+		expect(deletedLines[0].oldLineNumber).toBe(2);
+		expect(deletedLines[0].newLineNumber).toBeNull();
+	});
+
+	it("applies token data from tokenized lines", () => {
+		const modifiedTokens = [
+			{ tokens: [{ content: "line1", color: "#ff0000", offset: 0 }] },
+		];
+		const result = computeDiffBlocks(
+			[],
+			null,
+			modifiedTokens,
+			"line1\n",
+			"line1\n",
+		);
+
+		expect(result.blocks[0].lines[0].tokens).toHaveLength(1);
+		expect(result.blocks[0].lines[0].tokens[0].content).toBe("line1");
+		expect(result.blocks[0].lines[0].tokens[0].color).toBe("#ff0000");
+	});
+
+	it("skips backslash-only lines in hunks", () => {
+		const hunks = [
+			{
+				index: 0,
+				oldStart: 1,
+				oldLines: 1,
+				newStart: 1,
+				newLines: 1,
+				lines: ["-old", "+new", "\\ No newline at end of file"],
+			},
+		];
+		const result = computeDiffBlocks(hunks, null, null, "old", "new");
+
+		const changeBlock = result.blocks.find((b) => b.type === "change");
+		if (changeBlock == null) throw new Error("change block not found");
+		expect(
+			changeBlock.lines.some((l) => l.content.includes("No newline")),
+		).toBe(false);
+	});
+});
+
+describe("assignChangeGroupsToBlocks", () => {
+	it("returns blocks unchanged when no change groups", () => {
+		const blocks = [
+			{
+				type: "context" as const,
+				lines: [
+					{
+						type: "context" as const,
+						oldLineNumber: 1,
+						newLineNumber: 1,
+						tokens: [],
+						content: "line1",
+					},
+				],
+			},
+		];
+		const result = assignChangeGroupsToBlocks(blocks, []);
+		expect(result).toEqual(blocks);
+	});
+
+	it("assigns change group index to matching change block", () => {
+		const blocks = [
+			{
+				type: "change" as const,
+				lines: [
+					{
+						type: "added" as const,
+						oldLineNumber: null,
+						newLineNumber: 5,
+						tokens: [],
+						content: "new line",
+					},
+				],
+			},
+		];
+		const changeGroups = [{ groupIndex: 0, newStart: 5, newEnd: 5 }];
+		const result = assignChangeGroupsToBlocks(blocks, changeGroups);
+		expect(result[0].changeGroupIndex).toBe(0);
+	});
+});
+
+describe("progressive rendering fallback", () => {
+	it("returns content as plain token when tokens are null", () => {
+		const result = computeDiffBlocks(
+			[],
+			null,
+			null,
+			"hello world\n",
+			"hello world\n",
+		);
+		expect(result.blocks).toHaveLength(1);
+		expect(result.blocks[0].lines[0].tokens).toHaveLength(1);
+		expect(result.blocks[0].lines[0].tokens[0].content).toBe("hello world");
+	});
+
+	it("returns shiki tokens when tokenized lines are provided", () => {
+		const modifiedTokens = [
+			{ tokens: [{ content: "hello", color: "#ff0000", offset: 0 }] },
+		];
+		const result = computeDiffBlocks(
+			[],
+			null,
+			modifiedTokens,
+			"hello\n",
+			"hello\n",
+		);
+		expect(result.blocks[0].lines[0].tokens).toHaveLength(1);
+		expect(result.blocks[0].lines[0].tokens[0].content).toBe("hello");
+		expect(result.blocks[0].lines[0].tokens[0].color).toBe("#ff0000");
+	});
+
+	it("returns fallback tokens for hunk lines when tokens are null", () => {
+		const hunks = [
+			{
+				index: 0,
+				oldStart: 1,
+				oldLines: 1,
+				newStart: 1,
+				newLines: 2,
+				lines: [" ctx", "+added"],
+			},
+		];
+		const result = computeDiffBlocks(
+			hunks,
+			null,
+			null,
+			"ctx\n",
+			"ctx\nadded\n",
+		);
+		const changeBlock = result.blocks.find((b) => b.type === "change");
+		if (changeBlock == null) throw new Error("change block not found");
+
+		const addedLine = changeBlock.lines.find((l) => l.type === "added");
+		expect(addedLine).toBeDefined();
+		expect(addedLine?.tokens).toHaveLength(1);
+		expect(addedLine?.tokens[0].content).toBe("added");
+	});
+});

--- a/src/hooks/useDiffTokens.ts
+++ b/src/hooks/useDiffTokens.ts
@@ -202,21 +202,6 @@ export function assignChangeGroupsToBlocks(
 			}
 		}
 
-		if (changeGroups.length > 0) {
-			const firstLine = block.lines[0];
-			const lineNum = firstLine?.newLineNumber ?? firstLine?.oldLineNumber ?? 0;
-			let closest = changeGroups[0];
-			let minDist = Math.abs(lineNum - closest.newStart);
-			for (const cg of changeGroups) {
-				const dist = Math.abs(lineNum - cg.newStart);
-				if (dist < minDist) {
-					minDist = dist;
-					closest = cg;
-				}
-			}
-			return { ...block, changeGroupIndex: closest.groupIndex };
-		}
-
 		return block;
 	});
 }

--- a/src/hooks/useDiffTokens.ts
+++ b/src/hooks/useDiffTokens.ts
@@ -1,0 +1,222 @@
+import type { TokenizedLine } from "@/hooks/useShikiHighlighter";
+import type { Hunk } from "@/lib/computeHunks";
+
+export type DiffLineType = "added" | "deleted" | "context";
+
+export interface DiffLine {
+	type: DiffLineType;
+	oldLineNumber: number | null;
+	newLineNumber: number | null;
+	tokens: TokenizedLine["tokens"];
+	content: string;
+}
+
+export interface DiffBlock {
+	type: "change" | "context";
+	lines: DiffLine[];
+	changeGroupIndex?: number;
+}
+
+function splitContentToLines(content: string): string[] {
+	if (content === "") return [];
+	const lines = content.split("\n");
+	if (lines.length > 0 && lines[lines.length - 1] === "") {
+		lines.pop();
+	}
+	return lines;
+}
+
+function getTokensForLine(
+	tokenizedLines: TokenizedLine[] | null,
+	lineIndex: number,
+	fallbackContent?: string,
+): TokenizedLine["tokens"] {
+	if (tokenizedLines && lineIndex >= 0 && lineIndex < tokenizedLines.length) {
+		return tokenizedLines[lineIndex].tokens;
+	}
+	if (fallbackContent !== undefined) {
+		return [{ content: fallbackContent, color: undefined, offset: 0 }];
+	}
+	return [];
+}
+
+export interface DiffTokensResult {
+	blocks: DiffBlock[];
+	originalLines: string[];
+	modifiedLines: string[];
+}
+
+export function computeDiffBlocks(
+	hunks: Hunk[],
+	originalTokens: TokenizedLine[] | null,
+	modifiedTokens: TokenizedLine[] | null,
+	originalContent: string,
+	modifiedContent: string,
+): DiffTokensResult {
+	const originalLines = splitContentToLines(originalContent);
+	const modifiedLines = splitContentToLines(modifiedContent);
+
+	if (hunks.length === 0) {
+		const lines: DiffLine[] = modifiedLines.map((line, i) => ({
+			type: "context" as const,
+			oldLineNumber: i + 1,
+			newLineNumber: i + 1,
+			tokens: getTokensForLine(modifiedTokens, i, line),
+			content: line,
+		}));
+		return {
+			blocks: lines.length > 0 ? [{ type: "context", lines }] : [],
+			originalLines,
+			modifiedLines,
+		};
+	}
+
+	const blocks: DiffBlock[] = [];
+	let currentOldLine = 1;
+	let currentNewLine = 1;
+
+	for (const hunk of hunks) {
+		if (currentNewLine < hunk.newStart) {
+			const contextLines: DiffLine[] = [];
+			while (currentNewLine < hunk.newStart) {
+				const oldIdx = currentOldLine - 1;
+				const newIdx = currentNewLine - 1;
+				const lineContent =
+					modifiedLines[newIdx] ?? originalLines[oldIdx] ?? "";
+				contextLines.push({
+					type: "context",
+					oldLineNumber: currentOldLine,
+					newLineNumber: currentNewLine,
+					tokens: getTokensForLine(modifiedTokens, newIdx, lineContent),
+					content: lineContent,
+				});
+				currentOldLine++;
+				currentNewLine++;
+			}
+			if (contextLines.length > 0) {
+				blocks.push({ type: "context", lines: contextLines });
+			}
+		}
+
+		const changeLines: DiffLine[] = [];
+		for (const rawLine of hunk.lines) {
+			const prefix = rawLine[0];
+			const content = rawLine.slice(1);
+
+			if (prefix === "\\") continue;
+
+			if (prefix === "-") {
+				const oldIdx = currentOldLine - 1;
+				changeLines.push({
+					type: "deleted",
+					oldLineNumber: currentOldLine,
+					newLineNumber: null,
+					tokens: getTokensForLine(originalTokens, oldIdx, content),
+					content,
+				});
+				currentOldLine++;
+			} else if (prefix === "+") {
+				const newIdx = currentNewLine - 1;
+				changeLines.push({
+					type: "added",
+					oldLineNumber: null,
+					newLineNumber: currentNewLine,
+					tokens: getTokensForLine(modifiedTokens, newIdx, content),
+					content,
+				});
+				currentNewLine++;
+			} else {
+				const newIdx = currentNewLine - 1;
+				changeLines.push({
+					type: "context",
+					oldLineNumber: currentOldLine,
+					newLineNumber: currentNewLine,
+					tokens: getTokensForLine(modifiedTokens, newIdx, content),
+					content,
+				});
+				currentOldLine++;
+				currentNewLine++;
+			}
+		}
+
+		if (changeLines.length > 0) {
+			blocks.push({ type: "change", lines: changeLines });
+		}
+	}
+
+	if (currentNewLine <= modifiedLines.length) {
+		const contextLines: DiffLine[] = [];
+		while (currentNewLine <= modifiedLines.length) {
+			const newIdx = currentNewLine - 1;
+			const lineContent = modifiedLines[newIdx] ?? "";
+			contextLines.push({
+				type: "context",
+				oldLineNumber: currentOldLine,
+				newLineNumber: currentNewLine,
+				tokens: getTokensForLine(modifiedTokens, newIdx, lineContent),
+				content: lineContent,
+			});
+			currentOldLine++;
+			currentNewLine++;
+		}
+		if (contextLines.length > 0) {
+			blocks.push({ type: "context", lines: contextLines });
+		}
+	}
+
+	return { blocks, originalLines, modifiedLines };
+}
+
+export function assignChangeGroupsToBlocks(
+	blocks: DiffBlock[],
+	changeGroups: { groupIndex: number; newStart: number; newEnd: number }[],
+): DiffBlock[] {
+	if (changeGroups.length === 0) return blocks;
+
+	return blocks.map((block) => {
+		if (block.type !== "change") return block;
+
+		const firstNewLine = block.lines.find(
+			(l) => l.newLineNumber != null,
+		)?.newLineNumber;
+		const lastNewLine = [...block.lines]
+			.reverse()
+			.find((l) => l.newLineNumber != null)?.newLineNumber;
+		const firstOldLine = block.lines.find(
+			(l) => l.oldLineNumber != null,
+		)?.oldLineNumber;
+
+		for (const cg of changeGroups) {
+			if (firstNewLine != null && lastNewLine != null) {
+				if (cg.newStart >= firstNewLine && cg.newEnd <= lastNewLine) {
+					return { ...block, changeGroupIndex: cg.groupIndex };
+				}
+				if (firstNewLine >= cg.newStart && firstNewLine <= cg.newEnd) {
+					return { ...block, changeGroupIndex: cg.groupIndex };
+				}
+			}
+			if (firstNewLine == null && firstOldLine != null) {
+				if (cg.newStart <= (firstOldLine ?? 0)) {
+					return { ...block, changeGroupIndex: cg.groupIndex };
+				}
+			}
+		}
+
+		if (changeGroups.length > 0) {
+			const firstLine = block.lines[0];
+			const lineNum = firstLine?.newLineNumber ?? firstLine?.oldLineNumber ?? 0;
+			let closest = changeGroups[0];
+			let minDist = Math.abs(lineNum - closest.newStart);
+			for (const cg of changeGroups) {
+				const dist = Math.abs(lineNum - cg.newStart);
+				if (dist < minDist) {
+					minDist = dist;
+					closest = cg;
+				}
+			}
+			return { ...block, changeGroupIndex: closest.groupIndex };
+		}
+
+		return block;
+	});
+}

--- a/src/hooks/useShikiHighlighter.ts
+++ b/src/hooks/useShikiHighlighter.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+import type { ThemedToken } from "shiki/core";
+import type { TokenizeRequest, TokenizeResponse } from "@/workers/shiki.worker";
+
+export type { ThemedToken };
+
+export interface TokenizedLine {
+	tokens: ThemedToken[];
+}
+
+let worker: Worker | null = null;
+let nextRequestId = 0;
+const pendingCallbacks = new Map<number, (lines: TokenizedLine[]) => void>();
+
+function getWorker(): Worker {
+	if (worker) return worker;
+
+	worker = new Worker(new URL("../workers/shiki.worker.ts", import.meta.url), {
+		type: "module",
+	});
+
+	worker.onmessage = (e: MessageEvent<TokenizeResponse>) => {
+		const { id, lines } = e.data;
+		const cb = pendingCallbacks.get(id);
+		if (cb) {
+			pendingCallbacks.delete(id);
+			cb(lines as TokenizedLine[]);
+		}
+	};
+
+	return worker;
+}
+
+function tokenizeInWorker(
+	code: string,
+	language: string,
+): { id: number; cancel: () => void } {
+	const id = ++nextRequestId;
+	const w = getWorker();
+
+	w.postMessage({ id, code, language } satisfies TokenizeRequest);
+
+	return {
+		id,
+		cancel: () => {
+			pendingCallbacks.delete(id);
+		},
+	};
+}
+
+export function preloadHighlighter(): void {
+	getWorker();
+}
+
+export function useShikiHighlighter(
+	code: string,
+	language: string,
+): TokenizedLine[] | null {
+	const [lines, setLines] = useState<TokenizedLine[] | null>(null);
+	const requestRef = useRef<{ cancel: () => void } | null>(null);
+
+	useEffect(() => {
+		setLines(null);
+
+		if (requestRef.current) {
+			requestRef.current.cancel();
+		}
+
+		if (code === "") {
+			setLines([]);
+			return;
+		}
+
+		const req = tokenizeInWorker(code, language);
+		requestRef.current = req;
+
+		pendingCallbacks.set(req.id, (result) => {
+			requestRef.current = null;
+			setLines(result);
+		});
+
+		return () => {
+			req.cancel();
+			requestRef.current = null;
+		};
+	}, [code, language]);
+
+	return lines;
+}

--- a/src/hooks/useShikiHighlighter.ts
+++ b/src/hooks/useShikiHighlighter.ts
@@ -28,6 +28,13 @@ function getWorker(): Worker {
 		}
 	};
 
+	worker.onerror = () => {
+		for (const [id, cb] of pendingCallbacks) {
+			cb([]);
+			pendingCallbacks.delete(id);
+		}
+	};
+
 	return worker;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { SentryErrorBoundary } from "./components/ErrorBoundary";
+import { preloadHighlighter } from "./hooks/useShikiHighlighter";
 import "./index.css";
 import { initSentry } from "./lib/sentry";
 
 async function bootstrap() {
+	preloadHighlighter();
+
 	let crashReportingEnabled = true;
 	try {
 		crashReportingEnabled = await invoke<boolean>(

--- a/src/workers/shiki.worker.ts
+++ b/src/workers/shiki.worker.ts
@@ -1,0 +1,139 @@
+import type { HighlighterCore } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+let highlighterInstance: HighlighterCore | null = null;
+
+async function getHighlighter(): Promise<HighlighterCore> {
+	if (highlighterInstance) return highlighterInstance;
+	if (highlighterPromise) return highlighterPromise;
+
+	highlighterPromise = (async () => {
+		const { createHighlighterCore } = await import("shiki/core");
+		const githubDark = (await import("@shikijs/themes/github-dark")).default;
+
+		const hl = await createHighlighterCore({
+			themes: [githubDark],
+			langs: [],
+			engine: createJavaScriptRegexEngine(),
+		});
+
+		highlighterInstance = hl;
+		return hl;
+	})();
+
+	return highlighterPromise;
+}
+
+const LANG_IMPORT_MAP: Record<string, () => Promise<unknown>> = {
+	typescript: () => import("@shikijs/langs/typescript"),
+	javascript: () => import("@shikijs/langs/javascript"),
+	rust: () => import("@shikijs/langs/rust"),
+	json: () => import("@shikijs/langs/json"),
+	toml: () => import("@shikijs/langs/toml"),
+	yaml: () => import("@shikijs/langs/yaml"),
+	html: () => import("@shikijs/langs/html"),
+	css: () => import("@shikijs/langs/css"),
+	scss: () => import("@shikijs/langs/scss"),
+	python: () => import("@shikijs/langs/python"),
+	go: () => import("@shikijs/langs/go"),
+	shell: () => import("@shikijs/langs/shellscript"),
+	sql: () => import("@shikijs/langs/sql"),
+	markdown: () => import("@shikijs/langs/markdown"),
+	xml: () => import("@shikijs/langs/xml"),
+	c: () => import("@shikijs/langs/c"),
+	cpp: () => import("@shikijs/langs/cpp"),
+	java: () => import("@shikijs/langs/java"),
+	ruby: () => import("@shikijs/langs/ruby"),
+	swift: () => import("@shikijs/langs/swift"),
+	kotlin: () => import("@shikijs/langs/kotlin"),
+	php: () => import("@shikijs/langs/php"),
+	lua: () => import("@shikijs/langs/lua"),
+	r: () => import("@shikijs/langs/r"),
+	dart: () => import("@shikijs/langs/dart"),
+};
+
+const loadedLanguages = new Set<string>();
+const loadingLanguages = new Map<string, Promise<void>>();
+
+async function ensureLanguageLoaded(
+	hl: HighlighterCore,
+	language: string,
+): Promise<boolean> {
+	if (language === "plaintext" || loadedLanguages.has(language)) return true;
+
+	if (hl.getLoadedLanguages().includes(language)) {
+		loadedLanguages.add(language);
+		return true;
+	}
+
+	const existing = loadingLanguages.get(language);
+	if (existing) {
+		await existing;
+		return loadedLanguages.has(language);
+	}
+
+	const importFn = LANG_IMPORT_MAP[language];
+	if (!importFn) return false;
+
+	const promise = (async () => {
+		const mod = await importFn();
+		const langDef = (mod as { default: unknown }).default;
+		await hl.loadLanguage(
+			langDef as Parameters<HighlighterCore["loadLanguage"]>[0],
+		);
+		loadedLanguages.add(language);
+	})();
+
+	loadingLanguages.set(language, promise);
+
+	try {
+		await promise;
+		return true;
+	} catch {
+		return false;
+	} finally {
+		loadingLanguages.delete(language);
+	}
+}
+
+const THEME = "github-dark";
+
+export interface TokenizeRequest {
+	id: number;
+	code: string;
+	language: string;
+}
+
+export interface TokenizeResponse {
+	id: number;
+	lines: { tokens: { content: string; color?: string; offset: number }[] }[];
+}
+
+self.onmessage = async (e: MessageEvent<TokenizeRequest>) => {
+	const { id, code, language } = e.data;
+
+	if (code === "") {
+		self.postMessage({ id, lines: [] } satisfies TokenizeResponse);
+		return;
+	}
+
+	const hl = await getHighlighter();
+	const loaded = await ensureLanguageLoaded(hl, language);
+	const effectiveLang = loaded && language !== "plaintext" ? language : "text";
+
+	const tokenLines = hl.codeToTokensBase(code, {
+		lang: effectiveLang,
+		theme: THEME,
+	});
+
+	const lines = tokenLines.map((tokens) => ({
+		tokens: tokens.map((t) => ({
+			content: t.content,
+			color: t.color,
+			offset: t.offset,
+		})),
+	}));
+
+	self.postMessage({ id, lines } satisfies TokenizeResponse);
+};

--- a/src/workers/shiki.worker.ts
+++ b/src/workers/shiki.worker.ts
@@ -25,33 +25,33 @@ async function getHighlighter(): Promise<HighlighterCore> {
 	return highlighterPromise;
 }
 
-const LANG_IMPORT_MAP: Record<string, () => Promise<unknown>> = {
-	typescript: () => import("@shikijs/langs/typescript"),
-	javascript: () => import("@shikijs/langs/javascript"),
-	rust: () => import("@shikijs/langs/rust"),
-	json: () => import("@shikijs/langs/json"),
-	toml: () => import("@shikijs/langs/toml"),
-	yaml: () => import("@shikijs/langs/yaml"),
-	html: () => import("@shikijs/langs/html"),
-	css: () => import("@shikijs/langs/css"),
-	scss: () => import("@shikijs/langs/scss"),
-	python: () => import("@shikijs/langs/python"),
-	go: () => import("@shikijs/langs/go"),
-	shell: () => import("@shikijs/langs/shellscript"),
-	sql: () => import("@shikijs/langs/sql"),
-	markdown: () => import("@shikijs/langs/markdown"),
-	xml: () => import("@shikijs/langs/xml"),
-	c: () => import("@shikijs/langs/c"),
-	cpp: () => import("@shikijs/langs/cpp"),
-	java: () => import("@shikijs/langs/java"),
-	ruby: () => import("@shikijs/langs/ruby"),
-	swift: () => import("@shikijs/langs/swift"),
-	kotlin: () => import("@shikijs/langs/kotlin"),
-	php: () => import("@shikijs/langs/php"),
-	lua: () => import("@shikijs/langs/lua"),
-	r: () => import("@shikijs/langs/r"),
-	dart: () => import("@shikijs/langs/dart"),
-};
+const LANG_IMPORT_MAP = new Map<string, () => Promise<unknown>>([
+	["typescript", () => import("@shikijs/langs/typescript")],
+	["javascript", () => import("@shikijs/langs/javascript")],
+	["rust", () => import("@shikijs/langs/rust")],
+	["json", () => import("@shikijs/langs/json")],
+	["toml", () => import("@shikijs/langs/toml")],
+	["yaml", () => import("@shikijs/langs/yaml")],
+	["html", () => import("@shikijs/langs/html")],
+	["css", () => import("@shikijs/langs/css")],
+	["scss", () => import("@shikijs/langs/scss")],
+	["python", () => import("@shikijs/langs/python")],
+	["go", () => import("@shikijs/langs/go")],
+	["shell", () => import("@shikijs/langs/shellscript")],
+	["sql", () => import("@shikijs/langs/sql")],
+	["markdown", () => import("@shikijs/langs/markdown")],
+	["xml", () => import("@shikijs/langs/xml")],
+	["c", () => import("@shikijs/langs/c")],
+	["cpp", () => import("@shikijs/langs/cpp")],
+	["java", () => import("@shikijs/langs/java")],
+	["ruby", () => import("@shikijs/langs/ruby")],
+	["swift", () => import("@shikijs/langs/swift")],
+	["kotlin", () => import("@shikijs/langs/kotlin")],
+	["php", () => import("@shikijs/langs/php")],
+	["lua", () => import("@shikijs/langs/lua")],
+	["r", () => import("@shikijs/langs/r")],
+	["dart", () => import("@shikijs/langs/dart")],
+]);
 
 const loadedLanguages = new Set<string>();
 const loadingLanguages = new Map<string, Promise<void>>();
@@ -73,7 +73,7 @@ async function ensureLanguageLoaded(
 		return loadedLanguages.has(language);
 	}
 
-	const importFn = LANG_IMPORT_MAP[language];
+	const importFn = LANG_IMPORT_MAP.get(language);
 	if (!importFn) return false;
 
 	const promise = (async () => {
@@ -118,22 +118,28 @@ self.onmessage = async (e: MessageEvent<TokenizeRequest>) => {
 		return;
 	}
 
-	const hl = await getHighlighter();
-	const loaded = await ensureLanguageLoaded(hl, language);
-	const effectiveLang = loaded && language !== "plaintext" ? language : "text";
+	try {
+		const hl = await getHighlighter();
+		const loaded = await ensureLanguageLoaded(hl, language);
+		const effectiveLang =
+			loaded && language !== "plaintext" ? language : "text";
 
-	const tokenLines = hl.codeToTokensBase(code, {
-		lang: effectiveLang,
-		theme: THEME,
-	});
+		const tokenLines = hl.codeToTokensBase(code, {
+			lang: effectiveLang,
+			theme: THEME,
+		});
 
-	const lines = tokenLines.map((tokens) => ({
-		tokens: tokens.map((t) => ({
-			content: t.content,
-			color: t.color,
-			offset: t.offset,
-		})),
-	}));
+		const lines = tokenLines.map((tokens) => ({
+			tokens: tokens.map((t) => ({
+				content: t.content,
+				color: t.color,
+				offset: t.offset,
+			})),
+		}));
 
-	self.postMessage({ id, lines } satisfies TokenizeResponse);
+		self.postMessage({ id, lines } satisfies TokenizeResponse);
+	} catch (err) {
+		console.error("shiki worker tokenize failed:", err);
+		self.postMessage({ id, lines: [] } satisfies TokenizeResponse);
+	}
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,9 @@ export default defineConfig(async () => ({
 	build: {
 		sourcemap: true,
 	},
+	worker: {
+		format: "es",
+	},
 	test: {
 		globals: true,
 		environment: "jsdom",


### PR DESCRIPTION
## Summary
- Monaco DiffEditor/GutterEditorを廃止し、Shiki + 自前HTMLレンダリングによる軽量なdiff表示UIに置き換え
- Gutter / Inline / Split の3表示モード、Shikiシンタックスハイライト、ChangeGroup単位のstage/unstage、Diff-onlyモードを提供
- `@tanstack/react-virtual` による仮想スクロールで大ファイル対応

## Test plan
- [ ] pnpm test 全PASS確認
- [ ] pnpm lint エラーなし確認
- [ ] pnpm build 成功確認
- [ ] Gutter / Inline / Split の3モード切り替え動作確認
- [ ] ChangeGroupのstage/unstageボタン動作確認
- [ ] Diff-onlyモードの折りたたみ/展開動作確認
- [ ] シンタックスハイライトが適用されることの確認

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Shiki駆動のカスタムdiff UIを実装（Gutter、Inline、Split表示モード対応）
  * コードdiffの構文ハイライト機能を追加

* **ドキュメント**
  * diff レンダリング移行の仕様書を追加

* **テスト**
  * ShikiDiffViewerコンポーネントとdiffトークン化ロジックの包括的なテストカバレッジを追加

* **リファクタリング**
  * MonacoベースのdiffレンダリングをShiki実装に置き換え

* **その他**
  * Shiki関連の依存関係を追加
  * Viteワーカー設定を更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->