### PR TITLE
feat: Diffビュー選択ファイルのワークスペース永続化

### DIFF
--- a/docs/spec/issues-835.md
+++ b/docs/spec/issues-835.md
@@ -1,0 +1,56 @@
+## 要求
+
+**種別**: 改善
+**ゴール**: ワークスペースを切り替えて戻ってきたとき、以前Diffビューで選択していたファイルが復元される
+**背景**: 現在、Diffビューの選択ファイル（`selectedFile`）は`useReviewPanel`内のローカルstateで管理されており、ワークスペース切り替え時にnullにリセットされる。ワークスペースを頻繁に切り替えるユーザーにとって、毎回ファイルを選び直す必要があり不便
+**影響範囲**: WorkspaceState型の拡張、useReviewPanel/useWorktreeStateの永続化フロー
+
+## 振る舞い定義
+
+```gherkin
+Feature: Diffビュー選択ファイルのワークスペース永続化
+  ワークスペースを切り替えて戻ったとき、以前Diffビューで選択していたファイルが復元される
+
+  Rule: ワークスペース切り替え時に選択ファイルが保存される
+    Scenario: ワークスペースAでファイルを選択し、Bに切り替え、Aに戻ると選択が復元される
+      Given ワークスペースAのDiffビューでファイル "src/main.rs" を選択している
+      When ワークスペースBに切り替える
+      And ワークスペースAに戻る
+      Then Diffビューでファイル "src/main.rs" が選択されている
+
+  Rule: 選択ファイルが存在しなくなった場合はリセットされる
+    Scenario: 保存されていた選択ファイルが削除されている場合、選択なしになる
+      Given ワークスペースAのDiffビューでファイル "src/deleted.rs" を選択した状態で保存されている
+      And ファイル "src/deleted.rs" は既に削除されている
+      When ワークスペースAを開く
+      Then Diffビューでファイルは選択されていない
+
+  Rule: 初回オープン時はデフォルト状態で表示される
+    Scenario: 保存状態がないワークスペースを開くと選択なしで表示される
+      Given ワークスペースCに保存された状態がない
+      When ワークスペースCを開く
+      Then Diffビューでファイルは選択されていない
+```
+
+## 実装仕様
+
+**対応方針**: 既存のワークスペース状態永続化フロー（`WorkspaceState` → `InternalWorktreeState` → `useWorkspacePersistence` → `workspace_state_store.rs`）に `selectedDiffFile` フィールドを追加し、Diffビューの選択ファイルをワークスペースごとに保存・復元する。
+
+**対象コンポーネント**:
+- **`src/types/workspace-state.ts`**: `WorkspaceState.layout` に `selectedDiffFile?: string | null` を追加。`InternalWorktreeState` にも `selectedDiffFile` を追加。`buildWorkspaceState` で変換。
+- **`src-tauri/src/workspace_state_store.rs`**: `WorkspaceLayoutState` に `selected_diff_file: Option<String>` を追加（`serde(skip_serializing_if)`付き）。diff対象ファイルはGit管理のためディスク存在チェック不要。
+- **`src/screens/useWorktreeState.tsx`**: `selectedDiffFile` を `useState` で管理（初期値は `initialWorkspaceState?.layout.selectedDiffFile`）。`internalStateMapRef` への同期useEffectに追加。`setSelectedDiffFile` を返す。
+- **`src/hooks/useReviewPanel.ts`**: `UseReviewPanelOptions` に `initialSelectedFile?: string | null` を追加し、`useState` の初期値として使用。
+- **`src/hooks/useWorkspacePersistence.ts`**: 変更不要（`internalStateMapRef` と `buildWorkspaceState` 経由で自動永続化）。
+
+**データフロー**:
+1. `useWorktreeState` が `selectedDiffFile` のstateを保持し、`internalStateMapRef` に同期
+2. `ReviewPanel` に `initialSelectedDiffFile` と `onSelectedDiffFileChange` コールバックを渡す
+3. `useReviewPanel` の `selectFile` 呼び出し時に `onSelectedDiffFileChange` 経由で `useWorktreeState` に通知
+4. ワークスペース切り替え時、既存の `buildWorkspaceState` → `flushState` フローで自動保存
+5. 復元時、`initialWorkspaceState.layout.selectedDiffFile` が `useWorktreeState` → `ReviewPanel` → `useReviewPanel` に伝播
+
+**影響するテスト**:
+- **`src/hooks/useWorkspacePersistence.test.ts`**: A→B→Aの往復で `selectedDiffFile` が復元されるシナリオを追加
+- **`src-tauri/src/workspace_state_store.rs`**: `make_state()` に `selected_diff_file` フィールドを追加、既存テストの更新
+- **`src/hooks/useReviewPanel.test.ts`** (既存 or 新規): `initialSelectedFile` で初期値が設定されることを検証

