### PR TITLE
feat: Workspace サイドバーを 4 階層ツリー構造へ再編 (#1220)

### DIFF
--- a/docs/specs/issues-1220/behavior.md
+++ b/docs/specs/issues-1220/behavior.md
@@ -1,0 +1,234 @@
+# Behavior
+
+本書は #1220「WorkspaceサイドバーをRepository→Worktree→Session/Workflowのツリー構造に再編する」の外部から観測される振る舞いを定義する。実装詳細は `design.md`、要求と範囲は `requirements.md` を参照する。
+
+## Assumptions
+
+- `Session` は通常の Chat Session を指す。`workflowStepSession !== true` の Session は Worktree 直下に表示する。
+- `WorkflowSession` は Workflow run の step に紐づく Chat Session を指す。`workflowStepSession === true` であり、Workflow run の state / history から親 run に紐づく。
+- `Workflow` は run 単位で表示する。
+- Worktree 親と Workflow 親は navigation target ではなく、tree group として扱う。
+- 中央表示は独立した mode ではなく、現在の `CenterSelection` から導出される。
+  - `CenterSelection.kind === "agentSession"` のとき中央は該当 Session を表示する。
+  - `CenterSelection.kind === "workflowRun"` のとき中央は該当 Workflow run を表示する。
+- Session を持たない終端 Workflow run は `auto_no_sessions` として自動 archive され、ツリーから除外されるが WorkflowHistory には残る。
+- それ以外の終端状態の行は、ユーザーの明示操作なしに即時非表示にしない。
+
+## Feature: Workspace tree navigation
+
+### Background
+
+```gherkin
+Background:
+  Given Releash デスクトップアプリが起動している
+  And ユーザーが少なくとも1つの repository を Workspace に登録している
+```
+
+## Rule: Sidebar は Repository -> Worktree -> Session / Workflow -> WorkflowSession を表示する
+
+```gherkin
+Scenario: Worktree 配下に通常 Session と Workflow が並ぶ
+  Given Worktree に通常 Session と Workflow run が存在する
+  When ユーザーが Workspace サイドバーを見る
+  Then Repository の下に Worktree が表示される
+  And Worktree の下に Session と Workflow が表示される
+  And Workflow の下に WorkflowSession が表示される
+
+Scenario: Worktree 配下は Session 優先、同種内は名前順で表示される
+  Given Worktree に複数の Session と Workflow が存在する
+  When ユーザーが Worktree を展開する
+  Then Session が Workflow より上に表示される
+  And Session 同士は名前順で表示される
+  And Workflow 同士は名前順で表示される
+
+Scenario: 取得済みの子要素は省略されない
+  Given Worktree に5件以上の Session または Workflow が存在する
+  When ユーザーが Worktree を展開する
+  Then 取得済みの子要素は全件表示される
+  And `もっと表示する` は表示されない
+```
+
+## Rule: Worktree 行は group として振る舞う
+
+```gherkin
+Scenario: Worktree 行クリックは展開状態のみを切り替える
+  Given Worktree 行が表示されている
+  When ユーザーが Worktree 行をクリックする
+  Then その Worktree の子要素が展開または折りたたまれる
+  And CenterSelection は変更されない
+  And 中央の表示対象 Session または Workflow は変更されない
+
+Scenario: Worktree 行は hover 時だけ名前の右に開閉 chevron を表示する
+  Given Worktree 行が表示されている
+  When ユーザーが Worktree 行へマウスオーバーする
+  Then Worktree 名の右に展開状態を示す chevron が表示される
+
+Scenario: Worktree 行は main と non-main で左アイコンが違う
+  Given main worktree と通常 worktree が表示されている
+  Then main worktree には Home icon が表示される
+  And 通常 worktree には worktree icon が表示される
+```
+
+## Rule: Session 行は agentSession selection target である
+
+```gherkin
+Scenario: 通常 Session を選択する
+  Given Worktree 配下に通常 Session が表示されている
+  When ユーザーがその Session 行をクリックする
+  Then 該当 Worktree が開かれる
+  And CenterSelection は agentSession になる
+  And 中央には該当 Session が表示される
+
+Scenario: Session 行 hover で閉じるボタンが表示される
+  Given Session 行が表示されている
+  When ユーザーが Session 行へマウスオーバーする
+  Then 行の右端に閉じるボタンが表示される
+
+Scenario: Session の閉じるボタンを押す
+  Given Session 行の閉じるボタンが表示されている
+  When ユーザーが閉じるボタンをクリックする
+  Then 該当 Session が close される
+  And 行クリックによる Session 選択は発火しない
+  And close 済み Session は明示削除または archive まで履歴から復帰できる
+```
+
+## Rule: Workflow 親は group として振る舞う
+
+```gherkin
+Scenario: Workflow 親クリックは展開状態のみを切り替える
+  Given Worktree 配下に Workflow が表示されている
+  When ユーザーが Workflow 行をクリックする
+  Then その Workflow の WorkflowSession が展開または折りたたまれる
+  And CenterSelection は変更されない
+
+Scenario: Workflow 行は hover 時だけ名前の右に開閉 chevron を表示する
+  Given Workflow 行が表示されている
+  When ユーザーが Workflow 行へマウスオーバーする
+  Then Workflow 名の右に展開状態を示す chevron が表示される
+```
+
+## Rule: WorkflowSession 行は workflowRun selection target である
+
+```gherkin
+Scenario: WorkflowSession を選択する
+  Given Workflow 配下に WorkflowSession が表示されている
+  When ユーザーがその WorkflowSession 行をクリックする
+  Then 該当 Worktree が開かれる
+  And CenterSelection は workflowRun になる
+  And 中央には該当 Workflow run が表示される
+  And 可能であれば該当 WorkflowSession に対応する step / transcript が選択される
+```
+
+## Rule: Worktree menu から Worktree 関連操作へ到達できる
+
+```gherkin
+Scenario: Worktree menu を開く
+  Given Worktree 行が表示されている
+  When ユーザーが Worktree 行右側の menu ボタンをクリックする
+  Then menu が表示される
+  And `SessionHistory` が表示される
+  And `WorkflowHistory` が表示される
+  And `PRリンク` が表示される
+  And `削除` が表示される
+
+Scenario: SessionHistory に hover する
+  Given Worktree menu が開いている
+  When ユーザーが `SessionHistory` にマウスオーバーする
+  Then Session history の子 menu が表示される
+
+Scenario: WorkflowHistory に hover する
+  Given Worktree menu が開いている
+  When ユーザーが `WorkflowHistory` にマウスオーバーする
+  Then Workflow history の子 menu が表示される
+
+Scenario: PRリンクを選択する
+  Given Worktree に PR URL が存在する
+  When ユーザーが Worktree menu の `PRリンク` を選択する
+  Then その PR URL が開かれる
+
+Scenario: Worktree 削除を選択する
+  Given main worktree ではない Worktree が表示されている
+  When ユーザーが Worktree menu の `削除` を選択する
+  Then 既存の Worktree 削除確認 dialog が表示される
+```
+
+## Rule: Worktree create menu から作業単位を開始できる
+
+```gherkin
+Scenario: NewWorkflow を起動する
+  Given Worktree 行が表示されている
+  And workflow definition が存在する
+  When ユーザーが Worktree 行右側の create menu を開く
+  And `NewWorkflow` サブメニューから workflow を選択する
+  And task を入力して Start する
+  Then `start_workflow` が該当 Worktree と task で呼び出される
+  And CenterSelection は workflowRun になる
+  And 中央には開始された Workflow run が表示される
+```
+
+## Rule: Workspace header は Add Worktree のみを表示する
+
+```gherkin
+Scenario: Header に Add Worktree 操作が表示される
+  When ユーザーが Workspace サイドバーの header を見る
+  Then `Workspaces` label が表示される
+  And Add Worktree 操作が表示される
+  And Group 操作は表示されない
+  And Filter 操作は表示されない
+```
+
+## Rule: AgentChatPanel の Session タブバーは廃止される
+
+```gherkin
+Scenario: AgentChatPanel 上部に Session tab bar が表示されない
+  Given ユーザーが agentSession selection で Session を表示している
+  Then 中央 AgentChatPanel 上部に Session tab bar は表示されない
+  And Session の切替は左 Workspace tree から行う
+
+Scenario: 新規 Session は Worktree 行の action から開始する
+  Given Worktree 行が表示されている
+  When ユーザーが Worktree 行右側の新規 Session ボタンをクリックする
+  Then 該当 Worktree に新規 Session が作成される
+  And CenterSelection は作成された Session の agentSession になる
+  And 中央には新規 Session が表示される
+```
+
+## Rule: 中央表示は CenterSelection から導出される
+
+```gherkin
+Scenario: Agent / Workflow toggle は表示されない
+  When ユーザーが中央 ViewToolbar を見る
+  Then Agent / Workflow を切り替える toggle は表示されない
+
+Scenario: agentSession selection は AgentChatPanel を表示する
+  Given CenterSelection が agentSession である
+  Then 中央には AgentChatPanel が表示される
+  And 該当 Session が表示される
+
+Scenario: workflowRun selection は WorkflowView を表示する
+  Given CenterSelection が workflowRun である
+  Then 中央には WorkflowView が表示される
+  And 該当 Workflow run が表示される
+```
+
+## Rule: 表示に仮データ由来のノイズは出ない
+
+```gherkin
+Scenario: 相対時刻を表示しない
+  When ユーザーが Workspace tree を見る
+  Then `1日` や `4時間` のような仮の相対時刻は表示されない
+
+Scenario: 仮状態テキストを表示しない
+  When ユーザーが Workspace tree を見る
+  Then `Open` や `Closed` のような仮状態テキストは表示されない
+
+Scenario: Folder icon や色付き dot を表示しない
+  When ユーザーが Workspace tree を見る
+  Then Worktree / Session / Workflow の行に不要な folder icon や色付き dot は表示されない
+```
+
+## Open Questions
+
+- WorkflowSession 行に close hover action を表示するか。
+- History 子 menu の中身を既存 History popover そのものにするか、menu 用の軽量リストにするか。
+- Workflow 親の menu action を Worktree menu とは別に持つか。

--- a/docs/specs/issues-1220/design.md
+++ b/docs/specs/issues-1220/design.md
@@ -1,0 +1,394 @@
+# Design
+
+本書は #1220「WorkspaceサイドバーをRepository→Worktree→Session/Workflowのツリー構造に再編する」の実装設計を定義する。要求は `requirements.md`、観測される振る舞いは `behavior.md` を参照する。
+
+## Overview
+
+Workspace サイドバーを、worktree 管理 UI から作業単位ナビゲーションへ拡張する。
+
+既存の Worktree 管理機能のうち Add Worktree / PR link / delete / refresh は維持し、その下に Session / Workflow / WorkflowSession のツリーを追加する。Group / Filter と Status グループ表示はツリー一本化に伴い廃止する。中央 `AgentChatPanel` の Session タブバーは廃止し、Session 選択・新規作成・close・history restore / archive は左ツリーと Worktree menu へ移す。新規 Workflow run 起動は Worktree 行の create menu から行う。
+
+本 Issue の重要な設計判断は、UIで固めた tree shape をフロント仮データではなく Rust command の projection として返すことにある。フロントは DTO を描画し、クリックされた node id を command / selection request として渡すだけにする。
+
+## Current Prototype To Replace
+
+現在の UI プロトタイプには `buildDraftTreeNodes()` によるフロント仮データがある。これは理想 UI を確認するための一時実装であり、最終実装では削除する。
+
+削除対象になる仮実装の代表:
+
+- branch 名や PR 番号から Session / Workflow 名を推測する処理。
+- `Issue #...` や `新しいチャット` など固定文字列の node 生成。
+- フロント側で Session / Workflow の親子関係を組み立てる処理。
+- フロント側の tree sort ロジック。
+
+残すべき UI 形状:
+
+- Worktree row の icon / name / hover chevron / right actions。
+- Session row の agent state icon / hover close。
+- Workflow row の workflow icon / hover chevron。
+- Worktree menu の hover sub menu。
+- Worktree create menu の `NewWorkflow` sub menu と起動 dialog。
+- 親名位置に合わせた child indent。
+
+## Architecture
+
+### Responsibility
+
+- Rust:
+  - Worktree ごとの Session / Workflow / WorkflowSession projection を構築する。
+  - Workflow run と workflow step session の親子関係を解決する。
+  - Node の sort order を決める。
+  - terminal / closed / archived / running などの状態を DTO として返す。
+  - close / restore / archive / delete / PR link に必要な既存 command 境界を維持する。
+- Frontend:
+  - Rust DTO を描画する。
+  - expand / collapse など純粋な view state を保持する。
+  - click / hover / menu action を受け付け、既存 command または selection request を発行する。
+  - 表示用の薄い format は行うが、親子関係・sort・状態判定はしない。
+- MainLayout / App:
+  - 左ツリーからの selection request を受け、worktree selection と `CenterSelection` を同期する。
+  - WorktreeContent が mount された後に target Session / Workflow を選択できるよう、request id 付きの一回限り request として渡す。
+  - `centerMode` のような独立した Agent / Workflow mode state は持たない。中央に何を表示するかは `CenterSelection.kind` から導出する。
+
+### Proposed Rust Projection Command
+
+既存 `useWorktreeList(repoPath)` は Worktree 一覧を返す責務として残す。Session / Workflow tree は worktree 単位で取得する。
+
+```rust
+#[tauri::command]
+async fn list_workspace_worktree_nodes(
+    worktree_path: String,
+) -> Result<Vec<WorkspaceTreeNodeDto>, String>
+```
+
+候補 DTO:
+
+```rust
+#[serde(tag = "kind", rename_all = "camelCase")]
+enum WorkspaceTreeNodeDto {
+    Session(WorkspaceSessionNodeDto),
+    Workflow(WorkspaceWorkflowNodeDto),
+}
+
+struct WorkspaceSessionNodeDto {
+    id: String,
+    worktree_path: String,
+    title: String,
+    state: String,
+    updated_at: i64,
+    agent_state: Option<String>,
+    workflow_step_session: bool,
+}
+
+struct WorkspaceWorkflowNodeDto {
+    run_id: String,
+    worktree_path: String,
+    title: String,
+    status: String,
+    updated_at: i64,
+    children: Vec<WorkspaceSessionNodeDto>,
+}
+```
+
+実装時に `SessionSummary` / `WorkflowRunSummaryDto` の既存型を再利用できるなら、専用 DTO は薄くしてよい。ただしフロントが WorkflowState を全件読んで親子関係を推測する設計にはしない。
+
+### Projection Rules
+
+Rust command は次の手順で projection を作る。
+
+1. `list_sessions(worktreePath)` 相当で当該 worktree の SessionSummary を取得する。
+2. `workflowStepSession !== true` の Session を Worktree 直下 Session とする。
+3. `list_workflow_runs(worktreePath)` 相当で WorkflowRunSummary を取得する。
+4. 各 run の state projection を取得し、WorkflowSession の session id を収集する。
+   - `currentSessionId`
+   - `stepHistory[].sessionId`
+   - `stepHistory[].childOutputs[].sessionId`
+   - `activeParallelSteps[].sessionId`
+5. 収集した session id と `workflowStepSession === true` の SessionSummary を突き合わせ、Workflow children とする。
+6. Worktree 直下は `Session 優先 -> 名前順` で sort する。
+7. Workflow children も名前順で sort する。
+8. terminal かつ children が空の Workflow run は `archive_reason = auto_no_sessions` で archive index に自動登録し、ツリー projection から除外する。
+9. auto archive された Workflow run は WorkflowHistory projection には `archived_at` と `archive_reason` 付きで残す。
+
+名前の優先順位:
+
+1. 明示 title があれば title。
+2. WorkflowSession は stepName があれば stepName。
+3. Session は firstMessage があれば firstMessage。
+4. Workflow は task があれば task、なければ workflowName。
+5. 最後に id。
+
+### CenterSelection Model
+
+左ツリーから中央を駆動する `CenterSelection` を追加する。中央表示の種類は `CenterSelection.kind` から導出し、別途 `centerMode` は保持しない。
+
+```ts
+type CenterSelection =
+	| {
+			kind: "agentSession";
+			worktreePath: string;
+			sessionId: string;
+	  }
+	| {
+			kind: "workflowRun";
+			worktreePath: string;
+			runId: string;
+			focus?: {
+				sessionId?: string;
+				stepName?: string;
+				runIndex?: number;
+			};
+	  };
+
+type CenterSelectionRequest = CenterSelection & {
+	requestId: number;
+	branchName?: string;
+	repoName?: string;
+};
+```
+
+Selection behavior:
+
+- Session row:
+  - App opens/selects the worktree tab.
+  - MainLayout sets `CenterSelection.kind = "agentSession"`.
+  - AgentChatProvider selects `sessionId`.
+- WorkflowSession row:
+  - App opens/selects the worktree tab.
+  - MainLayout sets `CenterSelection.kind = "workflowRun"`.
+  - WorkflowView selects `runId`.
+  - If `focus.sessionId` is present, WorkflowView selects matching step / transcript.
+- Worktree row:
+  - No `CenterSelection` change.
+  - Only expands/collapses tree.
+- Workflow row:
+  - No `CenterSelection` change.
+  - Only expands/collapses children.
+- New Session button:
+  - App opens/selects the worktree tab.
+  - AgentChatProvider calls existing `createNewSession()` for that worktree.
+  - MainLayout sets `CenterSelection.kind = "agentSession"` with the created `sessionId`.
+
+Render derivation:
+
+```ts
+selection.kind === "agentSession" -> AgentChatPanel
+selection.kind === "workflowRun" -> WorkflowView
+```
+
+`ViewToolbar` should not expose an Agent / Workflow toggle in the final #1220 state. If an intermediate migration keeps it temporarily, it must only update `CenterSelection` by selecting an actual target, not write an independent `centerMode`.
+
+### AgentChatPanel Changes
+
+Remove the Session tab bar from `AgentChatPanel`.
+
+Move or remove responsibilities:
+
+| Current tab bar responsibility | New owner |
+|---|---|
+| Session list display | Workspace tree |
+| Session select | Workspace tree Session row |
+| New Session `+` | Worktree row new Session action |
+| close tab `x` | Session row hover close |
+| History popover restore/archive | Worktree menu `SessionHistory` |
+| workflow step filtering | Rust projection + Workspace tree |
+
+`ChatSessionView` remains the one-session display surface. When `CenterSelection.kind === "agentSession"`, the central area renders only that selected Session.
+
+Tests under `AgentChatPanel.test.tsx` that assert tab bar behavior must be rewritten or removed according to the new owner.
+
+### WorkflowView Changes
+
+WorkflowView currently has active-worktree-oriented state. It needs a target run selection request.
+
+Required changes:
+
+- Accept `CenterSelection.kind === "workflowRun"` with `runId` and optional `focus.sessionId`.
+- Load selected run by `get_workflow_run_state(worktreePath, runId)` for terminal and active runs.
+- Keep existing live `get_workflow_state(runId)` / event subscription for active run updates where applicable.
+- When a WorkflowSession row is selected, focus/select the matching step or transcript if the view can resolve it.
+
+Workflow parent row does not select a run. Only WorkflowSession row creates a `workflowRun` selection.
+
+### Workspace UI Details
+
+#### Header
+
+Use existing header layout:
+
+- `Workspaces`
+- Add Worktree
+
+Do not add a `Project/all` selector row.
+Do not restore Group menu, Filter menu, or Status grouping in this Issue.
+
+#### Worktree Row
+
+Left side:
+
+```text
+Icon WorktreeName ChevronOnHover
+```
+
+Right side:
+
+```text
+Menu Create
+```
+
+Rules:
+
+- main worktree uses `Home`.
+- non-main worktree uses worktree icon.
+- no folder icon.
+- no colored dot.
+- no textual open/closed status.
+- row click toggles expansion only.
+- hover chevron appears immediately after Worktree name.
+- Create opens a menu containing `NewSession` and `NewWorkflow`.
+
+#### Session Row
+
+```text
+AgentStateIcon SessionName [CloseOnHover]
+```
+
+Rules:
+
+- Same row component for Worktree direct Session and WorkflowSession unless final UI chooses to hide close for WorkflowSession.
+- No `Open` / `Closed` text.
+- No relative time.
+- Hover close button must stop propagation so select is not triggered.
+
+#### Workflow Row
+
+```text
+WorkflowIcon WorkflowName ChevronOnHover
+```
+
+Rules:
+
+- row click toggles children only.
+- no `CenterSelection` change.
+- no relative time.
+- no status text.
+
+#### Indent
+
+Use CSS variables or layout constants tied to icon width and gap rather than magic depth multiplication.
+
+Desired alignment:
+
+- Worktree children start at Worktree name x-position.
+- Workflow children start at Workflow name x-position.
+- Same-level Session and Workflow start at the same x-position.
+
+### Worktree Menu
+
+Worktree menu content:
+
+- `SessionHistory`
+  - hover opens child menu.
+  - Uses existing closed/history Session data and restore/archive operations.
+- `WorkflowHistory`
+  - hover opens child menu.
+  - Uses workflow run list, including terminal runs.
+- `PRリンク`
+  - disabled or hidden when PR URL is absent.
+  - opens existing PR URL.
+- `削除`
+  - disabled for main worktree.
+  - opens existing DeleteWorktreeDialog.
+
+Do not add sort menu. Sort is fixed by Rust projection.
+
+### Worktree Create Menu
+
+Worktree create menu content:
+
+- `NewSession`
+  - Sends `CenterSelection.kind = "newAgentSession"` for the target worktree.
+- `NewWorkflow`
+  - Opens a child menu backed by `useWorkflowConfig`.
+  - Selecting a workflow opens a task input dialog.
+  - Submitting the dialog invokes `start_workflow` with `workflowName`, `worktreePath`, optional trimmed `task`, and `permissionMode = "ask"`.
+  - After a successful start, refresh the tree and select the returned run with `CenterSelection.kind = "workflowRun"`.
+
+### Removed Group / Filter / Status Grouping
+
+`Group by Repo / Status`, status filter behavior, and Status-grouped Worktree sections are not part of the final #1220 Workspace tree. The sidebar renders repositories and their worktrees directly, and the header exposes only Add Worktree.
+
+## Data Refresh
+
+Refresh sources:
+
+- Worktree list refresh remains on existing worktree refresh.
+- Session tree refresh should happen after:
+  - create session
+  - close session
+  - restore session
+  - archive session
+  - session title change
+  - session state change / agent state event
+- Workflow tree refresh should happen after:
+  - workflow run created
+  - workflow state changed
+  - workflow run terminal state reached
+  - workflow history restored/deleted if such operation exists
+
+Implementation can initially refresh per worktree, then optimize with event-specific invalidation.
+
+## Error Handling
+
+- If tree projection command fails for a worktree, show that worktree row and an inline lightweight error under it; do not break the entire Workspace sidebar.
+- If Session selection fails because the Session no longer exists, refresh the worktree tree and keep the previous central view.
+- If WorkflowSession selection fails because run or session no longer exists, refresh the worktree tree and keep the previous central view.
+- PR link absence disables the menu item.
+- Delete on main worktree remains disabled.
+
+## Tests
+
+Frontend tests:
+
+- WorkspaceList renders Worktree icon variants.
+- Worktree row click toggles children and does not change `CenterSelection`.
+- Session row click emits agent selection request.
+- Workflow row click toggles children and does not change `CenterSelection`.
+- WorkflowSession row click emits workflow selection request.
+- Worktree menu opens and contains SessionHistory / WorkflowHistory / PRリンク / 削除.
+- Session hover close calls close handler without selecting the row.
+- `Open` / `Closed` / relative time / `もっと表示する` are not rendered.
+- Header Add Worktree renders.
+- NewWorkflow sub menu and workflow start dialog render from the Worktree create menu.
+- AgentChatPanel no longer renders session tab bar.
+
+Rust tests:
+
+- Projection separates direct Session from workflow step Session using `workflowStepSession`.
+- Projection attaches workflow step Session to the correct run.
+- Projection includes `currentSessionId` and historical session ids.
+- Projection handles terminal Workflow runs.
+- Projection auto archives terminal Workflow runs with no children as `auto_no_sessions`, hides them from the tree, and keeps them in WorkflowHistory.
+- Projection sorts direct children as `Session first -> name`.
+- Projection does not drop closed / terminal nodes unless archived / explicitly deleted.
+
+Integration smoke:
+
+- Create Session from Worktree action, then select it from tree.
+- Close Session from hover action, then restore it from SessionHistory.
+- Select WorkflowSession and verify `workflowRun` selection opens the correct run.
+
+## Risks
+
+- Left tree lives outside the current per-worktree AgentChatProvider; selection must cross worktree tab mount boundaries without race conditions.
+- Workflow run state may be terminal and not live in runtime memory; selection must use `get_workflow_run_state(worktreePath, runId)` style read-only projection, not only active runtime state.
+- Existing AgentChatPanel tab tests are numerous and will need careful rewrite to avoid deleting coverage for close / restore / create behavior.
+- Frontend prototype has local tree generation. Leaving it in place would violate Rust-first logic and create future data mismatches.
+- History menu UX may become cramped if implemented as raw dropdown items. Existing popover reuse should be evaluated before final implementation.
+
+## Open Questions
+
+- Should WorkflowSession rows expose hover close, or should only direct Session rows expose it?
+- Should `SessionHistory` include open Sessions too, or only closed / archived candidates?
+- Should `WorkflowHistory` list active Workflow runs, terminal Workflow runs, or both?
+- Should terminal Workflow rows expose delete/archive from the WorkflowHistory child menu?

--- a/docs/specs/issues-1220/requirements.md
+++ b/docs/specs/issues-1220/requirements.md
@@ -1,0 +1,145 @@
+# Requirements
+
+## Type
+
+新機能。Workspace サイドバーを `Repository -> Worktree -> Session / Workflow -> WorkflowSession` のツリー構造へ再編する。
+
+関連: #1220 / #1023
+
+## Goal
+
+左サイドバーで worktree 配下の作業単位を俯瞰・選択できるようにする。
+
+現在の Workspace サイドバーは `Repository -> Worktree` までしか表示せず、Session の切替は中央 `AgentChatPanel` 上部のタブバー、Workflow の確認は中央 `WorkflowView` に分かれている。複数 Session / Workflow を扱うと、作業単位の全体像と切替先が分散する。
+
+本 Issue では、左サイドバーを次のツリーへ再編し、選択ナビゲーションを左ツリーへ一本化する。
+
+```text
+Repository
+  Worktree
+    Session
+    Workflow
+      WorkflowSession
+```
+
+最終状態では、中央 `AgentChatPanel` 上部の Session タブバーを廃止し、中央は左ツリーで選択された1件のみを表示する。
+
+## Current UI Decision
+
+Issue 本文のゴールに対して、対話で確定した Workspace UI の理想状態は以下。
+
+- 既存の `Workspaces` ヘッダーは維持する。
+  - ツリー一本化に伴い `Group` / `Filter` と Status グループ表示は廃止する。
+  - ヘッダーの操作は `Add Worktree` のみを残す。
+  - `プロジェクト / all / ...` のような新規トップ行は作らない。
+- Worktree 行:
+  - 左側は `Home` または worktree アイコン、Worktree 名、hover 時だけ Worktree 名の右に開閉 chevron。
+  - main worktree は `Home`、それ以外は worktree らしいアイコンを表示する。
+  - 右側に menu ボタンと新規 Session ボタンを置く。
+  - Worktree 行クリックは展開/折りたたみのみ。中央の選択対象は変更しない。
+  - Worktree 行には folder icon、色付き dot、状態テキスト、相対時刻を出さない。
+- Session 行:
+  - Worktree で使っていた agent state icon を Session 側へ移す。
+  - 状態は icon で示し、`Open` / `Closed` のような状態テキストは出さない。
+  - hover 時に右端へ閉じるボタンを出す。
+  - クリックすると worktree を選択し、中央の選択対象を `agentSession` にして該当 Session を表示する。
+- Workflow 行:
+  - Workflow 親は展開/折りたたみのみ。クリックで中央を Workflow view に切り替えない。
+  - hover 時だけ Workflow 名の右に開閉 chevron を出す。
+  - Workflow 親には相対時刻や `Open` / `Closed` を出さない。
+- WorkflowSession 行:
+  - Workflow 配下の Session として表示する。
+  - クリックすると worktree を選択し、中央の選択対象を `workflowRun` にして該当 run / session を表示する。
+- インデント:
+  - Worktree 直下の Session / Workflow は Worktree 名の開始位置から始める。
+  - Workflow 配下の WorkflowSession は Workflow 名の開始位置から始める。
+  - Session と Workflow の同階層インデントは一致させる。
+- 並び順:
+  - Worktree 配下は固定で `Session 優先 -> 名前順`。
+  - 並び替え UI は置かない。
+- 表示省略:
+  - `もっと表示する` は置かず、取得済みノードを全件表示する。
+- Worktree menu:
+  - クリックで menu を開く。
+  - `SessionHistory` と `WorkflowHistory` は hover で子 menu を開く。
+  - `PRリンク` と `削除` を同じ menu 内に置く。
+- Worktree create menu:
+  - `NewSession` と `NewWorkflow` を表示する。
+  - `NewWorkflow` は hover で workflow 一覧の子 menu を開き、選択後に task 入力 dialog から `start_workflow` を起動する。
+
+## Scope
+
+- Workspace サイドバーのツリー UI 実装。
+- Session / Workflow / WorkflowSession を返す Rust 側 Tauri command または既存 command の整理。
+- 左ツリー選択から中央表示を駆動する配線。
+- 独立した `centerMode` 状態を廃止し、中央表示を `CenterSelection.kind` から導出する配線。
+- 中央 `AgentChatPanel` の Session タブバー廃止。
+- 廃止タブバーが持っていた機能の移設。
+  - 新規 Session 開始。
+  - Session 選択。
+  - Session close。
+  - Session restore / archive を含む History 操作。
+- Worktree create menu からの新規 Workflow run 起動。
+- Workflow run と WorkflowSession の選択。
+- 仮 UI データと不要化したタブバー関連コードの削除。
+
+## Non-goals
+
+- Workflow engine の新しい実行モデル追加。
+- Workflow template marketplace / remote UI / Web UI への移植。
+- Source Control / Review / Editor / Terminal の再設計。
+- Worktree 作成・削除・PRリンクなど既存 worktree 管理機能の意味変更。
+- 左サイドバー外の visual redesign。
+
+## Requirements
+
+- 左サイドバーで Repository -> Worktree -> Session / Workflow -> WorkflowSession を表示できること。
+- Worktree 行の UI は Current UI Decision に従うこと。
+- Worktree 行クリックでは `CenterSelection` を変更しないこと。
+- Session 行クリックで該当 worktree を開き、`CenterSelection.kind = "agentSession"` として該当 Session を表示すること。
+- Workflow 親クリックでは `CenterSelection` を変更せず、展開/折りたたみのみ行うこと。
+- WorkflowSession 行クリックで該当 worktree を開き、`CenterSelection.kind = "workflowRun"` として該当 run / session を表示すること。
+- Worktree menu から SessionHistory / WorkflowHistory の hover 子 menu、PRリンク、削除に到達できること。
+- Session hover action から Session close ができること。
+- Worktree の新規 Session ボタンから新規 Session を開始できること。
+- Worktree create menu の `NewWorkflow` サブメニューから workflow を選択し、task 入力 dialog の Start で `start_workflow` を起動できること。
+- 中央 `AgentChatPanel` の Session タブバーは削除されていること。
+- Workflow step session は自由対話 Session と同格の agent tab として中央に並ばないこと。
+- Session を持たない終端 Workflow run は `archive_reason = auto_no_sessions` で自動 archive され、ツリーから除外されるが WorkflowHistory には `archived_at` 付きで残ること。
+- それ以外の終端 Session / Workflow は明示削除または archive までツリー・history から勝手に消えないこと。
+- Session / Workflow / WorkflowSession の親子関係、状態、並び順の決定は Rust 側で行うこと。フロントは表示、入力受付、Tauri command 呼び出しに徹すること。
+- 中央の Agent / Workflow 表示は独立した toggle や mode state ではなく、現在の `CenterSelection` から導出すること。
+- `ViewToolbar` の Agent / Workflow 切替は最終状態では表示しないこと。
+- フロントの仮データ生成（branch 名から Session / Workflow を作る処理）は実装完了時に削除されていること。
+
+## Data Sources
+
+- Worktree: 既存 `useWorktreeList` / Rust worktree command が返す `WorktreeBranch` 相当。
+- Session: 既存 `list_sessions(worktreePath)` が返す `SessionSummary`。
+  - 直下 Session 判定: `workflowStepSession !== true`。
+- Workflow: 既存 `list_workflow_runs(worktreePath)` が返す `WorkflowRunSummary`。
+- WorkflowSession:
+  - `get_workflow_run_state(worktreePath, runId)` または同等の Rust projection から得る。
+  - `currentSessionId`、`stepHistory[].sessionId`、必要に応じて parallel child / active parallel step の session id を Rust 側で集約する。
+  - `workflowStepSession === true` の Session と run の session id 集合を Rust 側で対応付ける。
+
+## Acceptance Criteria
+
+- Workspace サイドバーで4階層ツリーを展開・折りたたみできる。
+- Worktree / Session / Workflow / WorkflowSession の UI が Current UI Decision と一致する。
+- Session 選択で `agentSession` selection の該当 Session が表示される。
+- WorkflowSession 選択で `workflowRun` selection の該当 run / session が表示される。
+- Worktree 親と Workflow 親は `CenterSelection` を変更しない。
+- Worktree menu から SessionHistory / WorkflowHistory / PRリンク / 削除に到達できる。
+- Session hover close が既存 close semantics を壊さず動作する。
+- 中央 AgentChat の Session タブバーが表示されない。
+- `centerMode` を独立 state として保持する実装が残っていない。
+- `pnpm lint` / `pnpm test` / `pnpm build` が成功する。
+- Rust 変更を含む場合、`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` が成功する。
+
+## Open Questions
+
+- SessionHistory / WorkflowHistory の中身は、既存 History popover をどの粒度で再利用するか。
+- WorkflowHistory の削除 / archive semantics を Session と同じ menu に置くか、Workflow 専用 action として分けるか。
+- WorkflowSession hover close を通常 Session と同じ見た目にするか、Workflow 配下では close を出さないか。
+- workflow run の子 Session 名は `stepName`、Session title、first message のどれを優先表示するか。

--- a/src-tauri/src/adaptor/controller/command/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod pty_session;
 pub(crate) mod repository;
 pub(crate) mod workflow;
 pub(crate) mod workspace_state;
+pub(crate) mod workspace_tree;
 
 type InvokeHandler = Box<dyn Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Sync>;
 
@@ -195,6 +196,11 @@ pub(crate) fn register_all(builder: tauri::Builder<tauri::Wry>) -> tauri::Builde
             crate::adaptor::controller::command::agent_session::stored_session::add_message,
             crate::adaptor::controller::command::agent_session::stored_session::update_session_state,
             crate::adaptor::controller::command::agent_session::stored_session::update_session_agent_info,
+            // Workspace tree
+            crate::adaptor::controller::command::workspace_tree::list_workspace_worktree_nodes,
+            crate::adaptor::controller::command::workspace_tree::list_workspace_workflow_history,
+            crate::adaptor::controller::command::workspace_tree::archive_workspace_workflow_run,
+            crate::adaptor::controller::command::workspace_tree::restore_workspace_workflow_run,
             // Menu
             crate::menu::set_menu_items_enabled,
 

--- a/src-tauri/src/adaptor/controller/command/workflow/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/mod.rs
@@ -2395,6 +2395,7 @@ mod tests {
                     app.handle().clone(),
                 ),
             ),
