### PR TITLE
fix: 削除済みファイルのDiff表示が空になるバグを修正

### DIFF
--- a/docs/spec/issues-829.md
+++ b/docs/spec/issues-829.md
@@ -1,0 +1,52 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: ReviewPanelのDiffFileTreeで削除済みファイルを選択すると、DiffViewerSectionが空表示になる（ファイル自体は一覧に表示される）
+**期待する挙動**: 削除済みファイルを選択したとき、削除された全行が赤（削除行）としてDiff表示される
+**再現手順**:
+1. ファイルを削除する（git rmまたはファイルシステムから削除）
+2. ReviewPanelのDiffFileTreeで削除済みファイルを選択する
+3. DiffViewerSectionが空で表示される（差分内容が表示されない）
+**背景**: 削除済みファイルの差分を確認できないと、何が削除されたかをレビューできない
+
+## 振る舞い定義
+
+```gherkin
+Feature: 削除済みファイルの差分表示
+  削除されたファイルの差分をReviewPanelで確認できる
+
+  Rule: 削除済みファイルの差分は削除前の全行が削除行として算出される
+    Scenario: ワーキングツリーから削除されたファイルの差分取得
+      Given ファイルがHEADに存在する
+      And ワーキングツリーからファイルが削除されている
+      When 削除済みファイルの差分を取得する
+      Then 削除前の全行が削除行として差分に含まれる
+
+    Scenario: ステージで削除されたファイルの差分取得
+      Given ファイルがHEADに存在する
+      And ステージでファイルが削除されている
+      When 削除済みファイルの差分を取得する
+      Then 削除前の全行が削除行として差分に含まれる
+
+  Rule: 削除行を含む差分は赤色の削除行としてDiffビューに表示される
+    Scenario: 削除済みファイルのDiff表示
+      Given 削除済みファイルの差分が存在する
+      When DiffFileTreeで削除済みファイルを選択する
+      Then DiffViewerSectionに全行が削除行（赤）として表示される
+```
+
+## 実装仕様
+
+**対応方針**: 削除済みファイルの差分が空表示になるバグを修正するために、`useFileDiffContent`のコンテンツ取得ロジックを改修し、削除済みファイルの場合にHEADから元の内容を取得できるようにする。
+
+**対象コンポーネント**:
+- `src/hooks/useFileDiffContent.ts`: 削除済みファイルの場合にフォールバックでHEADから内容を取得するロジックを追加
+  - Changesセクション(Staged→WorkingTree)で、`get_staged_content`が失敗（ステージに無い）かつ`readTextFile`が失敗（ワーキングツリーに無い）の場合、originalContentとしてHEAD(`get_file_at_ref`)から取得する
+  - Staged Changesセクション(HEAD→Staged)では、`get_staged_content`が失敗した場合、modifiedContentを空文字とする（現状通り。削除=空文字は正しい）
+
+**検討した代替案**:
+- Rust側で`get_staged_content`を修正し、ステージ削除時にHEADのコンテンツを返す案 → ステージ内容の取得という責務に反するため却下
+- `computeDiffBlocks`で両方空の場合に特別処理する案 → データ取得側で正しい値を返すべきであり、表示側での回避策は根本解決にならないため却下
+
+**影響するテスト**:
+- `src/hooks/useFileDiffContent.test.ts`: 削除済みファイルケースのテスト追加（存在する場合は修正、無い場合は新規作成）

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -3,10 +3,26 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use git2::Repository;
 use std::path::Path;
 
