### PR TITLE
feat: Approvalステップ Rejectコメント保存・遷移・復元機能

### DIFF
--- a/docs/spec/issues-897.md
+++ b/docs/spec/issues-897.md
@@ -1,0 +1,142 @@
+## 要求
+
+**種別**: 新機能
+**ゴール**: Workflow の approval step で Reject する際に、人間が差し戻し理由・修正指示をコメントとして入力でき、そのコメントが後続の fix step へ渡されることで、自動修正サイクルが人間の指摘を起点に再開できるようにする。
+**背景**: 現状の approval は approve / reject / abort の判定のみで、Reject 理由を Workflow Engine に渡せない。Spec 承認や実装結果承認で人間が Reject しても、次の auto step が何を修正すべきかを構造的に受け取れない。
+**利用シーン**: Spec 承認・実装結果承認等の approval step で Reject → fix step への差し戻しフロー
+**制約**:
+- #896（Step Output / Collect / Reduce）の output 永続化・prompt 注入基盤が前提
+- Approve / Abort の既存挙動を維持すること
+**影響範囲**: ApprovalDecision 型、Tauri コマンド、Frontend UI、StepOutput、Trace view
+
+**受け入れ基準**:
+- approval step で Reject する際、空コメントでは Reject できない
+- Reject comment 付きで Reject すると、workflow は reject rule の遷移先へ進む
+- 遷移先 step の prompt に Reject comment が注入される
+- Step history / Trace view で Reject comment を確認できる
+- NDJSON ログ再構築後も Reject comment が復元される
+- 既存の Approve / Abort フローが壊れていない
+
+**非スコープ**:
+- ビルトイン Workflow の追加
+- レビュー観点ごとの並列実行
+- approval 以外の human feedback 汎用化
+
+## 振る舞い定義
+
+```gherkin
+Feature: Approval Rejectコメント付き差し戻し
+  Workflow の approval step で人間が Reject する際にコメントを入力し、
+  後続の fix step が人間の指摘を起点に修正サイクルを再開できる。
+
+  Rule: Reject時にコメントが必須である
+    Scenario: コメント付きでRejectする
+      Given approval step が WaitingApproval 状態である
+      When ユーザーがコメント付きで Reject する
+      Then ワークフローは reject ルールの遷移先へ進む
+
+    Scenario: 空コメントではRejectできない
+      Given approval step が WaitingApproval 状態である
+      When ユーザーが空コメントで Reject しようとする
+      Then Reject は拒否される
+
+  Rule: RejectコメントはStepOutputとして保存される
+    Scenario: Rejectコメントがstep outputに記録される
+      Given approval step が WaitingApproval 状態である
+      When ユーザーがコメント付きで Reject する
+      Then step の output_text にRejectコメントが保存される
+      And step の result が "reject" として保存される
+
+  Rule: 遷移先stepがRejectコメントをprompt contextとして受け取る
+    Scenario: pass_previous_responseで前stepのRejectコメントを受け取る
+      Given approval step が Reject コメント付きで完了している
+      And 遷移先 step に pass_previous_response が true で設定されている
+      When 遷移先 step が起動される
+      Then 遷移先 step の prompt に Reject コメントが注入される
+
+    Scenario: pass_output_fromで任意のapproval stepのRejectコメントを受け取る
+      Given approval step が Reject コメント付きで完了している
+      And 遷移先 step に pass_output_from で approval step 名が指定されている
+      When 遷移先 step が起動される
+      Then 遷移先 step の prompt に Reject コメントが注入される
+
+  Rule: Rejectコメントは追跡可能である
+    Scenario: Trace viewでRejectコメントを確認する
+      Given approval step が Reject コメント付きで完了している
+      When ユーザーが Trace view を表示する
+      Then Reject コメントが表示される
+
+    Scenario: NDJSONログからRejectコメントを復元する
+      Given Reject コメント付きで完了した approval step のログが存在する
+      When ログから WorkflowState を再構築する
+      Then 復元された StepOutput に Reject コメントが含まれる
+
+  Rule: Approve/Abortの既存挙動は維持される
+    Scenario: Approveは従来通りコメントなしで動作する
+      Given approval step が WaitingApproval 状態である
+      When ユーザーが Approve する
+      Then ワークフローは次のステップへ進む
+
+    Scenario: Abortは従来通りコメントなしで動作する
+      Given approval step が WaitingApproval 状態である
+      When ユーザーが Abort する
+      Then ワークフローは中止される
+```
+
+## 実装仕様
+
+**対応方針**: 振る舞い定義を実現するために、ApprovalDecision型・Tauriコマンド・エンジン・フロントエンドUIに対して、Reject時のcommentパラメータ追加で対応する。Rejectコメントは既存の `StepOutput.output_text` に格納し、`pass_previous_response` / `pass_output_from` の既存基盤をそのまま活用する。
+
+**対象コンポーネント**:
+
+### Rust側
+
+1. **`engine.rs` — ApprovalDecision enum変更**
+   - `Reject` variant に `comment: String` フィールドを追加
+   - `Reject { comment: String }` （tagged enum、serde rename_all = "snake_case"）
+
+2. **`engine.rs` — handle_approval()変更**
+   - Reject時、`fetch_current_output()` および `decide_approval_action()` の前に `comment.trim().is_empty()` をチェックし、空の場合は `WorkflowEngineError` を返して処理を中断する（不要な副作用を避けるため最初にバリデーション）
+   - バリデーション通過後、`output_text` を `fetch_current_output()` の結果ではなく、`decision` から取り出した `comment`（trim前の原文）に差し替える
+   - Approve は既存どおり `fetch_current_output()` の結果を `output_text` として履歴に保存する
+   - Abort は既存どおり履歴エントリを追加せず、状態を Aborted に遷移するのみ（`output_text` の保存なし）
+
+3. **`engine.rs` — decide_approval_action()変更**
+   - 変更不要。`ApprovalDecision::Reject { .. }` のパターンマッチ更新のみ
+
+4. **`commands.rs` — approve_workflow_step コマンド**
+   - パラメータ変更不要。`ApprovalDecision` のserde deserializeで `{ "reject": { "comment": "..." } }` を受け取る
+
+### フロントエンド側
+
+5. **`WorkflowPanel.tsx` — Reject UI**
+   - Reject ボタン押下でコメント入力UIを表示（テキストエリア + 送信/キャンセル）
+   - 空コメントでは送信ボタンを disabled にする
+   - `invoke("approve_workflow_step", { worktreePath, decision: { reject: { comment } } })` で送信
+
+6. **`WorkflowTrace.tsx` — 表示**
+   - 変更不要。既存の `outputText` 表示で Reject コメントが表示される（`result: "reject"` で区別可能）
+
+### ログ・永続化
+
+7. **`log.rs`**
+   - 変更不要。`StepCompleted` の `output_text` と `result` フィールドにRejectコメントと "reject" がそのまま記録される
+
+8. **`state.rs`**
+   - 変更不要。`StepOutput` / `StepHistoryEntry` の既存フィールドで対応可能
+
+**検討した代替案**:
+- StepOutput / StepHistoryEntry に `reject_comment` フィールドを新設する案 → `output_text` に格納すれば `pass_previous_response` / `pass_output_from` / inject_step_outputs / NDJSON復元がすべて既存実装のまま動作するため却下。専用フィールドを追加すると全層（型定義・ログ・復元・表示）に変更が波及する
+
+**影響するテスト**:
+- Rust: `engine.rs` の既存テスト（approval判定テスト）を `Reject { comment }` に更新
+- Rust: Reject時の `output_text` がコメントになることのテスト追加
+- Rust: 空コメントRejectのバリデーションテスト追加
+- Rust: `pass_previous_response` でRejectコメントが次stepのpromptに注入されるテスト追加
+- Rust: `pass_output_from` で任意stepのRejectコメントが注入されるテスト追加
+- Rust: `StepCompleted` ログからRejectコメント（`output_text` + `result: "reject"`）が復元されるテスト追加
+- Rust: Approve時に `handle_approval()` が `output_text` を履歴に保存しadvanceするテスト追加
+- Rust: Abort時に `handle_approval()` が `step_history` を増やさず Aborted に遷移するテスト追加
+- Frontend: WorkflowPanel のReject UIテスト（コメント入力 → invoke呼び出し）
+- Frontend: 空コメント時のdisabled状態テスト
+- Frontend: Trace viewでRejectコメント（`result: "reject"` + `outputText`）が表示されるテスト

