### PR TITLE
feat: Reviewパネルにワークツリーをエディタで開くボタンを追加

### DIFF
--- a/docs/spec/issues-834.md
+++ b/docs/spec/issues-834.md
@@ -1,0 +1,59 @@
+# Issue #834: ワークスペースを指定のエディタで開くボタンを用意したい
+
+## 要求
+
+**種別**: 改善
+**ゴール**: Reviewパネルのヘッダーにある「Send all comments」ボタンを削除し、代わりにワークツリーのディレクトリを外部エディタ（VSCode/Cursor等）でフォルダごと開くボタンを配置する
+**背景**: レビュー中に該当ワークツリーを外部エディタで開いて確認・編集したい場面があるが、現在は手動でエディタからフォルダを開く必要がある。Reviewパネルから直接外部エディタを起動できるようにすることで、レビューワークフローの効率を向上させる
+**制約**: 既存の外部エディタ検出・設定機能（`detect_editors` / `external_editor` config）を活用する。ファイル単位ではなくフォルダ単位で開く
+**影響範囲**: ReviewPanelヘッダーのUI変更（Send all commentsボタンの削除・差し替え）
+
+## 振る舞い定義
+
+```gherkin
+Feature: ワークスペースを外部エディタで開く
+  Reviewパネルから現在のワークツリーを外部エディタでフォルダごと開く
+
+  Rule: エディタ起動の状態遷移
+    Scenario: 外部エディタが設定済みの場合、ワークツリーを設定済みエディタで開く
+      Given 外部エディタが設定されている
+      And Reviewパネルが表示されている
+      When ユーザーが「エディタで開く」ボタンを押す
+      Then 設定済みのエディタでワークツリーのディレクトリが開かれる
+
+    Scenario: 外部エディタが未設定の場合、システムデフォルトで開く
+      Given 外部エディタが設定されていない
+      And Reviewパネルが表示されている
+      When ユーザーが「エディタで開く」ボタンを押す
+      Then システムデフォルトのアプリケーションでワークツリーのディレクトリが開かれる
+
+  Rule: ボタンの表示
+    Scenario: Reviewパネルのヘッダーにエディタで開くボタンが表示される
+      Given Reviewパネルが表示されている
+      When ユーザーがヘッダーを確認する
+      Then 「Send all comments」ボタンの代わりに「エディタで開く」ボタンが表示されている
+```
+
+## 実装仕様
+
+**対応方針**: ReviewパネルヘッダーのSend all commentsボタンを「エディタで開く」ボタンに差し替える。ワークツリーのディレクトリを外部エディタで開くために、macOSの`open -a 'エディタ.app' /path`コマンドを使用する新規Tauriコマンドを追加する。
+
+**対象コンポーネント**:
+- `src-tauri/src/external_editor.rs`:
+  - 新規Tauriコマンド `open_folder_in_editor` を追加
+  - `std::process::Command`で `open -a <editor_path> <folder_path>` を実行
+  - エディタ未設定時は `open <folder_path>`（Finderが開く）にフォールバック
+- `src-tauri/src/lib.rs`: 新コマンドを登録
+- `src/components/panels/ReviewPanel.tsx`:
+  - ヘッダーのSend all commentsボタン（497-526行）を「エディタで開く」ボタンに差し替え
+  - `invoke("open_folder_in_editor", { folderPath: rootPath })`で呼び出し
+  - 不要になるもの削除:
+    - `Send` アイコンのimport
+    - `useDiffComments`からの `unsentCount`, `sendAllUnsent` のdestructuring
+  - 維持するもの:
+    - `onSendToAgent` prop（インラインコメント送信で使用）
+    - `useDiffComments`フック自体（コメント機能は維持）
+
+**影響するテスト**:
+- `src-tauri/src/external_editor.rs`: `open_folder_in_editor`のユニットテスト追加（コマンド構築のテスト）
+- ReviewPanelのテスト（存在する場合）: Send all commentsボタン関連を更新

--- a/src-tauri/src/external_editor.rs
+++ b/src-tauri/src/external_editor.rs
@@ -57,64 +57,52 @@ pub fn detect_editors() -> Vec<EditorInfo> {
     scan_applications()
 }
 