+/// Discover a git repository from a file path.
+/// Falls back to the parent directory if the file does not exist (e.g. deleted files).
+fn discover_repo(path: &Path) -> Result<Repository, git2::Error> {
+    match Repository::discover(path) {
+        Ok(repo) => Ok(repo),
+        Err(_) if !path.exists() => {
+            if let Some(parent) = path.parent() {
+                Repository::discover(parent)
+            } else {
+                Repository::discover(path)
+            }
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// merge-base コミットのファイル内容を取得する（テキスト）
 pub fn get_file_at_branch_base(file_path: String) -> Result<String, GitError> {
     let path = Path::new(&file_path);
-    let repo = Repository::discover(path)?;
+    let repo = discover_repo(path)?;
 
     let repo_workdir = repo
         .workdir()
@@ -26,7 +42,7 @@ pub fn get_file_at_branch_base(file_path: String) -> Result<String, GitError> {
 /// merge-base コミットのファイル内容を取得する（バイナリ → Base64）
 pub fn get_binary_file_at_branch_base(file_path: String) -> Result<String, GitError> {
     let path = Path::new(&file_path);
-    let repo = Repository::discover(path)?;
+    let repo = discover_repo(path)?;
 
     let repo_workdir = repo
         .workdir()
@@ -96,7 +112,7 @@ fn find_merge_base_commit(repo: &Repository) -> Result<git2::Commit<'_>, GitErro
 
 pub fn get_file_at_ref(file_path: String, git_ref: String) -> Result<String, GitError> {
     let path = Path::new(&file_path);
-    let repo = Repository::discover(path)?;
+    let repo = discover_repo(path)?;
 
     let repo_workdir = repo
         .workdir()
@@ -116,7 +132,7 @@ pub fn get_file_at_ref(file_path: String, git_ref: String) -> Result<String, Git
 
 pub fn get_binary_file_at_ref(file_path: String, git_ref: String) -> Result<String, GitError> {
     let path = Path::new(&file_path);
-    let repo = Repository::discover(path)?;
+    let repo = discover_repo(path)?;
 
     let repo_workdir = repo
         .workdir()
@@ -135,7 +151,7 @@ pub fn get_binary_file_at_ref(file_path: String, git_ref: String) -> Result<Stri
 
 pub fn get_staged_content(file_path: String) -> Result<String, GitError> {
     let path = Path::new(&file_path);
-    let repo = Repository::discover(path)?;
+    let repo = discover_repo(path)?;
 
     let repo_workdir = repo
         .workdir()
@@ -161,7 +177,7 @@ pub fn get_staged_content(file_path: String) -> Result<String, GitError> {
 
 pub fn get_binary_staged_content(file_path: String) -> Result<String, GitError> {
     let path = Path::new(&file_path);
-    let repo = Repository::discover(path)?;
+    let repo = discover_repo(path)?;
 
     let repo_workdir = repo
         .workdir()
@@ -269,5 +285,39 @@ mod tests {
         let result =
             get_binary_file_at_ref(workdir_file(&repo, "img.bin"), "HEAD".to_string()).unwrap();
         assert_eq!(result, STANDARD.encode(b"binary at HEAD"));
+    }
+
+    #[test]
+    fn test_get_file_at_ref_deleted_file() {
+        let (_dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        add_and_commit(&repo, "deleted.txt", "original content\n", "add file");
+
+        // Delete the file from working tree
+        let file_path = workdir_file(&repo, "deleted.txt");
+        std::fs::remove_file(&file_path).unwrap();
+
+        // Should still be able to get content from HEAD
+        let result = get_file_at_ref(file_path.clone(), "HEAD".to_string());
+        println!("get_file_at_ref for deleted file: {:?}", result);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+        assert_eq!(result.unwrap(), "original content\n");
+    }
+
+    #[test]
+    fn test_get_staged_content_deleted_file() {
+        let (_dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        add_and_commit(&repo, "deleted.txt", "staged content\n", "add file");
+
+        // File still in index (only rm, not git rm)
+        let file_path = workdir_file(&repo, "deleted.txt");
+        std::fs::remove_file(&file_path).unwrap();
+
+        // Should still be able to get content from index
+        let result = get_staged_content(file_path.clone());
+        println!("get_staged_content for deleted file: {:?}", result);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+        assert_eq!(result.unwrap(), "staged content\n");
     }
 }

--- a/src-tauri/src/git/stage.rs
+++ b/src-tauri/src/git/stage.rs
@@ -228,6 +228,7 @@ mod tests {
         let statuses = get_git_status(dir.path().to_str().unwrap().to_string()).unwrap();
         assert_eq!(statuses.len(), 1);
         assert_eq!(statuses[0].index_status, "deleted");
+        assert_eq!(statuses[0].worktree_status, "none");
     }
 
     #[test]

--- a/src/hooks/useDiffTokens.test.ts
+++ b/src/hooks/useDiffTokens.test.ts
@@ -99,6 +99,30 @@ describe("computeDiffBlocks", () => {
 		expect(result.blocks[0].lines[0].tokens[0].color).toBe("#ff0000");
 	});
 
+	it("processes all-deletion hunks (file deleted)", () => {
+		// Simulates git2 output for "content\n" → "" (file deleted)
+		// git2 returns: old_start=1, old_lines=1, new_start=0, new_lines=0
+		const hunks = [
+			{
+				index: 0,
+				oldStart: 1,
+				oldLines: 1,
+				newStart: 0,
+				newLines: 0,
+				lines: ["-content"],
+			},
+		];
+		const result = computeDiffBlocks(hunks, null, null, "content\n", "");
+
+		expect(result.blocks).toHaveLength(1);
+		expect(result.blocks[0].type).toBe("change");
+		expect(result.blocks[0].lines).toHaveLength(1);
+		expect(result.blocks[0].lines[0].type).toBe("deleted");
+		expect(result.blocks[0].lines[0].content).toBe("content");
+		expect(result.blocks[0].lines[0].oldLineNumber).toBe(1);
+		expect(result.blocks[0].lines[0].newLineNumber).toBeNull();
+	});
+
 	it("skips backslash-only lines in hunks", () => {
 		const hunks = [
 			{

--- a/src/hooks/useFileDiffContent.test.ts
+++ b/src/hooks/useFileDiffContent.test.ts
@@ -58,6 +58,24 @@ describe("useFileDiffContent", () => {
 			expect(result.current.modifiedContent).toBe("");
 		});
 
+		it("does not fall back to HEAD when both staged and working tree are genuinely empty (not deleted)", async () => {
+			mockInvoke.mockImplementation((cmd: string) => {
+				if (cmd === "get_staged_content") return Promise.resolve("");
+				return Promise.resolve("");
+			});
+			mockReadTextFile.mockResolvedValue("");
+
+			const { result } = renderHook(() =>
+				useFileDiffContent("empty-file.ts", "head", "changes", 0),
+			);
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+			expect(result.current.originalContent).toBe("");
+			expect(result.current.modifiedContent).toBe("");
+		});
+
 		it("does not fall back to HEAD when staged has content but working tree is empty", async () => {
 			mockInvoke.mockImplementation((cmd: string) => {
 				if (cmd === "get_staged_content")

--- a/src/hooks/useFileDiffContent.test.ts
+++ b/src/hooks/useFileDiffContent.test.ts
@@ -1,0 +1,132 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFileDiffContent } from "./useFileDiffContent";
+
+const mockInvoke = vi.fn();
+const mockReadTextFile = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+	readTextFile: (...args: unknown[]) => mockReadTextFile(...args),
+}));
+
+describe("useFileDiffContent", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("Changes section (Staged → Working Tree)", () => {
+		it("returns staged as original and working tree as modified", async () => {
+			mockInvoke.mockImplementation((cmd: string) => {
+				if (cmd === "get_staged_content")
+					return Promise.resolve("staged content");
+				return Promise.resolve("");
+			});
+			mockReadTextFile.mockResolvedValue("working tree content");
+
+			const { result } = renderHook(() =>
+				useFileDiffContent("file.ts", "head", "changes", 0),
+			);
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+			expect(result.current.originalContent).toBe("staged content");
+			expect(result.current.modifiedContent).toBe("working tree content");
+		});
+
+		it("falls back to HEAD for original when both staged and working tree are empty (deleted file)", async () => {
+			mockInvoke.mockImplementation((cmd: string) => {
+				if (cmd === "get_staged_content")
+					return Promise.reject(new Error("file not staged"));
+				if (cmd === "get_file_at_ref") return Promise.resolve("head content");
+				return Promise.resolve("");
+			});
+			mockReadTextFile.mockRejectedValue(new Error("file not found"));
+
+			const { result } = renderHook(() =>
+				useFileDiffContent("deleted.ts", "head", "changes", 0),
+			);
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+			expect(result.current.originalContent).toBe("head content");
+			expect(result.current.modifiedContent).toBe("");
+		});
+
+		it("does not fall back to HEAD when staged has content but working tree is empty", async () => {
+			mockInvoke.mockImplementation((cmd: string) => {
+				if (cmd === "get_staged_content")
+					return Promise.resolve("staged content");
+				return Promise.resolve("");
+			});
+			mockReadTextFile.mockRejectedValue(new Error("file not found"));
+
+			const { result } = renderHook(() =>
+				useFileDiffContent("file.ts", "head", "changes", 0),
+			);
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+			expect(result.current.originalContent).toBe("staged content");
+			expect(result.current.modifiedContent).toBe("");
+		});
+	});
+
+	describe("Staged Changes section (HEAD → Staged)", () => {
+		it("returns HEAD as original and staged as modified", async () => {
+			mockInvoke.mockImplementation((cmd: string) => {
+				if (cmd === "get_file_at_ref") return Promise.resolve("head content");
+				if (cmd === "get_staged_content")
+					return Promise.resolve("staged content");
+				return Promise.resolve("");
+			});
+
+			const { result } = renderHook(() =>
+				useFileDiffContent("file.ts", "head", "staged", 0),
+			);
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+			expect(result.current.originalContent).toBe("head content");
+			expect(result.current.modifiedContent).toBe("staged content");
+		});
+
+		it("returns empty modified when file is staged for deletion", async () => {
+			mockInvoke.mockImplementation((cmd: string) => {
+				if (cmd === "get_file_at_ref") return Promise.resolve("head content");
+				if (cmd === "get_staged_content")
+					return Promise.reject(new Error("file not staged"));
+				return Promise.resolve("");
+			});
+
+			const { result } = renderHook(() =>
+				useFileDiffContent("deleted.ts", "head", "staged", 0),
+			);
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+			expect(result.current.originalContent).toBe("head content");
+			expect(result.current.modifiedContent).toBe("");
+		});
+	});
+
+	describe("null filePath", () => {
+		it("returns empty content and no loading", () => {
+			const { result } = renderHook(() =>
+				useFileDiffContent(null, "head", "changes", 0),
+			);
+
+			expect(result.current.originalContent).toBe("");
+			expect(result.current.modifiedContent).toBe("");
+			expect(result.current.loading).toBe(false);
+		});
+	});
+});

--- a/src/hooks/useFileDiffContent.ts
+++ b/src/hooks/useFileDiffContent.ts
@@ -73,7 +73,17 @@ export function useFileDiffContent(
 			fetchPair = Promise.all([fetchHead(), fetchStaged()]);
 		} else {
 			// Changes: Staged → Working Tree
-			fetchPair = Promise.all([fetchStaged(), fetchWorkingTree()]);
+			// When both staged and working tree are empty (deleted file),
+			// fall back to HEAD for original content
+			fetchPair = Promise.all([fetchStaged(), fetchWorkingTree()]).then(
+				async ([staged, workingTree]) => {
+					if (staged === "" && workingTree === "") {
+						const head = await fetchHead();
+						return [head, workingTree] as [string, string];
+					}
+					return [staged, workingTree] as [string, string];
+				},
+			);
 		}
 
 		fetchPair

--- a/src/hooks/useFileDiffContent.ts
+++ b/src/hooks/useFileDiffContent.ts
@@ -27,11 +27,11 @@ export function useFileDiffContent(
 
 		setLoading(true);
 
-		const fetchStaged = async () => {
+		const fetchStaged = async (): Promise<string | null> => {
 			try {
 				return await invoke<string>("get_staged_content", { filePath });
 			} catch {
-				return "";
+				return null;
 			}
 		};
 
@@ -56,32 +56,36 @@ export function useFileDiffContent(
 			}
 		};
 
-		const fetchWorkingTree = async () => {
+		const fetchWorkingTree = async (): Promise<string | null> => {
 			try {
 				return await readTextFile(filePath);
 			} catch {
-				return "";
+				return null;
 			}
 		};
 
 		let fetchPair: Promise<[string, string]>;
 
 		if (diffBase === "branch-base") {
-			fetchPair = Promise.all([fetchBranchBase(), fetchWorkingTree()]);
+			fetchPair = Promise.all([fetchBranchBase(), fetchWorkingTree()]).then(
+				([base, wt]) => [base, wt ?? ""] as [string, string],
+			);
 		} else if (section === "staged") {
 			// Staged Changes: HEAD → Staged
-			fetchPair = Promise.all([fetchHead(), fetchStaged()]);
+			fetchPair = Promise.all([fetchHead(), fetchStaged()]).then(
+				([head, staged]) => [head, staged ?? ""] as [string, string],
+			);
 		} else {
 			// Changes: Staged → Working Tree
-			// When both staged and working tree are empty (deleted file),
+			// When both fetch fail (null = deleted file),
 			// fall back to HEAD for original content
 			fetchPair = Promise.all([fetchStaged(), fetchWorkingTree()]).then(
 				async ([staged, workingTree]) => {
-					if (staged === "" && workingTree === "") {
+					if (staged === null && workingTree === null) {
 						const head = await fetchHead();
-						return [head, workingTree] as [string, string];
+						return [head, ""] as [string, string];
 					}
-					return [staged, workingTree] as [string, string];
+					return [staged ?? "", workingTree ?? ""] as [string, string];
 				},
 			);
 		}


### PR DESCRIPTION
## Summary
- 削除済みファイルをDiffFileTreeで選択した際にDiffViewerSectionが空表示になるバグを修正
- `Repository::discover`が削除済みファイルパスで失敗する問題に対し、親ディレクトリへのフォールバック(`discover_repo`)を追加
- フロントエンドでstaged/workingTree両方取得失敗時にHEADから元の内容を取得するロジックを追加

## Test plan
- [x] `cargo test` — `test_get_file_at_ref_deleted_file`, `test_get_staged_content_deleted_file` が PASS
- [x] `pnpm test` — `useFileDiffContent` / `useDiffTokens` の削除ファイルケースが PASS
- [ ] 手動確認: ファイルを削除後、DiffFileTreeで選択し全行が赤（削除行）として表示されること

Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 削除されたファイルの差分表示で、ステージング領域とワーキングツリーの両方が空の場合、HEAD からの元の内容を適切に取得して表示するように修正しました

* **Tests**
  * 削除ファイルシナリオに対する複数のテストケースを追加し、ステージングと HEAD からのコンテンツ取得機能をカバーしました

* **Documentation**
  * 削除ファイルの差分表示に関する仕様書を追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->