### PR TITLE
fix(workflow): 逐次 step session を Workspace 一覧に表示する

### DIFF
--- a/src-tauri/src/adaptor/controller/command/workflow/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/mod.rs
@@ -686,6 +686,7 @@ mod tests {
             .map(|event| match event {
                 WorkflowEvent::RunStarted { .. } => "RunStarted",
                 WorkflowEvent::NodeStarted { .. } => "NodeStarted",
+                WorkflowEvent::StepSessionStarted { .. } => "StepSessionStarted",
                 WorkflowEvent::NodeCompleted { .. } => "NodeCompleted",
                 WorkflowEvent::NodeFailed { .. } => "NodeFailed",
                 WorkflowEvent::ApprovalRequested { .. } => "ApprovalRequested",

--- a/src-tauri/src/adaptor/gateway/workflow/event.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event.rs
@@ -93,6 +93,17 @@ pub enum WorkflowEvent {
         execution_count: u32,
         timestamp: f64,
     },
+    /// 逐次 step の AgentSession が起動された（session_id を観測経路に露出する）。
+    /// `ParallelChildStarted` 相当の単発版で、event projection から
+    /// `current_session_id` を populate するために用いる。
+    StepSessionStarted {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        execution_count: u32,
+        session_id: String,
+        timestamp: f64,
+    },
     /// node が完了した（approval 経由の completion も含む）。
     NodeCompleted {
         run_id: String,
@@ -392,6 +403,7 @@ impl WorkflowEvent {
         match self {
             Self::RunStarted { run_id, .. }
             | Self::NodeStarted { run_id, .. }
+            | Self::StepSessionStarted { run_id, .. }
             | Self::NodeCompleted { run_id, .. }
             | Self::NodeFailed { run_id, .. }
             | Self::ApprovalRequested { run_id, .. }

--- a/src-tauri/src/adaptor/gateway/workflow/event_projection.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event_projection.rs
@@ -211,6 +211,15 @@ pub enum WorkflowEventView {
         #[serde(rename = "timestampMs")]
         timestamp_ms: f64,
     },
+    StepSessionStarted {
+        run_id: String,
+        workflow_name: String,
+        node_name: String,
+        execution_count: u32,
+        session_id: String,
+        #[serde(rename = "timestampMs")]
+        timestamp_ms: f64,
+    },
     NodeCompleted {
         run_id: String,
         workflow_name: String,
@@ -405,6 +414,21 @@ impl From<WorkflowEvent> for WorkflowEventView {
                 workflow_name,
                 node_name,
                 execution_count,
+                timestamp_ms: seconds_to_ms(timestamp),
+            },
+            WorkflowEvent::StepSessionStarted {
+                run_id,
+                workflow_name,
+                node_name,
+                execution_count,
+                session_id,
+                timestamp,
+            } => WorkflowEventView::StepSessionStarted {
+                run_id,
+                workflow_name,
+                node_name,
+                execution_count,
+                session_id,
                 timestamp_ms: seconds_to_ms(timestamp),
             },
             WorkflowEvent::NodeCompleted {
@@ -984,6 +1008,7 @@ pub(crate) fn reconstruct_state_from_events(
     let mut current_step_index = 0usize;
     let mut workflow_name = String::new();
     let mut active_parallel_steps: Vec<ParallelStepState> = Vec::new();
+    let mut current_session_id: Option<String> = None;
 
     for event in events {
         match event {
@@ -1009,6 +1034,9 @@ pub(crate) fn reconstruct_state_from_events(
                     .position(|s| s.name == *node_name)
                     .unwrap_or(0);
                 step_execution_counts.insert(node_name.clone(), *execution_count);
+                // 新しい node が始まった時点では session 起動前。
+                // `StepSessionStarted` が後続で観測されるまで current_session_id は None。
+                current_session_id = None;
                 // [04] approval を経て次 node が開始した場合に exec_state を
                 // Running へ復元する。ApprovalRequested で WaitingApproval に
                 // 切り替わったまま NodeStarted が来ると、復元 state が承認待ち
@@ -1016,6 +1044,14 @@ pub(crate) fn reconstruct_state_from_events(
                 if matches!(exec_state, WorkflowExecutionState::WaitingApproval) {
                     exec_state = WorkflowExecutionState::Running;
                 }
+                updated_at = *timestamp;
+            }
+            WorkflowEvent::StepSessionStarted {
+                session_id,
+                timestamp,
+                ..
+            } => {
+                current_session_id = Some(session_id.clone());
                 updated_at = *timestamp;
             }
             WorkflowEvent::NodeCompleted {
@@ -1059,6 +1095,7 @@ pub(crate) fn reconstruct_state_from_events(
                 if let Some(ref usage) = token_usage {
                     total_token_usage.add(usage);
                 }
+                current_session_id = None;
                 updated_at = *timestamp;
             }
             WorkflowEvent::NodeFailed {
@@ -1072,6 +1109,7 @@ pub(crate) fn reconstruct_state_from_events(
                 exec_state = WorkflowExecutionState::Failed {
                     reason: reason.clone(),
                 };
+                current_session_id = None;
                 updated_at = *timestamp;
             }
             WorkflowEvent::ApprovalRequested {
@@ -1108,6 +1146,7 @@ pub(crate) fn reconstruct_state_from_events(
                 // 終端へ到達した経路（NodeFailed → RunFailed 等）でも UI が stale な
                 // 並列子を表示しないよう projection 側でも同じ不変条件を担保する。
                 active_parallel_steps.clear();
+                current_session_id = None;
                 updated_at = *timestamp;
             }
             WorkflowEvent::RunFailed {
@@ -1117,6 +1156,7 @@ pub(crate) fn reconstruct_state_from_events(
                     reason: reason.clone(),
                 };
                 active_parallel_steps.clear();
+                current_session_id = None;
                 updated_at = *timestamp;
             }
             WorkflowEvent::RunAborted {
@@ -1215,6 +1255,7 @@ pub(crate) fn reconstruct_state_from_events(
                 }
 
                 active_parallel_steps.clear();
+                current_session_id = None;
                 updated_at = *timestamp;
             }
             WorkflowEvent::OutputCollected { timestamp, .. } => {
@@ -1232,6 +1273,8 @@ pub(crate) fn reconstruct_state_from_events(
                     .iter()
                     .position(|s| s.name == *parent_node_name)
                     .unwrap_or(current_step_index);
+                // parallel parent には逐次 session が無い。
+                current_session_id = None;
                 if matches!(exec_state, WorkflowExecutionState::WaitingApproval) {
                     exec_state = WorkflowExecutionState::Running;
                 }
@@ -1415,7 +1458,7 @@ pub(crate) fn reconstruct_state_from_events(
         state: exec_state,
         current_step_index,
         current_step_name,
-        current_session_id: None,
+        current_session_id,
         total_steps: workflow.nodes.len(),
         step_history,
         step_execution_counts,

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
@@ -3184,6 +3184,25 @@ impl WorkflowRuntimeService {
             }
         };
 
+        // event log に session_id を露出することで、projection 経由の
+        // workspace_tree 等の read-model から逐次 step session を観測できる。
+        if let Some(ref snapshot) = snapshot {
+            let exec_count = snapshot
+                .step_execution_counts
+                .get(&snapshot.current_step_name)
+                .copied()
+                .unwrap_or(1);
+            deps.write_step_session_started_event(WorkflowEvent::StepSessionStarted {
+                run_id: snapshot.execution_id.clone(),
+                workflow_name: snapshot.workflow_name.clone(),
+                node_name: snapshot.current_step_name.clone(),
+                execution_count: exec_count,
+                session_id: step_session_id.clone(),
+                timestamp: snapshot.updated_at,
+            })
+            .await;
+        }
+
         if let Some(snapshot) = snapshot {
             deps.broadcast_state(worktree_path, snapshot).await;
         }

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -2331,6 +2331,8 @@ impl StepSessionDeps for RecordingStepSessionDeps {
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
 
+    async fn write_step_session_started_event(&self, _event: WorkflowEvent) {}
+
     async fn broadcast_state(&self, _worktree_path: &str, _snapshot: WorkflowState) {
         self.broadcast_state_count
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_events.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_events.rs
@@ -532,6 +532,7 @@ pub(crate) fn workflow_event_timestamp(event: &WorkflowEvent) -> f64 {
     match event {
         WorkflowEvent::RunStarted { timestamp, .. }
         | WorkflowEvent::NodeStarted { timestamp, .. }
+        | WorkflowEvent::StepSessionStarted { timestamp, .. }
         | WorkflowEvent::NodeCompleted { timestamp, .. }
         | WorkflowEvent::NodeFailed { timestamp, .. }
         | WorkflowEvent::ApprovalRequested { timestamp, .. }
@@ -555,6 +556,7 @@ pub(crate) fn set_workflow_event_timestamp(event: &mut WorkflowEvent, commit_tim
     match event {
         WorkflowEvent::RunStarted { timestamp, .. }
         | WorkflowEvent::NodeStarted { timestamp, .. }
+        | WorkflowEvent::StepSessionStarted { timestamp, .. }
         | WorkflowEvent::NodeCompleted { timestamp, .. }
         | WorkflowEvent::NodeFailed { timestamp, .. }
         | WorkflowEvent::ApprovalRequested { timestamp, .. }

--- a/src-tauri/src/adaptor/gateway/workflow/step_session_boundary.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/step_session_boundary.rs
@@ -4,6 +4,7 @@ use tokio::sync::Mutex;
 
 use super::runtime_session as workflow_runtime_session;
 use crate::adaptor::gateway::workflow::engine_error::WorkflowEngineError;
+use crate::adaptor::gateway::workflow::event::WorkflowEvent;
 use crate::adaptor::gateway::workflow::state::WorkflowState;
 use crate::adaptor::gateway::workflow::step_settings::WorkflowDefaults;
 use crate::infrastructure::agent_session::runtime::AgentProcessMap;
@@ -80,6 +81,11 @@ pub(crate) trait StepSessionDeps: Send + Sync {
     ) -> Result<(), WorkflowEngineError>;
 
     async fn mark_step_tab_open(&self, step_session_id: &str);
+
+    /// 逐次 step session 起動を event log に記録する（best-effort）。
+    /// projection 経路（`event_projection::reconstruct_state_from_events`）から
+    /// `current_session_id` を観測するために必要。
+    async fn write_step_session_started_event(&self, event: WorkflowEvent);
 
     /// ワークフロー状態をブロードキャストする（best-effort）。
     async fn broadcast_state(&self, worktree_path: &str, snapshot: WorkflowState);
@@ -159,6 +165,17 @@ impl<'a, R: tauri::Runtime> StepSessionDeps for RealStepSessionDeps<'a, R> {
 
     async fn mark_step_tab_open(&self, step_session_id: &str) {
         crate::adaptor::gateway::workflow::mark_started_step_tab_open(self.app, step_session_id);
+    }
+
+    async fn write_step_session_started_event(&self, event: WorkflowEvent) {
+        if let Err(e) =
+            crate::adaptor::gateway::workflow::event_log_writer::append_required_events_for_app(
+                self.app,
+                std::slice::from_ref(&event),
+            )
+        {
+            log::warn!("Failed to write StepSessionStarted event: {e}");
+        }
     }
 
     async fn broadcast_state(&self, worktree_path: &str, snapshot: WorkflowState) {

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1413,6 +1413,7 @@ fn event_kind_display_name(kind: &str) -> &str {
     match kind {
         "run_started" => "RunStarted",
         "node_started" => "NodeStarted",
+        "step_session_started" => "StepSessionStarted",
         "node_completed" => "NodeCompleted",
         "node_failed" => "NodeFailed",
         "approval_requested" => "ApprovalRequested",


### PR DESCRIPTION
## Summary

- Workflow を起動した際、逐次（並列でない）step session が Workspace 一覧の workflow node 配下に表示されない不具合を修正
- 根本原因: \`list_workspace_worktree_nodes\` は永続化された event log を projection した state を引くが、`NodeStarted` イベントは session_id を持たず、`event_projection::reconstruct_state_from_events` が `current_session_id: None` ハードコードだったため、`collect_step_session_refs` が逐次 step session を拾えなかった（並列子は `ParallelChildStarted` が session_id を持つため表示されていた）
- 修正: 新イベント `WorkflowEvent::StepSessionStarted` を追加し、`start_step_session` 内で session_id を event log に append。projection で `current_session_id` を populate し、`NodeStarted` / `NodeCompleted` / `NodeFailed` / `RunCompleted` / `RunFailed` / `RunAborted` / `ParallelStarted` の境界でクリア

## Test plan

- [x] \`cargo clippy -- -D warnings\` 通過
- [x] \`cargo fmt --check\` 通過
- [x] \`cargo test --lib\` 全 2173 件通過
- [ ] 手動確認: Workflow を起動し、逐次 step が Workspace サイドバーの workflow node 配下に表示されることを確認
- [ ] 手動確認: 並列ブロックを含む workflow でも従来通り子 session が表示されることを確認
- [ ] 手動確認: step 完了後 / workflow 終了後に session が消える（または完了表示になる）ことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ステップセッション開始イベントの追跡機能を追加しました。ワークフロー実行時のセッション開始がイベントログに記録されるようになり、ワークフロー状態管理がより正確になります。

* **改善**
  * ワークフロー状態管理においてセッション識別情報の保持・追跡機能を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->