### PR TITLE
feat: cycle_guardのon_exhausted/resets_cycle_forでループ上限回復を実現

### DIFF
--- a/docs/spec/issues-932.md
+++ b/docs/spec/issues-932.md
@@ -1,0 +1,319 @@
+## 要求
+
+**種別**: 改善
+**ゴール**: ワークフローエンジンの cycle_guard（ループ上限）到達時に、Failed終了ではなく指定したステップへ遷移できるようにする。併せてガードのカウントリセット機構を追加し、ビルトインワークフローのガード設定を見直す。
+**背景**: 現状、cycle_guard 到達時はワークフロー全体が Failed で終了し回復手段がない。ループ上限に達しても内容が問題なければユーザー判断で先に進みたいケースがあり、Interactive ステップに遷移して「先に進む」等を選択可能にすることでワークフロー全体のやり直しを防ぐ。
+
+### 詳細
+
+#### 1. cycle_guard に `on_exhausted` オプションを追加
+
+現状の cycle_guard は `max_iterations` のみで、上限到達時は一律 Failed になる。
+遷移先ステップを指定できる `on_exhausted` を追加し、設定されていれば Failed ではなくそのステップに遷移する。
+未設定の場合は現行通り Failed で終了する。
+
+```yaml
+cycle_guard:
+  max_iterations: 2
+  on_exhausted: plan_approval  # 任意。未設定なら現行通り Failed
+```
+
+#### 2. ステップ定義に `resets_cycle_for` を追加
+
+特定のステップに到達した際に、指定したステップの cycle_guard カウントをリセットする。
+on_exhausted で approval ステップに遷移した後、ユーザー判断でループに戻す場合にカウントがリセットされている必要がある。
+
+```yaml
+- name: plan_approval
+  mode: interactive
+  resets_cycle_for:       # このステップに到達したら指定ステップのカウントをリセット
+    - plan_fix
+```
+
+#### 3. `plan_fix` のガード設定変更
+
+`spec-driven-development.yml` の `plan_fix` ステップ:
+- `cycle_guard.max_iterations` を 3 → 2 に変更
+- `on_exhausted: plan_approval` を追加（上限到達時は既存の承認ステップへ）
+
+#### 4. `fix`（コードレビュー修正）にガードを追加
+
+`fix` ステップにはガードが未設定。新規追加する:
+- `cycle_guard.max_iterations: 3`
+- `on_exhausted: implementation_approval`（上限到達時は既存の承認ステップへ）
+
+#### 5. approval ステップの判断を fix / review に伝播
+
+approval ステップ（`plan_approval` / `implementation_approval`）でユーザーが NEEDS_FIX で拒否した場合、その判断（無視してよい観点、修正方針等）を後続の fix や review が参照できるようにする。
+既存の `output_contract: review-verdict` の出力を `pass_output_from` で伝播する。
+
+- `fix` の `pass_output_from` に `implementation_approval` を追加
+- `code_review_parallel` の各子ステップの `pass_output_from` に `implementation_approval` を追加
+- `plan_fix` の `pass_output_from` に `plan_approval` を追加（既に `plan_review_parallel` 経由で到達するが、approval の判断も渡す）
+- `plan_review_parallel` の各子ステップの `pass_output_from` に `plan_approval` を追加
+
+#### 6. ビルトインワークフローの適用イメージ
+
+```yaml
+# plan_fix: レビュー修正ループ（上限2回、超過時は承認ステップへ）
+- name: plan_fix
+  mode: auto
+  pass_output_from:
+    - plan_review_parallel
+    - plan_spec
+    - plan_approval             # ユーザーの判断（無視する観点、修正方針）
+  cycle_guard:
+    max_iterations: 2
+    on_exhausted: plan_approval
+
+# plan_approval: 到達時に plan_fix のカウントをリセット
+- name: plan_approval
+  mode: interactive
+  output_contract: review-verdict
+  pass_output_from:
+    - plan_spec
+    - plan_review_parallel      # レビュー結果（on_exhausted経由時に判断材料として必要）
+  resets_cycle_for:
+    - plan_fix
+  rules:
+    - match: NEEDS_FIX
+      next: plan_fix
+
+# plan_review の各子ステップ: ユーザーの判断を参照
+- name: plan_review_completeness  # （他の子ステップも同様）
+  pass_output_from:
+    - plan_spec
+    - plan_approval             # ユーザーの判断（無視してよい観点等）
+
+# fix: コードレビュー修正ループ（上限3回、超過時は承認ステップへ）
+- name: fix
+  mode: auto
+  pass_output_from:
+    - code_review_parallel
+    - plan_spec
+    - implementation_approval   # ユーザーの判断（無視する観点、修正方針）
+  cycle_guard:
+    max_iterations: 3
+    on_exhausted: implementation_approval
+
+# implementation_approval: 到達時に fix のカウントをリセット
+- name: implementation_approval
+  mode: interactive
+  output_contract: review-verdict
+  pass_output_from:
+    - plan_spec
+    - implement
+    - code_review_parallel      # レビュー結果（on_exhausted経由時に判断材料として必要）
+  resets_cycle_for:
+    - fix
+  rules:
+    - match: NEEDS_FIX
+      next: fix
+
+# code_review の各子ステップ: ユーザーの判断を参照
+- name: code_review_acceptance  # （他の子ステップも同様）
+  pass_output_from:
+    - plan_spec
+    - implement
+    - implementation_approval   # ユーザーの判断（無視してよい観点等）
+```
+
+#### 7. `fix_quality_check` の既存ガードを削除
+
+`fix` にガードを追加するため、`fix_quality_check` の既存ガード（max_iterations: 5）は不要。削除する。
+
+## 振る舞い定義
+
+```gherkin
+Feature: ワークフローのループ上限回復
+
+  Rule: ループ上限到達時に遷移先ステップを指定できる
+    Scenario: on_exhausted 設定済みステップがループ上限に達する
+      Given ステップの cycle_guard に on_exhausted が設定されている
+      When ループ回数が max_iterations に達する
+      Then on_exhausted で指定されたステップに遷移する
+
+    Scenario: on_exhausted 未設定のステップがループ上限に達する
+      Given ステップの cycle_guard に on_exhausted が設定されていない
+      When ループ回数が max_iterations に達する
+      Then ワークフローは Failed で終了する
+
+  Rule: ステップ到達時に指定ステップのループカウントをリセットできる
+    Scenario: resets_cycle_for 設定のステップに到達する
+      Given ステップに resets_cycle_for が設定されている
+      When そのステップに到達する
+      Then 指定されたステップの cycle_guard カウントが 0 にリセットされる
+
+    Scenario: リセット後にループ上限まで再実行できる
+      Given あるステップの cycle_guard カウントがリセットされた
+      When そのステップへの遷移が発生する
+      Then max_iterations 回まで再実行できる
+
+  Rule: on_exhausted の遷移先が cycle_guard 超過状態の場合は連鎖的に遷移する
+    Scenario: 遷移先も cycle_guard 超過で on_exhausted 設定済みの場合は更に遷移する
+      Given ステップ A の on_exhausted がステップ B を指定している
+      And ステップ B も cycle_guard 超過状態で on_exhausted がステップ C を指定している
+      When ステップ A がループ上限に達する
+      Then ステップ C に遷移する
+
+    Scenario: 遷移先が cycle_guard 超過で on_exhausted 未設定の場合は Failed で終了する
+      Given ステップ A の on_exhausted がステップ B を指定している
+      And ステップ B は cycle_guard 超過状態で on_exhausted が設定されていない
+      When ステップ A がループ上限に達する
+      Then ワークフローは Failed で終了する
+
+Feature: ビルトインワークフローのループ制御
+
+  Rule: 計画修正ループは上限2回で承認に遷移する
+    Scenario: plan_fix が2回実行され plan_approval へ遷移する
+      Given plan_fix がレビュー指摘の修正を実行している
+      When plan_fix が 2 回実行される
+      Then plan_approval に遷移する
+
+  Rule: コード修正ループは上限3回で承認に遷移する
+    Scenario: fix が3回実行され implementation_approval へ遷移する
+      Given fix がコードレビュー指摘の修正を実行している
+      When fix が 3 回実行される
+      Then implementation_approval に遷移する
+
+  Rule: 承認ステップ到達でループカウントがリセットされる
+    Scenario: plan_approval で plan_fix のカウントがリセットされる
+      Given plan_fix のループが上限に達した
+      When plan_approval に到達する
+      Then plan_fix のループカウントがリセットされる
+
+    Scenario: implementation_approval で fix のカウントがリセットされる
+      Given fix のループが上限に達した
+      When implementation_approval に到達する
+      Then fix のループカウントがリセットされる
+
+  Rule: 承認ステップの判断が修正・レビューに伝播される
+    Scenario: plan_approval の判断が計画修正・レビューに伝播される
+      Given ユーザーが plan_approval で修正方針を判断した
+      When plan_fix または plan_review_parallel の各子ステップが実行される
+      Then ステップの実行コンテキストに plan_approval の出力（review-verdict）が含まれる
+
+    Scenario: implementation_approval の判断がコード修正・レビューに伝播される
+      Given ユーザーが implementation_approval で修正方針を判断した
+      When fix または code_review_parallel の各子ステップが実行される
+      Then ステップの実行コンテキストに implementation_approval の出力（review-verdict）が含まれる
+
+  Rule: fix-review サイクルの上限制御は fix ステップに集約される
+    Scenario: fix_quality_check は独自の cycle_guard を持たない
+      Given fix ステップに cycle_guard が設定されている
+      When fix ループ内で fix_quality_check が実行される
+      Then fix_quality_check に独自の cycle_guard は適用されない
+
+Feature: pass_output_from の参照制約
+
+  Rule: pass_output_from は定義済みの全ステップを参照できる
+    Scenario: 定義順で後方のステップを pass_output_from で参照できる
+      Given ステップ A が pass_output_from にステップ B を指定している
+      And ステップ B はステップ A より後に定義されている
+      When ワークフローのバリデーションが実行される
+      Then バリデーションが成功する
+
+    Scenario: 後方参照先の出力が未生成の場合は空として扱われる
+      Given ステップ A が pass_output_from にステップ B を指定している
+      And ステップ B はまだ実行されていない
+      When ステップ A が実行される
+      Then ステップ B の出力は空として扱われる
+
+Feature: on_exhausted の安全性
+
+  Rule: on_exhausted の参照先はバリデーションで検証される
+    Scenario: on_exhausted が存在しないステップを参照するとバリデーションエラーになる
+      Given ステップ A の on_exhausted が存在しないステップ名を指定している
+      When ワークフローのバリデーションが実行される
+      Then UnknownOnExhausted エラーが返される
+
+  Rule: on_exhausted の循環参照はバリデーションで検出される
+    Scenario: on_exhausted が循環する構成はバリデーションエラーになる
+      Given ステップ A の on_exhausted がステップ B を指定している
+      And ステップ B の on_exhausted がステップ A を指定している
+      When ワークフローのバリデーションが実行される
+      Then CircularOnExhausted エラーが返される
+
+  Rule: resets_cycle_for の参照先はバリデーションで検証される
+    Scenario: resets_cycle_for が存在しないステップを参照するとバリデーションエラーになる
+      Given ステップ A の resets_cycle_for に存在しないステップ名が含まれている
+      When ワークフローのバリデーションが実行される
+      Then UnknownResetsCycleFor エラーが返される
+
+    Scenario: resets_cycle_for が cycle_guard を持たないステップを参照するとバリデーションエラーになる
+      Given ステップ A の resets_cycle_for に cycle_guard が設定されていないステップ B が含まれている
+      When ワークフローのバリデーションが実行される
+      Then ResetsCycleForNonGuardedStep エラーが返される
+```
+
+## 実装仕様
+
+**対応方針**: 振る舞い定義（ループ上限回復・カウントリセット・承認判断の伝播）を実現するために、ワークフロースキーマ（`CycleGuard`, `Step`）にフィールドを追加し、エンジンの遷移ロジック（`apply_transition`）で `on_exhausted` による代替遷移と `resets_cycle_for` によるカウントリセットを処理する。ビルトインワークフロー YAML の設定変更で計画・コード修正ループの制御を反映する。
+
+### 対象コンポーネント
+
+#### A. スキーマ変更 — `src-tauri/src/workflow/schema.rs`
+
+1. **`CycleGuard` 構造体** (L142-145): `on_exhausted: Option<String>` フィールドを追加
+   - `#[serde(default, skip_serializing_if = "Option::is_none")]` で後方互換性を確保
+   - ループ上限到達時の遷移先ステップ名を保持。未設定なら現行通り Failed
+
+2. **`Step` 構造体** (L12-41): `resets_cycle_for: Option<Vec<String>>` フィールドを追加
+   - `#[serde(default, skip_serializing_if = "Option::is_none")]` で後方互換性を確保
+   - このステップに到達した際に、指定ステップの `step_execution_counts` をリセット
+
+#### B. エンジン変更 — `src-tauri/src/workflow/engine.rs`
+
+3. **`CycleGuardResult::Exceeded` バリアント** (L213-220): `on_exhausted: Option<String>` フィールドを追加
+   - ガード超過時に代替遷移先の情報をエンジンに伝達
+
+4. **`check_cycle_guard` メソッド** (L362-397): `Exceeded` 返却時に `guard.on_exhausted.clone()` を含める
+
+5. **`apply_transition` 関数** (L2608-2661): 2つのロジック追加
+   - **on_exhausted 処理**: `CycleGuardResult::Exceeded` かつ `on_exhausted: Some(target)` の場合、Failed にせず `apply_transition(exec, &target)` を再帰呼び出しして代替ステップへ遷移する。`on_exhausted: None` の場合は現行通り Failed。再帰呼び出しにはステップ数を上限とする深度制限を設け、超過時は Failed とする（バリデーションで循環は検出されるが、防御的に制限する）
+   - **resets_cycle_for 処理**: `CycleGuardResult::Allowed` で遷移成功した後（カウント increment の後）、遷移先ステップの `resets_cycle_for` を確認し、指定されたステップ名の `step_execution_counts` エントリを `remove` してリセット
+
+#### C. バリデーション変更 — `src-tauri/src/workflow/validation.rs`
+
+6. **`ValidationError` enum**: 3つのバリアントを追加
+   - `UnknownOnExhausted { step, target }`: `on_exhausted` が存在しないステップを参照
+   - `UnknownResetsCycleFor { step, target }`: `resets_cycle_for` が存在しないステップを参照
+   - `CircularOnExhausted { cycle }`: `on_exhausted` の遷移チェーンが循環を形成（`cycle` は循環に含まれるステップ名のリスト）
+   - `ResetsCycleForNonGuardedStep { step, target }`: `resets_cycle_for` が `cycle_guard` を持たないステップを参照
+
+7. **`validate` 関数**: 各ステップの検証に追加
+   - `cycle_guard.on_exhausted` の参照先が `transition_target_names`（トップレベルステップ名）に存在するか検証
+   - `resets_cycle_for` の各参照先が `transition_target_names` に存在するか検証
+   - `resets_cycle_for` の各参照先が `cycle_guard` を持つステップであるか検証（持たない場合は `ResetsCycleForNonGuardedStep` エラー）
+   - `on_exhausted` の循環参照検出: `on_exhausted` の遷移チェーンを辿り、同じステップが2度出現した場合（循環）を `CircularOnExhausted` エラーとする
+
+8. **`pass_output_from` の順序制約を緩和**: `pass_output_from` の参照先検証を `preceding_step_names`（先行ステップのみ）から `referenceable_step_names`（全定義済みステップ名）に変更する（L258, L364 の2箇所、および並列子ステップの検証 L247-261）。approval ステップの出力を後続の fix/review が参照する要求5のパターンでは、`pass_output_from` が定義順で後方のステップを参照する必要がある。出力が未生成の場合は空として扱われる（エンジン側の既存動作）
+
+#### D. ビルトインワークフロー変更 — `src-tauri/src/workflow/builtin/spec-driven-development.yml`
+
+9. **計画修正ループの変更**:
+   - `plan_fix` (L66-78): `max_iterations: 3` → `2` に変更、`on_exhausted: plan_approval` を追加、`pass_output_from` に `plan_approval` を追加
+   - `plan_approval` (L80-91): `resets_cycle_for: [plan_fix]` を追加、`pass_output_from` に `plan_review_parallel` を追加
+   - `plan_review_*` 各子ステップ (L32-59): `pass_output_from` に `plan_approval` を追加
+
+10. **コード修正ループの変更**:
+   - `fix` (L163-171): `cycle_guard: { max_iterations: 3, on_exhausted: implementation_approval }` を追加、`pass_output_from` に `implementation_approval` を追加
+   - `fix_quality_check` (L173-183): `cycle_guard` を削除（`max_iterations: 5` を除去）
+   - `implementation_approval` (L185-197): `resets_cycle_for: [fix]` を追加、`pass_output_from` に `code_review_parallel` を追加
+   - `code_review_*` 各子ステップ (L109-157): `pass_output_from` に `implementation_approval` を追加
+
+### 後方互換性
+
+- 新規フィールドはすべて `Option` + `#[serde(default)]` のため、既存の永続化済み `WorkflowState`（`workflow_definition` フィールドに `Workflow` を含む）のデシリアライズに影響しない
+- 既存のユーザー定義ワークフロー YAML も `on_exhausted` / `resets_cycle_for` 未設定で動作が変わらない
+
+### 影響するテスト
+
+- **schema.rs テスト**: `on_exhausted` / `resets_cycle_for` を含む YAML のパースと、未設定時のデフォルト値検証
+- **validation.rs テスト**: `on_exhausted` / `resets_cycle_for` の参照先検証（正常系・存在しないステップ参照のエラー系）、`resets_cycle_for` が `cycle_guard` を持たないステップを参照した場合のエラー検出、`on_exhausted` 循環参照の検出、`pass_output_from` の後方参照が許可されること
+- **engine.rs テスト**:
+  - `check_cycle_guard` が `on_exhausted` 付きの `Exceeded` を返すこと
+  - `apply_transition` で `on_exhausted` 設定済みステップのガード超過時に代替ステップへ遷移すること
+  - `apply_transition` で `on_exhausted` 未設定のガード超過時に従来通り Failed になること
+  - ステップ到達時に `resets_cycle_for` で指定ステップのカウントがリセットされること
+  - リセット後にループ上限まで再実行できること（リセット→再ループ→上限到達のシナリオ）

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1183,6 +1183,7 @@ mod tests {
                     collect: None,
                     parallel: None,
                     aggregate: None,
+                    resets_cycle_for: None,
                 },
                 Step {
                     name: "implement".to_string(),
@@ -1199,6 +1200,7 @@ mod tests {
                     collect: None,
                     parallel: None,
                     aggregate: None,
+                    resets_cycle_for: None,
                 },
                 Step {
                     name: "review".to_string(),
@@ -1215,6 +1217,7 @@ mod tests {
                     collect: None,
                     parallel: None,
                     aggregate: None,
+                    resets_cycle_for: None,
                 },
                 Step {
                     name: "report".to_string(),
@@ -1231,6 +1234,7 @@ mod tests {
                     collect: None,
                     parallel: None,
                     aggregate: None,
+                    resets_cycle_for: None,
                 },
             ],
         }

--- a/src-tauri/src/workflow/builtin/spec-driven-development.yml
+++ b/src-tauri/src/workflow/builtin/spec-driven-development.yml
@@ -36,6 +36,7 @@ steps:
         output_contract: review-verdict
         pass_output_from:
           - plan_spec
+          - plan_approval
       - name: plan_review_clarity
         mode: auto
         instruction: plan-review-clarity
@@ -43,6 +44,7 @@ steps:
         output_contract: review-verdict
         pass_output_from:
           - plan_spec
+          - plan_approval
       - name: plan_review_security
         mode: auto
         instruction: plan-review-security
@@ -50,6 +52,7 @@ steps:
         output_contract: review-verdict
         pass_output_from:
           - plan_spec
+          - plan_approval
       - name: plan_review_consistency
         mode: auto
         instruction: plan-review-consistency
@@ -57,6 +60,7 @@ steps:
         output_contract: review-verdict
         pass_output_from:
           - plan_spec
+          - plan_approval
     aggregate:
       all_match: LGTM
       then: plan_approval
@@ -71,11 +75,13 @@ steps:
     pass_output_from:
       - plan_review_parallel
       - plan_spec
+      - plan_approval
     rules:
       - match: ".*"
         next: plan_review_parallel
     cycle_guard:
-      max_iterations: 3
+      max_iterations: 2
+      on_exhausted: plan_approval
 
   # 7. 実装仕様承認（interactive対話 → review-verdictで判定）
   - name: plan_approval
@@ -85,6 +91,9 @@ steps:
     output_contract: review-verdict
     pass_output_from:
       - plan_spec
+      - plan_review_parallel
+    resets_cycle_for:
+      - plan_fix
     rules:
       - match: NEEDS_FIX
         next: plan_fix
@@ -115,6 +124,7 @@ steps:
         pass_output_from:
           - plan_spec
           - implement
+          - implementation_approval
       - name: code_review_structure
         mode: auto
         instruction: review-structure
@@ -123,6 +133,7 @@ steps:
         pass_output_from:
           - plan_spec
           - implement
+          - implementation_approval
       - name: code_review_quality
         mode: auto
         instruction: review-quality
@@ -131,6 +142,7 @@ steps:
         pass_output_from:
           - plan_spec
           - implement
+          - implementation_approval
       - name: code_review_test
         mode: auto
         instruction: review-test
@@ -139,6 +151,7 @@ steps:
         pass_output_from:
           - plan_spec
           - implement
+          - implementation_approval
       - name: code_review_security
         mode: auto
         instruction: review-security
@@ -147,6 +160,7 @@ steps:
         pass_output_from:
           - plan_spec
           - implement
+          - implementation_approval
       - name: code_review_architecture
         mode: auto
         instruction: review-architecture
@@ -155,6 +169,7 @@ steps:
         pass_output_from:
           - plan_spec
           - implement
+          - implementation_approval
     aggregate:
       all_match: LGTM
       then: implementation_approval
@@ -169,6 +184,10 @@ steps:
     pass_output_from:
       - code_review_parallel
       - plan_spec
+      - implementation_approval
+    cycle_guard:
+      max_iterations: 3
+      on_exhausted: implementation_approval
 
   # 13. 修正後品質チェック（auto）
   - name: fix_quality_check
@@ -179,8 +198,6 @@ steps:
     rules:
       - match: ".*"
         next: code_review_parallel
-    cycle_guard:
-      max_iterations: 5
 
   # 14. 実装結果承認（interactive対話 → review-verdictで判定）
   - name: implementation_approval
@@ -191,6 +208,9 @@ steps:
     pass_output_from:
       - plan_spec
       - implement
+      - code_review_parallel
+    resets_cycle_for:
+      - fix
     rules:
       - match: NEEDS_FIX
         next: fix

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -216,7 +216,11 @@ enum CycleGuardResult {
     /// 許可（ガードなし or 上限内）
     Allowed,
     /// 超過
-    Exceeded { max_iterations: u32, count: u32 },
+    Exceeded {
+        max_iterations: u32,
+        count: u32,
+        on_exhausted: Option<String>,
+    },
 }
 
 /// on_turn_complete後のモード別アクション判定結果。
@@ -387,6 +391,7 @@ impl WorkflowExecution {
                 Ok(CycleGuardResult::Exceeded {
                     max_iterations: guard.max_iterations,
                     count,
+                    on_exhausted: guard.on_exhausted.clone(),
                 })
             } else {
                 Ok(CycleGuardResult::Allowed)
@@ -2613,6 +2618,23 @@ impl WorkflowEngine {
             return Ok(StepOutcome::Persist(exec.to_workflow_state()));
         }
 
+        Self::apply_transition_inner(exec, target_step_name, 0)
+    }
+
+    fn apply_transition_inner(
+        exec: &mut WorkflowExecution,
+        target_step_name: &str,
+        depth: usize,
+    ) -> Result<StepOutcome, WorkflowEngineError> {
+        let max_depth = exec.workflow.steps.len();
+        if depth >= max_depth {
+            exec.state = WorkflowExecutionState::Failed {
+                reason: format!("on_exhausted chain depth exceeded (max={})", max_depth),
+            };
+            exec.updated_at = current_timestamp();
+            return Ok(StepOutcome::Persist(exec.to_workflow_state()));
+        }
+
         let idx = exec
             .workflow
             .steps
@@ -2630,15 +2652,20 @@ impl WorkflowEngine {
             CycleGuardResult::Exceeded {
                 max_iterations,
                 count,
+                on_exhausted,
             } => {
-                exec.state = WorkflowExecutionState::Failed {
-                    reason: format!(
-                        "Cycle guard exceeded for step '{}': max_iterations={}, executed={}",
-                        target_step_name, max_iterations, count
-                    ),
-                };
-                exec.updated_at = current_timestamp();
-                Ok(StepOutcome::Persist(exec.to_workflow_state()))
+                if let Some(fallback_target) = on_exhausted {
+                    Self::apply_transition_inner(exec, &fallback_target, depth + 1)
+                } else {
+                    exec.state = WorkflowExecutionState::Failed {
+                        reason: format!(
+                            "Cycle guard exceeded for step '{}': max_iterations={}, executed={}",
+                            target_step_name, max_iterations, count
+                        ),
+                    };
+                    exec.updated_at = current_timestamp();
+                    Ok(StepOutcome::Persist(exec.to_workflow_state()))
+                }
             }
             CycleGuardResult::Allowed => {
                 exec.current_step_index = idx;
@@ -2648,6 +2675,15 @@ impl WorkflowEngine {
                     .entry(target_step_name.to_string())
                     .or_insert(0) += 1;
                 exec.updated_at = current_timestamp();
+
+                // resets_cycle_for: 遷移先ステップの設定に従い指定ステップのカウントをリセット
+                let resets = exec.workflow.steps[idx].resets_cycle_for.clone();
+                if let Some(targets) = resets {
+                    for target in &targets {
+                        exec.step_execution_counts.remove(target);
+                    }
+                }
+
                 let step = &exec.workflow.steps[idx];
                 if step.is_parallel_block() {
                     Ok(StepOutcome::StartParallel(exec.to_workflow_state()))
@@ -3477,6 +3513,7 @@ mod tests {
             collect: None,
             parallel: None,
             aggregate: None,
+            resets_cycle_for: None,
         }
     }
 
@@ -3508,7 +3545,10 @@ mod tests {
                             next: "report".to_string(),
                         },
                     ],
-                    Some(CycleGuard { max_iterations: 3 }),
+                    Some(CycleGuard {
+                        max_iterations: 3,
+                        on_exhausted: None,
+                    }),
                 ),
                 make_test_step(
                     "report",
@@ -3856,6 +3896,7 @@ mod tests {
             CycleGuardResult::Exceeded {
                 max_iterations: 3,
                 count: 3,
+                on_exhausted: None,
             }
         );
     }
@@ -3943,7 +3984,8 @@ mod tests {
             exec.check_cycle_guard("review").unwrap(),
             CycleGuardResult::Exceeded {
                 max_iterations: 3,
-                count: 3
+                count: 3,
+                on_exhausted: None,
             }
         );
     }
@@ -5158,6 +5200,7 @@ mod tests {
             collect: None,
             parallel: None,
             aggregate: None,
+            resets_cycle_for: None,
         };
         let result = WorkflowEngine::build_step_prompt(
             &step,
@@ -5456,6 +5499,7 @@ mod tests {
                     collect: None,
                     parallel: None,
                     aggregate: None,
+                    resets_cycle_for: None,
                 }],
             },
             state,
@@ -5570,6 +5614,7 @@ mod tests {
                         collect: None,
                         parallel: None,
                         aggregate: None,
+                        resets_cycle_for: None,
                     },
                     Step {
                         name: "fix".to_string(),
@@ -5586,6 +5631,7 @@ mod tests {
                         collect: None,
                         parallel: None,
                         aggregate: None,
+                        resets_cycle_for: None,
                     },
                 ],
             },