--- a/src-tauri/src/workflow/builtin/trace-test.yml
+++ b/src-tauri/src/workflow/builtin/trace-test.yml
@@ -56,3 +56,6 @@ steps:
     knowledge: test-context
     output_contract: test-report
     pass_previous_response: true
+    rules:
+      - match: reject
+        next: execute

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -418,10 +418,12 @@ impl WorkflowExecution {
         let step = &self.workflow.steps[self.current_step_index];
         match decision {
             ApprovalDecision::Approve => Ok(ApprovalAction::Advance),
-            ApprovalDecision::Reject => match step.rules.iter().find(|r| r.r#match == "reject") {
-                Some(r) => Ok(ApprovalAction::TransitionTo(r.next.clone())),
-                None => Ok(ApprovalAction::FailedNoRejectRule(step.name.clone())),
-            },
+            ApprovalDecision::Reject { .. } => {
+                match step.rules.iter().find(|r| r.r#match == "reject") {
+                    Some(r) => Ok(ApprovalAction::TransitionTo(r.next.clone())),
+                    None => Ok(ApprovalAction::FailedNoRejectRule(step.name.clone())),
+                }
+            }
             ApprovalDecision::Abort => Ok(ApprovalAction::Abort),
         }
     }
@@ -455,7 +457,7 @@ impl WorkflowExecution {
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalDecision {
     Approve,
-    Reject,
+    Reject { comment: String },
     Abort,
 }
 
@@ -790,6 +792,18 @@ impl WorkflowEngine {
         }
     }
 
