### PR TITLE
feat: ステップ別Model/Permission指定 (#939)

### DIFF
--- a/docs/spec/issues-939.md
+++ b/docs/spec/issues-939.md
@@ -1,0 +1,126 @@
+## 要求
+
+**種別**: 新機能
+**ゴール**: ワークフローYAMLの各ステップにModel/Permissionフィールドを追加し、ステップごとに異なるモデル・権限モードで実行できるようにする。Model指定により対応するバックエンドが自動的に選択される
+**背景**: 現在のワークフローは全ステップがワークフロー起動時のセッション設定（Backend/Model/PermissionMode）で統一的に動作する。しかし、タスク特性に応じた使い分け（例: 計画ステップでは高性能モデル、実装ステップでは高速モデル、レビューステップではファイル編集権限を制限）が求められる
+
+### 成功基準
+
+- ワークフローYAMLの各ステップに `model`（モデルID）、`permission`（PermissionMode）フィールドをオプションで指定できる
+- model値から `available_models()` を使って対応するバックエンドが自動的に解決される
+- ワークフローエンジンがステップ実行時に、解決されたバックエンド・モデルでエージェントセッションを起動し、指定のPermissionModeで動作する
+- 未指定時は親セッションの設定（ワークフロー起動時のBackend/Model/PermissionMode）をそのまま継承する
+
+### 設計メモ
+
+- Model指定で実行バックエンドを自動解決する。各バックエンドの `available_models()` からmodel値を逆引きし、対応するバックエンドを特定する
+- 各ステップに指定可能なフィールドは `model`（モデルID）と `permission`（PermissionMode）の2つ。いずれもオプション
+- PermissionModeは既存の3モード（`acceptEdits` / `bypassPermissions` / `plan`）から選択
+- 未指定時は親セッションの設定を継承する
+
+## 振る舞い定義
+
+```gherkin
+Feature: ステップ別Model/Permission指定
+  ワークフローYAMLの各ステップにModel・Permissionをオプション指定し、
+  ステップごとに異なるモデル・権限モードで実行できる。
+  Model値から対応するバックエンドが自動的に解決される。
+
+  Background:
+    Given ワークフローセッションが "claude" バックエンド、"opus-4" モデル、"acceptEdits" 権限モードで起動されている
+
+  Rule: ステップに指定された設定でセッションを起動する
+
+    Scenario: Model・Permissionが指定されたステップを実行する
+      Given ステップに model: "codex-mini"、permission: "bypassPermissions" が指定されている
+      When そのステップが実行される
+      Then "codex-mini" から対応するバックエンド "codex" が自動解決される
+      And ステップセッションは "codex" バックエンド、"codex-mini" モデルで起動される
+      And ステップセッションは "bypassPermissions" 権限モードで動作する
+
+    Scenario: Modelのみ指定されたステップを実行する
+      Given ステップに model: "haiku" のみ指定されている
+      When そのステップが実行される
+      Then "haiku" から対応するバックエンド "claude" が自動解決される
+      And ステップセッションは "claude" バックエンド、"haiku" モデルで起動される
+      And ステップセッションは親セッションの "acceptEdits" 権限モードを継承する
+
+    Scenario: Permissionのみ指定されたステップを実行する
+      Given ステップに permission: "plan" のみ指定されている
+      When そのステップが実行される
+      Then ステップセッションは親セッションの "claude" バックエンドを継承する
+      And ステップセッションは親セッションの "opus-4" モデルを継承する
+      And ステップセッションは "plan" 権限モードで動作する
+
+  Rule: 未指定フィールドは親セッションの設定を継承する
+
+    Scenario: 全フィールドが未指定のステップを実行する
+      Given ステップに model・permission がいずれも指定されていない
+      When そのステップが実行される
+      Then ステップセッションは親セッションの "claude" バックエンドを継承する
+      And ステップセッションは親セッションの "opus-4" モデルを継承する
+      And ステップセッションは親セッションの "acceptEdits" 権限モードを継承する
+
+  Rule: 並列ステップでもModel/Permissionを個別に指定できる
+
+    Scenario: 並列ブロック内の各ステップに異なる設定を指定する
+      Given 並列ブロック内にステップAとステップBがある
+      And ステップAに model: "opus-4"、permission: "plan" が指定されている
+      And ステップBに model: "codex-mini"、permission: "bypassPermissions" が指定されている
+      When 並列ブロックが実行される
+      Then ステップAは "opus-4" から解決されたバックエンド "claude" で、"plan" 権限モードで起動される
+      And ステップBは "codex-mini" から解決されたバックエンド "codex" で、"bypassPermissions" 権限モードで起動される
+
+  Rule: 無効な設定値はYAMLロード時にバリデーションエラーとする
+
+    Scenario: どのバックエンドにも存在しないModelが指定されたワークフローをロードする
+      Given ステップに model: "unknown-model" が指定されている
+      When ワークフローYAMLをロードする
+      Then バリデーションエラー "unknown model: unknown-model" が返される
+      And ワークフローは実行されない
+
+    Scenario: 無効なPermissionが指定されたワークフローをロードする
+      Given ステップに permission: "invalid-mode" が指定されている
+      When ワークフローYAMLをロードする
+      Then バリデーションエラー "invalid permission mode: invalid-mode" が返される
+      And ワークフローは実行されない
+```
+
+## アーキテクチャ概要
+
+### 責務配置
+
+- **workflow::schema（`schema.rs`）**: ステップ定義の型を担当する。`Step`/`ParallelStep`にオプショナルな`model`/`permission`フィールドを持つ / ステップ設定の解決（継承ロジック）は担当しない
+- **workflow::validation（`validation.rs`）**: ワークフローYAMLのバリデーションを担当する。`model`値が全バックエンドの`available_models()`のいずれかに存在するか、`permission`値が有効なPermissionMode（`acceptEdits`/`bypassPermissions`/`plan`）かを検証する / ステップ設定の解決（継承ロジック）は担当しない
+- **workflow::engine（`engine.rs`）**: ステップ実行時の設定解決を担当する。ステップの`model`/`permission`と親セッションの設定をマージし、`model`値から`available_models()`を走査して対応するバックエンドを特定し、解決済みの`backend_id`/`model`/`permission_mode`でセッション起動・ターン送信を行う / ステップ定義の型や構文解析は担当しない
+- **session（`session/mod.rs`）**: セッション永続化を担当する。`ChatSession`に`backend_id`/`selected_model`/`permission_mode`を保持し、セッション生成時にこれらを設定する / 設定のマージや継承ロジックは担当しない
+- **backends::bridge_common（`bridge_common.rs`）**: ブリッジプロセス起動を担当する。`ChatSession`の`backend_id`/`selected_model`を読み取り、対応するブリッジプロセスを起動する。ターン開始時に`permission_mode`をSDKに送信する / 設定の解決やフォールバックロジックは担当しない
+- **backends（`mod.rs`、`AgentBackendRegistry`）**: バックエンドの登録と`available_models()`の提供を担当する。validation層・engine層からの問い合わせに対し、モデル一覧とバックエンド解決を提供する / ステップ設定のマージは担当しない
+
+### データ/通信フロー
+
+- **逐次ステップ実行**: engine `start_step_session` → ステップ定義から`model`/`permission`を読み取り → 未指定フィールドは親セッション（`ChatSession`）の値で補完 → `model`値から`available_models()`を走査して対応する`backend_id`を特定 → `create_session_internal`で解決済みの`backend_id`/`selected_model`/`permission_mode`を持つステップセッションを生成 → `start_agent_session_internal`で対応バックエンドのブリッジプロセスを起動 → `start_agent_turn_internal`で解決済み`permission_mode`とプロンプトを送信
+- **並列ステップ実行**: engine `start_parallel_children` → 各子ステップの`model`/`permission`を個別に読み取り → 逐次ステップと同じ解決ロジックで各子セッションを生成・起動
+
+### 状態Owner
+
+- **ステップ定義の`model`/`permission`値（YAML由来）**: `workflow::schema::Step`/`ParallelStep` — YAMLデシリアライズ時に設定、ワークフロー実行中は不変
+- **親セッションの設定（`backend_id`/`selected_model`/`permission_mode`）**: `session::ChatSession`（ワークフロー起動時のセッション） — ワークフロー実行中は不変、フォールバック元として参照される
+- **解決済みステップ設定**: Owner無し（一時的な値） — `start_step_session`/`start_parallel_children`内で都度計算し、ステップセッション生成パラメータとして消費される
+- **ステップセッションの設定**: `session::ChatSession`（ステップ用セッション） — 生成時に解決済みの値が設定され、セッション存続中は不変
+
+### 境界
+
+- schema層は「何が指定されたか」を保持するのみで、「未指定時にどうするか」は知らない。継承ロジックはengine層が担当する
+- validation層（`validation.rs`）は`model`値が全バックエンドの`available_models()`に存在するか、`permission`値が有効かを検証する。モデル一覧へのアクセスが必要となる
+- engine層はステップ実行時に`model`値から対応するバックエンドを解決し、設定の解決結果をsession生成パラメータとして渡すが、ブリッジプロセスの起動方法やSDK通信の詳細には関与しない
+- session層は渡された値をそのまま保持・永続化する。値の妥当性はvalidation層で検証済みであることを前提とする
+- bridge_common層はChatSessionから読み取った値でブリッジを起動する。値がどこから来たか（ステップ指定か親セッション継承か）は知らない
+
+### 実装に委ねること
+
+- 設定解決ロジックのヘルパー関数名・配置（engine.rs内のprivateメソッド or 別関数）
+- `create_session_internal`のシグネチャ拡張方法（引数追加 or 構造体パラメータ化）
+- validation.rsでの`AgentBackendRegistry`（モデル一覧）へのアクセス方法（引数追加 or 静的参照等）
+- テストの具体的な配置とヘルパー関数
+- ParallelStepの新フィールドの属性マクロ（`#[serde(default)]`等）の具体的記法

--- a/src-tauri/src/backends/claude.rs
+++ b/src-tauri/src/backends/claude.rs
@@ -20,16 +20,16 @@ impl ClaudeBackend {
 pub fn claude_supported_models() -> Vec<ModelInfo> {
     vec![
         ModelInfo {
-            value: "sonnet".to_string(),
-            display_name: "Claude Sonnet".to_string(),
+            value: "claude-sonnet-4-6".to_string(),
+            display_name: "claude-sonnet-4-6".to_string(),
         },
         ModelInfo {
-            value: "opus".to_string(),
-            display_name: "Claude Opus".to_string(),
+            value: "claude-opus-4-7".to_string(),
+            display_name: "claude-opus-4-7".to_string(),
         },
         ModelInfo {
-            value: "haiku".to_string(),
-            display_name: "Claude Haiku".to_string(),
+            value: "claude-haiku-4-5-20251001".to_string(),
+            display_name: "claude-haiku-4-5-20251001".to_string(),
         },
     ]
 }
@@ -88,7 +88,7 @@ mod tests {
     async fn available_models_returns_claude_defaults() {
         let backend = ClaudeBackend::new();
         let models = backend.available_models().await.unwrap();
-        assert!(models.iter().any(|m| m.value == "sonnet"));
-        assert!(models.iter().any(|m| m.value == "opus"));
+        assert!(models.iter().any(|m| m.value == "claude-sonnet-4-6"));
+        assert!(models.iter().any(|m| m.value == "claude-opus-4-7"));
     }
 }

--- a/src-tauri/src/backends/codex.rs
+++ b/src-tauri/src/backends/codex.rs
@@ -24,24 +24,28 @@ pub struct CodexBackend {
 pub fn codex_supported_models() -> Vec<ModelInfo> {
     vec![
         ModelInfo {
+            value: "gpt-5.5".to_string(),
+            display_name: "gpt-5.5".to_string(),
+        },
+        ModelInfo {
             value: "gpt-5.4".to_string(),
-            display_name: "GPT-5.4".to_string(),
+            display_name: "gpt-5.4".to_string(),
+        },
+        ModelInfo {
+            value: "gpt-5.4-mini".to_string(),
+            display_name: "gpt-5.4-mini".to_string(),
         },
         ModelInfo {
             value: "gpt-5.3-codex".to_string(),
-            display_name: "GPT-5.3 Codex".to_string(),
+            display_name: "gpt-5.3-codex".to_string(),
         },
         ModelInfo {
-            value: "gpt-5.2-codex".to_string(),
-            display_name: "GPT-5.2 Codex".to_string(),
+            value: "gpt-5.3-codex-spark".to_string(),
+            display_name: "gpt-5.3-codex-spark".to_string(),
         },
         ModelInfo {
-            value: "gpt-5-codex".to_string(),
-            display_name: "GPT-5 Codex".to_string(),
-        },
-        ModelInfo {
-            value: "o3".to_string(),
-            display_name: "o3".to_string(),
+            value: "gpt-5.2".to_string(),
+            display_name: "gpt-5.2".to_string(),
         },
     ]
 }
@@ -288,8 +292,8 @@ mod tests {
     async fn available_models_returns_codex_defaults() {
         let backend = CodexBackend::new();
         let models = backend.available_models().await.unwrap();
+        assert!(models.iter().any(|m| m.value == "gpt-5.5"));
         assert!(models.iter().any(|m| m.value == "gpt-5.4"));
-        assert!(models.iter().any(|m| m.value == "o3"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/backends/mod.rs
+++ b/src-tauri/src/backends/mod.rs
@@ -241,9 +241,14 @@ impl AgentBackendRegistry {
             if !*available {
                 continue;
             }
-            if let Ok(models) = self.available_models(id).await {
-                for m in models {
-                    values.insert(m.value);
+            match self.available_models(id).await {
+                Ok(models) => {
+                    for m in models {
+                        values.insert(m.value);
+                    }
+                }
+                Err(e) => {
+                    log::warn!("failed to fetch models from backend '{id}': {e}");
                 }
             }
         }
@@ -257,9 +262,14 @@ impl AgentBackendRegistry {
             if !*available {
                 continue;
             }
-            if let Ok(models) = self.available_models(id).await {
-                if models.iter().any(|m| m.value == model) {
-                    return Some(id.clone());
+            match self.available_models(id).await {
+                Ok(models) => {
+                    if models.iter().any(|m| m.value == model) {
+                        return Some(id.clone());
+                    }
+                }
+                Err(e) => {
+                    log::warn!("failed to fetch models from backend '{id}': {e}");
                 }
             }
         }

--- a/src-tauri/src/backends/mod.rs
+++ b/src-tauri/src/backends/mod.rs
@@ -233,6 +233,38 @@ impl AgentBackendRegistry {
             .map(|(id, _, _)| id.clone())
             .ok_or_else(|| "利用可能なバックエンドが登録されていません".to_string())
     }
+
+    /// 全バックエンドの `available_models()` を走査し、有効なモデルID（value）の集合を返す。
+    pub async fn collect_all_model_values(&self) -> std::collections::HashSet<String> {
+        let mut values = std::collections::HashSet::new();
+        for (id, _, available) in &self.backends {
+            if !*available {
+                continue;
+            }
+            if let Ok(models) = self.available_models(id).await {
+                for m in models {
+                    values.insert(m.value);
+                }
+            }
+        }
+        values
+    }
+
+    /// モデルIDから対応するバックエンドIDを解決する。
+    /// 全バックエンドの `available_models()` を走査し、最初に一致したバックエンドIDを返す。
+    pub async fn resolve_backend_for_model(&self, model: &str) -> Option<String> {
+        for (id, _, available) in &self.backends {
+            if !*available {
+                continue;
+            }
+            if let Ok(models) = self.available_models(id).await {
+                if models.iter().any(|m| m.value == model) {
+                    return Some(id.clone());
+                }
+            }
+        }
+        None
+    }
 }
 
 // --- Tauri コマンド ---
@@ -522,5 +554,153 @@ mod tests {
         );
         let reg = build_registry(&config);
         assert_eq!(reg.resolve_default_id().unwrap(), "claude");
+    }
+
+    struct MockBackendWithModels {
+        backend_id: String,
+        backend_name: String,
+        models: Vec<ModelInfo>,
+    }
+
+    #[async_trait]
+    impl AgentBackend for MockBackendWithModels {
+        fn id(&self) -> &str {
+            &self.backend_id
+        }
+        fn name(&self) -> &str {
+            &self.backend_name
+        }
+        async fn start_session(&self, _config: SessionConfig) -> Result<SessionHandle, String> {
+            Ok(SessionHandle {
+                chat_session_id: "test".to_string(),
+                backend_id: self.backend_id.clone(),
+            })
+        }
+        async fn send_message(
+            &self,
+            _session: &SessionHandle,
+            _message: AgentMessage,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        async fn interrupt(&self, _session: &SessionHandle) -> Result<(), String> {
+            Ok(())
+        }
+        async fn respond_permission(
+            &self,
+            _session: &SessionHandle,
+            _response: PermissionResponse,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        async fn available_models(&self) -> Result<Vec<ModelInfo>, String> {
+            Ok(self.models.clone())
+        }
+        async fn close_session(&self, _session: &SessionHandle) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    fn mock_backend_with_models(
+        id: &str,
+        name: &str,
+        models: Vec<(&str, &str)>,
+    ) -> Arc<dyn AgentBackend> {
+        Arc::new(MockBackendWithModels {
+            backend_id: id.to_string(),
+            backend_name: name.to_string(),
+            models: models
+                .into_iter()
+                .map(|(v, d)| ModelInfo {
+                    value: v.to_string(),
+                    display_name: d.to_string(),
+                })
+                .collect(),
+        })
+    }
+
+    #[tokio::test]
+    async fn collect_all_model_values_from_multiple_backends() {
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend_with_models(
+            "claude",
+            "Claude",
+            vec![("opus-4", "Opus 4"), ("haiku", "Haiku")],
+        ));
+        reg.register(mock_backend_with_models(
+            "codex",
+            "Codex",
+            vec![("codex-mini", "Codex Mini")],
+        ));
+        let models = reg.collect_all_model_values().await;
+        assert!(models.contains("opus-4"));
+        assert!(models.contains("haiku"));
+        assert!(models.contains("codex-mini"));
+        assert_eq!(models.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn collect_all_model_values_skips_unavailable_backends() {
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend_with_models(
+            "claude",
+            "Claude",
+            vec![("opus-4", "Opus 4")],
+        ));
+        reg.register(mock_backend_with_models(
+            "codex",
+            "Codex",
+            vec![("codex-mini", "Codex Mini")],
+        ));
+        reg.set_available("codex", false);
+        let models = reg.collect_all_model_values().await;
+        assert!(models.contains("opus-4"));
+        assert!(!models.contains("codex-mini"));
+    }
+
+    #[tokio::test]
+    async fn resolve_backend_for_model_finds_correct_backend() {
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend_with_models(
+            "claude",
+            "Claude",
+            vec![("opus-4", "Opus 4"), ("haiku", "Haiku")],
+        ));
+        reg.register(mock_backend_with_models(
+            "codex",
+            "Codex",
+            vec![("codex-mini", "Codex Mini")],
+        ));
+        assert_eq!(
+            reg.resolve_backend_for_model("opus-4").await,
+            Some("claude".to_string())
+        );
+        assert_eq!(
+            reg.resolve_backend_for_model("codex-mini").await,
+            Some("codex".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_backend_for_model_returns_none_for_unknown() {
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend_with_models(
+            "claude",
+            "Claude",
+            vec![("opus-4", "Opus 4")],
+        ));
+        assert_eq!(reg.resolve_backend_for_model("unknown").await, None);
+    }
+
+    #[tokio::test]
+    async fn resolve_backend_for_model_skips_unavailable_backends() {
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend_with_models(
+            "claude",
+            "Claude",
+            vec![("opus-4", "Opus 4")],
+        ));
+        reg.set_available("claude", false);
+        assert_eq!(reg.resolve_backend_for_model("opus-4").await, None);
     }
 }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1225,6 +1225,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
                 Step {
                     name: "implement".to_string(),
@@ -1243,6 +1245,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
                 Step {
                     name: "review".to_string(),
@@ -1261,6 +1265,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
                 Step {
                     name: "report".to_string(),
@@ -1279,6 +1285,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
             ],
         }

--- a/src-tauri/src/workflow/builtin/spec-driven-development.yml
+++ b/src-tauri/src/workflow/builtin/spec-driven-development.yml
@@ -6,6 +6,7 @@ steps:
   # 1. 要求整理（approval、Spec作成）
   - name: plan_requirements
     mode: approval
+    model: claude-opus-4-7
     instruction: plan-requirements
     policy: planning
     output_contract: spec-file-path
@@ -13,6 +14,7 @@ steps:
   # 2. 振る舞い定義（approval、Spec更新）
   - name: plan_behavior
     mode: approval
+    model: claude-opus-4-7
     instruction: plan-behavior
     policy: planning
     output_contract: spec-file-path
@@ -21,6 +23,7 @@ steps:
   # 3. アーキテクチャ概要（approval、Spec更新）
   - name: plan_architecture
     mode: approval
+    model: claude-opus-4-7
     instruction: plan-architecture
     policy: planning
     output_contract: spec-file-path
@@ -31,6 +34,7 @@ steps:
     parallel:
       - name: plan_review_completeness
         mode: auto
+        model: gpt-5.5
         instruction: plan-review-completeness
         policy: plan-review
         output_contract: review-verdict
@@ -39,6 +43,7 @@ steps:
           - plan_approval
       - name: plan_review_clarity
         mode: auto
+        model: gpt-5.5
         instruction: plan-review-clarity
         policy: plan-review
         output_contract: review-verdict
@@ -47,6 +52,7 @@ steps:
           - plan_approval
       - name: plan_review_security
         mode: auto
+        model: gpt-5.5
         instruction: plan-review-security
         policy: plan-review
         output_contract: review-verdict
@@ -55,6 +61,7 @@ steps:
           - plan_approval
       - name: plan_review_consistency
         mode: auto
+        model: gpt-5.5
         instruction: plan-review-consistency
         policy: plan-review
         output_contract: review-verdict
@@ -69,6 +76,7 @@ steps:
   # 6. Plan修正方針確認（approval）
   - name: plan_fix_policy
     mode: approval
+    model: claude-opus-4-7
     instruction: plan-fix-policy
     policy: planning
     output_contract: approved-fix-policy
@@ -83,6 +91,7 @@ steps:
   # 7. アーキテクチャ概要修正（auto、Spec更新）
   - name: plan_fix
     mode: auto
+    model: claude-opus-4-7
     instruction: plan-fix
     output_contract: spec-file-path
     pass_output_from:
@@ -100,6 +109,7 @@ steps:
   # 8. アーキテクチャ概要承認（approval）
   - name: plan_approval
     mode: approval
+    model: claude-opus-4-7
     instruction: plan-approval
     policy: planning
     pass_output_from:
@@ -114,6 +124,7 @@ steps:
   # 9. 実装（auto）
   - name: implement
     mode: auto
+    model: claude-opus-4-7
     instruction: implement
     policy: coding
     pass_output_from:
@@ -122,6 +133,7 @@ steps:
   # 9. 品質チェック（auto）
   - name: quality_check
     mode: auto
+    model: claude-opus-4-7
     instruction: quality-check
     policy: coding
     pass_previous_response: true
@@ -131,6 +143,7 @@ steps:
     parallel:
       - name: code_review_acceptance
         mode: auto
+        model: gpt-5.5
         instruction: review-acceptance
         policy: review
         output_contract: review-verdict
@@ -140,6 +153,7 @@ steps:
           - implementation_approval
       - name: code_review_structure
         mode: auto
+        model: gpt-5.5
         instruction: review-structure
         policy: review
         output_contract: review-verdict
@@ -149,6 +163,7 @@ steps:
           - implementation_approval
       - name: code_review_quality
         mode: auto
+        model: gpt-5.5
         instruction: review-quality
         policy: review
         output_contract: review-verdict
@@ -158,6 +173,7 @@ steps:
           - implementation_approval
       - name: code_review_test
         mode: auto
+        model: gpt-5.5
         instruction: review-test
         policy: review
         output_contract: review-verdict
@@ -167,6 +183,7 @@ steps:
           - implementation_approval
       - name: code_review_security
         mode: auto
+        model: gpt-5.5
         instruction: review-security
         policy: review
         output_contract: review-verdict
@@ -176,6 +193,7 @@ steps:
           - implementation_approval
       - name: code_review_architecture
         mode: auto
+        model: gpt-5.5
         instruction: review-architecture
         policy: review
         output_contract: review-verdict
@@ -191,6 +209,7 @@ steps:
   # 13. 実装修正方針確認（approval）
   - name: implementation_fix_policy
     mode: approval
+    model: claude-opus-4-7
     instruction: implementation-fix-policy
     policy: coding
     output_contract: approved-fix-policy
@@ -205,6 +224,7 @@ steps:
   # 14. 修正（auto）
   - name: fix
     mode: auto
+    model: claude-opus-4-7
     instruction: implement-fix
     policy: coding
     pass_output_from:
@@ -219,6 +239,7 @@ steps:
   # 15. 修正後品質チェック（auto）
   - name: fix_quality_check
     mode: auto
+    model: claude-opus-4-7
     instruction: quality-check
     policy: coding
     pass_previous_response: true
@@ -229,6 +250,7 @@ steps:
   # 16. 実装結果承認（approval）
   - name: implementation_approval
     mode: approval
+    model: claude-opus-4-7
     instruction: implementation-approval
     policy: coding
     pass_output_from:

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -658,6 +658,8 @@ mod tests {
                 parallel: None,
                 aggregate: None,
                 resets_cycle_for: None,
+                model: None,
+                permission: None,
             }],
         }
     }

--- a/src-tauri/src/workflow/diagnostics.rs
+++ b/src-tauri/src/workflow/diagnostics.rs
@@ -307,6 +307,12 @@ fn validation_error_context(e: &validation::ValidationError) -> (Option<String>,
         ValidationError::InvalidApprovalRules { step, .. } => {
             (Some(step.clone()), Some("rules".to_string()))
         }
+        ValidationError::InvalidPermissionMode { step, .. } => {
+            (Some(step.clone()), Some("permission".to_string()))
+        }
+        ValidationError::UnknownModel { step, .. } => {
+            (Some(step.clone()), Some("model".to_string()))
+        }
     }
 }
 
@@ -845,6 +851,8 @@ mod tests {
             parallel: None,
             aggregate: None,
             resets_cycle_for: None,
+            model: None,
+            permission: None,
         }
     }
 
@@ -1406,6 +1414,8 @@ mod tests {
                         output_contract: None,
                         pass_previous_response: None,
                         pass_output_from: Some(vec!["report".to_string()]),
+                        model: None,
+                        permission: None,
                     }]),
                     ..make_step("par", None)
                 },
@@ -1450,6 +1460,8 @@ mod tests {
                         output_contract: None,
                         pass_previous_response: None,
                         pass_output_from: None,
+                        model: None,
+                        permission: None,
                     },
                     ParallelStep {
                         name: "child2".to_string(),
@@ -1461,6 +1473,8 @@ mod tests {
                         output_contract: None,
                         pass_previous_response: None,
                         pass_output_from: Some(vec!["child1".to_string()]),
+                        model: None,
+                        permission: None,
                     },
                 ]),
                 ..make_step("par", None)

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -9,7 +9,7 @@ use tokio::sync::Mutex;
 
 use crate::agent_sdk::AgentProcessMap;
 use crate::agent_status::{current_timestamp, AgentStatusCenter};
-use crate::session::SessionStore;
+use crate::session::{ChatSession, SessionStore};
 use crate::workflow::contract::{
     build_repair_prompt, extract_workflow_output, validate_contract, ContractValidationResult,
     ExtractionResult,
@@ -545,6 +545,46 @@ enum ContractCheckResult {
     Failed,
 }
 
+/// ステップ設定解決の結果。
+/// ステップのmodel/permission指定と親セッション設定のマージ結果を保持する。
+#[derive(Debug, Clone, PartialEq)]
+struct ResolvedStepSettings {
+    backend_id: Option<String>,
+    selected_model: Option<String>,
+    permission_mode: String,
+}
+
+/// ステップの model/permission 設定を親セッション設定とマージして解決する。
+///
+/// - permission: ステップ指定があれば採用、なければ親セッションの値を継承
+/// - backend_id: model指定があれば resolved_backend_id を採用、なければ親セッションの値を継承
+/// - selected_model: ステップ指定があれば採用、なければ親セッションの値を継承
+///
+/// `resolved_backend_id` は、ステップにmodel指定がある場合に
+/// `resolve_backend_for_step_model` で事前に解決されたbackend_id。
+/// model未指定時は無視される。
+fn resolve_step_settings(
+    step_model: Option<String>,
+    step_permission: Option<String>,
+    resolved_backend_id: Option<String>,
+    parent_backend_id: Option<String>,
+    parent_selected_model: Option<String>,
+    parent_permission_mode: String,
+) -> ResolvedStepSettings {
+    let permission_mode = step_permission.unwrap_or(parent_permission_mode);
+    let backend_id = if step_model.is_some() {
+        resolved_backend_id
+    } else {
+        parent_backend_id
+    };
+    let selected_model = step_model.or(parent_selected_model);
+    ResolvedStepSettings {
+        backend_id,
+        selected_model,
+        permission_mode,
+    }
+}
+
 /// ワークフローのステップを順次実行するステートマシンエンジン。
 pub struct WorkflowEngine {
     /// worktree_path → WorkflowExecution のマッピング
@@ -559,6 +599,70 @@ impl WorkflowEngine {
             executions: Mutex::new(HashMap::new()),
             session_workflow_refs: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// ステップの model 値から対応するバックエンドIDを解決する。
+    async fn resolve_backend_for_step_model(
+        &self,
+        app: &tauri::AppHandle,
+        model: &str,
+    ) -> Result<Option<String>, WorkflowEngineError> {
+        if let Some(registry) = app.try_state::<Arc<crate::backends::AgentBackendRegistry>>() {
+            let backend_id = registry
+                .resolve_backend_for_model(model)
+                .await
+                .ok_or_else(|| {
+                    WorkflowEngineError::InvalidWorkflow(format!("unknown model: {model}"))
+                })?;
+            Ok(Some(backend_id))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// ステップ設定の解決 → セッション生成 → 解決済み設定の反映 → 保存を一括で行う。
+    ///
+    /// `start_step_session` と `start_parallel_children` の共通パターンを抽出したヘルパー。
+    #[allow(clippy::too_many_arguments)]
+    async fn create_step_session_with_settings(
+        &self,
+        app: &tauri::AppHandle,
+        session_store: &SessionStore,
+        data_dir: &std::path::Path,
+        worktree_path: &str,
+        step_model: Option<String>,
+        step_permission: Option<String>,
+        parent_backend_id: Option<String>,
+        parent_selected_model: Option<String>,
+        parent_permission_mode: String,
+    ) -> Result<ChatSession, WorkflowEngineError> {
+        let resolved_backend_id = match step_model {
+            Some(ref model) => self.resolve_backend_for_step_model(app, model).await?,
+            None => None,
+        };
+        let settings = resolve_step_settings(
+            step_model,
+            step_permission,
+            resolved_backend_id,
+            parent_backend_id,
+            parent_selected_model,
+            parent_permission_mode,
+        );
+
+        let mut step_session = crate::session::create_session_internal(
+            session_store,
+            data_dir,
+            worktree_path,
+            settings.backend_id,
+        )
+        .map_err(|e| WorkflowEngineError::SessionStore(format!("create step session: {e}")))?;
+        step_session.selected_model = settings.selected_model;
+        step_session.permission_mode = settings.permission_mode;
+        session_store
+            .save_session(data_dir, &step_session)
+            .map_err(|e| WorkflowEngineError::SessionStore(format!("save step session: {e}")))?;
+
+        Ok(step_session)
     }
 
     /// ワークフローを開始する。
@@ -583,6 +687,13 @@ impl WorkflowEngine {
             .map_err(|e| WorkflowEngineError::SessionStore(format!("get_session: {e}")))?
             .ok_or_else(|| WorkflowEngineError::SessionNotFound(chat_session_id.to_string()))?;
         let worktree_path = session.worktree_path.clone();
+
+        // ステップ設定のmodel検証: 全バックエンドの available_models から有効モデルを収集
+        if let Some(registry) = app.try_state::<Arc<crate::backends::AgentBackendRegistry>>() {
+            let valid_models = registry.collect_all_model_values().await;
+            crate::workflow::validation::validate_models(&workflow, &valid_models)
+                .map_err(|e| WorkflowEngineError::InvalidWorkflow(e.to_string()))?;
+        }
 
         let now = current_timestamp();
         let mut execution = WorkflowExecution {
@@ -1911,17 +2022,11 @@ impl WorkflowEngine {
         let permission_mode = {
             let data_dir = crate::session::resolve_data_dir(app)
                 .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
-            let execs = self.executions.lock().await;
-            let exec = execs
-                .get(worktree_path)
-                .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(worktree_path.to_string()))?;
-            let parent_session = session_store
-                .get_session(&data_dir, &exec.chat_session_id)
+            let step_session = session_store
+                .get_session(&data_dir, session_id)
                 .map_err(|e| WorkflowEngineError::SessionStore(format!("get_session: {e}")))?
-                .ok_or_else(|| {
-                    WorkflowEngineError::SessionNotFound(exec.chat_session_id.clone())
-                })?;
-            parent_session.permission_mode
+                .ok_or_else(|| WorkflowEngineError::SessionNotFound(session_id.to_string()))?;
+            step_session.permission_mode
         };
         crate::agent_sdk::start_agent_turn_internal(
             app,
@@ -2350,17 +2455,22 @@ impl WorkflowEngine {
             .get_session(&data_dir, &chat_session_id)
             .map_err(|e| WorkflowEngineError::SessionStore(format!("get_session: {e}")))?
             .ok_or_else(|| WorkflowEngineError::SessionNotFound(chat_session_id.clone()))?;
-        let permission_mode = parent_session.permission_mode;
-        let backend_id = parent_session.backend_id.clone();
 
-        // ステップ用の新しいChatSessionを生成
-        let step_session = crate::session::create_session_internal(
-            session_store,
-            &data_dir,
-            worktree_path,
-            backend_id,
-        )
-        .map_err(|e| WorkflowEngineError::SessionStore(format!("create step session: {e}")))?;
+        // ステップ設定の解決 → セッション生成
+        let step_session = self
+            .create_step_session_with_settings(
+                app,
+                session_store,
+                &data_dir,
+                worktree_path,
+                step_clone.model.clone(),
+                step_clone.permission.clone(),
+                parent_session.backend_id.clone(),
+                parent_session.selected_model.clone(),
+                parent_session.permission_mode,
+            )
+            .await?;
+        let permission_mode = step_session.permission_mode.clone();
         let step_session_id = step_session.id.clone();
 
         // ステップセッションID → SessionWorkflowRefのマッピングを登録
@@ -3371,8 +3481,9 @@ impl WorkflowEngine {
             .get_session(&data_dir, &chat_session_id)
             .map_err(|e| WorkflowEngineError::SessionStore(format!("get_session: {e}")))?
             .ok_or_else(|| WorkflowEngineError::SessionNotFound(chat_session_id.clone()))?;
-        let permission_mode = parent_session.permission_mode;
-        let backend_id = parent_session.backend_id.clone();
+        let parent_permission_mode = parent_session.permission_mode;
+        let parent_backend_id = parent_session.backend_id.clone();
+        let parent_selected_model = parent_session.selected_model.clone();
 
         // step_outputsとworkflow_variablesのスナップショットをロック外で取得
         let (step_outputs_snapshot, wf_variables_snapshot) = {
@@ -3390,19 +3501,26 @@ impl WorkflowEngine {
             system_prompt: Option<String>,
             user_message: String,
             output_contract: Option<String>,
+            permission_mode: String,
         }
         let mut child_setups: Vec<ChildSetup> = Vec::new();
 
         for ps in &parallel_steps {
-            let step_session = crate::session::create_session_internal(
-                session_store,
-                &data_dir,
-                worktree_path,
-                backend_id.clone(),
-            )
-            .map_err(|e| {
-                WorkflowEngineError::SessionStore(format!("create parallel session: {e}"))
-            })?;
+            // 子ステップ設定の解決 → セッション生成
+            let step_session = self
+                .create_step_session_with_settings(
+                    app,
+                    session_store,
+                    &data_dir,
+                    worktree_path,
+                    ps.model.clone(),
+                    ps.permission.clone(),
+                    parent_backend_id.clone(),
+                    parent_selected_model.clone(),
+                    parent_permission_mode.clone(),
+                )
+                .await?;
+            let child_permission_mode = step_session.permission_mode.clone();
             let step_session_id = step_session.id.clone();
 
             // session_workflow_refs に ParallelChild として登録
@@ -3435,6 +3553,7 @@ impl WorkflowEngine {
                 session_id: step_session_id,
                 system_prompt,
                 user_message,
+                permission_mode: child_permission_mode,
                 output_contract: ps.output_contract.clone(),
             });
         }
@@ -3526,7 +3645,7 @@ impl WorkflowEngine {
                 session_store,
                 &cs.session_id,
                 worktree_path,
-                &permission_mode,
+                &cs.permission_mode,
                 &cs.user_message,
             )
             .await
@@ -3940,6 +4059,8 @@ impl WorkflowEngine {
                 parallel: None,
                 aggregate: None,
                 resets_cycle_for: None,
+                model: None,
+                permission: None,
             }],
         };
         let exec = WorkflowExecution {
@@ -4019,6 +4140,8 @@ mod tests {
                         r#else: "implementation_fix_policy".to_string(),
                     }),
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
                 Step {
                     name: "implementation_fix_policy".to_string(),
@@ -4037,6 +4160,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
             ],
         }
@@ -4228,6 +4353,8 @@ mod tests {
             parallel: None,
             aggregate: None,
             resets_cycle_for: None,
+            model: None,
+            permission: None,
         }
     }
 
@@ -5544,6 +5671,8 @@ mod tests {
             parallel: None,
             aggregate: None,
             resets_cycle_for: None,
+            model: None,
+            permission: None,
         });
         let outcome = WorkflowEngine::apply_approval_application(
             &mut exec,
@@ -6184,6 +6313,8 @@ mod tests {
             parallel: None,
             aggregate: None,
             resets_cycle_for: None,
+            model: None,
+            permission: None,
         };
         let result = WorkflowEngine::build_step_prompt(
             &step,
@@ -6484,6 +6615,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 }],
             },
             state,
@@ -7121,6 +7254,8 @@ mod tests {
                         parallel: None,
                         aggregate: None,
                         resets_cycle_for: None,
+                        model: None,
+                        permission: None,
                     },
                     Step {
                         name: "fix".to_string(),
@@ -7139,6 +7274,8 @@ mod tests {
                         parallel: None,
                         aggregate: None,
                         resets_cycle_for: None,
+                        model: None,
+                        permission: None,
                     },
                 ],
             },
@@ -7235,6 +7372,8 @@ mod tests {
                         parallel: None,
                         aggregate: None,
                         resets_cycle_for: None,
+                        model: None,
+                        permission: None,
                     },
                     make_test_step("fix", StepMode::Auto, "Fix", vec![], None),
                 ],
@@ -7616,6 +7755,8 @@ mod tests {
                         parallel: None,
                         aggregate: None,
                         resets_cycle_for: None,
+                        model: None,
+                        permission: None,
                     },
                     make_test_step("fix", StepMode::Auto, "Fix", vec![], None),
                     Step {
@@ -7640,6 +7781,8 @@ mod tests {
                             r#else: "implementation_fix_policy".to_string(),
                         }),
                         resets_cycle_for: None,
+                        model: None,
+                        permission: None,
                     },
                 ],
             },
@@ -7804,6 +7947,8 @@ mod tests {
                             r#else: "implementation_fix_policy".to_string(),
                         }),
                         resets_cycle_for: None,
+                        model: None,
+                        permission: None,
                     },
                     Step {
                         name: "implementation_fix_policy".to_string(),
@@ -7822,6 +7967,8 @@ mod tests {
                         parallel: None,
                         aggregate: None,
                         resets_cycle_for: None,
+                        model: None,
+                        permission: None,
                     },
                     fix_step,
                 ],