@@ -5753,5 +5799,368 @@ mod tests {
         assert_eq!(entry.result.as_deref(), Some("complete"));
         assert!(entry.structured_output.is_none());
         assert!(exec.step_outputs.get("plan").is_none());
+    }
+
+    // ---- on_exhausted: apply_transition テスト ----
+
+    fn make_on_exhausted_workflow() -> Workflow {
+        Workflow {
+            name: "on-exhausted-test".to_string(),
+            description: "Test on_exhausted".to_string(),
+            builtin: false,
+            steps: vec![
+                make_test_step(
+                    "fix",
+                    StepMode::Auto,
+                    "Fix issues",
+                    vec![TransitionRule {
+                        r#match: ".*".to_string(),
+                        next: "review".to_string(),
+                    }],
+                    Some(CycleGuard {
+                        max_iterations: 2,
+                        on_exhausted: Some("approval".to_string()),
+                    }),
+                ),
+                make_test_step(
+                    "review",
+                    StepMode::Auto,
+                    "Review",
+                    vec![TransitionRule {
+                        r#match: "NEEDS_FIX".to_string(),
+                        next: "fix".to_string(),
+                    }],
+                    None,
+                ),
+                Step {
+                    resets_cycle_for: Some(vec!["fix".to_string()]),
+                    ..make_test_step(
+                        "approval",
+                        StepMode::Interactive,
+                        "Approve",
+                        vec![TransitionRule {
+                            r#match: "NEEDS_FIX".to_string(),
+                            next: "fix".to_string(),
+                        }],
+                        None,
+                    )
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn on_exhausted_transitions_to_fallback_step() {
+        let mut exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_on_exhausted_workflow(),
+            state: WorkflowExecutionState::Running,
+            current_step_index: 1, // review
+            step_execution_counts: {
+                let mut m = HashMap::new();
+                m.insert("fix".to_string(), 2); // already at max
+                m
+            },
+            step_history: vec![],
+            step_outputs: HashMap::new(),
+            chat_session_id: "s1".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: None,
+            current_step_token_usage: TokenUsage::default(),
+            task: None,
+            parallel_run: None,
+            workflow_variables: HashMap::new(),
+            contract_retry_count: 0,
+        };
+
+        // fix への遷移を試みる → ガード超過 → on_exhausted で approval へ
+        let outcome = WorkflowEngine::apply_transition(&mut exec, "fix").unwrap();
+        assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
+        assert_eq!(
+            exec.workflow.steps[exec.current_step_index].name,
+            "approval"
+        );
+    }
+
+    #[test]
+    fn on_exhausted_none_fails_workflow() {
+        let mut wf = make_on_exhausted_workflow();
+        // on_exhausted を None に変更
+        wf.steps[0].cycle_guard = Some(CycleGuard {
+            max_iterations: 2,
+            on_exhausted: None,
+        });
+
+        let mut exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: wf,
+            state: WorkflowExecutionState::Running,
+            current_step_index: 1,
+            step_execution_counts: {
+                let mut m = HashMap::new();
+                m.insert("fix".to_string(), 2);
+                m
+            },
+            step_history: vec![],
+            step_outputs: HashMap::new(),
+            chat_session_id: "s1".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: None,
+            current_step_token_usage: TokenUsage::default(),
+            task: None,
+            parallel_run: None,
+            workflow_variables: HashMap::new(),
+            contract_retry_count: 0,
+        };
+
+        let outcome = WorkflowEngine::apply_transition(&mut exec, "fix").unwrap();
+        assert!(matches!(outcome, StepOutcome::Persist(_)));
+        assert!(matches!(exec.state, WorkflowExecutionState::Failed { .. }));
+    }
+
+    #[test]
+    fn check_cycle_guard_exceeded_with_on_exhausted() {
+        let exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_on_exhausted_workflow(),
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0,
+            step_execution_counts: {
+                let mut m = HashMap::new();
+                m.insert("fix".to_string(), 2);
+                m
+            },
+            step_history: vec![],
+            step_outputs: HashMap::new(),
+            chat_session_id: "s1".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: None,
+            current_step_token_usage: TokenUsage::default(),
+            task: None,
+            parallel_run: None,
+            workflow_variables: HashMap::new(),
+            contract_retry_count: 0,
+        };
+
+        assert_eq!(
+            exec.check_cycle_guard("fix").unwrap(),
+            CycleGuardResult::Exceeded {
+                max_iterations: 2,
+                count: 2,
+                on_exhausted: Some("approval".to_string()),
+            }
+        );
+    }
+
+    // ---- resets_cycle_for テスト ----
+
+    #[test]
+    fn resets_cycle_for_clears_execution_count() {
+        let mut exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_on_exhausted_workflow(),
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0, // fix
+            step_execution_counts: {
+                let mut m = HashMap::new();
+                m.insert("fix".to_string(), 2);
+                m
+            },
+            step_history: vec![],
+            step_outputs: HashMap::new(),
+            chat_session_id: "s1".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: None,
+            current_step_token_usage: TokenUsage::default(),
+            task: None,
+            parallel_run: None,
+            workflow_variables: HashMap::new(),
+            contract_retry_count: 0,
+        };
+
+        // approval に遷移 → resets_cycle_for で fix のカウントがリセット
+        let outcome = WorkflowEngine::apply_transition(&mut exec, "approval").unwrap();
+        assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
+        assert_eq!(
+            exec.workflow.steps[exec.current_step_index].name,
+            "approval"
+        );
+        // fix のカウントがリセットされている
+        assert_eq!(exec.step_execution_counts.get("fix"), None);
+    }
+
+    #[test]
+    fn resets_cycle_for_allows_reloop_after_reset() {
+        let mut exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: make_on_exhausted_workflow(),
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0,
+            step_execution_counts: {
+                let mut m = HashMap::new();
+                m.insert("fix".to_string(), 2);
+                m
+            },
+            step_history: vec![],
+            step_outputs: HashMap::new(),
+            chat_session_id: "s1".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: None,
+            current_step_token_usage: TokenUsage::default(),
+            task: None,
+            parallel_run: None,
+            workflow_variables: HashMap::new(),
+            contract_retry_count: 0,
+        };
+
+        // approval に遷移（カウントリセット）
+        WorkflowEngine::apply_transition(&mut exec, "approval").unwrap();
+        assert_eq!(exec.step_execution_counts.get("fix"), None);
+
+        // fix に再遷移可能（リセット後なのでガードに引っかからない）
+        let outcome = WorkflowEngine::apply_transition(&mut exec, "fix").unwrap();
+        assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
+        assert_eq!(exec.workflow.steps[exec.current_step_index].name, "fix");
+        assert_eq!(exec.step_execution_counts.get("fix"), Some(&1));
+
+        // 2回目も可能
+        let outcome = WorkflowEngine::apply_transition(&mut exec, "fix").unwrap();
+        assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
+        assert_eq!(exec.step_execution_counts.get("fix"), Some(&2));
+
+        // 3回目は上限到達 → on_exhausted で approval へ
+        let outcome = WorkflowEngine::apply_transition(&mut exec, "fix").unwrap();
+        assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
+        assert_eq!(
+            exec.workflow.steps[exec.current_step_index].name,
+            "approval"
+        );
+    }
+
+    // ---- on_exhausted チェーン遷移テスト ----
+
+    #[test]
+    fn on_exhausted_chain_transitions() {
+        // step_a → (exhausted) → step_b → (exhausted) → step_c
+        let wf = Workflow {
+            name: "chain-test".to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            steps: vec![
+                make_test_step(
+                    "step_a",
+                    StepMode::Auto,
+                    "A",
+                    vec![],
+                    Some(CycleGuard {
+                        max_iterations: 1,
+                        on_exhausted: Some("step_b".to_string()),
+                    }),
+                ),
+                make_test_step(
+                    "step_b",
+                    StepMode::Auto,
+                    "B",
+                    vec![],
+                    Some(CycleGuard {
+                        max_iterations: 1,
+                        on_exhausted: Some("step_c".to_string()),
+                    }),
+                ),
+                make_test_step("step_c", StepMode::Interactive, "C", vec![], None),
+            ],
+        };
+        let mut exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: wf,
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0,
+            step_execution_counts: {
+                let mut m = HashMap::new();
+                m.insert("step_a".to_string(), 1);
+                m.insert("step_b".to_string(), 1);
+                m
+            },
+            step_history: vec![],
+            step_outputs: HashMap::new(),
+            chat_session_id: "s1".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: None,
+            current_step_token_usage: TokenUsage::default(),
+            task: None,
+            parallel_run: None,
+            workflow_variables: HashMap::new(),
+            contract_retry_count: 0,
+        };
+
+        // step_a → exhausted → step_b → exhausted → step_c
+        let outcome = WorkflowEngine::apply_transition(&mut exec, "step_a").unwrap();
+        assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
+        assert_eq!(exec.workflow.steps[exec.current_step_index].name, "step_c");
+    }
+
+    #[test]
+    fn on_exhausted_chain_to_non_exhausted_fails() {
+        // step_a → (exhausted) → step_b (exhausted, no on_exhausted) → Failed
+        let wf = Workflow {
+            name: "chain-fail-test".to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            steps: vec![
+                make_test_step(
+                    "step_a",
+                    StepMode::Auto,
+                    "A",
+                    vec![],
+                    Some(CycleGuard {
+                        max_iterations: 1,
+                        on_exhausted: Some("step_b".to_string()),
+                    }),
+                ),
+                make_test_step(
+                    "step_b",
+                    StepMode::Auto,
+                    "B",
+                    vec![],
+                    Some(CycleGuard {
+                        max_iterations: 1,
+                        on_exhausted: None,
+                    }),
+                ),
+            ],
+        };
+        let mut exec = WorkflowExecution {
+            id: "exec-1".to_string(),
+            workflow: wf,
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0,
+            step_execution_counts: {
+                let mut m = HashMap::new();
+                m.insert("step_a".to_string(), 1);
+                m.insert("step_b".to_string(), 1);
+                m
+            },
+            step_history: vec![],
+            step_outputs: HashMap::new(),
+            chat_session_id: "s1".to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: None,
+            current_step_token_usage: TokenUsage::default(),
+            task: None,
+            parallel_run: None,
+            workflow_variables: HashMap::new(),
+            contract_retry_count: 0,
+        };
+
+        let outcome = WorkflowEngine::apply_transition(&mut exec, "step_a").unwrap();
+        assert!(matches!(outcome, StepOutcome::Persist(_)));
+        assert!(matches!(exec.state, WorkflowExecutionState::Failed { .. }));
     }
 }

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -2596,6 +2596,15 @@ impl WorkflowEngine {
                 exec.state = WorkflowExecutionState::Running;
                 *exec.step_execution_counts.entry(name).or_insert(0) += 1;
                 exec.updated_at = current_timestamp();
+
+                // resets_cycle_for: 遷移先ステップの設定に従い指定ステップのカウントをリセット
+                let resets = exec.workflow.steps[idx].resets_cycle_for.clone();
+                if let Some(targets) = resets {
+                    for target in &targets {
+                        exec.step_execution_counts.remove(target);
+                    }
+                }
+
                 let step = &exec.workflow.steps[idx];
                 if step.is_parallel_block() {
                     StepOutcome::StartParallel(exec.to_workflow_state())

--- a/src-tauri/src/workflow/facet.rs
+++ b/src-tauri/src/workflow/facet.rs
@@ -245,6 +245,7 @@ mod tests {
             collect: None,
             parallel: None,
             aggregate: None,
+            resets_cycle_for: None,
         }
     }
 

--- a/src-tauri/src/workflow/log.rs
+++ b/src-tauri/src/workflow/log.rs
@@ -792,6 +792,7 @@ mod tests {
                     collect: None,
                     parallel: None,
                     aggregate: None,
+                    resets_cycle_for: None,
                 },
                 Step {
                     name: "implement".to_string(),
@@ -811,12 +812,16 @@ mod tests {
                     collect: None,
                     parallel: None,
                     aggregate: None,
+                    resets_cycle_for: None,
                 },
                 Step {
                     name: "review".to_string(),
                     mode: Some(crate::workflow::schema::StepMode::Approval),
                     rules: vec![],
-                    cycle_guard: Some(CycleGuard { max_iterations: 3 }),
+                    cycle_guard: Some(CycleGuard {
+                        max_iterations: 3,
+                        on_exhausted: None,
+                    }),
                     persona: None,
                     policy: None,
                     knowledge: None,
@@ -827,6 +832,7 @@ mod tests {
                     collect: None,
                     parallel: None,
                     aggregate: None,
+                    resets_cycle_for: None,
                 },
             ],
         }
@@ -1035,6 +1041,7 @@ mod tests {
                     collect: None,
                     parallel: None,
                     aggregate: None,
+                    resets_cycle_for: None,
                 },
                 Step {
                     name: "parallel-review".to_string(),
@@ -1079,6 +1086,7 @@ mod tests {
                         then: "_complete".to_string(),
                         r#else: "_complete".to_string(),
                     }),
+                    resets_cycle_for: None,
                 },
             ],
         };

