### PR TITLE
fix: Approvalステップの承認アクションをステップ行内に配置 (#925)

### DIFF
--- a/docs/spec/issues-925.md
+++ b/docs/spec/issues-925.md
@@ -1,0 +1,179 @@
+## 要求
+
+**種別**: バグ修正
+
+**ゴール**:
+- ワークフローパネルにおいて、Approval ステップの承認系アクション（Approve / Reject）を、現在のようにパネル最上部の固定アクションバーではなく、対応するステップ行内（`WorkflowTrace` の該当 `TraceItem`）に表示する。
+- 並列ブロック実行中の承認（親ブロック単位・子ステップ単位の双方）は本Issueの対象外とし、後続Issueで扱う。現行バックエンドでは並列ブロック親ステップが `waiting_approval` 状態に遷移しないため、フロントエンドの行内承認UIだけを変更しても並列ブロックには適用できない。本Issueにバックエンド変更を含めるとスコープを大きく超えるため切り離す。
+- 同一ステップが cycle_guard やループ遷移により複数回実行されるケースでは、`occurrence` 番号で識別される「現在実行中の occurrence」の行にのみアクションボタンを表示し、過去 occurrence の完了行には表示しない。
+- ワークフロー全体に対するアクション（Stop = `abort_workflow`）は、これまで通りワークフロー単位のため、ステップ行内ではなくパネル上部に残す。Stop はステップに紐づかないので今回の移行対象には含めない。
+- 結果として「いまどのステップに対して操作しているのか」が画面上のボタン位置から一意に判別でき、複数 occurrence ステップとの紐づけもボタンの配置位置のみで識別可能となる。
+
+**スコープ確定（対象外の明示）**:
+- 本Issueの実装・テスト対象は **通常（非並列）Approval ステップの Approve / Reject の行内配置のみ**。
+- Interactive ステップの Complete は、Interactive モード自体が #944 (c6dcfa0) でビルトインから廃止済みであり、TypeScript の `StepMode` も `auto | approval` のみ、Rust 側 validation も `mode: interactive` を拒否する。よって Interactive Complete は **本Issueの実装・テスト対象外**（背景説明としてのみ登場する）。
+- 並列ブロック内の承認（親ブロック行内承認・子ステップ個別承認の双方）は **本Issueの実装・テスト対象外**。現行バックエンド (`src-tauri/src/workflow/validation.rs`) は並列ブロック内子ステップを `mode: auto` のみに制限しており、並列親ステップに対する `mode: approval` 指定も受け付けない。そのため並列ブロックが `waiting_approval` 状態に遷移するケースは現行仕様では発生せず、本Issueは並列ブロック行内に承認UIを描画しない（境界 Scenario で回帰防止を担保）。並列ブロック承認はバックエンド拡張を伴うため後続Issueで扱う。
+- Stop（ワークフロー全体中断）は移行対象ではなく現状維持。
+
+**背景**:
+- Issue #925 で「Interactive ステップの Complete ボタンがステップではなくワークフローの位置に表示されている」と報告されている。Interactive モード自体は #944 (c6dcfa0) でビルトインから廃止されたが、Approval ステップの Approve/Reject ボタンも全く同じ構造（パネル上部のアクションバー内に配置）で実装されており、根本的には同一の UI 設計上の不具合が残存している。
+- 現状 `WorkflowActivePanel`（`src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx` L406-584）はステップ単位の Approve/Reject をパネル最上部のアクションバー（L534-572）に置いており、`WorkflowTrace` で描画される「どのステップ行に対するアクションか」が視覚的に紐付かない。これが以下の具体的な課題を生んでいる:
+  - **どのステップに対するアクションか不明瞭**: トレースを下にスクロールしてステップ詳細を確認している際、ボタンは画面上部に固定されているため、操作対象のステップとボタンの空間的距離が遠く、関連付けが直感的に取れない。
+  - **複数回実行されるステップとの紐づけが不明**: cycle_guard やループにより同名ステップが複数 occurrence 実行される際、どの occurrence に対する承認なのかボタン位置からは判別できない。
+- 根本解決として、ステップに紐づくアクション（Approve / Reject / 旧 Complete）はステップ行内に配置し、ワークフローに紐づくアクション（Stop）のみ上部に残す、という責務分離を行う。これにより本 Issue（Interactive 由来の構造的不具合）と Approval ステップが現在抱える同種の問題、および複数 occurrence ステップへの紐づけ不明を同時に解消する。並列ブロック親・子ステップに対する承認はバックエンドAPIの拡張を伴うため別Issueで扱う。
+
+## 振る舞い定義
+
+```gherkin
+Feature: ワークフロー承認系アクションのステップ行内配置
+
+  対象ステップに紐づく承認系アクション（Approve / Reject）を、
+  パネル最上部の固定アクションバーではなく、操作対象のステップ行内に配置する。
+  ワークフロー全体に紐づく Stop アクションのみパネル上部に残す。
+  注: Interactive ステップの Complete は #944 (c6dcfa0) でビルトインから廃止済みであり、
+  TypeScript の StepMode は auto|approval のみ、Rust 側 validation も mode: interactive を
+  拒否するため、本 Feature では実装・テスト対象に含めず背景説明としてのみ参照する。
+
+  Rule: ステップ行内アクションによるワークフロー進行
+    Scenario: 承認待ちステップ行内の Approve でステップが承認される
+      Given ワークフローの currentStepName が "review" であり state.type が "waiting_approval" である
+      When ユーザーが "review" ステップ行内の Approve ボタンを押す
+      Then approve_workflow_step が decision: "approve" で呼び出される
+      And 状態遷移後、currentStepName が次ステップ "implement" となる
+      And 行内に表示されていた Approve / Reject ボタンは消える
+
+    Scenario: 承認待ちステップ行内の Reject でステップが拒否される
+      Given ワークフローの currentStepName が "review" であり state.type が "waiting_approval" である
+      And "review" ステップの rules に match: "reject" / next: "fix" が定義されている
+      When ユーザーが "review" 行内の Reject ボタンから "needs fix" というコメントを添えて送信する
+      Then approve_workflow_step が decision: { reject: { comment: "needs fix" } } で呼び出される
+      And stepHistory に追加された "review" エントリの result が "reject" となる
+      And currentStepName が match: reject の遷移先 "fix" となる
+      And 行内に表示されていた Approve / Reject ボタンは消える
+
+    Scenario: Approve が API エラーで失敗した場合に行内へエラーが表示される
+      Given ワークフローの currentStepName が "review" で state.type が "waiting_approval" である
+      When ユーザーが "review" 行内の Approve ボタンを押し、approve_workflow_step が拒否エラー（例: 承認競合・既に他クライアントが承認済み）を返す
+      Then useStepApprovalAction の approvalError が更新される
+      And "review" 行内に approvalError のメッセージが表示される
+      And 当該ステップ行は承認待ち表示のまま維持され、サイレントに失敗しない
+
+    Scenario: Reject が API エラーで失敗した場合に行内へエラーが表示される
+      Given ワークフローの currentStepName が "review" で state.type が "waiting_approval" である
+      When ユーザーが "review" 行内の Reject にコメントを添えて送信し、approve_workflow_step がエラーを返す
+      Then useStepApprovalAction の approvalError にエラーメッセージが保持される
+      And "review" 行内にエラーメッセージが表示され、Reject 入力欄は維持される（再送信が可能である）
+
+    Scenario: Reject コメントが空または空白のみの場合は送信不可
+      Given ワークフローの currentStepName が "review" で state.type が "waiting_approval" である
+      And ユーザーが "review" 行内の Reject 入力欄を開き、コメントが空または空白のみ（例: "", "   ", "\n"）である
+      When ユーザーが Reject 送信を試みる
+      Then 送信ボタンは disabled である
+      And approve_workflow_step は呼び出されない
+
+    Scenario: Reject コメントが上限（8192 文字）を超える場合は行内にエラーが表示される
+      Given ワークフローの currentStepName が "review" で state.type が "waiting_approval" である
+      And ユーザーが "review" 行内の Reject 入力欄に 8192 文字を超えるコメントを入力している
+      When ユーザーが Reject 送信を実行する
+      Then approve_workflow_step がバックエンド側 validation により拒否エラーを返す
+      And useStepApprovalAction の approvalError にエラーメッセージが保持される
+      And "review" 行内にエラーメッセージが表示される
+      And Reject 入力欄は維持され、入力内容も保持され、再送信が可能である
+
+  Rule: ワークフロー全体アクションによる中断
+    Scenario: パネル上部の Stop でワークフロー全体が中断される
+      Given ワークフローが実行中または承認待ち状態である
+      When ユーザーがパネル上部の Stop ボタンを押す
+      Then abort_workflow が呼び出され、実行中のワークフロー全体が中断される
+
+    Scenario: Stop が API エラーで失敗した場合にパネル上部にエラーが表示される
+      Given ワークフローが実行中または承認待ち状態である
+      When ユーザーがパネル上部の Stop ボタンを押し、abort_workflow がエラーを返す
+      Then パネル上部にエラーメッセージが表示される
+      And ワークフローは中断されないまま継続表示され、サイレントに失敗しない
+
+  Rule: ステップに紐づく承認系アクションの表示位置
+    Scenario: 承認待ちの通常ステップ行にのみ Approve/Reject が表示される
+      Given ワークフローの currentStepName が "review"、state.type が "waiting_approval"、approvalOperations.canReject が true である
+      And "review" の TraceItem が kind: "current" として描画されている
+      When ユーザーがワークフローパネルを閲覧する
+      Then "review" の TraceItem 行内にのみ Approve / Reject ボタンが表示される
+      And パネル最上部のアクションバーには承認系ボタンが表示されない
+
+    Scenario: 並列ブロック行内には承認系ボタンを描画しない（本Issueでは対象外）
+      Given ワークフローパネルに kind: "parallel" の TraceItem（親並列ブロック行）が描画されている
+      When ユーザーがワークフローパネルを閲覧する
+      Then 当該並列ブロック行（kind: "parallel" の親行）内には承認系ボタンが表示されない
+      And 並列ブロック内の子ステップ行にも承認系ボタンが表示されない
+
+    Scenario: 現在実行中の occurrence 行にのみ承認系ボタンが表示される
+      Given workflowState.currentStepName が "review"、state.type が "waiting_approval" である
+      And workflowState.stepExecutionCounts["review"] が 2 である
+      And buildTraceItems が "review" について 2 行を返し、run 1 は kind: "completed" / occurrence: 1、run 2 は kind: "current" / occurrence: 2 である
+      When ユーザーがワークフローパネルを閲覧する
+      Then "review" の run 2（kind: "current" / occurrence: 2）の行にのみ承認系ボタンが表示される
+      And "review" の run 1（kind: "completed" / occurrence: 1）の行には承認系ボタンが表示されない
+
+    Scenario: 拒否が許可されていない場合は Reject ボタンが表示されない
+      Given ワークフローの currentStepName が "review"、state.type が "waiting_approval"、approvalOperations.canReject が false である
+      And "review" の TraceItem が kind: "current" として描画されている
+      When ユーザーがワークフローパネルを閲覧する
+      Then "review" の TraceItem 行内には Approve ボタンのみが表示され、Reject ボタンは表示されない
+
+  Rule: ワークフローに紐づくアクションの表示位置
+    Scenario: ワークフロー実行中はパネル上部に Stop ボタンが表示される
+      Given ワークフローが実行中または承認待ち状態である
+      When ユーザーがワークフローパネルを閲覧する
+      Then パネル上部に Stop ボタンが表示される
+      And Stop ボタンはステップ行内には表示されない
+```
+
+## アーキテクチャ概要
+
+### 責務配置
+- `WorkflowPanel.tsx` / `WorkflowActivePanel`: タブ管理・パネル上部アクションバーの描画・ワークフロー全体アクション（Stop）の発火、および Stop API 呼び出し失敗時のエラー（`abortError`）の保持・パネル上部での表示を担当。ステップ単位の承認系UI状態・API呼び出しは担当しない。
+- `WorkflowTrace.tsx`（`TraceItemRow` / `ParallelBlockRow`）: ステップ行のレイアウト描画と「この行が現在の承認対象か」の判定を担当。承認アクションUI状態の保持は担当しない。判定条件は既存 `TraceItem` 型に整合させ、以下のとおりとする:
+  - 共通条件: `workflowState.state.type === "waiting_approval"` かつ `item.stepName === workflowState.currentStepName`。
+  - 通常ステップ行: 上記共通条件に加えて `item.kind === "current"` の行が現在の承認対象であり、その行内に承認系UIを描画する。
+  - 並列ブロック行（`item.kind === "parallel"`）: 本Issueでは承認対象外とし、行内に承認系UIを一切描画しない。現行バックエンドでは並列親ステップが `waiting_approval` 状態に遷移しないため、フロントエンド単独で並列ブロック内承認を実現できない。並列ブロック承認の対応は後続Issueで扱う。
+  - 過去 occurrence（`item.kind === "completed"` の行）: 承認系UIを描画しない。
+- 新規カスタムフック `useStepApprovalAction`（`src/hooks/` 配下、Rust側ロジックは触らないReactレイヤー専用）: 行内承認UIから使う承認アクションUI状態（rejectMode / rejectComment / approvalError）と、`approve_workflow_step` Tauriコマンド呼び出しを担当。承認可否そのものの判定や、ワークフロー進行ロジックは担当しない。
+- Tauriバックエンド（`src-tauri/src/workflow/`）: 承認対象の妥当性検証・承認/拒否の適用・`approvalOperations.canReject` の算出・ワークフロー状態遷移・`abort_workflow`。今回スコープでは変更なし。
+
+### データ/通信フロー
+- ワークフロー状態の取得: Rust `WorkflowEngine` → イベント/Tauriコマンド → `WorkflowState` → `WorkflowActivePanel` → `WorkflowTrace` で `buildTraceItems` により行列を構築 → 現在承認待ちの行を判別。
+- Approve操作: ステップ行内Approveボタン → `useStepApprovalAction` → `invoke("approve_workflow_step", { worktreePath, executionId, stepName, decision: "approve" })` → Rust側で状態遷移 → 新しい `WorkflowState` がUIへ反映。
+- Reject操作: 行内Rejectボタンで reject mode を ON → コメント入力 → Submit → `useStepApprovalAction` → `invoke("approve_workflow_step", { worktreePath, executionId, stepName, decision: { reject: { comment } } })`。エラー時は `approvalError` をフックが保持し行内に表示。
+- Stop操作（変更なし）: パネル上部Stopボタン → `WorkflowActivePanel` → `invoke("abort_workflow", { worktreePath })`。
+
+### worktree-scoped command context の受け渡し契約
+- `worktreePath` および `executionId` は `WorkflowActivePanel` が所有する（既存と同じ）。
+- 承認系アクションを行内で発火するため、`WorkflowActivePanel` はこれらを「承認アクション用 context」として `WorkflowTrace` 経由で行コンポーネント（`TraceItemRow`）へ渡す。
+- 既存 `WorkflowTraceProps` を拡張し、`approvalAction?: { worktreePath: string; executionId: string }` を **optional props** として追加する。これは行内承認UIの描画と Tauri command 発火に必要な context をひとまとめにし、`WorkflowTrace` を承認 context 不要の場面（履歴表示等）でも従来通り再利用可能にするための契約である。
+- 履歴表示用途（例: `ExecutionView` のように完了済みワークフローを閲覧するだけの呼び出し元）では `approvalAction` を **指定しない**。`approvalAction` が未指定（`undefined`）の場合、`WorkflowTrace` および行コンポーネントは行内に承認系UIを一切描画しない契約とする。
+- `approvalAction` が指定された場合のみ、行コンポーネントは承認対象判定（共通条件 + `kind === "current"`）を満たす行で `useStepApprovalAction` を呼び出し、`approvalAction` の `worktreePath` / `executionId` をフックに渡す。その他のワークフロー状態（`canReject` 等）は既存どおり `WorkflowState` 由来の派生値として props 経由で受け取る。
+- `useStepApprovalAction` は受け取った `worktreePath` / `executionId` / `stepName` を Tauri command 引数に転送するのみで、自前で context を解決しない。
+
+### 状態Owner
+- ワークフロー実行状態 (`WorkflowState`、承認可否を含む `approvalOperations`): Rust `WorkflowEngine`。
+- 承認アクションUI状態 (rejectMode / rejectComment / approvalError): `useStepApprovalAction` フック（行コンポーネント内で呼び出して保持）。
+- Stop アクションのエラー状態 (`abortError`): `WorkflowActivePanel`。パネル上部のアクションバー領域に表示する。
+- パネルのタブ表示状態 (activeTab / openPastIds / historyOpen 等): `WorkflowPanel`（変更なし）。
+- 「どの行が承認対象か」の派生情報: `WorkflowTrace` の `buildTraceItems`（既存ロジックを継続利用）。本Issueでは通常ステップのみが承認対象であり、`kind === "current"` の行で識別する（並列ブロック行 `kind === "parallel"` は本Issueでは承認対象外）。
+
+### 境界
+- 承認系アクションUI（Approve / Reject / Reject comment 入力 / approvalError 表示）は、ステップ行コンポーネントの内部に閉じる。`WorkflowActivePanel` 直下のアクションバーには配置しない。
+- パネル上部アクションバーはワークフロー単位アクション（現状は Stop のみ）に限定する。
+- 過去 occurrence の行には承認系UIを描画しない。「現在実行中の occurrence」の判定は `buildTraceItems` が返す `item.kind === "current"` で識別する（履歴由来の通常ステップ行は `kind === "completed"` となるため、`kind` 一致で一意に判別可能）。行コンポーネント内で独自の occurrence 比較ロジックや stepHistory への参照は持ち込まず、`buildTraceItems` が返す `kind` / `stepName` と上位から渡される `workflowState` のフィールド（`currentStepName` / `state.type`）の比較のみで判定する。
+- 並列ブロック行（`kind === "parallel"`）は本Issueでは承認対象外とし、親行・子ステップのいずれにも承認系UIを描画しない。並列ブロック承認はバックエンドAPI拡張を伴うため後続Issueで扱う。
+- `useStepApprovalAction` は Tauriコマンドを直接 invoke するが、「承認待ちか」「Rejectが許可されているか」の判定は引数で受け取り、自前で `WorkflowState` を解釈しない。
+- `approvalAction` props が未指定の `WorkflowTrace` 呼び出し（履歴表示等）では、承認系UIを行内に描画しない。これにより `WorkflowTrace` を承認 context 不要の場面でも再利用可能とする。
+
+### 実装に委ねること
+- 行内承認UIの具体的なレイアウト（ボタン配置順、Reject comment 入力欄の展開方向、エラーメッセージの表示位置・色味）。
+- `useStepApprovalAction` の関数シグネチャ詳細（引数のまとめ方、返り値オブジェクトのキー名、リセットトリガーの渡し方）。
+- ステップ行の承認UIをサブコンポーネントに切り出すか、`TraceItemRow` / `ParallelBlockRow` 内にインライン展開するかの粒度。
+- Reject comment 入力時のキーボードショートカット（Cmd+Enter で送信等）の有無。
+- テストケースの具体的配置（`WorkflowPanel.test.tsx` 既存ファイルに追記するか、`useStepApprovalAction.test.ts` を新設するか）。
+- 既存 `WorkflowActivePanel` 内のアクションバー関連ステート/ハンドラ（`rejectMode`, `rejectComment`, `approvalError`, `handleApprove`, `handleReject*`）の最終的な削除/移譲の細部。
+

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkflowState } from "@/types/workflow";
 
