### PR TITLE
fix: Workspace ステータスをオープン中 Session のみで集約 (#954)

### DIFF
--- a/docs/spec/issues-954.md
+++ b/docs/spec/issues-954.md
@@ -1,0 +1,124 @@
+## 要求
+
+**種別**: バグ修正
+**ゴール**: Workspace ナビのステータス表示が「現在タブが存在する（= オープン中の）Session のみ」を構築元として集約され、エラーになった Session をタブから閉じれば Workspace ステータスがその Session の Error 状態の影響を受けなくなる状態にする。
+**背景**: 現状、`AgentStatusCenter` の `aggregate()` は worktree 配下の全 `SessionStatus` を集約対象にしており、`SessionState::Closed`（= AgentChatPanel でタブを閉じた Session）も含めてしまう。集約規則は Error > Waiting > Running > Done のため、過去にエラーになった Session が 1 つでも残っていると Workspace の `aggregated_state` が永続的に `Error` のまま固定され、ユーザーがエラー状態から復帰する手段がなくなってしまう。
+
+### 現在の挙動
+- worktree 配下のいずれかの Session で Error が発生する
+- ユーザーが該当 Session のタブを閉じる（`close_session` で `SessionState::Closed` に遷移）
+- `AgentStatusCenter.sessions` には Closed の `SessionStatus` が残り続け、`aggregate()` がそれも含めて集約するため、Workspace ナビのステータスが `Error` のままになる
+- 他の Session を新規に開いたり既存の Session で正常に Done になっても、Workspace ステータスは `Error` から変化しない
+
+### 期待する挙動
+- `aggregate()` が `SessionState::Closed` の `SessionStatus` を集約対象から除外する
+- ユーザーが Error になった Session のタブを閉じた瞬間に、その Session が Workspace の集約から外れ、残りのオープン中 Session の状態だけで `aggregated_state` が再計算される
+- Closed の Session を `restore_session` で復帰させた場合は、再び集約対象に戻る
+- worktree 配下のオープン中 Session（Closed を除外した Session）が 0 件のときは、Workspace ステータスは集約対象なしを示す
+
+### 再現手順
+1. ある worktree 配下の Session A でエラーを発生させる（`SessionState::Error`）
+2. Workspace ナビのその worktree のステータスが Error 表示になることを確認する
+3. AgentChatPanel で Session A のタブを閉じる
+4. Workspace ナビのステータスが Error から変化せず、復帰できないことを確認する
+
+### スコープ外
+- `AgentStatusCenter.sessions` マップそのものから Closed Session を削除する変更は行わない（`SessionStatus` 自体は保持し続け、`aggregate()` のフィルタリングのみで対応する）
+- `close_session` コマンド側からの `AgentStatusCenter` への明示的な削除呼び出しは行わない
+
+## 振る舞い定義
+
+```gherkin
+Feature: Workspace ステータスのオープン中 Session 限定集約
+
+  Rule: Workspace のステータスは現在オープン中の Session のみから決まる
+
+    Scenario: エラーになった Session を閉じれば Workspace のエラー表示は解消する
+      Given Workspace にエラー状態の Session と完了状態の Session がオープン中である
+      And Workspace のステータスはエラーとして示されている
+      When ユーザーがエラー状態の Session を閉じる
+      Then Workspace のステータスは残るオープン中 Session の状態を反映するように変化する
+
+    Scenario: 閉じた Session は Workspace のステータスにもう寄与しない
+      Given Workspace に過去に閉じられた Session が残されている
+      And 残るオープン中の Session はすべて完了状態にある
+      When Workspace のステータスが評価される
+      Then 閉じた Session の状態は Workspace のステータスに反映されない
+
+    Scenario: 唯一のオープン中 Session を閉じれば Workspace は集約対象なしとして示される
+      Given Workspace にオープン中の Session が 1 つだけ存在する
+      And その Session はエラー状態にある
+      When ユーザーがその Session を閉じる
+      Then Workspace のステータスは集約対象なしとして示される
+
+    Scenario: 同種のエラー Session が残っていれば Workspace のエラー表示は維持される
+      Given Workspace にエラー状態の Session が複数オープン中である
+      And Workspace のステータスはエラーとして示されている
+      When ユーザーがそのうち 1 つの Session を閉じる
+      Then Workspace のステータスはエラーのまま維持される
+
+  Rule: 閉じた Session をユーザーが復帰させれば再び Workspace のステータスに寄与する
+
+    Scenario: 閉じた Session を復帰させれば Workspace の集約対象に戻る
+      Given Workspace に閉じられた Session が存在する
+      And Workspace には他にオープン中の Session が存在する
+      When ユーザーが閉じられた Session を復帰させる
+      Then 復帰した Session はオープン中として扱われ Workspace のステータスへ再び寄与する
+      And Workspace のステータスは復帰後のオープン中 Session 全体から再評価される
+
+  Rule: オープン中 Session の状態は Error > Waiting > Running > Done の優先度で集約される
+
+    Scenario: オープン中の Session にエラーが 1 つでも含まれていれば Workspace はエラーになる
+      Given Workspace のオープン中 Session にエラー状態のものが含まれている
+      When Workspace のステータスが評価される
+      Then Workspace のステータスはエラーとして示される
+
+    Scenario: オープン中の Session に待機と実行中のみが含まれていれば Workspace は待機を示す
+      Given Workspace のオープン中 Session の状態は待機と実行中のみで構成されている
+      When Workspace のステータスが評価される
+      Then Workspace のステータスは待機として示される
+
+    Scenario: オープン中の Session に実行中と完了のみが含まれていれば Workspace は実行中を示す
+      Given Workspace のオープン中 Session の状態は実行中と完了のみで構成されている
+      When Workspace のステータスが評価される
+      Then Workspace のステータスは実行中として示される
+
+    Scenario: オープン中の Session がすべて完了であれば Workspace は完了を示す
+      Given Workspace のオープン中 Session の状態はすべて完了で構成されている
+      When Workspace のステータスが評価される
+      Then Workspace のステータスは完了として示される
+```
+
+## アーキテクチャ概要
+
+### 責務配置
+- `AgentStatusCenter`（`src-tauri/src/agent_status.rs`）: SessionStatus / WorkspaceStatus の中央管理と集約規則の適用、Tauri イベント・WS broadcast の発火を担当する。`SessionState` の真実値は決定しないが、SessionStore からの状態変更通知を受け取ったときは、自身が保持する `SessionStatus` スナップショットの `session_state` フィールドへその新値を反映する（=「最新化」する役割）。 / SessionStore の永続化、`SessionState` の値そのものを独自判断で書き換えること、タブ UI からの `close_session` / `restore_session` 呼び出しは担当しない。
+- `SessionStore`（`src-tauri/src/session/store.rs` / `session/mod.rs`）: ChatSession の永続化と `SessionState` の確定を担当し、状態が変化した事実を観測可能なシグナルとして外部に公開する。 / 集約規則の適用、Workspace 状態の保持・emit は担当しない。
+- `close_session` / `restore_session`（`src-tauri/src/session/mod.rs`）: SessionStore 上の `SessionState` を Closed / Idle に遷移させ、`SessionStore` の状態変更通知を経由して再集約をトリガすることだけを担当する。 / `AgentStatusCenter` の内部マップを直接操作したり、aggregate の引数を組み立てたりしない。
+- フロントエンド（`src/hooks/useWorkspaceStatus.ts` 系・`useWorktreeList.ts`・`useWorkspaceNavigation.ts` 等）: Tauri イベント `workspace-status-changed` / `session-status-changed` を購読し UI に反映するだけ。 / 集約・フィルタリングのロジックは持たない。
+
+### データ/通信フロー
+- ユーザーが Error Session のタブを閉じる: AgentChatPanel → `close_session` Tauri command → SessionStore が `SessionState::Closed` を保存 → SessionStore の状態変更通知 → AgentStatusCenter（購読側）が該当 SessionStatus の `session_state` を最新化し、Closed を除外した上で当該 worktree を再集約 → `session-status-changed` / `workspace-status-changed` を emit → フロント Hook が反映 → Workspace ナビが新しい aggregated_state を表示。
+- Closed Session を復帰させる: AgentChatPanel → `restore_session` Tauri command → SessionStore が `SessionState::Idle` を保存 → SessionStore の状態変更通知 → AgentStatusCenter が該当 SessionStatus の `session_state` を Idle に最新化し再集約 → `session-status-changed` と `workspace-status-changed` の両方を emit → ナビ反映。
+- 通常のターン進行（既存経路）: バックエンド bridge → `notify_status_transition` → `AgentStatusCenter::update_session` → 集約 → emit。本フローは Closed フィルタの影響を受けるが構造は変えない。
+
+### 状態Owner
+- ChatSession の永続化済み `SessionState`（Active/Idle/Done/Error/Closed）: SessionStore（唯一の真実）。
+- 実行時の SessionStatus（`turn_phase`, `agent_state`, `session_state` のスナップショット）と WorkspaceStatus（`aggregated_state` を含み、集約対象が 0 件のときは「集約対象なし」を表現する）: AgentStatusCenter（メモリ上）。
+- Workspace ナビの表示状態: フロントエンド Hook（`AgentStatusCenter` から流れてくるイベントのキャッシュ）。
+- 「どの Session タブが開いているか」: `SessionState` 自体（Closed か否か）が事実上のソース。タブ UI は SessionStore の状態に従う。
+- SessionState と振る舞い定義の用語対応: Active → 実行中、Idle → 待機、Done → 完了、Error → エラー、Closed → 閉じた。集約規則「Error > Waiting > Running > Done」はそれぞれ SessionState の Error > Idle > Active > Done に対応する。
+
+### 境界
+- 集約規則（Error > Waiting > Running > Done）と「Closed を除外する」フィルタは `AgentStatusCenter::aggregate`（およびその呼び出し側のフィルタ責務）にのみ存在し、フロントエンドや SessionStore は知らない。Closed を除外した結果オープン中 Session が 0 件になった場合は、WorkspaceStatus の `aggregated_state` を「集約対象なし」として表現する責務も `AgentStatusCenter` 側にあり、フロントエンドはその値を表示するだけで独自に補正しない。
+- SessionStore は `SessionState` の値を保持・公開するだけで、それが「集約対象か否か」の解釈は持たない。AgentStatusCenter 側が `SessionState::Closed` を集約対象から外す唯一の主体である。
+- 永続化と中央管理の同期は SessionStore からの状態変更通知（一方向）に集約する。AgentStatusCenter から SessionStore への書き込みは行わない。
+- フロントエンドは `workspace-status-changed` / `session-status-changed` の最新値だけを信頼し、独自に集約・補正しない。
+
+### 実装に委ねること
+- SessionStore の状態変更通知の具体的な仕組み（`tokio::sync::broadcast` / コールバックリスト / `parking_lot` で守るリスナー Vec など）と、その購読側（AgentStatusCenter）への配線位置。
+- AgentStatusCenter が SessionStore からの通知を受けたときに、`update_session` を再利用するか、Closed 専用の内部経路を用意するか（外部 API シグネチャを変えない範囲での選択）。
+- `aggregate` への Closed フィルタの実装位置（`aggregate` 呼び出し前の `Vec` 構築段階で除外するか、`aggregate` 内で除外するか）。
+- 既存テストへの追記か新規テストファイル追加か、ヘルパー関数（`mk_session` 等）の再利用範囲。
+- 通知の重複発火を防ぐ dedup の判断（既存 `is_session_state_equivalent` を流用するか専用判定を追加するか）。
+- ログ出力の有無・粒度。

--- a/src-tauri/src/agent_status.rs
+++ b/src-tauri/src/agent_status.rs
@@ -9,6 +9,20 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, State};
 
