### PR TITLE
feat: 非ASCIIファイルメンションの構造化データ対応

### DIFF
--- a/docs/spec/issues-836.md
+++ b/docs/spec/issues-836.md
@@ -1,0 +1,91 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: `@` でファイル名を指定する際、ファイル名に日本語・全角スペース・中黒（・）など正規表現 `\w` に一致しない文字が含まれていると、ファイル指定が外れる（パースされずファイルコンテキストがAIエージェントに送信されない）
+**期待する挙動**: 日本語を含むファイル名でも `@` 参照が正しく機能し、ファイルコンテキストがAIエージェントに送信される
+**再現手順**:
+1. 日本語名を含むファイルを用意する（例: `docs/decisions/PJT-1691/Gitフロー　・デプロイサイクル見直し.md`）
+2. AgentChatで `@` を入力し、当該ファイルを選択する
+3. 行番号指定（`:L50`）も付与してメッセージを送信する
+4. ファイルコンテキストがAIエージェントに送信されない
+**背景**: `file_mention.rs` の正規表現 `[\w./_\-\[\]]+` の `\w` がASCII範囲（`[a-zA-Z0-9_]`）のみに対応しており、日本語やUnicodeのワード文字をカバーしていない
+
+## 振る舞い定義
+
+```gherkin
+Feature: 非ASCII文字を含むファイルの@メンション参照
+  ファイル名に日本語・全角記号等の非ASCII文字を含むファイルを
+  @メンション構文で参照し、ファイルコンテキストをAIエージェントに送信できる
+
+  Rule: ファイル選択結果の構造化データ伝達
+    Scenario: ポップアップで選択したファイルパスが構造化データとしてAgentに渡される
+      Given ユーザーが@メンションで "docs/Gitフロー　・デプロイサイクル見直し.md" を選択した
+      When メッセージを送信する
+      Then 選択されたファイルパスが構造化データとしてRust側のAgent処理に渡される
+      And Rust側でファイル内容が読み取られる
+      And ファイルの内容がuser messageのコンテキストとしてAgentプロンプトに含まれる
+
+    Scenario: 行番号指定付きのファイル選択が構造化データとして渡される
+      Given ユーザーが@メンションで "docs/Gitフロー.md" を選択し ":L50" を付与した
+      When メッセージを送信する
+      Then ファイルパスと行番号50が構造化データとしてRust側に渡される
+      And 該当行の内容がuser messageのコンテキストとしてAgentプロンプトに含まれる
+
+    Scenario: 行範囲指定付きのファイル選択が構造化データとして渡される
+      Given ユーザーが@メンションで "docs/Gitフロー.md" を選択し ":L10-L20" を付与した
+      When メッセージを送信する
+      Then ファイルパスと行範囲10-20が構造化データとしてRust側に渡される
+      And 該当行範囲の内容がuser messageのコンテキストとしてAgentプロンプトに含まれる
+
+  Rule: 表示用メンションバッジの分離
+    Scenario: 日本語ファイル名がメンションバッジとして表示される
+      Given 送信済みメッセージに "docs/Gitフロー.md" のメンションが含まれている
+      When メッセージを表示する
+      Then メンション部分がバッジとして視覚的に区別して表示される
+```
+
+## 実装仕様
+
+**対応方針**: Agent送信時のファイルコンテキスト構築を、テキスト埋め込み→正規表現パース方式から構造化データ直接伝達方式に変更する。表示用パースの正規表現はUnicode対応に修正する。
+
+**対象コンポーネント**:
+
+### Rust側
+
+- **`src-tauri/src/file_mention.rs`**:
+  - `MentionReference` 構造体を追加（`file_path: String, start_line: Option<u32>, end_line: Option<u32>`）
+  - `resolve_from_references()` 新設: 構造化データから直接ファイル読み込み・`<file_context>` ブロック構築
+  - `MENTION_RE` の文字クラスをUnicode対応に修正（`parse_display_mentions` の表示用パースのため）
+  - `parse_mentions` / `resolve_mentions_internal` / `resolve_mentions_or_fallback` は削除（呼び出し元がなくなる）
+
+- **`src-tauri/src/agent_sdk.rs`**:
+  - `send_agent_message` コマンドに `mentions: Option<Vec<MentionReference>>` パラメータ追加
+  - `PendingMessage` に `mentions` フィールド追加
+  - `resolve_mentions_or_fallback` 呼び出しを `resolve_from_references` に置き換え
+
+- **`src-tauri/src/diff_comment_sender.rs`**:
+  - `format_comments_for_agent` → `build_mentions_from_comments`: `DiffComment[]` を `MentionReference[]` に変換
+  - コメントテキストは別途渡す
+  - `SendDiffCommentsResult` に `mentions: Vec<MentionReference>` フィールド追加
+
+### フロントエンド側
+
+- **`src/types/session.ts`**: `MentionReference` 型追加
+- **`MessageInput.tsx`**: 選択ファイルを `MentionReference[]` stateに保持し `onSend` に渡す
+- **`useAgentChat.ts`** / **`useSessionStore.ts`**: `mentions` 引数を中継
+- **`MainLayout.tsx`**: `sendAgentMessageRef` の型を拡張（`mentions` 引数追加）
+- **`ReviewPanel.tsx`**: コメント送信時に `mentions` + コメントテキストを渡す
+
+### 表示
+
+- `content` テキストには `@filepath` がそのまま残る（変更なし）
+- `parse_display_mentions` の正規表現をUnicode対応に修正 → 日本語ファイル名もバッジ表示される
+
+**検討した代替案**:
+- 正規表現の文字クラスをUnicode対応に拡張するのみの案: Agent送信側もテキストパースに依存し続ける。全角スペース等でメンション区間の終端判定が困難。OSS（Continue.dev, Zed, Void）全件が構造化データ方式を採用。却下
+
+**影響するテスト**:
+- `file_mention.rs`: `resolve_from_references` の新規テスト、`parse_display_mentions` のUnicode対応テスト
+- `diff_comment_sender.rs`: `build_mentions_from_comments` のテスト
+- `MessageInput.test.tsx`: メンション選択時に構造化データ保持のテスト
+- `useDiffComments.test.ts`: コメント送信時のメンションデータ伝達テスト

--- a/docs/spec/issues-836.md
+++ b/docs/spec/issues-836.md
@@ -46,23 +46,31 @@ Feature: 非ASCII文字を含むファイルの@メンション参照
 
 ## 実装仕様
 
-**対応方針**: Agent送信時のファイルコンテキスト構築を、テキスト埋め込み→正規表現パース方式から構造化データ直接伝達方式に変更する。表示用パースの正規表現はUnicode対応に修正する。
+**対応方針**: Agent送信時のファイルコンテキスト構築を、テキスト埋め込み→正規表現パース方式から構造化データ直接伝達方式に変更する。表示用バッジ生成も構造化データ（mentions配列）をソースオブトゥルースとし、`parse_display_mentions` Tauriコマンドによるテキストパースは廃止する。
 
 **対象コンポーネント**:
 
 ### Rust側
 
+- **`src-tauri/src/session/mod.rs`**:
+  - `ChatMessage` に `mentions: Option<Vec<crate::file_mention::MentionReference>>` フィールド追加（永続化対応）
+  - `add_message_internal` に `mentions` パラメータ追加
+  - humanメッセージ送信時にフロントエンドから渡されたmentionsをそのまま保存
+
 - **`src-tauri/src/file_mention.rs`**:
-  - `MentionReference` 構造体を追加（`file_path: String, start_line: Option<u32>, end_line: Option<u32>`）
-  - `resolve_from_references()` 新設: 構造化データから直接ファイル読み込み・`<file_context>` ブロック構築
-  - `resolve_mentions_or_fallback()` は `resolve_from_references` のフォールバック付きラッパーとして残す（エラー時にログ出力し元のcontentを返す）
-  - `MENTION_RE` の文字クラスをASCII空白限定に修正（`parse_display_mentions` の表示用パースで全角スペースを含むパスを切り捨てないため）
-  - `parse_mentions` / `resolve_mentions_internal` は削除（呼び出し元がなくなる）
+  - `MentionReference` 構造体（`file_path: String, start_line: Option<u32>, end_line: Option<u32>`）
+  - `resolve_from_references()`: 構造化データから直接ファイル読み込み・`<file_context>` ブロック構築
+  - `resolve_mentions_or_fallback()`: `resolve_from_references` のフォールバック付きラッパー
+  - 削除: `parse_display_mentions` コマンド、`DisplayPart` enum、`MENTION_RE` 正規表現、`is_valid_mention_position` 関数（テキストパース方式の全廃）
 
 - **`src-tauri/src/agent_sdk.rs`**:
   - `send_agent_message` コマンドに `mentions: Option<Vec<MentionReference>>` パラメータ追加
   - `PendingMessage` に `mentions` フィールド追加
-  - `resolve_mentions_or_fallback` を経由して `resolve_from_references` を呼び出す（フォールバック付きで後方互換性を維持）
+  - `resolve_mentions_or_fallback` を経由して `resolve_from_references` を呼び出す
+  - humanメッセージ保存時にmentionsをChatMessageに含める
+
+- **`src-tauri/src/lib.rs`**:
+  - `file_mention::parse_display_mentions` のコマンド登録を削除
 
 - **`src-tauri/src/diff_comment_sender.rs`**:
   - `format_comments_for_agent` → `build_mentions_from_comments`: `DiffComment[]` を `MentionReference[]` に変換
@@ -71,8 +79,9 @@ Feature: 非ASCII文字を含むファイルの@メンション参照
 
 ### フロントエンド側
 
-- **`src/types/session.ts`**: `MentionReference` 型追加
-- **`MessageInput.tsx`**: 選択ファイルを `MentionReference[]` stateに保持し `onSend` に渡す
+- **`src/types/session.ts`**: `ChatMessage` / `LegacyChatMessage` に `mentions?: MentionReference[]` フィールド追加
+- **`src/hooks/useSessionStore.ts`**: `convertLegacyMessage` で `mentions` を引き継ぎ
+- **`MessageInput.tsx`**: 選択ファイルを `MentionReference[]` stateに保持し `onSend` に渡す。`syncMentionsWithText` をテキスト出現順にイテレーションするよう修正（C2対応）
 - **`useAgentChat.ts`** / **`useSessionStore.ts`**: `mentions` 引数を中継
 - **`MainLayout.tsx`**: `sendAgentMessageRef` の型を拡張（`mentions` 引数追加）
 - **`ReviewPanel.tsx`**: コメント送信時に `mentions` + コメントテキストを渡す
@@ -80,13 +89,19 @@ Feature: 非ASCII文字を含むファイルの@メンション参照
 ### 表示
 
 - `content` テキストには `@filepath` がそのまま残る（変更なし）
-- `parse_display_mentions` の正規表現をUnicode対応に修正 → 日本語ファイル名もバッジ表示される
+- **`StreamMessage.tsx`**: `invoke("parse_display_mentions")` を完全削除。`buildDisplayParts()` 関数で `mentions` prop から同期的にバッジ生成（表示用フォーマットの範疇でフロントエンドに配置）
+- **`AgentChatPanel.tsx`**: `<StreamMessage>` に `mentions={msg.mentions}` を渡す
 
 **検討した代替案**:
 - 正規表現の文字クラスをUnicode対応に拡張するのみの案: Agent送信側もテキストパースに依存し続ける。全角スペース等でメンション区間の終端判定が困難。OSS（Continue.dev, Zed, Void）全件が構造化データ方式を採用。却下
+- `format_comment_text` でファイルパスをエスケープする案: テキストパースの複雑化を避けるため却下。VS Code / Cursor / Continue.dev 等のOSSが構造化データSoT方式を採用しており、業界標準に合わせる
+
+**`syncMentionsWithText` の順序修正（C2）**:
+- 変更前: `refs` 配列の順でイテレーションし、テキスト中の出現順と食い違う可能性があった
+- 変更後: テキスト中の `@filePath` 出現順で正規表現マッチをイテレーションし、各マッチの `filePath` に対応する `refs` をカウンターで消費する方式に修正
 
 **影響するテスト**:
-- `file_mention.rs`: `resolve_from_references` の新規テスト、`parse_display_mentions` のUnicode対応テスト
-- `diff_comment_sender.rs`: `build_mentions_from_comments` のテスト
+- `file_mention.rs`: `parse_display_mentions_*` テスト9件を削除、`resolve_from_references` テストは既存のまま維持
+- `session/mod.rs` / `session/store.rs`: `ChatMessage` 手動構築箇所に `mentions: None` 追加
+- `StreamMessage.test.tsx`: `parse_display_mentions` モック削除、`mentions` propベースのバッジ表示テストに書き換え
 - `MessageInput.test.tsx`: メンション選択時に構造化データ保持のテスト
-- `useDiffComments.test.ts`: コメント送信時のメンションデータ伝達テスト

