### PR TITLE
fix(agent): Question回答後のUIを質問(Agent)と回答(ユーザー)に分離

### DIFF
--- a/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
@@ -970,6 +970,43 @@ describe("PermissionDialog — AskUserQuestion", () => {
 		expect(selected).toHaveLength(1);
 		expect(selected[0].textContent).toContain("React");
 	});
+
+	it("highlights a single-select option whose label contains a comma", async () => {
+		const commaRequest = {
+			...askRequest,
+			input: {
+				questions: [
+					{
+						question: "Pick a stack",
+						header: "Stack",
+						options: [
+							{ label: "React, Vite", description: "SPA" },
+							{ label: "Next.js", description: "SSR" },
+						],
+						multiSelect: false,
+					},
+				],
+			},
+		};
+		render(
+			<PermissionDialog
+				request={commaRequest}
+				status="allowed"
+				resolvedAnswers={{ "Pick a stack": "React, Vite" }}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+			/>,
+		);
+		const resolved = screen.getByTestId("permission-resolved");
+		await userEvent.click(await within(resolved).findByText("Choices"));
+		const options = within(resolved).getAllByTestId("resolved-option");
+		// 単一選択ではカンマを含むラベルが1要素として扱われ、正しくハイライトされる
+		const selected = options.filter(
+			(o) => o.getAttribute("data-selected") === "true",
+		);
+		expect(selected).toHaveLength(1);
+		expect(selected[0].textContent).toContain("React, Vite");
+	});
 });
 
 describe("AskUserQuestion — multiSelect", () => {

--- a/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resetAgentEditPreviewPanelStateForTest } from "./AgentEditPreviewPanel";
@@ -939,6 +945,31 @@ describe("PermissionDialog — AskUserQuestion", () => {
 			screen.queryByLabelText("Other input for Which library should we use?"),
 		).not.toBeInTheDocument();
 	});
+
+	it("shows proposed options with the selected one highlighted after answering", async () => {
+		render(
+			<PermissionDialog
+				request={askRequest}
+				status="allowed"
+				resolvedAnswers={{ "Which library should we use?": "React" }}
+				onAllow={vi.fn()}
+				onDeny={vi.fn()}
+			/>,
+		);
+		const resolved = screen.getByTestId("permission-resolved");
+		// 「Choices」を展開すると提案された選択肢が表示される
+		await userEvent.click(await within(resolved).findByText("Choices"));
+		const options = within(resolved).getAllByTestId("resolved-option");
+		expect(options).toHaveLength(2);
+		expect(options.some((o) => o.textContent?.includes("React"))).toBe(true);
+		expect(options.some((o) => o.textContent?.includes("Vue"))).toBe(true);
+		// 選択した React だけがハイライト（data-selected=true）
+		const selected = options.filter(
+			(o) => o.getAttribute("data-selected") === "true",
+		);
+		expect(selected).toHaveLength(1);
+		expect(selected[0].textContent).toContain("React");
+	});
 });
 
 describe("AskUserQuestion — multiSelect", () => {
@@ -1179,8 +1210,6 @@ describe("AskUserQuestion — markdown rendering", () => {
 		// 回答はユーザーの選択内容なのでプレーンテキスト表示（Markdown要素は生成しない）
 		expect(resolved.querySelector("code")).toBeNull();
 		expect(resolved.querySelector("strong")).toBeNull();
-		expect(resolved.textContent).toContain(
-			"Selected `option-A` with **bold**",
-		);
+		expect(resolved.textContent).toContain("Selected `option-A` with **bold**");
 	});
 });

--- a/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
@@ -1151,7 +1151,7 @@ describe("AskUserQuestion — markdown rendering", () => {
 		expect(codeTexts).toContain("react-markdown");
 	});
 
