### PR TITLE
feat: dev/prod CLI alias と workflow 変数で facet 展開を環境対応

### DIFF
--- a/docs/specs/issues-1054/behavior.md
+++ b/docs/specs/issues-1054/behavior.md
@@ -1,0 +1,86 @@
+# Behavior
+
+## Source
+- requirements.md
+
+## Behavior
+
+```gherkin
+Feature: 環境別 CLI alias と workflow 変数による facet 展開
+
+  Rule: 起動環境に応じた CLI alias の解決
+    Scenario: 本番起動の agent は releash を受け取る
+      Given Releash が本番ビルドで起動している
+      When agent が facet 経由で CLI コマンドの提示を受ける
+      Then 提示されるコマンドは `releash workflow ...` 形式である
+
+    Scenario: dev 起動の agent は releash-dev を受け取る
+      Given Releash が dev ビルドで起動している
+      When agent が facet 経由で CLI コマンドの提示を受ける
+      Then 提示されるコマンドは `releash-dev workflow ...` 形式である
+
+  Rule: dev 起動による本番 CLI の不変性
+    Scenario: dev 起動しても本番 CLI 実体は維持される
+      Given 本番 CLI が既にシステムにインストールされている
+      When Releash を dev ビルドで起動する
+      Then 本番 CLI は dev 起動後も本番用 CLI として解決・動作し続ける
+
+  Rule: CLI alias と実行対象の一意な対応
+    Scenario: dev alias は dev データ領域に紐づく
+      Given Releash が dev ビルドで起動している
+      When agent が `releash-dev` 経由で workflow の状態参照コマンドを実行する
+      Then 参照される workflow 状態は dev データ領域のものである
+
+    Scenario: 本番 alias は本番データ領域に紐づく
+      Given Releash が本番ビルドで起動している
+      When agent が `releash` 経由で workflow の状態参照コマンドを実行する
+      Then 参照される workflow 状態は本番データ領域のものである
+
+    Scenario: 子プロセス側の明示指定が alias 内包値より優先される
+      Given Releash が dev ビルドで起動している
+      And 子プロセスが RELEASH_DATA_DIR を明示指定して起動される
+      When その子プロセス内で workflow の状態参照コマンドを実行する
+      Then 参照される workflow 状態は明示指定されたデータ領域のものである
+
+  Rule: agent 子プロセスへの実行環境の伝搬
+    Scenario: agent が起動する子プロセスは起動環境の alias を解決できる
+      Given Releash が特定のビルド種別で起動している
+      When agent がコマンド実行用の子プロセスを起動する
+      Then 子プロセスはその環境に対応する CLI alias とデータ領域を解決できる
+
+  Rule: facet テンプレートにおける CLI alias の展開
+    Scenario: 本番環境では {{path_alias.releash}} が releash に展開される
+      Given Releash が本番ビルドで起動している
+      And facet 本文に {{path_alias.releash}} が含まれている
+      When facet 本文が agent 向けに展開される
+      Then 該当部分は `releash` に置き換えられる
+
+    Scenario: dev 環境では {{path_alias.releash}} が releash-dev に展開される
+      Given Releash が dev ビルドで起動している
+      And facet 本文に {{path_alias.releash}} が含まれている
+      When facet 本文が agent 向けに展開される
+      Then 該当部分は `releash-dev` に置き換えられる
+
+    Scenario: built-in prompt 内の固定 releash 表記も環境別 alias に展開される
+      Given built-in prompt 内で従来固定で `releash` を出していたコマンド表記が含まれている
+      When built-in prompt が agent 向けに展開される
+      Then 本番起動では `releash`、dev 起動では `releash-dev` として agent に提示される
+
+  Rule: workflow 定義変数の facet 展開
+    Scenario: workflow が宣言した変数は {{vars.<name>}} で facet から参照できる
+      Given workflow 定義が変数 `<name>` を宣言している
+      And facet 本文に {{vars.<name>}} が含まれている
+      When facet 本文が agent 向けに展開される
+      Then 該当部分は workflow 定義側で宣言された値に置き換えられる
+
+    Scenario: 未定義の {{vars.<name>}} を参照する workflow は拒否される
+      Given workflow 定義に存在しない `<name>` を facet 本文が {{vars.<name>}} として参照している
+      When その workflow を読み込みまたは保存または展開しようとする
+      Then 未定義変数参照として明示的なエラーが提示される
+
+  Rule: 既存プレースホルダの互換性
+    Scenario: {{project_name}} / {{task}} の展開結果は変更前と等価である
+      Given facet 本文に {{project_name}} や {{task}} などの既存プレースホルダのみが含まれている
+      When facet 本文が agent 向けに展開される
+      Then 展開結果は本変更前と等価である
+```

--- a/docs/specs/issues-1054/design.md
+++ b/docs/specs/issues-1054/design.md
@@ -1,0 +1,105 @@
+# Design
+
+## Behavior Coverage
+
+| Rule | 設計方針 |
+| --- | --- |
+| 起動環境に応じた CLI alias の解決 | 起動環境（dev / 本番）から一意に決まる `PathAliases` を構築し、facet 展開・子プロセス起動の双方に同じ alias を供給する。 |
+| dev 起動による本番 CLI の不変性 | CLI install は本番 binary のときのみ `/usr/local/bin/releash` を更新する。dev binary は本番 CLI 名を所有せず、別 alias の install 経路に閉じる。 |
+| CLI alias と実行対象の一意な対応 | `PathAliases` は alias 名・実行 binary・データディレクトリの三者を組として保持し、alias を解決した時点で実行対象とデータ領域が確定する。 |
+| agent 子プロセスへの実行環境の伝搬 | PTY / oneshot / agent bridge のいずれも、共通の子プロセス環境ビルダーを通して alias 解決可能な `PATH` と環境別 `RELEASH_DATA_DIR` を載せる。 |
+| facet テンプレートにおける CLI alias の展開 | facet 展開エンジンに `path_alias` namespace を追加し、`{{path_alias.releash}}` を起動環境の CLI alias に展開する。 |
+| workflow 定義変数の facet 展開 | workflow 定義に変数宣言領域を追加し、facet 展開エンジンが `{{vars.<name>}}` を namespace 経由で解決する。 |
+| 未定義 workflow 変数の拒否 | workflow 読み込み時を一次境界として未定義 `vars.*` を明示的なエラーにする。保存時・展開時での重複検出は許容する。 |
+| 既存プレースホルダの互換性 | 既存プレースホルダの展開は変更前と同一の名前空間・同一の解決経路に残し、新規 namespace と分離する。 |
+
+## Key Decisions
+
+- **CLI alias を「名前空間」として扱う**: 単なる文字列定数ではなく、`PathAlias` という解決単位（alias 名 + 実行 binary + 内包データ領域）として定義する。これによりテンプレート展開と子プロセス起動が同じソースから値を引ける。
+- **dev alias は wrapper として扱う**: dev binary を本番 CLI 名にぶら下げる方式（symlink 上書き）ではなく、dev alias 自身が dev データ領域を内包する独立した実行対象として扱う。本番 CLI install 経路と dev alias install 経路を完全に分離する。
+  - 代替案: dev 起動時に `/usr/local/bin/releash` を dev binary に張り替え、`RELEASH_DATA_DIR` だけで切り分ける。→ 本番 CLI 破壊リスクと利用者の明示指定との競合があるため不採用。
+- **テンプレート展開は namespace 制**: `{{path_alias.<name>}}` と `{{vars.<name>}}` を namespace 付きで導入する。既存の `{{project_name}}` / `{{task}}` はトップレベル namespace として残し、衝突しない。
+  - 代替案: workflow 変数を既存のフラット namespace に同居させる。→ システム定義名との衝突や上書き事故を防げないため不採用。
+- **未定義変数はエラー**: 黙って空文字に展開せず、検出した境界でエラーとする。`{{path_alias.<name>}}` は起動環境が確定すれば必ず解決可能なので、検出対象は主に `{{vars.<name>}}` および typo した namespace。
+- **`RELEASH_DATA_DIR` 解決順序**: 明示指定 > alias 内包値 > プロセス既定。利用者の明示指定を奪わない。
+- **path_alias は当面 `releash` キーに限定**: 公開する alias は `releash` のみとし、将来拡張は名前空間構造で吸収できる形にとどめる（一般化は今回スコープ外）。
+
+## Responsibility Boundaries
+
+- **PathAliases（バックエンド）**
+  - 起動環境から CLI alias 名・実行 binary・データディレクトリを決定する単一のソース。
+  - facet 展開・子プロセス環境ビルダーに同一の値を提供する。
+- **CLI install 経路（バックエンド）**
+  - 本番 binary 起動時のみ本番 alias を所有する。dev binary は本番 alias install 経路に関与しない。
+- **子プロセス環境ビルダー（バックエンド）**
+  - PTY / oneshot / agent bridge いずれの起動経路にも、PathAliases から導いた `PATH` と `RELEASH_DATA_DIR` を載せる責務。
+- **Workflow 定義（schema / storage）**
+  - 変数宣言を保持・配布する。値の意味は workflow 作成者に委ねる。
+- **Facet 展開エンジン**
+  - namespace ごとの解決元（path_alias / vars / 既存プレースホルダ）を統合して展開する。
+  - 未定義参照を検出する。
+- **Agent / フロントエンド**
+  - alias 名や `RELEASH_DATA_DIR` を自力で組み立てない。展開済み facet と環境変数の入った子プロセスを受け取るだけ。
+
+## Contracts
+
+- **`{{path_alias.releash}}`**
+  - 本番起動時は literal `releash` に展開される。
+  - dev 起動時は literal `releash-dev` に展開される。
+  - facet 本文・built-in prompt の双方で同じ意味を持つ。
+- **`{{vars.<name>}}`**
+  - workflow 定義側で宣言された名前→値の組から解決される。
+  - 値は静的文字列のみとし、動的解決値を含まない。
+  - 未定義の `<name>` を参照する facet は workflow 読み込み時に一次検出され、明示的なエラーとなる。保存時・展開時での重複検出は許容する。
+- **既存プレースホルダ（`{{project_name}}` / `{{task}}` 等）**
+  - 展開結果は本変更前と等価。
+- **workflow 定義における変数宣言**
+  - workflow 定義ファイルに facet 展開用の変数群（名前→静的文字列値）を宣言できる。
+- **CLI alias と実行対象の対応**
+  - 本番 alias の CLI 呼び出しは本番データ領域を参照する。
+  - dev alias の CLI 呼び出しは、呼び出し側が `RELEASH_DATA_DIR` を明示しない限り dev データ領域を参照する。
+- **子プロセスの実行環境**
+  - 起動環境に対応する CLI alias が `PATH` 経由で解決可能。
+  - 起動環境に対応する `RELEASH_DATA_DIR` が設定される（明示指定がある場合はそちらが優先）。
+- **本番 CLI install**
+  - 本番 binary 起動時のみ `/usr/local/bin/releash` を更新する。dev 起動はこのパスへ書き込まない。
+
+## Data / Communication Flow
+
+- **起動 → PathAliases 確定**
+  - アプリ起動時に、ビルド種別から `PathAliases`（本番 alias セット or dev alias セット）が一意に確定する。
+- **PathAliases → 子プロセス起動経路**
+  - PTY / oneshot / agent bridge の起動コードは、PathAliases を参照して `PATH` と `RELEASH_DATA_DIR` を子プロセス env に積む。
+- **PathAliases + workflow 定義 → facet 展開エンジン**
+  - facet 展開時、展開エンジンは PathAliases（`path_alias.*` の解決元）と workflow 定義の変数宣言（`vars.*` の解決元）の両方を受け取り、namespace ごとに解決する。
+- **agent ← facet 展開結果**
+  - agent には既に展開済みの facet 本文が渡る。alias 名や変数値を agent 側で組み立てない。
+
+## State Ownership
+
+- **CLI alias 名・実行 binary・内包データ領域**: `PathAliases`（バックエンドの起動時確定値）。
+- **workflow 変数の宣言値**: workflow 定義（ストレージ上の workflow ファイル）。
+- **実行時に積み上がる workflow 実行変数**: 既存の workflow engine（execution 状態）。本タスクで導入する宣言型変数とは別領域として並存する。
+- **`/usr/local/bin/releash` の指す実体**: 本番 binary の install 経路のみが所有。dev binary は所有しない。
+- **`RELEASH_DATA_DIR` の最終値**: 子プロセスの環境変数として確定。決定順序は契約に記載のとおり。
+
+## Boundaries
+
+- フロントエンドは alias 文字列・CLI コマンド文字列・データディレクトリパスを自前で組み立てない。
+- agent は facet 本文の文字列置換を行わない。展開済み本文だけを受け取る。
+- facet 展開エンジンは workflow execution 状態（実行時変数）の意味づけに踏み込まない。`vars.*` namespace は宣言型変数の解決にのみ使う。
+- CLI install 経路は dev binary を本番 alias の所有者にしない。dev 起動が本番 alias の実体を書き換える経路は存在させない。
+- `RELEASH_DATA_DIR` の利用者明示指定は alias 内包値で上書きしない。
+- 既存プレースホルダ namespace と新規 namespace（`path_alias` / `vars`）は同一キーで衝突させない。
+- 本タスクの範囲は `path_alias.releash` のみ。任意の alias 種別の公開・一般化はスコープ外。
+
+## Implementation Freedom
+
+- `PathAliases` の具体的な型表現（struct 構成、`HashMap` か固定フィールドか等）。
+- facet 展開エンジン内部での namespace 解決の合成方法（事前マージ vs 名前空間別ルックアップ）。
+- 未定義変数エラー検出の一次境界は workflow 読み込み時で確定。保存時・展開時で重複検出を行うかは実装自由。
+- workflow 定義ファイルにおける変数宣言の表記（フィールド名・位置・YAML 構造）。
+- dev alias binary の物理配置（resource bundle 内 / 別パス）と、`PATH` への追加方法。
+- 子プロセス環境ビルダーの実装単位（共通 helper として切り出すか、各起動経路に同等のロジックを持たせるか）。
+- `RELEASH_DATA_DIR` の明示指定検出方法（env 直読み / 起動コンテキスト経由）。
+- facet 展開エンジン内における namespace 対応の API 形（既存 helper の拡張か新規導入か含む）。