--- a/docs/spec/issues-836.md
+++ b/docs/spec/issues-836.md
@@ -55,13 +55,14 @@ Feature: 非ASCII文字を含むファイルの@メンション参照
 - **`src-tauri/src/file_mention.rs`**:
   - `MentionReference` 構造体を追加（`file_path: String, start_line: Option<u32>, end_line: Option<u32>`）
   - `resolve_from_references()` 新設: 構造化データから直接ファイル読み込み・`<file_context>` ブロック構築
-  - `MENTION_RE` の文字クラスをUnicode対応に修正（`parse_display_mentions` の表示用パースのため）
-  - `parse_mentions` / `resolve_mentions_internal` / `resolve_mentions_or_fallback` は削除（呼び出し元がなくなる）
+  - `resolve_mentions_or_fallback()` は `resolve_from_references` のフォールバック付きラッパーとして残す（エラー時にログ出力し元のcontentを返す）
+  - `MENTION_RE` の文字クラスをASCII空白限定に修正（`parse_display_mentions` の表示用パースで全角スペースを含むパスを切り捨てないため）
+  - `parse_mentions` / `resolve_mentions_internal` は削除（呼び出し元がなくなる）
 
 - **`src-tauri/src/agent_sdk.rs`**:
   - `send_agent_message` コマンドに `mentions: Option<Vec<MentionReference>>` パラメータ追加
   - `PendingMessage` に `mentions` フィールド追加
-  - `resolve_mentions_or_fallback` 呼び出しを `resolve_from_references` に置き換え
+  - `resolve_mentions_or_fallback` を経由して `resolve_from_references` を呼び出す（フォールバック付きで後方互換性を維持）
 
 - **`src-tauri/src/diff_comment_sender.rs`**:
   - `format_comments_for_agent` → `build_mentions_from_comments`: `DiffComment[]` を `MentionReference[]` に変換

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -1744,6 +1744,7 @@ async fn consume_pending_message(
         MessageRole::Agent,
         "",
         None,
+        None,
     ) {
         Ok(msg) => msg,
         Err(e) => {
@@ -2187,6 +2188,11 @@ pub async fn send_agent_message(
             MessageRole::Human,
             &content,
             parts,
+            if mentions.is_empty() {
+                None
+            } else {
+                Some(mentions.clone())
+            },
         )?
     };
 
@@ -2231,6 +2237,7 @@ pub async fn send_agent_message(
             &sid,
             MessageRole::Agent,
             "",
+            None,
             None,
         )?;
         let resolved_prompt =

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -67,6 +67,7 @@ pub struct PendingMessage {
     pub permission_mode: String,
     pub images: Vec<ImageAttachment>,
     pub worktree_path: String,
+    pub mentions: Vec<crate::file_mention::MentionReference>,
 }
 
 /// Model information from Agent SDK.
@@ -1763,9 +1764,11 @@ async fn consume_pending_message(
         );
     }
 
-    // 3b. Resolve @file mentions in the pending content
-    let resolved_prompt =
-        crate::file_mention::resolve_mentions_or_fallback(&pending.worktree_path, &pending.content);
+    let resolved_prompt = crate::file_mention::resolve_mentions_or_fallback(
+        &pending.worktree_path,
+        &pending.content,
+        &pending.mentions,
+    );
 
     // 4. Sync permissionMode + selected_model + send message directly to the running Bridge.
     //    The process is guaranteed running since it just emitted turn_complete.
