### PR TITLE
fix(agent): session_ready 時に pending を drain して復帰直後の送信を発火

### DIFF
--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
@@ -2432,17 +2432,47 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                         let _ = app_stdout.emit("agent-supported-commands-updated", &payload);
                     }
                     "session_ready" => {
-                        let mut map = handles_stdout.lock().await;
-                        if let Some(proc) = map.get_mut(&csid_stdout) {
-                            // Only transition to Ready if still Initializing (not already Streaming)
-                            if proc.state == BridgeState::Initializing {
-                                proc.state = BridgeState::Ready;
+                        let became_ready = {
+                            let mut map = handles_stdout.lock().await;
+                            if let Some(proc) = map.get_mut(&csid_stdout) {
+                                // Only transition to Ready if still Initializing (not already Streaming)
+                                let was_initializing = proc.state == BridgeState::Initializing;
+                                if was_initializing {
+                                    proc.state = BridgeState::Ready;
+                                }
+                                if let Some(sid) = msg.get("session_id").and_then(|v| v.as_str()) {
+                                    proc.sdk_session_id = Some(sid.to_string());
+                                }
+                                was_initializing
+                            } else {
+                                false
                             }
-                            if let Some(sid) = msg.get("session_id").and_then(|v| v.as_str()) {
-                                proc.sdk_session_id = Some(sid.to_string());
+                        };
+                        let _ = app_stdout.emit("agent-sdk-message", &msg);
+                        // Initializing 中（起動直後）に enqueue された pending を Ready 化
+                        // 時に drain する。drain トリガーが turn_complete のみだと、ターンが
+                        // 一度も開始されないためキューが永久に消費されない（再起動／履歴
+                        // 復帰直後に送信が発火しない不具合の修正）。turn_complete と同じく
+                        // session_runtime_lock を保持しない経路で起動する。
+                        if became_ready {
+                            if let Some(pending) =
+                                take_pending_message(&handles_stdout, &csid_stdout).await
+                            {
+                                let app_p = app_stdout.clone();
+                                let ss_p = Arc::clone(&session_store_clone);
+                                let h_p = Arc::clone(&handles_stdout);
+                                let csid_p = csid_stdout.clone();
+                                let handle = tokio::runtime::Handle::current();
+                                std::thread::spawn(move || {
+                                    handle.block_on(async move {
+                                        start_pending_message_turn(
+                                            &app_p, &h_p, &ss_p, &csid_p, pending,
+                                        )
+                                        .await;
+                                    });
+                                });
                             }
                         }
-                        let _ = app_stdout.emit("agent-sdk-message", &msg);
                     }
                     "session_cleared" => {
                         {

--- a/src-tauri/src/infrastructure/agent_session/runtime/codex.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/codex.rs
@@ -377,6 +377,12 @@ impl AppServerCodexRuntime {
                     let mut guard = state.lock().await;
                     app_server_message_to_bridge_messages(&message, &mut guard.bridge_state)
                 };
+                // session_ready（Initializing→Ready）でも、起動直後に enqueue された
+                // pending を drain する。drain が turn/completed のみだとターン未開始で
+                // キューが消費されない（再起動／履歴復帰直後に送信が発火しない不具合）。
+                let is_session_ready = bridge_messages
+                    .iter()
+                    .any(|m| m.get("type").and_then(|v| v.as_str()) == Some("session_ready"));
                 for bridge_message in bridge_messages {
                     let mut guard = state.lock().await;
                     handle_external_bridge_message(
@@ -389,7 +395,7 @@ impl AppServerCodexRuntime {
                     )
                     .await;
                 }
-                if is_turn_completed {
+                if is_turn_completed || is_session_ready {
                     if let Err(e) = start_next_app_server_pending_turn(
                         &app,
                         &session_store,


### PR DESCRIPTION
## 概要

アプリ再起動直後、または session 履歴からの復帰直後に、Chat メッセージが発火せず pending キューに追加されるだけになる不具合を修正する。

## 原因

復帰時に bridge プロセスを spawn すると state が `Initializing` になる。`Initializing` は busy 判定（`bridge_common.rs`）に含まれるため、起動中（Ready 化前）に送信したメッセージは `proc.pending_messages` へ enqueue される。

しかし pending の drain トリガーは `turn_complete` 系のみで、`session_ready`（Initializing→Ready）では drain しない。起動中に enqueue されたメッセージはターンが一度も開始されないため `turn_complete` も来ず、**キューに積まれたまま永久に消費されない**。

`Initializing` を busy 判定へ加えた変更時に「Ready 化時の drain」を追加しなかったことによる回帰。

## 修正

`Initializing → Ready` 遷移時にも各 backend 既存の drain を起動する。

- **Claude**（`bridge_common.rs` session_ready ハンドラ）: 実際に `became_ready`（was Initializing）のときだけ pending を `start_pending_message_turn` で drain。turn_complete と同じく `session_runtime_lock` を保持しない offload 経路で起動し再入デッドロックを回避。
- **Codex**（`codex.rs` read loop）: bridge メッセージに `session_ready` が含まれるかを検知し、既存の `start_next_app_server_pending_turn`（turn 完了時と同じ drain）を呼ぶ（`is_turn_completed || is_session_ready`）。

pending が無ければ no-op で、既存の turn_complete 経路と二重消費しない（`take_pending_message` が atomic に pop）。

## 検証

- `cargo clippy -- -D warnings` / `cargo fmt --check`: パス
- `cargo test`（bridge_common 240 + codex 77）: 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * エージェント初期化直後に保留中のメッセージが処理されない問題を修正しました。セッション準備完了時に保留中のメッセージが即座に処理されるようになり、応答性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->