### PR TITLE
feat(agent): Claude turn の無音停止を watchdog で検出し回復する (#1178)

### DIFF
--- a/docs/specs/feat-issues-1178/behavior.md
+++ b/docs/specs/feat-issues-1178/behavior.md
@@ -1,0 +1,149 @@
+# Behavior
+
+requirements.md を観測可能な振る舞いとして定義する。実装の内部経路（bridge / runtime のモジュール名・関数名・内部状態名）は持ち込まず、ユーザーまたは次 turn の送信者が外部から観測できる結果に絞って記述する。
+
+## 用語
+
+- **turn**: ユーザーが 1 メッセージを送ってから、その応答が完了するまでの 1 単位。
+- **進捗イベント**: agent の応答が前進していることを示す出力。thinking の更新、ツール実行、progress 通知、応答テキストの増分を含む。
+- **stale（無音停止）**: turn が完了せず、かつ進捗イベントも届かない状態が続くこと。
+- **stale timeout**: 応答中（Thinking 表示中）の turn を stale と判定するまでの無進捗許容時間。既定 180 秒。
+- **permission timeout**: 権限承認待ちの turn を timeout と判定するまでの待機許容時間。既定 300 秒。headless 経路のみ適用。
+
+## Feature: Claude agent turn の無音停止からの回復
+
+Claude（Opus 4.8 等）との通信が応答も終了通知も返さず無音停止しても、agent turn が永続的に Thinking 表示のまま固まらず、一定時間後に失敗として完了し、ユーザーが再試行できる。
+
+### Background
+
+```gherkin
+Given Releash デスクトップアプリで Claude と対話している
+And agent session が開始している
+And ユーザーがメッセージを送信して turn が応答中（Thinking 表示）になっている
+```
+
+### Rule: 応答中の turn が無進捗のまま stale timeout を超えると失敗完了する
+
+```gherkin
+Scenario: 終了通知も進捗も返らず無音停止した turn が stale timeout 後に失敗完了する
+  Given turn が応答中である
+  When 進捗イベントが一切届かないまま stale timeout（180 秒）を超過する
+  Then 当該 turn は失敗状態として完了する
+  And UI は永続 Thinking 表示から復帰する
+  And UI に「Claude 応答が停止したため中断した。再試行できる」旨が表示される
+  And 同一セッションで次のメッセージを送信できる状態になる
+```
+
+```gherkin
+Scenario: stale 完了時にそれまでの部分出力が保持される
+  Given turn が応答中で、一部のテキストや thinking がすでに表示されている
+  When 進捗のないまま stale timeout を超過して turn が失敗完了する
+  Then それまでに表示された部分出力は失われず残る
+```
+
+### Rule: 進捗イベントが届く間は stale 判定しない（正当に長い thinking を誤中断しない）
+
+```gherkin
+Scenario Outline: 進捗イベントが届き続ける限り timeout しない
+  Given turn が応答中である
+  When stale timeout 未満の間隔で <イベント> が届き続ける
+  Then turn は stale と判定されず Thinking 表示を継続する
+  And turn は中断されない
+
+  Examples:
+    | イベント            |
+    | thinking の更新     |
+    | ツール実行          |
+    | progress 通知       |
+    | 応答テキストの増分  |
+```
+
+```gherkin
+Scenario: 最後の進捗から無進捗時間で stale を判定する
+  Given turn が応答中で、過去に進捗イベントを受信している
+  When 最後の進捗イベントから新たな進捗が stale timeout を超えて届かない
+  Then 当該 turn は stale と判定され失敗完了する
+```
+
+```gherkin
+Scenario: api/request の補助ログだけでは進捗とみなさない
+  Given turn が応答中である
+  When 応答や thinking の前進を伴わない補助的なログのみが出力される
+  And それ以外の進捗イベントは届かない
+  Then 当該ログは進捗とみなされず、stale timeout 超過で turn は失敗完了する
+```
+
+### Rule: 終了通知なしに通信が閉じた turn は正常終了扱いにしない
+
+```gherkin
+Scenario: 終了通知を受信しないまま通信が閉じても失敗完了する
+  Given turn が応答中である
+  When 終了通知（result）を受信しないまま agent との通信が閉じる
+  Then 当該 turn は正常終了扱いにならず失敗状態として完了する
+  And 壊れた接続状態は次の turn に持ち越されない
+  And 同一セッションで次のメッセージを送信できる
+```
+
+### Rule: stale 検出時に通信プロセスを停止・回復し、壊れた状態を次 turn に残さない
+
+```gherkin
+Scenario: stale 検出時に通信を中断し、回復しなければプロセスを停止・再生成する
+  Given turn が応答中で stale と判定された
+  When 回復のための中断要求を送る
+  And 一定時間で turn が解消しない
+  Then 通信プロセスは停止される
+  And 必要に応じて通信プロセスが再生成される
+  And 壊れた接続状態は次の turn に持ち越されない
+```
+
+### Rule: 権限承認待ちの timeout は headless 経路のみ適用する
+
+```gherkin
+Scenario: headless 経路の権限待ちは permission timeout で打ち切られる
+  Given headless 経路で turn が権限承認待ちになっている
+  When 承認も拒否もされないまま permission timeout（300 秒）を超過する
+  Then 当該 turn は timeout として失敗完了する
+  And 同一セッションで次のメッセージを送信できる状態になる
+```
+
+```gherkin
+Scenario: デスクトップ経路の権限待ちは無期限に待つ
+  Given デスクトップ経路で turn が権限承認待ちになっている
+  When permission timeout 相当の時間が経過しても承認も拒否もされない
+  Then turn は timeout せず権限承認待ちを継続する
+```
+
+### Rule: Stop と stale timeout が競合しても二重完了しない
+
+```gherkin
+Scenario: ユーザー Stop と stale timeout が同時に発生しても turn は一度だけ完了する
+  Given turn が応答中で stale 判定の直前である
+  When ユーザーが Stop 操作を行う
+  And ほぼ同時に stale timeout が発生する
+  Then turn は一度だけ完了する
+  And 二重完了・二重エラーは発生しない
+  And 同一セッションで次のメッセージを送信できる状態になる
+```
+
+### Rule: 正常系の turn 完了挙動は変わらない
+
+```gherkin
+Scenario: 終了通知を正常に受信した turn は従来どおり完了する
+  Given turn が応答中である
+  When 進捗イベントののち終了通知（result）を受信する
+  Then 当該 turn は正常完了する
+  And stale 判定や中断は発生しない
+  And 同一セッションで次のメッセージを送信できる
+```
+
+## 仮定
+
+- stale timeout は固定値 180 秒、permission timeout は固定値 300 秒とし、ユーザー設定 UI は設けない（requirements の仮定に準拠）。
+- 失敗完了後の回復はユーザーの手動再試行で行い、自動リトライ・自動 resume は行わない。
+- 補助的な api/request ログ（応答・thinking の前進を伴わないもの）は進捗イベントに含めない。
+- 本振る舞いの対象は Claude Agent SDK 経路に限定する。他の agent backend は対象外。
+- permission timeout は headless 経路のみに適用し、デスクトップ経路では権限承認を無期限に待つ。
+
+## Open Questions
+
+なし

--- a/docs/specs/feat-issues-1178/design.md
+++ b/docs/specs/feat-issues-1178/design.md
@@ -1,0 +1,247 @@
+# Design
+
+requirements.md / behavior.md を満たすための実装設計。Claude Agent SDK 経路（`claude-sdk-bridge.mjs` + `bridge_common.rs`）における stale turn 検出・復旧機構を、既存の turn ライフサイクルへ最小侵襲で組み込む。
+
+## 概要
+
+現状、turn 完了は SDK/bridge からの `result` → bridge の `turn_complete` 出力 → Rust 側 `run_turn_complete_transition_locked()`（`TurnPhase::Streaming` → `Idle`）だけで成立しており、`result` が来なければ永続 Thinking になる。
+
+本設計では Rust runtime（`AgentProcess`）に **進捗時刻（liveness）** を記録し、turn ごとに **watchdog（tokio タスク）** を起動して、進捗のない `Streaming` turn / 一定経路の `WaitingPermission` turn を **stale** と判定する。stale 検出時は既存の終端遷移（`run_turn_complete_transition_locked`）へ **失敗 exit_code** で合流させて UI を回復させ、続けて bridge へ interrupt → grace 後に応答しなければプロセスグループを kill して次 turn 用に破棄する。`result` なしで bridge loop が閉じた場合も失敗完了として扱う。これらの遷移はすべて既存の per-session runtime lock 下で原子的に行い、Stop との二重完了を防ぐ。
+
+正常系（`result` 受信）の挙動は一切変えない。
+
+## 変更対象
+
+### Rust（実装の中心）
+
+- `src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs`
+  - `AgentProcess` 構造体: liveness / origin / watchdog 管理フィールドを追加。
+  - stdout reader ループ: 進捗イベント受信時に liveness を更新。
+  - watchdog タスクの spawn / tick ロジックを新設。
+  - stale 完了の終端遷移ヘルパー（`run_turn_complete_transition_locked` を失敗 exit_code で呼ぶ薄いラッパ）と冪等ガードを追加。
+  - bridge 停止/破棄（interrupt → grace → `sweep_process_group`）の復旧シーケンスを追加。
+  - `spawn_bridge_process()`: native の idle 防御を turn timeout と整合させる env を bridge プロセスに設定（`CLAUDE_STREAM_IDLE_TIMEOUT_MS` / `CLAUDE_ENABLE_STREAM_WATCHDOG` / `CLAUDE_ENABLE_BYTE_WATCHDOG` / `CLAUDE_CODE_MAX_RETRIES` / `API_TIMEOUT_MS`）。`CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` は CLI v2.1.112 に存在しないため使わない。
+  - 定数追加: `STALE_TIMEOUT_SECS`、`PERMISSION_TIMEOUT_SECS`、`STALE_RECOVERY_GRACE_SECS`、`WATCHDOG_TICK_SECS`。
+  - `turn_origin_for_session()` で `ChatSession.workflow_step_session` を参照し、runtime 内で `Desktop` / `Headless` を導出する。`AgentMessageDispatchRequest` や remote handler へ origin フィールドは追加しない。
+
+### Node bridge
+
+- `src-tauri/resources/claude-sdk-bridge.mjs`
+  - `query()` ループが `result` を受け取らずに終了（非 interrupt）した場合、`turn_complete` を **失敗 exit_code（非 0）** で emit する。
+  - 既存の user-interrupt 経由の正常 abort（exit_code 0）は維持。
+
+### フロント（表示のみ）
+
+- 既存の `agent-session-state-changed`（`TurnPhase::Idle` + 失敗 exit_code）受信で永続 Thinking から復帰する経路は変更不要。stale 完了時に「Claude 応答が停止したため中断した。再試行できる」旨を表示するため、合成エラー part（後述）を `streaming_parts` に積んで既存の error part 表示経路へ載せる。新規 UI ロジックは持たせない（ロジックは Rust）。
+
+## アーキテクチャと責務分割
+
+```
+[runtime: bridge_common.rs]
+   send_agent_message_internal / start_agent_turn_*  ──┐
+        │ turn 開始時:                                  │
+        │   last_progress_at = now                       │
+        │   turn_phase_since = now                       │
+        │   turn_origin = turn_origin_for_session(session)│
+        │   spawn_turn_watchdog(generation_id)  ─────────┘
+        │
+   stdout reader loop（進捗イベント）
+        │   thinking/text/tool/progress delta 受信 → touch_liveness()
+        │   permission_request → turn_phase_since = now
+        │   turn_complete(result) → 正常終端（既存経路、watchdog 自然終了）
+        │   EOF / result なし close → 失敗終端
+        ▼
+   turn watchdog（tokio task, per turn, generation_id で識別）
+        │   WATCHDOG_TICK_SECS ごとに lock 取得して判定:
+        │     Streaming かつ now - last_progress_at > STALE_TIMEOUT      → stale
+        │     WaitingPermission かつ origin == Headless
+        │            かつ now - turn_phase_since > PERMISSION_TIMEOUT     → timeout
+        │   検出時:
+        │     1) finalize_turn_as_failure_locked()（冪等・lock 下）→ UI 回復
+        │     2) bridge interrupt 送信
+        │     3) grace 後 Ready 未復帰なら sweep_process_group + map から破棄
+        ▼
+   既存: run_turn_complete_transition_locked()（TurnPhase::Idle, 失敗 exit_code）
+```
+
+責務:
+
+- **検出** は watchdog タスクのみが担う（タイマー判定を一箇所に集約）。
+- **終端遷移** は既存 `run_turn_complete_transition_locked()` に一本化し、stale 経路も同じ終端状態（`Idle` + 失敗 exit_code）へ収束させる（正常系と同じ最終形）。
+- **bridge 破棄** は既存 `sweep_process_group()` / PGID 機構（`killpg`）を踏襲。
+- **排他** は既存 `acquire_session_runtime_lock()` を使い、Stop / turn_complete / watchdog のすべてが同一 lock 下で終端遷移を行う。
+
+## データモデルまたは型
+
+### `AgentProcess` への追加フィールド（`bridge_common.rs`）
+
+```rust
+pub struct AgentProcess {
+    // 既存 ...
+    pub turn_phase: TurnPhase,
+    pub generation_id: u64,            // 既存。watchdog と turn を対応付ける鍵として再利用
+
+    // 追加:
+    pub last_progress_at: Option<Instant>, // 最後に進捗イベントを受信した時刻
+    pub turn_phase_since: Instant,         // 現 turn_phase に入った時刻（permission timeout 用）
+    pub turn_origin: TurnOrigin,           // 現 turn の種別（desktop / headless）
+    pub watchdog_active: bool,             // 現 turn の watchdog が稼働中か（多重 spawn 防止）
+}
+```
+
+- `last_progress_at` は turn 開始時に `now` で初期化し、進捗イベントごとに `now` で更新。`Streaming` 以外では判定に使わない。
+- `turn_phase_since` は `Streaming` / `WaitingPermission` への遷移時に `now` を記録。
+- `generation_id` は既存の per-spawn 採番をそのまま使う。watchdog 起動時に値を capture し、tick 時に proc の現 `generation_id` と一致する場合のみ作用する（プロセス再生成・turn 入れ替わり後の誤作動を防ぐ）。さらに turn 単位の入れ替わりを区別するため、turn 開始ごとにインクリメントする `turn_seq: u64` を併用する（同一プロセス内で複数 turn が走るため、generation_id だけでは turn を一意にできない）。
+
+### `TurnOrigin`（新規 enum）
+
+```rust
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum TurnOrigin {
+    Desktop,         // Tauri command 経由。permission は無期限待ち
+    Headless,        // workflow step / 自律実行。permission timeout 適用
+}
+```
+
+- `Desktop` は permission timeout を適用しない（人が応答しうる）。
+- `Headless` は permission timeout を適用する。
+- Headless 判定は既存 `ChatSession.workflow_step_session` を流用し、true なら `Headless` とする。
+
+### 合成エラー part
+
+- stale 完了時、ユーザー向け文言を持つ `MessagePart::Error`（既存バリアント）を `streaming_parts` に push し、force flush + persist する。
+- 文言（固定）: 「Claude 応答が停止したため中断しました。もう一度お試しください。」
+- これにより behavior.md の「『Claude 応答が停止したため中断した。再試行できる』旨が表示される」を、既存 error part 表示経路で満たす。
+
+### 定数（`bridge_common.rs`）
+
+```rust
+const STALE_TIMEOUT_SECS: u64 = 180;          // Streaming 無進捗の許容
+const PERMISSION_TIMEOUT_SECS: u64 = 300;     // headless の permission 待ち許容
+const STALE_RECOVERY_GRACE_SECS: u64 = 10;    // interrupt 後に Ready 復帰を待つ猶予
+const WATCHDOG_TICK_SECS: u64 = 5;            // watchdog の判定間隔
+```
+
+native（`claude` CLI v2.1.112）の idle 防御を Releash の `STALE_TIMEOUT_SECS` と整合させるため、bridge env に以下を設定する（当初想定の `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` は **CLI に存在しない env** であり無効。requirements.md「native 側の既存防御と盲点」参照）。
+
+| env | 役割 | 設定方針 |
+|---|---|---|
+| `CLAUDE_STREAM_IDLE_TIMEOUT_MS` | watchdog の idle 閾値 | event 層は**生値**を使用（既定 90000ms、clamp なし）。byte 層のみ `Math.max(…, 300000)` で 300000ms に下限 clamp。event 層を効かせたいので `STALE_TIMEOUT_SECS` 近傍（例 90000〜150000）に設定。byte 層は 300000ms 下限のまま |
+| `CLAUDE_ENABLE_STREAM_WATCHDOG` | event 単位 watchdog（既定オフ）の有効化 | **`1` で有効化する**。有効時の挙動はコード上確定済み: 実イベント毎にタイマーをリセットし（SDK が `if(w.event==="ping")continue` で **ping を yield しないため ping ではリセットされない**）、`u6/2` で warning、`u6` 満了でストリームを abort・部分出力フラッシュ・clean な idle-timeout error を throw（`cli_streaming_idle_timeout` / `cli_stream_loop_exited_after_watchdog`）。これにより native 自身が ping 生存・content 停止の stall を検出して turn を失敗終端させられる |
+| `CLAUDE_ENABLE_BYTE_WATCHDOG` | byte 単位 watchdog（既定オン）の制御 | 無効化しない（既定オンを維持） |
+| `CLAUDE_CODE_MAX_RETRIES` | API リトライ回数（既定 10） | 既定維持（transient 失敗の透過リトライは native に委ねる） |
+| `API_TIMEOUT_MS` | 1リクエスト上限（既定 600000ms） | 既定維持または turn timeout と整合する値を検討 |
+
+> 重要: native の byte watchdog は SSE `ping` でリセットされ ping 生存 stall を拾えないが、event watchdog（`CLAUDE_ENABLE_STREAM_WATCHDOG=1`）は ping を除外するため拾える。それでも最終的な stale 検出は Rust 側 watchdog（進捗イベントベース）が担う。理由: (1) native の throw が agent-sdk `query()` の内部リトライ（既定 maxRetries まで）で握られると、bridge に伝播するまで最悪 `u6 × リトライ回数` かかりうる、(2) bridge/SDK プロセス自体がハングした場合は native watchdog では検出不能。Rust watchdog（`STALE_TIMEOUT_SECS=180`）はこれらの外側上限として機能する。env 設定は native の一次防御を働かせる補助であり、Rust watchdog を置き換えない。
+
+## 処理フロー
+
+### turn 開始（正常時の初期化）
+
+1. `start_agent_turn()` / `start_agent_turn_locked()` が `turn_origin_for_chat_session()` を呼び、`ChatSession.workflow_step_session` から `Desktop` / `Headless` を導出する。
+2. `send_agent_message_internal()` / `start_agent_turn_*_locked()` で turn が `Streaming` に入る際、lock 下で:
+   - `last_progress_at = Some(now)`、`turn_phase_since = now`、`turn_origin = derived_origin`、`turn_seq += 1`。
+   - watchdog 未稼働なら `spawn_turn_watchdog(generation_id, turn_seq)`。
+
+### 進捗イベント受信（liveness 更新）
+
+stdout reader ループの既存 dispatch に touch を追加する。
+
+- 進捗として扱う（`last_progress_at = now`）: `thinking` delta、`text` delta、`tool_use` / `tool_result`、`progress` 通知。既存の streaming accumulate 経路（`accumulate_sdk_message()`）に入るメッセージはすべて liveness とみなす。
+- 進捗として扱わない: stderr のみの api/request ログ、`session_ready`、`supported_commands` 等の制御系。stderr reader からは liveness を更新しない。
+- `permission_request` 受信時は `turn_phase_since = now`（WaitingPermission 起点）に更新。`Streaming` の `last_progress_at` 判定からは外れる。
+
+### watchdog tick（検出）
+
+`tokio::spawn` した per-turn タスクが `WATCHDOG_TICK_SECS` 間隔で:
+
+1. lock 取得（`acquire_session_runtime_lock`）。
+2. proc の `generation_id` / `turn_seq` が capture 値と不一致、または `turn_phase == Idle` → この turn は既に終わっている。watchdog 終了。
+3. 判定:
+   - `turn_phase == Streaming` かつ `now - last_progress_at > STALE_TIMEOUT_SECS` → **stale**。
+   - `turn_phase == WaitingPermission` かつ `turn_origin == Headless` かつ `now - turn_phase_since > PERMISSION_TIMEOUT_SECS` → **permission timeout**。
+   - `turn_phase == WaitingPermission` かつ `turn_origin == Desktop` → 何もしない（無期限待ち）。
+4. 非検出ならそのまま次 tick。検出時は recovery へ。
+
+### recovery（復旧シーケンス）
+
+検出した watchdog tick 内（lock 保持中）で:
+
+1. `finalize_turn_as_failure_locked()` を呼ぶ:
+   - 既に `Idle`（Stop / 正常 turn_complete が先着）なら **no-op**（冪等ガード）。
+   - 合成エラー part を `streaming_parts` に push。
+   - `run_turn_complete_transition_locked(proc, csid, exit_code = STALE_EXIT_CODE, emit)` を呼び、`TurnPhase::Idle` + `BridgeState::Crashed`（失敗）へ遷移。`STALE_EXIT_CODE` は非 0 の専用値（例: `124`、timeout 慣例）。
+   - `agent-session-state-changed(Idle, exit_code=STALE_EXIT_CODE)` と `agent-streaming-updated` を emit（UI 即時回復）。
+2. lock を解放し、bridge 復旧をバックグラウンドで実施:
+   - captured `generation_id` / `turn_seq` が現在の proc と一致する場合のみ `write_bridge_command_for_captured_turn(interrupt)` を送信する。一致しない場合は新しい turn を中断しない。
+   - interrupt を送信できた場合は `STALE_RECOVERY_GRACE_SECS` 待機する。
+   - 再 lock し、proc の `generation_id` が変わらず `BridgeState` が `Ready` に戻っていなければ（＝ bridge が interrupt に応答していない）:
+     - `sweep_process_group(pgid)`（SIGTERM → SIGKILL）でプロセスグループを kill。
+     - `remove_pgid()` で PID ファイル削除、map から proc を除去（または `Crashed` 固定）。
+   - これにより次 turn は `ensure_runtime_for_turn()` で **新規 bridge を spawn** し、壊れた SDK client 状態を持ち越さない。
+3. watchdog タスク終了。
+
+> stale 完了を **先に** 行い、bridge kill を後追いにする理由: UI の永続 Thinking を最優先で解消するため。bridge が interrupt に応答して自然に `turn_complete` を出すケースでは、その turn_complete は既に `Idle` なので冪等ガードで no-op になり二重完了しない。
+
+### `result` なしで bridge loop が閉じた場合
+
+- bridge 側: `query()` ループが `result` 未受信のまま終了し、かつ user-interrupt 由来でない場合、`turn_complete` を **exit_code = 非 0** で emit するよう `claude-sdk-bridge.mjs` を変更。
+- Rust 側: 既存 `turn_complete` 経路がそのまま失敗終端（`Crashed` + `Idle`）に落とす。
+- bridge プロセス自体が落ちて stdout が EOF になった場合は `run_bridge_eof_crash_transition_locked()` が `run_turn_complete_transition_locked()` に合流し、`Crashed` + `Idle` に遷移させる。この経路の exit_code が 0（正常）になっていないか実装時に確認し、失敗 exit_code を保証する（behavior「正常終了扱いにしない」）。
+
+### Stop との競合
+
+- Stop（`interrupt_agent_query`）は bridge へ interrupt を送り、bridge が `turn_complete`（exit 0）を返して既存経路で完了する。
+- Stop と watchdog の stale 完了がほぼ同時でも、両者とも `acquire_session_runtime_lock` 下で `run_turn_complete_transition_locked` 系を呼び、**先着が `Idle` にした後は後着が冪等 no-op** になる（`turn_phase == Idle` ガード）。二重完了・二重エラーは発生しない。
+
+## エラー処理
+
+- **lock 取得失敗 / proc 消失**: watchdog tick で proc が map から消えていれば（セッションクローズ等）watchdog は静かに終了する。
+- **interrupt 送信失敗**（stdin closed）: 既に bridge は死んでいるとみなし、grace を待たず即 `sweep_process_group` へ進む。
+- **kill 失敗**: 既存 orphan cleanup（`cleanup_orphan_processes()`）が次回起動時に PID ファイルから回収する safety net を踏襲。
+- **STALE_EXIT_CODE**: 正常系（0）・既存クラッシュ（1）と区別できる専用値（`124`）にし、フロントの表示分岐や将来のメトリクスで「stale 起因の失敗」を識別可能にする。ただし最終 `TurnPhase` は既存と同じ `Idle` で、非 0 はすべて失敗表示として扱う（既存挙動を変えない）。
+- **部分出力の保持**: `run_turn_complete_transition_locked()` は既に `streaming_parts` をスナップショットし persist する。stale 経路も同関数を通すため、合成エラー part を含む部分出力が失われない。
+
+## テスト方針
+
+Rust unit test（`bridge_common.rs` の `#[cfg(test)]`）を中心に、既存のテスト用 helper（emit closure 注入パターン）と時刻注入で時間を制御する。`Instant::now()` 依存を避けるため、watchdog 判定ロジックを「現在時刻・最終進捗時刻・turn_phase・origin・経過秒を受け取り判定結果を返す純関数」`evaluate_turn_liveness(...)` に切り出し、これを単体テストする（時間を実際に待たない）。
+
+検証ケース（requirements / behavior 対応）:
+
+1. **stale 失敗完了**: `Streaming` で `last_progress_at` から 180 秒超過 → `evaluate_turn_liveness` が `Stale` を返し、`finalize_turn_as_failure_locked` で `TurnPhase::Idle` + 非 0 exit_code に遷移する（behavior: 終了通知も進捗も返らない turn）。
+2. **進捗継続で非 timeout**: thinking / tool / progress / text delta を 180 秒未満間隔で touch し続けると `Stale` にならない（Scenario Outline 4 種を網羅）。
+3. **最後の進捗からの計測**: 過去に進捗があっても、最後の touch から 180 秒超過で `Stale`。
+4. **api/request 補助ログは非進捗**: stderr 由来ログでは `last_progress_at` が更新されず stale 判定に至る。
+5. **result なし close**: `turn_complete(exit_code != 0)` / EOF crash で `Idle` + 失敗、`Ready` へ戻らないこと（次 turn が再 spawn する状態）。
+6. **bridge 再生成**: stale 後に interrupt → grace 内で Ready 未復帰なら破棄され、次 turn が新規 spawn される（map から proc が除去される / `Crashed` 固定であることを確認）。kill 呼び出しはテストでは実プロセスを起動せず、proc 状態と PID ファイル操作の分岐で検証する。
+7. **permission timeout（headless のみ）**: `WaitingPermission` + `Headless` で 300 秒超過 → `PermissionTimeout`。`Desktop` では超過しても `Ok`（無期限待ち）。
+8. **二重完了防止**: `Idle` 済みの proc に `finalize_turn_as_failure_locked` を呼んでも no-op（既存 message / state が変わらない）。Stop 先着 → watchdog 後着の順で完了が一度きりであること。
+9. **正常系不変**: `result` → `turn_complete(0)` の既存遷移テストが従来どおり通り、watchdog が誤検出しない。
+
+統合テスト（任意・可能なら）: 無音 stall を模した stub bridge スクリプト（`result` を返さず一定時間ハングする `.mjs`）でセッションを起動し、180 秒未満に短縮した timeout 定数（テスト用に env / feature で短縮可能にするか、判定純関数経由で検証）で stale 完了→次メッセージ送信可を確認。なお実 180 秒を待つテストは CI で回さない（純関数テストでカバー）。
+
+## リスクと代替案
+
+- **誤中断リスク（正当に長い Opus thinking）**: thinking delta を確実に liveness に含めることで緩和。180 秒は保守的設定。SDK が thinking 中に delta を一切出さないモデル設定があると誤検出し得る → 実装時に Opus 4.8 の thinking delta 出力有無を確認し、必要なら timeout を引き上げる（定数で調整可能）。
+- **watchdog の多重起動**: `watchdog_active` フラグ + `generation_id`/`turn_seq` capture で防止。turn 完了時にフラグを倒す。
+- **代替案A（watchdog を既存 streaming timer に相乗り）**: `spawn_streaming_timer()` は「pending delta があり Streaming のとき」だけ回り、無進捗（pending 0）では自然停止するため stale 検出に使えない。→ 専用 watchdog を採用。
+- **代替案B（絶対 timeout のみ）**: 進捗無視の固定上限。正当に長い thinking を切るため不採用。idle（無進捗）ベースを採用。
+- **代替案C（bridge 側 watchdog）**: bridge 内で無音検出。だが「全ロジックは Rust」方針と、bridge 自体がハングした場合に検出不能なため Rust 側に置く。bridge は native の idle 防御 env 設定（上表）と result なし close の失敗 emit のみ担う。
+- **代替案D（native の防御に全面依存）**: `claude` CLI v2.1.112 はリトライ（既定10回）・byte watchdog（既定オン、最低300秒）・event watchdog（既定オフ）を持つ。event watchdog を `CLAUDE_ENABLE_STREAM_WATCHDOG=1` で有効化すれば ping 生存 stall も検出でき、これを一次防御に併用する。ただし native 防御のみへの全面依存は不採用: (1) リトライは HTTP エラー応答時のみ発火し無音 stall を拾わない、(2) byte watchdog は SSE `ping` でリセットされ content 停止を拾えない、(3) event watchdog の throw が agent-sdk 内部リトライで握られると bridge 伝播が遅延しうる、(4) bridge/SDK 自体のハングは native では検出不能。よって Rust 側 watchdog を最終手段として採用し、native 防御は env で併用する（requirements.md「native 側の既存防御と盲点」参照）。
+- **origin 判定の境界**: handler/dispatcher/gateway へ origin を引き回すと変更範囲が広がるため採用しない。runtime が `ChatSession.workflow_step_session` から `Desktop` / `Headless` を導出し、未取得時はエラーとして turn 開始を止める。
+
+## 仮定
+
+- 対象は Claude Agent SDK 経路（`claude-sdk-bridge.mjs` + `bridge_common.rs`）に限定。他 backend は対象外。
+- timeout は固定定数（stale 180 秒 / permission 300 秒 / grace 10 秒 / tick 5 秒）。ユーザー設定 UI は設けない。
+- 失敗完了後の回復はユーザーの手動再試行。自動リトライ / 自動 resume は行わない。
+- turn の origin は runtime 内で `ChatSession.workflow_step_session` から導出する。`workflow_step_session == true` のセッションは `Headless` として permission timeout を適用し、それ以外は `Desktop` として permission を無期限に待つ。
+- 進捗イベントは thinking / text / tool / progress delta を含み、stderr のみの api/request ログは含めない。
+- `STALE_EXIT_CODE` は非 0 の専用値（`124`）。最終 `TurnPhase` は既存と同じ `Idle`、非 0 は失敗として既存表示経路で扱う。
+- bridge env は実在する native lever（`CLAUDE_STREAM_IDLE_TIMEOUT_MS` / `CLAUDE_ENABLE_STREAM_WATCHDOG` / `CLAUDE_ENABLE_BYTE_WATCHDOG` / `CLAUDE_CODE_MAX_RETRIES` / `API_TIMEOUT_MS`）で設定する。`CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` は CLI v2.1.112 に存在しないため使わない。`CLAUDE_ENABLE_STREAM_WATCHDOG=1` 有効時の挙動はコード調査で確定済み（event 層タイマー、ping 非リセット、abort＋部分フラッシュ＋clean throw、`CLAUDE_STREAM_IDLE_TIMEOUT_MS` は event 層で clamp なし）。native の throw が agent-sdk 内部リトライで握られた場合の伝播遅延のみ実機で確認するが、Rust watchdog（180秒）が外側上限を担保するため設計判断には影響しない。
+- watchdog 判定の中核は純関数 `evaluate_turn_liveness` に切り出し、時間を実待ちせず単体テストする。
+- Spec ディレクトリ ID は `docs/specs/feat-issues-1178`。
+
+## Open Questions
+
+なし

--- a/docs/specs/feat-issues-1178/requirements.md
+++ b/docs/specs/feat-issues-1178/requirements.md
@@ -1,0 +1,135 @@
+# Requirements
+
+## Type
+
+不具合修正 / 堅牢性改善（resilience）
+
+## Goal
+
+Claude Agent SDK 経路で Opus 4.8（および他モデル）との通信が無音停止しても、Releash 上の agent turn が永続的に Thinking 表示のまま固まらないようにする。具体的には、SDK からの `result` 到着だけを turn 完了条件として信用せず、Rust runtime 側で「進捗のない turn（stale turn）」を検出し、必ず turn を失敗状態として完了させ、次のメッセージ送信を可能にする。あわせて、停止した Node bridge を破棄・再生成し、壊れた SDK client 状態を次 turn に持ち越さない。
+
+完了時には、SDK から `result` が返らない再現ケースでも、UI が永続 Thinking にならず、stale timeout 後に該当 turn が失敗として完了し、部分出力が残り、ユーザーが再試行できる状態になる。
+
+## Background
+
+Releash は Claude CLI を TTY で直接操作するのではなく、Rust runtime から Node bridge（`src-tauri/resources/claude-sdk-bridge.mjs`）を起動し、`@anthropic-ai/claude-agent-sdk` の `query()` を介して Claude Code と通信している。
+
+現状の turn ライフサイクルはイベント駆動であり、turn の完了は SDK/bridge からの `result`（`message.type === "result"`）を起点として bridge が `turn_complete` を出力し、Rust 側（`bridge_common.rs`）の `run_turn_complete_transition_locked()` が `TurnPhase::Streaming` → `TurnPhase::Idle` へ遷移、フロント（`useAgentSdkListeners.ts` → `agentChatReducer.ts`）が `SET_TURN_PHASE` で UI を更新する、という流れで成立している。
+
+このため、SDK iterator が `result` を返さず無音でハングすると、以下の連鎖で永続 Thinking が発生する。
+
+- bridge: `for await (const message of currentQuery)` がブロックし、`gotResult` が false のまま `turn_complete` を出さない。
+- Rust: turn は `Streaming` のまま保持され、状態遷移が起きず `streaming_parts` が蓄積され続ける。
+- フロント: `turn_phase === "streaming"` が維持され、`ThinkingPart` が `isStreaming=true` で `animate-pulse` を継続表示する。
+
+現状の Rust runtime には turn 完了を待つ watchdog や absolute/idle timeout が存在しない（タイムアウトはセッションクローズ時の `CLOSE_TIMEOUT_SECS = 5` のみ）。Node bridge のプロセス再生成（restart）も session 単位の新規 spawn のみで、turn 単位の復旧手段はない。
+
+### native（Claude Code CLI）側の既存防御と盲点
+
+bridge が起動する `claude` CLI（調査時点 v2.1.112）の実装（`cli.js`）を確認した結果、無音 stall に対する native の防御は存在するが、本不具合の故障モードには構造的な盲点があることが判明した。
+
+- **API リトライ（既定10回）**: `maxRetries` の既定は `10`（`CLAUDE_CODE_MAX_RETRIES` で上書き可）。ただし発火条件は HTTP エラー応答（408/409/429/≥500/`x-should-retry`）か transport 例外のみ（`shouldRetry`）。無音 stall は 200 OK のまま応答も例外も出ないため、リトライ枠は一度も使われない。1リクエスト上限は `API_TIMEOUT_MS`（既定 600000ms = 10分）。
+- **byte 単位 idle watchdog（既定オン）**: SSE body を監視し、最低300秒（`Math.max(CLAUDE_STREAM_IDLE_TIMEOUT_MS||90000, 300000)`）バイトが途絶えると `StreamIdleTimeoutError` でストリームをエラーにし、部分出力をフラッシュして clean に抜ける。`CLAUDE_ENABLE_BYTE_WATCHDOG` を falsy にしない限り有効。ただしタイマーは**あらゆるバイトでリセット**されるため、Anthropic API の SSE `ping` キープアライブが届く限り発火しない。
+- **event 単位 watchdog（既定オフ）**: `CLAUDE_ENABLE_STREAM_WATCHDOG` 未設定時は無効（`f1()` 内 `if(!s6)return`）。有効時は実ストリームイベント毎にタイマーをリセットし、`CLAUDE_STREAM_IDLE_TIMEOUT_MS`（既定 90000ms、**clamp なし**）の半分で warning、満了で「`Streaming idle timeout … aborting stream`」を出してストリームを abort、部分出力をフラッシュして clean な idle-timeout error を throw する（`cli_streaming_idle_timeout` / `cli_stream_loop_exited_after_watchdog`）。重要なのは、SDK の SSE デコーダが `if(w.event==="ping")continue` で **ping をイベントとして yield しない**ため、このタイマーは **ping ではリセットされない**点。したがって event 単位 watchdog は「ping 生存・content 停止」を**正しく検出できる**——ただし既定オフのため、現状の Releash 起動では働いていない。
+
+結論として、native は「**接続は byte 的に生きている（ping は届く）が `result` も意味あるデルタも来ない**」状態を**既定構成では**捕捉できない（byte watchdog は ping でリセット、event watchdog は既定オフ）。これが永続 Thinking の直接原因。対策の方向は2つあり、両立する: (1) bridge env で `CLAUDE_ENABLE_STREAM_WATCHDOG=1` を有効化し native 側に一次防御を効かせる、(2) Releash 側で進捗イベント（thinking/text/tool/progress デルタ）ベースの stale 検出を持つ。(2) は byte ではなく**意味ある進捗**で測るため ping に騙されず、かつ native ではなく bridge/SDK 自体がハングした場合も拾える最終手段となる。
+
+公開 issue（claude-agent-sdk-typescript #333 / #339 / #348、claude-code #54434 / #63583）および他ツールの回避策（OpenClaw / tg_content_factory / PocketPaw / MassGen / clawcodex）から、SDK / stream-json / SSE 系で終端イベント欠落または無出力 stall が起きるケースが確認されており、consumer 側で watchdog・defensive fallback・client 破棄を入れる方針が共通している。Releash でも同様に、外部 SDK/CLI が無音停止しても UI 状態を回復できるようにする必要がある。
+
+## Users / Actors
+
+- Releash デスクトップアプリで Claude（Opus 4.8 等）と対話する開発者
+- workflow/headless 経路から agent を利用するユーザー
+- Releash 内で turn を進行する AgentChat / agent session runtime（Rust）
+- `query()` を介して Claude Code と通信する Node bridge
+
+## Scope
+
+- Rust の agent session runtime において、turn ごとに「最後に bridge/SDK から進捗イベントを受信した時刻」を記録する。
+- `Streaming` / `WaitingPermission` の turn が一定時間進捗なしの場合に stale turn として検出する。
+  - Claude 4 系の thinking / tool / progress イベントを liveness（進捗）として扱う。
+  - text delta だけでなく thinking delta も liveness として扱う。
+- stale 検出時に、対象 turn へ合成エラーイベントを流し、必ず `turn_complete` 相当の状態遷移（`TurnPhase::Idle`、失敗扱い）を発生させる。
+- stale 検出時に Node bridge へ abort/interrupt を送り、一定時間で正常に戻らなければ bridge プロセス（プロセスグループ）を kill/restart する。
+- stale で完了させる際、それまでの部分出力（`streaming_parts`）を失わず persist し、UI に「Claude 応答が停止したため中断した。再試行できる」旨の状態を表示する。
+- bridge プロセスへ、native の idle 防御を Releash の turn timeout と整合させる環境変数を設定する。設定対象は実在する lever（`CLAUDE_STREAM_IDLE_TIMEOUT_MS` / `CLAUDE_ENABLE_STREAM_WATCHDOG` / `CLAUDE_ENABLE_BYTE_WATCHDOG` / `CLAUDE_CODE_MAX_RETRIES` / `API_TIMEOUT_MS`）とする。**注意**: 当初想定していた `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` は CLI v2.1.112 に存在せず、無効である。
+- `result` なしで stream/bridge loop が閉じた場合に、正常終了扱いにせず bridge/client を破棄して次 turn に持ち越さないようにする。
+- permission 待ち（`WaitingPermission`）にも別 timeout を設け、headless 経路で永久待ちにならないようにする。
+- Stop（ユーザー中断）操作と stale timeout 操作が競合しても、二重完了/二重エラーにならないよう排他制御する。
+- 上記を unit test または統合テストで検証する。
+
+## Non-goals
+
+- Anthropic 側（Opus 4.8）のモデル障害そのものの解消。Releash は外部が無音停止しても UI 状態を回復できるようにするのみ。
+- SDK/CLI 通信プロトコルや `@anthropic-ai/claude-agent-sdk` 自体の改修・差し替え。
+- Claude 以外の agent backend（Codex / Cursor 内蔵 AI 等）への同等機構の新規導入（本対応は Claude SDK 経路を対象とする。共通化が自然な場合の流用は妨げないが、目標には含めない）。
+- リトライ（自動再送）や自動 resume による回復。本対応は「失敗として完了させ、ユーザーが手動で再試行できる状態にする」までを範囲とする。
+- turn timeout 値をユーザー設定 UI として公開すること（**仮定**: 本対応では固定の定数値とする。設定可能化は別途）。
+- AgentChat の権限モデルや承認 UI のデザイン刷新。
+- 永続 Thinking 以外の UI 表示課題（Thinking 蓄積量の soft limit / drain 等）の対応。
+
+## Requirements
+
+### 検出（stale detection）
+
+- agent session runtime は、turn ごとに最後の進捗イベント受信時刻を記録すること。
+- `Streaming` 状態の turn が、進捗イベントなしで stale timeout（既定 **180 秒**）を超過した場合に stale と判定すること。
+- `WaitingPermission` 状態の turn は、**headless 経路に限り** permission 用 timeout（既定 **300 秒**）を超過した場合に timeout と判定すること。デスクトップ（人が応答しうる経路）では permission 応答を無期限に待ち、timeout しないこと。
+- Claude 4 系の thinking delta / tool イベント / progress イベントの受信を進捗として扱い、これらが届く間は stale 判定しないこと。
+- **仮定**: stderr のみの api/request ログは liveness として扱わない（無音 stall を進捗ありと誤判定しないため）。
+
+### 復旧（recovery）
+
+- stale 検出時、対象 turn を失敗状態として完了させ、`TurnPhase` を `Idle` に遷移させること。これにより UI が永続 Thinking から復帰すること。
+- stale 完了後、同一セッションで次のメッセージを送信できる状態になること。
+- stale 完了時、それまでの部分出力を失わず保持・表示すること。
+- stale 検出時、Node bridge へ abort/interrupt を送ること。一定時間で turn が解消しない場合は bridge プロセスを kill し、必要に応じて再生成すること。
+- stale で bridge を停止/再生成した後、壊れた SDK client 状態が次 turn に混入しないこと。
+- `result` を受信しないまま stream/bridge loop が閉じた場合も、正常終了扱いにせず bridge/client を破棄し、次 turn に持ち越さないこと。
+- stale 完了時、UI に「Claude 応答が停止したため中断した。再試行できる」旨の状態を表示すること。
+
+### 競合制御
+
+- Stop（ユーザー中断）操作と stale timeout 操作が同時に発生しても、turn の二重完了/二重エラーが起きないこと（既存の per-session runtime lock を用いた排他で保証する）。
+
+### 設定
+
+- native の idle 防御を Releash の turn timeout と整合させるため、実在する環境変数（`CLAUDE_STREAM_IDLE_TIMEOUT_MS` / `CLAUDE_ENABLE_STREAM_WATCHDOG` / `CLAUDE_ENABLE_BYTE_WATCHDOG` / `CLAUDE_CODE_MAX_RETRIES` / `API_TIMEOUT_MS`）を bridge プロセスの環境へ設定すること。`CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` は存在しない env のため使用しないこと。
+
+### テスト
+
+- unit test または統合テストで以下を確認すること:
+  - `result` 欠落（無音 stall）時に stale turn が失敗完了扱いになる。
+  - bridge から進捗イベントが届き続ける間は stale timeout しない。
+  - stale timeout 後に bridge プロセスが（必要に応じて）再生成される。
+
+## Constraints
+
+- 検出・復旧ロジックは Rust（agent session runtime）側に実装すること（プロジェクト方針: 全ロジックは Rust）。フロントは状態表示に徹する。
+- 正当に長時間かかる Opus の thinking を stale と誤判定して中断しないよう、進捗イベント（thinking 含む）による liveness 判定を確実に行うこと。
+- 既存の turn 完了経路（`result` → `turn_complete` → `run_turn_complete_transition_locked`）の正常系挙動を変えないこと。stale 経路は同じ終端状態（`TurnPhase::Idle`、失敗 exit_code）へ収束させること。
+- 二重完了防止のため、turn 完了状態の遷移は per-session の排他ロック下で原子的に行うこと。
+- bridge プロセスの kill はプロセスグループ単位で行い、孤児プロセスを残さないこと（既存の PGID/`killpg` 機構を踏襲）。
+
+## Acceptance Criteria（概要）
+
+- SDK から `result` が返らない再現ケースでも、UI が永続 Thinking にならない。
+- stale timeout 後、該当 turn が失敗状態として完了し、次のメッセージ送信が可能になる。
+- timeout 時に部分出力が残る。
+- timeout 時に Node bridge が停止/再生成され、壊れた SDK client 状態が次 turn に混入しない。
+- Stop 操作と timeout 操作が競合しても二重完了/二重エラーにならない。
+- 上記をカバーする unit/統合テストが存在し、`result` 欠落時の stale 完了・進捗継続時の非 timeout・timeout 後の bridge 再生成を確認できる。
+
+## Assumptions（仮定）
+
+- 本対応の対象は Claude Agent SDK 経路（`claude-sdk-bridge.mjs` + `bridge_common.rs`）に限定する。
+- 失敗完了後の回復はユーザーの手動再試行で行う（自動リトライ/自動 resume は含めない）。
+- turn timeout / permission timeout は固定の定数値とし、ユーザー設定 UI は設けない。
+- stale turn timeout（Streaming 進捗なし）の既定値は 180 秒とする（保守的設定。正当に長い Opus thinking の誤中断を避ける）。
+- permission 応答待ち timeout は headless 経路に限り適用し、既定値は 300 秒とする。デスクトップ経路では permission を無期限に待つ。
+- stale 判定の進捗イベントには thinking / tool / progress / text delta を含め、stderr のみの api/request ログは含めない。
+- Spec ディレクトリ ID は worktree/ブランチ名に合わせ `docs/specs/feat-issues-1178` とする。
+
+## Open Questions
+
+なし

--- a/src-tauri/resources/claude-sdk-bridge.mjs
+++ b/src-tauri/resources/claude-sdk-bridge.mjs
@@ -299,6 +299,13 @@ async function handleInit(cmd) {
 				}
 				continue;
 			}
