### PR TITLE
fix: watcher_idベースのイベントフィルタリングでDiff一覧の即時反映を改善

### DIFF
--- a/docs/spec/issues-827.md
+++ b/docs/spec/issues-827.md
@@ -1,0 +1,72 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: 外部プロセス（組み込みAI Agent含む）がファイルを変更しても、Diff一覧（SourceControlPanel）に変更が反映されないことがある
+**期待する挙動**: 何がファイルを変更しても（外部プロセス、Agent、手動編集問わず）、Diff一覧に常に即座に反映される
+**再現手順**: 不明（間欠的に発生）
+**背景**: 現在のファイル変更監視（watcher）が外部プロセスによるファイル変更を検知できないケースがあり、Diff一覧が最新の状態と乖離する
+
+## 振る舞い定義
+
+```gherkin
+Feature: ファイル変更のDiff一覧即時反映
+  ワーキングツリー内のファイルが変更されたとき、
+  変更元がエディタ操作・外部プロセス・AI Agentのいずれであっても
+  Diff一覧（SourceControlPanel）に即座に反映される
+
+  Rule: ファイル変更はDiff一覧の状態に反映される
+    Scenario: 外部プロセスがファイルを新規作成する
+      Given ワーキングツリーにuntracked fileがない
+      When 外部プロセスが新規ファイルを作成する
+      Then Diff一覧にそのファイルが新規ファイルとして表示される
+
+    Scenario: 外部プロセスが既存ファイルを変更する
+      Given ワーキングツリーにtracked fileが存在する
+      When 外部プロセスがそのファイルを変更する
+      Then Diff一覧にそのファイルが変更ファイルとして表示される
+
+    Scenario: 外部プロセスがファイルを削除する
+      Given ワーキングツリーにtracked fileが存在する
+      When 外部プロセスがそのファイルを削除する
+      Then Diff一覧にそのファイルが削除ファイルとして表示される
+
+    Scenario: 外部プロセスが複数ファイルを一括変更する
+      Given ワーキングツリーにtracked fileが複数存在する
+      When 外部プロセスが複数ファイルを短時間に連続で変更する
+      Then Diff一覧に全ての変更ファイルが表示される
+
+  Rule: Diff一覧はファイル変更前の状態に戻らない
+    Scenario: 変更検知後にDiff一覧がリセットされない
+      Given 外部プロセスがファイルを変更してDiff一覧に反映された
+      When 追加のファイル変更が発生しない
+      Then Diff一覧は変更ファイルを表示し続ける
+```
+
+## 実装仕様
+
+**対応方針**: ファイル変更のDiff一覧即時反映を実現するために、watcher.rs（バックエンド）とuseGitEventRefresh（フロントエンド）に対して、イベント検知の信頼性向上で対応する。
+
+**対象コンポーネント**:
+- `src-tauri/src/watcher.rs`: file-changeイベントのパスを正規化して発行する
+- `src/hooks/useGitEventRefresh.ts`: パスマッチングの堅牢化、デバウンス後の確実なリフレッシュ保証
+
+**具体的な変更:**
+
+1. **watcher.rs — パスの正規化**
+   - `start_watching` のイベント発行時に `event.path.canonicalize()` でパスを正規化
+   - シンボリックリンクやOS依存のパス表現の差異を解消
+
+2. **useGitEventRefresh.ts — パスマッチングの堅牢化**
+   - `rootPath` もマウント時にTauriコマンド経由で正規化パスを取得し比較に使用
+   - あるいは、パス前方一致ではなくwatcher_idベースのフィルタリングに変更（useFileWatcherと同じ方式）
+
+3. **useGitEventRefresh.ts — デバウンスの trailing edge 保証**
+   - 現在のsetTimeoutベースのデバウンスで、連続イベント時に最後のイベント後に確実に1回実行されることを確認・修正
+
+**検討した代替案**:
+- ポーリング方式（定期的にgit statusを取得）: 不要な呼び出しが増えるため却下
+- ファイルウォッチャーのデバウンスを短縮: OS負荷が増えるため却下
+
+**影響するテスト**:
+- Rust単体テスト: watcher.rsのパス正規化ロジック
+- フロントエンド単体テスト: useGitEventRefreshのイベントフィルタリング

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -36,6 +36,21 @@ fn resolve_git_watch_paths(repo_path: &str) -> Result<GitWatchPaths, String> {
     })
 }
 