--- a/src-tauri/src/workflow/schema.rs
+++ b/src-tauri/src/workflow/schema.rs
@@ -38,6 +38,8 @@ pub struct Step {
     pub parallel: Option<Vec<ParallelStep>>,
     #[serde(default)]
     pub aggregate: Option<AggregateConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resets_cycle_for: Option<Vec<String>>,
 }
 
 fn has_any_facet_ref(
@@ -142,6 +144,8 @@ pub struct TransitionRule {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CycleGuard {
     pub max_iterations: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_exhausted: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -385,6 +389,7 @@ steps:
             }),
             parallel: None,
             aggregate: None,
+            resets_cycle_for: None,
         };
         assert!(!step.has_facet_refs());
     }
@@ -469,5 +474,73 @@ steps:
             pass_output_from: None,
         };
         assert!(!ps_no_facet.has_facet_refs());
+    }
+
+    #[test]
+    fn parse_cycle_guard_with_on_exhausted() {
+        let yaml = r#"
+name: exhausted-test
+description: on_exhausted test
+steps:
+  - name: fix
+    mode: auto
+    instruction: fix
+    rules:
+      - match: ".*"
+        next: review
+    cycle_guard:
+      max_iterations: 2
+      on_exhausted: approval
+  - name: review
+    mode: auto
+    instruction: review
+  - name: approval
+    mode: interactive
+    instruction: approve
+"#;
+        let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
+        let guard = wf.steps[0].cycle_guard.as_ref().unwrap();
+        assert_eq!(guard.max_iterations, 2);
+        assert_eq!(guard.on_exhausted.as_deref(), Some("approval"));
+    }
+
+    #[test]
+    fn parse_cycle_guard_without_on_exhausted_defaults_to_none() {
+        let yaml = r#"
+name: default-test
+description: default on_exhausted test
+steps:
+  - name: review
+    mode: auto
+    instruction: review
+    cycle_guard:
+      max_iterations: 5
+"#;
+        let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
+        let guard = wf.steps[0].cycle_guard.as_ref().unwrap();
+        assert_eq!(guard.max_iterations, 5);
+        assert!(guard.on_exhausted.is_none());
+    }
+
+    #[test]
+    fn parse_step_with_resets_cycle_for() {
+        let yaml = r#"
+name: reset-test
+description: resets_cycle_for test
+steps:
+  - name: fix
+    mode: auto
+    instruction: fix
+    cycle_guard:
+      max_iterations: 3
+  - name: approval
+    mode: interactive
+    instruction: approve
+    resets_cycle_for:
+      - fix
+"#;
+        let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(wf.steps[1].resets_cycle_for, Some(vec!["fix".to_string()]));
+        assert!(wf.steps[0].resets_cycle_for.is_none());
     }
 }