+			if (!closed && !gotResult) {
+				emit({
+					type: "turn_complete",
+					session_id: currentSessionId || null,
+					exit_code: 1,
+				});
+			}
 			break;
 		} catch (e) {
 			if (currentAbortController?.signal?.aborted) {

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
@@ -64,6 +64,27 @@ pub enum TurnPhase {
     WaitingPermission,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum TurnOrigin {
+    #[default]
+    Desktop,
+    Headless,
+}
+
+impl TurnOrigin {
+    fn permission_timeout_applies(self) -> bool {
+        matches!(self, Self::Headless)
+    }
+}
+
+fn turn_origin_for_session(session: &ChatSession) -> TurnOrigin {
+    if session.workflow_step_session {
+        TurnOrigin::Headless
+    } else {
+        TurnOrigin::Desktop
+    }
+}
+
 /// A message queued while the agent is streaming, consumed on turn_complete.
 pub struct PendingMessage {
     pub id: String,
@@ -137,6 +158,17 @@ pub struct AgentProcess {
     /// itself when it exits (turn ended and the buffer drained). Used to
     /// avoid spawning a duplicate timer on overlapping turn starts.
     streaming_timer_active: bool,
+    /// Last meaningful SDK/bridge progress observed for the current turn.
+    pub last_progress_at: Option<Instant>,
+    /// Timestamp of the current turn phase; used for permission wait timeout.
+    pub turn_phase_since: Instant,
+    /// Origin of the current turn. Headless turns apply permission timeout.
+    turn_origin: TurnOrigin,
+    /// Monotonic per-process turn sequence. Watchdogs capture it to avoid
+    /// acting on a later turn that reused the same bridge process.
+    pub turn_seq: u64,
+    /// True while a per-turn stale watchdog task is alive.
+    turn_watchdog_active: bool,
 }
 
 #[cfg(test)]
@@ -173,6 +205,11 @@ pub(crate) fn make_test_agent_process() -> AgentProcess {
         pending_stream_bytes: 0,
         last_stream_emit_at: None,
         streaming_timer_active: false,
+        last_progress_at: None,
+        turn_phase_since: Instant::now(),
+        turn_origin: TurnOrigin::Desktop,
+        turn_seq: 0,
+        turn_watchdog_active: false,
     }
 }
 
@@ -366,8 +403,42 @@ pub(crate) async fn write_bridge_command(
     Ok(())
 }
 
+async fn write_bridge_command_for_captured_turn(
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    chat_session_id: &str,
+    captured_gen_id: u64,
+    captured_turn_seq: u64,
+    payload: serde_json::Value,
+) -> Result<bool, String> {
+    let data = format!("{payload}\n");
+    let mut map = handles.lock().await;
+    let Some(proc) = map.get_mut(chat_session_id) else {
+        return Ok(false);
+    };
+    if proc.generation_id != captured_gen_id || proc.turn_seq != captured_turn_seq {
+        return Ok(false);
+    }
+    proc.stdin
+        .write_all(data.as_bytes())
+        .await
+        .map_err(|e| format!("Failed to write bridge command: {e}"))?;
+    proc.stdin
+        .flush()
+        .await
+        .map_err(|e| format!("Failed to flush bridge command: {e}"))?;
+    Ok(true)
+}
+
 const PERSIST_INTERVAL_MS: u64 = 1000;
 const BRIDGE_EOF_ERROR_MESSAGE: &str = "Bridge process exited unexpectedly.";
+pub(crate) const STALE_EXIT_CODE: i64 = 124;
+const STALE_TIMEOUT_SECS: u64 = 180;
+const PERMISSION_TIMEOUT_SECS: u64 = 300;
+const STALE_RECOVERY_GRACE_SECS: u64 = 10;
+const WATCHDOG_TICK_SECS: u64 = 5;
+const STALE_ERROR_MESSAGE: &str = "Claude 応答が停止したため中断しました。もう一度お試しください。";
+const PERMISSION_TIMEOUT_ERROR_MESSAGE: &str =
+    "権限承認の待機がタイムアウトしたため中断しました。もう一度お試しください。";
 
 /// Aggregation interval for `agent-streaming-updated` / `AgentStreamSync`.
 /// Roughly 30fps — balances UI smoothness against re-render cost.
@@ -382,6 +453,42 @@ const STREAMING_PENDING_PART_LIMIT: usize = 1000;
 /// Same semantics as `STREAMING_PENDING_PART_LIMIT`: flush threshold in normal
 /// operation, soft cap (allowed to overflow) while delivery is failing.
 const STREAMING_PENDING_BYTE_LIMIT: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TurnLivenessTimeout {
+    Stale,
+    PermissionTimeout,
+}
+
+impl TurnLivenessTimeout {
+    fn user_message(self) -> &'static str {
+        match self {
+            Self::Stale => STALE_ERROR_MESSAGE,
+            Self::PermissionTimeout => PERMISSION_TIMEOUT_ERROR_MESSAGE,
+        }
+    }
+}
+
+fn evaluate_turn_liveness(
+    turn_phase: TurnPhase,
+    turn_origin: TurnOrigin,
+    last_progress_at: Option<Instant>,
+    turn_phase_since: Instant,
+    now: Instant,
+) -> Option<TurnLivenessTimeout> {
+    match turn_phase {
+        TurnPhase::Streaming => {
+            let base = last_progress_at.unwrap_or(turn_phase_since);
+            (now.duration_since(base) > Duration::from_secs(STALE_TIMEOUT_SECS))
+                .then_some(TurnLivenessTimeout::Stale)
+        }
+        TurnPhase::WaitingPermission if turn_origin.permission_timeout_applies() => {
+            (now.duration_since(turn_phase_since) > Duration::from_secs(PERMISSION_TIMEOUT_SECS))
+                .then_some(TurnLivenessTimeout::PermissionTimeout)
+        }
+        TurnPhase::Idle | TurnPhase::WaitingPermission => None,
+    }
+}
 
 fn backend_runtime_config<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
@@ -481,6 +588,22 @@ impl AgentProcess {
         self.last_stream_emit_at = None;
         self.last_message_id = None;
         self.task_id_map.clear();
+    }
+
+    fn begin_turn_liveness(&mut self, origin: TurnOrigin) {
+        let now = Instant::now();
+        self.turn_seq = self.turn_seq.saturating_add(1);
+        self.turn_origin = origin;
+        self.last_progress_at = Some(now);
+        self.turn_phase_since = now;
+    }
+
+    fn touch_liveness(&mut self) {
+        self.last_progress_at = Some(Instant::now());
+    }
+
+    fn mark_turn_phase_since_now(&mut self) {
+        self.turn_phase_since = Instant::now();
     }
 
     /// Write setMode commands to the Bridge stdin before a turn starts.
@@ -1197,6 +1320,7 @@ where
     let was_streaming = flush_streaming_before_transition(proc, chat_session_id, emit_stream);
     if was_streaming {
         proc.turn_phase = TurnPhase::WaitingPermission;
+        proc.mark_turn_phase_since_now();
     }
     PermissionRequestTransition {
         did_transition: was_streaming,
@@ -1229,6 +1353,9 @@ fn run_turn_complete_transition_locked<F>(
 where
     F: FnMut(&str, &[MessagePart]) -> (bool, bool),
 {
+    if proc.turn_phase == TurnPhase::Idle && proc.state != BridgeState::Initializing {
+        return TurnCompleteTransition::default();
+    }
     let was_streaming = flush_streaming_before_transition(proc, chat_session_id, emit_stream);
     proc.state = if exit_code == 0 {
         BridgeState::Ready
@@ -1236,6 +1363,9 @@ where
         BridgeState::Crashed
     };
     proc.turn_phase = TurnPhase::Idle;
+    proc.turn_phase_since = Instant::now();
+    proc.last_progress_at = None;
+    proc.turn_watchdog_active = false;
     let turn_token_usage = proc.last_result_token_usage.take();
     let final_parts = consolidate_parts_from_slice(&proc.streaming_parts);
     let final_msg_id = proc.streaming_message_id.take();
@@ -1247,6 +1377,64 @@ where
         final_msg_id,
         final_parts,
         turn_token_usage,
+    }
+}
+
+fn finalize_turn_as_timeout_locked<F>(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    timeout: TurnLivenessTimeout,
+    emit_stream: F,
+) -> TurnCompleteTransition
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
+    if proc.turn_phase == TurnPhase::Idle {
+        return TurnCompleteTransition::default();
+    }
+    let error_part = MessagePart::Error {
+        content: timeout.user_message().to_string(),
+        parent_tool_use_id: None,
+    };
+    proc.streaming_parts.push(error_part.clone());
+    enqueue_pending_delta(proc, &[error_part]);
+    run_turn_complete_transition_locked(proc, chat_session_id, STALE_EXIT_CODE, emit_stream)
+}
+
+#[derive(Debug, Default)]
+struct BridgeErrorTransition {
+    turn_complete: TurnCompleteTransition,
+    was_initializing: bool,
+    context_restore_failed_on_init: bool,
+}
+
+fn run_bridge_error_transition_locked<F>(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    msg: &serde_json::Value,
+    emit_stream: F,
+) -> BridgeErrorTransition
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
+    let was_initializing = proc.state == BridgeState::Initializing;
+    if proc.state == BridgeState::Streaming {
+        let prev_len = proc.streaming_parts.len();
+        accumulate_sdk_message(msg, &mut proc.streaming_parts, &mut proc.task_id_map);
+        let delta: Vec<MessagePart> = proc.streaming_parts[prev_len..].to_vec();
+        if !delta.is_empty() {
+            enqueue_pending_delta(proc, &delta);
+        }
+    }
+    let turn_complete = run_turn_complete_transition_locked(proc, chat_session_id, 1, emit_stream);
+    let context_restore_failed_on_init = !turn_complete.was_streaming
+        && was_initializing
+        && proc.context_carry_on_ready.take().is_some();
+
+    BridgeErrorTransition {
+        turn_complete,
+        was_initializing,
+        context_restore_failed_on_init,
     }
 }
 
@@ -1280,6 +1468,8 @@ where
     let did_transition = proc.turn_phase == TurnPhase::WaitingPermission;
     if did_transition {
         proc.turn_phase = TurnPhase::Streaming;
+        proc.mark_turn_phase_since_now();
+        proc.touch_liveness();
     }
     let new_status = if behavior == "allow" {
         "allowed"
@@ -1368,58 +1558,58 @@ fn delta_has_tool_event(delta: &[MessagePart]) -> bool {
 }
 
 #[derive(Debug, Default)]
-struct BridgeEofCrashEffect {
-    was_streaming: bool,
+struct BridgeEofCrashTransition {
+    turn_complete: TurnCompleteTransition,
     was_initializing: bool,
-    message_id: Option<String>,
-    error_delta: Vec<MessagePart>,
-    persisted_parts: Vec<MessagePart>,
     sdk_error_message: Option<String>,
+    context_restore_failed_on_init: bool,
 }
 
-fn apply_bridge_eof_crash(
+fn run_bridge_eof_crash_transition_locked<F>(
     generation_matches: bool,
-    state: &mut BridgeState,
-    turn_phase: &mut TurnPhase,
-    streaming_message_id: Option<&str>,
-    streaming_parts: &mut Vec<MessagePart>,
-    backend_id: &str,
-) -> BridgeEofCrashEffect {
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    emit_stream: F,
+) -> BridgeEofCrashTransition
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
     if !generation_matches {
-        return BridgeEofCrashEffect::default();
+        return BridgeEofCrashTransition::default();
     }
 
-    let was_streaming = *state == BridgeState::Streaming;
-    let was_initializing = *state == BridgeState::Initializing;
-    let mut effect = BridgeEofCrashEffect {
-        was_streaming,
-        was_initializing,
-        message_id: streaming_message_id.map(str::to_string),
-        error_delta: Vec::new(),
-        persisted_parts: Vec::new(),
-        sdk_error_message: None,
+    let was_streaming = proc.state == BridgeState::Streaming;
+    let was_initializing = proc.state == BridgeState::Initializing;
+    let sdk_error_message = if was_streaming || was_initializing {
+        Some(format!("{}: {BRIDGE_EOF_ERROR_MESSAGE}", proc.backend_id))
+    } else {
+        None
     };
-
-    if was_streaming || was_initializing {
-        effect.sdk_error_message = Some(format!("{backend_id}: {BRIDGE_EOF_ERROR_MESSAGE}"));
-    }
 
     if was_streaming {
         let part = MessagePart::Error {
             content: format!("Error: {BRIDGE_EOF_ERROR_MESSAGE}"),
             parent_tool_use_id: None,
         };
-        streaming_parts.push(part.clone());
-        effect.error_delta.push(part);
-        effect.persisted_parts = consolidate_parts_from_slice(streaming_parts);
+        proc.streaming_parts.push(part.clone());
+        enqueue_pending_delta(proc, &[part]);
     }
 
-    if was_streaming || was_initializing {
-        *state = BridgeState::Crashed;
-        *turn_phase = TurnPhase::Idle;
-    }
+    let turn_complete = if was_streaming || was_initializing {
+        run_turn_complete_transition_locked(proc, chat_session_id, -1, emit_stream)
+    } else {
+        TurnCompleteTransition::default()
+    };
+    let context_restore_failed_on_init = !turn_complete.was_streaming
+        && was_initializing
+        && proc.context_carry_on_ready.take().is_some();
 
-    effect
+    BridgeEofCrashTransition {
+        turn_complete,
+        was_initializing,
+        sdk_error_message,
+        context_restore_failed_on_init,
+    }
 }
 
 /// 状態遷移時に AgentStatusCenter へ通知する統一エントリ。
@@ -1947,6 +2137,41 @@ fn should_forward_sdk_message(accumulated: bool, msg_type: &str) -> bool {
     !accumulated || msg_type == "permission_request"
 }
 
+struct SdkMessageAccumulation {
+    handled: bool,
+    updated_parts: Option<Vec<MessagePart>>,
+    liveness: bool,
+}
+
+fn is_explicit_liveness_progress_message(msg: &serde_json::Value) -> bool {
+    msg.get("type").and_then(|v| v.as_str()) == Some("system")
+        && matches!(
+            msg.get("subtype").and_then(|v| v.as_str()),
+            Some("task_started" | "task_notification" | "task_progress" | "task_updated")
+        )
+}
+
+fn accumulate_sdk_message_with_liveness(
+    msg: &serde_json::Value,
+    parts: &mut Vec<MessagePart>,
+    task_id_map: &mut HashMap<String, String>,
+) -> SdkMessageAccumulation {
+    let prev_len = parts.len();
+    let (handled, updated_parts) = accumulate_sdk_message(msg, parts, task_id_map);
+    let liveness = handled
+        && (parts.len() > prev_len
+            || updated_parts
+                .as_ref()
+                .is_some_and(|parts| !parts.is_empty())
+            || is_explicit_liveness_progress_message(msg));
+
+    SdkMessageAccumulation {
+        handled,
+        updated_parts,
+        liveness,
+    }
+}
+
 /// Extract background task ID from tool_result content.
 /// Handles both Task tool ("agentId: a72ca50") and Bash tool ("with ID: b8625ae") formats.
 fn extract_agent_id(content: &str) -> Option<&str> {
@@ -2375,6 +2600,19 @@ pub(crate) fn session_specific_env_overrides(
     env
 }
 
+fn claude_bridge_watchdog_env_overrides() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "CLAUDE_STREAM_IDLE_TIMEOUT_MS",
+            (STALE_TIMEOUT_SECS * 1000).to_string(),
+        ),
+        ("CLAUDE_ENABLE_STREAM_WATCHDOG", "1".to_string()),
+        ("CLAUDE_ENABLE_BYTE_WATCHDOG", "1".to_string()),
+        ("CLAUDE_CODE_MAX_RETRIES", "10".to_string()),
+        ("API_TIMEOUT_MS", "600000".to_string()),
+    ]
+}
+
 /// ユーザー指定の system_prompt に Releash CLI の long help を append する。
 ///
 /// spec issues-1022 "Agent process environment contract": Agent process の
@@ -2470,6 +2708,9 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
         .ok()
         .flatten();
     for (k, v) in session_specific_env_overrides(chat_session_id, base_branch.as_deref()) {
+        cmd.env(k, v);
+    }
+    for (k, v) in claude_bridge_watchdog_env_overrides() {
         cmd.env(k, v);
     }
 
@@ -2590,6 +2831,11 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                 pending_stream_bytes: 0,
                 last_stream_emit_at: None,
                 streaming_timer_active: false,
+                last_progress_at: None,
+                turn_phase_since: Instant::now(),
+                turn_origin: TurnOrigin::Desktop,
+                turn_seq: 0,
+                turn_watchdog_active: false,
             },
         );
     }