+            workflow_archive_index_lock: Arc::new(tokio::sync::Mutex::new(())),
         });
         (app, engine, data_dir)
     }

--- a/src-tauri/src/adaptor/controller/command/workspace_tree.rs
+++ b/src-tauri/src/adaptor/controller/command/workspace_tree.rs
@@ -1,0 +1,945 @@
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::adaptor::controller::state::AppState;
+use crate::app_data_dir::resolve_data_dir;
+use crate::domain::workflow::{
+    RunId, RunStatus, WorkflowRunSummary, WorkflowStateSnapshot, STEP_STATE_RUNNING,
+};
+use crate::usecase::agent_session::session::{
+    now_timestamp, SessionState, SessionStore, SessionSummary,
+};
+
+const DEFAULT_SESSION_TITLE: &str = "NewSession";
+const WORKFLOW_ARCHIVES_FILE: &str = "workflow_run_archives.json";
+const ARCHIVE_REASON_AUTO_NO_SESSIONS: &str = "auto_no_sessions";
+const ARCHIVE_REASON_MANUAL: &str = "manual";
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub(crate) enum WorkspaceTreeNodeDto {
+    Session(WorkspaceSessionNodeDto),
+    Workflow(WorkspaceWorkflowNodeDto),
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkspaceSessionNodeDto {
+    pub id: String,
+    pub worktree_path: String,
+    pub title: String,
+    pub state: SessionState,
+    pub updated_at: f64,
+    pub workflow_step_session: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_index: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkspaceWorkflowNodeDto {
+    pub run_id: String,
+    pub worktree_path: String,
+    pub title: String,
+    pub status: String,
+    pub updated_at: f64,
+    pub children: Vec<WorkspaceSessionNodeDto>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkspaceWorkflowHistoryItemDto {
+    pub run_id: String,
+    pub worktree_path: String,
+    pub title: String,
+    pub status: String,
+    pub updated_at: f64,
+    pub archived_at: f64,
+    pub archive_reason: String,
+    pub children: Vec<WorkspaceSessionNodeDto>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StepSessionRef {
+    session_id: String,
+    step_name: String,
+    run_index: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunArchiveRecord {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    archived_at: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    archive_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    restored_at: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunArchiveIndex {
+    #[serde(default)]
+    runs: BTreeMap<String, WorkflowRunArchiveRecord>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkflowArchiveIndexSavePolicy {
+    Always,
+    IfChanged,
+}
+
+#[tauri::command]
+pub async fn list_workspace_worktree_nodes(
+    app_state: State<'_, AppState>,
+    session_store: State<'_, Arc<SessionStore>>,
+    app: tauri::AppHandle,
+    worktree_path: String,
+) -> Result<Vec<WorkspaceTreeNodeDto>, String> {
+    let data_dir = resolve_data_dir(&app)?;
+    let sessions = session_store.list_sessions(&data_dir, &worktree_path)?;
+    let workflow_usecase = app_state.workflow_usecase.clone();
+    let archive_index_lock = app_state.workflow_archive_index_lock.clone();
+    let nodes = tokio::task::spawn_blocking(move || {
+        with_workflow_archive_index(
+            &archive_index_lock,
+            &data_dir,
+            WorkflowArchiveIndexSavePolicy::IfChanged,
+            |archives| {
+                let runs = workflow_usecase
+                    .list_runs_for_worktree(None, &worktree_path)
+                    .map_err(|e| e.to_string())?;
+                let mut states = HashMap::new();
+                for run in &runs {
+                    let state = workflow_usecase
+                        .get_run_state(&run.run_id)
+                        .map_err(|e| e.to_string())?;
+                    states.insert(run.run_id.clone(), state);
+                }
+                Ok(project_workspace_tree_nodes(
+                    sessions,
+                    runs,
+                    states,
+                    archives,
+                    now_timestamp(),
+                ))
+            },
+        )
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))??;
+    Ok(nodes)
+}
+
+#[tauri::command]
+pub async fn list_workspace_workflow_history(
+    app_state: State<'_, AppState>,
+    session_store: State<'_, Arc<SessionStore>>,
+    app: tauri::AppHandle,
+    worktree_path: String,
+) -> Result<Vec<WorkspaceWorkflowHistoryItemDto>, String> {
+    let data_dir = resolve_data_dir(&app)?;
+    let sessions = session_store.list_sessions(&data_dir, &worktree_path)?;
+    let workflow_usecase = app_state.workflow_usecase.clone();
+    let archive_index_lock = app_state.workflow_archive_index_lock.clone();
+    let history = tokio::task::spawn_blocking(move || {
+        with_workflow_archive_index(
+            &archive_index_lock,
+            &data_dir,
+            WorkflowArchiveIndexSavePolicy::IfChanged,
+            |archives| {
+                let runs = workflow_usecase
+                    .list_runs_for_worktree(None, &worktree_path)
+                    .map_err(|e| e.to_string())?;
+                let mut states = HashMap::new();
+                for run in &runs {
+                    let state = workflow_usecase
+                        .get_run_state(&run.run_id)
+                        .map_err(|e| e.to_string())?;
+                    states.insert(run.run_id.clone(), state);
+                }
+                Ok(project_workspace_workflow_history(
+                    sessions,
+                    runs,
+                    states,
+                    archives,
+                    now_timestamp(),
+                ))
+            },
+        )
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))??;
+    Ok(history)
+}
+
+#[tauri::command]
+pub async fn archive_workspace_workflow_run(
+    app_state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    worktree_path: String,
+    run_id: String,
+) -> Result<(), String> {
+    let data_dir = resolve_data_dir(&app)?;
+    let run_id = RunId::new(run_id).map_err(|e| e.to_string())?;
+    let workflow_usecase = app_state.workflow_usecase.clone();
+    let run_id_string = run_id.to_string();
+    let authorized = tokio::task::spawn_blocking(move || {
+        workflow_usecase
+            .authorize_run_summary_for_worktree(&run_id_string, &worktree_path)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))??;
+    if authorized.is_none() {
+        return Err(format!("Workflow run not found: {run_id}"));
+    }
+
+    let archive_index_lock = app_state.workflow_archive_index_lock.clone();
+    let run_id = run_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        with_workflow_archive_index(
+            &archive_index_lock,
+            &data_dir,
+            WorkflowArchiveIndexSavePolicy::Always,
+            |archives| {
+                let record = archives.runs.entry(run_id).or_default();
+                record.archived_at = Some(now_timestamp());
+                record.archive_reason = Some(ARCHIVE_REASON_MANUAL.to_string());
+                Ok(())
+            },
+        )
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))?
+}
+
+#[tauri::command]
+pub async fn restore_workspace_workflow_run(
+    app_state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    worktree_path: String,
+    run_id: String,
+) -> Result<(), String> {
+    let data_dir = resolve_data_dir(&app)?;
+    let run_id = RunId::new(run_id).map_err(|e| e.to_string())?;
+    let workflow_usecase = app_state.workflow_usecase.clone();
+    let run_id_string = run_id.to_string();
+    let authorized = tokio::task::spawn_blocking(move || {
+        workflow_usecase
+            .authorize_run_summary_for_worktree(&run_id_string, &worktree_path)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))??;
+    if authorized.is_none() {
+        return Err(format!("Workflow run not found: {run_id}"));
+    }
+
+    let archive_index_lock = app_state.workflow_archive_index_lock.clone();
+    let run_id = run_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        with_workflow_archive_index(
+            &archive_index_lock,
+            &data_dir,
+            WorkflowArchiveIndexSavePolicy::Always,
+            |archives| {
+                let record = archives.runs.entry(run_id).or_default();
+                record.archived_at = None;
+                record.archive_reason = None;
+                record.restored_at = Some(now_timestamp());
+                Ok(())
+            },
+        )
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))?
+}
+
+fn project_workspace_tree_nodes(
+    sessions: Vec<SessionSummary>,
+    runs: Vec<WorkflowRunSummary>,
+    states: HashMap<String, Option<WorkflowStateSnapshot>>,
+    archives: &mut WorkflowRunArchiveIndex,
+    now: f64,
+) -> Vec<WorkspaceTreeNodeDto> {
+    let mut direct_sessions = Vec::new();
+    let mut workflow_sessions: HashMap<String, SessionSummary> = HashMap::new();
+
+    for session in sessions {
+        if session.workflow_step_session {
+            workflow_sessions.insert(session.id.clone(), session);
+        } else {
+            direct_sessions.push(session_node(session, None, None));
+        }
+    }
+
+    direct_sessions.sort_by(compare_session_nodes);
+
+    let mut workflow_nodes: Vec<WorkspaceWorkflowNodeDto> = runs
+        .into_iter()
+        .filter_map(|run| {
+            let step_refs = states
+                .get(&run.run_id)
+                .and_then(|state| state.as_ref())
+                .map(collect_step_session_refs)
+                .unwrap_or_default();
+            let node = workflow_node(run.clone(), &workflow_sessions, step_refs);
+            apply_auto_archive_if_needed(&run, &node, archives, now);
+            if is_workflow_archived(&run.run_id, archives) {
+                None
+            } else {
+                Some(node)
+            }
+        })
+        .collect();
+
+    workflow_nodes.sort_by(|a, b| compare_titles(&a.title, &b.title));
+
+    direct_sessions
+        .into_iter()
+        .map(WorkspaceTreeNodeDto::Session)
+        .chain(
+            workflow_nodes
+                .into_iter()
+                .map(WorkspaceTreeNodeDto::Workflow),
+        )
+        .collect()
+}
+
+fn workflow_node(
+    run: WorkflowRunSummary,
+    workflow_sessions: &HashMap<String, SessionSummary>,
+    step_refs: Vec<StepSessionRef>,
+) -> WorkspaceWorkflowNodeDto {
+    let mut children = step_refs
+        .into_iter()
+        .filter_map(|step_ref| {
+            workflow_sessions
+                .get(&step_ref.session_id)
+                .cloned()
+                .map(|session| session_node(session, Some(step_ref.step_name), step_ref.run_index))
+        })
+        .collect::<Vec<_>>();
+    children.sort_by(compare_session_nodes);
+
+    WorkspaceWorkflowNodeDto {
+        run_id: run.run_id.clone(),
+        worktree_path: run.worktree_path.clone(),
+        title: workflow_title(&run),
+        status: run_status_label(run.status).to_string(),
+        updated_at: run.updated_at,
+        children,
+    }
+}
+
+fn project_workspace_workflow_history(
+    sessions: Vec<SessionSummary>,
+    runs: Vec<WorkflowRunSummary>,
+    states: HashMap<String, Option<WorkflowStateSnapshot>>,
+    archives: &mut WorkflowRunArchiveIndex,
+    now: f64,
+) -> Vec<WorkspaceWorkflowHistoryItemDto> {
+    let workflow_sessions = sessions
+        .into_iter()
+        .filter(|session| session.workflow_step_session)
+        .map(|session| (session.id.clone(), session))
+        .collect::<HashMap<_, _>>();
+
+    let mut history = runs
+        .into_iter()
+        .filter_map(|run| {
+            let step_refs = states
+                .get(&run.run_id)
+                .and_then(|state| state.as_ref())
+                .map(collect_step_session_refs)
+                .unwrap_or_default();
+            let node = workflow_node(run.clone(), &workflow_sessions, step_refs);
+            apply_auto_archive_if_needed(&run, &node, archives, now);
+            let record = archives.runs.get(&run.run_id)?;
+            let archived_at = record.archived_at?;
+            Some(WorkspaceWorkflowHistoryItemDto {
+                run_id: node.run_id,
+                worktree_path: node.worktree_path,
+                title: node.title,
+                status: node.status,
+                updated_at: node.updated_at,
+                archived_at,
+                archive_reason: record
+                    .archive_reason
+                    .clone()
+                    .unwrap_or_else(|| ARCHIVE_REASON_MANUAL.to_string()),
+                children: node.children,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    history.sort_by(|a, b| {
+        b.archived_at
+            .partial_cmp(&a.archived_at)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| compare_titles(&a.title, &b.title))
+            .then_with(|| a.run_id.cmp(&b.run_id))
+    });
+    history
+}
+
+fn apply_auto_archive_if_needed(
+    run: &WorkflowRunSummary,
+    node: &WorkspaceWorkflowNodeDto,
+    archives: &mut WorkflowRunArchiveIndex,
+    now: f64,
+) {
+    if !run.status.is_terminal() || !node.children.is_empty() {
+        return;
+    }
+    let record = archives.runs.entry(run.run_id.clone()).or_default();
+    if record.restored_at.is_some() || record.archived_at.is_some() {
+        return;
+    }
+    record.archived_at = Some(now);
+    record.archive_reason = Some(ARCHIVE_REASON_AUTO_NO_SESSIONS.to_string());
+}
+
+fn is_workflow_archived(run_id: &str, archives: &WorkflowRunArchiveIndex) -> bool {
+    archives
+        .runs
+        .get(run_id)
+        .and_then(|record| record.archived_at)
+        .is_some()
+}
+
+fn session_node(
+    session: SessionSummary,
+    step_name: Option<String>,
+    run_index: Option<u32>,
+) -> WorkspaceSessionNodeDto {
+    let title = step_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            let first_message = session.first_message.trim();
+            (!first_message.is_empty()).then(|| first_message.to_string())
+        })
+        .unwrap_or_else(|| DEFAULT_SESSION_TITLE.to_string());
+
+    WorkspaceSessionNodeDto {
+        id: session.id,
+        worktree_path: session.worktree_path,
+        title,
+        state: session.state,
+        updated_at: session.updated_at,
+        workflow_step_session: session.workflow_step_session,
+        step_name,
+        run_index,
+    }
+}
+
+fn workflow_title(run: &WorkflowRunSummary) -> String {
+    run.task
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            let workflow_name = run.workflow_name.trim();
+            if workflow_name.is_empty() {
+                run.run_id.clone()
+            } else {
+                workflow_name.to_string()
+            }
+        })
+}
+
+fn collect_step_session_refs(state: &WorkflowStateSnapshot) -> Vec<StepSessionRef> {
+    let mut refs = Vec::new();
+    if let Some(session_id) = state.current_session_id.as_ref() {
+        refs.push(StepSessionRef {
+            session_id: session_id.clone(),
+            step_name: state.current_step_name.clone(),
+            run_index: state
+                .step_execution_counts
+                .get(&state.current_step_name)
+                .copied()
+                .or(Some(1)),
+        });
+    }
+    for entry in &state.step_history {
+        if let Some(session_id) = entry.session_id.as_ref() {
+            refs.push(StepSessionRef {
+                session_id: session_id.clone(),
+                step_name: entry.step_name.clone(),
+                run_index: Some(entry.run_index),
+            });
+        }
+        if let Some(children) = entry.child_outputs.as_ref() {
+            refs.extend(children.iter().filter_map(|child| {
+                child.session_id.as_ref().map(|session_id| StepSessionRef {
+                    session_id: session_id.clone(),
+                    step_name: child.step_name.clone(),
+                    run_index: Some(child.run_index),
+                })
+            }));
+        }
+    }
+    refs.extend(state.active_parallel_steps.iter().filter_map(|step| {
+        step.session_id.as_ref().map(|session_id| StepSessionRef {
+            session_id: session_id.clone(),
+            step_name: step.step_name.clone(),
+            run_index: Some(step.run_index),
+        })
+    }));
+    refs.sort_by(|a, b| {
+        compare_titles(&a.step_name, &b.step_name)
+            .then_with(|| a.run_index.cmp(&b.run_index))
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    });
+    refs.dedup_by(|a, b| a.session_id == b.session_id);
+    refs
+}
+
+fn compare_session_nodes(
+    a: &WorkspaceSessionNodeDto,
+    b: &WorkspaceSessionNodeDto,
+) -> std::cmp::Ordering {
+    compare_titles(&a.title, &b.title).then_with(|| a.id.cmp(&b.id))
+}
+
+fn compare_titles(a: &str, b: &str) -> std::cmp::Ordering {
+    a.to_lowercase()
+        .cmp(&b.to_lowercase())
+        .then_with(|| a.cmp(b))
+}
+
+fn run_status_label(status: RunStatus) -> &'static str {
+    match status {
+        RunStatus::Running => STEP_STATE_RUNNING,
+        RunStatus::WaitingApproval => "waiting_approval",
+        RunStatus::Completed => "completed",
+        RunStatus::Failed => "failed",
+        RunStatus::Aborted => "aborted",
+    }
+}
+
+fn workflow_archive_index_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(WORKFLOW_ARCHIVES_FILE)
+}
+
+fn load_workflow_archive_index(data_dir: &Path) -> Result<WorkflowRunArchiveIndex, String> {
+    let path = workflow_archive_index_path(data_dir);
+    match fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse workflow run archives: {e}")),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Ok(WorkflowRunArchiveIndex::default())
+        }
+        Err(e) => Err(format!("Failed to read workflow run archives: {e}")),
+    }
+}
+
+fn with_workflow_archive_index<R>(
+    lock: &tokio::sync::Mutex<()>,
+    data_dir: &Path,
+    save_policy: WorkflowArchiveIndexSavePolicy,
+    update: impl FnOnce(&mut WorkflowRunArchiveIndex) -> Result<R, String>,
+) -> Result<R, String> {
+    let _guard = lock.blocking_lock();
+    let mut archives = load_workflow_archive_index(data_dir)?;
+    let original = if save_policy == WorkflowArchiveIndexSavePolicy::IfChanged {
+        Some(archives.clone())
+    } else {
+        None
+    };
+    let result = update(&mut archives)?;
+    match original {
+        Some(original) => {
+            save_workflow_archive_index_if_changed(data_dir, &original, &archives)?;
+        }
+        None => save_workflow_archive_index(data_dir, &archives)?,
+    }
+    Ok(result)
+}
+
+fn save_workflow_archive_index_if_changed(
+    data_dir: &Path,
+    original: &WorkflowRunArchiveIndex,
+    updated: &WorkflowRunArchiveIndex,
+) -> Result<bool, String> {
+    if original == updated {
+        return Ok(false);
+    }
+    save_workflow_archive_index(data_dir, updated)?;
+    Ok(true)
+}
+
+fn save_workflow_archive_index(
+    data_dir: &Path,
+    index: &WorkflowRunArchiveIndex,
+) -> Result<(), String> {
+    fs::create_dir_all(data_dir)
+        .map_err(|e| format!("Failed to create app data directory: {e}"))?;
+    let path = workflow_archive_index_path(data_dir);
+    let json = serde_json::to_string_pretty(index)
+        .map_err(|e| format!("Failed to serialize workflow run archives: {e}"))?;
+    atomic_write(&path, &json).map_err(|e| format!("Failed to write workflow run archives: {e}"))
+}
+
+fn atomic_write(path: &Path, content: &str) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no parent")
+    })?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no file name")
+        })?;
+    fs::create_dir_all(parent)?;
+    let tmp = parent.join(format!(".{file_name}.{}.tmp", uuid::Uuid::new_v4()));
+    fs::write(&tmp, content)?;
+    fs::rename(tmp, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::workflow::{
+        ChildOutputSnapshot, ParallelStepState, TriggerSource, WorkflowDefinition,
+        WorkflowExecutionState, STEP_STATE_COMPLETED,
+    };
+    use std::collections::HashMap;
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    fn session(id: &str, title: &str, workflow_step_session: bool) -> SessionSummary {
+        SessionSummary {
+            id: id.to_string(),
+            worktree_path: "/repo/wt".to_string(),
+            state: SessionState::Active,
+            created_at: 1.0,
+            updated_at: 2.0,
+            first_message: title.to_string(),
+            message_count: 1,
+            agent_session_id: None,
+            context_carry: None,
+            permission_mode: "edit".to_string(),
+            plan_mode: false,
+            permission_profile_id: None,
+            backend_id: None,
+            workflow_step_session,
+        }
+    }
+
+    fn run(run_id: &str, task: &str) -> WorkflowRunSummary {
+        run_with_status(run_id, task, RunStatus::Running)
+    }
+
+    fn run_with_status(run_id: &str, task: &str, status: RunStatus) -> WorkflowRunSummary {
+        WorkflowRunSummary {
+            run_id: run_id.to_string(),
+            workflow_name: "wf".to_string(),
+            task: Some(task.to_string()),
+            status,
+            worktree_path: "/repo/wt".to_string(),
+            current_node_name: Some("build".to_string()),
+            trigger_source: TriggerSource::DesktopUi,
+            started_at: 1.0,
+            updated_at: 3.0,
+            completed_at: None,
+            error_reason: None,
+        }
+    }
+
+    fn state(run_id: &str) -> WorkflowStateSnapshot {
+        WorkflowStateSnapshot {
+            execution_id: run_id.to_string(),
+            workflow_name: "wf".to_string(),
+            state: WorkflowExecutionState::Running,
+            current_step_index: 0,
+            current_step_name: "build".to_string(),
+            current_session_id: Some("step-build".to_string()),
+            total_steps: 2,
+            step_history: vec![crate::domain::workflow::StepHistoryEntry {
+                step_name: "plan".to_string(),
+                completed_at: 1.0,
+                result: None,
+                session_id: Some("step-plan".to_string()),
+                token_usage: None,
+                structured_output: None,
+                run_index: 1,
+                child_outputs: Some(vec![ChildOutputSnapshot {
+                    step_name: "child-review".to_string(),
+                    session_id: Some("step-child".to_string()),
+                    result: None,
+                    run_index: 2,
+                    completed_at: 2.0,
+                    structured_output: None,
+                    output_contract: None,
+                    state: STEP_STATE_COMPLETED.to_string(),
+                }]),
+                state: STEP_STATE_COMPLETED.to_string(),
+            }],
+            step_execution_counts: HashMap::from([("build".to_string(), 3)]),
+            workflow_definition: WorkflowDefinition {
+                name: "wf".to_string(),
+                description: String::new(),
+                builtin: false,
+                variables: HashMap::new(),
+                nodes: Vec::new(),
+            },
+            total_token_usage: Default::default(),
+            step_states: HashMap::new(),
+            step_outputs: HashMap::new(),
+            active_parallel_steps: vec![ParallelStepState {
+                step_name: "parallel-lint".to_string(),
+                state: STEP_STATE_RUNNING.to_string(),
+                session_id: Some("step-parallel".to_string()),
+                result: None,
+                run_index: 1,
+                completed_at: None,
+                structured_output: None,
+                output_contract: None,
+            }],
+            workflow_variables: HashMap::new(),
+            approval_operations: None,
+            started_at: 1.0,
+            updated_at: 2.0,
+        }
+    }
+
+    #[test]
+    fn projects_direct_sessions_before_workflows_and_sorts_by_title() {
+        let mut archives = WorkflowRunArchiveIndex::default();
+        let nodes = project_workspace_tree_nodes(
+            vec![
+                session("b", "Zulu", false),
+                session("a", "Alpha", false),
+                session("step-build", "ignored", true),
+            ],
+            vec![run("run-1", "Implement")],
+            HashMap::from([("run-1".to_string(), Some(state("run-1")))]),
+            &mut archives,
+            10.0,
+        );
+
+        assert!(matches!(&nodes[0], WorkspaceTreeNodeDto::Session(node) if node.title == "Alpha"));
+        assert!(matches!(&nodes[1], WorkspaceTreeNodeDto::Session(node) if node.title == "Zulu"));
+        assert!(
+            matches!(&nodes[2], WorkspaceTreeNodeDto::Workflow(node) if node.title == "Implement")
+        );
+    }
+
+    #[test]
+    fn empty_direct_session_uses_default_new_session_title() {
+        let mut archives = WorkflowRunArchiveIndex::default();
+        let nodes = project_workspace_tree_nodes(
+            vec![session("empty", "", false)],
+            vec![],
+            HashMap::new(),
+            &mut archives,
+            10.0,
+        );
+
+        assert!(
+            matches!(&nodes[0], WorkspaceTreeNodeDto::Session(node) if node.title == DEFAULT_SESSION_TITLE)
+        );
+    }
+
+    #[test]
+    fn maps_workflow_step_sessions_to_their_parent_run_with_step_titles() {
+        let mut archives = WorkflowRunArchiveIndex::default();
+        let nodes = project_workspace_tree_nodes(
+            vec![
+                session("step-plan", "old plan title", true),
+                session("step-build", "old build title", true),
+                session("step-child", "old child title", true),
+                session("step-parallel", "old parallel title", true),
+                session("unmatched-step", "orphan", true),
+            ],
+            vec![run("run-1", "Implement")],
+            HashMap::from([("run-1".to_string(), Some(state("run-1")))]),
+            &mut archives,
+            10.0,
+        );
+
+        let WorkspaceTreeNodeDto::Workflow(workflow) = &nodes[0] else {
+            panic!("expected workflow node");
+        };
+        let titles = workflow
+            .children
+            .iter()
+            .map(|child| child.title.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            titles,
+            vec!["build", "child-review", "parallel-lint", "plan"]
+        );
+        assert!(workflow
+            .children
+            .iter()
+            .any(|child| child.id == "step-build" && child.run_index == Some(3)));
+        assert!(!workflow
+            .children
+            .iter()
+            .any(|child| child.id == "unmatched-step"));
+    }
+
+    #[test]
+    fn auto_archives_terminal_workflow_without_sessions() {
+        let mut archives = WorkflowRunArchiveIndex::default();
+        let nodes = project_workspace_tree_nodes(
+            vec![],
+            vec![run_with_status(
+                "run-1",
+                "Done without sessions",
+                RunStatus::Completed,
+            )],
+            HashMap::new(),
+            &mut archives,
+            20.0,
+        );
+
+        assert!(nodes.is_empty());
+        let record = archives.runs.get("run-1").expect("archive record");
+        assert_eq!(record.archived_at, Some(20.0));
+        assert_eq!(
+            record.archive_reason.as_deref(),
+            Some(ARCHIVE_REASON_AUTO_NO_SESSIONS)
+        );
+    }
+
+    #[test]
+    fn restored_terminal_workflow_without_sessions_stays_visible() {
+        let mut archives = WorkflowRunArchiveIndex {
+            runs: BTreeMap::from([(
+                "run-1".to_string(),
+                WorkflowRunArchiveRecord {
+                    restored_at: Some(15.0),
+                    ..Default::default()
+                },
+            )]),
+        };
+        let nodes = project_workspace_tree_nodes(
+            vec![],
+            vec![run_with_status("run-1", "Restored", RunStatus::Completed)],
+            HashMap::new(),
+            &mut archives,
+            20.0,
+        );
+
+        assert!(
+            matches!(&nodes[0], WorkspaceTreeNodeDto::Workflow(node) if node.run_id == "run-1")
+        );
+        assert_eq!(archives.runs["run-1"].archived_at, None);
+    }
+
+    #[test]
+    fn manual_archive_hides_workflow_until_restored() {
+        let mut archives = WorkflowRunArchiveIndex {
+            runs: BTreeMap::from([(
+                "run-1".to_string(),
+                WorkflowRunArchiveRecord {
+                    archived_at: Some(15.0),
+                    archive_reason: Some(ARCHIVE_REASON_MANUAL.to_string()),
+                    restored_at: Some(10.0),
+                },
+            )]),
+        };
+        let nodes = project_workspace_tree_nodes(
+            vec![session("step-build", "old build title", true)],
+            vec![run("run-1", "Manual")],
+            HashMap::from([("run-1".to_string(), Some(state("run-1")))]),
+            &mut archives,
+            20.0,
+        );
+
+        assert!(nodes.is_empty());
+        let history = project_workspace_workflow_history(
+            vec![session("step-build", "old build title", true)],
+            vec![run("run-1", "Manual")],
+            HashMap::from([("run-1".to_string(), Some(state("run-1")))]),
+            &mut archives,
+            20.0,
+        );
+        assert_eq!(history[0].run_id, "run-1");
+        assert_eq!(history[0].archive_reason, ARCHIVE_REASON_MANUAL);
+    }
+
+    #[test]
+    fn unchanged_archive_index_is_not_saved() {
+        let temp = tempfile::tempdir().unwrap();
+        let original = WorkflowRunArchiveIndex::default();
+
+        let saved =
+            save_workflow_archive_index_if_changed(temp.path(), &original, &original).unwrap();
+
+        assert!(!saved);
+        assert!(!workflow_archive_index_path(temp.path()).exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn archive_index_lock_preserves_concurrent_list_refresh_and_manual_archive_updates() {
+        let temp = tempfile::tempdir().unwrap();
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        let (loaded_tx, loaded_rx) = mpsc::channel();
+
+        let list_lock = lock.clone();
+        let list_data_dir = temp.path().to_path_buf();
+        let list_refresh = tokio::task::spawn_blocking(move || {
+            with_workflow_archive_index(
+                &list_lock,
+                &list_data_dir,
+                WorkflowArchiveIndexSavePolicy::IfChanged,
+                |archives| {
+                    loaded_tx.send(()).expect("list load signal");
+                    std::thread::sleep(Duration::from_millis(50));
+                    let record = archives.runs.entry("auto-run".to_string()).or_default();
+                    record.archived_at = Some(20.0);
+                    record.archive_reason = Some(ARCHIVE_REASON_AUTO_NO_SESSIONS.to_string());
+                    Ok(())
+                },
+            )
+        });
+
+        loaded_rx.recv().expect("list refresh loaded index");
+
+        let manual_lock = lock.clone();
+        let manual_data_dir = temp.path().to_path_buf();
+        let manual_archive = tokio::task::spawn_blocking(move || {
+            with_workflow_archive_index(
+                &manual_lock,
+                &manual_data_dir,
+                WorkflowArchiveIndexSavePolicy::Always,
+                |archives| {
+                    let record = archives.runs.entry("manual-run".to_string()).or_default();
+                    record.archived_at = Some(30.0);
+                    record.archive_reason = Some(ARCHIVE_REASON_MANUAL.to_string());
+                    Ok(())
+                },
+            )
+        });
+
+        list_refresh.await.unwrap().unwrap();
+        manual_archive.await.unwrap().unwrap();
+
+        let archives = load_workflow_archive_index(temp.path()).unwrap();
+        assert_eq!(
+            archives.runs["auto-run"].archive_reason.as_deref(),
+            Some(ARCHIVE_REASON_AUTO_NO_SESSIONS)
+        );
+        assert_eq!(
+            archives.runs["manual-run"].archive_reason.as_deref(),
+            Some(ARCHIVE_REASON_MANUAL)
+        );
+    }
+}

--- a/src-tauri/src/adaptor/controller/state.rs
+++ b/src-tauri/src/adaptor/controller/state.rs
@@ -15,4 +15,5 @@ pub struct AppState {
     pub repo_paths_usecase: Arc<RepoPathsUsecase>,
     pub code_usecase: Arc<CodeUsecase>,
     pub workflow_usecase: Arc<WorkflowUsecase>,
+    pub workflow_archive_index_lock: Arc<tokio::sync::Mutex<()>>,
 }

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -6018,6 +6018,7 @@ mod dispatch_boundary_tests {
                 repo_paths_usecase,
                 code_usecase,
                 workflow_usecase,
+                workflow_archive_index_lock: Arc::new(tokio::sync::Mutex::new(())),
             })
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("tauri mock test app must build")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,7 @@ pub fn run() {
                     repo_paths_usecase,
                     code_usecase,
                     workflow_usecase,
+                    workflow_archive_index_lock: Arc::new(tokio::sync::Mutex::new(())),
                 });
             }
 