+fn validate_path(path: &str, label: &str) -> Result<(), String> {
+    if path.is_empty() {
+        return Err(format!("{label}が指定されていません"));
+    }
+    Ok(())
+}
+
+fn open_path_with_opener(
+    app: &tauri::AppHandle,
+    path: &str,
+    editor: &str,
+    label: &str,
+) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+
+    if editor.is_empty() {
+        app.opener()
+            .open_path(path, None::<&str>)
+            .map_err(|e| format!("{label}を開けませんでした: {e}"))
+    } else {
+        app.opener()
+            .open_path(path, Some(editor))
+            .map_err(|e| format!("エディタで{label}を開けませんでした: {e}"))
+    }
+}
+
 #[tauri::command]
 pub fn open_in_editor(
     app: tauri::AppHandle,
     state: tauri::State<'_, Arc<AppConfig>>,
     file_path: String,
 ) -> Result<(), String> {
-    if file_path.is_empty() {
-        return Err("ファイルパスが指定されていません".to_string());
-    }
-
-    use tauri_plugin_opener::OpenerExt;
-
+    validate_path(&file_path, "ファイルパス")?;
     let config = state.get_config()?;
-    let editor = &config.app.external_editor;
-
-    if editor.is_empty() {
-        app.opener()
-            .open_path(&file_path, None::<&str>)
-            .map_err(|e| format!("ファイルを開けませんでした: {e}"))
-    } else {
-        app.opener()
-            .open_path(&file_path, Some(editor.as_str()))
-            .map_err(|e| format!("エディタでファイルを開けませんでした: {e}"))
-    }
+    open_path_with_opener(&app, &file_path, &config.app.external_editor, "ファイル")
 }
 
 #[tauri::command]
 pub fn open_folder_in_editor(
+    app: tauri::AppHandle,
     state: tauri::State<'_, Arc<AppConfig>>,
     folder_path: String,
 ) -> Result<(), String> {
-    if folder_path.is_empty() {
-        return Err("フォルダパスが指定されていません".to_string());
-    }
-
+    validate_path(&folder_path, "フォルダパス")?;
     let config = state.get_config()?;
-    let editor = &config.app.external_editor;
-
-    let output = if editor.is_empty() {
-        std::process::Command::new("open")
-            .arg(&folder_path)
-            .output()
-    } else {
-        std::process::Command::new("open")
-            .arg("-a")
-            .arg(editor)
-            .arg(&folder_path)
-            .output()
-    };
-
-    match output {
-        Ok(o) if o.status.success() => Ok(()),
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            Err(format!("エディタでフォルダを開けませんでした: {stderr}"))
-        }
-        Err(e) => Err(format!("コマンドの実行に失敗しました: {e}")),
-    }
+    open_path_with_opener(&app, &folder_path, &config.app.external_editor, "フォルダ")
 }
 
 #[cfg(test)]
@@ -189,5 +177,25 @@ mod tests {
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains("Test Editor"));
         assert!(json.contains("/Applications/Test.app"));
+    }
+
+    #[test]
+    fn validate_path_rejects_empty() {
+        let result = validate_path("", "ファイルパス");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "ファイルパスが指定されていません");
+    }
+
+    #[test]
+    fn validate_path_rejects_empty_folder() {
+        let result = validate_path("", "フォルダパス");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "フォルダパスが指定されていません");
+    }
+
+    #[test]
+    fn validate_path_accepts_non_empty() {
+        assert!(validate_path("/some/path", "ファイルパス").is_ok());
+        assert!(validate_path("/some/folder", "フォルダパス").is_ok());
     }
 }

--- a/src-tauri/src/external_editor.rs
+++ b/src-tauri/src/external_editor.rs
@@ -83,6 +83,40 @@ pub fn open_in_editor(
     }
 }
 