@@ -8628,5 +8775,131 @@ mod tests {
         let outcome = WorkflowEngine::apply_transition(&mut exec, "step_a").unwrap();
         assert!(matches!(outcome, StepOutcome::Persist(_)));
         assert!(matches!(exec.state, WorkflowExecutionState::Failed { .. }));
+    }
+
+    // ---- resolve_step_settings ----
+
+    #[test]
+    fn resolve_step_settings_model_and_permission_specified() {
+        let result = resolve_step_settings(
+            Some("codex-mini".to_string()),
+            Some("bypassPermissions".to_string()),
+            Some("codex".to_string()),
+            Some("claude".to_string()),
+            Some("opus-4".to_string()),
+            "acceptEdits".to_string(),
+        );
+        assert_eq!(
+            result,
+            ResolvedStepSettings {
+                backend_id: Some("codex".to_string()),
+                selected_model: Some("codex-mini".to_string()),
+                permission_mode: "bypassPermissions".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_step_settings_model_only() {
+        let result = resolve_step_settings(
+            Some("haiku".to_string()),
+            None,
+            Some("claude".to_string()),
+            Some("claude".to_string()),
+            Some("opus-4".to_string()),
+            "acceptEdits".to_string(),
+        );
+        assert_eq!(
+            result,
+            ResolvedStepSettings {
+                backend_id: Some("claude".to_string()),
+                selected_model: Some("haiku".to_string()),
+                permission_mode: "acceptEdits".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_step_settings_permission_only() {
+        let result = resolve_step_settings(
+            None,
+            Some("plan".to_string()),
+            None,
+            Some("claude".to_string()),
+            Some("opus-4".to_string()),
+            "acceptEdits".to_string(),
+        );
+        assert_eq!(
+            result,
+            ResolvedStepSettings {
+                backend_id: Some("claude".to_string()),
+                selected_model: Some("opus-4".to_string()),
+                permission_mode: "plan".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_step_settings_nothing_specified() {
+        let result = resolve_step_settings(
+            None,
+            None,
+            None,
+            Some("claude".to_string()),
+            Some("opus-4".to_string()),
+            "acceptEdits".to_string(),
+        );
+        assert_eq!(
+            result,
+            ResolvedStepSettings {
+                backend_id: Some("claude".to_string()),
+                selected_model: Some("opus-4".to_string()),
+                permission_mode: "acceptEdits".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_step_settings_parallel_children_different_configs() {
+        // ステップA: model=opus-4, permission=plan
+        let result_a = resolve_step_settings(
+            Some("opus-4".to_string()),
+            Some("plan".to_string()),
+            Some("claude".to_string()),
+            Some("claude".to_string()),
+            Some("opus-4".to_string()),
+            "acceptEdits".to_string(),
+        );
+        assert_eq!(
+            result_a,
+            ResolvedStepSettings {
+                backend_id: Some("claude".to_string()),
+                selected_model: Some("opus-4".to_string()),
+                permission_mode: "plan".to_string(),
+            }
+        );
+
+        // ステップB: model=codex-mini, permission=bypassPermissions
+        let result_b = resolve_step_settings(
+            Some("codex-mini".to_string()),
+            Some("bypassPermissions".to_string()),
+            Some("codex".to_string()),
+            Some("claude".to_string()),
+            Some("opus-4".to_string()),
+            "acceptEdits".to_string(),
+        );
+        assert_eq!(
+            result_b,
+            ResolvedStepSettings {
+                backend_id: Some("codex".to_string()),
+                selected_model: Some("codex-mini".to_string()),
+                permission_mode: "bypassPermissions".to_string(),
+            }
+        );
+
+        // 並列ステップ間で結果が独立していることを確認
+        assert_ne!(result_a.backend_id, result_b.backend_id);
+        assert_ne!(result_a.selected_model, result_b.selected_model);
+        assert_ne!(result_a.permission_mode, result_b.permission_mode);
     }
 }

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -607,17 +607,20 @@ impl WorkflowEngine {
         app: &tauri::AppHandle,
         model: &str,
     ) -> Result<Option<String>, WorkflowEngineError> {
-        if let Some(registry) = app.try_state::<Arc<crate::backends::AgentBackendRegistry>>() {
-            let backend_id = registry
-                .resolve_backend_for_model(model)
-                .await
-                .ok_or_else(|| {
-                    WorkflowEngineError::InvalidWorkflow(format!("unknown model: {model}"))
-                })?;
-            Ok(Some(backend_id))
-        } else {
-            Ok(None)
-        }
+        let registry = app
+            .try_state::<Arc<crate::backends::AgentBackendRegistry>>()
+            .ok_or_else(|| {
+                WorkflowEngineError::InvalidWorkflow(format!(
+                    "cannot resolve model '{model}': backend registry is unavailable"
+                ))
+            })?;
+        let backend_id = registry
+            .resolve_backend_for_model(model)
+            .await
+            .ok_or_else(|| {
+                WorkflowEngineError::InvalidWorkflow(format!("unknown model: {model}"))
+            })?;
+        Ok(Some(backend_id))
     }
 
     /// ステップ設定の解決 → セッション生成 → 解決済み設定の反映 → 保存を一括で行う。

--- a/src-tauri/src/workflow/facet.rs
+++ b/src-tauri/src/workflow/facet.rs
@@ -374,6 +374,8 @@ mod tests {
             parallel: None,
             aggregate: None,
             resets_cycle_for: None,
+            model: None,
+            permission: None,
         }
     }
 

--- a/src-tauri/src/workflow/log.rs
+++ b/src-tauri/src/workflow/log.rs
@@ -795,6 +795,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
                 Step {
                     name: "implement".to_string(),
@@ -816,6 +818,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
                 Step {
                     name: "review".to_string(),
@@ -837,6 +841,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
             ],
         }
@@ -1047,6 +1053,8 @@ mod tests {
                     parallel: None,
                     aggregate: None,
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
                 Step {
                     name: "parallel-review".to_string(),
@@ -1073,6 +1081,8 @@ mod tests {
                             output_contract: None,
                             pass_previous_response: None,
                             pass_output_from: None,
+                            model: None,
+                            permission: None,
                         },
                         ParallelStep {
                             name: "security-review".to_string(),
@@ -1084,6 +1094,8 @@ mod tests {
                             output_contract: None,
                             pass_previous_response: None,
                             pass_output_from: None,
+                            model: None,
+                            permission: None,
                         },
                     ]),
                     aggregate: Some(AggregateConfig {
@@ -1093,6 +1105,8 @@ mod tests {
                         r#else: "_complete".to_string(),
                     }),
                     resets_cycle_for: None,
+                    model: None,
+                    permission: None,
                 },
             ],
         };

--- a/src-tauri/src/workflow/schema.rs
+++ b/src-tauri/src/workflow/schema.rs
@@ -42,6 +42,10 @@ pub struct Step {
     pub aggregate: Option<AggregateConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resets_cycle_for: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission: Option<String>,
 }
 
 fn has_any_facet_ref(
@@ -103,6 +107,10 @@ pub struct ParallelStep {
     pub pass_previous_response: Option<bool>,
     #[serde(default)]
     pub pass_output_from: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission: Option<String>,
 }
 
 impl ParallelStep {
@@ -403,6 +411,8 @@ steps:
             parallel: None,
             aggregate: None,
             resets_cycle_for: None,
+            model: None,
+            permission: None,
         };
         assert!(!step.has_facet_refs());
     }
@@ -472,6 +482,8 @@ steps:
             output_contract: None,
             pass_previous_response: None,
             pass_output_from: None,
+            model: None,
+            permission: None,
         };
         assert!(ps.has_facet_refs());
 
@@ -485,6 +497,8 @@ steps:
             output_contract: None,
             pass_previous_response: None,
             pass_output_from: None,
+            model: None,
+            permission: None,
         };
         assert!(!ps_no_facet.has_facet_refs());
     }
@@ -587,5 +601,109 @@ steps:
 "#;
         let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
         assert!(wf.steps[0].inline_prompt.is_none());
+    }
+
+    #[test]
+    fn parse_step_with_model_and_permission() {
+        let yaml = r#"
+name: model-test
+description: model/permission test
+steps:
+  - name: plan
+    mode: auto
+    instruction: plan
+    model: opus-4
+    permission: plan
+  - name: implement
+    mode: auto
+    instruction: implement
+    model: codex-mini
+    permission: bypassPermissions
+"#;
+        let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(wf.steps[0].model.as_deref(), Some("opus-4"));
+        assert_eq!(wf.steps[0].permission.as_deref(), Some("plan"));
+        assert_eq!(wf.steps[1].model.as_deref(), Some("codex-mini"));
+        assert_eq!(wf.steps[1].permission.as_deref(), Some("bypassPermissions"));
+    }
+
+    #[test]
+    fn parse_step_without_model_permission_defaults_to_none() {
+        let yaml = r#"
+name: default-test
+description: default test
+steps:
+  - name: step1
+    mode: auto
+    instruction: implement
+"#;
+        let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
+        assert!(wf.steps[0].model.is_none());
+        assert!(wf.steps[0].permission.is_none());
+    }
+
+    #[test]
+    fn parse_parallel_step_with_model_and_permission() {
+        let yaml = r#"
+name: parallel-model-test
+description: parallel model/permission test
+steps:
+  - name: parallel-review
+    parallel:
+      - name: arch-review
+        mode: auto
+        persona: reviewer
+        instruction: architecture-review
+        model: opus-4
+        permission: plan
+      - name: security-review
+        mode: auto
+        persona: reviewer
+        instruction: security-review
+        model: codex-mini
+        permission: bypassPermissions
+    aggregate:
+      all_match: "LGTM"
+      then: parallel-review
+      else: parallel-review
+"#;
+        let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
+        let children = wf.steps[0].parallel.as_ref().unwrap();
+        assert_eq!(children[0].model.as_deref(), Some("opus-4"));
+        assert_eq!(children[0].permission.as_deref(), Some("plan"));
+        assert_eq!(children[1].model.as_deref(), Some("codex-mini"));
+        assert_eq!(children[1].permission.as_deref(), Some("bypassPermissions"));
+    }
+
+    #[test]
+    fn parse_step_model_only() {
+        let yaml = r#"
+name: model-only-test
+description: model only test
+steps:
+  - name: step1
+    mode: auto
+    instruction: implement
+    model: haiku
+"#;
+        let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(wf.steps[0].model.as_deref(), Some("haiku"));
+        assert!(wf.steps[0].permission.is_none());
+    }
+
+    #[test]
+    fn parse_step_permission_only() {
+        let yaml = r#"
+name: permission-only-test
+description: permission only test
+steps:
+  - name: step1
+    mode: auto
+    instruction: implement
+    permission: plan
+"#;
+        let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
+        assert!(wf.steps[0].model.is_none());
+        assert_eq!(wf.steps[0].permission.as_deref(), Some("plan"));
     }
 }

--- a/src-tauri/src/workflow/storage.rs
+++ b/src-tauri/src/workflow/storage.rs
@@ -254,6 +254,8 @@ mod tests {
                 parallel: None,
                 aggregate: None,
                 resets_cycle_for: None,
+                model: None,
+                permission: None,
             }],
         }
     }

--- a/src-tauri/src/workflow/validation.rs
+++ b/src-tauri/src/workflow/validation.rs
@@ -99,6 +99,16 @@ pub enum ValidationError {
         step: String,
         reason: String,
     },
+    /// 無効な permission mode が指定されている
+    InvalidPermissionMode {
+        step: String,
+        value: String,
+    },
+    /// 存在しないモデルが指定されている
+    UnknownModel {
+        step: String,
+        value: String,
+    },
 }
 
 impl fmt::Display for ValidationError {
@@ -194,6 +204,18 @@ impl fmt::Display for ValidationError {
             ),
             Self::InvalidApprovalRules { step, reason } => {
                 write!(f, "approvalステップ '{step}' のrulesが不正です: {reason}")
+            }
+            Self::InvalidPermissionMode { step, value } => {
+                write!(
+                    f,
+                    "ステップ '{step}' のpermissionが不正です: invalid permission mode: {value}"
+                )
+            }
+            Self::UnknownModel { step, value } => {
+                write!(
+                    f,
+                    "ステップ '{step}' のmodelが不正です: unknown model: {value}"
+                )
             }
         }
     }