--- a/docs/specs/issues-1054/requirements.md
+++ b/docs/specs/issues-1054/requirements.md
@@ -1,0 +1,95 @@
+# Requirements
+
+## Type
+
+新機能 / 改善
+
+## Goal
+
+dev 起動の Releash でも、workflow facet 経由で agent に渡される CLI コマンドが dev 側 (`releash-dev` / dev data dir) を確実に指すようにし、かつ facet 本文から workflow 定義由来の変数 (`{{vars.<name>}}`) を参照できるようにする。
+
+完了時には、dev 起動した Releash 内の agent が facet から受け取る CLI コマンドが `releash-dev workflow ...` となり、本番起動した Releash 内の agent が受け取る CLI コマンドが `releash workflow ...` のままで、いずれの環境でも `workflow output submit` 等の動作テストが意図したデータディレクトリ側で完結する。あわせて、workflow 定義で宣言した変数を facet 本文に埋め込んで agent に渡せる。
+
+## Background
+
+現状の Releash には dev / 本番起動の CLI 取り扱いに以下の課題がある。
+
+- macOS 起動時の CLI install が `current_exe()` を `/usr/local/bin/releash` に張るため、dev 起動でも本番 CLI 名 `releash` が debug binary を指してしまい、本番 CLI を壊す。
+- Releash CLI の default data dir は `com.releash.app` 固定であり、dev app が `com.releash.app.dev` を使っていても、facet が agent に渡す `releash workflow output submit ...` 系コマンドが本番側データを参照しうる。
+- 結果として、dev 環境で workflow の `output submit` / `approve` / `reject` などを agent 経由で実動作テストしづらく、検証のたびに本番状態を汚染する懸念がある。
+
+また facet 本文には現状 `{{project_name}}` / `{{task}}` といった限られたプレースホルダしか展開されず、workflow 定義側で宣言した値を facet から再利用する手段がない。テンプレートに埋め込みたい固有値 (CLI 名や workflow 固有の用語など) を workflow 側で集中管理できない。
+
+これらを解消するため、CLI 名を環境ごとに切り替え可能な抽象（PathAlias）として扱い、facet 本文側からその alias と workflow 変数を共通の置換規則で参照できるようにする。
+
+## Users / Actors
+
+- Releash を dev ビルドで起動して機能検証する開発者
+- Releash を本番ビルドで利用するエンドユーザー
+- Releash 内で workflow を進行する AgentChat / agent backend
+- facet を起点に CLI コマンドを実行する agent
+- workflow を定義・編集する作成者（YAML 等で `variables` を宣言する側）
+
+## Scope
+
+- dev 起動 / 本番起動で CLI alias を切り替える仕組み（`releash` / `releash-dev`）を導入する。
+- dev alias は単なる debug binary への symlink ではなく、dev データディレクトリを内包した wrapper として振る舞う。
+- 本番起動時の CLI install (`/usr/local/bin/releash`) が dev 起動によって debug binary へ張り替わらないようにする。
+- agent や facet が起動する子プロセス（PTY / oneshot / agent bridge）に対し、実行環境に応じた alias が解決可能な `PATH` と、実行環境に応じた `RELEASH_DATA_DIR` を伝搬する。
+- facet 本文・built-in prompt 内で固定文字列 `releash` を使っている箇所を、環境に応じて展開される `{{path_alias.releash}}` 経由に置き換える。
+- workflow 定義に facet 展開用の `variables`（名前→静的文字列値）を workflow 全体共通のスコープで持てるようにする。
+- facet 本文から `{{vars.<name>}}` で workflow 定義側の変数を参照できるようにする。
+- 未定義の `{{vars.<name>}}` 参照を明示的なエラーとして検出する。
+- 既存の `{{project_name}}` / `{{task}}` などのプレースホルダは互換維持する。
+
+## Non-goals
+
+- 既存 workflow の意味そのものを変えること。
+- AgentChat の権限モデルや承認 UI の変更。
+- 本番 / dev 以外の任意の追加 build profile（staging 等）の新設。
+- CLI コマンド体系そのものの再設計（`workflow output submit` 等のサブコマンドの追加・改名）。
+- `releash-dev` の Windows / Linux 向けインストール導線の整備（今回は macOS の起動時挙動の修正範囲に留める）。
+- `path_alias.releash` 以外の任意の alias 種別を一般化して公開すること。
+- facet 内テンプレート言語の本格的な拡張（条件分岐・ループ等の導入）。
+- 旧プレースホルダ (`{{project_name}}` / `{{task}}`) の廃止や改名。
+- workflow 定義側の `variables` を step / facet 単位で上書きできるようにすること（今回は workflow 全体共通のみ）。
+- `{{vars.<name>}}` の値として動的解決値（環境変数・実行時情報等）を扱うこと（今回は静的文字列のみ）。
+
+## Requirements
+
+- 本番起動時、agent から見える CLI alias は `releash` として解決できること。
+- dev 起動時、agent から見える CLI alias は `releash-dev` として解決できること。
+- dev 起動時、`/usr/local/bin/releash` が debug binary に張り替えられないこと。
+- `releash-dev` は dev データディレクトリ (`com.releash.app.dev` 相当) を内包しており、呼び出し側が `RELEASH_DATA_DIR` を明示しなくても dev 側データを参照すること。
+- agent が起動する PTY・oneshot・agent bridge では、実行環境に応じた alias を解決できる `PATH` と、実行環境に応じた `RELEASH_DATA_DIR` が設定されること。
+- 本番環境では `{{path_alias.releash}}` が `releash` に展開されること。
+- dev 環境では `{{path_alias.releash}}` が `releash-dev` に展開されること。
+- facet 本文・built-in prompt 内で従来固定で `releash` を出していたコマンド表記は、`{{path_alias.releash}}` 経由で展開されること。
+- workflow 定義は facet 展開用の変数群（名前→静的文字列値）を workflow 全体共通スコープで宣言できること。
+- facet 本文から `{{vars.<name>}}` で workflow 定義側の変数（静的文字列値）を参照できること。
+- 未定義の `{{vars.<name>}}` 参照は workflow 読み込み時に一次検出され、明示的なエラーとして提示されること（保存時・展開時での重複検出は許容する）。
+- 既存プレースホルダ (`{{project_name}}` / `{{task}}` 等) の展開結果が従来と変わらないこと。
+- 本番アプリ内 agent が facet から受け取る `workflow output submit` 系コマンドは `releash workflow output submit ...` 形式のままであること。
+- dev アプリ内 agent が facet から受け取る `workflow output submit` 系コマンドは `releash-dev workflow output submit ...` 形式となること。
+- `releash-dev workflow runs` 等の dev alias 経由の CLI 操作が dev データディレクトリを参照すること。
+
+## Constraints
+
+- dev 起動による副作用で本番 CLI (`/usr/local/bin/releash` が指す実体) が破壊されないこと。
+- dev / 本番のいずれの環境でも、agent から見える CLI alias と実際の実行対象（バイナリ・データディレクトリ）の対応が一意であること。
+- facet テンプレートの未定義参照を黙って空文字に展開しないこと（権限や宛先がずれる事故を防ぐため）。
+- workflow 定義側の変数名と既存プレースホルダ（`project_name` / `task` 等）が衝突して既存挙動を変えないこと。
+- dev / 本番で同じ facet 文面が異なる CLI コマンドへ安全に展開できること。
+- `RELEASH_DATA_DIR` の解決順序が、明示指定 > alias 内包値 > プロセス既定 となり、利用者の明示指定を奪わないこと。
+- `{{vars.<name>}}` の値は静的文字列のみとし、環境変数・実行時情報などの動的解決値を含まないこと。
+
+## Success Criteria
+
+- dev 起動を行っても `/usr/local/bin/releash` が debug binary に張り替わらない。
+- dev app 内の agent が facet から受け取る CLI コマンドが `releash-dev workflow output submit ...` 形式になっている。
+- `releash-dev workflow runs` 等の dev alias 経由 CLI が dev データディレクトリを参照する。
+- 本番 app 内の agent が facet から受け取る CLI コマンドが `releash workflow output submit ...` 形式のままである。
+- workflow YAML（または同等の定義）に宣言した `variables` を facet 本文から `{{vars.<name>}}` で参照でき、展開結果に反映される。
+- 未定義の `{{vars.<name>}}` を含む workflow を読み込んだ時点で明示的なエラーとして通知される。
+- 既存の `{{project_name}}` / `{{task}}` を使った facet の展開結果が、本変更前と等価である。
+

--- a/src-tauri/src/backends/bridge_common.rs
+++ b/src-tauri/src/backends/bridge_common.rs
@@ -1916,6 +1916,24 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped());
 
