### PR TITLE
feat: バックエンド対応モデル一覧の動的管理と検証経路の統一 (#946)

### DIFF
--- a/docs/spec/issues-946.md
+++ b/docs/spec/issues-946.md
@@ -1,0 +1,303 @@
+## 要求
+
+**種別**: 改善
+
+**ゴール**:
+- `ModelInfo.display_name` フィールドを廃止し、`value` に統一する（フロントエンドは `value` をそのまま表示する）
+- 各バックエンド（claude / codex）の対応モデル一覧を `config.toml` で一元管理する（既存の `available_models.json` キャッシュは廃止する）
+- アプリ起動時にバックグラウンドで各バックエンドCLI（`codex debug models` 等）からモデル一覧を取得し、`config.toml` を自動更新する
+- ユーザー／ワークフローから指定されたモデルIDは `config.toml` に登録されているもののみ受け入れる（サイレントフォールバックしない）
+
+**背景**:
+- 現在モデル一覧は `claude_supported_models()` / `codex_supported_models()` にハードコードされており、CLI側のモデル追加・廃止への追従が手動コード変更を要する
+- 並行して、起動済みプロセスから流れる `supported_models` イベントの結果が `bridge_common.rs` の `save_available_models()` で `available_models.json` に保存されており、永続化先が二重化している
+- `ModelInfo.display_name` は現状 `value` と同値で、独立した表示名管理の必要性がない
+- #939（ステップ別Model/Permission指定）でモデル一覧がバリデーションに使われるため、最新性が確保されないと有効なモデルが弾かれる
+
+**制約**:
+- モデル一覧の保存先は `config.toml` のみ（`available_models.json` / `available_models_{backend_id}.json` は廃止）
+- 起動時のCLI取得はバックエンド単位で独立して非同期実行し、アプリ起動をブロックしない
+- いずれかのバックエンドのCLI取得に失敗しても、他バックエンドの取得・更新は継続する（部分失敗を許容する）
+- CLI取得に失敗した場合は当該バックエンドの `config.toml` の既存値をそのまま使い続ける（ログは出す）
+- 初期状態（`config.toml` に未保存）では空の一覧で開始し、CLI取得完了後に埋める
+- コード内のハードコードフォールバック値は持たない（テスト用モックを除く）
+- CLI取得結果およびユーザー指定モデルIDは入力検証を行い、検証に失敗した値は `config.toml` を上書きしない／指定として受け入れない
+
+**影響範囲**:
+- `src-tauri/src/backends/mod.rs`（`ModelInfo` 構造体、`AgentBackendRegistry`、`collect_all_model_values` / `resolve_backend_for_model`）
+- `src-tauri/src/backends/claude.rs` / `codex.rs`（ハードコードされた `supported_models` 関数廃止、CLI問い合わせロジック追加）
+- `src-tauri/src/backends/bridge_common.rs`（`available_models_path` / `save_available_models` / `load_available_models` 廃止、`supported_models` メッセージ処理時の永続化を config.toml 経由へ統合、`set_agent_model` / `set_agent_model_internal` の入力検証を config 由来へ切替）
+- `src-tauri/src/config.rs`（`AppConfig` にバックエンド別モデル一覧セクション追加）
+- `src-tauri/src/protocol/agent.rs`（`AgentModelSetRequest` の検証経路）
+- `src-tauri/src/ws_server/routing.rs` / `ws_server/handlers.rs`（`handle_agent_model_set_request` の検証経路）
+- `src-tauri/src/lib.rs`（起動時バックグラウンド同期のトリガー）
+- フロントエンド: `ModelSelector.tsx`、`MessageInput.tsx`、`session.ts`、`useSessionStore.ts`、`useAgentSdkListeners.ts`、`useAgentChat.ts`、`agentChatReducer.ts` 等の `ModelInfo.displayName` 参照箇所
+  - 対象は `ModelInfo.displayName` のみ。`PermissionRequest.display_name`（権限ダイアログ表示名）は対象外
+- Remote UI 経由のモデル指定（`src/remote/` 配下のモデル選択導線 → `AgentModelSetRequest` 送信経路）
+- 関連テスト全般
+
+## 振る舞い定義
+
+```gherkin
+Feature: バックエンド対応モデル一覧の動的管理
+  ユーザーが指定可能なモデルは、各バックエンドの権威ある情報源から得られた
+  最新の一覧を信頼できる単一の場所で管理し、ユーザーが常に有効なモデルだけを
+  選択・指定できるようにする。
+
+  Rule: モデル一覧はバックエンドごとに独立して最新化される
+    各バックエンドのモデル一覧は、そのバックエンド固有の情報源から取得され、
+    他バックエンドの取得結果や障害に影響されない。
+
+    Scenario: 起動時に各バックエンドのモデル一覧が最新化される
+      Given アプリには複数のバックエンドが登録されている
+      When アプリが起動する
+      Then 各バックエンドのモデル一覧が、それぞれの情報源から得られた最新の一覧で記録される
+
+    Scenario: アプリ起動はモデル一覧取得の完了を待たない
+      Given アプリ起動時に各バックエンドのモデル一覧の最新化が開始される
+      And いずれかのバックエンドのモデル一覧取得に時間を要している
+      When アプリの起動シーケンスが進行する
+      Then アプリの起動は当該バックエンドのモデル一覧取得の完了を待たずに完了する
+      And 当該バックエンドのモデル一覧は取得完了後に当該バックエンドの一覧へ反映される
+
+    Scenario: あるバックエンドの取得失敗は他バックエンドの最新化を妨げない
+      Given 一部のバックエンドではモデル一覧の取得に失敗する
+      And 他のバックエンドではモデル一覧の取得に成功する
+      When アプリが起動する
+      Then 成功したバックエンドのモデル一覧は最新化される
+      And 失敗したバックエンドのモデル一覧は直前の登録内容のまま維持される
+      And 失敗したことが運用ログから追跡できる
+
+    Scenario: 取得結果が信頼できない場合は登録内容を変更しない
+      Given あるバックエンドの取得結果が要件を満たさない不正な内容である
+      When アプリがその結果を反映しようとする
+      Then 当該バックエンドのモデル一覧は直前の登録内容のまま維持される
+      And 不正な内容を受け入れなかったことが運用ログから追跡できる
+
+    Scenario: 取得結果に同一識別子の重複が含まれていても登録上は一意に保たれる
+      Given あるバックエンドの取得結果に同一のモデル識別子が複数含まれる
+      When アプリがその結果を反映する
+      Then 当該バックエンドのモデル一覧には同一識別子が重複して現れない
+
+    Scenario: 既に動いているバックエンドからの一覧通知も同じ規準で取り込まれる
+      Given アプリが既に起動しており、あるバックエンドが稼働している
+      When 当該バックエンドから新しいモデル一覧の通知が届く
+      Then 当該バックエンドのモデル一覧は、起動時と同じ受け入れ規準を経て最新化される
+      And ユーザーが見ているモデル選択候補も、その最新化された内容に追従する
+
+    Scenario: 同一バックエンドへの更新が競合しても他バックエンドの一覧を失わない
+      Given 同一バックエンドに対する複数の更新がほぼ同時に発生する
+      When それぞれの更新が処理される
+      Then 当該バックエンドのモデル一覧には、最後に受け入れられた有効な内容が反映される
+      And 他バックエンドのモデル一覧はその影響を受けない
+
+    Scenario: 既定モデルが現行の一覧に含まれない場合は未指定として扱う
+      Given あるバックエンドに既定モデルが設定されている
+      And その既定モデルが当該バックエンドの現行のモデル一覧に含まれない
+      When 当該バックエンドの新しいセッションが開始される
+      Then そのセッションの初期モデルは未指定として扱われる
+      And 既定モデルがサイレントに別のモデルへ書き換えられることはない
+      And 当該既定モデルが一覧外であることが運用ログから追跡できる
+
+    Scenario: 既定モデルが現行の一覧に含まれる場合は初期モデルとして使われる
+      Given あるバックエンドに既定モデルが設定されている
+      And その既定モデルが当該バックエンドの現行のモデル一覧に含まれる
+      When 当該バックエンドの新しいセッションが開始される
+      Then そのセッションの初期モデルは当該既定モデルとなる
+
+  Rule: モデル選択候補は登録済み一覧そのものを提示する
+    ユーザーがモデルを選ぶ場面では、登録済みのモデル一覧がそのまま候補として
+    提示される。コードに埋め込まれた候補や暗黙のフォールバック候補は提示しない。
+
+    Scenario: 登録済みのモデルが選択候補として提示される
+      Given あるバックエンドのモデル一覧が登録されている
+      When ユーザーが当該バックエンドのモデル選択を開く
+      Then 候補として、登録されているモデル識別子がそのまま提示される
+
+    Scenario: モデル識別子は取得元の文字列がそのまま表示される
+      Given あるバックエンドに、取得元から得られた識別子がそのまま登録されている
+      When ユーザーがモデル選択候補を見る
+      Then 候補欄には当該識別子が、加工や整形なしの文字列としてそのまま表示される
+
+    Scenario: モデル識別子は安全な文字列として表示される
+      Given 登録されているモデル識別子に、表示時に副作用を起こしうる文字が含まれる
+      When ユーザーがモデル選択候補を見る
+      Then 当該識別子は文字列としてのみ表示される
+      And 当該識別子に含まれる内容が画面上で実行・解釈されることはない
+      And メイン画面・リモート画面のいずれでも同様に振る舞う
+
+    Scenario: モデル一覧が空でも選択UI自体は提示される
+      Given あるバックエンドのモデル一覧が空である
+      When ユーザーが当該バックエンドのモデル選択を開く
+      Then モデル選択UI自体は表示される
+      And 候補は0件として提示される
+      And 暗黙のフォールバック候補や代替文言は含まれない
+
+  Rule: モデル指定は登録済み一覧に照らして検証される
+    ユーザーやワークフローが指定したモデルは、登録済みのモデル一覧と
+    照らし合わせて検証される。検証を通らなかった指定は、サイレントに
+    別のモデルへ置き換えられることはなく、明示的に拒否される。
+
+    Scenario: 当該セッションのバックエンドに登録済みのモデル指定は受け入れる
+      Given セッションのバックエンドが特定されている
+      And 指定されたモデルが、当該バックエンドのモデル一覧に登録されている
+      When ユーザーまたはワークフローがそのモデルを指定する
+      Then 指定は受け入れられ、当該セッションの選択モデルとなる
+
+    Scenario: 当該セッションのバックエンドに未登録のモデル指定は明示的に拒否する
+      Given セッションのバックエンドが特定されている
+      And 指定されたモデルが、当該バックエンドのモデル一覧に登録されていない
+      When ユーザーまたはワークフローがそのモデルを指定する
+      Then 指定は明示的なエラーで拒否される
+      And 当該セッションの選択モデルは変更されない
+      And サイレントに別のモデルへフォールバックすることはない
+
+    Scenario: 他バックエンドのモデルを当該セッションに指定するとバックエンド不一致として拒否する
+      Given セッションのバックエンドが特定されている
+      And 指定されたモデルは別バックエンドのモデル一覧にのみ登録されている
+      When ユーザーまたはワークフローがそのモデルを指定する
+      Then 指定はバックエンド不一致を示すエラーで拒否される
+      And 当該セッションの選択モデルは変更されない
+
+    Scenario: モデル指定がバックエンドに固定されないワークフロー経路では識別子から所属バックエンドを特定して受け入れる
+      Given ワークフローのステップではセッションのバックエンドが事前に固定されていない
+      And 指定されたモデルが、ただ一つのバックエンドのモデル一覧にのみ登録されている
+      When ワークフローが当該ステップを実行する
+      Then 指定モデルから所属するバックエンドが一意に特定される
+      And 当該バックエンドのセッションが、その指定モデルで開始される
+
+    Scenario: ワークフロー経路で指定モデルが複数バックエンドに登録されている場合は明示的に拒否する
+      Given ワークフローのステップではセッションのバックエンドが事前に固定されていない
+      And 指定されたモデルが、複数のバックエンドのモデル一覧に同一識別子で登録されている
+      When ワークフローが当該ステップを実行する
+      Then 所属バックエンドを一意に特定できないことを示す明示的なエラーで拒否され、セッションは開始されない
+      And いずれかのバックエンドへサイレントに割り当てられることはない
+
+    Scenario: いずれのバックエンドにも登録されていないモデル指定は、ワークフロー経路でも明示的に拒否する
+      Given ワークフローのステップではセッションのバックエンドが事前に固定されていない
+      And 指定されたモデルは、いずれのバックエンドのモデル一覧にも登録されていない
+      When ワークフローが当該ステップを実行する
+      Then 指定は明示的なエラーで拒否され、セッションは開始されない
+      And サイレントに別のモデルへフォールバックすることはない
+
+    Scenario: モデル未指定（選択解除）は受け入れ、暗黙のフォールバックは行わない
+      Given 当該セッションに選択モデルが設定されている
+      When ユーザーまたはワークフローがモデル未指定を指示する
+      Then 指示は受け入れられ、当該セッションの選択モデルは「未指定」状態に戻る
+      And 以降のセッション実行で、暗黙のうちに既定モデルへフォールバックすることはない
+
+    Scenario: 形式として無効なモデル指定は、登録判定に進まず拒否する
+      Given ユーザーまたはワークフローが、識別子として成立しない値をモデルに指定する
+      When その指定がモデル設定経路に到達する
+      Then 指定は登録一覧との照合に進む前に、形式不正として拒否される
+      And 指定された値は変更や正規化を受けない
+
+    Scenario: 検証は指定経路によらず同一の基準で行われる
+      Given ユーザーまたはワークフローが何らかの経路からモデルを指定する
+      When 同一内容の指定が異なる指定経路から行われる
+      Then モデル識別子の形式検証は、指定経路によらず同一のルールで行われる
+      And 登録済み一覧との照合判定も、指定経路によらず同一のルールで行われる
+      And 照合対象となる登録済み一覧は、当該経路が前提とする「セッションのバックエンドが固定されているか否か」のみに依存する（既存セッション経路は当該セッションの所属バックエンドの一覧、ワークフロー経路は全バックエンドの一覧から所属バックエンドを一意に特定する）
+      And 経路間で受け入れ／拒否の判定基準が分岐することはない
+```
+
+## アーキテクチャ概要
+
+### 責務配置
+
+- **`src-tauri/src/config.rs`（`AgentsSection` / `ClaudeAgentSection` / `CodexAgentSection`）**
+  - 担当する: 各バックエンドのモデル一覧（モデルID文字列のリスト）の永続化スキーマ定義、デフォルト値（空リスト）の提供、`config.toml` への書き出し、既存の `agents.<backend>.model`（起動時の初期モデル）の永続化スキーマ維持
+  - 担当しない: モデル一覧の取得・検証・更新タイミングの決定、`agents.<backend>.model` を `agents.<backend>.models` に対して整合チェックする処理（整合チェックは起動シーケンス側で実施）
+
+- **`src-tauri/src/backends/{claude,codex}.rs`（各 `AgentBackend` 実装）**
+  - 担当する: 自バックエンドCLIへ問い合わせて生のモデル識別子リストを取得する処理（CLIコマンド呼び出し・出力パース・タイムアウト・エラーハンドリング）
+  - 担当しない: 取得結果の永続化、ハードコードされたモデル一覧の保持、`available_models()` の表示用整形
+
+- **`src-tauri/src/backends/mod.rs`（`AgentBackendRegistry` / `ModelInfo`）**
+  - 担当する: 「設定ファイル上のモデル一覧」と「バックエンドCLI取得処理」の仲介、`available_models()` を config 由来で返す、起動時バックグラウンド同期処理のエントリポイント提供、モデル指定の検証（`resolve_backend_for_model` / `collect_all_model_values` を config.toml 由来へ切替）、モデルID入力検証ルールの提供、ワークフロー step 実行経路における所属バックエンド特定の一意性保証（同一モデルIDが複数バックエンドに登録されている場合は一意特定不能として明示エラーを返す／`model_id=None` は選択解除として扱い暗黙の既定モデルへフォールバックさせない）
+  - 担当しない: モデル取得CLIの具体的な呼び出し、`config.toml` のスキーマ詳細
+
+- **`src-tauri/src/backends/bridge_common.rs`**
+  - 担当する: `supported_models` メッセージ受信時の検証＆ config.toml への保存呼び出し、`agent-models-updated` イベントは config.toml 由来の最新値で配信、`set_agent_model` / `set_agent_model_internal` における config 由来の登録済みモデル検証（当該セッションの `backend_id` に登録されたモデル一覧のみと突合し、別バックエンドのモデルは backend mismatch として拒否）、`model_id` が `None`（null）の場合の選択解除処理（暗黙の既定モデルへフォールバックさせない）
+  - 担当しない: `available_models.json` 系ファイルへの読み書き（経路を廃止）
+
+- **`src-tauri/src/ws_server/handlers.rs`（`handle_agent_model_set_request`）**
+  - 担当する: `AgentModelSetRequest` を transport 層として受け付け、共通のモデル設定処理（`bridge_common.rs` の `set_agent_model_internal`）へ委譲する。委譲先から返ったエラー（入力検証エラー／backend mismatch／登録外モデル）を WebSocket クライアントへエラー応答として返却し、成功時は成功応答を返す
+  - 担当しない: 入力検証ロジックそのもの、config 由来の登録済みモデル検証ロジックそのもの（これらは単一経路の `set_agent_model_internal` に集約する）、モデル一覧の保持
+
+- **`src-tauri/src/lib.rs`（setup フック）**
+  - 担当する: アプリ起動時に Registry の同期処理を `tokio::spawn` でバックエンド単位に独立して起動するトリガー、起動時に `agents.<backend>.model` が `agents.<backend>.models` に含まれるかを検査し、未登録なら警告ログを出して当該バックエンドの初期モデルを「未指定」として扱う
+  - 担当しない: 同期処理本体のロジック、`agents.<backend>.model` の書き換え（サイレントなフォールバック書き換えはしない）
+
+- **フロントエンド（`ModelSelector.tsx` / `MessageInput.tsx` / `session.ts` 等、および `src/remote/` 配下のモデル指定導線）**
+  - 担当する: Tauri コマンドから返ったモデル一覧の表示、選択状態の保持、`value` をそのまま画面に表示、Remote UI から `AgentModelSetRequest` を送信
+  - 担当しない: モデル一覧のキャッシュ・補完・フォールバック生成、`ModelInfo.displayName` 由来の派生表示
+
+### データ/通信フロー
+
+- **起動時のモデル一覧同期**:
+  `lib.rs setup` → バックエンドごとに `tokio::spawn(Registry::refresh_models_to_config_for(backend_id, AppConfig))` →
+  各 `AgentBackend::fetch_models_from_cli()` → 入力検証を通過した場合のみ `AppConfig::with_config_mut` で
+  `agents.<backend>.models` を書き換え＆`write_config` → 失敗時は当該バックエンドのみ `log::warn!` で記録し他バックエンドは継続。
+  アプリ起動自体はこの spawn を待たない。
+
+- **`supported_models` メッセージ経由の更新**:
+  起動済みエージェントプロセスからの `supported_models` 受信 → `bridge_common.rs` で入力検証 →
+  config.toml の `agents.<backend>.models` を書き換え → 既存契約名 `agent-models-updated` イベントを
+  config.toml 由来の最新値で配信（`available_models.json` / `available_models_{backend_id}.json`
+  への書き込みは行わない）。
+
+- **モデル選択候補の取得（UI 表示用）**:
+  フロントエンド `ModelSelector` → 既存契約 `get_session` の response に含まれる `available_models`
+  フィールド、および既存契約 `agent-models-updated` イベント（増分配信） →
+  いずれも供給元を `config.toml` の `agents.<backend>.models` に統合し、`AgentBackendRegistry::available_models(id)`
+  経由で `AppConfig` から読み出す → `Vec<ModelInfo { value }>` を返却（`value` のみ／空リストもあり得る）。
+
+- **モデル指定の検証（経路別）**:
+  - **共通の前段（入力検証）**: ユーザー／ワークフローによるモデル指定 → 入力検証（入力値を変更せず、Unicode White_Space のみで構成される文字列・空文字列・制御文字を含む文字列・上限長 128 文字を超える文字列は形式不正として即拒否）。
+  - **set_agent_model / AgentModelSetRequest（既存セッションへのモデル設定）**:
+    `model_id` が `None`（null）の場合は当該セッションの選択モデルを未指定状態へ戻し、後続の暗黙フォールバックを行わない →
+    非 null の場合は当該セッションの `backend_id` に登録されたモデル一覧（`AgentBackendRegistry::available_models()` 経由で config から取得）とのみ突合 →
+    別バックエンドのモデルは backend mismatch、当該バックエンドの一覧にも無いものは登録外として、いずれも明示エラーを呼び出し元へ返す（サイレントフォールバックなし）。
+    検証ロジックは `bridge_common.rs` の `set_agent_model_internal` に集約し、Tauri コマンド／WebSocket handler はこれへ委譲する。
+  - **ワークフロー step 実行（新規セッション起動）**:
+    `model_id` が `None`（null／未指定）の場合は当該 step session の選択モデルを未指定状態のままとし、暗黙の既定モデルへフォールバックさせない →
+    非 null の場合は共通の前段（入力検証）を通した上で、既存契約の `resolve_backend_for_model` により指定 model から backend を決定し、当該 step session の backend をその backend に切り替える →
+    全 backend のいずれにも登録されていないモデルは登録外として明示エラー（validation error）で拒否する（サイレントフォールバックなし） →
+    同一モデルIDが複数 backend に登録されている場合は所属 backend を一意に特定できないため、明示エラー（validation error）で拒否する（いずれかの backend へサイレントに割り当てない）。
+    ワークフロー経路は当該セッションの backend_id を事前に固定しないため、backend mismatch ルールは適用しない。
+
+### 状態 Owner
+
+- **永続的なモデル一覧（バックエンド毎）**: `config.toml`（`AppConfig` がメモリ上のキャッシュと書き出しを Own。`available_models.json` は廃止）
+- **CLI 取得処理の実装**: 各 `AgentBackend` 実装（`ClaudeBackend` / `CodexBackend`）
+- **同期処理のスケジューリング（起動時 1 回、バックエンド単位）**: `lib.rs` の setup フック
+- **モデル選択 UI の選択状態**: フロントエンド（既存の `useSessionStore` 等、本 issue で変更しない）
+- **`ModelInfo` の正規定義**: `src-tauri/src/backends/mod.rs`（`value: String` のみ）／フロントは `src/types/session.ts`（`value: string` のみ）
+
+### 境界
+
+- Rust ↔ フロントエンド: `ModelInfo` は `{ value }` のみ。`displayName` フィールドをシリアライズに含めない。フロントは `value` をテキストとして表示し、HTML/JS として解釈しない（メイン UI・Remote UI ともに React 既定のテキストノードとして描画し、`dangerouslySetInnerHTML` 等での挿入を行わない）。対象は `ModelInfo.displayName` のみで、`PermissionRequest.display_name`（権限ダイアログ表示名）は本変更の対象外。
+- バックエンド trait ↔ config: `AgentBackend` は config を直接書き換えない。書き換えは Registry の同期処理経由でのみ行う。
+- CLI 取得 ↔ 永続化: CLI 取得失敗（プロセス起動失敗・タイムアウト・パース失敗・空応答）および入力検証失敗（空文字モデルID・制御文字・上限長超過・上限件数超過）は決して config を上書きしない。重複モデルIDは除去した上で保存する。
+- 既存 JSON キャッシュの廃止: `bridge_common.rs` の `available_models_path` / `save_available_models` / `load_available_models` および `available_models.json` / `available_models_{backend_id}.json` 経路は廃止する。永続化先は `config.toml` のみとし、`agent-models-updated` イベントの供給元も config.toml に統合する。
+- ハードコード禁止: `*_supported_models()` 由来のリテラルなモデル一覧はコード上に残さない（テストフィクスチャ内のモックを除く）。
+- 同期処理 ↔ 起動シーケンス: 同期処理はバックエンドごとに独立して `tokio::spawn` し、起動フローをブロックしない。1バックエンドの失敗は他バックエンドの同期処理に伝播しない。
+- バックエンド単位の原子性: モデル一覧の更新（起動時CLI同期および `supported_models` 受信経由）は各バックエンド単位で原子的に反映する。同一バックエンドに対する複数の更新が競合した場合は、最後にコミットされた有効値を `config.toml` の値とする。1 バックエンドの更新は他バックエンドの一覧に影響を与えない（他バックエンドの一覧を失わない）。
+- モデルID入力検証: モデルIDは「入力値は変更しない（trim 等の正規化を一切行わない）」「Unicode White_Space のみで構成される文字列は空白のみとして拒否」「空文字列を拒否」「制御文字（U+0000–U+001F、U+007F）を含まない」「上限長 128 文字以内（UTF-8 のコードポイント数）」「同一文字列の重複は除去し、重複除去後のユニーク件数が 1 バックエンドあたり 256 件以内」を満たす場合のみ有効。129 文字以上のモデルIDは拒否する。配列の件数上限は重複除去後のユニーク件数で判定し、重複除去後のユニーク件数が 257 件以上なら拒否する（重複除去前の入力配列が 257 件以上でも、除去後に 256 件以内に収まる場合は受け入れる）。検証に失敗した場合は `config.toml` を更新しない／指定として受け入れない。CLI由来・ユーザー由来（`set_agent_model` Tauri コマンド／`AgentModelSetRequest` WebSocket／ワークフロー step config／Remote UI 自由入力）すべてに同一の検証ルールを適用する（経路間で正規化方針は分岐させない）。
+- 未登録モデル指定の扱い: 入力検証を通過した上で当該セッションの `backend_id` の `config.toml` モデル一覧に登録されていないモデルIDが指定された場合、サイレントに既定モデルへフォールバックせず、明示エラー（validation error / エラー応答）を呼び出し元（ワークフロー検証経路 / Tauri コマンド呼び出し元 / WebSocket クライアント / Remote UI）へ返す。別バックエンドに登録されたモデルIDの指定は backend mismatch として拒否する。`model_id=null`（`Option<String>=None`）は選択解除として受け入れ、当該セッションのモデル選択を未指定状態へ戻す（暗黙の既定モデルへフォールバックさせない）。
+- ワークフロー経路の所属バックエンド一意性: ワークフロー step 実行経路では当該セッションの `backend_id` を事前に固定しないため、指定モデルIDから所属バックエンドが一意に特定できる場合のみ受け入れる。同一モデルIDが複数バックエンドの `config.toml` モデル一覧に登録されている場合は所属バックエンドを一意に特定できないものとして、いずれかの backend にサイレント割り当てを行わず、明示エラーで拒否する。
+- Remote UI / WebSocket 経路の認可: `AgentModelSetRequest` を含むモデル設定操作の認可は、既存の WebSocket 認証（HMAC トークン）およびセッション認可スキームに従う。本変更で新たな認可経路・権限モデルは導入しない。
+
+### 実装に委ねること
+
+- 各バックエンドCLI問い合わせの具体的なコマンド・引数・出力パース手順（例: `codex debug models` のフォーマット、Claude 側の取得手段選定）
+- CLI 呼び出しのタイムアウト値・リトライ有無
+- `fetch_models_from_cli()` のメソッド名・シグネチャの細部、および `AgentBackend` trait に追加するか別 trait に切り出すかの選択
+- `AgentsSection` 配下の `models` フィールドを `ClaudeAgentSection` / `CodexAgentSection` に持たせるか共通の `HashMap<String, Vec<String>>` で持たせるかの選択
+- Registry 同期処理の関数名・配置モジュール、およびバックエンド単位 spawn の具体的な並行制御手段
+- ログメッセージの具体文言
+- 既存 `collect_all_model_values` / `resolve_backend_for_model` を config 経由に切り替える際の内部リファクタリング詳細
+- `available_models.json` 既存ファイルの除去タイミング（起動時クリーンアップを行うか単に参照をやめるかの選択）
+- テストケースの具体的な配置（既存テストのうち `display_name` 依存箇所の更新方法、CLI モック化の手段）
+- フロントエンド側 `displayName` 参照箇所の置き換え順序（型・コンポーネント・ストア・テスト）

--- a/scripts/build-bridge.mjs
+++ b/scripts/build-bridge.mjs
@@ -5,6 +5,10 @@ const outputDir = "src-tauri/generated/bridges";
 
 const bridges = [
 	["claude-sdk-bridge.mjs", "claude-sdk-bridge.bundled.mjs"],
+	[
+		"claude-sdk-bridge-list-models.mjs",
+		"claude-sdk-bridge-list-models.bundled.mjs",
+	],
 	["codex-sdk-bridge.mjs", "codex-sdk-bridge.bundled.mjs"],
 ];
 

--- a/src-tauri/resources/claude-sdk-bridge-list-models.mjs
+++ b/src-tauri/resources/claude-sdk-bridge-list-models.mjs
@@ -1,0 +1,69 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
+
+const TIMEOUT_MS = 8000;
+
+export async function collectClaudeModels({
+	queryImpl = query,
+	cwd = tmpdir(),
+	timeoutMs = TIMEOUT_MS,
+	AbortControllerImpl = AbortController,
+} = {}) {
+	const abort = new AbortControllerImpl();
+
+	// Generator awaits forever; we only need the SDK initializationResult,
+	// not an actual turn. Abort triggers cleanup on exit.
+	const generator = (async function* () {
+		await new Promise(() => {});
+	})();
+
+	const q = queryImpl({
+		prompt: generator,
+		options: {
+			cwd,
+			abortController: abort,
+			permissionMode: "acceptEdits",
+			settingSources: ["user"],
+			pathToClaudeCodeExecutable: "claude",
+		},
+	});
+
+	let timer;
+	try {
+		const result = await Promise.race([
+			q.initializationResult(),
+			new Promise((_, reject) => {
+				timer = setTimeout(
+					() => reject(new Error("initializationResult timeout")),
+					timeoutMs,
+				);
+			}),
+		]);
+		return Array.isArray(result?.models) ? result.models : [];
+	} finally {
+		if (timer) clearTimeout(timer);
+		abort.abort();
+	}
+}
+
+export async function runClaudeListModelsProbe({
+	writeStdout = (text) => process.stdout.write(text),
+	writeStderr = (text) => process.stderr.write(text),
+	exit = (code) => process.exit(code),
+	...deps
+} = {}) {
+	try {
+		const models = await collectClaudeModels(deps);
+		writeStdout(`${JSON.stringify({ models })}\n`);
+		exit(0);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		writeStderr(`claude-list-models failed: ${msg}\n`);
+		exit(1);
+	}
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	await runClaudeListModelsProbe();
+}

--- a/src-tauri/resources/claude-sdk-bridge-list-models.test.mjs
+++ b/src-tauri/resources/claude-sdk-bridge-list-models.test.mjs
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+const sdk = vi.hoisted(() => ({
+	query: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+	query: sdk.query,
+}));
+
+import { runClaudeListModelsProbe } from "./claude-sdk-bridge-list-models.mjs";
+
+function makeProbeIo() {
+	const stdout = [];
+	const stderr = [];
+	const exits = [];
+	return {
+		stdout,
+		stderr,
+		exits,
+		writeStdout: (text) => stdout.push(text),
+		writeStderr: (text) => stderr.push(text),
+		exit: (code) => exits.push(code),
+	};
+}
+
+describe("claude-sdk-bridge-list-models", () => {
+	it("writes initializationResult models as stdout JSON", async () => {
+		sdk.query.mockReturnValue({
+			initializationResult: vi.fn(async () => ({
+				models: [{ value: "claude-sonnet" }, { value: "claude-opus" }],
+			})),
+		});
+		const io = makeProbeIo();
+
+		await runClaudeListModelsProbe(io);
+
+		expect(io.stdout.join("")).toBe(
+			`${JSON.stringify({
+				models: [{ value: "claude-sonnet" }, { value: "claude-opus" }],
+			})}\n`,
+		);
+		expect(io.stderr).toEqual([]);
+		expect(io.exits).toEqual([0]);
+	});
+
+	it("writes an empty models array when initializationResult omits models", async () => {
+		sdk.query.mockReturnValue({
+			initializationResult: vi.fn(async () => ({ sessionId: "s1" })),
+		});
+		const io = makeProbeIo();
+
+		await runClaudeListModelsProbe(io);
+
+		expect(io.stdout.join("")).toBe(`${JSON.stringify({ models: [] })}\n`);
+		expect(io.stderr).toEqual([]);
+		expect(io.exits).toEqual([0]);
+	});
+
+	it("writes stderr and exits non-zero on SDK failure", async () => {
+		sdk.query.mockReturnValue({
+			initializationResult: vi.fn(async () => {
+				throw new Error("bad credentials");
+			}),
+		});
+		const io = makeProbeIo();
+
+		await runClaudeListModelsProbe(io);
+
+		expect(io.stdout).toEqual([]);
+		expect(io.stderr.join("")).toBe(
+			"claude-list-models failed: bad credentials\n",
+		);
+		expect(io.exits).toEqual([1]);
+	});
+});

--- a/src-tauri/resources/codex-sdk-bridge-runtime.mjs
+++ b/src-tauri/resources/codex-sdk-bridge-runtime.mjs
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
-	SUPPORTED_CODEX_MODELS,
 	codexEventToBridgeMessages,
 	createThreadOptions,
 } from "./codex-sdk-bridge-utils.mjs";