+fn canonicalize_event_path(path: &std::path::Path) -> Option<String> {
+    if let Ok(canonical) = path.canonicalize() {
+        return Some(canonical.to_string_lossy().to_string());
+    }
+    let parent = path.parent()?;
+    let file_name = path.file_name()?;
+    let canonical_parent = parent.canonicalize().ok()?;
+    Some(
+        canonical_parent
+            .join(file_name)
+            .to_string_lossy()
+            .to_string(),
+    )
+}
+
 static WATCHER_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 fn generate_watcher_id() -> u64 {
@@ -93,7 +108,8 @@ pub fn start_watching(
                             DebouncedEventKind::AnyContinuous => "change",
                             _ => "change",
                         };
-                        let event_path = event.path.to_string_lossy().to_string();
+                        let event_path = canonicalize_event_path(&event.path)
+                            .unwrap_or_else(|| event.path.to_string_lossy().to_string());
                         let _ = app_clone.emit(
                             "file-change",
                             FileChangeEvent {
@@ -397,5 +413,36 @@ mod tests {
         let (branch, index) = classify_git_dir_events(&events);
         assert!(!branch);
         assert!(index);
+    }
+
+    #[test]
+    fn canonicalize_existing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file_path = dir.path().join("test.txt");
+        std::fs::write(&file_path, "hello").unwrap();
+
+        let result = canonicalize_event_path(&file_path);
+        assert!(result.is_some());
+        let canonical = result.unwrap();
+        assert!(canonical.ends_with("test.txt"));
+        assert!(!canonical.contains(".."));
+    }
+
+    #[test]
+    fn canonicalize_deleted_file_falls_back_to_parent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file_path = dir.path().join("deleted.txt");
+
+        let result = canonicalize_event_path(&file_path);
+        assert!(result.is_some());
+        let canonical = result.unwrap();
+        assert!(canonical.ends_with("deleted.txt"));
+    }
+
+    #[test]
+    fn canonicalize_nonexistent_parent_returns_none() {
+        let path = PathBuf::from("/nonexistent/parent/file.txt");
+        let result = canonicalize_event_path(&path);
+        assert!(result.is_none());
     }
 }

--- a/src/hooks/useGitEventRefresh.test.ts
+++ b/src/hooks/useGitEventRefresh.test.ts
@@ -10,17 +10,30 @@ import {
 } from "vitest";
 import { useGitEventRefresh } from "./useGitEventRefresh";
 
