### PR TITLE
feat: 設定画面Repositoriesセクションにリポジトリ削除UIを追加

### DIFF
--- a/docs/spec/issues-917.md
+++ b/docs/spec/issues-917.md
@@ -1,0 +1,85 @@
+## 要求
+
+**種別**: 改善
+**ゴール**: ユーザーが設定画面（SettingsModal）のRepositoriesセクションから、登録済みリポジトリを削除できる
+**背景**: バックエンド（`remove_repo_path` Tauriコマンド）とフロントエンドフック（`useRepoList.removeRepo`）は実装済みだが、UIに削除操作の導線がない。ユーザーは登録したリポジトリを解除する手段がなく、不要なリポジトリが一覧に残り続ける。
+
+### 現状
+- `src-tauri/src/repo_registry.rs`: `remove_repo_path` コマンド実装済み
+- `src/hooks/useRepoList.ts`: `removeRepo` 関数実装済み
+- `src/components/panels/SettingsModal.tsx`: `RepositoriesSection` にはベースブランチ設定のみ表示。削除UIなし
+
+### 要件
+- 設定画面のRepositoriesセクションで、各リポジトリに削除ボタンを表示する
+- 削除ボタン押下時に確認ダイアログを表示し、確認後に削除を実行する
+- 削除は登録解除のみ（ディスク上のリポジトリは削除しない）
+- 削除操作はワークスペースマネージャー画面（`App.tsx`）の設定画面からのみ可能とする。worktreeビュー（`MainLayout.tsx`）の設定画面では削除ボタンを表示しない（現在作業中のリポジトリを削除した場合の画面遷移が未定義のため）
+- 確認ダイアログは既存の `DeleteConfirmDialog` を再利用するが、説明文をカスタマイズ可能にし、登録解除であることが伝わるメッセージ（例: "Remove from list? The repository will not be deleted from disk."）を表示する
+- 削除処理のエラーは現時点ではログのみとし、ユーザー通知は行わない
+
+## 振る舞い定義
+
+```gherkin
+Feature: 登録済みリポジトリの削除
+
+  Rule: リポジトリの登録解除
+    Scenario: 確認後にリポジトリが登録解除される
+      Given リポジトリが登録されている
+      When そのリポジトリの削除を確認する
+      Then リポジトリが登録一覧から除外される
+      And ディスク上のリポジトリは削除されない
+
+    Scenario: 削除をキャンセルするとリポジトリは維持される
+      Given リポジトリが登録されている
+      When そのリポジトリの削除をキャンセルする
+      Then リポジトリは登録一覧に残る
+
+  Rule: Repositoriesセクションの削除UI表示
+    Scenario: ワークスペースマネージャーの設定画面で各リポジトリに削除操作が表示される
+      Given ワークスペースマネージャーの設定画面のRepositoriesセクションを表示している
+      When リポジトリが登録されている
+      Then 各リポジトリに削除ボタンが表示される
+
+    Scenario: worktreeビューの設定画面では削除ボタンが表示されない
+      Given worktreeビューの設定画面のRepositoriesセクションを表示している
+      When リポジトリが登録されている
+      Then リポジトリに削除ボタンが表示されない
+
+    Scenario: 削除開始時に確認ダイアログが表示される
+      Given ワークスペースマネージャーの設定画面のRepositoriesセクションを表示している
+      When リポジトリの削除ボタンを押す
+      Then 確認ダイアログが表示される
+      And 確認ダイアログにはリポジトリがディスクから削除されない旨のメッセージが表示される
+
+    Scenario: 登録解除後にリポジトリが一覧から消える
+      Given ワークスペースマネージャーの設定画面のRepositoriesセクションにリポジトリが表示されている
+      When そのリポジトリの登録が解除される
+      Then リポジトリが一覧から消える
+```
+
+## 実装仕様
+
+**対応方針**: 振る舞い定義を実現するために、`SettingsModal` に `onRemoveRepo` コールバックを追加し、`RepositoriesSection` の各リポジトリ項目に削除ボタンを配置する。削除確認には既存の `DeleteConfirmDialog` コンポーネントを再利用し、説明文をカスタマイズ可能にする。バックエンド（`remove_repo_path`）とフック（`useRepoList.removeRepo`）は実装済みのため、UI層の接続のみで完結する。
+
+**対象コンポーネント**:
+- `src/components/panels/DeleteConfirmDialog.tsx`:
+  - `DeleteConfirmDialogProps` にオプショナルな `description?: string` を追加
+  - `description` が指定された場合はデフォルトメッセージの代わりに表示する
+- `src/components/panels/SettingsModal.tsx`:
+  - `SettingsModalProps` に `onRemoveRepo?: (path: string) => void` を追加
+  - `RepositoriesSection` に `onRemoveRepo` を伝播
+  - `onRemoveRepo` が未指定の場合、削除ボタンを表示しない
+  - `RepoBaseBranchItem` の各行に `Trash2` アイコンの削除ボタンを追加（`onRemoveRepo` が指定されている場合のみ）
+  - 削除ボタン押下で `DeleteConfirmDialog` を表示する状態管理を `RepositoriesSection` に追加
+  - `DeleteConfirmDialog` の `description` に登録解除である旨のメッセージを指定する
+  - 確認後に `onRemoveRepo(path)` を呼び出し（リスト更新は `repo-paths-changed` イベント経由で自動反映）
+- `src/App.tsx`: `SettingsModal` に `onRemoveRepo={removeRepo}` を追加（`useRepoList` から `removeRepo` を取得）
+- `src/screens/MainLayout.tsx`: `SettingsModal` に `onRemoveRepo` を渡さない（worktreeビューでは削除操作を提供しない）
+
+**エラーハンドリング**: `useRepoList.removeRepo` のエラーは現時点では `console.warn` でログするのみとし、UIレベルでのエラー通知は行わない。
+
+**影響するテスト**:
+- `src/components/panels/SettingsModal.test.tsx`: 削除ボタンの表示（`onRemoveRepo` 有無による出し分け）、確認ダイアログの表示/キャンセル/確認後コールバック呼び出しのテストを追加
+- `src/components/panels/DeleteConfirmDialog.test.tsx`: カスタム `description` の表示テストを追加（既存テストがある場合）
+- `src/hooks/useRepoList.test.ts`: 既存テストで `removeRepo` はカバー済み。追加不要
+- `src-tauri/src/repo_registry.rs`: 既存テストで `remove_repo` はカバー済み。追加不要

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
 	const updateChecker = useUpdateChecker(settings.autoUpdate);
 	const { worktrees, selectedWorktreeId, openWorktreeTab } =
 		useWorkspaceNavigation();