--- a/src-tauri/src/workflow/storage.rs
+++ b/src-tauri/src/workflow/storage.rs
@@ -241,6 +241,7 @@ mod tests {
                 collect: None,
                 parallel: None,
                 aggregate: None,
+                resets_cycle_for: None,
             }],
         }
     }

--- a/src-tauri/src/workflow/validation.rs
+++ b/src-tauri/src/workflow/validation.rs
@@ -71,6 +71,25 @@ pub enum ValidationError {
         parent: String,
         child: String,
     },
+    /// on_exhausted が存在しないステップを参照
+    UnknownOnExhausted {
+        step: String,
+        target: String,
+    },
+    /// resets_cycle_for が存在しないステップを参照
+    UnknownResetsCycleFor {
+        step: String,
+        target: String,
+    },
+    /// on_exhausted の遷移チェーンが循環を形成
+    CircularOnExhausted {
+        cycle: Vec<String>,
+    },
+    /// resets_cycle_for が cycle_guard を持たないステップを参照
+    ResetsCycleForNonGuardedStep {
+        step: String,
+        target: String,
+    },
 }
 
 impl fmt::Display for ValidationError {
@@ -142,6 +161,23 @@ impl fmt::Display for ValidationError {
             Self::ParallelChildMissingFacet { parent, child } => write!(
                 f,
                 "parallelブロック '{parent}' の子ステップ '{child}' にはファセット参照が必要です"
+            ),
+            Self::UnknownOnExhausted { step, target } => write!(
+                f,
+                "ステップ '{step}' のon_exhaustedが存在しないステップ '{target}' を参照しています"
+            ),
+            Self::UnknownResetsCycleFor { step, target } => write!(
+                f,
+                "ステップ '{step}' のresets_cycle_forが存在しないステップ '{target}' を参照しています"
+            ),
+            Self::CircularOnExhausted { cycle } => write!(
+                f,
+                "on_exhaustedの遷移チェーンが循環しています: {}",
+                cycle.join(" → ")
+            ),
+            Self::ResetsCycleForNonGuardedStep { step, target } => write!(
+                f,
+                "ステップ '{step}' のresets_cycle_forがcycle_guardを持たないステップ '{target}' を参照しています"
             ),
         }
     }