@@ -2140,10 +2143,12 @@ pub async fn send_agent_message(
     content: String,
     permission_mode: Option<String>,
     images: Option<Vec<ImageAttachment>>,
+    mentions: Option<Vec<crate::file_mention::MentionReference>>,
 ) -> Result<SendMessageResponse, String> {
     let data_dir = resolve_data_dir(&app)?;
     let pm = permission_mode.unwrap_or_else(|| "acceptEdits".to_string());
     let images = images.unwrap_or_default();
+    let mentions = mentions.unwrap_or_default();
 
     // 1. Create or get session
     let session = if let Some(ref sid) = chat_session_id {
@@ -2193,56 +2198,57 @@ pub async fn send_agent_message(
             .unwrap_or(TurnPhase::Idle)
     };
 
-    let agent_message =
-        if current_phase == TurnPhase::Streaming || current_phase == TurnPhase::WaitingPermission {
-            // 4a. Queue pending message + interrupt
-            {
-                let mut map = handles.lock().await;
-                if let Some(proc) = map.get_mut(&sid) {
-                    proc.pending_message = Some(PendingMessage {
-                        content: content.clone(),
-                        permission_mode: pm.clone(),
-                        images: images.clone(),
-                        worktree_path: worktree_path.clone(),
-                    });
-                    proc.stdin
-                        .write_all(b"{\"type\":\"interrupt\"}\n")
-                        .await
-                        .map_err(|e| format!("Failed to write interrupt: {e}"))?;
-                    proc.stdin
-                        .flush()
-                        .await
-                        .map_err(|e| format!("Failed to flush: {e}"))?;
-                }
+    let agent_message = if current_phase == TurnPhase::Streaming
+        || current_phase == TurnPhase::WaitingPermission
+    {
+        // 4a. Queue pending message + interrupt
+        {
+            let mut map = handles.lock().await;
+            if let Some(proc) = map.get_mut(&sid) {
+                proc.pending_message = Some(PendingMessage {
+                    content: content.clone(),
+                    permission_mode: pm.clone(),
+                    images: images.clone(),
+                    worktree_path: worktree_path.clone(),
+                    mentions: mentions.clone(),
+                });
+                proc.stdin
+                    .write_all(b"{\"type\":\"interrupt\"}\n")
+                    .await
+                    .map_err(|e| format!("Failed to write interrupt: {e}"))?;
+                proc.stdin
+                    .flush()
+                    .await
+                    .map_err(|e| format!("Failed to flush: {e}"))?;
             }
-            None
-        } else {
-            // 4b. Create agent message + start turn
-            let agent_msg = add_message_internal(
-                &session_store,
-                &data_dir,
-                &sid,
-                MessageRole::Agent,
-                "",
-                None,
-            )?;
-            // Resolve @file mentions: parse mentions, read files, build context prompt
-            let resolved_prompt =
-                crate::file_mention::resolve_mentions_or_fallback(&worktree_path, &content);
-            start_agent_turn(
-                &app,
-                handles.inner(),
-                session_store.inner(),
-                &sid,
-                &worktree_path,
-                &pm,
-                &resolved_prompt,
-                &agent_msg.id,
-                &images,
-            )
-            .await?;
-            Some(agent_msg)
-        };
+        }
+        None
+    } else {
+        // 4b. Create agent message + start turn
+        let agent_msg = add_message_internal(
+            &session_store,
+            &data_dir,
+            &sid,
+            MessageRole::Agent,
+            "",
+            None,
+        )?;
+        let resolved_prompt =
+            crate::file_mention::resolve_mentions_or_fallback(&worktree_path, &content, &mentions);
+        start_agent_turn(
+            &app,
+            handles.inner(),
+            session_store.inner(),
+            &sid,
+            &worktree_path,
+            &pm,
+            &resolved_prompt,
+            &agent_msg.id,
+            &images,
+        )
+        .await?;
+        Some(agent_msg)
+    };
 
     // 5. Get updated session and list
     let updated_session = session_store

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -2210,23 +2210,24 @@ pub async fn send_agent_message(
         // 4a. Queue pending message + interrupt
         {
             let mut map = handles.lock().await;
-            if let Some(proc) = map.get_mut(&sid) {
-                proc.pending_message = Some(PendingMessage {
-                    content: content.clone(),
-                    permission_mode: pm.clone(),
-                    images: images.clone(),
-                    worktree_path: worktree_path.clone(),
-                    mentions: mentions.clone(),
-                });
-                proc.stdin
-                    .write_all(b"{\"type\":\"interrupt\"}\n")
-                    .await
-                    .map_err(|e| format!("Failed to write interrupt: {e}"))?;
-                proc.stdin
-                    .flush()
-                    .await
-                    .map_err(|e| format!("Failed to flush: {e}"))?;
-            }
+            let proc = map
+                .get_mut(&sid)
+                .ok_or_else(|| format!("No active agent process for session {sid}"))?;
+            proc.pending_message = Some(PendingMessage {
+                content: content.clone(),
+                permission_mode: pm.clone(),
+                images: images.clone(),
+                worktree_path: worktree_path.clone(),
+                mentions: mentions.clone(),
+            });
+            proc.stdin
+                .write_all(b"{\"type\":\"interrupt\"}\n")
+                .await
+                .map_err(|e| format!("Failed to write interrupt: {e}"))?;
+            proc.stdin
+                .flush()
+                .await
+                .map_err(|e| format!("Failed to flush: {e}"))?;
         }
         None
     } else {

--- a/src-tauri/src/diff_comment_sender.rs
+++ b/src-tauri/src/diff_comment_sender.rs
@@ -3,31 +3,41 @@ use std::sync::Arc;
 use tauri::{Emitter, Manager};
 
 use crate::diff_comment_store::{DiffComment, DiffCommentStore};
+use crate::file_mention::MentionReference;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SendDiffCommentsResult {
     pub sent_count: usize,
     pub formatted_message: String,
+    pub mentions: Vec<MentionReference>,
     pub comment_ids: Vec<String>,
 }
 
-/// Format comments for agent using @mention syntax compatible with file_mention regex.
-/// Output format: `@filepath:Lx-Ly comment` (line range), `@filepath:Lx comment` (single line),
-/// `@filepath comment` (file-level).
-pub fn format_comments_for_agent(comments: &[DiffComment]) -> String {
+pub fn build_mentions_from_comments(comments: &[DiffComment]) -> Vec<MentionReference> {
+    comments
+        .iter()
+        .map(|c| MentionReference {
+            file_path: c.file_path.clone(),
+            start_line: c.line_number,
+            end_line: c.end_line,
+        })
+        .collect()
+}
+
+pub fn format_comment_text(comments: &[DiffComment]) -> String {
     let mut lines: Vec<String> = Vec::new();
 
     for comment in comments {
-        let mention = if let (Some(start), Some(end)) = (comment.line_number, comment.end_line) {
-            format!("@{}:L{}-L{}", comment.file_path, start, end)
+        let location = if let (Some(start), Some(end)) = (comment.line_number, comment.end_line) {
+            format!("{}:L{}-L{}", comment.file_path, start, end)
         } else if let Some(line) = comment.line_number {
-            format!("@{}:L{}", comment.file_path, line)
+            format!("{}:L{}", comment.file_path, line)
         } else {
-            format!("@{}", comment.file_path)
+            comment.file_path.clone()
         };
 
-        lines.push(format!("{} {}", mention, comment.content));
+        lines.push(format!("@{} {}", location, comment.content));
     }
 
     lines.join("\n")
@@ -52,13 +62,15 @@ pub async fn send_diff_comments_to_agent(
         return Err("No comments to send".to_string());
     }
 
-    let formatted_message = format_comments_for_agent(&comments);
+    let mentions = build_mentions_from_comments(&comments);
+    let formatted_message = format_comment_text(&comments);
     let sent_ids: Vec<String> = comments.iter().map(|c| c.id.clone()).collect();
     let sent_count = sent_ids.len();
 
     Ok(SendDiffCommentsResult {
         sent_count,
         formatted_message,
+        mentions,
         comment_ids: sent_ids,
     })
 }
@@ -88,11 +100,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn format_single_line_comment() {
+    fn build_mentions_single_line() {
         let comments = vec![DiffComment {
             id: "1".to_string(),
             file_path: "src/components/Example.tsx".to_string(),
-
             line_number: Some(42),
             end_line: None,
             content: "ここのロジックは〇〇すべき".to_string(),
@@ -100,19 +111,18 @@ mod tests {
             created_at: 0.0,
         }];
 
-        let result = format_comments_for_agent(&comments);
-        assert_eq!(
-            result,
-            "@src/components/Example.tsx:L42 ここのロジックは〇〇すべき"
-        );
+        let mentions = build_mentions_from_comments(&comments);
+        assert_eq!(mentions.len(), 1);
+        assert_eq!(mentions[0].file_path, "src/components/Example.tsx");
+        assert_eq!(mentions[0].start_line, Some(42));
+        assert_eq!(mentions[0].end_line, None);
     }
 
     #[test]
-    fn format_range_comment() {
+    fn build_mentions_range() {
         let comments = vec![DiffComment {
             id: "2".to_string(),
             file_path: "src/components/Example.tsx".to_string(),
-
             line_number: Some(10),
             end_line: Some(15),
             content: "この範囲のエラーハンドリングが不足".to_string(),
@@ -120,37 +130,34 @@ mod tests {
             created_at: 0.0,
         }];
 
-        let result = format_comments_for_agent(&comments);
-        assert_eq!(
-            result,
-            "@src/components/Example.tsx:L10-L15 この範囲のエラーハンドリングが不足"
-        );
+        let mentions = build_mentions_from_comments(&comments);
+        assert_eq!(mentions.len(), 1);
+        assert_eq!(mentions[0].start_line, Some(10));
+        assert_eq!(mentions[0].end_line, Some(15));
     }
 
     #[test]
-    fn format_file_comment() {
+    fn format_comment_text_single() {
         let comments = vec![DiffComment {
-            id: "3".to_string(),
-            file_path: "src/lib/utils.ts".to_string(),
-
-            line_number: None,
+            id: "1".to_string(),
+            file_path: "src/a.ts".to_string(),
+            line_number: Some(42),
             end_line: None,
-            content: "全体的にテストが不足している".to_string(),
+            content: "Comment A".to_string(),
             status: "unsent".to_string(),
             created_at: 0.0,
         }];
 
-        let result = format_comments_for_agent(&comments);
-        assert_eq!(result, "@src/lib/utils.ts 全体的にテストが不足している");
+        let result = format_comment_text(&comments);
+        assert_eq!(result, "@src/a.ts:L42 Comment A");
     }
 
     #[test]
-    fn format_multiple_comments() {
+    fn format_comment_text_multiple() {
         let comments = vec![
             DiffComment {
                 id: "1".to_string(),
                 file_path: "src/a.ts".to_string(),
-
                 line_number: Some(42),
                 end_line: None,
                 content: "Comment A".to_string(),
@@ -160,7 +167,6 @@ mod tests {
             DiffComment {
                 id: "2".to_string(),
                 file_path: "src/b.ts".to_string(),
-
                 line_number: Some(10),
                 end_line: Some(15),
                 content: "Comment B".to_string(),
@@ -170,7 +176,6 @@ mod tests {
             DiffComment {
                 id: "3".to_string(),
                 file_path: "src/c.ts".to_string(),
-
                 line_number: None,
                 end_line: None,
                 content: "Comment C".to_string(),
@@ -179,15 +184,17 @@ mod tests {
             },
         ];
 
-        let result = format_comments_for_agent(&comments);
-        let expected = "@src/a.ts:L42 Comment A\n@src/b.ts:L10-L15 Comment B\n@src/c.ts Comment C";
-        assert_eq!(result, expected);
+        let result = format_comment_text(&comments);
+        assert_eq!(
+            result,
+            "@src/a.ts:L42 Comment A\n@src/b.ts:L10-L15 Comment B\n@src/c.ts Comment C"
+        );
     }
 
     #[test]
-    fn format_empty_comments() {
+    fn build_mentions_empty() {
         let comments: Vec<DiffComment> = Vec::new();
-        let result = format_comments_for_agent(&comments);
-        assert_eq!(result, "");
+        let mentions = build_mentions_from_comments(&comments);
+        assert!(mentions.is_empty());
     }
 }

--- a/src-tauri/src/file_mention.rs
+++ b/src-tauri/src/file_mention.rs
@@ -1,11 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
-use std::sync::LazyLock;
-
-static MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"@([^ \t\r\n@:]+(?:\.[^ \t\r\n@:]+)*)(?::L(\d+)(?:-L(\d+))?)?")
-        .expect("invalid mention regex")
-});
 
 /// A structured file mention reference passed from the frontend.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -16,14 +10,6 @@ pub struct MentionReference {
     pub start_line: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_line: Option<u32>,
-}
-
-/// A segment of message text for display: either plain text or a @mention.
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum DisplayPart {
-    Text { value: String },
-    Mention { value: String },
 }
 
 /// List files in a worktree that match a fuzzy query, respecting .gitignore.
@@ -76,16 +62,6 @@ pub fn list_mentionable_files(worktree_path: String, query: String) -> Result<Ve
     Ok(results)
 }
 
-/// Check whether a regex match at `start` is a valid mention position:
-/// the `@` must appear at the beginning of the text or after whitespace.
-fn is_valid_mention_position(content: &str, start: usize) -> bool {
-    start == 0
-        || content
-            .as_bytes()
-            .get(start - 1)
-            .is_some_and(|&b| b.is_ascii_whitespace())
-}
-
 /// Subsequence fuzzy match: all characters in `query` appear in `haystack` in order.
 fn fuzzy_match(haystack: &str, query: &str) -> bool {
     let mut haystack_chars = haystack.chars();
@@ -99,6 +75,13 @@ fn fuzzy_match(haystack: &str, query: &str) -> bool {
         }
     }
     true
+}
+
+fn escape_xml_attr(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 /// Resolve structured mention references into a file_context block prepended to the content.
@@ -139,10 +122,11 @@ pub fn resolve_from_references(
 
         let excerpt = extract_excerpt(&file_content, mention.start_line, mention.end_line);
 
+        let escaped_path = escape_xml_attr(&mention.file_path);
         let attrs = match (mention.start_line, mention.end_line) {
-            (Some(s), Some(e)) => format!(r#" path="{}" lines="{}-{}""#, mention.file_path, s, e),
-            (Some(s), None) => format!(r#" path="{}" lines="{}""#, mention.file_path, s),
-            _ => format!(r#" path="{}""#, mention.file_path),
+            (Some(s), Some(e)) => format!(r#" path="{escaped_path}" lines="{s}-{e}""#),
+            (Some(s), None) => format!(r#" path="{escaped_path}" lines="{s}""#),
+            _ => format!(r#" path="{escaped_path}""#),
         };
 
         file_sections.push(format!("<file{attrs}>\n{excerpt}\n</file>"));
@@ -203,38 +187,6 @@ fn extract_excerpt(file_content: &str, start_line: Option<u32>, end_line: Option
         }
         _ => file_content.to_string(),
     }
-}
-
-/// Parse message text into display parts, splitting @mentions from plain text.
-/// Used by the frontend to render mentions as badges without duplicating parse logic.
-#[tauri::command]
-pub fn parse_display_mentions(content: String) -> Vec<DisplayPart> {
-    let mut parts = Vec::new();
-    let mut last_index = 0;
-
-    for mat in MENTION_RE.find_iter(&content) {
-        let start = mat.start();
-        if !is_valid_mention_position(&content, start) {
-            continue;
-        }
-        if start > last_index {
-            parts.push(DisplayPart::Text {
-                value: content[last_index..start].to_string(),
-            });
-        }
-        parts.push(DisplayPart::Mention {
-            value: mat.as_str().to_string(),
-        });
-        last_index = mat.end();
-    }
-
-    if last_index < content.len() {
-        parts.push(DisplayPart::Text {
-            value: content[last_index..].to_string(),
-        });
-    }
-
-    parts
 }
 
 #[cfg(test)]
@@ -410,156 +362,6 @@ mod tests {
 
         assert!(result.contains(&"main.rs".to_string()));
         assert!(!result.contains(&"lib.rs".to_string()));
-    }
-
-    // --- parse_display_mentions tests ---
-
-    #[test]
-    fn parse_display_mentions_no_mentions() {
-        let parts = parse_display_mentions("Hello world".to_string());
-        assert_eq!(
-            parts,
-            vec![DisplayPart::Text {
-                value: "Hello world".to_string()
-            }]
-        );
-    }
-
-    #[test]
-    fn parse_display_mentions_single() {
-        let parts = parse_display_mentions("Check @src/main.rs please".to_string());
-        assert_eq!(
-            parts,
-            vec![
-                DisplayPart::Text {
-                    value: "Check ".to_string()
-                },
-                DisplayPart::Mention {
-                    value: "@src/main.rs".to_string()
-                },
-                DisplayPart::Text {
-                    value: " please".to_string()
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn parse_display_mentions_with_line_range() {
-        let parts = parse_display_mentions("See @src/lib.rs:L10-L20".to_string());
-        assert_eq!(
-            parts,
-            vec![
-                DisplayPart::Text {
-                    value: "See ".to_string()
-                },
-                DisplayPart::Mention {
-                    value: "@src/lib.rs:L10-L20".to_string()
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn parse_display_mentions_multiple() {
-        let parts = parse_display_mentions("Compare @a.rs and @b.rs end".to_string());
-        assert_eq!(
-            parts,
-            vec![
-                DisplayPart::Text {
-                    value: "Compare ".to_string()
-                },
-                DisplayPart::Mention {
-                    value: "@a.rs".to_string()
-                },
-                DisplayPart::Text {
-                    value: " and ".to_string()
-                },
-                DisplayPart::Mention {
-                    value: "@b.rs".to_string()
-                },
-                DisplayPart::Text {
-                    value: " end".to_string()
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn parse_display_mentions_empty_string() {
-        let parts = parse_display_mentions(String::new());
-        assert!(parts.is_empty());
-    }
-
-    #[test]
-    fn parse_display_mentions_ignores_email() {
-        let parts = parse_display_mentions("user@example.com says hello".to_string());
-        assert_eq!(
-            parts,
-            vec![DisplayPart::Text {
-                value: "user@example.com says hello".to_string()
-            }]
-        );
-    }
-
-    #[test]
-    fn parse_display_mentions_mixed_email_and_mention() {
-        let parts =
-            parse_display_mentions("From user@example.com see @src/main.rs end".to_string());
-        assert_eq!(
-            parts,
-            vec![
-                DisplayPart::Text {
-                    value: "From user@example.com see ".to_string()
-                },
-                DisplayPart::Mention {
-                    value: "@src/main.rs".to_string()
-                },
-                DisplayPart::Text {
-                    value: " end".to_string()
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn parse_display_mentions_japanese_filename() {
-        let parts = parse_display_mentions("確認 @docs/Gitフロー.md してください".to_string());
-        assert_eq!(
-            parts,
-            vec![
-                DisplayPart::Text {
-                    value: "確認 ".to_string()
-                },
-                DisplayPart::Mention {
-                    value: "@docs/Gitフロー.md".to_string()
-                },
-                DisplayPart::Text {
-                    value: " してください".to_string()
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn parse_display_mentions_fullwidth_space_in_path() {
-        let parts = parse_display_mentions(
-            "確認 @docs/Gitフロー\u{3000}・デプロイサイクル見直し.md してください".to_string(),
-        );
-        assert_eq!(
-            parts,
-            vec![
-                DisplayPart::Text {
-                    value: "確認 ".to_string()
-                },
-                DisplayPart::Mention {
-                    value: "@docs/Gitフロー\u{3000}・デプロイサイクル見直し.md".to_string()
-                },
-                DisplayPart::Text {
-                    value: " してください".to_string()
-                },
-            ]
-        );
     }
 
     #[test]

--- a/src-tauri/src/file_mention.rs
+++ b/src-tauri/src/file_mention.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 static MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"@([^\s@:]+(?:\.[^\s@:]+)*)(?::L(\d+)(?:-L(\d+))?)?")
+    regex::Regex::new(r"@([^ \t\r\n@:]+(?:\.[^ \t\r\n@:]+)*)(?::L(\d+)(?:-L(\d+))?)?")
         .expect("invalid mention regex")
 });
 
@@ -533,6 +533,27 @@ mod tests {
                 },
                 DisplayPart::Mention {
                     value: "@docs/Gitフロー.md".to_string()
+                },
+                DisplayPart::Text {
+                    value: " してください".to_string()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_display_mentions_fullwidth_space_in_path() {
+        let parts = parse_display_mentions(
+            "確認 @docs/Gitフロー\u{3000}・デプロイサイクル見直し.md してください".to_string(),
+        );
+        assert_eq!(
+            parts,
+            vec![
+                DisplayPart::Text {
+                    value: "確認 ".to_string()
+                },
+                DisplayPart::Mention {
+                    value: "@docs/Gitフロー\u{3000}・デプロイサイクル見直し.md".to_string()
                 },
                 DisplayPart::Text {
                     value: " してください".to_string()

--- a/src-tauri/src/file_mention.rs
+++ b/src-tauri/src/file_mention.rs
@@ -1,18 +1,21 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::LazyLock;
 
 static MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"@([\w./_\-\[\]]+(?:\.[\w]+)*)(?::L(\d+)(?:-L(\d+))?)?")
+    regex::Regex::new(r"@([^\s@:]+(?:\.[^\s@:]+)*)(?::L(\d+)(?:-L(\d+))?)?")
         .expect("invalid mention regex")
 });
 
-/// A single file mention parsed from message text.
-#[derive(Debug, Clone, PartialEq)]
-struct ParsedMention {
-    file_path: String,
-    start_line: Option<u32>,
-    end_line: Option<u32>,
+/// A structured file mention reference passed from the frontend.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MentionReference {
+    pub file_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<u32>,
 }
 
 /// A segment of message text for display: either plain text or a @mention.
@@ -98,38 +101,14 @@ fn fuzzy_match(haystack: &str, query: &str) -> bool {
     true
 }
 
-/// Parse mention patterns from message text.
-/// Recognized formats:
-/// - `@filepath`
-/// - `@filepath:L10-L20`
-/// - `@filepath:L10` (single line)
-fn parse_mentions(content: &str) -> Vec<ParsedMention> {
-    let mut mentions = Vec::new();
-    for caps in MENTION_RE.captures_iter(content) {
-        let mat = caps.get(0).unwrap();
-        if !is_valid_mention_position(content, mat.start()) {
-            continue;
-        }
-        let file_path = caps[1].to_string();
-        let start_line = caps.get(2).and_then(|m| m.as_str().parse::<u32>().ok());
-        let end_line = caps.get(3).and_then(|m| m.as_str().parse::<u32>().ok());
-        mentions.push(ParsedMention {
-            file_path,
-            start_line,
-            end_line,
-        });
-    }
-    mentions
-}
-
-/// Resolve all @mentions in `content`:
-/// 1. Parse mentions
-/// 2. Read each file (or line range)
-/// 3. Build a prompt with <file_context> + original message
-///
-/// If there are no mentions, returns the content unchanged.
-pub fn resolve_mentions_internal(worktree_path: &str, content: &str) -> Result<String, String> {
-    let mentions = parse_mentions(content);
+/// Resolve structured mention references into a file_context block prepended to the content.
+/// Each mention is read from the filesystem and inserted as a <file> element.
+/// If no mentions are provided, returns the content unchanged.
+pub fn resolve_from_references(
+    worktree_path: &str,
+    content: &str,
+    mentions: &[MentionReference],
+) -> Result<String, String> {
     if mentions.is_empty() {
         return Ok(content.to_string());
     }
@@ -140,7 +119,7 @@ pub fn resolve_mentions_internal(worktree_path: &str, content: &str) -> Result<S
         .map_err(|e| format!("Failed to resolve worktree root: {e}"))?;
     let mut file_sections = Vec::new();
 
-    for mention in &mentions {
+    for mention in mentions {
         let file_path = root.join(&mention.file_path);
         let canonical = match file_path.canonicalize() {
             Ok(p) => p,
@@ -158,32 +137,7 @@ pub fn resolve_mentions_internal(worktree_path: &str, content: &str) -> Result<S
             Err(_) => continue,
         };
 
-        let excerpt = match (mention.start_line, mention.end_line) {
-            (Some(start), Some(end)) => {
-                let lines: Vec<&str> = file_content.lines().collect();
-                if start == 0 || end < start {
-                    String::new()
-                } else {
-                    let s = (start as usize) - 1;
-                    let e = (end as usize).min(lines.len());
-                    if s >= lines.len() || s >= e {
-                        String::new()
-                    } else {
-                        lines[s..e].join("\n")
-                    }
-                }
-            }
-            (Some(start), None) => {
-                if start == 0 {
-                    String::new()
-                } else {
-                    let lines: Vec<&str> = file_content.lines().collect();
-                    let s = (start as usize) - 1;
-                    lines.get(s).unwrap_or(&"").to_string()
-                }
-            }
-            _ => file_content,
-        };
+        let excerpt = extract_excerpt(&file_content, mention.start_line, mention.end_line);
 
         let attrs = match (mention.start_line, mention.end_line) {
             (Some(s), Some(e)) => format!(r#" path="{}" lines="{}-{}""#, mention.file_path, s, e),
@@ -206,16 +160,49 @@ pub fn resolve_mentions_internal(worktree_path: &str, content: &str) -> Result<S
     Ok(format!("{context_block}\n\n{content}"))
 }
 
-/// Resolve @mentions with fallback: if resolution fails or worktree_path is empty,
-/// log and return the original content unchanged.
-pub fn resolve_mentions_or_fallback(worktree_path: &str, content: &str) -> String {
-    if worktree_path.is_empty() {
+/// Resolve mentions with logging fallback.
+/// Returns the original content unchanged if mentions is empty or resolution fails.
+pub fn resolve_mentions_or_fallback(
+    worktree_path: &str,
+    content: &str,
+    mentions: &[MentionReference],
+) -> String {
+    if mentions.is_empty() {
         return content.to_string();
     }
-    resolve_mentions_internal(worktree_path, content).unwrap_or_else(|e| {
+    resolve_from_references(worktree_path, content, mentions).unwrap_or_else(|e| {
         log::warn!("Failed to resolve mentions: {e}");
         content.to_string()
     })
+}
+
+fn extract_excerpt(file_content: &str, start_line: Option<u32>, end_line: Option<u32>) -> String {
+    match (start_line, end_line) {
+        (Some(start), Some(end)) => {
+            let lines: Vec<&str> = file_content.lines().collect();
+            if start == 0 || end < start {
+                String::new()
+            } else {
+                let s = (start as usize) - 1;
+                let e = (end as usize).min(lines.len());
+                if s >= lines.len() || s >= e {
+                    String::new()
+                } else {
+                    lines[s..e].join("\n")
+                }
+            }
+        }
+        (Some(start), None) => {
+            if start == 0 {
+                String::new()
+            } else {
+                let lines: Vec<&str> = file_content.lines().collect();
+                let s = (start as usize) - 1;
+                lines.get(s).unwrap_or(&"").to_string()
+            }
+        }
+        _ => file_content.to_string(),
+    }
 }
 
 /// Parse message text into display parts, splitting @mentions from plain text.
@@ -269,79 +256,48 @@ mod tests {
         assert!(fuzzy_match("anything.rs", ""));
     }
 
-    #[test]
-    fn parse_mentions_no_mentions() {
-        let result = parse_mentions("Hello world");
-        assert!(result.is_empty());
-    }
+    // --- resolve_from_references tests ---
 
     #[test]
-    fn parse_mentions_simple_path() {
-        let result = parse_mentions("Check @src/main.rs for details");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].file_path, "src/main.rs");
-        assert_eq!(result[0].start_line, None);
-        assert_eq!(result[0].end_line, None);
-    }
-
-    #[test]
-    fn parse_mentions_with_line_range() {
-        let result = parse_mentions("See @src/lib.rs:L10-L20");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].file_path, "src/lib.rs");
-        assert_eq!(result[0].start_line, Some(10));
-        assert_eq!(result[0].end_line, Some(20));
-    }
-
-    #[test]
-    fn parse_mentions_single_line() {
-        let result = parse_mentions("Look at @src/lib.rs:L42");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].file_path, "src/lib.rs");
-        assert_eq!(result[0].start_line, Some(42));
-        assert_eq!(result[0].end_line, None);
-    }
-
-    #[test]
-    fn parse_mentions_multiple() {
-        let result = parse_mentions("Compare @src/a.rs and @src/b.rs:L1-L5");
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].file_path, "src/a.rs");
-        assert_eq!(result[1].file_path, "src/b.rs");
-        assert_eq!(result[1].start_line, Some(1));
-        assert_eq!(result[1].end_line, Some(5));
-    }
-
-    #[test]
-    fn resolve_mentions_no_mentions_returns_content_unchanged() {
-        let result = resolve_mentions_internal("/tmp", "Hello world").unwrap();
+    fn resolve_refs_no_mentions_returns_content_unchanged() {
+        let result = resolve_from_references("/tmp", "Hello world", &[]).unwrap();
         assert_eq!(result, "Hello world");
     }
 
     #[test]
-    fn resolve_mentions_reads_file() {
+    fn resolve_refs_reads_file() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         fs::write(&file, "line1\nline2\nline3\n").unwrap();
 
+        let mentions = vec![MentionReference {
+            file_path: "test.txt".to_string(),
+            start_line: None,
+            end_line: None,
+        }];
         let result =
-            resolve_mentions_internal(dir.path().to_str().unwrap(), "Check @test.txt please")
+            resolve_from_references(dir.path().to_str().unwrap(), "Check please", &mentions)
                 .unwrap();
 
         assert!(result.contains("<file_context>"));
         assert!(result.contains(r#"path="test.txt""#));
         assert!(result.contains("line1\nline2\nline3\n"));
-        assert!(result.contains("Check @test.txt please"));
+        assert!(result.contains("Check please"));
     }
 
     #[test]
-    fn resolve_mentions_line_range() {
+    fn resolve_refs_line_range() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         fs::write(&file, "line1\nline2\nline3\nline4\nline5\n").unwrap();
 
+        let mentions = vec![MentionReference {
+            file_path: "test.txt".to_string(),
+            start_line: Some(2),
+            end_line: Some(4),
+        }];
         let result =
-            resolve_mentions_internal(dir.path().to_str().unwrap(), "See @test.txt:L2-L4").unwrap();
+            resolve_from_references(dir.path().to_str().unwrap(), "See file", &mentions).unwrap();
 
         assert!(result.contains(r#"lines="2-4""#));
         assert!(result.contains("line2\nline3\nline4"));
@@ -350,13 +306,18 @@ mod tests {
     }
 
     #[test]
-    fn resolve_mentions_single_line() {
+    fn resolve_refs_single_line() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         fs::write(&file, "line1\nline2\nline3\n").unwrap();
 
+        let mentions = vec![MentionReference {
+            file_path: "test.txt".to_string(),
+            start_line: Some(2),
+            end_line: None,
+        }];
         let result =
-            resolve_mentions_internal(dir.path().to_str().unwrap(), "Look at @test.txt:L2")
+            resolve_from_references(dir.path().to_str().unwrap(), "Look at file", &mentions)
                 .unwrap();
 
         assert!(result.contains(r#"lines="2""#));
@@ -364,12 +325,66 @@ mod tests {
     }
 
     #[test]
+    fn resolve_refs_japanese_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("Gitフロー.md");
+        fs::write(&file, "日本語の内容\n2行目\n").unwrap();
+
+        let mentions = vec![MentionReference {
+            file_path: "Gitフロー.md".to_string(),
+            start_line: None,
+            end_line: None,
+        }];
+        let result =
+            resolve_from_references(dir.path().to_str().unwrap(), "確認してください", &mentions)
+                .unwrap();
+
+        assert!(result.contains("<file_context>"));
+        assert!(result.contains(r#"path="Gitフロー.md""#));
+        assert!(result.contains("日本語の内容"));
+    }
+
+    #[test]
+    fn resolve_refs_missing_file_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        let mentions = vec![MentionReference {
+            file_path: "nonexistent.txt".to_string(),
+            start_line: None,
+            end_line: None,
+        }];
+        let result =
+            resolve_from_references(dir.path().to_str().unwrap(), "Check", &mentions).unwrap();
+        assert_eq!(result, "Check");
+    }
+
+    #[test]
+    fn resolve_refs_rejects_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().parent().unwrap();
+        let sibling = tempfile::tempdir_in(parent).unwrap();
+        let outside_file = sibling.path().join("outside.txt");
+        fs::write(&outside_file, "secret").unwrap();
+
+        let sibling_name = sibling.path().file_name().unwrap().to_str().unwrap();
+        let mentions = vec![MentionReference {
+            file_path: format!("../{sibling_name}/outside.txt"),
+            start_line: None,
+            end_line: None,
+        }];
+        let result = resolve_from_references(dir.path().to_str().unwrap(), "Check", &mentions);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("traversal"), "Error message: {err}");
+    }
+
+    // --- list_mentionable_files tests ---
+
+    #[test]
     fn list_mentionable_files_basic() {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("hello.rs"), "fn main() {}").unwrap();
         fs::write(dir.path().join("world.txt"), "hello").unwrap();
 
-        // Initialize git repo so .gitignore is respected
         git2::Repository::init(dir.path()).unwrap();
 
         let result =
@@ -389,55 +404,15 @@ mod tests {
 
         git2::Repository::init(dir.path()).unwrap();
 
-        let result = list_mentionable_files(
-            dir.path().to_str().unwrap().to_string(),
-            "mn".to_string(), // fuzzy matches "main.rs"
-        )
-        .unwrap();
+        let result =
+            list_mentionable_files(dir.path().to_str().unwrap().to_string(), "mn".to_string())
+                .unwrap();
 
         assert!(result.contains(&"main.rs".to_string()));
         assert!(!result.contains(&"lib.rs".to_string()));
     }
 
-    #[test]
-    fn resolve_mentions_missing_file_skips() {
-        let dir = tempfile::tempdir().unwrap();
-        let result =
-            resolve_mentions_internal(dir.path().to_str().unwrap(), "Check @nonexistent.txt");
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "Check @nonexistent.txt");
-    }
-
-    #[test]
-    fn resolve_mentions_partial_failure_includes_successful() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("exists.txt"), "content here").unwrap();
-        let result = resolve_mentions_internal(
-            dir.path().to_str().unwrap(),
-            "See @exists.txt and @missing.txt",
-        )
-        .unwrap();
-        assert!(result.contains("content here"));
-        assert!(result.contains("<file_context>"));
-    }
-
-    #[test]
-    fn resolve_mentions_rejects_path_traversal() {
-        let dir = tempfile::tempdir().unwrap();
-        let parent = dir.path().parent().unwrap();
-        let sibling = tempfile::tempdir_in(parent).unwrap();
-        let outside_file = sibling.path().join("outside.txt");
-        fs::write(&outside_file, "secret").unwrap();
-
-        let sibling_name = sibling.path().file_name().unwrap().to_str().unwrap();
-        let result = resolve_mentions_internal(
-            dir.path().to_str().unwrap(),
-            &format!("Check @../{sibling_name}/outside.txt"),
-        );
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.contains("traversal"), "Error message: {err}");
-    }
+    // --- parse_display_mentions tests ---
 
     #[test]
     fn parse_display_mentions_no_mentions() {
@@ -517,32 +492,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_mentions_ignores_email_addresses() {
-        let result = parse_mentions("Contact user@example.com for details");
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn parse_mentions_ignores_mid_word_at() {
-        let result = parse_mentions("something@path.rs is not a mention");
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn parse_mentions_accepts_after_whitespace() {
-        let result = parse_mentions("Check @src/main.rs please");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].file_path, "src/main.rs");
-    }
-
-    #[test]
-    fn parse_mentions_accepts_at_start() {
-        let result = parse_mentions("@src/lib.rs has the code");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].file_path, "src/lib.rs");
-    }
-
-    #[test]
     fn parse_display_mentions_ignores_email() {
         let parts = parse_display_mentions("user@example.com says hello".to_string());
         assert_eq!(
@@ -571,5 +520,58 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn parse_display_mentions_japanese_filename() {
+        let parts = parse_display_mentions("確認 @docs/Gitフロー.md してください".to_string());
+        assert_eq!(
+            parts,
+            vec![
+                DisplayPart::Text {
+                    value: "確認 ".to_string()
+                },
+                DisplayPart::Mention {
+                    value: "@docs/Gitフロー.md".to_string()
+                },
+                DisplayPart::Text {
+                    value: " してください".to_string()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn fallback_empty_mentions() {
+        let result = resolve_mentions_or_fallback("/tmp", "Hello world", &[]);
+        assert_eq!(result, "Hello world");
+    }
+
+    #[test]
+    fn fallback_with_valid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "line1\nline2\n").unwrap();
+
+        let mentions = vec![MentionReference {
+            file_path: "test.txt".to_string(),
+            start_line: None,
+            end_line: None,
+        }];
+        let result = resolve_mentions_or_fallback(dir.path().to_str().unwrap(), "Check", &mentions);
+        assert!(result.contains("<file_context>"));
+        assert!(result.contains("Check"));
+    }
+
+    #[test]
+    fn fallback_missing_file_returns_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let mentions = vec![MentionReference {
+            file_path: "nonexistent.txt".to_string(),
+            start_line: None,
+            end_line: None,
+        }];
+        let result = resolve_mentions_or_fallback(dir.path().to_str().unwrap(), "Check", &mentions);
+        assert_eq!(result, "Check");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -344,7 +344,6 @@ pub fn run() {
             pty::oneshot::find_oneshot_pty,
             // File Mention
             file_mention::list_mentionable_files,
-            file_mention::parse_display_mentions,
             // Agent SDK
             agent_sdk::start_agent_session,
             agent_sdk::execute_agent_query,

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -154,6 +154,8 @@ pub struct ChatMessage {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub parts: Option<Vec<MessagePart>>,
     pub timestamp: f64,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mentions: Option<Vec<crate::file_mention::MentionReference>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -371,6 +373,7 @@ pub fn add_message_internal(
     role: MessageRole,
     content: &str,
     parts: Option<Vec<MessagePart>>,
+    mentions: Option<Vec<crate::file_mention::MentionReference>>,
 ) -> Result<ChatMessage, String> {
     let mut session = session_store
         .get_session(data_dir, session_id)?
@@ -384,6 +387,7 @@ pub fn add_message_internal(
         activities: None,
         parts,
         timestamp: now,
+        mentions,
     };
     session.messages.push(message.clone());
     session.updated_at = now;
@@ -410,7 +414,7 @@ pub fn add_message(
     content: String,
 ) -> Result<ChatMessage, String> {
     let data_dir = resolve_data_dir(&app)?;
-    add_message_internal(&state, &data_dir, &session_id, role, &content, None)
+    add_message_internal(&state, &data_dir, &session_id, role, &content, None, None)
 }
 
 #[tauri::command]
@@ -506,6 +510,7 @@ mod tests {
                 activities: None,
                 parts: None,
                 timestamp: 1000.0,
+                mentions: None,
             }],
             state: SessionState::Active,
             created_at: 1000.0,
@@ -535,6 +540,7 @@ mod tests {
                 activities: None,
                 parts: None,
                 timestamp: 1000.0,
+                mentions: None,
             }],
             state: SessionState::Idle,
             created_at: 1000.0,
@@ -563,6 +569,7 @@ mod tests {
                 activities: None,
                 parts: None,
                 timestamp: 1000.0,
+                mentions: None,
             }],
             state: SessionState::Idle,
             created_at: 1000.0,
@@ -646,6 +653,7 @@ mod tests {
             activities: None,
             parts: None,
             timestamp: 1000.0,
+            mentions: None,
         };
         let json = serde_json::to_string(&msg_with).unwrap();
         assert!(json.contains("\"thinking\":\"deep thought\""));
@@ -660,6 +668,7 @@ mod tests {
             activities: None,
             parts: None,
             timestamp: 1000.0,
+            mentions: None,
         };
         let json = serde_json::to_string(&msg_without).unwrap();
         assert!(!json.contains("thinking"));
@@ -688,6 +697,7 @@ mod tests {
                     activities: None,
                     parts: None,
                     timestamp: 1000.0,
+                    mentions: None,
                 },
                 ChatMessage {
                     id: "m2".to_string(),
@@ -697,6 +707,7 @@ mod tests {
                     activities: None,
                     parts: None,
                     timestamp: 1001.0,
+                    mentions: None,
                 },
             ],
             state: SessionState::Active,
@@ -824,6 +835,7 @@ mod tests {
             ]),
             parts: None,
             timestamp: 1000.0,
+            mentions: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: ChatMessage = serde_json::from_str(&json).unwrap();
@@ -903,6 +915,7 @@ mod tests {
                 },
             ]),
             timestamp: 1000.0,
+            mentions: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: ChatMessage = serde_json::from_str(&json).unwrap();
@@ -1106,6 +1119,7 @@ mod tests {
                 },
             ]),
             timestamp: 1000.0,
+            mentions: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: ChatMessage = serde_json::from_str(&json).unwrap();

--- a/src-tauri/src/session/store.rs
+++ b/src-tauri/src/session/store.rs
@@ -190,6 +190,7 @@ mod tests {
                 activities: None,
                 parts: None,
                 timestamp: 1000.0,
+                mentions: None,
             }],
             state: SessionState::Active,
             created_at: 1000.0,
@@ -259,6 +260,7 @@ mod tests {
             activities: None,
             parts: None,
             timestamp: 1001.0,
+            mentions: None,
         });
         session.updated_at = 1001.0;
         store.save_session(tmp.path(), &session).unwrap();

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
@@ -22,6 +22,7 @@ import type {
 	ChatMessage,
 	ImageAttachment,
 	ImagePart,
+	MentionReference,
 	MessagePart,
 } from "@/types/session";
 import { getTextContent } from "@/types/session";
@@ -237,7 +238,7 @@ interface AgentChatPanelProps {
 		onDrop?: (paths: string[]) => void,
 	) => void;
 	sendMessageRef?: React.MutableRefObject<
-		((content: string) => Promise<void>) | null
+		((content: string, mentions?: MentionReference[]) => Promise<void>) | null
 	>;
 }
 
@@ -271,10 +272,13 @@ export function AgentChatPanel({
 		setModel,
 	} = useAgentChat(worktreePath);
 
-	// Expose sendMessage to parent via ref
+	// Expose sendMessage to parent via ref (without images parameter)
 	useEffect(() => {
 		if (sendMessageRef) {
-			sendMessageRef.current = sendMessage;
+			sendMessageRef.current = (
+				content: string,
+				mentions?: MentionReference[],
+			) => sendMessage(content, undefined, mentions);
 		}
 		return () => {
 			if (sendMessageRef) {

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
@@ -604,6 +604,7 @@ export function AgentChatPanel({
 													images={
 														imageParts.length > 0 ? imageParts : undefined
 													}
+													mentions={msg.mentions}
 												/>
 											</div>
 										);

--- a/src/components/panels/AgentChatPanel/MessageInput.test.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.test.tsx
@@ -53,7 +53,7 @@ describe("MessageInput", () => {
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "Hello" } });
 		fireEvent.click(screen.getByLabelText("Send message"));
-		expect(onSend).toHaveBeenCalledWith("Hello");
+		expect(onSend).toHaveBeenCalledWith("Hello", undefined, undefined);
 	});
 
 	it("clears input after sending", () => {
@@ -72,7 +72,7 @@ describe("MessageInput", () => {
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "Hello" } });
 		fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
-		expect(onSend).toHaveBeenCalledWith("Hello");
+		expect(onSend).toHaveBeenCalledWith("Hello", undefined, undefined);
 	});
 
 	it("does not send on Shift+Enter", () => {
@@ -302,7 +302,7 @@ describe("MessageInput slash command popup", () => {
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "/review" } });
 		fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
-		expect(onSend).toHaveBeenCalledWith("/review");
+		expect(onSend).toHaveBeenCalledWith("/review", undefined, undefined);
 	});
 
 	it("does not show popup when commands cache is empty", () => {
@@ -363,7 +363,11 @@ describe("MessageInput image attachments", () => {
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "Check this" } });
 		fireEvent.click(screen.getByLabelText("Send message"));
-		expect(onSend).toHaveBeenCalledWith("Check this", [sampleAttachment]);
+		expect(onSend).toHaveBeenCalledWith(
+			"Check this",
+			[sampleAttachment],
+			undefined,
+		);
 	});
 
 	it("sends images only (no text) when text is empty", () => {
@@ -374,7 +378,7 @@ describe("MessageInput image attachments", () => {
 			ref.current?.addImageAttachments([sampleAttachment]);
 		});
 		fireEvent.click(screen.getByLabelText("Send message"));
-		expect(onSend).toHaveBeenCalledWith("", [sampleAttachment]);
+		expect(onSend).toHaveBeenCalledWith("", [sampleAttachment], undefined);
 	});
 
 	it("clears image preview after sending", () => {
@@ -683,5 +687,115 @@ describe("MessageInput mention popup", () => {
 			worktreePath: "/test/repo",
 			query: "mai",
 		});
+	});
+
+	it("sends mentions with onSend after selecting a mention", async () => {
+		const onSend = vi.fn();
+		render(
+			<MessageInput
+				{...defaultProps}
+				onSend={onSend}
+				worktreePath="/test/repo"
+			/>,
+		);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, {
+			target: { value: "@", selectionStart: 1 },
+		});
+		await act(() => vi.advanceTimersByTimeAsync(150));
+		fireEvent.keyDown(textarea, { key: "Enter" });
+		fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+		expect(onSend).toHaveBeenCalledWith("@src/main.rs", undefined, [
+			{ filePath: "src/main.rs", startLine: undefined, endLine: undefined },
+		]);
+	});
+
+	it("excludes deleted mentions from onSend", async () => {
+		const onSend = vi.fn();
+		render(
+			<MessageInput
+				{...defaultProps}
+				onSend={onSend}
+				worktreePath="/test/repo"
+			/>,
+		);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, {
+			target: { value: "@", selectionStart: 1 },
+		});
+		await act(() => vi.advanceTimersByTimeAsync(150));
+		fireEvent.keyDown(textarea, { key: "Enter" });
+		expect(textarea.value).toBe("@src/main.rs ");
+		fireEvent.change(textarea, {
+			target: { value: "hello world", selectionStart: 11 },
+		});
+		fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+		expect(onSend).toHaveBeenCalledWith("hello world", undefined, undefined);
+	});
+
+	it("extracts line number from @filePath:L50 in text", async () => {
+		const onSend = vi.fn();
+		render(
+			<MessageInput
+				{...defaultProps}
+				onSend={onSend}
+				worktreePath="/test/repo"
+			/>,
+		);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, {
+			target: { value: "@", selectionStart: 1 },
+		});
+		await act(() => vi.advanceTimersByTimeAsync(150));
+		fireEvent.keyDown(textarea, { key: "Enter" });
+		fireEvent.change(textarea, {
+			target: {
+				value: "@src/main.rs:L50 check this",
+				selectionStart: 27,
+			},
+		});
+		fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+		expect(onSend).toHaveBeenCalledWith(
+			"@src/main.rs:L50 check this",
+			undefined,
+			[{ filePath: "src/main.rs", startLine: 50, endLine: undefined }],
+		);
+	});
+
+	it("extracts line range from @filePath:L10-L20 in text", async () => {
+		const onSend = vi.fn();
+		render(
+			<MessageInput
+				{...defaultProps}
+				onSend={onSend}
+				worktreePath="/test/repo"
+			/>,
+		);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, {
+			target: { value: "@", selectionStart: 1 },
+		});
+		await act(() => vi.advanceTimersByTimeAsync(150));
+		fireEvent.keyDown(textarea, { key: "Enter" });
+		fireEvent.change(textarea, {
+			target: {
+				value: "@src/main.rs:L10-L20 review",
+				selectionStart: 27,
+			},
+		});
+		fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+		expect(onSend).toHaveBeenCalledWith(
+			"@src/main.rs:L10-L20 review",
+			undefined,
+			[{ filePath: "src/main.rs", startLine: 10, endLine: 20 }],
+		);
 	});
 });

--- a/src/components/panels/AgentChatPanel/MessageInput.test.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.test.tsx
@@ -9,7 +9,11 @@ import {
 import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setSlashCommands } from "@/hooks/useSlashCommands";
-import { MessageInput, type MessageInputHandle } from "./MessageInput";
+import {
+	MessageInput,
+	type MessageInputHandle,
+	syncMentionsWithText,
+} from "./MessageInput";
 import { findMentionTrigger } from "./popupInputUtils";
 
 const mockInvoke = vi.mocked(invoke);
@@ -766,6 +770,40 @@ describe("MessageInput mention popup", () => {
 			undefined,
 			[{ filePath: "src/main.rs", startLine: 50, endLine: undefined }],
 		);
+	});
+
+	it("handles multiple mentions of the same file with different ranges", async () => {
+		const refs = [{ filePath: "src/main.rs" }, { filePath: "src/main.rs" }];
+		const text = "@src/main.rs:L1-L5 and @src/main.rs:L20-L25";
+		const result = syncMentionsWithText(text, refs);
+		expect(result).toEqual([
+			{ filePath: "src/main.rs", startLine: 1, endLine: 5 },
+			{ filePath: "src/main.rs", startLine: 20, endLine: 25 },
+		]);
+	});
+
+	it("excludes extra refs when text has fewer mentions than refs", async () => {
+		const refs = [{ filePath: "src/main.rs" }, { filePath: "src/main.rs" }];
+		const text = "@src/main.rs:L1-L5 only one mention";
+		const result = syncMentionsWithText(text, refs);
+		expect(result).toEqual([
+			{ filePath: "src/main.rs", startLine: 1, endLine: 5 },
+		]);
+	});
+
+	it("handles mixed files with duplicates correctly", async () => {
+		const refs = [
+			{ filePath: "src/main.rs" },
+			{ filePath: "src/lib.rs" },
+			{ filePath: "src/main.rs" },
+		];
+		const text = "@src/main.rs:L1 and @src/lib.rs:L10-L20 and @src/main.rs:L50";
+		const result = syncMentionsWithText(text, refs);
+		expect(result).toEqual([
+			{ filePath: "src/main.rs", startLine: 1, endLine: undefined },
+			{ filePath: "src/lib.rs", startLine: 10, endLine: 20 },
+			{ filePath: "src/main.rs", startLine: 50, endLine: undefined },
+		]);
 	});
 
 	it("extracts line range from @filePath:L10-L20 in text", async () => {

--- a/src/components/panels/AgentChatPanel/MessageInput.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.tsx
@@ -19,6 +19,9 @@ import type {
 } from "@/types/session";
 import { MentionPopup } from "./MentionPopup";
 import { ModelSelector } from "./ModelSelector";
+import { ModeSelector } from "./ModeSelector";
+import { findMentionTrigger, handlePopupKeyDown } from "./popupInputUtils";
+import { SlashCommandPopup } from "./SlashCommandPopup";
 
 const MENTION_SYNC_RE =
 	/@([^ \t\r\n@:]+(?:\.[^ \t\r\n@:]+)*)(?::L(\d+)(?:-L(\d+))?)?/g;
@@ -28,39 +31,26 @@ export function syncMentionsWithText(
 	refs: MentionReference[],
 ): MentionReference[] | undefined {
 	const re = new RegExp(MENTION_SYNC_RE.source, "g");
-	const queues = new Map<
-		string,
-		Array<{ startLine?: number; endLine?: number }>
-	>();
+	const available = new Map<string, number>();
+	for (const ref of refs) {
+		available.set(ref.filePath, (available.get(ref.filePath) ?? 0) + 1);
+	}
+	const synced: MentionReference[] = [];
 	for (;;) {
 		const m = re.exec(text);
 		if (m === null) break;
 		const filePath = m[1];
-		const queue = queues.get(filePath) ?? [];
-		if (!queues.has(filePath)) queues.set(filePath, queue);
-		queue.push({
+		const remaining = available.get(filePath) ?? 0;
+		if (remaining === 0) continue;
+		synced.push({
+			filePath,
 			startLine: m[2] ? Number(m[2]) : undefined,
 			endLine: m[3] ? Number(m[3]) : undefined,
 		});
-	}
-	const synced: MentionReference[] = [];
-	for (const ref of refs) {
-		const queue = queues.get(ref.filePath);
-		if (!queue || queue.length === 0) continue;
-		const range = queue.shift();
-		if (!range) continue;
-		synced.push({
-			filePath: ref.filePath,
-			startLine: range.startLine,
-			endLine: range.endLine,
-		});
+		available.set(filePath, remaining - 1);
 	}
 	return synced.length > 0 ? synced : undefined;
 }
-
-import { ModeSelector } from "./ModeSelector";
-import { findMentionTrigger, handlePopupKeyDown } from "./popupInputUtils";
-import { SlashCommandPopup } from "./SlashCommandPopup";
 
 interface AttachedImage {
 	id: string;

--- a/src/components/panels/AgentChatPanel/MessageInput.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.tsx
@@ -13,11 +13,43 @@ import type { SlashCommand } from "@/hooks/useSlashCommands";
 import { useSlashCommands } from "@/hooks/useSlashCommands";
 import type {
 	ImageAttachment,
+	MentionReference,
 	ModelInfo,
 	PermissionMode,
 } from "@/types/session";
 import { MentionPopup } from "./MentionPopup";
 import { ModelSelector } from "./ModelSelector";
+
+const MENTION_SYNC_RE = /@([^\s@:]+(?:\.[^\s@:]+)*)(?::L(\d+)(?:-L(\d+))?)?/g;
+
+function syncMentionsWithText(
+	text: string,
+	refs: MentionReference[],
+): MentionReference[] | undefined {
+	const re = new RegExp(MENTION_SYNC_RE.source, "g");
+	const found = new Map<string, { startLine?: number; endLine?: number }>();
+	for (;;) {
+		const m = re.exec(text);
+		if (m === null) break;
+		found.set(m[1], {
+			startLine: m[2] ? Number(m[2]) : undefined,
+			endLine: m[3] ? Number(m[3]) : undefined,
+		});
+	}
+	const synced = refs
+		.filter((ref) => found.has(ref.filePath))
+		.map((ref) => {
+			const info = found.get(ref.filePath);
+			if (!info) return { filePath: ref.filePath };
+			return {
+				filePath: ref.filePath,
+				startLine: info.startLine,
+				endLine: info.endLine,
+			};
+		});
+	return synced.length > 0 ? synced : undefined;
+}
+
 import { ModeSelector } from "./ModeSelector";
 import { findMentionTrigger, handlePopupKeyDown } from "./popupInputUtils";
 import { SlashCommandPopup } from "./SlashCommandPopup";
@@ -33,7 +65,11 @@ export interface MessageInputHandle {
 }
 
 interface MessageInputProps {
-	onSend: (content: string, images?: ImageAttachment[]) => void;
+	onSend: (
+		content: string,
+		images?: ImageAttachment[],
+		mentions?: MentionReference[],
+	) => void;
 	onInterrupt: () => void;
 	isStreaming: boolean;
 	onCycleMode?: () => void;
@@ -74,6 +110,7 @@ export function MessageInput({
 		start: number;
 		query: string;
 	} | null>(null);
+	const [mentionRefs, setMentionRefs] = useState<MentionReference[]>([]);
 
 	const allCommands = useSlashCommands();
 
@@ -201,6 +238,10 @@ export function MessageInput({
 				.replace(/^\s/, "");
 			const newValue = `${before}@${filePath} ${after}`;
 			setValue(newValue);
+			setMentionRefs((prev) => [
+				...prev,
+				{ filePath, startLine: undefined, endLine: undefined },
+			]);
 			setMentionTrigger(null);
 			setMentionDismissed(true);
 			setMentionSelectedIndex(0);
@@ -220,16 +261,19 @@ export function MessageInput({
 		const trimmed = value.trim();
 		const hasImages = attachedImages.length > 0;
 		if (!trimmed && !hasImages) return;
+		const currentMentions = syncMentionsWithText(trimmed, mentionRefs);
 		if (hasImages) {
 			onSend(
 				trimmed,
 				attachedImages.map((img) => img.attachment),
+				currentMentions,
 			);
 		} else {
-			onSend(trimmed);
+			onSend(trimmed, undefined, currentMentions);
 		}
 		setValue("");
 		setAttachedImages([]);
+		setMentionRefs([]);
 		setSlashPopupDismissed(false);
 		setSelectedIndex(0);
 		setMentionTrigger(null);
@@ -238,7 +282,7 @@ export function MessageInput({
 		if (textareaRef.current) {
 			textareaRef.current.style.height = "auto";
 		}
-	}, [value, onSend, attachedImages]);
+	}, [value, onSend, attachedImages, mentionRefs]);
 
 	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/components/panels/AgentChatPanel/MessageInput.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.tsx
@@ -23,31 +23,38 @@ import { ModelSelector } from "./ModelSelector";
 const MENTION_SYNC_RE =
 	/@([^ \t\r\n@:]+(?:\.[^ \t\r\n@:]+)*)(?::L(\d+)(?:-L(\d+))?)?/g;
 
-function syncMentionsWithText(
+export function syncMentionsWithText(
 	text: string,
 	refs: MentionReference[],
 ): MentionReference[] | undefined {
 	const re = new RegExp(MENTION_SYNC_RE.source, "g");
-	const found = new Map<string, { startLine?: number; endLine?: number }>();
+	const queues = new Map<
+		string,
+		Array<{ startLine?: number; endLine?: number }>
+	>();
 	for (;;) {
 		const m = re.exec(text);
 		if (m === null) break;
-		found.set(m[1], {
+		const filePath = m[1];
+		const queue = queues.get(filePath) ?? [];
+		if (!queues.has(filePath)) queues.set(filePath, queue);
+		queue.push({
 			startLine: m[2] ? Number(m[2]) : undefined,
 			endLine: m[3] ? Number(m[3]) : undefined,
 		});
 	}
-	const synced = refs
-		.filter((ref) => found.has(ref.filePath))
-		.map((ref) => {
-			const info = found.get(ref.filePath);
-			if (!info) return { filePath: ref.filePath };
-			return {
-				filePath: ref.filePath,
-				startLine: info.startLine,
-				endLine: info.endLine,
-			};
+	const synced: MentionReference[] = [];
+	for (const ref of refs) {
+		const queue = queues.get(ref.filePath);
+		if (!queue || queue.length === 0) continue;
+		const range = queue.shift();
+		if (!range) continue;
+		synced.push({
+			filePath: ref.filePath,
+			startLine: range.startLine,
+			endLine: range.endLine,
 		});
+	}
 	return synced.length > 0 ? synced : undefined;
 }
 

--- a/src/components/panels/AgentChatPanel/MessageInput.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.tsx
@@ -20,7 +20,8 @@ import type {
 import { MentionPopup } from "./MentionPopup";
 import { ModelSelector } from "./ModelSelector";
 
-const MENTION_SYNC_RE = /@([^\s@:]+(?:\.[^\s@:]+)*)(?::L(\d+)(?:-L(\d+))?)?/g;
+const MENTION_SYNC_RE =
+	/@([^ \t\r\n@:]+(?:\.[^ \t\r\n@:]+)*)(?::L(\d+)(?:-L(\d+))?)?/g;
 
 function syncMentionsWithText(
 	text: string,

--- a/src/components/panels/AgentChatPanel/StreamMessage.test.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.test.tsx
@@ -1,11 +1,8 @@
-import { invoke } from "@tauri-apps/api/core";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MessageRole } from "@/types/session";
 import { StreamMessage } from "./StreamMessage";
-
-const mockInvoke = vi.mocked(invoke);
 
 const mockOpenUrl = vi.fn().mockResolvedValue(undefined);
 vi.mock("@tauri-apps/plugin-opener", () => ({
@@ -19,33 +16,6 @@ const system: MessageRole = "system";
 describe("StreamMessage", () => {
 	beforeEach(() => {
 		mockOpenUrl.mockClear();
-		mockInvoke.mockReset();
-		const displayFixtures: Record<
-			string,
-			Array<{ type: string; value: string }>
-		> = {
-			"Hello agent": [{ type: "text", value: "Hello agent" }],
-			"**not bold**": [{ type: "text", value: "**not bold**" }],
-			"Check @src/main.rs for details": [
-				{ type: "text", value: "Check " },
-				{ type: "mention", value: "@src/main.rs" },
-				{ type: "text", value: " for details" },
-			],
-			"Compare @src/a.rs and @src/b.rs:L1-L5": [
-				{ type: "text", value: "Compare " },
-				{ type: "mention", value: "@src/a.rs" },
-				{ type: "text", value: " and " },
-				{ type: "mention", value: "@src/b.rs:L1-L5" },
-			],
-			"No mentions here": [{ type: "text", value: "No mentions here" }],
-		};
-		mockInvoke.mockImplementation(async (cmd: string, args?: unknown) => {
-			if (cmd === "parse_display_mentions") {
-				const { content } = args as { content: string };
-				return displayFixtures[content] ?? [{ type: "text", value: content }];
-			}
-			return undefined;
-		});
 	});
 
 	it("renders human message", async () => {
@@ -194,7 +164,11 @@ describe("StreamMessage", () => {
 
 	it("renders @mention as badge in human messages", async () => {
 		render(
-			<StreamMessage content="Check @src/main.rs for details" role={human} />,
+			<StreamMessage
+				content="Check @src/main.rs for details"
+				role={human}
+				mentions={[{ filePath: "src/main.rs" }]}
+			/>,
 		);
 		const el = screen.getByTestId("stream-message-human");
 		await waitFor(() => {
@@ -209,6 +183,10 @@ describe("StreamMessage", () => {
 			<StreamMessage
 				content="Compare @src/a.rs and @src/b.rs:L1-L5"
 				role={human}
+				mentions={[
+					{ filePath: "src/a.rs" },
+					{ filePath: "src/b.rs", startLine: 1, endLine: 5 },
+				]}
 			/>,
 		);
 		const el = screen.getByTestId("stream-message-human");
@@ -217,6 +195,22 @@ describe("StreamMessage", () => {
 			expect(badges.length).toBe(2);
 			expect(badges[0].textContent).toBe("@src/a.rs");
 			expect(badges[1].textContent).toBe("@src/b.rs:L1-L5");
+		});
+	});
+
+	it("renders Japanese filename @mention as badge in human messages", async () => {
+		render(
+			<StreamMessage
+				content="確認してください @docs/Gitフロー.md の内容"
+				role={human}
+				mentions={[{ filePath: "docs/Gitフロー.md" }]}
+			/>,
+		);
+		const el = screen.getByTestId("stream-message-human");
+		await waitFor(() => {
+			const badge = el.querySelector(".font-mono");
+			expect(badge).not.toBeNull();
+			expect(badge?.textContent).toBe("@docs/Gitフロー.md");
 		});
 	});
 

--- a/src/components/panels/AgentChatPanel/StreamMessage.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.tsx
@@ -33,6 +33,16 @@ function ExternalLink(props: AnchorHTMLAttributes<HTMLAnchorElement>) {
 	);
 }
 
+function formatMentionToken(mention: MentionReference): string {
+	if (mention.startLine && mention.endLine) {
+		return `@${mention.filePath}:L${mention.startLine}-L${mention.endLine}`;
+	}
+	if (mention.startLine) {
+		return `@${mention.filePath}:L${mention.startLine}`;
+	}
+	return `@${mention.filePath}`;
+}
+
 function buildDisplayParts(
 	content: string,
 	mentions?: MentionReference[],
@@ -40,24 +50,32 @@ function buildDisplayParts(
 	if (!mentions || mentions.length === 0) {
 		return content ? [{ type: "text", value: content }] : [];
 	}
+	const tokens = mentions.map(formatMentionToken);
 	const parts: DisplayPart[] = [];
-	let remaining = content;
-	for (const mention of mentions) {
-		const mentionText = `@${mention.filePath}`;
-		const idx = remaining.indexOf(mentionText);
-		if (idx === -1) continue;
-		let matchEnd = idx + mentionText.length;
-		const after = remaining.slice(matchEnd);
-		const lineMatch = after.match(/^:L(\d+)(?:-L(\d+))?/);
-		if (lineMatch) matchEnd += lineMatch[0].length;
-		if (idx > 0) parts.push({ type: "text", value: remaining.slice(0, idx) });
-		parts.push({
-			type: "mention",
-			value: remaining.slice(idx, matchEnd),
-		});
-		remaining = remaining.slice(matchEnd);
+	let cursor = 0;
+	while (cursor < content.length) {
+		let best: { idx: number; token: string } | null = null;
+		for (const token of tokens) {
+			const idx = content.indexOf(token, cursor);
+			if (idx === -1) continue;
+			if (
+				!best ||
+				idx < best.idx ||
+				(idx === best.idx && token.length > best.token.length)
+			) {
+				best = { idx, token };
+			}
+		}
+		if (!best) {
+			parts.push({ type: "text", value: content.slice(cursor) });
+			break;
+		}
+		if (best.idx > cursor) {
+			parts.push({ type: "text", value: content.slice(cursor, best.idx) });
+		}
+		parts.push({ type: "mention", value: best.token });
+		cursor = best.idx + best.token.length;
 	}
-	if (remaining) parts.push({ type: "text", value: remaining });
 	return parts;
 }
 

--- a/src/components/panels/AgentChatPanel/StreamMessage.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.tsx
@@ -1,11 +1,10 @@
-import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { AnchorHTMLAttributes } from "react";
-import { useDeferredValue, useEffect, useState } from "react";
+import { useDeferredValue } from "react";
 import Markdown from "react-markdown";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { rehypePluginList, remarkPluginList } from "@/lib/markdownConfig";
-import type { ImagePart, MessageRole } from "@/types/session";
+import type { ImagePart, MentionReference, MessageRole } from "@/types/session";
 
 interface DisplayPart {
 	type: "text" | "mention";
@@ -16,6 +15,7 @@ interface StreamMessageProps {
 	content: string;
 	role: MessageRole;
 	images?: ImagePart[];
+	mentions?: MentionReference[];
 }
 
 function ExternalLink(props: AnchorHTMLAttributes<HTMLAnchorElement>) {
@@ -33,47 +33,44 @@ function ExternalLink(props: AnchorHTMLAttributes<HTMLAnchorElement>) {
 	);
 }
 
-const displayPartsCache = new Map<string, DisplayPart[]>();
+function buildDisplayParts(
+	content: string,
+	mentions?: MentionReference[],
+): DisplayPart[] {
+	if (!mentions || mentions.length === 0) {
+		return content ? [{ type: "text", value: content }] : [];
+	}
+	const parts: DisplayPart[] = [];
+	let remaining = content;
+	for (const mention of mentions) {
+		const mentionText = `@${mention.filePath}`;
+		const idx = remaining.indexOf(mentionText);
+		if (idx === -1) continue;
+		let matchEnd = idx + mentionText.length;
+		const after = remaining.slice(matchEnd);
+		const lineMatch = after.match(/^:L(\d+)(?:-L(\d+))?/);
+		if (lineMatch) matchEnd += lineMatch[0].length;
+		if (idx > 0) parts.push({ type: "text", value: remaining.slice(0, idx) });
+		parts.push({
+			type: "mention",
+			value: remaining.slice(idx, matchEnd),
+		});
+		remaining = remaining.slice(matchEnd);
+	}
+	if (remaining) parts.push({ type: "text", value: remaining });
+	return parts;
+}
 
 function HumanMessageContent({
 	content,
 	images,
+	mentions,
 }: {
 	content: string;
 	images?: ImagePart[];
+	mentions?: MentionReference[];
 }) {
-	const [parts, setParts] = useState<DisplayPart[] | null>(
-		() => displayPartsCache.get(content) ?? null,
-	);
-
-	useEffect(() => {
-		const cached = displayPartsCache.get(content);
-		if (cached) {
-			setParts(cached);
-			return;
-		}
-
-		let cancelled = false;
-		invoke<DisplayPart[]>("parse_display_mentions", { content })
-			.then((result) => {
-				if (!cancelled) {
-					displayPartsCache.set(content, result);
-					setParts(result);
-				}
-			})
-			.catch(() => {
-				if (!cancelled) {
-					const fallback: DisplayPart[] = [{ type: "text", value: content }];
-					displayPartsCache.set(content, fallback);
-					setParts(fallback);
-				}
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [content]);
-
-	const displayParts = parts ?? [{ type: "text" as const, value: content }];
+	const displayParts = buildDisplayParts(content, mentions);
 
 	const imageElements =
 		images && images.length > 0
@@ -112,7 +109,12 @@ function HumanMessageContent({
 	);
 }
 
-export function StreamMessage({ content, role, images }: StreamMessageProps) {
+export function StreamMessage({
+	content,
+	role,
+	images,
+	mentions,
+}: StreamMessageProps) {
 	const isHuman = role === "human";
 	const deferredContent = useDeferredValue(content);
 
@@ -132,7 +134,11 @@ export function StreamMessage({ content, role, images }: StreamMessageProps) {
 			className={`${isHuman ? "px-2" : "pt-1 pb-2 px-5"}`}
 		>
 			{isHuman ? (
-				<HumanMessageContent content={content} images={images} />
+				<HumanMessageContent
+					content={content}
+					images={images}
+					mentions={mentions}
+				/>
 			) : (
 				<div className="markdown-preview prose prose-sm dark:prose-invert max-w-none break-words">
 					<Markdown

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -35,6 +35,7 @@ import { useReviewPanel } from "@/hooks/useReviewPanel";
 import { isImageFile } from "@/lib/imageUtils";
 import { isMarkdownFile } from "@/lib/markdownUtils";
 import { cn } from "@/lib/utils";
+import type { MentionReference } from "@/types/session";
 import type { DiffBase, DiffMode, DiffSection } from "@/types/settings";
 import { Breadcrumb } from "./Breadcrumb";
 import { FileCommentPopoverTrigger } from "./DiffFileComment";
@@ -51,7 +52,10 @@ interface ReviewPanelProps {
 	diffOnlyMode: boolean;
 	onDiffOnlyModeChange: (enabled: boolean) => void;
 	navigateToFile?: { path: string; line?: number } | null;
-	onSendToAgent?: (message: string) => Promise<void>;
+	onSendToAgent?: (
+		message: string,
+		mentions?: MentionReference[],
+	) => Promise<void>;
 	initialSelectedFile?: string | null;
 	onSelectedFileChange?: (file: string | null) => void;
 }
@@ -338,7 +342,7 @@ export function ReviewPanel({
 		async (commentIds: string[]) => {
 			const result = await sendToAgent(commentIds);
 			if (result.formattedMessage && onSendToAgent) {
-				await onSendToAgent(result.formattedMessage);
+				await onSendToAgent(result.formattedMessage, result.mentions);
 				await markSent(result.commentIds);
 			}
 		},

--- a/src/components/panels/RightSidebarBottom.tsx
+++ b/src/components/panels/RightSidebarBottom.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, ChevronUp } from "lucide-react";
+import { useCallback } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { DiffCommentList } from "@/components/panels/DiffCommentList";
 import { TerminalPanel } from "@/components/panels/TerminalPanel";
@@ -37,6 +38,20 @@ export function RightSidebarBottom({
 		sendAllUnsent,
 	} = useDiffComments({ worktreeName });
 
+	const handleSendResult = useCallback(
+		async (result: {
+			formattedMessage: string;
+			mentions: MentionReference[];
+			commentIds: string[];
+		}) => {
+			if (result.formattedMessage && onSendToAgent) {
+				await onSendToAgent(result.formattedMessage, result.mentions);
+				await markSent(result.commentIds);
+			}
+		},
+		[onSendToAgent, markSent],
+	);
+
 	return (
 		<div className="flex flex-col h-full">
 			<div className="flex items-center gap-2 shrink-0 px-0 pt-0 bg-background border-y border-border">
@@ -70,26 +85,8 @@ export function RightSidebarBottom({
 								unsentCount={unsentCount}
 								onCommentClick={onCommentClick ?? (() => {})}
 								onDelete={deleteComment}
-								onSend={async (ids) => {
-									const result = await sendToAgent(ids);
-									if (result.formattedMessage && onSendToAgent) {
-										await onSendToAgent(
-											result.formattedMessage,
-											result.mentions,
-										);
-										await markSent(result.commentIds);
-									}
-								}}
-								onSendAll={async () => {
-									const result = await sendAllUnsent();
-									if (result.formattedMessage && onSendToAgent) {
-										await onSendToAgent(
-											result.formattedMessage,
-											result.mentions,
-										);
-										await markSent(result.commentIds);
-									}
-								}}
+								onSend={async (ids) => handleSendResult(await sendToAgent(ids))}
+								onSendAll={async () => handleSendResult(await sendAllUnsent())}
 							/>
 						</div>
 					</Panel>

--- a/src/components/panels/RightSidebarBottom.tsx
+++ b/src/components/panels/RightSidebarBottom.tsx
@@ -3,13 +3,17 @@ import { Group, Panel, Separator } from "react-resizable-panels";
 import { DiffCommentList } from "@/components/panels/DiffCommentList";
 import { TerminalPanel } from "@/components/panels/TerminalPanel";
 import { useDiffComments } from "@/hooks/useDiffComments";
+import type { MentionReference } from "@/types/session";
 import type { Theme } from "@/types/settings";
 
 interface RightSidebarBottomProps {
 	rootPath: string;
 	theme?: Theme;
 	worktreeName: string;
-	onSendToAgent?: (message: string) => Promise<void>;
+	onSendToAgent?: (
+		message: string,
+		mentions?: MentionReference[],
+	) => Promise<void>;
 	onCommentClick?: (filePath: string, lineNumber?: number) => void;
 	onToggleCollapse?: () => void;
 	collapsed?: boolean;
@@ -69,14 +73,20 @@ export function RightSidebarBottom({
 								onSend={async (ids) => {
 									const result = await sendToAgent(ids);
 									if (result.formattedMessage && onSendToAgent) {
-										await onSendToAgent(result.formattedMessage);
+										await onSendToAgent(
+											result.formattedMessage,
+											result.mentions,
+										);
 										await markSent(result.commentIds);
 									}
 								}}
 								onSendAll={async () => {
 									const result = await sendAllUnsent();
 									if (result.formattedMessage && onSendToAgent) {
-										await onSendToAgent(result.formattedMessage);
+										await onSendToAgent(
+											result.formattedMessage,
+											result.mentions,
+										);
 										await markSent(result.commentIds);
 									}
 								}}

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -114,6 +114,8 @@ describe("useAgentChat", () => {
 			"/repo",
 			"hello",
 			"acceptEdits",
+			undefined,
+			undefined,
 		);
 	});
 
@@ -135,6 +137,33 @@ describe("useAgentChat", () => {
 			"check this",
 			"acceptEdits",
 			images,
+			undefined,
+		);
+	});
+
+	it("sendMessage passes mentions to sendAgentMessage", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		const mentions = [{ filePath: "src/main.rs", startLine: 10, endLine: 20 }];
+		await act(async () => {
+			await result.current.sendMessage(
+				"check @src/main.rs:L10-L20",
+				undefined,
+				mentions,
+			);
+		});
+
+		expect(sessionStore.sendAgentMessage).toHaveBeenCalledWith(
+			null,
+			"/repo",
+			"check @src/main.rs:L10-L20",
+			"acceptEdits",
+			undefined,
+			mentions,
 		);
 	});
 
@@ -156,6 +185,7 @@ describe("useAgentChat", () => {
 			"",
 			"acceptEdits",
 			images,
+			undefined,
 		);
 	});
 
@@ -175,6 +205,8 @@ describe("useAgentChat", () => {
 			"/repo",
 			"hello",
 			"acceptEdits",
+			undefined,
+			undefined,
 		);
 	});
 
@@ -244,6 +276,8 @@ describe("useAgentChat", () => {
 			"/repo",
 			"hello",
 			"acceptEdits",
+			undefined,
+			undefined,
 		);
 	});
 
@@ -269,6 +303,8 @@ describe("useAgentChat", () => {
 			"/repo",
 			"second",
 			"acceptEdits",
+			undefined,
+			undefined,
 		);
 	});
 
@@ -453,6 +489,8 @@ describe("useAgentChat", () => {
 			"/repo",
 			"hello",
 			"plan",
+			undefined,
+			undefined,
 		);
 	});
 
@@ -556,6 +594,8 @@ describe("useAgentChat", () => {
 			"/repo",
 			"second",
 			"acceptEdits",
+			undefined,
+			undefined,
 		);
 	});
 

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -5,6 +5,7 @@ import type {
 	ChatMessage,
 	ChatSession,
 	ImageAttachment,
+	MentionReference,
 	ModelInfo,
 	PermissionMode,
 	SessionSummary,
@@ -40,7 +41,11 @@ export interface UseAgentChatResult {
 	error: string | null;
 	permissionMode: PermissionMode;
 	sessionAgentStates: Map<string, AgentState>;
-	sendMessage: (content: string, images?: ImageAttachment[]) => Promise<void>;
+	sendMessage: (
+		content: string,
+		images?: ImageAttachment[],
+		mentions?: MentionReference[],
+	) => Promise<void>;
 	interrupt: () => void;
 	selectSession: (sessionId: string) => Promise<void>;
 	refreshSessions: () => Promise<SessionSummary[] | undefined>;
@@ -224,18 +229,26 @@ export function useAgentChat(worktreePath: string): UseAgentChatResult {
 	}, []);
 
 	const sendMessage = useCallback(
-		async (content: string, images?: ImageAttachment[]) => {
+		async (
+			content: string,
+			images?: ImageAttachment[],
+			mentions?: MentionReference[],
+		) => {
 			const trimmed = content.trim();
 			if (!trimmed && (!images || images.length === 0)) return;
 
 			try {
-				const hasImages = images && images.length > 0;
 				const sessionId = activeSessionRef.current?.id ?? null;
 				const wPath = worktreePathRef.current;
 				const pm = permissionModeRef.current;
-				const response = hasImages
-					? await sendAgentMessage(sessionId, wPath, trimmed, pm, images)
-					: await sendAgentMessage(sessionId, wPath, trimmed, pm);
+				const response = await sendAgentMessage(
+					sessionId,
+					wPath,
+					trimmed,
+					pm,
+					images,
+					mentions,
+				);
 				// Only update if the user hasn't switched to a different session during await
 				const currentSessionId = activeSessionRef.current?.id ?? null;
 				if (

--- a/src/hooks/useDiffComments.test.ts
+++ b/src/hooks/useDiffComments.test.ts
@@ -179,6 +179,39 @@ describe("useDiffComments", () => {
 		});
 	});
 
+	it("sendToAgent returns mentions from invoke result", async () => {
+		mockInvoke.mockResolvedValue([]);
+
+		const { result } = renderHook(() =>
+			useDiffComments({ worktreeName: "wt" }),
+		);
+
+		await waitFor(() => {
+			expect(result.current.loading).toBe(false);
+		});
+
+		const mentions = [
+			{ filePath: "src/main.ts", startLine: 10, endLine: null },
+			{ filePath: "src/app.tsx", startLine: 5, endLine: 15 },
+		];
+		mockInvoke.mockResolvedValue({
+			sentCount: 2,
+			formattedMessage: "msg",
+			mentions,
+			commentIds: ["c1", "c2"],
+		});
+
+		let sendResult:
+			| Awaited<ReturnType<typeof result.current.sendToAgent>>
+			| undefined;
+		await act(async () => {
+			sendResult = await result.current.sendToAgent(["c1", "c2"]);
+		});
+
+		expect(sendResult?.mentions).toEqual(mentions);
+		expect(sendResult?.commentIds).toEqual(["c1", "c2"]);
+	});
+
 	it("sendAllUnsent calls sendToAgent with empty array", async () => {
 		mockInvoke.mockResolvedValue([]);
 

--- a/src/hooks/useDiffComments.ts
+++ b/src/hooks/useDiffComments.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { DiffComment } from "@/types/diffComment";
+import type { MentionReference } from "@/types/session";
 
 interface UseDiffCommentsOptions {
 	worktreeName: string;
@@ -88,6 +89,7 @@ export function useDiffComments({ worktreeName }: UseDiffCommentsOptions) {
 			return invoke<{
 				sentCount: number;
 				formattedMessage: string;
+				mentions: MentionReference[];
 				commentIds: string[];
 			}>("send_diff_comments_to_agent", {
 				worktreeName,

--- a/src/hooks/useSessionStore.ts
+++ b/src/hooks/useSessionStore.ts
@@ -4,6 +4,7 @@ import type {
 	ChatSession,
 	ImageAttachment,
 	LegacyChatMessage,
+	MentionReference,
 	MessagePart,
 	MessageRole,
 	ModelInfo,
@@ -193,6 +194,7 @@ export async function sendAgentMessage(
 	content: string,
 	permissionMode: string,
 	images?: ImageAttachment[],
+	mentions?: MentionReference[],
 ): Promise<SendMessageResponse> {
 	const raw = await invoke<RawSendMessageResponse>("send_agent_message", {
 		chatSessionId,
@@ -200,6 +202,7 @@ export async function sendAgentMessage(
 		content,
 		permissionMode,
 		images: images && images.length > 0 ? images : undefined,
+		mentions: mentions && mentions.length > 0 ? mentions : undefined,
 	});
 	return {
 		session: convertLegacySession(raw.session),

--- a/src/hooks/useSessionStore.ts
+++ b/src/hooks/useSessionStore.ts
@@ -74,6 +74,7 @@ function convertLegacyMessage(
 		role: msg.role,
 		parts: msg.parts ?? legacyToParts(msg),
 		timestamp: msg.timestamp,
+		mentions: msg.mentions,
 	};
 }
 

--- a/src/screens/MainLayout.tsx
+++ b/src/screens/MainLayout.tsx
@@ -33,6 +33,7 @@ import {
 	CreateBranchDialog,
 	GitErrorDialog,
 } from "@/screens/WorktreeViewDialogs";
+import type { MentionReference } from "@/types/session";
 import type { AppSettings } from "@/types/settings";
 import type { WorkspaceState } from "@/types/workspace-state";
 
@@ -83,12 +84,15 @@ function WorktreeContent({
 	}, [rootPath]);
 
 	const sendAgentMessageRef = useRef<
-		((content: string) => Promise<void>) | null
+		((content: string, mentions?: MentionReference[]) => Promise<void>) | null
 	>(null);
 
-	const handleSendToAgent = useCallback(async (message: string) => {
-		await sendAgentMessageRef.current?.(message);
-	}, []);
+	const handleSendToAgent = useCallback(
+		async (message: string, mentions?: MentionReference[]) => {
+			await sendAgentMessageRef.current?.(message, mentions);
+		},
+		[],
+	);
 
 	const handleCommentClick = useCallback(
 		(filePath: string, lineNumber?: number) => {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -182,3 +182,9 @@ export interface ImageAttachment {
 	data: string;
 	mediaType: string;
 }
+
+export interface MentionReference {
+	filePath: string;
+	startLine?: number;
+	endLine?: number;
+}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -103,6 +103,7 @@ export interface ChatMessage {
 	role: MessageRole;
 	parts: MessagePart[];
 	timestamp: number;
+	mentions?: MentionReference[];
 }
 
 /** Rust backend ChatMessage format (for DB persistence) */
@@ -113,6 +114,7 @@ export interface LegacyChatMessage {
 	thinking?: string;
 	activities?: ActivityEntry[];
 	timestamp: number;
+	mentions?: MentionReference[];
 }
 
 export interface ChatSession {


### PR DESCRIPTION
## Summary
- @mentionのファイル参照を正規表現テキスト解析から構造化データ(`MentionReference`)に移行し、非ASCIIファイル名・行番号指定を正しく処理する
- `resolve_mentions_or_fallback`ヘルパーで`agent_sdk.rs`内の重複パターンをDRY化
- `syncMentionsWithText`でテキストと`mentionRefs`の同期を実装し、送信時に削除済みメンションを除外・行番号を反映
- Diffコメント送信フォーマットを`@path:Lx-Ly`形式に修正しメンションバッジ表示に対応

## Test plan
- [ ] `cargo test diff_comment_sender` — フォーマット変更のテスト
- [ ] `cargo test file_mention` — resolve_mentions_or_fallback含む解決テスト
- [ ] `pnpm test` — MessageInput / useAgentChat / useDiffComments のフロントテスト
- [ ] 手動: 非ASCIIファイル名の@メンション → バッジ表示・ファイル内容解決を確認
- [ ] 手動: Diffコメントから送信 → チャットUIでメンションバッジが表示されることを確認

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ファイルメンションをファイルパス＋任意の行範囲の構造化メタデータとして送受信できるようになりました。チャット送信、差分コメント送信、レビュー送信経路でメンション情報が伝播します。

* **改善**
  * メンション表示はテキスト再解析に依存せず、受信した構造化メタデータから同期的にバッジ表示され、日本語や非ASCIIを含むファイル名も正しくレンダリングされます。

* **ドキュメント**
  * 期待動作をGherkinで定義した仕様ドキュメントを追加しました。

* **テスト**
  * メンションの抽出・解決・表示に関するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->