@@ -89,6 +95,11 @@ describe("WorkflowPanel", () => {
 		expect(
 			screen.getByRole("button", { name: "Stop workflow" }),
 		).toBeInTheDocument();
+		expect(
+			within(screen.getByTestId("trace-item-step-1-1")).queryByRole("button", {
+				name: "Stop workflow",
+			}),
+		).not.toBeInTheDocument();
 	});
 
 	it("shows Stop button when waiting_approval", () => {
@@ -148,6 +159,57 @@ describe("WorkflowPanel", () => {
 		});
 	});
 
+	it("shows abort command errors in the top action area", async () => {
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "abort_workflow") {
+				return Promise.reject("abort failed");
+			}
+			return Promise.resolve([]);
+		});
+
+		render(
+			<WorkflowPanel
+				workflowState={makeWorkflowState()}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Stop workflow" }));
+
+		expect(await screen.findByRole("alert")).toHaveTextContent("abort failed");
+	});
+
+	it("clears abort command errors when workflow identity changes", async () => {
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "abort_workflow") {
+				return Promise.reject("abort failed");
+			}
+			return Promise.resolve([]);
+		});
+
+		const { rerender } = render(
+			<WorkflowPanel
+				workflowState={makeWorkflowState()}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Stop workflow" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent("abort failed");
+
+		rerender(
+			<WorkflowPanel
+				workflowState={makeWorkflowState({ executionId: "exec-002" })}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		});
+	});
+
 	it("shows current execution as a tab with workflow name", () => {
 		render(
 			<WorkflowPanel
@@ -195,12 +257,18 @@ describe("WorkflowPanel", () => {
 				chatSessionId="session-1"
 			/>,
 		);
+		const currentRow = screen.getByTestId("trace-item-step-1-1");
 		expect(
-			screen.getByRole("button", { name: "Approve step" }),
+			within(currentRow).getByRole("button", { name: "Approve step" }),
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole("button", { name: "Reject step" }),
+			within(currentRow).getByRole("button", { name: "Reject step" }),
 		).toBeInTheDocument();
+		expect(
+			screen
+				.getByRole("button", { name: "Stop workflow" })
+				.parentElement?.querySelector('[aria-label="Approve step"]'),
+		).not.toBeInTheDocument();
 	});
 
 	it("hides Reject button when waiting_approval cannot reject", () => {
@@ -214,11 +282,12 @@ describe("WorkflowPanel", () => {
 				chatSessionId="session-1"
 			/>,
 		);
+		const currentRow = screen.getByTestId("trace-item-step-1-1");
 		expect(
-			screen.getByRole("button", { name: "Approve step" }),
+			within(currentRow).getByRole("button", { name: "Approve step" }),
 		).toBeInTheDocument();
 		expect(
-			screen.queryByRole("button", { name: "Reject step" }),
+			within(currentRow).queryByRole("button", { name: "Reject step" }),
 		).not.toBeInTheDocument();
 	});
 
@@ -260,9 +329,12 @@ describe("WorkflowPanel", () => {
 				chatSessionId="session-1"
 			/>,
 		);
-		fireEvent.click(screen.getByRole("button", { name: "Approve step" }));
+		const currentRow = screen.getByTestId("trace-item-step-1-1");
+		fireEvent.click(
+			within(currentRow).getByRole("button", { name: "Approve step" }),
+		);
 
-		expect(await screen.findByRole("alert")).toHaveTextContent(
+		expect(await within(currentRow).findByRole("alert")).toHaveTextContent(
 			"Workflow approval is no longer available for the current step.",
 		);
 	});
@@ -285,12 +357,34 @@ describe("WorkflowPanel", () => {
 		).toBeDisabled();
 	});
 
-	it("invokes approve_workflow_step with reject comment when submitted", async () => {
-		render(
+	it("invokes approve_workflow_step with reject comment when submitted and clears row actions after transition", async () => {
+		const workflowDefinition = {
+			name: "test-workflow",
+			description: "test",
+			builtin: false,
+			steps: [
+				{
+					name: "review",
+					mode: "approval" as const,
+					instruction: "review",
+					rules: [{ match: "reject", next: "fix" }],
+				},
+				{ name: "fix", mode: "auto" as const, instruction: "fix", rules: [] },
+			],
+		} satisfies WorkflowState["workflowDefinition"];
+		const { rerender } = render(
 			<WorkflowPanel
 				workflowState={makeWorkflowState({
 					state: { type: "waiting_approval" },
+					currentStepName: "review",
+					currentStepIndex: 0,
+					totalSteps: 2,
 					approvalOperations: { canReject: true },
+					stepStates: {
+						review: "waiting_approval",
+						fix: "pending",
+					},
+					workflowDefinition,
 				})}
 				worktreePath="/repo"
 				chatSessionId="session-1"
@@ -308,11 +402,46 @@ describe("WorkflowPanel", () => {
 			worktreePath: "/repo",
 			decision: { reject: { comment: "Please fix the bug" } },
 			executionId: "exec-001",
-			stepName: "step-1",
+			stepName: "review",
 		});
 		await waitFor(() => {
 			expect(screen.queryByLabelText("Reject comment")).not.toBeInTheDocument();
 		});
+
+		rerender(
+			<WorkflowPanel
+				workflowState={makeWorkflowState({
+					state: { type: "running" },
+					currentStepName: "fix",
+					currentStepIndex: 1,
+					totalSteps: 2,
+					stepStates: {
+						review: "completed",
+						fix: "running",
+					},
+					stepHistory: [
+						{
+							stepName: "review",
+							completedAt: 1001,
+							result: "reject",
+						},
+					],
+					workflowDefinition,
+				})}
+				worktreePath="/repo"
+				chatSessionId="session-1"
+			/>,
+		);
+
+		const reviewRow = screen.getByTestId("trace-item-review-1");
+		expect(within(reviewRow).getByText("Result: reject")).toBeInTheDocument();
+		expect(screen.getByText("Running fix")).toBeInTheDocument();
+		expect(
+			within(reviewRow).queryByRole("button", { name: "Approve step" }),
+		).not.toBeInTheDocument();
+		expect(
+			within(reviewRow).queryByRole("button", { name: "Reject step" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("hides reject form after successful submit", async () => {

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
@@ -420,9 +420,13 @@ function WorkflowActivePanel({
 
 	const [abortError, setAbortError] = useState<string | null>(null);
 
-	useEffect(() => {
+	const abortIdentityKey = `${worktreePath}|${workflowState.executionId}|${workflowState.state.type}`;
+	const [prevAbortIdentityKey, setPrevAbortIdentityKey] =
+		useState(abortIdentityKey);
+	if (prevAbortIdentityKey !== abortIdentityKey) {
+		setPrevAbortIdentityKey(abortIdentityKey);
 		setAbortError(null);
-	}, [worktreePath, workflowState.executionId, workflowState.state.type]);
+	}
 
 	const handleAbort = useCallback(() => {
 		invoke("abort_workflow", { worktreePath })

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { Check, History, Square, X } from "lucide-react";
+import { AlertTriangle, History, Square, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
 	Popover,
@@ -418,145 +418,35 @@ function WorkflowActivePanel({
 		workflowState.state.type === "running" ||
 		workflowState.state.type === "waiting_approval";
 
-	const isWaitingApproval = workflowState.state.type === "waiting_approval";
-	const canReject = workflowState.approvalOperations?.canReject === true;
+	const [abortError, setAbortError] = useState<string | null>(null);
 
-	const [rejectMode, setRejectMode] = useState(false);
-	const [rejectComment, setRejectComment] = useState("");
-	const [approvalError, setApprovalError] = useState<string | null>(null);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reset reject form when step/execution/approval state changes
 	useEffect(() => {
-		setRejectMode(false);
-		setRejectComment("");
-		setApprovalError(null);
-	}, [
-		workflowState.executionId,
-		workflowState.currentStepName,
-		isWaitingApproval,
-	]);
+		setAbortError(null);
+	}, [worktreePath, workflowState.executionId, workflowState.state.type]);
 
 	const handleAbort = useCallback(() => {
-		invoke("abort_workflow", { worktreePath }).catch((e) =>
-			console.warn("[WorkflowPanel] abort_workflow failed", e),
-		);
+		invoke("abort_workflow", { worktreePath })
+			.then(() => setAbortError(null))
+			.catch((e) => {
+				console.warn("[WorkflowPanel] abort_workflow failed", e);
+				setAbortError(String(e));
+			});
 	}, [worktreePath]);
-
-	const handleApprove = useCallback(() => {
-		invoke("approve_workflow_step", {
-			worktreePath,
-			decision: "approve",
-			executionId: workflowState.executionId,
-			stepName: workflowState.currentStepName,
-		})
-			.then(() => setApprovalError(null))
-			.catch((e) => {
-				console.warn("[WorkflowPanel] approve_workflow_step failed", e);
-				setApprovalError(formatWorkflowApprovalError(e));
-			});
-	}, [worktreePath, workflowState.executionId, workflowState.currentStepName]);
-
-	const handleRejectClick = useCallback(() => {
-		setRejectMode(true);
-	}, []);
-
-	const handleRejectSubmit = useCallback(() => {
-		invoke("approve_workflow_step", {
-			worktreePath,
-			decision: { reject: { comment: rejectComment } },
-			executionId: workflowState.executionId,
-			stepName: workflowState.currentStepName,
-		})
-			.then(() => {
-				setRejectMode(false);
-				setRejectComment("");
-				setApprovalError(null);
-			})
-			.catch((e) => {
-				console.warn("[WorkflowPanel] approve_workflow_step failed", e);
-				setApprovalError(formatWorkflowApprovalError(e));
-			});
-	}, [
-		worktreePath,
-		rejectComment,
-		workflowState.executionId,
-		workflowState.currentStepName,
-	]);
-
-	const handleRejectCancel = useCallback(() => {
-		setRejectMode(false);
-		setRejectComment("");
-	}, []);
 
 	return (
 		<div className="flex flex-col h-full overflow-hidden">
-			{approvalError && (
+			{abortError && (
 				<div
 					role="alert"
 					className="flex items-start gap-2 px-3 py-2 border-b bg-red-500/10 text-red-700 dark:text-red-300 text-xs shrink-0"
 				>
-					<X className="size-3.5 mt-0.5 shrink-0" />
-					<span>{approvalError}</span>
-				</div>
-			)}
-			{/* Reject comment input */}
-			{isWaitingApproval && rejectMode && (
-				<div className="flex flex-col gap-1.5 px-3 py-2 border-b shrink-0">
-					<textarea
-						className="w-full px-2 py-1 text-xs rounded border bg-background resize-none"
-						rows={3}
-						placeholder="Reject comment..."
-						value={rejectComment}
-						onChange={(e) => setRejectComment(e.target.value)}
-						aria-label="Reject comment"
-					/>
-					<div className="flex items-center gap-2 justify-end">
-						<button
-							type="button"
-							onClick={handleRejectCancel}
-							className="px-2 py-0.5 text-xs rounded bg-muted hover:bg-muted/80 transition-colors"
-						>
-							Cancel
-						</button>
-						<button
-							type="button"
-							onClick={handleRejectSubmit}
-							disabled={rejectComment.trim().length === 0}
-							className="px-2 py-0.5 text-xs rounded bg-yellow-500/20 text-yellow-700 dark:text-yellow-300 hover:bg-yellow-500/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-							aria-label="Submit reject"
-						>
-							Reject
-						</button>
-					</div>
+					<AlertTriangle className="size-3.5 mt-0.5 shrink-0" />
+					<span>{abortError}</span>
 				</div>
 			)}
 			{/* Action bar */}
 			<div className="flex items-center justify-end px-3 py-1.5 border-b shrink-0">
 				<div className="flex items-center gap-2">
-					{isWaitingApproval && !rejectMode && (
-						<>
-							<button
-								type="button"
-								onClick={handleApprove}
-								className="flex items-center gap-1 px-2 py-0.5 text-xs rounded bg-green-500/20 text-green-700 dark:text-green-300 hover:bg-green-500/30 transition-colors"
-								aria-label="Approve step"
-							>
-								<Check className="size-3" />
-								Approve
-							</button>
-							{canReject && (
-								<button
-									type="button"
-									onClick={handleRejectClick}
-									className="flex items-center gap-1 px-2 py-0.5 text-xs rounded bg-yellow-500/20 text-yellow-700 dark:text-yellow-300 hover:bg-yellow-500/30 transition-colors"
-									aria-label="Reject step"
-								>
-									<X className="size-3" />
-									Reject
-								</button>
-							)}
-						</>
-					)}
 					{isRunning && (
 						<button
 							type="button"
@@ -577,27 +467,14 @@ function WorkflowActivePanel({
 					workflowState={workflowState}
 					onSessionClick={onSessionClick}
 					onFileClick={onFileClick}
+					approvalAction={{
+						worktreePath,
+						executionId: workflowState.executionId,
+					}}
 				/>
 			</div>
 		</div>
 	);
-}
-
-function formatWorkflowApprovalError(error: unknown): string {
-	const message = String(error);
-	if (message.startsWith("invalid_state:")) {
-		return "Workflow approval is no longer available for the current step.";
-	}
-	if (message.startsWith("validation_error:")) {
-		return message.replace(/^validation_error:\s*/, "");
-	}
-	if (message.startsWith("unauthorized_worktree:")) {
-		return "This approval belongs to a different worktree.";
-	}
-	if (message.startsWith("unauthorized_approval_target:")) {
-		return "This approval request no longer matches the current workflow step.";
-	}
-	return message;
 }
 
 function StatusBadge({ state }: { state: string }) {

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
@@ -1,9 +1,4 @@
-import {
-	fireEvent,
-	render,
-	screen,
-	within,
-} from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkflowState } from "@/types/workflow";
 import { WorkflowTrace } from "./WorkflowTrace";

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
@@ -1,7 +1,17 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import {
+	fireEvent,
+	render,
+	screen,
+	within,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkflowState } from "@/types/workflow";
 import { WorkflowTrace } from "./WorkflowTrace";
+
+const mockInvoke = vi.fn().mockResolvedValue(undefined);
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
 
 function makeWorkflowState(
 	overrides: Partial<WorkflowState> = {},
@@ -35,6 +45,11 @@ function makeWorkflowState(
 }
 
 describe("WorkflowTrace", () => {
+	beforeEach(() => {
+		mockInvoke.mockReset();
+		mockInvoke.mockResolvedValue(undefined);
+	});
+
 	it("shows current action and total token usage", () => {
 		render(<WorkflowTrace workflowState={makeWorkflowState()} />);
 		expect(screen.getByText("Running plan")).toBeInTheDocument();
@@ -69,6 +84,335 @@ describe("WorkflowTrace", () => {
 		expect(screen.getByText("review")).toBeInTheDocument();
 		expect(screen.getByText("approval")).toBeInTheDocument();
 		expect(screen.getByText("Waiting for approval")).toBeInTheDocument();
+	});
+
+	it("renders approval actions inside the current waiting step row when context is provided", () => {
+		render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+					currentStepName: "review",
+					currentStepIndex: 1,
+					approvalOperations: { canReject: true },
+					stepStates: {
+						plan: "completed",
+						review: "waiting_approval",
+						fix: "pending",
+					},
+				})}
+				approvalAction={{
+					worktreePath: "/repo",
+					executionId: "exec-001",
+				}}
+			/>,
+		);
+
+		const reviewRow = screen.getByTestId("trace-item-review-1");
+		expect(
+			within(reviewRow).getByRole("button", { name: "Approve step" }),
+		).toBeInTheDocument();
+		expect(
+			within(reviewRow).getByRole("button", { name: "Reject step" }),
+		).toBeInTheDocument();
+	});
+
+	it("does not render approval actions without approval context", () => {
+		render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+					currentStepName: "review",
+					currentStepIndex: 1,
+					approvalOperations: { canReject: true },
+					stepStates: {
+						plan: "completed",
+						review: "waiting_approval",
+						fix: "pending",
+					},
+				})}
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("button", { name: "Approve step" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Reject step" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("invokes approve_workflow_step from the current step row and clears row actions after transition", () => {
+		const { rerender } = render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+					currentStepName: "review",
+					currentStepIndex: 1,
+					stepStates: {
+						plan: "completed",
+						review: "waiting_approval",
+						fix: "pending",
+					},
+				})}
+				approvalAction={{
+					worktreePath: "/repo",
+					executionId: "exec-001",
+				}}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Approve step" }));
+
+		expect(mockInvoke).toHaveBeenCalledWith("approve_workflow_step", {
+			worktreePath: "/repo",
+			decision: "approve",
+			executionId: "exec-001",
+			stepName: "review",
+		});
+
+		rerender(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					state: { type: "running" },
+					currentStepName: "fix",
+					currentStepIndex: 2,
+					stepStates: {
+						plan: "completed",
+						review: "completed",
+						fix: "running",
+					},
+					stepHistory: [
+						{
+							stepName: "review",
+							completedAt: 1001,
+							result: "approve",
+						},
+					],
+				})}
+				approvalAction={{
+					worktreePath: "/repo",
+					executionId: "exec-001",
+				}}
+			/>,
+		);
+
+		const reviewRow = screen.getByTestId("trace-item-review-1");
+		expect(
+			within(reviewRow).queryByRole("button", { name: "Approve step" }),
+		).not.toBeInTheDocument();
+		expect(
+			within(reviewRow).queryByRole("button", { name: "Reject step" }),
+		).not.toBeInTheDocument();
+		expect(screen.getByText("Running fix")).toBeInTheDocument();
+	});
+
+	it("keeps reject input and shows row error when reject command fails", async () => {
+		mockInvoke.mockRejectedValue("validation_error: comment is too long");
+
+		render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+					currentStepName: "review",
+					currentStepIndex: 1,
+					approvalOperations: { canReject: true },
+					stepStates: {
+						plan: "completed",
+						review: "waiting_approval",
+						fix: "pending",
+					},
+				})}
+				approvalAction={{
+					worktreePath: "/repo",
+					executionId: "exec-001",
+				}}
+			/>,
+		);
+
+		const row = screen.getByTestId("trace-item-review-1");
+		fireEvent.click(within(row).getByRole("button", { name: "Reject step" }));
+		fireEvent.change(within(row).getByLabelText("Reject comment"), {
+			target: { value: "x".repeat(8193) },
+		});
+		fireEvent.click(within(row).getByRole("button", { name: "Submit reject" }));
+
+		expect(await within(row).findByRole("alert")).toHaveTextContent(
+			"comment is too long",
+		);
+		expect(within(row).getByLabelText("Reject comment")).toHaveValue(
+			"x".repeat(8193),
+		);
+	});
+
+	it("renders approval actions only on the current occurrence row", () => {
+		render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+					currentStepName: "review",
+					currentStepIndex: 1,
+					stepExecutionCounts: { review: 2 },
+					approvalOperations: { canReject: true },
+					stepStates: {
+						plan: "completed",
+						review: "waiting_approval",
+						fix: "pending",
+					},
+					stepHistory: [
+						{
+							stepName: "review",
+							completedAt: 1001,
+							result: "reject",
+						},
+					],
+				})}
+				approvalAction={{
+					worktreePath: "/repo",
+					executionId: "exec-001",
+				}}
+			/>,
+		);
+
+		expect(
+			within(screen.getByTestId("trace-item-review-1")).queryByRole("button", {
+				name: "Approve step",
+			}),
+		).not.toBeInTheDocument();
+		expect(
+			within(screen.getByTestId("trace-item-review-2")).getByRole("button", {
+				name: "Approve step",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("does not render approval actions in parallel block rows", () => {
+		render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+					currentStepName: "parallel-review",
+					currentStepIndex: 0,
+					totalSteps: 2,
+					approvalOperations: { canReject: true },
+					stepStates: {
+						"parallel-review": "waiting_approval",
+						report: "pending",
+					},
+					workflowDefinition: {
+						name: "test-workflow",
+						description: "test",
+						builtin: false,
+						steps: [
+							{
+								name: "parallel-review",
+								rules: [],
+								parallel: [
+									{ name: "arch-review", mode: "auto" },
+									{ name: "security-review", mode: "auto" },
+								],
+							},
+							{
+								name: "report",
+								mode: "auto",
+								instruction: "report",
+								rules: [],
+							},
+						],
+					},
+					activeParallelSteps: [
+						{
+							stepName: "arch-review",
+							state: "running",
+							runIndex: 0,
+						},
+						{
+							stepName: "security-review",
+							state: "running",
+							runIndex: 0,
+						},
+					],
+				})}
+				approvalAction={{
+					worktreePath: "/repo",
+					executionId: "exec-001",
+				}}
+			/>,
+		);
+
+		const parentRow = screen.getByTestId("trace-item-parallel-review-1");
+		const childRow = screen.getByTestId("trace-child-item-arch-review-1");
+
+		expect(
+			within(parentRow).queryByRole("button", { name: "Approve step" }),
+		).not.toBeInTheDocument();
+		expect(
+			within(parentRow).queryByRole("button", { name: "Reject step" }),
+		).not.toBeInTheDocument();
+		expect(
+			within(childRow).queryByRole("button", { name: "Approve step" }),
+		).not.toBeInTheDocument();
+		expect(
+			within(childRow).queryByRole("button", { name: "Reject step" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Approve step" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Reject step" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not render approval actions for a current parallel definition without active child rows", () => {
+		render(
+			<WorkflowTrace
+				workflowState={makeWorkflowState({
+					state: { type: "waiting_approval" },
+					currentStepName: "parallel-review",
+					currentStepIndex: 0,
+					totalSteps: 2,
+					approvalOperations: { canReject: true },
+					stepStates: {
+						"parallel-review": "waiting_approval",
+						report: "pending",
+					},
+					workflowDefinition: {
+						name: "test-workflow",
+						description: "test",
+						builtin: false,
+						steps: [
+							{
+								name: "parallel-review",
+								rules: [],
+								parallel: [
+									{ name: "arch-review", mode: "auto" },
+									{ name: "security-review", mode: "auto" },
+								],
+							},
+							{
+								name: "report",
+								mode: "auto",
+								instruction: "report",
+								rules: [],
+							},
+						],
+					},
+					activeParallelSteps: [],
+				})}
+				approvalAction={{
+					worktreePath: "/repo",
+					executionId: "exec-001",
+				}}
+			/>,
+		);
+
+		const parentRow = screen.getByTestId("trace-item-parallel-review-1");
+
+		expect(
+			within(parentRow).queryByRole("button", { name: "Approve step" }),
+		).not.toBeInTheDocument();
+		expect(
+			within(parentRow).queryByRole("button", { name: "Reject step" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("shows step history entries in chronological loop order", () => {

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
@@ -1,6 +1,7 @@
 import {
 	AlertTriangle,
 	Ban,
+	Check,
 	CheckCircle2,
 	ChevronDown,
 	ChevronRight,
@@ -8,8 +9,10 @@ import {
 	Clock,
 	GitBranch,
 	Loader2,
+	X,
 } from "lucide-react";
 import { useState } from "react";
+import { useStepApprovalAction } from "@/hooks/useStepApprovalAction";
 import type {
 	JsonValue,
 	ParallelStepState,
@@ -24,6 +27,12 @@ interface WorkflowTraceProps {
 	events?: WorkflowLogEvent[];
 	onSessionClick?: (sessionId: string) => void;
 	onFileClick?: (path: string) => void;
+	approvalAction?: WorkflowApprovalActionContext;
+}
+
+interface WorkflowApprovalActionContext {
+	worktreePath: string;
+	executionId: string;
 }
 
 const stateClasses: Record<string, string> = {
@@ -42,6 +51,7 @@ export function WorkflowTrace({
 	events = [],
 	onSessionClick,
 	onFileClick,
+	approvalAction,
 }: WorkflowTraceProps) {
 	const totalTokens =
 		workflowState.totalTokenUsage.inputTokens +
@@ -62,8 +72,10 @@ export function WorkflowTrace({
 							item={item}
 							index={index}
 							isLast={index === traceItems.length - 1}
+							workflowState={workflowState}
 							onSessionClick={onSessionClick}
 							onFileClick={onFileClick}
+							approvalAction={approvalAction}
 						/>
 					))}
 				</div>
@@ -270,14 +282,18 @@ function TraceItemRow({
 	item,
 	index,
 	isLast,
+	workflowState,
 	onSessionClick,
 	onFileClick,
+	approvalAction,
 }: {
 	item: TraceItem;
 	index: number;
 	isLast: boolean;
+	workflowState: WorkflowState;
 	onSessionClick?: (sessionId: string) => void;
 	onFileClick?: (path: string) => void;
+	approvalAction?: WorkflowApprovalActionContext;
 }) {
 	if (item.kind === "parallel") {
 		return (
@@ -292,6 +308,14 @@ function TraceItemRow({
 	}
 
 	const stepMode = item.step?.mode ?? "unknown";
+	const approvalTarget =
+		workflowState.state.type === "waiting_approval" &&
+		item.kind === "current" &&
+		!item.step?.parallel &&
+		item.stepName === workflowState.currentStepName
+			? approvalAction
+			: undefined;
+	const canReject = workflowState.approvalOperations?.canReject === true;
 
 	return (
 		<div className="grid grid-cols-[24px_1fr] gap-2">
@@ -304,6 +328,7 @@ function TraceItemRow({
 				{!isLast && <div className="w-px flex-1 min-h-4 bg-border" />}
 			</div>
 			<div
+				data-testid={`trace-item-${item.stepName}-${item.occurrence}`}
 				className={`mb-2 overflow-hidden rounded-md border px-3 py-2 ${
 					item.kind === "current"
 						? "border-primary/60 bg-primary/5"
@@ -329,7 +354,107 @@ function TraceItemRow({
 					onSessionClick={onSessionClick}
 					onFileClick={onFileClick}
 				/>
+				{approvalTarget && (
+					<StepApprovalActions
+						approvalAction={approvalTarget}
+						stepName={item.stepName}
+						canReject={canReject}
+					/>
+				)}
 			</div>
+		</div>
+	);
+}
+
+function StepApprovalActions({
+	approvalAction,
+	stepName,
+	canReject,
+}: {
+	approvalAction: WorkflowApprovalActionContext;
+	stepName: string;
+	canReject: boolean;
+}) {
+	const {
+		rejectMode,
+		rejectComment,
+		setRejectComment,
+		canSubmitReject,
+		approvalError,
+		approve,
+		openReject,
+		cancelReject,
+		submitReject,
+	} = useStepApprovalAction({
+		worktreePath: approvalAction.worktreePath,
+		executionId: approvalAction.executionId,
+		stepName,
+	});
+
+	return (
+		<div className="mt-2 flex min-w-0 flex-col gap-1.5 border-t pt-2">
+			{approvalError && (
+				<div
+					role="alert"
+					className="flex items-start gap-2 rounded border border-red-500/30 bg-red-500/10 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
+				>
+					<AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+					<span className="min-w-0 break-words">{approvalError}</span>
+				</div>
+			)}
+			{rejectMode ? (
+				<div className="flex min-w-0 flex-col gap-1.5">
+					<textarea
+						className="w-full min-w-0 rounded border bg-background px-2 py-1 text-xs resize-none"
+						rows={3}
+						placeholder="Reject comment..."
+						value={rejectComment}
+						onChange={(e) => setRejectComment(e.target.value)}
+						aria-label="Reject comment"
+					/>
+					<div className="flex items-center justify-end gap-2">
+						<button
+							type="button"
+							onClick={cancelReject}
+							className="rounded bg-muted px-2 py-0.5 text-xs transition-colors hover:bg-muted/80"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							onClick={submitReject}
+							disabled={!canSubmitReject}
+							className="rounded bg-yellow-500/20 px-2 py-0.5 text-xs text-yellow-700 transition-colors hover:bg-yellow-500/30 disabled:cursor-not-allowed disabled:opacity-50 dark:text-yellow-300"
+							aria-label="Submit reject"
+						>
+							Reject
+						</button>
+					</div>
+				</div>
+			) : (
+				<div className="flex flex-wrap items-center justify-end gap-2">
+					<button
+						type="button"
+						onClick={approve}
+						className="flex items-center gap-1 rounded bg-green-500/20 px-2 py-0.5 text-xs text-green-700 transition-colors hover:bg-green-500/30 dark:text-green-300"
+						aria-label="Approve step"
+					>
+						<Check className="size-3" />
+						Approve
+					</button>
+					{canReject && (
+						<button
+							type="button"
+							onClick={openReject}
+							className="flex items-center gap-1 rounded bg-yellow-500/20 px-2 py-0.5 text-xs text-yellow-700 transition-colors hover:bg-yellow-500/30 dark:text-yellow-300"
+							aria-label="Reject step"
+						>
+							<X className="size-3" />
+							Reject
+						</button>
+					)}
+				</div>
+			)}
 		</div>
 	);
 }
@@ -366,6 +491,7 @@ function ParallelBlockRow({
 				{!isLast && <div className="w-px flex-1 min-h-4 bg-border" />}
 			</div>
 			<div
+				data-testid={`trace-item-${item.stepName}-${item.occurrence}`}
 				className={`mb-2 overflow-hidden rounded-md border px-3 py-2 ${
 					item.state === "running"
 						? "border-primary/60 bg-primary/5"
@@ -436,7 +562,10 @@ function ParallelChildRow({
 			? ((so as Record<string, unknown>).verdict as string | undefined)
 			: undefined;
 	return (
-		<div className="flex min-w-0 flex-col gap-1 rounded px-2 py-1 text-xs">
+		<div
+			data-testid={`trace-child-item-${child.stepName}-${child.runIndex + 1}`}
+			className="flex min-w-0 flex-col gap-1 rounded px-2 py-1 text-xs"
+		>
 			<div className="flex items-center gap-2">
 				<div
 					className={`flex size-4 items-center justify-center rounded-full border ${stateClasses[child.state] ?? stateClasses.pending}`}

--- a/src/hooks/useStepApprovalAction.test.ts
+++ b/src/hooks/useStepApprovalAction.test.ts
@@ -1,0 +1,37 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useStepApprovalAction } from "./useStepApprovalAction";
+
+const mockInvoke = vi.fn().mockResolvedValue(undefined);
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+describe("useStepApprovalAction", () => {
+	beforeEach(() => {
+		mockInvoke.mockReset();
+		mockInvoke.mockResolvedValue(undefined);
+	});
+
+	it("does not submit reject when comment is blank", async () => {
+		const { result } = renderHook(() =>
+			useStepApprovalAction({
+				worktreePath: "/repo",
+				executionId: "exec-001",
+				stepName: "review",
+			}),
+		);
+
+		act(() => {
+			result.current.setRejectComment("   ");
+		});
+
+		expect(result.current.canSubmitReject).toBe(false);
+
+		await act(async () => {
+			await result.current.submitReject();
+		});
+
+		expect(mockInvoke).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/useStepApprovalAction.ts
+++ b/src/hooks/useStepApprovalAction.ts
@@ -1,0 +1,100 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useState } from "react";
+
+export interface StepApprovalActionContext {
+	worktreePath: string;
+	executionId: string;
+	stepName: string;
+}
+
+export function useStepApprovalAction({
+	worktreePath,
+	executionId,
+	stepName,
+}: StepApprovalActionContext) {
+	const [rejectMode, setRejectMode] = useState(false);
+	const [rejectComment, setRejectComment] = useState("");
+	const [approvalError, setApprovalError] = useState<string | null>(null);
+
+	useEffect(() => {
+		setRejectMode(false);
+		setRejectComment("");
+		setApprovalError(null);
+	}, [worktreePath, executionId, stepName]);
+
+	const approve = useCallback(() => {
+		return invoke("approve_workflow_step", {
+			worktreePath,
+			decision: "approve",
+			executionId,
+			stepName,
+		})
+			.then(() => setApprovalError(null))
+			.catch((e) => {
+				console.warn("[useStepApprovalAction] approve_workflow_step failed", e);
+				setApprovalError(formatWorkflowApprovalError(e));
+			});
+	}, [worktreePath, executionId, stepName]);
+
+	const openReject = useCallback(() => {
+		setRejectMode(true);
+		setApprovalError(null);
+	}, []);
+
+	const cancelReject = useCallback(() => {
+		setRejectMode(false);
+		setRejectComment("");
+	}, []);
+
+	const canSubmitReject = rejectComment.trim().length > 0;
+
+	const submitReject = useCallback(() => {
+		if (!canSubmitReject) {
+			return Promise.resolve();
+		}
+		return invoke("approve_workflow_step", {
+			worktreePath,
+			decision: { reject: { comment: rejectComment } },
+			executionId,
+			stepName,
+		})
+			.then(() => {
+				setRejectMode(false);
+				setRejectComment("");
+				setApprovalError(null);
+			})
+			.catch((e) => {
+				console.warn("[useStepApprovalAction] approve_workflow_step failed", e);
+				setApprovalError(formatWorkflowApprovalError(e));
+			});
+	}, [worktreePath, executionId, stepName, rejectComment, canSubmitReject]);
+
+	return {
+		rejectMode,
+		rejectComment,
+		setRejectComment,
+		canSubmitReject,
+		approvalError,
+		approve,
+		openReject,
+		cancelReject,
+		submitReject,
+	};
+}
+
+function formatWorkflowApprovalError(error: unknown): string {
+	const message = String(error);
+	if (message.startsWith("invalid_state:")) {
+		return "Workflow approval is no longer available for the current step.";
+	}
+	if (message.startsWith("validation_error:")) {
+		return message.replace(/^validation_error:\s*/, "");
+	}
+	if (message.startsWith("unauthorized_worktree:")) {
+		return "This approval belongs to a different worktree.";
+	}
+	if (message.startsWith("unauthorized_approval_target:")) {
+		return "This approval request no longer matches the current workflow step.";
+	}
+	return message;
+}

--- a/src/hooks/useStepApprovalAction.ts
+++ b/src/hooks/useStepApprovalAction.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 export interface StepApprovalActionContext {
 	worktreePath: string;
@@ -16,11 +16,14 @@ export function useStepApprovalAction({
 	const [rejectComment, setRejectComment] = useState("");
 	const [approvalError, setApprovalError] = useState<string | null>(null);
 
-	useEffect(() => {
+	const identityKey = `${worktreePath}|${executionId}|${stepName}`;
+	const [prevIdentityKey, setPrevIdentityKey] = useState(identityKey);
+	if (prevIdentityKey !== identityKey) {
+		setPrevIdentityKey(identityKey);
 		setRejectMode(false);
 		setRejectComment("");
 		setApprovalError(null);
-	}, [worktreePath, executionId, stepName]);
+	}
 
 	const approve = useCallback(() => {
 		return invoke("approve_workflow_step", {


### PR DESCRIPTION
## Summary
- Approval ステップの Approve / Reject ボタンを、ワークフローパネル上部の固定アクションバーから対応する `TraceItem` 行内へ移行。複数 occurrence でも操作対象のステップが配置位置から一意に判別可能になる。
- 並列ブロック親ステップは行内承認UIの描画対象外（現行バックエンドは並列親の `waiting_approval` 遷移を発生させないためスコープ外。後続Issueで扱う）。
- ワークフロー identity（worktree / executionId / state.type）変更時に `abort_workflow` のエラー表示をクリア。
- `useStepApprovalAction` で `canSubmitReject` を一元化し、空コメントでの reject 送信を hook 側でガード。

Closes #925

## Test plan
- [ ] `pnpm lint`
- [ ] `pnpm test`（`WorkflowPanel` / `WorkflowTrace` / `useStepApprovalAction`）
- [ ] `pnpm build`
- [ ] 手動: Approval ステップで Approve / Reject が該当行内のボタンから実行できる
- [ ] 手動: 同一ステップが複数 occurrence で実行された場合、現在の occurrence 行にのみアクションが表示される
- [ ] 手動: ワークフロー切替時に上部の Stop エラーがクリアされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ワークフロー承認・却下UI改善

* **新機能**
  * 承認・却下ボタンがパネル上部からワークフロー手順行に移動しました。却下コメント入力およびエラー表示が同じ行に統合されました。
  * 複数回実行される手順では、現在実行中の手順にのみボタンが表示されます。
  * 却下コメントの検証が強化され、空白のみの入力は送信できなくなりました。

* **バグ修正**
  * 承認・却下エラーがより明確なメッセージで表示されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/992)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->