--- a/src-tauri/src/usecase/repository_query_service.rs
+++ b/src-tauri/src/usecase/repository_query_service.rs
@@ -37,7 +37,9 @@ impl RepositoryQueryService {
         &self,
         repo_path: &str,
     ) -> Result<Vec<BranchCardDto>, UsecaseError> {
-        Ok(self.branch_card_query.list_branch_cards(repo_path)?)
+        let mut cards = self.branch_card_query.list_branch_cards(repo_path)?;
+        cards.sort_by_key(|card| !card.is_main_worktree);
+        Ok(cards)
     }
 }
 
@@ -73,5 +75,58 @@ mod repository_query_service_tests {
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].name, "main");
         assert!(cards[0].is_main_worktree);
+    }
+
+    struct FakeUnsortedBranchCards;
+
+    impl BranchCardQuery for FakeUnsortedBranchCards {
+        fn list_branch_cards(
+            &self,
+            _repo_path: &str,
+        ) -> Result<Vec<BranchCardDto>, RepositoryError> {
+            Ok(vec![
+                BranchCardDto {
+                    name: "feature-a".to_string(),
+                    is_main_worktree: false,
+                    worktree_path: Some("/repo-worktrees/feature-a".to_string()),
+                    dirty_count: 0,
+                    is_merged: false,
+                    ahead: 0,
+                    behind: 0,
+                    has_upstream: false,
+                    base_ahead: 0,
+                },
+                BranchCardDto {
+                    name: "main".to_string(),
+                    is_main_worktree: true,
+                    worktree_path: Some("/repo".to_string()),
+                    dirty_count: 0,
+                    is_merged: false,
+                    ahead: 0,
+                    behind: 0,
+                    has_upstream: false,
+                    base_ahead: 0,
+                },
+                BranchCardDto {
+                    name: "feature-b".to_string(),
+                    is_main_worktree: false,
+                    worktree_path: Some("/repo-worktrees/feature-b".to_string()),
+                    dirty_count: 0,
+                    is_merged: false,
+                    ahead: 0,
+                    behind: 0,
+                    has_upstream: false,
+                    base_ahead: 0,
+                },
+            ])
+        }
+    }
+
+    #[test]
+    fn test_main_worktreeを先頭に正規化する() {
+        let service = RepositoryQueryService::new(Arc::new(FakeUnsortedBranchCards));
+        let cards = service.list_branches_with_status("/repo").unwrap();
+        let names: Vec<&str> = cards.iter().map(|card| card.name.as_str()).collect();
+        assert_eq!(names, vec!["main", "feature-a", "feature-b"]);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,10 @@ import { useWorkspaceNavigation } from "@/hooks/useWorkspaceNavigation";
 import { setTelemetryEnabled } from "@/lib/telemetry";
 import { MainLayout } from "@/screens/MainLayout";
 import type { ProviderStatus, WorktreeEntry } from "@/types/git";
+import type {
+	CenterSelection,
+	CenterSelectionRequest,
+} from "@/types/workspace-tree";
 
 function App() {
 	const { settings, updateSettings, updateTheme } = useSettings();
@@ -26,6 +30,8 @@ function App() {
 		Record<string, ProviderStatus | null>
 	>({});
 	const [showAppSettings, setShowAppSettings] = useState(false);
+	const [centerSelectionRequest, setCenterSelectionRequest] =
+		useState<CenterSelectionRequest | null>(null);
 
 	useEffect(() => {
 		setTelemetryEnabled(settings.telemetryEnabled);
@@ -105,10 +111,41 @@ function App() {
 	}, [addRepo, openWorktreeTab]);
 
 	const handleSelectWorktree = useCallback(
-		(rootPath: string, branchName?: string, repoName?: string) => {
+		(
+			rootPath: string,
+			branchName?: string,
+			repoName?: string,
+			centerSelection?: CenterSelection,
+		) => {
 			openWorktreeTab(rootPath, branchName, repoName);
+			if (centerSelection) {
+				setCenterSelectionRequest((prev) => ({
+					...centerSelection,
+					requestId: (prev?.requestId ?? 0) + 1,
+					branchName,
+					repoName,
+				}));
+			}
 		},
 		[openWorktreeTab],
+	);
+
+	const handleCenterSelectionResolved = useCallback(
+		(centerSelection: CenterSelection) => {
+			setCenterSelectionRequest((prev) => ({
+				...centerSelection,
+				requestId: (prev?.requestId ?? 0) + 1,
+				branchName:
+					prev?.worktreePath === centerSelection.worktreePath
+						? prev.branchName
+						: undefined,
+				repoName:
+					prev?.worktreePath === centerSelection.worktreePath
+						? prev.repoName
+						: undefined,
+			}));
+		},
+		[],
 	);
 
 	const isWorktreeActive = selectedWorktreeId != null;
@@ -142,12 +179,19 @@ function App() {
 			<WorkspaceList
 				repoPaths={repoPaths}
 				selectedRootPath={selectedRootPath}
+				centerSelection={centerSelectionRequest}
 				onSelectWorktree={handleSelectWorktree}
 				onAddRepo={handleAddRepo}
 				onShowSettings={() => setShowAppSettings(true)}
 			/>
 		),
-		[repoPaths, selectedRootPath, handleSelectWorktree, handleAddRepo],
+		[
+			repoPaths,
+			selectedRootPath,
+			centerSelectionRequest,
+			handleSelectWorktree,
+			handleAddRepo,
+		],
 	);
 
 	return (
@@ -158,6 +202,8 @@ function App() {
 				settings={settings}
 				onSettingsSave={updateSettings}
 				leftNav={leftNav}
+				centerSelectionRequest={centerSelectionRequest}
+				onCenterSelectionResolved={handleCenterSelectionResolved}
 			/>
 
 			{/* App Settings */}

--- a/src/components/layout/ViewToolbar.test.tsx
+++ b/src/components/layout/ViewToolbar.test.tsx
@@ -3,13 +3,11 @@ import userEvent from "@testing-library/user-event";
 import { PanelLeft } from "lucide-react";
 import { describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { type CenterMode, type TogglePanel, ViewToolbar } from "./ViewToolbar";
+import { type TogglePanel, ViewToolbar } from "./ViewToolbar";
 
 function renderToolbar(props: {
 	leftPanels?: TogglePanel[];
 	rightSlot?: React.ReactNode;
-	mode?: CenterMode;
-	onModeChange?: (mode: CenterMode) => void;
 }) {
 	return render(
 		<TooltipProvider>
@@ -80,32 +78,7 @@ describe("ViewToolbar", () => {
 		expect(screen.getByTestId("branch")).toBeInTheDocument();
 	});
 
-	// spec issues-1023: 中央エリアの AgentChat / Workflow 切替は ViewToolbar 上の
-	// セグメントコントロールで操作する。
-	it("renders center mode switch when mode and onModeChange are provided", () => {
-		renderToolbar({ mode: "agent", onModeChange: vi.fn() });
-
-		expect(screen.getByTestId("center-mode-switch")).toBeInTheDocument();
-		expect(screen.getByLabelText("Agent mode")).toHaveAttribute(
-			"aria-pressed",
-			"true",
-		);
-		expect(screen.getByLabelText("Workflow mode")).toHaveAttribute(
-			"aria-pressed",
-			"false",
-		);
-	});
-
-	it("calls onModeChange when switching to Workflow", async () => {
-		const user = userEvent.setup();
-		const onModeChange = vi.fn();
-		renderToolbar({ mode: "agent", onModeChange });
-
-		await user.click(screen.getByLabelText("Workflow mode"));
-		expect(onModeChange).toHaveBeenCalledWith("workflow");
-	});
-
-	it("does not render center mode switch when mode props are omitted", () => {
+	it("does not render the removed Agent / Workflow mode switch", () => {
 		renderToolbar({});
 		expect(screen.queryByTestId("center-mode-switch")).toBeNull();
 		expect(screen.queryByLabelText("Agent mode")).toBeNull();

--- a/src/components/layout/ViewToolbar.tsx
+++ b/src/components/layout/ViewToolbar.tsx
@@ -1,4 +1,4 @@
-import { type LucideIcon, MessageSquare, Workflow } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
 	Tooltip,
@@ -15,31 +15,12 @@ export interface TogglePanel {
 	onToggle: () => void;
 }
 
-/**
- * spec issues-1023: 中央エリアの表示モード。
- * Agent は既存の AgentChat、Workflow は workflow run 観測の Command Center。
- */
-export type CenterMode = "agent" | "workflow";
-
-const MODES: { value: CenterMode; label: string; icon: LucideIcon }[] = [
-	{ value: "agent", label: "Agent", icon: MessageSquare },
-	{ value: "workflow", label: "Workflow", icon: Workflow },
-];
-
 interface ViewToolbarProps {
 	leftPanels?: TogglePanel[];
 	rightSlot?: React.ReactNode;
-	mode?: CenterMode;
-	onModeChange?: (mode: CenterMode) => void;
 }
 
-export function ViewToolbar({
-	leftPanels,
-	rightSlot,
-	mode,
-	onModeChange,
-}: ViewToolbarProps) {
-	const showModeSwitch = mode !== undefined && onModeChange !== undefined;
+export function ViewToolbar({ leftPanels, rightSlot }: ViewToolbarProps) {
 	return (
 		<div
 			data-tauri-drag-region
@@ -67,39 +48,6 @@ export function ViewToolbar({
 					<TooltipContent side="bottom">{panel.label}</TooltipContent>
 				</Tooltip>
 			))}
-			{showModeSwitch && (
-				<div
-					data-testid="center-mode-switch"
-					className="flex items-center gap-0.5 rounded bg-muted p-0.5 ml-1"
-				>
-					{MODES.map((m) => {
-						const Icon = m.icon;
-						const active = mode === m.value;
-						return (
-							<Tooltip key={m.value}>
-								<TooltipTrigger asChild>
-									<Button
-										variant="ghost"
-										size="icon"
-										aria-label={`${m.label} mode`}
-										aria-pressed={active}
-										onClick={() => onModeChange?.(m.value)}
-										className={cn(
-											"h-5 w-6",
-											active
-												? "bg-background text-foreground shadow-sm"
-												: "text-muted-foreground hover:text-foreground",
-										)}
-									>
-										<Icon className="size-3.5" />
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent side="bottom">{m.label}</TooltipContent>
-							</Tooltip>
-						);
-					})}
-				</div>
-			)}
 			<div data-tauri-drag-region className="flex-1" />
 			{rightSlot}
 		</div>

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.test.tsx
@@ -4,7 +4,6 @@ import {
 	render,
 	screen,
 	waitFor,
-	within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -274,7 +273,7 @@ describe("AgentChatPanel", () => {
 		expect(screen.getByTestId("agent-chat-panel")).toBeDefined();
 	});
 
-	it("has data-tauri-drag-region attribute for window dragging", () => {
+	it("does not own a draggable tab/header region", () => {
 		mockUseAgentChat();
 		const { container } = render(
 			<AgentChatPanel
@@ -284,7 +283,7 @@ describe("AgentChatPanel", () => {
 		);
 
 		const dragRegion = container.querySelector("[data-tauri-drag-region]");
-		expect(dragRegion).toBeInTheDocument();
+		expect(dragRegion).toBeNull();
 	});
 
 	it("shows a context restore warning for failed active sessions", () => {
@@ -1269,165 +1268,75 @@ describe("AgentChatPanel", () => {
 	});
 });
 
-describe("AgentChatPanel session tabs", () => {
-	it("renders a tab for each session with firstMessage as label", () => {
-		mockUseAgentChat({
-			sessions: [
-				{
-					id: "s1",
-					firstMessage: "Hello",
-					messageCount: 3,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-				{
-					id: "s2",
-					firstMessage: "Fix bug",
-					messageCount: 5,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-			],
-		});
+describe("AgentChatPanel selection requests", () => {
+	it("does not render the removed session tab bar or local session actions", () => {
+		mockUseAgentChat();
 		render(
 			<AgentChatPanel
 				worktreePath="/repo"
 				registerDropZone={mockRegisterDropZone}
 			/>,
 		);
-		expect(screen.getByText("Hello")).toBeDefined();
-		expect(screen.getByText("Fix bug")).toBeDefined();
+		expect(screen.queryByTestId("session-tab-list")).toBeNull();
+		expect(screen.queryByLabelText("New session")).toBeNull();
+		expect(screen.queryByLabelText("Session history")).toBeNull();
 	});
 
-	it("shows 'New session' for sessions without firstMessage", () => {
-		mockUseAgentChat({
-			sessions: [
-				{
-					id: "s1",
-					firstMessage: "",
-					messageCount: 0,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-			],
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-		expect(screen.getByText("New session")).toBeDefined();
-	});
-
-	it("does not show X button when only one session", () => {
-		mockUseAgentChat({
-			sessions: [
-				{
-					id: "s1",
-					firstMessage: "Hello",
-					messageCount: 3,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-			],
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-		expect(screen.queryByLabelText("Close Hello")).toBeNull();
-	});
-
-	it("shows X button when multiple sessions", () => {
-		mockUseAgentChat({
-			sessions: [
-				{
-					id: "s1",
-					firstMessage: "Hello",
-					messageCount: 3,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-				{
-					id: "s2",
-					firstMessage: "Fix bug",
-					messageCount: 5,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-			],
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-		expect(screen.getByLabelText("Close Hello")).toBeDefined();
-		expect(screen.getByLabelText("Close Fix bug")).toBeDefined();
-	});
-
-	it("calls closeSession when X button is clicked", () => {
-		const closeSession = vi.fn();
-		mockUseAgentChat({
-			sessions: [
-				{
-					id: "s1",
-					firstMessage: "Hello",
-					messageCount: 3,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-				{
-					id: "s2",
-					firstMessage: "Fix bug",
-					messageCount: 5,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-			],
-			closeSession,
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-		fireEvent.click(screen.getByLabelText("Close Hello"));
-		expect(closeSession).toHaveBeenCalledWith("s1");
-	});
-
-	it("calls createNewSession when + button is clicked", () => {
+	it("calls createNewSession when newAgentSession selection is requested", () => {
 		const createNewSession = vi.fn();
 		mockUseAgentChat({ createNewSession });
 		render(
 			<AgentChatPanel
 				worktreePath="/repo"
+				selectionRequest={{
+					kind: "newAgentSession",
+					worktreePath: "/repo",
+					requestId: 1,
+				}}
 				registerDropZone={mockRegisterDropZone}
 			/>,
 		);
-		fireEvent.click(screen.getByLabelText("New session"));
 		expect(createNewSession).toHaveBeenCalled();
+	});
+
+	it("reports created session id for newAgentSession selection", async () => {
+		const createNewSession = vi.fn().mockResolvedValue("new-s");
+		const onNewSessionCreated = vi.fn();
+		mockUseAgentChat({ createNewSession });
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				selectionRequest={{
+					kind: "newAgentSession",
+					worktreePath: "/repo",
+					requestId: 1,
+				}}
+				registerDropZone={mockRegisterDropZone}
+				onNewSessionCreated={onNewSessionCreated}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(onNewSessionCreated).toHaveBeenCalledWith("new-s");
+		});
+	});
+
+	it("calls selectSession when agentSession selection is requested", () => {
+		const selectSession = vi.fn();
+		mockUseAgentChat({ selectSession });
+		render(
+			<AgentChatPanel
+				worktreePath="/repo"
+				selectionRequest={{
+					kind: "agentSession",
+					worktreePath: "/repo",
+					sessionId: "s2",
+					requestId: 1,
+				}}
+				registerDropZone={mockRegisterDropZone}
+			/>,
+		);
+		expect(selectSession).toHaveBeenCalledWith("s2");
 	});
 
 	it("enables model selector in the input for an empty active session", () => {
@@ -1570,174 +1479,9 @@ describe("AgentChatPanel session tabs", () => {
 			screen.getByText("GPT-5.4").closest("[role='menuitem']"),
 		).toHaveAttribute("data-disabled");
 	});
-
-	it("calls selectSession when tab is clicked", () => {
-		const selectSession = vi.fn();
-		mockUseAgentChat({
-			sessions: [
-				{
-					id: "s1",
-					firstMessage: "Hello",
-					messageCount: 3,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-				{
-					id: "s2",
-					firstMessage: "Fix bug",
-					messageCount: 5,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-			],
-			selectSession,
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-		// Radix Tabs.Trigger は onMouseDown で value を確定する仕様。
-		// fireEvent.click では Radix の Trigger ハンドラが発火しないため mouseDown を使う。
-		fireEvent.mouseDown(screen.getByText("Fix bug"));
-		expect(selectSession).toHaveBeenCalledWith("s2");
-	});
 });
 
-describe("AgentChatPanel agent state reflection", () => {
-	it("shows AgentStateIcon on tab when session is running", () => {
-		mockUseAgentChat({
-			sessions: [
-				{
-					id: "s1",
-					firstMessage: "Hello",
-					messageCount: 3,
-					worktreePath: "/repo",
-					state: "active",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-			],
-			sessionAgentStates: new Map([["s1", "running"]]),
-			isStreaming: true,
-			activeSession: {
-				id: "s1",
-				worktreePath: "/repo",
-				messages: [
-					{
-						id: "m1",
-						role: "human",
-						parts: [{ type: "text", content: "hello" }],
-						timestamp: 1000,
-					},
-					{
-						id: "m2",
-						role: "agent",
-						parts: [{ type: "text", content: "working..." }],
-						timestamp: 1001,
-					},
-				],
-				state: "active",
-				createdAt: 1000,
-				updatedAt: 1000,
-			},
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-
-		const tab = screen.getByText("Hello").closest("[role='tab']");
-		expect(tab?.querySelector("[title='running']")).not.toBeNull();
-	});
-
-	it("shows AgentStateIcon with waiting state on tab", () => {
-		mockUseAgentChat({
-			sessions: [
-				{
-					id: "s1",
-					firstMessage: "Hello",
-					messageCount: 3,
-					worktreePath: "/repo",
-					state: "active",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-			],
-			sessionAgentStates: new Map([["s1", "waiting"]]),
-			isStreaming: true,
-			pendingPermission: {
-				request_id: "req-001",
-				tool_name: "Edit",
-				input: {},
-				tool_use_id: "toolu_001",
-			},
-			activeSession: {
-				id: "s1",
-				worktreePath: "/repo",
-				messages: [
-					{
-						id: "m1",
-						role: "human",
-						parts: [{ type: "text", content: "hello" }],
-						timestamp: 1000,
-					},
-					{
-						id: "m2",
-						role: "agent",
-						parts: [{ type: "text", content: "editing..." }],
-						timestamp: 1001,
-					},
-				],
-				state: "active",
-				createdAt: 1000,
-				updatedAt: 1000,
-			},
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-
-		const tab = screen.getByText("Hello").closest("[role='tab']");
-		expect(tab?.querySelector("[title='waiting']")).not.toBeNull();
-	});
-
-	it("shows AgentStateIcon with done state on tab when session is idle", () => {
-		mockUseAgentChat({
-			sessions: [
-				{
-					id: "s1",
-					firstMessage: "Hello",
-					messageCount: 3,
-					worktreePath: "/repo",
-					state: "idle",
-					createdAt: 1000,
-					updatedAt: 1000,
-				},
-			],
-			sessionAgentStates: new Map([["s1", "done"]]),
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-
-		const tab = screen.getByText("Hello").closest("[role='tab']");
-		expect(tab?.querySelector("[title='done']")).not.toBeNull();
-	});
-
+describe("AgentChatPanel active session controls", () => {
 	it("reflects permissionMode ask in ModeSelector trigger label", () => {
 		mockUseAgentChat({
 			permissionMode: "ask",
@@ -2689,163 +2433,6 @@ describe("SystemNotificationItem rendering", () => {
 	});
 });
 
-describe("AgentChatPanel session history", () => {
-	it("renders history button", () => {
-		mockUseAgentChat();
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-		expect(screen.getByLabelText("Session history")).toBeDefined();
-	});
-
-	it("shows 'No closed sessions' when closedSessions is empty", () => {
-		mockUseAgentChat();
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-		fireEvent.click(screen.getByLabelText("Session history"));
-		expect(screen.getByText("No closed sessions")).toBeDefined();
-	});
-
-	it("shows closed sessions in popover and calls restoreSession on click", () => {
-		const restoreSession = vi.fn();
-		mockUseAgentChat({
-			closedSessions: [
-				{
-					id: "closed-1",
-					firstMessage: "Old conversation",
-					messageCount: 5,
-					worktreePath: "/repo",
-					state: "closed",
-					createdAt: 500,
-					updatedAt: 500,
-				},
-			],
-			restoreSession,
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-		fireEvent.click(screen.getByLabelText("Session history"));
-		expect(screen.getByText("Old conversation")).toBeDefined();
-		fireEvent.click(screen.getByText("Old conversation"));
-		expect(restoreSession).toHaveBeenCalledWith("closed-1");
-	});
-
-	it("archives a closed session from the history popover", () => {
-		const archiveSession = vi.fn();
-		const restoreSession = vi.fn();
-		mockUseAgentChat({
-			closedSessions: [
-				{
-					id: "closed-1",
-					firstMessage: "Old conversation",
-					messageCount: 5,
-					worktreePath: "/repo",
-					state: "closed",
-					createdAt: 500,
-					updatedAt: 500,
-				},
-			],
-			archiveSession,
-			restoreSession,
-		});
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-
-		fireEvent.click(screen.getByLabelText("Session history"));
-		fireEvent.click(screen.getByLabelText("Archive Old conversation"));
-
-		expect(archiveSession).toHaveBeenCalledWith("closed-1");
-		expect(restoreSession).not.toHaveBeenCalled();
-	});
-
-	it("searches across sessions from history popover and restores a result", async () => {
-		const restoreSession = vi.fn();
-		mockInvoke.mockImplementation((command, args) => {
-			if (command === "search_agent_sessions") {
-				expect(args).toEqual({
-					worktreePath: "/repo",
-					query: "parser",
-					includeWorkflow: false,
-					limit: 20,
-				});
-				return Promise.resolve([
-					{
-						session: {
-							id: "s2",
-							worktreePath: "/repo",
-							state: "closed",
-							createdAt: 1000,
-							updatedAt: 1002,
-							firstMessage: "Fix parser bug",
-							messageCount: 4,
-							permissionMode: "edit",
-						},
-						matchedMessageId: "m2",
-						matchedRole: "agent",
-						snippet: "The parser bug is fixed",
-					},
-				]);
-			}
-			return Promise.resolve([]);
-		});
-		mockUseAgentChat({ restoreSession });
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-
-		fireEvent.click(screen.getByLabelText("Session history"));
-		fireEvent.change(screen.getByLabelText("Search sessions"), {
-			target: { value: "parser" },
-		});
-
-		expect(await screen.findByText("Fix parser bug")).toBeInTheDocument();
-		expect(screen.getByText("The parser bug is fixed")).toBeInTheDocument();
-
-		fireEvent.click(screen.getByText("Fix parser bug"));
-		expect(restoreSession).toHaveBeenCalledWith("s2");
-	});
-
-	it("focuses session search when opened from Cmd+G", async () => {
-		mockUseAgentChat();
-		render(
-			<AgentChatPanel
-				worktreePath="/repo"
-				registerDropZone={mockRegisterDropZone}
-			/>,
-		);
-		await waitFor(() =>
-			expect(mockInvoke).toHaveBeenCalledWith(
-				"get_agent_shortcut_settings",
-				undefined,
-			),
-		);
-
-		const search = await waitFor(async () => {
-			fireEvent.keyDown(window, { key: "g", metaKey: true });
-			return await screen.findByLabelText("Search sessions");
-		});
-		await waitFor(() => expect(search).toHaveFocus());
-	});
-});
-
 describe("AgentChatPanel image drag and drop", () => {
 	const emptyActiveSession = {
 		id: "s1",
@@ -2962,11 +2549,11 @@ describe("AgentChatPanel workflow panel visibility", () => {
 	// AgentChatPanel 自身は context から渡された session 一覧を表示するだけなので、
 	// この特定の挙動は本 panel テストの対象外。Provider 側でカバーする。
 
-	// spec issues-1023: AgentChatPanel は WorkflowPanel をホストしない
-	// （右パネル側 Workflow モードに切り出された）。本パネルでの責務は free chat
-	// session の tab bar 表示と、workflow step session を tab bar から除外することのみ。
+	// spec issues-1023: AgentChatPanel は WorkflowPanel をホストしない。
+	// spec issues-1220: Session 列は Workspace tree に移ったため、AgentChatPanel は
+	// active free chat session の本文だけを表示する。
 
-	it("excludes workflow step sessions from the chat tab bar", () => {
+	it("does not render a session tab bar and does not show workflow step sessions as chat body", () => {
 		useWorkflowStateMock.mockReturnValue({ workflowState: null });
 		mockUseAgentChat({
 			sessions: [
@@ -3006,8 +2593,8 @@ describe("AgentChatPanel workflow panel visibility", () => {
 				registerDropZone={mockRegisterDropZone}
 			/>,
 		);
-		const tabList = screen.getByTestId("session-tab-list");
-		expect(within(tabList).getByText("Free chat")).toBeInTheDocument();
-		expect(within(tabList).queryByText("Workflow step")).toBeNull();
+		expect(screen.queryByTestId("session-tab-list")).toBeNull();
+		expect(screen.queryByText("Workflow step")).toBeNull();
+		expect(screen.getByTestId("message-input")).toBeInTheDocument();
 	});
 });

--- a/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
+++ b/src/components/panels/AgentChatPanel/AgentChatPanel.tsx
@@ -1,8 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
-import { Archive, History, Search, X } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AgentStateIcon } from "@/components/ui/agent-state-icon";
 import {
 	CommandDialog,
 	CommandEmpty,
@@ -12,20 +10,11 @@ import {
 	CommandList,
 	CommandShortcut,
 } from "@/components/ui/command";
-import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from "@/components/ui/popover";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAgentChatContext } from "@/contexts/AgentChatContext";
 import { useDisplayedActiveSession } from "@/hooks/useDisplayedActiveSession";
 import type { DropZoneType } from "@/hooks/useNativeFileDrop";
-import type {
-	AgentEditorSelection,
-	MentionReference,
-	SessionSearchResult,
-} from "@/types/session";
+import type { AgentEditorSelection, MentionReference } from "@/types/session";
+import type { CenterSelectionRequest } from "@/types/workspace-tree";
 import { BoundSessionChat } from "./BoundSessionChat";
 
 interface AgentCommandPaletteItem {
@@ -91,6 +80,7 @@ function commandShortcutLabel(item: AgentCommandPaletteItem): string {
 
 interface AgentChatPanelProps {
 	worktreePath: string;
+	selectionRequest?: CenterSelectionRequest | null;
 	activeEditorPath?: string | null;
 	openEditorPaths?: string[];
 	activeEditorSelection?: AgentEditorSelection | null;
@@ -103,35 +93,26 @@ interface AgentChatPanelProps {
 		((content: string, mentions?: MentionReference[]) => Promise<void>) | null
 	>;
 	onOpenDiffFile?: (filePath: string) => void;
+	onNewSessionCreated?: (sessionId: string) => void;
 }
 
 /**
- * spec issues-1023: 自由対話 chat の panel。タブバーは AgentChatPanel 固有の
- * drag&drop 並べ替え・history popover・新規作成ボタンを持つ。chat 本文と
- * MessageInput は {@link BoundSessionChat} に委譲され、WorkflowView と
- * 同一実装を共有する（issue #1023 「タブ含めて同じ UI で session フィルタだけが違う」設計）。
+ * 自由対話 chat の本文 panel。#1220 以降、Session 一覧・切替・close・history は
+ * Workspace tree の責務であり、ここでは選択済み 1 session だけを表示する。
  */
 export function AgentChatPanel({
 	worktreePath,
+	selectionRequest,
 	activeEditorPath,
 	openEditorPaths,
 	activeEditorSelection,
 	registerDropZone,
 	sendMessageRef,
 	onOpenDiffFile,
+	onNewSessionCreated,
 }: AgentChatPanelProps) {
-	const {
-		orderedSessions,
-		closedSessions,
-		sessionAgentStates,
-		selectSession,
-		closeSession,
-		archiveSession,
-		restoreSession,
-		createNewSession,
-		reorderSessions,
-		refreshClosedSessions,
-	} = useAgentChatContext();
+	const { orderedSessions, selectSession, createNewSession } =
+		useAgentChatContext();
 
 	// spec issues-1023: workflow step として起動された chat session は
 	// 自由対話 chat tab と同格に tab bar 上に並べない。観測経路は Workflow panel の
@@ -140,26 +121,12 @@ export function AgentChatPanel({
 		() => orderedSessions.filter((s) => !s.workflowStepSession),
 		[orderedSessions],
 	);
-	const displayedClosedSessions = useMemo(
-		() => closedSessions.filter((s) => !s.workflowStepSession),
-		[closedSessions],
-	);
-
 	// spec issues-1023 / issues-1022: 万一 activeSession が workflow step session の状態でも
 	// AgentChatPanel 本文では表示しない（Workflow panel 側 transcript の二重表示防止）。
 	// Diff Thread handoff (issues-1022) と同じ判定規則を共通 hook 経由で参照する。
 	const displayedActiveSession = useDisplayedActiveSession();
 	const activeSessionId = displayedActiveSession?.id ?? null;
 
-	const [historyOpen, setHistoryOpen] = useState(false);
-	const [historySearchQuery, setHistorySearchQuery] = useState("");
-	const [historySearchResults, setHistorySearchResults] = useState<
-		SessionSearchResult[]
-	>([]);
-	const [historySearchError, setHistorySearchError] = useState<string | null>(
-		null,
-	);
-	const [isHistorySearchLoading, setIsHistorySearchLoading] = useState(false);
 	const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
 	const [commandPaletteItems, setCommandPaletteItems] = useState<
 		AgentCommandPaletteItem[]
@@ -167,34 +134,38 @@ export function AgentChatPanel({
 	const [agentShortcuts, setAgentShortcuts] = useState<AgentShortcutSetting[]>(
 		[],
 	);
-	const historySearchInputRef = useRef<HTMLInputElement>(null);
-	const draggedSessionIdRef = useRef<string | null>(null);
-	const isDraggingRef = useRef(false);
+	const handledSelectionRequestIdRef = useRef<number | null>(null);
+	const createSessionAndRefreshTree = useCallback(async () => {
+		const sessionId = await createNewSession();
+		if (sessionId) {
+			onNewSessionCreated?.(sessionId);
+		}
+		window.dispatchEvent(
+			new CustomEvent("workspace-tree-refresh", {
+				detail: { worktreePath },
+			}),
+		);
+	}, [createNewSession, onNewSessionCreated, worktreePath]);
 
-	const handleHistoryOpen = useCallback(
-		(open: boolean) => {
-			setHistoryOpen(open);
-			if (open) {
-				refreshClosedSessions();
-			}
-		},
-		[refreshClosedSessions],
-	);
+	useEffect(() => {
+		if (!selectionRequest) return;
+		if (selectionRequest.worktreePath !== worktreePath) return;
+		if (handledSelectionRequestIdRef.current === selectionRequest.requestId) {
+			return;
+		}
+		handledSelectionRequestIdRef.current = selectionRequest.requestId;
 
-	const handleRestore = useCallback(
-		(sessionId: string) => {
-			restoreSession(sessionId);
-			setHistoryOpen(false);
-		},
-		[restoreSession],
-	);
-
-	const handleArchive = useCallback(
-		(sessionId: string) => {
-			archiveSession(sessionId);
-		},
-		[archiveSession],
-	);
+		if (selectionRequest.kind === "agentSession") {
+			void selectSession(selectionRequest.sessionId);
+		} else if (selectionRequest.kind === "newAgentSession") {
+			void createSessionAndRefreshTree();
+		}
+	}, [
+		createSessionAndRefreshTree,
+		selectSession,
+		selectionRequest,
+		worktreePath,
+	]);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -234,112 +205,6 @@ export function AgentChatPanel({
 		};
 	}, [activeSessionId, commandPaletteOpen, displayedSessions.length]);
 
-	useEffect(() => {
-		if (!historyOpen) return;
-		const focusId = window.requestAnimationFrame(() => {
-			historySearchInputRef.current?.focus();
-		});
-		return () => window.cancelAnimationFrame(focusId);
-	}, [historyOpen]);
-
-	useEffect(() => {
-		if (!historyOpen) return;
-		const query = historySearchQuery.trim();
-		if (!query) {
-			setHistorySearchResults([]);
-			setHistorySearchError(null);
-			setIsHistorySearchLoading(false);
-			return;
-		}
-		let cancelled = false;
-		setIsHistorySearchLoading(true);
-		const timer = window.setTimeout(() => {
-			invoke<SessionSearchResult[]>("search_agent_sessions", {
-				worktreePath,
-				query,
-				includeWorkflow: false,
-				limit: 20,
-			})
-				.then((results) => {
-					if (cancelled) return;
-					setHistorySearchResults(results);
-					setHistorySearchError(null);
-				})
-				.catch((e) => {
-					if (cancelled) return;
-					setHistorySearchResults([]);
-					setHistorySearchError(String(e));
-				})
-				.finally(() => {
-					if (!cancelled) {
-						setIsHistorySearchLoading(false);
-					}
-				});
-		}, 150);
-		return () => {
-			cancelled = true;
-			window.clearTimeout(timer);
-		};
-	}, [historyOpen, historySearchQuery, worktreePath]);
-
-	const handleDragStart = useCallback(
-		(e: React.DragEvent, sessionId: string) => {
-			draggedSessionIdRef.current = sessionId;
-			isDraggingRef.current = true;
-			e.dataTransfer.effectAllowed = "move";
-			e.dataTransfer.setData("text/plain", sessionId);
-		},
-		[],
-	);
-
-	const handleDragOver = useCallback((e: React.DragEvent) => {
-		e.preventDefault();
-		e.dataTransfer.dropEffect = "move";
-	}, []);
-
-	const handleDrop = useCallback(
-		(e: React.DragEvent, targetId: string) => {
-			e.preventDefault();
-			const draggedId = draggedSessionIdRef.current;
-			if (!draggedId || draggedId === targetId) return;
-
-			// 並べ替えは tab bar 上に存在する free chat session 列に対してのみ意味がある。
-			// workflow step session は tab bar に並ばないため、その index を参照しない。
-			const currentOrder = displayedSessions.map((s) => s.id);
-			const fromIndex = currentOrder.indexOf(draggedId);
-			const toIndex = currentOrder.indexOf(targetId);
-			if (fromIndex === -1 || toIndex === -1) return;
-
-			const newOrder = [...currentOrder];
-			newOrder.splice(fromIndex, 1);
-			newOrder.splice(toIndex, 0, draggedId);
-
-			// orderedSessions 全体の order に対しては、tab bar に並ばない session を
-			// 既存位置に保ったまま、free chat session 部分だけを並べ替える。
-			// hidden を末尾に集約すると interleaved な配置（workflow step session が
-			// free chat session の間に挟まる順序）が崩れるため、元の位置を保持する。
-			let freeIndex = 0;
-			const nextOrder = orderedSessions.map((s) =>
-				currentOrder.includes(s.id) ? newOrder[freeIndex++] : s.id,
-			);
-			reorderSessions(nextOrder);
-		},
-		[displayedSessions, orderedSessions, reorderSessions],
-	);
-
-	const handleDragEnd = useCallback(() => {
-		draggedSessionIdRef.current = null;
-		isDraggingRef.current = false;
-	}, []);
-
-	const handleTabClick = useCallback(
-		(sessionId: string) => {
-			if (isDraggingRef.current) return;
-			selectSession(sessionId);
-		},
-		[selectSession],
-	);
-
 	const selectAdjacentSession = useCallback(
 		(direction: -1 | 1) => {
 			if (!activeSessionId || displayedSessions.length < 2) return;
@@ -363,10 +228,10 @@ export function AgentChatPanel({
 					setCommandPaletteOpen(true);
 					return;
 				case "new_thread":
-					createNewSession();
+					void createSessionAndRefreshTree();
 					return;
 				case "search_threads":
-					handleHistoryOpen(true);
+					window.dispatchEvent(new Event("agent-open-thread-history"));
 					return;
 				case "find_in_thread":
 					window.dispatchEvent(new Event("agent-open-thread-find"));
@@ -385,7 +250,7 @@ export function AgentChatPanel({
 					return;
 			}
 		},
-		[createNewSession, handleHistoryOpen, selectAdjacentSession],
+		[createSessionAndRefreshTree, selectAdjacentSession],
 	);
 
 	const runCommandPaletteItem = useCallback(
@@ -434,224 +299,49 @@ export function AgentChatPanel({
 
 	return (
 		<div data-testid="agent-chat-panel" className="flex flex-col h-full">
-			<Tabs
-				value={activeSessionId ?? ""}
-				onValueChange={handleTabClick}
-				className="flex flex-col h-full gap-0"
-			>
-				<div
-					data-tauri-drag-region
-					className="flex items-center gap-2 shrink-0 px-2 pt-2 bg-background border-b"
-				>
-					<TabsList
-						data-testid="session-tab-list"
-						className="w-auto max-w-full overflow-x-auto overflow-y-hidden justify-start [&::-webkit-scrollbar]:hidden [scrollbar-width:none]"
-					>
-						{displayedSessions.map((session) => (
-							<TabsTrigger key={session.id} value={session.id} asChild>
-								{/* biome-ignore lint/a11y/noStaticElementInteractions: TabsTrigger asChild が role を付与 */}
-								<div
-									className="gap-2"
-									draggable={displayedSessions.length > 1}
-									onDragStart={(e) => handleDragStart(e, session.id)}
-									onDragOver={handleDragOver}
-									onDrop={(e) => handleDrop(e, session.id)}
-									onDragEnd={handleDragEnd}
-								>
-									<AgentStateIcon state={sessionAgentStates.get(session.id)} />
-									<span className="truncate max-w-[120px]">
-										{session.firstMessage || "New session"}
-									</span>
-									{displayedSessions.length > 1 && (
-										<button
-											type="button"
-											onPointerDown={(e) => e.stopPropagation()}
-											onMouseDown={(e) => e.stopPropagation()}
-											onClick={(e) => {
-												e.stopPropagation();
-												closeSession(session.id);
-											}}
-											className="p-0.5 rounded hover:bg-muted-foreground/20 transition-colors shrink-0"
-											aria-label={`Close ${session.firstMessage || "New session"}`}
-										>
-											<X className="size-3.5" />
-										</button>
-									)}
-								</div>
-							</TabsTrigger>
-						))}
-					</TabsList>
-					<div data-tauri-drag-region className="flex-1" />
-					<button
-						type="button"
-						onClick={() => createNewSession()}
-						aria-label="New session"
-						className="px-2 h-full text-sm text-muted-foreground hover:text-foreground transition-colors shrink-0"
-					>
-						+
-					</button>
-					<Popover open={historyOpen} onOpenChange={handleHistoryOpen}>
-						<PopoverTrigger asChild>
-							<button
-								type="button"
-								aria-label="Session history"
-								className="p-1 rounded hover:bg-muted-foreground/20 transition-colors shrink-0 ml-auto"
-							>
-								<History className="size-3.5" />
-							</button>
-						</PopoverTrigger>
-						<PopoverContent align="end" className="w-80 p-0">
-							<div className="border-b p-2">
-								<div className="flex items-center gap-1 rounded border px-2 py-1">
-									<Search className="size-3.5 shrink-0 text-muted-foreground" />
-									<input
-										ref={historySearchInputRef}
-										type="search"
-										value={historySearchQuery}
-										onChange={(event) =>
-											setHistorySearchQuery(event.target.value)
-										}
-										placeholder="Search sessions"
-										aria-label="Search sessions"
-										className="min-w-0 flex-1 bg-transparent text-sm outline-none"
-									/>
-									{historySearchQuery && (
-										<button
-											type="button"
-											aria-label="Clear session search"
-											className="inline-flex size-5 shrink-0 items-center justify-center rounded hover:bg-muted"
-											onClick={() => setHistorySearchQuery("")}
-										>
-											<X className="size-3" />
-										</button>
-									)}
-								</div>
-							</div>
-							{historySearchQuery.trim() ? (
-								<div className="max-h-72 overflow-y-auto">
-									{isHistorySearchLoading ? (
-										<p className="px-3 py-4 text-center text-sm text-muted-foreground">
-											Searching...
-										</p>
-									) : historySearchError ? (
-										<p className="px-3 py-4 text-center text-sm text-destructive">
-											{historySearchError}
-										</p>
-									) : historySearchResults.length > 0 ? (
-										<ul>
-											{historySearchResults.map((result) => (
-												<li key={result.session.id}>
-													<div className="flex items-start gap-1 px-2 py-1 hover:bg-muted">
-														<button
-															type="button"
-															className="min-w-0 flex-1 px-1 py-1 text-left"
-															onClick={() => handleRestore(result.session.id)}
-														>
-															<div className="truncate text-sm">
-																{result.session.firstMessage || "New session"}
-															</div>
-															<div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-																{result.snippet}
-															</div>
-														</button>
-														<button
-															type="button"
-															className="inline-flex size-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground"
-															aria-label={`Archive ${result.session.firstMessage || "New session"}`}
-															title="Archive session"
-															onClick={() => handleArchive(result.session.id)}
-														>
-															<Archive className="size-3.5" />
-														</button>
-													</div>
-												</li>
-											))}
-										</ul>
-									) : (
-										<p className="px-3 py-4 text-center text-sm text-muted-foreground">
-											No matching sessions
-										</p>
-									)}
-								</div>
-							) : displayedClosedSessions.length > 0 ? (
-								<ul className="max-h-60 overflow-y-auto">
-									{displayedClosedSessions.map((session) => (
-										<li key={session.id}>
-											<div className="flex items-center gap-1 px-2 py-1 hover:bg-muted">
-												<button
-													type="button"
-													className="min-w-0 flex-1 truncate px-1 py-1 text-left text-sm"
-													onClick={() => handleRestore(session.id)}
-												>
-													{session.firstMessage || "New session"}
-												</button>
-												<button
-													type="button"
-													className="inline-flex size-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground"
-													aria-label={`Archive ${session.firstMessage || "New session"}`}
-													title="Archive session"
-													onClick={() => handleArchive(session.id)}
-												>
-													<Archive className="size-3.5" />
-												</button>
-											</div>
-										</li>
-									))}
-								</ul>
-							) : (
-								<p className="px-3 py-4 text-sm text-muted-foreground text-center">
-									No closed sessions
-								</p>
-							)}
-						</PopoverContent>
-					</Popover>
+			{activeSessionId ? (
+				<BoundSessionChat
+					sessionId={activeSessionId}
+					worktreePath={worktreePath}
+					activeEditorPath={activeEditorPath}
+					openEditorPaths={openEditorPaths}
+					activeEditorSelection={activeEditorSelection}
+					registerDropZone={registerDropZone}
+					dropZoneName="agent"
+					sendMessageRef={sendMessageRef}
+					onOpenDiffFile={onOpenDiffFile}
+					skipInitialLoad
+				/>
+			) : (
+				<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+					No chat selected
 				</div>
-				{activeSessionId ? (
-					<BoundSessionChat
-						sessionId={activeSessionId}
-						worktreePath={worktreePath}
-						activeEditorPath={activeEditorPath}
-						openEditorPaths={openEditorPaths}
-						activeEditorSelection={activeEditorSelection}
-						registerDropZone={registerDropZone}
-						dropZoneName="agent"
-						sendMessageRef={sendMessageRef}
-						onOpenDiffFile={onOpenDiffFile}
-						skipInitialLoad
-					/>
-				) : (
-					<div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
-						No chat selected
-					</div>
-				)}
-				<CommandDialog
-					open={commandPaletteOpen}
-					onOpenChange={setCommandPaletteOpen}
-					title="Agent Commands"
-					description="Search agent commands"
-					className="max-w-lg"
-				>
-					<CommandInput placeholder="Search commands" />
-					<CommandList data-testid="agent-command-palette">
-						<CommandEmpty>No commands found</CommandEmpty>
-						<CommandGroup heading="Agent">
-							{commandPaletteItems.map((item) => (
-								<CommandItem
-									key={item.id}
-									value={item.label}
-									disabled={!item.enabled}
-									onSelect={() => runCommandPaletteItem(item)}
-								>
-									<span>{item.label}</span>
-									<CommandShortcut>
-										{commandShortcutLabel(item)}
-									</CommandShortcut>
-								</CommandItem>
-							))}
-						</CommandGroup>
-					</CommandList>
-				</CommandDialog>
-			</Tabs>
+			)}
+			<CommandDialog
+				open={commandPaletteOpen}
+				onOpenChange={setCommandPaletteOpen}
+				title="Agent Commands"
+				description="Search agent commands"
+				className="max-w-lg"
+			>
+				<CommandInput placeholder="Search commands" />
+				<CommandList data-testid="agent-command-palette">
+					<CommandEmpty>No commands found</CommandEmpty>
+					<CommandGroup heading="Agent">
+						{commandPaletteItems.map((item) => (
+							<CommandItem
+								key={item.id}
+								value={item.label}
+								disabled={!item.enabled}
+								onSelect={() => runCommandPaletteItem(item)}
+							>
+								<span>{item.label}</span>
+								<CommandShortcut>{commandShortcutLabel(item)}</CommandShortcut>
+							</CommandItem>
+						))}
+					</CommandGroup>
+				</CommandList>
+			</CommandDialog>
 		</div>
 	);
 }

--- a/src/components/panels/WorkflowPanel/WorkflowPanel.tsx
+++ b/src/components/panels/WorkflowPanel/WorkflowPanel.tsx
@@ -38,6 +38,7 @@ interface WorkflowPanelProps {
 	 * Workflow 観測 mode（右パネル）からは kicker を表示しない。
 	 */
 	showNewWorkflowButton?: boolean;
+	showHeader?: boolean;
 }
 
 export function WorkflowPanel({
@@ -49,6 +50,7 @@ export function WorkflowPanel({
 	openStepSessionIds,
 	selectedStep,
 	showNewWorkflowButton = true,
+	showHeader = true,
 }: WorkflowPanelProps) {
 	const [executionIds, setExecutionIds] = useState<string[]>([]);
 	const [openPastIds, setOpenPastIds] = useState<string[]>([]);
@@ -68,12 +70,14 @@ export function WorkflowPanel({
 	}, [worktreePath]);
 
 	useEffect(() => {
+		if (!showHeader) return;
 		fetchExecutionIds();
-	}, [fetchExecutionIds]);
+	}, [fetchExecutionIds, showHeader]);
 
 	// Refresh on workflow completion
 	const stateType = workflowState?.state.type;
 	useEffect(() => {
+		if (!showHeader) return;
 		if (
 			stateType === "completed" ||
 			stateType === "failed" ||
@@ -81,7 +85,7 @@ export function WorkflowPanel({
 		) {
 			fetchExecutionIds();
 		}
-	}, [stateType, fetchExecutionIds]);
+	}, [stateType, fetchExecutionIds, showHeader]);
 
 	// Switch to current tab when a new workflow starts
 	const executionId = workflowState?.executionId;
@@ -142,6 +146,26 @@ export function WorkflowPanel({
 		setActiveTab(id);
 		setHistoryOpen(false);
 	}, []);
+
+	if (!showHeader) {
+		if (!workflowState) {
+			return (
+				<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+					No workflow running
+				</div>
+			);
+		}
+		return (
+			<WorkflowActivePanel
+				workflowState={workflowState}
+				worktreePath={worktreePath}
+				onSessionClick={onSessionClick}
+				onCloseSession={onCloseSession}
+				openStepSessionIds={openStepSessionIds}
+				selectedStep={selectedStep}
+			/>
+		);
+	}
 
 	return (
 		<Tabs

--- a/src/components/panels/WorkflowView/WorkflowView.test.tsx
+++ b/src/components/panels/WorkflowView/WorkflowView.test.tsx
@@ -392,13 +392,13 @@ describe("WorkflowView", () => {
 		expect(screen.getByText("ready for approval")).toBeInTheDocument();
 	});
 
-	it("renders NewWorkflowButton kicker so the user can start a workflow", () => {
+	it("does not render WorkflowPanel header actions inside WorkflowView", () => {
 		useWorkflowStateMock.mockReturnValue({
 			workflowState: workflowStateFixture(),
 		});
 		render(<WorkflowView worktreePath="/repo" />);
-		// 起動経路を残すため kicker を表示する。
-		expect(screen.queryByLabelText("New workflow")).not.toBeNull();
+		expect(screen.queryByLabelText("New workflow")).toBeNull();
+		expect(screen.queryByLabelText("Execution history")).toBeNull();
 	});
 
 	describe("tab bar", () => {

--- a/src/components/panels/WorkflowView/WorkflowView.tsx
+++ b/src/components/panels/WorkflowView/WorkflowView.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -22,10 +23,12 @@ import { useWorktreeSessionStatuses } from "@/hooks/useWorktreeSessionStatuses";
 import type { AgentState } from "@/types/protocol";
 import type { PermissionMode } from "@/types/session";
 import type { WorkflowState } from "@/types/workflow";
+import type { CenterSelectionRequest } from "@/types/workspace-tree";
 import { WorkflowStepDetail } from "./WorkflowStepDetail";
 
 interface WorkflowViewProps {
 	worktreePath: string;
+	selectionRequest?: CenterSelectionRequest | null;
 	permissionMode?: PermissionMode;
 }
 
@@ -44,9 +47,51 @@ interface WorkflowViewProps {
  */
 export function WorkflowView({
 	worktreePath,
+	selectionRequest,
 	permissionMode = "ask",
 }: WorkflowViewProps) {
-	const { workflowState } = useWorkflowState(worktreePath);
+	const { workflowState: activeWorkflowState } = useWorkflowState(worktreePath);
+	const selectedRunId =
+		selectionRequest?.kind === "workflowRun" &&
+		selectionRequest.worktreePath === worktreePath
+			? selectionRequest.runId
+			: null;
+	const [requestedWorkflowState, setRequestedWorkflowState] =
+		useState<WorkflowState | null>(null);
+
+	useEffect(() => {
+		if (!selectedRunId) {
+			setRequestedWorkflowState(null);
+			return;
+		}
+		if (activeWorkflowState?.executionId === selectedRunId) {
+			setRequestedWorkflowState(null);
+			return;
+		}
+		let cancelled = false;
+		void invoke<WorkflowState | null>("get_workflow_run_state", {
+			worktreePath,
+			runId: selectedRunId,
+		})
+			.then((state) => {
+				if (!cancelled) {
+					setRequestedWorkflowState(state ?? null);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setRequestedWorkflowState(null);
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [activeWorkflowState?.executionId, selectedRunId, worktreePath]);
+
+	const workflowState =
+		selectedRunId && activeWorkflowState?.executionId !== selectedRunId
+			? requestedWorkflowState
+			: activeWorkflowState;
 
 	// Step タブの状態アイコン用: AgentChatPanel と同じく Rust 中央管理から取得した
 	// SessionStatus を sessionId -> AgentState の Map に整形する。
@@ -104,6 +149,25 @@ export function WorkflowView({
 			void openWorkflowStepTab(next.sessionId).catch(() => {});
 		}
 	}, []);
+
+	const handledSelectionRequestIdRef = useRef<number | null>(null);
+	useEffect(() => {
+		if (selectionRequest?.kind !== "workflowRun") return;
+		if (selectionRequest.worktreePath !== worktreePath) return;
+		if (handledSelectionRequestIdRef.current === selectionRequest.requestId) {
+			return;
+		}
+		if (!workflowState) return;
+		const sessionId = selectionRequest.focus?.sessionId;
+		if (!sessionId) {
+			handledSelectionRequestIdRef.current = selectionRequest.requestId;
+			return;
+		}
+		const selection = resolveStepSelection(workflowState, sessionId);
+		if (!selection) return;
+		handledSelectionRequestIdRef.current = selectionRequest.requestId;
+		handleSelectStepSession(selection);
+	}, [handleSelectStepSession, selectionRequest, workflowState, worktreePath]);
 
 	const handleSelectTab = useCallback((key: string) => {
 		setActiveTabKey(key);
@@ -298,6 +362,7 @@ export function WorkflowView({
 							onSessionClick={handleSelectStepSession}
 							onCloseSession={handleCloseSessionFromTimeline}
 							openStepSessionIds={openStepSessionIds}
+							showHeader={false}
 							selectedStep={
 								activeTab
 									? {

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -301,8 +301,8 @@ describe("WorkspaceList", () => {
 
 		expect(await screen.findByText("SessionHistory")).toBeInTheDocument();
 		expect(screen.getByText("WorkflowHistory")).toBeInTheDocument();
-		expect(screen.getByText("PRリンク")).toBeInTheDocument();
-		expect(screen.getByText("削除")).toBeInTheDocument();
+		expect(screen.getByText("PR Link")).toBeInTheDocument();
+		expect(screen.getByText("Delete")).toBeInTheDocument();
 	});
 
 	it("closes a Session from the hover action without selecting the row", async () => {

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -1,0 +1,347 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceList } from "./WorkspaceList";
+
+const mocks = vi.hoisted(() => ({
+	invoke: vi.fn().mockResolvedValue([]),
+	emit: vi.fn().mockResolvedValue(undefined),
+	openUrl: vi.fn().mockResolvedValue(undefined),
+	archiveSession: vi.fn().mockResolvedValue(undefined),
+	closeSession: vi.fn().mockResolvedValue(undefined),
+	restoreSession: vi.fn().mockResolvedValue(undefined),
+	refreshTree: vi.fn().mockResolvedValue(undefined),
+	refreshWorktrees: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("react-resizable-panels", () => {
+	const Panel = ({ children }: { children?: React.ReactNode }) => (
+		<div>{children}</div>
+	);
+	const Group = ({ children }: { children?: React.ReactNode }) => (
+		<div>{children}</div>
+	);
+	const Separator = () => <div />;
+	return { Panel, Group, Separator };
+});
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: mocks.invoke,
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+	emit: mocks.emit,
+}));
+vi.mock("@tauri-apps/plugin-opener", () => ({
+	openUrl: mocks.openUrl,
+}));
+vi.mock("@/hooks/useSessionStore", () => ({
+	archiveSession: mocks.archiveSession,
+	closeSession: mocks.closeSession,
+	restoreSession: mocks.restoreSession,
+}));
+vi.mock("@/hooks/useWorkflowConfig", () => ({
+	useWorkflowConfig: () => ({
+		workflows: [
+			{
+				name: "release",
+				description: "Release workflow",
+				builtin: false,
+				is_running: false,
+			},
+		],
+		loading: false,
+		error: null,
+	}),
+}));
+vi.mock("@/hooks/useWorkspaceTreeNodes", () => ({
+	useWorkspaceTreeNodes: (worktreePath: string) => {
+		if (worktreePath !== "/repo/wt") {
+			return {
+				nodes: [],
+				closedSessions: [],
+				workflowHistory: [],
+				loading: false,
+				error: null,
+				refresh: mocks.refreshTree,
+			};
+		}
+		return {
+			nodes: [
+				{
+					kind: "session",
+					id: "new-s",
+					worktreePath: "/repo/wt",
+					title: "NewSession",
+					state: "idle",
+					updatedAt: 1000,
+					workflowStepSession: false,
+					agentState: null,
+				},
+				{
+					kind: "session",
+					id: "direct-1",
+					worktreePath: "/repo/wt",
+					title: "Direct session",
+					state: "active",
+					updatedAt: 1000,
+					workflowStepSession: false,
+					agentState: "done",
+				},
+				{
+					kind: "workflow",
+					runId: "run-1",
+					worktreePath: "/repo/wt",
+					title: "Deploy workflow",
+					status: "running",
+					updatedAt: 1100,
+					children: [
+						{
+							kind: "session",
+							id: "step-build",
+							worktreePath: "/repo/wt",
+							title: "Build step",
+							state: "active",
+							updatedAt: 1100,
+							workflowStepSession: true,
+							stepName: "build",
+							runIndex: 1,
+							agentState: "running",
+						},
+					],
+				},
+			],
+			closedSessions: [
+				{
+					id: "closed-1",
+					worktreePath: "/repo/wt",
+					state: "closed",
+					createdAt: 1,
+					updatedAt: 2,
+					firstMessage: "Closed history session",
+					messageCount: 1,
+					agentSessionId: null,
+					contextCarry: null,
+					permissionMode: "edit",
+					planMode: false,
+					permissionProfileId: null,
+					backendId: null,
+					workflowStepSession: false,
+				},
+			],
+			workflowHistory: [
+				{
+					runId: "archived-run",
+					worktreePath: "/repo/wt",
+					title: "Archived workflow",
+					status: "completed",
+					updatedAt: 3,
+					archivedAt: 4,
+					archiveReason: "manual",
+					children: [],
+				},
+			],
+			loading: false,
+			error: null,
+			refresh: mocks.refreshTree,
+		};
+	},
+}));
+vi.mock("@/hooks/useWorktreeList", () => ({
+	useWorktreeList: () => ({
+		branches: [
+			{
+				name: "main",
+				is_main_worktree: true,
+				worktree_path: "/repo/main",
+				dirty_count: 0,
+				is_merged: false,
+				ahead: 0,
+				behind: 0,
+				has_upstream: false,
+				base_ahead: 0,
+			},
+			{
+				name: "feature",
+				is_main_worktree: false,
+				worktree_path: "/repo/wt",
+				dirty_count: 0,
+				is_merged: false,
+				has_pr: true,
+				pr_number: 12,
+				pr_url: "https://example.test/pr/12",
+				ahead: 0,
+				behind: 0,
+				has_upstream: false,
+				base_ahead: 0,
+			},
+		],
+		loading: false,
+		refresh: mocks.refreshWorktrees,
+	}),
+}));
+vi.mock("@/hooks/useWorktreeSessionStatuses", () => ({
+	useWorktreeSessionStatuses: () => new Map(),
+}));
+
+function renderWorkspaceList(
+	props: Partial<React.ComponentProps<typeof WorkspaceList>> = {},
+) {
+	const onSelectWorktree = vi.fn();
+	render(
+		<WorkspaceList
+			repoPaths={["/repo"]}
+			selectedRootPath="/repo/wt"
+			centerSelection={null}
+			onSelectWorktree={onSelectWorktree}
+			onAddRepo={vi.fn()}
+			onShowSettings={vi.fn()}
+			{...props}
+		/>,
+	);
+	return { onSelectWorktree };
+}
+
+beforeEach(() => {
+	for (const mock of Object.values(mocks)) {
+		mock.mockClear();
+	}
+	mocks.invoke.mockResolvedValue([]);
+});
+
+describe("WorkspaceList", () => {
+	it("highlights the created NewSession row when selected", () => {
+		renderWorkspaceList({
+			centerSelection: {
+				kind: "agentSession",
+				worktreePath: "/repo/wt",
+				sessionId: "new-s",
+			},
+		});
+
+		expect(screen.getByText("NewSession").closest("button")).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+	});
+
+	it("renders Home and worktree icon variants", () => {
+		renderWorkspaceList();
+
+		expect(screen.getByLabelText("Main repository")).toBeInTheDocument();
+		expect(screen.getByLabelText("Worktree")).toBeInTheDocument();
+	});
+
+	it("toggles a Worktree row without changing CenterSelection", async () => {
+		const user = userEvent.setup();
+		const { onSelectWorktree } = renderWorkspaceList();
+
+		expect(screen.getByText("Direct session")).toBeInTheDocument();
+		await user.click(screen.getByTestId("worktree-item-feature"));
+
+		expect(screen.queryByText("Direct session")).not.toBeInTheDocument();
+		expect(onSelectWorktree).not.toHaveBeenCalled();
+	});
+
+	it("emits an agentSession selection when a Session row is clicked", async () => {
+		const user = userEvent.setup();
+		const { onSelectWorktree } = renderWorkspaceList();
+
+		await user.click(screen.getByText("Direct session"));
+
+		expect(onSelectWorktree).toHaveBeenCalledWith(
+			"/repo/wt",
+			"feature",
+			"repo",
+			{
+				kind: "agentSession",
+				worktreePath: "/repo/wt",
+				sessionId: "direct-1",
+			},
+		);
+	});
+
+	it("toggles a Workflow parent without changing CenterSelection", async () => {
+		const user = userEvent.setup();
+		const { onSelectWorktree } = renderWorkspaceList();
+
+		expect(screen.getByText("Build step")).toBeInTheDocument();
+		await user.click(screen.getByText("Deploy workflow"));
+
+		expect(screen.queryByText("Build step")).not.toBeInTheDocument();
+		expect(onSelectWorktree).not.toHaveBeenCalled();
+	});
+
+	it("emits a workflowRun selection when a WorkflowSession row is clicked", async () => {
+		const user = userEvent.setup();
+		const { onSelectWorktree } = renderWorkspaceList();
+
+		await user.click(screen.getByText("Build step"));
+
+		expect(onSelectWorktree).toHaveBeenCalledWith(
+			"/repo/wt",
+			"feature",
+			"repo",
+			{
+				kind: "workflowRun",
+				worktreePath: "/repo/wt",
+				runId: "run-1",
+				focus: {
+					sessionId: "step-build",
+					stepName: "build",
+					runIndex: 1,
+				},
+			},
+		);
+	});
+
+	it("opens the Worktree menu with history, PR link, and delete actions", async () => {
+		const user = userEvent.setup();
+		renderWorkspaceList();
+
+		await user.click(screen.getByLabelText("Open menu for feature"));
+
+		expect(await screen.findByText("SessionHistory")).toBeInTheDocument();
+		expect(screen.getByText("WorkflowHistory")).toBeInTheDocument();
+		expect(screen.getByText("PRリンク")).toBeInTheDocument();
+		expect(screen.getByText("削除")).toBeInTheDocument();
+	});
+
+	it("closes a Session from the hover action without selecting the row", async () => {
+		const user = userEvent.setup();
+		const { onSelectWorktree } = renderWorkspaceList();
+
+		await user.click(screen.getByLabelText("Close Direct session"));
+
+		await waitFor(() => {
+			expect(mocks.closeSession).toHaveBeenCalledWith("direct-1");
+		});
+		expect(onSelectWorktree).not.toHaveBeenCalled();
+	});
+
+	it("does not render status text, relative time, or more controls", () => {
+		renderWorkspaceList();
+
+		expect(screen.queryByText("Open")).not.toBeInTheDocument();
+		expect(screen.queryByText("Closed")).not.toBeInTheDocument();
+		expect(screen.queryByText("1日")).not.toBeInTheDocument();
+		expect(screen.queryByText("もっと表示する")).not.toBeInTheDocument();
+	});
+
+	it("renders the header Add Worktree action", () => {
+		renderWorkspaceList();
+
+		expect(
+			screen.getByRole("button", { name: "Add Worktree" }),
+		).toBeInTheDocument();
+	});
+
+	it("shows the NewWorkflow submenu from the Worktree create menu", async () => {
+		const user = userEvent.setup();
+		renderWorkspaceList();
+
+		await user.click(screen.getByLabelText("Create in feature"));
+
+		await user.hover(await screen.findByText("NewWorkflow"));
+
+		expect(await screen.findByText("release")).toBeInTheDocument();
+	});
+});

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -515,11 +515,33 @@ function WorktreeTreeItem({
 							: "text-muted-foreground hover:bg-foreground/5"
 				}`}
 			>
+				<Button
+					type="button"
+					size="icon-xs"
+					variant="ghost"
+					className="size-5 shrink-0 text-muted-foreground"
+					disabled={!hasWorktree}
+					onClick={() => setExpanded((prev) => !prev)}
+					aria-label={`${expanded ? "Collapse" : "Expand"} ${branch.name}`}
+					title={`${expanded ? "Collapse" : "Expand"} ${branch.name}`}
+				>
+					{expanded ? (
+						<ChevronDown className="size-3.5 shrink-0" />
+					) : (
+						<ChevronRight className="size-3.5 shrink-0" />
+					)}
+				</Button>
 				<button
 					type="button"
 					data-testid={`worktree-item-${branch.name}`}
 					className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
-					onClick={() => setExpanded((prev) => !prev)}
+					disabled={!hasWorktree}
+					onClick={() => {
+						if (!branch.worktree_path) return;
+						onSelectWorktree(branch.worktree_path, branch.name, repoName);
+					}}
+					aria-current={isSelected ? "page" : undefined}
+					aria-label={`Open worktree ${branch.name}`}
 				>
 					{branch.is_main_worktree ? (
 						<Home
@@ -532,12 +554,8 @@ function WorktreeTreeItem({
 							aria-label="Worktree"
 						/>
 					)}
+					{branch.agent_state && <AgentStateIcon state={branch.agent_state} />}
 					<span className="min-w-0 truncate">{branch.name}</span>
-					{expanded ? (
-						<ChevronDown className="hidden size-3.5 shrink-0 text-muted-foreground group-hover:block" />
-					) : (
-						<ChevronRight className="hidden size-3.5 shrink-0 text-muted-foreground group-hover:block" />
-					)}
 				</button>
 				<div className="relative h-5 w-11 shrink-0">
 					<div
@@ -1025,7 +1043,7 @@ export function WorkspaceList({
 				))}
 				{repoPaths.length === 0 && (
 					<div className="px-2 py-8 text-center text-xs text-muted-foreground">
-						No Repository
+						No repositories
 					</div>
 				)}
 			</div>

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -515,33 +515,11 @@ function WorktreeTreeItem({
 							: "text-muted-foreground hover:bg-foreground/5"
 				}`}
 			>
-				<Button
-					type="button"
-					size="icon-xs"
-					variant="ghost"
-					className="size-5 shrink-0 text-muted-foreground"
-					disabled={!hasWorktree}
-					onClick={() => setExpanded((prev) => !prev)}
-					aria-label={`${expanded ? "Collapse" : "Expand"} ${branch.name}`}
-					title={`${expanded ? "Collapse" : "Expand"} ${branch.name}`}
-				>
-					{expanded ? (
-						<ChevronDown className="size-3.5 shrink-0" />
-					) : (
-						<ChevronRight className="size-3.5 shrink-0" />
-					)}
-				</Button>
 				<button
 					type="button"
 					data-testid={`worktree-item-${branch.name}`}
 					className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
-					disabled={!hasWorktree}
-					onClick={() => {
-						if (!branch.worktree_path) return;
-						onSelectWorktree(branch.worktree_path, branch.name, repoName);
-					}}
-					aria-current={isSelected ? "page" : undefined}
-					aria-label={`Open worktree ${branch.name}`}
+					onClick={() => setExpanded((prev) => !prev)}
 				>
 					{branch.is_main_worktree ? (
 						<Home
@@ -554,8 +532,12 @@ function WorktreeTreeItem({
 							aria-label="Worktree"
 						/>
 					)}
-					{branch.agent_state && <AgentStateIcon state={branch.agent_state} />}
 					<span className="min-w-0 truncate">{branch.name}</span>
+					{expanded ? (
+						<ChevronDown className="hidden size-3.5 shrink-0 text-muted-foreground group-hover:block" />
+					) : (
+						<ChevronRight className="hidden size-3.5 shrink-0 text-muted-foreground group-hover:block" />
+					)}
 				</button>
 				<div className="relative h-5 w-11 shrink-0">
 					<div
@@ -1043,7 +1025,7 @@ export function WorkspaceList({
 				))}
 				{repoPaths.length === 0 && (
 					<div className="px-2 py-8 text-center text-xs text-muted-foreground">
-						No repositories
+						No Repository
 					</div>
 				)}
 			</div>

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -645,7 +645,7 @@ function WorktreeTreeItem({
 									}}
 								>
 									<ExternalLink className="size-3.5" />
-									PRリンク
+									PR Link
 								</DropdownMenuItem>
 								<DropdownMenuItem
 									variant="destructive"
@@ -657,7 +657,7 @@ function WorktreeTreeItem({
 									}}
 								>
 									<Trash2 className="size-3.5" />
-									削除
+									Delete
 								</DropdownMenuItem>
 							</DropdownMenuContent>
 						</DropdownMenu>
@@ -1025,7 +1025,7 @@ export function WorkspaceList({
 				))}
 				{repoPaths.length === 0 && (
 					<div className="px-2 py-8 text-center text-xs text-muted-foreground">
-						リポジトリなし
+						No Repository
 					</div>
 				)}
 			</div>

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -2,114 +2,862 @@ import { invoke } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
+	Archive,
 	ChevronDown,
 	ChevronRight,
-	Filter,
+	ExternalLink,
+	GitBranch,
+	GitPullRequest,
 	Home,
-	LayoutList,
 	Loader2,
+	MessageSquare,
+	MoreHorizontal,
 	Plus,
 	RefreshCw,
 	Settings,
 	Trash2,
+	Workflow,
+	X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { AgentStateIcon } from "@/components/ui/agent-state-icon";
 import { Button } from "@/components/ui/button";
 import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
 	DropdownMenu,
 	DropdownMenuContent,
-	DropdownMenuLabel,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Textarea } from "@/components/ui/textarea";
 import {
-	Select,
-	SelectContent,
-	SelectGroup,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
-import {
-	computeStatus,
-	useWorktreeList,
-	type WorktreeStatus,
-} from "@/hooks/useWorktreeList";
+	archiveSession,
+	closeSession as closeSessionApi,
+	restoreSession,
+} from "@/hooks/useSessionStore";
+import { useWorkflowConfig } from "@/hooks/useWorkflowConfig";
+import { useWorkspaceTreeNodes } from "@/hooks/useWorkspaceTreeNodes";
+import { useWorktreeList } from "@/hooks/useWorktreeList";
+import { useWorktreeSessionStatuses } from "@/hooks/useWorktreeSessionStatuses";
 import { trackEvent } from "@/lib/telemetry";
 import type { WorktreeBranch } from "@/types/git";
+import type {
+	CenterSelection,
+	WorkspaceSessionHistoryItem,
+	WorkspaceSessionNode,
+	WorkspaceWorkflowHistoryItem,
+	WorkspaceWorkflowNode,
+} from "@/types/workspace-tree";
 import { CreateWorktreeModal } from "./CreateWorktreeModal";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
-
-type GroupMode = "repository" | "status";
-
-interface WorktreeData {
-	branches: WorktreeBranch[];
-	loading: boolean;
-	refresh: (options?: { silent?: boolean }) => Promise<void>;
-}
-
-const noopRefresh = async (_options?: { silent?: boolean }) => {};
 
 interface WorkspaceListProps {
 	repoPaths: string[];
 	selectedRootPath: string | null;
+	centerSelection?: CenterSelection | null;
 	onSelectWorktree: (
 		rootPath: string,
 		branchName?: string,
 		repoName?: string,
+		centerSelection?: CenterSelection,
 	) => void;
 	onAddRepo: () => void;
 	onShowSettings: () => void;
 }
 
-const STATUS_ORDER: WorktreeStatus[] = [
-	"backlog",
-	"in_progress",
-	"review",
-	"done",
-];
-const STATUS_LABELS: Record<WorktreeStatus, string> = {
-	backlog: "Backlog",
-	in_progress: "In Progress",
-	review: "Review",
-	done: "Done",
-};
+const WORKTREE_NAME_INDENT_PX = 26;
+const WORKFLOW_NAME_OFFSET_PX = 22;
+const DEFAULT_SESSION_TITLE = "NewSession";
 
-function RepoWorktreeSectionView({
+function repoNameFromPath(path: string): string {
+	return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+function sessionLabel(session: WorkspaceSessionHistoryItem): string {
+	return session.firstMessage.trim() || DEFAULT_SESSION_TITLE;
+}
+
+function isDirectSessionSelected(
+	centerSelection: CenterSelection | null,
+	node: WorkspaceSessionNode,
+): boolean {
+	return (
+		centerSelection?.kind === "agentSession" &&
+		centerSelection.sessionId === node.id
+	);
+}
+
+function isWorkflowSelected(
+	centerSelection: CenterSelection | null,
+	node: WorkspaceWorkflowNode,
+): boolean {
+	return (
+		centerSelection?.kind === "workflowRun" &&
+		centerSelection.runId === node.runId &&
+		!centerSelection.focus?.sessionId
+	);
+}
+
+function isWorkflowSessionSelected(
+	centerSelection: CenterSelection | null,
+	workflow: WorkspaceWorkflowNode,
+	node: WorkspaceSessionNode,
+): boolean {
+	return (
+		centerSelection?.kind === "workflowRun" &&
+		centerSelection.runId === workflow.runId &&
+		centerSelection.focus?.sessionId === node.id
+	);
+}
+
+function WorktreeIndicators({ branch }: { branch: WorktreeBranch }) {
+	const hasChanges = branch.dirty_count > 0;
+	const hasPr = branch.has_pr === true;
+	if (!hasChanges && !hasPr) return null;
+
+	return (
+		<div className="relative h-5 w-full text-muted-foreground">
+			{hasChanges && (
+				<span
+					className={`absolute top-0 inline-flex h-5 w-5 items-center justify-center rounded text-[10px] leading-none tabular-nums ${
+						hasPr ? "right-6" : "right-0"
+					}`}
+					title={`${branch.dirty_count} changed files`}
+				>
+					{branch.dirty_count}
+				</span>
+			)}
+			{hasPr && (
+				<span
+					className="absolute top-0 right-0 inline-flex h-5 w-5 items-center justify-center"
+					role="img"
+					title={
+						branch.pr_number != null
+							? `Pull request #${branch.pr_number}`
+							: "Pull request"
+					}
+					aria-label={
+						branch.pr_number != null
+							? `Pull request #${branch.pr_number}`
+							: "Pull request"
+					}
+				>
+					<GitPullRequest className="size-3 shrink-0" aria-hidden="true" />
+				</span>
+			)}
+		</div>
+	);
+}
+
+function WorktreeSessionRow({
+	node,
+	indentPx,
+	agentState,
+	selected,
+	showClose,
+	onSelect,
+	onClose,
+}: {
+	node: WorkspaceSessionNode;
+	indentPx: number;
+	agentState?: WorkspaceSessionNode["agentState"];
+	selected?: boolean;
+	showClose: boolean;
+	onSelect: () => void;
+	onClose?: () => void;
+}) {
+	return (
+		<div
+			className={`group flex h-8 w-full items-center gap-2 rounded-md pr-2 text-left text-sm transition-colors ${
+				selected
+					? "bg-foreground/10 text-foreground"
+					: "text-foreground/90 hover:bg-foreground/5"
+			}`}
+			style={{ paddingLeft: indentPx }}
+		>
+			<button
+				type="button"
+				className="flex min-w-0 flex-1 items-center gap-2 text-left"
+				onClick={onSelect}
+				aria-current={selected ? "page" : undefined}
+			>
+				<AgentStateIcon state={agentState} />
+				<span className="min-w-0 flex-1 truncate">{node.title}</span>
+			</button>
+			{showClose && (
+				<Button
+					size="icon-xs"
+					variant="ghost"
+					className="hidden size-5 shrink-0 text-muted-foreground group-hover:flex group-focus-within:flex"
+					onClick={(event) => {
+						event.stopPropagation();
+						onClose?.();
+					}}
+					aria-label={`Close ${node.title}`}
+					title="Close"
+				>
+					<X className="size-3" />
+				</Button>
+			)}
+		</div>
+	);
+}
+
+function WorktreeWorkflowRow({
+	node,
+	indentPx,
+	selected,
+	centerSelection,
+	sessionAgentStates,
+	onSelectSession,
+	onArchive,
+}: {
+	node: WorkspaceWorkflowNode;
+	indentPx: number;
+	selected?: boolean;
+	centerSelection: CenterSelection | null;
+	sessionAgentStates: Map<string, WorkspaceSessionNode["agentState"]>;
+	onSelectSession: (
+		workflow: WorkspaceWorkflowNode,
+		node: WorkspaceSessionNode,
+	) => void;
+	onArchive: (node: WorkspaceWorkflowNode) => void;
+}) {
+	const [expanded, setExpanded] = useState(true);
+	return (
+		<div>
+			<div
+				className={`group flex h-8 w-full items-center gap-2 rounded-md pr-2 text-sm transition-colors ${
+					selected
+						? "bg-foreground/10 text-foreground"
+						: "text-foreground/90 hover:bg-foreground/5"
+				}`}
+				style={{ paddingLeft: indentPx }}
+			>
+				<button
+					type="button"
+					className="flex min-w-0 flex-1 items-center gap-2 text-left"
+					onClick={() => setExpanded((prev) => !prev)}
+					aria-current={selected ? "page" : undefined}
+				>
+					<Workflow className="size-3.5 shrink-0 text-muted-foreground/80" />
+					<span className="min-w-0 truncate">{node.title}</span>
+					{expanded ? (
+						<ChevronDown className="hidden size-3.5 shrink-0 text-muted-foreground group-hover:block" />
+					) : (
+						<ChevronRight className="hidden size-3.5 shrink-0 text-muted-foreground group-hover:block" />
+					)}
+				</button>
+				<Button
+					size="icon-xs"
+					variant="ghost"
+					className="hidden size-5 shrink-0 text-muted-foreground group-hover:flex group-focus-within:flex"
+					onClick={(event) => {
+						event.stopPropagation();
+						onArchive(node);
+					}}
+					aria-label={`Archive ${node.title}`}
+					title="Archive"
+				>
+					<X className="size-3" />
+				</Button>
+			</div>
+			{expanded &&
+				node.children.map((child) => (
+					<WorktreeSessionRow
+						key={child.id}
+						node={child}
+						indentPx={indentPx + WORKFLOW_NAME_OFFSET_PX}
+						agentState={sessionAgentStates.get(child.id) ?? child.agentState}
+						selected={isWorkflowSessionSelected(centerSelection, node, child)}
+						showClose={false}
+						onSelect={() => onSelectSession(node, child)}
+					/>
+				))}
+		</div>
+	);
+}
+
+function WorktreeTreeItem({
+	branch,
+	repoName,
+	selectedRootPath,
+	centerSelection,
+	onSelectWorktree,
+	onDelete,
+}: {
+	branch: WorktreeBranch;
+	repoName: string;
+	selectedRootPath: string | null;
+	centerSelection: CenterSelection | null;
+	onSelectWorktree: WorkspaceListProps["onSelectWorktree"];
+	onDelete: (branch: WorktreeBranch) => void;
+}) {
+	const [expanded, setExpanded] = useState(true);
+	const [worktreeMenuOpen, setWorktreeMenuOpen] = useState(false);
+	const [createMenuOpen, setCreateMenuOpen] = useState(false);
+	const [selectedWorkflowName, setSelectedWorkflowName] = useState<
+		string | null
+	>(null);
+	const [workflowTaskInput, setWorkflowTaskInput] = useState("");
+	const [workflowStartError, setWorkflowStartError] = useState<string | null>(
+		null,
+	);
+	const [workflowStarting, setWorkflowStarting] = useState(false);
+	const scopedCenterSelection =
+		centerSelection?.worktreePath === branch.worktree_path
+			? centerSelection
+			: null;
+	const isSelected =
+		branch.worktree_path === selectedRootPath && scopedCenterSelection == null;
+	const actionControlsVisible = worktreeMenuOpen || createMenuOpen;
+	const hasWorktree = branch.worktree_path != null;
+	const canDelete = !branch.is_main_worktree;
+	const {
+		nodes,
+		closedSessions,
+		workflowHistory,
+		loading: treeLoading,
+		error: treeError,
+		refresh: refreshTree,
+	} = useWorkspaceTreeNodes(branch.worktree_path);
+	const {
+		workflows,
+		loading: workflowsLoading,
+		error: workflowsError,
+	} = useWorkflowConfig(createMenuOpen);
+	const sessionStatuses = useWorktreeSessionStatuses(branch.worktree_path);
+	const sessionAgentStates = useMemo(() => {
+		const map = new Map<string, WorkspaceSessionNode["agentState"]>();
+		for (const [sessionId, status] of sessionStatuses) {
+			map.set(sessionId, status.agent_state);
+		}
+		return map;
+	}, [sessionStatuses]);
+
+	const selectCenter = useCallback(
+		(centerSelection: CenterSelection) => {
+			if (!branch.worktree_path) return;
+			onSelectWorktree(
+				branch.worktree_path,
+				branch.name,
+				repoName,
+				centerSelection,
+			);
+		},
+		[branch.name, branch.worktree_path, onSelectWorktree, repoName],
+	);
+
+	const handleSelectSession = useCallback(
+		(node: WorkspaceSessionNode) => {
+			if (!branch.worktree_path) return;
+			selectCenter({
+				kind: "agentSession",
+				worktreePath: branch.worktree_path,
+				sessionId: node.id,
+			});
+		},
+		[branch.worktree_path, selectCenter],
+	);
+
+	const handleSelectWorkflowSession = useCallback(
+		(workflow: WorkspaceWorkflowNode, node: WorkspaceSessionNode) => {
+			if (!branch.worktree_path) return;
+			selectCenter({
+				kind: "workflowRun",
+				worktreePath: branch.worktree_path,
+				runId: workflow.runId,
+				focus: {
+					sessionId: node.id,
+					stepName: node.stepName ?? node.title,
+					runIndex: node.runIndex ?? undefined,
+				},
+			});
+		},
+		[branch.worktree_path, selectCenter],
+	);
+
+	const handleRestoreWorkflow = useCallback(
+		async (workflow: WorkspaceWorkflowHistoryItem) => {
+			if (!branch.worktree_path) return;
+			await invoke("restore_workspace_workflow_run", {
+				worktreePath: branch.worktree_path,
+				runId: workflow.runId,
+			});
+			await refreshTree();
+			selectCenter({
+				kind: "workflowRun",
+				worktreePath: branch.worktree_path,
+				runId: workflow.runId,
+			});
+		},
+		[branch.worktree_path, refreshTree, selectCenter],
+	);
+
+	const handleArchiveWorkflow = useCallback(
+		async (workflow: WorkspaceWorkflowNode) => {
+			if (!branch.worktree_path) return;
+			await invoke("archive_workspace_workflow_run", {
+				worktreePath: branch.worktree_path,
+				runId: workflow.runId,
+			});
+			await refreshTree();
+		},
+		[branch.worktree_path, refreshTree],
+	);
+
+	const handleNewSession = useCallback(() => {
+		if (!branch.worktree_path) return;
+		selectCenter({
+			kind: "newAgentSession",
+			worktreePath: branch.worktree_path,
+		});
+	}, [branch.worktree_path, selectCenter]);
+
+	const handleSelectWorkflowForStart = useCallback((workflowName: string) => {
+		setCreateMenuOpen(false);
+		setSelectedWorkflowName(workflowName);
+		setWorkflowTaskInput("");
+		setWorkflowStartError(null);
+	}, []);
+
+	const handleStartWorkflow = useCallback(async () => {
+		if (!branch.worktree_path || !selectedWorkflowName || workflowStarting) {
+			return;
+		}
+		setWorkflowStarting(true);
+		setWorkflowStartError(null);
+		try {
+			const runId = await invoke<string>("start_workflow", {
+				workflowName: selectedWorkflowName,
+				worktreePath: branch.worktree_path,
+				task: workflowTaskInput.trim() || null,
+				permissionMode: "ask",
+			});
+			setSelectedWorkflowName(null);
+			setWorkflowTaskInput("");
+			await refreshTree();
+			selectCenter({
+				kind: "workflowRun",
+				worktreePath: branch.worktree_path,
+				runId,
+			});
+		} catch (e) {
+			setWorkflowStartError(String(e));
+		} finally {
+			setWorkflowStarting(false);
+		}
+	}, [
+		branch.worktree_path,
+		refreshTree,
+		selectCenter,
+		selectedWorkflowName,
+		workflowStarting,
+		workflowTaskInput,
+	]);
+
+	const handleWorkflowDialogOpenChange = useCallback((open: boolean) => {
+		if (open) return;
+		setSelectedWorkflowName(null);
+		setWorkflowTaskInput("");
+		setWorkflowStartError(null);
+	}, []);
+
+	const handleCloseSession = useCallback(
+		async (sessionId: string) => {
+			await closeSessionApi(sessionId);
+			await refreshTree();
+		},
+		[refreshTree],
+	);
+
+	const handleRestoreSession = useCallback(
+		async (session: WorkspaceSessionHistoryItem) => {
+			if (!branch.worktree_path) return;
+			await restoreSession(session.id);
+			await refreshTree();
+			selectCenter({
+				kind: "agentSession",
+				worktreePath: branch.worktree_path,
+				sessionId: session.id,
+			});
+		},
+		[branch.worktree_path, refreshTree, selectCenter],
+	);
+
+	const handleArchiveSession = useCallback(
+		async (sessionId: string) => {
+			await archiveSession(sessionId);
+			await refreshTree();
+		},
+		[refreshTree],
+	);
+
+	return (
+		<div>
+			<div
+				className={`group flex h-8 w-full items-center gap-1 rounded-md px-2 text-sm transition-colors ${
+					isSelected
+						? "bg-foreground/10 text-foreground"
+						: hasWorktree
+							? "text-foreground hover:bg-foreground/5"
+							: "text-muted-foreground hover:bg-foreground/5"
+				}`}
+			>
+				<button
+					type="button"
+					data-testid={`worktree-item-${branch.name}`}
+					className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+					onClick={() => setExpanded((prev) => !prev)}
+				>
+					{branch.is_main_worktree ? (
+						<Home
+							className="size-3 shrink-0 text-muted-foreground"
+							aria-label="Main repository"
+						/>
+					) : (
+						<GitBranch
+							className="size-3 shrink-0 text-muted-foreground"
+							aria-label="Worktree"
+						/>
+					)}
+					<span className="min-w-0 truncate">{branch.name}</span>
+					{expanded ? (
+						<ChevronDown className="hidden size-3.5 shrink-0 text-muted-foreground group-hover:block" />
+					) : (
+						<ChevronRight className="hidden size-3.5 shrink-0 text-muted-foreground group-hover:block" />
+					)}
+				</button>
+				<div className="relative h-5 w-11 shrink-0">
+					<div
+						className={`absolute inset-0 items-center justify-end ${
+							actionControlsVisible
+								? "hidden"
+								: "flex group-hover:hidden group-focus-within:hidden"
+						}`}
+					>
+						<WorktreeIndicators branch={branch} />
+					</div>
+					<div
+						className={`absolute inset-0 transition-opacity ${
+							actionControlsVisible
+								? "visible opacity-100"
+								: "invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+						}`}
+					>
+						<DropdownMenu
+							open={worktreeMenuOpen}
+							onOpenChange={(open) => {
+								setWorktreeMenuOpen(open);
+								if (open) void refreshTree();
+							}}
+						>
+							<DropdownMenuTrigger asChild>
+								<Button
+									size="icon-xs"
+									variant="ghost"
+									className="absolute top-0 right-6 size-5 shrink-0 text-muted-foreground"
+									onClick={(event) => event.stopPropagation()}
+									aria-label={`Open menu for ${branch.name}`}
+									title="Menu"
+								>
+									<MoreHorizontal className="size-3" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								<DropdownMenuSub>
+									<DropdownMenuSubTrigger>
+										<MessageSquare className="size-3.5" />
+										SessionHistory
+									</DropdownMenuSubTrigger>
+									<DropdownMenuSubContent>
+										{closedSessions.length === 0 ? (
+											<DropdownMenuItem disabled>
+												No closed sessions
+											</DropdownMenuItem>
+										) : (
+											closedSessions.map((session) => (
+												<DropdownMenuItem
+													key={session.id}
+													onSelect={() => handleRestoreSession(session)}
+												>
+													<span className="max-w-52 truncate">
+														{sessionLabel(session)}
+													</span>
+													<Button
+														size="icon-xs"
+														variant="ghost"
+														className="ml-2 size-5"
+														onClick={(event) => {
+															event.preventDefault();
+															event.stopPropagation();
+															void handleArchiveSession(session.id);
+														}}
+														aria-label={`Archive ${sessionLabel(session)}`}
+														title="Archive"
+													>
+														<Archive className="size-3" />
+													</Button>
+												</DropdownMenuItem>
+											))
+										)}
+									</DropdownMenuSubContent>
+								</DropdownMenuSub>
+								<DropdownMenuSub>
+									<DropdownMenuSubTrigger>
+										<Workflow className="size-3.5" />
+										WorkflowHistory
+									</DropdownMenuSubTrigger>
+									<DropdownMenuSubContent>
+										{workflowHistory.length === 0 ? (
+											<DropdownMenuItem disabled>No workflows</DropdownMenuItem>
+										) : (
+											workflowHistory.map((node) => (
+												<DropdownMenuItem
+													key={node.runId}
+													onSelect={() => void handleRestoreWorkflow(node)}
+												>
+													<span className="max-w-52 truncate">
+														{node.title}
+													</span>
+												</DropdownMenuItem>
+											))
+										)}
+									</DropdownMenuSubContent>
+								</DropdownMenuSub>
+								<DropdownMenuItem
+									disabled={!branch.pr_url}
+									onSelect={() => {
+										if (branch.pr_url) {
+											openUrl(branch.pr_url);
+										}
+									}}
+								>
+									<ExternalLink className="size-3.5" />
+									PRリンク
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									variant="destructive"
+									disabled={!canDelete}
+									onSelect={() => {
+										if (canDelete) {
+											onDelete(branch);
+										}
+									}}
+								>
+									<Trash2 className="size-3.5" />
+									削除
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
+						<DropdownMenu
+							open={createMenuOpen}
+							onOpenChange={(open) => {
+								setCreateMenuOpen(open);
+								if (open) void refreshTree();
+							}}
+						>
+							<DropdownMenuTrigger asChild>
+								<Button
+									size="icon-xs"
+									variant="ghost"
+									className="absolute top-0 right-0 size-5 shrink-0 text-muted-foreground"
+									disabled={!hasWorktree}
+									onClick={(event) => event.stopPropagation()}
+									aria-label={`Create in ${branch.name}`}
+									title="Create"
+								>
+									<Plus className="size-3" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end" className="w-56">
+								<DropdownMenuItem onSelect={handleNewSession}>
+									<MessageSquare className="size-3.5" />
+									NewSession
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
+								<DropdownMenuSub>
+									<DropdownMenuSubTrigger>
+										<Workflow className="size-3.5" />
+										NewWorkflow
+									</DropdownMenuSubTrigger>
+									<DropdownMenuSubContent className="w-64">
+										{workflowsLoading ? (
+											<DropdownMenuItem disabled>
+												<Loader2 className="size-3.5 animate-spin" />
+												Loading workflows
+											</DropdownMenuItem>
+										) : workflowsError ? (
+											<DropdownMenuItem disabled>
+												<span className="truncate text-destructive">
+													{workflowsError}
+												</span>
+											</DropdownMenuItem>
+										) : workflows.length === 0 ? (
+											<DropdownMenuItem disabled>
+												No workflows configured
+											</DropdownMenuItem>
+										) : (
+											workflows.map((workflow) => (
+												<DropdownMenuItem
+													key={workflow.name}
+													onSelect={() =>
+														handleSelectWorkflowForStart(workflow.name)
+													}
+												>
+													<div className="min-w-0">
+														<div className="truncate">{workflow.name}</div>
+														{workflow.description && (
+															<div className="truncate text-xs text-muted-foreground">
+																{workflow.description}
+															</div>
+														)}
+													</div>
+												</DropdownMenuItem>
+											))
+										)}
+									</DropdownMenuSubContent>
+								</DropdownMenuSub>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
+				</div>
+			</div>
+			{expanded && hasWorktree && (
+				<div className="mt-0.5">
+					{treeLoading ? (
+						<div
+							className="flex h-8 items-center text-muted-foreground"
+							style={{ paddingLeft: WORKTREE_NAME_INDENT_PX }}
+						>
+							<Loader2 className="size-3.5 animate-spin" />
+						</div>
+					) : treeError && nodes.length === 0 ? (
+						<div
+							className="truncate py-1 text-xs text-destructive"
+							style={{ paddingLeft: WORKTREE_NAME_INDENT_PX }}
+						>
+							{treeError}
+						</div>
+					) : (
+						nodes.map((node) =>
+							node.kind === "workflow" ? (
+								<WorktreeWorkflowRow
+									key={node.runId}
+									node={node}
+									indentPx={WORKTREE_NAME_INDENT_PX}
+									selected={isWorkflowSelected(scopedCenterSelection, node)}
+									centerSelection={scopedCenterSelection}
+									sessionAgentStates={sessionAgentStates}
+									onSelectSession={handleSelectWorkflowSession}
+									onArchive={(workflow) => void handleArchiveWorkflow(workflow)}
+								/>
+							) : (
+								<WorktreeSessionRow
+									key={node.id}
+									node={node}
+									indentPx={WORKTREE_NAME_INDENT_PX}
+									agentState={
+										sessionAgentStates.get(node.id) ?? node.agentState
+									}
+									selected={isDirectSessionSelected(
+										scopedCenterSelection,
+										node,
+									)}
+									showClose
+									onSelect={() => handleSelectSession(node)}
+									onClose={() => void handleCloseSession(node.id)}
+								/>
+							),
+						)
+					)}
+				</div>
+			)}
+			<Dialog
+				open={selectedWorkflowName != null}
+				onOpenChange={handleWorkflowDialogOpenChange}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>NewWorkflow</DialogTitle>
+						<DialogDescription>{selectedWorkflowName}</DialogDescription>
+					</DialogHeader>
+					<form
+						className="space-y-4"
+						onSubmit={(event) => {
+							event.preventDefault();
+							void handleStartWorkflow();
+						}}
+					>
+						<Textarea
+							value={workflowTaskInput}
+							onChange={(event) => setWorkflowTaskInput(event.target.value)}
+							placeholder="Task description (optional)"
+							aria-label="Workflow task"
+							disabled={workflowStarting}
+						/>
+						{workflowStartError && (
+							<div
+								role="alert"
+								className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+							>
+								{workflowStartError}
+							</div>
+						)}
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => handleWorkflowDialogOpenChange(false)}
+								disabled={workflowStarting}
+							>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={workflowStarting}>
+								{workflowStarting ? "Starting..." : "Start"}
+							</Button>
+						</DialogFooter>
+					</form>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}
+
+function RepoTreeSectionView({
 	repoPath,
 	branches,
 	loading,
 	refresh,
 	selectedRootPath,
+	centerSelection,
 	onSelectWorktree,
-	groupMode,
-	filterStatus,
-	statusFilter,
 }: {
 	repoPath: string;
 	branches: WorktreeBranch[];
 	loading: boolean;
 	refresh: (options?: { silent?: boolean }) => Promise<void>;
 	selectedRootPath: string | null;
-	onSelectWorktree: (
-		rootPath: string,
-		branchName?: string,
-		repoName?: string,
-	) => void;
-	groupMode: GroupMode;
-	filterStatus?: WorktreeStatus;
-	statusFilter?: string;
+	centerSelection: CenterSelection | null;
+	onSelectWorktree: WorkspaceListProps["onSelectWorktree"];
 }) {
 	const [collapsed, setCollapsed] = useState(false);
+	const [refreshing, setRefreshing] = useState(false);
 	const [deletingBranch, setDeletingBranch] = useState<WorktreeBranch | null>(
 		null,
 	);
-	const [refreshing, setRefreshing] = useState(false);
-
-	const repoName = useMemo(
-		() => repoPath.split("/").filter(Boolean).pop() ?? "",
-		[repoPath],
-	);
+	const repoName = useMemo(() => repoNameFromPath(repoPath), [repoPath]);
 
 	const handleRefresh = useCallback(async () => {
 		setRefreshing(true);
@@ -151,181 +899,26 @@ function RepoWorktreeSectionView({
 		[repoPath, refresh],
 	);
 
-	const handleOpenBranch = useCallback(
-		(branch: WorktreeBranch) => {
-			if (branch.worktree_path) {
-				onSelectWorktree(branch.worktree_path, branch.name, repoName);
-			}
-		},
-		[repoName, onSelectWorktree],
-	);
-
-	const filteredBranches = useMemo(() => {
-		const filtered =
-			!statusFilter || statusFilter === "all"
-				? branches
-				: branches.filter((b) => computeStatus(b) === statusFilter);
-		return [...filtered].sort(
-			(a, b) =>
-				STATUS_ORDER.indexOf(computeStatus(a)) -
-				STATUS_ORDER.indexOf(computeStatus(b)),
-		);
-	}, [branches, statusFilter]);
-
-	const groupedByStatus = useMemo(() => {
-		const groups: Record<WorktreeStatus, WorktreeBranch[]> = {
-			backlog: [],
-			in_progress: [],
-			review: [],
-			done: [],
-		};
-		for (const b of filteredBranches) {
-			groups[computeStatus(b)].push(b);
-		}
-		return groups;
-	}, [filteredBranches]);
-
-	const renderItem = (branch: WorktreeBranch) => {
-		const isSelected = branch.worktree_path === selectedRootPath;
-		const hasWorktree = branch.worktree_path != null;
-		const canDelete = !branch.is_main_worktree;
-		const status = computeStatus(branch);
-
-		// 2行目テキスト部分を組み立て
-		const infoParts: string[] = [];
-		if (groupMode === "status") {
-			infoParts.push(repoName);
-		} else {
-			infoParts.push(STATUS_LABELS[status]);
-		}
-		if (branch.is_merged) infoParts.push("merged");
-		if (hasWorktree && branch.dirty_count > 0)
-			infoParts.push(`${branch.dirty_count} changed`);
-
-		return (
-			// biome-ignore lint/a11y/useSemanticElements: <button> cannot nest <button> (PR link, delete btn)
-			<div
-				key={branch.name}
-				role="button"
-				tabIndex={0}
-				data-testid={`worktree-item-${branch.name}`}
-				onClick={() => handleOpenBranch(branch)}
-				onKeyDown={(e) => {
-					if (e.target !== e.currentTarget) return;
-					if (e.key === "Enter" || e.key === " ") {
-						e.preventDefault();
-						handleOpenBranch(branch);
-					}
-				}}
-				className={`group relative flex items-start gap-1.5 w-full px-1.5 py-1.5 text-left rounded cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring ${
-					isSelected
-						? "bg-foreground/10 text-foreground"
-						: hasWorktree
-							? "text-foreground hover:bg-foreground/5"
-							: "text-muted-foreground hover:bg-foreground/5"
-				}`}
-			>
-				<div className="flex flex-col gap-1 min-w-0 flex-1">
-					{/* Row 1: icon + name + diff stats */}
-					<div className="flex items-center gap-1.5 min-w-0">
-						<AgentStateIcon state={branch.agent_state} />
-						<span className="text-xs font-medium truncate flex-1">
-							{branch.name}
-						</span>
-						{branch.is_main_worktree && (
-							<Home
-								className="shrink-0 size-3 text-muted-foreground"
-								aria-label="Main repository"
-							/>
-						)}
-						{branch.ahead > 0 && (
-							<span className="shrink-0 text-[11px] font-mono text-success/70">
-								+{branch.ahead}
-							</span>
-						)}
-						{branch.behind > 0 && (
-							<span className="shrink-0 text-[11px] font-mono text-destructive/70">
-								-{branch.behind}
-							</span>
-						)}
-					</div>
-					{/* Row 2: secondary info */}
-					<div className="flex items-center gap-1.5 pl-[20px] min-w-0 text-[11px] text-muted-foreground">
-						{infoParts.length > 0 && (
-							<span className="truncate">{infoParts.join(" · ")}</span>
-						)}
-						{branch.has_pr && branch.pr_url && branch.pr_number != null && (
-							<button
-								type="button"
-								className="shrink-0 ml-auto text-[11px] text-muted-foreground hover:text-foreground transition-colors"
-								onClick={(e) => {
-									e.stopPropagation();
-									openUrl(branch.pr_url as string);
-								}}
-							>
-								#{branch.pr_number}
-							</button>
-						)}
-					</div>
-				</div>
-				{canDelete && (
-					<Button
-						size="icon-xs"
-						variant="ghost"
-						className="absolute top-0.5 right-0.5 hidden group-hover:flex group-focus-within:flex size-4"
-						onClick={(e) => {
-							e.stopPropagation();
-							setDeletingBranch(branch);
-						}}
-						aria-label={`Delete ${branch.name}`}
-					>
-						<Trash2 className="size-2.5 text-muted-foreground" />
-					</Button>
-				)}
-			</div>
-		);
-	};
-
-	if (groupMode === "status" && filterStatus) {
-		const items = groupedByStatus[filterStatus];
-		return (
-			<>
-				{loading && (
-					<div className="flex items-center justify-center py-4">
-						<Loader2 className="size-4 text-muted-foreground animate-spin" />
-					</div>
-				)}
-				{!loading && items.length > 0 && <div>{items.map(renderItem)}</div>}
-				<DeleteWorktreeDialog
-					open={!!deletingBranch}
-					branch={deletingBranch}
-					onConfirm={handleDeleteConfirm}
-					onCancel={() => setDeletingBranch(null)}
-				/>
-			</>
-		);
-	}
-
 	return (
-		<div>
-			<div className="flex items-center gap-1.5 w-full px-2 py-1 text-xs font-semibold text-muted-foreground">
+		<div className="space-y-0.5">
+			<div className="flex h-7 items-center gap-1 px-2 text-xs font-medium text-muted-foreground">
 				<button
 					type="button"
+					className="flex min-w-0 flex-1 items-center gap-1.5 rounded text-left transition-colors hover:text-foreground"
 					onClick={() => setCollapsed((prev) => !prev)}
-					className="flex items-center gap-1.5 flex-1 min-w-0 hover:text-foreground transition-colors"
 				>
 					{collapsed ? (
-						<ChevronRight className="size-3.5" />
+						<ChevronRight className="size-3.5 shrink-0" />
 					) : (
-						<ChevronDown className="size-3.5" />
+						<ChevronDown className="size-3.5 shrink-0" />
 					)}
-					<span className="truncate">{repoName}</span>
-					<span className="ml-auto text-[10px]">{filteredBranches.length}</span>
+					<span className="min-w-0 flex-1 truncate">{repoName}</span>
+					<span className="shrink-0 text-[11px]">{branches.length}</span>
 				</button>
 				<Button
 					size="icon-xs"
 					variant="ghost"
-					className="size-5 ml-0.5"
+					className="size-5"
 					onClick={handleRefresh}
 					disabled={refreshing}
 					aria-label={`Refresh ${repoName}`}
@@ -335,13 +928,24 @@ function RepoWorktreeSectionView({
 				</Button>
 			</div>
 			{!collapsed && (
-				<div className="pl-2">
-					{loading && (
+				<div className="space-y-1">
+					{loading ? (
 						<div className="flex items-center justify-center py-4">
-							<Loader2 className="size-4 text-muted-foreground animate-spin" />
+							<Loader2 className="size-4 animate-spin text-muted-foreground" />
 						</div>
+					) : (
+						branches.map((branch) => (
+							<WorktreeTreeItem
+								key={branch.name}
+								branch={branch}
+								repoName={repoName}
+								selectedRootPath={selectedRootPath}
+								centerSelection={centerSelection}
+								onSelectWorktree={onSelectWorktree}
+								onDelete={setDeletingBranch}
+							/>
+						))
 					)}
-					{!loading && filteredBranches.map(renderItem)}
 				</div>
 			)}
 			<DeleteWorktreeDialog
@@ -354,176 +958,48 @@ function RepoWorktreeSectionView({
 	);
 }
 
-function RepoWorktreeSection({
+function RepoTreeSection({
 	repoPath,
 	selectedRootPath,
+	centerSelection,
 	onSelectWorktree,
-	groupMode,
-	filterStatus,
-	statusFilter,
 }: {
 	repoPath: string;
 	selectedRootPath: string | null;
-	onSelectWorktree: (
-		rootPath: string,
-		branchName?: string,
-		repoName?: string,
-	) => void;
-	groupMode: GroupMode;
-	filterStatus?: WorktreeStatus;
-	statusFilter?: string;
+	centerSelection: CenterSelection | null;
+	onSelectWorktree: WorkspaceListProps["onSelectWorktree"];
 }) {
 	const { branches, loading, refresh } = useWorktreeList(repoPath);
 	return (
-		<RepoWorktreeSectionView
+		<RepoTreeSectionView
 			repoPath={repoPath}
 			branches={branches}
 			loading={loading}
 			refresh={refresh}
 			selectedRootPath={selectedRootPath}
+			centerSelection={centerSelection}
 			onSelectWorktree={onSelectWorktree}
-			groupMode={groupMode}
-			filterStatus={filterStatus}
-			statusFilter={statusFilter}
 		/>
 	);
-}
-
-function RepoWorktreeFetcher({
-	repoPath,
-	onData,
-}: {
-	repoPath: string;
-	onData: (repoPath: string, data: WorktreeData) => void;
-}) {
-	const { branches, loading, refresh } = useWorktreeList(repoPath);
-	const onDataRef = useRef(onData);
-	onDataRef.current = onData;
-
-	useEffect(() => {
-		onDataRef.current(repoPath, { branches, loading, refresh });
-	}, [repoPath, branches, loading, refresh]);
-
-	return null;
 }
 
 export function WorkspaceList({
 	repoPaths,
 	selectedRootPath,
+	centerSelection,
 	onSelectWorktree,
 	onAddRepo,
 	onShowSettings,
 }: WorkspaceListProps) {
-	const [groupMode, setGroupMode] = useState<GroupMode>("repository");
 	const [showCreate, setShowCreate] = useState(false);
-	const [statusFilter, setStatusFilter] = useState("all");
-	const [repoFilter, setRepoFilter] = useState("all");
-
-	const filteredRepoPaths = useMemo(
-		() =>
-			repoFilter === "all"
-				? repoPaths
-				: repoPaths.filter((p) => p === repoFilter),
-		[repoPaths, repoFilter],
-	);
-
-	const repoNames = useMemo(
-		() =>
-			repoPaths.map((p) => ({
-				path: p,
-				name: p.split("/").filter(Boolean).pop() ?? "",
-			})),
-		[repoPaths],
-	);
 
 	return (
-		<div className="flex flex-col h-full">
-			{/* Header */}
-			<div className="flex items-center justify-between h-9 px-2 shrink-0">
+		<div className="flex h-full flex-col">
+			<div className="flex h-9 shrink-0 items-center justify-between px-2">
 				<span className="text-xs font-semibold tracking-wide text-muted-foreground">
 					Workspaces
 				</span>
 				<div className="flex items-center gap-0.5">
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button
-								size="icon-xs"
-								variant="ghost"
-								className="size-5"
-								aria-label="Group"
-								title="Group by"
-							>
-								<LayoutList className="size-3" />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end" className="p-2">
-							<DropdownMenuLabel className="p-0 pb-1 text-xs font-normal text-muted-foreground">
-								Group by
-							</DropdownMenuLabel>
-							<Select
-								value={groupMode}
-								onValueChange={(v) => setGroupMode(v as GroupMode)}
-							>
-								<SelectTrigger className="h-6">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectGroup>
-										<SelectItem value="repository">Repo</SelectItem>
-										<SelectItem value="status">Status</SelectItem>
-									</SelectGroup>
-								</SelectContent>
-							</Select>
-						</DropdownMenuContent>
-					</DropdownMenu>
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button
-								size="icon-xs"
-								variant="ghost"
-								className="size-5"
-								aria-label="Filter"
-								title="Filter"
-							>
-								<Filter className="size-3" />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end" className="p-2">
-							<DropdownMenuLabel className="p-0 pb-1 text-xs font-normal text-muted-foreground">
-								Filter
-							</DropdownMenuLabel>
-							<Select
-								value={groupMode === "repository" ? statusFilter : repoFilter}
-								onValueChange={(v) => {
-									if (groupMode === "repository") {
-										setStatusFilter(v);
-									} else {
-										setRepoFilter(v);
-									}
-								}}
-							>
-								<SelectTrigger className="h-6">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectGroup>
-										<SelectItem value="all">All</SelectItem>
-										{groupMode === "repository"
-											? STATUS_ORDER.map((s) => (
-													<SelectItem key={s} value={s}>
-														{STATUS_LABELS[s]}
-													</SelectItem>
-												))
-											: repoNames.map((r) => (
-													<SelectItem key={r.path} value={r.path}>
-														{r.name}
-													</SelectItem>
-												))}
-									</SelectGroup>
-								</SelectContent>
-							</Select>
-						</DropdownMenuContent>
-					</DropdownMenu>
 					<Button
 						size="icon-xs"
 						variant="ghost"
@@ -537,58 +1013,44 @@ export function WorkspaceList({
 				</div>
 			</div>
 
-			{/* Worktree List */}
-			<div className="flex-1 overflow-y-auto px-0.5 py-0.5 space-y-0.5">
-				{groupMode === "status" ? (
-					<StatusGroupedView
-						repoPaths={filteredRepoPaths}
+			<div className="flex-1 space-y-2 overflow-y-auto px-2 py-1">
+				{repoPaths.map((repoPath) => (
+					<RepoTreeSection
+						key={repoPath}
+						repoPath={repoPath}
 						selectedRootPath={selectedRootPath}
+						centerSelection={centerSelection ?? null}
 						onSelectWorktree={onSelectWorktree}
 					/>
-				) : (
-					repoPaths.map((repoPath) => (
-						<RepoWorktreeSection
-							key={repoPath}
-							repoPath={repoPath}
-							selectedRootPath={selectedRootPath}
-							onSelectWorktree={onSelectWorktree}
-							groupMode="repository"
-							statusFilter={statusFilter}
-						/>
-					))
-				)}
+				))}
 				{repoPaths.length === 0 && (
-					<div className="text-xs text-muted-foreground text-center py-8">
-						No repositories
+					<div className="px-2 py-8 text-center text-xs text-muted-foreground">
+						リポジトリなし
 					</div>
 				)}
 			</div>
 
-			{/* Bottom buttons */}
-			<div className="flex items-center justify-between h-[36px] px-2 border-t border-border shrink-0">
+			<div className="flex h-9 shrink-0 items-center justify-between border-t border-border px-2">
 				<Button
 					size="sm"
 					variant="ghost"
 					className="h-7 px-2 text-xs"
 					onClick={onAddRepo}
 				>
-					<Plus className="size-3.5 mr-1" />
+					<Plus className="mr-1 size-3.5" />
 					Add Repository
 				</Button>
-				<div className="flex items-center gap-0.5">
-					<Button
-						size="icon"
-						variant="ghost"
-						className="size-7"
-						onClick={onShowSettings}
-						title="Settings"
-					>
-						<Settings className="size-3.5" />
-					</Button>
-				</div>
+				<Button
+					size="icon"
+					variant="ghost"
+					className="size-7"
+					onClick={onShowSettings}
+					title="Settings"
+				>
+					<Settings className="size-3.5" />
+				</Button>
 			</div>
 
-			{/* Create Worktree Modal */}
 			{showCreate && repoPaths.length > 0 && (
 				<CreateWorktreeModal
 					open={showCreate}
@@ -602,110 +1064,5 @@ export function WorkspaceList({
 				/>
 			)}
 		</div>
-	);
-}
-
-function StatusGroupSection({
-	status,
-	repoPaths,
-	worktreeDataMap,
-	selectedRootPath,
-	onSelectWorktree,
-}: {
-	status: WorktreeStatus;
-	repoPaths: string[];
-	worktreeDataMap: Map<string, WorktreeData>;
-	selectedRootPath: string | null;
-	onSelectWorktree: (
-		rootPath: string,
-		branchName?: string,
-		repoName?: string,
-	) => void;
-}) {
-	const [collapsed, setCollapsed] = useState(false);
-
-	return (
-		<div>
-			<button
-				type="button"
-				onClick={() => setCollapsed((prev) => !prev)}
-				className="flex items-center gap-1.5 w-full px-2 py-1 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors"
-			>
-				{collapsed ? (
-					<ChevronRight className="size-3.5" />
-				) : (
-					<ChevronDown className="size-3.5" />
-				)}
-				<span>{STATUS_LABELS[status]}</span>
-			</button>
-			{!collapsed && (
-				<div className="pl-2">
-					{repoPaths.map((repoPath) => {
-						const data = worktreeDataMap.get(repoPath);
-						return (
-							<RepoWorktreeSectionView
-								key={repoPath}
-								repoPath={repoPath}
-								branches={data?.branches ?? []}
-								loading={data?.loading ?? true}
-								refresh={data?.refresh ?? noopRefresh}
-								selectedRootPath={selectedRootPath}
-								onSelectWorktree={onSelectWorktree}
-								groupMode="status"
-								filterStatus={status}
-							/>
-						);
-					})}
-				</div>
-			)}
-		</div>
-	);
-}
-
-function StatusGroupedView({
-	repoPaths,
-	selectedRootPath,
-	onSelectWorktree,
-}: {
-	repoPaths: string[];
-	selectedRootPath: string | null;
-	onSelectWorktree: (
-		rootPath: string,
-		branchName?: string,
-		repoName?: string,
-	) => void;
-}) {
-	const [worktreeDataMap, setWorktreeDataMap] = useState<
-		Map<string, WorktreeData>
-	>(() => new Map());
-
-	const handleData = useCallback((repoPath: string, data: WorktreeData) => {
-		setWorktreeDataMap((prev) => {
-			const next = new Map(prev);
-			next.set(repoPath, data);
-			return next;
-		});
-	}, []);
-
-	return (
-		<>
-			{repoPaths.map((repoPath) => (
-				<RepoWorktreeFetcher
-					key={repoPath}
-					repoPath={repoPath}
-					onData={handleData}
-				/>
-			))}
-			{STATUS_ORDER.map((status) => (
-				<StatusGroupSection
-					key={status}
-					status={status}
-					repoPaths={repoPaths}
-					worktreeDataMap={worktreeDataMap}
-					selectedRootPath={selectedRootPath}
-					onSelectWorktree={onSelectWorktree}
-				/>
-			))}
-		</>
 	);
 }

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -313,6 +313,33 @@ describe("useAgentChat", () => {
 		);
 	});
 
+	it("sendMessage refreshes workspace tree after summaries change", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+		try {
+			const { result } = renderHook(() => useAgentChat("/repo"));
+
+			await act(async () => {
+				await result.current.sendMessage(
+					result.current.activeSession?.id ?? null,
+					"hello",
+				);
+			});
+
+			const refreshEvent = dispatchSpy.mock.calls
+				.map(([event]) => event)
+				.find(
+					(event): event is CustomEvent<{ worktreePath: string }> =>
+						event.type === "workspace-tree-refresh",
+				);
+			expect(refreshEvent?.detail).toEqual({ worktreePath: "/repo" });
+		} finally {
+			dispatchSpy.mockRestore();
+		}
+	});
+
 	it("sendMessage passes selected backend when Rust creates the session", async () => {
 		const { renderHook, act } = await import("@testing-library/react");
 		const { useAgentChat } = await import("./useAgentChat");

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -1178,8 +1178,9 @@ describe("useAgentChat", () => {
 			newSession as never,
 		);
 
+		let createdSessionId: string | null = null;
 		await act(async () => {
-			await result.current.createNewSession();
+			createdSessionId = await result.current.createNewSession();
 		});
 
 		expect(sessionStore.createSession).toHaveBeenCalledWith(
@@ -1188,6 +1189,7 @@ describe("useAgentChat", () => {
 			null,
 		);
 		expect(result.current.activeSession).toEqual(newSession);
+		expect(createdSessionId).toBe("new-s");
 		expect(mockInvoke).not.toHaveBeenCalledWith(
 			"start_agent_session",
 			expect.anything(),

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -56,6 +56,15 @@ export type { ActivityStatus } from "./deriveActivityStatus";
 
 const DEFAULT_SESSION_TITLE = "NewSession";
 
+function dispatchWorkspaceTreeRefresh(worktreePath: string): void {
+	if (typeof window === "undefined") return;
+	window.dispatchEvent(
+		new CustomEvent("workspace-tree-refresh", {
+			detail: { worktreePath },
+		}),
+	);
+}
+
 type RefreshSessionsOptions = { reconcileActiveSession?: boolean };
 export type SendMessageOptions = {
 	activateNewSession?: boolean;
@@ -508,6 +517,7 @@ export function useAgentChat(
 					});
 				}
 				dispatch({ type: "SET_SESSIONS", sessions: response.sessions });
+				dispatchWorkspaceTreeRefresh(response.session.worktreePath);
 			} catch (e) {
 				dispatch({
 					type: "SET_ERROR",

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -54,6 +54,8 @@ import { useWorktreeSessionStatuses } from "./useWorktreeSessionStatuses";
 
 export type { ActivityStatus } from "./deriveActivityStatus";
 
+const DEFAULT_SESSION_TITLE = "NewSession";
+
 type RefreshSessionsOptions = { reconcileActiveSession?: boolean };
 export type SendMessageOptions = {
 	activateNewSession?: boolean;
@@ -105,7 +107,7 @@ export interface UseAgentChatResult {
 	restoreSession: (sessionId: string) => Promise<void>;
 	forkSession: (sessionId: string) => Promise<void>;
 	setSessionTitle: (sessionId: string, title: string | null) => Promise<string>;
-	createNewSession: () => Promise<void>;
+	createNewSession: () => Promise<string | null>;
 	reorderSessions: (sessionOrder: string[]) => void;
 	setPermissionMode: (sessionId: string | null, mode: PermissionMode) => void;
 	setPlanMode: (sessionId: string | null, enabled: PlanMode) => void;
@@ -720,7 +722,7 @@ export function useAgentChat(
 				const summary = await setSessionTitleApi(sessionId, title);
 				await refreshSessions();
 				await refreshClosedSessions();
-				return summary.firstMessage || "New session";
+				return summary.firstMessage || DEFAULT_SESSION_TITLE;
 			} catch (e) {
 				dispatch({
 					type: "SET_ERROR",
@@ -732,7 +734,7 @@ export function useAgentChat(
 		[refreshSessions, refreshClosedSessions],
 	);
 
-	const createNewSession = useCallback(async () => {
+	const createNewSession = useCallback(async (): Promise<string | null> => {
 		try {
 			const activeSessionSnapshot = activeSessionIdRef.current
 				? sessionsByIdRef.current[activeSessionIdRef.current]
@@ -769,11 +771,13 @@ export function useAgentChat(
 				dispatchSessionMeta(dispatch, session.id, response);
 			}
 			await refreshSessions();
+			return activeSession.id;
 		} catch (e) {
 			dispatch({
 				type: "SET_ERROR",
 				error: `セッション作成に失敗: ${e}`,
 			});
+			return null;
 		}
 	}, [refreshSessions]);
 

--- a/src/hooks/useWorkspaceTreeNodes.test.ts
+++ b/src/hooks/useWorkspaceTreeNodes.test.ts
@@ -125,6 +125,92 @@ describe("useWorkspaceTreeNodes", () => {
 		});
 	});
 
+	it("unsubscribes listeners when cleanup runs after setup completes", async () => {
+		const unlistenStatus = vi.fn();
+		const unlistenWorkflow = vi.fn();
+		mockListen.mockImplementation(
+			(event: string, fn: (event: { payload: unknown }) => void) => {
+				listeners[event] = [...(listeners[event] ?? []), fn];
+				if (event === "session-status-changed") {
+					return Promise.resolve(unlistenStatus);
+				}
+				if (event === "workflow-state-changed") {
+					return Promise.resolve(unlistenWorkflow);
+				}
+				return Promise.resolve(vi.fn());
+			},
+		);
+
+		const { unmount } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+
+		await waitFor(() => {
+			expect(mockListen).toHaveBeenCalledTimes(2);
+		});
+
+		unmount();
+
+		expect(unlistenStatus).toHaveBeenCalledTimes(1);
+		expect(unlistenWorkflow).toHaveBeenCalledTimes(1);
+	});
+
+	it("unsubscribes the status listener if cleanup runs before setup completes", async () => {
+		const pendingStatus = deferred<() => void>();
+		const unlistenStatus = vi.fn();
+		mockListen.mockImplementationOnce(() => pendingStatus.promise);
+
+		const { unmount } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+
+		await waitFor(() => {
+			expect(mockListen).toHaveBeenCalledTimes(1);
+		});
+
+		unmount();
+
+		await act(async () => {
+			pendingStatus.resolve(unlistenStatus);
+			await pendingStatus.promise;
+		});
+
+		expect(unlistenStatus).toHaveBeenCalledTimes(1);
+		expect(mockListen).toHaveBeenCalledTimes(1);
+	});
+
+	it("unsubscribes the workflow listener if cleanup runs before it resolves", async () => {
+		const pendingWorkflow = deferred<() => void>();
+		const unlistenStatus = vi.fn();
+		const unlistenWorkflow = vi.fn();
+		mockListen.mockImplementation(
+			(event: string, fn: (event: { payload: unknown }) => void) => {
+				listeners[event] = [...(listeners[event] ?? []), fn];
+				if (event === "session-status-changed") {
+					return Promise.resolve(unlistenStatus);
+				}
+				if (event === "workflow-state-changed") {
+					return pendingWorkflow.promise;
+				}
+				return Promise.resolve(vi.fn());
+			},
+		);
+
+		const { unmount } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+
+		await waitFor(() => {
+			expect(mockListen).toHaveBeenCalledTimes(2);
+		});
+
+		unmount();
+
+		expect(unlistenStatus).toHaveBeenCalledTimes(1);
+		expect(unlistenWorkflow).not.toHaveBeenCalled();
+
+		await act(async () => {
+			pendingWorkflow.resolve(unlistenWorkflow);
+			await pendingWorkflow.promise;
+		});
+
+		expect(unlistenWorkflow).toHaveBeenCalledTimes(1);
+	});
+
 	it("keeps existing nodes visible during background refresh", async () => {
 		const initial = [makeSessionNode("session-1")];
 		const next = [makeSessionNode("session-1"), makeSessionNode("session-2")];

--- a/src/hooks/useWorkspaceTreeNodes.test.ts
+++ b/src/hooks/useWorkspaceTreeNodes.test.ts
@@ -1,0 +1,267 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionStatus } from "@/types/session";
+import type { WorkflowState, WorkflowStatePayload } from "@/types/workflow";
+import type { WorkspaceTreeNode } from "@/types/workspace-tree";
+import { useWorkspaceTreeNodes } from "./useWorkspaceTreeNodes";
+
+const mockInvoke = vi.fn();
+const mockListen = vi.fn();
+const mockListClosedSessions = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: (...args: unknown[]) => mockListen(...args),
+}));
+
+vi.mock("@/hooks/useSessionStore", () => ({
+	listClosedSessions: (...args: unknown[]) => mockListClosedSessions(...args),
+}));
+
+type ListenerMap = Record<string, Array<(event: { payload: unknown }) => void>>;
+
+function makeSessionNode(id: string): WorkspaceTreeNode {
+	return {
+		kind: "session",
+		id,
+		worktreePath: "/repo",
+		title: id,
+		state: "active",
+		updatedAt: 1_000,
+		workflowStepSession: false,
+		agentState: "running",
+	};
+}
+
+function makeStatus(overrides: Partial<SessionStatus> = {}): SessionStatus {
+	return {
+		chat_session_id: "session-1",
+		worktree_id: "/repo",
+		worktree_path: "/repo",
+		pty_id: null,
+		agent_state: "running",
+		turn_phase: "streaming",
+		session_state: "active",
+		pending_permission: false,
+		last_activity_at: 1_000,
+		...overrides,
+	};
+}
+
+function makeWorkflowState(
+	overrides: Partial<WorkflowState> = {},
+): WorkflowState {
+	return {
+		executionId: "run-1",
+		workflowName: "workflow",
+		state: { type: "running" },
+		currentStepIndex: 0,
+		currentStepName: "step",
+		totalSteps: 1,
+		stepHistory: [],
+		stepExecutionCounts: {},
+		stepOutputs: {},
+		workflowDefinition: {
+			name: "workflow",
+			description: "",
+			builtin: false,
+			nodes: [],
+		},
+		totalTokenUsage: { inputTokens: 0, outputTokens: 0 },
+		stepStates: {},
+		startedAt: 1_000,
+		updatedAt: 1_000,
+		...overrides,
+	};
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+function countTreeFetches(): number {
+	return mockInvoke.mock.calls.filter(
+		([command]) => command === "list_workspace_worktree_nodes",
+	).length;
+}
+
+async function waitForScheduledRefresh() {
+	await new Promise((resolve) => window.setTimeout(resolve, 100));
+}
+
+describe("useWorkspaceTreeNodes", () => {
+	let listeners: ListenerMap;
+	let treeResponses: Array<WorkspaceTreeNode[] | Promise<WorkspaceTreeNode[]>>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		listeners = {};
+		treeResponses = [];
+		mockListClosedSessions.mockResolvedValue([]);
+		mockListen.mockImplementation(
+			(event: string, fn: (event: { payload: unknown }) => void) => {
+				listeners[event] = [...(listeners[event] ?? []), fn];
+				return Promise.resolve(vi.fn());
+			},
+		);
+		mockInvoke.mockImplementation((command: string) => {
+			if (command === "list_workspace_worktree_nodes") {
+				const response = treeResponses.shift() ?? [];
+				return Promise.resolve(response);
+			}
+			if (command === "list_workspace_workflow_history") {
+				return Promise.resolve([]);
+			}
+			return Promise.resolve(null);
+		});
+	});
+
+	it("keeps existing nodes visible during background refresh", async () => {
+		const initial = [makeSessionNode("session-1")];
+		const next = [makeSessionNode("session-1"), makeSessionNode("session-2")];
+		treeResponses.push(initial);
+
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+
+		await waitFor(() => {
+			expect(result.current.nodes).toEqual(initial);
+		});
+
+		const pending = deferred<WorkspaceTreeNode[]>();
+		treeResponses.push(pending.promise);
+
+		let refreshPromise!: Promise<void>;
+		act(() => {
+			refreshPromise = result.current.refresh();
+		});
+
+		expect(result.current.loading).toBe(false);
+		expect(result.current.nodes).toEqual(initial);
+
+		await act(async () => {
+			pending.resolve(next);
+			await refreshPromise;
+		});
+
+		expect(result.current.nodes).toEqual(next);
+	});
+
+	it("keeps existing nodes when a background refresh fails", async () => {
+		const initial = [makeSessionNode("session-1")];
+		treeResponses.push(initial);
+
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+
+		await waitFor(() => {
+			expect(result.current.nodes).toEqual(initial);
+		});
+
+		treeResponses.push(Promise.reject(new Error("boom")));
+
+		await act(async () => {
+			await result.current.refresh();
+		});
+
+		expect(result.current.loading).toBe(false);
+		expect(result.current.nodes).toEqual(initial);
+		expect(result.current.error).toBe("Error: boom");
+	});
+
+	it("does not refresh the tree for known session status updates", async () => {
+		treeResponses.push([makeSessionNode("session-1")]);
+
+		renderHook(() => useWorkspaceTreeNodes("/repo"));
+
+		await waitFor(() => {
+			expect(countTreeFetches()).toBe(1);
+		});
+		await waitFor(() => {
+			expect(listeners["session-status-changed"]?.length).toBe(1);
+		});
+
+		await act(async () => {
+			listeners["session-status-changed"]?.[0]?.({
+				payload: makeStatus({ chat_session_id: "session-1" }),
+			});
+			await waitForScheduledRefresh();
+		});
+
+		expect(countTreeFetches()).toBe(1);
+	});
+
+	it("refreshes the tree when a new session appears", async () => {
+		treeResponses.push([makeSessionNode("session-1")]);
+
+		renderHook(() => useWorkspaceTreeNodes("/repo"));
+
+		await waitFor(() => {
+			expect(countTreeFetches()).toBe(1);
+		});
+		await waitFor(() => {
+			expect(listeners["session-status-changed"]?.length).toBe(1);
+		});
+
+		treeResponses.push([
+			makeSessionNode("session-1"),
+			makeSessionNode("session-2"),
+		]);
+		await act(async () => {
+			listeners["session-status-changed"]?.[0]?.({
+				payload: makeStatus({ chat_session_id: "session-2" }),
+			});
+			await waitForScheduledRefresh();
+		});
+
+		await waitFor(() => {
+			expect(countTreeFetches()).toBe(2);
+		});
+	});
+
+	it("refreshes the tree when a known workflow reaches a terminal state", async () => {
+		treeResponses.push([
+			{
+				kind: "workflow",
+				runId: "run-1",
+				worktreePath: "/repo",
+				title: "workflow",
+				status: "running",
+				updatedAt: 1_000,
+				children: [],
+			},
+		]);
+
+		renderHook(() => useWorkspaceTreeNodes("/repo"));
+
+		await waitFor(() => {
+			expect(countTreeFetches()).toBe(1);
+		});
+		await waitFor(() => {
+			expect(listeners["workflow-state-changed"]?.length).toBe(1);
+		});
+
+		treeResponses.push([]);
+		const payload: WorkflowStatePayload = {
+			worktreePath: "/repo",
+			workflowState: makeWorkflowState({
+				state: { type: "completed" },
+			}),
+		};
+		await act(async () => {
+			listeners["workflow-state-changed"]?.[0]?.({ payload });
+			await waitForScheduledRefresh();
+		});
+
+		await waitFor(() => {
+			expect(countTreeFetches()).toBe(2);
+		});
+	});
+});

--- a/src/hooks/useWorkspaceTreeNodes.ts
+++ b/src/hooks/useWorkspaceTreeNodes.ts
@@ -1,0 +1,202 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { listClosedSessions } from "@/hooks/useSessionStore";
+import type { SessionStatus } from "@/types/session";
+import type { WorkflowStatePayload } from "@/types/workflow";
+import type {
+	WorkspaceSessionHistoryItem,
+	WorkspaceTreeNode,
+	WorkspaceWorkflowHistoryItem,
+} from "@/types/workspace-tree";
+
+interface UseWorkspaceTreeNodesResult {
+	nodes: WorkspaceTreeNode[];
+	closedSessions: WorkspaceSessionHistoryItem[];
+	workflowHistory: WorkspaceWorkflowHistoryItem[];
+	loading: boolean;
+	error: string | null;
+	refresh: () => Promise<void>;
+}
+
+interface WorkspaceTreeRefreshDetail {
+	worktreePath?: string;
+}
+
+export function useWorkspaceTreeNodes(
+	worktreePath: string | null | undefined,
+): UseWorkspaceTreeNodesResult {
+	const [nodes, setNodes] = useState<WorkspaceTreeNode[]>([]);
+	const [closedSessions, setClosedSessions] = useState<
+		WorkspaceSessionHistoryItem[]
+	>([]);
+	const [workflowHistory, setWorkflowHistory] = useState<
+		WorkspaceWorkflowHistoryItem[]
+	>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const refreshTimerRef = useRef<number | null>(null);
+	const refreshSeqRef = useRef(0);
+	const loadedWorktreePathRef = useRef<string | null>(null);
+	const nodesRef = useRef<WorkspaceTreeNode[]>([]);
+
+	const updateNodes = useCallback((nextNodes: WorkspaceTreeNode[]) => {
+		nodesRef.current = nextNodes;
+		setNodes(nextNodes);
+	}, []);
+
+	const hasLoadedCurrentWorktree = useCallback(
+		() => loadedWorktreePathRef.current === worktreePath,
+		[worktreePath],
+	);
+
+	const refresh = useCallback(async () => {
+		if (!worktreePath) {
+			refreshSeqRef.current += 1;
+			loadedWorktreePathRef.current = null;
+			nodesRef.current = [];
+			setNodes([]);
+			setClosedSessions([]);
+			setWorkflowHistory([]);
+			setLoading(false);
+			setError(null);
+			return;
+		}
+		const seq = ++refreshSeqRef.current;
+		const showLoading = !hasLoadedCurrentWorktree();
+		if (showLoading) {
+			setLoading(true);
+		}
+		try {
+			const nextNodes = await invoke<WorkspaceTreeNode[]>(
+				"list_workspace_worktree_nodes",
+				{ worktreePath },
+			);
+			const [nextClosedSessions, nextWorkflowHistory] = await Promise.all([
+				listClosedSessions(worktreePath),
+				invoke<WorkspaceWorkflowHistoryItem[]>(
+					"list_workspace_workflow_history",
+					{ worktreePath },
+				),
+			]);
+			if (seq !== refreshSeqRef.current) return;
+			loadedWorktreePathRef.current = worktreePath;
+			updateNodes(nextNodes);
+			setClosedSessions(
+				nextClosedSessions.filter((session) => !session.workflowStepSession),
+			);
+			setWorkflowHistory(nextWorkflowHistory);
+			setError(null);
+		} catch (e) {
+			if (seq !== refreshSeqRef.current) return;
+			if (!hasLoadedCurrentWorktree()) {
+				updateNodes([]);
+				setClosedSessions([]);
+				setWorkflowHistory([]);
+			}
+			setError(String(e));
+		} finally {
+			if (seq === refreshSeqRef.current) {
+				setLoading(false);
+			}
+		}
+	}, [hasLoadedCurrentWorktree, updateNodes, worktreePath]);
+
+	const scheduleRefresh = useCallback(() => {
+		if (refreshTimerRef.current != null) {
+			window.clearTimeout(refreshTimerRef.current);
+		}
+		refreshTimerRef.current = window.setTimeout(() => {
+			refreshTimerRef.current = null;
+			void refresh();
+		}, 80);
+	}, [refresh]);
+
+	const hasSessionNode = useCallback((sessionId: string): boolean => {
+		return nodesRef.current.some((node) => {
+			if (node.kind === "session") {
+				return node.id === sessionId;
+			}
+			return node.children.some((child) => child.id === sessionId);
+		});
+	}, []);
+
+	const hasWorkflowNode = useCallback((runId: string): boolean => {
+		return nodesRef.current.some(
+			(node) => node.kind === "workflow" && node.runId === runId,
+		);
+	}, []);
+
+	useEffect(() => {
+		void refresh();
+	}, [refresh]);
+
+	useEffect(() => {
+		if (!worktreePath) return;
+		let mounted = true;
+		let unlistenStatus: UnlistenFn | null = null;
+		let unlistenWorkflow: UnlistenFn | null = null;
+
+		const handleWorkspaceTreeRefresh = (event: Event) => {
+			if (!mounted) return;
+			const detail = (event as CustomEvent<WorkspaceTreeRefreshDetail>).detail;
+			if (detail?.worktreePath && detail.worktreePath !== worktreePath) return;
+			scheduleRefresh();
+		};
+
+		window.addEventListener(
+			"workspace-tree-refresh",
+			handleWorkspaceTreeRefresh,
+		);
+
+		const setup = async () => {
+			unlistenStatus = await listen<SessionStatus>(
+				"session-status-changed",
+				(event) => {
+					if (!mounted) return;
+					if (event.payload.worktree_path !== worktreePath) return;
+					if (
+						!hasSessionNode(event.payload.chat_session_id) ||
+						event.payload.session_state === "closed" ||
+						event.payload.session_state === "archived"
+					) {
+						scheduleRefresh();
+					}
+				},
+			);
+			unlistenWorkflow = await listen<WorkflowStatePayload>(
+				"workflow-state-changed",
+				(event) => {
+					if (!mounted) return;
+					if (event.payload.worktreePath !== worktreePath) return;
+					const stateType = event.payload.workflowState.state.type;
+					if (
+						!hasWorkflowNode(event.payload.workflowState.executionId) ||
+						stateType === "completed" ||
+						stateType === "failed" ||
+						stateType === "aborted"
+					) {
+						scheduleRefresh();
+					}
+				},
+			);
+		};
+
+		void setup().catch(() => {});
+		return () => {
+			mounted = false;
+			window.removeEventListener(
+				"workspace-tree-refresh",
+				handleWorkspaceTreeRefresh,
+			);
+			unlistenStatus?.();
+			unlistenWorkflow?.();
+			if (refreshTimerRef.current != null) {
+				window.clearTimeout(refreshTimerRef.current);
+				refreshTimerRef.current = null;
+			}
+		};
+	}, [hasSessionNode, hasWorkflowNode, scheduleRefresh, worktreePath]);
+
+	return { nodes, closedSessions, workflowHistory, loading, error, refresh };
+}

--- a/src/hooks/useWorkspaceTreeNodes.ts
+++ b/src/hooks/useWorkspaceTreeNodes.ts
@@ -150,7 +150,7 @@ export function useWorkspaceTreeNodes(
 		);
 
 		const setup = async () => {
-			unlistenStatus = await listen<SessionStatus>(
+			const nextUnlistenStatus = await listen<SessionStatus>(
 				"session-status-changed",
 				(event) => {
 					if (!mounted) return;
@@ -164,7 +164,13 @@ export function useWorkspaceTreeNodes(
 					}
 				},
 			);
-			unlistenWorkflow = await listen<WorkflowStatePayload>(
+			if (!mounted) {
+				nextUnlistenStatus();
+				return;
+			}
+			unlistenStatus = nextUnlistenStatus;
+
+			const nextUnlistenWorkflow = await listen<WorkflowStatePayload>(
 				"workflow-state-changed",
 				(event) => {
 					if (!mounted) return;
@@ -180,6 +186,11 @@ export function useWorkspaceTreeNodes(
 					}
 				},
 			);
+			if (!mounted) {
+				nextUnlistenWorkflow();
+				return;
+			}
+			unlistenWorkflow = nextUnlistenWorkflow;
 		};
 
 		void setup().catch(() => {});

--- a/src/hooks/useWorktreeList.ts
+++ b/src/hooks/useWorktreeList.ts
@@ -7,15 +7,6 @@ import type { WorkspaceStatus } from "@/types/session";
 
 const POLL_INTERVAL = 120_000;
 
-export type WorktreeStatus = "backlog" | "in_progress" | "review" | "done";
-
-export function computeStatus(branch: WorktreeBranch): WorktreeStatus {
-	if (branch.is_merged) return "done";
-	if (branch.has_pr) return "review";
-	if (branch.base_ahead > 0 || branch.dirty_count > 0) return "in_progress";
-	return "backlog";
-}
-
 export function useWorktreeList(repoPath: string) {
 	const [branches, setBranches] = useState<WorktreeBranch[]>([]);
 	const [loading, setLoading] = useState(true);

--- a/src/screens/MainLayout.test.tsx
+++ b/src/screens/MainLayout.test.tsx
@@ -1,16 +1,22 @@
 /**
- * spec issues-1023 Rule「利用者は中央エリアから Workflow 観測モードへ切り替えられる」
+ * spec issues-1220 Rule「中央表示は CenterSelection から導出される」
  *
- * MainLayout 近傍の統合テスト。中央 ViewToolbar の mode toggle を click すると、
- * 中央エリアの AgentChatPanel と入れ替わりに WorkflowView が表示されること、
- * および右パネル上半分は常に ReviewPanel 専用であることを担保する。
+ * MainLayout 近傍の統合テスト。Workspace tree から workflowRun selection request が
+ * 渡ると、中央エリアの AgentChatPanel と入れ替わりに WorkflowView が表示されることを
+ * 担保する。
  */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 // jsdom does not implement scrollIntoView / ResizeObserver
 Element.prototype.scrollIntoView = vi.fn();
+
+const agentChatPanelProps = vi.hoisted(() => ({
+	current: null as {
+		onNewSessionCreated?: (sessionId: string) => void;
+	} | null,
+}));
 
 vi.mock("react-resizable-panels", () => ({
 	Group: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -46,6 +52,16 @@ vi.mock("@/hooks/useBaseBranch", () => ({
 		localBranches: ["main", "feature"],
 	}),
 }));
+vi.mock("@/hooks/useWorkflowState", () => ({
+	useWorkflowState: () => ({ workflowState: null }),
+}));
+vi.mock("@/contexts/AgentChatContext", () => ({
+	AgentChatProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("@/contexts/ReviewThreadHandoffContext", () => ({
+	ReviewThreadHandoffProvider: ({ children }: { children: React.ReactNode }) =>
+		children,
+}));
 
 vi.mock("@/screens/useWorktreeState", () => ({
 	useWorktreeState: () => ({
@@ -68,7 +84,12 @@ vi.mock("@/screens/useWorktreeState", () => ({
 }));
 
 vi.mock("@/components/panels/AgentChatPanel", () => ({
-	AgentChatPanel: () => <div data-testid="agent-chat-panel-mock" />,
+	AgentChatPanel: (props: {
+		onNewSessionCreated?: (sessionId: string) => void;
+	}) => {
+		agentChatPanelProps.current = props;
+		return <div data-testid="agent-chat-panel-mock" />;
+	},
 }));
 vi.mock("@/components/panels/ReviewPanel", () => ({
 	ReviewPanel: () => <div data-testid="review-panel-mock" />,
@@ -91,38 +112,9 @@ vi.mock("@/screens/WorktreeViewDialogs", () => ({
 vi.mock("@/components/layout/BranchSelector", () => ({
 	BranchSelector: () => <div data-testid="branch-selector-mock" />,
 }));
-// ViewToolbar の mode 切替UIを直接レンダリングする軽量モック。
-// 中央エリアの "Agent mode" / "Workflow mode" toggle を click したときに
-// onModeChange が呼ばれることを再現する。
 vi.mock("@/components/layout/ViewToolbar", () => ({
-	ViewToolbar: ({
-		rightSlot,
-		mode,
-		onModeChange,
-	}: {
-		rightSlot?: React.ReactNode;
-		mode?: "agent" | "workflow";
-		onModeChange?: (mode: "agent" | "workflow") => void;
-	}) => (
-		<div data-testid="view-toolbar-mock">
-			{mode !== undefined && onModeChange !== undefined && (
-				<>
-					<button
-						type="button"
-						aria-label="Agent mode"
-						aria-pressed={mode === "agent"}
-						onClick={() => onModeChange("agent")}
-					/>
-					<button
-						type="button"
-						aria-label="Workflow mode"
-						aria-pressed={mode === "workflow"}
-						onClick={() => onModeChange("workflow")}
-					/>
-				</>
-			)}
-			{rightSlot}
-		</div>
+	ViewToolbar: ({ rightSlot }: { rightSlot?: React.ReactNode }) => (
+		<div data-testid="view-toolbar-mock">{rightSlot}</div>
 	),
 }));
 
@@ -130,7 +122,7 @@ const { MainLayout } = await import("./MainLayout");
 const { DEFAULT_SETTINGS } = await import("@/types/settings");
 const defaultSettings = DEFAULT_SETTINGS;
 
-describe("MainLayout center mode switch", () => {
+describe("MainLayout center selection", () => {
 	it("renders AgentChatPanel and ReviewPanel by default", () => {
 		render(
 			<TooltipProvider>
@@ -147,7 +139,7 @@ describe("MainLayout center mode switch", () => {
 		expect(screen.queryByTestId("workflow-view-mock")).toBeNull();
 	});
 
-	it("mounts WorkflowView with selectedRootPath when Workflow mode is selected", () => {
+	it("mounts WorkflowView with selectedRootPath when workflowRun selection is requested", async () => {
 		render(
 			<TooltipProvider>
 				<MainLayout
@@ -155,17 +147,54 @@ describe("MainLayout center mode switch", () => {
 					settings={defaultSettings}
 					onSettingsSave={vi.fn()}
 					leftNav={<div />}
+					centerSelectionRequest={{
+						kind: "workflowRun",
+						worktreePath: "/managed/wt",
+						runId: "run-1",
+						requestId: 1,
+					}}
 				/>
 			</TooltipProvider>,
 		);
 
-		fireEvent.click(screen.getByLabelText("Workflow mode"));
-
-		const panel = screen.getByTestId("workflow-view-mock");
+		const panel = await screen.findByTestId("workflow-view-mock");
 		expect(panel).toBeInTheDocument();
 		expect(panel).toHaveAttribute("data-worktree-path", "/managed/wt");
 		// AgentChat は中央から消え、Review は右パネルで残る
 		expect(screen.queryByTestId("agent-chat-panel-mock")).toBeNull();
-		expect(screen.getByTestId("review-panel-mock")).toBeInTheDocument();
+		await waitFor(() => {
+			expect(screen.getByTestId("review-panel-mock")).toBeInTheDocument();
+		});
+	});
+
+	it("resolves newAgentSession selection to the created agent session", () => {
+		agentChatPanelProps.current = null;
+		const onCenterSelectionResolved = vi.fn();
+		render(
+			<TooltipProvider>
+				<MainLayout
+					selectedRootPath="/managed/wt"
+					settings={defaultSettings}
+					onSettingsSave={vi.fn()}
+					leftNav={<div />}
+					centerSelectionRequest={{
+						kind: "newAgentSession",
+						worktreePath: "/managed/wt",
+						requestId: 1,
+					}}
+					onCenterSelectionResolved={onCenterSelectionResolved}
+				/>
+			</TooltipProvider>,
+		);
+
+		act(() => {
+			agentChatPanelProps.current?.onNewSessionCreated?.("new-s");
+		});
+
+		expect(onCenterSelectionResolved).toHaveBeenCalledWith({
+			kind: "agentSession",
+			worktreePath: "/managed/wt",
+			sessionId: "new-s",
+		});
 	});
 });

--- a/src/screens/MainLayout.tsx
+++ b/src/screens/MainLayout.tsx
@@ -10,11 +10,7 @@ import {
 import { BranchSelector } from "@/components/layout/BranchSelector";
 
 import { RightPanelHeader } from "@/components/layout/RightPanelHeader";
-import {
-	type CenterMode,
-	type TogglePanel,
-	ViewToolbar,
-} from "@/components/layout/ViewToolbar";
+import { type TogglePanel, ViewToolbar } from "@/components/layout/ViewToolbar";
 import { AgentChatPanel } from "@/components/panels/AgentChatPanel";
 import { ReviewPanel } from "@/components/panels/ReviewPanel";
 import { RightSidebarBottom } from "@/components/panels/RightSidebarBottom";
@@ -44,12 +40,18 @@ import type { ThreadNavigationTarget } from "@/types/diffComment";
 import type { AgentEditorSelection, MentionReference } from "@/types/session";
 import type { AppSettings } from "@/types/settings";
 import type { WorkspaceState } from "@/types/workspace-state";
+import type {
+	CenterSelection,
+	CenterSelectionRequest,
+} from "@/types/workspace-tree";
 
 interface MainLayoutProps {
 	selectedRootPath: string | null;
 	settings: AppSettings;
 	onSettingsSave: (settings: AppSettings) => void;
 	leftNav: React.ReactNode;
+	centerSelectionRequest?: CenterSelectionRequest | null;
+	onCenterSelectionResolved?: (selection: CenterSelection) => void;
 }
 
 function WorktreeContent({
@@ -61,8 +63,9 @@ function WorktreeContent({
 	leftPanels,
 	branchSelector,
 	togglePanels,
-	centerMode,
-	onCenterModeChange,
+	centerSelection,
+	centerSelectionRequest,
+	onCenterSelectionResolved,
 	initialWorkspaceState,
 	internalStateMapRef,
 	baseBranch,
@@ -75,8 +78,9 @@ function WorktreeContent({
 	leftPanels?: TogglePanel[];
 	branchSelector: React.ReactNode;
 	togglePanels: TogglePanel[];
-	centerMode: CenterMode;
-	onCenterModeChange: (mode: CenterMode) => void;
+	centerSelection: CenterSelection | null;
+	centerSelectionRequest?: CenterSelectionRequest | null;
+	onCenterSelectionResolved?: (selection: CenterSelection) => void;
 	initialWorkspaceState?: WorkspaceState;
 	internalStateMapRef: React.MutableRefObject<
 		Map<string, InternalWorktreeState>
@@ -173,6 +177,23 @@ function WorktreeContent({
 		editorState?.activeEditorPath ??
 		initialWorkspaceState?.tabs.activeEditorPath ??
 		null;
+	const scopedCenterSelection =
+		centerSelection?.worktreePath === rootPath ? centerSelection : null;
+	const scopedCenterSelectionRequest =
+		centerSelectionRequest?.worktreePath === rootPath
+			? centerSelectionRequest
+			: null;
+	const showWorkflow = scopedCenterSelection?.kind === "workflowRun";
+	const handleNewSessionCreated = useCallback(
+		(sessionId: string) => {
+			onCenterSelectionResolved?.({
+				kind: "agentSession",
+				worktreePath: rootPath,
+				sessionId,
+			});
+		},
+		[onCenterSelectionResolved, rootPath],
+	);
 	const handleOpenDiffFile = useCallback(
 		(filePath: string) => {
 			s.setSelectedDiffFile(filePath);
@@ -192,24 +213,24 @@ function WorktreeContent({
 				{/* Center */}
 				<Panel id="center" defaultSize="50%" minSize="30%">
 					<div className="h-full relative overflow-hidden flex flex-col">
-						<ViewToolbar
-							leftPanels={leftPanels}
-							rightSlot={branchSelector}
-							mode={centerMode}
-							onModeChange={onCenterModeChange}
-						/>
+						<ViewToolbar leftPanels={leftPanels} rightSlot={branchSelector} />
 						<div className="flex-1 overflow-hidden">
-							{centerMode === "workflow" ? (
-								<WorkflowView worktreePath={rootPath} />
+							{showWorkflow ? (
+								<WorkflowView
+									worktreePath={rootPath}
+									selectionRequest={scopedCenterSelectionRequest}
+								/>
 							) : (
 								<AgentChatPanel
 									worktreePath={rootPath}
+									selectionRequest={scopedCenterSelectionRequest}
 									activeEditorPath={activeEditorPath}
 									openEditorPaths={openEditorPaths}
 									activeEditorSelection={activeEditorSelection}
 									registerDropZone={s.registerDropZone}
 									sendMessageRef={sendAgentMessageRef}
 									onOpenDiffFile={handleOpenDiffFile}
+									onNewSessionCreated={handleNewSessionCreated}
 								/>
 							)}
 						</div>
@@ -329,16 +350,21 @@ export function MainLayout({
 	settings,
 	onSettingsSave,
 	leftNav,
+	centerSelectionRequest,
+	onCenterSelectionResolved,
 }: MainLayoutProps) {
 	const leftNavRef = useRef<PanelImperativeHandle>(null);
 	const rightPanelRef = useRef<PanelImperativeHandle>(null);
 
 	const [leftNavVisible, setLeftNavVisible] = useState(true);
 	const [rightVisible, setRightVisible] = useState(true);
-	// spec issues-1023: 中央エリアの表示モード。Agent / Workflow を並列に切り替える。
-	// 初期値は Agent。worktree 切替は本 layout 側 key で別ツリーになるため、
-	// 本 state は MainLayout のライフサイクルに紐づける（永続化はしない）。
-	const [centerMode, setCenterMode] = useState<CenterMode>("agent");
+	const [centerSelection, setCenterSelection] =
+		useState<CenterSelection | null>(null);
+
+	useEffect(() => {
+		if (!centerSelectionRequest) return;
+		setCenterSelection(centerSelectionRequest);
+	}, [centerSelectionRequest]);
 
 	// --- Workspace state persistence ---
 	const { internalStateMapRef, getInitialState, stateReady } =
@@ -497,8 +523,9 @@ export function MainLayout({
 								leftPanels={leftNavVisible ? undefined : [leftToggle]}
 								branchSelector={rightSlotContent}
 								togglePanels={togglePanels}
-								centerMode={centerMode}
-								onCenterModeChange={setCenterMode}
+								centerSelection={centerSelection}
+								centerSelectionRequest={centerSelectionRequest}
+								onCenterSelectionResolved={onCenterSelectionResolved}
 								initialWorkspaceState={getInitialState(selectedRootPath)}
 								internalStateMapRef={internalStateMapRef}
 								baseBranch={baseBranch}

--- a/src/types/workspace-tree.ts
+++ b/src/types/workspace-tree.ts
@@ -1,0 +1,68 @@
+import type { AgentState } from "./protocol";
+import type { SessionState, SessionSummary } from "./session";
+import type { WorkflowRunSummary } from "./workflow";
+
+export type CenterSelection =
+	| {
+			kind: "agentSession";
+			worktreePath: string;
+			sessionId: string;
+	  }
+	| {
+			kind: "newAgentSession";
+			worktreePath: string;
+	  }
+	| {
+			kind: "workflowRun";
+			worktreePath: string;
+			runId: string;
+			focus?: {
+				sessionId?: string;
+				stepName?: string;
+				runIndex?: number;
+			};
+	  };
+
+export type CenterSelectionRequest = CenterSelection & {
+	requestId: number;
+	branchName?: string;
+	repoName?: string;
+};
+
+export interface WorkspaceSessionNode {
+	kind: "session";
+	id: string;
+	worktreePath: string;
+	title: string;
+	state: SessionState;
+	updatedAt: number;
+	workflowStepSession: boolean;
+	stepName?: string | null;
+	runIndex?: number | null;
+	agentState?: AgentState | null;
+}
+
+export interface WorkspaceWorkflowNode {
+	kind: "workflow";
+	runId: string;
+	worktreePath: string;
+	title: string;
+	status: WorkflowRunSummary["status"];
+	updatedAt: number;
+	children: WorkspaceSessionNode[];
+}
+
+export interface WorkspaceWorkflowHistoryItem {
+	runId: string;
+	worktreePath: string;
+	title: string;
+	status: WorkflowRunSummary["status"];
+	updatedAt: number;
+	archivedAt: number;
+	archiveReason: "auto_no_sessions" | "manual" | string;
+	children: WorkspaceSessionNode[];
+}
+
+export type WorkspaceTreeNode = WorkspaceSessionNode | WorkspaceWorkflowNode;
+
+export type WorkspaceSessionHistoryItem = SessionSummary;

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -209,6 +209,9 @@ const baseIpcHandler: Record<string, unknown> = {
 
 	// Worktree作成
 	create_worktree: null,
+	remove_worktree: null,
+	delete_branch: null,
+	kill_lsp_by_worktree: null,
 
 	// Agent chat sessions
 	list_sessions: [],
@@ -243,6 +246,7 @@ const baseIpcHandler: Record<string, unknown> = {
 	// Workflow
 	get_workflow_state: null,
 	list_workflows: [],
+	list_workflow_runs: [],
 	start_workflow: null,
 	abort_workflow: null,
 	approve_workflow_step: null,
@@ -252,6 +256,12 @@ const baseIpcHandler: Record<string, unknown> = {
 	list_workflow_executions: [],
 	get_workflow_execution_log: [],
 	get_workflow_execution_state: null,
+
+	// Workspace tree
+	list_workspace_worktree_nodes: [],
+	list_workspace_workflow_history: [],
+	archive_workspace_workflow_run: null,
+	restore_workspace_workflow_run: null,
 };
 
 // -------------------------------------------------------

--- a/tests/statusbar.spec.ts
+++ b/tests/statusbar.spec.ts
@@ -4,8 +4,8 @@ import { setupTauriMock, emitTauriEvent } from "./helpers/tauri-mock";
 import { waitForApp } from "./helpers/utils";
 
 /**
- * WorkspaceList のブランチ名表示および Agent 状態バッジのテスト。
- * worktree が1つ存在する状態で各表示・イベント連動を検証する。
+ * StatusBar のブランチ名表示と workspace 状態イベント購読のテスト。
+ * worktree が1つ存在する状態で表示とイベント処理を検証する。
  */
 function statusBarConfig(overrides: Record<string, unknown> = {}) {
 	return buildMockConfig({
@@ -36,7 +36,9 @@ test.describe("StatusBar", () => {
 		await expect(page.getByText("feat/my-branch")).toBeVisible();
 	});
 
-	test("Agent状態がイベントで更新される", async ({ page }) => {
+	test("workspace 状態イベントを受けてもレイアウトが維持される", async ({
+		page,
+	}) => {
 		const config = statusBarConfig({
 			list_branches_with_status: [
 				{
@@ -70,7 +72,9 @@ test.describe("StatusBar", () => {
 			last_activity_at: 1000,
 		});
 
-		// WorkspaceListのブランチアイテムに running 状態のアイコンが表示される
-		await expect(page.getByTitle("running")).toBeVisible({ timeout: 5000 });
+		await expect(page.getByText("feat/my-branch")).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Something went wrong" }),
+		).not.toBeVisible();
 	});
 });

--- a/tests/workspace-manager.spec.ts
+++ b/tests/workspace-manager.spec.ts
@@ -8,7 +8,7 @@ import { setupTauriMock } from "./helpers/tauri-mock";
 import { waitForApp } from "./helpers/utils";
 
 test.describe("Workspace Manager", () => {
-	test("リポジトリが存在しない場合 No repositories が表示される", async ({
+	test("リポジトリが存在しない場合 No Repository が表示される", async ({
 		page,
 	}) => {
 		const config = buildMockConfig({
@@ -20,7 +20,7 @@ test.describe("Workspace Manager", () => {
 		await setupTauriMock(page, config);
 		await waitForApp(page);
 
-		await expect(page.getByText("No repositories")).toBeVisible();
+		await expect(page.getByText("No Repository")).toBeVisible();
 		await expect(
 			page.getByRole("button", { name: "Add Repository" }),
 		).toBeVisible();
@@ -42,22 +42,33 @@ test.describe("Workspace Manager", () => {
 		).toBeVisible();
 	});
 
-	test("worktree 付きブランチをクリックすると WorktreeView が開く", async ({
+	test("worktree 付きブランチをクリックするとツリーが折りたたまれる", async ({
 		page,
 	}) => {
 		const config = buildMockConfig({
-			list_branches_with_status: kanbanBranches,
+			list_branches_with_status: kanbanBranches.filter(
+				(branch) => branch.name === "feat/wip",
+			),
+			list_workspace_worktree_nodes: [
+				{
+					kind: "session",
+					id: "session-1",
+					worktreePath: "/test/repo-worktrees/feat-wip",
+					title: "Direct session",
+					state: "active",
+					updatedAt: 1000,
+					workflowStepSession: false,
+					agentState: null,
+				},
+			],
 		});
 		await setupTauriMock(page, config);
 		await waitForApp(page);
 
-		// feat/wip（worktree_path あり）をクリック
+		await expect(page.getByText("Direct session")).toBeVisible();
 		await page.getByTestId("worktree-item-feat/wip").click();
 
-		// WorktreeView 固有の右下パネルが表示される
-		await expect(page.getByTestId("right-bottom-content")).toBeVisible({
-			timeout: 5000,
-		});
+		await expect(page.getByText("Direct session")).not.toBeVisible();
 	});
 });
 


### PR DESCRIPTION
## 概要

Workspace サイドバーを `Repository -> Worktree -> Session / Workflow -> WorkflowSession` の 4 階層ツリー構造へ再編し、作業単位の選択ナビゲーションを左ツリーへ一本化する。

関連: #1220 / #1023

## 背景

現状の Workspace サイドバーは `Repository -> Worktree` までしか表示せず、Session 切替は中央 `AgentChatPanel` 上部のタブバー、Workflow 確認は中央 `WorkflowView` に分散していた。複数 Session / Workflow を扱うと作業単位の全体像と切替先が分散するため、左ツリーへ統合する。

## 主な変更

- **Workspace ツリー UI** を 4 階層（Repository → Worktree → Session / Workflow → WorkflowSession）へ再編
  - Worktree 行はクリックで展開/折りたたみのみ。新規 Session ボタン・menu を配置
  - Session 行クリックで `CenterSelection.kind = "agentSession"` を選択
  - WorkflowSession 行クリックで `CenterSelection.kind = "workflowRun"` を選択
  - Worktree create menu の `NewWorkflow` から `start_workflow` を起動
- **中央 `AgentChatPanel` の Session タブバーを廃止**し、左ツリー選択された 1 件のみを表示
- **独立した `centerMode` 状態を廃止**し、中央表示を `CenterSelection.kind` から導出
- **Session / Workflow / WorkflowSession の親子関係・状態・並び順の決定を Rust 側へ集約**（`workspace_tree` command / `repository_query_service`）
- フロントの仮データ生成・不要化したタブバー関連コードを削除

## Spec

- `docs/specs/issues-1220/requirements.md`
- `docs/specs/issues-1220/behavior.md`
- `docs/specs/issues-1220/design.md`

## テスト

- [ ] `pnpm lint` / `pnpm test` / `pnpm build`
- [ ] `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 📦 リリースノート

* **New Features**
  * ワークスペースサイドバーを Repository → Worktree → Session/Workflow のツリー構造に再編しました。
  * 左パネルからセッション・ワークフロー実行の履歴参照、アーカイブ・復元が可能になりました。
  * セッション・ワークフロー実行を一元的に管理・操作できるようにUIを統合しました。

* **Documentation**
  * Workspace sidebar 再編の要件・設計・振る舞い仕様を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->