### PR TITLE
feat: workflow run の read-only 観測経路 (API + CLI) と engine 内部 typed command 化 (#1015)

### DIFF
--- a/docs/spec/issues-1015.md
+++ b/docs/spec/issues-1015.md
@@ -1,0 +1,204 @@
+# issues-1015: Workflow Engine Evolution - Read-Only Run APIs + CLI
+
+関連: [GitHub Issue #1015](https://github.com/siro33950/releash/issues/1015) / マイルストーン [05] / [`workflow-engine-evolution-plan.md`](../workflow-engine-evolution-plan.md) / [`workflow-engine-model-boundary.md`](../workflow-engine-model-boundary.md) / 先行 [issues-1011](./issues-1011.md) / [issues-1013](./issues-1013.md)
+
+## 要求
+
+**種別**: 新機能
+
+**ゴール**: 外部 caller（UI / Remote / Agent / 人間オペレータ）が `run_id` を主語として workflow run を観測でき、engine 内部の node 完了 / 失敗遷移も typed command として揃った状態を作る。具体的には以下が満たされること。
+
+- 外部 caller が workflow template の一覧と過去 / 進行中の workflow run を `run_id` 主語で観測できる read-only な API 入口（Tauri / local API command）が成立している。
+  - workflow template の一覧を取得できる（`list_workflows`）。
+  - 過去および進行中の workflow run の一覧を取得できる（`list_workflow_runs`）。
+  - 単一の run の summary metadata を取得できる（`get_workflow_run`）。
+  - 単一の run の event log を取得できる（`get_workflow_run_log`）。
+  - 単一の run の現在 state を取得できる（`get_workflow_run_state`）。
+- 上記 API と等価な観測手段を CLI からも実行できる。
+  - `releash workflow list` — 利用可能な workflow template の一覧。
+  - `releash workflow runs` — 過去 / 進行中の run の一覧。
+  - `releash workflow status <run-id>` — 指定 run の現在 state。
+  - `releash workflow logs <run-id>` — 指定 run の event log。
+- engine 内部の node 完了 / 失敗遷移が typed command（`WorkflowCommand::CompleteNode` / `FailNode`）経由で行われる。
+  - これらは外部入口（UI / CLI / Agent）には公開せず、engine 内部の状態遷移を typed に表現するための command である。
+  - 対応する `WorkflowEvent::NodeCompleted` / `NodeFailed` の発行点が typed command の経路に集約される。
+- read-only API / CLI 経由で取得できる情報は、engine が一次 owner として保持する run metadata / event log / state の投影であり、別系統のキャッシュや再構築は行わない。
+- running workflow を `run_id` で inspect でき、completed workflow の log を `run_id` で読める。
+
+**スコープ外**: 以下は後続マイルストーンに明示的に振り分け済み。
+
+- mutating CLI（[06]）: `releash workflow run` / `approve` / `reject` / `abort` 等の CLI 入口。本 issue は read-only 観測経路と engine 内部の node 完了 / 失敗 typed 化に閉じる。
+- structured output 提出 CLI（[08]）: `WorkflowCommand::SubmitOutput` / `releash workflow output submit|validate|get`。
+- Workflow Panel / Command Center UI（[07]）: 本 issue では UI パネル新規追加は行わない。既存 UI が API を消費する経路の最小調整は許容するが、新パネル導入は対象外。
+- bash node 実行系統（[13]）: `releash workflow status` の表示対象に `bash` node が含まれても、bash 実行ランタイム自体の整備は行わない。
+- main-agent narrator への typed event 配信と user decision の CLI 戻り経路整備（[16]）。
+- engine 内部 typed command の他 variant（`SubmitOutput` 等、本 issue 対象外）の導入。
+
+**現状温存**: agent 返信テキスト解釈に基づく engine 内部の分岐ロジック（aggregate の LGTM マッチング、`<workflow_output>` 抽出など step agent 出力解釈経路）は本 issue では廃止対象としない（[issues-1013](./issues-1013.md) と同じ方針を踏襲）。
+
+**背景**: マイルストーン [04] までで workflow state を変化させる入口は `WorkflowCommand` 型に typed 化され、engine が発行する事実列は `WorkflowEvent` 語彙に集約された（[issues-1013](./issues-1013.md)）。一方、外部 caller が `run_id` を主語に workflow run を観測する手段は依然として既存 worktree-scoped Tauri command の戻り値に散在しており、CLI 入口は存在しない。また、user decision 系 4 command（`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode`）は [04] で typed 化されたが、engine 内部の node 完了 / 失敗遷移は依然として method 直接呼び出しとして表現されており、typed boundary の片側だけが欠けている状態にある。
+
+本 issue は、後続の [06] mutating CLI / [07] Workflow Panel / [16] Main Agent Mediation がいずれも「`run_id` を主語に観測でき、engine 内部の全 state 遷移が typed command 経由である」ことを前提とするため、その土台として read-only 観測経路と engine 内部 typed 化の残務を確立する。
+
+**前提**: マイルストーン [04] Command / Event Boundary 完了済み（[issues-1013](./issues-1013.md)）。`WorkflowCommand` typed 入口 4 variant（`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode`）と `WorkflowEvent` 語彙は確立済み。Run Store（[03] / [issues-1011](./issues-1011.md)）により `run_id` を一次キーとする run metadata / event log の永続化基盤は成立済み。
+
+## 関連マイルストーン上の位置
+
+- 直接の依存元: [03] Run Store / Run ID / [04] Command / Event Boundary。
+- 直接の依存先: [06] Mutating CLI / [07] Workflow Panel / [16] Main Agent Mediation。
+- 本 issue は read-only 観測経路と engine 内部 typed 化の残務に閉じ、mutating CLI / UI パネル / structured output は後続に委ねる。
+
+## 振る舞い定義
+
+```gherkin
+Feature: Workflow Run の観測と engine 内部状態遷移の typed boundary
+
+  Rule: 外部 caller は run_id を主語として workflow run を観測できる
+    Scenario: 利用可能な workflow template の一覧を観測する
+      Given workflow engine が利用可能な workflow template を保持している
+      When 外部 caller が workflow template の一覧を要求する
+      Then 利用可能な workflow template の一覧が外部 caller に伝わる
+
+    Scenario: workflow run の一覧を観測する
+      Given workflow engine が過去または進行中の workflow run を保持している
+      When 外部 caller が workflow run の一覧を要求する
+      Then 過去および進行中の workflow run の一覧が外部 caller に伝わる
+
+    Scenario: 指定 run の summary metadata を観測する
+      Given workflow engine が指定の run_id に対応する workflow run を保持している
+      When 外部 caller が当該 run の summary metadata を要求する
+      Then 当該 run の summary metadata が外部 caller に伝わる
+
+    Scenario: 指定 run の event log を観測する
+      Given workflow engine が指定の run_id に対応する workflow run を保持している
+      When 外部 caller が当該 run の event log を要求する
+      Then 当該 run の event log が外部 caller に伝わる
+
+    Scenario: 指定 run の現在 state を観測する
+      Given workflow engine が指定の run_id に対応する workflow run を保持している
+      When 外部 caller が当該 run の現在 state を要求する
+      Then 当該 run の現在 state が外部 caller に伝わる
+
+    Scenario: 進行中の run を run_id で inspect する
+      Given workflow engine 上で workflow run が進行中である
+      When 外部 caller が当該 run を run_id で inspect する
+      Then 進行中の run の現在 state が外部 caller に伝わる
+
+    Scenario: 完了済みの run の log を run_id で読む
+      Given workflow engine 上で workflow run が完了している
+      When 外部 caller が当該 run の event log を run_id で要求する
+      Then 完了済みの run の event log が外部 caller に伝わる
+
+  Rule: 観測経路は API と CLI で等価な手段を提供する
+    Scenario: API 経路と CLI 経路で同等の観測結果が得られる
+      Given workflow engine が観測対象の workflow template / run / state / event log を保持している
+      When 外部 caller が API 経路または CLI 経路を通じて同一の観測項目を要求する
+      Then いずれの経路からも同等の観測結果が外部 caller に伝わる
+
+  Rule: 観測される情報は engine が一次 owner として保持するデータと一致する
+    Scenario: read-only な観測結果は engine 保持の情報と一致する
+      Given workflow engine が run metadata / event log / state を一次 owner として保持している
+      When 外部 caller が読み取り経路を通じてこれらを観測する
+      Then 観測結果は engine が保持している run metadata / event log / state と一致する形で外部 caller に伝わる
+
+  Rule: 観測経路は権限を持つ caller のみに開かれる
+    Scenario: 権限を持たない caller は workflow run を観測できない
+      Given workflow engine が workflow template / run / state / event log を保持している
+      When 観測権限を持たない caller が API / CLI / Remote 経路で観測を要求する
+      Then 観測結果は当該 caller には伝わらない
+
+    Scenario: 権限を持つ caller は workflow run を観測できる
+      Given workflow engine が workflow template / run / state / event log を保持している
+      When 観測権限を持つ caller が API / CLI / Remote 経路で観測を要求する
+      Then 観測結果が当該 caller に伝わる
+
+  Rule: 観測対象として存在しない run_id は明示的に「該当 run なし」として扱われる
+    Scenario: 存在しない run_id を観測しようとする
+      Given workflow engine が指定された run_id に対応する workflow run を保持していない
+      When 外部 caller が当該 run_id で summary metadata / event log / 現在 state を要求する
+      Then 「該当 run なし」が外部 caller に伝わる
+
+  Rule: 外部 caller には node 完了 / 失敗を直接要求する操作が提供されない
+    Scenario: node が完了したときの状態遷移が run に反映される
+      Given workflow run の中で node が処理されている
+      When その node が完了する
+      Then node 完了が workflow run の状態に反映され、node 完了の事実が event log に記録される
+
+    Scenario: node が失敗したときの状態遷移が run に反映される
+      Given workflow run の中で node が処理されている
+      When その node が失敗する
+      Then node 失敗が workflow run の状態に反映され、node 失敗の事実が event log に記録される
+
+    Scenario: 外部 caller から node 完了 / 失敗を直接要求できない
+      Given workflow engine が node 完了 / 失敗の状態遷移を内部的に処理している
+      When 外部 caller が UI / CLI / Agent 経路を通じて利用可能な操作を観測する
+      Then 外部 caller には node 完了 / 失敗を直接要求できる操作は提供されない
+```
+
+## アーキテクチャ概要
+
+本 issue は (a) `run_id` 主語の read-only 観測経路（Tauri API / CLI）を確立すること、(b) engine 内部の node 完了 / 失敗遷移を typed command 経路に集約すること、の 2 系統を内部 boundary として確立する。observation source-of-truth は **engine が一次 owner として書き出すファイル群**（`workflow_runs/{run_id}.json` と NDJSON event log）に揃え、CLI は Archon 事例（[Archon CLI Reference](https://archon.diy/reference/cli/)）に倣い **engine と IPC せず file-direct でこれらを読む** 構成とする。in-memory active run map と persistence は state 遷移と同期する atomic mutation 境界の中で揃える（[04] 既存境界に整合）。
+
+### 責務配置
+
+- **`workflow/command.rs`（既存・拡張）**: `WorkflowCommand` enum に internal variant として `CompleteNode` / `FailNode` を追加する。外部入口（Tauri adapter / CLI / agent path）からこれら variant を組み立てる経路は提供しない。担当しない: handler 実体、CLI / Tauri adapter からの組み立て。
+- **`workflow/engine.rs`（既存・拡張）**: 既存 `WorkflowEngine::dispatch` を内部 node 完了 / 失敗の発火点とし、現状 method 直接呼び出しになっている経路を `WorkflowCommand::CompleteNode` / `FailNode` を組み立てて `dispatch` に渡す形に集約する。`WorkflowEvent::NodeCompleted` / `NodeFailed` の発行点を typed command 経路の単一経路に揃える。rollback / atomic mutation 境界は [04] 既存境界をそのまま継承する。担当しない: 発行 event vocabulary の拡張。
+- **`workflow/event.rs`（既存）**: `WorkflowEvent::NodeCompleted` / `NodeFailed` の shape は維持し、発行点が typed command 経由に変わるだけ。担当しない: 新規 variant 追加。
+- **`workflow/commands.rs`（既存・破壊的置換）**: read-only Tauri command を spec 名称へ完全置換する。既存の `list_active_workflow_runs` / `list_completed_workflow_runs` / `list_workflow_runs_for_worktree` / `get_workflow_execution_log` / `get_workflow_execution_state` は **削除** し、以下に置き換える。後方互換 wrapper は導入しない。
+  - `list_workflows` — workflow template 一覧（既存）
+  - `list_workflow_runs` — active / terminal を含む run 一覧（active/completed 分離 command を統合）
+  - `get_workflow_run` — 単一 run の summary metadata
+  - `get_workflow_run_log` — `WorkflowEvent` 列
+  - `get_workflow_run_state` — projection された run state view
+- **`workflow/run.rs` / `workflow/log.rs` / `workflow/event_projection.rs`（既存）**: 観測経路の一次 source-of-truth として保持する。Tauri command も CLI も最終的にこれらの helper を介してファイルを読む。担当しない: 別系統の index / cache の導入。
+- **CLI binary（新設）**: `releash workflow list / runs / status <run-id> / logs <run-id>` を提供する。**engine と IPC せず、`workflow_runs/` 配下と `workflows/` YAML / builtin を直接読む**。Tauri command と同じ projection helper を共有して divergence を防ぐ。担当しない: mutating 操作（[06] へ振り分け）、structured output 提出（[08]）、daemon 接続。
+- **フロントエンド（`src/`）**: spec 名称の read-only API への invoke 置換と、戻り値の表示整形のみ。run 観測ロジックを持たない。
+
+### データ/通信フロー
+
+- **template 一覧（API）**: UI → `list_workflows` → `storage::list_workflows` + builtin → `Vec<Summary>` 返却。
+- **template 一覧（CLI）**: `releash workflow list` → CLI が `workflows/` / builtin を直接読む → 同等の Summary 投影。
+- **run 一覧（API）**: UI → `list_workflow_runs` → engine 経由で in-memory active map + `workflow_runs/{run_id}.json` 走査 → `Vec<WorkflowRunSummary>`。
+- **run 一覧（CLI）**: `releash workflow runs` → CLI が `workflow_runs/` 配下を直接走査 → 同じ projection helper → 等価結果。
+- **single run summary**: 観測者 → `get_workflow_run(run_id)` → in-memory または metadata file → `WorkflowRunSummary`。
+- **run state**: 観測者 → `get_workflow_run_state(run_id)` または `releash workflow status <run-id>` → NDJSON 読込 → `event_projection::reconstruct_state_from_events` → state view。
+- **run event log**: 観測者 → `get_workflow_run_log(run_id)` または `releash workflow logs <run-id>` → NDJSON 読込 → `Vec<WorkflowEvent>`。
+- **node 完了 / 失敗（internal command）**: engine 内部 node 実行点 → `WorkflowCommand::CompleteNode { ... }` / `FailNode { ... }` を組み立て → `WorkflowEngine::dispatch` → state mutation + `WorkflowEvent::NodeCompleted` / `NodeFailed` 発行 → atomic rollback 境界は [04] 既存境界を継承。
+
+### 状態 Owner
+
+- **workflow template 集合**: `workflows/` YAML + builtin。read-only。観測経路は file-direct（Tauri / CLI ともに）。
+- **active run 集合**: Run Store の in-memory map + `workflow_runs/{run_id}.json`（state 遷移ごとに engine が同期書き込み）。CLI は file 側のみを観測対象とする。
+- **`WorkflowEvent` 列**: NDJSON ファイル（[04] 確立）。read-only API も CLI もここを唯一の log source-of-truth として扱う。
+- **run state の投影**: `event_projection.rs` の `reconstruct_state_from_events`（既存）。NDJSON からの純粋関数 projection で、別系統のキャッシュは持たない。
+- **internal node complete/fail の判断権威**: engine（既存）。typed command 経由化で発行点を集約するだけで権威は変わらない。
+
+### 境界
+
+- **read-only と mutating の分離**: 本 issue で導入する API / CLI 経路はすべて read-only。観測ルートからは engine の state mutation を起動しない。mutating CLI は [06] へ。
+- **observation source-of-truth の境界**: read-only API も CLI も「engine が一次 owner として書き出した metadata / NDJSON」のみを観測対象とする。別系統のキャッシュ / index / 再構築（並行 reconstruct パス、別 DB、別 file format）は導入しない。
+- **API / CLI の意味的等価性境界**: 同一 run_id / template に対し、API と CLI は同等の観測結果を返す。実装経路は分かれてよいが（Tauri command via engine vs. CLI による file-direct）、同じ projection helper を経由させて divergence を防ぐ。
+- **CLI の認証境界**: CLI は同一デバイス所有者の OS user 権限下で動作する前提とし、`workflow_runs/` および `workflows/` の OS ファイル権限に依拠する。CLI 用の追加認証層は導入しない。リモートセッション経由の CLI は本 issue 対象外。
+- **観測経路の認可境界**: 観測経路ごとに認可主体を分担する。Tauri API は既存 worktree-scoped Tauri 認証に依拠し、当該 worktree への操作権限を持つ UI セッションのみが観測できる。Remote 経路は既存 Remote 認可（HMAC トークン + セッション管理）の枠内に閉じ、Remote 認可を通過したセッションのみが観測できる。Agent 経路は engine 内部経路のみで外部 caller からは到達しない。CLI は前述の OS user 権限に依拠する。本 issue で新規の認可層を導入しない。
+- **観測結果の露出範囲境界**: 観測経路（API / CLI）が外部 caller に返す情報は、engine が一次 owner として既に保持している run metadata / event log / state の投影に限定する。観測経路の都合で agent 出力 / ユーザー入力 / ファイルパス / workflow 出力等の機密データを新たに収集 / 加工 / 保存することはしない。すなわち、観測経路の出力には engine 保持データを超える範囲の追加情報を含めない。
+- **CLI 入力の信頼境界**: CLI が読み取る `workflow_runs/` 配下のメタデータ / NDJSON と `workflows/` の YAML / builtin template は engine-owned かつ同一デバイス内の信頼済み入力として扱う（書き手は engine 自身 / リポジトリ管理者）。一方、CLI が caller から受け取る `run-id` 引数およびサブコマンド引数のみを外部入力として扱い、書式バリデーション / 存在確認を経た上で projection helper に渡す。
+- **CLI 起動独立性境界**: CLI はデスクトップアプリ非稼働でも動作する（file-direct）。アプリ稼働中の in-memory 瞬時状態は次回同期書き込みまで CLI には可視化されないが、state 遷移と同期書き込みは [04] の atomic mutation 境界の中で揃っているため、観測可能な遅延は dispatch サイクル単位に閉じる。
+- **internal command の非公開境界**: `WorkflowCommand::CompleteNode` / `FailNode` の組み立て経路は Tauri adapter / CLI / agent path に置かない（コードレビュー / モジュール配置 / pub(crate) で担保）。外部から `dispatch` に到達する経路で internal variant が現れた場合は内部不整合として `Err` に変換する（[04] adapter 境界に整合）。
+- **観測値の整合性境界**: in-memory map と metadata file の同期書き込みが完了するまでの間、API（in-memory 優先）と CLI（file 経由）の観測結果が極短時間 divergence しうる。state 遷移と同期書き込みは [04] の atomic mutation 境界の中で揃え、divergence は dispatch サイクル単位に閉じる。
+- **既存命名の破壊的置換境界**: `list_active_workflow_runs` / `list_completed_workflow_runs` / `list_workflow_runs_for_worktree` / `get_workflow_execution_log` / `get_workflow_execution_state` は本 issue で削除する。フロント側 invoke 呼び出しも spec 名称に揃える。後方互換 wrapper は導入しない。
+- **scope の境界**: 本 issue は read-only API / CLI と `CompleteNode` / `FailNode` internal typed 化に閉じる。mutating CLI（[06]）/ Workflow Panel UI（[07]）/ structured output 提出 CLI（[08]）/ bash node ランタイム（[13]）/ main-agent narrator（[16]）は対象外。
+
+### 実装に委ねること
+
+- CLI binary の Cargo パッケージ配置（`src-tauri/src/bin/releash.rs` か、別 crate か、`releash_lib` を流用するか）。
+- CLI が file-direct で利用する projection helper の共有形（既存 `event_projection.rs` を crate 内に公開して共用するか、CLI 用 module を切り出すか）。
+- `list_workflow_runs` における active / terminal の区別表現（filter 引数か、`status` field で見せるか、別 endpoint か）。
+- `get_workflow_run` の戻り値 shape（`WorkflowRunSummary` のみか、追加で `current_node` / `last_event_at` 等を含めるか）。
+- run state の `WorkflowStateView` を CLI 上で整形する責務の所在（[`rust-first-logic`](../../.claude/rules/rust-first-logic.md) に従い Rust 側 presenter）。
+- 既存 read-only Tauri command 5 件削除に伴うフロント側追従の具体的な置換箇所（`hooks/` の名称、`components/` の invoke 呼び出し）。
+- `WorkflowCommand::CompleteNode` / `FailNode` の variant フィールド shape（`WorkflowEvent::NodeCompleted` / `NodeFailed` のフィールドと揃えるか、handler 内で event を組み立てるための最小集合に絞るか）。
+- internal command 経由化に伴う既存 method（node 完了 / 失敗の現状直接呼び出し点）の置換粒度。
+- CLI のサブコマンドパース実装（clap などの選定）と出力フォーマット（plain / `--json` フラグ）。
+- file-direct 読み出し時の lock / 同時アクセスポリシー（read 専用なので OS の atomic write を信頼するか、advisory lock を入れるか）。
+- テスト配置: read-only API は既存 Tauri command テストハーネス、CLI は tempdir 上に `workflow_runs/` 構造を作って integration テスト、internal `CompleteNode` / `FailNode` は engine `dispatch` テストハーネスで検証。
+

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,7 @@ bytes = "1"
 flate2 = "1"
 tar = "0.4"
 url = "2"
+clap = { version = "4", features = ["derive"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1,0 +1,1084 @@
+//! [05] `releash workflow ...` CLI 入口。
+//!
+//! engine と IPC せず、`workflow_runs/` 配下と `workflows/` YAML / builtin を file-direct
+//! で読む（spec [05] アーキテクチャ概要: Archon 事例に倣う file-direct 構成）。
+//! 同じ projection helper（`event_projection::reconstruct_state_from_events`）を Tauri
+//! command と共有することで API / CLI の意味的等価性境界を担保する。
+//!
+//! 本モジュールは read-only 観測経路に閉じ、state mutation を起動する経路は持たない
+//! （mutating CLI は [06] / structured output 提出 CLI は [08] へ振り分け済み）。
+
+use std::path::{Path, PathBuf};
+
+use clap::{Parser, Subcommand};
+
+use crate::config::read_config_if_exists;
+use crate::protocol::WorkflowStateView;
+use crate::workflow::event::WorkflowEvent;
+use crate::workflow::event_projection::reconstruct_state_from_events;
+use crate::workflow::log::WorkflowEventLog;
+use crate::workflow::run::{
+    iter_valid_run_metadata, project_runs_to_summaries, running_workflow_names_from_metadata,
+    RunListFilter, RunStatusFilter, WorkflowRunSummary,
+};
+use crate::workflow::storage;
+use crate::workflow::worktree::canonicalize_managed_worktree_path_inner;
+use crate::workflow_state_presenter::workflow_state_to_view;
+
+/// `releash` CLI のトップ args。
+///
+/// clap AST は外部公開せず、エントリーポイントは `cli::run()` に限定する
+/// （spec [05] scope の境界 + 内部 AST の非公開境界）。
+#[derive(Parser, Debug)]
+#[command(name = "releash", disable_help_subcommand = true)]
+struct Cli {
+    #[command(subcommand)]
+    command: TopCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum TopCommand {
+    /// workflow 観測サブコマンド。
+    Workflow {
+        #[command(subcommand)]
+        command: WorkflowSubcommand,
+    },
+}
+
+/// CLI の workflow サブコマンド集合。
+///
+/// engine domain の `workflow::command::WorkflowCommand`（state mutating typed
+/// command）と語彙衝突しないよう CLI 側は `WorkflowSubcommand` として分離する
+/// （spec [05] read-only と mutating の分離 / observation source-of-truth の境界）。
+#[derive(Subcommand, Debug)]
+enum WorkflowSubcommand {
+    /// 利用可能な workflow template 一覧を表示する。
+    List {
+        #[arg(long)]
+        json: bool,
+    },
+    /// 過去 / 進行中の workflow run 一覧を表示する。
+    Runs {
+        /// status filter: `active` または `terminal`。省略時は両方。
+        #[arg(long)]
+        status: Option<String>,
+        /// worktree_path filter。
+        #[arg(long)]
+        worktree: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// 指定 run の現在 state を表示する。
+    Status {
+        run_id: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// 指定 run の event log を表示する。
+    Logs {
+        run_id: String,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// CLI のエントリーポイント。`std::process::exit` 用の終了コードを返す。
+pub fn run() -> i32 {
+    let cli = match Cli::try_parse() {
+        Ok(c) => c,
+        Err(e) => {
+            // clap の help / version は exit_code() でハンドリング。
+            e.print().ok();
+            return e.exit_code();
+        }
+    };
+    let workflows_dir = storage::workflows_dir();
+    // data_dir は List / Runs / Status / Logs それぞれの branch 内で解決する。
+    // List も workflow_runs/ 由来の `is_running` 反映のため data_dir を必要とするが、
+    // 各 branch 内で解決することで未到達の branch では I/O を走らせない。
+    let resolve = || -> Result<PathBuf, CliError> { resolve_data_dir().map_err(CliError::Other) };
+    let result = match cli.command {
+        TopCommand::Workflow { command } => match command {
+            WorkflowSubcommand::List { json } => match resolve() {
+                Ok(data_dir) => cmd_list(&workflows_dir, &data_dir, json),
+                Err(e) => Err(e),
+            },
+            WorkflowSubcommand::Runs {
+                status,
+                worktree,
+                json,
+            } => match resolve() {
+                Ok(data_dir) => cmd_runs(&data_dir, status, worktree, json),
+                Err(e) => Err(e),
+            },
+            WorkflowSubcommand::Status { run_id, json } => match resolve() {
+                Ok(data_dir) => cmd_status(&data_dir, &run_id, json),
+                Err(e) => Err(e),
+            },
+            WorkflowSubcommand::Logs { run_id, json } => match resolve() {
+                Ok(data_dir) => cmd_logs(&data_dir, &run_id, json),
+                Err(e) => Err(e),
+            },
+        },
+    };
+    match result {
+        Ok(()) => 0,
+        Err(CliError::NotFound(msg)) => {
+            eprintln!("{msg}");
+            4
+        }
+        Err(CliError::InvalidInput(msg)) => {
+            eprintln!("error: {msg}");
+            2
+        }
+        Err(CliError::Other(msg)) => {
+            eprintln!("error: {msg}");
+            1
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CliError {
+    /// run / template が見つからない（spec Rule: 存在しない run_id は明示的に「該当 run なし」）。
+    NotFound(String),
+    /// 入力フォーマット不正（不正な run_id、不正な status filter 値など）。
+    InvalidInput(String),
+    /// その他の I/O / serialization エラー。
+    Other(String),
+}
+
+impl From<String> for CliError {
+    fn from(msg: String) -> Self {
+        CliError::Other(msg)
+    }
+}
+
+/// データディレクトリの解決。
+///
+/// Tauri 側 `AppHandle::path().app_data_dir()` と同等のパスを CLI 側で計算する。
+/// CLI 起動独立性境界: デスクトップアプリ非稼働でも動作する。
+fn resolve_data_dir() -> Result<PathBuf, String> {
+    if let Ok(custom) = std::env::var("RELEASH_DATA_DIR") {
+        return Ok(PathBuf::from(custom));
+    }
+    let base = dirs::data_dir().ok_or_else(|| "Cannot resolve OS data_dir".to_string())?;
+    Ok(base.join("com.releash.app"))
+}
+
+/// workflow template 一覧。
+///
+/// `is_running` は `workflow_runs/` 配下の active metadata から導出した
+/// workflow_name set を反映する（spec [05] Rule: 観測経路は API と CLI で
+/// 等価な手段を提供する）。
+fn cmd_list(workflows_dir: &Path, data_dir: &Path, json: bool) -> Result<(), CliError> {
+    let summaries = list_workflows_file_direct(workflows_dir, data_dir)?;
+    if json {
+        let text = serde_json::to_string_pretty(&summaries)
+            .map_err(|e| format!("serialize workflows: {e}"))?;
+        println!("{text}");
+    } else {
+        if summaries.is_empty() {
+            println!("(no workflows)");
+            return Ok(());
+        }
+        for s in &summaries {
+            let tag = if s.builtin { "[builtin]" } else { "         " };
+            let running_marker = if s.is_running { " (running)" } else { "" };
+            println!("{tag} {:<32}  {}{running_marker}", s.name, s.description);
+        }
+    }
+    Ok(())
+}
+
+/// workflow run 一覧。
+fn cmd_runs(
+    data_dir: &Path,
+    status: Option<String>,
+    worktree: Option<String>,
+    json: bool,
+) -> Result<(), CliError> {
+    let status_filter = match status.as_deref() {
+        None | Some("") => None,
+        Some("active") => Some(RunStatusFilter::Active),
+        Some("terminal") => Some(RunStatusFilter::Terminal),
+        Some(other) => {
+            return Err(CliError::InvalidInput(format!(
+                "Invalid --status value: {other} (expected: active | terminal)"
+            )));
+        }
+    };
+    // [05] API / CLI 等価性境界: Tauri API 経路と同じ
+    // `canonicalize_managed_worktree_path_inner` を経由する。
+    // 相対パス / symlink で同一 worktree を指定した場合に API / CLI の観測結果が
+    // 分岐しないようにするだけでなく、managed worktree かどうかの検証も同じ
+    // ルートで実施する（spec L92-96 API / CLI の意味的等価性境界）。
+    let worktree_path = match worktree.as_deref() {
+        Some(path) => Some(canonicalize_cli_worktree_filter_path(data_dir, path)?),
+        None => None,
+    };
+    let filter = RunListFilter {
+        status: status_filter,
+        worktree_path,
+    };
+    let summaries = list_runs_file_direct(data_dir, filter);
+    if json {
+        let text =
+            serde_json::to_string_pretty(&summaries).map_err(|e| format!("serialize runs: {e}"))?;
+        println!("{text}");
+    } else {
+        if summaries.is_empty() {
+            println!("(no runs)");
+            return Ok(());
+        }
+        println!(
+            "{:<36}  {:<20}  {:<18}  WORKTREE",
+            "RUN_ID", "WORKFLOW", "STATUS"
+        );
+        for s in &summaries {
+            let status = format!("{:?}", s.status);
+            println!(
+                "{:<36}  {:<20}  {:<18}  {}",
+                s.run_id,
+                truncate(&s.workflow_name, 20),
+                status,
+                s.worktree_path
+            );
+        }
+    }
+    Ok(())
+}
+
+/// 指定 run の現在 state。
+fn cmd_status(data_dir: &Path, run_id: &str, json: bool) -> Result<(), CliError> {
+    validate_run_id(run_id)?;
+    if get_run_summary_file_direct(data_dir, run_id).is_none() {
+        return Err(CliError::NotFound(format!(
+            "Workflow run not found: {run_id}"
+        )));
+    }
+    let view = reconstruct_state_view(data_dir, run_id)?;
+    if json {
+        let text =
+            serde_json::to_string_pretty(&view).map_err(|e| format!("serialize state: {e}"))?;
+        println!("{text}");
+    } else {
+        println!(
+            "run_id:        {}\nworkflow:      {}\nstate:         {:?}\ncurrent_step:  {}\nupdated_at:    {}",
+            view.state.execution_id,
+            view.state.workflow_name,
+            view.state.state,
+            view.state.current_step_name,
+            view.state.updated_at,
+        );
+    }
+    Ok(())
+}
+
+/// 指定 run の event log。
+fn cmd_logs(data_dir: &Path, run_id: &str, json: bool) -> Result<(), CliError> {
+    validate_run_id(run_id)?;
+    if get_run_summary_file_direct(data_dir, run_id).is_none() {
+        return Err(CliError::NotFound(format!(
+            "Workflow run not found: {run_id}"
+        )));
+    }
+    let events = read_log(data_dir, run_id)?;
+    if json {
+        let text =
+            serde_json::to_string_pretty(&events).map_err(|e| format!("serialize log: {e}"))?;
+        println!("{text}");
+    } else {
+        for event in &events {
+            println!("{}", format_event(event));
+        }
+    }
+    Ok(())
+}
+
+/// [05] CLI: `workflows/` + builtin と `workflow_runs/` の active metadata を file-direct
+/// で読み、`is_running` を反映した `Summary` 一覧を返す（spec [05] Rule: 観測経路は
+/// API と CLI で等価な手段を提供する）。
+///
+/// API 側（`commands::list_workflows`）は engine in-memory active map を running source として
+/// 使うが、CLI は file metadata を running source として使う。両者は file 同期境界
+/// （[04] atomic mutation 境界）の中で揃うので、観測結果は等価となる。
+fn list_workflows_file_direct(
+    workflows_dir: &Path,
+    data_dir: &Path,
+) -> Result<Vec<crate::workflow::schema::Summary>, CliError> {
+    let mut summaries = storage::list_workflows(workflows_dir).map_err(|e| e.to_string())?;
+    let running = running_workflow_names_from_metadata(data_dir);
+    for s in &mut summaries {
+        s.is_running = running.contains(&s.name);
+    }
+    Ok(summaries)
+}
+
+/// `workflow_runs/` を file-direct で走査し、filter を適用した summary 一覧を返す。
+/// API 経路（`RunStore::list_runs`）と同じ `project_runs_to_summaries` を経由することで
+/// 観測ロジックの divergence を防ぐ（spec [05] API / CLI の意味的等価性境界）。
+fn list_runs_file_direct(data_dir: &Path, filter: RunListFilter) -> Vec<WorkflowRunSummary> {
+    let runs = iter_valid_run_metadata(data_dir);
+    project_runs_to_summaries(runs, &filter)
+}
+
+fn get_run_summary_file_direct(data_dir: &Path, run_id: &str) -> Option<WorkflowRunSummary> {
+    if uuid::Uuid::parse_str(run_id).is_err() {
+        return None;
+    }
+    iter_valid_run_metadata(data_dir)
+        .iter()
+        .find(|run| run.run_id == run_id)
+        .map(WorkflowRunSummary::from)
+}
+
+/// [05] API / CLI 等価性境界: Tauri 側 `canonicalize_managed_worktree_path`
+/// と同じ `canonicalize_managed_worktree_path_inner` を CLI 経路でも経由する。
+/// data_dir 配下の `releash.toml` から `last_repo_paths` / `last_root_path` を読み出して
+/// repo_paths を組み立て、managed worktree かどうかを Tauri API と同一ロジックで検証する。
+///
+/// 観測専用 CLI helper として書き込みを発生させない `read_config_if_exists` を使う
+/// （spec [05] read-only と mutating の分離）。typed error:
+///
+/// - `CliError::Other`: config read / parse 失敗（設定読込側の問題）。
+/// - `CliError::InvalidInput`: managed worktree でない入力（caller の問題）。
+///
+/// 両者を同じ `InvalidInput` に潰すと caller が原因を取り違えるため明確に分ける
+/// （spec [05] CLI 入力の信頼境界 + read-only と mutating の分離）。
+fn canonicalize_cli_worktree_filter_path(
+    data_dir: &Path,
+    worktree_path: &str,
+) -> Result<String, CliError> {
+    let config_path = data_dir.join("releash.toml");
+    let repo_paths = match read_config_if_exists(&config_path).map_err(CliError::Other)? {
+        Some(config) => {
+            let mut paths = config.app.last_repo_paths.clone();
+            if !config.app.last_root_path.is_empty() && !paths.contains(&config.app.last_root_path)
+            {
+                paths.push(config.app.last_root_path.clone());
+            }
+            paths
+        }
+        None => Vec::new(),
+    };
+    canonicalize_managed_worktree_path_inner(repo_paths, worktree_path.to_string())
+        .map_err(CliError::InvalidInput)
+}
+
+fn validate_run_id(run_id: &str) -> Result<(), CliError> {
+    uuid::Uuid::parse_str(run_id)
+        .map(|_| ())
+        .map_err(|_| CliError::InvalidInput("Invalid run_id format (must be UUID)".to_string()))
+}
+
+fn read_log(data_dir: &Path, run_id: &str) -> Result<Vec<WorkflowEvent>, CliError> {
+    let event_log = WorkflowEventLog::new(data_dir);
+    event_log.read_log(run_id).map_err(CliError::Other)
+}
+
+/// Spec [05] API / CLI 等価性境界: Tauri `get_workflow_run_state` と同じ
+/// `WorkflowStateView` shape を CLI 側でも返すため、再構築した `WorkflowState` を
+/// `workflow_state_to_view` 経由で投影し、`runtime_states` 空 HashMap で
+/// `WorkflowStateView::from_parts` に通す（CLI は engine の in-memory runtime を
+/// 観測しない）。
+fn reconstruct_state_view(data_dir: &Path, run_id: &str) -> Result<WorkflowStateView, CliError> {
+    let events = read_log(data_dir, run_id)?;
+    let state = reconstruct_state_from_events(run_id, &events).map_err(CliError::Other)?;
+    let state = state
+        .ok_or_else(|| CliError::NotFound(format!("No event log available for run: {run_id}")))?;
+    Ok(WorkflowStateView::from_parts(
+        workflow_state_to_view(state),
+        std::collections::HashMap::new(),
+    ))
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    }
+}
+
+fn format_event(event: &WorkflowEvent) -> String {
+    let kind = match event {
+        WorkflowEvent::RunStarted { .. } => "RunStarted",
+        WorkflowEvent::NodeStarted { .. } => "NodeStarted",
+        WorkflowEvent::NodeCompleted { .. } => "NodeCompleted",
+        WorkflowEvent::NodeFailed { .. } => "NodeFailed",
+        WorkflowEvent::ApprovalRequested { .. } => "ApprovalRequested",
+        WorkflowEvent::ApprovalResolved { .. } => "ApprovalResolved",
+        WorkflowEvent::RunCompleted { .. } => "RunCompleted",
+        WorkflowEvent::RunFailed { .. } => "RunFailed",
+        WorkflowEvent::RunAborted { .. } => "RunAborted",
+        WorkflowEvent::OutputCollected { .. } => "OutputCollected",
+        WorkflowEvent::ParallelStarted { .. } => "ParallelStarted",
+        WorkflowEvent::ParallelChildStarted { .. } => "ParallelChildStarted",
+        WorkflowEvent::ParallelChildCompleted { .. } => "ParallelChildCompleted",
+        WorkflowEvent::ParallelCompleted { .. } => "ParallelCompleted",
+        WorkflowEvent::ContractRepairRequested { .. } => "ContractRepairRequested",
+    };
+    match serde_json::to_string(event) {
+        Ok(json) => format!("{kind} {json}"),
+        Err(_) => kind.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::run::{RunStatus, TriggerSource, WorkflowRun};
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_run(run_id: &str, worktree: &str, status: RunStatus, started_at: f64) -> WorkflowRun {
+        WorkflowRun {
+            run_id: run_id.to_string(),
+            workflow_name: "wf".to_string(),
+            task: None,
+            status,
+            worktree_path: worktree.to_string(),
+            chat_session_id: None,
+            current_node_name: None,
+            trigger_source: TriggerSource::Cli,
+            started_at,
+            updated_at: started_at,
+            completed_at: if status.is_terminal() {
+                Some(started_at + 1.0)
+            } else {
+                None
+            },
+            error_reason: None,
+        }
+    }
+
+    fn write_run_file(data_dir: &Path, run: &WorkflowRun) {
+        let runs_dir = data_dir.join("workflow_runs");
+        fs::create_dir_all(&runs_dir).unwrap();
+        let path = runs_dir.join(format!("{}.json", run.run_id));
+        let json = serde_json::to_string_pretty(run).unwrap();
+        fs::write(path, json).unwrap();
+    }
+
+    fn test_uuid(seed: u8) -> String {
+        uuid::Uuid::from_bytes([seed; 16]).to_string()
+    }
+
+    /// Rule: 観測対象として存在しない run_id は明示的に「該当 run なし」として扱われる
+    #[test]
+    fn get_run_summary_file_direct_returns_none_for_missing_run() {
+        let tmp = TempDir::new().unwrap();
+        let result = get_run_summary_file_direct(tmp.path(), &test_uuid(99));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_run_summary_file_direct_rejects_invalid_run_id() {
+        let tmp = TempDir::new().unwrap();
+        let result = get_run_summary_file_direct(tmp.path(), "not-a-uuid");
+        assert!(result.is_none());
+    }
+
+    /// Rule: CLI 経路で active / terminal を含む run 一覧を観測できる
+    #[test]
+    fn list_runs_file_direct_returns_active_and_terminal_runs() {
+        let tmp = TempDir::new().unwrap();
+        let active_id = test_uuid(1);
+        let done_id = test_uuid(2);
+        write_run_file(
+            tmp.path(),
+            &make_run(&active_id, "/wt/a", RunStatus::Running, 100.0),
+        );
+        write_run_file(
+            tmp.path(),
+            &make_run(&done_id, "/wt/b", RunStatus::Completed, 90.0),
+        );
+
+        let all = list_runs_file_direct(tmp.path(), RunListFilter::default());
+        assert_eq!(all.len(), 2);
+        // active が先頭
+        assert_eq!(all[0].run_id, active_id);
+        assert_eq!(all[1].run_id, done_id);
+
+        let active_only = list_runs_file_direct(
+            tmp.path(),
+            RunListFilter {
+                status: Some(RunStatusFilter::Active),
+                worktree_path: None,
+            },
+        );
+        assert_eq!(active_only.len(), 1);
+        assert_eq!(active_only[0].run_id, active_id);
+
+        let terminal_only = list_runs_file_direct(
+            tmp.path(),
+            RunListFilter {
+                status: Some(RunStatusFilter::Terminal),
+                worktree_path: None,
+            },
+        );
+        assert_eq!(terminal_only.len(), 1);
+        assert_eq!(terminal_only[0].run_id, done_id);
+    }
+
+    /// Rule: worktree filter で対応する run のみが返る
+    #[test]
+    fn list_runs_file_direct_filters_by_worktree() {
+        let tmp = TempDir::new().unwrap();
+        let run_a = test_uuid(1);
+        let run_b = test_uuid(2);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_a, "/wt/a", RunStatus::Running, 100.0),
+        );
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_b, "/wt/b", RunStatus::Running, 100.0),
+        );
+
+        let filtered = list_runs_file_direct(
+            tmp.path(),
+            RunListFilter {
+                status: None,
+                worktree_path: Some("/wt/a".to_string()),
+            },
+        );
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].run_id, run_a);
+    }
+
+    /// Rule: 観測される情報は engine が一次 owner として保持するデータと一致する
+    #[test]
+    fn get_run_summary_file_direct_matches_persisted_metadata() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(1);
+        let run = make_run(&run_id, "/wt/a", RunStatus::Running, 100.0);
+        write_run_file(tmp.path(), &run);
+
+        let summary = get_run_summary_file_direct(tmp.path(), &run_id).unwrap();
+        assert_eq!(summary.run_id, run_id);
+        assert_eq!(summary.worktree_path, "/wt/a");
+        assert_eq!(summary.status, RunStatus::Running);
+        assert_eq!(summary.started_at, 100.0);
+    }
+
+    #[test]
+    fn validate_run_id_rejects_non_uuid() {
+        assert!(validate_run_id("not-a-uuid").is_err());
+        assert!(validate_run_id("").is_err());
+        assert!(validate_run_id("../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn validate_run_id_accepts_valid_uuid() {
+        assert!(validate_run_id("550e8400-e29b-41d4-a716-446655440000").is_ok());
+    }
+
+    fn write_event_log(data_dir: &Path, _run_id: &str, events: &[WorkflowEvent]) {
+        let log = WorkflowEventLog::new(data_dir);
+        for event in events {
+            log.append(event).unwrap();
+        }
+    }
+
+    fn run_started_event(run_id: &str, workflow_name: &str, worktree: &str) -> WorkflowEvent {
+        WorkflowEvent::RunStarted {
+            run_id: run_id.to_string(),
+            workflow_name: workflow_name.to_string(),
+            workflow_file_stem: workflow_name.to_string(),
+            worktree_path: worktree.to_string(),
+            workflow_definition: crate::workflow::schema::Workflow {
+                name: workflow_name.to_string(),
+                description: "test".to_string(),
+                builtin: false,
+                nodes: vec![],
+            },
+            timestamp: 100.0,
+        }
+    }
+
+    /// Spec [05] Rule: CLI 経路から指定 run の現在 state を観測できる。
+    #[test]
+    fn cmd_status_returns_ok_for_existing_run_with_event_log() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(11);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/cli-status", RunStatus::Running, 100.0),
+        );
+        write_event_log(
+            tmp.path(),
+            &run_id,
+            &[run_started_event(&run_id, "wf", "/wt/cli-status")],
+        );
+        let result = cmd_status(tmp.path(), &run_id, true);
+        assert!(result.is_ok(), "cmd_status must succeed: {result:?}");
+    }
+
+    /// Spec [05] Rule: 存在しない run_id は明示的に「該当 run なし」として扱われる（CLI 経路）。
+    #[test]
+    fn cmd_status_returns_not_found_for_missing_run() {
+        let tmp = TempDir::new().unwrap();
+        let result = cmd_status(tmp.path(), &test_uuid(99), false);
+        assert!(matches!(result, Err(CliError::NotFound(_))));
+    }
+
+    #[test]
+    fn cmd_status_returns_invalid_input_for_non_uuid_run_id() {
+        let tmp = TempDir::new().unwrap();
+        let result = cmd_status(tmp.path(), "not-a-uuid", false);
+        assert!(matches!(result, Err(CliError::InvalidInput(_))));
+    }
+
+    /// Spec [05] Rule: CLI 経路から指定 run の event log を観測できる。
+    #[test]
+    fn cmd_logs_returns_ok_for_existing_run() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(12);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/cli-logs", RunStatus::Completed, 200.0),
+        );
+        write_event_log(
+            tmp.path(),
+            &run_id,
+            &[run_started_event(&run_id, "wf", "/wt/cli-logs")],
+        );
+        let result = cmd_logs(tmp.path(), &run_id, true);
+        assert!(result.is_ok(), "cmd_logs must succeed: {result:?}");
+    }
+
+    #[test]
+    fn cmd_logs_returns_not_found_for_missing_run() {
+        let tmp = TempDir::new().unwrap();
+        let result = cmd_logs(tmp.path(), &test_uuid(98), false);
+        assert!(matches!(result, Err(CliError::NotFound(_))));
+    }
+
+    #[test]
+    fn cmd_logs_returns_invalid_input_for_non_uuid_run_id() {
+        let tmp = TempDir::new().unwrap();
+        let result = cmd_logs(tmp.path(), "../etc/passwd", false);
+        assert!(matches!(result, Err(CliError::InvalidInput(_))));
+    }
+
+    /// Spec [05] Rule: 観測経路は API と CLI で等価な手段を提供する。
+    /// 同一 tempdir 上の metadata + NDJSON を入力に、API 側（RunStore + event_log +
+    /// projection）と CLI 側（list_runs_file_direct / get_run_summary_file_direct /
+    /// read_log / reconstruct_state_view）が同じ観測結果を返すことを直接検証する。
+    #[tokio::test]
+    async fn api_and_cli_observation_paths_produce_equivalent_results() {
+        use crate::workflow::event_projection::reconstruct_state_from_events;
+        use crate::workflow::run::RunStore;
+
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(21);
+        let other_id = test_uuid(22);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/api-cli", RunStatus::Completed, 300.0),
+        );
+        write_run_file(
+            tmp.path(),
+            &make_run(&other_id, "/wt/api-cli-2", RunStatus::Completed, 250.0),
+        );
+        write_event_log(
+            tmp.path(),
+            &run_id,
+            &[run_started_event(&run_id, "wf", "/wt/api-cli")],
+        );
+
+        // CLI 経路
+        let cli_summaries = list_runs_file_direct(tmp.path(), RunListFilter::default());
+        let cli_summary = get_run_summary_file_direct(tmp.path(), &run_id)
+            .expect("CLI summary must be available");
+        let cli_events = read_log(tmp.path(), &run_id).unwrap();
+        let cli_state_view = reconstruct_state_view(tmp.path(), &run_id).unwrap();
+
+        // API 経路（RunStore は active in-memory map + workflow_runs/ file の両方を参照）
+        let store = RunStore::default();
+        store.set_data_dir(tmp.path().to_path_buf()).await;
+        let api_summaries = store.list_runs(RunListFilter::default()).await;
+        let api_summary = store
+            .get_run(&run_id)
+            .await
+            .expect("API summary must be available");
+        let api_events = WorkflowEventLog::new(tmp.path()).read_log(&run_id).unwrap();
+        let api_state = reconstruct_state_from_events(&run_id, &api_events)
+            .unwrap()
+            .unwrap();
+        let api_state_view = WorkflowStateView::from_parts(
+            workflow_state_to_view(api_state),
+            std::collections::HashMap::new(),
+        );
+
+        // 並び順 + 件数の一致
+        assert_eq!(api_summaries.len(), cli_summaries.len());
+        for (a, c) in api_summaries.iter().zip(cli_summaries.iter()) {
+            assert_eq!(a.run_id, c.run_id);
+            assert_eq!(a.status, c.status);
+            assert_eq!(a.worktree_path, c.worktree_path);
+        }
+        // 単一 summary の一致
+        assert_eq!(api_summary.run_id, cli_summary.run_id);
+        assert_eq!(api_summary.status, cli_summary.status);
+        assert_eq!(api_summary.worktree_path, cli_summary.worktree_path);
+        // event log の件数 / 種別の一致
+        assert_eq!(api_events.len(), cli_events.len());
+        assert_eq!(api_events.len(), 1);
+        // state view の serialize 等価性: API/CLI は同じ shape の WorkflowStateView を返す。
+        let api_json = serde_json::to_value(&api_state_view).unwrap();
+        let cli_json = serde_json::to_value(&cli_state_view).unwrap();
+        assert_eq!(api_json, cli_json);
+    }
+
+    /// Spec [05] Rule: 観測経路は API と CLI で等価な手段を提供する（workflow template 経路）。
+    /// CLI の `list_workflows_file_direct` は `workflow_runs/` 配下の active metadata から
+    /// `is_running` を反映する。API 側（`engine.running_workflow_names()` + `storage::list_workflows`）
+    /// と同じ workflow template 集合 + `is_running` フラグを返すことを直接検証する。
+    #[tokio::test]
+    async fn list_workflows_file_direct_reflects_running_active_metadata() {
+        use crate::workflow::storage;
+
+        let tmp = TempDir::new().unwrap();
+        let workflows_dir = tmp.path().join("workflows");
+        std::fs::create_dir_all(&workflows_dir).unwrap();
+        let yaml = concat!(
+            "name: api-cli-list\n",
+            "description: list test\n",
+            "nodes:\n",
+            "  - name: step1\n",
+            "    type: agent\n",
+            "    instruction: do thing\n",
+            "    permission: edit\n",
+        );
+        std::fs::write(workflows_dir.join("api-cli-list.yml"), yaml).unwrap();
+
+        // 該当 workflow を active 状態で書き込む。
+        let active_id = test_uuid(50);
+        write_run_file(
+            tmp.path(),
+            &WorkflowRun {
+                run_id: active_id.clone(),
+                workflow_name: "api-cli-list".to_string(),
+                task: None,
+                status: RunStatus::Running,
+                worktree_path: "/wt/list".to_string(),
+                chat_session_id: None,
+                current_node_name: None,
+                trigger_source: TriggerSource::Cli,
+                started_at: 500.0,
+                updated_at: 500.0,
+                completed_at: None,
+                error_reason: None,
+            },
+        );
+
+        let cli_summaries = list_workflows_file_direct(&workflows_dir, tmp.path()).unwrap();
+        let target = cli_summaries
+            .iter()
+            .find(|s| s.name == "api-cli-list")
+            .expect("workflow must be listed");
+        assert!(target.is_running, "is_running must reflect active metadata");
+
+        // API 側と等価性: storage::list_workflows + (active metadata 由来の running set)。
+        let mut api_summaries = storage::list_workflows(&workflows_dir).unwrap();
+        let api_running = running_workflow_names_from_metadata(tmp.path());
+        for s in &mut api_summaries {
+            s.is_running = api_running.contains(&s.name);
+        }
+        // 同じ projection に通したので JSON shape も一致する。
+        let api_json = serde_json::to_value(&api_summaries).unwrap();
+        let cli_json = serde_json::to_value(&cli_summaries).unwrap();
+        assert_eq!(api_json, cli_json);
+    }
+
+    /// Spec [05] API / CLI 等価性境界: list_workflows の API 経路は
+    /// `engine.running_workflow_names()`（in-memory `executions` map 由来）を
+    /// running source とし、CLI は `running_workflow_names_from_metadata`
+    /// （`workflow_runs/` file 由来）を使う。engine が active run を登録すると
+    /// 両 source が同期して同一 running 集合を返すことを実 API 経路で検証する
+    /// （spec L92-96 / L160-162）。
+    #[tokio::test]
+    async fn engine_running_workflow_names_matches_cli_file_direct_after_register_active() {
+        use crate::workflow::engine::WorkflowEngine;
+        use crate::workflow::schema::{NodeDefinition, NodeType, Workflow};
+        use crate::workflow::state::WorkflowExecutionState;
+
+        let tmp = TempDir::new().unwrap();
+        let engine = WorkflowEngine::new_for_test();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+
+        let workflow = Workflow {
+            name: "engine-cli-list".to_string(),
+            description: String::new(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "step1".to_string(),
+                node_type: NodeType::Agent,
+                ..Default::default()
+            }],
+        };
+        let run_id = test_uuid(60);
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                workflow,
+                WorkflowExecutionState::Running,
+                "/wt/engine-cli-list".to_string(),
+                "sess-1".to_string(),
+                TriggerSource::Cli,
+            )
+            .await;
+
+        let api_running = engine.running_workflow_names().await;
+        let cli_running = running_workflow_names_from_metadata(tmp.path());
+        assert_eq!(
+            api_running, cli_running,
+            "API path engine.running_workflow_names() must equal CLI file-direct set"
+        );
+        assert!(api_running.contains("engine-cli-list"));
+    }
+
+    /// Spec [05] API / CLI 等価性境界: CLI `--worktree` 入力は
+    /// `canonicalize_managed_worktree_path_inner` 経由で managed worktree 検証を
+    /// 通過する。configured repo path に紐づかない非 canonical 入力は
+    /// CLI 側で InvalidInput として弾かれる（API 側と同一エラー経路）。
+    #[test]
+    fn cli_worktree_filter_rejects_non_managed_path() {
+        let tmp = TempDir::new().unwrap();
+        // releash.toml に repo 設定なし → どの worktree も managed として認識されない。
+        let outside = tempfile::TempDir::new().unwrap();
+        let result =
+            canonicalize_cli_worktree_filter_path(tmp.path(), &outside.path().to_string_lossy());
+        assert!(
+            result.is_err(),
+            "non-managed worktree path must be rejected"
+        );
+    }
+
+    /// Spec [05] API / CLI 等価性境界: configured repo path 配下の managed worktree
+    /// を CLI 経路で指定した場合、相対 / 末尾スラッシュ等の非 canonical 入力でも
+    /// 正規化済みの絶対パス文字列として projection helper に渡せる。
+    #[test]
+    fn cli_worktree_filter_accepts_managed_worktree_with_non_canonical_input() {
+        let (repo_dir, repo) = crate::git::test_helpers::create_test_repo();
+        crate::git::test_helpers::create_initial_commit(&repo);
+        let worktree_parent = tempfile::TempDir::new().unwrap();
+        let worktree_path = worktree_parent.path().join("managed-wt");
+        repo.worktree("managed-wt", &worktree_path, None).unwrap();
+
+        // CLI 用 data_dir に releash.toml を配置し、repo を configured repo として登録。
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let config_path = data_dir.path().join("releash.toml");
+        let mut config = crate::config::ReleashConfig::default();
+        config.app.last_repo_paths = vec![repo_dir.path().to_string_lossy().to_string()];
+        crate::config::write_config(&config_path, &config).unwrap();
+
+        // 末尾スラッシュ / `.` を含む非 canonical 入力で呼び出しても、canonicalize した
+        // 絶対パスが返り、その値は worktree_path.canonicalize() と一致する。
+        let non_canonical = worktree_path.join(".").to_string_lossy().to_string();
+        let normalized =
+            canonicalize_cli_worktree_filter_path(data_dir.path(), &non_canonical).unwrap();
+        assert_eq!(
+            std::path::PathBuf::from(normalized),
+            worktree_path.canonicalize().unwrap()
+        );
+    }
+
+    /// Spec [05] API / CLI 等価性境界: `list_workflows` Tauri command が委譲する実
+    /// inner 関数（`workflow::commands::list_workflows_inner`）と CLI 側の
+    /// `list_workflows_file_direct` を、同一 tempdir / 同一 running 集合に対して比較し、
+    /// 両者が JSON shape として完全に一致することを境界仕様として担保する。
+    ///
+    /// engine.running_workflow_names()（in-memory）と
+    /// running_workflow_names_from_metadata()（file-direct）は engine の同期書き込み
+    /// 境界により等価。本テストでは CLI 側と同じ source（file-direct）で running 集合を
+    /// 構築して inner に渡し、両経路の出力 shape が等価であることを検証する。
+    #[test]
+    fn list_workflows_inner_api_path_equals_cli_file_direct_path() {
+        let tmp = TempDir::new().unwrap();
+        let workflows_dir = tmp.path().join("workflows");
+        std::fs::create_dir_all(&workflows_dir).unwrap();
+        let yaml = concat!(
+            "name: api-cli-inner\n",
+            "description: api-cli-inner test\n",
+            "nodes:\n",
+            "  - name: step1\n",
+            "    type: agent\n",
+            "    instruction: do thing\n",
+            "    permission: edit\n",
+        );
+        std::fs::write(workflows_dir.join("api-cli-inner.yml"), yaml).unwrap();
+
+        // 該当 workflow を active 状態で書き込む。
+        let active_id = test_uuid(70);
+        write_run_file(
+            tmp.path(),
+            &WorkflowRun {
+                run_id: active_id.clone(),
+                workflow_name: "api-cli-inner".to_string(),
+                task: None,
+                status: RunStatus::Running,
+                worktree_path: "/wt/inner".to_string(),
+                chat_session_id: None,
+                current_node_name: None,
+                trigger_source: TriggerSource::Cli,
+                started_at: 700.0,
+                updated_at: 700.0,
+                completed_at: None,
+                error_reason: None,
+            },
+        );
+
+        // API 経路: list_workflows_inner（Tauri command が委譲する実関数）
+        let running = running_workflow_names_from_metadata(tmp.path());
+        let api_summaries =
+            crate::workflow::commands::list_workflows_inner(&running, &workflows_dir).unwrap();
+
+        // CLI 経路: list_workflows_file_direct
+        let cli_summaries = list_workflows_file_direct(&workflows_dir, tmp.path()).unwrap();
+
+        // 両者は同じ projection を通すので JSON shape も完全一致。
+        let api_json = serde_json::to_value(&api_summaries).unwrap();
+        let cli_json = serde_json::to_value(&cli_summaries).unwrap();
+        assert_eq!(
+            api_json, cli_json,
+            "list_workflows_inner と list_workflows_file_direct は同一観測結果を返さなければならない"
+        );
+
+        // is_running が active metadata から正しく反映されている。
+        let api_target = api_summaries
+            .iter()
+            .find(|s| s.name == "api-cli-inner")
+            .expect("workflow must be present in API path");
+        assert!(api_target.is_running);
+    }
+
+    /// Spec [05] read-only と mutating の分離: 観測専用 CLI helper は config 不在時に
+    /// `releash.toml` を作成しない。`load_or_create_config` の hidden write 経路を
+    /// CLI から廃止したことを境界仕様として担保する。
+    #[test]
+    fn cli_worktree_filter_does_not_create_config_when_missing() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let config_path = data_dir.path().join("releash.toml");
+        let outside = tempfile::TempDir::new().unwrap();
+        // 設定ファイル不在で呼び出す。managed worktree でないため Err になる。
+        let _ = canonicalize_cli_worktree_filter_path(
+            data_dir.path(),
+            &outside.path().to_string_lossy(),
+        );
+        assert!(
+            !config_path.exists(),
+            "CLI must not create releash.toml in read-only paths"
+        );
+    }
+
+    /// Spec [05] CLI 入力の信頼境界: 設定 parse エラーは「managed worktree でない」
+    /// 入力エラーに化けず、原因付きで Err として伝播する。
+    #[test]
+    fn cli_worktree_filter_propagates_config_parse_error() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let config_path = data_dir.path().join("releash.toml");
+        std::fs::write(&config_path, b"this = is = invalid = toml").unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let err = canonicalize_cli_worktree_filter_path(
+            data_dir.path(),
+            &outside.path().to_string_lossy(),
+        )
+        .expect_err("parse error must propagate");
+        // typed error: config parse failure は CliError::Other で伝播し、
+        // 「managed worktree でない」入力エラー（InvalidInput）と取り違えない。
+        let CliError::Other(msg) = &err else {
+            panic!("expected CliError::Other for config parse failure, got: {err:?}");
+        };
+        assert!(
+            msg.contains("パース失敗") || msg.to_lowercase().contains("parse"),
+            "error must indicate config parse failure, got: {msg}"
+        );
+    }
+
+    /// [05] CLI 公開入口の parse 境界: `releash workflow list|runs|status|logs` の
+    /// 4 サブコマンドが clap で parse できることを parser-level で担保する。本テストは
+    /// I/O を発生させない（`try_parse_from` のみ）。
+    #[test]
+    fn cli_workflow_subcommands_parse_via_clap() {
+        for argv in [
+            vec!["releash", "workflow", "list"],
+            vec!["releash", "workflow", "list", "--json"],
+            vec!["releash", "workflow", "runs"],
+            vec!["releash", "workflow", "runs", "--status", "active"],
+            vec![
+                "releash", "workflow", "runs", "--status", "terminal", "--json",
+            ],
+            vec![
+                "releash",
+                "workflow",
+                "runs",
+                "--worktree",
+                "/some/path",
+                "--json",
+            ],
+            vec![
+                "releash",
+                "workflow",
+                "status",
+                "550e8400-e29b-41d4-a716-446655440000",
+            ],
+            vec![
+                "releash",
+                "workflow",
+                "logs",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "--json",
+            ],
+        ] {
+            assert!(
+                Cli::try_parse_from(&argv).is_ok(),
+                "parser must accept {argv:?}"
+            );
+        }
+    }
+
+    /// [05] mutating 用 subcommand 非存在: mutating CLI（[06] へ振り分け済み）
+    /// の subcommand 名は parser 段階で reject される。run / approve / reject / abort /
+    /// output 等の動詞が現状 CLI に出現しないことを境界仕様として担保する。
+    #[test]
+    fn cli_does_not_expose_mutating_subcommands() {
+        for argv in [
+            vec!["releash", "workflow", "run"],
+            vec!["releash", "workflow", "approve"],
+            vec!["releash", "workflow", "reject"],
+            vec!["releash", "workflow", "abort"],
+            vec!["releash", "workflow", "output"],
+            vec!["releash", "workflow", "submit"],
+        ] {
+            assert!(
+                Cli::try_parse_from(&argv).is_err(),
+                "parser must reject mutating subcommand: {argv:?}"
+            );
+        }
+    }
+
+    /// [05] CLI 入力の信頼境界: managed worktree でない入力は
+    /// `CliError::InvalidInput` として伝播し、`CliError::Other`（config 読込側）と
+    /// 混同しない。typed error を直接 match して境界を担保する。
+    #[test]
+    fn cli_worktree_filter_returns_invalid_input_for_non_managed_path() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let err = canonicalize_cli_worktree_filter_path(
+            data_dir.path(),
+            &outside.path().to_string_lossy(),
+        )
+        .expect_err("non-managed path must be rejected");
+        assert!(
+            matches!(err, CliError::InvalidInput(_)),
+            "non-managed input must surface as InvalidInput, got: {err:?}"
+        );
+    }
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -346,6 +346,31 @@ pub fn generate_token() -> String {
         .collect()
 }
 