+/// Tauri イベントの emit を抽象化するための内部トレイト。
+/// プロダクションでは任意の Tauri `Runtime` を持つ `AppHandle` で実装され、
+/// テストでは noop 実装に差し替えられる。
+trait EventEmitter: Send + Sync {
+    fn emit_event(&self, event: &str, payload: serde_json::Value);
+}
+
+impl<R: tauri::Runtime> EventEmitter for AppHandle<R> {
+    fn emit_event(&self, event: &str, payload: serde_json::Value) {
+        use tauri::Emitter;
+        let _ = self.emit(event, payload);
+    }
+}
+
 /// 1 つの ChatSession に対する状態スナップショット。
 /// AgentState は turn_phase / session_state から算出した派生値。
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -73,28 +87,38 @@ pub struct WorkspaceStatus {
 pub struct AgentStatusCenter {
     sessions: RwLock<HashMap<String, SessionStatus>>,
     workspaces: RwLock<HashMap<String, WorkspaceStatus>>,
-    app_handle: AppHandle,
+    emitter: Arc<dyn EventEmitter>,
     broadcaster: Arc<WsBroadcaster>,
 }
 
 impl AgentStatusCenter {
-    pub fn new(app_handle: AppHandle, broadcaster: Arc<WsBroadcaster>) -> Self {
+    pub fn new<R: tauri::Runtime>(
+        app_handle: AppHandle<R>,
+        broadcaster: Arc<WsBroadcaster>,
+    ) -> Self {
+        Self::with_emitter(Arc::new(app_handle), broadcaster)
+    }
+
+    fn with_emitter(emitter: Arc<dyn EventEmitter>, broadcaster: Arc<WsBroadcaster>) -> Self {
         Self {
             sessions: RwLock::new(HashMap::new()),
             workspaces: RwLock::new(HashMap::new()),
-            app_handle,
+            emitter,
             broadcaster,
         }
     }
 
     /// AgentState は turn_phase / session_state から派生する。
-    /// frontend `deriveAgentState` と同じ規則。
+    /// Spec line 110 の集約規則対応 (Error > Idle > Active > Done) に揃え、
+    /// turn_phase が Idle の場合は session_state=Error → Error、Idle → Waiting、
+    /// それ以外 → Done として個別 Session の agent_state を決定する。
     pub fn derive_agent_state(turn_phase: TurnPhase, session_state: SessionState) -> AgentState {
         match turn_phase {
             TurnPhase::Streaming => AgentState::Running,
             TurnPhase::WaitingPermission => AgentState::Waiting,
             TurnPhase::Idle => match session_state {
                 SessionState::Error => AgentState::Error,
+                SessionState::Idle => AgentState::Waiting,
                 _ => AgentState::Done,
             },
         }
@@ -124,18 +148,27 @@ impl AgentStatusCenter {
             && a.session_count == b.session_count
     }
 
-    /// Workspace の集約規則: Error > Waiting > Running > Done
+    /// Workspace の集約規則: Error > Waiting > Running > Done。
+    /// `SessionState::Closed`（タブを閉じた Session）はオープン中でないため集約対象から除外する。
+    /// 全てフィルタされて 0 件になった場合は `aggregated_state: Done` / `session_count: 0` で表現する
+    /// （= 集約対象なし）。
     fn aggregate(
         worktree_id: &str,
         worktree_path: &str,
         sessions: &[&SessionStatus],
         last_activity_at: f64,
     ) -> WorkspaceStatus {
+        let open_sessions: Vec<&SessionStatus> = sessions
+            .iter()
+            .copied()
+            .filter(|s| s.session_state != SessionState::Closed)
+            .collect();
+
         let mut running_count = 0usize;
         let mut waiting_count = 0usize;
         let mut error_count = 0usize;
 
-        for s in sessions {
+        for s in &open_sessions {
             match s.agent_state {
                 AgentState::Running => running_count += 1,
                 AgentState::Waiting => waiting_count += 1,
@@ -161,7 +194,7 @@ impl AgentStatusCenter {
             running_count,
             waiting_count,
             error_count,
-            session_count: sessions.len(),
+            session_count: open_sessions.len(),
             last_activity_at,
         }
     }
@@ -196,7 +229,7 @@ impl AgentStatusCenter {
             sessions.insert(chat_session_id.clone(), status.clone());
         }
 
-        // 3. workspace 再集約
+        // 3. workspace 再集約（aggregate 内で Closed は集約対象から除外される）
         let new_workspace = {
             let sessions = self.sessions.read();
             let same_workspace: Vec<&SessionStatus> = sessions
@@ -237,6 +270,52 @@ impl AgentStatusCenter {
             Some(chat_session_id),
             pty_id,
         );
+    }
+
+    /// SessionStore からの `SessionState` 変更通知を受け取り、保持している
+    /// `SessionStatus` の `session_state` を最新化した上で再集約する。
+    /// Closed への遷移は `aggregate` 段階で集約対象から外れ、Closed → 他状態の
+    /// 復帰では再び集約対象に戻る。
+    pub fn on_session_state_changed(&self, chat_session_id: &str, new_state: SessionState) {
+        let existing = self.sessions.read().get(chat_session_id).cloned();
+        let Some(existing) = existing else {
+            return;
+        };
+        if let Some(updated) =
+            Self::build_state_transition(&existing, new_state, current_timestamp())
+        {
+            self.update_session(updated);
+        }
+    }
+
+    /// `on_session_state_changed` の中核ロジック。
+    /// Closed / Idle への tab lifecycle 遷移では、閉じる前の Streaming や
+    /// WaitingPermission の `turn_phase` / `pending_permission` を引きずらないよう
+    /// `turn_phase=Idle`, `pending_permission=false` に正規化してから
+    /// `agent_state` を再算出する。状態が変わらない場合は `None`。
+    fn build_state_transition(
+        existing: &SessionStatus,
+        new_state: SessionState,
+        last_activity_at: f64,
+    ) -> Option<SessionStatus> {
+        if existing.session_state == new_state {
+            return None;
+        }
+        let normalize_to_idle = matches!(new_state, SessionState::Closed | SessionState::Idle);
+        let (turn_phase_repr, pending_permission) = if normalize_to_idle {
+            (TurnPhaseRepr::Idle, false)
+        } else {
+            (existing.turn_phase, existing.pending_permission)
+        };
+        let agent_state = Self::derive_agent_state(turn_phase_repr.into(), new_state.clone());
+        Some(SessionStatus {
+            session_state: new_state,
+            agent_state,
+            turn_phase: turn_phase_repr,
+            pending_permission,
+            last_activity_at,
+            ..existing.clone()
+        })
     }
 
     /// Session を削除し、worktree を再集約する。
@@ -333,13 +412,13 @@ impl AgentStatusCenter {
     }
 
     fn emit_session_changed(&self, status: &SessionStatus) {
-        use tauri::Emitter;
-        let _ = self.app_handle.emit("session-status-changed", status);
+        let payload = serde_json::to_value(status).unwrap_or(serde_json::Value::Null);
+        self.emitter.emit_event("session-status-changed", payload);
     }
 
     fn emit_workspace_changed(&self, status: &WorkspaceStatus) {
-        use tauri::Emitter;
-        let _ = self.app_handle.emit("workspace-status-changed", status);
+        let payload = serde_json::to_value(status).unwrap_or(serde_json::Value::Null);
+        self.emitter.emit_event("workspace-status-changed", payload);
     }
 
     /// ワークフロー状態変更を通知する（Tauriイベント + WebSocket）。
@@ -348,8 +427,6 @@ impl AgentStatusCenter {
         worktree_path: &str,
         workflow_state: &crate::protocol::WorkflowStateView,
     ) {
-        use tauri::Emitter;
-
         // Tauriイベント（デスクトップUI向け）
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -361,7 +438,8 @@ impl AgentStatusCenter {
             worktree_path,
             workflow_state,
         };
-        let _ = self.app_handle.emit("workflow-state-changed", &payload);
+        let payload = serde_json::to_value(&payload).unwrap_or(serde_json::Value::Null);
+        self.emitter.emit_event("workflow-state-changed", payload);
 
         // WebSocketブロードキャスト（リモートアプリ向け）
         let ws_sync = crate::protocol::WorkflowStateSync {
@@ -379,7 +457,6 @@ impl AgentStatusCenter {
         state: &AgentState,
         pty_id: Option<&str>,
     ) {
-        use tauri::Emitter;
         let payload = AgentStateSync {
             worktree_path: worktree_path.to_string(),
             state: state.clone(),
@@ -388,7 +465,8 @@ impl AgentStatusCenter {
             session_id: None,
             pty_id: pty_id.map(|s| s.to_string()),
         };
-        let _ = self.app_handle.emit("agent-state-changed", &payload);
+        let payload = serde_json::to_value(&payload).unwrap_or(serde_json::Value::Null);
+        self.emitter.emit_event("agent-state-changed", payload);
     }
 
     fn broadcast_agent_state_sync(
@@ -529,10 +607,9 @@ mod tests {
     }
 
     #[test]
-    fn idle_with_non_error_session_maps_to_done() {
+    fn idle_with_non_error_non_idle_session_maps_to_done() {
         for ss in [
             SessionState::Active,
-            SessionState::Idle,
             SessionState::Done,
             SessionState::Closed,
         ] {
@@ -541,6 +618,14 @@ mod tests {
                 AgentState::Done
             );
         }
+    }
+
+    #[test]
+    fn idle_with_idle_session_maps_to_waiting() {
+        assert_eq!(
+            AgentStatusCenter::derive_agent_state(TurnPhase::Idle, SessionState::Idle),
+            AgentState::Waiting
+        );
     }
 
     // ---- aggregate ----
@@ -559,7 +644,7 @@ mod tests {
     #[test]
     fn aggregate_only_done_is_done() {
         let s1 = mk_session("a", "/repo", TurnPhase::Idle, SessionState::Done);
-        let s2 = mk_session("b", "/repo", TurnPhase::Idle, SessionState::Idle);
+        let s2 = mk_session("b", "/repo", TurnPhase::Idle, SessionState::Done);
         let ws = AgentStatusCenter::aggregate("/repo", "/repo", &[&s1, &s2], 0.0);
         assert_eq!(ws.aggregated_state, AgentState::Done);
         assert_eq!(ws.session_count, 2);
@@ -587,6 +672,55 @@ mod tests {
         assert_eq!(ws.aggregated_state, AgentState::Waiting);
         assert_eq!(ws.waiting_count, 1);
         assert_eq!(ws.running_count, 1);
+    }
+
+    #[test]
+    fn aggregate_excludes_closed_sessions() {
+        // Closed Session（過去に Error → Closed になったタブを想定）は集約に寄与しない。
+        // 残るオープン中 Session の状態で判定される。
+        let open_done = mk_session("a", "/repo", TurnPhase::Idle, SessionState::Done);
+        let mut closed_with_error_history =
+            mk_session("b", "/repo", TurnPhase::Idle, SessionState::Closed);
+        // 過去に Error だった「痕跡」: agent_state は Error のまま残っていても、
+        // session_state=Closed なのでフィルタされる。
+        closed_with_error_history.agent_state = AgentState::Error;
+        let ws = AgentStatusCenter::aggregate(
+            "/repo",
+            "/repo",
+            &[&open_done, &closed_with_error_history],
+            0.0,
+        );
+        assert_eq!(ws.aggregated_state, AgentState::Done);
+        assert_eq!(ws.error_count, 0);
+        assert_eq!(ws.session_count, 1);
+    }
+
+    #[test]
+    fn aggregate_all_closed_yields_no_aggregation_target() {
+        // オープン中 Session が 0 件のとき: session_count=0 で「集約対象なし」を示す
+        let closed_a = mk_session("a", "/repo", TurnPhase::Idle, SessionState::Closed);
+        let closed_b = mk_session("b", "/repo", TurnPhase::Idle, SessionState::Closed);
+        let ws = AgentStatusCenter::aggregate("/repo", "/repo", &[&closed_a, &closed_b], 0.0);
+        assert_eq!(ws.session_count, 0);
+        assert_eq!(ws.error_count, 0);
+        assert_eq!(ws.aggregated_state, AgentState::Done);
+    }
+
+    #[test]
+    fn aggregate_keeps_error_when_multiple_open_errors_exist() {
+        // 同じ worktree に Error が複数オープン中ならエラー集約は維持される
+        let open_error_a = mk_session("a", "/repo", TurnPhase::Idle, SessionState::Error);
+        let open_error_b = mk_session("b", "/repo", TurnPhase::Idle, SessionState::Error);
+        let closed = mk_session("c", "/repo", TurnPhase::Idle, SessionState::Closed);
+        let ws = AgentStatusCenter::aggregate(
+            "/repo",
+            "/repo",
+            &[&open_error_a, &open_error_b, &closed],
+            0.0,
+        );
+        assert_eq!(ws.aggregated_state, AgentState::Error);
+        assert_eq!(ws.error_count, 2);
+        assert_eq!(ws.session_count, 2);
     }
 
     #[test]
@@ -644,6 +778,149 @@ mod tests {
             let back = TurnPhase::from(repr);
             assert_eq!(tp, back);
         }
+    }
+
+    // ---- on_session_state_changed core (build_state_transition) ----
+
+    #[test]
+    fn build_state_transition_returns_none_when_state_unchanged() {
+        let s = mk_session("a", "/repo", TurnPhase::Idle, SessionState::Idle);
+        assert!(AgentStatusCenter::build_state_transition(&s, SessionState::Idle, 0.0).is_none());
+    }
+
+    #[test]
+    fn build_state_transition_closes_streaming_session_with_idle_normalization() {
+        // 閉じる前に Streaming だった SessionStatus を Closed に遷移させると
+        // turn_phase / pending_permission を引きずらず正規化される
+        let mut streaming = mk_session("a", "/repo", TurnPhase::Streaming, SessionState::Active);
+        streaming.pending_permission = true;
+        let updated =
+            AgentStatusCenter::build_state_transition(&streaming, SessionState::Closed, 42.0)
+                .expect("transition should produce updated session");
+        assert_eq!(updated.session_state, SessionState::Closed);
+        assert_eq!(updated.turn_phase, TurnPhaseRepr::Idle);
+        assert!(!updated.pending_permission);
+        assert_eq!(updated.last_activity_at, 42.0);
+    }
+
+    #[test]
+    fn build_state_transition_restores_to_idle_normalizes_turn_phase() {
+        // Closed Session を Idle に復帰させる際も turn_phase が Idle に正規化され
+        // agent_state は Waiting として再寄与する
+        let mut closed = mk_session(
+            "a",
+            "/repo",
+            TurnPhase::WaitingPermission,
+            SessionState::Closed,
+        );
+        closed.pending_permission = true;
+        let updated = AgentStatusCenter::build_state_transition(&closed, SessionState::Idle, 0.0)
+            .expect("transition should produce updated session");
+        assert_eq!(updated.session_state, SessionState::Idle);
+        assert_eq!(updated.turn_phase, TurnPhaseRepr::Idle);
+        assert!(!updated.pending_permission);
+        assert_eq!(updated.agent_state, AgentState::Waiting);
+    }
+
+    #[test]
+    fn build_state_transition_preserves_turn_phase_for_non_lifecycle_states() {
+        // Active / Done / Error への遷移では turn_phase はそのまま再計算に使われる
+        let streaming = mk_session("a", "/repo", TurnPhase::Streaming, SessionState::Active);
+        let updated =
+            AgentStatusCenter::build_state_transition(&streaming, SessionState::Error, 0.0)
+                .expect("transition should produce updated session");
+        // Streaming のまま再計算されるので derive 結果は Running
+        assert_eq!(updated.turn_phase, TurnPhaseRepr::Streaming);
+        assert_eq!(updated.agent_state, AgentState::Running);
+        assert_eq!(updated.session_state, SessionState::Error);
+    }
+
+    #[test]
+    fn close_error_session_yields_done_aggregate_with_session_count_one() {
+        // Spec 中核挙動: Error + Done 登録後に Error 側を Closed に遷移させると
+        // aggregate は Done / session_count=1 になる
+        let mut error_session = mk_session("err", "/repo", TurnPhase::Idle, SessionState::Error);
+        let done_session = mk_session("done", "/repo", TurnPhase::Idle, SessionState::Done);
+
+        let initial =
+            AgentStatusCenter::aggregate("/repo", "/repo", &[&error_session, &done_session], 0.0);
+        assert_eq!(initial.aggregated_state, AgentState::Error);
+        assert_eq!(initial.session_count, 2);
+
+        let closed =
+            AgentStatusCenter::build_state_transition(&error_session, SessionState::Closed, 0.0)
+                .expect("transition should produce updated session");
+        error_session = closed;
+
+        let after =
+            AgentStatusCenter::aggregate("/repo", "/repo", &[&error_session, &done_session], 0.0);
+        assert_eq!(after.aggregated_state, AgentState::Done);
+        assert_eq!(after.session_count, 1);
+        assert_eq!(after.error_count, 0);
+    }
+
+    #[test]
+    fn restore_closed_session_to_idle_recontributes_to_aggregate() {
+        // Closed → Idle で再び集約対象に戻り、aggregate に Waiting として寄与する
+        let mut closed = mk_session("a", "/repo", TurnPhase::Idle, SessionState::Closed);
+        let done_session = mk_session("b", "/repo", TurnPhase::Idle, SessionState::Done);
+
+        let before = AgentStatusCenter::aggregate("/repo", "/repo", &[&closed, &done_session], 0.0);
+        assert_eq!(before.session_count, 1);
+        assert_eq!(before.aggregated_state, AgentState::Done);
+
+        let restored = AgentStatusCenter::build_state_transition(&closed, SessionState::Idle, 0.0)
+            .expect("transition should produce updated session");
+        closed = restored;
+
+        let after = AgentStatusCenter::aggregate("/repo", "/repo", &[&closed, &done_session], 0.0);
+        assert_eq!(after.session_count, 2);
+        assert_eq!(after.aggregated_state, AgentState::Waiting);
+        assert_eq!(after.waiting_count, 1);
+    }
+
+    struct NoopEmitter;
+    impl EventEmitter for NoopEmitter {
+        fn emit_event(&self, _event: &str, _payload: serde_json::Value) {}
+    }
+
+    fn mk_center() -> AgentStatusCenter {
+        AgentStatusCenter::with_emitter(Arc::new(NoopEmitter), Arc::new(WsBroadcaster::default()))
+    }
+
+    #[test]
+    fn on_session_state_changed_closes_error_session_and_reaggregates_workspace() {
+        // Spec Scenario「エラー Session を閉じれば Workspace のエラー表示は解消する」
+        // および「閉じた Session を復帰させれば再寄与する」の本経路を担保する。
+        // build_state_transition + aggregate の単体合成ではなく、
+        // on_session_state_changed -> update_session -> workspace 再集約の経路を通す。
+        let center = mk_center();
+        let error_session = mk_session("err", "/repo", TurnPhase::Idle, SessionState::Error);
+        let done_session = mk_session("done", "/repo", TurnPhase::Idle, SessionState::Done);
+        center.update_session(error_session.clone());
+        center.update_session(done_session.clone());
+
+        let initial = center.get_workspace("/repo").expect("workspace registered");
+        assert_eq!(initial.aggregated_state, AgentState::Error);
+        assert_eq!(initial.session_count, 2);
+
+        // Error Session を Closed に遷移させると Workspace は Done / session_count=1 に再集約される
+        center.on_session_state_changed("err", SessionState::Closed);
+        let after_close = center
+            .get_workspace("/repo")
+            .expect("workspace still tracked");
+        assert_eq!(after_close.aggregated_state, AgentState::Done);
+        assert_eq!(after_close.session_count, 1);
+        assert_eq!(after_close.error_count, 0);
+
+        // Closed → Idle で復帰させると Waiting / session_count=2 として再寄与する
+        center.on_session_state_changed("err", SessionState::Idle);
+        let after_restore = center
+            .get_workspace("/repo")
+            .expect("workspace still tracked");
+        assert_eq!(after_restore.aggregated_state, AgentState::Waiting);
+        assert_eq!(after_restore.session_count, 2);
+        assert_eq!(after_restore.waiting_count, 1);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -148,6 +148,18 @@ pub fn run() {
                 app.handle().clone(),
                 broadcaster,
             ));
+            // SessionStore の状態変更通知を購読して、保持している SessionStatus を
+            // 最新化＋再集約する。Closed への遷移は aggregate でフィルタされ、
+            // Closed → Idle の復帰では再び集約対象に戻る。
+            {
+                let center_for_listener = agent_status_center.clone();
+                let session_store_state = app.state::<Arc<session::SessionStore>>().inner().clone();
+                session_store_state.register_state_change_listener(Arc::new(
+                    move |session_id, _worktree_path, new_state| {
+                        center_for_listener.on_session_state_changed(session_id, new_state.clone());
+                    },
+                ));
+            }
             app.manage(agent_status_center);
             app.manage(Arc::new(workflow::engine::WorkflowEngine::new()));
 

--- a/src-tauri/src/session/store.rs
+++ b/src-tauri/src/session/store.rs
@@ -2,14 +2,20 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use super::{ChatSession, SessionState, SessionSummary};
+
+/// `SessionState` の遷移を観測する購読者向けコールバック。
+/// 引数は `(session_id, worktree_path, new_state)`。
+pub type SessionStateChangeListener =
+    Arc<dyn Fn(&str, &str, &SessionState) + Send + Sync + 'static>;
 
 pub struct SessionStore {
     cache: RwLock<HashMap<String, ChatSession>>,
     file_lock: parking_lot::Mutex<()>,
     loaded: AtomicBool,
+    state_change_listeners: RwLock<Vec<SessionStateChangeListener>>,
 }
 
 impl Default for SessionStore {
@@ -18,6 +24,7 @@ impl Default for SessionStore {
             cache: RwLock::new(HashMap::new()),
             file_lock: parking_lot::Mutex::new(()),
             loaded: AtomicBool::new(false),
+            state_change_listeners: RwLock::new(Vec::new()),
         }
     }
 }
@@ -108,6 +115,22 @@ impl SessionStore {
     }
 
     pub fn save_session(&self, app_data_dir: &Path, session: &ChatSession) -> Result<(), String> {
+        // file_lock を保持したまま listener を同期実行すると、listener から
+        // save_session / set_session_state などへ再入したときに parking_lot::Mutex の
+        // 自己デッドロックが発生する。lock スコープは永続化と cache 更新までに限定し、
+        // 通知に必要なデータを返してからスコープを抜けて listener を呼ぶ。
+        let state_changed = self.persist_and_update_cache(app_data_dir, session)?;
+        if state_changed {
+            self.notify_state_change(&session.id, &session.worktree_path, &session.state);
+        }
+        Ok(())
+    }
+
+    fn persist_and_update_cache(
+        &self,
+        app_data_dir: &Path,
+        session: &ChatSession,
+    ) -> Result<bool, String> {
         let _lock = self.file_lock.lock();
         let dir = sessions_dir(app_data_dir);
         std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create sessions dir: {e}"))?;
@@ -120,10 +143,25 @@ impl SessionStore {
             .map_err(|e| format!("Failed to write session temp file: {e}"))?;
         std::fs::rename(&tmp_file, &file)
             .map_err(|e| format!("Failed to rename session temp file: {e}"))?;
-        self.cache
+        let prev = self
+            .cache
             .write()
             .insert(session.id.clone(), session.clone());
-        Ok(())
+        Ok(prev.as_ref().map(|p| &p.state) != Some(&session.state))
+    }
+
+    /// `SessionState` の遷移を購読するリスナーを登録する。
+    /// 登録順に保存後に発火される。AgentStatusCenter のような中央管理が
+    /// SessionStore からの状態変更を一方向に受け取るための入口。
+    pub fn register_state_change_listener(&self, listener: SessionStateChangeListener) {
+        self.state_change_listeners.write().push(listener);
+    }
+
+    fn notify_state_change(&self, session_id: &str, worktree_path: &str, new_state: &SessionState) {
+        let listeners = self.state_change_listeners.read().clone();
+        for listener in listeners {
+            listener(session_id, worktree_path, new_state);
+        }
     }
 
     pub fn set_session_state(
@@ -435,6 +473,68 @@ mod tests {
         let result = store.update_permission_mode(tmp.path(), UUID1, "plan");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Session not found"));
+    }
+
+    #[test]
+    fn state_change_listener_fires_on_close_and_restore() {
+        use parking_lot::Mutex as PlMutex;
+
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::default();
+        let session = make_session(UUID1, "/repo");
+        store.save_session(tmp.path(), &session).unwrap();
+
+        let events: Arc<PlMutex<Vec<(String, String, SessionState)>>> =
+            Arc::new(PlMutex::new(Vec::new()));
+        let events_for_listener = events.clone();
+        store.register_state_change_listener(Arc::new(
+            move |session_id, worktree_path, new_state| {
+                events_for_listener.lock().push((
+                    session_id.to_string(),
+                    worktree_path.to_string(),
+                    new_state.clone(),
+                ));
+            },
+        ));
+
+        // タブを閉じる: Active → Closed
+        store
+            .set_session_state(tmp.path(), UUID1, SessionState::Closed)
+            .unwrap();
+        // 復帰: Closed → Idle
+        store
+            .set_session_state(tmp.path(), UUID1, SessionState::Idle)
+            .unwrap();
+
+        let captured = events.lock().clone();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[0].0, UUID1);
+        assert_eq!(captured[0].1, "/repo");
+        assert_eq!(captured[0].2, SessionState::Closed);
+        assert_eq!(captured[1].2, SessionState::Idle);
+    }
+
+    #[test]
+    fn state_change_listener_does_not_fire_when_state_unchanged() {
+        use parking_lot::Mutex as PlMutex;
+
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::default();
+        let session = make_session(UUID1, "/repo");
+        store.save_session(tmp.path(), &session).unwrap();
+
+        let count = Arc::new(PlMutex::new(0usize));
+        let count_for_listener = count.clone();
+        store.register_state_change_listener(Arc::new(move |_, _, _| {
+            *count_for_listener.lock() += 1;
+        }));
+
+        // 状態は変えずに permission_mode を更新する
+        store
+            .update_permission_mode(tmp.path(), UUID1, "plan")
+            .unwrap();
+
+        assert_eq!(*count.lock(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `AgentStatusCenter.aggregate()` で `SessionState::Closed` を集約対象から除外し、エラーになった Session をタブから閉じれば Workspace のエラー表示が解消するようにした
- `SessionStore` に `SessionStateChangeListener` の購読機構を追加し、`AgentStatusCenter` が状態変更を受け取って再集約・通知できるようにした
- `EventEmitter` トレイトを導入してテストから `Tauri::AppHandle` 非依存で挙動を検証できるようにした

Closes #954

## Test plan
- [ ] `cargo test` で `agent_status` / `session::store` の新規テストが通る
- [ ] `cargo clippy -- -D warnings` / `cargo fmt --check` が通る
- [ ] 手動検証: ある worktree でエラー Session を発生させ、タブを閉じると Workspace ナビのステータスが Error から解除されること
- [ ] 手動検証: Closed Session を `restore_session` で復帰させると、再び Workspace 集約に寄与すること
- [ ] 手動検証: 唯一のオープン中 Session を閉じると、Workspace ステータスが「集約対象なし」になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ワークスペースナビの状態集約で、クローズされたセッションが除外されるように改善。アクティブなセッションのみを対象に正確な状態を表示
  * セッション状態が変更された際の状態更新処理を最適化し、不要な再計算を削減

* **新機能**
  * セッション状態の変化をリアルタイムで検出し、ワークスペース状態を自動更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/997)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->