@@ -113,7 +112,8 @@ export class CodexBridgeRuntime {
 		this.currentThreadId = this.initialResumeThreadId;
 		this.currentThread = this.createThread();
 
-		this.emit({ type: "supported_models", models: SUPPORTED_CODEX_MODELS });
+		// Codex のモデル一覧は起動時 CLI 同期（`codex debug models`）で config.toml に
+		// 反映するため、bridge からは supported_models を emit しない（ハードコード一覧の撤去）。
 		this.emit({
 			type: "session_ready",
 			session_id: this.currentThreadId,

--- a/src-tauri/resources/codex-sdk-bridge-runtime.test.mjs
+++ b/src-tauri/resources/codex-sdk-bridge-runtime.test.mjs
@@ -105,7 +105,7 @@ async function waitFor(predicate) {
 }
 
 describe("CodexBridgeRuntime", () => {
-	it("initializes a new thread and emits supported models", () => {
+	it("initializes a new thread and does not emit a hardcoded supported_models list", () => {
 		const codex = new FakeCodex();
 		const { runtime, emitted } = makeRuntime(codex);
 
@@ -123,8 +123,12 @@ describe("CodexBridgeRuntime", () => {
 			approvalPolicy: "never",
 			sandboxMode: "workspace-write",
 		});
-		expect(emitted[0]).toMatchObject({ type: "supported_models" });
-		expect(emitted[1]).toMatchObject({
+		// Codex のモデル一覧は起動時 CLI 同期で config.toml に反映するため、
+		// bridge からは supported_models を emit しない。
+		expect(
+			emitted.some((m) => m.type === "supported_models"),
+		).toBe(false);
+		expect(emitted[0]).toMatchObject({
 			type: "session_ready",
 			session_id: null,
 			initialized: true,
@@ -155,8 +159,10 @@ describe("CodexBridgeRuntime", () => {
 
 		expect(calls).toEqual(["/usr/local/bin/codex"]);
 		expect(codex.started).toHaveLength(1);
-		expect(emitted[0]).toMatchObject({ type: "supported_models" });
-		expect(emitted[1]).toMatchObject({
+		expect(
+			emitted.some((m) => m.type === "supported_models"),
+		).toBe(false);
+		expect(emitted[0]).toMatchObject({
 			type: "session_ready",
 			session_id: null,
 			initialized: true,

--- a/src-tauri/resources/codex-sdk-bridge-utils.mjs
+++ b/src-tauri/resources/codex-sdk-bridge-utils.mjs
@@ -1,11 +1,3 @@
-export const SUPPORTED_CODEX_MODELS = [
-	{ value: "gpt-5.4", displayName: "GPT-5.4" },
-	{ value: "gpt-5.3-codex", displayName: "GPT-5.3 Codex" },
-	{ value: "gpt-5.2-codex", displayName: "GPT-5.2 Codex" },
-	{ value: "gpt-5-codex", displayName: "GPT-5 Codex" },
-	{ value: "o3", displayName: "o3" },
-];
-
 export function approvalPolicyFromPermissionMode(permissionMode) {
 	switch (permissionMode) {
 		case "plan":

--- a/src-tauri/src/backends/bridge_common.rs
+++ b/src-tauri/src/backends/bridge_common.rs
@@ -2667,14 +2667,10 @@ fn get_persisted_spawn_info(
     app: &tauri::AppHandle,
     session_store: &SessionStore,
     chat_session_id: &str,
-) -> (Option<String>, Option<String>, String) {
-    let persisted = resolve_data_dir(app).ok().and_then(|data_dir| {
-        session_store
-            .get_session(&data_dir, chat_session_id)
-            .ok()
-            .flatten()
-    });
-    resolve_spawn_info(persisted)
+) -> Result<(Option<String>, Option<String>, String), String> {
+    let data_dir = resolve_data_dir(app)?;
+    let persisted = session_store.get_session(&data_dir, chat_session_id)?;
+    Ok(resolve_spawn_info(persisted))
 }
 
 /// 永続化セッションから spawn 情報を組み立てる純粋関数。
@@ -2724,7 +2720,7 @@ pub(crate) async fn start_agent_session_internal(
     }
 
     let (resume_sid, selected_model, backend_id) =
-        get_persisted_spawn_info(app, session_store, chat_session_id);
+        get_persisted_spawn_info(app, session_store, chat_session_id)?;
 
     spawn_bridge_process(
         app,
@@ -2766,7 +2762,7 @@ pub(crate) async fn start_agent_turn(
         || async {
             wait_until_session_close_finished(chat_session_id).await;
             let (resume_sid, selected_model, backend_id) =
-                get_persisted_spawn_info(app, session_store, chat_session_id);
+                get_persisted_spawn_info(app, session_store, chat_session_id)?;
 
             spawn_bridge_process(
                 app,
@@ -2820,7 +2816,7 @@ async fn start_agent_turn_locked(
         images,
         || async {
             let (resume_sid, selected_model, backend_id) =
-                get_persisted_spawn_info(app, session_store, chat_session_id);
+                get_persisted_spawn_info(app, session_store, chat_session_id)?;
 
             spawn_bridge_process(
                 app,

--- a/src-tauri/src/backends/bridge_common.rs
+++ b/src-tauri/src/backends/bridge_common.rs
@@ -13,15 +13,20 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::Mutex;
 
+use crate::backends::model_catalog_sync::{
+    build_agent_models_updated_payload, handle_supported_models_message,
+};
 use crate::backends::runtime_coordinator::{
     acquire_spawn_session_guard, clear_pending_turn_starting, clear_session_closing,
     is_pending_turn_starting, mark_pending_turn_starting, mark_session_closing,
     prune_session_runtime_lock, wait_until_session_close_finished,
 };
 use crate::backends::{BackendRuntimeConfig, ImageAttachment, ModelInfo};
+#[cfg(test)]
+use crate::session::create_session_internal;
 use crate::session::{
-    add_message_internal, create_session_internal, now_timestamp, resolve_data_dir, ChatMessage,
-    ChatSession, GetSessionResponse, MessagePart, MessageRole, SessionStore, SessionSummary,
+    add_message_internal, now_timestamp, resolve_data_dir, ChatMessage, ChatSession,
+    GetSessionResponse, MessagePart, MessageRole, SessionStore, SessionSummary,
 };
 
 pub(crate) use crate::backends::runtime_coordinator::{
@@ -182,37 +187,6 @@ async fn agent_session_has_pending_message(
         .is_some_and(|proc| proc.pending_message.is_some())
 }
 
-pub(crate) fn available_models_path(app_data_dir: &Path, backend_id: &str) -> PathBuf {
-    if backend_id == CLAUDE_BACKEND_ID {
-        app_data_dir.join("available_models.json")
-    } else {
-        app_data_dir.join(format!("available_models_{backend_id}.json"))
-    }
-}
-
-pub(crate) fn save_available_models(
-    app_data_dir: &Path,
-    backend_id: &str,
-    models: &[ModelInfo],
-) -> Result<(), String> {
-    std::fs::create_dir_all(app_data_dir).map_err(|e| format!("Failed to create data dir: {e}"))?;
-    let file = available_models_path(app_data_dir, backend_id);
-    let json =
-        serde_json::to_string(models).map_err(|e| format!("Failed to serialize models: {e}"))?;
-    let tmp = file.with_extension("json.tmp");
-    std::fs::write(&tmp, json).map_err(|e| format!("Failed to write models temp file: {e}"))?;
-    std::fs::rename(&tmp, &file).map_err(|e| format!("Failed to rename models temp file: {e}"))?;
-    Ok(())
-}
-
-pub(crate) fn load_available_models(app_data_dir: &Path, backend_id: &str) -> Vec<ModelInfo> {
-    let file = available_models_path(app_data_dir, backend_id);
-    match std::fs::read_to_string(&file) {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => Vec::new(),
-    }
-}
-
 pub(crate) fn bridge_script_names(backend_id: &str) -> (&'static str, &'static str) {
     match backend_id {
         CODEX_BACKEND_ID => (
@@ -296,25 +270,21 @@ fn backend_runtime_config(app: &tauri::AppHandle, backend_id: &str) -> BackendRu
         .unwrap_or_default()
 }
 
-fn load_available_models_for_backend(app_data_dir: &Path, backend_id: &str) -> Vec<ModelInfo> {
-    load_available_models(app_data_dir, backend_id)
-}
-
-async fn available_models_for_backend(
-    app_data_dir: &Path,
+/// 指定 backend の登録モデル一覧を config.toml から取得する。
+///
+/// - registry 未指定（テスト等）: `Ok(Vec::new())`
+/// - registry の lookup が失敗（config 未紐付け／schema 未対応／lock 失敗）: `Err`
+///
+/// 「登録済みモデルが 0 件」と infrastructure 故障を呼び出し側で区別できるよう
+/// 必ず Err を伝播する。表示専用経路は warn + 既存値維持で空上書きを防ぐこと、
+/// 永続化に絡む経路は Err をそのまま呼び出し元に伝えること。
+fn available_models_for_backend(
     backend_id: &str,
     registry: Option<&Arc<crate::backends::AgentBackendRegistry>>,
-) -> Vec<ModelInfo> {
-    let cached = load_available_models_for_backend(app_data_dir, backend_id);
-    if !cached.is_empty() {
-        return cached;
-    }
+) -> Result<Vec<ModelInfo>, String> {
     match registry {
-        Some(registry) => registry
-            .available_models(backend_id)
-            .await
-            .unwrap_or_default(),
-        None => Vec::new(),
+        Some(registry) => registry.available_models(backend_id),
+        None => Ok(Vec::new()),
     }
 }
 
@@ -1787,53 +1757,16 @@ async fn spawn_bridge_process(
                         let _ = app_stdout.emit("agent-sdk-message", &msg);
                     }
                     "supported_models" => {
-                        // Parse models from Bridge and store in AgentProcess
-                        let models: Vec<ModelInfo> = msg
-                            .get("models")
-                            .and_then(|v| v.as_array())
-                            .map(|arr| {
-                                arr.iter()
-                                    .filter_map(|m| {
-                                        let value =
-                                            m.get("value").and_then(|v| v.as_str())?.to_string();
-                                        let display_name = m
-                                            .get("displayName")
-                                            .and_then(|v| v.as_str())
-                                            .unwrap_or(&value)
-                                            .to_string();
-                                        Some(ModelInfo {
-                                            value,
-                                            display_name,
-                                        })
-                                    })
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-
-                        let (selected_model, backend_id) = {
-                            let mut map = handles_stdout.lock().await;
-                            if let Some(proc) = map.get_mut(&csid_stdout) {
-                                proc.available_models = models.clone();
-                                (proc.selected_model.clone(), proc.backend_id.clone())
-                            } else {
-                                (None, CLAUDE_BACKEND_ID.to_string())
-                            }
-                        };
-
-                        // Persist models per backend
-                        if let Ok(data_dir) = resolve_data_dir(&app_stdout) {
-                            let _ = save_available_models(&data_dir, &backend_id, &models);
-                        }
-
-                        // Emit models to frontend
-                        let _ = app_stdout.emit(
-                            "agent-models-updated",
-                            serde_json::json!({
-                                "chat_session_id": csid_stdout,
-                                "available_models": models,
-                                "selected_model": selected_model,
-                            }),
-                        );
+                        let registry_state =
+                            app_stdout.try_state::<Arc<crate::backends::AgentBackendRegistry>>();
+                        handle_supported_models_message(
+                            Some(&app_stdout),
+                            &handles_stdout,
+                            registry_state.as_deref().map(|arc| arc.as_ref()),
+                            &csid_stdout,
+                            &msg,
+                        )
+                        .await;
                     }
                     "session_cleared" => {
                         {
@@ -2537,29 +2470,23 @@ async fn get_session_internal_with_data_dir(
     match session {
         None => Ok(None),
         Some(mut session) => {
-            let (turn_phase, raw_parts, streaming_mid, proc_models) = {
+            let (turn_phase, raw_parts, streaming_mid) = {
                 let map = handles.lock().await;
                 if let Some(proc) = map.get(session_id) {
                     // Override persisted mode with runtime mode (includes transient "plan")
                     session.permission_mode = proc.current_permission_mode.clone();
                     let phase = proc.turn_phase;
-                    let models = if !proc.available_models.is_empty() {
-                        proc.available_models.clone()
-                    } else {
-                        Vec::new()
-                    };
                     if proc.state == BridgeState::Streaming {
                         (
                             phase,
                             proc.streaming_parts.clone(),
                             proc.streaming_message_id.clone(),
-                            models,
                         )
                     } else {
-                        (phase, Vec::new(), None, models)
+                        (phase, Vec::new(), None)
                     }
                 } else {
-                    (TurnPhase::Idle, Vec::new(), None, Vec::new())
+                    (TurnPhase::Idle, Vec::new(), None)
                 }
             };
 
@@ -2574,13 +2501,19 @@ async fn get_session_internal_with_data_dir(
                 }
             }
 
-            // Use process models (latest from SDK) if available, otherwise fall back to global cache
-            let available_models = if !proc_models.is_empty() {
-                proc_models
-            } else {
-                let backend_id = session.backend_id.as_deref().unwrap_or(CLAUDE_BACKEND_ID);
-                available_models_for_backend(data_dir, backend_id, registry).await
-            };
+            // 永続的なモデル一覧の owner は config.toml 単一。プロセス内キャッシュは
+            // 参照しない（プロセス側の `proc.available_models` は emit 整合用にのみ
+            // 維持される）。
+            // get_session は表示専用経路のため、infrastructure 故障で取得に失敗した場合は
+            // warn を残して空一覧を返し、上位の UI 描画を妨げない。
+            let backend_id = session.backend_id.as_deref().unwrap_or(CLAUDE_BACKEND_ID);
+            let available_models =
+                available_models_for_backend(backend_id, registry).unwrap_or_else(|e| {
+                    log::warn!(
+                        "get_session: backend '{backend_id}' のモデル一覧取得に失敗（空一覧で応答）: {e}"
+                    );
+                    Vec::new()
+                });
 
             Ok(Some(GetSessionResponse {
                 session,
@@ -2668,8 +2601,8 @@ async fn set_session_backend_internal(
         ));
     }
 
+    session.selected_model = registry.initial_model_for(&resolved_backend_id);
     session.backend_id = Some(resolved_backend_id);
-    session.selected_model = None;
     session.updated_at = now_timestamp();
     session_store.save_session(data_dir, &session)?;
     remove_stale_unstarted_agent_process(handles, data_dir, chat_session_id).await;
@@ -2725,24 +2658,33 @@ pub async fn get_session(
 }
 
 /// Retrieve persisted session fields needed for spawning a Bridge process.
+///
+/// `selected_model` は永続化されている値をそのまま採用する。
+/// 初期モデルはセッション作成時 (`create_session_with_initial_model`) に解決して
+/// 永続化されているため、spawn 経路では「`selected_model == None` は常に
+/// 明示的に未指定」を意味する。暗黙の既定モデルへのフォールバックはしない。
 fn get_persisted_spawn_info(
     app: &tauri::AppHandle,
     session_store: &SessionStore,
     chat_session_id: &str,
 ) -> (Option<String>, Option<String>, String) {
-    let mut info =
-        persisted_spawn_info_from_session(resolve_data_dir(app).ok().and_then(|data_dir| {
-            session_store
-                .get_session(&data_dir, chat_session_id)
-                .ok()
-                .flatten()
-        }));
+    let persisted = resolve_data_dir(app).ok().and_then(|data_dir| {
+        session_store
+            .get_session(&data_dir, chat_session_id)
+            .ok()
+            .flatten()
+    });
+    resolve_spawn_info(persisted)
+}
 
-    if info.1.is_none() {
-        info.1 = backend_runtime_config(app, &info.2).initial_model;
-    }
-
-    info
+/// 永続化セッションから spawn 情報を組み立てる純粋関数。
+///
+/// `selected_model == None` は「明示的に未指定」を意味し、初期モデルへのフォールバックは
+/// この関数では行わない（fallback はセッション作成時にのみ適用される）。
+pub(crate) fn resolve_spawn_info(
+    persisted: Option<ChatSession>,
+) -> (Option<String>, Option<String>, String) {
+    persisted_spawn_info_from_session(persisted)
 }
 
 fn persisted_spawn_info_from_session(
@@ -3377,7 +3319,7 @@ pub(crate) async fn set_active_process_model(
     handles: &Arc<Mutex<AgentProcessMap>>,
     chat_session_id: &str,
     model_id: Option<String>,
-) -> Result<Option<Vec<ModelInfo>>, String> {
+) -> Result<(), String> {
     let data = build_set_model_command(model_id.as_deref());
     let mut map = handles.lock().await;
     if let Some(proc) = map.get_mut(chat_session_id) {
@@ -3390,10 +3332,8 @@ pub(crate) async fn set_active_process_model(
             .await
             .map_err(|e| format!("Failed to flush setModel: {e}"))?;
         proc.selected_model = model_id;
-        Ok(Some(proc.available_models.clone()))
-    } else {
-        Ok(None)
     }
+    Ok(())
 }
 
 pub(crate) async fn set_agent_model_internal(
@@ -3404,41 +3344,122 @@ pub(crate) async fn set_agent_model_internal(
     chat_session_id: &str,
     model_id: Option<String>,
 ) -> Result<(), String> {
+    let data_dir = resolve_data_dir(app)?;
+    set_agent_model_internal_with_data_dir(
+        Some(app),
+        handles,
+        session_store,
+        registry,
+        &data_dir,
+        chat_session_id,
+        model_id,
+    )
+    .await
+}
+
+/// `set_agent_model_internal` のテスト用バリエーション。
+/// `tauri::AppHandle` の代わりに `data_dir` を直接受け取り、emit は AppHandle が
+/// 渡された場合のみ行う。検証ロジックの単体テストに用いる。
+pub(crate) async fn set_agent_model_internal_with_data_dir(
+    app: Option<&tauri::AppHandle>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    registry: Option<&Arc<crate::backends::AgentBackendRegistry>>,
+    data_dir: &Path,
+    chat_session_id: &str,
+    model_id: Option<String>,
+) -> Result<(), String> {
+    let mut session = session_store
+        .get_session(data_dir, chat_session_id)?
+        .ok_or_else(|| format!("Session not found: {chat_session_id}"))?;
+    let backend_id = session
+        .backend_id
+        .clone()
+        .unwrap_or_else(|| CLAUDE_BACKEND_ID.to_string());
+
+    // 非 null のみ検証。`model_id=None` は選択解除として受け入れ、暗黙のフォールバックは行わない。
+    if let Some(model) = model_id.as_deref() {
+        crate::domain::agent_session::ModelId::parse(model)?;
+        if let Some(reg) = registry {
+            let session_models: Vec<String> = reg.config_models_for(&backend_id).map_err(|e| {
+                log::warn!(
+                    "set_agent_model: backend '{backend_id}' の登録済みモデル一覧取得に失敗: {e}"
+                );
+                format!("バックエンド '{backend_id}' の登録済みモデル一覧を取得できません: {e}")
+            })?;
+            if !session_models.iter().any(|v| v == model) {
+                // 「未登録」を伝える前に、別バックエンドに登録されていないかを問い合わせる。
+                // - Ok(Some(other)) かつ other != current backend: backend mismatch として返す
+                // - Ok(Some(same)) / Ok(None): 当該 backend への未登録として返す
+                // - Err: infrastructure 故障。warn を残して当該 backend への未登録として返す
+                //   （別バックエンドに登録されているかは判定できないため、ヒントは付けない）
+                match reg.resolve_backend_for_model(model) {
+                    Ok(Some(bid)) if bid != backend_id => {
+                        return Err(format!(
+                            "モデル '{model}' はバックエンド '{backend_id}' に登録されていません (別バックエンド '{bid}' に登録)"
+                        ));
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        log::warn!(
+                            "set_agent_model: モデル '{model}' の所属バックエンド解決に失敗（未登録として扱う）: {e}"
+                        );
+                    }
+                }
+                return Err(format!(
+                    "モデル '{model}' はバックエンド '{backend_id}' に登録されていません"
+                ));
+            }
+        }
+    }
+
     // 1. Send setModel command to Bridge + update process state when the process is active.
-    let available_models =
-        set_active_process_model(handles, chat_session_id, model_id.clone()).await?;
+    //    proc.available_models は config 単一 owner に追従させるため、active process が
+    //    存在する場合も config 由来の最新値で同期する。
+    //    infrastructure 故障時は Err を伝播し、proc キャッシュを空一覧で上書きしない。
+    let models_from_config = available_models_for_backend(&backend_id, registry).map_err(|e| {
+        log::warn!(
+            "set_agent_model: backend '{backend_id}' のモデル一覧取得に失敗したため proc キャッシュ同期を中止: {e}"
+        );
+        format!("バックエンド '{backend_id}' のモデル一覧を取得できません: {e}")
+    })?;
+    sync_active_process_available_models(handles, chat_session_id, &models_from_config).await;
+    set_active_process_model(handles, chat_session_id, model_id.clone()).await?;
 
     // 2. Persist to ChatSession
-    let data_dir = resolve_data_dir(app)?;
-    let mut session = session_store
-        .get_session(&data_dir, chat_session_id)?
-        .ok_or_else(|| format!("Session not found: {chat_session_id}"))?;
     session.selected_model = model_id.clone();
     session.updated_at = now_timestamp();
-    session_store.save_session(&data_dir, &session)?;
+    session_store.save_session(data_dir, &session)?;
 
-    // 3. Always emit event to keep frontend in sync (use global cache when process not running)
-    {
+    // 3. Always emit event to keep frontend in sync.
+    //    供給元は常に config.toml（registry 経由）に統一する。
+    if let Some(app) = app {
         use tauri::Emitter;
-        let backend_id = session.backend_id.as_deref().unwrap_or(CLAUDE_BACKEND_ID);
-        let models = available_models
-            .unwrap_or_else(|| load_available_models_for_backend(&data_dir, backend_id));
-        let models = if models.is_empty() {
-            available_models_for_backend(&data_dir, backend_id, registry).await
-        } else {
-            models
-        };
         let _ = app.emit(
             "agent-models-updated",
-            serde_json::json!({
-                "chat_session_id": chat_session_id,
-                "available_models": models,
-                "selected_model": model_id,
-            }),
+            build_agent_models_updated_payload(
+                chat_session_id,
+                &models_from_config,
+                model_id.as_deref(),
+            ),
         );
     }
 
     Ok(())
+}
+
+/// active process の `available_models` キャッシュを config 由来の最新値で同期する。
+/// 永続的なモデル一覧の owner は config.toml 単一であり、process 側のキャッシュは
+/// emit 整合用にのみ維持する。
+async fn sync_active_process_available_models(
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    chat_session_id: &str,
+    models: &[ModelInfo],
+) {
+    let mut map = handles.lock().await;
+    if let Some(proc) = map.get_mut(chat_session_id) {
+        proc.available_models = models.to_vec();
+    }
 }
 
 #[tauri::command]
@@ -3584,11 +3605,12 @@ async fn prepare_send_agent_message_internal(
         ensure_session_backend_selected(session_store, registry, data_dir, session)?
     } else {
         let resolved_backend_id = registry.resolve_backend_id(backend_id)?;
-        create_session_internal(
+        crate::session::create_session_with_initial_model(
             session_store,
+            registry,
             data_dir,
             &worktree_path,
-            Some(resolved_backend_id),
+            resolved_backend_id,
         )?
     };
     let sid = session.id.clone();
@@ -4161,6 +4183,7 @@ pub(crate) async fn start_agent_turn_internal_locked(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backends::model_catalog_sync::*;
     use crate::backends::{
         AgentBackend, AgentBackendRegistry, AgentMessage, PermissionResponse, SessionConfig,
         SessionHandle,
@@ -4177,7 +4200,7 @@ mod tests {
 
     struct MockModelBackend {
         backend_id: String,
-        models: Vec<ModelInfo>,
+        models: Vec<String>,
     }
 
     #[async_trait]
@@ -4217,7 +4240,7 @@ mod tests {
             Ok(())
         }
 
-        async fn available_models(&self) -> Result<Vec<ModelInfo>, String> {
+        async fn fetch_models_from_cli(&self) -> Result<Vec<String>, String> {
             Ok(self.models.clone())
         }
 
@@ -5780,23 +5803,45 @@ mod tests {
         assert!(effect.sdk_error_message.is_some());
     }
 
-    #[tokio::test]
-    async fn available_models_for_backend_uses_registry_when_cache_is_empty() {
-        let temp = tempfile::tempdir().unwrap();
+    #[test]
+    fn available_models_for_backend_reads_from_config_via_registry() {
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = vec!["mock-model".to_string()];
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let config = Arc::new(crate::config::AppConfig::new(cfg, tmp.path().to_path_buf()));
+
         let mut registry = AgentBackendRegistry::new();
         registry.register(Arc::new(MockModelBackend {
-            backend_id: "mock".to_string(),
-            models: vec![ModelInfo {
-                value: "mock-model".to_string(),
-                display_name: "Mock Model".to_string(),
-            }],
+            backend_id: CLAUDE_BACKEND_ID.to_string(),
+            models: vec![],
         }));
+        registry.set_config(config);
         let registry = Arc::new(registry);
 
-        let models = available_models_for_backend(temp.path(), "mock", Some(&registry)).await;
+        let models = available_models_for_backend(CLAUDE_BACKEND_ID, Some(&registry)).unwrap();
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].value, "mock-model");
+    }
+
+    #[test]
+    fn available_models_for_backend_propagates_registry_error() {
+        // registry に config が未紐付けの状態では Err が返り、空配列で潰れない。
+        let mut registry = AgentBackendRegistry::new();
+        registry.register(Arc::new(MockModelBackend {
+            backend_id: CLAUDE_BACKEND_ID.to_string(),
+            models: vec![],
+        }));
+        let registry = Arc::new(registry);
+        let err = available_models_for_backend(CLAUDE_BACKEND_ID, Some(&registry));
+        assert!(err.is_err(), "config 未紐付けは Err として伝播する");
+    }
+
+    #[test]
+    fn available_models_for_backend_returns_empty_without_registry() {
+        // registry が無い経路（テスト等）は Ok(empty) として扱う。
+        let models = available_models_for_backend(CLAUDE_BACKEND_ID, None).unwrap();
+        assert!(models.is_empty());
     }
 
     #[tokio::test]
@@ -6269,18 +6314,21 @@ mod tests {
             &session_store,
             temp.path(),
             "/repo",
-            Some("mock".to_string()),
+            Some(CLAUDE_BACKEND_ID.to_string()),
         )
         .unwrap();
 
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = vec!["mock-model".to_string()];
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let config = Arc::new(crate::config::AppConfig::new(cfg, tmp.path().to_path_buf()));
+
         let mut registry = AgentBackendRegistry::new();
         registry.register(Arc::new(MockModelBackend {
-            backend_id: "mock".to_string(),
-            models: vec![ModelInfo {
-                value: "mock-model".to_string(),
-                display_name: "Mock Model".to_string(),
-            }],
+            backend_id: CLAUDE_BACKEND_ID.to_string(),
+            models: vec![],
         }));
+        registry.set_config(config);
         let registry = Arc::new(registry);
         let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
 
@@ -6307,26 +6355,29 @@ mod tests {
             &session_store,
             temp.path(),
             "/repo",
-            Some("mock-a".to_string()),
+            Some(CLAUDE_BACKEND_ID.to_string()),
         )
         .unwrap();
         session.selected_model = Some("old-model".to_string());
         session_store.save_session(temp.path(), &session).unwrap();
+
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = vec!["a-model".to_string()];
+        cfg.agents.codex.model = Some("b-model".to_string());
+        cfg.agents.codex.models = vec!["b-model".to_string()];
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let config = Arc::new(crate::config::AppConfig::new(cfg, tmp.path().to_path_buf()));
+
         let mut registry = AgentBackendRegistry::new();
         registry.register(Arc::new(MockModelBackend {
-            backend_id: "mock-a".to_string(),
-            models: vec![ModelInfo {
-                value: "a-model".to_string(),
-                display_name: "A Model".to_string(),
-            }],
+            backend_id: CLAUDE_BACKEND_ID.to_string(),
+            models: vec![],
         }));
         registry.register(Arc::new(MockModelBackend {
-            backend_id: "mock-b".to_string(),
-            models: vec![ModelInfo {
-                value: "b-model".to_string(),
-                display_name: "B Model".to_string(),
-            }],
+            backend_id: CODEX_BACKEND_ID.to_string(),
+            models: vec![],
         }));
+        registry.set_config(config);
         let registry = Arc::new(registry);
         let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
 
@@ -6336,13 +6387,16 @@ mod tests {
             &handles,
             temp.path(),
             &session.id,
-            "mock-b".to_string(),
+            CODEX_BACKEND_ID.to_string(),
         )
         .await
         .unwrap();
 
-        assert_eq!(response.session.backend_id, Some("mock-b".to_string()));
-        assert_eq!(response.session.selected_model, None);
+        assert_eq!(
+            response.session.backend_id,
+            Some(CODEX_BACKEND_ID.to_string())
+        );
+        assert_eq!(response.session.selected_model, Some("b-model".to_string()));
         assert_eq!(response.available_models.len(), 1);
         assert_eq!(response.available_models[0].value, "b-model");
     }
@@ -8864,25 +8918,21 @@ mod tests {
                 let mut proc = make_dummy_agent_process(child, stdin, pgid);
                 proc.available_models = vec![ModelInfo {
                     value: "gpt-5.4".to_string(),
-                    display_name: "GPT-5.4".to_string(),
                 }];
                 proc.selected_model = Some("old-model".to_string());
                 map.insert("session-1".to_string(), proc);
             }
 
-            let models =
-                set_active_process_model(&handles, "session-1", Some("gpt-5.4".to_string()))
-                    .await
-                    .unwrap()
-                    .unwrap();
+            set_active_process_model(&handles, "session-1", Some("gpt-5.4".to_string()))
+                .await
+                .unwrap();
 
-            assert_eq!(models[0].value, "gpt-5.4");
             {
                 let map = handles.lock().await;
-                assert_eq!(
-                    map.get("session-1").unwrap().selected_model,
-                    Some("gpt-5.4".to_string())
-                );
+                let proc = map.get("session-1").unwrap();
+                assert_eq!(proc.selected_model, Some("gpt-5.4".to_string()));
+                // available_models は process キャッシュとして変更されないこと（owner は config）。
+                assert_eq!(proc.available_models[0].value, "gpt-5.4");
             }
 
             let mut map = handles.lock().await;
@@ -8893,11 +8943,10 @@ mod tests {
         async fn set_active_process_model_inactive_session_is_ok() {
             let handles = Arc::new(Mutex::new(HashMap::new()));
 
-            let models = set_active_process_model(&handles, "missing", Some("gpt-5.4".to_string()))
+            // 該当 session が無くてもエラーにせず Ok(()) を返す（active 不在は no-op）。
+            set_active_process_model(&handles, "missing", Some("gpt-5.4".to_string()))
                 .await
                 .unwrap();
-
-            assert!(models.is_none());
         }
 
         #[tokio::test]
@@ -8908,21 +8957,25 @@ mod tests {
                 &session_store,
                 temp.path(),
                 "/repo",
-                Some("mock-a".to_string()),
+                Some(CLAUDE_BACKEND_ID.to_string()),
             )
             .unwrap();
+
+            let mut cfg = crate::config::ReleashConfig::default();
+            cfg.agents.codex.models = vec!["b-model".to_string()];
+            let tmp = tempfile::NamedTempFile::new().unwrap();
+            let config = Arc::new(crate::config::AppConfig::new(cfg, tmp.path().to_path_buf()));
+
             let mut registry = AgentBackendRegistry::new();
             registry.register(Arc::new(MockModelBackend {
-                backend_id: "mock-a".to_string(),
+                backend_id: CLAUDE_BACKEND_ID.to_string(),
                 models: Vec::new(),
             }));
             registry.register(Arc::new(MockModelBackend {
-                backend_id: "mock-b".to_string(),
-                models: vec![ModelInfo {
-                    value: "b-model".to_string(),
-                    display_name: "B Model".to_string(),
-                }],
+                backend_id: CODEX_BACKEND_ID.to_string(),
+                models: Vec::new(),
             }));
+            registry.set_config(config);
             let registry = Arc::new(registry);
 
             let mut cmd = tokio::process::Command::new("sleep");
@@ -8958,12 +9011,15 @@ mod tests {
                 &handles,
                 temp.path(),
                 &session.id,
-                "mock-b".to_string(),
+                CODEX_BACKEND_ID.to_string(),
             )
             .await
             .unwrap();
 
-            assert_eq!(response.session.backend_id, Some("mock-b".to_string()));
+            assert_eq!(
+                response.session.backend_id,
+                Some(CODEX_BACKEND_ID.to_string())
+            );
             assert_eq!(response.available_models[0].value, "b-model");
             assert!(handles.lock().await.get(&session.id).is_none());
             assert!(!pids_dir(temp.path())
@@ -9032,5 +9088,785 @@ mod tests {
             assert!(map.is_empty());
             assert!(returned_ids.is_empty());
         }
+    }
+
+    // --- extract_model_ids_from_supported_models: all-or-nothing 検証 ---
+
+    #[test]
+    fn extract_model_ids_accepts_value_field() {
+        let v = serde_json::json!({
+            "models": [{"value": "a"}, {"value": "b"}]
+        });
+        let result = extract_model_ids_from_supported_models(&v).unwrap();
+        assert_eq!(result, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn extract_model_ids_accepts_id_field_fallback() {
+        let v = serde_json::json!({
+            "models": [{"id": "a"}, {"value": "b"}]
+        });
+        let result = extract_model_ids_from_supported_models(&v).unwrap();
+        assert_eq!(result, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn extract_model_ids_rejects_missing_models_array() {
+        let v = serde_json::json!({"foo": "bar"});
+        assert!(extract_model_ids_from_supported_models(&v).is_err());
+    }
+
+    #[test]
+    fn extract_model_ids_rejects_entry_without_value_or_id() {
+        // all-or-nothing: 不正要素を 1 件でも含めば Err。silent drop しない。
+        let v = serde_json::json!({
+            "models": [{"value": "a"}, {"name": "missing"}]
+        });
+        assert!(extract_model_ids_from_supported_models(&v).is_err());
+    }
+
+    #[test]
+    fn extract_model_ids_rejects_non_string_value() {
+        let v = serde_json::json!({
+            "models": [{"value": 123}]
+        });
+        assert!(extract_model_ids_from_supported_models(&v).is_err());
+    }
+
+    #[test]
+    fn supported_models_log_messages_are_traceable() {
+        assert_eq!(
+            supported_models_empty_payload_log(CODEX_BACKEND_ID),
+            "supported_models 受信内容のモデル配列が空のため 'codex' のモデル一覧は更新しません"
+        );
+        assert_eq!(
+            supported_models_write_failed_log(CODEX_BACKEND_ID, "write failed"),
+            "supported_models から 'codex' のモデル一覧を反映できませんでした: write failed"
+        );
+        assert_eq!(
+            supported_models_invalid_payload_log(CODEX_BACKEND_ID, "bad payload"),
+            "supported_models 受信内容が不正のため 'codex' のモデル一覧は更新しません: bad payload"
+        );
+        assert_eq!(
+            supported_models_fallback_read_failed_log(CODEX_BACKEND_ID, "read failed"),
+            "supported_models フォールバック読み出し失敗 (backend='codex'): read failed - proc キャッシュと emit は維持"
+        );
+        assert_eq!(
+            startup_model_refresh_failed_log(CODEX_BACKEND_ID, "cli timed out"),
+            "backend 'codex' model refresh failed: cli timed out"
+        );
+    }
+
+    // --- set_agent_model_internal: 仕様の中核 Rule の回帰防止テスト ---
+
+    fn make_test_registry_with_models(
+        claude_models: &[&str],
+        codex_models: &[&str],
+    ) -> Arc<AgentBackendRegistry> {
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = claude_models.iter().map(|s| s.to_string()).collect();
+        cfg.agents.codex.models = codex_models.iter().map(|s| s.to_string()).collect();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let config = Arc::new(crate::config::AppConfig::new(cfg, tmp.path().to_path_buf()));
+        let mut registry = AgentBackendRegistry::new();
+        registry.register(Arc::new(MockModelBackend {
+            backend_id: CLAUDE_BACKEND_ID.to_string(),
+            models: vec![],
+        }));
+        registry.register(Arc::new(MockModelBackend {
+            backend_id: CODEX_BACKEND_ID.to_string(),
+            models: vec![],
+        }));
+        registry.set_config(config);
+        Arc::new(registry)
+    }
+
+    #[tokio::test]
+    async fn set_agent_model_accepts_registered_model() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::default());
+        let session = create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let registry = make_test_registry_with_models(&["claude-4"], &["gpt-5"]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+
+        set_agent_model_internal_with_data_dir(
+            None,
+            &handles,
+            &session_store,
+            Some(&registry),
+            temp.path(),
+            &session.id,
+            Some("claude-4".to_string()),
+        )
+        .await
+        .unwrap();
+
+        let updated = session_store
+            .get_session(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.selected_model, Some("claude-4".to_string()));
+    }
+
+    #[tokio::test]
+    async fn set_agent_model_preserves_surrounding_whitespace() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::default());
+        let session = create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let model = "  claude-4  ";
+        let registry = make_test_registry_with_models(&[model], &[]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+
+        set_agent_model_internal_with_data_dir(
+            None,
+            &handles,
+            &session_store,
+            Some(&registry),
+            temp.path(),
+            &session.id,
+            Some(model.to_string()),
+        )
+        .await
+        .unwrap();
+
+        let updated = session_store
+            .get_session(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.selected_model, Some(model.to_string()));
+    }
+
+    #[tokio::test]
+    async fn set_agent_model_rejects_unregistered_model() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::default());
+        let mut session = create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        session.selected_model = Some("existing".to_string());
+        session_store.save_session(temp.path(), &session).unwrap();
+
+        let registry = make_test_registry_with_models(&["claude-4"], &[]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+
+        let err = set_agent_model_internal_with_data_dir(
+            None,
+            &handles,
+            &session_store,
+            Some(&registry),
+            temp.path(),
+            &session.id,
+            Some("unknown".to_string()),
+        )
+        .await;
+        assert!(err.is_err());
+
+        // 拒否時は selected_model を維持
+        let after = session_store
+            .get_session(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.selected_model, Some("existing".to_string()));
+    }
+
+    #[tokio::test]
+    async fn set_agent_model_rejects_other_backend_model_as_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::default());
+        let session = create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let registry = make_test_registry_with_models(&["claude-4"], &["gpt-5"]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+
+        let err = set_agent_model_internal_with_data_dir(
+            None,
+            &handles,
+            &session_store,
+            Some(&registry),
+            temp.path(),
+            &session.id,
+            Some("gpt-5".to_string()),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("別バックエンド"));
+
+        // selected_model は変更されない
+        let after = session_store
+            .get_session(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.selected_model, None);
+    }
+
+    #[tokio::test]
+    async fn set_agent_model_accepts_none_as_selection_clear() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::default());
+        let mut session = create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        session.selected_model = Some("claude-4".to_string());
+        session_store.save_session(temp.path(), &session).unwrap();
+
+        let registry = make_test_registry_with_models(&["claude-4"], &[]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+
+        set_agent_model_internal_with_data_dir(
+            None,
+            &handles,
+            &session_store,
+            Some(&registry),
+            temp.path(),
+            &session.id,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let after = session_store
+            .get_session(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        // 選択解除（未指定状態）として保存される
+        assert_eq!(after.selected_model, None);
+    }
+
+    // --- supported_models 受信経路の統合テスト ---
+
+    fn make_registry_with_config(
+        claude_models: &[&str],
+        codex_models: &[&str],
+    ) -> (Arc<AgentBackendRegistry>, Arc<crate::config::AppConfig>) {
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = claude_models.iter().map(|s| s.to_string()).collect();
+        cfg.agents.codex.models = codex_models.iter().map(|s| s.to_string()).collect();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let config = Arc::new(crate::config::AppConfig::new(cfg, tmp.path().to_path_buf()));
+        let mut registry = AgentBackendRegistry::new();
+        registry.register(Arc::new(MockModelBackend {
+            backend_id: CLAUDE_BACKEND_ID.to_string(),
+            models: vec![],
+        }));
+        registry.register(Arc::new(MockModelBackend {
+            backend_id: CODEX_BACKEND_ID.to_string(),
+            models: vec![],
+        }));
+        registry.set_config(config.clone());
+        (Arc::new(registry), config)
+    }
+
+    #[test]
+    fn apply_supported_models_writes_config_and_returns_config_derived() {
+        let (registry, config) = make_registry_with_config(&[], &["stale"]);
+        let msg = serde_json::json!({
+            "type": "supported_models",
+            "models": [{"value": "gpt-5.5"}, {"value": "o3"}]
+        });
+
+        let models = apply_supported_models_to_config(Some(&*registry), CODEX_BACKEND_ID, &msg)
+            .expect("models should be returned on success");
+
+        // 戻り値が config 由来（書き込み後）の最新一覧であること
+        let values: Vec<String> = models.iter().map(|m| m.value.clone()).collect();
+        assert_eq!(values, vec!["gpt-5.5".to_string(), "o3".to_string()]);
+        // config が書き換わっていること
+        let cfg = config.get_config().unwrap();
+        assert_eq!(
+            cfg.agents.codex.models,
+            vec!["gpt-5.5".to_string(), "o3".to_string()]
+        );
+    }
+
+    #[test]
+    fn apply_supported_models_keeps_config_on_invalid_payload() {
+        let (registry, config) = make_registry_with_config(&[], &["existing"]);
+        // models 配列無し → all-or-nothing で拒否
+        let msg = serde_json::json!({"type": "supported_models"});
+
+        let models = apply_supported_models_to_config(Some(&*registry), CODEX_BACKEND_ID, &msg)
+            .expect("config 読み出しに成功するため Some が返る");
+
+        // 拒否時は現在 config に登録されている値が返る（暗黙のフォールバックは無し）
+        let values: Vec<String> = models.iter().map(|m| m.value.clone()).collect();
+        assert_eq!(values, vec!["existing".to_string()]);
+        // config は変更されない
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.codex.models, vec!["existing".to_string()]);
+    }
+
+    #[test]
+    fn apply_supported_models_keeps_config_when_entry_invalid() {
+        let (registry, config) = make_registry_with_config(&[], &["existing"]);
+        // 制御文字含み → 形式検証で拒否
+        let msg = serde_json::json!({
+            "models": [{"value": "valid"}, {"value": "bad\u{0001}id"}]
+        });
+
+        let models = apply_supported_models_to_config(Some(&*registry), CODEX_BACKEND_ID, &msg)
+            .expect("config 読み出しに成功するため Some が返る");
+
+        let values: Vec<String> = models.iter().map(|m| m.value.clone()).collect();
+        assert_eq!(values, vec!["existing".to_string()]);
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.codex.models, vec!["existing".to_string()]);
+    }
+
+    #[test]
+    fn apply_supported_models_returns_none_when_registry_unavailable() {
+        let msg = serde_json::json!({"models": [{"value": "a"}]});
+        let models = apply_supported_models_to_config(None, CODEX_BACKEND_ID, &msg);
+        // registry 未紐付け時は更新指示なし (None) — 呼び出し側は cache/emit を上書きしない
+        assert!(models.is_none());
+    }
+
+    #[test]
+    fn build_agent_models_updated_payload_emits_event_contract_fields() {
+        let models = vec![
+            ModelInfo {
+                value: "a".to_string(),
+            },
+            ModelInfo {
+                value: "b".to_string(),
+            },
+        ];
+        let payload = build_agent_models_updated_payload("sess-1", &models, Some("a"));
+
+        assert_eq!(payload["chat_session_id"], "sess-1");
+        let candidates = payload["available_models"]
+            .as_array()
+            .expect("available_models is array");
+        let values: Vec<String> = candidates
+            .iter()
+            .map(|v| v["value"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(values, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(payload["selected_model"], "a");
+    }
+
+    #[test]
+    fn build_agent_models_updated_payload_serializes_unset_as_null() {
+        let payload = build_agent_models_updated_payload("sess-2", &[], None);
+        assert!(payload["selected_model"].is_null());
+        assert_eq!(payload["available_models"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn build_agent_backend_models_updated_payload_includes_backend_id_and_models() {
+        // spec: backend 全体向け通知は backend_id を含み、session 単位 payload とは
+        // 分離された event 名 (`agent-backend-models-updated`) で配信される。
+        let models = vec![
+            ModelInfo {
+                value: "gpt-5.5".to_string(),
+            },
+            ModelInfo {
+                value: "o3".to_string(),
+            },
+        ];
+        let payload = build_agent_backend_models_updated_payload(CODEX_BACKEND_ID, &models);
+
+        assert_eq!(payload["backend_id"], CODEX_BACKEND_ID);
+        // chat_session_id / selected_model フィールドは含めない（session 単位の責務）。
+        assert!(payload.get("chat_session_id").is_none());
+        assert!(payload.get("selected_model").is_none());
+        let values: Vec<String> = payload["available_models"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["value"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(values, vec!["gpt-5.5".to_string(), "o3".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn sync_active_processes_for_backend_noops_when_no_active_session() {
+        // spec: active session が 0 件のとき、対象バックエンドに紐づく更新先が無いため
+        // cache 同期は no-op になり、呼び出し側は backend-wide 通知のみを emit する。
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        sync_active_processes_for_backend(
+            &handles,
+            CODEX_BACKEND_ID,
+            &[ModelInfo {
+                value: "gpt-5.5".to_string(),
+            }],
+        )
+        .await;
+        assert!(handles.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sync_active_processes_for_backend_updates_only_matched_backend() {
+        // spec: 起動時 CLI 同期で取得した一覧は、対象バックエンドの active session
+        // にのみ反映され、他バックエンドの session は影響を受けない。
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        {
+            let mut map = handles.lock().await;
+            let mut codex_proc = make_test_agent_process();
+            codex_proc.backend_id = CODEX_BACKEND_ID.to_string();
+            codex_proc.available_models = vec![ModelInfo {
+                value: "stale".to_string(),
+            }];
+            codex_proc.selected_model = Some("user-pick".to_string());
+            map.insert("codex-sess".to_string(), codex_proc);
+
+            let mut claude_proc = make_test_agent_process();
+            claude_proc.backend_id = CLAUDE_BACKEND_ID.to_string();
+            claude_proc.available_models = vec![ModelInfo {
+                value: "claude-original".to_string(),
+            }];
+            map.insert("claude-sess".to_string(), claude_proc);
+        }
+
+        let new_models = vec![
+            ModelInfo {
+                value: "gpt-5.5".to_string(),
+            },
+            ModelInfo {
+                value: "o3".to_string(),
+            },
+        ];
+        sync_active_processes_for_backend(&handles, CODEX_BACKEND_ID, &new_models).await;
+
+        let map = handles.lock().await;
+        let codex = map.get("codex-sess").unwrap();
+        assert_eq!(codex.selected_model, Some("user-pick".to_string()));
+        let codex_values: Vec<String> = codex
+            .available_models
+            .iter()
+            .map(|m| m.value.clone())
+            .collect();
+        assert_eq!(codex_values, vec!["gpt-5.5".to_string(), "o3".to_string()]);
+
+        // claude 側は影響を受けない
+        let claude = map.get("claude-sess").unwrap();
+        let claude_values: Vec<String> = claude
+            .available_models
+            .iter()
+            .map(|m| m.value.clone())
+            .collect();
+        assert_eq!(claude_values, vec!["claude-original".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn handle_supported_models_message_updates_proc_cache_from_config() {
+        // 受信→config 書き換え→proc.available_models 更新までを実関数経路で検証。
+        // spec Rule: 既に動いているバックエンドからの一覧通知も同じ規準で取り込まれ、
+        // ユーザーが見ているモデル選択候補も最新化された内容に追従する。
+        let (registry, config) = make_registry_with_config(&[], &["stale"]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        {
+            let mut map = handles.lock().await;
+            let mut proc = make_test_agent_process();
+            proc.backend_id = CODEX_BACKEND_ID.to_string();
+            proc.available_models = vec![ModelInfo {
+                value: "stale".to_string(),
+            }];
+            map.insert("sess-1".to_string(), proc);
+        }
+
+        let msg = serde_json::json!({
+            "type": "supported_models",
+            "models": [{"value": "gpt-5.5"}, {"value": "o3"}]
+        });
+
+        handle_supported_models_message(None, &handles, Some(&*registry), "sess-1", &msg).await;
+
+        // config に書き込まれている
+        let cfg = config.get_config().unwrap();
+        assert_eq!(
+            cfg.agents.codex.models,
+            vec!["gpt-5.5".to_string(), "o3".to_string()]
+        );
+        // proc.available_models が config 由来の最新値に同期されている
+        let map = handles.lock().await;
+        let proc = map.get("sess-1").unwrap();
+        let values: Vec<String> = proc
+            .available_models
+            .iter()
+            .map(|m| m.value.clone())
+            .collect();
+        assert_eq!(values, vec!["gpt-5.5".to_string(), "o3".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn handle_supported_models_message_keeps_proc_cache_aligned_with_config_on_invalid() {
+        // 不正 payload の場合、config は変更されず proc.available_models は
+        // 現在 config に登録されている値に揃う（暗黙のフォールバックは無し）。
+        let (registry, config) = make_registry_with_config(&[], &["existing"]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        {
+            let mut map = handles.lock().await;
+            let mut proc = make_test_agent_process();
+            proc.backend_id = CODEX_BACKEND_ID.to_string();
+            proc.available_models = vec![ModelInfo {
+                value: "stale".to_string(),
+            }];
+            map.insert("sess-1".to_string(), proc);
+        }
+
+        // models 配列無し → all-or-nothing で拒否
+        let msg = serde_json::json!({"type": "supported_models"});
+        handle_supported_models_message(None, &handles, Some(&*registry), "sess-1", &msg).await;
+
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.codex.models, vec!["existing".to_string()]);
+        let map = handles.lock().await;
+        let proc = map.get("sess-1").unwrap();
+        let values: Vec<String> = proc
+            .available_models
+            .iter()
+            .map(|m| m.value.clone())
+            .collect();
+        assert_eq!(values, vec!["existing".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn handle_supported_models_message_rejects_empty_models_array() {
+        // spec Rule: 起動時 CLI 同期と同じ受け入れ規準。`models: []` は空一覧として
+        // 受け入れず、当該 backend の config は既存値のまま維持される。proc.available_models
+        // も config 由来の既存値に揃う。
+        let (registry, config) = make_registry_with_config(&[], &["existing"]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        {
+            let mut map = handles.lock().await;
+            let mut proc = make_test_agent_process();
+            proc.backend_id = CODEX_BACKEND_ID.to_string();
+            proc.available_models = vec![ModelInfo {
+                value: "stale".to_string(),
+            }];
+            map.insert("sess-1".to_string(), proc);
+        }
+
+        let msg = serde_json::json!({"type": "supported_models", "models": []});
+        handle_supported_models_message(None, &handles, Some(&*registry), "sess-1", &msg).await;
+
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.codex.models, vec!["existing".to_string()]);
+        let map = handles.lock().await;
+        let proc = map.get("sess-1").unwrap();
+        let values: Vec<String> = proc
+            .available_models
+            .iter()
+            .map(|m| m.value.clone())
+            .collect();
+        // 空配列を proc キャッシュに上書きせず、config 由来の既存値に揃う。
+        assert_eq!(values, vec!["existing".to_string()]);
+    }
+
+    // --- get_persisted_spawn_info: 新規未起動セッションと選択解除後の区別 ---
+
+    fn make_chat_session_for_spawn(
+        agent_session_id: Option<String>,
+        selected_model: Option<String>,
+        backend_id: &str,
+    ) -> ChatSession {
+        ChatSession {
+            id: "s1".to_string(),
+            worktree_path: "/repo".to_string(),
+            messages: Vec::new(),
+            state: crate::session::SessionState::Active,
+            created_at: 0.0,
+            updated_at: 0.0,
+            agent_session_id,
+            permission_mode: "acceptEdits".to_string(),
+            selected_model,
+            workflow_state: None,
+            backend_id: Some(backend_id.to_string()),
+            workflow_step_session: false,
+        }
+    }
+
+    #[test]
+    fn resolve_spawn_info_returns_none_for_unstarted_session_without_persisted_model() {
+        // spec: selected_model=None は常に「明示的に未指定」を意味する。
+        // 未起動セッションで selected_model 未指定でも spawn 経路で暗黙の
+        // 既定モデルへフォールバックさせない（初期モデルはセッション作成時にのみ反映される）。
+        let session = make_chat_session_for_spawn(None, None, CODEX_BACKEND_ID);
+        let info = resolve_spawn_info(Some(session));
+        assert_eq!(info.0, None); // resume_sid
+        assert_eq!(info.1, None); // selected_model — fallback しない
+        assert_eq!(info.2, CODEX_BACKEND_ID.to_string());
+    }
+
+    #[test]
+    fn resolve_spawn_info_does_not_reinject_default_after_explicit_clear() {
+        // 既に一度起動済み（agent_session_id Some）で selected_model を None に戻した場合、
+        // 次回 spawn でも None のまま。
+        let session =
+            make_chat_session_for_spawn(Some("sdk-id".to_string()), None, CODEX_BACKEND_ID);
+        let info = resolve_spawn_info(Some(session));
+        assert!(info.1.is_none());
+    }
+
+    #[test]
+    fn resolve_spawn_info_preserves_existing_selected_model() {
+        // 永続化済みの selected_model はそのまま採用する。
+        let session =
+            make_chat_session_for_spawn(None, Some("user-picked".to_string()), CODEX_BACKEND_ID);
+        let info = resolve_spawn_info(Some(session));
+        assert_eq!(info.1, Some("user-picked".to_string()));
+    }
+
+    #[test]
+    fn resolve_spawn_info_uses_default_backend_when_session_missing() {
+        // 永続化セッションが存在しない場合は新規セッション扱い。
+        // backend_id は claude（既定）にフォールバックする。selected_model は None。
+        let info = resolve_spawn_info(None);
+        assert!(info.1.is_none());
+        assert_eq!(info.2, CLAUDE_BACKEND_ID.to_string());
+    }
+
+    // --- get_session: active process が居ても config 由来を返す ---
+
+    #[tokio::test]
+    async fn get_session_returns_config_derived_available_models_even_with_active_process() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::default());
+        let session = create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some(CODEX_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let (registry, _config) = make_registry_with_config(&[], &["from-config"]);
+
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        // active process の stale キャッシュ
+        {
+            let mut map = handles.lock().await;
+            let mut proc = make_test_agent_process();
+            proc.backend_id = CODEX_BACKEND_ID.to_string();
+            proc.available_models = vec![ModelInfo {
+                value: "stale-from-process".to_string(),
+            }];
+            map.insert(session.id.clone(), proc);
+        }
+
+        let response = get_session_internal_with_data_dir(
+            &session_store,
+            &handles,
+            Some(&registry),
+            temp.path(),
+            &session.id,
+        )
+        .await
+        .unwrap()
+        .expect("session should exist");
+
+        let values: Vec<String> = response
+            .available_models
+            .into_iter()
+            .map(|m| m.value)
+            .collect();
+        assert_eq!(values, vec!["from-config".to_string()]);
+
+        let mut map = handles.lock().await;
+        force_kill_all_sessions(&mut map).await;
+    }
+
+    #[tokio::test]
+    async fn set_agent_model_syncs_active_process_available_models_from_config() {
+        // active process が居る状態で set_agent_model を呼ぶと、proc.available_models が
+        // config 由来の最新値で同期される（spec: モデル選択候補は config 単一 owner、
+        // process キャッシュは emit 整合用にのみ維持）。
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::default());
+        let session = create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let registry = make_test_registry_with_models(&["claude-4", "haiku"], &[]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        {
+            let mut map = handles.lock().await;
+            let mut proc = make_test_agent_process();
+            proc.backend_id = CLAUDE_BACKEND_ID.to_string();
+            // process cache が stale な状態
+            proc.available_models = vec![ModelInfo {
+                value: "stale".to_string(),
+            }];
+            map.insert(session.id.clone(), proc);
+        }
+
+        set_agent_model_internal_with_data_dir(
+            None,
+            &handles,
+            &session_store,
+            Some(&registry),
+            temp.path(),
+            &session.id,
+            Some("claude-4".to_string()),
+        )
+        .await
+        .unwrap();
+
+        // proc.available_models が registry/config 由来の最新値に同期される
+        let map = handles.lock().await;
+        let proc = map.get(&session.id).unwrap();
+        let values: Vec<String> = proc
+            .available_models
+            .iter()
+            .map(|m| m.value.clone())
+            .collect();
+        assert_eq!(values, vec!["claude-4".to_string(), "haiku".to_string()]);
+        // selected_model も反映される
+        assert_eq!(proc.selected_model, Some("claude-4".to_string()));
+    }
+
+    #[tokio::test]
+    async fn set_agent_model_rejects_invalid_format_before_registry_check() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::default());
+        let session = create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let registry = make_test_registry_with_models(&["claude-4"], &[]);
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+
+        // 空文字（形式不正）は登録判定に進む前に拒否
+        let err = set_agent_model_internal_with_data_dir(
+            None,
+            &handles,
+            &session_store,
+            Some(&registry),
+            temp.path(),
+            &session.id,
+            Some("".to_string()),
+        )
+        .await;
+        assert!(err.is_err());
     }
 }

--- a/src-tauri/src/backends/claude.rs
+++ b/src-tauri/src/backends/claude.rs
@@ -1,37 +1,104 @@
 use async_trait::async_trait;
+use std::path::PathBuf;
+use std::time::Duration;
+use tauri::Manager;
+use tokio::process::Command;
 
 use crate::backends::bridge_common::CLAUDE_BACKEND_ID;
+use crate::backends::process_io::run_command_with_output_limit;
 use crate::backends::{
-    AgentBackend, AgentMessage, ModelInfo, PermissionResponse, SessionConfig, SessionHandle,
+    AgentBackend, AgentMessage, BackendRuntimeConfig, PermissionResponse, SessionConfig,
+    SessionHandle,
 };
+
+/// 起動時 Claude モデル一覧 probe のタイムアウト。SDK 側で 8 秒のタイムアウトを
+/// 持っているため、外側はそれより少し長めに取って包む。
+const CLAUDE_PROBE_TIMEOUT: Duration = Duration::from_secs(12);
+
+/// probe スクリプトの stdout/stderr の取り込み上限（バイト）。
+const CLAUDE_PROBE_OUTPUT_MAX_BYTES: usize = 1024 * 1024;
 
 /// Claude Agent SDK Bridge バックエンド。
 /// Node.js ブリッジプロセスを経由して Claude Agent SDK と通信する。
 pub struct ClaudeBackend {
-    _private: (),
+    /// 起動時 probe で使う `claude-sdk-bridge-list-models` スクリプトの解決結果。
+    /// AppHandle が無い構成（テスト等）では `None` を保持し、CLI fetch を「サポートしない」
+    /// 扱いとして起動時同期から skip する。
+    /// 実アプリ（`with_app`）では Result を保持し、解決失敗（resource_dir 失敗等）は
+    /// infrastructure failure として `fetch_models_from_cli` で Err を返す。
+    list_models_script: Option<Result<PathBuf, String>>,
 }
 
 impl ClaudeBackend {
     pub fn new() -> Self {
-        Self { _private: () }
+        Self {
+            list_models_script: None,
+        }
+    }
+
+    /// AppHandle 経由で probe スクリプトのパスを解決して保持する。
+    /// 解決失敗は capability ではなく infrastructure failure として保持し、
+    /// `fetch_models_from_cli` から Err を返すことで起動時 refresh の warn 経路に乗せる。
+    pub fn with_app(app: &tauri::AppHandle) -> Self {
+        Self {
+            list_models_script: Some(resolve_claude_list_models_script(app)),
+        }
     }
 }
 
-pub fn claude_supported_models() -> Vec<ModelInfo> {
-    vec![
-        ModelInfo {
-            value: "claude-sonnet-4-6".to_string(),
-            display_name: "claude-sonnet-4-6".to_string(),
-        },
-        ModelInfo {
-            value: "claude-opus-4-7".to_string(),
-            display_name: "claude-opus-4-7".to_string(),
-        },
-        ModelInfo {
-            value: "claude-haiku-4-5-20251001".to_string(),
-            display_name: "claude-haiku-4-5-20251001".to_string(),
-        },
-    ]
+/// Claude 起動時モデル一覧 probe 用スクリプト名（dev / production）。
+/// `claude-sdk-bridge.mjs` の通常ブリッジとは分離しており、initializationResult のみ
+/// を返して即時終了する一発スクリプト。
+pub(crate) fn claude_list_models_script_names() -> (&'static str, &'static str) {
+    (
+        "claude-sdk-bridge-list-models.mjs",
+        "generated/bridges/claude-sdk-bridge-list-models.bundled.mjs",
+    )
+}
+
+/// Claude 起動時モデル一覧 probe スクリプトのパスを解決する。
+/// dev 環境では `src-tauri/resources/` を優先、production では resource_dir を参照。
+pub(crate) fn resolve_claude_list_models_script(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let (dev_name, bundled_name) = claude_list_models_script_names();
+    #[cfg(debug_assertions)]
+    {
+        let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("resources")
+            .join(dev_name);
+        if dev_path.exists() {
+            return Ok(dev_path);
+        }
+    }
+    #[cfg(not(debug_assertions))]
+    let _ = dev_name;
+
+    app.path()
+        .resource_dir()
+        .map(|d| d.join(bundled_name))
+        .map_err(|e| format!("resource_dir 解決失敗: {e}"))
+}
+
+/// probe スクリプトの stdout を解析して `models[].value` のリストを抽出する。
+/// 出力フォーマットは `{"models":[{"value":"..."}, ...]}` を想定。
+pub(crate) fn parse_claude_list_models_output(stdout: &str) -> Result<Vec<String>, String> {
+    let value: serde_json::Value = serde_json::from_str(stdout.trim())
+        .map_err(|e| format!("claude list-models の JSON 解析に失敗: {e}"))?;
+    let arr = value
+        .get("models")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "claude list-models 出力に 'models' 配列がありません".to_string())?;
+    let mut result = Vec::with_capacity(arr.len());
+    for (idx, entry) in arr.iter().enumerate() {
+        let id = entry
+            .get("value")
+            .and_then(|v| v.as_str())
+            .or_else(|| entry.get("id").and_then(|v| v.as_str()))
+            .ok_or_else(|| {
+                format!("claude list-models 出力の models[{idx}] に有効な value/id がありません")
+            })?;
+        result.push(id.to_string());
+    }
+    Ok(result)
 }
 
 #[async_trait]
@@ -71,8 +138,67 @@ impl AgentBackend for ClaudeBackend {
         Ok(())
     }
 
-    async fn available_models(&self) -> Result<Vec<ModelInfo>, String> {
-        Ok(claude_supported_models())
+    fn supports_cli_model_fetch(&self) -> bool {
+        // `with_app` 経由で構築された場合は capability あり（解決失敗も Err として
+        // fetch から返す）。`new()` 由来（テスト時等）は skip。
+        self.list_models_script.is_some()
+    }
+
+    async fn fetch_models_from_cli(&self) -> Result<Vec<String>, String> {
+        let script = match self.list_models_script.as_ref() {
+            Some(Ok(path)) => path,
+            Some(Err(e)) => {
+                return Err(format!(
+                    "Claude probe スクリプトの resource 解決に失敗: {e}"
+                ));
+            }
+            None => {
+                return Err("Claude probe スクリプトが未解決のため取得できません".to_string());
+            }
+        };
+        let script_str = script
+            .to_str()
+            .ok_or_else(|| "Claude probe スクリプトパスに不正な UTF-8 が含まれます".to_string())?;
+
+        let mut cmd = Command::new("node");
+        cmd.arg(script_str);
+
+        let output = run_command_with_output_limit(
+            cmd,
+            CLAUDE_PROBE_TIMEOUT,
+            CLAUDE_PROBE_OUTPUT_MAX_BYTES,
+            "claude probe",
+            &format!("claude probe 起動失敗 ({script_str})"),
+            "claude probe 待機失敗",
+            format!(
+                "claude probe タイムアウト ({} 秒)",
+                CLAUDE_PROBE_TIMEOUT.as_secs()
+            ),
+        )
+        .await?;
+
+        if !output.status.success() {
+            // stderr 本文には SDK/CLI 側の診断文字列が含まれ、認証ヘッダや token などの
+            // 機密文字列が混ざる可能性があるためログに残さない。
+            let _ = output.stderr;
+            log::debug!("claude probe failed status={:?}", output.status.code());
+            return Err(format!(
+                "claude probe が失敗しました (status={:?})",
+                output.status.code()
+            ));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let models = parse_claude_list_models_output(&stdout)?;
+        if models.is_empty() {
+            return Err("claude probe の出力が空でした".to_string());
+        }
+        Ok(models)
+    }
+
+    fn runtime_config(&self, _app: &tauri::AppHandle) -> BackendRuntimeConfig {
+        BackendRuntimeConfig {
+            bridge_init_options: serde_json::Map::new(),
+        }
     }
 
     async fn close_session(&self, _session: &SessionHandle) -> Result<(), String> {
@@ -84,11 +210,98 @@ impl AgentBackend for ClaudeBackend {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn available_models_returns_claude_defaults() {
+    #[test]
+    fn supports_cli_model_fetch_is_false() {
         let backend = ClaudeBackend::new();
-        let models = backend.available_models().await.unwrap();
-        assert!(models.iter().any(|m| m.value == "claude-sonnet-4-6"));
-        assert!(models.iter().any(|m| m.value == "claude-opus-4-7"));
+        assert!(!backend.supports_cli_model_fetch());
+    }
+
+    #[test]
+    fn parse_claude_list_models_output_extracts_values_in_order() {
+        let stdout = r#"{"models":[{"value":"sonnet"},{"value":"haiku"}]}"#;
+        let result = parse_claude_list_models_output(stdout).unwrap();
+        assert_eq!(result, vec!["sonnet".to_string(), "haiku".to_string()]);
+    }
+
+    #[test]
+    fn parse_claude_list_models_output_falls_back_to_id_when_value_missing() {
+        let stdout = r#"{"models":[{"id":"only-id"},{"value":"vv","id":"ignored"}]}"#;
+        let result = parse_claude_list_models_output(stdout).unwrap();
+        // value 優先、無ければ id を採用する
+        assert_eq!(result, vec!["only-id".to_string(), "vv".to_string()]);
+    }
+
+    #[test]
+    fn parse_claude_list_models_output_errors_on_invalid_json() {
+        let stdout = "not-json";
+        let err = parse_claude_list_models_output(stdout).unwrap_err();
+        assert!(err.contains("JSON 解析"));
+    }
+
+    #[test]
+    fn parse_claude_list_models_output_errors_when_models_missing() {
+        let stdout = r#"{"other": []}"#;
+        let err = parse_claude_list_models_output(stdout).unwrap_err();
+        assert!(err.contains("'models' 配列"));
+    }
+
+    #[test]
+    fn parse_claude_list_models_output_errors_when_entry_has_no_id() {
+        let stdout = r#"{"models":[{"foo":"bar"}]}"#;
+        let err = parse_claude_list_models_output(stdout).unwrap_err();
+        assert!(err.contains("value/id"));
+    }
+
+    #[test]
+    fn parse_claude_list_models_output_accepts_empty_models_array() {
+        // 空配列は parser としては成功、空 ID 拒否は呼び出し側（fetch_models_from_cli）の責務
+        let stdout = r#"{"models":[]}"#;
+        let result = parse_claude_list_models_output(stdout).unwrap();
+        assert!(result.is_empty());
+    }
+
+    fn write_probe_script(body: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("probe.mjs");
+        std::fs::write(&path, body).unwrap();
+        (dir, path)
+    }
+
+    #[tokio::test]
+    async fn fetch_models_from_cli_runs_probe_script_and_returns_models() {
+        let (_dir, path) = write_probe_script(
+            r#"console.log(JSON.stringify({models:[{value:"sonnet"},{id:"haiku"}]}));"#,
+        );
+        let backend = ClaudeBackend {
+            list_models_script: Some(Ok(path)),
+        };
+
+        let models = backend.fetch_models_from_cli().await.unwrap();
+
+        assert_eq!(models, vec!["sonnet".to_string(), "haiku".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn fetch_models_from_cli_rejects_empty_models() {
+        let (_dir, path) = write_probe_script(r#"console.log(JSON.stringify({models:[]}));"#);
+        let backend = ClaudeBackend {
+            list_models_script: Some(Ok(path)),
+        };
+
+        let err = backend.fetch_models_from_cli().await.unwrap_err();
+
+        assert!(err.contains("空"));
+    }
+
+    #[tokio::test]
+    async fn fetch_models_from_cli_errors_on_nonzero_exit() {
+        let (_dir, path) = write_probe_script(r#"console.error("boom"); process.exit(7);"#);
+        let backend = ClaudeBackend {
+            list_models_script: Some(Ok(path)),
+        };
+
+        let err = backend.fetch_models_from_cli().await.unwrap_err();
+
+        assert!(err.contains("失敗"));
     }
 }

--- a/src-tauri/src/backends/codex.rs
+++ b/src-tauri/src/backends/codex.rs
@@ -459,9 +459,9 @@ mod tests {
 
     #[test]
     fn redact_secrets_redacts_api_key_value() {
-        let s = "api_key=sk_live_supersecretvalue123";
+        let s = "api_key=fake_test_key_value_1234567890";
         let redacted = redact_secrets(s);
-        assert!(!redacted.contains("supersecretvalue123"));
+        assert!(!redacted.contains("fake_test_key_value_1234567890"));
         assert!(redacted.contains("[REDACTED]"));
     }
 

--- a/src-tauri/src/backends/codex.rs
+++ b/src-tauri/src/backends/codex.rs
@@ -1,59 +1,132 @@
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::{AppHandle, Manager};
+use tokio::process::Command;
 use tokio::sync::Mutex;
 
 use crate::backends::bridge_common::{
     start_agent_session_internal, start_agent_turn, write_bridge_command, AgentProcessMap,
     CODEX_BACKEND_ID,
 };
+use crate::backends::process_io::run_command_with_output_limit;
 use crate::backends::{
-    AgentBackend, AgentMessage, BackendRuntimeConfig, ModelInfo, PermissionResponse, SessionConfig,
+    AgentBackend, AgentMessage, BackendRuntimeConfig, PermissionResponse, SessionConfig,
     SessionHandle,
 };
 use crate::session::{resolve_data_dir, SessionStore};
+
+/// `codex debug models` の取得タイムアウト。長くなる場合は CLI 側の問題として扱う。
+const CODEX_FETCH_MODELS_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// `codex debug models` の stdout/stderr の取り込み上限（バイト）。
+/// CLI が暴走したり巨大な出力を返した場合のメモリ・ログ肥大化を防ぐ。
+const CODEX_OUTPUT_MAX_BYTES: usize = 1024 * 1024;
+
+/// stderr ログに残す要約バイト数（末尾）。機密情報の偶発的な漏えいを抑制する。
+const CODEX_STDERR_LOG_SUMMARY_BYTES: usize = 512;
 
 /// Codex SDK Bridge バックエンド。
 /// 実際のプロセス制御は AgentProcess bridge runtime に委譲する。
 pub struct CodexBackend {
     #[allow(dead_code)]
     runtime: Option<Arc<dyn CodexBackendRuntime>>,
+    cli_path: Option<String>,
 }
 
-pub fn codex_supported_models() -> Vec<ModelInfo> {
-    vec![
-        ModelInfo {
-            value: "gpt-5.5".to_string(),
-            display_name: "gpt-5.5".to_string(),
-        },
-        ModelInfo {
-            value: "gpt-5.4".to_string(),
-            display_name: "gpt-5.4".to_string(),
-        },
-        ModelInfo {
-            value: "gpt-5.4-mini".to_string(),
-            display_name: "gpt-5.4-mini".to_string(),
-        },
-        ModelInfo {
-            value: "gpt-5.3-codex".to_string(),
-            display_name: "gpt-5.3-codex".to_string(),
-        },
-        ModelInfo {
-            value: "gpt-5.3-codex-spark".to_string(),
-            display_name: "gpt-5.3-codex-spark".to_string(),
-        },
-        ModelInfo {
-            value: "gpt-5.2".to_string(),
-            display_name: "gpt-5.2".to_string(),
-        },
-    ]
+/// `codex debug models` の標準出力（JSON カタログ）をパースし、`models[].slug` を抽出する。
+/// 出力が JSON として不正、または `models` 配列が欠落している場合は Err を返す。
+/// 値は加工せずそのまま返し、検証は呼び出し側に委ねる（all-or-nothing）。
+pub(crate) fn parse_codex_models_output(stdout: &str) -> Result<Vec<String>, String> {
+    let value: serde_json::Value = serde_json::from_str(stdout.trim())
+        .map_err(|e| format!("codex debug models の JSON 解析に失敗: {e}"))?;
+    let arr = value
+        .get("models")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "codex debug models 出力に 'models' 配列がありません".to_string())?;
+
+    let mut result = Vec::with_capacity(arr.len());
+    for (idx, entry) in arr.iter().enumerate() {
+        let slug = entry.get("slug").and_then(|v| v.as_str()).ok_or_else(|| {
+            format!("codex debug models 出力の models[{idx}] に 'slug' がありません")
+        })?;
+        result.push(slug.to_string());
+    }
+    Ok(result)
 }
 
-pub(crate) fn configured_initial_model(app: &tauri::AppHandle) -> Option<String> {
-    app.try_state::<std::sync::Arc<crate::config::AppConfig>>()
-        .and_then(|cfg_state| cfg_state.get_config().ok())
-        .and_then(|cfg| cfg.agents.codex.model)
+/// stderr ログ要約: 末尾 N バイトのみ、制御文字を除去し、機密情報候補を redaction する。
+/// 通常運用ログでは `error_message_for_failure` 経由で固定メッセージのみ出すこと。
+/// 詳細出力はデバッグ用途に限定し、API key・Bearer/Authorization トークン等は伏字化する。
+fn summarize_stderr(bytes: &[u8]) -> String {
+    let start = bytes.len().saturating_sub(CODEX_STDERR_LOG_SUMMARY_BYTES);
+    let tail = &bytes[start..];
+    let s = String::from_utf8_lossy(tail);
+    let sanitized: String = s
+        .chars()
+        .map(|c| {
+            if c == '\n' || c == '\r' || c == '\t' {
+                c
+            } else if c.is_control() {
+                '?'
+            } else {
+                c
+            }
+        })
+        .collect();
+    let redacted = redact_secrets(&sanitized);
+    if start > 0 {
+        format!("[...truncated...]{redacted}")
+    } else {
+        redacted
+    }
+}
+
+/// 機密情報候補を伏字化する。
+/// - `Authorization: <scheme> <token>` / `Bearer <token>`
+/// - `api[_-]?key`, `secret`, `token`, `password` 等のキー直後の値
+/// - 長めの英数字混在トークン（24 文字以上）
+fn redact_secrets(s: &str) -> String {
+    use std::sync::OnceLock;
+    static PATTERNS: OnceLock<Vec<regex::Regex>> = OnceLock::new();
+    let patterns = PATTERNS.get_or_init(|| {
+        vec![
+            // Authorization ヘッダ全体（scheme + value）
+            regex::RegexBuilder::new(r#"(?i)authorization\s*[:=]\s*\S+(\s+\S+)?"#)
+                .build()
+                .unwrap(),
+            // Bearer / Basic などスキーム付きトークン
+            regex::RegexBuilder::new(r#"(?i)\b(?:bearer|basic|token)\s+[A-Za-z0-9._\-/+=]{8,}"#)
+                .build()
+                .unwrap(),
+            // api_key / api-key / apikey / secret / password / token = VALUE
+            regex::RegexBuilder::new(
+                r#"(?i)\b(?:api[_-]?key|secret(?:[_-]?key)?|password|access[_-]?token|refresh[_-]?token|token)\b\s*[:=]\s*['"]?[^\s'"]+"#,
+            )
+            .build()
+            .unwrap(),
+            // 単独で現れる長い英数字混在トークン（誤検知許容）
+            regex::RegexBuilder::new(r#"\b(?:sk|pk|tok|key|sess|bearer)[_-][A-Za-z0-9_\-]{16,}"#)
+                .case_insensitive(true)
+                .build()
+                .unwrap(),
+        ]
+    });
+    let mut out = s.to_string();
+    for re in patterns {
+        out = re.replace_all(&out, "[REDACTED]").into_owned();
+    }
+    out
+}
+
+/// 失敗時の通常ログ用メッセージ（exit status と固定文言のみ）。
+/// stderr 本文は debug! へ降格して出力するため、ここでは含めない。
+fn error_message_for_failure(status_code: Option<i32>) -> String {
+    format!(
+        "codex debug models が失敗しました (status={:?})",
+        status_code
+    )
 }
 
 pub(crate) fn configured_cli_path(app: &tauri::AppHandle) -> Option<String> {
@@ -66,7 +139,10 @@ pub(crate) fn configured_cli_path(app: &tauri::AppHandle) -> Option<String> {
 #[allow(dead_code)]
 impl CodexBackend {
     pub fn new() -> Self {
-        Self { runtime: None }
+        Self {
+            runtime: None,
+            cli_path: None,
+        }
     }
 
     pub fn with_agent_process_runtime(
@@ -74,12 +150,14 @@ impl CodexBackend {
         handles: Arc<Mutex<AgentProcessMap>>,
         session_store: Arc<SessionStore>,
     ) -> Self {
+        let cli_path = configured_cli_path(&app);
         Self {
             runtime: Some(Arc::new(AgentProcessCodexRuntime {
                 app,
                 handles,
                 session_store,
             })),
+            cli_path,
         }
     }
 
@@ -87,6 +165,10 @@ impl CodexBackend {
         self.runtime.clone().ok_or_else(|| {
             "CodexBackend runtime is not attached; build the registry with app runtime".to_string()
         })
+    }
+
+    fn cli_path(&self) -> String {
+        self.cli_path.clone().unwrap_or_else(|| "codex".to_string())
     }
 }
 
@@ -260,8 +342,37 @@ impl AgentBackend for CodexBackend {
         self.runtime()?.respond_permission(session, response).await
     }
 
-    async fn available_models(&self) -> Result<Vec<ModelInfo>, String> {
-        Ok(codex_supported_models())
+    async fn fetch_models_from_cli(&self) -> Result<Vec<String>, String> {
+        let cli = self.cli_path();
+        let mut cmd = Command::new(&cli);
+        cmd.arg("debug").arg("models");
+
+        let output = run_command_with_output_limit(
+            cmd,
+            CODEX_FETCH_MODELS_TIMEOUT,
+            CODEX_OUTPUT_MAX_BYTES,
+            "codex CLI",
+            &format!("codex CLI 起動失敗 ({cli})"),
+            "codex CLI 待機失敗",
+            format!(
+                "codex CLI 取得タイムアウト ({} 秒)",
+                CODEX_FETCH_MODELS_TIMEOUT.as_secs()
+            ),
+        )
+        .await?;
+
+        if !output.status.success() {
+            // 通常ログは exit status と固定メッセージのみ。stderr 詳細は debug! 限定。
+            let message = error_message_for_failure(output.status.code());
+            log::debug!("{}: stderr={}", message, summarize_stderr(&output.stderr));
+            return Err(message);
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let models = parse_codex_models_output(&stdout)?;
+        if models.is_empty() {
+            return Err("codex debug models の出力が空でした".to_string());
+        }
+        Ok(models)
     }
 
     fn runtime_config(&self, app: &tauri::AppHandle) -> BackendRuntimeConfig {
@@ -274,7 +385,6 @@ impl AgentBackend for CodexBackend {
         );
 
         BackendRuntimeConfig {
-            initial_model: configured_initial_model(app),
             bridge_init_options,
         }
     }
@@ -288,12 +398,168 @@ impl AgentBackend for CodexBackend {
 mod tests {
     use super::*;
 
+    #[test]
+    fn parse_codex_models_output_extracts_slugs_from_json_catalog() {
+        let stdout = r#"{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5"},{"slug":"o3","display_name":"o3"}]}"#;
+        let parsed = parse_codex_models_output(stdout).unwrap();
+        assert_eq!(parsed, vec!["gpt-5.5".to_string(), "o3".to_string()]);
+    }
+
+    #[test]
+    fn parse_codex_models_output_does_not_normalize_slug() {
+        // CLI 由来でも値は加工せずそのまま返す（trim 等の正規化禁止）。
+        let stdout = r#"{"models":[{"slug":"  spaced-slug  "}]}"#;
+        let parsed = parse_codex_models_output(stdout).unwrap();
+        assert_eq!(parsed, vec!["  spaced-slug  ".to_string()]);
+    }
+
+    #[test]
+    fn parse_codex_models_output_rejects_invalid_json() {
+        assert!(parse_codex_models_output("not json").is_err());
+    }
+
+    #[test]
+    fn parse_codex_models_output_rejects_missing_models_array() {
+        assert!(parse_codex_models_output(r#"{"foo":"bar"}"#).is_err());
+    }
+
+    #[test]
+    fn parse_codex_models_output_rejects_entry_without_slug() {
+        // models[].slug が欠落していた場合は all-or-nothing で拒否。
+        assert!(
+            parse_codex_models_output(r#"{"models":[{"slug":"a"},{"display_name":"b"}]}"#).is_err()
+        );
+    }
+
+    #[test]
+    fn summarize_stderr_truncates_and_sanitizes_control_chars() {
+        let mut input = Vec::new();
+        input.extend(std::iter::repeat_n(b'a', 1024));
+        input.extend_from_slice(b"\x01tail");
+        let s = summarize_stderr(&input);
+        assert!(s.starts_with("[...truncated...]"));
+        assert!(s.contains("?tail"));
+    }
+
+    #[test]
+    fn redact_secrets_redacts_authorization_header() {
+        let s = "request failed: Authorization: Bearer abcdef1234567890XYZ";
+        let redacted = redact_secrets(s);
+        assert!(!redacted.contains("abcdef1234567890XYZ"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_secrets_redacts_bearer_token_alone() {
+        let s = "got token bearer abcDEF1234567890";
+        let redacted = redact_secrets(s);
+        assert!(!redacted.contains("abcDEF1234567890"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_secrets_redacts_api_key_value() {
+        let s = "api_key=sk_live_supersecretvalue123";
+        let redacted = redact_secrets(s);
+        assert!(!redacted.contains("supersecretvalue123"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_secrets_redacts_secret_assignment() {
+        let s = "secret: \"top-secret-value-1234\"";
+        let redacted = redact_secrets(s);
+        assert!(!redacted.contains("top-secret-value-1234"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn summarize_stderr_redacts_authorization() {
+        let bytes = b"Authorization: Bearer abcdef1234567890SECRET";
+        let s = summarize_stderr(bytes);
+        assert!(!s.contains("abcdef1234567890SECRET"));
+        assert!(s.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn error_message_for_failure_does_not_include_stderr() {
+        let msg = error_message_for_failure(Some(1));
+        assert!(msg.contains("status="));
+        // 通常ログ用メッセージには stderr 由来の文字列を含めない
+        assert!(!msg.to_lowercase().contains("bearer"));
+        assert!(!msg.to_lowercase().contains("authorization"));
+    }
+
+    #[cfg(unix)]
+    fn write_codex_cli_script(body: &str) -> (tempfile::TempDir, String) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("codex-test-cli");
+        std::fs::write(&path, body).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        (dir, path.to_string_lossy().into_owned())
+    }
+
+    #[cfg(unix)]
     #[tokio::test]
-    async fn available_models_returns_codex_defaults() {
-        let backend = CodexBackend::new();
-        let models = backend.available_models().await.unwrap();
-        assert!(models.iter().any(|m| m.value == "gpt-5.5"));
-        assert!(models.iter().any(|m| m.value == "gpt-5.4"));
+    async fn fetch_models_from_cli_runs_debug_models_and_returns_stdout_models() {
+        let (_dir, cli_path) = write_codex_cli_script(
+            r#"#!/bin/sh
+if [ "$1" != "debug" ] || [ "$2" != "models" ]; then
+  echo "unexpected args: $*" >&2
+  exit 42
+fi
+printf '{"models":[{"slug":"gpt-5.5"},{"slug":"o3"}]}'
+"#,
+        );
+        let mut backend = CodexBackend::new();
+        backend.cli_path = Some(cli_path);
+
+        let models = backend.fetch_models_from_cli().await.unwrap();
+
+        assert_eq!(models, vec!["gpt-5.5".to_string(), "o3".to_string()]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn fetch_models_from_cli_errors_on_nonzero_exit() {
+        let (_dir, cli_path) = write_codex_cli_script(
+            r#"#!/bin/sh
+echo "boom" >&2
+exit 7
+"#,
+        );
+        let mut backend = CodexBackend::new();
+        backend.cli_path = Some(cli_path);
+
+        let err = backend.fetch_models_from_cli().await.unwrap_err();
+
+        assert!(err.contains("status"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn fetch_models_from_cli_rejects_empty_models() {
+        let (_dir, cli_path) = write_codex_cli_script(
+            r#"#!/bin/sh
+printf '{"models":[]}'
+"#,
+        );
+        let mut backend = CodexBackend::new();
+        backend.cli_path = Some(cli_path);
+
+        let err = backend.fetch_models_from_cli().await.unwrap_err();
+
+        assert!(err.contains("空"));
+    }
+
+    #[tokio::test]
+    async fn fetch_models_from_cli_errors_when_cli_missing() {
+        let mut backend = CodexBackend::new();
+        backend.cli_path = Some("/nonexistent-codex-binary-for-test".to_string());
+        let result = backend.fetch_models_from_cli().await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src-tauri/src/backends/mod.rs
+++ b/src-tauri/src/backends/mod.rs
@@ -1,6 +1,8 @@
 pub mod bridge_common;
 pub mod claude;
 pub mod codex;
+pub(crate) mod model_catalog_sync;
+pub(crate) mod process_io;
 pub mod runtime_coordinator;
 
 use async_trait::async_trait;
@@ -10,12 +12,12 @@ use tauri::State;
 use tokio::sync::Mutex;
 
 use crate::config::AppConfig;
+use crate::domain::agent_session::{escaped_for_log, ModelId, ModelIdList};
 use crate::session::SessionStore;
 
 /// Backend-specific runtime values consumed by the generic bridge process runner.
 #[derive(Debug, Clone, Default)]
 pub struct BackendRuntimeConfig {
-    pub initial_model: Option<String>,
     pub bridge_init_options: serde_json::Map<String, serde_json::Value>,
 }
 
@@ -26,6 +28,7 @@ pub struct BackendInfo {
     pub id: String,
     pub name: String,
     pub available: bool,
+    pub available_models: Vec<ModelInfo>,
 }
 
 /// モデル情報（共通型）。全バックエンドで使用する。
@@ -33,7 +36,14 @@ pub struct BackendInfo {
 #[serde(rename_all = "camelCase")]
 pub struct ModelInfo {
     pub value: String,
-    pub display_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InitialModelResolution {
+    Unset,
+    Registered(String),
+    Invalid { model: String, reason: String },
+    Unregistered { model: String },
 }
 
 /// 画像添付（共通型）。全バックエンドで使用する。
@@ -109,8 +119,21 @@ pub trait AgentBackend: Send + Sync {
         response: PermissionResponse,
     ) -> Result<(), String>;
 
-    /// 利用可能なモデル一覧を取得する。
-    async fn available_models(&self) -> Result<Vec<ModelInfo>, String>;
+    /// 起動時の CLI 由来モデル一覧取得をサポートするか。
+    /// `false` を返すバックエンドは `refresh_models_to_config_for` から skip され、
+    /// `fetch_models_from_cli` は呼ばれない。
+    fn supports_cli_model_fetch(&self) -> bool {
+        true
+    }
+
+    /// バックエンドCLIから生のモデル識別子リストを取得する。
+    /// 検証・永続化は呼び出し側（Registry）で行うため、本メソッドは
+    /// 取得した生の値を返すだけで config を書き換えない。
+    ///
+    /// `supports_cli_model_fetch()` が `false` のバックエンドでは呼ばれない。
+    async fn fetch_models_from_cli(&self) -> Result<Vec<String>, String> {
+        Err("このバックエンドは起動時CLIモデル取得をサポートしていません".to_string())
+    }
 
     /// Bridge 起動時に必要なバックエンド固有の設定を返す。
     fn runtime_config(&self, _app: &tauri::AppHandle) -> BackendRuntimeConfig {
@@ -126,6 +149,7 @@ pub trait AgentBackend: Send + Sync {
 pub struct AgentBackendRegistry {
     backends: Vec<(String, Arc<dyn AgentBackend>, bool)>,
     default_id: Option<String>,
+    config: Option<Arc<AppConfig>>,
 }
 
 impl AgentBackendRegistry {
@@ -133,7 +157,112 @@ impl AgentBackendRegistry {
         Self {
             backends: Vec::new(),
             default_id: None,
+            config: None,
         }
+    }
+
+    /// `AppConfig` を関連付ける。`available_models()` / `resolve_backend_for_model()` は
+    /// この config の `agents.<backend>.models` を参照する。
+    pub fn set_config(&mut self, config: Arc<AppConfig>) {
+        self.config = Some(config);
+    }
+
+    /// 指定 backend の config 由来の初期モデルを返す。
+    /// `agents.<backend>.model` が `agents.<backend>.models` に含まれる場合のみ採用する。
+    /// 未紐付け／schema 未対応／未登録の場合は `None` を返す。
+    pub fn initial_model_for(&self, backend_id: &str) -> Option<String> {
+        match self.initial_model_resolution_for(backend_id) {
+            InitialModelResolution::Registered(model) => Some(model),
+            InitialModelResolution::Invalid { model, reason } => {
+                let model = escaped_for_log(&model);
+                log::warn!(
+                    "backend '{backend_id}' configured initial model {model} is invalid and will be ignored: {reason}"
+                );
+                None
+            }
+            InitialModelResolution::Unregistered { model } => {
+                let model = escaped_for_log(&model);
+                log::warn!(
+                    "backend '{backend_id}' configured initial model {model} is not registered in current models and will be ignored"
+                );
+                None
+            }
+            InitialModelResolution::Unset => None,
+        }
+    }
+
+    /// 起動時警告とセッション作成で共有する初期モデル整合性判定。
+    /// 判定のみを返し、ログ出力や config 書き換えは行わない。
+    pub fn initial_model_resolution_for(&self, backend_id: &str) -> InitialModelResolution {
+        let Some(config) = self.config.as_ref() else {
+            return InitialModelResolution::Unset;
+        };
+        let Some(model) = config.configured_initial_model_for_backend(backend_id) else {
+            return InitialModelResolution::Unset;
+        };
+        if let Err(reason) = ModelId::parse(model.clone()) {
+            return InitialModelResolution::Invalid { model, reason };
+        }
+        let Ok(models) = self.config_models_for(backend_id) else {
+            return InitialModelResolution::Unset;
+        };
+        if models.iter().any(|value| value == &model) {
+            InitialModelResolution::Registered(model)
+        } else {
+            InitialModelResolution::Unregistered { model }
+        }
+    }
+
+    /// config に保存されているバックエンドごとのモデルID一覧を取得する。
+    /// config 未紐付け／未知バックエンドの場合は `Err` を返し、登録済みモデルが
+    /// 0 件の場合と区別できるようにする。
+    pub fn config_models_for(&self, backend_id: &str) -> Result<Vec<String>, String> {
+        let config = self
+            .config
+            .as_ref()
+            .ok_or_else(|| "AppConfig not attached to registry".to_string())?;
+        config.models_for_backend(backend_id)
+    }
+
+    /// config の `agents.<backend>.models` を入力検証 → 重複除去した上で原子的に書き換える。
+    /// 検証に失敗した場合・config schema に当該バックエンドが存在しない場合は
+    /// config を変更せず `Err` を返す。他バックエンドの一覧は影響を受けない。
+    pub fn write_models_to_config(
+        &self,
+        backend_id: &str,
+        models: Vec<String>,
+    ) -> Result<Vec<String>, String> {
+        let validated = ModelIdList::parse_many(&models)?.into_strings();
+        let Some(config) = &self.config else {
+            return Err("AppConfig not attached to registry".to_string());
+        };
+        if self.get(backend_id).is_none() {
+            return Err(format!(
+                "バックエンド '{backend_id}' がレジストリに登録されていません"
+            ));
+        }
+        config.set_models_for_backend(backend_id, validated.clone())?;
+        Ok(validated)
+    }
+
+    /// 指定バックエンドのCLIへ問い合わせて結果を config に反映する。
+    /// 失敗時は config を変更せず Err を返す。他バックエンドの一覧には影響を与えない。
+    /// `supports_cli_model_fetch()` が `false` のバックエンドは `Ok(None)` を返す。
+    pub async fn refresh_models_to_config_for(
+        &self,
+        backend_id: &str,
+    ) -> Result<Option<Vec<String>>, String> {
+        let backend = self.get(backend_id).ok_or_else(|| {
+            format!("バックエンド '{backend_id}' がレジストリに登録されていません")
+        })?;
+        if !backend.supports_cli_model_fetch() {
+            return Ok(None);
+        }
+        let raw = backend.fetch_models_from_cli().await?;
+        if raw.is_empty() {
+            return Err("CLI 取得結果が空です".to_string());
+        }
+        self.write_models_to_config(backend_id, raw).map(Some)
     }
 
     /// バックエンドを登録する。同一IDの重複登録は無視する。
@@ -167,6 +296,10 @@ impl AgentBackendRegistry {
                 id: id.clone(),
                 name: b.name().to_string(),
                 available: *available,
+                available_models: self.available_models(id).unwrap_or_else(|e| {
+                    log::warn!("backend '{id}' model list could not be read for backend list: {e}");
+                    Vec::new()
+                }),
             })
             .collect()
     }
@@ -179,12 +312,21 @@ impl AgentBackendRegistry {
             .map(|(_, b, _)| Arc::clone(b))
     }
 
-    /// 指定バックエンドのモデル一覧を返す。
-    pub async fn available_models(&self, id: &str) -> Result<Vec<ModelInfo>, String> {
-        let backend = self
-            .get(id)
-            .ok_or_else(|| format!("バックエンド '{id}' がレジストリに登録されていません"))?;
-        backend.available_models().await
+    /// 指定バックエンドのモデル一覧を返す。供給元は config.toml の
+    /// `agents.<backend>.models`（順序保持）。
+    /// config 未紐付け／schema 未対応／lock 失敗は `Err` として伝播し、
+    /// 「登録済みモデルが 0 件」と区別できるようにする。
+    pub fn available_models(&self, id: &str) -> Result<Vec<ModelInfo>, String> {
+        if self.get(id).is_none() {
+            return Err(format!(
+                "バックエンド '{id}' がレジストリに登録されていません"
+            ));
+        }
+        Ok(self
+            .config_models_for(id)?
+            .into_iter()
+            .map(|value| ModelInfo { value })
+            .collect())
     }
 
     pub fn runtime_config(&self, id: &str, app: &tauri::AppHandle) -> Option<BackendRuntimeConfig> {
@@ -235,46 +377,30 @@ impl AgentBackendRegistry {
             .ok_or_else(|| "利用可能なバックエンドが登録されていません".to_string())
     }
 
-    /// 全バックエンドの `available_models()` を走査し、有効なモデルID（value）の集合を返す。
-    pub async fn collect_all_model_values(&self) -> std::collections::HashSet<String> {
-        let mut values = std::collections::HashSet::new();
-        for (id, _, available) in &self.backends {
-            if !*available {
-                continue;
-            }
-            match self.available_models(id).await {
-                Ok(models) => {
-                    for m in models {
-                        values.insert(m.value);
-                    }
-                }
-                Err(e) => {
-                    log::warn!("failed to fetch models from backend '{id}': {e}");
-                }
-            }
-        }
-        values
-    }
-
     /// モデルIDから対応するバックエンドIDを解決する。
-    /// 全バックエンドの `available_models()` を走査し、最初に一致したバックエンドIDを返す。
-    pub async fn resolve_backend_for_model(&self, model: &str) -> Option<String> {
+    /// 同一モデルIDが複数バックエンドに登録されている場合は一意特定不能として
+    /// `Err` を返す（サイレントフォールバックを避けるため）。
+    /// 該当するバックエンドが存在しない場合は `Ok(None)` を返す。
+    /// いずれかのバックエンドで config 取得に失敗した場合も `Err` を返す。
+    pub fn resolve_backend_for_model(&self, model: &str) -> Result<Option<String>, String> {
+        let mut matched: Vec<String> = Vec::new();
         for (id, _, available) in &self.backends {
             if !*available {
                 continue;
             }
-            match self.available_models(id).await {
-                Ok(models) => {
-                    if models.iter().any(|m| m.value == model) {
-                        return Some(id.clone());
-                    }
-                }
-                Err(e) => {
-                    log::warn!("failed to fetch models from backend '{id}': {e}");
-                }
+            let models = self.config_models_for(id)?;
+            if models.iter().any(|v| v == model) {
+                matched.push(id.clone());
             }
         }
-        None
+        match matched.len() {
+            0 => Ok(None),
+            1 => Ok(matched.into_iter().next()),
+            _ => Err(format!(
+                "モデル '{model}' が複数のバックエンドに登録されているため一意特定できません: {}",
+                matched.join(", ")
+            )),
+        }
     }
 }
 
@@ -298,19 +424,20 @@ pub fn list_agent_backends(registry: State<'_, Arc<AgentBackendRegistry>>) -> Ba
 
 /// config.toml `[agents]` セクションからレジストリを構築する。
 #[allow(dead_code)]
-pub fn build_registry(config: &AppConfig) -> AgentBackendRegistry {
-    build_registry_inner(config, None)
+pub fn build_registry(config: Arc<AppConfig>) -> AgentBackendRegistry {
+    build_registry_inner(config, None, None)
 }
 
 /// 実アプリ用: CodexBackend に AgentProcess bridge runtime を接続して登録する。
 pub fn build_registry_with_runtime(
-    config: &AppConfig,
+    config: Arc<AppConfig>,
     app: tauri::AppHandle,
     handles: Arc<Mutex<bridge_common::AgentProcessMap>>,
     session_store: Arc<SessionStore>,
 ) -> AgentBackendRegistry {
     build_registry_inner(
         config,
+        Some(Arc::new(claude::ClaudeBackend::with_app(&app))),
         Some(Arc::new(codex::CodexBackend::with_agent_process_runtime(
             app,
             handles,
@@ -320,13 +447,14 @@ pub fn build_registry_with_runtime(
 }
 
 fn build_registry_inner(
-    config: &AppConfig,
+    config: Arc<AppConfig>,
+    claude_backend: Option<Arc<dyn AgentBackend>>,
     codex_backend: Option<Arc<dyn AgentBackend>>,
 ) -> AgentBackendRegistry {
     let mut registry = AgentBackendRegistry::new();
 
     // Claude バックエンドは常に利用可能（組み込み）
-    let claude = Arc::new(claude::ClaudeBackend::new());
+    let claude = claude_backend.unwrap_or_else(|| Arc::new(claude::ClaudeBackend::new()));
     registry.register(claude);
 
     // Codex バックエンドもプロジェクト依存として常に利用可能
@@ -337,6 +465,7 @@ fn build_registry_inner(
     if let Ok(cfg) = config.get_config() {
         registry.set_default(cfg.agents.default.clone());
     }
+    registry.set_config(config);
 
     registry
 }
@@ -344,10 +473,11 @@ fn build_registry_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
-
     struct MockBackend {
         backend_id: String,
         backend_name: String,
+        cli_models: Result<Vec<String>, String>,
+        supports_cli_fetch: bool,
     }
 
     #[async_trait]
@@ -381,8 +511,11 @@ mod tests {
         ) -> Result<(), String> {
             Ok(())
         }
-        async fn available_models(&self) -> Result<Vec<ModelInfo>, String> {
-            Ok(vec![])
+        fn supports_cli_model_fetch(&self) -> bool {
+            self.supports_cli_fetch
+        }
+        async fn fetch_models_from_cli(&self) -> Result<Vec<String>, String> {
+            self.cli_models.clone()
         }
         async fn close_session(&self, _session: &SessionHandle) -> Result<(), String> {
             Ok(())
@@ -393,7 +526,70 @@ mod tests {
         Arc::new(MockBackend {
             backend_id: id.to_string(),
             backend_name: name.to_string(),
+            cli_models: Ok(Vec::new()),
+            supports_cli_fetch: true,
         })
+    }
+
+    fn mock_backend_with_cli(
+        id: &str,
+        name: &str,
+        cli_models: Result<Vec<String>, String>,
+    ) -> Arc<dyn AgentBackend> {
+        Arc::new(MockBackend {
+            backend_id: id.to_string(),
+            backend_name: name.to_string(),
+            cli_models,
+            supports_cli_fetch: true,
+        })
+    }
+
+    fn mock_backend_unsupported_cli(id: &str, name: &str) -> Arc<dyn AgentBackend> {
+        Arc::new(MockBackend {
+            backend_id: id.to_string(),
+            backend_name: name.to_string(),
+            cli_models: Err("never called".to_string()),
+            supports_cli_fetch: false,
+        })
+    }
+
+    fn make_test_app_config() -> Arc<AppConfig> {
+        Arc::new(AppConfig::new(
+            crate::config::ReleashConfig::default(),
+            std::path::PathBuf::from("/tmp/test-releash.toml"),
+        ))
+    }
+
+    fn make_test_app_config_with_models(
+        claude_models: &[&str],
+        codex_models: &[&str],
+    ) -> Arc<AppConfig> {
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = claude_models.iter().map(|s| s.to_string()).collect();
+        cfg.agents.codex.models = codex_models.iter().map(|s| s.to_string()).collect();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        Arc::new(AppConfig::new(cfg, tmp.path().to_path_buf()))
+    }
+
+    fn make_test_app_config_with_initial_model(
+        backend_id: &str,
+        model: Option<&str>,
+        models: &[&str],
+    ) -> Arc<AppConfig> {
+        let mut cfg = crate::config::ReleashConfig::default();
+        match backend_id {
+            "claude" => {
+                cfg.agents.claude.model = model.map(str::to_string);
+                cfg.agents.claude.models = models.iter().map(|s| s.to_string()).collect();
+            }
+            "codex" => {
+                cfg.agents.codex.model = model.map(str::to_string);
+                cfg.agents.codex.models = models.iter().map(|s| s.to_string()).collect();
+            }
+            _ => {}
+        }
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        Arc::new(AppConfig::new(cfg, tmp.path().to_path_buf()))
     }
 
     #[test]
@@ -411,6 +607,74 @@ mod tests {
         assert_eq!(list[0].id, "claude");
         assert_eq!(list[0].name, "Claude");
         assert!(list[0].available);
+    }
+
+    #[test]
+    fn initial_model_for_returns_some_when_registered() {
+        let config =
+            make_test_app_config_with_initial_model("claude", Some("opus-4"), &["opus-4", "haiku"]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config);
+
+        assert_eq!(reg.initial_model_for("claude"), Some("opus-4".to_string()));
+    }
+
+    #[test]
+    fn initial_model_for_returns_none_when_unregistered() {
+        let config = make_test_app_config_with_initial_model("claude", Some("opus-4"), &["haiku"]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config);
+
+        assert_eq!(reg.initial_model_for("claude"), None);
+    }
+
+    #[test]
+    fn initial_model_resolution_reports_unregistered_model() {
+        let config = make_test_app_config_with_initial_model("claude", Some("opus-4"), &["haiku"]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config);
+
+        assert_eq!(
+            reg.initial_model_resolution_for("claude"),
+            InitialModelResolution::Unregistered {
+                model: "opus-4".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn initial_model_for_returns_none_when_configured_model_is_invalid() {
+        let config =
+            make_test_app_config_with_initial_model("claude", Some("bad\u{0001}model"), &[]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config);
+
+        assert_eq!(reg.initial_model_for("claude"), None);
+    }
+
+    #[test]
+    fn initial_model_for_returns_none_when_configured_model_is_too_long() {
+        let model = "x".repeat(129);
+        let config = make_test_app_config_with_initial_model("claude", Some(&model), &[]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config);
+
+        assert_eq!(reg.initial_model_for("claude"), None);
+    }
+
+    #[test]
+    fn initial_model_for_returns_none_when_model_unset() {
+        let config = make_test_app_config_with_initial_model("claude", None, &["opus-4"]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config);
+
+        assert_eq!(reg.initial_model_for("claude"), None);
     }
 
     #[test]
@@ -533,11 +797,8 @@ mod tests {
 
     #[test]
     fn build_registry_registers_claude_backend() {
-        let config = AppConfig::new(
-            crate::config::ReleashConfig::default(),
-            std::path::PathBuf::from("/tmp/test-releash.toml"),
-        );
-        let reg = build_registry(&config);
+        let config = make_test_app_config();
+        let reg = build_registry(config);
         let list = reg.list();
         assert_eq!(list.len(), 2);
         assert_eq!(list[0].id, "claude");
@@ -552,166 +813,377 @@ mod tests {
     fn build_registry_applies_default_from_config() {
         let mut cfg = crate::config::ReleashConfig::default();
         cfg.agents.default = Some("codex".to_string());
-        let config = AppConfig::new(cfg, std::path::PathBuf::from("/tmp/test-releash.toml"));
-        let reg = build_registry(&config);
+        let config = Arc::new(AppConfig::new(
+            cfg,
+            std::path::PathBuf::from("/tmp/test-releash.toml"),
+        ));
+        let reg = build_registry(config);
         assert_eq!(reg.resolve_default_id().unwrap(), "codex");
     }
 
     #[test]
     fn build_registry_without_default_config_falls_back_to_first() {
-        let config = AppConfig::new(
-            crate::config::ReleashConfig::default(),
-            std::path::PathBuf::from("/tmp/test-releash.toml"),
-        );
-        let reg = build_registry(&config);
+        let config = make_test_app_config();
+        let reg = build_registry(config);
         assert_eq!(reg.resolve_default_id().unwrap(), "claude");
     }
 
-    struct MockBackendWithModels {
-        backend_id: String,
-        backend_name: String,
-        models: Vec<ModelInfo>,
-    }
-
-    #[async_trait]
-    impl AgentBackend for MockBackendWithModels {
-        fn id(&self) -> &str {
-            &self.backend_id
-        }
-        fn name(&self) -> &str {
-            &self.backend_name
-        }
-        async fn start_session(&self, _config: SessionConfig) -> Result<SessionHandle, String> {
-            Ok(SessionHandle {
-                chat_session_id: "test".to_string(),
-                backend_id: self.backend_id.clone(),
-            })
-        }
-        async fn send_message(
-            &self,
-            _session: &SessionHandle,
-            _message: AgentMessage,
-        ) -> Result<(), String> {
-            Ok(())
-        }
-        async fn interrupt(&self, _session: &SessionHandle) -> Result<(), String> {
-            Ok(())
-        }
-        async fn respond_permission(
-            &self,
-            _session: &SessionHandle,
-            _response: PermissionResponse,
-        ) -> Result<(), String> {
-            Ok(())
-        }
-        async fn available_models(&self) -> Result<Vec<ModelInfo>, String> {
-            Ok(self.models.clone())
-        }
-        async fn close_session(&self, _session: &SessionHandle) -> Result<(), String> {
-            Ok(())
-        }
-    }
-
-    fn mock_backend_with_models(
-        id: &str,
-        name: &str,
-        models: Vec<(&str, &str)>,
-    ) -> Arc<dyn AgentBackend> {
-        Arc::new(MockBackendWithModels {
-            backend_id: id.to_string(),
-            backend_name: name.to_string(),
-            models: models
-                .into_iter()
-                .map(|(v, d)| ModelInfo {
-                    value: v.to_string(),
-                    display_name: d.to_string(),
-                })
-                .collect(),
-        })
-    }
-
-    #[tokio::test]
-    async fn collect_all_model_values_from_multiple_backends() {
+    #[test]
+    fn available_models_returns_empty_when_config_empty() {
         let mut reg = AgentBackendRegistry::new();
-        reg.register(mock_backend_with_models(
-            "claude",
-            "Claude",
-            vec![("opus-4", "Opus 4"), ("haiku", "Haiku")],
-        ));
-        reg.register(mock_backend_with_models(
-            "codex",
-            "Codex",
-            vec![("codex-mini", "Codex Mini")],
-        ));
-        let models = reg.collect_all_model_values().await;
-        assert!(models.contains("opus-4"));
-        assert!(models.contains("haiku"));
-        assert!(models.contains("codex-mini"));
-        assert_eq!(models.len(), 3);
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(make_test_app_config());
+        assert!(reg.available_models("claude").unwrap().is_empty());
     }
 
-    #[tokio::test]
-    async fn collect_all_model_values_skips_unavailable_backends() {
+    #[test]
+    fn available_models_reads_from_config() {
+        let config = make_test_app_config_with_models(&["opus-4", "haiku"], &["codex-mini"]);
         let mut reg = AgentBackendRegistry::new();
-        reg.register(mock_backend_with_models(
-            "claude",
-            "Claude",
-            vec![("opus-4", "Opus 4")],
-        ));
-        reg.register(mock_backend_with_models(
-            "codex",
-            "Codex",
-            vec![("codex-mini", "Codex Mini")],
-        ));
-        reg.set_available("codex", false);
-        let models = reg.collect_all_model_values().await;
-        assert!(models.contains("opus-4"));
-        assert!(!models.contains("codex-mini"));
+        reg.register(mock_backend("claude", "Claude"));
+        reg.register(mock_backend("codex", "Codex"));
+        reg.set_config(config);
+        let claude_models = reg.available_models("claude").unwrap();
+        assert_eq!(claude_models.len(), 2);
+        assert_eq!(claude_models[0].value, "opus-4");
+        assert_eq!(claude_models[1].value, "haiku");
+        let codex_models = reg.available_models("codex").unwrap();
+        assert_eq!(codex_models.len(), 1);
+        assert_eq!(codex_models[0].value, "codex-mini");
     }
 
-    #[tokio::test]
-    async fn resolve_backend_for_model_finds_correct_backend() {
+    #[test]
+    fn resolve_backend_for_model_finds_correct_backend() {
+        let config = make_test_app_config_with_models(&["opus-4", "haiku"], &["codex-mini"]);
         let mut reg = AgentBackendRegistry::new();
-        reg.register(mock_backend_with_models(
-            "claude",
-            "Claude",
-            vec![("opus-4", "Opus 4"), ("haiku", "Haiku")],
-        ));
-        reg.register(mock_backend_with_models(
-            "codex",
-            "Codex",
-            vec![("codex-mini", "Codex Mini")],
-        ));
+        reg.register(mock_backend("claude", "Claude"));
+        reg.register(mock_backend("codex", "Codex"));
+        reg.set_config(config);
         assert_eq!(
-            reg.resolve_backend_for_model("opus-4").await,
+            reg.resolve_backend_for_model("opus-4").unwrap(),
             Some("claude".to_string())
         );
         assert_eq!(
-            reg.resolve_backend_for_model("codex-mini").await,
+            reg.resolve_backend_for_model("codex-mini").unwrap(),
             Some("codex".to_string())
         );
     }
 
-    #[tokio::test]
-    async fn resolve_backend_for_model_returns_none_for_unknown() {
+    #[test]
+    fn resolve_backend_for_model_returns_none_for_unknown() {
+        let config = make_test_app_config_with_models(&["opus-4"], &[]);
         let mut reg = AgentBackendRegistry::new();
-        reg.register(mock_backend_with_models(
-            "claude",
-            "Claude",
-            vec![("opus-4", "Opus 4")],
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config);
+        assert_eq!(reg.resolve_backend_for_model("unknown").unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_backend_for_model_errors_when_multiple_backends_match() {
+        let config = make_test_app_config_with_models(&["shared"], &["shared"]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.register(mock_backend("codex", "Codex"));
+        reg.set_config(config);
+        let err = reg.resolve_backend_for_model("shared").unwrap_err();
+        assert!(err.contains("claude"));
+        assert!(err.contains("codex"));
+    }
+
+    #[test]
+    fn resolve_backend_for_model_skips_unavailable_backends() {
+        let config = make_test_app_config_with_models(&["opus-4"], &[]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config);
+        reg.set_available("claude", false);
+        assert_eq!(reg.resolve_backend_for_model("opus-4").unwrap(), None);
+    }
+
+    #[test]
+    fn write_models_to_config_dedupes_and_persists() {
+        let config = make_test_app_config();
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config.clone());
+        let stored = reg
+            .write_models_to_config(
+                "claude",
+                vec!["a".to_string(), "b".to_string(), "a".to_string()],
+            )
+            .unwrap();
+        assert_eq!(stored, vec!["a".to_string(), "b".to_string()]);
+        let cfg = config.get_config().unwrap();
+        assert_eq!(
+            cfg.agents.claude.models,
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn write_models_to_config_rejects_invalid_without_changing_state() {
+        let config = make_test_app_config_with_models(&["existing"], &[]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config.clone());
+        let err = reg.write_models_to_config("claude", vec!["valid".to_string(), "".to_string()]);
+        assert!(err.is_err());
+        // 既存値は維持されること
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.claude.models, vec!["existing".to_string()]);
+    }
+
+    #[test]
+    fn write_models_to_config_rejects_unregistered_backend() {
+        let config = make_test_app_config();
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.set_config(config.clone());
+        let err = reg.write_models_to_config("nonexistent", vec!["a".to_string()]);
+        assert!(err.is_err());
+        // config が変更されていない（unknown backend は no-op success にならない）
+        let cfg = config.get_config().unwrap();
+        assert!(cfg.agents.claude.models.is_empty());
+        assert!(cfg.agents.codex.models.is_empty());
+    }
+
+    #[test]
+    fn write_models_to_config_does_not_affect_other_backend() {
+        let config = make_test_app_config_with_models(&["c1"], &["x1", "x2"]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend("claude", "Claude"));
+        reg.register(mock_backend("codex", "Codex"));
+        reg.set_config(config.clone());
+        reg.write_models_to_config("claude", vec!["c2".to_string()])
+            .unwrap();
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.claude.models, vec!["c2".to_string()]);
+        assert_eq!(
+            cfg.agents.codex.models,
+            vec!["x1".to_string(), "x2".to_string()]
+        );
+    }
+
+    // --- refresh_models_to_config_for: 仕様の中核 Rule の回帰防止テスト ---
+
+    #[tokio::test]
+    async fn refresh_updates_config_on_cli_success() {
+        let config = make_test_app_config_with_models(&[], &["stale"]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend_with_cli(
+            "codex",
+            "Codex",
+            Ok(vec!["gpt-5.5".to_string(), "o3".to_string()]),
         ));
-        assert_eq!(reg.resolve_backend_for_model("unknown").await, None);
+        reg.set_config(config.clone());
+
+        let result = reg.refresh_models_to_config_for("codex").await.unwrap();
+        assert_eq!(result, Some(vec!["gpt-5.5".to_string(), "o3".to_string()]));
+        let cfg = config.get_config().unwrap();
+        assert_eq!(
+            cfg.agents.codex.models,
+            vec!["gpt-5.5".to_string(), "o3".to_string()]
+        );
     }
 
     #[tokio::test]
-    async fn resolve_backend_for_model_skips_unavailable_backends() {
+    async fn refresh_keeps_existing_models_on_cli_failure() {
+        let config = make_test_app_config_with_models(&[], &["existing"]);
         let mut reg = AgentBackendRegistry::new();
-        reg.register(mock_backend_with_models(
+        reg.register(mock_backend_with_cli(
+            "codex",
+            "Codex",
+            Err("CLI が見つかりません".to_string()),
+        ));
+        reg.set_config(config.clone());
+
+        let err = reg.refresh_models_to_config_for("codex").await;
+        assert!(err.is_err());
+        // 失敗時は config を変更しない
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.codex.models, vec!["existing".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn refresh_rejects_invalid_cli_results_without_changing_state() {
+        let config = make_test_app_config_with_models(&[], &["existing"]);
+        let mut reg = AgentBackendRegistry::new();
+        // 空文字を含む → 検証失敗
+        reg.register(mock_backend_with_cli(
+            "codex",
+            "Codex",
+            Ok(vec!["valid".to_string(), "".to_string()]),
+        ));
+        reg.set_config(config.clone());
+
+        let err = reg.refresh_models_to_config_for("codex").await;
+        assert!(err.is_err());
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.codex.models, vec!["existing".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn refresh_one_backend_does_not_affect_others() {
+        let config = make_test_app_config_with_models(&["c-existing"], &["x-existing"]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend_with_cli(
             "claude",
             "Claude",
-            vec![("opus-4", "Opus 4")],
+            Ok(vec!["c-new".to_string()]),
         ));
-        reg.set_available("claude", false);
-        assert_eq!(reg.resolve_backend_for_model("opus-4").await, None);
+        reg.register(mock_backend_with_cli(
+            "codex",
+            "Codex",
+            Err("fail".to_string()),
+        ));
+        reg.set_config(config.clone());
+
+        let _ = reg.refresh_models_to_config_for("claude").await.unwrap();
+        let _ = reg.refresh_models_to_config_for("codex").await;
+
+        let cfg = config.get_config().unwrap();
+        // 成功側だけ更新、失敗側の既存値は維持
+        assert_eq!(cfg.agents.claude.models, vec!["c-new".to_string()]);
+        assert_eq!(cfg.agents.codex.models, vec!["x-existing".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn refresh_skips_when_backend_does_not_support_cli_fetch() {
+        let config = make_test_app_config_with_models(&["existing"], &[]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend_unsupported_cli("claude", "Claude"));
+        reg.set_config(config.clone());
+
+        let result = reg.refresh_models_to_config_for("claude").await.unwrap();
+        assert_eq!(result, None);
+        // CLI 未対応バックエンドは fetch を呼ばないので config は変わらない
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.claude.models, vec!["existing".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn refresh_concurrent_backends_complete_independently() {
+        // 起動時に各バックエンドを並行 spawn しても、片方の遅延/失敗が他方を
+        // ブロックしないこと（spec: 起動シーケンスはモデル取得完了を待たない）。
+        use std::sync::Arc as StdArc;
+        use std::time::Duration;
+        use tokio::sync::Mutex as TokioMutex;
+
+        struct SlowBackend {
+            backend_id: String,
+            delay_ms: u64,
+            result: Result<Vec<String>, String>,
+        }
+
+        #[async_trait]
+        impl AgentBackend for SlowBackend {
+            fn id(&self) -> &str {
+                &self.backend_id
+            }
+            fn name(&self) -> &str {
+                "Slow"
+            }
+            async fn start_session(&self, _config: SessionConfig) -> Result<SessionHandle, String> {
+                Ok(SessionHandle {
+                    chat_session_id: "x".to_string(),
+                    backend_id: self.backend_id.clone(),
+                })
+            }
+            async fn send_message(
+                &self,
+                _session: &SessionHandle,
+                _message: AgentMessage,
+            ) -> Result<(), String> {
+                Ok(())
+            }
+            async fn interrupt(&self, _session: &SessionHandle) -> Result<(), String> {
+                Ok(())
+            }
+            async fn respond_permission(
+                &self,
+                _session: &SessionHandle,
+                _response: PermissionResponse,
+            ) -> Result<(), String> {
+                Ok(())
+            }
+            async fn fetch_models_from_cli(&self) -> Result<Vec<String>, String> {
+                tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
+                self.result.clone()
+            }
+            async fn close_session(&self, _session: &SessionHandle) -> Result<(), String> {
+                Ok(())
+            }
+        }
+
+        let config = make_test_app_config_with_models(&["c-existing"], &["x-existing"]);
+        let mut registry = AgentBackendRegistry::new();
+        // claude: 即時失敗
+        registry.register(StdArc::new(SlowBackend {
+            backend_id: bridge_common::CLAUDE_BACKEND_ID.to_string(),
+            delay_ms: 0,
+            result: Err("fail".to_string()),
+        }));
+        // codex: 遅延あり成功
+        registry.register(StdArc::new(SlowBackend {
+            backend_id: bridge_common::CODEX_BACKEND_ID.to_string(),
+            delay_ms: 200,
+            result: Ok(vec!["gpt-5.5".to_string()]),
+        }));
+        registry.set_config(config.clone());
+        let registry = Arc::new(registry);
+
+        // 起動シーケンスを模擬: 並行 spawn
+        let r1 = Arc::clone(&registry);
+        let r2 = Arc::clone(&registry);
+        let started = std::time::Instant::now();
+        let setup_completed = StdArc::new(TokioMutex::new(false));
+        let setup_completed_clone = StdArc::clone(&setup_completed);
+
+        let claude_task = tokio::spawn(async move {
+            r1.refresh_models_to_config_for(bridge_common::CLAUDE_BACKEND_ID)
+                .await
+        });
+        let codex_task = tokio::spawn(async move {
+            r2.refresh_models_to_config_for(bridge_common::CODEX_BACKEND_ID)
+                .await
+        });
+
+        // 起動シーケンスは spawn 後に即時続行する
+        {
+            let mut flag = setup_completed_clone.lock().await;
+            *flag = true;
+        }
+        let setup_elapsed = started.elapsed();
+        // setup 自体は遅い backend の完了を待たない（200ms 未満で完了する想定）
+        assert!(
+            setup_elapsed < Duration::from_millis(150),
+            "startup should not wait for slow backend; took {:?}",
+            setup_elapsed
+        );
+        assert!(*setup_completed.lock().await);
+
+        // 片方が失敗、もう片方は遅延の末に成功する。最終的に両方 join できる。
+        let claude_result = claude_task.await.unwrap();
+        let codex_result = codex_task.await.unwrap();
+        assert!(claude_result.is_err());
+        assert_eq!(codex_result.unwrap(), Some(vec!["gpt-5.5".to_string()]));
+
+        // 成功側だけ反映、失敗側は config 既存値を維持
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.claude.models, vec!["c-existing".to_string()]);
+        assert_eq!(cfg.agents.codex.models, vec!["gpt-5.5".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn refresh_rejects_empty_cli_result() {
+        let config = make_test_app_config_with_models(&[], &["existing"]);
+        let mut reg = AgentBackendRegistry::new();
+        reg.register(mock_backend_with_cli("codex", "Codex", Ok(Vec::new())));
+        reg.set_config(config.clone());
+
+        let err = reg.refresh_models_to_config_for("codex").await;
+        assert!(err.is_err());
+        let cfg = config.get_config().unwrap();
+        assert_eq!(cfg.agents.codex.models, vec!["existing".to_string()]);
     }
 }

--- a/src-tauri/src/backends/mod.rs
+++ b/src-tauri/src/backends/mod.rs
@@ -554,9 +554,10 @@ mod tests {
     }
 
     fn make_test_app_config() -> Arc<AppConfig> {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
         Arc::new(AppConfig::new(
             crate::config::ReleashConfig::default(),
-            std::path::PathBuf::from("/tmp/test-releash.toml"),
+            tmp.path().to_path_buf(),
         ))
     }
 

--- a/src-tauri/src/backends/model_catalog_sync.rs
+++ b/src-tauri/src/backends/model_catalog_sync.rs
@@ -1,0 +1,250 @@
+use std::sync::Arc;
+
+use tauri::{Emitter, Manager};
+use tokio::sync::Mutex;
+
+use crate::backends::bridge_common::AgentProcessMap;
+use crate::backends::ModelInfo;
+
+/// `supported_models` メッセージを受信した際の共通処理。
+///
+/// 1. 生 ID を抽出（all-or-nothing 検証）
+/// 2. registry 経由で config.toml に書き込み（検証失敗時は config を変更しない）
+/// 3. 最新の available_models（config 由来）を返す
+///
+/// emit や proc キャッシュ同期はこの関数の責務ではない。呼び出し側で行う。
+/// `None` を返した場合は呼び出し側で proc キャッシュ・emit 共に上書きせず、
+/// 「現在の状態を維持」として扱う（空配列で上書きしない）。
+pub(crate) fn apply_supported_models_to_config(
+    registry: Option<&crate::backends::AgentBackendRegistry>,
+    backend_id: &str,
+    msg: &serde_json::Value,
+) -> Option<Vec<ModelInfo>> {
+    let registry = registry?;
+    match extract_model_ids_from_supported_models(msg) {
+        Ok(raw_ids) if raw_ids.is_empty() => {
+            log::warn!("{}", supported_models_empty_payload_log(backend_id));
+            fallback_models_from_config(registry, backend_id)
+        }
+        Ok(raw_ids) => match registry.write_models_to_config(backend_id, raw_ids) {
+            Ok(stored) => Some(
+                stored
+                    .into_iter()
+                    .map(|value| ModelInfo { value })
+                    .collect(),
+            ),
+            Err(e) => {
+                log::warn!("{}", supported_models_write_failed_log(backend_id, &e));
+                fallback_models_from_config(registry, backend_id)
+            }
+        },
+        Err(e) => {
+            log::warn!("{}", supported_models_invalid_payload_log(backend_id, &e));
+            fallback_models_from_config(registry, backend_id)
+        }
+    }
+}
+
+pub(crate) fn supported_models_empty_payload_log(backend_id: &str) -> String {
+    format!(
+        "supported_models 受信内容のモデル配列が空のため '{backend_id}' のモデル一覧は更新しません"
+    )
+}
+
+pub(crate) fn supported_models_write_failed_log(backend_id: &str, error: &str) -> String {
+    format!("supported_models から '{backend_id}' のモデル一覧を反映できませんでした: {error}")
+}
+
+pub(crate) fn supported_models_invalid_payload_log(backend_id: &str, error: &str) -> String {
+    format!(
+        "supported_models 受信内容が不正のため '{backend_id}' のモデル一覧は更新しません: {error}"
+    )
+}
+
+pub(crate) fn supported_models_fallback_read_failed_log(backend_id: &str, error: &str) -> String {
+    format!(
+        "supported_models フォールバック読み出し失敗 (backend='{backend_id}'): {error} - proc キャッシュと emit は維持"
+    )
+}
+
+pub(crate) fn startup_model_refresh_failed_log(backend_id: &str, error: &str) -> String {
+    format!("backend '{backend_id}' model refresh failed: {error}")
+}
+
+fn fallback_models_from_config(
+    registry: &crate::backends::AgentBackendRegistry,
+    backend_id: &str,
+) -> Option<Vec<ModelInfo>> {
+    match registry.available_models(backend_id) {
+        Ok(models) => Some(models),
+        Err(e) => {
+            log::warn!(
+                "{}",
+                supported_models_fallback_read_failed_log(backend_id, &e)
+            );
+            None
+        }
+    }
+}
+
+/// `supported_models` メッセージ受信時の完全処理。
+pub(crate) async fn handle_supported_models_message(
+    app: Option<&tauri::AppHandle>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    registry: Option<&crate::backends::AgentBackendRegistry>,
+    chat_session_id: &str,
+    msg: &serde_json::Value,
+) {
+    let (selected_model, backend_id) = {
+        let map = handles.lock().await;
+        match map.get(chat_session_id) {
+            Some(proc) => (proc.selected_model.clone(), proc.backend_id.clone()),
+            None => {
+                log::warn!(
+                    "supported_models 受信時に session '{chat_session_id}' の active process が見つからないため何もしません"
+                );
+                return;
+            }
+        }
+    };
+
+    let Some(models) = apply_supported_models_to_config(registry, &backend_id, msg) else {
+        return;
+    };
+
+    {
+        let mut map = handles.lock().await;
+        if let Some(proc) = map.get_mut(chat_session_id) {
+            proc.available_models = models.clone();
+        }
+    }
+
+    if let Some(app) = app {
+        let _ = app.emit(
+            "agent-models-updated",
+            build_agent_models_updated_payload(chat_session_id, &models, selected_model.as_deref()),
+        );
+        let _ = app.emit(
+            "agent-backend-models-updated",
+            build_agent_backend_models_updated_payload(&backend_id, &models),
+        );
+        notify_backend_models_updated(app, &backend_id, &models);
+    }
+}
+
+pub(crate) fn build_agent_models_updated_payload(
+    chat_session_id: &str,
+    available_models: &[ModelInfo],
+    selected_model: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "chat_session_id": chat_session_id,
+        "available_models": available_models,
+        "selected_model": selected_model,
+    })
+}
+
+pub(crate) fn extract_model_ids_from_supported_models(
+    value: &serde_json::Value,
+) -> Result<Vec<String>, String> {
+    let arr = value
+        .get("models")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "supported_models に 'models' 配列が含まれていません".to_string())?;
+
+    let mut result = Vec::with_capacity(arr.len());
+    for (idx, m) in arr.iter().enumerate() {
+        let id = m
+            .get("value")
+            .and_then(|v| v.as_str())
+            .or_else(|| m.get("id").and_then(|v| v.as_str()))
+            .ok_or_else(|| {
+                format!("supported_models models[{idx}] に有効な value/id がありません")
+            })?;
+        result.push(id.to_string());
+    }
+    Ok(result)
+}
+
+pub async fn refresh_models_for_backend_and_propagate(
+    app: tauri::AppHandle,
+    handles: Arc<Mutex<AgentProcessMap>>,
+    registry: Arc<crate::backends::AgentBackendRegistry>,
+    backend_id: String,
+) {
+    match registry.refresh_models_to_config_for(&backend_id).await {
+        Ok(Some(models)) => {
+            log::info!(
+                "backend '{backend_id}' models refreshed ({} entries)",
+                models.len()
+            );
+            propagate_refreshed_models_to_active_sessions(&app, &handles, &backend_id, &models)
+                .await;
+        }
+        Ok(None) => {
+            log::info!("backend '{backend_id}' does not support startup CLI model fetch; skipped");
+        }
+        Err(e) => {
+            log::warn!("{}", startup_model_refresh_failed_log(&backend_id, &e));
+        }
+    }
+}
+
+pub async fn propagate_refreshed_models_to_active_sessions(
+    app: &tauri::AppHandle,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    backend_id: &str,
+    models: &[String],
+) {
+    let model_infos: Vec<ModelInfo> = models
+        .iter()
+        .map(|v| ModelInfo { value: v.clone() })
+        .collect();
+
+    sync_active_processes_for_backend(handles, backend_id, &model_infos).await;
+
+    let _ = app.emit(
+        "agent-backend-models-updated",
+        build_agent_backend_models_updated_payload(backend_id, &model_infos),
+    );
+    notify_backend_models_updated(app, backend_id, &model_infos);
+}
+
+fn notify_backend_models_updated(
+    app: &tauri::AppHandle,
+    backend_id: &str,
+    available_models: &[ModelInfo],
+) {
+    if let Some(notifier) =
+        app.try_state::<crate::usecase::backend_models::BackendModelsUpdateNotifierState>()
+    {
+        let values: Vec<String> = available_models
+            .iter()
+            .map(|model| model.value.clone())
+            .collect();
+        notifier.broadcast_backend_models_updated(backend_id, &values);
+    }
+}
+
+pub(crate) fn build_agent_backend_models_updated_payload(
+    backend_id: &str,
+    available_models: &[ModelInfo],
+) -> serde_json::Value {
+    serde_json::json!({
+        "backend_id": backend_id,
+        "available_models": available_models,
+    })
+}
+
+pub(crate) async fn sync_active_processes_for_backend(
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    backend_id: &str,
+    model_infos: &[ModelInfo],
+) {
+    let mut map = handles.lock().await;
+    for proc in map.values_mut() {
+        if proc.backend_id == backend_id {
+            proc.available_models = model_infos.to_vec();
+        }
+    }
+}

--- a/src-tauri/src/backends/model_catalog_sync.rs
+++ b/src-tauri/src/backends/model_catalog_sync.rs
@@ -95,10 +95,10 @@ pub(crate) async fn handle_supported_models_message(
     chat_session_id: &str,
     msg: &serde_json::Value,
 ) {
-    let (selected_model, backend_id) = {
+    let backend_id = {
         let map = handles.lock().await;
         match map.get(chat_session_id) {
-            Some(proc) => (proc.selected_model.clone(), proc.backend_id.clone()),
+            Some(proc) => proc.backend_id.clone(),
             None => {
                 log::warn!(
                     "supported_models 受信時に session '{chat_session_id}' の active process が見つからないため何もしません"
@@ -112,12 +112,29 @@ pub(crate) async fn handle_supported_models_message(
         return;
     };
 
-    {
+    // ロック解放中に session が再作成 / backend 切替された可能性があるため、
+    // 2 回目のロックでは backend_id の一致を再検証してから更新・emit する。
+    let selected_model = {
         let mut map = handles.lock().await;
-        if let Some(proc) = map.get_mut(chat_session_id) {
-            proc.available_models = models.clone();
+        match map.get_mut(chat_session_id) {
+            Some(proc) if proc.backend_id == backend_id => {
+                proc.available_models = models.clone();
+                proc.selected_model.clone()
+            }
+            Some(_) => {
+                log::warn!(
+                    "supported_models 受信処理中に session '{chat_session_id}' の backend が切り替わったため更新をスキップします"
+                );
+                return;
+            }
+            None => {
+                log::warn!(
+                    "supported_models 受信処理中に session '{chat_session_id}' の active process が失われたため更新をスキップします"
+                );
+                return;
+            }
         }
-    }
+    };
 
     if let Some(app) = app {
         let _ = app.emit(

--- a/src-tauri/src/backends/process_io.rs
+++ b/src-tauri/src/backends/process_io.rs
@@ -1,0 +1,199 @@
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+pub(crate) struct CommandOutput {
+    pub(crate) status: ExitStatus,
+    pub(crate) stdout: Vec<u8>,
+    pub(crate) stderr: Vec<u8>,
+}
+
+/// 上限バイト数まで非同期で読み出す。上限到達後の残りは破棄する（プロセスは継続）。
+pub(crate) async fn read_with_limit<R>(
+    reader: &mut R,
+    max_bytes: usize,
+    context: &str,
+) -> Result<Vec<u8>, String>
+where
+    R: AsyncReadExt + Unpin,
+{
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        if buf.len() >= max_bytes {
+            let mut sink = [0u8; 8192];
+            while reader
+                .read(&mut sink)
+                .await
+                .map_err(|e| format!("{context} 出力読み出し失敗: {e}"))?
+                > 0
+            {}
+            break;
+        }
+        let n = reader
+            .read(&mut chunk)
+            .await
+            .map_err(|e| format!("{context} 出力読み出し失敗: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        let take = n.min(max_bytes - buf.len());
+        buf.extend_from_slice(&chunk[..take]);
+    }
+    Ok(buf)
+}
+
+struct ProcessTreeGuard {
+    #[cfg(unix)]
+    pgid: Option<u32>,
+    armed: bool,
+}
+
+impl ProcessTreeGuard {
+    fn new() -> Self {
+        Self {
+            #[cfg(unix)]
+            pgid: None,
+            armed: true,
+        }
+    }
+
+    #[cfg(unix)]
+    fn set_child_id(&mut self, child_id: Option<u32>) {
+        self.pgid = child_id;
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    fn kill_now(&mut self) {
+        if !self.armed {
+            return;
+        }
+        kill_process_tree(
+            #[cfg(unix)]
+            self.pgid,
+        );
+    }
+}
+
+impl Drop for ProcessTreeGuard {
+    fn drop(&mut self) {
+        self.kill_now();
+    }
+}
+
+#[cfg(unix)]
+fn configure_process_tree(cmd: &mut Command) {
+    cmd.as_std_mut().process_group(0);
+}
+
+#[cfg(not(unix))]
+fn configure_process_tree(_cmd: &mut Command) {}
+
+#[cfg(unix)]
+fn kill_process_tree(pgid: Option<u32>) {
+    let Some(pgid) = pgid else {
+        return;
+    };
+    unsafe {
+        libc::killpg(pgid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_process_tree() {}
+
+pub(crate) async fn run_command_with_output_limit(
+    mut cmd: Command,
+    timeout: Duration,
+    max_bytes: usize,
+    output_context: &str,
+    spawn_context: &str,
+    wait_context: &str,
+    timeout_message: String,
+) -> Result<CommandOutput, String> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    configure_process_tree(&mut cmd);
+
+    let mut child = cmd.spawn().map_err(|e| format!("{spawn_context}: {e}"))?;
+    let mut process_tree_guard = ProcessTreeGuard::new();
+    #[cfg(unix)]
+    process_tree_guard.set_child_id(child.id());
+
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+
+    let stdout_task = async {
+        match stdout_handle {
+            Some(mut h) => read_with_limit(&mut h, max_bytes, output_context).await,
+            None => Ok(Vec::new()),
+        }
+    };
+    let stderr_task = async {
+        match stderr_handle {
+            Some(mut h) => read_with_limit(&mut h, max_bytes, output_context).await,
+            None => Ok(Vec::new()),
+        }
+    };
+    let wait_fut = async {
+        let (stdout_res, stderr_res) = tokio::join!(stdout_task, stderr_task);
+        let stdout = stdout_res?;
+        let stderr = stderr_res?;
+        let status = child
+            .wait()
+            .await
+            .map_err(|e| format!("{wait_context}: {e}"))?;
+        process_tree_guard.disarm();
+        Ok::<_, String>(CommandOutput {
+            status,
+            stdout,
+            stderr,
+        })
+    };
+
+    match tokio::time::timeout(timeout, wait_fut).await {
+        Ok(result) => result,
+        Err(_) => {
+            process_tree_guard.kill_now();
+            let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
+            Err(timeout_message)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn run_command_with_output_limit_returns_timeout_message() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("sleep 1");
+
+        let result = run_command_with_output_limit(
+            cmd,
+            Duration::from_millis(10),
+            1024,
+            "test command",
+            "spawn failed",
+            "wait failed",
+            "test timeout".to_string(),
+        )
+        .await;
+
+        match result {
+            Ok(_) => panic!("expected timeout error"),
+            Err(err) => assert_eq!(err, "test timeout"),
+        }
+    }
+}

--- a/src-tauri/src/backends/process_io.rs
+++ b/src-tauri/src/backends/process_io.rs
@@ -76,6 +76,9 @@ impl ProcessTreeGuard {
         if !self.armed {
             return;
         }
+        // PGID 再利用時に二度 kill しないよう、kill 前に disarm する。
+        // これにより以降の kill_now（Drop 経由含む）は no-op となる。
+        self.armed = false;
         kill_process_tree(
             #[cfg(unix)]
             self.pgid,

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -3,12 +3,16 @@ use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::notion::types::NotionRepoConfig;
 
 const TOKEN_LENGTH: usize = 48;
+static CONFIG_WRITE_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn default_true() -> bool {
     true
@@ -38,6 +42,8 @@ pub struct ReleashConfig {
 pub struct AgentsSection {
     pub default: Option<String>,
     #[serde(default)]
+    pub claude: ClaudeAgentSection,
+    #[serde(default)]
     pub codex: CodexAgentSection,
 }
 
@@ -48,9 +54,18 @@ pub struct WorkflowSection {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClaudeAgentSection {
+    pub model: Option<String>,
+    #[serde(default)]
+    pub models: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CodexAgentSection {
     pub model: Option<String>,
     pub cli_path: Option<String>,
+    #[serde(default)]
+    pub models: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -264,6 +279,63 @@ impl AppConfig {
         write_config(&self.config_path, &config)?;
         Ok(result)
     }
+
+    /// 指定バックエンドの `agents.<backend>.models` を返す。
+    /// スキーマ未対応のバックエンドは `Err`。
+    pub fn models_for_backend(&self, backend_id: &str) -> Result<Vec<String>, String> {
+        let config = self
+            .config
+            .lock()
+            .map_err(|e| format!("ロック取得失敗: {e}"))?;
+        match backend_id {
+            "claude" => Ok(config.agents.claude.models.clone()),
+            "codex" => Ok(config.agents.codex.models.clone()),
+            _ => Err(format!(
+                "config schema にバックエンド '{backend_id}' のモデル一覧が存在しません"
+            )),
+        }
+    }
+
+    /// 指定バックエンドの `agents.<backend>.model`（生の設定値）を返す。
+    /// 登録判定は行わない。lib.rs から起動時整合性チェックの「設定値が
+    /// 登録一覧に含まれているか」を判定するために、schema 構造を漏らさず
+    /// 生値だけを問い合わせる経路として使う。
+    /// スキーマ未対応のバックエンドは `None`。
+    pub fn configured_initial_model_for_backend(&self, backend_id: &str) -> Option<String> {
+        let config = self.config.lock().ok()?;
+        match backend_id {
+            "claude" => config.agents.claude.model.clone(),
+            "codex" => config.agents.codex.model.clone(),
+            _ => None,
+        }
+    }
+
+    /// 指定バックエンドの `agents.<backend>.models` を transactional に書き換える。
+    /// in-memory のクローンを更新 → ディスクへ書き込み成功 → in-memory に反映、の順で
+    /// 失敗時はメモリ状態を一切変更しない。スキーマ未対応のバックエンドは `Err`。
+    pub fn set_models_for_backend(
+        &self,
+        backend_id: &str,
+        models: Vec<String>,
+    ) -> Result<(), String> {
+        let mut guard = self
+            .config
+            .lock()
+            .map_err(|e| format!("ロック取得失敗: {e}"))?;
+        let mut next = guard.clone();
+        match backend_id {
+            "claude" => next.agents.claude.models = models,
+            "codex" => next.agents.codex.models = models,
+            _ => {
+                return Err(format!(
+                    "config schema にバックエンド '{backend_id}' のモデル一覧が存在しません"
+                ));
+            }
+        }
+        write_config(&self.config_path, &next)?;
+        *guard = next;
+        Ok(())
+    }
 }
 
 pub fn generate_token() -> String {
@@ -308,9 +380,15 @@ pub fn write_config(path: &Path, config: &ReleashConfig) -> Result<(), String> {
     let content =
         toml::to_string_pretty(config).map_err(|e| format!("設定のシリアライズ失敗: {e}"))?;
 
-    let tmp_path = path.with_extension("toml.tmp");
-    fs::write(&tmp_path, &content).map_err(|e| format!("一時ファイル書き込み失敗: {e}"))?;
-    fs::rename(&tmp_path, path).map_err(|e| format!("ファイルのリネーム失敗: {e}"))?;
+    let tmp_path = next_config_tmp_path(path);
+    if let Err(e) = write_config_tmp_file(&tmp_path, &content) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    if let Err(e) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(format!("ファイルのリネーム失敗: {e}"));
+    }
 
     #[cfg(unix)]
     {
@@ -319,6 +397,35 @@ pub fn write_config(path: &Path, config: &ReleashConfig) -> Result<(), String> {
             .map_err(|e| format!("パーミッション設定失敗: {e}"))?;
     }
 
+    Ok(())
+}
+
+fn next_config_tmp_path(path: &Path) -> PathBuf {
+    let counter = CONFIG_WRITE_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("releash.toml");
+    let tmp_name = format!("{file_name}.{}.{}.tmp", std::process::id(), counter);
+    path.parent()
+        .map(|parent| parent.join(&tmp_name))
+        .unwrap_or_else(|| PathBuf::from(tmp_name))
+}
+
+fn write_config_tmp_file(tmp_path: &Path, content: &str) -> Result<(), String> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options
+        .open(tmp_path)
+        .map_err(|e| format!("一時ファイル作成失敗: {e}"))?;
+    file.write_all(content.as_bytes())
+        .map_err(|e| format!("一時ファイル書き込み失敗: {e}"))?;
     Ok(())
 }
 
@@ -1045,6 +1152,26 @@ token = ""
 
         assert!(path.exists());
         assert!(!path.with_extension("toml.tmp").exists());
+        let tmp_files = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().ends_with(".tmp"))
+            .count();
+        assert_eq!(tmp_files, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_tmp_file_is_created_with_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let tmp_path = dir.path().join("releash.toml.tmp");
+
+        write_config_tmp_file(&tmp_path, "secret").unwrap();
+
+        let mode = fs::metadata(&tmp_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
     }
 
     fn releash_hook_entry(matcher: &str, port: u16) -> serde_json::Value {
@@ -1640,5 +1767,181 @@ token = "existing_token_value_here_with_enough_length_!!"
         let config = load_or_create_config(&path).unwrap();
         assert!(config.agents.default.is_none());
         assert!(config.agents.codex.model.is_none());
+    }
+
+    #[test]
+    fn models_for_backend_returns_persisted_values() {
+        let dir = TempDir::new().unwrap();
+        let path = config_path(&dir);
+        let mut config = ReleashConfig::default();
+        config.agents.claude.models = vec!["a".to_string(), "b".to_string()];
+        config.agents.codex.models = vec!["c".to_string()];
+        let app_config = AppConfig::new(config, path);
+
+        assert_eq!(
+            app_config.models_for_backend("claude").unwrap(),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        assert_eq!(
+            app_config.models_for_backend("codex").unwrap(),
+            vec!["c".to_string()]
+        );
+    }
+
+    #[test]
+    fn models_for_backend_errors_for_unknown_backend() {
+        let dir = TempDir::new().unwrap();
+        let path = config_path(&dir);
+        let app_config = AppConfig::new(ReleashConfig::default(), path);
+        assert!(app_config.models_for_backend("unknown").is_err());
+    }
+
+    #[test]
+    fn set_models_for_backend_persists_and_keeps_other_intact() {
+        let dir = TempDir::new().unwrap();
+        let path = config_path(&dir);
+        let mut config = ReleashConfig::default();
+        config.server.token = generate_token();
+        config.agents.claude.models = vec!["old".to_string()];
+        config.agents.codex.models = vec!["x".to_string()];
+        let app_config = AppConfig::new(config, path.clone());
+
+        app_config
+            .set_models_for_backend("claude", vec!["new1".to_string(), "new2".to_string()])
+            .unwrap();
+
+        // メモリ上の状態が更新されている
+        let cfg = app_config.get_config().unwrap();
+        assert_eq!(
+            cfg.agents.claude.models,
+            vec!["new1".to_string(), "new2".to_string()]
+        );
+        assert_eq!(cfg.agents.codex.models, vec!["x".to_string()]);
+
+        // ディスクにも反映されている
+        let reloaded: ReleashConfig = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            reloaded.agents.claude.models,
+            vec!["new1".to_string(), "new2".to_string()]
+        );
+        assert_eq!(reloaded.agents.codex.models, vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn set_models_for_backend_errors_for_unknown_backend_without_changing_state() {
+        let dir = TempDir::new().unwrap();
+        let path = config_path(&dir);
+        let mut config = ReleashConfig::default();
+        config.agents.claude.models = vec!["existing".to_string()];
+        let app_config = AppConfig::new(config, path);
+
+        let err = app_config.set_models_for_backend("nope", vec!["a".to_string()]);
+        assert!(err.is_err());
+        // メモリ状態は変更されない
+        let cfg = app_config.get_config().unwrap();
+        assert_eq!(cfg.agents.claude.models, vec!["existing".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn set_models_for_backend_concurrent_updates_keep_last_writer_value_intact() {
+        use std::sync::Arc;
+        use tokio::sync::Barrier;
+
+        // 同一バックエンドへのほぼ同時更新が走った場合、最後にコミットされた
+        // 有効値が config に残り、他バックエンドの models は影響を受けない。
+        let dir = TempDir::new().unwrap();
+        let path = config_path(&dir);
+        let mut config = ReleashConfig::default();
+        config.server.token = generate_token();
+        config.agents.claude.models = vec!["initial".to_string()];
+        config.agents.codex.models = vec!["codex-keep-a".to_string(), "codex-keep-b".to_string()];
+        let app_config = Arc::new(AppConfig::new(config, path));
+
+        let writers = 8usize;
+        let barrier = Arc::new(Barrier::new(writers));
+        let mut handles = Vec::with_capacity(writers);
+
+        for i in 0..writers {
+            let cfg = app_config.clone();
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                cfg.set_models_for_backend("claude", vec![format!("writer-{i}")])
+            }));
+        }
+        for h in handles {
+            h.await.unwrap().unwrap();
+        }
+
+        // 最後に勝った writer の値が反映されており、書き込みのいずれかが in-memory に
+        // 残っている（"initial" や混在値ではない）。
+        let final_models = app_config.get_config().unwrap().agents.claude.models;
+        assert_eq!(final_models.len(), 1);
+        let v = &final_models[0];
+        assert!(
+            v.starts_with("writer-"),
+            "expected one of writer-* but got {v}"
+        );
+
+        // 他バックエンドの models は変更されない。
+        let codex_models = app_config.get_config().unwrap().agents.codex.models;
+        assert_eq!(
+            codex_models,
+            vec!["codex-keep-a".to_string(), "codex-keep-b".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn set_models_for_backend_sequential_writers_keep_last_committed_value() {
+        use std::sync::Arc;
+        use tokio::sync::Mutex as TokioMutex;
+
+        // 同一バックエンドへの更新を順序付きで複数回行ったとき、最後にコミットされた
+        // writer の値が in-memory / on-disk のいずれにも反映されることを担保する。
+        let dir = TempDir::new().unwrap();
+        let path = config_path(&dir);
+        let mut config = ReleashConfig::default();
+        config.server.token = generate_token();
+        config.agents.claude.models = vec!["initial".to_string()];
+        let app_config = Arc::new(AppConfig::new(config, path.clone()));
+
+        // 共有 Mutex で writer 間の順序を直列化し、書き込み順を確定させる。
+        let order = Arc::new(TokioMutex::new(()));
+        let writers = ["first", "second", "third", "final"];
+        for name in &writers {
+            let cfg = app_config.clone();
+            let order = order.clone();
+            let value = (*name).to_string();
+            let guard = order.lock().await;
+            cfg.set_models_for_backend("claude", vec![value]).unwrap();
+            drop(guard);
+        }
+
+        // 最後の writer の値が in-memory に残る。
+        let in_memory = app_config.get_config().unwrap().agents.claude.models;
+        assert_eq!(in_memory, vec!["final".to_string()]);
+
+        // on-disk にも反映されている。
+        let reloaded: ReleashConfig = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(reloaded.agents.claude.models, vec!["final".to_string()]);
+    }
+
+    #[test]
+    fn set_models_for_backend_keeps_state_if_write_fails() {
+        // 書き込み失敗時に in-memory が変更されないことを確認するため、
+        // tempdir 内で親パスをファイル化し、環境に依存せず ENOTDIR を発生させる。
+        let dir = TempDir::new().unwrap();
+        let file_parent = dir.path().join("not-a-directory");
+        fs::write(&file_parent, "not a directory").unwrap();
+        let mut config = ReleashConfig::default();
+        config.agents.claude.models = vec!["original".to_string()];
+        let bad_path = file_parent.join("releash.toml");
+        let app_config = AppConfig::new(config, bad_path);
+
+        let err = app_config.set_models_for_backend("claude", vec!["new".to_string()]);
+        assert!(err.is_err());
+        // 書き込み失敗時は in-memory も変更されない
+        let cfg = app_config.get_config().unwrap();
+        assert_eq!(cfg.agents.claude.models, vec!["original".to_string()]);
     }
 }

--- a/src-tauri/src/domain/agent_session/mod.rs
+++ b/src-tauri/src/domain/agent_session/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod value_objects;
+
+pub(crate) use value_objects::{escaped_for_log, ModelId, ModelIdList};

--- a/src-tauri/src/domain/agent_session/value_objects/mod.rs
+++ b/src-tauri/src/domain/agent_session/value_objects/mod.rs
@@ -1,0 +1,3 @@
+mod model_id;
+
+pub(crate) use model_id::{escaped_for_log, ModelId, ModelIdList};

--- a/src-tauri/src/domain/agent_session/value_objects/model_id.rs
+++ b/src-tauri/src/domain/agent_session/value_objects/model_id.rs
@@ -1,0 +1,165 @@
+/// モデルID 1 件の最大コードポイント数。
+pub(crate) const MAX_MODEL_ID_LEN: usize = 128;
+
+/// 1 バックエンドあたりに保持するユニークなモデルIDの最大件数。
+pub(crate) const MAX_MODELS_PER_BACKEND: usize = 256;
+
+/// 検証済みモデルID。
+///
+/// 入力値は変更せず、trim 等の正規化も行わない。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ModelId(String);
+
+impl ModelId {
+    /// モデルID の形式検証。
+    /// - 空文字列は拒否
+    /// - Unicode White_Space のみで構成される文字列は拒否
+    /// - 制御文字（U+0000-U+001F, U+007F）を含む文字列は拒否
+    /// - コードポイント数が `MAX_MODEL_ID_LEN` を超える場合は拒否
+    /// - 入力値は変更しない（trim 等の正規化は行わない）
+    pub(crate) fn parse(model_id: impl Into<String>) -> Result<Self, String> {
+        let model_id = model_id.into();
+        if model_id.is_empty() {
+            return Err("モデルIDが空です".to_string());
+        }
+        if model_id.chars().all(|c| c.is_whitespace()) {
+            return Err("モデルIDが空白のみで構成されています".to_string());
+        }
+        if model_id.chars().any(|c| c.is_control() || c == '\u{007F}') {
+            return Err("モデルIDに制御文字が含まれています".to_string());
+        }
+        if model_id.chars().count() > MAX_MODEL_ID_LEN {
+            return Err(format!(
+                "モデルIDが上限長 {MAX_MODEL_ID_LEN} を超えています"
+            ));
+        }
+        Ok(Self(model_id))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn into_string(self) -> String {
+        self.0
+    }
+}
+
+/// 検証済みかつ重複除去済みのバックエンド別モデルID一覧。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelIdList(Vec<ModelId>);
+
+impl ModelIdList {
+    /// モデルID 配列の検証。
+    /// - 各要素が `ModelId::parse` を満たす場合のみ受け入れる
+    /// - 重複は除去（最初に現れた順を保持）
+    /// - 重複除去後のユニーク件数が `MAX_MODELS_PER_BACKEND` を超える場合は拒否
+    /// - 検証に失敗した場合は Err を返し、呼び出し元は config を更新してはならない
+    pub(crate) fn parse_many(ids: &[String]) -> Result<Self, String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut result = Vec::new();
+        for id in ids {
+            let parsed = ModelId::parse(id.clone())?;
+            if seen.insert(parsed.as_str().to_string()) {
+                result.push(parsed);
+            }
+        }
+        if result.len() > MAX_MODELS_PER_BACKEND {
+            return Err(format!(
+                "モデルID件数が上限 {MAX_MODELS_PER_BACKEND} を超えています: {}",
+                result.len()
+            ));
+        }
+        Ok(Self(result))
+    }
+
+    pub(crate) fn into_strings(self) -> Vec<String> {
+        self.0.into_iter().map(ModelId::into_string).collect()
+    }
+}
+
+pub(crate) fn escaped_for_log(value: &str) -> String {
+    format!("{value:?}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_id_rejects_empty() {
+        assert!(ModelId::parse("").is_err());
+    }
+
+    #[test]
+    fn model_id_rejects_whitespace_only() {
+        assert!(ModelId::parse("   ").is_err());
+        assert!(ModelId::parse("\t\n").is_err());
+    }
+
+    #[test]
+    fn model_id_preserves_surrounding_whitespace() {
+        let input = "  model  ";
+        assert_eq!(ModelId::parse(input).unwrap().into_string(), input);
+    }
+
+    #[test]
+    fn model_id_rejects_unicode_whitespace_only() {
+        assert!(ModelId::parse("\u{3000}").is_err());
+        assert!(ModelId::parse("\u{00A0}\u{3000}").is_err());
+    }
+
+    #[test]
+    fn model_id_rejects_control_characters() {
+        assert!(ModelId::parse("model\u{0001}id").is_err());
+        assert!(ModelId::parse("model\u{007F}id").is_err());
+    }
+
+    #[test]
+    fn model_id_rejects_too_long() {
+        let id: String = "x".repeat(MAX_MODEL_ID_LEN + 1);
+        assert!(ModelId::parse(id).is_err());
+    }
+
+    #[test]
+    fn model_id_accepts_exact_max_length() {
+        let id: String = "x".repeat(MAX_MODEL_ID_LEN);
+        assert!(ModelId::parse(id).is_ok());
+    }
+
+    #[test]
+    fn model_id_list_removes_duplicates_preserving_order() {
+        let input = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "a".to_string(),
+            "c".to_string(),
+            "b".to_string(),
+        ];
+        let out = ModelIdList::parse_many(&input).unwrap().into_strings();
+        assert_eq!(out, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    }
+
+    #[test]
+    fn model_id_list_accepts_duplicate_heavy_input_that_collapses() {
+        let many: Vec<String> = (0..MAX_MODELS_PER_BACKEND)
+            .map(|i| format!("m{i}"))
+            .chain(std::iter::repeat_n("m0".to_string(), 10))
+            .collect();
+        let out = ModelIdList::parse_many(&many).unwrap().into_strings();
+        assert_eq!(out.len(), MAX_MODELS_PER_BACKEND);
+    }
+
+    #[test]
+    fn model_id_list_rejects_too_many_unique() {
+        let many: Vec<String> = (0..(MAX_MODELS_PER_BACKEND + 1))
+            .map(|i| format!("m{i}"))
+            .collect();
+        assert!(ModelIdList::parse_many(&many).is_err());
+    }
+
+    #[test]
+    fn escaped_for_log_escapes_control_characters() {
+        assert_eq!(escaped_for_log("bad\nmodel"), "\"bad\\nmodel\"");
+    }
+}

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod agent_session;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod backends;
 mod config;
 mod diff_comment_sender;
 mod diff_comment_store;
+mod domain;
 mod external_editor;
 mod file_mention;
 mod focus_tracker;
@@ -25,6 +26,7 @@ mod session_commands;
 mod shell_integration;
 mod tls;
 mod tray;
+mod usecase;
 mod vpn_detect;
 mod watcher;
 mod webhook;
@@ -45,6 +47,85 @@ use tauri::Manager;
 use tauri_plugin_aptabase::EventTracker;
 use tokio::sync::Mutex;
 
+/// 起動時の初期モデル整合性チェック。
+/// `agents.<backend>.model` が `agents.<backend>.models` に含まれない場合は
+/// 警告ログのみ出し、書き換えは行わない（暗黙のフォールバックを避ける）。
+fn warn_on_unregistered_initial_models(
+    registry: &backends::AgentBackendRegistry,
+    backend_ids: &[&str],
+) {
+    for backend_id in backend_ids {
+        if let Some(message) = initial_model_resolution_warning(
+            backend_id,
+            &registry.initial_model_resolution_for(backend_id),
+        ) {
+            log::warn!("{message}");
+        }
+    }
+}
+
+fn initial_model_resolution_warning(
+    backend_id: &str,
+    resolution: &backends::InitialModelResolution,
+) -> Option<String> {
+    match resolution {
+        backends::InitialModelResolution::Invalid { model, reason } => Some(format!(
+            "backend '{backend_id}' initial model {} is invalid ({reason}); treating as unset until refreshed",
+            domain::agent_session::escaped_for_log(model)
+        )),
+        backends::InitialModelResolution::Unregistered { model } => Some(format!(
+            "backend '{backend_id}' initial model {} is not in agents.{backend_id}.models; treating as unset until refreshed",
+            domain::agent_session::escaped_for_log(model)
+        )),
+        backends::InitialModelResolution::Registered(_) | backends::InitialModelResolution::Unset => {
+            None
+        }
+    }
+}
+
+/// 起動時のバックエンド単位のモデル一覧同期 spawn。
+/// バックエンドごとに独立した `tokio::spawn` を発行し、片方の失敗・遅延は
+/// もう片方の spawn に影響しない。アプリ起動は spawn 後即時続行する。
+fn spawn_startup_model_refresh_for_backends(
+    app: tauri::AppHandle,
+    handles: Arc<Mutex<agent_sdk::AgentProcessMap>>,
+    registry: Arc<backends::AgentBackendRegistry>,
+    backend_ids: &[&str],
+) {
+    spawn_startup_model_refresh_with(backend_ids, |backend_id| {
+        let registry_clone = registry.clone();
+        let handles_clone = handles.clone();
+        let app_clone = app.clone();
+        async move {
+            backends::model_catalog_sync::refresh_models_for_backend_and_propagate(
+                app_clone,
+                handles_clone,
+                registry_clone,
+                backend_id,
+            )
+            .await;
+        }
+    });
+}
+
+/// 内部ヘルパー: backend_id ごとに独立 task を spawn する純粋ループ。
+/// 各 backend の `task_factory` 呼び出し結果は独立した `tokio::spawn` に渡され、
+/// 片方のタスクが完了・遅延・panic しても他方は影響を受けない。
+///
+/// テストでは `task_factory` に副作用カウンタを返すクロージャを渡して、
+/// 「複数 backend が独立に spawn されること」「ある backend のクロージャが
+/// panic しても他の backend は影響を受けないこと」を検証する。
+fn spawn_startup_model_refresh_with<F, Fut>(backend_ids: &[&str], mut task_factory: F)
+where
+    F: FnMut(String) -> Fut,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    for backend_id in backend_ids {
+        let fut = task_factory(backend_id.to_string());
+        tokio::spawn(fut);
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let _sentry_guard = sentry_integration::init_sentry();
@@ -58,6 +139,10 @@ pub fn run() {
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     let _ = fix_path_env::fix();
+
+    let ws_broadcaster = Arc::new(ws_bridge::WsBroadcaster::default());
+    let backend_models_notifier =
+        ws_server::gateway::WsBackendModelsUpdateNotifier::new(Arc::clone(&ws_broadcaster));
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -76,7 +161,10 @@ pub fn run() {
         .manage(Arc::new(session::SessionStore::default()))
         .manage(Arc::new(pty::PtyManager::default()))
         .manage(watcher::FileWatcherManager::default())
-        .manage(Arc::new(ws_bridge::WsBroadcaster::default()))
+        .manage(Arc::clone(&ws_broadcaster))
+        .manage::<usecase::backend_models::BackendModelsUpdateNotifierState>(Arc::new(
+            backend_models_notifier,
+        ))
         .manage(Arc::new(tokio::sync::Mutex::new(
             agent_sdk::AgentProcessMap::new(),
         )))
@@ -170,12 +258,37 @@ pub fn run() {
                 .clone();
             let session_store = app.state::<Arc<session::SessionStore>>().inner().clone();
             let registry = Arc::new(backends::build_registry_with_runtime(
-                &app_config,
+                app_config.clone(),
                 app.handle().clone(),
                 agent_handles,
                 session_store,
             ));
-            app.manage(registry);
+            app.manage(registry.clone());
+
+            // 起動時の初期モデル整合性チェック（agents.<backend>.model が登録一覧に
+            // 含まれない場合は警告のみ。書き換えは行わない）
+            warn_on_unregistered_initial_models(
+                &registry,
+                &[
+                    backends::bridge_common::CLAUDE_BACKEND_ID,
+                    backends::bridge_common::CODEX_BACKEND_ID,
+                ],
+            );
+
+            // 起動時バックグラウンドモデル一覧同期（バックエンド単位で独立、起動をブロックしない）
+            let handles_for_refresh = app
+                .state::<Arc<Mutex<agent_sdk::AgentProcessMap>>>()
+                .inner()
+                .clone();
+            spawn_startup_model_refresh_for_backends(
+                app.handle().clone(),
+                handles_for_refresh,
+                registry.clone(),
+                &[
+                    backends::bridge_common::CLAUDE_BACKEND_ID,
+                    backends::bridge_common::CODEX_BACKEND_ID,
+                ],
+            );
 
             menu::setup_menu(app)?;
             tray::setup_tray(app)?;
@@ -489,6 +602,11 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::Arc as StdArc;
+    use std::sync::Mutex as StdMutex;
+
     #[test]
     fn tokio_runtime_context_is_available_after_setup() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
@@ -500,5 +618,126 @@ mod tests {
         let handle = tokio::spawn(async { 42 });
         let result = runtime.block_on(handle).unwrap();
         assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn spawn_startup_model_refresh_schedules_independent_task_per_backend() {
+        let scheduled: StdArc<StdMutex<Vec<String>>> = StdArc::new(StdMutex::new(Vec::new()));
+        let completed = StdArc::new(AtomicUsize::new(0));
+
+        let scheduled_clone = scheduled.clone();
+        let completed_clone = completed.clone();
+        spawn_startup_model_refresh_with(&["claude", "codex"], move |backend_id| {
+            scheduled_clone.lock().unwrap().push(backend_id.clone());
+            let completed_inner = completed_clone.clone();
+            async move {
+                completed_inner.fetch_add(1, AtomicOrdering::SeqCst);
+                let _ = backend_id; // 各 task は独立して動く
+            }
+        });
+
+        // factory は backend_id ごとに呼ばれ、戻り値の future が個別 task として spawn される。
+        let scheduled_now = scheduled.lock().unwrap().clone();
+        assert_eq!(
+            scheduled_now,
+            vec!["claude".to_string(), "codex".to_string()]
+        );
+
+        // 各 task が独立して完走する（短い処理なのですぐに完了する）。
+        for _ in 0..50 {
+            if completed.load(AtomicOrdering::SeqCst) == 2 {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!(
+            "spawned tasks did not complete in time: completed={}",
+            completed.load(AtomicOrdering::SeqCst)
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_startup_model_refresh_isolates_one_failure_from_others() {
+        // 片方の backend は task 内で panic、もう片方は成功する。
+        let other_completed = StdArc::new(AtomicUsize::new(0));
+        let other_completed_clone = other_completed.clone();
+
+        spawn_startup_model_refresh_with(&["claude", "codex"], move |backend_id| {
+            let counter = other_completed_clone.clone();
+            async move {
+                if backend_id == "claude" {
+                    panic!("simulated refresh failure for claude");
+                }
+                counter.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        });
+
+        // claude 側の panic は codex 側の spawn・完了を妨げない。
+        for _ in 0..50 {
+            if other_completed.load(AtomicOrdering::SeqCst) == 1 {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("non-failing backend task did not complete despite peer failure");
+    }
+
+    #[test]
+    fn warn_on_unregistered_initial_models_does_not_mutate_config() {
+        use crate::config::ReleashConfig;
+        let mut cfg = ReleashConfig::default();
+        cfg.agents.claude.model = Some("missing-from-registry".to_string());
+        cfg.agents.claude.models = vec!["sonnet".to_string()];
+        cfg.agents.codex.model = Some("o3".to_string());
+        cfg.agents.codex.models = vec!["o3".to_string()];
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let app_config = StdArc::new(AppConfig::new(cfg, tmp.path().to_path_buf()));
+        let registry = backends::build_registry(app_config.clone());
+
+        warn_on_unregistered_initial_models(&registry, &["claude", "codex"]);
+
+        // 書き換えは行わない（暗黙のフォールバック禁止）
+        let after = app_config.get_config().unwrap();
+        assert_eq!(
+            after.agents.claude.model.as_deref(),
+            Some("missing-from-registry")
+        );
+        assert_eq!(after.agents.codex.model.as_deref(), Some("o3"));
+    }
+
+    #[test]
+    fn initial_model_warning_messages_are_traceable() {
+        assert_eq!(
+            initial_model_resolution_warning(
+                "claude",
+                &backends::InitialModelResolution::Unregistered {
+                    model: "missing-from-registry".to_string(),
+                },
+            ),
+            Some(
+                "backend 'claude' initial model \"missing-from-registry\" is not in agents.claude.models; treating as unset until refreshed"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            initial_model_resolution_warning(
+                "codex",
+                &backends::InitialModelResolution::Invalid {
+                    model: "bad model".to_string(),
+                    reason: "contains whitespace".to_string(),
+                },
+            ),
+            Some(
+                "backend 'codex' initial model \"bad model\" is invalid (contains whitespace); treating as unset until refreshed"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            initial_model_resolution_warning(
+                "codex",
+                &backends::InitialModelResolution::Registered("o3".to_string()),
+            ),
+            None
+        );
     }
 }

--- a/src-tauri/src/protocol/agent.rs
+++ b/src-tauri/src/protocol/agent.rs
@@ -34,6 +34,26 @@ pub struct BackendInfoMsg {
     pub id: String,
     pub name: String,
     pub available: bool,
+    pub available_models: Vec<ModelInfoMsg>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelInfoMsg {
+    pub value: String,
+}
+
+impl From<crate::backends::ModelInfo> for ModelInfoMsg {
+    fn from(info: crate::backends::ModelInfo) -> Self {
+        Self { value: info.value }
+    }
+}
+
+impl From<&crate::backends::ModelInfo> for ModelInfoMsg {
+    fn from(info: &crate::backends::ModelInfo) -> Self {
+        Self {
+            value: info.value.clone(),
+        }
+    }
 }
 
 impl From<crate::backends::BackendInfo> for BackendInfoMsg {
@@ -42,8 +62,19 @@ impl From<crate::backends::BackendInfo> for BackendInfoMsg {
             id: info.id,
             name: info.name,
             available: info.available,
+            available_models: info
+                .available_models
+                .into_iter()
+                .map(ModelInfoMsg::from)
+                .collect(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackendModelsUpdated {
+    pub backend_id: String,
+    pub available_models: Vec<ModelInfoMsg>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -86,6 +86,8 @@ pub enum WsMessage {
     BackendListRequest(BackendListRequest),
     #[serde(rename = "backend_list_response")]
     BackendListResponse(BackendListResponse),
+    #[serde(rename = "backend_models_updated")]
+    BackendModelsUpdated(BackendModelsUpdated),
 
     // エージェントセッション
     #[serde(rename = "agent_session_start_request")]
@@ -372,8 +374,15 @@ mod tests {
                     id: "claude".to_string(),
                     name: "Claude".to_string(),
                     available: true,
+                    available_models: vec![],
                 }],
                 default_id: Some("claude".to_string()),
+            }),
+            WsMessage::BackendModelsUpdated(BackendModelsUpdated {
+                backend_id: "claude".to_string(),
+                available_models: vec![ModelInfoMsg {
+                    value: "opus-4".to_string(),
+                }],
             }),
             WsMessage::AgentSessionStartRequest(AgentSessionStartRequest {
                 worktree_path: "/repo".to_string(),

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -367,8 +367,14 @@ pub fn create_session_internal(
     worktree_path: &str,
     backend_id: Option<String>,
 ) -> Result<ChatSession, String> {
+    let session = build_new_session(worktree_path, backend_id);
+    session_store.save_session(data_dir, &session)?;
+    Ok(session)
+}
+
+fn build_new_session(worktree_path: &str, backend_id: Option<String>) -> ChatSession {
     let now = now_timestamp();
-    let session = ChatSession {
+    ChatSession {
         id: uuid::Uuid::new_v4().to_string(),
         worktree_path: worktree_path.to_string(),
         messages: Vec::new(),
@@ -381,7 +387,27 @@ pub fn create_session_internal(
         workflow_state: None,
         backend_id,
         workflow_step_session: false,
-    };
+    }
+}
+
+/// 新規セッションを作成し、当該 backend の登録済み初期モデルがあれば
+/// `selected_model` に永続化する。
+///
+/// 「selected_model=None」を「明示的に未指定」の意味に固定するため、初期モデルは
+/// セッション作成時にのみ書き込む。以後の spawn 経路では `selected_model` が None
+/// なら暗黙の既定モデルへフォールバックさせない。
+pub fn create_session_with_initial_model(
+    session_store: &SessionStore,
+    registry: &crate::backends::AgentBackendRegistry,
+    data_dir: &std::path::Path,
+    worktree_path: &str,
+    backend_id: String,
+) -> Result<ChatSession, String> {
+    let mut session = build_new_session(worktree_path, Some(backend_id.clone()));
+    if let Some(initial_model) = registry.initial_model_for(&backend_id) {
+        session.selected_model = Some(initial_model);
+        session.updated_at = now_timestamp();
+    }
     session_store.save_session(data_dir, &session)?;
     Ok(session)
 }
@@ -426,7 +452,13 @@ pub fn create_session(
 ) -> Result<ChatSession, String> {
     let resolved_backend_id = registry.resolve_backend_id(backend_id)?;
     let data_dir = resolve_data_dir(&app)?;
-    create_session_internal(&state, &data_dir, &worktree_path, Some(resolved_backend_id))
+    create_session_with_initial_model(
+        &state,
+        registry.inner(),
+        &data_dir,
+        &worktree_path,
+        resolved_backend_id,
+    )
 }
 
 #[tauri::command]
@@ -1502,6 +1534,82 @@ mod tests {
     }
 
     #[test]
+    fn create_session_with_initial_model_persists_when_registered() {
+        // spec: 既定モデルが現行の一覧に含まれる場合は初期モデルとして使われる。
+        // セッション作成時に解決して `selected_model` に永続化する。
+        let store = SessionStore::default();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = vec!["opus-4".to_string(), "haiku".to_string()];
+        cfg.agents.claude.model = Some("opus-4".to_string());
+        let cfg_tmp = tempfile::NamedTempFile::new().unwrap();
+        let config = std::sync::Arc::new(crate::config::AppConfig::new(
+            cfg,
+            cfg_tmp.path().to_path_buf(),
+        ));
+
+        let mut registry = crate::backends::AgentBackendRegistry::new();
+        registry.register(std::sync::Arc::new(
+            crate::backends::claude::ClaudeBackend::new(),
+        ));
+        registry.register(std::sync::Arc::new(
+            crate::backends::codex::CodexBackend::new(),
+        ));
+        registry.set_config(config);
+
+        let session = create_session_with_initial_model(
+            &store,
+            &registry,
+            dir.path(),
+            "/repo",
+            "claude".to_string(),
+        )
+        .unwrap();
+        assert_eq!(session.selected_model, Some("opus-4".to_string()));
+
+        // 永続化されている (on-disk から再ロードしても保持される)
+        let reloaded = store.get_session(dir.path(), &session.id).unwrap().unwrap();
+        assert_eq!(reloaded.selected_model, Some("opus-4".to_string()));
+    }
+
+    #[test]
+    fn create_session_with_initial_model_keeps_none_when_unregistered() {
+        // spec: 既定モデルが現行の一覧に含まれない場合は未指定として扱う。
+        // 暗黙のフォールバックは行わない。
+        let store = SessionStore::default();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = vec!["haiku".to_string()];
+        cfg.agents.claude.model = Some("opus-4".to_string());
+        let cfg_tmp = tempfile::NamedTempFile::new().unwrap();
+        let config = std::sync::Arc::new(crate::config::AppConfig::new(
+            cfg,
+            cfg_tmp.path().to_path_buf(),
+        ));
+
+        let mut registry = crate::backends::AgentBackendRegistry::new();
+        registry.register(std::sync::Arc::new(
+            crate::backends::claude::ClaudeBackend::new(),
+        ));
+        registry.register(std::sync::Arc::new(
+            crate::backends::codex::CodexBackend::new(),
+        ));
+        registry.set_config(config);
+
+        let session = create_session_with_initial_model(
+            &store,
+            &registry,
+            dir.path(),
+            "/repo",
+            "claude".to_string(),
+        )
+        .unwrap();
+        assert_eq!(session.selected_model, None);
+    }
+
+    #[test]
     fn chat_session_without_backend_id_deserializes() {
         let json = r#"{"id":"s1","worktreePath":"/repo","messages":[],"state":"active","createdAt":1000.0,"updatedAt":1000.0}"#;
         let session: ChatSession = serde_json::from_str(json).unwrap();
@@ -1564,8 +1672,8 @@ mod tests {
     mod resolve_session_backend_tests {
         use super::*;
         use crate::backends::{
-            AgentBackend, AgentBackendRegistry, AgentMessage, ModelInfo, PermissionResponse,
-            SessionConfig, SessionHandle,
+            AgentBackend, AgentBackendRegistry, AgentMessage, PermissionResponse, SessionConfig,
+            SessionHandle,
         };
         use async_trait::async_trait;
 
@@ -1604,7 +1712,7 @@ mod tests {
             ) -> Result<(), String> {
                 Ok(())
             }
-            async fn available_models(&self) -> Result<Vec<ModelInfo>, String> {
+            async fn fetch_models_from_cli(&self) -> Result<Vec<String>, String> {
                 Ok(vec![])
             }
             async fn close_session(&self, _session: &SessionHandle) -> Result<(), String> {

--- a/src-tauri/src/usecase/backend_models.rs
+++ b/src-tauri/src/usecase/backend_models.rs
@@ -1,0 +1,7 @@
+use std::sync::Arc;
+
+pub(crate) trait BackendModelsUpdateNotifier: Send + Sync {
+    fn broadcast_backend_models_updated(&self, backend_id: &str, available_models: &[String]);
+}
+
+pub(crate) type BackendModelsUpdateNotifierState = Arc<dyn BackendModelsUpdateNotifier>;

--- a/src-tauri/src/usecase/mod.rs
+++ b/src-tauri/src/usecase/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod backend_models;

--- a/src-tauri/src/workflow/diagnostics.rs
+++ b/src-tauri/src/workflow/diagnostics.rs
@@ -312,6 +312,12 @@ fn validation_error_context(e: &validation::ValidationError) -> (Option<String>,
         ValidationError::UnknownModel { step, .. } => {
             (Some(step.clone()), Some("model".to_string()))
         }
+        ValidationError::InvalidModelFormat { step, .. } => {
+            (Some(step.clone()), Some("model".to_string()))
+        }
+        ValidationError::ModelResolutionFailed { step, .. } => {
+            (Some(step.clone()), Some("model".to_string()))
+        }
     }
 }
 

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -974,12 +974,18 @@ impl WorkflowEngine {
         let worktree_path = session.worktree_path.clone();
 
         // ステップ設定のmodel検証: 各 model から所属 backend を一意に解決する。
-        if let Some(registry) = app.try_state::<Arc<crate::backends::AgentBackendRegistry>>() {
-            crate::workflow::validation::validate_models(&workflow, |model| {
-                registry.resolve_backend_for_model(model)
-            })
-            .map_err(|e| WorkflowEngineError::InvalidWorkflow(e.to_string()))?;
-        }
+        // registry 未登録自体を InvalidWorkflow として即時失敗にする（検証スキップを避ける）。
+        let registry = app
+            .try_state::<Arc<crate::backends::AgentBackendRegistry>>()
+            .ok_or_else(|| {
+                WorkflowEngineError::InvalidWorkflow(
+                    "AgentBackendRegistry is not registered".to_string(),
+                )
+            })?;
+        crate::workflow::validation::validate_models(&workflow, |model| {
+            registry.resolve_backend_for_model(model)
+        })
+        .map_err(|e| WorkflowEngineError::InvalidWorkflow(e.to_string()))?;
 
         let now = current_timestamp();
         let mut execution = WorkflowExecution {

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -819,7 +819,9 @@ struct ResolvedStepSettings {
 ///
 /// - permission: ステップ指定があれば採用、なければ親セッションの値を継承
 /// - backend_id: model指定があれば resolved_backend_id を採用、なければ親セッションの値を継承
-/// - selected_model: ステップ指定があれば採用、なければ親セッションの値を継承
+/// - selected_model: ステップ指定があれば採用、なければ未指定（None）として扱う。
+///   Spec: workflow 経路の `model_id=None` は当該 step session の選択モデルを
+///   未指定状態のままとし、親の選択モデルへの暗黙フォールバックを行わない。
 ///
 /// `resolved_backend_id` は、ステップにmodel指定がある場合に
 /// `resolve_backend_for_step_model` で事前に解決されたbackend_id。
@@ -829,7 +831,7 @@ fn resolve_step_settings(
     step_permission: Option<String>,
     resolved_backend_id: Option<String>,
     parent_backend_id: Option<String>,
-    parent_selected_model: Option<String>,
+    _parent_selected_model: Option<String>,
     parent_permission_mode: String,
 ) -> ResolvedStepSettings {
     let permission_mode = step_permission.unwrap_or(parent_permission_mode);
@@ -838,7 +840,7 @@ fn resolve_step_settings(
     } else {
         parent_backend_id
     };
-    let selected_model = step_model.or(parent_selected_model);
+    let selected_model = step_model;
     ResolvedStepSettings {
         backend_id,
         selected_model,
@@ -863,6 +865,8 @@ impl WorkflowEngine {
     }
 
     /// ステップの model 値から対応するバックエンドIDを解決する。
+    /// 形式検証（`ModelId`）と登録判定（`resolve_backend_for_model`）を
+    /// 一括で行い、`set_agent_model_internal` と同一の受け入れ基準を適用する。
     async fn resolve_backend_for_step_model(
         &self,
         app: &tauri::AppHandle,
@@ -875,15 +879,31 @@ impl WorkflowEngine {
                     "cannot resolve model '{model}': backend registry is unavailable"
                 ))
             })?;
-        let backend_id = registry
-            .resolve_backend_for_model(model)
-            .await
-            .ok_or_else(|| {
-                WorkflowEngineError::InvalidWorkflow(format!("unknown model: {model}"))
-            })?;
-        Ok(Some(backend_id))
+        resolve_step_model_with_registry(&registry, model).map(Some)
     }
+}
 
+/// 形式検証＋登録判定をレジストリ単体で行う、ワークフロー経路用の解決関数。
+/// `resolve_backend_for_step_model` の実体ロジックで、テストではこちらを直接呼ぶ。
+pub(crate) fn resolve_step_model_with_registry(
+    registry: &crate::backends::AgentBackendRegistry,
+    model: &str,
+) -> Result<String, WorkflowEngineError> {
+    crate::domain::agent_session::ModelId::parse(model).map_err(|e| {
+        WorkflowEngineError::InvalidWorkflow(format!("invalid model '{model}': {e}"))
+    })?;
+    let backend_id = registry
+        .resolve_backend_for_model(model)
+        .map_err(|e| {
+            WorkflowEngineError::InvalidWorkflow(format!(
+                "model '{model}' could not be resolved: {e}"
+            ))
+        })?
+        .ok_or_else(|| WorkflowEngineError::InvalidWorkflow(format!("unknown model: {model}")))?;
+    Ok(backend_id)
+}
+
+impl WorkflowEngine {
     /// ステップ設定の解決 → セッション生成 → 解決済み設定の反映 → 保存を一括で行う。
     ///
     /// `start_step_session` と `start_parallel_children` の共通パターンを抽出したヘルパー。
@@ -953,11 +973,12 @@ impl WorkflowEngine {
             .ok_or_else(|| WorkflowEngineError::SessionNotFound(chat_session_id.to_string()))?;
         let worktree_path = session.worktree_path.clone();
 
-        // ステップ設定のmodel検証: 全バックエンドの available_models から有効モデルを収集
+        // ステップ設定のmodel検証: 各 model から所属 backend を一意に解決する。
         if let Some(registry) = app.try_state::<Arc<crate::backends::AgentBackendRegistry>>() {
-            let valid_models = registry.collect_all_model_values().await;
-            crate::workflow::validation::validate_models(&workflow, &valid_models)
-                .map_err(|e| WorkflowEngineError::InvalidWorkflow(e.to_string()))?;
+            crate::workflow::validation::validate_models(&workflow, |model| {
+                registry.resolve_backend_for_model(model)
+            })
+            .map_err(|e| WorkflowEngineError::InvalidWorkflow(e.to_string()))?;
         }
 
         let now = current_timestamp();
@@ -4704,11 +4725,124 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backends::{
+        AgentBackend, AgentBackendRegistry, AgentMessage as BackendAgentMessage,
+        PermissionResponse, SessionConfig as BackendSessionConfig,
+        SessionHandle as BackendSessionHandle,
+    };
     use crate::session::MessagePart;
+    use async_trait::async_trait;
 
     const TEST_PARENT_SESSION_ID: &str = "11111111-1111-4111-8111-111111111111";
     const TEST_STEP_SESSION_ID: &str = "22222222-2222-4222-8222-222222222222";
     const TEST_REGULAR_SESSION_ID: &str = "33333333-3333-4333-8333-333333333333";
+
+    struct WorkflowMockBackend {
+        backend_id: String,
+    }
+
+    #[async_trait]
+    impl AgentBackend for WorkflowMockBackend {
+        fn id(&self) -> &str {
+            &self.backend_id
+        }
+        fn name(&self) -> &str {
+            "Mock"
+        }
+        async fn start_session(
+            &self,
+            cfg: BackendSessionConfig,
+        ) -> Result<BackendSessionHandle, String> {
+            Ok(BackendSessionHandle {
+                chat_session_id: cfg.chat_session_id,
+                backend_id: self.backend_id.clone(),
+            })
+        }
+        async fn send_message(
+            &self,
+            _s: &BackendSessionHandle,
+            _m: BackendAgentMessage,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        async fn interrupt(&self, _s: &BackendSessionHandle) -> Result<(), String> {
+            Ok(())
+        }
+        async fn respond_permission(
+            &self,
+            _s: &BackendSessionHandle,
+            _r: PermissionResponse,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        async fn close_session(&self, _s: &BackendSessionHandle) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    fn make_workflow_test_registry(
+        claude_models: &[&str],
+        codex_models: &[&str],
+    ) -> AgentBackendRegistry {
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = claude_models.iter().map(|s| s.to_string()).collect();
+        cfg.agents.codex.models = codex_models.iter().map(|s| s.to_string()).collect();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let app_cfg = Arc::new(crate::config::AppConfig::new(cfg, tmp.path().to_path_buf()));
+        let mut registry = AgentBackendRegistry::new();
+        registry.register(Arc::new(WorkflowMockBackend {
+            backend_id: "claude".to_string(),
+        }));
+        registry.register(Arc::new(WorkflowMockBackend {
+            backend_id: "codex".to_string(),
+        }));
+        registry.set_config(app_cfg);
+        registry
+    }
+
+    #[test]
+    fn workflow_resolve_unique_model_returns_owning_backend() {
+        let registry = make_workflow_test_registry(&["claude-4"], &["gpt-5"]);
+        let result = resolve_step_model_with_registry(&registry, "claude-4").unwrap();
+        assert_eq!(result, "claude");
+    }
+
+    #[test]
+    fn workflow_resolve_rejects_ambiguous_model_in_multiple_backends() {
+        let registry = make_workflow_test_registry(&["shared"], &["shared"]);
+        let err = resolve_step_model_with_registry(&registry, "shared").unwrap_err();
+        match err {
+            WorkflowEngineError::InvalidWorkflow(msg) => {
+                assert!(msg.contains("could not be resolved"));
+            }
+            other => panic!("expected InvalidWorkflow, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn workflow_resolve_rejects_unknown_model() {
+        let registry = make_workflow_test_registry(&["claude-4"], &[]);
+        let err = resolve_step_model_with_registry(&registry, "unknown").unwrap_err();
+        match err {
+            WorkflowEngineError::InvalidWorkflow(msg) => {
+                assert!(msg.contains("unknown model"));
+            }
+            other => panic!("expected InvalidWorkflow, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn workflow_resolve_rejects_invalid_format() {
+        let registry = make_workflow_test_registry(&["claude-4"], &[]);
+        // 形式不正（空文字）は登録判定に進む前に拒否される
+        let err = resolve_step_model_with_registry(&registry, "").unwrap_err();
+        match err {
+            WorkflowEngineError::InvalidWorkflow(msg) => {
+                assert!(msg.contains("invalid model"));
+            }
+            other => panic!("expected InvalidWorkflow, got {:?}", other),
+        }
+    }
 
     fn chat_session_for_test(
         id: &str,
@@ -10262,7 +10396,9 @@ mod tests {
     }
 
     #[test]
-    fn resolve_step_settings_permission_only() {
+    fn resolve_step_settings_permission_only_clears_model_to_unset() {
+        // Spec: workflow 経路では step model 未指定なら親の選択モデルへフォールバックしない。
+        // permission のみ指定でも selected_model は None になる。
         let result = resolve_step_settings(
             None,
             Some("plan".to_string()),
@@ -10275,14 +10411,16 @@ mod tests {
             result,
             ResolvedStepSettings {
                 backend_id: Some("claude".to_string()),
-                selected_model: Some("opus-4".to_string()),
+                selected_model: None,
                 permission_mode: "plan".to_string(),
             }
         );
     }
 
     #[test]
-    fn resolve_step_settings_nothing_specified() {
+    fn resolve_step_settings_nothing_specified_clears_model_to_unset() {
+        // Spec: model 未指定（None）は未指定状態のまま。親の selected_model へ
+        // 暗黙フォールバックしない。
         let result = resolve_step_settings(
             None,
             None,
@@ -10295,7 +10433,7 @@ mod tests {
             result,
             ResolvedStepSettings {
                 backend_id: Some("claude".to_string()),
-                selected_model: Some("opus-4".to_string()),
+                selected_model: None,
                 permission_mode: "acceptEdits".to_string(),
             }
         );

--- a/src-tauri/src/workflow/validation.rs
+++ b/src-tauri/src/workflow/validation.rs
@@ -109,6 +109,20 @@ pub enum ValidationError {
         step: String,
         value: String,
     },
+    /// モデルIDが形式として無効（空文字・空白のみ・制御文字・上限長超過など）。
+    /// `reason` には `ModelId` の戻り値（理由文言）を保持し、
+    /// 呼び出し側・ログで未登録（UnknownModel）と区別できるようにする。
+    InvalidModelFormat {
+        step: String,
+        value: String,
+        reason: String,
+    },
+    /// モデルIDの形式は有効だが、バックエンド所属を一意に解決できない。
+    ModelResolutionFailed {
+        step: String,
+        value: String,
+        reason: String,
+    },
 }
 
 impl fmt::Display for ValidationError {
@@ -215,6 +229,26 @@ impl fmt::Display for ValidationError {
                 write!(
                     f,
                     "ステップ '{step}' のmodelが不正です: unknown model: {value}"
+                )
+            }
+            Self::InvalidModelFormat {
+                step,
+                value,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "ステップ '{step}' のmodel '{value}' は形式として無効です: {reason}"
+                )
+            }
+            Self::ModelResolutionFailed {
+                step,
+                value,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "ステップ '{step}' のmodel '{value}' の所属バックエンドを解決できません: {reason}"
                 )
             }
         }
@@ -609,34 +643,64 @@ fn validate_permission(step_name: &str, value: &str) -> Result<(), ValidationErr
 }
 
 /// ワークフロー内の全ステップの `model` フィールドを検証する。
-/// `valid_models` は全バックエンドの `available_models()` から収集した有効なモデルID集合。
-pub fn validate_models(
-    workflow: &Workflow,
-    valid_models: &HashSet<String>,
-) -> Result<(), ValidationError> {
+///
+/// 検証は経路によらず同一の基準で行う:
+/// 1. 形式検証（`crate::domain::agent_session::ModelId`）— 空文字・空白のみ・制御文字・
+///    上限長超過は登録判定に進まず形式不正として拒否する
+/// 2. 登録判定（呼び出し側の resolver）— 未登録なら `UnknownModel`
+/// 3. 所属解決（呼び出し側の resolver）— 複数 backend に登録された曖昧な model は拒否する
+pub fn validate_models<F>(workflow: &Workflow, mut resolve_model: F) -> Result<(), ValidationError>
+where
+    F: FnMut(&str) -> Result<Option<String>, String>,
+{
     for step in &workflow.steps {
         if let Some(ref model) = step.model {
-            if !valid_models.contains(model.as_str()) {
-                return Err(ValidationError::UnknownModel {
-                    step: step.name.clone(),
-                    value: model.clone(),
-                });
-            }
+            validate_model_format(&step.name, model)?;
+            validate_model_registered(&step.name, model, &mut resolve_model)?;
         }
         if let Some(ref children) = step.parallel {
             for child in children {
                 if let Some(ref model) = child.model {
-                    if !valid_models.contains(model.as_str()) {
-                        return Err(ValidationError::UnknownModel {
-                            step: child.name.clone(),
-                            value: model.clone(),
-                        });
-                    }
+                    validate_model_format(&child.name, model)?;
+                    validate_model_registered(&child.name, model, &mut resolve_model)?;
                 }
             }
         }
     }
     Ok(())
+}
+
+fn validate_model_format(step_name: &str, model: &str) -> Result<(), ValidationError> {
+    crate::domain::agent_session::ModelId::parse(model).map_err(|reason| {
+        ValidationError::InvalidModelFormat {
+            step: step_name.to_string(),
+            value: model.to_string(),
+            reason,
+        }
+    })?;
+    Ok(())
+}
+
+fn validate_model_registered<F>(
+    step_name: &str,
+    model: &str,
+    resolve_model: &mut F,
+) -> Result<(), ValidationError>
+where
+    F: FnMut(&str) -> Result<Option<String>, String>,
+{
+    match resolve_model(model) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(ValidationError::UnknownModel {
+            step: step_name.to_string(),
+            value: model.to_string(),
+        }),
+        Err(reason) => Err(ValidationError::ModelResolutionFailed {
+            step: step_name.to_string(),
+            value: model.to_string(),
+            reason,
+        }),
+    }
 }
 
 /// 診断用: 全てのバリデーションエラーを収集して返す。
@@ -942,6 +1006,10 @@ mod tests {
             builtin: false,
             steps,
         }
+    }
+
+    fn resolve_from_set(valid: &HashSet<String>, model: &str) -> Result<Option<String>, String> {
+        Ok(valid.contains(model).then(|| "backend".to_string()))
     }
 
     fn make_step(name: &str, mode: StepMode, rules: Vec<TransitionRule>) -> Step {
@@ -1885,7 +1953,7 @@ mod tests {
             ..make_step("step1", StepMode::Auto, vec![])
         }]);
         let valid = HashSet::from(["haiku".to_string(), "opus-4".to_string()]);
-        assert!(validate_models(&wf, &valid).is_ok());
+        assert!(validate_models(&wf, |model| resolve_from_set(&valid, model)).is_ok());
     }
 
     #[test]
@@ -1895,7 +1963,7 @@ mod tests {
             ..make_step("step1", StepMode::Auto, vec![])
         }]);
         let valid = HashSet::from(["haiku".to_string(), "opus-4".to_string()]);
-        let err = validate_models(&wf, &valid).unwrap_err();
+        let err = validate_models(&wf, |model| resolve_from_set(&valid, model)).unwrap_err();
         assert!(matches!(
             err,
             ValidationError::UnknownModel { ref step, ref value }
@@ -1915,7 +1983,7 @@ mod tests {
             None,
         )]);
         let valid = HashSet::from(["haiku".to_string()]);
-        let err = validate_models(&wf, &valid).unwrap_err();
+        let err = validate_models(&wf, |model| resolve_from_set(&valid, model)).unwrap_err();
         assert!(matches!(
             err,
             ValidationError::UnknownModel { ref step, ref value }
@@ -1924,10 +1992,29 @@ mod tests {
     }
 
     #[test]
+    fn validate_models_rejects_ambiguous_model_from_resolver() {
+        let wf = make_workflow(vec![Step {
+            model: Some("shared".to_string()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        let err = validate_models(&wf, |model| {
+            Err(format!(
+                "モデル '{model}' が複数のバックエンドに登録されています"
+            ))
+        })
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::ModelResolutionFailed { ref step, ref value, ref reason }
+                if step == "step1" && value == "shared" && reason.contains("複数")
+        ));
+    }
+
+    #[test]
     fn validate_models_no_model_specified_passes() {
         let wf = make_workflow(vec![make_step("step1", StepMode::Auto, vec![])]);
         let valid = HashSet::from(["haiku".to_string()]);
-        assert!(validate_models(&wf, &valid).is_ok());
+        assert!(validate_models(&wf, |model| resolve_from_set(&valid, model)).is_ok());
     }
 
     #[test]
@@ -1941,6 +2028,44 @@ mod tests {
             None,
         )]);
         let valid = HashSet::from(["haiku".to_string()]);
-        assert!(validate_models(&wf, &valid).is_ok());
+        assert!(validate_models(&wf, |model| resolve_from_set(&valid, model)).is_ok());
+    }
+
+    #[test]
+    fn validate_models_rejects_empty_model_before_registry_check() {
+        // 形式不正（空文字）は registry に含まれるかにかかわらず拒否される。
+        // 未登録（UnknownModel）と区別するため InvalidModelFormat として報告される。
+        let wf = make_workflow(vec![Step {
+            model: Some(String::new()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        // valid_models に空文字を含めても形式検証で先に弾く
+        let valid = HashSet::from([String::new(), "haiku".to_string()]);
+        let err = validate_models(&wf, |model| resolve_from_set(&valid, model)).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::InvalidModelFormat { ref step, ref value, .. }
+                if step == "step1" && value.is_empty()
+        ));
+    }
+
+    #[test]
+    fn validate_models_rejects_whitespace_only_model() {
+        let wf = make_workflow(vec![Step {
+            model: Some("   ".to_string()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        let valid = HashSet::from(["   ".to_string()]);
+        assert!(validate_models(&wf, |model| resolve_from_set(&valid, model)).is_err());
+    }
+
+    #[test]
+    fn validate_models_rejects_control_character_model() {
+        let wf = make_workflow(vec![Step {
+            model: Some("a\u{0001}b".to_string()),
+            ..make_step("step1", StepMode::Auto, vec![])
+        }]);
+        let valid = HashSet::from(["a\u{0001}b".to_string()]);
+        assert!(validate_models(&wf, |model| resolve_from_set(&valid, model)).is_err());
     }
 }

--- a/src-tauri/src/ws_server/gateway.rs
+++ b/src-tauri/src/ws_server/gateway.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use crate::backends::ModelInfo;
+use crate::protocol::{BackendModelsUpdated, ModelInfoMsg, WsMessage};
+use crate::usecase::backend_models::BackendModelsUpdateNotifier;
+use crate::ws_bridge::WsBroadcaster;
+
+pub(crate) struct WsBackendModelsUpdateNotifier {
+    broadcaster: Arc<WsBroadcaster>,
+}
+
+impl WsBackendModelsUpdateNotifier {
+    pub(crate) fn new(broadcaster: Arc<WsBroadcaster>) -> Self {
+        Self { broadcaster }
+    }
+}
+
+pub(crate) fn build_backend_models_updated_message(
+    backend_id: &str,
+    available_models: &[ModelInfo],
+) -> WsMessage {
+    WsMessage::BackendModelsUpdated(BackendModelsUpdated {
+        backend_id: backend_id.to_string(),
+        available_models: available_models.iter().map(ModelInfoMsg::from).collect(),
+    })
+}
+
+pub(crate) fn broadcast_backend_models_updated(
+    broadcaster: &WsBroadcaster,
+    backend_id: &str,
+    available_models: &[ModelInfo],
+) {
+    broadcaster.send_without_buffer(build_backend_models_updated_message(
+        backend_id,
+        available_models,
+    ));
+}
+
+impl BackendModelsUpdateNotifier for WsBackendModelsUpdateNotifier {
+    fn broadcast_backend_models_updated(&self, backend_id: &str, available_models: &[String]) {
+        let available_models: Vec<ModelInfo> = available_models
+            .iter()
+            .map(|value| ModelInfo {
+                value: value.clone(),
+            })
+            .collect();
+        broadcast_backend_models_updated(&self.broadcaster, backend_id, &available_models);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_backend_models_updated_message_uses_ws_contract_fields() {
+        let msg = build_backend_models_updated_message(
+            "codex",
+            &[ModelInfo {
+                value: "gpt-5.5".to_string(),
+            }],
+        );
+        match msg {
+            WsMessage::BackendModelsUpdated(payload) => {
+                assert_eq!(payload.backend_id, "codex");
+                assert_eq!(payload.available_models.len(), 1);
+                assert_eq!(payload.available_models[0].value, "gpt-5.5");
+            }
+            _ => panic!("expected BackendModelsUpdated"),
+        }
+    }
+}

--- a/src-tauri/src/ws_server/handlers.rs
+++ b/src-tauri/src/ws_server/handlers.rs
@@ -527,7 +527,7 @@ pub(super) async fn handle_agent_model_set_request(
 ) -> Option<WsMessage> {
     use tauri::Manager;
 
-    let result = if let Some(app) = &state.app_handle {
+    if let Some(app) = &state.app_handle {
         let session_store = app
             .state::<Arc<crate::session::SessionStore>>()
             .inner()
@@ -536,25 +536,58 @@ pub(super) async fn handle_agent_model_set_request(
             .state::<Arc<tokio::sync::Mutex<crate::agent_sdk::AgentProcessMap>>>()
             .inner()
             .clone();
-        crate::agent_sdk::set_agent_model_internal(
-            app,
+        let data_dir = match crate::session::resolve_data_dir(app) {
+            Ok(data_dir) => data_dir,
+            Err(e) => {
+                return Some(agent_model_set_response(req, Err(e)));
+            }
+        };
+        return handle_agent_model_set_request_with_data_dir(
+            req,
+            Some(app),
             &handles,
             &session_store,
             Some(state.get_backend_registry()),
-            &req.session_id,
-            req.model_id.clone(),
+            &data_dir,
         )
-        .await
-    } else {
-        Err("App handle not available".to_string())
-    };
+        .await;
+    }
 
-    Some(WsMessage::AgentModelSetResponse(AgentModelSetResponse {
+    Some(agent_model_set_response(
+        req,
+        Err("App handle not available".to_string()),
+    ))
+}
+
+fn agent_model_set_response(req: &AgentModelSetRequest, result: Result<(), String>) -> WsMessage {
+    WsMessage::AgentModelSetResponse(AgentModelSetResponse {
         success: result.is_ok(),
         session_id: req.session_id.clone(),
         model_id: req.model_id.clone(),
         error: result.err(),
-    }))
+    })
+}
+
+async fn handle_agent_model_set_request_with_data_dir(
+    req: &AgentModelSetRequest,
+    app: Option<&tauri::AppHandle>,
+    handles: &Arc<tokio::sync::Mutex<crate::agent_sdk::AgentProcessMap>>,
+    session_store: &Arc<crate::session::SessionStore>,
+    registry: Option<&Arc<crate::backends::AgentBackendRegistry>>,
+    data_dir: &std::path::Path,
+) -> Option<WsMessage> {
+    let result = crate::agent_sdk::set_agent_model_internal_with_data_dir(
+        app,
+        handles,
+        session_store,
+        registry,
+        data_dir,
+        &req.session_id,
+        req.model_id.clone(),
+    )
+    .await;
+
+    Some(agent_model_set_response(req, result))
 }
 
 pub(super) async fn handle_pty_kill_request(
@@ -649,6 +682,252 @@ mod tests {
             backend_id: Some("claude".to_string()),
             workflow_step_session: false,
         }
+    }
+
+    struct MockBackend {
+        backend_id: String,
+        backend_name: String,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::backends::AgentBackend for MockBackend {
+        fn id(&self) -> &str {
+            &self.backend_id
+        }
+
+        fn name(&self) -> &str {
+            &self.backend_name
+        }
+
+        async fn start_session(
+            &self,
+            _config: crate::backends::SessionConfig,
+        ) -> Result<crate::backends::SessionHandle, String> {
+            Ok(crate::backends::SessionHandle {
+                chat_session_id: "test".to_string(),
+                backend_id: self.backend_id.clone(),
+            })
+        }
+
+        async fn send_message(
+            &self,
+            _session: &crate::backends::SessionHandle,
+            _message: crate::backends::AgentMessage,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn interrupt(&self, _session: &crate::backends::SessionHandle) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn respond_permission(
+            &self,
+            _session: &crate::backends::SessionHandle,
+            _response: crate::backends::PermissionResponse,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn close_session(
+            &self,
+            _session: &crate::backends::SessionHandle,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    fn make_model_registry(
+        claude_models: &[&str],
+        codex_models: &[&str],
+    ) -> Arc<crate::backends::AgentBackendRegistry> {
+        let mut cfg = crate::config::ReleashConfig::default();
+        cfg.agents.claude.models = claude_models.iter().map(|s| s.to_string()).collect();
+        cfg.agents.codex.models = codex_models.iter().map(|s| s.to_string()).collect();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let config = Arc::new(crate::config::AppConfig::new(cfg, tmp.path().to_path_buf()));
+        let mut registry = crate::backends::AgentBackendRegistry::new();
+        registry.register(Arc::new(MockBackend {
+            backend_id: "claude".to_string(),
+            backend_name: "Claude".to_string(),
+        }));
+        registry.register(Arc::new(MockBackend {
+            backend_id: "codex".to_string(),
+            backend_name: "Codex".to_string(),
+        }));
+        registry.set_config(config);
+        Arc::new(registry)
+    }
+
+    async fn call_agent_model_set_for_test(
+        session_store: &Arc<crate::session::SessionStore>,
+        registry: &Arc<crate::backends::AgentBackendRegistry>,
+        data_dir: &std::path::Path,
+        session_id: &str,
+        model_id: Option<String>,
+    ) -> AgentModelSetResponse {
+        let req = AgentModelSetRequest {
+            session_id: session_id.to_string(),
+            model_id,
+        };
+        let handles = Arc::new(Mutex::new(crate::agent_sdk::AgentProcessMap::new()));
+        match handle_agent_model_set_request_with_data_dir(
+            &req,
+            None,
+            &handles,
+            session_store,
+            Some(registry),
+            data_dir,
+        )
+        .await
+        {
+            Some(WsMessage::AgentModelSetResponse(resp)) => resp,
+            other => panic!("expected AgentModelSetResponse, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_agent_model_set_request_accepts_registered_model_as_ws_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::session::SessionStore::default());
+        let session = crate::session::create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some("claude".to_string()),
+        )
+        .unwrap();
+        let registry = make_model_registry(&["claude-4"], &["gpt-5"]);
+
+        let resp = call_agent_model_set_for_test(
+            &session_store,
+            &registry,
+            temp.path(),
+            &session.id,
+            Some("claude-4".to_string()),
+        )
+        .await;
+
+        assert!(resp.success);
+        assert_eq!(resp.session_id, session.id);
+        assert_eq!(resp.model_id.as_deref(), Some("claude-4"));
+        assert_eq!(resp.error, None);
+    }
+
+    #[tokio::test]
+    async fn handle_agent_model_set_request_rejects_unregistered_model_as_ws_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::session::SessionStore::default());
+        let session = crate::session::create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some("claude".to_string()),
+        )
+        .unwrap();
+        let registry = make_model_registry(&["claude-4"], &[]);
+
+        let resp = call_agent_model_set_for_test(
+            &session_store,
+            &registry,
+            temp.path(),
+            &session.id,
+            Some("unknown".to_string()),
+        )
+        .await;
+
+        assert!(!resp.success);
+        assert_eq!(resp.session_id, session.id);
+        assert_eq!(resp.model_id.as_deref(), Some("unknown"));
+        assert!(resp.error.unwrap().contains("登録されていません"));
+    }
+
+    #[tokio::test]
+    async fn handle_agent_model_set_request_rejects_other_backend_model_as_ws_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::session::SessionStore::default());
+        let session = crate::session::create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some("claude".to_string()),
+        )
+        .unwrap();
+        let registry = make_model_registry(&["claude-4"], &["gpt-5"]);
+
+        let resp = call_agent_model_set_for_test(
+            &session_store,
+            &registry,
+            temp.path(),
+            &session.id,
+            Some("gpt-5".to_string()),
+        )
+        .await;
+
+        assert!(!resp.success);
+        assert_eq!(resp.model_id.as_deref(), Some("gpt-5"));
+        assert!(resp.error.unwrap().contains("別バックエンド"));
+    }
+
+    #[tokio::test]
+    async fn handle_agent_model_set_request_rejects_invalid_model_as_ws_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::session::SessionStore::default());
+        let session = crate::session::create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some("claude".to_string()),
+        )
+        .unwrap();
+        let registry = make_model_registry(&["claude-4"], &[]);
+
+        let resp = call_agent_model_set_for_test(
+            &session_store,
+            &registry,
+            temp.path(),
+            &session.id,
+            Some("bad\u{0001}model".to_string()),
+        )
+        .await;
+
+        assert!(!resp.success);
+        assert_eq!(resp.model_id.as_deref(), Some("bad\u{0001}model"));
+        assert!(resp.error.unwrap().contains("制御文字"));
+    }
+
+    #[tokio::test]
+    async fn handle_agent_model_set_request_accepts_null_model_as_clear_ws_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::session::SessionStore::default());
+        let mut session = crate::session::create_session_internal(
+            &session_store,
+            temp.path(),
+            "/repo",
+            Some("claude".to_string()),
+        )
+        .unwrap();
+        session.selected_model = Some("claude-4".to_string());
+        session_store.save_session(temp.path(), &session).unwrap();
+        let registry = make_model_registry(&["claude-4"], &[]);
+
+        let resp = call_agent_model_set_for_test(
+            &session_store,
+            &registry,
+            temp.path(),
+            &session.id,
+            None,
+        )
+        .await;
+
+        assert!(resp.success);
+        assert_eq!(resp.model_id, None);
+        assert_eq!(resp.error, None);
+        let after = session_store
+            .get_session(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.selected_model, None);
     }
 
     // --- A. ユーティリティ ---

--- a/src-tauri/src/ws_server/mod.rs
+++ b/src-tauri/src/ws_server/mod.rs
@@ -1,5 +1,6 @@
 mod auth;
 pub(crate) mod commands;
+pub(crate) mod gateway;
 mod handlers;
 mod http;
 mod rate_limit;
@@ -121,12 +122,21 @@ impl WsServerState {
         let app = self.app_handle.as_ref().ok_or("App handle not available")?;
         let session_store = app.state::<Arc<crate::session::SessionStore>>();
         let data_dir = crate::session::resolve_data_dir(app)?;
-        crate::session::create_session_internal(
-            &session_store,
-            &data_dir,
-            worktree_path,
-            backend_id,
-        )
+        match backend_id {
+            Some(bid) => crate::session::create_session_with_initial_model(
+                &session_store,
+                &self.backend_registry,
+                &data_dir,
+                worktree_path,
+                bid,
+            ),
+            None => crate::session::create_session_internal(
+                &session_store,
+                &data_dir,
+                worktree_path,
+                None,
+            ),
+        }
     }
 
     pub(crate) fn get_repo_paths(&self) -> Vec<String> {

--- a/src-tauri/src/ws_server/routing.rs
+++ b/src-tauri/src/ws_server/routing.rs
@@ -218,13 +218,15 @@ mod tests {
     }
 
     fn test_state_with_registry() -> WsServerState {
-        let config = crate::config::ReleashConfig::default();
+        let mut config = crate::config::ReleashConfig::default();
+        config.agents.claude.models = vec!["opus-4".to_string(), "haiku".to_string()];
         let app_config = Arc::new(crate::config::AppConfig::new(
             config,
             std::path::PathBuf::from("/tmp/test-releash.toml"),
         ));
         let mut registry = crate::backends::AgentBackendRegistry::new();
         registry.register(Arc::new(crate::backends::claude::ClaudeBackend::new()));
+        registry.set_config(app_config.clone());
         WsServerState::new(
             None,
             Arc::new(WsBroadcaster::default()),
@@ -250,6 +252,12 @@ mod tests {
                 assert_eq!(r.backends[0].id, "claude");
                 assert_eq!(r.backends[0].name, "Claude");
                 assert!(r.backends[0].available);
+                let values: Vec<&str> = r.backends[0]
+                    .available_models
+                    .iter()
+                    .map(|m| m.value.as_str())
+                    .collect();
+                assert_eq!(values, vec!["opus-4", "haiku"]);
             }
             _ => panic!("expected BackendListResponse"),
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,6 +46,7 @@
     "resources": [
       "generated/remote/",
       "generated/bridges/claude-sdk-bridge.bundled.mjs",
+      "generated/bridges/claude-sdk-bridge-list-models.bundled.mjs",
       "generated/bridges/codex-sdk-bridge.bundled.mjs"
     ],
     "icon": [

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
@@ -308,8 +308,8 @@ describe("AgentChatPanel session tabs", () => {
 				backendId: "claude",
 			},
 			backends: [
-				{ id: "claude", name: "Claude", available: true },
-				{ id: "codex", name: "Codex", available: true },
+				{ id: "claude", name: "Claude", available: true, availableModels: [] },
+				{ id: "codex", name: "Codex", available: true, availableModels: [] },
 			],
 			selectedBackendId: "claude",
 		});
@@ -343,8 +343,8 @@ describe("AgentChatPanel session tabs", () => {
 				backendId: "claude",
 			},
 			backends: [
-				{ id: "claude", name: "Claude", available: true },
-				{ id: "codex", name: "Codex", available: true },
+				{ id: "claude", name: "Claude", available: true, availableModels: [] },
+				{ id: "codex", name: "Codex", available: true, availableModels: [] },
 			],
 			selectedBackendId: "claude",
 		});

--- a/src/components/panels/AgentChatPanel/BackendSelector.test.tsx
+++ b/src/components/panels/AgentChatPanel/BackendSelector.test.tsx
@@ -7,6 +7,7 @@ const makeBackend = (
 	overrides: Partial<BackendInfo> & { id: string; name: string },
 ): BackendInfo => ({
 	available: true,
+	availableModels: [],
 	...overrides,
 });
 

--- a/src/components/panels/AgentChatPanel/MessageInput.test.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.test.tsx
@@ -182,7 +182,7 @@ describe("MessageInput", () => {
 		render(<MessageInput {...defaultProps} />);
 		expect(screen.getByTestId("model-selector-trigger")).toBeDefined();
 		expect(screen.getByTestId("model-selector-trigger")).toHaveTextContent(
-			"未指定",
+			"Unset",
 		);
 	});
 

--- a/src/components/panels/AgentChatPanel/MessageInput.test.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.test.tsx
@@ -163,8 +163,13 @@ describe("MessageInput", () => {
 				{...defaultProps}
 				currentBackendId="codex"
 				backends={[
-					{ id: "claude", name: "Claude", available: true },
-					{ id: "codex", name: "Codex", available: true },
+					{
+						id: "claude",
+						name: "Claude",
+						available: true,
+						availableModels: [],
+					},
+					{ id: "codex", name: "Codex", available: true, availableModels: [] },
 				]}
 			/>,
 		);
@@ -177,15 +182,12 @@ describe("MessageInput", () => {
 		render(<MessageInput {...defaultProps} />);
 		expect(screen.getByTestId("model-selector-trigger")).toBeDefined();
 		expect(screen.getByTestId("model-selector-trigger")).toHaveTextContent(
-			"Auto",
+			"未指定",
 		);
 	});
 
-	it("renders ModelSelector with selected model name", () => {
-		const models = [
-			{ value: "claude-opus", displayName: "Claude Opus" },
-			{ value: "claude-sonnet", displayName: "Claude Sonnet" },
-		];
+	it("renders ModelSelector with selected model value", () => {
+		const models = [{ value: "claude-opus" }, { value: "claude-sonnet" }];
 		render(
 			<MessageInput
 				{...defaultProps}
@@ -194,7 +196,7 @@ describe("MessageInput", () => {
 			/>,
 		);
 		expect(screen.getByTestId("model-selector-trigger")).toHaveTextContent(
-			"Claude Opus",
+			"claude-opus",
 		);
 	});
 
@@ -203,8 +205,13 @@ describe("MessageInput", () => {
 			<MessageInput
 				{...defaultProps}
 				backends={[
-					{ id: "claude", name: "Claude", available: true },
-					{ id: "codex", name: "Codex", available: true },
+					{
+						id: "claude",
+						name: "Claude",
+						available: true,
+						availableModels: [],
+					},
+					{ id: "codex", name: "Codex", available: true, availableModels: [] },
 				]}
 				currentBackendId="claude"
 				backendDisabled={false}
@@ -221,8 +228,13 @@ describe("MessageInput", () => {
 			<MessageInput
 				{...defaultProps}
 				backends={[
-					{ id: "claude", name: "Claude", available: true },
-					{ id: "codex", name: "Codex", available: true },
+					{
+						id: "claude",
+						name: "Claude",
+						available: true,
+						availableModels: [],
+					},
+					{ id: "codex", name: "Codex", available: true, availableModels: [] },
 				]}
 				currentBackendId="claude"
 				backendDisabled={true}

--- a/src/components/panels/AgentChatPanel/ModelSelector.test.tsx
+++ b/src/components/panels/AgentChatPanel/ModelSelector.test.tsx
@@ -16,7 +16,7 @@ describe("ModelSelector", () => {
 			/>,
 		);
 		expect(screen.getByTestId("model-selector-trigger")).toHaveTextContent(
-			"未指定",
+			"Unset",
 		);
 	});
 

--- a/src/components/panels/AgentChatPanel/ModelSelector.test.tsx
+++ b/src/components/panels/AgentChatPanel/ModelSelector.test.tsx
@@ -3,13 +3,10 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ModelSelector } from "./ModelSelector";
 
-const models = [
-	{ value: "claude-4", displayName: "Claude 4" },
-	{ value: "claude-3.5", displayName: "Claude 3.5 Sonnet" },
-];
+const models = [{ value: "claude-4" }, { value: "claude-3.5" }];
 
 describe("ModelSelector", () => {
-	it("shows 'Auto' when no model is selected", () => {
+	it("shows fallback label when no model is selected", () => {
 		render(
 			<ModelSelector
 				models={models}
@@ -19,11 +16,11 @@ describe("ModelSelector", () => {
 			/>,
 		);
 		expect(screen.getByTestId("model-selector-trigger")).toHaveTextContent(
-			"Auto",
+			"未指定",
 		);
 	});
 
-	it("shows selected model name when a model is selected", () => {
+	it("shows selected model value when a model is selected", () => {
 		render(
 			<ModelSelector
 				models={models}
@@ -33,7 +30,7 @@ describe("ModelSelector", () => {
 			/>,
 		);
 		expect(screen.getByTestId("model-selector-trigger")).toHaveTextContent(
-			"Claude 4",
+			"claude-4",
 		);
 	});
 
@@ -50,7 +47,7 @@ describe("ModelSelector", () => {
 		);
 
 		await user.click(screen.getByTestId("model-selector-trigger"));
-		await user.click(screen.getByText("Claude 4"));
+		await user.click(screen.getByText("claude-4"));
 		expect(onModelChange).toHaveBeenCalledWith("claude-4");
 	});
 
@@ -66,7 +63,7 @@ describe("ModelSelector", () => {
 		expect(screen.getByTestId("model-selector-trigger")).toBeEnabled();
 	});
 
-	it("calls onModelChange with null when Auto is selected", async () => {
+	it("does not include an Auto fallback option in the dropdown", async () => {
 		const user = userEvent.setup();
 		const onModelChange = vi.fn();
 		render(
@@ -79,11 +76,43 @@ describe("ModelSelector", () => {
 		);
 
 		await user.click(screen.getByTestId("model-selector-trigger"));
-		await user.click(screen.getByText("Auto"));
+		// 候補に "Auto" は含まれない（暗黙のフォールバック候補を提示しない）
+		expect(screen.queryByText("Auto")).toBeNull();
+	});
+
+	it("calls onModelChange with null when the unset option is selected", async () => {
+		const user = userEvent.setup();
+		const onModelChange = vi.fn();
+		render(
+			<ModelSelector
+				models={models}
+				currentModelId="claude-4"
+				onModelChange={onModelChange}
+				disabled={false}
+			/>,
+		);
+
+		await user.click(screen.getByTestId("model-selector-trigger"));
+		await user.click(screen.getByTestId("model-selector-clear"));
 		expect(onModelChange).toHaveBeenCalledWith(null);
 	});
 
-	it("disables trigger when disabled is true", () => {
+	it("does not show the unset option when no model is currently selected", async () => {
+		const user = userEvent.setup();
+		render(
+			<ModelSelector
+				models={models}
+				currentModelId={null}
+				onModelChange={vi.fn()}
+				disabled={false}
+			/>,
+		);
+
+		await user.click(screen.getByTestId("model-selector-trigger"));
+		expect(screen.queryByTestId("model-selector-clear")).toBeNull();
+	});
+
+	it("disables trigger when disabled prop is true", () => {
 		render(
 			<ModelSelector
 				models={models}
@@ -95,7 +124,7 @@ describe("ModelSelector", () => {
 		expect(screen.getByTestId("model-selector-trigger")).toBeDisabled();
 	});
 
-	it("disables trigger when models list is empty", () => {
+	it("keeps trigger enabled when models list is empty", () => {
 		render(
 			<ModelSelector
 				models={[]}
@@ -104,6 +133,67 @@ describe("ModelSelector", () => {
 				disabled={false}
 			/>,
 		);
-		expect(screen.getByTestId("model-selector-trigger")).toBeDisabled();
+		// 空一覧でも選択UI 自体は開ける（仕様: モデル一覧が空でも選択UIは提示）
+		expect(screen.getByTestId("model-selector-trigger")).toBeEnabled();
+	});
+
+	it("shows zero candidates when models list is empty", async () => {
+		const user = userEvent.setup();
+		render(
+			<ModelSelector
+				models={[]}
+				currentModelId={null}
+				onModelChange={vi.fn()}
+				disabled={false}
+			/>,
+		);
+
+		await user.click(screen.getByTestId("model-selector-trigger"));
+		// 候補は 0 件として提示され、暗黙のフォールバック候補や代替文言は含まれない。
+		expect(screen.queryAllByRole("menuitemradio")).toHaveLength(0);
+		expect(screen.queryByText("Auto")).toBeNull();
+		expect(screen.queryByText("候補なし")).toBeNull();
+	});
+
+	it("renders dangerous model identifiers as plain text", async () => {
+		// spec: 表示時に副作用を起こしうる文字を含むモデル識別子は文字列として
+		// のみ表示され、画面上で実行・解釈されない。
+		const user = userEvent.setup();
+		const dangerous = "<script>window.__pwned=true</script>";
+		const onerrorImg = '" onerror="alert(1)';
+		const danger = [{ value: dangerous }, { value: onerrorImg }];
+
+		render(
+			<ModelSelector
+				models={danger}
+				currentModelId={dangerous}
+				onModelChange={vi.fn()}
+				disabled={false}
+			/>,
+		);
+
+		const trigger = screen.getByTestId("model-selector-trigger");
+		expect(trigger).toHaveTextContent(dangerous);
+
+		await user.click(trigger);
+
+		// candidate も textContent として表示され、script タグ / onerror 属性が
+		// DOM 上に副作用を持つ要素として現れない。
+		const items = screen.getAllByRole("menuitemradio");
+		const itemTexts = items.map((el) => el.textContent ?? "");
+		expect(itemTexts).toContain(dangerous);
+		expect(itemTexts).toContain(onerrorImg);
+
+		// script タグや onerror 属性付き img が DOM に挿入されていない（React の
+		// 既定のテキストエスケープにより文字列として描画される）。
+		// onerror is technically a valid attribute name on many HTML elements,
+		// so we only assert that no element actually carries it as an attribute
+		// or that no <script> tag appears in the rendered tree.
+		expect(document.querySelectorAll("script").length).toBe(0);
+		expect(document.querySelectorAll("[onerror]").length).toBe(0);
+		// And the dangerous payload did not run.
+		expect(
+			(window as unknown as { __pwned?: boolean }).__pwned,
+		).toBeUndefined();
 	});
 });

--- a/src/components/panels/AgentChatPanel/ModelSelector.tsx
+++ b/src/components/panels/AgentChatPanel/ModelSelector.tsx
@@ -16,8 +16,6 @@ interface ModelSelectorProps {
 	disabled: boolean;
 }
 
-const AUTO_VALUE = "__auto__";
-
 export function ModelSelector({
 	models,
 	currentModelId,
@@ -25,7 +23,9 @@ export function ModelSelector({
 	disabled,
 }: ModelSelectorProps) {
 	const currentLabel =
-		models.find((m) => m.value === currentModelId)?.displayName ?? "Auto";
+		models.find((m) => m.value === currentModelId)?.value ??
+		currentModelId ??
+		"未指定";
 
 	return (
 		<DropdownMenu>
@@ -33,7 +33,7 @@ export function ModelSelector({
 				<Button
 					variant="ghost"
 					size="xs"
-					disabled={disabled || models.length === 0}
+					disabled={disabled}
 					data-testid="model-selector-trigger"
 					className="gap-1"
 				>
@@ -43,13 +43,21 @@ export function ModelSelector({
 			</DropdownMenuTrigger>
 			<DropdownMenuContent side="top" align="start">
 				<DropdownMenuRadioGroup
-					value={currentModelId ?? AUTO_VALUE}
-					onValueChange={(v) => onModelChange(v === AUTO_VALUE ? null : v)}
+					value={currentModelId ?? ""}
+					onValueChange={(v) => onModelChange(v === "" ? null : v)}
 				>
-					<DropdownMenuRadioItem value={AUTO_VALUE}>Auto</DropdownMenuRadioItem>
+					{currentModelId !== null && (
+						<DropdownMenuRadioItem
+							key="__unset__"
+							value=""
+							data-testid="model-selector-clear"
+						>
+							未指定
+						</DropdownMenuRadioItem>
+					)}
 					{models.map((m) => (
 						<DropdownMenuRadioItem key={m.value} value={m.value}>
-							{m.displayName}
+							{m.value}
 						</DropdownMenuRadioItem>
 					))}
 				</DropdownMenuRadioGroup>

--- a/src/components/panels/AgentChatPanel/ModelSelector.tsx
+++ b/src/components/panels/AgentChatPanel/ModelSelector.tsx
@@ -25,7 +25,7 @@ export function ModelSelector({
 	const currentLabel =
 		models.find((m) => m.value === currentModelId)?.value ??
 		currentModelId ??
-		"未指定";
+		"Unset";
 
 	return (
 		<DropdownMenu>
@@ -52,7 +52,7 @@ export function ModelSelector({
 							value=""
 							data-testid="model-selector-clear"
 						>
-							未指定
+							Unset
 						</DropdownMenuRadioItem>
 					)}
 					{models.map((m) => (

--- a/src/hooks/agentChatReducer.test.ts
+++ b/src/hooks/agentChatReducer.test.ts
@@ -38,6 +38,7 @@ describe("agentChatReducer", () => {
 			permissionMode: "acceptEdits" as const,
 			pendingPermissions: {},
 			availableModels: [],
+			availableModelsByBackend: {},
 			sessionModels: {},
 			backends: [],
 			selectedBackendId: null,
@@ -499,15 +500,56 @@ describe("agentChatReducer", () => {
 
 	describe("SET_AVAILABLE_MODELS", () => {
 		it("stores available models globally", () => {
-			const models = [
-				{ value: "claude-4", displayName: "Claude 4" },
-				{ value: "claude-3.5", displayName: "Claude 3.5" },
-			];
+			const models = [{ value: "claude-4" }, { value: "claude-3.5" }];
 			const next = reducer(INITIAL_STATE, {
 				type: "SET_AVAILABLE_MODELS",
 				models,
 			});
 			expect(next.availableModels).toBe(models);
+		});
+
+		it("stores available models by backend when backendId is provided", () => {
+			const models = [{ value: "claude-4" }];
+			const next = reducer(INITIAL_STATE, {
+				type: "SET_AVAILABLE_MODELS",
+				models,
+				backendId: "claude",
+			});
+			expect(next.availableModelsByBackend.claude).toBe(models);
+		});
+	});
+
+	describe("SET_BACKEND_MODELS", () => {
+		it("stores backend models and updates visible models for current backend", () => {
+			const models = [{ value: "gpt-5.5" }];
+			const state: AgentChatState = {
+				...INITIAL_STATE,
+				selectedBackendId: "codex",
+			};
+			const next = reducer(state, {
+				type: "SET_BACKEND_MODELS",
+				backendId: "codex",
+				models,
+			});
+			expect(next.availableModels).toBe(models);
+			expect(next.availableModelsByBackend.codex).toBe(models);
+		});
+
+		it("stores backend models without changing visible models for another backend", () => {
+			const visible = [{ value: "claude-4" }];
+			const codexModels = [{ value: "gpt-5.5" }];
+			const state: AgentChatState = {
+				...INITIAL_STATE,
+				selectedBackendId: "claude",
+				availableModels: visible,
+			};
+			const next = reducer(state, {
+				type: "SET_BACKEND_MODELS",
+				backendId: "codex",
+				models: codexModels,
+			});
+			expect(next.availableModels).toBe(visible);
+			expect(next.availableModelsByBackend.codex).toBe(codexModels);
 		});
 	});
 
@@ -594,11 +636,13 @@ describe("agentChatReducer", () => {
 			id: "b1",
 			name: "Backend 1",
 			available: true,
+			availableModels: [{ value: "b1-model" }],
 		};
 		const backend2: BackendInfo = {
 			id: "b2",
 			name: "Backend 2",
 			available: true,
+			availableModels: [{ value: "b2-model" }],
 		};
 
 		it("sets selectedBackendId to defaultId when selectedBackendId is null", () => {
@@ -613,6 +657,11 @@ describe("agentChatReducer", () => {
 			});
 			expect(next.backends).toEqual([backend1, backend2]);
 			expect(next.selectedBackendId).toBe("b2");
+			expect(next.availableModels).toEqual([{ value: "b2-model" }]);
+			expect(next.availableModelsByBackend).toEqual({
+				b1: [{ value: "b1-model" }],
+				b2: [{ value: "b2-model" }],
+			});
 		});
 
 		it("selects the first backend when selectedBackendId is null and defaultId is null", () => {
@@ -660,11 +709,16 @@ describe("agentChatReducer", () => {
 
 	describe("SET_SELECTED_BACKEND", () => {
 		it("updates selectedBackendId with backendId", () => {
-			const next = reducer(INITIAL_STATE, {
+			const state: AgentChatState = {
+				...INITIAL_STATE,
+				availableModelsByBackend: { b1: [{ value: "model-1" }] },
+			};
+			const next = reducer(state, {
 				type: "SET_SELECTED_BACKEND",
 				backendId: "b1",
 			});
 			expect(next.selectedBackendId).toBe("b1");
+			expect(next.availableModels).toEqual([{ value: "model-1" }]);
 		});
 
 		it("clears selectedBackendId with null", () => {

--- a/src/hooks/agentChatReducer.ts
+++ b/src/hooks/agentChatReducer.ts
@@ -21,6 +21,7 @@ export interface AgentChatState {
 	permissionMode: PermissionMode;
 	pendingPermissions: Record<string, PermissionRequest>;
 	availableModels: ModelInfo[];
+	availableModelsByBackend: Record<string, ModelInfo[]>;
 	sessionModels: Record<string, string | null>;
 	backends: BackendInfo[];
 	selectedBackendId: string | null;
@@ -51,7 +52,12 @@ export type AgentChatAction =
 			messageId: string;
 			parts: MessagePart[];
 	  }
-	| { type: "SET_AVAILABLE_MODELS"; models: ModelInfo[] }
+	| {
+			type: "SET_AVAILABLE_MODELS";
+			models: ModelInfo[];
+			backendId?: string | null;
+	  }
+	| { type: "SET_BACKEND_MODELS"; backendId: string; models: ModelInfo[] }
 	| {
 			type: "SET_SESSION_MODEL";
 			sessionId: string;
@@ -83,6 +89,42 @@ function updateMessageInSession(
 	const messages = msgs.slice();
 	messages[idx] = updater(msgs[idx]);
 	return { ...state, activeSession: { ...state.activeSession, messages } };
+}
+
+function displayBackendId(state: AgentChatState): string | null {
+	return state.activeSession?.backendId ?? state.selectedBackendId;
+}
+
+function modelsForDisplayBackend(
+	state: Pick<
+		AgentChatState,
+		| "activeSession"
+		| "selectedBackendId"
+		| "availableModelsByBackend"
+		| "availableModels"
+	>,
+): ModelInfo[] {
+	const backendId = state.activeSession?.backendId ?? state.selectedBackendId;
+	if (!backendId) return [];
+	return backendId in state.availableModelsByBackend
+		? state.availableModelsByBackend[backendId]
+		: state.availableModels;
+}
+
+function withBackendModels(
+	state: AgentChatState,
+	backendId: string,
+	models: ModelInfo[],
+): AgentChatState {
+	const availableModelsByBackend = {
+		...state.availableModelsByBackend,
+		[backendId]: models,
+	};
+	const nextState = { ...state, availableModelsByBackend };
+	return {
+		...nextState,
+		availableModels: modelsForDisplayBackend(nextState),
+	};
 }
 
 export function reducer(
@@ -158,11 +200,13 @@ export function reducer(
 				parts: action.parts,
 			}));
 		}
-		case "SET_AVAILABLE_MODELS":
-			return {
-				...state,
-				availableModels: action.models,
-			};
+		case "SET_AVAILABLE_MODELS": {
+			const backendId = action.backendId ?? displayBackendId(state);
+			if (!backendId) return { ...state, availableModels: action.models };
+			return withBackendModels(state, backendId, action.models);
+		}
+		case "SET_BACKEND_MODELS":
+			return withBackendModels(state, action.backendId, action.models);
 		case "SET_SESSION_MODEL":
 			return {
 				...state,
@@ -185,18 +229,47 @@ export function reducer(
 			};
 		}
 		case "SET_BACKENDS": {
+			const availableModelsByBackend = action.backends.reduce<
+				Record<string, ModelInfo[]>
+			>(
+				(acc, backend) => {
+					acc[backend.id] = backend.availableModels;
+					return acc;
+				},
+				{ ...state.availableModelsByBackend },
+			);
 			const selectedBackendId =
 				state.selectedBackendId ??
 				action.defaultId ??
 				(action.backends.length > 0 ? action.backends[0].id : null);
-			return {
+			const nextDisplayBackendId =
+				state.activeSession?.backendId ??
+				(state.activeSession ? null : selectedBackendId);
+			const nextState = {
 				...state,
 				backends: action.backends,
 				selectedBackendId,
+				availableModelsByBackend,
+			};
+			return {
+				...nextState,
+				availableModels: nextDisplayBackendId
+					? (availableModelsByBackend[nextDisplayBackendId] ?? [])
+					: state.activeSession
+						? state.availableModels
+						: [],
 			};
 		}
-		case "SET_SELECTED_BACKEND":
-			return { ...state, selectedBackendId: action.backendId };
+		case "SET_SELECTED_BACKEND": {
+			const nextState = {
+				...state,
+				selectedBackendId: action.backendId,
+			};
+			return {
+				...nextState,
+				availableModels: modelsForDisplayBackend(nextState),
+			};
+		}
 	}
 }
 
@@ -210,6 +283,7 @@ export const INITIAL_STATE: AgentChatState = {
 	permissionMode: "acceptEdits",
 	pendingPermissions: {},
 	availableModels: [],
+	availableModelsByBackend: {},
 	sessionModels: {},
 	backends: [],
 	selectedBackendId: null,

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -623,7 +623,7 @@ describe("useAgentChat", () => {
 			session: mockSession,
 			turnPhase: "idle",
 			selectedModel: "claude-4",
-			availableModels: [{ value: "claude-4", displayName: "Claude 4" }],
+			availableModels: [{ value: "claude-4" }],
 		} as never);
 
 		await act(async () => {
@@ -631,9 +631,7 @@ describe("useAgentChat", () => {
 		});
 
 		expect(result.current.selectedModel).toBe("claude-4");
-		expect(result.current.availableModels).toEqual([
-			{ value: "claude-4", displayName: "Claude 4" },
-		]);
+		expect(result.current.availableModels).toEqual([{ value: "claude-4" }]);
 	});
 
 	it("selectSession restores streaming state from backend response", async () => {
@@ -1002,7 +1000,7 @@ describe("useAgentChat", () => {
 			permissionMode: "acceptEdits",
 			backendId: "codex",
 		};
-		const models = [{ value: "sonnet", displayName: "Claude Sonnet" }];
+		const models = [{ value: "sonnet" }];
 		vi.mocked(sessionStore.createSession).mockResolvedValueOnce(
 			newSession as never,
 		);
@@ -1054,7 +1052,7 @@ describe("useAgentChat", () => {
 			session: newSession,
 			turnPhase: "idle",
 			selectedModel: null,
-			availableModels: [{ value: "sonnet", displayName: "Claude Sonnet" }],
+			availableModels: [{ value: "sonnet" }],
 		} as never);
 
 		await act(async () => {
@@ -1110,7 +1108,7 @@ describe("useAgentChat", () => {
 			session: newSession,
 			turnPhase: "idle",
 			selectedModel: null,
-			availableModels: [{ value: "sonnet", displayName: "Claude Sonnet" }],
+			availableModels: [{ value: "sonnet" }],
 		} as never);
 
 		await act(async () => {
@@ -1266,7 +1264,7 @@ describe("useAgentChat", () => {
 			},
 			turnPhase: "idle",
 			selectedModel: null,
-			availableModels: [{ value: "codex-mini", displayName: "Codex Mini" }],
+			availableModels: [{ value: "codex-mini" }],
 		} as never);
 
 		await act(async () => {
@@ -1279,9 +1277,7 @@ describe("useAgentChat", () => {
 			"codex",
 		);
 		expect(result.current.selectedBackendId).toBe("codex");
-		expect(result.current.availableModels).toEqual([
-			{ value: "codex-mini", displayName: "Codex Mini" },
-		]);
+		expect(result.current.availableModels).toEqual([{ value: "codex-mini" }]);
 
 		const newSession = {
 			id: "new-claude",
@@ -1848,7 +1844,7 @@ describe("useAgentChat", () => {
 				},
 				turnPhase: "idle",
 				selectedModel: "claude-4",
-				availableModels: [{ value: "claude-4", displayName: "Claude 4" }],
+				availableModels: [{ value: "claude-4" }],
 			},
 		} as never);
 
@@ -1859,9 +1855,7 @@ describe("useAgentChat", () => {
 		});
 
 		expect(result.current.selectedModel).toBe("claude-4");
-		expect(result.current.availableModels).toEqual([
-			{ value: "claude-4", displayName: "Claude 4" },
-		]);
+		expect(result.current.availableModels).toEqual([{ value: "claude-4" }]);
 	});
 });
 

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -95,7 +95,7 @@ function dispatchSessionMeta(
 	dispatch: React.Dispatch<AgentChatAction>,
 	sessionId: string,
 	response: {
-		session: { permissionMode?: PermissionMode };
+		session: { permissionMode?: PermissionMode; backendId?: string | null };
 		turnPhase: TurnPhase;
 		selectedModel: string | null;
 		availableModels: ModelInfo[];
@@ -120,6 +120,7 @@ function dispatchSessionMeta(
 	dispatch({
 		type: "SET_AVAILABLE_MODELS",
 		models: response.availableModels,
+		backendId: response.session.backendId,
 	});
 }
 

--- a/src/hooks/useAgentSdkListeners.test.ts
+++ b/src/hooks/useAgentSdkListeners.test.ts
@@ -1,8 +1,10 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, type Mock, vi } from "vitest";
+import type { AgentSdkListenerRefs } from "./useAgentSdkListeners";
 
 type ListenCallback = (event: { payload: unknown }) => void;
 type UnlistenFn = Mock;
+type TestRefs = Omit<AgentSdkListenerRefs, "dispatch"> & { dispatch: Mock };
 
 let listenResolvers: Array<{
 	resolve: (fn: UnlistenFn) => void;
@@ -39,7 +41,7 @@ vi.mock("./useSessionStore", async (importOriginal) => {
 
 const { useAgentSdkListeners } = await import("./useAgentSdkListeners");
 
-function makeRefs() {
+function makeRefs(): TestRefs {
 	return {
 		dispatch: vi.fn(),
 		activeSessionRef: { current: null },
@@ -99,7 +101,7 @@ describe("useAgentSdkListeners cancelled flag", () => {
 		}
 	});
 
-	it("registers listeners for agent-sdk-message, agent-session-state-changed, agent-streaming-updated, agent-pending-message-consumed, agent-permission-mode-changed, agent-models-updated", () => {
+	it("registers listeners for agent-sdk-message, agent-session-state-changed, agent-streaming-updated, agent-pending-message-consumed, agent-permission-mode-changed, agent-models-updated, agent-backend-models-updated", () => {
 		listenResolvers = [];
 		const refs = makeRefs();
 
@@ -112,6 +114,7 @@ describe("useAgentSdkListeners cancelled flag", () => {
 		expect(eventNames).toContain("agent-pending-message-consumed");
 		expect(eventNames).toContain("agent-permission-mode-changed");
 		expect(eventNames).toContain("agent-models-updated");
+		expect(eventNames).toContain("agent-backend-models-updated");
 		expect(eventNames).not.toContain("agent-streaming-started");
 		expect(eventNames).not.toContain("agent-query-completed");
 	});
@@ -820,10 +823,11 @@ describe("agent-pending-message-consumed event", () => {
 });
 
 describe("agent-models-updated event", () => {
-	it("dispatches SET_AVAILABLE_MODELS and SET_SESSION_MODEL when agent-models-updated is received", () => {
+	it("dispatches SET_AVAILABLE_MODELS and SET_SESSION_MODEL when agent-models-updated is received for the active session", () => {
 		listenResolvers = [];
 		listenCallbacks.clear();
 		const refs = makeRefs();
+		refs.activeSessionRef.current = { id: "session-1" } as never;
 
 		renderHook(() => useAgentSdkListeners(refs));
 		for (const { resolve } of listenResolvers) resolve(vi.fn());
@@ -831,10 +835,7 @@ describe("agent-models-updated event", () => {
 		const cb = listenCallbacks.get("agent-models-updated");
 		expect(cb).toBeDefined();
 
-		const models = [
-			{ value: "claude-4", displayName: "Claude 4" },
-			{ value: "claude-3.5-sonnet", displayName: "Claude 3.5 Sonnet" },
-		];
+		const models = [{ value: "claude-4" }, { value: "claude-3.5-sonnet" }];
 
 		cb?.({
 			payload: {
@@ -848,6 +849,36 @@ describe("agent-models-updated event", () => {
 			type: "SET_AVAILABLE_MODELS",
 			models,
 		});
+		expect(refs.dispatch).toHaveBeenCalledWith({
+			type: "SET_SESSION_MODEL",
+			sessionId: "session-1",
+			modelId: "claude-4",
+		});
+	});
+
+	it("does not dispatch SET_AVAILABLE_MODELS for another session", () => {
+		listenResolvers = [];
+		listenCallbacks.clear();
+		const refs = makeRefs();
+		refs.activeSessionRef.current = { id: "session-2" } as never;
+
+		renderHook(() => useAgentSdkListeners(refs));
+		for (const { resolve } of listenResolvers) resolve(vi.fn());
+
+		const cb = listenCallbacks.get("agent-models-updated");
+		cb?.({
+			payload: {
+				chat_session_id: "session-1",
+				available_models: [{ value: "claude-4" }],
+				selected_model: "claude-4",
+			},
+		});
+
+		const availCalls = refs.dispatch.mock.calls.filter(
+			(call: unknown[]) =>
+				(call[0] as { type: string }).type === "SET_AVAILABLE_MODELS",
+		);
+		expect(availCalls).toHaveLength(0);
 		expect(refs.dispatch).toHaveBeenCalledWith({
 			type: "SET_SESSION_MODEL",
 			sessionId: "session-1",
@@ -876,6 +907,94 @@ describe("agent-models-updated event", () => {
 			type: "SET_SESSION_MODEL",
 			sessionId: "session-1",
 			modelId: null,
+		});
+	});
+});
+
+describe("agent-backend-models-updated event", () => {
+	it("dispatches SET_BACKEND_MODELS for backend-wide model updates", () => {
+		listenResolvers = [];
+		listenCallbacks.clear();
+		const refs = makeRefs();
+
+		renderHook(() => useAgentSdkListeners(refs));
+		for (const { resolve } of listenResolvers) resolve(vi.fn());
+
+		const cb = listenCallbacks.get("agent-backend-models-updated");
+		expect(cb).toBeDefined();
+
+		const models = [{ value: "gpt-5.5" }, { value: "o3" }];
+
+		cb?.({
+			payload: {
+				backend_id: "codex",
+				available_models: models,
+			},
+		});
+
+		expect(refs.dispatch).toHaveBeenCalledWith({
+			type: "SET_BACKEND_MODELS",
+			backendId: "codex",
+			models,
+		});
+		// session 単位の payload と異なり、SET_SESSION_MODEL は dispatch しない。
+		const sessionModelCalls = refs.dispatch.mock.calls.filter(
+			(call: unknown[]) =>
+				(call[0] as { type: string }).type === "SET_SESSION_MODEL",
+		);
+		expect(sessionModelCalls).toHaveLength(0);
+	});
+
+	it("keeps backend-wide updates even when another active session backend is selected", () => {
+		listenResolvers = [];
+		listenCallbacks.clear();
+		const refs = makeRefs();
+		refs.activeSessionRef.current = {
+			id: "session-1",
+			backendId: "claude",
+		} as never;
+
+		renderHook(() => useAgentSdkListeners(refs));
+		for (const { resolve } of listenResolvers) resolve(vi.fn());
+
+		const cb = listenCallbacks.get("agent-backend-models-updated");
+		expect(cb).toBeDefined();
+
+		cb?.({
+			payload: {
+				backend_id: "codex",
+				available_models: [{ value: "gpt-5.5" }],
+			},
+		});
+
+		expect(refs.dispatch).toHaveBeenCalledWith({
+			type: "SET_BACKEND_MODELS",
+			backendId: "codex",
+			models: [{ value: "gpt-5.5" }],
+		});
+	});
+
+	it("keeps backend-wide updates when no active session is set", () => {
+		listenResolvers = [];
+		listenCallbacks.clear();
+		const refs = makeRefs();
+		refs.activeSessionRef.current = null;
+
+		renderHook(() => useAgentSdkListeners(refs));
+		for (const { resolve } of listenResolvers) resolve(vi.fn());
+
+		const cb = listenCallbacks.get("agent-backend-models-updated");
+		cb?.({
+			payload: {
+				backend_id: "codex",
+				available_models: [{ value: "gpt-5.5" }],
+			},
+		});
+
+		expect(refs.dispatch).toHaveBeenCalledWith({
+			type: "SET_BACKEND_MODELS",
+			backendId: "codex",
+			models: [{ value: "gpt-5.5" }],
 		});
 	});
 });

--- a/src/hooks/useAgentSdkListeners.ts
+++ b/src/hooks/useAgentSdkListeners.ts
@@ -65,6 +65,11 @@ interface ModelsUpdated {
 	selected_model: string | null;
 }
 
+interface BackendModelsUpdated {
+	backend_id: string;
+	available_models: ModelInfo[];
+}
+
 export interface AgentSdkListenerRefs {
 	dispatch: Dispatch<AgentChatAction>;
 	activeSessionRef: MutableRefObject<ChatSession | null>;
@@ -375,7 +380,7 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 		};
 	}, [dispatch, activeSessionRef]);
 
-	// Listen to agent-models-updated from Rust backend
+	// Listen to agent-models-updated (session 単位の更新) from Rust backend
 	useEffect(() => {
 		let unlisten: UnlistenFn | null = null;
 		let cancelled = false;
@@ -383,14 +388,48 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 		listen<ModelsUpdated>("agent-models-updated", (event) => {
 			const { chat_session_id, available_models, selected_model } =
 				event.payload;
-			dispatch({
-				type: "SET_AVAILABLE_MODELS",
-				models: available_models,
-			});
+			const activeSession = activeSessionRef.current;
+			if (activeSession?.id === chat_session_id) {
+				dispatch({
+					type: "SET_AVAILABLE_MODELS",
+					models: available_models,
+					...(activeSession.backendId
+						? { backendId: activeSession.backendId }
+						: {}),
+				});
+			}
 			dispatch({
 				type: "SET_SESSION_MODEL",
 				sessionId: chat_session_id,
 				modelId: selected_model,
+			});
+		}).then((fn) => {
+			if (cancelled) {
+				fn();
+			} else {
+				unlisten = fn;
+			}
+		});
+
+		return () => {
+			cancelled = true;
+			unlisten?.();
+		};
+	}, [dispatch, activeSessionRef]);
+
+	// Listen to agent-backend-models-updated (backend 全体向け候補更新通知)
+	// 全 backend の候補を保持し、表示対象 backend_id と一致する場合のみ現在候補にも反映する。
+	// session 単位の payload とは event 名を分離しており、選択モデルへの dispatch は行わない。
+	useEffect(() => {
+		let unlisten: UnlistenFn | null = null;
+		let cancelled = false;
+
+		listen<BackendModelsUpdated>("agent-backend-models-updated", (event) => {
+			const { backend_id, available_models } = event.payload;
+			dispatch({
+				type: "SET_BACKEND_MODELS",
+				backendId: backend_id,
+				models: available_models,
 			});
 		}).then((fn) => {
 			if (cancelled) {

--- a/src/remote/components/RemoteAgentPanel.test.tsx
+++ b/src/remote/components/RemoteAgentPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,8 +17,8 @@ function renderPanel(
 	const props: ComponentProps<typeof RemoteAgentPanel> = {
 		selectedWorktree: "/repo/worktree",
 		backends: [
-			{ id: "claude", name: "Claude", available: true },
-			{ id: "codex", name: "Codex", available: true },
+			{ id: "claude", name: "Claude", available: true, available_models: [] },
+			{ id: "codex", name: "Codex", available: true, available_models: [] },
 		],
 		selectedBackendId: "codex",
 		backendLoading: false,
@@ -288,7 +288,17 @@ describe("RemoteAgentPanel", () => {
 
 	it("sends interrupt and model set commands for the active session", async () => {
 		const user = userEvent.setup();
-		const { send, emit } = renderPanel();
+		const { send, emit } = renderPanel({
+			backends: [
+				{ id: "claude", name: "Claude", available: true, available_models: [] },
+				{
+					id: "codex",
+					name: "Codex",
+					available: true,
+					available_models: [{ value: "gpt-5.4" }],
+				},
+			],
+		});
 		emit({
 			type: "agent_session_start_response",
 			payload: {
@@ -308,7 +318,7 @@ describe("RemoteAgentPanel", () => {
 		});
 
 		await user.click(screen.getByLabelText("Interrupt agent"));
-		await user.type(screen.getByPlaceholderText("Model"), "gpt-5.4");
+		await user.selectOptions(screen.getByLabelText("Model"), "gpt-5.4");
 		await user.click(screen.getByText("Set"));
 
 		expect(send).toHaveBeenCalledWith({
@@ -319,6 +329,125 @@ describe("RemoteAgentPanel", () => {
 			type: "agent_model_set_request",
 			payload: { session_id: "session-1", model_id: "gpt-5.4" },
 		});
+	});
+
+	it("presents registered model candidates and sends the selected value", async () => {
+		const user = userEvent.setup();
+		const { send, emit } = renderPanel({
+			backends: [
+				{ id: "claude", name: "Claude", available: true, available_models: [] },
+				{
+					id: "codex",
+					name: "Codex",
+					available: true,
+					available_models: [{ value: "gpt-5.4" }],
+				},
+			],
+		});
+		emit({
+			type: "agent_session_start_response",
+			payload: {
+				success: true,
+				session_id: "session-1",
+				backend_id: "codex",
+			},
+		});
+
+		expect(screen.getByRole("option", { name: "gpt-5.4" })).toBeInTheDocument();
+		expect(screen.queryByRole("option", { name: "Unset" })).toBeNull();
+		await user.selectOptions(screen.getByLabelText("Model"), "gpt-5.4");
+		await user.click(screen.getByText("Set"));
+
+		expect(send).toHaveBeenCalledWith({
+			type: "agent_model_set_request",
+			payload: { session_id: "session-1", model_id: "gpt-5.4" },
+		});
+	});
+
+	it("keeps the model selector visible with zero candidates when backend has no models", () => {
+		const { emit } = renderPanel({
+			backends: [
+				{ id: "claude", name: "Claude", available: true, available_models: [] },
+				{ id: "codex", name: "Codex", available: true, available_models: [] },
+			],
+		});
+		emit({
+			type: "agent_session_start_response",
+			payload: {
+				success: true,
+				session_id: "session-1",
+				backend_id: "codex",
+			},
+		});
+
+		const modelSelect = screen.getByLabelText("Model");
+		const options = within(modelSelect).queryAllByRole("option");
+		expect(options).toHaveLength(0);
+		expect(screen.queryByRole("option", { name: "Unset" })).toBeNull();
+		expect(screen.queryByRole("option", { name: "gpt-5.4" })).toBeNull();
+	});
+
+	it("sends null model_id only through the clear model action", async () => {
+		const user = userEvent.setup();
+		const { send, emit } = renderPanel();
+		emit({
+			type: "agent_session_start_response",
+			payload: {
+				success: true,
+				session_id: "session-1",
+				backend_id: "codex",
+			},
+		});
+
+		await user.click(screen.getByLabelText("Clear model"));
+
+		expect(send).toHaveBeenCalledWith({
+			type: "agent_model_set_request",
+			payload: { session_id: "session-1", model_id: null },
+		});
+	});
+
+	it("renders dangerous model identifiers as plain text on remote UI", async () => {
+		// spec: メイン画面・リモート画面のいずれでも、表示時に副作用を起こしうる文字を
+		// 含むモデル識別子は文字列としてのみ表示され、画面上で実行・解釈されない。
+		const user = userEvent.setup();
+		const dangerous = "<script>window.__pwned_remote=true</script>";
+		const { send, emit } = renderPanel({
+			backends: [
+				{ id: "claude", name: "Claude", available: true, available_models: [] },
+				{
+					id: "codex",
+					name: "Codex",
+					available: true,
+					available_models: [{ value: dangerous }],
+				},
+			],
+		});
+		emit({
+			type: "agent_session_start_response",
+			payload: {
+				success: true,
+				session_id: "session-1",
+				backend_id: "codex",
+			},
+		});
+
+		expect(screen.getByRole("option", { name: dangerous })).toBeInTheDocument();
+		await user.selectOptions(screen.getByLabelText("Model"), dangerous);
+		await user.click(screen.getByText("Set"));
+
+		// 登録済み候補として提示された識別子はそのまま payload に乗る。
+		expect(send).toHaveBeenCalledWith({
+			type: "agent_model_set_request",
+			payload: { session_id: "session-1", model_id: dangerous },
+		});
+
+		// option のテキストとして表示されるため、script 実行や onerror 属性の挿入は発生しない。
+		expect(document.querySelectorAll("script").length).toBe(0);
+		expect(document.querySelectorAll("[onerror]").length).toBe(0);
+		expect(
+			(window as unknown as { __pwned_remote?: boolean }).__pwned_remote,
+		).toBeUndefined();
 	});
 
 	it("shows errors from failed agent responses", () => {

--- a/src/remote/components/RemoteAgentPanel.tsx
+++ b/src/remote/components/RemoteAgentPanel.tsx
@@ -6,6 +6,7 @@ import {
 	RefreshCw,
 	Send,
 	Square,
+	X,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { BackendInfoMsg, WsMessage } from "@/types/protocol";
@@ -167,6 +168,9 @@ export function RemoteAgentPanel({
 				case "agent_model_set_response":
 					if (!msg.payload.success) {
 						setError(msg.payload.error ?? "Agent command failed.");
+					} else if (msg.type === "agent_model_set_response") {
+						setModelId(msg.payload.model_id ?? "");
+						setError(null);
 					}
 					break;
 			}
@@ -178,6 +182,7 @@ export function RemoteAgentPanel({
 		availableBackends.find((backend) => backend.id === lockedBackendId) ??
 		availableBackends[0] ??
 		null;
+	const selectedBackendModels = selectedBackend?.available_models ?? [];
 
 	const startSession = () => {
 		if (status !== "connected" || !selectedBackend) return;
@@ -225,11 +230,23 @@ export function RemoteAgentPanel({
 
 	const applyModel = () => {
 		if (!startedSession) return;
+		if (modelId.length === 0) return;
 		send({
 			type: "agent_model_set_request",
 			payload: {
 				session_id: startedSession.sessionId,
-				model_id: modelId.trim() || null,
+				model_id: modelId,
+			},
+		});
+	};
+
+	const clearModel = () => {
+		if (!startedSession) return;
+		send({
+			type: "agent_model_set_request",
+			payload: {
+				session_id: startedSession.sessionId,
+				model_id: null,
 			},
 		});
 	};
@@ -306,18 +323,33 @@ export function RemoteAgentPanel({
 
 				{startedSession && (
 					<div className="flex gap-2">
-						<input
+						<select
 							value={modelId}
 							onChange={(event) => setModelId(event.target.value)}
-							placeholder="Model"
 							className="min-w-0 flex-1 h-9 rounded border border-border bg-background px-2 text-sm"
-						/>
+							aria-label="Model"
+						>
+							{selectedBackendModels.map((model) => (
+								<option key={model.value} value={model.value}>
+									{model.value}
+								</option>
+							))}
+						</select>
 						<button
 							type="button"
 							onClick={applyModel}
+							disabled={modelId.length === 0}
 							className="px-3 h-9 rounded border border-border text-sm"
 						>
 							Set
+						</button>
+						<button
+							type="button"
+							onClick={clearModel}
+							className="inline-flex items-center justify-center h-9 w-9 rounded border border-border"
+							aria-label="Clear model"
+						>
+							<X className="size-4" />
 						</button>
 					</div>
 				)}

--- a/src/remote/hooks/useRemoteBackends.test.ts
+++ b/src/remote/hooks/useRemoteBackends.test.ts
@@ -9,6 +9,7 @@ const makeBackend = (
 	id: "backend-1",
 	name: "Claude",
 	available: true,
+	available_models: [],
 	...overrides,
 });
 
@@ -211,6 +212,50 @@ describe("useRemoteBackends", () => {
 			payload: {},
 		});
 		expect(result.current.loading).toBe(true);
+	});
+
+	it("backend_models_updated を受信したら対象 backend の候補だけ更新される", () => {
+		let handler: ((msg: WsMessage) => void) | null = null;
+		const subscribe = vi.fn((cb: (msg: WsMessage) => void) => {
+			handler = cb;
+			return vi.fn();
+		});
+		const send = vi.fn();
+		const backends = [
+			makeBackend({
+				id: "claude",
+				available_models: [{ value: "old-claude" }],
+			}),
+			makeBackend({
+				id: "codex",
+				available_models: [{ value: "old-codex" }],
+			}),
+		];
+
+		const { result } = renderHook(() =>
+			useRemoteBackends({ subscribe, send, connected: true }),
+		);
+
+		act(() => {
+			handler?.({
+				type: "backend_list_response",
+				payload: { backends, default_id: "claude" },
+			});
+		});
+		act(() => {
+			handler?.({
+				type: "backend_models_updated",
+				payload: {
+					backend_id: "codex",
+					available_models: [{ value: "gpt-5.5" }],
+				},
+			});
+		});
+
+		expect(result.current.backends).toEqual([
+			backends[0],
+			{ ...backends[1], available_models: [{ value: "gpt-5.5" }] },
+		]);
 	});
 
 	it("アンマウント時に unsubscribe が呼ばれる", () => {

--- a/src/remote/hooks/useRemoteBackends.ts
+++ b/src/remote/hooks/useRemoteBackends.ts
@@ -52,6 +52,17 @@ export function useRemoteBackends({
 							: null)
 					);
 				});
+			} else if (msg.type === "backend_models_updated") {
+				setBackends((current) =>
+					current.map((backend) =>
+						backend.id === msg.payload.backend_id
+							? {
+									...backend,
+									available_models: msg.payload.available_models,
+								}
+							: backend,
+					),
+				);
 			}
 		});
 	}, [subscribe]);

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,5 +1,5 @@
 import type { WorkflowStatePayload } from "@/types/workflow";
-import type { MessagePart } from "./session";
+import type { MessagePart, ModelInfo } from "./session";
 
 // --- 認証 ---
 
@@ -147,11 +147,17 @@ export interface BackendInfoMsg {
 	id: string;
 	name: string;
 	available: boolean;
+	available_models: ModelInfo[];
 }
 
 export interface BackendListResponse {
 	backends: BackendInfoMsg[];
 	default_id: string | null;
+}
+
+export interface BackendModelsUpdated {
+	backend_id: string;
+	available_models: ModelInfo[];
 }
 
 export interface AgentSessionStartRequest {
@@ -252,6 +258,7 @@ export type WsMessage =
 	| { type: "agent_state_sync"; payload: AgentStateSync }
 	| { type: "backend_list_request"; payload: BackendListRequest }
 	| { type: "backend_list_response"; payload: BackendListResponse }
+	| { type: "backend_models_updated"; payload: BackendModelsUpdated }
 	| { type: "agent_session_start_request"; payload: AgentSessionStartRequest }
 	| { type: "agent_session_start_response"; payload: AgentSessionStartResponse }
 	| { type: "agent_message_request"; payload: AgentMessageRequest }

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -8,7 +8,6 @@ export type PermissionMode =
 
 export interface ModelInfo {
 	value: string;
-	displayName: string;
 }
 
 export interface PermissionRequest {
@@ -155,6 +154,7 @@ export interface BackendInfo {
 	id: string;
 	name: string;
 	available: boolean;
+	availableModels: ModelInfo[];
 }
 
 /**


### PR DESCRIPTION
Closes #946

## Summary

- `ModelInfo.display_name` を廃止し `value` に統一（Rust/TS 両方）
- 各バックエンドの対応モデルを `config.toml` で一元管理（`available_models.json` キャッシュは廃止）
- アプリ起動時に各バックエンドCLIから非同期でモデル一覧を取得し `config.toml` を自動更新（バックエンド単位 `tokio::spawn`、起動はブロックしない、部分失敗を許容）
- ユーザー／ワークフローからのモデル指定は `config.toml` 登録値に対して同一規準で検証し、未登録・形式不正・他バックエンドのモデルは明示エラーで拒否（サイレントフォールバックなし）
- モデルID 入力検証ルール（空文字／White_Space のみ／制御文字／128 文字超過／重複除去後 256 件超過を拒否）を `domain/agent_session/value_objects/model_id.rs` に集約
- 識別子は React テキストノードとして描画し XSS を防止（メイン UI / Remote UI 両方）

## 主な変更ファイル

- 新規: `docs/spec/issues-946.md`、`backends/model_catalog_sync.rs`、`backends/process_io.rs`、`domain/agent_session/`、`usecase/backend_models.rs`、`ws_server/gateway.rs`、`resources/claude-sdk-bridge-list-models.mjs`
- 49 files changed, 5433 insertions(+), 622 deletions(-)

## Test plan

- [ ] `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`
- [ ] `pnpm lint` / `pnpm test` / `pnpm build`
- [ ] 起動時に各バックエンドのモデル一覧が `config.toml` に反映される
- [ ] CLI 取得失敗時に他バックエンドの同期は継続し、当該バックエンドの既存値は維持される
- [ ] 未登録モデル指定が明示エラーで拒否される（メイン UI / Remote UI / ワークフロー経路）
- [ ] 識別子に HTML/JS を含む文字列が表示されても実行されない（メイン UI / Remote UI）
- [ ] `model_id=null` で選択解除され、暗黙の既定モデルへフォールバックしない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * バックエンドのモデル一覧が起動時及びバックエンド実行時に動的に更新されるようになりました。

* **Improvements**
  * モデル検証の厳格化により、登録されていないモデルIDは明示的に拒否されるようになりました。
  * モデル情報の表示形式を統一し、UI上の表示が簡潔になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->