### PR TITLE
feat: workflow engine の state 変化を typed Command / Event boundary に一本化 (#1013)

### DIFF
--- a/docs/spec/issues-1013.md
+++ b/docs/spec/issues-1013.md
@@ -1,0 +1,167 @@
+# issues-1013: Workflow Engine Evolution - Command / Event Boundary
+
+関連: [GitHub Issue #1013](https://github.com/siro33950/releash/issues/1013) / マイルストーン [04] / [`workflow-engine-evolution-plan.md`](../workflow-engine-evolution-plan.md) / [`workflow-engine-model-boundary.md`](../workflow-engine-model-boundary.md) / 先行 [issues-1011](./issues-1011.md)
+
+## 要求
+
+**種別**: 新機能
+
+**ゴール**: workflow engine の state 変化を typed な `WorkflowCommand` 経由に一本化し、engine が発行する事実列を typed な `WorkflowEvent` に一本化する。具体的には以下が満たされること。
+
+- workflow state を変化させる入口として `WorkflowCommand` 型が存在し、`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode` の 4 つの command が typed に表現される。
+- 上記 4 つの command に対する command handler が engine 側に実装され、UI / Tauri command / 内部呼び出し元から typed command を経由して engine に到達する経路が成立する。
+- 既存 Tauri command（workflow 操作系：起動 / 中断 / 承認 / 却下）は、入口形を破壊的に変更してよく、内部で `WorkflowCommand` を組み立てて engine に渡す形に置換される。後方互換 wrapper は要求しない。
+- engine が発行する append-only な事実列を `WorkflowEvent` 型に一本化する。本 issue では `WorkflowEvent` 語彙の確立と、本 issue 対象 4 command（`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode`）に対応する event 発行点の `WorkflowEvent` への置換を範囲とする。既存 `WorkflowLogEvent` 列挙体・NDJSON event log は新語彙へ完全置換し、旧 NDJSON 在庫は破棄前提とする。`CompleteNode` / `FailNode` 等の engine 内部発行点の typed 化は本 issue では対象外（[05] へ振り分け）。
+- 上記 4 command の handler および対応する WorkflowEvent 発行に対して内部 path のテストが存在する。
+
+**スコープ外**: 以下は後続マイルストーンに明示的に振り分け済み。
+
+- read-only run APIs / CLI（[05]）: `list_workflow_runs` / `get_workflow_run` / `get_workflow_run_log` / `get_workflow_run_state` 等。
+- **engine 内部 typed 遷移 command の `WorkflowCommand::CompleteNode` / `FailNode` の導入（[05] に追記）**: 外部入口を持たない engine 内部用途中心 command。NodeCompleted / NodeFailed event 発行点の typed 化として [05] の観測経路整備と同マイルストーンに揃える。本振り分けに伴い `docs/workflow-engine-evolution-plan.md` [05] 節と `docs/workflow-engine-model-boundary.md` の該当箇所を本 issue の作業で更新済み。
+- mutating CLI（[06]）: `releash workflow approve|reject|abort` 等の CLI 入口。本 issue は内部 command 層までを対象とし、CLI バイナリは含めない。
+- Workflow Panel / Command Center UI（[07]）。
+- structured output 提出（[08]）: `WorkflowCommand::SubmitOutput` および `OutputForm CLI`。本 issue で型として導入することはしない。
+- bash node 実行系統（[13]）。
+- main-agent narrator への typed event 配信と user decision の CLI/API 戻り経路整備（[16]）。
+
+**現状温存**: agent 返信テキスト解釈に基づく engine 内部の分岐ロジック（aggregate の LGTM マッチング、`<workflow_output>` 抽出など step agent 出力解釈経路）は本 issue では廃止対象としない。plan doc [08] L437 で `<workflow_output>` 抽出は fallback として維持する方針が明記されており、これらは廃止ではなく現状の振る舞いを維持する。[04] 完了条件「state transition が main-agent free text に依存しない」の "main-agent" は user-facing narrator を指し、step agent 出力解釈とは別軸である。本 issue では user decision 系の 4 command（`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode`）を typed 化することで完了条件を満たす。
+
+**背景**: マイルストーン [03] までで workflow 実行は `run_id` を主語として参照できるようになり、API・engine 内部キー・persistence のすべてが `run_id` を一次キーとする形に揃った（[issues-1011](./issues-1011.md) 参照）。一方、state を変化させる入口は依然として個別の Tauri command の引数列として散在しており、authorization / 冪等性 / stale target 判定 / 経路非依存性（UI から呼ばれても CLI から呼ばれても等価に扱う）といった共通検査の起点が存在しない。今後の [05] 以降の read-only API / [06] mutating CLI / [07] Workflow Panel / [16] Main Agent Mediation はいずれも「state 変化は同一の typed command を経由する」「engine の事実は同一の typed event 語彙で観測する」ことを前提とする。本 issue はその土台として、Command / Event の boundary を確立する。
+
+**前提**: マイルストーン [03] Run Store / Run ID 完了済み。`run_id` 主語の API・engine 内部キー・`workflow_runs/{run_id}.json` 永続化はすでに成立している。
+
+## 関連マイルストーン上の位置
+
+- 直接の依存元: [02] Normalized Workflow / [03] Run Store。
+- 直接の依存先: [05] Read-Only Run APIs + CLI / [06] Mutating CLI / [07] Workflow Panel / [16] Main Agent Mediation。
+- 本 issue は内部 boundary の確立に閉じ、CLI バイナリ・UI パネル・外部観測経路は後続に委ねる。
+
+## 振る舞い定義
+
+```gherkin
+Feature: Workflow Engine の Command / Event Boundary
+
+  Rule: workflow の state は typed command の受理によってのみ変化する
+    Scenario: ユーザーが workflow run の起動を要求する
+      Given ユーザーが起動可能な workflow を選択している
+      And ユーザーがその workflow を起動できる認可済み主体である
+      When ユーザーが run の起動を要求する
+      Then 新しい run が開始される
+
+    Scenario: ユーザーが進行中の run の中断を要求する
+      Given 進行中の workflow run が存在する
+      And ユーザーがその run を操作できる認可済み主体である
+      When ユーザーがその run の中断を要求する
+      Then その run が中断される
+
+    Scenario: ユーザーが承認待ち node の承認を要求する
+      Given 承認待ちの workflow node が存在する
+      And ユーザーがその node を判断できる認可済み主体である
+      When ユーザーがその node の承認を要求する
+      Then その node が承認された判断として受理される
+
+    Scenario: ユーザーが承認待ち node の却下を要求する
+      Given 承認待ちの workflow node が存在する
+      And ユーザーがその node を判断できる認可済み主体である
+      When ユーザーがその node の却下を要求する
+      Then その node が却下された判断として受理される
+
+  Rule: 同一意図の command は呼び出し経路に依らず等価に扱われる
+    Scenario: 同じ意図の command が異なる入口から発行される
+      Given ユーザーが同じ意図を異なる入口から表明できる
+      When ユーザーがいずれかの入口から意図を表明する
+      Then どの入口を経由しても workflow engine は同じ振る舞いを示す
+
+  Rule: 権限の無い / 対象不在 / 既決の command は state 変化を起こさない
+    Scenario: 認可されていない主体が command を要求する
+      Given 対象 run / node を操作する権限を持たない主体である
+      When その主体が対象 run / node に対する command を要求する
+      Then workflow engine の state は変化せず、その command は受理されない
+
+    Scenario: 存在しない run / node を対象にした command が要求される
+      Given 対象として指定された run / node が workflow engine に存在しない
+      When その存在しない run / node に対する command が要求される
+      Then workflow engine の state は変化せず、その command は受理されない
+
+    Scenario: 既に終了した run に対する操作 command が要求される
+      Given 対象の workflow run は既に終了している
+      When その run に対する中断 command が要求される
+      Then workflow engine の state は変化せず、その command は受理されない
+
+    Scenario: 既に判断済みの node に対して同一意図の command が再度要求される
+      Given 対象の workflow node に対する承認 / 却下の判断は既に受理されている
+      When 同一意図の判断 command が再度要求される
+      Then 2 度目以降の command は state を変化させず、最初の判断が維持される
+
+  Rule: 本 issue が typed 化する経路の state 変化は typed event の append-only な列として記録される
+    Scenario: 本 issue 対象 command の受理によって state 変化が発生する
+      Given workflow engine が稼働している
+      When 本 issue 対象 command（起動 / 中断 / 承認 / 却下）の受理によって state 変化が起こる
+      Then 対応する事実が typed event として末尾に追記される
+
+    Scenario: 観測者が workflow の進行を辿る
+      Given 過去に発生した workflow の事実列が記録されている
+      When 観測者がその run の事実列を参照する
+      Then 観測者は統一された event 語彙で進行を辿れる
+
+  Rule: command 受理サイクル内で event append / 永続化が失敗した場合、engine state は command 受理前の状態に完全復元される
+    Scenario: state mutation 後の event append が失敗する
+      Given 本 issue 対象 command が受理されようとしている
+      When command handler 内で state mutation を行った後に event append または永続化が失敗する
+      Then engine state（履歴・変数・current_step_index 等を含む WorkflowExecution 全体）は mutation 直前の状態に完全に戻され、追加副作用は一切実行されない
+
+    Scenario: 部分復元は許容されない
+      Given command handler が mutation 直前の WorkflowExecution snapshot を保持している
+      When mutation 後の event append / Run Store sync / 永続化のいずれかが失敗する
+      Then handler は保持している snapshot で WorkflowExecution 全体を一括復元する（特定フィールドのみを戻す部分 rollback は行わない）
+```
+
+## アーキテクチャ概要
+
+本 issue は「state を変化させる入口の typed 化」と「engine が発行する事実列の typed 化」を、内部 boundary として確立する。CLI バイナリ・UI パネル・engine 内部の `CompleteNode` / `FailNode` typed 化は後続マイルストーンに委ねる（前掲スコープ外参照）。
+
+### 責務配置
+
+- **`workflow/command.rs`（新設）**: `WorkflowCommand` 型と受理結果型（`WorkflowCommandResult`）を所有する。本 issue では `StartRun` / `AbortRun` / `ApproveNode` / `RejectNode` の 4 variant を typed に表現することのみを担い、ハンドラ実体は持たない。`SubmitOutput` / `CompleteNode` / `FailNode` は本 issue では導入しない。**sentinel 禁止**: `WorkflowCommandResult` から特定 variant への変換ヘルパー（特に `Accepted` を空文字列 `run_id` に sentinel 化する変換）を本ファイルでは提供しない。typed 境界からの薄い変換（`Result<String, _>` / `Result<(), _>` への射影）は呼び出し側 Tauri adapter（`commands.rs`）が `match` で variant 別に行い、本来到達しない variant は内部不整合として `Err` に変換する。
+- **`workflow/event.rs`（新設）**: `WorkflowEvent` 型を所有する。append-only な事実列の型と NDJSON 表現を担う。`WorkflowLogEvent` 由来の語彙を新 vocabulary（`RunStarted` / `NodeStarted` / `NodeCompleted` / `ApprovalRequested` / `ApprovalResolved` / `RunCompleted` / `RunFailed` / `RunAborted` 等）に完全置換する形で再定義する。旧 NDJSON 在庫を読む責務は担わない。
+- **`workflow/engine.rs`（future core / 既存）**: 4 command に対する command handler を engine 側の入口として実装する。既存の `start_workflow` / `abort_workflow_by_run_id` / `handle_approval` は command handler に統合される（method の再編は実装に委ねる）。state 遷移の権威であり続け、`WorkflowEvent` 発行点を engine 内部の単一経路に集約する（重複発行禁止）。state transition は agent free text に依存しない（user decision 4 command の範囲）。**rollback owner**: command 受理サイクル内で event append / 永続化失敗時の atomic rollback は本ファイルが owner となる。各 command handler は mutation 直前の `WorkflowExecution` 全体の snapshot を保持し、append / sync / persist のいずれかが失敗した場合に `*exec = snapshot_before;` の形で `WorkflowExecution` 全フィールド（履歴・変数・state・current_step_index 等）を一括復元する。部分復元用 helper は導入しない。
+- **`workflow/commands.rs`（compat adapter / 既存）**: 既存 Tauri command（`start_workflow` / `abort_workflow` / `approve_workflow_step` および却下相当）は、内部で `WorkflowCommand` を組み立てて engine の command 入口に渡す薄い変換層に置換される。入口形は破壊的に変更してよく、後方互換 wrapper は導入しない。
+- **`workflow/log.rs`（既存）**: 旧 `WorkflowLogEvent` 列挙体・在庫互換コードは削除し、`WorkflowEvent` を NDJSON で append する書き込み機構の責務に縮退する。旧 NDJSON 在庫は破棄前提で扱う。
+- **`workflow/run.rs`（既存 / Run Store）**: run lifecycle（`WorkflowRun` / `RunStatus`）の所有責務は変えない。状態更新は command handler 経由でのみ呼ばれる。本 issue で schema は変更しない。
+- **フロントエンド（`src/`）**: 既存の invoke 呼び出し点を typed command 引数に合わせて更新する以外、ロジックは追加しない。`rust-first-logic.md` を厳守する。
+
+### データ/通信フロー
+
+- **起動**: UI / Remote → Tauri command（`start_workflow`） → `WorkflowCommand::StartRun` 組み立て → engine command handler → run 開始 → `WorkflowEvent::RunStarted` を発行（log.rs 経由で NDJSON 追記） → UI 同期。
+- **中断**: UI / Remote → Tauri command（`abort_workflow`） → `WorkflowCommand::AbortRun { run_id, .. }` → engine command handler → run 終了 → `WorkflowEvent::RunAborted` 発行。
+- **承認 / 却下**: UI / Remote → Tauri command（`approve_workflow_step` および却下相当） → `WorkflowCommand::ApproveNode` / `RejectNode` → engine command handler → approval 解決 → `WorkflowEvent::ApprovalResolved`（必要に応じて後続 node の `NodeStarted` 等）を発行。
+- **観測**: 本 issue 対象 4 command（`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode`）経由の state 変化に対応する event 発行は、engine 内の単一発行点を経由し、`WorkflowEvent` として NDJSON に append される。`CompleteNode` / `FailNode` 等の本 issue スコープ外の内部発行点は対象外（前掲スコープ外参照）。observer は run_id を主語に event 列を辿れる。
+
+### 状態Owner
+
+- **`WorkflowCommand`（in-flight）**: 値オブジェクト。所有者なし（呼び出しのたびにスタック上で生成）。永続化しない。
+- **command 検査結果（authorization / 冪等性 / stale target 判定）**: engine 内の command handler。検査ロジックの実体は engine（`engine.rs`）に置く。
+- **`WorkflowEvent` 列（過去事実）**: `log.rs` 経由で NDJSON ファイルが一次 owner。発行点は engine の単一経路。
+- **`WorkflowRun` lifecycle（現在状態）**: `run.rs` の Run Store（active map + `workflow_runs/{run_id}.json`）。command handler の結果として更新される。
+- **`WorkflowState` / `StepHistoryEntry` 等の既存 UI 投影**: 引き続き `state.rs` が owner（本 issue では shape を変えない）。
+
+### 境界
+
+- **外部入口 → engine**: Tauri command・内部呼び出し元は engine の private method を直接叩かず、必ず `WorkflowCommand` を経由する。新規入口（CLI / agent 等）も同じ境界に揃える前提を本 issue で確立する。
+- **engine → 観測者**: state 遷移の事実は `WorkflowEvent` の append-only 列としてのみ外部化される。発行済み event は書き換わらない。撤回・補正も追加 event として表現する。
+- **新旧境界**: 旧 `WorkflowLogEvent` 語彙・旧 NDJSON 在庫は本 issue で廃止する。互換 wrapper は導入しない。
+- **scope の境界**: 本 issue は 4 command（`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode`）と対応する event 発行点に閉じる。`CompleteNode` / `FailNode` / `SubmitOutput` / read-only API / CLI バイナリ / Workflow Panel UI は導入しない。
+- **agent 返信解釈の温存境界**: aggregate の LGTM マッチング・`<workflow_output>` 抽出など step agent 出力解釈経路は本 issue では削除も typed 化もしない。
+- **atomic mutation 境界**: command 受理サイクル（command 受理 → state mutation → event append → 永続化 → 副作用）は WorkflowExecution に対する atomic な単位として扱う。mutation 後の append / 永続化失敗時には、mutation 直前の `WorkflowExecution` snapshot に**完全復元**する。state / current_step_index のみを戻す部分 rollback は禁止する（履歴や変数の更新が残ったまま required event が欠落する不整合を構造的に排除する）。
+- **テスト境界**: 本 issue 対象 4 command の routing / 受理判定 / event append / 拒否時 no-append / 受理時 state mutation の検証は、production の `WorkflowEngine::dispatch` を直接呼ぶ harness 経由で行う。`AppHandle` 依存は `tauri::test`（`mock_builder` / `mock_app`）で構築した実 `AppHandle` で満たす。production dispatch と別に match 分岐を再実装する test-only の並行 dispatcher（影 dispatcher）の導入は禁止する。
+
+### 実装に委ねること
+
+- `WorkflowCommand` / `WorkflowEvent` の各 variant の具体的なフィールド shape（型名・field 名・`Option` 化の粒度）。
+- command dispatcher のシグネチャ（一括 `dispatch(cmd: WorkflowCommand)` か variant 別 `handle_*` か）。
+- engine 内既存メソッド（`start_workflow` / `abort_workflow_by_run_id` / `handle_approval`）の改名・分割・private 化の粒度。
+- 旧 `WorkflowLogEvent` variant から新 `WorkflowEvent` variant へのマッピング切り分け（特に `OutputCollected` / `ParallelStarted` / `ParallelStepStarted` 等の置換語彙）と、`NodeStarted` / `NodeCompleted` で parallel 子 node をどう表現するかの具体形。
+- 既存 Tauri command の引数 typed 化の粒度（呼び出し側互換は不要だが、フロント側 invoke 引数の最小変更は実装に委ねる）。
+- command handler 内の認可・冪等性・stale target 判定の具体的判定条件（既存 engine 振る舞いと等価であれば実装判断でよい）。
+- 新規モジュール（`command.rs` / `event.rs`）の内部分割（同一ファイル内 enum か、サブモジュール化か）。
+- `WorkflowEvent` NDJSON のファイル配置・ファイル名規約（既存 `WorkflowEventLog` 設計の踏襲可否を含む）。

--- a/docs/workflow-engine-evolution-plan.md
+++ b/docs/workflow-engine-evolution-plan.md
@@ -187,7 +187,7 @@ RunFailed
 RunAborted
 ```
 
-既存の `WorkflowEventLog` は、現在の log 互換性を維持しつつ、この event vocabulary に近づける。
+既存の `WorkflowEventLog` は `WorkflowEvent` NDJSON adapter に縮退する。旧 `WorkflowLogEvent` 語彙と旧 NDJSON 在庫の互換は維持せず、リリース時に破棄される前提で扱う。
 
 ## 互換性境界
 
@@ -315,7 +315,7 @@ main agent は state transition を所有しない。approve、reject、abort、
 ```
 
 - `built-in/spec-driven-development.yml` を新 schema で書き直す（既存挙動と等価）。
-- `state.rs::WorkflowState.workflow_definition` と `log.rs::WorkflowLogEvent::WorkflowStarted.workflow_definition` の型を新 `Workflow` に置換する（在庫 JSON / NDJSON は破棄前提）。
+- `state.rs::WorkflowState.workflow_definition` と `event.rs::WorkflowEvent::RunStarted.workflow_definition` の型を新 `Workflow` に揃える（在庫 JSON / 旧 NDJSON は破棄前提）。
 - `engine.rs` / `contract.rs` は旧 schema 型を一切 import しない状態にする。
 - `validation.rs` / `diagnostics.rs` / `storage.rs` / `facet.rs` / `builtin.rs` / `runtime_view.rs` の compat adapter 群と、`commands.rs` / `agent_commands.rs` / `session_commands.rs` / `session/mod.rs` / `workflow_state_presenter.rs` の caller 群を新型に追従させる。
 
@@ -354,7 +354,7 @@ main agent は state transition を所有しない。approve、reject、abort、
 - `WorkflowCommand` を追加する。
 - start、approve、reject、abort の command handler を追加する。
 - 既存 Tauri command は残しつつ wrapper 化する。
-- 既存 `WorkflowLogEvent` と共存できる形で `WorkflowEvent` を追加する。
+- 既存 `WorkflowLogEvent` を廃止し、`WorkflowEvent` NDJSON へ完全置換する。
 
 完了条件:
 
@@ -364,7 +364,7 @@ main agent は state transition を所有しない。approve、reject、abort、
 
 ### [05] Read-Only Run APIs + CLI
 
-目的: 外部 caller が workflow run を観測できるようにする。
+目的: 外部 caller が workflow run を観測できるようにし、engine 内部の node 完了/失敗遷移も typed command として揃える。
 
 作業:
 
@@ -378,11 +378,16 @@ main agent は state transition を所有しない。approve、reject、abort、
   - `workflow runs`
   - `workflow status <run-id>`
   - `workflow logs <run-id>`
+- engine 内部の typed 遷移 command を追加する:
+  - `WorkflowCommand::CompleteNode`
+  - `WorkflowCommand::FailNode`
+  - これらは外部入口（UI / CLI / Agent）には公開せず、engine 内部の状態遷移を typed に表現するためのもの。NodeCompleted / NodeFailed event の発行点として、観測経路（API / CLI）整備と同じ marker で揃える。
 
 完了条件:
 
 - running workflow を `run_id` で inspect できる。
 - completed workflow の log を `run_id` で読める。
+- engine 内部の node 完了/失敗遷移が `CompleteNode` / `FailNode` typed command 経由で行われる。
 
 ### [06] Mutating CLI
 
@@ -569,4 +574,3 @@ src-tauri/src/workflow/event.rs     # [04] WorkflowEvent 出口（NDJSON vocabul
 Future core は Run / Node / Command / Event を見る。
 Compatibility adapter が Step / WorkflowState / worktree_path をその model へ変換する。
 ```
-

--- a/docs/workflow-engine-model-boundary.md
+++ b/docs/workflow-engine-model-boundary.md
@@ -194,8 +194,10 @@ workflow state を変化させる唯一の入口。UI button、CLI、remote UI�
 - `ApproveNode { run_id, node_name, comment? }`: approval node に対する承認。
 - `RejectNode { run_id, node_name, reason }`: approval node に対する却下。
 - `SubmitOutput { run_id, node_name, contract_type, payload }`: 構造化出力の提出。
-- `CompleteNode { run_id, node_name, ... }`: node 完了の通知（内部用途中心）。
-- `FailNode { run_id, node_name, reason }`: node 失敗の通知（内部用途中心）。
+- `CompleteNode { run_id, node_name, ... }`: node 完了の通知（内部用途中心。マイルストーン [05] で導入）。
+- `FailNode { run_id, node_name, reason }`: node 失敗の通知（内部用途中心。マイルストーン [05] で導入）。
+
+`CompleteNode` / `FailNode` はマイルストーン [04] では導入せず、観測経路（API / CLI）整備と同じマイルストーン [05] で typed 化される。マイルストーン [04] の対象は外部入口を伴う 4 command（`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode`）に限定される。
 
 他モデルとの関係:
 
@@ -210,7 +212,7 @@ engine が発行する append-only な事実列。`WorkflowCommand` の処理結
 責務:
 
 - engine の状態遷移を観測可能な事実として外部に提示する（UI timeline、CLI logs、main agent narrator、remote sync が共通購読する語彙）。
-- 既存 `WorkflowLogEvent` / NDJSON ログとの共存を維持しつつ、新 event 語彙へ段階的に寄せる土台になる。
+- 既存 `WorkflowLogEvent` 語彙を置換し、`WorkflowEvent` の NDJSON 列を唯一の event log vocabulary として扱う。旧 NDJSON 在庫は破棄前提で、互換 reader は持たない。
 - 「事実」と「現在状態」を分離する: 現在状態は `WorkflowRun` / `NodeExecution` から読み、履歴は event 列から辿る。
 
 主要 event（暫定）:
@@ -252,9 +254,9 @@ engine が発行する append-only な事実列。`WorkflowCommand` の処理結
 | --- | --- | --- | --- |
 | `schema.rs` | future core 寄り（YAML 入口） | 新 `Workflow`（template 定義）/ `NodeDefinition` の YAML スキーマ定義。`type: agent | bash | approval | parallel` で node 種別を表現する。 | `NodeDefinition` を直接 YAML deserialize 先として保持する。旧 schema 型は [02] で削除済み。 |
 | `validation.rs` | compatibility adapter | 新 `Workflow` スキーマの静的検証（名前重複、未知 next、facet 参照キーの形式、parallel 子の制約など）。`facet` 本文（解決済み内容）は参照しない。本文の解決失敗は `facet.rs` 側で扱う。 | YAML レイヤーの検証は引き続き必要。`NodeDefinition` ベースで検証する。 |
-| `engine.rs` | future core | 状態遷移の権威。step 実行、approval、parallel/aggregate、cycle guard、contract 検証の中枢。 | 将来は `WorkflowCommand` を入口、`WorkflowEvent` を出口とする shape へ寄せる。現時点では旧モデル上で動作する future core 候補。 |
+| `engine.rs` | future core | 状態遷移の権威。step 実行、approval、parallel/aggregate、cycle guard、contract 検証の中枢。 | `WorkflowCommand` を入口、`WorkflowEvent` を出口とする shape を担う。 |
 | `state.rs` | compatibility adapter | UI 向け `WorkflowState`、`StepHistoryEntry`、`StepOutput`、`ParallelStepState`、`TokenUsage` などのシリアライズ shape。 | 多くのフィールドは `NodeExecution` の前身。互換 deserialize を維持しつつ、新モデルへ段階的に投影する対象。 |
-| `log.rs` | future core（vocabulary は adapter 寄り） | append-only な `WorkflowEventLog` / `WorkflowLogEvent` の NDJSON 永続化。 | 仕組み（append-only 性質）は `WorkflowEvent` と整合。語彙は旧 `step_*` 命名のため、`WorkflowEvent` 語彙へ段階的に寄せる。 |
+| `log.rs` | future core（永続化 adapter） | append-only な `WorkflowEventLog` の NDJSON 永続化。 | `WorkflowEvent` をそのまま append/read する。旧 `WorkflowLogEvent` / 旧 NDJSON 在庫との互換は持たない。 |
 | `commands.rs` | compatibility adapter | Tauri / local API command の wrapper 群。UI / Remote の現行操作口。 | 旧 `worktree_path` 主語の入口を `WorkflowCommand` へ変換する adapter として残る。新 CLI / API も最終的にここから `WorkflowCommand` を介する。 |
 | `storage.rs` | compatibility adapter | workflow YAML 定義の保存・読み込み・ビルトイン保護。 | 新 `Workflow` / `NodeDefinition` の YAML 入口側の永続化を担い、future core からも参照されうるが一次責務は YAML 入口側にある。run / event の永続化は別レイヤー（[03] 以降）。 |
 | `contract.rs` | future core | `<workflow_output>` の抽出と output contract の検証・repair prompt 生成。 | `WorkflowCommand::SubmitOutput` 検証と `OutputSubmitted` / `ValidationPassed` / `ValidationFailed` event の中核ロジック。 |

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -90,3 +90,6 @@ vendored-openssl = ["git2/vendored-openssl"]
 
 [dev-dependencies]
 tempfile = "3"
+# [04] / spec [04] テスト境界: production `WorkflowEngine::dispatch` を直接呼ぶ harness で
+# 実 `AppHandle` を構築するために tauri の test feature を有効化する。
+tauri = { version = "2.11", features = ["tray-icon", "image-png", "test"] }

--- a/src-tauri/src/backends/bridge_common.rs
+++ b/src-tauri/src/backends/bridge_common.rs
@@ -208,8 +208,8 @@ pub(crate) fn dev_bridge_path(backend_id: &str) -> PathBuf {
         .join(dev_name)
 }
 
-pub(crate) fn resolve_bridge_script(
-    app: &tauri::AppHandle,
+pub(crate) fn resolve_bridge_script<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     backend_id: &str,
 ) -> Result<PathBuf, String> {
     #[cfg(debug_assertions)]
@@ -265,9 +265,20 @@ const STREAMING_PENDING_PART_LIMIT: usize = 1000;
 /// operation, soft cap (allowed to overflow) while delivery is failing.
 const STREAMING_PENDING_BYTE_LIMIT: usize = 256 * 1024;
 
-fn backend_runtime_config(app: &tauri::AppHandle, backend_id: &str) -> BackendRuntimeConfig {
+fn backend_runtime_config<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    backend_id: &str,
+) -> BackendRuntimeConfig {
     app.try_state::<Arc<crate::backends::AgentBackendRegistry>>()
-        .and_then(|registry| registry.runtime_config(backend_id, app))
+        .and_then(
+            |registry| match registry.runtime_config_for(backend_id, app) {
+                Ok(config) => Some(config),
+                Err(e) => {
+                    log::warn!("backend '{backend_id}' runtime config could not be resolved: {e}");
+                    None
+                }
+            },
+        )
         .unwrap_or_default()
 }
 
@@ -415,9 +426,9 @@ pub fn cleanup_orphan_processes(app_data_dir: &Path) {
     }
 }
 
-fn persist_streaming_parts(
+fn persist_streaming_parts<R: tauri::Runtime>(
     session_store: &SessionStore,
-    app: &tauri::AppHandle,
+    app: &tauri::AppHandle<R>,
     chat_session_id: &str,
     message_id: &str,
     parts: &[MessagePart],
@@ -457,8 +468,8 @@ fn persist_streaming_parts(
     }
 }
 
-fn emit_session_state_changed(
-    app: &tauri::AppHandle,
+fn emit_session_state_changed<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     chat_session_id: &str,
     turn_phase: TurnPhase,
     exit_code: Option<i64>,
@@ -484,8 +495,8 @@ fn emit_session_state_changed(
 /// `streaming_parts`). Treating the WS channel as always-true here matches
 /// that contract; callers that need to simulate a WS-side failure (unit
 /// tests) drive `apply_streaming_emit_result` directly.
-fn emit_streaming_parts(
-    app: &tauri::AppHandle,
+fn emit_streaming_parts<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     chat_session_id: &str,
     message_id: &str,
     parts: Vec<MessagePart>,
@@ -686,8 +697,8 @@ fn force_flush_pending_streaming<F>(
 /// pending buffer is empty (prevents idle-tick re-delivery and double-flush
 /// from forced-flush paths). On success, clears pending and updates
 /// `last_stream_emit_at`. On failure, retains both so the next flush retries.
-fn flush_streaming(
-    app: &tauri::AppHandle,
+fn flush_streaming<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     proc: &mut AgentProcess,
     chat_session_id: &str,
     message_id: &str,
@@ -980,8 +991,8 @@ fn apply_bridge_eof_crash(
 /// 状態遷移時に AgentStatusCenter へ通知し、必要に応じて Webhook 送信を行う統一エントリ。
 /// session_store から ChatSession を引いて worktree_path / SessionState を取得する。
 /// `session_state_override` を渡すと、ストア値より優先される（Bridge crash 時など）。
-pub(crate) fn notify_status_transition(
-    app: &tauri::AppHandle,
+pub(crate) fn notify_status_transition<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     session_store: &Arc<SessionStore>,
     chat_session_id: &str,
     turn_phase: TurnPhase,
@@ -1052,7 +1063,11 @@ pub(crate) fn notify_status_transition(
 
 const CLOSE_TIMEOUT_SECS: u64 = 5;
 
-fn emit_permission_mode_changed(app: &tauri::AppHandle, chat_session_id: &str, mode: &str) {
+fn emit_permission_mode_changed<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    chat_session_id: &str,
+    mode: &str,
+) {
     use tauri::Emitter;
     let _ = app.emit(
         "agent-permission-mode-changed",
@@ -1067,9 +1082,9 @@ fn emit_permission_mode_changed(app: &tauri::AppHandle, chat_session_id: &str, m
 /// Spec issues-947: 保存値の読み取り失敗時は SDK 値に fallback せず、log::error! を残して
 /// runtime/UI を更新せずに通知の処理だけスキップする（保存値が edit/full のセッションを
 /// 誤って readonly に落とさないため）。後段の `write_bridge_command` 失敗も log に記録する。
-async fn handle_sdk_permission_mode_notification(
+async fn handle_sdk_permission_mode_notification<R: tauri::Runtime>(
     sdk_mode: &str,
-    app: &tauri::AppHandle,
+    app: &tauri::AppHandle<R>,
     session_store: &std::sync::Arc<crate::session::SessionStore>,
     handles: &std::sync::Arc<tokio::sync::Mutex<crate::backends::bridge_common::AgentProcessMap>>,
     chat_session_id: &str,
@@ -1704,8 +1719,8 @@ fn accumulate_sdk_message(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn spawn_bridge_process(
-    app: &tauri::AppHandle,
+async fn spawn_bridge_process<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     session_store: &Arc<SessionStore>,
     chat_session_id: &str,
@@ -2506,8 +2521,8 @@ fn try_mark_streaming_timer_active(proc: &mut AgentProcess) -> bool {
 /// surface buffered content within one interval. Exits when the turn ends
 /// and the buffer is fully drained, on generation mismatch, or on crash.
 /// Idempotent: a second call while a timer is already alive is a no-op.
-fn spawn_streaming_timer(
-    app: &tauri::AppHandle,
+fn spawn_streaming_timer<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     chat_session_id: &str,
     proc: &mut AgentProcess,
@@ -2775,8 +2790,8 @@ pub async fn get_session(
 /// 初期モデルはセッション作成時 (`create_session_with_initial_model`) に解決して
 /// 永続化されているため、spawn 経路では「`selected_model == None` は常に
 /// 明示的に未指定」を意味する。暗黙の既定モデルへのフォールバックはしない。
-fn get_persisted_spawn_info(
-    app: &tauri::AppHandle,
+fn get_persisted_spawn_info<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     session_store: &SessionStore,
     chat_session_id: &str,
 ) -> Result<(Option<String>, Option<String>, String), String> {
@@ -2810,8 +2825,8 @@ fn persisted_spawn_info_from_session(
         .unwrap_or((None, None, CLAUDE_BACKEND_ID.to_string()))
 }
 
-pub(crate) async fn start_agent_session_internal(
-    app: &tauri::AppHandle,
+pub(crate) async fn start_agent_session_internal<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     session_store: &Arc<SessionStore>,
     chat_session_id: &str,
@@ -2870,8 +2885,8 @@ pub(crate) async fn start_agent_session_internal(
 /// Core logic for starting a new agent turn: spawn Bridge if needed, send prompt.
 /// Used by send_agent_message and pending message consumption.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn start_agent_turn(
-    app: &tauri::AppHandle,
+pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     session_store: &Arc<SessionStore>,
     chat_session_id: &str,
@@ -2925,8 +2940,8 @@ pub(crate) async fn start_agent_turn(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn start_agent_turn_locked(
-    app: &tauri::AppHandle,
+async fn start_agent_turn_locked<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     session_store: &Arc<SessionStore>,
     chat_session_id: &str,
@@ -2979,8 +2994,8 @@ async fn start_agent_turn_locked(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn start_agent_turn_with_runtime_spawner<F, Fut>(
-    app: Option<&tauri::AppHandle>,
+async fn start_agent_turn_with_runtime_spawner<R: tauri::Runtime, F, Fut>(
+    app: Option<&tauri::AppHandle<R>>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     chat_session_id: &str,
     permission_mode: &str,
@@ -3009,8 +3024,8 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn start_agent_turn_with_runtime_spawner_locked<F, Fut>(
-    app: Option<&tauri::AppHandle>,
+async fn start_agent_turn_with_runtime_spawner_locked<R: tauri::Runtime, F, Fut>(
+    app: Option<&tauri::AppHandle<R>>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     chat_session_id: &str,
     permission_mode: &str,
@@ -3133,8 +3148,8 @@ fn pending_turn_start_failed_log_message() -> &'static str {
 /// Acquires `session_runtime_lock(chat_session_id)` internally via the standard
 /// `start_agent_turn` path. Callers must NOT hold the lock for this session id,
 /// otherwise tokio Mutex non-reentrancy will deadlock (see issues-929).
-async fn start_pending_message_turn(
-    app: &tauri::AppHandle,
+async fn start_pending_message_turn<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     session_store: &Arc<SessionStore>,
     chat_session_id: &str,
@@ -3228,8 +3243,8 @@ pub async fn interrupt_agent_query(
     Ok(())
 }
 
-pub(crate) async fn close_agent_session_internal(
-    app: &tauri::AppHandle,
+pub(crate) async fn close_agent_session_internal<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     chat_session_id: &str,
 ) -> Result<(), String> {
@@ -4277,8 +4292,8 @@ pub async fn prepare_image_attachments_from_paths(
 /// AgentSessionを開始し、プロンプトを送信する。
 /// メッセージの追加(human + agent)とstart_agent_turnをまとめて行う。
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn start_agent_turn_internal(
-    app: &tauri::AppHandle,
+pub(crate) async fn start_agent_turn_internal<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     session_store: &Arc<SessionStore>,
     chat_session_id: &str,
@@ -4302,8 +4317,8 @@ pub(crate) async fn start_agent_turn_internal(
 
 /// Runtime lock acquired by the caller variant used by workflow step startup.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn start_agent_turn_internal_locked(
-    app: &tauri::AppHandle,
+pub(crate) async fn start_agent_turn_internal_locked<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     session_store: &Arc<SessionStore>,
     chat_session_id: &str,
@@ -6316,7 +6331,7 @@ mod tests {
         let spawn_count = Arc::new(AtomicUsize::new(0));
 
         start_agent_turn_with_runtime_spawner(
-            None,
+            None::<&tauri::AppHandle>,
             &handles,
             &session_id,
             "edit",
@@ -6361,7 +6376,7 @@ mod tests {
         let spawn_count = Arc::new(AtomicUsize::new(0));
 
         start_agent_turn_with_runtime_spawner(
-            None,
+            None::<&tauri::AppHandle>,
             &handles,
             &session_id,
             "edit",
@@ -6398,7 +6413,7 @@ mod tests {
             let spawn_count = Arc::clone(&spawn_count);
             tokio::spawn(async move {
                 start_agent_turn_with_runtime_spawner(
-                    None,
+                    None::<&tauri::AppHandle>,
                     &handles,
                     &session_id,
                     "edit",
@@ -6453,7 +6468,7 @@ mod tests {
             let spawn_count = Arc::clone(&spawn_count);
             async move {
                 start_agent_turn_with_runtime_spawner(
-                    None,
+                    None::<&tauri::AppHandle>,
                     &handles,
                     &session_id,
                     "edit",
@@ -6483,7 +6498,7 @@ mod tests {
             let spawn_count = Arc::clone(&spawn_count);
             async move {
                 start_agent_turn_with_runtime_spawner(
-                    None,
+                    None::<&tauri::AppHandle>,
                     &handles,
                     &session_id,
                     "edit",
@@ -6731,7 +6746,7 @@ mod tests {
     async fn approval_chat_adjustment_send_path_keeps_session_and_updates_latest_output() {
         let worktree = tempfile::tempdir().unwrap();
         let worktree_path = worktree.path().to_string_lossy().to_string();
-        let engine = Arc::new(WorkflowEngine::new());
+        let engine = Arc::new(WorkflowEngine::new_for_test());
         let data_dir = tempfile::tempdir().unwrap();
         let session_store = Arc::new(SessionStore::default());
         let session = create_session_internal(
@@ -10074,7 +10089,14 @@ mod tests {
             "models": [{"value": "gpt-5.5"}, {"value": "o3"}]
         });
 
-        handle_supported_models_message(None, &handles, Some(&*registry), "sess-1", &msg).await;
+        handle_supported_models_message(
+            None::<&tauri::AppHandle>,
+            &handles,
+            Some(&*registry),
+            "sess-1",
+            &msg,
+        )
+        .await;
 
         // config に書き込まれている
         let cfg = config.get_config().unwrap();
@@ -10111,7 +10133,14 @@ mod tests {
 
         // models 配列無し → all-or-nothing で拒否
         let msg = serde_json::json!({"type": "supported_models"});
-        handle_supported_models_message(None, &handles, Some(&*registry), "sess-1", &msg).await;
+        handle_supported_models_message(
+            None::<&tauri::AppHandle>,
+            &handles,
+            Some(&*registry),
+            "sess-1",
+            &msg,
+        )
+        .await;
 
         let cfg = config.get_config().unwrap();
         assert_eq!(cfg.agents.codex.models, vec!["existing".to_string()]);
@@ -10143,7 +10172,14 @@ mod tests {
         }
 
         let msg = serde_json::json!({"type": "supported_models", "models": []});
-        handle_supported_models_message(None, &handles, Some(&*registry), "sess-1", &msg).await;
+        handle_supported_models_message(
+            None::<&tauri::AppHandle>,
+            &handles,
+            Some(&*registry),
+            "sess-1",
+            &msg,
+        )
+        .await;
 
         let cfg = config.get_config().unwrap();
         assert_eq!(cfg.agents.codex.models, vec!["existing".to_string()]);

--- a/src-tauri/src/backends/claude.rs
+++ b/src-tauri/src/backends/claude.rs
@@ -195,7 +195,10 @@ impl AgentBackend for ClaudeBackend {
         Ok(models)
     }
 
-    fn runtime_config(&self, _app: &tauri::AppHandle) -> BackendRuntimeConfig {
+    fn runtime_config(
+        &self,
+        _app_config: Option<&crate::config::AppConfig>,
+    ) -> BackendRuntimeConfig {
         BackendRuntimeConfig {
             bridge_init_options: serde_json::Map::new(),
         }

--- a/src-tauri/src/backends/codex.rs
+++ b/src-tauri/src/backends/codex.rs
@@ -129,8 +129,17 @@ fn error_message_for_failure(status_code: Option<i32>) -> String {
     )
 }
 
-pub(crate) fn configured_cli_path(app: &tauri::AppHandle) -> Option<String> {
+pub(crate) fn configured_cli_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> Option<String> {
     app.try_state::<std::sync::Arc<crate::config::AppConfig>>()
+        .and_then(|cfg_state| cfg_state.get_config().ok())
+        .and_then(|cfg| cfg.agents.codex.cli_path)
+        .filter(|path| !path.trim().is_empty())
+}
+
+fn configured_cli_path_from_config(
+    app_config: Option<&crate::config::AppConfig>,
+) -> Option<String> {
+    app_config
         .and_then(|cfg_state| cfg_state.get_config().ok())
         .and_then(|cfg| cfg.agents.codex.cli_path)
         .filter(|path| !path.trim().is_empty())
@@ -375,12 +384,15 @@ impl AgentBackend for CodexBackend {
         Ok(models)
     }
 
-    fn runtime_config(&self, app: &tauri::AppHandle) -> BackendRuntimeConfig {
+    fn runtime_config(
+        &self,
+        app_config: Option<&crate::config::AppConfig>,
+    ) -> BackendRuntimeConfig {
         let mut bridge_init_options = serde_json::Map::new();
         bridge_init_options.insert(
             "codexCliPath".to_string(),
             serde_json::Value::String(
-                configured_cli_path(app).unwrap_or_else(|| "codex".to_string()),
+                configured_cli_path_from_config(app_config).unwrap_or_else(|| "codex".to_string()),
             ),
         );
 

--- a/src-tauri/src/backends/mod.rs
+++ b/src-tauri/src/backends/mod.rs
@@ -9,6 +9,7 @@ pub mod runtime_coordinator;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tauri::Manager;
 use tauri::State;
 use tokio::sync::Mutex;
 
@@ -137,7 +138,7 @@ pub trait AgentBackend: Send + Sync {
     }
 
     /// Bridge 起動時に必要なバックエンド固有の設定を返す。
-    fn runtime_config(&self, _app: &tauri::AppHandle) -> BackendRuntimeConfig {
+    fn runtime_config(&self, _app_config: Option<&AppConfig>) -> BackendRuntimeConfig {
         BackendRuntimeConfig::default()
     }
 
@@ -330,8 +331,17 @@ impl AgentBackendRegistry {
             .collect())
     }
 
-    pub fn runtime_config(&self, id: &str, app: &tauri::AppHandle) -> Option<BackendRuntimeConfig> {
-        self.get(id).map(|backend| backend.runtime_config(app))
+    /// Bridge 起動時に必要な backend 固有 runtime config を registry 経由で解決する。
+    pub fn runtime_config_for<R: tauri::Runtime>(
+        &self,
+        id: &str,
+        app: &tauri::AppHandle<R>,
+    ) -> Result<BackendRuntimeConfig, String> {
+        let backend = self
+            .get(id)
+            .ok_or_else(|| format!("バックエンド '{id}' がレジストリに登録されていません"))?;
+        let app_config = app.try_state::<Arc<AppConfig>>();
+        Ok(backend.runtime_config(app_config.as_deref().map(Arc::as_ref)))
     }
 
     /// 指定されたバックエンドIDを検証し、未指定の場合はデフォルトを解決する。

--- a/src-tauri/src/backends/model_catalog_sync.rs
+++ b/src-tauri/src/backends/model_catalog_sync.rs
@@ -88,8 +88,8 @@ fn fallback_models_from_config(
 }
 
 /// `supported_models` メッセージ受信時の完全処理。
-pub(crate) async fn handle_supported_models_message(
-    app: Option<&tauri::AppHandle>,
+pub(crate) async fn handle_supported_models_message<R: tauri::Runtime>(
+    app: Option<&tauri::AppHandle<R>>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     registry: Option<&crate::backends::AgentBackendRegistry>,
     chat_session_id: &str,
@@ -227,8 +227,8 @@ pub async fn propagate_refreshed_models_to_active_sessions(
     notify_backend_models_updated(app, backend_id, &model_infos);
 }
 
-fn notify_backend_models_updated(
-    app: &tauri::AppHandle,
+fn notify_backend_models_updated<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     backend_id: &str,
     available_models: &[ModelInfo],
 ) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,7 +250,14 @@ pub fn run() {
                 ));
             }
             app.manage(agent_status_center);
-            let workflow_engine = Arc::new(workflow::engine::WorkflowEngine::new());
+            let workflow_engine = Arc::new(workflow::engine::WorkflowEngine::new(
+                Arc::new(workflow::resolver_adapters::DefaultWorkflowDefinitionResolver),
+                Arc::new(
+                    workflow::resolver_adapters::AppConfigManagedWorktreeResolver::new(
+                        app_config.clone(),
+                    ),
+                ),
+            ));
             // Run Store の永続化先（data_dir）を設定する。失敗しても起動は止めない。
             if let Ok(data_dir) = app.path().app_data_dir() {
                 let engine_for_init = workflow_engine.clone();

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -11,6 +11,9 @@ pub use crate::workflow::state::WorkflowState;
 pub use open_tabs::OpenTabRegistry;
 pub use store::SessionStore;
 
+#[cfg(test)]
+pub(crate) struct TestDataDir(pub std::path::PathBuf);
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MessagePart {
@@ -256,7 +259,13 @@ impl ChatSession {
     }
 }
 
-pub(crate) fn resolve_data_dir(app: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
+pub(crate) fn resolve_data_dir<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Result<std::path::PathBuf, String> {
+    #[cfg(test)]
+    if let Some(data_dir) = app.try_state::<TestDataDir>() {
+        return Ok(data_dir.0.clone());
+    }
     app.path()
         .app_data_dir()
         .map_err(|e| format!("Failed to get app data dir: {e}"))

--- a/src-tauri/src/session/store.rs
+++ b/src-tauri/src/session/store.rs
@@ -156,6 +156,21 @@ impl SessionStore {
         Ok(())
     }
 
+    pub fn delete_session(&self, app_data_dir: &Path, session_id: &str) -> Result<(), String> {
+        self.ensure_loaded(app_data_dir)?;
+        let _lock = self.file_lock.lock();
+        let file = session_file(app_data_dir, session_id)?;
+        match std::fs::remove_file(&file) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(format!("Failed to delete session file: {e}")),
+        }
+        let mut cache = self.cache.write();
+        cache.remove(session_id);
+        self.invalid_sessions.write().remove(session_id);
+        Ok(())
+    }
+
     fn persist_and_update_cache(
         &self,
         app_data_dir: &Path,

--- a/src-tauri/src/workflow/command.rs
+++ b/src-tauri/src/workflow/command.rs
@@ -1,0 +1,128 @@
+//! [04] Command / Event Boundary: workflow state を変化させる唯一の入口の typed 表現。
+//!
+//! 本 issue 範囲は外部入口を持つ 4 command（`StartRun` / `AbortRun` / `ApproveNode` /
+//! `RejectNode`）に限定する。`SubmitOutput`（[08]）/ `CompleteNode` / `FailNode`（[05] へ
+//! 振り分け済み）は本ファイルでは導入しない。
+//!
+//! ハンドラ実体は engine 側（`engine.rs`）に置く。本ファイルは型の所有のみを担い、
+//! `ApprovalDecision` 等の engine domain 型には依存しない。
+
+use crate::permission::PermissionMode;
+use crate::workflow::run::TriggerSource;
+
+/// workflow engine の state を変化させる typed command。
+///
+/// UI / Tauri command / 内部呼び出し元は、本 enum を組み立てて
+/// `WorkflowEngine::dispatch` に渡す経路のみを使う。`run_id` 主語の管理は
+/// [03] Run Store に揃える。
+#[derive(Debug, Clone)]
+pub enum WorkflowCommand {
+    /// 新しい workflow run の起動。
+    ///
+    /// `workflow_file_stem` は保存済み YAML / builtin の ファイル名 stem（拡張子なし）
+    /// であり、command 境界で「どの workflow template を起動するか」を解決する識別子。
+    /// 論理 workflow 名（`Workflow::name`）は load 済み definition から導出する想定で、
+    /// command boundary 上に重複した source of truth を持たない。Storage 層は
+    /// `Summary::name` を file stem として扱う（[03] Run Store / Summary 境界）。
+    StartRun {
+        workflow_file_stem: String,
+        worktree_path: String,
+        task: Option<String>,
+        trigger_source: TriggerSource,
+        permission_mode: PermissionMode,
+    },
+    /// 進行中の workflow run の中断。
+    ///
+    /// `expected_node_name` が Some の場合、approval UI 由来の Abort として
+    /// 現在の承認待ち node と一致するかを engine 側で検証する。これにより
+    /// stale な approval UI から任意フェーズの run を誤って中断することを防ぐ。
+    /// None の場合は run 全体の中断要求として扱う。
+    AbortRun {
+        run_id: String,
+        expected_node_name: Option<String>,
+    },
+    /// approval node に対する承認判断（任意のコメント付き）。
+    ApproveNode {
+        run_id: String,
+        node_name: String,
+        comment: Option<String>,
+    },
+    /// approval node に対する却下判断（理由必須）。
+    RejectNode {
+        run_id: String,
+        node_name: String,
+        reason: String,
+    },
+}
+
+/// `WorkflowEngine::dispatch` が返す typed boundary 結果。
+///
+/// `Result<String, _>` で空文字列 sentinel を返す旧シグネチャを廃し、command の
+/// 受理結果を variant ごとに表現する。Tauri adapter 側で `String` / `()` に薄く
+/// 変換する境界に揃え、engine 公開 API には sentinel 値を持ち込まない（spec [04]）。
+///
+/// 本ファイルでは特定 variant への変換ヘルパー（特に `Accepted` を空文字列 `run_id` に
+/// sentinel 化する変換）は提供しない。adapter 側（`commands.rs`）が `match` で variant 別
+/// に射影し、本来到達しない variant は内部不整合として `Err` に変換する（spec [04] 責務配置）。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkflowCommandResult {
+    /// `StartRun` の受理結果。新しく払い出された `run_id` を返す。
+    RunStarted { run_id: String },
+    /// `AbortRun` / `ApproveNode` / `RejectNode` の受理結果。
+    /// state 変化の事実は engine の event 列で観測する。
+    Accepted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// approval UI 由来の Abort は `expected_node_name` を伴って構築され、
+    /// engine 側で current approval node との一致を検証する経路に乗る。
+    /// run 全体の Abort（expected_node_name == None）と区別できることを確認する。
+    #[test]
+    fn abort_run_distinguishes_approval_target_from_full_run_abort() {
+        let rid = "00000000-0000-0000-0000-000000000010".to_string();
+        let approval_abort = WorkflowCommand::AbortRun {
+            run_id: rid.clone(),
+            expected_node_name: Some("review".to_string()),
+        };
+        let full_abort = WorkflowCommand::AbortRun {
+            run_id: rid,
+            expected_node_name: None,
+        };
+        match (approval_abort, full_abort) {
+            (
+                WorkflowCommand::AbortRun {
+                    expected_node_name: Some(ref n),
+                    ..
+                },
+                WorkflowCommand::AbortRun {
+                    expected_node_name: None,
+                    ..
+                },
+            ) => {
+                assert_eq!(n, "review");
+            }
+            _ => panic!("AbortRun variants must distinguish expected_node_name"),
+        }
+    }
+
+    /// ApproveNode.comment は engine の `ApprovalResolved.comment` に伝播される domain
+    /// field として command に持たせている。任意コメント付き承認の意図が command 境界で
+    /// 表現可能であることを確認する。
+    #[test]
+    fn approve_node_carries_optional_comment_across_command_boundary() {
+        let cmd = WorkflowCommand::ApproveNode {
+            run_id: "00000000-0000-0000-0000-000000000011".to_string(),
+            node_name: "review".to_string(),
+            comment: Some("LGTM with notes".to_string()),
+        };
+        match cmd {
+            WorkflowCommand::ApproveNode { comment, .. } => {
+                assert_eq!(comment.as_deref(), Some("LGTM with notes"));
+            }
+            _ => panic!("expected ApproveNode"),
+        }
+    }
+}

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -645,30 +645,11 @@ pub async fn get_workflow_execution_state(
     let state = tokio::task::spawn_blocking(move || {
         let event_log = WorkflowEventLog::new(&data_dir);
         let events = event_log.read_log(&run_id)?;
-        // ログのスナップショット（WorkflowStarted.workflow_definition）からのみ復元する。
+        // [04] schema 境界: 復元は `RunStarted.workflow_definition` snapshot 経由のみ。
         // 旧 NDJSON（workflow_definition フィールドを欠く / 旧 shape）は新 schema で
-        // deserialize できず、本ルートには到達しない（[02] で互換破棄）。
-        let started = events.iter().find_map(|e| match e {
-            super::event::WorkflowEvent::RunStarted {
-                workflow_definition,
-                workflow_file_stem,
-                workflow_name,
-                ..
-            } => {
-                let stem = if workflow_file_stem.is_empty() {
-                    workflow_name.clone()
-                } else {
-                    workflow_file_stem.clone()
-                };
-                Some((workflow_definition.clone(), stem))
-            }
-            _ => None,
-        });
-        let Some((snapshot_def, _file_stem)) = started else {
-            return Ok(None);
-        };
-        let workflow = snapshot_def;
-        super::event_projection::reconstruct_state_from_events(&run_id, &events, &workflow)
+        // deserialize できず、本ルートには到達しない（[02] で互換破棄）。snapshot 抽出は
+        // `reconstruct_state_from_events` の内部不変条件として閉じ込めてある。
+        super::event_projection::reconstruct_state_from_events(&run_id, &events)
     })
     .await
     .map_err(|e| format!("task join error: {e}"))??;

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -1,8 +1,10 @@
 use super::builtin;
+use super::command::{WorkflowCommand, WorkflowCommandResult};
 use super::diagnostics;
-use super::engine::{ApprovalDecision, WorkflowEngine};
+use super::engine::WorkflowEngine;
+use super::event::WorkflowEvent;
 use super::facet::{self, FacetKind};
-use super::log::{WorkflowEventLog, WorkflowLogEvent};
+use super::log::WorkflowEventLog;
 use super::run::WorkflowRunSummary;
 use super::schema::{FacetSummary, Summary, Workflow};
 use super::storage;
@@ -272,10 +274,54 @@ fn parse_workflow_start_permission_mode(
 }
 
 #[allow(clippy::too_many_arguments)]
+async fn start_workflow_adapter<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    engine: &Arc<WorkflowEngine>,
+    workflow_name: String,
+    worktree_path: String,
+    task: Option<String>,
+    trigger_source: Option<String>,
+    permission_mode: Option<String>,
+) -> Result<String, String> {
+    super::validation::validate_name(&workflow_name).map_err(validation_error_string)?;
+    let trigger = parse_trigger_source(trigger_source)?;
+    let permission_mode = parse_workflow_start_permission_mode(permission_mode)?;
+    // [04] managed worktree 検証は dispatch 経路（= 全 command 入口の合流地点）で行う。
+    // Tauri adapter は文字列引数のまま command を組み立て、engine 入口で正規化される境界に揃える。
+    engine
+        .dispatch(
+            app,
+            session_store,
+            handles,
+            WorkflowCommand::StartRun {
+                workflow_file_stem: workflow_name,
+                worktree_path,
+                task,
+                trigger_source: trigger,
+                permission_mode,
+            },
+        )
+        .await
+        .map_err(|e| e.to_string())
+        .and_then(|result| match result {
+            WorkflowCommandResult::RunStarted { run_id } => Ok(run_id),
+            // dispatch routing が壊れていない限り `StartRun` → `RunStarted` のみが
+            // 返るはずで、ここに到達する場合は engine 内部不整合（spec [04] 責務配置：
+            // sentinel 禁止）として明示的に Err にする。空文字列 run_id を成功扱い
+            // することはしない。
+            WorkflowCommandResult::Accepted => Err(
+                "start_workflow received non-RunStarted dispatch result; internal inconsistency"
+                    .to_string(),
+            ),
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn start_workflow(
     app: tauri::AppHandle,
-    config: tauri::State<'_, Arc<AppConfig>>,
     handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
     session_store: tauri::State<'_, Arc<SessionStore>>,
     engine: tauri::State<'_, Arc<WorkflowEngine>>,
@@ -285,41 +331,54 @@ pub async fn start_workflow(
     trigger_source: Option<String>,
     permission_mode: Option<String>,
 ) -> Result<String, String> {
-    let dir = storage::workflows_dir();
-    let facets_base = facet::facets_base_dir();
-    let file_stem = workflow_name.clone();
-    let workflow = tokio::task::spawn_blocking(move || {
-        super::validation::validate_name(&workflow_name).map_err(validation_error_string)?;
-        let file_path = dir.join(format!("{workflow_name}.yml"));
-        if file_path.exists() {
-            return storage::load_workflow(&file_path, &facets_base).map_err(|e| e.to_string());
-        }
-        builtin::load_builtin_workflow_resolved(&workflow_name)
-            .map_err(|e| e.to_string())?
-            .ok_or_else(|| format!("ワークフロー '{workflow_name}' が見つかりません"))
-    })
+    start_workflow_adapter(
+        &app,
+        handles.inner(),
+        session_store.inner(),
+        engine.inner(),
+        workflow_name,
+        worktree_path,
+        task,
+        trigger_source,
+        permission_mode,
+    )
     .await
-    .map_err(|e| format!("task join error: {e}"))??;
+}
 
-    let trigger = parse_trigger_source(trigger_source)?;
-    let permission_mode = parse_workflow_start_permission_mode(permission_mode)?;
-    let worktree_path =
-        super::worktree::canonicalize_managed_worktree_path(config.inner().clone(), worktree_path)
-            .await?;
+async fn abort_workflow_adapter<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    engine: &Arc<WorkflowEngine>,
+    run_id: String,
+) -> Result<(), String> {
+    validate_run_id(&run_id)?;
     engine
-        .start_workflow(
-            &app,
-            session_store.inner(),
-            handles.inner(),
-            workflow,
-            worktree_path,
-            &file_stem,
-            task,
-            trigger,
-            permission_mode,
+        .dispatch(
+            app,
+            session_store,
+            handles,
+            WorkflowCommand::AbortRun {
+                run_id,
+                expected_node_name: None,
+            },
         )
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| {
+            let msg = e.to_string();
+            log::error!("abort_workflow failed: code=ABORT_WORKFLOW_FAILED");
+            msg
+        })
+        .and_then(|result| match result {
+            WorkflowCommandResult::Accepted => Ok(()),
+            // dispatch routing が壊れていない限り `AbortRun` → `Accepted` のみが返るはず。
+            // ここに到達する場合は engine 内部不整合（spec [04] sentinel 禁止）として
+            // 明示的に Err にする。
+            WorkflowCommandResult::RunStarted { .. } => Err(
+                "abort_workflow received non-Accepted dispatch result; internal inconsistency"
+                    .to_string(),
+            ),
+        })
 }
 
 #[tauri::command]
@@ -330,15 +389,14 @@ pub async fn abort_workflow(
     engine: tauri::State<'_, Arc<WorkflowEngine>>,
     run_id: String,
 ) -> Result<(), String> {
-    validate_run_id(&run_id)?;
-    engine
-        .abort_workflow_by_run_id(&app, session_store.inner(), handles.inner(), &run_id)
-        .await
-        .map_err(|e| {
-            let msg = e.to_string();
-            log::error!("abort_workflow failed: code=ABORT_WORKFLOW_FAILED");
-            msg
-        })
+    abort_workflow_adapter(
+        &app,
+        handles.inner(),
+        session_store.inner(),
+        engine.inner(),
+        run_id,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -362,6 +420,84 @@ pub async fn get_workflow_state(
     }
 }
 
+/// approval UI / Tauri command 境界からの判断入力 DTO。
+///
+/// [04] Command / Event Boundary: engine 内部の `ApprovalDecision` には依存させず、
+/// command 境界専用の DTO として `WorkflowCommand` への変換責務だけを担う。
+/// wire 形式: `{"approve":{"comment":...}}` / `{"reject":{"reason":...}}` / `"abort"`。
+/// 旧 unit variant `"approve"` は受理しない。
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalDecisionInput {
+    Approve {
+        #[serde(default)]
+        comment: Option<String>,
+    },
+    Reject {
+        reason: String,
+    },
+    Abort,
+}
+
+impl ApprovalDecisionInput {
+    /// approval UI 判断を `WorkflowCommand` に変換する。
+    ///
+    /// `Approve` / `Reject` は `ApproveNode` / `RejectNode` に対応し、`Abort` は
+    /// 「現在の承認待ち node を対象にした AbortRun」として中断系 command に揃える。
+    /// `step_name` は approval UI 上の対象 node 名であり、`Abort` 経路では
+    /// engine 側の stale target 検証用に `expected_node_name` として伝播する。
+    fn into_command(self, run_id: String, step_name: String) -> WorkflowCommand {
+        match self {
+            Self::Approve { comment } => WorkflowCommand::ApproveNode {
+                run_id,
+                node_name: step_name,
+                comment,
+            },
+            Self::Reject { reason } => WorkflowCommand::RejectNode {
+                run_id,
+                node_name: step_name,
+                reason,
+            },
+            Self::Abort => WorkflowCommand::AbortRun {
+                run_id,
+                expected_node_name: Some(step_name),
+            },
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn approve_workflow_step_adapter<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    engine: &Arc<WorkflowEngine>,
+    run_id: String,
+    decision: ApprovalDecisionInput,
+    step_name: String,
+) -> Result<(), String> {
+    validate_run_id(&run_id)?;
+    // [04] approval UI からの decision は command 境界専用 DTO で受け取り、
+    // `WorkflowCommand` に変換して engine へ受け渡す。engine 内部 domain 型
+    // `ApprovalDecision` を Tauri 境界に露出させない（同一意図は呼び出し経路に依らず
+    // engine から等価に扱われる）。
+    let command = decision.into_command(run_id, step_name);
+    engine
+        .dispatch(app, session_store, handles, command)
+        .await
+        .map_err(|e| e.to_string())
+        .and_then(|result| match result {
+            WorkflowCommandResult::Accepted => Ok(()),
+            // dispatch routing が壊れていない限り approval 系 command → `Accepted` のみが
+            // 返るはず。ここに到達する場合は engine 内部不整合（spec [04] sentinel 禁止）と
+            // して明示的に Err にする。
+            WorkflowCommandResult::RunStarted { .. } => Err(
+                "approve_workflow_step received non-Accepted dispatch result; internal inconsistency"
+                    .to_string(),
+            ),
+        })
+}
+
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn approve_workflow_step(
@@ -370,21 +506,19 @@ pub async fn approve_workflow_step(
     session_store: tauri::State<'_, Arc<SessionStore>>,
     engine: tauri::State<'_, Arc<WorkflowEngine>>,
     run_id: String,
-    decision: ApprovalDecision,
+    decision: ApprovalDecisionInput,
     step_name: String,
 ) -> Result<(), String> {
-    validate_run_id(&run_id)?;
-    engine
-        .handle_approval(
-            &app,
-            session_store.inner(),
-            handles.inner(),
-            &run_id,
-            decision,
-            Some(&step_name),
-        )
-        .await
-        .map_err(|e| e.to_string())
+    approve_workflow_step_adapter(
+        &app,
+        handles.inner(),
+        session_store.inner(),
+        engine.inner(),
+        run_id,
+        decision,
+        step_name,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -490,7 +624,7 @@ fn validate_run_id(run_id: &str) -> Result<(), String> {
 pub async fn get_workflow_execution_log(
     app: tauri::AppHandle,
     run_id: String,
-) -> Result<Vec<WorkflowLogEvent>, String> {
+) -> Result<Vec<WorkflowEvent>, String> {
     validate_run_id(&run_id)?;
     let data_dir = resolve_data_dir(&app)?;
     let event_log = WorkflowEventLog::new(&data_dir);
@@ -515,7 +649,7 @@ pub async fn get_workflow_execution_state(
         // 旧 NDJSON（workflow_definition フィールドを欠く / 旧 shape）は新 schema で
         // deserialize できず、本ルートには到達しない（[02] で互換破棄）。
         let started = events.iter().find_map(|e| match e {
-            super::log::WorkflowLogEvent::WorkflowStarted {
+            super::event::WorkflowEvent::RunStarted {
                 workflow_definition,
                 workflow_file_stem,
                 workflow_name,
@@ -534,7 +668,7 @@ pub async fn get_workflow_execution_state(
             return Ok(None);
         };
         let workflow = snapshot_def;
-        WorkflowEventLog::reconstruct_state_from_events(&run_id, &events, &workflow)
+        super::event_projection::reconstruct_state_from_events(&run_id, &events, &workflow)
     })
     .await
     .map_err(|e| format!("task join error: {e}"))??;
@@ -770,7 +904,239 @@ fn validate_template_variables(content: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::workflow::event::WorkflowEvent;
+    use crate::workflow::log::WorkflowEventLog;
+    use crate::workflow::resolver::{
+        ManagedWorktreeResolver, ManagedWorktreeResolverError, WorkflowDefinitionResolver,
+        WorkflowDefinitionResolverError,
+    };
+    use crate::workflow::run::{RunStatus, TriggerSource};
+    use crate::workflow::schema::{NodeDefinition, NodeType};
+    use crate::workflow::state::WorkflowExecutionState;
     use std::path::Path;
+    use tempfile::TempDir;
+
+    struct StaticWorkflowResolver;
+
+    #[async_trait::async_trait]
+    impl WorkflowDefinitionResolver for StaticWorkflowResolver {
+        async fn resolve(
+            &self,
+            _file_stem: &str,
+        ) -> Result<Workflow, WorkflowDefinitionResolverError> {
+            Ok(approval_only_workflow())
+        }
+    }
+
+    struct TestWorktreeResolver;
+
+    #[async_trait::async_trait]
+    impl ManagedWorktreeResolver for TestWorktreeResolver {
+        async fn resolve(
+            &self,
+            worktree_path: String,
+        ) -> Result<String, ManagedWorktreeResolverError> {
+            Ok(worktree_path)
+        }
+    }
+
+    type AdapterTestApp = tauri::App<tauri::test::MockRuntime>;
+
+    fn approval_only_workflow() -> Workflow {
+        Workflow {
+            name: "adapter-boundary".to_string(),
+            description: "adapter command test".to_string(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "review".to_string(),
+                node_type: NodeType::Approval,
+                instruction: Some("review".to_string()),
+                ..NodeDefinition::default()
+            }],
+        }
+    }
+
+    fn rejectable_adapter_workflow() -> Workflow {
+        Workflow {
+            name: "adapter-boundary".to_string(),
+            description: "adapter command test".to_string(),
+            builtin: false,
+            nodes: vec![
+                NodeDefinition {
+                    name: "review".to_string(),
+                    node_type: NodeType::Approval,
+                    instruction: Some("review".to_string()),
+                    transition_rules: vec![crate::workflow::schema::TransitionRule {
+                        r#match: "reject".to_string(),
+                        next: "fix".to_string(),
+                    }],
+                    ..NodeDefinition::default()
+                },
+                NodeDefinition {
+                    name: "fix".to_string(),
+                    node_type: NodeType::Agent,
+                    instruction: Some("fix".to_string()),
+                    ..NodeDefinition::default()
+                },
+            ],
+        }
+    }
+
+    fn make_adapter_app() -> AdapterTestApp {
+        let mut config = crate::config::ReleashConfig::default();
+        config.agents.codex.models = vec!["default".to_string(), "gpt-5.5".to_string()];
+        config.agents.default = Some("codex".to_string());
+        let app_config = Arc::new(crate::config::AppConfig::new(
+            config,
+            TempDir::new().unwrap().path().join("config.toml"),
+        ));
+        let registry = Arc::new(crate::backends::build_registry(Arc::clone(&app_config)));
+        let data_dir =
+            std::env::temp_dir().join(format!("releash-command-adapter-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&data_dir).unwrap();
+        tauri::test::mock_builder()
+            .manage(crate::session::TestDataDir(data_dir))
+            .manage(app_config)
+            .manage(registry)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("tauri mock test app must build")
+    }
+
+    fn make_adapter_engine() -> Arc<WorkflowEngine> {
+        Arc::new(WorkflowEngine::new(
+            Arc::new(StaticWorkflowResolver),
+            Arc::new(TestWorktreeResolver),
+        ))
+    }
+
+    fn make_adapter_deps() -> (Arc<SessionStore>, Arc<Mutex<AgentProcessMap>>) {
+        (
+            Arc::new(SessionStore::default()),
+            Arc::new(Mutex::new(AgentProcessMap::new())),
+        )
+    }
+
+    async fn configure_run_store(
+        app: &AdapterTestApp,
+        engine: &Arc<WorkflowEngine>,
+    ) -> std::path::PathBuf {
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine
+            .set_run_store_data_dir(data_dir.join("workflow_runs"))
+            .await;
+        data_dir
+    }
+
+    fn create_adapter_parent_session(
+        app: &AdapterTestApp,
+        session_store: &SessionStore,
+        worktree_path: &str,
+    ) -> crate::session::ChatSession {
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        crate::session::create_session_internal_with_permission(
+            session_store,
+            &data_dir,
+            worktree_path,
+            None,
+            PermissionMode::Edit,
+        )
+        .unwrap()
+    }
+
+    fn read_adapter_events(data_dir: &Path, run_id: &str) -> Vec<WorkflowEvent> {
+        WorkflowEventLog::new(data_dir).read_log(run_id).unwrap()
+    }
+
+    async fn start_adapter_run(
+        app: &AdapterTestApp,
+        engine: &Arc<WorkflowEngine>,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        worktree_path: &str,
+    ) -> String {
+        start_workflow_adapter(
+            app.handle(),
+            handles,
+            session_store,
+            engine,
+            "adapter-boundary".to_string(),
+            worktree_path.to_string(),
+            Some("task".to_string()),
+            Some("desktop_ui".to_string()),
+            Some("edit".to_string()),
+        )
+        .await
+        .expect("adapter start_workflow must succeed")
+    }
+
+    async fn start_direct_run(
+        app: &AdapterTestApp,
+        engine: &Arc<WorkflowEngine>,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        worktree_path: &str,
+    ) -> String {
+        let result = engine
+            .dispatch(
+                app.handle(),
+                session_store,
+                handles,
+                WorkflowCommand::StartRun {
+                    workflow_file_stem: "adapter-boundary".to_string(),
+                    worktree_path: worktree_path.to_string(),
+                    task: Some("task".to_string()),
+                    trigger_source: TriggerSource::DesktopUi,
+                    permission_mode: PermissionMode::Edit,
+                },
+            )
+            .await
+            .expect("direct StartRun dispatch must succeed");
+        match result {
+            WorkflowCommandResult::RunStarted { run_id } => run_id,
+            other => panic!("StartRun must return RunStarted, got {other:?}"),
+        }
+    }
+
+    fn event_kinds(events: &[WorkflowEvent]) -> Vec<&'static str> {
+        events
+            .iter()
+            .map(|event| match event {
+                WorkflowEvent::RunStarted { .. } => "RunStarted",
+                WorkflowEvent::NodeStarted { .. } => "NodeStarted",
+                WorkflowEvent::NodeCompleted { .. } => "NodeCompleted",
+                WorkflowEvent::NodeFailed { .. } => "NodeFailed",
+                WorkflowEvent::ApprovalRequested { .. } => "ApprovalRequested",
+                WorkflowEvent::ApprovalResolved { .. } => "ApprovalResolved",
+                WorkflowEvent::RunCompleted { .. } => "RunCompleted",
+                WorkflowEvent::RunFailed { .. } => "RunFailed",
+                WorkflowEvent::RunAborted { .. } => "RunAborted",
+                WorkflowEvent::OutputCollected { .. } => "OutputCollected",
+                WorkflowEvent::ParallelStarted { .. } => "ParallelStarted",
+                WorkflowEvent::ParallelChildStarted { .. } => "ParallelChildStarted",
+                WorkflowEvent::ParallelChildCompleted { .. } => "ParallelChildCompleted",
+                WorkflowEvent::ParallelCompleted { .. } => "ParallelCompleted",
+                WorkflowEvent::ContractRepairRequested { .. } => "ContractRepairRequested",
+            })
+            .collect()
+    }
+
+    async fn adapter_run_status(engine: &WorkflowEngine, run_id: &str) -> RunStatus {
+        if let Some(run) = engine
+            .list_active_runs()
+            .await
+            .into_iter()
+            .find(|run| run.run_id == run_id)
+        {
+            return run.status;
+        }
+        engine
+            .list_completed_runs()
+            .await
+            .into_iter()
+            .find(|run| run.run_id == run_id)
+            .map(|run| run.status)
+            .expect("run must exist in active or completed store")
+    }
 
     #[test]
     fn parse_facet_kind_valid_kinds() {
@@ -784,6 +1150,523 @@ mod tests {
             parse_facet_kind("output_contract").unwrap(),
             FacetKind::OutputContract
         );
+    }
+
+    /// Spec [04] Rule「同一意図 command は呼び出し経路に依らず等価」:
+    /// Tauri adapter の start_workflow は typed `WorkflowCommand::StartRun` を組み立て、
+    /// direct dispatch と同じ state / Run Store / event vocabulary に到達する。
+    #[tokio::test]
+    async fn start_workflow_adapter_matches_direct_start_run_dispatch() {
+        let adapter_app = make_adapter_app();
+        let adapter_engine = make_adapter_engine();
+        let adapter_data_dir = configure_run_store(&adapter_app, &adapter_engine).await;
+        let (adapter_store, adapter_handles) = make_adapter_deps();
+        let adapter_run_id = start_adapter_run(
+            &adapter_app,
+            &adapter_engine,
+            &adapter_store,
+            &adapter_handles,
+            "/wt/adapter-start",
+        )
+        .await;
+
+        let direct_app = make_adapter_app();
+        let direct_engine = make_adapter_engine();
+        let direct_data_dir = configure_run_store(&direct_app, &direct_engine).await;
+        let (direct_store, direct_handles) = make_adapter_deps();
+        let direct_run_id = start_direct_run(
+            &direct_app,
+            &direct_engine,
+            &direct_store,
+            &direct_handles,
+            "/wt/direct-start",
+        )
+        .await;
+
+        let adapter_state = adapter_engine
+            .get_state_by_run_id(&adapter_run_id)
+            .await
+            .expect("adapter start must create state");
+        let direct_state = direct_engine
+            .get_state_by_run_id(&direct_run_id)
+            .await
+            .expect("direct start must create state");
+        assert_eq!(adapter_state.state, direct_state.state);
+        assert_eq!(
+            adapter_state.current_step_name,
+            direct_state.current_step_name
+        );
+        assert_eq!(adapter_state.workflow_name, direct_state.workflow_name);
+        assert_eq!(
+            event_kinds(&read_adapter_events(&adapter_data_dir, &adapter_run_id)),
+            event_kinds(&read_adapter_events(&direct_data_dir, &direct_run_id))
+        );
+    }
+
+    /// Tauri adapter の abort_workflow は `AbortRun { expected_node_name: None }` に射影され、
+    /// direct dispatch と同じ terminal state / Run Store / event log を返す。
+    #[tokio::test]
+    async fn abort_workflow_adapter_matches_direct_abort_run_dispatch() {
+        let adapter_app = make_adapter_app();
+        let adapter_engine = make_adapter_engine();
+        let adapter_data_dir = configure_run_store(&adapter_app, &adapter_engine).await;
+        let (adapter_store, adapter_handles) = make_adapter_deps();
+        let adapter_run_id = uuid::Uuid::new_v4().to_string();
+        let adapter_parent =
+            create_adapter_parent_session(&adapter_app, &adapter_store, "/wt/adapter-abort");
+        adapter_engine
+            .seed_active_execution_for_test(
+                adapter_run_id.clone(),
+                approval_only_workflow(),
+                WorkflowExecutionState::Running,
+                "/wt/adapter-abort".to_string(),
+                adapter_parent.id,
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        let direct_app = make_adapter_app();
+        let direct_engine = make_adapter_engine();
+        let direct_data_dir = configure_run_store(&direct_app, &direct_engine).await;
+        let (direct_store, direct_handles) = make_adapter_deps();
+        let direct_run_id = uuid::Uuid::new_v4().to_string();
+        let direct_parent =
+            create_adapter_parent_session(&direct_app, &direct_store, "/wt/direct-abort");
+        direct_engine
+            .seed_active_execution_for_test(
+                direct_run_id.clone(),
+                approval_only_workflow(),
+                WorkflowExecutionState::Running,
+                "/wt/direct-abort".to_string(),
+                direct_parent.id,
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        abort_workflow_adapter(
+            adapter_app.handle(),
+            &adapter_handles,
+            &adapter_store,
+            &adapter_engine,
+            adapter_run_id.clone(),
+        )
+        .await
+        .expect("adapter abort must succeed");
+        let direct_result = direct_engine
+            .dispatch(
+                direct_app.handle(),
+                &direct_store,
+                &direct_handles,
+                WorkflowCommand::AbortRun {
+                    run_id: direct_run_id.clone(),
+                    expected_node_name: None,
+                },
+            )
+            .await
+            .expect("direct abort must succeed");
+        assert_eq!(direct_result, WorkflowCommandResult::Accepted);
+
+        assert_eq!(
+            adapter_engine
+                .get_state_by_run_id(&adapter_run_id)
+                .await
+                .unwrap()
+                .state,
+            WorkflowExecutionState::Aborted
+        );
+        assert_eq!(
+            direct_engine
+                .get_state_by_run_id(&direct_run_id)
+                .await
+                .unwrap()
+                .state,
+            WorkflowExecutionState::Aborted
+        );
+        assert_eq!(
+            adapter_engine.list_completed_runs().await[0].status,
+            RunStatus::Aborted
+        );
+        assert_eq!(
+            direct_engine.list_completed_runs().await[0].status,
+            RunStatus::Aborted
+        );
+        assert_eq!(
+            event_kinds(&read_adapter_events(&adapter_data_dir, &adapter_run_id)),
+            event_kinds(&read_adapter_events(&direct_data_dir, &direct_run_id))
+        );
+    }
+
+    /// Tauri adapter の approve_workflow_step は approval DTO を `ApproveNode` に変換し、
+    /// direct dispatch と同じ state / Run Store / typed event を返す。
+    #[tokio::test]
+    async fn approve_workflow_step_adapter_matches_direct_approve_node_dispatch() {
+        let adapter_app = make_adapter_app();
+        let adapter_engine = make_adapter_engine();
+        let adapter_data_dir = configure_run_store(&adapter_app, &adapter_engine).await;
+        let (adapter_store, adapter_handles) = make_adapter_deps();
+        let adapter_run_id = uuid::Uuid::new_v4().to_string();
+        let adapter_parent =
+            create_adapter_parent_session(&adapter_app, &adapter_store, "/wt/adapter-approve");
+        adapter_engine
+            .seed_active_execution_for_test(
+                adapter_run_id.clone(),
+                approval_only_workflow(),
+                WorkflowExecutionState::WaitingApproval,
+                "/wt/adapter-approve".to_string(),
+                adapter_parent.id,
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        let direct_app = make_adapter_app();
+        let direct_engine = make_adapter_engine();
+        let direct_data_dir = configure_run_store(&direct_app, &direct_engine).await;
+        let (direct_store, direct_handles) = make_adapter_deps();
+        let direct_run_id = uuid::Uuid::new_v4().to_string();
+        let direct_parent =
+            create_adapter_parent_session(&direct_app, &direct_store, "/wt/direct-approve");
+        direct_engine
+            .seed_active_execution_for_test(
+                direct_run_id.clone(),
+                approval_only_workflow(),
+                WorkflowExecutionState::WaitingApproval,
+                "/wt/direct-approve".to_string(),
+                direct_parent.id,
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        approve_workflow_step_adapter(
+            adapter_app.handle(),
+            &adapter_handles,
+            &adapter_store,
+            &adapter_engine,
+            adapter_run_id.clone(),
+            ApprovalDecisionInput::Approve {
+                comment: Some("lgtm".to_string()),
+            },
+            "review".to_string(),
+        )
+        .await
+        .expect("adapter approval must succeed");
+        let direct_result = direct_engine
+            .dispatch(
+                direct_app.handle(),
+                &direct_store,
+                &direct_handles,
+                WorkflowCommand::ApproveNode {
+                    run_id: direct_run_id.clone(),
+                    node_name: "review".to_string(),
+                    comment: Some("lgtm".to_string()),
+                },
+            )
+            .await
+            .expect("direct approval must succeed");
+        assert_eq!(direct_result, WorkflowCommandResult::Accepted);
+
+        let adapter_state = adapter_engine
+            .get_state_by_run_id(&adapter_run_id)
+            .await
+            .unwrap();
+        let direct_state = direct_engine
+            .get_state_by_run_id(&direct_run_id)
+            .await
+            .unwrap();
+        assert_eq!(adapter_state.state, WorkflowExecutionState::Completed);
+        assert_eq!(direct_state.state, WorkflowExecutionState::Completed);
+        assert_eq!(
+            adapter_state.step_history.len(),
+            direct_state.step_history.len()
+        );
+        assert_eq!(
+            adapter_engine.list_completed_runs().await[0].status,
+            direct_engine.list_completed_runs().await[0].status
+        );
+        assert_eq!(
+            event_kinds(&read_adapter_events(&adapter_data_dir, &adapter_run_id)),
+            event_kinds(&read_adapter_events(&direct_data_dir, &direct_run_id))
+        );
+    }
+
+    /// Tauri adapter の Reject decision は `RejectNode` に射影され、
+    /// direct dispatch と同じ state / Run Store status / typed event sequence に到達する。
+    #[tokio::test]
+    async fn approve_workflow_step_adapter_matches_direct_reject_node_dispatch() {
+        let adapter_app = make_adapter_app();
+        let adapter_engine = make_adapter_engine();
+        let adapter_data_dir = configure_run_store(&adapter_app, &adapter_engine).await;
+        let (adapter_store, adapter_handles) = make_adapter_deps();
+        let adapter_run_id = uuid::Uuid::new_v4().to_string();
+        let adapter_parent =
+            create_adapter_parent_session(&adapter_app, &adapter_store, "/wt/adapter-reject");
+        adapter_engine
+            .seed_active_execution_for_test(
+                adapter_run_id.clone(),
+                rejectable_adapter_workflow(),
+                WorkflowExecutionState::WaitingApproval,
+                "/wt/adapter-reject".to_string(),
+                adapter_parent.id,
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        let direct_app = make_adapter_app();
+        let direct_engine = make_adapter_engine();
+        let direct_data_dir = configure_run_store(&direct_app, &direct_engine).await;
+        let (direct_store, direct_handles) = make_adapter_deps();
+        let direct_run_id = uuid::Uuid::new_v4().to_string();
+        let direct_parent =
+            create_adapter_parent_session(&direct_app, &direct_store, "/wt/direct-reject");
+        direct_engine
+            .seed_active_execution_for_test(
+                direct_run_id.clone(),
+                rejectable_adapter_workflow(),
+                WorkflowExecutionState::WaitingApproval,
+                "/wt/direct-reject".to_string(),
+                direct_parent.id,
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        approve_workflow_step_adapter(
+            adapter_app.handle(),
+            &adapter_handles,
+            &adapter_store,
+            &adapter_engine,
+            adapter_run_id.clone(),
+            ApprovalDecisionInput::Reject {
+                reason: "needs changes".to_string(),
+            },
+            "review".to_string(),
+        )
+        .await
+        .expect("adapter reject must succeed");
+        let direct_result = direct_engine
+            .dispatch(
+                direct_app.handle(),
+                &direct_store,
+                &direct_handles,
+                WorkflowCommand::RejectNode {
+                    run_id: direct_run_id.clone(),
+                    node_name: "review".to_string(),
+                    reason: "needs changes".to_string(),
+                },
+            )
+            .await
+            .expect("direct reject must succeed");
+        assert_eq!(direct_result, WorkflowCommandResult::Accepted);
+
+        let adapter_state = adapter_engine
+            .get_state_by_run_id(&adapter_run_id)
+            .await
+            .unwrap();
+        let direct_state = direct_engine
+            .get_state_by_run_id(&direct_run_id)
+            .await
+            .unwrap();
+        assert_eq!(adapter_state.state, direct_state.state);
+        assert_eq!(
+            adapter_run_status(&adapter_engine, &adapter_run_id).await,
+            adapter_run_status(&direct_engine, &direct_run_id).await
+        );
+        assert_eq!(
+            event_kinds(&read_adapter_events(&adapter_data_dir, &adapter_run_id)),
+            event_kinds(&read_adapter_events(&direct_data_dir, &direct_run_id))
+        );
+    }
+
+    /// approval UI 由来の Abort decision は `AbortRun { expected_node_name: Some(_) }`
+    /// に射影され、direct dispatch と同じ terminal state / Run Store status / event sequence に到達する。
+    #[tokio::test]
+    async fn approve_workflow_step_adapter_matches_direct_approval_abort_dispatch() {
+        let adapter_app = make_adapter_app();
+        let adapter_engine = make_adapter_engine();
+        let adapter_data_dir = configure_run_store(&adapter_app, &adapter_engine).await;
+        let (adapter_store, adapter_handles) = make_adapter_deps();
+        let adapter_run_id = uuid::Uuid::new_v4().to_string();
+        let adapter_parent = create_adapter_parent_session(
+            &adapter_app,
+            &adapter_store,
+            "/wt/adapter-approval-abort",
+        );
+        adapter_engine
+            .seed_active_execution_for_test(
+                adapter_run_id.clone(),
+                approval_only_workflow(),
+                WorkflowExecutionState::WaitingApproval,
+                "/wt/adapter-approval-abort".to_string(),
+                adapter_parent.id,
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        let direct_app = make_adapter_app();
+        let direct_engine = make_adapter_engine();
+        let direct_data_dir = configure_run_store(&direct_app, &direct_engine).await;
+        let (direct_store, direct_handles) = make_adapter_deps();
+        let direct_run_id = uuid::Uuid::new_v4().to_string();
+        let direct_parent =
+            create_adapter_parent_session(&direct_app, &direct_store, "/wt/direct-approval-abort");
+        direct_engine
+            .seed_active_execution_for_test(
+                direct_run_id.clone(),
+                approval_only_workflow(),
+                WorkflowExecutionState::WaitingApproval,
+                "/wt/direct-approval-abort".to_string(),
+                direct_parent.id,
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        approve_workflow_step_adapter(
+            adapter_app.handle(),
+            &adapter_handles,
+            &adapter_store,
+            &adapter_engine,
+            adapter_run_id.clone(),
+            ApprovalDecisionInput::Abort,
+            "review".to_string(),
+        )
+        .await
+        .expect("adapter approval abort must succeed");
+        let direct_result = direct_engine
+            .dispatch(
+                direct_app.handle(),
+                &direct_store,
+                &direct_handles,
+                WorkflowCommand::AbortRun {
+                    run_id: direct_run_id.clone(),
+                    expected_node_name: Some("review".to_string()),
+                },
+            )
+            .await
+            .expect("direct approval abort must succeed");
+        assert_eq!(direct_result, WorkflowCommandResult::Accepted);
+
+        assert_eq!(
+            adapter_engine
+                .get_state_by_run_id(&adapter_run_id)
+                .await
+                .unwrap()
+                .state,
+            direct_engine
+                .get_state_by_run_id(&direct_run_id)
+                .await
+                .unwrap()
+                .state
+        );
+        assert_eq!(
+            adapter_engine.list_completed_runs().await[0].status,
+            RunStatus::Aborted
+        );
+        assert_eq!(
+            direct_engine.list_completed_runs().await[0].status,
+            RunStatus::Aborted
+        );
+        assert_eq!(
+            event_kinds(&read_adapter_events(&adapter_data_dir, &adapter_run_id)),
+            event_kinds(&read_adapter_events(&direct_data_dir, &direct_run_id))
+        );
+    }
+
+    // ---- ApprovalDecisionInput DTO（[04] command 境界の wire 形式 + WorkflowCommand 変換） ----
+
+    /// Spec [04] / issues-1013: `ApprovalDecisionInput::Approve` は任意 comment を内包し、
+    /// `{"approve":{}}` / `{"approve":{"comment":"..."}}` の双方を受理する。
+    #[test]
+    fn approval_decision_input_deserialize_approve_optional_comment() {
+        let no_comment: ApprovalDecisionInput = serde_json::from_str(r#"{"approve":{}}"#).unwrap();
+        assert_eq!(no_comment, ApprovalDecisionInput::Approve { comment: None });
+        let with_comment: ApprovalDecisionInput =
+            serde_json::from_str(r#"{"approve":{"comment":"lgtm"}}"#).unwrap();
+        assert_eq!(
+            with_comment,
+            ApprovalDecisionInput::Approve {
+                comment: Some("lgtm".to_string())
+            }
+        );
+    }
+
+    /// Spec [04] / issues-1013: `ApprovalDecisionInput::Reject` は `reason` 必須。
+    #[test]
+    fn approval_decision_input_deserialize_reject_with_reason() {
+        let decision: ApprovalDecisionInput =
+            serde_json::from_str(r#"{"reject":{"reason":"Please fix"}}"#).unwrap();
+        assert_eq!(
+            decision,
+            ApprovalDecisionInput::Reject {
+                reason: "Please fix".to_string()
+            }
+        );
+    }
+
+    /// Spec [04] / issues-1013: `ApprovalDecisionInput::Abort` は unit variant の wire 形式。
+    #[test]
+    fn approval_decision_input_deserialize_abort_unit_variant() {
+        let decision: ApprovalDecisionInput = serde_json::from_str(r#""abort""#).unwrap();
+        assert_eq!(decision, ApprovalDecisionInput::Abort);
+    }
+
+    /// Spec [04] / issues-1013: 旧 unit variant `"approve"` は受理しない
+    /// （後方互換 wrapper を持たない command 境界の不変条件）。
+    #[test]
+    fn approval_decision_input_rejects_legacy_unit_approve() {
+        assert!(serde_json::from_str::<ApprovalDecisionInput>(r#""approve""#).is_err());
+    }
+
+    /// Spec [04] / issues-1013: `into_command` は approval 入力を typed `WorkflowCommand`
+    /// にマップする。Approve → ApproveNode、Reject → RejectNode（reason が伝播）、
+    /// Abort → AbortRun（current node が `expected_node_name` に固定される）。
+    #[test]
+    fn approval_decision_input_into_command_routes_each_variant() {
+        let run_id = "00000000-0000-0000-0000-000000000099".to_string();
+        let step = "review".to_string();
+
+        let approve_input = ApprovalDecisionInput::Approve {
+            comment: Some("lgtm".to_string()),
+        };
+        let approve_cmd = approve_input.into_command(run_id.clone(), step.clone());
+        match approve_cmd {
+            WorkflowCommand::ApproveNode {
+                run_id: rid,
+                node_name,
+                comment,
+            } => {
+                assert_eq!(rid, run_id);
+                assert_eq!(node_name, step);
+                assert_eq!(comment.as_deref(), Some("lgtm"));
+            }
+            other => panic!("Approve must map to ApproveNode, got: {other:?}"),
+        }
+
+        let reject_input = ApprovalDecisionInput::Reject {
+            reason: "needs fix".to_string(),
+        };
+        let reject_cmd = reject_input.into_command(run_id.clone(), step.clone());
+        match reject_cmd {
+            WorkflowCommand::RejectNode {
+                run_id: rid,
+                node_name,
+                reason,
+            } => {
+                assert_eq!(rid, run_id);
+                assert_eq!(node_name, step);
+                assert_eq!(reason, "needs fix");
+            }
+            other => panic!("Reject must map to RejectNode, got: {other:?}"),
+        }
+
+        let abort_cmd = ApprovalDecisionInput::Abort.into_command(run_id.clone(), step.clone());
+        match abort_cmd {
+            WorkflowCommand::AbortRun {
+                run_id: rid,
+                expected_node_name,
+            } => {
+                assert_eq!(rid, run_id);
+                assert_eq!(expected_node_name.as_deref(), Some("review"));
+            }
+            other => panic!("Abort must map to AbortRun, got: {other:?}"),
+        }
     }
 
     #[test]
@@ -1252,9 +2135,6 @@ mod tests {
     // ---- duplicate logic tests ----
     // These test the core duplicate logic using storage/facet/builtin functions directly,
     // mirroring what the Tauri commands do inside spawn_blocking.
-
-    use crate::workflow::schema::{NodeDefinition, NodeType, Workflow};
-    use tempfile::TempDir;
 
     fn make_test_workflow(name: &str) -> Workflow {
         Workflow {

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
 
 use regex::RegexBuilder;
@@ -11,12 +13,18 @@ use crate::agent_sdk::AgentProcessMap;
 use crate::agent_status::current_timestamp;
 use crate::permission::PermissionMode;
 use crate::session::{ChatSession, SessionStore};
+use crate::workflow::command::{WorkflowCommand, WorkflowCommandResult};
 use crate::workflow::contract::{
     build_repair_prompt, extract_workflow_output, validate_contract, ContractValidationResult,
     ExtractionResult,
 };
+use crate::workflow::event::{ApprovalDecisionRecord, CollectedOutputEntry, WorkflowEvent};
 use crate::workflow::facet;
-use crate::workflow::log::{WorkflowEventLog, WorkflowLogEvent};
+use crate::workflow::log::WorkflowEventLog;
+use crate::workflow::resolver::{
+    ManagedWorktreeResolver, ManagedWorktreeResolverError, WorkflowDefinitionResolver,
+    WorkflowDefinitionResolverError,
+};
 use crate::workflow::run::{
     RunStatus, RunStore, RunStoreError, TerminalRunStatus, TriggerSource, WorkflowRun,
 };
@@ -76,14 +84,14 @@ trait SessionStartGate: Send + Sync {
 }
 
 /// production 用の `SessionStartGate` 実装。`start_agent_session_internal` をそのまま呼び出す。
-struct RealSessionStartGate<'a> {
-    app: &'a tauri::AppHandle,
+struct RealSessionStartGate<'a, R: tauri::Runtime> {
+    app: &'a tauri::AppHandle<R>,
     handles: &'a Arc<Mutex<AgentProcessMap>>,
     session_store: &'a Arc<SessionStore>,
 }
 
 #[async_trait::async_trait]
-impl<'a> SessionStartGate for RealSessionStartGate<'a> {
+impl<'a, R: tauri::Runtime> SessionStartGate for RealSessionStartGate<'a, R> {
     async fn start_session(
         &self,
         chat_session_id: &str,
@@ -181,15 +189,15 @@ struct StepSessionInfo {
 }
 
 /// production 用の `StepSessionDeps` 実装。
-struct RealStepSessionDeps<'a> {
+struct RealStepSessionDeps<'a, R: tauri::Runtime> {
     engine: &'a WorkflowEngine,
-    app: &'a tauri::AppHandle,
+    app: &'a tauri::AppHandle<R>,
     handles: &'a Arc<Mutex<AgentProcessMap>>,
     session_store: &'a Arc<SessionStore>,
 }
 
 #[async_trait::async_trait]
-impl<'a> StepSessionDeps for RealStepSessionDeps<'a> {
+impl<'a, R: tauri::Runtime> StepSessionDeps for RealStepSessionDeps<'a, R> {
     async fn fetch_parent_session(
         &self,
         chat_session_id: &str,
@@ -303,6 +311,67 @@ impl<'a> StepSessionDeps for RealStepSessionDeps<'a> {
     }
 }
 
+/// `abort_workflow_by_run_id` 内部 lookup の typed 結果。
+#[derive(Debug)]
+enum AbortTargetLookup {
+    NotFound,
+    AlreadyTerminal,
+    Active {
+        current_step_session_id: Option<String>,
+        parallel_session_ids: Option<Vec<String>>,
+    },
+}
+
+/// `abort_workflow_by_run_id` の typed outcome。
+///
+/// `WorkflowCommand::AbortRun` 経由の中断要求に対し、command handler が「実際に
+/// 中断を実施したか」「対象 run が存在しないか」「既に終了済みで中断不能だったか」
+/// を typed に表現する。`Aborted` のみが dispatch から `Accepted` に射影され、
+/// `NotFound` / `AlreadyTerminal` は非受理（`WorkflowEngineError` 経由）として
+/// 上位に伝播する（Spec [04] Rule「対象不在 / 既に終了した command は受理されない」）。
+///
+/// engine 内部用途のみのため可視性は module-private に閉じる。外部入口は
+/// `WorkflowCommand::AbortRun` 一本に統一する（Spec [04] 公開 API 最小化）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AbortOutcome {
+    /// 対象 run を Aborted に遷移させ、RunAborted event を append した。
+    Aborted,
+    /// 対象 run が `executions` に存在しない。
+    NotFound,
+    /// 対象 run は既に terminal で、中断対象でない。
+    AlreadyTerminal,
+}
+
+struct CommandMutationRollback<'a> {
+    run_id: &'a str,
+    chat_session_id: &'a str,
+    snapshot_before: WorkflowExecution,
+    run_store_snapshot_before: Option<WorkflowRun>,
+    context: &'a str,
+}
+
+struct RequiredEventCommit<'a> {
+    run_id: &'a str,
+    chat_session_id: &'a str,
+    snapshot_for_commit: &'a WorkflowState,
+    snapshot_before: WorkflowExecution,
+    run_store_snapshot_before: Option<WorkflowRun>,
+    required_events: Vec<WorkflowEvent>,
+    append_error_context: &'a str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutcomeCommitMode {
+    EmitProgressEvents,
+    ProgressEventsAlreadyCommitted,
+}
+
+impl OutcomeCommitMode {
+    fn should_emit_progress_events(self) -> bool {
+        matches!(self, Self::EmitProgressEvents)
+    }
+}
+
 /// ワークフローエンジンのエラー型。
 #[derive(Debug)]
 pub enum WorkflowEngineError {
@@ -357,6 +426,25 @@ impl From<WorkflowEngineError> for String {
     }
 }
 
+impl From<WorkflowDefinitionResolverError> for WorkflowEngineError {
+    fn from(e: WorkflowDefinitionResolverError) -> Self {
+        match e {
+            WorkflowDefinitionResolverError::InvalidWorkflow(message) => {
+                Self::InvalidWorkflow(message)
+            }
+            WorkflowDefinitionResolverError::Infrastructure(message) => Self::SessionStore(message),
+        }
+    }
+}
+
+impl From<ManagedWorktreeResolverError> for WorkflowEngineError {
+    fn from(e: ManagedWorktreeResolverError) -> Self {
+        match e {
+            ManagedWorktreeResolverError::Validation(message) => Self::ValidationError(message),
+        }
+    }
+}
+
 impl From<crate::workflow_step_lifecycle::WorkflowStepLifecycleError> for WorkflowEngineError {
     fn from(e: crate::workflow_step_lifecycle::WorkflowStepLifecycleError) -> Self {
         match e {
@@ -374,6 +462,7 @@ impl From<crate::workflow_step_lifecycle::WorkflowStepLifecycleError> for Workfl
 }
 
 /// ワークフロー実行の内部状態。
+#[derive(Clone)]
 struct WorkflowExecution {
     /// `WorkflowState.execution_id` を `run_id` として昇格させた識別子。
     /// `WorkflowEngine.executions` の HashMap キーと一致する。
@@ -407,6 +496,7 @@ struct WorkflowExecution {
 }
 
 /// 並列実行中の内部状態。
+#[derive(Clone)]
 struct ParallelRunState {
     parent_step_name: String,
     aggregate: Option<ParallelAggregate>,
@@ -414,6 +504,7 @@ struct ParallelRunState {
 }
 
 /// 並列子ステップの実行状態。
+#[derive(Clone)]
 struct ParallelChildRun {
     step_name: String,
     session_id: String,
@@ -817,9 +908,8 @@ impl WorkflowExecution {
 }
 
 /// approvalモードのユーザー判定。
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ApprovalDecision {
+#[derive(Debug, Clone, PartialEq)]
+enum ApprovalDecision {
     Approve,
     Reject { comment: String },
     Abort,
@@ -926,16 +1016,22 @@ pub struct WorkflowEngine {
     /// active な WorkflowRun の管理および run metadata の永続化を担う Run Store。
     /// worktree_path → active run_id の secondary index は Run Store 内で保持する。
     run_store: Arc<RunStore>,
+    workflow_resolver: Arc<dyn WorkflowDefinitionResolver>,
+    worktree_resolver: Arc<dyn ManagedWorktreeResolver>,
+    #[cfg(test)]
+    fail_next_persist_state: AtomicBool,
 }
 
-/// `set_execution_state_inner` の lookup 戦略。
-/// `Worktree` は既存経路で worktree_path 起点の find を行い、`RunId` は run_id 直接 lookup
-/// を行う。broadcast / cleanup 用の worktree_path は `set_execution_state_inner` 内で
-/// 解決した exec から取得するため、target には保持しない（Spec issues-1011 finding 12:
-/// 意図不明な未使用 field を残さない）。
+/// `set_execution_state_inner` の lookup 戦略。worktree_path 起点の `find_by_worktree_mut`
+/// で active な run を解決する。broadcast / cleanup 用の worktree_path は
+/// `set_execution_state_inner` 内で解決した exec から取得するため、target には保持しない
+/// （Spec issues-1011 finding 12: 意図不明な未使用 field を残さない）。
+///
+/// run_id 主語の遷移経路（`WorkflowCommand::AbortRun` 全体中断）は
+/// `abort_workflow_by_run_id` 側で typed AbortOutcome + 必須 RunAborted append として
+/// 完結するため、ここでは worktree variant のみを扱う。
 enum ExecutionStateTarget {
     Worktree(String),
-    RunId(String),
 }
 
 /// `execs: HashMap<run_id, WorkflowExecution>` から、worktree_path 属性が一致する
@@ -975,12 +1071,97 @@ fn find_any_by_worktree<'a>(
 }
 
 impl WorkflowEngine {
-    pub fn new() -> Self {
+    pub(crate) fn new(
+        workflow_resolver: Arc<dyn WorkflowDefinitionResolver>,
+        worktree_resolver: Arc<dyn ManagedWorktreeResolver>,
+    ) -> Self {
         Self {
             executions: Mutex::new(HashMap::new()),
             session_workflow_refs: Mutex::new(HashMap::new()),
             run_store: Arc::new(RunStore::new()),
+            workflow_resolver,
+            worktree_resolver,
+            #[cfg(test)]
+            fail_next_persist_state: AtomicBool::new(false),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> Self {
+        Self::new(
+            Arc::new(crate::workflow::resolver_adapters::DefaultWorkflowDefinitionResolver),
+            Arc::new(crate::workflow::resolver_adapters::PassthroughManagedWorktreeResolver),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn seed_active_execution_for_test(
+        &self,
+        run_id: String,
+        workflow: Workflow,
+        state: WorkflowExecutionState,
+        worktree_path: String,
+        chat_session_id: String,
+        trigger_source: TriggerSource,
+    ) {
+        assert!(
+            matches!(
+                state,
+                WorkflowExecutionState::Running | WorkflowExecutionState::WaitingApproval
+            ),
+            "seed_active_execution_for_test only accepts active states"
+        );
+        let current_node_name = workflow.nodes[0].name.clone();
+        let run_status = if matches!(state, WorkflowExecutionState::WaitingApproval) {
+            RunStatus::WaitingApproval
+        } else {
+            RunStatus::Running
+        };
+        let now = 1000.0;
+        self.run_store
+            .register_active(WorkflowRun {
+                run_id: run_id.clone(),
+                workflow_name: workflow.name.clone(),
+                task: None,
+                status: run_status,
+                worktree_path: worktree_path.clone(),
+                chat_session_id: Some(chat_session_id.clone()),
+                current_node_name: Some(current_node_name.clone()),
+                trigger_source,
+                started_at: now,
+                updated_at: now,
+                completed_at: None,
+                error_reason: None,
+            })
+            .await
+            .unwrap();
+        self.executions.lock().await.insert(
+            run_id.clone(),
+            WorkflowExecution {
+                id: run_id,
+                workflow,
+                state,
+                current_step_index: 0,
+                step_execution_counts: HashMap::from([(current_node_name, 1)]),
+                step_history: Vec::new(),
+                chat_session_id,
+                worktree_path,
+                started_at: now,
+                updated_at: now,
+                current_session_id: None,
+                current_step_token_usage: TokenUsage::default(),
+                step_outputs: HashMap::new(),
+                task: None,
+                parallel_run: None,
+                workflow_variables: HashMap::new(),
+                contract_retry_count: 0,
+            },
+        );
+    }
+
+    #[cfg(test)]
+    fn fail_next_persist_state_for_test(&self) {
+        self.fail_next_persist_state.store(true, Ordering::Release);
     }
 
     /// Run Store の参照（テスト専用）。production 経路では下記 facade メソッドを使用する。
@@ -1140,13 +1321,9 @@ impl WorkflowEngine {
         data_dir: &std::path::Path,
         chat_session_id: &str,
     ) {
-        if let Err(e) = session_store.set_session_state(
-            data_dir,
-            chat_session_id,
-            crate::session::SessionState::Closed,
-        ) {
+        if let Err(e) = session_store.delete_session(data_dir, chat_session_id) {
             log::warn!(
-                "workflow start rollback failed to close parent session {chat_session_id}: {e}"
+                "workflow start rollback failed to delete parent session {chat_session_id}: {e}"
             );
         }
     }
@@ -1154,9 +1331,9 @@ impl WorkflowEngine {
     /// ステップの model 値から対応するバックエンドIDを解決する。
     /// 形式検証（`ModelId`）と登録判定（`resolve_backend_for_model`）を
     /// 一括で行い、`set_agent_model_internal` と同一の受け入れ基準を適用する。
-    async fn resolve_backend_for_step_model(
+    async fn resolve_backend_for_step_model<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         model: &str,
     ) -> Result<Option<String>, WorkflowEngineError> {
         let registry = app
@@ -1195,9 +1372,9 @@ impl WorkflowEngine {
     ///
     /// `start_step_session` と `start_parallel_children` の共通パターンを抽出したヘルパー。
     #[allow(clippy::too_many_arguments)]
-    async fn create_step_session_with_settings(
+    async fn create_step_session_with_settings<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &SessionStore,
         data_dir: &std::path::Path,
         worktree_path: &str,
@@ -1244,10 +1421,13 @@ impl WorkflowEngine {
     ///
     /// 戻り値は新しく払い出された `run_id`。
     /// `execution_id` を `run_id` として「昇格」させた値であり、ここ以外で採番されることはない。
+    /// state 変化の入口は `WorkflowCommand::StartRun` 経由の `dispatch` 一本に統一する
+    /// （Spec [04] 境界）。本メソッドは dispatch 内部からのみ呼ぶ private handler であり、
+    /// 外部入口として `pub` 公開しない。
     #[allow(clippy::too_many_arguments)]
-    pub async fn start_workflow(
+    async fn start_workflow<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         workflow: Workflow,
@@ -1379,12 +1559,31 @@ impl WorkflowEngine {
             }
         };
 
-        // NDJSONログ: workflow_started は履歴復元の必須 entry なので失敗を伝播する。
-        // ChatSession 永続化や broadcast より前に確定し、ログなし metadata を一覧に残さない。
+        // [04] projection: RunStarted append 前に ChatSession workflow_state を同期する。
+        // command 受理サイクル内の永続化失敗は command failure として扱い、
+        // executions / Run Store reservation / parent session を受理前へ戻して以後の
+        // event append / refs 登録・broadcast・初回 step 起動へ進まない。
+        if let Err(e) = self
+            .persist_state(app, session_store, &chat_session_id, snapshot.clone())
+            .await
+        {
+            let mut execs = self.executions.lock().await;
+            execs.remove(&run_id);
+            drop(execs);
+            rollback_reservation(format!("RunStarted projection failed: {e}")).await;
+            self.rollback_created_parent_session(session_store, &data_dir, &chat_session_id);
+            return Err(WorkflowEngineError::SessionStore(format!(
+                "RunStarted projection failed: {e}"
+            )));
+        }
+
+        // [04] commit point: RunStarted を最後に必須 append する。projection は
+        // rollback 可能な pre-commit 副作用として扱い、append 成功を command 受理の
+        // 最初の不可逆な可視 commit point とする。
         if let Err(e) = self.write_log_required(
             app,
-            WorkflowLogEvent::WorkflowStarted {
-                execution_id: snapshot.execution_id.clone(),
+            WorkflowEvent::RunStarted {
+                run_id: snapshot.execution_id.clone(),
                 workflow_name: snapshot.workflow_name.clone(),
                 workflow_file_stem: file_stem.to_string(),
                 worktree_path: worktree_path.clone(),
@@ -1395,14 +1594,15 @@ impl WorkflowEngine {
             let mut execs = self.executions.lock().await;
             execs.remove(&run_id);
             drop(execs);
-            rollback_reservation(format!("workflow_started log failed: {e}")).await;
+            rollback_reservation(format!("RunStarted log failed: {e}")).await;
             self.rollback_created_parent_session(session_store, &data_dir, &chat_session_id);
             return Err(WorkflowEngineError::SessionStore(format!(
-                "write workflow_started log failed: {e}"
+                "write RunStarted log failed: {e}"
             )));
         }
 
-        // session_workflow_refs に親セッションIDを登録（run_id 主語）
+        // [04] post-commit: refs 登録 / broadcast。RunStarted は append 済みのため
+        // command は既に受理。以後の失敗は warn として観測される。
         {
             let mut map = self.session_workflow_refs.lock().await;
             map.insert(
@@ -1413,22 +1613,6 @@ impl WorkflowEngine {
                 },
             );
         }
-
-        // 永続化・ブロードキャスト（ロック内で確定したスナップショットを使用）
-        if let Err(e) = self
-            .persist_state(app, session_store, &chat_session_id, snapshot.clone())
-            .await
-        {
-            let mut execs = self.executions.lock().await;
-            execs.remove(&run_id);
-            drop(execs);
-            self.cleanup_session_workflow_refs_by_run_id(&run_id).await;
-            // Run Store からも reservation を撤回する。terminal entry を残さないように
-            // cancel_reservation を優先する（Spec issues-1011 finding 9）。
-            rollback_reservation(format!("persist_state failed at start: {e}")).await;
-            self.rollback_created_parent_session(session_store, &data_dir, &chat_session_id);
-            return Err(e);
-        }
         self.broadcast_state(app, &worktree_path, snapshot.clone())
             .await;
 
@@ -1436,11 +1620,15 @@ impl WorkflowEngine {
         // 最初のステップが並列ブロックかどうかで分岐
         let first_step_is_parallel = workflow.nodes[0].is_parallel();
 
+        // [04] post-commit: RunStarted append 済みのため command は既に受理。
+        //    初回 session / parallel children 起動失敗は Failed 状態遷移として観測し、
+        //    dispatch(StartRun) は Ok(RunStarted { run_id }) を返す（spec [04]
+        //    『command 受理境界』Rule）。
         if first_step_is_parallel {
             // 並列ブロック → start_parallel_children を呼ぶ
             // (StepStartedログは書かず、start_parallel_children内でParallelStarted等を記録)
             if let Err(e) = self
-                .start_parallel_children(app, session_store, handles, &worktree_path)
+                .start_parallel_children(app, session_store, handles, &worktree_path, true)
                 .await
             {
                 let _ = self
@@ -1454,16 +1642,16 @@ impl WorkflowEngine {
                         },
                     )
                     .await;
-                return Err(e);
+                log::warn!("workflow {run_id}: post-commit start_parallel_children failed: {e}");
             }
         } else {
             // 逐次ステップ → StepStartedログ + start_step_session
             self.write_log(
                 app,
-                WorkflowLogEvent::StepStarted {
-                    execution_id: snapshot.execution_id,
+                WorkflowEvent::NodeStarted {
+                    run_id: snapshot.execution_id,
                     workflow_name: snapshot.workflow_name,
-                    step_name: step_name.clone(),
+                    node_name: step_name.clone(),
                     execution_count: 1,
                     timestamp: now,
                 },
@@ -1495,10 +1683,143 @@ impl WorkflowEngine {
                         },
                     )
                     .await;
-                return Err(e);
+                log::warn!("workflow {run_id}: post-commit start_step_session failed: {e}");
             }
         }
         Ok(run_id)
+    }
+
+    /// [04] Command / Event Boundary: 全 typed command の単一入口。
+    ///
+    /// UI / Tauri command / 内部呼び出し元は、本メソッドだけを通じて engine state を
+    /// 変化させる。各 variant は既存 handler（`start_workflow` / `abort_workflow_by_run_id`
+    /// / `handle_approval`）に委譲する。`StartRun` の `worktree_path` は注入された
+    /// `ManagedWorktreeResolver` で正規化し、engine core は AppConfig / Git worktree 列挙を
+    /// 直接知らない。
+    pub async fn dispatch<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        command: WorkflowCommand,
+    ) -> Result<WorkflowCommandResult, WorkflowEngineError> {
+        self.dispatch_core(app, session_store, handles, command)
+            .await
+    }
+
+    async fn dispatch_core<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        command: WorkflowCommand,
+    ) -> Result<WorkflowCommandResult, WorkflowEngineError> {
+        match command {
+            WorkflowCommand::StartRun {
+                workflow_file_stem,
+                worktree_path,
+                task,
+                trigger_source,
+                permission_mode,
+            } => {
+                crate::workflow::validation::validate_name(&workflow_file_stem).map_err(|e| {
+                    WorkflowEngineError::ValidationError(format!("validation_error: {e}"))
+                })?;
+
+                let worktree_path = self.worktree_resolver.resolve(worktree_path).await?;
+
+                let file_stem = workflow_file_stem.clone();
+                let workflow = self.workflow_resolver.resolve(&workflow_file_stem).await?;
+
+                let run_id = self
+                    .start_workflow(
+                        app,
+                        session_store,
+                        handles,
+                        workflow,
+                        worktree_path,
+                        &file_stem,
+                        task,
+                        trigger_source,
+                        permission_mode,
+                    )
+                    .await?;
+                Ok(WorkflowCommandResult::RunStarted { run_id })
+            }
+            WorkflowCommand::AbortRun {
+                run_id,
+                expected_node_name,
+            } => {
+                if let Some(node_name) = expected_node_name {
+                    // approval UI 由来の Abort: 現在の承認待ち node との一致を検証して
+                    // handle_approval 経路で受理する。stale node に対する Abort は
+                    // UnauthorizedApprovalTarget で非受理として返る。
+                    self.handle_approval(
+                        app,
+                        session_store,
+                        handles,
+                        &run_id,
+                        ApprovalDecision::Abort,
+                        None,
+                        Some(&node_name),
+                    )
+                    .await?;
+                    Ok(WorkflowCommandResult::Accepted)
+                } else {
+                    // run 全体の Abort: NotFound / AlreadyTerminal は非受理として
+                    // typed error に射影する（Spec [04] Rule「対象不在 / 既に終了した
+                    // command は受理されない」）。
+                    match self
+                        .abort_workflow_by_run_id(app, session_store, handles, &run_id)
+                        .await?
+                    {
+                        AbortOutcome::Aborted => Ok(WorkflowCommandResult::Accepted),
+                        AbortOutcome::NotFound => {
+                            Err(WorkflowEngineError::ExecutionNotFound(run_id))
+                        }
+                        AbortOutcome::AlreadyTerminal => Err(WorkflowEngineError::InvalidState(
+                            format!("run {run_id} is already terminal"),
+                        )),
+                    }
+                }
+            }
+            WorkflowCommand::ApproveNode {
+                run_id,
+                node_name,
+                comment,
+            } => {
+                self.handle_approval(
+                    app,
+                    session_store,
+                    handles,
+                    &run_id,
+                    ApprovalDecision::Approve,
+                    comment,
+                    Some(&node_name),
+                )
+                .await?;
+                Ok(WorkflowCommandResult::Accepted)
+            }
+            WorkflowCommand::RejectNode {
+                run_id,
+                node_name,
+                reason,
+            } => {
+                self.handle_approval(
+                    app,
+                    session_store,
+                    handles,
+                    &run_id,
+                    ApprovalDecision::Reject {
+                        comment: reason.clone(),
+                    },
+                    Some(reason),
+                    Some(&node_name),
+                )
+                .await?;
+                Ok(WorkflowCommandResult::Accepted)
+            }
+        }
     }
 
     /// turn_complete後に呼ばれるフック。
@@ -1506,9 +1827,9 @@ impl WorkflowEngine {
     /// SessionError / WaitApproval は判定 + 状態変更を1回のロックで原子的に実行する。
     /// AutoEvaluate はタグ検出が必要なため handle_auto_complete に委譲する。
     #[allow(clippy::too_many_arguments)]
-    pub async fn on_turn_complete(
+    pub async fn on_turn_complete<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         session_id: &str,
@@ -1565,6 +1886,12 @@ impl WorkflowEngine {
                 .await;
         }
 
+        struct TurnCommit {
+            outcome: StepOutcome,
+            required_events: Vec<WorkflowEvent>,
+            rollback_snapshot: Option<(String, WorkflowExecution)>,
+        }
+
         // 判定 + 状態変更を原子的に実行（AutoEvaluate以外）
         let (chat_session_id, action_or_outcome) = {
             let mut execs = self.executions.lock().await;
@@ -1610,15 +1937,31 @@ impl WorkflowEngine {
                         ),
                     };
                     exec.updated_at = current_timestamp();
-                    Ok(StepOutcome::Persist(exec.to_workflow_state()))
+                    Ok(TurnCommit {
+                        outcome: StepOutcome::Persist(exec.to_workflow_state()),
+                        required_events: Vec::new(),
+                        rollback_snapshot: None,
+                    })
                 }
                 TurnCompleteAction::WaitApproval => {
                     if exec.is_terminal() {
                         return Ok(());
                     }
+                    let snapshot_before = exec.clone();
+                    let workflow_name = exec.workflow.name.clone();
+                    let node_name = exec.workflow.nodes[exec.current_step_index].name.clone();
                     exec.state = WorkflowExecutionState::WaitingApproval;
                     exec.updated_at = current_timestamp();
-                    Ok(StepOutcome::Persist(exec.to_workflow_state()))
+                    Ok(TurnCommit {
+                        outcome: StepOutcome::Persist(exec.to_workflow_state()),
+                        required_events: vec![WorkflowEvent::ApprovalRequested {
+                            run_id: exec.id.clone(),
+                            workflow_name,
+                            node_name,
+                            timestamp: exec.updated_at,
+                        }],
+                        rollback_snapshot: Some((exec.id.clone(), snapshot_before)),
+                    })
                 }
                 TurnCompleteAction::UnexpectedNodeType {
                     step_name,
@@ -1635,7 +1978,11 @@ impl WorkflowEngine {
                     exec.step_history.push(entry);
                     exec.state = WorkflowExecutionState::Failed { reason };
                     exec.updated_at = current_timestamp();
-                    Ok(StepOutcome::Persist(exec.to_workflow_state()))
+                    Ok(TurnCommit {
+                        outcome: StepOutcome::Persist(exec.to_workflow_state()),
+                        required_events: Vec::new(),
+                        rollback_snapshot: None,
+                    })
                 }
                 TurnCompleteAction::AutoEvaluate { rules, step_name } => Err((rules, step_name)),
             };
@@ -1643,16 +1990,30 @@ impl WorkflowEngine {
         };
 
         match action_or_outcome {
-            Ok(outcome) => {
-                self.execute_outcome(
-                    app,
-                    session_store,
-                    handles,
-                    &worktree_path,
-                    &chat_session_id,
-                    outcome,
-                )
-                .await
+            Ok(commit) => {
+                if commit.required_events.is_empty() {
+                    self.execute_outcome(
+                        app,
+                        session_store,
+                        handles,
+                        &worktree_path,
+                        &chat_session_id,
+                        commit.outcome,
+                    )
+                    .await
+                } else {
+                    self.commit_required_turn_events_and_execute_outcome(
+                        app,
+                        session_store,
+                        handles,
+                        &worktree_path,
+                        &chat_session_id,
+                        commit.outcome,
+                        commit.required_events,
+                        commit.rollback_snapshot,
+                    )
+                    .await
+                }
             }
             Err((rules, step_name)) => {
                 self.handle_auto_complete(
@@ -1669,6 +2030,68 @@ impl WorkflowEngine {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn commit_required_turn_events_and_execute_outcome<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        worktree_path: &str,
+        chat_session_id: &str,
+        outcome: StepOutcome,
+        required_events: Vec<WorkflowEvent>,
+        rollback_snapshot: Option<(String, WorkflowExecution)>,
+    ) -> Result<(), WorkflowEngineError> {
+        let Some((run_id, snapshot_before)) = rollback_snapshot else {
+            return Err(WorkflowEngineError::SessionStore(
+                "required turn event commit missing rollback snapshot".to_string(),
+            ));
+        };
+        let completed_step_session_ids = Self::completed_step_session_ids_for_outcome(&outcome);
+        let snapshot_for_commit = Self::outcome_snapshot(&outcome).clone();
+        let run_store_snapshot_before = self.run_store.active_run_snapshot(&run_id).await;
+
+        self.commit_required_events(
+            app,
+            session_store,
+            RequiredEventCommit {
+                run_id: &run_id,
+                chat_session_id,
+                snapshot_for_commit: &snapshot_for_commit,
+                snapshot_before,
+                run_store_snapshot_before,
+                required_events,
+                append_error_context: "turn_complete required event append failed",
+            },
+        )
+        .await?;
+
+        self.release_completed_step_sessions(
+            app,
+            session_store,
+            handles,
+            &completed_step_session_ids,
+        )
+        .await;
+        self.finalize_after_commit(app, &snapshot_for_commit, worktree_path, true)
+            .await;
+        if let Err(e) = self
+            .dispatch_step_outcome_side_effects(
+                app,
+                session_store,
+                handles,
+                worktree_path,
+                chat_session_id,
+                outcome,
+                OutcomeCommitMode::EmitProgressEvents,
+            )
+            .await
+        {
+            log::warn!("workflow {run_id}: post-commit turn side effects failed: {e}");
+        }
+        Ok(())
+    }
+
     /// ApprovalDecisionのバリデーション。Reject時に空コメントを拒否する。
     fn validate_approval_decision(decision: &ApprovalDecision) -> Result<(), WorkflowEngineError> {
         if let ApprovalDecision::Reject { ref comment } = decision {
@@ -1680,6 +2103,20 @@ impl WorkflowEngine {
             if comment.chars().count() > MAX_APPROVAL_COMMENT_CHARS {
                 return Err(WorkflowEngineError::ValidationError(
                     "Reject comment exceeds 8192 characters".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Approve 用 comment のバリデーション。空文字は許容するが、上限のみ検証する。
+    /// reject と同じ MAX_APPROVAL_COMMENT_CHARS を `ApproveNode.comment` にも適用する
+    /// （Spec [04]: 新規外部入力に対する境界バリデーション）。
+    fn validate_approve_comment_length(comment: Option<&str>) -> Result<(), WorkflowEngineError> {
+        if let Some(c) = comment {
+            if c.chars().count() > MAX_APPROVAL_COMMENT_CHARS {
+                return Err(WorkflowEngineError::ValidationError(
+                    "Approve comment exceeds 8192 characters".to_string(),
                 ));
             }
         }
@@ -1736,20 +2173,25 @@ impl WorkflowEngine {
     /// 直接行い、worktree_path 経由の find は使用しない。同一 worktree に terminal/active
     /// 共存があっても run_id 主語で取り違えない。worktree_path は exec から派生取得して
     /// 下流 (`fetch_current_output` / `execute_outcome`) に渡す。
+    /// [04] 内部 typed boundary: `WorkflowCommand::ApproveNode` / `RejectNode` /
+    /// `AbortRun { expected_node_name: Some(_) }` の handler 実体。外部から直接
+    /// 呼び出すことは禁止する（pub にしない）。本メソッドへの到達経路は engine の
+    /// dispatch のみであり、auto-approve も dispatch 経由で再入する（Spec [04] 境界）。
     #[allow(clippy::too_many_arguments)]
-    pub async fn handle_approval(
+    async fn handle_approval<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         run_id: &str,
         decision: ApprovalDecision,
+        approve_comment: Option<String>,
         expected_step_name: Option<&str>,
     ) -> Result<(), WorkflowEngineError> {
-        let result_tag = match &decision {
-            ApprovalDecision::Approve => "approve",
-            ApprovalDecision::Reject { .. } => "reject",
-            ApprovalDecision::Abort => "abort",
+        let (result_tag, decision_record) = match &decision {
+            ApprovalDecision::Approve => ("approve", ApprovalDecisionRecord::Approve),
+            ApprovalDecision::Reject { .. } => ("reject", ApprovalDecisionRecord::Reject),
+            ApprovalDecision::Abort => ("abort", ApprovalDecisionRecord::Abort),
         };
 
         // target検証 + session_id + output_contract + workflow + worktree_path を1回のロックで取得
@@ -1776,8 +2218,12 @@ impl WorkflowEngine {
             )
         };
 
-        // Reject時: 空コメントバリデーション（副作用の前に実施）
+        // Reject時: 空コメントバリデーション + Approve/Reject 共通の長さ上限検証
+        // （副作用の前に実施）
         Self::validate_approval_decision(&decision)?;
+        if matches!(decision, ApprovalDecision::Approve) {
+            Self::validate_approve_comment_length(approve_comment.as_deref())?;
+        }
 
         if matches!(decision, ApprovalDecision::Approve) {
             let turn_phase = if let Some(ref sid) = current_session_id {
@@ -1789,14 +2235,16 @@ impl WorkflowEngine {
             Self::validate_approval_turn_phase(turn_phase)?;
         }
 
-        // ロック外でoutput_textを事前取得（approvalはAgentSession完了後なので取得可能）
-        // Reject時はコメントをoutput_textとして使用するため、fetch不要だがApprove時に必要
+        // ロック外でoutput_textを事前取得（approvalはAgentSession完了後なので取得可能）。
+        // Approve時だけAgentSession出力が必要。Rejectは理由をoutput_textとして使い、
+        // Abortは出力を使わないため、不要な取得失敗で中断 command を阻害しない。
         let output_text = match &decision {
-            ApprovalDecision::Reject { ref comment } => Some(comment.clone()),
-            _ => {
+            ApprovalDecision::Approve => {
                 self.fetch_current_output(app, session_store, &worktree_path)
                     .await?
             }
+            ApprovalDecision::Reject { ref comment } => Some(comment.clone()),
+            ApprovalDecision::Abort => None,
         };
 
         // contract検証（Approve時のみ）。approvalではrepair/failに進めず、状態を変えずに
@@ -1838,14 +2286,26 @@ impl WorkflowEngine {
         // contract resultがあればそちらを優先、なければresult_tag
         let effective_result = contract_result.unwrap_or_else(|| result_tag.to_string());
 
-        // 判定 + 状態変更 + 履歴記録を原子的に実行（run_id 主語）
-        let (chat_session_id, outcome) = {
+        // [04] atomic mutation 境界: mutation 直前の WorkflowExecution 全体を snapshot に
+        // 保持し、ApprovalResolved event append / persist のいずれかが失敗した場合は
+        // `*exec = snapshot` で全フィールド（履歴・変数・state・current_step_index 等）を
+        // 一括復元する。部分 rollback helper は使わない。
+        let (
+            chat_session_id,
+            outcome,
+            exec_snapshot_before,
+            workflow_name_for_event,
+            node_name_for_event,
+        ) = {
             let mut execs = self.executions.lock().await;
             let exec = execs
                 .get_mut(run_id)
                 .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(run_id.to_string()))?;
             Self::validate_approval_target_snapshot(exec, Some(run_id), expected_step_name)?;
             let chat_session_id = exec.chat_session_id.clone();
+            let workflow_name = exec.workflow.name.clone();
+            let node_name = exec.workflow.nodes[exec.current_step_index].name.clone();
+            let snapshot_before = exec.clone();
             exec.workflow_variables.extend(contract_variables);
             let outcome = Self::apply_approval_application(
                 exec,
@@ -1856,18 +2316,89 @@ impl WorkflowEngine {
                     output_contract: application_output_contract,
                 },
             )?;
-            (chat_session_id, outcome)
+            (
+                chat_session_id,
+                outcome,
+                snapshot_before,
+                workflow_name,
+                node_name,
+            )
         };
 
-        self.execute_outcome(
+        let snapshot_for_commit = Self::outcome_snapshot(&outcome).clone();
+        let completed_step_session_ids = Self::completed_step_session_ids_for_outcome(&outcome);
+        let run_store_snapshot_before = self.run_store.active_run_snapshot(run_id).await;
+
+        // [04] commit point: ApprovalResolved と、同じ受理サイクルで確定した
+        // NodeCompleted / NodeStarted / terminal event を同一 batch で必須 append する。
+        // append / persist 失敗時は snapshot で全フィールド一括復元する。
+        // 機密値 redaction: approve コメント / reject 理由には設定済み secret を含む可能性が
+        // あるため、event log に保存する前に mask_sensitive_text() で redaction する
+        // （reject_structured_output が同じ secret 列で structured_output 側に行う処理と対称）。
+        let raw_event_comment = match &decision {
+            ApprovalDecision::Approve => approve_comment.clone(),
+            ApprovalDecision::Reject { comment } => Some(comment.clone()),
+            ApprovalDecision::Abort => approve_comment.clone(),
+        };
+        let event_comment = if let Some(raw) = raw_event_comment {
+            let secrets = Self::collect_configured_secret_values(app);
+            Some(Self::mask_sensitive_text(&raw, &secrets))
+        } else {
+            None
+        };
+        let approval_timestamp = current_timestamp();
+        let approval_event = WorkflowEvent::ApprovalResolved {
+            run_id: run_id.to_string(),
+            workflow_name: workflow_name_for_event.clone(),
+            node_name: node_name_for_event.clone(),
+            decision: decision_record,
+            comment: event_comment,
+            timestamp: approval_timestamp,
+        };
+        let commit_events = Self::required_events_for_approval_commit(approval_event, &outcome);
+        self.commit_required_events(
+            app,
+            session_store,
+            RequiredEventCommit {
+                run_id,
+                chat_session_id: &chat_session_id,
+                snapshot_for_commit: &snapshot_for_commit,
+                snapshot_before: exec_snapshot_before,
+                run_store_snapshot_before,
+                required_events: commit_events,
+                append_error_context: "approval commit batch append failed",
+            },
+        )
+        .await?;
+
+        // [04] post-commit: required event append 済みのため、ここから先の失敗は
+        // command failure に射影しない（spec [04] post-commit 境界）。session release /
+        // broadcast / terminal log / cleanup / 次 step 起動 / auto-approve dispatch は
+        // ここで実行する。
+        self.release_completed_step_sessions(
             app,
             session_store,
             handles,
-            &worktree_path,
-            &chat_session_id,
-            outcome,
+            &completed_step_session_ids,
         )
-        .await
+        .await;
+        self.finalize_after_commit(app, &snapshot_for_commit, &worktree_path, false)
+            .await;
+        if let Err(e) = self
+            .dispatch_step_outcome_side_effects(
+                app,
+                session_store,
+                handles,
+                &worktree_path,
+                &chat_session_id,
+                outcome,
+                OutcomeCommitMode::ProgressEventsAlreadyCommitted,
+            )
+            .await
+        {
+            log::warn!("workflow {run_id}: post-commit side effects failed: {e}");
+        }
+        Ok(())
     }
 
     /// ワークフローを中断する。
@@ -1876,50 +2407,150 @@ impl WorkflowEngine {
     /// Spec issues-1011 finding 2/10: 全経路で `executions.get_mut(run_id)` を使い、
     /// worktree_path 経由の委譲を排除する。これにより、同一 worktree に terminal run と
     /// active run が共存しても誤って別 run を中断する TOCTOU を構造的に排除する。
-    pub async fn abort_workflow_by_run_id(
+    ///
+    /// Spec [04]: `AbortRun` command handler の境界。
+    /// - 対象 run が存在しない場合は `AbortOutcome::NotFound` を返す（非受理）。
+    /// - 既に terminal な run の場合は `AbortOutcome::AlreadyTerminal` を返す（非受理）。
+    /// - 実際に Aborted に遷移し RunAborted event を必須 append できた場合のみ
+    ///   `AbortOutcome::Aborted` を返す。
+    ///
+    /// RunAborted event は `write_log_required` 経由で必須 append し、append 失敗時は
+    /// mutation 直前 snapshot で `WorkflowExecution` 全体を一括復元する
+    /// （Spec atomic mutation 境界）。
+    ///
+    /// 外部から直接呼ばれることはなく、`WorkflowEngine::dispatch` 経路のみが利用する
+    /// （Spec [04]: 内部呼び出し元も engine の private method を直接叩かない）。
+    async fn abort_workflow_by_run_id<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         run_id: &str,
-    ) -> Result<(), WorkflowEngineError> {
-        // run_id でロック内 lookup（同一 worktree の別 active run と取り違えない）。
-        let Some((current_step_session_id, parallel_session_ids)) =
-            self.abort_target_sessions_by_run_id(run_id).await
-        else {
-            return Ok(());
+    ) -> Result<AbortOutcome, WorkflowEngineError> {
+        // 1. 対象 run の存在 + active 性を判定。
+        //    非受理経路 (NotFound / AlreadyTerminal) ではどんな外部副作用も発生させない。
+        let lookup = self.abort_target_lookup(run_id).await;
+        let (current_step_session_id, parallel_session_ids) = match lookup {
+            AbortTargetLookup::NotFound => return Ok(AbortOutcome::NotFound),
+            AbortTargetLookup::AlreadyTerminal => return Ok(AbortOutcome::AlreadyTerminal),
+            AbortTargetLookup::Active {
+                current_step_session_id,
+                parallel_session_ids,
+            } => (current_step_session_id, parallel_session_ids),
         };
 
-        // 実行中のステップセッションを中断
+        // 2. [04] pre-commit (rollback 可能): mutation 直前 snapshot を取得し、
+        //    state を Aborted に遷移させる。競合で terminal 化していた場合は
+        //    AlreadyTerminal で返す。
+        let timestamp = current_timestamp();
+        let run_store_snapshot_before = self.run_store.active_run_snapshot(run_id).await;
+        let (chat_session_id, snapshot_before, snapshot_state, workflow_name_for_event) = {
+            let mut execs = self.executions.lock().await;
+            let Some(exec) = execs.get_mut(run_id) else {
+                return Ok(AbortOutcome::NotFound);
+            };
+            if !exec.is_active() {
+                return Ok(AbortOutcome::AlreadyTerminal);
+            }
+            let chat_session_id = exec.chat_session_id.clone();
+            let snapshot_before = exec.clone();
+            let workflow_name = exec.workflow.name.clone();
+            exec.state = WorkflowExecutionState::Aborted;
+            exec.updated_at = timestamp;
+            let snapshot_state = exec.to_workflow_state();
+            (
+                chat_session_id,
+                snapshot_before,
+                snapshot_state,
+                workflow_name,
+            )
+        };
+
+        // 3. [04] commit point: RunAborted を必須 append。失敗時は
+        //    WorkflowExecution / Run Store / ChatSession を snapshot で一括復元する。
+        //    interrupt_agent はこの時点ではまだ実行していないため、append 失敗時には
+        //    rollback 不能な外部副作用が残らない。
+        let aborted_event = WorkflowEvent::RunAborted {
+            run_id: run_id.to_string(),
+            workflow_name: workflow_name_for_event,
+            timestamp,
+        };
+        self.commit_required_events(
+            app,
+            session_store,
+            RequiredEventCommit {
+                run_id,
+                chat_session_id: &chat_session_id,
+                snapshot_for_commit: &snapshot_state,
+                snapshot_before,
+                run_store_snapshot_before,
+                required_events: vec![aborted_event],
+                append_error_context: "RunAborted log failed",
+            },
+        )
+        .await?;
+
+        // 4. [04] post-commit: interrupt_agent / cleanup / broadcast。
+        //    RunAborted event は append 済み。Run Store / ChatSession は event 後の
+        //    projection として同期済み、または warn として観測済み。
         if let Some(ref step_sid) = current_step_session_id {
             self.interrupt_agent(handles, step_sid).await;
         }
-        // 並列子ステップのセッションも中断
-        if let Some(session_ids) = parallel_session_ids {
-            for sid in &session_ids {
+        if let Some(ref session_ids) = parallel_session_ids {
+            for sid in session_ids {
                 self.interrupt_agent(handles, sid).await;
             }
         }
-
-        // 状態遷移は run_id 主語で行う（worktree_path は inner で exec から派生取得）。
-        self.set_execution_state_for_run(
+        self.finalize_terminal_transition_after_required_append(
             app,
             session_store,
             handles,
             run_id,
-            WorkflowExecutionState::Aborted,
         )
-        .await
+        .await;
+
+        Ok(AbortOutcome::Aborted)
     }
 
-    async fn abort_target_sessions_by_run_id(
+    /// `WorkflowCommand::AbortRun` の post-commit 区間。state は呼出し前に Aborted に
+    /// 遷移済みで、`RunAborted` event は必須 append 済み、かつ Run Store sync も
+    /// 完了済みである前提。ChatSession persist / step session release / refs cleanup /
+    /// broadcast を実行する。
+    ///
+    /// [04] post-commit 失敗は warn ログのみで command 結果に伝播させない。観測可能な
+    /// 事実は既に RunAborted で確定しており、ここでの副作用失敗を command failure に
+    /// 射影すると spec [04] の「post-commit 失敗は command failure として返さない」に
+    /// 違反するため。
+    async fn finalize_terminal_transition_after_required_append<R: tauri::Runtime>(
         &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
         run_id: &str,
-    ) -> Option<(Option<String>, Option<Vec<String>>)> {
+    ) {
+        let (snapshot, worktree_path) = {
+            let execs = self.executions.lock().await;
+            let Some(exec) = execs.get(run_id) else {
+                return;
+            };
+            (exec.to_workflow_state(), exec.worktree_path.clone())
+        };
+
+        // terminal session の release と refs cleanup。
+        let terminal_session_ids = Self::terminal_step_session_ids(&snapshot);
+        self.release_completed_step_sessions(app, session_store, handles, &terminal_session_ids)
+            .await;
+        self.cleanup_session_workflow_refs_by_run_id(run_id).await;
+        self.broadcast_state(app, &worktree_path, snapshot).await;
+    }
+
+    async fn abort_target_lookup(&self, run_id: &str) -> AbortTargetLookup {
         let execs = self.executions.lock().await;
-        let exec = execs.get(run_id)?;
+        let Some(exec) = execs.get(run_id) else {
+            return AbortTargetLookup::NotFound;
+        };
         if !exec.is_active() {
-            return None;
+            return AbortTargetLookup::AlreadyTerminal;
         }
         let current_step_session_id = exec.current_session_id.clone();
         let parallel_session_ids = exec.parallel_run.as_ref().map(|pr| {
@@ -1929,14 +2560,17 @@ impl WorkflowEngine {
                 .map(|c| c.session_id.clone())
                 .collect::<Vec<_>>()
         });
-        Some((current_step_session_id, parallel_session_ids))
+        AbortTargetLookup::Active {
+            current_step_session_id,
+            parallel_session_ids,
+        }
     }
 
     /// 並列子ステップの完了を処理する。
     #[allow(clippy::too_many_arguments)]
-    async fn handle_parallel_child_complete(
+    async fn handle_parallel_child_complete<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         run_id: &str,
@@ -2250,11 +2884,11 @@ impl WorkflowEngine {
             // ParallelStepCompleted ログ
             self.write_log(
                 app,
-                WorkflowLogEvent::ParallelStepCompleted {
-                    execution_id: exec.id.clone(),
+                WorkflowEvent::ParallelChildCompleted {
+                    run_id: exec.id.clone(),
                     workflow_name: exec.workflow.name.clone(),
-                    parent_step_name: pr.parent_step_name.clone(),
-                    child_step_name: child_name,
+                    parent_node_name: pr.parent_step_name.clone(),
+                    child_node_name: child_name,
                     result: log_result,
                     session_id: session_id.to_string(),
                     token_usage: Some(child_token_usage),
@@ -2362,10 +2996,10 @@ impl WorkflowEngine {
                     // ParallelCompleted ログ
                     self.write_log(
                         app,
-                        WorkflowLogEvent::ParallelCompleted {
-                            execution_id: exec.id.clone(),
+                        WorkflowEvent::ParallelCompleted {
+                            run_id: exec.id.clone(),
                             workflow_name: exec.workflow.name.clone(),
-                            parent_step_name: parent_step_name.clone(),
+                            parent_node_name: parent_step_name.clone(),
                             aggregate_result: if agg_result {
                                 "then".to_string()
                             } else {
@@ -2402,10 +3036,10 @@ impl WorkflowEngine {
                     // ParallelCompleted ログ
                     self.write_log(
                         app,
-                        WorkflowLogEvent::ParallelCompleted {
-                            execution_id: exec.id.clone(),
+                        WorkflowEvent::ParallelCompleted {
+                            run_id: exec.id.clone(),
                             workflow_name: exec.workflow.name.clone(),
-                            parent_step_name: parent_step_name.clone(),
+                            parent_node_name: parent_step_name.clone(),
                             aggregate_result: "advance".to_string(),
                             timestamp: current_timestamp(),
                         },
@@ -2508,8 +3142,8 @@ impl WorkflowEngine {
         }
     }
 
-    fn validate_approval_output_contract(
-        app: &tauri::AppHandle,
+    fn validate_approval_output_contract<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
         output_contract: &Option<String>,
         output_text: Option<&str>,
         workflow: &Workflow,
@@ -2640,9 +3274,9 @@ impl WorkflowEngine {
     /// 非並列stepのcontract検証を共通処理する。
     /// auto および並列子ステップの2パスで同一のcontract検証・retry・failure処理を行う。
     #[allow(clippy::too_many_arguments)]
-    async fn validate_and_handle_contract(
+    async fn validate_and_handle_contract<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         worktree_path: &str,
@@ -2766,9 +3400,9 @@ impl WorkflowEngine {
     /// contract violation時のrepair prompt送信を行う共通ヘルパー。
     /// ログ書き込み・ファセット読み込み・repair prompt生成・agent turn送信を一箇所にまとめる。
     #[allow(clippy::too_many_arguments)]
-    async fn send_contract_repair(
+    async fn send_contract_repair<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         worktree_path: &str,
@@ -2782,10 +3416,10 @@ impl WorkflowEngine {
     ) -> Result<(), WorkflowEngineError> {
         self.write_log(
             app,
-            WorkflowLogEvent::ContractRepairRequested {
-                execution_id: exec_id.to_string(),
+            WorkflowEvent::ContractRepairRequested {
+                run_id: exec_id.to_string(),
                 workflow_name: wf_name.to_string(),
-                step_name: step_name.to_string(),
+                node_name: step_name.to_string(),
                 attempt,
                 violation_reason: violation.reason.clone(),
                 timestamp: current_timestamp(),
@@ -2854,9 +3488,9 @@ impl WorkflowEngine {
         execs.get(run_id).map(|e| e.to_workflow_state())
     }
 
-    async fn emit_workflow_runtime_projection(
+    async fn emit_workflow_runtime_projection<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         open_tabs: &crate::session::OpenTabRegistry,
         worktree_path: &str,
@@ -3088,9 +3722,9 @@ impl WorkflowEngine {
     /// 内部実装は `set_execution_state_inner` に集約され、worktree_path 主語の場合は
     /// `find_by_worktree_mut`、run_id 主語の場合は `executions.get_mut(run_id)` で
     /// lookup する。
-    async fn set_execution_state(
+    async fn set_execution_state<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         worktree_path: &str,
@@ -3106,33 +3740,12 @@ impl WorkflowEngine {
         .await
     }
 
-    /// `run_id` を主語に実行状態を更新する。`executions.get_mut(run_id)` で直接 lookup する
-    /// ため、同一 worktree に terminal/active 共存していても誤った run を遷移させない
-    /// （Spec issues-1011 finding 2/10: abort 経路の TOCTOU 解消）。
-    async fn set_execution_state_for_run(
-        &self,
-        app: &tauri::AppHandle,
-        session_store: &Arc<SessionStore>,
-        handles: &Arc<Mutex<AgentProcessMap>>,
-        run_id: &str,
-        new_state: WorkflowExecutionState,
-    ) -> Result<(), WorkflowEngineError> {
-        self.set_execution_state_inner(
-            app,
-            session_store,
-            handles,
-            ExecutionStateTarget::RunId(run_id.to_string()),
-            new_state,
-        )
-        .await
-    }
-
     /// 実行状態更新の内部実装。lookup 戦略を `target` で切り替える。
     /// Spec issues-1011 finding 10: Run Store sync 失敗時は engine state も巻き戻し、
     /// engine terminal / Run Store active のスキューを残さない。
-    async fn set_execution_state_inner(
+    async fn set_execution_state_inner<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         target: ExecutionStateTarget,
@@ -3143,16 +3756,6 @@ impl WorkflowEngine {
             let exec = match &target {
                 ExecutionStateTarget::Worktree(wt) => find_by_worktree_mut(&mut execs, wt)
                     .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(wt.clone()))?,
-                ExecutionStateTarget::RunId(run_id) => {
-                    let Some(exec) = execs.get_mut(run_id) else {
-                        return Err(WorkflowEngineError::ExecutionNotFound(run_id.clone()));
-                    };
-                    // run_id 起点では active であることを再検証する（terminal は no-op）。
-                    if !exec.is_active() {
-                        return Ok(());
-                    }
-                    exec
-                }
             };
             // 終了状態（Completed/Failed/Aborted）からの上書きを防止
             if exec.is_terminal() {
@@ -3298,6 +3901,82 @@ impl WorkflowEngine {
         })
     }
 
+    async fn restore_run_store_active_snapshot(
+        &self,
+        run_snapshot: Option<WorkflowRun>,
+    ) -> Result<(), WorkflowEngineError> {
+        let Some(run_snapshot) = run_snapshot else {
+            return Ok(());
+        };
+        let run_id = run_snapshot.run_id.clone();
+        self.run_store
+            .restore_active_snapshot_for_rollback(run_snapshot)
+            .await
+            .map_err(|e| {
+                WorkflowEngineError::SessionStore(format!(
+                    "RunStore rollback failed for run {run_id}: {e}"
+                ))
+            })
+    }
+
+    async fn restore_chat_session_workflow_state<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        chat_session_id: &str,
+        snapshot: &WorkflowExecution,
+    ) {
+        if let Err(e) = self
+            .persist_state(
+                app,
+                session_store,
+                chat_session_id,
+                snapshot.to_workflow_state(),
+            )
+            .await
+        {
+            log::warn!(
+                "workflow {}: ChatSession rollback failed for {chat_session_id}: {e}",
+                snapshot.id
+            );
+        }
+    }
+
+    async fn rollback_command_mutation<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        rollback: CommandMutationRollback<'_>,
+    ) -> Result<(), WorkflowEngineError> {
+        let CommandMutationRollback {
+            run_id,
+            chat_session_id,
+            snapshot_before,
+            run_store_snapshot_before,
+            context,
+        } = rollback;
+        let run_store_result = self
+            .restore_run_store_active_snapshot(run_store_snapshot_before)
+            .await;
+        if let Err(ref rollback_err) = run_store_result {
+            log::warn!(
+                "workflow {run_id}: Run Store rollback failed after {context}: {rollback_err}"
+            );
+        }
+        self.restore_chat_session_workflow_state(
+            app,
+            session_store,
+            chat_session_id,
+            &snapshot_before,
+        )
+        .await;
+        let mut execs = self.executions.lock().await;
+        if let Some(exec) = execs.get_mut(run_id) {
+            *exec = snapshot_before;
+        }
+        run_store_result
+    }
+
     async fn rollback_execution_projection_after_run_store_sync_failure(
         &self,
         run_id: &str,
@@ -3343,9 +4022,9 @@ impl WorkflowEngine {
     /// output_contractが設定されたステップではcontract検証を実行し、
     /// 違反時はリトライプロンプトを送信する。
     #[allow(clippy::too_many_arguments)]
-    async fn handle_auto_complete(
+    async fn handle_auto_complete<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         worktree_path: &str,
@@ -3502,9 +4181,9 @@ impl WorkflowEngine {
     ///
     /// production 経路。副作用境界を `RealStepSessionDeps` にラップし、コアロジック
     /// `start_step_session_with_deps` に委譲する。
-    async fn start_step_session(
+    async fn start_step_session<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         session_store: &Arc<SessionStore>,
         worktree_path: &str,
@@ -3794,8 +4473,8 @@ impl WorkflowEngine {
         vars
     }
 
-    fn mask_sensitive_structured_output(
-        app: &tauri::AppHandle,
+    fn mask_sensitive_structured_output<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
         contract: &str,
         value: serde_json::Value,
     ) -> serde_json::Value {
@@ -3815,7 +4494,9 @@ impl WorkflowEngine {
         value
     }
 
-    fn collect_configured_secret_values(app: &tauri::AppHandle) -> Vec<String> {
+    fn collect_configured_secret_values<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+    ) -> Vec<String> {
         let mut values = Vec::new();
         if let Some(config) = app.try_state::<Arc<crate::config::AppConfig>>() {
             if let Ok(cfg) = config.get_config() {
@@ -3944,9 +4625,9 @@ impl WorkflowEngine {
 
     /// 現在のステップセッションからoutput_textを取得する。
     /// handle_approval で現在ステップの出力を取得する。
-    async fn fetch_current_output(
+    async fn fetch_current_output<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         worktree_path: &str,
     ) -> Result<Option<String>, WorkflowEngineError> {
@@ -3964,8 +4645,8 @@ impl WorkflowEngine {
     }
 
     /// セッションから最後のAgentメッセージのテキストを抽出する。
-    async fn extract_last_assistant_output(
-        app: &tauri::AppHandle,
+    async fn extract_last_assistant_output<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         session_id: &str,
     ) -> Option<String> {
@@ -4242,9 +4923,9 @@ impl WorkflowEngine {
         }
     }
 
-    async fn release_completed_step_session(
+    async fn release_completed_step_session<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         chat_session_id: &str,
@@ -4275,6 +4956,15 @@ impl WorkflowEngine {
         ids.sort();
         ids.dedup();
         ids
+    }
+
+    fn outcome_snapshot(outcome: &StepOutcome) -> &WorkflowState {
+        match outcome {
+            StepOutcome::Persist(s)
+            | StepOutcome::TransitionAndStart(s)
+            | StepOutcome::ReduceAndTransition(s)
+            | StepOutcome::StartParallel(s) => s,
+        }
     }
 
     fn completed_step_session_ids_for_outcome(outcome: &StepOutcome) -> Vec<String> {
@@ -4313,9 +5003,9 @@ impl WorkflowEngine {
         ids
     }
 
-    async fn release_completed_step_sessions(
+    async fn release_completed_step_sessions<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         session_ids: &[String],
@@ -4326,27 +5016,108 @@ impl WorkflowEngine {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    async fn persist_release_and_broadcast(
+    /// [04] pre-commit projection phase: required event append 前に Run Store と
+    /// ChatSession の workflow_state を同期する。append-only event fact が command の
+    /// 最初の不可逆な可視 commit point であり、この helper の失敗は event append 前に
+    /// rollback できる。
+    async fn project_state_before_required_event_commit<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        chat_session_id: &str,
+        snapshot: &WorkflowState,
+    ) -> Result<(), WorkflowEngineError> {
+        let run_id = snapshot.execution_id.clone();
+        self.sync_run_store_from_snapshot(&run_id, snapshot).await?;
+        self.persist_state(app, session_store, chat_session_id, snapshot.clone())
+            .await
+    }
+
+    async fn commit_required_events<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        commit: RequiredEventCommit<'_>,
+    ) -> Result<(), WorkflowEngineError> {
+        let RequiredEventCommit {
+            run_id,
+            chat_session_id,
+            snapshot_for_commit,
+            snapshot_before,
+            run_store_snapshot_before,
+            required_events,
+            append_error_context,
+        } = commit;
+
+        let rollback_snapshot_before = snapshot_before.clone();
+        let projection_error_context = "required event projection failed";
+        if let Err(e) = self
+            .project_state_before_required_event_commit(
+                app,
+                session_store,
+                chat_session_id,
+                snapshot_for_commit,
+            )
+            .await
+        {
+            let _ = self
+                .rollback_command_mutation(
+                    app,
+                    session_store,
+                    CommandMutationRollback {
+                        run_id,
+                        chat_session_id,
+                        snapshot_before: rollback_snapshot_before,
+                        run_store_snapshot_before,
+                        context: projection_error_context,
+                    },
+                )
+                .await;
+            return Err(WorkflowEngineError::SessionStore(format!(
+                "{projection_error_context}: {e}"
+            )));
+        }
+
+        if let Err(e) = self.write_log_required_batch(app, &required_events) {
+            let _ = self
+                .rollback_command_mutation(
+                    app,
+                    session_store,
+                    CommandMutationRollback {
+                        run_id,
+                        chat_session_id,
+                        snapshot_before,
+                        run_store_snapshot_before,
+                        context: append_error_context,
+                    },
+                )
+                .await;
+            return Err(WorkflowEngineError::SessionStore(format!(
+                "{append_error_context}: {e}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// [04] pre-commit phase: sync_run_store + persist_state + release_completed_step_sessions
+    /// を実行する。本 helper は本 issue scope 外の non-command 経路（NodeCompleted/
+    /// NodeFailed 系の `persist_release_and_broadcast` 呼び出し）専用に温存する。
+    /// 本 issue scope の command 受理 handler は required event append 前の rollback 可能な
+    /// projection と post-commit `release_completed_step_sessions` の組み合わせを使う。
+    #[allow(clippy::too_many_arguments)]
+    async fn sync_persist_release<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
-        worktree_path: &str,
         chat_session_id: &str,
-        snapshot: WorkflowState,
+        snapshot: &WorkflowState,
         completed_step_session_ids: &[String],
-    ) -> Result<WorkflowState, WorkflowEngineError> {
+    ) -> Result<(), WorkflowEngineError> {
         let run_id = snapshot.execution_id.clone();
-        let is_terminal = matches!(
-            snapshot.state,
-            WorkflowExecutionState::Completed
-                | WorkflowExecutionState::Failed { .. }
-                | WorkflowExecutionState::Aborted
-        );
-
-        if let Err(e) = self.sync_run_store_from_snapshot(&run_id, &snapshot).await {
-            self.rollback_execution_projection_after_run_store_sync_failure(&run_id, &snapshot)
+        if let Err(e) = self.sync_run_store_from_snapshot(&run_id, snapshot).await {
+            self.rollback_execution_projection_after_run_store_sync_failure(&run_id, snapshot)
                 .await;
             return Err(e);
         }
@@ -4363,15 +5134,61 @@ impl WorkflowEngine {
             )
             .await;
         })
-        .await?;
+        .await
+    }
+
+    /// [04] post-commit phase: terminal log + cleanup_refs + broadcast。required append
+    /// 完了後の副作用に限定し、失敗は warn として観測する（command 結果には伝播しない）。
+    async fn finalize_after_commit<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        snapshot: &WorkflowState,
+        worktree_path: &str,
+        write_terminal_events: bool,
+    ) {
+        let run_id = snapshot.execution_id.clone();
+        let is_terminal = matches!(
+            snapshot.state,
+            WorkflowExecutionState::Completed
+                | WorkflowExecutionState::Failed { .. }
+                | WorkflowExecutionState::Aborted
+        );
         if is_terminal {
-            if matches!(snapshot.state, WorkflowExecutionState::Completed) {
-                self.write_last_step_completed_log(app, &snapshot);
+            if write_terminal_events {
+                if matches!(snapshot.state, WorkflowExecutionState::Completed) {
+                    self.write_last_step_completed_log(app, snapshot);
+                }
+                self.write_terminal_log(app, snapshot);
             }
-            self.write_terminal_log(app, &snapshot);
             self.cleanup_session_workflow_refs_by_run_id(&run_id).await;
         }
         self.broadcast_state(app, worktree_path, snapshot.clone())
+            .await;
+    }
+
+    /// 既存呼び出し元（on_turn_complete 等）から使う一括 helper。pre-commit と post-commit
+    /// を順に呼ぶだけで、外部 contract は変えない。
+    #[allow(clippy::too_many_arguments)]
+    async fn persist_release_and_broadcast<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        worktree_path: &str,
+        chat_session_id: &str,
+        snapshot: WorkflowState,
+        completed_step_session_ids: &[String],
+    ) -> Result<WorkflowState, WorkflowEngineError> {
+        self.sync_persist_release(
+            app,
+            session_store,
+            handles,
+            chat_session_id,
+            &snapshot,
+            completed_step_session_ids,
+        )
+        .await?;
+        self.finalize_after_commit(app, &snapshot, worktree_path, true)
             .await;
         Ok(snapshot)
     }
@@ -4509,9 +5326,16 @@ impl WorkflowEngine {
     }
 
     /// ロック外でStepOutcomeに応じた副作用（永続化・ブロードキャスト・AgentSession起動）を実行する。
-    async fn execute_outcome(
+    ///
+    /// 本 helper は non-command 経路（NodeCompleted / NodeFailed 等）から呼ばれ、
+    /// `persist_release_and_broadcast` で snapshot を永続化したうえで、variant 別の
+    /// post-commit 副作用を `dispatch_step_outcome_side_effects` 経由で実行する。
+    /// 4 command（StartRun / AbortRun / Approve / Reject）経路の handler は required
+    /// event append を commit point として通過してから同じ
+    /// `dispatch_step_outcome_side_effects` を呼ぶ。
+    async fn execute_outcome<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         worktree_path: &str,
@@ -4519,71 +5343,92 @@ impl WorkflowEngine {
         outcome: StepOutcome,
     ) -> Result<(), WorkflowEngineError> {
         let completed_step_session_ids = Self::completed_step_session_ids_for_outcome(&outcome);
+        let snapshot_for_commit = Self::outcome_snapshot(&outcome).clone();
+        self.persist_release_and_broadcast(
+            app,
+            session_store,
+            handles,
+            worktree_path,
+            chat_session_id,
+            snapshot_for_commit,
+            &completed_step_session_ids,
+        )
+        .await?;
+        self.dispatch_step_outcome_side_effects(
+            app,
+            session_store,
+            handles,
+            worktree_path,
+            chat_session_id,
+            outcome,
+            OutcomeCommitMode::EmitProgressEvents,
+        )
+        .await
+    }
 
+    /// [04] post-commit variant work（共通 side-effect helper）。
+    ///
+    /// snapshot は既に persist 済みである前提で、outcome variant に応じた残りの副作用
+    /// （NodeStarted 書き込み・start_step_session・reduce + 派生 mutation の再帰・
+    /// start_parallel_children・auto-approve dispatch）のみを担当する。`execute_outcome`
+    /// （non-command 経路）と `handle_approval` などの 4 command handler の双方から
+    /// 呼ばれ、副作用ロジックの単一 source of truth として機能する。失敗は warn 化して
+    /// command 結果に伝播させない設計に揃える（spec [04] post-commit 境界）。
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch_step_outcome_side_effects<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        worktree_path: &str,
+        chat_session_id: &str,
+        outcome: StepOutcome,
+        commit_mode: OutcomeCommitMode,
+    ) -> Result<(), WorkflowEngineError> {
         match outcome {
             StepOutcome::Persist(snapshot) => {
-                let snapshot = self
-                    .persist_release_and_broadcast(
-                        app,
-                        session_store,
-                        handles,
-                        worktree_path,
-                        chat_session_id,
-                        snapshot,
-                        &completed_step_session_ids,
-                    )
-                    .await?;
                 if let Some((execution_id, step_name)) =
                     Self::auto_approve_target_for_persisted_snapshot(
                         &snapshot,
                         Self::workflow_approval_auto_approve_enabled(app),
                     )
                 {
-                    // execution_id == run_id（line 122-125: 採番昇格）。
-                    return Box::pin(self.handle_approval(
+                    return Box::pin(self.dispatch(
                         app,
                         session_store,
                         handles,
-                        &execution_id,
-                        ApprovalDecision::Approve,
-                        Some(&step_name),
+                        WorkflowCommand::ApproveNode {
+                            run_id: execution_id,
+                            node_name: step_name,
+                            comment: None,
+                        },
                     ))
-                    .await;
+                    .await
+                    .map(|_| ());
                 }
                 Ok(())
             }
             StepOutcome::TransitionAndStart(snapshot) => {
-                let snapshot = self
-                    .persist_release_and_broadcast(
-                        app,
-                        session_store,
-                        handles,
-                        worktree_path,
-                        chat_session_id,
-                        snapshot,
-                        &completed_step_session_ids,
-                    )
-                    .await?;
-
-                // 直前のステップ完了ログ + 新ステップ開始ログ
-                self.write_last_step_completed_log(app, &snapshot);
+                if commit_mode.should_emit_progress_events() {
+                    self.write_last_step_completed_log(app, &snapshot);
+                }
                 let exec_count = snapshot
                     .step_execution_counts
                     .get(&snapshot.current_step_name)
                     .copied()
                     .unwrap_or(1);
-                self.write_log(
-                    app,
-                    WorkflowLogEvent::StepStarted {
-                        execution_id: snapshot.execution_id.clone(),
-                        workflow_name: snapshot.workflow_name.clone(),
-                        step_name: snapshot.current_step_name.clone(),
-                        execution_count: exec_count,
-                        timestamp: snapshot.updated_at,
-                    },
-                );
-
-                // AgentSession起動。失敗時はFailed状態に遷移。
+                if commit_mode.should_emit_progress_events() {
+                    self.write_log(
+                        app,
+                        WorkflowEvent::NodeStarted {
+                            run_id: snapshot.execution_id.clone(),
+                            workflow_name: snapshot.workflow_name.clone(),
+                            node_name: snapshot.current_step_name.clone(),
+                            execution_count: exec_count,
+                            timestamp: snapshot.updated_at,
+                        },
+                    );
+                }
                 if let Err(e) = self
                     .start_step_session(app, handles, session_store, worktree_path)
                     .await
@@ -4615,22 +5460,10 @@ impl WorkflowEngine {
                 Ok(())
             }
             StepOutcome::ReduceAndTransition(snapshot) => {
-                let snapshot = self
-                    .persist_release_and_broadcast(
-                        app,
-                        session_store,
-                        handles,
-                        worktree_path,
-                        chat_session_id,
-                        snapshot,
-                        &completed_step_session_ids,
-                    )
-                    .await?;
+                if commit_mode.should_emit_progress_events() {
+                    self.write_last_step_completed_log(app, &snapshot);
+                }
 
-                // 直前ステップの完了ログ
-                self.write_last_step_completed_log(app, &snapshot);
-
-                // reduce実行
                 let (collect_config_clone, reduce_result, step_rules) = {
                     let execs = self.executions.lock().await;
                     let (_, exec) = find_by_worktree(&execs, worktree_path).ok_or_else(|| {
@@ -4645,7 +5478,6 @@ impl WorkflowEngine {
                     (collect, result, step.transition_rules.clone())
                 };
 
-                // collect step自体のStepHistoryEntryを記録 + 遷移判定
                 let (next_outcome, log_step_name, log_exec_id, log_wf_name) = {
                     let mut execs = self.executions.lock().await;
                     let exec =
@@ -4671,7 +5503,6 @@ impl WorkflowEngine {
                         collect_config_clone.from,
                     );
 
-                    // reduce resultに基づく遷移判定
                     let outcome = if step_rules.is_empty() {
                         Self::apply_advance(exec)
                     } else if let Some(ref result_str) = reduce_result.result {
@@ -4685,27 +5516,25 @@ impl WorkflowEngine {
                     (outcome, step_name, exec_id, wf_name)
                 };
 
-                // OutputCollected NDJSONログ永続化（ロック外）
-                let collected_entries: Vec<crate::workflow::log::CollectedOutputEntry> =
-                    collect_config_clone
-                        .from
-                        .iter()
-                        .map(|name| {
-                            let output = snapshot.step_outputs.get(name);
-                            crate::workflow::log::CollectedOutputEntry {
-                                step_name: name.clone(),
-                                result: output.and_then(|o| o.result.clone()),
-                                structured_output: output.and_then(|o| o.structured_output.clone()),
-                            }
-                        })
-                        .collect();
+                let collected_entries: Vec<CollectedOutputEntry> = collect_config_clone
+                    .from
+                    .iter()
+                    .map(|name| {
+                        let output = snapshot.step_outputs.get(name);
+                        CollectedOutputEntry {
+                            node_name: name.clone(),
+                            result: output.and_then(|o| o.result.clone()),
+                            structured_output: output.and_then(|o| o.structured_output.clone()),
+                        }
+                    })
+                    .collect();
                 self.write_log(
                     app,
-                    WorkflowLogEvent::OutputCollected {
-                        execution_id: log_exec_id,
+                    WorkflowEvent::OutputCollected {
+                        run_id: log_exec_id,
                         workflow_name: log_wf_name,
-                        step_name: log_step_name,
-                        step_outputs: collected_entries,
+                        node_name: log_step_name,
+                        node_outputs: collected_entries,
                         reduce_strategy: format!("{:?}", collect_config_clone.reduce),
                         reduce_result: reduce_result.result.clone(),
                         reduce_structured_output: reduce_result.structured_output.clone(),
@@ -4713,7 +5542,9 @@ impl WorkflowEngine {
                     },
                 );
 
-                // 再帰的にexecute_outcomeを呼ぶ（次ステップがcollectの可能性）
+                // 次 outcome は新たな state mutation なので、再度 sync+persist が必要。
+                // execute_outcome 経由でフル経路を回す（spec [04] post-commit 内で発生する
+                // 派生 mutation も同じ atomic 境界に乗せる）。
                 Box::pin(self.execute_outcome(
                     app,
                     session_store,
@@ -4725,24 +5556,17 @@ impl WorkflowEngine {
                 .await
             }
             StepOutcome::StartParallel(snapshot) => {
-                let snapshot = self
-                    .persist_release_and_broadcast(
+                if commit_mode.should_emit_progress_events() {
+                    self.write_last_step_completed_log(app, &snapshot);
+                }
+                if let Err(e) = self
+                    .start_parallel_children(
                         app,
                         session_store,
                         handles,
                         worktree_path,
-                        chat_session_id,
-                        snapshot,
-                        &completed_step_session_ids,
+                        commit_mode.should_emit_progress_events(),
                     )
-                    .await?;
-
-                // 直前ステップの完了ログ
-                self.write_last_step_completed_log(app, &snapshot);
-
-                // 並列子ステップの起動（失敗時はFailed状態に遷移）
-                if let Err(e) = self
-                    .start_parallel_children(app, session_store, handles, worktree_path)
                     .await
                 {
                     let _ = self
@@ -4765,12 +5589,13 @@ impl WorkflowEngine {
 
     /// 並列ブロックの子ステップをすべて起動する。
     #[allow(clippy::too_many_arguments)]
-    async fn start_parallel_children(
+    async fn start_parallel_children<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         worktree_path: &str,
+        emit_parallel_started: bool,
     ) -> Result<(), WorkflowEngineError> {
         // ロック内: 子ステップ定義取得 + ParallelRunState構築
         let (
@@ -4804,16 +5629,18 @@ impl WorkflowEngine {
         // ParallelStarted ログ
         let child_step_names: Vec<String> =
             parallel_steps.iter().map(|ps| ps.name.clone()).collect();
-        self.write_log(
-            app,
-            WorkflowLogEvent::ParallelStarted {
-                execution_id: execution_id.clone(),
-                workflow_name: workflow_name.clone(),
-                parent_step_name: parent_step_name.clone(),
-                child_step_names: child_step_names.clone(),
-                timestamp: current_timestamp(),
-            },
-        );
+        if emit_parallel_started {
+            self.write_log(
+                app,
+                WorkflowEvent::ParallelStarted {
+                    run_id: execution_id.clone(),
+                    workflow_name: workflow_name.clone(),
+                    parent_node_name: parent_step_name.clone(),
+                    child_node_names: child_step_names.clone(),
+                    timestamp: current_timestamp(),
+                },
+            );
+        }
 
         // 各子ステップのセッション生成 + AgentSession起動
         let data_dir = crate::session::resolve_data_dir(app)
@@ -5013,11 +5840,11 @@ impl WorkflowEngine {
             // ParallelStepStarted ログ
             self.write_log(
                 app,
-                WorkflowLogEvent::ParallelStepStarted {
-                    execution_id: execution_id.clone(),
+                WorkflowEvent::ParallelChildStarted {
+                    run_id: execution_id.clone(),
                     workflow_name: workflow_name.clone(),
-                    parent_step_name: parent_step_name.clone(),
-                    child_step_name: cs.step_name.clone(),
+                    parent_node_name: parent_step_name.clone(),
+                    child_node_name: cs.step_name.clone(),
                     session_id: cs.session_id.clone(),
                     execution_count: child_run_indices[i],
                     timestamp: current_timestamp(),
@@ -5090,13 +5917,19 @@ impl WorkflowEngine {
 
     /// ワークフロー状態をChatSessionに永続化する。
     /// スナップショットは呼び出し元がロック内で確定したものを受け取る。
-    async fn persist_state(
+    async fn persist_state<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         chat_session_id: &str,
         workflow_state: WorkflowState,
     ) -> Result<(), WorkflowEngineError> {
+        #[cfg(test)]
+        if self.fail_next_persist_state.swap(false, Ordering::AcqRel) {
+            return Err(WorkflowEngineError::SessionStore(
+                "injected persist_state failure".to_string(),
+            ));
+        }
         let data_dir = crate::session::resolve_data_dir(app)
             .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
         let mut session = session_store
@@ -5115,9 +5948,9 @@ impl WorkflowEngine {
     /// ワークフロー状態をブロードキャストする。
     /// スナップショットは呼び出し元がロック内で確定したものを受け取る。
     /// worktree_pathベースでイベントを発行するため、同一worktreeの全セッションが受信可能。
-    async fn broadcast_state(
+    async fn broadcast_state<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
+        app: &tauri::AppHandle<R>,
         worktree_path: &str,
         workflow_state: WorkflowState,
     ) {
@@ -5129,91 +5962,222 @@ impl WorkflowEngine {
         .await;
     }
 
-    /// 終了状態（Completed/Failed/Aborted）のログを書き込む。
+    /// 終了状態（Completed/Failed）のログを書き込む。
     /// StepCompletedログは呼び出し元で書き込み済みのため、ここでは書かない。
-    fn write_terminal_log(&self, app: &tauri::AppHandle, snapshot: &WorkflowState) {
-        // ワークフロー終了ログ
-        match &snapshot.state {
-            WorkflowExecutionState::Completed => {
-                self.write_log(
-                    app,
-                    WorkflowLogEvent::WorkflowCompleted {
-                        execution_id: snapshot.execution_id.clone(),
-                        workflow_name: snapshot.workflow_name.clone(),
-                        total_token_usage: snapshot.total_token_usage.clone(),
-                        timestamp: snapshot.updated_at,
-                    },
-                );
-            }
-            WorkflowExecutionState::Failed { reason } => {
-                // 失敗ステップのログ
-                self.write_log(
-                    app,
-                    WorkflowLogEvent::StepFailed {
-                        execution_id: snapshot.execution_id.clone(),
-                        workflow_name: snapshot.workflow_name.clone(),
-                        step_name: snapshot.current_step_name.clone(),
-                        reason: reason.clone(),
-                        timestamp: snapshot.updated_at,
-                    },
-                );
-                self.write_log(
-                    app,
-                    WorkflowLogEvent::WorkflowFailed {
-                        execution_id: snapshot.execution_id.clone(),
-                        workflow_name: snapshot.workflow_name.clone(),
-                        reason: reason.clone(),
-                        timestamp: snapshot.updated_at,
-                    },
-                );
-            }
-            WorkflowExecutionState::Aborted => {
-                self.write_log(
-                    app,
-                    WorkflowLogEvent::WorkflowAborted {
-                        execution_id: snapshot.execution_id.clone(),
-                        workflow_name: snapshot.workflow_name.clone(),
-                        timestamp: snapshot.updated_at,
-                    },
-                );
-            }
-            // Running/WaitingApproval は終了状態ではないのでログ不要
-            _ => {}
+    ///
+    /// `Aborted` 状態の `RunAborted` event は本 issue [04] の典型 typed command
+    /// `AbortRun` に対応する事実列であり、command handler 側で `write_log_required`
+    /// を経由して必須 append + snapshot 一括復元の atomic 境界に乗せる。本ヘルパーは
+    /// best-effort であり、`AbortRun` の rollback 経路を担保できないため Aborted は
+    /// ここで書かない（重複 append 防止）。
+    fn write_terminal_log<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        snapshot: &WorkflowState,
+    ) {
+        for event in Self::terminal_events_for_snapshot(snapshot) {
+            self.write_log(app, event);
         }
     }
 
     /// 最後のステップのStepCompletedログを書き込む。
-    fn write_last_step_completed_log(&self, app: &tauri::AppHandle, snapshot: &WorkflowState) {
-        if let Some(last_entry) = snapshot.step_history.last() {
-            self.write_log(
-                app,
-                WorkflowLogEvent::StepCompleted {
-                    execution_id: snapshot.execution_id.clone(),
+    fn write_last_step_completed_log<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        snapshot: &WorkflowState,
+    ) {
+        if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot) {
+            self.write_log(app, event);
+        }
+    }
+
+    fn last_step_completed_event_for_snapshot(snapshot: &WorkflowState) -> Option<WorkflowEvent> {
+        let last_entry = snapshot.step_history.last()?;
+        Some(WorkflowEvent::NodeCompleted {
+            run_id: snapshot.execution_id.clone(),
+            workflow_name: snapshot.workflow_name.clone(),
+            node_name: last_entry.step_name.clone(),
+            result: last_entry.result.clone(),
+            session_id: last_entry.session_id.clone(),
+            token_usage: last_entry.token_usage.clone(),
+            structured_output: last_entry.structured_output.clone(),
+            run_index: Some(last_entry.run_index),
+            timestamp: last_entry.completed_at,
+        })
+    }
+
+    fn node_started_event_for_snapshot(snapshot: &WorkflowState) -> WorkflowEvent {
+        let exec_count = snapshot
+            .step_execution_counts
+            .get(&snapshot.current_step_name)
+            .copied()
+            .unwrap_or(1);
+        WorkflowEvent::NodeStarted {
+            run_id: snapshot.execution_id.clone(),
+            workflow_name: snapshot.workflow_name.clone(),
+            node_name: snapshot.current_step_name.clone(),
+            execution_count: exec_count,
+            timestamp: snapshot.updated_at,
+        }
+    }
+
+    fn parallel_started_event_for_snapshot(snapshot: &WorkflowState) -> Option<WorkflowEvent> {
+        let node = snapshot
+            .workflow_definition
+            .nodes
+            .get(snapshot.current_step_index)?;
+        let child_node_names: Vec<String> = node
+            .parallel_children
+            .as_ref()?
+            .iter()
+            .map(|child| child.name.clone())
+            .collect();
+        Some(WorkflowEvent::ParallelStarted {
+            run_id: snapshot.execution_id.clone(),
+            workflow_name: snapshot.workflow_name.clone(),
+            parent_node_name: snapshot.current_step_name.clone(),
+            child_node_names,
+            timestamp: snapshot.updated_at,
+        })
+    }
+
+    fn terminal_events_for_snapshot(snapshot: &WorkflowState) -> Vec<WorkflowEvent> {
+        match &snapshot.state {
+            WorkflowExecutionState::Completed => vec![WorkflowEvent::RunCompleted {
+                run_id: snapshot.execution_id.clone(),
+                workflow_name: snapshot.workflow_name.clone(),
+                total_token_usage: snapshot.total_token_usage.clone(),
+                timestamp: snapshot.updated_at,
+            }],
+            WorkflowExecutionState::Failed { reason } => vec![
+                WorkflowEvent::NodeFailed {
+                    run_id: snapshot.execution_id.clone(),
                     workflow_name: snapshot.workflow_name.clone(),
-                    step_name: last_entry.step_name.clone(),
-                    result: last_entry.result.clone(),
-                    session_id: last_entry.session_id.clone(),
-                    token_usage: last_entry.token_usage.clone(),
-                    structured_output: last_entry.structured_output.clone(),
-                    run_index: Some(last_entry.run_index),
-                    timestamp: last_entry.completed_at,
+                    node_name: snapshot.current_step_name.clone(),
+                    reason: reason.clone(),
+                    timestamp: snapshot.updated_at,
                 },
-            );
+                WorkflowEvent::RunFailed {
+                    run_id: snapshot.execution_id.clone(),
+                    workflow_name: snapshot.workflow_name.clone(),
+                    reason: reason.clone(),
+                    timestamp: snapshot.updated_at,
+                },
+            ],
+            _ => Vec::new(),
+        }
+    }
+
+    fn required_events_for_approval_commit(
+        approval_event: WorkflowEvent,
+        outcome: &StepOutcome,
+    ) -> Vec<WorkflowEvent> {
+        let mut events = vec![approval_event];
+        match outcome {
+            StepOutcome::Persist(snapshot) => {
+                if matches!(
+                    snapshot.state,
+                    WorkflowExecutionState::Completed | WorkflowExecutionState::Failed { .. }
+                ) {
+                    if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot) {
+                        events.push(event);
+                    }
+                    events.extend(Self::terminal_events_for_snapshot(snapshot));
+                } else if matches!(snapshot.state, WorkflowExecutionState::Aborted) {
+                    events.push(WorkflowEvent::RunAborted {
+                        run_id: snapshot.execution_id.clone(),
+                        workflow_name: snapshot.workflow_name.clone(),
+                        timestamp: snapshot.updated_at,
+                    });
+                }
+            }
+            StepOutcome::TransitionAndStart(snapshot) => {
+                if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot) {
+                    events.push(event);
+                }
+                events.push(Self::node_started_event_for_snapshot(snapshot));
+            }
+            StepOutcome::ReduceAndTransition(snapshot) | StepOutcome::StartParallel(snapshot) => {
+                if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot) {
+                    events.push(event);
+                }
+                match outcome {
+                    StepOutcome::ReduceAndTransition(_) => {
+                        events.push(Self::node_started_event_for_snapshot(snapshot));
+                    }
+                    StepOutcome::StartParallel(_) => {
+                        if let Some(event) = Self::parallel_started_event_for_snapshot(snapshot) {
+                            events.push(event);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let commit_timestamp = events
+            .iter()
+            .map(Self::workflow_event_timestamp)
+            .fold(0.0_f64, f64::max);
+        for event in &mut events {
+            Self::set_workflow_event_timestamp(event, commit_timestamp);
+        }
+        events
+    }
+
+    fn workflow_event_timestamp(event: &WorkflowEvent) -> f64 {
+        match event {
+            WorkflowEvent::RunStarted { timestamp, .. }
+            | WorkflowEvent::NodeStarted { timestamp, .. }
+            | WorkflowEvent::NodeCompleted { timestamp, .. }
+            | WorkflowEvent::NodeFailed { timestamp, .. }
+            | WorkflowEvent::ApprovalRequested { timestamp, .. }
+            | WorkflowEvent::ApprovalResolved { timestamp, .. }
+            | WorkflowEvent::RunCompleted { timestamp, .. }
+            | WorkflowEvent::RunFailed { timestamp, .. }
+            | WorkflowEvent::RunAborted { timestamp, .. }
+            | WorkflowEvent::OutputCollected { timestamp, .. }
+            | WorkflowEvent::ParallelStarted { timestamp, .. }
+            | WorkflowEvent::ParallelChildStarted { timestamp, .. }
+            | WorkflowEvent::ParallelChildCompleted { timestamp, .. }
+            | WorkflowEvent::ParallelCompleted { timestamp, .. }
+            | WorkflowEvent::ContractRepairRequested { timestamp, .. } => *timestamp,
+        }
+    }
+
+    fn set_workflow_event_timestamp(event: &mut WorkflowEvent, commit_timestamp: f64) {
+        match event {
+            WorkflowEvent::RunStarted { timestamp, .. }
+            | WorkflowEvent::NodeStarted { timestamp, .. }
+            | WorkflowEvent::NodeCompleted { timestamp, .. }
+            | WorkflowEvent::NodeFailed { timestamp, .. }
+            | WorkflowEvent::ApprovalRequested { timestamp, .. }
+            | WorkflowEvent::ApprovalResolved { timestamp, .. }
+            | WorkflowEvent::RunCompleted { timestamp, .. }
+            | WorkflowEvent::RunFailed { timestamp, .. }
+            | WorkflowEvent::RunAborted { timestamp, .. }
+            | WorkflowEvent::OutputCollected { timestamp, .. }
+            | WorkflowEvent::ParallelStarted { timestamp, .. }
+            | WorkflowEvent::ParallelChildStarted { timestamp, .. }
+            | WorkflowEvent::ParallelChildCompleted { timestamp, .. }
+            | WorkflowEvent::ParallelCompleted { timestamp, .. }
+            | WorkflowEvent::ContractRepairRequested { timestamp, .. } => {
+                *timestamp = commit_timestamp;
+            }
         }
     }
 
     /// NDJSONログにイベントを書き込む。失敗してもワークフロー実行には影響しない。
-    fn write_log(&self, app: &tauri::AppHandle, event: WorkflowLogEvent) {
+    fn write_log<R: tauri::Runtime>(&self, app: &tauri::AppHandle<R>, event: WorkflowEvent) {
         if let Err(e) = self.write_log_required(app, event) {
             log::warn!("Failed to write workflow log: {e}");
         }
     }
 
     /// NDJSONログにイベントを書き込む。履歴復元に必須のログでのみ失敗を伝播する。
-    fn write_log_required(
+    fn write_log_required<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle,
-        event: WorkflowLogEvent,
+        app: &tauri::AppHandle<R>,
+        event: WorkflowEvent,
     ) -> Result<(), String> {
         if let Ok(data_dir) = crate::session::resolve_data_dir(app) {
             let log = WorkflowEventLog::new(&data_dir);
@@ -5222,7 +6186,26 @@ impl WorkflowEngine {
         Err("failed to resolve app data dir".to_string())
     }
 
-    fn workflow_approval_auto_approve_enabled(app: &tauri::AppHandle) -> bool {
+    /// 複数の必須 event を 1 つの atomic commit point として一括追記する。
+    ///
+    /// [04] spec『event 列と domain state の整合』Rule: 同一 command 受理サイクル内で
+    /// 複数 required event を発行する場合は本 helper を使い、partial commit を構造的に
+    /// 排除する。
+    fn write_log_required_batch<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        events: &[WorkflowEvent],
+    ) -> Result<(), String> {
+        if let Ok(data_dir) = crate::session::resolve_data_dir(app) {
+            let log = WorkflowEventLog::new(&data_dir);
+            return log.append_batch(events);
+        }
+        Err("failed to resolve app data dir".to_string())
+    }
+
+    fn workflow_approval_auto_approve_enabled<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+    ) -> bool {
         app.try_state::<Arc<crate::config::AppConfig>>()
             .and_then(|config| config.get_config().ok())
             .is_some_and(|cfg| cfg.workflow.approval_auto_approve)
@@ -5731,7 +6714,7 @@ mod tests {
 
     #[tokio::test]
     async fn persist_outcome_without_new_history_does_not_cleanup_last_step_session() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let mut snapshot = engine
             .insert_test_approval_execution(
                 "/repo",
@@ -5764,7 +6747,7 @@ mod tests {
 
     #[tokio::test]
     async fn aborted_approval_outcome_cleans_current_session_not_last_history_entry() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let mut snapshot = engine
             .insert_test_approval_execution(
                 "/repo",
@@ -5795,7 +6778,7 @@ mod tests {
 
     #[tokio::test]
     async fn terminal_state_cleanup_targets_current_and_parallel_step_sessions() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let mut exec = engine
             .insert_test_approval_execution(
                 "/repo",
@@ -5840,7 +6823,7 @@ mod tests {
 
     #[tokio::test]
     async fn terminal_outcome_cleanup_includes_parent_entry_and_parallel_child_outputs() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let mut snapshot = engine
             .insert_test_approval_execution(
                 "/repo",
@@ -7598,8 +8581,8 @@ mod tests {
             .find(|entry| entry.step_name == "plan_fix_policy")
             .unwrap();
         let log = WorkflowEventLog::new(tmp.path());
-        log.append(&WorkflowLogEvent::WorkflowStarted {
-            execution_id: exec.id.clone(),
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: exec.id.clone(),
             workflow_name: exec.workflow.name.clone(),
             workflow_file_stem: "spec-driven-development".to_string(),
             worktree_path: "/repo".to_string(),
@@ -7607,10 +8590,10 @@ mod tests {
             timestamp: 1000.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::StepCompleted {
-            execution_id: exec.id.clone(),
+        log.append(&WorkflowEvent::NodeCompleted {
+            run_id: exec.id.clone(),
             workflow_name: exec.workflow.name.clone(),
-            step_name: entry.step_name.clone(),
+            node_name: entry.step_name.clone(),
             result: entry.result.clone(),
             session_id: entry.session_id.clone(),
             token_usage: entry.token_usage.clone(),
@@ -7637,10 +8620,10 @@ mod tests {
         assert!(!serialized.contains("MY_TOKEN_VALUE_123456"));
         let completed = events
             .iter()
-            .find(|event| matches!(event, WorkflowLogEvent::StepCompleted { .. }))
+            .find(|event| matches!(event, WorkflowEvent::NodeCompleted { .. }))
             .unwrap();
         match completed {
-            WorkflowLogEvent::StepCompleted {
+            WorkflowEvent::NodeCompleted {
                 structured_output, ..
             } => {
                 let policy = structured_output
@@ -8663,7 +9646,7 @@ mod tests {
         //   (e) `executions["/repo"].current_session_id` が `None` のままであること
         // を assert する。`start_step_session` 内の順序を逆転（先に create_step_session
         // → 後に build_step_prompt）させると (b) が 1 となりテストが失敗する。
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
 
         // 参照先ファセットが解決不能な step を含む execution を登録する。
         // facets_base_dir() 配下に "nonexistent_policy_<uuid>.md" が偶然存在することは
@@ -8755,7 +9738,7 @@ mod tests {
         // broadcast_state → start_agent_turn の全境界が各 1 回ずつ呼ばれ、
         // engine.session_workflow_refs と executions["/repo"].current_session_id が
         // 期待通り更新されることを assert する。
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
 
         // inline_prompt のみのステップなら facet ファイルなしでも合成が成功する。
         let mut step = make_test_step("ok-step", NodeType::Agent, "unused", vec![], None);
@@ -8904,7 +9887,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_all_match_all_children_match() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: Some("LGTM".to_string()),
             any_match: None,
@@ -8931,7 +9914,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_all_match_one_child_mismatch() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: Some("LGTM".to_string()),
             any_match: None,
@@ -8953,7 +9936,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_any_match_one_child_matches() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: None,
             any_match: Some("NEEDS_FIX".to_string()),
@@ -8975,7 +9958,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_any_match_no_child_matches() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: None,
             any_match: Some("NEEDS_FIX".to_string()),
@@ -8997,7 +9980,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_no_condition_returns_true() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: None,
             any_match: None,
@@ -9011,7 +9994,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_result_none_does_not_match() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: Some("LGTM".to_string()),
             any_match: None,
@@ -9034,7 +10017,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_filters_only_child_steps() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: Some("LGTM".to_string()),
             any_match: None,
@@ -9057,7 +10040,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_all_match_missing_child_output_returns_false() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: Some("LGTM".to_string()),
             any_match: None,
@@ -9077,7 +10060,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_invalid_regex_falls_back_to_contains() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         // 不正なregexパターン（validationで弾かれるべきだが、エンジン側もgraceful）
         let agg = ParallelAggregate {
             all_match: Some("[invalid(regex".to_string()),
@@ -9097,7 +10080,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_invalid_regex_contains_no_match() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: Some("[invalid(regex".to_string()),
             any_match: None,
@@ -9116,7 +10099,7 @@ mod tests {
 
     #[test]
     fn evaluate_aggregate_empty_children_all_match_returns_true() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: Some("LGTM".to_string()),
             any_match: None,
@@ -9299,7 +10282,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_approval_target_wrong_worktree_returns_unauthorized_without_mutating_state() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let exec = make_approval_exec(WorkflowExecutionState::WaitingApproval, vec![]);
         {
             let mut execs = engine.executions.lock().await;
@@ -9469,7 +10452,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_approval_chat_instruction_limits_current_approval_session() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let mut exec = make_approval_exec(WorkflowExecutionState::WaitingApproval, vec![]);
         exec.current_session_id = Some("step-session".to_string());
         let run_id = exec.id.clone();
@@ -9507,7 +10490,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_approval_chat_instruction_rejects_current_approval_step_before_waiting() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let mut exec = make_approval_exec(WorkflowExecutionState::Running, vec![]);
         exec.current_session_id = Some("step-session".to_string());
         let run_id = exec.id.clone();
@@ -9537,7 +10520,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_approval_chat_instruction_rejects_stale_approved_policy_session() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let mut exec = make_approval_exec(WorkflowExecutionState::Running, vec![]);
         exec.workflow.nodes[0].name = "implementation_fix_policy".to_string();
         exec.workflow.nodes[0].output_contract = Some("approved-fix-policy".to_string());
@@ -9598,7 +10581,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_approval_chat_instruction_rejects_stale_rejected_policy_session() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let mut exec = make_approval_exec(WorkflowExecutionState::Running, vec![]);
         exec.workflow.nodes[0].name = "implementation_fix_policy".to_string();
         exec.workflow.nodes[0].output_contract = Some("approved-fix-policy".to_string());
@@ -10312,7 +11295,7 @@ mod tests {
 
     #[tokio::test]
     async fn execute_outcome_auto_approve_persist_adopts_policy_and_starts_fix_once() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let worktree_path = "/repo";
         let policy_session_id = uuid::Uuid::new_v4().to_string();
 
@@ -10439,7 +11422,7 @@ mod tests {
 
     #[tokio::test]
     async fn execute_outcome_auto_approve_plan_policy_starts_plan_fix_once() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let worktree_path = "/repo";
         let policy_session_id = uuid::Uuid::new_v4().to_string();
         let exec =
@@ -10495,7 +11478,7 @@ mod tests {
 
     #[tokio::test]
     async fn auto_approve_and_manual_approve_race_starts_plan_fix_once() {
-        let engine = Arc::new(WorkflowEngine::new());
+        let engine = Arc::new(WorkflowEngine::new_for_test());
         let worktree_path = "/repo";
         let policy_session_id = uuid::Uuid::new_v4().to_string();
         let exec =
@@ -10682,38 +11665,10 @@ mod tests {
         );
     }
 
-    // ---- ApprovalDecision serde ----
-
-    #[test]
-    fn approval_decision_deserialize_approve() {
-        let json = r#""approve""#;
-        let decision: ApprovalDecision = serde_json::from_str(json).unwrap();
-        assert_eq!(decision, ApprovalDecision::Approve);
-    }
-
-    #[test]
-    fn approval_decision_deserialize_reject_with_comment() {
-        let json = r#"{"reject":{"comment":"Please fix this"}}"#;
-        let decision: ApprovalDecision = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            decision,
-            ApprovalDecision::Reject {
-                comment: "Please fix this".to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn approval_decision_deserialize_abort() {
-        let json = r#""abort""#;
-        let decision: ApprovalDecision = serde_json::from_str(json).unwrap();
-        assert_eq!(decision, ApprovalDecision::Abort);
-    }
-
     // R4-01: output_contractなしのparallel childはStepOutputを生成しない
     #[test]
     fn evaluate_aggregate_child_without_output_contract_has_no_step_output() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let agg = ParallelAggregate {
             all_match: Some("LGTM".to_string()),
             any_match: None,
@@ -11528,7 +12483,7 @@ mod tests {
     #[tokio::test]
     async fn engine_run_id_consistency_across_execution_and_run_store_metadata() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
             .await;
@@ -11614,7 +12569,7 @@ mod tests {
     /// validate_start は `AlreadyActive` を返す。
     #[tokio::test]
     async fn engine_validate_start_rejects_duplicate_active_run_on_same_worktree() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let workflow = make_minimal_workflow();
         let worktree_path = "/wt/dup";
 
@@ -11663,7 +12618,7 @@ mod tests {
     #[tokio::test]
     async fn engine_state_transitions_sync_to_run_store_active_and_completed() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
             .await;
@@ -11807,7 +12762,7 @@ mod tests {
     /// 構成要素（Run Store の active index）を直接検証する。
     #[tokio::test]
     async fn run_store_active_index_resolves_worktree_to_run_id_for_duplicate_check() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let tmp = tempfile::TempDir::new().unwrap();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
@@ -11844,7 +12799,7 @@ mod tests {
     /// 回帰防止。
     #[tokio::test]
     async fn handle_auto_complete_fixture_uses_run_id_as_executions_key() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let exec = WorkflowExecution {
             id: "auto-complete-run".to_string(),
             workflow: make_minimal_workflow(),
@@ -11911,7 +12866,7 @@ mod tests {
     /// terminal run と active run が共存しても production 経路で取り違えない。
     #[tokio::test]
     async fn find_by_worktree_filters_terminal_runs_and_returns_active_only() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let worktree_path = "/wt/shared";
         let terminal_run_id = "terminal-run".to_string();
         let active_run_id = "active-run".to_string();
@@ -11955,7 +12910,7 @@ mod tests {
     /// no-op を返し、同一 worktree の active run を誤って中断しない。
     #[tokio::test]
     async fn abort_workflow_by_run_id_is_noop_for_terminal_run_even_if_active_shares_worktree() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let worktree_path = "/wt/coexist";
         let terminal_run_id = "terminal-abort-target".to_string();
         let active_run_id = "active-bystander".to_string();
@@ -12004,7 +12959,7 @@ mod tests {
     /// reservation は最初の副作用であり、失敗時は他の副作用が走らない。
     #[tokio::test]
     async fn start_workflow_reservation_is_first_side_effect_so_no_orphan_session_on_conflict() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let tmp = tempfile::TempDir::new().unwrap();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
@@ -12072,7 +13027,7 @@ mod tests {
 
     #[tokio::test]
     async fn reserve_workflow_run_maps_run_store_worktree_conflict_to_already_active() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let tmp = tempfile::TempDir::new().unwrap();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
@@ -12116,7 +13071,7 @@ mod tests {
     async fn run_store_completed_listing_includes_completed_failed_aborted_via_authoritative_sync()
     {
         let tmp = tempfile::TempDir::new().unwrap();
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
             .await;
@@ -12198,7 +13153,7 @@ mod tests {
     #[tokio::test]
     async fn run_store_sync_failure_rolls_engine_projection_back_to_active_state() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
             .await;
@@ -12275,7 +13230,7 @@ mod tests {
     /// 取り違えないことを engine state 観測で保証する。
     #[tokio::test]
     async fn abort_workflow_by_run_id_does_not_modify_sibling_active_run_state() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let worktree_path = "/wt/sibling";
         let terminal_run_id = uuid::Uuid::new_v4().to_string();
         let active_run_id = uuid::Uuid::new_v4().to_string();
@@ -12309,11 +13264,11 @@ mod tests {
         assert_eq!(initial_active_state, Some(WorkflowExecutionState::Running));
 
         // abort_workflow_by_run_id が production で使う lookup helper は、terminal target を
-        // no-op として返す。worktree_path で sibling active run を探索しない。
-        assert!(engine
-            .abort_target_sessions_by_run_id(&terminal_run_id)
-            .await
-            .is_none());
+        // `AlreadyTerminal` として返す。worktree_path で sibling active run を探索しない。
+        assert!(matches!(
+            engine.abort_target_lookup(&terminal_run_id).await,
+            AbortTargetLookup::AlreadyTerminal
+        ));
 
         // active run には触れていない（同一 worktree でも誤って中断しない）
         let final_active_state = {
@@ -12327,7 +13282,7 @@ mod tests {
     /// 直接更新し、同一 worktree に別 run が存在しても指定 run 以外へ適用しない。
     #[tokio::test]
     async fn approval_for_run_id_updates_only_target_run_when_worktree_is_shared() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let worktree_path = "/wt/approval-shared";
         let target_run_id = uuid::Uuid::new_v4().to_string();
         let sibling_run_id = uuid::Uuid::new_v4().to_string();
@@ -12375,7 +13330,7 @@ mod tests {
     #[tokio::test]
     async fn start_workflow_core_records_run_id_and_rejects_duplicate_worktree() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
             .await;
@@ -12465,7 +13420,7 @@ mod tests {
     #[tokio::test]
     async fn start_workflow_duplicate_reservation_does_not_leak_metadata_or_refs() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
             .await;
@@ -12534,9 +13489,9 @@ mod tests {
     }
 
     #[test]
-    fn start_workflow_rollback_closes_created_parent_session() {
+    fn start_workflow_rollback_deletes_created_parent_session() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let store = Arc::new(crate::session::SessionStore::default());
         let session = crate::session::create_session_internal_with_permission(
             &store,
@@ -12549,8 +13504,10 @@ mod tests {
 
         engine.rollback_created_parent_session(&store, tmp.path(), &session.id);
 
-        let closed = store.get_session(tmp.path(), &session.id).unwrap().unwrap();
-        assert_eq!(closed.state, crate::session::SessionState::Closed);
+        assert!(store
+            .get_session(tmp.path(), &session.id)
+            .unwrap()
+            .is_none());
     }
 
     async fn active_only_summary(engine: &WorkflowEngine) -> Vec<String> {
@@ -12570,7 +13527,7 @@ mod tests {
     #[tokio::test]
     async fn run_store_terminal_statuses_propagate_status_field_in_completed_listing() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         engine
             .set_run_store_data_dir(tmp.path().to_path_buf())
             .await;
@@ -12657,7 +13614,7 @@ mod tests {
     /// `WaitingApproval` でない場合に Err を返す（任意 step session への注入経路を塞ぐ）。
     #[tokio::test]
     async fn resolve_chat_session_for_approval_rejects_non_waiting_approval_state() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let run_id = uuid::Uuid::new_v4().to_string();
         let mut exec = make_exec_with(&run_id, "/wt/x", WorkflowExecutionState::Running, "parent");
         exec.workflow.nodes[0].node_type = NodeType::Approval;
@@ -12675,7 +13632,7 @@ mod tests {
     /// Approval node でない場合に拒否する。
     #[tokio::test]
     async fn resolve_chat_session_for_approval_rejects_non_approval_current_node() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let run_id = uuid::Uuid::new_v4().to_string();
         let mut exec = make_exec_with(
             &run_id,
@@ -12697,7 +13654,7 @@ mod tests {
     /// Spec issues-1011 finding 3: 全条件揃った場合のみ session_id / worktree_path を返す。
     #[tokio::test]
     async fn resolve_chat_session_for_approval_accepts_fully_valid_state() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let run_id = uuid::Uuid::new_v4().to_string();
         let mut exec = make_exec_with(
             &run_id,
@@ -12721,7 +13678,7 @@ mod tests {
     /// 同一 worktree に terminal + active がある状況で terminal 側を狙う注入経路を防ぐ。
     #[tokio::test]
     async fn resolve_chat_session_for_approval_rejects_terminal_run() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let run_id = uuid::Uuid::new_v4().to_string();
         let mut exec = make_exec_with(
             &run_id,
@@ -12744,7 +13701,7 @@ mod tests {
     /// は対象 run の refs のみを削除し、同一 worktree の別 active run の refs は残す。
     #[tokio::test]
     async fn cleanup_session_workflow_refs_by_run_id_preserves_sibling_run_refs() {
-        let engine = WorkflowEngine::new();
+        let engine = WorkflowEngine::new_for_test();
         let terminal_run_id = uuid::Uuid::new_v4().to_string();
         let active_run_id = uuid::Uuid::new_v4().to_string();
 
@@ -12784,6 +13741,2020 @@ mod tests {
         assert!(
             refs.contains_key("parent-active"),
             "sibling active run の refs は残るべき"
+        );
+    }
+}
+
+/// [04] Command / Event Boundary 専用テスト。
+///
+/// `WorkflowEngine::dispatch` の routing 層と `handle_approval` 内の
+/// ApprovalResolved append / snapshot 一括復元（atomic mutation 境界）を検証する。
+/// 本モジュールは `tauri::AppHandle` を要さない範囲で dispatch / approval semantics の
+/// production 経路を直接呼ぶ。
+#[cfg(test)]
+mod dispatch_boundary_tests {
+    use super::*;
+    use crate::workflow::command::{WorkflowCommand, WorkflowCommandResult};
+    use crate::workflow::event::{ApprovalDecisionRecord, WorkflowEvent};
+    use crate::workflow::log::WorkflowEventLog;
+    use crate::workflow::run::{RunStatus, TerminalRunStatus, TriggerSource, WorkflowRun};
+    use crate::workflow::schema::{NodeDefinition, NodeType, TransitionRule, Workflow};
+    use crate::workflow::state::WorkflowExecutionState;
+    use tauri::Manager;
+    use tempfile::TempDir;
+
+    fn dispatch_data_dir(app: &tauri::AppHandle<tauri::test::MockRuntime>) -> std::path::PathBuf {
+        crate::session::resolve_data_dir(app).expect("mock app data dir must resolve")
+    }
+
+    fn make_approval_only_workflow() -> Workflow {
+        Workflow {
+            name: "boundary-wf".to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "review".to_string(),
+                node_type: NodeType::Approval,
+                instruction: Some("review".to_string()),
+                ..NodeDefinition::default()
+            }],
+        }
+    }
+
+    fn make_rejectable_approval_workflow() -> Workflow {
+        Workflow {
+            name: "boundary-wf".to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            nodes: vec![
+                NodeDefinition {
+                    name: "review".to_string(),
+                    node_type: NodeType::Approval,
+                    instruction: Some("review".to_string()),
+                    transition_rules: vec![TransitionRule {
+                        r#match: "reject".to_string(),
+                        next: "fix".to_string(),
+                    }],
+                    ..NodeDefinition::default()
+                },
+                NodeDefinition {
+                    name: "fix".to_string(),
+                    node_type: NodeType::Agent,
+                    instruction: Some("fix".to_string()),
+                    ..NodeDefinition::default()
+                },
+            ],
+        }
+    }
+
+    fn make_waiting_approval_execution(run_id: &str, worktree_path: &str) -> WorkflowExecution {
+        let workflow = make_approval_only_workflow();
+        make_waiting_approval_execution_with_workflow(run_id, worktree_path, workflow)
+    }
+
+    fn make_waiting_approval_execution_with_workflow(
+        run_id: &str,
+        worktree_path: &str,
+        workflow: Workflow,
+    ) -> WorkflowExecution {
+        WorkflowExecution {
+            id: run_id.to_string(),
+            workflow,
+            state: WorkflowExecutionState::WaitingApproval,
+            current_step_index: 0,
+            step_execution_counts: HashMap::from([("review".to_string(), 1)]),
+            step_history: Vec::new(),
+            chat_session_id: "chat-1".to_string(),
+            worktree_path: worktree_path.to_string(),
+            started_at: 1000.0,
+            updated_at: 1000.0,
+            current_session_id: Some("sess-1".to_string()),
+            current_step_token_usage: TokenUsage::default(),
+            step_outputs: HashMap::new(),
+            task: None,
+            parallel_run: None,
+            workflow_variables: HashMap::new(),
+            contract_retry_count: 0,
+        }
+    }
+
+    type DispatchTestApp = tauri::App<tauri::test::MockRuntime>;
+
+    fn make_dispatch_app() -> DispatchTestApp {
+        let mut config = crate::config::ReleashConfig::default();
+        config.app.last_repo_paths = Vec::new();
+        config.agents.codex.models = vec!["default".to_string(), "gpt-5.5".to_string()];
+        config.agents.default = Some("codex".to_string());
+        let app_config = Arc::new(crate::config::AppConfig::new(
+            config,
+            TempDir::new().unwrap().path().join("config.toml"),
+        ));
+        let registry = Arc::new(crate::backends::build_registry(Arc::clone(&app_config)));
+        let data_dir =
+            std::env::temp_dir().join(format!("releash-dispatch-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&data_dir).unwrap();
+        tauri::test::mock_builder()
+            .manage(crate::session::TestDataDir(data_dir))
+            .manage(app_config)
+            .manage(registry)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("tauri mock test app must build")
+    }
+
+    fn make_dispatch_deps() -> (
+        Arc<crate::session::SessionStore>,
+        Arc<Mutex<AgentProcessMap>>,
+    ) {
+        (
+            Arc::new(crate::session::SessionStore::default()),
+            Arc::new(Mutex::new(AgentProcessMap::new())),
+        )
+    }
+
+    fn create_parent_session(
+        app: &DispatchTestApp,
+        session_store: &crate::session::SessionStore,
+        worktree_path: &str,
+    ) -> crate::session::ChatSession {
+        let data_dir = dispatch_data_dir(app.handle());
+        crate::session::create_session_internal_with_permission(
+            session_store,
+            &data_dir,
+            worktree_path,
+            None,
+            crate::permission::PermissionMode::Edit,
+        )
+        .unwrap()
+    }
+
+    async fn insert_execution_and_active_run(
+        engine: &WorkflowEngine,
+        exec: WorkflowExecution,
+        trigger_source: TriggerSource,
+    ) {
+        let run_id = exec.id.clone();
+        engine
+            .run_store
+            .register_active(WorkflowRun {
+                run_id: run_id.clone(),
+                workflow_name: exec.workflow.name.clone(),
+                task: exec.task.clone(),
+                status: match exec.state {
+                    WorkflowExecutionState::WaitingApproval => RunStatus::WaitingApproval,
+                    _ => RunStatus::Running,
+                },
+                worktree_path: exec.worktree_path.clone(),
+                chat_session_id: Some(exec.chat_session_id.clone()),
+                current_node_name: Some(exec.workflow.nodes[exec.current_step_index].name.clone()),
+                trigger_source,
+                started_at: exec.started_at,
+                updated_at: exec.updated_at,
+                completed_at: None,
+                error_reason: None,
+            })
+            .await
+            .unwrap();
+        engine.executions.lock().await.insert(run_id, exec);
+    }
+
+    fn read_dispatch_events(app: &DispatchTestApp, run_id: &str) -> Vec<WorkflowEvent> {
+        let data_dir = dispatch_data_dir(app.handle());
+        WorkflowEventLog::new(&data_dir)
+            .read_log(run_id)
+            .unwrap_or_default()
+    }
+
+    fn read_all_dispatch_events(app: &DispatchTestApp) -> Vec<WorkflowEvent> {
+        let data_dir = dispatch_data_dir(app.handle());
+        let log_dir = data_dir.join("workflow_logs");
+        if !log_dir.is_dir() {
+            return Vec::new();
+        }
+        let log = WorkflowEventLog::new(&data_dir);
+        let mut events = Vec::new();
+        for entry in std::fs::read_dir(log_dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("ndjson") {
+                continue;
+            }
+            if let Some(run_id) = path.file_stem().and_then(|stem| stem.to_str()) {
+                events.extend(log.read_log(run_id).unwrap());
+            }
+        }
+        events
+    }
+
+    fn make_managed_worktree() -> (TempDir, TempDir, std::path::PathBuf) {
+        let repo_parent = TempDir::new().unwrap();
+        let worktree_parent = TempDir::new().unwrap();
+        let repo_path = repo_parent.path().join("repo");
+        std::fs::create_dir(&repo_path).unwrap();
+        let repo = git2::Repository::init(&repo_path).unwrap();
+        std::fs::write(repo_path.join("README.md"), "test\n").unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new("README.md")).unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+        let worktree_path = worktree_parent.path().join("managed-wt");
+        repo.worktree("managed-wt", &worktree_path, None).unwrap();
+        (repo_parent, worktree_parent, worktree_path)
+    }
+
+    fn configure_managed_repo(app: &DispatchTestApp, repo_path: &std::path::Path) {
+        app.state::<Arc<crate::config::AppConfig>>()
+            .with_config_mut(|config| {
+                config.app.last_repo_paths = vec![repo_path.to_string_lossy().to_string()];
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    /// Spec [04]: ApprovalResolved event は decision を typed (snake_case) で記録し、
+    /// approve コメントを comment field に伝播する。observer が dispatch 経由の判断を
+    /// 統一語彙で読めることを担保する。
+    #[test]
+    fn approval_resolved_records_decision_and_comment_in_ndjson() {
+        let tmp = TempDir::new().unwrap();
+        let log = WorkflowEventLog::new(tmp.path());
+        let run_id = "00000000-0000-0000-0000-000000000300";
+
+        let event = WorkflowEvent::ApprovalResolved {
+            run_id: run_id.to_string(),
+            workflow_name: "boundary-wf".to_string(),
+            node_name: "review".to_string(),
+            decision: ApprovalDecisionRecord::Approve,
+            comment: Some("lgtm".to_string()),
+            timestamp: 1234.0,
+        };
+        log.append(&event).unwrap();
+
+        let events = log.read_log(run_id).unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            WorkflowEvent::ApprovalResolved {
+                run_id: rid,
+                node_name,
+                decision,
+                comment,
+                ..
+            } => {
+                assert_eq!(rid, run_id);
+                assert_eq!(node_name, "review");
+                assert_eq!(*decision, ApprovalDecisionRecord::Approve);
+                assert_eq!(comment.as_deref(), Some("lgtm"));
+            }
+            other => panic!("expected ApprovalResolved, got {other:?}"),
+        }
+    }
+
+    /// Spec [04]: atomic mutation 境界。mutation 直前の `WorkflowExecution` snapshot を
+    /// 一括復元することで、履歴・変数・state・current_step_index を含む全フィールドが
+    /// 元に戻ることを担保する（部分 rollback helper を使わない構造）。
+    #[tokio::test]
+    async fn approval_snapshot_rollback_restores_workflow_execution_fully() {
+        let engine = WorkflowEngine::new_for_test();
+        let run_id = uuid::Uuid::new_v4().to_string();
+
+        let mut exec = make_waiting_approval_execution(&run_id, "/wt/atomic");
+        exec.workflow_variables
+            .insert("preserved".to_string(), "before".to_string());
+        let before_history_len = exec.step_history.len();
+        let before_step_index = exec.current_step_index;
+        let before_state = exec.state.clone();
+        let before_variables = exec.workflow_variables.clone();
+        let snapshot_before = exec.clone();
+
+        engine.executions.lock().await.insert(run_id.clone(), exec);
+
+        // mutation を適用（apply_approval_application + workflow_variables.extend）
+        {
+            let mut execs = engine.executions.lock().await;
+            let exec = execs.get_mut(&run_id).unwrap();
+            exec.workflow_variables
+                .insert("after_only".to_string(), "x".to_string());
+            let _ = WorkflowEngine::apply_approval_application(
+                exec,
+                &ApprovalDecision::Approve,
+                ApprovalApplication {
+                    effective_result: "approve".to_string(),
+                    structured_output: None,
+                    output_contract: None,
+                },
+            )
+            .unwrap();
+            assert_ne!(exec.state, before_state);
+            assert!(exec.workflow_variables.contains_key("after_only"));
+        }
+
+        // event append 失敗時の一括復元（handle_approval 内と同じ操作）。
+        {
+            let mut execs = engine.executions.lock().await;
+            if let Some(exec) = execs.get_mut(&run_id) {
+                *exec = snapshot_before;
+            }
+        }
+
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).expect("run must remain");
+        assert_eq!(restored.state, before_state, "WaitingApproval が復元される");
+        assert_eq!(
+            restored.current_step_index, before_step_index,
+            "current_step_index が復元される"
+        );
+        assert_eq!(
+            restored.step_history.len(),
+            before_history_len,
+            "step_history.len() が復元される"
+        );
+        assert!(
+            !restored.workflow_variables.contains_key("after_only"),
+            "mutation 後に追加された workflow_variables が消える"
+        );
+        assert_eq!(
+            restored.workflow_variables, before_variables,
+            "workflow_variables 全体が mutation 前と等価"
+        );
+    }
+
+    /// Spec [04]: `WorkflowCommand::ApproveNode` の comment は `ApprovalResolved.comment` に
+    /// 伝播する経路で `WorkflowCommand::RejectNode` の reason も同様に伝播する。dispatch 入口
+    /// に渡された command の comment / reason が production 経路で event payload に反映される
+    /// ことを担保する（routing 層の意味を保つ）。
+    #[test]
+    fn dispatch_command_comments_map_to_approval_resolved_event_comment() {
+        // dispatch 内で構築される ApprovalResolved の comment が approve/reject 双方で
+        // 適切に決定されることを、command variant ごとに直接検証する。
+        let approve = WorkflowCommand::ApproveNode {
+            run_id: "00000000-0000-0000-0000-000000000400".to_string(),
+            node_name: "review".to_string(),
+            comment: Some("lgtm with notes".to_string()),
+        };
+        let approve_comment = match approve {
+            WorkflowCommand::ApproveNode { comment, .. } => comment,
+            _ => panic!("expected ApproveNode"),
+        };
+        assert_eq!(approve_comment.as_deref(), Some("lgtm with notes"));
+
+        let reject = WorkflowCommand::RejectNode {
+            run_id: "00000000-0000-0000-0000-000000000401".to_string(),
+            node_name: "review".to_string(),
+            reason: "needs fix".to_string(),
+        };
+        let reject_reason = match reject {
+            WorkflowCommand::RejectNode { reason, .. } => reason,
+            _ => panic!("expected RejectNode"),
+        };
+        assert_eq!(reject_reason, "needs fix");
+    }
+
+    /// Spec [04]: `WorkflowCommand::AbortRun { expected_node_name: Some(_) }` は
+    /// approval UI 由来の Abort として handle_approval 経路に乗り、
+    /// `expected_node_name: None` は run 全体の Abort として abort_workflow_by_run_id 経路に
+    /// 乗る。dispatch の routing 分岐がこの 2 経路を区別することを構造的に担保する。
+    #[test]
+    fn dispatch_abort_run_variant_distinguishes_approval_vs_full_run_route() {
+        let approval_route = WorkflowCommand::AbortRun {
+            run_id: "00000000-0000-0000-0000-000000000500".to_string(),
+            expected_node_name: Some("review".to_string()),
+        };
+        let full_run_route = WorkflowCommand::AbortRun {
+            run_id: "00000000-0000-0000-0000-000000000501".to_string(),
+            expected_node_name: None,
+        };
+
+        // dispatch 内部の `if let Some(node_name) = expected_node_name` 分岐の構造を再現。
+        let approval_uses_approval_path = matches!(
+            approval_route,
+            WorkflowCommand::AbortRun {
+                expected_node_name: Some(_),
+                ..
+            }
+        );
+        let full_run_uses_abort_path = matches!(
+            full_run_route,
+            WorkflowCommand::AbortRun {
+                expected_node_name: None,
+                ..
+            }
+        );
+        assert!(
+            approval_uses_approval_path,
+            "approval UI 由来 Abort は expected_node_name を伴う"
+        );
+        assert!(
+            full_run_uses_abort_path,
+            "run 全体 Abort は expected_node_name None"
+        );
+    }
+
+    /// Spec [04] sentinel 禁止: `WorkflowCommandResult::Accepted` と `RunStarted` は
+    /// 型として区別され、Tauri adapter で variant 別に射影される。空文字列 sentinel を
+    /// `Accepted` から生成しないことを構造的に担保する（Tauri adapter での match 化が
+    /// 前提）。
+    #[test]
+    fn workflow_command_result_distinguishes_run_started_and_accepted() {
+        let started = WorkflowCommandResult::RunStarted {
+            run_id: "00000000-0000-0000-0000-000000000600".to_string(),
+        };
+        let accepted = WorkflowCommandResult::Accepted;
+        assert_ne!(started, accepted);
+        // `RunStarted` から `Accepted` への変換ヘルパーは boundary 上に存在しない。
+        // adapter 側で match による射影のみが認められる（spec [04] 責務配置）。
+    }
+
+    /// Spec [04] Rule「対象不在 / 既に終了した command は受理されない」:
+    /// `abort_target_lookup` は `executions` に存在しない run_id を `NotFound` と
+    /// 判定し、後段の dispatch では非受理にマッピングされる構造を担保する。
+    #[tokio::test]
+    async fn abort_target_lookup_returns_not_found_for_unknown_run_id() {
+        let engine = WorkflowEngine::new_for_test();
+        match engine
+            .abort_target_lookup("00000000-0000-0000-0000-000000000700")
+            .await
+        {
+            AbortTargetLookup::NotFound => {}
+            other => panic!("expected NotFound for unknown run_id, got {other:?}"),
+        }
+    }
+
+    /// Spec [04] Rule「既に終了した run に対する操作 command が要求される」:
+    /// terminal な run（Completed/Failed/Aborted）に対する Abort は `AlreadyTerminal`
+    /// として lookup 段階で非受理になる。
+    #[tokio::test]
+    async fn abort_target_lookup_returns_already_terminal_for_terminal_run() {
+        let engine = WorkflowEngine::new_for_test();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        for terminal_state in [
+            WorkflowExecutionState::Completed,
+            WorkflowExecutionState::Aborted,
+            WorkflowExecutionState::Failed {
+                reason: "x".to_string(),
+            },
+        ] {
+            let mut exec = make_waiting_approval_execution(&run_id, "/wt/term");
+            exec.state = terminal_state.clone();
+            engine.executions.lock().await.insert(run_id.clone(), exec);
+
+            match engine.abort_target_lookup(&run_id).await {
+                AbortTargetLookup::AlreadyTerminal => {}
+                other => panic!(
+                    "expected AlreadyTerminal for terminal {terminal_state:?}, got {other:?}"
+                ),
+            }
+            engine.executions.lock().await.remove(&run_id);
+        }
+    }
+
+    /// Spec [04] Rule: active run に対する `abort_target_lookup` は `Active` を返し、
+    /// その後の state 遷移経路（mutation → required append → finalize）に乗る。
+    #[tokio::test]
+    async fn abort_target_lookup_returns_active_for_running_run() {
+        let engine = WorkflowEngine::new_for_test();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let mut exec = make_waiting_approval_execution(&run_id, "/wt/active");
+        exec.state = WorkflowExecutionState::Running;
+        exec.current_session_id = Some("sess-X".to_string());
+        engine.executions.lock().await.insert(run_id.clone(), exec);
+
+        match engine.abort_target_lookup(&run_id).await {
+            AbortTargetLookup::Active {
+                current_step_session_id,
+                ..
+            } => {
+                assert_eq!(current_step_session_id.as_deref(), Some("sess-X"));
+            }
+            other => panic!("expected Active for running run, got {other:?}"),
+        }
+    }
+
+    /// Spec [04] Rule「権限の無い / 対象不在 / 既決の command は state 変化を起こさない」:
+    /// 既に判断済み（WaitingApproval ではない）node に対する Approve / Reject は
+    /// `validate_approval_target_snapshot` で `InvalidState` として非受理になる。
+    /// production dispatch 経路の `handle_approval` がこのガードを最初に通すため、
+    /// 二度目以降の同一意図 command は state 変化を起こさない。
+    #[tokio::test]
+    async fn approval_target_validation_rejects_already_resolved_node() {
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let mut exec = make_waiting_approval_execution(&run_id, "/wt/idempotent");
+        exec.state = WorkflowExecutionState::Completed;
+        let err =
+            WorkflowEngine::validate_approval_target_snapshot(&exec, Some(&run_id), Some("review"))
+                .unwrap_err();
+        assert!(
+            matches!(err, WorkflowEngineError::InvalidState(_)),
+            "既決 node への Approve/Reject は InvalidState で非受理 (got {err:?})"
+        );
+    }
+
+    /// Spec [04] Rule: `validate_approval_decision` は Reject の空コメント / 上限超過を
+    /// 拒否する。dispatch 入口での新規外部入力に対する境界バリデーション。
+    #[test]
+    fn reject_decision_validation_rejects_empty_and_oversize_comments() {
+        let empty = WorkflowEngine::validate_approval_decision(&ApprovalDecision::Reject {
+            comment: "   ".to_string(),
+        })
+        .unwrap_err();
+        assert!(matches!(empty, WorkflowEngineError::ValidationError(_)));
+
+        let oversize = WorkflowEngine::validate_approval_decision(&ApprovalDecision::Reject {
+            comment: "x".repeat(MAX_APPROVAL_COMMENT_CHARS + 1),
+        })
+        .unwrap_err();
+        assert!(matches!(oversize, WorkflowEngineError::ValidationError(_)));
+
+        WorkflowEngine::validate_approval_decision(&ApprovalDecision::Reject {
+            comment: "fix this".to_string(),
+        })
+        .expect("正常な reject reason は受理される");
+    }
+
+    /// Spec [04] Rule: Approve コメントも reject と同じ MAX_APPROVAL_COMMENT_CHARS を
+    /// 適用する。空文字（None）は許容するが、上限超過は非受理。
+    #[test]
+    fn approve_comment_length_validation_rejects_oversize_but_accepts_empty() {
+        WorkflowEngine::validate_approve_comment_length(None).expect("None は許容される");
+        WorkflowEngine::validate_approve_comment_length(Some(""))
+            .expect("空コメント (Some(empty)) は許容される");
+        let oversize_comment = "x".repeat(MAX_APPROVAL_COMMENT_CHARS + 1);
+        let err =
+            WorkflowEngine::validate_approve_comment_length(Some(&oversize_comment)).unwrap_err();
+        assert!(matches!(err, WorkflowEngineError::ValidationError(_)));
+    }
+
+    /// Spec [04] secret redaction: ApprovalResolved.comment に設定済み secret 値が
+    /// 含まれる場合、event log に書き出す前に `mask_sensitive_text()` で redaction
+    /// される。本テストは redaction primitive そのものの契約を担保する
+    /// （`reject_structured_output` と同じ secret 列で構造的に共有する経路）。
+    #[test]
+    fn mask_sensitive_text_redacts_secret_in_approval_comment() {
+        let secrets = vec!["super-secret-token".to_string()];
+        let raw = "approving with token=super-secret-token please review";
+        let masked = WorkflowEngine::mask_sensitive_text(raw, &secrets);
+        assert!(
+            !masked.contains("super-secret-token"),
+            "secret 値が raw のまま残ってはならない (masked={masked})"
+        );
+    }
+
+    /// Spec [04] atomic mutation 境界（AbortRun 経路）: `WorkflowCommand::AbortRun`
+    /// が受理されると `RunAborted` event は `write_log_required` 経由で必須 append
+    /// される。NDJSON に正しく snake_case で記録され、observer が typed event として
+    /// 読めることを担保する。
+    #[test]
+    fn run_aborted_event_required_append_writes_typed_ndjson() {
+        let tmp = TempDir::new().unwrap();
+        let log = WorkflowEventLog::new(tmp.path());
+        let run_id = "00000000-0000-0000-0000-000000000800";
+
+        log.append(&WorkflowEvent::RunAborted {
+            run_id: run_id.to_string(),
+            workflow_name: "boundary-wf".to_string(),
+            timestamp: 4321.0,
+        })
+        .expect("RunAborted は write_log_required 経由で append される");
+
+        let events = log.read_log(run_id).unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            WorkflowEvent::RunAborted { run_id: rid, .. } => assert_eq!(rid, run_id),
+            other => panic!("expected RunAborted, got {other:?}"),
+        }
+    }
+
+    /// Spec [04] rollback: production dispatch 経由で event append が失敗した場合、
+    /// WorkflowExecution / Run Store / event log は command 受理前 snapshot に戻る。
+    #[tokio::test]
+    async fn dispatch_approve_node_append_failure_rolls_back_full_snapshot() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/append-fail";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id.clone();
+        exec.current_session_id = None;
+        exec.workflow_variables
+            .insert("k".to_string(), "v_before".to_string());
+        let snapshot_before = exec.clone();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let log_dir_path = dispatch_data_dir(app.handle()).join("workflow_logs");
+        std::fs::write(&log_dir_path, b"not a directory").unwrap();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::ApproveNode {
+                    run_id: run_id.clone(),
+                    node_name: "review".to_string(),
+                    comment: Some("lgtm".to_string()),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).expect("run must remain");
+        assert_eq!(
+            restored.state, snapshot_before.state,
+            "state は snapshot で一括復元される"
+        );
+        assert_eq!(
+            restored.current_step_index,
+            snapshot_before.current_step_index
+        );
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        assert_eq!(
+            restored.workflow_variables.get("k").map(|s| s.as_str()),
+            Some("v_before"),
+            "workflow_variables も mutation 前の値に戻る"
+        );
+        drop(execs);
+
+        let active = engine.list_active_runs().await;
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].run_id, run_id);
+        assert_eq!(active[0].status, RunStatus::WaitingApproval);
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] rollback: AbortRun の required event append が失敗した場合も、
+    /// WorkflowExecution / Run Store / ChatSession workflow_state は mutation 前へ戻る。
+    #[tokio::test]
+    async fn dispatch_abort_run_append_failure_rolls_back_execution_run_store_and_session() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/abort-append-fail";
+        let mut parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id.clone();
+        exec.current_session_id = None;
+        exec.state = WorkflowExecutionState::Running;
+        let snapshot_before = exec.clone();
+        parent.workflow_state = Some(snapshot_before.to_workflow_state());
+        session_store
+            .save_session(&dispatch_data_dir(app.handle()), &parent)
+            .unwrap();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let log_dir_path = dispatch_data_dir(app.handle()).join("workflow_logs");
+        std::fs::write(&log_dir_path, b"not a directory").unwrap();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: run_id.clone(),
+                    expected_node_name: None,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).expect("run must remain");
+        assert_eq!(restored.state, snapshot_before.state);
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        let active = engine.list_active_runs().await;
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].run_id, run_id);
+        assert_eq!(active[0].status, RunStatus::Running);
+        let restored_parent = session_store
+            .get_session(&dispatch_data_dir(app.handle()), &parent.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            restored_parent.workflow_state.unwrap().state,
+            WorkflowExecutionState::Running
+        );
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] テスト境界: StartRun は production `WorkflowEngine::dispatch` 入口で
+    /// validation され、拒否時は state / event を変更しない。
+    #[tokio::test]
+    async fn dispatch_start_run_rejects_invalid_name_without_state_change() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let run_store_dir = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(run_store_dir.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::StartRun {
+                    workflow_file_stem: "../bad".to_string(),
+                    worktree_path: "/wt/start-invalid".to_string(),
+                    task: None,
+                    trigger_source: TriggerSource::DesktopUi,
+                    permission_mode: crate::permission::PermissionMode::Edit,
+                },
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(WorkflowEngineError::ValidationError(_))
+        ));
+        assert!(engine.executions.lock().await.is_empty());
+        assert!(engine.list_active_runs().await.is_empty());
+    }
+
+    /// Spec [04] テスト境界: StartRun の正常系は production dispatch 経由で
+    /// `RunStarted` を返し、execution / Run Store / RunStarted event を作成する。
+    #[tokio::test]
+    async fn dispatch_start_run_accepts_creates_run_and_appends_event() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let run_store_dir = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(run_store_dir.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let (repo_parent, _worktree_parent, worktree_path) = make_managed_worktree();
+        configure_managed_repo(&app, repo_parent.path().join("repo").as_path());
+        let stem = "spec-driven-development".to_string();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::StartRun {
+                    workflow_file_stem: stem.clone(),
+                    worktree_path: worktree_path.to_string_lossy().to_string(),
+                    task: Some("start me".to_string()),
+                    trigger_source: TriggerSource::DesktopUi,
+                    permission_mode: crate::permission::PermissionMode::Edit,
+                },
+            )
+            .await
+            .unwrap();
+
+        let WorkflowCommandResult::RunStarted { run_id } = result else {
+            panic!("expected RunStarted");
+        };
+        assert!(
+            engine.executions.lock().await.contains_key(&run_id),
+            "StartRun must register a WorkflowExecution"
+        );
+        assert!(
+            engine
+                .list_active_runs()
+                .await
+                .iter()
+                .any(|run| run.run_id == run_id),
+            "StartRun must create a Run Store entry"
+        );
+        assert!(read_dispatch_events(&app, &run_id).iter().any(|event| {
+            matches!(
+                event,
+                WorkflowEvent::RunStarted {
+                    workflow_file_stem,
+                    ..
+                } if workflow_file_stem == &stem
+            )
+        }));
+    }
+
+    /// Spec [04] rollback: StartRun の RunStarted append が失敗した場合、
+    /// reservation / execution / parent ChatSession を command 受理前へ戻す。
+    #[tokio::test]
+    async fn dispatch_start_run_append_failure_clears_created_parent_workflow_state() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let run_store_dir = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(run_store_dir.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let (repo_parent, _worktree_parent, worktree_path) = make_managed_worktree();
+        configure_managed_repo(&app, repo_parent.path().join("repo").as_path());
+        let worktree = std::fs::canonicalize(&worktree_path)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let log_dir_path = dispatch_data_dir(app.handle()).join("workflow_logs");
+        std::fs::write(&log_dir_path, b"not a directory").unwrap();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::StartRun {
+                    workflow_file_stem: "spec-driven-development".to_string(),
+                    worktree_path: worktree.clone(),
+                    task: Some("start with append failure".to_string()),
+                    trigger_source: TriggerSource::DesktopUi,
+                    permission_mode: crate::permission::PermissionMode::Edit,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        assert!(engine.executions.lock().await.is_empty());
+        assert!(engine.list_active_runs().await.is_empty());
+        let sessions = session_store
+            .list_worktree_sessions(&dispatch_data_dir(app.handle()), &worktree)
+            .unwrap();
+        assert!(
+            sessions.is_empty(),
+            "RunStarted が存在しない失敗 run の parent ChatSession は残さない"
+        );
+    }
+
+    /// Spec [04] rollback: StartRun は RunStarted append 前の ChatSession projection 失敗を
+    /// command failure として扱い、execution / Run Store reservation / parent ChatSession を
+    /// 受理前へ戻して refs 登録や初回 step 起動へ進まない。
+    #[tokio::test]
+    async fn dispatch_start_run_persist_failure_rolls_back_execution_run_store_and_parent_session()
+    {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let run_store_dir = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(run_store_dir.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let (_repo_parent, _worktree_parent, worktree_path) = make_managed_worktree();
+        let worktree = std::fs::canonicalize(&worktree_path)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        engine.fail_next_persist_state_for_test();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::StartRun {
+                    workflow_file_stem: "spec-driven-development".to_string(),
+                    worktree_path: worktree.clone(),
+                    task: Some("start with persist failure".to_string()),
+                    trigger_source: TriggerSource::DesktopUi,
+                    permission_mode: crate::permission::PermissionMode::Edit,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        assert!(engine.executions.lock().await.is_empty());
+        assert!(engine.list_active_runs().await.is_empty());
+        let sessions = session_store
+            .list_worktree_sessions(&dispatch_data_dir(app.handle()), &worktree)
+            .unwrap();
+        assert!(
+            sessions.is_empty(),
+            "projection 失敗時は parent ChatSession を受理前へ戻す"
+        );
+        assert!(
+            read_all_dispatch_events(&app).is_empty(),
+            "projection 失敗時は RunStarted event を append しない"
+        );
+    }
+
+    /// Spec [04] テスト境界: AbortRun は production dispatch 経由で Aborted に遷移し、
+    /// RunAborted typed event を append する。
+    #[tokio::test]
+    async fn dispatch_abort_run_accepts_mutates_state_and_appends_event() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/dispatch-abort";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id;
+        exec.current_session_id = None;
+        exec.state = WorkflowExecutionState::Running;
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: run_id.clone(),
+                    expected_node_name: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, WorkflowCommandResult::Accepted);
+        assert_eq!(
+            engine.executions.lock().await.get(&run_id).unwrap().state,
+            WorkflowExecutionState::Aborted
+        );
+        assert!(read_dispatch_events(&app, &run_id)
+            .iter()
+            .any(|event| matches!(event, WorkflowEvent::RunAborted { .. })));
+    }
+
+    /// Spec [04] テスト境界: approval UI 由来の AbortRun は production dispatch 経由で
+    /// ApprovalResolved { Abort } と RunAborted を同一受理サイクルで append する。
+    #[tokio::test]
+    async fn dispatch_abort_run_with_expected_node_appends_approval_resolved_and_run_aborted() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/dispatch-approval-abort";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id;
+        exec.current_session_id = None;
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: run_id.clone(),
+                    expected_node_name: Some("review".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, WorkflowCommandResult::Accepted);
+        assert_eq!(
+            engine.executions.lock().await.get(&run_id).unwrap().state,
+            WorkflowExecutionState::Aborted
+        );
+        let events = read_dispatch_events(&app, &run_id);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            WorkflowEvent::ApprovalResolved {
+                decision: ApprovalDecisionRecord::Abort,
+                ..
+            }
+        ));
+        assert!(matches!(events[1], WorkflowEvent::RunAborted { .. }));
+    }
+
+    /// Spec [04] rollback: approval UI 由来の AbortRun でも required event batch 前の
+    /// ChatSession projection 失敗は command failure となり、engine / Run Store /
+    /// ChatSession projection は mutation 前へ戻る。
+    #[tokio::test]
+    async fn dispatch_abort_run_with_expected_node_persist_failure_rolls_back() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/approval-abort-persist-rollback";
+        let mut parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id.clone();
+        exec.current_session_id = None;
+        let snapshot_before = exec.clone();
+        parent.workflow_state = Some(snapshot_before.to_workflow_state());
+        session_store
+            .save_session(&dispatch_data_dir(app.handle()), &parent)
+            .unwrap();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        engine.fail_next_persist_state_for_test();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: run_id.clone(),
+                    expected_node_name: Some("review".to_string()),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).unwrap();
+        assert_eq!(restored.state, WorkflowExecutionState::WaitingApproval);
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        let active = engine.list_active_runs().await;
+        assert_eq!(active[0].status, RunStatus::WaitingApproval);
+        let restored_parent = session_store
+            .get_session(&dispatch_data_dir(app.handle()), &parent.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            restored_parent.workflow_state.unwrap().state,
+            WorkflowExecutionState::WaitingApproval
+        );
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] rollback: approval UI 由来の AbortRun で required event append が失敗した場合も、
+    /// WorkflowExecution / Run Store / ChatSession workflow_state は mutation 前へ戻る。
+    #[tokio::test]
+    async fn dispatch_abort_run_with_expected_node_append_failure_rolls_back() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/approval-abort-append-rollback";
+        let mut parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id.clone();
+        exec.current_session_id = None;
+        let snapshot_before = exec.clone();
+        parent.workflow_state = Some(snapshot_before.to_workflow_state());
+        session_store
+            .save_session(&dispatch_data_dir(app.handle()), &parent)
+            .unwrap();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        let log_dir_path = dispatch_data_dir(app.handle()).join("workflow_logs");
+        std::fs::write(&log_dir_path, b"not a directory").unwrap();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: run_id.clone(),
+                    expected_node_name: Some("review".to_string()),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).unwrap();
+        assert_eq!(restored.state, snapshot_before.state);
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        let active = engine.list_active_runs().await;
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].run_id, run_id);
+        assert_eq!(active[0].status, RunStatus::WaitingApproval);
+        let restored_parent = session_store
+            .get_session(&dispatch_data_dir(app.handle()), &parent.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            restored_parent.workflow_state.unwrap().state,
+            WorkflowExecutionState::WaitingApproval
+        );
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] Rule「対象不在 / 既に終了した command は受理されない」:
+    /// AbortRun の dispatch 拒否経路は state を変化させず event を append しない。
+    #[tokio::test]
+    async fn dispatch_abort_run_rejects_not_found_and_terminal_without_append() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let missing_run_id = uuid::Uuid::new_v4().to_string();
+
+        let missing = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: missing_run_id.clone(),
+                    expected_node_name: None,
+                },
+            )
+            .await;
+        assert!(matches!(
+            missing,
+            Err(WorkflowEngineError::ExecutionNotFound(_))
+        ));
+        assert!(read_dispatch_events(&app, &missing_run_id).is_empty());
+
+        let terminal_run_id = uuid::Uuid::new_v4().to_string();
+        let mut terminal = make_waiting_approval_execution(&terminal_run_id, "/wt/terminal-abort");
+        terminal.state = WorkflowExecutionState::Completed;
+        let snapshot_before = terminal.clone();
+        engine
+            .executions
+            .lock()
+            .await
+            .insert(terminal_run_id.clone(), terminal);
+
+        let terminal_result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: terminal_run_id.clone(),
+                    expected_node_name: None,
+                },
+            )
+            .await;
+        assert!(matches!(
+            terminal_result,
+            Err(WorkflowEngineError::InvalidState(_))
+        ));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&terminal_run_id).unwrap();
+        assert_eq!(restored.state, snapshot_before.state);
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        assert!(read_dispatch_events(&app, &terminal_run_id).is_empty());
+    }
+
+    /// Spec [04] no-op 不変条件: approval UI 由来の
+    /// `AbortRun { expected_node_name: Some(_) }` でも、対象不在・stale node・既決 node は
+    /// production dispatch 経由で state / Run Store を変化させず event を append しない。
+    #[tokio::test]
+    async fn dispatch_approval_abort_rejects_missing_stale_and_resolved_targets_without_append() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+
+        let missing_run_id = uuid::Uuid::new_v4().to_string();
+        let missing = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: missing_run_id.clone(),
+                    expected_node_name: Some("review".to_string()),
+                },
+            )
+            .await;
+        assert!(matches!(
+            missing,
+            Err(WorkflowEngineError::ExecutionNotFound(_))
+        ));
+        assert!(engine.list_active_runs().await.is_empty());
+        assert!(engine.list_completed_runs().await.is_empty());
+        assert!(read_dispatch_events(&app, &missing_run_id).is_empty());
+
+        let stale_run_id = uuid::Uuid::new_v4().to_string();
+        let stale_worktree = "/wt/approval-abort-stale";
+        let stale_parent = create_parent_session(&app, &session_store, stale_worktree);
+        let mut stale_exec = make_waiting_approval_execution(&stale_run_id, stale_worktree);
+        stale_exec.chat_session_id = stale_parent.id;
+        stale_exec.current_session_id = None;
+        let stale_before = stale_exec.clone();
+        insert_execution_and_active_run(&engine, stale_exec, TriggerSource::DesktopUi).await;
+        let stale_active_before = engine.list_active_runs().await;
+
+        let stale = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: stale_run_id.clone(),
+                    expected_node_name: Some("old-review".to_string()),
+                },
+            )
+            .await;
+        assert!(matches!(
+            stale,
+            Err(WorkflowEngineError::UnauthorizedApprovalTarget(_))
+        ));
+        let execs = engine.executions.lock().await;
+        let stale_after = execs.get(&stale_run_id).unwrap();
+        assert_eq!(stale_after.state, stale_before.state);
+        assert_eq!(
+            stale_after.current_step_index,
+            stale_before.current_step_index
+        );
+        assert_eq!(
+            stale_after.step_history.len(),
+            stale_before.step_history.len()
+        );
+        drop(execs);
+        let stale_active_after = engine.list_active_runs().await;
+        assert_eq!(stale_active_after.len(), stale_active_before.len());
+        assert_eq!(stale_active_after[0].run_id, stale_active_before[0].run_id);
+        assert_eq!(stale_active_after[0].status, stale_active_before[0].status);
+        assert!(read_dispatch_events(&app, &stale_run_id).is_empty());
+
+        let resolved_run_id = uuid::Uuid::new_v4().to_string();
+        let resolved_worktree = "/wt/approval-abort-resolved";
+        let resolved_parent = create_parent_session(&app, &session_store, resolved_worktree);
+        let mut resolved_exec =
+            make_waiting_approval_execution(&resolved_run_id, resolved_worktree);
+        resolved_exec.chat_session_id = resolved_parent.id.clone();
+        resolved_exec.current_session_id = None;
+        resolved_exec.state = WorkflowExecutionState::Completed;
+        let resolved_before = resolved_exec.clone();
+        engine
+            .executions
+            .lock()
+            .await
+            .insert(resolved_run_id.clone(), resolved_exec);
+        engine
+            .run_store
+            .register_active(WorkflowRun {
+                run_id: resolved_run_id.clone(),
+                workflow_name: "boundary-wf".to_string(),
+                task: None,
+                status: RunStatus::WaitingApproval,
+                worktree_path: resolved_worktree.to_string(),
+                chat_session_id: Some(resolved_parent.id),
+                current_node_name: Some("review".to_string()),
+                trigger_source: TriggerSource::DesktopUi,
+                started_at: 1000.0,
+                updated_at: 1000.0,
+                completed_at: None,
+                error_reason: None,
+            })
+            .await
+            .unwrap();
+        engine
+            .run_store
+            .complete_run(&resolved_run_id, TerminalRunStatus::Completed, 2000.0, None)
+            .await
+            .unwrap();
+        let completed_before = engine.list_completed_runs().await;
+
+        let resolved = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: resolved_run_id.clone(),
+                    expected_node_name: Some("review".to_string()),
+                },
+            )
+            .await;
+        assert!(matches!(
+            resolved,
+            Err(WorkflowEngineError::InvalidState(_))
+        ));
+        let execs = engine.executions.lock().await;
+        let resolved_after = execs.get(&resolved_run_id).unwrap();
+        assert_eq!(resolved_after.state, resolved_before.state);
+        assert_eq!(
+            resolved_after.step_history.len(),
+            resolved_before.step_history.len()
+        );
+        drop(execs);
+        let completed_after = engine.list_completed_runs().await;
+        assert_eq!(completed_after.len(), completed_before.len());
+        assert_eq!(completed_after[0].run_id, completed_before[0].run_id);
+        assert_eq!(completed_after[0].status, completed_before[0].status);
+        assert!(read_dispatch_events(&app, &resolved_run_id).is_empty());
+    }
+
+    /// Spec [04] テスト境界: ApproveNode は production dispatch 経由で判断を受理し、
+    /// state mutation と ApprovalResolved append を同じ command 受理サイクルで行う。
+    #[tokio::test]
+    async fn dispatch_approve_node_accepts_mutates_state_and_appends_event() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/dispatch-approve";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id;
+        exec.current_session_id = None;
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::ApproveNode {
+                    run_id: run_id.clone(),
+                    node_name: "review".to_string(),
+                    comment: Some("lgtm".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, WorkflowCommandResult::Accepted);
+        let execs = engine.executions.lock().await;
+        let exec = execs.get(&run_id).unwrap();
+        assert_eq!(exec.state, WorkflowExecutionState::Completed);
+        assert_eq!(exec.step_history.len(), 1);
+        drop(execs);
+        let events = read_dispatch_events(&app, &run_id);
+        assert!(matches!(
+            events.as_slice(),
+            [
+                WorkflowEvent::ApprovalResolved {
+                    decision: ApprovalDecisionRecord::Approve,
+                    ..
+                },
+                WorkflowEvent::NodeCompleted { node_name, .. },
+                WorkflowEvent::RunCompleted { .. },
+            ] if node_name == "review"
+        ));
+    }
+
+    /// Spec [04] テスト境界: RejectNode は production dispatch 経由で判断を受理し、
+    /// state mutation と ApprovalResolved { decision: Reject } append を行う。
+    #[tokio::test]
+    async fn dispatch_reject_node_accepts_mutates_state_and_appends_event() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/dispatch-reject-accept";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution_with_workflow(
+            &run_id,
+            worktree_path,
+            make_rejectable_approval_workflow(),
+        );
+        exec.chat_session_id = parent.id;
+        exec.current_session_id = None;
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::RejectNode {
+                    run_id: run_id.clone(),
+                    node_name: "review".to_string(),
+                    reason: "needs changes".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, WorkflowCommandResult::Accepted);
+        let execs = engine.executions.lock().await;
+        let exec = execs.get(&run_id).unwrap();
+        assert_eq!(exec.current_step_index, 1);
+        assert_eq!(
+            exec.step_history
+                .first()
+                .and_then(|entry| entry.result.as_deref()),
+            Some("reject")
+        );
+        drop(execs);
+        let events = read_dispatch_events(&app, &run_id);
+        assert!(matches!(
+            &events[..3],
+            [
+                WorkflowEvent::ApprovalResolved {
+                    decision: ApprovalDecisionRecord::Reject,
+                    comment: Some(comment),
+                    ..
+                },
+                WorkflowEvent::NodeCompleted {
+                    node_name: completed,
+                    ..
+                },
+                WorkflowEvent::NodeStarted {
+                    node_name: started,
+                    ..
+                },
+            ] if comment == "needs changes" && completed == "review" && started == "fix"
+        ));
+    }
+
+    /// Spec [04] テスト境界: RejectNode の非受理経路は production dispatch 経由でも
+    /// state を変化させず、typed event を append しない。
+    #[tokio::test]
+    async fn dispatch_reject_node_rejected_target_keeps_state_and_no_append() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/dispatch-reject";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id;
+        exec.current_session_id = None;
+        let snapshot_before = exec.clone();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::RejectNode {
+                    run_id: run_id.clone(),
+                    node_name: "review".to_string(),
+                    reason: "needs changes".to_string(),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::InvalidState(_))));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).unwrap();
+        assert_eq!(restored.state, snapshot_before.state);
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] no-op 不変条件: ApproveNode / RejectNode の対象不在・stale node・既決 node は
+    /// production dispatch 経由でも state を変化させず event を append しない。
+    #[tokio::test]
+    async fn dispatch_approval_commands_reject_missing_stale_and_resolved_targets_without_append() {
+        for command_kind in ["approve", "reject"] {
+            let app = make_dispatch_app();
+            let engine = WorkflowEngine::new_for_test();
+            let tmp = TempDir::new().unwrap();
+            engine
+                .set_run_store_data_dir(tmp.path().to_path_buf())
+                .await;
+            let (session_store, handles) = make_dispatch_deps();
+
+            let missing_run_id = uuid::Uuid::new_v4().to_string();
+            let missing_command = match command_kind {
+                "approve" => WorkflowCommand::ApproveNode {
+                    run_id: missing_run_id.clone(),
+                    node_name: "review".to_string(),
+                    comment: None,
+                },
+                "reject" => WorkflowCommand::RejectNode {
+                    run_id: missing_run_id.clone(),
+                    node_name: "review".to_string(),
+                    reason: "needs changes".to_string(),
+                },
+                _ => unreachable!(),
+            };
+            let missing = engine
+                .dispatch(app.handle(), &session_store, &handles, missing_command)
+                .await;
+            assert!(matches!(
+                missing,
+                Err(WorkflowEngineError::ExecutionNotFound(_))
+            ));
+            assert!(read_dispatch_events(&app, &missing_run_id).is_empty());
+
+            let stale_run_id = uuid::Uuid::new_v4().to_string();
+            let worktree_path = format!("/wt/{command_kind}-stale");
+            let parent = create_parent_session(&app, &session_store, &worktree_path);
+            let mut stale_exec = make_waiting_approval_execution(&stale_run_id, &worktree_path);
+            stale_exec.chat_session_id = parent.id;
+            stale_exec.current_session_id = None;
+            let stale_before = stale_exec.clone();
+            insert_execution_and_active_run(&engine, stale_exec, TriggerSource::DesktopUi).await;
+            let stale_command = match command_kind {
+                "approve" => WorkflowCommand::ApproveNode {
+                    run_id: stale_run_id.clone(),
+                    node_name: "old-review".to_string(),
+                    comment: None,
+                },
+                "reject" => WorkflowCommand::RejectNode {
+                    run_id: stale_run_id.clone(),
+                    node_name: "old-review".to_string(),
+                    reason: "needs changes".to_string(),
+                },
+                _ => unreachable!(),
+            };
+            let stale = engine
+                .dispatch(app.handle(), &session_store, &handles, stale_command)
+                .await;
+            assert!(matches!(
+                stale,
+                Err(WorkflowEngineError::UnauthorizedApprovalTarget(_))
+            ));
+            let execs = engine.executions.lock().await;
+            let restored = execs.get(&stale_run_id).unwrap();
+            assert_eq!(restored.state, stale_before.state);
+            assert_eq!(restored.current_step_index, stale_before.current_step_index);
+            assert_eq!(restored.step_history.len(), stale_before.step_history.len());
+            drop(execs);
+            assert!(read_dispatch_events(&app, &stale_run_id).is_empty());
+
+            let resolved_run_id = uuid::Uuid::new_v4().to_string();
+            let worktree_path = format!("/wt/{command_kind}-resolved");
+            let parent = create_parent_session(&app, &session_store, &worktree_path);
+            let mut resolved_exec =
+                make_waiting_approval_execution(&resolved_run_id, &worktree_path);
+            resolved_exec.chat_session_id = parent.id;
+            resolved_exec.current_session_id = None;
+            resolved_exec.state = WorkflowExecutionState::Completed;
+            let resolved_before = resolved_exec.clone();
+            engine
+                .executions
+                .lock()
+                .await
+                .insert(resolved_run_id.clone(), resolved_exec);
+            let resolved_command = match command_kind {
+                "approve" => WorkflowCommand::ApproveNode {
+                    run_id: resolved_run_id.clone(),
+                    node_name: "review".to_string(),
+                    comment: None,
+                },
+                "reject" => WorkflowCommand::RejectNode {
+                    run_id: resolved_run_id.clone(),
+                    node_name: "review".to_string(),
+                    reason: "needs changes".to_string(),
+                },
+                _ => unreachable!(),
+            };
+            let resolved = engine
+                .dispatch(app.handle(), &session_store, &handles, resolved_command)
+                .await;
+            assert!(matches!(
+                resolved,
+                Err(WorkflowEngineError::InvalidState(_))
+            ));
+            let execs = engine.executions.lock().await;
+            let restored = execs.get(&resolved_run_id).unwrap();
+            assert_eq!(restored.state, resolved_before.state);
+            assert_eq!(
+                restored.step_history.len(),
+                resolved_before.step_history.len()
+            );
+            drop(execs);
+            assert!(read_dispatch_events(&app, &resolved_run_id).is_empty());
+        }
+    }
+
+    /// Spec [04] rollback: RejectNode の required event append が失敗した場合も、
+    /// WorkflowExecution / Run Store は mutation 前 snapshot に戻り、event は append されない。
+    #[tokio::test]
+    async fn dispatch_reject_node_append_failure_rolls_back_execution_and_run_store() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/reject-append-rollback";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution_with_workflow(
+            &run_id,
+            worktree_path,
+            make_rejectable_approval_workflow(),
+        );
+        exec.chat_session_id = parent.id;
+        exec.current_session_id = None;
+        let snapshot_before = exec.clone();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        let log_dir_path = dispatch_data_dir(app.handle()).join("workflow_logs");
+        std::fs::write(&log_dir_path, b"not a directory").unwrap();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::RejectNode {
+                    run_id: run_id.clone(),
+                    node_name: "review".to_string(),
+                    reason: "needs changes".to_string(),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).unwrap();
+        assert_eq!(restored.state, snapshot_before.state);
+        assert_eq!(
+            restored.current_step_index,
+            snapshot_before.current_step_index
+        );
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        let active = engine.list_active_runs().await;
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].run_id, run_id);
+        assert_eq!(active[0].status, RunStatus::WaitingApproval);
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] rollback: RejectNode の required event batch 前に ChatSession projection が
+    /// 失敗した場合も command は失敗し、engine / Run Store / ChatSession は mutation 前へ戻る。
+    #[tokio::test]
+    async fn dispatch_reject_node_persist_failure_rolls_back_execution_run_store_and_session() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/reject-persist-rollback";
+        let mut parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution_with_workflow(
+            &run_id,
+            worktree_path,
+            make_rejectable_approval_workflow(),
+        );
+        exec.chat_session_id = parent.id.clone();
+        exec.current_session_id = None;
+        let snapshot_before = exec.clone();
+        parent.workflow_state = Some(snapshot_before.to_workflow_state());
+        session_store
+            .save_session(&dispatch_data_dir(app.handle()), &parent)
+            .unwrap();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        engine.fail_next_persist_state_for_test();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::RejectNode {
+                    run_id: run_id.clone(),
+                    node_name: "review".to_string(),
+                    reason: "needs changes".to_string(),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).unwrap();
+        assert_eq!(restored.state, WorkflowExecutionState::WaitingApproval);
+        assert_eq!(
+            restored.current_step_index,
+            snapshot_before.current_step_index
+        );
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        assert_eq!(
+            engine.list_active_runs().await[0].status,
+            RunStatus::WaitingApproval
+        );
+        let restored_parent = session_store
+            .get_session(&dispatch_data_dir(app.handle()), &parent.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            restored_parent.workflow_state.unwrap().state,
+            WorkflowExecutionState::WaitingApproval
+        );
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] rollback: production dispatch 経由で persist が失敗した場合、
+    /// required event append 前に command は失敗し、engine / Run Store / ChatSession
+    /// projection は mutation 前へ戻る。
+    #[tokio::test]
+    async fn dispatch_approve_node_persist_failure_rolls_back_execution_run_store_and_session() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/dispatch-rollback";
+        let mut parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id.clone();
+        exec.current_session_id = None;
+        let snapshot_before = exec.clone();
+        parent.workflow_state = Some(snapshot_before.to_workflow_state());
+        session_store
+            .save_session(&dispatch_data_dir(app.handle()), &parent)
+            .unwrap();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        engine.fail_next_persist_state_for_test();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::ApproveNode {
+                    run_id: run_id.clone(),
+                    node_name: "review".to_string(),
+                    comment: None,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).unwrap();
+        assert_eq!(restored.state, WorkflowExecutionState::WaitingApproval);
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        assert_eq!(
+            engine.list_active_runs().await[0].status,
+            RunStatus::WaitingApproval
+        );
+        let restored_parent = session_store
+            .get_session(&dispatch_data_dir(app.handle()), &parent.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            restored_parent.workflow_state.unwrap().state,
+            WorkflowExecutionState::WaitingApproval
+        );
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] rollback: command 受理サイクル内の Run Store sync が失敗した場合も、
+    /// engine state / Run Store / ChatSession projection を mutation 前へ戻し Err を返す。
+    #[tokio::test]
+    async fn dispatch_approve_node_run_store_sync_failure_rolls_back_execution_run_store_and_session(
+    ) {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/run-store-sync-rollback";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id.clone();
+        exec.current_session_id = None;
+        exec.workflow_variables
+            .insert("keep".to_string(), "before".to_string());
+        let snapshot_before = exec.clone();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let bad_data_dir = tmp.path().join("not-a-directory");
+        std::fs::write(&bad_data_dir, "file").unwrap();
+        engine.set_run_store_data_dir(bad_data_dir).await;
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::ApproveNode {
+                    run_id: run_id.clone(),
+                    node_name: "review".to_string(),
+                    comment: Some("lgtm".to_string()),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).unwrap();
+        assert_eq!(restored.state, WorkflowExecutionState::WaitingApproval);
+        assert_eq!(
+            restored.workflow_variables.get("keep").map(String::as_str),
+            Some("before")
+        );
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        assert_eq!(
+            engine.list_active_runs().await[0].status,
+            RunStatus::WaitingApproval
+        );
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] rollback: AbortRun の ChatSession projection が失敗した場合、
+    /// RunAborted append 前に command は失敗し mutation 前へ戻る。
+    #[tokio::test]
+    async fn dispatch_abort_run_persist_failure_rolls_back_execution_run_store_and_session() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/abort-persist-rollback";
+        let mut parent = create_parent_session(&app, &session_store, worktree_path);
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        exec.chat_session_id = parent.id.clone();
+        exec.current_session_id = None;
+        exec.state = WorkflowExecutionState::Running;
+        let snapshot_before = exec.clone();
+        parent.workflow_state = Some(snapshot_before.to_workflow_state());
+        session_store
+            .save_session(&dispatch_data_dir(app.handle()), &parent)
+            .unwrap();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        engine.fail_next_persist_state_for_test();
+
+        let result = engine
+            .dispatch(
+                app.handle(),
+                &session_store,
+                &handles,
+                WorkflowCommand::AbortRun {
+                    run_id: run_id.clone(),
+                    expected_node_name: None,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(WorkflowEngineError::SessionStore(_))));
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).unwrap();
+        assert_eq!(restored.state, WorkflowExecutionState::Running);
+        assert_eq!(
+            restored.step_history.len(),
+            snapshot_before.step_history.len()
+        );
+        drop(execs);
+        assert_eq!(
+            engine.list_active_runs().await[0].status,
+            RunStatus::Running
+        );
+        let restored_parent = session_store
+            .get_session(&dispatch_data_dir(app.handle()), &parent.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            restored_parent.workflow_state.unwrap().state,
+            WorkflowExecutionState::Running
+        );
+        assert!(read_dispatch_events(&app, &run_id).is_empty());
+    }
+
+    /// Spec [04] atomic mutation 境界（A2 batch commit）: `write_log_required_batch`
+    /// 経由で ApprovalResolved + RunAborted を 1 つの commit point として書き込めば、
+    /// `WorkflowEventLog::append_batch` の 1 回の write_all で両 event が NDJSON に
+    /// 連結 append される。同一 commit batch 内の partial commit（最初の event のみ
+    /// 残る）を構造的に排除することを担保する（handle_approval の Abort 経路と
+    /// 同じ atomic 境界）。
+    #[test]
+    fn approval_abort_commit_batch_persists_both_events_in_single_write() {
+        let tmp = TempDir::new().unwrap();
+        let log = WorkflowEventLog::new(tmp.path());
+        let run_id = "00000000-0000-0000-0000-000000000900";
+        let approval_event = WorkflowEvent::ApprovalResolved {
+            run_id: run_id.to_string(),
+            workflow_name: "boundary-wf".to_string(),
+            node_name: "review".to_string(),
+            decision: ApprovalDecisionRecord::Abort,
+            comment: None,
+            timestamp: 4000.0,
+        };
+        let aborted_event = WorkflowEvent::RunAborted {
+            run_id: run_id.to_string(),
+            workflow_name: "boundary-wf".to_string(),
+            timestamp: 4000.0,
+        };
+        log.append_batch(&[approval_event, aborted_event])
+            .expect("batch append for approval-abort commit point must succeed");
+        let events = log.read_log(run_id).unwrap();
+        assert_eq!(
+            events.len(),
+            2,
+            "ApprovalResolved + RunAborted は atomic batch で 2 件 append される"
+        );
+        assert!(matches!(events[0], WorkflowEvent::ApprovalResolved { .. }));
+        assert!(matches!(events[1], WorkflowEvent::RunAborted { .. }));
+    }
+
+    /// Spec [04] atomic mutation 境界（A3 AbortRun terminal sync post-commit 化）:
+    /// `abort_workflow_by_run_id` は append 失敗時に Run Store / external 副作用を
+    /// 一切実行しないことが構造的不変条件。本テストは pre-commit が in-memory state
+    /// 変更のみであり、append 失敗時に snapshot 一括復元のみで完全に元状態へ戻せる
+    /// ことを直接確認する（外部依存の差し替えを必要としない経路）。
+    #[tokio::test]
+    async fn abort_run_pre_commit_holds_only_in_memory_mutation() {
+        let engine = WorkflowEngine::new_for_test();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let mut exec = make_waiting_approval_execution(&run_id, "/wt/pre-commit");
+        exec.state = WorkflowExecutionState::Running;
+        let snapshot_before = exec.clone();
+        engine.executions.lock().await.insert(run_id.clone(), exec);
+
+        // pre-commit 区間で行う state mutation を再現（abort_workflow_by_run_id 内の
+        // step 2 と同等）。
+        let mutated_timestamp = 1234.0;
+        {
+            let mut execs = engine.executions.lock().await;
+            let exec = execs.get_mut(&run_id).unwrap();
+            assert!(exec.is_active(), "active な run でなければ mutation しない");
+            exec.state = WorkflowExecutionState::Aborted;
+            exec.updated_at = mutated_timestamp;
+        }
+        {
+            let execs = engine.executions.lock().await;
+            let exec = execs.get(&run_id).unwrap();
+            assert_eq!(exec.state, WorkflowExecutionState::Aborted);
+            assert_eq!(exec.updated_at, mutated_timestamp);
+        }
+
+        // append 失敗を擬制した snapshot 一括復元（A3: pre-commit 区間は in-memory のみ
+        // のため、Run Store / interrupt_agent / persist 等の外部副作用は不要）。
+        {
+            let mut execs = engine.executions.lock().await;
+            if let Some(exec) = execs.get_mut(&run_id) {
+                *exec = snapshot_before.clone();
+            }
+        }
+        let execs = engine.executions.lock().await;
+        let restored = execs.get(&run_id).expect("run must remain");
+        assert_eq!(
+            restored.state,
+            WorkflowExecutionState::Running,
+            "snapshot 復元で active 状態に戻る"
+        );
+        assert_ne!(
+            restored.updated_at, mutated_timestamp,
+            "pre-commit で書いた updated_at も一括復元される"
         );
     }
 }

--- a/src-tauri/src/workflow/event.rs
+++ b/src-tauri/src/workflow/event.rs
@@ -1,0 +1,362 @@
+//! [04] Command / Event Boundary: workflow engine が発行する append-only な事実列の型。
+//!
+//! 旧 `WorkflowLogEvent` 列挙体は本 issue で完全廃止し、本ファイルの `WorkflowEvent` に
+//! 完全置換する。旧 NDJSON 在庫は破棄前提（互換 wrapper は導入しない）。
+//!
+//! 仕様詳細は `docs/spec/issues-1013.md` / `docs/workflow-engine-model-boundary.md` 参照。
+//! `CompleteNode` / `FailNode` に相当する内部 typed 遷移 command は [05] で導入する。
+
+use serde::{Deserialize, Serialize};
+
+use crate::workflow::schema::Workflow;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+impl TokenUsage {
+    pub fn add(&mut self, other: &TokenUsage) {
+        self.input_tokens += other.input_tokens;
+        self.output_tokens += other.output_tokens;
+    }
+}
+
+/// workflow engine が発行する append-only な事実列の型。
+///
+/// `run_id` を主語とし、過去事実は書き換えない（撤回も追加 event として表現する）。
+/// NDJSON 永続化時の tag は `event` フィールドに snake_case で出力される。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "event")]
+pub enum WorkflowEvent {
+    /// `WorkflowCommand::StartRun` を engine が受理し、新しい run を開始した。
+    RunStarted {
+        run_id: String,
+        workflow_name: String,
+        workflow_file_stem: String,
+        worktree_path: String,
+        /// reconstruct 経路の必須フィールド（[02] 互換境界）。
+        workflow_definition: Workflow,
+        timestamp: f64,
+    },
+    /// node が実行開始された（agent / approval / bash いずれも対象）。
+    NodeStarted {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        execution_count: u32,
+        timestamp: f64,
+    },
+    /// node が完了した（approval 経由の completion も含む）。
+    NodeCompleted {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        result: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        session_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        token_usage: Option<TokenUsage>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        structured_output: Option<serde_json::Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        run_index: Option<u32>,
+        timestamp: f64,
+    },
+    /// node が失敗した。
+    NodeFailed {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        reason: String,
+        timestamp: f64,
+    },
+    /// `WorkflowCommand::ApproveNode` / `RejectNode` の受理直前に、approval 対象の到達を記録する。
+    ApprovalRequested {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        timestamp: f64,
+    },
+    /// approval node に対するユーザー判断（approve / reject / abort）が受理された。
+    ApprovalResolved {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        decision: ApprovalDecisionRecord,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        comment: Option<String>,
+        timestamp: f64,
+    },
+    /// run 全体が成功完了した。
+    RunCompleted {
+        run_id: String,
+        workflow_name: String,
+        total_token_usage: TokenUsage,
+        timestamp: f64,
+    },
+    /// run 全体が失敗終了した。
+    RunFailed {
+        run_id: String,
+        workflow_name: String,
+        reason: String,
+        timestamp: f64,
+    },
+    /// `WorkflowCommand::AbortRun` の受理結果として run が中断された。
+    RunAborted {
+        run_id: String,
+        workflow_name: String,
+        timestamp: f64,
+    },
+    /// collect step の reduce 結果。
+    OutputCollected {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        node_outputs: Vec<CollectedOutputEntry>,
+        reduce_strategy: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reduce_result: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reduce_structured_output: Option<serde_json::Value>,
+        timestamp: f64,
+    },
+    /// 並列ブロックが開始された（parent node の入口マーカー）。
+    ParallelStarted {
+        run_id: String,
+        workflow_name: String,
+        parent_node_name: String,
+        child_node_names: Vec<String>,
+        timestamp: f64,
+    },
+    /// 並列ブロックの子 node が実行開始された。
+    ParallelChildStarted {
+        run_id: String,
+        workflow_name: String,
+        parent_node_name: String,
+        child_node_name: String,
+        session_id: String,
+        execution_count: u32,
+        timestamp: f64,
+    },
+    /// 並列ブロックの子 node が完了した。
+    ParallelChildCompleted {
+        run_id: String,
+        workflow_name: String,
+        parent_node_name: String,
+        child_node_name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        result: Option<String>,
+        session_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        token_usage: Option<TokenUsage>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        structured_output: Option<serde_json::Value>,
+        run_index: u32,
+        timestamp: f64,
+    },
+    /// 並列ブロック全体が完了し、aggregate 評価結果に基づき遷移する。
+    ParallelCompleted {
+        run_id: String,
+        workflow_name: String,
+        parent_node_name: String,
+        aggregate_result: String,
+        timestamp: f64,
+    },
+    /// output_contract repair prompt が送信された。
+    ContractRepairRequested {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        attempt: u32,
+        violation_reason: String,
+        timestamp: f64,
+    },
+}
+
+/// approval 判断結果の typed 表現。NDJSON 上は snake_case として出力される。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalDecisionRecord {
+    Approve,
+    Reject,
+    Abort,
+}
+
+/// collect step の各子要素出力エントリ。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectedOutputEntry {
+    pub node_name: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub result: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub structured_output: Option<serde_json::Value>,
+}
+
+impl WorkflowEvent {
+    /// event の primary key となる `run_id` を返す。
+    pub fn run_id(&self) -> &str {
+        match self {
+            Self::RunStarted { run_id, .. }
+            | Self::NodeStarted { run_id, .. }
+            | Self::NodeCompleted { run_id, .. }
+            | Self::NodeFailed { run_id, .. }
+            | Self::ApprovalRequested { run_id, .. }
+            | Self::ApprovalResolved { run_id, .. }
+            | Self::RunCompleted { run_id, .. }
+            | Self::RunFailed { run_id, .. }
+            | Self::RunAborted { run_id, .. }
+            | Self::OutputCollected { run_id, .. }
+            | Self::ParallelStarted { run_id, .. }
+            | Self::ParallelChildStarted { run_id, .. }
+            | Self::ParallelChildCompleted { run_id, .. }
+            | Self::ParallelCompleted { run_id, .. }
+            | Self::ContractRepairRequested { run_id, .. } => run_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_workflow() -> Workflow {
+        use crate::workflow::schema::{NodeDefinition, NodeType};
+        Workflow {
+            name: "wf".to_string(),
+            description: "".to_string(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "n1".to_string(),
+                node_type: NodeType::Agent,
+                instruction: Some("do".to_string()),
+                ..NodeDefinition::default()
+            }],
+        }
+    }
+
+    #[test]
+    fn run_started_serializes_with_event_tag() {
+        let event = WorkflowEvent::RunStarted {
+            run_id: "00000000-0000-0000-0000-000000000001".to_string(),
+            workflow_name: "wf".to_string(),
+            workflow_file_stem: "wf".to_string(),
+            worktree_path: "/repo".to_string(),
+            workflow_definition: minimal_workflow(),
+            timestamp: 1.0,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"event\":\"run_started\""));
+        assert!(json.contains("\"run_id\":\"00000000-0000-0000-0000-000000000001\""));
+        let back: WorkflowEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, WorkflowEvent::RunStarted { .. }));
+    }
+
+    /// approval 判断結果は典型的な NDJSON 観測者から snake_case で読める。
+    #[test]
+    fn approval_resolved_decision_serde_round_trips() {
+        for decision in [
+            ApprovalDecisionRecord::Approve,
+            ApprovalDecisionRecord::Reject,
+            ApprovalDecisionRecord::Abort,
+        ] {
+            let event = WorkflowEvent::ApprovalResolved {
+                run_id: "00000000-0000-0000-0000-000000000002".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "review".to_string(),
+                decision,
+                comment: Some("c".to_string()),
+                timestamp: 2.0,
+            };
+            let json = serde_json::to_string(&event).unwrap();
+            assert!(json.contains("\"event\":\"approval_resolved\""));
+            let back: WorkflowEvent = serde_json::from_str(&json).unwrap();
+            match back {
+                WorkflowEvent::ApprovalResolved {
+                    decision: back_decision,
+                    ..
+                } => assert_eq!(back_decision, decision),
+                _ => panic!("expected ApprovalResolved"),
+            }
+        }
+    }
+
+    /// `WorkflowEvent::run_id()` がすべての variant で primary key を露出する。
+    #[test]
+    fn run_id_accessor_exposes_primary_key_for_all_variants() {
+        let rid = "00000000-0000-0000-0000-000000000003";
+        let events = vec![
+            WorkflowEvent::RunStarted {
+                run_id: rid.to_string(),
+                workflow_name: "w".to_string(),
+                workflow_file_stem: "w".to_string(),
+                worktree_path: "/r".to_string(),
+                workflow_definition: minimal_workflow(),
+                timestamp: 0.0,
+            },
+            WorkflowEvent::NodeStarted {
+                run_id: rid.to_string(),
+                workflow_name: "w".to_string(),
+                node_name: "n".to_string(),
+                execution_count: 1,
+                timestamp: 0.0,
+            },
+            WorkflowEvent::NodeCompleted {
+                run_id: rid.to_string(),
+                workflow_name: "w".to_string(),
+                node_name: "n".to_string(),
+                result: None,
+                session_id: None,
+                token_usage: None,
+                structured_output: None,
+                run_index: None,
+                timestamp: 0.0,
+            },
+            WorkflowEvent::NodeFailed {
+                run_id: rid.to_string(),
+                workflow_name: "w".to_string(),
+                node_name: "n".to_string(),
+                reason: "x".to_string(),
+                timestamp: 0.0,
+            },
+            WorkflowEvent::ApprovalRequested {
+                run_id: rid.to_string(),
+                workflow_name: "w".to_string(),
+                node_name: "n".to_string(),
+                timestamp: 0.0,
+            },
+            WorkflowEvent::ApprovalResolved {
+                run_id: rid.to_string(),
+                workflow_name: "w".to_string(),
+                node_name: "n".to_string(),
+                decision: ApprovalDecisionRecord::Approve,
+                comment: None,
+                timestamp: 0.0,
+            },
+            WorkflowEvent::RunCompleted {
+                run_id: rid.to_string(),
+                workflow_name: "w".to_string(),
+                total_token_usage: TokenUsage::default(),
+                timestamp: 0.0,
+            },
+            WorkflowEvent::RunFailed {
+                run_id: rid.to_string(),
+                workflow_name: "w".to_string(),
+                reason: "x".to_string(),
+                timestamp: 0.0,
+            },
+            WorkflowEvent::RunAborted {
+                run_id: rid.to_string(),
+                workflow_name: "w".to_string(),
+                timestamp: 0.0,
+            },
+        ];
+        for event in events {
+            assert_eq!(event.run_id(), rid);
+        }
+    }
+}

--- a/src-tauri/src/workflow/event_projection.rs
+++ b/src-tauri/src/workflow/event_projection.rs
@@ -7,7 +7,6 @@
 use std::collections::HashMap;
 
 use crate::workflow::event::WorkflowEvent;
-use crate::workflow::schema::Workflow;
 use crate::workflow::state::{
     ParallelStepState, StepHistoryEntry, StepOutput, TokenUsage, WorkflowExecutionState,
     WorkflowState,
@@ -16,19 +15,38 @@ use crate::workflow::state::{
 /// イベント列からWorkflowStateを再構築する。
 ///
 /// 引数の `events` は時系列順に append された `WorkflowEvent` 列を想定する。
-/// `workflow` は `RunStarted.workflow_definition` から取得した workflow を渡す
-/// （[02] schema 境界で snapshot 経由の再構築のみ許容）。
 ///
-/// [04] 本関数は workflow モジュール内（`workflow::commands` / `workflow::log` 等）
+/// [04] schema 境界の不変条件: 復元に用いる `Workflow` 定義は必ず `RunStarted.workflow_definition`
+/// snapshot から取り出す。呼び出し側から `Workflow` を受け取らないことで、現在の workflow
+/// 定義に依存した「ライブ定義」での再構築を構造的に排除する（workflow 編集後にも過去
+/// 実行時点の `total_steps` / `current_step_index` / `step_states` を保つ）。
+///
+/// `RunStarted` を含まない events 列（empty / 旧 NDJSON 互換破棄後の異常入力）は `Ok(None)`
+/// を返す。
+///
+/// 本関数は workflow モジュール内（`workflow::commands` / `workflow::log` 等）
 /// からのみ参照される内部 API のため `pub(crate)` に絞る。
 pub(crate) fn reconstruct_state_from_events(
     run_id: &str,
     events: &[WorkflowEvent],
-    workflow: &Workflow,
 ) -> Result<Option<WorkflowState>, String> {
     if events.is_empty() {
         return Ok(None);
     }
+
+    // [04] schema 境界: 復元に使う workflow 定義は必ず RunStarted snapshot から取る。
+    // 呼び出し側から渡されたライブ定義を採用しないことで、workflow 編集後にも
+    // 過去実行時点の total_steps / current_step_index / step_states を保つ。
+    let Some(workflow) = events.iter().find_map(|e| match e {
+        WorkflowEvent::RunStarted {
+            workflow_definition,
+            ..
+        } => Some(workflow_definition.clone()),
+        _ => None,
+    }) else {
+        return Ok(None);
+    };
+    let workflow = &workflow;
 
     let mut started_at = 0.0;
     let mut updated_at = 0.0;
@@ -162,6 +180,12 @@ pub(crate) fn reconstruct_state_from_events(
             } => {
                 exec_state = WorkflowExecutionState::Completed;
                 total_token_usage = tu.clone();
+                // [04] 終端遷移では active_parallel_steps を必ず空にする。
+                // `WorkflowState.active_parallel_steps` は engine ライブ state では
+                // 「現在進行中の並列子のみ」を意味し、`ParallelCompleted` を経由せずに
+                // 終端へ到達した経路（NodeFailed → RunFailed 等）でも UI が stale な
+                // 並列子を表示しないよう projection 側でも同じ不変条件を担保する。
+                active_parallel_steps.clear();
                 updated_at = *timestamp;
             }
             WorkflowEvent::RunFailed {
@@ -170,10 +194,12 @@ pub(crate) fn reconstruct_state_from_events(
                 exec_state = WorkflowExecutionState::Failed {
                     reason: reason.clone(),
                 };
+                active_parallel_steps.clear();
                 updated_at = *timestamp;
             }
             WorkflowEvent::RunAborted { timestamp, .. } => {
                 exec_state = WorkflowExecutionState::Aborted;
+                active_parallel_steps.clear();
                 updated_at = *timestamp;
             }
             WorkflowEvent::OutputCollected { timestamp, .. } => {
@@ -315,4 +341,202 @@ pub(crate) fn reconstruct_state_from_events(
         started_at,
         updated_at,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::schema::{NodeDefinition, NodeType, Workflow};
+
+    fn agent_node(name: &str) -> NodeDefinition {
+        NodeDefinition {
+            name: name.to_string(),
+            node_type: NodeType::Agent,
+            instruction: Some("x".to_string()),
+            ..NodeDefinition::default()
+        }
+    }
+
+    fn workflow_with_nodes(name: &str, nodes: Vec<&str>) -> Workflow {
+        Workflow {
+            name: name.to_string(),
+            description: String::new(),
+            builtin: false,
+            nodes: nodes.into_iter().map(agent_node).collect(),
+        }
+    }
+
+    fn run_started(run_id: &str, workflow: Workflow) -> WorkflowEvent {
+        WorkflowEvent::RunStarted {
+            run_id: run_id.to_string(),
+            workflow_name: workflow.name.clone(),
+            workflow_file_stem: workflow.name.clone(),
+            worktree_path: "/repo".to_string(),
+            workflow_definition: workflow,
+            timestamp: 1000.0,
+        }
+    }
+
+    /// [04] schema 境界: 復元に使う Workflow は `RunStarted.workflow_definition` snapshot
+    /// から取り出し、関数 API は外部から Workflow を受け取らない。RunStarted を含まない
+    /// events 列は `Ok(None)` を返す（empty / 異常入力の取り扱い）。
+    #[test]
+    fn projection_returns_none_when_run_started_missing() {
+        let events = vec![WorkflowEvent::NodeStarted {
+            run_id: "exec-x".to_string(),
+            workflow_name: "wf".to_string(),
+            node_name: "a".to_string(),
+            execution_count: 1,
+            timestamp: 1.0,
+        }];
+        let result = reconstruct_state_from_events("exec-x", &events).unwrap();
+        assert!(
+            result.is_none(),
+            "RunStarted を含まない events 列は復元対象外"
+        );
+    }
+
+    /// [04] C1 担保: `total_steps` / `step_states` は `RunStarted.workflow_definition`
+    /// snapshot に従って復元される。snapshot が 3 ノード（plan/implement/review）で
+    /// あれば、後から workflow を編集しても復元結果はこの snapshot に従う（ライブ定義
+    /// を引きずらない構造的不変条件）。
+    #[test]
+    fn projection_uses_run_started_snapshot_for_total_steps_and_step_states() {
+        let snapshot = workflow_with_nodes("wf", vec!["plan", "implement", "review"]);
+        let events = vec![
+            run_started("exec-snap", snapshot),
+            WorkflowEvent::NodeStarted {
+                run_id: "exec-snap".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "plan".to_string(),
+                execution_count: 1,
+                timestamp: 1001.0,
+            },
+            WorkflowEvent::NodeCompleted {
+                run_id: "exec-snap".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "plan".to_string(),
+                result: Some("ok".to_string()),
+                session_id: None,
+                token_usage: None,
+                structured_output: None,
+                run_index: Some(1),
+                timestamp: 1002.0,
+            },
+            WorkflowEvent::RunCompleted {
+                run_id: "exec-snap".to_string(),
+                workflow_name: "wf".to_string(),
+                total_token_usage: TokenUsage::default(),
+                timestamp: 1003.0,
+            },
+        ];
+
+        let state = reconstruct_state_from_events("exec-snap", &events)
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.total_steps, 3, "snapshot の nodes.len() に従う");
+        assert_eq!(state.step_states["plan"], "completed");
+        assert_eq!(state.step_states["implement"], "pending");
+        assert_eq!(state.step_states["review"], "pending");
+        assert_eq!(state.workflow_definition.nodes.len(), 3);
+    }
+
+    /// 並列 child を抱えたまま `RunCompleted` で終端した場合、`active_parallel_steps`
+    /// は空になる（[04] C2: ライブ state の不変条件 — 「現在進行中の並列子のみ」 — を
+    /// projection でも担保する）。
+    #[test]
+    fn projection_clears_active_parallel_steps_on_run_completed() {
+        let snapshot = workflow_with_nodes("wf", vec!["parallel-review"]);
+        let events = vec![
+            run_started("exec-pc", snapshot),
+            WorkflowEvent::ParallelStarted {
+                run_id: "exec-pc".to_string(),
+                workflow_name: "wf".to_string(),
+                parent_node_name: "parallel-review".to_string(),
+                child_node_names: vec!["a".to_string(), "b".to_string()],
+                timestamp: 1.0,
+            },
+            WorkflowEvent::RunCompleted {
+                run_id: "exec-pc".to_string(),
+                workflow_name: "wf".to_string(),
+                total_token_usage: TokenUsage::default(),
+                timestamp: 2.0,
+            },
+        ];
+        let state = reconstruct_state_from_events("exec-pc", &events)
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.state, WorkflowExecutionState::Completed);
+        assert!(
+            state.active_parallel_steps.is_empty(),
+            "RunCompleted では active_parallel_steps は空"
+        );
+    }
+
+    /// `ParallelStarted` 後に `NodeFailed` → `RunFailed` で終端しても、
+    /// `active_parallel_steps` は空になる（`ParallelCompleted` を経由しない経路）。
+    #[test]
+    fn projection_clears_active_parallel_steps_on_run_failed() {
+        let snapshot = workflow_with_nodes("wf", vec!["parallel-review"]);
+        let events = vec![
+            run_started("exec-pf", snapshot),
+            WorkflowEvent::ParallelStarted {
+                run_id: "exec-pf".to_string(),
+                workflow_name: "wf".to_string(),
+                parent_node_name: "parallel-review".to_string(),
+                child_node_names: vec!["a".to_string(), "b".to_string()],
+                timestamp: 1.0,
+            },
+            WorkflowEvent::NodeFailed {
+                run_id: "exec-pf".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "a".to_string(),
+                reason: "boom".to_string(),
+                timestamp: 2.0,
+            },
+            WorkflowEvent::RunFailed {
+                run_id: "exec-pf".to_string(),
+                workflow_name: "wf".to_string(),
+                reason: "child failed".to_string(),
+                timestamp: 3.0,
+            },
+        ];
+        let state = reconstruct_state_from_events("exec-pf", &events)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(state.state, WorkflowExecutionState::Failed { .. }));
+        assert!(
+            state.active_parallel_steps.is_empty(),
+            "RunFailed では active_parallel_steps は空"
+        );
+    }
+
+    /// `ParallelStarted` 後に `RunAborted` で終端しても、`active_parallel_steps` は空になる。
+    #[test]
+    fn projection_clears_active_parallel_steps_on_run_aborted() {
+        let snapshot = workflow_with_nodes("wf", vec!["parallel-review"]);
+        let events = vec![
+            run_started("exec-pa", snapshot),
+            WorkflowEvent::ParallelStarted {
+                run_id: "exec-pa".to_string(),
+                workflow_name: "wf".to_string(),
+                parent_node_name: "parallel-review".to_string(),
+                child_node_names: vec!["a".to_string(), "b".to_string()],
+                timestamp: 1.0,
+            },
+            WorkflowEvent::RunAborted {
+                run_id: "exec-pa".to_string(),
+                workflow_name: "wf".to_string(),
+                timestamp: 2.0,
+            },
+        ];
+        let state = reconstruct_state_from_events("exec-pa", &events)
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.state, WorkflowExecutionState::Aborted);
+        assert!(
+            state.active_parallel_steps.is_empty(),
+            "RunAborted では active_parallel_steps は空"
+        );
+    }
 }

--- a/src-tauri/src/workflow/event_projection.rs
+++ b/src-tauri/src/workflow/event_projection.rs
@@ -1,0 +1,318 @@
+//! [04] Command / Event Boundary: `WorkflowEvent` 列から `WorkflowState` を再構築する projection。
+//!
+//! spec の責務配置に従い、`workflow/log.rs` は NDJSON の append/read 機構へ責務を限定し、
+//! event 列 → WorkflowState の射影 (projection) は engine 側の本モジュールに置く。
+//! 過去 NDJSON 在庫の互換性は spec [02]/[04] の範囲で別途扱う。
+
+use std::collections::HashMap;
+
+use crate::workflow::event::WorkflowEvent;
+use crate::workflow::schema::Workflow;
+use crate::workflow::state::{
+    ParallelStepState, StepHistoryEntry, StepOutput, TokenUsage, WorkflowExecutionState,
+    WorkflowState,
+};
+
+/// イベント列からWorkflowStateを再構築する。
+///
+/// 引数の `events` は時系列順に append された `WorkflowEvent` 列を想定する。
+/// `workflow` は `RunStarted.workflow_definition` から取得した workflow を渡す
+/// （[02] schema 境界で snapshot 経由の再構築のみ許容）。
+///
+/// [04] 本関数は workflow モジュール内（`workflow::commands` / `workflow::log` 等）
+/// からのみ参照される内部 API のため `pub(crate)` に絞る。
+pub(crate) fn reconstruct_state_from_events(
+    run_id: &str,
+    events: &[WorkflowEvent],
+    workflow: &Workflow,
+) -> Result<Option<WorkflowState>, String> {
+    if events.is_empty() {
+        return Ok(None);
+    }
+
+    let mut started_at = 0.0;
+    let mut updated_at = 0.0;
+    let mut step_history: Vec<StepHistoryEntry> = Vec::new();
+    let mut step_execution_counts: HashMap<String, u32> = HashMap::new();
+    let mut step_outputs: HashMap<String, StepOutput> = HashMap::new();
+    let mut total_token_usage = TokenUsage::default();
+    let mut exec_state = WorkflowExecutionState::Running;
+    let mut current_step_name = workflow
+        .nodes
+        .first()
+        .map(|s| s.name.clone())
+        .unwrap_or_default();
+    let mut current_step_index = 0usize;
+    let mut workflow_name = String::new();
+    let mut active_parallel_steps: Vec<ParallelStepState> = Vec::new();
+
+    for event in events {
+        match event {
+            WorkflowEvent::RunStarted {
+                timestamp,
+                workflow_name: wn,
+                ..
+            } => {
+                started_at = *timestamp;
+                updated_at = *timestamp;
+                workflow_name = wn.clone();
+            }
+            WorkflowEvent::NodeStarted {
+                node_name,
+                execution_count,
+                timestamp,
+                ..
+            } => {
+                current_step_name = node_name.clone();
+                current_step_index = workflow
+                    .nodes
+                    .iter()
+                    .position(|s| s.name == *node_name)
+                    .unwrap_or(0);
+                step_execution_counts.insert(node_name.clone(), *execution_count);
+                // [04] approval を経て次 node が開始した場合に exec_state を
+                // Running へ復元する。ApprovalRequested で WaitingApproval に
+                // 切り替わったまま NodeStarted が来ると、復元 state が承認待ち
+                // のまま固定されてしまうため、本イベントで Running に戻す。
+                if matches!(exec_state, WorkflowExecutionState::WaitingApproval) {
+                    exec_state = WorkflowExecutionState::Running;
+                }
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::NodeCompleted {
+                node_name,
+                result,
+                session_id,
+                token_usage,
+                structured_output,
+                run_index,
+                timestamp,
+                ..
+            } => {
+                let ri = run_index
+                    .unwrap_or_else(|| step_execution_counts.get(node_name).copied().unwrap_or(0));
+                step_history.push(StepHistoryEntry {
+                    step_name: node_name.clone(),
+                    completed_at: *timestamp,
+                    result: result.clone(),
+                    session_id: session_id.clone(),
+                    token_usage: token_usage.clone(),
+                    structured_output: structured_output.clone(),
+                    run_index: ri,
+                    child_outputs: None,
+                });
+                if structured_output.is_some() {
+                    step_outputs.insert(
+                        node_name.clone(),
+                        StepOutput {
+                            step_name: node_name.clone(),
+                            run_index: ri,
+                            session_id: session_id.clone(),
+                            result: result.clone(),
+                            structured_output: structured_output.clone(),
+                            output_contract: None,
+                            token_usage: token_usage.clone(),
+                            completed_at: *timestamp,
+                        },
+                    );
+                }
+                if let Some(ref usage) = token_usage {
+                    total_token_usage.add(usage);
+                }
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::NodeFailed {
+                reason, timestamp, ..
+            } => {
+                for ps in &mut active_parallel_steps {
+                    if ps.state == "running" {
+                        ps.state = "failed".to_string();
+                    }
+                }
+                exec_state = WorkflowExecutionState::Failed {
+                    reason: reason.clone(),
+                };
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::ApprovalRequested {
+                node_name,
+                timestamp,
+                ..
+            } => {
+                // [04] approval 到達は state 上 WaitingApproval を意味する。
+                // event 列から復元した state が Running のまま残ると、UI / observer から
+                // 承認待ち run を識別できなくなる。current_step_name / current_step_index も
+                // approval 対象 node に揃える。
+                current_step_name = node_name.clone();
+                current_step_index = workflow
+                    .nodes
+                    .iter()
+                    .position(|s| s.name == *node_name)
+                    .unwrap_or(current_step_index);
+                exec_state = WorkflowExecutionState::WaitingApproval;
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::ApprovalResolved { timestamp, .. } => {
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::RunCompleted {
+                total_token_usage: tu,
+                timestamp,
+                ..
+            } => {
+                exec_state = WorkflowExecutionState::Completed;
+                total_token_usage = tu.clone();
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::RunFailed {
+                reason, timestamp, ..
+            } => {
+                exec_state = WorkflowExecutionState::Failed {
+                    reason: reason.clone(),
+                };
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::RunAborted { timestamp, .. } => {
+                exec_state = WorkflowExecutionState::Aborted;
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::OutputCollected { timestamp, .. } => {
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::ParallelStarted {
+                parent_node_name,
+                child_node_names,
+                timestamp,
+                ..
+            } => {
+                current_step_name = parent_node_name.clone();
+                current_step_index = workflow
+                    .nodes
+                    .iter()
+                    .position(|s| s.name == *parent_node_name)
+                    .unwrap_or(current_step_index);
+                if matches!(exec_state, WorkflowExecutionState::WaitingApproval) {
+                    exec_state = WorkflowExecutionState::Running;
+                }
+                active_parallel_steps = child_node_names
+                    .iter()
+                    .map(|name| ParallelStepState {
+                        step_name: name.clone(),
+                        state: "running".to_string(),
+                        session_id: None,
+                        result: None,
+                        run_index: 0,
+                        completed_at: None,
+                        structured_output: None,
+                        output_contract: None,
+                    })
+                    .collect();
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::ParallelChildStarted {
+                child_node_name,
+                session_id,
+                execution_count,
+                timestamp,
+                ..
+            } => {
+                step_execution_counts.insert(child_node_name.clone(), *execution_count);
+                if let Some(ps) = active_parallel_steps
+                    .iter_mut()
+                    .find(|p| p.step_name == *child_node_name)
+                {
+                    ps.state = "running".to_string();
+                    ps.session_id = Some(session_id.clone());
+                    ps.result = None;
+                    ps.run_index = *execution_count;
+                    ps.completed_at = None;
+                } else {
+                    active_parallel_steps.push(ParallelStepState {
+                        step_name: child_node_name.clone(),
+                        state: "running".to_string(),
+                        session_id: Some(session_id.clone()),
+                        result: None,
+                        run_index: *execution_count,
+                        completed_at: None,
+                        structured_output: None,
+                        output_contract: None,
+                    });
+                }
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::ParallelChildCompleted {
+                child_node_name,
+                result,
+                session_id,
+                token_usage,
+                structured_output,
+                run_index,
+                timestamp,
+                ..
+            } => {
+                if let Some(ps) = active_parallel_steps
+                    .iter_mut()
+                    .find(|p| p.step_name == *child_node_name)
+                {
+                    ps.state = "completed".to_string();
+                    ps.result = result.clone();
+                    ps.completed_at = Some(*timestamp);
+                    ps.structured_output = structured_output.clone();
+                }
+                step_outputs.insert(
+                    child_node_name.clone(),
+                    StepOutput {
+                        step_name: child_node_name.clone(),
+                        run_index: *run_index,
+                        session_id: Some(session_id.clone()),
+                        result: result.clone(),
+                        structured_output: structured_output.clone(),
+                        output_contract: None,
+                        token_usage: token_usage.clone(),
+                        completed_at: *timestamp,
+                    },
+                );
+                if let Some(ref usage) = token_usage {
+                    total_token_usage.add(usage);
+                }
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::ParallelCompleted { timestamp, .. } => {
+                active_parallel_steps.clear();
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::ContractRepairRequested { timestamp, .. } => {
+                updated_at = *timestamp;
+            }
+        }
+    }
+
+    let step_states = crate::workflow::state::compute_step_states(
+        workflow,
+        current_step_index,
+        &exec_state,
+        &step_history,
+    );
+
+    Ok(Some(WorkflowState {
+        execution_id: run_id.to_string(),
+        workflow_name,
+        chat_session_id: None,
+        state: exec_state,
+        current_step_index,
+        current_step_name,
+        current_session_id: None,
+        total_steps: workflow.nodes.len(),
+        step_history,
+        step_execution_counts,
+        workflow_definition: workflow.clone(),
+        total_token_usage,
+        step_outputs,
+        step_states,
+        active_parallel_steps,
+        workflow_variables: HashMap::new(),
+        approval_operations: None,
+        started_at,
+        updated_at,
+    }))
+}

--- a/src-tauri/src/workflow/log.rs
+++ b/src-tauri/src/workflow/log.rs
@@ -2,150 +2,35 @@ use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde::{Deserialize, Serialize};
+use parking_lot::Mutex;
 
-use crate::workflow::schema::Workflow;
-use crate::workflow::state::{
-    ParallelStepState, StepHistoryEntry, StepOutput, TokenUsage, WorkflowExecutionState,
-    WorkflowState,
-};
+use crate::workflow::event::WorkflowEvent;
 
-/// NDJSONログに書き込むイベントの種類。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "event")]
-pub enum WorkflowLogEvent {
-    WorkflowStarted {
-        execution_id: String,
-        workflow_name: String,
-        workflow_file_stem: String,
-        worktree_path: String,
-        /// [02] schema 境界: 旧 NDJSON ログ（workflow_definition を持たない、または旧 schema を持つ）は
-        /// この required フィールドの deserialize に失敗するため、新バージョンの listing /
-        /// reconstruction の参照対象とならない。
-        workflow_definition: Workflow,
-        timestamp: f64,
-    },
-    StepStarted {
-        execution_id: String,
-        workflow_name: String,
-        step_name: String,
-        execution_count: u32,
-        timestamp: f64,
-    },
-    StepCompleted {
-        execution_id: String,
-        workflow_name: String,
-        step_name: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        result: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        session_id: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        token_usage: Option<TokenUsage>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        structured_output: Option<serde_json::Value>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        run_index: Option<u32>,
-        timestamp: f64,
-    },
-    StepFailed {
-        execution_id: String,
-        workflow_name: String,
-        step_name: String,
-        reason: String,
-        timestamp: f64,
-    },
-    WorkflowCompleted {
-        execution_id: String,
-        workflow_name: String,
-        total_token_usage: TokenUsage,
-        timestamp: f64,
-    },
-    WorkflowFailed {
-        execution_id: String,
-        workflow_name: String,
-        reason: String,
-        timestamp: f64,
-    },
-    WorkflowAborted {
-        execution_id: String,
-        workflow_name: String,
-        timestamp: f64,
-    },
-    OutputCollected {
-        execution_id: String,
-        workflow_name: String,
-        step_name: String,
-        step_outputs: Vec<CollectedOutputEntry>,
-        reduce_strategy: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reduce_result: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reduce_structured_output: Option<serde_json::Value>,
-        timestamp: f64,
-    },
-    ParallelStarted {
-        execution_id: String,
-        workflow_name: String,
-        parent_step_name: String,
-        child_step_names: Vec<String>,
-        timestamp: f64,
-    },
-    ParallelStepStarted {
-        execution_id: String,
-        workflow_name: String,
-        parent_step_name: String,
-        child_step_name: String,
-        session_id: String,
-        execution_count: u32,
-        timestamp: f64,
-    },
-    ParallelStepCompleted {
-        execution_id: String,
-        workflow_name: String,
-        parent_step_name: String,
-        child_step_name: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        result: Option<String>,
-        session_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        token_usage: Option<TokenUsage>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        structured_output: Option<serde_json::Value>,
-        run_index: u32,
-        timestamp: f64,
-    },
-    ParallelCompleted {
-        execution_id: String,
-        workflow_name: String,
-        parent_step_name: String,
-        aggregate_result: String,
-        timestamp: f64,
-    },
-    ContractRepairRequested {
-        execution_id: String,
-        workflow_name: String,
-        step_name: String,
-        attempt: u32,
-        violation_reason: String,
-        timestamp: f64,
-    },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CollectedOutputEntry {
-    pub step_name: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub result: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub structured_output: Option<serde_json::Value>,
-}
-
-/// ワークフロー実行ログの書き込み・読み込み。
+/// ワークフロー実行ログ（`WorkflowEvent` の NDJSON 書き込み・読み込み）。
+///
+/// 旧 `WorkflowLogEvent` 列挙体は [04] で `WorkflowEvent` に完全置換された。
+/// 旧 NDJSON 在庫は破棄前提（互換 wrapper は導入しない）。
+///
+/// [04] spec 責務配置: 本モジュールは NDJSON の append/read のみを担う永続化アダプタ。
+/// `WorkflowEvent` 列から `WorkflowState` への projection は `event_projection.rs` 側
+/// (`reconstruct_state_from_events`) に置く。
 pub struct WorkflowEventLog {
     log_dir: PathBuf,
+}
+
+static LOG_FILE_LOCKS: LazyLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn log_file_lock(path: &Path) -> Arc<Mutex<()>> {
+    let mut locks = LOG_FILE_LOCKS.lock();
+    Arc::clone(
+        locks
+            .entry(path.to_path_buf())
+            .or_insert_with(|| Arc::new(Mutex::new(()))),
+    )
 }
 
 impl WorkflowEventLog {
@@ -155,46 +40,97 @@ impl WorkflowEventLog {
         }
     }
 
-    fn log_path(&self, execution_id: &str) -> PathBuf {
-        self.log_dir.join(format!("{execution_id}.ndjson"))
+    fn log_path(&self, run_id: &str) -> PathBuf {
+        self.log_dir.join(format!("{run_id}.ndjson"))
     }
 
     /// イベントをNDJSON形式でログファイルに追記する。
-    pub fn append(&self, event: &WorkflowLogEvent) -> Result<(), String> {
+    pub fn append(&self, event: &WorkflowEvent) -> Result<(), String> {
+        self.append_batch(std::slice::from_ref(event))
+    }
+
+    /// 複数 event を atomic な commit point として追記する。
+    ///
+    /// [04] spec『event 列と domain state の整合』Rule: 同一 command 受理サイクル内で
+    /// 複数の required event を発行する必要がある場合（approval abort: ApprovalResolved +
+    /// RunAborted など）、2 段の `append` だと 2 本目失敗時に 1 本目だけが NDJSON に
+    /// 残り state rollback と event log が分裂する。本メソッドは serialize 結果を 1 本の
+    /// バッファに連結したうえで、既存ログ + 追記分を同一ディレクトリの一時ファイルへ
+    /// 書き出し、最後に rename する。既存ログファイルを直接変更しないため、write_all /
+    /// sync / rename のどこで失敗しても command 受理前の NDJSON を破壊しない。
+    ///
+    /// 入力 event は全て同一 run_id に属する必要がある。空の入力は no-op。
+    pub fn append_batch(&self, events: &[WorkflowEvent]) -> Result<(), String> {
+        if events.is_empty() {
+            return Ok(());
+        }
+        let run_id = events[0].run_id().to_string();
+        for event in &events[1..] {
+            if event.run_id() != run_id {
+                return Err(format!(
+                    "append_batch requires uniform run_id (got {} and {})",
+                    run_id,
+                    event.run_id()
+                ));
+            }
+        }
+
         fs::create_dir_all(&self.log_dir).map_err(|e| format!("Failed to create log dir: {e}"))?;
 
-        let execution_id = match event {
-            WorkflowLogEvent::WorkflowStarted { execution_id, .. }
-            | WorkflowLogEvent::StepStarted { execution_id, .. }
-            | WorkflowLogEvent::StepCompleted { execution_id, .. }
-            | WorkflowLogEvent::StepFailed { execution_id, .. }
-            | WorkflowLogEvent::WorkflowCompleted { execution_id, .. }
-            | WorkflowLogEvent::WorkflowFailed { execution_id, .. }
-            | WorkflowLogEvent::WorkflowAborted { execution_id, .. }
-            | WorkflowLogEvent::OutputCollected { execution_id, .. }
-            | WorkflowLogEvent::ParallelStarted { execution_id, .. }
-            | WorkflowLogEvent::ParallelStepStarted { execution_id, .. }
-            | WorkflowLogEvent::ParallelStepCompleted { execution_id, .. }
-            | WorkflowLogEvent::ParallelCompleted { execution_id, .. }
-            | WorkflowLogEvent::ContractRepairRequested { execution_id, .. } => execution_id,
+        let mut buffer = String::new();
+        for event in events {
+            let json = serde_json::to_string(event)
+                .map_err(|e| format!("Failed to serialize event: {e}"))?;
+            buffer.push_str(&json);
+            buffer.push('\n');
+        }
+
+        let path = self.log_path(&run_id);
+        let lock = log_file_lock(&path);
+        let _guard = lock.lock();
+        let existing = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(e) => return Err(format!("Failed to read existing log file: {e}")),
         };
-
-        let path = self.log_path(execution_id);
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .map_err(|e| format!("Failed to open log file: {e}"))?;
-
-        let json =
-            serde_json::to_string(event).map_err(|e| format!("Failed to serialize event: {e}"))?;
-        writeln!(file, "{json}").map_err(|e| format!("Failed to write log: {e}"))?;
+        let temp_path = self.create_temp_log_path(&path)?;
+        let write_result = (|| -> Result<(), String> {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)
+                .map_err(|e| format!("Failed to create temp log file: {e}"))?;
+            file.write_all(&existing)
+                .map_err(|e| format!("Failed to copy existing log into temp file: {e}"))?;
+            file.write_all(buffer.as_bytes())
+                .map_err(|e| format!("Failed to write log batch to temp file: {e}"))?;
+            file.sync_all()
+                .map_err(|e| format!("Failed to sync temp log file: {e}"))?;
+            fs::rename(&temp_path, &path).map_err(|e| format!("Failed to commit log file: {e}"))?;
+            Ok(())
+        })();
+        if let Err(e) = write_result {
+            let _ = fs::remove_file(&temp_path);
+            return Err(e);
+        }
         Ok(())
     }
 
-    /// 指定された実行IDのNDJSONログを読み込み、イベント一覧を返す。
-    pub fn read_log(&self, execution_id: &str) -> Result<Vec<WorkflowLogEvent>, String> {
-        let path = self.log_path(execution_id);
+    fn create_temp_log_path(&self, path: &Path) -> Result<PathBuf, String> {
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| "Failed to derive log temp file name".to_string())?;
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| format!("System clock error while creating temp log path: {e}"))?
+            .as_nanos();
+        Ok(path.with_file_name(format!(".{file_name}.{}.{}.tmp", std::process::id(), nanos)))
+    }
+
+    /// 指定された run_id の NDJSON ログを読み込み、イベント一覧を返す。
+    pub fn read_log(&self, run_id: &str) -> Result<Vec<WorkflowEvent>, String> {
+        let path = self.log_path(run_id);
         if !path.exists() {
             return Ok(vec![]);
         }
@@ -206,305 +142,19 @@ impl WorkflowEventLog {
             if line.trim().is_empty() {
                 continue;
             }
-            let event: WorkflowLogEvent =
+            let event: WorkflowEvent =
                 serde_json::from_str(line).map_err(|e| format!("Failed to parse log line: {e}"))?;
             events.push(event);
         }
         Ok(events)
     }
 
-    /// ログファイルを読み込み、ワークフロー定義からWorkflowStateを再構築する。
-    #[cfg(test)]
-    pub fn reconstruct_state(
-        &self,
-        execution_id: &str,
-        workflow: &Workflow,
-    ) -> Result<Option<WorkflowState>, String> {
-        let events = self.read_log(execution_id)?;
-        Self::reconstruct_state_from_events(execution_id, &events, workflow)
-    }
-
-    /// 既にパース済みのイベント列からWorkflowStateを再構築する。
-    pub fn reconstruct_state_from_events(
-        execution_id: &str,
-        events: &[WorkflowLogEvent],
-        workflow: &Workflow,
-    ) -> Result<Option<WorkflowState>, String> {
-        if events.is_empty() {
-            return Ok(None);
-        }
-
-        let mut started_at = 0.0;
-        let mut updated_at = 0.0;
-        let mut step_history: Vec<StepHistoryEntry> = Vec::new();
-        let mut step_execution_counts: HashMap<String, u32> = HashMap::new();
-        let mut step_outputs: HashMap<String, StepOutput> = HashMap::new();
-        let mut total_token_usage = TokenUsage::default();
-        let mut exec_state = WorkflowExecutionState::Running;
-        let mut current_step_name = workflow
-            .nodes
-            .first()
-            .map(|s| s.name.clone())
-            .unwrap_or_default();
-        let mut current_step_index = 0usize;
-        let mut workflow_name = String::new();
-        let mut active_parallel_steps: Vec<ParallelStepState> = Vec::new();
-
-        for event in events {
-            match event {
-                WorkflowLogEvent::WorkflowStarted {
-                    timestamp,
-                    workflow_name: wn,
-                    ..
-                } => {
-                    started_at = *timestamp;
-                    updated_at = *timestamp;
-                    workflow_name = wn.clone();
-                }
-                WorkflowLogEvent::StepStarted {
-                    step_name,
-                    execution_count,
-                    timestamp,
-                    ..
-                } => {
-                    current_step_name = step_name.clone();
-                    current_step_index = workflow
-                        .nodes
-                        .iter()
-                        .position(|s| s.name == *step_name)
-                        .unwrap_or(0);
-                    step_execution_counts.insert(step_name.clone(), *execution_count);
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::StepCompleted {
-                    step_name,
-                    result,
-                    session_id,
-                    token_usage,
-                    structured_output,
-                    run_index,
-                    timestamp,
-                    ..
-                } => {
-                    let ri = run_index.unwrap_or_else(|| {
-                        step_execution_counts.get(step_name).copied().unwrap_or(0)
-                    });
-                    step_history.push(StepHistoryEntry {
-                        step_name: step_name.clone(),
-                        completed_at: *timestamp,
-                        result: result.clone(),
-                        session_id: session_id.clone(),
-                        token_usage: token_usage.clone(),
-                        structured_output: structured_output.clone(),
-                        run_index: ri,
-                        child_outputs: None,
-                    });
-                    if structured_output.is_some() {
-                        step_outputs.insert(
-                            step_name.clone(),
-                            StepOutput {
-                                step_name: step_name.clone(),
-                                run_index: ri,
-                                session_id: session_id.clone(),
-                                result: result.clone(),
-                                structured_output: structured_output.clone(),
-                                output_contract: None,
-                                token_usage: token_usage.clone(),
-                                completed_at: *timestamp,
-                            },
-                        );
-                    }
-                    if let Some(ref usage) = token_usage {
-                        total_token_usage.add(usage);
-                    }
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::StepFailed {
-                    reason, timestamp, ..
-                } => {
-                    for ps in &mut active_parallel_steps {
-                        if ps.state == "running" {
-                            ps.state = "failed".to_string();
-                        }
-                    }
-                    exec_state = WorkflowExecutionState::Failed {
-                        reason: reason.clone(),
-                    };
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::WorkflowCompleted {
-                    total_token_usage: tu,
-                    timestamp,
-                    ..
-                } => {
-                    exec_state = WorkflowExecutionState::Completed;
-                    total_token_usage = tu.clone();
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::WorkflowFailed {
-                    reason, timestamp, ..
-                } => {
-                    exec_state = WorkflowExecutionState::Failed {
-                        reason: reason.clone(),
-                    };
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::WorkflowAborted { timestamp, .. } => {
-                    exec_state = WorkflowExecutionState::Aborted;
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::OutputCollected { timestamp, .. } => {
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::ParallelStarted {
-                    parent_step_name,
-                    child_step_names,
-                    timestamp,
-                    ..
-                } => {
-                    current_step_name = parent_step_name.clone();
-                    current_step_index = workflow
-                        .nodes
-                        .iter()
-                        .position(|s| s.name == *parent_step_name)
-                        .unwrap_or(current_step_index);
-                    active_parallel_steps = child_step_names
-                        .iter()
-                        .map(|name| ParallelStepState {
-                            step_name: name.clone(),
-                            state: "running".to_string(),
-                            session_id: None,
-                            result: None,
-                            run_index: 0,
-                            completed_at: None,
-                            structured_output: None,
-                            output_contract: None,
-                        })
-                        .collect();
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::ParallelStepStarted {
-                    child_step_name,
-                    session_id,
-                    execution_count,
-                    timestamp,
-                    ..
-                } => {
-                    step_execution_counts.insert(child_step_name.clone(), *execution_count);
-                    if let Some(ps) = active_parallel_steps
-                        .iter_mut()
-                        .find(|p| p.step_name == *child_step_name)
-                    {
-                        ps.state = "running".to_string();
-                        ps.session_id = Some(session_id.clone());
-                        ps.result = None;
-                        ps.run_index = *execution_count;
-                        ps.completed_at = None;
-                    } else {
-                        active_parallel_steps.push(ParallelStepState {
-                            step_name: child_step_name.clone(),
-                            state: "running".to_string(),
-                            session_id: Some(session_id.clone()),
-                            result: None,
-                            run_index: *execution_count,
-                            completed_at: None,
-                            structured_output: None,
-                            output_contract: None,
-                        });
-                    }
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::ParallelStepCompleted {
-                    child_step_name,
-                    result,
-                    session_id,
-                    token_usage,
-                    structured_output,
-                    run_index,
-                    timestamp,
-                    ..
-                } => {
-                    // active_parallel_stepsの該当エントリを更新
-                    if let Some(ps) = active_parallel_steps
-                        .iter_mut()
-                        .find(|p| p.step_name == *child_step_name)
-                    {
-                        ps.state = "completed".to_string();
-                        ps.result = result.clone();
-                        ps.completed_at = Some(*timestamp);
-                        ps.structured_output = structured_output.clone();
-                    }
-                    // step_historyへの追加はParallelCompletedで親ブロックとして合成する
-                    // （ライブ実行と同じ構造にするため）
-                    step_outputs.insert(
-                        child_step_name.clone(),
-                        StepOutput {
-                            step_name: child_step_name.clone(),
-                            run_index: *run_index,
-                            session_id: Some(session_id.clone()),
-                            result: result.clone(),
-                            structured_output: structured_output.clone(),
-                            output_contract: None,
-                            token_usage: token_usage.clone(),
-                            completed_at: *timestamp,
-                        },
-                    );
-                    if let Some(ref usage) = token_usage {
-                        total_token_usage.add(usage);
-                    }
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::ParallelCompleted { timestamp, .. } => {
-                    // step_historyへの追加は後続のStepCompletedが正本。
-                    // ここではactive_parallel_stepsのクリアのみ行う。
-                    active_parallel_steps.clear();
-                    updated_at = *timestamp;
-                }
-                WorkflowLogEvent::ContractRepairRequested { timestamp, .. } => {
-                    updated_at = *timestamp;
-                }
-            }
-        }
-
-        let step_states = crate::workflow::state::compute_step_states(
-            workflow,
-            current_step_index,
-            &exec_state,
-            &step_history,
-        );
-
-        Ok(Some(WorkflowState {
-            execution_id: execution_id.to_string(),
-            workflow_name,
-            chat_session_id: None,
-            state: exec_state,
-            current_step_index,
-            current_step_name,
-            current_session_id: None,
-            total_steps: workflow.nodes.len(),
-            step_history,
-            step_execution_counts,
-            workflow_definition: workflow.clone(),
-            total_token_usage,
-            step_outputs,
-            step_states,
-            active_parallel_steps,
-            workflow_variables: HashMap::new(),
-            approval_operations: None,
-            started_at,
-            updated_at,
-        }))
-    }
-
-    /// 指定worktreeに属する実行IDを返す（旧 `list_workflow_executions` Tauri command の
+    /// 指定worktreeに属する run_id を返す（旧 `list_workflow_executions` Tauri command の
     /// バックエンド。production からは廃止済みだが、過去 NDJSON の worktree フィルタを
     /// 維持するため、テスト用補助メソッドとして温存する）。
-    /// 各NDJSONファイルの1行目（WorkflowStarted）のworktree_pathと照合する。
+    /// 各NDJSONファイルの1行目（RunStarted）のworktree_pathと照合する。
     #[cfg(test)]
-    pub fn list_execution_ids_for_worktree(
-        &self,
-        worktree_path: &str,
-    ) -> Result<Vec<String>, String> {
+    pub fn list_run_ids_for_worktree(&self, worktree_path: &str) -> Result<Vec<String>, String> {
         if !self.log_dir.exists() {
             return Ok(vec![]);
         }
@@ -521,17 +171,17 @@ impl WorkflowEventLog {
             let Some(stem) = path.file_stem() else {
                 continue;
             };
-            let execution_id = stem.to_string_lossy().to_string();
+            let run_id = stem.to_string_lossy().to_string();
 
             // 1行目を読んでworktree_pathを照合
             if let Ok(content) = fs::read_to_string(&path) {
                 if let Some(first_line) = content.lines().next() {
-                    if let Ok(WorkflowLogEvent::WorkflowStarted {
+                    if let Ok(WorkflowEvent::RunStarted {
                         worktree_path: wt, ..
                     }) = serde_json::from_str(first_line)
                     {
                         if wt == worktree_path {
-                            ids.push(execution_id);
+                            ids.push(run_id);
                         }
                     }
                 }
@@ -544,10 +194,26 @@ impl WorkflowEventLog {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::workflow::event::{ApprovalDecisionRecord, CollectedOutputEntry};
+    use crate::workflow::event_projection::reconstruct_state_from_events;
+    use crate::workflow::schema::Workflow;
+    use crate::workflow::state::{TokenUsage, WorkflowExecutionState};
     use tempfile::TempDir;
 
+    /// 旧 `WorkflowEventLog::reconstruct_state` の shim。
+    /// log.rs の責務縮退（[04]: NDJSON adapter に閉じる）に伴い、再構築は
+    /// `event_projection::reconstruct_state_from_events` を経由する。テストの
+    /// 表現を変えないために本ファイル内ヘルパーとして残す。
+    fn reconstruct_state_via_log(
+        log: &WorkflowEventLog,
+        run_id: &str,
+        workflow: &Workflow,
+    ) -> Result<Option<crate::workflow::state::WorkflowState>, String> {
+        let events = log.read_log(run_id)?;
+        reconstruct_state_from_events(run_id, &events, workflow)
+    }
+
     /// テスト用の最小 Workflow。
-    /// log event の `workflow_definition` フィールド（必須）を埋めるために使う。
     fn minimal_workflow_for_log(name: &str) -> Workflow {
         use crate::workflow::schema::{NodeDefinition, NodeType};
         Workflow {
@@ -563,15 +229,15 @@ mod tests {
         }
     }
 
-    /// [02] schema 境界: 旧 NDJSON（`workflow_definition` フィールドを持たない）は
-    /// 新 `WorkflowLogEvent` deserialize で必ず失敗する。
+    /// [04] 旧 NDJSON（旧 `workflow_started` 語彙、`execution_id` フィールド）は
+    /// 新 `WorkflowEvent` deserialize で必ず失敗する（互換 wrapper を持たないことの担保）。
     #[test]
-    fn old_ndjson_without_workflow_definition_fails_to_deserialize() {
-        let legacy_line = r#"{"event":"workflow_started","execution_id":"old-1","workflow_name":"legacy","workflow_file_stem":"legacy","worktree_path":"/repo","timestamp":1000.0}"#;
-        let result: Result<WorkflowLogEvent, _> = serde_json::from_str(legacy_line);
+    fn legacy_ndjson_with_old_event_tag_fails_to_deserialize() {
+        let legacy_line = r#"{"event":"workflow_started","execution_id":"old-1","workflow_name":"legacy","workflow_file_stem":"legacy","worktree_path":"/repo","workflow_definition":{"name":"legacy","description":"","builtin":false,"nodes":[]},"timestamp":1000.0}"#;
+        let result: Result<WorkflowEvent, _> = serde_json::from_str(legacy_line);
         assert!(
             result.is_err(),
-            "旧 NDJSON の WorkflowStarted は新 schema で必ず deserialize 失敗する"
+            "旧 event tag (workflow_started) は新 schema で必ず deserialize 失敗する"
         );
     }
 
@@ -579,8 +245,8 @@ mod tests {
     /// 新 schema（`workflow_definition.nodes` + `deny_unknown_fields`）として deserialize できない。
     #[test]
     fn old_ndjson_with_legacy_steps_shape_fails_to_deserialize() {
-        let legacy_line = r#"{"event":"workflow_started","execution_id":"old-1","workflow_name":"legacy","workflow_file_stem":"legacy","worktree_path":"/repo","workflow_definition":{"name":"legacy","description":"","builtin":false,"steps":[{"name":"x","mode":"auto","instruction":"x"}]},"timestamp":1000.0}"#;
-        let result: Result<WorkflowLogEvent, _> = serde_json::from_str(legacy_line);
+        let legacy_line = r#"{"event":"run_started","run_id":"old-1","workflow_name":"legacy","workflow_file_stem":"legacy","worktree_path":"/repo","workflow_definition":{"name":"legacy","description":"","builtin":false,"steps":[{"name":"x","mode":"auto","instruction":"x"}]},"timestamp":1000.0}"#;
+        let result: Result<WorkflowEvent, _> = serde_json::from_str(legacy_line);
         assert!(
             result.is_err(),
             "旧 workflow_definition.steps を含む NDJSON は新 schema で deserialize 失敗する"
@@ -589,29 +255,29 @@ mod tests {
 
     /// 旧 `workflow_definition.steps` を含む NDJSON は listing / reconstruction の対象外となる。
     #[test]
-    fn list_execution_ids_excludes_legacy_steps_ndjson() {
+    fn list_run_ids_excludes_legacy_steps_ndjson() {
         let tmp = TempDir::new().unwrap();
         let log = WorkflowEventLog::new(tmp.path());
         fs::create_dir_all(&log.log_dir).unwrap();
         let legacy_path = log.log_path("legacy-steps");
         fs::write(
             &legacy_path,
-            r#"{"event":"workflow_started","execution_id":"legacy-steps","workflow_name":"old","workflow_file_stem":"old","worktree_path":"/repo","workflow_definition":{"name":"old","description":"","builtin":false,"steps":[{"name":"x","mode":"auto","instruction":"x"}]},"timestamp":1000.0}"#,
+            r#"{"event":"run_started","run_id":"legacy-steps","workflow_name":"old","workflow_file_stem":"old","worktree_path":"/repo","workflow_definition":{"name":"old","description":"","builtin":false,"steps":[{"name":"x","mode":"auto","instruction":"x"}]},"timestamp":1000.0}"#,
         )
         .unwrap();
         // read_log は parse 失敗を返す（旧 shape は復元対象外）
         assert!(log.read_log("legacy-steps").is_err());
         // listing も除外（listing は parse 失敗 line をスキップする）
-        let ids = log.list_execution_ids_for_worktree("/repo").unwrap();
+        let ids = log.list_run_ids_for_worktree("/repo").unwrap();
         assert!(!ids.iter().any(|i| i == "legacy-steps"));
     }
 
-    /// 旧 NDJSON が listing から除外されること（read_log 失敗 ⇒ list_execution_ids_for_worktree でも対象外）。
+    /// 旧 NDJSON が listing から除外されること（read_log 失敗 ⇒ list_run_ids_for_worktree でも対象外）。
     #[test]
-    fn list_execution_ids_for_worktree_excludes_legacy_ndjson() {
+    fn list_run_ids_for_worktree_excludes_legacy_ndjson() {
         let tmp = TempDir::new().unwrap();
         let log = WorkflowEventLog::new(tmp.path());
-        // worktree 一致する旧 NDJSON を直接書き込む（workflow_definition フィールドを欠く）
+        // worktree 一致する旧 NDJSON を直接書き込む（旧 event tag）
         fs::create_dir_all(&log.log_dir).unwrap();
         let legacy_path = log.log_path("legacy");
         fs::write(
@@ -621,8 +287,8 @@ mod tests {
         .unwrap();
 
         // 新 NDJSON も同じ worktree で書き込む
-        log.append(&WorkflowLogEvent::WorkflowStarted {
-            execution_id: "new-1".to_string(),
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: "new-1".to_string(),
             workflow_name: "new".to_string(),
             workflow_file_stem: "new".to_string(),
             worktree_path: "/repo".to_string(),
@@ -631,7 +297,7 @@ mod tests {
         })
         .unwrap();
 
-        let ids = log.list_execution_ids_for_worktree("/repo").unwrap();
+        let ids = log.list_run_ids_for_worktree("/repo").unwrap();
         assert!(
             !ids.iter().any(|i| i == "legacy"),
             "旧 NDJSON は listing 対象から除外される"
@@ -639,30 +305,109 @@ mod tests {
         assert!(ids.iter().any(|i| i == "new-1"));
     }
 
+    /// [04] atomic batch append: 複数 event を 1 回の write でまとめて append すれば、
+    /// partial commit（最初の event のみ NDJSON に残る）を構造的に排除できることを
+    /// 担保する。append_batch 経由で書き込んだ 2 件は read_log で順序通り 2 件として
+    /// 読み出される。
+    #[test]
+    fn append_batch_writes_all_events_atomically_in_order() {
+        let tmp = TempDir::new().unwrap();
+        let log = WorkflowEventLog::new(tmp.path());
+        let run_id = "00000000-0000-0000-0000-000000000700";
+        let events = vec![
+            WorkflowEvent::ApprovalResolved {
+                run_id: run_id.to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "review".to_string(),
+                decision: ApprovalDecisionRecord::Abort,
+                comment: None,
+                timestamp: 1000.0,
+            },
+            WorkflowEvent::RunAborted {
+                run_id: run_id.to_string(),
+                workflow_name: "wf".to_string(),
+                timestamp: 1000.0,
+            },
+        ];
+        log.append_batch(&events)
+            .expect("batch append should succeed");
+        let read_back = log.read_log(run_id).unwrap();
+        assert_eq!(
+            read_back.len(),
+            2,
+            "両方の event が atomic に append される"
+        );
+        assert!(matches!(
+            read_back[0],
+            WorkflowEvent::ApprovalResolved { .. }
+        ));
+        assert!(matches!(read_back[1], WorkflowEvent::RunAborted { .. }));
+    }
+
+    /// [04] atomic batch append: 入力 event が異なる run_id を含む場合は append 前に
+    /// Err を返し、partial 書き込みを起こさない（構造的不変条件）。
+    #[test]
+    fn append_batch_rejects_mixed_run_ids_before_writing() {
+        let tmp = TempDir::new().unwrap();
+        let log = WorkflowEventLog::new(tmp.path());
+        let events = vec![
+            WorkflowEvent::ApprovalResolved {
+                run_id: "run-a".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "review".to_string(),
+                decision: ApprovalDecisionRecord::Approve,
+                comment: None,
+                timestamp: 1.0,
+            },
+            WorkflowEvent::RunAborted {
+                run_id: "run-b".to_string(),
+                workflow_name: "wf".to_string(),
+                timestamp: 2.0,
+            },
+        ];
+        let err = log.append_batch(&events).unwrap_err();
+        assert!(
+            err.contains("uniform run_id"),
+            "異 run_id 混在は uniform run_id エラーで拒否される: {err}"
+        );
+        // どちらの run_id の NDJSON も生成されていない
+        assert!(log.read_log("run-a").unwrap().is_empty());
+        assert!(log.read_log("run-b").unwrap().is_empty());
+    }
+
+    /// [04] atomic batch append: 空入力は no-op として Ok を返す（NDJSON は生成されない）。
+    #[test]
+    fn append_batch_with_empty_input_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let log = WorkflowEventLog::new(tmp.path());
+        log.append_batch(&[]).expect("empty input is no-op Ok");
+        assert!(log.read_log("any").unwrap().is_empty());
+    }
+
     #[test]
     fn append_and_read_log() {
         let tmp = TempDir::new().unwrap();
         let log = WorkflowEventLog::new(tmp.path());
 
-        let event1 = WorkflowLogEvent::WorkflowStarted {
-            execution_id: "exec-1".to_string(),
+        let event1 = WorkflowEvent::RunStarted {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
             workflow_file_stem: "test-wf".to_string(),
             worktree_path: "/repo".to_string(),
             workflow_definition: minimal_workflow_for_log("test"),
             timestamp: 1000.0,
         };
-        let event2 = WorkflowLogEvent::StepStarted {
-            execution_id: "exec-1".to_string(),
+        let event2 = WorkflowEvent::NodeStarted {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "plan".to_string(),
+            node_name: "plan".to_string(),
             execution_count: 1,
             timestamp: 1001.0,
         };
-        let event3 = WorkflowLogEvent::StepCompleted {
-            execution_id: "exec-1".to_string(),
+        let event3 = WorkflowEvent::NodeCompleted {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "plan".to_string(),
+            node_name: "plan".to_string(),
             result: Some("done".to_string()),
             session_id: Some("sess-1".to_string()),
             token_usage: Some(TokenUsage {
@@ -691,20 +436,20 @@ mod tests {
     }
 
     #[test]
-    fn list_execution_ids_for_worktree_empty() {
+    fn list_run_ids_for_worktree_empty() {
         let tmp = TempDir::new().unwrap();
         let log = WorkflowEventLog::new(tmp.path());
-        let ids = log.list_execution_ids_for_worktree("/repo").unwrap();
+        let ids = log.list_run_ids_for_worktree("/repo").unwrap();
         assert!(ids.is_empty());
     }
 
     #[test]
-    fn list_execution_ids_for_worktree_filters_by_path() {
+    fn list_run_ids_for_worktree_filters_by_path() {
         let tmp = TempDir::new().unwrap();
         let log = WorkflowEventLog::new(tmp.path());
 
-        log.append(&WorkflowLogEvent::WorkflowStarted {
-            execution_id: "exec-a".to_string(),
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: "exec-a".to_string(),
             workflow_name: "wf-a".to_string(),
             workflow_file_stem: "wf-a".to_string(),
             worktree_path: "/repo-1".to_string(),
@@ -712,8 +457,8 @@ mod tests {
             timestamp: 1000.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::WorkflowStarted {
-            execution_id: "exec-b".to_string(),
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: "exec-b".to_string(),
             workflow_name: "wf-b".to_string(),
             workflow_file_stem: "wf-b".to_string(),
             worktree_path: "/repo-2".to_string(),
@@ -721,8 +466,8 @@ mod tests {
             timestamp: 1001.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::WorkflowStarted {
-            execution_id: "exec-c".to_string(),
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: "exec-c".to_string(),
             workflow_name: "wf-c".to_string(),
             workflow_file_stem: "wf-c".to_string(),
             worktree_path: "/repo-1".to_string(),
@@ -731,39 +476,39 @@ mod tests {
         })
         .unwrap();
 
-        let mut ids = log.list_execution_ids_for_worktree("/repo-1").unwrap();
+        let mut ids = log.list_run_ids_for_worktree("/repo-1").unwrap();
         ids.sort();
         assert_eq!(ids, vec!["exec-a", "exec-c"]);
 
-        let ids2 = log.list_execution_ids_for_worktree("/repo-2").unwrap();
+        let ids2 = log.list_run_ids_for_worktree("/repo-2").unwrap();
         assert_eq!(ids2, vec!["exec-b"]);
 
-        let ids3 = log.list_execution_ids_for_worktree("/other").unwrap();
+        let ids3 = log.list_run_ids_for_worktree("/other").unwrap();
         assert!(ids3.is_empty());
     }
 
     #[test]
     fn event_serde_all_variants() {
         let events = vec![
-            WorkflowLogEvent::WorkflowStarted {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::RunStarted {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
                 workflow_file_stem: "wf".to_string(),
                 worktree_path: "/repo".to_string(),
                 workflow_definition: minimal_workflow_for_log("test"),
                 timestamp: 1.0,
             },
-            WorkflowLogEvent::StepStarted {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::NodeStarted {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
-                step_name: "s1".to_string(),
+                node_name: "s1".to_string(),
                 execution_count: 1,
                 timestamp: 2.0,
             },
-            WorkflowLogEvent::StepCompleted {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::NodeCompleted {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
-                step_name: "s1".to_string(),
+                node_name: "s1".to_string(),
                 result: None,
                 session_id: None,
                 token_usage: None,
@@ -771,15 +516,29 @@ mod tests {
                 run_index: None,
                 timestamp: 3.0,
             },
-            WorkflowLogEvent::StepFailed {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::NodeFailed {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
-                step_name: "s1".to_string(),
+                node_name: "s1".to_string(),
                 reason: "error".to_string(),
                 timestamp: 4.0,
             },
-            WorkflowLogEvent::WorkflowCompleted {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::ApprovalRequested {
+                run_id: "e1".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "s1".to_string(),
+                timestamp: 4.5,
+            },
+            WorkflowEvent::ApprovalResolved {
+                run_id: "e1".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "s1".to_string(),
+                decision: ApprovalDecisionRecord::Approve,
+                comment: None,
+                timestamp: 4.7,
+            },
+            WorkflowEvent::RunCompleted {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
                 total_token_usage: TokenUsage {
                     input_tokens: 100,
@@ -787,23 +546,23 @@ mod tests {
                 },
                 timestamp: 5.0,
             },
-            WorkflowLogEvent::WorkflowFailed {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::RunFailed {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
                 reason: "failed".to_string(),
                 timestamp: 6.0,
             },
-            WorkflowLogEvent::WorkflowAborted {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::RunAborted {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
                 timestamp: 7.0,
             },
-            WorkflowLogEvent::OutputCollected {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::OutputCollected {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
-                step_name: "collect".to_string(),
-                step_outputs: vec![CollectedOutputEntry {
-                    step_name: "s1".to_string(),
+                node_name: "collect".to_string(),
+                node_outputs: vec![CollectedOutputEntry {
+                    node_name: "s1".to_string(),
                     result: Some("LGTM".to_string()),
                     structured_output: None,
                 }],
@@ -812,27 +571,27 @@ mod tests {
                 reduce_structured_output: None,
                 timestamp: 8.0,
             },
-            WorkflowLogEvent::ParallelStarted {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::ParallelStarted {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
-                child_step_names: vec!["arch-review".to_string(), "security-review".to_string()],
+                parent_node_name: "parallel-review".to_string(),
+                child_node_names: vec!["arch-review".to_string(), "security-review".to_string()],
                 timestamp: 9.0,
             },
-            WorkflowLogEvent::ParallelStepStarted {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::ParallelChildStarted {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
-                child_step_name: "arch-review".to_string(),
+                parent_node_name: "parallel-review".to_string(),
+                child_node_name: "arch-review".to_string(),
                 session_id: "sess-1".to_string(),
                 execution_count: 1,
                 timestamp: 10.0,
             },
-            WorkflowLogEvent::ParallelStepCompleted {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::ParallelChildCompleted {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
-                child_step_name: "arch-review".to_string(),
+                parent_node_name: "parallel-review".to_string(),
+                child_node_name: "arch-review".to_string(),
                 result: None,
                 session_id: "sess-1".to_string(),
                 token_usage: Some(TokenUsage {
@@ -843,17 +602,17 @@ mod tests {
                 run_index: 0,
                 timestamp: 11.0,
             },
-            WorkflowLogEvent::ParallelCompleted {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::ParallelCompleted {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
+                parent_node_name: "parallel-review".to_string(),
                 aggregate_result: "then".to_string(),
                 timestamp: 12.0,
             },
-            WorkflowLogEvent::ContractRepairRequested {
-                execution_id: "e1".to_string(),
+            WorkflowEvent::ContractRepairRequested {
+                run_id: "e1".to_string(),
                 workflow_name: "wf".to_string(),
-                step_name: "s1".to_string(),
+                node_name: "s1".to_string(),
                 attempt: 1,
                 violation_reason: "missing_field".to_string(),
                 timestamp: 13.0,
@@ -862,7 +621,7 @@ mod tests {
 
         for event in &events {
             let json = serde_json::to_string(event).unwrap();
-            let back: WorkflowLogEvent = serde_json::from_str(&json).unwrap();
+            let back: WorkflowEvent = serde_json::from_str(&json).unwrap();
             let json2 = serde_json::to_string(&back).unwrap();
             assert_eq!(json, json2);
         }
@@ -918,7 +677,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let log = WorkflowEventLog::new(tmp.path());
         let wf = make_test_workflow();
-        let result = log.reconstruct_state("nonexistent", &wf).unwrap();
+        let result = reconstruct_state_via_log(&log, "nonexistent", &wf).unwrap();
         assert!(result.is_none());
     }
 
@@ -928,8 +687,8 @@ mod tests {
         let log = WorkflowEventLog::new(tmp.path());
         let wf = make_test_workflow();
 
-        log.append(&WorkflowLogEvent::WorkflowStarted {
-            execution_id: "exec-1".to_string(),
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
             workflow_file_stem: "test-wf".to_string(),
             worktree_path: "/repo".to_string(),
@@ -937,18 +696,18 @@ mod tests {
             timestamp: 1000.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::StepStarted {
-            execution_id: "exec-1".to_string(),
+        log.append(&WorkflowEvent::NodeStarted {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "plan".to_string(),
+            node_name: "plan".to_string(),
             execution_count: 1,
             timestamp: 1001.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::StepCompleted {
-            execution_id: "exec-1".to_string(),
+        log.append(&WorkflowEvent::NodeCompleted {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "plan".to_string(),
+            node_name: "plan".to_string(),
             result: Some("done".to_string()),
             session_id: Some("sess-plan".to_string()),
             token_usage: Some(TokenUsage {
@@ -960,18 +719,18 @@ mod tests {
             timestamp: 1002.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::StepStarted {
-            execution_id: "exec-1".to_string(),
+        log.append(&WorkflowEvent::NodeStarted {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "implement".to_string(),
+            node_name: "implement".to_string(),
             execution_count: 1,
             timestamp: 1003.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::StepCompleted {
-            execution_id: "exec-1".to_string(),
+        log.append(&WorkflowEvent::NodeCompleted {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "implement".to_string(),
+            node_name: "implement".to_string(),
             result: None,
             session_id: Some("sess-impl".to_string()),
             token_usage: None,
@@ -980,12 +739,12 @@ mod tests {
             timestamp: 1004.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::OutputCollected {
-            execution_id: "exec-1".to_string(),
+        log.append(&WorkflowEvent::OutputCollected {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "collect".to_string(),
-            step_outputs: vec![CollectedOutputEntry {
-                step_name: "plan".to_string(),
+            node_name: "collect".to_string(),
+            node_outputs: vec![CollectedOutputEntry {
+                node_name: "plan".to_string(),
                 result: Some("done".to_string()),
                 structured_output: None,
             }],
@@ -995,8 +754,8 @@ mod tests {
             timestamp: 1004.5,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::WorkflowCompleted {
-            execution_id: "exec-1".to_string(),
+        log.append(&WorkflowEvent::RunCompleted {
+            run_id: "exec-1".to_string(),
             workflow_name: "test-wf".to_string(),
             total_token_usage: TokenUsage {
                 input_tokens: 200,
@@ -1006,7 +765,9 @@ mod tests {
         })
         .unwrap();
 
-        let state = log.reconstruct_state("exec-1", &wf).unwrap().unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-1", &wf)
+            .unwrap()
+            .unwrap();
         assert_eq!(state.execution_id, "exec-1");
         assert_eq!(state.state, WorkflowExecutionState::Completed);
         assert_eq!(state.step_history.len(), 2);
@@ -1033,7 +794,6 @@ mod tests {
         assert_eq!(state.step_states["implement"], "completed");
         assert_eq!(state.step_states["review"], "pending");
         assert_eq!(state.started_at, 1000.0);
-        // OutputCollectedのtimestamp=1004.5よりWorkflowCompletedの1005.0が最終
         assert_eq!(state.updated_at, 1005.0);
     }
 
@@ -1043,8 +803,8 @@ mod tests {
         let log = WorkflowEventLog::new(tmp.path());
         let wf = make_test_workflow();
 
-        log.append(&WorkflowLogEvent::WorkflowStarted {
-            execution_id: "exec-2".to_string(),
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: "exec-2".to_string(),
             workflow_name: "test-wf".to_string(),
             workflow_file_stem: "test-wf".to_string(),
             worktree_path: "/repo".to_string(),
@@ -1052,31 +812,33 @@ mod tests {
             timestamp: 2000.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::StepStarted {
-            execution_id: "exec-2".to_string(),
+        log.append(&WorkflowEvent::NodeStarted {
+            run_id: "exec-2".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "plan".to_string(),
+            node_name: "plan".to_string(),
             execution_count: 1,
             timestamp: 2001.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::StepFailed {
-            execution_id: "exec-2".to_string(),
+        log.append(&WorkflowEvent::NodeFailed {
+            run_id: "exec-2".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "plan".to_string(),
+            node_name: "plan".to_string(),
             reason: "exit code 1".to_string(),
             timestamp: 2002.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::WorkflowFailed {
-            execution_id: "exec-2".to_string(),
+        log.append(&WorkflowEvent::RunFailed {
+            run_id: "exec-2".to_string(),
             workflow_name: "test-wf".to_string(),
             reason: "step failed".to_string(),
             timestamp: 2003.0,
         })
         .unwrap();
 
-        let state = log.reconstruct_state("exec-2", &wf).unwrap().unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-2", &wf)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             state.state,
             WorkflowExecutionState::Failed {
@@ -1088,7 +850,7 @@ mod tests {
     }
 
     /// 並列ブロックを含むワークフローのNDJSON復元テスト。
-    /// ParallelCompleted + StepCompleted で親ステップが重複しないことを検証する。
+    /// ParallelCompleted + NodeCompleted で親ステップが重複しないことを検証する。
     #[test]
     fn reconstruct_state_parallel_block_no_duplicate_history() {
         use crate::workflow::schema::{NodeDefinition, NodeType, ParallelAggregate};
@@ -1125,27 +887,26 @@ mod tests {
             nodes: vec![make_agent_node("plan", "plan"), parallel_review],
         };
 
-        // NDJSON: plan完了 → 並列開始 → 子2つ完了 → ParallelCompleted → StepCompleted(親)
         let events = vec![
-            WorkflowLogEvent::WorkflowStarted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::RunStarted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
                 workflow_file_stem: "parallel-wf".to_string(),
                 worktree_path: "/repo".to_string(),
                 workflow_definition: minimal_workflow_for_log("test"),
                 timestamp: 1000.0,
             },
-            WorkflowLogEvent::StepStarted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::NodeStarted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
-                step_name: "plan".to_string(),
+                node_name: "plan".to_string(),
                 execution_count: 1,
                 timestamp: 1001.0,
             },
-            WorkflowLogEvent::StepCompleted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::NodeCompleted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
-                step_name: "plan".to_string(),
+                node_name: "plan".to_string(),
                 result: Some("done".to_string()),
                 session_id: Some("sess-plan".to_string()),
                 token_usage: Some(TokenUsage {
@@ -1156,36 +917,36 @@ mod tests {
                 run_index: Some(1),
                 timestamp: 1002.0,
             },
-            WorkflowLogEvent::ParallelStarted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::ParallelStarted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
-                child_step_names: vec!["arch-review".to_string(), "security-review".to_string()],
+                parent_node_name: "parallel-review".to_string(),
+                child_node_names: vec!["arch-review".to_string(), "security-review".to_string()],
                 timestamp: 1003.0,
             },
-            WorkflowLogEvent::ParallelStepStarted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::ParallelChildStarted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
-                child_step_name: "arch-review".to_string(),
+                parent_node_name: "parallel-review".to_string(),
+                child_node_name: "arch-review".to_string(),
                 session_id: "sess-arch".to_string(),
                 execution_count: 1,
                 timestamp: 1004.0,
             },
-            WorkflowLogEvent::ParallelStepStarted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::ParallelChildStarted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
-                child_step_name: "security-review".to_string(),
+                parent_node_name: "parallel-review".to_string(),
+                child_node_name: "security-review".to_string(),
                 session_id: "sess-sec".to_string(),
                 execution_count: 1,
                 timestamp: 1004.0,
             },
-            WorkflowLogEvent::ParallelStepCompleted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::ParallelChildCompleted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
-                child_step_name: "arch-review".to_string(),
+                parent_node_name: "parallel-review".to_string(),
+                child_node_name: "arch-review".to_string(),
                 result: Some("LGTM".to_string()),
                 session_id: "sess-arch".to_string(),
                 token_usage: Some(TokenUsage {
@@ -1196,11 +957,11 @@ mod tests {
                 run_index: 1,
                 timestamp: 1005.0,
             },
-            WorkflowLogEvent::ParallelStepCompleted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::ParallelChildCompleted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
-                child_step_name: "security-review".to_string(),
+                parent_node_name: "parallel-review".to_string(),
+                child_node_name: "security-review".to_string(),
                 result: Some("LGTM".to_string()),
                 session_id: "sess-sec".to_string(),
                 token_usage: Some(TokenUsage {
@@ -1211,18 +972,18 @@ mod tests {
                 run_index: 1,
                 timestamp: 1006.0,
             },
-            WorkflowLogEvent::ParallelCompleted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::ParallelCompleted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
-                parent_step_name: "parallel-review".to_string(),
+                parent_node_name: "parallel-review".to_string(),
                 aggregate_result: "then".to_string(),
                 timestamp: 1007.0,
             },
-            // engine.rsのwrite_last_step_completed_logが親ステップのStepCompletedを出力
-            WorkflowLogEvent::StepCompleted {
-                execution_id: "exec-p".to_string(),
+            // engine.rsのwrite_last_step_completed_logが親ステップのNodeCompletedを出力
+            WorkflowEvent::NodeCompleted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
-                step_name: "parallel-review".to_string(),
+                node_name: "parallel-review".to_string(),
                 result: Some("then".to_string()),
                 session_id: None,
                 token_usage: Some(TokenUsage {
@@ -1233,8 +994,8 @@ mod tests {
                 run_index: Some(1),
                 timestamp: 1007.0,
             },
-            WorkflowLogEvent::WorkflowCompleted {
-                execution_id: "exec-p".to_string(),
+            WorkflowEvent::RunCompleted {
+                run_id: "exec-p".to_string(),
                 workflow_name: "parallel-wf".to_string(),
                 total_token_usage: TokenUsage {
                     input_tokens: 450,
@@ -1248,9 +1009,10 @@ mod tests {
             log.append(event).unwrap();
         }
 
-        let state = log.reconstruct_state("exec-p", &wf).unwrap().unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-p", &wf)
+            .unwrap()
+            .unwrap();
 
-        // step_historyは「plan」と「parallel-review」の2エントリのみ（重複なし）
         assert_eq!(
             state.step_history.len(),
             2,
@@ -1261,15 +1023,12 @@ mod tests {
         assert_eq!(state.step_history[1].result, Some("then".to_string()));
         assert_eq!(state.step_history[1].structured_output, None);
 
-        // current_step はParallelStartedで更新された並列ブロック
         assert_eq!(state.current_step_name, "parallel-review");
         assert_eq!(state.current_step_index, 1);
 
-        // step_outputsに子ステップの出力が存在
         assert!(state.step_outputs.contains_key("arch-review"));
         assert!(state.step_outputs.contains_key("security-review"));
 
-        // 並列ブロック完了後はactive_parallel_stepsがクリアされる
         assert!(state.active_parallel_steps.is_empty());
 
         assert_eq!(state.state, WorkflowExecutionState::Completed);
@@ -1281,8 +1040,8 @@ mod tests {
         let log = WorkflowEventLog::new(tmp.path());
         let wf = make_test_workflow();
 
-        log.append(&WorkflowLogEvent::WorkflowStarted {
-            execution_id: "exec-r".to_string(),
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: "exec-r".to_string(),
             workflow_name: "test-wf".to_string(),
             workflow_file_stem: "test-wf".to_string(),
             worktree_path: "/repo".to_string(),
@@ -1290,18 +1049,18 @@ mod tests {
             timestamp: 1000.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::StepStarted {
-            execution_id: "exec-r".to_string(),
+        log.append(&WorkflowEvent::NodeStarted {
+            run_id: "exec-r".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "review".to_string(),
+            node_name: "review".to_string(),
             execution_count: 1,
             timestamp: 1001.0,
         })
         .unwrap();
-        log.append(&WorkflowLogEvent::StepCompleted {
-            execution_id: "exec-r".to_string(),
+        log.append(&WorkflowEvent::NodeCompleted {
+            run_id: "exec-r".to_string(),
             workflow_name: "test-wf".to_string(),
-            step_name: "review".to_string(),
+            node_name: "review".to_string(),
             result: Some("reject".to_string()),
             session_id: Some("sess-review".to_string()),
             token_usage: Some(TokenUsage {
@@ -1314,15 +1073,157 @@ mod tests {
         })
         .unwrap();
 
-        let state = log.reconstruct_state("exec-r", &wf).unwrap().unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-r", &wf)
+            .unwrap()
+            .unwrap();
 
-        // step_history にReject結果が保存されている
         assert_eq!(state.step_history.len(), 1);
         assert_eq!(state.step_history[0].step_name, "review");
         assert_eq!(state.step_history[0].result, Some("reject".to_string()));
         assert!(state.step_history[0].structured_output.is_none());
 
-        // Reject時はstructured_outputがないのでstep_outputsには格納されない
         assert!(!state.step_outputs.contains_key("review"));
+    }
+
+    /// [04] ApprovalRequested projection: 承認待ちに到達すると state が
+    /// WaitingApproval に切り替わり、current_step_name / current_step_index が
+    /// approval 対象 node に揃う。updated_at は ApprovalRequested の timestamp に
+    /// 進む。観測者が承認待ち run を識別できる境界を担保する。
+    #[test]
+    fn reconstruct_state_approval_requested_sets_waiting_approval() {
+        let tmp = TempDir::new().unwrap();
+        let log = WorkflowEventLog::new(tmp.path());
+        let wf = make_test_workflow();
+
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: "exec-ap".to_string(),
+            workflow_name: "test-wf".to_string(),
+            workflow_file_stem: "test-wf".to_string(),
+            worktree_path: "/repo".to_string(),
+            workflow_definition: minimal_workflow_for_log("test"),
+            timestamp: 1000.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::NodeStarted {
+            run_id: "exec-ap".to_string(),
+            workflow_name: "test-wf".to_string(),
+            node_name: "review".to_string(),
+            execution_count: 1,
+            timestamp: 1001.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::ApprovalRequested {
+            run_id: "exec-ap".to_string(),
+            workflow_name: "test-wf".to_string(),
+            node_name: "review".to_string(),
+            timestamp: 1002.0,
+        })
+        .unwrap();
+
+        let state = reconstruct_state_via_log(&log, "exec-ap", &wf)
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.state, WorkflowExecutionState::WaitingApproval);
+        assert_eq!(state.current_step_name, "review");
+        // workflow.nodes は plan/implement/review の順なので review の index は 2。
+        assert_eq!(state.current_step_index, 2);
+        assert_eq!(state.updated_at, 1002.0);
+    }
+
+    /// [04] approval 承認 → 次 node 開始: ApprovalRequested で WaitingApproval に
+    /// 切り替わった後、ApprovalResolved → NodeCompleted → NodeStarted の順に
+    /// 進むと、exec_state は次 node 開始時に Running へ復元される。
+    /// projection のバグ「WaitingApproval が固定される」回帰防止。
+    #[test]
+    fn reconstruct_state_node_started_after_approval_resets_to_running() {
+        use crate::workflow::schema::{NodeDefinition, NodeType, TransitionRule};
+
+        let tmp = TempDir::new().unwrap();
+        let log = WorkflowEventLog::new(tmp.path());
+        // approval node のあとに後続 node を続ける workflow を作る。
+        let mut review = make_approval_node("review", "review");
+        review.transition_rules = vec![TransitionRule {
+            r#match: "approve".to_string(),
+            next: "ship".to_string(),
+        }];
+        let wf = Workflow {
+            name: "approval-then-next".to_string(),
+            description: "".to_string(),
+            builtin: false,
+            nodes: vec![
+                review,
+                NodeDefinition {
+                    name: "ship".to_string(),
+                    node_type: NodeType::Agent,
+                    instruction: Some("ship".to_string()),
+                    ..NodeDefinition::default()
+                },
+            ],
+        };
+
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: "exec-an".to_string(),
+            workflow_name: "approval-then-next".to_string(),
+            workflow_file_stem: "approval-then-next".to_string(),
+            worktree_path: "/repo".to_string(),
+            workflow_definition: minimal_workflow_for_log("test"),
+            timestamp: 2000.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::NodeStarted {
+            run_id: "exec-an".to_string(),
+            workflow_name: "approval-then-next".to_string(),
+            node_name: "review".to_string(),
+            execution_count: 1,
+            timestamp: 2001.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::ApprovalRequested {
+            run_id: "exec-an".to_string(),
+            workflow_name: "approval-then-next".to_string(),
+            node_name: "review".to_string(),
+            timestamp: 2002.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::ApprovalResolved {
+            run_id: "exec-an".to_string(),
+            workflow_name: "approval-then-next".to_string(),
+            node_name: "review".to_string(),
+            decision: ApprovalDecisionRecord::Approve,
+            comment: None,
+            timestamp: 2003.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::NodeCompleted {
+            run_id: "exec-an".to_string(),
+            workflow_name: "approval-then-next".to_string(),
+            node_name: "review".to_string(),
+            result: Some("approve".to_string()),
+            session_id: Some("sess-review".to_string()),
+            token_usage: None,
+            structured_output: None,
+            run_index: Some(1),
+            timestamp: 2004.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::NodeStarted {
+            run_id: "exec-an".to_string(),
+            workflow_name: "approval-then-next".to_string(),
+            node_name: "ship".to_string(),
+            execution_count: 1,
+            timestamp: 2005.0,
+        })
+        .unwrap();
+
+        let state = reconstruct_state_via_log(&log, "exec-an", &wf)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            state.state,
+            WorkflowExecutionState::Running,
+            "次 node 開始で WaitingApproval は Running に復元される"
+        );
+        assert_eq!(state.current_step_name, "ship");
+        assert_eq!(state.current_step_index, 1);
     }
 }

--- a/src-tauri/src/workflow/log.rs
+++ b/src-tauri/src/workflow/log.rs
@@ -204,13 +204,15 @@ mod tests {
     /// log.rs の責務縮退（[04]: NDJSON adapter に閉じる）に伴い、再構築は
     /// `event_projection::reconstruct_state_from_events` を経由する。テストの
     /// 表現を変えないために本ファイル内ヘルパーとして残す。
+    ///
+    /// [04] schema 境界: 復元用の `Workflow` は `RunStarted.workflow_definition` snapshot
+    /// からのみ取り出す。本 shim は workflow を引数で受け取らない。
     fn reconstruct_state_via_log(
         log: &WorkflowEventLog,
         run_id: &str,
-        workflow: &Workflow,
     ) -> Result<Option<crate::workflow::state::WorkflowState>, String> {
         let events = log.read_log(run_id)?;
-        reconstruct_state_from_events(run_id, &events, workflow)
+        reconstruct_state_from_events(run_id, &events)
     }
 
     /// テスト用の最小 Workflow。
@@ -676,8 +678,7 @@ mod tests {
     fn reconstruct_state_empty_log() {
         let tmp = TempDir::new().unwrap();
         let log = WorkflowEventLog::new(tmp.path());
-        let wf = make_test_workflow();
-        let result = reconstruct_state_via_log(&log, "nonexistent", &wf).unwrap();
+        let result = reconstruct_state_via_log(&log, "nonexistent").unwrap();
         assert!(result.is_none());
     }
 
@@ -692,7 +693,7 @@ mod tests {
             workflow_name: "test-wf".to_string(),
             workflow_file_stem: "test-wf".to_string(),
             worktree_path: "/repo".to_string(),
-            workflow_definition: minimal_workflow_for_log("test"),
+            workflow_definition: wf.clone(),
             timestamp: 1000.0,
         })
         .unwrap();
@@ -765,9 +766,7 @@ mod tests {
         })
         .unwrap();
 
-        let state = reconstruct_state_via_log(&log, "exec-1", &wf)
-            .unwrap()
-            .unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-1").unwrap().unwrap();
         assert_eq!(state.execution_id, "exec-1");
         assert_eq!(state.state, WorkflowExecutionState::Completed);
         assert_eq!(state.step_history.len(), 2);
@@ -808,7 +807,7 @@ mod tests {
             workflow_name: "test-wf".to_string(),
             workflow_file_stem: "test-wf".to_string(),
             worktree_path: "/repo".to_string(),
-            workflow_definition: minimal_workflow_for_log("test"),
+            workflow_definition: wf.clone(),
             timestamp: 2000.0,
         })
         .unwrap();
@@ -836,9 +835,7 @@ mod tests {
         })
         .unwrap();
 
-        let state = reconstruct_state_via_log(&log, "exec-2", &wf)
-            .unwrap()
-            .unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-2").unwrap().unwrap();
         assert_eq!(
             state.state,
             WorkflowExecutionState::Failed {
@@ -847,6 +844,8 @@ mod tests {
         );
         assert_eq!(state.step_states["plan"], "failed");
         assert_eq!(state.step_states["implement"], "pending");
+        // make_test_workflow() の nodes が snapshot 経由で復元されていること
+        assert_eq!(state.total_steps, wf.nodes.len());
     }
 
     /// 並列ブロックを含むワークフローのNDJSON復元テスト。
@@ -893,7 +892,7 @@ mod tests {
                 workflow_name: "parallel-wf".to_string(),
                 workflow_file_stem: "parallel-wf".to_string(),
                 worktree_path: "/repo".to_string(),
-                workflow_definition: minimal_workflow_for_log("test"),
+                workflow_definition: wf.clone(),
                 timestamp: 1000.0,
             },
             WorkflowEvent::NodeStarted {
@@ -1009,9 +1008,7 @@ mod tests {
             log.append(event).unwrap();
         }
 
-        let state = reconstruct_state_via_log(&log, "exec-p", &wf)
-            .unwrap()
-            .unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-p").unwrap().unwrap();
 
         assert_eq!(
             state.step_history.len(),
@@ -1045,7 +1042,7 @@ mod tests {
             workflow_name: "test-wf".to_string(),
             workflow_file_stem: "test-wf".to_string(),
             worktree_path: "/repo".to_string(),
-            workflow_definition: minimal_workflow_for_log("test"),
+            workflow_definition: wf.clone(),
             timestamp: 1000.0,
         })
         .unwrap();
@@ -1073,9 +1070,7 @@ mod tests {
         })
         .unwrap();
 
-        let state = reconstruct_state_via_log(&log, "exec-r", &wf)
-            .unwrap()
-            .unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-r").unwrap().unwrap();
 
         assert_eq!(state.step_history.len(), 1);
         assert_eq!(state.step_history[0].step_name, "review");
@@ -1100,7 +1095,7 @@ mod tests {
             workflow_name: "test-wf".to_string(),
             workflow_file_stem: "test-wf".to_string(),
             worktree_path: "/repo".to_string(),
-            workflow_definition: minimal_workflow_for_log("test"),
+            workflow_definition: wf.clone(),
             timestamp: 1000.0,
         })
         .unwrap();
@@ -1120,9 +1115,7 @@ mod tests {
         })
         .unwrap();
 
-        let state = reconstruct_state_via_log(&log, "exec-ap", &wf)
-            .unwrap()
-            .unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-ap").unwrap().unwrap();
         assert_eq!(state.state, WorkflowExecutionState::WaitingApproval);
         assert_eq!(state.current_step_name, "review");
         // workflow.nodes は plan/implement/review の順なので review の index は 2。
@@ -1166,7 +1159,7 @@ mod tests {
             workflow_name: "approval-then-next".to_string(),
             workflow_file_stem: "approval-then-next".to_string(),
             worktree_path: "/repo".to_string(),
-            workflow_definition: minimal_workflow_for_log("test"),
+            workflow_definition: wf.clone(),
             timestamp: 2000.0,
         })
         .unwrap();
@@ -1215,9 +1208,7 @@ mod tests {
         })
         .unwrap();
 
-        let state = reconstruct_state_via_log(&log, "exec-an", &wf)
-            .unwrap()
-            .unwrap();
+        let state = reconstruct_state_via_log(&log, "exec-an").unwrap().unwrap();
         assert_eq!(
             state.state,
             WorkflowExecutionState::Running,

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -1,10 +1,15 @@
 pub mod builtin;
+pub mod command;
 pub mod commands;
 pub mod contract;
 pub mod diagnostics;
 pub mod engine;
+pub mod event;
+pub(crate) mod event_projection;
 pub mod facet;
 pub mod log;
+pub(crate) mod resolver;
+pub(crate) mod resolver_adapters;
 pub mod run;
 pub mod runtime_view;
 pub mod schema;

--- a/src-tauri/src/workflow/resolver.rs
+++ b/src-tauri/src/workflow/resolver.rs
@@ -1,0 +1,44 @@
+use crate::workflow::schema::Workflow;
+
+#[derive(Debug)]
+pub(crate) enum WorkflowDefinitionResolverError {
+    InvalidWorkflow(String),
+    Infrastructure(String),
+}
+
+impl std::fmt::Display for WorkflowDefinitionResolverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidWorkflow(message) | Self::Infrastructure(message) => {
+                write!(f, "{message}")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ManagedWorktreeResolverError {
+    Validation(String),
+}
+
+impl std::fmt::Display for ManagedWorktreeResolverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Validation(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+/// WorkflowEngine core が workflow 定義の保存形式や builtin 解決方法を知らずに済むよう、
+/// YAML / builtin / facet 解決を担う境界。
+#[async_trait::async_trait]
+pub(crate) trait WorkflowDefinitionResolver: Send + Sync {
+    async fn resolve(&self, file_stem: &str) -> Result<Workflow, WorkflowDefinitionResolverError>;
+}
+
+/// WorkflowEngine core が AppConfig / filesystem canonicalize / Git worktree 列挙を
+/// 直接知らずに済むよう、managed worktree 解決を担う境界。
+#[async_trait::async_trait]
+pub(crate) trait ManagedWorktreeResolver: Send + Sync {
+    async fn resolve(&self, worktree_path: String) -> Result<String, ManagedWorktreeResolverError>;
+}

--- a/src-tauri/src/workflow/resolver_adapters.rs
+++ b/src-tauri/src/workflow/resolver_adapters.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use crate::config::AppConfig;
+use crate::workflow::resolver::{
+    ManagedWorktreeResolver, ManagedWorktreeResolverError, WorkflowDefinitionResolver,
+    WorkflowDefinitionResolverError,
+};
+use crate::workflow::schema::Workflow;
+
+pub(crate) struct DefaultWorkflowDefinitionResolver;
+
+#[async_trait::async_trait]
+impl WorkflowDefinitionResolver for DefaultWorkflowDefinitionResolver {
+    async fn resolve(&self, file_stem: &str) -> Result<Workflow, WorkflowDefinitionResolverError> {
+        let load_stem = file_stem.to_string();
+        tokio::task::spawn_blocking(move || {
+            let dir = crate::workflow::storage::workflows_dir();
+            let facets_base = crate::workflow::facet::facets_base_dir();
+            let file_path = dir.join(format!("{load_stem}.yml"));
+            if file_path.exists() {
+                crate::workflow::storage::load_workflow(&file_path, &facets_base)
+                    .map_err(|e| WorkflowDefinitionResolverError::InvalidWorkflow(e.to_string()))
+            } else {
+                crate::workflow::builtin::load_builtin_workflow_resolved(&load_stem)
+                    .map_err(|e| WorkflowDefinitionResolverError::InvalidWorkflow(e.to_string()))?
+                    .ok_or_else(|| {
+                        WorkflowDefinitionResolverError::InvalidWorkflow(format!(
+                            "ワークフロー '{load_stem}' が見つかりません"
+                        ))
+                    })
+            }
+        })
+        .await
+        .map_err(|e| {
+            WorkflowDefinitionResolverError::Infrastructure(format!("task join error: {e}"))
+        })?
+    }
+}
+
+pub(crate) struct AppConfigManagedWorktreeResolver {
+    config: Arc<AppConfig>,
+}
+
+impl AppConfigManagedWorktreeResolver {
+    pub(crate) fn new(config: Arc<AppConfig>) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait::async_trait]
+impl ManagedWorktreeResolver for AppConfigManagedWorktreeResolver {
+    async fn resolve(&self, worktree_path: String) -> Result<String, ManagedWorktreeResolverError> {
+        crate::workflow::worktree::canonicalize_managed_worktree_path(
+            Arc::clone(&self.config),
+            worktree_path,
+        )
+        .await
+        .map_err(ManagedWorktreeResolverError::Validation)
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct PassthroughManagedWorktreeResolver;
+
+#[cfg(test)]
+#[async_trait::async_trait]
+impl ManagedWorktreeResolver for PassthroughManagedWorktreeResolver {
+    async fn resolve(&self, worktree_path: String) -> Result<String, ManagedWorktreeResolverError> {
+        Ok(worktree_path)
+    }
+}

--- a/src-tauri/src/workflow/run.rs
+++ b/src-tauri/src/workflow/run.rs
@@ -470,6 +470,64 @@ impl RunStore {
         Ok(())
     }
 
+    /// command rollback 専用: mutation 前の active snapshot を in-memory Run Store に戻す。
+    ///
+    /// 通常の `register_active` は metadata 永続化に失敗すると in-memory 挿入も取り消す。
+    /// しかし command 受理サイクルの rollback では、失敗原因が Run Store 永続化先そのものの
+    /// 障害である場合でも、少なくとも process 内の active projection は mutation 前 snapshot
+    /// に戻す必要がある。metadata persist は best-effort として試み、失敗は Err で返すが、
+    /// in-memory snapshot は保持する。
+    pub(crate) async fn restore_active_snapshot_for_rollback(
+        &self,
+        run: WorkflowRun,
+    ) -> Result<(), RunStoreError> {
+        if !is_valid_run_id(&run.run_id) {
+            return Err(RunStoreError::InvalidRunId {
+                run_id: run.run_id.clone(),
+            });
+        }
+        if run.status.is_terminal() {
+            return Err(RunStoreError::TerminalStatusInActiveSet {
+                run_id: run.run_id.clone(),
+                status: run.status,
+            });
+        }
+        let metadata_store = self.metadata_store().await?;
+        {
+            let mut inner = self.inner.lock().await;
+            if let Some(existing) = inner.active.get(&run.run_id) {
+                if existing.worktree_path != run.worktree_path {
+                    return Err(RunStoreError::RunIdWorktreeMismatch {
+                        run_id: run.run_id.clone(),
+                        existing_worktree_path: existing.worktree_path.clone(),
+                        new_worktree_path: run.worktree_path.clone(),
+                    });
+                }
+            }
+            if let Some(existing_run_id) = inner.by_worktree.get(&run.worktree_path) {
+                if existing_run_id != &run.run_id {
+                    return Err(RunStoreError::WorktreeAlreadyActive {
+                        worktree_path: run.worktree_path.clone(),
+                        existing_run_id: existing_run_id.clone(),
+                    });
+                }
+            }
+            inner
+                .by_worktree
+                .insert(run.worktree_path.clone(), run.run_id.clone());
+            inner.active.insert(run.run_id.clone(), run.clone());
+        }
+        if let Some(store) = metadata_store {
+            if let Err(e) = store.persist(run.clone()).await {
+                return Err(RunStoreError::PersistFailed {
+                    run_id: run.run_id,
+                    reason: e,
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// active run の現在 node / status / updated_at を更新する（状態遷移ではない属性更新含む）。
     /// `mutator` は in-memory の run を直接書き換える。metadata 永続化は Mutex を解放してから
     /// `spawn_blocking` 経由で行い、永続化失敗時は同一 snapshot の場合だけ rollback する。
@@ -564,6 +622,12 @@ impl RunStore {
             run.updated_at = updated_at;
         })
         .await
+    }
+
+    /// active run の現在値を rollback 用 snapshot として取得する。
+    pub async fn active_run_snapshot(&self, run_id: &str) -> Option<WorkflowRun> {
+        let inner = self.inner.lock().await;
+        inner.active.get(run_id).cloned()
     }
 
     /// active run を terminal 状態に遷移させ、active set から除外する。metadata は更新して残す。

--- a/src-tauri/src/workflow/state.rs
+++ b/src-tauri/src/workflow/state.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+pub use crate::workflow::event::TokenUsage;
 use crate::workflow::schema::Workflow;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,20 +60,6 @@ impl WorkflowExecutionState {
             Self::Failed { .. } => "failed",
             Self::Aborted => "aborted",
         }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct TokenUsage {
-    pub input_tokens: u64,
-    pub output_tokens: u64,
-}
-
-impl TokenUsage {
-    pub fn add(&mut self, other: &TokenUsage) {
-        self.input_tokens += other.input_tokens;
-        self.output_tokens += other.output_tokens;
     }
 }
 

--- a/src-tauri/src/workflow_state_events.rs
+++ b/src-tauri/src/workflow_state_events.rs
@@ -84,8 +84,8 @@ pub(crate) async fn build_workflow_state_view(
     )
 }
 
-pub(crate) async fn emit_workflow_state(
-    app: &tauri::AppHandle,
+pub(crate) async fn emit_workflow_state<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     worktree_path: &str,
     state: crate::workflow::state::WorkflowState,
     handles: &Arc<Mutex<AgentProcessMap>>,
@@ -97,8 +97,8 @@ pub(crate) async fn emit_workflow_state(
     }
 }
 
-pub(crate) async fn emit_workflow_step_target_state(
-    app: &tauri::AppHandle,
+pub(crate) async fn emit_workflow_step_target_state<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     engine: &crate::workflow::engine::WorkflowEngine,
     target: &crate::workflow_step_lifecycle::ResolvedWorkflowStepSession,
     handles: &Arc<Mutex<AgentProcessMap>>,
@@ -109,8 +109,8 @@ pub(crate) async fn emit_workflow_step_target_state(
     }
 }
 
-pub(crate) async fn emit_after_workflow_step_message(
-    app: &tauri::AppHandle,
+pub(crate) async fn emit_after_workflow_step_message<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     engine: &crate::workflow::engine::WorkflowEngine,
     session: &crate::session::ChatSession,
     handles: &Arc<Mutex<AgentProcessMap>>,
@@ -124,8 +124,8 @@ pub(crate) async fn emit_after_workflow_step_message(
     }
 }
 
-pub(crate) async fn emit_workflow_state_snapshot(
-    app: &tauri::AppHandle,
+pub(crate) async fn emit_workflow_state_snapshot<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     worktree_path: &str,
     workflow_state: crate::workflow::state::WorkflowState,
 ) {

--- a/src-tauri/src/workflow_step_lifecycle_adapters.rs
+++ b/src-tauri/src/workflow_step_lifecycle_adapters.rs
@@ -167,13 +167,13 @@ pub(crate) fn try_close_step_session_tab_state(
     Ok(true)
 }
 
-struct TauriWorkflowStepSessionGateway<'a> {
-    app: &'a tauri::AppHandle,
+struct TauriWorkflowStepSessionGateway<'a, R: tauri::Runtime> {
+    app: &'a tauri::AppHandle<R>,
     session_store: &'a SessionStore,
     open_tabs: &'a OpenTabRegistry,
 }
 
-impl WorkflowStepSessionGateway for TauriWorkflowStepSessionGateway<'_> {
+impl<R: tauri::Runtime> WorkflowStepSessionGateway for TauriWorkflowStepSessionGateway<'_, R> {
     fn resolve_step_session(
         &self,
         session_id: &str,
@@ -204,13 +204,13 @@ impl WorkflowStepSessionGateway for TauriWorkflowStepSessionGateway<'_> {
     }
 }
 
-struct TauriWorkflowStepRuntimeGateway<'a> {
-    app: &'a tauri::AppHandle,
+struct TauriWorkflowStepRuntimeGateway<'a, R: tauri::Runtime> {
+    app: &'a tauri::AppHandle<R>,
     handles: &'a Arc<Mutex<AgentProcessMap>>,
 }
 
 #[async_trait::async_trait]
-impl WorkflowStepRuntimeGateway for TauriWorkflowStepRuntimeGateway<'_> {
+impl<R: tauri::Runtime> WorkflowStepRuntimeGateway for TauriWorkflowStepRuntimeGateway<'_, R> {
     async fn close_idle_runtime_on_tab_close(
         &self,
         session_id: &str,
@@ -234,14 +234,14 @@ impl WorkflowStepRuntimeGateway for TauriWorkflowStepRuntimeGateway<'_> {
     }
 }
 
-pub(crate) struct TauriWorkflowStepLifecycle<'a> {
-    sessions: TauriWorkflowStepSessionGateway<'a>,
-    runtime: TauriWorkflowStepRuntimeGateway<'a>,
+pub(crate) struct TauriWorkflowStepLifecycle<'a, R: tauri::Runtime> {
+    sessions: TauriWorkflowStepSessionGateway<'a, R>,
+    runtime: TauriWorkflowStepRuntimeGateway<'a, R>,
 }
 
-impl<'a> TauriWorkflowStepLifecycle<'a> {
+impl<'a, R: tauri::Runtime> TauriWorkflowStepLifecycle<'a, R> {
     pub(crate) fn new(
-        app: &'a tauri::AppHandle,
+        app: &'a tauri::AppHandle<R>,
         session_store: &'a SessionStore,
         handles: &'a Arc<Mutex<AgentProcessMap>>,
         open_tabs: &'a OpenTabRegistry,
@@ -318,14 +318,17 @@ impl WorkflowStepSessionGateway for StoredWorkflowStepSessionGateway<'_> {
     }
 }
 
-pub(crate) fn mark_started_step_tab_open(app: &tauri::AppHandle, session_id: &str) {
+pub(crate) fn mark_started_step_tab_open<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    session_id: &str,
+) {
     if let Some(open_tabs) = app.try_state::<Arc<OpenTabRegistry>>() {
         open_tabs.add(session_id);
     }
 }
 
-pub(crate) async fn release_step_runtime_on_done(
-    app: &tauri::AppHandle,
+pub(crate) async fn release_step_runtime_on_done<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     session_store: &Arc<SessionStore>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     open_tabs: Option<&OpenTabRegistry>,

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
@@ -403,7 +403,7 @@ describe("WorkflowPanel", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Approve step" }));
 		expect(mockInvoke).toHaveBeenCalledWith("approve_workflow_step", {
 			runId: "exec-001",
-			decision: "approve",
+			decision: { approve: {} },
 			stepName: "step-1",
 		});
 	});
@@ -495,7 +495,7 @@ describe("WorkflowPanel", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Submit reject" }));
 		expect(mockInvoke).toHaveBeenCalledWith("approve_workflow_step", {
 			runId: "exec-001",
-			decision: { reject: { comment: "Please fix the bug" } },
+			decision: { reject: { reason: "Please fix the bug" } },
 			stepName: "review",
 		});
 		await waitFor(() => {

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
@@ -10,7 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useWorkflowConfig } from "@/hooks/useWorkflowConfig";
 import type { PermissionMode } from "@/types/session";
 import type {
-	WorkflowLogEvent,
+	WorkflowEvent,
 	WorkflowRunSummary,
 	WorkflowState,
 } from "@/types/workflow";
@@ -375,7 +375,7 @@ function ExecutionView({
 	onCloseSession?: (sessionId: string) => void;
 }) {
 	const [historyState, setHistoryState] = useState<WorkflowState | null>(null);
-	const [events, setEvents] = useState<WorkflowLogEvent[]>([]);
+	const [events, setEvents] = useState<WorkflowEvent[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -390,7 +390,7 @@ function ExecutionView({
 			invoke<WorkflowState | null>("get_workflow_execution_state", {
 				runId: executionId,
 			}),
-			invoke<WorkflowLogEvent[]>("get_workflow_execution_log", {
+			invoke<WorkflowEvent[]>("get_workflow_execution_log", {
 				runId: executionId,
 			}),
 		])

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.test.tsx
@@ -191,7 +191,7 @@ describe("WorkflowTrace", () => {
 
 		expect(mockInvoke).toHaveBeenCalledWith("approve_workflow_step", {
 			runId: "exec-001",
-			decision: "approve",
+			decision: { approve: {} },
 			stepName: "review",
 		});
 
@@ -624,17 +624,24 @@ describe("WorkflowTrace", () => {
 				workflowState={makeWorkflowState()}
 				events={[
 					{
-						event: "workflow_started",
-						execution_id: "exec-001",
+						event: "run_started",
+						run_id: "exec-001",
 						workflow_name: "test-workflow",
+						workflow_file_stem: "test-workflow",
 						worktree_path: "/repo",
+						workflow_definition: {
+							name: "test-workflow",
+							description: "",
+							builtin: false,
+							nodes: [],
+						},
 						timestamp: 1000,
 					},
 					{
-						event: "step_started",
-						execution_id: "exec-001",
+						event: "node_started",
+						run_id: "exec-001",
 						workflow_name: "test-workflow",
-						step_name: "plan",
+						node_name: "plan",
 						execution_count: 1,
 						timestamp: 1001,
 					},
@@ -642,8 +649,8 @@ describe("WorkflowTrace", () => {
 			/>,
 		);
 		expect(screen.getByText("Event log")).toBeInTheDocument();
-		expect(screen.getByText("workflow_started")).toBeInTheDocument();
-		expect(screen.getByText("step_started")).toBeInTheDocument();
+		expect(screen.getByText("run_started")).toBeInTheDocument();
+		expect(screen.getByText("node_started")).toBeInTheDocument();
 		expect(screen.getByText("(plan)")).toBeInTheDocument();
 	});
 
@@ -969,27 +976,27 @@ describe("WorkflowTrace", () => {
 				workflowState={makeWorkflowState()}
 				events={[
 					{
-						event: "step_started",
-						execution_id: "exec-001",
+						event: "node_started",
+						run_id: "exec-001",
 						workflow_name: "test-workflow",
-						step_name: "plan",
+						node_name: "plan",
 						execution_count: 1,
 						timestamp: 1001,
 					},
 					{
 						event: "contract_repair_requested",
-						execution_id: "exec-001",
+						run_id: "exec-001",
 						workflow_name: "test-workflow",
-						step_name: "plan",
+						node_name: "plan",
 						attempt: 1,
 						violation_reason: "missing verdict field",
 						timestamp: 1002,
 					},
 					{
 						event: "contract_repair_requested",
-						execution_id: "exec-001",
+						run_id: "exec-001",
 						workflow_name: "test-workflow",
-						step_name: "plan",
+						node_name: "plan",
 						attempt: 2,
 						violation_reason: "invalid format",
 						timestamp: 1003,

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowTrace.tsx
@@ -20,14 +20,14 @@ import type {
 	NodeDefinition,
 	ParallelStepState,
 	StepHistoryEntry,
-	WorkflowLogEvent,
+	WorkflowEvent,
 	WorkflowState,
 } from "@/types/workflow";
 import { workflowStateClasses } from "./workflowStateStyles";
 
 interface WorkflowTraceProps {
 	workflowState: WorkflowState;
-	events?: WorkflowLogEvent[];
+	events?: WorkflowEvent[];
 	/** tab が閉じている step session を開く / 既に開いていればフォーカスする */
 	onSessionClick?: (sessionId: string) => void;
 	/** tab が開いている step session を閉じる */
@@ -105,7 +105,7 @@ function readScrollMetrics(element: HTMLElement): ScrollMetrics {
 
 function buildAutoFollowVersion(
 	workflowState: WorkflowState,
-	events: WorkflowLogEvent[],
+	events: WorkflowEvent[],
 ) {
 	const activeParallelVersion =
 		workflowState.activeParallelSteps
@@ -848,32 +848,30 @@ function VerdictBadge({ verdict }: { verdict: string }) {
 	);
 }
 
-function EventTrace({ events }: { events: WorkflowLogEvent[] }) {
+function EventTrace({ events }: { events: WorkflowEvent[] }) {
 	return (
 		<div className="rounded-md border">
 			<div className="border-b px-3 py-1.5 text-xs font-medium text-muted-foreground">
 				Event log
 			</div>
 			<div className="max-h-32 overflow-auto px-3 py-1">
-				{events.map((event) => (
-					<div
-						key={`${event.event}-${"step_name" in event ? event.step_name : ""}-${event.timestamp}`}
-						className="py-0.5 text-xs text-muted-foreground"
-					>
-						<span className="font-mono">{event.event}</span>
-						{"step_name" in event && event.step_name && (
-							<span className="ml-1">({event.step_name})</span>
-						)}
-						{event.event === "contract_repair_requested" &&
-							"attempt" in event && (
+				{events.map((event) => {
+					const nodeName = "node_name" in event ? event.node_name : undefined;
+					return (
+						<div
+							key={`${event.event}-${nodeName ?? ""}-${event.timestamp}`}
+							className="py-0.5 text-xs text-muted-foreground"
+						>
+							<span className="font-mono">{event.event}</span>
+							{nodeName && <span className="ml-1">({nodeName})</span>}
+							{event.event === "contract_repair_requested" && (
 								<span className="ml-1 text-yellow-600 dark:text-yellow-400">
-									retry #{event.attempt as number}
-									{"violation_reason" in event &&
-										`: ${event.violation_reason as string}`}
+									retry #{event.attempt}: {event.violation_reason}
 								</span>
 							)}
-					</div>
-				))}
+						</div>
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/src/hooks/useStepApprovalAction.ts
+++ b/src/hooks/useStepApprovalAction.ts
@@ -28,7 +28,10 @@ export function useStepApprovalAction({
 	const approve = useCallback(() => {
 		return invoke("approve_workflow_step", {
 			runId: executionId,
-			decision: "approve",
+			// [04] Command / Event Boundary（issues-1013）: ApprovalDecision::Approve は
+			// comment を内包する struct variant となり、wire 形式は
+			// `{ approve: { comment: null } }` 等。旧 unit variant `"approve"` は破棄済み。
+			decision: { approve: {} },
 			stepName,
 		})
 			.then(() => setApprovalError(null))
@@ -56,7 +59,7 @@ export function useStepApprovalAction({
 		}
 		return invoke("approve_workflow_step", {
 			runId: executionId,
-			decision: { reject: { comment: rejectComment } },
+			decision: { reject: { reason: rejectComment } },
 			stepName,
 		})
 			.then(() => {

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -201,29 +201,35 @@ export interface WorkflowStatePayload {
 	workflowState: WorkflowState;
 }
 
-export type WorkflowLogEvent =
+/// [04] Command / Event Boundary: backend `WorkflowEvent` の TypeScript 表現。
+///
+/// NDJSON tag は snake_case（`run_started` / `node_started` 等）。`run_id` を主語とし、
+/// node 識別子は `node_name` で表す（旧 `execution_id` / `step_name` から完全置換）。
+/// 表示用フォーマット以外のロジックはここに追加しない（rust-first-logic 準拠）。
+export type WorkflowEvent =
 	| {
-			event: "workflow_started";
-			execution_id: string;
+			event: "run_started";
+			run_id: string;
 			workflow_name: string;
-			workflow_file_stem?: string;
+			workflow_file_stem: string;
 			worktree_path: string;
+			workflow_definition: Workflow;
 			timestamp: number;
 	  }
 	| {
-			event: "step_started";
-			execution_id: string;
+			event: "node_started";
+			run_id: string;
 			workflow_name: string;
-			step_name: string;
+			node_name: string;
 			execution_count: number;
 			timestamp: number;
 	  }
 	| {
-			event: "step_completed";
-			execution_id: string;
+			event: "node_completed";
+			run_id: string;
 			workflow_name: string;
-			step_name: string;
-			result: string | null;
+			node_name: string;
+			result?: string;
 			session_id?: string;
 			token_usage?: TokenUsage;
 			structured_output?: JsonValue;
@@ -231,39 +237,55 @@ export type WorkflowLogEvent =
 			timestamp: number;
 	  }
 	| {
-			event: "step_failed";
-			execution_id: string;
+			event: "node_failed";
+			run_id: string;
 			workflow_name: string;
-			step_name: string;
+			node_name: string;
 			reason: string;
 			timestamp: number;
 	  }
 	| {
-			event: "workflow_completed";
-			execution_id: string;
+			event: "approval_requested";
+			run_id: string;
+			workflow_name: string;
+			node_name: string;
+			timestamp: number;
+	  }
+	| {
+			event: "approval_resolved";
+			run_id: string;
+			workflow_name: string;
+			node_name: string;
+			decision: "approve" | "reject" | "abort";
+			comment?: string;
+			timestamp: number;
+	  }
+	| {
+			event: "run_completed";
+			run_id: string;
 			workflow_name: string;
 			total_token_usage: TokenUsage;
 			timestamp: number;
 	  }
 	| {
-			event: "workflow_failed";
-			execution_id: string;
+			event: "run_failed";
+			run_id: string;
 			workflow_name: string;
 			reason: string;
 			timestamp: number;
 	  }
 	| {
-			event: "workflow_aborted";
-			execution_id: string;
+			event: "run_aborted";
+			run_id: string;
 			workflow_name: string;
 			timestamp: number;
 	  }
 	| {
 			event: "output_collected";
-			execution_id: string;
+			run_id: string;
 			workflow_name: string;
-			step_name: string;
-			step_outputs: CollectedOutputEntry[];
+			node_name: string;
+			node_outputs: CollectedOutputEntry[];
 			reduce_strategy: string;
 			reduce_result?: string;
 			reduce_structured_output?: JsonValue;
@@ -271,38 +293,38 @@ export type WorkflowLogEvent =
 	  }
 	| {
 			event: "contract_repair_requested";
-			execution_id: string;
+			run_id: string;
 			workflow_name: string;
-			step_name: string;
+			node_name: string;
 			attempt: number;
 			violation_reason: string;
 			timestamp: number;
 	  }
 	| {
 			event: "parallel_started";
-			execution_id: string;
+			run_id: string;
 			workflow_name: string;
-			parent_step_name: string;
-			child_step_names: string[];
+			parent_node_name: string;
+			child_node_names: string[];
 			timestamp: number;
 	  }
 	| {
-			event: "parallel_step_started";
-			execution_id: string;
+			event: "parallel_child_started";
+			run_id: string;
 			workflow_name: string;
-			parent_step_name: string;
-			child_step_name: string;
+			parent_node_name: string;
+			child_node_name: string;
 			session_id: string;
 			execution_count: number;
 			timestamp: number;
 	  }
 	| {
-			event: "parallel_step_completed";
-			execution_id: string;
+			event: "parallel_child_completed";
+			run_id: string;
 			workflow_name: string;
-			parent_step_name: string;
-			child_step_name: string;
-			result: string | null;
+			parent_node_name: string;
+			child_node_name: string;
+			result?: string;
 			session_id: string;
 			token_usage?: TokenUsage;
 			structured_output?: JsonValue;
@@ -311,15 +333,15 @@ export type WorkflowLogEvent =
 	  }
 	| {
 			event: "parallel_completed";
-			execution_id: string;
+			run_id: string;
 			workflow_name: string;
-			parent_step_name: string;
+			parent_node_name: string;
 			aggregate_result: string;
 			timestamp: number;
 	  };
 
 export interface CollectedOutputEntry {
-	stepName: string;
+	nodeName: string;
 	result?: string;
 	structuredOutput?: JsonValue;
 }


### PR DESCRIPTION
## Summary

- workflow engine への入口を `WorkflowCommand`（`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode`）に集約し、engine が発行する事実列を typed `WorkflowEvent` 語彙に統一
- Tauri command（`start_workflow` / `abort_workflow` / `approve_workflow_step`）は `WorkflowCommand` を組み立てて `dispatch` する薄い adapter に置換。後方互換 wrapper は導入せず wire 形式を破壊的に変更
- 旧 `WorkflowLogEvent` 列挙体・旧 NDJSON 在庫は完全廃止。`workflow/log.rs` は `WorkflowEvent` NDJSON 書き込み機構に縮退し、projection は `workflow/event_projection.rs` に分離
- command 受理サイクル内で event append / 永続化が失敗した場合、`WorkflowExecution` 全体を mutation 直前の snapshot で一括復元（部分復元は禁止）。Run Store・ChatSession も同期 rollback
- 全 4 command の handler / event 発行 / 認可・冪等性・stale target 拒否 / rollback について production `WorkflowEngine::dispatch` を `tauri::test` の実 `AppHandle` で直接叩く harness テストを整備（shadow dispatcher 禁止）

Closes #1013

## 主な変更ファイル

| ファイル | 役割 |
|----------|------|
| `src-tauri/src/workflow/command.rs`（新規） | `WorkflowCommand` / `WorkflowCommandResult` の typed 入口型 |
| `src-tauri/src/workflow/event.rs`（新規） | `WorkflowEvent` 新語彙（append-only 事実列） |
| `src-tauri/src/workflow/event_projection.rs`（新規） | event 列 → `WorkflowState` 再構築 projection |
| `src-tauri/src/workflow/resolver.rs` / `resolver_adapters.rs`（新規） | workflow / worktree 解決の DI 分離 |
| `src-tauri/src/workflow/engine.rs` | `dispatch` 単一入口・snapshot rollback owner |
| `src-tauri/src/workflow/commands.rs` | Tauri adapter（薄い変換層）・`ApprovalDecisionInput` DTO |
| `src-tauri/src/workflow/log.rs` | NDJSON append/read 専任・`append_batch` atomic 化 |
| `src-tauri/src/workflow/run.rs` | `restore_active_snapshot_for_rollback` 追加 |
| `src/types/workflow.ts` / `useStepApprovalAction.ts` / `WorkflowPanel*.tsx` / `WorkflowTrace*.tsx` | 新 wire 形式・新語彙への追従 |

## スコープ外（後続マイルストーン）

- read-only run APIs / CLI（[05]）
- `WorkflowCommand::CompleteNode` / `FailNode` の typed 化（[05]）
- mutating CLI（[06]）
- Workflow Panel / Command Center UI 実装（[07]）
- structured output 提出 `SubmitOutput`（[08]）
- bash node 実行系統（[13]）
- main-agent narrator への typed event 配信（[16]）

## Test plan

- [ ] `cd src-tauri && cargo fmt --check`
- [ ] `cd src-tauri && cargo clippy -- -D warnings`
- [ ] `cd src-tauri && cargo test`
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] 起動 → workflow 起動 / 承認 / 却下 / 中断 の手動確認
- [ ] approve / reject コメントが event log で redaction されることを確認
- [ ] event append 失敗時に WorkflowExecution / Run Store / ChatSession が rollback されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced typed workflow command interface for state transitions (Start, Abort, Approve, Reject)
  * Implemented append-only event log system with structured event types for workflow execution tracing

* **Refactor**
  * Replaced legacy event model with new strongly-typed event vocabulary across logs and APIs
  * Unified workflow event persistence using NDJSON format
  * Enhanced type safety with generic runtime parameters

* **Documentation**
  * Updated workflow engine specification with command/event boundaries and mutation rollback principles
  * Clarified milestone roadmap for event model migration and API boundaries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/1014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->