### PR TITLE
feat: ワークフローステートマシンエンジン (#860)

### DIFF
--- a/docs/spec/issues-860.md
+++ b/docs/spec/issues-860.md
@@ -245,7 +245,7 @@ pub enum WorkflowExecutionState {
 
 ### ブロードキャスト
 
-- `SessionStatus` に `workflow_step: Option<String>` と `workflow_state: Option<String>` を追加
+- `SessionStatus` に `workflow_step: Option<String>` と `workflow_execution_state: Option<String>` を追加
 - `update_session` 時に `workflow-state-changed` Tauriイベントを emit
 - WebSocket: `WsMessage::WorkflowStateSync` variant を追加（リモートクライアント向け）
 

--- a/docs/spec/issues-860.md
+++ b/docs/spec/issues-860.md
@@ -1,0 +1,262 @@
+## 要求
+
+**種別**: 新機能
+**ゴール**: ワークフロー定義（YAML）に基づきステップを順次実行するステートマシンエンジンを構築する。各ステップは既存のAgentSession（agent_sdk.rs）に委譲し、3つのモード（auto / approval / interactive）に応じた結果判定と遷移制御を行う。
+**背景**: Releashのオーケストレーション機能（Milestone #49）のPhase 2として、Phase 1（#859 Workflow Schema & Storage）で定義されたYAMLスキーマを実行可能にするエンジンが必要。計画→実装→レビュー→修正ループといったマルチステップのAIワークフローを自動遷移させることで、人間の介在ポイントを柔軟に制御しつつ品質担保を実現する。
+**対象ユーザー**: Releashユーザー（開発者）
+**制約**:
+  - 1ステップ = 1 AgentSession（既存agent_sdk.rsに委譲）
+  - AgentStatusCenterで進行状況をブロードキャスト
+  - SessionStoreでワークフロー状態を永続化
+  - 同一Worktree内の並列実行はなし（Phase 3 #862で対応）
+  - ワークフロー内並列もPhase 3スコープ（本Issueではシーケンシャル遷移のみ）
+**影響範囲**:
+  - agent_sdk.rs: AgentSessionの開始・終了をエンジンから制御
+  - agent_status.rs: ワークフロー進行状況の追加ブロードキャスト
+  - session/: ワークフロー実行状態の永続化
+
+### スコープ
+1. ステートマシン（ステップ遷移、状態管理、実行中/完了/失敗）
+2. ステップ実行 → 既存AgentSessionへの委譲
+3. 3モードの実装
+   - **auto**: AgentSessionを自動実行し、turn_complete後のテキストからタグを正規表現で検出→ルール照合→次ステップ決定
+   - **approval**: AgentSession完了後にGUIボタンで人間が判定（承認/差し戻し/中止）
+   - **interactive**: 対話型AgentSessionでユーザーが明示的に完了操作＋結果選択
+4. autoモードのタグ検出エンジン（正規表現パース）
+5. 遷移ルール評価（match条件→next先解決）
+6. サイクルガード（max_iterations、超過時の中止 or 警告）
+7. ワークフロー実行のTauriコマンド（開始、中止、状態取得）
+8. interactiveモードでのメッセージキューイング（旧#699）
+
+### 検証方法
+- autoステップが実行され、タグ検出でルールに基づき次ステップに遷移する
+- approvalステップで一時停止し、ユーザーの承認操作で次へ進む
+- interactiveステップで対話でき、ユーザーが完了操作で次へ進む
+- review→implementのサイクルガードがmax_iterationsで発火する
+- ワークフロー中断・再開が正しく動作する
+
+### 依存関係
+- #859 Workflow Schema & Storage（Phase 1完了後に着手）
+
+## 振る舞い定義
+
+```gherkin
+Feature: ワークフローエンジン
+  YAMLで定義されたワークフローのステップを順次実行し、
+  モードに応じた結果判定と遷移制御を行うステートマシンエンジン。
+
+  Rule: ワークフローはステップを順次実行し状態遷移する
+
+    Scenario: ワークフロー開始で最初のステップが実行される
+      Given ワークフロー "plan-implement-review" が定義されている
+      And 最初のステップは "plan"（interactiveモード）である
+      When ユーザーがワークフローを開始する
+      Then ワークフロー実行状態が "running" になる
+      And ステップ "plan" のAgentSessionが開始される
+
+    Scenario: ルールのないステップが完了すると定義順で次のステップに遷移する
+      Given ステップ "plan" が実行中である
+      And ステップ "plan" にrulesが定義されていない
+      When ステップ "plan" が完了する
+      Then 定義順で次のステップ "implement" のAgentSessionが開始される
+
+    Scenario: 最後のステップが完了するとワークフローが完了する
+      Given ステップ "report"（最後のステップ）が実行中である
+      When ステップ "report" が完了する
+      Then ワークフロー実行状態が "completed" になる
+
+    Scenario: ステップ実行中にAgentSessionがエラー終了するとワークフローが失敗する
+      Given ステップ "implement" が実行中である
+      When AgentSessionがエラー終了する
+      Then ワークフロー実行状態が "failed" になる
+
+  Rule: autoモードはタグ検出で遷移先を決定する
+
+    Scenario: タグがルールにマッチすると指定先に遷移する
+      Given ステップ "review" がautoモードで実行中である
+      And ルール match="NEEDS_FIX" next="implement" が定義されている
+      When AgentSessionが完了しテキストに "<decision>NEEDS_FIX</decision>" が含まれる
+      Then ステップ "implement" のAgentSessionが開始される
+
+    Scenario: タグが別のルールにマッチすると対応する遷移先に遷移する
+      Given ステップ "review" がautoモードで実行中である
+      And ルール match="LGTM" next="report" が定義されている
+      When AgentSessionが完了しテキストに "<decision>LGTM</decision>" が含まれる
+      Then ステップ "report" のAgentSessionが開始される
+
+    Scenario: タグが検出されない場合はワークフローが失敗する
+      Given ステップ "review" がautoモードで実行中である
+      And ルールが定義されている
+      When AgentSessionが完了しテキストにマッチするタグが含まれない
+      Then ワークフロー実行状態が "failed" になる
+
+  Rule: approvalモードは人間の判定で遷移先を決定する
+
+    Scenario: AgentSession完了後に承認待ちで一時停止する
+      Given ステップ "report" がapprovalモードで実行中である
+      When AgentSessionが完了する
+      Then ワークフロー実行状態が "waiting_approval" になる
+
+    Scenario: 承認されると次のステップに遷移する
+      Given ステップ "report" がapprovalモードで承認待ちである
+      When ユーザーが「承認」を選択する
+      Then 次のステップに遷移する
+
+    Scenario: 差し戻されるとルールで指定されたステップに遷移する
+      Given ステップ "report" がapprovalモードで承認待ちである
+      And ルール match="reject" next="implement" が定義されている
+      When ユーザーが「差し戻し」を選択する
+      Then ステップ "implement" のAgentSessionが開始される
+
+    Scenario: 中止されるとワークフローが中止になる
+      Given ステップ "report" がapprovalモードで承認待ちである
+      When ユーザーが「中止」を選択する
+      Then ワークフロー実行状態が "aborted" になる
+
+  Rule: interactiveモードはユーザーとの対話後に完了または中止する
+
+    Scenario: ユーザーがメッセージを送信するとAgentSessionに送られる
+      Given ステップ "plan" がinteractiveモードで実行中である
+      When ユーザーがメッセージを送信する
+      Then AgentSessionにメッセージがキューイングされ処理される
+
+    Scenario: ユーザーが完了操作を行うと次のステップに遷移する
+      Given ステップ "plan" がinteractiveモードで実行中である
+      When ユーザーが「完了」を選択する
+      Then 次のステップに遷移する
+
+    Scenario: ユーザーが中止操作を行うとワークフローが中止になる
+      Given ステップ "plan" がinteractiveモードで実行中である
+      When ユーザーが「中止」を選択する
+      Then ワークフロー実行状態が "aborted" になる
+
+  Rule: サイクルガードは同一ステップの無限ループを防止する
+
+    Scenario: max_iterations到達でワークフローが失敗する
+      Given ステップ "review" にcycle_guard max_iterations=3 が設定されている
+      And "review" ステップが3回実行済みである
+      When ステップ "review" に再び遷移しようとする
+      Then ワークフロー実行状態が "failed" になる
+      And サイクルガード超過が原因として記録される
+
+  Rule: 実行中のワークフローはユーザー操作で中断できる
+
+    Scenario: ユーザーがワークフローを中断する
+      Given ワークフローが実行中である
+      When ユーザーがワークフローの中断を要求する
+      Then 実行中のAgentSessionが中断される
+      And ワークフロー実行状態が "aborted" になる
+
+  Rule: ワークフロー実行状態はセッションに永続化される
+
+    Scenario: ステップ遷移時に実行状態が保存される
+      Given ワークフローが実行中である
+      When ステップが遷移する
+      Then 現在のステップ名と実行履歴がセッションに保存される
+
+  Rule: ワークフロー進行状況はリアルタイムでブロードキャストされる
+
+    Scenario: ステップ遷移時に進行状況が通知される
+      Given ワークフローが実行中である
+      When ステップが遷移する
+      Then ワークフローのステップ情報がAgentStatusCenterを通じてブロードキャストされる
+```
+
+## 実装仕様
+
+**対応方針**: 振る舞い定義のステートマシン・3モード実行・タグ検出・サイクルガードを実現するために、`src-tauri/src/workflow/` に `engine.rs` を新設し、既存の `agent_sdk.rs`（AgentSession委譲）・`agent_status.rs`（進行状況ブロードキャスト）・`session/`（状態永続化）と統合する。
+
+**対象コンポーネント**:
+- `src-tauri/src/workflow/engine.rs`（新規）: ステートマシン本体。`WorkflowExecution` 構造体でステップ遷移・状態管理・タグ検出・サイクルガードを実装
+- `src-tauri/src/workflow/commands.rs`（変更）: ワークフロー実行のTauriコマンド追加（`start_workflow`, `abort_workflow`, `get_workflow_state`, `approve_workflow_step`, `complete_interactive_step`）
+- `src-tauri/src/workflow/mod.rs`（変更）: `engine` モジュール追加
+- `src-tauri/src/session/mod.rs`（変更）: `ChatSession` に `workflow_state: Option<WorkflowState>` フィールド追加
+- `src-tauri/src/agent_status.rs`（変更）: `SessionStatus` にワークフローステップ情報を追加、`workflow-state-changed` イベント emit
+- `src-tauri/src/agent_sdk.rs`（変更）: `turn_complete` 後にワークフローエンジンへのコールバック追加
+
+### ステートマシン設計
+
+**WorkflowExecution 構造体**:
+```rust
+pub struct WorkflowExecution {
+    pub id: String,                                    // 実行ID (UUID)
+    pub workflow_name: String,                         // ワークフロー名
+    pub state: WorkflowExecutionState,                 // 実行状態
+    pub current_step_index: usize,                     // 現在のステップインデックス
+    pub current_step_name: String,                     // 現在のステップ名
+    pub step_execution_counts: HashMap<String, u32>,   // ステップ名→実行回数（サイクルガード用）
+    pub step_history: Vec<StepResult>,                 // 実行履歴
+    pub chat_session_id: String,                       // 紐づくChatSession ID
+    pub started_at: f64,
+    pub updated_at: f64,
+}
+```
+
+**WorkflowExecutionState enum**:
+```rust
+pub enum WorkflowExecutionState {
+    Running,
+    WaitingApproval,
+    Completed,
+    Failed { reason: String },
+    Aborted,
+}
+```
+
+### ステップ実行フロー
+
+**autoモード**:
+1. エンジンが `start_agent_session` → `send_agent_message`（プロンプト送信）
+2. `agent-session-state-changed`（turn_complete, exit_code=0）を検知
+3. SessionStoreから最終メッセージの `parts` を取得
+4. `Text` パートを結合し、rulesの `match` パターンを正規表現で検索
+5. マッチしたルールの `next` ステップに遷移 / マッチなしで `Failed`
+
+**approvalモード**:
+1. エンジンが `start_agent_session` → `send_agent_message`（プロンプト送信）
+2. turn_complete を検知
+3. `WorkflowExecutionState::WaitingApproval` に遷移し一時停止
+4. フロントエンドがGUIボタンで `approve_workflow_step` Tauriコマンドを呼び出し
+5. 承認→次ステップ / 差し戻し→ルールで指定されたステップ / 中止→Aborted
+
+**interactiveモード**:
+1. エンジンが `start_agent_session` → `send_agent_message`（プロンプト送信）
+2. ユーザーが `send_agent_message` で対話（既存のチャットUIをそのまま利用）
+3. ユーザーが `complete_interactive_step` Tauriコマンドで完了/中止を選択
+4. 完了→次ステップ / 中止→Aborted
+
+### タグ検出エンジン
+
+- `TransitionRule.match` の値を正規表現パターンとして `regex::Regex` でコンパイル
+- turn_complete後のテキスト（`consolidate_parts` 済み `MessagePart::Text` を結合）に対してマッチ
+- 複数ルールがマッチした場合は定義順で最初のルールを採用
+
+### サイクルガード
+
+- `step_execution_counts: HashMap<String, u32>` でステップ名ごとの実行回数を追跡
+- ステップに遷移する前に `cycle_guard.max_iterations` と比較
+- 超過時は `WorkflowExecutionState::Failed { reason: "Cycle guard exceeded..." }` に遷移
+
+### 永続化
+
+- `ChatSession.workflow_state: Option<WorkflowState>` に `WorkflowExecution` のサブセットを保存
+- `#[serde(skip_serializing_if = "Option::is_none", default)]` で既存セッションとのJSON互換性を維持
+- ステップ遷移のたびに `SessionStore::save_session` で自動保存
+
+### ブロードキャスト
+
+- `SessionStatus` に `workflow_step: Option<String>` と `workflow_state: Option<String>` を追加
+- `update_session` 時に `workflow-state-changed` Tauriイベントを emit
+- WebSocket: `WsMessage::WorkflowStateSync` variant を追加（リモートクライアント向け）
+
+### turn_complete統合
+
+- `agent_sdk.rs` の `turn_complete` ハンドラー末尾に、ワークフローエンジンへの通知フックを追加
+- ワークフロー実行中のセッションの場合のみ発火
+- `WorkflowEngine::on_turn_complete(chat_session_id, exit_code, final_parts)` を呼び出し
+
+**影響するテスト**:
+- `workflow/engine.rs`: ステートマシン遷移の単体テスト（正常遷移、タグ検出、サイクルガード、エラーケース）
+- `workflow/engine.rs`: タグ検出エンジンの単体テスト（マッチ/不一致/複数マッチ）
+- `session/mod.rs`: `workflow_state` フィールド付き ChatSession のシリアライズ/デシリアライズのラウンドトリップテスト
+- 既存の `agent_sdk.rs` テスト: turn_complete フックの追加による既存動作への影響がないことの確認

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "image-png"] }
+tauri = { version = "2.11", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -247,6 +247,10 @@ fn notify_status_transition(
     let agent_state = AgentStatusCenter::derive_agent_state(turn_phase, session_state.clone());
 
     if let Some(center) = app.try_state::<Arc<AgentStatusCenter>>() {
+        let (wf_step, wf_state) = center
+            .get_session(chat_session_id)
+            .map(|s| (s.workflow_step, s.workflow_execution_state))
+            .unwrap_or((None, None));
         let status = SessionStatus {
             chat_session_id: chat_session_id.to_string(),
             worktree_id: worktree_path.clone(),
@@ -257,6 +261,8 @@ fn notify_status_transition(
             session_state,
             pending_permission: matches!(turn_phase, TurnPhase::WaitingPermission),
             last_activity_at: current_timestamp(),
+            workflow_step: wf_step,
+            workflow_execution_state: wf_state,
         };
         center.update_session(status);
     }
@@ -1096,6 +1102,46 @@ async fn spawn_bridge_process(
                                 override_state,
                             );
 
+                            // Workflow engine hook: notify on turn_complete
+                            // Note: std::thread::spawn is required because on_turn_complete's
+                            // future is !Send (it transitively awaits spawn_bridge_process).
+                            // Handle::current() reuses the existing tokio runtime instead of
+                            // creating a new Runtime per turn_complete.
+                            {
+                                use tauri::Manager;
+                                let wf_engine: Option<
+                                    Arc<crate::workflow::engine::WorkflowEngine>,
+                                > = app_stdout
+                                    .try_state::<Arc<crate::workflow::engine::WorkflowEngine>>()
+                                    .map(|s| Arc::clone(&s));
+                                if let Some(engine) = wf_engine {
+                                    let app_wf = app_stdout.clone();
+                                    let ss_wf = Arc::clone(&session_store_clone);
+                                    let h_wf = Arc::clone(&handles_stdout);
+                                    let csid_wf = csid_stdout.clone();
+                                    let parts_wf = final_parts.clone();
+                                    let handle = tokio::runtime::Handle::current();
+                                    std::thread::spawn(move || {
+                                        handle.block_on(async move {
+                                            if engine.is_running(&csid_wf).await {
+                                                if let Err(e) = engine
+                                                    .on_turn_complete(
+                                                        &app_wf, &ss_wf, &h_wf, &csid_wf,
+                                                        exit_code, &parts_wf,
+                                                    )
+                                                    .await
+                                                {
+                                                    log::error!(
+                                                        "Workflow on_turn_complete error for {}: {e}",
+                                                        csid_wf
+                                                    );
+                                                }
+                                            }
+                                        });
+                                    });
+                                }
+                            }
+
                             // Auto-consume pending message queued by send_agent_message.
                             // Spawn a separate task to avoid oversized async state machine in stdout reader.
                             let has_pending = {
@@ -1565,7 +1611,7 @@ fn get_persisted_spawn_info(
         .unwrap_or((None, None))
 }
 
-async fn start_agent_session_internal(
+pub(crate) async fn start_agent_session_internal(
     app: &tauri::AppHandle,
     handles: &Arc<Mutex<AgentProcessMap>>,
     session_store: &Arc<SessionStore>,
@@ -2320,21 +2366,23 @@ pub async fn init_agent_sessions(
             active_session: Some(response),
         })
     } else {
-        // Start agent processes for all sessions with their persisted permission_mode
+        // Start agent processes for all sessions with their persisted permission_mode.
+        // Sequential execution is required because start_agent_session_internal
+        // transitively calls spawn_bridge_process, making the Future !Send
+        // and incompatible with tokio::spawn.
         for s in &sessions {
-            let app_c = app.clone();
-            let h_c = Arc::clone(handles.inner());
-            let ss_c = Arc::clone(session_store.inner());
-            let sid = s.id.clone();
-            let cwd = worktree_path.clone();
-            let pm_c = s.permission_mode.clone();
-            tokio::spawn(async move {
-                if let Err(e) =
-                    start_agent_session_internal(&app_c, &h_c, &ss_c, &sid, &cwd, Some(pm_c)).await
-                {
-                    log::error!("Failed to start agent session {sid}: {e}");
-                }
-            });
+            if let Err(e) = start_agent_session_internal(
+                &app,
+                handles.inner(),
+                session_store.inner(),
+                &s.id,
+                &worktree_path,
+                Some(s.permission_mode.clone()),
+            )
+            .await
+            {
+                log::error!("Failed to start agent session {}: {e}", s.id);
+            }
         }
 
         // Get first session as active
@@ -2580,6 +2628,57 @@ pub async fn prepare_image_attachments_from_paths(
         }
     }
     Ok(attachments)
+}
+
+/// ワークフローエンジンから呼ばれる内部版。
+/// AgentSessionを開始し、プロンプトを送信する。
+/// メッセージの追加(human + agent)とstart_agent_turnをまとめて行う。
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn start_agent_turn_internal(
+    app: &tauri::AppHandle,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    chat_session_id: &str,
+    cwd: &str,
+    permission_mode: &str,
+    prompt: &str,
+) -> Result<(), String> {
+    let data_dir = resolve_data_dir(app)?;
+
+    // Add human message
+    let _human_msg = add_message_internal(
+        session_store,
+        &data_dir,
+        chat_session_id,
+        MessageRole::Human,
+        prompt,
+        None,
+        None,
+    )?;
+
+    // Add empty agent message (will be filled by streaming)
+    let agent_msg = add_message_internal(
+        session_store,
+        &data_dir,
+        chat_session_id,
+        MessageRole::Agent,
+        "",
+        None,
+        None,
+    )?;
+
+    start_agent_turn(
+        app,
+        handles,
+        session_store,
+        chat_session_id,
+        cwd,
+        permission_mode,
+        prompt,
+        &agent_msg.id,
+        &[],
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/agent_status.rs
+++ b/src-tauri/src/agent_status.rs
@@ -22,6 +22,8 @@ pub struct SessionStatus {
     pub session_state: SessionState,
     pub pending_permission: bool,
     pub last_activity_at: f64,
+    pub workflow_step: Option<String>,
+    pub workflow_execution_state: Option<String>,
 }
 
 /// `TurnPhase` は `agent_sdk` 側で `Copy + Serialize` だが `Eq` を持たないため、
@@ -108,6 +110,8 @@ impl AgentStatusCenter {
             && a.turn_phase == b.turn_phase
             && a.session_state == b.session_state
             && a.pending_permission == b.pending_permission
+            && a.workflow_step == b.workflow_step
+            && a.workflow_execution_state == b.workflow_execution_state
     }
 
     fn is_workspace_state_equivalent(a: &WorkspaceStatus, b: &WorkspaceStatus) -> bool {
@@ -332,6 +336,12 @@ impl AgentStatusCenter {
         let _ = self.app_handle.emit("workspace-status-changed", status);
     }
 
+    /// ワークフロー状態変更を通知する。
+    pub fn emit_workflow_state_changed(&self, payload: &impl Serialize) {
+        use tauri::Emitter;
+        let _ = self.app_handle.emit("workflow-state-changed", payload);
+    }
+
     /// 既存 frontend / remote が購読している `agent-state-changed` を維持する。
     fn emit_agent_state_changed_compat(
         &self,
@@ -424,6 +434,8 @@ mod tests {
             session_state,
             pending_permission: matches!(turn_phase, TurnPhase::WaitingPermission),
             last_activity_at: 0.0,
+            workflow_step: None,
+            workflow_execution_state: None,
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -139,6 +139,7 @@ pub fn run() {
                 broadcaster,
             ));
             app.manage(agent_status_center);
+            app.manage(Arc::new(workflow::engine::WorkflowEngine::new()));
 
             menu::setup_menu(app)?;
             tray::setup_tray(app)?;
@@ -389,6 +390,11 @@ pub fn run() {
             workflow::commands::delete_workflow,
             workflow::commands::open_workflow_in_editor,
             workflow::commands::list_prompt_templates,
+            workflow::commands::start_workflow,
+            workflow::commands::abort_workflow,
+            workflow::commands::get_workflow_state,
+            workflow::commands::approve_workflow_step,
+            workflow::commands::complete_interactive_step,
             // Menu
             menu::set_menu_items_enabled,
         ])

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tauri::{Manager, State};
 
+pub use crate::workflow::state::WorkflowState;
 pub use store::SessionStore;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -173,6 +174,8 @@ pub struct ChatSession {
     pub permission_mode: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub selected_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub workflow_state: Option<WorkflowState>,
 }
 
 fn default_permission_mode() -> String {
@@ -360,6 +363,7 @@ pub fn create_session_internal(
         agent_session_id: None,
         permission_mode: default_permission_mode(),
         selected_model: None,
+        workflow_state: None,
     };
     session_store.save_session(data_dir, &session)?;
     Ok(session)
@@ -496,6 +500,7 @@ pub fn update_session_agent_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::workflow::state::{StepHistoryEntry, WorkflowExecutionState};
 
     #[test]
     fn chat_session_to_summary_basic() {
@@ -518,6 +523,7 @@ mod tests {
             agent_session_id: None,
             permission_mode: "acceptEdits".to_string(),
             selected_model: None,
+            workflow_state: None,
         };
         let summary = session.to_summary();
         assert_eq!(summary.id, "s1");
@@ -548,6 +554,7 @@ mod tests {
             agent_session_id: None,
             permission_mode: "acceptEdits".to_string(),
             selected_model: None,
+            workflow_state: None,
         };
         let summary = session.to_summary();
         assert_eq!(summary.first_message.len(), 100 + "…".len());
@@ -577,6 +584,7 @@ mod tests {
             agent_session_id: None,
             permission_mode: "acceptEdits".to_string(),
             selected_model: None,
+            workflow_state: None,
         };
         let summary = session.to_summary();
         // 100 chars of "あ" (300 bytes) + "…" (3 bytes)
@@ -597,6 +605,7 @@ mod tests {
             agent_session_id: None,
             permission_mode: "acceptEdits".to_string(),
             selected_model: None,
+            workflow_state: None,
         };
         let summary = session.to_summary();
         assert_eq!(summary.first_message, "");
@@ -716,6 +725,7 @@ mod tests {
             agent_session_id: None,
             permission_mode: "acceptEdits".to_string(),
             selected_model: None,
+            workflow_state: None,
         };
         let json = serde_json::to_string(&session).unwrap();
         let back: ChatSession = serde_json::from_str(&json).unwrap();
@@ -744,6 +754,7 @@ mod tests {
             agent_session_id: None,
             permission_mode: "acceptEdits".to_string(),
             selected_model: Some("claude-opus-4-6".to_string()),
+            workflow_state: None,
         };
         let json = serde_json::to_string(&session).unwrap();
         assert!(json.contains("selectedModel"));
@@ -1146,5 +1157,112 @@ mod tests {
         assert_eq!(content, "hello");
         assert_eq!(thinking, None);
         assert_eq!(activities, None);
+    }
+
+    // ---- WorkflowState serde ----
+
+    #[test]
+    fn workflow_state_serde_roundtrip() {
+        let state = WorkflowState {
+            execution_id: "exec-1".to_string(),
+            workflow_name: "review-cycle".to_string(),
+            state: WorkflowExecutionState::Running,
+            current_step_index: 2,
+            current_step_name: "review".to_string(),
+            total_steps: 4,
+            step_history: vec![
+                StepHistoryEntry {
+                    step_name: "plan".to_string(),
+                    completed_at: 1000.0,
+                    result: None,
+                },
+                StepHistoryEntry {
+                    step_name: "implement".to_string(),
+                    completed_at: 1001.0,
+                    result: Some("done".to_string()),
+                },
+            ],
+            started_at: 999.0,
+            updated_at: 1001.0,
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let back: WorkflowState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.execution_id, "exec-1");
+        assert_eq!(back.workflow_name, "review-cycle");
+        assert_eq!(back.state, WorkflowExecutionState::Running);
+        assert_eq!(back.current_step_index, 2);
+        assert_eq!(back.current_step_name, "review");
+        assert_eq!(back.total_steps, 4);
+        assert_eq!(back.step_history.len(), 2);
+        assert_eq!(back.step_history[0].step_name, "plan");
+        assert_eq!(back.step_history[1].result, Some("done".to_string()));
+    }
+
+    #[test]
+    fn workflow_execution_state_failed_tagged_enum_format() {
+        let state = WorkflowExecutionState::Failed {
+            reason: "exit code 1".to_string(),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "failed");
+        assert_eq!(v["reason"], "exit code 1");
+        let back: WorkflowExecutionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, state);
+    }
+
+    #[test]
+    fn workflow_execution_state_all_variants_serde() {
+        let variants = vec![
+            WorkflowExecutionState::Running,
+            WorkflowExecutionState::WaitingApproval,
+            WorkflowExecutionState::Completed,
+            WorkflowExecutionState::Failed {
+                reason: "err".to_string(),
+            },
+            WorkflowExecutionState::Aborted,
+        ];
+        for state in variants {
+            let json = serde_json::to_string(&state).unwrap();
+            let back: WorkflowExecutionState = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, state);
+        }
+    }
+
+    #[test]
+    fn chat_session_with_workflow_state_roundtrip() {
+        let session = ChatSession {
+            id: "s1".to_string(),
+            worktree_path: "/repo".to_string(),
+            messages: vec![],
+            state: SessionState::Active,
+            created_at: 1000.0,
+            updated_at: 1001.0,
+            agent_session_id: None,
+            permission_mode: "acceptEdits".to_string(),
+            selected_model: None,
+            workflow_state: Some(WorkflowState {
+                execution_id: "exec-1".to_string(),
+                workflow_name: "test-wf".to_string(),
+                state: WorkflowExecutionState::WaitingApproval,
+                current_step_index: 1,
+                current_step_name: "review".to_string(),
+                total_steps: 3,
+                step_history: vec![StepHistoryEntry {
+                    step_name: "implement".to_string(),
+                    completed_at: 1000.5,
+                    result: None,
+                }],
+                started_at: 999.0,
+                updated_at: 1000.5,
+            }),
+        };
+        let json = serde_json::to_string(&session).unwrap();
+        assert!(json.contains("workflowState"));
+        let back: ChatSession = serde_json::from_str(&json).unwrap();
+        let ws = back.workflow_state.unwrap();
+        assert_eq!(ws.execution_id, "exec-1");
+        assert_eq!(ws.state, WorkflowExecutionState::WaitingApproval);
+        assert_eq!(ws.step_history.len(), 1);
     }
 }

--- a/src-tauri/src/session/store.rs
+++ b/src-tauri/src/session/store.rs
@@ -198,6 +198,7 @@ mod tests {
             agent_session_id: None,
             permission_mode: "acceptEdits".to_string(),
             selected_model: None,
+            workflow_state: None,
         }
     }
 

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -84,7 +84,6 @@ pub async fn start_workflow(
     engine: tauri::State<'_, Arc<WorkflowEngine>>,
     workflow_name: String,
     chat_session_id: String,
-    worktree_path: String,
 ) -> Result<(), String> {
     let dir = storage::workflows_dir();
     let workflow = tokio::task::spawn_blocking(move || {
@@ -102,9 +101,9 @@ pub async fn start_workflow(
             handles.inner(),
             workflow,
             &chat_session_id,
-            &worktree_path,
         )
         .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -124,8 +123,9 @@ pub async fn abort_workflow(
         )
         .await
         .map_err(|e| {
-            log::error!("abort_workflow failed for session {chat_session_id}: {e}");
-            e
+            let msg = e.to_string();
+            log::error!("abort_workflow failed for session {chat_session_id}: {msg}");
+            msg
         })
 }
 
@@ -155,6 +155,7 @@ pub async fn approve_workflow_step(
             decision,
         )
         .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -175,4 +176,5 @@ pub async fn complete_interactive_step(
             abort,
         )
         .await
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -1,7 +1,11 @@
+use super::engine::{ApprovalDecision, WorkflowEngine};
 use super::schema::{Summary, Workflow};
 use super::storage;
+use crate::agent_sdk::AgentProcessMap;
 use crate::config::AppConfig;
+use crate::session::{SessionStore, WorkflowState};
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
 #[tauri::command]
 pub async fn list_workflows() -> Result<Vec<Summary>, String> {
@@ -68,4 +72,107 @@ pub async fn list_prompt_templates() -> Result<Vec<Summary>, String> {
     tokio::task::spawn_blocking(move || storage::list_prompts(&dir).map_err(|e| e.to_string()))
         .await
         .map_err(|e| format!("task join error: {e}"))?
+}
+
+// ---- ワークフロー実行コマンド ----
+
+#[tauri::command]
+pub async fn start_workflow(
+    app: tauri::AppHandle,
+    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
+    session_store: tauri::State<'_, Arc<SessionStore>>,
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    workflow_name: String,
+    chat_session_id: String,
+    worktree_path: String,
+) -> Result<(), String> {
+    let dir = storage::workflows_dir();
+    let workflow = tokio::task::spawn_blocking(move || {
+        super::validation::validate_name(&workflow_name).map_err(|e| e.to_string())?;
+        let file_path = dir.join(format!("{workflow_name}.yml"));
+        storage::load_workflow(&file_path).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))??;
+
+    engine
+        .start_workflow(
+            &app,
+            session_store.inner(),
+            handles.inner(),
+            workflow,
+            &chat_session_id,
+            &worktree_path,
+        )
+        .await
+}
+
+#[tauri::command]
+pub async fn abort_workflow(
+    app: tauri::AppHandle,
+    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
+    session_store: tauri::State<'_, Arc<SessionStore>>,
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    chat_session_id: String,
+) -> Result<(), String> {
+    engine
+        .abort_workflow(
+            &app,
+            session_store.inner(),
+            handles.inner(),
+            &chat_session_id,
+        )
+        .await
+        .map_err(|e| {
+            log::error!("abort_workflow failed for session {chat_session_id}: {e}");
+            e
+        })
+}
+
+#[tauri::command]
+pub async fn get_workflow_state(
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    chat_session_id: String,
+) -> Result<Option<WorkflowState>, String> {
+    Ok(engine.get_state(&chat_session_id).await)
+}
+
+#[tauri::command]
+pub async fn approve_workflow_step(
+    app: tauri::AppHandle,
+    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
+    session_store: tauri::State<'_, Arc<SessionStore>>,
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    chat_session_id: String,
+    decision: ApprovalDecision,
+) -> Result<(), String> {
+    engine
+        .handle_approval(
+            &app,
+            session_store.inner(),
+            handles.inner(),
+            &chat_session_id,
+            decision,
+        )
+        .await
+}
+
+#[tauri::command]
+pub async fn complete_interactive_step(
+    app: tauri::AppHandle,
+    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
+    session_store: tauri::State<'_, Arc<SessionStore>>,
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    chat_session_id: String,
+    abort: bool,
+) -> Result<(), String> {
+    engine
+        .complete_interactive(
+            &app,
+            session_store.inner(),
+            handles.inner(),
+            &chat_session_id,
+            abort,
+        )
+        .await
 }

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 use regex::RegexBuilder;
@@ -11,6 +12,49 @@ use crate::agent_status::{current_timestamp, AgentStatusCenter};
 use crate::session::SessionStore;
 use crate::workflow::schema::{StepMode, TransitionRule, Workflow};
 use crate::workflow::state::{StepHistoryEntry, WorkflowExecutionState, WorkflowState};
+
+/// ワークフローエンジンのエラー型。
+#[derive(Debug)]
+pub enum WorkflowEngineError {
+    /// ワークフロー実行が見つからない
+    ExecutionNotFound(String),
+    /// セッションが見つからない
+    SessionNotFound(String),
+    /// ワークフロー定義エラー（ステップなし、ステップ未発見等）
+    InvalidWorkflow(String),
+    /// ワークフローが既にアクティブ
+    AlreadyActive(String),
+    /// 不正な状態遷移（WaitingApprovalでない時にapproval等）
+    InvalidState(String),
+    /// セッションストアのIO/シリアライズエラー
+    SessionStore(String),
+    /// AgentSession起動エラー
+    AgentSession(String),
+}
+
+impl fmt::Display for WorkflowEngineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExecutionNotFound(id) => {
+                write!(f, "No workflow execution found for session '{id}'")
+            }
+            Self::SessionNotFound(id) => write!(f, "ChatSession not found: {id}"),
+            Self::InvalidWorkflow(msg) => write!(f, "{msg}"),
+            Self::AlreadyActive(name) => {
+                write!(f, "Workflow '{name}' is already running for this session")
+            }
+            Self::InvalidState(msg) => write!(f, "{msg}"),
+            Self::SessionStore(msg) => write!(f, "{msg}"),
+            Self::AgentSession(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl From<WorkflowEngineError> for String {
+    fn from(e: WorkflowEngineError) -> Self {
+        e.to_string()
+    }
+}
 
 /// ワークフローエンジンが外部にブロードキャストするイベントペイロード。
 #[derive(Debug, Clone, Serialize)]
@@ -46,15 +90,16 @@ impl WorkflowExecution {
     fn validate_start(
         workflow: &Workflow,
         existing: Option<&WorkflowExecution>,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         if workflow.steps.is_empty() {
-            return Err("Workflow has no steps".to_string());
+            return Err(WorkflowEngineError::InvalidWorkflow(
+                "Workflow has no steps".to_string(),
+            ));
         }
         if let Some(existing) = existing {
             if existing.is_active() {
-                return Err(format!(
-                    "Workflow '{}' is already running for this session",
-                    existing.workflow.name,
+                return Err(WorkflowEngineError::AlreadyActive(
+                    existing.workflow.name.clone(),
                 ));
             }
         }
@@ -125,13 +170,21 @@ impl WorkflowExecution {
     }
 
     /// 指定ステップへの遷移時にサイクルガードを検証する（純粋関数）。
-    fn check_cycle_guard(&self, target_step_name: &str) -> Result<CycleGuardResult, String> {
+    fn check_cycle_guard(
+        &self,
+        target_step_name: &str,
+    ) -> Result<CycleGuardResult, WorkflowEngineError> {
         let idx = self
             .workflow
             .steps
             .iter()
             .position(|s| s.name == target_step_name)
-            .ok_or_else(|| format!("Step '{}' not found in workflow", target_step_name))?;
+            .ok_or_else(|| {
+                WorkflowEngineError::InvalidWorkflow(format!(
+                    "Step '{}' not found in workflow",
+                    target_step_name
+                ))
+            })?;
 
         let step = &self.workflow.steps[idx];
         if let Some(guard) = &step.cycle_guard {
@@ -182,9 +235,11 @@ impl WorkflowExecution {
     fn decide_approval_action(
         &self,
         decision: &ApprovalDecision,
-    ) -> Result<ApprovalAction, String> {
+    ) -> Result<ApprovalAction, WorkflowEngineError> {
         if self.state != WorkflowExecutionState::WaitingApproval {
-            return Err("Workflow is not waiting for approval".to_string());
+            return Err(WorkflowEngineError::InvalidState(
+                "Workflow is not waiting for approval".to_string(),
+            ));
         }
         let step = &self.workflow.steps[self.current_step_index];
         match decision {
@@ -198,13 +253,20 @@ impl WorkflowExecution {
     }
 
     /// interactiveモードの判定ロジック（純粋関数）。
-    fn decide_interactive_action(&self, abort: bool) -> Result<InteractiveAction, String> {
+    fn decide_interactive_action(
+        &self,
+        abort: bool,
+    ) -> Result<InteractiveAction, WorkflowEngineError> {
         if self.state != WorkflowExecutionState::Running {
-            return Err("Workflow is not running".to_string());
+            return Err(WorkflowEngineError::InvalidState(
+                "Workflow is not running".to_string(),
+            ));
         }
         let step = &self.workflow.steps[self.current_step_index];
         if step.mode != StepMode::Interactive {
-            return Err("Current step is not interactive mode".to_string());
+            return Err(WorkflowEngineError::InvalidState(
+                "Current step is not interactive mode".to_string(),
+            ));
         }
         if abort {
             Ok(InteractiveAction::Abort)
@@ -260,12 +322,20 @@ impl WorkflowEngine {
         handles: &Arc<Mutex<AgentProcessMap>>,
         workflow: Workflow,
         chat_session_id: &str,
-        worktree_path: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         {
             let execs = self.executions.lock().await;
             WorkflowExecution::validate_start(&workflow, execs.get(chat_session_id))?;
         }
+
+        // worktree_pathはセッションから取得（唯一のソース）
+        let data_dir = crate::session::resolve_data_dir(app)
+            .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
+        let session = session_store
+            .get_session(&data_dir, chat_session_id)
+            .map_err(|e| WorkflowEngineError::SessionStore(format!("get_session: {e}")))?
+            .ok_or_else(|| WorkflowEngineError::SessionNotFound(chat_session_id.to_string()))?;
+        let worktree_path = session.worktree_path.clone();
 
         let now = current_timestamp();
         let mut execution = WorkflowExecution {
@@ -275,7 +345,7 @@ impl WorkflowEngine {
             current_step_index: 0,
             step_execution_counts: HashMap::new(),
             step_history: Vec::new(),
-            worktree_path: worktree_path.to_string(),
+            worktree_path,
             started_at: now,
             updated_at: now,
         };
@@ -293,8 +363,24 @@ impl WorkflowEngine {
         self.broadcast_state(app, chat_session_id).await;
 
         // 最初のステップのAgentSession開始＋プロンプト送信
-        self.start_step_session(app, handles, session_store, chat_session_id)
+        // 失敗時はFailed状態に遷移して永続化する
+        if let Err(e) = self
+            .start_step_session(app, handles, session_store, chat_session_id)
             .await
+        {
+            let _ = self
+                .set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::Failed {
+                        reason: format!("Failed to start step session: {e}"),
+                    },
+                )
+                .await;
+            return Err(e);
+        }
+        Ok(())
     }
 
     /// turn_complete後に呼ばれるフック。
@@ -307,12 +393,12 @@ impl WorkflowEngine {
         chat_session_id: &str,
         exit_code: i64,
         final_parts: &[crate::session::MessagePart],
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         let action = {
             let execs = self.executions.lock().await;
-            let exec = execs
-                .get(chat_session_id)
-                .ok_or("No workflow execution found")?;
+            let exec = execs.get(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
             exec.decide_turn_complete_action(exit_code)
         };
 
@@ -367,12 +453,12 @@ impl WorkflowEngine {
         handles: &Arc<Mutex<AgentProcessMap>>,
         chat_session_id: &str,
         decision: ApprovalDecision,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         let (action, step_name) = {
             let execs = self.executions.lock().await;
-            let exec = execs
-                .get(chat_session_id)
-                .ok_or("No workflow execution found")?;
+            let exec = execs.get(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
             let action = exec.decide_approval_action(&decision)?;
             let step_name = exec.workflow.steps[exec.current_step_index].name.clone();
             (action, step_name)
@@ -442,12 +528,12 @@ impl WorkflowEngine {
         handles: &Arc<Mutex<AgentProcessMap>>,
         chat_session_id: &str,
         abort: bool,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         let (action, step_name) = {
             let execs = self.executions.lock().await;
-            let exec = execs
-                .get(chat_session_id)
-                .ok_or("No workflow execution found")?;
+            let exec = execs.get(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
             let action = exec.decide_interactive_action(abort)?;
             let step_name = exec.workflow.steps[exec.current_step_index].name.clone();
             (action, step_name)
@@ -483,12 +569,12 @@ impl WorkflowEngine {
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         chat_session_id: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         {
             let execs = self.executions.lock().await;
-            let exec = execs
-                .get(chat_session_id)
-                .ok_or("No workflow execution found")?;
+            let exec = execs.get(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
 
             // 既に終了状態なら何もしない
             if !exec.is_active() {
@@ -529,12 +615,12 @@ impl WorkflowEngine {
         session_store: &Arc<SessionStore>,
         chat_session_id: &str,
         new_state: WorkflowExecutionState,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         {
             let mut execs = self.executions.lock().await;
-            let exec = execs
-                .get_mut(chat_session_id)
-                .ok_or("No workflow execution found")?;
+            let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
             exec.state = new_state;
             exec.updated_at = current_timestamp();
         }
@@ -555,7 +641,7 @@ impl WorkflowEngine {
         final_parts: &[crate::session::MessagePart],
         rules: &[TransitionRule],
         step_name: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         // テキストパートを結合
         let text = Self::extract_text_from_parts(final_parts);
 
@@ -633,20 +719,25 @@ impl WorkflowEngine {
         handles: &Arc<Mutex<AgentProcessMap>>,
         chat_session_id: &str,
         target_step_name: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         // サイクルガードチェック + 遷移実行を1回のロックで処理
         let exceeded_info = {
             let mut execs = self.executions.lock().await;
-            let exec = execs
-                .get_mut(chat_session_id)
-                .ok_or("No workflow execution found")?;
+            let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
 
             let idx = exec
                 .workflow
                 .steps
                 .iter()
                 .position(|s| s.name == target_step_name)
-                .ok_or_else(|| format!("Step '{}' not found in workflow", target_step_name))?;
+                .ok_or_else(|| {
+                    WorkflowEngineError::InvalidWorkflow(format!(
+                        "Step '{}' not found in workflow",
+                        target_step_name
+                    ))
+                })?;
 
             let guard_result = exec.check_cycle_guard(target_step_name)?;
 
@@ -689,8 +780,24 @@ impl WorkflowEngine {
         self.broadcast_state(app, chat_session_id).await;
 
         // 次のステップのAgentSession開始＋プロンプト送信
-        self.start_step_session(app, handles, session_store, chat_session_id)
+        // 失敗時はFailed状態に遷移して永続化する
+        if let Err(e) = self
+            .start_step_session(app, handles, session_store, chat_session_id)
             .await
+        {
+            let _ = self
+                .set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::Failed {
+                        reason: format!("Failed to start step session: {e}"),
+                    },
+                )
+                .await;
+            return Err(e);
+        }
+        Ok(())
     }
 
     /// 定義順で次のステップに遷移する。最後のステップならCompletedに。
@@ -700,12 +807,12 @@ impl WorkflowEngine {
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         chat_session_id: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         let decision = {
             let execs = self.executions.lock().await;
-            let exec = execs
-                .get(chat_session_id)
-                .ok_or("No workflow execution found")?;
+            let exec = execs.get(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
             exec.decide_next_step()
         };
 
@@ -733,22 +840,22 @@ impl WorkflowEngine {
         handles: &Arc<Mutex<AgentProcessMap>>,
         session_store: &Arc<SessionStore>,
         chat_session_id: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         let (worktree_path, prompt) = {
             let execs = self.executions.lock().await;
-            let exec = execs
-                .get(chat_session_id)
-                .ok_or("No workflow execution found")?;
+            let exec = execs.get(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
             let step = &exec.workflow.steps[exec.current_step_index];
             (exec.worktree_path.clone(), step.prompt.clone())
         };
 
-        let data_dir =
-            crate::session::resolve_data_dir(app).map_err(|e| format!("resolve_data_dir: {e}"))?;
+        let data_dir = crate::session::resolve_data_dir(app)
+            .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
         let session = session_store
             .get_session(&data_dir, chat_session_id)
-            .map_err(|e| format!("get_session: {e}"))?
-            .ok_or_else(|| format!("ChatSession not found: {}", chat_session_id))?;
+            .map_err(|e| WorkflowEngineError::SessionStore(format!("get_session: {e}")))?
+            .ok_or_else(|| WorkflowEngineError::SessionNotFound(chat_session_id.to_string()))?;
         let permission_mode = session.permission_mode;
 
         // AgentSession開始
@@ -760,7 +867,8 @@ impl WorkflowEngine {
             &worktree_path,
             None,
         )
-        .await?;
+        .await
+        .map_err(WorkflowEngineError::AgentSession)?;
 
         // プロンプト送信
         crate::agent_sdk::start_agent_turn_internal(
@@ -773,6 +881,7 @@ impl WorkflowEngine {
             &prompt,
         )
         .await
+        .map_err(WorkflowEngineError::AgentSession)
     }
 
     /// AgentSessionを中断する。
@@ -819,26 +928,26 @@ impl WorkflowEngine {
         app: &tauri::AppHandle,
         session_store: &Arc<SessionStore>,
         chat_session_id: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), WorkflowEngineError> {
         let workflow_state = {
             let execs = self.executions.lock().await;
             execs.get(chat_session_id).map(|e| e.to_workflow_state())
         };
 
         let workflow_state = workflow_state
-            .ok_or_else(|| format!("No workflow execution for session '{}'", chat_session_id))?;
+            .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string()))?;
 
-        let data_dir =
-            crate::session::resolve_data_dir(app).map_err(|e| format!("resolve_data_dir: {e}"))?;
+        let data_dir = crate::session::resolve_data_dir(app)
+            .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
         let mut session = session_store
             .get_session(&data_dir, chat_session_id)
-            .map_err(|e| format!("get_session: {e}"))?
-            .ok_or_else(|| format!("ChatSession not found: {}", chat_session_id))?;
+            .map_err(|e| WorkflowEngineError::SessionStore(format!("get_session: {e}")))?
+            .ok_or_else(|| WorkflowEngineError::SessionNotFound(chat_session_id.to_string()))?;
         session.workflow_state = Some(workflow_state);
         session.updated_at = crate::session::now_timestamp();
         session_store
             .save_session(&data_dir, &session)
-            .map_err(|e| format!("save_session: {e}"))?;
+            .map_err(|e| WorkflowEngineError::SessionStore(format!("save_session: {e}")))?;
 
         Ok(())
     }
@@ -1599,7 +1708,7 @@ mod tests {
         };
         let result = WorkflowExecution::validate_start(&workflow, None);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("no steps"));
+        assert!(result.unwrap_err().to_string().contains("no steps"));
     }
 
     #[test]
@@ -1608,7 +1717,7 @@ mod tests {
         let existing = make_exec(0); // Running state
         let result = WorkflowExecution::validate_start(&workflow, Some(&existing));
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("already running"));
+        assert!(result.unwrap_err().to_string().contains("already running"));
     }
 
     #[test]

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -311,6 +311,14 @@ enum InteractiveAction {
     Abort,
 }
 
+/// ロック内で確定した遷移結果。ロック外で永続化・AgentSession起動を行うための情報を持つ。
+enum StepOutcome {
+    /// 状態を永続化・ブロードキャストするだけ（終了状態遷移など）
+    Persist(WorkflowState),
+    /// 次のステップに遷移し、AgentSession を起動する
+    TransitionAndStart(WorkflowState),
+}
+
 /// ワークフローのステップを順次実行するステートマシンエンジン。
 pub struct WorkflowEngine {
     executions: Mutex<HashMap<String, WorkflowExecution>>,
@@ -356,19 +364,20 @@ impl WorkflowEngine {
             updated_at: now,
         };
 
-        // validate_start → insert を同一ロックで原子的に実行
+        // validate_start → insert → スナップショット確定を同一ロックで原子的に実行
         let step_name = workflow.steps[0].name.clone();
-        {
+        let snapshot = {
             let mut execs = self.executions.lock().await;
             WorkflowExecution::validate_start(&workflow, execs.get(chat_session_id))?;
             execution.step_execution_counts.insert(step_name.clone(), 1);
             execs.insert(chat_session_id.to_string(), execution);
-        }
+            execs.get(chat_session_id).unwrap().to_workflow_state()
+        };
 
-        // 永続化・ブロードキャスト
-        self.persist_state(app, session_store, chat_session_id)
+        // 永続化・ブロードキャスト（ロック内で確定したスナップショットを使用）
+        self.persist_state(app, session_store, chat_session_id, snapshot.clone())
             .await?;
-        self.broadcast_state(app, chat_session_id).await;
+        self.broadcast_state(app, chat_session_id, snapshot);
 
         // 最初のステップのAgentSession開始＋プロンプト送信
         // 失敗時はFailed状態に遷移して永続化する
@@ -393,6 +402,8 @@ impl WorkflowEngine {
 
     /// turn_complete後に呼ばれるフック。
     /// autoモード→タグ検出で遷移、approvalモード→WaitingApproval、interactiveモード→何もしない。
+    /// SessionError / WaitApproval は判定 + 状態変更を1回のロックで原子的に実行する。
+    /// AutoEvaluate はタグ検出が必要なため handle_auto_complete に委譲する。
     pub async fn on_turn_complete(
         &self,
         app: &tauri::AppHandle,
@@ -402,34 +413,50 @@ impl WorkflowEngine {
         exit_code: i64,
         final_parts: &[crate::session::MessagePart],
     ) -> Result<(), WorkflowEngineError> {
-        let action = {
-            let execs = self.executions.lock().await;
-            let exec = execs.get(chat_session_id).ok_or_else(|| {
+        // 判定 + 状態変更を原子的に実行（AutoEvaluate以外）
+        let action_or_outcome = {
+            let mut execs = self.executions.lock().await;
+            let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
                 WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
             })?;
-            exec.decide_turn_complete_action(exit_code)
-        };
+            let action = exec.decide_turn_complete_action(exit_code);
 
-        match action {
-            TurnCompleteAction::NotRunning | TurnCompleteAction::Noop => Ok(()),
-            TurnCompleteAction::SessionError {
-                step_name,
-                exit_code,
-            } => {
-                self.set_execution_state(
-                    app,
-                    session_store,
-                    chat_session_id,
-                    WorkflowExecutionState::Failed {
+            match action {
+                TurnCompleteAction::NotRunning | TurnCompleteAction::Noop => return Ok(()),
+                TurnCompleteAction::SessionError {
+                    step_name,
+                    exit_code,
+                } => {
+                    if exec.is_terminal() {
+                        return Ok(());
+                    }
+                    exec.state = WorkflowExecutionState::Failed {
                         reason: format!(
                             "AgentSession error at step '{}' (exit_code: {})",
                             step_name, exit_code
                         ),
-                    },
-                )
-                .await
+                    };
+                    exec.updated_at = current_timestamp();
+                    Ok(StepOutcome::Persist(exec.to_workflow_state()))
+                }
+                TurnCompleteAction::WaitApproval => {
+                    if exec.is_terminal() {
+                        return Ok(());
+                    }
+                    exec.state = WorkflowExecutionState::WaitingApproval;
+                    exec.updated_at = current_timestamp();
+                    Ok(StepOutcome::Persist(exec.to_workflow_state()))
+                }
+                TurnCompleteAction::AutoEvaluate { rules, step_name } => Err((rules, step_name)),
             }
-            TurnCompleteAction::AutoEvaluate { rules, step_name } => {
+        };
+
+        match action_or_outcome {
+            Ok(outcome) => {
+                self.execute_outcome(app, session_store, handles, chat_session_id, outcome)
+                    .await
+            }
+            Err((rules, step_name)) => {
                 self.handle_auto_complete(
                     app,
                     session_store,
@@ -441,19 +468,12 @@ impl WorkflowEngine {
                 )
                 .await
             }
-            TurnCompleteAction::WaitApproval => {
-                self.set_execution_state(
-                    app,
-                    session_store,
-                    chat_session_id,
-                    WorkflowExecutionState::WaitingApproval,
-                )
-                .await
-            }
         }
     }
 
     /// approvalモードでのユーザー判定を処理する。
+    /// 判定 + 状態変更 + 履歴記録を1回のロックで原子的に実行し、
+    /// ロック外では永続化・ブロードキャスト・AgentSession起動のみ行う。
     pub async fn handle_approval(
         &self,
         app: &tauri::AppHandle,
@@ -462,73 +482,64 @@ impl WorkflowEngine {
         chat_session_id: &str,
         decision: ApprovalDecision,
     ) -> Result<(), WorkflowEngineError> {
-        let (action, step_name) = {
-            let execs = self.executions.lock().await;
-            let exec = execs.get(chat_session_id).ok_or_else(|| {
-                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
-            })?;
-            let action = exec.decide_approval_action(&decision)?;
-            let step_name = exec.workflow.steps[exec.current_step_index].name.clone();
-            (action, step_name)
-        };
-
         let result_tag = match &decision {
             ApprovalDecision::Approve => "approve",
             ApprovalDecision::Reject => "reject",
             ApprovalDecision::Abort => "abort",
         };
 
-        match action {
-            ApprovalAction::Advance => {
-                self.record_step_completion(
-                    chat_session_id,
-                    &step_name,
-                    Some(result_tag.to_string()),
-                )
-                .await;
-                self.advance_to_next(app, session_store, handles, chat_session_id)
-                    .await
-            }
-            ApprovalAction::TransitionTo(target) => {
-                self.record_step_completion(
-                    chat_session_id,
-                    &step_name,
-                    Some(result_tag.to_string()),
-                )
-                .await;
-                self.transition_to_step(app, session_store, handles, chat_session_id, &target)
-                    .await
-            }
-            ApprovalAction::FailedNoRejectRule(name) => {
-                self.record_step_completion(
-                    chat_session_id,
-                    &step_name,
-                    Some(result_tag.to_string()),
-                )
-                .await;
-                self.set_execution_state(
-                    app,
-                    session_store,
-                    chat_session_id,
-                    WorkflowExecutionState::Failed {
+        // 判定 + 状態変更 + 履歴記録を原子的に実行
+        let outcome = {
+            let mut execs = self.executions.lock().await;
+            let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
+            let action = exec.decide_approval_action(&decision)?;
+            let step_name = exec.workflow.steps[exec.current_step_index].name.clone();
+
+            match action {
+                ApprovalAction::Advance => {
+                    exec.step_history.push(StepHistoryEntry {
+                        step_name,
+                        completed_at: current_timestamp(),
+                        result: Some(result_tag.to_string()),
+                    });
+                    Self::apply_advance(exec)
+                }
+                ApprovalAction::TransitionTo(target) => {
+                    exec.step_history.push(StepHistoryEntry {
+                        step_name,
+                        completed_at: current_timestamp(),
+                        result: Some(result_tag.to_string()),
+                    });
+                    Self::apply_transition(exec, &target)?
+                }
+                ApprovalAction::FailedNoRejectRule(name) => {
+                    exec.step_history.push(StepHistoryEntry {
+                        step_name,
+                        completed_at: current_timestamp(),
+                        result: Some(result_tag.to_string()),
+                    });
+                    exec.state = WorkflowExecutionState::Failed {
                         reason: format!("No reject rule defined for step '{}'", name),
-                    },
-                )
-                .await
+                    };
+                    exec.updated_at = current_timestamp();
+                    StepOutcome::Persist(exec.to_workflow_state())
+                }
+                ApprovalAction::Abort => {
+                    exec.state = WorkflowExecutionState::Aborted;
+                    exec.updated_at = current_timestamp();
+                    StepOutcome::Persist(exec.to_workflow_state())
+                }
             }
-            ApprovalAction::Abort => {
-                self.set_execution_state(
-                    app,
-                    session_store,
-                    chat_session_id,
-                    WorkflowExecutionState::Aborted,
-                )
-                .await
-            }
-        }
+        };
+
+        self.execute_outcome(app, session_store, handles, chat_session_id, outcome)
+            .await
     }
 
     /// interactiveモードの完了/中止を処理する。
+    /// 判定 + 状態変更 + 履歴記録を1回のロックで原子的に実行する。
     pub async fn complete_interactive(
         &self,
         app: &tauri::AppHandle,
@@ -537,37 +548,33 @@ impl WorkflowEngine {
         chat_session_id: &str,
         abort: bool,
     ) -> Result<(), WorkflowEngineError> {
-        let (action, step_name) = {
-            let execs = self.executions.lock().await;
-            let exec = execs.get(chat_session_id).ok_or_else(|| {
+        let outcome = {
+            let mut execs = self.executions.lock().await;
+            let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
                 WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
             })?;
             let action = exec.decide_interactive_action(abort)?;
             let step_name = exec.workflow.steps[exec.current_step_index].name.clone();
-            (action, step_name)
+
+            match action {
+                InteractiveAction::Abort => {
+                    exec.state = WorkflowExecutionState::Aborted;
+                    exec.updated_at = current_timestamp();
+                    StepOutcome::Persist(exec.to_workflow_state())
+                }
+                InteractiveAction::Advance => {
+                    exec.step_history.push(StepHistoryEntry {
+                        step_name,
+                        completed_at: current_timestamp(),
+                        result: Some("complete".to_string()),
+                    });
+                    Self::apply_advance(exec)
+                }
+            }
         };
 
-        match action {
-            InteractiveAction::Abort => {
-                self.set_execution_state(
-                    app,
-                    session_store,
-                    chat_session_id,
-                    WorkflowExecutionState::Aborted,
-                )
-                .await
-            }
-            InteractiveAction::Advance => {
-                self.record_step_completion(
-                    chat_session_id,
-                    &step_name,
-                    Some("complete".to_string()),
-                )
-                .await;
-                self.advance_to_next(app, session_store, handles, chat_session_id)
-                    .await
-            }
-        }
+        self.execute_outcome(app, session_store, handles, chat_session_id, outcome)
+            .await
     }
 
     /// ワークフローを中断する。
@@ -624,7 +631,7 @@ impl WorkflowEngine {
         chat_session_id: &str,
         new_state: WorkflowExecutionState,
     ) -> Result<(), WorkflowEngineError> {
-        {
+        let snapshot = {
             let mut execs = self.executions.lock().await;
             let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
                 WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
@@ -635,14 +642,16 @@ impl WorkflowEngine {
             }
             exec.state = new_state;
             exec.updated_at = current_timestamp();
-        }
-        self.persist_state(app, session_store, chat_session_id)
+            exec.to_workflow_state()
+        };
+        self.persist_state(app, session_store, chat_session_id, snapshot.clone())
             .await?;
-        self.broadcast_state(app, chat_session_id).await;
+        self.broadcast_state(app, chat_session_id, snapshot);
         Ok(())
     }
 
     /// autoモードのタグ検出結果を処理する。
+    /// 判定 + 状態変更 + 履歴記録を1回のロックで原子的に実行する。
     #[allow(clippy::too_many_arguments)]
     async fn handle_auto_complete(
         &self,
@@ -654,38 +663,55 @@ impl WorkflowEngine {
         rules: &[TransitionRule],
         step_name: &str,
     ) -> Result<(), WorkflowEngineError> {
-        // テキストパートを結合
+        // テキストパートを結合（ロック外で完了）
         let text = Self::extract_text_from_parts(final_parts);
 
-        if rules.is_empty() {
-            // ルールがない場合は定義順で次のステップに遷移
-            self.record_step_completion(chat_session_id, step_name, None)
-                .await;
-            return self
-                .advance_to_next(app, session_store, handles, chat_session_id)
-                .await;
-        }
+        // タグ検出もロック外で完了（純粋関数）
+        let rule_match = if rules.is_empty() {
+            None // ルールなし → 定義順で次へ
+        } else {
+            Some(Self::evaluate_auto_rules(&text, rules))
+        };
 
-        // タグ検出
-        match Self::evaluate_auto_rules(&text, rules) {
-            Some((next_step, matched_rule)) => {
-                self.record_step_completion(chat_session_id, step_name, Some(matched_rule))
-                    .await;
-                self.transition_to_step(app, session_store, handles, chat_session_id, &next_step)
-                    .await
-            }
-            None => {
-                self.set_execution_state(
-                    app,
-                    session_store,
-                    chat_session_id,
-                    WorkflowExecutionState::Failed {
+        // 判定 + 状態変更 + 履歴記録を原子的に実行
+        let outcome = {
+            let mut execs = self.executions.lock().await;
+            let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
+            })?;
+
+            match rule_match {
+                None => {
+                    // ルールなし → 定義順で次へ
+                    exec.step_history.push(StepHistoryEntry {
+                        step_name: step_name.to_string(),
+                        completed_at: current_timestamp(),
+                        result: None,
+                    });
+                    Self::apply_advance(exec)
+                }
+                Some(Some((next_step, matched_rule))) => {
+                    // ルールマッチ → 指定ステップへ遷移
+                    exec.step_history.push(StepHistoryEntry {
+                        step_name: step_name.to_string(),
+                        completed_at: current_timestamp(),
+                        result: Some(matched_rule),
+                    });
+                    Self::apply_transition(exec, &next_step)?
+                }
+                Some(None) => {
+                    // マッチなし → Failed
+                    exec.state = WorkflowExecutionState::Failed {
                         reason: format!("No matching rule found for step '{}' output", step_name),
-                    },
-                )
-                .await
+                    };
+                    exec.updated_at = current_timestamp();
+                    StepOutcome::Persist(exec.to_workflow_state())
+                }
             }
-        }
+        };
+
+        self.execute_outcome(app, session_store, handles, chat_session_id, outcome)
+            .await
     }
 
     /// autoモードのタグ検出。rulesの定義順で最初にマッチしたルールを返す。
@@ -721,133 +747,6 @@ impl WorkflowEngine {
             }
         }
         text
-    }
-
-    /// 指定ステップに遷移する（サイクルガード検証含む）。
-    async fn transition_to_step(
-        &self,
-        app: &tauri::AppHandle,
-        session_store: &Arc<SessionStore>,
-        handles: &Arc<Mutex<AgentProcessMap>>,
-        chat_session_id: &str,
-        target_step_name: &str,
-    ) -> Result<(), WorkflowEngineError> {
-        // サイクルガードチェック + 遷移実行を1回のロックで処理
-        let exceeded_info = {
-            let mut execs = self.executions.lock().await;
-            let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
-                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
-            })?;
-
-            // 終了状態（Completed/Failed/Aborted）からの遷移を防止
-            if exec.is_terminal() {
-                return Ok(());
-            }
-
-            let idx = exec
-                .workflow
-                .steps
-                .iter()
-                .position(|s| s.name == target_step_name)
-                .ok_or_else(|| {
-                    WorkflowEngineError::InvalidWorkflow(format!(
-                        "Step '{}' not found in workflow",
-                        target_step_name
-                    ))
-                })?;
-
-            let guard_result = exec.check_cycle_guard(target_step_name)?;
-
-            match guard_result {
-                CycleGuardResult::Exceeded {
-                    max_iterations,
-                    count,
-                } => Some((max_iterations, count)),
-                CycleGuardResult::Allowed => {
-                    exec.current_step_index = idx;
-                    exec.state = WorkflowExecutionState::Running;
-                    *exec
-                        .step_execution_counts
-                        .entry(target_step_name.to_string())
-                        .or_insert(0) += 1;
-                    exec.updated_at = current_timestamp();
-                    None
-                }
-            }
-        };
-
-        if let Some((max_iterations, count)) = exceeded_info {
-            return self
-                .set_execution_state(
-                    app,
-                    session_store,
-                    chat_session_id,
-                    WorkflowExecutionState::Failed {
-                        reason: format!(
-                            "Cycle guard exceeded for step '{}': max_iterations={}, executed={}",
-                            target_step_name, max_iterations, count
-                        ),
-                    },
-                )
-                .await;
-        }
-
-        self.persist_state(app, session_store, chat_session_id)
-            .await?;
-        self.broadcast_state(app, chat_session_id).await;
-
-        // 次のステップのAgentSession開始＋プロンプト送信
-        // 失敗時はFailed状態に遷移して永続化する
-        if let Err(e) = self
-            .start_step_session(app, handles, session_store, chat_session_id)
-            .await
-        {
-            let _ = self
-                .set_execution_state(
-                    app,
-                    session_store,
-                    chat_session_id,
-                    WorkflowExecutionState::Failed {
-                        reason: format!("Failed to start step session: {e}"),
-                    },
-                )
-                .await;
-            return Err(e);
-        }
-        Ok(())
-    }
-
-    /// 定義順で次のステップに遷移する。最後のステップならCompletedに。
-    async fn advance_to_next(
-        &self,
-        app: &tauri::AppHandle,
-        session_store: &Arc<SessionStore>,
-        handles: &Arc<Mutex<AgentProcessMap>>,
-        chat_session_id: &str,
-    ) -> Result<(), WorkflowEngineError> {
-        let decision = {
-            let execs = self.executions.lock().await;
-            let exec = execs.get(chat_session_id).ok_or_else(|| {
-                WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
-            })?;
-            exec.decide_next_step()
-        };
-
-        match decision {
-            NextStepDecision::Completed => {
-                self.set_execution_state(
-                    app,
-                    session_store,
-                    chat_session_id,
-                    WorkflowExecutionState::Completed,
-                )
-                .await
-            }
-            NextStepDecision::TransitionTo(name) => {
-                self.transition_to_step(app, session_store, handles, chat_session_id, &name)
-                    .await
-            }
-        }
     }
 
     /// 現在のステップのAgentSessionを開始し、プロンプトを送信する。
@@ -922,38 +821,134 @@ impl WorkflowEngine {
         }
     }
 
-    /// ステップ完了を履歴に記録する。
-    async fn record_step_completion(
+    /// ロック内で次ステップへの advance を適用する（純粋な状態変更）。
+    /// `&self` を使わないため関連関数として定義。
+    fn apply_advance(exec: &mut WorkflowExecution) -> StepOutcome {
+        let decision = exec.decide_next_step();
+        match decision {
+            NextStepDecision::Completed => {
+                exec.state = WorkflowExecutionState::Completed;
+                exec.updated_at = current_timestamp();
+                StepOutcome::Persist(exec.to_workflow_state())
+            }
+            NextStepDecision::TransitionTo(name) => {
+                let idx = exec
+                    .workflow
+                    .steps
+                    .iter()
+                    .position(|s| s.name == name)
+                    .expect("decide_next_step returned unknown step");
+                exec.current_step_index = idx;
+                exec.state = WorkflowExecutionState::Running;
+                *exec.step_execution_counts.entry(name).or_insert(0) += 1;
+                exec.updated_at = current_timestamp();
+                StepOutcome::TransitionAndStart(exec.to_workflow_state())
+            }
+        }
+    }
+
+    /// ロック内で指定ステップへの遷移を適用する（サイクルガード検証含む）。
+    /// `&self` を使わないため関連関数として定義。
+    fn apply_transition(
+        exec: &mut WorkflowExecution,
+        target_step_name: &str,
+    ) -> Result<StepOutcome, WorkflowEngineError> {
+        if exec.is_terminal() {
+            return Ok(StepOutcome::Persist(exec.to_workflow_state()));
+        }
+
+        let idx = exec
+            .workflow
+            .steps
+            .iter()
+            .position(|s| s.name == target_step_name)
+            .ok_or_else(|| {
+                WorkflowEngineError::InvalidWorkflow(format!(
+                    "Step '{}' not found in workflow",
+                    target_step_name
+                ))
+            })?;
+
+        let guard_result = exec.check_cycle_guard(target_step_name)?;
+        match guard_result {
+            CycleGuardResult::Exceeded {
+                max_iterations,
+                count,
+            } => {
+                exec.state = WorkflowExecutionState::Failed {
+                    reason: format!(
+                        "Cycle guard exceeded for step '{}': max_iterations={}, executed={}",
+                        target_step_name, max_iterations, count
+                    ),
+                };
+                exec.updated_at = current_timestamp();
+                Ok(StepOutcome::Persist(exec.to_workflow_state()))
+            }
+            CycleGuardResult::Allowed => {
+                exec.current_step_index = idx;
+                exec.state = WorkflowExecutionState::Running;
+                *exec
+                    .step_execution_counts
+                    .entry(target_step_name.to_string())
+                    .or_insert(0) += 1;
+                exec.updated_at = current_timestamp();
+                Ok(StepOutcome::TransitionAndStart(exec.to_workflow_state()))
+            }
+        }
+    }
+
+    /// ロック外でStepOutcomeに応じた副作用（永続化・ブロードキャスト・AgentSession起動）を実行する。
+    async fn execute_outcome(
         &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
         chat_session_id: &str,
-        step_name: &str,
-        result: Option<String>,
-    ) {
-        let mut execs = self.executions.lock().await;
-        if let Some(exec) = execs.get_mut(chat_session_id) {
-            exec.step_history.push(StepHistoryEntry {
-                step_name: step_name.to_string(),
-                completed_at: current_timestamp(),
-                result,
-            });
+        outcome: StepOutcome,
+    ) -> Result<(), WorkflowEngineError> {
+        match outcome {
+            StepOutcome::Persist(snapshot) => {
+                self.persist_state(app, session_store, chat_session_id, snapshot.clone())
+                    .await?;
+                self.broadcast_state(app, chat_session_id, snapshot);
+                Ok(())
+            }
+            StepOutcome::TransitionAndStart(snapshot) => {
+                self.persist_state(app, session_store, chat_session_id, snapshot.clone())
+                    .await?;
+                self.broadcast_state(app, chat_session_id, snapshot);
+
+                // AgentSession起動。失敗時はFailed状態に遷移。
+                if let Err(e) = self
+                    .start_step_session(app, handles, session_store, chat_session_id)
+                    .await
+                {
+                    let _ = self
+                        .set_execution_state(
+                            app,
+                            session_store,
+                            chat_session_id,
+                            WorkflowExecutionState::Failed {
+                                reason: format!("Failed to start step session: {e}"),
+                            },
+                        )
+                        .await;
+                    return Err(e);
+                }
+                Ok(())
+            }
         }
     }
 
     /// ワークフロー状態をChatSessionに永続化する。
+    /// スナップショットは呼び出し元がロック内で確定したものを受け取る。
     async fn persist_state(
         &self,
         app: &tauri::AppHandle,
         session_store: &Arc<SessionStore>,
         chat_session_id: &str,
+        workflow_state: WorkflowState,
     ) -> Result<(), WorkflowEngineError> {
-        let workflow_state = {
-            let execs = self.executions.lock().await;
-            execs.get(chat_session_id).map(|e| e.to_workflow_state())
-        };
-
-        let workflow_state = workflow_state
-            .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string()))?;
-
         let data_dir = crate::session::resolve_data_dir(app)
             .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
         let mut session = session_store
@@ -970,29 +965,30 @@ impl WorkflowEngine {
     }
 
     /// ワークフロー状態をブロードキャストする。
-    async fn broadcast_state(&self, app: &tauri::AppHandle, chat_session_id: &str) {
-        let payload = {
-            let execs = self.executions.lock().await;
-            execs.get(chat_session_id).map(|e| WorkflowStatePayload {
-                chat_session_id: chat_session_id.to_string(),
-                workflow_state: e.to_workflow_state(),
-            })
+    /// スナップショットは呼び出し元がロック内で確定したものを受け取る。
+    fn broadcast_state(
+        &self,
+        app: &tauri::AppHandle,
+        chat_session_id: &str,
+        workflow_state: WorkflowState,
+    ) {
+        let payload = WorkflowStatePayload {
+            chat_session_id: chat_session_id.to_string(),
+            workflow_state,
         };
 
-        if let Some(payload) = payload {
-            let center: Option<tauri::State<'_, Arc<AgentStatusCenter>>> =
-                app.try_state::<Arc<AgentStatusCenter>>();
-            if let Some(center) = center {
-                // ワークフロー状態変更イベントを emit
-                center.emit_workflow_state_changed(&payload);
+        let center: Option<tauri::State<'_, Arc<AgentStatusCenter>>> =
+            app.try_state::<Arc<AgentStatusCenter>>();
+        if let Some(center) = center {
+            // ワークフロー状態変更イベントを emit
+            center.emit_workflow_state_changed(&payload);
 
-                // SessionStatusのworkflowフィールドも更新
-                if let Some(mut status) = center.get_session(chat_session_id) {
-                    status.workflow_step = Some(payload.workflow_state.current_step_name.clone());
-                    status.workflow_execution_state =
-                        Some(payload.workflow_state.state.as_str().to_string());
-                    center.update_session(status);
-                }
+            // SessionStatusのworkflowフィールドも更新
+            if let Some(mut status) = center.get_session(chat_session_id) {
+                status.workflow_step = Some(payload.workflow_state.current_step_name.clone());
+                status.workflow_execution_state =
+                    Some(payload.workflow_state.state.as_str().to_string());
+                center.update_session(status);
             }
         }
     }

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -1,0 +1,1629 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use regex::RegexBuilder;
+use serde::Serialize;
+use tauri::Manager;
+use tokio::sync::Mutex;
+
+use crate::agent_sdk::AgentProcessMap;
+use crate::agent_status::{current_timestamp, AgentStatusCenter};
+use crate::session::SessionStore;
+use crate::workflow::schema::{StepMode, TransitionRule, Workflow};
+use crate::workflow::state::{StepHistoryEntry, WorkflowExecutionState, WorkflowState};
+
+/// ワークフローエンジンが外部にブロードキャストするイベントペイロード。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowStatePayload {
+    pub chat_session_id: String,
+    pub workflow_state: WorkflowState,
+}
+
+/// ワークフロー実行の内部状態。
+struct WorkflowExecution {
+    id: String,
+    workflow: Workflow,
+    state: WorkflowExecutionState,
+    current_step_index: usize,
+    step_execution_counts: HashMap<String, u32>,
+    step_history: Vec<StepHistoryEntry>,
+    worktree_path: String,
+    started_at: f64,
+    updated_at: f64,
+}
+
+impl WorkflowExecution {
+    /// ワークフローが実行中（Running または WaitingApproval）かどうかを返す。
+    fn is_active(&self) -> bool {
+        matches!(
+            self.state,
+            WorkflowExecutionState::Running | WorkflowExecutionState::WaitingApproval
+        )
+    }
+
+    /// ワークフロー開始の事前条件を検証する（純粋関数）。
+    fn validate_start(
+        workflow: &Workflow,
+        existing: Option<&WorkflowExecution>,
+    ) -> Result<(), String> {
+        if workflow.steps.is_empty() {
+            return Err("Workflow has no steps".to_string());
+        }
+        if let Some(existing) = existing {
+            if existing.is_active() {
+                return Err(format!(
+                    "Workflow '{}' is already running for this session",
+                    existing.workflow.name,
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// 次のステップ遷移の判定結果。
+#[derive(Debug, Clone, PartialEq)]
+enum NextStepDecision {
+    /// ワークフロー完了（最後のステップを超えた）
+    Completed,
+    /// 指定ステップへ遷移
+    TransitionTo(String),
+}
+
+/// サイクルガード検証結果。
+#[derive(Debug, Clone, PartialEq)]
+enum CycleGuardResult {
+    /// 許可（ガードなし or 上限内）
+    Allowed,
+    /// 超過
+    Exceeded { max_iterations: u32, count: u32 },
+}
+
+/// on_turn_complete後のモード別アクション判定結果。
+#[derive(Debug, Clone, PartialEq)]
+enum TurnCompleteAction {
+    /// AgentSessionがエラー終了 → Failed
+    SessionError { step_name: String, exit_code: i64 },
+    /// autoモード → タグ検出して遷移
+    AutoEvaluate {
+        rules: Vec<TransitionRule>,
+        step_name: String,
+    },
+    /// approvalモード → WaitingApproval
+    WaitApproval,
+    /// interactiveモード → 何もしない
+    Noop,
+    /// ワークフローが実行中でない → 何もしない
+    NotRunning,
+}
+
+impl WorkflowExecution {
+    /// 永続化用の `WorkflowState` に変換する。
+    fn to_workflow_state(&self) -> WorkflowState {
+        WorkflowState {
+            execution_id: self.id.clone(),
+            workflow_name: self.workflow.name.clone(),
+            state: self.state.clone(),
+            current_step_index: self.current_step_index,
+            current_step_name: self.workflow.steps[self.current_step_index].name.clone(),
+            total_steps: self.workflow.steps.len(),
+            step_history: self.step_history.clone(),
+            started_at: self.started_at,
+            updated_at: self.updated_at,
+        }
+    }
+
+    /// 次のステップ遷移先を判定する（純粋関数）。
+    fn decide_next_step(&self) -> NextStepDecision {
+        let current_index = self.current_step_index;
+        if current_index + 1 >= self.workflow.steps.len() {
+            NextStepDecision::Completed
+        } else {
+            NextStepDecision::TransitionTo(self.workflow.steps[current_index + 1].name.clone())
+        }
+    }
+
+    /// 指定ステップへの遷移時にサイクルガードを検証する（純粋関数）。
+    fn check_cycle_guard(&self, target_step_name: &str) -> Result<CycleGuardResult, String> {
+        let idx = self
+            .workflow
+            .steps
+            .iter()
+            .position(|s| s.name == target_step_name)
+            .ok_or_else(|| format!("Step '{}' not found in workflow", target_step_name))?;
+
+        let step = &self.workflow.steps[idx];
+        if let Some(guard) = &step.cycle_guard {
+            let count = self
+                .step_execution_counts
+                .get(target_step_name)
+                .copied()
+                .unwrap_or(0);
+            if count >= guard.max_iterations {
+                Ok(CycleGuardResult::Exceeded {
+                    max_iterations: guard.max_iterations,
+                    count,
+                })
+            } else {
+                Ok(CycleGuardResult::Allowed)
+            }
+        } else {
+            Ok(CycleGuardResult::Allowed)
+        }
+    }
+
+    /// turn_complete後のアクションを判定する（純粋関数）。
+    fn decide_turn_complete_action(&self, exit_code: i64) -> TurnCompleteAction {
+        if self.state != WorkflowExecutionState::Running {
+            return TurnCompleteAction::NotRunning;
+        }
+
+        let step = &self.workflow.steps[self.current_step_index];
+
+        if exit_code != 0 {
+            return TurnCompleteAction::SessionError {
+                step_name: step.name.clone(),
+                exit_code,
+            };
+        }
+
+        match step.mode {
+            StepMode::Auto => TurnCompleteAction::AutoEvaluate {
+                rules: step.rules.clone(),
+                step_name: step.name.clone(),
+            },
+            StepMode::Approval => TurnCompleteAction::WaitApproval,
+            StepMode::Interactive => TurnCompleteAction::Noop,
+        }
+    }
+
+    /// approvalモードの判定ロジック（純粋関数）。
+    fn decide_approval_action(
+        &self,
+        decision: &ApprovalDecision,
+    ) -> Result<ApprovalAction, String> {
+        if self.state != WorkflowExecutionState::WaitingApproval {
+            return Err("Workflow is not waiting for approval".to_string());
+        }
+        let step = &self.workflow.steps[self.current_step_index];
+        match decision {
+            ApprovalDecision::Approve => Ok(ApprovalAction::Advance),
+            ApprovalDecision::Reject => match step.rules.iter().find(|r| r.r#match == "reject") {
+                Some(r) => Ok(ApprovalAction::TransitionTo(r.next.clone())),
+                None => Ok(ApprovalAction::FailedNoRejectRule(step.name.clone())),
+            },
+            ApprovalDecision::Abort => Ok(ApprovalAction::Abort),
+        }
+    }
+
+    /// interactiveモードの判定ロジック（純粋関数）。
+    fn decide_interactive_action(&self, abort: bool) -> Result<InteractiveAction, String> {
+        if self.state != WorkflowExecutionState::Running {
+            return Err("Workflow is not running".to_string());
+        }
+        let step = &self.workflow.steps[self.current_step_index];
+        if step.mode != StepMode::Interactive {
+            return Err("Current step is not interactive mode".to_string());
+        }
+        if abort {
+            Ok(InteractiveAction::Abort)
+        } else {
+            Ok(InteractiveAction::Advance)
+        }
+    }
+}
+
+/// approvalモードのユーザー判定。
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalDecision {
+    Approve,
+    Reject,
+    Abort,
+}
+
+/// approvalモードの判定結果（純粋関数用）。
+#[derive(Debug, Clone, PartialEq)]
+enum ApprovalAction {
+    Advance,
+    TransitionTo(String),
+    Abort,
+    FailedNoRejectRule(String),
+}
+
+/// interactiveモードの判定結果（純粋関数用）。
+#[derive(Debug, Clone, PartialEq)]
+enum InteractiveAction {
+    Advance,
+    Abort,
+}
+
+/// ワークフローのステップを順次実行するステートマシンエンジン。
+pub struct WorkflowEngine {
+    executions: Mutex<HashMap<String, WorkflowExecution>>,
+}
+
+impl WorkflowEngine {
+    pub fn new() -> Self {
+        Self {
+            executions: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// ワークフローを開始する。
+    /// ChatSessionは既に作成済みの前提で、最初のステップのプロンプトを送信する。
+    pub async fn start_workflow(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        workflow: Workflow,
+        chat_session_id: &str,
+        worktree_path: &str,
+    ) -> Result<(), String> {
+        {
+            let execs = self.executions.lock().await;
+            WorkflowExecution::validate_start(&workflow, execs.get(chat_session_id))?;
+        }
+
+        let now = current_timestamp();
+        let mut execution = WorkflowExecution {
+            id: uuid::Uuid::new_v4().to_string(),
+            workflow: workflow.clone(),
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: worktree_path.to_string(),
+            started_at: now,
+            updated_at: now,
+        };
+
+        let step_name = workflow.steps[0].name.clone();
+        {
+            let mut execs = self.executions.lock().await;
+            execution.step_execution_counts.insert(step_name.clone(), 1);
+            execs.insert(chat_session_id.to_string(), execution);
+        }
+
+        // 永続化・ブロードキャスト
+        self.persist_state(app, session_store, chat_session_id)
+            .await?;
+        self.broadcast_state(app, chat_session_id).await;
+
+        // 最初のステップのAgentSession開始＋プロンプト送信
+        self.start_step_session(app, handles, session_store, chat_session_id)
+            .await
+    }
+
+    /// turn_complete後に呼ばれるフック。
+    /// autoモード→タグ検出で遷移、approvalモード→WaitingApproval、interactiveモード→何もしない。
+    pub async fn on_turn_complete(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        chat_session_id: &str,
+        exit_code: i64,
+        final_parts: &[crate::session::MessagePart],
+    ) -> Result<(), String> {
+        let action = {
+            let execs = self.executions.lock().await;
+            let exec = execs
+                .get(chat_session_id)
+                .ok_or("No workflow execution found")?;
+            exec.decide_turn_complete_action(exit_code)
+        };
+
+        match action {
+            TurnCompleteAction::NotRunning | TurnCompleteAction::Noop => Ok(()),
+            TurnCompleteAction::SessionError {
+                step_name,
+                exit_code,
+            } => {
+                self.set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::Failed {
+                        reason: format!(
+                            "AgentSession error at step '{}' (exit_code: {})",
+                            step_name, exit_code
+                        ),
+                    },
+                )
+                .await
+            }
+            TurnCompleteAction::AutoEvaluate { rules, step_name } => {
+                self.handle_auto_complete(
+                    app,
+                    session_store,
+                    handles,
+                    chat_session_id,
+                    final_parts,
+                    &rules,
+                    &step_name,
+                )
+                .await
+            }
+            TurnCompleteAction::WaitApproval => {
+                self.set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::WaitingApproval,
+                )
+                .await
+            }
+        }
+    }
+
+    /// approvalモードでのユーザー判定を処理する。
+    pub async fn handle_approval(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        chat_session_id: &str,
+        decision: ApprovalDecision,
+    ) -> Result<(), String> {
+        let (action, step_name) = {
+            let execs = self.executions.lock().await;
+            let exec = execs
+                .get(chat_session_id)
+                .ok_or("No workflow execution found")?;
+            let action = exec.decide_approval_action(&decision)?;
+            let step_name = exec.workflow.steps[exec.current_step_index].name.clone();
+            (action, step_name)
+        };
+
+        let result_tag = match &decision {
+            ApprovalDecision::Approve => "approve",
+            ApprovalDecision::Reject => "reject",
+            ApprovalDecision::Abort => "abort",
+        };
+
+        match action {
+            ApprovalAction::Advance => {
+                self.record_step_completion(
+                    chat_session_id,
+                    &step_name,
+                    Some(result_tag.to_string()),
+                )
+                .await;
+                self.advance_to_next(app, session_store, handles, chat_session_id)
+                    .await
+            }
+            ApprovalAction::TransitionTo(target) => {
+                self.record_step_completion(
+                    chat_session_id,
+                    &step_name,
+                    Some(result_tag.to_string()),
+                )
+                .await;
+                self.transition_to_step(app, session_store, handles, chat_session_id, &target)
+                    .await
+            }
+            ApprovalAction::FailedNoRejectRule(name) => {
+                self.record_step_completion(
+                    chat_session_id,
+                    &step_name,
+                    Some(result_tag.to_string()),
+                )
+                .await;
+                self.set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::Failed {
+                        reason: format!("No reject rule defined for step '{}'", name),
+                    },
+                )
+                .await
+            }
+            ApprovalAction::Abort => {
+                self.set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::Aborted,
+                )
+                .await
+            }
+        }
+    }
+
+    /// interactiveモードの完了/中止を処理する。
+    pub async fn complete_interactive(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        chat_session_id: &str,
+        abort: bool,
+    ) -> Result<(), String> {
+        let (action, step_name) = {
+            let execs = self.executions.lock().await;
+            let exec = execs
+                .get(chat_session_id)
+                .ok_or("No workflow execution found")?;
+            let action = exec.decide_interactive_action(abort)?;
+            let step_name = exec.workflow.steps[exec.current_step_index].name.clone();
+            (action, step_name)
+        };
+
+        match action {
+            InteractiveAction::Abort => {
+                self.set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::Aborted,
+                )
+                .await
+            }
+            InteractiveAction::Advance => {
+                self.record_step_completion(
+                    chat_session_id,
+                    &step_name,
+                    Some("complete".to_string()),
+                )
+                .await;
+                self.advance_to_next(app, session_store, handles, chat_session_id)
+                    .await
+            }
+        }
+    }
+
+    /// ワークフローを中断する。
+    pub async fn abort_workflow(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        chat_session_id: &str,
+    ) -> Result<(), String> {
+        {
+            let execs = self.executions.lock().await;
+            let exec = execs
+                .get(chat_session_id)
+                .ok_or("No workflow execution found")?;
+
+            // 既に終了状態なら何もしない
+            if !exec.is_active() {
+                return Ok(());
+            }
+        }
+
+        // 実行中のAgentSessionを中断
+        self.interrupt_agent(handles, chat_session_id).await;
+
+        self.set_execution_state(
+            app,
+            session_store,
+            chat_session_id,
+            WorkflowExecutionState::Aborted,
+        )
+        .await
+    }
+
+    /// 状態取得。
+    pub async fn get_state(&self, chat_session_id: &str) -> Option<WorkflowState> {
+        let execs = self.executions.lock().await;
+        execs.get(chat_session_id).map(|e| e.to_workflow_state())
+    }
+
+    /// chat_session_idがワークフロー実行中かどうか。
+    pub async fn is_running(&self, chat_session_id: &str) -> bool {
+        let execs = self.executions.lock().await;
+        execs.get(chat_session_id).is_some_and(|e| e.is_active())
+    }
+
+    // ---- 内部メソッド ----
+
+    /// 実行状態を更新し、永続化・ブロードキャストする。
+    async fn set_execution_state(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        chat_session_id: &str,
+        new_state: WorkflowExecutionState,
+    ) -> Result<(), String> {
+        {
+            let mut execs = self.executions.lock().await;
+            let exec = execs
+                .get_mut(chat_session_id)
+                .ok_or("No workflow execution found")?;
+            exec.state = new_state;
+            exec.updated_at = current_timestamp();
+        }
+        self.persist_state(app, session_store, chat_session_id)
+            .await?;
+        self.broadcast_state(app, chat_session_id).await;
+        Ok(())
+    }
+
+    /// autoモードのタグ検出結果を処理する。
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_auto_complete(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        chat_session_id: &str,
+        final_parts: &[crate::session::MessagePart],
+        rules: &[TransitionRule],
+        step_name: &str,
+    ) -> Result<(), String> {
+        // テキストパートを結合
+        let text = Self::extract_text_from_parts(final_parts);
+
+        if rules.is_empty() {
+            // ルールがない場合は定義順で次のステップに遷移
+            self.record_step_completion(chat_session_id, step_name, None)
+                .await;
+            return self
+                .advance_to_next(app, session_store, handles, chat_session_id)
+                .await;
+        }
+
+        // タグ検出
+        match Self::evaluate_auto_rules(&text, rules) {
+            Some((next_step, matched_rule)) => {
+                self.record_step_completion(chat_session_id, step_name, Some(matched_rule))
+                    .await;
+                self.transition_to_step(app, session_store, handles, chat_session_id, &next_step)
+                    .await
+            }
+            None => {
+                self.set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::Failed {
+                        reason: format!("No matching rule found for step '{}' output", step_name),
+                    },
+                )
+                .await
+            }
+        }
+    }
+
+    /// autoモードのタグ検出。rulesの定義順で最初にマッチしたルールを返す。
+    fn evaluate_auto_rules(text: &str, rules: &[TransitionRule]) -> Option<(String, String)> {
+        for rule in rules {
+            match RegexBuilder::new(&rule.r#match).size_limit(1 << 20).build() {
+                Ok(re) => {
+                    if re.is_match(text) {
+                        return Some((rule.next.clone(), rule.r#match.clone()));
+                    }
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Invalid regex pattern '{}' in transition rule (next='{}'): {e}",
+                        rule.r#match,
+                        rule.next
+                    );
+                }
+            }
+        }
+        None
+    }
+
+    /// MessagePartからテキストを抽出して結合する。
+    fn extract_text_from_parts(parts: &[crate::session::MessagePart]) -> String {
+        let mut text = String::new();
+        for part in parts {
+            if let crate::session::MessagePart::Text { content, .. } = part {
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(content);
+            }
+        }
+        text
+    }
+
+    /// 指定ステップに遷移する（サイクルガード検証含む）。
+    async fn transition_to_step(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        chat_session_id: &str,
+        target_step_name: &str,
+    ) -> Result<(), String> {
+        // サイクルガードチェック + 遷移実行を1回のロックで処理
+        let exceeded_info = {
+            let mut execs = self.executions.lock().await;
+            let exec = execs
+                .get_mut(chat_session_id)
+                .ok_or("No workflow execution found")?;
+
+            let idx = exec
+                .workflow
+                .steps
+                .iter()
+                .position(|s| s.name == target_step_name)
+                .ok_or_else(|| format!("Step '{}' not found in workflow", target_step_name))?;
+
+            let guard_result = exec.check_cycle_guard(target_step_name)?;
+
+            match guard_result {
+                CycleGuardResult::Exceeded {
+                    max_iterations,
+                    count,
+                } => Some((max_iterations, count)),
+                CycleGuardResult::Allowed => {
+                    exec.current_step_index = idx;
+                    exec.state = WorkflowExecutionState::Running;
+                    *exec
+                        .step_execution_counts
+                        .entry(target_step_name.to_string())
+                        .or_insert(0) += 1;
+                    exec.updated_at = current_timestamp();
+                    None
+                }
+            }
+        };
+
+        if let Some((max_iterations, count)) = exceeded_info {
+            return self
+                .set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::Failed {
+                        reason: format!(
+                            "Cycle guard exceeded for step '{}': max_iterations={}, executed={}",
+                            target_step_name, max_iterations, count
+                        ),
+                    },
+                )
+                .await;
+        }
+
+        self.persist_state(app, session_store, chat_session_id)
+            .await?;
+        self.broadcast_state(app, chat_session_id).await;
+
+        // 次のステップのAgentSession開始＋プロンプト送信
+        self.start_step_session(app, handles, session_store, chat_session_id)
+            .await
+    }
+
+    /// 定義順で次のステップに遷移する。最後のステップならCompletedに。
+    async fn advance_to_next(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        chat_session_id: &str,
+    ) -> Result<(), String> {
+        let decision = {
+            let execs = self.executions.lock().await;
+            let exec = execs
+                .get(chat_session_id)
+                .ok_or("No workflow execution found")?;
+            exec.decide_next_step()
+        };
+
+        match decision {
+            NextStepDecision::Completed => {
+                self.set_execution_state(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    WorkflowExecutionState::Completed,
+                )
+                .await
+            }
+            NextStepDecision::TransitionTo(name) => {
+                self.transition_to_step(app, session_store, handles, chat_session_id, &name)
+                    .await
+            }
+        }
+    }
+
+    /// 現在のステップのAgentSessionを開始し、プロンプトを送信する。
+    async fn start_step_session(
+        &self,
+        app: &tauri::AppHandle,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        session_store: &Arc<SessionStore>,
+        chat_session_id: &str,
+    ) -> Result<(), String> {
+        let (worktree_path, prompt) = {
+            let execs = self.executions.lock().await;
+            let exec = execs
+                .get(chat_session_id)
+                .ok_or("No workflow execution found")?;
+            let step = &exec.workflow.steps[exec.current_step_index];
+            (exec.worktree_path.clone(), step.prompt.clone())
+        };
+
+        let data_dir =
+            crate::session::resolve_data_dir(app).map_err(|e| format!("resolve_data_dir: {e}"))?;
+        let session = session_store
+            .get_session(&data_dir, chat_session_id)
+            .map_err(|e| format!("get_session: {e}"))?
+            .ok_or_else(|| format!("ChatSession not found: {}", chat_session_id))?;
+        let permission_mode = session.permission_mode;
+
+        // AgentSession開始
+        crate::agent_sdk::start_agent_session_internal(
+            app,
+            handles,
+            session_store,
+            chat_session_id,
+            &worktree_path,
+            None,
+        )
+        .await?;
+
+        // プロンプト送信
+        crate::agent_sdk::start_agent_turn_internal(
+            app,
+            handles,
+            session_store,
+            chat_session_id,
+            &worktree_path,
+            &permission_mode,
+            &prompt,
+        )
+        .await
+    }
+
+    /// AgentSessionを中断する。
+    async fn interrupt_agent(&self, handles: &Arc<Mutex<AgentProcessMap>>, chat_session_id: &str) {
+        use tokio::io::AsyncWriteExt;
+
+        let mut map = handles.lock().await;
+        if let Some(proc) = map.get_mut(chat_session_id) {
+            if let Err(e) = proc.stdin.write_all(b"{\"type\":\"interrupt\"}\n").await {
+                log::warn!(
+                    "Failed to write interrupt for session '{}': {e}",
+                    chat_session_id
+                );
+            }
+            if let Err(e) = proc.stdin.flush().await {
+                log::warn!(
+                    "Failed to flush interrupt for session '{}': {e}",
+                    chat_session_id
+                );
+            }
+        }
+    }
+
+    /// ステップ完了を履歴に記録する。
+    async fn record_step_completion(
+        &self,
+        chat_session_id: &str,
+        step_name: &str,
+        result: Option<String>,
+    ) {
+        let mut execs = self.executions.lock().await;
+        if let Some(exec) = execs.get_mut(chat_session_id) {
+            exec.step_history.push(StepHistoryEntry {
+                step_name: step_name.to_string(),
+                completed_at: current_timestamp(),
+                result,
+            });
+        }
+    }
+
+    /// ワークフロー状態をChatSessionに永続化する。
+    async fn persist_state(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &Arc<SessionStore>,
+        chat_session_id: &str,
+    ) -> Result<(), String> {
+        let workflow_state = {
+            let execs = self.executions.lock().await;
+            execs.get(chat_session_id).map(|e| e.to_workflow_state())
+        };
+
+        let workflow_state = workflow_state
+            .ok_or_else(|| format!("No workflow execution for session '{}'", chat_session_id))?;
+
+        let data_dir =
+            crate::session::resolve_data_dir(app).map_err(|e| format!("resolve_data_dir: {e}"))?;
+        let mut session = session_store
+            .get_session(&data_dir, chat_session_id)
+            .map_err(|e| format!("get_session: {e}"))?
+            .ok_or_else(|| format!("ChatSession not found: {}", chat_session_id))?;
+        session.workflow_state = Some(workflow_state);
+        session.updated_at = crate::session::now_timestamp();
+        session_store
+            .save_session(&data_dir, &session)
+            .map_err(|e| format!("save_session: {e}"))?;
+
+        Ok(())
+    }
+
+    /// ワークフロー状態をブロードキャストする。
+    async fn broadcast_state(&self, app: &tauri::AppHandle, chat_session_id: &str) {
+        let payload = {
+            let execs = self.executions.lock().await;
+            execs.get(chat_session_id).map(|e| WorkflowStatePayload {
+                chat_session_id: chat_session_id.to_string(),
+                workflow_state: e.to_workflow_state(),
+            })
+        };
+
+        if let Some(payload) = payload {
+            let center: Option<tauri::State<'_, Arc<AgentStatusCenter>>> =
+                app.try_state::<Arc<AgentStatusCenter>>();
+            if let Some(center) = center {
+                // ワークフロー状態変更イベントを emit
+                center.emit_workflow_state_changed(&payload);
+
+                // SessionStatusのworkflowフィールドも更新
+                if let Some(mut status) = center.get_session(chat_session_id) {
+                    status.workflow_step = Some(payload.workflow_state.current_step_name.clone());
+                    status.workflow_execution_state =
+                        Some(payload.workflow_state.state.as_str().to_string());
+                    center.update_session(status);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::MessagePart;
+    use crate::workflow::schema::{CycleGuard, Step, StepMode, TransitionRule, Workflow};
+
+    // ---- evaluate_auto_rules ----
+
+    #[test]
+    fn evaluate_auto_rules_matches_first_rule() {
+        let rules = vec![
+            TransitionRule {
+                r#match: "NEEDS_FIX".to_string(),
+                next: "implement".to_string(),
+            },
+            TransitionRule {
+                r#match: "LGTM".to_string(),
+                next: "report".to_string(),
+            },
+        ];
+
+        let text = "<decision>NEEDS_FIX</decision>";
+        let result = WorkflowEngine::evaluate_auto_rules(text, &rules);
+        assert_eq!(
+            result,
+            Some(("implement".to_string(), "NEEDS_FIX".to_string()))
+        );
+    }
+
+    #[test]
+    fn evaluate_auto_rules_matches_second_rule() {
+        let rules = vec![
+            TransitionRule {
+                r#match: "NEEDS_FIX".to_string(),
+                next: "implement".to_string(),
+            },
+            TransitionRule {
+                r#match: "LGTM".to_string(),
+                next: "report".to_string(),
+            },
+        ];
+
+        let text = "<decision>LGTM</decision>";
+        let result = WorkflowEngine::evaluate_auto_rules(text, &rules);
+        assert_eq!(result, Some(("report".to_string(), "LGTM".to_string())));
+    }
+
+    #[test]
+    fn evaluate_auto_rules_no_match_returns_none() {
+        let rules = vec![
+            TransitionRule {
+                r#match: "NEEDS_FIX".to_string(),
+                next: "implement".to_string(),
+            },
+            TransitionRule {
+                r#match: "LGTM".to_string(),
+                next: "report".to_string(),
+            },
+        ];
+
+        let text = "The code looks okay but needs minor refactoring";
+        let result = WorkflowEngine::evaluate_auto_rules(text, &rules);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn evaluate_auto_rules_first_match_wins() {
+        let rules = vec![
+            TransitionRule {
+                r#match: "FIX".to_string(),
+                next: "implement".to_string(),
+            },
+            TransitionRule {
+                r#match: "NEEDS_FIX".to_string(),
+                next: "review".to_string(),
+            },
+        ];
+
+        // Both "FIX" and "NEEDS_FIX" match, but first rule wins
+        let text = "<decision>NEEDS_FIX</decision>";
+        let result = WorkflowEngine::evaluate_auto_rules(text, &rules);
+        assert_eq!(result, Some(("implement".to_string(), "FIX".to_string())));
+    }
+
+    #[test]
+    fn evaluate_auto_rules_regex_pattern() {
+        let rules = vec![TransitionRule {
+            r#match: r"<decision>(LGTM|APPROVED)</decision>".to_string(),
+            next: "report".to_string(),
+        }];
+
+        let text = "Review complete. <decision>APPROVED</decision>";
+        let result = WorkflowEngine::evaluate_auto_rules(text, &rules);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().0, "report");
+    }
+
+    // ---- extract_text_from_parts ----
+
+    #[test]
+    fn extract_text_from_parts_combines_text_parts() {
+        let parts = vec![
+            MessagePart::Thinking {
+                content: "thinking...".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::Text {
+                content: "First line".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::Text {
+                content: "Second line".to_string(),
+                parent_tool_use_id: None,
+            },
+        ];
+
+        let text = WorkflowEngine::extract_text_from_parts(&parts);
+        assert_eq!(text, "First line\nSecond line");
+    }
+
+    #[test]
+    fn extract_text_from_parts_empty() {
+        let parts: Vec<MessagePart> = vec![];
+        let text = WorkflowEngine::extract_text_from_parts(&parts);
+        assert_eq!(text, "");
+    }
+
+    // ---- WorkflowExecution ----
+
+    fn make_test_workflow() -> Workflow {
+        Workflow {
+            name: "test-workflow".to_string(),
+            description: "Test workflow".to_string(),
+            builtin: false,
+            steps: vec![
+                Step {
+                    name: "plan".to_string(),
+                    mode: StepMode::Interactive,
+                    prompt: "Plan the work".to_string(),
+                    rules: vec![],
+                    cycle_guard: None,
+                },
+                Step {
+                    name: "implement".to_string(),
+                    mode: StepMode::Auto,
+                    prompt: "Implement the plan".to_string(),
+                    rules: vec![],
+                    cycle_guard: None,
+                },
+                Step {
+                    name: "review".to_string(),
+                    mode: StepMode::Auto,
+                    prompt: "Review the implementation".to_string(),
+                    rules: vec![
+                        TransitionRule {
+                            r#match: "NEEDS_FIX".to_string(),
+                            next: "implement".to_string(),
+                        },
+                        TransitionRule {
+                            r#match: "LGTM".to_string(),
+                            next: "report".to_string(),
+                        },
+                    ],
+                    cycle_guard: Some(CycleGuard { max_iterations: 3 }),
+                },
+                Step {
+                    name: "report".to_string(),
+                    mode: StepMode::Approval,
+                    prompt: "Generate report".to_string(),
+                    rules: vec![TransitionRule {
+                        r#match: "reject".to_string(),
+                        next: "implement".to_string(),
+                    }],
+                    cycle_guard: None,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn workflow_execution_to_workflow_state() {
+        let workflow = make_test_workflow();
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow,
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+        };
+
+        let state = exec.to_workflow_state();
+        assert_eq!(state.execution_id, "exec-1");
+        assert_eq!(state.workflow_name, "test-workflow");
+        assert_eq!(state.state, WorkflowExecutionState::Running);
+        assert_eq!(state.current_step_index, 0);
+        assert_eq!(state.current_step_name, "plan");
+        assert_eq!(state.total_steps, 4);
+        assert!(state.step_history.is_empty());
+    }
+
+    // ---- is_active ----
+
+    #[test]
+    fn is_active_running() {
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_test_workflow(),
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+        };
+        assert!(exec.is_active());
+    }
+
+    #[test]
+    fn is_active_waiting_approval() {
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_test_workflow(),
+            state: WorkflowExecutionState::WaitingApproval,
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+        };
+        assert!(exec.is_active());
+    }
+
+    #[test]
+    fn is_active_completed() {
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_test_workflow(),
+            state: WorkflowExecutionState::Completed,
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+        };
+        assert!(!exec.is_active());
+    }
+
+    #[test]
+    fn is_active_failed() {
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_test_workflow(),
+            state: WorkflowExecutionState::Failed {
+                reason: "err".to_string(),
+            },
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+        };
+        assert!(!exec.is_active());
+    }
+
+    #[test]
+    fn is_active_aborted() {
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_test_workflow(),
+            state: WorkflowExecutionState::Aborted,
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+        };
+        assert!(!exec.is_active());
+    }
+
+    // ---- to_workflow_state: all state variants ----
+
+    #[test]
+    fn to_workflow_state_waiting_approval() {
+        let workflow = make_test_workflow();
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow,
+            state: WorkflowExecutionState::WaitingApproval,
+            current_step_index: 3,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1001.0,
+        };
+        let ws = exec.to_workflow_state();
+        assert_eq!(ws.state, WorkflowExecutionState::WaitingApproval);
+        assert_eq!(ws.current_step_name, "report");
+        assert_eq!(ws.current_step_index, 3);
+    }
+
+    #[test]
+    fn to_workflow_state_failed() {
+        let workflow = make_test_workflow();
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow,
+            state: WorkflowExecutionState::Failed {
+                reason: "exit code 1".to_string(),
+            },
+            current_step_index: 1,
+            step_execution_counts: HashMap::new(),
+            step_history: vec![StepHistoryEntry {
+                step_name: "plan".to_string(),
+                completed_at: 1000.5,
+                result: None,
+            }],
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1001.0,
+        };
+        let ws = exec.to_workflow_state();
+        assert_eq!(
+            ws.state,
+            WorkflowExecutionState::Failed {
+                reason: "exit code 1".to_string()
+            }
+        );
+        assert_eq!(ws.current_step_name, "implement");
+        assert_eq!(ws.step_history.len(), 1);
+    }
+
+    #[test]
+    fn to_workflow_state_aborted() {
+        let workflow = make_test_workflow();
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow,
+            state: WorkflowExecutionState::Aborted,
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1001.0,
+        };
+        let ws = exec.to_workflow_state();
+        assert_eq!(ws.state, WorkflowExecutionState::Aborted);
+    }
+
+    #[test]
+    fn to_workflow_state_completed() {
+        let workflow = make_test_workflow();
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow,
+            state: WorkflowExecutionState::Completed,
+            current_step_index: 3,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1002.0,
+        };
+        let ws = exec.to_workflow_state();
+        assert_eq!(ws.state, WorkflowExecutionState::Completed);
+        assert_eq!(ws.total_steps, 4);
+    }
+
+    // ---- evaluate_auto_rules: boundary cases ----
+
+    #[test]
+    fn evaluate_auto_rules_empty_rules() {
+        let rules: Vec<TransitionRule> = vec![];
+        let result = WorkflowEngine::evaluate_auto_rules("any text", &rules);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn evaluate_auto_rules_invalid_regex_skipped() {
+        let rules = vec![
+            TransitionRule {
+                r#match: "[invalid".to_string(),
+                next: "bad".to_string(),
+            },
+            TransitionRule {
+                r#match: "LGTM".to_string(),
+                next: "report".to_string(),
+            },
+        ];
+        let result = WorkflowEngine::evaluate_auto_rules("LGTM", &rules);
+        assert_eq!(result, Some(("report".to_string(), "LGTM".to_string())));
+    }
+
+    #[test]
+    fn evaluate_auto_rules_all_invalid_regex_returns_none() {
+        let rules = vec![TransitionRule {
+            r#match: "[invalid".to_string(),
+            next: "bad".to_string(),
+        }];
+        let result = WorkflowEngine::evaluate_auto_rules("anything", &rules);
+        assert_eq!(result, None);
+    }
+
+    // ---- cycle_guard: boundary value at exactly max_iterations ----
+
+    #[test]
+    fn check_cycle_guard_at_boundary_minus_one_allowed() {
+        let mut exec = make_exec(2); // review (max_iterations=3)
+        exec.step_execution_counts.insert("review".to_string(), 2);
+        assert_eq!(
+            exec.check_cycle_guard("review").unwrap(),
+            CycleGuardResult::Allowed
+        );
+    }
+
+    #[test]
+    fn check_cycle_guard_at_exact_boundary_exceeded() {
+        let mut exec = make_exec(2); // review (max_iterations=3)
+        exec.step_execution_counts.insert("review".to_string(), 3);
+        assert_eq!(
+            exec.check_cycle_guard("review").unwrap(),
+            CycleGuardResult::Exceeded {
+                max_iterations: 3,
+                count: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn cycle_guard_no_guard_defined() {
+        let workflow = make_test_workflow();
+        let step = &workflow.steps[0]; // plan (no cycle_guard)
+        assert!(step.cycle_guard.is_none());
+    }
+
+    // ---- decide_next_step ----
+
+    fn make_exec(step_index: usize) -> WorkflowExecution {
+        WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_test_workflow(),
+            state: WorkflowExecutionState::Running,
+            current_step_index: step_index,
+            step_execution_counts: HashMap::new(),
+            step_history: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+        }
+    }
+
+    #[test]
+    fn decide_next_step_returns_next_step_name() {
+        let exec = make_exec(0); // plan → next is implement
+        assert_eq!(
+            exec.decide_next_step(),
+            NextStepDecision::TransitionTo("implement".to_string())
+        );
+    }
+
+    #[test]
+    fn decide_next_step_returns_completed_at_last_step() {
+        let exec = make_exec(3); // report (last)
+        assert_eq!(exec.decide_next_step(), NextStepDecision::Completed);
+    }
+
+    #[test]
+    fn decide_next_step_middle_step() {
+        let exec = make_exec(1); // implement → next is review
+        assert_eq!(
+            exec.decide_next_step(),
+            NextStepDecision::TransitionTo("review".to_string())
+        );
+    }
+
+    // ---- check_cycle_guard ----
+
+    #[test]
+    fn check_cycle_guard_allowed_no_guard() {
+        let exec = make_exec(0);
+        assert_eq!(
+            exec.check_cycle_guard("plan").unwrap(),
+            CycleGuardResult::Allowed
+        );
+    }
+
+    #[test]
+    fn check_cycle_guard_allowed_within_limit() {
+        let mut exec = make_exec(2);
+        exec.step_execution_counts.insert("review".to_string(), 2);
+        assert_eq!(
+            exec.check_cycle_guard("review").unwrap(),
+            CycleGuardResult::Allowed
+        );
+    }
+
+    #[test]
+    fn check_cycle_guard_exceeded() {
+        let mut exec = make_exec(2);
+        exec.step_execution_counts.insert("review".to_string(), 3);
+        assert_eq!(
+            exec.check_cycle_guard("review").unwrap(),
+            CycleGuardResult::Exceeded {
+                max_iterations: 3,
+                count: 3
+            }
+        );
+    }
+
+    #[test]
+    fn check_cycle_guard_step_not_found() {
+        let exec = make_exec(0);
+        assert!(exec.check_cycle_guard("nonexistent").is_err());
+    }
+
+    #[test]
+    fn check_cycle_guard_first_transition_no_count() {
+        // step_execution_counts にキーなし = 初回遷移
+        let exec = make_exec(2); // review has cycle_guard(max_iterations=3)
+        assert_eq!(
+            exec.check_cycle_guard("review").unwrap(),
+            CycleGuardResult::Allowed
+        );
+    }
+
+    // ---- decide_turn_complete_action ----
+
+    #[test]
+    fn turn_complete_action_not_running() {
+        let mut exec = make_exec(0);
+        exec.state = WorkflowExecutionState::Completed;
+        assert_eq!(
+            exec.decide_turn_complete_action(0),
+            TurnCompleteAction::NotRunning
+        );
+    }
+
+    #[test]
+    fn turn_complete_action_session_error() {
+        let exec = make_exec(0); // plan (interactive)
+        assert_eq!(
+            exec.decide_turn_complete_action(1),
+            TurnCompleteAction::SessionError {
+                step_name: "plan".to_string(),
+                exit_code: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn turn_complete_action_auto_evaluate() {
+        let exec = make_exec(2); // review (auto, has rules)
+        let action = exec.decide_turn_complete_action(0);
+        match action {
+            TurnCompleteAction::AutoEvaluate { rules, step_name } => {
+                assert_eq!(step_name, "review");
+                assert_eq!(rules.len(), 2);
+                assert_eq!(rules[0].r#match, "NEEDS_FIX");
+                assert_eq!(rules[1].r#match, "LGTM");
+            }
+            other => panic!("Expected AutoEvaluate, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn turn_complete_action_wait_approval() {
+        let exec = make_exec(3); // report (approval)
+        assert_eq!(
+            exec.decide_turn_complete_action(0),
+            TurnCompleteAction::WaitApproval
+        );
+    }
+
+    #[test]
+    fn turn_complete_action_interactive_noop() {
+        let exec = make_exec(0); // plan (interactive)
+        assert_eq!(
+            exec.decide_turn_complete_action(0),
+            TurnCompleteAction::Noop
+        );
+    }
+
+    #[test]
+    fn turn_complete_action_waiting_approval_state_returns_not_running() {
+        let mut exec = make_exec(3);
+        exec.state = WorkflowExecutionState::WaitingApproval;
+        assert_eq!(
+            exec.decide_turn_complete_action(0),
+            TurnCompleteAction::NotRunning
+        );
+    }
+
+    #[test]
+    fn turn_complete_action_negative_exit_code() {
+        let exec = make_exec(0); // plan (interactive)
+        assert_eq!(
+            exec.decide_turn_complete_action(-1),
+            TurnCompleteAction::SessionError {
+                step_name: "plan".to_string(),
+                exit_code: -1,
+            }
+        );
+    }
+
+    #[test]
+    fn turn_complete_action_auto_no_rules_returns_auto_evaluate_empty() {
+        let exec = make_exec(1); // implement (auto, no rules)
+        let action = exec.decide_turn_complete_action(0);
+        match action {
+            TurnCompleteAction::AutoEvaluate { rules, step_name } => {
+                assert_eq!(step_name, "implement");
+                assert!(rules.is_empty());
+            }
+            other => panic!("Expected AutoEvaluate with empty rules, got {:?}", other),
+        }
+    }
+
+    // ---- decide_approval_action ----
+
+    #[test]
+    fn decide_approval_action_approve() {
+        let mut exec = make_exec(3); // report (approval)
+        exec.state = WorkflowExecutionState::WaitingApproval;
+        assert_eq!(
+            exec.decide_approval_action(&ApprovalDecision::Approve)
+                .unwrap(),
+            ApprovalAction::Advance
+        );
+    }
+
+    #[test]
+    fn decide_approval_action_reject_with_rule() {
+        let mut exec = make_exec(3); // report (approval, reject→implement)
+        exec.state = WorkflowExecutionState::WaitingApproval;
+        assert_eq!(
+            exec.decide_approval_action(&ApprovalDecision::Reject)
+                .unwrap(),
+            ApprovalAction::TransitionTo("implement".to_string())
+        );
+    }
+
+    #[test]
+    fn decide_approval_action_reject_no_rule() {
+        let mut exec = make_exec(0); // plan (interactive, no reject rule)
+        exec.state = WorkflowExecutionState::WaitingApproval;
+        assert_eq!(
+            exec.decide_approval_action(&ApprovalDecision::Reject)
+                .unwrap(),
+            ApprovalAction::FailedNoRejectRule("plan".to_string())
+        );
+    }
+
+    #[test]
+    fn decide_approval_action_abort() {
+        let mut exec = make_exec(3); // report (approval)
+        exec.state = WorkflowExecutionState::WaitingApproval;
+        assert_eq!(
+            exec.decide_approval_action(&ApprovalDecision::Abort)
+                .unwrap(),
+            ApprovalAction::Abort
+        );
+    }
+
+    #[test]
+    fn decide_approval_action_not_waiting() {
+        let exec = make_exec(3); // report, state=Running
+        assert!(exec
+            .decide_approval_action(&ApprovalDecision::Approve)
+            .is_err());
+    }
+
+    // ---- decide_interactive_action ----
+
+    #[test]
+    fn decide_interactive_action_complete() {
+        let exec = make_exec(0); // plan (interactive, state=Running)
+        assert_eq!(
+            exec.decide_interactive_action(false).unwrap(),
+            InteractiveAction::Advance
+        );
+    }
+
+    #[test]
+    fn decide_interactive_action_abort() {
+        let exec = make_exec(0); // plan (interactive, state=Running)
+        assert_eq!(
+            exec.decide_interactive_action(true).unwrap(),
+            InteractiveAction::Abort
+        );
+    }
+
+    #[test]
+    fn decide_interactive_action_not_running() {
+        let mut exec = make_exec(0);
+        exec.state = WorkflowExecutionState::Completed;
+        assert!(exec.decide_interactive_action(false).is_err());
+    }
+
+    #[test]
+    fn decide_interactive_action_wrong_mode() {
+        let exec = make_exec(1); // implement (auto mode, state=Running)
+        assert!(exec.decide_interactive_action(false).is_err());
+    }
+
+    // ---- validate_start ----
+
+    #[test]
+    fn validate_start_empty_steps_returns_err() {
+        let workflow = Workflow {
+            name: "empty".to_string(),
+            description: String::new(),
+            builtin: false,
+            steps: vec![],
+        };
+        let result = WorkflowExecution::validate_start(&workflow, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("no steps"));
+    }
+
+    #[test]
+    fn validate_start_active_workflow_returns_err() {
+        let workflow = make_test_workflow();
+        let existing = make_exec(0); // Running state
+        let result = WorkflowExecution::validate_start(&workflow, Some(&existing));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("already running"));
+    }
+
+    #[test]
+    fn validate_start_completed_workflow_allows_restart() {
+        let workflow = make_test_workflow();
+        let mut existing = make_exec(0);
+        existing.state = WorkflowExecutionState::Completed;
+        let result = WorkflowExecution::validate_start(&workflow, Some(&existing));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_start_no_existing_returns_ok() {
+        let workflow = make_test_workflow();
+        let result = WorkflowExecution::validate_start(&workflow, None);
+        assert!(result.is_ok());
+    }
+}

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -86,6 +86,16 @@ impl WorkflowExecution {
         )
     }
 
+    /// ワークフローが終了状態（Completed / Failed / Aborted）かどうかを返す。
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self.state,
+            WorkflowExecutionState::Completed
+                | WorkflowExecutionState::Failed { .. }
+                | WorkflowExecutionState::Aborted
+        )
+    }
+
     /// ワークフロー開始の事前条件を検証する（純粋関数）。
     fn validate_start(
         workflow: &Workflow,
@@ -323,12 +333,8 @@ impl WorkflowEngine {
         workflow: Workflow,
         chat_session_id: &str,
     ) -> Result<(), WorkflowEngineError> {
-        {
-            let execs = self.executions.lock().await;
-            WorkflowExecution::validate_start(&workflow, execs.get(chat_session_id))?;
-        }
-
         // worktree_pathはセッションから取得（唯一のソース）
+        // ロック前に非同期I/Oを完了させる
         let data_dir = crate::session::resolve_data_dir(app)
             .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
         let session = session_store
@@ -350,9 +356,11 @@ impl WorkflowEngine {
             updated_at: now,
         };
 
+        // validate_start → insert を同一ロックで原子的に実行
         let step_name = workflow.steps[0].name.clone();
         {
             let mut execs = self.executions.lock().await;
+            WorkflowExecution::validate_start(&workflow, execs.get(chat_session_id))?;
             execution.step_execution_counts.insert(step_name.clone(), 1);
             execs.insert(chat_session_id.to_string(), execution);
         }
@@ -621,6 +629,10 @@ impl WorkflowEngine {
             let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
                 WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
             })?;
+            // 終了状態（Completed/Failed/Aborted）からの上書きを防止
+            if exec.is_terminal() {
+                return Ok(());
+            }
             exec.state = new_state;
             exec.updated_at = current_timestamp();
         }
@@ -726,6 +738,11 @@ impl WorkflowEngine {
             let exec = execs.get_mut(chat_session_id).ok_or_else(|| {
                 WorkflowEngineError::ExecutionNotFound(chat_session_id.to_string())
             })?;
+
+            // 終了状態（Completed/Failed/Aborted）からの遷移を防止
+            if exec.is_terminal() {
+                return Ok(());
+            }
 
             let idx = exec
                 .workflow
@@ -1734,5 +1751,43 @@ mod tests {
         let workflow = make_test_workflow();
         let result = WorkflowExecution::validate_start(&workflow, None);
         assert!(result.is_ok());
+    }
+
+    // ---- is_terminal ----
+
+    #[test]
+    fn is_terminal_completed() {
+        let mut exec = make_exec(0);
+        exec.state = WorkflowExecutionState::Completed;
+        assert!(exec.is_terminal());
+    }
+
+    #[test]
+    fn is_terminal_failed() {
+        let mut exec = make_exec(0);
+        exec.state = WorkflowExecutionState::Failed {
+            reason: "err".to_string(),
+        };
+        assert!(exec.is_terminal());
+    }
+
+    #[test]
+    fn is_terminal_aborted() {
+        let mut exec = make_exec(0);
+        exec.state = WorkflowExecutionState::Aborted;
+        assert!(exec.is_terminal());
+    }
+
+    #[test]
+    fn is_terminal_running_is_false() {
+        let exec = make_exec(0);
+        assert!(!exec.is_terminal());
+    }
+
+    #[test]
+    fn is_terminal_waiting_approval_is_false() {
+        let mut exec = make_exec(0);
+        exec.state = WorkflowExecutionState::WaitingApproval;
+        assert!(!exec.is_terminal());
     }
 }

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -1,6 +1,8 @@
 pub mod builtin;
 pub mod commands;
+pub mod engine;
 pub mod prompt_schema;
 pub mod schema;
+pub mod state;
 pub mod storage;
 pub mod validation;

--- a/src-tauri/src/workflow/state.rs
+++ b/src-tauri/src/workflow/state.rs
@@ -1,0 +1,45 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowState {
+    pub execution_id: String,
+    pub workflow_name: String,
+    pub state: WorkflowExecutionState,
+    pub current_step_index: usize,
+    pub current_step_name: String,
+    pub total_steps: usize,
+    pub step_history: Vec<StepHistoryEntry>,
+    pub started_at: f64,
+    pub updated_at: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum WorkflowExecutionState {
+    Running,
+    WaitingApproval,
+    Completed,
+    Failed { reason: String },
+    Aborted,
+}
+
+impl WorkflowExecutionState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::WaitingApproval => "waiting_approval",
+            Self::Completed => "completed",
+            Self::Failed { .. } => "failed",
+            Self::Aborted => "aborted",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StepHistoryEntry {
+    pub step_name: String,
+    pub completed_at: f64,
+    pub result: Option<String>,
+}

--- a/src-tauri/src/workflow/storage.rs
+++ b/src-tauri/src/workflow/storage.rs
@@ -140,7 +140,10 @@ fn list_yml_summaries<T, E: fmt::Display>(
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) == Some("yml") {
             let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-                log::warn!("{label}読み込みスキップ: {}: 無効なファイル名", path.display());
+                log::warn!(
+                    "{label}読み込みスキップ: {}: 無効なファイル名",
+                    path.display()
+                );
                 continue;
             };
             match loader(&path) {


### PR DESCRIPTION
## Summary
- YAMLワークフロー定義に基づきステップを順次実行するステートマシンエンジン（`workflow/engine.rs`）を新規実装
- auto（タグ検出遷移）/ approval（人間判定）/ interactive（対話型）の3モード対応
- サイクルガード、AgentSession委譲、状態永続化、AgentStatusCenterによるリアルタイムブロードキャスト

## Test plan
- [x] `cargo fmt --check` PASS
- [x] `cargo clippy -- -D warnings` PASS
- [x] `cargo test` 846テスト全PASS
- [ ] autoモードでタグ検出→ルールベース遷移の動作確認
- [ ] approvalモードで一時停止→承認/差し戻し/中止の動作確認
- [ ] interactiveモードで対話→完了/中止の動作確認
- [ ] サイクルガード超過時のfailed遷移確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ワークフローエンジンを追加。複数ステップ実行、auto/approval/interactive 等の遷移モード、サイクルガードと中止対応を備える
  * ワークフロー開始・中止・承認・対話完了・状態取得のコマンドを追加し、外部から制御可能に
  * 実行状態の永続化とリアルタイム通知で進捗を可視化

* **Documentation**
  * ワークフロー仕様ドキュメントを追加

* **Tests**
  * ワークフロー挙動やシリアライズの単体テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->