@@ -2815,12 +3061,7 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                         // 区間に限定する。workflow turn-complete usecase や pending
                         // message 消費は lock を保持しない経路で行い、それらが必要に応じ
                         // 自前で lock を取得する設計とする（再入デッドロックを防ぐ）。
-                        let was_streaming;
-                        let final_parts;
-                        let final_msg_id;
-                        let turn_token_usage;
-                        let context_restore_failed_on_init;
-                        {
+                        let (effect, context_restore_failed_on_init) = {
                             let _runtime_guard = acquire_session_runtime_lock(&csid_stdout).await;
                             let mut map = handles_stdout.lock().await;
                             if let Some(proc) = map.get_mut(&csid_stdout) {
@@ -2842,16 +3083,12 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                                         )
                                     },
                                 );
-                                was_streaming = effect.was_streaming;
-                                turn_token_usage = effect.turn_token_usage;
-                                final_parts = effect.final_parts;
-                                final_msg_id = effect.final_msg_id;
-                                context_restore_failed_on_init = !was_streaming
+                                let context_restore_failed_on_init = !effect.was_streaming
                                     && exit_code != 0
                                     && proc.context_carry_on_ready.take().is_some();
 
                                 // User turn succeeded: persist agent_session_id to SessionStore
-                                if was_streaming && exit_code == 0 {
+                                if effect.was_streaming && exit_code == 0 {
                                     if let Some(sid) = &proc.sdk_session_id {
                                         if let Ok(data_dir) = resolve_data_dir(&app_stdout) {
                                             if let Ok(Some(mut session)) = session_store_clone
@@ -2865,34 +3102,15 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                                         }
                                     }
                                 }
+                                (effect, context_restore_failed_on_init)
                             } else {
-                                was_streaming = false;
-                                final_parts = Vec::new();
-                                final_msg_id = None;
-                                turn_token_usage = None;
-                                context_restore_failed_on_init = false;
+                                (TurnCompleteTransition::default(), false)
                             }
                             // _runtime_guard はこのスコープを抜けて drop される
