### PR TITLE
fix(agent): Codex app-server 子プロセスへ session env と worktree cwd を伝搬

### DIFF
--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
@@ -2180,7 +2180,7 @@ fn accumulate_sdk_message(
 ///
 /// facet template に `{{session_id}}` のような動的解決値を持ち込まず、Spec issues-1054 の
 /// `{{vars.<name>}}` 静的値原則を破らない経路で session 固有値を agent に届ける単一責任 helper。
-fn session_specific_env_overrides(
+pub(crate) fn session_specific_env_overrides(
     chat_session_id: &str,
     base_branch: Option<&str>,
 ) -> Vec<(&'static str, String)> {

--- a/src-tauri/src/infrastructure/agent_session/runtime/codex.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/codex.rs
@@ -10,8 +10,9 @@ use crate::domain::agent_session::CODEX_FIXED_MODELS;
 use crate::infrastructure::agent_session::runtime::bridge_common::{
     close_external_agent_process, finish_external_pending_message_turn_start,
     handle_external_bridge_message, prepare_external_pending_message_turn,
-    register_external_agent_process, start_external_agent_turn_state, write_bridge_command,
-    AgentProcessMap, ExternalBridgeMessageState, CODEX_BACKEND_ID,
+    register_external_agent_process, session_specific_env_overrides,
+    start_external_agent_turn_state, write_bridge_command, AgentProcessMap,
+    ExternalBridgeMessageState, CODEX_BACKEND_ID,
 };
 use crate::infrastructure::agent_session::runtime::codex_app_server::{
     app_server_message_to_bridge_messages, build_app_server_permission_response_for_bridge_request,
@@ -194,7 +195,29 @@ impl AppServerCodexRuntime {
         }
 
         wait_until_session_close_finished(&config.chat_session_id).await;
-        let parts = spawn_app_server_process_parts(&self.cli_path)?;
+
+        // spec issues-1054 / issues-1022: app-server 経路でも legacy bridge と同様に、
+        // alias 解決用 env（PATH / RELEASH_DATA_DIR）と session 固有 env
+        // （RELEASH_SESSION_ID / RELEASH_BASE_BRANCH）を agent 子プロセスへ伝搬する。
+        // legacy Node bridge では spawn_bridge_process が担っていた責務であり、
+        // app-server 直結への移行で欠落していたため、ここで等価に復元する。
+        let mut child_envs = crate::path_aliases::prepare_child_env(
+            self.app.path().app_data_dir().ok(),
+        )
+        .map_err(|e| format!("failed to prepare alias child env for codex app-server: {e}"))?;
+        let base_branch = self
+            .app
+            .state::<crate::adaptor::controller::state::AppState>()
+            .code_usecase
+            .resolve_effective_base_branch_name(&config.cwd)
+            .ok()
+            .flatten();
+        for (key, value) in
+            session_specific_env_overrides(&config.chat_session_id, base_branch.as_deref())
+        {
+            child_envs.push((key.to_string(), value));
+        }
+        let parts = spawn_app_server_process_parts(&self.cli_path, Some(&config.cwd), &child_envs)?;
         let state = Arc::new(Mutex::new(AppServerSessionState::new()));
         let data_dir = resolve_data_dir(&self.app)?;
         let stored_session = self

--- a/src-tauri/src/infrastructure/agent_session/runtime/codex_app_server.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/codex_app_server.rs
@@ -132,6 +132,8 @@ fn app_server_args() -> [&'static str; 3] {
 
 pub(crate) fn spawn_app_server_process_parts(
     cli_path: &str,
+    cwd: Option<&str>,
+    envs: &[(String, String)],
 ) -> Result<CodexAppServerProcessParts, String> {
     let mut command = Command::new(cli_path);
     command
@@ -139,6 +141,12 @@ pub(crate) fn spawn_app_server_process_parts(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    if let Some(dir) = cwd {
+        command.current_dir(dir);
+    }
+    for (key, value) in envs {
+        command.env(key, value);
+    }
 
     #[cfg(unix)]
     // SAFETY: setsid() is async-signal-safe per POSIX.
@@ -1025,7 +1033,7 @@ pub(crate) fn app_server_message_to_bridge_messages(
 
 impl CodexAppServerProcess {
     pub(crate) fn spawn(cli_path: &str) -> Result<Self, String> {
-        let parts = spawn_app_server_process_parts(cli_path)?;
+        let parts = spawn_app_server_process_parts(cli_path, None, &[])?;
         Ok(Self {
             child: parts.child,
             stdin: parts.stdin,
@@ -1698,6 +1706,37 @@ mod tests {
     #[test]
     fn app_server_args_use_stdio_transport() {
         assert_eq!(app_server_args(), ["app-server", "--listen", "stdio://"]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_app_server_process_parts_injects_provided_envs() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // app-server 経路でも RELEASH_SESSION_ID 等が子プロセスへ確実に伝搬することを保証する。
+        // 偽 CLI が自分の env を file へ書き出し、その内容で注入有無を検証する。
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("env.out");
+        let script = dir.path().join("fake-cli.sh");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nprintenv RELEASH_SESSION_ID > \"{}\"\n",
+                out.display()
+            ),
+        )
+        .expect("write script");
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+
+        let envs = vec![("RELEASH_SESSION_ID".to_string(), "sid-xyz".to_string())];
+        let mut parts = spawn_app_server_process_parts(script.to_str().unwrap(), None, &envs)
+            .expect("spawn fake cli");
+        parts.child.wait().await.expect("wait fake cli");
+
+        let contents = std::fs::read_to_string(&out).expect("read env out");
+        assert_eq!(contents.trim(), "sid-xyz");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Codex backend の app-server 直結移行（#1141）で欠落していた agent 子プロセスへの env / cwd 伝搬を復元。
- `spawn_app_server_process_parts` に `cwd: Option<&str>` と `envs` を追加し、`ensure_session` から worktree path と session 固有 env（`RELEASH_SESSION_ID` / `RELEASH_BASE_BRANCH`）+ alias env（`PATH` / `RELEASH_DATA_DIR`）を注入。
- 短命 RPC 経路（`CodexAppServerProcess::spawn`）は `cwd=None` / `envs=&[]` で現状維持（scope を agent session に閉じる）。
- env 到達確認の結合テストを追加（偽 CLI に `printenv` させて検証）。

## なぜ必要か

legacy Node bridge 経路では `spawn_bridge_process` 内で `current_dir(cwd)` と `prepare_child_env` / `session_specific_env_overrides` を呼んでいたが、app-server 直結への移行時にこの責務がどこにも引き継がれていなかった。結果:

- agent から `RELEASH_SESSION_ID` / `RELEASH_BASE_BRANCH` が見えない（spec issues-1022 違反）
- codex 子プロセスが Tauri アプリの起動ディレクトリで動き、`git diff "$RELEASH_BASE_BRANCH"...HEAD` 等が誤った repo で評価される

## Test plan

- [x] `cargo build --tests`
- [x] `cargo test --lib spawn_app_server_process_parts_injects_provided_envs`
- [ ] 実機で Codex session を立ち上げ、agent から `printenv RELEASH_SESSION_ID` / `printenv RELEASH_BASE_BRANCH` / `pwd` が期待値になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)