+/// 読み取り専用の config ローダ。
+///
+/// 設定ファイルが存在する場合のみ parse して返す。`load_or_create_config` と異なり
+/// token 自動生成や `write_config` の副作用を持たず、観測専用 caller（CLI 等）が
+/// hidden write を発生させないことを境界仕様として担保する（spec [05]
+/// read-only と mutating の分離原則）。
+///
+/// 設定不在は `Ok(None)` として返す。parse / 読み取り失敗は原因付きで `Err` を返し、
+/// caller が「設定読み取り失敗」を「managed worktree でない」と取り違えないようにする。
+pub fn read_config_if_exists(path: &Path) -> Result<Option<ReleashConfig>, String> {
+    // `try_exists()` を使うことで、metadata 取得失敗（権限不足・I/O エラー等）を
+    // 「設定不在」と取り違えずに `Err` として呼出側に伝える。`exists()` は metadata
+    // error を false に潰すため、CLI の InvalidInput 誤分類につながる
+    // （spec [05] read-only と mutating の分離 / read 失敗は原因付き Err）。
+    match path.try_exists() {
+        Ok(true) => {}
+        Ok(false) => return Ok(None),
+        Err(e) => return Err(format!("設定ファイル存在確認失敗: {e}")),
+    }
+    let content = fs::read_to_string(path).map_err(|e| format!("設定ファイル読み込み失敗: {e}"))?;
+    let config = toml::from_str::<ReleashConfig>(&content)
+        .map_err(|e| format!("設定ファイルのパース失敗: {e}"))?;
+    Ok(Some(config))
+}
+
 pub fn load_or_create_config(path: &Path) -> Result<ReleashConfig, String> {
     let mut config = if path.exists() {
         let content =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod agent_message_dispatcher;
 mod agent_sdk;
 mod agent_status;
 mod backends;
+pub mod cli;
 mod config;
 mod diff_comment_sender;
 mod diff_comment_store;
@@ -561,11 +562,10 @@ pub fn run() {
             workflow::commands::approve_workflow_step,
             workflow::commands::send_workflow_approval_chat_message,
             workflow::commands::open_workflow_step_tab,
-            workflow::commands::get_workflow_execution_log,
-            workflow::commands::get_workflow_execution_state,
-            workflow::commands::list_active_workflow_runs,
-            workflow::commands::list_completed_workflow_runs,
-            workflow::commands::list_workflow_runs_for_worktree,
+            workflow::commands::list_workflow_runs,
+            workflow::commands::get_workflow_run,
+            workflow::commands::get_workflow_run_log,
+            workflow::commands::get_workflow_run_state,
             workflow::commands::resolve_active_run_by_worktree,
             workflow::commands::resolve_worktree_by_run,
             workflow::commands::list_facets,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // [05] CLI mode: 第一引数が `workflow` のとき file-direct な CLI を起動し、
+    // Tauri アプリは起動しない。CLI 起動独立性境界（spec [05] CLI 起動独立性境界）。
+    if std::env::args().nth(1).as_deref() == Some("workflow") {
+        std::process::exit(releash_lib::cli::run());
+    }
     releash_lib::run()
 }

--- a/src-tauri/src/workflow/command.rs
+++ b/src-tauri/src/workflow/command.rs
@@ -1,13 +1,20 @@
-//! [04] Command / Event Boundary: workflow state を変化させる唯一の入口の typed 表現。
+//! [04] / [05] Command / Event Boundary: workflow state を変化させる唯一の入口の
+//! typed 表現。
 //!
-//! 本 issue 範囲は外部入口を持つ 4 command（`StartRun` / `AbortRun` / `ApproveNode` /
-//! `RejectNode`）に限定する。`SubmitOutput`（[08]）/ `CompleteNode` / `FailNode`（[05] へ
-//! 振り分け済み）は本ファイルでは導入しない。
+//! 外部入口を持つ 4 command（`StartRun` / `AbortRun` / `ApproveNode` / `RejectNode`）
+//! に加え、engine 内部の node 完了 / 失敗遷移を typed 化する internal-only な
+//! 2 variant（`CompleteNode` / `FailNode`）を [05] で追加した。internal variant は
+//! 外部 adapter（Tauri command / CLI / agent path）から組み立てる経路を提供せず、
+//! `WorkflowEngine::dispatch` 経由で外部から到達した場合は内部不整合として `Err` に
+//! 変換する境界（spec [05] internal command の非公開境界）を engine 側で担保する。
+//!
+//! `SubmitOutput`（[08]）は本ファイルでは導入しない。
 //!
 //! ハンドラ実体は engine 側（`engine.rs`）に置く。本ファイルは型の所有のみを担い、
 //! `ApprovalDecision` 等の engine domain 型には依存しない。
 
 use crate::permission::PermissionMode;
+use crate::workflow::event::TokenUsage;
 use crate::workflow::run::TriggerSource;
 
 /// workflow engine の state を変化させる typed command。
@@ -15,6 +22,14 @@ use crate::workflow::run::TriggerSource;
 /// UI / Tauri command / 内部呼び出し元は、本 enum を組み立てて
 /// `WorkflowEngine::dispatch` に渡す経路のみを使う。`run_id` 主語の管理は
 /// [03] Run Store に揃える。
+///
+/// 外部入口を持つ 4 variant（`StartRun` / `AbortRun` / `ApproveNode` /
+/// `RejectNode`）に加え、engine 内部の node 完了 / 失敗遷移を typed 化する
+/// internal-only な 2 variant（`CompleteNode` / `FailNode`）を持つ。
+/// internal variant は外部 adapter（Tauri command / CLI / agent path）から
+/// 組み立てる経路を提供せず、`WorkflowEngine::dispatch` 経由で外部から到達した
+/// 場合は内部不整合として `Err` に変換する境界を engine 側で担保する
+/// （spec [05] internal command の非公開境界）。
 #[derive(Debug, Clone)]
 pub enum WorkflowCommand {
     /// 新しい workflow run の起動。
@@ -23,7 +38,7 @@ pub enum WorkflowCommand {
     /// であり、command 境界で「どの workflow template を起動するか」を解決する識別子。
     /// 論理 workflow 名（`Workflow::name`）は load 済み definition から導出する想定で、
     /// command boundary 上に重複した source of truth を持たない。Storage 層は
-    /// `Summary::name` を file stem として扱う（[03] Run Store / Summary 境界）。
+    /// `Summary::name` を file stem として扱う（[03] Run Store / Summary 境界)。
     StartRun {
         workflow_file_stem: String,
         worktree_path: String,
@@ -52,6 +67,34 @@ pub enum WorkflowCommand {
         run_id: String,
         node_name: String,
         reason: String,
+    },
+    /// [05] internal-only: engine 内部の node 完了遷移。発行 event は
+    /// `WorkflowEvent::NodeCompleted` と同一 shape のフィールドを持つ。
+    ///
+    /// 外部 adapter からこの variant を組み立てる経路は提供しない。
+    /// `WorkflowEngine::dispatch` 経由で到達した場合は内部不整合として `Err`。
+    CompleteNode {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        result: Option<String>,
+        session_id: Option<String>,
+        token_usage: Option<TokenUsage>,
+        structured_output: Option<serde_json::Value>,
+        run_index: Option<u32>,
+        timestamp: f64,
+    },
+    /// [05] internal-only: engine 内部の node 失敗遷移。発行 event は
+    /// `WorkflowEvent::NodeFailed` と同一 shape のフィールドを持つ。
+    ///
+    /// 外部 adapter からこの variant を組み立てる経路は提供しない。
+    /// `WorkflowEngine::dispatch` 経由で到達した場合は内部不整合として `Err`。
+    FailNode {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        reason: String,
+        timestamp: f64,
     },
 }
 
@@ -105,6 +148,56 @@ mod tests {
                 assert_eq!(n, "review");
             }
             _ => panic!("AbortRun variants must distinguish expected_node_name"),
+        }
+    }
+
+    /// [05] internal variants: `WorkflowCommand::CompleteNode` / `FailNode` は外部
+    /// caller 向けではないが `WorkflowCommand` の variant として typed boundary 上に
+    /// 揃え、対応する `WorkflowEvent::NodeCompleted` / `NodeFailed` と同一 shape の
+    /// フィールドを持つことを境界仕様として確認する。外部 adapter からは到達不能、
+    /// `dispatch` 経由で外部から流入した場合は engine 側で `Err` に変換する境界を
+    /// 担保する（spec [05] internal command の非公開境界 / 責務配置）。
+    #[test]
+    fn internal_node_command_variants_carry_event_shape_fields() {
+        let complete = WorkflowCommand::CompleteNode {
+            run_id: "00000000-0000-0000-0000-000000000020".to_string(),
+            workflow_name: "wf".to_string(),
+            node_name: "step1".to_string(),
+            result: Some("ok".to_string()),
+            session_id: Some("sess-1".to_string()),
+            token_usage: None,
+            structured_output: None,
+            run_index: Some(1),
+            timestamp: 100.0,
+        };
+        match complete {
+            WorkflowCommand::CompleteNode {
+                ref run_id,
+                ref node_name,
+                ..
+            } => {
+                assert_eq!(run_id, "00000000-0000-0000-0000-000000000020");
+                assert_eq!(node_name, "step1");
+            }
+            _ => panic!("expected CompleteNode"),
+        }
+        let fail = WorkflowCommand::FailNode {
+            run_id: "00000000-0000-0000-0000-000000000021".to_string(),
+            workflow_name: "wf".to_string(),
+            node_name: "step2".to_string(),
+            reason: "boom".to_string(),
+            timestamp: 200.0,
+        };
+        match fail {
+            WorkflowCommand::FailNode {
+                ref reason,
+                ref node_name,
+                ..
+            } => {
+                assert_eq!(reason, "boom");
+                assert_eq!(node_name, "step2");
+            }
+            _ => panic!("expected FailNode"),
         }
     }
 

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -5,7 +5,7 @@ use super::engine::WorkflowEngine;
 use super::event::WorkflowEvent;
 use super::facet::{self, FacetKind};
 use super::log::WorkflowEventLog;
-use super::run::WorkflowRunSummary;
+use super::run::{RunListFilter, RunStatusFilter, WorkflowRunSummary};
 use super::schema::{FacetSummary, Summary, Workflow};
 use super::storage;
 use crate::agent_message_dispatcher::{
@@ -134,21 +134,32 @@ fn validation_error_string(e: super::validation::ValidationError) -> String {
     format!("validation_error: {e}")
 }
 
+/// [05] `list_workflows` Tauri command が委譲する実 API inner 関数。
+///
+/// `running_names` は engine の in-memory active map 由来の workflow 名集合、
+/// `workflows_dir` は workflow YAML を読む対象ディレクトリ。Tauri State / Arc に
+/// 依存しない pure 関数として切り出すことで、API 経路と CLI 経路の意味的等価性を
+/// 直接テストできるようにする（spec [05] API / CLI の意味的等価性境界）。
+pub(crate) fn list_workflows_inner(
+    running_names: &std::collections::HashSet<String>,
+    workflows_dir: &std::path::Path,
+) -> Result<Vec<Summary>, String> {
+    let mut summaries = storage::list_workflows(workflows_dir).map_err(|e| e.to_string())?;
+    for s in &mut summaries {
+        s.is_running = running_names.contains(&s.name);
+    }
+    Ok(summaries)
+}
+
 #[tauri::command]
 pub async fn list_workflows(
     engine: tauri::State<'_, Arc<WorkflowEngine>>,
 ) -> Result<Vec<Summary>, String> {
     let running_names = engine.running_workflow_names().await;
     let dir = storage::workflows_dir();
-    tokio::task::spawn_blocking(move || {
-        let mut summaries = storage::list_workflows(&dir).map_err(|e| e.to_string())?;
-        for s in &mut summaries {
-            s.is_running = running_names.contains(&s.name);
-        }
-        Ok(summaries)
-    })
-    .await
-    .map_err(|e| format!("task join error: {e}"))?
+    tokio::task::spawn_blocking(move || list_workflows_inner(&running_names, &dir))
+        .await
+        .map_err(|e| format!("task join error: {e}"))?
 }
 
 #[tauri::command]
@@ -291,8 +302,10 @@ async fn start_workflow_adapter<R: tauri::Runtime>(
     let permission_mode = parse_workflow_start_permission_mode(permission_mode)?;
     // [04] managed worktree 検証は dispatch 経路（= 全 command 入口の合流地点）で行う。
     // Tauri adapter は文字列引数のまま command を組み立て、engine 入口で正規化される境界に揃える。
+    // [05] adapter-facing 拒否境界: 外部 adapter は internal-only variant を組み立てないため
+    // dispatch_external を経由する。
     engine
-        .dispatch(
+        .dispatch_external(
             app,
             session_store,
             handles,
@@ -355,7 +368,7 @@ async fn abort_workflow_adapter<R: tauri::Runtime>(
 ) -> Result<(), String> {
     validate_run_id(&run_id)?;
     engine
-        .dispatch(
+        .dispatch_external(
             app,
             session_store,
             handles,
@@ -484,7 +497,7 @@ async fn approve_workflow_step_adapter<R: tauri::Runtime>(
     // engine から等価に扱われる）。
     let command = decision.into_command(run_id, step_name);
     engine
-        .dispatch(app, session_store, handles, command)
+        .dispatch_external(app, session_store, handles, command)
         .await
         .map_err(|e| e.to_string())
         .and_then(|result| match result {
@@ -619,52 +632,166 @@ fn validate_run_id(run_id: &str) -> Result<(), String> {
         .map_err(|_| "Invalid run_id format (must be UUID)".to_string())
 }
 
-// ---- ワークフロー履歴閲覧コマンド ----
+// ---- [05] read-only Run 観測 API ----
+//
+// `run_id` 主語で workflow run を観測する read-only API。spec [05] により
+// 旧 `list_active_workflow_runs` / `list_completed_workflow_runs` /
+// `list_workflow_runs_for_worktree` / `get_workflow_execution_log` /
+// `get_workflow_execution_state` を破壊的に置換する。
 
-#[tauri::command]
-pub async fn get_workflow_execution_log(
-    app: tauri::AppHandle,
-    run_id: String,
-) -> Result<Vec<WorkflowEvent>, String> {
-    validate_run_id(&run_id)?;
-    let data_dir = resolve_data_dir(&app)?;
-    let event_log = WorkflowEventLog::new(&data_dir);
-    tokio::task::spawn_blocking(move || event_log.read_log(&run_id))
-        .await
-        .map_err(|e| format!("task join error: {e}"))?
+/// [05] worktree-scoped 認可境界: run metadata の `worktree_path` が caller の
+/// 認可済み (= 既存 managed worktree) のいずれかに合致するかを既存 helper
+/// `canonicalize_managed_worktree_path` で検証する。合致しない場合は `Ok(None)`
+/// として返し（not-found と同表現で存在情報を漏らさない）、observation 経路を
+/// 当該 caller から閉じる（spec [05] L104-108 観測経路の認可境界 / L182
+/// worktree-scoped Tauri 認証依拠）。
+async fn authorize_run_for_caller(
+    engine: &Arc<WorkflowEngine>,
+    config: &Arc<AppConfig>,
+    run_id: &str,
+) -> Result<Option<WorkflowRunSummary>, String> {
+    let Some(summary) = engine.get_run(run_id).await else {
+        return Ok(None);
+    };
+    match super::worktree::canonicalize_managed_worktree_path(
+        config.clone(),
+        summary.worktree_path.clone(),
+    )
+    .await
+    {
+        Ok(_) => Ok(Some(summary)),
+        Err(_) => Ok(None),
+    }
 }
 
+/// [05] read-only API: 過去 / 進行中の workflow run 一覧を返す。
+/// `worktree_path` は必須。caller の認可済み worktree のみを対象にすることで
+/// 別 worktree の run を観測できる経路を閉じる（spec [05] L104-108 観測経路の
+/// 認可境界）。`status` は optional な filter。
 #[tauri::command]
-pub async fn get_workflow_execution_state(
+pub async fn list_workflow_runs(
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    config: tauri::State<'_, Arc<AppConfig>>,
+    status: Option<String>,
+    worktree_path: String,
+) -> Result<Vec<WorkflowRunSummary>, String> {
+    let status = match status.as_deref() {
+        None | Some("") => None,
+        Some("active") => Some(RunStatusFilter::Active),
+        Some("terminal") => Some(RunStatusFilter::Terminal),
+        Some(other) => return Err(format!("Invalid status filter: {other}")),
+    };
+    let worktree_path =
+        super::worktree::canonicalize_managed_worktree_path(config.inner().clone(), worktree_path)
+            .await?;
+    Ok(engine
+        .list_runs(RunListFilter {
+            status,
+            worktree_path: Some(worktree_path),
+        })
+        .await)
+}
+
+/// [05] read-only API: 単一 run の summary metadata を返す。
+/// active / terminal のいずれであっても返す。該当 run なし、または run の
+/// worktree_path が caller の認可済み worktree に合致しない場合は `Ok(None)`
+/// （spec [05] L104-108 / L182）。
+#[tauri::command]
+pub async fn get_workflow_run(
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    config: tauri::State<'_, Arc<AppConfig>>,
+    run_id: String,
+) -> Result<Option<WorkflowRunSummary>, String> {
+    validate_run_id(&run_id)?;
+    authorize_run_for_caller(engine.inner(), config.inner(), &run_id).await
+}
+
+/// [05] read-only API: 指定 run の event log を返す。
+/// `workflow_logs/{run_id}.ndjson` を engine 一次 owner の log source として読む。
+/// 該当 run なし、または認可不一致は `None`（spec [05] L104-108 / L182）。
+#[tauri::command]
+pub async fn get_workflow_run_log(
     app: tauri::AppHandle,
-    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
-    open_tabs: tauri::State<'_, Arc<OpenTabRegistry>>,
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    config: tauri::State<'_, Arc<AppConfig>>,
+    run_id: String,
+) -> Result<Option<Vec<WorkflowEvent>>, String> {
+    get_workflow_run_log_inner(&app, engine.inner(), config.inner(), run_id).await
+}
+
+/// [05] generic 入口: テストで MockRuntime AppHandle を渡せるように runtime を generic 化する
+/// 内部経路。`#[tauri::command]` 側は Wry に固定して本関数に委譲する。
+async fn get_workflow_run_log_inner<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    engine: &Arc<WorkflowEngine>,
+    config: &Arc<AppConfig>,
+    run_id: String,
+) -> Result<Option<Vec<WorkflowEvent>>, String> {
+    validate_run_id(&run_id)?;
+    if authorize_run_for_caller(engine, config, &run_id)
+        .await?
+        .is_none()
+    {
+        return Ok(None);
+    }
+    let data_dir = resolve_data_dir(app)?;
+    let event_log = WorkflowEventLog::new(&data_dir);
+    let events = tokio::task::spawn_blocking(move || event_log.read_log(&run_id))
+        .await
+        .map_err(|e| format!("task join error: {e}"))??;
+    Ok(Some(events))
+}
+
+/// [05] read-only API: 指定 run の現在 state を返す。
+/// NDJSON event log から `reconstruct_state_from_events` で投影する。
+///
+/// 観測結果の露出範囲境界（spec [05]）に従い、戻り値は engine が一次 owner として
+/// 保持している event log / state の純粋投影のみを含む。`AgentProcessMap` /
+/// `OpenTabRegistry` 由来の runtime_active / tab_open enrichment は read-only API
+/// 経路では含めない（同種情報は live emission 経路の `WorkflowStateChanged` event を
+/// 通じて UI に届ける）。
+///
+/// 認可不一致は `None`（spec [05] L104-108 / L182）。
+#[tauri::command]
+pub async fn get_workflow_run_state(
+    app: tauri::AppHandle,
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    config: tauri::State<'_, Arc<AppConfig>>,
+    run_id: String,
+) -> Result<Option<WorkflowStateView>, String> {
+    get_workflow_run_state_inner(&app, engine.inner(), config.inner(), run_id).await
+}
+
+/// [05] generic 入口: テストで MockRuntime AppHandle を渡せるように runtime を generic 化する
+/// 内部経路。`#[tauri::command]` 側は Wry に固定して本関数に委譲する。
+async fn get_workflow_run_state_inner<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    engine: &Arc<WorkflowEngine>,
+    config: &Arc<AppConfig>,
     run_id: String,
 ) -> Result<Option<WorkflowStateView>, String> {
     validate_run_id(&run_id)?;
-    let data_dir = resolve_data_dir(&app)?;
+    if authorize_run_for_caller(engine, config, &run_id)
+        .await?
+        .is_none()
+    {
+        return Ok(None);
+    }
+    let data_dir = resolve_data_dir(app)?;
     let state = tokio::task::spawn_blocking(move || {
         let event_log = WorkflowEventLog::new(&data_dir);
         let events = event_log.read_log(&run_id)?;
         // [04] schema 境界: 復元は `RunStarted.workflow_definition` snapshot 経由のみ。
-        // 旧 NDJSON（workflow_definition フィールドを欠く / 旧 shape）は新 schema で
-        // deserialize できず、本ルートには到達しない（[02] で互換破棄）。snapshot 抽出は
-        // `reconstruct_state_from_events` の内部不変条件として閉じ込めてある。
         super::event_projection::reconstruct_state_from_events(&run_id, &events)
     })
     .await
     .map_err(|e| format!("task join error: {e}"))??;
-    match state {
-        Some(state) => Ok(Some(
-            crate::workflow_state_events::build_workflow_state_view(
-                state,
-                handles.inner(),
-                open_tabs.inner(),
-            )
-            .await,
-        )),
-        None => Ok(None),
-    }
+    Ok(state.map(|state| {
+        WorkflowStateView::from_parts(
+            crate::workflow_state_presenter::workflow_state_to_view(state),
+            std::collections::HashMap::new(),
+        )
+    }))
 }
 
 // ---- ファセットCRUDコマンド ----
@@ -809,37 +936,6 @@ pub async fn render_facet_preview(
 }
 
 // ---- Run Store / WorkflowRun コマンド ----
-
-/// 進行中（active）の workflow run 一覧を返す。
-#[tauri::command]
-pub async fn list_active_workflow_runs(
-    engine: tauri::State<'_, Arc<WorkflowEngine>>,
-) -> Result<Vec<WorkflowRunSummary>, String> {
-    Ok(engine.list_active_runs().await)
-}
-
-/// 終了済み（completed / failed / aborted）の workflow run 一覧を返す。
-/// `workflow_runs/{run_id}.json` を走査し、active set に含まれるものは除外する。
-/// 破損 metadata エントリは warn ログのうえスキップする。
-#[tauri::command]
-pub async fn list_completed_workflow_runs(
-    engine: tauri::State<'_, Arc<WorkflowEngine>>,
-) -> Result<Vec<WorkflowRunSummary>, String> {
-    Ok(engine.list_completed_runs().await)
-}
-
-/// 指定 worktree の active / terminal workflow run 一覧を返す。
-#[tauri::command]
-pub async fn list_workflow_runs_for_worktree(
-    engine: tauri::State<'_, Arc<WorkflowEngine>>,
-    config: tauri::State<'_, Arc<AppConfig>>,
-    worktree_path: String,
-) -> Result<Vec<WorkflowRunSummary>, String> {
-    let worktree_path =
-        super::worktree::canonicalize_managed_worktree_path(config.inner().clone(), worktree_path)
-            .await?;
-    Ok(engine.list_runs_for_worktree(&worktree_path).await)
-}
 
 /// worktree_path から active な run_id を解決する（双方向 lookup の一方向）。
 #[tauri::command]
@@ -1663,8 +1759,9 @@ mod tests {
     /// Spec issues-1011 finding 12: command 入口の `validate_run_id` は path traversal や
     /// 形式不正な run_id を拒否し、後段の Run Store / engine に到達させない。
     /// abort_workflow / get_workflow_state / approve_workflow_step /
-    /// get_workflow_execution_log / get_workflow_execution_state / resolve_worktree_by_run
-    /// の全 command で共通に使われるため、入力種別ごとに受理/拒否を一括で担保する。
+    /// get_workflow_run / get_workflow_run_log / get_workflow_run_state /
+    /// resolve_worktree_by_run の全 command で共通に使われるため、入力種別ごとに
+    /// 受理/拒否を一括で担保する。
     #[test]
     fn validate_run_id_table_accepts_uuid_and_rejects_invalid_inputs() {
         // 受理: 正規 UUID（生成値）と既知サンプル
@@ -2512,5 +2609,472 @@ mod tests {
         let result = simulate_save_workflow(dir, &renamed, Some("wf-a"));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("既に存在します"));
+    }
+
+    // ---- [05] read-only Run 観測 API: Tauri command 境界の直接テスト ----
+
+    fn read_only_test_uuid(seed: u8) -> String {
+        uuid::Uuid::from_bytes([seed; 16]).to_string()
+    }
+
+    fn make_read_only_run(
+        run_id: &str,
+        workflow_name: &str,
+        worktree: &str,
+        status: RunStatus,
+        started_at: f64,
+    ) -> crate::workflow::run::WorkflowRun {
+        crate::workflow::run::WorkflowRun {
+            run_id: run_id.to_string(),
+            workflow_name: workflow_name.to_string(),
+            task: None,
+            status,
+            worktree_path: worktree.to_string(),
+            chat_session_id: None,
+            current_node_name: None,
+            trigger_source: TriggerSource::DesktopUi,
+            started_at,
+            updated_at: started_at,
+            completed_at: if status.is_terminal() {
+                Some(started_at + 1.0)
+            } else {
+                None
+            },
+            error_reason: None,
+        }
+    }
+
+    fn write_read_only_run(data_dir: &Path, run: &crate::workflow::run::WorkflowRun) {
+        let runs_dir = data_dir.join("workflow_runs");
+        std::fs::create_dir_all(&runs_dir).unwrap();
+        let path = runs_dir.join(format!("{}.json", run.run_id));
+        let json = serde_json::to_string_pretty(run).unwrap();
+        std::fs::write(path, json).unwrap();
+    }
+
+    fn make_read_only_app() -> (AdapterTestApp, Arc<WorkflowEngine>, std::path::PathBuf) {
+        let app = make_adapter_app();
+        let engine = make_adapter_engine();
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        app.manage(engine.clone());
+        (app, engine, data_dir)
+    }
+
+    /// [05] worktree-scoped 認可境界のテスト用 fixture: 実 git repo + worktree を作り、
+    /// `AppConfig.last_repo_paths` に親 repo を登録する。戻り値は test app / engine /
+    /// data_dir / canonical worktree path / TempDir guards（lifetime 保持用）。
+    fn make_read_only_app_with_managed_worktree() -> (
+        AdapterTestApp,
+        Arc<WorkflowEngine>,
+        std::path::PathBuf,
+        String,
+        TempDir,
+        TempDir,
+    ) {
+        let (app, engine, data_dir) = make_read_only_app();
+        let repo_parent = TempDir::new().unwrap();
+        let worktree_parent = TempDir::new().unwrap();
+        let repo_path = repo_parent.path().join("repo");
+        std::fs::create_dir(&repo_path).unwrap();
+        let repo = git2::Repository::init(&repo_path).unwrap();
+        std::fs::write(repo_path.join("README.md"), "test\n").unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new("README.md")).unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+        let worktree_path = worktree_parent.path().join("managed-wt");
+        repo.worktree("managed-wt", &worktree_path, None).unwrap();
+        let canonical = worktree_path.canonicalize().unwrap();
+        let canonical_str = canonical.to_string_lossy().to_string();
+        app.state::<Arc<AppConfig>>()
+            .with_config_mut(|config| {
+                config.app.last_repo_paths = vec![repo_path.to_string_lossy().to_string()];
+                Ok(())
+            })
+            .unwrap();
+        (
+            app,
+            engine,
+            data_dir,
+            canonical_str,
+            repo_parent,
+            worktree_parent,
+        )
+    }
+
+    /// Spec [05] Rule: 外部 caller は run_id を主語として workflow run 一覧を観測できる。
+    /// `list_workflow_runs` Tauri command 経路が active を先頭・terminal を後続として
+    /// 並び替え、status filter が機能することを直接検証する。
+    ///
+    /// 観測経路の認可境界（spec [05] L104-108 / L182）として `worktree_path` は必須で、
+    /// caller の認可済み managed worktree のみを対象にする。
+    ///
+    /// active run は in-memory map + metadata file の両方に存在する境界状態であるため、
+    /// `RunStore::register_active` 経由で投入する。terminal run はメタデータファイル
+    /// のみに投入し、`list_completed` が拾い上げることを検証する。
+    #[tokio::test]
+    async fn list_workflow_runs_command_returns_active_first_filtered_by_status() {
+        let (app, engine, data_dir, worktree_path, _r, _w) =
+            make_read_only_app_with_managed_worktree();
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let active_id = read_only_test_uuid(1);
+        let done_id = read_only_test_uuid(2);
+        engine
+            .run_store()
+            .register_active(make_read_only_run(
+                &active_id,
+                "wf-active",
+                &worktree_path,
+                RunStatus::Running,
+                200.0,
+            ))
+            .await
+            .expect("register_active must succeed");
+        write_read_only_run(
+            &data_dir,
+            &make_read_only_run(
+                &done_id,
+                "wf-done",
+                &worktree_path,
+                RunStatus::Completed,
+                100.0,
+            ),
+        );
+
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let all = list_workflow_runs(engine_state, config_state, None, worktree_path.clone())
+            .await
+            .expect("list_workflow_runs must succeed");
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].status, RunStatus::Running);
+        assert_eq!(all[1].status, RunStatus::Completed);
+
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let terminal = list_workflow_runs(
+            engine_state,
+            config_state,
+            Some("terminal".to_string()),
+            worktree_path.clone(),
+        )
+        .await
+        .expect("terminal filter must succeed");
+        assert_eq!(terminal.len(), 1);
+        assert_eq!(terminal[0].run_id, done_id);
+
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let bad = list_workflow_runs(
+            engine_state,
+            config_state,
+            Some("garbage".to_string()),
+            worktree_path.clone(),
+        )
+        .await;
+        assert!(bad.is_err(), "invalid status filter must be rejected");
+    }
+
+    /// Spec [05] Rule: 観測経路は API と CLI で等価な手段を提供する。
+    /// `list_workflow_runs` の `worktree_path` 入力は `canonicalize_managed_worktree_path`
+    /// で正規化されたうえで filter に渡されるため、末尾 `/` 付きや `.` を含む形で
+    /// 同一 managed worktree を指定しても、canonical 表現で永続化された run と一致する。
+    /// CLI 経路と同じ `normalize_worktree_filter_path` を経由する境界を直接検証する。
+    #[tokio::test]
+    async fn list_workflow_runs_canonicalizes_worktree_path_filter() {
+        let (app, engine, data_dir, canonical_str, _r, _w) =
+            make_read_only_app_with_managed_worktree();
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+
+        // canonical な worktree_path で run を 1 件、別 worktree で run を 1 件登録する。
+        let target_id = read_only_test_uuid(40);
+        let other_id = read_only_test_uuid(41);
+        engine
+            .run_store()
+            .register_active(make_read_only_run(
+                &target_id,
+                "wf-target",
+                &canonical_str,
+                RunStatus::Running,
+                200.0,
+            ))
+            .await
+            .expect("register_active for target must succeed");
+        write_read_only_run(
+            &data_dir,
+            &make_read_only_run(
+                &other_id,
+                "wf-other",
+                "/wt/other",
+                RunStatus::Completed,
+                100.0,
+            ),
+        );
+
+        // 末尾 `/` を付けて非 canonical な表現で filter を渡す。
+        let trailing = format!("{canonical_str}/");
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let runs = list_workflow_runs(engine_state, config_state, None, trailing)
+            .await
+            .expect("list_workflow_runs with trailing slash must canonicalize and match");
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].run_id, target_id);
+        assert_eq!(runs[0].worktree_path, canonical_str);
+
+        // managed worktree でない path は Err。
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let outside = TempDir::new().unwrap();
+        let bad = list_workflow_runs(
+            engine_state,
+            config_state,
+            None,
+            outside.path().to_string_lossy().to_string(),
+        )
+        .await;
+        assert!(
+            bad.is_err(),
+            "worktree_path outside managed worktrees must be rejected"
+        );
+    }
+
+    /// Spec [05] Rule: 観測経路は権限を持つ caller のみに開かれる。
+    /// Tauri API 経路では worktree-scoped 認可境界として
+    /// `canonicalize_managed_worktree_path` を経由するため、configured repo に紐づかない
+    /// worktree_path を渡した場合は観測結果が caller に伝わらない（Err として拒否される）。
+    /// 既存 `list_workflow_runs_command_canonicalizes_managed_worktree_filter` と相補的に
+    /// 観測経路ごとの unauthorized 経路を明示する境界テスト。
+    #[tokio::test]
+    async fn list_workflow_runs_rejects_unauthorized_worktree_observation() {
+        let (app, engine, data_dir) = make_read_only_app();
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+
+        // run は存在する。ただし caller が指定する worktree_path は
+        // configured repo に紐づかない（= 観測権限を持たない）ので Err として弾かれる。
+        let run_id = read_only_test_uuid(60);
+        write_read_only_run(
+            &data_dir,
+            &make_read_only_run(&run_id, "wf", "/wt/inside", RunStatus::Running, 100.0),
+        );
+
+        let outside = TempDir::new().unwrap();
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let result = list_workflow_runs(
+            engine_state,
+            config_state,
+            None,
+            outside.path().to_string_lossy().to_string(),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "unauthorized worktree_path must be rejected as Err (no observation leak)"
+        );
+    }
+
+    /// Spec [05] Rule: 指定 run の summary metadata を観測する。
+    /// Spec [05] Rule: 存在しない run_id は明示的に「該当 run なし」として扱われる。
+    /// Spec [05] L104-108 / L182: caller の認可済み worktree に紐づかない run は Ok(None)。
+    #[tokio::test]
+    async fn get_workflow_run_command_returns_summary_or_none() {
+        let (app, engine, data_dir, worktree_path, _r, _w) =
+            make_read_only_app_with_managed_worktree();
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let run_id = read_only_test_uuid(3);
+        write_read_only_run(
+            &data_dir,
+            &make_read_only_run(&run_id, "wf", &worktree_path, RunStatus::Running, 300.0),
+        );
+
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let found = get_workflow_run(engine_state, config_state, run_id.clone())
+            .await
+            .expect("get_workflow_run must succeed");
+        let found = found.expect("run must be found");
+        assert_eq!(found.run_id, run_id);
+        assert_eq!(found.worktree_path, worktree_path);
+        assert_eq!(found.status, RunStatus::Running);
+
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let missing = get_workflow_run(engine_state, config_state, read_only_test_uuid(99))
+            .await
+            .expect("get_workflow_run for unknown run_id must Ok(None)");
+        assert!(missing.is_none());
+
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let invalid = get_workflow_run(engine_state, config_state, "not-a-uuid".to_string()).await;
+        assert!(invalid.is_err(), "non-UUID run_id must be rejected");
+    }
+
+    /// Spec [05] L104-108 / L182 negative test: 認可境界として、run metadata の
+    /// worktree_path が caller の認可済み managed worktree に合致しない場合、
+    /// `get_workflow_run` / `get_workflow_run_log` / `get_workflow_run_state` は
+    /// いずれも `Ok(None)` を返し、存在する run の summary / log / state を
+    /// 未認可 caller に伝えない。
+    #[tokio::test]
+    async fn single_run_read_only_apis_reject_unauthorized_worktree_observation() {
+        let (app, engine, data_dir, _managed, _r, _w) = make_read_only_app_with_managed_worktree();
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+
+        // run は別 worktree に紐づく metadata で書かれている（未認可）。
+        let run_id = read_only_test_uuid(70);
+        let unauthorized_wt = "/wt/unauthorized";
+        write_read_only_run(
+            &data_dir,
+            &make_read_only_run(&run_id, "wf", unauthorized_wt, RunStatus::Running, 100.0),
+        );
+        let event_log = WorkflowEventLog::new(&data_dir);
+        event_log
+            .append(&WorkflowEvent::RunStarted {
+                run_id: run_id.clone(),
+                workflow_name: "wf".to_string(),
+                workflow_file_stem: "wf".to_string(),
+                worktree_path: unauthorized_wt.to_string(),
+                workflow_definition: Workflow {
+                    name: "wf".to_string(),
+                    description: "test".to_string(),
+                    builtin: false,
+                    nodes: vec![],
+                },
+                timestamp: 100.0,
+            })
+            .unwrap();
+
+        let engine_state = app.state::<Arc<WorkflowEngine>>();
+        let config_state = app.state::<Arc<AppConfig>>();
+        let summary = get_workflow_run(engine_state, config_state, run_id.clone())
+            .await
+            .expect("get_workflow_run must succeed");
+        assert!(
+            summary.is_none(),
+            "unauthorized run summary must not be observable"
+        );
+
+        let config_state = app.state::<Arc<AppConfig>>();
+        let log = get_workflow_run_log_inner(app.handle(), &engine, &config_state, run_id.clone())
+            .await
+            .expect("get_workflow_run_log must succeed");
+        assert!(
+            log.is_none(),
+            "unauthorized run event log must not be observable"
+        );
+
+        let config_state = app.state::<Arc<AppConfig>>();
+        let state =
+            get_workflow_run_state_inner(app.handle(), &engine, &config_state, run_id.clone())
+                .await
+                .expect("get_workflow_run_state must succeed");
+        assert!(
+            state.is_none(),
+            "unauthorized run state must not be observable"
+        );
+    }
+
+    /// Spec [05] Rule: 指定 run の event log を観測する。
+    /// `get_workflow_run_log` Tauri command が NDJSON から読み込んだ event 列を返す。
+    #[tokio::test]
+    async fn get_workflow_run_log_command_reads_persisted_ndjson() {
+        let (app, engine, data_dir, worktree_path, _r, _w) =
+            make_read_only_app_with_managed_worktree();
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let run_id = read_only_test_uuid(4);
+        write_read_only_run(
+            &data_dir,
+            &make_read_only_run(&run_id, "wf", &worktree_path, RunStatus::Completed, 400.0),
+        );
+        let event_log = WorkflowEventLog::new(&data_dir);
+        event_log
+            .append(&WorkflowEvent::RunStarted {
+                run_id: run_id.clone(),
+                workflow_name: "wf".to_string(),
+                workflow_file_stem: "wf".to_string(),
+                worktree_path: worktree_path.clone(),
+                workflow_definition: Workflow {
+                    name: "wf".to_string(),
+                    description: "test".to_string(),
+                    builtin: false,
+                    nodes: vec![],
+                },
+                timestamp: 400.0,
+            })
+            .unwrap();
+
+        let config_state = app.state::<Arc<AppConfig>>();
+        let events =
+            get_workflow_run_log_inner(app.handle(), &engine, &config_state, run_id.clone())
+                .await
+                .expect("get_workflow_run_log must succeed")
+                .expect("run must be found");
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], WorkflowEvent::RunStarted { .. }));
+
+        let config_state = app.state::<Arc<AppConfig>>();
+        let missing = get_workflow_run_log_inner(
+            app.handle(),
+            &engine,
+            &config_state,
+            read_only_test_uuid(98),
+        )
+        .await
+        .expect("get_workflow_run_log for unknown run_id must Ok(None)");
+        assert!(missing.is_none());
+    }
+
+    /// Spec [05] Rule: 指定 run の現在 state を観測する（event log からの純粋投影）。
+    /// 観測結果の露出範囲境界: AgentProcessMap / OpenTabRegistry 由来の runtime_active /
+    /// tab_open enrichment は含めない（戻り値の runtime_states は空）。
+    #[tokio::test]
+    async fn get_workflow_run_state_command_projects_state_without_runtime_enrichment() {
+        let (app, engine, data_dir, worktree_path, _r, _w) =
+            make_read_only_app_with_managed_worktree();
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let run_id = read_only_test_uuid(5);
+        write_read_only_run(
+            &data_dir,
+            &make_read_only_run(&run_id, "wf", &worktree_path, RunStatus::Running, 500.0),
+        );
+        let event_log = WorkflowEventLog::new(&data_dir);
+        event_log
+            .append(&WorkflowEvent::RunStarted {
+                run_id: run_id.clone(),
+                workflow_name: "adapter-boundary".to_string(),
+                workflow_file_stem: "adapter-boundary".to_string(),
+                worktree_path: worktree_path.clone(),
+                workflow_definition: approval_only_workflow(),
+                timestamp: 500.0,
+            })
+            .unwrap();
+
+        let config_state = app.state::<Arc<AppConfig>>();
+        let view =
+            get_workflow_run_state_inner(app.handle(), &engine, &config_state, run_id.clone())
+                .await
+                .expect("get_workflow_run_state must succeed")
+                .expect("state must be available");
+        assert_eq!(view.state.execution_id, run_id);
+        assert!(
+            view.runtime_states.is_empty(),
+            "read-only state view must not include runtime enrichment"
+        );
+
+        // 存在しない run_id は Ok(None)。
+        let config_state = app.state::<Arc<AppConfig>>();
+        let missing = get_workflow_run_state_inner(
+            app.handle(),
+            &engine,
+            &config_state,
+            read_only_test_uuid(97),
+        )
+        .await
+        .expect("unknown run must Ok(None)");
+        assert!(missing.is_none());
     }
 }

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -1292,22 +1292,42 @@ impl WorkflowEngine {
         self.run_store.resolve_worktree_by_run(run_id).await
     }
 
-    /// 進行中の WorkflowRun summary 一覧を返す（facade）。
-    pub async fn list_active_runs(&self) -> Vec<crate::workflow::run::WorkflowRunSummary> {
-        self.run_store.list_active().await
-    }
-
-    /// 終了済み WorkflowRun summary 一覧を返す（facade）。
-    pub async fn list_completed_runs(&self) -> Vec<crate::workflow::run::WorkflowRunSummary> {
-        self.run_store.list_completed().await
-    }
-
-    /// worktree_path に紐づく active / terminal WorkflowRun summary 一覧を返す（facade）。
-    pub async fn list_runs_for_worktree(
+    /// [05] read-only API: optional な status / worktree filter を適用した
+    /// run summary 一覧を返す（facade）。
+    pub async fn list_runs(
         &self,
-        worktree_path: &str,
+        filter: crate::workflow::run::RunListFilter,
     ) -> Vec<crate::workflow::run::WorkflowRunSummary> {
-        self.run_store.list_for_worktree(worktree_path).await
+        self.run_store.list_runs(filter).await
+    }
+
+    /// テスト専用 facade: active な run 一覧を取得する。
+    /// production 経路は `list_runs(RunListFilter { status: Some(Active), .. })` を使う。
+    #[cfg(test)]
+    pub async fn list_active_runs(&self) -> Vec<crate::workflow::run::WorkflowRunSummary> {
+        self.run_store
+            .list_runs(crate::workflow::run::RunListFilter {
+                status: Some(crate::workflow::run::RunStatusFilter::Active),
+                worktree_path: None,
+            })
+            .await
+    }
+
+    /// テスト専用 facade: terminal な run 一覧を取得する。
+    #[cfg(test)]
+    pub async fn list_completed_runs(&self) -> Vec<crate::workflow::run::WorkflowRunSummary> {
+        self.run_store
+            .list_runs(crate::workflow::run::RunListFilter {
+                status: Some(crate::workflow::run::RunStatusFilter::Terminal),
+                worktree_path: None,
+            })
+            .await
+    }
+
+    /// [05] read-only API: 単一 run の summary を取得する（facade）。
+    /// active map → terminal metadata file の順で lookup する。
+    pub async fn get_run(&self, run_id: &str) -> Option<crate::workflow::run::WorkflowRunSummary> {
+        self.run_store.get_run(run_id).await
     }
 
     /// Run Store の永続化ディレクトリを設定する（アプリ起動時の setup から呼ぶ）。
@@ -1689,25 +1709,48 @@ impl WorkflowEngine {
         Ok(run_id)
     }
 
-    /// [04] Command / Event Boundary: 全 typed command の単一入口。
+    /// [05] adapter-facing 拒否境界: 外部 adapter（Tauri command / CLI / agent path）
+    /// 向けの単一入口。internal-only な `CompleteNode` / `FailNode` を外部 caller から
+    /// 組み立てて到達した場合は内部不整合として `Err` に変換する（spec [05] internal
+    /// command の非公開境界）。internal variant 受理境界は `dispatch` 側に集約。
     ///
-    /// UI / Tauri command / 内部呼び出し元は、本メソッドだけを通じて engine state を
-    /// 変化させる。各 variant は既存 handler（`start_workflow` / `abort_workflow_by_run_id`
-    /// / `handle_approval`）に委譲する。`StartRun` の `worktree_path` は注入された
-    /// `ManagedWorktreeResolver` で正規化し、engine core は AppConfig / Git worktree 列挙を
-    /// 直接知らない。
-    pub async fn dispatch<R: tauri::Runtime>(
+    /// engine 内部経路は `dispatch` を直接呼ぶ。本 wrapper は adapter からの外部入力
+    /// だけが通る非公開境界専用とする。
+    pub async fn dispatch_external<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
         handles: &Arc<Mutex<AgentProcessMap>>,
         command: WorkflowCommand,
     ) -> Result<WorkflowCommandResult, WorkflowEngineError> {
-        self.dispatch_core(app, session_store, handles, command)
-            .await
+        if matches!(
+            command,
+            WorkflowCommand::CompleteNode { .. } | WorkflowCommand::FailNode { .. }
+        ) {
+            let run_id = match &command {
+                WorkflowCommand::CompleteNode { run_id, .. }
+                | WorkflowCommand::FailNode { run_id, .. } => run_id.clone(),
+                _ => unreachable!(),
+            };
+            return Err(WorkflowEngineError::ValidationError(format!(
+                "internal-only WorkflowCommand variant reached public dispatch for run {run_id}"
+            )));
+        }
+        self.dispatch(app, session_store, handles, command).await
     }
 
-    async fn dispatch_core<R: tauri::Runtime>(
+    /// [04] / [05] Command / Event Boundary: typed command の単一発火点。
+    ///
+    /// `WorkflowEngine::dispatch` は外部 4 variant (`StartRun` / `AbortRun` /
+    /// `ApproveNode` / `RejectNode`) と internal 2 variant (`CompleteNode` /
+    /// `FailNode`) を同一の typed command handler で処理する。internal node 完了 /
+    /// 失敗の event 発行点もここに集約される（spec [05] L22-24, L145, L186）。
+    ///
+    /// 外部 adapter（Tauri command / CLI / agent path）は `dispatch_external` 経由で
+    /// internal variant を拒否してから本関数に委譲する。engine 内部からは内部経路の
+    /// 発火点として `dispatch` を直接呼び、internal variant も含めた typed command
+    /// を受理する。
+    pub async fn dispatch<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
         session_store: &Arc<SessionStore>,
@@ -1819,6 +1862,295 @@ impl WorkflowEngine {
                 .await?;
                 Ok(WorkflowCommandResult::Accepted)
             }
+            // [05] internal-only variant の commit handler。public `dispatch` 経由では
+            // 事前に拒否されるが、`dispatch_core` を engine 内部から typed command 経由で
+            // 呼び出した場合に到達する（spec [05]: dispatch を内部 node 完了 / 失敗の
+            // 発火点とし、event 発行点を typed command 経路に集約）。state mutation +
+            // event commit は `dispatch_internal_node_command` に委譲し、commit 失敗時は
+            // engine state を一括復元する rollback 境界に揃える。
+            command @ WorkflowCommand::CompleteNode { .. }
+            | command @ WorkflowCommand::FailNode { .. } => {
+                self.commit_internal_node_command(app, session_store, command)
+                    .await?;
+                Ok(WorkflowCommandResult::Accepted)
+            }
+        }
+    }
+
+    /// [05] `WorkflowCommand::CompleteNode` / `FailNode` 用の commit 境界。
+    ///
+    /// `dispatch` から呼ばれる engine 内部の typed command handler であり、外部
+    /// adapter からは `dispatch_external` の拒否境界で到達不能。state mutation +
+    /// `WorkflowEvent::NodeCompleted` / `NodeFailed` 発行を
+    /// `dispatch_internal_node_command` に集約し、append 失敗 / Run Store sync 失敗 /
+    /// ChatSession persist 失敗のいずれでも `commit_required_events` 経由で engine
+    /// state と Run Store snapshot を `snapshot_before` で一括復元する（spec [05]
+    /// commit_required_events 基盤の rollback 可能な共通 commit 境界 / silent error
+    /// 禁止）。
+    async fn commit_internal_node_command<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        command: WorkflowCommand,
+    ) -> Result<(), WorkflowEngineError> {
+        let run_id = match &command {
+            WorkflowCommand::CompleteNode { run_id, .. }
+            | WorkflowCommand::FailNode { run_id, .. } => run_id.clone(),
+            _ => {
+                return Err(WorkflowEngineError::ValidationError(
+                    "commit_internal_node_command received non-internal variant".to_string(),
+                ));
+            }
+        };
+
+        // lock + snapshot + mutation を atomic に実行: dispatch_internal_node_command の
+        // state mutation は snapshot 上に適用され、event を返した時点で engine.executions
+        // の対象 exec にも反映する。
+        let (chat_session_id, mutated_snapshot, exec_snapshot_before, event) = {
+            let mut execs = self.executions.lock().await;
+            let exec = execs
+                .get_mut(&run_id)
+                .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(run_id.clone()))?;
+            let exec_snapshot_before = exec.clone();
+            let mut snapshot = exec.to_workflow_state();
+            let event =
+                Self::dispatch_internal_node_command(&mut snapshot, command).inspect_err(|_e| {
+                    // commit 失敗: engine state は未変更（snapshot のみ mutate）。
+                    *exec = exec_snapshot_before.clone();
+                })?;
+            // snapshot の state / updated_at を live exec に書き戻す。
+            exec.state = snapshot.state.clone();
+            exec.updated_at = snapshot.updated_at;
+            let chat_session_id = exec.chat_session_id.clone();
+            (chat_session_id, snapshot, exec_snapshot_before, event)
+        };
+
+        // [05] commit_required_events 基盤の共通 commit 境界:
+        // RunStore sync → ChatSession persist → event log append の順序と
+        // rollback 方針を一箇所に集約する。いずれかの失敗時は engine state と
+        // Run Store snapshot を `exec_snapshot_before` で一括復元する。
+        let run_store_snapshot_before = self.run_store.active_run_snapshot(&run_id).await;
+        self.commit_required_events(
+            app,
+            session_store,
+            RequiredEventCommit {
+                run_id: &run_id,
+                chat_session_id: &chat_session_id,
+                snapshot_for_commit: &mutated_snapshot,
+                snapshot_before: exec_snapshot_before,
+                run_store_snapshot_before,
+                required_events: vec![event],
+                append_error_context: "internal node command event append failed",
+            },
+        )
+        .await
+    }
+
+    /// [05] internal dispatch path: engine 内部の node 完了 / 失敗 typed command の
+    /// 単一 commit 関数。`WorkflowCommand::CompleteNode` / `FailNode` を受け取り、
+    /// 対応する state mutation を snapshot に適用したうえで
+    /// `WorkflowEvent::NodeCompleted` / `NodeFailed` を返す（spec [05]: 発行点が
+    /// typed command の経路に集約される / state mutation と event 発行を同一 commit
+    /// 境界に集約）。
+    ///
+    /// 入力型は `WorkflowCommand` だが、internal variant 以外（外部 4 variant）が
+    /// 流入した場合は `ValidationError` を返す。外部 adapter からの組み立て経路は
+    /// 提供せず、`pub(crate)` で配置することで internal-only な commit 境界を担保する
+    /// （spec [05] internal command の非公開境界）。
+    ///
+    /// state mutation の責務は以下のとおり本関数に集約される:
+    ///
+    /// - `CompleteNode`: 上流コードが構築した `step_history` 末尾 entry が当該 command の
+    ///   effect（node_name / timestamp / result / session_id / token_usage /
+    ///   structured_output / run_index）と一致することを検証し、不一致時は
+    ///   `ValidationError` を返す。あわせて command の run_id / workflow_name が
+    ///   snapshot.execution_id / workflow_name と一致することも検証する（spec [05]
+    ///   commit 境界: snapshot が command effect を含むことの確証 / payload を
+    ///   snapshot と整合検証する厳格化）。
+    /// - `FailNode`: command の run_id / workflow_name / node_name を snapshot と
+    ///   照合した上で、snapshot.state が `Failed { .. }` でなければ
+    ///   `Failed { reason }` に遷移させ、updated_at を反映する。
+    pub(crate) fn dispatch_internal_node_command(
+        snapshot: &mut WorkflowState,
+        command: WorkflowCommand,
+    ) -> Result<WorkflowEvent, WorkflowEngineError> {
+        Self::apply_internal_node_command_state_mutation(snapshot, &command)?;
+        Self::map_internal_node_command_to_event(command)
+    }
+
+    /// [05] internal command → state mutation の commit。`dispatch_internal_node_command`
+    /// 内部からのみ呼ばれる。
+    ///
+    /// - `CompleteNode`: 上流の `make_step_history_entry` 経由で push 済みの step_history
+    ///   末尾 entry が当該 command の全 effect 列と一致するかを検証する。さらに command
+    ///   の run_id / workflow_name を snapshot の execution_id / workflow_name と
+    ///   照合する。不一致時は `ValidationError` を返し、command と snapshot の同期境界
+    ///   が崩れたことを呼出側に伝える（spec [05] commit 境界: snapshot mutation と
+    ///   event 発行を同一 commit に集約 / 二重適用は不可 / payload を snapshot と
+    ///   照合）。
+    /// - `FailNode`: command の run_id / workflow_name / node_name を snapshot と
+    ///   照合した上で、snapshot.state が `Failed { .. }` でなければ
+    ///   `Failed { reason }` に遷移させ、updated_at を反映する。既に Failed の場合は
+    ///   idempotent な no-op。
+    fn apply_internal_node_command_state_mutation(
+        snapshot: &mut WorkflowState,
+        command: &WorkflowCommand,
+    ) -> Result<(), WorkflowEngineError> {
+        match command {
+            WorkflowCommand::CompleteNode {
+                run_id,
+                workflow_name,
+                node_name,
+                result,
+                session_id,
+                token_usage,
+                structured_output,
+                run_index,
+                timestamp,
+            } => {
+                if run_id != &snapshot.execution_id {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode run_id mismatch: command='{run_id}', snapshot='{}'",
+                        snapshot.execution_id
+                    )));
+                }
+                if workflow_name != &snapshot.workflow_name {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode workflow_name mismatch: command='{workflow_name}', snapshot='{}'",
+                        snapshot.workflow_name
+                    )));
+                }
+                let Some(last_entry) = snapshot.step_history.last() else {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode for node '{node_name}' but snapshot.step_history is empty"
+                    )));
+                };
+                if last_entry.step_name != *node_name {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode node mismatch: command='{node_name}', snapshot last='{}'",
+                        last_entry.step_name
+                    )));
+                }
+                if (last_entry.completed_at - *timestamp).abs() > f64::EPSILON {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode timestamp mismatch for node '{node_name}': command={timestamp}, snapshot={}",
+                        last_entry.completed_at
+                    )));
+                }
+                if last_entry.result != *result {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode result mismatch for node '{node_name}'"
+                    )));
+                }
+                if last_entry.session_id != *session_id {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode session_id mismatch for node '{node_name}'"
+                    )));
+                }
+                if last_entry.token_usage != *token_usage {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode token_usage mismatch for node '{node_name}'"
+                    )));
+                }
+                if last_entry.structured_output != *structured_output {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode structured_output mismatch for node '{node_name}'"
+                    )));
+                }
+                if Some(last_entry.run_index) != *run_index {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "CompleteNode run_index mismatch for node '{node_name}': command={run_index:?}, snapshot={}",
+                        last_entry.run_index
+                    )));
+                }
+                Ok(())
+            }
+            WorkflowCommand::FailNode {
+                run_id,
+                workflow_name,
+                node_name,
+                reason,
+                timestamp,
+            } => {
+                if run_id != &snapshot.execution_id {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "FailNode run_id mismatch: command='{run_id}', snapshot='{}'",
+                        snapshot.execution_id
+                    )));
+                }
+                if workflow_name != &snapshot.workflow_name {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "FailNode workflow_name mismatch: command='{workflow_name}', snapshot='{}'",
+                        snapshot.workflow_name
+                    )));
+                }
+                if *node_name != snapshot.current_step_name {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "FailNode node_name mismatch: command='{node_name}', snapshot='{}'",
+                        snapshot.current_step_name
+                    )));
+                }
+                if !matches!(snapshot.state, WorkflowExecutionState::Failed { .. }) {
+                    snapshot.state = WorkflowExecutionState::Failed {
+                        reason: reason.clone(),
+                    };
+                    snapshot.updated_at = *timestamp;
+                }
+                Ok(())
+            }
+            _ => Err(WorkflowEngineError::ValidationError(
+                "dispatch_internal_node_command received non-internal variant".to_string(),
+            )),
+        }
+    }
+
+    /// [05] internal command → event 射影。
+    ///
+    /// `WorkflowCommand::CompleteNode` / `FailNode` から対応する
+    /// `WorkflowEvent::NodeCompleted` / `NodeFailed` を組み立てる純粋関数。emission
+    /// 経路は `dispatch_internal_node_command` を入口として用い、本関数を直接呼ぶ
+    /// 経路は持たない（spec [05]: 発行点が typed command の単一経路に集約される）。
+    fn map_internal_node_command_to_event(
+        command: WorkflowCommand,
+    ) -> Result<WorkflowEvent, WorkflowEngineError> {
+        match command {
+            WorkflowCommand::CompleteNode {
+                run_id,
+                workflow_name,
+                node_name,
+                result,
+                session_id,
+                token_usage,
+                structured_output,
+                run_index,
+                timestamp,
+            } => Ok(WorkflowEvent::NodeCompleted {
+                run_id,
+                workflow_name,
+                node_name,
+                result,
+                session_id,
+                token_usage,
+                structured_output,
+                run_index,
+                timestamp,
+            }),
+            WorkflowCommand::FailNode {
+                run_id,
+                workflow_name,
+                node_name,
+                reason,
+                timestamp,
+            } => Ok(WorkflowEvent::NodeFailed {
+                run_id,
+                workflow_name,
+                node_name,
+                reason,
+                timestamp,
+            }),
+            _ => Err(WorkflowEngineError::ValidationError(
+                "map_internal_node_command_to_event received non-internal variant".to_string(),
+            )),
         }
     }
 