--- a/src-tauri/src/workspace_state_store.rs
+++ b/src-tauri/src/workspace_state_store.rs
@@ -26,6 +26,8 @@ pub struct WorkspaceLayoutState {
     pub right_bottom_collapsed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub right_bottom_active_tab: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_diff_file: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -89,6 +91,18 @@ impl WorkspaceStateStore {
             let still_exists = state.tabs.editors.iter().any(|e| e.path == *active);
             if !still_exists {
                 state.tabs.active_editor_path = state.tabs.editors.first().map(|e| e.path.clone());
+            }
+        }
+
+        // Clear selected diff file if the file no longer exists
+        if let Some(ref diff_file) = state.layout.selected_diff_file {
+            let full_path = if diff_file.starts_with('/') || diff_file.starts_with('\\') {
+                PathBuf::from(diff_file)
+            } else {
+                Path::new(worktree_root).join(diff_file)
+            };
+            if !full_path.exists() {
+                state.layout.selected_diff_file = None;
             }
         }
 
@@ -190,6 +204,7 @@ mod tests {
                 right_collapsed: false,
                 right_bottom_collapsed: false,
                 right_bottom_active_tab: None,
+                selected_diff_file: None,
             },
         }
     }
@@ -300,5 +315,52 @@ mod tests {
         store.set("wt1", make_state());
         let got = store.get("wt1").unwrap();
         assert_eq!(got.tabs.editors.len(), 2);
+    }
+
+    #[test]
+    fn load_clears_selected_diff_file_when_deleted() {
+        let dir = TempDir::new().unwrap();
+        let worktree_dir = dir.path().join("worktree");
+        std::fs::create_dir_all(worktree_dir.join("src")).unwrap();
+        std::fs::write(worktree_dir.join("src/main.rs"), "fn main() {}").unwrap();
+        std::fs::write(worktree_dir.join("src/lib.rs"), "// lib").unwrap();
+
+        let mut state = make_state();
+        state.layout.selected_diff_file = Some("src/deleted.rs".to_string());
+
+        let store = WorkspaceStateStore::default();
+        store.set("wt1", state);
+        store.save(dir.path(), "wt1").unwrap();
+
+        let store2 = WorkspaceStateStore::default();
+        let loaded = store2
+            .load(dir.path(), "wt1", worktree_dir.to_str().unwrap())
+            .unwrap();
+        assert_eq!(loaded.layout.selected_diff_file, None);
+    }
+
+    #[test]
+    fn load_preserves_selected_diff_file_when_exists() {
+        let dir = TempDir::new().unwrap();
+        let worktree_dir = dir.path().join("worktree");
+        std::fs::create_dir_all(worktree_dir.join("src")).unwrap();
+        std::fs::write(worktree_dir.join("src/main.rs"), "fn main() {}").unwrap();
+        std::fs::write(worktree_dir.join("src/lib.rs"), "// lib").unwrap();
+
+        let mut state = make_state();
+        state.layout.selected_diff_file = Some("src/main.rs".to_string());
+
+        let store = WorkspaceStateStore::default();
+        store.set("wt1", state);
+        store.save(dir.path(), "wt1").unwrap();
+
+        let store2 = WorkspaceStateStore::default();
+        let loaded = store2
+            .load(dir.path(), "wt1", worktree_dir.to_str().unwrap())
+            .unwrap();
+        assert_eq!(
+            loaded.layout.selected_diff_file.as_deref(),
+            Some("src/main.rs")
+        );
     }
 }

