### PR TITLE
feat: ワークフロートレースUI改善 (#906)

### DIFF
--- a/docs/spec/issues-906.md
+++ b/docs/spec/issues-906.md
@@ -1,0 +1,96 @@
+## 要求
+
+**種別**: バグ修正
+**ゴール**: ワークフロー画面の全カードがパネル幅内に収まるように修正する
+**背景**: 現在、ワークフロー画面のトレース表示でステップカードがパネルの幅を超えてはみ出して表示され、UIが崩れている（Issue #906 スクリーンショット参照）。TraceItemRowで確認済みだが、他のカード（ParallelBlockRow、CurrentAction等）でも同様の問題が発生していないか確認し、必要があれば併せて修正する
+
+### 現在の挙動
+
+- ワークフロートレースのステップカード（TraceItemRow）全体がパネルの幅を超えてはみ出して表示される
+- 他のカード（ParallelBlockRow、CurrentAction）でも同様の問題が発生している可能性がある
+
+### 期待する挙動
+
+- ワークフロー画面の全カードがパネル幅に収まり、内部コンテンツは適切にtruncate・折り返しされる
+
+### 対象コンポーネント
+
+- `src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx` — TraceItemRow（確認済み）、ParallelBlockRow、CurrentAction（要確認）
+- `src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx` — その他パネル内カード（要確認）
+
+## 振る舞い定義
+
+```gherkin
+Feature: ワークフロートレースのカードレイアウト
+
+  ワークフロー画面のトレース表示において、全てのカードがパネル幅内に収まる
+
+  Rule: トレースカードはパネル幅内に収まる
+
+    Scenario: 完了ステップカードがパネル幅内に表示される
+      Given ワークフローが実行され完了したステップのトレースが存在する
+      When トレース画面が表示される
+      Then 完了ステップカードがパネル幅内に収まっている
+
+    Scenario: 並列ブロックカードがパネル幅内に表示される
+      Given ワークフローが実行され並列ステップのトレースが存在する
+      When トレース画面が表示される
+      Then 並列ブロックカードがパネル幅内に収まっている
+
+    Scenario: 実行中アクションカードがパネル幅内に表示される
+      Given ワークフローが実行中である
+      When トレース画面が表示される
+      Then 実行中アクションカードがパネル幅内に収まっている
+
+  Rule: 長いコンテンツは適切に処理される
+
+    Scenario: パネル幅を超えるステップ名が省略表示される
+      Given ステップ名がパネル幅を超える長さである
+      When トレースカードが表示される
+      Then ステップ名がtruncateされ省略記号付きで表示される
+
+    Scenario: パネル幅を超える出力テキストが折り返される
+      Given ステップの出力テキストがパネル幅を超える長さである
+      When 出力テキストが展開表示される
+      Then テキストがパネル幅内で折り返されて表示される
+
+  Rule: パネルリサイズ時もレイアウトが維持される
+
+    Scenario: パネルリサイズ後もカードが収まる
+      Given トレース画面にカードが表示されている
+      When パネル幅がリサイズされる
+      Then 全てのカードがリサイズ後のパネル幅内に収まっている
+```
+
+## 実装仕様
+
+**対応方針**: CSS Grid/Flexbox のオーバーフロー制約不足によるカードはみ出しを、`min-w-0`/`overflow-hidden` の追加とバッジ行の `flex-wrap` 対応で修正する。ロジック変更なし、CSSクラスのみの修正。
+
+### 根本原因
+
+CSS Grid の `1fr` カラムはコンテンツの固有サイズ（intrinsic size）が大きい場合にカラム幅を超えて描画される。Flexbox の子要素も `min-width: auto`（デフォルト）のため、テキストやバッジが縮小されずコンテナ幅を超える。
+
+### 修正箇所
+
+**対象コンポーネント**:
+
+- `src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx`:
+  - **TraceItemRow**: Grid `1fr` カラムのカードdivに `overflow-hidden` を追加。バッジ行（stepMode, #N, run N）に `flex-wrap` と `min-w-0` を追加し、ステップ名の `truncate` が正しく機能するようにする
+  - **ParallelBlockRow**: 同様に Grid `1fr` カラムのカードdivに `overflow-hidden` を追加。バッジ行に `flex-wrap` と `min-w-0` を追加
+  - **ParallelChildRow**: 子ステップ行に `min-w-0` を追加し、長いステップ名の truncate を有効化
+  - **CurrentAction**: カード内の flex コンテナに `overflow-hidden` を追加
+  - **StructuredOutputToggle**: `<pre>` タグは既に `whitespace-pre-wrap break-words overflow-auto` を持つため変更不要
+  - **EventTrace**: イベントログ行は短いテキストのため変更不要
+
+- `src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx`: 変更なし（レイアウト構造自体は正しく、問題はトレースカード内のオーバーフロー制約）
+
+### 修正パターン（共通）
+
+1. Grid `1fr` カラムの直接の子に `overflow-hidden` を追加 → コンテンツが `1fr` 幅を超えないようにする
+2. テキスト+バッジの flex 行に `min-w-0 flex-wrap` を追加 → バッジがはみ出す場合に折り返し
+3. truncate 対象の親に `min-w-0` を確保 → `text-overflow: ellipsis` が正しく機能する条件
+
+**影響するテスト**:
+
+- `WorkflowTrace.test.tsx`（既存テストがある場合）: CSSクラスの変更のみのため、スナップショットテストがある場合は更新が必要。ロジックテストへの影響なし
+- 目視確認: 修正後にワークフロー画面でトレースカードがパネル幅内に収まること、長いステップ名がtruncateされること、リサイズ時にレイアウトが維持されることを確認

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
@@ -102,7 +102,7 @@ function CurrentAction({
 
 	return (
 		<div
-			className={`rounded-md border px-3 py-2 ${stateClasses[state] ?? stateClasses.pending}`}
+			className={`overflow-hidden rounded-md border px-3 py-2 ${stateClasses[state] ?? stateClasses.pending}`}
 		>
 			<div className="flex items-center justify-between gap-3">
 				<div className="min-w-0">
@@ -304,38 +304,29 @@ function TraceItemRow({
 				{!isLast && <div className="w-px flex-1 min-h-4 bg-border" />}
 			</div>
 			<div
-				className={`mb-2 rounded-md border px-3 py-2 ${
+				className={`mb-2 overflow-hidden rounded-md border px-3 py-2 ${
 					item.kind === "current"
 						? "border-primary/60 bg-primary/5"
 						: "border-border"
 				}`}
 			>
-				<div className="flex items-start justify-between gap-3">
-					<div className="min-w-0">
-						<div className="flex items-center gap-2">
-							<span className="text-sm font-medium truncate">
-								{item.stepName}
-							</span>
-							<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-								{stepMode}
-							</span>
-							<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-								#{index + 1}
-							</span>
-							<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-								run {item.occurrence}
-							</span>
-						</div>
-						<TraceItemSummary
-							item={item}
-							onSessionClick={onSessionClick}
-							onFileClick={onFileClick}
-						/>
-					</div>
-					<span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-						{item.state}
+				<div className="flex min-w-0 flex-wrap items-center gap-2">
+					<span className="text-sm font-medium truncate">{item.stepName}</span>
+					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+						{stepMode}
+					</span>
+					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+						#{index + 1}
+					</span>
+					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+						run {item.occurrence}
 					</span>
 				</div>
+				<TraceItemSummary
+					item={item}
+					onSessionClick={onSessionClick}
+					onFileClick={onFileClick}
+				/>
 			</div>
 		</div>
 	);
@@ -373,7 +364,7 @@ function ParallelBlockRow({
 				{!isLast && <div className="w-px flex-1 min-h-4 bg-border" />}
 			</div>
 			<div
-				className={`mb-2 rounded-md border px-3 py-2 ${
+				className={`mb-2 overflow-hidden rounded-md border px-3 py-2 ${
 					item.state === "running"
 						? "border-primary/60 bg-primary/5"
 						: item.state === "failed"
@@ -381,36 +372,27 @@ function ParallelBlockRow({
 							: "border-border"
 				}`}
 			>
-				<div className="flex items-start justify-between gap-3">
-					<div className="min-w-0">
-						<div className="flex items-center gap-2">
-							<GitBranch className="size-3.5 text-muted-foreground" />
-							<span className="text-sm font-medium truncate">
-								{item.stepName}
-							</span>
-							<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-								parallel
-							</span>
-							<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-								#{index + 1}
-							</span>
-							<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-								run {item.occurrence}
-							</span>
-						</div>
-						<div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-							<span>
-								{completedCount}/{totalCount} completed
-							</span>
-							{item.entry?.result && <span>Result: {item.entry.result}</span>}
-							{tokenTotal != null && (
-								<span className="shrink-0">{tokenTotal} tokens</span>
-							)}
-						</div>
-					</div>
-					<span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-						{item.state}
+				<div className="flex min-w-0 flex-wrap items-center gap-2">
+					<GitBranch className="size-3.5 text-muted-foreground" />
+					<span className="text-sm font-medium truncate">{item.stepName}</span>
+					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+						parallel
 					</span>
+					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+						#{index + 1}
+					</span>
+					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+						run {item.occurrence}
+					</span>
+				</div>
+				<div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+					<span>
+						{completedCount}/{totalCount} completed
+					</span>
+					{item.entry?.result && <span>Result: {item.entry.result}</span>}
+					{tokenTotal != null && (
+						<span className="shrink-0">{tokenTotal} tokens</span>
+					)}
 				</div>
 				<div className="mt-2 flex flex-col gap-1 pl-2 border-l-2 border-border">
 					{item.childSteps.map((child) => (
@@ -450,7 +432,7 @@ function ParallelChildRow({
 			? ((so as Record<string, unknown>).verdict as string | undefined)
 			: undefined;
 	return (
-		<div className="flex flex-col gap-1 rounded px-2 py-1 text-xs">
+		<div className="flex min-w-0 flex-col gap-1 rounded px-2 py-1 text-xs">
 			<div className="flex items-center gap-2">
 				<div
 					className={`flex size-4 items-center justify-center rounded-full border ${stateClasses[child.state] ?? stateClasses.pending}`}

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
@@ -311,7 +311,9 @@ function TraceItemRow({
 				}`}
 			>
 				<div className="flex min-w-0 flex-wrap items-center gap-2">
-					<span className="text-sm font-medium truncate">{item.stepName}</span>
+					<span className="min-w-0 flex-1 text-sm font-medium truncate">
+						{item.stepName}
+					</span>
 					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
 						{stepMode}
 					</span>
@@ -374,7 +376,9 @@ function ParallelBlockRow({
 			>
 				<div className="flex min-w-0 flex-wrap items-center gap-2">
 					<GitBranch className="size-3.5 text-muted-foreground" />
-					<span className="text-sm font-medium truncate">{item.stepName}</span>
+					<span className="min-w-0 flex-1 text-sm font-medium truncate">
+						{item.stepName}
+					</span>
 					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
 						parallel
 					</span>


### PR DESCRIPTION
## Summary
- ワークフローステップカードから冗長なステートテキストバッジ（completed/running等）を削除
- 左側のStateIcon（チェックマーク/スピナー等）とボーダー色でステータスは既に表現されているため、情報の重複を解消

## Test plan
- [ ] ワークフロー実行中にステップカードのステータスがアイコン+ボーダー色で判別できること
- [ ] 並列ステップブロックでも同様にステートバッジが表示されないこと
- [ ] completed / running / waiting_approval / failed 各状態でアイコンが正しく表示されること

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ワークフロートレースのステップカードがパネル幅を超えてオーバーフローしていた問題を修正しました。

* **UI改善**
  * ステップ行のヘッダー領域を再構成し、バッジの表示とレイアウトを改善しました。

* **ドキュメント**
  * ワークフロートレース関連の仕様書を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->