+    // spec issues-1054: agent bridge にも起動環境別 alias が解決可能な PATH と
+    // `RELEASH_DATA_DIR` を伝搬する（bridge 経由で呼ばれるツールが alias を解決できるように）。
+    match crate::path_aliases::prepare_child_env(app.path().app_data_dir().ok()) {
+        Ok(env) => {
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+        }
+        Err(e) => {
+            // 提示する alias と実行環境の不整合を避けるため、wrapper 作成失敗時は
+            // bridge 起動を中止する（spec issues-1054「agent 子プロセスへの実行
+            // 環境の伝搬」: PATH 経由で alias 解決可能な環境を約束する）。
+            return Err(format!(
+                "failed to prepare alias child env for agent bridge: {e}"
+            ));
+        }
+    }
+
     #[cfg(unix)]
     // SAFETY: setsid() is async-signal-safe per POSIX.
     unsafe {
@@ -6268,6 +6286,7 @@ mod tests {
             step_history: Vec::new(),
             step_execution_counts: HashMap::new(),
             workflow_definition: crate::workflow::schema::Workflow {
+                variables: Default::default(),
                 name: "wf".to_string(),
                 description: String::new(),
                 builtin: false,

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -295,12 +295,26 @@ impl From<String> for CliError {
 ///
 /// Tauri 側 `AppHandle::path().app_data_dir()` と同等のパスを CLI 側で計算する。
 /// CLI 起動独立性境界: デスクトップアプリ非稼働でも動作する。
+///
+/// 解決順序（spec [01]「解決順序: 明示指定 > alias 内包値 > プロセス既定」）:
+/// 1. `RELEASH_DATA_DIR` の明示指定
+/// 2. `PathAliases` から決まる alias 内包の data_dir。`PathAliases` が CLI alias 名・
+///    実行 binary・data dir の単一所有者として dev / 本番 を切り分けるため、CLI 側で
+///    `cfg!(debug_assertions)` を再実装しない
 fn resolve_data_dir() -> Result<PathBuf, String> {
-    if let Ok(custom) = std::env::var("RELEASH_DATA_DIR") {
+    resolve_data_dir_from_env(std::env::var("RELEASH_DATA_DIR").ok())
+}
+
+/// `resolve_data_dir` の pure 版（env を入力で受ける）。
+///
+/// spec [01] 解決順序「明示指定 > alias 内包値」をテストで検証可能にするための分離。
+/// 明示指定が空文字列の場合は未設定扱いとし、alias 内包値にフォールバックする。
+fn resolve_data_dir_from_env(env_value: Option<String>) -> Result<PathBuf, String> {
+    if let Some(custom) = env_value.filter(|s| !s.is_empty()) {
         return Ok(PathBuf::from(custom));
     }
-    let base = dirs::data_dir().ok_or_else(|| "Cannot resolve OS data_dir".to_string())?;
-    Ok(base.join("com.releash.app"))
+    let aliases = crate::path_aliases::PathAliases::from_runtime(None)?;
+    Ok(aliases.releash().data_dir.clone())
 }
 
 /// data_dir を解決し、パスが実在することを確認する。
@@ -1086,6 +1100,7 @@ mod tests {
             workflow_file_stem: workflow_name.to_string(),
             worktree_path: worktree.to_string(),
             workflow_definition: crate::workflow::schema::Workflow {
+                variables: Default::default(),
                 name: workflow_name.to_string(),
                 description: "test".to_string(),
                 builtin: false,
@@ -1309,6 +1324,7 @@ mod tests {
             .await;
 
         let workflow = Workflow {
+            variables: Default::default(),
             name: "engine-cli-list".to_string(),
             description: String::new(),
             builtin: false,
@@ -1639,6 +1655,7 @@ mod tests {
         contract: &str,
     ) {
         let workflow = crate::workflow::schema::Workflow {
+            variables: Default::default(),
             name: "wf".to_string(),
             description: String::new(),
             builtin: false,
@@ -1883,6 +1900,7 @@ mod tests {
         let run_id = test_uuid(95);
         // RunStarted event に workflow definition を埋め込む
         let yaml = crate::workflow::schema::Workflow {
+            variables: Default::default(),
             name: "wf".to_string(),
             description: String::new(),
             builtin: false,
@@ -1960,6 +1978,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let run_id = test_uuid(96);
         let workflow = crate::workflow::schema::Workflow {
+            variables: Default::default(),
             name: "wf".to_string(),
             description: String::new(),
             builtin: false,
@@ -2309,6 +2328,52 @@ mod tests {
         assert!(
             entries.is_empty(),
             "pending file must not be written when run is unknown"
+        );
+    }
+
+    /// spec [01] 解決順序「明示指定 > alias 内包値」: RELEASH_DATA_DIR が明示
+    /// 指定されている場合は、その値がそのまま採用される（PathBuf 化のみ）。
+    #[test]
+    fn resolve_data_dir_uses_explicit_env_when_set() {
+        let resolved = resolve_data_dir_from_env(Some("/explicit/path".to_string())).unwrap();
+        assert_eq!(resolved, std::path::PathBuf::from("/explicit/path"));
+    }
+
+    /// spec [01] 解決順序「明示指定 > alias 内包値」: 明示指定が無い場合は
+    /// `PathAliases` から導いた alias 内包の data_dir を返す（既定値は bundle
+    /// identifier suffix を持つ）。
+    #[test]
+    fn resolve_data_dir_falls_back_to_alias_data_dir_when_env_unset() {
+        if dirs::data_dir().is_none() {
+            return;
+        }
+        let resolved = resolve_data_dir_from_env(None).unwrap();
+        let expected_suffix = crate::path_aliases::default_data_dir_name_for_profile(
+            crate::path_aliases::BuildProfile::current(),
+        );
+        assert!(
+            resolved.ends_with(expected_suffix),
+            "expected suffix {expected_suffix}, got {}",
+            resolved.display()
+        );
+    }
+
+    /// spec [01]: 明示指定が空文字列のときは未設定扱いとし alias 内包値に
+    /// フォールバックする（空文字列を data_dir として採用すると以降の
+    /// 観測経路で「runs 0 件」と紛れるため）。
+    #[test]
+    fn resolve_data_dir_treats_empty_env_as_unset() {
+        if dirs::data_dir().is_none() {
+            return;
+        }
+        let resolved = resolve_data_dir_from_env(Some(String::new())).unwrap();
+        let expected_suffix = crate::path_aliases::default_data_dir_name_for_profile(
+            crate::path_aliases::BuildProfile::current(),
+        );
+        assert!(
+            resolved.ends_with(expected_suffix),
+            "empty env should fall through to alias data_dir, got {}",
+            resolved.display()
         );
     }
 

--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -34,6 +34,10 @@ impl fmt::Display for CliInstallStatus {
 pub(crate) fn ensure_cli_symlink_installed() {
     #[cfg(target_os = "macos")]
     {
+        if !should_install_cli_symlink_for_profile(cfg!(debug_assertions)) {
+            log::info!("Skipping Releash CLI install on dev build to preserve production CLI");
+            return;
+        }
         let exe = match std::env::current_exe() {
             Ok(path) => path,
             Err(e) => {
@@ -46,6 +50,16 @@ pub(crate) fn ensure_cli_symlink_installed() {
             Err(e) => log::warn!("Failed to install Releash CLI: {e}"),
         }
     }
+}
+
+/// `/usr/local/bin/releash` を install してよいかをビルド種別から判定する純粋関数。
+///
+/// dev ビルドは本番 CLI 名 `releash` を所有しない（spec [01]「dev 起動による本番 CLI の不変性」）。
+/// `/usr/local/bin/releash` を debug binary に張り替えると本番 CLI を破壊するため、
+/// dev 起動はこの install 経路に関与しない。
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn should_install_cli_symlink_for_profile(is_debug_build: bool) -> bool {
+    !is_debug_build
 }
 
 #[cfg(all(unix, any(target_os = "macos", test)))]
@@ -299,5 +313,18 @@ mod tests {
     #[test]
     fn applescript_string_escapes_backslashes_and_quotes() {
         assert_eq!(applescript_string(r#"echo "a\b""#), r#""echo \"a\\b\"""#);
+    }
+
+    #[test]
+    fn should_install_cli_symlink_skips_dev_build() {
+        // dev (debug) ビルドは本番 CLI を所有しないため install しない
+        // （spec [01]「dev 起動による本番 CLI の不変性」）。
+        assert!(!should_install_cli_symlink_for_profile(true));
+    }
+
+    #[test]
+    fn should_install_cli_symlink_allows_release_build() {
+        // 本番 (release) ビルドは `/usr/local/bin/releash` を更新する。
+        assert!(should_install_cli_symlink_for_profile(false));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod mcp;
 mod menu;
 mod native_drop;
 mod notion;
+mod path_aliases;
 mod permission;
 mod protocol;
 mod pty;

--- a/src-tauri/src/path_aliases.rs
+++ b/src-tauri/src/path_aliases.rs
@@ -1,0 +1,528 @@
+//! PathAliases — 起動環境（dev / 本番）から一意に決まる CLI alias の解決単位。
+//!
+//! alias 名・実行 binary・データディレクトリの三者を組として保持する。
+//! facet 展開 (`{{path_alias.releash}}`) と子プロセス起動経路（PTY / oneshot /
+//! agent bridge）の双方が同じソースから値を引く。
+//!
+//! [01] CLI alias と実行対象の一意な対応:
+//! 本番ビルド (release) → alias 名 `releash` / data dir `com.releash.app`
+//! dev ビルド (debug)   → alias 名 `releash-dev` / data dir `com.releash.app.dev`
+
+use std::path::{Path, PathBuf};
+
+/// debug / release ビルド種別。
+///
+/// `cfg!(debug_assertions)` をテスト境界へ閉じ込めるための拡張点。
+/// pure helper (`alias_name_for_profile` / `default_data_dir_name_for_profile`) に
+/// 渡すことで、テストから dev / 本番 双方の分岐を同一バイナリで検証する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildProfile {
+    /// 本番ビルド (release)。
+    Production,
+    /// dev ビルド (debug)。
+    Development,
+}
+
+impl BuildProfile {
+    /// 現在の cargo ビルド種別から `BuildProfile` を導出する。
+    pub fn current() -> Self {
+        if cfg!(debug_assertions) {
+            Self::Development
+        } else {
+            Self::Production
+        }
+    }
+}
+
+/// `BuildProfile` から CLI alias 名を決定する。
+pub fn alias_name_for_profile(profile: BuildProfile) -> &'static str {
+    match profile {
+        BuildProfile::Production => "releash",
+        BuildProfile::Development => "releash-dev",
+    }
+}
+
+/// `BuildProfile` から既定の data dir 名（bundle identifier）を決定する。
+pub fn default_data_dir_name_for_profile(profile: BuildProfile) -> &'static str {
+    match profile {
+        BuildProfile::Production => "com.releash.app",
+        BuildProfile::Development => "com.releash.app.dev",
+    }
+}
+
+/// 単一の path alias 解決単位。
+#[derive(Debug, Clone)]
+pub struct PathAlias {
+    /// agent / facet に提示する alias 名（例: `releash`, `releash-dev`）。
+    pub name: String,
+    /// alias が実行する binary 実体への絶対パス。
+    pub exe_path: PathBuf,
+    /// alias が内包するデータディレクトリ。
+    /// 子プロセスに `RELEASH_DATA_DIR` として伝搬する既定値。
+    pub data_dir: PathBuf,
+}
+
+/// 起動環境から確定する path alias 集合。
+///
+/// 当面 `releash` キーのみを公開する（spec scope: `path_alias.releash` のみ）。
+#[derive(Debug, Clone)]
+pub struct PathAliases {
+    releash: PathAlias,
+}
+
+impl PathAliases {
+    /// 起動環境から `PathAliases` を構築する。
+    ///
+    /// `data_dir_override` を渡した場合、その値を `releash` alias の data_dir として使う。
+    /// Tauri 側では `AppHandle::path().app_data_dir()` の解決結果を渡すことで、
+    /// `tauri.conf.dev.json` の identifier (`com.releash.app.dev`) が反映された
+    /// 実 data dir と一致させる。CLI 単体起動などで override が無い場合は
+    /// `dirs::data_dir()` + bundle identifier 既定値から組み立てる。
+    ///
+    /// `data_dir_override` が `None` かつ `dirs::data_dir()` が解決失敗した場合は
+    /// `Err` を返す。spec [01]「CLI alias と実行対象の一意な対応」境界を守るため、
+    /// 失敗時は cwd へのサイレントフォールバックではなく明示エラー化する。
+    pub fn from_runtime(data_dir_override: Option<PathBuf>) -> Result<Self, String> {
+        let profile = BuildProfile::current();
+        let exe_path = std::env::current_exe()
+            .map_err(|e| format!("failed to resolve current executable path: {e}"))?;
+        let name = alias_name_for_profile(profile);
+        let data_dir = match data_dir_override {
+            Some(d) => d,
+            None => default_data_dir_for_profile(profile)?,
+        };
+        Ok(Self {
+            releash: PathAlias {
+                name: name.to_string(),
+                exe_path,
+                data_dir,
+            },
+        })
+    }
+
+    /// `releash` alias の解決結果を返す。
+    pub fn releash(&self) -> &PathAlias {
+        &self.releash
+    }
+
+    /// 公開対象の alias key 一覧（namespace `path_alias.<key>` の `<key>` 部分）。
+    ///
+    /// facet 展開エンジン側で「既知 alias key」を判定する際に使う。
+    pub fn known_keys() -> &'static [&'static str] {
+        &["releash"]
+    }
+}
+
+/// 起動環境別の既定 data dir。
+///
+/// 明示 override がない場合の解決ロジックを CLI / Tauri 両方で共有するための
+/// 単一エントリ。`dirs::data_dir()` 解決失敗時は `.` フォールバックではなく
+/// 明示エラーを返す（spec [01]「alias は alias 名・実行 binary・データディレクトリの
+/// 三者を組として保持」境界が曖昧化するのを防ぐため）。
+pub fn default_data_dir_for_profile(profile: BuildProfile) -> Result<PathBuf, String> {
+    let base = dirs::data_dir()
+        .ok_or_else(|| "failed to resolve OS data directory (dirs::data_dir)".to_string())?;
+    Ok(base.join(default_data_dir_name_for_profile(profile)))
+}
+
+/// 子プロセスへ alias 解決可能な PATH と alias 内包の `RELEASH_DATA_DIR` を提供する。
+///
+/// spec issues-1054 「agent 子プロセスへの実行環境の伝搬」:
+/// PTY / oneshot / agent bridge いずれの起動経路でも、起動環境に対応する CLI alias が
+/// `PATH` 経由で解決可能で、`RELEASH_DATA_DIR` が起動環境別に設定される必要がある。
+///
+/// `PATH` には alias wrapper の bin dir を**先頭**に追加する。既存 PATH 前方に
+/// `releash` / `releash-dev` を含む別ディレクトリ（例: `/usr/local/bin`）があると
+/// 末尾追加では wrapper が解決されず alias と実行 binary の一意対応 (spec [01]) が崩れる。
+/// wrapper bin dir に置く実体は `releash` / `releash-dev` の wrapper のみで、他システム
+/// コマンド (`node` / `git` / `sh` 等) を shadow する経路は生じない。
+///
+/// `RELEASH_DATA_DIR` の解決順序（spec: 明示指定 > alias 内包値 > プロセス既定）は
+/// 本 helper の入力 `parent_releash_data_dir` で守る:
+/// - Releash プロセス自身に明示指定がある場合（`Some(...)`）は alias 内包値で上書き
+///   しない（戻り値に `RELEASH_DATA_DIR` を含めない）。子プロセスは inherit で
+///   親の明示値を受け取る。
+/// - 明示指定が無い場合（`None`）は alias 内包値を戻り値に積む。
+pub fn child_env_overrides(aliases: &PathAliases) -> Result<Vec<(String, String)>, String> {
+    child_env_overrides_from(
+        aliases,
+        std::env::var("PATH").ok().as_deref(),
+        std::env::var("RELEASH_DATA_DIR").ok().as_deref(),
+    )
+}
+
+/// `child_env_overrides` の pure 版。env をパラメータで受け取り副作用を持たない。
+///
+/// `parent_releash_data_dir` の Some / None で alias 内包値の上書き有無が分岐する
+/// （spec 解決順序: 明示指定 > alias 内包値）。テストはこちらを直接叩く。
+pub fn child_env_overrides_from(
+    aliases: &PathAliases,
+    parent_path: Option<&str>,
+    parent_releash_data_dir: Option<&str>,
+) -> Result<Vec<(String, String)>, String> {
+    let releash = aliases.releash();
+    let bin_dir = ensure_alias_wrapper(releash)?;
+    let path_value = compose_path_with_alias_bin(parent_path, &bin_dir);
+    let mut env = vec![("PATH".to_string(), path_value)];
+    // spec issues-1054: 利用者明示指定（親プロセスの RELEASH_DATA_DIR）は alias 内包値で
+    // 上書きしない。明示指定が無いときだけ alias 既定値を子プロセス env に積む。
+    if parent_releash_data_dir.is_none_or(str::is_empty) {
+        env.push((
+            "RELEASH_DATA_DIR".to_string(),
+            releash.data_dir.display().to_string(),
+        ));
+    }
+    Ok(env)
+}
+
+/// alias の wrapper bin dir を既存 `PATH` の**先頭**に追加した値を組み立てる。
+///
+/// 末尾追加にすると、既存 PATH 前方に `releash` / `releash-dev` を含む別ディレクトリが
+/// あった場合に wrapper が解決されず alias と実行 binary の一意対応 (spec [01]) が崩れる。
+/// wrapper bin dir に置くファイルは `releash` / `releash-dev` の wrapper のみで、
+/// 他システムコマンドを shadow する経路は生じないため、先頭挿入で問題ない。
+fn compose_path_with_alias_bin(existing_path: Option<&str>, bin_dir: &Path) -> String {
+    match existing_path {
+        Some(existing) if !existing.is_empty() => format!("{}:{}", bin_dir.display(), existing),
+        _ => bin_dir.display().to_string(),
+    }
+}
+
+/// PTY / oneshot / agent bridge 起動経路の env 準備ロジックの単一エントリ。
+///
+/// spec issues-1054 「agent 子プロセスへの実行環境の伝搬」: 各経路の env 構築を
+/// `PathAliases::from_runtime` → `child_env_overrides` の組として一箇所に束ね、
+/// テストから直接検証可能にする。
+///
+/// - `data_dir` が `None` の場合（Tauri 側 `app_data_dir()` 解決失敗時など）は空の env を
+///   返し、呼び出し側が alias なしで spawn する既存挙動を温存する。
+/// - `data_dir` が `Some` の場合に wrapper 作成等で失敗したら `Err` を返し、呼び出し側で
+///   spawn を中止する。
+pub fn prepare_child_env(data_dir: Option<PathBuf>) -> Result<Vec<(String, String)>, String> {
+    let Some(data_dir) = data_dir else {
+        return Ok(Vec::new());
+    };
+    let aliases = PathAliases::from_runtime(Some(data_dir))?;
+    child_env_overrides(&aliases)
+}
+
+/// `<data_dir>/bin/<alias_name>` に CLI 実行 binary を指す wrapper を用意し、bin dir を返す。
+///
+/// wrapper はシェルスクリプトで、呼び出し側が `RELEASH_DATA_DIR` を明示指定していない
+/// 場合のみ alias 内包の data_dir を設定する（spec 解決順序: 明示指定 > alias 内包値）。
+fn ensure_alias_wrapper(releash: &PathAlias) -> Result<PathBuf, String> {
+    let bin_dir = releash.data_dir.join("bin");
+    std::fs::create_dir_all(&bin_dir)
+        .map_err(|e| format!("failed to create alias bin dir {}: {e}", bin_dir.display()))?;
+    let wrapper_path = bin_dir.join(&releash.name);
+    let exe_str = releash
+        .exe_path
+        .to_str()
+        .ok_or_else(|| "exe_path is not valid UTF-8".to_string())?;
+    let data_dir_str = releash
+        .data_dir
+        .to_str()
+        .ok_or_else(|| "data_dir is not valid UTF-8".to_string())?;
+    let script = build_wrapper_script(exe_str, data_dir_str);
+    // 既存の wrapper と内容が同じ場合は書き換えを省く（mtime ノイズを避ける）。
+    if wrapper_path.exists() {
+        if let Ok(existing) = std::fs::read_to_string(&wrapper_path) {
+            if existing == script {
+                return Ok(bin_dir);
+            }
+        }
+    }
+    write_wrapper_script(&wrapper_path, &script)?;
+    Ok(bin_dir)
+}
+
+fn build_wrapper_script(exe_path: &str, data_dir: &str) -> String {
+    // 呼び出し側の明示指定を奪わない: `RELEASH_DATA_DIR` 未設定時のみ alias 内包値を使う。
+    format!(
+        "#!/bin/sh\nif [ -z \"$RELEASH_DATA_DIR\" ]; then\n  export RELEASH_DATA_DIR={}\nfi\nexec {} \"$@\"\n",
+        shell_quote(data_dir),
+        shell_quote(exe_path)
+    )
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(unix)]
+fn write_wrapper_script(path: &Path, script: &str) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::write(path, script)
+        .map_err(|e| format!("failed to write wrapper {}: {e}", path.display()))?;
+    let mut perms = std::fs::metadata(path)
+        .map_err(|e| format!("failed to stat wrapper {}: {e}", path.display()))?
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms)
+        .map_err(|e| format!("failed to chmod wrapper {}: {e}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_wrapper_script(path: &Path, script: &str) -> Result<(), String> {
+    std::fs::write(path, script)
+        .map_err(|e| format!("failed to write wrapper {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alias_name_for_profile_returns_releash_for_production() {
+        assert_eq!(alias_name_for_profile(BuildProfile::Production), "releash");
+    }
+
+    #[test]
+    fn alias_name_for_profile_returns_releash_dev_for_development() {
+        assert_eq!(
+            alias_name_for_profile(BuildProfile::Development),
+            "releash-dev"
+        );
+    }
+
+    #[test]
+    fn default_data_dir_name_distinguishes_dev_and_production() {
+        assert_eq!(
+            default_data_dir_name_for_profile(BuildProfile::Production),
+            "com.releash.app"
+        );
+        assert_eq!(
+            default_data_dir_name_for_profile(BuildProfile::Development),
+            "com.releash.app.dev"
+        );
+    }
+
+    #[test]
+    fn from_runtime_uses_build_profile_for_alias_name() {
+        let aliases = PathAliases::from_runtime(Some(PathBuf::from("/tmp/data"))).unwrap();
+        let releash = aliases.releash();
+        assert_eq!(
+            releash.name,
+            alias_name_for_profile(BuildProfile::current())
+        );
+        assert_eq!(releash.data_dir, PathBuf::from("/tmp/data"));
+    }
+
+    #[test]
+    fn known_keys_contains_only_releash() {
+        assert_eq!(PathAliases::known_keys(), &["releash"]);
+    }
+
+    #[test]
+    fn from_runtime_uses_default_dir_when_no_override() {
+        // dirs::data_dir() が解決できる環境では default 解決経路に乗る。
+        if dirs::data_dir().is_none() {
+            return;
+        }
+        let aliases = PathAliases::from_runtime(None).unwrap();
+        let releash = aliases.releash();
+        let expected_suffix = default_data_dir_name_for_profile(BuildProfile::current());
+        assert!(
+            releash.data_dir.ends_with(expected_suffix),
+            "data_dir should end with {expected_suffix}: {}",
+            releash.data_dir.display()
+        );
+    }
+
+    #[test]
+    fn compose_path_with_alias_bin_prepends_to_head_when_path_set() {
+        // alias bin dir は既存 PATH の**先頭**にあること。末尾だと既存 PATH 前方に
+        // `releash` / `releash-dev` を含む別ディレクトリがあると wrapper が解決されず
+        // alias と実行 binary の一意対応 (spec [01]) が崩れる。bin dir に置く実体は
+        // wrapper のみで、システムコマンドの shadow 経路は生じない。
+        let bin_dir = PathBuf::from("/tmp/my-data/bin");
+        let composed =
+            compose_path_with_alias_bin(Some("/system-bin:/other-bin"), bin_dir.as_path());
+        assert_eq!(composed, "/tmp/my-data/bin:/system-bin:/other-bin");
+    }
+
+    #[test]
+    fn compose_path_with_alias_bin_falls_back_to_bin_only_when_path_unset() {
+        let bin_dir = PathBuf::from("/tmp/my-data/bin");
+        assert_eq!(
+            compose_path_with_alias_bin(None, bin_dir.as_path()),
+            "/tmp/my-data/bin"
+        );
+        assert_eq!(
+            compose_path_with_alias_bin(Some(""), bin_dir.as_path()),
+            "/tmp/my-data/bin"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_env_overrides_from_sets_releash_data_dir_when_parent_unset() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let exe = tmp.path().join("releash-bin");
+        std::fs::write(&exe, "").unwrap();
+        let aliases = PathAliases {
+            releash: PathAlias {
+                name: "releash-test".to_string(),
+                exe_path: exe,
+                data_dir: tmp.path().join("data"),
+            },
+        };
+        let overrides = child_env_overrides_from(&aliases, Some("/bin"), None).unwrap();
+        let data_dir_value = overrides
+            .iter()
+            .find_map(|(k, v)| (k == "RELEASH_DATA_DIR").then(|| v.clone()))
+            .expect("RELEASH_DATA_DIR override missing");
+        assert_eq!(
+            data_dir_value,
+            tmp.path().join("data").display().to_string()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_env_overrides_from_omits_releash_data_dir_when_parent_set() {
+        // spec issues-1054 解決順序「明示指定 > alias 内包値」: 親プロセスに
+        // RELEASH_DATA_DIR が明示されているときは alias 内包値で上書きしない。
+        let tmp = tempfile::TempDir::new().unwrap();
+        let exe = tmp.path().join("releash-bin");
+        std::fs::write(&exe, "").unwrap();
+        let aliases = PathAliases {
+            releash: PathAlias {
+                name: "releash-test".to_string(),
+                exe_path: exe,
+                data_dir: tmp.path().join("data"),
+            },
+        };
+        let overrides =
+            child_env_overrides_from(&aliases, Some("/bin"), Some("/explicit/path")).unwrap();
+        assert!(
+            overrides.iter().all(|(k, _)| k != "RELEASH_DATA_DIR"),
+            "RELEASH_DATA_DIR must not be in overrides when parent set it: {overrides:?}"
+        );
+        // PATH は依然として alias bin を先頭に積む。
+        let path_value = overrides
+            .iter()
+            .find_map(|(k, v)| (k == "PATH").then(|| v.clone()))
+            .expect("PATH override missing");
+        assert!(path_value.starts_with(tmp.path().join("data").join("bin").to_str().unwrap()));
+        assert!(path_value.ends_with(":/bin"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_env_overrides_from_treats_empty_parent_data_dir_as_unset() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let exe = tmp.path().join("releash-bin");
+        std::fs::write(&exe, "").unwrap();
+        let aliases = PathAliases {
+            releash: PathAlias {
+                name: "releash-test".to_string(),
+                exe_path: exe,
+                data_dir: tmp.path().join("data"),
+            },
+        };
+        let overrides = child_env_overrides_from(&aliases, None, Some("")).unwrap();
+        assert!(
+            overrides.iter().any(|(k, _)| k == "RELEASH_DATA_DIR"),
+            "empty parent RELEASH_DATA_DIR should be treated as unset: {overrides:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_child_env_returns_empty_when_data_dir_none() {
+        // app_data_dir() 解決失敗時の経路: 既存挙動 (silent skip) を温存。
+        let env = prepare_child_env(None).unwrap();
+        assert!(
+            env.is_empty(),
+            "no overrides expected when data_dir is None"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_child_env_returns_path_and_data_dir_when_data_dir_provided() {
+        // spec issues-1054「agent 子プロセスへの実行環境の伝搬」:
+        // PTY / agent bridge が共有する env builder は alias bin の PATH と
+        // RELEASH_DATA_DIR の両方を出力する。
+        let tmp = tempfile::TempDir::new().unwrap();
+        let env = prepare_child_env(Some(tmp.path().join("data"))).unwrap();
+        assert!(env.iter().any(|(k, _)| k == "PATH"));
+        // 親プロセスに RELEASH_DATA_DIR が無いテスト前提でのみ data_dir が積まれる。
+        if std::env::var("RELEASH_DATA_DIR").is_err() {
+            assert!(env.iter().any(|(k, _)| k == "RELEASH_DATA_DIR"));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_child_env_propagates_wrapper_failure() {
+        // wrapper 作成不能（既存ファイルが bin dir 位置を占有）→ Err を返し、
+        // 呼び出し側（PTY / bridge）で spawn を中止する。
+        let tmp = tempfile::TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        // bin に通常ファイルを置くと create_dir_all が失敗する。
+        std::fs::write(data_dir.join("bin"), "").unwrap();
+        let err = prepare_child_env(Some(data_dir)).unwrap_err();
+        assert!(
+            err.contains("alias bin dir"),
+            "expected wrapper bin dir error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn default_data_dir_for_profile_returns_path_when_dirs_available() {
+        // dirs::data_dir() が解決できる環境では Ok を返し、bundle identifier suffix を持つ。
+        if dirs::data_dir().is_none() {
+            return;
+        }
+        let path = default_data_dir_for_profile(BuildProfile::Production).unwrap();
+        assert!(path.ends_with("com.releash.app"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_alias_wrapper_exports_data_dir_only_when_unset() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let exe = tmp.path().join("releash-bin");
+        std::fs::write(&exe, "").unwrap();
+        let alias = PathAlias {
+            name: "releash-test".to_string(),
+            exe_path: exe,
+            data_dir: tmp.path().join("data"),
+        };
+        let bin_dir = ensure_alias_wrapper(&alias).unwrap();
+        let wrapper = bin_dir.join("releash-test");
+        let script = std::fs::read_to_string(&wrapper).unwrap();
+        // wrapper は `RELEASH_DATA_DIR` 未設定時のみ alias 内包値を export する
+        // （spec 解決順序: 明示指定 > alias 内包値）。
+        assert!(
+            script.contains(r#"if [ -z "$RELEASH_DATA_DIR" ]; then"#),
+            "wrapper must guard RELEASH_DATA_DIR export: {script}"
+        );
+        assert!(
+            script.contains("export RELEASH_DATA_DIR="),
+            "wrapper must export alias data_dir when unset: {script}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_alias_wrapper_creates_executable() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let exe = tmp.path().join("releash-bin");
+        std::fs::write(&exe, "").unwrap();
+        let alias = PathAlias {
+            name: "releash-test".to_string(),
+            exe_path: exe,
+            data_dir: tmp.path().join("data"),
+        };
+        let bin_dir = ensure_alias_wrapper(&alias).unwrap();
+        let wrapper = bin_dir.join("releash-test");
+        let mode = std::fs::metadata(&wrapper).unwrap().permissions().mode();
+        assert_eq!(mode & 0o111, 0o111, "wrapper should be executable");
+    }
+}

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -354,6 +354,7 @@ mod tests {
                             step_execution_counts: std::collections::HashMap::new(),
                             step_outputs: std::collections::HashMap::new(),
                             workflow_definition: crate::workflow::schema::Workflow {
+                                variables: Default::default(),
                                 name: "test".to_string(),
                                 description: "test".to_string(),
                                 builtin: false,

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -466,6 +466,21 @@ impl PtyManager {
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
 
         let mut extra_env = Vec::new();
+        // spec issues-1054: agent が起動する子プロセスに対し、起動環境別 alias が
+        // 解決可能な PATH と alias 内包の `RELEASH_DATA_DIR` を伝搬する。
+        // データディレクトリは Tauri の bundle identifier に従って `app_data_dir()` が
+        // 解決した値を渡し、dev / 本番で実体が分かれることを保証する。
+        match crate::path_aliases::prepare_child_env(app.path().app_data_dir().ok()) {
+            Ok(env) => extra_env.extend(env),
+            Err(e) => {
+                // 提示する alias と実行環境の不整合を避けるため、wrapper 作成失敗時は
+                // PTY spawn を中止する（spec issues-1054「agent 子プロセスへの実行
+                // 環境の伝搬」: PATH 経由で alias 解決可能な環境を約束する）。
+                return Err(format!(
+                    "failed to prepare alias child env for PTY spawn: {e}"
+                ));
+            }
+        }
         if let Some(mcp_handle) = app.try_state::<crate::mcp::McpServerHandle>() {
             if let Some(info) = mcp_handle.connection_info() {
                 extra_env.push(("RELEASH_MCP_URL".to_string(), info.url));

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1429,6 +1429,7 @@ mod tests {
 
     fn make_test_workflow_for_session() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "review-cycle".to_string(),
             description: "Test".to_string(),
             builtin: false,

--- a/src-tauri/src/workflow/builtin.rs
+++ b/src-tauri/src/workflow/builtin.rs
@@ -918,6 +918,7 @@ mod tests {
                         &HashMap::new(),
                         &[],
                         &workflow_variables,
+                        &HashMap::new(),
                     )
                     .expect("build_step_prompt must succeed");
                     (&node.resolved_facets.input_contracts, prompt)
@@ -946,6 +947,7 @@ mod tests {
                         false,
                         None,
                         &workflow_variables,
+                        &HashMap::new(),
                     )
                     .expect("build_parallel_step_prompt must succeed");
                     (&child.resolved_facets.input_contracts, prompt)
@@ -1056,6 +1058,7 @@ mod tests {
             &HashMap::new(),
             &[],
             &HashMap::new(),
+            &HashMap::new(),
         )
         .expect("build_step_prompt must succeed");
 
@@ -1089,6 +1092,7 @@ mod tests {
             Some(evil),
             &HashMap::new(),
             &[],
+            &HashMap::new(),
             &HashMap::new(),
         )
         .expect("build_step_prompt must succeed");

--- a/src-tauri/src/workflow/commands.rs
+++ b/src-tauri/src/workflow/commands.rs
@@ -1287,6 +1287,7 @@ mod tests {
 
     fn approval_only_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "adapter-boundary".to_string(),
             description: "adapter command test".to_string(),
             builtin: false,
@@ -1301,6 +1302,7 @@ mod tests {
 
     fn rejectable_adapter_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "adapter-boundary".to_string(),
             description: "adapter command test".to_string(),
             builtin: false,
@@ -2696,6 +2698,7 @@ mod tests {
 
     fn make_test_workflow(name: &str) -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: name.to_string(),
             description: "test workflow".to_string(),
             builtin: false,
@@ -3420,6 +3423,7 @@ mod tests {
                 workflow_file_stem: "wf".to_string(),
                 worktree_path: unauthorized_wt.to_string(),
                 workflow_definition: Workflow {
+                    variables: Default::default(),
                     name: "wf".to_string(),
                     description: "test".to_string(),
                     builtin: false,
@@ -3489,6 +3493,7 @@ mod tests {
                 workflow_file_stem: "wf".to_string(),
                 worktree_path: worktree_path.clone(),
                 workflow_definition: Workflow {
+                    variables: Default::default(),
                     name: "wf".to_string(),
                     description: "test".to_string(),
                     builtin: false,
@@ -3604,6 +3609,7 @@ mod tests {
         );
         let event_log = WorkflowEventLog::new(&data_dir);
         let snapshot = Workflow {
+            variables: Default::default(),
             name: "wf".to_string(),
             description: String::new(),
             builtin: false,

--- a/src-tauri/src/workflow/contract.rs
+++ b/src-tauri/src/workflow/contract.rs
@@ -695,6 +695,7 @@ mod tests {
     fn workflow_with_review_contract(contract: Option<&str>) -> Workflow {
         use crate::workflow::schema::{NodeDefinition, NodeType};
         Workflow {
+            variables: Default::default(),
             name: "wf-resolve".to_string(),
             description: "".to_string(),
             builtin: false,

--- a/src-tauri/src/workflow/diagnostics.rs
+++ b/src-tauri/src/workflow/diagnostics.rs
@@ -941,6 +941,7 @@ mod tests {
         let wf_dir = tmp.path();
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -964,6 +965,7 @@ mod tests {
         setup_facet(wf_dir, "instructions", "impl", "content");
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -995,6 +997,7 @@ mod tests {
         setup_facet(wf_dir, "contracts", "input-contract", "format: text");
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1028,6 +1031,7 @@ mod tests {
         setup_facet(wf_dir, "instructions", "impl", "content");
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1063,6 +1067,7 @@ mod tests {
         setup_facet(wf_dir, "instructions", "impl", "content");
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1090,6 +1095,7 @@ mod tests {
         setup_facet(wf_dir, "instructions", "review", "content");
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1124,6 +1130,7 @@ mod tests {
 
         // step1 が Auto + rules で step3 へ遷移 → orphan は到達不能
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1160,6 +1167,7 @@ mod tests {
         // rules なしの step → 次の step は暗黙的に到達可能（到達不能ではない）
         // ただし明示的遷移なしの warning は出る
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1250,6 +1258,7 @@ mod tests {
         let wf_dir = tmp.path();
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1275,6 +1284,7 @@ mod tests {
         let wf_dir = tmp.path();
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "bash-wf".to_string(),
             description: "bash test".to_string(),
             builtin: false,
@@ -1305,6 +1315,7 @@ mod tests {
         let wf_dir = tmp.path();
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "bash-wf".to_string(),
             description: "bash test".to_string(),
             builtin: false,
@@ -1335,6 +1346,7 @@ mod tests {
         setup_facet(wf_dir, "instructions", "impl", "content");
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1358,6 +1370,7 @@ mod tests {
         // diagnose_allでは「読み込みに失敗」エラーとして報告される
         fs::create_dir_all(wf_dir).unwrap();
         let wf = Workflow {
+            variables: Default::default(),
             name: "bad workflow".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1380,6 +1393,7 @@ mod tests {
         setup_facet(wf_dir, "instructions", "review", "content");
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1451,6 +1465,7 @@ mod tests {
         setup_facet(wf_dir, "instructions", "task", "content");
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "dup-step".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1480,6 +1495,7 @@ mod tests {
         setup_facet(wf_dir, "instructions", "task", "content");
 
         let wf = Workflow {
+            variables: Default::default(),
             name: "agg-no-par".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1516,6 +1532,7 @@ mod tests {
 
         // step1 が後続の step2 を pass_output_from で参照 → 後方参照は許可（エラーにならない）
         let wf = Workflow {
+            variables: Default::default(),
             name: "backward-ref".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1549,6 +1566,7 @@ mod tests {
 
         // step1 が後続の step2 を collect.from で参照 → エラーになるべき
         let wf = Workflow {
+            variables: Default::default(),
             name: "subsequent-collect".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1586,6 +1604,7 @@ mod tests {
 
         // parallel block の子step が後続の report を参照 → 後方参照は許可（エラーにならない）
         let wf = Workflow {
+            variables: Default::default(),
             name: "par-backward".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -1624,6 +1643,7 @@ mod tests {
 
         // parallel block の子step が兄弟を参照 → エラーになるべき
         let wf = Workflow {
+            variables: Default::default(),
             name: "par-sibling".to_string(),
             description: "test".to_string(),
             builtin: false,

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -4104,14 +4104,26 @@ impl WorkflowEngine {
                 )
             })
             .unwrap_or_default();
+        // CLI 名は起動環境別に解決する（dev → `releash-dev`、本番 → `releash`）。
+        let cli = Self::resolve_releash_alias();
         format!(
             "The required structured output for this workflow step has not been submitted.\n\n\
 Submit it by running this command with a JSON object that satisfies the `{contract}` contract:{contract_section}\n\n\
 ```sh\n\
-releash workflow output submit {run_id} \\\n  --step {step_name} \\\n  --type {contract} \\\n  --json '{{...}}'\n\
+{cli} workflow output submit {run_id} \\\n  --step {step_name} \\\n  --type {contract} \\\n  --json '{{...}}'\n\
 ```\n\n\
 Do not create a temporary JSON file for this. Do not finish the step until the command succeeds."
         )
+    }
+
+    /// 起動環境別の `releash` alias 名を返す（spec issues-1054）。
+    ///
+    /// 本関数は alias 名のみを必要とするため、data_dir 解決を経由しない pure helper
+    /// (`alias_name_for_profile`) を直接呼び、`dirs::data_dir()` 失敗で alias 名解決が
+    /// 巻き込まれないようにする。
+    pub(crate) fn resolve_releash_alias() -> String {
+        crate::path_aliases::alias_name_for_profile(crate::path_aliases::BuildProfile::current())
+            .to_string()
     }
 
     fn contract_repair_attempt_count<R: tauri::Runtime>(
@@ -5022,6 +5034,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
             step_history_clone,
             task_clone,
             workflow_variables_clone,
+            workflow_declared_variables_clone,
             workflow_defaults_clone,
         ) = {
             let execs = self.executions.lock().await;
@@ -5035,6 +5048,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
                 exec.step_history.clone(),
                 exec.task.clone(),
                 exec.workflow_variables.clone(),
+                exec.workflow.variables.clone(),
                 exec.workflow_defaults.clone(),
             )
         };
@@ -5052,6 +5066,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
             &step_outputs_clone,
             &step_history_clone,
             &workflow_variables_clone,
+            &workflow_declared_variables_clone,
         )?;
 
         // ステップ設定の解決 → セッション生成（workflow_defaults を継承元に注入）
@@ -5111,6 +5126,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
     /// `{{run_id}}` / `{{step_name}}` プレースホルダを実値に展開する。これにより
     /// agent が表示された CLI コマンドをそのまま `releash workflow output submit` 用に
     /// 呼び出せる（spec [08] 要求: run_id と step_name を主語に CLI 提出できる）。
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn build_step_prompt(
         step: &NodeDefinition,
         run_id: &str,
@@ -5119,12 +5135,15 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
         step_outputs: &HashMap<String, StepOutput>,
         step_history: &[StepHistoryEntry],
         workflow_variables: &HashMap<String, String>,
+        workflow_declared_variables: &HashMap<String, String>,
     ) -> Result<(Option<String>, String), WorkflowEngineError> {
         // inline_prompt のみ（ファセット参照なし）のステップ: inline_prompt をそのまま使用
         if !step.has_facet_refs() {
             if let Some(ref inline) = step.inline_prompt {
                 let rendered = Self::render_facet_variables(inline, worktree_path, task);
                 let rendered = Self::render_submit_command_variables(&rendered, run_id, &step.name);
+                let rendered =
+                    Self::render_namespaced_variables(&rendered, workflow_declared_variables);
                 let prompt = Self::inject_step_outputs(
                     &rendered,
                     step,
@@ -5154,11 +5173,13 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
         let composed = crate::workflow::facet::compose_facets(step);
         let system_prompt = composed.system_prompt.map(|s| {
             let s = Self::render_facet_variables(&s, worktree_path, task);
-            Self::render_submit_command_variables(&s, run_id, &step.name)
+            let s = Self::render_submit_command_variables(&s, run_id, &step.name);
+            Self::render_namespaced_variables(&s, workflow_declared_variables)
         });
         let rendered_user = {
             let s = Self::render_facet_variables(&composed.user_message, worktree_path, task);
-            Self::render_submit_command_variables(&s, run_id, &step.name)
+            let s = Self::render_submit_command_variables(&s, run_id, &step.name);
+            Self::render_namespaced_variables(&s, workflow_declared_variables)
         };
         let mut prompt = Self::inject_step_outputs(
             &rendered_user,
@@ -5176,6 +5197,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
             step.output_contract.as_deref(),
             run_id,
             &step.name,
+            workflow_declared_variables,
         );
         Ok((system_prompt, prompt))
     }
@@ -5227,6 +5249,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
             step_outputs,
             step_history,
             workflow_variables,
+            &HashMap::new(),
         )?;
         Self::dispatch_session_start(
             gate,
@@ -5466,6 +5489,29 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
             .replace("{{step_name}}", step_name)
     }
 
+    /// facet 本文に対し、起動環境別 alias と workflow 定義変数を namespace 展開する。
+    ///
+    /// spec issues-1054:
+    /// - `{{path_alias.releash}}` → 起動環境別 alias 名 (`releash` / `releash-dev`)
+    /// - `{{vars.<name>}}` → workflow 定義側の宣言値
+    ///
+    /// 既存プレースホルダ (`{{project_name}}` / `{{task}}` / `{{run_id}}` / `{{step_name}}`) は
+    /// 名前空間を持たないトップレベル namespace に残り、別途 `render_facet_variables` /
+    /// `render_submit_command_variables` で展開される。
+    pub(crate) fn render_namespaced_variables(
+        content: &str,
+        workflow_declared_variables: &HashMap<String, String>,
+    ) -> String {
+        // path_alias の展開は alias 名のみで完結する。data_dir 解決を経由しないため
+        // `alias_name_for_profile` を直接渡し、`dirs::data_dir()` 失敗から切り離す。
+        let releash_alias = crate::path_aliases::alias_name_for_profile(
+            crate::path_aliases::BuildProfile::current(),
+        );
+        let s =
+            crate::workflow::facet::render_path_alias_variables_with_name(content, releash_alias);
+        crate::workflow::facet::render_workflow_variables(&s, workflow_declared_variables)
+    }
+
     /// [08] prose 抽出経路は engine から完全除去された（spec [08] Rule 4 構造化出力の
     /// 確定経路は明示的提出のみ）。本 helper は ChatSession 表示など event log と無関係な
     /// 経路で「最後の Agent メッセージ本文」を取り出すテスト用 fixture としてのみ残す。
@@ -5557,12 +5603,14 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
         output_contract: Option<&str>,
         run_id: &str,
         step_name: &str,
+        workflow_declared_variables: &HashMap<String, String>,
     ) {
         let Some(contract) = output_contract else {
             return;
         };
         let action = crate::workflow::facet::output_contract_completion_action(contract);
         let action = Self::render_submit_command_variables(&action, run_id, step_name);
+        let action = Self::render_namespaced_variables(&action, workflow_declared_variables);
         if !prompt.is_empty() {
             prompt.push_str("\n\n");
         }
@@ -6603,11 +6651,15 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
             .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
 
         // step_outputsとworkflow_variablesのスナップショットをロック外で取得
-        let (step_outputs_snapshot, wf_variables_snapshot) = {
+        let (step_outputs_snapshot, wf_variables_snapshot, wf_declared_variables_snapshot) = {
             let execs = self.executions.lock().await;
             let (_, exec) = find_by_worktree(&execs, worktree_path)
                 .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(worktree_path.to_string()))?;
-            (exec.step_outputs.clone(), exec.workflow_variables.clone())
+            (
+                exec.step_outputs.clone(),
+                exec.workflow_variables.clone(),
+                exec.workflow.variables.clone(),
+            )
         };
 
         // Phase 1: セッション生成 + ref登録 + プロンプト構築（AgentSessionはまだ起動しない）
@@ -6659,6 +6711,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
                 ps.pass_previous_response.unwrap_or(false),
                 ps.pass_output_from.as_deref(),
                 &wf_variables_snapshot,
+                &wf_declared_variables_snapshot,
             )?;
 
             child_setups.push(ChildSetup {
@@ -6810,6 +6863,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
         pass_previous_response: bool,
         pass_output_from: Option<&[String]>,
         workflow_variables: &HashMap<String, String>,
+        workflow_declared_variables: &HashMap<String, String>,
     ) -> Result<(Option<String>, String), WorkflowEngineError> {
         if ps.has_facet_refs() && ps.resolved_facets.is_empty() {
             return Err(WorkflowEngineError::InvalidWorkflow(format!(
@@ -6821,10 +6875,13 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
 
         let system_prompt = composed.system_prompt.map(|s| {
             let s = Self::render_facet_variables(&s, worktree_path, task);
-            Self::render_submit_command_variables(&s, run_id, &ps.name)
+            let s = Self::render_submit_command_variables(&s, run_id, &ps.name);
+            Self::render_namespaced_variables(&s, workflow_declared_variables)
         });
         let mut user_message =
             Self::render_facet_variables(&composed.user_message, worktree_path, task);
+        user_message =
+            Self::render_namespaced_variables(&user_message, workflow_declared_variables);
 
         // pass_output_from による出力注入
         if let Some(from_steps) = pass_output_from {
@@ -6864,6 +6921,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
             ps.output_contract.as_deref(),
             run_id,
             &ps.name,
+            workflow_declared_variables,
         );
 
         Ok((system_prompt, user_message))
@@ -7381,6 +7439,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
         state: WorkflowExecutionState,
     ) -> WorkflowState {
         let workflow = Workflow {
+            variables: Default::default(),
             name: "test-approval-workflow".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -7443,6 +7502,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
         worktree_path: &str,
     ) {
         let workflow = Workflow {
+            variables: Default::default(),
             name: "pending-pickup-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -7894,6 +7954,7 @@ mod tests {
     #[allow(dead_code)]
     fn make_approved_fix_policy_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "approved-fix-policy-test".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -8152,6 +8213,7 @@ mod tests {
 
     fn make_test_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "test-workflow".to_string(),
             description: "Test workflow".to_string(),
             builtin: false,
@@ -8880,6 +8942,7 @@ mod tests {
     #[test]
     fn validate_start_empty_steps_returns_err() {
         let workflow = Workflow {
+            variables: Default::default(),
             name: "empty".to_string(),
             description: String::new(),
             builtin: false,
@@ -8920,6 +8983,7 @@ mod tests {
     #[test]
     fn validate_start_rejects_bash_node() {
         let workflow = Workflow {
+            variables: Default::default(),
             name: "bash-wf".to_string(),
             description: String::new(),
             builtin: false,
@@ -10131,7 +10195,6 @@ mod tests {
             child_outputs: None,
             state: crate::workflow::state::default_step_entry_state(),
         }];
-
         let (sys, prompt) = WorkflowEngine::build_step_prompt(
             &step,
             "00000000-0000-0000-0000-000000000000",
@@ -10139,6 +10202,7 @@ mod tests {
             Some("Fix bug"),
             &outputs,
             &history,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap();
@@ -10153,9 +10217,11 @@ mod tests {
         // output_contract がある場合、作業本文の末尾にも Contract 由来の
         // 完了時アクションを置き、初回完了時に CLI 提出へ誘導する。
         assert!(prompt.contains("完了時の必須アクション"));
-        assert!(
-            prompt.contains("releash workflow output submit 00000000-0000-0000-0000-000000000000")
-        );
+        // CLI 名は起動環境別 alias で展開される（spec issues-1054）。
+        let cli_alias = WorkflowEngine::resolve_releash_alias();
+        assert!(prompt.contains(&format!(
+            "{cli_alias} workflow output submit 00000000-0000-0000-0000-000000000000"
+        )));
         assert!(prompt.contains("--step build"));
         assert!(prompt.contains("--type plan-doc"));
         assert!(prompt.contains("--json"));
@@ -10201,6 +10267,7 @@ mod tests {
             &HashMap::new(),
             &[],
             &HashMap::new(),
+            &HashMap::new(),
         );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -10219,7 +10286,6 @@ mod tests {
         step.policy = Some("review".to_string());
         step.instruction = None;
         resolve_node_facets_for_test(&mut step, tmp.path());
-
         let (sys, prompt) = WorkflowEngine::build_step_prompt(
             &step,
             "00000000-0000-0000-0000-000000000000",
@@ -10227,6 +10293,7 @@ mod tests {
             None,
             &HashMap::new(),
             &[],
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap();
@@ -10253,7 +10320,6 @@ mod tests {
         step.output_contract = Some("plan-doc".to_string());
         step.instruction = None;
         resolve_node_facets_for_test(&mut step, tmp.path());
-
         let (sys, prompt) = WorkflowEngine::build_step_prompt(
             &step,
             "00000000-0000-0000-0000-000000000000",
@@ -10261,6 +10327,7 @@ mod tests {
             None,
             &HashMap::new(),
             &[],
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap();
@@ -10271,12 +10338,72 @@ mod tests {
         assert!(sys.contains("POLICY_BODY"));
         assert!(sys.contains("CONTRACT_BODY"));
         assert!(prompt.contains("完了時の必須アクション"));
-        assert!(
-            prompt.contains("releash workflow output submit 00000000-0000-0000-0000-000000000000")
-        );
+        // CLI 名は起動環境別 alias で展開される（spec issues-1054）。
+        let cli_alias = WorkflowEngine::resolve_releash_alias();
+        assert!(prompt.contains(&format!(
+            "{cli_alias} workflow output submit 00000000-0000-0000-0000-000000000000"
+        )));
         assert!(prompt.contains("--step s"));
         assert!(prompt.contains("--type plan-doc"));
         assert!(!prompt.contains("+  --step"));
+    }
+
+    #[test]
+    fn build_step_prompt_expands_workflow_declared_variables_in_user_message() {
+        // spec issues-1054「workflow 定義変数の facet 展開」:
+        // build_step_prompt は workflow_declared_variables を facet 本文の
+        // `{{vars.<name>}}` 展開に渡す。本テストは instruction（user_message）と
+        // policy（system_prompt）の双方で `{{vars.*}}` が宣言値に置換されることを検証する。
+        let tmp = tempfile::TempDir::new().unwrap();
+        let base = tmp.path();
+        let instructions = base.join("instructions");
+        let policies = base.join("policies");
+        std::fs::create_dir_all(&instructions).unwrap();
+        std::fs::create_dir_all(&policies).unwrap();
+        std::fs::write(
+            instructions.join("impl-vars.md"),
+            "Spec dir: {{vars.spec_dir}}\nEnv: {{vars.env}}",
+        )
+        .unwrap();
+        std::fs::write(
+            policies.join("vars-policy.md"),
+            "Operate within {{vars.env}}.",
+        )
+        .unwrap();
+
+        let mut step = make_test_step("impl", NodeType::Agent, "unused", vec![], None);
+        step.instruction = Some("impl-vars".to_string());
+        step.policy = Some("vars-policy".to_string());
+        step.output_contract = None;
+        resolve_node_facets_for_test(&mut step, base);
+
+        let mut declared = HashMap::new();
+        declared.insert("spec_dir".to_string(), "docs/specs/issues-1054".to_string());
+        declared.insert("env".to_string(), "production".to_string());
+
+        let (sys, prompt) = WorkflowEngine::build_step_prompt(
+            &step,
+            "00000000-0000-0000-0000-000000000000",
+            "/repo",
+            None,
+            &HashMap::new(),
+            &[],
+            &HashMap::new(),
+            &declared,
+        )
+        .unwrap();
+
+        // user_message 側の `{{vars.spec_dir}}` / `{{vars.env}}` が宣言値に展開される
+        assert!(prompt.contains("Spec dir: docs/specs/issues-1054"));
+        assert!(prompt.contains("Env: production"));
+        // 未展開トークンが残らない
+        assert!(!prompt.contains("{{vars.spec_dir}}"));
+        assert!(!prompt.contains("{{vars.env}}"));
+
+        // system_prompt 側でも `{{vars.env}}` が展開される
+        let sys_str = sys.expect("system_prompt should be set");
+        assert!(sys_str.contains("Operate within production."));
+        assert!(!sys_str.contains("{{vars.env}}"));
     }
 
     // ---- dispatch_session_start (SessionStartGate 経由のテストダブル検証) ----
@@ -10341,6 +10468,7 @@ mod tests {
             None,
             &HashMap::new(),
             &[],
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap();
@@ -10460,7 +10588,6 @@ mod tests {
         let mut step = make_test_step("s", NodeType::Agent, "unused", vec![], None);
         step.instruction = Some("only-instr".to_string());
         resolve_node_facets_for_test(&mut step, tmp.path());
-
         let (system_prompt, _prompt) = WorkflowEngine::build_step_prompt(
             &step,
             "00000000-0000-0000-0000-000000000000",
@@ -10468,6 +10595,7 @@ mod tests {
             None,
             &HashMap::new(),
             &[],
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap();
@@ -10613,6 +10741,7 @@ mod tests {
         step: NodeDefinition,
     ) {
         let workflow = Workflow {
+            variables: Default::default(),
             name: "regression-workflow".to_string(),
             description: "regression test".to_string(),
             builtin: false,
@@ -10831,7 +10960,6 @@ mod tests {
         ps.instruction = Some("inst".to_string());
         ps.output_contract = Some("oc".to_string());
         resolve_child_facets_for_test(&mut ps, base);
-
         let (system_prompt, user_message) = WorkflowEngine::build_parallel_step_prompt(
             &ps,
             "11111111-1111-1111-1111-111111111111",
@@ -10840,6 +10968,7 @@ mod tests {
             &HashMap::new(),
             false,
             None,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap();
@@ -10858,8 +10987,11 @@ mod tests {
         assert!(user_message.contains("PARALLEL_KNOWLEDGE_BODY"));
         assert!(user_message.contains("PARALLEL_INSTRUCTION_BODY"));
         assert!(user_message.contains("完了時の必須アクション"));
-        assert!(user_message
-            .contains("releash workflow output submit 11111111-1111-1111-1111-111111111111"));
+        // CLI 名は起動環境別 alias で展開される（spec issues-1054）。
+        let cli_alias = WorkflowEngine::resolve_releash_alias();
+        assert!(user_message.contains(&format!(
+            "{cli_alias} workflow output submit 11111111-1111-1111-1111-111111111111"
+        )));
         assert!(user_message.contains("--step child"));
         assert!(user_message.contains("--type oc"));
         assert!(!user_message.contains("+  --step"));
@@ -10880,7 +11012,6 @@ mod tests {
         let mut ps = make_parallel_step("child");
         ps.instruction = Some("inst".to_string());
         resolve_child_facets_for_test(&mut ps, base);
-
         let (system_prompt, user_message) = WorkflowEngine::build_parallel_step_prompt(
             &ps,
             "11111111-1111-1111-1111-111111111111",
@@ -10889,6 +11020,7 @@ mod tests {
             &HashMap::new(),
             false,
             None,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap();
@@ -11136,6 +11268,7 @@ mod tests {
         WorkflowExecution {
             id: "exec-1".to_string(),
             workflow: Workflow {
+                variables: Default::default(),
                 name: "test".to_string(),
                 description: "test".to_string(),
                 builtin: false,
@@ -11643,6 +11776,7 @@ mod tests {
         let mut exec = WorkflowExecution {
             id: "exec-1".to_string(),
             workflow: Workflow {
+                variables: Default::default(),
                 name: "review-fix".to_string(),
                 description: "test".to_string(),
                 builtin: false,
@@ -11767,6 +11901,7 @@ mod tests {
         let mut exec = WorkflowExecution {
             id: "exec-1".to_string(),
             workflow: Workflow {
+                variables: Default::default(),
                 name: "auto-approve".to_string(),
                 description: "test".to_string(),
                 builtin: false,
@@ -12032,6 +12167,7 @@ mod tests {
         let mut exec = WorkflowExecution {
             id: "exec-auto-approve".to_string(),
             workflow: Workflow {
+                variables: Default::default(),
                 name: "auto-approve-path".to_string(),
                 description: "test".to_string(),
                 builtin: false,
@@ -12178,6 +12314,7 @@ mod tests {
         let exec = WorkflowExecution {
             id: "exec-auto-approve".to_string(),
             workflow: Workflow {
+                variables: Default::default(),
                 name: "auto-approve-execute-outcome".to_string(),
                 description: "test".to_string(),
                 builtin: false,
@@ -12614,6 +12751,7 @@ mod tests {
 
     fn make_on_exhausted_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "on-exhausted-test".to_string(),
             description: "Test on_exhausted".to_string(),
             builtin: false,
@@ -12872,6 +13010,7 @@ mod tests {
     fn on_exhausted_chain_transitions() {
         // step_a → (exhausted) → step_b → (exhausted) → step_c
         let wf = Workflow {
+            variables: Default::default(),
             name: "chain-test".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -12936,6 +13075,7 @@ mod tests {
     fn on_exhausted_chain_to_non_exhausted_fails() {
         // step_a → (exhausted) → step_b (exhausted, no on_exhausted) → Failed
         let wf = Workflow {
+            variables: Default::default(),
             name: "chain-fail-test".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -13063,6 +13203,7 @@ mod tests {
             ..NodeDefinition::default()
         };
         let wf = Workflow {
+            variables: Default::default(),
             name: "loop-parallel".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -13575,6 +13716,7 @@ mod tests {
 
     fn make_minimal_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "engine-test-wf".to_string(),
             description: "minimal".to_string(),
             builtin: false,
@@ -13595,6 +13737,7 @@ mod tests {
     fn validate_workflow_shape_rejects_empty_and_bash_workflows_without_side_effects() {
         // 空 nodes は InvalidWorkflow
         let empty = Workflow {
+            variables: Default::default(),
             name: "wf".to_string(),
             description: "".to_string(),
             builtin: false,
@@ -13607,6 +13750,7 @@ mod tests {
 
         // bash node を含む workflow も InvalidWorkflow
         let bash = Workflow {
+            variables: Default::default(),
             name: "wf".to_string(),
             description: "".to_string(),
             builtin: false,
@@ -14572,6 +14716,7 @@ mod dispatch_boundary_tests {
 
     fn make_approval_only_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "boundary-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -14586,6 +14731,7 @@ mod dispatch_boundary_tests {
 
     fn make_rejectable_approval_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "boundary-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -14906,6 +15052,7 @@ mod dispatch_boundary_tests {
             step_history: vec![],
             step_execution_counts: HashMap::new(),
             workflow_definition: crate::workflow::schema::Workflow {
+                variables: Default::default(),
                 name: workflow_name.to_string(),
                 description: String::new(),
                 builtin: false,
@@ -15606,6 +15753,7 @@ mod dispatch_boundary_tests {
             step_history: vec![],
             step_execution_counts: HashMap::new(),
             workflow_definition: crate::workflow::schema::Workflow {
+                variables: Default::default(),
                 name: "fail-wf".to_string(),
                 description: String::new(),
                 builtin: false,
@@ -16232,6 +16380,7 @@ mod dispatch_boundary_tests {
     #[test]
     fn make_aborted_parallel_history_entry_snapshots_mixed_child_states() {
         let workflow = Workflow {
+            variables: Default::default(),
             name: "wf".to_string(),
             description: String::new(),
             builtin: false,
@@ -17131,6 +17280,7 @@ mod dispatch_boundary_tests {
             workflow_file_stem: "wf".to_string(),
             worktree_path: "/wt/a".to_string(),
             workflow_definition: Workflow {
+                variables: Default::default(),
                 name: "wf".to_string(),
                 description: String::new(),
                 builtin: false,
@@ -17276,6 +17426,7 @@ mod dispatch_boundary_tests {
 
     fn make_submit_output_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "submit-wf".to_string(),
             description: String::new(),
             builtin: false,
@@ -17574,6 +17725,7 @@ mod dispatch_boundary_tests {
         engine.set_run_store_data_dir(data_dir).await;
         let run_id = uuid::Uuid::new_v4().to_string();
         let workflow = Workflow {
+            variables: Default::default(),
             name: "spec-wf".to_string(),
             description: String::new(),
             builtin: false,
@@ -17630,6 +17782,7 @@ mod dispatch_boundary_tests {
         engine.set_run_store_data_dir(data_dir).await;
         let run_id = uuid::Uuid::new_v4().to_string();
         let workflow = Workflow {
+            variables: Default::default(),
             name: "multi-step".to_string(),
             description: String::new(),
             builtin: false,
@@ -17829,6 +17982,7 @@ mod dispatch_boundary_tests {
         engine.set_run_store_data_dir(data_dir).await;
         let run_id = uuid::Uuid::new_v4().to_string();
         let workflow = Workflow {
+            variables: Default::default(),
             name: "spec-wf".to_string(),
             description: String::new(),
             builtin: false,

--- a/src-tauri/src/workflow/engine.rs
+++ b/src-tauri/src/workflow/engine.rs
@@ -6880,6 +6880,7 @@ Do not create a temporary JSON file for this. Do not finish the step until the c
         });
         let mut user_message =
             Self::render_facet_variables(&composed.user_message, worktree_path, task);
+        user_message = Self::render_submit_command_variables(&user_message, run_id, &ps.name);
         user_message =
             Self::render_namespaced_variables(&user_message, workflow_declared_variables);
 

--- a/src-tauri/src/workflow/event.rs
+++ b/src-tauri/src/workflow/event.rs
@@ -373,6 +373,7 @@ mod tests {
     fn minimal_workflow() -> Workflow {
         use crate::workflow::schema::{NodeDefinition, NodeType};
         Workflow {
+            variables: Default::default(),
             name: "wf".to_string(),
             description: "".to_string(),
             builtin: false,

--- a/src-tauri/src/workflow/event_projection.rs
+++ b/src-tauri/src/workflow/event_projection.rs
@@ -1407,6 +1407,7 @@ mod tests {
 
     fn workflow_with_nodes(name: &str, nodes: Vec<&str>) -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: name.to_string(),
             description: String::new(),
             builtin: false,

--- a/src-tauri/src/workflow/facet.rs
+++ b/src-tauri/src/workflow/facet.rs
@@ -16,8 +16,30 @@ pub fn facets_base_dir() -> PathBuf {
     storage::workflows_dir()
 }
 
-/// システム定義テンプレート変数（commands.rs / diagnostics.rs 両方から参照）
+/// システム定義テンプレート変数（commands.rs / diagnostics.rs 両方から参照）。
+///
+/// トップレベル namespace（namespace 接頭辞を持たない）として展開される変数群。
+/// 新規 namespace (`path_alias.*` / `vars.*`) とは別経路で解決され、互換性のために
+/// そのまま残す（spec [01] 既存プレースホルダの互換性）。
 pub const SYSTEM_TEMPLATE_VARIABLES: &[&str] = &["project_name", "task"];
+
+/// テンプレート変数の namespace 接頭辞。
+///
+/// `path_alias.<key>` と `vars.<key>` の 2 つのみを公開する
+/// （spec [01] テンプレート展開は namespace 制）。
+pub const PATH_ALIAS_NAMESPACE: &str = "path_alias";
+pub const VARS_NAMESPACE: &str = "vars";
+
+/// 既知の namespace 接頭辞集合。`<namespace>.<key>` 形式の変数参照を判定する。
+pub const KNOWN_NAMESPACES: &[&str] = &[PATH_ALIAS_NAMESPACE, VARS_NAMESPACE];
+
+/// テンプレート変数参照を namespace と key に分解する。
+///
+/// - `"path_alias.releash"` → `Some(("path_alias", "releash"))`
+/// - `"project_name"` → `None`（namespace を持たないトップレベル変数）
+pub fn split_namespaced(var: &str) -> Option<(&str, &str)> {
+    var.split_once('.')
+}
 
 #[derive(Debug)]
 pub enum FacetError {
@@ -97,8 +119,11 @@ impl FacetKind {
 /// typed API）のみ。step agent の自由文に書かれた `<workflow_output>` 相当の表現は
 /// engine から観測されないため、必ず CLI 経由で提出する必要がある。
 pub fn output_contract_preamble(key: &str) -> String {
+    // CLI 名は起動環境別に展開する。`{{path_alias.releash}}` は engine の
+    // `render_namespaced_variables` 段で `releash` / `releash-dev` に置換される
+    // （spec issues-1054 facet テンプレートにおける CLI alias の展開）。
     format!(
-        "step 完了時に下記データ仕様 (型: {key}) に従う JSON を `releash workflow output submit` で提出すること。\nチャット本文や最終応答に JSON をそのまま書いても提出とは扱われない。必ず CLI コマンドを実行すること。\n\n```sh\nreleash workflow output submit {{{{run_id}}}} \\\n  --step {{{{step_name}}}} \\\n  --type {key} \\\n  --json '{{...}}'\n```\n\n提出が成功するまで step は完了として扱われない。失敗時は `releash workflow output validate` でフォーマットを確認してから再提出する。\n\nデータ仕様 (型: {key}):"
+        "step 完了時に下記データ仕様 (型: {key}) に従う JSON を `{{{{path_alias.releash}}}} workflow output submit` で提出すること。\nチャット本文や最終応答に JSON をそのまま書いても提出とは扱われない。必ず CLI コマンドを実行すること。\n\n```sh\n{{{{path_alias.releash}}}} workflow output submit {{{{run_id}}}} \\\n  --step {{{{step_name}}}} \\\n  --type {key} \\\n  --json '{{...}}'\n```\n\n提出が成功するまで step は完了として扱われない。失敗時は `{{{{path_alias.releash}}}} workflow output validate` でフォーマットを確認してから再提出する。\n\nデータ仕様 (型: {key}):"
     )
 }
 
@@ -109,13 +134,15 @@ pub fn output_contract_preamble(key: &str) -> String {
 /// 余地が残る。Contract 由来の提出手順を user message の末尾にも置き、提出値が
 /// 確定した時点の次アクションを CLI 実行に固定する。
 pub fn output_contract_completion_action(key: &str) -> String {
+    // CLI 名は起動環境別に展開する（dev → `releash-dev` / 本番 → `releash`）。
+    // engine 側で `{{path_alias.releash}}` を解決する（spec issues-1054）。
     format!(
         "## 完了時の必須アクション\n\n\
 提出値が確定した時点で、次の assistant action は最終応答ではなく CLI 実行でなければならない。\n\
 チャット本文に JSON や要約を書いても提出とは扱われない。必ず次のコマンドで出力を提出すること。\n\
 このコマンドが成功するまで step は完了していない。\n\n\
 ```sh\n\
-releash workflow output submit {{{{run_id}}}} \\\n  --step {{{{step_name}}}} \\\n  --type {key} \\\n  --json '{{...}}'\n\
+{{{{path_alias.releash}}}} workflow output submit {{{{run_id}}}} \\\n  --step {{{{step_name}}}} \\\n  --type {key} \\\n  --json '{{...}}'\n\
 ```"
     )
 }
@@ -165,10 +192,55 @@ pub fn extract_template_variables(content: &str) -> Vec<String> {
 
 /// テンプレート変数がすべてシステム定義変数であることを検証する。
 /// 未定義変数があればそのリストを返す。
+///
+/// namespace 付きの参照は namespace 別に判定する:
+/// - `path_alias.<key>`: `PathAliases::known_keys()` に含まれる key のみ既知。
+///   未知 key（typo 等）は未定義として返す（spec design.md「未定義参照はエラー」）。
+/// - `vars.<key>`: workflow 文脈に依存して解決可能性が決まるため、ここでは「定義済み」とみなし
+///   対象から除外する。`vars.*` の未定義検出は `find_undefined_workflow_variable_refs` 経由で
+///   workflow 読み込み時に行う（spec [01] 未定義 workflow 変数の拒否）。
+/// - 未知 namespace（`KNOWN_NAMESPACES` 外）は未定義として返す。
 pub fn find_undefined_template_variables(content: &str) -> Vec<String> {
     extract_template_variables(content)
         .into_iter()
-        .filter(|v| !SYSTEM_TEMPLATE_VARIABLES.contains(&v.as_str()))
+        .filter(|v| {
+            if let Some((ns, key)) = split_namespaced(v) {
+                if ns == PATH_ALIAS_NAMESPACE {
+                    // 公開 path_alias key 集合に含まれないものは未定義（typo の検出）。
+                    !crate::path_aliases::PathAliases::known_keys().contains(&key)
+                } else if ns == VARS_NAMESPACE {
+                    // workflow 定義依存のため facet 単体検証では弾かない。
+                    false
+                } else {
+                    // 未知 namespace は未定義として扱う。
+                    !KNOWN_NAMESPACES.contains(&ns)
+                }
+            } else {
+                !SYSTEM_TEMPLATE_VARIABLES.contains(&v.as_str())
+            }
+        })
+        .collect()
+}
+
+/// facet 本文に含まれる `{{vars.<name>}}` 参照のうち、`defined` に存在しないものを返す。
+///
+/// workflow 読み込み時 (`storage::load_workflow`) に、宣言された変数定義を渡して
+/// 未定義参照を検出する境界として使う（spec [01] 未定義 workflow 変数の拒否）。
+pub fn find_undefined_workflow_variable_refs(
+    content: &str,
+    defined: &std::collections::HashMap<String, String>,
+) -> Vec<String> {
+    extract_template_variables(content)
+        .into_iter()
+        .filter_map(|v| {
+            split_namespaced(&v).and_then(|(ns, key)| {
+                if ns == VARS_NAMESPACE && !defined.contains_key(key) {
+                    Some(key.to_string())
+                } else {
+                    None
+                }
+            })
+        })
         .collect()
 }
 
@@ -178,10 +250,85 @@ pub fn render_template_variables(
     content: &str,
     values: &std::collections::HashMap<String, String>,
 ) -> String {
-    let mut result = content.to_string();
-    for (key, value) in values {
-        let pattern = format!("{{{{{key}}}}}");
-        result = result.replace(&pattern, value);
+    replace_template_refs(content, |inner| values.get(inner).cloned())
+}
+
+/// facet 本文中の `{{path_alias.<key>}}` を解決済み alias 名で置換する。
+///
+/// spec [01] 「facet テンプレートにおける CLI alias の展開」:
+/// - 本番起動時 `{{path_alias.releash}}` → `releash`
+/// - dev 起動時 `{{path_alias.releash}}` → `releash-dev`
+///
+/// 既知 key のみを置換し、`{{path_alias.relase}}`（typo）等は未展開のまま残す。
+/// 未展開は `find_undefined_template_variables` 側で未定義として検出される
+/// （spec design.md「未定義参照はエラー」）。
+///
+/// 引数で alias 名のみを受け取る。data_dir 解決を経由しないため、`dirs::data_dir()`
+/// 失敗の経路と切り離せる。
+pub fn render_path_alias_variables_with_name(content: &str, releash_alias_name: &str) -> String {
+    replace_template_refs(content, |inner| match inner {
+        "path_alias.releash" => Some(releash_alias_name.to_string()),
+        _ => None,
+    })
+}
+
+/// facet 本文中の `{{vars.<name>}}` を workflow 定義側の変数値で置換する。
+///
+/// spec [01] 「workflow 定義変数の facet 展開」:
+/// `vars` namespace は workflow 定義で宣言された静的文字列のみを解決する。
+/// 未定義参照の検出は load 時 (`find_undefined_workflow_variable_refs`) が一次境界。
+///
+/// 元 content から `{{...}}` を**単一パス**で検出して置換する（置換後文字列を再スキャン
+/// しない）。これにより、変数値に `{{vars.other}}` の文字列が含まれていても二次展開
+/// されず、HashMap 反復順序にも依存しない（spec Contracts「{{vars.<name>}} の値は
+/// 静的文字列のみとし、動的解決値を含まない」）。
+pub fn render_workflow_variables(
+    content: &str,
+    variables: &std::collections::HashMap<String, String>,
+) -> String {
+    replace_template_refs(content, |inner| {
+        inner
+            .strip_prefix("vars.")
+            .and_then(|name| variables.get(name).cloned())
+    })
+}
+
+/// `{{...}}` 参照を元 content から単一パスで検出し、`resolve` が `Some` を返した
+/// 参照のみを置換する。`None` を返した参照は元の `{{...}}` を保ったまま残す。
+///
+/// 置換後の文字列を再スキャンしないため、二次展開が発生せず、入力の HashMap 反復順序
+/// にも依存しない。
+///
+/// `{{...}}` 内側の前後空白は trim してから `resolve` に渡すため、`{{key}}` と
+/// `{{ key }}` は同一参照として扱う。未解決時に元のまま残す出力は `raw_inner`
+/// （trim 前）を用いるため、内側スペースは保存される。
+fn replace_template_refs(content: &str, mut resolve: impl FnMut(&str) -> Option<String>) -> String {
+    let mut result = String::with_capacity(content.len());
+    let mut rest = content;
+    while !rest.is_empty() {
+        let Some(open_idx) = rest.find("{{") else {
+            result.push_str(rest);
+            break;
+        };
+        result.push_str(&rest[..open_idx]);
+        let after_open = &rest[open_idx + 2..];
+        let Some(close_idx) = after_open.find("}}") else {
+            // 閉じが見つからない: 残り全部をそのまま出して終わる。
+            result.push_str("{{");
+            result.push_str(after_open);
+            break;
+        };
+        let raw_inner = &after_open[..close_idx];
+        let inner = raw_inner.trim();
+        match resolve(inner) {
+            Some(value) => result.push_str(&value),
+            None => {
+                result.push_str("{{");
+                result.push_str(raw_inner);
+                result.push_str("}}");
+            }
+        }
+        rest = &after_open[close_idx + 2..];
     }
     result
 }
@@ -748,8 +895,9 @@ mod tests {
 
         let sys = result.system_prompt.expect("system_prompt should be set");
         // 出力 Contract preamble は CLI 提出経路（[08]）を agent に指示し、
-        // 型ラベルと Contract 本文を含む
-        assert!(sys.contains("releash workflow output submit"));
+        // 型ラベルと Contract 本文を含む。CLI 名は engine 側で
+        // `{{path_alias.releash}}` を起動環境別 alias に置換する（spec issues-1054）。
+        assert!(sys.contains("{{path_alias.releash}} workflow output submit"));
         assert!(sys.contains("--type plan-doc"));
         assert!(sys.contains("--json"));
         assert!(sys.contains("チャット本文や最終応答に JSON をそのまま書いても提出とは扱われない"));
@@ -764,7 +912,8 @@ mod tests {
 
         assert!(action.contains("完了時の必須アクション"));
         assert!(action.contains("次の assistant action は最終応答ではなく CLI 実行"));
-        assert!(action.contains("releash workflow output submit"));
+        // CLI 名は engine 側の `render_namespaced_variables` で展開される。
+        assert!(action.contains("{{path_alias.releash}} workflow output submit"));
         assert!(action.contains("--type plan-doc"));
         assert!(action.contains("--json"));
         assert!(!action.contains("--file"));
@@ -1036,5 +1185,135 @@ mod tests {
                 FacetError::BuiltinProtected { .. }
             ));
         }
+    }
+
+    // --- namespace 展開 (spec issues-1054) ---
+
+    #[test]
+    fn render_path_alias_substitutes_releash_with_runtime_alias() {
+        // Rule: 起動環境別 `{{path_alias.releash}}` が `releash` / `releash-dev` に展開される
+        let alias_name = crate::path_aliases::alias_name_for_profile(
+            crate::path_aliases::BuildProfile::current(),
+        );
+        let content = "Run `{{path_alias.releash}} workflow output submit`";
+        let rendered = render_path_alias_variables_with_name(content, alias_name);
+        let expected_alias = if cfg!(debug_assertions) {
+            "releash-dev"
+        } else {
+            "releash"
+        };
+        assert!(
+            rendered.contains(&format!("Run `{expected_alias} workflow output submit`")),
+            "rendered={rendered}"
+        );
+    }
+
+    #[test]
+    fn render_workflow_variables_substitutes_declared_vars() {
+        // Rule: workflow が宣言した変数は `{{vars.<name>}}` で facet から参照できる
+        let mut vars = std::collections::HashMap::new();
+        vars.insert("project_label".to_string(), "Releash".to_string());
+        vars.insert("env".to_string(), "production".to_string());
+        let content = "Project: {{vars.project_label}}, env={{vars.env}}";
+        let rendered = render_workflow_variables(content, &vars);
+        assert_eq!(rendered, "Project: Releash, env=production");
+    }
+
+    #[test]
+    fn find_undefined_workflow_variable_refs_returns_only_undefined_vars() {
+        let mut vars = std::collections::HashMap::new();
+        vars.insert("known".to_string(), "value".to_string());
+        let content = "{{vars.known}} {{vars.unknown}} {{vars.another_missing}}";
+        let mut undefined = find_undefined_workflow_variable_refs(content, &vars);
+        undefined.sort();
+        assert_eq!(undefined, vec!["another_missing", "unknown"]);
+    }
+
+    #[test]
+    fn find_undefined_template_variables_does_not_flag_namespaced_refs() {
+        // 既存 SYSTEM_TEMPLATE_VARIABLES 以外のトップレベル参照は未定義扱いだが、
+        // 既知 namespace + 既知 key（`path_alias.releash` / `vars.*`）は facet 単体検証では対象外。
+        let content = "{{project_name}} {{vars.x}} {{path_alias.releash}} {{unknown_top}}";
+        let undefined = find_undefined_template_variables(content);
+        assert_eq!(undefined, vec!["unknown_top".to_string()]);
+    }
+
+    #[test]
+    fn find_undefined_template_variables_flags_unknown_namespace() {
+        // 既知 namespace に含まれない `<ns>.<key>` は未定義扱いになる。
+        let content = "{{not_a_namespace.key}}";
+        let undefined = find_undefined_template_variables(content);
+        assert_eq!(undefined, vec!["not_a_namespace.key".to_string()]);
+    }
+
+    #[test]
+    fn find_undefined_template_variables_flags_unknown_path_alias_key() {
+        // path_alias namespace は known_keys に含まれる key のみ既知扱い。
+        // typo（例: `relase`）は未定義として検出される（spec design.md「未定義参照はエラー」）。
+        let content = "{{path_alias.relase}} {{path_alias.releash}}";
+        let undefined = find_undefined_template_variables(content);
+        assert_eq!(undefined, vec!["path_alias.relase".to_string()]);
+    }
+
+    #[test]
+    fn render_path_alias_variables_leaves_unknown_keys_intact() {
+        // typo した key は置換せず未展開のまま残す（未定義検出側でエラーになる）。
+        let alias_name = crate::path_aliases::alias_name_for_profile(
+            crate::path_aliases::BuildProfile::current(),
+        );
+        let content = "{{path_alias.relase}} / {{path_alias.releash}}";
+        let rendered = render_path_alias_variables_with_name(content, alias_name);
+        assert!(
+            rendered.contains("{{path_alias.relase}}"),
+            "unknown key should remain unexpanded: {rendered}"
+        );
+        let expected_alias = if cfg!(debug_assertions) {
+            "releash-dev"
+        } else {
+            "releash"
+        };
+        assert!(
+            rendered.contains(expected_alias),
+            "known key should be expanded: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_workflow_variables_does_not_secondary_expand() {
+        // Rule: 値内に `{{vars.other}}` の文字列があっても二次展開せず、HashMap
+        // 反復順序に依存しない（spec Contracts: 値は静的文字列のみ）。
+        let mut vars = std::collections::HashMap::new();
+        vars.insert("a".to_string(), "{{vars.b}}".to_string());
+        vars.insert("b".to_string(), "RESOLVED_B".to_string());
+        let content = "A={{vars.a}} B={{vars.b}}";
+        let rendered = render_workflow_variables(content, &vars);
+        // 反復順序によらず: `{{vars.a}}` は値そのもの (`{{vars.b}}` 文字列) になる。
+        assert_eq!(rendered, "A={{vars.b}} B=RESOLVED_B");
+    }
+
+    #[test]
+    fn render_workflow_variables_leaves_undefined_refs_unchanged() {
+        let vars = std::collections::HashMap::new();
+        let rendered = render_workflow_variables("hello {{vars.missing}} world", &vars);
+        assert_eq!(rendered, "hello {{vars.missing}} world");
+    }
+
+    #[test]
+    fn render_template_variables_treats_surrounding_whitespace_inside_refs_as_equivalent() {
+        // `{{ task }}` と `{{task}}` を同一参照として扱う（trim 後にマッチ）。
+        // 既存テンプレートに空白付き参照は存在しないため互換性影響はなく、
+        // 本挙動は `replace_template_refs` の意図的な仕様（doc 参照）。
+        let mut vars = std::collections::HashMap::new();
+        vars.insert("task".to_string(), "do".to_string());
+        let out = render_template_variables("a {{ task }} b", &vars);
+        assert_eq!(out, "a do b");
+    }
+
+    #[test]
+    fn render_template_variables_keeps_unresolved_ref_verbatim_including_whitespace() {
+        // 解決できない参照は元の `{{ ... }}` をそのまま残し、内側のスペースを変更しない。
+        let vars = std::collections::HashMap::new();
+        let out = render_template_variables("x {{ unknown }} y", &vars);
+        assert_eq!(out, "x {{ unknown }} y");
     }
 }

--- a/src-tauri/src/workflow/log.rs
+++ b/src-tauri/src/workflow/log.rs
@@ -232,6 +232,7 @@ mod tests {
     fn minimal_workflow_for_log(name: &str) -> Workflow {
         use crate::workflow::schema::{NodeDefinition, NodeType};
         Workflow {
+            variables: Default::default(),
             name: name.to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -705,6 +706,7 @@ mod tests {
         });
         let _ = &mut plan;
         Workflow {
+            variables: Default::default(),
             name: "test-wf".to_string(),
             description: "".to_string(),
             builtin: false,
@@ -923,6 +925,7 @@ mod tests {
             ..NodeDefinition::default()
         };
         let wf = Workflow {
+            variables: Default::default(),
             name: "parallel-wf".to_string(),
             description: "".to_string(),
             builtin: false,
@@ -1189,6 +1192,7 @@ mod tests {
             next: "ship".to_string(),
         }];
         let wf = Workflow {
+            variables: Default::default(),
             name: "approval-then-next".to_string(),
             description: "".to_string(),
             builtin: false,

--- a/src-tauri/src/workflow/pending_command_dispatcher.rs
+++ b/src-tauri/src/workflow/pending_command_dispatcher.rs
@@ -353,6 +353,7 @@ mod tests {
 
     fn make_approval_only_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "boundary-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -367,6 +368,7 @@ mod tests {
 
     fn make_submit_output_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "boundary-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
@@ -399,6 +401,7 @@ mod tests {
 
     fn make_rejectable_approval_workflow() -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "boundary-wf".to_string(),
             description: "test".to_string(),
             builtin: false,

--- a/src-tauri/src/workflow/runtime_view.rs
+++ b/src-tauri/src/workflow/runtime_view.rs
@@ -70,6 +70,7 @@ mod tests {
             }],
             step_execution_counts: HashMap::new(),
             workflow_definition: Workflow {
+                variables: Default::default(),
                 name: "wf".to_string(),
                 description: String::new(),
                 builtin: false,
@@ -167,6 +168,7 @@ mod tests {
             ],
             step_execution_counts: HashMap::new(),
             workflow_definition: Workflow {
+                variables: Default::default(),
                 name: "wf".to_string(),
                 description: String::new(),
                 builtin: false,

--- a/src-tauri/src/workflow/schema.rs
+++ b/src-tauri/src/workflow/schema.rs
@@ -1,17 +1,26 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// ワークフローテンプレート定義（[02] Normalized Workflow）。
 ///
 /// 旧 `steps:` 記法は廃止され、`nodes:` 配下の `NodeDefinition` 列が
 /// YAML deserialize 先となる。実行インスタンス（`WorkflowRun` / `NodeExecution`）
 /// とは語彙が分離される（後者は [03][04] で導入予定）。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Workflow {
     pub name: String,
     pub description: String,
     #[serde(default)]
     pub builtin: bool,
+    /// facet 展開用の静的変数宣言（spec issues-1054）。
+    ///
+    /// workflow 全体共通スコープで宣言され、facet 本文から `{{vars.<name>}}` で参照できる。
+    /// 値は静的文字列のみで、環境変数や実行時情報などの動的解決値は含まない。
+    /// 実行時に積み上がる workflow 実行変数 (`WorkflowExecution.workflow_variables`) とは
+    /// 別領域として並存する。
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub variables: HashMap<String, String>,
     pub nodes: Vec<NodeDefinition>,
 }
 

--- a/src-tauri/src/workflow/storage.rs
+++ b/src-tauri/src/workflow/storage.rs
@@ -14,8 +14,18 @@ pub enum StorageError {
     YamlSerialize(serde_saphyr::ser::Error),
     Validation(ValidationError),
     FacetResolution(facet::FacetError),
-    NotFound { name: String },
-    BuiltinProtected { name: String },
+    /// facet 本文が `{{vars.<name>}}` で workflow 定義に存在しない変数を参照している。
+    /// spec issues-1054 「未定義 workflow 変数の拒否」: load 経路を一次境界として検出する。
+    UndefinedWorkflowVariables {
+        node_name: String,
+        undefined: Vec<String>,
+    },
+    NotFound {
+        name: String,
+    },
+    BuiltinProtected {
+        name: String,
+    },
 }
 
 impl fmt::Display for StorageError {
@@ -26,6 +36,14 @@ impl fmt::Display for StorageError {
             Self::YamlSerialize(e) => write!(f, "YAMLシリアライズ失敗: {e}"),
             Self::Validation(e) => write!(f, "validation_error: {e}"),
             Self::FacetResolution(e) => write!(f, "facet解決失敗: {e}"),
+            Self::UndefinedWorkflowVariables {
+                node_name,
+                undefined,
+            } => write!(
+                f,
+                "node '{node_name}' の facet が未定義の workflow 変数を参照しています: {} （workflow 定義の `variables` で宣言してください）",
+                undefined.join(", ")
+            ),
             Self::NotFound { name } => {
                 write!(f, "ワークフロー '{name}' が見つかりません")
             }
@@ -44,7 +62,9 @@ impl std::error::Error for StorageError {
             Self::YamlSerialize(e) => Some(e),
             Self::Validation(e) => Some(e),
             Self::FacetResolution(e) => Some(e),
-            _ => None,
+            Self::UndefinedWorkflowVariables { .. } => None,
+            Self::NotFound { .. } => None,
+            Self::BuiltinProtected { .. } => None,
         }
     }
 }
@@ -154,7 +174,63 @@ pub fn load_workflow(path: &Path, facets_base_dir: &Path) -> Result<Workflow, St
     workflow.builtin = builtin::is_builtin_workflow(&workflow.name);
     validation::validate(&workflow)?;
     facet::resolve_workflow_facets(&mut workflow, facets_base_dir)?;
+    // spec issues-1054: 未定義 `{{vars.<name>}}` 参照は load 経路を一次境界として検出する。
+    validate_workflow_variable_refs(&workflow)?;
     Ok(workflow)
+}
+
+/// resolved_facets の各本文に `{{vars.<name>}}` 参照が含まれている場合、
+/// すべて workflow.variables で宣言されていることを検証する。
+///
+/// spec issues-1054 「未定義 workflow 変数の拒否」: load 時点でエラーとし、
+/// 黙って空文字へ展開させない（権限や宛先ずれの事故防止）。
+fn validate_workflow_variable_refs(workflow: &Workflow) -> Result<(), StorageError> {
+    for node in &workflow.nodes {
+        for body in resolved_bodies(&node.resolved_facets) {
+            check_undefined_vars(&node.name, body, &workflow.variables)?;
+        }
+        if let Some(inline) = &node.inline_prompt {
+            check_undefined_vars(&node.name, inline, &workflow.variables)?;
+        }
+        if let Some(children) = &node.parallel_children {
+            for child in children {
+                for body in resolved_bodies(&child.resolved_facets) {
+                    check_undefined_vars(&child.name, body, &workflow.variables)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn resolved_bodies(
+    rf: &crate::workflow::schema::ResolvedFacets,
+) -> impl Iterator<Item = &str> + '_ {
+    rf.policy
+        .as_deref()
+        .into_iter()
+        .chain(rf.knowledge.as_deref())
+        .chain(rf.instruction.as_deref())
+        .chain(rf.output_contract.as_deref())
+        .chain(rf.input_contracts.iter().map(|s| s.as_str()))
+}
+
+fn check_undefined_vars(
+    node_name: &str,
+    body: &str,
+    defined: &std::collections::HashMap<String, String>,
+) -> Result<(), StorageError> {
+    let undefined = facet::find_undefined_workflow_variable_refs(body, defined);
+    if undefined.is_empty() {
+        return Ok(());
+    }
+    let mut unique: Vec<String> = undefined;
+    unique.sort();
+    unique.dedup();
+    Err(StorageError::UndefinedWorkflowVariables {
+        node_name: node_name.to_string(),
+        undefined: unique,
+    })
 }
 
 fn list_yml_summaries<T, E: fmt::Display>(
@@ -274,6 +350,7 @@ mod tests {
 
     fn sample_workflow(name: &str, builtin: bool) -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: name.to_string(),
             description: format!("{name} workflow"),
             builtin,
@@ -703,5 +780,80 @@ nodes:
         std::fs::write(&file_path, yaml).unwrap();
         let result = load_workflow(&file_path, dir);
         assert!(matches!(result, Err(StorageError::FacetResolution(_))));
+    }
+
+    /// spec issues-1054 「未定義 workflow 変数の拒否」: facet 本文が宣言されていない
+    /// `{{vars.<name>}}` を参照している workflow は load 経路で拒否される。
+    #[test]
+    fn load_workflow_rejects_undefined_workflow_variable_reference() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let instructions = dir.join("instructions");
+        std::fs::create_dir_all(&instructions).unwrap();
+        std::fs::write(
+            instructions.join("impl.md"),
+            "Run `{{vars.cli_alias}} workflow output submit`",
+        )
+        .unwrap();
+
+        let yaml = r#"
+name: undefined-var-ref
+description: undefined variable test
+variables:
+  other_var: "value"
+nodes:
+  - name: implement
+    type: agent
+    instruction: impl
+    permission: edit
+"#;
+        let file_path = dir.join("undefined-var-ref.yml");
+        std::fs::write(&file_path, yaml).unwrap();
+        let result = load_workflow(&file_path, dir);
+        let err = result.expect_err("undefined {{vars.cli_alias}} must be rejected");
+        match err {
+            StorageError::UndefinedWorkflowVariables {
+                node_name,
+                undefined,
+            } => {
+                assert_eq!(node_name, "implement");
+                assert_eq!(undefined, vec!["cli_alias".to_string()]);
+            }
+            other => panic!("expected UndefinedWorkflowVariables, got {other:?}"),
+        }
+    }
+
+    /// spec issues-1054 「workflow 定義変数の facet 展開」: workflow 定義の
+    /// `variables` で宣言された変数を参照する facet は load 経路を通る。
+    #[test]
+    fn load_workflow_accepts_declared_workflow_variable_reference() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let instructions = dir.join("instructions");
+        std::fs::create_dir_all(&instructions).unwrap();
+        std::fs::write(
+            instructions.join("impl.md"),
+            "Label: {{vars.project_label}}",
+        )
+        .unwrap();
+
+        let yaml = r#"
+name: declared-var-ref
+description: declared variable test
+variables:
+  project_label: "Releash"
+nodes:
+  - name: implement
+    type: agent
+    instruction: impl
+    permission: edit
+"#;
+        let file_path = dir.join("declared-var-ref.yml");
+        std::fs::write(&file_path, yaml).unwrap();
+        let wf = load_workflow(&file_path, dir).expect("load must succeed");
+        assert_eq!(
+            wf.variables.get("project_label").map(String::as_str),
+            Some("Releash")
+        );
     }
 }

--- a/src-tauri/src/workflow/validation.rs
+++ b/src-tauri/src/workflow/validation.rs
@@ -1268,6 +1268,7 @@ mod tests {
 
     fn make_workflow(nodes: Vec<NodeDefinition>) -> Workflow {
         Workflow {
+            variables: Default::default(),
             name: "test".to_string(),
             description: "test workflow".to_string(),
             builtin: false,

--- a/src-tauri/src/workflow_state_presenter.rs
+++ b/src-tauri/src/workflow_state_presenter.rs
@@ -319,6 +319,7 @@ mod tests {
             }],
             step_execution_counts: HashMap::new(),
             workflow_definition: Workflow {
+                variables: Default::default(),
                 name: "wf".to_string(),
                 description: String::new(),
                 builtin: false,

--- a/src-tauri/src/workflow_step_lifecycle.rs
+++ b/src-tauri/src/workflow_step_lifecycle.rs
@@ -802,6 +802,7 @@ mod tests {
             }],
             step_execution_counts: HashMap::new(),
             workflow_definition: Workflow {
+                variables: Default::default(),
                 name: "wf".to_string(),
                 description: String::new(),
                 builtin: false,


### PR DESCRIPTION
Closes #1054

## Summary

- 起動環境別に `PathAliases` (`releash` / `releash-dev`) を解決し、facet 本文・built-in prompt の `{{path_alias.releash}}` と子プロセスの `PATH` / `RELEASH_DATA_DIR` に**同一ソース**から値を供給する。
- dev 起動時は `/usr/local/bin/releash` の CLI install を**スキップ**し、本番 CLI を破壊しない。dev alias は dev データディレクトリ (`com.releash.app.dev`) を内包した wrapper として動作する。
- workflow 定義に `variables`（静的文字列のみ）を宣言可能にし、facet 本文から `{{vars.<name>}}` で参照できるようにする。未定義参照は workflow 読み込み時に `StorageError::UndefinedWorkflowVariables` として明示エラー化。
- 既存プレースホルダ (`{{project_name}}` / `{{task}}`) の展開結果は互換維持。

仕様: `docs/specs/issues-1054/{requirements,behavior,design}.md`

## Test plan

- [x] `cargo fmt --check` / `cargo clippy -- -D warnings`
- [x] `cargo test --lib`（1936 件 PASS）
- [ ] dev ビルド起動で agent が受け取る CLI コマンドが `releash-dev workflow output submit ...` 形式
- [ ] dev 起動後も `/usr/local/bin/releash` の symlink 先が本番 binary のまま
- [ ] `releash-dev workflow runs` 等が `com.releash.app.dev` データを参照
- [ ] 本番ビルド起動で agent が受け取る CLI コマンドが `releash workflow output submit ...` 形式
- [ ] workflow YAML に宣言した `variables` を facet から `{{vars.<name>}}` で参照すると展開される
- [ ] 未定義の `{{vars.<name>}}` を含む workflow は読み込み時にエラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 環境別のCLIコマンド自動切り替え（本番環境では `releash`、開発環境では `releash-dev`）が可能に
  * ワークフロー定義で変数を宣言し、ファセット内で `{{vars.<名前>}}` として参照可能に

* **Improvements**
  * 実行環境に応じたデータディレクトリの自動解決機能を強化
  * 開発ビルド時のCLI設定処理を最適化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siro33950/releash/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->