+#[tauri::command]
+pub fn open_folder_in_editor(
+    state: tauri::State<'_, Arc<AppConfig>>,
+    folder_path: String,
+) -> Result<(), String> {
+    if folder_path.is_empty() {
+        return Err("フォルダパスが指定されていません".to_string());
+    }
+
+    let config = state.get_config()?;
+    let editor = &config.app.external_editor;
+
+    let output = if editor.is_empty() {
+        std::process::Command::new("open")
+            .arg(&folder_path)
+            .output()
+    } else {
+        std::process::Command::new("open")
+            .arg("-a")
+            .arg(editor)
+            .arg(&folder_path)
+            .output()
+    };
+
+    match output {
+        Ok(o) if o.status.success() => Ok(()),
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            Err(format!("エディタでフォルダを開けませんでした: {stderr}"))
+        }
+        Err(e) => Err(format!("コマンドの実行に失敗しました: {e}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -296,6 +296,7 @@ pub fn run() {
             // External Editor
             external_editor::detect_editors,
             external_editor::open_in_editor,
+            external_editor::open_folder_in_editor,
             // Agent Status (Rust 中央管理)
             agent_status::get_session_status,
             agent_status::get_workspace_status,

--- a/src/components/panels/ReviewPanel.test.tsx
+++ b/src/components/panels/ReviewPanel.test.tsx
@@ -389,4 +389,45 @@ describe("ReviewPanel", () => {
 		const toolbar = screen.getByTestId("diff-toolbar");
 		expect(toolbar).toHaveAttribute("data-file-path", "/repo/src/main.ts");
 	});
+
+	it("should show 'Open in editor' button instead of 'Send all comments' button", () => {
+		vi.mocked(useDiffFileTree).mockReturnValue({
+			stagedTree: [],
+			changesTree: [
+				{
+					id: "file:file.ts",
+					name: "file.ts",
+					path: "file.ts",
+					node_type: "file",
+					status: "modified",
+					additions: 1,
+					deletions: 0,
+					children: [],
+				},
+			],
+			stagedFileCount: 0,
+			changesFileCount: 1,
+			branchBaseTree: [],
+			branchBaseFileCount: 0,
+			loading: false,
+		});
+
+		render(
+			<TooltipProvider>
+				<ReviewPanel
+					rootPath="/repo"
+					baseBranch="main"
+					diffOnlyMode={false}
+					onDiffOnlyModeChange={vi.fn()}
+				/>
+			</TooltipProvider>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Open in editor" }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Send all comments to Agent" }),
+		).not.toBeInTheDocument();
+	});
 });

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -463,6 +463,8 @@ export function ReviewPanel({
 									onClick={() => {
 										invoke("open_folder_in_editor", {
 											folderPath: rootPath,
+										}).catch((e: unknown) => {
+											console.error("Failed to open folder in editor:", e);
 										});
 									}}
 									className="h-5 w-5 text-muted-foreground hover:text-foreground"
@@ -523,6 +525,8 @@ export function ReviewPanel({
 								onClick={() => {
 									invoke("open_folder_in_editor", {
 										folderPath: rootPath,
+									}).catch((e: unknown) => {
+										console.error("Failed to open folder in editor:", e);
 									});
 								}}
 								className="h-5 w-5 text-muted-foreground hover:text-foreground"

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import {
 	Code,
 	Eye,
@@ -5,7 +6,7 @@ import {
 	GitCommitHorizontal,
 	PanelLeftClose,
 	PanelLeftOpen,
-	Send,
+	SquareArrowOutUpRight,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -260,13 +261,11 @@ export function ReviewPanel({
 
 	const {
 		comments: allComments,
-		unsentCount,
 		addComment,
 		updateComment,
 		deleteComment,
 		sendToAgent,
 		markSent,
-		sendAllUnsent,
 		getCommentsForFile,
 	} = useDiffComments({ worktreeName });
 
@@ -451,10 +450,32 @@ export function ReviewPanel({
 			<div className="flex flex-col h-full">
 				<div className="flex items-center justify-between px-2 h-[32px] border-b border-border bg-card shrink-0">
 					<div className="w-5" />
-					<DiffBaseToggle
-						diffBase={diffBase}
-						onDiffBaseChange={handleDiffBaseChange}
-					/>
+					<div className="flex items-center gap-1">
+						<DiffBaseToggle
+							diffBase={diffBase}
+							onDiffBaseChange={handleDiffBaseChange}
+						/>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon-xs"
+									onClick={() => {
+										invoke("open_folder_in_editor", {
+											folderPath: rootPath,
+										});
+									}}
+									className="h-5 w-5 text-muted-foreground hover:text-foreground"
+									aria-label="Open in editor"
+								>
+									<SquareArrowOutUpRight className="h-3.5 w-3.5" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom" className="text-xs">
+								Open in editor
+							</TooltipContent>
+						</Tooltip>
+					</div>
 				</div>
 				<div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">
 					No changes
@@ -499,29 +520,19 @@ export function ReviewPanel({
 							<Button
 								variant="ghost"
 								size="icon-xs"
-								onClick={async () => {
-									const result = await sendAllUnsent();
-									if (result.formattedMessage && onSendToAgent) {
-										await onSendToAgent(result.formattedMessage);
-										await markSent(result.commentIds);
-									}
+								onClick={() => {
+									invoke("open_folder_in_editor", {
+										folderPath: rootPath,
+									});
 								}}
-								disabled={unsentCount === 0}
-								className="h-5 w-5 text-muted-foreground hover:text-foreground relative disabled:opacity-30"
-								aria-label="Send all comments to Agent"
+								className="h-5 w-5 text-muted-foreground hover:text-foreground"
+								aria-label="Open in editor"
 							>
-								<Send className="h-3.5 w-3.5" />
-								{unsentCount > 0 && (
-									<span className="absolute -top-1 -right-1 min-w-[14px] h-[14px] rounded-full bg-blue-600 text-[9px] text-white flex items-center justify-center px-0.5">
-										{unsentCount}
-									</span>
-								)}
+								<SquareArrowOutUpRight className="h-3.5 w-3.5" />
 							</Button>
 						</TooltipTrigger>
 						<TooltipContent side="bottom" className="text-xs">
-							{unsentCount > 0
-								? `Send ${unsentCount} comments to Agent`
-								: "No unsent comments"}
+							Open in editor
 						</TooltipContent>
 					</Tooltip>
 				</div>


### PR DESCRIPTION
## Summary
- ReviewパネルヘッダーのSend all commentsボタンを削除し、ワークツリーを外部エディタで開くボタンに差し替え
- 新規Tauriコマンド`open_folder_in_editor`を追加（macOSの`open -a`でエディタ起動）
- empty state（ファイル0件時）のヘッダーにもボタンを配置し、表示ラグを解消

## Test plan
- [x] ReviewPanel.test.tsx: Open in editorボタンの存在とSend all commentsボタンの不在を検証
- [x] pnpm lint / pnpm test (1297 tests) / pnpm build PASS
- [x] cargo fmt / cargo clippy / cargo test PASS

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* ReviewPanel のヘッダーに「エディタで開く」ボタンを追加しました。現在のディレクトリを設定済みの外部エディタで開くことができます。エディタが設定されていない場合はシステムデフォルトが使用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->