### PR TITLE
feat(workflow): structured output 提出の CLI/API 入口を追加 (issues-1029)

### DIFF
--- a/docs/spec/issues-1029.md
+++ b/docs/spec/issues-1029.md
@@ -1,0 +1,182 @@
+# issues-1029: Workflow Engine Evolution - OutputForm CLI
+
+関連: [GitHub Issue #1029](https://github.com/siro33950/releash/issues/1029) / マイルストーン [08] / [`workflow-engine-evolution-plan.md`](../workflow-engine-evolution-plan.md) / [`workflow-engine-model-boundary.md`](../workflow-engine-model-boundary.md) / 先行 [issues-1011](./issues-1011.md) / [issues-1013](./issues-1013.md) / [issues-1015](./issues-1015.md) / [issues-1019](./issues-1019.md) / [issues-1023](./issues-1023.md)
+
+## 要求
+
+**種別**: 新機能
+
+**ゴール**: step agent が「自由文中に `<workflow_output>` ブロックを書く」という prose parsing 経由ではなく、`run_id` を主語とした typed CLI/API 経由で contract に従う structured output を engine に提出できるようにする。具体的には以下が満たされること。
+
+- 利用者・Agent・外部 caller は `run_id` と `step_name` を主語に、step の output contract に従う JSON を CLI/API 経由で engine に提出できる。提出は file-direct 経路（[05]/[06] CLI と同じく、起動中の Releash app を介さず `workflow_runs/` 配下の run metadata / event log を直接読み書きする経路）で完結する。
+- 提出経路として、以下の 3 CLI コマンドが存在する。各コマンドは対応する Tauri/local API 入口を engine 側に伴う。
+  - `releash workflow output submit <run-id> --step <step-name> --type <contract> --json '{...}'`（`--json` の代替として `--file output.json` も受け付ける）
+  - `releash workflow output validate <run-id> --step <step-name> --file output.json`
+  - `releash workflow output get <run-id> --step <step-name>`
+- `submit` は engine の既存 output contract validation（`workflow/contract.rs`）を再利用して入力 JSON を contract 適合か検査し、適合した場合のみ当該 step の `step_outputs` と `workflow_variables` を更新する。
+- 適合した `submit` は append-only な `WorkflowEvent::OutputSubmitted`（または同義の typed event）を発行し、event log（NDJSON）と active state の双方に反映する。後続 step は従来通り `pass_output_from` で当該 output を参照できる。
+- 不適合な入力（contract 違反・JSON parse 失敗・対象 step 不在・stale step 等）は決定論的な validation error として CLI 終了コード / API エラーで返り、`step_outputs` / `workflow_variables` / event log は副作用なしの状態に保たれる。`validate` は副作用なしで同一の validation 結果のみを返す。
+- `get` は当該 step に対し既に提出済みの structured output（および提出時刻等の付随メタ情報）を返す。未提出の場合は決定論的に「未提出」を返す。
+- 既存の `<workflow_output>` プロース抽出経路（step agent の自由文出力から contract を抽出して `step_outputs` を更新する経路）は本 issue で廃止する。CLI/API 経由の typed 提出が唯一の structured output 提出経路となる。
+- 廃止に伴い、built-in workflow（`built-in/spec-driven-development.yml` および同梱されている他の built-in YAML）の step agent instruction を CLI 提出前提に書き換える。具体的には「step 完了時に `releash workflow output submit ...` を呼ぶことで contract を提出する」旨を step prompt / instruction 側で明示するように移行する。
+
+**スコープ外**: 以下は本 issue の対象外。
+
+- Workflow panel（[07]）への structured output 表示 UI・提出 UI の追加。submit 済 output を Workflow panel の step detail 上で structured に整形して見せる UI、Workflow panel から人間オペレータが output を submit する UI のいずれも本 issue では追加しない。step detail 上での output 表示は、既存の `WorkflowEvent` / `WorkflowState` 由来の素朴な表示（[07] で既に成立しているもの）の範囲に閉じる。
+- Agent 向け Skill / Instructions file の追加（[15]）。step agent に「CLI をいつ・どう呼ぶか」を教える skill 文書化は本 issue では行わない。本 issue は built-in workflow の step prompt 内に必要な指示を埋め込む範囲に閉じる。
+- bash node 実行系統（[13]）。
+- Workflow template marketplace / external triggers / Web UI 移植（plan doc「採用しないもの」）。
+- main-agent narrator への typed event 配信と user-facing report の整備（[16]）。`OutputSubmitted` event を main agent narrator に配信する経路は [16] の責務範囲に閉じる。
+- Workflow run の起動 / approve / reject / abort CLI（[05]/[06] で既に確立済み）。本 issue はそれら CLI と並列に `workflow output` サブコマンド群を追加するに留まる。
+- Remote セッション側（`src/remote/`）への structured output 提出 UI 提供。CLI/API 経路として engine 側に typed 入口を生やすため、Remote から将来この入口を利用することは妨げないが、本 issue で Remote 専用 UI を追加することはしない。
+
+**現状温存**:
+
+- 既存の typed command boundary（[04]/[06]）と `WorkflowEngine::dispatch_external` 単一入口は破壊しない。`OutputSubmitted` 系統の typed 入口も同じ `dispatch_external` 経由で engine に到達する。
+- 既存の run_id 主語 read-only API / mutating API（[05]/[06]）と既存 UI command（[07]）はそのまま動き続ける。本 issue は `workflow_runs/` 配下の永続化形式に互換性を保ったまま `step_outputs` / event log を更新する。
+- 既存の `step_outputs` を後続 step が `pass_output_from` で参照する semantics（[02] 以降で確立済み）は破壊しない。CLI 経由で更新された `step_outputs` は、従来 prose 抽出経由で更新されていた `step_outputs` と同一の slot に書き込まれ、後続 step から経路非依存に参照できる。
+- 既存 output contract 定義（`workflow/contract.rs` 配下の contract 種別・facet 解決経路）は破壊しない。本 issue は新規の contract type を追加せず、既存 contract validation ロジックを CLI 入口から再利用する。
+- 既存の Workflow panel（[07]）の表示構造・既存の自由対話 chat tab・既存の右パネル各モードは破壊しない。本 issue は engine 側の typed 提出経路と CLI 入口の追加・既存 prose 抽出経路の廃止・built-in workflow の step prompt 書き換えに限定する。
+
+**背景**: マイルストーン [02]–[07] により、workflow engine は `run_id` を主語に state を観測・変化させる典型操作（list / status / logs / approve / reject / abort）を typed command boundary 経由で扱えるようになり、UI 側にも `run_id` 主語の第一級観測 surface（Workflow panel）が成立した。
+
+一方、step agent から engine への「structured output の受け渡し」だけは依然として step agent の自由文出力に `<workflow_output>` ブロックを書かせ、engine がそれを prose parsing して `step_outputs` を更新する経路に閉じている。これは以下の問題を持つ。
+
+- step agent の自由文出力が contract に適合しない（block 開始タグの欠落・JSON 構文崩れ・余計な markdown 装飾の混入等）と、engine 側は「無いものとして扱う / repair prompt を出す」しかなく、決定論的な validation gate にならない。
+- agent が出力を contract 形式で書けるかは prompt 設計と LLM 出力の安定性に依存し、Agent / 外部 caller / 人間オペレータが「engine に明示的に contract を提出する」入口を持たない。
+- step agent 以外の caller（外部スクリプト・人間オペレータ・将来の bash node など）から contract を engine に提出する経路が存在せず、step output が常に「agent の自由文」起点でしか更新されない。
+- plan doc が完了条件として置く「step agent が prose parsing に頼らず structured output を提出できる」「invalid output が決定論的な validation error になる」を満たすには、agent-to-engine の structured output 経路を typed CLI/API として一段抽象化する必要がある。
+
+本 issue は、`run_id` を主語に typed structured output を engine に提出する CLI/API を追加し、既存 prose 抽出経路を廃止して CLI 経路を唯一の structured output 提出経路に揃える。これにより、後続マイルストーン（[13] bash gate / [15] Skill / [16] Main Agent Mediation）が「agent / 外部 caller / 人間オペレータが engine に対し決定論的に contract を提出できる」を前提に組み立て可能になる。
+
+**前提**:
+
+- マイルストーン [02] Normalized Workflow 完了済み。`Workflow` / `NodeDefinition` / `WorkflowEvent` の新 schema が成立し、`workflow/contract.rs` 配下の output contract validation が新 schema 前提で動作する。
+- マイルストーン [03] Run Store / Run ID 完了済み（[issues-1011](./issues-1011.md)）。`run_id` を一次キーとする run metadata と event log の永続化基盤が `workflow_runs/{run_id}/` に確立されており、CLI から file-direct で run metadata / event log を読み書きできる。
+- マイルストーン [04] Command / Event Boundary 完了済み（[issues-1013](./issues-1013.md)）。`WorkflowCommand` typed 入口と `WorkflowEvent` 語彙、`WorkflowEngine::dispatch_external` 単一入口、認可・冪等性・stale target 判定が engine 内に閉じている。`OutputSubmitted` 系統の typed event を [04] で確立した event 語彙に追加する形で受け入れられる。
+- マイルストーン [05] Read-Only Run APIs + CLI 完了済み（[issues-1015](./issues-1015.md)）。CLI が file-direct で `workflow_runs/` を読む基盤と Tauri/local API による run 観測経路が既に存在し、`workflow output get` / `workflow output validate` の実装基盤として再利用できる。
+- マイルストーン [06] Mutating CLI 完了済み（[issues-1019](./issues-1019.md)）。CLI から file-direct で run 状態を変化させる経路と、CLI 経路・UI 経路が `dispatch_external` で合流する境界が確立されており、`workflow output submit` も同じ file-direct + typed command 合流のパターンを踏襲できる。
+- マイルストーン [07] Workflow Panel / Command Center 完了済み（[issues-1023](./issues-1023.md)）。Workflow panel が `WorkflowEvent` 列を一次観測 surface としているため、本 issue で追加する `OutputSubmitted` event は追加実装なしに timeline 上の事実として観測できる。
+
+## 振る舞い定義
+
+```gherkin
+Feature: Workflow step への構造化出力の提出
+
+  Rule: 提出された構造化出力は contract に適合する場合のみ step output として確定する
+    Scenario: contract に適合する構造化出力が提出される
+      Given 進行中の workflow run に output contract を持つ step が存在する
+      When 提出者が当該 step に対し contract に適合する構造化出力を提出する
+      Then 当該 step の構造化出力として確定する
+      And 後続 step から参照可能な状態になる
+      And 当該提出が run の事実履歴に記録される
+
+    Scenario: contract に適合しない構造化出力が提出される
+      Given 進行中の workflow run に output contract を持つ step が存在する
+      When 提出者が当該 step に対し contract に適合しない構造化出力を提出する
+      Then 提出は拒否されたことが提出者に伝わる
+      And 当該 step の構造化出力は提出前の状態のまま保たれる
+      And 当該拒否は run の事実履歴に残らない
+
+    Scenario: 提出対象として妥当でない step に対し提出する
+      Given workflow run が存在する
+      And 提出対象として指定された step が当該 run に存在しない、あるいは既に出力を受け付けられる状態にない
+      When 提出者が当該 step に対し構造化出力を提出する
+      Then 提出は拒否されたことが提出者に伝わる
+      And 当該 run の状態は提出前のまま保たれる
+
+  Rule: 提出前に副作用なしで適合性を確認できる
+    Scenario: 構造化出力の適合性のみを確認する
+      Given 進行中の workflow run に output contract を持つ step が存在する
+      When 提出者が当該 step に対し構造化出力の適合性確認のみを要求する
+      Then 適合性の判定結果が提出者に伝わる
+      And 当該 step の構造化出力および run の事実履歴は要求前の状態のまま保たれる
+
+  Rule: 提出済みの構造化出力は経路非依存に参照できる
+    Scenario: 提出済みの構造化出力を参照する
+      Given workflow run の step に構造化出力が提出済みである
+      When 参照者が当該 step の構造化出力を要求する
+      Then 提出済みの構造化出力と提出に伴う付随情報が参照者に伝わる
+
+    Scenario: 未提出の step の構造化出力を参照する
+      Given workflow run に output contract を持つ step が存在する
+      And 当該 step にはまだ構造化出力が提出されていない
+      When 参照者が当該 step の構造化出力を要求する
+      Then 未提出であることが参照者に伝わる
+
+    Scenario: 提出済みの構造化出力を後続 step が参照する
+      Given workflow run の先行 step に構造化出力が提出済みである
+      And 後続 step が当該 step の出力を入力として参照するよう定義されている
+      When 後続 step が起動する
+      Then 後続 step は提出済みの構造化出力を入力として受け取る
+
+  Rule: 構造化出力の確定経路は明示的提出のみに統一される
+    Scenario: step agent の自由文出力に構造化出力相当の表現が含まれる
+      Given 進行中の workflow run に output contract を持つ step が存在する
+      When 当該 step の agent が自由文出力の中に構造化出力相当の表現を含める
+      But 明示的な提出は行わない
+      Then 当該 step の構造化出力は未提出のまま保たれる
+      And 後続 step からも未提出として扱われる
+```
+
+## アーキテクチャ概要
+
+### 責務配置
+
+- **CLI 層（`src-tauri/src/cli/`）**:
+  - 担当: `releash workflow output submit / validate / get` 3 サブコマンドの引数解析、`--json` と `--file` の受付、`submit` の pending command file 書き出し（[06] と同じ file-direct 経路）、`get` の `workflow_runs/` / `workflow_logs/` file-direct 読み出し（[05] 基盤の再利用）、`validate` の contract validator 呼び出し
+  - 担当しない: state の直接更新、`step_outputs` への書き込み、`WorkflowEvent` の append、contract validation ロジック本体の実装
+- **Tauri command 層（`src-tauri/src/workflow/commands.rs`）**:
+  - 担当: `submit` / `validate` / `get` の local API 入口提供（in-process 経路として CLI と並列に存在し、UI/Remote/外部 caller から呼べる）、`engine.dispatch_external` への集約
+  - 担当しない: pending file 経路（in-process 経路は pending を経由しない）、state mutation 本体
+- **Workflow engine（`src-tauri/src/workflow/engine.rs`）**:
+  - 担当: `WorkflowCommand::SubmitOutput`（新規 variant）を `dispatch_external` 単一入口で受理し、contract 適合判定 → `step_outputs` / `workflow_variables` 更新 → `WorkflowEvent::OutputSubmitted` append を 1 つの不可分なトランザクションとして実行、stale target / 不在 step / 認可違反の決定論的拒否、CLI 経路と in-process 経路の合流
+  - 担当しない: agent 自由文からの structured output 抽出（本 issue で除去）
+- **Contract module（`src-tauri/src/workflow/contract.rs`）**:
+  - 担当: 既存 output contract 適合判定を pure validator として engine と `validate` CLI の双方から再利用される形で提供
+  - 担当しない: prose 抽出（`<workflow_output>` block を agent 自由文から取り出すヘルパは本 issue で除去）、state への副作用
+- **Event log / Run store（`src-tauri/src/workflow/event.rs`, `log.rs`, `run.rs`, `state.rs`）**:
+  - 担当: `WorkflowEvent::OutputSubmitted` variant の追加、append-only NDJSON への書き込み、`step_outputs` slot の永続化（書き込み入口は engine 経由のみ）
+- **Pending command queue（`src-tauri/src/workflow/pending_command.rs`, `pending_command_dispatcher.rs`）**:
+  - 担当: `SubmitOutput` を `PendingCommandPayload` の新 variant として受け入れ、`workflow_pending/{pending,processing,processed}/` 経路で engine に取り次ぐ
+- **Built-in workflow YAML（`workflows/built-in/spec-driven-development.yml` および同梱の他 built-in YAML）**:
+  - 担当: step agent prompt に「step 完了時に `releash workflow output submit ...` 経由で contract を提出する」旨を明示
+  - 担当しない: 自由文中に `<workflow_output>` を書かせる旧来の指示（本 issue で除去）
+
+### データ/通信フロー
+
+- **submit（CLI 経路）**: CLI が引数解析 → `PendingCommandPayload::SubmitOutput` を `workflow_pending/pending/` に書き出し → engine 側 pending dispatcher が pickup → `WorkflowCommand::SubmitOutput` に変換 → `engine.dispatch_external` → contract validate → 適合時のみ `step_outputs` / `workflow_variables` 更新 + `OutputSubmitted` event append（不適合時は副作用なしで決定論的エラー、event も残さない）→ CLI に outcome を返す
+- **submit（in-process / Tauri command 経路）**: caller → `#[tauri::command]` → 同じ `engine.dispatch_external` 入口 → 上と同一の engine 処理に合流
+- **validate**: CLI/API → `contract.rs` の pure validator を直接呼び出し → 判定結果のみ返却（pending file・event log・state のいずれにも触れない）
+- **get**: CLI/API → `workflow_runs/{run_id}.json` と `workflow_logs/{run_id}.ndjson` を file-direct で読み、`step_outputs` slot を参照 → 提出済みなら構造化出力と付随メタを返却、未提出なら決定論的に「未提出」を返す
+- **後続 step による参照**: engine が `pass_output_from` を解決する際に `step_outputs` slot を経路非依存に読む（CLI 経由でも in-process 経由でも同一 slot に書かれているため後続 step 側は提出経路を区別しない）
+
+### 状態 Owner
+
+- **`step_outputs` / `workflow_variables`**: workflow engine（`workflow/state.rs::WorkflowState` 上）が単一 owner。書き込み入口は `engine.dispatch_external` のみ
+- **`WorkflowEvent` 列（NDJSON）**: `workflow/log.rs` が永続化 owner。append は engine 経由のみ
+- **`WorkflowRun` metadata**: `workflow/run.rs` の `RunStore` が owner
+- **Pending command queue（`workflow_pending/`）**: ファイルシステムが owner。CLI が producer、engine 側 pending dispatcher が consumer
+- **CLI 入力（コマンド引数・`--json` / `--file` 内容）**: CLI プロセス内で完結。engine に届くのは `PendingCommandPayload` にシリアライズされた構造化入力のみ
+- **Contract 定義**: `workflow/contract.rs` が静的に保持。本 issue では新規 contract 種別を追加しない
+
+### 境界
+
+- **CLI 層は engine state を直接読み書きしない**: `submit` は必ず pending file 経由、`get` は read-only file-direct のみ、`validate` は副作用のない pure validator 呼び出しのみ
+- **Contract validation は engine と CLI（`validate`）の双方から再利用される pure 関数**: state mutation を伴わず、入力に対する判定だけを返す
+- **Prose 抽出経路は engine 側から完全に除去**: step agent の自由文に含まれる `<workflow_output>` 相当の表現を engine は一切観測しない（振る舞い定義の「明示的提出は行わない」シナリオに対応）
+- **OutputSubmitted の append は適合判定および state 更新と同一トランザクション境界内**: validation 失敗時は event を残さず `step_outputs` / `workflow_variables` も不変、成功時は 3 者が原子的に揃う
+- **CLI 経路と in-process 経路は `dispatch_external` で合流**: 入口層に依らず同一の engine 処理を経るため、提出経路ごとの分岐は engine の責務範囲に閉じる
+- **Workflow panel（[07]）への追加実装は本 issue の境界外**: `OutputSubmitted` event は既存 timeline 表示の中で素朴に観測されるに留め、structured output 表示専用 UI は追加しない
+
+### 実装に委ねること
+
+- CLI サブコマンドのパーサ構成詳細（clap の sub-builder 分割、`--json` と `--file` の相互排他の表現方法）
+- `PendingCommandPayload` における `SubmitOutput` variant の field 名・シリアライズ表現
+- engine 内 `SubmitOutput` handler の関数分割と helper 命名
+- 不適合・stale・不在 step などのエラー種別に対する CLI exit code および API error code の具体値
+- `get` の返却ペイロードに含める付随メタ（提出時刻・event index 等）の項目選定と命名
+- Built-in workflow YAML 内の step prompt 文面（CLI 提出を指示する具体的な日本語/英語表現）
+- テストケースの具体的配置（contract 適合判定 reuse は `contract.rs` 内、submit 一貫トランザクションは `engine.rs` 内、CLI 経路は `cli` モジュール内、pending dispatcher との結合は `pending_command_dispatcher.rs` 内など）と各テストのデータ準備手順
+- prose 抽出経路除去に伴う関連 dead code（旧 helper・旧 prompt 文字列など）の物理的な削除範囲
+

--- a/docs/spec/issues-1029.md
+++ b/docs/spec/issues-1029.md
@@ -76,7 +76,8 @@ Feature: Workflow step への構造化出力の提出
       When 提出者が当該 step に対し contract に適合しない構造化出力を提出する
       Then 提出は拒否されたことが提出者に伝わる
       And 当該 step の構造化出力は提出前の状態のまま保たれる
-      And 当該拒否は run の事実履歴に残らない
+      And 当該拒否は run のメイン履歴（OutputSubmitted）に残らない
+      And 当該拒否は observability 用の補助履歴として記録される
 
     Scenario: 提出対象として妥当でない step に対し提出する
       Given workflow run が存在する
@@ -84,6 +85,7 @@ Feature: Workflow step への構造化出力の提出
       When 提出者が当該 step に対し構造化出力を提出する
       Then 提出は拒否されたことが提出者に伝わる
       And 当該 run の状態は提出前のまま保たれる
+      And 当該拒否は observability 用の補助履歴として記録される
 
   Rule: 提出前に副作用なしで適合性を確認できる
     Scenario: 構造化出力の適合性のみを確認する
@@ -104,6 +106,13 @@ Feature: Workflow step への構造化出力の提出
       When 参照者が当該 step の構造化出力を要求する
       Then 未提出であることが参照者に伝わる
 
+    Scenario: workflow に存在しない step の構造化出力を参照する
+      Given workflow run が存在する
+      And 参照者が指定した step が当該 workflow に存在しない
+      When 参照者が当該 step の構造化出力を要求する
+      Then 参照は拒否されたことが参照者に伝わる
+      And 当該拒否は適合性確認（validate）の不在 step に対する判定と同じ扱いになる
+
     Scenario: 提出済みの構造化出力を後続 step が参照する
       Given workflow run の先行 step に構造化出力が提出済みである
       And 後続 step が当該 step の出力を入力として参照するよう定義されている
@@ -117,6 +126,33 @@ Feature: Workflow step への構造化出力の提出
       But 明示的な提出は行わない
       Then 当該 step の構造化出力は未提出のまま保たれる
       And 後続 step からも未提出として扱われる
+
+  Rule: CLI 入口は対象 run の実在を提出前に検証する
+    Scenario: 存在しない run_id に対し mutation を要求する
+      Given workflow run の観測経路に対象 run_id が存在しない
+      When 提出者が当該 run_id に対し承認・却下・中止・構造化出力提出のいずれかを要求する
+      Then 提出は CLI 入口で拒否されたことが提出者に伝わる
+      And 受理キューには当該要求が投入されない
+
+    Scenario: 観測経路の向き先が存在しない
+      Given 観測経路として指定されたデータ領域そのものが存在しない
+      When 提出者が観測経路を介して run 一覧・状態・履歴を要求する
+      Then 観測は拒否されたことが提出者に伝わる
+      And 「観測対象が 0 件」と区別される
+
+  Rule: engine が判断した拒否は観測可能な補助履歴として記録される
+    Scenario: 拒否規則を持たない承認待ち step に対し却下する
+      Given 進行中の workflow run の承認待ち step に対する却下規則が定義されていない
+      When 提出者が当該 step に対し却下を要求する
+      Then 当該 step の状態は承認待ちのまま保たれる
+      And 当該却下要求が受理された事実は run の事実履歴に記録される
+      And 当該要求が engine によって拒否された事実が補助履歴として記録される
+
+    Scenario: 承認規則と整合しない理由で却下要求が engine に拒否される
+      Given 進行中の workflow run の承認待ち step に対し engine の認可・状態判定が承認外と判断する条件が成立している
+      When 提出者が当該 step に対し却下を要求する
+      Then 当該要求が engine によって拒否された事実が補助履歴として記録される
+      And 補助履歴には拒否理由の分類が含まれる
 ```
 
 ## アーキテクチャ概要
@@ -136,7 +172,7 @@ Feature: Workflow step への構造化出力の提出
   - 担当: 既存 output contract 適合判定を pure validator として engine と `validate` CLI の双方から再利用される形で提供
   - 担当しない: prose 抽出（`<workflow_output>` block を agent 自由文から取り出すヘルパは本 issue で除去）、state への副作用
 - **Event log / Run store（`src-tauri/src/workflow/event.rs`, `log.rs`, `run.rs`, `state.rs`）**:
-  - 担当: `WorkflowEvent::OutputSubmitted` variant の追加、append-only NDJSON への書き込み、`step_outputs` slot の永続化（書き込み入口は engine 経由のみ）
+  - 担当: `WorkflowEvent::OutputSubmitted` variant の追加、`WorkflowEvent::CliMutationRejected` variant の追加（観測経路用の補助履歴）、append-only NDJSON への書き込み、`step_outputs` slot の永続化（書き込み入口は engine 経由のみ）
 - **Pending command queue（`src-tauri/src/workflow/pending_command.rs`, `pending_command_dispatcher.rs`）**:
   - 担当: `SubmitOutput` を `PendingCommandPayload` の新 variant として受け入れ、`workflow_pending/{pending,processing,processed}/` 経路で engine に取り次ぐ
 - **Built-in workflow YAML（`workflows/built-in/spec-driven-development.yml` および同梱の他 built-in YAML）**:
@@ -165,7 +201,8 @@ Feature: Workflow step への構造化出力の提出
 - **CLI 層は engine state を直接読み書きしない**: `submit` は必ず pending file 経由、`get` は read-only file-direct のみ、`validate` は副作用のない pure validator 呼び出しのみ
 - **Contract validation は engine と CLI（`validate`）の双方から再利用される pure 関数**: state mutation を伴わず、入力に対する判定だけを返す
 - **Prose 抽出経路は engine 側から完全に除去**: step agent の自由文に含まれる `<workflow_output>` 相当の表現を engine は一切観測しない（振る舞い定義の「明示的提出は行わない」シナリオに対応）
-- **OutputSubmitted の append は適合判定および state 更新と同一トランザクション境界内**: validation 失敗時は event を残さず `step_outputs` / `workflow_variables` も不変、成功時は 3 者が原子的に揃う
+- **OutputSubmitted の append は適合判定および state 更新と同一トランザクション境界内**: validation 失敗時はメイン履歴（OutputSubmitted）を残さず `step_outputs` / `workflow_variables` も不変、成功時は 3 者が原子的に揃う
+- **CliMutationRejected はメイン履歴と独立した観測経路用補助履歴**: engine が CLI mutation（承認・却下・中止・構造化出力提出）を拒否した事実を observability 用途で記録する。accepted のメイン履歴（`OutputSubmitted` / `CliMutationRequested` / `ApprovalResolved` 等）に出ない条件と並列に発火し、CLI ユーザに「engine が無効と判断した」事実と理由分類を提供する
 - **CLI 経路と in-process 経路は `dispatch_external` で合流**: 入口層に依らず同一の engine 処理を経るため、提出経路ごとの分岐は engine の責務範囲に閉じる
 - **Workflow panel（[07]）への追加実装は本 issue の境界外**: `OutputSubmitted` event は既存 timeline 表示の中で素朴に観測されるに留め、structured output 表示専用 UI は追加しない
 
@@ -175,6 +212,8 @@ Feature: Workflow step への構造化出力の提出
 - `PendingCommandPayload` における `SubmitOutput` variant の field 名・シリアライズ表現
 - engine 内 `SubmitOutput` handler の関数分割と helper 命名
 - 不適合・stale・不在 step などのエラー種別に対する CLI exit code および API error code の具体値
+- CLI 入口で run_id / data_dir / step の実在チェックを行うタイミング・順序・エラーメッセージ文面（CLI 入口バリデーション境界）
+- `CliMutationRejected` event の拒否理由分類の追加・粗粒度設計（`run_not_found` / `no_reject_rule` / `step_not_accepting` / `contract_mismatch` / 他）
 - `get` の返却ペイロードに含める付随メタ（提出時刻・event index 等）の項目選定と命名
 - Built-in workflow YAML 内の step prompt 文面（CLI 提出を指示する具体的な日本語/英語表現）
 - テストケースの具体的配置（contract 適合判定 reuse は `contract.rs` 内、submit 一貫トランザクションは `engine.rs` 内、CLI 経路は `cli` モジュール内、pending dispatcher との結合は `pending_command_dispatcher.rs` 内など）と各テストのデータ準備手順

--- a/src-tauri/src/backends/bridge_common.rs
+++ b/src-tauri/src/backends/bridge_common.rs
@@ -29,9 +29,7 @@ use crate::session::{
     GetSessionResponse, MessagePart, MessageRole, SessionStore, SessionSummary,
 };
 
-pub(crate) use crate::backends::runtime_coordinator::{
-    acquire_session_runtime_lock, is_session_closing,
-};
+pub(crate) use crate::backends::runtime_coordinator::acquire_session_runtime_lock;
 
 pub const CLAUDE_BACKEND_ID: &str = "claude";
 pub const CODEX_BACKEND_ID: &str = "codex";
@@ -4463,6 +4461,10 @@ pub async fn prepare_image_attachments_from_paths(
 /// ワークフローエンジンから呼ばれる内部版。
 /// AgentSessionを開始し、プロンプトを送信する。
 /// メッセージの追加(human + agent)とstart_agent_turnをまとめて行う。
+///
+/// [08] prose 抽出経路（contract repair prompt 経由）の廃止により caller が消えたが、
+/// 将来の再利用余地のため pub(crate) を保持する。
+#[allow(dead_code)]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn start_agent_turn_internal<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
@@ -7026,19 +7028,10 @@ mod tests {
             .rev()
             .find(|msg| msg.role == MessageRole::Agent)
             .unwrap();
-        match crate::workflow::contract::validate_contract(
-            "approved-fix-policy",
-            crate::workflow::contract::extract_workflow_output(&latest_agent.content),
-        ) {
-            crate::workflow::contract::ContractValidationResult::Valid {
-                structured_output,
-                result,
-            } => {
-                assert_eq!(result.as_deref(), Some("approved"));
-                assert_eq!(structured_output["policy"], "Latest adjusted policy.");
-            }
-            other => panic!("expected latest assistant output to be valid policy, got {other:?}"),
-        }
+        // [08] prose 抽出経路は廃止済み。session が更新されていることだけ確認し、
+        // contract 検証は CLI submit 経由（`workflow::contract::validate_contract_value`）
+        // の単体テストでカバーする。
+        assert!(latest_agent.content.contains("Latest adjusted policy."));
 
         let removed_proc = handles.lock().await.remove(&session.id);
         if let Some(mut proc) = removed_proc {

--- a/src-tauri/src/backends/bridge_common.rs
+++ b/src-tauri/src/backends/bridge_common.rs
@@ -6850,7 +6850,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn approval_chat_adjustment_send_path_keeps_session_and_updates_latest_output() {
+    async fn approval_chat_adjustment_send_path_keeps_session_state() {
         let worktree = tempfile::tempdir().unwrap();
         let worktree_path = worktree.path().to_string_lossy().to_string();
         let engine = Arc::new(WorkflowEngine::new_for_test());
@@ -6997,10 +6997,13 @@ mod tests {
             .rev()
             .find(|msg| msg.role == MessageRole::Agent)
             .unwrap();
-        // [08] prose 抽出経路は廃止済み。session が更新されていることだけ確認し、
-        // contract 検証は CLI submit 経由（`workflow::contract::validate_contract_value`）
-        // の単体テストでカバーする。
-        assert!(latest_agent.content.contains("Latest adjusted policy."));
+        // [08] このテストの責務は「send path で session が破壊されず維持されること」のみに限定する。
+        // typed structured output の contract 検証（typed な step_outputs 更新の保証）は
+        // SubmitOutput を経由する CLI/API 経路でしか発生しないため、本テストでは保証しない。
+        // contract 検証経路の回帰テストは `workflow::contract` の単体テスト群および
+        // `workflow::engine` の SubmitOutput 経路テストで別途カバーする。
+        // ここでは「session の最新 Agent メッセージが上書きされて存在すること」のみ確認する。
+        assert_eq!(latest_agent.id, agent.id);
 
         let removed_proc = handles.lock().await.remove(&session.id);
         if let Some(mut proc) = removed_proc {

--- a/src-tauri/src/backends/bridge_common.rs
+++ b/src-tauri/src/backends/bridge_common.rs
@@ -4458,37 +4458,6 @@ pub async fn prepare_image_attachments_from_paths(
     Ok(attachments)
 }
 
-/// ワークフローエンジンから呼ばれる内部版。
-/// AgentSessionを開始し、プロンプトを送信する。
-/// メッセージの追加(human + agent)とstart_agent_turnをまとめて行う。
-///
-/// [08] prose 抽出経路（contract repair prompt 経由）の廃止により caller が消えたが、
-/// 将来の再利用余地のため pub(crate) を保持する。
-#[allow(dead_code)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn start_agent_turn_internal<R: tauri::Runtime>(
-    app: &tauri::AppHandle<R>,
-    handles: &Arc<Mutex<AgentProcessMap>>,
-    session_store: &Arc<SessionStore>,
-    chat_session_id: &str,
-    cwd: &str,
-    permission_mode: &str,
-    prompt: &str,
-) -> Result<(), String> {
-    wait_until_session_close_finished(chat_session_id).await;
-    let _runtime_guard = acquire_session_runtime_lock(chat_session_id).await;
-    start_agent_turn_internal_locked(
-        app,
-        handles,
-        session_store,
-        chat_session_id,
-        cwd,
-        permission_mode,
-        prompt,
-    )
-    .await
-}
-
 /// Runtime lock acquired by the caller variant used by workflow step startup.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn start_agent_turn_internal_locked<R: tauri::Runtime>(

--- a/src-tauri/src/backends/runtime_coordinator.rs
+++ b/src-tauri/src/backends/runtime_coordinator.rs
@@ -104,18 +104,6 @@ pub(crate) async fn wait_until_session_close_finished(chat_session_id: &str) {
     }
 }
 
-/// 指定 session_id が現在 close 中（mark_session_closing 後 clear_session_closing 前）か返す。
-/// engine 層の retry / spawn 判断で「ユーザーが閉じた直後の bridge を再起動しない」ガードに使う。
-/// [08] prose 抽出経路廃止以降は engine 内 caller がいないが、将来の再導入余地のため保持する。
-#[allow(dead_code)]
-pub(crate) async fn is_session_closing(chat_session_id: &str) -> bool {
-    RUNTIME_COORDINATOR
-        .closing_counts
-        .lock()
-        .await
-        .contains_key(chat_session_id)
-}
-
 pub(crate) async fn mark_pending_turn_starting(chat_session_id: &str) {
     RUNTIME_COORDINATOR
         .pending_turns

--- a/src-tauri/src/backends/runtime_coordinator.rs
+++ b/src-tauri/src/backends/runtime_coordinator.rs
@@ -106,6 +106,8 @@ pub(crate) async fn wait_until_session_close_finished(chat_session_id: &str) {
 
 /// 指定 session_id が現在 close 中（mark_session_closing 後 clear_session_closing 前）か返す。
 /// engine 層の retry / spawn 判断で「ユーザーが閉じた直後の bridge を再起動しない」ガードに使う。
+/// [08] prose 抽出経路廃止以降は engine 内 caller がいないが、将来の再導入余地のため保持する。
+#[allow(dead_code)]
 pub(crate) async fn is_session_closing(chat_session_id: &str) -> bool {
     RUNTIME_COORDINATOR
         .closing_counts

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -553,7 +553,16 @@ fn cmd_output_submit(
             "contract mismatch: step '{step}' expects '{expected_contract}', got '{contract}'"
         )));
     }
-    match crate::workflow::contract::validate_contract_value(contract, structured_output.clone()) {
+    // [08] preflight と本 submit (`handle_submit_output`) で同一の前処理 + validation を
+    // 共有するため、`preprocess_and_validate_output_with_secrets` 経由で呼ぶ。
+    // CLI は別プロセスでアプリ状態 (`AppConfig` / `AppHandle`) を持たないため、ここでは
+    // `secrets = &[]` で呼び、最終的な masking 込み判定は engine 側 watcher 経由で再評価される
+    // （spec [08] CLI 完了基準: pending を書き出した時点で CLI は完了、最終判定は engine 側）。
+    match crate::workflow::engine::WorkflowEngine::preprocess_and_validate_output_with_secrets(
+        contract,
+        structured_output.clone(),
+        &[],
+    ) {
         crate::workflow::contract::ContractValidationResult::Valid { .. } => {}
         crate::workflow::contract::ContractValidationResult::Invalid(violation) => {
             return Err(CliError::InvalidInput(format!(
@@ -591,7 +600,15 @@ fn cmd_output_validate(
         .map_err(|e| CliError::InvalidInput(format!("Failed to read file {:?}: {e}", file)))?;
     let value: serde_json::Value = serde_json::from_str(&raw_json)
         .map_err(|e| CliError::InvalidInput(format!("Failed to parse JSON: {e}")))?;
-    match crate::workflow::contract::validate_contract_value(&contract, value) {
+    // [08] preflight と本 submit (`handle_submit_output`) で同一の前処理 + validation を
+    // 共有するため、`preprocess_and_validate_output_with_secrets` 経由で呼ぶ。
+    // CLI は別プロセスでアプリ状態を持たないため、ここでは `secrets = &[]` で呼ぶ
+    // （最終 masking 込み judging は engine 側で再評価される）。
+    match crate::workflow::engine::WorkflowEngine::preprocess_and_validate_output_with_secrets(
+        &contract,
+        value,
+        &[],
+    ) {
         crate::workflow::contract::ContractValidationResult::Valid { .. } => {
             println!("ok: contract '{contract}' is satisfied");
             Ok(())

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -570,6 +570,7 @@ fn format_event(event: &WorkflowEvent) -> String {
         WorkflowEvent::ParallelCompleted { .. } => "ParallelCompleted",
         WorkflowEvent::ContractRepairRequested { .. } => "ContractRepairRequested",
         WorkflowEvent::CliMutationRequested { .. } => "CliMutationRequested",
+        WorkflowEvent::OutputSubmitted { .. } => "OutputSubmitted",
     };
     match serde_json::to_string(event) {
         Ok(json) => format!("{kind} {json}"),

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -167,7 +167,9 @@ pub fn run() -> i32 {
     // data_dir は List / Runs / Status / Logs それぞれの branch 内で解決する。
     // List も workflow_runs/ 由来の `is_running` 反映のため data_dir を必要とするが、
     // 各 branch 内で解決することで未到達の branch では I/O を走らせない。
-    let resolve = || -> Result<PathBuf, CliError> { resolve_data_dir().map_err(CliError::Other) };
+    // [05] 観測経路境界: data_dir 自体が存在しない場合は `NotFound` として扱い、
+    // 「run が 0 件」と「向き先がそもそも無い」を区別する（5-1 修正）。
+    let resolve = || -> Result<PathBuf, CliError> { resolve_existing_data_dir() };
     let result = match cli.command {
         TopCommand::Workflow { command } => match command {
             WorkflowSubcommand::List { json } => match resolve() {
@@ -289,7 +291,7 @@ impl From<String> for CliError {
     }
 }
 
-/// データディレクトリの解決。
+/// データディレクトリの解決（パス計算のみ。存在チェックは行わない）。
 ///
 /// Tauri 側 `AppHandle::path().app_data_dir()` と同等のパスを CLI 側で計算する。
 /// CLI 起動独立性境界: デスクトップアプリ非稼働でも動作する。
@@ -299,6 +301,28 @@ fn resolve_data_dir() -> Result<PathBuf, String> {
     }
     let base = dirs::data_dir().ok_or_else(|| "Cannot resolve OS data_dir".to_string())?;
     Ok(base.join("com.releash.app"))
+}
+
+/// data_dir を解決し、パスが実在することを確認する。
+///
+/// [05] 観測経路境界: `RELEASH_DATA_DIR` の typo / アプリ未起動などで data_dir
+/// が存在しない場合に「runs が 0 件」と紛れないよう、CLI 入口で `NotFound`
+/// として弾く（5-1 修正）。
+fn resolve_existing_data_dir() -> Result<PathBuf, CliError> {
+    let path = resolve_data_dir().map_err(CliError::Other)?;
+    ensure_existing_data_dir(&path)?;
+    Ok(path)
+}
+
+/// data_dir パスの実在を確認する純粋判定（環境変数に依存せずテスト可能）。
+fn ensure_existing_data_dir(path: &Path) -> Result<(), CliError> {
+    if !path.exists() {
+        return Err(CliError::NotFound(format!(
+            "data directory does not exist: {}",
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 /// workflow template 一覧。
@@ -448,6 +472,15 @@ fn enqueue_pending_command(
     payload: CliRequestPayload,
 ) -> Result<PendingEnqueueOutput, CliError> {
     validate_run_id(run_id)?;
+    // [06] 入口バリデーション (5-2 修正): 不在 run_id への mutation は engine で
+    // silent-drop されるため、pending file 書き出し前に CLI で弾く。spec [06] の
+    // 「CLI 完了基準＝pending file 書き出しまで」境界は維持され、本チェックは
+    // 書き出し前の入口バリデーションとして位置づける。
+    if get_run_summary_file_direct(data_dir, run_id).is_none() {
+        return Err(CliError::NotFound(format!(
+            "Workflow run not found: {run_id}"
+        )));
+    }
     let store = PendingCommandStore::new(data_dir);
     let command = PendingCommand::new(run_id.to_string(), payload, current_timestamp());
     let path = store
@@ -485,6 +518,19 @@ fn command_input_error_to_cli_error(err: CommandInputError) -> CliError {
 
 /// [08] `releash workflow output submit`: 構造化出力を pending command として書き出す。
 /// engine 到達は稼働中アプリの watcher が担う（spec [08] CLI 完了基準境界）。
+///
+/// CLI 入口で同期的に以下を検証し、不適合な入力は pending file を作らずに
+/// `CliError::InvalidInput` として返す（spec [08]:「不適合な入力は決定論的な
+/// validation error として CLI 終了コードで返り、`step_outputs` / 事実履歴は
+/// 副作用なしの状態に保たれる」）。
+///
+/// 検証項目:
+///   - run が存在する（event log の RunStarted から workflow を解決）
+///   - step が workflow に存在し output_contract を持つ
+///   - caller の `--type` が step の expected contract と一致する
+///   - 入力 JSON が contract 適合（pure validator 再利用）
+///
+/// stale step 判定（受付中であるか）は engine の権威に委ねる。
 fn cmd_output_submit(
     data_dir: &Path,
     run_id: &str,
@@ -499,6 +545,24 @@ fn cmd_output_submit(
     let raw_json = read_submit_input_json(json_arg, file_arg)?;
     let structured_output: serde_json::Value = serde_json::from_str(&raw_json)
         .map_err(|e| CliError::InvalidInput(format!("Failed to parse JSON: {e}")))?;
+
+    // 同期検証: run / step / contract type 一致 / contract validation。
+    let expected_contract = resolve_step_output_contract_via_log(data_dir, run_id, step)?;
+    if expected_contract != contract {
+        return Err(CliError::InvalidInput(format!(
+            "contract mismatch: step '{step}' expects '{expected_contract}', got '{contract}'"
+        )));
+    }
+    match crate::workflow::contract::validate_contract_value(contract, structured_output.clone()) {
+        crate::workflow::contract::ContractValidationResult::Valid { .. } => {}
+        crate::workflow::contract::ContractValidationResult::Invalid(violation) => {
+            return Err(CliError::InvalidInput(format!(
+                "contract violation ({}): {}",
+                violation.reason, violation.details
+            )));
+        }
+    }
+
     let output = enqueue_pending_command(
         data_dir,
         run_id,
@@ -551,6 +615,10 @@ fn cmd_output_get(data_dir: &Path, run_id: &str, step: &str, json: bool) -> Resu
             "Workflow run not found: {run_id}"
         )));
     }
+    // [08] 振る舞い定義 Rule 3 (5-5 修正): step が workflow に存在しない場合は
+    // `output validate` と対称に `InvalidInput` を返す。`not_submitted` 出力は
+    // 「step は存在するが未提出」専用とする。
+    let _contract = resolve_step_output_contract_via_log(data_dir, run_id, step)?;
     let events = read_log(data_dir, run_id)?;
     let view = build_output_get_view(events, step);
     if json {
@@ -625,56 +693,31 @@ fn read_submit_input_json(
 
 /// event log の `RunStarted` から workflow definition を取り出し、step の
 /// `output_contract` を解決する。
+///
+/// 経路本体は pure helper
+/// `workflow::contract::resolve_step_output_contract_from_events` に委譲し、CLI
+/// 層は `ContractLookupError` を `CliError` に射影するだけを担う（[08]
+/// アーキテクチャ概要: Contract 解決は engine と CLI 双方から再利用される
+/// pure 関数。CLI 層は engine internals に依存しない境界）。
 fn resolve_step_output_contract_via_log(
     data_dir: &Path,
     run_id: &str,
     step: &str,
 ) -> Result<String, CliError> {
     let events = read_log(data_dir, run_id)?;
-    let workflow = events
-        .iter()
-        .find_map(|e| match e {
-            WorkflowEvent::RunStarted {
-                workflow_definition,
-                ..
-            } => Some(workflow_definition.clone()),
-            _ => None,
-        })
-        .ok_or_else(|| CliError::NotFound(format!("Workflow run not found: {run_id}")))?;
-    for node in &workflow.nodes {
-        if node.name == step {
-            return node
-                .output_contract
-                .clone()
-                .filter(|c| !c.trim().is_empty())
-                .ok_or_else(|| {
-                    CliError::InvalidInput(format!(
-                        "step '{step}' has no output_contract in workflow '{}'",
-                        workflow.name
-                    ))
-                });
-        }
-        if let Some(children) = &node.parallel_children {
-            for child in children {
-                if child.name == step {
-                    return child
-                        .output_contract
-                        .clone()
-                        .filter(|c| !c.trim().is_empty())
-                        .ok_or_else(|| {
-                            CliError::InvalidInput(format!(
-                                "step '{step}' has no output_contract in workflow '{}'",
-                                workflow.name
-                            ))
-                        });
-                }
+    crate::workflow::contract::resolve_step_output_contract_from_events(&events, step).map_err(
+        |err| match err {
+            crate::workflow::contract::ContractLookupError::RunNotFound => {
+                CliError::NotFound(format!("Workflow run not found: {run_id}"))
             }
-        }
-    }
-    Err(CliError::InvalidInput(format!(
-        "step '{step}' not found in workflow '{}'",
-        workflow.name
-    )))
+            crate::workflow::contract::ContractLookupError::NoOutputContract {
+                workflow_name,
+                step,
+            } => CliError::InvalidInput(format!(
+                "step '{step}' has no output_contract in workflow '{workflow_name}'"
+            )),
+        },
+    )
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -693,31 +736,19 @@ enum OutputGetView {
 }
 
 fn build_output_get_view(events: Vec<WorkflowEvent>, step: &str) -> OutputGetView {
-    // 最新 (= 最後尾) の OutputSubmitted を採用する。
-    let mut latest: Option<OutputGetView> = None;
-    for event in events {
-        if let WorkflowEvent::OutputSubmitted {
-            node_name,
-            contract,
-            structured_output,
-            submitted_at,
-            request_id,
-            timestamp,
-            ..
-        } = event
-        {
-            if node_name == step {
-                latest = Some(OutputGetView::Submitted {
-                    contract,
-                    structured_output,
-                    submitted_at,
-                    request_id,
-                    timestamp,
-                });
-            }
-        }
+    // 最新の OutputSubmitted は pure projection helper（spec [08] L165 / 振る舞い定義
+    // Rule 3）に集約する。CLI / Tauri 経路はそれぞれ自層の DTO（OutputGetView /
+    // WorkflowGetOutputResponse）へ map するだけで挙動を共有する。
+    match crate::workflow::event_projection::latest_output_submitted_for(&events, step) {
+        Some(snapshot) => OutputGetView::Submitted {
+            contract: snapshot.contract,
+            structured_output: snapshot.structured_output,
+            submitted_at: snapshot.submitted_at,
+            request_id: snapshot.request_id,
+            timestamp: snapshot.timestamp,
+        },
+        None => OutputGetView::NotSubmitted,
     }
-    latest.unwrap_or(OutputGetView::NotSubmitted)
 }
 
 /// 指定 run の event log。
@@ -866,6 +897,7 @@ fn format_event(event: &WorkflowEvent) -> String {
         WorkflowEvent::ContractRepairRequested { .. } => "ContractRepairRequested",
         WorkflowEvent::CliMutationRequested { .. } => "CliMutationRequested",
         WorkflowEvent::OutputSubmitted { .. } => "OutputSubmitted",
+        WorkflowEvent::CliMutationRejected { .. } => "CliMutationRejected",
     };
     match serde_json::to_string(event) {
         Ok(json) => format!("{kind} {json}"),
@@ -1578,6 +1610,44 @@ mod tests {
         assert!(Cli::try_parse_from(&argv).is_err());
     }
 
+    /// テスト用 helper: 指定 step に output_contract を持つ workflow を含む RunStarted
+    /// event を log に append し、run_file も書き込む。CLI submit / validate の synchronous
+    /// 解決経路は event log の RunStarted から workflow を取り出すため、テストでも本前提を
+    /// 揃えてからコマンドを呼ぶ。
+    fn seed_submit_workflow_log(
+        data_dir: &Path,
+        run_id: &str,
+        worktree_path: &str,
+        step_name: &str,
+        contract: &str,
+    ) {
+        let workflow = crate::workflow::schema::Workflow {
+            name: "wf".to_string(),
+            description: String::new(),
+            builtin: false,
+            nodes: vec![crate::workflow::schema::NodeDefinition {
+                name: step_name.to_string(),
+                node_type: crate::workflow::schema::NodeType::Agent,
+                output_contract: Some(contract.to_string()),
+                ..Default::default()
+            }],
+        };
+        write_run_file(
+            data_dir,
+            &make_run(run_id, worktree_path, RunStatus::Running, 100.0),
+        );
+        let log = WorkflowEventLog::new(data_dir);
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: run_id.to_string(),
+            workflow_name: "wf".to_string(),
+            workflow_file_stem: "wf".to_string(),
+            worktree_path: worktree_path.to_string(),
+            workflow_definition: workflow,
+            timestamp: 100.0,
+        })
+        .unwrap();
+    }
+
     /// [08] CLI 完了基準境界: `submit` は受理キュー投入（pending file の書き出し）まで
     /// 完了した時点で `Ok(())` を返す。書き出された pending entry は
     /// `PendingCommandPayload::SubmitOutput` shape を持ち、`run_id` と `step` /
@@ -1587,6 +1657,13 @@ mod tests {
         use crate::workflow::pending_command::PendingCommandPayload;
         let tmp = TempDir::new().unwrap();
         let run_id = test_uuid(91);
+        seed_submit_workflow_log(
+            tmp.path(),
+            &run_id,
+            "/wt/submit-pending",
+            "review",
+            "review-verdict",
+        );
         let json = "{\"verdict\":\"LGTM\"}";
         cmd_output_submit(
             tmp.path(),
@@ -1621,6 +1698,13 @@ mod tests {
         let input_file = tmp.path().join("input.json");
         std::fs::write(&input_file, b"{\"verdict\":\"LGTM\"}").unwrap();
         let run_id = test_uuid(92);
+        seed_submit_workflow_log(
+            tmp.path(),
+            &run_id,
+            "/wt/submit-pending-file",
+            "review",
+            "review-verdict",
+        );
         cmd_output_submit(
             tmp.path(),
             &run_id,
@@ -1665,8 +1749,117 @@ mod tests {
         assert!(matches!(err, CliError::InvalidInput(_)));
     }
 
+    /// [08] 振る舞い定義 Rule 1: 対象 run が存在しなければ pending file を作らず CliError。
+    /// CLI 同期検証の reject 経路を担保する（spec [08] 副作用なし境界）。
+    #[test]
+    fn cmd_output_submit_rejects_unknown_run_without_side_effects() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(101);
+        let err = cmd_output_submit(
+            tmp.path(),
+            &run_id,
+            "review",
+            "review-verdict",
+            Some("{\"verdict\":\"LGTM\"}".to_string()),
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CliError::NotFound(_)));
+        // pending file が作られていない
+        assert!(PendingCommandStore::new(tmp.path())
+            .list_pending()
+            .unwrap()
+            .is_empty());
+    }
+
+    /// [08] CLI 同期検証: workflow に存在しない step に対する submit は
+    /// pending file を作らず CliError::InvalidInput を返す。
+    #[test]
+    fn cmd_output_submit_rejects_unknown_step_without_side_effects() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(102);
+        seed_submit_workflow_log(
+            tmp.path(),
+            &run_id,
+            "/wt/submit-unknown-step",
+            "review",
+            "review-verdict",
+        );
+        let err = cmd_output_submit(
+            tmp.path(),
+            &run_id,
+            "no-such-step",
+            "review-verdict",
+            Some("{\"verdict\":\"LGTM\"}".to_string()),
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CliError::InvalidInput(_)));
+        assert!(PendingCommandStore::new(tmp.path())
+            .list_pending()
+            .unwrap()
+            .is_empty());
+    }
+
+    /// [08] CLI 同期検証: caller の `--type` が step の expected contract と
+    /// 一致しない場合は pending file を作らず CliError::InvalidInput。
+    #[test]
+    fn cmd_output_submit_rejects_contract_type_mismatch_without_side_effects() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(103);
+        seed_submit_workflow_log(
+            tmp.path(),
+            &run_id,
+            "/wt/submit-type-mismatch",
+            "review",
+            "review-verdict",
+        );
+        let err = cmd_output_submit(
+            tmp.path(),
+            &run_id,
+            "review",
+            "fix-result",
+            Some("{\"status\":\"FIXED\"}".to_string()),
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CliError::InvalidInput(_)));
+        assert!(PendingCommandStore::new(tmp.path())
+            .list_pending()
+            .unwrap()
+            .is_empty());
+    }
+
+    /// [08] CLI 同期検証: contract に適合しない JSON は pending file を作らず CliError。
+    #[test]
+    fn cmd_output_submit_rejects_contract_violation_without_side_effects() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(104);
+        seed_submit_workflow_log(
+            tmp.path(),
+            &run_id,
+            "/wt/submit-violation",
+            "review",
+            "review-verdict",
+        );
+        let err = cmd_output_submit(
+            tmp.path(),
+            &run_id,
+            "review",
+            "review-verdict",
+            Some("{\"verdict\":\"MAYBE\"}".to_string()),
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CliError::InvalidInput(_)));
+        assert!(PendingCommandStore::new(tmp.path())
+            .list_pending()
+            .unwrap()
+            .is_empty());
+    }
+
     /// [08] 振る舞い定義 Rule 2: validate は pure validator を呼び、副作用を起こさない。
-    /// pending dir / event log のいずれも変化しない。
+    /// pending dir / event log / run file / 既存 step_outputs のいずれも変化しない。
     #[test]
     fn cmd_output_validate_returns_ok_for_contract_compliant_input() {
         let tmp = TempDir::new().unwrap();
@@ -1697,16 +1890,52 @@ mod tests {
             timestamp: 100.0,
         })
         .unwrap();
+        // 既存の OutputSubmitted を 1 件入れておき、validate がそれを変化させないことも確認する。
+        log.append(&WorkflowEvent::OutputSubmitted {
+            run_id: run_id.clone(),
+            workflow_name: "wf".to_string(),
+            node_name: "review".to_string(),
+            contract: "review-verdict".to_string(),
+            structured_output: serde_json::json!({"verdict": "LGTM"}),
+            request_id: Some("00000000-0000-0000-0000-0000000000aa".to_string()),
+            submitted_at: Some(120.0),
+            timestamp: 130.0,
+        })
+        .unwrap();
         let input_file = tmp.path().join("input.json");
         std::fs::write(&input_file, b"{\"verdict\":\"LGTM\"}").unwrap();
 
+        let run_file_path = tmp
+            .path()
+            .join("workflow_runs")
+            .join(format!("{run_id}.json"));
+        let event_log_before = log.read_log(&run_id).unwrap();
+        let run_file_before = std::fs::read_to_string(&run_file_path).unwrap();
+
         cmd_output_validate(tmp.path(), &run_id, "review", &input_file).unwrap();
 
-        // 副作用なし: pending dir に何も書き込まれていない
+        // pending dir 不変
         assert!(PendingCommandStore::new(tmp.path())
             .list_pending()
             .unwrap()
             .is_empty());
+        // event log の長さ・内容が validate 前後で一致
+        let event_log_after = log.read_log(&run_id).unwrap();
+        assert_eq!(event_log_before.len(), event_log_after.len());
+        // run file の中身が変わっていない
+        let run_file_after = std::fs::read_to_string(&run_file_path).unwrap();
+        assert_eq!(run_file_before, run_file_after);
+        // 既存の OutputSubmitted がそのまま残る（reconstruct で step_outputs slot が不変）
+        let view = build_output_get_view(event_log_after.clone(), "review");
+        assert!(matches!(
+            view,
+            OutputGetView::Submitted {
+                ref contract,
+                submitted_at: Some(120.0),
+                timestamp: 130.0,
+                ..
+            } if contract == "review-verdict"
+        ));
     }
 
     #[test]
@@ -1915,6 +2144,10 @@ mod tests {
     fn cmd_enqueue_pending_writes_pending_file_for_approve() {
         let tmp = TempDir::new().unwrap();
         let run_id = test_uuid(81);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/approve", RunStatus::Running, 100.0),
+        );
         let payload = CliRequestPayload::Approve {
             node_name: Some("review".to_string()),
             comment: Some("LGTM".to_string()),
@@ -1933,6 +2166,10 @@ mod tests {
     fn cmd_enqueue_pending_writes_pending_file_for_reject_with_reason_and_node() {
         let tmp = TempDir::new().unwrap();
         let run_id = test_uuid(82);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/reject", RunStatus::Running, 100.0),
+        );
         let payload = CliRequestPayload::Reject {
             node_name: Some("review".to_string()),
             reason: "needs changes".to_string(),
@@ -1950,6 +2187,10 @@ mod tests {
     fn cmd_enqueue_pending_writes_pending_file_for_abort_with_node() {
         let tmp = TempDir::new().unwrap();
         let run_id = test_uuid(83);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/abort", RunStatus::Running, 100.0),
+        );
         let payload = CliRequestPayload::Abort {
             node_name: Some("review".to_string()),
         };
@@ -1969,6 +2210,89 @@ mod tests {
         let payload = CliRequestPayload::Abort { node_name: None };
         let err = enqueue_pending_command(tmp.path(), "not-a-uuid", payload).unwrap_err();
         assert!(matches!(err, CliError::InvalidInput(_)));
+    }
+
+    /// [05] 観測経路境界 (5-1 修正): data_dir が存在しない場合は `NotFound` として
+    /// 扱い、「runs 0 件」と「向き先がそもそも無い」を区別する。
+    #[test]
+    fn ensure_existing_data_dir_returns_not_found_for_missing_path() {
+        let missing = std::path::PathBuf::from("/non/existent/releash-data-dir-test-path");
+        let err = ensure_existing_data_dir(&missing).expect_err("missing data_dir must error");
+        let CliError::NotFound(msg) = &err else {
+            panic!("expected CliError::NotFound for missing data_dir, got: {err:?}");
+        };
+        assert!(
+            msg.contains(&missing.display().to_string()),
+            "error message must contain the path, got: {msg}"
+        );
+    }
+
+    /// [05] 観測経路境界 (5-1 修正): data_dir が存在する場合は Ok を返す。
+    #[test]
+    fn ensure_existing_data_dir_returns_ok_for_existing_path() {
+        let tmp = TempDir::new().unwrap();
+        ensure_existing_data_dir(tmp.path()).expect("existing data_dir must succeed");
+    }
+
+    /// [08] 振る舞い定義 Rule 3 (5-5 修正): `output get` は step が workflow に
+    /// 存在しない場合、`output validate` と対称に `CliError::InvalidInput` を返す
+    /// （exit=2）。`not_submitted` は「step は存在するが未提出」専用。
+    #[test]
+    fn cmd_output_get_rejects_unknown_step_with_invalid_input() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(96);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/get-unknown-step", RunStatus::Running, 100.0),
+        );
+        // step "review" を持つ workflow を log に播種し、それとは別名の step を問い合わせる。
+        seed_submit_workflow_log(
+            tmp.path(),
+            &run_id,
+            "/wt/get-unknown-step",
+            "review",
+            "review-verdict",
+        );
+        let err =
+            cmd_output_get(tmp.path(), &run_id, "nonexistent_step", true).expect_err("must error");
+        let CliError::InvalidInput(msg) = &err else {
+            panic!("expected CliError::InvalidInput for unknown step, got: {err:?}");
+        };
+        assert!(
+            msg.contains("nonexistent_step"),
+            "error message must include step name, got: {msg}"
+        );
+        assert!(
+            msg.contains("output_contract"),
+            "error message must mention output_contract (symmetric with validate), got: {msg}"
+        );
+    }
+
+    /// [06] 入口バリデーション (5-2 修正): 不存在 run_id への mutation は pending
+    /// file を書き出さずに `CliError::NotFound` で弾かれる。engine 到達後の
+    /// silent-drop を待たずに CLI 入口で検知する。
+    #[test]
+    fn cmd_enqueue_pending_rejects_unknown_run_id_without_side_effects() {
+        let tmp = TempDir::new().unwrap();
+        let unknown_run_id = test_uuid(99);
+        let payload = CliRequestPayload::Approve {
+            node_name: None,
+            comment: Some("x".to_string()),
+        };
+        let err = enqueue_pending_command(tmp.path(), &unknown_run_id, payload).unwrap_err();
+        let CliError::NotFound(msg) = &err else {
+            panic!("expected CliError::NotFound for unknown run_id, got: {err:?}");
+        };
+        assert!(
+            msg.contains(&unknown_run_id),
+            "error message must include run_id, got: {msg}"
+        );
+        // pending file は一切書き出されていない（副作用なし）。
+        let entries = PendingCommandStore::new(tmp.path()).list_pending().unwrap();
+        assert!(
+            entries.is_empty(),
+            "pending file must not be written when run is unknown"
+        );
     }
 
     /// [05] CLI 入力の信頼境界: managed worktree でない入力は

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -111,6 +111,46 @@ enum WorkflowSubcommand {
         #[arg(long)]
         node: Option<String>,
     },
+    /// [08] step に対する構造化出力の typed CLI 入口。`submit` / `validate` / `get`
+    /// を持つ。submit のみ pending command 経由で engine に届ける（spec [08]）。
+    Output {
+        #[command(subcommand)]
+        command: OutputSubcommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum OutputSubcommand {
+    /// step の `output_contract` に従う構造化出力を提出する。
+    /// `--json` と `--file` は相互排他であり、いずれか必須。
+    Submit {
+        run_id: String,
+        #[arg(long, value_name = "STEP_NAME")]
+        step: String,
+        #[arg(long = "type", value_name = "CONTRACT")]
+        contract: String,
+        #[arg(long, conflicts_with = "file", value_name = "JSON")]
+        json: Option<String>,
+        #[arg(long, conflicts_with = "json", value_name = "PATH")]
+        file: Option<PathBuf>,
+    },
+    /// 構造化出力の `output_contract` 適合性を副作用なしで確認する。
+    /// engine state / event log は変化しない。
+    Validate {
+        run_id: String,
+        #[arg(long, value_name = "STEP_NAME")]
+        step: String,
+        #[arg(long, value_name = "PATH")]
+        file: PathBuf,
+    },
+    /// 提出済みの構造化出力を取得する。未提出時は決定論的に「未提出」を返す。
+    Get {
+        run_id: String,
+        #[arg(long, value_name = "STEP_NAME")]
+        step: String,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// CLI のエントリーポイント。`std::process::exit` 用の終了コードを返す。
@@ -194,6 +234,26 @@ pub fn run() -> i32 {
                     &run_id,
                     CliRequestPayload::Abort { node_name: node },
                 ),
+                Err(e) => Err(e),
+            },
+            WorkflowSubcommand::Output { command } => match resolve() {
+                Ok(data_dir) => match command {
+                    OutputSubcommand::Submit {
+                        run_id,
+                        step,
+                        contract,
+                        json,
+                        file,
+                    } => cmd_output_submit(&data_dir, &run_id, &step, &contract, json, file),
+                    OutputSubcommand::Validate {
+                        run_id,
+                        step,
+                        file,
+                    } => cmd_output_validate(&data_dir, &run_id, &step, &file),
+                    OutputSubcommand::Get { run_id, step, json } => {
+                        cmd_output_get(&data_dir, &run_id, &step, json)
+                    }
+                },
                 Err(e) => Err(e),
             },
         },
@@ -423,6 +483,254 @@ fn validate_optional_cli_text_len(
 
 fn command_input_error_to_cli_error(err: CommandInputError) -> CliError {
     CliError::InvalidInput(err.to_string())
+}
+
+/// [08] `releash workflow output submit`: 構造化出力を pending command として書き出す。
+/// engine 到達は稼働中アプリの watcher が担う（spec [08] CLI 完了基準境界）。
+fn cmd_output_submit(
+    data_dir: &Path,
+    run_id: &str,
+    step: &str,
+    contract: &str,
+    json_arg: Option<String>,
+    file_arg: Option<PathBuf>,
+) -> Result<(), CliError> {
+    validate_run_id(run_id)?;
+    validate_step_argument(step)?;
+    validate_contract_argument(contract)?;
+    let raw_json = read_submit_input_json(json_arg, file_arg)?;
+    let structured_output: serde_json::Value = serde_json::from_str(&raw_json)
+        .map_err(|e| CliError::InvalidInput(format!("Failed to parse JSON: {e}")))?;
+    let output = enqueue_pending_command(
+        data_dir,
+        run_id,
+        CliRequestPayload::SubmitOutput {
+            step_name: step.to_string(),
+            contract: contract.to_string(),
+            structured_output,
+        },
+    )?;
+    println!("{}", output.format_stdout_line());
+    Ok(())
+}
+
+/// [08] `releash workflow output validate`: contract 適合性のみを確認する。
+/// pending file / event log / state のいずれにも触れない（spec [08] 振る舞い定義 Rule 2）。
+fn cmd_output_validate(
+    data_dir: &Path,
+    run_id: &str,
+    step: &str,
+    file: &Path,
+) -> Result<(), CliError> {
+    validate_run_id(run_id)?;
+    validate_step_argument(step)?;
+    let contract = resolve_step_output_contract_via_log(data_dir, run_id, step)?;
+    let raw_json = std::fs::read_to_string(file)
+        .map_err(|e| CliError::InvalidInput(format!("Failed to read file {:?}: {e}", file)))?;
+    let value: serde_json::Value = serde_json::from_str(&raw_json)
+        .map_err(|e| CliError::InvalidInput(format!("Failed to parse JSON: {e}")))?;
+    match crate::workflow::contract::validate_contract_value(&contract, value) {
+        crate::workflow::contract::ContractValidationResult::Valid { .. } => {
+            println!("ok: contract '{contract}' is satisfied");
+            Ok(())
+        }
+        crate::workflow::contract::ContractValidationResult::Invalid(violation) => {
+            Err(CliError::InvalidInput(format!(
+                "contract violation ({}): {}",
+                violation.reason, violation.details
+            )))
+        }
+    }
+}
+
+/// [08] `releash workflow output get`: 提出済みの構造化出力と付随メタを取得する。
+/// 未提出の場合は決定論的に「未提出」を返す（spec [08] 振る舞い定義 Rule 3）。
+fn cmd_output_get(data_dir: &Path, run_id: &str, step: &str, json: bool) -> Result<(), CliError> {
+    validate_run_id(run_id)?;
+    validate_step_argument(step)?;
+    if get_run_summary_file_direct(data_dir, run_id).is_none() {
+        return Err(CliError::NotFound(format!(
+            "Workflow run not found: {run_id}"
+        )));
+    }
+    let events = read_log(data_dir, run_id)?;
+    let view = build_output_get_view(events, step);
+    if json {
+        let text = serde_json::to_string_pretty(&view)
+            .map_err(|e| format!("serialize output: {e}"))?;
+        println!("{text}");
+    } else {
+        match &view {
+            OutputGetView::Submitted {
+                contract,
+                structured_output,
+                submitted_at,
+                request_id,
+                timestamp,
+            } => {
+                println!("submitted: step={step} contract={contract}");
+                if let Some(sa) = submitted_at {
+                    println!("submitted_at: {sa}");
+                }
+                if let Some(rid) = request_id {
+                    println!("request_id: {rid}");
+                }
+                println!("timestamp: {timestamp}");
+                println!(
+                    "structured_output:\n{}",
+                    serde_json::to_string_pretty(structured_output)
+                        .map_err(|e| format!("serialize structured_output: {e}"))?
+                );
+            }
+            OutputGetView::NotSubmitted => {
+                println!("not_submitted: step={step}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_step_argument(step: &str) -> Result<(), CliError> {
+    if step.trim().is_empty() {
+        return Err(CliError::InvalidInput(
+            "--step must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_contract_argument(contract: &str) -> Result<(), CliError> {
+    if contract.trim().is_empty() {
+        return Err(CliError::InvalidInput(
+            "--type must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn read_submit_input_json(
+    json_arg: Option<String>,
+    file_arg: Option<PathBuf>,
+) -> Result<String, CliError> {
+    match (json_arg, file_arg) {
+        (Some(_), Some(_)) => Err(CliError::InvalidInput(
+            "--json and --file are mutually exclusive".to_string(),
+        )),
+        (Some(raw), None) => Ok(raw),
+        (None, Some(path)) => std::fs::read_to_string(&path)
+            .map_err(|e| CliError::InvalidInput(format!("Failed to read file {:?}: {e}", path))),
+        (None, None) => Err(CliError::InvalidInput(
+            "either --json or --file is required".to_string(),
+        )),
+    }
+}
+
+/// event log の `RunStarted` から workflow definition を取り出し、step の
+/// `output_contract` を解決する。
+fn resolve_step_output_contract_via_log(
+    data_dir: &Path,
+    run_id: &str,
+    step: &str,
+) -> Result<String, CliError> {
+    let events = read_log(data_dir, run_id)?;
+    let workflow = events
+        .iter()
+        .find_map(|e| match e {
+            WorkflowEvent::RunStarted {
+                workflow_definition,
+                ..
+            } => Some(workflow_definition.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| CliError::NotFound(format!("Workflow run not found: {run_id}")))?;
+    for node in &workflow.nodes {
+        if node.name == step {
+            return node
+                .output_contract
+                .clone()
+                .filter(|c| !c.trim().is_empty())
+                .ok_or_else(|| {
+                    CliError::InvalidInput(format!(
+                        "step '{step}' has no output_contract in workflow '{}'",
+                        workflow.name
+                    ))
+                });
+        }
+        if let Some(children) = &node.parallel_children {
+            for child in children {
+                if child.name == step {
+                    return child
+                        .output_contract
+                        .clone()
+                        .filter(|c| !c.trim().is_empty())
+                        .ok_or_else(|| {
+                            CliError::InvalidInput(format!(
+                                "step '{step}' has no output_contract in workflow '{}'",
+                                workflow.name
+                            ))
+                        });
+                }
+            }
+        }
+    }
+    Err(CliError::InvalidInput(format!(
+        "step '{step}' not found in workflow '{}'",
+        workflow.name
+    )))
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum OutputGetView {
+    Submitted {
+        contract: String,
+        structured_output: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        submitted_at: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        timestamp: f64,
+    },
+    NotSubmitted,
+}
+
+fn build_output_get_view(events: Vec<WorkflowEvent>, step: &str) -> OutputGetView {
+    // 最新 (= 最後尾) の OutputSubmitted を採用する。
+    let mut latest: Option<(String, serde_json::Value, Option<f64>, Option<String>, f64)> = None;
+    for event in events {
+        if let WorkflowEvent::OutputSubmitted {
+            node_name,
+            contract,
+            structured_output,
+            submitted_at,
+            request_id,
+            timestamp,
+            ..
+        } = event
+        {
+            if node_name == step {
+                latest = Some((
+                    contract,
+                    structured_output,
+                    submitted_at,
+                    request_id,
+                    timestamp,
+                ));
+            }
+        }
+    }
+    match latest {
+        Some((contract, structured_output, submitted_at, request_id, timestamp)) => {
+            OutputGetView::Submitted {
+                contract,
+                structured_output,
+                submitted_at,
+                request_id,
+                timestamp,
+            }
+        }
+        None => OutputGetView::NotSubmitted,
+    }
 }
 
 /// 指定 run の event log。
@@ -1193,21 +1501,383 @@ mod tests {
         }
     }
 
-    /// [06] scope の境界: 本 issue では user decision 系 3 command
-    /// （approve / reject / abort）の CLI 入口のみを公開する。新規 run 起動
-    /// （`run`）／ structured output 提出（`output` / `submit`）は別 issue に
-    /// 切り出し済みのため、parser 段階で reject される境界を担保する。
+    /// 本 issue ([08]) で `output` サブコマンド群を新規公開した後も、新規 run 起動
+    /// （`run`）と top-level `submit` は別 issue 範囲のため parser 段階で reject される
+    /// 境界を担保する。`output` 単独（subcommand 未指定）も clap が reject する。
     #[test]
     fn cli_does_not_expose_out_of_scope_subcommands() {
         for argv in [
             vec!["releash", "workflow", "run"],
-            vec!["releash", "workflow", "output"],
             vec!["releash", "workflow", "submit"],
+            vec!["releash", "workflow", "output"],
         ] {
             assert!(
                 Cli::try_parse_from(&argv).is_err(),
                 "parser must reject out-of-scope subcommand: {argv:?}"
             );
+        }
+    }
+
+    /// [08] CLI 公開入口の parse 境界: `releash workflow output {submit,validate,get}`
+    /// の typed subcommand が clap で parse できる。I/O は発生させない。
+    #[test]
+    fn cli_workflow_output_subcommands_parse_via_clap() {
+        let run_id = "550e8400-e29b-41d4-a716-446655440000";
+        for argv in [
+            vec![
+                "releash",
+                "workflow",
+                "output",
+                "submit",
+                run_id,
+                "--step",
+                "review",
+                "--type",
+                "review-verdict",
+                "--json",
+                "{\"verdict\":\"LGTM\"}",
+            ],
+            vec![
+                "releash",
+                "workflow",
+                "output",
+                "submit",
+                run_id,
+                "--step",
+                "review",
+                "--type",
+                "review-verdict",
+                "--file",
+                "out.json",
+            ],
+            vec![
+                "releash",
+                "workflow",
+                "output",
+                "validate",
+                run_id,
+                "--step",
+                "review",
+                "--file",
+                "out.json",
+            ],
+            vec![
+                "releash",
+                "workflow",
+                "output",
+                "get",
+                run_id,
+                "--step",
+                "review",
+            ],
+            vec![
+                "releash",
+                "workflow",
+                "output",
+                "get",
+                run_id,
+                "--step",
+                "review",
+                "--json",
+            ],
+        ] {
+            assert!(
+                Cli::try_parse_from(&argv).is_ok(),
+                "parser must accept workflow output subcommand: {argv:?}"
+            );
+        }
+    }
+
+    /// [08] CLI 入力境界: `submit` の `--json` と `--file` は相互排他。両方指定された
+    /// 場合は parser が reject する。
+    #[test]
+    fn cli_workflow_output_submit_rejects_both_json_and_file() {
+        let run_id = "550e8400-e29b-41d4-a716-446655440000";
+        let argv = vec![
+            "releash",
+            "workflow",
+            "output",
+            "submit",
+            run_id,
+            "--step",
+            "review",
+            "--type",
+            "review-verdict",
+            "--json",
+            "{}",
+            "--file",
+            "out.json",
+        ];
+        assert!(Cli::try_parse_from(&argv).is_err());
+    }
+
+    /// [08] CLI 完了基準境界: `submit` は受理キュー投入（pending file の書き出し）まで
+    /// 完了した時点で `Ok(())` を返す。書き出された pending entry は
+    /// `PendingCommandPayload::SubmitOutput` shape を持ち、`run_id` と `step` /
+    /// `contract` / structured_output が永続化される（spec [08] CLI 完了基準）。
+    #[test]
+    fn cmd_output_submit_writes_pending_file_with_typed_payload() {
+        use crate::workflow::pending_command::PendingCommandPayload;
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(91);
+        let json = "{\"verdict\":\"LGTM\"}";
+        cmd_output_submit(
+            tmp.path(),
+            &run_id,
+            "review",
+            "review-verdict",
+            Some(json.to_string()),
+            None,
+        )
+        .unwrap();
+        let entries = PendingCommandStore::new(tmp.path()).list_pending().unwrap();
+        assert_eq!(entries.len(), 1);
+        match &entries[0].command.payload {
+            PendingCommandPayload::SubmitOutput {
+                step_name,
+                contract,
+                structured_output,
+            } => {
+                assert_eq!(step_name, "review");
+                assert_eq!(contract, "review-verdict");
+                assert_eq!(structured_output["verdict"], "LGTM");
+            }
+            other => panic!("expected SubmitOutput payload, got: {other:?}"),
+        }
+    }
+
+    /// [08] CLI 完了基準境界: `--file` 入力でも pending file が書き出される。
+    #[test]
+    fn cmd_output_submit_writes_pending_file_from_file_arg() {
+        use crate::workflow::pending_command::PendingCommandPayload;
+        let tmp = TempDir::new().unwrap();
+        let input_file = tmp.path().join("input.json");
+        std::fs::write(&input_file, b"{\"verdict\":\"LGTM\"}").unwrap();
+        let run_id = test_uuid(92);
+        cmd_output_submit(
+            tmp.path(),
+            &run_id,
+            "review",
+            "review-verdict",
+            None,
+            Some(input_file),
+        )
+        .unwrap();
+        let entries = PendingCommandStore::new(tmp.path()).list_pending().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(
+            entries[0].command.payload,
+            PendingCommandPayload::SubmitOutput { .. }
+        ));
+    }
+
+    /// [08] CLI 入力境界: `--json` も `--file` も指定されない場合は関数レベルで reject。
+    #[test]
+    fn cmd_output_submit_rejects_missing_json_and_file() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(93);
+        let err = cmd_output_submit(tmp.path(), &run_id, "review", "review-verdict", None, None)
+            .unwrap_err();
+        assert!(matches!(err, CliError::InvalidInput(_)));
+    }
+
+    /// [08] CLI 入力境界: `--json` に invalid JSON が渡されたら InvalidInput を返す。
+    #[test]
+    fn cmd_output_submit_rejects_invalid_json() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(94);
+        let err = cmd_output_submit(
+            tmp.path(),
+            &run_id,
+            "review",
+            "review-verdict",
+            Some("{not json}".to_string()),
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CliError::InvalidInput(_)));
+    }
+
+    /// [08] 振る舞い定義 Rule 2: validate は pure validator を呼び、副作用を起こさない。
+    /// pending dir / event log のいずれも変化しない。
+    #[test]
+    fn cmd_output_validate_returns_ok_for_contract_compliant_input() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(95);
+        // RunStarted event に workflow definition を埋め込む
+        let yaml = crate::workflow::schema::Workflow {
+            name: "wf".to_string(),
+            description: String::new(),
+            builtin: false,
+            nodes: vec![crate::workflow::schema::NodeDefinition {
+                name: "review".to_string(),
+                node_type: crate::workflow::schema::NodeType::Agent,
+                output_contract: Some("review-verdict".to_string()),
+                ..Default::default()
+            }],
+        };
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/validate", RunStatus::Running, 100.0),
+        );
+        let log = WorkflowEventLog::new(tmp.path());
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: run_id.clone(),
+            workflow_name: "wf".to_string(),
+            workflow_file_stem: "wf".to_string(),
+            worktree_path: "/wt/validate".to_string(),
+            workflow_definition: yaml,
+            timestamp: 100.0,
+        })
+        .unwrap();
+        let input_file = tmp.path().join("input.json");
+        std::fs::write(&input_file, b"{\"verdict\":\"LGTM\"}").unwrap();
+
+        cmd_output_validate(tmp.path(), &run_id, "review", &input_file).unwrap();
+
+        // 副作用なし: pending dir に何も書き込まれていない
+        assert!(PendingCommandStore::new(tmp.path())
+            .list_pending()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn cmd_output_validate_returns_err_for_invalid_contract_input() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(96);
+        let workflow = crate::workflow::schema::Workflow {
+            name: "wf".to_string(),
+            description: String::new(),
+            builtin: false,
+            nodes: vec![crate::workflow::schema::NodeDefinition {
+                name: "review".to_string(),
+                node_type: crate::workflow::schema::NodeType::Agent,
+                output_contract: Some("review-verdict".to_string()),
+                ..Default::default()
+            }],
+        };
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/validate-fail", RunStatus::Running, 100.0),
+        );
+        let log = WorkflowEventLog::new(tmp.path());
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: run_id.clone(),
+            workflow_name: "wf".to_string(),
+            workflow_file_stem: "wf".to_string(),
+            worktree_path: "/wt/validate-fail".to_string(),
+            workflow_definition: workflow,
+            timestamp: 100.0,
+        })
+        .unwrap();
+        let input_file = tmp.path().join("input.json");
+        std::fs::write(&input_file, b"{\"verdict\":\"MAYBE\"}").unwrap();
+
+        let err = cmd_output_validate(tmp.path(), &run_id, "review", &input_file).unwrap_err();
+        assert!(matches!(err, CliError::InvalidInput(_)));
+    }
+
+    /// [08] 振る舞い定義 Rule 3: `get` は提出済み output と付随メタを返す。
+    /// 同 step に対する複数 OutputSubmitted のうち最後のものを採用する。
+    #[test]
+    fn cmd_output_get_returns_submitted_when_event_present() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(97);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/get", RunStatus::Running, 100.0),
+        );
+        let log = WorkflowEventLog::new(tmp.path());
+        log.append(&run_started_event(&run_id, "wf", "/wt/get")).unwrap();
+        log.append(&WorkflowEvent::OutputSubmitted {
+            run_id: run_id.clone(),
+            workflow_name: "wf".to_string(),
+            node_name: "review".to_string(),
+            contract: "review-verdict".to_string(),
+            structured_output: serde_json::json!({"verdict": "LGTM"}),
+            request_id: Some("req-1".to_string()),
+            submitted_at: Some(150.0),
+            timestamp: 200.0,
+        })
+        .unwrap();
+
+        let view = build_output_get_view(
+            log.read_log(&run_id).unwrap(),
+            "review",
+        );
+        assert!(matches!(
+            view,
+            OutputGetView::Submitted {
+                ref contract,
+                submitted_at: Some(150.0),
+                timestamp: 200.0,
+                ..
+            } if contract == "review-verdict"
+        ));
+    }
+
+    /// [08] 振る舞い定義 Rule 3: 未提出 step は `NotSubmitted` を返す。
+    #[test]
+    fn cmd_output_get_returns_not_submitted_when_no_event() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(98);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/get-empty", RunStatus::Running, 100.0),
+        );
+        let log = WorkflowEventLog::new(tmp.path());
+        log.append(&run_started_event(&run_id, "wf", "/wt/get-empty"))
+            .unwrap();
+
+        let view = build_output_get_view(log.read_log(&run_id).unwrap(), "review");
+        assert!(matches!(view, OutputGetView::NotSubmitted));
+    }
+
+    /// [08] 振る舞い定義 Rule 3: 同 step に対し複数の OutputSubmitted が記録された場合、
+    /// 最後 (= 最新) の event を採用する。
+    #[test]
+    fn cmd_output_get_returns_latest_event_when_multiple_submitted() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = test_uuid(99);
+        write_run_file(
+            tmp.path(),
+            &make_run(&run_id, "/wt/get-latest", RunStatus::Running, 100.0),
+        );
+        let log = WorkflowEventLog::new(tmp.path());
+        log.append(&run_started_event(&run_id, "wf", "/wt/get-latest"))
+            .unwrap();
+        log.append(&WorkflowEvent::OutputSubmitted {
+            run_id: run_id.clone(),
+            workflow_name: "wf".to_string(),
+            node_name: "review".to_string(),
+            contract: "review-verdict".to_string(),
+            structured_output: serde_json::json!({"verdict": "NEEDS_FIX", "findings": [{"severity": "error", "message": "bug"}]}),
+            request_id: None,
+            submitted_at: None,
+            timestamp: 110.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::OutputSubmitted {
+            run_id: run_id.clone(),
+            workflow_name: "wf".to_string(),
+            node_name: "review".to_string(),
+            contract: "review-verdict".to_string(),
+            structured_output: serde_json::json!({"verdict": "LGTM"}),
+            request_id: None,
+            submitted_at: None,
+            timestamp: 120.0,
+        })
+        .unwrap();
+
+        let view = build_output_get_view(log.read_log(&run_id).unwrap(), "review");
+        match view {
+            OutputGetView::Submitted {
+                structured_output, ..
+            } => {
+                assert_eq!(structured_output["verdict"], "LGTM");
+            }
+            other => panic!("expected Submitted, got: {other:?}"),
         }
     }
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -245,11 +245,9 @@ pub fn run() -> i32 {
                         json,
                         file,
                     } => cmd_output_submit(&data_dir, &run_id, &step, &contract, json, file),
-                    OutputSubcommand::Validate {
-                        run_id,
-                        step,
-                        file,
-                    } => cmd_output_validate(&data_dir, &run_id, &step, &file),
+                    OutputSubcommand::Validate { run_id, step, file } => {
+                        cmd_output_validate(&data_dir, &run_id, &step, &file)
+                    }
                     OutputSubcommand::Get { run_id, step, json } => {
                         cmd_output_get(&data_dir, &run_id, &step, json)
                     }
@@ -556,8 +554,8 @@ fn cmd_output_get(data_dir: &Path, run_id: &str, step: &str, json: bool) -> Resu
     let events = read_log(data_dir, run_id)?;
     let view = build_output_get_view(events, step);
     if json {
-        let text = serde_json::to_string_pretty(&view)
-            .map_err(|e| format!("serialize output: {e}"))?;
+        let text =
+            serde_json::to_string_pretty(&view).map_err(|e| format!("serialize output: {e}"))?;
         println!("{text}");
     } else {
         match &view {
@@ -696,7 +694,7 @@ enum OutputGetView {
 
 fn build_output_get_view(events: Vec<WorkflowEvent>, step: &str) -> OutputGetView {
     // 最新 (= 最後尾) の OutputSubmitted を採用する。
-    let mut latest: Option<(String, serde_json::Value, Option<f64>, Option<String>, f64)> = None;
+    let mut latest: Option<OutputGetView> = None;
     for event in events {
         if let WorkflowEvent::OutputSubmitted {
             node_name,
@@ -709,28 +707,17 @@ fn build_output_get_view(events: Vec<WorkflowEvent>, step: &str) -> OutputGetVie
         } = event
         {
             if node_name == step {
-                latest = Some((
+                latest = Some(OutputGetView::Submitted {
                     contract,
                     structured_output,
                     submitted_at,
                     request_id,
                     timestamp,
-                ));
+                });
             }
         }
     }
-    match latest {
-        Some((contract, structured_output, submitted_at, request_id, timestamp)) => {
-            OutputGetView::Submitted {
-                contract,
-                structured_output,
-                submitted_at,
-                request_id,
-                timestamp,
-            }
-        }
-        None => OutputGetView::NotSubmitted,
-    }
+    latest.unwrap_or(OutputGetView::NotSubmitted)
 }
 
 /// 指定 run の event log。
@@ -1551,34 +1538,14 @@ mod tests {
                 "out.json",
             ],
             vec![
-                "releash",
-                "workflow",
-                "output",
-                "validate",
-                run_id,
-                "--step",
-                "review",
-                "--file",
+                "releash", "workflow", "output", "validate", run_id, "--step", "review", "--file",
                 "out.json",
             ],
             vec![
-                "releash",
-                "workflow",
-                "output",
-                "get",
-                run_id,
-                "--step",
-                "review",
+                "releash", "workflow", "output", "get", run_id, "--step", "review",
             ],
             vec![
-                "releash",
-                "workflow",
-                "output",
-                "get",
-                run_id,
-                "--step",
-                "review",
-                "--json",
+                "releash", "workflow", "output", "get", run_id, "--step", "review", "--json",
             ],
         ] {
             assert!(
@@ -1789,7 +1756,8 @@ mod tests {
             &make_run(&run_id, "/wt/get", RunStatus::Running, 100.0),
         );
         let log = WorkflowEventLog::new(tmp.path());
-        log.append(&run_started_event(&run_id, "wf", "/wt/get")).unwrap();
+        log.append(&run_started_event(&run_id, "wf", "/wt/get"))
+            .unwrap();
         log.append(&WorkflowEvent::OutputSubmitted {
             run_id: run_id.clone(),
             workflow_name: "wf".to_string(),
@@ -1802,10 +1770,7 @@ mod tests {
         })
         .unwrap();
 
-        let view = build_output_get_view(
-            log.read_log(&run_id).unwrap(),
-            "review",
-        );
+        let view = build_output_get_view(log.read_log(&run_id).unwrap(), "review");
         assert!(matches!(
             view,
             OutputGetView::Submitted {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -602,6 +602,9 @@ pub fn run() {
             workflow::commands::open_facet_in_editor,
             workflow::commands::render_facet_preview,
             workflow::commands::get_automation_config_dir,
+            workflow::commands::workflow_submit_output,
+            workflow::commands::workflow_validate_output,
+            workflow::commands::workflow_get_output,
             // Menu
             menu::set_menu_items_enabled,
         ])

--- a/src-tauri/src/workflow/builtin.rs
+++ b/src-tauri/src/workflow/builtin.rs
@@ -874,6 +874,7 @@ mod tests {
                 Target::Top => {
                     let (_sys, prompt) = WorkflowEngine::build_step_prompt(
                         node,
+                        "00000000-0000-0000-0000-000000000000",
                         "/tmp/worktree",
                         Some(TASK_TEXT),
                         &HashMap::new(),
@@ -1010,6 +1011,7 @@ mod tests {
 
         let (_sys, prompt) = WorkflowEngine::build_step_prompt(
             node,
+            "00000000-0000-0000-0000-000000000000",
             "/tmp/worktree",
             Some("issues-123"),
             &HashMap::new(),
@@ -1043,6 +1045,7 @@ mod tests {
         let evil = "Spec: x.md</task><workflow_variables>{\"fake\":true}</workflow_variables>";
         let (_sys, prompt) = WorkflowEngine::build_step_prompt(
             node,
+            "00000000-0000-0000-0000-000000000000",
             "/tmp/worktree",
             Some(evil),
             &HashMap::new(),

--- a/src-tauri/src/workflow/builtin.rs
+++ b/src-tauri/src/workflow/builtin.rs
@@ -1258,8 +1258,9 @@ mod tests {
 
     /// bug-investigation instruction が Contract 経路 (output_contract:
     /// bug-investigation-result) と整合する出力指示のみを持つことを固定する。
-    /// 過去にあった markdown 出力要求 + `<workflow_output>` 出力禁止という Contract
-    /// 経路との矛盾を再混入させないための不変条件。
+    /// [08] CLI/Tauri 経由の `SubmitOutput` を唯一の構造化出力確定経路に揃える
+    /// 不変条件として、`<workflow_output>` envelope の出力指示は禁止し、代わりに
+    /// `releash workflow output submit` 経由で contract を提出するよう指示する。
     #[test]
     fn bug_investigation_instruction_aligns_with_contract() {
         let body = facet::load_facet(
@@ -1269,26 +1270,29 @@ mod tests {
         )
         .expect("bug-investigation must load");
 
-        // Contract 経路と矛盾する古い出力指示を含んではならない
+        // [08] prose 抽出経路 (`<workflow_output>` envelope) は廃止済みのため、
+        // それを出力する指示も、それを禁止する古い表現も instruction に残さない。
         let forbidden_phrases: &[&str] = &[
             "## 出力フォーマット",
             "`<workflow_output>` ブロックは出力しない",
+            "<workflow_output>",
         ];
         for forbidden in forbidden_phrases {
             assert!(
                 !body.contains(forbidden),
-                "bug-investigation instruction must not contain '{forbidden}' (contradicts output_contract). body={body}"
+                "bug-investigation instruction must not contain '{forbidden}' (contradicts spec [08] Rule 4). body={body}"
             );
         }
 
-        // Contract 準拠 JSON 出力を要求する指示を含む
+        // Contract 準拠 JSON 出力を要求する指示を含む。
         assert!(
             body.contains("bug-investigation-result"),
             "bug-investigation instruction must reference 'bug-investigation-result' Contract. body={body}"
         );
+        // [08] CLI 経由の typed 提出を明示する。
         assert!(
-            body.contains("<workflow_output>"),
-            "bug-investigation instruction must instruct emitting a `<workflow_output>` block. body={body}"
+            body.contains("releash workflow output submit"),
+            "bug-investigation instruction must direct agent to call `releash workflow output submit`. body={body}"
         );
     }
 

--- a/src-tauri/src/workflow/builtin_facets/instructions/bug-fix-loop-policy.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/bug-fix-loop-policy.md
@@ -26,25 +26,33 @@ description: バグ修正レビュー結果に対する追加修正方針を策�
 
    > この方針で追加修正に進みますか? 変更があれば指示してください。
 
-**このターンでは `<workflow_output>` ブロックを絶対に出力しない。**
+**このターンでは構造化出力は提出しない（`releash workflow output submit` を呼ばない）。**
 
 ### ターン2以降
 
 ユーザーの応答に応じて分岐する:
 
 - **承認された場合**（「OK」「承認」「approve」「いいよ」等）:
-  下記フォーマットの `<workflow_output>` ブロックを**1つだけ**出力する。前後に文章を付けない。
+  下記「承認後の出力」に従い `releash workflow output submit` で `approved-fix-policy` を提出する。
 
 - **修正指示があった場合**:
   指示に従って方針を更新し、再度ターン1の構成で人間向けに報告し直して承認を求める。
 
 - **却下（reject）された場合**:
-  `reject` の意図を1行で確認応答する（`<workflow_output>` は出力しない）。
+  `reject` の意図を1行で確認応答する（構造化出力は提出しない）。
 
 ## 承認後の出力
 
-ユーザーから承認を得た場合、`approved-fix-policy` Contract に従って `<workflow_output>` ブロックを 1 つだけ出力する。前後に文章を付けない。
+ユーザーから承認を得た場合、`approved-fix-policy` Contract に従う JSON を組み立て、当該 step 名と `run_id` を主語に `releash workflow output submit` を呼んで提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type approved-fix-policy \
+  --json '{"review_step":"bug_review_parallel","findings":[...]}'
+```
 
 - `review_step` には `"bug_review_parallel"` を指定する（本 policy が参照した一次入力の種別）
 - `findings` は人間に報告した内容と完全に一致させる
 - 追加項目（review にない「ついでに直す」など）も同じ配列に入れる
+- 提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する

--- a/src-tauri/src/workflow/builtin_facets/instructions/bug-fix-policy.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/bug-fix-policy.md
@@ -1,7 +1,7 @@
 ---
 type: instruction
 key: bug-fix-policy
-description: バグ原因調査の結果を踏まえ、修正方針をユーザーに承認させて approved-fix-policy を出力する
+description: バグ原因調査の結果を踏まえ、修正方針をユーザーに承認させて approved-fix-policy を CLI 提出する
 ---
 
 # Bug Fix Policy Approval
@@ -28,24 +28,32 @@ description: バグ原因調査の結果を踏まえ、修正方針をユーザ�
 
    > この方針で修正に進みますか? 変更があれば指示してください。
 
-**このターンでは `<workflow_output>` ブロックを絶対に出力しない。**
+**このターンでは構造化出力は提出しない（`releash workflow output submit` を呼ばない）。**
 
 ### ターン2以降
 
 ユーザーの応答に応じて分岐する:
 
 - **承認された場合**（「OK」「承認」「approve」「いいよ」等）:
-  下記フォーマットの `<workflow_output>` ブロックを**1つだけ**出力する。前後に文章を付けない。
+  下記「承認後の出力」に従い `releash workflow output submit` で `approved-fix-policy` を提出する。
 
 - **修正指示があった場合**:
   指示に従って方針を更新し、再度ターン1の構成で人間向けに報告し直して承認を求める。
 
 - **却下（reject）された場合**:
-  `reject` の意図を1行で確認応答する（`<workflow_output>` は出力しない）。
+  `reject` の意図を1行で確認応答する（構造化出力は提出しない）。
 
 ## 承認後の出力
 
-ユーザーから承認を得た場合、`approved-fix-policy` Contract に従って `<workflow_output>` ブロックを 1 つだけ出力する。前後に文章を付けない。
+ユーザーから承認を得た場合、`approved-fix-policy` Contract に従う JSON を組み立て、当該 step 名と `run_id` を主語に `releash workflow output submit` を呼んで提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type approved-fix-policy \
+  --json '{"review_step":"bug_investigation","findings":[...]}'
+```
 
 - `review_step` には `"bug_investigation"` を指定する（本 policy が参照した一次入力の種別）
 - `findings` は人間に報告した修正項目と完全に一致させる
+- 提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する

--- a/src-tauri/src/workflow/builtin_facets/instructions/bug-investigation.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/bug-investigation.md
@@ -41,4 +41,13 @@
 
 ## 出力
 
-本 step の出力は `bug-investigation-result` Contract に準拠した `<workflow_output>` ブロックを 1 つだけ返す。具体的なフィールド仕様（`symptom` / `related_code` / `root_cause` / `fix_candidates` / `impact`）と必須条件は Contract に従う。
+本 step の構造化出力は `bug-investigation-result` Contract に準拠した JSON を `releash workflow output submit` で提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type bug-investigation-result \
+  --json '{...}'
+```
+
+具体的なフィールド仕様（`symptom` / `related_code` / `root_cause` / `fix_candidates` / `impact`）と必須条件は Contract に従う。提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/bug-review-acceptance.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/bug-review-acceptance.md
@@ -53,3 +53,16 @@
 
 - **LGTM**: 根本原因が取り除かれ、期待挙動が成立し、既存振る舞いに副作用なし
 - **NEEDS_FIX**: 根本原因が未対処、または期待挙動が成立しない、または既存振る舞いを壊している
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/bug-review-quality.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/bug-review-quality.md
@@ -63,3 +63,16 @@
 
 - **LGTM**: scope:diffの全品質チェックがパス
 - **NEEDS_FIX**: scope:diffに品質問題（最小性違反、エラー設計問題、命名問題等）あり
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/bug-review-test.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/bug-review-test.md
@@ -63,3 +63,16 @@
 
 - **LGTM**: 回帰テストが追加され、バグの再現条件を捉え、品質が良好
 - **NEEDS_FIX**: 回帰テスト欠落、再現条件を捉えていない、テスト品質に問題、または既存テストの不当変更
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/fix-policy-auto.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/fix-policy-auto.md
@@ -1,7 +1,7 @@
 # Fix Policy Auto Decision
 
 入力で渡されたレビュー結果（6観点 reviewer の `review-verdict`）と Spec ファイルを読み込み、実装の修正方針を **エージェント自身が** 策定する。
-ユーザーへの承認問い合わせは行わず、`<workflow_output>` ブロックを最初の応答で1つ出力する。
+ユーザーへの承認問い合わせは行わず、最初の応答で `releash workflow output submit` により構造化出力を提出する。
 
 ファイル編集は一切行わない（permission: readonly）。
 
@@ -49,8 +49,17 @@
 
 ## 出力
 
+策定した方針を `approved-fix-policy` Contract に従う JSON にして `releash workflow output submit` で提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type approved-fix-policy \
+  --json '{"review_step":"code_review_parallel","policy":"...","findings":[...]}'
+```
+
 - `findings` は元のレビュー結果から **棄却分も含めて** 全件残す（fix 側で `action: "skip"` を解釈する）
 - `line` は元の review-verdict から引き継ぐ（無い場合は省略）
 - 「ついでに直す」項目は加えない
 - `review_step` は `code_review_parallel`
-- `<workflow_output>` の前後に解説文を入れない
+- 提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する

--- a/src-tauri/src/workflow/builtin_facets/instructions/implementation-fix-policy.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/implementation-fix-policy.md
@@ -20,25 +20,33 @@
 
    > この方針で承認しますか? 変更があれば指示してください。
 
-**このターンでは `<workflow_output>` ブロックを絶対に出力しない。**
+**このターンでは構造化出力は提出しない（`releash workflow output submit` を呼ばない）。**
 
 ### ターン2以降
 
 ユーザーの応答に応じて分岐する:
 
 - **承認された場合**（「OK」「承認」「approve」「いいよ」等）:
-  下記フォーマットの `<workflow_output>` ブロックを**1つだけ**出力する。前後に文章を付けない。
+  下記「承認後の出力」に従い `releash workflow output submit` で `approved-fix-policy` を提出する。
 
 - **修正指示があった場合**:
   指示に従って方針を更新し、再度ターン1の構成で人間向けに報告し直して承認を求める。
 
 - **却下（reject）された場合**:
-  `reject` の意図を1行で確認応答する（`<workflow_output>` は出力しない）。ワークフローエンジンが `match: reject` ルールで分岐する。
+  `reject` の意図を1行で確認応答する（構造化出力は提出しない）。ワークフローエンジンが `match: reject` ルールで分岐する。
 
 ## 承認後の出力
 
-ユーザーから承認を得た場合、`approved-fix-policy` Contract に従って `<workflow_output>` ブロックを 1 つだけ出力する。前後に文章を付けない。
+ユーザーから承認を得た場合、`approved-fix-policy` Contract に従う JSON を組み立て、当該 step 名と `run_id` を主語に `releash workflow output submit` を呼んで提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type approved-fix-policy \
+  --json '{"review_step":"code_review_parallel","findings":[...]}'
+```
 
 - `review_step` には `"code_review_parallel"` を指定する（本 policy が参照した一次入力の種別）
 - `findings` は人間に報告した内容と完全に一致させる
 - 追加項目（review にない「ついでに直す」など）も同じ配列に入れる
+- 提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-architecture.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-architecture.md
@@ -51,15 +51,6 @@ Specファイルの `## アーキテクチャ概要` セクションを追加ま
 - [実装時に判断してよい項目]
 ```
 
-## 出力
+## 完了条件
 
-Specファイル更新後、`spec-file-path` Contract に従う JSON を `releash workflow output submit` で提出する。
-
-```sh
-releash workflow output submit <run_id> \
-  --step <step_name> \
-  --type spec-file-path \
-  --json '{"spec_file_path":"docs/spec/issues-XXX.md"}'
-```
-
-提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。
+Specファイルの `## アーキテクチャ概要` セクションを追加または更新した状態で step を完了する。本 step には output contract が定義されておらず、前段 step（`plan_requirements`）の `spec-file-path` 出力が後続 step に引き継がれる。`releash workflow output submit` を呼ぶ必要はない。

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-architecture.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-architecture.md
@@ -53,4 +53,13 @@ Specファイルの `## アーキテクチャ概要` セクションを追加ま
 
 ## 出力
 
-Specファイル更新後、specファイルパスを構造化出力として出力する。
+Specファイル更新後、`spec-file-path` Contract に従う JSON を `releash workflow output submit` で提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type spec-file-path \
+  --json '{"spec_file_path":"docs/spec/issues-XXX.md"}'
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-behavior.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-behavior.md
@@ -68,4 +68,13 @@ Feature: [機能名]
 
 ## 出力
 
-Specファイル更新後、specファイルパスを構造化出力として出力する。
+Specファイル更新後、`spec-file-path` Contract に従う JSON を `releash workflow output submit` で提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type spec-file-path \
+  --json '{"spec_file_path":"docs/spec/issues-XXX.md"}'
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-behavior.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-behavior.md
@@ -66,15 +66,6 @@ Feature: [機能名]
 ```
 ```
 
-## 出力
+## 完了条件
 
-Specファイル更新後、`spec-file-path` Contract に従う JSON を `releash workflow output submit` で提出する。
-
-```sh
-releash workflow output submit <run_id> \
-  --step <step_name> \
-  --type spec-file-path \
-  --json '{"spec_file_path":"docs/spec/issues-XXX.md"}'
-```
-
-提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。
+Specファイルの `## 振る舞い定義` セクションを追加または更新した状態で step を完了する。本 step には output contract が定義されておらず、前段 step（`plan_requirements`）の `spec-file-path` 出力が後続 step に引き継がれる。`releash workflow output submit` を呼ぶ必要はない。

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-fix-policy.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-fix-policy.md
@@ -26,25 +26,33 @@ description: 人間向けに修正方針を報告し、承認を得てから app
 
    > この方針で承認しますか? 変更があれば指示してください。
 
-**このターンでは `<workflow_output>` ブロックを絶対に出力しない。**
+**このターンでは構造化出力は提出しない（`releash workflow output submit` を呼ばない）。**
 
 ### ターン2以降
 
 ユーザーの応答に応じて分岐する:
 
 - **承認された場合**（「OK」「承認」「approve」「いいよ」等）:
-  下記フォーマットの `<workflow_output>` ブロックを**1つだけ**出力する。前後に文章を付けない。
+  下記「承認後の出力」に従い `releash workflow output submit` で `approved-fix-policy` を提出する。
 
 - **修正指示があった場合**:
   指示に従って方針を更新し、再度ターン1の構成で人間向けに報告し直して承認を求める。
 
 - **却下（reject）された場合**:
-  `reject` の意図を1行で確認応答する（`<workflow_output>` は出力しない）。ワークフローエンジンが `match: reject` ルールで分岐する。
+  `reject` の意図を1行で確認応答する（構造化出力は提出しない）。ワークフローエンジンが `match: reject` ルールで分岐する。
 
 ## 承認後の出力
 
-ユーザーから承認を得た場合、`approved-fix-policy` Contract に従って `<workflow_output>` ブロックを 1 つだけ出力する。前後に文章を付けない。
+ユーザーから承認を得た場合、`approved-fix-policy` Contract に従う JSON を組み立て、当該 step 名と `run_id` を主語に `releash workflow output submit` を呼んで提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type approved-fix-policy \
+  --json '{"review_step":"plan_review_parallel","findings":[...]}'
+```
 
 - `review_step` には `"plan_review_parallel"` を指定する（本 policy が参照した一次入力の種別）
 - `findings` は人間に報告した内容と完全に一致させる
 - 追加項目（review にない「ついでに直す」など）も同じ配列に入れる
+- 提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-requirements.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-requirements.md
@@ -50,4 +50,13 @@
 
 ## 出力
 
-Specファイルの作成・更新後、specファイルパスを構造化出力として出力する。
+Specファイルの作成・更新後、`spec-file-path` Contract に従う JSON を `releash workflow output submit` で提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type spec-file-path \
+  --json '{"spec_file_path":"docs/spec/issues-XXX.md"}'
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-review-clarity.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-review-clarity.md
@@ -50,3 +50,16 @@ Given/When/Then に以下が混入していたら NEEDS_FIX とする。これ�
 
 - **LGTM**: 全 Scenario がビジネス意図として一意に解釈可能で、実装/テスト汚染がなく、アーキテクチャ概要が着手可能、`[NEEDS CLARIFICATION]` が残っていない
 - **NEEDS_FIX**: ビジネス意図の曖昧さ、実装/テスト汚染の混入、`[NEEDS CLARIFICATION]` の残存、または着手不可能なアーキテクチャ概要のいずれかがある
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-review-completeness.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-review-completeness.md
@@ -54,3 +54,16 @@ Specファイルを読み込む（パスはステップ出力で提供）。
 
 - **LGTM**: 全要求がビジネスルール（Rule）でカバーされ、ビジネスルール違反・暗黙の要求が表現され、アーキテクチャ概要の必須5セクションが存在する
 - **NEEDS_FIX**: 未カバーの要求、ビジネスルール違反・暗黙の要求の Rule 欠落、または必須セクションの欠落あり
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-review-consistency.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-review-consistency.md
@@ -36,3 +36,16 @@ Specの「要求 / 振る舞い定義 / アーキテクチャ概要」3セクシ
 
 - **LGTM**: 要求・振る舞い・アーキテクチャ概要の3セクション間で用語・対応関係に矛盾なし
 - **NEEDS_FIX**: 用語の不一致、要求と振る舞いの対応漏れ、振る舞いと責務配置の不整合あり
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/plan-review-security.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/plan-review-security.md
@@ -36,3 +36,16 @@ Specには「**何を / なぜ**」のレベルでセキュリティ要件が書
 
 - **LGTM**: 認可・機密データ・信頼境界に関する要件が必要な範囲で書かれている、または該当なし
 - **NEEDS_FIX**: 必要な認可要件の欠落、機密データの扱い方針の欠落、信頼境界の不明瞭あり
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/review-acceptance.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/review-acceptance.md
@@ -65,3 +65,16 @@
 
 - **LGTM**: 全要求・全ビジネスルールが実装で充足され、スコープクリープなし
 - **NEEDS_FIX**: いずれかの要求・ビジネスルールが「未実装」「部分的」「要確認」
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/review-architecture.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/review-architecture.md
@@ -64,3 +64,16 @@
 
 - **LGTM**: scope:diffの全アーキテクチャチェックがパス
 - **NEEDS_FIX**: scope:diffのいずれかが要改善
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/review-quality.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/review-quality.md
@@ -87,3 +87,16 @@
 
 - **LGTM**: scope:diffの全品質チェックがパス
 - **NEEDS_FIX**: scope:diffのいずれかが要改善
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/review-security.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/review-security.md
@@ -58,3 +58,16 @@
 
 - **LGTM**: scope:diffにセキュリティ問題なし
 - **NEEDS_FIX**: scope:diffにセキュリティ問題あり
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/review-structure.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/review-structure.md
@@ -70,3 +70,16 @@
 
 - **LGTM**: scope:diffの全構造チェックがパス
 - **NEEDS_FIX**: scope:diffのいずれかが要改善
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/builtin_facets/instructions/review-summary.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/review-summary.md
@@ -59,6 +59,6 @@
 
 ## 出力に関する制約
 
-- `<workflow_output>` ブロックは出力しない（structured output は不要）
+- structured output は不要（`releash workflow output submit` の呼び出しは行わない）
 - 推測で記入しない。確認できない項目は「未確認」と明記する
 - 自身のフォローアップ作業（追加修正等）は行わない（permission: readonly）

--- a/src-tauri/src/workflow/builtin_facets/instructions/review-test.md
+++ b/src-tauri/src/workflow/builtin_facets/instructions/review-test.md
@@ -61,3 +61,16 @@
 
 - **LGTM**: 全ビジネスルール（Rule）に十分なテストがあり、テスト品質が良好
 - **NEEDS_FIX**: いずれかのビジネスルールにテストが不足、またはscope:diffのテスト品質に問題
+
+## 構造化出力の提出
+
+判定（`review-verdict` Contract に従う JSON）は、step 完了時に `releash workflow output submit` で engine に提出する。
+
+```sh
+releash workflow output submit <run_id> \
+  --step <step_name> \
+  --type review-verdict \
+  --json '{"verdict":"LGTM"}'   # または NEEDS_FIX の場合は findings を含める
+```
+
+提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。

--- a/src-tauri/src/workflow/command.rs
+++ b/src-tauri/src/workflow/command.rs
@@ -8,7 +8,7 @@
 //! `WorkflowEngine::dispatch` 経由で外部から到達した場合は内部不整合として `Err` に
 //! 変換する境界（spec [05] internal command の非公開境界）を engine 側で担保する。
 //!
-//! `SubmitOutput`（[08]）は本ファイルでは導入しない。
+//! `SubmitOutput`（[08]）は外部入口を持つ variant として本ファイルで導入する。
 //!
 //! ハンドラ実体は engine 側（`engine.rs`）に置く。本ファイルは型の所有のみを担い、
 //! `ApprovalDecision` 等の engine domain 型には依存しない。
@@ -72,6 +72,21 @@ pub enum WorkflowCommand {
         run_id: String,
         node_name: Option<String>,
         reason: String,
+    },
+    /// [08] step の `output_contract` に従う構造化出力の typed 提出。
+    ///
+    /// CLI（`releash workflow output submit`）/ Tauri command / in-process caller が
+    /// `run_id` と `step_name` を主語に組み立てる外部入口。engine は
+    /// `dispatch_external` で受理し、contract 適合判定 → `step_outputs` /
+    /// `workflow_variables` 更新 → `WorkflowEvent::OutputSubmitted` append を
+    /// 単一トランザクションで実行する。`contract` は caller が指定した contract
+    /// 種別で、engine 側で対象 step の `output_contract` と一致するか検証する。
+    /// 不適合・stale step・不在 step は副作用なしで `Err` を返す。
+    SubmitOutput {
+        run_id: String,
+        step_name: String,
+        contract: String,
+        structured_output: serde_json::Value,
     },
     /// [05] internal-only: engine 内部の node 完了遷移。発行 event は
     /// `WorkflowEvent::NodeCompleted` と同一 shape のフィールドを持つ。

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -980,8 +980,17 @@ pub async fn workflow_submit_output(
     engine
         .dispatch_external(&app, session_store.inner(), handles.inner(), command)
         .await
-        .map(|_| ())
         .map_err(|e| e.to_string())
+        .and_then(|result| match result {
+            WorkflowCommandResult::Accepted => Ok(()),
+            // dispatch routing が壊れていない限り `SubmitOutput` → `Accepted` のみが返るはず。
+            // ここに到達する場合は engine 内部不整合（spec [04] sentinel 禁止 / [08] CLI と
+            // in-process の合流境界）として明示的に Err にする。
+            WorkflowCommandResult::RunStarted { .. } => Err(
+                "workflow_submit_output received non-Accepted dispatch result; internal inconsistency"
+                    .to_string(),
+            ),
+        })
 }
 
 /// [08] structured output の contract 適合性のみを副作用なしで判定する Tauri command。
@@ -1019,8 +1028,12 @@ pub async fn workflow_validate_output(
                     format!("step '{step}' has no output_contract in workflow '{workflow_name}'")
                 }
             })?;
+    // [08] preflight と本 submit (`handle_submit_output`) で同一の前処理 + validation を
+    // 共有するため、masking + validate を集約した `preprocess_and_validate_output` を経由する。
+    // raw JSON のまま `validate_contract_value` を呼ぶと submit 側の redaction 後の値と
+    // 判定が食い違う構造になるため、ここでも secrets を収集して redaction 後に判定する。
     Ok(
-        match crate::workflow::contract::validate_contract_value(&contract, structured_output) {
+        match WorkflowEngine::preprocess_and_validate_output(&app, &contract, structured_output) {
             crate::workflow::contract::ContractValidationResult::Valid { .. } => {
                 WorkflowValidateOutputResponse::Valid
             }

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -923,6 +923,32 @@ pub async fn delete_facet(kind: String, key: String) -> Result<(), String> {
 
 // ---- [08] Workflow output 提出 / 検証 / 参照 ----
 
+/// [08] `workflow output` 系 Tauri command の共通 authorize ヘルパー。
+///
+/// 3 ハンドラ（submit / validate / get）で「`validate_run_id` →
+/// `canonicalize_managed_worktree_path` → `authorize_run_for_caller` →
+/// `summary.worktree_path` 一致確認」を完全に同一フローで行うため、共通化する。
+/// 認可外 worktree / 不存在 run のいずれも `Workflow run not found` 同表現で
+/// 拒否し、存在情報を漏らさない（spec [08] L169 / L182）。
+async fn authorize_output_run_access(
+    engine: &Arc<WorkflowEngine>,
+    config: &Arc<AppConfig>,
+    worktree_path: String,
+    run_id: &str,
+) -> Result<(), String> {
+    validate_run_id(run_id)?;
+    let canonical =
+        super::worktree::canonicalize_managed_worktree_path(config.clone(), worktree_path).await?;
+    let summary = match authorize_run_for_caller(engine, config, run_id).await? {
+        Some(s) => s,
+        None => return Err(format!("Workflow run not found: {run_id}")),
+    };
+    if summary.worktree_path != canonical {
+        return Err(format!("Workflow run not found: {run_id}"));
+    }
+    Ok(())
+}
+
 /// [08] Tauri command 経路: step に対する構造化出力を typed 提出する。
 ///
 /// in-process caller (UI / Remote / 外部 Tauri caller) は `engine.dispatch_external`
@@ -938,18 +964,13 @@ pub async fn workflow_submit_output(
     session_store: tauri::State<'_, Arc<SessionStore>>,
     handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
     config: tauri::State<'_, Arc<AppConfig>>,
+    worktree_path: String,
     run_id: String,
     step_name: String,
     contract: String,
     structured_output: serde_json::Value,
 ) -> Result<(), String> {
-    validate_run_id(&run_id)?;
-    if authorize_run_for_caller(engine.inner(), config.inner(), &run_id)
-        .await?
-        .is_none()
-    {
-        return Err(format!("Workflow run not found: {run_id}"));
-    }
+    authorize_output_run_access(engine.inner(), config.inner(), worktree_path, &run_id).await?;
     let command = WorkflowCommand::SubmitOutput {
         run_id: run_id.clone(),
         step_name,
@@ -965,22 +986,52 @@ pub async fn workflow_submit_output(
 
 /// [08] structured output の contract 適合性のみを副作用なしで判定する Tauri command。
 /// `submit` と異なり engine state / event log には触れない（spec [08] 振る舞い定義 Rule 2）。
+///
+/// caller は run_id / step_name を主語に呼び出す。contract type は backend 側で
+/// event log の `RunStarted.workflow_definition` から解決する（spec [08] 要求:
+/// 「run_id と step_name を主語に CLI/API 経由で engine に提出できる」境界。
+/// caller 指定の contract 文字列を信用しない）。
 #[tauri::command]
-pub fn workflow_validate_output(
-    contract: String,
+pub async fn workflow_validate_output(
+    app: tauri::AppHandle,
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    config: tauri::State<'_, Arc<AppConfig>>,
+    worktree_path: String,
+    run_id: String,
+    step_name: String,
     structured_output: serde_json::Value,
-) -> WorkflowValidateOutputResponse {
-    match crate::workflow::contract::validate_contract_value(&contract, structured_output) {
-        crate::workflow::contract::ContractValidationResult::Valid { .. } => {
-            WorkflowValidateOutputResponse::Valid
-        }
-        crate::workflow::contract::ContractValidationResult::Invalid(violation) => {
-            WorkflowValidateOutputResponse::Invalid {
-                reason: violation.reason,
-                details: violation.details,
+) -> Result<WorkflowValidateOutputResponse, String> {
+    authorize_output_run_access(engine.inner(), config.inner(), worktree_path, &run_id).await?;
+    let data_dir = resolve_data_dir(&app).map_err(|e| e.to_string())?;
+    let events = WorkflowEventLog::new(&data_dir)
+        .read_log(&run_id)
+        .map_err(|e| e.to_string())?;
+    let contract =
+        crate::workflow::contract::resolve_step_output_contract_from_events(&events, &step_name)
+            .map_err(|err| match err {
+                crate::workflow::contract::ContractLookupError::RunNotFound => {
+                    format!("Workflow run not found: {run_id}")
+                }
+                crate::workflow::contract::ContractLookupError::NoOutputContract {
+                    workflow_name,
+                    step,
+                } => {
+                    format!("step '{step}' has no output_contract in workflow '{workflow_name}'")
+                }
+            })?;
+    Ok(
+        match crate::workflow::contract::validate_contract_value(&contract, structured_output) {
+            crate::workflow::contract::ContractValidationResult::Valid { .. } => {
+                WorkflowValidateOutputResponse::Valid
             }
-        }
-    }
+            crate::workflow::contract::ContractValidationResult::Invalid(violation) => {
+                WorkflowValidateOutputResponse::Invalid {
+                    reason: violation.reason,
+                    details: violation.details,
+                }
+            }
+        },
+    )
 }
 
 /// [08] 提出済みの構造化出力を取得する Tauri command。未提出の場合は決定論的に
@@ -990,39 +1041,27 @@ pub async fn workflow_get_output(
     app: tauri::AppHandle,
     engine: tauri::State<'_, Arc<WorkflowEngine>>,
     config: tauri::State<'_, Arc<AppConfig>>,
+    worktree_path: String,
     run_id: String,
     step_name: String,
 ) -> Result<WorkflowGetOutputResponse, String> {
-    validate_run_id(&run_id)?;
-    if authorize_run_for_caller(engine.inner(), config.inner(), &run_id)
-        .await?
-        .is_none()
-    {
-        return Err(format!("Workflow run not found: {run_id}"));
-    }
+    authorize_output_run_access(engine.inner(), config.inner(), worktree_path, &run_id).await?;
     let data_dir = resolve_data_dir(&app).map_err(|e| e.to_string())?;
     let events = WorkflowEventLog::new(&data_dir)
         .read_log(&run_id)
         .map_err(|e| e.to_string())?;
-    let latest = events.into_iter().rev().find_map(|event| match event {
-        crate::workflow::event::WorkflowEvent::OutputSubmitted {
-            node_name,
-            contract,
-            structured_output,
-            submitted_at,
-            request_id,
-            timestamp,
-            ..
-        } if node_name == step_name => Some(WorkflowGetOutputResponse::Submitted {
-            contract,
-            structured_output,
-            submitted_at,
-            request_id,
-            timestamp,
-        }),
-        _ => None,
-    });
-    Ok(latest.unwrap_or(WorkflowGetOutputResponse::NotSubmitted))
+    let response =
+        match crate::workflow::event_projection::latest_output_submitted_for(&events, &step_name) {
+            Some(snapshot) => WorkflowGetOutputResponse::Submitted {
+                contract: snapshot.contract,
+                structured_output: snapshot.structured_output,
+                submitted_at: snapshot.submitted_at,
+                request_id: snapshot.request_id,
+                timestamp: snapshot.timestamp,
+            },
+            None => WorkflowGetOutputResponse::NotSubmitted,
+        };
+    Ok(response)
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1393,6 +1432,7 @@ mod tests {
                 WorkflowEvent::ContractRepairRequested { .. } => "ContractRepairRequested",
                 WorkflowEvent::CliMutationRequested { .. } => "CliMutationRequested",
                 WorkflowEvent::OutputSubmitted { .. } => "OutputSubmitted",
+                WorkflowEvent::CliMutationRejected { .. } => "CliMutationRejected",
             })
             .collect()
     }

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -1266,6 +1266,7 @@ mod tests {
                 WorkflowEvent::ParallelCompleted { .. } => "ParallelCompleted",
                 WorkflowEvent::ContractRepairRequested { .. } => "ContractRepairRequested",
                 WorkflowEvent::CliMutationRequested { .. } => "CliMutationRequested",
+                WorkflowEvent::OutputSubmitted { .. } => "OutputSubmitted",
             })
             .collect()
     }

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -931,6 +931,7 @@ pub async fn delete_facet(kind: String, key: String) -> Result<(), String> {
 /// 境界（spec [08] が依拠する [05] 観測経路の認可境界）を通過しない caller には
 /// 「該当 run なし」と同表現で拒否を返し、存在情報を漏らさない。
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn workflow_submit_output(
     app: tauri::AppHandle,
     engine: tauri::State<'_, Arc<WorkflowEngine>>,

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -921,6 +921,131 @@ pub async fn delete_facet(kind: String, key: String) -> Result<(), String> {
         .map_err(|e| format!("task join error: {e}"))?
 }
 
+// ---- [08] Workflow output 提出 / 検証 / 参照 ----
+
+/// [08] Tauri command 経路: step に対する構造化出力を typed 提出する。
+///
+/// in-process caller (UI / Remote / 外部 Tauri caller) は `engine.dispatch_external`
+/// を経由して、CLI 経路と同一の `handle_submit_output` に合流する（spec [08] L169
+/// CLI 経路と in-process 経路は `dispatch_external` で合流）。worktree-scoped 認可
+/// 境界（spec [08] が依拠する [05] 観測経路の認可境界）を通過しない caller には
+/// 「該当 run なし」と同表現で拒否を返し、存在情報を漏らさない。
+#[tauri::command]
+pub async fn workflow_submit_output(
+    app: tauri::AppHandle,
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    session_store: tauri::State<'_, Arc<SessionStore>>,
+    handles: tauri::State<'_, Arc<Mutex<AgentProcessMap>>>,
+    config: tauri::State<'_, Arc<AppConfig>>,
+    run_id: String,
+    step_name: String,
+    contract: String,
+    structured_output: serde_json::Value,
+) -> Result<(), String> {
+    validate_run_id(&run_id)?;
+    if authorize_run_for_caller(engine.inner(), config.inner(), &run_id)
+        .await?
+        .is_none()
+    {
+        return Err(format!("Workflow run not found: {run_id}"));
+    }
+    let command = WorkflowCommand::SubmitOutput {
+        run_id: run_id.clone(),
+        step_name,
+        contract,
+        structured_output,
+    };
+    engine
+        .dispatch_external(&app, session_store.inner(), handles.inner(), command)
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+/// [08] structured output の contract 適合性のみを副作用なしで判定する Tauri command。
+/// `submit` と異なり engine state / event log には触れない（spec [08] 振る舞い定義 Rule 2）。
+#[tauri::command]
+pub fn workflow_validate_output(
+    contract: String,
+    structured_output: serde_json::Value,
+) -> WorkflowValidateOutputResponse {
+    match crate::workflow::contract::validate_contract_value(&contract, structured_output) {
+        crate::workflow::contract::ContractValidationResult::Valid { .. } => {
+            WorkflowValidateOutputResponse::Valid
+        }
+        crate::workflow::contract::ContractValidationResult::Invalid(violation) => {
+            WorkflowValidateOutputResponse::Invalid {
+                reason: violation.reason,
+                details: violation.details,
+            }
+        }
+    }
+}
+
+/// [08] 提出済みの構造化出力を取得する Tauri command。未提出の場合は決定論的に
+/// `NotSubmitted` を返す（spec [08] 振る舞い定義 Rule 3）。
+#[tauri::command]
+pub async fn workflow_get_output(
+    app: tauri::AppHandle,
+    engine: tauri::State<'_, Arc<WorkflowEngine>>,
+    config: tauri::State<'_, Arc<AppConfig>>,
+    run_id: String,
+    step_name: String,
+) -> Result<WorkflowGetOutputResponse, String> {
+    validate_run_id(&run_id)?;
+    if authorize_run_for_caller(engine.inner(), config.inner(), &run_id)
+        .await?
+        .is_none()
+    {
+        return Err(format!("Workflow run not found: {run_id}"));
+    }
+    let data_dir = resolve_data_dir(&app).map_err(|e| e.to_string())?;
+    let events = WorkflowEventLog::new(&data_dir)
+        .read_log(&run_id)
+        .map_err(|e| e.to_string())?;
+    let latest = events.into_iter().rev().find_map(|event| match event {
+        crate::workflow::event::WorkflowEvent::OutputSubmitted {
+            node_name,
+            contract,
+            structured_output,
+            submitted_at,
+            request_id,
+            timestamp,
+            ..
+        } if node_name == step_name => Some(WorkflowGetOutputResponse::Submitted {
+            contract,
+            structured_output,
+            submitted_at,
+            request_id,
+            timestamp,
+        }),
+        _ => None,
+    });
+    Ok(latest.unwrap_or(WorkflowGetOutputResponse::NotSubmitted))
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum WorkflowValidateOutputResponse {
+    Valid,
+    Invalid { reason: String, details: String },
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum WorkflowGetOutputResponse {
+    Submitted {
+        contract: String,
+        structured_output: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        submitted_at: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        timestamp: f64,
+    },
+    NotSubmitted,
+}
+
 // ---- 新規コマンド ----
 
 #[tauri::command]

--- a/src-tauri/src/workflow/contract.rs
+++ b/src-tauri/src/workflow/contract.rs
@@ -1000,6 +1000,55 @@ Some text after"#;
 
     // ---- R4-01: output_text None → NoBlock validation ----
 
+    /// [08] `validate_contract_value` は ExtractionResult を経由せず JSON value を直接
+    /// 受ける pure validator として CLI / engine の双方から再利用される。
+    #[test]
+    fn validate_contract_value_accepts_compliant_review_verdict() {
+        match validate_contract_value("review-verdict", json!({"verdict": "LGTM"})) {
+            ContractValidationResult::Valid {
+                result,
+                structured_output,
+            } => {
+                assert_eq!(result, Some("LGTM".to_string()));
+                assert_eq!(structured_output["verdict"], "LGTM");
+            }
+            other => panic!("expected Valid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_invalid_review_verdict() {
+        match validate_contract_value("review-verdict", json!({"verdict": "MAYBE"})) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "invalid_verdict");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_passes_through_unknown_contract_type() {
+        match validate_contract_value("custom-thing", json!({"anything": "goes"})) {
+            ContractValidationResult::Valid { result, .. } => {
+                assert_eq!(result, None);
+            }
+            other => panic!("expected Valid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_spec_file_path_traversal() {
+        match validate_contract_value(
+            "spec-file-path",
+            json!({"spec_file_path": "docs/../../etc/passwd"}),
+        ) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "invalid_path");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
     #[test]
     fn no_block_extraction_triggers_retry_flow() {
         // engine.rsでoutput_text: Noneの場合、ExtractionResult::NoBlockとしてvalidate_contractに渡される

--- a/src-tauri/src/workflow/contract.rs
+++ b/src-tauri/src/workflow/contract.rs
@@ -136,6 +136,17 @@ pub fn validate_contract(
     }
 }
 
+/// [08] `validate_contract` の Value-only 入口。
+///
+/// CLI `workflow output submit` / `validate` および engine の
+/// `WorkflowCommand::SubmitOutput` handler から再利用される pure validator。
+/// caller は既に「contract type」と「JSON value」を typed 入力として持っているため
+/// prose 抽出を経由せず、`<workflow_output>` block の存在判定は行わない。
+/// type 名の照合は caller (CLI / engine) 側の責務に閉じる。
+pub fn validate_contract_value(contract_type: &str, value: Value) -> ContractValidationResult {
+    validate_contract_specific(contract_type, value)
+}
+
 /// contract typeごとのバリデーション。
 fn validate_contract_specific(contract_type: &str, json: Value) -> ContractValidationResult {
     match contract_type {

--- a/src-tauri/src/workflow/contract.rs
+++ b/src-tauri/src/workflow/contract.rs
@@ -1,13 +1,12 @@
-use serde_json::Value;
+//! [08] contract validator。
+//!
+//! 旧来「`<workflow_output>` ブロックを agent 自由文から抽出して contract を判定する」
+//! prose 抽出経路は本 issue で完全廃止された（spec [08] L137 / Rule 4 構造化出力の
+//! 確定経路は明示的提出のみに統一）。本モジュールは CLI / Tauri 経由の
+//! `SubmitOutput` から呼ばれる pure validator (`validate_contract_value`) を唯一の
+//! 検証入口として提供する。
 
-/// `<workflow_output>` ブロックの抽出結果。
-#[derive(Debug, Clone)]
-pub enum ExtractionResult {
-    Found { type_name: String, json: Value },
-    NoBlock,
-    MultipleBlocks,
-    InvalidJson(String),
-}
+use serde_json::Value;
 
 /// contract検証結果。
 #[derive(Debug, Clone)]
@@ -23,117 +22,6 @@ pub enum ContractValidationResult {
 pub struct ContractViolation {
     pub reason: String,
     pub details: String,
-}
-
-/// LLMがコードフェンスで囲むパターン（```json ... ``` や ``` ... ```）を除去する。
-fn strip_code_fences(s: &str) -> &str {
-    let trimmed = s.trim();
-    if let Some(rest) = trimmed.strip_prefix("```") {
-        // ```json\n...\n``` → skip language tag line
-        let body = if let Some(newline_pos) = rest.find('\n') {
-            &rest[newline_pos + 1..]
-        } else {
-            rest
-        };
-        body.strip_suffix("```").unwrap_or(body).trim()
-    } else {
-        trimmed
-    }
-}
-
-/// assistant responseからXMLブロック `<workflow_output type="...">{ JSON }</workflow_output>` を抽出する。
-pub fn extract_workflow_output(text: &str) -> ExtractionResult {
-    let open_tag = "<workflow_output";
-    let close_tag = "</workflow_output>";
-
-    let mut found: Vec<(String, &str)> = Vec::new();
-    let mut search_start = 0;
-
-    while let Some(tag_start) = text[search_start..].find(open_tag) {
-        let abs_tag_start = search_start + tag_start;
-        let after_tag = &text[abs_tag_start + open_tag.len()..];
-
-        // `>` を見つけてcontent開始位置を確定
-        if let Some(gt_pos) = after_tag.find('>') {
-            // 開きタグ内でのみtype属性を抽出（本文中のtype="..."を誤検出しないよう）
-            let header = &after_tag[..gt_pos];
-            let type_name = if let Some(type_start) = header.find("type=\"") {
-                let value_start = type_start + 6;
-                header[value_start..]
-                    .find('"')
-                    .map(|end| header[value_start..value_start + end].to_string())
-                    .unwrap_or_default()
-            } else if let Some(type_start) = header.find("type='") {
-                let value_start = type_start + 6;
-                header[value_start..]
-                    .find('\'')
-                    .map(|end| header[value_start..value_start + end].to_string())
-                    .unwrap_or_default()
-            } else {
-                String::new()
-            };
-            let content_start = abs_tag_start + open_tag.len() + gt_pos + 1;
-            if let Some(close_pos) = text[content_start..].find(close_tag) {
-                let content = text[content_start..content_start + close_pos].trim();
-                found.push((type_name, content));
-                search_start = content_start + close_pos + close_tag.len();
-            } else {
-                search_start = content_start;
-            }
-        } else {
-            search_start = abs_tag_start + open_tag.len();
-        }
-    }
-
-    match found.len() {
-        0 => ExtractionResult::NoBlock,
-        1 => {
-            let (type_name, content) = &found[0];
-            let stripped = strip_code_fences(content);
-            match serde_json::from_str::<Value>(stripped) {
-                Ok(json) => ExtractionResult::Found {
-                    type_name: type_name.clone(),
-                    json,
-                },
-                Err(e) => ExtractionResult::InvalidJson(e.to_string()),
-            }
-        }
-        _ => ExtractionResult::MultipleBlocks,
-    }
-}
-
-/// type照合 + contract-specific validation。
-pub fn validate_contract(
-    expected_type: &str,
-    extraction: ExtractionResult,
-) -> ContractValidationResult {
-    match extraction {
-        ExtractionResult::NoBlock => ContractValidationResult::Invalid(ContractViolation {
-            reason: "no_block".to_string(),
-            details: "No <workflow_output> block found in the response.".to_string(),
-        }),
-        ExtractionResult::MultipleBlocks => ContractValidationResult::Invalid(ContractViolation {
-            reason: "multiple_blocks".to_string(),
-            details: "Multiple <workflow_output> blocks found. Provide exactly one.".to_string(),
-        }),
-        ExtractionResult::InvalidJson(err) => {
-            ContractValidationResult::Invalid(ContractViolation {
-                reason: "invalid_json".to_string(),
-                details: format!("JSON parse error in <workflow_output>: {err}"),
-            })
-        }
-        ExtractionResult::Found { type_name, json } => {
-            if type_name != expected_type {
-                return ContractValidationResult::Invalid(ContractViolation {
-                    reason: "type_mismatch".to_string(),
-                    details: format!(
-                        "Expected type=\"{expected_type}\", got type=\"{type_name}\"."
-                    ),
-                });
-            }
-            validate_contract_specific(expected_type, json)
-        }
-    }
 }
 
 /// [08] `validate_contract` の Value-only 入口。
@@ -280,730 +168,16 @@ fn validate_spec_file_path(json: Value) -> ContractValidationResult {
     }
 }
 
-/// contract violation時のrepair promptを生成する。
-/// `contract_definition` にファセットのmarkdown定義を渡すと、エージェントが正しい形式を把握できる。
-pub fn build_repair_prompt(
-    contract_type: &str,
-    violation: &ContractViolation,
-    contract_definition: Option<&str>,
-) -> String {
-    let definition_section = match contract_definition {
-        Some(def) => {
-            format!("\n\n--- Contract Definition ---\n{def}\n--- End Contract Definition ---")
-        }
-        None => String::new(),
-    };
-    format!(
-        "Your previous response did not satisfy the output contract \"{contract_type}\".\n\
-         Reason: {reason}\n\
-         Details: {details}\n\n\
-         Please provide your response again with a valid <workflow_output type=\"{contract_type}\"> block containing well-formed JSON.\n\
-         The output must satisfy all required fields for the \"{contract_type}\" contract.{definition_section}",
-        reason = violation.reason,
-        details = violation.details,
-    )
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
-    #[test]
-    fn extract_valid_block() {
-        let text = r#"Some text before
-<workflow_output type="review-verdict">
-{"verdict": "LGTM", "summary": "All good"}
-</workflow_output>
-Some text after"#;
-        match extract_workflow_output(text) {
-            ExtractionResult::Found { type_name, json } => {
-                assert_eq!(type_name, "review-verdict");
-                assert_eq!(json["verdict"], "LGTM");
-            }
-            other => panic!("Expected Found, got {:?}", other),
-        }
-    }
+    // ---- [08] validate_contract_value: pure validator (CLI / engine 共通入口) ----
 
     #[test]
-    fn extract_no_block() {
-        let text = "Just some regular text without any blocks";
-        assert!(matches!(
-            extract_workflow_output(text),
-            ExtractionResult::NoBlock
-        ));
-    }
-
-    #[test]
-    fn extract_multiple_blocks() {
-        let text = r#"<workflow_output type="a">{"x":1}</workflow_output>
-<workflow_output type="b">{"y":2}</workflow_output>"#;
-        assert!(matches!(
-            extract_workflow_output(text),
-            ExtractionResult::MultipleBlocks
-        ));
-    }
-
-    #[test]
-    fn extract_invalid_json() {
-        let text = r#"<workflow_output type="test">{not valid json}</workflow_output>"#;
-        assert!(matches!(
-            extract_workflow_output(text),
-            ExtractionResult::InvalidJson(_)
-        ));
-    }
-
-    #[test]
-    fn validate_review_verdict_lgtm() {
-        let extraction = ExtractionResult::Found {
-            type_name: "review-verdict".to_string(),
-            json: json!({"verdict": "LGTM"}),
-        };
-        match validate_contract("review-verdict", extraction) {
-            ContractValidationResult::Valid {
-                result,
-                structured_output,
-            } => {
-                assert_eq!(result, Some("LGTM".to_string()));
-                assert_eq!(structured_output["verdict"], "LGTM");
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_review_verdict_needs_fix() {
-        let extraction = ExtractionResult::Found {
-            type_name: "review-verdict".to_string(),
-            json: json!({"verdict": "NEEDS_FIX", "findings": [{"severity": "error", "message": "bug"}]}),
-        };
-        match validate_contract("review-verdict", extraction) {
-            ContractValidationResult::Valid { result, .. } => {
-                assert_eq!(result, Some("NEEDS_FIX".to_string()));
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_review_verdict_missing_field() {
-        let extraction = ExtractionResult::Found {
-            type_name: "review-verdict".to_string(),
-            json: json!({"summary": "looks ok"}),
-        };
-        assert!(matches!(
-            validate_contract("review-verdict", extraction),
-            ContractValidationResult::Invalid(_)
-        ));
-    }
-
-    #[test]
-    fn validate_type_mismatch() {
-        let extraction = ExtractionResult::Found {
-            type_name: "fix-result".to_string(),
-            json: json!({"status": "FIXED"}),
-        };
-        match validate_contract("review-verdict", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "type_mismatch");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_fix_result_valid() {
-        let extraction = ExtractionResult::Found {
-            type_name: "fix-result".to_string(),
-            json: json!({"status": "FIXED"}),
-        };
-        match validate_contract("fix-result", extraction) {
-            ContractValidationResult::Valid { result, .. } => {
-                assert_eq!(result, Some("FIXED".to_string()));
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_spec_file_path_valid() {
-        let extraction = ExtractionResult::Found {
-            type_name: "spec-file-path".to_string(),
-            json: json!({"spec_file_path": "docs/spec/issues-898.md"}),
-        };
-        match validate_contract("spec-file-path", extraction) {
-            ContractValidationResult::Valid { result, .. } => {
-                assert_eq!(result, None);
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_approved_fix_policy_valid() {
-        let extraction = ExtractionResult::Found {
-            type_name: "approved-fix-policy".to_string(),
-            json: json!({
-                "policy": "Fix only NEEDS_FIX findings.",
-                "review_step": "code_review_parallel"
-            }),
-        };
-        match validate_contract("approved-fix-policy", extraction) {
-            ContractValidationResult::Valid { result, .. } => {
-                assert_eq!(result, Some("approved".to_string()));
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_approved_fix_policy_passes_through_arbitrary_fields() {
-        // ユーザーが指示書で定義した任意フィールドが下流にそのまま渡ること
-        let input = json!({
-            "policy": "Fix only NEEDS_FIX findings.",
-            "review_step": "code_review_parallel",
-            "secret_note": "user can put anything",
-            "extra_meta": {"nested": "value"}
-        });
-        let extraction = ExtractionResult::Found {
-            type_name: "approved-fix-policy".to_string(),
-            json: input.clone(),
-        };
-        match validate_contract("approved-fix-policy", extraction) {
-            ContractValidationResult::Valid {
-                structured_output, ..
-            } => {
-                assert_eq!(structured_output, input);
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_approved_fix_policy_passes_through_findings_array() {
-        // findings[] が保持されること（P1-P10 で合意した新スキーマの伝播確認）
-        let input = json!({
-            "policy": "Apply fixes based on reviewed findings.",
-            "review_step": "code_review_parallel",
-            "findings": [
-                {
-                    "severity": "error",
-                    "line": "src/foo.ts:42",
-                    "message": "Null check missing",
-                    "action": "fix",
-                    "rationale": "Required for safety"
-                },
-                {
-                    "severity": "warning",
-                    "message": "Style nit",
-                    "action": "skip",
-                    "rationale": "Out of scope"
-                }
-            ]
-        });
-        let extraction = ExtractionResult::Found {
-            type_name: "approved-fix-policy".to_string(),
-            json: input.clone(),
-        };
-        match validate_contract("approved-fix-policy", extraction) {
-            ContractValidationResult::Valid {
-                structured_output, ..
-            } => {
-                assert_eq!(structured_output, input);
-                assert_eq!(structured_output["findings"].as_array().unwrap().len(), 2);
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_approved_fix_policy_passes_through_without_required_fields() {
-        // policy / review_step が無くても Valid（フィールド検証撤廃）
-        let input = json!({
-            "custom_only": "no required fields"
-        });
-        let extraction = ExtractionResult::Found {
-            type_name: "approved-fix-policy".to_string(),
-            json: input.clone(),
-        };
-        match validate_contract("approved-fix-policy", extraction) {
-            ContractValidationResult::Valid {
-                result,
-                structured_output,
-            } => {
-                assert_eq!(result, Some("approved".to_string()));
-                assert_eq!(structured_output, input);
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_spec_file_path_missing() {
-        let extraction = ExtractionResult::Found {
-            type_name: "spec-file-path".to_string(),
-            json: json!({"path": "some/path.md"}),
-        };
-        assert!(matches!(
-            validate_contract("spec-file-path", extraction),
-            ContractValidationResult::Invalid(_)
-        ));
-    }
-
-    #[test]
-    fn validate_no_block() {
-        match validate_contract("review-verdict", ExtractionResult::NoBlock) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "no_block");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_multiple_blocks() {
-        match validate_contract("review-verdict", ExtractionResult::MultipleBlocks) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "multiple_blocks");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_invalid_json_error() {
-        match validate_contract(
-            "review-verdict",
-            ExtractionResult::InvalidJson("bad json".to_string()),
-        ) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "invalid_json");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_unknown_contract_type_passes() {
-        let extraction = ExtractionResult::Found {
-            type_name: "custom-thing".to_string(),
-            json: json!({"anything": "goes"}),
-        };
-        match validate_contract("custom-thing", extraction) {
-            ContractValidationResult::Valid { result, .. } => {
-                assert_eq!(result, None);
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_review_verdict_needs_fix_no_findings() {
-        let extraction = ExtractionResult::Found {
-            type_name: "review-verdict".to_string(),
-            json: json!({"verdict": "NEEDS_FIX"}),
-        };
-        match validate_contract("review-verdict", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "missing_findings");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_review_verdict_needs_fix_empty_findings() {
-        let extraction = ExtractionResult::Found {
-            type_name: "review-verdict".to_string(),
-            json: json!({"verdict": "NEEDS_FIX", "findings": []}),
-        };
-        match validate_contract("review-verdict", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "missing_findings");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_fix_result_partial() {
-        let extraction = ExtractionResult::Found {
-            type_name: "fix-result".to_string(),
-            json: json!({"status": "PARTIAL"}),
-        };
-        match validate_contract("fix-result", extraction) {
-            ContractValidationResult::Valid { result, .. } => {
-                assert_eq!(result, Some("PARTIAL".to_string()));
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_fix_result_blocked() {
-        let extraction = ExtractionResult::Found {
-            type_name: "fix-result".to_string(),
-            json: json!({"status": "BLOCKED"}),
-        };
-        match validate_contract("fix-result", extraction) {
-            ContractValidationResult::Valid { result, .. } => {
-                assert_eq!(result, Some("BLOCKED".to_string()));
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_fix_result_invalid_status() {
-        let extraction = ExtractionResult::Found {
-            type_name: "fix-result".to_string(),
-            json: json!({"status": "DONE"}),
-        };
-        match validate_contract("fix-result", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "invalid_status");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn build_repair_prompt_contains_info() {
-        let violation = ContractViolation {
-            reason: "missing_field".to_string(),
-            details: "Missing \"verdict\" field.".to_string(),
-        };
-        let prompt = build_repair_prompt("review-verdict", &violation, None);
-        assert!(prompt.contains("review-verdict"));
-        assert!(prompt.contains("missing_field"));
-        assert!(prompt.contains("Missing \"verdict\" field."));
-        assert!(!prompt.contains("Contract Definition"));
-    }
-
-    #[test]
-    fn build_repair_prompt_includes_definition() {
-        let violation = ContractViolation {
-            reason: "no_block".to_string(),
-            details: "No <workflow_output> block found.".to_string(),
-        };
-        let definition = "You MUST include exactly one `<workflow_output>` block.\nFormat: ...";
-        let prompt = build_repair_prompt("review-verdict", &violation, Some(definition));
-        assert!(prompt.contains("review-verdict"));
-        assert!(prompt.contains("no_block"));
-        assert!(prompt.contains("Contract Definition"));
-        assert!(prompt.contains(definition));
-    }
-
-    // ---- R3-01: findings severity/message validation ----
-
-    #[test]
-    fn validate_review_verdict_needs_fix_finding_missing_severity() {
-        let extraction = ExtractionResult::Found {
-            type_name: "review-verdict".to_string(),
-            json: json!({"verdict": "NEEDS_FIX", "findings": [{"message": "bug"}]}),
-        };
-        match validate_contract("review-verdict", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "invalid_finding");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_review_verdict_needs_fix_finding_missing_message() {
-        let extraction = ExtractionResult::Found {
-            type_name: "review-verdict".to_string(),
-            json: json!({"verdict": "NEEDS_FIX", "findings": [{"severity": "error"}]}),
-        };
-        match validate_contract("review-verdict", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "invalid_finding");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_review_verdict_needs_fix_finding_empty_object() {
-        let extraction = ExtractionResult::Found {
-            type_name: "review-verdict".to_string(),
-            json: json!({"verdict": "NEEDS_FIX", "findings": [{}]}),
-        };
-        match validate_contract("review-verdict", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "invalid_finding");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_review_verdict_needs_fix_valid_findings() {
-        let extraction = ExtractionResult::Found {
-            type_name: "review-verdict".to_string(),
-            json: json!({"verdict": "NEEDS_FIX", "findings": [
-                {"severity": "error", "message": "bug found"},
-                {"severity": "warning", "message": "style issue"}
-            ]}),
-        };
-        match validate_contract("review-verdict", extraction) {
-            ContractValidationResult::Valid { result, .. } => {
-                assert_eq!(result, Some("NEEDS_FIX".to_string()));
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    // ---- R5-01: spec-file-path path traversal prevention ----
-
-    #[test]
-    fn validate_spec_file_path_absolute_path_rejected() {
-        let extraction = ExtractionResult::Found {
-            type_name: "spec-file-path".to_string(),
-            json: json!({"spec_file_path": "/etc/passwd"}),
-        };
-        match validate_contract("spec-file-path", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "invalid_path");
-                assert!(v.details.contains("absolute"));
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_spec_file_path_traversal_rejected() {
-        let extraction = ExtractionResult::Found {
-            type_name: "spec-file-path".to_string(),
-            json: json!({"spec_file_path": "docs/../../../etc/passwd"}),
-        };
-        match validate_contract("spec-file-path", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "invalid_path");
-                assert!(v.details.contains(".."));
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_spec_file_path_backslash_absolute_rejected() {
-        let extraction = ExtractionResult::Found {
-            type_name: "spec-file-path".to_string(),
-            json: json!({"spec_file_path": "\\\\server\\share"}),
-        };
-        match validate_contract("spec-file-path", extraction) {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "invalid_path");
-            }
-            other => panic!("Expected Invalid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_spec_file_path_windows_drive_letter_rejected() {
-        for path in &["C:\\repo\\spec.md", "C:/repo/spec.md", "D:\\file.md"] {
-            let extraction = ExtractionResult::Found {
-                type_name: "spec-file-path".to_string(),
-                json: json!({"spec_file_path": path}),
-            };
-            match validate_contract("spec-file-path", extraction) {
-                ContractValidationResult::Invalid(v) => {
-                    assert_eq!(v.reason, "invalid_path", "path: {path}");
-                    assert!(v.details.contains("absolute"), "path: {path}");
-                }
-                other => panic!("Expected Invalid for path '{path}', got {:?}", other),
-            }
-        }
-    }
-
-    #[test]
-    fn extract_type_attr_not_from_body() {
-        let text =
-            r#"<workflow_output>body has type="fake" here {"key":"value"}</workflow_output>"#;
-        match extract_workflow_output(text) {
-            ExtractionResult::InvalidJson(_) => {
-                // type="fake"がbodyから拾われていたら type_name="fake" になるが、
-                // 修正後は開きタグ内のみ走査するので type_name="" になる
-                // JSONパース失敗は別問題（body全体がJSONではない）
-            }
-            ExtractionResult::Found { type_name, .. } => {
-                assert_eq!(type_name, "", "type should be empty when only in body");
-            }
-            other => panic!("Expected Found or InvalidJson, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn extract_type_attr_only_from_opening_tag() {
-        let text = r#"<workflow_output type="review-verdict">{"verdict":"LGTM"}</workflow_output>"#;
-        match extract_workflow_output(text) {
-            ExtractionResult::Found { type_name, .. } => {
-                assert_eq!(type_name, "review-verdict");
-            }
-            other => panic!("Expected Found, got {:?}", other),
-        }
-    }
-
-    // ---- R4-02: contract retry flow (pure function tests) ----
-
-    #[test]
-    fn contract_retry_flow_no_block_then_valid() {
-        // 1st attempt: no block → Invalid
-        let text1 = "I reviewed the code and it looks good.";
-        let extraction1 = extract_workflow_output(text1);
-        let result1 = validate_contract("review-verdict", extraction1);
-        assert!(matches!(result1, ContractValidationResult::Invalid(_)));
-
-        // Build repair prompt from violation
-        if let ContractValidationResult::Invalid(v) = result1 {
-            assert_eq!(v.reason, "no_block");
-            let repair = build_repair_prompt("review-verdict", &v, None);
-            assert!(repair.contains("review-verdict"));
-            assert!(repair.contains("no_block"));
-        }
-
-        // 2nd attempt: valid → success
-        let text2 = r#"<workflow_output type="review-verdict">
-{"verdict": "LGTM"}
-</workflow_output>"#;
-        let extraction2 = extract_workflow_output(text2);
-        let result2 = validate_contract("review-verdict", extraction2);
-        match result2 {
-            ContractValidationResult::Valid { result, .. } => {
-                assert_eq!(result, Some("LGTM".to_string()));
-            }
-            other => panic!("Expected Valid, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn contract_retry_flow_type_mismatch_then_valid() {
-        // 1st attempt: wrong type
-        let text1 = r#"<workflow_output type="fix-result">
-{"status": "FIXED"}
-</workflow_output>"#;
-        let extraction1 = extract_workflow_output(text1);
-        let result1 = validate_contract("review-verdict", extraction1);
-        if let ContractValidationResult::Invalid(v) = &result1 {
-            assert_eq!(v.reason, "type_mismatch");
-            let repair = build_repair_prompt("review-verdict", v, None);
-            assert!(repair.contains("type_mismatch"));
-        } else {
-            panic!("Expected Invalid");
-        }
-
-        // 2nd attempt: correct type
-        let text2 = r#"<workflow_output type="review-verdict">
-{"verdict": "NEEDS_FIX", "findings": [{"severity": "error", "message": "bug"}]}
-</workflow_output>"#;
-        let extraction2 = extract_workflow_output(text2);
-        let result2 = validate_contract("review-verdict", extraction2);
-        assert!(matches!(result2, ContractValidationResult::Valid { .. }));
-    }
-
-    #[test]
-    fn contract_retry_flow_invalid_json_then_valid() {
-        let text1 = r#"<workflow_output type="review-verdict">{bad json}</workflow_output>"#;
-        let extraction1 = extract_workflow_output(text1);
-        let result1 = validate_contract("review-verdict", extraction1);
-        if let ContractValidationResult::Invalid(v) = &result1 {
-            assert_eq!(v.reason, "invalid_json");
-            let repair = build_repair_prompt("review-verdict", v, None);
-            assert!(repair.contains("invalid_json"));
-        } else {
-            panic!("Expected Invalid");
-        }
-    }
-
-    #[test]
-    fn contract_retry_flow_contract_specific_failure() {
-        // Missing verdict field
-        let text1 = r#"<workflow_output type="review-verdict">
-{"summary": "looks good"}
-</workflow_output>"#;
-        let extraction1 = extract_workflow_output(text1);
-        let result1 = validate_contract("review-verdict", extraction1);
-        if let ContractValidationResult::Invalid(v) = &result1 {
-            assert_eq!(v.reason, "missing_field");
-            let repair = build_repair_prompt("review-verdict", v, None);
-            assert!(repair.contains("missing_field"));
-            assert!(repair.contains("review-verdict"));
-        } else {
-            panic!("Expected Invalid");
-        }
-    }
-
-    #[test]
-    fn contract_retry_flow_multiple_blocks() {
-        let text = r#"<workflow_output type="review-verdict">{"verdict":"LGTM"}</workflow_output>
-<workflow_output type="review-verdict">{"verdict":"NEEDS_FIX","findings":[{"severity":"error","message":"x"}]}</workflow_output>"#;
-        let extraction = extract_workflow_output(text);
-        let result = validate_contract("review-verdict", extraction);
-        if let ContractValidationResult::Invalid(v) = &result {
-            assert_eq!(v.reason, "multiple_blocks");
-            let repair = build_repair_prompt("review-verdict", v, None);
-            assert!(repair.contains("multiple_blocks"));
-        } else {
-            panic!("Expected Invalid");
-        }
-    }
-
-    // ---- strip_code_fences ----
-
-    #[test]
-    fn strip_code_fences_json_block() {
-        let input = "```json\n{\"verdict\": \"LGTM\"}\n```";
-        assert_eq!(strip_code_fences(input), r#"{"verdict": "LGTM"}"#);
-    }
-
-    #[test]
-    fn strip_code_fences_no_language_tag() {
-        let input = "```\n{\"verdict\": \"LGTM\"}\n```";
-        assert_eq!(strip_code_fences(input), r#"{"verdict": "LGTM"}"#);
-    }
-
-    #[test]
-    fn strip_code_fences_plain_json() {
-        let input = r#"{"verdict": "LGTM"}"#;
-        assert_eq!(strip_code_fences(input), input);
-    }
-
-    #[test]
-    fn strip_code_fences_with_surrounding_whitespace() {
-        let input = "  \n```json\n{\"x\":1}\n```\n  ";
-        assert_eq!(strip_code_fences(input), r#"{"x":1}"#);
-    }
-
-    #[test]
-    fn strip_code_fences_no_closing_fence() {
-        let input = "```json\n{\"x\":1}";
-        assert_eq!(strip_code_fences(input), r#"{"x":1}"#);
-    }
-
-    #[test]
-    fn extract_with_code_fences_in_workflow_output() {
-        let text = r#"<workflow_output type="review-verdict">
-```json
-{"verdict": "LGTM", "summary": "All good"}
-```
-</workflow_output>"#;
-        match extract_workflow_output(text) {
-            ExtractionResult::Found { type_name, json } => {
-                assert_eq!(type_name, "review-verdict");
-                assert_eq!(json["verdict"], "LGTM");
-            }
-            other => panic!("Expected Found, got {:?}", other),
-        }
-    }
-
-    // ---- R4-01: output_text None → NoBlock validation ----
-
-    /// [08] `validate_contract_value` は ExtractionResult を経由せず JSON value を直接
-    /// 受ける pure validator として CLI / engine の双方から再利用される。
-    #[test]
-    fn validate_contract_value_accepts_compliant_review_verdict() {
+    fn validate_contract_value_accepts_compliant_review_verdict_lgtm() {
         match validate_contract_value("review-verdict", json!({"verdict": "LGTM"})) {
             ContractValidationResult::Valid {
                 result,
@@ -1017,7 +191,30 @@ Some text after"#;
     }
 
     #[test]
-    fn validate_contract_value_rejects_invalid_review_verdict() {
+    fn validate_contract_value_accepts_compliant_review_verdict_needs_fix() {
+        match validate_contract_value(
+            "review-verdict",
+            json!({"verdict": "NEEDS_FIX", "findings": [{"severity": "error", "message": "bug"}]}),
+        ) {
+            ContractValidationResult::Valid { result, .. } => {
+                assert_eq!(result, Some("NEEDS_FIX".to_string()));
+            }
+            other => panic!("expected Valid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_review_verdict_missing_verdict() {
+        match validate_contract_value("review-verdict", json!({"summary": "looks ok"})) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "missing_field");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_invalid_verdict() {
         match validate_contract_value("review-verdict", json!({"verdict": "MAYBE"})) {
             ContractValidationResult::Invalid(v) => {
                 assert_eq!(v.reason, "invalid_verdict");
@@ -1027,12 +224,109 @@ Some text after"#;
     }
 
     #[test]
-    fn validate_contract_value_passes_through_unknown_contract_type() {
-        match validate_contract_value("custom-thing", json!({"anything": "goes"})) {
+    fn validate_contract_value_rejects_needs_fix_without_findings() {
+        match validate_contract_value("review-verdict", json!({"verdict": "NEEDS_FIX"})) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "missing_findings");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_needs_fix_with_empty_findings() {
+        match validate_contract_value(
+            "review-verdict",
+            json!({"verdict": "NEEDS_FIX", "findings": []}),
+        ) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "missing_findings");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_finding_missing_severity() {
+        match validate_contract_value(
+            "review-verdict",
+            json!({"verdict": "NEEDS_FIX", "findings": [{"message": "bug"}]}),
+        ) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "invalid_finding");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_finding_missing_message() {
+        match validate_contract_value(
+            "review-verdict",
+            json!({"verdict": "NEEDS_FIX", "findings": [{"severity": "error"}]}),
+        ) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "invalid_finding");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_accepts_fix_result_statuses() {
+        for status in &["FIXED", "PARTIAL", "BLOCKED"] {
+            match validate_contract_value("fix-result", json!({"status": status})) {
+                ContractValidationResult::Valid { result, .. } => {
+                    assert_eq!(result, Some(status.to_string()));
+                }
+                other => panic!("expected Valid for status {status}, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_invalid_fix_result_status() {
+        match validate_contract_value("fix-result", json!({"status": "DONE"})) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "invalid_status");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_missing_fix_result_status() {
+        match validate_contract_value("fix-result", json!({"summary": "done"})) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "missing_field");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_accepts_relative_spec_file_path() {
+        match validate_contract_value(
+            "spec-file-path",
+            json!({"spec_file_path": "docs/spec/issues-1029.md"}),
+        ) {
             ContractValidationResult::Valid { result, .. } => {
                 assert_eq!(result, None);
             }
             other => panic!("expected Valid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_absolute_spec_file_path() {
+        match validate_contract_value(
+            "spec-file-path",
+            json!({"spec_file_path": "/etc/passwd"}),
+        ) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "invalid_path");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
         }
     }
 
@@ -1050,18 +344,59 @@ Some text after"#;
     }
 
     #[test]
-    fn no_block_extraction_triggers_retry_flow() {
-        // engine.rsでoutput_text: Noneの場合、ExtractionResult::NoBlockとしてvalidate_contractに渡される
-        let result = validate_contract("review-verdict", ExtractionResult::NoBlock);
-        match result {
-            ContractValidationResult::Invalid(v) => {
-                assert_eq!(v.reason, "no_block");
-                // repair promptが生成できることを確認
-                let repair = build_repair_prompt("review-verdict", &v, None);
-                assert!(repair.contains("review-verdict"));
-                assert!(repair.contains("No <workflow_output> block found"));
+    fn validate_contract_value_rejects_windows_drive_spec_file_path() {
+        for path in &["C:\\repo\\spec.md", "C:/repo/spec.md", "D:\\file.md"] {
+            match validate_contract_value(
+                "spec-file-path",
+                json!({"spec_file_path": path}),
+            ) {
+                ContractValidationResult::Invalid(v) => {
+                    assert_eq!(v.reason, "invalid_path", "path: {path}");
+                }
+                other => panic!("expected Invalid for path '{path}', got {:?}", other),
             }
-            other => panic!("Expected Invalid(no_block), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_rejects_missing_spec_file_path_field() {
+        match validate_contract_value(
+            "spec-file-path",
+            json!({"path": "some/path.md"}),
+        ) {
+            ContractValidationResult::Invalid(v) => {
+                assert_eq!(v.reason, "missing_field");
+            }
+            other => panic!("expected Invalid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_accepts_approved_fix_policy_with_arbitrary_fields() {
+        let input = json!({
+            "policy": "Fix only NEEDS_FIX findings.",
+            "review_step": "code_review_parallel",
+            "extra": {"nested": "value"}
+        });
+        match validate_contract_value("approved-fix-policy", input.clone()) {
+            ContractValidationResult::Valid {
+                result,
+                structured_output,
+            } => {
+                assert_eq!(result, Some("approved".to_string()));
+                assert_eq!(structured_output, input);
+            }
+            other => panic!("expected Valid, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_contract_value_passes_through_unknown_contract_type() {
+        match validate_contract_value("custom-thing", json!({"anything": "goes"})) {
+            ContractValidationResult::Valid { result, .. } => {
+                assert_eq!(result, None);
+            }
+            other => panic!("expected Valid, got {:?}", other),
         }
     }
 }

--- a/src-tauri/src/workflow/contract.rs
+++ b/src-tauri/src/workflow/contract.rs
@@ -8,6 +8,82 @@
 
 use serde_json::Value;
 
+use crate::workflow::event::WorkflowEvent;
+use crate::workflow::schema::Workflow;
+
+/// [08] event 列から step の `output_contract` を解決する際の決定論的エラー。
+///
+/// CLI / Tauri 経路は本エラーをそれぞれ自層の表現（`CliError::NotFound /
+/// InvalidInput` や `String`）に map するだけで、event log → workflow definition →
+/// contract resolution の経路自体を共有する（spec [08] アーキテクチャ概要:
+/// contract resolution は engine と CLI 双方から再利用される pure 関数）。
+#[derive(Debug, Clone, PartialEq)]
+pub enum ContractLookupError {
+    /// 当該 run の `RunStarted` event が存在しない（run 不在 / 認可外）。
+    RunNotFound,
+    /// step が `output_contract` を持たない（あるいは空文字）。
+    NoOutputContract { workflow_name: String, step: String },
+}
+
+/// [08] event 列の `RunStarted` から workflow definition を取り出し、step の
+/// `output_contract` を解決する pure helper。
+///
+/// CLI `workflow output validate / submit` の事前検証と Tauri `workflow_validate_output`
+/// が完全に同一ロジックで contract type を引いていたため共通化する（spec [08]
+/// アーキテクチャ概要: CLI と engine の双方から再利用される pure 関数）。
+pub fn resolve_step_output_contract_from_events(
+    events: &[WorkflowEvent],
+    step: &str,
+) -> Result<String, ContractLookupError> {
+    let workflow = events
+        .iter()
+        .find_map(|e| match e {
+            WorkflowEvent::RunStarted {
+                workflow_definition,
+                ..
+            } => Some(workflow_definition.clone()),
+            _ => None,
+        })
+        .ok_or(ContractLookupError::RunNotFound)?;
+    lookup_step_output_contract(&workflow, step).ok_or_else(|| {
+        ContractLookupError::NoOutputContract {
+            workflow_name: workflow.name,
+            step: step.to_string(),
+        }
+    })
+}
+
+/// [08] workflow definition から `step_name` の `output_contract` を解決する pure helper。
+///
+/// top-level node / parallel child の両方を探索し、`output_contract` が空文字 /
+/// 未設定の step は「提出対象として妥当でない」として `None` を返す。
+///
+/// engine の `WorkflowCommand::SubmitOutput` handler と CLI `workflow output submit /
+/// validate` の双方から再利用される pure 関数として contract モジュールに置く
+/// （spec [08] アーキテクチャ概要: contract resolution は engine と CLI 双方から
+/// 再利用される pure 関数。CLI 層が engine internals に依存しないようにする境界）。
+pub fn lookup_step_output_contract(workflow: &Workflow, step_name: &str) -> Option<String> {
+    for node in &workflow.nodes {
+        if node.name == step_name {
+            return node
+                .output_contract
+                .clone()
+                .filter(|c| !c.trim().is_empty());
+        }
+        if let Some(children) = &node.parallel_children {
+            for child in children {
+                if child.name == step_name {
+                    return child
+                        .output_contract
+                        .clone()
+                        .filter(|c| !c.trim().is_empty());
+                }
+            }
+        }
+    }
+    None
+}
+
 /// contract検証結果。
 #[derive(Debug, Clone)]
 pub enum ContractValidationResult {
@@ -388,5 +464,68 @@ mod tests {
             }
             other => panic!("expected Valid, got {:?}", other),
         }
+    }
+
+    // ---- [08] resolve_step_output_contract_from_events: CLI / Tauri 共通の解決経路 ----
+
+    fn workflow_with_review_contract(contract: Option<&str>) -> Workflow {
+        use crate::workflow::schema::{NodeDefinition, NodeType};
+        Workflow {
+            name: "wf-resolve".to_string(),
+            description: "".to_string(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "review".to_string(),
+                node_type: NodeType::Agent,
+                instruction: Some("review".to_string()),
+                output_contract: contract.map(str::to_string),
+                ..NodeDefinition::default()
+            }],
+        }
+    }
+
+    fn run_started_event(workflow: Workflow) -> WorkflowEvent {
+        WorkflowEvent::RunStarted {
+            run_id: "run-1".to_string(),
+            workflow_name: workflow.name.clone(),
+            workflow_file_stem: workflow.name.clone(),
+            worktree_path: "/wt".to_string(),
+            workflow_definition: workflow,
+            timestamp: 1.0,
+        }
+    }
+
+    /// spec [08]: RunStarted から workflow_definition を引き、step の contract を解決する。
+    #[test]
+    fn resolve_step_output_contract_from_events_resolves_compliant_contract() {
+        let events = vec![run_started_event(workflow_with_review_contract(Some(
+            "review-verdict",
+        )))];
+        let contract = resolve_step_output_contract_from_events(&events, "review")
+            .expect("contract should be resolved");
+        assert_eq!(contract, "review-verdict");
+    }
+
+    /// spec [08]: RunStarted event がない event 列は `RunNotFound`。
+    #[test]
+    fn resolve_step_output_contract_from_events_returns_run_not_found_without_run_started() {
+        let err = resolve_step_output_contract_from_events(&[], "review")
+            .expect_err("missing RunStarted should yield error");
+        assert_eq!(err, ContractLookupError::RunNotFound);
+    }
+
+    /// spec [08]: step に `output_contract` が無い場合は `NoOutputContract`。
+    #[test]
+    fn resolve_step_output_contract_from_events_returns_no_output_contract_when_unset() {
+        let events = vec![run_started_event(workflow_with_review_contract(None))];
+        let err = resolve_step_output_contract_from_events(&events, "review")
+            .expect_err("missing output_contract should yield error");
+        assert_eq!(
+            err,
+            ContractLookupError::NoOutputContract {
+                workflow_name: "wf-resolve".to_string(),
+                step: "review".to_string(),
+            }
+        );
     }
 }

--- a/src-tauri/src/workflow/contract.rs
+++ b/src-tauri/src/workflow/contract.rs
@@ -168,7 +168,6 @@ fn validate_spec_file_path(json: Value) -> ContractValidationResult {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,10 +318,7 @@ mod tests {
 
     #[test]
     fn validate_contract_value_rejects_absolute_spec_file_path() {
-        match validate_contract_value(
-            "spec-file-path",
-            json!({"spec_file_path": "/etc/passwd"}),
-        ) {
+        match validate_contract_value("spec-file-path", json!({"spec_file_path": "/etc/passwd"})) {
             ContractValidationResult::Invalid(v) => {
                 assert_eq!(v.reason, "invalid_path");
             }
@@ -346,10 +342,7 @@ mod tests {
     #[test]
     fn validate_contract_value_rejects_windows_drive_spec_file_path() {
         for path in &["C:\\repo\\spec.md", "C:/repo/spec.md", "D:\\file.md"] {
-            match validate_contract_value(
-                "spec-file-path",
-                json!({"spec_file_path": path}),
-            ) {
+            match validate_contract_value("spec-file-path", json!({"spec_file_path": path})) {
                 ContractValidationResult::Invalid(v) => {
                     assert_eq!(v.reason, "invalid_path", "path: {path}");
                 }
@@ -360,10 +353,7 @@ mod tests {
 
     #[test]
     fn validate_contract_value_rejects_missing_spec_file_path_field() {
-        match validate_contract_value(
-            "spec-file-path",
-            json!({"path": "some/path.md"}),
-        ) {
+        match validate_contract_value("spec-file-path", json!({"path": "some/path.md"})) {
             ContractValidationResult::Invalid(v) => {
                 assert_eq!(v.reason, "missing_field");
             }

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -18,13 +18,9 @@ use crate::workflow::command_input::{
     validate_optional_comment_text, validate_reject_reason_text, validate_required_comment_text,
     CommandInputError,
 };
-use crate::workflow::contract::{
-    build_repair_prompt, extract_workflow_output, validate_contract, validate_contract_value,
-    ContractValidationResult, ExtractionResult,
-};
+use crate::workflow::contract::{validate_contract_value, ContractValidationResult};
 use crate::workflow::event::{ApprovalDecisionRecord, CollectedOutputEntry, WorkflowEvent};
 use crate::workflow::event_projection::reconstruct_state_from_events;
-use crate::workflow::facet;
 use crate::workflow::log::WorkflowEventLog;
 use crate::workflow::resolver::{
     ManagedWorktreeResolver, ManagedWorktreeResolverError, WorkflowDefinitionResolver,
@@ -45,7 +41,6 @@ use crate::workflow::state::{
 
 #[allow(dead_code)]
 const MAX_OUTPUT_SIZE: usize = 100 * 1024; // 100KB
-const MAX_CONTRACT_RETRIES: u32 = 2;
 
 static PRIVATE_KEY_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     regex::Regex::new(r"(?is)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----")
@@ -491,6 +486,9 @@ struct ParallelChildRun {
     output_contract: Option<String>,
     token_usage: TokenUsage,
     run_index: u32,
+    /// [08] prose 抽出経路の廃止により本 field は事実上常に 0 で推移する。
+    /// 既存 NDJSON 互換と struct shape 維持のため field 自体は残す。
+    #[allow(dead_code)]
     contract_retry_count: u32,
 }
 
@@ -995,6 +993,11 @@ struct ReduceResult {
 }
 
 /// Contract検証の結果（呼び出し元の次アクションを示す）
+/// [08] prose 抽出経路の廃止により本 enum は事実上 `NoContract` 単一となったが、
+/// `validate_*_contract` の戻り値 shape を保持し、呼び出し側の `match` 構造を
+/// 変えずにスタブ化するために `Valid` / `RetrySent` / `Failed` を残す（将来の
+/// 「engine 内 contract 副作用」を再導入する余地としても保持）。
+#[allow(dead_code)]
 enum ContractCheckResult {
     /// contractなし → 通常フローで続行
     NoContract,
@@ -1890,17 +1893,19 @@ impl WorkflowEngine {
             (exec.workflow.name.clone(), run_index, expected_contract)
         };
         // 2. contract 適合判定（pure validator、副作用なし）。
-        let validated_output = match validate_contract_value(&contract, structured_output) {
-            ContractValidationResult::Valid {
-                structured_output, ..
-            } => structured_output,
-            ContractValidationResult::Invalid(violation) => {
-                return Err(WorkflowEngineError::ValidationError(format!(
-                    "contract validation failed ({}): {}",
-                    violation.reason, violation.details
-                )));
-            }
-        };
+        let (validated_output, validated_result) =
+            match validate_contract_value(&contract, structured_output) {
+                ContractValidationResult::Valid {
+                    structured_output,
+                    result,
+                } => (structured_output, result),
+                ContractValidationResult::Invalid(violation) => {
+                    return Err(WorkflowEngineError::ValidationError(format!(
+                        "contract validation failed ({}): {}",
+                        violation.reason, violation.details
+                    )));
+                }
+            };
         debug_assert_eq!(expected_contract, contract);
 
         // 3. state mutation（writer lock スコープ）。step_outputs と workflow_variables
@@ -1921,7 +1926,7 @@ impl WorkflowEngine {
                     step_name: step_name.clone(),
                     run_index,
                     session_id: None,
-                    result: None,
+                    result: validated_result.clone(),
                     structured_output: Some(validated_output.clone()),
                     output_contract: Some(contract.clone()),
                     token_usage: None,
@@ -3398,160 +3403,20 @@ impl WorkflowEngine {
             })
         };
 
-        // contract検証（exit_code == 0 かつ output_contractが設定されている場合のみ）
-        let (child_result, child_structured_output) = if exit_code == 0 {
-            if let Some(ref contract) = child_output_contract {
-                // output_textがNoneの場合もNoBlockとして検証する
-                let extraction = match &output_text {
-                    Some(text) => extract_workflow_output(text),
-                    None => ExtractionResult::NoBlock,
-                };
-                match validate_contract(contract, extraction) {
-                    ContractValidationResult::Valid {
-                        structured_output,
-                        result,
-                    } => (
-                        result,
-                        Some(Self::mask_sensitive_structured_output(
-                            app,
-                            contract,
-                            structured_output,
-                        )),
-                    ),
-                    ContractValidationResult::Invalid(violation) => {
-                        // contract violation: child単位のリトライまたは失敗
-                        let (should_retry, retry_count, exec_id, wf_name, child_step_name) = {
-                            let mut execs = self.executions.lock().await;
-                            let exec = execs.get_mut(run_id).ok_or_else(|| {
-                                WorkflowEngineError::ExecutionNotFound(run_id.to_string())
-                            })?;
-                            let exec_id = exec.id.clone();
-                            let wf_name = exec.workflow.name.clone();
-                            let pr = exec.parallel_run.as_mut().ok_or_else(|| {
-                                WorkflowEngineError::ExecutionNotFound(worktree_path.to_string())
-                            })?;
-                            let child = pr
-                                .children
-                                .iter_mut()
-                                .find(|c| c.session_id == session_id)
-                                .ok_or_else(|| {
-                                    WorkflowEngineError::ExecutionNotFound(
-                                        worktree_path.to_string(),
-                                    )
-                                })?;
-                            let retry_count = child.contract_retry_count;
-                            let child_step_name = child.step_name.clone();
-                            if retry_count < MAX_CONTRACT_RETRIES {
-                                child.contract_retry_count += 1;
-                                (true, retry_count, exec_id, wf_name, child_step_name)
-                            } else {
-                                (false, retry_count, exec_id, wf_name, child_step_name)
-                            }
-                        };
-
-                        if should_retry {
-                            self.send_contract_repair(
-                                app,
-                                session_store,
-                                handles,
-                                worktree_path,
-                                session_id,
-                                contract,
-                                &violation,
-                                &exec_id,
-                                &wf_name,
-                                &child_step_name,
-                                retry_count + 1,
-                            )
-                            .await?;
-                            return Ok(());
-                        } else {
-                            // リトライ上限超過 → ワークフロー全体をFailed
-                            // [05] commit 境界: terminal event は pre-commit batch で
-                            // append し、append 失敗時は engine state を mutation 直前
-                            // snapshot で一括復元する（post-persist warn 廃止）。
-                            let (snapshot, running_ids, exec_snapshot_before) = {
-                                let mut execs = self.executions.lock().await;
-                                let exec = execs.get_mut(run_id).ok_or_else(|| {
-                                    WorkflowEngineError::ExecutionNotFound(run_id.to_string())
-                                })?;
-                                let exec_snapshot_before = exec.clone();
-                                let running_ids: Vec<String> = exec
-                                    .parallel_run
-                                    .as_mut()
-                                    .map(|pr| {
-                                        pr.children
-                                            .iter_mut()
-                                            .filter(|c| c.state == ParallelChildState::Running)
-                                            .map(|c| {
-                                                c.state = ParallelChildState::Interrupted;
-                                                c.session_id.clone()
-                                            })
-                                            .collect()
-                                    })
-                                    .unwrap_or_default();
-                                exec.state = WorkflowExecutionState::Failed {
-                                        reason: format!(
-                                        "Contract violation at parallel child '{}' after {} retries: {}",
-                                        child_step_name, MAX_CONTRACT_RETRIES, violation.details
-                                    ),
-                                    };
-                                exec.parallel_run = None;
-                                exec.updated_at = current_timestamp();
-                                (exec.to_workflow_state(), running_ids, exec_snapshot_before)
-                            };
-
-                            // [05] pre-commit: terminal event を先に append。失敗時は
-                            // engine state を snapshot_before で一括復元し Err を返す。
-                            if let Err(e) = self.write_terminal_log(app, &snapshot) {
-                                let mut execs = self.executions.lock().await;
-                                if let Some(exec) = execs.get_mut(run_id) {
-                                    *exec = exec_snapshot_before;
-                                }
-                                return Err(WorkflowEngineError::SessionStore(format!(
-                                    "contract failure terminal event append failed: {e}"
-                                )));
-                            }
-
-                            if let Err(e) =
-                                self.sync_run_store_from_snapshot(run_id, &snapshot).await
-                            {
-                                self.rollback_execution_projection_after_run_store_sync_failure(
-                                    run_id, &snapshot,
-                                )
-                                .await;
-                                return Err(e);
-                            }
-                            for sid in &running_ids {
-                                self.interrupt_agent(handles, sid).await;
-                            }
-                            let mut cleanup_ids = running_ids;
-                            cleanup_ids.push(session_id.to_string());
-                            cleanup_ids.sort();
-                            cleanup_ids.dedup();
-                            for sid in cleanup_ids {
-                                self.release_completed_step_session(
-                                    app,
-                                    session_store,
-                                    handles,
-                                    &sid,
-                                )
-                                .await;
-                            }
-                            self.broadcast_state(app, worktree_path, snapshot.clone())
-                                .await;
-                            self.cleanup_session_workflow_refs_by_run_id(&snapshot.execution_id)
-                                .await;
-                            return Ok(());
-                        }
-                    }
-                }
+        // [08] parallel child の構造化出力は CLI / Tauri 経由の `SubmitOutput` で確定する。
+        // 旧来の「agent 自由文から `<workflow_output>` を抽出して step output を確定する」
+        // 経路は廃止された（spec [08] Rule 4 構造化出力の確定経路は明示的提出のみ）。
+        // child 完了時点では `child_structured_output = None` のまま進行し、後続 step
+        // からは未提出として扱われる。
+        let _ = (session_id, session_store, handles); // 旧 contract retry 経路用引数の参照を維持
+        let (child_result, child_structured_output): (Option<String>, Option<serde_json::Value>) =
+            if exit_code == 0 {
+                let _ = child_output_contract.as_ref();
+                let _ = output_text.as_deref();
+                (None, None)
             } else {
                 (None, None)
-            }
-        } else {
-            (None, None)
-        };
+            };
 
         // contract検証成功時のworkflow_variables反映
         self.apply_contract_variables_for_run(
@@ -3953,363 +3818,37 @@ impl WorkflowEngine {
         }
     }
 
+    /// [08] approval node の構造化出力は CLI / Tauri 経由の `SubmitOutput` で確定する。
+    /// engine 側で自由文から `<workflow_output>` を抽出する経路は廃止された
+    /// （spec [08] Rule 4）。`output_contract` の有無に依らず常に `NoContract` を返し、
+    /// 後続経路では `structured_output = None` として進行する。
     fn validate_approval_output_contract<R: tauri::Runtime>(
-        app: &tauri::AppHandle<R>,
-        output_contract: &Option<String>,
-        output_text: Option<&str>,
-        workflow: &Workflow,
-        current_step_index: usize,
+        _app: &tauri::AppHandle<R>,
+        _output_contract: &Option<String>,
+        _output_text: Option<&str>,
+        _workflow: &Workflow,
+        _current_step_index: usize,
     ) -> Result<ContractCheckResult, WorkflowEngineError> {
-        let contract = match output_contract {
-            Some(c) => c,
-            None => return Ok(ContractCheckResult::NoContract),
-        };
-        let extraction = match output_text {
-            Some(text) if !text.trim().is_empty() => extract_workflow_output(text),
-            _ => ExtractionResult::NoBlock,
-        };
-        match Self::validate_approval_contract_extraction(
-            contract,
-            extraction,
-            workflow,
-            current_step_index,
-        )? {
-            ContractCheckResult::Valid {
-                structured_output,
-                result,
-            } => Ok(ContractCheckResult::Valid {
-                structured_output: Self::mask_sensitive_structured_output(
-                    app,
-                    contract,
-                    structured_output,
-                ),
-                result,
-            }),
-            other => Ok(other),
-        }
+        Ok(ContractCheckResult::NoContract)
     }
 
-    fn validate_approval_contract_extraction(
-        contract: &str,
-        extraction: ExtractionResult,
-        workflow: &Workflow,
-        current_step_index: usize,
-    ) -> Result<ContractCheckResult, WorkflowEngineError> {
-        let step_name = workflow
-            .nodes
-            .get(current_step_index)
-            .map(|s| s.name.as_str())
-            .unwrap_or("<unknown>");
-        match validate_contract(contract, extraction) {
-            ContractValidationResult::Valid {
-                structured_output,
-                result,
-            } => {
-                Self::validate_approval_contract_semantics(
-                    contract,
-                    &structured_output,
-                    workflow,
-                    current_step_index,
-                )?;
-                Ok(ContractCheckResult::Valid {
-                    structured_output,
-                    result,
-                })
-            }
-            ContractValidationResult::Invalid(violation) => {
-                Err(WorkflowEngineError::ValidationError(format!(
-                    "approval output contract violation at step '{}': {} ({})",
-                    step_name, violation.details, violation.reason
-                )))
-            }
-        }
-    }
-
-    fn validate_approval_contract_semantics(
-        contract: &str,
-        structured_output: &serde_json::Value,
-        workflow: &Workflow,
-        current_step_index: usize,
-    ) -> Result<(), WorkflowEngineError> {
-        if contract != "approved-fix-policy" {
-            return Ok(());
-        }
-        let step = workflow.nodes.get(current_step_index).ok_or_else(|| {
-            WorkflowEngineError::InvalidWorkflow(format!(
-                "Current step index {} is out of range",
-                current_step_index
-            ))
-        })?;
-        let review_step = structured_output
-            .get("review_step")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                WorkflowEngineError::ValidationError(format!(
-                    "approval output contract violation at step '{}': Missing required field \"review_step\". (missing_field)",
-                    step.name
-                ))
-            })?;
-        if !step
-            .pass_output_from
-            .as_deref()
-            .is_some_and(|refs| refs.iter().any(|r| r == review_step))
-        {
-            return Err(WorkflowEngineError::ValidationError(format!(
-                "approval output contract violation at step '{}': \"review_step\" must name a review source passed to this approval step. (unknown_review_step)",
-                step.name
-            )));
-        }
-        if !Self::workflow_step_is_review_source(workflow, review_step) {
-            return Err(WorkflowEngineError::ValidationError(format!(
-                "approval output contract violation at step '{}': \"review_step\" must name a review or aggregate step in the current workflow. (unknown_review_step)",
-                step.name
-            )));
-        }
-        Ok(())
-    }
-
-    fn workflow_step_is_review_source(workflow: &Workflow, step_name: &str) -> bool {
-        workflow.nodes.iter().any(|step| {
-            (step.name == step_name
-                && (step.aggregate.is_some()
-                    || step.output_contract.as_deref() == Some("review-verdict")))
-                || step.parallel_children.as_ref().is_some_and(|children| {
-                    children.iter().any(|child| {
-                        child.name == step_name
-                            && child.output_contract.as_deref() == Some("review-verdict")
-                    })
-                })
-        })
-    }
-
-    /// 非並列stepのcontract検証を共通処理する。
-    /// auto および並列子ステップの2パスで同一のcontract検証・retry・failure処理を行う。
+    /// [08] agent step の構造化出力は CLI / Tauri 経由の `SubmitOutput` で確定する。
+    /// engine 側で自由文から `<workflow_output>` を抽出する経路は廃止された
+    /// （spec [08] Rule 4）。`output_contract` の有無に依らず常に `NoContract` を返し、
+    /// 後続経路では `structured_output = None` として進行する。
     #[allow(clippy::too_many_arguments)]
     async fn validate_and_handle_contract<R: tauri::Runtime>(
         &self,
-        app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
-        handles: &Arc<Mutex<AgentProcessMap>>,
-        worktree_path: &str,
-        output_contract: &Option<String>,
-        output_text: Option<&str>,
-        current_session_id: &Option<String>,
-        step_name: &str,
+        _app: &tauri::AppHandle<R>,
+        _session_store: &Arc<SessionStore>,
+        _handles: &Arc<Mutex<AgentProcessMap>>,
+        _worktree_path: &str,
+        _output_contract: &Option<String>,
+        _output_text: Option<&str>,
+        _current_session_id: &Option<String>,
+        _step_name: &str,
     ) -> Result<ContractCheckResult, WorkflowEngineError> {
-        let contract = match output_contract {
-            Some(c) => c,
-            None => return Ok(ContractCheckResult::NoContract),
-        };
-
-        // output_textがNoneの場合もNoBlockとして検証する（Spec: blockが存在しない場合はretry）
-        let extraction = match output_text {
-            Some(text) => extract_workflow_output(text),
-            None => ExtractionResult::NoBlock,
-        };
-        match validate_contract(contract, extraction) {
-            ContractValidationResult::Valid {
-                structured_output,
-                result,
-            } => Ok(ContractCheckResult::Valid {
-                structured_output: Self::mask_sensitive_structured_output(
-                    app,
-                    contract,
-                    structured_output,
-                ),
-                result,
-            }),
-            ContractValidationResult::Invalid(violation) => {
-                let (should_retry, retry_count, exec_id, wf_name) = {
-                    let mut execs = self.executions.lock().await;
-                    let exec =
-                        find_by_worktree_mut(&mut execs, worktree_path).ok_or_else(|| {
-                            WorkflowEngineError::ExecutionNotFound(worktree_path.to_string())
-                        })?;
-                    let retry_count = exec.contract_retry_count;
-                    let exec_id = exec.id.clone();
-                    let wf_name = exec.workflow.name.clone();
-                    if retry_count < MAX_CONTRACT_RETRIES {
-                        exec.contract_retry_count += 1;
-                        (true, retry_count, exec_id, wf_name)
-                    } else {
-                        (false, retry_count, exec_id, wf_name)
-                    }
-                };
-
-                if should_retry {
-                    if let Some(ref sid) = current_session_id {
-                        self.send_contract_repair(
-                            app,
-                            session_store,
-                            handles,
-                            worktree_path,
-                            sid,
-                            contract,
-                            &violation,
-                            &exec_id,
-                            &wf_name,
-                            step_name,
-                            retry_count + 1,
-                        )
-                        .await?;
-                        return Ok(ContractCheckResult::RetrySent);
-                    }
-                }
-                // retry不可またはsession_idなし → Failed遷移
-                {
-                    let (snapshot, snapshot_before, run_id) = {
-                        let mut execs = self.executions.lock().await;
-                        let exec =
-                            find_by_worktree_mut(&mut execs, worktree_path).ok_or_else(|| {
-                                WorkflowEngineError::ExecutionNotFound(worktree_path.to_string())
-                            })?;
-                        // [05] commit 境界: terminal event を required append にするため、
-                        // mutation 前の snapshot を捕捉して rollback target に揃える。
-                        let snapshot_before = exec.clone();
-                        let run_id = exec.id.clone();
-                        let entry = exec.make_step_history_entry(
-                            Some("contract_violation".to_string()),
-                            None,
-                            output_contract.clone(),
-                        );
-                        exec.step_history.push(entry);
-                        let fail_reason = if should_retry {
-                            format!(
-                                "Contract violation at step '{}': no active session for repair: {}",
-                                step_name, violation.details
-                            )
-                        } else {
-                            format!(
-                                "Contract violation at step '{}' after {} retries: {}",
-                                step_name, MAX_CONTRACT_RETRIES, violation.details
-                            )
-                        };
-                        exec.state = WorkflowExecutionState::Failed {
-                            reason: fail_reason,
-                        };
-                        exec.updated_at = current_timestamp();
-                        (exec.to_workflow_state(), snapshot_before, run_id)
-                    };
-
-                    // [05] commit_required_events 基盤の共通 commit 境界に統合:
-                    // terminal event 列 (NodeFailed + RunFailed) を required event として
-                    // append し、失敗時は engine state と Run Store snapshot を
-                    // snapshot_before で一括復元する（spec [05] atomic mutation 境界 /
-                    // best-effort warn 廃止）。
-                    let mut terminal_snapshot = snapshot.clone();
-                    let required_events =
-                        match Self::terminal_events_for_snapshot(&mut terminal_snapshot) {
-                            Ok(events) => events,
-                            Err(e) => {
-                                // event 構築失敗時は engine state を snapshot_before に復元する。
-                                let mut execs = self.executions.lock().await;
-                                if let Some(exec) = execs.get_mut(&run_id) {
-                                    *exec = snapshot_before;
-                                }
-                                return Err(e);
-                            }
-                        };
-                    let completed_step_session_ids = Self::completed_step_session_ids(&snapshot);
-                    let run_store_snapshot_before =
-                        self.run_store.active_run_snapshot(&run_id).await;
-                    self.commit_required_events(
-                        app,
-                        session_store,
-                        RequiredEventCommit {
-                            run_id: &run_id,
-                            snapshot_for_commit: &snapshot,
-                            snapshot_before,
-                            run_store_snapshot_before,
-                            required_events,
-                            append_error_context: "contract violation terminal event append failed",
-                        },
-                    )
-                    .await?;
-                    self.release_completed_step_sessions(
-                        app,
-                        session_store,
-                        handles,
-                        &completed_step_session_ids,
-                    )
-                    .await;
-                    // terminal 系副作用: cleanup + broadcast。terminal event は append 済みのため
-                    // finalize_after_commit 側では write_terminal_events=false で二重 append を避ける。
-                    self.finalize_after_commit(app, &snapshot, worktree_path, false)
-                        .await;
-                    Ok(ContractCheckResult::Failed)
-                }
-            }
-        }
-    }
-
-    /// contract violation時のrepair prompt送信を行う共通ヘルパー。
-    /// ログ書き込み・ファセット読み込み・repair prompt生成・agent turn送信を一箇所にまとめる。
-    #[allow(clippy::too_many_arguments)]
-    async fn send_contract_repair<R: tauri::Runtime>(
-        &self,
-        app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
-        handles: &Arc<Mutex<AgentProcessMap>>,
-        worktree_path: &str,
-        session_id: &str,
-        contract: &str,
-        violation: &crate::workflow::contract::ContractViolation,
-        exec_id: &str,
-        wf_name: &str,
-        step_name: &str,
-        attempt: u32,
-    ) -> Result<(), WorkflowEngineError> {
-        self.write_log(
-            app,
-            WorkflowEvent::ContractRepairRequested {
-                run_id: exec_id.to_string(),
-                workflow_name: wf_name.to_string(),
-                node_name: step_name.to_string(),
-                attempt,
-                violation_reason: violation.reason.clone(),
-                timestamp: current_timestamp(),
-            },
-        );
-
-        // ユーザーが当該 session を閉じている最中なら retry を skip する。
-        // turn_complete cleanup と tab close が並走したとき、close 後に
-        // bridge が無いままここに来ても spawn し直してしまうのを防ぐ。
-        if crate::agent_sdk::is_session_closing(session_id).await {
-            return Ok(());
-        }
-
-        let contract_definition = {
-            let base_dir = facet::facets_base_dir();
-            crate::workflow::facet::load_facet(
-                crate::workflow::facet::FacetKind::Contract,
-                contract,
-                &base_dir,
-            )
-            .ok()
-        };
-        let repair_prompt =
-            build_repair_prompt(contract, violation, contract_definition.as_deref());
-        let permission_mode = {
-            let data_dir = crate::session::resolve_data_dir(app)
-                .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
-            let step_session = session_store
-                .get_session(&data_dir, session_id)
-                .map_err(|e| WorkflowEngineError::SessionStore(format!("get_session: {e}")))?
-                .ok_or_else(|| WorkflowEngineError::SessionNotFound(session_id.to_string()))?;
-            step_session.permission_mode
-        };
-        crate::agent_sdk::start_agent_turn_internal(
-            app,
-            handles,
-            session_store,
-            session_id,
-            worktree_path,
-            &permission_mode,
-            &repair_prompt,
-        )
-        .await
-        .map_err(WorkflowEngineError::AgentSession)?;
-        Ok(())
+        Ok(ContractCheckResult::NoContract)
     }
 
     /// `run_id` を直接指定して session_workflow_refs を掃除する。
@@ -5306,6 +4845,7 @@ impl WorkflowEngine {
         vars
     }
 
+    #[allow(dead_code)]
     fn mask_sensitive_structured_output<R: tauri::Runtime>(
         app: &tauri::AppHandle<R>,
         contract: &str,
@@ -5315,6 +4855,7 @@ impl WorkflowEngine {
         Self::mask_sensitive_structured_output_with_secrets(contract, value, &secrets)
     }
 
+    #[allow(dead_code)]
     fn mask_sensitive_structured_output_with_secrets(
         contract: &str,
         mut value: serde_json::Value,
@@ -5395,6 +4936,7 @@ impl WorkflowEngine {
         values
     }
 
+    #[allow(dead_code)]
     fn mask_json_strings(value: &mut serde_json::Value, configured_secrets: &[String]) {
         match value {
             serde_json::Value::String(s) => {
@@ -7311,35 +6853,19 @@ impl WorkflowEngine {
             ApprovalDecision::Approve => "approve",
             ApprovalDecision::Reject { .. } => "reject",
         };
-        let (structured_output, contract_result) = match &decision {
-            ApprovalDecision::Approve => match output_contract.as_deref() {
-                Some(contract) => {
-                    let extraction = match output_text.as_deref() {
-                        Some(text) => extract_workflow_output(text),
-                        None => ExtractionResult::NoBlock,
-                    };
-                    match Self::validate_approval_contract_extraction(
-                        contract,
-                        extraction,
-                        &workflow_for_contract,
-                        current_step_index_for_contract,
-                    )? {
-                        ContractCheckResult::Valid {
-                            structured_output,
-                            result,
-                        } => (Some(structured_output), result),
-                        ContractCheckResult::NoContract => (None, None),
-                        ContractCheckResult::RetrySent | ContractCheckResult::Failed => {
-                            unreachable!()
-                        }
-                    }
+        // [08] approval 経路の自由文 contract 抽出は廃止。approval node の構造化出力は
+        // CLI / Tauri 経由の `SubmitOutput` で確定する（spec [08] Rule 4）。Approve 時の
+        // `structured_output` は None で固定し、Reject 時のみ comment 由来の暫定 payload を
+        // 維持する（既存 reject 経路は本 issue のスコープ外）。
+        let _ = (workflow_for_contract, current_step_index_for_contract);
+        let _ = output_text.as_deref();
+        let (structured_output, contract_result): (Option<serde_json::Value>, Option<String>) =
+            match &decision {
+                ApprovalDecision::Approve => (None, None),
+                ApprovalDecision::Reject { comment } => {
+                    (Some(Self::reject_structured_output(comment, &[])), None)
                 }
-                None => (None, None),
-            },
-            ApprovalDecision::Reject { comment } => {
-                (Some(Self::reject_structured_output(comment, &[])), None)
-            }
-        };
+            };
 
         let application_output_contract = if matches!(decision, ApprovalDecision::Approve) {
             output_contract.clone()
@@ -7917,6 +7443,7 @@ mod tests {
         )
     }
 
+    #[allow(dead_code)]
     fn make_approved_fix_policy_workflow() -> Workflow {
         Workflow {
             name: "approved-fix-policy-test".to_string(),
@@ -9735,27 +9262,8 @@ mod tests {
         assert!(vars.is_empty());
     }
 
-    // ---- contract retry判定 ----
-
-    #[test]
-    fn contract_retry_within_limit() {
-        let retry_count: u32 = 0;
-        assert!(retry_count < MAX_CONTRACT_RETRIES);
-        let retry_count: u32 = 1;
-        assert!(retry_count < MAX_CONTRACT_RETRIES);
-    }
-
-    #[test]
-    fn contract_retry_at_limit_should_fail() {
-        let retry_count: u32 = MAX_CONTRACT_RETRIES;
-        assert!(retry_count >= MAX_CONTRACT_RETRIES);
-    }
-
-    #[test]
-    fn contract_retry_over_limit_should_fail() {
-        let retry_count: u32 = MAX_CONTRACT_RETRIES + 1;
-        assert!(retry_count >= MAX_CONTRACT_RETRIES);
-    }
+    // ---- contract retry 判定テストは prose 抽出経路 ([08] で廃止) の付随物だったため削除した。
+    //      contract 適合判定は CLI / Tauri 経由の SubmitOutput で発生し、retry は行わない。
 
     // ---- apply_reduce ----
 
@@ -11347,133 +10855,10 @@ mod tests {
         .is_ok());
     }
 
-    #[test]
-    fn validate_approval_contract_valid_returns_structured_output() {
-        let workflow = make_approved_fix_policy_workflow();
-        let result = WorkflowEngine::validate_approval_contract_extraction(
-            "approved-fix-policy",
-            ExtractionResult::Found {
-                type_name: "approved-fix-policy".to_string(),
-                json: serde_json::json!({
-                    "policy": "Fix the reported issue.",
-                    "review_step": "code_review_parallel"
-                }),
-            },
-            &workflow,
-            1,
-        )
-        .unwrap();
-        match result {
-            ContractCheckResult::Valid {
-                structured_output,
-                result,
-            } => {
-                assert_eq!(result.as_deref(), Some("approved"));
-                assert_eq!(structured_output["review_step"], "code_review_parallel");
-            }
-            _ => panic!("expected valid approval contract"),
-        }
-    }
-
-    #[test]
-    fn validate_approval_contract_rejects_review_step_not_passed_to_approval_step() {
-        let workflow = make_approved_fix_policy_workflow();
-        let result = WorkflowEngine::validate_approval_contract_extraction(
-            "approved-fix-policy",
-            ExtractionResult::Found {
-                type_name: "approved-fix-policy".to_string(),
-                json: serde_json::json!({
-                    "policy": "Fix the reported issue.",
-                    "review_step": "other_review_parallel"
-                }),
-            },
-            &workflow,
-            1,
-        );
-        match result {
-            Err(err) => {
-                let err = err.to_string();
-                assert!(err.starts_with("validation_error:"));
-                assert!(err.contains("unknown_review_step"));
-            }
-            Ok(_) => panic!("expected validation_error"),
-        }
-    }
-
-    #[test]
-    fn approval_contract_without_completed_assistant_output_returns_validation_error() {
-        let workflow = make_approved_fix_policy_workflow();
-        let result = WorkflowEngine::validate_approval_contract_extraction(
-            "approved-fix-policy",
-            ExtractionResult::NoBlock,
-            &workflow,
-            1,
-        );
-        match result {
-            Err(WorkflowEngineError::ValidationError(message)) => {
-                assert!(message.contains("no_block"));
-            }
-            _ => panic!("expected validation_error"),
-        }
-    }
-
-    #[test]
-    fn approval_contract_ignores_valid_policy_from_other_session_when_current_has_no_output() {
-        let workflow = make_approved_fix_policy_workflow();
-        let other_session = crate::session::ChatSession {
-            id: "other-policy-session".to_string(),
-            worktree_path: "/repo".to_string(),
-            messages: vec![crate::session::ChatMessage {
-                id: "m1".to_string(),
-                role: crate::session::MessageRole::Agent,
-                content: approved_fix_policy_output(
-                    "Policy from a previous run.",
-                    "code_review_parallel",
-                ),
-                thinking: None,
-                activities: None,
-                parts: None,
-                timestamp: 1.0,
-                mentions: None,
-            }],
-            state: crate::session::SessionState::Idle,
-            created_at: 1.0,
-            updated_at: 1.0,
-            agent_session_id: None,
-            permission_mode: "edit".to_string(),
-            selected_model: None,
-            backend_id: None,
-            workflow_step_session: false,
-        };
-        let current_session = crate::session::ChatSession {
-            id: "current-policy-session".to_string(),
-            worktree_path: "/repo".to_string(),
-            messages: vec![],
-            state: crate::session::SessionState::Idle,
-            created_at: 2.0,
-            updated_at: 2.0,
-            agent_session_id: None,
-            permission_mode: "edit".to_string(),
-            selected_model: None,
-            backend_id: None,
-            workflow_step_session: false,
-        };
-
-        assert!(WorkflowEngine::extract_last_assistant_text_from_session(&other_session).is_some());
-        assert!(
-            WorkflowEngine::extract_last_assistant_text_from_session(&current_session).is_none()
-        );
-        let result = WorkflowEngine::validate_approval_contract_extraction(
-            "approved-fix-policy",
-            ExtractionResult::NoBlock,
-            &workflow,
-            1,
-        );
-        match result {
-            Err(WorkflowEngineError::ValidationError(_)) => {}
-            _ => panic!("expected validation_error"),
-        }
-    }
+    // [08] 旧 `validate_approval_contract_extraction` ベースの 4 テストは prose 抽出経路の
+    // 廃止に伴い削除した。approval node の構造化出力は CLI / Tauri 経由の `SubmitOutput`
+    // で確定し、対応する境界テストは `dispatch_boundary_tests::submit_output_*` 群と
+    // `workflow::contract::tests::validate_contract_value_*` 群でカバーされる。
 
     #[tokio::test]
     async fn validate_approval_chat_instruction_limits_current_approval_session() {
@@ -11998,26 +11383,16 @@ mod tests {
 
     #[test]
     fn spec_driven_plan_fix_policy_approve_records_policy_and_starts_plan_fix_once() {
+        // [08] prose 抽出経路は廃止済み。テストでは CLI submit 経由で確定する想定の
+        // structured_output と effective_result を直接組み立てて apply_approval_application
+        // の遷移挙動を検証する（spec [08] Rule 4 / [05] internal node command 境界）。
         let mut exec =
             make_spec_driven_plan_fix_policy_exec("exec-plan-approve", "plan-policy-session");
-        let policy_text = approved_fix_policy_output(
-            "Update the spec only for the approved plan review finding.",
-            "plan_review_parallel",
-        );
-        let contract_result = WorkflowEngine::validate_approval_contract_extraction(
-            "approved-fix-policy",
-            extract_workflow_output(&policy_text),
-            &exec.workflow,
-            exec.current_step_index,
-        )
-        .unwrap();
-        let (structured_output, effective_result) = match contract_result {
-            ContractCheckResult::Valid {
-                structured_output,
-                result,
-            } => (structured_output, result.unwrap()),
-            _ => panic!("expected valid approved-fix-policy output"),
-        };
+        let structured_output = serde_json::json!({
+            "policy": "Update the spec only for the approved plan review finding.",
+            "review_step": "plan_review_parallel",
+        });
+        let effective_result = "approved".to_string();
 
         let outcome = WorkflowEngine::apply_approval_application(
             &mut exec,
@@ -12295,26 +11670,18 @@ mod tests {
             backend_id: None,
             workflow_step_session: false,
         };
-        let latest = WorkflowEngine::extract_last_assistant_text_from_session(&session).unwrap();
-        let contract_result = WorkflowEngine::validate_approval_contract_extraction(
-            "approved-fix-policy",
-            extract_workflow_output(&latest),
-            &exec.workflow,
-            exec.current_step_index,
-        )
-        .unwrap();
-        let (structured_output, contract_result) = match contract_result {
-            ContractCheckResult::Valid {
-                structured_output,
-                result,
-            } => (structured_output, result),
-            _ => panic!("expected valid approval contract"),
-        };
+        // [08] prose 抽出経路は廃止済み。CLI submit 経由で確定する想定の structured_output
+        // を直接組み立てて apply_approval_application の遷移挙動を検証する。
+        let _ = WorkflowEngine::extract_last_assistant_text_from_session(&session);
+        let structured_output = serde_json::json!({
+            "policy": "Fix only reviewed findings.",
+            "review_step": "code_review_parallel",
+        });
         let outcome = WorkflowEngine::apply_approval_application(
             &mut exec,
             &ApprovalDecision::Approve,
             ApprovalApplication {
-                effective_result: contract_result.unwrap(),
+                effective_result: "approved".to_string(),
                 structured_output: Some(structured_output),
                 output_contract: Some("approved-fix-policy".to_string()),
             },
@@ -12474,14 +11841,13 @@ mod tests {
                 .count(),
             1
         );
-        assert_eq!(
-            exec.step_outputs
-                .get("implementation_fix_policy")
-                .and_then(|output| output.structured_output.as_ref())
-                .and_then(|output| output.get("policy"))
-                .and_then(|policy| policy.as_str()),
-            Some("Fix only the approved review finding.")
-        );
+        // [08] prose 抽出経路は廃止済み。auto approve 経路でも structured_output は
+        // 確定されず、step は output 無しで完了する（spec [08] Rule 4）。
+        assert!(exec
+            .step_outputs
+            .get("implementation_fix_policy")
+            .and_then(|output| output.structured_output.as_ref())
+            .is_none());
     }
 
     #[tokio::test]
@@ -12529,14 +11895,12 @@ mod tests {
                 .count(),
             1
         );
-        assert_eq!(
-            exec.step_outputs
-                .get("plan_fix_policy")
-                .and_then(|output| output.structured_output.as_ref())
-                .and_then(|output| output.get("policy"))
-                .and_then(|policy| policy.as_str()),
-            Some("Revise the spec using the approved plan policy.")
-        );
+        // [08] prose 抽出経路は廃止済み（spec [08] Rule 4）。
+        assert!(exec
+            .step_outputs
+            .get("plan_fix_policy")
+            .and_then(|output| output.structured_output.as_ref())
+            .is_none());
     }
 
     #[tokio::test]
@@ -12653,14 +12017,12 @@ mod tests {
                 .count(),
             1
         );
-        assert_eq!(
-            exec.step_outputs
-                .get("plan_fix_policy")
-                .and_then(|output| output.structured_output.as_ref())
-                .and_then(|output| output.get("review_step"))
-                .and_then(|review_step| review_step.as_str()),
-            Some("plan_review_parallel")
-        );
+        // [08] prose 抽出経路は廃止済み（spec [08] Rule 4）。
+        assert!(exec
+            .step_outputs
+            .get("plan_fix_policy")
+            .and_then(|output| output.structured_output.as_ref())
+            .is_none());
     }
 
     #[test]

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -1825,14 +1825,11 @@ impl WorkflowEngine {
         //    [08] 機密値 redaction: caller (CLI / Tauri API) 入力に approve コメントや
         //    secret token が混入していても event log / step_outputs に生で残らないよう、
         //    redaction 後の structured output を contract validation に通す。
-        let secrets = Self::collect_configured_secret_values(app);
-        let redacted_input = Self::mask_sensitive_structured_output_with_secrets(
-            &contract,
-            structured_output,
-            &secrets,
-        );
+        //    preflight (workflow_validate_output / CLI cmd_output_validate) と本 submit で
+        //    同一の前処理 + validation を共有するため、`preprocess_and_validate_output`
+        //    に集約する（spec [08] L169 / Rule 2）。
         let (validated_output, validated_result) =
-            match validate_contract_value(&contract, redacted_input) {
+            match Self::preprocess_and_validate_output(app, &contract, structured_output) {
                 ContractValidationResult::Valid {
                     structured_output,
                     result,
@@ -4871,6 +4868,44 @@ impl WorkflowEngine {
         }
         Self::mask_json_strings(&mut value, secrets);
         value
+    }
+
+    /// [08] structured output に対する「機密値 redaction → contract 適合判定」を
+    /// 1 関数にまとめた共有 preflight/validate ヘルパー（pure / 副作用なし）。
+    ///
+    /// `handle_submit_output` の本体・`workflow_validate_output` の preflight・
+    /// CLI 経路の preflight (`cmd_output_submit` / `cmd_output_validate`) を
+    /// 同一の前処理 + validation に揃え、preflight と本 submit で判定が
+    /// 食い違う構造を排除する（spec [08] CLI 完了基準: 最終判定は engine 側）。
+    ///
+    /// `secrets` は呼び出し側責任で収集する:
+    ///   - Tauri command / engine 内部: [`Self::collect_configured_secret_values`]
+    ///     経由（AppConfig + env vars）。
+    ///   - CLI 経路: 別プロセスでありアプリ状態を持たないため、現状は空配列で
+    ///     呼ぶ（最終 masking は engine 側で再評価される）。
+    pub(crate) fn preprocess_and_validate_output_with_secrets(
+        contract: &str,
+        structured_output: serde_json::Value,
+        secrets: &[String],
+    ) -> ContractValidationResult {
+        let redacted = Self::mask_sensitive_structured_output_with_secrets(
+            contract,
+            structured_output,
+            secrets,
+        );
+        validate_contract_value(contract, redacted)
+    }
+
+    /// [08] AppHandle 経由で secrets を収集した上で
+    /// [`Self::preprocess_and_validate_output_with_secrets`] に委譲する便利関数。
+    /// Tauri command / engine 内部からの呼び出し用。
+    pub(crate) fn preprocess_and_validate_output<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+        contract: &str,
+        structured_output: serde_json::Value,
+    ) -> ContractValidationResult {
+        let secrets = Self::collect_configured_secret_values(app);
+        Self::preprocess_and_validate_output_with_secrets(contract, structured_output, &secrets)
     }
 
     fn collect_configured_secret_values<R: tauri::Runtime>(

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -19,8 +19,8 @@ use crate::workflow::command_input::{
     CommandInputError,
 };
 use crate::workflow::contract::{
-    build_repair_prompt, extract_workflow_output, validate_contract, ContractValidationResult,
-    ExtractionResult,
+    build_repair_prompt, extract_workflow_output, validate_contract, validate_contract_value,
+    ContractValidationResult, ExtractionResult,
 };
 use crate::workflow::event::{ApprovalDecisionRecord, CollectedOutputEntry, WorkflowEvent};
 use crate::workflow::event_projection::reconstruct_state_from_events;
@@ -1116,6 +1116,32 @@ fn find_any_by_worktree<'a>(
     execs.values().find(|e| e.worktree_path == worktree_path)
 }
 
+/// [08] workflow definition から `step_name` の `output_contract` を解決する。
+///
+/// top-level node / parallel child の両方を探索し、`output_contract` が空文字 /
+/// 未設定の step は「提出対象として妥当でない」として `None` を返す。
+fn lookup_step_output_contract(workflow: &Workflow, step_name: &str) -> Option<String> {
+    for node in &workflow.nodes {
+        if node.name == step_name {
+            return node
+                .output_contract
+                .clone()
+                .filter(|c| !c.trim().is_empty());
+        }
+        if let Some(children) = &node.parallel_children {
+            for child in children {
+                if child.name == step_name {
+                    return child
+                        .output_contract
+                        .clone()
+                        .filter(|c| !c.trim().is_empty());
+                }
+            }
+        }
+    }
+    None
+}
+
 impl WorkflowEngine {
     pub(crate) fn new(
         workflow_resolver: Arc<dyn WorkflowDefinitionResolver>,
@@ -1770,6 +1796,162 @@ impl WorkflowEngine {
             .await
     }
 
+    /// [08] CLI pending command 経由で `SubmitOutput` を engine に取り次ぐ entry。
+    ///
+    /// in-process 経路 (`dispatch_external` の `SubmitOutput` match arm) と同じ
+    /// `handle_submit_output` に合流するが、CLI 経由では caller の `request_id`
+    /// （pending entry id）と `submitted_at`（CLI 側 timestamp）を `OutputSubmitted`
+    /// event に保存する（spec [08] アーキテクチャ概要 / 状態 Owner）。
+    pub(crate) async fn dispatch_submit_output_with_context<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        run_id: &str,
+        step_name: String,
+        contract: String,
+        structured_output: serde_json::Value,
+        request_id: Option<String>,
+        submitted_at: Option<f64>,
+    ) -> Result<(), WorkflowEngineError> {
+        self.handle_submit_output(
+            app,
+            run_id,
+            step_name,
+            contract,
+            structured_output,
+            request_id,
+            submitted_at,
+        )
+        .await
+    }
+
+    /// [08] step に対する構造化出力提出の単一トランザクション handler。
+    ///
+    /// 1. run / step / contract の妥当性検証
+    /// 2. `validate_contract_value` で contract 適合判定
+    /// 3. 適合時のみ `step_outputs` / `workflow_variables` を更新し、
+    ///    `OutputSubmitted` event を append
+    /// 4. 不適合・stale step・不在 step・契約タイプ不一致は副作用なしで `Err` を返し、
+    ///    `step_outputs` / `workflow_variables` / event log を一切変更しない。
+    async fn handle_submit_output<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        run_id: &str,
+        step_name: String,
+        contract: String,
+        structured_output: serde_json::Value,
+        request_id: Option<String>,
+        submitted_at: Option<f64>,
+    ) -> Result<(), WorkflowEngineError> {
+        uuid::Uuid::parse_str(run_id).map_err(|_| {
+            WorkflowEngineError::ValidationError("run_id must be UUID".to_string())
+        })?;
+        if step_name.trim().is_empty() {
+            return Err(WorkflowEngineError::ValidationError(
+                "step_name must not be empty".to_string(),
+            ));
+        }
+        if contract.trim().is_empty() {
+            return Err(WorkflowEngineError::ValidationError(
+                "contract must not be empty".to_string(),
+            ));
+        }
+
+        // 1. run / step の妥当性検証（read-only lock スコープ）。
+        let (workflow_name, run_index, expected_contract) = {
+            let execs = self.executions.lock().await;
+            let exec = execs
+                .get(run_id)
+                .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(run_id.to_string()))?;
+            match exec.state {
+                WorkflowExecutionState::Running | WorkflowExecutionState::WaitingApproval => {}
+                _ => {
+                    return Err(WorkflowEngineError::InvalidState(format!(
+                        "run {run_id} is not accepting structured output (state: {})",
+                        exec.state.as_str()
+                    )));
+                }
+            }
+            let expected_contract = lookup_step_output_contract(&exec.workflow, &step_name)
+                .ok_or_else(|| {
+                    WorkflowEngineError::ValidationError(format!(
+                        "step '{step_name}' is not a valid submission target"
+                    ))
+                })?;
+            if expected_contract != contract {
+                return Err(WorkflowEngineError::ValidationError(format!(
+                    "contract mismatch: step '{step_name}' expects '{expected_contract}', got '{contract}'"
+                )));
+            }
+            let run_index = exec
+                .step_execution_counts
+                .get(&step_name)
+                .copied()
+                .unwrap_or(0);
+            (exec.workflow.name.clone(), run_index, expected_contract)
+        };
+        // 2. contract 適合判定（pure validator、副作用なし）。
+        let validated_output = match validate_contract_value(&contract, structured_output) {
+            ContractValidationResult::Valid {
+                structured_output, ..
+            } => structured_output,
+            ContractValidationResult::Invalid(violation) => {
+                return Err(WorkflowEngineError::ValidationError(format!(
+                    "contract validation failed ({}): {}",
+                    violation.reason, violation.details
+                )));
+            }
+        };
+        debug_assert_eq!(expected_contract, contract);
+
+        // 3. state mutation（writer lock スコープ）。step_outputs と workflow_variables
+        //    を 1 度のロックで揃って更新する。
+        let timestamp = current_timestamp();
+        let contract_vars = Self::extract_contract_variables(
+            &Some(contract.clone()),
+            &Some(validated_output.clone()),
+        );
+        {
+            let mut execs = self.executions.lock().await;
+            let exec = execs
+                .get_mut(run_id)
+                .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(run_id.to_string()))?;
+            exec.step_outputs.insert(
+                step_name.clone(),
+                StepOutput {
+                    step_name: step_name.clone(),
+                    run_index,
+                    session_id: None,
+                    result: None,
+                    structured_output: Some(validated_output.clone()),
+                    output_contract: Some(contract.clone()),
+                    token_usage: None,
+                    completed_at: timestamp,
+                },
+            );
+            if !contract_vars.is_empty() {
+                exec.workflow_variables.extend(contract_vars);
+            }
+        }
+
+        // 4. OutputSubmitted event を append。append 失敗時は state を rollback せず、
+        //    storage 異常として SessionStore エラーで伝播する（spec [08] 状態 Owner:
+        //    event log は engine 経由のみ）。
+        let event = WorkflowEvent::OutputSubmitted {
+            run_id: run_id.to_string(),
+            workflow_name,
+            node_name: step_name,
+            contract,
+            structured_output: validated_output,
+            request_id,
+            submitted_at,
+            timestamp,
+        };
+        self.write_log_required(app, event)
+            .map_err(WorkflowEngineError::SessionStore)?;
+
+        Ok(())
+    }
+
     pub(crate) async fn append_command_commit_context<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
@@ -2085,6 +2267,28 @@ impl WorkflowEngine {
                     Some(reason),
                     node_name.as_deref(),
                     commit_context,
+                )
+                .await?;
+                Ok(WorkflowCommandResult::Accepted)
+            }
+            // [08] step に対する構造化出力の typed 提出。CLI / Tauri command / in-process
+            // caller が組み立てた外部入口の単一合流点。in-process 経路 (commit_context = None)
+            // と CLI pending 経路 (dispatcher が `dispatch_submit_output_with_context`
+            // 直接呼び出し) の双方が同一 handler を経由する。
+            WorkflowCommand::SubmitOutput {
+                run_id,
+                step_name,
+                contract,
+                structured_output,
+            } => {
+                self.handle_submit_output(
+                    app,
+                    &run_id,
+                    step_name,
+                    contract,
+                    structured_output,
+                    None,
+                    None,
                 )
                 .await?;
                 Ok(WorkflowCommandResult::Accepted)
@@ -6901,7 +7105,8 @@ impl WorkflowEngine {
             | WorkflowEvent::ParallelChildCompleted { timestamp, .. }
             | WorkflowEvent::ParallelCompleted { timestamp, .. }
             | WorkflowEvent::ContractRepairRequested { timestamp, .. }
-            | WorkflowEvent::CliMutationRequested { timestamp, .. } => *timestamp,
+            | WorkflowEvent::CliMutationRequested { timestamp, .. }
+            | WorkflowEvent::OutputSubmitted { timestamp, .. } => *timestamp,
         }
     }
 
@@ -6922,7 +7127,8 @@ impl WorkflowEngine {
             | WorkflowEvent::ParallelChildCompleted { timestamp, .. }
             | WorkflowEvent::ParallelCompleted { timestamp, .. }
             | WorkflowEvent::ContractRepairRequested { timestamp, .. }
-            | WorkflowEvent::CliMutationRequested { timestamp, .. } => {
+            | WorkflowEvent::CliMutationRequested { timestamp, .. }
+            | WorkflowEvent::OutputSubmitted { timestamp, .. } => {
                 *timestamp = commit_timestamp;
             }
         }

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -19,7 +19,10 @@ use crate::workflow::command_input::{
     CommandInputError,
 };
 use crate::workflow::contract::{validate_contract_value, ContractValidationResult};
-use crate::workflow::event::{ApprovalDecisionRecord, CollectedOutputEntry, WorkflowEvent};
+use crate::workflow::event::{
+    ApprovalDecisionRecord, CliMutationRejectionReason, CliMutationRequestRecord,
+    CollectedOutputEntry, WorkflowEvent,
+};
 use crate::workflow::event_projection::reconstruct_state_from_events;
 use crate::workflow::log::WorkflowEventLog;
 use crate::workflow::resolver::{
@@ -125,7 +128,7 @@ impl<'a, R: tauri::Runtime> SessionStartGate for RealSessionStartGate<'a, R> {
 /// - ステップ用 ChatSession の生成（設定解決を含む）
 /// - AgentSession 起動 (`start_agent_session_internal` 相当)
 /// - ワークフロー状態の永続化／ブロードキャスト
-/// - ステップセッションへのターン起動 (`start_agent_turn_internal` 相当)
+/// - ステップセッションへのターン起動 (`start_agent_turn_internal_locked` 相当)
 ///
 /// production では `AppHandle` / `SessionStore` / `AgentProcessMap` を握る
 /// `RealStepSessionDeps` を渡し、テストでは記録用のテストダブルを差し替えることで、
@@ -463,8 +466,6 @@ struct WorkflowExecution {
     parallel_run: Option<ParallelRunState>,
     /// ワークフローレベルの変数（spec-file-path等のcontract結果から設定）。
     workflow_variables: HashMap<String, String>,
-    /// 現在のステップでのcontractリトライ回数。
-    contract_retry_count: u32,
 }
 
 /// 並列実行中の内部状態。
@@ -486,10 +487,6 @@ struct ParallelChildRun {
     output_contract: Option<String>,
     token_usage: TokenUsage,
     run_index: u32,
-    /// [08] prose 抽出経路の廃止により本 field は事実上常に 0 で推移する。
-    /// 既存 NDJSON 互換と struct shape 維持のため field 自体は残す。
-    #[allow(dead_code)]
-    contract_retry_count: u32,
 }
 
 /// 並列子ステップの状態。
@@ -698,7 +695,7 @@ impl WorkflowExecution {
     /// spec issues-1023: 中断された通常 step の `step_history` entry を作る。
     ///
     /// 既存 `make_step_history_entry` の副作用（`current_session_id` reset /
-    /// `contract_retry_count` reset）を**起こさない**点が違い。`abort_workflow_by_run_id`
+    /// step_outputs の前段クリーンアップ等）を**起こさない**点が違い。`abort_workflow_by_run_id`
     /// は post-commit で interrupt_agent や cleanup を行うため、reset 系は
     /// `finalize_terminal_transition_after_required_append` 経路に任せる。
     ///
@@ -828,7 +825,6 @@ impl WorkflowExecution {
             state: crate::workflow::state::default_step_entry_state(),
         };
         self.current_session_id = None;
-        self.contract_retry_count = 0;
         entry
     }
 
@@ -992,26 +988,6 @@ struct ReduceResult {
     structured_output: Option<serde_json::Value>,
 }
 
-/// Contract検証の結果（呼び出し元の次アクションを示す）
-/// [08] prose 抽出経路の廃止により本 enum は事実上 `NoContract` 単一となったが、
-/// `validate_*_contract` の戻り値 shape を保持し、呼び出し側の `match` 構造を
-/// 変えずにスタブ化するために `Valid` / `RetrySent` / `Failed` を残す（将来の
-/// 「engine 内 contract 副作用」を再導入する余地としても保持）。
-#[allow(dead_code)]
-enum ContractCheckResult {
-    /// contractなし → 通常フローで続行
-    NoContract,
-    /// 検証成功
-    Valid {
-        structured_output: serde_json::Value,
-        result: Option<String>,
-    },
-    /// repair prompt送信済み → 呼び出し元はreturn Ok(())
-    RetrySent,
-    /// workflow Failed化済み → 呼び出し元はreturn Ok(())
-    Failed,
-}
-
 /// ステップ設定解決の結果。
 /// ステップのmodel/permission指定と親セッション設定のマージ結果を保持する。
 #[derive(Debug, Clone, PartialEq)]
@@ -1119,31 +1095,9 @@ fn find_any_by_worktree<'a>(
     execs.values().find(|e| e.worktree_path == worktree_path)
 }
 
-/// [08] workflow definition から `step_name` の `output_contract` を解決する。
-///
-/// top-level node / parallel child の両方を探索し、`output_contract` が空文字 /
-/// 未設定の step は「提出対象として妥当でない」として `None` を返す。
-fn lookup_step_output_contract(workflow: &Workflow, step_name: &str) -> Option<String> {
-    for node in &workflow.nodes {
-        if node.name == step_name {
-            return node
-                .output_contract
-                .clone()
-                .filter(|c| !c.trim().is_empty());
-        }
-        if let Some(children) = &node.parallel_children {
-            for child in children {
-                if child.name == step_name {
-                    return child
-                        .output_contract
-                        .clone()
-                        .filter(|c| !c.trim().is_empty());
-                }
-            }
-        }
-    }
-    None
-}
+// [08] `lookup_step_output_contract` は `workflow::contract` に移動済み。
+// engine と CLI の双方が `crate::workflow::contract::lookup_step_output_contract`
+// を直接参照するため、本モジュールではメモのみ残す。
 
 impl WorkflowEngine {
     pub(crate) fn new(
@@ -1230,7 +1184,6 @@ impl WorkflowEngine {
                 task: None,
                 parallel_run: None,
                 workflow_variables: HashMap::new(),
-                contract_retry_count: 0,
             },
         );
     }
@@ -1239,6 +1192,14 @@ impl WorkflowEngine {
     pub(crate) fn fail_next_required_event_append_for_test(&self) {
         self.fail_next_required_event_append
             .store(true, Ordering::Release);
+    }
+
+    /// テスト専用: 指定 run の `current_step_index` を移動させて stale 状態を作る。
+    #[cfg(test)]
+    pub(crate) async fn force_current_step_index_for_test(&self, run_id: &str, index: usize) {
+        if let Some(exec) = self.executions.lock().await.get_mut(run_id) {
+            exec.current_step_index = index;
+        }
     }
 
     /// Run Store の参照（テスト専用）。production 経路では下記 facade メソッドを使用する。
@@ -1311,7 +1272,6 @@ impl WorkflowEngine {
             parallel_run: None,
             workflow_variables: HashMap::new(),
             worktree_path: worktree_path.clone(),
-            contract_retry_count: 0,
         };
 
         let step_name = workflow.nodes[0].name.clone();
@@ -1799,33 +1759,33 @@ impl WorkflowEngine {
             .await
     }
 
-    /// [08] CLI pending command 経由で `SubmitOutput` を engine に取り次ぐ entry。
-    ///
-    /// in-process 経路 (`dispatch_external` の `SubmitOutput` match arm) と同じ
-    /// `handle_submit_output` に合流するが、CLI 経由では caller の `request_id`
-    /// （pending entry id）と `submitted_at`（CLI 側 timestamp）を `OutputSubmitted`
-    /// event に保存する（spec [08] アーキテクチャ概要 / 状態 Owner）。
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn dispatch_submit_output_with_context<R: tauri::Runtime>(
+    /// [08] 指定 run の event log 内に同じ `request_id` を持つ OutputSubmitted が既に
+    /// append されているかを判定する idempotency 用 helper。CLI pending command の
+    /// 再処理時に重複 OutputSubmitted を作らないように、dispatch 入口側で短絡する。
+    pub(crate) fn output_submitted_already_recorded<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
         run_id: &str,
-        step_name: String,
-        contract: String,
-        structured_output: serde_json::Value,
-        request_id: Option<String>,
-        submitted_at: Option<f64>,
-    ) -> Result<(), WorkflowEngineError> {
-        self.handle_submit_output(
-            app,
-            run_id,
-            step_name,
-            contract,
-            structured_output,
-            request_id,
-            submitted_at,
-        )
-        .await
+        request_id: &str,
+    ) -> Result<bool, WorkflowEngineError> {
+        uuid::Uuid::parse_str(run_id).map_err(|_| {
+            WorkflowEngineError::ValidationError("SubmitOutput run_id must be UUID".to_string())
+        })?;
+        uuid::Uuid::parse_str(request_id).map_err(|_| {
+            WorkflowEngineError::ValidationError("SubmitOutput request_id must be UUID".to_string())
+        })?;
+        let data_dir =
+            crate::session::resolve_data_dir(app).map_err(WorkflowEngineError::SessionStore)?;
+        let log = WorkflowEventLog::new(&data_dir);
+        let events = log
+            .read_log(run_id)
+            .map_err(WorkflowEngineError::SessionStore)?;
+        Ok(events.iter().any(|e| {
+            matches!(
+                e,
+                WorkflowEvent::OutputSubmitted { request_id: Some(rid), .. } if rid == request_id
+            )
+        }))
     }
 
     /// [08] step に対する構造化出力提出の単一トランザクション handler。
@@ -1860,42 +1820,19 @@ impl WorkflowEngine {
             ));
         }
 
-        // 1. run / step の妥当性検証（read-only lock スコープ）。
-        let (workflow_name, run_index, expected_contract) = {
-            let execs = self.executions.lock().await;
-            let exec = execs
-                .get(run_id)
-                .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(run_id.to_string()))?;
-            match exec.state {
-                WorkflowExecutionState::Running | WorkflowExecutionState::WaitingApproval => {}
-                _ => {
-                    return Err(WorkflowEngineError::InvalidState(format!(
-                        "run {run_id} is not accepting structured output (state: {})",
-                        exec.state.as_str()
-                    )));
-                }
-            }
-            let expected_contract = lookup_step_output_contract(&exec.workflow, &step_name)
-                .ok_or_else(|| {
-                    WorkflowEngineError::ValidationError(format!(
-                        "step '{step_name}' is not a valid submission target"
-                    ))
-                })?;
-            if expected_contract != contract {
-                return Err(WorkflowEngineError::ValidationError(format!(
-                    "contract mismatch: step '{step_name}' expects '{expected_contract}', got '{contract}'"
-                )));
-            }
-            let run_index = exec
-                .step_execution_counts
-                .get(&step_name)
-                .copied()
-                .unwrap_or(0);
-            (exec.workflow.name.clone(), run_index, expected_contract)
-        };
-        // 2. contract 適合判定（pure validator、副作用なし）。
+        // 1. contract 適合判定（pure validator、副作用なし）。ロック取得前に行い、
+        //    無効入力は writer lock を取らずに弾く。
+        //    [08] 機密値 redaction: caller (CLI / Tauri API) 入力に approve コメントや
+        //    secret token が混入していても event log / step_outputs に生で残らないよう、
+        //    redaction 後の structured output を contract validation に通す。
+        let secrets = Self::collect_configured_secret_values(app);
+        let redacted_input = Self::mask_sensitive_structured_output_with_secrets(
+            &contract,
+            structured_output,
+            &secrets,
+        );
         let (validated_output, validated_result) =
-            match validate_contract_value(&contract, structured_output) {
+            match validate_contract_value(&contract, redacted_input) {
                 ContractValidationResult::Valid {
                     structured_output,
                     result,
@@ -1907,20 +1844,56 @@ impl WorkflowEngine {
                     )));
                 }
             };
-        debug_assert_eq!(expected_contract, contract);
 
-        // 3. state mutation（writer lock スコープ）。step_outputs と workflow_variables
-        //    を 1 度のロックで揃って更新する。
-        let timestamp = current_timestamp();
+        // 2. writer lock 取得後に state / contract / accepting target / run_index を
+        //    再検証し、snapshot 採取と mutation を同一 lock スコープで行う
+        //    （spec [08] 境界: OutputSubmitted の append は適合判定および state 更新と
+        //    同一トランザクション境界内。並行 dispatch によって stale step の output が
+        //    確定されないよう、validation と mutation のあいだに lock を手放さない）。
         let contract_vars = Self::extract_contract_variables(
             &Some(contract.clone()),
             &Some(validated_output.clone()),
         );
-        {
+        let timestamp = current_timestamp();
+        let (workflow_name, prior_step_output, prior_workflow_variables) = {
             let mut execs = self.executions.lock().await;
             let exec = execs
                 .get_mut(run_id)
                 .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(run_id.to_string()))?;
+            match exec.state {
+                WorkflowExecutionState::Running | WorkflowExecutionState::WaitingApproval => {}
+                _ => {
+                    return Err(WorkflowEngineError::InvalidState(format!(
+                        "run {run_id} is not accepting structured output (state: {})",
+                        exec.state.as_str()
+                    )));
+                }
+            }
+            let expected_contract =
+                crate::workflow::contract::lookup_step_output_contract(&exec.workflow, &step_name)
+                    .ok_or_else(|| {
+                        WorkflowEngineError::ValidationError(format!(
+                            "step '{step_name}' is not a valid submission target"
+                        ))
+                    })?;
+            if expected_contract != contract {
+                return Err(WorkflowEngineError::ValidationError(format!(
+                    "contract mismatch: step '{step_name}' expects '{expected_contract}', got '{contract}'"
+                )));
+            }
+            if !Self::is_accepting_submission_target(exec, &step_name) {
+                return Err(WorkflowEngineError::InvalidState(format!(
+                    "step '{step_name}' is not currently accepting structured output"
+                )));
+            }
+            let run_index = exec
+                .step_execution_counts
+                .get(&step_name)
+                .copied()
+                .unwrap_or(0);
+            let workflow_name = exec.workflow.name.clone();
+            let prior_step_output = exec.step_outputs.get(&step_name).cloned();
+            let prior_workflow_variables = exec.workflow_variables.clone();
             exec.step_outputs.insert(
                 step_name.clone(),
                 StepOutput {
@@ -1937,25 +1910,69 @@ impl WorkflowEngine {
             if !contract_vars.is_empty() {
                 exec.workflow_variables.extend(contract_vars);
             }
-        }
+            (workflow_name, prior_step_output, prior_workflow_variables)
+        };
 
-        // 4. OutputSubmitted event を append。append 失敗時は state を rollback せず、
-        //    storage 異常として SessionStore エラーで伝播する（spec [08] 状態 Owner:
-        //    event log は engine 経由のみ）。
+        // 3. OutputSubmitted event を append。append 失敗時は state を snapshot から
+        //    一括復元することで「validation・state 更新・event append」を原子的に揃える
+        //    （spec [08] 振る舞い定義 Rule 1: 適合しない場合 / 適合する場合いずれも
+        //    state と event log が一致する）。
         let event = WorkflowEvent::OutputSubmitted {
             run_id: run_id.to_string(),
             workflow_name,
-            node_name: step_name,
+            node_name: step_name.clone(),
             contract,
             structured_output: validated_output,
             request_id,
             submitted_at,
             timestamp,
         };
-        self.write_log_required(app, event)
-            .map_err(WorkflowEngineError::SessionStore)?;
+        if let Err(append_err) = self.write_log_required(app, event) {
+            let mut execs = self.executions.lock().await;
+            if let Some(exec) = execs.get_mut(run_id) {
+                match prior_step_output {
+                    Some(prior) => {
+                        exec.step_outputs.insert(step_name, prior);
+                    }
+                    None => {
+                        exec.step_outputs.remove(&step_name);
+                    }
+                }
+                exec.workflow_variables = prior_workflow_variables;
+            }
+            return Err(WorkflowEngineError::SessionStore(append_err));
+        }
 
         Ok(())
+    }
+
+    /// [08] step が現在「構造化出力を受け付けられる」か判定する。
+    ///
+    /// 受付対象は以下のいずれか:
+    /// - top-level の現在 step（`current_step_index`）であり、当該 step が
+    ///   parallel ではない（Running / WaitingApproval どちらでも提出可能）
+    /// - 親 step が parallel で、当該名前の parallel child が Running 状態
+    ///
+    /// 既に完了 / 失敗した step、未到達の future step、別 parallel child の名前を
+    /// 指定された場合はいずれも accepting target ではない（spec [08] 振る舞い定義
+    /// Rule 1 Scenario 3: 出力を受け付けられる状態にない step は拒否）。
+    fn is_accepting_submission_target(exec: &WorkflowExecution, step_name: &str) -> bool {
+        if exec.current_step_index >= exec.workflow.nodes.len() {
+            return false;
+        }
+        let current = &exec.workflow.nodes[exec.current_step_index];
+        if current.name == step_name && current.node_type != NodeType::Parallel {
+            return true;
+        }
+        if let Some(ref pr) = exec.parallel_run {
+            if pr.parent_step_name == current.name {
+                return pr
+                    .children
+                    .iter()
+                    .any(|c| c.step_name == step_name && c.state == ParallelChildState::Running);
+            }
+        }
+        false
     }
 
     pub(crate) async fn append_command_commit_context<R: tauri::Runtime>(
@@ -1963,9 +1980,15 @@ impl WorkflowEngine {
         app: &tauri::AppHandle<R>,
         context: CommandCommitContext,
     ) -> Result<(), WorkflowEngineError> {
-        let run_id = context.mutation().run_id().to_string();
+        // SubmitOutput 経路は CliMutationRequested を emit せず、OutputSubmitted 単体で
+        // 記録する（spec [08]）。ここでは何もせず Ok を返す。
+        let Some(mutation_ref) = context.cli_pending_mutation() else {
+            return Ok(());
+        };
+        let run_id = mutation_ref.run_id().to_string();
         let workflow_name = self.workflow_name_for_external_run(&run_id).await?;
-        let event = Self::command_commit_context_event(&workflow_name, context);
+        let event = Self::command_commit_context_event(&workflow_name, context)
+            .expect("CliPending context must produce a CliMutationRequested event");
         self.write_log_required(app, event)
             .map_err(WorkflowEngineError::SessionStore)?;
         Ok(())
@@ -1974,17 +1997,17 @@ impl WorkflowEngine {
     fn command_commit_context_event(
         workflow_name: &str,
         context: CommandCommitContext,
-    ) -> WorkflowEvent {
-        let (run_id, request, requested_at, request_id) =
-            context.into_mutation().into_event_parts();
-        WorkflowEvent::CliMutationRequested {
+    ) -> Option<WorkflowEvent> {
+        let mutation = context.into_cli_pending_mutation()?;
+        let (run_id, request, requested_at, request_id) = mutation.into_event_parts();
+        Some(WorkflowEvent::CliMutationRequested {
             run_id,
             workflow_name: workflow_name.to_string(),
             request_id,
             request,
             requested_at,
             timestamp: current_timestamp(),
-        }
+        })
     }
 
     pub(crate) async fn workflow_name_for_external_run(
@@ -2011,6 +2034,135 @@ impl WorkflowEngine {
                 | WorkflowEngineError::UnauthorizedApprovalTarget(_)
                 | WorkflowEngineError::UnauthorizedWorktree(_)
         )
+    }
+
+    /// 5-3 / 5-4 修正: engine が拒否した CLI mutation の `WorkflowEngineError` を
+    /// `CliMutationRejectionReason` に分類する。observability 用途のため詳細は
+    /// `CliMutationRejected.message` で人間可読に保ち、ここでは粗粒度の分類に
+    /// 留める。
+    pub(crate) fn classify_rejection_reason(
+        error: &WorkflowEngineError,
+    ) -> CliMutationRejectionReason {
+        use CliMutationRejectionReason::*;
+        match error {
+            WorkflowEngineError::ExecutionNotFound(_) => RunNotFound,
+            WorkflowEngineError::UnauthorizedApprovalTarget(_) => NotWaitingApproval,
+            WorkflowEngineError::UnauthorizedWorktree(_) => Other,
+            WorkflowEngineError::ValidationError(msg) => {
+                if msg.contains("contract mismatch") {
+                    ContractMismatch
+                } else if msg.contains("is not a valid submission target") {
+                    NodeNotFound
+                } else {
+                    Other
+                }
+            }
+            WorkflowEngineError::InvalidState(msg) => {
+                if msg.contains("does not allow reject") {
+                    NoRejectRule
+                } else if msg.contains("is not currently accepting structured output") {
+                    StepNotAccepting
+                } else if msg.contains("is already terminal")
+                    || msg.contains("is not accepting structured output (state:")
+                {
+                    RunNotActive
+                } else {
+                    Other
+                }
+            }
+            // 以下は retryable / 内部 I/O 経路で本来は到達しない（呼び出し側で
+            // `should_commit_rejected_external_request` で弾く）。安全側で Other。
+            _ => Other,
+        }
+    }
+
+    /// 5-3 / 5-4 修正: engine が拒否した CLI mutation を `CliMutationRejected`
+    /// event として補助履歴に追記する。
+    ///
+    /// 失敗時は呼び出し側に `WorkflowEngineError` として伝播し、dispatcher 側で
+    /// retryable / final を分類する。本 event は spec [08] Rule 1 の意味
+    /// （accepted のメイン履歴に出さない）を壊さない補助履歴である点に注意。
+    pub(crate) async fn append_cli_mutation_rejected<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        context: &CommandCommitContext,
+        error: &WorkflowEngineError,
+    ) -> Result<(), WorkflowEngineError> {
+        let run_id = match context {
+            CommandCommitContext::CliPending { mutation } => mutation.run_id().to_string(),
+            CommandCommitContext::SubmitOutput { .. } => {
+                // SubmitOutput 経路の run_id は dispatcher 側が pending command から
+                // 取り出しているが、commit_context には保持していない。run_id
+                // 解決は engine 側の `workflow_name_for_external_run` でも引けず、
+                // SubmitOutput では呼び出し元（dispatcher）から別途渡してもらう
+                // 設計にする。本メソッドは CliPending を直接扱うバリアントに限定
+                // し、SubmitOutput 経路は専用 helper `append_cli_mutation_rejected_for_submit_output`
+                // を使う。
+                return Err(WorkflowEngineError::InvalidState(
+                    "append_cli_mutation_rejected requires CliPending context".to_string(),
+                ));
+            }
+        };
+        let workflow_name = self.workflow_name_for_external_run(&run_id).await?;
+        let (request, requested_at, request_id) = match context {
+            CommandCommitContext::CliPending { mutation } => {
+                let (_, request, requested_at, request_id) = mutation.clone().into_event_parts();
+                (request, requested_at, request_id)
+            }
+            CommandCommitContext::SubmitOutput { .. } => unreachable!(),
+        };
+        let event = WorkflowEvent::CliMutationRejected {
+            run_id,
+            workflow_name,
+            request_id,
+            request,
+            reason: Self::classify_rejection_reason(error),
+            message: error.to_string(),
+            requested_at,
+            timestamp: current_timestamp(),
+        };
+        self.write_log_required(app, event)
+            .map_err(WorkflowEngineError::SessionStore)?;
+        Ok(())
+    }
+
+    /// 5-3 修正: SubmitOutput 経路用の `CliMutationRejected` append。
+    ///
+    /// SubmitOutput の commit_context は `WorkflowMutationContext` を持たないため、
+    /// `run_id` は dispatcher 側から渡してもらう。spec [08] Rule 1 維持のため
+    /// `CliMutationRequested` は引き続き emit せず、本 event のみが補助履歴と
+    /// して残る。
+    pub(crate) async fn append_cli_mutation_rejected_for_submit_output<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        run_id: &str,
+        context: &CommandCommitContext,
+        error: &WorkflowEngineError,
+    ) -> Result<(), WorkflowEngineError> {
+        let (request_id, requested_at, step_name, contract) =
+            context.submit_output_rejection_parts().ok_or_else(|| {
+                WorkflowEngineError::InvalidState(
+                    "append_cli_mutation_rejected_for_submit_output requires SubmitOutput context"
+                        .to_string(),
+                )
+            })?;
+        let workflow_name = self.workflow_name_for_external_run(run_id).await?;
+        let event = WorkflowEvent::CliMutationRejected {
+            run_id: run_id.to_string(),
+            workflow_name,
+            request_id,
+            request: CliMutationRequestRecord::SubmitOutput {
+                step_name,
+                contract,
+            },
+            reason: Self::classify_rejection_reason(error),
+            message: error.to_string(),
+            requested_at,
+            timestamp: current_timestamp(),
+        };
+        self.write_log_required(app, event)
+            .map_err(WorkflowEngineError::SessionStore)?;
+        Ok(())
     }
 
     pub(crate) fn cli_mutation_already_recorded<R: tauri::Runtime>(
@@ -2132,7 +2284,6 @@ impl WorkflowEngine {
             task: run.task,
             parallel_run: None,
             workflow_variables: state.workflow_variables,
-            contract_retry_count: 0,
         };
 
         let _ = session_store; // session_store は parent session 撤去後の本経路では未使用
@@ -2278,23 +2429,29 @@ impl WorkflowEngine {
                 Ok(WorkflowCommandResult::Accepted)
             }
             // [08] step に対する構造化出力の typed 提出。CLI / Tauri command / in-process
-            // caller が組み立てた外部入口の単一合流点。in-process 経路 (commit_context = None)
-            // と CLI pending 経路 (dispatcher が `dispatch_submit_output_with_context`
-            // 直接呼び出し) の双方が同一 handler を経由する。
+            // caller の双方が `dispatch_external` を経由して同一 handler に合流する。
+            // CLI pending 経路では commit_context が `SubmitOutput { request_id,
+            // submitted_at }` を運び、OutputSubmitted event に保存する。in-process 経路
+            // では commit_context = None で metadata は None になる。
             WorkflowCommand::SubmitOutput {
                 run_id,
                 step_name,
                 contract,
                 structured_output,
             } => {
+                let (request_id, submitted_at) = commit_context
+                    .as_ref()
+                    .and_then(|ctx| ctx.submit_output_metadata())
+                    .map(|(rid, ts)| (Some(rid), Some(ts)))
+                    .unwrap_or((None, None));
                 self.handle_submit_output(
                     app,
                     &run_id,
                     step_name,
                     contract,
                     structured_output,
-                    None,
-                    None,
+                    request_id,
+                    submitted_at,
                 )
                 .await?;
                 Ok(WorkflowCommandResult::Accepted)
@@ -2940,28 +3097,14 @@ impl WorkflowEngine {
             ApprovalDecision::Reject { .. } => ("reject", ApprovalDecisionRecord::Reject),
         };
 
-        // target検証 + session_id + output_contract + workflow + worktree_path を1回のロックで取得
-        let (
-            current_session_id,
-            output_contract,
-            workflow_for_contract,
-            current_step_index_for_contract,
-            worktree_path,
-        ) = {
+        // target検証 + session_id + worktree_path を1回のロックで取得
+        let (current_session_id, worktree_path) = {
             let execs = self.executions.lock().await;
             let exec = execs
                 .get(run_id)
                 .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(run_id.to_string()))?;
             Self::resolve_approval_target_snapshot(exec, Some(run_id), expected_step_name)?;
-            (
-                exec.current_session_id.clone(),
-                exec.workflow.nodes[exec.current_step_index]
-                    .output_contract
-                    .clone(),
-                exec.workflow.clone(),
-                exec.current_step_index,
-                exec.worktree_path.clone(),
-            )
+            (exec.current_session_id.clone(), exec.worktree_path.clone())
         };
 
         // Reject時: 空コメントバリデーション + Approve/Reject 共通の長さ上限検証
@@ -2981,47 +3124,26 @@ impl WorkflowEngine {
             Self::validate_approval_turn_phase(turn_phase)?;
         }
 
-        // ロック外でoutput_textを事前取得（approvalはAgentSession完了後なので取得可能）。
-        // Approve時だけAgentSession出力が必要。Rejectは理由をoutput_textとして使う。
-        let output_text = match &decision {
-            ApprovalDecision::Approve => {
-                self.fetch_current_output(app, session_store, &worktree_path)
-                    .await?
-            }
-            ApprovalDecision::Reject { ref comment } => Some(comment.clone()),
-        };
+        // [08] prose 抽出経路廃止に伴い、approval node の structured output は CLI / Tauri
+        // 経由の `SubmitOutput` でしか確定しない。Approve 時に agent 自由文を構造化
+        // 出力に昇格させない（spec [08] Rule 4: 構造化出力の確定経路は明示的提出のみ）。
+        // Reject は理由を redaction 済み JSON に整形し、application 入力に渡す。
+        let (structured_output, contract_result): (Option<serde_json::Value>, Option<String>) =
+            match &decision {
+                ApprovalDecision::Approve => (None, None),
+                ApprovalDecision::Reject { comment } => {
+                    let secrets = Self::collect_configured_secret_values(app);
+                    (
+                        Some(Self::reject_structured_output(comment, &secrets)),
+                        None,
+                    )
+                }
+            };
 
-        // contract検証（Approve時のみ）。approvalではrepair/failに進めず、状態を変えずに
-        // validation_errorとして返す。
-        let (structured_output, contract_result) = match &decision {
-            ApprovalDecision::Approve => match Self::validate_approval_output_contract(
-                app,
-                &output_contract,
-                output_text.as_deref(),
-                &workflow_for_contract,
-                current_step_index_for_contract,
-            )? {
-                ContractCheckResult::NoContract => (None, None),
-                ContractCheckResult::Valid {
-                    structured_output,
-                    result,
-                } => (Some(structured_output), result),
-                ContractCheckResult::RetrySent | ContractCheckResult::Failed => unreachable!(),
-            },
-            ApprovalDecision::Reject { comment } => {
-                let secrets = Self::collect_configured_secret_values(app);
-                (
-                    Some(Self::reject_structured_output(comment, &secrets)),
-                    None,
-                )
-            }
-        };
-
-        let application_output_contract = if matches!(decision, ApprovalDecision::Approve) {
-            output_contract.clone()
-        } else {
-            None
-        };
+        // SubmitOutput で確定する output_contract は application_output_contract に
+        // 直接持ち込まない（CLI 経由でのみ確定する境界）。Approve / Reject いずれも
+        // application 入力上は contract 名を持たせない。
+        let application_output_contract: Option<String> = None;
         let contract_variables =
             Self::extract_contract_variables(&application_output_contract, &structured_output);
 
@@ -3107,10 +3229,11 @@ impl WorkflowEngine {
                 }
             };
         if let Some(context) = commit_context {
-            commit_events.push(Self::command_commit_context_event(
-                &workflow_name_for_event,
-                context,
-            ));
+            if let Some(event) =
+                Self::command_commit_context_event(&workflow_name_for_event, context)
+            {
+                commit_events.push(event);
+            }
         }
         self.commit_required_events(
             app,
@@ -3267,10 +3390,11 @@ impl WorkflowEngine {
         };
         let mut required_events = vec![aborted_event];
         if let Some(context) = commit_context {
-            required_events.push(Self::command_commit_context_event(
-                &workflow_name_for_event,
-                context,
-            ));
+            if let Some(event) =
+                Self::command_commit_context_event(&workflow_name_for_event, context)
+            {
+                required_events.push(event);
+            }
         }
         self.commit_required_events(
             app,
@@ -3377,55 +3501,14 @@ impl WorkflowEngine {
         final_parts: &[crate::session::MessagePart],
         token_usage: Option<(u64, u64)>,
     ) -> Result<(), WorkflowEngineError> {
-        // 子ステップのoutput_textを取得
-        let output_text = {
-            let text = Self::extract_text_from_parts(final_parts);
-            if text.is_empty() {
-                None
-            } else {
-                Some(text)
-            }
-        };
-
-        // 子ステップのoutput_contractを取得し、contract検証を実行（ロック外）
-        let child_output_contract = {
-            let execs = self.executions.lock().await;
-            let exec = execs
-                .get(run_id)
-                .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(run_id.to_string()))?;
-            let step = &exec.workflow.nodes[exec.current_step_index];
-            step.parallel_children.as_ref().and_then(|children| {
-                let pr = exec.parallel_run.as_ref()?;
-                let child_run = pr.children.iter().find(|c| c.session_id == session_id)?;
-                children
-                    .iter()
-                    .find(|c| c.name == child_run.step_name)
-                    .and_then(|c| c.output_contract.clone())
-            })
-        };
-
         // [08] parallel child の構造化出力は CLI / Tauri 経由の `SubmitOutput` で確定する。
         // 旧来の「agent 自由文から `<workflow_output>` を抽出して step output を確定する」
         // 経路は廃止された（spec [08] Rule 4 構造化出力の確定経路は明示的提出のみ）。
-        // child 完了時点では `child_structured_output = None` のまま進行し、後続 step
-        // からは未提出として扱われる。
-        let _ = (session_id, session_store, handles); // 旧 contract retry 経路用引数の参照を維持
-        let (child_result, child_structured_output): (Option<String>, Option<serde_json::Value>) =
-            if exit_code == 0 {
-                let _ = child_output_contract.as_ref();
-                let _ = output_text.as_deref();
-                (None, None)
-            } else {
-                (None, None)
-            };
-
-        // contract検証成功時のworkflow_variables反映
-        self.apply_contract_variables_for_run(
-            run_id,
-            &child_output_contract,
-            &child_structured_output,
-        )
-        .await;
+        // child 完了時点では agent 自由文を観測せず、後続 step は SubmitOutput で
+        // 確定済みの output（projection で merge 済み）を経路非依存に参照する。
+        let _ = final_parts;
+        let child_result: Option<String> = None;
+        let child_structured_output: Option<serde_json::Value> = None;
 
         // ロック内: 子ステップの状態更新 + 全完了チェック
         let (all_completed, outcome_opt, exec_snapshot_before) = {
@@ -3533,24 +3616,9 @@ impl WorkflowEngine {
             let child_token_usage = child.token_usage.clone();
             let child_run_index = child.run_index;
 
-            // output_contractがあるstepのみStepOutputを生成する（Spec準拠）
-            let log_result = child_result.clone();
-            let log_structured_output = child_structured_output.clone();
-            if child_structured_output.is_some() {
-                exec.step_outputs.insert(
-                    child_name.clone(),
-                    StepOutput {
-                        step_name: child_name.clone(),
-                        run_index: child_run_index,
-                        session_id: Some(session_id.to_string()),
-                        result: child_result,
-                        structured_output: child_structured_output,
-                        output_contract: child_output_contract,
-                        token_usage: Some(child_token_usage.clone()),
-                        completed_at: current_timestamp(),
-                    },
-                );
-            }
+            // [08] child の StepOutput は CLI / Tauri 経由の SubmitOutput でのみ確定する。
+            // ここでは step_outputs slot に触れず、SubmitOutput 済みの値を保持したまま
+            // 親 ParallelChildCompleted の事実だけを event log に積む。
 
             // ParallelStepCompleted ログ
             self.write_log(
@@ -3560,10 +3628,10 @@ impl WorkflowEngine {
                     workflow_name: exec.workflow.name.clone(),
                     parent_node_name: pr.parent_step_name.clone(),
                     child_node_name: child_name,
-                    result: log_result,
+                    result: child_result.clone(),
                     session_id: session_id.to_string(),
-                    token_usage: Some(child_token_usage),
-                    structured_output: log_structured_output,
+                    token_usage: Some(child_token_usage.clone()),
+                    structured_output: child_structured_output.clone(),
                     run_index: child_run_index,
                     timestamp: current_timestamp(),
                 },
@@ -3817,39 +3885,6 @@ impl WorkflowEngine {
         } else {
             true
         }
-    }
-
-    /// [08] approval node の構造化出力は CLI / Tauri 経由の `SubmitOutput` で確定する。
-    /// engine 側で自由文から `<workflow_output>` を抽出する経路は廃止された
-    /// （spec [08] Rule 4）。`output_contract` の有無に依らず常に `NoContract` を返し、
-    /// 後続経路では `structured_output = None` として進行する。
-    fn validate_approval_output_contract<R: tauri::Runtime>(
-        _app: &tauri::AppHandle<R>,
-        _output_contract: &Option<String>,
-        _output_text: Option<&str>,
-        _workflow: &Workflow,
-        _current_step_index: usize,
-    ) -> Result<ContractCheckResult, WorkflowEngineError> {
-        Ok(ContractCheckResult::NoContract)
-    }
-
-    /// [08] agent step の構造化出力は CLI / Tauri 経由の `SubmitOutput` で確定する。
-    /// engine 側で自由文から `<workflow_output>` を抽出する経路は廃止された
-    /// （spec [08] Rule 4）。`output_contract` の有無に依らず常に `NoContract` を返し、
-    /// 後続経路では `structured_output = None` として進行する。
-    #[allow(clippy::too_many_arguments)]
-    async fn validate_and_handle_contract<R: tauri::Runtime>(
-        &self,
-        _app: &tauri::AppHandle<R>,
-        _session_store: &Arc<SessionStore>,
-        _handles: &Arc<Mutex<AgentProcessMap>>,
-        _worktree_path: &str,
-        _output_contract: &Option<String>,
-        _output_text: Option<&str>,
-        _current_session_id: &Option<String>,
-        _step_name: &str,
-    ) -> Result<ContractCheckResult, WorkflowEngineError> {
-        Ok(ContractCheckResult::NoContract)
     }
 
     /// `run_id` を直接指定して session_workflow_refs を掃除する。
@@ -4412,40 +4447,22 @@ impl WorkflowEngine {
         // テキストパートを結合（ロック外で完了）
         let text = Self::extract_text_from_parts(final_parts);
 
-        // contract検証
-        let (output_contract, current_session_id) = {
+        // [08] prose 抽出経路廃止: agent step の structured output は CLI / Tauri 経由の
+        // `SubmitOutput` でしか確定しない。本経路では output_contract の有無に依らず
+        // 自由文を structured output に昇格させず、後続経路は `structured_output = None`
+        // で進行する（spec [08] Rule 4: 構造化出力の確定経路は明示的提出のみに統一）。
+        let output_contract = {
             let execs = self.executions.lock().await;
             let (_, exec) = find_by_worktree(&execs, worktree_path)
                 .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(worktree_path.to_string()))?;
-            let step = &exec.workflow.nodes[exec.current_step_index];
-            (
-                step.output_contract.clone(),
-                exec.current_session_id.clone(),
-            )
+            exec.workflow.nodes[exec.current_step_index]
+                .output_contract
+                .clone()
         };
+        let structured_output: Option<serde_json::Value> = None;
+        let contract_result: Option<String> = None;
 
-        let contract_check = self
-            .validate_and_handle_contract(
-                app,
-                session_store,
-                handles,
-                worktree_path,
-                &output_contract,
-                Some(&text),
-                &current_session_id,
-                step_name,
-            )
-            .await?;
-        let (structured_output, contract_result) = match contract_check {
-            ContractCheckResult::NoContract => (None, None),
-            ContractCheckResult::Valid {
-                structured_output,
-                result,
-            } => (Some(structured_output), result),
-            ContractCheckResult::RetrySent | ContractCheckResult::Failed => return Ok(()),
-        };
-
-        // contract検証成功時のworkflow_variables反映
+        // contract検証成功時のworkflow_variables反映（structured_output が None の本経路では no-op）。
         self.apply_contract_variables(worktree_path, &output_contract, &structured_output)
             .await;
 
@@ -4624,6 +4641,7 @@ impl WorkflowEngine {
         // ChatSession や参照マップ entry を残さないことを構造的に保証する。
         let (system_prompt, prompt) = Self::build_step_prompt(
             &step_clone,
+            &run_id_for_ref,
             worktree_path,
             task_clone.as_deref(),
             &step_outputs_clone,
@@ -4683,8 +4701,14 @@ impl WorkflowEngine {
 
     /// ファセット合成パイプライン: compose → 変数展開 → step output注入
     /// start_step_session の中核ロジックを純粋関数として切り出し、テスト可能にする。
+    ///
+    /// [08] `run_id` を引数で受け取り、`output_contract_preamble` が埋め込む
+    /// `{{run_id}}` / `{{step_name}}` プレースホルダを実値に展開する。これにより
+    /// agent が表示された CLI コマンドをそのまま `releash workflow output submit` 用に
+    /// 呼び出せる（spec [08] 要求: run_id と step_name を主語に CLI 提出できる）。
     pub(crate) fn build_step_prompt(
         step: &NodeDefinition,
+        run_id: &str,
         worktree_path: &str,
         task: Option<&str>,
         step_outputs: &HashMap<String, StepOutput>,
@@ -4695,6 +4719,7 @@ impl WorkflowEngine {
         if !step.has_facet_refs() {
             if let Some(ref inline) = step.inline_prompt {
                 let rendered = Self::render_facet_variables(inline, worktree_path, task);
+                let rendered = Self::render_submit_command_variables(&rendered, run_id, &step.name);
                 let prompt = Self::inject_step_outputs(
                     &rendered,
                     step,
@@ -4722,11 +4747,14 @@ impl WorkflowEngine {
             )));
         }
         let composed = crate::workflow::facet::compose_facets(step);
-        let system_prompt = composed
-            .system_prompt
-            .map(|s| Self::render_facet_variables(&s, worktree_path, task));
-        let rendered_user =
-            Self::render_facet_variables(&composed.user_message, worktree_path, task);
+        let system_prompt = composed.system_prompt.map(|s| {
+            let s = Self::render_facet_variables(&s, worktree_path, task);
+            Self::render_submit_command_variables(&s, run_id, &step.name)
+        });
+        let rendered_user = {
+            let s = Self::render_facet_variables(&composed.user_message, worktree_path, task);
+            Self::render_submit_command_variables(&s, run_id, &step.name)
+        };
         let mut prompt = Self::inject_step_outputs(
             &rendered_user,
             step,
@@ -4771,6 +4799,7 @@ impl WorkflowEngine {
     async fn build_and_dispatch_step_session<G: SessionStartGate + ?Sized>(
         gate: &G,
         step: &NodeDefinition,
+        run_id: &str,
         step_session_id: &str,
         worktree_path: &str,
         permission_mode: Option<String>,
@@ -4781,6 +4810,7 @@ impl WorkflowEngine {
     ) -> Result<String, WorkflowEngineError> {
         let (system_prompt, prompt) = Self::build_step_prompt(
             step,
+            run_id,
             worktree_path,
             task,
             step_outputs,
@@ -4815,21 +4845,6 @@ impl WorkflowEngine {
         }
     }
 
-    async fn apply_contract_variables_for_run(
-        &self,
-        run_id: &str,
-        output_contract: &Option<String>,
-        structured_output: &Option<serde_json::Value>,
-    ) {
-        let vars = Self::extract_contract_variables(output_contract, structured_output);
-        if !vars.is_empty() {
-            let mut execs = self.executions.lock().await;
-            if let Some(exec) = execs.get_mut(run_id) {
-                exec.workflow_variables.extend(vars);
-            }
-        }
-    }
-
     /// contractとstructured_outputからworkflow_variablesに設定すべきキー/値を抽出する。
     fn extract_contract_variables(
         output_contract: &Option<String>,
@@ -4846,17 +4861,6 @@ impl WorkflowEngine {
         vars
     }
 
-    #[allow(dead_code)]
-    fn mask_sensitive_structured_output<R: tauri::Runtime>(
-        app: &tauri::AppHandle<R>,
-        contract: &str,
-        value: serde_json::Value,
-    ) -> serde_json::Value {
-        let secrets = Self::collect_configured_secret_values(app);
-        Self::mask_sensitive_structured_output_with_secrets(contract, value, &secrets)
-    }
-
-    #[allow(dead_code)]
     fn mask_sensitive_structured_output_with_secrets(
         contract: &str,
         mut value: serde_json::Value,
@@ -4937,7 +4941,6 @@ impl WorkflowEngine {
         values
     }
 
-    #[allow(dead_code)]
     fn mask_json_strings(value: &mut serde_json::Value, configured_secrets: &[String]) {
         match value {
             serde_json::Value::String(s) => {
@@ -4999,38 +5002,25 @@ impl WorkflowEngine {
         }
     }
 
-    /// 現在のステップセッションからoutput_textを取得する。
-    /// handle_approval で現在ステップの出力を取得する。
-    async fn fetch_current_output<R: tauri::Runtime>(
-        &self,
-        app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
-        worktree_path: &str,
-    ) -> Result<Option<String>, WorkflowEngineError> {
-        let current_session_id = {
-            let execs = self.executions.lock().await;
-            let (_, exec) = find_by_worktree(&execs, worktree_path)
-                .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(worktree_path.to_string()))?;
-            exec.current_session_id.clone()
-        };
-        Ok(if let Some(ref sid) = current_session_id {
-            Self::extract_last_assistant_output(app, session_store, sid).await
-        } else {
-            None
-        })
+    /// [08] `releash workflow output submit` の CLI 例を実 run_id / step_name に展開する。
+    ///
+    /// `output_contract_preamble` が生成する `{{run_id}}` / `{{step_name}}` プレースホルダを
+    /// 実行時の値に置き換え、agent / 人間オペレータがそのまま CLI を呼べるようにする
+    /// （spec [08] 要求: 「run_id と step_name を主語に CLI/API 経由で engine に提出できる」）。
+    pub(crate) fn render_submit_command_variables(
+        content: &str,
+        run_id: &str,
+        step_name: &str,
+    ) -> String {
+        content
+            .replace("{{run_id}}", run_id)
+            .replace("{{step_name}}", step_name)
     }
 
-    /// セッションから最後のAgentメッセージのテキストを抽出する。
-    async fn extract_last_assistant_output<R: tauri::Runtime>(
-        app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
-        session_id: &str,
-    ) -> Option<String> {
-        let data_dir = crate::session::resolve_data_dir(app).ok()?;
-        let session = session_store.get_session(&data_dir, session_id).ok()??;
-        Self::extract_last_assistant_text_from_session(&session)
-    }
-
+    /// [08] prose 抽出経路は engine から完全除去された（spec [08] Rule 4 構造化出力の
+    /// 確定経路は明示的提出のみ）。本 helper は ChatSession 表示など event log と無関係な
+    /// 経路で「最後の Agent メッセージ本文」を取り出すテスト用 fixture としてのみ残す。
+    #[cfg(test)]
     fn extract_last_assistant_text_from_session(
         session: &crate::session::ChatSession,
     ) -> Option<String> {
@@ -6245,7 +6235,6 @@ impl WorkflowEngine {
                     output_contract: cs.output_contract.clone(),
                     token_usage: TokenUsage::default(),
                     run_index,
-                    contract_retry_count: 0,
                 })
                 .collect();
 
@@ -6649,7 +6638,8 @@ impl WorkflowEngine {
             | WorkflowEvent::ParallelCompleted { timestamp, .. }
             | WorkflowEvent::ContractRepairRequested { timestamp, .. }
             | WorkflowEvent::CliMutationRequested { timestamp, .. }
-            | WorkflowEvent::OutputSubmitted { timestamp, .. } => *timestamp,
+            | WorkflowEvent::OutputSubmitted { timestamp, .. }
+            | WorkflowEvent::CliMutationRejected { timestamp, .. } => *timestamp,
         }
     }
 
@@ -6671,7 +6661,8 @@ impl WorkflowEngine {
             | WorkflowEvent::ParallelCompleted { timestamp, .. }
             | WorkflowEvent::ContractRepairRequested { timestamp, .. }
             | WorkflowEvent::CliMutationRequested { timestamp, .. }
-            | WorkflowEvent::OutputSubmitted { timestamp, .. } => {
+            | WorkflowEvent::OutputSubmitted { timestamp, .. }
+            | WorkflowEvent::CliMutationRejected { timestamp, .. } => {
                 *timestamp = commit_timestamp;
             }
         }
@@ -6690,11 +6681,11 @@ impl WorkflowEngine {
         app: &tauri::AppHandle<R>,
         event: WorkflowEvent,
     ) -> Result<(), String> {
-        if let Ok(data_dir) = crate::session::resolve_data_dir(app) {
-            let log = WorkflowEventLog::new(&data_dir);
-            return log.append(&event);
-        }
-        Err("failed to resolve app data dir".to_string())
+        // [08] テスト fixture (`fail_next_required_event_append_for_test`) を
+        // 単発の write_log_required 経路でも観測できるよう、内部で batch helper に
+        // 委譲する。production の振る舞いは変わらず、SubmitOutput 等の rollback
+        // テストが append 失敗を再現できる。
+        self.write_log_required_batch(app, std::slice::from_ref(&event))
     }
 
     /// 複数の必須 event を 1 つの atomic commit point として一括追記する。
@@ -6757,7 +6748,6 @@ impl WorkflowEngine {
         decision: ApprovalDecision,
         expected_execution_id: Option<&str>,
         expected_step_name: Option<&str>,
-        output_text: Option<String>,
     ) -> Result<StepOutcome, WorkflowEngineError> {
         let run_id = {
             let execs = self.executions.lock().await;
@@ -6771,7 +6761,6 @@ impl WorkflowEngine {
             decision,
             expected_execution_id,
             expected_step_name,
-            output_text,
         )
         .await
     }
@@ -6817,7 +6806,6 @@ impl WorkflowEngine {
         decision: ApprovalDecision,
         expected_execution_id: Option<&str>,
         expected_step_name: Option<&str>,
-        output_text: Option<String>,
     ) -> Result<StepOutcome, WorkflowEngineError> {
         {
             let execs = self.executions.lock().await;
@@ -6836,18 +6824,14 @@ impl WorkflowEngine {
             Self::validate_approval_turn_phase(None)?;
         }
 
-        let (output_contract, workflow_for_contract, current_step_index_for_contract) = {
+        let output_contract = {
             let execs = self.executions.lock().await;
             let exec = execs
                 .get(run_id)
                 .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(run_id.to_string()))?;
-            (
-                exec.workflow.nodes[exec.current_step_index]
-                    .output_contract
-                    .clone(),
-                exec.workflow.clone(),
-                exec.current_step_index,
-            )
+            exec.workflow.nodes[exec.current_step_index]
+                .output_contract
+                .clone()
         };
 
         let result_tag = match &decision {
@@ -6858,8 +6842,6 @@ impl WorkflowEngine {
         // CLI / Tauri 経由の `SubmitOutput` で確定する（spec [08] Rule 4）。Approve 時の
         // `structured_output` は None で固定し、Reject 時のみ comment 由来の暫定 payload を
         // 維持する（既存 reject 経路は本 issue のスコープ外）。
-        let _ = (workflow_for_contract, current_step_index_for_contract);
-        let _ = output_text.as_deref();
         let (structured_output, contract_result): (Option<serde_json::Value>, Option<String>) =
             match &decision {
                 ApprovalDecision::Approve => (None, None),
@@ -6899,7 +6881,6 @@ impl WorkflowEngine {
         &self,
         worktree_path: &str,
         snapshot: &WorkflowState,
-        output_text: String,
     ) -> Result<Option<StepOutcome>, WorkflowEngineError> {
         if let Some((execution_id, step_name)) =
             Self::auto_approve_target_for_persisted_snapshot(snapshot, true)
@@ -6909,7 +6890,6 @@ impl WorkflowEngine {
                 ApprovalDecision::Approve,
                 Some(&execution_id),
                 Some(&step_name),
-                Some(output_text),
             )
             .await
             .map(Some)
@@ -6970,7 +6950,6 @@ impl WorkflowEngine {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let snapshot = exec.to_workflow_state();
         let run_id = exec.id.clone();
@@ -7019,7 +6998,6 @@ impl WorkflowEngine {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         self.run_store
             .register_active(WorkflowRun {
@@ -7438,12 +7416,6 @@ mod tests {
         CollectConfig, CycleGuard, ParallelAggregate, ReduceStrategy, TransitionRule, Workflow,
     };
 
-    fn approved_fix_policy_output(policy: &str, review_step: &str) -> String {
-        format!(
-            r#"<workflow_output type="approved-fix-policy">{{"policy":"{policy}","review_step":"{review_step}"}}</workflow_output>"#
-        )
-    }
-
     #[allow(dead_code)]
     fn make_approved_fix_policy_workflow() -> Workflow {
         Workflow {
@@ -7541,7 +7513,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         }
     }
 
@@ -7774,7 +7745,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         let state = exec.to_workflow_state();
@@ -7811,7 +7781,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         assert!(exec.is_active());
     }
@@ -7838,7 +7807,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         assert!(exec.is_active());
     }
@@ -7865,7 +7833,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         assert!(!exec.is_active());
     }
@@ -7894,7 +7861,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         assert!(!exec.is_active());
     }
@@ -7921,7 +7887,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         assert!(!exec.is_active());
     }
@@ -7951,7 +7916,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let ws = exec.to_workflow_state();
         assert_eq!(ws.state, WorkflowExecutionState::WaitingApproval);
@@ -7986,7 +7950,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let ws = exec.to_workflow_state();
         assert_eq!(
@@ -8031,7 +7994,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let ws = exec.to_workflow_state();
         assert_eq!(
@@ -8067,7 +8029,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let ws = exec.to_workflow_state();
         assert_eq!(ws.state, WorkflowExecutionState::Aborted);
@@ -8096,7 +8057,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let ws = exec.to_workflow_state();
         assert_eq!(ws.state, WorkflowExecutionState::Completed);
@@ -8194,7 +8154,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         }
     }
 
@@ -9698,6 +9657,7 @@ mod tests {
 
         let (sys, prompt) = WorkflowEngine::build_step_prompt(
             &step,
+            "00000000-0000-0000-0000-000000000000",
             "/home/user/my-app",
             Some("Fix bug"),
             &outputs,
@@ -9742,6 +9702,7 @@ mod tests {
         };
         let result = WorkflowEngine::build_step_prompt(
             &step,
+            "00000000-0000-0000-0000-000000000000",
             "/repo",
             None,
             &HashMap::new(),
@@ -9768,6 +9729,7 @@ mod tests {
 
         let (sys, prompt) = WorkflowEngine::build_step_prompt(
             &step,
+            "00000000-0000-0000-0000-000000000000",
             "/repo",
             None,
             &HashMap::new(),
@@ -9801,6 +9763,7 @@ mod tests {
 
         let (sys, _prompt) = WorkflowEngine::build_step_prompt(
             &step,
+            "00000000-0000-0000-0000-000000000000",
             "/repo",
             None,
             &HashMap::new(),
@@ -9873,6 +9836,7 @@ mod tests {
         // build_step_prompt → dispatch_session_start の経路をそのまま再現する。
         let (system_prompt, _prompt) = WorkflowEngine::build_step_prompt(
             &step,
+            "00000000-0000-0000-0000-000000000000",
             "/repo",
             None,
             &HashMap::new(),
@@ -9947,6 +9911,7 @@ mod tests {
         let prompt = WorkflowEngine::build_and_dispatch_step_session(
             &gate,
             &step,
+            "00000000-0000-0000-0000-000000000000",
             "step-session-id",
             "/repo",
             None,
@@ -9997,6 +9962,7 @@ mod tests {
 
         let (system_prompt, _prompt) = WorkflowEngine::build_step_prompt(
             &step,
+            "00000000-0000-0000-0000-000000000000",
             "/repo",
             None,
             &HashMap::new(),
@@ -10171,7 +10137,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         execs.insert(exec.id.clone(), exec);
     }
@@ -10689,7 +10654,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         }
     }
 
@@ -11233,7 +11197,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         // 4. decide
@@ -11340,7 +11303,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let structured_output = serde_json::json!({
             "policy": "Fix only the reported issues.",
@@ -11623,7 +11585,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let snapshot = exec.to_workflow_state();
         assert_eq!(
@@ -11634,46 +11595,8 @@ mod tests {
             ))
         );
 
-        let session = crate::session::ChatSession {
-            id: "policy-session".to_string(),
-            worktree_path: "/repo".to_string(),
-            messages: vec![
-                crate::session::ChatMessage {
-                    id: "m1".to_string(),
-                    role: crate::session::MessageRole::Agent,
-                    content: approved_fix_policy_output("Old policy.", "code_review_parallel"),
-                    thinking: None,
-                    activities: None,
-                    parts: None,
-                    timestamp: 1.0,
-                    mentions: None,
-                },
-                crate::session::ChatMessage {
-                    id: "m2".to_string(),
-                    role: crate::session::MessageRole::Agent,
-                    content: approved_fix_policy_output(
-                        "Fix only reviewed findings.",
-                        "code_review_parallel",
-                    ),
-                    thinking: None,
-                    activities: None,
-                    parts: None,
-                    timestamp: 2.0,
-                    mentions: None,
-                },
-            ],
-            state: crate::session::SessionState::Idle,
-            created_at: 1.0,
-            updated_at: 2.0,
-            agent_session_id: None,
-            permission_mode: "edit".to_string(),
-            selected_model: None,
-            backend_id: None,
-            workflow_step_session: false,
-        };
         // [08] prose 抽出経路は廃止済み。CLI submit 経由で確定する想定の structured_output
         // を直接組み立てて apply_approval_application の遷移挙動を検証する。
-        let _ = WorkflowEngine::extract_last_assistant_text_from_session(&session);
         let structured_output = serde_json::json!({
             "policy": "Fix only reviewed findings.",
             "review_step": "code_review_parallel",
@@ -11806,7 +11729,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let snapshot = exec.to_workflow_state();
         let run_id = exec.id.clone();
@@ -11819,14 +11741,7 @@ mod tests {
         );
 
         let outcome = engine
-            .execute_outcome_persist_auto_approve_for_test(
-                worktree_path,
-                &snapshot,
-                approved_fix_policy_output(
-                    "Fix only the approved review finding.",
-                    "code_review_parallel",
-                ),
-            )
+            .execute_outcome_persist_auto_approve_for_test(worktree_path, &snapshot)
             .await
             .unwrap()
             .unwrap();
@@ -11869,14 +11784,7 @@ mod tests {
         );
 
         let outcome = engine
-            .execute_outcome_persist_auto_approve_for_test(
-                worktree_path,
-                &snapshot,
-                approved_fix_policy_output(
-                    "Revise the spec using the approved plan policy.",
-                    "plan_review_parallel",
-                ),
-            )
+            .execute_outcome_persist_auto_approve_for_test(worktree_path, &snapshot)
             .await
             .unwrap()
             .unwrap();
@@ -11944,14 +11852,7 @@ mod tests {
             }
             auto_barrier.wait().await;
             auto_engine
-                .execute_outcome_persist_auto_approve_for_test(
-                    &auto_worktree_path,
-                    &auto_snapshot,
-                    approved_fix_policy_output(
-                        "Revise the spec from the auto approval path.",
-                        "plan_review_parallel",
-                    ),
-                )
+                .execute_outcome_persist_auto_approve_for_test(&auto_worktree_path, &auto_snapshot)
                 .await
                 .and_then(|outcome| {
                     outcome.ok_or_else(|| {
@@ -11983,10 +11884,6 @@ mod tests {
                     ApprovalDecision::Approve,
                     Some(&expected_execution_id),
                     Some(&expected_step_name),
-                    Some(approved_fix_policy_output(
-                        "Revise the spec from the manual approval path.",
-                        "plan_review_parallel",
-                    )),
                 )
                 .await
         };
@@ -12136,7 +12033,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         let structured = serde_json::json!({"verdict": "LGTM", "findings": []});
@@ -12187,7 +12083,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         let entry = exec.make_step_history_entry(Some("complete".to_string()), None, None);
@@ -12271,7 +12166,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         // fix への遷移を試みる → ガード超過 → on_exhausted で approval へ
@@ -12316,7 +12210,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         let outcome = WorkflowEngine::apply_transition(&mut exec, "fix").unwrap();
@@ -12350,7 +12243,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         assert_eq!(
@@ -12391,7 +12283,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         // approval に遷移 → resets_cycle_for で fix のカウントがリセット
@@ -12431,7 +12322,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         // approval に遷移（カウントリセット）
@@ -12516,7 +12406,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         // step_a → exhausted → step_b → exhausted → step_c
@@ -12580,7 +12469,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         let outcome = WorkflowEngine::apply_transition(&mut exec, "step_a").unwrap();
@@ -12701,7 +12589,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         let outcome = WorkflowEngine::apply_transition(&mut exec, "code_review_parallel").unwrap();
@@ -12975,7 +12862,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         engine.executions.lock().await.insert(exec.id.clone(), exec);
         engine
@@ -13058,7 +12944,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let existing_id = exec.id.clone();
         engine.executions.lock().await.insert(exec.id.clone(), exec);
@@ -13285,7 +13170,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
         let run_id = exec.id.clone();
         let worktree_path = exec.worktree_path.clone();
@@ -13327,7 +13211,6 @@ mod tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         }
     }
 
@@ -13759,7 +13642,6 @@ mod tests {
                 ApprovalDecision::Approve,
                 Some(&target_run_id),
                 Some("review"),
-                None,
             )
             .await
             .unwrap();
@@ -14240,7 +14122,6 @@ mod dispatch_boundary_tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         }
     }
 
@@ -15870,7 +15751,6 @@ mod dispatch_boundary_tests {
                         output_contract: None,
                         token_usage: TokenUsage::default(),
                         run_index: 1,
-                        contract_retry_count: 0,
                     },
                     ParallelChildRun {
                         step_name: "child-b".to_string(),
@@ -15881,7 +15761,6 @@ mod dispatch_boundary_tests {
                         output_contract: None,
                         token_usage: TokenUsage::default(),
                         run_index: 1,
-                        contract_retry_count: 0,
                     },
                 ],
             }),
@@ -15890,7 +15769,6 @@ mod dispatch_boundary_tests {
                 backend_id: None,
                 permission_mode: "edit".to_string(),
             },
-            contract_retry_count: 0,
         };
 
         let entry = exec
@@ -16829,6 +16707,55 @@ mod dispatch_boundary_tests {
 
     // ---- [08] handle_submit_output: 単一トランザクション境界 ----
 
+    /// テスト用 helper: `dispatch_external_with_commit_context` 経由で SubmitOutput を
+    /// 提出する。production 経路（CLI pending dispatcher → dispatch_external）と同じ
+    /// 入口を踏むため、テストでも bypass を経由しない。
+    #[allow(clippy::too_many_arguments)]
+    async fn submit_output_for_test(
+        engine: &Arc<WorkflowEngine>,
+        app: &tauri::AppHandle<tauri::test::MockRuntime>,
+        run_id: &str,
+        step_name: &str,
+        contract: &str,
+        structured_output: serde_json::Value,
+        request_id: Option<&str>,
+        submitted_at: Option<f64>,
+    ) -> Result<(), WorkflowEngineError> {
+        let (session_store, handles) = make_dispatch_deps();
+        let command = WorkflowCommand::SubmitOutput {
+            run_id: run_id.to_string(),
+            step_name: step_name.to_string(),
+            contract: contract.to_string(),
+            structured_output,
+        };
+        let result = match (request_id, submitted_at) {
+            (Some(rid), Some(ts)) => {
+                let ctx = CommandCommitContext::submit_output(
+                    rid.to_string(),
+                    ts,
+                    step_name.to_string(),
+                    contract.to_string(),
+                );
+                engine
+                    .dispatch_external_with_commit_context(
+                        app,
+                        &session_store,
+                        &handles,
+                        command,
+                        ctx,
+                    )
+                    .await
+            }
+            (None, None) => {
+                engine
+                    .dispatch_external(app, &session_store, &handles, command)
+                    .await
+            }
+            _ => panic!("request_id と submitted_at は両方 Some か両方 None で渡すこと"),
+        };
+        result.map(|_| ())
+    }
+
     fn make_submit_output_workflow() -> Workflow {
         Workflow {
             name: "submit-wf".to_string(),
@@ -16882,18 +16809,18 @@ mod dispatch_boundary_tests {
             )
             .await;
 
-        engine
-            .dispatch_submit_output_with_context(
-                app.handle(),
-                &run_id,
-                "review".to_string(),
-                "review-verdict".to_string(),
-                serde_json::json!({"verdict": "LGTM"}),
-                Some("req-1".to_string()),
-                Some(800.0),
-            )
-            .await
-            .unwrap();
+        submit_output_for_test(
+            &engine,
+            app.handle(),
+            &run_id,
+            "review",
+            "review-verdict",
+            serde_json::json!({"verdict": "LGTM"}),
+            Some("00000000-0000-0000-0000-000000000aa1"),
+            Some(800.0),
+        )
+        .await
+        .unwrap();
 
         // step_outputs slot に書き込まれている
         let step_output = step_output_for(&engine, &run_id, "review")
@@ -16931,7 +16858,10 @@ mod dispatch_boundary_tests {
             .expect("OutputSubmitted event must be appended");
         assert_eq!(submitted.0, "review-verdict");
         assert_eq!(submitted.1["verdict"], "LGTM");
-        assert_eq!(submitted.2.as_deref(), Some("req-1"));
+        assert_eq!(
+            submitted.2.as_deref(),
+            Some("00000000-0000-0000-0000-000000000aa1")
+        );
         assert_eq!(submitted.3, Some(800.0));
     }
 
@@ -16954,18 +16884,18 @@ mod dispatch_boundary_tests {
             )
             .await;
 
-        let err = engine
-            .dispatch_submit_output_with_context(
-                app.handle(),
-                &run_id,
-                "review".to_string(),
-                "review-verdict".to_string(),
-                serde_json::json!({"verdict": "MAYBE"}),
-                None,
-                None,
-            )
-            .await
-            .unwrap_err();
+        let err = submit_output_for_test(
+            &engine,
+            app.handle(),
+            &run_id,
+            "review",
+            "review-verdict",
+            serde_json::json!({"verdict": "MAYBE"}),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, WorkflowEngineError::ValidationError(_)));
 
         // step_outputs は更新されない
@@ -16995,18 +16925,18 @@ mod dispatch_boundary_tests {
             )
             .await;
 
-        let err = engine
-            .dispatch_submit_output_with_context(
-                app.handle(),
-                &run_id,
-                "ghost-step".to_string(),
-                "review-verdict".to_string(),
-                serde_json::json!({"verdict": "LGTM"}),
-                None,
-                None,
-            )
-            .await
-            .unwrap_err();
+        let err = submit_output_for_test(
+            &engine,
+            app.handle(),
+            &run_id,
+            "ghost-step",
+            "review-verdict",
+            serde_json::json!({"verdict": "LGTM"}),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, WorkflowEngineError::ValidationError(_)));
         let events = read_submit_output_events(&app, &run_id);
         assert!(events
@@ -17023,18 +16953,18 @@ mod dispatch_boundary_tests {
         engine.set_run_store_data_dir(data_dir).await;
         let run_id = uuid::Uuid::new_v4().to_string();
 
-        let err = engine
-            .dispatch_submit_output_with_context(
-                app.handle(),
-                &run_id,
-                "review".to_string(),
-                "review-verdict".to_string(),
-                serde_json::json!({"verdict": "LGTM"}),
-                None,
-                None,
-            )
-            .await
-            .unwrap_err();
+        let err = submit_output_for_test(
+            &engine,
+            app.handle(),
+            &run_id,
+            "review",
+            "review-verdict",
+            serde_json::json!({"verdict": "LGTM"}),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, WorkflowEngineError::ExecutionNotFound(_)));
     }
 
@@ -17057,18 +16987,18 @@ mod dispatch_boundary_tests {
             )
             .await;
 
-        let err = engine
-            .dispatch_submit_output_with_context(
-                app.handle(),
-                &run_id,
-                "review".to_string(),
-                "fix-result".to_string(),
-                serde_json::json!({"status": "FIXED"}),
-                None,
-                None,
-            )
-            .await
-            .unwrap_err();
+        let err = submit_output_for_test(
+            &engine,
+            app.handle(),
+            &run_id,
+            "review",
+            "fix-result",
+            serde_json::json!({"status": "FIXED"}),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, WorkflowEngineError::ValidationError(_)));
         assert!(step_output_for(&engine, &run_id, "review").await.is_none());
     }
@@ -17093,18 +17023,18 @@ mod dispatch_boundary_tests {
             )
             .await;
 
-        engine
-            .dispatch_submit_output_with_context(
-                app.handle(),
-                &run_id,
-                "review".to_string(),
-                "review-verdict".to_string(),
-                serde_json::json!({"verdict": "LGTM"}),
-                None,
-                None,
-            )
-            .await
-            .unwrap();
+        submit_output_for_test(
+            &engine,
+            app.handle(),
+            &run_id,
+            "review",
+            "review-verdict",
+            serde_json::json!({"verdict": "LGTM"}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         let step_output = step_output_for(&engine, &run_id, "review")
             .await
             .expect("step_outputs slot must be populated");
@@ -17146,18 +17076,18 @@ mod dispatch_boundary_tests {
             )
             .await;
 
-        engine
-            .dispatch_submit_output_with_context(
-                app.handle(),
-                &run_id,
-                "plan".to_string(),
-                "spec-file-path".to_string(),
-                serde_json::json!({"spec_file_path": "docs/spec/issues-1029.md"}),
-                None,
-                None,
-            )
-            .await
-            .unwrap();
+        submit_output_for_test(
+            &engine,
+            app.handle(),
+            &run_id,
+            "plan",
+            "spec-file-path",
+            serde_json::json!({"spec_file_path": "docs/spec/issues-1029.md"}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
 
         let vars = engine
             .executions
@@ -17170,5 +17100,253 @@ mod dispatch_boundary_tests {
             vars.get("spec_file_path").map(|s| s.as_str()),
             Some("docs/spec/issues-1029.md")
         );
+    }
+
+    /// [08] 振る舞い定義 Rule 1 Scenario 3: 既に出力を受け付けられる状態にない step に
+    /// 対する提出は拒否され、state と event log が変化しないことを確認する。
+    #[tokio::test]
+    async fn submit_output_rejects_non_accepting_step_without_side_effects() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let workflow = Workflow {
+            name: "multi-step".to_string(),
+            description: String::new(),
+            builtin: false,
+            nodes: vec![
+                NodeDefinition {
+                    name: "first".to_string(),
+                    node_type: NodeType::Agent,
+                    output_contract: Some("review-verdict".to_string()),
+                    ..NodeDefinition::default()
+                },
+                NodeDefinition {
+                    name: "second".to_string(),
+                    node_type: NodeType::Agent,
+                    output_contract: Some("review-verdict".to_string()),
+                    ..NodeDefinition::default()
+                },
+            ],
+        };
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                workflow,
+                WorkflowExecutionState::Running,
+                "/wt/submit-stale".to_string(),
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        // current step を `second` に進めて、`first` を提出受付対象から外す。
+        engine.force_current_step_index_for_test(&run_id, 1).await;
+
+        let events_before = read_submit_output_events(&app, &run_id);
+        let exec_before = engine
+            .executions
+            .lock()
+            .await
+            .get(&run_id)
+            .map(|e| (e.step_outputs.clone(), e.workflow_variables.clone()))
+            .unwrap();
+
+        let err = submit_output_for_test(
+            &engine,
+            app.handle(),
+            &run_id,
+            "first",
+            "review-verdict",
+            serde_json::json!({"verdict": "LGTM"}),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, WorkflowEngineError::InvalidState(_)));
+
+        // state は変化していない
+        let exec_after = engine
+            .executions
+            .lock()
+            .await
+            .get(&run_id)
+            .map(|e| (e.step_outputs.clone(), e.workflow_variables.clone()))
+            .unwrap();
+        assert_eq!(exec_before.0.len(), exec_after.0.len());
+        assert_eq!(exec_before.1, exec_after.1);
+
+        // OutputSubmitted event は append されない
+        let events_after = read_submit_output_events(&app, &run_id);
+        assert_eq!(events_before.len(), events_after.len());
+        assert!(events_after
+            .iter()
+            .all(|e| !matches!(e, WorkflowEvent::OutputSubmitted { .. })));
+    }
+
+    /// [08] 振る舞い定義 Rule 4: agent step の自由文出力に `<workflow_output>` 相当の
+    /// 表現が含まれていても、明示的提出が無い限り step_outputs は更新されず、
+    /// OutputSubmitted event も追記されない（prose 抽出経路の完全廃止）。
+    #[tokio::test]
+    async fn agent_free_text_workflow_output_block_does_not_confirm_step_output() {
+        use crate::session::MessagePart;
+
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                make_submit_output_workflow(),
+                WorkflowExecutionState::Running,
+                "/wt/agent-freetext".to_string(),
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        let outputs_before = engine
+            .executions
+            .lock()
+            .await
+            .get(&run_id)
+            .map(|e| e.step_outputs.clone())
+            .unwrap();
+        let events_before = read_submit_output_events(&app, &run_id);
+
+        let final_text = r#"承認します。
+<workflow_output type="review-verdict">{"verdict":"LGTM"}</workflow_output>"#;
+        let final_parts = vec![MessagePart::Text {
+            content: final_text.to_string(),
+            parent_tool_use_id: None,
+        }];
+
+        let (session_store, handles) = make_dispatch_deps();
+        // 自由文経路は prose 抽出を行わないため、step_outputs は変化しない。
+        // [08] handle_auto_complete のエラーを .ok() で握り潰さないこと（review 指摘）。
+        // 完了経路を通って初めて「自由文出力中の `<workflow_output>` は無視される」を
+        // 検証できるため、.expect で経路実行を保証する。
+        engine
+            .handle_auto_complete(
+                app.handle(),
+                &session_store,
+                &handles,
+                "/wt/agent-freetext",
+                &final_parts,
+                &[],
+                "review",
+            )
+            .await
+            .expect("handle_auto_complete must succeed for agent free-text path");
+
+        let outputs_after = engine
+            .executions
+            .lock()
+            .await
+            .get(&run_id)
+            .map(|e| e.step_outputs.clone())
+            .unwrap_or_default();
+        // step_outputs 数は変わらず、structured_output を持つ entry が追加されていない
+        assert_eq!(outputs_before.len(), outputs_after.len());
+
+        // OutputSubmitted event も追記されていない
+        let events_after = read_submit_output_events(&app, &run_id);
+        let submitted_count_before = events_before
+            .iter()
+            .filter(|e| matches!(e, WorkflowEvent::OutputSubmitted { .. }))
+            .count();
+        let submitted_count_after = events_after
+            .iter()
+            .filter(|e| matches!(e, WorkflowEvent::OutputSubmitted { .. }))
+            .count();
+        assert_eq!(submitted_count_before, submitted_count_after);
+        // 経路実行の事実: review step の NodeCompleted が事実履歴に残る。
+        let node_completed = events_after
+            .iter()
+            .filter(|e| matches!(e, WorkflowEvent::NodeCompleted { node_name, .. } if node_name == "review"))
+            .count();
+        assert!(
+            node_completed > 0,
+            "handle_auto_complete should commit NodeCompleted for review step"
+        );
+    }
+
+    /// [08] 振る舞い定義 Rule 1: OutputSubmitted append が失敗した場合、
+    /// step_outputs / workflow_variables / event log は提出前状態のまま保たれる。
+    /// `write_log_required` の挿入 fail 経由で append 失敗を再現し、rollback の事実を
+    /// 直接検証する（spec [08]: 「副作用なしで提出前状態のまま保つ」）。
+    #[tokio::test]
+    async fn submit_output_rolls_back_state_when_event_append_fails() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let workflow = Workflow {
+            name: "spec-wf".to_string(),
+            description: String::new(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "plan".to_string(),
+                node_type: NodeType::Agent,
+                output_contract: Some("spec-file-path".to_string()),
+                ..NodeDefinition::default()
+            }],
+        };
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                workflow,
+                WorkflowExecutionState::Running,
+                "/wt/submit-rollback".to_string(),
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        let exec_before = engine
+            .executions
+            .lock()
+            .await
+            .get(&run_id)
+            .map(|e| (e.step_outputs.clone(), e.workflow_variables.clone()))
+            .unwrap();
+        let events_before = read_submit_output_events(&app, &run_id);
+
+        // 次の write_log_required を失敗させる。
+        engine.fail_next_required_event_append_for_test();
+        let err = submit_output_for_test(
+            &engine,
+            app.handle(),
+            &run_id,
+            "plan",
+            "spec-file-path",
+            serde_json::json!({"spec_file_path": "docs/spec/issues-1029.md"}),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, WorkflowEngineError::SessionStore(_)));
+
+        // state は提出前のまま保たれる
+        let exec_after = engine
+            .executions
+            .lock()
+            .await
+            .get(&run_id)
+            .map(|e| (e.step_outputs.clone(), e.workflow_variables.clone()))
+            .unwrap();
+        assert_eq!(exec_before.0.len(), exec_after.0.len());
+        assert!(!exec_after.0.contains_key("plan"));
+        assert_eq!(exec_before.1, exec_after.1);
+
+        // OutputSubmitted event は append されない（log への副作用なし）
+        let events_after = read_submit_output_events(&app, &run_id);
+        assert_eq!(events_before.len(), events_after.len());
+        assert!(events_after
+            .iter()
+            .all(|e| !matches!(e, WorkflowEvent::OutputSubmitted { .. })));
     }
 }

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -1805,6 +1805,7 @@ impl WorkflowEngine {
     /// `handle_submit_output` に合流するが、CLI 経由では caller の `request_id`
     /// （pending entry id）と `submitted_at`（CLI 側 timestamp）を `OutputSubmitted`
     /// event に保存する（spec [08] アーキテクチャ概要 / 状態 Owner）。
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn dispatch_submit_output_with_context<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
@@ -1835,6 +1836,7 @@ impl WorkflowEngine {
     ///    `OutputSubmitted` event を append
     /// 4. 不適合・stale step・不在 step・契約タイプ不一致は副作用なしで `Err` を返し、
     ///    `step_outputs` / `workflow_variables` / event log を一切変更しない。
+    #[allow(clippy::too_many_arguments)]
     async fn handle_submit_output<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
@@ -1845,9 +1847,8 @@ impl WorkflowEngine {
         request_id: Option<String>,
         submitted_at: Option<f64>,
     ) -> Result<(), WorkflowEngineError> {
-        uuid::Uuid::parse_str(run_id).map_err(|_| {
-            WorkflowEngineError::ValidationError("run_id must be UUID".to_string())
-        })?;
+        uuid::Uuid::parse_str(run_id)
+            .map_err(|_| WorkflowEngineError::ValidationError("run_id must be UUID".to_string()))?;
         if step_name.trim().is_empty() {
             return Err(WorkflowEngineError::ValidationError(
                 "step_name must not be empty".to_string(),
@@ -16842,10 +16843,7 @@ mod dispatch_boundary_tests {
         }
     }
 
-    fn read_submit_output_events(
-        app: &DispatchTestApp,
-        run_id: &str,
-    ) -> Vec<WorkflowEvent> {
+    fn read_submit_output_events(app: &DispatchTestApp, run_id: &str) -> Vec<WorkflowEvent> {
         let data_dir = crate::session::resolve_data_dir(app.handle()).expect("data_dir");
         WorkflowEventLog::new(&data_dir)
             .read_log(run_id)

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -17463,4 +17463,352 @@ mod dispatch_boundary_tests {
             .expect("metadata must remain");
         assert_eq!(summary.status, RunStatus::Completed);
     }
+
+    // ---- [08] handle_submit_output: 単一トランザクション境界 ----
+
+    fn make_submit_output_workflow() -> Workflow {
+        Workflow {
+            name: "submit-wf".to_string(),
+            description: String::new(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "review".to_string(),
+                node_type: NodeType::Agent,
+                output_contract: Some("review-verdict".to_string()),
+                ..NodeDefinition::default()
+            }],
+        }
+    }
+
+    fn read_submit_output_events(
+        app: &DispatchTestApp,
+        run_id: &str,
+    ) -> Vec<WorkflowEvent> {
+        let data_dir = crate::session::resolve_data_dir(app.handle()).expect("data_dir");
+        WorkflowEventLog::new(&data_dir)
+            .read_log(run_id)
+            .unwrap_or_default()
+    }
+
+    async fn step_output_for(
+        engine: &WorkflowEngine,
+        run_id: &str,
+        step_name: &str,
+    ) -> Option<StepOutput> {
+        engine
+            .executions
+            .lock()
+            .await
+            .get(run_id)
+            .and_then(|exec| exec.step_outputs.get(step_name).cloned())
+    }
+
+    /// [08] 振る舞い定義 Rule 1（適合する場合）: contract に適合する構造化出力は
+    /// step output として確定し、後続 step から参照可能になり、事実履歴に記録される。
+    #[tokio::test]
+    async fn submit_output_persists_step_output_and_appends_event_when_contract_satisfied() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                make_submit_output_workflow(),
+                WorkflowExecutionState::Running,
+                "/wt/submit-ok".to_string(),
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        engine
+            .dispatch_submit_output_with_context(
+                app.handle(),
+                &run_id,
+                "review".to_string(),
+                "review-verdict".to_string(),
+                serde_json::json!({"verdict": "LGTM"}),
+                Some("req-1".to_string()),
+                Some(800.0),
+            )
+            .await
+            .unwrap();
+
+        // step_outputs slot に書き込まれている
+        let step_output = step_output_for(&engine, &run_id, "review")
+            .await
+            .expect("step_outputs must be updated");
+        assert_eq!(
+            step_output.output_contract.as_deref(),
+            Some("review-verdict")
+        );
+        assert_eq!(
+            step_output.structured_output.as_ref().unwrap()["verdict"],
+            "LGTM"
+        );
+
+        // OutputSubmitted event が追記されている
+        let events = read_submit_output_events(&app, &run_id);
+        let submitted = events
+            .iter()
+            .find_map(|e| match e {
+                WorkflowEvent::OutputSubmitted {
+                    node_name,
+                    contract,
+                    structured_output,
+                    request_id,
+                    submitted_at,
+                    ..
+                } if node_name == "review" => Some((
+                    contract.clone(),
+                    structured_output.clone(),
+                    request_id.clone(),
+                    *submitted_at,
+                )),
+                _ => None,
+            })
+            .expect("OutputSubmitted event must be appended");
+        assert_eq!(submitted.0, "review-verdict");
+        assert_eq!(submitted.1["verdict"], "LGTM");
+        assert_eq!(submitted.2.as_deref(), Some("req-1"));
+        assert_eq!(submitted.3, Some(800.0));
+    }
+
+    /// [08] 振る舞い定義 Rule 1（適合しない場合）: contract 不適合の入力は拒否され、
+    /// step_outputs / workflow_variables / 事実履歴のいずれも変化しない。
+    #[tokio::test]
+    async fn submit_output_rejects_invalid_contract_without_side_effects() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                make_submit_output_workflow(),
+                WorkflowExecutionState::Running,
+                "/wt/submit-invalid".to_string(),
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        let err = engine
+            .dispatch_submit_output_with_context(
+                app.handle(),
+                &run_id,
+                "review".to_string(),
+                "review-verdict".to_string(),
+                serde_json::json!({"verdict": "MAYBE"}),
+                None,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WorkflowEngineError::ValidationError(_)));
+
+        // step_outputs は更新されない
+        assert!(step_output_for(&engine, &run_id, "review").await.is_none());
+        // OutputSubmitted event も書かれない
+        let events = read_submit_output_events(&app, &run_id);
+        assert!(events
+            .iter()
+            .all(|e| !matches!(e, WorkflowEvent::OutputSubmitted { .. })));
+    }
+
+    /// [08] 振る舞い定義 Rule 1: 不在 step に対する提出は副作用なしで拒否される。
+    #[tokio::test]
+    async fn submit_output_rejects_unknown_step_without_side_effects() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                make_submit_output_workflow(),
+                WorkflowExecutionState::Running,
+                "/wt/submit-unknown".to_string(),
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        let err = engine
+            .dispatch_submit_output_with_context(
+                app.handle(),
+                &run_id,
+                "ghost-step".to_string(),
+                "review-verdict".to_string(),
+                serde_json::json!({"verdict": "LGTM"}),
+                None,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WorkflowEngineError::ValidationError(_)));
+        let events = read_submit_output_events(&app, &run_id);
+        assert!(events
+            .iter()
+            .all(|e| !matches!(e, WorkflowEvent::OutputSubmitted { .. })));
+    }
+
+    /// [08] 振る舞い定義 Rule 1: 不在 run （UUID 未登録）に対する提出は ExecutionNotFound で拒否。
+    #[tokio::test]
+    async fn submit_output_rejects_unknown_run() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+
+        let err = engine
+            .dispatch_submit_output_with_context(
+                app.handle(),
+                &run_id,
+                "review".to_string(),
+                "review-verdict".to_string(),
+                serde_json::json!({"verdict": "LGTM"}),
+                None,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WorkflowEngineError::ExecutionNotFound(_)));
+    }
+
+    /// [08] caller の `--type` と engine の expected contract が一致しない場合は拒否され、
+    /// 副作用は発生しない。
+    #[tokio::test]
+    async fn submit_output_rejects_contract_type_mismatch() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                make_submit_output_workflow(),
+                WorkflowExecutionState::Running,
+                "/wt/submit-mismatch".to_string(),
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        let err = engine
+            .dispatch_submit_output_with_context(
+                app.handle(),
+                &run_id,
+                "review".to_string(),
+                "fix-result".to_string(),
+                serde_json::json!({"status": "FIXED"}),
+                None,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WorkflowEngineError::ValidationError(_)));
+        assert!(step_output_for(&engine, &run_id, "review").await.is_none());
+    }
+
+    /// [08] 振る舞い定義 Rule 3: 提出済み output は後続 step から
+    /// `pass_output_from` 経路で経路非依存に参照できる。step_outputs に
+    /// 書き込まれた entry が contract 由来の `output_contract` を保持することを担保する。
+    #[tokio::test]
+    async fn submit_output_step_output_carries_contract_for_downstream_reference() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                make_submit_output_workflow(),
+                WorkflowExecutionState::Running,
+                "/wt/submit-downstream".to_string(),
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        engine
+            .dispatch_submit_output_with_context(
+                app.handle(),
+                &run_id,
+                "review".to_string(),
+                "review-verdict".to_string(),
+                serde_json::json!({"verdict": "LGTM"}),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let step_output = step_output_for(&engine, &run_id, "review")
+            .await
+            .expect("step_outputs slot must be populated");
+        assert_eq!(
+            step_output.output_contract.as_deref(),
+            Some("review-verdict")
+        );
+        // structured_output が後続経路に渡る shape で保持される
+        assert!(step_output.structured_output.is_some());
+    }
+
+    /// [08] spec-file-path contract が submit された場合、workflow_variables に
+    /// `spec_file_path` が反映される（extract_contract_variables の合流）。
+    #[tokio::test]
+    async fn submit_output_applies_contract_variables_for_spec_file_path() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = crate::session::resolve_data_dir(app.handle()).unwrap();
+        engine.set_run_store_data_dir(data_dir).await;
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let workflow = Workflow {
+            name: "spec-wf".to_string(),
+            description: String::new(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "plan".to_string(),
+                node_type: NodeType::Agent,
+                output_contract: Some("spec-file-path".to_string()),
+                ..NodeDefinition::default()
+            }],
+        };
+        engine
+            .seed_active_execution_for_test(
+                run_id.clone(),
+                workflow,
+                WorkflowExecutionState::Running,
+                "/wt/submit-spec".to_string(),
+                TriggerSource::DesktopUi,
+            )
+            .await;
+
+        engine
+            .dispatch_submit_output_with_context(
+                app.handle(),
+                &run_id,
+                "plan".to_string(),
+                "spec-file-path".to_string(),
+                serde_json::json!({"spec_file_path": "docs/spec/issues-1029.md"}),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let vars = engine
+            .executions
+            .lock()
+            .await
+            .get(&run_id)
+            .map(|exec| exec.workflow_variables.clone())
+            .unwrap();
+        assert_eq!(
+            vars.get("spec_file_path").map(|s| s.as_str()),
+            Some("docs/spec/issues-1029.md")
+        );
+    }
 }

--- a/src-tauri/src/workflow/event.rs
+++ b/src-tauri/src/workflow/event.rs
@@ -225,6 +225,39 @@ pub enum WorkflowEvent {
         /// engine が本 event を append した時刻。
         timestamp: f64,
     },
+    /// [06] / [08] CLI 経路の mutation が engine 判断によって拒否された事実
+    /// （5-3 / 5-4 修正）。
+    ///
+    /// `CliMutationRequested` が「リクエストを受理した事実」であるのに対し、
+    /// 本 event は「engine が無効と判断して状態を変えなかった事実」を表す。
+    /// 両者は独立に発火し、両方記録される場合（reject rule なし node への
+    /// reject 等）と本 event のみ記録される場合（SubmitOutput の silent-drop
+    /// だった経路）がある。
+    ///
+    /// spec [08] Rule 1「SubmitOutput の拒否は事実履歴に残さない」の意味は、
+    /// accepted のメイン履歴（`OutputSubmitted` / `CliMutationRequested`）に
+    /// 出ないことを指すと再定義する。観測経路用の補助履歴として本 event は
+    /// 並列に追記される。
+    ///
+    /// `request` の自由記述（reason / comment）は平文で永続化される（spec
+    /// [06] 要求の運用境界と同じ）。
+    CliMutationRejected {
+        run_id: String,
+        workflow_name: String,
+        /// 元のリクエスト id（`CliMutationRequested` と同じ値）。
+        request_id: String,
+        /// 拒否されたリクエストの内容。SubmitOutput の場合は payload 本体を
+        /// 含めず `step_name` と `contract` のみ。
+        request: CliMutationRequestRecord,
+        /// 拒否理由の typed 分類。CLI ユーザはここを見て後続操作を判断する。
+        reason: CliMutationRejectionReason,
+        /// 人間可読の拒否理由（`WorkflowEngineError::to_string()` 由来）。
+        message: String,
+        /// caller が pending command を書き出した時刻（Unix 秒）。
+        requested_at: f64,
+        /// engine が本 event を append した時刻。
+        timestamp: f64,
+    },
 }
 
 /// [06] CLI mutating CLI が要求した内容の typed 表現。
@@ -232,6 +265,10 @@ pub enum WorkflowEvent {
 /// 各 variant の `node_name` は対象 node の限定の有無を表す（`None` = run 全体 /
 /// 現在の承認待ち node を engine 側で解決する、`Some` = caller が明示的に node
 /// を限定）。`Reject` の `reason` は CLI 入口で必須化済み。
+///
+/// `SubmitOutput` variant は `CliMutationRejected` でのみ使用する（accepted 経路
+/// は `OutputSubmitted` event が一次表現）。payload 本体は容量が大きい可能性が
+/// あるため `step_name` と `contract` のみを保持する。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum CliMutationRequestRecord {
@@ -250,6 +287,37 @@ pub enum CliMutationRequestRecord {
         #[serde(skip_serializing_if = "Option::is_none", default)]
         node_name: Option<String>,
     },
+    /// SubmitOutput リクエストの拒否事実用 representation（accepted 経路では
+    /// 使用しない）。容量肥大を避けるため structured_output 本体は含めない。
+    SubmitOutput { step_name: String, contract: String },
+}
+
+/// [06] / [08] `CliMutationRejected` event の typed 拒否理由（5-3 / 5-4 修正）。
+///
+/// CLI ユーザはこの分類を読んで「再試行可能か」「workflow 設計の問題か」を
+/// 判断する。新しい拒否理由が判明した場合は variant を追加する（破壊変更ではなく
+/// `serde(rename_all = "snake_case")` の蓄積的拡張として扱う）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliMutationRejectionReason {
+    /// 対象 run が engine から見つからない（CLI 側 5-2 チェックを通り抜けた
+    /// race condition 等）。
+    RunNotFound,
+    /// 対象 run が terminal 状態のため mutation を受け付けない。
+    RunNotActive,
+    /// 対象 node が workflow に存在しない。
+    NodeNotFound,
+    /// 現在 approval を待っていない node に approve/reject を要求した。
+    NotWaitingApproval,
+    /// 5-4: reject rule が定義されていない approval node に reject を要求した。
+    NoRejectRule,
+    /// 5-3: 構造化出力の受領を受け付けていない step に submit を要求した
+    /// （pending 等）。
+    StepNotAccepting,
+    /// 構造化出力の contract が step の expected と一致しない。
+    ContractMismatch,
+    /// 上記いずれにも分類されない、engine の InvalidState / Validation 由来の拒否。
+    Other,
 }
 
 /// approval 判断結果の typed 表現。NDJSON 上は snake_case として出力される。
@@ -292,7 +360,8 @@ impl WorkflowEvent {
             | Self::ParallelCompleted { run_id, .. }
             | Self::ContractRepairRequested { run_id, .. }
             | Self::CliMutationRequested { run_id, .. }
-            | Self::OutputSubmitted { run_id, .. } => run_id,
+            | Self::OutputSubmitted { run_id, .. }
+            | Self::CliMutationRejected { run_id, .. } => run_id,
         }
     }
 }
@@ -514,5 +583,96 @@ mod tests {
         for event in events {
             assert_eq!(event.run_id(), rid);
         }
+    }
+
+    /// 5-3 / 5-4 修正: `CliMutationRejected` event が全ての `request` variant
+    /// （SubmitOutput 含む）について NDJSON 上で round-trip し、`event` タグが
+    /// `cli_mutation_rejected` として出力される。`reason` は snake_case で
+    /// 出力される。
+    #[test]
+    fn cli_mutation_rejected_serde_round_trips_all_variants() {
+        let cases = vec![
+            (
+                WorkflowEvent::CliMutationRejected {
+                    run_id: "00000000-0000-0000-0000-000000000600".to_string(),
+                    workflow_name: "wf".to_string(),
+                    request_id: "00000000-0000-0000-0000-000000000700".to_string(),
+                    request: CliMutationRequestRecord::Reject {
+                        node_name: Some("plan_architecture".to_string()),
+                        reason: "rule なし node 拒否".to_string(),
+                    },
+                    reason: CliMutationRejectionReason::NoRejectRule,
+                    message: "Step 'plan_architecture' does not allow reject".to_string(),
+                    requested_at: 100.0,
+                    timestamp: 101.0,
+                },
+                "no_reject_rule",
+            ),
+            (
+                WorkflowEvent::CliMutationRejected {
+                    run_id: "00000000-0000-0000-0000-000000000601".to_string(),
+                    workflow_name: "wf".to_string(),
+                    request_id: "00000000-0000-0000-0000-000000000701".to_string(),
+                    request: CliMutationRequestRecord::SubmitOutput {
+                        step_name: "plan_fix_policy".to_string(),
+                        contract: "fix-policy".to_string(),
+                    },
+                    reason: CliMutationRejectionReason::StepNotAccepting,
+                    message: "step 'plan_fix_policy' is not currently accepting structured output"
+                        .to_string(),
+                    requested_at: 200.0,
+                    timestamp: 201.0,
+                },
+                "step_not_accepting",
+            ),
+            (
+                WorkflowEvent::CliMutationRejected {
+                    run_id: "00000000-0000-0000-0000-000000000602".to_string(),
+                    workflow_name: "wf".to_string(),
+                    request_id: "00000000-0000-0000-0000-000000000702".to_string(),
+                    request: CliMutationRequestRecord::Approve {
+                        node_name: None,
+                        comment: None,
+                    },
+                    reason: CliMutationRejectionReason::NotWaitingApproval,
+                    message: "approval target stale".to_string(),
+                    requested_at: 300.0,
+                    timestamp: 301.0,
+                },
+                "not_waiting_approval",
+            ),
+        ];
+        for (event, reason_str) in cases {
+            let json = serde_json::to_string(&event).unwrap();
+            assert!(
+                json.contains("\"event\":\"cli_mutation_rejected\""),
+                "event tag must be snake_case `cli_mutation_rejected`, got: {json}"
+            );
+            assert!(
+                json.contains(&format!("\"reason\":\"{reason_str}\"")),
+                "reason must serialize as snake_case `{reason_str}`, got: {json}"
+            );
+            let back: WorkflowEvent = serde_json::from_str(&json).unwrap();
+            let json2 = serde_json::to_string(&back).unwrap();
+            assert_eq!(json, json2);
+        }
+    }
+
+    /// 5-3 / 5-4 修正: `CliMutationRejected` event の `run_id()` accessor が
+    /// `run_id` を返す。
+    #[test]
+    fn cli_mutation_rejected_run_id_accessor_returns_run_id() {
+        let rid = "00000000-0000-0000-0000-000000000888";
+        let event = WorkflowEvent::CliMutationRejected {
+            run_id: rid.to_string(),
+            workflow_name: "wf".to_string(),
+            request_id: "00000000-0000-0000-0000-000000000999".to_string(),
+            request: CliMutationRequestRecord::Abort { node_name: None },
+            reason: CliMutationRejectionReason::Other,
+            message: "x".to_string(),
+            requested_at: 0.0,
+            timestamp: 0.0,
+        };
+        assert_eq!(event.run_id(), rid);
     }
 }

--- a/src-tauri/src/workflow/event.rs
+++ b/src-tauri/src/workflow/event.rs
@@ -199,6 +199,32 @@ pub enum WorkflowEvent {
         /// engine が本 event を受理・追記した時刻（commit timestamp）。
         timestamp: f64,
     },
+    /// [08] step に対する構造化出力が contract 適合判定を経て確定した事実。
+    ///
+    /// `WorkflowCommand::SubmitOutput`（CLI / in-process 経路問わず）が
+    /// engine の `dispatch_external` 単一入口で受理され、contract 適合判定 →
+    /// `step_outputs` / `workflow_variables` 更新と同一トランザクションで
+    /// append される。contract 不適合・stale step・不在 step などの拒否は本
+    /// event を残さない（spec [08] OutputSubmitted append の不可分性境界）。
+    OutputSubmitted {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        /// 対象 step の `output_contract`。
+        contract: String,
+        /// contract 適合判定を通過した構造化出力。
+        structured_output: serde_json::Value,
+        /// CLI pending command 経由で提出された場合の caller 側 request id。
+        /// in-process 経路（Tauri command 等）で提出された場合は `None`。
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        request_id: Option<String>,
+        /// caller が pending command を書き出した時刻（Unix 秒）。
+        /// in-process 経路では `None`。
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        submitted_at: Option<f64>,
+        /// engine が本 event を append した時刻。
+        timestamp: f64,
+    },
 }
 
 /// [06] CLI mutating CLI が要求した内容の typed 表現。
@@ -265,7 +291,8 @@ impl WorkflowEvent {
             | Self::ParallelChildCompleted { run_id, .. }
             | Self::ParallelCompleted { run_id, .. }
             | Self::ContractRepairRequested { run_id, .. }
-            | Self::CliMutationRequested { run_id, .. } => run_id,
+            | Self::CliMutationRequested { run_id, .. }
+            | Self::OutputSubmitted { run_id, .. } => run_id,
         }
     }
 }

--- a/src-tauri/src/workflow/event_projection.rs
+++ b/src-tauri/src/workflow/event_projection.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::workflow::event::{
-    ApprovalDecisionRecord, CliMutationRequestRecord, CollectedOutputEntry,
-    TokenUsage as EventTokenUsage, WorkflowEvent,
+    ApprovalDecisionRecord, CliMutationRejectionReason, CliMutationRequestRecord,
+    CollectedOutputEntry, TokenUsage as EventTokenUsage, WorkflowEvent,
 };
 use crate::workflow::schema::{NodeType, Workflow};
 use crate::workflow::state::{
@@ -128,6 +128,49 @@ pub(crate) fn compute_step_timings(events: &[WorkflowEvent]) -> Vec<WorkflowStep
             }
         })
         .collect()
+}
+
+/// spec [08]: 提出済みの構造化出力スナップショット。CLI / Tauri の `get` 入口が
+/// それぞれ別 DTO（`OutputGetView` / `WorkflowGetOutputResponse`）に map するための
+/// 中間型として、最新の `OutputSubmitted` から抽出した contract / structured_output /
+/// 付随メタを保持する。本構造体は engine projection 由来の事実情報のみを持ち、
+/// 表示用フォーマット変換は呼び出し側に閉じる。
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutputSubmittedSnapshot {
+    pub contract: String,
+    pub structured_output: serde_json::Value,
+    pub submitted_at: Option<f64>,
+    pub request_id: Option<String>,
+    pub timestamp: f64,
+}
+
+/// spec [08] Rule 3: 指定 step に対する最新の `OutputSubmitted` event を返す。
+///
+/// 同一 step に複数回 submit があった場合は最後（最新）の event を採用する。
+/// 該当 step に対する `OutputSubmitted` が一切なければ `None`（呼び出し側で
+/// 「未提出」として表現する）。
+pub fn latest_output_submitted_for(
+    events: &[WorkflowEvent],
+    step: &str,
+) -> Option<OutputSubmittedSnapshot> {
+    events.iter().rev().find_map(|event| match event {
+        WorkflowEvent::OutputSubmitted {
+            node_name,
+            contract,
+            structured_output,
+            submitted_at,
+            request_id,
+            timestamp,
+            ..
+        } if node_name == step => Some(OutputSubmittedSnapshot {
+            contract: contract.clone(),
+            structured_output: structured_output.clone(),
+            submitted_at: *submitted_at,
+            request_id: request_id.clone(),
+            timestamp: *timestamp,
+        }),
+        _ => None,
+    })
 }
 
 /// spec issues-1023: frontend へ返す event 列の view 型。
@@ -304,6 +347,19 @@ pub enum WorkflowEventView {
         request_id: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none", rename = "submittedAtMs")]
         submitted_at_ms: Option<f64>,
+        #[serde(rename = "timestampMs")]
+        timestamp_ms: f64,
+    },
+    /// [06] / [08] engine が拒否した CLI mutation 要求の事実（5-3 / 5-4 修正）。
+    CliMutationRejected {
+        run_id: String,
+        workflow_name: String,
+        request_id: String,
+        request: CliMutationRequestRecord,
+        reason: CliMutationRejectionReason,
+        message: String,
+        #[serde(rename = "requestedAtMs")]
+        requested_at_ms: f64,
         #[serde(rename = "timestampMs")]
         timestamp_ms: f64,
     },
@@ -563,6 +619,25 @@ impl From<WorkflowEvent> for WorkflowEventView {
                 structured_output,
                 request_id,
                 submitted_at_ms: submitted_at.map(seconds_to_ms),
+                timestamp_ms: seconds_to_ms(timestamp),
+            },
+            WorkflowEvent::CliMutationRejected {
+                run_id,
+                workflow_name,
+                request_id,
+                request,
+                reason,
+                message,
+                requested_at,
+                timestamp,
+            } => WorkflowEventView::CliMutationRejected {
+                run_id,
+                workflow_name,
+                request_id,
+                request,
+                reason,
+                message,
+                requested_at_ms: seconds_to_ms(requested_at),
                 timestamp_ms: seconds_to_ms(timestamp),
             },
         }
@@ -1184,6 +1259,17 @@ pub(crate) fn reconstruct_state_from_events(
                 timestamp,
                 ..
             } => {
+                // [08] 先行する OutputSubmitted で確定済みの structured_output /
+                //   output_contract は ParallelChildCompleted（prose 抽出廃止後は
+                //   `structured_output: None` 固定）で上書きしない。reload 経路でも
+                //   live と同じく「経路非依存に提出済み output を参照できる」
+                //   （spec [08] Rule 3 Scenario 1）を満たすため、既存 slot から
+                //   merge する。
+                let prior = step_outputs.get(child_node_name).cloned();
+                let merged_structured_output = structured_output
+                    .clone()
+                    .or_else(|| prior.as_ref().and_then(|p| p.structured_output.clone()));
+                let merged_output_contract = prior.as_ref().and_then(|p| p.output_contract.clone());
                 if let Some(ps) = active_parallel_steps
                     .iter_mut()
                     .find(|p| p.step_name == *child_node_name)
@@ -1191,7 +1277,8 @@ pub(crate) fn reconstruct_state_from_events(
                     ps.state = "completed".to_string();
                     ps.result = result.clone();
                     ps.completed_at = Some(*timestamp);
-                    ps.structured_output = structured_output.clone();
+                    ps.structured_output = merged_structured_output.clone();
+                    ps.output_contract = merged_output_contract.clone();
                 }
                 step_outputs.insert(
                     child_node_name.clone(),
@@ -1200,8 +1287,8 @@ pub(crate) fn reconstruct_state_from_events(
                         run_index: *run_index,
                         session_id: Some(session_id.clone()),
                         result: result.clone(),
-                        structured_output: structured_output.clone(),
-                        output_contract: None,
+                        structured_output: merged_structured_output,
+                        output_contract: merged_output_contract,
                         token_usage: token_usage.clone(),
                         completed_at: *timestamp,
                     },
@@ -1231,14 +1318,29 @@ pub(crate) fn reconstruct_state_from_events(
             } => {
                 // [08] CLI / in-process 経由で確定した step output を state に復元する。
                 // 後続 step が `pass_output_from` で経路非依存に参照できる shape に揃える。
+                // `result` は engine の live state と同じ値（contract validator の戻り値）
+                // を再導出する。これにより live と reload 経路で aggregate 評価が乖離しない。
                 let ri = step_execution_counts.get(node_name).copied().unwrap_or(0);
+                let restored_result = match crate::workflow::contract::validate_contract_value(
+                    contract,
+                    structured_output.clone(),
+                ) {
+                    crate::workflow::contract::ContractValidationResult::Valid {
+                        result, ..
+                    } => result,
+                    // append-only ログに記録された OutputSubmitted は engine 側で validator を
+                    // 通過しているため通常ここには到達しない。validator が将来変更されて
+                    // 不適合判定になっても、result を None にして live と同等に振る舞う
+                    // （aggregate 評価では match なしになるだけ）。
+                    crate::workflow::contract::ContractValidationResult::Invalid(_) => None,
+                };
                 step_outputs.insert(
                     node_name.clone(),
                     StepOutput {
                         step_name: node_name.clone(),
                         run_index: ri,
                         session_id: None,
-                        result: None,
+                        result: restored_result,
                         structured_output: Some(structured_output.clone()),
                         output_contract: Some(contract.clone()),
                         token_usage: None,
@@ -1256,6 +1358,10 @@ pub(crate) fn reconstruct_state_from_events(
                 }
                 updated_at = *timestamp;
             }
+            // [06] / [08] CliMutationRejected は観測経路用の補助履歴であり、
+            // engine の workflow state には影響しない（accepted 経路の event のみが
+            // 一次表現）。projection では no-op として扱う（5-3 / 5-4 修正）。
+            WorkflowEvent::CliMutationRejected { .. } => {}
         }
     }
 
@@ -1885,5 +1991,141 @@ mod tests {
         assert_eq!(detail.state, "pending");
         assert!(detail.result.is_none());
         assert_eq!(detail.input.instruction.as_deref(), Some("review later"));
+    }
+
+    /// [08] OutputSubmitted projection: live engine と同じ shape で `StepOutput` slot を
+    /// 復元する。`result` は contract validator を再導出するため、reload 経路でも
+    /// `pass_output_from` で経路非依存に参照できる（spec [08] Rule 3 Scenario 1/3）。
+    #[test]
+    fn projection_restores_step_output_from_output_submitted_with_validator_derived_result() {
+        let mut workflow = workflow_with_nodes("wf", vec!["review"]);
+        workflow.nodes[0].output_contract = Some("review-verdict".to_string());
+        let events = vec![
+            run_started("exec-submit", workflow),
+            WorkflowEvent::NodeStarted {
+                run_id: "exec-submit".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "review".to_string(),
+                execution_count: 1,
+                timestamp: 1001.0,
+            },
+            WorkflowEvent::OutputSubmitted {
+                run_id: "exec-submit".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "review".to_string(),
+                contract: "review-verdict".to_string(),
+                structured_output: serde_json::json!({"verdict": "LGTM"}),
+                request_id: Some("00000000-0000-0000-0000-0000000000aa".to_string()),
+                submitted_at: Some(1010.0),
+                timestamp: 1011.0,
+            },
+        ];
+
+        let state = reconstruct_state_from_events("exec-submit", &events)
+            .unwrap()
+            .unwrap();
+        let so = state
+            .step_outputs
+            .get("review")
+            .expect("OutputSubmitted should restore step_outputs slot");
+        assert_eq!(so.output_contract.as_deref(), Some("review-verdict"));
+        assert!(so.structured_output.is_some());
+        // validator から再導出された result を持つ（live と同じ shape）。
+        assert_eq!(so.result.as_deref(), Some("LGTM"));
+    }
+
+    fn output_submitted_event(
+        step: &str,
+        value: serde_json::Value,
+        request_id: Option<&str>,
+        submitted_at: Option<f64>,
+        timestamp: f64,
+    ) -> WorkflowEvent {
+        WorkflowEvent::OutputSubmitted {
+            run_id: "run-1".to_string(),
+            workflow_name: "wf".to_string(),
+            node_name: step.to_string(),
+            contract: "test-contract".to_string(),
+            structured_output: value,
+            request_id: request_id.map(str::to_string),
+            submitted_at,
+            timestamp,
+        }
+    }
+
+    /// spec [08] Rule 3: 同一 step に複数回 submit があった場合は最新の提出が返る。
+    #[test]
+    fn latest_output_submitted_for_picks_latest_when_multiple_submitted() {
+        let events = vec![
+            output_submitted_event(
+                "review",
+                serde_json::json!({"verdict": "FIRST"}),
+                Some("req-1"),
+                Some(1.0),
+                10.0,
+            ),
+            output_submitted_event(
+                "review",
+                serde_json::json!({"verdict": "LATEST"}),
+                Some("req-2"),
+                Some(2.0),
+                20.0,
+            ),
+        ];
+
+        let snapshot = latest_output_submitted_for(&events, "review")
+            .expect("latest OutputSubmitted should be returned");
+        assert_eq!(snapshot.contract, "test-contract");
+        assert_eq!(
+            snapshot.structured_output,
+            serde_json::json!({"verdict": "LATEST"})
+        );
+        assert_eq!(snapshot.request_id.as_deref(), Some("req-2"));
+        assert_eq!(snapshot.submitted_at, Some(2.0));
+        assert_eq!(snapshot.timestamp, 20.0);
+    }
+
+    /// spec [08] Rule 3: 別 step に対する OutputSubmitted は対象 step の最新提出に影響しない。
+    #[test]
+    fn latest_output_submitted_for_ignores_other_steps() {
+        let events = vec![
+            output_submitted_event(
+                "other",
+                serde_json::json!({"unused": true}),
+                None,
+                None,
+                30.0,
+            ),
+            output_submitted_event(
+                "review",
+                serde_json::json!({"verdict": "TARGET"}),
+                None,
+                None,
+                25.0,
+            ),
+        ];
+
+        let snapshot = latest_output_submitted_for(&events, "review")
+            .expect("OutputSubmitted for review step should be returned");
+        assert_eq!(
+            snapshot.structured_output,
+            serde_json::json!({"verdict": "TARGET"})
+        );
+        assert_eq!(snapshot.timestamp, 25.0);
+    }
+
+    /// spec [08] Rule 3 Scenario 2: 該当 step に OutputSubmitted が一切なければ None。
+    #[test]
+    fn latest_output_submitted_for_returns_none_when_no_match() {
+        let events = vec![output_submitted_event(
+            "other",
+            serde_json::json!({}),
+            None,
+            None,
+            10.0,
+        )];
+
+        assert!(latest_output_submitted_for(&events, "review").is_none());
+        assert!(latest_output_submitted_for(&[], "review").is_none());
     }
 }

--- a/src-tauri/src/workflow/event_projection.rs
+++ b/src-tauri/src/workflow/event_projection.rs
@@ -1231,10 +1231,7 @@ pub(crate) fn reconstruct_state_from_events(
             } => {
                 // [08] CLI / in-process 経由で確定した step output を state に復元する。
                 // 後続 step が `pass_output_from` で経路非依存に参照できる shape に揃える。
-                let ri = step_execution_counts
-                    .get(node_name)
-                    .copied()
-                    .unwrap_or(0);
+                let ri = step_execution_counts.get(node_name).copied().unwrap_or(0);
                 step_outputs.insert(
                     node_name.clone(),
                     StepOutput {

--- a/src-tauri/src/workflow/event_projection.rs
+++ b/src-tauri/src/workflow/event_projection.rs
@@ -294,6 +294,19 @@ pub enum WorkflowEventView {
         #[serde(rename = "timestampMs")]
         timestamp_ms: f64,
     },
+    OutputSubmitted {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        contract: String,
+        structured_output: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "submittedAtMs")]
+        submitted_at_ms: Option<f64>,
+        #[serde(rename = "timestampMs")]
+        timestamp_ms: f64,
+    },
 }
 
 impl From<WorkflowEvent> for WorkflowEventView {
@@ -531,6 +544,25 @@ impl From<WorkflowEvent> for WorkflowEventView {
                 request_id,
                 request,
                 requested_at_ms: seconds_to_ms(requested_at),
+                timestamp_ms: seconds_to_ms(timestamp),
+            },
+            WorkflowEvent::OutputSubmitted {
+                run_id,
+                workflow_name,
+                node_name,
+                contract,
+                structured_output,
+                request_id,
+                submitted_at,
+                timestamp,
+            } => WorkflowEventView::OutputSubmitted {
+                run_id,
+                workflow_name,
+                node_name,
+                contract,
+                structured_output,
+                request_id,
+                submitted_at_ms: submitted_at.map(seconds_to_ms),
                 timestamp_ms: seconds_to_ms(timestamp),
             },
         }
@@ -853,6 +885,7 @@ pub(crate) fn reconstruct_state_from_events(
     let mut step_history: Vec<StepHistoryEntry> = Vec::new();
     let mut step_execution_counts: HashMap<String, u32> = HashMap::new();
     let mut step_outputs: HashMap<String, StepOutput> = HashMap::new();
+    let mut workflow_variables: HashMap<String, String> = HashMap::new();
     let mut total_token_usage = TokenUsage::default();
     let mut exec_state = WorkflowExecutionState::Running;
     let mut current_step_name = workflow
@@ -1189,6 +1222,43 @@ pub(crate) fn reconstruct_state_from_events(
                 // [06] CLI mutation 要求の事実は append-only な観測情報のみで、
                 // engine domain state には影響しない。
             }
+            WorkflowEvent::OutputSubmitted {
+                node_name,
+                contract,
+                structured_output,
+                timestamp,
+                ..
+            } => {
+                // [08] CLI / in-process 経由で確定した step output を state に復元する。
+                // 後続 step が `pass_output_from` で経路非依存に参照できる shape に揃える。
+                let ri = step_execution_counts
+                    .get(node_name)
+                    .copied()
+                    .unwrap_or(0);
+                step_outputs.insert(
+                    node_name.clone(),
+                    StepOutput {
+                        step_name: node_name.clone(),
+                        run_index: ri,
+                        session_id: None,
+                        result: None,
+                        structured_output: Some(structured_output.clone()),
+                        output_contract: Some(contract.clone()),
+                        token_usage: None,
+                        completed_at: *timestamp,
+                    },
+                );
+                // contract 由来の workflow_variables を反映（spec-file-path のみ）。
+                if contract == "spec-file-path" {
+                    if let Some(path) = structured_output
+                        .get("spec_file_path")
+                        .and_then(|v| v.as_str())
+                    {
+                        workflow_variables.insert("spec_file_path".to_string(), path.to_string());
+                    }
+                }
+                updated_at = *timestamp;
+            }
         }
     }
 
@@ -1214,7 +1284,7 @@ pub(crate) fn reconstruct_state_from_events(
         step_outputs,
         step_states,
         active_parallel_steps,
-        workflow_variables: HashMap::new(),
+        workflow_variables,
         approval_operations: None,
         started_at,
         updated_at,

--- a/src-tauri/src/workflow/facet.rs
+++ b/src-tauri/src/workflow/facet.rs
@@ -89,11 +89,15 @@ impl FacetKind {
 /// 出力 Contract の前置定型文を組み立てる。
 ///
 /// Contract facet 本文は純粋な JSON shape 仕様（フォーマット + フィールドルール）のみを
-/// 保持し、`<workflow_output>` エンベロープの要求は本 preamble に閉じる。これにより
-/// 同じ Contract 本文が input/output 双方で再利用可能になる（[02] Contract 双方向対称性）。
+/// 保持し、提出経路の指示は本 preamble に閉じる。Contract 本文は input/output 双方で
+/// 再利用される（[02] Contract 双方向対称性）。
+///
+/// structured output の確定経路は `releash workflow output submit` CLI（および同等の
+/// typed API）のみ。step agent の自由文に書かれた `<workflow_output>` 相当の表現は
+/// engine から観測されないため、必ず CLI 経由で提出する必要がある。
 pub fn output_contract_preamble(key: &str) -> String {
     format!(
-        "レスポンスには下記データ仕様の `<workflow_output type=\"{key}\">...</workflow_output>` ブロックを必ず1つだけ含めること。\n\nデータ仕様 (型: {key}):"
+        "step 完了時に下記データ仕様 (型: {key}) に従う JSON を `releash workflow output submit` で提出すること。\n\n```sh\nreleash workflow output submit {{{{run_id}}}} \\\n  --step {{{{step_name}}}} \\\n  --type {key} \\\n  --json '{{...}}'\n```\n\n`--json` の代わりに `--file <path>.json` も使える。提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。\n\nデータ仕様 (型: {key}):"
     )
 }
 
@@ -716,9 +720,10 @@ mod tests {
         let result = compose_facets(&node);
 
         let sys = result.system_prompt.expect("system_prompt should be set");
-        // 出力 Contract preamble はキーに応じて `<workflow_output type="plan-doc">` の
-        // 署名を含み、本文（plan-doc Contract body）も連結される
-        assert!(sys.contains("<workflow_output type=\"plan-doc\">"));
+        // 出力 Contract preamble は CLI 提出経路（[08]）を agent に指示し、
+        // 型ラベルと Contract 本文を含む
+        assert!(sys.contains("releash workflow output submit"));
+        assert!(sys.contains("--type plan-doc"));
         assert!(sys.contains("Output as markdown."));
         assert_eq!(result.user_message, "");
     }

--- a/src-tauri/src/workflow/log.rs
+++ b/src-tauri/src/workflow/log.rs
@@ -45,6 +45,10 @@ impl WorkflowEventLog {
     }
 
     /// イベントをNDJSON形式でログファイルに追記する。
+    ///
+    /// [08] production の単発 append は `write_log_required` → `append_batch` 経路に
+    /// 集約された。本ヘルパは log 単体のセットアップが必要なテストからのみ呼ばれる。
+    #[cfg(test)]
     pub fn append(&self, event: &WorkflowEvent) -> Result<(), String> {
         self.append_batch(std::slice::from_ref(event))
     }

--- a/src-tauri/src/workflow/pending_command.rs
+++ b/src-tauri/src/workflow/pending_command.rs
@@ -66,6 +66,13 @@ pub enum PendingCommandPayload {
         #[serde(skip_serializing_if = "Option::is_none", default)]
         node_name: Option<String>,
     },
+    /// [08] `releash workflow output submit` 経由で書き出される構造化出力提出。
+    /// engine 側 dispatcher が `WorkflowCommand::SubmitOutput` に変換する。
+    SubmitOutput {
+        step_name: String,
+        contract: String,
+        structured_output: serde_json::Value,
+    },
 }
 
 pub type CliRequestPayload = PendingCommandPayload;

--- a/src-tauri/src/workflow/pending_command_dispatcher.rs
+++ b/src-tauri/src/workflow/pending_command_dispatcher.rs
@@ -106,6 +106,28 @@ pub(crate) async fn dispatch_pending_command<R: tauri::Runtime>(
         ..
     } = pending;
 
+    // [08] SubmitOutput は CliMutationRequested 系の commit_context を経由せず、
+    // engine 側で OutputSubmitted event を直接 append する独立トランザクション。
+    if let PendingCommandPayload::SubmitOutput {
+        step_name,
+        contract,
+        structured_output,
+    } = payload
+    {
+        return dispatch_submit_output_pending(
+            app,
+            engine,
+            session_store,
+            &run_id,
+            id,
+            step_name,
+            contract,
+            structured_output,
+            requested_at,
+        )
+        .await;
+    }
+
     let request = payload_to_cli_request(&payload);
     let metadata = WorkflowMutationContext::new(
         run_id.clone(),
@@ -145,6 +167,41 @@ pub(crate) async fn dispatch_pending_command<R: tauri::Runtime>(
             "CLI mutation dispatch returned unexpected result: {other:?}"
         )),
         Err(e) => handle_rejected_dispatch(app, engine, e, commit_context).await,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_submit_output_pending<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    engine: &Arc<WorkflowEngine>,
+    session_store: &Arc<SessionStore>,
+    run_id: &str,
+    request_id: String,
+    step_name: String,
+    contract: String,
+    structured_output: serde_json::Value,
+    requested_at: f64,
+) -> PendingCommandDispatchOutcome {
+    if let Err(e) = engine
+        .ensure_execution_loaded_for_external(app, session_store, run_id)
+        .await
+    {
+        return classify_dispatch_error(e);
+    }
+    match engine
+        .dispatch_submit_output_with_context(
+            app,
+            run_id,
+            step_name,
+            contract,
+            structured_output,
+            Some(request_id),
+            Some(requested_at),
+        )
+        .await
+    {
+        Ok(()) => PendingCommandDispatchOutcome::Accepted,
+        Err(e) => classify_dispatch_error(e),
     }
 }
 
@@ -195,6 +252,11 @@ fn payload_to_cli_request(payload: &PendingCommandPayload) -> CliMutationRequest
         PendingCommandPayload::Abort { node_name } => CliMutationRequestRecord::Abort {
             node_name: node_name.clone(),
         },
+        PendingCommandPayload::SubmitOutput { .. } => {
+            unreachable!(
+                "SubmitOutput payload must be routed via dispatch_submit_output_pending"
+            )
+        }
     }
 }
 
@@ -219,6 +281,16 @@ fn payload_to_workflow_command(payload: PendingCommandPayload, run_id: String) -
         PendingCommandPayload::Abort { node_name } => WorkflowCommand::AbortRun {
             run_id,
             expected_node_name: node_name,
+        },
+        PendingCommandPayload::SubmitOutput {
+            step_name,
+            contract,
+            structured_output,
+        } => WorkflowCommand::SubmitOutput {
+            run_id,
+            step_name,
+            contract,
+            structured_output,
         },
     }
 }

--- a/src-tauri/src/workflow/pending_command_dispatcher.rs
+++ b/src-tauri/src/workflow/pending_command_dispatcher.rs
@@ -253,9 +253,7 @@ fn payload_to_cli_request(payload: &PendingCommandPayload) -> CliMutationRequest
             node_name: node_name.clone(),
         },
         PendingCommandPayload::SubmitOutput { .. } => {
-            unreachable!(
-                "SubmitOutput payload must be routed via dispatch_submit_output_pending"
-            )
+            unreachable!("SubmitOutput payload must be routed via dispatch_submit_output_pending")
         }
     }
 }
@@ -733,11 +731,9 @@ mod tests {
                     request_id,
                     submitted_at,
                     ..
-                } if node_name == "review" => Some((
-                    contract.clone(),
-                    request_id.clone(),
-                    *submitted_at,
-                )),
+                } if node_name == "review" => {
+                    Some((contract.clone(), request_id.clone(), *submitted_at))
+                }
                 _ => None,
             })
             .expect("OutputSubmitted event must be appended via dispatcher");

--- a/src-tauri/src/workflow/pending_command_dispatcher.rs
+++ b/src-tauri/src/workflow/pending_command_dispatcher.rs
@@ -359,6 +359,38 @@ mod tests {
         }
     }
 
+    fn make_submit_output_workflow() -> Workflow {
+        Workflow {
+            name: "boundary-wf".to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "review".to_string(),
+                node_type: NodeType::Agent,
+                instruction: Some("review".to_string()),
+                output_contract: Some("review-verdict".to_string()),
+                ..NodeDefinition::default()
+            }],
+        }
+    }
+
+    async fn seed_running_agent(
+        engine: &WorkflowEngine,
+        run_id: &str,
+        worktree_path: &str,
+        workflow: Workflow,
+    ) {
+        engine
+            .seed_active_execution_for_test(
+                run_id.to_string(),
+                workflow,
+                crate::workflow::state::WorkflowExecutionState::Running,
+                worktree_path.to_string(),
+                TriggerSource::Cli,
+            )
+            .await;
+    }
+
     fn make_rejectable_approval_workflow() -> Workflow {
         Workflow {
             name: "boundary-wf".to_string(),
@@ -654,5 +686,105 @@ mod tests {
             })
             .expect("CliMutationRequested reject reason must be recorded");
         assert_eq!(cli_reason, raw_reason);
+    }
+
+    /// [08] CLI pending 経由の SubmitOutput が engine の handle_submit_output
+    /// に合流し、`OutputSubmitted` event が caller の `request_id` と `submitted_at`
+    /// を保持する形で append される（spec [08] CLI 経路と in-process 経路の合流境界）。
+    #[tokio::test]
+    async fn dispatch_pending_submit_output_appends_event_with_caller_metadata() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir).await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        seed_running_agent(
+            &engine,
+            &run_id,
+            "/wt/pending-dispatcher-submit",
+            make_submit_output_workflow(),
+        )
+        .await;
+
+        let pending = PendingCommand::new(
+            run_id.clone(),
+            CliRequestPayload::SubmitOutput {
+                step_name: "review".to_string(),
+                contract: "review-verdict".to_string(),
+                structured_output: serde_json::json!({"verdict": "LGTM"}),
+            },
+            950.5,
+        );
+        let pending_id = pending.id.clone();
+
+        let result =
+            dispatch_pending_command(app.handle(), &engine, &session_store, &handles, pending)
+                .await;
+        assert_eq!(result, PendingCommandDispatchOutcome::Accepted);
+
+        let events = read_dispatch_events(&app, &run_id);
+        let submitted = events
+            .iter()
+            .find_map(|event| match event {
+                WorkflowEvent::OutputSubmitted {
+                    node_name,
+                    contract,
+                    request_id,
+                    submitted_at,
+                    ..
+                } if node_name == "review" => Some((
+                    contract.clone(),
+                    request_id.clone(),
+                    *submitted_at,
+                )),
+                _ => None,
+            })
+            .expect("OutputSubmitted event must be appended via dispatcher");
+        assert_eq!(submitted.0, "review-verdict");
+        assert_eq!(submitted.1.as_deref(), Some(pending_id.as_str()));
+        assert_eq!(submitted.2, Some(950.5));
+    }
+
+    /// [08] CLI pending 経由の SubmitOutput が contract 不適合の場合、event は残らず、
+    /// dispatcher は `RejectedFinal` を返す（spec [08] 振る舞い定義 Rule 1 適合しない場合）。
+    #[tokio::test]
+    async fn dispatch_pending_submit_output_rejects_invalid_contract() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir).await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        seed_running_agent(
+            &engine,
+            &run_id,
+            "/wt/pending-dispatcher-submit-invalid",
+            make_submit_output_workflow(),
+        )
+        .await;
+
+        let pending = PendingCommand::new(
+            run_id.clone(),
+            CliRequestPayload::SubmitOutput {
+                step_name: "review".to_string(),
+                contract: "review-verdict".to_string(),
+                structured_output: serde_json::json!({"verdict": "MAYBE"}),
+            },
+            960.0,
+        );
+
+        let result =
+            dispatch_pending_command(app.handle(), &engine, &session_store, &handles, pending)
+                .await;
+        assert!(matches!(
+            result,
+            PendingCommandDispatchOutcome::RejectedFinal(_)
+        ));
+
+        let events = read_dispatch_events(&app, &run_id);
+        assert!(events
+            .iter()
+            .all(|event| !matches!(event, WorkflowEvent::OutputSubmitted { .. })));
     }
 }

--- a/src-tauri/src/workflow/pending_command_dispatcher.rs
+++ b/src-tauri/src/workflow/pending_command_dispatcher.rs
@@ -106,50 +106,58 @@ pub(crate) async fn dispatch_pending_command<R: tauri::Runtime>(
         ..
     } = pending;
 
-    // [08] SubmitOutput は CliMutationRequested 系の commit_context を経由せず、
-    // engine 側で OutputSubmitted event を直接 append する独立トランザクション。
-    if let PendingCommandPayload::SubmitOutput {
-        step_name,
-        contract,
-        structured_output,
-    } = payload
-    {
-        return dispatch_submit_output_pending(
-            app,
-            engine,
-            session_store,
-            &run_id,
-            id,
-            step_name,
-            contract,
-            structured_output,
-            requested_at,
+    let is_submit_output = matches!(&payload, PendingCommandPayload::SubmitOutput { .. });
+
+    // [08] CLI 提出経路と in-process 経路は dispatch_external で合流する。
+    // CLI pending の SubmitOutput は CliMutationRequested を伴わず OutputSubmitted 単体で
+    // 記録されるため commit_context は `SubmitOutput { request_id, submitted_at }` を運ぶ。
+    // 他の CLI mutation（Approve / Reject / Abort）は従来通り `CliPending` を運ぶ。
+    let (commit_context, request_id) = if is_submit_output {
+        // 5-3 修正: SubmitOutput の拒否時にも `CliMutationRejected` を補助履歴として
+        // 残せるよう、step_name と contract を commit_context に保持する。
+        let (step_name, contract) = match &payload {
+            PendingCommandPayload::SubmitOutput {
+                step_name,
+                contract,
+                ..
+            } => (step_name.clone(), contract.clone()),
+            _ => unreachable!("is_submit_output guard guarantees SubmitOutput variant"),
+        };
+        (
+            CommandCommitContext::submit_output(id.clone(), requested_at, step_name, contract),
+            id.clone(),
         )
-        .await;
-    }
-
-    let request = payload_to_cli_request(&payload);
-    let metadata = WorkflowMutationContext::new(
-        run_id.clone(),
-        WorkflowMutationSource::CliPendingCommand { request_id: id },
-        request,
-        requested_at,
-    );
-
+    } else {
+        let request = payload_to_cli_request(&payload);
+        let metadata = WorkflowMutationContext::new(
+            run_id.clone(),
+            WorkflowMutationSource::CliPendingCommand {
+                request_id: id.clone(),
+            },
+            request,
+            requested_at,
+        );
+        (CommandCommitContext::cli_pending(metadata), id.clone())
+    };
     let command = payload_to_workflow_command(payload, run_id.clone());
-    let request_id = metadata.request_id().to_string();
-    match engine.cli_mutation_already_recorded(app, &run_id, &request_id) {
+
+    let already_recorded = if is_submit_output {
+        engine.output_submitted_already_recorded(app, &run_id, &request_id)
+    } else {
+        engine.cli_mutation_already_recorded(app, &run_id, &request_id)
+    };
+    match already_recorded {
         Ok(true) => return PendingCommandDispatchOutcome::Accepted,
         Ok(false) => {}
         Err(e) => return classify_dispatch_error(e),
     }
-    let commit_context = CommandCommitContext::cli_pending(metadata);
 
     if let Err(e) = engine
         .ensure_execution_loaded_for_external(app, session_store, &run_id)
         .await
     {
-        return handle_rejected_dispatch(app, engine, e, commit_context).await;
+        return handle_rejected_dispatch(app, engine, e, commit_context, &run_id, is_submit_output)
+            .await;
     }
 
     match engine
@@ -166,42 +174,10 @@ pub(crate) async fn dispatch_pending_command<R: tauri::Runtime>(
         Ok(other) => PendingCommandDispatchOutcome::RejectedFinal(format!(
             "CLI mutation dispatch returned unexpected result: {other:?}"
         )),
-        Err(e) => handle_rejected_dispatch(app, engine, e, commit_context).await,
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn dispatch_submit_output_pending<R: tauri::Runtime>(
-    app: &tauri::AppHandle<R>,
-    engine: &Arc<WorkflowEngine>,
-    session_store: &Arc<SessionStore>,
-    run_id: &str,
-    request_id: String,
-    step_name: String,
-    contract: String,
-    structured_output: serde_json::Value,
-    requested_at: f64,
-) -> PendingCommandDispatchOutcome {
-    if let Err(e) = engine
-        .ensure_execution_loaded_for_external(app, session_store, run_id)
-        .await
-    {
-        return classify_dispatch_error(e);
-    }
-    match engine
-        .dispatch_submit_output_with_context(
-            app,
-            run_id,
-            step_name,
-            contract,
-            structured_output,
-            Some(request_id),
-            Some(requested_at),
-        )
-        .await
-    {
-        Ok(()) => PendingCommandDispatchOutcome::Accepted,
-        Err(e) => classify_dispatch_error(e),
+        Err(e) => {
+            handle_rejected_dispatch(app, engine, e, commit_context, &run_id, is_submit_output)
+                .await
+        }
     }
 }
 
@@ -210,13 +186,43 @@ async fn handle_rejected_dispatch<R: tauri::Runtime>(
     engine: &WorkflowEngine,
     error: WorkflowEngineError,
     commit_context: CommandCommitContext,
+    run_id: &str,
+    is_submit_output: bool,
 ) -> PendingCommandDispatchOutcome {
     let reason = error.to_string();
-    if WorkflowEngine::should_commit_rejected_external_request(&error) {
+    let should_commit = WorkflowEngine::should_commit_rejected_external_request(&error);
+    // [06] spec [08] Rule 1 維持: SubmitOutput は accepted のメイン履歴
+    // （`OutputSubmitted` / `CliMutationRequested`）に拒否事実を残さない。
+    // 一方、それ以外の CLI mutation（Approve / Reject / Abort）は従来通り
+    // `CliMutationRequested` を記録する。
+    if !is_submit_output && should_commit {
         if let Err(record_error) = engine
-            .append_command_commit_context(app, commit_context)
+            .append_command_commit_context(app, commit_context.clone())
             .await
         {
+            return classify_dispatch_error(record_error);
+        }
+    }
+    // 5-3 / 5-4 修正: 全 mutation 種別について engine 判断による拒否事実を
+    // `CliMutationRejected` event として補助履歴に追記する。spec [08] Rule 1
+    // の意味は「accepted のメイン履歴に出ない」と再定義し、本 event は観測
+    // 経路用の補助履歴として並列に存在する。
+    if should_commit {
+        let append_result = if is_submit_output {
+            engine
+                .append_cli_mutation_rejected_for_submit_output(
+                    app,
+                    run_id,
+                    &commit_context,
+                    &error,
+                )
+                .await
+        } else {
+            engine
+                .append_cli_mutation_rejected(app, &commit_context, &error)
+                .await
+        };
+        if let Err(record_error) = append_result {
             return classify_dispatch_error(record_error);
         }
     }
@@ -253,7 +259,9 @@ fn payload_to_cli_request(payload: &PendingCommandPayload) -> CliMutationRequest
             node_name: node_name.clone(),
         },
         PendingCommandPayload::SubmitOutput { .. } => {
-            unreachable!("SubmitOutput payload must be routed via dispatch_submit_output_pending")
+            unreachable!(
+                "SubmitOutput payload must use CommandCommitContext::SubmitOutput, not CliMutationRequestRecord"
+            )
         }
     }
 }
@@ -744,6 +752,9 @@ mod tests {
 
     /// [08] CLI pending 経由の SubmitOutput が contract 不適合の場合、event は残らず、
     /// dispatcher は `RejectedFinal` を返す（spec [08] 振る舞い定義 Rule 1 適合しない場合）。
+    ///
+    /// 5-3 修正: `OutputSubmitted` / `CliMutationRequested` は引き続き残らないが、
+    /// 観測経路用の補助履歴として `CliMutationRejected` event が追記される。
     #[tokio::test]
     async fn dispatch_pending_submit_output_rejects_invalid_contract() {
         let app = make_dispatch_app();
@@ -769,6 +780,7 @@ mod tests {
             },
             960.0,
         );
+        let pending_id = pending.id.clone();
 
         let result =
             dispatch_pending_command(app.handle(), &engine, &session_store, &handles, pending)
@@ -779,8 +791,153 @@ mod tests {
         ));
 
         let events = read_dispatch_events(&app, &run_id);
+        // accepted のメイン履歴には出ない（spec [08] Rule 1 維持）。
         assert!(events
             .iter()
             .all(|event| !matches!(event, WorkflowEvent::OutputSubmitted { .. })));
+        assert!(events
+            .iter()
+            .all(|event| !matches!(event, WorkflowEvent::CliMutationRequested { .. })));
+        // 5-3 修正: 補助履歴として CliMutationRejected が追記される。
+        let rejected = events
+            .iter()
+            .find_map(|event| match event {
+                WorkflowEvent::CliMutationRejected {
+                    request,
+                    request_id,
+                    requested_at,
+                    ..
+                } => Some((request.clone(), request_id.clone(), *requested_at)),
+                _ => None,
+            })
+            .expect("CliMutationRejected event must be appended for rejected submit");
+        assert_eq!(rejected.1, pending_id);
+        assert!((rejected.2 - 960.0).abs() < f64::EPSILON);
+        match rejected.0 {
+            CliMutationRequestRecord::SubmitOutput {
+                step_name,
+                contract,
+            } => {
+                assert_eq!(step_name, "review");
+                assert_eq!(contract, "review-verdict");
+            }
+            other => panic!("expected SubmitOutput request record, got: {other:?}"),
+        }
+    }
+
+    /// 5-4 修正: reject rule の無い approval node への reject は engine 側で
+    /// `InvalidState` として拒否される。dispatcher は `CliMutationRequested`
+    /// （リクエスト受領事実）に加え、`CliMutationRejected{reason: no_reject_rule}`
+    /// を補助履歴として追記する。`ApprovalResolved` は記録されない。
+    #[tokio::test]
+    async fn dispatch_pending_reject_without_rule_records_cli_mutation_rejected() {
+        use crate::workflow::event::CliMutationRejectionReason;
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowEngine::new_for_test());
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir).await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        // reject rule を持たない approval-only workflow を使う。
+        seed_waiting_approval(
+            &engine,
+            &run_id,
+            "/wt/pending-dispatcher-reject-without-rule",
+            make_approval_only_workflow(),
+        )
+        .await;
+
+        let pending = PendingCommand::new(
+            run_id.clone(),
+            CliRequestPayload::Reject {
+                node_name: None,
+                reason: "engine 側に reject rule が無い node を拒否".to_string(),
+            },
+            970.0,
+        );
+
+        let result =
+            dispatch_pending_command(app.handle(), &engine, &session_store, &handles, pending)
+                .await;
+        assert!(matches!(
+            result,
+            PendingCommandDispatchOutcome::RejectedFinal(_)
+        ));
+
+        let events = read_dispatch_events(&app, &run_id);
+        // ApprovalResolved は出ない（state 変化が起きていないため）。
+        assert!(events
+            .iter()
+            .all(|event| !matches!(event, WorkflowEvent::ApprovalResolved { .. })));
+        // CliMutationRequested は引き続き記録される（リクエスト受領事実）。
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, WorkflowEvent::CliMutationRequested { .. })));
+        // 5-4 修正: CliMutationRejected{reason: no_reject_rule} が補助履歴として追記される。
+        let reason = events
+            .iter()
+            .find_map(|event| match event {
+                WorkflowEvent::CliMutationRejected { reason, .. } => Some(*reason),
+                _ => None,
+            })
+            .expect("CliMutationRejected event must be appended for no-reject-rule path");
+        assert!(matches!(reason, CliMutationRejectionReason::NoRejectRule));
+    }
+
+    /// 5-3 / 5-4 修正: `classify_rejection_reason` は engine error の典型的な
+    /// メッセージから `CliMutationRejectionReason` を導出する。
+    #[test]
+    fn classify_rejection_reason_maps_known_errors() {
+        use crate::workflow::event::CliMutationRejectionReason as R;
+        let cases: Vec<(WorkflowEngineError, R)> = vec![
+            (
+                WorkflowEngineError::ExecutionNotFound("run".to_string()),
+                R::RunNotFound,
+            ),
+            (
+                WorkflowEngineError::UnauthorizedApprovalTarget("target".to_string()),
+                R::NotWaitingApproval,
+            ),
+            (
+                WorkflowEngineError::ValidationError(
+                    "contract mismatch: step 'r' expects 'a', got 'b'".to_string(),
+                ),
+                R::ContractMismatch,
+            ),
+            (
+                WorkflowEngineError::ValidationError(
+                    "step 'r' is not a valid submission target".to_string(),
+                ),
+                R::NodeNotFound,
+            ),
+            (
+                WorkflowEngineError::InvalidState("Step 'r' does not allow reject".to_string()),
+                R::NoRejectRule,
+            ),
+            (
+                WorkflowEngineError::InvalidState(
+                    "step 'r' is not currently accepting structured output".to_string(),
+                ),
+                R::StepNotAccepting,
+            ),
+            (
+                WorkflowEngineError::InvalidState("run x is already terminal".to_string()),
+                R::RunNotActive,
+            ),
+            (
+                WorkflowEngineError::InvalidState(
+                    "run x is not accepting structured output (state: Completed)".to_string(),
+                ),
+                R::RunNotActive,
+            ),
+            (
+                WorkflowEngineError::InvalidState("something else".to_string()),
+                R::Other,
+            ),
+        ];
+        for (err, expected) in cases {
+            let got = WorkflowEngine::classify_rejection_reason(&err);
+            assert_eq!(got, expected, "unexpected reason for error: {err}");
+        }
     }
 }

--- a/src-tauri/src/workflow/route_context.rs
+++ b/src-tauri/src/workflow/route_context.rs
@@ -38,12 +38,6 @@ impl WorkflowMutationContext {
         &self.run_id
     }
 
-    pub(crate) fn request_id(&self) -> &str {
-        match &self.source {
-            WorkflowMutationSource::CliPendingCommand { request_id } => request_id,
-        }
-    }
-
     /// `WorkflowEvent::CliMutationRequested` 構築時に所有を `run_id` /
     /// `request` ごと engine 側へ移譲するための分解関数。
     pub(crate) fn into_event_parts(self) -> (String, CliMutationRequestRecord, f64, String) {
@@ -59,21 +53,93 @@ pub(crate) enum WorkflowMutationSource {
     CliPendingCommand { request_id: String },
 }
 
+/// dispatch_external 経由で渡される commit metadata。
+///
+/// `CliPending` は CliMutationRequested を伴う Approve / Reject / Abort 系の文脈。
+/// `SubmitOutput` は OutputSubmitted 単体で記録される [08] structured output 提出系で、
+/// CliMutationRequested は emit しない（spec [08] 振る舞い定義 Rule 1 / Rule 4:
+/// SubmitOutput 単独で `request_id` / `submitted_at` を伴う OutputSubmitted を記録）。
+///
+/// 5-3 / 5-4 修正: いずれの variant も engine 拒否時に `CliMutationRejected` event
+/// を補助履歴として記録する。SubmitOutput variant は payload 本体を持たないが、
+/// `step_name` と `contract` を保持して rejected event の `request` フィールドを
+/// 構築できるようにする（payload 全体は容量肥大を避けるため含めない）。
 #[derive(Debug, Clone)]
-pub(crate) struct CommandCommitContext {
-    mutation: WorkflowMutationContext,
+pub(crate) enum CommandCommitContext {
+    CliPending {
+        mutation: WorkflowMutationContext,
+    },
+    SubmitOutput {
+        request_id: String,
+        submitted_at: f64,
+        step_name: String,
+        contract: String,
+    },
 }
 
 impl CommandCommitContext {
     pub(crate) fn cli_pending(mutation: WorkflowMutationContext) -> Self {
-        Self { mutation }
+        Self::CliPending { mutation }
     }
 
-    pub(crate) fn mutation(&self) -> &WorkflowMutationContext {
-        &self.mutation
+    pub(crate) fn submit_output(
+        request_id: String,
+        submitted_at: f64,
+        step_name: String,
+        contract: String,
+    ) -> Self {
+        Self::SubmitOutput {
+            request_id,
+            submitted_at,
+            step_name,
+            contract,
+        }
     }
 
-    pub(crate) fn into_mutation(self) -> WorkflowMutationContext {
-        self.mutation
+    /// `CliPending` バリアントに含まれる `WorkflowMutationContext` への参照を返す。
+    /// `SubmitOutput` バリアントには CliMutationRequested 用の mutation context は無い。
+    pub(crate) fn cli_pending_mutation(&self) -> Option<&WorkflowMutationContext> {
+        match self {
+            Self::CliPending { mutation } => Some(mutation),
+            Self::SubmitOutput { .. } => None,
+        }
+    }
+
+    pub(crate) fn into_cli_pending_mutation(self) -> Option<WorkflowMutationContext> {
+        match self {
+            Self::CliPending { mutation } => Some(mutation),
+            Self::SubmitOutput { .. } => None,
+        }
+    }
+
+    /// SubmitOutput context の `(request_id, submitted_at)` を取り出す。
+    pub(crate) fn submit_output_metadata(&self) -> Option<(String, f64)> {
+        match self {
+            Self::SubmitOutput {
+                request_id,
+                submitted_at,
+                ..
+            } => Some((request_id.clone(), *submitted_at)),
+            Self::CliPending { .. } => None,
+        }
+    }
+
+    /// SubmitOutput context から CliMutationRejected event 用の構成要素を取り出す。
+    /// `(request_id, requested_at, step_name, contract)` を返す（5-3 修正）。
+    pub(crate) fn submit_output_rejection_parts(&self) -> Option<(String, f64, String, String)> {
+        match self {
+            Self::SubmitOutput {
+                request_id,
+                submitted_at,
+                step_name,
+                contract,
+            } => Some((
+                request_id.clone(),
+                *submitted_at,
+                step_name.clone(),
+                contract.clone(),
+            )),
+            Self::CliPending { .. } => None,
+        }
     }
 }


### PR DESCRIPTION
## Summary

- step agent の自由文 `<workflow_output>` プロース抽出経路を廃止し、`run_id` を主語とした typed CLI/API 経由で structured output を engine に提出できるようにする
- `releash workflow output submit / validate / get` の 3 CLI コマンドを追加し、`SubmitOutput` typed command と `OutputSubmitted` event を engine event 語彙に組み込む
- contract 不適合な提出や存在しない step への参照などの拒否を observability 用の補助履歴として記録、CLI 入口で `run_id` の実在を提出前に検証

関連: GitHub Issue #1029 / マイルストーン [08]

## Phase 構成

- Phase 1/2: `SubmitOutput` typed command と `OutputSubmitted` event を導入
- Phase 3: structured output 提出の CLI/Tauri 入口を追加
- Phase 4: prose 抽出経路を engine と contract から完全廃止
- Phase 5: built-in instruction を CLI 提出前提に書き換え
- Phase 6: cargo fmt / clippy -D warnings 適用
- Phase 7: 拒否を補助履歴として観測可能化し CLI 入口で run 実在を検証

## Test plan

- [ ] \`cd src-tauri && cargo fmt --check\`
- [ ] \`cd src-tauri && cargo clippy -- -D warnings\`
- [ ] \`cd src-tauri && cargo test\`
- [ ] \`pnpm lint\`
- [ ] \`pnpm test\`
- [ ] \`pnpm build\`
- [ ] \`releash workflow output submit / validate / get\` の手動動作確認（contract 適合・不適合・存在しない run_id / step）
- [ ] built-in workflow（spec-driven-development.yml 等）の step agent が CLI 提出経路で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ワークフロー出力提出機能を追加。`releash workflow output` サブコマンド（submit/validate/get）により、構造化出力の提出、検証、取得が可能に。

* **Bug Fixes**
  * ワークフローエンジンの出力処理をプロース抽出から型付きCLI/API経由に切り替え。契約検証とエラー処理を決定論的に改善。

* **Documentation**
  * 複数のワークフロー手順ドキュメントを更新。新しい出力提出方式の使用方法と完了条件を明記。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/1038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->