### PR TITLE
feat: Agentプロセスグループ管理によるゾンビプロセス防止

### DIFF
--- a/docs/spec/issues-911.md
+++ b/docs/spec/issues-911.md
@@ -1,0 +1,108 @@
+## 要求
+
+**種別**: バグ修正
+**現在の挙動**: `close_agent_session()`は`proc.child.kill()`で直接の子プロセス（Claude Code SDKプロセス）のみをkillしている。SDKが起動した孫プロセス（rust-analyzer、proc-macro-srv等）はプロセスグループ管理されていないため、親がkillされても残存する。セッションを繰り返すたびに孤児プロセスが蓄積し、rust-analyzer 1プロセスあたり4-5GBのメモリを消費する。
+**期待する挙動**: セッション終了時に、直接の子プロセスだけでなく、その子孫プロセス全てがkillされ、メモリが解放される。
+**再現手順**:
+1. Releash上でClaude Codeエージェントセッションを開始する
+2. エージェントがRustプロジェクトを解析する過程でrust-analyzerが起動される
+3. セッションを終了する
+4. `ps -eo pid,rss,comm | grep rust-analyzer` で確認すると、rust-analyzerプロセスが残存している
+**背景**: セッションを繰り返すたびに孤児プロセスが蓄積し、ユーザーが手動でkillしない限り解放されない。観測では合計約9.5GBがセッション終了後も占有されていた。
+**影響範囲**: agent_sdk.rs（エージェントセッションのプロセス管理）、lib.rs（終了時クリーンアップ）、tray.rs（Quit処理）
+
+## 振る舞い定義
+
+```gherkin
+Feature: セッション終了時の子孫プロセス全kill
+  Agentセッション終了時に、直接の子プロセスだけでなく
+  孫プロセス以下の全子孫プロセスをkillし、メモリを解放する。
+  PTY側はportable_ptyが既にsetsid()でプロセスグループを管理しているため対象外。
+
+  Rule: Agentセッション終了時にプロセスグループ全体がkillされる
+    Scenario: Agentセッション終了で孫プロセスもkillされる
+      Given Agentセッションが起動しており、SDKプロセスがrust-analyzer等の孫プロセスを起動している
+      When セッションを終了する
+      Then SDKプロセスと全ての孫プロセスがkillされる
+
+    Scenario: Graceful shutdown後にプロセスグループが強制killされる
+      Given Agentセッションが起動しており、SDKプロセスがgraceful closeに応答しない
+      When セッション終了のタイムアウト（5秒）が経過する
+      Then プロセスグループ全体がSIGKILLで強制killされる
+
+  Rule: プロセスグループは起動時に設定される
+    Scenario: Agentセッション起動時にプロセスグループが作成される
+      Given 新しいAgentセッションを起動する
+      When SDKプロセスが生成される
+      Then SDKプロセスは新しいプロセスグループのリーダーとして起動される
+
+  Rule: Releash正常終了時に全Agentセッションのプロセスグループがkillされる
+    Scenario: アプリ終了で全Agentセッションの子孫プロセスがkillされる
+      Given 複数のAgentセッションが起動している
+      When Releashを正常終了する
+      Then 全てのAgentセッションのプロセスグループがkillされる
+
+  Rule: Releash起動時に前回の孤児プロセスが検出・killされる
+    Scenario: 前回クラッシュで残存した孤児プロセスがkillされる
+      Given 前回のReleashがクラッシュし、孤児プロセスが残存している
+      When Releashを起動する
+      Then 前回セッション由来の孤児プロセスが検出されkillされる
+```
+
+## 実装仕様
+
+**対応方針**: Agentセッション終了時に子孫プロセスが残存するバグを、Unixプロセスグループ管理の導入で修正する。Agent SDKプロセス起動時に`setsid()`で新しいプロセスグループを作成し、終了時に`killpg()`でグループ全体をkillする。また、Releash正常終了時の全セッションクリーンアップと、起動時のPIDファイルベースの孤児プロセス検出・killを追加する。PTY側はportable_ptyが既に`setsid()`を使用しており対象外。
+
+**対象コンポーネント**:
+- `src-tauri/src/agent_sdk.rs`: プロセスグループ設定（spawn）、グループkill（close）、PGID永続化
+- `src-tauri/src/lib.rs`: Releash終了時の全Agentセッションクリーンアップ、起動時孤児プロセスクリーンアップ
+- `src-tauri/src/tray.rs`: Quit処理にAgentセッション全killを追加
+
+**変更内容**:
+
+### A. プロセスグループ管理（agent_sdk.rs）
+
+1. **spawn_bridge_process()に`pre_exec`追加**:
+   - `Command::new("node")` に `.pre_exec(|| { libc::setsid(); Ok(()) })` を追加
+   - 子プロセスが新しいプロセスグループのリーダーとして起動される
+
+2. **AgentProcess構造体にpgid保存**:
+   - `pub pgid: Option<u32>` フィールドを追加
+   - spawn後に `child.id()` でPIDを取得（= PGID、setsid後はPID == PGIDのため）
+
+3. **close_agent_session()のkill処理変更**:
+   - Graceful shutdown（closeコマンド送信）は維持
+   - タイムアウト後の強制killを `proc.child.kill()` → `libc::killpg(pgid, libc::SIGKILL)` に変更
+   - Graceful shutdown成功後もプロセスグループに残存プロセスがないか `killpg(pgid, SIGTERM)` で掃除
+
+### B. PIDファイル永続化
+
+4. **PGID保存ディレクトリ**: `{app_data_dir}/pids/` に `{chat_session_id}.pid` ファイルとしてPGIDを保存
+5. **セッション起動時**: spawn成功後にPIDファイルを書き込み
+6. **セッション終了時**: プロセスグループkill成功後にPIDファイルを削除
+
+### C. Releash正常終了時のクリーンアップ
+
+7. **tray.rs Quit処理の拡張**: `stop_server_core()` の前に全Agentセッションの`close_agent_session()`を呼ぶ
+   - `close_all_agent_sessions()` 関数を新設
+
+### D. 起動時の孤児プロセス検出・kill
+
+8. **起動時クリーンアップ関数**: `cleanup_orphan_processes()` を新設
+   - `{app_data_dir}/pids/` 内の全PIDファイルを走査
+   - 各PGIDについて `libc::killpg(pgid, 0)` でプロセスグループの生存確認
+   - 生存していれば `killpg(pgid, SIGTERM)` → タイムアウト → `killpg(pgid, SIGKILL)`
+   - PIDファイルを削除
+9. **呼び出し箇所**: `lib.rs` の `.setup()` 内、`init_agent_sessions()` の前に実行
+
+**検討した代替案**:
+- プロセスツリー探索方式（`pgrep -P`等）: プロセス名やコマンドラインのパターンマッチに依存するため誤検出リスクがある。PIDファイル方式の方が確実
+
+**リスク**:
+- `setsid()`はUnix専用。macOS/Linuxでは動作するが、Windows対応が必要になった場合は`Job Object`等の別機構が必要
+  - 緩和策: `#[cfg(unix)]` で条件コンパイルし、非Unix環境では従来動作を維持
+
+**影響するテスト**:
+- ユニットテスト: `cleanup_orphan_processes()` のPIDファイル読み書き・削除ロジック
+- ユニットテスト: `close_all_agent_sessions()` のイテレーションロジック
+- 統合テスト: プロセスグループ管理は実プロセス起動が必要なため、手動テストで確認

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,9 @@ flate2 = "1"
 tar = "0.4"
 url = "2"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", branch = "release" }
 

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -4760,7 +4760,7 @@ mod tests {
             std::fs::create_dir_all(&dir).unwrap();
 
             // Spawn a process in a new process group via setsid()
-            let child = unsafe {
+            let mut child = unsafe {
                 Command::new("sleep")
                     .arg("999")
                     .stdout(std::process::Stdio::null())
@@ -4790,8 +4790,10 @@ mod tests {
 
             cleanup_orphan_processes(app_data_dir);
 
-            // Give processes time to be reaped
-            std::thread::sleep(std::time::Duration::from_secs(3));
+            // Reap the child to clear zombie state from process table.
+            // cleanup_orphan_processes sends SIGTERM/SIGKILL via killpg, but without
+            // wait() the child becomes a zombie and killpg(pgid, 0) still returns 0.
+            let _ = child.wait();
 
             // Verify process group is terminated
             let still_alive = unsafe { libc::killpg(pgid, 0) };

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -2117,6 +2117,8 @@ pub async fn close_agent_session(
     tokio::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_secs(CLOSE_TIMEOUT_SECS)).await;
         let mut map = handles_clone.lock().await;
+        #[cfg(unix)]
+        let mut force_killed = false;
         if let Some(proc) = map.get_mut(&csid) {
             if timeout_gen_id == Some(proc.generation_id) {
                 log::warn!("Close timeout for session {csid}, killing process group");
@@ -2125,6 +2127,7 @@ pub async fn close_agent_session(
                     unsafe {
                         libc::killpg(pg as libc::pid_t, libc::SIGKILL);
                     }
+                    force_killed = true;
                 }
                 #[cfg(not(unix))]
                 {
@@ -2137,13 +2140,17 @@ pub async fn close_agent_session(
         }
         map.remove(&csid);
         drop(map);
-        // Sweep any remaining group members (grandchild processes) and clean up pid file
         #[cfg(unix)]
         {
-            if let Some(pg) = pgid {
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                unsafe {
-                    libc::killpg(pg as libc::pid_t, libc::SIGTERM);
+            // After graceful shutdown (process exited on its own), sweep any remaining
+            // group members (grandchild processes) that may not have received the exit signal.
+            // Skip this if we already sent SIGKILL to the entire group above.
+            if !force_killed {
+                if let Some(pg) = pgid {
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    unsafe {
+                        libc::killpg(pg as libc::pid_t, libc::SIGTERM);
+                    }
                 }
             }
             if let Ok(data_dir) = resolve_data_dir(&app_clone) {

--- a/src-tauri/src/agent_sdk.rs
+++ b/src-tauri/src/agent_sdk.rs
@@ -83,8 +83,11 @@ pub struct AgentProcess {
     pub state: BridgeState,
     pub turn_phase: TurnPhase,
     pub sdk_session_id: Option<String>,
+    #[cfg_attr(unix, allow(dead_code))]
     pub child: tokio::process::Child,
     pub generation_id: u64,
+    #[cfg(unix)]
+    pub pgid: Option<u32>,
     pub streaming_message_id: Option<String>,
     pub streaming_parts: Vec<crate::session::MessagePart>,
     /// Retained after turn_complete so post-turn background task events
@@ -139,6 +142,91 @@ impl AgentProcess {
 
 /// Per-session agent process map: chat_session_id → AgentProcess
 pub type AgentProcessMap = HashMap<String, AgentProcess>;
+
+#[cfg(unix)]
+fn pids_dir(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("pids")
+}
+
+#[cfg(unix)]
+fn validate_session_id_for_path(chat_session_id: &str) -> Result<(), String> {
+    if chat_session_id.is_empty()
+        || chat_session_id.contains('/')
+        || chat_session_id.contains('\\')
+        || chat_session_id.contains("..")
+        || chat_session_id.contains('\0')
+    {
+        return Err(format!(
+            "Invalid chat_session_id for PID file: {chat_session_id:?}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn save_pgid(app_data_dir: &Path, chat_session_id: &str, pgid: u32) -> Result<(), String> {
+    validate_session_id_for_path(chat_session_id)?;
+    let dir = pids_dir(app_data_dir);
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create pids dir: {e}"))?;
+    let file = dir.join(format!("{chat_session_id}.pid"));
+    std::fs::write(&file, pgid.to_string())
+        .map_err(|e| format!("Failed to write pid file: {e}"))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn remove_pgid(app_data_dir: &Path, chat_session_id: &str) {
+    if validate_session_id_for_path(chat_session_id).is_err() {
+        return;
+    }
+    let file = pids_dir(app_data_dir).join(format!("{chat_session_id}.pid"));
+    let _ = std::fs::remove_file(file);
+}
+
+#[cfg(unix)]
+pub fn cleanup_orphan_processes(app_data_dir: &Path) {
+    let dir = pids_dir(app_data_dir);
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return, // No pids dir — nothing to clean up
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "pid") {
+            if let Ok(contents) = std::fs::read_to_string(&path) {
+                if let Ok(pgid) = contents.trim().parse::<i32>() {
+                    if pgid <= 1 {
+                        log::warn!("Invalid PGID {pgid} in {}, removing file", path.display());
+                        let _ = std::fs::remove_file(&path);
+                        continue;
+                    }
+                    // Check if the process group is still alive
+                    let alive = unsafe { libc::killpg(pgid, 0) } == 0;
+                    if alive {
+                        log::info!(
+                            "Cleaning up orphan process group {pgid} from {}",
+                            path.display()
+                        );
+                        unsafe {
+                            libc::killpg(pgid, libc::SIGTERM);
+                        }
+                        // Give processes time to exit, then force kill
+                        std::thread::sleep(std::time::Duration::from_secs(2));
+                        let still_alive = unsafe { libc::killpg(pgid, 0) } == 0;
+                        if still_alive {
+                            log::warn!("Orphan process group {pgid} did not exit, sending SIGKILL");
+                            unsafe {
+                                libc::killpg(pgid, libc::SIGKILL);
+                            }
+                        }
+                    }
+                }
+            }
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
 
 fn dev_bridge_path() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -843,22 +931,57 @@ async fn spawn_bridge_process(
         ));
     }
 
-    let mut child = Command::new("node")
-        .arg(
-            bridge_path
-                .to_str()
-                .ok_or_else(|| "Bridge script path contains invalid UTF-8".to_string())?,
-        )
-        .current_dir(cwd)
-        // Remove Claude Code nesting-detection env vars so the SDK-spawned
-        // `claude` CLI does not refuse to start.
-        .env_remove("CLAUDECODE")
-        .env_remove("CLAUDE_CODE_ENTRYPOINT")
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+    let mut cmd = Command::new("node");
+    cmd.arg(
+        bridge_path
+            .to_str()
+            .ok_or_else(|| "Bridge script path contains invalid UTF-8".to_string())?,
+    )
+    .current_dir(cwd)
+    // Remove Claude Code nesting-detection env vars so the SDK-spawned
+    // `claude` CLI does not refuse to start.
+    .env_remove("CLAUDECODE")
+    .env_remove("CLAUDE_CODE_ENTRYPOINT")
+    .stdin(std::process::Stdio::piped())
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::piped());
+
+    #[cfg(unix)]
+    // SAFETY: setsid() is async-signal-safe per POSIX.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = cmd
         .spawn()
         .map_err(|e| format!("Failed to spawn node process: {e}"))?;
+
+    #[cfg(unix)]
+    let pgid = child.id();
+    #[cfg(unix)]
+    if let Some(pg) = pgid {
+        let data_dir = resolve_data_dir(app).map_err(|e| {
+            log::error!("Failed to resolve data dir, killing spawned process group: {e}");
+            unsafe {
+                libc::killpg(pg as libc::pid_t, libc::SIGKILL);
+            }
+            format!("Failed to resolve data dir for session {chat_session_id}: {e}")
+        })?;
+        if let Err(e) = save_pgid(&data_dir, chat_session_id, pg) {
+            log::error!("Failed to save PGID file, killing spawned process group: {e}");
+            unsafe {
+                libc::killpg(pg as libc::pid_t, libc::SIGKILL);
+            }
+            return Err(format!(
+                "Failed to save PGID file for session {chat_session_id}: {e}"
+            ));
+        }
+    }
 
     let mut stdin = child
         .stdin
@@ -899,6 +1022,8 @@ async fn spawn_bridge_process(
                 sdk_session_id: session_id,
                 child,
                 generation_id: gen_id,
+                #[cfg(unix)]
+                pgid,
                 streaming_message_id: None,
                 streaming_parts: Vec::new(),
                 last_message_id: None,
@@ -1952,12 +2077,20 @@ pub async fn interrupt_agent_query(
 
 #[tauri::command]
 pub async fn close_agent_session(
+    app: tauri::AppHandle,
     handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
     chat_session_id: String,
 ) -> Result<(), String> {
+    #[cfg(unix)]
+    let pgid: Option<u32>;
+
     {
         let mut map = handles.lock().await;
         if let Some(proc) = map.get_mut(&chat_session_id) {
+            #[cfg(unix)]
+            {
+                pgid = proc.pgid;
+            }
             if let Err(e) = proc.stdin.write_all(b"{\"type\":\"close\"}\n").await {
                 log::warn!("Failed to send close command for session {chat_session_id}: {e}");
             }
@@ -1977,22 +2110,107 @@ pub async fn close_agent_session(
         let map = handles_clone.lock().await;
         map.get(&csid).map(|p| p.generation_id)
     };
+    #[cfg(unix)]
+    let app_clone = app.clone();
+    #[cfg(unix)]
+    let csid_for_pid = chat_session_id.clone();
     tokio::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_secs(CLOSE_TIMEOUT_SECS)).await;
         let mut map = handles_clone.lock().await;
         if let Some(proc) = map.get_mut(&csid) {
             if timeout_gen_id == Some(proc.generation_id) {
-                log::warn!("Close timeout for session {csid}, killing process");
-                let _ = proc.child.kill().await;
+                log::warn!("Close timeout for session {csid}, killing process group");
+                #[cfg(unix)]
+                if let Some(pg) = proc.pgid {
+                    unsafe {
+                        libc::killpg(pg as libc::pid_t, libc::SIGKILL);
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = proc.child.kill().await;
+                }
             } else {
                 // Generation mismatch: a new process has been spawned; skip kill and remove
                 return;
             }
         }
         map.remove(&csid);
+        drop(map);
+        // Sweep any remaining group members (grandchild processes) and clean up pid file
+        #[cfg(unix)]
+        {
+            if let Some(pg) = pgid {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                unsafe {
+                    libc::killpg(pg as libc::pid_t, libc::SIGTERM);
+                }
+            }
+            if let Ok(data_dir) = resolve_data_dir(&app_clone) {
+                remove_pgid(&data_dir, &csid_for_pid);
+            }
+        }
     });
 
     Ok(())
+}
+
+/// Force kill remaining processes in the map and clear it.
+/// Returns the list of session IDs that were in the map (for pid file cleanup).
+async fn force_kill_all_sessions(map: &mut AgentProcessMap) -> Vec<String> {
+    let session_ids: Vec<String> = map.keys().cloned().collect();
+    for csid in &session_ids {
+        if let Some(proc) = map.get_mut(csid) {
+            #[cfg(unix)]
+            if let Some(pg) = proc.pgid {
+                unsafe {
+                    libc::killpg(pg as libc::pid_t, libc::SIGKILL);
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = proc.child.kill().await;
+            }
+        }
+    }
+    map.clear();
+    session_ids
+}
+
+pub async fn close_all_agent_sessions(
+    app: &tauri::AppHandle,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+) {
+    // Send graceful close command to all sessions in a single lock
+    {
+        let mut map = handles.lock().await;
+        let ids: Vec<String> = map.keys().cloned().collect();
+        for csid in &ids {
+            if let Some(proc) = map.get_mut(csid) {
+                let _ = proc.stdin.write_all(b"{\"type\":\"close\"}\n").await;
+                let _ = proc.stdin.flush().await;
+            }
+        }
+    }
+
+    // Wait for graceful shutdown
+    tokio::time::sleep(std::time::Duration::from_secs(CLOSE_TIMEOUT_SECS)).await;
+
+    // Force kill remaining processes
+    let mut map = handles.lock().await;
+    let session_ids = force_kill_all_sessions(&mut map).await;
+    drop(map);
+
+    // Remove all pid files
+    #[cfg(unix)]
+    if let Ok(data_dir) = resolve_data_dir(app) {
+        for csid in &session_ids {
+            remove_pgid(&data_dir, csid);
+        }
+    }
+
+    #[cfg(not(unix))]
+    let _ = app;
 }
 
 #[tauri::command]
@@ -4352,5 +4570,367 @@ mod tests {
         assert_eq!(imgs.len(), 1);
         assert_eq!(imgs[0]["data"], "base64data");
         assert_eq!(imgs[0]["mediaType"], "image/png");
+    }
+
+    #[cfg(unix)]
+    mod process_group_tests {
+        use super::*;
+        use std::os::unix::process::CommandExt as _;
+
+        #[test]
+        fn save_and_remove_pgid() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+
+            save_pgid(app_data_dir, "session-1", 12345).unwrap();
+
+            let pid_file = pids_dir(app_data_dir).join("session-1.pid");
+            assert!(pid_file.exists());
+            let contents = std::fs::read_to_string(&pid_file).unwrap();
+            assert_eq!(contents, "12345");
+
+            remove_pgid(app_data_dir, "session-1");
+            assert!(!pid_file.exists());
+        }
+
+        #[test]
+        fn save_pgid_rejects_path_traversal() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+
+            assert!(save_pgid(app_data_dir, "../escape", 12345).is_err());
+            assert!(save_pgid(app_data_dir, "a/b", 12345).is_err());
+            assert!(save_pgid(app_data_dir, "", 12345).is_err());
+            assert!(save_pgid(app_data_dir, "valid-session-id", 12345).is_ok());
+        }
+
+        #[test]
+        fn cleanup_orphan_processes_removes_stale_pid_files() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+            let dir = pids_dir(app_data_dir);
+            std::fs::create_dir_all(&dir).unwrap();
+
+            // Write a PID file with a PGID that doesn't exist (use a very high number)
+            let pid_file = dir.join("stale-session.pid");
+            std::fs::write(&pid_file, "999999999").unwrap();
+            assert!(pid_file.exists());
+
+            cleanup_orphan_processes(app_data_dir);
+
+            // PID file should be removed
+            assert!(!pid_file.exists());
+        }
+
+        #[test]
+        fn cleanup_orphan_processes_handles_empty_dir() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+            let dir = pids_dir(app_data_dir);
+            std::fs::create_dir_all(&dir).unwrap();
+
+            cleanup_orphan_processes(app_data_dir);
+        }
+
+        #[test]
+        fn cleanup_orphan_processes_handles_no_dir() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path().join("nonexistent");
+
+            cleanup_orphan_processes(&app_data_dir);
+        }
+
+        #[test]
+        fn cleanup_orphan_processes_ignores_non_pid_files() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+            let dir = pids_dir(app_data_dir);
+            std::fs::create_dir_all(&dir).unwrap();
+
+            let other_file = dir.join("notes.txt");
+            std::fs::write(&other_file, "not a pid").unwrap();
+
+            cleanup_orphan_processes(app_data_dir);
+
+            assert!(other_file.exists());
+        }
+
+        /// Spawn a process in a new process group via setsid(), verify it
+        /// becomes a process group leader (pgid == pid), then verify that
+        /// killpg terminates the entire group.
+        #[test]
+        fn setsid_creates_new_process_group_leader() {
+            use std::process::Command;
+
+            let child = unsafe {
+                Command::new("sleep")
+                    .arg("999")
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .pre_exec(|| {
+                        if libc::setsid() == -1 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        Ok(())
+                    })
+                    .spawn()
+                    .unwrap()
+            };
+
+            let pid = child.id() as libc::pid_t;
+
+            // After setsid(), the child's PGID should equal its PID
+            let pgid = unsafe { libc::getpgid(pid) };
+            assert_eq!(
+                pgid, pid,
+                "setsid child should be its own process group leader"
+            );
+
+            // killpg should successfully terminate the group
+            let ret = unsafe { libc::killpg(pid, libc::SIGKILL) };
+            assert_eq!(ret, 0, "killpg should succeed");
+
+            // Reap the child
+            let mut child = child;
+            let _ = child.wait();
+
+            // Verify process is gone
+            let alive = unsafe { libc::kill(pid, 0) };
+            assert_ne!(alive, 0, "process should be terminated");
+        }
+
+        /// Verify killpg kills grandchild processes within the same group.
+        #[test]
+        fn killpg_kills_grandchild_processes() {
+            use std::process::Command;
+
+            // Spawn a shell that itself spawns a grandchild (sleep).
+            // Both shell and sleep will be in the new process group.
+            let child = unsafe {
+                Command::new("sh")
+                    .args(["-c", "sleep 999 & wait"])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .pre_exec(|| {
+                        if libc::setsid() == -1 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        Ok(())
+                    })
+                    .spawn()
+                    .unwrap()
+            };
+
+            let pgid = child.id() as libc::pid_t;
+
+            // Give the grandchild time to spawn
+            std::thread::sleep(std::time::Duration::from_millis(200));
+
+            // Kill the entire process group
+            let ret = unsafe { libc::killpg(pgid, libc::SIGKILL) };
+            assert_eq!(ret, 0, "killpg should succeed");
+
+            // Reap the child
+            let mut child = child;
+            let _ = child.wait();
+
+            // Verify no processes remain in this group
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            let group_alive = unsafe { libc::killpg(pgid, 0) };
+            assert_ne!(
+                group_alive, 0,
+                "no processes should remain in the killed group"
+            );
+        }
+
+        #[test]
+        fn cleanup_orphan_processes_kills_alive_process_group() {
+            use std::process::Command;
+
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+            let dir = pids_dir(app_data_dir);
+            std::fs::create_dir_all(&dir).unwrap();
+
+            // Spawn a process in a new process group via setsid()
+            let child = unsafe {
+                Command::new("sleep")
+                    .arg("999")
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .pre_exec(|| {
+                        if libc::setsid() == -1 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        Ok(())
+                    })
+                    .spawn()
+                    .unwrap()
+            };
+
+            let pgid = child.id() as libc::pid_t;
+
+            // Write a PID file for this process group
+            let pid_file = dir.join("alive-session.pid");
+            std::fs::write(&pid_file, pgid.to_string()).unwrap();
+
+            // Verify process is alive
+            assert_eq!(
+                unsafe { libc::killpg(pgid, 0) },
+                0,
+                "process group should be alive before cleanup"
+            );
+
+            cleanup_orphan_processes(app_data_dir);
+
+            // Give processes time to be reaped
+            std::thread::sleep(std::time::Duration::from_secs(3));
+
+            // Verify process group is terminated
+            let still_alive = unsafe { libc::killpg(pgid, 0) };
+            assert_ne!(
+                still_alive, 0,
+                "process group should be terminated after cleanup"
+            );
+
+            // PID file should be removed
+            assert!(!pid_file.exists());
+        }
+
+        #[test]
+        fn cleanup_orphan_processes_ignores_invalid_pgid_zero() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+            let dir = pids_dir(app_data_dir);
+            std::fs::create_dir_all(&dir).unwrap();
+
+            // Write a PID file with pgid=0 (dangerous: would target caller's group)
+            let pid_file = dir.join("bad-zero.pid");
+            std::fs::write(&pid_file, "0").unwrap();
+
+            cleanup_orphan_processes(app_data_dir);
+
+            // PID file should be removed without calling killpg(0, ...)
+            assert!(!pid_file.exists());
+        }
+
+        #[test]
+        fn cleanup_orphan_processes_ignores_invalid_pgid_one() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+            let dir = pids_dir(app_data_dir);
+            std::fs::create_dir_all(&dir).unwrap();
+
+            // Write a PID file with pgid=1 (init process)
+            let pid_file = dir.join("bad-one.pid");
+            std::fs::write(&pid_file, "1").unwrap();
+
+            cleanup_orphan_processes(app_data_dir);
+
+            // PID file should be removed without calling killpg(1, ...)
+            assert!(!pid_file.exists());
+        }
+
+        #[test]
+        fn cleanup_orphan_processes_ignores_negative_pgid() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+            let dir = pids_dir(app_data_dir);
+            std::fs::create_dir_all(&dir).unwrap();
+
+            let pid_file = dir.join("bad-negative.pid");
+            std::fs::write(&pid_file, "-1").unwrap();
+
+            cleanup_orphan_processes(app_data_dir);
+
+            assert!(!pid_file.exists());
+        }
+
+        fn make_dummy_agent_process(
+            child: tokio::process::Child,
+            stdin: tokio::process::ChildStdin,
+            pgid: Option<u32>,
+        ) -> AgentProcess {
+            AgentProcess {
+                stdin,
+                state: BridgeState::Initializing,
+                turn_phase: TurnPhase::Idle,
+                sdk_session_id: None,
+                child,
+                generation_id: 1,
+                pgid,
+                streaming_message_id: None,
+                streaming_parts: Vec::new(),
+                last_message_id: None,
+                task_id_map: HashMap::new(),
+                pending_message: None,
+                current_permission_mode: "default".to_string(),
+                available_models: Vec::new(),
+                selected_model: None,
+                last_result_token_usage: None,
+            }
+        }
+
+        /// Spawn processes with setsid into AgentProcessMap, then verify
+        /// force_kill_all_sessions actually terminates them.
+        #[tokio::test]
+        async fn force_kill_all_sessions_clears_map_and_kills_processes() {
+            let mut map: AgentProcessMap = HashMap::new();
+            let mut pids: Vec<u32> = Vec::new();
+
+            for id in ["sess-a", "sess-b"] {
+                let mut cmd = tokio::process::Command::new("sleep");
+                cmd.arg("999")
+                    .stdin(std::process::Stdio::piped())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null());
+                unsafe {
+                    cmd.pre_exec(|| {
+                        if libc::setsid() == -1 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        Ok(())
+                    });
+                }
+                let mut child = cmd.spawn().unwrap();
+                let stdin = child.stdin.take().unwrap();
+                let pid = child.id();
+                if let Some(p) = pid {
+                    pids.push(p);
+                }
+                map.insert(id.to_string(), make_dummy_agent_process(child, stdin, pid));
+            }
+
+            assert_eq!(map.len(), 2);
+
+            let returned_ids = force_kill_all_sessions(&mut map).await;
+
+            assert!(map.is_empty());
+            assert_eq!(returned_ids.len(), 2);
+            assert!(returned_ids.contains(&"sess-a".to_string()));
+            assert!(returned_ids.contains(&"sess-b".to_string()));
+
+            // Give processes time to be reaped
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+            // Verify all processes are actually dead
+            for pid in &pids {
+                let alive = unsafe { libc::kill(*pid as libc::pid_t, 0) };
+                assert_ne!(
+                    alive, 0,
+                    "process {pid} should be terminated after force_kill_all_sessions"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn force_kill_all_sessions_handles_empty_map() {
+            let mut map: AgentProcessMap = HashMap::new();
+
+            let returned_ids = force_kill_all_sessions(&mut map).await;
+
+            assert!(map.is_empty());
+            assert!(returned_ids.is_empty());
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -192,6 +192,18 @@ pub fn run() {
                 });
             }
 
+            // Clean up orphan agent processes from previous crashes (non-blocking)
+            #[cfg(unix)]
+            {
+                let data_dir_clone = data_dir.clone();
+                tauri::async_runtime::spawn(async move {
+                    let _ = tokio::task::spawn_blocking(move || {
+                        agent_sdk::cleanup_orphan_processes(&data_dir_clone);
+                    })
+                    .await;
+                });
+            }
+
             // Initialize builtin workflows
             if let Err(e) =
                 workflow::builtin::init_builtin_workflows(&workflow::storage::workflows_dir())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -192,16 +192,15 @@ pub fn run() {
                 });
             }
 
-            // Clean up orphan agent processes from previous crashes (non-blocking)
+            // Clean up orphan agent processes from previous crashes.
+            // Must complete before init_agent_sessions() to prevent killing newly spawned processes.
             #[cfg(unix)]
             {
                 let data_dir_clone = data_dir.clone();
-                tauri::async_runtime::spawn(async move {
-                    let _ = tokio::task::spawn_blocking(move || {
-                        agent_sdk::cleanup_orphan_processes(&data_dir_clone);
-                    })
-                    .await;
-                });
+                let _ = std::thread::spawn(move || {
+                    agent_sdk::cleanup_orphan_processes(&data_dir_clone);
+                })
+                .join();
             }
 
             // Initialize builtin workflows

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -84,6 +84,12 @@ fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
             QUIT_REQUESTED.store(true, Ordering::SeqCst);
             let app = app.clone();
             tauri::async_runtime::spawn(async move {
+                // Kill all agent sessions before stopping the server
+                if let Some(handles) =
+                    app.try_state::<std::sync::Arc<tokio::sync::Mutex<crate::agent_sdk::AgentProcessMap>>>()
+                {
+                    crate::agent_sdk::close_all_agent_sessions(&app, handles.inner()).await;
+                }
                 let _ = crate::ws_server::commands::stop_server_core(&app).await;
                 app.exit(0);
             });


### PR DESCRIPTION
## Summary
- Agent起動時に`setsid()`で独立プロセスグループを作成し、`killpg`で子プロセス（claude CLI, rust-analyzer等）を確実に終了
- PIDファイルによる孤児プロセス検出・クリーンアップ（アプリ起動時）
- アプリ終了時（トレイQuit）の全セッション一括終了

Closes #911

## Test plan
- [ ] `cargo test process_group_tests --lib` (10件PASS)
- [ ] セッション終了後にclaude CLIや孫プロセスが残っていないことを確認
- [ ] トレイメニューからQuit時に全Agentプロセスが終了することを確認
- [ ] アプリクラッシュ後の再起動で孤児プロセスがクリーンアップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * セッション終了時にメモリが適切に解放されない問題を修正
  * エージェント実行中に孤児化するプロセスが残存する問題を解決
  * アプリケーション起動時に残存するプロセスの検出と自動クリーンアップを実装

* **Documentation**
  * プロセス管理の仕様ドキュメントを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->