-                        }
-
-                        // Final persist of streaming buffer
-                        if was_streaming {
-                            if let Some(ref mid) = final_msg_id {
-                                if !final_parts.is_empty() {
-                                    persist_streaming_parts(
-                                        &session_store_clone,
-                                        &app_stdout,
-                                        &csid_stdout,
-                                        mid,
-                                        &final_parts,
-                                        Some(now_timestamp()),
-                                    );
-                                }
-                            }
-                        }
+                        };
 
                         // Resume failure (error during init) → clear stale agent_session_id
-                        if !was_streaming && exit_code != 0 {
+                        if !effect.was_streaming && exit_code != 0 {
                             persist_context_carry_failed_after_init_error(
                                 &app_stdout,
                                 &session_store_clone,
@@ -2903,45 +3121,16 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                         }
 
                         // Emit state change only for user turns (was Streaming)
-                        if was_streaming {
-                            emit_session_state_changed(
-                                &app_stdout,
-                                &csid_stdout,
-                                TurnPhase::Idle,
-                                Some(exit_code),
-                            );
-                            // AgentStatusCenter にも通知（exit_code 非0 なら Error 扱い）
-                            let override_state = if exit_code != 0 {
-                                Some(crate::usecase::agent_session::session::SessionState::Error)
-                            } else {
-                                None
-                            };
-                            notify_status_transition(
-                                &app_stdout,
-                                &session_store_clone,
-                                &csid_stdout,
-                                TurnPhase::Idle,
-                                override_state,
-                            );
-
-                            // Workflow engine への通知と pending message 消費は
-                            // session_runtime_lock を保持しない経路で実施する。
-                            // 共通ヘルパーが内部で thread::spawn + block_on し、ここの
-                            // lock スコープから切り離す（engine 内で同 session への turn
-                            // 再投入があると再入デッドロックするため）。pending は
-                            // 同期文脈で先に取り出してから渡す。
-                            let pending = take_pending_message(&handles_stdout, &csid_stdout).await;
-                            spawn_workflow_turn_complete_notification(
-                                app_stdout.clone(),
-                                Arc::clone(&session_store_clone),
-                                Arc::clone(&handles_stdout),
-                                csid_stdout.clone(),
-                                exit_code,
-                                final_parts,
-                                turn_token_usage,
-                                pending,
-                            );
-                        }
+                        complete_streaming_turn_post_lock(
+                            &app_stdout,
+                            &session_store_clone,
+                            &handles_stdout,
+                            &csid_stdout,
+                            exit_code,
+                            effect,
+                            true,
+                        )
+                        .await;
                     }
                     "error" => {
                         let error_msg = msg
@@ -2950,60 +3139,44 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                             .unwrap_or("Unknown bridge error");
                         log::error!("Bridge error [{}]: {}", csid_stdout, error_msg);
 
-                        // Accumulate the error part, enqueue it for emission, and
-                        // force-flush so the UI surfaces the failure immediately.
-                        {
+                        let transition = {
+                            let _runtime_guard = acquire_session_runtime_lock(&csid_stdout).await;
                             let mut map = handles_stdout.lock().await;
-                            if let Some(proc) = map.get_mut(&csid_stdout) {
-                                if proc.state == BridgeState::Streaming {
-                                    let prev_len = proc.streaming_parts.len();
-                                    accumulate_sdk_message(
-                                        &msg,
-                                        &mut proc.streaming_parts,
-                                        &mut proc.task_id_map,
-                                    );
-                                    let delta: Vec<MessagePart> =
-                                        proc.streaming_parts[prev_len..].to_vec();
-                                    let mid = proc.streaming_message_id.clone();
-                                    if !delta.is_empty() {
-                                        enqueue_pending_delta(proc, &delta);
-                                    }
-                                    if let Some(ref mid) = mid {
-                                        flush_streaming(&app_stdout, proc, &csid_stdout, mid);
-                                    }
-                                }
-                            }
-                        }
+                            map.get_mut(&csid_stdout).map(|proc| {
+                                run_bridge_error_transition_locked(
+                                    proc,
+                                    &csid_stdout,
+                                    &msg,
+                                    |mid, parts| {
+                                        emit_streaming_parts(
+                                            &app_stdout,
+                                            &csid_stdout,
+                                            mid,
+                                            parts.to_vec(),
+                                        )
+                                    },
+                                )
+                            })
+                        };
 
                         let _ = app_stdout.emit("agent-sdk-message", &msg);
 
-                        // Transition to Crashed for both Streaming and Initializing states
-                        let (was_streaming, was_initializing, context_restore_failed_on_init) = {
-                            let mut map = handles_stdout.lock().await;
-                            if let Some(proc) = map.get_mut(&csid_stdout) {
-                                let ws = proc.state == BridgeState::Streaming;
-                                let wi = proc.state == BridgeState::Initializing;
-                                let failed_context =
-                                    wi && proc.context_carry_on_ready.take().is_some();
-                                if ws || wi {
-                                    proc.state = BridgeState::Crashed;
-                                    proc.turn_phase = TurnPhase::Idle;
-                                }
-                                (ws, wi, failed_context)
-                            } else {
-                                (false, false, false)
-                            }
-                        };
-                        if was_streaming {
-                            emit_session_state_changed(
-                                &app_stdout,
-                                &csid_stdout,
-                                TurnPhase::Idle,
-                                Some(1),
-                            );
-                        }
-                        // Bridge crash: AgentStatusCenter に Error として通知
-                        if was_streaming || was_initializing {
+                        let transition = transition.unwrap_or_default();
+                        let was_initializing = transition.was_initializing;
+                        let context_restore_failed_on_init =
+                            transition.context_restore_failed_on_init;
+                        let turn_complete = transition.turn_complete;
+                        complete_streaming_turn_post_lock(
+                            &app_stdout,
+                            &session_store_clone,
+                            &handles_stdout,
+                            &csid_stdout,
+                            1,
+                            turn_complete,
+                            true,
+                        )
+                        .await;
+                        if was_initializing {
                             notify_status_transition(
                                 &app_stdout,
                                 &session_store_clone,
@@ -3056,17 +3229,20 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                                     (false, None, false, Vec::new())
                                 } else {
                                     let prev_len = proc.streaming_parts.len();
-                                    let (acc, updated_parts) = accumulate_sdk_message(
+                                    let accumulation = accumulate_sdk_message_with_liveness(
                                         &msg,
                                         &mut proc.streaming_parts,
                                         &mut proc.task_id_map,
                                     );
-                                    if !acc {
+                                    if !accumulation.handled {
                                         (false, None, false, Vec::new())
                                     } else {
+                                        if in_streaming && accumulation.liveness {
+                                            proc.touch_liveness();
+                                        }
                                         let mut delta: Vec<MessagePart> =
                                             proc.streaming_parts[prev_len..].to_vec();
-                                        if let Some(up) = updated_parts {
+                                        if let Some(up) = accumulation.updated_parts {
                                             delta.extend(up);
                                         }
                                         let mid = if in_streaming {
@@ -3211,37 +3387,24 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
         // Streaming 中の終了だけでなく、Initializing (session_ready 前) の終了も
         // AgentStatusCenter に Error として伝搬させる。Initializing の場合は
         // turn_id=-1 を伴う Idle emit は行わない（streaming が無かったため）。
-        let (effect, context_carry_failed_after_init_error) = {
+        let transition = {
+            let _runtime_guard = acquire_session_runtime_lock(&csid_stdout).await;
             let mut map = handles_stdout.lock().await;
             if let Some(proc) = map.get_mut(&csid_stdout) {
-                let streaming_message_id = proc.streaming_message_id.clone();
                 let generation_matches = proc.generation_id == captured_gen_id;
-                let backend_id = proc.backend_id.clone();
-                let context_carry_failed_after_init_error = generation_matches
-                    && proc.state == BridgeState::Initializing
-                    && proc.context_carry_on_ready.take().is_some();
-                let effect = apply_bridge_eof_crash(
+                run_bridge_eof_crash_transition_locked(
                     generation_matches,
-                    &mut proc.state,
-                    &mut proc.turn_phase,
-                    streaming_message_id.as_deref(),
-                    &mut proc.streaming_parts,
-                    &backend_id,
-                );
-                // Enqueue the synthetic crash delta into the coalescing buffer and
-                // force-flush so the UI sees the error before the Idle transition.
-                if let (Some(mid), false) =
-                    (streaming_message_id.as_ref(), effect.error_delta.is_empty())
-                {
-                    enqueue_pending_delta(proc, &effect.error_delta);
-                    flush_streaming(&app_stdout, proc, &csid_stdout, mid);
-                }
-                (effect, context_carry_failed_after_init_error)
+                    proc,
+                    &csid_stdout,
+                    |mid, parts| {
+                        emit_streaming_parts(&app_stdout, &csid_stdout, mid, parts.to_vec())
+                    },
+                )
             } else {
-                (BridgeEofCrashEffect::default(), false)
+                BridgeEofCrashTransition::default()
             }
         };
-        if context_carry_failed_after_init_error {
+        if transition.context_restore_failed_on_init {
             persist_context_carry_failed_after_init_error(
                 &app_stdout,
                 &session_store_clone,
@@ -3250,7 +3413,7 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                 true,
             );
         }
-        if let Some(message) = effect.sdk_error_message.as_deref() {
+        if let Some(message) = transition.sdk_error_message.as_deref() {
             let _ = app_stdout.emit(
                 "agent-sdk-message",
                 serde_json::json!({
@@ -3260,28 +3423,20 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                 }),
             );
         }
-        if let Some(message_id) = effect.message_id.as_deref() {
-            if !effect.persisted_parts.is_empty() {
-                persist_streaming_parts(
-                    &session_store_clone,
-                    &app_stdout,
-                    &csid_stdout,
-                    message_id,
-                    &effect.persisted_parts,
-                    Some(now_timestamp()),
-                );
-            }
-        }
+        let was_initializing = transition.was_initializing;
+        let effect = transition.turn_complete;
         if effect.was_streaming {
-            emit_session_state_changed(&app_stdout, &csid_stdout, TurnPhase::Idle, Some(-1));
-            notify_status_transition(
+            complete_streaming_turn_post_lock(
                 &app_stdout,
                 &session_store_clone,
+                &handles_stdout,
                 &csid_stdout,
-                TurnPhase::Idle,
-                Some(crate::usecase::agent_session::session::SessionState::Error),
-            );
-        } else if effect.was_initializing {
+                -1,
+                effect,
+                true,
+            )
+            .await;
+        } else if was_initializing {
             notify_status_transition(
                 &app_stdout,
                 &session_store_clone,
@@ -3309,6 +3464,403 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
     // would hold `AgentProcessMap` lock every 33ms even while idle.
 
     Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum TurnWatchdogDecision {
+    Continue,
+    Timeout(TurnLivenessTimeout),
+    BreakClearFlag,
+    BreakKeepFlag,
+}
+
+fn turn_watchdog_decision(
+    proc: &AgentProcess,
+    captured_gen_id: u64,
+    captured_turn_seq: u64,
+    now: Instant,
+) -> TurnWatchdogDecision {
+    if proc.generation_id != captured_gen_id || proc.turn_seq != captured_turn_seq {
+        return TurnWatchdogDecision::BreakKeepFlag;
+    }
+    if proc.turn_phase == TurnPhase::Idle || proc.state == BridgeState::Crashed {
+        return TurnWatchdogDecision::BreakClearFlag;
+    }
+    match evaluate_turn_liveness(
+        proc.turn_phase,
+        proc.turn_origin,
+        proc.last_progress_at,
+        proc.turn_phase_since,
+        now,
+    ) {
+        Some(timeout) => TurnWatchdogDecision::Timeout(timeout),
+        None => TurnWatchdogDecision::Continue,
+    }
+}
+
+fn try_mark_turn_watchdog_active(proc: &mut AgentProcess) -> bool {
+    if proc.turn_watchdog_active {
+        return false;
+    }
+    proc.turn_watchdog_active = true;
+    true
+}
+
+async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    session_store: &Arc<SessionStore>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    chat_session_id: &str,
+    exit_code: i64,
+    effect: TurnCompleteTransition,
+    consume_pending: bool,
+) {
+    if !effect.was_streaming {
+        return;
+    }
+
+    if let Some(ref mid) = effect.final_msg_id {
+        if !effect.final_parts.is_empty() {
+            persist_streaming_parts(
+                session_store,
+                app,
+                chat_session_id,
+                mid,
+                &effect.final_parts,
+                Some(now_timestamp()),
+            );
+        }
+    }
+
+    emit_session_state_changed(app, chat_session_id, TurnPhase::Idle, Some(exit_code));
+    let override_state = if exit_code != 0 {
+        Some(crate::usecase::agent_session::session::SessionState::Error)
+    } else {
+        None
+    };
+    notify_status_transition(
+        app,
+        session_store,
+        chat_session_id,
+        TurnPhase::Idle,
+        override_state,
+    );
+
+    let pending = if consume_pending {
+        take_pending_message(handles, chat_session_id).await
+    } else {
+        None
+    };
+    spawn_workflow_turn_complete_notification(
+        app.clone(),
+        Arc::clone(session_store),
+        Arc::clone(handles),
+        chat_session_id.to_string(),
+        exit_code,
+        effect.final_parts,
+        effect.turn_token_usage,
+        pending,
+    );
+}
+
+struct TimeoutFinalizeOutcome {
+    completed: bool,
+    continue_watchdog: bool,
+    captured_pgid: Option<u32>,
+}
+
+struct TimeoutFinalizeTransition {
+    effect: Option<TurnCompleteTransition>,
+    continue_watchdog: bool,
+    captured_pgid: Option<u32>,
+}
+
+fn run_timeout_finalize_transition_locked<F>(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    captured_gen_id: u64,
+    captured_turn_seq: u64,
+    now: Instant,
+    emit_stream: F,
+) -> TimeoutFinalizeTransition
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
+    let timeout = match turn_watchdog_decision(proc, captured_gen_id, captured_turn_seq, now) {
+        TurnWatchdogDecision::Timeout(timeout) => timeout,
+        TurnWatchdogDecision::Continue => {
+            return TimeoutFinalizeTransition {
+                effect: None,
+                continue_watchdog: true,
+                captured_pgid: None,
+            };
+        }
+        TurnWatchdogDecision::BreakClearFlag => {
+            proc.turn_watchdog_active = false;
+            return TimeoutFinalizeTransition {
+                effect: None,
+                continue_watchdog: false,
+                captured_pgid: None,
+            };
+        }
+        TurnWatchdogDecision::BreakKeepFlag => {
+            return TimeoutFinalizeTransition {
+                effect: None,
+                continue_watchdog: false,
+                captured_pgid: None,
+            };
+        }
+    };
+
+    #[cfg(unix)]
+    let captured_pgid = proc.pgid;
+    #[cfg(not(unix))]
+    let captured_pgid = None;
+
+    let effect = finalize_turn_as_timeout_locked(proc, chat_session_id, timeout, emit_stream);
+    TimeoutFinalizeTransition {
+        effect: Some(effect),
+        continue_watchdog: false,
+        captured_pgid,
+    }
+}
+
+async fn finalize_timed_out_turn<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    chat_session_id: &str,
+    captured_gen_id: u64,
+    captured_turn_seq: u64,
+) -> TimeoutFinalizeOutcome {
+    let transition;
+    {
+        let _runtime_guard = acquire_session_runtime_lock(chat_session_id).await;
+        let mut map = handles.lock().await;
+        let Some(proc) = map.get_mut(chat_session_id) else {
+            return TimeoutFinalizeOutcome {
+                completed: false,
+                continue_watchdog: false,
+                captured_pgid: None,
+            };
+        };
+        transition = run_timeout_finalize_transition_locked(
+            proc,
+            chat_session_id,
+            captured_gen_id,
+            captured_turn_seq,
+            Instant::now(),
+            |mid, parts| emit_streaming_parts(app, chat_session_id, mid, parts.to_vec()),
+        );
+    }
+
+    let Some(effect) = transition.effect else {
+        return TimeoutFinalizeOutcome {
+            completed: false,
+            continue_watchdog: transition.continue_watchdog,
+            captured_pgid: transition.captured_pgid,
+        };
+    };
+
+    if !effect.was_streaming {
+        return TimeoutFinalizeOutcome {
+            completed: false,
+            continue_watchdog: false,
+            captured_pgid: transition.captured_pgid,
+        };
+    }
+
+    complete_streaming_turn_post_lock(
+        app,
+        session_store,
+        handles,
+        chat_session_id,
+        STALE_EXIT_CODE,
+        effect,
+        true,
+    )
+    .await;
+
+    TimeoutFinalizeOutcome {
+        completed: true,
+        continue_watchdog: false,
+        captured_pgid: transition.captured_pgid,
+    }
+}
+
+async fn recover_timed_out_bridge<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    chat_session_id: &str,
+    captured_gen_id: u64,
+    captured_turn_seq: u64,
+    captured_pgid: Option<u32>,
+) {
+    let interrupt_sent = match write_bridge_command_for_captured_turn(
+        handles,
+        chat_session_id,
+        captured_gen_id,
+        captured_turn_seq,
+        serde_json::json!({ "type": "interrupt" }),
+    )
+    .await
+    {
+        Ok(sent) => sent,
+        Err(e) => {
+            log::warn!("Failed to interrupt timed-out bridge {chat_session_id}: {e}");
+            false
+        }
+    };
+
+    if interrupt_sent {
+        tokio::time::sleep(Duration::from_secs(STALE_RECOVERY_GRACE_SECS)).await;
+    }
+
+    let (remove_current_pid_file, sweep_captured_pgid) = {
+        let mut map = handles.lock().await;
+        mark_timed_out_bridge_for_recovery_locked(
+            &mut map,
+            chat_session_id,
+            captured_gen_id,
+            captured_turn_seq,
+            captured_pgid,
+        )
+    };
+
+    #[cfg(unix)]
+    {
+        if let (true, Some(pg)) = (sweep_captured_pgid, captured_pgid) {
+            sweep_process_group(pg).await;
+        }
+        if remove_current_pid_file {
+            if let Ok(data_dir) = resolve_data_dir(app) {
+                remove_pgid(&data_dir, chat_session_id);
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        if remove_current_pid_file {
+            let _ = app;
+        }
+    }
+}
+
+fn mark_timed_out_bridge_for_recovery_locked(
+    map: &mut AgentProcessMap,
+    chat_session_id: &str,
+    captured_gen_id: u64,
+    captured_turn_seq: u64,
+    captured_pgid: Option<u32>,
+) -> (bool, bool) {
+    if let Some(proc) = map.get_mut(chat_session_id) {
+        if proc.generation_id == captured_gen_id
+            && proc.turn_seq == captured_turn_seq
+            && proc.state != BridgeState::Ready
+        {
+            proc.state = BridgeState::Crashed;
+            proc.turn_phase = TurnPhase::Idle;
+            proc.turn_watchdog_active = false;
+            proc.last_progress_at = None;
+            proc.mark_turn_phase_since_now();
+            return (true, true);
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        let current_owns_captured_pgid = captured_pgid.is_some_and(|pg| {
+            map.get(chat_session_id)
+                .and_then(|proc| proc.pgid)
+                .is_some_and(|current_pg| current_pg == pg)
+        });
+        (
+            false,
+            captured_pgid.is_some() && !current_owns_captured_pgid,
+        )
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = captured_pgid;
+        (false, false)
+    }
+}
+
+fn spawn_turn_watchdog<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    handles: &Arc<Mutex<AgentProcessMap>>,
+    session_store: &Arc<SessionStore>,
+    chat_session_id: &str,
+    proc: &mut AgentProcess,
+) {
+    if !try_mark_turn_watchdog_active(proc) {
+        return;
+    }
+    let app_watchdog = app.clone();
+    let handles_watchdog = Arc::clone(handles);
+    let session_store_watchdog = Arc::clone(session_store);
+    let csid_watchdog = chat_session_id.to_string();
+    let captured_gen_id = proc.generation_id;
+    let captured_turn_seq = proc.turn_seq;
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(WATCHDOG_TICK_SECS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let decision = {
+                let mut map = handles_watchdog.lock().await;
+                let Some(proc) = map.get_mut(&csid_watchdog) else {
+                    break;
+                };
+                match turn_watchdog_decision(
+                    proc,
+                    captured_gen_id,
+                    captured_turn_seq,
+                    Instant::now(),
+                ) {
+                    TurnWatchdogDecision::BreakClearFlag => {
+                        proc.turn_watchdog_active = false;
+                        TurnWatchdogDecision::BreakClearFlag
+                    }
+                    other => other,
+                }
+            };
+
+            match decision {
+                TurnWatchdogDecision::Continue => {}
+                TurnWatchdogDecision::BreakKeepFlag | TurnWatchdogDecision::BreakClearFlag => break,
+                TurnWatchdogDecision::Timeout(_) => {
+                    let outcome = finalize_timed_out_turn(
+                        &app_watchdog,
+                        &handles_watchdog,
+                        &session_store_watchdog,
+                        &csid_watchdog,
+                        captured_gen_id,
+                        captured_turn_seq,
+                    )
+                    .await;
+                    if outcome.completed {
+                        recover_timed_out_bridge(
+                            &app_watchdog,
+                            &handles_watchdog,
+                            &csid_watchdog,
+                            captured_gen_id,
+                            captured_turn_seq,
+                            outcome.captured_pgid,
+                        )
+                        .await;
+                        break;
+                    }
+                    if outcome.continue_watchdog {
+                        continue;
+                    }
+                    break;
+                }
+            }
+        }
+    });
 }
 
 /// Loop control decision for the per-turn streaming timer. Extracted as a
@@ -4185,6 +4737,18 @@ pub(crate) async fn start_agent_session_internal<R: tauri::Runtime>(
 
 /// Core logic for starting a new agent turn: spawn Bridge if needed, send prompt.
 /// Used by send_agent_message and pending message consumption.
+fn turn_origin_for_chat_session<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    session_store: &SessionStore,
+    chat_session_id: &str,
+) -> Result<TurnOrigin, String> {
+    let data_dir = resolve_data_dir(app)?;
+    let session = session_store
+        .get_session(&data_dir, chat_session_id)?
+        .ok_or_else(|| format!("Session not found: {chat_session_id}"))?;
+    Ok(turn_origin_for_session(&session))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
@@ -4198,6 +4762,7 @@ pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
     streaming_message_id: &str,
     images: &[ImageAttachment],
 ) -> Result<(), String> {
+    let origin = turn_origin_for_chat_session(app, session_store, chat_session_id)?;
     let spawn_info = get_persisted_spawn_info(app, session_store, chat_session_id)?;
     if spawn_info.backend_id == CODEX_BACKEND_ID {
         return start_codex_backend_turn(
@@ -4214,12 +4779,14 @@ pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
 
     start_agent_turn_with_runtime_spawner(
         Some(app),
+        Some(session_store),
         handles,
         chat_session_id,
         permission_mode,
         prompt,
         streaming_message_id,
         images,
+        origin,
         || async {
             wait_until_session_close_finished(chat_session_id).await;
             let spawn_info = get_persisted_spawn_info_before_turn(
@@ -4274,6 +4841,7 @@ async fn start_agent_turn_locked<R: tauri::Runtime>(
     streaming_message_id: &str,
     images: &[ImageAttachment],
 ) -> Result<(), String> {
+    let origin = turn_origin_for_chat_session(app, session_store, chat_session_id)?;
     let spawn_info = get_persisted_spawn_info(app, session_store, chat_session_id)?;
     if spawn_info.backend_id == CODEX_BACKEND_ID {
         return start_codex_backend_turn(
@@ -4290,12 +4858,14 @@ async fn start_agent_turn_locked<R: tauri::Runtime>(
 
     start_agent_turn_with_runtime_spawner_locked(
         Some(app),
+        Some(session_store),
         handles,
         chat_session_id,
         permission_mode,
         prompt,
         streaming_message_id,
         images,
+        origin,
         || async {
             let spawn_info = get_persisted_spawn_info_before_turn(
                 app,
@@ -4379,12 +4949,14 @@ async fn start_codex_backend_turn<R: tauri::Runtime>(
 #[allow(clippy::too_many_arguments)]
 async fn start_agent_turn_with_runtime_spawner<R: tauri::Runtime, F, Fut>(
     app: Option<&tauri::AppHandle<R>>,
+    session_store: Option<&Arc<SessionStore>>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     chat_session_id: &str,
     permission_mode: &str,
     prompt: &str,
     streaming_message_id: &str,
     images: &[ImageAttachment],
+    origin: TurnOrigin,
     spawn_runtime: F,
 ) -> Result<(), String>
 where
@@ -4395,12 +4967,14 @@ where
     let _runtime_guard = acquire_session_runtime_lock(chat_session_id).await;
     start_agent_turn_with_runtime_spawner_locked(
         app,
+        session_store,
         handles,
         chat_session_id,
         permission_mode,
         prompt,
         streaming_message_id,
         images,
+        origin,
         spawn_runtime,
     )
     .await
@@ -4409,12 +4983,14 @@ where
 #[allow(clippy::too_many_arguments)]
 async fn start_agent_turn_with_runtime_spawner_locked<R: tauri::Runtime, F, Fut>(
     app: Option<&tauri::AppHandle<R>>,
+    session_store: Option<&Arc<SessionStore>>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     chat_session_id: &str,
     permission_mode: &str,
     prompt: &str,
     streaming_message_id: &str,
     images: &[ImageAttachment],
+    origin: TurnOrigin,
     spawn_runtime: F,
 ) -> Result<(), String>
 where
@@ -4442,6 +5018,7 @@ where
             proc.turn_phase = TurnPhase::Streaming;
             proc.streaming_message_id = Some(streaming_message_id.to_string());
             proc.reset_streaming_state_for_new_turn();
+            proc.begin_turn_liveness(origin);
             proc.stdin
                 .write_all(data.as_bytes())
                 .await
@@ -4452,6 +5029,9 @@ where
                 .map_err(|e| format!("Failed to flush message: {e}"))?;
             if let Some(app) = app {
                 spawn_streaming_timer(app, handles, chat_session_id, proc);
+                if let Some(session_store) = session_store {
+                    spawn_turn_watchdog(app, handles, session_store, chat_session_id, proc);
+                }
             }
         } else {
             return Err(format!("No agent process for session {chat_session_id}"));
@@ -4552,6 +5132,9 @@ async fn crash_agent_process_for_context_reinject<R: tauri::Runtime>(
     };
     proc.state = BridgeState::Crashed;
     proc.turn_phase = TurnPhase::Idle;
+    proc.turn_watchdog_active = false;
+    proc.last_progress_at = None;
+    proc.mark_turn_phase_since_now();
     proc.sdk_session_id = None;
     proc.context_carry_on_ready = None;
     #[cfg(unix)]
@@ -5476,6 +6059,11 @@ pub(crate) async fn register_external_agent_process<R: tauri::Runtime>(
                 pending_stream_bytes: 0,
                 last_stream_emit_at: None,
                 streaming_timer_active: false,
+                last_progress_at: None,
+                turn_phase_since: Instant::now(),
+                turn_origin: TurnOrigin::Desktop,
+                turn_seq: 0,
+                turn_watchdog_active: false,
             },
         );
     }
@@ -5838,50 +6426,72 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
             }
         }
         "error" => {
-            let (_was_streaming, was_initializing, context_restore_failed_on_init) = {
+            let transition = {
+                let _runtime_guard = acquire_session_runtime_lock(chat_session_id).await;
                 let mut map = handles.lock().await;
-                if let Some(proc) = map.get_mut(chat_session_id) {
-                    let was_streaming = proc.state == BridgeState::Streaming;
-                    let was_initializing = proc.state == BridgeState::Initializing;
-                    let context_restore_failed =
-                        was_initializing && proc.context_carry_on_ready.take().is_some();
-                    if proc.state == BridgeState::Streaming {
-                        let prev_len = proc.streaming_parts.len();
-                        accumulate_sdk_message(
-                            &msg,
-                            &mut proc.streaming_parts,
-                            &mut proc.task_id_map,
-                        );
-                        let delta: Vec<MessagePart> = proc.streaming_parts[prev_len..].to_vec();
-                        let mid = proc.streaming_message_id.clone();
-                        if !delta.is_empty() {
-                            enqueue_pending_delta(proc, &delta);
-                        }
-                        if let Some(ref mid) = mid {
-                            flush_streaming(app, proc, chat_session_id, mid);
-                        }
-                    }
-                    if proc.state == BridgeState::Streaming
-                        || proc.state == BridgeState::Initializing
-                    {
-                        proc.state = BridgeState::Crashed;
-                        proc.turn_phase = TurnPhase::Idle;
-                    }
-                    (was_streaming, was_initializing, context_restore_failed)
-                } else {
-                    (false, false, false)
-                }
+                map.get_mut(chat_session_id).map(|proc| {
+                    run_bridge_error_transition_locked(proc, chat_session_id, &msg, |mid, parts| {
+                        emit_streaming_parts(app, chat_session_id, mid, parts.to_vec())
+                    })
+                })
             };
             let _ = app.emit("agent-sdk-message", &msg);
-            emit_session_state_changed(app, chat_session_id, TurnPhase::Idle, Some(1));
-            notify_status_transition(
-                app,
-                session_store,
-                chat_session_id,
-                TurnPhase::Idle,
-                Some(crate::usecase::agent_session::session::SessionState::Error),
-            );
-            if was_initializing
+
+            let transition = transition.unwrap_or_default();
+            let effect = transition.turn_complete;
+            if effect.was_streaming {
+                if let Some(ref mid) = effect.final_msg_id {
+                    if !effect.final_parts.is_empty() {
+                        persist_streaming_parts(
+                            session_store,
+                            app,
+                            chat_session_id,
+                            mid,
+                            &effect.final_parts,
+                            Some(now_timestamp()),
+                        );
+                    }
+                }
+                emit_session_state_changed(app, chat_session_id, TurnPhase::Idle, Some(1));
+                notify_status_transition(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    TurnPhase::Idle,
+                    Some(crate::usecase::agent_session::session::SessionState::Error),
+                );
+                let pending = {
+                    let is_legacy_bridge = {
+                        let map = handles.lock().await;
+                        map.get(chat_session_id)
+                            .is_some_and(|proc| proc.backend_id != CODEX_BACKEND_ID)
+                    };
+                    if is_legacy_bridge {
+                        take_pending_message(handles, chat_session_id).await
+                    } else {
+                        None
+                    }
+                };
+                spawn_workflow_turn_complete_notification(
+                    app.clone(),
+                    Arc::clone(session_store),
+                    Arc::clone(handles),
+                    chat_session_id.to_string(),
+                    1,
+                    effect.final_parts,
+                    effect.turn_token_usage,
+                    pending,
+                );
+            } else if transition.was_initializing {
+                notify_status_transition(
+                    app,
+                    session_store,
+                    chat_session_id,
+                    TurnPhase::Idle,
+                    Some(crate::usecase::agent_session::session::SessionState::Error),
+                );
+            }
+            if transition.was_initializing
                 || msg
                     .get("clear_session_id")
                     .and_then(|v| v.as_bool())
@@ -5895,12 +6505,12 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     app,
                     session_store,
                     chat_session_id,
-                    was_initializing
+                    transition.was_initializing
                         || msg
                             .get("clear_session_id")
                             .and_then(|v| v.as_bool())
                             .unwrap_or(false),
-                    context_restore_failed_on_init
+                    transition.context_restore_failed_on_init
                         || msg
                             .get("context_carry_failed")
                             .and_then(|v| v.as_bool())
@@ -5920,17 +6530,20 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                         (false, None, false, Vec::new())
                     } else {
                         let prev_len = proc.streaming_parts.len();
-                        let (acc, updated_parts) = accumulate_sdk_message(
+                        let accumulation = accumulate_sdk_message_with_liveness(
                             &msg,
                             &mut proc.streaming_parts,
                             &mut proc.task_id_map,
                         );
-                        if !acc {
+                        if !accumulation.handled {
                             (false, None, false, Vec::new())
                         } else {
+                            if in_streaming && accumulation.liveness {
+                                proc.touch_liveness();
+                            }
                             let mut delta: Vec<MessagePart> =
                                 proc.streaming_parts[prev_len..].to_vec();
-                            if let Some(up) = updated_parts {
+                            if let Some(up) = accumulation.updated_parts {
                                 delta.extend(up);
                             }
                             let mid = if in_streaming {
@@ -7021,6 +7634,22 @@ mod tests {
         )
     }
 
+    fn pending_message_for_test(id: &str, content: &str, created_at: f64) -> PendingMessage {
+        PendingMessage {
+            id: id.to_string(),
+            content: content.to_string(),
+            created_at,
+            permission_mode: "edit".to_string(),
+            plan_mode: false,
+            images: Vec::new(),
+            worktree_path: "/repo".to_string(),
+            mentions: Vec::new(),
+            editor_context: None,
+            existing_human_message_id: None,
+            existing_agent_message_id: None,
+        }
+    }
+
     struct MockModelBackend {
         backend_id: String,
         #[allow(dead_code)]
@@ -7634,25 +8263,22 @@ mod tests {
         proc.context_carry_on_ready = Some(ContextCarryState::Resumed);
         handles.lock().await.insert(session.id.clone(), proc);
 
-        let (effect, context_carry_failed_after_init_error) = {
+        let (was_initializing, context_carry_failed_after_init_error) = {
             let mut map = handles.lock().await;
             let proc = map.get_mut(&session.id).unwrap();
             let generation_matches = proc.generation_id == 42;
-            let backend_id = proc.backend_id.clone();
-            let context_carry_failed_after_init_error = generation_matches
-                && proc.state == BridgeState::Initializing
-                && proc.context_carry_on_ready.take().is_some();
-            let effect = apply_bridge_eof_crash(
+            let transition = run_bridge_eof_crash_transition_locked(
                 generation_matches,
-                &mut proc.state,
-                &mut proc.turn_phase,
-                None,
-                &mut proc.streaming_parts,
-                &backend_id,
+                proc,
+                &session.id,
+                |_mid, _parts| (true, true),
             );
-            (effect, context_carry_failed_after_init_error)
+            (
+                transition.was_initializing,
+                transition.context_restore_failed_on_init,
+            )
         };
-        assert!(effect.was_initializing);
+        assert!(was_initializing);
         assert!(context_carry_failed_after_init_error);
         persist_context_carry_failed_after_init_error(
             &app.handle(),
@@ -7705,20 +8331,14 @@ mod tests {
             let mut map = handles.lock().await;
             let proc = map.get_mut(&session.id).unwrap();
             let generation_matches = proc.generation_id == 7;
-            let backend_id = proc.backend_id.clone();
-            let context_carry_failed_after_init_error = generation_matches
-                && proc.state == BridgeState::Initializing
-                && proc.context_carry_on_ready.take().is_some();
-            let effect = apply_bridge_eof_crash(
+            let transition = run_bridge_eof_crash_transition_locked(
                 generation_matches,
-                &mut proc.state,
-                &mut proc.turn_phase,
-                None,
-                &mut proc.streaming_parts,
-                &backend_id,
+                proc,
+                &session.id,
+                |_mid, _parts| (true, true),
             );
-            assert!(effect.was_initializing);
-            context_carry_failed_after_init_error
+            assert!(transition.was_initializing);
+            transition.context_restore_failed_on_init
         };
         assert!(!context_carry_failed_after_init_error);
         if context_carry_failed_after_init_error {
@@ -7849,6 +8469,109 @@ mod tests {
         let pending = proc.pending_messages.pop_front().unwrap();
         assert_eq!(pending.id, "queued-before-crash");
         assert_eq!(pending.content, "continue after reinject");
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
+    async fn timed_out_recovery_preserves_remaining_pending_messages_for_replacement() {
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let session_id = "timeout-with-multiple-pending".to_string();
+        let mut timed_out = make_test_agent_process();
+        let _ = timed_out.child.kill().await;
+        timed_out.generation_id = 42;
+        timed_out.turn_seq = 7;
+        timed_out.state = BridgeState::Crashed;
+        timed_out.turn_phase = TurnPhase::Idle;
+        timed_out
+            .pending_messages
+            .push_back(pending_message_for_test(
+                "queued-after-timeout-1",
+                "first remaining",
+                1.0,
+            ));
+        timed_out
+            .pending_messages
+            .push_back(pending_message_for_test(
+                "queued-after-timeout-2",
+                "second remaining",
+                2.0,
+            ));
+        handles.lock().await.insert(session_id.clone(), timed_out);
+
+        {
+            let mut map = handles.lock().await;
+            let (remove_pid_file, _sweep_pgid) =
+                mark_timed_out_bridge_for_recovery_locked(&mut map, &session_id, 42, 7, None);
+            assert!(remove_pid_file);
+            assert!(
+                map.contains_key(&session_id),
+                "timeout recovery must retain crashed runtime so pending queue can be preserved"
+            );
+        }
+
+        ensure_runtime_for_turn(&handles, &session_id, {
+            let handles = Arc::clone(&handles);
+            let session_id = session_id.clone();
+            move || async move {
+                handles
+                    .lock()
+                    .await
+                    .insert(session_id, make_test_agent_process());
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+        let mut proc = handles
+            .lock()
+            .await
+            .remove("timeout-with-multiple-pending")
+            .unwrap();
+        let pending_ids = proc
+            .pending_messages
+            .iter()
+            .map(|pending| pending.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            pending_ids,
+            vec!["queued-after-timeout-1", "queued-after-timeout-2"]
+        );
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
+    async fn ensure_runtime_for_turn_spawns_fresh_runtime_after_timeout_crash() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let session_id = "timed-out-runtime".to_string();
+        let mut timed_out = make_test_agent_process();
+        let _ = timed_out.child.kill().await;
+        timed_out.state = BridgeState::Crashed;
+        timed_out.turn_phase = TurnPhase::Idle;
+        handles.lock().await.insert(session_id.clone(), timed_out);
+        let spawn_count = Arc::new(AtomicUsize::new(0));
+
+        ensure_runtime_for_turn(&handles, &session_id, {
+            let handles = Arc::clone(&handles);
+            let session_id = session_id.clone();
+            let spawn_count = Arc::clone(&spawn_count);
+            move || async move {
+                spawn_count.fetch_add(1, Ordering::SeqCst);
+                handles
+                    .lock()
+                    .await
+                    .insert(session_id, make_test_agent_process());
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(spawn_count.load(Ordering::SeqCst), 1);
+        let mut proc = handles.lock().await.remove("timed-out-runtime").unwrap();
+        assert_eq!(proc.state, BridgeState::Ready);
         let _ = proc.child.kill().await;
     }
 
@@ -8738,7 +9461,8 @@ mod tests {
                 parts_count: parts.len(),
                 tail_text: match parts.last() {
                     Some(MessagePart::Text { content, .. })
-                    | Some(MessagePart::Thinking { content, .. }) => Some(content.clone()),
+                    | Some(MessagePart::Thinking { content, .. })
+                    | Some(MessagePart::Error { content, .. }) => Some(content.clone()),
                     _ => None,
                 },
             });
@@ -8791,6 +9515,213 @@ mod tests {
                 exit_code: Some(exit_code),
             });
         }
+    }
+
+    #[test]
+    fn liveness_marks_streaming_stale_after_last_progress_timeout() {
+        let now = Instant::now();
+        let timeout = evaluate_turn_liveness(
+            TurnPhase::Streaming,
+            TurnOrigin::Desktop,
+            Some(now - Duration::from_secs(STALE_TIMEOUT_SECS + 1)),
+            now - Duration::from_secs(STALE_TIMEOUT_SECS + 1),
+            now,
+        );
+
+        assert_eq!(timeout, Some(TurnLivenessTimeout::Stale));
+    }
+
+    #[test]
+    fn liveness_keeps_streaming_alive_when_progress_is_recent() {
+        let now = Instant::now();
+        let timeout = evaluate_turn_liveness(
+            TurnPhase::Streaming,
+            TurnOrigin::Desktop,
+            Some(now - Duration::from_secs(STALE_TIMEOUT_SECS - 1)),
+            now - Duration::from_secs(STALE_TIMEOUT_SECS + 10),
+            now,
+        );
+
+        assert_eq!(timeout, None);
+    }
+
+    #[test]
+    fn liveness_permission_timeout_applies_only_to_headless() {
+        let now = Instant::now();
+        let since = now - Duration::from_secs(PERMISSION_TIMEOUT_SECS + 1);
+
+        assert_eq!(
+            evaluate_turn_liveness(
+                TurnPhase::WaitingPermission,
+                TurnOrigin::Headless,
+                None,
+                since,
+                now,
+            ),
+            Some(TurnLivenessTimeout::PermissionTimeout)
+        );
+        assert_eq!(
+            evaluate_turn_liveness(
+                TurnPhase::WaitingPermission,
+                TurnOrigin::Desktop,
+                None,
+                since,
+                now,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn turn_origin_is_derived_from_session_workflow_step_flag() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::default());
+        let mut session =
+            create_session_internal(&session_store, data_dir.path(), "/repo", None).unwrap();
+
+        assert_eq!(turn_origin_for_session(&session), TurnOrigin::Desktop);
+
+        session.workflow_step_session = true;
+        assert_eq!(turn_origin_for_session(&session), TurnOrigin::Headless);
+    }
+
+    #[tokio::test]
+    async fn touch_liveness_resets_streaming_stale_clock() {
+        let mut proc = make_streaming_test_process();
+        let stale_base = Instant::now() - Duration::from_secs(STALE_TIMEOUT_SECS + 1);
+        proc.last_progress_at = Some(stale_base);
+        proc.turn_phase_since = stale_base;
+
+        assert_eq!(
+            turn_watchdog_decision(&proc, proc.generation_id, proc.turn_seq, Instant::now()),
+            TurnWatchdogDecision::Timeout(TurnLivenessTimeout::Stale)
+        );
+
+        proc.touch_liveness();
+        assert_eq!(
+            turn_watchdog_decision(&proc, proc.generation_id, proc.turn_seq, Instant::now()),
+            TurnWatchdogDecision::Continue
+        );
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
+    async fn timeout_finalize_rechecks_liveness_and_continues_when_progress_arrives_after_decision()
+    {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness(TurnOrigin::Desktop);
+        proc.turn_watchdog_active = true;
+        let captured_gen_id = proc.generation_id;
+        let captured_turn_seq = proc.turn_seq;
+        let stale_base = Instant::now() - Duration::from_secs(STALE_TIMEOUT_SECS + 1);
+        proc.last_progress_at = Some(stale_base);
+        proc.turn_phase_since = stale_base;
+
+        let decision_now = Instant::now();
+        assert_eq!(
+            turn_watchdog_decision(&proc, captured_gen_id, captured_turn_seq, decision_now),
+            TurnWatchdogDecision::Timeout(TurnLivenessTimeout::Stale)
+        );
+
+        proc.last_progress_at = Some(decision_now);
+        let mut events = Vec::new();
+        let transition = run_timeout_finalize_transition_locked(
+            &mut proc,
+            "csid",
+            captured_gen_id,
+            captured_turn_seq,
+            decision_now,
+            recording_emit(&mut events),
+        );
+
+        assert!(transition.effect.is_none());
+        assert!(transition.continue_watchdog);
+        assert_eq!(proc.state, BridgeState::Streaming);
+        assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+        assert!(proc.turn_watchdog_active);
+        assert!(proc.streaming_parts.is_empty());
+        assert!(events.is_empty());
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
+    async fn finalize_timeout_adds_error_part_and_completes_as_failure() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness(TurnOrigin::Desktop);
+        let partial = MessagePart::Text {
+            content: "partial response".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(partial.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&partial));
+        let mut events = Vec::new();
+
+        let effect = finalize_turn_as_timeout_locked(
+            &mut proc,
+            "csid",
+            TurnLivenessTimeout::Stale,
+            recording_emit(&mut events),
+        );
+
+        assert!(effect.was_streaming);
+        assert_eq!(proc.state, BridgeState::Crashed);
+        assert_eq!(proc.turn_phase, TurnPhase::Idle);
+        assert_eq!(effect.final_msg_id.as_deref(), Some("m1"));
+        assert!(effect.final_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Text { content, .. } if content == "partial response"
+        )));
+        assert!(effect.final_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Error { content, .. } if content == STALE_ERROR_MESSAGE
+        )));
+        assert_eq!(proc.pending_stream_part_count, 0);
+        assert!(!proc.turn_watchdog_active);
+        assert_eq!(events.len(), 1);
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
+    async fn late_turn_complete_after_timeout_does_not_restore_ready_state() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness(TurnOrigin::Desktop);
+        let _ = finalize_turn_as_timeout_locked(
+            &mut proc,
+            "csid",
+            TurnLivenessTimeout::Stale,
+            |_mid, _parts| (true, true),
+        );
+
+        let effect =
+            run_turn_complete_transition_locked(&mut proc, "csid", 0, |_mid, _parts| (true, true));
+
+        assert!(!effect.was_streaming);
+        assert_eq!(proc.state, BridgeState::Crashed);
+        assert_eq!(proc.turn_phase, TurnPhase::Idle);
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
+    async fn timed_out_recovery_interrupt_is_scoped_to_captured_turn() {
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let mut proc = make_test_agent_process();
+        proc.generation_id = 2;
+        proc.turn_seq = 7;
+        handles.lock().await.insert("csid".to_string(), proc);
+
+        let sent = write_bridge_command_for_captured_turn(
+            &handles,
+            "csid",
+            1,
+            6,
+            serde_json::json!({ "type": "interrupt" }),
+        )
+        .await
+        .unwrap();
+
+        assert!(!sent, "must not interrupt a later bridge turn");
+        let mut proc = handles.lock().await.remove("csid").unwrap();
+        let _ = proc.child.kill().await;
     }
 
     /// Drive the production `respond_agent_permission` lock-block via
@@ -9023,82 +9954,45 @@ mod tests {
         assert_eq!(proc.turn_phase, TurnPhase::Streaming);
     }
 
-    /// Drive the production `bridge error` lock-block: accumulate an error
-    /// part, enqueue it as a pending delta, force-flush via the same
-    /// `force_flush_pending_streaming` helper the production reader uses,
-    /// then push a `StateChanged(Idle)` event to mirror the post-lock
-    /// `emit_session_state_changed`. Mirrors `bridge_common.rs:1982-2038`.
+    /// Drive the production `bridge error` lock-block via
+    /// `run_bridge_error_transition_locked`, then mirror the post-lock
+    /// `emit_session_state_changed`.
     fn drive_bridge_error_path(
         proc: &mut AgentProcess,
         chat_session_id: &str,
-        error_part: MessagePart,
+        error_message: &str,
         events: &mut Vec<RecordedEmit>,
-    ) {
-        let was_streaming = proc.state == BridgeState::Streaming;
-        let mid = proc.streaming_message_id.clone();
-        if was_streaming {
-            proc.streaming_parts.push(error_part.clone());
-            enqueue_pending_delta(proc, std::slice::from_ref(&error_part));
-            if let Some(ref mid) = mid {
-                force_flush_pending_streaming(proc, chat_session_id, mid, |parts| {
-                    events.push(RecordedEmit::StreamingFlush {
-                        parts_count: parts.len(),
-                        tail_text: match parts.last() {
-                            Some(MessagePart::Error { content, .. })
-                            | Some(MessagePart::Text { content, .. })
-                            | Some(MessagePart::Thinking { content, .. }) => Some(content.clone()),
-                            _ => None,
-                        },
-                    });
-                    (true, true)
-                });
-            }
-            // Mirror production: state transitions to Crashed → Idle after flush.
-            proc.state = BridgeState::Crashed;
-            proc.turn_phase = TurnPhase::Idle;
+    ) -> BridgeErrorTransition {
+        let msg = serde_json::json!({
+            "type": "error",
+            "message": error_message,
+        });
+        let transition =
+            run_bridge_error_transition_locked(proc, chat_session_id, &msg, recording_emit(events));
+        if transition.turn_complete.was_streaming {
             events.push(RecordedEmit::StateChanged {
                 phase: TurnPhase::Idle,
                 exit_code: Some(1),
             });
         }
+        transition
     }
 
-    /// Drive the production `EOF crash` lock-block: run
-    /// `apply_bridge_eof_crash`, enqueue the synthetic error delta, force-flush
-    /// via the same helper the production reader uses, then push a
+    /// Drive the production `EOF crash` lock-block via
+    /// `run_bridge_eof_crash_transition_locked`, then push a
     /// `StateChanged(Idle)` event to mirror `emit_session_state_changed`.
-    /// Mirrors `bridge_common.rs:2268-2333`.
     fn drive_bridge_eof_crash_path(
         proc: &mut AgentProcess,
         chat_session_id: &str,
         events: &mut Vec<RecordedEmit>,
     ) {
-        let streaming_message_id = proc.streaming_message_id.clone();
-        let backend_id = proc.backend_id.clone();
-        let effect = apply_bridge_eof_crash(
+        let transition = run_bridge_eof_crash_transition_locked(
             true,
-            &mut proc.state,
-            &mut proc.turn_phase,
-            streaming_message_id.as_deref(),
-            &mut proc.streaming_parts,
-            &backend_id,
+            proc,
+            chat_session_id,
+            recording_emit(events),
         );
-        if let (Some(mid), false) = (streaming_message_id.as_ref(), effect.error_delta.is_empty()) {
-            enqueue_pending_delta(proc, &effect.error_delta);
-            force_flush_pending_streaming(proc, chat_session_id, mid, |parts| {
-                events.push(RecordedEmit::StreamingFlush {
-                    parts_count: parts.len(),
-                    tail_text: match parts.last() {
-                        Some(MessagePart::Error { content, .. })
-                        | Some(MessagePart::Text { content, .. })
-                        | Some(MessagePart::Thinking { content, .. }) => Some(content.clone()),
-                        _ => None,
-                    },
-                });
-                (true, true)
-            });
-        }
-        if effect.was_streaming {
+        if transition.turn_complete.was_streaming {
             events.push(RecordedEmit::StateChanged {
                 phase: TurnPhase::Idle,
                 exit_code: Some(-1),
@@ -9122,14 +10016,20 @@ mod tests {
         proc.streaming_parts.push(pending_text.clone());
         enqueue_pending_delta(&mut proc, std::slice::from_ref(&pending_text));
 
-        let error_part = MessagePart::Error {
-            content: "Error: bridge reported failure".to_string(),
-            parent_tool_use_id: None,
-        };
         let mut events = Vec::new();
-        drive_bridge_error_path(&mut proc, "csid", error_part, &mut events);
+        let transition =
+            drive_bridge_error_path(&mut proc, "csid", "bridge reported failure", &mut events);
 
         assert_eq!(events.len(), 2, "flush emit then state emit");
+        assert!(transition.turn_complete.was_streaming);
+        assert!(transition
+            .turn_complete
+            .final_parts
+            .iter()
+            .any(|part| matches!(
+                part,
+                MessagePart::Error { content, .. } if content == "Error: bridge reported failure"
+            )));
         match &events[0] {
             RecordedEmit::StreamingFlush {
                 parts_count,
@@ -9181,7 +10081,7 @@ mod tests {
                 parts_count,
                 tail_text,
             } => {
-                // cumulative: pending Text + apply_bridge_eof_crash が積んだ Error。
+                // cumulative: pending Text + EOF transition が積んだ Error。
                 assert_eq!(*parts_count, 2);
                 assert!(
                     tail_text
@@ -9262,57 +10162,60 @@ mod tests {
         proc
     }
 
-    #[test]
-    fn bridge_eof_crash_adds_error_part_for_streaming_message() {
-        let mut state = BridgeState::Streaming;
-        let mut turn_phase = TurnPhase::Streaming;
-        let mut parts = vec![MessagePart::Text {
+    #[tokio::test]
+    async fn bridge_eof_crash_adds_error_part_for_streaming_message() {
+        let mut proc = make_test_agent_process();
+        proc.state = BridgeState::Streaming;
+        proc.turn_phase = TurnPhase::Streaming;
+        proc.streaming_message_id = Some("message-1".to_string());
+        proc.streaming_parts.push(MessagePart::Text {
             content: "partial".to_string(),
             parent_tool_use_id: None,
-        }];
+        });
 
-        let effect = apply_bridge_eof_crash(
-            true,
-            &mut state,
-            &mut turn_phase,
-            Some("message-1"),
-            &mut parts,
-            "mock",
+        let transition =
+            run_bridge_eof_crash_transition_locked(true, &mut proc, "csid", |_mid, _parts| {
+                (true, true)
+            });
+
+        assert_eq!(proc.state, BridgeState::Crashed);
+        assert_eq!(proc.turn_phase, TurnPhase::Idle);
+        assert!(transition.turn_complete.was_streaming);
+        assert_eq!(
+            transition.turn_complete.final_msg_id.as_deref(),
+            Some("message-1")
         );
-
-        assert_eq!(state, BridgeState::Crashed);
-        assert_eq!(turn_phase, TurnPhase::Idle);
-        assert!(effect.was_streaming);
-        assert_eq!(effect.message_id.as_deref(), Some("message-1"));
-        assert_eq!(effect.error_delta.len(), 1);
-        assert_eq!(effect.persisted_parts.len(), 2);
-        assert!(effect
+        assert_eq!(transition.turn_complete.final_parts.len(), 2);
+        assert!(transition
             .sdk_error_message
             .as_deref()
             .unwrap()
             .contains("mock"));
         assert!(matches!(
-            &effect.error_delta[0],
+            &transition.turn_complete.final_parts[1],
             MessagePart::Error { content, .. }
                 if content.contains("Bridge process exited unexpectedly")
         ));
+        let _ = proc.child.kill().await;
     }
 
-    #[test]
-    fn bridge_eof_crash_marks_initializing_without_streaming_part() {
-        let mut state = BridgeState::Initializing;
-        let mut turn_phase = TurnPhase::Idle;
-        let mut parts = Vec::new();
+    #[tokio::test]
+    async fn bridge_eof_crash_marks_initializing_without_streaming_part() {
+        let mut proc = make_test_agent_process();
+        proc.state = BridgeState::Initializing;
+        proc.turn_phase = TurnPhase::Idle;
 
-        let effect =
-            apply_bridge_eof_crash(true, &mut state, &mut turn_phase, None, &mut parts, "mock");
+        let transition =
+            run_bridge_eof_crash_transition_locked(true, &mut proc, "csid", |_mid, _parts| {
+                (true, true)
+            });
 
-        assert_eq!(state, BridgeState::Crashed);
-        assert_eq!(turn_phase, TurnPhase::Idle);
-        assert!(effect.was_initializing);
-        assert!(effect.error_delta.is_empty());
-        assert!(effect.persisted_parts.is_empty());
-        assert!(effect.sdk_error_message.is_some());
+        assert_eq!(proc.state, BridgeState::Crashed);
+        assert_eq!(proc.turn_phase, TurnPhase::Idle);
+        assert!(transition.was_initializing);
+        assert!(transition.turn_complete.final_parts.is_empty());
+        assert!(transition.sdk_error_message.is_some());
+        let _ = proc.child.kill().await;
     }
 
     #[test]
@@ -9798,12 +10701,14 @@ mod tests {
 
         start_agent_turn_with_runtime_spawner(
             None::<&tauri::AppHandle>,
+            None,
             &handles,
             &session_id,
             "edit",
             "resume step",
             "agent-msg-1",
             &[],
+            TurnOrigin::Desktop,
             {
                 let handles = Arc::clone(&handles);
                 let session_id = session_id.clone();
@@ -9843,12 +10748,14 @@ mod tests {
 
         start_agent_turn_with_runtime_spawner(
             None::<&tauri::AppHandle>,
+            None,
             &handles,
             &session_id,
             "edit",
             "continue step",
             "agent-msg-2",
             &[],
+            TurnOrigin::Desktop,
             {
                 let spawn_count = Arc::clone(&spawn_count);
                 move || async move {
@@ -9880,12 +10787,14 @@ mod tests {
             tokio::spawn(async move {
                 start_agent_turn_with_runtime_spawner(
                     None::<&tauri::AppHandle>,
+                    None,
                     &handles,
                     &session_id,
                     "edit",
                     "resume step",
                     "agent-msg-locked",
                     &[],
+                    TurnOrigin::Desktop,
                     {
                         let handles = Arc::clone(&handles);
                         let session_id = session_id.clone();
@@ -9935,12 +10844,14 @@ mod tests {
             async move {
                 start_agent_turn_with_runtime_spawner(
                     None::<&tauri::AppHandle>,
+                    None,
                     &handles,
                     &session_id,
                     "edit",
                     "first",
                     "agent-msg-1",
                     &[],
+                    TurnOrigin::Desktop,
                     {
                         let handles = Arc::clone(&handles);
                         let session_id = session_id.clone();
@@ -9965,12 +10876,14 @@ mod tests {
             async move {
                 start_agent_turn_with_runtime_spawner(
                     None::<&tauri::AppHandle>,
+                    None,
                     &handles,
                     &session_id,
                     "edit",
                     "second",
                     "agent-msg-2",
                     &[],
+                    TurnOrigin::Desktop,
                     {
                         let handles = Arc::clone(&handles);
                         let session_id = session_id.clone();
@@ -10289,6 +11202,11 @@ mod tests {
                 pending_stream_bytes: 0,
                 last_stream_emit_at: None,
                 streaming_timer_active: false,
+                last_progress_at: None,
+                turn_phase_since: Instant::now(),
+                turn_origin: TurnOrigin::Desktop,
+                turn_seq: 0,
+                turn_watchdog_active: false,
             },
         );
 
@@ -11602,6 +12520,24 @@ mod tests {
     }
 
     #[test]
+    fn test_accumulation_liveness_tracks_visible_part_changes() {
+        let msg = serde_json::json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Hello"}
+            }
+        });
+        let mut parts = vec![];
+        let accumulation =
+            accumulate_sdk_message_with_liveness(&msg, &mut parts, &mut HashMap::new());
+
+        assert!(accumulation.handled);
+        assert!(accumulation.liveness);
+        assert_eq!(parts.len(), 1);
+    }
+
+    #[test]
     fn test_accumulate_tool_use() {
         let msg = serde_json::json!({
             "type": "assistant",
@@ -12084,6 +13020,77 @@ mod tests {
             assert!(updated.is_none());
             assert!(parts.is_empty());
         }
+    }
+
+    #[test]
+    fn test_accumulation_liveness_ignores_removed_system_subtypes() {
+        for msg in [
+            serde_json::json!({
+                "type": "system",
+                "subtype": "hook_started",
+                "hook_name": "SessionEnd",
+                "hook_event": "StopSession",
+                "hook_id": "hook-001"
+            }),
+            serde_json::json!({
+                "type": "system",
+                "subtype": "hook_progress",
+                "hook_id": "hook-001",
+                "message": "running"
+            }),
+            serde_json::json!({
+                "type": "system",
+                "subtype": "hook_response",
+                "hook_id": "hook-001",
+                "outcome": "success",
+                "exit_code": 0
+            }),
+            serde_json::json!({
+                "type": "system",
+                "subtype": "files_persisted",
+                "filePaths": ["CLAUDE.md", "src/main.rs"]
+            }),
+            serde_json::json!({
+                "type": "system",
+                "subtype": "local_command_output",
+                "content": "npm test output here"
+            }),
+            serde_json::json!({
+                "type": "system",
+                "subtype": "codex_realtime",
+                "notification_type": "codex_realtime",
+                "status": "in_progress",
+                "label": "Codex realtime started",
+                "detail": "thread=thr_123, version=v2"
+            }),
+        ] {
+            let mut parts = vec![];
+            let accumulation =
+                accumulate_sdk_message_with_liveness(&msg, &mut parts, &mut HashMap::new());
+
+            assert!(accumulation.handled);
+            assert!(!accumulation.liveness);
+            assert!(accumulation.updated_parts.is_none());
+            assert!(parts.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_accumulation_liveness_accepts_explicit_progress_notifications() {
+        let msg = serde_json::json!({
+            "type": "system",
+            "subtype": "task_updated",
+            "task_id": "task-001",
+            "patch": {"status": "progress", "summary": "still running"}
+        });
+        let mut parts = vec![];
+        let accumulation =
+            accumulate_sdk_message_with_liveness(&msg, &mut parts, &mut HashMap::new());
+
+        assert!(accumulation.handled);
+        assert!(accumulation.liveness);
+        assert!(accumulation.updated_parts.is_none());
+        assert!(parts.is_empty());
     }
 
     #[test]
@@ -12778,6 +13785,11 @@ mod tests {
             pending_stream_bytes: 0,
             last_stream_emit_at: None,
             streaming_timer_active: false,
+            last_progress_at: None,
+            turn_phase_since: Instant::now(),
+            turn_origin: TurnOrigin::Desktop,
+            turn_seq: 0,
+            turn_watchdog_active: false,
         };
         (proc, stdout)
     }
@@ -13484,6 +14496,11 @@ mod tests {
                 pending_stream_bytes: 0,
                 last_stream_emit_at: None,
                 streaming_timer_active: false,
+                last_progress_at: None,
+                turn_phase_since: Instant::now(),
+                turn_origin: TurnOrigin::Desktop,
+                turn_seq: 0,
+                turn_watchdog_active: false,
             }
         }
 
@@ -14517,6 +15534,36 @@ mod tests {
         assert!(
             !env.iter().any(|(k, _)| *k == "RELEASH_BASE_BRANCH"),
             "RELEASH_BASE_BRANCH must not be set when base branch cannot be resolved"
+        );
+    }
+
+    #[test]
+    fn claude_bridge_watchdog_env_uses_existing_native_levers() {
+        let env = claude_bridge_watchdog_env_overrides();
+        let keys: Vec<&str> = env.iter().map(|(key, _)| *key).collect();
+
+        assert_eq!(
+            keys,
+            vec![
+                "CLAUDE_STREAM_IDLE_TIMEOUT_MS",
+                "CLAUDE_ENABLE_STREAM_WATCHDOG",
+                "CLAUDE_ENABLE_BYTE_WATCHDOG",
+                "CLAUDE_CODE_MAX_RETRIES",
+                "API_TIMEOUT_MS",
+            ]
+        );
+        assert!(!keys.contains(&"CLAUDE_CODE_STREAM_CLOSE_TIMEOUT"));
+        assert_eq!(
+            env.iter()
+                .find_map(|(key, value)| (*key == "CLAUDE_ENABLE_STREAM_WATCHDOG")
+                    .then_some(value.as_str())),
+            Some("1")
+        );
+        assert_eq!(
+            env.iter()
+                .find_map(|(key, value)| (*key == "CLAUDE_STREAM_IDLE_TIMEOUT_MS")
+                    .then_some(value.as_str())),
+            Some("180000")
         );
     }
 }


### PR DESCRIPTION
## 概要

Claude Agent SDK 経路の turn が無音停止（result も進捗イベントも届かない）した際に、turn watchdog で検出して失敗完了させ、bridge を復旧して次 turn に持ち越さないようにする。Issue #1178 の対応。

## 変更内容

- **stale timeout 検出**: `Streaming` 状態で進捗イベント（thinking / tool / progress / text delta）が 180 秒届かない turn を stale と判定
- **permission timeout 検出**: headless 経路（`workflow_step_session`）の `WaitingPermission` を 300 秒で打ち切り。デスクトップ経路は無期限待ち
- **回復シーケンス**: 失敗完了（部分出力を persist）→ interrupt → grace 待機 → 未復帰なら `sweep_process_group` で破棄
- **TurnOrigin の導出**: handler/dispatcher へ origin を引き回さず、runtime 内で `ChatSession.workflow_step_session` から `Desktop` / `Headless` を導出
- **result なし close**: bridge が `turn_complete(exit_code=1)` を emit し、正常終了扱いを防止
- **Spec 更新**: requirements / behavior / design を remote 経路削除に合わせて更新

## テスト

- `bridge_common.rs` の `#[cfg(test)]` で stale / permission timeout / 二重完了防止 / 正常系不変などを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)