@@ -1889,7 +2221,7 @@ impl WorkflowEngine {
         struct TurnCommit {
             outcome: StepOutcome,
             required_events: Vec<WorkflowEvent>,
-            rollback_snapshot: Option<(String, WorkflowExecution)>,
+            rollback_snapshot: (String, WorkflowExecution),
         }
 
         // 判定 + 状態変更を原子的に実行（AutoEvaluate以外）
@@ -1924,6 +2256,7 @@ impl WorkflowEngine {
                     if exec.is_terminal() {
                         return Ok(());
                     }
+                    let snapshot_before = exec.clone();
                     let entry = exec.make_step_history_entry(
                         Some(format!("error (exit_code: {})", exit_code)),
                         None,
@@ -1940,7 +2273,7 @@ impl WorkflowEngine {
                     Ok(TurnCommit {
                         outcome: StepOutcome::Persist(exec.to_workflow_state()),
                         required_events: Vec::new(),
-                        rollback_snapshot: None,
+                        rollback_snapshot: (exec.id.clone(), snapshot_before),
                     })
                 }
                 TurnCompleteAction::WaitApproval => {
@@ -1960,7 +2293,7 @@ impl WorkflowEngine {
                             node_name,
                             timestamp: exec.updated_at,
                         }],
-                        rollback_snapshot: Some((exec.id.clone(), snapshot_before)),
+                        rollback_snapshot: (exec.id.clone(), snapshot_before),
                     })
                 }
                 TurnCompleteAction::UnexpectedNodeType {
@@ -1970,6 +2303,7 @@ impl WorkflowEngine {
                     if exec.is_terminal() {
                         return Ok(());
                     }
+                    let snapshot_before = exec.clone();
                     let reason = format!(
                         "Workflow engine reached turn_complete for unexpected node type {:?} at step '{}' (this should have been rejected upstream)",
                         node_type, step_name
@@ -1981,7 +2315,7 @@ impl WorkflowEngine {
                     Ok(TurnCommit {
                         outcome: StepOutcome::Persist(exec.to_workflow_state()),
                         required_events: Vec::new(),
-                        rollback_snapshot: None,
+                        rollback_snapshot: (exec.id.clone(), snapshot_before),
                     })
                 }
                 TurnCompleteAction::AutoEvaluate { rules, step_name } => Err((rules, step_name)),
@@ -1991,6 +2325,7 @@ impl WorkflowEngine {
 
         match action_or_outcome {
             Ok(commit) => {
+                let (_, snapshot_before) = commit.rollback_snapshot.clone();
                 if commit.required_events.is_empty() {
                     self.execute_outcome(
                         app,
@@ -1999,6 +2334,7 @@ impl WorkflowEngine {
                         &worktree_path,
                         &chat_session_id,
                         commit.outcome,
+                        snapshot_before,
                     )
                     .await
                 } else {
@@ -2010,7 +2346,7 @@ impl WorkflowEngine {
                         &chat_session_id,
                         commit.outcome,
                         commit.required_events,
-                        commit.rollback_snapshot,
+                        Some(commit.rollback_snapshot),
                     )
                     .await
                 }
@@ -2292,7 +2628,7 @@ impl WorkflowEngine {
         // 一括復元する。部分 rollback helper は使わない。
         let (
             chat_session_id,
-            outcome,
+            mut outcome,
             exec_snapshot_before,
             workflow_name_for_event,
             node_name_for_event,
@@ -2355,7 +2691,30 @@ impl WorkflowEngine {
             comment: event_comment,
             timestamp: approval_timestamp,
         };
-        let commit_events = Self::required_events_for_approval_commit(approval_event, &outcome);
+        // [05] silent error の禁止: required event 組立中に
+        // `dispatch_internal_node_command` の ValidationError 等が発生した場合は
+        // approval commit 境界として失敗扱いし、snapshot_before で engine state /
+        // Run Store / ChatSession を一括復元してから Err を返す。
+        let commit_events =
+            match Self::required_events_for_approval_commit(approval_event, &mut outcome) {
+                Ok(events) => events,
+                Err(e) => {
+                    let _ = self
+                        .rollback_command_mutation(
+                            app,
+                            session_store,
+                            CommandMutationRollback {
+                                run_id,
+                                chat_session_id: &chat_session_id,
+                                snapshot_before: exec_snapshot_before,
+                                run_store_snapshot_before,
+                                context: "approval required event build failed",
+                            },
+                        )
+                        .await;
+                    return Err(e);
+                }
+            };
         self.commit_required_events(
             app,
             session_store,
@@ -2677,11 +3036,15 @@ impl WorkflowEngine {
                             return Ok(());
                         } else {
                             // リトライ上限超過 → ワークフロー全体をFailed
-                            let (chat_session_id, snapshot, running_ids) = {
+                            // [05] commit 境界: terminal event は pre-commit batch で
+                            // append し、append 失敗時は engine state を mutation 直前
+                            // snapshot で一括復元する（post-persist warn 廃止）。
+                            let (chat_session_id, snapshot, running_ids, exec_snapshot_before) = {
                                 let mut execs = self.executions.lock().await;
                                 let exec = execs.get_mut(run_id).ok_or_else(|| {
                                     WorkflowEngineError::ExecutionNotFound(run_id.to_string())
                                 })?;
+                                let exec_snapshot_before = exec.clone();
                                 let chat_session_id = exec.chat_session_id.clone();
                                 let running_ids: Vec<String> = exec
                                     .parallel_run
@@ -2705,8 +3068,26 @@ impl WorkflowEngine {
                                     };
                                 exec.parallel_run = None;
                                 exec.updated_at = current_timestamp();
-                                (chat_session_id, exec.to_workflow_state(), running_ids)
+                                (
+                                    chat_session_id,
+                                    exec.to_workflow_state(),
+                                    running_ids,
+                                    exec_snapshot_before,
+                                )
                             };
+
+                            // [05] pre-commit: terminal event を先に append。失敗時は
+                            // engine state を snapshot_before で一括復元し Err を返す。
+                            if let Err(e) = self.write_terminal_log(app, &snapshot) {
+                                let mut execs = self.executions.lock().await;
+                                if let Some(exec) = execs.get_mut(run_id) {
+                                    *exec = exec_snapshot_before;
+                                }
+                                return Err(WorkflowEngineError::SessionStore(format!(
+                                    "contract failure terminal event append failed: {e}"
+                                )));
+                            }
+
                             if let Err(e) =
                                 self.sync_run_store_from_snapshot(run_id, &snapshot).await
                             {
@@ -2743,7 +3124,6 @@ impl WorkflowEngine {
                             persist_result?;
                             self.broadcast_state(app, worktree_path, snapshot.clone())
                                 .await;
-                            self.write_terminal_log(app, &snapshot);
                             self.cleanup_session_workflow_refs_by_run_id(&snapshot.execution_id)
                                 .await;
                             return Ok(());
@@ -2766,7 +3146,7 @@ impl WorkflowEngine {
         .await;
 
         // ロック内: 子ステップの状態更新 + 全完了チェック
-        let (chat_session_id, all_completed, outcome_opt) = {
+        let (chat_session_id, all_completed, outcome_opt, exec_snapshot_before) = {
             let mut execs = self.executions.lock().await;
             let exec = execs
                 .get_mut(run_id)
@@ -2777,6 +3157,10 @@ impl WorkflowEngine {
             }
 
             let chat_session_id = exec.chat_session_id.clone();
+            // [05] commit 境界: 子ステップ失敗 → workflow 全体 Failed の terminal event は
+            // pre-commit batch で append し、失敗時は engine state を snapshot_before で
+            // 一括復元する（post-persist warn 廃止）。snapshot は mutation 前にここで取得する。
+            let exec_snapshot_before = exec.clone();
             let Some(pr) = exec.parallel_run.as_mut() else {
                 return Ok(());
             };
@@ -2823,6 +3207,18 @@ impl WorkflowEngine {
                 let snapshot = exec.to_workflow_state();
                 drop(execs);
 
+                // [05] pre-commit: terminal event を先に append。失敗時は engine state
+                // を snapshot_before で一括復元し Err を返す。
+                if let Err(e) = self.write_terminal_log(app, &snapshot) {
+                    let mut execs = self.executions.lock().await;
+                    if let Some(exec) = execs.get_mut(run_id) {
+                        *exec = exec_snapshot_before;
+                    }
+                    return Err(WorkflowEngineError::SessionStore(format!(
+                        "parallel child failure terminal event append failed: {e}"
+                    )));
+                }
+
                 if let Err(e) = self.sync_run_store_from_snapshot(run_id, &snapshot).await {
                     self.rollback_execution_projection_after_run_store_sync_failure(
                         run_id, &snapshot,
@@ -2848,7 +3244,6 @@ impl WorkflowEngine {
                 persist_result?;
                 self.broadcast_state(app, worktree_path, snapshot.clone())
                     .await;
-                self.write_terminal_log(app, &snapshot);
                 self.cleanup_session_workflow_refs_by_run_id(&snapshot.execution_id)
                     .await;
                 return Ok(());
@@ -2908,7 +3303,12 @@ impl WorkflowEngine {
                 // まだ未完了の子がある → ブロードキャストのみ
                 exec.updated_at = current_timestamp();
                 let snapshot = exec.to_workflow_state();
-                (chat_session_id, false, Some(StepOutcome::Persist(snapshot)))
+                (
+                    chat_session_id,
+                    false,
+                    Some(StepOutcome::Persist(snapshot)),
+                    exec_snapshot_before,
+                )
             } else {
                 // 全完了 → 親ブロック名でstep_outputsに集約登録 + aggregate評価 + 遷移
                 let aggregate = pr.aggregate.clone();
@@ -3062,7 +3462,7 @@ impl WorkflowEngine {
 
                     Self::apply_advance(exec)
                 };
-                (chat_session_id, true, Some(outcome))
+                (chat_session_id, true, Some(outcome), exec_snapshot_before)
             }
         };
 
@@ -3075,6 +3475,7 @@ impl WorkflowEngine {
                     worktree_path,
                     &chat_session_id,
                     outcome,
+                    exec_snapshot_before,
                 )
                 .await?;
             } else {
@@ -3346,13 +3747,17 @@ impl WorkflowEngine {
                 }
                 // retry不可またはsession_idなし → Failed遷移
                 {
-                    let (chat_session_id, snapshot) = {
+                    let (chat_session_id, snapshot, snapshot_before, run_id) = {
                         let mut execs = self.executions.lock().await;
                         let exec =
                             find_by_worktree_mut(&mut execs, worktree_path).ok_or_else(|| {
                                 WorkflowEngineError::ExecutionNotFound(worktree_path.to_string())
                             })?;
                         let chat_session_id = exec.chat_session_id.clone();
+                        // [05] commit 境界: terminal event を required append にするため、
+                        // mutation 前の snapshot を捕捉して rollback target に揃える。
+                        let snapshot_before = exec.clone();
+                        let run_id = exec.id.clone();
                         let entry = exec.make_step_history_entry(
                             Some("contract_violation".to_string()),
                             None,
@@ -3374,22 +3779,59 @@ impl WorkflowEngine {
                             reason: fail_reason,
                         };
                         exec.updated_at = current_timestamp();
-                        (chat_session_id, exec.to_workflow_state())
-                    };
-                    let completed_step_session_ids = Self::completed_step_session_ids(&snapshot);
-                    let snapshot = self
-                        .persist_release_and_broadcast(
-                            app,
-                            session_store,
-                            handles,
-                            worktree_path,
-                            &chat_session_id,
-                            snapshot,
-                            &completed_step_session_ids,
+                        (
+                            chat_session_id,
+                            exec.to_workflow_state(),
+                            snapshot_before,
+                            run_id,
                         )
-                        .await?;
-                    self.write_terminal_log(app, &snapshot);
-                    self.cleanup_session_workflow_refs_by_run_id(&snapshot.execution_id)
+                    };
+
+                    // [05] commit_required_events 基盤の共通 commit 境界に統合:
+                    // terminal event 列 (NodeFailed + RunFailed) を required event として
+                    // append し、失敗時は engine state と Run Store snapshot を
+                    // snapshot_before で一括復元する（spec [05] atomic mutation 境界 /
+                    // best-effort warn 廃止）。
+                    let mut terminal_snapshot = snapshot.clone();
+                    let required_events =
+                        match Self::terminal_events_for_snapshot(&mut terminal_snapshot) {
+                            Ok(events) => events,
+                            Err(e) => {
+                                // event 構築失敗時は engine state を snapshot_before に復元する。
+                                let mut execs = self.executions.lock().await;
+                                if let Some(exec) = execs.get_mut(&run_id) {
+                                    *exec = snapshot_before;
+                                }
+                                return Err(e);
+                            }
+                        };
+                    let completed_step_session_ids = Self::completed_step_session_ids(&snapshot);
+                    let run_store_snapshot_before =
+                        self.run_store.active_run_snapshot(&run_id).await;
+                    self.commit_required_events(
+                        app,
+                        session_store,
+                        RequiredEventCommit {
+                            run_id: &run_id,
+                            chat_session_id: &chat_session_id,
+                            snapshot_for_commit: &snapshot,
+                            snapshot_before,
+                            run_store_snapshot_before,
+                            required_events,
+                            append_error_context: "contract violation terminal event append failed",
+                        },
+                    )
+                    .await?;
+                    self.release_completed_step_sessions(
+                        app,
+                        session_store,
+                        handles,
+                        &completed_step_session_ids,
+                    )
+                    .await;
+                    // terminal 系副作用: cleanup + broadcast。terminal event は append 済みのため
+                    // finalize_after_commit 側では write_terminal_events=false で二重 append を避ける。
+                    self.finalize_after_commit(app, &snapshot, worktree_path, false)
                         .await;
                     Ok(ContractCheckResult::Failed)
                 }
@@ -3751,7 +4193,7 @@ impl WorkflowEngine {
         target: ExecutionStateTarget,
         new_state: WorkflowExecutionState,
     ) -> Result<(), WorkflowEngineError> {
-        let (chat_session_id, snapshot, run_id, worktree_path, previous_state) = {
+        let (chat_session_id, snapshot, run_id, worktree_path, snapshot_before) = {
             let mut execs = self.executions.lock().await;
             let exec = match &target {
                 ExecutionStateTarget::Worktree(wt) => find_by_worktree_mut(&mut execs, wt)
@@ -3761,7 +4203,7 @@ impl WorkflowEngine {
             if exec.is_terminal() {
                 return Ok(());
             }
-            let previous_state = exec.state.clone();
+            let snapshot_before = exec.clone();
             exec.state = new_state;
             exec.updated_at = current_timestamp();
             (
@@ -3769,35 +4211,10 @@ impl WorkflowEngine {
                 exec.to_workflow_state(),
                 exec.id.clone(),
                 exec.worktree_path.clone(),
-                previous_state,
+                snapshot_before,
             )
         };
 
-        // sync 失敗時に engine 側の state を previous に巻き戻す helper
-        // （Spec issues-1011 finding 10: engine terminal / Run Store active のスキュー禁止）。
-        let rollback_engine_state =
-            |run_id_for_rollback: String, previous: WorkflowExecutionState| async move {
-                let mut execs = self.executions.lock().await;
-                if let Some(exec) = execs.get_mut(&run_id_for_rollback) {
-                    exec.state = previous;
-                    exec.updated_at = current_timestamp();
-                }
-            };
-
-        // Spec issues-1011 finding 5: transaction 境界の再構成。
-        // 旧実装は persist_state → release → sync_run_store の順で、sync 失敗時に
-        // ChatSession に terminal snapshot を保存済みのまま engine state を rollback すると
-        // (ChatSession=terminal, engine=active, RunStore=active) の不整合が残った。
-        // 新実装では Run Store sync を「最初の外部観測可能な永続化」とする:
-        //   1. sync_run_store_from_snapshot（terminal も active も同じく Run Store 経由）
-        //      失敗時: engine state を rollback。ChatSession には何も書いていない。
-        //   2. persist_state（ChatSession）
-        //      失敗時: ChatSession 未更新、engine + Run Store は新 status のまま。
-        //      ChatSession は次回読み込み時に Run Store / engine snapshot から再導出可能
-        //      （Run Store が active 集合と metadata の権威）。
-        //   3. cleanup / log / broadcast を最後に実行。
-        // これにより「sync 成功前に外部観測可能な永続化・broadcast・cleanup を確定しない」
-        // 境界が成立する。
         let is_terminal = matches!(
             snapshot.state,
             WorkflowExecutionState::Completed
@@ -3805,15 +4222,84 @@ impl WorkflowEngine {
                 | WorkflowExecutionState::Aborted
         );
 
-        // Step 1: Run Store sync (権威)
+        // [05] terminal 経路は commit_required_events 基盤の共通 commit 境界に統合する。
+        // terminal events (NodeCompleted（Completed のみ）+ RunCompleted / NodeFailed+RunFailed)
+        // を required event 列として集約し、RunStore sync → ChatSession persist → event log
+        // append の順序で commit する。いずれかが失敗した場合は engine state と Run Store snapshot
+        // を snapshot_before で一括復元する（spec [05] atomic mutation 境界 / best-effort warn 廃止）。
+        // Aborted は AbortRun command handler 側で別途 commit されるため本経路では event 集合に含めない。
+        if is_terminal && !matches!(snapshot.state, WorkflowExecutionState::Aborted) {
+            let mut terminal_snapshot = snapshot.clone();
+            let mut required_events = Vec::new();
+            if matches!(snapshot.state, WorkflowExecutionState::Completed) {
+                match Self::last_step_completed_event_for_snapshot(&mut terminal_snapshot) {
+                    Ok(Some(ev)) => required_events.push(ev),
+                    Ok(None) => {}
+                    Err(e) => {
+                        let mut execs = self.executions.lock().await;
+                        if let Some(exec) = execs.get_mut(&run_id) {
+                            *exec = snapshot_before;
+                        }
+                        return Err(e);
+                    }
+                }
+            }
+            match Self::terminal_events_for_snapshot(&mut terminal_snapshot) {
+                Ok(events) => required_events.extend(events),
+                Err(e) => {
+                    let mut execs = self.executions.lock().await;
+                    if let Some(exec) = execs.get_mut(&run_id) {
+                        *exec = snapshot_before;
+                    }
+                    return Err(e);
+                }
+            }
+            let run_store_snapshot_before = self.run_store.active_run_snapshot(&run_id).await;
+            self.commit_required_events(
+                app,
+                session_store,
+                RequiredEventCommit {
+                    run_id: &run_id,
+                    chat_session_id: &chat_session_id,
+                    snapshot_for_commit: &snapshot,
+                    snapshot_before,
+                    run_store_snapshot_before,
+                    required_events,
+                    append_error_context: "set_execution_state terminal event append failed",
+                },
+            )
+            .await?;
+
+            // terminal 副作用: step session release + refs cleanup + broadcast。
+            let terminal_session_ids = Self::terminal_step_session_ids(&snapshot);
+            self.release_completed_step_sessions(
+                app,
+                session_store,
+                handles,
+                &terminal_session_ids,
+            )
+            .await;
+            self.cleanup_session_workflow_refs_by_run_id(&run_id).await;
+            self.broadcast_state(app, &worktree_path, snapshot.clone())
+                .await;
+            return Ok(());
+        }
+
+        // 非 terminal / Aborted 経路: required event が無いため従来の sync→persist 順で commit する。
+        // Aborted は AbortRun command handler 側で event を別途 append 済み。
+        let rollback_engine_state =
+            |run_id_for_rollback: String, previous_snapshot: WorkflowExecution| async move {
+                let mut execs = self.executions.lock().await;
+                if let Some(exec) = execs.get_mut(&run_id_for_rollback) {
+                    *exec = previous_snapshot;
+                }
+            };
+
         if let Err(e) = self.sync_run_store_from_snapshot(&run_id, &snapshot).await {
-            rollback_engine_state(run_id.clone(), previous_state).await;
+            rollback_engine_state(run_id.clone(), snapshot_before).await;
             return Err(e);
         }
 
-        // Step 2: ChatSession persist。失敗時は engine + Run Store が新 status のまま残るが、
-        // ChatSession の workflow_state は次回読み込み時に Run Store / engine snapshot から
-        // 再導出可能なので、致命的な不整合にはならない。warn ログを残して呼出側に Err を伝える。
         let persist_result = self
             .persist_state(app, session_store, &chat_session_id, snapshot.clone())
             .await;
@@ -3831,7 +4317,6 @@ impl WorkflowEngine {
             None
         };
 
-        // Step 3: terminal の場合は step session の release / 終了ログ / refs cleanup。
         if is_terminal {
             let terminal_session_ids = Self::terminal_step_session_ids(&snapshot);
             self.release_completed_step_sessions(
@@ -3841,11 +4326,6 @@ impl WorkflowEngine {
                 &terminal_session_ids,
             )
             .await;
-            if matches!(snapshot.state, WorkflowExecutionState::Completed) {
-                self.write_last_step_completed_log(app, &snapshot);
-            }
-            self.write_terminal_log(app, &snapshot);
-            // Spec issues-1011 finding 1: refs cleanup は run_id 主語に統一する。
             self.cleanup_session_workflow_refs_by_run_id(&run_id).await;
         }
         self.broadcast_state(app, &worktree_path, snapshot.clone())
@@ -4085,11 +4565,12 @@ impl WorkflowEngine {
         };
 
         // 判定 + 状態変更 + 履歴記録を原子的に実行
-        let (chat_session_id, outcome) = {
+        let (chat_session_id, outcome, snapshot_before) = {
             let mut execs = self.executions.lock().await;
             let exec = find_by_worktree_mut(&mut execs, worktree_path)
                 .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(worktree_path.to_string()))?;
             let chat_session_id = exec.chat_session_id.clone();
+            let snapshot_before = exec.clone();
 
             let outcome = match rule_match {
                 None => {
@@ -4127,7 +4608,7 @@ impl WorkflowEngine {
                     StepOutcome::Persist(exec.to_workflow_state())
                 }
             };
-            (chat_session_id, outcome)
+            (chat_session_id, outcome, snapshot_before)
         };
 
         self.execute_outcome(
@@ -4137,6 +4618,7 @@ impl WorkflowEngine {
             worktree_path,
             &chat_session_id,
             outcome,
+            snapshot_before,
         )
         .await
     }
@@ -5201,9 +5683,13 @@ impl WorkflowEngine {
         if is_terminal {
             if write_terminal_events {
                 if matches!(snapshot.state, WorkflowExecutionState::Completed) {
-                    self.write_last_step_completed_log(app, snapshot);
+                    if let Err(e) = self.write_last_step_completed_log(app, snapshot) {
+                        log::warn!("Failed to append NodeCompleted workflow event: {e}");
+                    }
                 }
-                self.write_terminal_log(app, snapshot);
+                if let Err(e) = self.write_terminal_log(app, snapshot) {
+                    log::warn!("Failed to append terminal workflow events: {e}");
+                }
             }
             self.cleanup_session_workflow_refs_by_run_id(&run_id).await;
         }
@@ -5372,12 +5858,18 @@ impl WorkflowEngine {
 
     /// ロック外でStepOutcomeに応じた副作用（永続化・ブロードキャスト・AgentSession起動）を実行する。
     ///
-    /// 本 helper は non-command 経路（NodeCompleted / NodeFailed 等）から呼ばれ、
-    /// `persist_release_and_broadcast` で snapshot を永続化したうえで、variant 別の
-    /// post-commit 副作用を `dispatch_step_outcome_side_effects` 経由で実行する。
-    /// 4 command（StartRun / AbortRun / Approve / Reject）経路の handler は required
-    /// event append を commit point として通過してから同じ
-    /// `dispatch_step_outcome_side_effects` を呼ぶ。
+    /// 本 helper は non-command 経路（NodeCompleted / NodeFailed 等）から呼ばれる。
+    ///
+    /// [05] commit 境界: spec [04] commit_required_events を基盤に、StepOutcome から
+    /// `NodeCompleted` / `NodeFailed` / `RunCompleted` / `RunFailed` の必須 event を
+    /// 組み立て、RunStore sync → ChatSession persist → event log append の順で commit
+    /// する。いずれかの phase で失敗した場合は engine state と Run Store snapshot を
+    /// `snapshot_before` で一括復元することで、event log と engine state / RunStore /
+    /// ChatSession の分離を防ぐ（spec [05]: state mutation と event log の分離を防ぐ
+    /// rollback 境界 / atomic mutation 境界）。
+    ///
+    /// 必須 event が空の場合は従来通り `sync_persist_release` のみを実行する。
+    #[allow(clippy::too_many_arguments)]
     async fn execute_outcome<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
@@ -5386,19 +5878,68 @@ impl WorkflowEngine {
         worktree_path: &str,
         chat_session_id: &str,
         outcome: StepOutcome,
+        snapshot_before: WorkflowExecution,
     ) -> Result<(), WorkflowEngineError> {
         let completed_step_session_ids = Self::completed_step_session_ids_for_outcome(&outcome);
         let snapshot_for_commit = Self::outcome_snapshot(&outcome).clone();
-        self.persist_release_and_broadcast(
-            app,
-            session_store,
-            handles,
-            worktree_path,
-            chat_session_id,
-            snapshot_for_commit,
-            &completed_step_session_ids,
-        )
-        .await?;
+        let run_id = snapshot_for_commit.execution_id.clone();
+
+        // [05] pre-commit phase: 必須 event の生成。`dispatch_internal_node_command` の
+        // ValidationError は engine state を snapshot_before で復元して伝播する
+        // （spec [05] silent error 禁止）。
+        let pre_commit_events = match Self::pre_commit_required_events_for_outcome(&outcome) {
+            Ok(events) => events,
+            Err(e) => {
+                let mut execs = self.executions.lock().await;
+                if let Some(exec) = execs.get_mut(&run_id) {
+                    *exec = snapshot_before;
+                }
+                return Err(e);
+            }
+        };
+
+        if !pre_commit_events.is_empty() {
+            // [05] commit_required_events 基盤: 順序と rollback 方針を一箇所に集約。
+            // 失敗時は engine state と Run Store snapshot を一括復元する。
+            let run_store_snapshot_before = self.run_store.active_run_snapshot(&run_id).await;
+            self.commit_required_events(
+                app,
+                session_store,
+                RequiredEventCommit {
+                    run_id: &run_id,
+                    chat_session_id,
+                    snapshot_for_commit: &snapshot_for_commit,
+                    snapshot_before,
+                    run_store_snapshot_before,
+                    required_events: pre_commit_events,
+                    append_error_context: "execute_outcome required event append failed",
+                },
+            )
+            .await?;
+            self.release_completed_step_sessions(
+                app,
+                session_store,
+                handles,
+                &completed_step_session_ids,
+            )
+            .await;
+        } else {
+            // 必須 event 無し: 従来通り sync_persist_release のみ。
+            self.sync_persist_release(
+                app,
+                session_store,
+                handles,
+                chat_session_id,
+                &snapshot_for_commit,
+                &completed_step_session_ids,
+            )
+            .await?;
+        }
+
+        // terminal / NodeCompleted は append 済みのため finalize_after_commit には
+        // write_terminal_events=false を渡し二重 append を避ける（commit 境界の単一性）。
+        self.finalize_after_commit(app, &snapshot_for_commit, worktree_path, false)
+            .await;
         self.dispatch_step_outcome_side_effects(
             app,
             session_store,
@@ -5406,9 +5947,53 @@ impl WorkflowEngine {
             worktree_path,
             chat_session_id,
             outcome,
-            OutcomeCommitMode::EmitProgressEvents,
+            OutcomeCommitMode::ProgressEventsAlreadyCommitted,
         )
         .await
+    }
+
+    /// [05] StepOutcome から persist 前に append すべき必須 event を組み立てる
+    /// 純粋関数。`execute_outcome` の pre-commit phase でのみ呼ばれる。
+    ///
+    /// `Persist`:
+    /// terminal（Completed / Failed）の場合 NodeCompleted（Completed のみ）+ terminal
+    /// events（RunCompleted / NodeFailed+RunFailed）を返す。Aborted は `AbortRun`
+    /// command 経路で別途 append されるため本関数では扱わない。
+    ///
+    /// `TransitionAndStart` / `ReduceAndTransition` / `StartParallel`:
+    /// 直前の step 完了に対応する NodeCompleted を返す。NodeStarted は best-effort
+    /// write_log 側で扱う（spec scope: required append は NodeCompleted / 終了系のみ）。
+    fn pre_commit_required_events_for_outcome(
+        outcome: &StepOutcome,
+    ) -> Result<Vec<WorkflowEvent>, WorkflowEngineError> {
+        let mut events = Vec::new();
+        let mut snapshot = Self::outcome_snapshot(outcome).clone();
+        match outcome {
+            StepOutcome::Persist(s) => {
+                let is_terminal = matches!(
+                    s.state,
+                    WorkflowExecutionState::Completed | WorkflowExecutionState::Failed { .. }
+                );
+                if is_terminal {
+                    if matches!(s.state, WorkflowExecutionState::Completed) {
+                        if let Some(ev) =
+                            Self::last_step_completed_event_for_snapshot(&mut snapshot)?
+                        {
+                            events.push(ev);
+                        }
+                    }
+                    events.extend(Self::terminal_events_for_snapshot(&mut snapshot)?);
+                }
+            }
+            StepOutcome::TransitionAndStart(_)
+            | StepOutcome::ReduceAndTransition(_)
+            | StepOutcome::StartParallel(_) => {
+                if let Some(ev) = Self::last_step_completed_event_for_snapshot(&mut snapshot)? {
+                    events.push(ev);
+                }
+            }
+        }
+        Ok(events)
     }
 
     /// [04] post-commit variant work（共通 side-effect helper）。
@@ -5455,7 +6040,11 @@ impl WorkflowEngine {
             }
             StepOutcome::TransitionAndStart(snapshot) => {
                 if commit_mode.should_emit_progress_events() {
-                    self.write_last_step_completed_log(app, &snapshot);
+                    if let Err(e) = self.write_last_step_completed_log(app, &snapshot) {
+                        return Err(WorkflowEngineError::SessionStore(format!(
+                            "TransitionAndStart pre-commit NodeCompleted append failed: {e}"
+                        )));
+                    }
                 }
                 let exec_count = snapshot
                     .step_execution_counts
@@ -5506,7 +6095,11 @@ impl WorkflowEngine {
             }
             StepOutcome::ReduceAndTransition(snapshot) => {
                 if commit_mode.should_emit_progress_events() {
-                    self.write_last_step_completed_log(app, &snapshot);
+                    if let Err(e) = self.write_last_step_completed_log(app, &snapshot) {
+                        return Err(WorkflowEngineError::SessionStore(format!(
+                            "ReduceAndTransition pre-commit NodeCompleted append failed: {e}"
+                        )));
+                    }
                 }
 
                 let (collect_config_clone, reduce_result, step_rules) = {
@@ -5523,12 +6116,13 @@ impl WorkflowEngine {
                     (collect, result, step.transition_rules.clone())
                 };
 
-                let (next_outcome, log_step_name, log_exec_id, log_wf_name) = {
+                let (next_outcome, log_step_name, log_exec_id, log_wf_name, snapshot_before) = {
                     let mut execs = self.executions.lock().await;
                     let exec =
                         find_by_worktree_mut(&mut execs, worktree_path).ok_or_else(|| {
                             WorkflowEngineError::ExecutionNotFound(worktree_path.to_string())
                         })?;
+                    let snapshot_before = exec.clone();
 
                     let entry = exec.make_step_history_entry(
                         reduce_result.result.clone(),
@@ -5558,7 +6152,7 @@ impl WorkflowEngine {
                     } else {
                         Self::apply_advance(exec)
                     };
-                    (outcome, step_name, exec_id, wf_name)
+                    (outcome, step_name, exec_id, wf_name, snapshot_before)
                 };
 
                 let collected_entries: Vec<CollectedOutputEntry> = collect_config_clone
@@ -5597,12 +6191,17 @@ impl WorkflowEngine {
                     worktree_path,
                     chat_session_id,
                     next_outcome,
+                    snapshot_before,
                 ))
                 .await
             }
             StepOutcome::StartParallel(snapshot) => {
                 if commit_mode.should_emit_progress_events() {
-                    self.write_last_step_completed_log(app, &snapshot);
+                    if let Err(e) = self.write_last_step_completed_log(app, &snapshot) {
+                        return Err(WorkflowEngineError::SessionStore(format!(
+                            "StartParallel pre-commit NodeCompleted append failed: {e}"
+                        )));
+                    }
                 }
                 if let Err(e) = self
                     .start_parallel_children(
@@ -6010,48 +6609,79 @@ impl WorkflowEngine {
         .await;
     }
 
-    /// 終了状態（Completed/Failed）のログを書き込む。
+    /// 終了状態（Completed/Failed）のログを書き込む required append helper。
     /// StepCompletedログは呼び出し元で書き込み済みのため、ここでは書かない。
     ///
     /// `Aborted` 状態の `RunAborted` event は本 issue [04] の典型 typed command
     /// `AbortRun` に対応する事実列であり、command handler 側で `write_log_required`
     /// を経由して必須 append + snapshot 一括復元の atomic 境界に乗せる。本ヘルパーは
-    /// best-effort であり、`AbortRun` の rollback 経路を担保できないため Aborted は
-    /// ここで書かない（重複 append 防止）。
+    /// `AbortRun` の rollback 経路を担保できないため Aborted はここで書かない（重複
+    /// append 防止）。
+    ///
+    /// [05] event 発行点の集約: terminal events（NodeFailed / RunCompleted / RunFailed）は
+    /// `dispatch_internal_node_command` 経由で生成し、`write_log_required_batch` で必須
+    /// append 経路に乗せる。append 失敗時は `Err` を返し、呼出側で state mutation
+    /// rollback / persist スキップに乗せる（spec [05]: best-effort warn を廃止し
+    /// commit 境界に揃える）。
     fn write_terminal_log<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
         snapshot: &WorkflowState,
-    ) {
-        for event in Self::terminal_events_for_snapshot(snapshot) {
-            self.write_log(app, event);
+    ) -> Result<(), String> {
+        let mut local = snapshot.clone();
+        let events =
+            Self::terminal_events_for_snapshot(&mut local).map_err(|e| format!("{e:?}"))?;
+        if events.is_empty() {
+            return Ok(());
         }
+        self.write_log_required_batch(app, &events)
     }
 
-    /// 最後のステップのStepCompletedログを書き込む。
+    /// 最後のステップの NodeCompleted ログを書き込む required append helper。
+    /// [05] event 発行点の集約: `dispatch_internal_node_command` 経由で生成した
+    /// `NodeCompleted` を `write_log_required` で必須 append 経路に乗せる。
+    /// append 失敗時は `Err` を返し、呼出側で commit 境界に乗せる（spec [05]:
+    /// best-effort warn を廃止）。
     fn write_last_step_completed_log<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
         snapshot: &WorkflowState,
-    ) {
-        if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot) {
-            self.write_log(app, event);
+    ) -> Result<(), String> {
+        let mut local = snapshot.clone();
+        match Self::last_step_completed_event_for_snapshot(&mut local) {
+            Ok(Some(event)) => self.write_log_required(app, event),
+            Ok(None) => Ok(()),
+            Err(e) => Err(format!("{e:?}")),
         }
     }
 
-    fn last_step_completed_event_for_snapshot(snapshot: &WorkflowState) -> Option<WorkflowEvent> {
-        let last_entry = snapshot.step_history.last()?;
-        Some(WorkflowEvent::NodeCompleted {
+    /// [05] internal command boundary: NodeCompleted event の発行点を typed command
+    /// 経路に揃える。snapshot から `WorkflowCommand::CompleteNode` を組み立て、
+    /// `dispatch_internal_node_command` 経由で (state mutation + event) を atomic
+    /// commit する（Complete の mutation は上流 push 完了点と一致することの検証）。
+    ///
+    /// `Ok(None)` は step_history 空（NodeCompleted 該当なし）の合法な経路。
+    /// `dispatch_internal_node_command` の `ValidationError` は `.ok()` で握り潰さず
+    /// `Err` として呼出側に伝播し、commit 境界の判断材料を奪わないようにする
+    /// （spec [05] silent error の禁止）。
+    fn last_step_completed_event_for_snapshot(
+        snapshot: &mut WorkflowState,
+    ) -> Result<Option<WorkflowEvent>, WorkflowEngineError> {
+        let Some(last_entry) = snapshot.step_history.last().cloned() else {
+            return Ok(None);
+        };
+        let command = WorkflowCommand::CompleteNode {
             run_id: snapshot.execution_id.clone(),
             workflow_name: snapshot.workflow_name.clone(),
-            node_name: last_entry.step_name.clone(),
-            result: last_entry.result.clone(),
-            session_id: last_entry.session_id.clone(),
-            token_usage: last_entry.token_usage.clone(),
-            structured_output: last_entry.structured_output.clone(),
+            node_name: last_entry.step_name,
+            result: last_entry.result,
+            session_id: last_entry.session_id,
+            token_usage: last_entry.token_usage,
+            structured_output: last_entry.structured_output,
             run_index: Some(last_entry.run_index),
             timestamp: last_entry.completed_at,
-        })
+        };
+        Self::dispatch_internal_node_command(snapshot, command).map(Some)
     }
 
     fn node_started_event_for_snapshot(snapshot: &WorkflowState) -> WorkflowEvent {
@@ -6089,48 +6719,66 @@ impl WorkflowEngine {
         })
     }
 
-    fn terminal_events_for_snapshot(snapshot: &WorkflowState) -> Vec<WorkflowEvent> {
+    /// [05] internal command boundary: terminal event 列の発行点を typed command 経路に
+    /// 揃える。`Failed` の場合は `FailNode` typed command を組み立てて
+    /// `dispatch_internal_node_command` で state mutation + NodeFailed event を atomic
+    /// に commit し、その後 RunFailed を追記する。`dispatch_internal_node_command` の
+    /// `ValidationError` は `.ok()` で握り潰さず `Err` として呼出側に伝播する
+    /// （spec [05] silent error の禁止）。
+    fn terminal_events_for_snapshot(
+        snapshot: &mut WorkflowState,
+    ) -> Result<Vec<WorkflowEvent>, WorkflowEngineError> {
         match &snapshot.state {
-            WorkflowExecutionState::Completed => vec![WorkflowEvent::RunCompleted {
+            WorkflowExecutionState::Completed => Ok(vec![WorkflowEvent::RunCompleted {
                 run_id: snapshot.execution_id.clone(),
                 workflow_name: snapshot.workflow_name.clone(),
                 total_token_usage: snapshot.total_token_usage.clone(),
                 timestamp: snapshot.updated_at,
-            }],
-            WorkflowExecutionState::Failed { reason } => vec![
-                WorkflowEvent::NodeFailed {
-                    run_id: snapshot.execution_id.clone(),
-                    workflow_name: snapshot.workflow_name.clone(),
-                    node_name: snapshot.current_step_name.clone(),
+            }]),
+            WorkflowExecutionState::Failed { reason } => {
+                let run_id = snapshot.execution_id.clone();
+                let workflow_name = snapshot.workflow_name.clone();
+                let node_name = snapshot.current_step_name.clone();
+                let reason = reason.clone();
+                let timestamp = snapshot.updated_at;
+                let fail_command = WorkflowCommand::FailNode {
+                    run_id: run_id.clone(),
+                    workflow_name: workflow_name.clone(),
+                    node_name,
                     reason: reason.clone(),
-                    timestamp: snapshot.updated_at,
-                },
-                WorkflowEvent::RunFailed {
-                    run_id: snapshot.execution_id.clone(),
-                    workflow_name: snapshot.workflow_name.clone(),
-                    reason: reason.clone(),
-                    timestamp: snapshot.updated_at,
-                },
-            ],
-            _ => Vec::new(),
+                    timestamp,
+                };
+                let node_failed = Self::dispatch_internal_node_command(snapshot, fail_command)?;
+                Ok(vec![
+                    node_failed,
+                    WorkflowEvent::RunFailed {
+                        run_id,
+                        workflow_name,
+                        reason,
+                        timestamp,
+                    },
+                ])
+            }
+            _ => Ok(Vec::new()),
         }
     }
 
     fn required_events_for_approval_commit(
         approval_event: WorkflowEvent,
-        outcome: &StepOutcome,
-    ) -> Vec<WorkflowEvent> {
+        outcome: &mut StepOutcome,
+    ) -> Result<Vec<WorkflowEvent>, WorkflowEngineError> {
         let mut events = vec![approval_event];
         match outcome {
             StepOutcome::Persist(snapshot) => {
-                if matches!(
+                let is_terminal = matches!(
                     snapshot.state,
                     WorkflowExecutionState::Completed | WorkflowExecutionState::Failed { .. }
-                ) {
-                    if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot) {
+                );
+                if is_terminal {
+                    if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot)? {
                         events.push(event);
                     }
-                    events.extend(Self::terminal_events_for_snapshot(snapshot));
+                    events.extend(Self::terminal_events_for_snapshot(snapshot)?);
                 } else if matches!(snapshot.state, WorkflowExecutionState::Aborted) {
                     events.push(WorkflowEvent::RunAborted {
                         run_id: snapshot.execution_id.clone(),
@@ -6140,25 +6788,23 @@ impl WorkflowEngine {
                 }
             }
             StepOutcome::TransitionAndStart(snapshot) => {
-                if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot) {
+                if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot)? {
                     events.push(event);
                 }
                 events.push(Self::node_started_event_for_snapshot(snapshot));
             }
-            StepOutcome::ReduceAndTransition(snapshot) | StepOutcome::StartParallel(snapshot) => {
-                if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot) {
+            StepOutcome::ReduceAndTransition(snapshot) => {
+                if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot)? {
                     events.push(event);
                 }
-                match outcome {
-                    StepOutcome::ReduceAndTransition(_) => {
-                        events.push(Self::node_started_event_for_snapshot(snapshot));
-                    }
-                    StepOutcome::StartParallel(_) => {
-                        if let Some(event) = Self::parallel_started_event_for_snapshot(snapshot) {
-                            events.push(event);
-                        }
-                    }
-                    _ => {}
+                events.push(Self::node_started_event_for_snapshot(snapshot));
+            }
+            StepOutcome::StartParallel(snapshot) => {
+                if let Some(event) = Self::last_step_completed_event_for_snapshot(snapshot)? {
+                    events.push(event);
+                }
+                if let Some(event) = Self::parallel_started_event_for_snapshot(snapshot) {
+                    events.push(event);
                 }
             }
         }
@@ -6169,7 +6815,7 @@ impl WorkflowEngine {
         for event in &mut events {
             Self::set_workflow_event_timestamp(event, commit_timestamp);
         }
-        events
+        Ok(events)
     }
 
     fn workflow_event_timestamp(event: &WorkflowEvent) -> f64 {
@@ -6302,6 +6948,42 @@ impl WorkflowEngine {
             expected_execution_id,
             expected_step_name,
             output_text,
+        )
+        .await
+    }
+
+    /// [05] Test-only: 既に `Failed` state に遷移した snapshot に対して
+    /// `execute_outcome(StepOutcome::Persist(snapshot))` を実行する production 経路の
+    /// ショートカット。pre-commit append 失敗時に RunStore / state が persist されない
+    /// ことを検証するために用いる（spec [05] commit 境界の継承）。
+    #[cfg(test)]
+    async fn execute_outcome_persist_failed_for_test<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        handles: &Arc<Mutex<AgentProcessMap>>,
+        worktree_path: &str,
+        chat_session_id: &str,
+        snapshot: WorkflowState,
+    ) -> Result<(), WorkflowEngineError> {
+        // テスト helper の snapshot_before は engine.executions の現在状態を採用する。
+        // production 経路では call site が mutation 前に capture するが、本 helper は
+        // 既に mutated snapshot を直接渡すための短絡として、現在状態を rollback target
+        // 扱いにする（pre-commit 失敗時の挙動を観測する用途のため）。
+        let snapshot_before = {
+            let execs = self.executions.lock().await;
+            execs.get(&snapshot.execution_id).cloned().ok_or_else(|| {
+                WorkflowEngineError::ExecutionNotFound(snapshot.execution_id.clone())
+            })?
+        };
+        self.execute_outcome(
+            app,
+            session_store,
+            handles,
+            worktree_path,
+            chat_session_id,
+            StepOutcome::Persist(snapshot),
+            snapshot_before,
         )
         .await
     }
@@ -14125,6 +14807,828 @@ mod dispatch_boundary_tests {
             restored.workflow_variables, before_variables,
             "workflow_variables 全体が mutation 前と等価"
         );
+    }
+
+    /// Spec [05] adapter-facing 拒否境界: `WorkflowCommand::CompleteNode` /
+    /// `FailNode` は engine 内部の node 完了 / 失敗遷移を typed 化した internal-only
+    /// variant であり、外部 adapter（Tauri command / CLI / agent path）から組み立てる
+    /// 経路は提供しない。adapter 入口の `dispatch_external` から外部 caller が組み立てて
+    /// 到達した場合は内部不整合として `Err` に変換することを境界仕様として確認する。
+    /// engine 内部の commit 経路は `dispatch` を直接呼ぶ（次の
+    /// `dispatch_commits_internal_*` テスト参照）。
+    #[tokio::test]
+    async fn workflow_command_internal_variants_are_rejected_by_dispatch_external() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let (session_store, handles) = make_dispatch_deps();
+        let internal_complete = WorkflowCommand::CompleteNode {
+            run_id: "00000000-0000-0000-0000-000000000600".to_string(),
+            workflow_name: "wf".to_string(),
+            node_name: "step-1".to_string(),
+            result: None,
+            session_id: None,
+            token_usage: None,
+            structured_output: None,
+            run_index: None,
+            timestamp: 0.0,
+        };
+        let result = engine
+            .dispatch_external(app.handle(), &session_store, &handles, internal_complete)
+            .await;
+        assert!(
+            matches!(result, Err(WorkflowEngineError::ValidationError(_))),
+            "dispatch_external must reject CompleteNode as internal-only; got {result:?}"
+        );
+
+        let internal_fail = WorkflowCommand::FailNode {
+            run_id: "00000000-0000-0000-0000-000000000601".to_string(),
+            workflow_name: "wf".to_string(),
+            node_name: "step-1".to_string(),
+            reason: "boom".to_string(),
+            timestamp: 0.0,
+        };
+        let result = engine
+            .dispatch_external(app.handle(), &session_store, &handles, internal_fail)
+            .await;
+        assert!(
+            matches!(result, Err(WorkflowEngineError::ValidationError(_))),
+            "dispatch_external must reject FailNode as internal-only; got {result:?}"
+        );
+    }
+
+    fn dispatch_internal_test_snapshot(run_id: &str, workflow_name: &str) -> WorkflowState {
+        WorkflowState {
+            execution_id: run_id.to_string(),
+            workflow_name: workflow_name.to_string(),
+            chat_session_id: None,
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0,
+            current_step_name: "node-1".to_string(),
+            current_session_id: None,
+            total_steps: 1,
+            step_history: vec![],
+            step_execution_counts: HashMap::new(),
+            workflow_definition: crate::workflow::schema::Workflow {
+                name: workflow_name.to_string(),
+                description: String::new(),
+                builtin: false,
+                nodes: vec![],
+            },
+            total_token_usage: TokenUsage::default(),
+            step_states: HashMap::new(),
+            step_outputs: HashMap::new(),
+            active_parallel_steps: vec![],
+            workflow_variables: HashMap::new(),
+            approval_operations: None,
+            started_at: 0.0,
+            updated_at: 0.0,
+        }
+    }
+
+    /// Spec [05]: `dispatch_internal_node_command` は `InternalNodeCommand` を受け取り、
+    /// 対応する state mutation を snapshot に適用したうえで event を返す
+    /// atomic commit 関数として機能する（spec [05]: 発行点が typed command 経路に
+    /// 集約 / state mutation と event 発行を同一 commit 境界に集約）。
+    #[test]
+    fn dispatch_internal_node_command_projects_complete_and_fail_commands() {
+        // Complete は snapshot.step_history 末尾 entry と command effect の整合を
+        // 検証する（commit 関数: 上流 push との同期境界）。
+        let mut snapshot =
+            dispatch_internal_test_snapshot("00000000-0000-0000-0000-000000000602", "wf");
+        snapshot.step_history.push(StepHistoryEntry {
+            step_name: "node-1".to_string(),
+            completed_at: 100.0,
+            result: Some("ok".to_string()),
+            session_id: Some("sess-1".to_string()),
+            token_usage: None,
+            structured_output: None,
+            run_index: 1,
+            child_outputs: None,
+        });
+        let complete = WorkflowCommand::CompleteNode {
+            run_id: "00000000-0000-0000-0000-000000000602".to_string(),
+            workflow_name: "wf".to_string(),
+            node_name: "node-1".to_string(),
+            result: Some("ok".to_string()),
+            session_id: Some("sess-1".to_string()),
+            token_usage: None,
+            structured_output: None,
+            run_index: Some(1),
+            timestamp: 100.0,
+        };
+        match WorkflowEngine::dispatch_internal_node_command(&mut snapshot, complete) {
+            Ok(WorkflowEvent::NodeCompleted {
+                run_id,
+                node_name,
+                result,
+                timestamp,
+                ..
+            }) => {
+                assert_eq!(run_id, "00000000-0000-0000-0000-000000000602");
+                assert_eq!(node_name, "node-1");
+                assert_eq!(result.as_deref(), Some("ok"));
+                assert_eq!(timestamp, 100.0);
+            }
+            other => panic!("expected NodeCompleted, got {other:?}"),
+        }
+
+        let mut fail_snapshot =
+            dispatch_internal_test_snapshot("00000000-0000-0000-0000-000000000603", "wf");
+        let fail = WorkflowCommand::FailNode {
+            run_id: "00000000-0000-0000-0000-000000000603".to_string(),
+            workflow_name: "wf".to_string(),
+            node_name: "node-1".to_string(),
+            reason: "boom".to_string(),
+            timestamp: 200.0,
+        };
+        match WorkflowEngine::dispatch_internal_node_command(&mut fail_snapshot, fail) {
+            Ok(WorkflowEvent::NodeFailed {
+                run_id,
+                node_name,
+                reason,
+                timestamp,
+                ..
+            }) => {
+                assert_eq!(run_id, "00000000-0000-0000-0000-000000000603");
+                assert_eq!(node_name, "node-1");
+                assert_eq!(reason, "boom");
+                assert_eq!(timestamp, 200.0);
+            }
+            other => panic!("expected NodeFailed, got {other:?}"),
+        }
+        // state mutation: Fail 受領後 snapshot.state は Failed { reason } に遷移し、
+        // updated_at は command の timestamp と一致する。
+        assert!(matches!(
+            fail_snapshot.state,
+            WorkflowExecutionState::Failed { ref reason } if reason == "boom"
+        ));
+        assert_eq!(fail_snapshot.updated_at, 200.0);
+
+        // Complete で snapshot の step_history 末尾と node_name が不一致な場合、
+        // commit 関数は ValidationError を返す（spec [05] commit 境界: snapshot が
+        // command effect を含まないことの検出）。
+        let mut mismatched =
+            dispatch_internal_test_snapshot("00000000-0000-0000-0000-000000000604", "wf");
+        let mismatched_cmd = WorkflowCommand::CompleteNode {
+            run_id: "00000000-0000-0000-0000-000000000604".to_string(),
+            workflow_name: "wf".to_string(),
+            node_name: "node-1".to_string(),
+            result: None,
+            session_id: None,
+            token_usage: None,
+            structured_output: None,
+            run_index: None,
+            timestamp: 100.0,
+        };
+        assert!(matches!(
+            WorkflowEngine::dispatch_internal_node_command(&mut mismatched, mismatched_cmd),
+            Err(WorkflowEngineError::ValidationError(_))
+        ));
+    }
+
+    /// Spec [05] commit 境界（snapshot と command effect の整合検証）の table-driven 網羅。
+    /// `CompleteNode` の全 effect 列（run_id / workflow_name / node_name / result /
+    /// session_id / token_usage / structured_output / run_index / timestamp）について、
+    /// snapshot 側で 1 個ずつ意図的に mismatch を作成し、`dispatch_internal_node_command`
+    /// が `ValidationError` を返すことを境界仕様として担保する（policy 指示）。
+    #[test]
+    fn dispatch_internal_complete_node_validates_all_effect_fields() {
+        fn base_snapshot() -> WorkflowState {
+            let mut s =
+                dispatch_internal_test_snapshot("00000000-0000-0000-0000-000000000620", "table-wf");
+            s.step_history.push(StepHistoryEntry {
+                step_name: "node-1".to_string(),
+                completed_at: 100.0,
+                result: Some("ok".to_string()),
+                session_id: Some("sess-1".to_string()),
+                token_usage: Some(TokenUsage {
+                    input_tokens: 10,
+                    output_tokens: 20,
+                }),
+                structured_output: Some(serde_json::json!({"k":"v"})),
+                run_index: 1,
+                child_outputs: None,
+            });
+            s
+        }
+        fn base_command() -> WorkflowCommand {
+            WorkflowCommand::CompleteNode {
+                run_id: "00000000-0000-0000-0000-000000000620".to_string(),
+                workflow_name: "table-wf".to_string(),
+                node_name: "node-1".to_string(),
+                result: Some("ok".to_string()),
+                session_id: Some("sess-1".to_string()),
+                token_usage: Some(TokenUsage {
+                    input_tokens: 10,
+                    output_tokens: 20,
+                }),
+                structured_output: Some(serde_json::json!({"k":"v"})),
+                run_index: Some(1),
+                timestamp: 100.0,
+            }
+        }
+
+        // baseline は受理される（all fields match）。
+        let mut s = base_snapshot();
+        assert!(WorkflowEngine::dispatch_internal_node_command(&mut s, base_command()).is_ok());
+
+        // 各 field を 1 個ずつ意図的に乖離させて ValidationError を確認する。
+        type CompleteNodeMutator = Box<dyn Fn(WorkflowCommand) -> WorkflowCommand>;
+        let mutators: Vec<(&str, CompleteNodeMutator)> = vec![
+            (
+                "run_id",
+                Box::new(|_cmd| {
+                    let mut c = base_command();
+                    if let WorkflowCommand::CompleteNode {
+                        run_id: ref mut r, ..
+                    } = c
+                    {
+                        *r = "00000000-0000-0000-0000-000000000999".to_string();
+                    }
+                    c
+                }),
+            ),
+            (
+                "workflow_name",
+                Box::new(|_cmd| {
+                    let mut c = base_command();
+                    if let WorkflowCommand::CompleteNode {
+                        workflow_name: ref mut w,
+                        ..
+                    } = c
+                    {
+                        *w = "other-wf".to_string();
+                    }
+                    c
+                }),
+            ),
+            (
+                "node_name",
+                Box::new(|_cmd| {
+                    let mut c = base_command();
+                    if let WorkflowCommand::CompleteNode {
+                        node_name: ref mut n,
+                        ..
+                    } = c
+                    {
+                        *n = "node-X".to_string();
+                    }
+                    c
+                }),
+            ),
+            (
+                "result",
+                Box::new(|_cmd| {
+                    let mut c = base_command();
+                    if let WorkflowCommand::CompleteNode {
+                        result: ref mut r, ..
+                    } = c
+                    {
+                        *r = Some("DIFFERENT".to_string());
+                    }
+                    c
+                }),
+            ),
+            (
+                "session_id",
+                Box::new(|_cmd| {
+                    let mut c = base_command();
+                    if let WorkflowCommand::CompleteNode {
+                        session_id: ref mut s,
+                        ..
+                    } = c
+                    {
+                        *s = Some("sess-X".to_string());
+                    }
+                    c
+                }),
+            ),
+            (
+                "token_usage",
+                Box::new(|_cmd| {
+                    let mut c = base_command();
+                    if let WorkflowCommand::CompleteNode {
+                        token_usage: ref mut t,
+                        ..
+                    } = c
+                    {
+                        *t = Some(TokenUsage {
+                            input_tokens: 999,
+                            output_tokens: 999,
+                        });
+                    }
+                    c
+                }),
+            ),
+            (
+                "structured_output",
+                Box::new(|_cmd| {
+                    let mut c = base_command();
+                    if let WorkflowCommand::CompleteNode {
+                        structured_output: ref mut so,
+                        ..
+                    } = c
+                    {
+                        *so = Some(serde_json::json!({"k":"other"}));
+                    }
+                    c
+                }),
+            ),
+            (
+                "run_index",
+                Box::new(|_cmd| {
+                    let mut c = base_command();
+                    if let WorkflowCommand::CompleteNode {
+                        run_index: ref mut r,
+                        ..
+                    } = c
+                    {
+                        *r = Some(99);
+                    }
+                    c
+                }),
+            ),
+            (
+                "timestamp",
+                Box::new(|_cmd| {
+                    let mut c = base_command();
+                    if let WorkflowCommand::CompleteNode {
+                        timestamp: ref mut t,
+                        ..
+                    } = c
+                    {
+                        *t = 999.0;
+                    }
+                    c
+                }),
+            ),
+        ];
+
+        for (label, mutate) in mutators {
+            let mut snapshot = base_snapshot();
+            let cmd = mutate(base_command());
+            let result = WorkflowEngine::dispatch_internal_node_command(&mut snapshot, cmd);
+            assert!(
+                matches!(result, Err(WorkflowEngineError::ValidationError(_))),
+                "CompleteNode {label} mismatch must return ValidationError, got: {result:?}"
+            );
+        }
+    }
+
+    /// Spec [05] commit 境界: `FailNode` の整合検証も run_id / workflow_name / node_name の
+    /// 各次元で snapshot との mismatch を ValidationError として検出することを担保する。
+    #[test]
+    fn dispatch_internal_fail_node_validates_all_effect_fields() {
+        fn base_snapshot() -> WorkflowState {
+            let mut s =
+                dispatch_internal_test_snapshot("00000000-0000-0000-0000-000000000621", "fail-wf");
+            s.current_step_name = "node-1".to_string();
+            s
+        }
+        fn base_command() -> WorkflowCommand {
+            WorkflowCommand::FailNode {
+                run_id: "00000000-0000-0000-0000-000000000621".to_string(),
+                workflow_name: "fail-wf".to_string(),
+                node_name: "node-1".to_string(),
+                reason: "boom".to_string(),
+                timestamp: 200.0,
+            }
+        }
+
+        // baseline は受理される。
+        let mut s = base_snapshot();
+        assert!(WorkflowEngine::dispatch_internal_node_command(&mut s, base_command()).is_ok());
+
+        // run_id mismatch
+        let mut s = base_snapshot();
+        let mut bad = base_command();
+        if let WorkflowCommand::FailNode {
+            run_id: ref mut r, ..
+        } = bad
+        {
+            *r = "00000000-0000-0000-0000-000000000999".to_string();
+        }
+        assert!(matches!(
+            WorkflowEngine::dispatch_internal_node_command(&mut s, bad),
+            Err(WorkflowEngineError::ValidationError(_))
+        ));
+
+        // workflow_name mismatch
+        let mut s = base_snapshot();
+        let mut bad = base_command();
+        if let WorkflowCommand::FailNode {
+            workflow_name: ref mut w,
+            ..
+        } = bad
+        {
+            *w = "other-wf".to_string();
+        }
+        assert!(matches!(
+            WorkflowEngine::dispatch_internal_node_command(&mut s, bad),
+            Err(WorkflowEngineError::ValidationError(_))
+        ));
+
+        // node_name mismatch
+        let mut s = base_snapshot();
+        let mut bad = base_command();
+        if let WorkflowCommand::FailNode {
+            node_name: ref mut n,
+            ..
+        } = bad
+        {
+            *n = "node-X".to_string();
+        }
+        assert!(matches!(
+            WorkflowEngine::dispatch_internal_node_command(&mut s, bad),
+            Err(WorkflowEngineError::ValidationError(_))
+        ));
+    }
+
+    /// Spec [05] Rule: node が失敗したときの状態遷移が run に反映され、node 失敗の事実が
+    /// event log に記録される。engine の実 production 経路 (`set_execution_state` →
+    /// `sync_run_store_from_snapshot` + `write_terminal_log` 一連) を通過して、
+    /// (1) RunStore の status が Failed terminal に同期される、
+    /// (2) NDJSON event log に NodeFailed + RunFailed が追記される、
+    /// の双方が成立することを直接検証する（spec L122-130）。
+    #[tokio::test]
+    async fn engine_set_execution_state_failed_drives_run_state_and_node_failed_event_log() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps();
+
+        let worktree_path = "/wt/engine-node-failure";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let workflow = make_rejectable_approval_workflow();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let mut exec =
+            make_waiting_approval_execution_with_workflow(&run_id, worktree_path, workflow);
+        exec.state = WorkflowExecutionState::Running;
+        exec.current_step_index = 1; // node-1 = "fix"
+        exec.chat_session_id = parent.id;
+        exec.current_session_id = None;
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        // 実 production 経路: set_execution_state → Failed への遷移を engine 経由で実施。
+        // write_terminal_log + sync_run_store_from_snapshot がこの経路の中で連続して
+        // 実行されることを境界仕様として担保する。
+        engine
+            .set_execution_state(
+                app.handle(),
+                &session_store,
+                &handles,
+                worktree_path,
+                WorkflowExecutionState::Failed {
+                    reason: "node failure".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // (1) engine.executions の state は Failed に遷移している。
+        {
+            let execs = engine.executions.lock().await;
+            let exec = execs
+                .get(&run_id)
+                .expect("execution must remain after Failed");
+            assert!(matches!(
+                exec.state,
+                WorkflowExecutionState::Failed { ref reason } if reason == "node failure"
+            ));
+        }
+
+        // (2) RunStore の status も Failed terminal に同期される。
+        let run = engine
+            .run_store
+            .get_run(&run_id)
+            .await
+            .expect("RunStore must reflect the run");
+        assert!(
+            run.status.is_terminal(),
+            "RunStore status must be terminal, got {:?}",
+            run.status
+        );
+        assert_eq!(run.error_reason.as_deref(), Some("node failure"));
+
+        // (3) NDJSON event log に NodeFailed + RunFailed が連続 append される。
+        let events = WorkflowEventLog::new(&data_dir).read_log(&run_id).unwrap();
+        let node_failed = events
+            .iter()
+            .find(|e| matches!(e, WorkflowEvent::NodeFailed { .. }));
+        let run_failed = events
+            .iter()
+            .find(|e| matches!(e, WorkflowEvent::RunFailed { .. }));
+        assert!(
+            node_failed.is_some(),
+            "NodeFailed event must be appended via engine dispatch path; got: {events:?}"
+        );
+        assert!(
+            run_failed.is_some(),
+            "RunFailed event must follow NodeFailed; got: {events:?}"
+        );
+    }
+
+    /// Spec [05] commit 境界: production 経路 `execute_outcome` の pre-commit phase で
+    /// `write_log_required_batch` が失敗した場合、`sync_run_store_from_snapshot` /
+    /// `persist_state` は実行されず、RunStore は active のまま / NDJSON 上にも terminal
+    /// event が残らないことを直接検証する（spec [05]: state mutation と event log の
+    /// 分離を防ぐ rollback 境界）。
+    ///
+    /// 障害シミュレーション: workflow_logs ディレクトリパスに通常ファイルを置くと、
+    /// `WorkflowEventLog::append_batch` 内の `create_dir_all` が失敗し、batch append が
+    /// `Err` を返す。
+    #[tokio::test]
+    async fn execute_outcome_pre_commit_append_failure_keeps_run_store_active() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps();
+
+        let worktree_path = "/wt/append-failure";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+
+        let workflow = make_rejectable_approval_workflow();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let mut exec =
+            make_waiting_approval_execution_with_workflow(&run_id, worktree_path, workflow);
+        exec.state = WorkflowExecutionState::Running;
+        exec.current_step_index = 1; // node "fix"
+        exec.chat_session_id = parent.id.clone();
+        exec.current_session_id = None;
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        // workflow_logs ディレクトリを通常ファイルで塞いで append を恒常失敗させる。
+        let log_dir = data_dir.join("workflow_logs");
+        if log_dir.exists() {
+            std::fs::remove_dir_all(&log_dir).unwrap();
+        }
+        std::fs::write(&log_dir, b"block").unwrap();
+
+        // snapshot を Failed terminal に遷移させ、execute_outcome に persist 経路で渡す。
+        let mut snapshot = {
+            let execs = engine.executions.lock().await;
+            execs.get(&run_id).unwrap().to_workflow_state()
+        };
+        snapshot.state = WorkflowExecutionState::Failed {
+            reason: "node failure".to_string(),
+        };
+        snapshot.updated_at = 9999.0;
+
+        let result = engine
+            .execute_outcome_persist_failed_for_test(
+                app.handle(),
+                &session_store,
+                &handles,
+                worktree_path,
+                &parent.id,
+                snapshot,
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "execute_outcome must return Err when pre-commit append fails: {result:?}"
+        );
+
+        // RunStore は active のまま（terminal に sync されていない）。
+        let stored = engine
+            .run_store
+            .get_run(&run_id)
+            .await
+            .expect("RunStore must still hold the run");
+        assert!(
+            !stored.status.is_terminal(),
+            "RunStore status must NOT be terminal when event log append fails; got {:?}",
+            stored.status
+        );
+        assert!(
+            stored.error_reason.is_none(),
+            "RunStore error_reason must remain unset when event log append fails"
+        );
+
+        // workflow_logs ディレクトリを復旧して NDJSON が空であることを確認する。
+        std::fs::remove_file(&log_dir).unwrap();
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let events = WorkflowEventLog::new(&data_dir).read_log(&run_id).unwrap();
+        assert!(
+            events.is_empty(),
+            "NDJSON event log must be empty when pre-commit append fails; got {events:?}"
+        );
+    }
+
+    /// Spec [05]: engine 内部の typed command 経路として、`WorkflowEngine::dispatch`
+    /// 経由で `WorkflowCommand::FailNode` を流すと `WorkflowEvent::NodeFailed` が
+    /// event log に commit され、engine.executions の state も Failed に遷移することを
+    /// 境界仕様として担保する（spec L22-24, L144-146: dispatch を内部 node 失敗の発火点へ
+    /// 集約）。adapter-facing 拒否境界は `dispatch_external` 側に分離されており、
+    /// engine 内部経路は `dispatch` が internal variant を受理する。
+    #[tokio::test]
+    async fn dispatch_commits_internal_fail_node_via_typed_command() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps();
+
+        let worktree_path = "/wt/dispatch-internal-fail";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let workflow = make_rejectable_approval_workflow();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let mut exec =
+            make_waiting_approval_execution_with_workflow(&run_id, worktree_path, workflow);
+        exec.state = WorkflowExecutionState::Running;
+        exec.current_step_index = 1;
+        exec.chat_session_id = parent.id;
+        exec.current_session_id = None;
+        let workflow_name = exec.workflow.name.clone();
+        let node_name = exec.workflow.nodes[exec.current_step_index].name.clone();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let cmd = WorkflowCommand::FailNode {
+            run_id: run_id.clone(),
+            workflow_name: workflow_name.clone(),
+            node_name: node_name.clone(),
+            reason: "internal node failure".to_string(),
+            timestamp: 9999.0,
+        };
+        let result = engine
+            .dispatch(app.handle(), &session_store, &handles, cmd)
+            .await
+            .expect("dispatch must accept internal FailNode and commit");
+        assert!(matches!(result, WorkflowCommandResult::Accepted));
+
+        // engine.executions の state が Failed に遷移している。
+        {
+            let execs = engine.executions.lock().await;
+            let exec = execs.get(&run_id).expect("exec must remain");
+            assert!(matches!(
+                exec.state,
+                WorkflowExecutionState::Failed { ref reason } if reason == "internal node failure"
+            ));
+        }
+
+        // event log には NodeFailed が append されている。
+        let events = WorkflowEventLog::new(&data_dir).read_log(&run_id).unwrap();
+        let node_failed = events
+            .iter()
+            .find(|e| matches!(e, WorkflowEvent::NodeFailed { .. }));
+        assert!(
+            node_failed.is_some(),
+            "dispatch must append NodeFailed via typed command path; got: {events:?}"
+        );
+    }
+
+    /// Spec [05]: engine 内部の typed command 経路として、`WorkflowEngine::dispatch`
+    /// 経由で `WorkflowCommand::CompleteNode` を流すと `WorkflowEvent::NodeCompleted` が
+    /// event log に commit され、上流が push 済みの step_history 末尾 entry と整合する
+    /// snapshot で受理されることを境界仕様として担保する（spec L22-24: NodeCompleted の
+    /// 発行点が typed command 経路に集約される）。
+    #[tokio::test]
+    async fn dispatch_commits_internal_complete_node_via_typed_command() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps();
+
+        let worktree_path = "/wt/dispatch-internal-complete";
+        let parent = create_parent_session(&app, &session_store, worktree_path);
+        let workflow = make_rejectable_approval_workflow();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let mut exec =
+            make_waiting_approval_execution_with_workflow(&run_id, worktree_path, workflow);
+        exec.state = WorkflowExecutionState::Running;
+        exec.current_step_index = 1; // node "fix"
+        exec.chat_session_id = parent.id;
+        exec.current_session_id = None;
+        // CompleteNode は dispatch_internal_node_command の整合検証で step_history 末尾と
+        // command effect の一致を要求するため、対応する entry を事前に push する。
+        let node_name = exec.workflow.nodes[exec.current_step_index].name.clone();
+        let workflow_name = exec.workflow.name.clone();
+        exec.step_history
+            .push(crate::workflow::state::StepHistoryEntry {
+                step_name: node_name.clone(),
+                completed_at: 8888.0,
+                result: Some("done".to_string()),
+                session_id: Some("sess-x".to_string()),
+                token_usage: None,
+                structured_output: None,
+                run_index: 1,
+                child_outputs: None,
+            });
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let cmd = WorkflowCommand::CompleteNode {
+            run_id: run_id.clone(),
+            workflow_name: workflow_name.clone(),
+            node_name: node_name.clone(),
+            result: Some("done".to_string()),
+            session_id: Some("sess-x".to_string()),
+            token_usage: None,
+            structured_output: None,
+            run_index: Some(1),
+            timestamp: 8888.0,
+        };
+        let result = engine
+            .dispatch(app.handle(), &session_store, &handles, cmd)
+            .await
+            .expect("dispatch must accept internal CompleteNode and commit");
+        assert!(matches!(result, WorkflowCommandResult::Accepted));
+
+        // event log に NodeCompleted が required append されている。
+        let events = WorkflowEventLog::new(&data_dir).read_log(&run_id).unwrap();
+        let node_completed = events
+            .iter()
+            .find(|e| matches!(e, WorkflowEvent::NodeCompleted { .. }));
+        assert!(
+            node_completed.is_some(),
+            "dispatch must append NodeCompleted via typed command path; got: {events:?}"
+        );
+
+        // engine.executions は state を維持（CompleteNode は state 遷移を起こさない）。
+        let execs = engine.executions.lock().await;
+        let exec = execs.get(&run_id).expect("exec must remain");
+        assert!(matches!(exec.state, WorkflowExecutionState::Running));
+    }
+
+    /// Spec [05] Rule: snapshot に Failed state が反映済みの場合、`write_terminal_log` の
+    /// 単体経路 (`terminal_events_for_snapshot` → `write_log_required_batch`) が
+    /// `NodeFailed` + `RunFailed` を順序通り append することを直接検証する（commit 境界の単位テスト）。
+    #[test]
+    fn write_terminal_log_emits_node_failed_followed_by_run_failed_for_failed_snapshot() {
+        let app = make_dispatch_app();
+        let engine = WorkflowEngine::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        let run_id = "00000000-0000-0000-0000-000000000605".to_string();
+
+        let snapshot = WorkflowState {
+            execution_id: run_id.clone(),
+            workflow_name: "fail-wf".to_string(),
+            chat_session_id: None,
+            state: WorkflowExecutionState::Failed {
+                reason: "node boom".to_string(),
+            },
+            current_step_index: 0,
+            current_step_name: "step-1".to_string(),
+            current_session_id: None,
+            total_steps: 1,
+            step_history: vec![],
+            step_execution_counts: HashMap::new(),
+            workflow_definition: crate::workflow::schema::Workflow {
+                name: "fail-wf".to_string(),
+                description: String::new(),
+                builtin: false,
+                nodes: vec![],
+            },
+            total_token_usage: TokenUsage::default(),
+            step_states: HashMap::new(),
+            step_outputs: HashMap::new(),
+            active_parallel_steps: vec![],
+            workflow_variables: HashMap::new(),
+            approval_operations: None,
+            started_at: 900.0,
+            updated_at: 1000.0,
+        };
+
+        engine
+            .write_terminal_log(app.handle(), &snapshot)
+            .expect("write_terminal_log must succeed");
+
+        let events = WorkflowEventLog::new(&data_dir).read_log(&run_id).unwrap();
+        assert_eq!(
+            events.len(),
+            2,
+            "terminal log must contain NodeFailed + RunFailed; got {events:?}"
+        );
+        match &events[0] {
+            WorkflowEvent::NodeFailed {
+                run_id: ev_run_id,
+                workflow_name,
+                node_name,
+                reason,
+                ..
+            } => {
+                assert_eq!(ev_run_id, &run_id);
+                assert_eq!(workflow_name, "fail-wf");
+                assert_eq!(node_name, "step-1");
+                assert_eq!(reason, "node boom");
+            }
+            other => panic!("expected NodeFailed first, got {other:?}"),
+        }
+        match &events[1] {
+            WorkflowEvent::RunFailed {
+                run_id: ev_run_id,
+                workflow_name,
+                reason,
+                ..
+            } => {
+                assert_eq!(ev_run_id, &run_id);
+                assert_eq!(workflow_name, "fail-wf");
+                assert_eq!(reason, "node boom");
+            }
+            other => panic!("expected RunFailed second, got {other:?}"),
+        }
     }
 
     /// Spec [04]: `WorkflowCommand::ApproveNode` の comment は `ApprovalResolved.comment` に

--- a/src-tauri/src/workflow/event.rs
+++ b/src-tauri/src/workflow/event.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::workflow::schema::Workflow;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenUsage {
     pub input_tokens: u64,

--- a/src-tauri/src/workflow/run.rs
+++ b/src-tauri/src/workflow/run.rs
@@ -7,7 +7,7 @@
 //!   ファイルシステムから列挙できるようにする。
 //! - 状態遷移ロジックは持たず、engine からの「開始通知」「終了通知」を受けて反映するのみ。
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -70,6 +70,24 @@ pub enum TriggerSource {
     Remote,
     Cli,
     Agent,
+}
+
+/// [05] `list_workflow_runs` の status filter。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatusFilter {
+    Active,
+    Terminal,
+}
+
+/// [05] `list_workflow_runs` の filter 入力。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunListFilter {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<RunStatusFilter>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
 }
 
 /// 1 回の workflow 実行インスタンス。
@@ -222,7 +240,68 @@ fn load_validated_metadata_entry(runs_dir: &Path, path: &Path) -> Result<Workflo
     load_validated_run_file(path)
 }
 
-fn iter_valid_run_metadata(data_dir: &Path) -> Vec<WorkflowRun> {
+/// [05] API / CLI 共通の projection helper。`Vec<WorkflowRun>` に filter（status /
+/// worktree_path）を適用し、active を先頭・以降は完了時刻降順で並べた
+/// `Vec<WorkflowRunSummary>` を返す。
+///
+/// `RunStore::list_runs`（API 経路）と CLI の file-direct 経路の双方が同じ projection
+/// に揃うことで観測ロジックの divergence を防ぐ（spec [05] API / CLI の意味的等価性境界）。
+pub fn project_runs_to_summaries(
+    runs: Vec<WorkflowRun>,
+    filter: &RunListFilter,
+) -> Vec<WorkflowRunSummary> {
+    let mut summaries: Vec<WorkflowRunSummary> = runs
+        .into_iter()
+        .filter(|run| match filter.status {
+            Some(RunStatusFilter::Active) => !run.status.is_terminal(),
+            Some(RunStatusFilter::Terminal) => run.status.is_terminal(),
+            None => true,
+        })
+        .filter(|run| match filter.worktree_path.as_deref() {
+            Some(wt) => run.worktree_path == wt,
+            None => true,
+        })
+        .map(|run| WorkflowRunSummary::from(&run))
+        .collect();
+    sort_summaries_active_first(&mut summaries);
+    summaries
+}
+
+/// `Vec<WorkflowRunSummary>` を「active を先頭・以降は completed_at（無ければ updated_at）
+/// の降順」で並び替える。projection helper と RunStore::list_runs から共通で使う。
+pub(crate) fn sort_summaries_active_first(summaries: &mut [WorkflowRunSummary]) {
+    summaries.sort_by(|a, b| {
+        let a_active = !a.status.is_terminal();
+        let b_active = !b.status.is_terminal();
+        match (a_active, b_active) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => {
+                let a_key = a.completed_at.unwrap_or(a.updated_at);
+                let b_key = b.completed_at.unwrap_or(b.updated_at);
+                b_key
+                    .partial_cmp(&a_key)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            }
+        }
+    });
+}
+
+/// [05] CLI: `workflow_runs/` 配下の active 状態の run から、現在 running 中の
+/// workflow_name の集合を導出する。CLI の `workflow list` で `is_running` を
+/// 反映するために使用する（spec [05] Rule: 観測経路は API と CLI で等価な手段を提供する）。
+///
+/// API 側は engine の in-memory active map から `running_workflow_names()` で
+/// 集合を取るが、CLI は file-direct で同等の集合を導出する。
+pub fn running_workflow_names_from_metadata(data_dir: &Path) -> HashSet<String> {
+    iter_valid_run_metadata(data_dir)
+        .into_iter()
+        .filter(|run| !run.status.is_terminal())
+        .map(|run| run.workflow_name)
+        .collect()
+}
+
+pub(crate) fn iter_valid_run_metadata(data_dir: &Path) -> Vec<WorkflowRun> {
     let runs_dir = runs_dir(data_dir);
     if !runs_dir.exists() {
         return Vec::new();
@@ -733,6 +812,11 @@ impl RunStore {
     /// 検証済み loader（`load_validated_run_file`）を経由するため、ファイル名 stem が
     /// UUID 形式でない、もしくは metadata.run_id が一致しないエントリは破損として
     /// warn ログのうえスキップする（Spec issues-1011 line 130 / Rule 7 / finding 11）。
+    ///
+    /// 本メソッドは観測経路の primary entry ではない（spec [05]: production 観測は
+    /// `list_runs` に集約され `project_runs_to_summaries` を経由する）。テストでの
+    /// metadata file 直読を検証するための補助 API として温存する。
+    #[allow(dead_code)]
     pub async fn list_completed(&self) -> Vec<WorkflowRunSummary> {
         let Some(store) = self.metadata_store().await.ok().flatten() else {
             return Vec::new();
@@ -757,19 +841,81 @@ impl RunStore {
         summaries
     }
 
-    /// worktree_path に紐づく active / terminal run を結合し、新しい更新順で返す。
+    /// テスト専用: worktree_path 限定の active+terminal 一覧（合成順）を返す。
+    /// production 経路は `list_runs(RunListFilter { worktree_path: Some(..), .. })` を使う。
+    #[cfg(test)]
     pub async fn list_for_worktree(&self, worktree_path: &str) -> Vec<WorkflowRunSummary> {
-        let mut summaries = self.list_active().await;
-        summaries.extend(self.list_completed().await);
-        summaries.retain(|run| run.worktree_path == worktree_path);
-        summaries.sort_by(|a, b| {
-            let a_key = a.completed_at.unwrap_or(a.updated_at);
-            let b_key = b.completed_at.unwrap_or(b.updated_at);
-            b_key
-                .partial_cmp(&a_key)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        summaries
+        self.list_runs(RunListFilter {
+            status: None,
+            worktree_path: Some(worktree_path.to_string()),
+        })
+        .await
+    }
+
+    /// [05] read-only API: active / terminal を含む全 run summary を、optional な
+    /// status / worktree filter を適用して返す。filter なしの場合は全件を返す。
+    /// 並び順は active を先頭・以降は完了時刻降順とする。
+    ///
+    /// 観測経路は file metadata（`workflow_runs/{run_id}.json`）全件を一次 source とし、
+    /// in-memory active map に存在する run はその snapshot で de-dupe / 上書きする
+    /// （in-memory 側が状態遷移時点で先行するため）。最終的に CLI と同じ
+    /// `project_runs_to_summaries` を経由することで観測ロジックの divergence を防ぐ
+    /// （spec [05] API / CLI の意味的等価性境界, 観測値の整合性境界: list / get の
+    /// データソース統一）。
+    pub async fn list_runs(&self, filter: RunListFilter) -> Vec<WorkflowRunSummary> {
+        let active_runs: HashMap<String, WorkflowRun> = {
+            let inner = self.inner.lock().await;
+            inner.active.clone()
+        };
+        let file_runs = match self.metadata_store().await {
+            Ok(Some(store)) => store.list_valid().await,
+            _ => Vec::new(),
+        };
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut combined: Vec<WorkflowRun> =
+            Vec::with_capacity(file_runs.len() + active_runs.len());
+        for run in active_runs.values() {
+            if seen.insert(run.run_id.clone()) {
+                combined.push(run.clone());
+            }
+        }
+        for run in file_runs {
+            if seen.insert(run.run_id.clone()) {
+                combined.push(run);
+            }
+        }
+        project_runs_to_summaries(combined, &filter)
+    }
+
+    /// [05] read-only API: 単一 run の summary を取得する。
+    /// active map → terminal metadata file の順で lookup する。`run_id` は UUID 形式
+    /// として検証する（path traversal 対策）。
+    pub async fn get_run(&self, run_id: &str) -> Option<WorkflowRunSummary> {
+        {
+            let inner = self.inner.lock().await;
+            if let Some(run) = inner.active.get(run_id) {
+                return Some(WorkflowRunSummary::from(run));
+            }
+        }
+        if !is_valid_run_id(run_id) {
+            log::warn!("RunStore: rejected non-UUID run_id in get_run");
+            return None;
+        }
+        let dir = self.data_dir().await?;
+        let path = run_file_path(&dir, run_id);
+        if !path.exists() {
+            return None;
+        }
+        match load_validated_metadata_entry(&runs_dir(&dir), &path) {
+            Ok(run) => Some(WorkflowRunSummary::from(&run)),
+            Err(e) => {
+                log::warn!(
+                    "RunStore: failed to load run metadata at {} for get_run: {e}",
+                    path.display()
+                );
+                None
+            }
+        }
     }
 
     /// worktree_path から active な run_id を解決する。
@@ -1117,6 +1263,9 @@ mod tests {
         assert_eq!(metadata.task.as_deref(), Some("do thing"));
     }
 
+    /// [05] list_runs / list_for_worktree は active を先頭、以降は完了時刻降順で
+    /// 返す（spec [05] read-only API 並び順）。worktree filter で対象 worktree のみに
+    /// 絞り込まれる。
     #[tokio::test]
     async fn list_for_worktree_combines_filters_and_sorts_runs() {
         let tmp = TempDir::new().unwrap();
@@ -1154,7 +1303,8 @@ mod tests {
 
         let runs = store.list_for_worktree("/wt/a").await;
         let ids: Vec<_> = runs.iter().map(|run| run.run_id.as_str()).collect();
-        assert_eq!(ids, vec![completed_new.as_str(), active.as_str()]);
+        // active が先頭、以降は完了時刻降順（spec [05] 並び順）。
+        assert_eq!(ids, vec![active.as_str(), completed_new.as_str()]);
     }
 
     /// 終了 status は completed / failed / aborted の 3 つを含む
@@ -1899,6 +2049,138 @@ mod tests {
 
         let predictable_tmp = run_file_path(tmp.path(), &run_id).with_extension("json.tmp");
         assert!(!predictable_tmp.exists());
+    }
+
+    // ---- [05] read-only API: list_runs / get_run ----
+
+    /// Rule [05]: 外部 caller は run_id を主語として workflow run を観測できる
+    /// （単一 run の summary metadata を観測する）。get_run は active / terminal の
+    /// いずれであっても summary を返す。
+    #[tokio::test]
+    async fn get_run_returns_summary_for_active_and_terminal_runs() {
+        let tmp = TempDir::new().unwrap();
+        let store = RunStore::new_in_memory_for_tests();
+        store.set_data_dir(tmp.path().to_path_buf()).await;
+
+        let active_id = test_uuid(20);
+        let done_id = test_uuid(21);
+        store
+            .register_active(make_run(&active_id, "/wt/a", RunStatus::Running, 100.0))
+            .await
+            .unwrap();
+        store
+            .register_active(make_run(&done_id, "/wt/b", RunStatus::Running, 90.0))
+            .await
+            .unwrap();
+        store
+            .complete_run(&done_id, TerminalRunStatus::Completed, 95.0, None)
+            .await
+            .unwrap();
+
+        let active_summary = store.get_run(&active_id).await.unwrap();
+        assert_eq!(active_summary.run_id, active_id);
+        assert_eq!(active_summary.status, RunStatus::Running);
+        assert_eq!(active_summary.worktree_path, "/wt/a");
+
+        let terminal_summary = store.get_run(&done_id).await.unwrap();
+        assert_eq!(terminal_summary.run_id, done_id);
+        assert_eq!(terminal_summary.status, RunStatus::Completed);
+        assert_eq!(terminal_summary.completed_at, Some(95.0));
+    }
+
+    /// Rule [05]: 観測対象として存在しない run_id は明示的に「該当 run なし」として扱われる。
+    #[tokio::test]
+    async fn get_run_returns_none_for_unknown_run_id() {
+        let tmp = TempDir::new().unwrap();
+        let store = RunStore::new_in_memory_for_tests();
+        store.set_data_dir(tmp.path().to_path_buf()).await;
+        let result = store.get_run(&test_uuid(99)).await;
+        assert!(result.is_none());
+    }
+
+    /// Spec [05]: get_run は path traversal 対策として非 UUID run_id を拒否する。
+    #[tokio::test]
+    async fn get_run_rejects_non_uuid_run_id() {
+        let tmp = TempDir::new().unwrap();
+        let store = RunStore::new_in_memory_for_tests();
+        store.set_data_dir(tmp.path().to_path_buf()).await;
+        let result = store.get_run("../etc/passwd").await;
+        assert!(result.is_none());
+    }
+
+    /// Rule [05]: list_runs は active と terminal を統合し、active を先頭・以降は完了時刻
+    /// 降順で返す。status filter で active のみ / terminal のみに絞り込める。
+    #[tokio::test]
+    async fn list_runs_returns_active_and_terminal_with_status_filter() {
+        let tmp = TempDir::new().unwrap();
+        let store = RunStore::new_in_memory_for_tests();
+        store.set_data_dir(tmp.path().to_path_buf()).await;
+
+        let active_id = test_uuid(30);
+        let done_id = test_uuid(31);
+        store
+            .register_active(make_run(&active_id, "/wt/a", RunStatus::Running, 100.0))
+            .await
+            .unwrap();
+        store
+            .register_active(make_run(&done_id, "/wt/b", RunStatus::Running, 90.0))
+            .await
+            .unwrap();
+        store
+            .complete_run(&done_id, TerminalRunStatus::Completed, 95.0, None)
+            .await
+            .unwrap();
+
+        let all = store.list_runs(RunListFilter::default()).await;
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].run_id, active_id);
+        assert_eq!(all[1].run_id, done_id);
+
+        let active_only = store
+            .list_runs(RunListFilter {
+                status: Some(RunStatusFilter::Active),
+                worktree_path: None,
+            })
+            .await;
+        assert_eq!(active_only.len(), 1);
+        assert_eq!(active_only[0].run_id, active_id);
+
+        let terminal_only = store
+            .list_runs(RunListFilter {
+                status: Some(RunStatusFilter::Terminal),
+                worktree_path: None,
+            })
+            .await;
+        assert_eq!(terminal_only.len(), 1);
+        assert_eq!(terminal_only[0].run_id, done_id);
+    }
+
+    /// Rule [05]: list_runs の worktree filter は指定 worktree の run のみを返す。
+    #[tokio::test]
+    async fn list_runs_with_worktree_filter_returns_matching_runs_only() {
+        let tmp = TempDir::new().unwrap();
+        let store = RunStore::new_in_memory_for_tests();
+        store.set_data_dir(tmp.path().to_path_buf()).await;
+
+        let run_a = test_uuid(40);
+        let run_b = test_uuid(41);
+        store
+            .register_active(make_run(&run_a, "/wt/a", RunStatus::Running, 100.0))
+            .await
+            .unwrap();
+        store
+            .register_active(make_run(&run_b, "/wt/b", RunStatus::Running, 100.0))
+            .await
+            .unwrap();
+
+        let filtered = store
+            .list_runs(RunListFilter {
+                status: None,
+                worktree_path: Some("/wt/a".to_string()),
+            })
+            .await;
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].run_id, run_a);
     }
 
     /// Spec issues-1011 finding 12: `complete_run` は `TerminalRunStatus` のみを受け付ける。

--- a/src-tauri/src/workflow/worktree.rs
+++ b/src-tauri/src/workflow/worktree.rs
@@ -11,13 +11,26 @@ fn configured_repo_paths(config: &ReleashConfig) -> Vec<String> {
     paths
 }
 
+/// [05] API / CLI 共有 helper: `worktree_path` filter input を OS レベルで canonicalize し、
+/// 末尾 `/` を除去した正規化済み文字列を返す。AppConfig 非依存で、相対パス / symlink
+/// 経由でも同じ物理パスに対して同一の filter 値を生成することで、API / CLI の
+/// 観測結果が分岐しないようにする（spec [05] API / CLI の意味的等価性境界）。
+pub(crate) fn normalize_worktree_filter_path(worktree_path: &str) -> Result<String, String> {
+    let canonical = PathBuf::from(worktree_path)
+        .canonicalize()
+        .map_err(|e| format!("invalid worktree_path: {e}"))?;
+    canonical
+        .to_str()
+        .map(|p| p.trim_end_matches('/').to_string())
+        .ok_or_else(|| "worktree_path has invalid encoding".to_string())
+}
+
 pub(crate) fn canonicalize_managed_worktree_path_inner(
     repo_paths: Vec<String>,
     worktree_path: String,
 ) -> Result<String, String> {
-    let requested = PathBuf::from(&worktree_path)
-        .canonicalize()
-        .map_err(|e| format!("invalid worktree_path: {e}"))?;
+    let requested_normalized = normalize_worktree_filter_path(&worktree_path)?;
+    let requested = PathBuf::from(&requested_normalized);
     for repo_path in repo_paths {
         let Ok(repo_path) = PathBuf::from(&repo_path).canonicalize() else {
             continue;
@@ -34,10 +47,7 @@ pub(crate) fn canonicalize_managed_worktree_path_inner(
                 continue;
             };
             if candidate == requested {
-                return requested
-                    .to_str()
-                    .map(|p| p.trim_end_matches('/').to_string())
-                    .ok_or_else(|| "worktree_path has invalid encoding".to_string());
+                return Ok(requested_normalized);
             }
         }
     }

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 const { WorkflowPanel } = await import("./WorkflowPanel");
 
-/// run_id 一覧の test helper。`list_workflow_runs_for_worktree` が返す
+/// run_id 一覧の test helper。`list_workflow_runs` が返す
 /// `WorkflowRunSummary[]` の最小形を生成する。
 function makeRunSummaries(
 	runIds: string[],
@@ -120,12 +120,12 @@ describe("WorkflowPanel", () => {
 			clientHeight: 100,
 		});
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "list_workflow_runs_for_worktree") {
+			if (cmd === "list_workflow_runs") {
 				return Promise.resolve(
 					makeRunSummaries(["exec-current", "exec-old"], "/repo"),
 				);
 			}
-			if (cmd === "get_workflow_execution_state") {
+			if (cmd === "get_workflow_run_state") {
 				return Promise.resolve(
 					makeWorkflowState({
 						executionId: "exec-old",
@@ -138,7 +138,7 @@ describe("WorkflowPanel", () => {
 					}),
 				);
 			}
-			if (cmd === "get_workflow_execution_log") {
+			if (cmd === "get_workflow_run_log") {
 				return Promise.resolve([]);
 			}
 			return Promise.resolve(undefined);
@@ -633,7 +633,7 @@ describe("WorkflowPanel", () => {
 						},
 					]);
 				}
-				if (cmd === "list_workflow_runs_for_worktree") {
+				if (cmd === "list_workflow_runs") {
 					return Promise.resolve([]);
 				}
 				return Promise.resolve(undefined);
@@ -722,10 +722,10 @@ describe("WorkflowPanel", () => {
 
 	it("keeps past execution workflow status outside the trace scroll region", async () => {
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "list_workflow_runs_for_worktree") {
+			if (cmd === "list_workflow_runs") {
 				return Promise.resolve(makeRunSummaries(["exec-old"], "/repo"));
 			}
-			if (cmd === "get_workflow_execution_state") {
+			if (cmd === "get_workflow_run_state") {
 				return Promise.resolve(
 					makeWorkflowState({
 						executionId: "exec-old",
@@ -737,7 +737,7 @@ describe("WorkflowPanel", () => {
 					}),
 				);
 			}
-			if (cmd === "get_workflow_execution_log") {
+			if (cmd === "get_workflow_run_log") {
 				return Promise.resolve([]);
 			}
 			return Promise.resolve(undefined);
@@ -757,13 +757,13 @@ describe("WorkflowPanel", () => {
 
 	it("shows an alert instead of Loading when past execution data fails to load", async () => {
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "list_workflow_runs_for_worktree") {
+			if (cmd === "list_workflow_runs") {
 				return Promise.resolve(makeRunSummaries(["exec-old"], "/repo"));
 			}
-			if (cmd === "get_workflow_execution_state") {
+			if (cmd === "get_workflow_run_state") {
 				return Promise.reject(new Error("state failed"));
 			}
-			if (cmd === "get_workflow_execution_log") {
+			if (cmd === "get_workflow_run_log") {
 				return Promise.resolve([]);
 			}
 			return Promise.resolve(undefined);
@@ -782,13 +782,13 @@ describe("WorkflowPanel", () => {
 
 	it("shows an alert instead of Loading when past execution state is missing", async () => {
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "list_workflow_runs_for_worktree") {
+			if (cmd === "list_workflow_runs") {
 				return Promise.resolve(makeRunSummaries(["exec-old"], "/repo"));
 			}
-			if (cmd === "get_workflow_execution_state") {
+			if (cmd === "get_workflow_run_state") {
 				return Promise.resolve(null);
 			}
-			if (cmd === "get_workflow_execution_log") {
+			if (cmd === "get_workflow_run_log") {
 				return Promise.resolve([]);
 			}
 			return Promise.resolve(undefined);
@@ -807,10 +807,10 @@ describe("WorkflowPanel", () => {
 
 	it("shows an alert instead of Loading when past execution log fails to load", async () => {
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "list_workflow_runs_for_worktree") {
+			if (cmd === "list_workflow_runs") {
 				return Promise.resolve(makeRunSummaries(["exec-old"], "/repo"));
 			}
-			if (cmd === "get_workflow_execution_state") {
+			if (cmd === "get_workflow_run_state") {
 				return Promise.resolve(
 					makeWorkflowState({
 						executionId: "exec-old",
@@ -818,7 +818,7 @@ describe("WorkflowPanel", () => {
 					}),
 				);
 			}
-			if (cmd === "get_workflow_execution_log") {
+			if (cmd === "get_workflow_run_log") {
 				return Promise.reject(new Error("log failed"));
 			}
 			return Promise.resolve(undefined);

--- a/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
+++ b/src/components/panels/AgentChatPanel/WorkflowPanel/WorkflowPanel.tsx
@@ -38,7 +38,7 @@ export function WorkflowPanel({
 	const [historyOpen, setHistoryOpen] = useState(false);
 
 	const fetchExecutionIds = useCallback(() => {
-		invoke<WorkflowRunSummary[]>("list_workflow_runs_for_worktree", {
+		invoke<WorkflowRunSummary[]>("list_workflow_runs", {
 			worktreePath,
 		})
 			.then((runs) => setExecutionIds(runs.map((r) => r.runId)))
@@ -387,16 +387,16 @@ function ExecutionView({
 		setIsLoading(true);
 
 		Promise.all([
-			invoke<WorkflowState | null>("get_workflow_execution_state", {
+			invoke<WorkflowState | null>("get_workflow_run_state", {
 				runId: executionId,
 			}),
-			invoke<WorkflowEvent[]>("get_workflow_execution_log", {
+			invoke<WorkflowEvent[] | null>("get_workflow_run_log", {
 				runId: executionId,
 			}),
 		])
 			.then(([state, logEvents]) => {
 				if (cancelled) return;
-				if (!state) {
+				if (!state || !logEvents) {
 					setLoadError("Failed to load execution history.");
 					return;
 				}


### PR DESCRIPTION
## Summary

issues-1015 (マイルストーン [05]) に対応。`run_id` を主語に workflow run を観測する read-only 経路 (Tauri API + CLI) を確立し、engine 内部の node 完了 / 失敗遷移を typed command 経由に集約する。

- **Tauri API (read-only, 5 種)**: `list_workflows` / `list_workflow_runs` / `get_workflow_run` / `get_workflow_run_log` / `get_workflow_run_state`
- **CLI (`releash workflow ...`)**: `list` / `runs` / `status <run-id>` / `logs <run-id>` を engine 非 IPC・file-direct で提供
- **engine 内部 typed 化**: `WorkflowCommand::CompleteNode` / `FailNode` を追加し、`NodeCompleted` / `NodeFailed` 発行点を `dispatch` 経由に集約。外部入口は `dispatch_external` で internal variant を拒否
- **破壊的削除**: 旧 5 command (`list_active_workflow_runs` / `list_completed_workflow_runs` / `list_workflow_runs_for_worktree` / `get_workflow_execution_log` / `get_workflow_execution_state`) を削除。後方互換 wrapper なし。フロント invoke も新名称に追従
- **DRY 担保**: API / CLI が `project_runs_to_summaries` / `list_workflows_inner` / `canonicalize_managed_worktree_path_inner` を共有し、等価性をテストで照合

## スコープ外（後続マイルストーン）

- mutating CLI（[06]）/ structured output 提出 CLI（[08]）/ Workflow Panel UI（[07]）/ bash node ランタイム（[13]）/ main-agent narrator（[16]）

## Test plan

- [ ] `cd src-tauri && cargo fmt --check`
- [ ] `cd src-tauri && cargo clippy -- -D warnings`
- [ ] `cd src-tauri && cargo test`
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] CLI 動作確認: `releash workflow list` / `runs` / `status <run-id>` / `logs <run-id>`
- [ ] 旧 5 command の invoke 呼び出しが残っていないこと
- [ ] 外部経路 (Tauri adapter / CLI) から `CompleteNode` / `FailNode` を組み立てる経路が存在しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow観測専用のCLIコマンドを実装（list、runs、status、logs）
  * Workflow実行履歴とステータスの読み取り専用API群を追加

* **Documentation**
  * Workflow Engine Evolution（read-only run APIs + CLI）の詳細仕様書を新規追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/1018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->