### PR TITLE
feat: Markdownファイルのデフォルト表示をプレビューからコード表示に変更

### DIFF
--- a/docs/spec/issues-810.md
+++ b/docs/spec/issues-810.md
@@ -1,0 +1,34 @@
+## 要求
+
+**種別**: 改善
+**ゴール**: Diffビューを開いた時のデフォルト表示をDiff表示からコード（ファイル内容）表示に変更する
+**背景**: 現在はファイルを開くとDiff表示がデフォルトだが、コード表示をデフォルトにした方が使いやすい
+
+## 振る舞い定義
+
+```gherkin
+Feature: Markdownファイルのデフォルト表示モード
+  Markdownファイルを開いた時のデフォルト表示をプレビューからコード表示に変更する
+
+  Rule: Markdownファイルのデフォルト表示はコード表示である
+    Scenario: Markdownファイルを開くとコード表示になる
+      Given 変更のあるMarkdownファイルが存在する
+      When ユーザーがそのファイルを選択する
+      Then コード表示がデフォルトで表示される
+
+  Rule: プレビュー表示への切り替えは手動で行える
+    Scenario: コード表示からプレビュー表示に切り替える
+      Given Markdownファイルがコード表示で表示されている
+      When ユーザーがプレビュー表示に切り替える
+      Then プレビュー表示に変わる
+```
+
+## 実装仕様
+
+**対応方針**: Markdownファイルのデフォルト表示をプレビューからコード表示に変更するために、`ReviewPanel.tsx` の `showMarkdownPreview` の初期値を `true` → `false` に変更する。
+
+**対象コンポーネント**:
+- `src/components/panels/ReviewPanel.tsx`: `showMarkdownPreview` の `useState(true)` → `useState(false)` に変更
+
+**影響するテスト**:
+- `ReviewPanel` のテストで `showMarkdownPreview` のデフォルト値に依存するケースがあれば修正

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -228,7 +228,7 @@ export function ReviewPanel({
 	// Image / Markdown detection
 	const isImage = selectedFile ? isImageFile(selectedFile) : false;
 	const isMarkdown = selectedFile ? isMarkdownFile(selectedFile) : false;
-	const [showMarkdownPreview, setShowMarkdownPreview] = useState(true);
+	const [showMarkdownPreview, setShowMarkdownPreview] = useState(false);
 	const imageDiff = useImageDiff(
 		isImage ? selectedFilePath : null,
 		diffBase,


### PR DESCRIPTION
## Summary
- Markdownファイルを開いた際のデフォルト表示をプレビューからコード表示に変更
- `showMarkdownPreview` の初期値を `true` → `false` に変更

Closes #810

## Test plan
- [ ] Markdownファイルを選択してデフォルトでコード表示になることを確認
- [ ] プレビューボタンでプレビュー表示に手動切り替えできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Markdownファイルの初期表示仕様に関するドキュメントを追加しました。

* **Bug Fixes**
  * Markdownファイルを開いた際、デフォルト表示をプレビュービューからコードビューに変更しました。プレビュー表示への切り替えは手動で行う必要があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->