@@ -299,6 +321,11 @@ pub fn validate(workflow: &Workflow) -> Result<(), ValidationError> {
                     });
                 }
 
+                // 子step の permission 妥当性チェック
+                if let Some(ref perm) = child.permission {
+                    validate_permission(&child.name, perm)?;
+                }
+
                 // pass_output_from の参照先チェック
                 if let Some(ref refs) = child.pass_output_from {
                     for r in refs {
@@ -396,6 +423,11 @@ pub fn validate(workflow: &Workflow) -> Result<(), ValidationError> {
             }
             if step.mode == Some(StepMode::Approval) {
                 validate_approval_rules(&step.name, &step.rules)?;
+            }
+
+            // permission の妥当性チェック
+            if let Some(ref perm) = step.permission {
+                validate_permission(&step.name, perm)?;
             }
 
             // aggregate が parallel なしで指定されている場合はエラー
@@ -564,6 +596,49 @@ fn validate_approval_rules(
     Ok(())
 }
 
+const VALID_PERMISSION_MODES: &[&str] = &["acceptEdits", "bypassPermissions", "plan"];
+
+fn validate_permission(step_name: &str, value: &str) -> Result<(), ValidationError> {
+    if !VALID_PERMISSION_MODES.contains(&value) {
+        return Err(ValidationError::InvalidPermissionMode {
+            step: step_name.to_string(),
+            value: value.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// ワークフロー内の全ステップの `model` フィールドを検証する。
+/// `valid_models` は全バックエンドの `available_models()` から収集した有効なモデルID集合。
+pub fn validate_models(
+    workflow: &Workflow,
+    valid_models: &HashSet<String>,
+) -> Result<(), ValidationError> {
+    for step in &workflow.steps {
+        if let Some(ref model) = step.model {
+            if !valid_models.contains(model.as_str()) {
+                return Err(ValidationError::UnknownModel {
+                    step: step.name.clone(),
+                    value: model.clone(),
+                });
+            }
+        }
+        if let Some(ref children) = step.parallel {
+            for child in children {
+                if let Some(ref model) = child.model {
+                    if !valid_models.contains(model.as_str()) {
+                        return Err(ValidationError::UnknownModel {
+                            step: child.name.clone(),
+                            value: model.clone(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// 診断用: 全てのバリデーションエラーを収集して返す。
 /// `validate` は最初のエラーで早期リターンするが、診断エンジンでは全エラーを網羅的に報告したいため、
 /// 構造的に安全な範囲でエラーを蓄積する。
@@ -641,6 +716,11 @@ pub fn validate_all(workflow: &Workflow) -> Vec<ValidationError> {
                         parent: step.name.clone(),
                         child: child.name.clone(),
                     });
+                }
+                if let Some(ref perm) = child.permission {
+                    if let Err(e) = validate_permission(&child.name, perm) {
+                        errors.push(e);
+                    }
                 }
                 if let Some(ref refs) = child.pass_output_from {
                     for r in refs {
@@ -727,6 +807,11 @@ pub fn validate_all(workflow: &Workflow) -> Vec<ValidationError> {
             }
             if step.mode == Some(StepMode::Approval) {
                 if let Err(e) = validate_approval_rules(&step.name, &step.rules) {
+                    errors.push(e);
+                }
+            }
+            if let Some(ref perm) = step.permission {
+                if let Err(e) = validate_permission(&step.name, perm) {
                     errors.push(e);
                 }
             }
@@ -877,6 +962,8 @@ mod tests {
             parallel: None,
             aggregate: None,
             resets_cycle_for: None,
+            model: None,
+            permission: None,
         }
     }
 
@@ -891,6 +978,8 @@ mod tests {
             output_contract: None,
             pass_previous_response: None,
             pass_output_from: None,
+            model: None,
+            permission: None,
         }
     }
 
@@ -916,6 +1005,8 @@ mod tests {
             parallel: Some(children),
             aggregate,
             resets_cycle_for: None,
+            model: None,
+            permission: None,
         }
     }
 
@@ -1701,5 +1792,159 @@ mod tests {
             ..make_step("step1", StepMode::Auto, vec![])
         }]);
         assert!(validate(&wf).is_ok());
+    }
+
+    // ---- permission バリデーション ----
+
+    #[test]
+    fn valid_permission_accept_edits_passes() {
+        let wf = make_workflow(vec![Step {
+            permission: Some("acceptEdits".to_string()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        assert!(validate(&wf).is_ok());
+    }
+
+    #[test]
+    fn valid_permission_bypass_passes() {
+        let wf = make_workflow(vec![Step {
+            permission: Some("bypassPermissions".to_string()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        assert!(validate(&wf).is_ok());
+    }
+
+    #[test]
+    fn valid_permission_plan_passes() {
+        let wf = make_workflow(vec![Step {
+            permission: Some("plan".to_string()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        assert!(validate(&wf).is_ok());
+    }
+
+    #[test]
+    fn invalid_permission_fails() {
+        let wf = make_workflow(vec![Step {
+            permission: Some("invalid-mode".to_string()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        let err = validate(&wf).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::InvalidPermissionMode { ref step, ref value }
+                if step == "step1" && value == "invalid-mode"
+        ));
+        assert!(err
+            .to_string()
+            .contains("invalid permission mode: invalid-mode"));
+    }
+
+    #[test]
+    fn invalid_permission_on_parallel_child_fails() {
+        let wf = make_workflow(vec![make_parallel_block(
+            "par",
+            vec![ParallelStep {
+                permission: Some("invalid-mode".to_string()),
+                ..make_parallel_step("child1")
+            }],
+            None,
+        )]);
+        let err = validate(&wf).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::InvalidPermissionMode { ref step, ref value }
+                if step == "child1" && value == "invalid-mode"
+        ));
+    }
+
+    #[test]
+    fn valid_permission_on_parallel_child_passes() {
+        let wf = make_workflow(vec![make_parallel_block(
+            "par",
+            vec![ParallelStep {
+                permission: Some("bypassPermissions".to_string()),
+                ..make_parallel_step("child1")
+            }],
+            None,
+        )]);
+        assert!(validate(&wf).is_ok());
+    }
+
+    #[test]
+    fn step_without_permission_passes() {
+        let wf = make_workflow(vec![Step {
+            permission: None,
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        assert!(validate(&wf).is_ok());
+    }
+
+    // ---- model バリデーション (validate_models) ----
+
+    #[test]
+    fn validate_models_valid_model_passes() {
+        let wf = make_workflow(vec![Step {
+            model: Some("haiku".to_string()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        let valid = HashSet::from(["haiku".to_string(), "opus-4".to_string()]);
+        assert!(validate_models(&wf, &valid).is_ok());
+    }
+
+    #[test]
+    fn validate_models_unknown_model_fails() {
+        let wf = make_workflow(vec![Step {
+            model: Some("unknown-model".to_string()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        let valid = HashSet::from(["haiku".to_string(), "opus-4".to_string()]);
+        let err = validate_models(&wf, &valid).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::UnknownModel { ref step, ref value }
+                if step == "step1" && value == "unknown-model"
+        ));
+        assert!(err.to_string().contains("unknown model: unknown-model"));
+    }
+
+    #[test]
+    fn validate_models_unknown_model_on_parallel_child_fails() {
+        let wf = make_workflow(vec![make_parallel_block(
+            "par",
+            vec![ParallelStep {
+                model: Some("unknown-model".to_string()),
+                ..make_parallel_step("child1")
+            }],
+            None,
+        )]);
+        let valid = HashSet::from(["haiku".to_string()]);
+        let err = validate_models(&wf, &valid).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::UnknownModel { ref step, ref value }
+                if step == "child1" && value == "unknown-model"
+        ));
+    }
+
+    #[test]
+    fn validate_models_no_model_specified_passes() {
+        let wf = make_workflow(vec![make_step("step1", StepMode::Auto, vec![])]);
+        let valid = HashSet::from(["haiku".to_string()]);
+        assert!(validate_models(&wf, &valid).is_ok());
+    }
+
+    #[test]
+    fn validate_models_valid_model_on_parallel_child_passes() {
+        let wf = make_workflow(vec![make_parallel_block(
+            "par",
+            vec![ParallelStep {
+                model: Some("haiku".to_string()),
+                ..make_parallel_step("child1")
+            }],
+            None,
+        )]);
+        let valid = HashSet::from(["haiku".to_string()]);
+        assert!(validate_models(&wf, &valid).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- ワークフローYAMLの各ステップに `model` / `permission` フィールドをオプションで指定可能にする (#939)
- Model値から対応バックエンドを `available_models()` 逆引きで自動解決
- 未指定時は親セッションの設定 (Backend/Model/PermissionMode) を継承
- 対応モデル一覧を CLI 最新版 (Claude v2.1.139 / Codex v0.130.0) のカタログに更新し full model name へ移行
- builtin ワークフロー `spec-driven-development` のレビューステップ (10件) を `gpt-5.5`、それ以外を `claude-opus-4-7` に設定

Closes #939

## 主な変更

| レイヤ | 変更 |
|--------|------|
| schema | `Step` / `ParallelStep` に optional な `model` / `permission` フィールド追加 |
| validation | `validate_permission` / `validate_models` で値の妥当性検証 |
| engine | `ResolvedStepSettings` による継承ロジック + バックエンド自動解決 |
| backends | `AgentBackendRegistry::collect_all_model_values` / `resolve_backend_for_model` 追加 |
| session | ステップ用 ChatSession の生成パラメータ拡張 |
| diagnostics | `InvalidPermissionMode` / `UnknownModel` のコンテキスト抽出対応 |

## 関連Issue

- Closes #939
- Follow-up: #946 (display_name廃止 + 設定ファイル管理), #947 (パーミッション3段階抽象化)

## Test plan

- [x] `cargo test` 全件PASS (1280 passed)
- [x] `cargo clippy -- -D warnings` PASS
- [x] `cargo fmt --check` PASS
- [x] schema/validation/engine/backends に対する単体テスト追加 (20+件)
- [ ] 手動E2E: ワークフローYAMLに model/permission を書いて実行し、対応バックエンドが起動することを確認
- [ ] 手動E2E: 並列ブロック内で異なるmodel/permissionが個別に適用されることを確認
- [ ] 手動E2E: 未指定ステップが親セッション設定を継承することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノーツ

* **New Features**
  * ワークフローの各ステップで個別のAIモデルと権限モードを指定可能に。未指定時は親セッションの設定を継承
  * 複数のAIモデルをバージョン更新・刷新

* **Documentation**
  * ワークフローステップのモデル・権限設定仕様を詳細に文書化

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/948)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->