-type ListenCallback = (event: { payload: Record<string, string> }) => void;
+type ListenCallback = (event: {
+	payload: Record<string, string | number>;
+}) => void;
 
 const mockListen = vi.fn();
 vi.mock("@tauri-apps/api/event", () => ({
 	listen: (...args: unknown[]) => mockListen(...args),
 }));
 
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+const WATCHER_ID = 42;
+
 describe("useGitEventRefresh", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 		mockListen.mockResolvedValue(vi.fn());
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "start_watching") return Promise.resolve(WATCHER_ID);
+			return Promise.resolve();
+		});
 	});
 
 	afterEach(() => {
@@ -32,6 +45,10 @@ describe("useGitEventRefresh", () => {
 		const onRefresh = vi.fn();
 		renderHook(() => useGitEventRefresh("/repo", onRefresh, false));
 		expect(mockListen).not.toHaveBeenCalled();
+		expect(mockInvoke).not.toHaveBeenCalledWith(
+			"start_watching",
+			expect.anything(),
+		);
 	});
 
 	it("should not register listeners when rootPath=null", () => {
@@ -40,7 +57,7 @@ describe("useGitEventRefresh", () => {
 		expect(mockListen).not.toHaveBeenCalled();
 	});
 
-	it("should register both listeners when enabled and rootPath provided", async () => {
+	it("should register both listeners and start file watcher", async () => {
 		const onRefresh = vi.fn();
 		renderHook(() => useGitEventRefresh("/repo", onRefresh));
 
@@ -56,38 +73,68 @@ describe("useGitEventRefresh", () => {
 			"git-status-changed",
 			expect.any(Function),
 		);
+		expect(mockInvoke).toHaveBeenCalledWith("start_watching", {
+			path: "/repo",
+		});
 	});
 
-	it("should debounce onRefresh on file-change event with matching path", async () => {
+	it("should debounce onRefresh on file-change event with matching watcher_id", async () => {
 		const onRefresh = vi.fn();
+		let fileChangeCb: ListenCallback | null = null;
+
 		mockListen.mockImplementation((event: string, cb: ListenCallback) => {
 			if (event === "file-change") {
-				setTimeout(() => cb({ payload: { path: "/repo/src/main.ts" } }), 0);
+				fileChangeCb = cb;
 			}
 			return Promise.resolve(vi.fn());
 		});
 
 		renderHook(() => useGitEventRefresh("/repo", onRefresh));
 
-		await vi.advanceTimersByTimeAsync(0);
-		expect(onRefresh).not.toHaveBeenCalled();
+		await vi.waitFor(() => {
+			expect(fileChangeCb).not.toBeNull();
+		});
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("start_watching", {
+				path: "/repo",
+			});
+		});
 
+		(fileChangeCb as unknown as Mock)({
+			payload: { watcher_id: WATCHER_ID, path: "/repo/src/main.ts" },
+		});
+
+		expect(onRefresh).not.toHaveBeenCalled();
 		await vi.advanceTimersByTimeAsync(300);
 		expect(onRefresh).toHaveBeenCalledTimes(1);
 	});
 
-	it("should ignore file-change event with non-matching path", async () => {
+	it("should ignore file-change event with non-matching watcher_id", async () => {
 		const onRefresh = vi.fn();
+		let fileChangeCb: ListenCallback | null = null;
+
 		mockListen.mockImplementation((event: string, cb: ListenCallback) => {
 			if (event === "file-change") {
-				setTimeout(() => cb({ payload: { path: "/other-repo/file.ts" } }), 0);
+				fileChangeCb = cb;
 			}
 			return Promise.resolve(vi.fn());
 		});
 
 		renderHook(() => useGitEventRefresh("/repo", onRefresh));
 
-		await vi.advanceTimersByTimeAsync(0);
+		await vi.waitFor(() => {
+			expect(fileChangeCb).not.toBeNull();
+		});
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("start_watching", {
+				path: "/repo",
+			});
+		});
+
+		(fileChangeCb as unknown as Mock)({
+			payload: { watcher_id: 999, path: "/other-repo/file.ts" },
+		});
+
 		await vi.advanceTimersByTimeAsync(300);
 		expect(onRefresh).not.toHaveBeenCalled();
 	});
@@ -126,7 +173,7 @@ describe("useGitEventRefresh", () => {
 		expect(onRefresh).not.toHaveBeenCalled();
 	});
 
-	it("should call unlisten on cleanup", async () => {
+	it("should call unlisten and stop watcher on cleanup", async () => {
 		const mockUnlisten = vi.fn();
 		mockListen.mockResolvedValue(mockUnlisten);
 
@@ -135,9 +182,17 @@ describe("useGitEventRefresh", () => {
 		await vi.waitFor(() => {
 			expect(mockListen).toHaveBeenCalledTimes(2);
 		});
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("start_watching", {
+				path: "/repo",
+			});
+		});
 
 		unmount();
 		expect(mockUnlisten).toHaveBeenCalledTimes(2);
+		expect(mockInvoke).toHaveBeenCalledWith("stop_watching", {
+			watcherId: WATCHER_ID,
+		});
 	});
 
 	it("should debounce multiple rapid events into single call", async () => {
@@ -156,12 +211,56 @@ describe("useGitEventRefresh", () => {
 		await vi.waitFor(() => {
 			expect(fileChangeCb).not.toBeNull();
 		});
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("start_watching", {
+				path: "/repo",
+			});
+		});
 
-		(fileChangeCb as unknown as Mock)({ payload: { path: "/repo/a.ts" } });
-		(fileChangeCb as unknown as Mock)({ payload: { path: "/repo/b.ts" } });
-		(fileChangeCb as unknown as Mock)({ payload: { path: "/repo/c.ts" } });
+		(fileChangeCb as unknown as Mock)({
+			payload: { watcher_id: WATCHER_ID, path: "/repo/a.ts" },
+		});
+		(fileChangeCb as unknown as Mock)({
+			payload: { watcher_id: WATCHER_ID, path: "/repo/b.ts" },
+		});
+		(fileChangeCb as unknown as Mock)({
+			payload: { watcher_id: WATCHER_ID, path: "/repo/c.ts" },
+		});
 
 		await vi.advanceTimersByTimeAsync(300);
+		expect(onRefresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not call onRefresh again after debounce without new events", async () => {
+		const onRefresh = vi.fn();
+		let fileChangeCb: ListenCallback | null = null;
+
+		mockListen.mockImplementation((event: string, cb: ListenCallback) => {
+			if (event === "file-change") {
+				fileChangeCb = cb;
+			}
+			return Promise.resolve(vi.fn());
+		});
+
+		renderHook(() => useGitEventRefresh("/repo", onRefresh));
+
+		await vi.waitFor(() => {
+			expect(fileChangeCb).not.toBeNull();
+		});
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("start_watching", {
+				path: "/repo",
+			});
+		});
+
+		(fileChangeCb as unknown as Mock)({
+			payload: { watcher_id: WATCHER_ID, path: "/repo/src/main.ts" },
+		});
+
+		await vi.advanceTimersByTimeAsync(300);
+		expect(onRefresh).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(1000);
 		expect(onRefresh).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/hooks/useGitEventRefresh.ts
+++ b/src/hooks/useGitEventRefresh.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef } from "react";
 import type { FileChangeEvent } from "./useFileWatcher";
@@ -8,6 +9,7 @@ export function useGitEventRefresh(
 	enabled = true,
 ): void {
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const watcherIdRef = useRef<number | null>(null);
 
 	const debouncedRefresh = useCallback(() => {
 		if (timerRef.current) clearTimeout(timerRef.current);
@@ -26,8 +28,8 @@ export function useGitEventRefresh(
 			const off = await listen<FileChangeEvent>("file-change", (event) => {
 				if (
 					!disposed &&
-					(event.payload.path === rootPath ||
-						event.payload.path.startsWith(`${rootPath}/`))
+					watcherIdRef.current !== null &&
+					event.payload.watcher_id === watcherIdRef.current
 				) {
 					debouncedRefresh();
 				}
@@ -37,6 +39,19 @@ export function useGitEventRefresh(
 				return;
 			}
 			unlisten = off;
+
+			try {
+				const id = await invoke<number>("start_watching", {
+					path: rootPath,
+				});
+				if (disposed) {
+					invoke("stop_watching", { watcherId: id }).catch(() => {});
+					return;
+				}
+				watcherIdRef.current = id;
+			} catch (e) {
+				console.error("Failed to start file watcher:", e);
+			}
 		};
 		void setup();
 
@@ -44,6 +59,12 @@ export function useGitEventRefresh(
 			disposed = true;
 			unlisten?.();
 			if (timerRef.current) clearTimeout(timerRef.current);
+			if (watcherIdRef.current !== null) {
+				invoke("stop_watching", { watcherId: watcherIdRef.current }).catch(
+					() => {},
+				);
+				watcherIdRef.current = null;
+			}
 		};
 	}, [debouncedRefresh, rootPath, enabled]);
 

--- a/src/hooks/useGitStatus.test.ts
+++ b/src/hooks/useGitStatus.test.ts
@@ -14,14 +14,23 @@ vi.mock("@tauri-apps/api/event", () => ({
 	listen: (...args: unknown[]) => mockListen(...args),
 }));
 
+function gitStatusCallCount(): number {
+	return mockInvoke.mock.calls.filter((call) => call[0] === "get_git_status")
+		.length;
+}
+
 describe("useGitStatus", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockListen.mockResolvedValue(vi.fn());
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 	});
 
 	it("should return empty data when rootPath is null", () => {
-		mockInvoke.mockResolvedValue([]);
 		const { result } = renderHook(() => useGitStatus(null));
 
 		expect(result.current.statusMap.size).toBe(0);
@@ -39,7 +48,12 @@ describe("useGitStatus", () => {
 			{ path: "new_file.txt", index_status: "none", worktree_status: "new" },
 			{ path: "staged.txt", index_status: "new", worktree_status: "none" },
 		];
-		mockInvoke.mockResolvedValue(mockEntries);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		const { result } = renderHook(() => useGitStatus("/test/repo"));
 
@@ -63,7 +77,12 @@ describe("useGitStatus", () => {
 		const mockEntries: GitFileStatus[] = [
 			{ path: "deleted.txt", index_status: "none", worktree_status: "deleted" },
 		];
-		mockInvoke.mockResolvedValue(mockEntries);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		const { result } = renderHook(() => useGitStatus("/test/repo"));
 
@@ -94,7 +113,12 @@ describe("useGitStatus", () => {
 				worktree_status: "none",
 			},
 		];
-		mockInvoke.mockResolvedValue(mockEntries);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		const { result } = renderHook(() => useGitStatus("/test/repo"));
 
@@ -126,7 +150,12 @@ describe("useGitStatus", () => {
 				worktree_status: "modified",
 			},
 		];
-		mockInvoke.mockResolvedValue(mockEntries);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		const { result } = renderHook(() => useGitStatus("/test/repo"));
 
@@ -145,12 +174,18 @@ describe("useGitStatus", () => {
 	});
 
 	it("should handle invoke error gracefully", async () => {
-		mockInvoke.mockRejectedValue(new Error("not a git repo"));
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status")
+				return Promise.reject(new Error("not a git repo"));
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		const { result } = renderHook(() => useGitStatus("/test/not-repo"));
 
 		await waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalled();
+			expect(gitStatusCallCount()).toBeGreaterThanOrEqual(1);
 		});
 
 		expect(result.current.statusMap.size).toBe(0);
@@ -160,9 +195,18 @@ describe("useGitStatus", () => {
 
 	it("should debounce refresh on file-change events", async () => {
 		vi.useFakeTimers();
-		mockInvoke.mockResolvedValue([]);
 
-		type ListenCallback = (event: { payload: { path: string } }) => void;
+		const WATCHER_ID = 42;
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "start_watching") return Promise.resolve(WATCHER_ID);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
+
+		type ListenCallback = (event: {
+			payload: { watcher_id: number; path: string };
+		}) => void;
 		let fileChangeCallback: ListenCallback | null = null;
 		mockListen.mockImplementation((event: string, cb: ListenCallback) => {
 			if (event === "file-change") {
@@ -174,33 +218,53 @@ describe("useGitStatus", () => {
 		renderHook(() => useGitStatus("/test/repo"));
 
 		await vi.waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(1);
+			expect(gitStatusCallCount()).toBe(1);
+		});
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("start_watching", {
+				path: "/test/repo",
+			});
 		});
 
 		expect(fileChangeCallback).not.toBeNull();
 
 		act(() => {
-			fileChangeCallback?.({ payload: { path: "/test/repo/src/a.ts" } });
-			fileChangeCallback?.({ payload: { path: "/test/repo/src/b.ts" } });
-			fileChangeCallback?.({ payload: { path: "/test/repo/src/c.ts" } });
+			fileChangeCallback?.({
+				payload: { watcher_id: WATCHER_ID, path: "/test/repo/src/a.ts" },
+			});
+			fileChangeCallback?.({
+				payload: { watcher_id: WATCHER_ID, path: "/test/repo/src/b.ts" },
+			});
+			fileChangeCallback?.({
+				payload: { watcher_id: WATCHER_ID, path: "/test/repo/src/c.ts" },
+			});
 		});
 
-		expect(mockInvoke).toHaveBeenCalledTimes(1);
+		expect(gitStatusCallCount()).toBe(1);
 
 		await act(async () => {
 			vi.advanceTimersByTime(300);
 		});
 
-		expect(mockInvoke).toHaveBeenCalledTimes(2);
+		expect(gitStatusCallCount()).toBe(2);
 
 		vi.useRealTimers();
 	});
 
-	it("should ignore file-change events from different rootPath", async () => {
+	it("should ignore file-change events with non-matching watcher_id", async () => {
 		vi.useFakeTimers();
-		mockInvoke.mockResolvedValue([]);
 
-		type ListenCallback = (event: { payload: { path: string } }) => void;
+		const WATCHER_ID = 42;
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "start_watching") return Promise.resolve(WATCHER_ID);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
+
+		type ListenCallback = (event: {
+			payload: { watcher_id: number; path: string };
+		}) => void;
 		let fileChangeCallback: ListenCallback | null = null;
 		mockListen.mockImplementation((event: string, cb: ListenCallback) => {
 			if (event === "file-change") {
@@ -212,44 +276,17 @@ describe("useGitStatus", () => {
 		renderHook(() => useGitStatus("/test/repo-a"));
 
 		await vi.waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(1);
+			expect(gitStatusCallCount()).toBe(1);
 		});
-
-		act(() => {
-			fileChangeCallback?.({ payload: { path: "/test/repo-b/src/file.ts" } });
-		});
-
-		await act(async () => {
-			vi.advanceTimersByTime(300);
-		});
-
-		expect(mockInvoke).toHaveBeenCalledTimes(1);
-
-		vi.useRealTimers();
-	});
-
-	it("should ignore file-change events from a path that shares the same prefix but is a different directory", async () => {
-		vi.useFakeTimers();
-		mockInvoke.mockResolvedValue([]);
-
-		type ListenCallback = (event: { payload: { path: string } }) => void;
-		let fileChangeCallback: ListenCallback | null = null;
-		mockListen.mockImplementation((event: string, cb: ListenCallback) => {
-			if (event === "file-change") {
-				fileChangeCallback = cb;
-			}
-			return Promise.resolve(vi.fn());
-		});
-
-		renderHook(() => useGitStatus("/test/repo"));
-
 		await vi.waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(1);
+			expect(mockInvoke).toHaveBeenCalledWith("start_watching", {
+				path: "/test/repo-a",
+			});
 		});
 
 		act(() => {
 			fileChangeCallback?.({
-				payload: { path: "/test/repo-other/src/file.ts" },
+				payload: { watcher_id: 999, path: "/test/repo-b/src/file.ts" },
 			});
 		});
 
@@ -257,13 +294,15 @@ describe("useGitStatus", () => {
 			vi.advanceTimersByTime(300);
 		});
 
-		expect(mockInvoke).toHaveBeenCalledTimes(1);
+		expect(gitStatusCallCount()).toBe(1);
 
 		vi.useRealTimers();
 	});
 
 	it("should deduplicate when debounce fires after externalRefreshKey fetch", async () => {
 		vi.useFakeTimers();
+
+		const WATCHER_ID = 42;
 		const mockEntries: GitFileStatus[] = [
 			{
 				path: "src/main.ts",
@@ -271,9 +310,16 @@ describe("useGitStatus", () => {
 				worktree_status: "modified",
 			},
 		];
-		mockInvoke.mockResolvedValue(mockEntries);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "start_watching") return Promise.resolve(WATCHER_ID);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
-		type ListenCallback = (event: { payload: { path: string } }) => void;
+		type ListenCallback = (event: {
+			payload: { watcher_id: number; path: string };
+		}) => void;
 		let fileChangeCallback: ListenCallback | null = null;
 		mockListen.mockImplementation((event: string, cb: ListenCallback) => {
 			if (event === "file-change") {
@@ -289,38 +335,48 @@ describe("useGitStatus", () => {
 		);
 
 		await vi.waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(1);
+			expect(gitStatusCallCount()).toBe(1);
+		});
+		await vi.waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("start_watching", {
+				path: "/test/repo",
+			});
 		});
 
 		act(() => {
-			fileChangeCallback?.({ payload: { path: "/test/repo/src/a.ts" } });
+			fileChangeCallback?.({
+				payload: { watcher_id: WATCHER_ID, path: "/test/repo/src/a.ts" },
+			});
 		});
 
 		rerender({ refreshKey: 1 });
 
 		await vi.waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(2);
+			expect(gitStatusCallCount()).toBe(2);
 		});
 
 		await act(async () => {
 			vi.advanceTimersByTime(300);
 		});
 
-		// Debounce fires (3rd invoke call), but prevEntriesRef dedup prevents state update
-		expect(mockInvoke).toHaveBeenCalledTimes(3);
-		// State remains the same (only 1 entry)
+		expect(gitStatusCallCount()).toBe(3);
 		expect(result.current.statusMap.size).toBe(1);
 
 		vi.useRealTimers();
 	});
 
 	it("should re-fetch when refresh is called", async () => {
-		mockInvoke.mockResolvedValue([]);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		const { result } = renderHook(() => useGitStatus("/test/repo"));
 
 		await waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(1);
+			expect(gitStatusCallCount()).toBe(1);
 		});
 
 		act(() => {
@@ -328,7 +384,7 @@ describe("useGitStatus", () => {
 		});
 
 		await waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(2);
+			expect(gitStatusCallCount()).toBe(2);
 		});
 	});
 
@@ -340,7 +396,12 @@ describe("useGitStatus", () => {
 				worktree_status: "modified",
 			},
 		];
-		mockInvoke.mockResolvedValue(mockEntries);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		const { result } = renderHook(() => useGitStatus("/test/repo"));
 
@@ -356,7 +417,7 @@ describe("useGitStatus", () => {
 		});
 
 		await waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(2);
+			expect(gitStatusCallCount()).toBe(2);
 		});
 
 		expect(result.current.statusMap).toBe(firstStatusMap);
@@ -371,7 +432,12 @@ describe("useGitStatus", () => {
 				worktree_status: "modified",
 			},
 		];
-		mockInvoke.mockResolvedValue(initialEntries);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve(initialEntries);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		const { result } = renderHook(() => useGitStatus("/test/repo"));
 
@@ -393,7 +459,12 @@ describe("useGitStatus", () => {
 				worktree_status: "new",
 			},
 		];
-		mockInvoke.mockResolvedValue(updatedEntries);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve(updatedEntries);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		act(() => {
 			result.current.refresh();
@@ -408,7 +479,12 @@ describe("useGitStatus", () => {
 
 	it("should debounce refresh on git-status-changed events", async () => {
 		vi.useFakeTimers();
-		mockInvoke.mockResolvedValue([]);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		type GitStatusCallback = (event: {
 			payload: { repo_path: string };
@@ -424,7 +500,7 @@ describe("useGitStatus", () => {
 		renderHook(() => useGitStatus("/test/repo"));
 
 		await vi.waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(1);
+			expect(gitStatusCallCount()).toBe(1);
 		});
 
 		expect(gitStatusCallback).not.toBeNull();
@@ -433,20 +509,25 @@ describe("useGitStatus", () => {
 			gitStatusCallback?.({ payload: { repo_path: "/test/repo" } });
 		});
 
-		expect(mockInvoke).toHaveBeenCalledTimes(1);
+		expect(gitStatusCallCount()).toBe(1);
 
 		await act(async () => {
 			vi.advanceTimersByTime(300);
 		});
 
-		expect(mockInvoke).toHaveBeenCalledTimes(2);
+		expect(gitStatusCallCount()).toBe(2);
 
 		vi.useRealTimers();
 	});
 
 	it("should ignore git-status-changed events from different repo_path", async () => {
 		vi.useFakeTimers();
-		mockInvoke.mockResolvedValue([]);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
 
 		type GitStatusCallback = (event: {
 			payload: { repo_path: string };
@@ -462,7 +543,7 @@ describe("useGitStatus", () => {
 		renderHook(() => useGitStatus("/test/repo-a"));
 
 		await vi.waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledTimes(1);
+			expect(gitStatusCallCount()).toBe(1);
 		});
 
 		act(() => {
@@ -473,7 +554,7 @@ describe("useGitStatus", () => {
 			vi.advanceTimersByTime(300);
 		});
 
-		expect(mockInvoke).toHaveBeenCalledTimes(1);
+		expect(gitStatusCallCount()).toBe(1);
 
 		vi.useRealTimers();
 	});


### PR DESCRIPTION
## Summary

- ファイル変更イベントのフィルタリングをパス文字列の前方一致から `watcher_id` の一致比較に変更し、シンボリックリンクやOS依存のパス表現差異による検知漏れを解消
- `watcher.rs` に `canonicalize_event_path` を追加し、イベントパスを正規化してからemit
- `useGitEventRefresh` が独自に `start_watching`/`stop_watching` を管理し、自身の watcher_id でイベントをフィルタリング

## Test plan

- [x] `pnpm test` — Vitest 1308テスト全PASS
- [ ] 外部プロセス（AI Agent等）でファイルを変更し、Diff一覧に即時反映されることを確認
- [ ] macOSで `/private/var` 配下のワークツリーでも検知が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファイル変更検出メカニズムを改善し、Diff一覧がより信頼性高く、迅速に更新されるようになりました。外部からのファイル作成・修正・削除時の検出精度が向上し、連続した複数ファイルの変更にも正確に対応します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->