### PR TITLE
refactor(workflow): terminal 化した run の WorkflowExecution を即時解放しメモリ無制限増大を解消 (#1196)

### DIFF
--- a/docs/specs/issues-1196/behavior.md
+++ b/docs/specs/issues-1196/behavior.md
@@ -1,0 +1,131 @@
+# Behavior
+
+terminal 化した workflow run の常駐メモリ解放（#1196）について、外部から観測可能な振る舞いを Gherkin で定義する。
+
+本書は「振る舞いの不変性」を中心に据える。解放そのものは内部構造の変更であり、エンドユーザー・フロント・バックエンドから観測できるのは「履歴表示・状態問い合わせ・active run 進行が変わらないこと」と「run を重ねても常駐メモリが比例して積み上がらないこと」である。`executions` map・Run Store・Event Log・再構築経路等の内部実装名は、観測可能な振る舞いではないため本書の Scenario には持ち込まない。
+
+## 用語
+
+- **terminal run**: status が Completed / Failed / Aborted のいずれかになった workflow run。
+- **active run**: status が Running / WaitingApproval の workflow run。
+- **履歴問い合わせ**: 完了済み run の状態・ログ・step 出力・step 詳細・run サマリ・worktree 解決といった、run を参照する読み取り操作の総称。
+
+## Feature: terminal run の常駐メモリ解放と振る舞いの不変
+
+  workflow run が terminal 化したとき、その run 本体は常駐メモリから解放される。
+  解放後も、エンドユーザー・フロント・バックエンドから観測できる振る舞い
+  （履歴問い合わせ結果・active run の進行・worktree 起点の active run 検索）は一切変化しない。
+
+  Background:
+    Given workflow runtime が起動している
+    And run の状態・履歴は永続化されている
+
+  ## Rule: terminal 化した run の本体は常駐し続けない
+
+    Scenario: 単一 run を完了させても本体が常駐し続けない
+      Given 1 つの workflow run を実行している
+      When その run が terminal 化する
+      Then その run 本体の常駐メモリは解放される
+
+    Scenario Outline: いずれの terminal status でも本体が解放される
+      Given 1 つの workflow run を実行している
+      When その run が "<status>" になる
+      Then その run 本体の常駐メモリは解放される
+
+      Examples:
+        | status         |
+        | Completed      |
+        | Failed         |
+        | Aborted        |
+
+    Scenario: 複数 run を完了させても常駐メモリが run 数に比例して積み上がらない
+      Given 同種の workflow run を複数回 実行して順次 terminal 化させる
+      When run の完了回数を増やしていく
+      Then terminal 化済み run に由来する常駐メモリは run 数に比例して増加しない
+
+    Scenario: step 出力が大きい run を完了させても常駐メモリが出力量に比例して積み上がらない
+      Given step 出力量の大きい workflow run を実行している
+      When その run が terminal 化する
+      Then その run の step 出力量に比例した常駐メモリは残らない
+
+  ## Rule: terminal run の履歴問い合わせは解放の前後で同一の結果を返す
+
+    Scenario Outline: 各履歴問い合わせが解放後も従来どおりの結果を返す
+      Given 完了済みの workflow run がある
+      When その run に対して "<query>" を要求する
+      Then 解放前と同一の結果が返る
+
+      Examples:
+        | query        |
+        | run サマリ取得  |
+        | run 状態取得    |
+        | run ログ取得    |
+        | step 出力取得   |
+        | step 詳細取得   |
+        | run 一覧取得    |
+
+    Scenario: 完了直後に履歴表示を要求しても従来どおり表示できる
+      Given 1 つの workflow run を実行している
+      When その run が terminal 化した直後に履歴表示を要求する
+      Then その run の履歴が従来どおり表示される
+      And 体感的な表示応答性に劣化が生じない
+
+    Scenario: 同一 terminal run に対する履歴問い合わせを繰り返しても結果が一貫する
+      Given 完了済みの workflow run がある
+      When その run に対して履歴問い合わせを複数回 行う
+      Then いずれの問い合わせも同一の結果を返す
+
+  ## Rule: active run の振る舞いは本修正の影響を受けない
+
+    Scenario: active run の進行と状態遷移が変化しない
+      Given workflow run が実行中である
+      When run が step を進め状態が遷移する
+      Then 進行・状態遷移・状態通知（broadcast）は従来どおり行われる
+      And active run 本体は解放されない
+
+    Scenario: worktree 起点の active run 検索が変化しない
+      Given 特定の worktree に紐づく active run がある
+      When その worktree を起点に active run を検索する
+      Then 従来どおり該当の active run が見つかる
+
+    Scenario: terminal 化した run は active run 検索の対象から外れる
+      Given ある worktree に紐づいていた run が terminal 化している
+      When その worktree を起点に active run を検索する
+      Then その run は active run としては返らない
+      And その run の履歴は履歴問い合わせから参照できる
+
+  ## Rule: 解放と再構築が競合しても状態の不整合や取りこぼしが起きない
+
+    Scenario: terminal 化直後の状態問い合わせで不整合が生じない
+      Given 1 つの workflow run が terminal 化する
+      When terminal 化とほぼ同時にその run の状態問い合わせが行われる
+      Then 状態の不整合やエラーなく、その run の terminal 状態が返る
+
+    Scenario: 複数 run の並列実行・完了で run の取りこぼしが起きない
+      Given 複数の workflow run を並列に実行している
+      When それらが相次いで terminal 化する
+      Then いずれの run も履歴問い合わせから漏れなく参照できる
+      And active run の進行は他 run の terminal 化の影響を受けない
+
+    Scenario: terminal 化した run を後から再開・参照しても整合する
+      Given terminal 化済みの workflow run がある
+      When その run を後から参照・再開しようとする
+      Then 永続化された状態に基づき整合した結果が得られる
+
+  ## Rule: 既存の品質ゲートを通過する
+
+    Scenario: 既存のテストと lint が green である
+      Given 本修正を適用したコードベースがある
+      When cargo test / pnpm test / cargo clippy -D warnings / pnpm lint を実行する
+      Then すべて成功する
+
+## 仮定
+
+- [仮定] terminal run の解放は「即時解放」（terminal 化と同時に本体を常駐メモリから外し、必要時に永続化済み状態から再構築）で行う。「直近 N 件保持」「遅延解放」等の保持戦略は採用しない（requirements の合意済み仮定に準拠）。
+- [仮定] terminal run の履歴問い合わせは、全 terminal status（Completed / Failed / Aborted）・全問い合わせ経路（run サマリ・状態・ログ・step 出力・step 詳細・一覧）について、解放後も永続化済み状態から従来と同一の結果を供給できる。この網羅性は design / 実装フェーズで裏取りする。
+- [仮定] terminal 化直後に履歴表示を要求した場合の再構築コストは、ユーザーの体感的な表示応答性を劣化させない範囲に収まる。劣化が観測された場合は design フェーズで保持戦略を再検討する。
+- [仮定] 「常駐メモリが run 数・step 出力量に比例して積み上がらない」ことの確認手段（実測の取り方）は本書では振る舞いとしてのみ規定し、具体的な計測方法は design / 実装フェーズで定める。
+
+## Open Questions
+
+なし（解放方針はユーザー合意により「即時解放」で確定）。

--- a/docs/specs/issues-1196/design.md
+++ b/docs/specs/issues-1196/design.md
@@ -1,0 +1,167 @@
+# Design
+
+terminal 化した workflow run の `WorkflowExecution` を `executions` map から即時解放し、無制限増大経路 C10（#1196）を是正するための実装設計。requirements.md / behavior.md に準拠する。
+
+## 概要
+
+workflow runtime（`WorkflowRuntimeService`）は `executions: Mutex<HashMap<String, WorkflowExecution>>` に run の本体を常駐させる。現状、terminal 化（Completed / Failed / Aborted）後も本体（`step_history` / `step_outputs` / `workflow_variables` / `workflow_definition`）は通常経路では削除されず、run の進行・蓄積に比例して常駐メモリが無制限に増大する。
+
+本設計の方針は次の 2 点に集約される。
+
+1. **即時解放**: terminal 化と同時に、当該 run を `executions` map から `remove` する。terminal 化の副作用（step session release・`session_workflow_refs` cleanup・状態 broadcast）が完了し、broadcast 用 snapshot を取り終えた直後に削除する。削除は冪等とし、全 terminal sink に共通ヘルパとして適用する。
+2. **読み取り経路の不変性保証**: 履歴問い合わせ・状態問い合わせが解放後も同一結果を返すことを保証する。履歴問い合わせは既に Event Log / State Projection（永続化）から供給されており map に依存しないため影響を受けない。Aborted run では terminal 解放後も中断 step の `session_id` 等を復元できるよう、`RunAborted` event に optional な中断 step snapshot を持たせ、projection 境界で read model に変換する。`get_state_by_run_id`（gateway）は run_id のみを受ける live active 用 API に留め、terminal run の状態取得は controller 側で `worktree_path` 認可を通る `get_workflow_run_state` に寄せる。
+
+この方針により「terminal run の本体が常駐し続けない」かつ「履歴問い合わせ・active run 進行という外部観測可能な振る舞いが不変」を両立する。
+
+## 変更対象
+
+- `src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs`
+  - terminal sink への即時解放の挿入（下記 3 経路）と共通ヘルパ追加。
+  - abort 経路で中断 step の event snapshot を `RunAborted` に書き込む。
+  - `get_state_by_run_id` を in-memory live state 参照専用に保つ回帰テスト追加。
+  - `#[cfg(test)]` 検証用アクセサの追加。
+- `src-tauri/src/adaptor/gateway/workflow/event.rs`
+  - `WorkflowEvent::RunAborted` に後方互換の optional `aborted_step` を追加する。
+  - `aborted_step` は Event Log 専用 snapshot であり、`StepHistoryEntry` の表示用 state までは永続化しない。
+- `src-tauri/src/adaptor/gateway/workflow/runtime_events.rs`
+  - `StepHistoryEntry` から `RunAborted` 用 snapshot へ変換する mapper を追加する。
+- `src-tauri/src/adaptor/gateway/workflow/event_projection.rs`
+  - `RunAborted.aborted_step` が存在する場合は snapshot を優先して `StepHistoryEntry` へ変換する。
+  - `aborted_step` が存在しない旧 event は既存の復元経路で扱う。
+- 上記以外のファイルは原則変更しない。
+  - `usecase/workflow/query_service.rs` ほか履歴問い合わせ経路は Event Log / State Projection 依存で map を読まないため変更不要（後述 [調査結果]）。
+  - `execution_registry.rs` の `find_by_worktree` / `find_by_worktree_mut` は `is_active()` フィルタ済みで terminal run を返さない設計のため変更不要。
+  - Run Store / 永続化ファイル配置は変更しない。Event Log schema は `RunAborted.aborted_step` の optional 拡張のみ例外として扱う。
+
+## アーキテクチャと責務分割
+
+レイヤー境界（`infrastructure → adaptor/gateway → domain ← usecase ← adaptor/controller`）は維持し、本修正は gateway（`WorkflowRuntimeService`）内に閉じる。
+
+- **解放の責務**: gateway の terminal 遷移 sink。terminal 化の確定（required event の append commit）と副作用（session release / refs cleanup / broadcast）の後段に「map からの本体解放」を追加する。解放は in-memory 表の管理であり gateway の責務に閉じる。
+- **再構築の責務**: 既存の永続化読み取り（Event Log → `reconstruct_state_from_events` → projected state）を gateway 内で再利用する。`RunAborted.aborted_step` は Event Log から read model へ射影する責務を `event_projection.rs` に閉じ、usecase / controller の契約は変更しない。
+- **履歴問い合わせの責務**: 既に usecase `query_service` が Event Log / State Projection から供給しており、本修正の前後で経路・契約とも不変。
+
+### terminal sink の集約
+
+terminal 化が最終的に通る sink は次の 3 経路で、現状いずれも `executions` からの削除を行っていない。
+
+| sink | 位置（現状） | 扱う status | 呼び出し起点 |
+|---|---|---|---|
+| `set_execution_state_inner` の terminal branch | L2703-2742 付近 | Completed / Failed（Aborted は除外） | `set_execution_state` ← 各 `handle_*` / command handler |
+| `finalize_after_commit` の terminal branch | L3316-3329 付近 | Completed / Failed / Aborted | `persist_release_and_broadcast` / `execute_outcome`（on_turn_complete 系） |
+| `finalize_terminal_transition_after_required_append` | L1948-1966 付近 | Aborted（AbortRun post-commit） | `abort_workflow_by_run_id` |
+
+これら 3 sink に対し、broadcast 完了後の末尾で共通ヘルパ `release_terminal_execution(run_id)` を呼ぶ。各 sink は broadcast 用の snapshot（`to_workflow_state()` の結果）を削除前に取得済みであるため、削除によって broadcast 内容は影響を受けない。
+
+- **冪等性**: `HashMap::remove` は対象不在でも安全。Completed/Failed が複数 sink を通過し得る経路（例: `set_execution_state` 経由と `finalize_after_commit` 経由）でも、二重削除は無害。これにより「全 terminal sink を漏れなく覆う（漏れ＝メモリ残留）／重複は無害」という設計原則で安全側に倒す。
+- **active run の保護**: ヘルパは呼び出し側が terminal 確定後にのみ呼ぶ。ヘルパ内でも防御的に「対象 run が `is_terminal()` のときのみ削除」を確認し、active run を誤って解放しない。
+
+## データモデルまたは型
+
+Run Store schema と永続化ファイル配置は変更しない。Event Log schema は Aborted run の復元精度を保つため、`WorkflowEvent::RunAborted` に optional `aborted_step` を追加する。
+
+- `WorkflowExecution`（`runtime_state.rs`）: フィールド・`is_active()` / `is_terminal()` / `to_workflow_state()` は不変。
+- `executions: Mutex<HashMap<String, WorkflowExecution>>`: 構造不変。ライフサイクルのみ変更（terminal 化で entry を除去）。
+- `RunAbortedStepSnapshot` / `RunAbortedChildOutputSnapshot`（`event.rs`）: Event Log 専用の snapshot。中断された通常 step / parallel child の `session_id`・`result`・`structured_output`・`run_index` 等を保持するが、read model 表示用の `state` は projection 境界で補う。`aborted_step` は `#[serde(skip_serializing_if = "Option::is_none", default)]` とし、旧 event との deserialize 互換を保つ。
+- `event_projection.rs`: `RunAborted.aborted_step` が存在する場合は snapshot から `StepHistoryEntry` を構築し、存在しない場合は従来の current step / active parallel snapshot 由来の復元にフォールバックする。
+- 共通ヘルパ（新規・private）:
+
+  ```rust
+  /// terminal 化した run を executions map から解放する。
+  /// 全 terminal sink から broadcast 完了後に呼ぶ。冪等。
+  async fn release_terminal_execution(&self, run_id: &str) {
+      let mut execs = self.executions.lock().await;
+      if let Some(exec) = execs.get(run_id) {
+          if exec.is_terminal() {
+              execs.remove(run_id);
+          }
+      }
+  }
+  ```
+
+- `get_state_by_run_id` の live state 境界（既存 method の責務明確化）:
+
+  ```rust
+  pub async fn get_state_by_run_id(&self, run_id: &str) -> Option<WorkflowState> {
+      let execs = self.executions.lock().await;
+      execs.get(run_id).map(|e| e.to_workflow_state())
+  }
+  ```
+
+  `get_state_by_run_id` は `get_workflow_state` command 経由で run_id のみを受けるため、map miss 時に Run Store + Event Log から terminal history を返すと worktree 認可境界を迂回する。terminal run の状態取得は `worktree_path` を必須にする `get_workflow_run_state`（controller → `authorize_run_summary_for_worktree` → query_service）で行う。
+
+## 処理フロー
+
+### terminal 化時（解放）
+
+1. step / abort / state 設定の各経路で terminal status を確定。
+2. required event を append commit（既存）。Aborted run では、commit 前に中断 step の snapshot を作成し、`RunAborted.aborted_step` として append する。
+3. step session release・`session_workflow_refs` cleanup（既存）。
+4. broadcast 用 snapshot を取得済みの状態で `broadcast_state`（既存）。
+5. **（追加）`release_terminal_execution(run_id)` を呼び、map から本体を除去。**
+
+これにより terminal 化直後に `executions` から当該 run が消える。broadcast は手順 4 で完了済みのため、UI への terminal 状態通知は従来どおり行われる。
+
+### terminal run の状態・履歴問い合わせ（解放後）
+
+- **`get_run_log` / `get_run_state` / `get_output` / `get_step_detail` / `list_runs`（usecase `query_service`）**: Event Log / State Projection / Run Store から供給。map を読まないため解放の影響を受けず、解放前と同一結果。Aborted run の中断 step は `RunAborted.aborted_step` があればそれを read model へ変換し、旧 event では既存復元経路を使う。
+- **`get_state_by_run_id`（gateway, `get_workflow_state` command 経由）**: in-memory map に存在する live run の状態だけを返す。terminal 化で release 済みの run は `None` になり、terminal history は `get_workflow_run_state` 経由で参照する。
+- **worktree 起点の active run 検索（`get_state` / `find_by_worktree`）**: `is_active()` フィルタ済みで terminal run を元来返さない。解放により map から消えても「active としては返らない」という従来の振る舞いと一致する。
+
+### 競合・並列
+
+- terminal 化と状態問い合わせがほぼ同時の場合: map 取得が削除前なら live 値、削除後なら再構築値を返す。いずれも同一の terminal 状態であり不整合は生じない（behavior: terminal 化直後の状態問い合わせで不整合が生じない）。
+- 複数 run の並列 terminal 化: 削除は run_id 単位で独立。`cleanup_session_workflow_refs_by_run_id` も run_id 主語のため他 run の refs を巻き込まない。active run の進行は他 run の解放の影響を受けない。
+- terminal run の後からの再開（CLI dispatch `ensure_execution_loaded_for_external`）: 当該経路は `validate_run_record_for_external_restore` で terminal run を `InvalidState("already terminal")` として拒否する（実装確認済み）。したがって即時解放した terminal run が CLI dispatch 経由で map へ恒久再挿入されることはなく、解放方針と整合する。
+
+## エラー処理
+
+- `release_terminal_execution`: I/O を伴わない map 操作のみ。失敗経路を持たない（戻り値なし）。terminal でない run に対しては no-op。
+- `get_state_by_run_id`: in-memory map の読み取りのみを行い、対象不在は `None` を返す。永続履歴の読み取りエラーはこの経路に持ち込まず、認可付き履歴 API 側で既存どおり扱う。
+- terminal 副作用（session release / broadcast）は既存どおり best-effort（post-commit 失敗は warn）であり、解放追加によってこの方針は変えない。解放は副作用の後段に置くため、副作用失敗時も解放は実行され、メモリ解放が副作用結果に依存しない。
+
+## テスト方針
+
+`#[cfg(test)]` の検証用アクセサ（例: `async fn contains_execution_for_test(&self, run_id: &str) -> bool` および `async fn executions_len_for_test(&self) -> usize`）を `WorkflowRuntimeService` に追加し、map の membership / len を検査可能にする。これは「常駐メモリが run 数・step output 量に比例して積み上がらない」ことの決定的な代理指標（terminal run が map に残らない＝本体が常駐しない）として用いる。
+
+- **解放（Rust, gateway）**
+  - 単一 run を Completed させた後、`contains_execution_for_test(run_id) == false`。
+  - Failed / Aborted それぞれで terminal 化させ、いずれも map から除去される（behavior の Scenario Outline に対応）。
+  - 複数 run（N 件）を順次完了させた後、terminal run 由来の entry 数が増加しない（`executions_len_for_test` が run 数に比例しない／terminal 分は 0）。
+  - step output が大きい run を完了させても entry が残らない（output 量に比例した常駐がない）。
+- **履歴問い合わせの不変性**
+  - terminal run に対する `get_workflow_run_state` が、解放後も worktree 認可を通したうえで terminal 状態を返す。
+  - `RunAborted.aborted_step` が Event Log 専用 snapshot として serialize され、`StepHistoryEntry` の表示用 `state` を直接永続化しない。
+  - projection が `RunAborted.aborted_step` を優先して `StepHistoryEntry` に変換し、中断 step の `session_id` を復元できる。
+  - released terminal run に対する `get_state_by_run_id` は `None` を返し、run_id-only command から履歴状態を露出しない。
+  - `get_run_log` / `get_run_state` / `get_output` / `get_step_detail` / `list_runs`（usecase）が解放前後で同一結果（既存テストの維持で担保しつつ、terminal 後参照のケースを補強）。
+  - 同一 terminal run への問い合わせを繰り返しても結果が一貫する。
+- **active run の不変性**
+  - active run（Running / WaitingApproval）は解放されず map に残る。
+  - worktree 起点の active run 検索が従来どおり該当 run を返す。terminal 化後は active 検索から外れ、履歴問い合わせからは参照できる。
+- **競合**
+  - terminal 化直後の状態問い合わせで terminal 状態が返り、エラー / 不整合が生じない。
+  - 並列 run の相次ぐ terminal 化で取りこぼし（履歴参照漏れ）が生じない。
+- **品質ゲート**: `cargo test` / `pnpm test` / `cargo clippy -- -D warnings` / `pnpm lint` が green。フロント変更はないが回帰確認として `pnpm test` を実行する。
+
+## リスクと代替案
+
+- **terminal sink の網羅性**: 3 sink の列挙が漏れていると、その経路で terminal 化した run が map に残りメモリ解放が不完全になる。緩和: 削除を冪等にし全 sink へ配置、かつ「複数 run 完了後に terminal entry が 0」を検証するテストで網羅漏れを検出する。実装フェーズで terminal 遷移の全経路（特に Aborted の複数入口）を再確認する。
+- **run_id-only public command の認可境界**: `get_state_by_run_id` に永続 fallback を持たせると、`worktree_path` を受けない `get_workflow_state` から terminal history を読める。緩和: `get_state_by_run_id` は live active 専用に留め、terminal 状態は `get_workflow_run_state` の `authorize_run_summary_for_worktree` 境界へ寄せる。
+- **代替案 A（`get_workflow_state` に `worktree_path` 認可を追加する）**: 既存 command signature と active run UI 経路の契約変更が大きいため不採用。本 issue では terminal history を既存の履歴 API へ寄せる。
+- **代替案 B（直近 N 件保持 / 遅延解放）**: 表示応答性を優先する保持戦略。requirements / behavior で即時解放に確定済みのため不採用。即時解放で体感応答性の劣化が観測された場合にのみ再検討する（requirements の仮定に準拠）。
+- **再構築コストの応答性**: terminal 化直後の表示は broadcast（terminal snapshot）で供給される。後続の履歴表示は Event Log / State Projection を読む既存履歴 API 経由で行うため、live API に再構築コストを持ち込まない。
+- **Event Log schema 拡張の互換性**: `RunAborted.aborted_step` は optional かつ default 付きで、旧 `RunAborted` event は従来復元経路で扱う。緩和: serialize 形と projection の回帰テストで、snapshot が存在する場合の復元精度と存在しない場合の互換性を検証する。
+
+## 仮定
+
+- [仮定] terminal run の解放方針は「即時解放」で確定（requirements / behavior の合意済み仮定に準拠）。直近 N 件保持・遅延解放は採用しない。
+- [仮定] terminal run の履歴問い合わせは、全 terminal status・全履歴問い合わせ経路について Event Log / State Projection / Run Store から従来と同一結果を供給できる。query_service の public 関数は map 非依存であり、controller の履歴 API は `worktree_path` 認可を通る。
+- [仮定] `RunAborted.aborted_step` は Aborted run の中断 step 復元精度を保つための optional Event Log 拡張として扱う。Run Store schema と永続化ファイル配置は変更せず、旧 `RunAborted` event は `aborted_step: None` として従来どおり復元する。
+- [仮定] terminal 化直後の表示は broadcast 由来であり、以後の terminal history は履歴 API 経由で取得される。
+- [仮定] terminal run は CLI dispatch の restore（`ensure_execution_loaded_for_external`）で拒否されるため、即時解放後に map へ恒久再挿入されることはない（`validate_run_record_for_external_restore` の terminal 拒否を確認済み）。
+- [仮定] 「常駐メモリが比例して積み上がらない」ことの検証は、`#[cfg(test)]` アクセサによる map membership / len 検査を決定的代理指標として用いる（実バイト計測の常設プロファイラは Non-goals）。
+
+## Open Questions
+
+なし（解放方針は「即時解放」で確定。terminal history は認可付き履歴 API に寄せる）。

--- a/docs/specs/issues-1196/requirements.md
+++ b/docs/specs/issues-1196/requirements.md
@@ -1,0 +1,72 @@
+# Requirements
+
+## Type
+
+メモリ削減（構造的問題の是正）。親 ISSUE #1191 の広域調査で特定した無制限増大経路 C10 を分離して対応する。
+
+## Goal
+
+terminal 化した workflow run の `WorkflowExecution` 本体を runtime の `executions` map に常駐させ続けることで生じる、workflow run の進行・蓄積に比例したメモリの無制限増大を解消する。
+
+完了時には、workflow run を複数回完了させても、terminal 化した run の `WorkflowExecution`（`step_history` / `step_outputs` / `workflow_variables` / `workflow_definition` を含む）が常駐し続けず、run 数・step output 量に比例して常駐メモリが積み上がらない状態を目指す。同時に、完了 run の履歴表示・復元、および active run の進行という外部から観測可能な振る舞いは不変に保つ。
+
+## Background
+
+- 親 ISSUE #1191 の広域調査で特定した無制限増大経路の一つ（候補 C10）。#1191 本体（A群: 振る舞い不変・低リスクな純粋削減）から分離し、解放/復元の設計判断を要するため別 ISSUE（本 #1196）とした。詳細は `docs/specs/issues-1191/design.md`（候補 C10）を参照。
+- workflow runtime の `executions`（`run_id -> WorkflowExecution` の `Mutex<HashMap<String, WorkflowExecution>>`）は、terminal 化（Completed / Failed / Aborted）後も `WorkflowExecution` 本体を通常経路では削除しない。
+  - 定義: `src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs` L161-167 付近。
+  - terminal 経路（L1948-1966 / L2730-2741 / L3316-3329 付近）は step session 解放・`session_workflow_refs` の cleanup・状態 broadcast のみを行い、`executions` からの削除は行わない。
+  - `execs.remove` は起動失敗系（RunStarted ログ書き込み失敗時のロールバック、L652 付近）でのみ呼ばれる。
+- `WorkflowExecution` は `step_history` / `step_outputs` / `workflow_variables` / `workflow_definition` を保持し、`to_snapshot()` / `to_workflow_state()` でも全フィールドを clone するため、run が大きいほど常駐量と状態 emit 時のピークが増える。
+- 旧バージョン（v0.3.53）の `workflow/engine.rs` にも同型の `executions` map と cleanup-only な terminal 経路が存在するため、これは v0.3.55 だけの新規混入ではなく、workflow 利用時の構造的問題である。
+- 調査により、terminal run の履歴は既に永続化されており、`executions` から消えても再構築可能な素地があることを確認済み（[仮定] 下記参照）。
+  - Run Store（`workflow_runs/{run_id}.json` の metadata）と Event Log（`workflow_logs/{run_id}.ndjson` の append-only event 列）に run の状態・履歴が永続化されている。
+  - `restore_execution_by_run_id()`（`runtime_engine_impl.rs` L1040-1097 付近）が、`executions` に run が存在しない場合に Run Store + Event Log から `WorkflowExecution` を on-demand 再構築する経路として既に実装されている。
+  - 完了 run の履歴表示は `usecase/workflow/query_service.rs` の `get_run_log` 経由で Event Log から供給される。
+
+## Users / Actors
+
+- Releash で workflow run を複数回実行・完了させるエンドユーザー（terminal run の履歴を後から参照する利用者を含む）。
+- workflow run を進行・terminal 化し、状態を永続化・broadcast するバックエンド（workflow runtime）。
+- メモリ挙動の切り分け・検証を行う開発者。
+
+## Scope
+
+- terminal 化（Completed / Failed / Aborted）した workflow run の `WorkflowExecution` を、terminal 化と同時に `executions` map から解放する（即時解放方針）。
+- terminal run の履歴表示・状態問い合わせが必要になった時点で、Run Store + Event Log からの再構築（`restore_execution_by_run_id()` 経路）で `WorkflowExecution` を供給する。
+- active run（Running / WaitingApproval）の進行、および terminal run の履歴表示・復元という外部から観測可能な振る舞いの不変を保つこと。
+- terminal run の常駐メモリが解放されること（run 数・step output 量に比例して積み上がらないこと）を確認するための検証手段の整備。
+
+## Non-goals
+
+- 親 #1191 の A群純粋削減（C2/C3/C4/C7/C8/C9）の実装。本 ISSUE では扱わない。
+- 他の分離 ISSUE が扱う解放設計（C1 → #1194 / C6 → #1195）の対応。
+- terminal run 解放の「即時 / 遅延 / 直近 N 件保持」のうち、即時解放以外の保持戦略の導入。本 ISSUE は即時解放を採用する（[仮定]）。
+- workflow run の履歴永続化・event log・Run Store の機能仕様そのものの変更・再設計。
+- 完了 run のメモリ削減と無関係なリファクタ（clean architecture 構造の不要な変更を含む）の混在。
+- メモリ使用量の新規モニタリング機能・常設プロファイラの製品化。
+
+## Requirements
+
+- terminal 化した run の `WorkflowExecution` が、terminal 化と同時に `executions` map から削除され、本体（`step_history` / `step_outputs` / `workflow_variables` / `workflow_definition`）が常駐し続けないこと。
+- terminal run の履歴表示・状態問い合わせが、解放後も Run Store + Event Log からの再構築によって従来どおり供給され、表示内容が変化しないこと。
+- active run（Running / WaitingApproval）の進行・状態遷移・broadcast、および worktree 起点の active run 検索（`find_by_worktree` 等）の振る舞いが、本修正によって変化しないこと。
+- 即時解放と再構築の併用によって、解放と再構築が競合する状況（terminal 化直後の状態問い合わせ・再開・並列 run など）でも、状態の不整合や run の取りこぼしが発生しないこと。
+- 既存のテスト（`cargo test` / `pnpm test`）および lint（`cargo clippy -D warnings` / `pnpm lint`）が通ること。
+
+## Acceptance Criteria（概要）
+
+- workflow run を複数回完了させた後、terminal 化した run の `WorkflowExecution` 相当のメモリが `executions` に常駐し続けず、run 数・step output 量に比例して常駐メモリが積み上がらないことを実測で確認できる。
+- terminal run の履歴表示・状態問い合わせが、解放前後で同一の表示内容を返す（再構築経由でも振る舞いが変わらない）。
+- active run の進行・terminal 化・broadcast、worktree 起点の active run 検索に退行がない。
+- 既存の `cargo test` / `pnpm test` / `cargo clippy -D warnings` / `pnpm lint` が green。
+
+## Assumptions（仮定）
+
+- [仮定] terminal run の解放方針は「即時解放（terminal 化と同時に `executions` から削除し、必要時に再構築）」とする（ユーザー合意済み）。直近 run の表示応答性確保のための「直近 N 件保持」「遅延解放」等の保持戦略は本 ISSUE では採用しない。
+- [仮定] terminal run の履歴表示・復元は、既存の Run Store（`workflow_runs/{run_id}.json`）+ Event Log（`workflow_logs/{run_id}.ndjson`）と `restore_execution_by_run_id()` 経路で再構築可能であり、即時解放してもこれらから従来どおり供給できる。再構築経路の網羅性（全 terminal status・全表示経路で再構築が成立するか）は design / 実装フェーズで裏取りする。
+- [仮定] terminal 化直後にフロントが run snapshot を要求した場合の再構築コストは許容範囲であり、ユーザーの体感的な表示応答性に劣化を生じさせない範囲に収まる。劣化が観測された場合は design フェーズで保持戦略の再検討を行う。
+
+## Open Questions
+
+なし（解放方針はユーザー合意により「即時解放」で確定）。

--- a/src-tauri/src/adaptor/controller/command/workflow/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/mod.rs
@@ -456,6 +456,7 @@ mod tests {
     };
     use super::*;
     use crate::adaptor::gateway::workflow::event::WorkflowEvent;
+    use crate::adaptor::gateway::workflow::event_projection::reconstruct_state_from_events;
     use crate::adaptor::gateway::workflow::log::WorkflowEventLog;
     use crate::adaptor::gateway::workflow::resolver::{
         ManagedWorktreeResolver, ManagedWorktreeResolverError, WorkflowDefinitionResolver,
@@ -463,7 +464,7 @@ mod tests {
     };
     use crate::adaptor::gateway::workflow::run::{RunStatus, TriggerSource};
     use crate::adaptor::gateway::workflow::schema::{NodeDefinition, NodeType};
-    use crate::adaptor::gateway::workflow::state::WorkflowExecutionState;
+    use crate::adaptor::gateway::workflow::state::{WorkflowExecutionState, WorkflowState};
     use crate::domain::workflow::ApprovalDecision;
     use std::collections::HashSet;
     use std::path::Path;
@@ -611,14 +612,19 @@ mod tests {
         engine: &Arc<TestRuntimeKernel>,
     ) -> std::path::PathBuf {
         let data_dir = crate::app_data_dir::resolve_data_dir(app.handle()).unwrap();
-        engine
-            .set_run_store_data_dir(data_dir.join("workflow_runs"))
-            .await;
+        engine.set_run_store_data_dir(data_dir.clone()).await;
         data_dir
     }
 
     fn read_adapter_events(data_dir: &Path, run_id: &str) -> Vec<WorkflowEvent> {
         WorkflowEventLog::new(data_dir).read_log(run_id).unwrap()
+    }
+
+    fn project_adapter_state(data_dir: &Path, run_id: &str) -> WorkflowState {
+        let events = read_adapter_events(data_dir, run_id);
+        reconstruct_state_from_events(run_id, &events)
+            .unwrap()
+            .expect("adapter events must project state")
     }
 
     async fn start_adapter_run(
@@ -770,14 +776,8 @@ mod tests {
         )
         .await;
 
-        let adapter_state = adapter_engine
-            .get_state_by_run_id(&adapter_run_id)
-            .await
-            .expect("adapter start must create state");
-        let direct_state = direct_engine
-            .get_state_by_run_id(&direct_run_id)
-            .await
-            .expect("direct start must create state");
+        let adapter_state = project_adapter_state(&adapter_data_dir, &adapter_run_id);
+        let direct_state = project_adapter_state(&direct_data_dir, &direct_run_id);
         assert_eq!(adapter_state.state, direct_state.state);
         assert_eq!(
             adapter_state.current_step_name,
@@ -845,19 +845,11 @@ mod tests {
             .expect("direct abort primitive must succeed");
 
         assert_eq!(
-            adapter_engine
-                .get_state_by_run_id(&adapter_run_id)
-                .await
-                .unwrap()
-                .state,
+            project_adapter_state(&adapter_data_dir, &adapter_run_id).state,
             WorkflowExecutionState::Aborted
         );
         assert_eq!(
-            direct_engine
-                .get_state_by_run_id(&direct_run_id)
-                .await
-                .unwrap()
-                .state,
+            project_adapter_state(&direct_data_dir, &direct_run_id).state,
             WorkflowExecutionState::Aborted
         );
         assert_eq!(
@@ -934,14 +926,8 @@ mod tests {
             .await
             .expect("direct approval primitive must succeed");
 
-        let adapter_state = adapter_engine
-            .get_state_by_run_id(&adapter_run_id)
-            .await
-            .unwrap();
-        let direct_state = direct_engine
-            .get_state_by_run_id(&direct_run_id)
-            .await
-            .unwrap();
+        let adapter_state = project_adapter_state(&adapter_data_dir, &adapter_run_id);
+        let direct_state = project_adapter_state(&direct_data_dir, &direct_run_id);
         assert_eq!(adapter_state.state, WorkflowExecutionState::Completed);
         assert_eq!(direct_state.state, WorkflowExecutionState::Completed);
         assert_eq!(
@@ -1020,14 +1006,8 @@ mod tests {
             .await
             .expect("direct reject primitive must succeed");
 
-        let adapter_state = adapter_engine
-            .get_state_by_run_id(&adapter_run_id)
-            .await
-            .unwrap();
-        let direct_state = direct_engine
-            .get_state_by_run_id(&direct_run_id)
-            .await
-            .unwrap();
+        let adapter_state = project_adapter_state(&adapter_data_dir, &adapter_run_id);
+        let direct_state = project_adapter_state(&direct_data_dir, &direct_run_id);
         assert_eq!(adapter_state.state, direct_state.state);
         assert_eq!(
             adapter_run_status(&adapter_engine, &adapter_run_id).await,
@@ -1096,16 +1076,8 @@ mod tests {
             .expect("direct approval abort primitive must succeed");
 
         assert_eq!(
-            adapter_engine
-                .get_state_by_run_id(&adapter_run_id)
-                .await
-                .unwrap()
-                .state,
-            direct_engine
-                .get_state_by_run_id(&direct_run_id)
-                .await
-                .unwrap()
-                .state
+            project_adapter_state(&adapter_data_dir, &adapter_run_id).state,
+            project_adapter_state(&direct_data_dir, &direct_run_id).state
         );
         assert_eq!(
             adapter_engine.list_completed_runs().await[0].status,
@@ -1197,8 +1169,8 @@ mod tests {
             crate::adaptor::gateway::workflow::pending_command_dispatcher::PendingCommandDispatchOutcome::Accepted
         );
 
-        let ui_state = ui_engine.get_state_by_run_id(&ui_run_id).await.unwrap();
-        let cli_state = cli_engine.get_state_by_run_id(&cli_run_id).await.unwrap();
+        let ui_state = project_adapter_state(&ui_data_dir, &ui_run_id);
+        let cli_state = project_adapter_state(&cli_data_dir, &cli_run_id);
         assert_eq!(ui_state.state, cli_state.state);
         assert_eq!(
             adapter_run_status(&ui_engine, &ui_run_id).await,
@@ -1277,8 +1249,8 @@ mod tests {
             crate::adaptor::gateway::workflow::pending_command_dispatcher::PendingCommandDispatchOutcome::Accepted
         );
 
-        let ui_state = ui_engine.get_state_by_run_id(&ui_run_id).await.unwrap();
-        let cli_state = cli_engine.get_state_by_run_id(&cli_run_id).await.unwrap();
+        let ui_state = project_adapter_state(&ui_data_dir, &ui_run_id);
+        let cli_state = project_adapter_state(&cli_data_dir, &cli_run_id);
         assert_eq!(ui_state.state, cli_state.state);
         assert_eq!(
             adapter_run_status(&ui_engine, &ui_run_id).await,
@@ -1350,8 +1322,8 @@ mod tests {
             crate::adaptor::gateway::workflow::pending_command_dispatcher::PendingCommandDispatchOutcome::Accepted
         );
 
-        let ui_state = ui_engine.get_state_by_run_id(&ui_run_id).await.unwrap();
-        let cli_state = cli_engine.get_state_by_run_id(&cli_run_id).await.unwrap();
+        let ui_state = project_adapter_state(&ui_data_dir, &ui_run_id);
+        let cli_state = project_adapter_state(&cli_data_dir, &cli_run_id);
         assert_eq!(ui_state.state, WorkflowExecutionState::Aborted);
         assert_eq!(cli_state.state, WorkflowExecutionState::Aborted);
         assert_eq!(

--- a/src-tauri/src/adaptor/gateway/workflow/event.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event.rs
@@ -24,6 +24,50 @@ impl TokenUsage {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RunAbortedStepSnapshot {
+    pub step_name: String,
+    pub completed_at: f64,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub result: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub token_usage: Option<TokenUsage>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub structured_output: Option<serde_json::Value>,
+    #[serde(default)]
+    pub run_index: u32,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub child_outputs: Option<Vec<RunAbortedChildOutputSnapshot>>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunAbortedChildOutcome {
+    Completed,
+    Aborted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RunAbortedChildOutputSnapshot {
+    pub step_name: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub result: Option<String>,
+    pub run_index: u32,
+    pub completed_at: f64,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub structured_output: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub output_contract: Option<String>,
+    #[serde(alias = "state")]
+    pub outcome: RunAbortedChildOutcome,
+}
+
 /// workflow engine が発行する append-only な事実列の型。
 ///
 /// `run_id` を主語とし、過去事実は書き換えない（撤回も追加 event として表現する）。
@@ -109,6 +153,8 @@ pub enum WorkflowEvent {
     RunAborted {
         run_id: String,
         workflow_name: String,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        aborted_step: Option<RunAbortedStepSnapshot>,
         timestamp: f64,
     },
     /// collect step の reduce 結果。
@@ -403,6 +449,52 @@ mod tests {
         assert!(matches!(back, WorkflowEvent::RunStarted { .. }));
     }
 
+    #[test]
+    fn run_aborted_step_snapshot_serializes_without_step_history_display_state() {
+        let event = WorkflowEvent::RunAborted {
+            run_id: "00000000-0000-0000-0000-000000000801".to_string(),
+            workflow_name: "wf".to_string(),
+            aborted_step: Some(RunAbortedStepSnapshot {
+                step_name: "review".to_string(),
+                completed_at: 2.0,
+                result: None,
+                session_id: Some("session-review".to_string()),
+                token_usage: None,
+                structured_output: None,
+                run_index: 1,
+                child_outputs: Some(vec![RunAbortedChildOutputSnapshot {
+                    step_name: "child-review".to_string(),
+                    session_id: Some("session-child-review".to_string()),
+                    result: None,
+                    run_index: 1,
+                    completed_at: 2.0,
+                    structured_output: None,
+                    output_contract: None,
+                    outcome: RunAbortedChildOutcome::Aborted,
+                }]),
+            }),
+            timestamp: 2.0,
+        };
+
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["event"].as_str(), Some("run_aborted"));
+        let aborted_step = value
+            .get("aborted_step")
+            .expect("aborted_step snapshot must be present");
+        assert_eq!(aborted_step["stepName"].as_str(), Some("review"));
+        assert_eq!(aborted_step["sessionId"].as_str(), Some("session-review"));
+        assert!(
+            aborted_step.get("state").is_none(),
+            "RunAborted stores an event snapshot, not StepHistoryEntry"
+        );
+        let child = &aborted_step["childOutputs"][0];
+        assert!(
+            child.get("state").is_none(),
+            "RunAborted child snapshot stores an event fact, not read-model state"
+        );
+        assert_eq!(child["outcome"].as_str(), Some("aborted"));
+    }
+
     /// approval 判断結果は典型的な NDJSON 観測者から snake_case で読める。
     #[test]
     fn approval_resolved_decision_serde_round_trips() {
@@ -578,6 +670,7 @@ mod tests {
             WorkflowEvent::RunAborted {
                 run_id: rid.to_string(),
                 workflow_name: "w".to_string(),
+                aborted_step: None,
                 timestamp: 0.0,
             },
         ];

--- a/src-tauri/src/adaptor/gateway/workflow/event_log_writer.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event_log_writer.rs
@@ -30,6 +30,7 @@ mod tests {
         let event = WorkflowEvent::RunAborted {
             run_id: run_id.to_string(),
             workflow_name: "wf".to_string(),
+            aborted_step: None,
             timestamp: 42.0,
         };
 
@@ -43,6 +44,7 @@ mod tests {
                 run_id: restored_run_id,
                 workflow_name,
                 timestamp,
+                ..
             } if restored_run_id == run_id
                 && workflow_name == "wf"
                 && (*timestamp - 42.0).abs() < f64::EPSILON

--- a/src-tauri/src/adaptor/gateway/workflow/event_projection.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event_projection.rs
@@ -13,11 +13,14 @@ use crate::adaptor::gateway::workflow::event::{
     ApprovalDecisionRecord, CliMutationRejectionReason, CliMutationRequestRecord,
     CollectedOutputEntry,
 };
-use crate::adaptor::gateway::workflow::event::{TokenUsage as EventTokenUsage, WorkflowEvent};
+use crate::adaptor::gateway::workflow::event::{
+    RunAbortedChildOutcome, RunAbortedChildOutputSnapshot, RunAbortedStepSnapshot,
+    TokenUsage as EventTokenUsage, WorkflowEvent,
+};
 use crate::adaptor::gateway::workflow::schema::{NodeType, Workflow};
 use crate::adaptor::gateway::workflow::state::{
-    ParallelStepState, StepHistoryEntry, StepOutput, TokenUsage, WorkflowExecutionState,
-    WorkflowState,
+    ChildOutputSnapshot, ParallelStepState, StepHistoryEntry, StepOutput, TokenUsage,
+    WorkflowExecutionState, WorkflowState,
 };
 use crate::domain::workflow::services::{
     contract as workflow_contract, parallel as workflow_parallel,
@@ -34,6 +37,46 @@ const SECONDS_TO_MS: f64 = 1000.0;
 #[inline]
 fn seconds_to_ms(value: f64) -> f64 {
     value * SECONDS_TO_MS
+}
+
+fn step_history_entry_from_run_aborted_snapshot(
+    snapshot: &RunAbortedStepSnapshot,
+) -> StepHistoryEntry {
+    StepHistoryEntry {
+        step_name: snapshot.step_name.clone(),
+        completed_at: snapshot.completed_at,
+        result: snapshot.result.clone(),
+        session_id: snapshot.session_id.clone(),
+        token_usage: snapshot.token_usage.clone(),
+        structured_output: snapshot.structured_output.clone(),
+        run_index: snapshot.run_index,
+        child_outputs: snapshot.child_outputs.as_ref().map(|children| {
+            children
+                .iter()
+                .map(child_output_from_run_aborted_snapshot)
+                .collect()
+        }),
+        state: STEP_STATE_ABORTED.to_string(),
+    }
+}
+
+fn child_output_from_run_aborted_snapshot(
+    snapshot: &RunAbortedChildOutputSnapshot,
+) -> ChildOutputSnapshot {
+    ChildOutputSnapshot {
+        step_name: snapshot.step_name.clone(),
+        session_id: snapshot.session_id.clone(),
+        result: snapshot.result.clone(),
+        run_index: snapshot.run_index,
+        completed_at: snapshot.completed_at,
+        structured_output: snapshot.structured_output.clone(),
+        output_contract: snapshot.output_contract.clone(),
+        state: match snapshot.outcome {
+            RunAbortedChildOutcome::Completed => STEP_STATE_COMPLETED,
+            RunAbortedChildOutcome::Aborted => STEP_STATE_ABORTED,
+        }
+        .to_string(),
+    }
 }
 
 /// spec issues-1023: event 列から (step_name, run_index) ごとの started/completed/duration を
@@ -450,6 +493,7 @@ impl From<WorkflowEvent> for WorkflowEventView {
                 run_id,
                 workflow_name,
                 timestamp,
+                ..
             } => WorkflowEventView::RunAborted {
                 run_id,
                 workflow_name,
@@ -1075,81 +1119,99 @@ pub(crate) fn reconstruct_state_from_events(
                 active_parallel_steps.clear();
                 updated_at = *timestamp;
             }
-            WorkflowEvent::RunAborted { timestamp, .. } => {
+            WorkflowEvent::RunAborted {
+                aborted_step,
+                timestamp,
+                ..
+            } => {
                 exec_state = WorkflowExecutionState::Aborted;
 
-                // spec issues-1023: 中断時に走っていた current step / parallel
-                // children を `step_history` に "aborted" 状態として記録する。
-                // session log への到達経路（child の session_id）を残すために
-                // active_parallel_steps の snapshot を child_outputs に転写する。
-                // 通常 step 経路では projection 上 `current_session_id` は
-                // 追えないため、entry の session_id は None になる（ライブ
-                // engine 経路では engine 側で session_id を入れる）。
-                // spec issues-1023: 同名 step の retry を中断したケース（例:
-                // `plan#1` 完了 → `plan#2` 開始 → RunAborted）でも aborted entry を
-                // 残せるよう、step_name に加えて run_index も比較する。step_name のみ
-                // 比較すると `plan#1` の完了 entry に当たって `plan#2` の aborted
-                // entry の追加がスキップされ、session log への到達経路が失われる。
-                let current_run_index = step_execution_counts.get(&current_step_name).copied();
-                let already_in_history = step_history.last().is_some_and(|e| {
-                    e.step_name == current_step_name && Some(e.run_index) == current_run_index
-                });
-                let current_started = current_run_index.is_some();
+                if let Some(aborted_step) = aborted_step {
+                    let aborted_step = step_history_entry_from_run_aborted_snapshot(aborted_step);
+                    let already_in_history = step_history.last().is_some_and(|entry| {
+                        entry.step_name == aborted_step.step_name
+                            && entry.run_index == aborted_step.run_index
+                            && entry.state == aborted_step.state
+                    });
+                    if !already_in_history {
+                        step_history.push(aborted_step);
+                    }
+                } else {
+                    // spec issues-1023: 中断時に走っていた current step / parallel
+                    // children を `step_history` に "aborted" 状態として記録する。
+                    // session log への到達経路（child の session_id）を残すために
+                    // active_parallel_steps の snapshot を child_outputs に転写する。
+                    // 旧 RunAborted event は通常 step の current_session_id を持たないため、
+                    // 通常 step entry の session_id は None になる。
+                    // spec issues-1023: 同名 step の retry を中断したケース（例:
+                    // `plan#1` 完了 → `plan#2` 開始 → RunAborted）でも aborted entry を
+                    // 残せるよう、step_name に加えて run_index も比較する。step_name のみ
+                    // 比較すると `plan#1` の完了 entry に当たって `plan#2` の aborted
+                    // entry の追加がスキップされ、session log への到達経路が失われる。
+                    let current_run_index = step_execution_counts.get(&current_step_name).copied();
+                    let already_in_history = step_history.last().is_some_and(|e| {
+                        e.step_name == current_step_name && Some(e.run_index) == current_run_index
+                    });
+                    let current_started = current_run_index.is_some();
 
-                if !active_parallel_steps.is_empty() {
-                    let parent_run_index = step_execution_counts
-                        .get(&current_step_name)
-                        .copied()
-                        .unwrap_or(0);
-                    let child_snapshots: Vec<
-                        crate::adaptor::gateway::workflow::state::ChildOutputSnapshot,
-                    > = active_parallel_steps
-                        .iter()
-                        .map(|child| {
-                            let snapshot_state = if child.state == STEP_STATE_COMPLETED {
-                                STEP_STATE_COMPLETED
-                            } else {
-                                STEP_STATE_ABORTED
-                            };
-                            crate::adaptor::gateway::workflow::state::ChildOutputSnapshot {
-                                step_name: child.step_name.clone(),
-                                session_id: child.session_id.clone(),
-                                result: child.result.clone(),
-                                run_index: child.run_index,
-                                completed_at: child.completed_at.unwrap_or(*timestamp),
-                                structured_output: child.structured_output.clone(),
-                                output_contract: child.output_contract.clone(),
-                                state: snapshot_state.to_string(),
-                            }
-                        })
-                        .collect();
-                    step_history.push(StepHistoryEntry {
-                        step_name: current_step_name.clone(),
-                        completed_at: *timestamp,
-                        result: None,
-                        session_id: None,
-                        token_usage: None,
-                        structured_output: None,
-                        run_index: parent_run_index,
-                        child_outputs: Some(child_snapshots),
-                        state: STEP_STATE_ABORTED.to_string(),
-                    });
-                } else if current_started && !already_in_history && !current_step_name.is_empty() {
-                    let run_index = step_execution_counts
-                        .get(&current_step_name)
-                        .copied()
-                        .unwrap_or(0);
-                    step_history.push(StepHistoryEntry {
-                        step_name: current_step_name.clone(),
-                        completed_at: *timestamp,
-                        result: None,
-                        session_id: None,
-                        token_usage: None,
-                        structured_output: None,
-                        run_index,
-                        child_outputs: None,
-                        state: STEP_STATE_ABORTED.to_string(),
-                    });
+                    if !active_parallel_steps.is_empty() {
+                        let parent_run_index = step_execution_counts
+                            .get(&current_step_name)
+                            .copied()
+                            .unwrap_or(0);
+                        let child_snapshots: Vec<
+                            crate::adaptor::gateway::workflow::state::ChildOutputSnapshot,
+                        > = active_parallel_steps
+                            .iter()
+                            .map(|child| {
+                                let snapshot_state = if child.state == STEP_STATE_COMPLETED {
+                                    STEP_STATE_COMPLETED
+                                } else {
+                                    STEP_STATE_ABORTED
+                                };
+                                crate::adaptor::gateway::workflow::state::ChildOutputSnapshot {
+                                    step_name: child.step_name.clone(),
+                                    session_id: child.session_id.clone(),
+                                    result: child.result.clone(),
+                                    run_index: child.run_index,
+                                    completed_at: child.completed_at.unwrap_or(*timestamp),
+                                    structured_output: child.structured_output.clone(),
+                                    output_contract: child.output_contract.clone(),
+                                    state: snapshot_state.to_string(),
+                                }
+                            })
+                            .collect();
+                        step_history.push(StepHistoryEntry {
+                            step_name: current_step_name.clone(),
+                            completed_at: *timestamp,
+                            result: None,
+                            session_id: None,
+                            token_usage: None,
+                            structured_output: None,
+                            run_index: parent_run_index,
+                            child_outputs: Some(child_snapshots),
+                            state: STEP_STATE_ABORTED.to_string(),
+                        });
+                    } else if current_started
+                        && !already_in_history
+                        && !current_step_name.is_empty()
+                    {
+                        let run_index = step_execution_counts
+                            .get(&current_step_name)
+                            .copied()
+                            .unwrap_or(0);
+                        step_history.push(StepHistoryEntry {
+                            step_name: current_step_name.clone(),
+                            completed_at: *timestamp,
+                            result: None,
+                            session_id: None,
+                            token_usage: None,
+                            structured_output: None,
+                            run_index,
+                            child_outputs: None,
+                            state: STEP_STATE_ABORTED.to_string(),
+                        });
+                    }
                 }
 
                 active_parallel_steps.clear();
@@ -1566,6 +1628,7 @@ mod tests {
             WorkflowEvent::RunAborted {
                 run_id: "exec-pa".to_string(),
                 workflow_name: "wf".to_string(),
+                aborted_step: None,
                 timestamp: 2.0,
             },
         ];
@@ -1616,6 +1679,7 @@ mod tests {
             WorkflowEvent::RunAborted {
                 run_id: "exec-abort-current".to_string(),
                 workflow_name: "wf".to_string(),
+                aborted_step: None,
                 timestamp: 2.0,
             },
         ];
@@ -1630,6 +1694,81 @@ mod tests {
         assert_eq!(entry.session_id, None);
         assert_eq!(entry.run_index, 1);
         assert!(entry.child_outputs.is_none());
+    }
+
+    /// issues-1196: `RunAborted.aborted_step` は event 専用 snapshot として永続化し、
+    /// projection 境界で `StepHistoryEntry` に変換する。
+    #[test]
+    fn projection_uses_run_aborted_step_snapshot_when_present() {
+        let snapshot = workflow_with_nodes("wf", vec!["plan"]);
+        let events = vec![
+            run_started("exec-abort-snapshot", snapshot),
+            WorkflowEvent::NodeStarted {
+                run_id: "exec-abort-snapshot".to_string(),
+                workflow_name: "wf".to_string(),
+                node_name: "plan".to_string(),
+                execution_count: 1,
+                timestamp: 1.0,
+            },
+            WorkflowEvent::RunAborted {
+                run_id: "exec-abort-snapshot".to_string(),
+                workflow_name: "wf".to_string(),
+                aborted_step: Some(RunAbortedStepSnapshot {
+                    step_name: "plan".to_string(),
+                    completed_at: 2.0,
+                    result: None,
+                    session_id: Some("session-plan".to_string()),
+                    token_usage: None,
+                    structured_output: None,
+                    run_index: 1,
+                    child_outputs: Some(vec![
+                        RunAbortedChildOutputSnapshot {
+                            step_name: "child-completed".to_string(),
+                            session_id: Some("session-child-completed".to_string()),
+                            result: Some("ok".to_string()),
+                            run_index: 1,
+                            completed_at: 1.5,
+                            structured_output: None,
+                            output_contract: None,
+                            outcome: RunAbortedChildOutcome::Completed,
+                        },
+                        RunAbortedChildOutputSnapshot {
+                            step_name: "child-aborted".to_string(),
+                            session_id: Some("session-child-aborted".to_string()),
+                            result: None,
+                            run_index: 1,
+                            completed_at: 2.0,
+                            structured_output: None,
+                            output_contract: None,
+                            outcome: RunAbortedChildOutcome::Aborted,
+                        },
+                    ]),
+                }),
+                timestamp: 2.0,
+            },
+        ];
+
+        let state = reconstruct_state_from_events("exec-abort-snapshot", &events)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(state.state, WorkflowExecutionState::Aborted);
+        assert_eq!(state.step_history.len(), 1);
+        let entry = &state.step_history[0];
+        assert_eq!(entry.step_name, "plan");
+        assert_eq!(entry.session_id.as_deref(), Some("session-plan"));
+        assert_eq!(entry.state.as_str(), STEP_STATE_ABORTED);
+        let children = entry.child_outputs.as_ref().expect("children restored");
+        let completed_child = children
+            .iter()
+            .find(|child| child.step_name == "child-completed")
+            .expect("completed child restored");
+        assert_eq!(completed_child.state.as_str(), STEP_STATE_COMPLETED);
+        let aborted_child = children
+            .iter()
+            .find(|child| child.step_name == "child-aborted")
+            .expect("aborted child restored");
+        assert_eq!(aborted_child.state.as_str(), STEP_STATE_ABORTED);
     }
 
     /// spec issues-1023: parallel ブロック実行中に一部 child が完了し、残りが
@@ -1687,6 +1826,7 @@ mod tests {
             WorkflowEvent::RunAborted {
                 run_id: "exec-mixed".to_string(),
                 workflow_name: "wf".to_string(),
+                aborted_step: None,
                 timestamp: 2.0,
             },
         ];

--- a/src-tauri/src/adaptor/gateway/workflow/log.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/log.rs
@@ -424,6 +424,7 @@ mod tests {
             WorkflowEvent::RunAborted {
                 run_id: run_id.to_string(),
                 workflow_name: "wf".to_string(),
+                aborted_step: None,
                 timestamp: 1000.0,
             },
         ];
@@ -462,6 +463,7 @@ mod tests {
         log.append(&WorkflowEvent::RunAborted {
             run_id: run_id.to_string(),
             workflow_name: "wf".to_string(),
+            aborted_step: None,
             timestamp: 2.0,
         })
         .unwrap();
@@ -496,6 +498,7 @@ mod tests {
             WorkflowEvent::RunAborted {
                 run_id: "00000000-0000-0000-0000-000000000904".to_string(),
                 workflow_name: "wf".to_string(),
+                aborted_step: None,
                 timestamp: 2.0,
             },
         ];
@@ -708,6 +711,7 @@ mod tests {
             WorkflowEvent::RunAborted {
                 run_id: "00000000-0000-0000-0000-000000000911".to_string(),
                 workflow_name: "wf".to_string(),
+                aborted_step: None,
                 timestamp: 7.0,
             },
             WorkflowEvent::OutputCollected {

--- a/src-tauri/src/adaptor/gateway/workflow/mapper.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/mapper.rs
@@ -341,6 +341,7 @@ pub(crate) fn domain_event_draft_to_legacy(
             Ok(legacy_event::WorkflowEvent::RunAborted {
                 run_id: event.run_id.clone(),
                 workflow_name: payload.workflow_name,
+                aborted_step: None,
                 timestamp: event.timestamp,
             })
         }

--- a/src-tauri/src/adaptor/gateway/workflow/orphan_recovery.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/orphan_recovery.rs
@@ -20,6 +20,7 @@ pub(crate) fn orphan_run_recovery_items(
             let event = WorkflowEvent::RunAborted {
                 run_id: run_id.clone(),
                 workflow_name: run.workflow_name.clone(),
+                aborted_step: None,
                 timestamp,
             };
             OrphanRunRecoveryItem {
@@ -68,6 +69,7 @@ mod tests {
                 run_id,
                 workflow_name,
                 timestamp,
+                ..
             } if run_id == "run-1"
                 && workflow_name == "wf-1"
                 && (*timestamp - 42.0).abs() < f64::EPSILON
@@ -78,6 +80,7 @@ mod tests {
                 run_id,
                 workflow_name,
                 timestamp,
+                ..
             } if run_id == "run-2"
                 && workflow_name == "wf-2"
                 && (*timestamp - 42.0).abs() < f64::EPSILON

--- a/src-tauri/src/adaptor/gateway/workflow/run.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/run.rs
@@ -451,6 +451,11 @@ impl RunStore {
         self.data_dir.lock().await.clone()
     }
 
+    #[cfg(test)]
+    pub(crate) async fn data_dir_for_test(&self) -> Option<PathBuf> {
+        self.data_dir().await
+    }
+
     async fn persistence_dir(&self) -> Result<Option<PathBuf>, RunStoreError> {
         match self.data_dir().await {
             Some(dir) => Ok(Some(dir)),

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
@@ -174,6 +174,8 @@ pub struct WorkflowRuntimeService {
     worktree_resolver: Arc<dyn ManagedWorktreeResolver>,
     #[cfg(test)]
     fail_next_required_event_append: AtomicBool,
+    #[cfg(test)]
+    abort_after_lookup_gate: Mutex<Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>>,
 }
 
 struct ParallelChildStartedLogObserver<'a, R: tauri::Runtime> {
@@ -222,6 +224,8 @@ impl WorkflowRuntimeService {
             worktree_resolver,
             #[cfg(test)]
             fail_next_required_event_append: AtomicBool::new(false),
+            #[cfg(test)]
+            abort_after_lookup_gate: Mutex::new(None),
         }
     }
 
@@ -272,6 +276,18 @@ impl WorkflowRuntimeService {
             })
             .await
             .unwrap();
+        if let Some(data_dir) = self.run_store.data_dir_for_test().await {
+            WorkflowEventLog::new(&data_dir)
+                .append(&WorkflowEvent::RunStarted {
+                    run_id: run_id.clone(),
+                    workflow_name: workflow.name.clone(),
+                    workflow_file_stem: workflow.name.clone(),
+                    worktree_path: worktree_path.clone(),
+                    workflow_definition: workflow.clone(),
+                    timestamp: now,
+                })
+                .unwrap();
+        }
         self.executions.lock().await.insert(
             run_id.clone(),
             WorkflowExecution {
@@ -302,6 +318,34 @@ impl WorkflowRuntimeService {
     pub(crate) fn fail_next_required_event_append_for_test(&self) {
         self.fail_next_required_event_append
             .store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn pause_abort_after_lookup_for_test(
+        &self,
+        lookup_completed: Arc<tokio::sync::Notify>,
+        continue_precommit: Arc<tokio::sync::Notify>,
+    ) {
+        *self.abort_after_lookup_gate.lock().await = Some((lookup_completed, continue_precommit));
+    }
+
+    #[cfg(test)]
+    async fn wait_abort_after_lookup_for_test(&self) {
+        let gate = self.abort_after_lookup_gate.lock().await.take();
+        if let Some((lookup_completed, continue_precommit)) = gate {
+            lookup_completed.notify_one();
+            continue_precommit.notified().await;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn contains_execution_for_test(&self, run_id: &str) -> bool {
+        self.executions.lock().await.contains_key(run_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn executions_len_for_test(&self) -> usize {
+        self.executions.lock().await.len()
     }
 
     /// テスト専用: 指定 run の `current_step_index` を移動させて stale 状態を作る。
@@ -1812,16 +1856,23 @@ impl WorkflowRuntimeService {
                 parallel_session_ids,
             } => (current_step_session_id, parallel_session_ids),
         };
+        #[cfg(test)]
+        self.wait_abort_after_lookup_for_test().await;
 
         // 2. [04] pre-commit (rollback 可能): mutation 直前 snapshot を取得し、
         //    state を Aborted に遷移させる。競合で terminal 化していた場合は
         //    AlreadyTerminal で返す。
         let timestamp = current_timestamp();
         let run_store_snapshot_before = self.run_store.active_run_snapshot(run_id).await;
-        let (snapshot_before, snapshot_state, workflow_name_for_event) = {
+        let (snapshot_before, snapshot_state, workflow_name_for_event, aborted_step_for_event) = {
             let mut execs = self.executions.lock().await;
             let Some(exec) = execs.get_mut(run_id) else {
-                return Ok(AbortOutcome::NotFound);
+                drop(execs);
+                return Ok(if self.has_terminal_run_record(run_id).await {
+                    AbortOutcome::AlreadyTerminal
+                } else {
+                    AbortOutcome::NotFound
+                });
             };
             if !exec.is_active() {
                 return Ok(AbortOutcome::AlreadyTerminal);
@@ -1845,6 +1896,7 @@ impl WorkflowRuntimeService {
             }
             let snapshot_before = exec.clone();
             let workflow_name = exec.workflow.name.clone();
+            let mut aborted_step_for_event = None;
 
             // spec issues-1023: state を Aborted にする前に、中断時の current step /
             // parallel children を `step_history` に "aborted" entry として記録する。
@@ -1853,17 +1905,31 @@ impl WorkflowRuntimeService {
             // 明示クリアして `to_workflow_state()` 経由の二重表示を防ぐ。
             if exec.parallel_run.is_some() {
                 if let Some(entry) = exec.make_aborted_parallel_history_entry(timestamp) {
+                    aborted_step_for_event = Some(
+                        workflow_runtime_events::run_aborted_step_snapshot_from_history_entry(
+                            &entry,
+                        ),
+                    );
                     exec.step_history.push(entry);
                 }
                 exec.parallel_run = None;
             } else {
                 let current_step_name = exec.workflow.nodes[exec.current_step_index].name.clone();
-                let already_in_history = exec
-                    .step_history
-                    .last()
-                    .is_some_and(|e| e.step_name == current_step_name);
+                let current_run_index = exec
+                    .step_execution_counts
+                    .get(&current_step_name)
+                    .copied()
+                    .unwrap_or(1);
+                let already_in_history = exec.step_history.last().is_some_and(|e| {
+                    e.step_name == current_step_name && e.run_index == current_run_index
+                });
                 if !already_in_history {
                     let entry = exec.make_aborted_history_entry(timestamp);
+                    aborted_step_for_event = Some(
+                        workflow_runtime_events::run_aborted_step_snapshot_from_history_entry(
+                            &entry,
+                        ),
+                    );
                     exec.step_history.push(entry);
                 }
             }
@@ -1871,7 +1937,12 @@ impl WorkflowRuntimeService {
             exec.state = WorkflowExecutionState::Aborted;
             exec.updated_at = timestamp;
             let snapshot_state = exec.to_workflow_state();
-            (snapshot_before, snapshot_state, workflow_name)
+            (
+                snapshot_before,
+                snapshot_state,
+                workflow_name,
+                aborted_step_for_event,
+            )
         };
 
         // 3. [04] commit point: RunAborted を必須 append。失敗時は
@@ -1881,6 +1952,7 @@ impl WorkflowRuntimeService {
         let aborted_event = WorkflowEvent::RunAborted {
             run_id: run_id.to_string(),
             workflow_name: workflow_name_for_event.clone(),
+            aborted_step: aborted_step_for_event,
             timestamp,
         };
         let mut required_events = vec![aborted_event];
@@ -1964,28 +2036,42 @@ impl WorkflowRuntimeService {
         .await;
         self.cleanup_session_workflow_refs_by_run_id(run_id).await;
         workflow_runtime_session::broadcast_state(app, &worktree_path, snapshot).await;
+        self.release_terminal_execution(run_id).await;
     }
 
     async fn abort_target_lookup(&self, run_id: &str) -> AbortTargetLookup {
-        let execs = self.executions.lock().await;
-        let Some(exec) = execs.get(run_id) else {
-            return AbortTargetLookup::NotFound;
-        };
-        if !exec.is_active() {
-            return AbortTargetLookup::AlreadyTerminal;
+        {
+            let execs = self.executions.lock().await;
+            if let Some(exec) = execs.get(run_id) {
+                if !exec.is_active() {
+                    return AbortTargetLookup::AlreadyTerminal;
+                }
+                let current_step_session_id = exec.current_session_id.clone();
+                let parallel_session_ids = exec.parallel_run.as_ref().map(|pr| {
+                    pr.children
+                        .iter()
+                        .filter(|c| c.state == ParallelChildState::Running)
+                        .map(|c| c.session_id.clone())
+                        .collect::<Vec<_>>()
+                });
+                return AbortTargetLookup::Active {
+                    current_step_session_id,
+                    parallel_session_ids,
+                };
+            }
         }
-        let current_step_session_id = exec.current_session_id.clone();
-        let parallel_session_ids = exec.parallel_run.as_ref().map(|pr| {
-            pr.children
-                .iter()
-                .filter(|c| c.state == ParallelChildState::Running)
-                .map(|c| c.session_id.clone())
-                .collect::<Vec<_>>()
-        });
-        AbortTargetLookup::Active {
-            current_step_session_id,
-            parallel_session_ids,
+        if self.has_terminal_run_record(run_id).await {
+            AbortTargetLookup::AlreadyTerminal
+        } else {
+            AbortTargetLookup::NotFound
         }
+    }
+
+    async fn has_terminal_run_record(&self, run_id: &str) -> bool {
+        self.run_store
+            .get_run_record(run_id)
+            .await
+            .is_some_and(|run| run.status.is_terminal())
     }
 
     /// 並列子ステップの完了を処理する。
@@ -2177,6 +2263,7 @@ impl WorkflowRuntimeService {
                     .await;
                 self.cleanup_session_workflow_refs_by_run_id(&snapshot.execution_id)
                     .await;
+                self.release_terminal_execution(run_id).await;
                 return Ok(());
             }
 
@@ -2327,7 +2414,14 @@ impl WorkflowRuntimeService {
     /// `run_id` から `WorkflowState` を取得する。
     pub async fn get_state_by_run_id(&self, run_id: &str) -> Option<WorkflowState> {
         let execs = self.executions.lock().await;
-        execs.get(run_id).map(|e| e.to_workflow_state())
+        execs.get(run_id).map(|exec| exec.to_workflow_state())
+    }
+
+    async fn release_terminal_execution(&self, run_id: &str) {
+        let mut execs = self.executions.lock().await;
+        if execs.get(run_id).is_some_and(|exec| exec.is_terminal()) {
+            execs.remove(run_id);
+        }
     }
 
     /// 起動環境別の `releash` alias 名を返す（spec issues-1054）。
@@ -2739,6 +2833,7 @@ impl WorkflowRuntimeService {
             .await;
             self.cleanup_session_workflow_refs_by_run_id(&run_id).await;
             workflow_runtime_session::broadcast_state(app, &worktree_path, snapshot.clone()).await;
+            self.release_terminal_execution(&run_id).await;
             return Ok(());
         }
 
@@ -2776,6 +2871,9 @@ impl WorkflowRuntimeService {
             self.cleanup_session_workflow_refs_by_run_id(&run_id).await;
         }
         workflow_runtime_session::broadcast_state(app, &worktree_path, snapshot.clone()).await;
+        if is_terminal {
+            self.release_terminal_execution(&run_id).await;
+        }
         Ok(())
     }
 
@@ -3327,6 +3425,9 @@ impl WorkflowRuntimeService {
             self.cleanup_session_workflow_refs_by_run_id(&run_id).await;
         }
         workflow_runtime_session::broadcast_state(app, worktree_path, snapshot.clone()).await;
+        if is_terminal {
+            self.release_terminal_execution(&run_id).await;
+        }
     }
 
     /// 既存呼び出し元（on_turn_complete 等）から使う一括 helper。pre-commit と post-commit

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -6645,17 +6645,11 @@ mod dispatch_boundary_tests {
             .await
             .unwrap();
 
-        // (1) engine.executions の state は Failed に遷移している。
-        {
-            let execs = engine.executions.lock().await;
-            let exec = execs
-                .get(&run_id)
-                .expect("execution must remain after Failed");
-            assert!(matches!(
-                exec.state,
-                WorkflowExecutionState::Failed { ref reason } if reason == "node failure"
-            ));
-        }
+        // (1) terminal 化した execution は runtime map から即時解放される。
+        assert!(
+            !engine.contains_execution_for_test(&run_id).await,
+            "terminal execution must be released after Failed"
+        );
 
         // (2) RunStore の status も Failed terminal に同期される。
         let run = engine
@@ -6685,6 +6679,128 @@ mod dispatch_boundary_tests {
         assert!(
             run_failed.is_some(),
             "RunFailed event must follow NodeFailed; got: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn parallel_child_failure_releases_terminal_execution_after_broadcast() {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps();
+
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/parallel-child-failure";
+        let failed_child_session_id = "parallel-child-failed-session";
+        let interrupted_child_session_id = "parallel-child-interrupted-session";
+        let workflow = Workflow {
+            variables: Default::default(),
+            name: "parallel-failure-wf".to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            nodes: vec![NodeDefinition {
+                name: "parallel-review".to_string(),
+                node_type: NodeType::Parallel,
+                parallel_children: Some(vec![
+                    make_parallel_step("review-a"),
+                    make_parallel_step("review-b"),
+                ]),
+                ..NodeDefinition::default()
+            }],
+        };
+        let mut exec =
+            make_waiting_approval_execution_with_workflow(&run_id, worktree_path, workflow);
+        exec.state = WorkflowExecutionState::Running;
+        exec.current_step_index = 0;
+        exec.current_session_id = None;
+        exec.step_execution_counts = HashMap::from([
+            ("parallel-review".to_string(), 1),
+            ("review-a".to_string(), 1),
+            ("review-b".to_string(), 1),
+        ]);
+        exec.parallel_run = Some(ParallelRunState {
+            parent_step_name: "parallel-review".to_string(),
+            aggregate: None,
+            children: vec![
+                ParallelChildRun {
+                    step_name: "review-a".to_string(),
+                    session_id: failed_child_session_id.to_string(),
+                    state: ParallelChildState::Running,
+                    result: None,
+                    structured_output: None,
+                    output_contract: None,
+                    token_usage: TokenUsage::default(),
+                    run_index: 1,
+                },
+                ParallelChildRun {
+                    step_name: "review-b".to_string(),
+                    session_id: interrupted_child_session_id.to_string(),
+                    state: ParallelChildState::Running,
+                    result: None,
+                    structured_output: None,
+                    output_contract: None,
+                    token_usage: TokenUsage::default(),
+                    run_index: 1,
+                },
+            ],
+        });
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        {
+            let mut refs = engine.session_workflow_refs.lock().await;
+            refs.insert(
+                failed_child_session_id.to_string(),
+                SessionWorkflowRef {
+                    run_id: run_id.clone(),
+                },
+            );
+            refs.insert(
+                interrupted_child_session_id.to_string(),
+                SessionWorkflowRef {
+                    run_id: run_id.clone(),
+                },
+            );
+        }
+
+        engine
+            .on_turn_complete(
+                app.handle(),
+                &session_store,
+                &handles,
+                failed_child_session_id,
+                1,
+                &[],
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !engine.contains_execution_for_test(&run_id).await,
+            "parallel child failure must release the Failed terminal execution"
+        );
+        let stored = engine
+            .run_store
+            .get_run(&run_id)
+            .await
+            .expect("RunStore must keep the terminal run metadata");
+        assert_eq!(stored.status, RunStatus::Failed);
+        assert_eq!(
+            stored.error_reason.as_deref(),
+            Some("Parallel child 'review-a' failed (exit_code: 1)")
+        );
+        let events = WorkflowEventLog::new(&data_dir).read_log(&run_id).unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, WorkflowEvent::RunFailed { .. })),
+            "parallel child failure must append RunFailed; got {events:?}"
+        );
+        let refs = engine.session_workflow_refs.lock().await;
+        assert!(
+            refs.values()
+                .all(|session_ref| session_ref.run_id != run_id),
+            "terminal cleanup must remove all session refs for the failed parallel run"
         );
     }
 
@@ -6895,6 +7011,41 @@ mod dispatch_boundary_tests {
         }
     }
 
+    #[tokio::test]
+    async fn abort_target_lookup_returns_already_terminal_for_released_terminal_run_record() {
+        let engine = WorkflowRuntimeService::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        engine
+            .set_run_store_data_dir(tmp.path().to_path_buf())
+            .await;
+
+        for (terminal_status, error_reason) in [
+            (TerminalRunStatus::Completed, None),
+            (
+                TerminalRunStatus::Failed,
+                Some("failed after release".to_string()),
+            ),
+            (TerminalRunStatus::Aborted, None),
+        ] {
+            let run_id = uuid::Uuid::new_v4().to_string();
+            let exec = make_waiting_approval_execution(&run_id, "/wt/released-terminal");
+            insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+            engine
+                .run_store
+                .complete_run(&run_id, terminal_status, 2000.0, error_reason)
+                .await
+                .unwrap();
+            engine.executions.lock().await.remove(&run_id);
+
+            match engine.abort_target_lookup(&run_id).await {
+                AbortTargetLookup::AlreadyTerminal => {}
+                other => {
+                    panic!("expected AlreadyTerminal for released terminal run, got {other:?}")
+                }
+            }
+        }
+    }
+
     /// Spec [04] Rule: active run に対する `abort_target_lookup` は `Active` を返し、
     /// その後の state 遷移経路（mutation → required append → finalize）に乗る。
     #[tokio::test]
@@ -6915,6 +7066,115 @@ mod dispatch_boundary_tests {
             }
             other => panic!("expected Active for running run, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn release_terminal_execution_removes_terminal_entries_only() {
+        let engine = WorkflowRuntimeService::new_for_test();
+
+        for (label, terminal_state) in [
+            ("completed", WorkflowExecutionState::Completed),
+            (
+                "failed",
+                WorkflowExecutionState::Failed {
+                    reason: "boom".to_string(),
+                },
+            ),
+            ("aborted", WorkflowExecutionState::Aborted),
+        ] {
+            let run_id = uuid::Uuid::new_v4().to_string();
+            let mut exec = make_waiting_approval_execution(&run_id, &format!("/wt/{label}"));
+            exec.state = terminal_state;
+            engine.executions.lock().await.insert(run_id.clone(), exec);
+
+            engine.release_terminal_execution(&run_id).await;
+
+            assert!(
+                !engine.contains_execution_for_test(&run_id).await,
+                "{label} terminal execution must be removed"
+            );
+        }
+
+        let active_run_id = uuid::Uuid::new_v4().to_string();
+        let mut active = make_waiting_approval_execution(&active_run_id, "/wt/active-release");
+        active.state = WorkflowExecutionState::Running;
+        engine
+            .executions
+            .lock()
+            .await
+            .insert(active_run_id.clone(), active);
+
+        engine.release_terminal_execution(&active_run_id).await;
+
+        assert!(
+            engine.contains_execution_for_test(&active_run_id).await,
+            "active execution must not be released"
+        );
+        assert_eq!(engine.executions_len_for_test().await, 1);
+    }
+
+    #[tokio::test]
+    async fn get_state_by_run_id_returns_none_for_released_terminal_state() {
+        let engine = WorkflowRuntimeService::new_for_test();
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/reconstruct-terminal";
+        let exec = make_waiting_approval_execution(&run_id, worktree_path);
+        let workflow = exec.workflow.clone();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let log = WorkflowEventLog::new(&data_dir);
+        log.append(&WorkflowEvent::RunStarted {
+            run_id: run_id.clone(),
+            workflow_name: workflow.name.clone(),
+            workflow_file_stem: "boundary-wf".to_string(),
+            worktree_path: worktree_path.to_string(),
+            workflow_definition: workflow.clone(),
+            timestamp: 1000.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::NodeStarted {
+            run_id: run_id.clone(),
+            workflow_name: workflow.name.clone(),
+            node_name: "review".to_string(),
+            execution_count: 1,
+            timestamp: 1001.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::NodeCompleted {
+            run_id: run_id.clone(),
+            workflow_name: workflow.name.clone(),
+            node_name: "review".to_string(),
+            result: Some("approve".to_string()),
+            session_id: Some("sess-1".to_string()),
+            token_usage: None,
+            structured_output: None,
+            run_index: Some(1),
+            timestamp: 1002.0,
+        })
+        .unwrap();
+        log.append(&WorkflowEvent::RunCompleted {
+            run_id: run_id.clone(),
+            workflow_name: workflow.name.clone(),
+            total_token_usage: TokenUsage::default(),
+            timestamp: 1003.0,
+        })
+        .unwrap();
+
+        engine
+            .run_store
+            .complete_run(&run_id, TerminalRunStatus::Completed, 1003.0, None)
+            .await
+            .unwrap();
+        engine.executions.lock().await.remove(&run_id);
+
+        assert!(
+            engine.get_state_by_run_id(&run_id).await.is_none(),
+            "run_id-only live API must not expose released terminal history"
+        );
     }
 
     /// Spec [04] Rule「権限の無い / 対象不在 / 既決の command は state 変化を起こさない」:
@@ -7015,6 +7275,7 @@ mod dispatch_boundary_tests {
         log.append(&WorkflowEvent::RunAborted {
             run_id: run_id.to_string(),
             workflow_name: "boundary-wf".to_string(),
+            aborted_step: None,
             timestamp: 4321.0,
         })
         .expect("RunAborted は write_log_required 経由で append される");
@@ -7274,52 +7535,150 @@ mod dispatch_boundary_tests {
     async fn dispatch_abort_run_accepts_mutates_state_and_appends_event() {
         let app = make_dispatch_app();
         let engine = WorkflowRuntimeService::new_for_test();
-        let tmp = TempDir::new().unwrap();
-        engine
-            .set_run_store_data_dir(tmp.path().to_path_buf())
-            .await;
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
         let (session_store, handles) = make_dispatch_deps();
         let run_id = uuid::Uuid::new_v4().to_string();
         let worktree_path = "/wt/dispatch-abort";
         let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        let workflow = exec.workflow.clone();
         // spec issues-1023: session log 到達経路の維持を検証するため、
         // current_session_id を入れた状態で abort する。
         exec.current_session_id = Some("aborted-step-session".to_string());
         exec.state = WorkflowExecutionState::Running;
         insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        WorkflowEventLog::new(&data_dir)
+            .append(&WorkflowEvent::RunStarted {
+                run_id: run_id.clone(),
+                workflow_name: workflow.name.clone(),
+                workflow_file_stem: workflow.name.clone(),
+                worktree_path: worktree_path.to_string(),
+                workflow_definition: workflow,
+                timestamp: 1000.0,
+            })
+            .unwrap();
 
         engine
             .abort_workflow_run(app.handle(), &session_store, &handles, &run_id, None)
             .await
             .unwrap();
 
-        let execs = engine.executions.lock().await;
-        let aborted_exec = execs.get(&run_id).unwrap();
-        assert_eq!(aborted_exec.state, WorkflowExecutionState::Aborted);
+        assert!(
+            !engine.contains_execution_for_test(&run_id).await,
+            "terminal execution must be released after Aborted"
+        );
 
-        // spec issues-1023: 中断された current step が `state="aborted"` entry として
-        // step_history に積まれ、session_id が引き継がれていることを検証する。
-        // これにより history タブ経由でも session log に到達できる。
-        let aborted_entries: Vec<&StepHistoryEntry> = aborted_exec
+        let events = read_dispatch_events(&app, &run_id);
+        let aborted_event = events
+            .iter()
+            .find_map(|event| match event {
+                WorkflowEvent::RunAborted { aborted_step, .. } => aborted_step.as_ref(),
+                _ => None,
+            })
+            .expect("RunAborted must persist the aborted step snapshot");
+        assert_eq!(
+            aborted_event.session_id.as_deref(),
+            Some("aborted-step-session"),
+            "RunAborted snapshot must keep the interrupted step session_id"
+        );
+
+        assert!(
+            engine.get_state_by_run_id(&run_id).await.is_none(),
+            "run_id-only live API must not expose released terminal history"
+        );
+        let reconstructed =
+            crate::adaptor::gateway::workflow::event_projection::reconstruct_state_from_events(
+                &run_id, &events,
+            )
+            .unwrap()
+            .expect("released aborted run history must reconstruct from Event Log projection");
+        assert_eq!(reconstructed.state, WorkflowExecutionState::Aborted);
+        let aborted_entries: Vec<&StepHistoryEntry> = reconstructed
             .step_history
             .iter()
-            .filter(|e| e.state == "aborted")
+            .filter(|entry| entry.state == "aborted")
             .collect();
         assert_eq!(
             aborted_entries.len(),
             1,
-            "current step が 1 件 aborted entry として記録される"
+            "released aborted run must reconstruct the aborted current step"
         );
         assert_eq!(
             aborted_entries[0].session_id.as_deref(),
             Some("aborted-step-session"),
-            "session_id が step_history に引き継がれ session log に到達可能"
+            "reconstructed state must preserve the session log reachability"
         );
-        drop(execs);
+    }
 
-        assert!(read_dispatch_events(&app, &run_id)
+    #[tokio::test]
+    async fn dispatch_abort_run_snapshots_current_run_index_for_retried_step() {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/dispatch-abort-retry";
+        let mut exec = make_waiting_approval_execution(&run_id, worktree_path);
+        let workflow = exec.workflow.clone();
+        exec.state = WorkflowExecutionState::Running;
+        exec.current_session_id = Some("session-review-2".to_string());
+        exec.step_execution_counts.insert("review".to_string(), 2);
+        exec.step_history.push(StepHistoryEntry {
+            step_name: "review".to_string(),
+            completed_at: 1001.0,
+            result: Some("retry".to_string()),
+            session_id: Some("session-review-1".to_string()),
+            token_usage: None,
+            structured_output: None,
+            run_index: 1,
+            child_outputs: None,
+            state: crate::adaptor::gateway::workflow::state::default_step_entry_state(),
+        });
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        WorkflowEventLog::new(&data_dir)
+            .append(&WorkflowEvent::RunStarted {
+                run_id: run_id.clone(),
+                workflow_name: workflow.name.clone(),
+                workflow_file_stem: workflow.name.clone(),
+                worktree_path: worktree_path.to_string(),
+                workflow_definition: workflow,
+                timestamp: 1000.0,
+            })
+            .unwrap();
+
+        engine
+            .abort_workflow_run(app.handle(), &session_store, &handles, &run_id, None)
+            .await
+            .unwrap();
+
+        let events = read_dispatch_events(&app, &run_id);
+        let aborted_step = events
             .iter()
-            .any(|event| matches!(event, WorkflowEvent::RunAborted { .. })));
+            .find_map(|event| match event {
+                WorkflowEvent::RunAborted { aborted_step, .. } => aborted_step.as_ref(),
+                _ => None,
+            })
+            .expect("retried current step must be persisted as aborted_step");
+        assert_eq!(aborted_step.step_name, "review");
+        assert_eq!(aborted_step.run_index, 2);
+        assert_eq!(aborted_step.session_id.as_deref(), Some("session-review-2"));
+
+        let reconstructed =
+            crate::adaptor::gateway::workflow::event_projection::reconstruct_state_from_events(
+                &run_id, &events,
+            )
+            .unwrap()
+            .expect("released aborted retry must reconstruct from Event Log projection");
+        let aborted_entry = reconstructed
+            .step_history
+            .iter()
+            .find(|entry| entry.step_name == "review" && entry.run_index == 2)
+            .expect("reconstructed history must contain the retried aborted step");
+        assert_eq!(
+            aborted_entry.session_id.as_deref(),
+            Some("session-review-2")
+        );
     }
 
     /// spec issues-1023: `make_aborted_parallel_history_entry` の単体検証。
@@ -7435,9 +7794,9 @@ mod dispatch_boundary_tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            engine.executions.lock().await.get(&run_id).unwrap().state,
-            WorkflowExecutionState::Aborted
+        assert!(
+            !engine.contains_execution_for_test(&run_id).await,
+            "terminal execution must be released after Aborted"
         );
         let events = read_dispatch_events(&app, &run_id);
         assert_eq!(events.len(), 1);
@@ -7558,6 +7917,106 @@ mod dispatch_boundary_tests {
         );
         drop(execs);
         assert!(read_dispatch_events(&app, &terminal_run_id).is_empty());
+
+        let released_terminal_run_id = uuid::Uuid::new_v4().to_string();
+        let released_terminal =
+            make_waiting_approval_execution(&released_terminal_run_id, "/wt/released-terminal");
+        insert_execution_and_active_run(&engine, released_terminal, TriggerSource::DesktopUi).await;
+        engine
+            .run_store
+            .complete_run(
+                &released_terminal_run_id,
+                TerminalRunStatus::Completed,
+                2000.0,
+                None,
+            )
+            .await
+            .unwrap();
+        engine
+            .executions
+            .lock()
+            .await
+            .remove(&released_terminal_run_id);
+
+        let released_terminal_result = engine
+            .abort_workflow_run(
+                app.handle(),
+                &session_store,
+                &handles,
+                &released_terminal_run_id,
+                None,
+            )
+            .await;
+        assert!(matches!(
+            released_terminal_result,
+            Err(WorkflowEngineError::InvalidState(_))
+        ));
+        assert!(read_dispatch_events(&app, &released_terminal_run_id).is_empty());
+    }
+
+    #[tokio::test]
+    async fn dispatch_abort_run_treats_execution_released_after_lookup_as_already_terminal() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowRuntimeService::new_for_test());
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir).await;
+        let (session_store, handles) = make_dispatch_deps();
+
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let exec = make_waiting_approval_execution(&run_id, "/wt/released-after-lookup");
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+
+        let lookup_completed = Arc::new(tokio::sync::Notify::new());
+        let continue_precommit = Arc::new(tokio::sync::Notify::new());
+        engine
+            .pause_abort_after_lookup_for_test(lookup_completed.clone(), continue_precommit.clone())
+            .await;
+
+        let abort_engine = engine.clone();
+        let abort_session_store = session_store.clone();
+        let abort_handles = handles.clone();
+        let abort_run_id = run_id.clone();
+        let app_handle = app.handle().clone();
+        let abort_task = tokio::spawn(async move {
+            abort_engine
+                .abort_workflow_run(
+                    &app_handle,
+                    &abort_session_store,
+                    &abort_handles,
+                    &abort_run_id,
+                    None,
+                )
+                .await
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            lookup_completed.notified(),
+        )
+        .await
+        .expect("abort lookup must reach Active before the pre-commit relock");
+
+        engine
+            .run_store
+            .complete_run(&run_id, TerminalRunStatus::Completed, 2000.0, None)
+            .await
+            .unwrap();
+        engine.executions.lock().await.remove(&run_id);
+        continue_precommit.notify_one();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), abort_task)
+            .await
+            .expect("abort task must finish")
+            .expect("abort task must not panic");
+        assert!(matches!(
+            result,
+            Err(WorkflowEngineError::InvalidState(message))
+                if message.contains("already terminal")
+        ));
+        assert!(
+            read_dispatch_events(&app, &run_id).is_empty(),
+            "released-after-lookup race must not append dispatch events"
+        );
     }
 
     /// Spec [04] no-op 不変条件: approval UI 由来の
@@ -7724,11 +8183,10 @@ mod dispatch_boundary_tests {
             .await
             .unwrap();
 
-        let execs = engine.executions.lock().await;
-        let exec = execs.get(&run_id).unwrap();
-        assert_eq!(exec.state, WorkflowExecutionState::Completed);
-        assert_eq!(exec.step_history.len(), 1);
-        drop(execs);
+        assert!(
+            !engine.contains_execution_for_test(&run_id).await,
+            "terminal execution must be released after Completed"
+        );
         let events = read_dispatch_events(&app, &run_id);
         assert!(matches!(
             events.as_slice(),
@@ -7781,16 +8239,6 @@ mod dispatch_boundary_tests {
             .await
             .unwrap();
 
-        let execs = engine.executions.lock().await;
-        let exec = execs.get(&run_id).unwrap();
-        assert_eq!(exec.current_step_index, 1);
-        assert_eq!(
-            exec.step_history
-                .first()
-                .and_then(|entry| entry.result.as_deref()),
-            Some("reject")
-        );
-        drop(execs);
         let events = read_dispatch_events(&app, &run_id);
         assert!(matches!(
             &events[..3],
@@ -7802,13 +8250,17 @@ mod dispatch_boundary_tests {
                 },
                 WorkflowEvent::NodeCompleted {
                     node_name: completed,
+                    result,
                     ..
                 },
                 WorkflowEvent::NodeStarted {
                     node_name: started,
                     ..
                 },
-            ] if comment == "needs changes" && completed == "review" && started == "fix"
+            ] if comment == "needs changes"
+                && completed == "review"
+                && result.as_deref() == Some("reject")
+                && started == "fix"
         ));
     }
 
@@ -8157,6 +8609,7 @@ mod dispatch_boundary_tests {
         let aborted_event = WorkflowEvent::RunAborted {
             run_id: run_id.to_string(),
             workflow_name: "boundary-wf".to_string(),
+            aborted_step: None,
             timestamp: 4000.0,
         };
         log.append_batch(&[approval_event, aborted_event])
@@ -8907,16 +9360,15 @@ mod dispatch_boundary_tests {
             node_completed, 0,
             "handle_auto_complete must not advance a contract step without SubmitOutput"
         );
-        let state_after = engine
-            .executions
-            .lock()
-            .await
-            .get(&run_id)
-            .map(|e| e.state.clone())
-            .unwrap();
         assert!(
-            matches!(state_after, WorkflowExecutionState::Failed { .. }),
-            "seeded test execution has no active session, so missing SubmitOutput fails instead of advancing"
+            !engine.contains_execution_for_test(&run_id).await,
+            "seeded test execution has no active session, so missing SubmitOutput fails and releases the terminal execution"
+        );
+        assert!(
+            events_after
+                .iter()
+                .any(|event| matches!(event, WorkflowEvent::RunFailed { .. })),
+            "terminal failure must be recorded in the event log"
         );
     }
 

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_events.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_events.rs
@@ -1,11 +1,17 @@
 use crate::adaptor::gateway::workflow::engine_error::{
     classify_cli_mutation_rejection_reason, WorkflowEngineError,
 };
-use crate::adaptor::gateway::workflow::event::{CliMutationRequestRecord, WorkflowEvent};
+use crate::adaptor::gateway::workflow::event::{
+    CliMutationRequestRecord, RunAbortedChildOutcome, RunAbortedChildOutputSnapshot,
+    RunAbortedStepSnapshot, WorkflowEvent,
+};
 use crate::adaptor::gateway::workflow::internal_node_command::InternalNodeCommand;
 use crate::adaptor::gateway::workflow::route_context::CommandCommitContext;
 use crate::adaptor::gateway::workflow::runtime_commit::StepOutcome;
-use crate::adaptor::gateway::workflow::state::{WorkflowExecutionState, WorkflowState};
+use crate::adaptor::gateway::workflow::state::{
+    ChildOutputSnapshot, StepHistoryEntry, WorkflowExecutionState, WorkflowState,
+};
+use crate::domain::workflow::{STEP_STATE_ABORTED, STEP_STATE_COMPLETED};
 
 /// [05] internal dispatch path: engine 内部の node 完了 / 失敗 typed command の
 /// 単一 commit 関数。`InternalNodeCommand::CompleteNode` / `FailNode` を受け取り、
@@ -439,6 +445,11 @@ pub(crate) fn required_events_for_approval_commit(
                 events.push(WorkflowEvent::RunAborted {
                     run_id: snapshot.execution_id.clone(),
                     workflow_name: snapshot.workflow_name.clone(),
+                    aborted_step: snapshot
+                        .step_history
+                        .last()
+                        .filter(|entry| entry.state == STEP_STATE_ABORTED)
+                        .map(run_aborted_step_snapshot_from_history_entry),
                     timestamp: snapshot.updated_at,
                 });
             }
@@ -472,6 +483,49 @@ pub(crate) fn required_events_for_approval_commit(
         set_workflow_event_timestamp(event, commit_timestamp);
     }
     Ok(events)
+}
+
+pub(crate) fn run_aborted_step_snapshot_from_history_entry(
+    entry: &StepHistoryEntry,
+) -> RunAbortedStepSnapshot {
+    RunAbortedStepSnapshot {
+        step_name: entry.step_name.clone(),
+        completed_at: entry.completed_at,
+        result: entry.result.clone(),
+        session_id: entry.session_id.clone(),
+        token_usage: entry.token_usage.clone(),
+        structured_output: entry.structured_output.clone(),
+        run_index: entry.run_index,
+        child_outputs: entry.child_outputs.as_ref().map(|children| {
+            children
+                .iter()
+                .map(run_aborted_child_snapshot_from_child_output)
+                .collect()
+        }),
+    }
+}
+
+fn run_aborted_child_snapshot_from_child_output(
+    child: &ChildOutputSnapshot,
+) -> RunAbortedChildOutputSnapshot {
+    RunAbortedChildOutputSnapshot {
+        step_name: child.step_name.clone(),
+        session_id: child.session_id.clone(),
+        result: child.result.clone(),
+        run_index: child.run_index,
+        completed_at: child.completed_at,
+        structured_output: child.structured_output.clone(),
+        output_contract: child.output_contract.clone(),
+        outcome: run_aborted_child_outcome_from_state(&child.state),
+    }
+}
+
+fn run_aborted_child_outcome_from_state(state: &str) -> RunAbortedChildOutcome {
+    if state == STEP_STATE_COMPLETED {
+        RunAbortedChildOutcome::Completed
+    } else {
+        RunAbortedChildOutcome::Aborted
+    }
 }
 
 pub(crate) fn workflow_event_timestamp(event: &WorkflowEvent) -> f64 {
@@ -527,7 +581,7 @@ mod tests {
     use super::*;
     use crate::adaptor::gateway::workflow::schema::Workflow;
     use crate::adaptor::gateway::workflow::state::{
-        default_step_entry_state, StepHistoryEntry, TokenUsage,
+        default_step_entry_state, ChildOutputSnapshot, StepHistoryEntry, TokenUsage,
     };
     use crate::{
         adaptor::gateway::workflow::event::CliMutationRejectionReason,
@@ -608,6 +662,48 @@ mod tests {
                 && workflow_name == "wf"
                 && (*timestamp - 42.0).abs() < f64::EPSILON
         ));
+    }
+
+    #[test]
+    fn run_aborted_snapshot_maps_child_display_state_to_typed_outcome() {
+        let entry = StepHistoryEntry {
+            step_name: "parallel-review".to_string(),
+            completed_at: 42.0,
+            result: None,
+            session_id: None,
+            token_usage: None,
+            structured_output: None,
+            run_index: 1,
+            child_outputs: Some(vec![
+                ChildOutputSnapshot {
+                    step_name: "child-a".to_string(),
+                    session_id: Some("session-a".to_string()),
+                    result: Some("ok".to_string()),
+                    run_index: 1,
+                    completed_at: 40.0,
+                    structured_output: None,
+                    output_contract: None,
+                    state: STEP_STATE_COMPLETED.to_string(),
+                },
+                ChildOutputSnapshot {
+                    step_name: "child-b".to_string(),
+                    session_id: Some("session-b".to_string()),
+                    result: None,
+                    run_index: 1,
+                    completed_at: 42.0,
+                    structured_output: None,
+                    output_contract: None,
+                    state: STEP_STATE_ABORTED.to_string(),
+                },
+            ]),
+            state: STEP_STATE_ABORTED.to_string(),
+        };
+
+        let snapshot = run_aborted_step_snapshot_from_history_entry(&entry);
+        let children = snapshot.child_outputs.expect("child outputs are preserved");
+
+        assert_eq!(children[0].outcome, RunAbortedChildOutcome::Completed);
+        assert_eq!(children[1].outcome, RunAbortedChildOutcome::Aborted);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

親 ISSUE #1191 の広域調査で特定した無制限メモリ増大経路 C10 を分離して対応する (#1196)。

terminal 化（Completed / Failed / Aborted）した workflow run の `WorkflowExecution` が runtime の `executions` map に常駐し続け、run 数・step output 量に比例して常駐メモリが無制限に積み上がる構造的問題を解消する。

## 変更内容

- terminal 化と同時に `WorkflowExecution` を `executions` map から即時解放する
- 履歴表示・状態問い合わせ時は Run Store + Event Log から `restore_execution_by_run_id()` 経由で再構築する
- `RunAborted` event に `aborted_step` snapshot を追加し、abort 時の step 履歴を event から再構築可能にする
- adapter テストを、in-memory store ではなく event log からの projection で検証するよう変更

## 振る舞いの不変性

- active run（Running / WaitingApproval）の進行は不変
- terminal run の履歴表示・復元という外部観測可能な振る舞いは不変

## Spec

`docs/specs/issues-1196/`（requirements / behavior / design）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 完了・失敗・中止されたワークフローの実行メモリをターミナル化時に解放し、メモリ利用を最適化

* **改善**
  * ワークフロー中止時にステップの詳細情報（完了時刻・実行結果・セッション情報など）をスナップショットとして保持し、復元精度を向上

* **ドキュメント**
  * 要件・設計・振る舞いに関する仕様書を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->