### PR TITLE
docs: ワークフローエンジン進化計画の設計境界ドキュメントを追加 (#1003)

### DIFF
--- a/docs/spec/issues-1003.md
+++ b/docs/spec/issues-1003.md
@@ -1,0 +1,147 @@
+## 要求
+
+**種別**: リファクタリング（設計境界の固定 / ドキュメント整備）
+
+**ゴール**:
+Workflow Engine Evolution の milestone [01]「設計境界の固定」を完了する。具体的には、Releash のワークフローランタイムが将来的に主語として扱うべき未来形モデル（`WorkflowRun` / `NodeDefinition` / `NodeExecution` / `WorkflowCommand` / `WorkflowEvent`）の仕様と、既存モジュールにおける future core / compatibility adapter の境界を、新規設計文書として確定する。runtime behavior は変更しない。
+
+**背景**:
+現在のワークフローエンジンは、`Workflow` / `Step` / `WorkflowState` / `worktree_path` を主語とした旧モデルで実装されている。今後 CLI、Skill、structured output、approval 操作を追加していくと、UI 上の主語と engine 上の主語のずれが拡大し、互換性の圧力で設計が崩れるリスクがある。後続マイルストーン（[02] Normalized Workflow 以降）が実装に踏み込む前に、目標モデルと互換性境界をドキュメントとして固定し、北極星（north star）として参照可能にする必要がある。`docs/workflow-engine-evolution-plan.md` に概要は記載済みだが、各モデルのフィールド詳細と既存モジュールの分類はまだ確定していない。
+
+**スコープ（GitHub Issue #1003 / Milestone 57「[01] Workflow Engine Evolution - 設計境界の固定」対応範囲）**:
+
+- 未来形モデルのフィールド・責務をドキュメントとして定義する
+  - `WorkflowRun`: workflow template の 1 実行インスタンス
+  - `NodeDefinition`: 正規化後の実行単位
+  - `NodeExecution`: run 中の node 実行結果
+  - `WorkflowCommand`: state を変化させる唯一の入口
+  - `WorkflowEvent`: engine が発行する append-only な事実
+- 既存モジュールを future core / compatibility adapter のいずれに位置付けるかを明文化する
+- 新規設計文書を `docs/workflow-engine-evolution-plan.md` から north star としてリンクする
+
+**スコープ外（後続マイルストーンに委ねる）**:
+
+- Rust の struct / enum としての型コード化（[02] Normalized Workflow 以降）
+- `workflow/normalized.rs` / `workflow/run.rs` / `workflow/command.rs` / `workflow/event.rs` の新規モジュール追加
+- 既存 `engine.rs` / `commands.rs` / `state.rs` の振る舞い変更
+- CLI / API / UI の追加
+
+**制約**:
+
+- runtime behavior は一切変えない（plan doc 281-296 行目の明示的な制約）
+- 既存 `Workflow` / `Step` / `WorkflowState` YAML / JSON 互換は維持される前提を文書化する
+- ドキュメントは日本語で記述する（既存 plan doc と同じ）
+- 出力先は新規 `docs/workflow-engine-model-boundary.md` とし、plan doc からはリンクのみ追加する（plan doc 本文は大きく書き換えない）
+
+**完了条件**（plan doc の `### [01] 設計境界の固定` 完了条件に準拠）:
+
+- 未来形モデル 5 種のフィールド・責務が文書化されている
+- 既存モジュール（`schema.rs` / `validation.rs` / `engine.rs` / `state.rs` / `log.rs` / `commands.rs` / `storage.rs` / `contract.rs` / `facet.rs` / `runtime_view.rs` / `diagnostics.rs` / `session_errors.rs` / `builtin*`）が future core か compatibility adapter かを説明できる
+- `docs/workflow-engine-evolution-plan.md` から新規設計文書への参照リンクが追加されている
+- Rust / フロントエンドの実装コードは変更されない
+
+## 振る舞い定義
+
+```gherkin
+Feature: Workflow Engine Evolution の設計境界ドキュメント
+
+  Rule: 未来形モデルの仕様が north star として参照できる
+    Scenario: 後続マイルストーンの設計者が未来形モデルの責務を確認する
+      Given 設計者が後続マイルストーンに着手しようとしている
+      When 設計者が未来形モデルの責務とフィールドを参照する
+      Then WorkflowRun / NodeDefinition / NodeExecution / WorkflowCommand / WorkflowEvent それぞれの責務とフィールドが文書から読み取れる
+
+  Rule: 既存モジュールの位置付けが明確になっている
+    Scenario: 改修担当者が既存モジュールの扱いを判断する
+      Given 改修担当者がワークフローエンジンの既存モジュールに手を入れようとしている
+      When 改修担当者が当該モジュールの位置付けを確認する
+      Then そのモジュールが future core と compatibility adapter のいずれであるかが文書から読み取れる
+
+  Rule: 設計文書が plan doc から辿れる
+    Scenario: 関係者が進化計画から設計境界の詳細を参照する
+      Given 関係者が Workflow Engine Evolution の plan doc を起点に情報を辿っている
+      When 関係者が設計境界の詳細を求める
+      Then plan doc から新規設計文書への参照が存在し、設計境界の詳細に到達できる
+
+  Rule: 設計境界の固定は runtime 振る舞いを変えない
+    Scenario: マイルストーン[01]完了時点でランタイムを利用する
+      Given Workflow Engine を利用する利用者が既存のワークフロー定義を実行する
+      When マイルストーン[01]の作業が完了した状態でランタイムが動作する
+      Then ランタイムの振る舞い（既存 Workflow / Step / WorkflowState の挙動・YAML/JSON 互換）は変化していない
+
+  Rule: state を変化させる入口は WorkflowCommand に一本化される
+    Scenario: 何らかの主体がワークフローの state を変えようとする
+      Given ある主体がワークフローの state を変化させようとしている
+      When その主体が engine に対して state 変化を要求する
+      Then 要求は WorkflowCommand として表現される経路でしか受理されない
+
+  Rule: engine が発行する事実は append-only な事実列として積み上がる
+    Scenario: 何らかのきっかけで engine が事実を発行する
+      Given engine が処理を進めて事実を発行する場面に至っている
+      When engine が新しい事実を発行する
+      Then その事実は WorkflowEvent として既存の事実列に追記され、過去の事実は書き換わらない
+
+  Rule: 実行の単位は WorkflowRun として識別される
+    Scenario: 同一の workflow template から複数回の実行が行われる
+      Given 1 つの workflow template が複数回実行されている
+      When 関係者がある時点の実行を指し示そうとする
+      Then その実行は WorkflowRun として他の実行と区別して識別できる
+
+  Rule: 実行単位は正規化された NodeDefinition で表現される
+    Scenario: workflow template の中身が engine で扱われる
+      Given workflow template がさまざまな記述スタイルで定義されている
+      When engine がその template の実行単位を扱う
+      Then 各実行単位は NodeDefinition として一貫した正規化済みの表現で扱われる
+
+  Rule: run 中の各実行の結果は NodeExecution として記録される
+    Scenario: WorkflowRun の中で個々の実行単位が処理される
+      Given WorkflowRun が進行しており、その中で実行単位が処理されている
+      When ある実行単位の処理が一区切りつく
+      Then その実行の結果は NodeExecution として、所属する WorkflowRun と紐づけて記録される
+```
+
+## アーキテクチャ概要
+
+本タスクは runtime 振る舞いを変更しないドキュメント整備であるため、アーキテクチャ概要は「ドキュメント間の責務配置」と「読み手が情報を辿るフロー」を主軸に整理する。
+
+### 責務配置
+
+- `docs/workflow-engine-evolution-plan.md`（既存 / plan doc）:
+  - 担当する: マイルストーン全体の進化方針・北極星モデルの概要紹介・各マイルストーンの完了条件・新規設計文書への参照リンクの追加。
+  - 担当しない: 未来形モデル各々のフィールド詳細・既存モジュールごとの分類表・将来コードの型シグネチャ。
+- `docs/workflow-engine-model-boundary.md`（新規 / boundary doc / north star 本体）:
+  - 担当する: 未来形 5 モデル（`WorkflowRun` / `NodeDefinition` / `NodeExecution` / `WorkflowCommand` / `WorkflowEvent`）のフィールドと責務の確定記述・既存 Rust モジュールの future core / compatibility adapter 分類・「設計境界の固定」フェーズで合意した境界条件。
+  - 担当しない: Rust の型コード化・モジュール再配置・既存 plan doc の戦略記述の重複転載（参照リンクで賄う）。
+- 既存 Rust モジュール群（`src-tauri/src/workflow/`）:
+  - 担当する: 現行の runtime 振る舞い（変更なし）。本マイルストーン期間中は実装は据え置く。
+  - 担当しない: 未来形モデルの型としての存在・新規 enum/struct 追加。コードへの反映は [02] 以降。
+
+### データ/通信フロー
+
+- 設計境界の参照フロー: plan doc（north star の入口）→ boundary doc（モデル詳細・モジュール分類）→ 既存 Rust モジュール（現状の実装根拠の確認先）。読み手はこの順で辿れば、戦略 → 境界定義 → 現状実装 へ降りられる。
+- 既存モジュール位置付けの判定フロー: 改修担当者がモジュールを見る → boundary doc のモジュール分類表で future core / compatibility adapter を確認 → 当該モジュールに対する許容変更の幅を判断（future core は段階的に未来形へ寄せる / adapter は互換のみ）。
+- 未来形モデルの参照フロー: 後続マイルストーンの設計者が boundary doc 内の各モデル節（責務・フィールド・他モデルとの関係）を読む → そのまま [02] 以降の型コード化の入力として再利用する。
+
+### 状態Owner
+
+- 未来形モデル 5 種の定義（フィールド・責務・関係）: boundary doc が一次 Owner。plan doc は概要のみで、詳細の正本は boundary doc。
+- 既存モジュールの分類（future core / compatibility adapter）: boundary doc が Owner。コード側に分類メタ情報は持たない（注釈追加もしない／runtime に影響しないため）。
+- マイルストーン進行状況・完了条件: plan doc が Owner（既存通り）。
+- runtime 振る舞いの定義: 既存 Rust モジュール（コード）が Owner（変更なし）。
+
+### 境界
+
+- plan doc と boundary doc の境界: plan doc は「なぜ」「何を目指すか」「いつまでに」を語り、boundary doc は「何が」「どこに」を定義する。両者の間で詳細の重複は持たず、plan doc → boundary doc への一方向リンクで接続する。
+- boundary doc とコードの境界: boundary doc は将来形の宣言であり、現行コードへの注釈や型強制を行わない。コードは現行 runtime を変えずに残し、boundary doc とコードの差分は「未対応であること」が前提として明示される。
+- スコープ境界: 本マイルストーンの成果物はドキュメント追加・plan doc へのリンク追記のみ。Rust / TS のコード修正・新規モジュール作成・型定義の追加は本タスクの境界の外（[02] 以降）。
+- 互換性境界: 既存 `Workflow` / `Step` / `WorkflowState` の YAML / JSON 互換は維持される前提を boundary doc 内で明文化する。boundary doc は互換破壊を要求しない。
+
+### 実装に委ねること
+
+- boundary doc 内の節構成の細部（例: モデルごとに節を分けるか、共通項目をまとめるか）。
+- 既存モジュール分類の提示形式（表形式 / 箇条書き / モジュール別節）。
+- フィールド一覧の提示粒度（型名抜きの名前と説明で済ますか、暫定の型ヒントを括弧書きするか）— ただし「Rust の struct/enum としての型コード化」はスコープ外なので、確定的なシグネチャは書かない。
+- plan doc 側に追記する参照リンクの文言・配置位置（north star 章付近 or [01] マイルストーン節）。
+- boundary doc の見出し階層やアンカー名。
+- 用語ゆれの最終調整（例: 「実行単位」「ノード」「ステップ」のいずれを主表現にするか）— 振る舞い定義で使われた語彙との整合は取る。
+

--- a/docs/workflow-engine-evolution-plan.md
+++ b/docs/workflow-engine-evolution-plan.md
@@ -83,6 +83,8 @@ workflow engine は状態遷移の唯一の権威であり続ける。Agent や 
 
 既存 YAML と既存 Tauri command を維持しながら、内部の未来形モデルを明確にする。
 
+未来形モデル各々のフィールド詳細・既存モジュールの future core / compatibility adapter 分類・境界条件は、本文書から派生する north star ドキュメントとして [`workflow-engine-model-boundary.md`](./workflow-engine-model-boundary.md) にまとめている。詳細を参照する場合はそちらを正本とすること。
+
 ### Workflow Definition
 
 ユーザーが書く workflow template。既存の `Workflow` と `steps:` YAML は有効なままにする。
@@ -293,6 +295,8 @@ main agent は state transition を所有しない。approve、reject、abort、
 
 - モデルが文書化されている。
 - どの module が compatibility adapter で、どの module が future core か説明できる。
+
+成果物: [`workflow-engine-model-boundary.md`](./workflow-engine-model-boundary.md)（未来形モデル仕様と既存モジュール分類の正本）。
 
 ### [02] Normalized Workflow
 

--- a/docs/workflow-engine-model-boundary.md
+++ b/docs/workflow-engine-model-boundary.md
@@ -1,0 +1,258 @@
+# ワークフローエンジン 設計境界（north star）
+
+本文書は、Releash のワークフローランタイムが将来的に主語として扱うべき未来形モデルの仕様と、既存 Rust モジュールにおける future core / compatibility adapter の境界を確定する north star ドキュメントである。
+
+位置付け・前提・採用方針の戦略記述は [`workflow-engine-evolution-plan.md`](./workflow-engine-evolution-plan.md) を一次 Owner とする。本文書では戦略の重複を避け、「何が」「どこに」属するかを定義することに徹する。
+
+## 本文書のスコープ
+
+- 担当する:
+  - 未来形 5 モデル（`WorkflowRun` / `NodeDefinition` / `NodeExecution` / `WorkflowCommand` / `WorkflowEvent`）の責務とフィールド定義。
+  - 既存 Rust モジュール（`src-tauri/src/workflow/`）の future core / compatibility adapter 分類。
+  - マイルストーン [01] で合意した境界条件（互換性境界・state 入口・event 性質）。
+- 担当しない:
+  - Rust の struct / enum としての型コード化（[02] 以降）。
+  - 既存モジュールの再配置・型強制・注釈追加。
+  - plan doc の戦略記述（採用判断・マイルストーン進行管理）の重複転載。
+
+## 前提となる互換性境界
+
+本文書で定義する未来形モデルは、既存ランタイムの互換性を破壊しない。`docs/workflow-engine-evolution-plan.md` の「互換性境界」節に従い、本マイルストーン以降も以下が維持される前提を持つ。
+
+- 既存 YAML（`Workflow` / `Step` / `ParallelStep` / `AggregateConfig` を含む `steps:` 記法）は有効なまま deserialize できる。
+- 既存 Tauri command（`commands.rs` で公開される workflow 操作）は呼び出し可能であり続ける。
+- 既存 `WorkflowState` JSON は deserialize 互換を保つ（フィールドの後方互換維持）。
+- 新モデルは旧概念を曲げない。旧 `Step` から新 `NodeDefinition` への変換は専用の normalization レイヤーに閉じ込める（[02] 以降）。
+- `worktree_path` 主語の API は、active `run_id` を解決する互換 wrapper として残す。
+
+## 未来形モデル
+
+5 モデルの関係を概念図で示す。
+
+```text
+Workflow Definition (既存 YAML / Workflow / Step)
+        |
+        v
+  normalize（[02] 以降の責務）
+        |
+        v
+NodeDefinition*  ← run の中の各実行単位を正規化した shape
+        |
+        |  StartRun (WorkflowCommand)
+        v
+WorkflowRun ───────────────► WorkflowEvent*（append-only）
+        |
+        |  node 実行の都度
+        v
+NodeExecution*（run に紐づく実行結果）
+
+外部 (UI / CLI / Agent / Remote) ──► WorkflowCommand ──► engine
+```
+
+それぞれのモデルは、現行コードの対応物が部分的に存在するが、本文書では「将来このように扱う」という宣言にとどめ、現行コードへの注釈や型強制は行わない。
+
+### WorkflowRun
+
+workflow template を 1 回起動した実行インスタンスを識別するモデル。後続マイルストーン以降、UI / CLI / API は worktree ではなく `run_id` を主語にする。
+
+責務:
+
+- 1 回の実行インスタンスを他の実行と区別して識別する（同一 template の複数回実行が並行・継起しうる）。
+- 実行の現在状態と関連リソース（worktree、chat session、現在 node）を集約する。
+- 実行の進行に応じて状態の遷移と監査可能なタイムスタンプを保持する。
+
+フィールド（暫定）:
+
+- `run_id`: 実行インスタンスを一意に識別する ID。初期実装では既存 `WorkflowState.execution_id` を `run_id` として扱える。
+- `workflow_name`: どの workflow template を実行しているか。
+- `task`: 実行起動時に渡された task 表現（自由テキスト相当）。
+- `status`: 実行のライフサイクル状態（pending / running / awaiting_approval / completed / failed / aborted など）。最終的な状態語彙は [03] / [04] で確定する。
+- `worktree_path`: 実行が紐づく worktree。互換 wrapper 経由の lookup の起点でもある。
+- `chat_session_id`: 実行と紐づく main agent session（存在する場合）。
+- `current_node_name`: 現在処理中（または直近停止した）NodeDefinition の名前。
+- `trigger_source`: 起動経路（UI / CLI / remote / agent など）。
+- `started_at` / `updated_at` / `completed_at`: 状態遷移を辿れる時刻情報。
+- `error_reason`: failure / abort 時の理由。
+
+他モデルとの関係:
+
+- `WorkflowEvent` の発行主体に紐づく一次 ID は `run_id`。
+- `NodeExecution` は必ず 1 つの `WorkflowRun` に属する（`run_id` を保持する）。
+- `WorkflowCommand` の多くは対象 run を `run_id` で指す。
+
+### NodeDefinition
+
+run の中で扱われる、正規化済みの実行単位。既存 `Step` / `ParallelStep` / `AggregateConfig` のさまざまな記述スタイルを、engine 内部で一貫した shape に揃える。
+
+責務:
+
+- run 中の各実行単位を「種別 + 振る舞いに必要な設定」として均一に表現する。
+- YAML の記述ゆれ（`mode` の有無、`parallel` block の有無、暗黙の `agent` 既定など）を吸収し、engine 中核がスタイルに依存しないようにする。
+- node 種別ごとの実行戦略の入口を一本化する。
+
+フィールド（暫定）:
+
+- `node_name`: 当該実行単位の名前。run 内で識別子として用いる。
+- `node_type`: `agent` / `bash` / `approval` / `parallel` / `aggregate` などの実行種別。[13] で `bash` の取り扱いが具体化する。
+- `agent_config`: type=agent 系の振る舞い設定（policy / knowledge / instruction / output_contract、pass_previous_response、pass_output_from、inline_prompt、collect 等）。
+- `command_config`: type=bash 系の command 表現（command 文字列、exit code 取り扱い方針など）。
+- `approval_config`: type=approval 系の必要承認条件・承認後遷移ルール。
+- `parallel_children`: type=parallel 時に並列実行する子 NodeDefinition 群と aggregate 戦略。
+- `transition_rules`: 完了結果に応じた次 node 解決ルール（既存 `TransitionRule` 相当）。
+- `cycle_guard` / `resets_cycle_for`: 既存サイクルガード意味論をそのまま受け継ぐ。
+- `model` / `permission` などの実行コンテキスト override。
+
+旧 `Step` との対応関係（変換規則の例示）:
+
+```text
+mode 未指定 / mode: auto  -> node_type: agent
+mode: approval            -> node_type: approval
+mode: interactive         -> node_type: agent（対話前提の agent として扱う）
+type: bash                -> node_type: bash
+parallel: [...]           -> node_type: parallel + parallel_children
+aggregate: ...            -> parallel node の aggregate 振る舞い
+```
+
+他モデルとの関係:
+
+- `WorkflowRun` の進行中、現在 node は NodeDefinition で指される。
+- `NodeExecution` は 1 つの NodeDefinition の 1 回分の実行を表す（同じ NodeDefinition が `run_index` 違いで複数回実行されることを許容する）。
+
+### NodeExecution
+
+WorkflowRun の中で 1 つの NodeDefinition が実行された結果。状態遷移の足跡として、append-only に積まれる NodeExecution 列と、`WorkflowEvent` 列とで監査性を担保する。
+
+責務:
+
+- ある実行単位の 1 回分の処理結果を「所属 run + node + 反復回」で識別可能に記録する。
+- 構造化出力・契約検証結果・トークン使用量・失敗理由など、後続 UI / CLI / Skill が観測する観測単位を保持する。
+- 既存 `StepHistoryEntry` / `StepOutput` / `ParallelStepState` が部分的に担っている情報を、`run_id` 主語で一元化する場として位置付ける。
+
+フィールド（暫定）:
+
+- `run_id`: 所属する WorkflowRun。
+- `node_name`: 実行された NodeDefinition の名前。
+- `node_type`: 実行時点での node 種別（NodeDefinition と整合）。
+- `status`: 当該実行のライフサイクル状態（pending / running / awaiting_approval / succeeded / failed / aborted など）。
+- `run_index`: 同一 node の何回目の実行か（cycle / 再試行を識別）。
+- `session_id`: 当該実行に対応する session（agent 実行時など、存在する場合）。
+- `started_at` / `completed_at`: 実行のタイムスタンプ。
+- `result`: 実行結果の自由テキスト要約（互換用途）。
+- `structured_output`: 構造化出力。output_contract に従って検証済みの場合は contract の type 名と JSON を保持する。
+- `output_contract`: 検証に用いた contract 種別の識別子。
+- `token_usage`: 当該実行のトークン使用量。
+- `error_reason`: failure / abort 時の理由。
+- `child_executions`: parallel node の場合、子 NodeExecution（または子の参照）を集約する。
+
+他モデルとの関係:
+
+- WorkflowRun:NodeExecution = 1:N。
+- NodeDefinition:NodeExecution = 1:N（同一 node の複数回実行を許容）。
+- 主要な状態変化は `WorkflowEvent` として併発的に発行され、NodeExecution と event log の両方から実行履歴を辿れる。
+
+### WorkflowCommand
+
+workflow state を変化させる唯一の入口。UI button、CLI、remote UI、Agent action は、すべてこの command に落として engine に到達する。`run_id` を主語とする。
+
+責務:
+
+- engine の状態遷移エンドポイントを typed に集約する（main agent の自由文や implicit な副作用で state が動くことを禁ずる）。
+- 旧 Tauri command や旧 worktree 主語 API は、command への変換器（compat adapter）を経由してこの入口に揃える。
+- 認可・冪等性・stale target の判定など、state 入口の前段で要求される検査の起点となる。
+
+主要 command（暫定）:
+
+- `StartRun { workflow_name, task, worktree_path, trigger_source }`: 新規 run の起動。
+- `AbortRun { run_id, reason? }`: 進行中 run の中断。
+- `ApproveNode { run_id, node_name, comment? }`: approval node に対する承認。
+- `RejectNode { run_id, node_name, reason }`: approval node に対する却下。
+- `SubmitOutput { run_id, node_name, contract_type, payload }`: 構造化出力の提出。
+- `CompleteNode { run_id, node_name, ... }`: node 完了の通知（内部用途中心）。
+- `FailNode { run_id, node_name, reason }`: node 失敗の通知（内部用途中心）。
+
+他モデルとの関係:
+
+- 受理された command は engine 内で state 遷移を発生させ、結果として 1 つ以上の `WorkflowEvent` が発行される。
+- 命令の到達経路（UI / CLI / Agent / Remote）に依らず、同一 command であれば engine からは等価に扱われる。
+- 旧 API（worktree_path 主語）は active `run_id` を解決して command に変換する compat adapter として扱われる。
+
+### WorkflowEvent
+
+engine が発行する append-only な事実列。`WorkflowCommand` の処理結果として（あるいは engine 内部の遷移の都度）発行され、過去の event は書き換わらない。
+
+責務:
+
+- engine の状態遷移を観測可能な事実として外部に提示する（UI timeline、CLI logs、main agent narrator、remote sync が共通購読する語彙）。
+- 既存 `WorkflowLogEvent` / NDJSON ログとの共存を維持しつつ、新 event 語彙へ段階的に寄せる土台になる。
+- 「事実」と「現在状態」を分離する: 現在状態は `WorkflowRun` / `NodeExecution` から読み、履歴は event 列から辿る。
+
+主要 event（暫定）:
+
+- `RunStarted { run_id, workflow_name, task, worktree_path, started_at }`
+- `NodeStarted { run_id, node_name, node_type, run_index, started_at }`
+- `NodeCompleted { run_id, node_name, run_index, status, result?, structured_output?, completed_at }`
+- `ApprovalRequested { run_id, node_name, requested_at }`
+- `ApprovalResolved { run_id, node_name, decision, comment?, resolved_at }`
+- `OutputSubmitted { run_id, node_name, contract_type, payload_summary, submitted_at }`
+- `ValidationPassed { run_id, node_name, contract_type, validated_at }`
+- `ValidationFailed { run_id, node_name, contract_type, reason, validated_at }`
+- `RunCompleted { run_id, completed_at }`
+- `RunFailed { run_id, reason, failed_at }`
+- `RunAborted { run_id, reason?, aborted_at }`
+
+不変条件:
+
+- event は append-only。発行済み event の内容は書き換えない。撤回も新たな event（補正 event / abort 等）として表現する。
+- 同じ事実を別経路で二度発行しない（例: command 経由の遷移と内部遷移で重複発行しない）ことを engine の責務とする。
+
+他モデルとの関係:
+
+- 1 件の `WorkflowCommand` 受理は 0 件以上の `WorkflowEvent` 発行に対応する（command 拒否時は 0 件もありうる）。
+- `WorkflowRun` / `NodeExecution` の現在状態は、論理的には event 列のリプレイから導けるが、実装上は派生キャッシュとして保持してよい。
+
+## 既存モジュールの分類（future core / compatibility adapter）
+
+`src-tauri/src/workflow/` 配下の既存モジュールを、本マイルストーン時点の運用観点で future core / compatibility adapter のいずれに位置付けるかを示す。本マイルストーンではコードに注釈を入れず、本文書を一次 Owner とする。
+
+分類の語彙:
+
+- **future core**: 未来形 5 モデル（Run / Node / Command / Event）に直接寄せていく中核責務。将来は新モデルに対して語る形にリファクタリングされる。
+- **compatibility adapter**: 旧概念（`Workflow` / `Step` / `WorkflowState` / `worktree_path`）を未来形モデルへ橋渡しする責務。互換性維持のため、旧 API / 旧 YAML / 旧 JSON の入口として残る。future core からも再利用される補助も、一次責務が旧概念側にあるものはここに分類する。
+
+### 分類表
+
+| モジュール | 分類 | 担当する責務（現状） | 未来形モデルとの関係 |
+| --- | --- | --- | --- |
+| `schema.rs` | compatibility adapter | ユーザー記述の `Workflow` / `Step` / `ParallelStep` / `AggregateConfig` などの YAML スキーマ定義。 | 旧 `Step` を `NodeDefinition` へ正規化する変換の入力。本モジュール自体は YAML 入口として残り続ける。 |
+| `validation.rs` | compatibility adapter | `Workflow` スキーマの静的検証（名前重複、未知 next、facet 参照欠落など）。 | YAML レイヤーの検証は引き続き必要。`NodeDefinition` 化後の検証は [02] 以降の新モジュール（normalized 層）が担う。 |
+| `engine.rs` | future core | 状態遷移の権威。step 実行、approval、parallel/aggregate、cycle guard、contract 検証の中枢。 | 将来は `WorkflowCommand` を入口、`WorkflowEvent` を出口とする shape へ寄せる。現時点では旧モデル上で動作する future core 候補。 |
+| `state.rs` | compatibility adapter | UI 向け `WorkflowState`、`StepHistoryEntry`、`StepOutput`、`ParallelStepState`、`TokenUsage` などのシリアライズ shape。 | 多くのフィールドは `NodeExecution` の前身。互換 deserialize を維持しつつ、新モデルへ段階的に投影する対象。 |
+| `log.rs` | future core（vocabulary は adapter 寄り） | append-only な `WorkflowEventLog` / `WorkflowLogEvent` の NDJSON 永続化。 | 仕組み（append-only 性質）は `WorkflowEvent` と整合。語彙は旧 `step_*` 命名のため、`WorkflowEvent` 語彙へ段階的に寄せる。 |
+| `commands.rs` | compatibility adapter | Tauri / local API command の wrapper 群。UI / Remote の現行操作口。 | 旧 `worktree_path` 主語の入口を `WorkflowCommand` へ変換する adapter として残る。新 CLI / API も最終的にここから `WorkflowCommand` を介する。 |
+| `storage.rs` | compatibility adapter | workflow YAML 定義の保存・読み込み・ビルトイン保護。 | 旧 `Workflow` YAML 入口側の永続化を担い、future core からも参照されうるが一次責務は旧概念側にある。run / event の永続化は別レイヤー（[03] 以降）。 |
+| `contract.rs` | future core | `<workflow_output>` の抽出と output contract の検証・repair prompt 生成。 | `WorkflowCommand::SubmitOutput` 検証と `OutputSubmitted` / `ValidationPassed` / `ValidationFailed` event の中核ロジック。 |
+| `facet.rs` | compatibility adapter | policy / knowledge / instruction / output_contract のファセット解決。 | 旧 `Step` の facet 参照解決を一次責務として担い、`NodeDefinition.agent_config` の素材としても再利用される。一次入口は旧概念側にある。 |
+| `runtime_view.rs` | compatibility adapter | `WorkflowState` 上から step 関連 session id を集約するビュー処理。 | UI / session 連携の互換補助。長期的には `NodeExecution` ベースのビューに置き換わる候補。 |
+| `diagnostics.rs` | compatibility adapter | YAML レイヤーの追加診断（facet 欠落、参照不一致など）。 | `validation.rs` と同様に YAML 入口側の責務。 |
+| `session_errors.rs` | compatibility adapter | workflow 由来エラーの redaction ヘルパ。 | 旧 `WorkflowState` / 旧 session 連携で生じるエラー文言の整形を一次責務とし、future core 側からも再利用されうるが入口は旧概念側にある。 |
+| `builtin.rs` / `builtin/` / `builtin_facets/` | compatibility adapter | curated built-in workflow / facet の同梱。 | 旧 YAML 入口の curated assets として機能する。将来 [14] で template 追加が進んでも本モジュール群の役割（旧 YAML レイヤーへの同梱・提供）は変わらない。 |
+
+### 補足: ランタイム振る舞いとの境界
+
+本分類はあくまで「将来どちらの責務へ寄せるか」の宣言である。本マイルストーン期間中は、上記いずれのモジュールにも振る舞い変更を加えない。コード上にも分類メタ情報を持たない（注釈追加もしない）。runtime 振る舞いの一次 Owner は引き続き既存 Rust モジュール群（コード）であり、本文書は将来形の宣言として独立に維持される。
+
+## 設計境界の不変条件（マイルストーン [01] 合意）
+
+本マイルストーンで以下を境界として固定する。後続マイルストーンで実装に踏み込む際は、これらを前提とする。
+
+- state を変化させる入口は `WorkflowCommand` に一本化される。旧 Tauri command や旧 worktree 主語 API も、最終的に compat adapter を通じて `WorkflowCommand` に変換されて engine に到達する。
+- engine が発行する事実は `WorkflowEvent` の append-only な事実列として積み上がる。発行済み event は書き換わらず、撤回や補正も追加 event として表現される。
+- 実行の単位は `WorkflowRun` として識別される。worktree 主語の参照は active `run_id` 解決を経て扱われる。
+- workflow template の実行単位は、engine 内部では `NodeDefinition` の正規化済み表現で扱う。YAML 記述スタイルのゆれは正規化レイヤーが吸収する。
+- 1 回の node 実行結果は `NodeExecution` として記録され、所属 `WorkflowRun` および対応する `NodeDefinition` に紐づく。
+- 旧 YAML / 旧 `WorkflowState` JSON / 旧 Tauri command は互換性が維持される。新設計を旧概念に合わせて曲げず、旧概念を新モデルへ adapter する。
+
+## 関連文書
+
+- 戦略・採用判断・マイルストーン進行: [`workflow-engine-evolution-plan.md`](./workflow-engine-evolution-plan.md)
+- 既存実装の現状根拠（runtime 振る舞いの一次 Owner）: `src-tauri/src/workflow/` 配下の Rust モジュール群。


### PR DESCRIPTION
## Summary

- Workflow Engine Evolution の milestone [01]「設計境界の固定」に対応するドキュメント整備
- 未来形モデル（`WorkflowRun` / `NodeDefinition` / `NodeExecution` / `WorkflowCommand` / `WorkflowEvent`）の責務とフィールドを north star として `docs/workflow-engine-model-boundary.md` に確定
- 既存モジュールの future core / compatibility adapter 分類を明文化し、`docs/workflow-engine-evolution-plan.md` から参照リンクを追加
- runtime / 実装コードの変更は無し（plan doc に明示された制約に準拠）

Closes #1003

## Test plan

- [ ] `docs/workflow-engine-evolution-plan.md` から `docs/workflow-engine-model-boundary.md` へのリンクが機能することを確認
- [ ] 未来形モデル 5 種のフィールド・責務が文書から読み取れることを確認
- [ ] 既存モジュール（`schema.rs` / `engine.rs` / `state.rs` / `commands.rs` / `storage.rs` / `contract.rs` / `facet.rs` / `runtime_view.rs` 他）の分類が記述されていることを確認
- [ ] Rust / フロントエンドのコード変更が無いこと（差分はドキュメントのみ）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* ワークフローエンジンのアーキテクチャ設計仕様書を追加しました。将来のコアモデルの責務定義、既存モジュールの設計上の位置付け、段階的な進化計画、および既存機能との互換性保証の指針を明文化しています。これによりチーム全体で設計ビジョンが共有可能になります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/1004?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->