@@ -254,8 +290,8 @@ pub fn validate(workflow: &Workflow) -> Result<(), ValidationError> {
                                 reference: r.clone(),
                             });
                         }
-                        // 親parallel blockより前に定義されたステップのみ参照可能
-                        if !preceding_step_names.contains(r.as_str()) {
+                        // 定義済みステップ（兄弟以外）を参照可能（後方参照も許可）
+                        if !referenceable_step_names.contains(r.as_str()) {
                             return Err(ValidationError::UnknownOutputFrom {
                                 step: child.name.clone(),
                                 reference: r.clone(),
@@ -358,10 +394,11 @@ pub fn validate(workflow: &Workflow) -> Result<(), ValidationError> {
                 }
             }
 
-            // pass_output_from の参照先 step 名が先行stepに存在するか検証（並列子stepも参照可）
+            // pass_output_from の参照先 step 名が定義済みステップに存在するか検証
+            // （後方参照を許可：出力が未生成の場合は空として扱われる）
             if let Some(ref refs) = step.pass_output_from {
                 for r in refs {
-                    if !preceding_step_names.contains(r.as_str()) {
+                    if !referenceable_step_names.contains(r.as_str()) {
                         return Err(ValidationError::UnknownOutputFrom {
                             step: step.name.clone(),
                             reference: r.clone(),
@@ -404,12 +441,74 @@ pub fn validate(workflow: &Workflow) -> Result<(), ValidationError> {
             }
         }
 
+        // on_exhausted の参照先検証
+        if let Some(ref guard) = step.cycle_guard {
+            if let Some(ref target) = guard.on_exhausted {
+                if !transition_target_names.contains(target.as_str()) {
+                    return Err(ValidationError::UnknownOnExhausted {
+                        step: step.name.clone(),
+                        target: target.clone(),
+                    });
+                }
+            }
+        }
+
+        // resets_cycle_for の参照先検証
+        if let Some(ref targets) = step.resets_cycle_for {
+            for target in targets {
+                if !transition_target_names.contains(target.as_str()) {
+                    return Err(ValidationError::UnknownResetsCycleFor {
+                        step: step.name.clone(),
+                        target: target.clone(),
+                    });
+                }
+                // 参照先が cycle_guard を持つか検証
+                let target_step = workflow.steps.iter().find(|s| s.name == *target);
+                if let Some(ts) = target_step {
+                    if ts.cycle_guard.is_none() {
+                        return Err(ValidationError::ResetsCycleForNonGuardedStep {
+                            step: step.name.clone(),
+                            target: target.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
         // 次のステップのvalidationで使えるよう、このステップ名を追加
         preceding_step_names.insert(&step.name);
         // parallel blockの子step名も追加（後続parallel blockの子stepから参照可能にするため）
         if let Some(ref children) = step.parallel {
             for child in children {
                 preceding_step_names.insert(&child.name);
+            }
+        }
+    }
+
+    // on_exhausted の循環参照検出
+    for step in &workflow.steps {
+        if let Some(ref guard) = step.cycle_guard {
+            if let Some(ref target) = guard.on_exhausted {
+                let mut visited = vec![step.name.clone()];
+                let mut current = target.clone();
+                loop {
+                    if visited.contains(&current) {
+                        visited.push(current);
+                        return Err(ValidationError::CircularOnExhausted { cycle: visited });
+                    }
+                    visited.push(current.clone());
+                    // current のステップの on_exhausted を辿る
+                    let next = workflow
+                        .steps
+                        .iter()
+                        .find(|s| s.name == current)
+                        .and_then(|s| s.cycle_guard.as_ref())
+                        .and_then(|g| g.on_exhausted.as_ref());
+                    match next {
+                        Some(n) => current = n.clone(),
+                        None => break,
+                    }
+                }
             }
         }
     }
@@ -450,6 +549,7 @@ mod tests {
             collect: None,
             parallel: None,
             aggregate: None,
+            resets_cycle_for: None,
         }
     }
 
@@ -487,6 +587,7 @@ mod tests {
             collect: None,
             parallel: Some(children),
             aggregate,
+            resets_cycle_for: None,
         }
     }
 
@@ -497,7 +598,10 @@ mod tests {
         let wf = make_workflow(vec![
             make_step("plan", StepMode::Interactive, vec![]),
             Step {
-                cycle_guard: Some(CycleGuard { max_iterations: 3 }),
+                cycle_guard: Some(CycleGuard {
+                    max_iterations: 3,
+                    on_exhausted: None,
+                }),
                 rules: vec![TransitionRule {
                     r#match: "DONE".to_string(),
                     next: "plan".to_string(),
@@ -999,8 +1103,9 @@ mod tests {
     }
 
     #[test]
-    fn parallel_child_pass_output_from_subsequent_step_fails() {
-        // parallel block より後に定義されたステップへの参照は拒否される
+    fn parallel_child_pass_output_from_subsequent_step_passes() {
+        // parallel block より後に定義されたステップへの後方参照は許可される
+        // （出力が未生成の場合は空として扱われる）
         let wf = make_workflow(vec![
             make_step("plan", StepMode::Auto, vec![]),
             make_parallel_block(
@@ -1013,11 +1118,7 @@ mod tests {
             ),
             make_step("report", StepMode::Auto, vec![]),
         ]);
-        let err = validate(&wf).unwrap_err();
-        assert!(matches!(
-            err,
-            ValidationError::UnknownOutputFrom { ref reference, .. } if reference == "report"
-        ));
+        assert!(validate(&wf).is_ok());
     }
 
     #[test]
@@ -1059,6 +1160,132 @@ mod tests {
                 }],
                 None,
             ),
+        ]);
+        assert!(validate(&wf).is_ok());
+    }
+
+    // ---- on_exhausted バリデーション ----
+
+    #[test]
+    fn on_exhausted_valid_target_passes() {
+        let wf = make_workflow(vec![
+            Step {
+                cycle_guard: Some(CycleGuard {
+                    max_iterations: 2,
+                    on_exhausted: Some("approval".to_string()),
+                }),
+                rules: vec![TransitionRule {
+                    r#match: ".*".to_string(),
+                    next: "approval".to_string(),
+                }],
+                ..make_step("fix", StepMode::Auto, vec![])
+            },
+            make_step("approval", StepMode::Interactive, vec![]),
+        ]);
+        assert!(validate(&wf).is_ok());
+    }
+
+    #[test]
+    fn on_exhausted_unknown_target_fails() {
+        let wf = make_workflow(vec![Step {
+            cycle_guard: Some(CycleGuard {
+                max_iterations: 2,
+                on_exhausted: Some("nonexistent".to_string()),
+            }),
+            ..make_step("fix", StepMode::Auto, vec![])
+        }]);
+        let err = validate(&wf).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::UnknownOnExhausted { ref step, ref target }
+                if step == "fix" && target == "nonexistent"
+        ));
+    }
+
+    #[test]
+    fn on_exhausted_circular_fails() {
+        let wf = make_workflow(vec![
+            Step {
+                cycle_guard: Some(CycleGuard {
+                    max_iterations: 2,
+                    on_exhausted: Some("step_b".to_string()),
+                }),
+                ..make_step("step_a", StepMode::Auto, vec![])
+            },
+            Step {
+                cycle_guard: Some(CycleGuard {
+                    max_iterations: 2,
+                    on_exhausted: Some("step_a".to_string()),
+                }),
+                ..make_step("step_b", StepMode::Auto, vec![])
+            },
+        ]);
+        let err = validate(&wf).unwrap_err();
+        assert!(matches!(err, ValidationError::CircularOnExhausted { .. }));
+    }
+
+    // ---- resets_cycle_for バリデーション ----
+
+    #[test]
+    fn resets_cycle_for_valid_target_passes() {
+        let wf = make_workflow(vec![
+            Step {
+                cycle_guard: Some(CycleGuard {
+                    max_iterations: 3,
+                    on_exhausted: None,
+                }),
+                ..make_step("fix", StepMode::Auto, vec![])
+            },
+            Step {
+                resets_cycle_for: Some(vec!["fix".to_string()]),
+                ..make_step("approval", StepMode::Interactive, vec![])
+            },
+        ]);
+        assert!(validate(&wf).is_ok());
+    }
+
+    #[test]
+    fn resets_cycle_for_unknown_target_fails() {
+        let wf = make_workflow(vec![Step {
+            resets_cycle_for: Some(vec!["nonexistent".to_string()]),
+            ..make_step("approval", StepMode::Interactive, vec![])
+        }]);
+        let err = validate(&wf).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::UnknownResetsCycleFor { ref step, ref target }
+                if step == "approval" && target == "nonexistent"
+        ));
+    }
+
+    #[test]
+    fn resets_cycle_for_non_guarded_step_fails() {
+        let wf = make_workflow(vec![
+            make_step("fix", StepMode::Auto, vec![]),
+            Step {
+                resets_cycle_for: Some(vec!["fix".to_string()]),
+                ..make_step("approval", StepMode::Interactive, vec![])
+            },
+        ]);
+        let err = validate(&wf).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::ResetsCycleForNonGuardedStep { ref step, ref target }
+                if step == "approval" && target == "fix"
+        ));
+    }
+
+    // ---- pass_output_from 後方参照 ----
+
+    #[test]
+    fn pass_output_from_backward_reference_passes() {
+        // 定義順で後方のステップを pass_output_from で参照できる
+        let wf = make_workflow(vec![
+            Step {
+                pass_output_from: Some(vec!["step_b".to_string()]),
+                ..make_step("step_a", StepMode::Auto, vec![])
+            },
+            make_step("step_b", StepMode::Auto, vec![]),
         ]);
         assert!(validate(&wf).is_ok());
     }


### PR DESCRIPTION
## Summary

Closes #932

- cycle_guardに`on_exhausted`オプションを追加し、ループ上限到達時にFailed終了ではなく指定ステップへ遷移可能にした
- `resets_cycle_for`機構を追加し、承認ステップ到達時にループカウントをリセット可能にした
- ビルトインワークフローの`plan_fix`(上限2回→plan_approval)と`fix`(上限3回→implementation_approval)に適用
- 承認ステップの判断(review-verdict)をfix/reviewステップにpass_output_fromで伝播
- `fix_quality_check`の独自cycle_guardを削除し、`fix`ステップに集約
- バリデーション追加: on_exhaustedの存在チェック・循環検出、resets_cycle_forの存在チェック・cycle_guard有無チェック
- `pass_output_from`の後方参照を許可（出力未生成時は空として扱う）

## Test plan

- [x] `cargo fmt --check` PASS
- [x] `cargo clippy -- -D warnings` PASS
- [x] `cargo test` PASS (1067 passed, 0 failed)
- [x] `pnpm lint` PASS
- [x] `pnpm build` PASS
- [ ] ビルトインワークフロー実行でon_exhausted遷移とカウントリセットの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワークフローの再試行上限に達した際、失敗終了の代わりに指定ステップへ遷移する設定に対応しました。
  * 特定ステップ到達時にループカウントをリセットし、ステップの再実行を可能にする設定に対応しました。
  * 組み込みワークフロー（仕様駆動開発）の承認・修正フローを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->