+    /// ApprovalDecisionのバリデーション。Reject時に空コメントを拒否する。
+    fn validate_approval_decision(decision: &ApprovalDecision) -> Result<(), WorkflowEngineError> {
+        if let ApprovalDecision::Reject { ref comment } = decision {
+            if comment.trim().is_empty() {
+                return Err(WorkflowEngineError::InvalidState(
+                    "Reject comment must not be empty".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// approvalモードでのユーザー判定を処理する。
     /// 判定 + 状態変更 + 履歴記録を1回のロックで原子的に実行し、
     /// ロック外では永続化・ブロードキャスト・AgentSession起動のみ行う。
@@ -801,16 +815,24 @@ impl WorkflowEngine {
         worktree_path: &str,
         decision: ApprovalDecision,
     ) -> Result<(), WorkflowEngineError> {
+        // Reject時: 空コメントバリデーション（副作用の前に実施）
+        Self::validate_approval_decision(&decision)?;
+
         let result_tag = match &decision {
             ApprovalDecision::Approve => "approve",
-            ApprovalDecision::Reject => "reject",
+            ApprovalDecision::Reject { .. } => "reject",
             ApprovalDecision::Abort => "abort",
         };
 
         // ロック外でoutput_textを事前取得（approvalはAgentSession完了後なので取得可能）
-        let output_text = self
-            .fetch_current_output(app, session_store, worktree_path)
-            .await?;
+        // Reject時はコメントをoutput_textとして使用するため、fetch不要だがApprove時に必要
+        let output_text = match &decision {
+            ApprovalDecision::Reject { ref comment } => Some(comment.clone()),
+            _ => {
+                self.fetch_current_output(app, session_store, worktree_path)
+                    .await?
+            }
+        };
 
         // 判定 + 状態変更 + 履歴記録を原子的に実行
         let (chat_session_id, outcome) = {
@@ -3369,8 +3391,10 @@ mod tests {
         let mut exec = make_exec(3); // report (approval, reject→implement)
         exec.state = WorkflowExecutionState::WaitingApproval;
         assert_eq!(
-            exec.decide_approval_action(&ApprovalDecision::Reject)
-                .unwrap(),
+            exec.decide_approval_action(&ApprovalDecision::Reject {
+                comment: "Needs fix".to_string()
+            })
+            .unwrap(),
             ApprovalAction::TransitionTo("implement".to_string())
         );
     }
@@ -3380,8 +3404,10 @@ mod tests {
         let mut exec = make_exec(0); // plan (interactive, no reject rule)
         exec.state = WorkflowExecutionState::WaitingApproval;
         assert_eq!(
-            exec.decide_approval_action(&ApprovalDecision::Reject)
-                .unwrap(),
+            exec.decide_approval_action(&ApprovalDecision::Reject {
+                comment: "Needs fix".to_string()
+            })
+            .unwrap(),
             ApprovalAction::FailedNoRejectRule("plan".to_string())
         );
     }
@@ -3664,6 +3690,21 @@ mod tests {
         let result = WorkflowEngine::inject_step_outputs("Do C", &step, &outputs, &[]);
         assert!(result.contains("<step_output name=\"step_a\">"));
         assert!(result.contains("output A"));
+    }
+
+    #[test]
+    fn reject_comment_accessible_via_pass_output_from() {
+        let mut step = make_test_step("fix", StepMode::Auto, "Fix issues", vec![], None);
+        step.pass_output_from = Some(vec!["review".to_string()]);
+
+        let mut outputs = HashMap::new();
+        outputs.insert(
+            "review".to_string(),
+            make_step_output("review", "Fix the naming convention", Some("reject")),
+        );
+        let result = WorkflowEngine::inject_step_outputs("Fix issues", &step, &outputs, &[]);
+        assert!(result.contains("<step_output name=\"review\">"));
+        assert!(result.contains("Fix the naming convention"));
     }
 
     #[test]
@@ -4300,5 +4341,259 @@ mod tests {
         // 空childrenの場合: child_outputs.len()==0, child_step_names.len()==0 → 等しいので
         // all()が空イテレータでtrueを返す
         assert!(engine.evaluate_aggregate(&agg, &outputs, &children));
+    }
+
+    // ---- decide_approval_action ----
+
+    fn make_approval_exec(
+        state: WorkflowExecutionState,
+        rules: Vec<TransitionRule>,
+    ) -> WorkflowExecution {
+        WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: Workflow {
+                name: "test".to_string(),
+                description: "test".to_string(),
+                builtin: false,
+                steps: vec![Step {
+                    name: "review".to_string(),
+                    mode: Some(StepMode::Approval),
+                    persona: None,
+                    policy: None,
+                    knowledge: None,
+                    instruction: Some("Review the code".to_string()),
+                    output_contract: None,
+                    rules,
+                    cycle_guard: None,
+                    pass_previous_response: None,
+                    pass_output_from: None,
+                    collect: None,
+                    parallel: None,
+                    aggregate: None,
+                }],
+            },
+            state,
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: vec![],
+            chat_session_id: "session-1".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: None,
+            current_step_token_usage: TokenUsage::default(),
+            step_outputs: HashMap::new(),
+            task: None,
+            parallel_run: None,
+        }
+    }
+
+    // ---- validate_approval_decision ----
+
+    #[test]
+    fn validate_approval_decision_reject_empty_comment_returns_error() {
+        let result = WorkflowEngine::validate_approval_decision(&ApprovalDecision::Reject {
+            comment: "".to_string(),
+        });
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Reject comment must not be empty"));
+    }
+
+    #[test]
+    fn validate_approval_decision_reject_whitespace_only_returns_error() {
+        let result = WorkflowEngine::validate_approval_decision(&ApprovalDecision::Reject {
+            comment: "   \n\t  ".to_string(),
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_approval_decision_reject_with_comment_ok() {
+        let result = WorkflowEngine::validate_approval_decision(&ApprovalDecision::Reject {
+            comment: "Please fix the bug".to_string(),
+        });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_approval_decision_approve_ok() {
+        let result = WorkflowEngine::validate_approval_decision(&ApprovalDecision::Approve);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_approval_decision_abort_ok() {
+        let result = WorkflowEngine::validate_approval_decision(&ApprovalDecision::Abort);
+        assert!(result.is_ok());
+    }
+
+    // ---- make_step_history_entry ----
+
+    #[test]
+    fn make_step_history_entry_stores_reject_comment_in_step_outputs() {
+        let mut exec = make_approval_exec(WorkflowExecutionState::WaitingApproval, vec![]);
+        let reject_comment = "Please fix the formatting".to_string();
+        let entry =
+            exec.make_step_history_entry(Some("reject".to_string()), Some(reject_comment.clone()));
+        assert_eq!(entry.result.as_deref(), Some("reject"));
+        assert_eq!(
+            entry.output_text.as_deref(),
+            Some("Please fix the formatting")
+        );
+        let stored = exec.step_outputs.get("review").unwrap();
+        assert_eq!(stored.output_text, reject_comment);
+        assert_eq!(stored.result.as_deref(), Some("reject"));
+    }
+
+    // ---- handle_approval integration (lock-inner logic) ----
+
+    #[test]
+    fn reject_comment_flows_through_approval_to_transition_and_history() {
+        // handle_approval() のロック内ロジックを再現:
+        // validate → decide → make_step_history_entry → apply_transition
+        let decision = ApprovalDecision::Reject {
+            comment: "Fix the naming convention".to_string(),
+        };
+
+        // 1. validate
+        WorkflowEngine::validate_approval_decision(&decision).unwrap();
+
+        // 2. output_text をRejectコメントから取得（handle_approval L692-693相当）
+        let output_text = match &decision {
+            ApprovalDecision::Reject { ref comment } => Some(comment.clone()),
+            _ => None,
+        };
+        let result_tag = "reject".to_string();
+
+        // 3. 遷移先 "fix" ステップを含むワークフローを構築
+        let mut exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: Workflow {
+                name: "review-fix".to_string(),
+                description: "test".to_string(),
+                builtin: false,
+                steps: vec![
+                    Step {
+                        name: "review".to_string(),
+                        mode: Some(StepMode::Approval),
+                        persona: None,
+                        policy: None,
+                        knowledge: None,
+                        instruction: Some("Review the code".to_string()),
+                        output_contract: None,
+                        rules: vec![TransitionRule {
+                            r#match: "reject".to_string(),
+                            next: "fix".to_string(),
+                        }],
+                        cycle_guard: None,
+                        pass_previous_response: None,
+                        pass_output_from: None,
+                        collect: None,
+                        parallel: None,
+                        aggregate: None,
+                    },
+                    Step {
+                        name: "fix".to_string(),
+                        mode: Some(StepMode::Auto),
+                        persona: None,
+                        policy: None,
+                        knowledge: None,
+                        instruction: Some("Fix the issues".to_string()),
+                        output_contract: None,
+                        rules: vec![],
+                        cycle_guard: None,
+                        pass_previous_response: Some(true),
+                        pass_output_from: None,
+                        collect: None,
+                        parallel: None,
+                        aggregate: None,
+                    },
+                ],
+            },
+            state: WorkflowExecutionState::WaitingApproval,
+            current_step_index: 0,
+            step_execution_counts: HashMap::new(),
+            step_history: vec![],
+            chat_session_id: "session-1".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: None,
+            current_step_token_usage: TokenUsage::default(),
+            step_outputs: HashMap::new(),
+            task: None,
+            parallel_run: None,
+        };
+
+        // 4. decide
+        let action = exec.decide_approval_action(&decision).unwrap();
+        assert_eq!(action, ApprovalAction::TransitionTo("fix".to_string()));
+
+        // 5. make_step_history_entry + push
+        let entry = exec.make_step_history_entry(Some(result_tag), output_text);
+        exec.step_history.push(entry);
+
+        // 6. apply_transition
+        let outcome = WorkflowEngine::apply_transition(&mut exec, "fix").unwrap();
+        assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
+
+        // 検証: step_history にRejectコメントが記録されている
+        assert_eq!(exec.step_history.len(), 1);
+        let hist = &exec.step_history[0];
+        assert_eq!(hist.step_name, "review");
+        assert_eq!(hist.result.as_deref(), Some("reject"));
+        assert_eq!(
+            hist.output_text.as_deref(),
+            Some("Fix the naming convention")
+        );
+
+        // 検証: step_outputs にRejectコメントが格納されている
+        let output = exec.step_outputs.get("review").unwrap();
+        assert_eq!(output.output_text, "Fix the naming convention");
+        assert_eq!(output.result.as_deref(), Some("reject"));
+
+        // 検証: 遷移先 "fix" ステップに移動している
+        assert_eq!(exec.current_step_index, 1);
+        assert_eq!(exec.workflow.steps[exec.current_step_index].name, "fix");
+
+        // 検証: inject_step_outputs で Reject コメントが遷移先 step の prompt に注入される
+        let fix_step = &exec.workflow.steps[exec.current_step_index];
+        let injected_prompt = WorkflowEngine::inject_step_outputs(
+            fix_step.instruction.as_deref().unwrap_or(""),
+            fix_step,
+            &exec.step_outputs,
+            &exec.step_history,
+        );
+        assert!(injected_prompt.contains("<step_output name=\"review\">"));
+        assert!(injected_prompt.contains("Fix the naming convention"));
+    }
+
+    // ---- ApprovalDecision serde ----
+
+    #[test]
+    fn approval_decision_deserialize_approve() {
+        let json = r#""approve""#;
+        let decision: ApprovalDecision = serde_json::from_str(json).unwrap();
+        assert_eq!(decision, ApprovalDecision::Approve);
+    }
+
+    #[test]
+    fn approval_decision_deserialize_reject_with_comment() {
+        let json = r#"{"reject":{"comment":"Please fix this"}}"#;
+        let decision: ApprovalDecision = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            decision,
+            ApprovalDecision::Reject {
+                comment: "Please fix this".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn approval_decision_deserialize_abort() {
+        let json = r#""abort""#;
+        let decision: ApprovalDecision = serde_json::from_str(json).unwrap();
+        assert_eq!(decision, ApprovalDecision::Abort);
     }
 }

--- a/src-tauri/src/workflow/log.rs
+++ b/src-tauri/src/workflow/log.rs
@@ -1247,10 +1247,7 @@ mod tests {
         // step_history にRejectコメントが保存されている
         assert_eq!(state.step_history.len(), 1);
         assert_eq!(state.step_history[0].step_name, "review");
-        assert_eq!(
-            state.step_history[0].result,
-            Some("reject".to_string())
-        );
+        assert_eq!(state.step_history[0].result, Some("reject".to_string()));
         assert_eq!(
             state.step_history[0].output_text,
             Some("Please fix the naming convention".to_string())

--- a/src-tauri/src/workflow/log.rs
+++ b/src-tauri/src/workflow/log.rs
@@ -1202,4 +1202,63 @@ mod tests {
 
         assert_eq!(state.state, WorkflowExecutionState::Completed);
     }
+
+    #[test]
+    fn reconstruct_state_reject_comment_preserved() {
+        let tmp = TempDir::new().unwrap();
+        let log = WorkflowEventLog::new(tmp.path());
+        let wf = make_test_workflow();
+
+        log.append(&WorkflowLogEvent::WorkflowStarted {
+            execution_id: "exec-r".to_string(),
+            workflow_name: "test-wf".to_string(),
+            workflow_file_stem: "test-wf".to_string(),
+            worktree_path: "/repo".to_string(),
+            workflow_definition: None,
+            timestamp: 1000.0,
+        })
+        .unwrap();
+        log.append(&WorkflowLogEvent::StepStarted {
+            execution_id: "exec-r".to_string(),
+            workflow_name: "test-wf".to_string(),
+            step_name: "review".to_string(),
+            execution_count: 1,
+            timestamp: 1001.0,
+        })
+        .unwrap();
+        log.append(&WorkflowLogEvent::StepCompleted {
+            execution_id: "exec-r".to_string(),
+            workflow_name: "test-wf".to_string(),
+            step_name: "review".to_string(),
+            result: Some("reject".to_string()),
+            session_id: Some("sess-review".to_string()),
+            token_usage: Some(TokenUsage {
+                input_tokens: 200,
+                output_tokens: 80,
+            }),
+            output_text: Some("Please fix the naming convention".to_string()),
+            run_index: Some(1),
+            timestamp: 1002.0,
+        })
+        .unwrap();
+
+        let state = log.reconstruct_state("exec-r", &wf).unwrap().unwrap();
+
+        // step_history にRejectコメントが保存されている
+        assert_eq!(state.step_history.len(), 1);
+        assert_eq!(state.step_history[0].step_name, "review");
+        assert_eq!(
+            state.step_history[0].result,
+            Some("reject".to_string())
+        );
+        assert_eq!(
+            state.step_history[0].output_text,
+            Some("Please fix the naming convention".to_string())
+        );
+
+        // step_outputs にもRejectコメントが格納されている
+        let output = state.step_outputs.get("review").unwrap();
+        assert_eq!(output.output_text, "Please fix the naming convention");
+        assert_eq!(output.result, Some("reject".to_string()));
+    }
 }

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
@@ -214,7 +214,7 @@ describe("WorkflowPanel", () => {
 		});
 	});
 
-	it("invokes approve_workflow_step with reject when Reject is clicked", () => {
+	it("shows reject comment form when Reject is clicked", () => {
 		render(
 			<WorkflowPanel
 				workflowState={makeWorkflowState({
@@ -225,10 +225,116 @@ describe("WorkflowPanel", () => {
 			/>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Reject step" }));
+		expect(screen.getByLabelText("Reject comment")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Submit reject" }),
+		).toBeDisabled();
+	});
+
+	it("invokes approve_workflow_step with reject comment when submitted", async () => {
+		render(
+			<WorkflowPanel
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+				})}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Reject step" }));
+		fireEvent.change(screen.getByLabelText("Reject comment"), {
+			target: { value: "Please fix the bug" },
+		});
+		expect(
+			screen.getByRole("button", { name: "Submit reject" }),
+		).not.toBeDisabled();
+		fireEvent.click(screen.getByRole("button", { name: "Submit reject" }));
 		expect(mockInvoke).toHaveBeenCalledWith("approve_workflow_step", {
 			worktreePath: "/repo",
-			decision: "reject",
+			decision: { reject: { comment: "Please fix the bug" } },
 		});
+		await waitFor(() => {
+			expect(screen.queryByLabelText("Reject comment")).not.toBeInTheDocument();
+		});
+	});
+
+	it("hides reject form after successful submit", async () => {
+		render(
+			<WorkflowPanel
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+				})}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Reject step" }));
+		fireEvent.change(screen.getByLabelText("Reject comment"), {
+			target: { value: "Please fix" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Submit reject" }));
+		await waitFor(() => {
+			expect(screen.queryByLabelText("Reject comment")).not.toBeInTheDocument();
+		});
+	});
+
+	it("does not allow submitting reject with empty comment", () => {
+		render(
+			<WorkflowPanel
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+				})}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Reject step" }));
+		fireEvent.change(screen.getByLabelText("Reject comment"), {
+			target: { value: "   " },
+		});
+		expect(
+			screen.getByRole("button", { name: "Submit reject" }),
+		).toBeDisabled();
+	});
+
+	it("cancels reject mode when Cancel is clicked", () => {
+		render(
+			<WorkflowPanel
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+				})}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Reject step" }));
+		expect(screen.getByLabelText("Reject comment")).toBeInTheDocument();
+		fireEvent.click(screen.getByText("Cancel"));
+		expect(screen.queryByLabelText("Reject comment")).not.toBeInTheDocument();
+	});
+
+	it("hides reject form when state changes from waiting_approval to running", () => {
+		const { rerender } = render(
+			<WorkflowPanel
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+				})}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Reject step" }));
+		expect(screen.getByLabelText("Reject comment")).toBeInTheDocument();
+		rerender(
+			<WorkflowPanel
+				workflowState={makeWorkflowState({
+					state: { type: "running" },
+				})}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+		expect(screen.queryByLabelText("Reject comment")).not.toBeInTheDocument();
 	});
 
 	it("shows Complete button for interactive mode when running", () => {

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
@@ -413,6 +413,19 @@ function WorkflowActivePanel({
 		currentStep?.mode === "interactive" &&
 		workflowState.state.type === "running";
 
+	const [rejectMode, setRejectMode] = useState(false);
+	const [rejectComment, setRejectComment] = useState("");
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset reject form when step/execution/approval state changes
+	useEffect(() => {
+		setRejectMode(false);
+		setRejectComment("");
+	}, [
+		workflowState.executionId,
+		workflowState.currentStepName,
+		isWaitingApproval,
+	]);
+
 	const handleAbort = useCallback(() => {
 		invoke("abort_workflow", { worktreePath }).catch((e) =>
 			console.warn("[WorkflowPanel] abort_workflow failed", e),
@@ -428,14 +441,28 @@ function WorkflowActivePanel({
 		);
 	}, [worktreePath]);
 
-	const handleReject = useCallback(() => {
+	const handleRejectClick = useCallback(() => {
+		setRejectMode(true);
+	}, []);
+
+	const handleRejectSubmit = useCallback(() => {
 		invoke("approve_workflow_step", {
 			worktreePath,
-			decision: "reject",
-		}).catch((e) =>
-			console.warn("[WorkflowPanel] approve_workflow_step failed", e),
-		);
-	}, [worktreePath]);
+			decision: { reject: { comment: rejectComment } },
+		})
+			.then(() => {
+				setRejectMode(false);
+				setRejectComment("");
+			})
+			.catch((e) =>
+				console.warn("[WorkflowPanel] approve_workflow_step failed", e),
+			);
+	}, [worktreePath, rejectComment]);
+
+	const handleRejectCancel = useCallback(() => {
+		setRejectMode(false);
+		setRejectComment("");
+	}, []);
 
 	const handleCompleteInteractive = useCallback(() => {
 		invoke("complete_interactive_step", {
@@ -448,10 +475,41 @@ function WorkflowActivePanel({
 
 	return (
 		<div className="flex flex-col h-full overflow-hidden">
+			{/* Reject comment input */}
+			{isWaitingApproval && rejectMode && (
+				<div className="flex flex-col gap-1.5 px-3 py-2 border-b shrink-0">
+					<textarea
+						className="w-full px-2 py-1 text-xs rounded border bg-background resize-none"
+						rows={3}
+						placeholder="Reject comment..."
+						value={rejectComment}
+						onChange={(e) => setRejectComment(e.target.value)}
+						aria-label="Reject comment"
+					/>
+					<div className="flex items-center gap-2 justify-end">
+						<button
+							type="button"
+							onClick={handleRejectCancel}
+							className="px-2 py-0.5 text-xs rounded bg-muted hover:bg-muted/80 transition-colors"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							onClick={handleRejectSubmit}
+							disabled={rejectComment.trim().length === 0}
+							className="px-2 py-0.5 text-xs rounded bg-yellow-500/20 text-yellow-700 dark:text-yellow-300 hover:bg-yellow-500/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+							aria-label="Submit reject"
+						>
+							Reject
+						</button>
+					</div>
+				</div>
+			)}
 			{/* Action bar */}
 			<div className="flex items-center justify-end px-3 py-1.5 border-b shrink-0">
 				<div className="flex items-center gap-2">
-					{isWaitingApproval && (
+					{isWaitingApproval && !rejectMode && (
 						<>
 							<button
 								type="button"
@@ -464,7 +522,7 @@ function WorkflowActivePanel({
 							</button>
 							<button
 								type="button"
-								onClick={handleReject}
+								onClick={handleRejectClick}
 								className="flex items-center gap-1 px-2 py-0.5 text-xs rounded bg-yellow-500/20 text-yellow-700 dark:text-yellow-300 hover:bg-yellow-500/30 transition-colors"
 								aria-label="Reject step"
 							>

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
@@ -440,6 +440,38 @@ describe("WorkflowTrace", () => {
 		expect(screen.getByText("Output")).toBeInTheDocument();
 	});
 
+	it("displays reject result and comment in trace view", () => {
+		render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					stepStates: {
+						plan: "completed",
+						review: "completed",
+						fix: "running",
+					},
+					stepHistory: [
+						{
+							stepName: "plan",
+							completedAt: 1001,
+							result: "done",
+						},
+						{
+							stepName: "review",
+							completedAt: 1002,
+							result: "reject",
+							outputText: "Please fix the naming convention",
+						},
+					],
+				})}
+			/>,
+		);
+		expect(screen.getByText("Result: reject")).toBeInTheDocument();
+		fireEvent.click(screen.getByText("Output"));
+		expect(
+			screen.getByText("Please fix the naming convention"),
+		).toBeInTheDocument();
+	});
+
 	it("renders parallel block as completed when all children done", () => {
 		render(
 			<WorkflowTrace


### PR DESCRIPTION
## Summary
- ApprovalステップでReject時にコメントを`step_outputs`/`step_history`に保存し、遷移先ステップへ`inject_step_outputs`で注入
- NDJSONログからのRejectコメント復元に対応
- Trace viewでReject結果とコメントを表示
- trace-test.ymlのconfirmステップにreject→executeルールを追加

## Test plan
- [ ] `cargo test workflow::engine` / `cargo test workflow::log` PASS
- [ ] `pnpm test` (WorkflowPanel / WorkflowTrace) PASS
- [ ] 実機でtrace-testワークフローをconfirmまで進めてReject → executeに遷移しコメントが保持されることを確認

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワークフロー承認ステップで拒否時にコメントを添付できるようになりました。
  * 拒否コメントの入力フィールドがUIに追加され、ユーザーが理由を記入して送信できます。
  * 拒否コメントは後続のワークフローステップに自動的に渡されます。
  * ワークフロートレース画面で拒否結果とそのコメントが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->