-	const { repoPaths, addRepo, initFromCwd } = useRepoList();
+	const { repoPaths, addRepo, removeRepo, initFromCwd } = useRepoList();
 
 	const [initializing, setInitializing] = useState(true);
 	useRemoteAutoStart(!initializing);
@@ -200,6 +200,7 @@ function App() {
 				settings={settings}
 				onSave={updateSettings}
 				repoPaths={repoPaths}
+				onRemoveRepo={removeRepo}
 			/>
 		</TooltipProvider>
 	);

--- a/src/components/panels/DeleteConfirmDialog.test.tsx
+++ b/src/components/panels/DeleteConfirmDialog.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
+
+beforeAll(() => {
+	HTMLElement.prototype.hasPointerCapture = vi.fn() as never;
+	HTMLElement.prototype.releasePointerCapture = vi.fn() as never;
+	HTMLElement.prototype.setPointerCapture = vi.fn() as never;
+	HTMLElement.prototype.scrollIntoView = vi.fn() as never;
+});
+
+describe("DeleteConfirmDialog", () => {
+	const defaultProps = {
+		open: true,
+		itemName: "test-item",
+		onConfirm: vi.fn(),
+		onCancel: vi.fn(),
+	};
+
+	it("should display default description when description prop is not provided", () => {
+		render(<DeleteConfirmDialog {...defaultProps} />);
+		expect(
+			screen.getByText('Delete "test-item"? This action cannot be undone.'),
+		).toBeInTheDocument();
+	});
+
+	it("should display custom description when description prop is provided", () => {
+		render(
+			<DeleteConfirmDialog
+				{...defaultProps}
+				description="Remove from list? The repository will not be deleted from disk."
+			/>,
+		);
+		expect(
+			screen.getByText(
+				"Remove from list? The repository will not be deleted from disk.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("should call onConfirm when Delete button is clicked", async () => {
+		const user = userEvent.setup();
+		const onConfirm = vi.fn();
+		render(<DeleteConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+		await user.click(screen.getByRole("button", { name: "Delete" }));
+		expect(onConfirm).toHaveBeenCalledOnce();
+	});
+
+	it("should call onCancel when Cancel button is clicked", async () => {
+		const user = userEvent.setup();
+		const onCancel = vi.fn();
+		render(<DeleteConfirmDialog {...defaultProps} onCancel={onCancel} />);
+		await user.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(onCancel).toHaveBeenCalled();
+	});
+});

--- a/src/components/panels/DeleteConfirmDialog.tsx
+++ b/src/components/panels/DeleteConfirmDialog.tsx
@@ -12,6 +12,7 @@ import {
 interface DeleteConfirmDialogProps {
 	open: boolean;
 	itemName: string;
+	description?: string;
 	onConfirm: () => void;
 	onCancel: () => void;
 }
@@ -19,6 +20,7 @@ interface DeleteConfirmDialogProps {
 export function DeleteConfirmDialog({
 	open,
 	itemName,
+	description,
 	onConfirm,
 	onCancel,
 }: DeleteConfirmDialogProps) {
@@ -28,7 +30,8 @@ export function DeleteConfirmDialog({
 				<AlertDialogHeader>
 					<AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
 					<AlertDialogDescription>
-						Delete "{itemName}"? This action cannot be undone.
+						{description ??
+							`Delete "${itemName}"? This action cannot be undone.`}
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>

--- a/src/components/panels/SettingsModal.test.tsx
+++ b/src/components/panels/SettingsModal.test.tsx
@@ -661,4 +661,110 @@ describe("SettingsModal", () => {
 
 		expect(screen.queryByTitle("Delete workflow")).not.toBeInTheDocument();
 	});
+
+	describe("Repository removal", () => {
+		const repoMockSetup = async () => {
+			const { invoke } = await import("@tauri-apps/api/core");
+			vi.mocked(invoke).mockImplementation((cmd: string) => {
+				switch (cmd) {
+					case "list_branches":
+						return Promise.resolve([{ name: "main", is_remote: false }]);
+					case "get_releash_base":
+						return Promise.resolve(null);
+					case "get_notify_config":
+						return Promise.resolve({
+							webhook_url: "",
+							on_running: false,
+							on_done: true,
+							on_error: true,
+							on_waiting: true,
+							desktop_mode: "always",
+							inactive_timeout_minutes: 2,
+						});
+					case "get_remote_config":
+						return Promise.resolve({
+							auto_start: false,
+							auto_start_on_lan: false,
+						});
+					case "get_mcp_config":
+						return Promise.resolve({ port: 19801, token: "test-token" });
+					case "get_configured_agents":
+						return Promise.resolve([]);
+					case "preview_agent_mcp_config":
+						return Promise.resolve("");
+					default:
+						return Promise.resolve(null);
+				}
+			});
+		};
+
+		it("should show remove button when onRemoveRepo is provided", async () => {
+			await repoMockSetup();
+			const onRemoveRepo = vi.fn();
+			render(<SettingsModal {...defaultProps} onRemoveRepo={onRemoveRepo} />);
+			fireEvent.click(screen.getByText("Repositories"));
+			await waitFor(() => {
+				expect(
+					screen.getByRole("button", { name: /Remove repository/ }),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("should not show remove button when onRemoveRepo is not provided", async () => {
+			await repoMockSetup();
+			render(<SettingsModal {...defaultProps} />);
+			fireEvent.click(screen.getByText("Repositories"));
+			await waitFor(() => {
+				expect(screen.getByText("Base branch")).toBeInTheDocument();
+			});
+			expect(
+				screen.queryByRole("button", { name: /Remove repository/ }),
+			).not.toBeInTheDocument();
+		});
+
+		it("should show confirm dialog with unregister message when remove button is clicked", async () => {
+			await repoMockSetup();
+			const user = userEvent.setup();
+			const onRemoveRepo = vi.fn();
+			render(<SettingsModal {...defaultProps} onRemoveRepo={onRemoveRepo} />);
+			fireEvent.click(screen.getByText("Repositories"));
+			const removeBtn = await screen.findByRole("button", {
+				name: /Remove repository/,
+			});
+			await user.click(removeBtn);
+			expect(
+				screen.getByText(
+					"Remove from list? The repository will not be deleted from disk.",
+				),
+			).toBeInTheDocument();
+		});
+
+		it("should call onRemoveRepo when deletion is confirmed", async () => {
+			await repoMockSetup();
+			const user = userEvent.setup();
+			const onRemoveRepo = vi.fn();
+			render(<SettingsModal {...defaultProps} onRemoveRepo={onRemoveRepo} />);
+			fireEvent.click(screen.getByText("Repositories"));
+			const removeBtn = await screen.findByRole("button", {
+				name: /Remove repository/,
+			});
+			await user.click(removeBtn);
+			await user.click(screen.getByRole("button", { name: "Delete" }));
+			expect(onRemoveRepo).toHaveBeenCalledWith("/repos/my-app");
+		});
+
+		it("should not call onRemoveRepo when deletion is cancelled", async () => {
+			await repoMockSetup();
+			const user = userEvent.setup();
+			const onRemoveRepo = vi.fn();
+			render(<SettingsModal {...defaultProps} onRemoveRepo={onRemoveRepo} />);
+			fireEvent.click(screen.getByText("Repositories"));
+			const removeBtn = await screen.findByRole("button", {
+				name: /Remove repository/,
+			});
+			await user.click(removeBtn);
+			await user.click(screen.getByRole("button", { name: "Cancel" }));
+			expect(onRemoveRepo).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/src/components/panels/SettingsModal.tsx
+++ b/src/components/panels/SettingsModal.tsx
@@ -60,6 +60,7 @@ import {
 	type DesktopNotifyMode,
 	INACTIVE_TIMEOUT_OPTIONS,
 } from "@/types/webhook";
+import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
 import { McpSettingsSection } from "./McpSettingsSection";
 import { NotionSettingsSection } from "./NotionSettingsSection";
 
@@ -547,6 +548,7 @@ function RepositoriesSection({
 	onDirtyChange,
 	error,
 	revision,
+	onRemoveRepo,
 }: {
 	repoPaths: string[];
 	onDirtyChange: (
@@ -556,7 +558,10 @@ function RepositoriesSection({
 	) => void;
 	error: string | null;
 	revision: number;
+	onRemoveRepo?: (path: string) => void;
 }) {
+	const [removeTarget, setRemoveTarget] = useState<string | null>(null);
+
 	if (repoPaths.length === 0) {
 		return (
 			<p className="text-xs text-muted-foreground">
@@ -571,12 +576,40 @@ function RepositoriesSection({
 			{repoPaths.map((repoPath, i) => (
 				<Fragment key={`${repoPath}-${revision}`}>
 					{i > 0 && <Separator className="my-3" />}
-					<RepoBaseBranchItem
-						repoPath={repoPath}
-						onDirtyChange={onDirtyChange}
-					/>
+					<div className="flex items-start gap-1">
+						<div className="flex-1 min-w-0">
+							<RepoBaseBranchItem
+								repoPath={repoPath}
+								onDirtyChange={onDirtyChange}
+							/>
+						</div>
+						{onRemoveRepo && (
+							<Button
+								variant="ghost"
+								size="icon"
+								className="size-7 mt-1.5 shrink-0 text-destructive hover:text-destructive"
+								onClick={() => setRemoveTarget(repoPath)}
+								aria-label={`Remove repository ${repoPath.split(/[\\/]/).pop() ?? repoPath}`}
+								title="Remove repository"
+							>
+								<Trash2 className="size-3.5" />
+							</Button>
+						)}
+					</div>
 				</Fragment>
 			))}
+			{onRemoveRepo && removeTarget && (
+				<DeleteConfirmDialog
+					open={true}
+					itemName={removeTarget.split(/[\\/]/).pop() ?? removeTarget}
+					description="Remove from list? The repository will not be deleted from disk."
+					onConfirm={() => {
+						onRemoveRepo(removeTarget);
+						setRemoveTarget(null);
+					}}
+					onCancel={() => setRemoveTarget(null)}
+				/>
+			)}
 		</div>
 	);
 }
@@ -1287,6 +1320,7 @@ export interface SettingsModalProps {
 	settings: AppSettings;
 	onSave: (settings: AppSettings) => void;
 	repoPaths?: string[];
+	onRemoveRepo?: (path: string) => void;
 }
 
 export function SettingsModal({
@@ -1295,6 +1329,7 @@ export function SettingsModal({
 	settings,
 	onSave,
 	repoPaths = [],
+	onRemoveRepo,
 }: SettingsModalProps) {
 	const [state, dispatchSettings] = useReducer(settingsReducer, {
 		activeSection: "appearance" as SettingsSection,
@@ -1475,6 +1510,7 @@ export function SettingsModal({
 						onDirtyChange={repos.handleDirtyChange}
 						error={repos.error}
 						revision={repos.revision}
+						onRemoveRepo={onRemoveRepo}
 					/>
 				);
 			case "notion":


### PR DESCRIPTION
## Summary
- ワークスペースマネージャーの設定画面 Repositories セクションに、登録済みリポジトリの削除ボタンを追加
- `DeleteConfirmDialog` にカスタム `description` prop を追加し、登録解除である旨のメッセージを表示
- worktreeビューの設定画面では削除ボタンを非表示（安全性のため）

Closes #917

## Test plan
- [x] `onRemoveRepo` 指定時に削除ボタンが表示される
- [x] `onRemoveRepo` 未指定時に削除ボタンが非表示
- [x] 削除ボタン押下で確認ダイアログが表示され、登録解除メッセージが表示される
- [x] 確認後に `onRemoveRepo` コールバックが呼ばれる
- [x] キャンセル時に `onRemoveRepo` が呼ばれない
- [x] `DeleteConfirmDialog` のカスタム description 表示
- [x] lint / test / build 全て PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Settings モーダルのリポジトリセクションから登録済みリポジトリを削除（登録解除）できるようになりました。削除操作時には確認ダイアログが表示され、キャンセルで削除を中止できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->