--- a/src-tauri/src/workspace_state_store.rs
+++ b/src-tauri/src/workspace_state_store.rs
@@ -78,10 +78,11 @@ impl WorkspaceStateStore {
 
         // Filter out tabs whose files no longer exist
         state.tabs.editors.retain(|tab| {
-            let full_path = if tab.path.starts_with('/') || tab.path.starts_with('\\') {
-                PathBuf::from(&tab.path)
+            let tab_path = Path::new(&tab.path);
+            let full_path = if tab_path.is_absolute() {
+                tab_path.to_path_buf()
             } else {
-                Path::new(worktree_root).join(&tab.path)
+                Path::new(worktree_root).join(tab_path)
             };
             full_path.exists()
         });
@@ -96,10 +97,11 @@ impl WorkspaceStateStore {
 
         // Clear selected diff file if the file no longer exists
         if let Some(ref diff_file) = state.layout.selected_diff_file {
-            let full_path = if diff_file.starts_with('/') || diff_file.starts_with('\\') {
-                PathBuf::from(diff_file)
+            let diff_path = Path::new(diff_file.as_str());
+            let full_path = if diff_path.is_absolute() {
+                diff_path.to_path_buf()
             } else {
-                Path::new(worktree_root).join(diff_file)
+                Path::new(worktree_root).join(diff_path)
             };
             if !full_path.exists() {
                 state.layout.selected_diff_file = None;

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -51,6 +51,8 @@ interface ReviewPanelProps {
 	onDiffOnlyModeChange: (enabled: boolean) => void;
 	navigateToFile?: { path: string; line?: number } | null;
 	onSendToAgent?: (message: string) => Promise<void>;
+	initialSelectedFile?: string | null;
+	onSelectedFileChange?: (file: string | null) => void;
 }
 
 function DiffBaseToggle({
@@ -119,6 +121,8 @@ export function ReviewPanel({
 	onDiffOnlyModeChange,
 	navigateToFile,
 	onSendToAgent,
+	initialSelectedFile,
+	onSelectedFileChange,
 }: ReviewPanelProps) {
 	const {
 		diffBase,
@@ -127,11 +131,20 @@ export function ReviewPanel({
 		selectedSection,
 		setDiffBase,
 		setDiffMode,
-		selectFile,
+		selectFile: selectFileInternal,
 	} = useReviewPanel({
 		initialDiffBase: defaultDiffBase,
 		initialDiffMode: defaultDiffMode,
+		initialSelectedFile,
 	});
+
+	const selectFile = useCallback(
+		(path: string | null, section?: DiffSection) => {
+			selectFileInternal(path, section);
+			onSelectedFileChange?.(path);
+		},
+		[selectFileInternal, onSelectedFileChange],
+	);
 
 	const [gitRefreshKey, setGitRefreshKey] = useState(0);
 

--- a/src/hooks/__tests__/useReviewPanel.test.ts
+++ b/src/hooks/__tests__/useReviewPanel.test.ts
@@ -91,6 +91,24 @@ describe("useReviewPanel", () => {
 		expect(result.current.selectedSection).toBe("changes");
 	});
 
+	it("initializes selectedFile with initialSelectedFile option", () => {
+		const { result } = renderHook(() =>
+			useReviewPanel({
+				initialSelectedFile: "src/main.rs",
+			}),
+		);
+		expect(result.current.selectedFile).toBe("src/main.rs");
+	});
+
+	it("initializes selectedFile as null when initialSelectedFile is null", () => {
+		const { result } = renderHook(() =>
+			useReviewPanel({
+				initialSelectedFile: null,
+			}),
+		);
+		expect(result.current.selectedFile).toBeNull();
+	});
+
 	it("preserves selectedSection when selectFile is called without section", () => {
 		const { result } = renderHook(() => useReviewPanel());
 

--- a/src/hooks/useReviewPanel.ts
+++ b/src/hooks/useReviewPanel.ts
@@ -4,6 +4,7 @@ import type { DiffBase, DiffMode, DiffSection } from "@/types/settings";
 export interface UseReviewPanelOptions {
 	initialDiffBase?: DiffBase;
 	initialDiffMode?: DiffMode;
+	initialSelectedFile?: string | null;
 }
 
 export interface UseReviewPanelResult {
@@ -25,7 +26,9 @@ export function useReviewPanel(
 	const [diffMode, setDiffMode] = useState<DiffMode>(
 		options?.initialDiffMode ?? "inline",
 	);
-	const [selectedFile, setSelectedFile] = useState<string | null>(null);
+	const [selectedFile, setSelectedFile] = useState<string | null>(
+		options?.initialSelectedFile ?? null,
+	);
 	const [selectedSection, setSelectedSection] =
 		useState<DiffSection>("changes");
 

--- a/src/hooks/useWorkspacePersistence.test.ts
+++ b/src/hooks/useWorkspacePersistence.test.ts
@@ -560,4 +560,176 @@ describe("useWorkspacePersistence", () => {
 
 		expect(mockLoadState).not.toHaveBeenCalled();
 	});
+
+	it("stateReady: キャッシュがある場合は即座にtrue", () => {
+		mockGetState.mockReturnValue(makeState());
+
+		const setCenterTab = vi.fn();
+		const leftNavRef = makePanelRef();
+		const rightPanelRef = makePanelRef();
+
+		const { result } = renderHook(() =>
+			useWorkspacePersistence({
+				selectedRootPath: "/repoX",
+				centerTab: "editor",
+				leftNavVisible: true,
+				rightVisible: true,
+				setCenterTab,
+				leftNavRef,
+				rightPanelRef,
+			}),
+		);
+
+		expect(result.current.stateReady).toBe(true);
+	});
+
+	it("stateReady: キャッシュがない場合はloadState完了後にtrue", async () => {
+		let resolveLoad!: (v: WorkspaceState | undefined) => void;
+		mockLoadState.mockReturnValue(
+			new Promise((resolve) => {
+				resolveLoad = resolve;
+			}),
+		);
+		mockGetState.mockReturnValue(undefined);
+
+		const setCenterTab = vi.fn();
+		const leftNavRef = makePanelRef();
+		const rightPanelRef = makePanelRef();
+
+		const { result } = renderHook(() =>
+			useWorkspacePersistence({
+				selectedRootPath: "/repoX",
+				centerTab: "editor",
+				leftNavVisible: true,
+				rightVisible: true,
+				setCenterTab,
+				leftNavRef,
+				rightPanelRef,
+			}),
+		);
+
+		// loadState完了前はfalse
+		expect(result.current.stateReady).toBe(false);
+
+		// loadState完了
+		await act(async () => {
+			resolveLoad(makeState());
+		});
+
+		expect(result.current.stateReady).toBe(true);
+	});
+
+	it("stateReady: selectedRootPathがnullの場合はtrue", () => {
+		mockGetState.mockReturnValue(undefined);
+
+		const setCenterTab = vi.fn();
+		const leftNavRef = makePanelRef();
+		const rightPanelRef = makePanelRef();
+
+		const { result } = renderHook(() =>
+			useWorkspacePersistence({
+				selectedRootPath: null,
+				centerTab: "editor",
+				leftNavVisible: true,
+				rightVisible: true,
+				setCenterTab,
+				leftNavRef,
+				rightPanelRef,
+			}),
+		);
+
+		expect(result.current.stateReady).toBe(true);
+	});
+
+	it("stateReady: ワークスペース切替時にキャッシュがあれば即true", () => {
+		const stateB = makeState({
+			layout: {
+				centerTab: "agent",
+				activeView: "git",
+				leftNavCollapsed: false,
+				rightCollapsed: false,
+				rightBottomCollapsed: false,
+			},
+		});
+		mockGetState.mockImplementation((path: string) =>
+			path === "/repoB" ? stateB : undefined,
+		);
+
+		const setCenterTab = vi.fn();
+		const leftNavRef = makePanelRef();
+		const rightPanelRef = makePanelRef();
+
+		const { result, rerender } = renderHook(
+			({ selectedRootPath }) =>
+				useWorkspacePersistence({
+					selectedRootPath,
+					centerTab: "editor",
+					leftNavVisible: true,
+					rightVisible: true,
+					setCenterTab,
+					leftNavRef,
+					rightPanelRef,
+				}),
+			{ initialProps: { selectedRootPath: "/repoA" as string | null } },
+		);
+
+		// /repoAはキャッシュなし → false
+		expect(result.current.stateReady).toBe(false);
+
+		// /repoBに切替（キャッシュあり）
+		rerender({ selectedRootPath: "/repoB" });
+		expect(result.current.stateReady).toBe(true);
+	});
+
+	it("stateReady: ワークスペース切替時にキャッシュがなければloadState完了後にtrue", async () => {
+		let resolveLoad!: (v: WorkspaceState | undefined) => void;
+		mockGetState.mockReturnValue(undefined);
+		mockLoadState.mockReturnValue(
+			new Promise((resolve) => {
+				resolveLoad = resolve;
+			}),
+		);
+
+		const setCenterTab = vi.fn();
+		const leftNavRef = makePanelRef();
+		const rightPanelRef = makePanelRef();
+
+		const { result, rerender } = renderHook(
+			({ selectedRootPath }) =>
+				useWorkspacePersistence({
+					selectedRootPath,
+					centerTab: "editor",
+					leftNavVisible: true,
+					rightVisible: true,
+					setCenterTab,
+					leftNavRef,
+					rightPanelRef,
+				}),
+			{ initialProps: { selectedRootPath: "/repoA" as string | null } },
+		);
+
+		// loadState完了でstateReady=true
+		await act(async () => {
+			resolveLoad(undefined);
+		});
+		expect(result.current.stateReady).toBe(true);
+
+		// 新しいloadStateのPromiseを設定
+		let resolveLoad2!: (v: WorkspaceState | undefined) => void;
+		mockLoadState.mockReturnValue(
+			new Promise((resolve) => {
+				resolveLoad2 = resolve;
+			}),
+		);
+
+		// /repoBに切替（キャッシュなし）
+		rerender({ selectedRootPath: "/repoB" });
+		expect(result.current.stateReady).toBe(false);
+
+		// loadState完了
+		await act(async () => {
+			resolveLoad2(makeState());
+		});
+		expect(result.current.stateReady).toBe(true);
+	});
 });

--- a/src/hooks/useWorkspacePersistence.test.ts
+++ b/src/hooks/useWorkspacePersistence.test.ts
@@ -59,6 +59,7 @@ function makeInternalState(
 		rightBottomCollapsed: false,
 		reviewCollapsed: false,
 		diffOnlyMode: false,
+		selectedDiffFile: null,
 		...overrides,
 	};
 }
@@ -439,6 +440,81 @@ describe("useWorkspacePersistence", () => {
 		expect(result.current.internalStateMapRef.current.has("/repoB")).toBe(
 			false,
 		);
+	});
+
+	it("シナリオ9: A→B→A の往復で selectedDiffFile が復元される", () => {
+		const stateA = makeState({
+			layout: {
+				centerTab: "editor",
+				activeView: "git",
+				leftNavCollapsed: false,
+				rightCollapsed: false,
+				rightBottomCollapsed: false,
+				selectedDiffFile: "src/main.rs",
+			},
+		});
+		const stateB = makeState({
+			layout: {
+				centerTab: "agent",
+				activeView: "explorer",
+				leftNavCollapsed: false,
+				rightCollapsed: false,
+				rightBottomCollapsed: false,
+			},
+		});
+
+		mockGetState.mockImplementation((path: string) => {
+			if (path === "/repoA") return stateA;
+			if (path === "/repoB") return stateB;
+			return undefined;
+		});
+
+		const setCenterTab = vi.fn();
+		const leftNavRef = makePanelRef();
+		const rightPanelRef = makePanelRef();
+
+		const { result, rerender } = renderHook(
+			({ selectedRootPath }) =>
+				useWorkspacePersistence({
+					selectedRootPath,
+					centerTab: "editor",
+					leftNavVisible: true,
+					rightVisible: true,
+					setCenterTab,
+					leftNavRef,
+					rightPanelRef,
+				}),
+			{ initialProps: { selectedRootPath: "/repoA" as string | null } },
+		);
+
+		// Set internal state for A with selectedDiffFile
+		act(() => {
+			result.current.internalStateMapRef.current.set(
+				"/repoA",
+				makeInternalState({ selectedDiffFile: "src/main.rs" }),
+			);
+		});
+
+		// A → B
+		rerender({ selectedRootPath: "/repoB" });
+
+		// A's state should be saved with selectedDiffFile
+		const savedState = mockUpdateState.mock.calls[0][1] as WorkspaceState;
+		expect(savedState.layout.selectedDiffFile).toBe("src/main.rs");
+
+		// B → A
+		setCenterTab.mockClear();
+		act(() => {
+			result.current.internalStateMapRef.current.set(
+				"/repoB",
+				makeInternalState({ activeView: "explorer" }),
+			);
+		});
+		rerender({ selectedRootPath: "/repoA" });
+
+		// A's cached state should have selectedDiffFile restored
+		const initialState = result.current.getInitialState("/repoA");
+		expect(initialState?.layout.selectedDiffFile).toBe("src/main.rs");
 	});
 
 	it("pre-load: 初回マウント時にloadStateが呼ばれる", () => {

--- a/src/hooks/useWorkspacePersistence.ts
+++ b/src/hooks/useWorkspacePersistence.ts
@@ -119,9 +119,15 @@ export function useWorkspacePersistence({
 		if (!selectedRootPath) return;
 		const cache = workspaceCacheRef.current;
 		if (cache.getState(selectedRootPath)) return;
+		let cancelled = false;
 		cache.loadState(selectedRootPath).then(() => {
-			setStateReady(true);
+			if (!cancelled) {
+				setStateReady(true);
+			}
 		});
+		return () => {
+			cancelled = true;
+		};
 	}, [selectedRootPath]);
 
 	return {

--- a/src/hooks/useWorkspacePersistence.ts
+++ b/src/hooks/useWorkspacePersistence.ts
@@ -22,6 +22,7 @@ interface UseWorkspacePersistenceReturn {
 		Map<string, InternalWorktreeState>
 	>;
 	getInitialState: (rootPath: string) => WorkspaceState | undefined;
+	stateReady: boolean;
 }
 
 export function useWorkspacePersistence({
@@ -37,6 +38,11 @@ export function useWorkspacePersistence({
 	const internalStateMapRef = useRef<Map<string, InternalWorktreeState>>(
 		new Map(),
 	);
+
+	const [stateReady, setStateReady] = useState(() => {
+		if (!selectedRootPath) return true;
+		return !!workspaceCache.getState(selectedRootPath);
+	});
 
 	const centerTabRef = useRef(centerTab);
 	centerTabRef.current = centerTab;
@@ -73,6 +79,12 @@ export function useWorkspacePersistence({
 			? workspaceCache.getState(selectedRootPath)
 			: undefined;
 		setCenterTab(cached?.layout.centerTab ?? "agent");
+
+		// 切替先のキャッシュ有無でstateReadyを更新
+		const hasCache = selectedRootPath
+			? !!workspaceCache.getState(selectedRootPath)
+			: true;
+		setStateReady(hasCache);
 	}
 
 	// Restore panel expand/collapse (DOM操作のためuseEffect + rAF)
@@ -107,11 +119,14 @@ export function useWorkspacePersistence({
 		if (!selectedRootPath) return;
 		const cache = workspaceCacheRef.current;
 		if (cache.getState(selectedRootPath)) return;
-		cache.loadState(selectedRootPath);
+		cache.loadState(selectedRootPath).then(() => {
+			setStateReady(true);
+		});
 	}, [selectedRootPath]);
 
 	return {
 		internalStateMapRef,
 		getInitialState: workspaceCache.getState,
+		stateReady,
 	};
 }

--- a/src/screens/MainLayout.tsx
+++ b/src/screens/MainLayout.tsx
@@ -269,15 +269,16 @@ export function MainLayout({
 	const [rightVisible, setRightVisible] = useState(true);
 
 	// --- Workspace state persistence ---
-	const { internalStateMapRef, getInitialState } = useWorkspacePersistence({
-		selectedRootPath,
-		centerTab: "agent",
-		leftNavVisible,
-		rightVisible,
-		setCenterTab: () => {},
-		leftNavRef,
-		rightPanelRef,
-	});
+	const { internalStateMapRef, getInitialState, stateReady } =
+		useWorkspacePersistence({
+			selectedRootPath,
+			centerTab: "agent",
+			leftNavVisible,
+			rightVisible,
+			setCenterTab: () => {},
+			leftNavRef,
+			rightPanelRef,
+		});
 
 	const { branch } = useCurrentBranch(selectedRootPath);
 	const { baseBranch, setBaseBranch, localBranches } = useBaseBranch(
@@ -412,7 +413,7 @@ export function MainLayout({
 				<Separator />
 				<Panel id="main-area" minSize="30%">
 					<Group orientation="horizontal" className="h-full">
-						{selectedRootPath ? (
+						{selectedRootPath && stateReady ? (
 							<WorktreeContent
 								key={selectedRootPath}
 								rootPath={selectedRootPath}
@@ -434,9 +435,13 @@ export function MainLayout({
 										leftPanels={leftNavVisible ? undefined : [leftToggle]}
 										rightSlot={rightSlotContent}
 									/>
-									<div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
-										Select a worktree from the sidebar to start working
-									</div>
+									{!selectedRootPath ? (
+										<div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+											Select a worktree from the sidebar to start working
+										</div>
+									) : (
+										<div className="flex-1" />
+									)}
 								</div>
 							</Panel>
 						)}

--- a/src/screens/MainLayout.tsx
+++ b/src/screens/MainLayout.tsx
@@ -187,6 +187,8 @@ function WorktreeContent({
 										onDiffOnlyModeChange={s.setDiffOnlyMode}
 										navigateToFile={navigateToFile}
 										onSendToAgent={handleSendToAgent}
+										initialSelectedFile={s.selectedDiffFile}
+										onSelectedFileChange={s.setSelectedDiffFile}
 									/>
 								</div>
 							</Panel>

--- a/src/screens/useWorktreeState.tsx
+++ b/src/screens/useWorktreeState.tsx
@@ -53,6 +53,10 @@ export function useWorktreeState({
 			false,
 	);
 
+	const [selectedDiffFile, setSelectedDiffFile] = useState<string | null>(
+		initialWorkspaceState?.layout.selectedDiffFile ?? null,
+	);
+
 	const { branch } = useCurrentBranch(rootPath);
 	const [ready, setReady] = useState(false);
 
@@ -125,6 +129,7 @@ export function useWorktreeState({
 			rightBottomCollapsed,
 			reviewCollapsed,
 			diffOnlyMode,
+			selectedDiffFile,
 		});
 	}, [
 		internalStateMapRef,
@@ -132,6 +137,7 @@ export function useWorktreeState({
 		rightBottomCollapsed,
 		reviewCollapsed,
 		diffOnlyMode,
+		selectedDiffFile,
 	]);
 
 	return {
@@ -158,5 +164,7 @@ export function useWorktreeState({
 		setReviewCollapsed,
 		diffOnlyMode,
 		setDiffOnlyMode,
+		selectedDiffFile,
+		setSelectedDiffFile,
 	};
 }

--- a/src/types/workspace-state.test.ts
+++ b/src/types/workspace-state.test.ts
@@ -31,6 +31,7 @@ describe("buildWorkspaceState", () => {
 			rightBottomCollapsed: false,
 			reviewCollapsed: false,
 			diffOnlyMode: false,
+			selectedDiffFile: null,
 		};
 
 		const result = buildWorkspaceState(internal, "editor", true, true);
@@ -49,6 +50,7 @@ describe("buildWorkspaceState", () => {
 				rightBottomCollapsed: false,
 				reviewCollapsed: false,
 				diffOnlyMode: false,
+				selectedDiffFile: null,
 			},
 		});
 	});
@@ -61,6 +63,7 @@ describe("buildWorkspaceState", () => {
 			rightBottomCollapsed: false,
 			reviewCollapsed: false,
 			diffOnlyMode: false,
+			selectedDiffFile: null,
 		};
 
 		const result = buildWorkspaceState(internal, "editor", true, true);
@@ -75,6 +78,7 @@ describe("buildWorkspaceState", () => {
 			rightBottomCollapsed: false,
 			reviewCollapsed: false,
 			diffOnlyMode: false,
+			selectedDiffFile: null,
 		};
 
 		const result = buildWorkspaceState(internal, "editor", false, true);
@@ -89,6 +93,7 @@ describe("buildWorkspaceState", () => {
 			rightBottomCollapsed: false,
 			reviewCollapsed: false,
 			diffOnlyMode: false,
+			selectedDiffFile: null,
 		};
 
 		const result = buildWorkspaceState(internal, "editor", true, false);
@@ -103,11 +108,27 @@ describe("buildWorkspaceState", () => {
 			rightBottomCollapsed: true,
 			reviewCollapsed: false,
 			diffOnlyMode: false,
+			selectedDiffFile: null,
 		};
 
 		const result = buildWorkspaceState(internal, "agent", true, true);
 		expect(result.layout.rightBottomCollapsed).toBe(true);
 		expect(result.layout.centerTab).toBe("agent");
+	});
+
+	it("selectedDiffFileが非null値で保持される", () => {
+		const internal = {
+			tabs: [],
+			activeEditorPath: null,
+			activeView: "git",
+			rightBottomCollapsed: false,
+			reviewCollapsed: false,
+			diffOnlyMode: false,
+			selectedDiffFile: "src/main.rs",
+		};
+
+		const result = buildWorkspaceState(internal, "editor", true, true);
+		expect(result.layout.selectedDiffFile).toBe("src/main.rs");
 	});
 
 	it("diffOnlyMode=trueが保持される", () => {
@@ -118,6 +139,7 @@ describe("buildWorkspaceState", () => {
 			rightBottomCollapsed: false,
 			reviewCollapsed: false,
 			diffOnlyMode: true,
+			selectedDiffFile: null,
 		};
 
 		const result = buildWorkspaceState(internal, "editor", true, true);

--- a/src/types/workspace-state.ts
+++ b/src/types/workspace-state.ts
@@ -16,6 +16,7 @@ export interface WorkspaceState {
 		rightBottomCollapsed: boolean;
 		reviewCollapsed?: boolean;
 		diffOnlyMode?: boolean;
+		selectedDiffFile?: string | null;
 	};
 }
 
@@ -26,6 +27,7 @@ export interface InternalWorktreeState {
 	rightBottomCollapsed: boolean;
 	reviewCollapsed: boolean;
 	diffOnlyMode: boolean;
+	selectedDiffFile: string | null;
 }
 
 export function buildWorkspaceState(
@@ -48,6 +50,7 @@ export function buildWorkspaceState(
 			rightBottomCollapsed: internal.rightBottomCollapsed,
 			reviewCollapsed: internal.reviewCollapsed,
 			diffOnlyMode: internal.diffOnlyMode,
+			selectedDiffFile: internal.selectedDiffFile,
 		},
 	};
 }


### PR DESCRIPTION
## Summary
- ワークスペース切り替え時にDiffビューの選択ファイルが失われる問題を解決
- `WorkspaceState` に `selectedDiffFile` フィールドを追加し、既存の永続化フローで自動保存・復元
- Rust側で復元時に削除済みファイルの存在チェックを実施し、存在しなければ選択をリセット

## Test plan
- [x] Vitest 1312テスト全PASS
- [x] Rust 763テスト全PASS
- [ ] ワークスペースAでDiffファイルを選択→Bに切替→Aに戻り、選択が復元されることを確認
- [ ] 選択していたファイルが削除された状態でワークスペースを開き、選択なしになることを確認
- [ ] 保存状態がないワークスペースを開き、選択なしで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Diff ビューで選択したファイルがワークスペース間で保持されるようになりました。ワークスペースを切り替えて戻ると、以前選択していたファイルが自動的に復元されます。選択されたファイルが削除された場合は、選択がリセットされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->