### PR TITLE
refactor: ステップカードから冗長・特殊なUI要素を除去 (#927)

### DIFF
--- a/docs/spec/issues-927.md
+++ b/docs/spec/issues-927.md
@@ -1,0 +1,144 @@
+# issues-927: ステップカードのUI改善
+
+## 要求
+
+**種別**: 改善
+
+**ゴール**: ワークフロー実行画面のステップカードから冗長・特殊な要素を取り除き、情報の重複や認知負荷を減らした表示にする。具体的には次の4点が達成されている状態とする。
+
+1. 「#1」「#2」のようなフロー内順序を示すバッジが表示されていない（フローのUIを見れば順序は自明）
+2. 「Result: ...」のテキストと、同じ値を示すVerdictバッジの二重表示が解消されている
+3. 「run 1」「run 2」のような同一ステップの実行回数バッジが表示されていない
+4. Structured Output の値が `spec_file_path` を持つときだけ表示される専用リンクボタンが表示されていない（Output内容に応じて出し分ける特殊UIをやめる）
+
+**背景**: 現状のステップカードには、フローの並びを見れば自明な順序バッジ、同じ情報を二重に伝えるResultテキスト＋バッジ、ニュアンスが伝わりづらい "run N" 表記、Outputが特定形状（`spec_file_path` を含む）のときだけ現れる特殊なリンクUIなど、ノイズや一貫性のない要素が混在している。これらを整理して、ステップカードを「必要十分な情報のみが載っている、シンプルで一貫したカード」にしたい。
+
+**影響範囲**:
+- `src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx` の通常ステップ行（StepRow相当）と並列ブロック行（ParallelBlockRow）の両方
+- `StructuredOutputToggle` の `spec_file_path` 専用リンク表示
+- 関連テスト（`WorkflowTrace.test.tsx` など）
+
+## 振る舞い定義
+
+```gherkin
+Feature: ステップカードのUI改善
+
+  Rule: フロー内順序の表示
+    ステップの並び順はワークフローのUIから自明であり、カード上に順序バッジを重ねて表示しない。
+
+    Scenario: 複数ステップから成るワークフローを表示する
+      Given ワークフローに2つ以上のステップが定義されている
+      And いずれかのステップが実行済みまたは実行中である
+      When ワークフロー実行画面のステップカードが描画される
+      Then 「#1」「#2」のようなフロー内順序を示すバッジはどのステップカードにも表示されない
+
+    Scenario: 1ステップのみのワークフローを表示する
+      Given ワークフローに1つだけステップが定義されている
+      And そのステップが実行済みまたは実行中である
+      When ワークフロー実行画面のステップカードが描画される
+      Then 「#1」というフロー内順序を示すバッジはステップカードに表示されない
+
+  Rule: 実行結果(Result)の表示
+    完了ステップの結果は1か所（Verdictバッジ）でのみ伝え、同じ値を別のテキストとして重複して表示しない。完了ステップごとに Verdict バッジは最大1つに正規化する。
+
+    Scenario: 結果を持つ完了ステップを表示する
+      Given ステップが完了状態である
+      And そのステップが結果文字列（例: "LGTM" や "completed"）を持つ
+      When ステップカードが描画される
+      Then 結果は Verdict バッジとしてのみ表示される
+      And 同じ値を含む「Result: ...」というテキスト行は表示されない
+
+    Scenario: 結果文字列を持たない完了ステップを表示する
+      Given ステップが完了状態である
+      And そのステップが結果文字列を持たない
+      When ステップカードが描画される
+      Then 「Result: completed」のような Result テキスト行は表示されない
+
+    Scenario: 並列ブロック全体の結果を表示する
+      Given 並列ステップブロックが完了状態である
+      And ブロック全体の結果文字列を持つ
+      When 並列ブロック行が描画される
+      Then 「Result: ...」というテキスト表記は表示されない
+      And ブロック全体の結果を示す Verdict バッジも表示されない（本要求では並列ブロック行の Result テキスト行を除去するのみで、ブロックレベルの VerdictBadge は新たに追加しない）
+
+    Scenario: collect/reduce で同一結果が重複し得る完了ステップを表示する
+      Given collect ステップが完了状態である
+      And ステップ自身の結果文字列と reduce 結果が同値である
+      When ステップカードが描画される
+      Then 結果を示す Verdict バッジは1つだけ表示される
+      And 同一結果の Verdict バッジが2つ並んで表示されることはない
+
+  Rule: 同一ステップの実行回数(run)の表示
+    同一ステップの何回目の実行かを示すバッジは表示しない。
+
+    Scenario: 同一ステップが繰り返し実行される
+      Given あるステップが同一ワークフロー内で2回以上実行された
+      When それぞれの実行に対応するステップカードが描画される
+      Then 「run 1」「run 2」のような実行回数を示すバッジはどのカードにも表示されない
+
+    Scenario: 通常ステップが初回実行中である
+      Given 通常ステップがワークフロー内で初めて実行中である
+      When そのステップのカードが描画される
+      Then 「run 1」のような実行回数を示すバッジは表示されない
+
+    Scenario: 通常ステップが初回完了である
+      Given 通常ステップがワークフロー内で1回だけ実行され完了している
+      When そのステップのカードが描画される
+      Then 「run 1」のような実行回数を示すバッジは表示されない
+
+    Scenario: 並列ブロック行を表示する
+      Given 並列ステップブロックが描画対象である
+      When 並列ブロック行が描画される
+      Then 「run N」バッジは表示されない
+
+  Rule: Structured Output の表示
+    Structured Output は内容の形状に依存しない一貫したUI（トグル）でのみ閲覧でき、特定フィールドに対する専用UIは持たない。
+
+    Scenario: spec_file_path を含む Structured Output を表示する
+      Given ステップの Structured Output が `spec_file_path` フィールドを持つ
+      When ステップカードが描画される
+      Then `spec_file_path` の値をリンクとして直接表示する専用ボタンは表示されない
+      And Structured Output は通常のトグル展開によってのみ閲覧できる
+
+    Scenario: spec_file_path を含まない Structured Output を表示する
+      Given ステップの Structured Output が `spec_file_path` フィールドを持たない
+      When ステップカードが描画される
+      Then Structured Output は通常のトグル展開によって閲覧できる
+      And `spec_file_path` の有無に関わらず、専用リンクボタンは表示されず、同じ Structured Output トグルボタンと展開後の JSON pre のみで閲覧できる
+```
+
+## アーキテクチャ概要
+
+本変更はプレゼンテーション層に閉じたUI整理であり、通信プロトコル・Rust側ロジック・状態管理には手を入れない。ただしフロントエンド側では「描画しなくなったことで不要になった実装は全て削除する」方針とする（描画停止だけでなく、付随するデータ参照・props・helper・import・テストを残骸として残さない）。
+
+### 責務配置
+- `src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx`: ステップカードの見た目を構成する責務。通常ステップ行（`TraceItemRow` 内のヘッダ）、`ParallelBlockRow` のヘッダ・サマリ、`TraceItemSummary` のResult表示、`StructuredOutputToggle` の `spec_file_path` 専用リンクを削除し、削除に伴って不要になった内部変数・helper・props・importも併せて削除する責務 / バックエンドからの取得・整形・状態遷移は担当しない
+- `WorkflowTrace.tsx` 内のデータ変換層（`buildTraceItems`）: `stepHistory` から `TraceItem[]` を組み立てる責務は維持。`occurrence` は `run N` 表示用途からは外す。ただし React key 安定化（`traceItemKey`）や現在ステップの出現回数計算に必要な値、または同等の内部識別子は維持する。表示削除によって完全に未使用となった派生フィールドのみ削除し、`TraceItem` の型からも未使用フィールドのみを除去する
+- バックエンド（Rust / WebSocket protocol / `workflow` 関連型）: 何も担当しない（変更なし） / 表示形式の整理に巻き込まれない
+- 型定義 `src/types/workflow.ts`: バックエンドと共有する型は変更しない / フロントローカルで参照される派生型が未使用になる場合に限り、フロント側で削除する
+
+### データ/通信フロー
+- ステップ完了の表示: 既存と同じ「WorkflowState → `buildTraceItems` → `TraceItemRow` / `ParallelBlockRow`」。本変更では末端のJSX出力から `#N` バッジ・`run N` バッジ・`Result: ...` テキスト・`spec_file_path` 専用リンクの描画分岐を除去する。中間データのうち、run バッジ表示にのみ使われる派生値（`occurrence` の `run N` 描画用途）は削除する。ただし `seenCounts` のうち以下の用途で参照されている内部値は表示しなくなっても維持する: (a) `currentAlreadyCompleted` 判定（現在ステップが履歴に既出かの判定）、(b) 現在ステップを TraceItem として追加する際の出現回数計算、(c) React key の安定性確保
+- Structured Output の閲覧: 「`StructuredOutputToggle` の展開ボタン → JSON pre 表示」のフローのみに一本化。`spec_file_path` を検出する分岐と `onFileClick` 経由のリンクボタンを除去する
+- `onFileClick` プロパティの去就: `StructuredOutputToggle` が `spec_file_path` 専用リンク以外に使っていなければ、`StructuredOutputToggle` および呼び出し元（`WorkflowTrace` / `ParallelBlockRow` / `ParallelChildRow`）の `onFileClick` 受け渡しは全削除する。`WorkflowTraceProps` の `onFileClick`、さらに上位の呼び出し元から渡されている経路も実装時に辿って削除する
+
+### 状態Owner
+- ステップ履歴・結果文字列・Structured Output: Rustバックエンド（`workflow` ステート）が Owner。フロントは props 経由で受け取るのみ（変更なし）
+- `StructuredOutputToggle` の展開状態 (`expanded`): `StructuredOutputToggle` 内部の `useState`（変更なし）
+- 表示の出し分けロジック: `WorkflowTrace.tsx` 内の各サブコンポーネントが Owner。本変更で「出し分け自体を廃止する」とともに、出し分けに使っていたローカル状態・派生値もOwner側から削除する
+
+### 境界
+- 振る舞いの実現は `WorkflowTrace.tsx`（および `WorkflowTrace.test.tsx`、`onFileClick` を渡している上位呼び出し元）の編集のみで完結させる。Tauriコマンド・WebSocketプロトコル・Rust側ロジック・バックエンド共有型には触れない
+- 「描画停止のみ」の中途半端な状態を残さない: 表示削除に伴って参照されなくなった変数・関数・props・import・型フィールド・テストヘルパーは全て削除する
+- Verdictバッジ（`VerdictBadge`）のスタイル・対象値は変更しない。Resultテキスト行を除去し、完了ステップごとの結果表示は最大1つの Verdict バッジに正規化する。collect/reduce 由来で同一結果（`item.entry.result` と `reduceResult` が同値）が重複し得る場合も、Verdict バッジが2つ並ばないよう重複表示を抑止する
+- 並列子ステップ行（`ParallelChildRow`）内の `verdict` バッジと「verdictが無い場合の child.result バッジ」表示は本要求のスコープ外であり、変更しない
+- `EventTrace` および `CurrentAction` は本要求のスコープ外であり、変更しない
+
+### 実装に委ねること
+- 削除に伴って未使用になる変数・分岐・import・型フィールド（例: `occurrence` の run バッジ表示専用用途、`spec_file_path` 検出ロジック、`onFileClick` プロパティ連鎖、`TraceItem` 内の未使用フィールド）の具体的な削除手順。なお `seenCounts` は run バッジ表示専用の派生値（`occurrence` の表示用途）のみを削除対象とし、`currentAlreadyCompleted` 判定・現在ステップの出現回数計算・React key 安定性確保に必要な内部カウンタは維持する
+- `StructuredOutputToggle` のレイアウト微調整（`spec_file_path` ボタン除去後の余白・縦並び）
+- `TraceItemSummary` 完了ブロックの「Result行」除去後にトークン数・Viewボタンをどの行構造で残すかの細かなレイアウト
+- `WorkflowTrace.test.tsx` の既存テストのうち、削除対象UIを検証していたテストの扱い（削除 or 反転：「表示されない」の検証へ書き換え）と新規テストケースの具体的な書き方
+- 並列ブロック行サマリの「`completedCount`/`totalCount` completed」「tokens」表示の維持・整列方法
+- `onFileClick` を `WorkflowTrace` に渡している呼び出し元の追跡範囲と、上位プロパティ削除のチェイン
+

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
@@ -434,7 +434,7 @@ describe("WorkflowPanel", () => {
 		);
 
 		const reviewRow = screen.getByTestId("trace-item-review-1");
-		expect(within(reviewRow).getByText("Result: reject")).toBeInTheDocument();
+		expect(within(reviewRow).getByText("reject")).toBeInTheDocument();
 		expect(screen.getByText("Running fix")).toBeInTheDocument();
 		expect(
 			within(reviewRow).queryByRole("button", { name: "Approve step" }),

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
@@ -16,7 +16,6 @@ interface WorkflowPanelProps {
 	worktreePath: string;
 	chatSessionId: string | null;
 	onSessionClick?: (sessionId: string) => void;
-	onFileClick?: (path: string) => void;
 }
 
 export function WorkflowPanel({
@@ -24,7 +23,6 @@ export function WorkflowPanel({
 	worktreePath,
 	chatSessionId,
 	onSessionClick,
-	onFileClick,
 }: WorkflowPanelProps) {
 	const [executionIds, setExecutionIds] = useState<string[]>([]);
 	const [openPastIds, setOpenPastIds] = useState<string[]>([]);
@@ -196,18 +194,13 @@ export function WorkflowPanel({
 						workflowState={workflowState}
 						worktreePath={worktreePath}
 						onSessionClick={onSessionClick}
-						onFileClick={onFileClick}
 					/>
 				</TabsContent>
 			)}
 
 			{visiblePastIds.map((id) => (
 				<TabsContent key={id} value={id} className="flex-1 min-h-0 mt-0">
-					<ExecutionView
-						executionId={id}
-						onSessionClick={onSessionClick}
-						onFileClick={onFileClick}
-					/>
+					<ExecutionView executionId={id} onSessionClick={onSessionClick} />
 				</TabsContent>
 			))}
 
@@ -343,11 +336,9 @@ function NewWorkflowButton({ chatSessionId }: { chatSessionId: string }) {
 function ExecutionView({
 	executionId,
 	onSessionClick,
-	onFileClick,
 }: {
 	executionId: string;
 	onSessionClick?: (sessionId: string) => void;
-	onFileClick?: (path: string) => void;
 }) {
 	const [historyState, setHistoryState] = useState<WorkflowState | null>(null);
 	const [events, setEvents] = useState<WorkflowLogEvent[]>([]);
@@ -396,7 +387,6 @@ function ExecutionView({
 					workflowState={historyState}
 					events={events}
 					onSessionClick={onSessionClick}
-					onFileClick={onFileClick}
 				/>
 			</div>
 		</div>
@@ -407,12 +397,10 @@ function WorkflowActivePanel({
 	workflowState,
 	worktreePath,
 	onSessionClick,
-	onFileClick,
 }: {
 	workflowState: WorkflowState;
 	worktreePath: string;
 	onSessionClick?: (sessionId: string) => void;
-	onFileClick?: (path: string) => void;
 }) {
 	const isRunning =
 		workflowState.state.type === "running" ||
@@ -470,7 +458,6 @@ function WorkflowActivePanel({
 				<WorkflowTrace
 					workflowState={workflowState}
 					onSessionClick={onSessionClick}
-					onFileClick={onFileClick}
 					approvalAction={{
 						worktreePath,
 						executionId: workflowState.executionId,

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
@@ -56,6 +56,7 @@ describe("WorkflowTrace", () => {
 		expect(screen.getByText("plan")).toBeInTheDocument();
 		expect(screen.getByText("auto")).toBeInTheDocument();
 		expect(screen.getByText("Running")).toBeInTheDocument();
+		expect(screen.queryByText("run 1")).not.toBeInTheDocument();
 	});
 
 	it("shows waiting approval as the required current action", () => {
@@ -459,14 +460,45 @@ describe("WorkflowTrace", () => {
 			.getAllByText(/^(review|fix)$/)
 			.map((node) => node.textContent);
 		expect(stepNames).toEqual(["review", "fix", "review", "fix", "review"]);
-		expect(screen.getAllByText("Result: NEEDS_FIX")).toHaveLength(2);
-		expect(screen.getAllByText("Result: FIX_DONE")).toHaveLength(2);
-		expect(screen.getByText("Result: LGTM")).toBeInTheDocument();
-		expect(screen.getAllByText("run 1")).toHaveLength(2);
-		expect(screen.getAllByText("run 2")).toHaveLength(2);
-		expect(screen.getByText("run 3")).toBeInTheDocument();
+		expect(screen.getAllByText("NEEDS_FIX")).toHaveLength(2);
+		expect(screen.getAllByText("FIX_DONE")).toHaveLength(2);
+		expect(screen.getByText("LGTM")).toBeInTheDocument();
+		expect(screen.queryByText("Result: NEEDS_FIX")).not.toBeInTheDocument();
+		expect(screen.queryByText("Result: FIX_DONE")).not.toBeInTheDocument();
+		expect(screen.queryByText("Result: LGTM")).not.toBeInTheDocument();
+		expect(screen.queryByText("run 1")).not.toBeInTheDocument();
+		expect(screen.queryByText("run 2")).not.toBeInTheDocument();
+		expect(screen.queryByText("run 3")).not.toBeInTheDocument();
+		expect(screen.queryByText("#1")).not.toBeInTheDocument();
+		expect(screen.queryByText("#2")).not.toBeInTheDocument();
 		expect(screen.getByText("80 tokens")).toBeInTheDocument();
 		expect(screen.getByText("100 tokens")).toBeInTheDocument();
+	});
+
+	it("does not render order badge for a single-step workflow", () => {
+		render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					workflowDefinition: {
+						name: "test-workflow",
+						description: "test",
+						builtin: false,
+						steps: [
+							{
+								name: "plan",
+								mode: "auto",
+								instruction: "plan",
+								rules: [],
+							},
+						],
+					},
+					totalSteps: 1,
+					stepStates: { plan: "running" },
+				})}
+			/>,
+		);
+		expect(screen.getByText("plan")).toBeInTheDocument();
+		expect(screen.queryByText("#1")).not.toBeInTheDocument();
 	});
 
 	it("calls onSessionClick when a history entry View button is clicked", () => {
@@ -538,6 +570,7 @@ describe("WorkflowTrace", () => {
 		render(
 			<WorkflowTrace
 				workflowState={makeWorkflowState({
+					state: { type: "completed" },
 					stepStates: {
 						plan: "completed",
 						review: "pending",
@@ -555,6 +588,30 @@ describe("WorkflowTrace", () => {
 			/>,
 		);
 		expect(screen.getByText("Structured Output")).toBeInTheDocument();
+	});
+
+	it("does not render default Result text for completed step without result", () => {
+		render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					state: { type: "completed" },
+					stepStates: {
+						plan: "completed",
+						review: "pending",
+						fix: "pending",
+					},
+					stepHistory: [
+						{
+							stepName: "plan",
+							completedAt: 1001,
+							result: null,
+						},
+					],
+				})}
+			/>,
+		);
+		expect(screen.getByText("plan")).toBeInTheDocument();
+		expect(screen.queryByText("Result: completed")).not.toBeInTheDocument();
 	});
 
 	it("expands structuredOutput on toggle click", () => {
@@ -581,8 +638,7 @@ describe("WorkflowTrace", () => {
 		expect(screen.getByText(/"verdict": "LGTM"/)).toBeInTheDocument();
 	});
 
-	it("renders spec_file_path as clickable link and calls onFileClick", () => {
-		const onFileClick = vi.fn();
+	it("shows spec_file_path only inside expanded Structured Output JSON", () => {
 		render(
 			<WorkflowTrace
 				workflowState={makeWorkflowState({
@@ -602,13 +658,19 @@ describe("WorkflowTrace", () => {
 						},
 					],
 				})}
-				onFileClick={onFileClick}
 			/>,
 		);
-		const link = screen.getByText("docs/spec/issues-909.md");
-		expect(link).toBeInTheDocument();
-		fireEvent.click(link);
-		expect(onFileClick).toHaveBeenCalledWith("docs/spec/issues-909.md");
+		expect(
+			screen.queryByRole("button", { name: "docs/spec/issues-909.md" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText("docs/spec/issues-909.md"),
+		).not.toBeInTheDocument();
+		fireEvent.click(screen.getByText("Structured Output"));
+		expect(screen.getByText(/docs\/spec\/issues-909\.md/)).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "docs/spec/issues-909.md" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("shows VerdictBadge for collect step reduce result", () => {
@@ -659,8 +721,8 @@ describe("WorkflowTrace", () => {
 				})}
 			/>,
 		);
-		const badges = screen.getAllByText("NEEDS_FIX");
-		expect(badges.length).toBeGreaterThanOrEqual(1);
+		expect(screen.getAllByText("NEEDS_FIX")).toHaveLength(1);
+		expect(screen.queryByText("Result: NEEDS_FIX")).not.toBeInTheDocument();
 	});
 
 	it("renders parallel block with child steps", () => {
@@ -717,6 +779,8 @@ describe("WorkflowTrace", () => {
 		expect(screen.getByText("arch-review")).toBeInTheDocument();
 		expect(screen.getByText("security-review")).toBeInTheDocument();
 		expect(screen.getByText("1/2 completed")).toBeInTheDocument();
+		expect(screen.queryByText("#1")).not.toBeInTheDocument();
+		expect(screen.queryByText("run 1")).not.toBeInTheDocument();
 	});
 
 	it("renders completed parallel block from stepHistory with child steps and output", () => {
@@ -808,7 +872,8 @@ describe("WorkflowTrace", () => {
 		expect(screen.getByText("arch-review")).toBeInTheDocument();
 		expect(screen.getByText("security-review")).toBeInTheDocument();
 		expect(screen.getByText("2/2 completed")).toBeInTheDocument();
-		expect(screen.getByText("Result: then")).toBeInTheDocument();
+		expect(screen.queryByText("Result: then")).not.toBeInTheDocument();
+		expect(screen.queryByText("then")).not.toBeInTheDocument();
 		expect(screen.getByText("150 tokens")).toBeInTheDocument();
 		expect(
 			screen.getAllByText("Structured Output").length,
@@ -884,7 +949,8 @@ describe("WorkflowTrace", () => {
 				})}
 			/>,
 		);
-		expect(screen.getByText("Result: reject")).toBeInTheDocument();
+		expect(screen.getByText("reject")).toBeInTheDocument();
+		expect(screen.queryByText("Result: reject")).not.toBeInTheDocument();
 		fireEvent.click(screen.getByText("Structured Output"));
 		expect(
 			screen.getByText(/"Please fix the naming convention"/),

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
@@ -26,7 +26,6 @@ interface WorkflowTraceProps {
 	workflowState: WorkflowState;
 	events?: WorkflowLogEvent[];
 	onSessionClick?: (sessionId: string) => void;
-	onFileClick?: (path: string) => void;
 	approvalAction?: WorkflowApprovalActionContext;
 }
 
@@ -50,7 +49,6 @@ export function WorkflowTrace({
 	workflowState,
 	events = [],
 	onSessionClick,
-	onFileClick,
 	approvalAction,
 }: WorkflowTraceProps) {
 	const totalTokens =
@@ -70,11 +68,9 @@ export function WorkflowTrace({
 						<TraceItemRow
 							key={traceItemKey(item, index)}
 							item={item}
-							index={index}
 							isLast={index === traceItems.length - 1}
 							workflowState={workflowState}
 							onSessionClick={onSessionClick}
-							onFileClick={onFileClick}
 							approvalAction={approvalAction}
 						/>
 					))}
@@ -280,29 +276,23 @@ function traceItemKey(item: TraceItem, index: number) {
 
 function TraceItemRow({
 	item,
-	index,
 	isLast,
 	workflowState,
 	onSessionClick,
-	onFileClick,
 	approvalAction,
 }: {
 	item: TraceItem;
-	index: number;
 	isLast: boolean;
 	workflowState: WorkflowState;
 	onSessionClick?: (sessionId: string) => void;
-	onFileClick?: (path: string) => void;
 	approvalAction?: WorkflowApprovalActionContext;
 }) {
 	if (item.kind === "parallel") {
 		return (
 			<ParallelBlockRow
 				item={item}
-				index={index}
 				isLast={isLast}
 				onSessionClick={onSessionClick}
-				onFileClick={onFileClick}
 			/>
 		);
 	}
@@ -342,18 +332,8 @@ function TraceItemRow({
 					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
 						{stepMode}
 					</span>
-					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-						#{index + 1}
-					</span>
-					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-						run {item.occurrence}
-					</span>
 				</div>
-				<TraceItemSummary
-					item={item}
-					onSessionClick={onSessionClick}
-					onFileClick={onFileClick}
-				/>
+				<TraceItemSummary item={item} onSessionClick={onSessionClick} />
 				{approvalTarget && (
 					<StepApprovalActions
 						approvalAction={approvalTarget}
@@ -461,16 +441,12 @@ function StepApprovalActions({
 
 function ParallelBlockRow({
 	item,
-	index,
 	isLast,
 	onSessionClick,
-	onFileClick,
 }: {
 	item: Extract<TraceItem, { kind: "parallel" }>;
-	index: number;
 	isLast: boolean;
 	onSessionClick?: (sessionId: string) => void;
-	onFileClick?: (path: string) => void;
 }) {
 	const completedCount = item.childSteps.filter(
 		(cs) => cs.state === "completed",
@@ -508,18 +484,11 @@ function ParallelBlockRow({
 					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
 						parallel
 					</span>
-					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-						#{index + 1}
-					</span>
-					<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-						run {item.occurrence}
-					</span>
 				</div>
 				<div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
 					<span>
 						{completedCount}/{totalCount} completed
 					</span>
-					{item.entry?.result && <span>Result: {item.entry.result}</span>}
 					{tokenTotal != null && (
 						<span className="shrink-0">{tokenTotal} tokens</span>
 					)}
@@ -530,16 +499,12 @@ function ParallelBlockRow({
 							key={`${child.stepName}-${child.runIndex}`}
 							child={child}
 							onSessionClick={onSessionClick}
-							onFileClick={onFileClick}
 						/>
 					))}
 				</div>
 				{item.entry?.structuredOutput && (
 					<div className="mt-2">
-						<StructuredOutputToggle
-							output={item.entry.structuredOutput}
-							onFileClick={onFileClick}
-						/>
+						<StructuredOutputToggle output={item.entry.structuredOutput} />
 					</div>
 				)}
 			</div>
@@ -550,11 +515,9 @@ function ParallelBlockRow({
 function ParallelChildRow({
 	child,
 	onSessionClick,
-	onFileClick,
 }: {
 	child: ParallelStepState;
 	onSessionClick?: (sessionId: string) => void;
-	onFileClick?: (path: string) => void;
 }) {
 	const so = child.structuredOutput;
 	const verdict =
@@ -595,10 +558,7 @@ function ParallelChildRow({
 			</div>
 			{child.structuredOutput && (
 				<div className="ml-6">
-					<StructuredOutputToggle
-						output={child.structuredOutput}
-						onFileClick={onFileClick}
-					/>
+					<StructuredOutputToggle output={child.structuredOutput} />
 				</div>
 			)}
 		</div>
@@ -617,47 +577,52 @@ function StateIcon({ state }: { state: string }) {
 function TraceItemSummary({
 	item,
 	onSessionClick,
-	onFileClick,
 }: {
 	item: Exclude<TraceItem, { kind: "parallel" }>;
 	onSessionClick?: (sessionId: string) => void;
-	onFileClick?: (path: string) => void;
 }) {
 	if (item.kind === "completed") {
 		const tokenTotal = item.entry.tokenUsage
 			? item.entry.tokenUsage.inputTokens + item.entry.tokenUsage.outputTokens
 			: null;
-		const isCollectStep = item.step?.collect != null;
-		const reduceResult = isCollectStep ? item.entry.result : null;
+		const structuredOutput = item.entry.structuredOutput;
+		const hasSummary =
+			item.entry.result != null ||
+			tokenTotal != null ||
+			(item.sessionId != null && onSessionClick != null);
+		const hasStructuredOutput = structuredOutput != null;
+
+		if (!hasSummary && !hasStructuredOutput) {
+			return null;
+		}
 
 		return (
 			<div className="mt-1 space-y-1">
-				<div className="flex items-center gap-2 text-xs text-muted-foreground">
-					<span className="min-w-0 flex-1 truncate">
-						Result: {item.entry.result ?? "completed"}
-					</span>
-					{item.entry.result && <VerdictBadge verdict={item.entry.result} />}
-					{reduceResult && <VerdictBadge verdict={reduceResult} />}
-					{tokenTotal != null && (
-						<span className="shrink-0">{tokenTotal} tokens</span>
-					)}
-					{item.sessionId && onSessionClick && (
-						<button
-							type="button"
-							className="shrink-0 text-primary hover:underline"
-							onClick={() => {
-								if (item.sessionId) onSessionClick(item.sessionId);
-							}}
-						>
-							View
-						</button>
-					)}
-				</div>
-				{item.entry.structuredOutput && (
-					<StructuredOutputToggle
-						output={item.entry.structuredOutput}
-						onFileClick={onFileClick}
-					/>
+				{hasSummary && (
+					<div className="flex items-center gap-2 text-xs text-muted-foreground">
+						<div className="min-w-0 flex-1">
+							{item.entry.result && (
+								<VerdictBadge verdict={item.entry.result} />
+							)}
+						</div>
+						{tokenTotal != null && (
+							<span className="shrink-0">{tokenTotal} tokens</span>
+						)}
+						{item.sessionId && onSessionClick && (
+							<button
+								type="button"
+								className="shrink-0 text-primary hover:underline"
+								onClick={() => {
+									if (item.sessionId) onSessionClick(item.sessionId);
+								}}
+							>
+								View
+							</button>
+						)}
+					</div>
+				)}
+				{hasStructuredOutput && (
+					<StructuredOutputToggle output={structuredOutput} />
 				)}
 			</div>
 		);
@@ -707,34 +672,12 @@ function TraceItemSummary({
 	}
 }
 
-function StructuredOutputToggle({
-	output,
-	onFileClick,
-}: {
-	output: JsonValue;
-	onFileClick?: (path: string) => void;
-}) {
+function StructuredOutputToggle({ output }: { output: JsonValue }) {
 	const [expanded, setExpanded] = useState(false);
 	const json = JSON.stringify(output, null, 2);
-	const specFilePath =
-		output != null &&
-		typeof output === "object" &&
-		!Array.isArray(output) &&
-		typeof (output as Record<string, unknown>).spec_file_path === "string"
-			? ((output as Record<string, unknown>).spec_file_path as string)
-			: undefined;
 
 	return (
 		<div className="text-xs">
-			{specFilePath && (
-				<button
-					type="button"
-					className="text-primary hover:underline"
-					onClick={() => onFileClick?.(specFilePath)}
-				>
-					{specFilePath}
-				</button>
-			)}
 			<button
 				type="button"
 				className="flex items-center gap-1 text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
Closes #927

## Summary
- フロー内順序バッジ (`#1`/`#2`)、`run N` 実行回数バッジを廃止（UIから順序・実行回数は自明）
- Resultテキストと Verdict バッジの二重表示を解消し、Verdict バッジに一本化
- Structured Output が `spec_file_path` を持つときだけ表示していた専用リンクボタンを廃止
- 上記に対応する Spec (`docs/spec/issues-927.md`) を追加し、Gherkin で受け入れ基準を定義

## Test plan
- [ ] `pnpm test` (Vitest) が通る
- [ ] `pnpm lint` が通る
- [ ] `pnpm build` が通る
- [ ] ワークフロー実行画面のステップカードに順序バッジ・`run N` バッジ・`Result: ...` テキスト・`spec_file_path` 専用リンクが表示されないことを目視で確認
- [ ] 完了ステップで Verdict バッジが正しく1つだけ表示されることを目視で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)