### PR TITLE
fix: AgentChatストリーミング応答の表示遅延・行途中停止を解消 (#970)

### DIFF
--- a/docs/spec/issues-970.md
+++ b/docs/spec/issues-970.md
@@ -1,0 +1,280 @@
+# AgentChat: ストリーミング応答の表示が遅延・行途中で止まる問題を修正
+
+参照: https://github.com/siro33950/releash/issues/970
+
+## 要求
+
+**種別**: バグ修正
+
+**ゴール**:
+AgentChat において、エージェントからのストリーミング応答が Frontend に配信された直後に UI へ反映される状態にする。行の途中で表示が止まる現象、およびストリーミング完了後に全文が一気に表示される現象を解消する。
+
+なお、ここでの「即時反映」の基準点は **SDK delta が Rust に到着した瞬間ではなく、Rust 側の集約（coalescing）処理を経て Frontend / Remote が配信を受信した直後** を指す。Rust 側で 33ms 程度の集約を行うことはこのゴールと矛盾しない（[対応方針（概要）](#対応方針概要)参照）。
+
+**背景**:
+AgentChat ではエージェントからの Response があっても UI 表示が遅れたり、行の途中までしか表示されないままストリーミング完了時に一気に追いつくケースが頻発している。原因は複数要因の重なりであることが調査で判明している:
+
+1. **`useDeferredValue` による表示停止（主因）**
+   `src/components/panels/AgentChatPanel/StreamMessage.tsx:136` で Markdown 描画前に `useDeferredValue` を使用。delta が連続して流れてくる状況では React がほぼ常にビジー状態となり、deferred value が最新に追いつかず古い content をレンダリングし続ける。LLM ストリーミング UI のベストプラクティス（Vercel AI SDK / Chrome 公式等）でも非推奨。
+
+2. **Rust 側で `agent-streaming-updated` をスロットリングなしで emit**
+   `src-tauri/src/backends/bridge_common.rs:1672` 付近で SDK からの delta ごとに即 emit している。トークンごとに `SET_STREAMING_MESSAGE` が発火し、`activeSession` ツリー全体が再レンダリング、Markdown が再パースされる。
+
+3. **`StreamMessage` がメモ化されていない**
+   親の再レンダリングに連動し、content が変わらないメッセージも再描画される。
+
+## 現在の挙動
+
+- Response の delta が届いても UI 反映が遅れる
+- 行の途中で表示が止まる
+- ストリーミング完了後に全文が一気に表示されるケースがある
+
+## 期待する挙動
+
+- ストリーミング中、Frontend / Remote が配信を受信した直後に UI に反映される
+- 行の途中で表示が止まる現象が発生しない
+- ストリーミング完了を待たずに進行中の文字列が反映される
+
+## 再現手順
+
+1. AgentChat パネルでエージェントとの対話を開始する
+2. 長文の応答を生成させる（複数行の Markdown を含む応答）
+3. ストリーミング中の UI 描画を観察する → 遅延・停止・完了時の一気表示が発生する
+
+## 対応方針（概要）
+
+業界ベストプラクティス（Vercel AI SDK の `experimental_throttle`、ChatGPT の RAF バッファリング等）に沿う。「ロジックは Rust 側に置く」方針（`rust-first-logic.md`）に従い、throttle は Rust 側で実装する。
+
+1. `useDeferredValue` を削除（主因の直接除去）
+2. Rust 側で `agent-streaming-updated` / `agent_stream_sync`（WS 経由）の emit を coalescing（`STREAMING_EMIT_INTERVAL_MS = 33` ≈ 30fps 間隔）
+   - `AgentProcess` に pending delta buffer と last emit 時刻を持たせる
+   - pending buffer に蓄積するのは既存パーサ通過済みの `MessagePart` 列のみ。件数上限（1000 件）と総 byte 上限（`STREAMING_PENDING_BYTE_LIMIT`）を設け、いずれかの上限到達時は次 delta 到着で即 flush する。これらの上限は **通常時は flush 閾値**（上限到達で集約間隔を待たず即 flush）として機能し、**配信失敗中のみ上限超過を許容して保持**する（ハード上限ではない）
+   - 初回 delta（`last_emit_at` が未設定）は即 flush し、`last_emit_at` をセットする
+   - 間隔未満は溜め込み、間隔到達時に flush
+   - flush トリガーは「次 delta 到着時に経過時間が 33ms 以上なら flush」と「補助タイマー（33ms 周期）で pending があれば flush」の併用とし、無音期間中の pending 配信も保証する
+   - turn_complete / state 遷移時は強制 flush
+   - emit は `emit_streaming_parts`（Tauri event `agent-streaming-updated` と WS `AgentStreamSync` の同時送信）を best-effort で行い、`Result` 化はしない。emit 失敗時（Tauri event / WS いずれかが失敗、または両方が失敗）でも pending と `last_emit_at` を破棄せず保持し、次の flush 契機で再試行する
+   - 配信ペイロードである `streaming_parts` は **累積置換型**（毎回そのメッセージの全パーツ列を送る）であり、Frontend / Remote 側は受信内容で該当メッセージ状態を完全置換する。これにより、Tauri event / WS のいずれか片方だけが成功した場合でも、次 flush で両チャネルへ同じ累積 parts を再送すれば、成功済みチャネル側でも再受信が単純な置換となり、重複表示・重複適用は発生しない。`sequence_id` 等の追加重複排除は不要
+3. `StreamMessage` を `React.memo` 化（同一 content での無駄な再パースを抑止）
+
+ブロック単位（marked.lexer）の memo 化は、上記 3 つを実施した上で必要性を判断する。
+
+## 振る舞い定義
+
+```gherkin
+Feature: AgentChat ストリーミング応答の即時反映
+
+  Rule: ストリーミング応答の配信は一定間隔で集約する
+
+    Scenario: ストリーミング開始直後の応答は即座に配信される
+      Given ストリーミングが開始されたばかりで、まだ一度も配信していない
+      When 最初の応答が到着する
+      Then その応答は即座にフロントエンドへ配信される
+
+    Scenario: 集約間隔内に到着した応答は未配信バッファに蓄積される
+      Given 直前の配信から集約間隔が経過していない
+      When 新しい応答が到着する
+      Then その応答は未配信バッファに蓄積され、まだフロントエンドへは配信されない
+
+    Scenario: 集約間隔経過後の応答到着時にまとめて配信される
+      Given 未配信バッファに応答が蓄積されている
+      And 直前の配信から集約間隔が経過している
+      When 新しい応答が到着する
+      Then 未配信バッファの内容と今回の応答をまとめてフロントエンドへ配信する
+
+    Scenario: 無音期間中も未配信バッファは自動的に配信される
+      Given 未配信バッファに応答が蓄積されている
+      And 新しい応答が到着しないまま集約間隔以上が経過する
+      Then 未配信バッファの内容がフロントエンドへ自動的に配信される
+
+    Scenario: 未配信バッファが空のときは自動配信を発火しない
+      Given 未配信バッファが空である
+      When 自動配信のタイミングが到来する
+      Then フロントエンドへの配信を行わない
+
+    # 注: 総バイト数の境界条件を検証するテストは、実装定数
+    # `STREAMING_PENDING_BYTE_LIMIT` を参照して上限到達条件を生成すること
+    # （[実装に委ねること](#実装に委ねること) 参照）。
+    Scenario Outline: バッファ容量上限到達時は集約間隔を待たず即配信する
+      Given 未配信バッファが <上限種別> の上限に達している
+      When 新しい応答が到着する
+      Then 集約間隔の経過に関わらず、未配信バッファと今回の応答をまとめて即配信する
+
+      Examples:
+        | 上限種別   |
+        | 件数       |
+        | 総バイト数 |
+
+    Scenario: 配信失敗時は未配信バッファと最終配信時刻を保持して再試行する
+      Given 未配信バッファに応答が蓄積されている
+      When フロントエンドへの配信に失敗する
+      Then 未配信バッファの内容を破棄せず保持する
+      And 最終配信時刻を更新しない
+      And 次回の配信タイミングで再試行する
+
+    Scenario: 上限到達中に配信が失敗しても新しい応答はバッファに追加する
+      Given 未配信バッファが容量上限に達している
+      And 直前の配信が失敗している
+      When 新しい応答が到着する
+      Then その応答も未配信バッファに追加する（上限超過を許容する）
+      And 次の配信タイミングで再試行する
+
+    Scenario: 配信チャネルの片方だけが失敗しても次 flush で両チャネルに同じ累積を再送する
+      Given Tauri event と WS `AgentStreamSync` の一方が成功し、もう一方が失敗した直前の flush がある
+      And `streaming_parts` の累積パーツ列は両チャネル向けに同一である
+      When 次の flush 契機が到来する
+      Then 両チャネルに対して同じ累積 `streaming_parts` を送信する
+      And 成功済みチャネル側でも受信内容で該当メッセージ状態を完全置換するため、重複表示・重複適用は発生しない
+
+    Scenario: 配信失敗時の警告ログには応答本文を含めない
+      Given 配信に失敗した状況である
+      When 警告ログが出力される
+      Then ログには応答本文・ツール入出力・画像・メンションなどのユーザーデータを含めない
+      And ログにはイベント名・件数・バッファ長・エラー種別などの非本文メタデータのみを含める
+
+  Rule: ターン完了・状態遷移時には未配信バッファを強制配信する
+
+    Scenario: ターン完了時に未配信バッファを強制配信する
+      Given 未配信バッファに応答が残っている
+      When エージェントのターンが完了する
+      Then 残っている応答を即座にフロントエンドへ配信する
+
+    Scenario Outline: ストリーミングに関わる状態遷移時に未配信バッファを強制配信する
+      Given 未配信バッファに応答が残っている
+      When <遷移> が発生する
+      Then 残っている応答を即座にフロントエンドへ配信してから状態を遷移させる
+
+      Examples:
+        | 遷移                          |
+        | ストリーミング → アイドル     |
+        | ストリーミング → 権限待ち     |
+        | 権限待ち → ストリーミング     |
+        | ストリーミング → 実行準備完了 |
+        | ストリーミング → クラッシュ   |
+        | ツール実行の開始              |
+        | ツール実行の終了              |
+
+    Scenario: 強制配信が失敗しても後続の状態遷移は続行する
+      Given 状態遷移またはターン完了に伴う強制配信を実行している
+      When フロントエンドへの配信に失敗する
+      Then 未配信バッファを保持したまま、状態遷移・完了通知などの後続処理は続行する
+
+    Scenario: 配信済みの状態で再度強制配信が呼ばれても二重配信は発生しない
+      Given 直前の強制配信で未配信バッファを全て配信済みである
+      When 同じ契機で再度強制配信が呼ばれる
+      Then 配信は発火せず、同じ応答が再配信されることはない
+
+  Rule: WS `AgentStreamSync` の配信先は該当 chat_session に認可されたセッションのみとする
+
+    Scenario: 認証済みかつ該当 chat_session を購読するセッションのみが配信を受信する
+      Given Rust が `AgentStreamSync` を flush する
+      And `chat_session_id` が S である
+      When 配信が WS ブロードキャスターを通る
+      Then 認証済みで chat_session S に対する閲覧権限を持つ WS セッションのみが配信を受信する
+      And それ以外（未認証セッション・別 chat_session を見ているセッション）には配信されない
+
+    Scenario: 認証されていないセッションには配信されない
+      Given 認証が完了していない WS セッションが存在する
+      When `AgentStreamSync` の配信が発生する
+      Then 当該未認証セッションには配信メッセージが届かない
+
+  Rule: ストリーミング応答は受信した直後に画面へ反映する
+
+    Scenario: 配信受信時に該当メッセージの表示が更新される
+      Given AgentChat パネルでストリーミング中のメッセージが表示されている
+      When フロントエンドがストリーミング配信を受信する
+      Then 配信受信を起点に同一 React render サイクル内（または次の microtask 完了時点）で該当メッセージの DOM ノードに新しい content が反映される
+
+    Scenario: Remote が `AgentStreamSync` を受信した直後に対応メッセージ状態と表示が即時更新される
+      Given Remote の AgentChat 相当画面でストリーミング中のメッセージが表示されている
+      When Remote が WS `AgentStreamSync` を受信する
+      Then 受信を起点に同一 React render サイクル内（または次の microtask 完了時点）で、該当メッセージの状態が受信した累積 `streaming_parts` で完全置換される
+      And その置換結果が DOM ノードに即時反映される
+
+    Scenario: 連続する応答に対して行の途中で描画が止まらない
+      Given 長文の Markdown 応答をストリーミングで受信している
+      When N 回（N ≥ 2）の配信が連続して到着する
+      Then N 回それぞれに対応する content 変化が DOM に反映され、最後の配信を待たずに途中の content も観測できる
+
+    Scenario: メッセージ内容が同一であれば再描画されない
+      Given AgentChat に複数のメッセージが表示されている
+      When 親コンポーネントが再レンダリングされるが、特定メッセージの表示内容（本文・役割・画像・メンション）が全て同一である
+      Then そのメッセージは再描画されない
+
+## アーキテクチャ概要
+
+### 責務配置
+
+- **Rust: `AgentProcess` / `bridge_common.rs` の stdout reader**
+  - 担当する: SDK delta の受信、`streaming_parts` への accumulate、配信間隔の判定、未配信 delta のバッファリング、間隔到達/turn_complete/状態遷移時の flush（`emit_streaming_parts` 呼び出し）、最終配信時刻の保持。
+  - 担当しない: UI 描画タイミングの判断、Markdown 解析、メッセージの差分計算（再パース）。
+
+- **配信チャネル: `agent-streaming-updated`（Tauri event、デスクトップ向け） / `AgentStreamSync`（WebSocket、Remote 向け）**
+  - 担当する: Rust → Frontend / Remote の delta 配信チャネル（既存）。`emit_streaming_parts` が両者を同時に発火する。WS `AgentStreamSync` は **該当 `chat_session_id` に対して認証済みかつ閲覧権限を持つセッションにのみ** 配信される（既存の WS 認可機構に乗る）。
+  - 担当しない: イベントの間引きや結合（その判断は Rust 側に集約）。coalescing / flush / pending buffer の対象は Tauri event と WS `AgentStreamSync` の両方。
+
+- **Frontend: `useAgentSdkListeners` / `agentChatReducer`（デスクトップ） / Remote の `agent_stream_sync` ハンドラ**
+  - 担当する: イベント受信 → `SET_STREAMING_MESSAGE` 発火、reducer による activeSession への反映、Remote 側の対応する状態更新。
+  - 担当しない: 配信間隔・throttle・debounce のような時間ベースの制御（`useDeferredValue` 含む）。
+
+- **Frontend: `StreamMessage` コンポーネント**
+  - 担当する: 受け取った content の Markdown 描画、同一 props での再描画抑止（`React.memo`）。
+  - 担当しない: content の遅延適用、描画スケジューリング、ロジック層への問い合わせ。
+
+### データ/通信フロー
+
+- **delta 到着時（集約中）**: SDK delta → stdout reader → `AgentProcess.streaming_parts` 更新 → 集約間隔未到達なら未配信 delta をバッファに保持して終了。
+- **delta 到着時（集約間隔到達）**: バッファ＋今回 delta をまとめて `emit_streaming_parts` → `agent-streaming-updated`（Tauri event） と `AgentStreamSync`（WS）を同時発火 → デスクトップ側 `useAgentSdkListeners` で `SET_STREAMING_MESSAGE` dispatch / Remote 側 `agent_stream_sync` ハンドラで対応状態を更新 → reducer 更新 → `StreamMessage` 再描画（`content` / `role` / `images` / `mentions` の 4 props 浅比較で差分のあるメッセージのみ）。**emit が成功した場合のみ `last_emit_at` を現時刻に更新する。emit 失敗時は pending と `last_emit_at` を保持し、次の flush 契機で再試行する**（[振る舞い定義](#振る舞い定義) "配信失敗時は未配信バッファと最終配信時刻を保持して再試行する" Scenario と整合）。
+- **turn_complete / 実行状態遷移時**: バッファに残った delta を強制 flush（即 emit）→ 通常イベント（`turn_complete` 処理 / 状態通知）を続行。flush が失敗した場合も pending を保持したまま後続処理は続行（best-effort）。
+
+### 状態 Owner
+
+- **未配信 delta バッファ**: `AgentProcess`（Rust）。件数上限・総 byte 上限は **通常時は flush 閾値**（上限到達で集約間隔を待たず即 flush）として扱い、**配信失敗中のみ上限超過を許容して保持**する（ハード上限ではない）。
+- **最終配信時刻 (`last_emit_at`)**: `AgentProcess`（Rust）。
+- **集約間隔（定数）**: `bridge_common.rs` 内の定数（Rust）。
+- **`streaming_parts`（累積パーツ列）**: `AgentProcess`（既存、変更なし）。
+- **`turn_phase` / `BridgeState`**: `AgentProcess`（既存、変更なし。flush タイミングの判定に使用）。
+- **session 内ストリーミングメッセージ**: `agentChatReducer` の activeSession（Frontend、既存）。
+- **Remote 側 session 内ストリーミングメッセージ**: Remote の `agent_stream_sync` ハンドラが管理する session 状態（Remote、既存）。受信した累積 `streaming_parts` で該当メッセージを完全置換する。
+- **メッセージ描画状態**: `StreamMessage` の props（content/role/images/mentions のみ）。
+
+### 境界
+
+#### 責務の境界
+
+- 時間制御は Rust 側 `AgentProcess` に集約する。Frontend / Remote は時間制御を持たず、受信したら即時反映する。
+- `streaming_parts`（累積） と「未配信 delta」（差分バッファ）は別概念として保持する。前者は永続化や consolidate の入力、後者は emit 制御のための一時バッファ。
+- 強制 flush 経路は emit 順序を保つこと（バッファ flush → 状態通知 → 後続処理）。逆順だと Frontend が古い content で完了表示する。flush が失敗しても順序保証のため後続処理は続行する。
+- `StreamMessage` の memo 化は props を浅く比較できる形に保つ。親側で毎回新規参照になる props を渡さない（必要に応じて呼び出し側で安定化する）。
+
+#### 信頼境界
+
+- SDK 応答に含まれる **エージェント応答本文・ツール入出力・画像・メンション** は、すべて **外部由来のユーザーデータ** として扱う。Releash は内容を解釈・実行・整形（Markdown 描画含む）の対象とするだけで、信頼済み入力とは見なさない。
+- これらの外部由来データは、ログ・テレメトリ・エラーレポートに本文として載せない（[振る舞い定義](#振る舞い定義) "配信失敗時の警告ログには応答本文を含めない" Scenario と整合）。出力できるのは event 名・件数・バッファ長・エラー種別などの非本文メタデータに限る。
+- WS `AgentStreamSync` の配信先は該当 `chat_session_id` に対して認証済みかつ閲覧権限を持つセッションに限定する（既存 WS 認可機構に乗る）。未認証セッション・別 chat_session を見ているセッションには配信しない。
+
+### 実装に委ねること
+
+- 未配信 delta バッファのフィールド名（型は `MessagePart` 列で確定、件数上限 1000 件は Spec で確定、総 byte 上限の定数値 `STREAMING_PENDING_BYTE_LIMIT` の具体値は実装時に決定）。総バイト数上限の境界条件を検証するテストは、ハードコードした数値ではなく実装定数 `STREAMING_PENDING_BYTE_LIMIT` を参照して上限到達条件を生成すること。
+- 集約間隔定数の配置場所（名前は `STREAMING_EMIT_INTERVAL_MS`、値は 33 で確定）。
+- 補助タイマー（33ms 周期）の具体的な実装手段（tokio interval / 別タスク等）。補助タイマーは `chat_session_id` + `generation_id` に紐付け、flush 時に `AgentProcessMap` 内の generation 一致を確認し、不一致・process removal・crash 時は終了する方針は Spec で確定。
+- 状態遷移を検出する具体的なフック点（対象遷移は Scenario で列挙済み）。
+- `React.memo` の比較関数の実装（比較対象は `content` / `role` / `images` / `mentions` の浅比較で確定）と props 安定化の手段（必要時のみ）。
+- emit 失敗時の警告ログの具体的な出力先・フォーマット（含めるフィールドは event 名・part_count・buffer_len・error 種別など非本文メタデータに限定で確定）。
+- 各レイヤーでのテストケースの具体的な配置と粒度（Rust 側：`AgentProcess` ユニット相当 / TS 側：reducer・listener・component の既存テストへの追加）。
+
+## 受け入れ基準
+
+- `agent-streaming-updated` 受信時に該当メッセージの DOM が更新される
+- delta が連続到着している間、行の途中で表示が止まる現象が解消され、ストリーミング完了を待たずに進行中の文字列が反映され続ける
+- `pnpm test` が通る
+- `cargo test` が通る
+- `pnpm lint` が通る
+- `cargo clippy -- -D warnings` が通る
+
+## 参考
+
+- [Next.js: Markdown Chatbot with Memoization (Vercel AI SDK)](https://ai-sdk.dev/cookbook/next/markdown-chatbot-with-memoization)
+- [Best practices to render streamed LLM responses (Chrome for Developers)](https://developer.chrome.com/docs/ai/render-llm-responses)
+- [Streaming Backends & React: Controlling Re-render Chaos (SitePoint)](https://www.sitepoint.com/streaming-backends-react-controlling-re-render-chaos/)
+- [How To Build a Performant AI Markdown Renderer](https://tigerabrodi.blog/how-to-build-a-performant-ai-markdown-renderer)

--- a/src-tauri/src/backends/bridge_common.rs
+++ b/src-tauri/src/backends/bridge_common.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 static GENERATION_COUNTER: AtomicU64 = AtomicU64::new(1);
 
@@ -83,6 +84,26 @@ pub struct AgentProcess {
     /// Token usage from the latest `result` message (extracted from modelUsage).
     /// Consumed by turn_complete handler and passed to WorkflowEngine.
     pub last_result_token_usage: Option<(u64, u64)>,
+    /// Count of streaming delta parts queued since the last successful emit.
+    /// Acts as the dirty signal for coalescing — `> 0` means a flush is owed.
+    /// The actual payload lives in `streaming_parts` (cumulative); this field
+    /// only tracks how many entries have been added since the last flush so we
+    /// can detect the count threshold and decide when there's work to do.
+    pending_stream_part_count: usize,
+    /// Accumulated payload bytes for parts queued since the last successful
+    /// emit. Used to decide whether to flush early when the byte cap is
+    /// reached. Mirrors `pending_stream_part_count` semantically — count and
+    /// bytes are the only state we need; the delta entries themselves remain
+    /// in `streaming_parts`.
+    pending_stream_bytes: usize,
+    /// Timestamp of the most recent successful streaming emit. `None` means
+    /// the first emit for this turn — flush immediately.
+    last_stream_emit_at: Option<Instant>,
+    /// True while a per-turn auxiliary streaming-flush timer task is alive.
+    /// Set when the timer is spawned at streaming start; cleared by the timer
+    /// itself when it exits (turn ended and the buffer drained). Used to
+    /// avoid spawning a duplicate timer on overlapping turn starts.
+    streaming_timer_active: bool,
 }
 
 /// Per-session agent process map: chat_session_id -> AgentProcess
@@ -182,6 +203,20 @@ pub(crate) async fn write_bridge_command(
 const PERSIST_INTERVAL_MS: u64 = 1000;
 const BRIDGE_EOF_ERROR_MESSAGE: &str = "Bridge process exited unexpectedly.";
 
+/// Aggregation interval for `agent-streaming-updated` / `AgentStreamSync`.
+/// Roughly 30fps — balances UI smoothness against re-render cost.
+const STREAMING_EMIT_INTERVAL_MS: u64 = 33;
+
+/// Maximum number of pending delta parts before we flush early.
+/// Acts as a flush threshold in normal operation, and as a soft cap
+/// (we keep accepting parts even past this) while delivery is failing.
+const STREAMING_PENDING_PART_LIMIT: usize = 1000;
+
+/// Maximum cumulative byte size of pending delta payloads before we flush early.
+/// Same semantics as `STREAMING_PENDING_PART_LIMIT`: flush threshold in normal
+/// operation, soft cap (allowed to overflow) while delivery is failing.
+const STREAMING_PENDING_BYTE_LIMIT: usize = 256 * 1024;
+
 fn backend_runtime_config(app: &tauri::AppHandle, backend_id: &str) -> BackendRuntimeConfig {
     app.try_state::<Arc<crate::backends::AgentBackendRegistry>>()
         .and_then(|registry| registry.runtime_config(backend_id, app))
@@ -211,6 +246,20 @@ async fn available_models_for_backend(
 }
 
 impl AgentProcess {
+    /// Reset per-turn streaming state (cumulative parts, coalescing buffer,
+    /// last-emit timestamp, retained message id, task id map). Called on every
+    /// path that begins a new agent turn so the coalescer doesn't carry over
+    /// residue from the previous turn — e.g. a stale `last_stream_emit_at`
+    /// would block the first emit of the new turn from firing immediately.
+    fn reset_streaming_state_for_new_turn(&mut self) {
+        self.streaming_parts.clear();
+        self.pending_stream_part_count = 0;
+        self.pending_stream_bytes = 0;
+        self.last_stream_emit_at = None;
+        self.last_message_id = None;
+        self.task_id_map.clear();
+    }
+
     /// Write setMode + setModel commands to the Bridge stdin before a turn starts.
     async fn sync_pre_turn_settings(&mut self, permission_mode: &str) -> Result<(), String> {
         let mode_data = build_set_mode_command(permission_mode);
@@ -381,28 +430,452 @@ fn emit_session_state_changed(
     );
 }
 
+/// Emit the cumulative `streaming_parts` payload over both delivery channels.
+///
+/// Returns `(tauri_ok, ws_ok)`. `tauri_ok` reflects whether the Tauri event
+/// dispatcher accepted the payload. `ws_ok` is always `true` on the
+/// production broadcaster path: `WsBroadcaster::send_stream_sync` is a
+/// best-effort enqueue (slot writes cannot fail and downstream WS transport
+/// failure is recovered by the next flush re-sending the cumulative
+/// `streaming_parts`). Treating the WS channel as always-true here matches
+/// that contract; callers that need to simulate a WS-side failure (unit
+/// tests) drive `apply_streaming_emit_result` directly.
 fn emit_streaming_parts(
     app: &tauri::AppHandle,
     chat_session_id: &str,
     message_id: &str,
     parts: Vec<MessagePart>,
-) {
+) -> (bool, bool) {
     use tauri::{Emitter, Manager};
     let payload = serde_json::json!({
         "chat_session_id": chat_session_id,
         "message_id": message_id,
         "parts": parts,
     });
-    let _ = app.emit("agent-streaming-updated", &payload);
+    let tauri_ok = app.emit("agent-streaming-updated", &payload).is_ok();
     if let Some(broadcaster) = app.try_state::<Arc<crate::ws_bridge::WsBroadcaster>>() {
-        broadcaster.send_without_buffer(crate::protocol::WsMessage::AgentStreamSync(
-            crate::protocol::AgentStreamSync {
-                session_id: chat_session_id.to_string(),
-                message_id: message_id.to_string(),
-                parts: serde_json::from_value(payload["parts"].clone()).unwrap_or_default(),
-            },
-        ));
+        broadcaster.send_stream_sync(crate::protocol::AgentStreamSync {
+            session_id: chat_session_id.to_string(),
+            message_id: message_id.to_string(),
+            parts,
+        });
     }
+    (tauri_ok, true)
+}
+
+/// Estimate the wire byte size contributed by one delta part. Used to decide
+/// whether the pending buffer has crossed the byte cap. Exact values aren't
+/// required — only proportional growth matters.
+fn part_byte_size(part: &MessagePart) -> usize {
+    match part {
+        MessagePart::Text { content, .. }
+        | MessagePart::Thinking { content, .. }
+        | MessagePart::Error { content, .. }
+        | MessagePart::ToolResult { content, .. } => content.len(),
+        MessagePart::ToolUse {
+            tool, input, id, ..
+        } => tool.len() + id.len() + serde_json::to_string(input).map(|s| s.len()).unwrap_or(0),
+        MessagePart::Permission {
+            request,
+            status,
+            answers,
+            ..
+        } => {
+            status.len()
+                + serde_json::to_string(request).map(|s| s.len()).unwrap_or(0)
+                + answers
+                    .as_ref()
+                    .and_then(|a| serde_json::to_string(a).ok())
+                    .map(|s| s.len())
+                    .unwrap_or(0)
+        }
+        MessagePart::TaskStatus {
+            task_tool_use_id,
+            status,
+            description,
+            summary,
+        } => {
+            task_tool_use_id.len()
+                + status.len()
+                + description.as_ref().map(|s| s.len()).unwrap_or(0)
+                + summary.as_ref().map(|s| s.len()).unwrap_or(0)
+        }
+        MessagePart::SystemNotification {
+            notification_type,
+            status,
+            label,
+            detail,
+            hook_id,
+        } => {
+            notification_type.len()
+                + status.len()
+                + label.len()
+                + detail.as_ref().map(|s| s.len()).unwrap_or(0)
+                + hook_id.as_ref().map(|s| s.len()).unwrap_or(0)
+        }
+        MessagePart::Image { data, media_type } => data.len() + media_type.len(),
+    }
+}
+
+/// Record that delta parts have been queued for the next coalescing flush.
+/// We only track the count and total byte size — the actual delta entries
+/// remain in `streaming_parts` (cumulative), so storing them twice would
+/// just inflate memory for no benefit. The count is the dirty signal; bytes
+/// drives the byte-cap flush trigger.
+fn enqueue_pending_delta(proc: &mut AgentProcess, delta: &[MessagePart]) {
+    for p in delta {
+        proc.pending_stream_bytes = proc.pending_stream_bytes.saturating_add(part_byte_size(p));
+    }
+    proc.pending_stream_part_count = proc.pending_stream_part_count.saturating_add(delta.len());
+}
+
+/// True when the pending buffer has crossed either the count or byte threshold.
+/// While delivery is succeeding this triggers an immediate flush; while
+/// delivery is failing the buffer continues to grow past these thresholds.
+fn pending_exceeds_threshold(proc: &AgentProcess) -> bool {
+    proc.pending_stream_part_count >= STREAMING_PENDING_PART_LIMIT
+        || proc.pending_stream_bytes >= STREAMING_PENDING_BYTE_LIMIT
+}
+
+/// True when enough time has elapsed since the last successful emit for the
+/// next-delta flush trigger to fire. First emit (no `last_stream_emit_at`)
+/// always returns true so the initial chunk reaches the UI without delay.
+fn streaming_interval_elapsed(proc: &AgentProcess) -> bool {
+    match proc.last_stream_emit_at {
+        None => true,
+        Some(t) => t.elapsed() >= Duration::from_millis(STREAMING_EMIT_INTERVAL_MS),
+    }
+}
+
+/// Snapshot of pending-flush bookkeeping captured before an emit attempt.
+/// Holds enough metadata to build a failure log without re-reading the
+/// process state, and is the source of `apply_streaming_emit_result`.
+#[derive(Debug, Clone)]
+struct StreamingFlushSnapshot {
+    parts: Vec<MessagePart>,
+    part_count: usize,
+    buffer_len: usize,
+    pending_bytes: usize,
+}
+
+/// Prepare a streaming flush: snapshot the consolidated cumulative parts and
+/// the buffer metadata. Returns `None` when the pending buffer is empty so
+/// callers can short-circuit the emit (idle-tick / double-flush no-op).
+fn prepare_streaming_flush(proc: &AgentProcess) -> Option<StreamingFlushSnapshot> {
+    if proc.pending_stream_part_count == 0 {
+        return None;
+    }
+    let parts = consolidate_parts(proc.streaming_parts.clone());
+    Some(StreamingFlushSnapshot {
+        part_count: parts.len(),
+        buffer_len: proc.pending_stream_part_count,
+        pending_bytes: proc.pending_stream_bytes,
+        parts,
+    })
+}
+
+/// Apply the emit result to the coalescing state. On success clears the
+/// pending buffer and bumps `last_stream_emit_at`; on failure retains both
+/// (so the next flush retries the cumulative payload) and emits a warning
+/// log containing only non-body metadata. Returns whether the emit succeeded.
+fn apply_streaming_emit_result(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    message_id: &str,
+    snapshot: &StreamingFlushSnapshot,
+    tauri_ok: bool,
+    ws_ok: bool,
+) -> bool {
+    if tauri_ok && ws_ok {
+        proc.pending_stream_part_count = 0;
+        proc.pending_stream_bytes = 0;
+        proc.last_stream_emit_at = Some(Instant::now());
+        true
+    } else {
+        // NB: deliberately exclude payload content / tool I/O / mentions —
+        // those are external user data and must not appear in logs.
+        log::warn!(
+            "agent-streaming-updated emit failure: chat_session={} message_id={} \
+             part_count={} buffer_len={} pending_bytes={} tauri_ok={} ws_ok={}",
+            chat_session_id,
+            message_id,
+            snapshot.part_count,
+            snapshot.buffer_len,
+            snapshot.pending_bytes,
+            tauri_ok,
+            ws_ok
+        );
+        false
+    }
+}
+
+/// Run the prepare → emit → apply sequence with a caller-supplied emit
+/// function. Extracting this lets unit tests drive the production flush
+/// pipeline with a recording emit closure, instead of mirroring the prepare
+/// / apply calls inline (which used to drift from the production path).
+///
+/// The closure receives the cumulative `MessagePart` slice destined for the
+/// frontend and returns `(tauri_ok, ws_ok)` matching `emit_streaming_parts`.
+fn force_flush_pending_streaming<F>(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    message_id: &str,
+    mut emit: F,
+) where
+    F: FnMut(&[MessagePart]) -> (bool, bool),
+{
+    let Some(snapshot) = prepare_streaming_flush(proc) else {
+        return;
+    };
+    let (tauri_ok, ws_ok) = emit(&snapshot.parts);
+    apply_streaming_emit_result(
+        proc,
+        chat_session_id,
+        message_id,
+        &snapshot,
+        tauri_ok,
+        ws_ok,
+    );
+}
+
+/// Attempt to emit the cumulative `streaming_parts` payload. No-op when the
+/// pending buffer is empty (prevents idle-tick re-delivery and double-flush
+/// from forced-flush paths). On success, clears pending and updates
+/// `last_stream_emit_at`. On failure, retains both so the next flush retries.
+fn flush_streaming(
+    app: &tauri::AppHandle,
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    message_id: &str,
+) {
+    force_flush_pending_streaming(proc, chat_session_id, message_id, |parts| {
+        emit_streaming_parts(app, chat_session_id, message_id, parts.to_vec())
+    });
+}
+
+/// Force-flush pending streaming delta before a turn-phase transition
+/// (permission_request, turn_complete, tool boundary, error). Returns
+/// `true` when the process was in `Streaming` state so the caller knows to
+/// emit a `agent-session-state-changed` notification after releasing the
+/// lock. The flush runs FIRST so the frontend never observes a state
+/// transition ahead of the tail content for the current message.
+///
+/// The emit closure mirrors `emit_streaming_parts`: it receives the message
+/// id and the consolidated cumulative parts and returns `(tauri_ok, ws_ok)`.
+/// Production callers pass a closure that delegates to `emit_streaming_parts`;
+/// unit tests pass a recording closure to verify the ordering invariant.
+fn flush_streaming_before_transition<F>(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    mut emit_stream: F,
+) -> bool
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
+    let was_streaming = proc.state == BridgeState::Streaming;
+    let Some(mid) = proc.streaming_message_id.clone() else {
+        return was_streaming;
+    };
+    force_flush_pending_streaming(proc, chat_session_id, &mid, |parts| {
+        emit_stream(&mid, parts)
+    });
+    was_streaming
+}
+
+/// Effect returned by `run_permission_request_transition_locked`. The caller
+/// (production stdout reader / unit tests) inspects `did_transition` to decide
+/// whether to emit `agent-session-state-changed(WaitingPermission)` after
+/// releasing the process lock.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct PermissionRequestTransition {
+    did_transition: bool,
+}
+
+/// Run the in-lock part of the `permission_request` transition: force-flush
+/// the pending streaming delta first, then — only when the process was in
+/// `Streaming` — promote `turn_phase` to `WaitingPermission`. The flush runs
+/// before the state mutation so the frontend never observes a state change
+/// ahead of the tail content. The caller is responsible for emitting the
+/// state-change notification outside the lock when `did_transition` is true.
+fn run_permission_request_transition_locked<F>(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    emit_stream: F,
+) -> PermissionRequestTransition
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
+    let was_streaming = flush_streaming_before_transition(proc, chat_session_id, emit_stream);
+    if was_streaming {
+        proc.turn_phase = TurnPhase::WaitingPermission;
+    }
+    PermissionRequestTransition {
+        did_transition: was_streaming,
+    }
+}
+
+/// Effect returned by `run_turn_complete_transition_locked`. Carries the
+/// data the caller needs to perform the post-lock follow-ups: state-change
+/// emission, message persistence, and workflow hooks. `was_streaming` gates
+/// the `agent-session-state-changed(Idle)` emission.
+#[derive(Debug, Default)]
+struct TurnCompleteTransition {
+    was_streaming: bool,
+    final_msg_id: Option<String>,
+    raw_parts: Vec<MessagePart>,
+    turn_token_usage: Option<(u64, u64)>,
+}
+
+/// Run the in-lock part of the `turn_complete` transition: force-flush
+/// pending streaming delta first, then mutate `state` / `turn_phase` and
+/// snapshot the data the caller needs after releasing the lock. Mirrors the
+/// production stdout reader so tests can drive the exact same code path
+/// (instead of mirroring prepare/apply inline).
+fn run_turn_complete_transition_locked<F>(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    exit_code: i64,
+    emit_stream: F,
+) -> TurnCompleteTransition
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
+    let was_streaming = flush_streaming_before_transition(proc, chat_session_id, emit_stream);
+    proc.state = if exit_code == 0 {
+        BridgeState::Ready
+    } else {
+        BridgeState::Crashed
+    };
+    proc.turn_phase = TurnPhase::Idle;
+    let turn_token_usage = proc.last_result_token_usage.take();
+    let raw_parts = proc.streaming_parts.clone();
+    let final_msg_id = proc.streaming_message_id.take();
+    if final_msg_id.is_some() {
+        proc.last_message_id.clone_from(&final_msg_id);
+    }
+    TurnCompleteTransition {
+        was_streaming,
+        final_msg_id,
+        raw_parts,
+        turn_token_usage,
+    }
+}
+
+/// Effect returned by `apply_respond_permission_locked`. `did_transition` is
+/// `true` only when the process was actually in `WaitingPermission`; this
+/// gates both the post-lock `agent-session-state-changed(Streaming)`
+/// emission and the per-turn auxiliary timer restart.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct PermissionResponseTransition {
+    did_transition: bool,
+}
+
+/// Run the in-lock part of `respond_agent_permission`: flip `turn_phase`
+/// back to `Streaming` (only when actually waiting), patch the matching
+/// `Permission` part status in the streaming buffer, enqueue the updated
+/// part as a pending delta, and force-flush so the frontend observes the
+/// permission decision before the state-change notification. The caller
+/// handles stdin write before, and timer restart / state-change emission
+/// after.
+fn apply_respond_permission_locked<F>(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    request_id: &str,
+    behavior: &str,
+    answers_value: Option<&serde_json::Value>,
+    mut emit_stream: F,
+) -> PermissionResponseTransition
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
+    let did_transition = proc.turn_phase == TurnPhase::WaitingPermission;
+    if did_transition {
+        proc.turn_phase = TurnPhase::Streaming;
+    }
+    let new_status = if behavior == "allow" {
+        "allowed"
+    } else {
+        "denied"
+    };
+    let mut found_part: Option<MessagePart> = None;
+    for part in &mut proc.streaming_parts {
+        if let MessagePart::Permission {
+            request,
+            status,
+            answers,
+            ..
+        } = part
+        {
+            if request.get("request_id").and_then(|v| v.as_str()) == Some(request_id) {
+                *status = new_status.to_string();
+                if let Some(av) = answers_value {
+                    *answers = Some(av.clone());
+                }
+                found_part = Some(part.clone());
+            }
+        }
+    }
+    let emit_msg_id = proc.streaming_message_id.clone();
+    if let (Some(mid), Some(part)) = (emit_msg_id, found_part) {
+        enqueue_pending_delta(proc, std::slice::from_ref(&part));
+        force_flush_pending_streaming(proc, chat_session_id, &mid, |parts| {
+            emit_stream(&mid, parts)
+        });
+    }
+    PermissionResponseTransition { did_transition }
+}
+
+/// Per-delta flush decision used by the stdout reader. `post_turn` is true
+/// when the delta is arriving after `turn_complete` (background-task events
+/// piggy-backed on the closed turn) — those are always force-flushed so the
+/// post-turn UI does not stall on the throttle.
+fn should_flush_per_delta(proc: &AgentProcess, delta: &[MessagePart], post_turn: bool) -> bool {
+    let force = post_turn || delta_has_tool_event(delta) || pending_exceeds_threshold(proc);
+    force || streaming_interval_elapsed(proc)
+}
+
+/// One iteration of the auxiliary timer loop. Bound to a single process by
+/// the caller (generation_id / state checks happen above this helper). The
+/// emit closure mirrors `force_flush_pending_streaming` so tests can drive
+/// the same code path the production timer uses.
+///
+/// Returns `true` when the timer should continue running this turn, and
+/// `false` when the loop should exit (turn is over and the buffer has been
+/// fully drained).
+fn run_streaming_timer_tick<F>(proc: &mut AgentProcess, chat_session_id: &str, mut emit: F) -> bool
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
+    let pending = proc.pending_stream_part_count > 0;
+    let streaming = proc.state == BridgeState::Streaming;
+    if !pending && !streaming {
+        // Turn ended and the buffer is empty — timer has nothing left to do.
+        return false;
+    }
+    if !pending || !streaming_interval_elapsed(proc) {
+        return true;
+    }
+    let Some(mid) = proc
+        .streaming_message_id
+        .clone()
+        .or_else(|| proc.last_message_id.clone())
+    else {
+        return true;
+    };
+    force_flush_pending_streaming(proc, chat_session_id, &mid, |parts| emit(&mid, parts));
+    true
+}
+
+/// Returns `true` when any delta part represents a tool invocation boundary.
+/// Used to force a flush around tool start/end so the UI never shows a stale
+/// frame across these transitions.
+fn delta_has_tool_event(delta: &[MessagePart]) -> bool {
+    delta.iter().any(|p| {
+        matches!(
+            p,
+            MessagePart::ToolUse { .. } | MessagePart::ToolResult { .. }
+        )
+    })
 }
 
 #[derive(Debug, Default)]
@@ -572,8 +1045,10 @@ fn build_set_model_command(model_id: Option<&str>) -> String {
     format!("{}\n", cmd)
 }
 
-/// Append text/thinking chunk to streaming parts as a new part.
-/// Merging consecutive same-type chunks is handled by the frontend's `mergeDeltaParts`.
+/// Append text/thinking chunk to streaming parts as an individual part.
+/// Each chunk is retained as a separate `MessagePart`; consolidation into
+/// merged same-type runs is performed by `consolidate_parts` when generating
+/// emit/persist payloads.
 fn append_to_parts(
     parts: &mut Vec<MessagePart>,
     part_type: &str,
@@ -593,9 +1068,11 @@ fn append_to_parts(
     }
 }
 
-/// Consolidate consecutive same-type text/thinking parts for persistence.
-/// During streaming, parts are kept as individual chunks for correct delta extraction.
-/// This function merges them into single parts before persisting.
+/// Normalize accumulated streaming parts by merging consecutive same-type
+/// text/thinking chunks sharing the same `parent_tool_use_id`.
+/// During streaming, `append_to_parts` keeps each chunk as an individual part;
+/// this helper produces the consolidated view used both for streaming emit
+/// payloads (via `prepare_streaming_flush`) and for persistence.
 fn consolidate_parts(parts: Vec<MessagePart>) -> Vec<MessagePart> {
     let mut result: Vec<MessagePart> = Vec::with_capacity(parts.len());
     for part in parts {
@@ -1191,6 +1668,10 @@ async fn spawn_bridge_process(
                 available_models: Vec::new(),
                 selected_model,
                 last_result_token_usage: None,
+                pending_stream_part_count: 0,
+                pending_stream_bytes: 0,
+                last_stream_emit_at: None,
+                streaming_timer_active: false,
             },
         );
     }
@@ -1336,30 +1817,28 @@ async fn spawn_bridge_process(
                         {
                             let mut map = handles_stdout.lock().await;
                             if let Some(proc) = map.get_mut(&csid_stdout) {
-                                was_streaming = proc.state == BridgeState::Streaming;
-                                proc.state = if exit_code == 0 {
-                                    BridgeState::Ready
-                                } else {
-                                    BridgeState::Crashed
-                                };
-                                proc.turn_phase = TurnPhase::Idle;
-
-                                // Take token usage from preceding result message
-                                turn_token_usage = proc.last_result_token_usage.take();
-
-                                // Capture streaming buffer for consolidation outside lock.
-                                // Keep parts in buffer so post-turn_complete background task
-                                // events can append to them (cleared at next query start).
-                                raw_parts = proc.streaming_parts.clone();
-                                final_msg_id = proc.streaming_message_id.take();
-
-                                // Retain message ID for post-turn_complete background task events.
-                                // Only update if we have a real ID — a second turn_complete
-                                // (from background task result) would yield None and must not
-                                // overwrite the ID set by the first turn_complete.
-                                if final_msg_id.is_some() {
-                                    proc.last_message_id = final_msg_id.clone();
-                                }
+                                // Run the in-lock transition through the shared
+                                // helper so production and unit tests exercise the
+                                // exact same flush → state-mutation order. Flush
+                                // failure is best-effort — we still mutate state so
+                                // turn_complete notification fires.
+                                let effect = run_turn_complete_transition_locked(
+                                    proc,
+                                    &csid_stdout,
+                                    exit_code,
+                                    |mid, parts| {
+                                        emit_streaming_parts(
+                                            &app_stdout,
+                                            &csid_stdout,
+                                            mid,
+                                            parts.to_vec(),
+                                        )
+                                    },
+                                );
+                                was_streaming = effect.was_streaming;
+                                turn_token_usage = effect.turn_token_usage;
+                                raw_parts = effect.raw_parts;
+                                final_msg_id = effect.final_msg_id;
 
                                 // User turn succeeded: persist agent_session_id to SessionStore
                                 if was_streaming && exit_code == 0 {
@@ -1507,8 +1986,9 @@ async fn spawn_bridge_process(
                             .unwrap_or("Unknown bridge error");
                         log::error!("Bridge error [{}]: {}", csid_stdout, error_msg);
 
-                        // Accumulate error into streaming parts and extract delta
-                        let (error_delta, error_emit_msg_id) = {
+                        // Accumulate the error part, enqueue it for emission, and
+                        // force-flush so the UI surfaces the failure immediately.
+                        {
                             let mut map = handles_stdout.lock().await;
                             if let Some(proc) = map.get_mut(&csid_stdout) {
                                 if proc.state == BridgeState::Streaming {
@@ -1518,21 +1998,16 @@ async fn spawn_bridge_process(
                                         &mut proc.streaming_parts,
                                         &mut proc.task_id_map,
                                     );
-                                    let delta = proc.streaming_parts[prev_len..].to_vec();
+                                    let delta: Vec<MessagePart> =
+                                        proc.streaming_parts[prev_len..].to_vec();
                                     let mid = proc.streaming_message_id.clone();
-                                    (delta, mid)
-                                } else {
-                                    (Vec::new(), None)
+                                    if !delta.is_empty() {
+                                        enqueue_pending_delta(proc, &delta);
+                                    }
+                                    if let Some(ref mid) = mid {
+                                        flush_streaming(&app_stdout, proc, &csid_stdout, mid);
+                                    }
                                 }
-                            } else {
-                                (Vec::new(), None)
-                            }
-                        };
-
-                        // Emit error delta so UI can display the error message
-                        if !error_delta.is_empty() {
-                            if let Some(ref mid) = error_emit_msg_id {
-                                emit_streaming_parts(&app_stdout, &csid_stdout, mid, error_delta);
                             }
                         }
 
@@ -1593,19 +2068,20 @@ async fn spawn_bridge_process(
                         }
                     }
                     _ => {
-                        // Accumulate into streaming buffer and emit delta update
-                        let (
-                            accumulated,
-                            delta_parts,
-                            emit_msg_id,
-                            should_persist,
-                            raw_persist_parts,
-                        ) = {
+                        // Accumulate into streaming buffer, enqueue delta into the
+                        // coalescing buffer, and flush when warranted. We hold the
+                        // lock across the flush so the emit observes consistent
+                        // state with `streaming_parts`.
+                        let (accumulated, emit_msg_id, should_persist, raw_persist_parts) = {
                             let mut map = handles_stdout.lock().await;
                             if let Some(proc) = map.get_mut(&csid_stdout) {
-                                if proc.state == BridgeState::Streaming
-                                    && proc.streaming_message_id.is_some()
-                                {
+                                let in_streaming = proc.state == BridgeState::Streaming
+                                    && proc.streaming_message_id.is_some();
+                                let post_turn = !in_streaming && proc.last_message_id.is_some();
+
+                                if !in_streaming && !post_turn {
+                                    (false, None, false, Vec::new())
+                                } else {
                                     let prev_len = proc.streaming_parts.len();
                                     let (acc, updated_parts) = accumulate_sdk_message(
                                         &msg,
@@ -1613,73 +2089,58 @@ async fn spawn_bridge_process(
                                         &mut proc.task_id_map,
                                     );
                                     if !acc {
-                                        (false, Vec::new(), None, false, Vec::new())
+                                        (false, None, false, Vec::new())
                                     } else {
-                                        // Extract only newly added parts as delta
                                         let mut delta: Vec<MessagePart> =
                                             proc.streaming_parts[prev_len..].to_vec();
-                                        // Include in-place updated parts in the delta
                                         if let Some(up) = updated_parts {
                                             delta.extend(up);
                                         }
-                                        let mid = proc.streaming_message_id.clone();
+                                        let mid = if in_streaming {
+                                            proc.streaming_message_id.clone()
+                                        } else {
+                                            proc.last_message_id.clone()
+                                        };
 
-                                        let now = std::time::Instant::now();
+                                        enqueue_pending_delta(proc, &delta);
+
+                                        // Flush triggers: in-stream uses
+                                        // interval + threshold; post-turn events
+                                        // (background tasks) are flushed eagerly.
+                                        if should_flush_per_delta(proc, &delta, post_turn) {
+                                            if let Some(ref mid) = mid {
+                                                flush_streaming(
+                                                    &app_stdout,
+                                                    proc,
+                                                    &csid_stdout,
+                                                    mid,
+                                                );
+                                            }
+                                        }
+
+                                        let now = Instant::now();
                                         let elapsed_persist =
                                             now.duration_since(last_persist_time).as_millis()
                                                 as u64;
-                                        let should_persist = elapsed_persist >= PERSIST_INTERVAL_MS;
+                                        let should_persist =
+                                            post_turn || elapsed_persist >= PERSIST_INTERVAL_MS;
                                         let raw_persist_parts = if should_persist {
                                             proc.streaming_parts.clone()
                                         } else {
                                             Vec::new()
                                         };
-
-                                        (true, delta, mid, should_persist, raw_persist_parts)
+                                        (true, mid, should_persist, raw_persist_parts)
                                     }
-                                } else if proc.last_message_id.is_some() {
-                                    // Post-turn_complete: background task events
-                                    // (task_notification, task_progress, etc.)
-                                    // Accumulate and emit immediately (no throttle needed).
-                                    let prev_len = proc.streaming_parts.len();
-                                    let (acc, updated_parts) = accumulate_sdk_message(
-                                        &msg,
-                                        &mut proc.streaming_parts,
-                                        &mut proc.task_id_map,
-                                    );
-                                    if !acc {
-                                        (false, Vec::new(), None, false, Vec::new())
-                                    } else {
-                                        let mut delta: Vec<MessagePart> =
-                                            proc.streaming_parts[prev_len..].to_vec();
-                                        if let Some(up) = updated_parts {
-                                            delta.extend(up);
-                                        }
-                                        let mid = proc.last_message_id.clone();
-
-                                        // Always persist post-turn events immediately
-                                        let raw_persist_parts = proc.streaming_parts.clone();
-                                        (true, delta, mid, true, raw_persist_parts)
-                                    }
-                                } else {
-                                    (false, Vec::new(), None, false, Vec::new())
                                 }
                             } else {
-                                (false, Vec::new(), None, false, Vec::new())
+                                (false, None, false, Vec::new())
                             }
                         };
-
-                        // Emit agent-streaming-updated with delta parts (no throttle)
-                        if !delta_parts.is_empty() {
-                            if let Some(ref mid) = emit_msg_id {
-                                emit_streaming_parts(&app_stdout, &csid_stdout, mid, delta_parts);
-                            }
-                        }
 
                         // Periodic persist (1s interval) — consolidate outside lock
                         if should_persist {
                             if let Some(ref mid) = emit_msg_id {
-                                last_persist_time = std::time::Instant::now();
+                                last_persist_time = Instant::now();
                                 let persist_parts = consolidate_parts(raw_persist_parts);
                                 persist_streaming_parts(
                                     &session_store_clone,
@@ -1750,42 +2211,54 @@ async fn spawn_bridge_process(
                             }
                         }
 
+                        // For permission_request, force-flush pending stream content
+                        // BEFORE emitting agent-sdk-message so the UI receives the
+                        // accumulated text before SET_PENDING_PERMISSION dispatches
+                        // and the WaitingPermission state notification fires.
+                        // Order: buffer flush → state notify → followup.
+                        let permission_did_transition = if msg_type == "permission_request" {
+                            let mut map = handles_stdout.lock().await;
+                            if let Some(proc) = map.get_mut(&csid_stdout) {
+                                let effect = run_permission_request_transition_locked(
+                                    proc,
+                                    &csid_stdout,
+                                    |mid, parts| {
+                                        emit_streaming_parts(
+                                            &app_stdout,
+                                            &csid_stdout,
+                                            mid,
+                                            parts.to_vec(),
+                                        )
+                                    },
+                                );
+                                effect.did_transition
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        };
+
                         // Forward non-accumulated messages (meta events) as agent-sdk-message.
                         // permission_request needs both delta emit AND forwarding for SET_PENDING_PERMISSION.
                         if should_forward_sdk_message(accumulated, msg_type) {
                             let _ = app_stdout.emit("agent-sdk-message", &msg);
                         }
 
-                        // Transition to WaitingPermission when permission_request arrives
-                        if msg_type == "permission_request" {
-                            let did_transition = {
-                                let mut map = handles_stdout.lock().await;
-                                if let Some(proc) = map.get_mut(&csid_stdout) {
-                                    if proc.state == BridgeState::Streaming {
-                                        proc.turn_phase = TurnPhase::WaitingPermission;
-                                        true
-                                    } else {
-                                        false
-                                    }
-                                } else {
-                                    false
-                                }
-                            };
-                            if did_transition {
-                                emit_session_state_changed(
-                                    &app_stdout,
-                                    &csid_stdout,
-                                    TurnPhase::WaitingPermission,
-                                    None,
-                                );
-                                notify_status_transition(
-                                    &app_stdout,
-                                    &session_store_clone,
-                                    &csid_stdout,
-                                    TurnPhase::WaitingPermission,
-                                    None,
-                                );
-                            }
+                        if permission_did_transition {
+                            emit_session_state_changed(
+                                &app_stdout,
+                                &csid_stdout,
+                                TurnPhase::WaitingPermission,
+                                None,
+                            );
+                            notify_status_transition(
+                                &app_stdout,
+                                &session_store_clone,
+                                &csid_stdout,
+                                TurnPhase::WaitingPermission,
+                                None,
+                            );
                         }
                     }
                 }
@@ -1801,14 +2274,23 @@ async fn spawn_bridge_process(
                 let streaming_message_id = proc.streaming_message_id.clone();
                 let generation_matches = proc.generation_id == captured_gen_id;
                 let backend_id = proc.backend_id.clone();
-                apply_bridge_eof_crash(
+                let effect = apply_bridge_eof_crash(
                     generation_matches,
                     &mut proc.state,
                     &mut proc.turn_phase,
                     streaming_message_id.as_deref(),
                     &mut proc.streaming_parts,
                     &backend_id,
-                )
+                );
+                // Enqueue the synthetic crash delta into the coalescing buffer and
+                // force-flush so the UI sees the error before the Idle transition.
+                if let (Some(mid), false) =
+                    (streaming_message_id.as_ref(), effect.error_delta.is_empty())
+                {
+                    enqueue_pending_delta(proc, &effect.error_delta);
+                    flush_streaming(&app_stdout, proc, &csid_stdout, mid);
+                }
+                effect
             } else {
                 BridgeEofCrashEffect::default()
             }
@@ -1824,14 +2306,6 @@ async fn spawn_bridge_process(
             );
         }
         if let Some(message_id) = effect.message_id.as_deref() {
-            if !effect.error_delta.is_empty() {
-                emit_streaming_parts(
-                    &app_stdout,
-                    &csid_stdout,
-                    message_id,
-                    effect.error_delta.clone(),
-                );
-            }
             if !effect.persisted_parts.is_empty() {
                 persist_streaming_parts(
                     &session_store_clone,
@@ -1874,7 +2348,100 @@ async fn spawn_bridge_process(
         }
     });
 
+    // The auxiliary streaming-flush timer is spawned per-turn from
+    // `spawn_streaming_timer`, not at process spawn — process-lifetime ticks
+    // would hold `AgentProcessMap` lock every 33ms even while idle.
+
     Ok(())
+}
+
+/// Loop control decision for the per-turn streaming timer. Extracted as a
+/// pure function so the spawn loop's exit/flag-management semantics are
+/// covered by unit tests, instead of relying on a tokio task to be observable
+/// from the test harness.
+#[derive(Debug, PartialEq, Eq)]
+enum TimerDecision {
+    /// Generation matches and process is still streaming — run the tick.
+    Continue,
+    /// Generation matches and process has crashed — exit and release the
+    /// active flag so a future turn can spawn a fresh timer.
+    BreakClearFlag,
+    /// Generation no longer matches: a newer process owns the slot, and its
+    /// own timer is responsible for the flag. Exit without touching it.
+    BreakKeepFlag,
+}
+
+/// Decide what the streaming timer should do at the top of each tick.
+fn streaming_timer_decision(proc: &AgentProcess, captured_gen_id: u64) -> TimerDecision {
+    if proc.generation_id != captured_gen_id {
+        return TimerDecision::BreakKeepFlag;
+    }
+    if proc.state == BridgeState::Crashed {
+        return TimerDecision::BreakClearFlag;
+    }
+    TimerDecision::Continue
+}
+
+/// Idempotency gate for `spawn_streaming_timer`. Marks the timer slot active
+/// and returns `true` when the caller should spawn; returns `false` when a
+/// timer is already running for this process (duplicate spawn no-op).
+fn try_mark_streaming_timer_active(proc: &mut AgentProcess) -> bool {
+    if proc.streaming_timer_active {
+        return false;
+    }
+    proc.streaming_timer_active = true;
+    true
+}
+
+/// Spawn the per-turn auxiliary streaming-flush timer. Ticks every
+/// `STREAMING_EMIT_INTERVAL_MS` and drains the pending coalescing buffer so
+/// silent gaps between deltas (e.g. SDK ingesting a tool result) still
+/// surface buffered content within one interval. Exits when the turn ends
+/// and the buffer is fully drained, on generation mismatch, or on crash.
+/// Idempotent: a second call while a timer is already alive is a no-op.
+fn spawn_streaming_timer(
+    app: &tauri::AppHandle,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    chat_session_id: &str,
+    proc: &mut AgentProcess,
+) {
+    if !try_mark_streaming_timer_active(proc) {
+        return;
+    }
+    let handles_timer = Arc::clone(handles);
+    let app_timer = app.clone();
+    let csid_timer = chat_session_id.to_string();
+    let captured_gen_id_timer = proc.generation_id;
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_millis(STREAMING_EMIT_INTERVAL_MS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Skip the immediate first tick — the stdout reader's per-delta path
+        // handles the very first emit.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let mut map = handles_timer.lock().await;
+            let Some(proc) = map.get_mut(&csid_timer) else {
+                // Process removed — no flag to clear.
+                break;
+            };
+            match streaming_timer_decision(proc, captured_gen_id_timer) {
+                TimerDecision::BreakKeepFlag => break,
+                TimerDecision::BreakClearFlag => {
+                    proc.streaming_timer_active = false;
+                    break;
+                }
+                TimerDecision::Continue => {}
+            }
+            let keep_running = run_streaming_timer_tick(proc, &csid_timer, |mid, parts| {
+                emit_streaming_parts(&app_timer, &csid_timer, mid, parts.to_vec())
+            });
+            if !keep_running {
+                proc.streaming_timer_active = false;
+                break;
+            }
+        }
+    });
 }
 
 async fn get_session_internal(
@@ -2237,9 +2804,7 @@ pub(crate) async fn start_agent_turn(
             proc.state = BridgeState::Streaming;
             proc.turn_phase = TurnPhase::Streaming;
             proc.streaming_message_id = Some(streaming_message_id.to_string());
-            proc.streaming_parts.clear();
-            proc.last_message_id = None;
-            proc.task_id_map.clear();
+            proc.reset_streaming_state_for_new_turn();
             proc.stdin
                 .write_all(data.as_bytes())
                 .await
@@ -2248,6 +2813,7 @@ pub(crate) async fn start_agent_turn(
                 .flush()
                 .await
                 .map_err(|e| format!("Failed to flush message: {e}"))?;
+            spawn_streaming_timer(app, handles, chat_session_id, proc);
         } else {
             return Err(format!("No agent process for session {chat_session_id}"));
         }
@@ -2345,9 +2911,7 @@ async fn consume_pending_message(
             proc.state = BridgeState::Streaming;
             proc.turn_phase = TurnPhase::Streaming;
             proc.streaming_message_id = Some(agent_msg.id.clone());
-            proc.streaming_parts.clear();
-            proc.last_message_id = None;
-            proc.task_id_map.clear();
+            proc.reset_streaming_state_for_new_turn();
             if let Err(e) = proc.stdin.write_all(data.as_bytes()).await {
                 log::error!("consume_pending_message: failed to write message: {e}");
                 return;
@@ -2356,6 +2920,7 @@ async fn consume_pending_message(
                 log::error!("consume_pending_message: failed to flush message: {e}");
                 return;
             }
+            spawn_streaming_timer(app, handles, chat_session_id, proc);
         } else {
             log::error!("consume_pending_message: no agent process for session {chat_session_id}");
             return;
@@ -2731,8 +3296,6 @@ pub async fn respond_agent_permission(
     });
     let data = format!("{}\n", payload);
 
-    let updated_permission_part: Option<MessagePart>;
-    let emit_msg_id;
     let did_transition_to_streaming;
     {
         let mut map = handles.lock().await;
@@ -2746,49 +3309,32 @@ pub async fn respond_agent_permission(
                 .await
                 .map_err(|e| format!("Failed to flush: {e}"))?;
 
-            // Transition back to Streaming after permission response
-            did_transition_to_streaming = proc.turn_phase == TurnPhase::WaitingPermission;
+            // Apply the synchronous part of the permission response
+            // (phase flip + permission part patch + force flush) via the
+            // shared helper so production and unit tests exercise the same
+            // ordering: flush must complete before the state-change emit
+            // outside the lock.
+            let effect = apply_respond_permission_locked(
+                proc,
+                &chat_session_id,
+                &request_id,
+                &behavior,
+                answers_value.as_ref(),
+                |mid, parts| emit_streaming_parts(&app, &chat_session_id, mid, parts.to_vec()),
+            );
+            did_transition_to_streaming = effect.did_transition;
+
+            // Resuming the turn: restart the per-turn auxiliary timer if it
+            // has already exited (turn left Streaming when WaitingPermission
+            // was entered). Idempotent — no-op if a timer is still alive.
             if did_transition_to_streaming {
-                proc.turn_phase = TurnPhase::Streaming;
+                spawn_streaming_timer(&app, handles.inner(), &chat_session_id, proc);
             }
-
-            // Update Permission part status in streaming buffer
-            let new_status = if behavior == "allow" {
-                "allowed"
-            } else {
-                "denied"
-            };
-            let mut found_part = None;
-            for part in &mut proc.streaming_parts {
-                if let MessagePart::Permission {
-                    request,
-                    status,
-                    answers,
-                    ..
-                } = part
-                {
-                    if request.get("request_id").and_then(|v| v.as_str()) == Some(&request_id) {
-                        *status = new_status.to_string();
-                        if let Some(ref av) = answers_value {
-                            *answers = Some(av.clone());
-                        }
-                        found_part = Some(part.clone());
-                    }
-                }
-            }
-
-            updated_permission_part = found_part;
-            emit_msg_id = proc.streaming_message_id.clone();
         } else {
             return Err(format!(
                 "No active agent process for session {chat_session_id}"
             ));
         }
-    }
-
-    // Emit agent-streaming-updated with the updated permission part as delta
-    if let (Some(ref mid), Some(ref part)) = (&emit_msg_id, &updated_permission_part) {
-        emit_streaming_parts(&app, &chat_session_id, mid, vec![part.clone()]);
     }
 
     // Emit state change only if we actually transitioned: WaitingPermission → Streaming
@@ -3508,6 +4054,1454 @@ mod tests {
         assert!(!source.contains(&super_codex_path));
     }
 
+    #[tokio::test]
+    async fn enqueue_pending_delta_accumulates_parts_and_bytes() {
+        let mut proc = make_streaming_test_process();
+        let delta = vec![
+            MessagePart::Text {
+                content: "abcde".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::Thinking {
+                content: "fg".to_string(),
+                parent_tool_use_id: None,
+            },
+        ];
+        enqueue_pending_delta(&mut proc, &delta);
+        assert_eq!(proc.pending_stream_part_count, 2);
+        assert_eq!(proc.pending_stream_bytes, "abcde".len() + "fg".len());
+    }
+
+    #[tokio::test]
+    async fn streaming_interval_elapsed_is_true_before_any_emit() {
+        let proc = make_streaming_test_process();
+        assert!(
+            streaming_interval_elapsed(&proc),
+            "first emit must not wait for an interval"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_interval_elapsed_is_false_within_interval() {
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at = Some(Instant::now());
+        assert!(
+            !streaming_interval_elapsed(&proc),
+            "successive emit within {}ms must wait",
+            STREAMING_EMIT_INTERVAL_MS
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_exceeds_threshold_triggers_on_part_count() {
+        let mut proc = make_streaming_test_process();
+        for _ in 0..STREAMING_PENDING_PART_LIMIT {
+            enqueue_pending_delta(
+                &mut proc,
+                &[MessagePart::Text {
+                    content: "x".to_string(),
+                    parent_tool_use_id: None,
+                }],
+            );
+        }
+        assert!(pending_exceeds_threshold(&proc));
+    }
+
+    #[tokio::test]
+    async fn pending_exceeds_threshold_triggers_on_byte_count() {
+        let mut proc = make_streaming_test_process();
+        proc.pending_stream_bytes = STREAMING_PENDING_BYTE_LIMIT;
+        assert!(pending_exceeds_threshold(&proc));
+    }
+
+    #[tokio::test]
+    async fn pending_exceeds_threshold_returns_false_when_below_both_caps() {
+        let mut proc = make_streaming_test_process();
+        proc.pending_stream_bytes = STREAMING_PENDING_BYTE_LIMIT - 1;
+        proc.pending_stream_part_count = 1;
+        assert!(!pending_exceeds_threshold(&proc));
+    }
+
+    #[tokio::test]
+    async fn streaming_interval_elapsed_is_true_after_interval() {
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at =
+            Some(Instant::now() - Duration::from_millis(STREAMING_EMIT_INTERVAL_MS + 5));
+        assert!(streaming_interval_elapsed(&proc));
+    }
+
+    #[tokio::test]
+    async fn prepare_streaming_flush_is_none_when_buffer_is_empty() {
+        let proc = make_streaming_test_process();
+        // 空バッファでは flush 準備が None になり、emit を発火しない。
+        assert!(prepare_streaming_flush(&proc).is_none());
+    }
+
+    #[tokio::test]
+    async fn prepare_streaming_flush_consolidates_cumulative_parts() {
+        let mut proc = make_streaming_test_process();
+        proc.streaming_parts.push(MessagePart::Text {
+            content: "Hel".to_string(),
+            parent_tool_use_id: None,
+        });
+        proc.streaming_parts.push(MessagePart::Text {
+            content: "lo".to_string(),
+            parent_tool_use_id: None,
+        });
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "lo".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        let snapshot = prepare_streaming_flush(&proc).expect("snapshot");
+        assert_eq!(snapshot.parts.len(), 1);
+        match &snapshot.parts[0] {
+            MessagePart::Text { content, .. } => assert_eq!(content, "Hello"),
+            _ => panic!("expected consolidated Text part"),
+        }
+        assert_eq!(snapshot.buffer_len, 1);
+        assert_eq!(snapshot.pending_bytes, "lo".len());
+    }
+
+    #[tokio::test]
+    async fn apply_streaming_emit_result_clears_pending_on_success() {
+        let mut proc = make_streaming_test_process();
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "abc".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        let snapshot = prepare_streaming_flush(&proc).expect("snapshot");
+        let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, true, true);
+        assert!(ok);
+        assert_eq!(proc.pending_stream_part_count, 0);
+        assert_eq!(proc.pending_stream_bytes, 0);
+        assert!(proc.last_stream_emit_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn apply_streaming_emit_result_retains_pending_on_failure() {
+        let mut proc = make_streaming_test_process();
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "abc".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        let snapshot = prepare_streaming_flush(&proc).expect("snapshot");
+        // Tauri failed / WS ok
+        let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, false, true);
+        assert!(!ok);
+        assert_eq!(proc.pending_stream_part_count, 1);
+        assert_eq!(proc.pending_stream_bytes, "abc".len());
+        assert!(
+            proc.last_stream_emit_at.is_none(),
+            "last_emit_at must not advance on failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_streaming_emit_result_retains_when_both_channels_fail() {
+        let mut proc = make_streaming_test_process();
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "abc".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        let snapshot = prepare_streaming_flush(&proc).expect("snapshot");
+        let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, false, false);
+        assert!(!ok);
+        assert_eq!(proc.pending_stream_part_count, 1);
+        assert!(proc.last_stream_emit_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn next_flush_after_partial_failure_re_sends_full_cumulative_parts() {
+        // チャネルの片方だけが失敗した場合、次 flush は累積 streaming_parts 全体を
+        // 両チャネル向けに同一ペイロードで再送する（spec: 累積置換型）。
+        let mut proc = make_streaming_test_process();
+        proc.streaming_parts.push(MessagePart::Text {
+            content: "Hel".to_string(),
+            parent_tool_use_id: None,
+        });
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "Hel".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        let first = prepare_streaming_flush(&proc).expect("first snapshot");
+        apply_streaming_emit_result(&mut proc, "csid", "mid", &first, true, false);
+
+        // 失敗後に次 delta が到着。
+        proc.streaming_parts.push(MessagePart::Text {
+            content: "lo".to_string(),
+            parent_tool_use_id: None,
+        });
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "lo".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        let second = prepare_streaming_flush(&proc).expect("second snapshot");
+        assert_eq!(second.parts.len(), 1);
+        match &second.parts[0] {
+            MessagePart::Text { content, .. } => assert_eq!(content, "Hello"),
+            _ => panic!("expected consolidated Text"),
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_can_overflow_thresholds_while_delivery_fails() {
+        // 上限到達状態で配信失敗しても、追加 delta はバッファに保持される（ソフト上限）。
+        let mut proc = make_streaming_test_process();
+        // streaming_parts にも同等の cumulative を入れて prepare_streaming_flush が
+        // snapshot を返せる状態にする。
+        for _ in 0..STREAMING_PENDING_PART_LIMIT {
+            let part = MessagePart::Text {
+                content: "x".to_string(),
+                parent_tool_use_id: None,
+            };
+            proc.streaming_parts.push(part.clone());
+            enqueue_pending_delta(&mut proc, std::slice::from_ref(&part));
+        }
+        assert!(pending_exceeds_threshold(&proc));
+
+        let snapshot = prepare_streaming_flush(&proc).expect("snapshot");
+        apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, false, true);
+
+        let before = proc.pending_stream_part_count;
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "extra".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        assert_eq!(proc.pending_stream_part_count, before + 1);
+    }
+
+    #[tokio::test]
+    async fn reset_streaming_state_for_new_turn_clears_all_coalescing_state() {
+        // 前ターン残骸 (pending / last_emit_at / streaming_parts / last_message_id)
+        // が新ターン開始時に確実にクリアされる。
+        let mut proc = make_streaming_test_process();
+        proc.streaming_parts.push(MessagePart::Text {
+            content: "old".to_string(),
+            parent_tool_use_id: None,
+        });
+        proc.pending_stream_part_count = 1;
+        proc.pending_stream_bytes = 32;
+        proc.last_stream_emit_at = Some(Instant::now());
+        proc.last_message_id = Some("old".to_string());
+        proc.task_id_map
+            .insert("task".to_string(), "tool".to_string());
+
+        proc.reset_streaming_state_for_new_turn();
+
+        assert!(proc.streaming_parts.is_empty());
+        assert_eq!(proc.pending_stream_part_count, 0);
+        assert_eq!(proc.pending_stream_bytes, 0);
+        assert!(proc.last_stream_emit_at.is_none());
+        assert!(proc.last_message_id.is_none());
+        assert!(proc.task_id_map.is_empty());
+
+        // 新ターン直後は最初の emit が即時 flush される (= interval elapsed).
+        assert!(streaming_interval_elapsed(&proc));
+    }
+
+    #[tokio::test]
+    async fn second_flush_after_success_is_noop_until_new_delta() {
+        // 強制 flush が同じ契機で連続呼ばれても、二重配信は起きない。
+        let mut proc = make_streaming_test_process();
+        proc.streaming_parts.push(MessagePart::Text {
+            content: "Hello".to_string(),
+            parent_tool_use_id: None,
+        });
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "Hello".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        let snapshot = prepare_streaming_flush(&proc).expect("snapshot");
+        assert!(apply_streaming_emit_result(
+            &mut proc, "csid", "mid", &snapshot, true, true,
+        ));
+
+        assert!(prepare_streaming_flush(&proc).is_none(), "no double emit");
+    }
+
+    #[tokio::test]
+    async fn apply_streaming_emit_result_does_not_leak_payload_into_log_args() {
+        // 失敗ログには本文・tool 入出力・画像・mention などのユーザーデータを含めない。
+        // log::warn! のフォーマット引数は固定 (snapshot.part_count / buffer_len /
+        // pending_bytes / tauri_ok / ws_ok) で、本文は引数として渡されない。
+        // 実装本体の format 引数を文字列として確認することで本文混入を検出する。
+        let source = include_str!("bridge_common.rs");
+        let warn_call = source
+            .split("\"agent-streaming-updated emit failure:")
+            .nth(1)
+            .expect("warn! present");
+        // log の format 文字列終端まで切り出す。
+        let format_block = warn_call.split(';').next().expect("statement ends with ;");
+        for forbidden in [
+            "snapshot.parts",
+            "streaming_parts",
+            "pending_stream_parts",
+            "delta",
+            "content",
+        ] {
+            assert!(
+                !format_block.contains(forbidden),
+                "log args must not reference body field `{forbidden}`: {format_block}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn forced_flush_continues_after_failure_for_state_transition() {
+        // Spec: 強制配信が失敗しても後続の状態遷移は続行する。
+        // apply_streaming_emit_result は false を返すだけで panic / abort せず、
+        // 呼び出し元は戻り値を見ずに後続処理へ進められる。
+        let mut proc = make_streaming_test_process();
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "tail".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        let snapshot = prepare_streaming_flush(&proc).expect("snapshot");
+        // 失敗を返してもパニックしない（= 状態遷移を続行できる）。
+        let _ = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, false, false);
+        // pending は保持され、次の契機で再試行可能。
+        assert!(proc.pending_stream_part_count > 0);
+    }
+
+    #[tokio::test]
+    async fn coalescing_first_delta_flushes_immediately() {
+        // 初回 delta: last_stream_emit_at が None なので interval elapsed=true、
+        // should_flush=true、flush_streaming で pending がクリアされる。
+        let mut proc = make_streaming_test_process();
+        let delta = vec![MessagePart::Text {
+            content: "first".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(delta.clone());
+        enqueue_pending_delta(&mut proc, &delta);
+
+        assert!(should_flush_per_delta(&proc, &delta, false));
+        let snapshot = prepare_streaming_flush(&proc).expect("first emit must flush");
+        apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, true, true);
+
+        assert!(proc.pending_stream_part_count == 0);
+        assert!(proc.last_stream_emit_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn coalescing_within_interval_does_not_flush() {
+        // 配信直後（last_stream_emit_at=now）で続く delta が来ても、
+        // 件数・byte 上限・tool event のいずれも当たらなければ flush しない。
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at = Some(Instant::now());
+        let delta = vec![MessagePart::Text {
+            content: "tick".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(delta.clone());
+        enqueue_pending_delta(&mut proc, &delta);
+
+        assert!(!should_flush_per_delta(&proc, &delta, false));
+        // pending は保持されたまま（次の契機まで蓄積される）。
+        assert_eq!(proc.pending_stream_part_count, 1);
+    }
+
+    #[tokio::test]
+    async fn coalescing_after_interval_flushes_accumulated_buffer() {
+        // 直前配信から interval を超えて経過した状態で次 delta が来ると、
+        // 既に溜まっている pending と新規 delta をまとめて flush する。
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at =
+            Some(Instant::now() - Duration::from_millis(STREAMING_EMIT_INTERVAL_MS + 5));
+        let earlier = MessagePart::Text {
+            content: "ear".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(earlier.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&earlier));
+
+        let new_delta = vec![MessagePart::Text {
+            content: "lier".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(new_delta.clone());
+        enqueue_pending_delta(&mut proc, &new_delta);
+
+        assert!(should_flush_per_delta(&proc, &new_delta, false));
+        let snapshot = prepare_streaming_flush(&proc).expect("must flush");
+        // consolidated 後は 1 個の Text に統合される。
+        assert_eq!(snapshot.parts.len(), 1);
+        match &snapshot.parts[0] {
+            MessagePart::Text { content, .. } => assert_eq!(content, "earlier"),
+            _ => panic!("expected consolidated Text"),
+        }
+        apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, true, true);
+        assert!(proc.pending_stream_part_count == 0);
+    }
+
+    #[tokio::test]
+    async fn coalescing_count_limit_forces_flush_within_interval() {
+        // pending parts が件数上限に達していれば、interval 未経過でも force flush。
+        // production 経路と同じ流れを踏ませる: enqueue_pending_delta で上限まで
+        // 蓄積 → 新規 delta が到着 → flush snapshot に新規 delta が含まれる →
+        // apply 成功で pending が空に戻る。
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at = Some(Instant::now());
+        for _ in 0..STREAMING_PENDING_PART_LIMIT {
+            let part = MessagePart::Text {
+                content: "x".to_string(),
+                parent_tool_use_id: None,
+            };
+            proc.streaming_parts.push(part.clone());
+            enqueue_pending_delta(&mut proc, std::slice::from_ref(&part));
+        }
+        assert!(pending_exceeds_threshold(&proc));
+
+        // 新規 delta を production と同じ手順で蓄積する。
+        let next = vec![MessagePart::Text {
+            content: "y".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(next.clone());
+        enqueue_pending_delta(&mut proc, &next);
+
+        assert!(!streaming_interval_elapsed(&proc));
+        assert!(should_flush_per_delta(&proc, &next, false));
+
+        let snapshot =
+            prepare_streaming_flush(&proc).expect("count-limit flush must produce snapshot");
+        // consolidate 後は全 Text が 1 個に統合され、末尾は新規 delta の "y"。
+        assert_eq!(snapshot.parts.len(), 1);
+        match snapshot
+            .parts
+            .last()
+            .expect("snapshot has at least one part")
+        {
+            MessagePart::Text { content, .. } => {
+                assert!(
+                    content.ends_with('y'),
+                    "consolidated tail should be the new delta"
+                );
+            }
+            _ => panic!("expected consolidated Text part"),
+        }
+        let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, true, true);
+        assert!(ok);
+        assert!(proc.pending_stream_part_count == 0);
+        assert_eq!(proc.pending_stream_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn coalescing_byte_limit_forces_flush_within_interval() {
+        // pending bytes が byte 上限に達していれば、interval 未経過でも force flush。
+        // ハードコード値ではなく実装定数 STREAMING_PENDING_BYTE_LIMIT から算出する。
+        // production 経路と同じ流れ: 上限相当の chunk を enqueue → 新規 delta
+        // 到着 → flush snapshot に新規 delta が含まれる → apply 成功で pending 空。
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at = Some(Instant::now());
+        let chunk = "z".repeat(STREAMING_PENDING_BYTE_LIMIT);
+        let part = MessagePart::Text {
+            content: chunk,
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(part.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&part));
+        assert!(pending_exceeds_threshold(&proc));
+
+        let next = vec![MessagePart::Text {
+            content: "n".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(next.clone());
+        enqueue_pending_delta(&mut proc, &next);
+
+        assert!(!streaming_interval_elapsed(&proc));
+        assert!(should_flush_per_delta(&proc, &next, false));
+
+        let snapshot =
+            prepare_streaming_flush(&proc).expect("byte-limit flush must produce snapshot");
+        assert_eq!(snapshot.parts.len(), 1);
+        match snapshot
+            .parts
+            .last()
+            .expect("snapshot has at least one part")
+        {
+            MessagePart::Text { content, .. } => {
+                assert!(
+                    content.ends_with('n'),
+                    "consolidated tail should be the new delta"
+                );
+            }
+            _ => panic!("expected consolidated Text part"),
+        }
+        let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, true, true);
+        assert!(ok);
+        assert!(proc.pending_stream_part_count == 0);
+        assert_eq!(proc.pending_stream_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn coalescing_tool_event_forces_flush_within_interval() {
+        // tool start / end は interval 未経過でも即 flush（UI に古いフレームを残さない）。
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at = Some(Instant::now());
+
+        let delta_tool_use = vec![MessagePart::ToolUse {
+            id: "tool-1".to_string(),
+            tool: "Bash".to_string(),
+            input: serde_json::json!({}),
+            parent_tool_use_id: None,
+        }];
+        assert!(!streaming_interval_elapsed(&proc));
+        assert!(should_flush_per_delta(&proc, &delta_tool_use, false));
+
+        let delta_tool_result = vec![MessagePart::ToolResult {
+            tool_use_id: Some("tool-1".to_string()),
+            content: "ok".to_string(),
+            is_error: false,
+            parent_tool_use_id: None,
+        }];
+        assert!(should_flush_per_delta(&proc, &delta_tool_result, false));
+    }
+
+    #[tokio::test]
+    async fn tool_event_flushes_pending_text_through_production_path() {
+        // Spec (Rule: ターン完了・状態遷移時には未配信バッファを強制配信する,
+        //  Examples ツール実行の開始 / 終了):
+        //   未配信 text が pending に積まれている状態で ToolUse / ToolResult
+        //   delta が到着すると、interval 未経過でも force flush され、
+        //   pending text + tool event が同一の cumulative payload として
+        //   emit され、emit 成功で pending が clear される。
+        //
+        // 本テストは production 経路 (enqueue_pending_delta →
+        // prepare_streaming_flush → apply_streaming_emit_result) を最初から
+        // 最後まで通し、ToolUse / ToolResult 双方について同じ流れを検証する。
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at = Some(Instant::now());
+
+        // 1) interval 未経過で未配信 text を pending に蓄積する。
+        let pending_text = MessagePart::Text {
+            content: "before-tool".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(pending_text.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&pending_text));
+        assert!(!streaming_interval_elapsed(&proc));
+        assert_eq!(proc.pending_stream_part_count, 1);
+
+        // 2) ToolUse delta が到着 → production と同じ手順で enqueue。
+        let tool_use_delta = vec![MessagePart::ToolUse {
+            id: "tool-1".to_string(),
+            tool: "Bash".to_string(),
+            input: serde_json::json!({"cmd": "ls"}),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(tool_use_delta.clone());
+        enqueue_pending_delta(&mut proc, &tool_use_delta);
+
+        // tool event は interval 未経過でも force flush。
+        assert!(!streaming_interval_elapsed(&proc));
+        assert!(should_flush_per_delta(&proc, &tool_use_delta, false));
+
+        // 3) prepare → emit (success) → apply で pending が clear される。
+        let snapshot = prepare_streaming_flush(&proc).expect("tool start must produce snapshot");
+        // cumulative payload には pending text + ToolUse が同一 emit で含まれる。
+        assert_eq!(snapshot.parts.len(), 2);
+        match &snapshot.parts[0] {
+            MessagePart::Text { content, .. } => assert_eq!(content, "before-tool"),
+            other => panic!("first cumulative part must be pending Text, got {other:?}"),
+        }
+        match &snapshot.parts[1] {
+            MessagePart::ToolUse { id, tool, .. } => {
+                assert_eq!(id, "tool-1");
+                assert_eq!(tool, "Bash");
+            }
+            other => panic!("second cumulative part must be ToolUse, got {other:?}"),
+        }
+        let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, true, true);
+        assert!(ok, "tool start emit must succeed → pending cleared");
+        assert_eq!(proc.pending_stream_part_count, 0);
+        assert_eq!(proc.pending_stream_bytes, 0);
+
+        // 4) 続いて ToolResult delta が到着 → 同じく force flush。
+        //    last_stream_emit_at は直前の apply で now() に更新されている。
+        let tool_result_delta = vec![MessagePart::ToolResult {
+            tool_use_id: Some("tool-1".to_string()),
+            content: "ok".to_string(),
+            is_error: false,
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(tool_result_delta.clone());
+        enqueue_pending_delta(&mut proc, &tool_result_delta);
+
+        assert!(!streaming_interval_elapsed(&proc));
+        assert!(should_flush_per_delta(&proc, &tool_result_delta, false));
+
+        let snapshot2 = prepare_streaming_flush(&proc).expect("tool end must produce snapshot");
+        // 累積 payload は text + ToolUse + ToolResult の 3 件を含む。
+        assert_eq!(snapshot2.parts.len(), 3);
+        assert!(matches!(
+            snapshot2.parts.last(),
+            Some(MessagePart::ToolResult { content, .. }) if content == "ok"
+        ));
+        let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot2, true, true);
+        assert!(ok, "tool end emit must succeed → pending cleared");
+        assert_eq!(proc.pending_stream_part_count, 0);
+        assert_eq!(proc.pending_stream_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn timer_flushes_when_pending_and_interval_elapsed() {
+        // 本番の補助 timer (`spawn_streaming_timer`) は `run_streaming_timer_tick`
+        // を毎 tick 呼ぶ。テストも同じ helper を直接呼び、pending と
+        // last_stream_emit_at の更新まで含めた挙動を検証する。
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at =
+            Some(Instant::now() - Duration::from_millis(STREAMING_EMIT_INTERVAL_MS + 5));
+        let part = MessagePart::Text {
+            content: "silent".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(part.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&part));
+
+        let mut emitted = Vec::new();
+        let keep_running = run_streaming_timer_tick(&mut proc, "csid", |mid, parts| {
+            emitted.push((mid.to_string(), parts.to_vec()));
+            (true, true)
+        });
+
+        assert!(keep_running, "still streaming → timer continues");
+        assert_eq!(emitted.len(), 1, "timer must call emit exactly once");
+        assert_eq!(emitted[0].0, "m1");
+        assert_eq!(emitted[0].1.len(), 1);
+        assert_eq!(
+            proc.pending_stream_part_count, 0,
+            "pending cleared on success"
+        );
+        assert!(
+            proc.last_stream_emit_at.is_some(),
+            "last_stream_emit_at updated on success"
+        );
+    }
+
+    #[tokio::test]
+    async fn timer_skips_when_pending_but_interval_not_elapsed() {
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at = Some(Instant::now());
+        let part = MessagePart::Text {
+            content: "fresh".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(part.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&part));
+
+        let mut emitted = false;
+        let keep_running = run_streaming_timer_tick(&mut proc, "csid", |_mid, _parts| {
+            emitted = true;
+            (true, true)
+        });
+        assert!(keep_running);
+        assert!(!emitted, "interval not elapsed → timer must not flush");
+        assert_eq!(proc.pending_stream_part_count, 1);
+    }
+
+    #[tokio::test]
+    async fn timer_skips_when_pending_empty_even_if_interval_elapsed() {
+        let mut proc = make_streaming_test_process();
+        proc.last_stream_emit_at =
+            Some(Instant::now() - Duration::from_millis(STREAMING_EMIT_INTERVAL_MS + 5));
+        assert!(streaming_interval_elapsed(&proc));
+        assert_eq!(proc.pending_stream_part_count, 0);
+
+        let mut emitted = false;
+        let keep_running = run_streaming_timer_tick(&mut proc, "csid", |_mid, _parts| {
+            emitted = true;
+            (true, true)
+        });
+        // pending=0 & still Streaming → continue running but no flush this tick.
+        assert!(keep_running);
+        assert!(!emitted);
+    }
+
+    #[tokio::test]
+    async fn timer_exits_when_turn_ended_and_buffer_empty() {
+        // turn 終了 (state != Streaming) かつ pending が空になった時点で timer は
+        // ループを終了させるべき。これを `run_streaming_timer_tick` の戻り値で表現する。
+        let mut proc = make_streaming_test_process();
+        proc.state = BridgeState::Ready;
+        proc.last_stream_emit_at =
+            Some(Instant::now() - Duration::from_millis(STREAMING_EMIT_INTERVAL_MS + 5));
+        assert_eq!(proc.pending_stream_part_count, 0);
+
+        let keep_running = run_streaming_timer_tick(&mut proc, "csid", |_mid, _parts| (true, true));
+        assert!(
+            !keep_running,
+            "turn ended (state != Streaming) and buffer empty → timer must exit"
+        );
+    }
+
+    #[tokio::test]
+    async fn timer_drains_pending_even_after_turn_ended() {
+        // turn 終了直後でも pending が残っていれば drain してから終了する次の
+        // tick で keep_running=false を返す。
+        let mut proc = make_streaming_test_process();
+        proc.state = BridgeState::Ready;
+        proc.last_stream_emit_at =
+            Some(Instant::now() - Duration::from_millis(STREAMING_EMIT_INTERVAL_MS + 5));
+        let part = MessagePart::Text {
+            content: "tail".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(part.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&part));
+
+        let mut emitted = 0usize;
+        let keep_running = run_streaming_timer_tick(&mut proc, "csid", |_mid, _parts| {
+            emitted += 1;
+            (true, true)
+        });
+        assert!(
+            keep_running,
+            "pending still > 0 → timer continues (will exit next tick when drained)"
+        );
+        assert_eq!(emitted, 1, "tail content flushed before exit");
+        assert_eq!(proc.pending_stream_part_count, 0);
+
+        let keep_running = run_streaming_timer_tick(&mut proc, "csid", |_mid, _parts| (true, true));
+        assert!(!keep_running, "post-drain tick → timer exits");
+    }
+
+    #[tokio::test]
+    async fn streaming_timer_decision_continue_when_generation_matches_and_streaming() {
+        let proc = make_streaming_test_process();
+        assert_eq!(
+            streaming_timer_decision(&proc, proc.generation_id),
+            TimerDecision::Continue
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_timer_decision_break_keep_flag_on_generation_mismatch() {
+        // 新しい turn (generation_id 更新) が同じ csid を再利用したケース。
+        // 既存 timer は自分の captured generation と一致しないので flag を残して
+        // 終了する (新 timer が flag を所有しているため触らない)。
+        let mut proc = make_streaming_test_process();
+        let captured = proc.generation_id;
+        proc.generation_id = captured.wrapping_add(1);
+        proc.streaming_timer_active = true;
+        assert_eq!(
+            streaming_timer_decision(&proc, captured),
+            TimerDecision::BreakKeepFlag
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_timer_decision_break_clear_flag_on_crash() {
+        // 同一 generation で Crashed に遷移したら drain 不要なので flag を解放して
+        // 終了する。
+        let mut proc = make_streaming_test_process();
+        proc.state = BridgeState::Crashed;
+        assert_eq!(
+            streaming_timer_decision(&proc, proc.generation_id),
+            TimerDecision::BreakClearFlag
+        );
+    }
+
+    #[tokio::test]
+    async fn try_mark_streaming_timer_active_marks_idle_and_returns_true() {
+        let mut proc = make_streaming_test_process();
+        assert!(!proc.streaming_timer_active);
+        assert!(try_mark_streaming_timer_active(&mut proc));
+        assert!(proc.streaming_timer_active);
+    }
+
+    #[tokio::test]
+    async fn try_mark_streaming_timer_active_returns_false_when_already_active() {
+        // Duplicate spawn no-op: 同じ turn で 2 回目の spawn_streaming_timer を
+        // 呼んでも flag は既に true なので false を返し新 task を起こさない。
+        let mut proc = make_streaming_test_process();
+        proc.streaming_timer_active = true;
+        assert!(!try_mark_streaming_timer_active(&mut proc));
+        assert!(proc.streaming_timer_active, "flag must remain set");
+    }
+
+    #[tokio::test]
+    async fn forced_flush_emits_pending_before_state_transition_inputs() {
+        // 強制 flush の呼び出し元（turn_complete / permission_request / error /
+        // tool start/end）は、まず flush_streaming で pending を排出してから
+        // state 遷移用の値（emit_session_state_changed の引数等）を組み立てる。
+        // 本テストは「flush 完了後に pending が空になっている」ことを通じて、
+        // 後続の状態通知が flush 済みデータの後で発火することを担保する。
+        let mut proc = make_streaming_test_process();
+        let delta = vec![MessagePart::Text {
+            content: "tail-before-state".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(delta.clone());
+        enqueue_pending_delta(&mut proc, &delta);
+
+        // forced flush の中身: snapshot → emit (mocked success) → apply
+        let snapshot = prepare_streaming_flush(&proc).expect("pending must yield snapshot");
+        let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, true, true);
+        assert!(
+            ok,
+            "forced flush succeeded → pending cleared before state emit"
+        );
+        assert!(proc.pending_stream_part_count == 0);
+
+        // この時点で呼び出し元が emit_session_state_changed を発火する。pending は
+        // 既にクリアされているので、状態通知より前にストリーム emit が完了している。
+    }
+
+    #[tokio::test]
+    async fn forced_flush_is_noop_when_no_pending_avoiding_double_delivery() {
+        // 直前の強制 flush で pending を空にしている状態で再度同じ契機 (e.g. error 経路
+        // と直後の EOF 経路) が forced flush を呼んでも、prepare_streaming_flush が
+        // None を返すため二重配信は発生しない。
+        let mut proc = make_streaming_test_process();
+        proc.streaming_parts.push(MessagePart::Text {
+            content: "once".to_string(),
+            parent_tool_use_id: None,
+        });
+        enqueue_pending_delta(
+            &mut proc,
+            &[MessagePart::Text {
+                content: "once".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+        let snapshot = prepare_streaming_flush(&proc).expect("first snapshot");
+        assert!(apply_streaming_emit_result(
+            &mut proc, "csid", "mid", &snapshot, true, true,
+        ));
+
+        // 二度目の forced flush は no-op になる。
+        assert!(prepare_streaming_flush(&proc).is_none());
+    }
+
+    #[tokio::test]
+    async fn forced_flush_failure_does_not_block_followup_processing() {
+        // Spec: 強制配信が失敗しても後続の状態遷移は続行する。失敗時 pending と
+        // last_stream_emit_at は保持され、apply は false を返すのみ（panic しない）。
+        let mut proc = make_streaming_test_process();
+        let delta = vec![MessagePart::Text {
+            content: "kept".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(delta.clone());
+        enqueue_pending_delta(&mut proc, &delta);
+        let snapshot = prepare_streaming_flush(&proc).expect("snapshot");
+        let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, false, false);
+        assert!(!ok);
+        // 呼び出し元はここから後続 (emit_session_state_changed 等) に進める。
+        // pending と last_stream_emit_at は次の契機での再試行のため保持される。
+        assert_eq!(proc.pending_stream_part_count, 1);
+        assert!(proc.last_stream_emit_at.is_none());
+    }
+
+    /// 呼び出し元経路で発火する 2 種類の emit を順序付きで記録するテスト用イベント。
+    /// 実コードの `emit_streaming_parts` と `emit_session_state_changed` は
+    /// `tauri::AppHandle` 直叩きでユニットテストから直接観測できないため、
+    /// 呼び出し元ロジックをミラーした下記ヘルパで両 emit を同じ Vec に
+    /// 記録し、ストリーム emit が state emit より先に来ることを確認する。
+    #[derive(Debug, PartialEq)]
+    enum RecordedEmit {
+        StreamingFlush {
+            parts_count: usize,
+            tail_text: Option<String>,
+        },
+        StateChanged {
+            phase: TurnPhase,
+            exit_code: Option<i64>,
+        },
+    }
+
+    /// Build a recording emit closure that pushes a `StreamingFlush` event
+    /// for each cumulative payload it observes. Shared by the
+    /// `permission_request` / `turn_complete` order tests so they exercise
+    /// the same `flush_streaming_before_transition` helper the production
+    /// stdout reader uses, instead of mirroring the prepare/apply sequence.
+    fn recording_emit<'a>(
+        events: &'a mut Vec<RecordedEmit>,
+    ) -> impl FnMut(&str, &[MessagePart]) -> (bool, bool) + 'a {
+        |_mid, parts| {
+            events.push(RecordedEmit::StreamingFlush {
+                parts_count: parts.len(),
+                tail_text: match parts.last() {
+                    Some(MessagePart::Text { content, .. })
+                    | Some(MessagePart::Thinking { content, .. }) => Some(content.clone()),
+                    _ => None,
+                },
+            });
+            (true, true)
+        }
+    }
+
+    /// Drive the production `permission_request` lock-block via
+    /// `run_permission_request_transition_locked` — the same helper the
+    /// production stdout reader calls. This guarantees that any drift in the
+    /// flush → state-mutation order would be caught here. The post-lock state
+    /// emit (production: `emit_session_state_changed` outside the lock) is
+    /// simulated by pushing a `StateChanged` event after the helper returns.
+    fn drive_permission_request_path(
+        proc: &mut AgentProcess,
+        chat_session_id: &str,
+        events: &mut Vec<RecordedEmit>,
+    ) -> bool {
+        let effect =
+            run_permission_request_transition_locked(proc, chat_session_id, recording_emit(events));
+        if effect.did_transition {
+            events.push(RecordedEmit::StateChanged {
+                phase: TurnPhase::WaitingPermission,
+                exit_code: None,
+            });
+        }
+        effect.did_transition
+    }
+
+    /// Drive the production `turn_complete` lock-block via
+    /// `run_turn_complete_transition_locked` — the same helper the production
+    /// stdout reader calls. State emit outside the lock is mirrored as a
+    /// pushed `StateChanged` event so the ordering invariant is asserted on
+    /// the event sequence.
+    fn drive_turn_complete_path(
+        proc: &mut AgentProcess,
+        chat_session_id: &str,
+        exit_code: i64,
+        events: &mut Vec<RecordedEmit>,
+    ) {
+        let effect = run_turn_complete_transition_locked(
+            proc,
+            chat_session_id,
+            exit_code,
+            recording_emit(events),
+        );
+        if effect.was_streaming {
+            events.push(RecordedEmit::StateChanged {
+                phase: TurnPhase::Idle,
+                exit_code: Some(exit_code),
+            });
+        }
+    }
+
+    /// Drive the production `respond_agent_permission` lock-block via
+    /// `apply_respond_permission_locked`. State emit outside the lock is
+    /// mirrored as a pushed `StateChanged(Streaming)` event after the helper
+    /// returns so the order assertion mirrors production.
+    fn drive_respond_permission_path(
+        proc: &mut AgentProcess,
+        chat_session_id: &str,
+        request_id: &str,
+        behavior: &str,
+        answers_value: Option<&serde_json::Value>,
+        events: &mut Vec<RecordedEmit>,
+    ) -> bool {
+        let effect = apply_respond_permission_locked(
+            proc,
+            chat_session_id,
+            request_id,
+            behavior,
+            answers_value,
+            recording_emit(events),
+        );
+        if effect.did_transition {
+            events.push(RecordedEmit::StateChanged {
+                phase: TurnPhase::Streaming,
+                exit_code: None,
+            });
+        }
+        effect.did_transition
+    }
+
+    #[tokio::test]
+    async fn permission_request_emits_pending_before_state_change() {
+        // Spec (Rule: ターン完了・状態遷移時には未配信バッファを強制配信する):
+        //   ストリーミング → 権限待ち の遷移時、未配信 delta が state 通知より
+        //   前にフロントエンドへ配信されること。
+        let mut proc = make_streaming_test_process();
+        let delta = vec![MessagePart::Text {
+            content: "tail-before-perm".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(delta.clone());
+        enqueue_pending_delta(&mut proc, &delta);
+
+        let mut events = Vec::new();
+        let transitioned = drive_permission_request_path(&mut proc, "csid", &mut events);
+        assert!(transitioned);
+
+        assert_eq!(events.len(), 2, "both emits must fire");
+        match &events[0] {
+            RecordedEmit::StreamingFlush {
+                parts_count,
+                tail_text,
+            } => {
+                assert_eq!(*parts_count, 1);
+                assert_eq!(tail_text.as_deref(), Some("tail-before-perm"));
+            }
+            other => panic!("first emit must be StreamingFlush, got {other:?}"),
+        }
+        assert_eq!(
+            events[1],
+            RecordedEmit::StateChanged {
+                phase: TurnPhase::WaitingPermission,
+                exit_code: None,
+            }
+        );
+        assert!(proc.pending_stream_part_count == 0);
+        assert_eq!(proc.turn_phase, TurnPhase::WaitingPermission);
+    }
+
+    #[tokio::test]
+    async fn permission_request_without_pending_skips_streaming_emit() {
+        // pending が空のとき、state 通知のみが発火し、ストリーム emit は
+        // 起きない (prepare_streaming_flush が None → no-op)。
+        let mut proc = make_streaming_test_process();
+
+        let mut events = Vec::new();
+        assert!(drive_permission_request_path(
+            &mut proc,
+            "csid",
+            &mut events,
+        ));
+
+        assert_eq!(
+            events,
+            vec![RecordedEmit::StateChanged {
+                phase: TurnPhase::WaitingPermission,
+                exit_code: None,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_complete_emits_pending_before_state_change() {
+        // Spec: ターン完了時に未配信バッファを強制配信する。
+        // streaming emit が state emit (Idle) より前に観測される。
+        let mut proc = make_streaming_test_process();
+        let delta = vec![MessagePart::Text {
+            content: "tail-before-idle".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(delta.clone());
+        enqueue_pending_delta(&mut proc, &delta);
+
+        let mut events = Vec::new();
+        drive_turn_complete_path(&mut proc, "csid", 0, &mut events);
+
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            RecordedEmit::StreamingFlush {
+                parts_count,
+                tail_text,
+            } => {
+                assert_eq!(*parts_count, 1);
+                assert_eq!(tail_text.as_deref(), Some("tail-before-idle"));
+            }
+            other => panic!("first emit must be StreamingFlush, got {other:?}"),
+        }
+        assert_eq!(
+            events[1],
+            RecordedEmit::StateChanged {
+                phase: TurnPhase::Idle,
+                exit_code: Some(0),
+            }
+        );
+        assert!(proc.pending_stream_part_count == 0);
+        assert_eq!(proc.turn_phase, TurnPhase::Idle);
+        assert_eq!(proc.state, BridgeState::Ready);
+    }
+
+    #[tokio::test]
+    async fn turn_complete_with_nonzero_exit_code_still_flushes_before_state() {
+        // 失敗終了 (exit_code != 0) でも emit 順序は同じ: streaming → state。
+        let mut proc = make_streaming_test_process();
+        let delta = vec![MessagePart::Text {
+            content: "tail-error".to_string(),
+            parent_tool_use_id: None,
+        }];
+        proc.streaming_parts.extend(delta.clone());
+        enqueue_pending_delta(&mut proc, &delta);
+
+        let mut events = Vec::new();
+        drive_turn_complete_path(&mut proc, "csid", 1, &mut events);
+
+        assert!(matches!(events[0], RecordedEmit::StreamingFlush { .. }));
+        assert_eq!(
+            events[1],
+            RecordedEmit::StateChanged {
+                phase: TurnPhase::Idle,
+                exit_code: Some(1),
+            }
+        );
+        assert_eq!(proc.state, BridgeState::Crashed);
+    }
+
+    /// Build a streaming-test process with one pending `Permission` part in
+    /// the streaming buffer matching `request_id`. Used by the
+    /// respond_permission tests to mimic the production state at the moment
+    /// `respond_agent_permission` runs.
+    fn make_process_waiting_for_permission(request_id: &str) -> AgentProcess {
+        let mut proc = make_streaming_test_process();
+        proc.turn_phase = TurnPhase::WaitingPermission;
+        proc.streaming_parts.push(MessagePart::Permission {
+            request: serde_json::json!({ "request_id": request_id }),
+            status: "pending".to_string(),
+            answers: None,
+            parent_tool_use_id: None,
+        });
+        proc
+    }
+
+    #[tokio::test]
+    async fn respond_permission_orders_flush_then_state_change() {
+        // Spec (Rule: ターン完了・状態遷移時には未配信バッファを強制配信する):
+        //   権限待ち → ストリーミング への遷移時、Permission part 更新を
+        //   含む強制 flush が state 通知より前に観測されること。
+        let mut proc = make_process_waiting_for_permission("req-1");
+        let mut events = Vec::new();
+        let transitioned =
+            drive_respond_permission_path(&mut proc, "csid", "req-1", "allow", None, &mut events);
+        assert!(transitioned);
+
+        assert_eq!(events.len(), 2, "flush emit then state emit");
+        match &events[0] {
+            RecordedEmit::StreamingFlush { parts_count, .. } => {
+                assert!(*parts_count >= 1);
+            }
+            other => panic!("first emit must be StreamingFlush, got {other:?}"),
+        }
+        assert_eq!(
+            events[1],
+            RecordedEmit::StateChanged {
+                phase: TurnPhase::Streaming,
+                exit_code: None,
+            }
+        );
+        assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+        assert!(proc.pending_stream_part_count == 0);
+        // Permission part status was updated in place.
+        let updated = proc
+            .streaming_parts
+            .iter()
+            .find_map(|p| match p {
+                MessagePart::Permission { status, .. } => Some(status.clone()),
+                _ => None,
+            })
+            .expect("permission part present");
+        assert_eq!(updated, "allowed");
+    }
+
+    #[tokio::test]
+    async fn respond_permission_no_transition_when_not_waiting() {
+        // 直前に WaitingPermission でなかった場合、state は変更されず、
+        // 後続の state-changed emit も発火しないこと。
+        let mut proc = make_process_waiting_for_permission("req-1");
+        proc.turn_phase = TurnPhase::Streaming; // not WaitingPermission
+
+        let mut events = Vec::new();
+        let transitioned =
+            drive_respond_permission_path(&mut proc, "csid", "req-1", "deny", None, &mut events);
+        assert!(
+            !transitioned,
+            "no transition when proc was not in WaitingPermission"
+        );
+
+        // StateChanged は events に積まれていないこと。
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, RecordedEmit::StateChanged { .. })));
+        assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+    }
+
+    /// Drive the production `bridge error` lock-block: accumulate an error
+    /// part, enqueue it as a pending delta, force-flush via the same
+    /// `force_flush_pending_streaming` helper the production reader uses,
+    /// then push a `StateChanged(Idle)` event to mirror the post-lock
+    /// `emit_session_state_changed`. Mirrors `bridge_common.rs:1982-2038`.
+    fn drive_bridge_error_path(
+        proc: &mut AgentProcess,
+        chat_session_id: &str,
+        error_part: MessagePart,
+        events: &mut Vec<RecordedEmit>,
+    ) {
+        let was_streaming = proc.state == BridgeState::Streaming;
+        let mid = proc.streaming_message_id.clone();
+        if was_streaming {
+            proc.streaming_parts.push(error_part.clone());
+            enqueue_pending_delta(proc, std::slice::from_ref(&error_part));
+            if let Some(ref mid) = mid {
+                force_flush_pending_streaming(proc, chat_session_id, mid, |parts| {
+                    events.push(RecordedEmit::StreamingFlush {
+                        parts_count: parts.len(),
+                        tail_text: match parts.last() {
+                            Some(MessagePart::Error { content, .. })
+                            | Some(MessagePart::Text { content, .. })
+                            | Some(MessagePart::Thinking { content, .. }) => Some(content.clone()),
+                            _ => None,
+                        },
+                    });
+                    (true, true)
+                });
+            }
+            // Mirror production: state transitions to Crashed → Idle after flush.
+            proc.state = BridgeState::Crashed;
+            proc.turn_phase = TurnPhase::Idle;
+            events.push(RecordedEmit::StateChanged {
+                phase: TurnPhase::Idle,
+                exit_code: Some(1),
+            });
+        }
+    }
+
+    /// Drive the production `EOF crash` lock-block: run
+    /// `apply_bridge_eof_crash`, enqueue the synthetic error delta, force-flush
+    /// via the same helper the production reader uses, then push a
+    /// `StateChanged(Idle)` event to mirror `emit_session_state_changed`.
+    /// Mirrors `bridge_common.rs:2268-2333`.
+    fn drive_bridge_eof_crash_path(
+        proc: &mut AgentProcess,
+        chat_session_id: &str,
+        events: &mut Vec<RecordedEmit>,
+    ) {
+        let streaming_message_id = proc.streaming_message_id.clone();
+        let backend_id = proc.backend_id.clone();
+        let effect = apply_bridge_eof_crash(
+            true,
+            &mut proc.state,
+            &mut proc.turn_phase,
+            streaming_message_id.as_deref(),
+            &mut proc.streaming_parts,
+            &backend_id,
+        );
+        if let (Some(mid), false) = (streaming_message_id.as_ref(), effect.error_delta.is_empty()) {
+            enqueue_pending_delta(proc, &effect.error_delta);
+            force_flush_pending_streaming(proc, chat_session_id, mid, |parts| {
+                events.push(RecordedEmit::StreamingFlush {
+                    parts_count: parts.len(),
+                    tail_text: match parts.last() {
+                        Some(MessagePart::Error { content, .. })
+                        | Some(MessagePart::Text { content, .. })
+                        | Some(MessagePart::Thinking { content, .. }) => Some(content.clone()),
+                        _ => None,
+                    },
+                });
+                (true, true)
+            });
+        }
+        if effect.was_streaming {
+            events.push(RecordedEmit::StateChanged {
+                phase: TurnPhase::Idle,
+                exit_code: Some(-1),
+            });
+        }
+    }
+
+    #[tokio::test]
+    async fn bridge_error_emits_pending_before_state_change() {
+        // Spec (Rule: ターン完了・状態遷移時には未配信バッファを強制配信する,
+        //  Examples ストリーミング → クラッシュ):
+        //   Bridge から error メッセージを受信したクラッシュ経路では、
+        //   未配信 delta + 合成 error part が同一 cumulative payload として
+        //   state 通知 (Idle) より前にフロントエンドへ配信されること。
+        let mut proc = make_streaming_test_process();
+        // 未配信 text が pending に残っている状態でクラッシュが起こる。
+        let pending_text = MessagePart::Text {
+            content: "tail-before-crash".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(pending_text.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&pending_text));
+
+        let error_part = MessagePart::Error {
+            content: "Error: bridge reported failure".to_string(),
+            parent_tool_use_id: None,
+        };
+        let mut events = Vec::new();
+        drive_bridge_error_path(&mut proc, "csid", error_part, &mut events);
+
+        assert_eq!(events.len(), 2, "flush emit then state emit");
+        match &events[0] {
+            RecordedEmit::StreamingFlush {
+                parts_count,
+                tail_text,
+            } => {
+                // cumulative: pending Text + 合成 Error
+                assert_eq!(*parts_count, 2);
+                assert_eq!(
+                    tail_text.as_deref(),
+                    Some("Error: bridge reported failure"),
+                    "tail must be the synthetic error part"
+                );
+            }
+            other => panic!("first emit must be StreamingFlush, got {other:?}"),
+        }
+        assert_eq!(
+            events[1],
+            RecordedEmit::StateChanged {
+                phase: TurnPhase::Idle,
+                exit_code: Some(1),
+            }
+        );
+        assert_eq!(proc.state, BridgeState::Crashed);
+        assert_eq!(proc.turn_phase, TurnPhase::Idle);
+        assert_eq!(proc.pending_stream_part_count, 0);
+    }
+
+    #[tokio::test]
+    async fn bridge_eof_crash_emits_pending_before_state_change() {
+        // Spec (Rule: ターン完了・状態遷移時には未配信バッファを強制配信する,
+        //  Examples ストリーミング → クラッシュ):
+        //   Bridge process EOF クラッシュ経路では、未配信 delta + 合成 error
+        //   part が同一 cumulative payload として state 通知 (Idle) より前に
+        //   フロントエンドへ配信されること。
+        let mut proc = make_streaming_test_process();
+        let pending_text = MessagePart::Text {
+            content: "tail-before-eof".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(pending_text.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&pending_text));
+
+        let mut events = Vec::new();
+        drive_bridge_eof_crash_path(&mut proc, "csid", &mut events);
+
+        assert_eq!(events.len(), 2, "flush emit then state emit");
+        match &events[0] {
+            RecordedEmit::StreamingFlush {
+                parts_count,
+                tail_text,
+            } => {
+                // cumulative: pending Text + apply_bridge_eof_crash が積んだ Error。
+                assert_eq!(*parts_count, 2);
+                assert!(
+                    tail_text
+                        .as_deref()
+                        .unwrap_or("")
+                        .contains("Bridge process exited unexpectedly"),
+                    "tail must be the synthetic EOF error part, got {tail_text:?}"
+                );
+            }
+            other => panic!("first emit must be StreamingFlush, got {other:?}"),
+        }
+        assert_eq!(
+            events[1],
+            RecordedEmit::StateChanged {
+                phase: TurnPhase::Idle,
+                exit_code: Some(-1),
+            }
+        );
+        assert_eq!(proc.state, BridgeState::Crashed);
+        assert_eq!(proc.turn_phase, TurnPhase::Idle);
+        assert_eq!(proc.pending_stream_part_count, 0);
+    }
+
+    #[tokio::test]
+    async fn respond_permission_continues_on_emit_failure() {
+        // Spec L157「強制配信が失敗しても後続の状態遷移は続行する」:
+        //  emit 失敗 (tauri_ok=false) でも did_transition は true のまま返り、
+        //  呼び出し側 (production: emit_session_state_changed) は続行できる。
+        let mut proc = make_process_waiting_for_permission("req-1");
+
+        let effect = apply_respond_permission_locked(
+            &mut proc,
+            "csid",
+            "req-1",
+            "allow",
+            None,
+            |_mid, _parts| (false, false), // emit failure on both channels
+        );
+        assert!(
+            effect.did_transition,
+            "transition must still be reported so caller emits state-change"
+        );
+        assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+        // Pending is retained for next-flush retry (Spec L108-113).
+        assert!(proc.pending_stream_part_count >= 1);
+        assert!(proc.last_stream_emit_at.is_none());
+    }
+
+    #[test]
+    fn delta_has_tool_event_detects_tool_use_and_tool_result() {
+        assert!(delta_has_tool_event(&[MessagePart::ToolUse {
+            id: "1".to_string(),
+            tool: "Bash".to_string(),
+            input: serde_json::json!({}),
+            parent_tool_use_id: None,
+        }]));
+        assert!(delta_has_tool_event(&[MessagePart::ToolResult {
+            tool_use_id: Some("1".to_string()),
+            content: "ok".to_string(),
+            is_error: false,
+            parent_tool_use_id: None,
+        }]));
+        assert!(!delta_has_tool_event(&[MessagePart::Text {
+            content: "plain".to_string(),
+            parent_tool_use_id: None,
+        }]));
+        assert!(!delta_has_tool_event(&[]));
+    }
+
+    fn make_streaming_test_process() -> AgentProcess {
+        // Standalone, non-running AgentProcess used purely to exercise the
+        // coalescing helpers. Stdin/child are tied to a `cat` subprocess so
+        // the struct is well-formed. Must run inside a Tokio runtime.
+        let mut tchild = tokio::process::Command::new("cat")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn cat (tokio)");
+        let stdin = tchild.stdin.take().expect("stdin");
+        AgentProcess {
+            stdin,
+            backend_id: "mock".to_string(),
+            state: BridgeState::Streaming,
+            turn_phase: TurnPhase::Streaming,
+            sdk_session_id: None,
+            child: tchild,
+            generation_id: 0,
+            #[cfg(unix)]
+            pgid: None,
+            streaming_message_id: Some("m1".to_string()),
+            streaming_parts: Vec::new(),
+            last_message_id: None,
+            task_id_map: HashMap::new(),
+            pending_message: None,
+            current_permission_mode: "acceptEdits".to_string(),
+            available_models: Vec::new(),
+            selected_model: None,
+            last_result_token_usage: None,
+            pending_stream_part_count: 0,
+            pending_stream_bytes: 0,
+            last_stream_emit_at: None,
+            streaming_timer_active: false,
+        }
+    }
+
     #[test]
     fn bridge_eof_crash_adds_error_part_for_streaming_message() {
         let mut state = BridgeState::Streaming;
@@ -3849,6 +5843,10 @@ mod tests {
                 available_models: Vec::new(),
                 selected_model: None,
                 last_result_token_usage: None,
+                pending_stream_part_count: 0,
+                pending_stream_bytes: 0,
+                last_stream_emit_at: None,
+                streaming_timer_active: false,
             },
         );
 
@@ -5938,6 +7936,10 @@ mod tests {
                 available_models: Vec::new(),
                 selected_model: None,
                 last_result_token_usage: None,
+                pending_stream_part_count: 0,
+                pending_stream_bytes: 0,
+                last_stream_emit_at: None,
+                streaming_timer_active: false,
             }
         }
 

--- a/src-tauri/src/ws_bridge.rs
+++ b/src-tauri/src/ws_bridge.rs
@@ -1,7 +1,7 @@
-use crate::protocol::WsMessage;
+use crate::protocol::{AgentStreamSync, WsMessage};
 use std::collections::{HashMap, VecDeque};
-use std::sync::Mutex;
-use tokio::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use tokio::sync::{mpsc, Notify};
 
 pub type WsSender = mpsc::UnboundedSender<WsMessage>;
 pub type WsReceiver = mpsc::UnboundedReceiver<WsMessage>;
@@ -11,6 +11,18 @@ const PTY_OUTPUT_BUFFER_SIZE: usize = 64 * 1024;
 pub struct WsBroadcaster {
     sender: Mutex<Option<WsSender>>,
     pty_output_buffers: Mutex<HashMap<u64, VecDeque<u8>>>,
+    /// Latest cumulative `AgentStreamSync` snapshot per
+    /// `(chat_session_id, message_id)`. The producer writes a fresh snapshot
+    /// here on every flush; the consumer drains the slot when woken. This
+    /// keeps the WS queue from accumulating O(N) cumulative payloads when
+    /// the receiver is slow — only the most recent snapshot is retained per
+    /// message, so memory is bounded by (number of live streaming messages
+    /// × one snapshot).
+    latest_stream_sync: Mutex<HashMap<(String, String), AgentStreamSync>>,
+    /// Wakeup for the consumer to drain `latest_stream_sync`. `Notify`
+    /// collapses multiple producer signals into a single permit, so a burst
+    /// of producer updates yields at most one drain pass.
+    stream_sync_notify: Arc<Notify>,
 }
 
 impl Default for WsBroadcaster {
@@ -18,6 +30,8 @@ impl Default for WsBroadcaster {
         Self {
             sender: Mutex::new(None),
             pty_output_buffers: Mutex::new(HashMap::new()),
+            latest_stream_sync: Mutex::new(HashMap::new()),
+            stream_sync_notify: Arc::new(Notify::new()),
         }
     }
 }
@@ -58,16 +72,92 @@ impl WsBroadcaster {
         }
     }
 
-    pub fn send_without_buffer(&self, msg: WsMessage) {
+    /// Forward a message to the active WS session without buffering.
+    /// Returns `true` if the message was delivered to the channel, `true`
+    /// when no sender is registered (no WS client to satisfy — not a failure),
+    /// and `false` only when the sender is registered but `send` failed
+    /// (i.e. the receiver was dropped).
+    pub fn send_without_buffer(&self, msg: WsMessage) -> bool {
         let guard = self.sender.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(sender) = guard.as_ref() {
-            let _ = sender.send(msg);
+        match guard.as_ref() {
+            Some(sender) => sender.send(msg).is_ok(),
+            None => true,
         }
+    }
+
+    /// Best-effort enqueue of an `AgentStreamSync` cumulative snapshot.
+    ///
+    /// The new snapshot replaces any prior unsent snapshot for the same
+    /// `(chat_session_id, message_id)` so a slow WS receiver cannot
+    /// accumulate stacks of full-content payloads in the channel — only the
+    /// most recent cumulative is retained per message. When no sender is
+    /// registered the snapshot is simply dropped (no client to satisfy);
+    /// reconnect must refetch fresh state via the agent session query path
+    /// rather than replay stale slot data.
+    ///
+    /// No return value: the slot write itself cannot fail, and downstream
+    /// transport failure (WS receiver gone) is recovered by the next flush
+    /// re-sending the cumulative `streaming_parts` — which is what the
+    /// producer's coalescer relies on. Reporting a "ws_ok" boolean here
+    /// would be misleading because there is no production path that can
+    /// observe it as `false`.
+    pub fn send_stream_sync(&self, msg: AgentStreamSync) {
+        // Hold the sender lock for the entire critical section so a concurrent
+        // `set_sender(None)` cannot clear `latest_stream_sync` between our
+        // sender-present check and the slot insert (which would leave a stale
+        // snapshot in the slot after disconnect). Lock order is sender → slot,
+        // matching `set_sender`.
+        let sender_guard = self.sender.lock().unwrap_or_else(|e| e.into_inner());
+        if sender_guard.is_none() {
+            return;
+        }
+        {
+            let mut slot = self
+                .latest_stream_sync
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            slot.insert((msg.session_id.clone(), msg.message_id.clone()), msg);
+        }
+        drop(sender_guard);
+        self.stream_sync_notify.notify_one();
+    }
+
+    /// Drain every queued `AgentStreamSync` snapshot and reset the slot to
+    /// empty. The returned vector contains at most one cumulative snapshot
+    /// per `(chat_session_id, message_id)` (latest write wins) — order
+    /// across distinct messages is not preserved, which is safe because each
+    /// snapshot is itself a complete replacement payload that the receiver
+    /// applies independently per message.
+    ///
+    /// Called by the WS forward task on each `stream_sync_notify` wakeup.
+    pub fn drain_stream_sync(&self) -> Vec<AgentStreamSync> {
+        let mut slot = self
+            .latest_stream_sync
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        slot.drain().map(|(_, v)| v).collect()
+    }
+
+    /// Notify handle for the WS forward task. The task `select!`s on this
+    /// alongside the regular `WsReceiver` and, on wakeup, calls
+    /// `drain_stream_sync` to forward queued snapshots to the WS client.
+    pub fn stream_sync_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.stream_sync_notify)
     }
 
     pub fn set_sender(&self, sender: Option<WsSender>) {
         let mut guard = self.sender.lock().unwrap_or_else(|e| e.into_inner());
+        let cleared = sender.is_none();
         *guard = sender;
+        if cleared {
+            // No active WS session — drop the queued cumulative snapshots so
+            // a future session does not start by receiving a snapshot the
+            // prior client was the intended recipient of.
+            self.latest_stream_sync
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clear();
+        }
     }
 
     pub fn remove_pty_output_buffer(&self, pty_id: u64) {
@@ -87,6 +177,7 @@ impl WsBroadcaster {
 mod tests {
     use super::*;
     use crate::protocol::PtyOutputMsg;
+    use crate::session::MessagePart;
 
     #[test]
     fn empty_buffer_returns_empty_string() {
@@ -198,10 +289,11 @@ mod tests {
         }));
         assert_eq!(broadcaster.get_pty_output_buffer(1), "original");
 
-        broadcaster.send_without_buffer(WsMessage::PtyOutput(PtyOutputMsg {
+        let sent = broadcaster.send_without_buffer(WsMessage::PtyOutput(PtyOutputMsg {
             pty_id: 1,
             data: "original".to_string(),
         }));
+        assert!(sent, "send must succeed when a receiver is registered");
         assert_eq!(
             broadcaster.get_pty_output_buffer(1),
             "original",
@@ -213,5 +305,172 @@ mod tests {
             received.push(msg);
         }
         assert_eq!(received.len(), 2, "both messages should be sent to channel");
+    }
+
+    #[test]
+    fn send_without_buffer_returns_false_when_receiver_dropped() {
+        // PTY replay (`handle_pty_output_request`) calls `send_without_buffer`
+        // to deliver the ring-buffer contents on subscribe without re-buffering
+        // them. `false` indicates the sender is registered but its receiver was
+        // dropped (client gone), letting callers decide whether to retry.
+        let broadcaster = WsBroadcaster::default();
+        let (tx, rx) = WsBroadcaster::create_channel();
+        broadcaster.set_sender(Some(tx));
+        drop(rx);
+
+        let sent = broadcaster.send_without_buffer(WsMessage::Error(crate::protocol::ErrorMsg {
+            code: "X".to_string(),
+            message: "x".to_string(),
+        }));
+        assert!(
+            !sent,
+            "send must return false when the receiver has been dropped"
+        );
+    }
+
+    #[test]
+    fn send_without_buffer_returns_true_when_no_sender_registered() {
+        // No WS client to satisfy → not a delivery failure. `true` lets the
+        // caller (PTY replay path) treat the absence of a subscriber as a
+        // benign no-op instead of an error.
+        let broadcaster = WsBroadcaster::default();
+        let sent = broadcaster.send_without_buffer(WsMessage::Error(crate::protocol::ErrorMsg {
+            code: "X".to_string(),
+            message: "x".to_string(),
+        }));
+        assert!(
+            sent,
+            "send must return true when no sender is registered (no client to satisfy)"
+        );
+    }
+
+    fn dummy_stream_sync(session: &str, message: &str, n: usize) -> AgentStreamSync {
+        AgentStreamSync {
+            session_id: session.to_string(),
+            message_id: message.to_string(),
+            parts: (0..n)
+                .map(|i| MessagePart::Text {
+                    content: format!("p{i}"),
+                    parent_tool_use_id: None,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn send_stream_sync_replaces_prior_snapshot_for_same_message() {
+        // Slow consumer scenario: producer pushes many cumulative snapshots
+        // before the consumer drains. Only the newest snapshot must remain.
+        let broadcaster = WsBroadcaster::default();
+        let (tx, _rx) = WsBroadcaster::create_channel();
+        broadcaster.set_sender(Some(tx));
+
+        for n in 1..=10 {
+            broadcaster.send_stream_sync(dummy_stream_sync("S", "M", n));
+        }
+
+        let drained = broadcaster.drain_stream_sync();
+        assert_eq!(drained.len(), 1, "only the latest snapshot is retained");
+        assert_eq!(drained[0].parts.len(), 10);
+
+        // After drain, the slot is empty.
+        assert!(broadcaster.drain_stream_sync().is_empty());
+    }
+
+    #[test]
+    fn send_stream_sync_keeps_distinct_messages_separately() {
+        let broadcaster = WsBroadcaster::default();
+        let (tx, _rx) = WsBroadcaster::create_channel();
+        broadcaster.set_sender(Some(tx));
+
+        broadcaster.send_stream_sync(dummy_stream_sync("S", "M1", 1));
+        broadcaster.send_stream_sync(dummy_stream_sync("S", "M2", 2));
+
+        let mut drained = broadcaster.drain_stream_sync();
+        drained.sort_by(|a, b| a.message_id.cmp(&b.message_id));
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].message_id, "M1");
+        assert_eq!(drained[1].message_id, "M2");
+    }
+
+    #[test]
+    fn send_stream_sync_drops_snapshot_when_no_sender() {
+        // Desktop-only / no WS client: the snapshot is dropped on the floor
+        // (no slot retention) so the producer's coalescing buffer cannot grow
+        // unbounded waiting for a non-existent receiver.
+        let broadcaster = WsBroadcaster::default();
+        broadcaster.send_stream_sync(dummy_stream_sync("S", "M", 1));
+        // No client → no snapshot retained.
+        assert!(broadcaster.drain_stream_sync().is_empty());
+    }
+
+    #[test]
+    fn set_sender_none_clears_queued_stream_sync_snapshots() {
+        // Disconnect must drop stale snapshots so reconnect doesn't see them.
+        let broadcaster = WsBroadcaster::default();
+        let (tx, _rx) = WsBroadcaster::create_channel();
+        broadcaster.set_sender(Some(tx));
+        broadcaster.send_stream_sync(dummy_stream_sync("S", "M", 1));
+        broadcaster.set_sender(None);
+        assert!(broadcaster.drain_stream_sync().is_empty());
+    }
+
+    #[test]
+    fn send_stream_sync_does_not_resurrect_slot_after_concurrent_disconnect() {
+        // Regression: prior implementation released the sender lock before
+        // inserting into `latest_stream_sync`, so a `set_sender(None)` racing
+        // between the sender check and the slot insert could leave a stale
+        // snapshot in the slot. With the sender lock held across the whole
+        // critical section, the two operations are serialised: either the
+        // disconnect wins (insert observes `sender_guard.is_none()` and
+        // returns early) or the send wins (slot has the snapshot and is
+        // cleared by the subsequent disconnect). Either ordering must leave
+        // the slot empty after disconnect.
+        for _ in 0..200 {
+            let broadcaster = Arc::new(WsBroadcaster::default());
+            let (tx, _rx) = WsBroadcaster::create_channel();
+            broadcaster.set_sender(Some(tx));
+
+            let producer = {
+                let broadcaster = Arc::clone(&broadcaster);
+                std::thread::spawn(move || {
+                    broadcaster.send_stream_sync(dummy_stream_sync("S", "M", 1));
+                })
+            };
+            let disconnector = {
+                let broadcaster = Arc::clone(&broadcaster);
+                std::thread::spawn(move || {
+                    broadcaster.set_sender(None);
+                })
+            };
+            producer.join().unwrap();
+            disconnector.join().unwrap();
+
+            assert!(
+                broadcaster.drain_stream_sync().is_empty(),
+                "slot must not retain a snapshot after disconnect"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn send_stream_sync_notifies_waiter() {
+        // Consumer waits on `stream_sync_notify`; producer sends; consumer is
+        // woken and drains the slot. Ensures the notify pipeline is connected.
+        let broadcaster = Arc::new(WsBroadcaster::default());
+        let (tx, _rx) = WsBroadcaster::create_channel();
+        broadcaster.set_sender(Some(tx));
+        let notify = broadcaster.stream_sync_notify();
+        let consumer = {
+            let broadcaster = Arc::clone(&broadcaster);
+            tokio::spawn(async move {
+                notify.notified().await;
+                broadcaster.drain_stream_sync()
+            })
+        };
+        broadcaster.send_stream_sync(dummy_stream_sync("S", "M", 3));
+        let drained = consumer.await.unwrap();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].parts.len(), 3);
     }
 }

--- a/src-tauri/src/ws_server/session.rs
+++ b/src-tauri/src/ws_server/session.rs
@@ -162,6 +162,8 @@ async fn handle_ws_authenticated<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
     let (tx, mut rx) = WsBroadcaster::create_channel();
     state.broadcaster.set_sender(Some(tx));
     let _sender_guard = BroadcasterGuard(state.broadcaster.clone());
+    let stream_sync_notify = state.broadcaster.stream_sync_notify();
+    let broadcaster_for_forward = state.broadcaster.clone();
 
     // --- 初期データ送信: worktreeリストのみ（PTYはworktree選択後に送信） ---
     if !state.get_repo_paths().is_empty() {
@@ -204,12 +206,41 @@ async fn handle_ws_authenticated<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
     // --- セッション単位のworktree選択状態 ---
     let selected_worktree: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
 
-    // PTY出力をWebSocketにフォワードするタスク
+    // PTY出力 + AgentStreamSync を WebSocket にフォワードするタスク。
+    // 通常の `WsMessage` は `rx` から受け取って即送信する。一方で
+    // `AgentStreamSync` は `WsBroadcaster::latest_stream_sync` slot に
+    // 最新累積のみを保持し、`stream_sync_notify` で起床して drain する。
+    // これにより遅い WS receiver に対しても累積 snapshot がキューに積み上がらず、
+    // メモリ消費は (live message × 1 snapshot) で頭打ちになる。
     let forward_task = tokio::spawn(async move {
-        while let Some(msg) = rx.recv().await {
-            if let Ok(json) = serialize_message(&msg) {
-                if write.send(Message::text(json)).await.is_err() {
-                    break;
+        loop {
+            tokio::select! {
+                biased;
+                _ = stream_sync_notify.notified() => {
+                    let drained = broadcaster_for_forward.drain_stream_sync();
+                    let mut send_failed = false;
+                    for sync in drained {
+                        let msg = WsMessage::AgentStreamSync(sync);
+                        if let Ok(json) = serialize_message(&msg) {
+                            if write.send(Message::text(json)).await.is_err() {
+                                send_failed = true;
+                                break;
+                            }
+                        }
+                    }
+                    if send_failed { break; }
+                }
+                maybe = rx.recv() => {
+                    match maybe {
+                        Some(msg) => {
+                            if let Ok(json) = serialize_message(&msg) {
+                                if write.send(Message::text(json)).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                        None => break,
+                    }
                 }
             }
         }

--- a/src/components/panels/AgentChatPanel/StreamMessage.test.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.test.tsx
@@ -9,6 +9,21 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 	openUrl: (...args: unknown[]) => mockOpenUrl(...args),
 }));
 
+const { markdownSpy } = vi.hoisted(() => ({ markdownSpy: vi.fn() }));
+// Wrap react-markdown so we can count how often it is invoked for each render.
+// The wrapper still delegates to the real implementation so unrelated markdown
+// assertions in this file (bold, code, links, tables …) keep working.
+vi.mock("react-markdown", async (importOriginal) => {
+	const orig = await importOriginal<typeof import("react-markdown")>();
+	const Wrapped = (
+		props: Parameters<(typeof orig)["default"]>[0],
+	): ReturnType<(typeof orig)["default"]> => {
+		markdownSpy(props);
+		return orig.default(props);
+	};
+	return { ...orig, default: Wrapped };
+});
+
 const human: MessageRole = "human";
 const agent: MessageRole = "agent";
 const system: MessageRole = "system";
@@ -16,6 +31,7 @@ const system: MessageRole = "system";
 describe("StreamMessage", () => {
 	beforeEach(() => {
 		mockOpenUrl.mockClear();
+		markdownSpy.mockClear();
 	});
 
 	it("renders human message", async () => {
@@ -239,5 +255,128 @@ describe("StreamMessage", () => {
 		render(<StreamMessage content="Plain text without table" role={agent} />);
 		const el = screen.getByTestId("stream-message-agent");
 		expect(el.querySelector(".overflow-x-auto")).toBeNull();
+	});
+
+	it("does not re-invoke react-markdown when parent re-renders with identical content/role/images/mentions", () => {
+		// React.memo on StreamMessage should short-circuit identical-prop
+		// re-renders so the markdown pipeline does not run again. We count
+		// how often the wrapped Markdown component is invoked: it must equal
+		// the mount-time count even after the parent re-renders.
+		let parentRenderCount = 0;
+		function Probe({ tick }: { tick: number }) {
+			parentRenderCount += 1;
+			void tick;
+			return <StreamMessage content="stable content" role={agent} />;
+		}
+
+		const { rerender } = render(<Probe tick={1} />);
+		const mountInvocations = markdownSpy.mock.calls.length;
+		expect(mountInvocations).toBeGreaterThan(0);
+
+		rerender(<Probe tick={2} />);
+		rerender(<Probe tick={3} />);
+
+		// Parent re-rendered, but the memoized child did not — so the markdown
+		// renderer was not invoked again.
+		expect(parentRenderCount).toBeGreaterThan(1);
+		expect(markdownSpy.mock.calls.length).toBe(mountInvocations);
+	});
+
+	it("re-renders when content changes (memo lets through real updates)", () => {
+		const { rerender } = render(<StreamMessage content="first" role={agent} />);
+		expect(screen.getByTestId("stream-message-agent").textContent).toContain(
+			"first",
+		);
+		rerender(<StreamMessage content="second" role={agent} />);
+		expect(screen.getByTestId("stream-message-agent").textContent).toContain(
+			"second",
+		);
+	});
+
+	it("memo skips re-render when images are value-equal but new references", () => {
+		// shallowEqualImages must compare by value so a parent re-render that
+		// creates a fresh array with the same image data does not bust the memo.
+		const initial = [
+			{ type: "image" as const, data: "aGVsbG8=", mediaType: "image/png" },
+		];
+		const equalButNewRef = [
+			{ type: "image" as const, data: "aGVsbG8=", mediaType: "image/png" },
+		];
+		const { rerender } = render(
+			<StreamMessage content="stable" role={agent} images={initial} />,
+		);
+		const mountInvocations = markdownSpy.mock.calls.length;
+		expect(mountInvocations).toBeGreaterThan(0);
+
+		rerender(
+			<StreamMessage content="stable" role={agent} images={equalButNewRef} />,
+		);
+		expect(markdownSpy.mock.calls.length).toBe(mountInvocations);
+	});
+
+	it("memo skips re-render when mentions are value-equal but new references", () => {
+		// shallowEqualMentions compares filePath / startLine / endLine — a fresh
+		// array with the same fields must not trigger a re-parse.
+		const initial = [{ filePath: "src/a.rs", startLine: 1, endLine: 5 }];
+		const equalButNewRef = [{ filePath: "src/a.rs", startLine: 1, endLine: 5 }];
+		const { rerender } = render(
+			<StreamMessage content="stable" role={agent} mentions={initial} />,
+		);
+		const mountInvocations = markdownSpy.mock.calls.length;
+		expect(mountInvocations).toBeGreaterThan(0);
+
+		rerender(
+			<StreamMessage content="stable" role={agent} mentions={equalButNewRef} />,
+		);
+		expect(markdownSpy.mock.calls.length).toBe(mountInvocations);
+	});
+
+	it("memo re-renders when images value changes", () => {
+		const initial = [
+			{ type: "image" as const, data: "aGVsbG8=", mediaType: "image/png" },
+		];
+		const changed = [
+			{ type: "image" as const, data: "Z29vZA==", mediaType: "image/png" },
+		];
+		const { rerender } = render(
+			<StreamMessage content="stable" role={human} images={initial} />,
+		);
+		const el = screen.getByTestId("stream-message-human");
+		expect(el.querySelector("img")?.getAttribute("src")).toBe(
+			"data:image/png;base64,aGVsbG8=",
+		);
+
+		rerender(<StreamMessage content="stable" role={human} images={changed} />);
+		expect(
+			screen
+				.getByTestId("stream-message-human")
+				.querySelector("img")
+				?.getAttribute("src"),
+		).toBe("data:image/png;base64,Z29vZA==");
+	});
+
+	it("memo re-renders when mentions value changes", () => {
+		// content は固定したまま mentions のみ切り替え、shallowEqualMentions の
+		// 差分判定が単独で再描画を引き起こすことを担保する。content も同時に
+		// 変えてしまうと content 差分だけで再描画されてしまい、mentions 比較が
+		// 壊れていても素通りしてしまうため。
+		const stableContent = "Check @src/a.rs and @src/b.rs";
+		const initial = [{ filePath: "src/a.rs" }];
+		const changed = [{ filePath: "src/b.rs" }];
+		const { rerender } = render(
+			<StreamMessage content={stableContent} role={human} mentions={initial} />,
+		);
+		expect(
+			screen.getByTestId("stream-message-human").querySelector(".font-mono")
+				?.textContent,
+		).toBe("@src/a.rs");
+
+		rerender(
+			<StreamMessage content={stableContent} role={human} mentions={changed} />,
+		);
+		expect(
+			screen.getByTestId("stream-message-human").querySelector(".font-mono")
+				?.textContent,
+		).toBe("@src/b.rs");
 	});
 });

--- a/src/components/panels/AgentChatPanel/StreamMessage.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.tsx
@@ -1,6 +1,6 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { AnchorHTMLAttributes } from "react";
-import { useDeferredValue } from "react";
+import { memo } from "react";
 import Markdown from "react-markdown";
 import { rehypePluginList, remarkPluginList } from "@/lib/markdownConfig";
 import type { ImagePart, MentionReference, MessageRole } from "@/types/session";
@@ -126,14 +126,13 @@ function HumanMessageContent({
 	);
 }
 
-export function StreamMessage({
+function StreamMessageImpl({
 	content,
 	role,
 	images,
 	mentions,
 }: StreamMessageProps) {
 	const isHuman = role === "human";
-	const deferredContent = useDeferredValue(content);
 
 	if (role === "system") {
 		return (
@@ -175,10 +174,53 @@ export function StreamMessage({
 							),
 						}}
 					>
-						{deferredContent}
+						{content}
 					</Markdown>
 				</div>
 			)}
 		</div>
 	);
 }
+
+function shallowEqualImages(a?: ImagePart[], b?: ImagePart[]): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (a[i].data !== b[i].data || a[i].mediaType !== b[i].mediaType)
+			return false;
+	}
+	return true;
+}
+
+function shallowEqualMentions(
+	a?: MentionReference[],
+	b?: MentionReference[],
+): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		const x = a[i];
+		const y = b[i];
+		if (
+			x.filePath !== y.filePath ||
+			x.startLine !== y.startLine ||
+			x.endLine !== y.endLine
+		)
+			return false;
+	}
+	return true;
+}
+
+// memoize on (content, role, images, mentions) — the four props that change
+// the rendered DOM. Skipping re-render when none of these differ is what
+// keeps streaming-heavy turns from re-parsing every sibling message's markdown.
+export const StreamMessage = memo(StreamMessageImpl, (prev, next) => {
+	return (
+		prev.content === next.content &&
+		prev.role === next.role &&
+		shallowEqualImages(prev.images, next.images) &&
+		shallowEqualMentions(prev.mentions, next.mentions)
+	);
+});

--- a/src/hooks/agentChatReducer.test.ts
+++ b/src/hooks/agentChatReducer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { BackendInfo, ChatMessage, ChatSession } from "@/types/session";
 import type { AgentChatState } from "./agentChatReducer";
-import { INITIAL_STATE, mergeDeltaParts, reducer } from "./agentChatReducer";
+import { INITIAL_STATE, reducer } from "./agentChatReducer";
 
 function makeSession(overrides?: Partial<ChatSession>): ChatSession {
 	return {
@@ -400,7 +400,10 @@ describe("agentChatReducer", () => {
 	});
 
 	describe("SET_STREAMING_MESSAGE", () => {
-		it("appends delta parts to existing parts in active session", () => {
+		it("replaces existing parts with the cumulative payload in active session", () => {
+			// Rust sends the full cumulative `streaming_parts` on every flush, so the
+			// reducer replaces the message's parts wholesale. A redelivery (same or
+			// extended cumulative payload) must converge without double-application.
 			const msg = makeMessage({
 				id: "m1",
 				role: "agent",
@@ -410,20 +413,43 @@ describe("agentChatReducer", () => {
 				...INITIAL_STATE,
 				activeSession: makeSession({ id: "s1", messages: [msg] }),
 			};
-			const deltaParts = [
-				{ type: "text" as const, content: " updated" },
+			const cumulativeParts = [
+				{ type: "text" as const, content: "old updated" },
 				{ type: "thinking" as const, content: "reasoning" },
 			];
 			const next = reducer(state, {
 				type: "SET_STREAMING_MESSAGE",
 				sessionId: "s1",
 				messageId: "m1",
-				parts: deltaParts,
+				parts: cumulativeParts,
 			});
-			expect(next.activeSession?.messages[0].parts).toEqual([
-				{ type: "text", content: "old updated" },
-				{ type: "thinking", content: "reasoning" },
-			]);
+			expect(next.activeSession?.messages[0].parts).toEqual(cumulativeParts);
+		});
+
+		it("converges on re-delivery of the same cumulative payload", () => {
+			const msg = makeMessage({
+				id: "m1",
+				role: "agent",
+				parts: [{ type: "text", content: "old" }],
+			});
+			const state: AgentChatState = {
+				...INITIAL_STATE,
+				activeSession: makeSession({ id: "s1", messages: [msg] }),
+			};
+			const cumulative = [{ type: "text" as const, content: "old updated" }];
+			const once = reducer(state, {
+				type: "SET_STREAMING_MESSAGE",
+				sessionId: "s1",
+				messageId: "m1",
+				parts: cumulative,
+			});
+			const twice = reducer(once, {
+				type: "SET_STREAMING_MESSAGE",
+				sessionId: "s1",
+				messageId: "m1",
+				parts: cumulative,
+			});
+			expect(twice.activeSession?.messages[0].parts).toEqual(cumulative);
 		});
 
 		it("does nothing when activeSession is null", () => {
@@ -468,195 +494,6 @@ describe("agentChatReducer", () => {
 				parts: [{ type: "text", content: "hello" }],
 			});
 			expect(next).toBe(state);
-		});
-	});
-
-	describe("mergeDeltaParts", () => {
-		it("merges consecutive text delta into last text part", () => {
-			const existing = [{ type: "text" as const, content: "Hello" }];
-			const delta = [{ type: "text" as const, content: " World" }];
-			const result = mergeDeltaParts(existing, delta);
-			expect(result).toEqual([{ type: "text", content: "Hello World" }]);
-		});
-
-		it("appends text delta when last part is different type", () => {
-			const existing = [{ type: "thinking" as const, content: "thinking..." }];
-			const delta = [{ type: "text" as const, content: "answer" }];
-			const result = mergeDeltaParts(existing, delta);
-			expect(result).toHaveLength(2);
-			expect(result[1]).toEqual({ type: "text", content: "answer" });
-		});
-
-		it("adds new permission part", () => {
-			const existing: import("@/types/session").MessagePart[] = [];
-			const delta: import("@/types/session").MessagePart[] = [
-				{
-					type: "permission",
-					request: {
-						request_id: "req-1",
-						tool_name: "ExitPlanMode",
-						input: {},
-						tool_use_id: "toolu_001",
-					},
-					status: "pending",
-				},
-			];
-			const result = mergeDeltaParts(existing, delta);
-			expect(result).toHaveLength(1);
-			expect(result[0]).toEqual({
-				type: "permission",
-				request: {
-					request_id: "req-1",
-					tool_name: "ExitPlanMode",
-					input: {},
-					tool_use_id: "toolu_001",
-				},
-				status: "pending",
-			});
-		});
-
-		it("updates existing permission part by request_id", () => {
-			const existing: import("@/types/session").MessagePart[] = [
-				{
-					type: "permission",
-					request: {
-						request_id: "req-1",
-						tool_name: "ExitPlanMode",
-						input: {},
-						tool_use_id: "toolu_001",
-					},
-					status: "pending",
-				},
-			];
-			const delta: import("@/types/session").MessagePart[] = [
-				{
-					type: "permission",
-					request: {
-						request_id: "req-1",
-						tool_name: "ExitPlanMode",
-						input: {},
-						tool_use_id: "toolu_001",
-					},
-					status: "allowed",
-				},
-			];
-			const result = mergeDeltaParts(existing, delta);
-			expect(result).toHaveLength(1);
-			expect(result[0]).toEqual({
-				type: "permission",
-				request: {
-					request_id: "req-1",
-					tool_name: "ExitPlanMode",
-					input: {},
-					tool_use_id: "toolu_001",
-				},
-				status: "allowed",
-			});
-		});
-
-		it("appends tool_use parts", () => {
-			const existing = [{ type: "text" as const, content: "hello" }];
-			const delta: import("@/types/session").MessagePart[] = [
-				{
-					type: "tool_use",
-					tool: "Edit",
-					input: { file_path: "/src/main.rs" },
-					id: "toolu_001",
-				},
-			];
-			const result = mergeDeltaParts(existing, delta);
-			expect(result).toHaveLength(2);
-			expect(result[1].type).toBe("tool_use");
-		});
-
-		it("returns existing when delta is empty", () => {
-			const existing = [{ type: "text" as const, content: "hello" }];
-			const result = mergeDeltaParts(existing, []);
-			expect(result).toBe(existing);
-		});
-
-		it("does not merge text with different parentToolUseId", () => {
-			const existing = [{ type: "text" as const, content: "main" }];
-			const delta = [
-				{ type: "text" as const, content: "sub", parentToolUseId: "parent1" },
-			];
-			const result = mergeDeltaParts(existing, delta);
-			expect(result).toHaveLength(2);
-		});
-
-		it("updates existing compaction notification in-place", () => {
-			const existing = [
-				{
-					type: "system_notification" as const,
-					notificationType: "compaction" as const,
-					status: "in_progress" as const,
-					label: "Compacting conversation...",
-				},
-			];
-			const delta = [
-				{
-					type: "system_notification" as const,
-					notificationType: "compaction" as const,
-					status: "completed" as const,
-					label: "Conversation compacted",
-					detail: "trigger=auto, 50000 tokens",
-				},
-			];
-			const result = mergeDeltaParts(existing, delta);
-			expect(result).toHaveLength(1);
-			expect(result[0]).toEqual({
-				type: "system_notification",
-				notificationType: "compaction",
-				status: "completed",
-				label: "Conversation compacted",
-				detail: "trigger=auto, 50000 tokens",
-			});
-		});
-
-		it("updates existing hook notification by hookId", () => {
-			const existing = [
-				{
-					type: "system_notification" as const,
-					notificationType: "hook" as const,
-					status: "in_progress" as const,
-					label: "SessionEnd (StopSession)",
-					hookId: "hook-001",
-				},
-			];
-			const delta = [
-				{
-					type: "system_notification" as const,
-					notificationType: "hook" as const,
-					status: "completed" as const,
-					label: "SessionEnd (StopSession)",
-					detail: "outcome=success, exit_code=0",
-					hookId: "hook-001",
-				},
-			];
-			const result = mergeDeltaParts(existing, delta);
-			expect(result).toHaveLength(1);
-			expect(result[0]).toEqual(
-				expect.objectContaining({
-					status: "completed",
-					detail: "outcome=success, exit_code=0",
-				}),
-			);
-		});
-
-		it("appends new system_notification when no match found", () => {
-			const existing = [{ type: "text" as const, content: "hello" }];
-			const delta = [
-				{
-					type: "system_notification" as const,
-					notificationType: "files_persisted" as const,
-					status: "completed" as const,
-					label: "Files persisted",
-					detail: "CLAUDE.md",
-				},
-			];
-			const result = mergeDeltaParts(existing, delta);
-			expect(result).toHaveLength(2);
-			expect(result[1].type).toBe("system_notification");
 		});
 	});
 

--- a/src/hooks/agentChatReducer.ts
+++ b/src/hooks/agentChatReducer.ts
@@ -61,71 +61,10 @@ export type AgentChatAction =
 	| { type: "SET_BACKENDS"; backends: BackendInfo[]; defaultId: string | null }
 	| { type: "SET_SELECTED_BACKEND"; backendId: string | null };
 
-/**
- * Merge delta parts into existing parts.
- * - text/thinking: merge into the last existing part if same type and parentToolUseId
- * - permission: update existing part by request_id if found, otherwise append
- * - other types: always append
- */
-export function mergeDeltaParts(
-	existing: MessagePart[],
-	delta: MessagePart[],
-): MessagePart[] {
-	if (delta.length === 0) return existing;
-	const result = existing.slice();
-	for (const part of delta) {
-		if (part.type === "text" || part.type === "thinking") {
-			const last = result.length > 0 ? result[result.length - 1] : undefined;
-			if (
-				last &&
-				(last.type === "text" || last.type === "thinking") &&
-				last.type === part.type &&
-				last.parentToolUseId === part.parentToolUseId
-			) {
-				result[result.length - 1] = {
-					...last,
-					content: last.content + part.content,
-				};
-			} else {
-				result.push(part);
-			}
-		} else if (part.type === "permission") {
-			const idx = result.findIndex(
-				(p) =>
-					p.type === "permission" &&
-					p.request.request_id === part.request.request_id,
-			);
-			if (idx !== -1) {
-				result[idx] = part;
-			} else {
-				result.push(part);
-			}
-		} else if (part.type === "system_notification") {
-			// Update existing notification in-place (compaction/hook completion)
-			const idx = result.findIndex((p) => {
-				if (p.type !== "system_notification") return false;
-				if (p.notificationType !== part.notificationType) return false;
-				// Hook: match by hookId
-				if (part.notificationType === "hook" && part.hookId) {
-					return p.hookId === part.hookId;
-				}
-				// Compaction: match by notificationType (only one active at a time)
-				if (part.notificationType === "compaction") {
-					return p.status === "in_progress";
-				}
-				return false;
-			});
-			if (idx !== -1) {
-				result[idx] = part;
-			} else {
-				result.push(part);
-			}
-		} else {
-			result.push(part);
-		}
-	}
-	return result;
-}
+// Rust now emits the cumulative `streaming_parts` array on every flush.
+// `SET_STREAMING_MESSAGE` replaces the message's parts wholesale so that
+// re-deliveries (e.g. when one transport channel previously failed) collapse
+// to a single state update with no double-application risk.
 
 function updateMessageInSession(
 	state: AgentChatState,
@@ -216,7 +155,7 @@ export function reducer(
 				return state;
 			return updateMessageInSession(state, action.messageId, (m) => ({
 				...m,
-				parts: mergeDeltaParts(m.parts, action.parts),
+				parts: action.parts,
 			}));
 		}
 		case "SET_AVAILABLE_MODELS":

--- a/src/remote/components/RemoteAgentPanel.test.tsx
+++ b/src/remote/components/RemoteAgentPanel.test.tsx
@@ -114,6 +114,8 @@ describe("RemoteAgentPanel", () => {
 				backend_id: "codex",
 			},
 		});
+		// Rust emits the cumulative streaming_parts on every flush — Remote
+		// replaces the message's parts on receipt.
 		emit({
 			type: "agent_stream_sync",
 			payload: {
@@ -122,15 +124,22 @@ describe("RemoteAgentPanel", () => {
 				parts: [{ type: "text", content: "Hel" }],
 			},
 		});
+		// First sync must surface in the DOM before the second arrives — long
+		// streamed responses are observed incrementally, not only at the end.
+		expect(screen.getByText("Hel")).toBeInTheDocument();
+
 		emit({
 			type: "agent_stream_sync",
 			payload: {
 				session_id: "session-1",
 				message_id: "agent-1",
-				parts: [{ type: "text", content: "lo" }],
+				parts: [{ type: "text", content: "Hello" }],
 			},
 		});
 
+		// Cumulative replace: "Hel" is no longer rendered after the next sync.
+		expect(screen.queryByText("Hel")).not.toBeInTheDocument();
+		// "Hello" appears in both the echoed human input and the agent reply.
 		expect(screen.getAllByText("Hello")).toHaveLength(2);
 	});
 

--- a/src/remote/components/RemoteAgentPanel.tsx
+++ b/src/remote/components/RemoteAgentPanel.tsx
@@ -31,28 +31,6 @@ interface RemoteChatMessage {
 	parts: MessagePart[];
 }
 
-function mergeParts(
-	existing: MessagePart[],
-	delta: MessagePart[],
-): MessagePart[] {
-	const merged = existing.slice();
-	for (const part of delta) {
-		const last = merged[merged.length - 1];
-		if (
-			(part.type === "text" || part.type === "thinking") &&
-			last?.type === part.type
-		) {
-			merged[merged.length - 1] = {
-				...last,
-				content: last.content + part.content,
-			} as MessagePart;
-		} else {
-			merged.push(part);
-		}
-	}
-	return merged;
-}
-
 function renderPart(part: MessagePart): string {
 	switch (part.type) {
 		case "text":
@@ -151,13 +129,16 @@ export function RemoteAgentPanel({
 						break;
 					}
 					setMessages((current) => {
+						// Rust sends the cumulative `streaming_parts` on every emit, so the
+						// receiver replaces the message state wholesale. Replays / partial
+						// failures collapse to the same final state without double-merging.
 						let found = false;
 						const next = current.map((message) => {
 							if (message.id !== msg.payload.message_id) return message;
 							found = true;
 							return {
 								...message,
-								parts: mergeParts(message.parts, msg.payload.parts),
+								parts: msg.payload.parts,
 							};
 						});
 						if (found) return next;
@@ -166,7 +147,7 @@ export function RemoteAgentPanel({
 							{
 								id: msg.payload.message_id,
 								role: "agent",
-								parts: mergeParts([], msg.payload.parts),
+								parts: msg.payload.parts,
 							},
 						];
 					});


### PR DESCRIPTION
## Summary

- Rust 側（`AgentProcess` / `bridge_common.rs`）で `agent-streaming-updated` / WS `AgentStreamSync` の emit を 33ms 間隔で集約（coalescing）し、件数1000件 / `STREAMING_PENDING_BYTE_LIMIT` 到達時は即 flush。turn_complete・状態遷移（権限待ち↔ストリーミング・クラッシュ・ツール実行）・補助タイマー（33ms 周期）で残存バッファを強制 flush。
- emit は best-effort で、Tauri event / WS のいずれかが失敗した場合も pending と `last_emit_at` を保持し次 flush で再試行。`streaming_parts` は累積置換型ペイロードのため、片チャネル成功でも次 flush の再送で重複表示は発生しない。
- Frontend の `StreamMessage` から `useDeferredValue` を撤去し、`React.memo`（content / role / images / mentions の浅比較）で同一 props の再描画を抑止。`agentChatReducer` / Remote の `mergeDeltaParts` 系を削除し、受信した累積 parts で完全置換する設計に統一。
- WS `AgentStreamSync` は `WsBroadcaster` の slot 経由で配信し、認証完了後の sender にのみ書き込み（未認証セッションには配信されない）。切断時に slot を clear。
- 配信失敗時の warn ログは `chat_session_id` / `message_id` / `part_count` / `buffer_len` / `pending_bytes` / `tauri_ok` / `ws_ok` のみで本文・ツール入出力・mention 等のユーザーデータは含めない（静的検査テスト付き）。

Closes #970

## Test plan

- [ ] `pnpm lint` が通る
- [ ] `pnpm test` が通る（StreamMessage / agentChatReducer / RemoteAgentPanel のテスト追加）
- [ ] `cargo fmt --check` が通る
- [ ] `cargo clippy -- -D warnings` が通る
- [ ] `cargo test`（bridge_common の coalescing / 強制flush / 補助タイマー / 認可 / ログリーク検査テスト）が通る
- [ ] AgentChat パネルで長文 Markdown 応答をストリーミングさせ、行途中で表示が止まらず受信即時で反映されることを目視確認
- [ ] Remote（モバイルブラウザ）からも同様にストリーミングが即時反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ストリーミング応答が受信直後に即座に表示されるようになりました
  * 表示途中での停止や完了時の遅延を解決しました
  * メッセージ表示がより滑らかになりました
  * 不要な再描画を削減し、パフォーマンスが向上しました

* **ドキュメント**
  * ストリーミング応答の仕様書を追加しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/972)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->