-	it("renders resolved answer markdown as HTML", async () => {
+	it("renders resolved answer as plain text (no markdown)", () => {
 		render(
 			<PermissionDialog
 				request={{
@@ -1176,12 +1176,11 @@ describe("AskUserQuestion — markdown rendering", () => {
 			/>,
 		);
 		const resolved = screen.getByTestId("permission-resolved");
-		const button = resolved.querySelector("button");
-		expect(button).toBeTruthy();
-		await userEvent.click(button as HTMLElement);
-		expect(resolved.querySelector("code")).toBeTruthy();
-		expect(resolved.querySelector("code")?.textContent).toBe("option-A");
-		expect(resolved.querySelector("strong")).toBeTruthy();
-		expect(resolved.querySelector("strong")?.textContent).toBe("bold");
+		// 回答はユーザーの選択内容なのでプレーンテキスト表示（Markdown要素は生成しない）
+		expect(resolved.querySelector("code")).toBeNull();
+		expect(resolved.querySelector("strong")).toBeNull();
+		expect(resolved.textContent).toContain(
+			"Selected `option-A` with **bold**",
+		);
 	});
 });

--- a/src/components/panels/AgentChatPanel/PermissionDialog.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.tsx
@@ -18,7 +18,7 @@ import { rehypePluginList, remarkPluginList } from "@/lib/markdownConfig";
 import { cn } from "@/lib/utils";
 import type { PermissionRequest } from "@/types/session";
 import { AgentEditPreviewPanel } from "./AgentEditPreviewPanel";
-import { MessageCopyButton } from "./StreamMessage";
+import { UserMessage } from "./StreamMessage";
 
 interface AskQuestion {
 	question: string;
@@ -180,19 +180,6 @@ function PermissionShell({
 			className="mx-3 my-2 overflow-hidden rounded border border-border bg-background px-2 py-2 text-xs"
 		>
 			{children}
-		</div>
-	);
-}
-
-function AnswerCard({ content }: { content: string }) {
-	return (
-		<div className="flex justify-end py-1">
-			<div className="max-w-[min(82%,48rem)] rounded-lg border border-border bg-background px-3 py-2">
-				<InlineMarkdown className="text-sm">{content}</InlineMarkdown>
-				<div className="mt-1.5 flex items-center justify-end gap-1 text-[11px] text-muted-foreground">
-					<MessageCopyButton content={content} ariaLabel="Copy answer" />
-				</div>
-			</div>
 		</div>
 	);
 }
@@ -483,7 +470,11 @@ export function PermissionDialog({
 								</InlineMarkdown>
 								{/* ユーザーの発言: 選択した内容 */}
 								{answer ? (
-									<AnswerCard content={answer} />
+									<div className="flex justify-end py-1">
+										<div className="max-w-[min(82%,48rem)]">
+											<UserMessage content={answer} copyLabel="Copy answer" />
+										</div>
+									</div>
 								) : (
 									<div className="text-muted-foreground italic">
 										未回答 / キャンセル

--- a/src/components/panels/AgentChatPanel/PermissionDialog.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.tsx
@@ -222,7 +222,11 @@ function ResolvedDetail({
 				{questions.map((q) => {
 					const selectedRaw = resolvedAnswers?.[q.question] ?? "";
 					const selectedLabels = new Set(
-						selectedRaw ? selectedRaw.split(", ") : [],
+						selectedRaw
+							? q.multiSelect
+								? selectedRaw.split(", ")
+								: [selectedRaw]
+							: [],
 					);
 					return (
 						<div key={q.question} className="text-xs">

--- a/src/components/panels/AgentChatPanel/PermissionDialog.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.tsx
@@ -448,11 +448,6 @@ export function PermissionDialog({
 		let label: string;
 		if (presentation.kind === "exit_plan") {
 			label = isAllowed ? "Plan approved" : "Plan denied";
-		} else if (presentation.kind === "ask_user_question") {
-			const answerSummary = resolvedAnswers
-				? Object.values(resolvedAnswers).join(", ")
-				: "";
-			label = answerSummary ? `Answered: ${answerSummary}` : "Answered";
 		} else {
 			const toolLabel =
 				request.title || request.display_name || request.tool_name;
@@ -460,56 +455,44 @@ export function PermissionDialog({
 		}
 
 		const hasDetail = presentation.hasResolvedDetail;
-		const answerSummary = resolvedAnswers
-			? Object.values(resolvedAnswers).join(", ")
-			: "";
-		const firstQuestion =
-			presentation.kind === "ask_user_question"
-				? (presentation.questions[0]?.question ??
-					request.description ??
-					"Question")
-				: "";
 
 		if (presentation.kind === "ask_user_question") {
+			const questions =
+				presentation.questions.length > 0
+					? presentation.questions
+					: [
+							{
+								question: request.description ?? "Question",
+								header: "",
+								options: [],
+								multiSelect: false,
+							},
+						];
 			return (
-				<PermissionShell data-testid="permission-resolved">
-					<div className="flex min-w-0 items-start gap-2 px-2 py-1 text-muted-foreground">
-						<PermissionKindIcon kind={presentation.kind} />
-						<div className="min-w-0 flex-1">
-							<InlineMarkdown className="text-foreground">
-								{firstQuestion}
-							</InlineMarkdown>
-							{answerSummary && <AnswerCard content={answerSummary} />}
-							{hasDetail && (
-								<button
-									type="button"
-									className="mt-1 inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
-									onClick={() => setIsExpanded(!isExpanded)}
-								>
-									<ChevronRight
-										className={cn(
-											"size-3 shrink-0 transition-transform",
-											isExpanded && "rotate-90",
-										)}
-									/>
-									Choices
-								</button>
-							)}
-							{isExpanded && (
-								<ResolvedDetail
-									request={request}
-									presentation={presentation}
-									resolvedAnswers={resolvedAnswers}
-								/>
-							)}
-						</div>
-						{isAllowed ? (
-							<Check className="size-3.5 shrink-0" />
-						) : (
-							<X className="size-3.5 shrink-0" />
-						)}
-					</div>
-				</PermissionShell>
+				<div
+					data-testid="permission-resolved"
+					className="mx-3 my-2 space-y-2 text-xs"
+				>
+					{questions.map((q) => {
+						const answer = resolvedAnswers?.[q.question];
+						return (
+							<div key={q.question} className="space-y-1">
+								{/* Agent の発言: 質問 */}
+								<InlineMarkdown className="text-foreground">
+									{q.question}
+								</InlineMarkdown>
+								{/* ユーザーの発言: 選択した内容 */}
+								{answer ? (
+									<AnswerCard content={answer} />
+								) : (
+									<div className="text-muted-foreground italic">
+										未回答 / キャンセル
+									</div>
+								)}
+							</div>
+						);
+					})}
+				</div>
 			);
 		}
 

--- a/src/components/panels/AgentChatPanel/PermissionDialog.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.tsx
@@ -218,19 +218,57 @@ function ResolvedDetail({
 		const questions = presentation.questions;
 		if (questions.length === 0) return null;
 		return (
-			<div className="mt-1.5 space-y-1">
-				{questions.map((q) => (
-					<div key={q.question} className="text-xs">
-						<InlineMarkdown className="text-muted-foreground">
-							{q.question}
-						</InlineMarkdown>
-						{resolvedAnswers?.[q.question] && (
-							<InlineMarkdown className="font-medium">
-								{resolvedAnswers[q.question]}
+			<div className="mt-1.5 space-y-2">
+				{questions.map((q) => {
+					const selectedRaw = resolvedAnswers?.[q.question] ?? "";
+					const selectedLabels = new Set(
+						selectedRaw ? selectedRaw.split(", ") : [],
+					);
+					return (
+						<div key={q.question} className="text-xs">
+							<InlineMarkdown className="text-muted-foreground">
+								{q.question}
 							</InlineMarkdown>
-						)}
-					</div>
-				))}
+							{q.options.length > 0 && (
+								<div className="mt-1 space-y-0.5">
+									{q.options.map((opt) => {
+										const isSelected = selectedLabels.has(opt.label);
+										return (
+											<div
+												key={opt.label}
+												data-testid="resolved-option"
+												data-selected={isSelected}
+												className={cn(
+													"flex items-start gap-1.5 rounded px-1.5 py-0.5",
+													isSelected
+														? "bg-foreground/5 text-foreground"
+														: "text-muted-foreground",
+												)}
+											>
+												{isSelected ? (
+													<Check className="mt-0.5 size-3 shrink-0" />
+												) : (
+													<span className="mt-0.5 size-3 shrink-0" />
+												)}
+												<span className="min-w-0">
+													<span className={isSelected ? "font-medium" : ""}>
+														{opt.label}
+													</span>
+													{opt.description && (
+														<span className="text-muted-foreground">
+															{" — "}
+															{opt.description}
+														</span>
+													)}
+												</span>
+											</div>
+										);
+									})}
+								</div>
+							)}
+						</div>
+					);
+				})}
 			</div>
 		);
 	}
@@ -442,47 +480,65 @@ export function PermissionDialog({
 		}
 
 		const hasDetail = presentation.hasResolvedDetail;
+		const answerSummary = resolvedAnswers
+			? Object.values(resolvedAnswers).join(", ")
+			: "";
+		const firstQuestion =
+			presentation.kind === "ask_user_question"
+				? (presentation.questions[0]?.question ??
+					request.description ??
+					"Question")
+				: "";
 
 		if (presentation.kind === "ask_user_question") {
-			const questions =
-				presentation.questions.length > 0
-					? presentation.questions
-					: [
-							{
-								question: request.description ?? "Question",
-								header: "",
-								options: [],
-								multiSelect: false,
-							},
-						];
 			return (
-				<div
-					data-testid="permission-resolved"
-					className="mx-3 my-2 space-y-2 text-xs"
-				>
-					{questions.map((q) => {
-						const answer = resolvedAnswers?.[q.question];
-						return (
-							<div key={q.question} className="space-y-1">
-								{/* Agent の発言: 質問 */}
+				<div data-testid="permission-resolved">
+					{/* Agent の発言: 質問＋選択肢ウィジェット（原状） */}
+					<PermissionShell>
+						<div className="flex min-w-0 items-start gap-2 px-2 py-1 text-muted-foreground">
+							<PermissionKindIcon kind={presentation.kind} />
+							<div className="min-w-0 flex-1">
 								<InlineMarkdown className="text-foreground">
-									{q.question}
+									{firstQuestion}
 								</InlineMarkdown>
-								{/* ユーザーの発言: 選択した内容 */}
-								{answer ? (
-									<div className="flex justify-end py-1">
-										<div className="max-w-[min(82%,48rem)]">
-											<UserMessage content={answer} copyLabel="Copy answer" />
-										</div>
-									</div>
-								) : (
-									<div className="text-muted-foreground italic">
-										未回答 / キャンセル
-									</div>
+								{hasDetail && (
+									<button
+										type="button"
+										className="mt-1 inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+										onClick={() => setIsExpanded(!isExpanded)}
+									>
+										<ChevronRight
+											className={cn(
+												"size-3 shrink-0 transition-transform",
+												isExpanded && "rotate-90",
+											)}
+										/>
+										Choices
+									</button>
+								)}
+								{isExpanded && (
+									<ResolvedDetail
+										request={request}
+										presentation={presentation}
+										resolvedAnswers={resolvedAnswers}
+									/>
 								)}
 							</div>
-						);
-					})}
+							{isAllowed ? (
+								<Check className="size-3.5 shrink-0" />
+							) : (
+								<X className="size-3.5 shrink-0" />
+							)}
+						</div>
+					</PermissionShell>
+					{/* ユーザーの発言: 選択した内容を分離表示 */}
+					{answerSummary && (
+						<div className="flex justify-end py-1">
+							<div className="max-w-[min(82%,48rem)]">
+								<UserMessage content={answerSummary} copyLabel="Copy answer" />
+							</div>
+						</div>
+					)}
 				</div>
 			);
 		}

--- a/src/components/panels/AgentChatPanel/StreamMessage.tsx
+++ b/src/components/panels/AgentChatPanel/StreamMessage.tsx
@@ -149,16 +149,18 @@ export function MessageCopyButton({
 	);
 }
 
-function HumanMessageContent({
+export function UserMessage({
 	content,
 	images,
 	mentions,
 	timestamp,
+	copyLabel = "Copy message",
 }: {
 	content: string;
 	images?: ImagePart[];
 	mentions?: MentionReference[];
 	timestamp?: number;
+	copyLabel?: string;
 }) {
 	const [isExpanded, setIsExpanded] = useState(false);
 	const lines = lineCount(content);
@@ -186,7 +188,7 @@ function HumanMessageContent({
 			: null;
 
 	return (
-		<div className="rounded-lg border border-border bg-background px-3 py-2">
+		<div className="rounded-lg bg-muted px-3 py-2">
 			{imageElements && imageElements.length > 0 && (
 				<div className="flex flex-wrap gap-2 mb-2">{imageElements}</div>
 			)}
@@ -225,7 +227,7 @@ function HumanMessageContent({
 			</p>
 			<div className="mt-1.5 flex items-center justify-end gap-1 text-[11px] text-muted-foreground">
 				{formattedTime && <span>{formattedTime}</span>}
-				<MessageCopyButton content={content} ariaLabel="Copy human message" />
+				<MessageCopyButton content={content} ariaLabel={copyLabel} />
 			</div>
 		</div>
 	);
@@ -409,11 +411,12 @@ function StreamMessageImpl({
 		>
 			{isHuman ? (
 				<div className="max-w-[min(82%,48rem)]">
-					<HumanMessageContent
+					<UserMessage
 						content={content}
 						images={images}
 						mentions={mentions}
 						timestamp={timestamp}
+						copyLabel="Copy human message"
 					/>
 				</div>
 			) : (


### PR DESCRIPTION
## 概要
Agent対話パネルで AskUserQuestion（選択肢付きの質問）に回答した後のUIを改善する。
回答後に質問・選択肢・回答が同じ permission ブロックに混在していた問題を、
「質問＋選択肢＝Agentの発言」「選んだ内容＝ユーザーの発言」に分離する。

## 変更内容
- **回答の分離**: resolved の質問ウィジェット（`PermissionShell`＋アイコン＋Choices展開＋Check）はそのまま維持し、選んだ内容を別の `UserMessage` バブル（右寄せ）として分離表示。
- **UserMessage への統合**: 通常のユーザーメッセージ（`HumanMessageContent`）とQuestion回答（旧 `AnswerCard`）で重複していたバブルを `UserMessage` に集約。回答もプレーンテキスト描画に揃え、選択時のラベル表示と一貫させた。
- **バブルUI刷新**: ユーザー発言バブルを外枠(border)廃止＋背景色(`bg-muted`)表現に変更。
- **提案選択肢の表示**: 回答後の「Choices」展開で、提案された選択肢一覧（`q.options`）を表示し、選んだ選択肢をハイライト。

## コミット
1. `8236350f` Question回答後のUIで質問と回答を発言単位に分離
2. `77db67d6` ユーザー発言を UserMessage に統合しバブルUIを刷新
3. `8b424739` Agentウィジェットを原状回復し提案選択肢を表示

## 検証
- `pnpm lint` 通過
- `pnpm exec tsc --noEmit` エラーなし
- `pnpm exec vitest run` 全1735件通過

## スコープ外
- バックエンド・リモート（`src/remote/`）は無改変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ユーザー許可ダイアログの表示方法を改善し、選択肢を展開したときに選択済みオプションがハイライト表示されるようになりました
  * ユーザーメッセージの表示スタイルを更新しました
  * 表示の正確性を検証するテストケースを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->