### PR TITLE
feat(agent): フロント agent チャットのメッセージ保持をウィンドウ化しメモリ増大を抑制 (#1195)

### DIFF
--- a/docs/specs/issues-1195/behavior.md
+++ b/docs/specs/issues-1195/behavior.md
@@ -1,0 +1,139 @@
+# Behavior
+
+requirements.md を観測可能な振る舞いとして定義する。本 ISSUE の中核は「webview が常駐保持する message body 量を有界化する内部最適化であり、外部観測可能な振る舞いは変えない」ことなので、Gherkin は退避機構の内部詳細（退避単位が drop か軽量プレースホルダ化か、トリガが非アクティブ化時か上限超過時か未参照時間ベースか、保持上限件数・session 数の具体値）を持ち込まない。それらは `design.md` の裁量で確定する実装詳細であり、ここではユーザーまたは表示系から外部観測できる結果に絞って記述する。
+
+## 用語
+
+- **session**: 1 件の agent チャット会話。Rust 側 session ストアが正本を保持し、webview の保持はそこから再取得可能なキャッシュである。
+- **アクティブ session**: 現在 UI に表示中の session（`AgentChatPanel` に開いて見えている会話）。
+- **非アクティブ session**: 開いた状態にあるが現在は表示していない session（切り替えて背面に回った会話）。close/delete はされていない。
+- **可視範囲**: アクティブ session のうち、現在スクロール位置から表示している message レンジ。これに加え、ストリーミング中・ターン進行中のアクティブなレンジを含む。
+- **スクロールバック**: 過去方向へ遡って、初回ページ（最新 50 件）より前の古い message を読み込む操作。`get_session_page(session_id, cursor, limit)` を再供給経路として用いる。
+- **退避（eviction）**: 可視範囲外の message body を webview の常駐保持から外すこと。退避しても Rust 正本は不変。
+- **再供給（再 hydrate）**: 退避済みレンジが再表示対象になった時点で、`get_session_page` により Rust 正本から再取得して表示を復元すること。
+- **有界**: 会話の総 message 数および同時に開いている session 数に対して、webview の常駐 message body 量が線形に増え続けない状態。
+
+## Feature: 開いている agent チャットの常駐メモリ有界化
+
+長い会話のスクロールバックや複数 session の同時オープンによって、webview が保持する message body 量が無制限に増え続ける経路を是正する。退避と再供給により常駐量を有界に保ちつつ、ユーザーから見た表示・スクロールバック・既読履歴・ストリーミング更新の外部観測可能な振る舞いは退避前と同一に保つ。
+
+### Background
+
+```gherkin
+Given Releash デスクトップアプリで agent チャット（AgentChatPanel 系）を開いている
+And session の message 正本は Rust 側 session ストアが保持している
+And webview は初回ロード時に最新 50 件（INITIAL_SESSION_PAGE_LIMIT）で hydrate している
+And 過去方向のスクロールバックは get_session_page により追加ページを取得できる
+```
+
+## Rule: アクティブ session のスクロールバック累積は上端離脱後に有界へ収束する
+
+長い単一会話を遡っても、webview が常駐保持する message body 量が会話の総 message 数に対して線形に増え続けない。連続した純上方向スクロールバック中（`oldest_visible_index` が 0 近傍）は、いま読み込んだ古い prefix を即退避しないため contiguous な窓が一時的に cap を超えて増大しうる。ユーザーが上端を離れた後（下方向スクロール）または present へ戻った時点で、drop 可能な古い page は退避され、live tail が `RETAINED_MESSAGE_CAP` 以下なら常駐量は cap へ収束する。live tail（最新 page・進行中レンジ）自体が cap を超える場合、その超過分は進行中表示を守るため退避せず、古い page のみ退避する。
+
+```gherkin
+Scenario: 長い会話を深くスクロールバックしても常駐 message body 量が有界に保たれる
+  Given 多数の message を持つ単一 session を開いている
+  When 過去方向へ繰り返しスクロールバックして古いページを読み込み続ける
+  Then 連続した純上方向スクロールバック中は contiguous な窓が一時的に cap を超えて増大しうる
+  When 上端を離れて古い prefix が可視範囲外になる
+  Then drop 可能な古い message body は退避される
+  And live tail が RETAINED_MESSAGE_CAP 以下なら webview が常駐保持する message body 量は RETAINED_MESSAGE_CAP へ収束する
+  And live tail が RETAINED_MESSAGE_CAP を超える場合は live tail を保持したまま古い page のみ退避される
+```
+
+```gherkin
+Scenario: スクロールバックで遡った古いレンジへ再び戻ると同一内容が復元される
+  Given スクロールバックで古いレンジを表示したのち、さらに別レンジへ移動して当該レンジが退避された
+  When 退避された古いレンジへ再びスクロールして戻る
+  Then 退避前と同一の message が同一順序で表示される
+  And 重複・欠落・順序崩れは発生しない
+```
+
+## Rule: 非アクティブ session の常駐量が有界である
+
+session を切り替えて複数を開いても、背面に回った非アクティブ session の body が常駐し続けず、同時保持量が session 数に対して線形に増え続けない。
+
+```gherkin
+Scenario: 複数 session を切り替えて開いても常駐 message body 量が有界に保たれる
+  Given 複数の session を順に開いて切り替えて使っている
+  When 開く session 数を増やしていく
+  Then webview が常駐保持する message body 量は同時に開いた session 数に比例して増え続けない
+  And 表示していない非アクティブ session の message body は退避される
+```
+
+```gherkin
+Scenario: 退避された非アクティブ session に戻ると表示が復元される
+  Given ある session を表示後に別 session へ切り替え、元の session が非アクティブとして退避された
+  When 退避された元の session へ表示を切り替えて戻る
+  Then 切り替え前と同一の表示・スクロール可能な履歴が復元される
+  And 重複・欠落・順序崩れは発生しない
+```
+
+## Rule: 退避は close/delete を伴わず、再供給は正本から行う
+
+退避は webview 内部のキャッシュ解放であって session の終了ではなく、再供給は Rust 正本の既存 paging API のみを用いる。
+
+```gherkin
+Scenario: 退避は session の close/delete を引き起こさない
+  Given アクティブ／非アクティブを問わず session の一部または全部の body が退避される
+  Then 当該 session は close/delete されず、開いた状態を保つ
+  And Rust 側の session 正本は退避によって変化しない
+```
+
+```gherkin
+Scenario: 再供給は既存の get_session_page のみで完結する
+  Given 退避済みレンジが再表示対象になった
+  When 退避済みレンジを復元する
+  Then 再取得は get_session_page（session_id, cursor, limit）経由で行われる
+  And 新規の read API・永続データ型・プロトコル型は追加されない
+```
+
+## Rule: ストリーミング中・ターン進行中の表示更新が退行しない
+
+退避対象はアクティブな進行中レンジを含めない。応答途中の表示やターン完了の確定が退避/仮想化によって壊れない。
+
+```gherkin
+Scenario: ストリーミング中のアクティブ session が退避対象にならない
+  Given アクティブ session で turn が応答中（ストリーミング中）である
+  When 退避処理が走りうるタイミングになる
+  Then 進行中の turn とその可視レンジは退避されない
+  And ストリーミングの逐次表示更新は従来どおり反映される
+```
+
+```gherkin
+Scenario Outline: ターン進行に伴う表示更新が退避導入後も不変である
+  Given アクティブ session で turn が進行している
+  When <更新> が発生する
+  Then 退避導入前と同一に表示へ反映される
+
+  Examples:
+    | 更新                        |
+    | ストリーミング途中のメッセージ更新 |
+    | 新規メッセージの追加          |
+    | ターン完了の確定             |
+```
+
+## Rule: 既読・履歴の外部観測可能な振る舞いが退避前と同一である
+
+退避はあくまで内部最適化であり、ユーザーから見える既読履歴・スクロール体験は退避前後で区別できない。
+
+```gherkin
+Scenario: 退避と再供給を経ても既読履歴が変化しない
+  Given session の一部レンジが退避され、のちに再供給された
+  When 当該レンジを表示する
+  Then 退避前と同一の既読／履歴状態が再現される
+  And ユーザーは退避が起きたことを表示上で区別できない
+```
+
+## 仮定
+
+- session ストア（Rust）が message の正本であり、webview の保持は再取得可能なキャッシュである。退避した body の再供給に整合性問題は生じない（#1213 の `get_session_page` が runtime streaming overlay・token usage metadata を含めて正本を返す前提）。
+- 退避の単位（body 全体 drop か軽量プレースホルダ化か）、退避トリガ（非アクティブ化時の即時／保持 message 数・session 数の上限超過時／未参照時間ベース）、および保持上限の具体値は、本 behavior の不変条件（有界化・表示不変・再供給整合）を満たす範囲で `design.md` の裁量により確定する。本 behavior はこれらの内部詳細に依存しない。
+- 退避判定・再供給に必要なロジックは `rust-first-logic` 方針に従って配置し、フロントは表示・入力・invoke・表示用フォーマットに徹する。フロントに新たなビジネスロジックを増やさない。
+- 退避/再供給は #1213 が確定した paging 契約（`initialPage` / `get_session_page` / cursor / `INITIAL_SESSION_PAGE_LIMIT`）の上に構築し、ページング方式の再設計・二重実装を生まない。
+- 対象は agent チャット（`AgentChatPanel` 系）であり、remote UI（`src/remote/`）は本 ISSUE の主対象外。
+- 「有界」の計測手順・観測点・具体的な保持上限値は `design.md` で定義する。本 behavior は「総 message 数・同時 session 数に対して線形に増え続けない」という外部観測可能な性質のみを固定する。
+
+## Open Questions
+
+なし

--- a/docs/specs/issues-1195/design.md
+++ b/docs/specs/issues-1195/design.md
@@ -1,0 +1,255 @@
+# design — メモリ削減: フロント agent チャットの常駐 message body を退避/再供給で有界化する (#1195)
+
+対象 ISSUE: #1195
+関連 Spec: `requirements.md`, `behavior.md`（同ディレクトリ）
+前提（裏取り済み）: #1213（M2: session storage を summary index + message paging に再設計）がマージ済み。`get_session_page(session_id, cursor, limit)` と `getSession` の `initialPage`（最新 50 件）が利用可能。
+
+## 概要
+
+webview（React）が常駐保持する agent チャットの message body 量を、会話の総 message 数および同時に開いている session 数に対して線形に増え続けない構造へ是正する。
+
+#1213 により「初回 hydrate の有界化（最新 50 件）」は完了済みだが、以下 2 経路で常駐量が無制限に増え続ける:
+
+1. **アクティブ session のスクロールバック累積**: `loadOlderMessages` が `PREPEND_MESSAGES` した古い page が drop されず `session.messages` が O(N) に積み上がる。
+2. **非アクティブ session の常駐**: 表示していない session の `messages` body が `CLEANUP_SESSION`（close/delete 時のみ）まで `sessionsById` に残り続ける。
+
+本設計は、この 2 経路に対して **Rust usecase が計画する webview キャッシュ退避（eviction）+ 既存 paging による再供給（再 hydrate）** を導入する。新規の永続データ型・WebSocket プロトコル型・read API は追加せず、#1213 が確定した paging 契約（`getSession.initialPage` / `get_session_page` / cursor）の上に構築する。退避 policy（保持上限、退避対象、cursor rewind、非アクティブ session の優先順位）は Rust 側 `plan_agent_chat_eviction` Tauri command に閉じ、フロントは scroll/window/viewable の観測値を渡して plan を反映する。
+
+### 設計の前提となる cursor 意味論（実コードで確認済み）
+
+再供給経路の設計を確定させるため、`get_session_page` の cursor 意味論を実装で確認した。
+
+- `PageCursor` は `u64`（= message の `seq`）を文字列化した不透明トークン（`session.rs:515`）。フロントは `string | null` として扱う。
+- `read_page_from_index`（`message_store.rs:406`）は **`entry.seq < cursor` を満たす message のうち末尾 `limit` 件**（= cursor の直前に位置する、より古い `limit` 件）を返す。
+- 返り値 `next_cursor` は「返した page の先頭（最も古い）message の seq」。`has_more=false` のとき `null`。
+- すなわち cursor が表現できるのは **「ある境界より古い方向（backward）への取得」のみ**。「より新しい方向（forward）への cursor 取得」は API に存在しない。
+- 同一 index に対し **同じ `requestCursor` で再呼び出しすれば同じ page が決定的に返る**（再供給の冪等性が成立）。
+
+この制約から、再供給は次の 2 経路に限定される:
+
+- **backward（より古い page）**: `get_session_page(cursor)` で取得（既存 `loadOlderMessages` がこれ）。
+- **newest（最新 page）**: `getSession` の `initialPage`（最新 50 件）で取得（既存 `selectSession` / `loadSession` がこれ）。
+
+「中間レンジを forward に再取得する」操作は存在しないため、**退避は常に「最も新しい live tail を残し、より古い側（または body 全体）を drop し、backward / newest 経路で再供給できる範囲に限定する」** という形に統一する。
+
+## 変更対象
+
+- `src-tauri/src/usecase/agent_session/session/message_window.rs`
+  - 退避 policy の定数（`RETAINED_MESSAGE_CAP` / `MAX_HYDRATED_SESSIONS`）、request/plan 型、active window の page 単位 drop、非アクティブ session body 退避の候補選定を実装する。
+  - 非アクティブ session は request の `evictionRank`（フロントが観測した参照順）を Rust 側で sort し、JS object の列挙順に依存しない。
+- `src-tauri/src/adaptor/controller/command/agent_session/session.rs`
+  - `plan_agent_chat_eviction` Tauri command として Rust usecase の plan を公開する。
+- `src/hooks/agentChatReducer.ts`
+  - 退避用 action（後述 `EVICT_SESSION_BODY` / `EVICT_OLDER_MESSAGES`）と reducer case を追加。
+  - 既存 `PREPEND_MESSAGES` / `ADD_MESSAGE` / `SET_STREAMING_MESSAGE` / `MARK_AGENT_TURN_COMPLETED` / `CLEANUP_SESSION` の挙動は不変。
+- `src/hooks/useAgentChat.ts`
+  - `pageStateRef` を拡張し、再供給のための loaded page cursor 履歴を保持する。
+  - scroll/window/viewable/loading/turnPhase/messageCount/`evictionRank` を観測して `plan_agent_chat_eviction` に渡し、返った plan に従って reducer action と `pageStateRef` rewind を適用する。
+  - viewable registry の遷移（非 viewable 化）を退避計画のトリガとして利用する。
+- `src/components/panels/AgentChatPanel/ChatSessionView.tsx`
+  - 既存 `handleScroll`（`scrollTop < 80` / 下端 100px 判定）に「上端から十分離れた」という観測点を追加する。表示層は観測値を渡すだけで、退避可否は Rust plan に従う。
+- `src/components/panels/AgentChatPanel/BoundSessionChat.tsx`
+  - 既存の viewable 登録/解除（`useEffect`）と `loadSession`（再 hydrate）はそのまま再供給経路として機能。退避トリガの呼び出し接続のみ追加。
+
+## アーキテクチャと責務分割
+
+### 責務境界（rust-first-logic との整合）
+
+- **message の正本・順序・dedup・streaming overlay・token usage metadata の構築**: すべて Rust（`get_session_page` / `getSession`）。本 ISSUE で一切複製しない。再供給は既存 API を呼ぶだけ。
+- **webview キャッシュ退避 policy（閾値、退避対象、cursor rewind、非アクティブ session の優先順位）**: Rust usecase（`message_window.rs`）。フロントは観測値を組み立てて Tauri command を呼び、返却 plan を適用するだけに留める。
+- **webview キャッシュ窓の状態保持と UI 観測**: フロント。`pageStateRef` / scroll 位置 / viewable registry / turnPhase / loading 状態を request に含める。退避の判定結果は Rust plan を正とする。
+- **退避判定に使う閾値（保持上限件数・同時保持 session 数の上限）**: Rust usecase の定数として集中管理する。フロント定数や JS object 列挙順には依存しない。
+
+### 経路 1: アクティブ session のスクロールバック累積の有界化
+
+`session.messages` は「最新の live tail を必ず含み、上方向（より古い）へ連続して伸びる contiguous な窓」である。退避はこの窓の **古い側（上端）を page 単位で drop** し、backward 再供給で復元する。
+
+- **退避単位**: page 単位の drop（軽量プレースホルダ化ではなく実体 drop）。DOM は既に `@tanstack/react-virtual`（`ChatSessionView.tsx`, `overscan: 8`）で仮想化済みのため、常駐量を支配するのは `session.messages` JS 配列そのもの。よって配列要素を実体 drop することが有界化の本質。プレースホルダは「ある中間レンジが欠けている」状態を生み、本設計の「contiguous 窓」前提と forward 再供給不在の制約に反するため採らない。
+- **退避トリガ**: アクティブ session について、
+  1. 保持 message 数が上限 `RETAINED_MESSAGE_CAP` を超え、かつ
+  2. ユーザーが上端から十分下へスクロール済み（= 直前にスクロールバックした古い prefix が可視範囲から離れた）
+  のとき、最古側の page を 1 つ以上 drop する。条件 2 により「いま読み込んだばかりの古い prefix を即座に drop → 即再取得」という thrash を防ぐ（anti-thrash）。
+  退避は live tail（最新 page・ストリーミング中/ターン進行中レンジ）を**決して含めない**（要求 4 / behavior「ストリーミング中は退避対象外」）。
+- **再供給**: drop した最古 prefix は backward 経路で復元する。drop と同時に backward-paging cursor を **drop した最古 page を再取得できる位置へ rewind** し、`hasMore=true` に戻す。以後、ユーザーが上端へ再スクロールすれば既存 `loadOlderMessages` がそのまま再取得・`PREPEND_MESSAGES` する。再供給専用コードは増やさない。
+
+### 経路 2: 非アクティブ session の常駐の有界化
+
+- **退避単位**: body 全体 drop（`messages` を空配列化）。summary（`sessions` / `sessionsById` のシェル: id・state・backendId 等の軽量フィールド）は残し、session は **close/delete されず開いた状態を保つ**（behavior「退避は close/delete を引き起こさない」）。
+- **退避トリガ**: ある session が「アクティブでもなく、現在 viewable でもない」状態へ遷移したとき（= `BoundSessionChat` unmount で viewable registry から外れた、または active 切替で背面に回った）。同時に body を保持する session 数は「active + 現在 viewable」に限定され、Rust plan は上限 `MAX_HYDRATED_SESSIONS` を超えた分を、request の `evictionRank` が小さい（最終参照が古い）非アクティブ session から drop する。同 rank の tie-break は session id で安定化する。
+- **再供給**: 既存 `selectSession` / `loadSession`（→ `getSession` の `initialPage` = 最新 50 件）と `rememberInitialPage`（pageState 再初期化）がそのまま再 hydrate する。`BoundSessionChat` は sessionId 表示時に `loadSession` を呼ぶ（既存実装）ため、背面→前面の切替で自動的に再供給される。再供給専用コードは増やさない。
+
+### 退避が「外部観測上不可視」である根拠
+
+- 経路 1: live tail（最新・ストリーミング・ターン進行中）は常に保持されるため、進行中表示・新規追加・ターン完了確定（`SET_STREAMING_MESSAGE` / `ADD_MESSAGE` / `MARK_AGENT_TURN_COMPLETED`）は退避の影響を受けない。古いレンジは backward 再供給で退避前と同一 message・同一順序に復元される（cursor 冪等性）。
+- 経路 2: 再表示時に正本から最新 page を再 hydrate するため、切替前と同一の表示・スクロール可能履歴が復元される。
+- 既読/履歴の状態は Rust 正本（および `getSession` が返す metadata）から再構築されるため、退避前後でユーザーから区別できない。
+
+## データモデルまたは型
+
+新規の永続型・WebSocket プロトコル型・read API は追加しない。退避判定用に Tauri command の request/plan 型を Rust usecase に追加し、フロントは同じ JSON shape を TypeScript 型として mirror する。
+
+### Rust request / plan 型（`message_window.rs`）
+
+```rust
+pub struct ActiveMessageWindowObservation {
+    session_id: String,
+    message_count: usize,
+    oldest_visible_index: usize,
+    loaded_pages: Vec<LoadedMessagePage>,
+    turn_phase: TurnPhase,
+}
+
+pub struct HydratedSessionObservation {
+    session_id: String,
+    message_count: usize,
+    eviction_rank: u64,
+    protected: bool,
+    loading: bool,
+}
+
+pub struct AgentChatEvictionPlanRequest {
+    active: Option<ActiveMessageWindowObservation>,
+    sessions: Vec<HydratedSessionObservation>,
+}
+```
+
+- `evictionRank` はフロントが session 表示・load・送信などの参照時に単調増加で更新する観測値であり、Rust 側が非アクティブ session 候補を「最終参照が古い順」に sort/select するためだけに使う。未記録 session は `0` として扱い、同 rank は Rust 側で session id により安定化する。
+- `AgentChatEvictionPlan` は active window の `count` / `nextCursor` / `loadedPages` rewind と、body 全体を退避する `evictSessionIds` を返す。
+- `RETAINED_MESSAGE_CAP = 200`、`MAX_HYDRATED_SESSIONS = 3` は Rust usecase の定数として持つ。
+
+### `pageStateRef` の拡張（`useAgentChat.ts`）
+
+現状:
+
+```ts
+Record<string, { nextCursor: string | null; hasMore: boolean; loading: boolean }>
+```
+
+拡張案（経路 1 の rewind に必要な loaded page cursor 履歴を追加）:
+
+```ts
+Record<string, {
+  nextCursor: string | null;   // 次に backward 取得する境界（既存）
+  hasMore: boolean;            // 既存
+  loading: boolean;            // 既存
+  // 新規: 読み込み済み page を新しい→古い順に記録。各 page を再取得する
+  // requestCursor（その page を取得した際に渡した cursor）と message 件数。
+  // 退避時はここから drop する page を pop し、nextCursor を rewind する。
+  loadedPages: Array<{ requestCursor: string | null; count: number }>;
+}>
+```
+
+- 初回 hydrate（`rememberInitialPage`）で `loadedPages = [{ requestCursor: null, count: initialPage件数 }]`。
+- `loadOlderMessages` 成功時に `loadedPages.push({ requestCursor: 使用した cursor, count: page.messages件数 })`。
+- 経路 1 退避時: 最古 page から `k` 件 pop し、その合計件数を `session.messages` 先頭から drop。`nextCursor = pop した中で最も新しい page の requestCursor`、`hasMore = true` に rewind（再取得の冪等性は cursor 意味論で担保）。
+
+### reducer action（`agentChatReducer.ts`）
+
+```ts
+// 非アクティブ session の body 全体退避（summary シェルは残す）
+| { type: "EVICT_SESSION_BODY"; sessionId: string }
+// アクティブ session の最古側 message を先頭から count 件退避
+| { type: "EVICT_OLDER_MESSAGES"; sessionId: string; count: number }
+```
+
+- `EVICT_SESSION_BODY`: `sessionsById[id]` を `{ ...session, messages: [] }` に置換（id 等のシェルは保持、`CLEANUP_SESSION` とは異なり turnPhase 等の per-session map は消さない）。
+- `EVICT_OLDER_MESSAGES`: `messages = messages.slice(count)`（先頭=最古を drop）。`count` は呼び出し側が page 境界に揃えて算出する。
+
+### 退避ポリシー定数（Rust usecase）
+
+```rust
+RETAINED_MESSAGE_CAP   // アクティブ session が常駐保持する message 上限件数
+MAX_HYDRATED_SESSIONS  // body を常駐保持する session 数の上限（active + viewable を優先）
+```
+
+**確定方針**: 退避 policy は `message_window.rs` の Rust 定数として集中管理する。値は `INITIAL_SESSION_PAGE_LIMIT` の数倍程度（`RETAINED_MESSAGE_CAP = 200`, `MAX_HYDRATED_SESSIONS = 3`）を初期値とし、有界化・anti-thrash を満たす範囲で調整する。アプリ設定や新規永続 config は追加しない。
+
+## 処理フロー
+
+### 経路 1（アクティブ session スクロールバック）
+
+1. ユーザーが上端付近へスクロール → `ChatSessionView.handleScroll` が `loadOlderMessages` を起動（既存）。
+2. `loadOlderMessages` が `get_session_page(nextCursor)` を呼び、`PREPEND_MESSAGES` + `loadedPages.push`（既存 + 拡張）。
+3. ユーザーが下方向へスクロールし、上端の古い prefix が可視範囲から離れる（`handleScroll` が観測）。
+4. `evictActiveOlderMessages` が active observation（session id、message_count、oldest_visible_index、loadedPages、turnPhase）を `plan_agent_chat_eviction` に渡す。`nextCursor` / `hasMore` は退避 plan の出力であり、入力には含めない。
+5. Rust plan が保持件数 > `RETAINED_MESSAGE_CAP`、上端離脱、turnPhase idle、loaded page 境界を満たす場合だけ active eviction plan を返す:
+   - drop する最古 page 群を `loadedPages` から決定（live tail は残す）。
+   - rewind 後の `nextCursor` / `hasMore` / `loadedPages` を返す。
+6. フロントは plan に従って `EVICT_OLDER_MESSAGES` を dispatch（先頭から該当件数 drop）し、`pageStateRef` を Rust plan の値に更新する。
+7. 後でユーザーが再び上端へスクロール → 手順 1〜2 がそのまま再供給（退避前と同一 page を冪等取得）。
+
+### 経路 2（非アクティブ session）
+
+1. session が active から外れる、または `BoundSessionChat` unmount で viewable registry から外れる。
+2. `evictInactiveSessions` を起動:
+   - フロントは「active + 現在 viewable」を `protected=true`、loading 中を `loading=true`、参照順を `evictionRank` として観測値を渡す。
+   - Rust は body を保持している session 数が `MAX_HYDRATED_SESSIONS` を超えた場合、保護集合外かつ非 loading の候補を `evictionRank` 昇順で sort し、超過分の `evictSessionIds` を返す。
+   - フロントは返却された session について、適用直前にも active/viewable/loading でないことを再確認し、`EVICT_SESSION_BODY` を dispatch する。
+3. 当該 session を再表示（`selectSession` / `BoundSessionChat` 再 mount → `loadSession`）すると `getSession.initialPage` で最新 page を再 hydrate（既存経路）。
+
+### 退避から除外する不変条件
+
+- アクティブ session の live tail（最新 page）、ストリーミング中・ターン進行中の message レンジは経路 1 退避の対象外。
+- active session 自体は経路 2 退避の対象外。
+- 退避は `messages` 配列の操作のみで、`turnPhases` / `pendingQueues` / `latestTokenUsage` 等の per-session メタや Rust 正本には触れない（`CLEANUP_SESSION` との明確な差異）。
+
+## エラー処理
+
+- 再供給（`loadOlderMessages` / `loadSession`）が失敗した場合は既存のエラーパス（`SET_ERROR` + `pageState.loading` 復帰）を踏襲する。退避によって失われるのは webview キャッシュのみで、正本は不変のため、再試行で復元可能。
+- `get_session_page` が `null`（session 消失等）を返す場合は既存どおり `hasMore=false` に確定し、再供給を止める。
+- 退避と再供給が競合しないよう、`loading` 中の session は経路 1 退避の対象外とする（dispatch 順序で整合を担保）。
+- 重複・欠落・順序崩れ防止: 再供給は既存 `prependMessages` / `appendMessage` の id ベース dedup（`agentChatReducer.ts:162,173`）に依存。退避は contiguous 窓の端のみ操作し、cursor は冪等取得を保証するため、再供給後も id 一意・seq 順序が保たれる。
+
+## テスト方針
+
+配置・粒度は CLAUDE.md の方針（reducer/hook は単体、外部プロセスは実行しない、Tauri API は `vi.mock`）に従う。
+
+### reducer 単体（`agentChatReducer.test.ts` に追加）
+
+- `EVICT_OLDER_MESSAGES`: 先頭 `count` 件のみ drop、tail と件数、参照不変条件を確認。`count=0` / `count>=length` の境界。
+- `EVICT_SESSION_BODY`: `messages` 空化、id/state 等シェル保持、他 session 不変、per-session メタ非破壊を確認。
+- 既存 `PREPEND_MESSAGES` / `ADD_MESSAGE` / `SET_STREAMING_MESSAGE` / `MARK_AGENT_TURN_COMPLETED` が退避 action 追加後も不変であること（回帰）。
+- 退避 → 再供給（`PREPEND_MESSAGES` / `UPSERT_SESSION`）往復で、退避前と同一 message・同一順序・重複/欠落なしを固定（behavior の「同一内容復元」シナリオ）。
+
+### hook 単体（`useAgentChat.test.ts` に追加）
+
+- `pageStateRef` の `loadedPages` 追跡と、経路 1 退避時の `nextCursor` rewind が再取得を冪等化することを、`get_session_page` モックで確認。
+- 経路 1: 上限超過 + 上端離脱時に最古 page が drop され、上端再スクロールで同一 page が再供給される（モック呼び出し列で検証）。
+- 経路 2: 非 viewable + active 外への遷移で `evictionRank` を含む request が Rust plan command に渡され、`EVICT_SESSION_BODY` が起動し、再表示で `getSession` 再 hydrate される。
+- 有界性: 上端離脱後（`oldestVisibleIndex > 0`）に drop 可能な古い page が退避され、live tail が `RETAINED_MESSAGE_CAP` 以下なら保持件数が cap へ収束することを固定する。live tail が cap を超える場合は live tail を保持したまま古い page の部分 drop plan が返ること、連続純上方向（`oldestVisibleIndex` が 0 近傍）では plan が `None` になり一時増大を許容することを固定する。多数 session を開いても hydrate 数が `MAX_HYDRATED_SESSIONS` を超えないことも assertion で固定する。
+- ストリーミング不変: 経路 1 退避タイミングで live tail / 進行中レンジが drop されないこと。
+
+### Rust usecase 単体（`message_window.rs`）
+
+- active window: turnPhase が idle で、保持件数が `RETAINED_MESSAGE_CAP` を超え、可視範囲外の page 境界で drop 可能な場合だけ `ActiveMessageEvictionPlan` を返す。
+- active window: streaming / waiting_permission など進行中 turn では plan を返さない。
+- inactive sessions: body 保持数が `MAX_HYDRATED_SESSIONS` を超えたとき、protected/loading を除外し、`evictionRank` 昇順（tie は session id）で退避対象を返す。入力 Vec の順序には依存しない。
+
+### lint / 既存テスト
+
+- `pnpm lint` / `pnpm test` / `cargo clippy -- -D warnings` / `cargo test` がすべて green。
+
+## リスクと代替案
+
+- **リスク: 退避↔再供給の thrash**。上限直上で頻繁に drop/再取得が起きるとスクロールが重くなる。→ 経路 1 はヒステリシス（上限 + 上端からの距離条件）と page 単位 drop で緩和。`RETAINED_MESSAGE_CAP` は `INITIAL_SESSION_PAGE_LIMIT` の数倍に設定。
+- **リスク: 中間レンジの forward 再供給不能**。cursor が backward しか無いため、live tail を残さず中間だけ drop すると復元不能。→ 退避は常に「最古側 drop（backward 復元）」または「body 全体 drop（newest 復元）」に限定し、中間 drop を設計から排除。
+- **リスク: 退避中にストリーミング/新規 message が到達**。→ live tail は退避対象外、`ADD_MESSAGE` / `SET_STREAMING_MESSAGE` は最後尾を操作するため経路 1 の最古側 drop と非干渉。`loading` 中 session は退避対象外。
+- **リスク: 非アクティブ session の候補選定が JS object の列挙順に依存する**。→ フロントは `evictionRank` を明示的な観測値として request に含め、Rust usecase が rank 昇順で sort/select する。tie は session id で安定化する。
+- **代替案（不採用）: 軽量プレースホルダ化**。中間欠落を生み forward 再供給不在の制約に反するため不採用。実体 drop + backward/newest 再供給に統一。
+- **代替案（不採用）: 退避ポリシー閾値をアプリ設定から供給**。現時点ではユーザー設定化の要求がなく、2 つの整数定数のために新規永続 config を増やすのは非スコープに反する。Rust usecase の定数として保持する。
+
+## 仮定
+
+- session ストア（Rust）が message の正本であり、webview 保持は再取得可能なキャッシュ。退避 body の再供給に整合性問題は生じない（#1213 の `get_session_page` / `getSession` が overlay・metadata を含めて正本を返す）。
+- 退避単位は **実体 drop**（プレースホルダ化しない）。経路 1 は page 単位の最古側 drop、経路 2 は body 全体 drop。
+- 退避トリガは **経路 1 = Rust plan が保持上限超過 + 上端離脱を満たすと判断したとき**、**経路 2 = 非アクティブ化（active 外 かつ 非 viewable）+ Rust plan が hydrate session 数上限超過と判断したとき**。未参照時間ベースのタイマは採らない（イベント駆動で十分かつ単純）。
+- 再供給は既存 `get_session_page`（backward）と `getSession.initialPage`（newest）のみで完結し、新規 read API・永続/プロトコル型を追加しない。中間レンジの forward 再供給 API は設計から排除する。
+- 対象は agent チャット（`AgentChatPanel` / `BoundSessionChat` / `ChatSessionView`）。remote UI（`src/remote/`）は対象外。
+- 「有界」の観測点はテストでの保持件数・hydrate session 数の assertion とする。アクティブ session は、上端離脱後かつ live tail が cap 以下なら `RETAINED_MESSAGE_CAP` へ収束すること、live tail が cap を超える場合は live tail 超過を例外として古い page のみ退避されること、連続純上方向では退避しないことを観測点にする。非アクティブ session は hydrate session 数が `MAX_HYDRATED_SESSIONS` を超えないことを観測点にする。
+
+## Open Questions
+
+なし。
+
+- 退避ポリシー閾値（`RETAINED_MESSAGE_CAP` / `MAX_HYDRATED_SESSIONS`）の配置 → **解消**: Rust usecase の定数として集中管理する。新規永続 config は追加しない。
+- 非アクティブ session の退避優先順位 → **解消**: フロントが `evictionRank` を観測値として渡し、Rust usecase が `evictionRank` 昇順（tie は session id）で sort/select する。

--- a/docs/specs/issues-1195/requirements.md
+++ b/docs/specs/issues-1195/requirements.md
@@ -1,0 +1,86 @@
+# requirements — メモリ削減: フロント agent チャットの全メッセージ保持を退避/仮想化する (C6 / #1191 から分離)
+
+対象 ISSUE: #1195
+関連: #1191（広域調査・候補 C6 の正本）, #1194（C1 / Rust 側 streaming_parts 解放）, #1213（M2 / session summary index + message paging。**マージ済み**, commit 8cd3efe8）
+正本ドキュメント: `docs/releash-performance-architecture-audit.md`
+Spec ディレクトリ: `docs/specs/issues-1195/`
+
+## 背景と目的
+
+### 背景
+
+`#1191` のメモリ枯渇広域調査で特定した無制限増大経路のうち、フロント（webview）側の常駐型増幅が候補 **C6** である。`#1191` 本体は振る舞い不変・低リスクな Rust 側純粋削減（A 群）に絞ったため、表示挙動・履歴の見え方に関わる設計判断を要する C6 を本 ISSUE に分離した。
+
+#### #1213 の完了により前提が更新された（裏取り済み）
+
+本 ISSUE 起票時点では Rust 側に部分取得 API が存在せず「初回に全 message を含む `ChatSession` を丸ごと hydrate する」ことが C6 の中核問題だったが、その後 **#1213（M2: session storage を summary index + message paging に再設計）がマージ済み**（commit 8cd3efe8）となり、初回 hydrate の有界化はすでに完了している。現状を実コードで確認した結果は以下のとおり:
+
+- Rust 側に部分取得 API `get_session_page(session_id, cursor, limit)` が**実装済み**である（`src-tauri/src/adaptor/controller/command/agent_session/session.rs:515`, `.../gateway/agent_session/session_storage/message_store.rs:68`, `.../infrastructure/agent_session/runtime/bridge_common.rs:4692`）。runtime streaming overlay・token usage metadata の適用、legacy flat JSON の移行、index 欠落の自己修復まで含む。
+- フロントは初回ロード時、`getSession` が返す `initialPage`（**最新 `INITIAL_SESSION_PAGE_LIMIT = 50` 件のみ**, `src/hooks/useSessionStore.ts:39`）で hydrate し、`pageStateRef` で `nextCursor` / `hasMore` を管理する（`src/hooks/useAgentChat.ts:276,288`）。
+- 過去方向のスクロールバックは `getSessionPage(sessionId, cursor)` を呼び、得た page を `PREPEND_MESSAGES` で `session.messages` の先頭に追記する（`src/hooks/useAgentChat.ts:442-468`, `agentChatReducer.ts:60,170-178`）。
+- すなわち「session を開いた瞬間に全 message body が常駐する」という当初の中核問題は #1213 で解消済みである。
+
+#### #1213 完了後に残る無制限増大経路（本 ISSUE の対象）
+
+`sessionsById: Record<string, ChatSession>`（`agentChatReducer.ts:29`）から message body が解放されるのは依然として `CLEANUP_SESSION`（session の close/delete 時のみ。`useAgentChat.ts:641,746`）に限られ、**退避（eviction）の経路が存在しない**。このため、初回 50 件制限の後にも次の2経路で webview メモリが無制限に増え続ける:
+
+1. **アクティブ session のスクロールバック累積**: `getSessionPage` で過去方向に遡って `PREPEND_MESSAGES` した古い message が drop されない。長い単一会話を遡るほど `session.messages` が O(N) に積み上がる。
+2. **非アクティブ session の常駐**: 開いた session の body は close/delete されるまで `sessionsById` に残り続ける。同時に開く（切り替えて使う）session 数だけ常駐量が倍増する。
+
+### 目的
+
+開いている agent チャット session の webview メモリ常駐量を、会話長・同時 session 数に対して線形に増え続けない構造へ是正する。表示・履歴・既読の外部から観測可能な振る舞いを変えずに、webview が保持する message body 量を有界化する。#1213 が導入済みの paging API（`get_session_page` + cursor）を再供給経路として活用し、新規の永続データ型・プロトコル型を増やさずに実現する。
+
+## スコープ
+
+本 ISSUE は、上記2経路の常駐量を有界化する **webview 側の退避（eviction）+ 必要時の再供給（再 hydrate）** を導入する。粒度・トリガの細部は `design.md` で確定する。
+
+1. **アクティブ session 内の可視範囲外 message の退避（仮想化）**: スクロールバックで遡って `sessionsById` に積み上がった、可視範囲から外れた古い message body を退避（drop / 軽量プレースホルダ化）し、保持件数を有界に保つ。
+2. **非アクティブ（バックグラウンド）session の body 退避**: close/delete されていないが現在表示していない session の `messages` body を退避し、同時保持量を有界に保つ。
+3. **退避した message の再供給経路**: 退避した範囲が再表示対象になった時点で、#1213 の `get_session_page(session_id, cursor, limit)` を用いて Rust の session 正本から再取得し、表示を復元する。再供給は既存 paging API の利用に留め、新規 read API の追加は行わない。
+4. **責務配置**: 退避判定・再供給に必要なロジックは `rust-first-logic` 方針に従って配置する。フロントは表示・入力・invoke・表示用フォーマットに徹し、新たなビジネスロジックを増やさない。
+
+## 非スコープ
+
+- Rust 側の session summary index 化、`get_session_page` 等の paging API 新設、fork の copy-on-write 化 → `#1213`（マージ済み）の責務。本 ISSUE は #1213 が提供する既存 API を利用するに留め、再設計・拡張は行わない。
+- Rust 側 `streaming_parts` のターン完了時解放 → `#1194`（C1）の責務。
+- Rust 側の `SessionStore` cache / clone / serialize 削減（C9）→ `#1191` A 群の責務。
+- ストリーミング表示・イベント永続化・session の保存正本フォーマットの変更。表示内容・永続化イベント・履歴復元の外部仕様は不変に保つ。
+- 初回ページロード件数（`INITIAL_SESSION_PAGE_LIMIT`）・cursor paging の取得方式そのものの変更（#1213 で確定済み。退避/再供給がこれを利用するだけで、ページング契約は変えない）。
+- remote UI（`src/remote/`）への退避/仮想化の適用。本 ISSUE の主対象は agent チャット（`AgentChatPanel` 系）であり、remote は必要なら別途扱う。
+- 新規の永続データ型・プロトコル型の追加（既存 `get_session_page` の利用で完結する想定）。
+
+## 要求事項
+
+1. 開いている session について、webview が常駐保持する message body 量が、会話の総 message 数および同時に開いている session 数に対して**線形に増え続けない**こと（有界化）。アクティブ session では、上端を離れた後（下方向スクロール）または present 復帰時に、drop 可能な古い page が退避され、live tail が `RETAINED_MESSAGE_CAP` 以下なら常駐量が `RETAINED_MESSAGE_CAP` へ収束する。ただし live tail（最新 page・進行中レンジ）自体が cap を超える長尺 session では、要求 4 により live tail 超過分は退避せず例外として保持し、drop 可能な古い page のみ退避する。連続した純上方向スクロールバック中（`oldest_visible_index` が 0 近傍）は、anti-thrash のため contiguous な窓が一時的に cap を超えて増大しうることを明示的な制約として許容する。非アクティブ session では body 退避により同時保持 session 数の増加に対して有界化する。
+2. message body を退避しても、ユーザーから見た表示・スクロールバック・既読履歴の**外部観測可能な振る舞いが変わらない**こと（退避は実装内部の最適化であり、表示は退避前と同一に再現できる）。
+3. 退避済み message が再表示対象になった場合、#1213 の `get_session_page` を用いて Rust 側の session 正本から再供給し、表示を復元できること。再供給に整合性の問題（重複・欠落・順序崩れ）を生じないこと。
+4. ストリーミング中・ターン進行中のアクティブ session の表示・更新が、退避/仮想化によって破壊されないこと（`SET_STREAMING_MESSAGE` / `ADD_MESSAGE` / `MARK_AGENT_TURN_COMPLETED` の挙動が不変。退避対象はアクティブな進行中レンジを含めない）。
+5. 退避判定・再供給に必要なロジックは `rust-first-logic` 方針に従って配置すること。フロントに新たなビジネスロジックを増やさない。
+6. #1213 が確定した paging 契約（`initialPage` / `get_session_page` / cursor / `INITIAL_SESSION_PAGE_LIMIT`）と矛盾しないこと。退避/再供給は既存契約の上に構築し、ページング方式の再設計・二重実装を生まない。
+7. 既存テスト・lint が green であること（`pnpm test` / `pnpm lint` / `cargo test` / `cargo clippy -- -D warnings`）。退避/再供給の振る舞い不変は新規テストで固定する。
+
+## 受け入れ基準の概要
+
+- 長い会話（多数 message）をスクロールバックで遡った後に上端を離れる、または present へ戻った状態、および複数 session を開いて切り替えた状態で、webview が保持する message body 量が有界である（live tail が cap 以下なら `RETAINED_MESSAGE_CAP` へ収束し、live tail が cap を超える場合は live tail を保持したまま古い page のみ退避される）ことを確認できる。
+- 退避と再供給を経た後でも、退避前と同一の表示・スクロールバック・既読履歴が再現される（振る舞い不変を単体テストで固定）。
+- 退避済みレンジへの再スクロール時、`get_session_page` 経由の再供給で重複・欠落・順序崩れなく表示が復元される。
+- ストリーミング中・ターン進行中の表示更新が退避/仮想化により退行しない。
+- `rust-first-logic` 方針に反するロジックがフロントに追加されていない。
+- 既存テスト・lint がすべて green。
+- 具体的な計測手順・閾値（保持上限件数・session 数上限等）・観測点は `behavior.md` で定義する。
+
+## 仮定
+
+- session ストア（Rust）が message の正本であり、webview の保持は再取得可能なキャッシュである。退避した body の再供給に整合性問題は生じない（#1213 の `get_session_page` が runtime streaming overlay・metadata を含めて正本を返す前提）。
+- 退避/再供給の対象は agent チャット（`AgentChatPanel` 系）であり、remote UI（`src/remote/`）は本 ISSUE の主対象外。
+- 退避のトリガ・閾値（非アクティブ化時に即時か、保持 message 数 / session 数の上限超過時か、未参照時間ベースか）と、退避単位（body 全体 drop か軽量プレースホルダ化か）は、要求（有界化・振る舞い不変・再供給整合）を満たす範囲で `design.md` の裁量により確定する。
+- 再供給は既存 `get_session_page` と `getSession.initialPage` で完結する。中間レンジの forward 再供給 API や新規 read API は追加しない。
+
+## Open Questions
+
+なし（起票時の3点はいずれも解消済み）。
+
+- #1213 との責務境界・再供給 API の先行実装要否 → **解消**: #1213 がマージ済みで `get_session_page` + cursor paging が実装済み。#1195 は既存 API を利用し、新規 API を追加しない。
+- 退避の粒度（非アクティブ session 全体 / アクティブ session 内可視範囲外 message）→ **解消**: 双方を対象とする（ユーザー合意済み）。
+- 退避トリガ（非アクティブ化時 / 上限超過時 / 未参照時間ベース） → **解消**: 要求を満たす範囲で `design.md` の裁量により確定する（仮定参照）。

--- a/src-tauri/src/adaptor/controller/command/agent_session/session.rs
+++ b/src-tauri/src/adaptor/controller/command/agent_session/session.rs
@@ -545,6 +545,13 @@ pub async fn get_session_page(
 }
 
 #[tauri::command]
+pub fn plan_agent_chat_eviction(
+    request: crate::usecase::agent_session::session::AgentChatEvictionPlanRequest,
+) -> Result<crate::usecase::agent_session::session::AgentChatEvictionPlan, String> {
+    Ok(crate::usecase::agent_session::session::plan_agent_chat_eviction(request))
+}
+
+#[tauri::command]
 pub async fn get_session_attachment(
     state: tauri::State<'_, Arc<SessionStore>>,
     app: tauri::AppHandle,

--- a/src-tauri/src/adaptor/controller/command/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/mod.rs
@@ -186,6 +186,7 @@ pub(crate) fn register_all(builder: tauri::Builder<tauri::Wry>) -> tauri::Builde
             crate::adaptor::controller::command::agent_session::stored_session::list_sessions,
             crate::adaptor::controller::command::agent_session::session::get_session,
             crate::adaptor::controller::command::agent_session::session::get_session_page,
+            crate::adaptor::controller::command::agent_session::session::plan_agent_chat_eviction,
             crate::adaptor::controller::command::agent_session::session::get_session_attachment,
             crate::adaptor::controller::command::agent_session::stored_session::create_session,
             crate::adaptor::controller::command::agent_session::stored_session::close_session,

--- a/src-tauri/src/usecase/agent_session/session/message_window.rs
+++ b/src-tauri/src/usecase/agent_session/session/message_window.rs
@@ -1,0 +1,341 @@
+use serde::{Deserialize, Serialize};
+
+use crate::usecase::agent_session::status::TurnPhase;
+
+pub const RETAINED_MESSAGE_CAP: usize = 200;
+pub const MAX_HYDRATED_SESSIONS: usize = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoadedMessagePage {
+    pub request_cursor: Option<String>,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveMessageWindowObservation {
+    pub session_id: String,
+    pub message_count: usize,
+    pub oldest_visible_index: usize,
+    #[serde(default)]
+    pub loaded_pages: Vec<LoadedMessagePage>,
+    pub turn_phase: TurnPhase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HydratedSessionObservation {
+    pub session_id: String,
+    pub message_count: usize,
+    pub eviction_rank: u64,
+    pub protected: bool,
+    pub loading: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentChatEvictionPlanRequest {
+    #[serde(default)]
+    pub active: Option<ActiveMessageWindowObservation>,
+    #[serde(default)]
+    pub sessions: Vec<HydratedSessionObservation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageEvictionDirection {
+    Older,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveMessageEvictionPlan {
+    pub session_id: String,
+    pub direction: MessageEvictionDirection,
+    pub count: usize,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+    pub loaded_pages: Vec<LoadedMessagePage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentChatEvictionPlan {
+    pub active: Option<ActiveMessageEvictionPlan>,
+    pub evict_session_ids: Vec<String>,
+}
+
+pub fn plan_agent_chat_eviction(request: AgentChatEvictionPlanRequest) -> AgentChatEvictionPlan {
+    AgentChatEvictionPlan {
+        active: request
+            .active
+            .as_ref()
+            .and_then(plan_active_window_eviction),
+        evict_session_ids: plan_inactive_session_eviction(&request.sessions),
+    }
+}
+
+fn plan_inactive_session_eviction(sessions: &[HydratedSessionObservation]) -> Vec<String> {
+    let hydrated_count = sessions
+        .iter()
+        .filter(|session| session.message_count > 0)
+        .count();
+    let excess = hydrated_count.saturating_sub(MAX_HYDRATED_SESSIONS);
+    if excess == 0 {
+        return Vec::new();
+    }
+
+    let mut candidates = sessions
+        .iter()
+        .filter(|session| session.message_count > 0 && !session.protected && !session.loading)
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        left.eviction_rank
+            .cmp(&right.eviction_rank)
+            .then_with(|| left.session_id.cmp(&right.session_id))
+    });
+
+    candidates
+        .into_iter()
+        .take(excess)
+        .map(|session| session.session_id.clone())
+        .collect()
+}
+
+fn plan_active_window_eviction(
+    observation: &ActiveMessageWindowObservation,
+) -> Option<ActiveMessageEvictionPlan> {
+    if observation.turn_phase != TurnPhase::Idle {
+        return None;
+    }
+    if observation.message_count <= RETAINED_MESSAGE_CAP {
+        return None;
+    }
+
+    let loaded_pages = sanitize_pages(observation.loaded_pages.clone());
+    if loaded_pages.len() <= 1 {
+        return None;
+    }
+
+    plan_older_eviction(observation, &loaded_pages)
+}
+
+fn plan_older_eviction(
+    observation: &ActiveMessageWindowObservation,
+    loaded_pages: &[LoadedMessagePage],
+) -> Option<ActiveMessageEvictionPlan> {
+    debug_assert!(observation.message_count > RETAINED_MESSAGE_CAP);
+    debug_assert!(loaded_pages.len() > 1);
+
+    let max_drop_count = observation
+        .oldest_visible_index
+        .min(observation.message_count);
+    if max_drop_count == 0 {
+        return None;
+    }
+
+    let mut retained_pages = loaded_pages.to_vec();
+    let mut dropped_pages = Vec::new();
+    let mut retained_message_count = observation.message_count;
+    let mut drop_count = 0usize;
+
+    while retained_message_count > RETAINED_MESSAGE_CAP && retained_pages.len() > 1 {
+        let page = retained_pages.last().cloned()?;
+        if drop_count + page.count > max_drop_count {
+            break;
+        }
+        retained_pages.pop();
+        drop_count += page.count;
+        retained_message_count = retained_message_count.saturating_sub(page.count);
+        dropped_pages.push(page);
+    }
+
+    if drop_count == 0 {
+        return None;
+    }
+
+    let rewind_page = dropped_pages.last()?;
+    Some(ActiveMessageEvictionPlan {
+        session_id: observation.session_id.clone(),
+        direction: MessageEvictionDirection::Older,
+        count: drop_count,
+        next_cursor: rewind_page.request_cursor.clone(),
+        has_more: true,
+        loaded_pages: retained_pages,
+    })
+}
+
+fn sanitize_pages(pages: Vec<LoadedMessagePage>) -> Vec<LoadedMessagePage> {
+    pages.into_iter().filter(|page| page.count > 0).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn page(request_cursor: Option<&str>, count: usize) -> LoadedMessagePage {
+        LoadedMessagePage {
+            request_cursor: request_cursor.map(str::to_string),
+            count,
+        }
+    }
+
+    fn loaded_message_count(pages: &[LoadedMessagePage]) -> usize {
+        pages.iter().map(|page| page.count).sum()
+    }
+
+    fn active_observation() -> ActiveMessageWindowObservation {
+        ActiveMessageWindowObservation {
+            session_id: "s1".to_string(),
+            message_count: 250,
+            oldest_visible_index: 60,
+            loaded_pages: vec![
+                page(None, 50),
+                page(Some("201"), 50),
+                page(Some("151"), 50),
+                page(Some("101"), 50),
+                page(Some("51"), 50),
+            ],
+            turn_phase: TurnPhase::Idle,
+        }
+    }
+
+    #[test]
+    fn active_eviction_drops_oldest_pages_when_prefix_is_outside_visible_range() {
+        let plan = plan_agent_chat_eviction(AgentChatEvictionPlanRequest {
+            active: Some(active_observation()),
+            sessions: Vec::new(),
+        })
+        .active
+        .expect("active plan");
+
+        assert_eq!(plan.direction, MessageEvictionDirection::Older);
+        assert_eq!(plan.count, 50);
+        assert_eq!(plan.next_cursor.as_deref(), Some("51"));
+        assert!(plan.has_more);
+        assert_eq!(plan.loaded_pages.len(), 4);
+        assert_eq!(
+            loaded_message_count(&plan.loaded_pages),
+            RETAINED_MESSAGE_CAP
+        );
+        assert_eq!(
+            plan.loaded_pages.last().unwrap().request_cursor.as_deref(),
+            Some("101")
+        );
+    }
+
+    #[test]
+    fn active_eviction_keeps_live_tail_when_user_is_scrolling_at_top() {
+        let mut observation = active_observation();
+        observation.oldest_visible_index = 0;
+
+        let plan = plan_agent_chat_eviction(AgentChatEvictionPlanRequest {
+            active: Some(observation),
+            sessions: Vec::new(),
+        });
+
+        assert!(plan.active.is_none());
+    }
+
+    #[test]
+    fn active_eviction_keeps_non_idle_window_intact() {
+        for turn_phase in [TurnPhase::Streaming, TurnPhase::WaitingPermission] {
+            let mut observation = active_observation();
+            observation.turn_phase = turn_phase;
+
+            let plan = plan_agent_chat_eviction(AgentChatEvictionPlanRequest {
+                active: Some(observation),
+                sessions: Vec::new(),
+            });
+
+            assert!(plan.active.is_none());
+        }
+    }
+
+    #[test]
+    fn active_eviction_returns_partial_plan_when_live_tail_exceeds_cap() {
+        let mut observation = active_observation();
+        observation.message_count = 350;
+        observation.oldest_visible_index = 100;
+        observation.loaded_pages = vec![
+            page(None, 250),
+            page(Some("251"), 50),
+            page(Some("201"), 50),
+        ];
+
+        let plan = plan_agent_chat_eviction(AgentChatEvictionPlanRequest {
+            active: Some(observation),
+            sessions: Vec::new(),
+        })
+        .active
+        .expect("partial active plan");
+
+        assert_eq!(plan.count, 100);
+        assert_eq!(plan.next_cursor.as_deref(), Some("251"));
+        assert!(plan.has_more);
+        assert_eq!(plan.loaded_pages, vec![page(None, 250)]);
+        assert!(loaded_message_count(&plan.loaded_pages) > RETAINED_MESSAGE_CAP);
+    }
+
+    #[test]
+    fn active_eviction_returns_none_at_or_below_cap() {
+        for message_count in [RETAINED_MESSAGE_CAP - 1, RETAINED_MESSAGE_CAP] {
+            let mut observation = active_observation();
+            observation.message_count = message_count;
+            observation.oldest_visible_index = 50;
+            observation.loaded_pages = vec![
+                page(None, 50),
+                page(Some("151"), 50),
+                page(Some("101"), 50),
+                page(Some("51"), message_count.saturating_sub(150)),
+            ];
+
+            let plan = plan_agent_chat_eviction(AgentChatEvictionPlanRequest {
+                active: Some(observation),
+                sessions: Vec::new(),
+            });
+
+            assert!(plan.active.is_none());
+        }
+    }
+
+    #[test]
+    fn active_eviction_returns_none_for_single_live_tail_page() {
+        let mut observation = active_observation();
+        observation.message_count = RETAINED_MESSAGE_CAP + 50;
+        observation.oldest_visible_index = 50;
+        observation.loaded_pages = vec![page(None, RETAINED_MESSAGE_CAP + 50)];
+
+        let plan = plan_agent_chat_eviction(AgentChatEvictionPlanRequest {
+            active: Some(observation),
+            sessions: Vec::new(),
+        });
+
+        assert!(plan.active.is_none());
+    }
+
+    #[test]
+    fn inactive_eviction_returns_unprotected_hydrated_sessions_above_cap() {
+        let sessions = [("s2", 20), ("s5", 5), ("s4", 1), ("s1", 10), ("s3", 0)]
+            .into_iter()
+            .map(|(session_id, eviction_rank)| HydratedSessionObservation {
+                session_id: session_id.to_string(),
+                message_count: 50,
+                eviction_rank,
+                protected: matches!(session_id, "s3"),
+                loading: matches!(session_id, "s4"),
+            })
+            .collect();
+
+        let plan = plan_agent_chat_eviction(AgentChatEvictionPlanRequest {
+            active: None,
+            sessions,
+        });
+
+        assert_eq!(
+            plan.evict_session_ids,
+            vec!["s5".to_string(), "s1".to_string()]
+        );
+    }
+}

--- a/src-tauri/src/usecase/agent_session/session/mod.rs
+++ b/src-tauri/src/usecase/agent_session/session/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod errors;
 pub(crate) mod image_attachment;
 pub(crate) mod lifecycle_controller;
+mod message_window;
 mod open_tabs;
 mod prompt_suggestion;
 mod store;
@@ -11,6 +12,9 @@ use serde::{Deserialize, Serialize};
 pub use crate::usecase::agent_session::status::TurnPhase;
 pub(crate) use image_attachment::{
     reject_oversized_base64_image, validate_image_bytes, validate_image_bytes_for_media_type,
+};
+pub(crate) use message_window::{
+    plan_agent_chat_eviction, AgentChatEvictionPlan, AgentChatEvictionPlanRequest,
 };
 pub use open_tabs::OpenTabRegistry;
 pub(crate) use prompt_suggestion::{

--- a/src/components/panels/AgentChatPanel/BoundSessionChat.tsx
+++ b/src/components/panels/AgentChatPanel/BoundSessionChat.tsx
@@ -65,6 +65,7 @@ export function BoundSessionChat({
 		getSessionById,
 		loadSession,
 		loadOlderMessages,
+		evictOlderMessages = () => {},
 		registerViewableSession,
 		getSessionTurnPhase,
 		getSessionInterrupting,
@@ -229,6 +230,9 @@ export function BoundSessionChat({
 				cancelQueuedTurn(session.id, queuedTurnId)
 			}
 			onLoadOlderMessages={() => loadOlderMessages(session.id)}
+			onEvictOlderMessages={(request) =>
+				evictOlderMessages(session.id, request)
+			}
 			onPermissionModeChange={handlePermissionModeChange}
 			onPlanModeChange={handlePlanModeChange}
 			onModelChange={handleModelChange}

--- a/src/components/panels/AgentChatPanel/ChatSessionView.test.ts
+++ b/src/components/panels/AgentChatPanel/ChatSessionView.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatSession } from "@/types/session";
@@ -7,7 +7,13 @@ import {
 	shouldTailFollowMessageChange,
 } from "./ChatSessionView";
 
-const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn() }));
+const { mockInvoke, mockVirtualRange, mockOffsetOverrides } = vi.hoisted(
+	() => ({
+		mockInvoke: vi.fn(),
+		mockVirtualRange: { startIndex: 0, endIndex: null as number | null },
+		mockOffsetOverrides: new Map<number, number>(),
+	}),
+);
 
 vi.mock("@tauri-apps/api/core", () => ({
 	invoke: (...args: unknown[]) => mockInvoke(...args),
@@ -28,22 +34,40 @@ vi.mock("@tanstack/react-virtual", () => ({
 		getItemKey?: (index: number) => string | number;
 	}) => ({
 		getVirtualItems: () =>
-			Array.from({ length: count }, (_, index) => {
-				const size = estimateSize(index);
-				return {
-					index,
-					key: getItemKey?.(index) ?? index,
-					start: index * size,
-					size,
-					end: (index + 1) * size,
-				};
-			}),
+			Array.from(
+				{
+					length:
+						Math.min(mockVirtualRange.endIndex ?? count - 1, count - 1) -
+						Math.min(mockVirtualRange.startIndex, count) +
+						1,
+				},
+				(_, offset) => {
+					const index = mockVirtualRange.startIndex + offset;
+					const size = estimateSize(index);
+					return {
+						index,
+						key: getItemKey?.(index) ?? index,
+						start: index * size,
+						size,
+						end: (index + 1) * size,
+					};
+				},
+			).filter((item) => item.index >= 0 && item.index < count),
 		getTotalSize: () => {
 			let total = 0;
 			for (let index = 0; index < count; index++) {
 				total += estimateSize(index);
 			}
 			return total;
+		},
+		getOffsetForIndex: (targetIndex: number) => {
+			const override = mockOffsetOverrides.get(targetIndex);
+			if (override !== undefined) return [override, "start"] as const;
+			let offset = 0;
+			for (let index = 0; index < targetIndex; index++) {
+				offset += estimateSize(index);
+			}
+			return [offset, "start"] as const;
 		},
 		measureElement: () => {},
 		scrollToIndex: () => {},
@@ -67,41 +91,56 @@ const session: ChatSession = {
 	permissionMode: "edit",
 };
 
-function renderChatSessionView(
-	onLoadOlderMessages: () => Promise<void> = vi
-		.fn()
-		.mockResolvedValue(undefined),
-) {
-	return render(
-		createElement(ChatSessionView, {
-			session,
-			isStreaming: false,
-			isInterrupting: false,
-			activityStatus: null,
-			error: null,
-			permissionMode: "edit",
-			planMode: false,
-			availableModels: [],
-			selectedModel: "claude:sonnet",
-			pendingQueue: [],
-			selectedBackendId: null,
-			canChangeBackend: false,
-			worktreePath: "/repo",
-			onSend: vi.fn().mockResolvedValue(undefined),
-			onInterrupt: vi.fn(),
-			onCancelQueuedTurn: vi.fn().mockResolvedValue(undefined),
-			onLoadOlderMessages,
-			onPermissionModeChange: vi.fn(),
-			onPlanModeChange: vi.fn(),
-			onModelChange: vi.fn(),
-			onRespondPermission: vi.fn(),
-		}),
-	);
+interface RenderOptions {
+	testSession?: ChatSession;
+	onLoadOlderMessages?: () => Promise<void>;
+	onEvictOlderMessages?: (options: {
+		oldestVisibleIndex?: number;
+		onEvicted?: (eviction: { count: number; direction: "older" }) => void;
+	}) => void;
+}
+
+function chatSessionViewElement({
+	testSession = session,
+	onLoadOlderMessages = vi.fn().mockResolvedValue(undefined),
+	onEvictOlderMessages,
+}: RenderOptions = {}) {
+	return createElement(ChatSessionView, {
+		session: testSession,
+		isStreaming: false,
+		isInterrupting: false,
+		activityStatus: null,
+		error: null,
+		permissionMode: "edit",
+		planMode: false,
+		availableModels: [],
+		selectedModel: "claude:sonnet",
+		pendingQueue: [],
+		selectedBackendId: null,
+		canChangeBackend: false,
+		worktreePath: "/repo",
+		onSend: vi.fn().mockResolvedValue(undefined),
+		onInterrupt: vi.fn(),
+		onCancelQueuedTurn: vi.fn().mockResolvedValue(undefined),
+		onLoadOlderMessages,
+		onEvictOlderMessages,
+		onPermissionModeChange: vi.fn(),
+		onPlanModeChange: vi.fn(),
+		onModelChange: vi.fn(),
+		onRespondPermission: vi.fn(),
+	});
+}
+
+function renderChatSessionView(options: RenderOptions = {}) {
+	return render(chatSessionViewElement(options));
 }
 
 beforeEach(() => {
 	mockInvoke.mockReset();
 	mockInvoke.mockResolvedValue(null);
+	mockVirtualRange.startIndex = 0;
+	mockVirtualRange.endIndex = null;
+	mockOffsetOverrides.clear();
 });
 
 describe("shouldTailFollowMessageChange", () => {
@@ -129,7 +168,7 @@ describe("shouldTailFollowMessageChange", () => {
 describe("ChatSessionView scroll loading", () => {
 	it("calls onLoadOlderMessages when scrollTop is below the threshold", () => {
 		const onLoadOlderMessages = vi.fn().mockResolvedValue(undefined);
-		renderChatSessionView(onLoadOlderMessages);
+		renderChatSessionView({ onLoadOlderMessages });
 		const scroll = screen.getByTestId("chat-session-scroll");
 
 		Object.defineProperty(scroll, "scrollTop", {
@@ -143,7 +182,7 @@ describe("ChatSessionView scroll loading", () => {
 
 	it("does not call onLoadOlderMessages when scrollTop is at the threshold", () => {
 		const onLoadOlderMessages = vi.fn().mockResolvedValue(undefined);
-		renderChatSessionView(onLoadOlderMessages);
+		renderChatSessionView({ onLoadOlderMessages });
 		const scroll = screen.getByTestId("chat-session-scroll");
 
 		Object.defineProperty(scroll, "scrollTop", {
@@ -153,5 +192,182 @@ describe("ChatSessionView scroll loading", () => {
 		fireEvent.scroll(scroll);
 
 		expect(onLoadOlderMessages).not.toHaveBeenCalled();
+	});
+
+	it("does not evict older messages while the oldest virtual row is still in overscan", () => {
+		const onEvictOlderMessages = vi.fn();
+		renderChatSessionView({ onEvictOlderMessages });
+		const scroll = screen.getByTestId("chat-session-scroll");
+
+		Object.defineProperty(scroll, "scrollTop", {
+			configurable: true,
+			value: 400,
+		});
+		fireEvent.scroll(scroll);
+
+		expect(onEvictOlderMessages).not.toHaveBeenCalled();
+	});
+
+	it("passes the virtual range and preserves the scroll anchor with virtualizer offsets", () => {
+		const messages = [
+			{ ...session.messages[0], id: "m1", role: "human" as const },
+			{
+				...session.messages[0],
+				id: "m2",
+				role: "agent" as const,
+				parts: [{ type: "text" as const, content: "agent" }],
+			},
+			{ ...session.messages[0], id: "m3", role: "human" as const },
+			{ ...session.messages[0], id: "m4", role: "human" as const },
+		];
+		const expandedSession = { ...session, messages };
+		const onEvictOlderMessages = vi.fn((options) => {
+			options.onEvicted?.({ count: 2, direction: "older" });
+		});
+		mockVirtualRange.startIndex = 2;
+		mockOffsetOverrides.set(2, 260);
+		const view = renderChatSessionView({
+			testSession: expandedSession,
+			onEvictOlderMessages,
+		});
+		const scroll = screen.getByTestId("chat-session-scroll");
+		Object.defineProperties(scroll, {
+			scrollTop: { configurable: true, writable: true, value: 400 },
+			scrollHeight: { configurable: true, value: 1000 },
+			clientHeight: { configurable: true, value: 200 },
+		});
+
+		fireEvent.scroll(scroll);
+
+		expect(onEvictOlderMessages).toHaveBeenCalledTimes(1);
+		expect(onEvictOlderMessages.mock.calls[0]?.[0].oldestVisibleIndex).toBe(2);
+
+		view.rerender(
+			chatSessionViewElement({
+				testSession: { ...expandedSession, messages: messages.slice(2) },
+				onEvictOlderMessages,
+			}),
+		);
+
+		expect(scroll.scrollTop).toBe(140);
+	});
+
+	it("requests eviction after loading older messages at the top", async () => {
+		const onLoadOlderMessages = vi.fn().mockResolvedValue(undefined);
+		const onEvictOlderMessages = vi.fn();
+		const initialMessages = Array.from({ length: 4 }, (_, index) => ({
+			...session.messages[0],
+			id: `m${index + 5}`,
+		}));
+		const olderMessages = Array.from({ length: 4 }, (_, index) => ({
+			...session.messages[0],
+			id: `m${index + 1}`,
+		}));
+		mockVirtualRange.startIndex = 0;
+		mockVirtualRange.endIndex = 3;
+		const view = renderChatSessionView({
+			testSession: { ...session, messages: initialMessages },
+			onLoadOlderMessages,
+			onEvictOlderMessages,
+		});
+		const scroll = screen.getByTestId("chat-session-scroll");
+		Object.defineProperty(scroll, "scrollTop", {
+			configurable: true,
+			value: 20,
+		});
+
+		fireEvent.scroll(scroll);
+		expect(onLoadOlderMessages).toHaveBeenCalledTimes(1);
+
+		view.rerender(
+			chatSessionViewElement({
+				testSession: {
+					...session,
+					messages: [...olderMessages, ...initialMessages],
+				},
+				onLoadOlderMessages,
+				onEvictOlderMessages,
+			}),
+		);
+
+		await waitFor(() => {
+			expect(onEvictOlderMessages).toHaveBeenCalledWith(
+				expect.objectContaining({
+					oldestVisibleIndex: 0,
+				}),
+			);
+		});
+	});
+
+	it("requests eviction when a new tail message arrives while following the bottom", async () => {
+		const onEvictOlderMessages = vi.fn();
+		const messages = Array.from({ length: 4 }, (_, index) => ({
+			...session.messages[0],
+			id: `m${index + 1}`,
+		}));
+		mockVirtualRange.startIndex = 2;
+		const view = renderChatSessionView({
+			testSession: { ...session, messages },
+			onEvictOlderMessages,
+		});
+
+		view.rerender(
+			chatSessionViewElement({
+				testSession: {
+					...session,
+					messages: [
+						...messages,
+						{ ...session.messages[0], id: "m5", timestamp: 1005 },
+					],
+				},
+				onEvictOlderMessages,
+			}),
+		);
+
+		await waitFor(() => {
+			expect(onEvictOlderMessages).toHaveBeenCalledWith(
+				expect.objectContaining({
+					oldestVisibleIndex: 2,
+				}),
+			);
+		});
+	});
+
+	it("does not request eviction for a new tail message while the user is away from the bottom", async () => {
+		const onEvictOlderMessages = vi.fn();
+		const messages = Array.from({ length: 4 }, (_, index) => ({
+			...session.messages[0],
+			id: `m${index + 1}`,
+		}));
+		mockVirtualRange.startIndex = 0;
+		const view = renderChatSessionView({
+			testSession: { ...session, messages },
+			onEvictOlderMessages,
+		});
+		const scroll = screen.getByTestId("chat-session-scroll");
+		Object.defineProperties(scroll, {
+			scrollTop: { configurable: true, value: 400 },
+			scrollHeight: { configurable: true, value: 1000 },
+			clientHeight: { configurable: true, value: 200 },
+		});
+
+		fireEvent.scroll(scroll);
+		onEvictOlderMessages.mockClear();
+		mockVirtualRange.startIndex = 2;
+		view.rerender(
+			chatSessionViewElement({
+				testSession: {
+					...session,
+					messages: [
+						...messages,
+						{ ...session.messages[0], id: "m5", timestamp: 1005 },
+					],
+				},
+				onEvictOlderMessages,
+			}),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(onEvictOlderMessages).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/panels/AgentChatPanel/ChatSessionView.tsx
+++ b/src/components/panels/AgentChatPanel/ChatSessionView.tsx
@@ -20,6 +20,7 @@ import React, {
 	useRef,
 	useState,
 } from "react";
+import type { OlderMessageEvictionOptions } from "@/hooks/useAgentChat";
 import type { DropZoneType } from "@/hooks/useNativeFileDrop";
 import type {
 	AgentEditorContext,
@@ -156,6 +157,18 @@ export function shouldTailFollowMessageChange(
 interface AgentPromptSuggestion {
 	text: string;
 	source: string;
+}
+
+const LOAD_OLDER_SCROLL_TOP_PX = 80;
+const AGENT_MESSAGE_ESTIMATED_HEIGHT_PX = 112;
+const HUMAN_MESSAGE_ESTIMATED_HEIGHT_PX = 72;
+const SHIMMER_ESTIMATED_HEIGHT_PX = 56;
+
+function estimateMessageRowSize(message: ChatMessage | undefined): number {
+	if (!message) return HUMAN_MESSAGE_ESTIMATED_HEIGHT_PX;
+	return message.role === "agent"
+		? AGENT_MESSAGE_ESTIMATED_HEIGHT_PX
+		: HUMAN_MESSAGE_ESTIMATED_HEIGHT_PX;
 }
 
 function isEditableShortcutTarget(target: EventTarget | null): boolean {
@@ -583,6 +596,9 @@ export interface ChatSessionViewProps {
 	onInterrupt: () => void;
 	onCancelQueuedTurn: (queuedTurnId?: string | null) => Promise<void>;
 	onLoadOlderMessages?: () => Promise<void>;
+	onEvictOlderMessages?: (
+		options: OlderMessageEvictionOptions,
+	) => void | Promise<void>;
 	onPermissionModeChange: (mode: PermissionMode) => void;
 	onPlanModeChange: (enabled: PlanMode) => void;
 	onModelChange: (modelId: string) => void;
@@ -638,6 +654,7 @@ export function ChatSessionView({
 	onInterrupt,
 	onCancelQueuedTurn,
 	onLoadOlderMessages,
+	onEvictOlderMessages,
 	onPermissionModeChange,
 	onPlanModeChange,
 	onModelChange,
@@ -695,11 +712,14 @@ export function ChatSessionView({
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const messageRefs = useRef(new Map<string, HTMLDivElement>());
 	const scrollRef = useRef<HTMLDivElement>(null);
+	const pendingScrollCompensationRef = useRef(0);
 	const lastMessageSnapshotRef = useRef<{
 		sessionId: string;
 		messageIds: string[];
 	}>({ sessionId: "", messageIds: [] });
+	const lastEvictionCheckMessageLengthRef = useRef(session.messages.length);
 	const isNearBottomRef = useRef(true);
+	const pendingTopLoadEvictionRef = useRef(false);
 	const lastTaskListRevisionRef = useRef<string | null>(null);
 	const currentTaskListRevision = useMemo(
 		() => taskListRevision(session.messages),
@@ -748,17 +768,6 @@ export function ChatSessionView({
 			setIsFileDragOver(false);
 		}
 	}, []);
-
-	// Track scroll position via onScroll handler
-	const handleScroll = useCallback(() => {
-		const el = scrollRef.current;
-		if (!el) return;
-		isNearBottomRef.current =
-			el.scrollHeight - el.scrollTop - el.clientHeight < 100;
-		if (el.scrollTop < 80) {
-			void onLoadOlderMessages?.();
-		}
-	}, [onLoadOlderMessages]);
 
 	// Derive streaming content tracking values
 	const agentMessages = session.messages.filter((m) => m.role === "agent");
@@ -830,14 +839,90 @@ export function ChatSessionView({
 		getScrollElement: () => scrollRef.current,
 		getItemKey: (index) => session.messages[index]?.id ?? "agent-shimmer",
 		estimateSize: (index) => {
-			if (index >= session.messages.length) return 56;
-			return session.messages[index]?.role === "agent" ? 112 : 72;
+			if (index >= session.messages.length) return SHIMMER_ESTIMATED_HEIGHT_PX;
+			return estimateMessageRowSize(session.messages[index]);
 		},
 		overscan: 8,
 		initialRect: {
 			width: 800,
 			height: 800,
 		},
+	});
+
+	const prefixOffsetForCount = useCallback(
+		(count: number) => {
+			if (count <= 0) return 0;
+			const offset = messageVirtualizer.getOffsetForIndex(count, "start")?.[0];
+			if (typeof offset === "number" && Number.isFinite(offset)) {
+				return offset;
+			}
+			const virtualItem = messageVirtualizer
+				.getVirtualItems()
+				.find((item) => item.index === count);
+			return virtualItem?.start ?? 0;
+		},
+		[messageVirtualizer],
+	);
+
+	const requestMessageEviction = useCallback(
+		(allowTopWindow = false) => {
+			const virtualItems = messageVirtualizer
+				.getVirtualItems()
+				.filter((item) => item.index < session.messages.length);
+			const firstVirtualItem = virtualItems[0];
+			if (!firstVirtualItem) return;
+			if (!allowTopWindow && firstVirtualItem.index <= 0) return;
+			void onEvictOlderMessages?.({
+				oldestVisibleIndex: firstVirtualItem.index,
+				onEvicted: ({ count }) => {
+					pendingScrollCompensationRef.current += prefixOffsetForCount(count);
+				},
+			});
+		},
+		[
+			session.messages.length,
+			messageVirtualizer,
+			onEvictOlderMessages,
+			prefixOffsetForCount,
+		],
+	);
+
+	// Track scroll position via onScroll handler.
+	const handleScroll = useCallback(() => {
+		const el = scrollRef.current;
+		if (!el) return;
+		isNearBottomRef.current =
+			el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+		if (el.scrollTop < LOAD_OLDER_SCROLL_TOP_PX) {
+			pendingTopLoadEvictionRef.current = true;
+			void onLoadOlderMessages?.();
+			return;
+		}
+		requestMessageEviction();
+	}, [onLoadOlderMessages, requestMessageEviction]);
+
+	useEffect(() => {
+		const previousLength = lastEvictionCheckMessageLengthRef.current;
+		lastEvictionCheckMessageLengthRef.current = session.messages.length;
+		if (session.messages.length <= previousLength) return;
+		if (pendingTopLoadEvictionRef.current) {
+			pendingTopLoadEvictionRef.current = false;
+			requestMessageEviction(true);
+			return;
+		}
+		if (!isNearBottomRef.current) return;
+		requestMessageEviction();
+	}, [requestMessageEviction, session.messages.length]);
+
+	useLayoutEffect(() => {
+		const compensation = pendingScrollCompensationRef.current;
+		if (compensation <= 0) return;
+		pendingScrollCompensationRef.current = 0;
+		const el = scrollRef.current;
+		if (!el) return;
+		el.scrollTop = Math.max(0, el.scrollTop - compensation);
+		isNearBottomRef.current =
+			el.scrollHeight - el.scrollTop - el.clientHeight < 100;
 	});
 
 	// Auto-scroll: keep tail-following behavior while only mounted rows are in the DOM.

--- a/src/components/panels/AgentChatPanel/ChatSessionView.tsx
+++ b/src/components/panels/AgentChatPanel/ChatSessionView.tsx
@@ -719,7 +719,9 @@ export function ChatSessionView({
 	}>({ sessionId: "", messageIds: [] });
 	const lastEvictionCheckMessageLengthRef = useRef(session.messages.length);
 	const isNearBottomRef = useRef(true);
-	const pendingTopLoadEvictionRef = useRef(false);
+	const pendingTopLoadEvictionRef = useRef<{
+		firstMessageId: string | null;
+	} | null>(null);
 	const lastTaskListRevisionRef = useRef<string | null>(null);
 	const currentTaskListRevision = useMemo(
 		() => taskListRevision(session.messages),
@@ -887,6 +889,8 @@ export function ChatSessionView({
 		],
 	);
 
+	const firstMessageId = session.messages[0]?.id ?? null;
+
 	// Track scroll position via onScroll handler.
 	const handleScroll = useCallback(() => {
 		const el = scrollRef.current;
@@ -894,25 +898,31 @@ export function ChatSessionView({
 		isNearBottomRef.current =
 			el.scrollHeight - el.scrollTop - el.clientHeight < 100;
 		if (el.scrollTop < LOAD_OLDER_SCROLL_TOP_PX) {
-			pendingTopLoadEvictionRef.current = true;
+			pendingTopLoadEvictionRef.current = { firstMessageId };
 			void onLoadOlderMessages?.();
 			return;
 		}
+		pendingTopLoadEvictionRef.current = null;
 		requestMessageEviction();
-	}, [onLoadOlderMessages, requestMessageEviction]);
+	}, [firstMessageId, onLoadOlderMessages, requestMessageEviction]);
 
 	useEffect(() => {
 		const previousLength = lastEvictionCheckMessageLengthRef.current;
 		lastEvictionCheckMessageLengthRef.current = session.messages.length;
 		if (session.messages.length <= previousLength) return;
-		if (pendingTopLoadEvictionRef.current) {
-			pendingTopLoadEvictionRef.current = false;
-			requestMessageEviction(true);
-			return;
+		const pendingTopLoadEviction = pendingTopLoadEvictionRef.current;
+		if (pendingTopLoadEviction) {
+			const didPrependOlderMessages =
+				firstMessageId !== pendingTopLoadEviction.firstMessageId;
+			if (didPrependOlderMessages) {
+				pendingTopLoadEvictionRef.current = null;
+				requestMessageEviction(true);
+				return;
+			}
 		}
 		if (!isNearBottomRef.current) return;
 		requestMessageEviction();
-	}, [requestMessageEviction, session.messages.length]);
+	}, [firstMessageId, requestMessageEviction, session.messages.length]);
 
 	useLayoutEffect(() => {
 		const compensation = pendingScrollCompensationRef.current;

--- a/src/hooks/agentChatReducer.test.ts
+++ b/src/hooks/agentChatReducer.test.ts
@@ -372,6 +372,138 @@ describe("agentChatReducer", () => {
 		});
 	});
 
+	describe("message body eviction", () => {
+		it("EVICT_OLDER_MESSAGES drops only the oldest prefix", () => {
+			const messages = [
+				makeMessage({ id: "m1" }),
+				makeMessage({ id: "m2" }),
+				makeMessage({ id: "m3" }),
+			];
+			const state: AgentChatState = {
+				...INITIAL_STATE,
+				sessionsById: { s1: makeSession({ id: "s1", messages }) },
+			};
+
+			const next = reducer(state, {
+				type: "EVICT_OLDER_MESSAGES",
+				sessionId: "s1",
+				count: 1,
+			});
+
+			expect(
+				next.sessionsById.s1.messages.map((message) => message.id),
+			).toEqual(["m2", "m3"]);
+			expect(
+				state.sessionsById.s1.messages.map((message) => message.id),
+			).toEqual(["m1", "m2", "m3"]);
+		});
+
+		it("EVICT_OLDER_MESSAGES is a no-op for count=0 and empties when count exceeds length", () => {
+			const messages = [makeMessage({ id: "m1" }), makeMessage({ id: "m2" })];
+			const state: AgentChatState = {
+				...INITIAL_STATE,
+				sessionsById: { s1: makeSession({ id: "s1", messages }) },
+			};
+
+			const unchanged = reducer(state, {
+				type: "EVICT_OLDER_MESSAGES",
+				sessionId: "s1",
+				count: 0,
+			});
+			expect(unchanged.sessionsById.s1.messages).toBe(messages);
+
+			const emptied = reducer(state, {
+				type: "EVICT_OLDER_MESSAGES",
+				sessionId: "s1",
+				count: 99,
+			});
+			expect(emptied.sessionsById.s1.messages).toEqual([]);
+		});
+
+		it("EVICT_SESSION_BODY clears messages while keeping session shell and per-session metadata", () => {
+			const session = makeSession({
+				id: "s1",
+				state: "active",
+				messages: [makeMessage({ id: "m1" })],
+				agentSessionId: "agent-1",
+			});
+			const state: AgentChatState = {
+				...INITIAL_STATE,
+				sessionsById: {
+					s1: session,
+					s2: makeSession({
+						id: "s2",
+						messages: [makeMessage({ id: "other" })],
+					}),
+				},
+				turnPhases: { s1: "streaming" },
+				pendingQueues: {
+					s1: [
+						{
+							id: "q1",
+							contentPreview: "queued",
+							createdAt: 1,
+							permissionMode: "edit",
+							imageCount: 0,
+						},
+					],
+				},
+				latestTokenUsage: { s1: { inputTokens: 1, outputTokens: 2 } },
+			};
+
+			const next = reducer(state, {
+				type: "EVICT_SESSION_BODY",
+				sessionId: "s1",
+			});
+
+			expect(next.sessionsById.s1).toMatchObject({
+				id: "s1",
+				state: "active",
+				agentSessionId: "agent-1",
+			});
+			expect(next.sessionsById.s1.messages).toEqual([]);
+			expect(
+				next.sessionsById.s2.messages.map((message) => message.id),
+			).toEqual(["other"]);
+			expect(next.turnPhases.s1).toBe("streaming");
+			expect(next.pendingQueues.s1).toEqual(state.pendingQueues.s1);
+			expect(next.latestTokenUsage.s1).toEqual({
+				inputTokens: 1,
+				outputTokens: 2,
+			});
+		});
+
+		it("evicted older messages can be rehydrated with PREPEND_MESSAGES without duplicates or order changes", () => {
+			const old = makeMessage({ id: "m1", timestamp: 1001 });
+			const middle = makeMessage({ id: "m2", timestamp: 1002 });
+			const latest = makeMessage({ id: "m3", timestamp: 1003 });
+			const state: AgentChatState = {
+				...INITIAL_STATE,
+				sessionsById: {
+					s1: makeSession({
+						id: "s1",
+						messages: [old, middle, latest],
+					}),
+				},
+			};
+
+			const evicted = reducer(state, {
+				type: "EVICT_OLDER_MESSAGES",
+				sessionId: "s1",
+				count: 1,
+			});
+			const rehydrated = reducer(evicted, {
+				type: "PREPEND_MESSAGES",
+				sessionId: "s1",
+				messages: [old, middle],
+			});
+
+			expect(
+				rehydrated.sessionsById.s1.messages.map((message) => message.id),
+			).toEqual(["m1", "m2", "m3"]);
+		});
+	});
+
 	describe("SET_TURN_PHASE", () => {
 		it("sets turn phase for a session", () => {
 			const next = reducer(INITIAL_STATE, {

--- a/src/hooks/agentChatReducer.ts
+++ b/src/hooks/agentChatReducer.ts
@@ -59,6 +59,8 @@ export type AgentChatAction =
 	| { type: "SET_ACTIVE_SESSION_ID"; sessionId: string | null }
 	| { type: "ADD_MESSAGE"; sessionId: string; message: ChatMessage }
 	| { type: "PREPEND_MESSAGES"; sessionId: string; messages: ChatMessage[] }
+	| { type: "EVICT_SESSION_BODY"; sessionId: string }
+	| { type: "EVICT_OLDER_MESSAGES"; sessionId: string; count: number }
 	| {
 			type: "SET_TURN_PHASE";
 			sessionId: string;
@@ -178,6 +180,12 @@ function prependMessages(
 	return { ...session, messages: [...newMessages, ...session.messages] };
 }
 
+function evictOlderMessages(session: ChatSession, count: number): ChatSession {
+	if (count <= 0) return session;
+	if (session.messages.length === 0) return session;
+	return { ...session, messages: session.messages.slice(count) };
+}
+
 function getActiveSession(state: AgentChatState): ChatSession | null {
 	if (!state.activeSessionId) return null;
 	return state.sessionsById[state.activeSessionId] ?? null;
@@ -292,6 +300,14 @@ export function reducer(
 		case "PREPEND_MESSAGES":
 			return updateSessionInStore(state, action.sessionId, (s) =>
 				prependMessages(s, action.messages),
+			);
+		case "EVICT_SESSION_BODY":
+			return updateSessionInStore(state, action.sessionId, (s) =>
+				s.messages.length === 0 ? s : { ...s, messages: [] },
+			);
+		case "EVICT_OLDER_MESSAGES":
+			return updateSessionInStore(state, action.sessionId, (s) =>
+				evictOlderMessages(s, action.count),
 			);
 		case "SET_TURN_PHASE": {
 			// idle に戻ったら interrupting 楽観フラグをクリアする。

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -22,6 +22,10 @@ vi.mock("./useSessionStore", () => ({
 	listSessions: vi.fn().mockResolvedValue([]),
 	getSession: vi.fn().mockResolvedValue(null),
 	getSessionPage: vi.fn().mockResolvedValue(null),
+	planAgentChatEviction: vi.fn().mockResolvedValue({
+		active: null,
+		evictSessionIds: [],
+	}),
 	createSession: vi.fn().mockResolvedValue({
 		id: "s1",
 		worktreePath: "/repo",
@@ -160,6 +164,11 @@ describe("useAgentChat", () => {
 		vi.mocked(sessionStore.getSession).mockClear();
 		vi.mocked(sessionStore.getSessionPage).mockResolvedValue(null);
 		vi.mocked(sessionStore.getSessionPage).mockClear();
+		vi.mocked(sessionStore.planAgentChatEviction).mockResolvedValue({
+			active: null,
+			evictSessionIds: [],
+		});
+		vi.mocked(sessionStore.planAgentChatEviction).mockClear();
 		vi.mocked(sessionStore.sendAgentMessage).mockClear();
 		vi.mocked(sessionStore.sendWorkflowApprovalChatMessage).mockClear();
 		vi.mocked(sessionStore.initAgentSessions).mockClear();
@@ -223,6 +232,12 @@ describe("useAgentChat", () => {
 			totalCount: messages.length,
 			latestTokenUsage: null,
 		}) as never;
+
+	const messageRange = (start: number, end: number) =>
+		Array.from({ length: end - start + 1 }, (_, index) => {
+			const value = start + index;
+			return chatMessage(`m${value}`, `message ${value}`, 1000 + value);
+		});
 
 	it("should define the hook", async () => {
 		const mod = await import("./useAgentChat");
@@ -1035,6 +1050,694 @@ describe("useAgentChat", () => {
 		expect(
 			result.current.activeSession?.messages.map((message) => message.id),
 		).toEqual(["m1", "m2"]);
+	});
+
+	it("evictOlderMessages drops the oldest loaded page and rewinds the cursor for rehydration", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce(
+			sessionResponse(chatSession("s1", messageRange(201, 250)), {
+				nextCursor: "201",
+				hasMore: true,
+				totalCount: 250,
+			}),
+		);
+		vi.mocked(sessionStore.getSessionPage).mockImplementation(
+			async (_sessionId, cursor) => {
+				if (cursor === "201")
+					return pageResponse(messageRange(151, 200), "151", true);
+				if (cursor === "151")
+					return pageResponse(messageRange(101, 150), "101", true);
+				if (cursor === "101")
+					return pageResponse(messageRange(51, 100), "51", true);
+				if (cursor === "51")
+					return pageResponse(messageRange(1, 50), null, false);
+				throw new Error(`unexpected cursor ${cursor}`);
+			},
+		);
+		vi.mocked(sessionStore.planAgentChatEviction).mockImplementation(
+			async (request) =>
+				request.active
+					? {
+							active: {
+								sessionId: "s1",
+								direction: "older",
+								count: 50,
+								nextCursor: "51",
+								hasMore: true,
+								loadedPages: [
+									{ requestCursor: null, count: 50 },
+									{ requestCursor: "201", count: 50 },
+									{ requestCursor: "151", count: 50 },
+									{ requestCursor: "101", count: 50 },
+								],
+							},
+							evictSessionIds: [],
+						}
+					: { active: null, evictSessionIds: [] },
+		);
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+		await act(async () => {
+			await result.current.selectSession("s1");
+		});
+		for (let i = 0; i < 4; i++) {
+			await act(async () => {
+				await result.current.loadOlderMessages("s1");
+			});
+		}
+		expect(result.current.activeSession?.messages).toHaveLength(250);
+
+		await act(async () => {
+			await result.current.evictOlderMessages("s1", {
+				oldestVisibleIndex: 50,
+			});
+		});
+
+		expect(sessionStore.planAgentChatEviction).toHaveBeenCalledWith({
+			active: expect.objectContaining({
+				sessionId: "s1",
+				messageCount: 250,
+				oldestVisibleIndex: 50,
+			}),
+		});
+		expect(result.current.activeSession?.messages).toHaveLength(200);
+		expect(result.current.activeSession?.messages[0]?.id).toBe("m51");
+
+		await act(async () => {
+			await result.current.loadOlderMessages("s1");
+		});
+
+		expect(sessionStore.getSessionPage).toHaveBeenLastCalledWith("s1", "51");
+		expect(result.current.activeSession?.messages).toHaveLength(250);
+		expect(result.current.activeSession?.messages[0]?.id).toBe("m1");
+		const restoredMessages = result.current.activeSession?.messages ?? [];
+		expect(restoredMessages[restoredMessages.length - 1]?.id).toBe("m250");
+	});
+
+	it("evictOlderMessages serializes eviction planning per session", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce(
+			sessionResponse(chatSession("s1", messageRange(201, 250)), {
+				nextCursor: "201",
+				hasMore: true,
+				totalCount: 250,
+			}),
+		);
+		vi.mocked(sessionStore.getSessionPage).mockImplementation(
+			async (_sessionId, cursor) => {
+				if (cursor === "201")
+					return pageResponse(messageRange(151, 200), "151", true);
+				if (cursor === "151")
+					return pageResponse(messageRange(101, 150), "101", true);
+				if (cursor === "101")
+					return pageResponse(messageRange(51, 100), "51", true);
+				if (cursor === "51")
+					return pageResponse(messageRange(1, 50), null, false);
+				throw new Error(`unexpected cursor ${cursor}`);
+			},
+		);
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+		await act(async () => {
+			await result.current.selectSession("s1");
+		});
+		for (let i = 0; i < 4; i++) {
+			await act(async () => {
+				await result.current.loadOlderMessages("s1");
+			});
+		}
+		expect(result.current.activeSession?.messages).toHaveLength(250);
+
+		let resolvePlan: (value: never) => void = () => {};
+		vi.mocked(sessionStore.planAgentChatEviction).mockImplementation(
+			(request) =>
+				request.active
+					? (new Promise((resolve) => {
+							resolvePlan = resolve;
+						}) as never)
+					: Promise.resolve({ active: null, evictSessionIds: [] }),
+		);
+		vi.mocked(sessionStore.planAgentChatEviction).mockClear();
+
+		let firstEviction = Promise.resolve();
+		await act(async () => {
+			firstEviction = result.current.evictOlderMessages("s1", {
+				oldestVisibleIndex: 50,
+			});
+			await result.current.evictOlderMessages("s1", {
+				oldestVisibleIndex: 50,
+			});
+		});
+
+		expect(sessionStore.planAgentChatEviction).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			resolvePlan({
+				active: {
+					sessionId: "s1",
+					direction: "older",
+					count: 50,
+					nextCursor: "51",
+					hasMore: true,
+					loadedPages: [
+						{ requestCursor: null, count: 50 },
+						{ requestCursor: "201", count: 50 },
+						{ requestCursor: "151", count: 50 },
+						{ requestCursor: "101", count: 50 },
+					],
+				},
+				evictSessionIds: [],
+			} as never);
+			await firstEviction;
+		});
+
+		expect(result.current.activeSession?.messages).toHaveLength(200);
+		expect(result.current.activeSession?.messages[0]?.id).toBe("m51");
+	});
+
+	it("evictOlderMessages discards a stale plan after page state changes", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce(
+			sessionResponse(chatSession("s1", messageRange(201, 250)), {
+				nextCursor: "201",
+				hasMore: true,
+				totalCount: 250,
+			}),
+		);
+		vi.mocked(sessionStore.getSessionPage).mockImplementation(
+			async (_sessionId, cursor) => {
+				if (cursor === "201")
+					return pageResponse(messageRange(151, 200), "151", true);
+				if (cursor === "151")
+					return pageResponse(messageRange(101, 150), "101", true);
+				if (cursor === "101")
+					return pageResponse(messageRange(51, 100), "51", true);
+				if (cursor === "51")
+					return pageResponse(messageRange(1, 50), null, false);
+				throw new Error(`unexpected cursor ${cursor}`);
+			},
+		);
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+		await act(async () => {
+			await result.current.selectSession("s1");
+		});
+		for (let i = 0; i < 4; i++) {
+			await act(async () => {
+				await result.current.loadOlderMessages("s1");
+			});
+		}
+		expect(result.current.activeSession?.messages).toHaveLength(250);
+
+		let resolvePlan: (value: never) => void = () => {};
+		vi.mocked(sessionStore.planAgentChatEviction).mockImplementation(
+			(request) =>
+				request.active
+					? (new Promise((resolve) => {
+							resolvePlan = resolve;
+						}) as never)
+					: Promise.resolve({ active: null, evictSessionIds: [] }),
+		);
+		vi.mocked(sessionStore.planAgentChatEviction).mockClear();
+
+		let eviction = Promise.resolve();
+		await act(async () => {
+			eviction = result.current.evictOlderMessages("s1", {
+				oldestVisibleIndex: 50,
+			});
+		});
+
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce(
+			sessionResponse(chatSession("s1", messageRange(201, 250)), {
+				nextCursor: "201",
+				hasMore: true,
+				totalCount: 250,
+			}),
+		);
+		await act(async () => {
+			await result.current.selectSession("s1");
+		});
+
+		await act(async () => {
+			resolvePlan({
+				active: {
+					sessionId: "s1",
+					direction: "older",
+					count: 50,
+					nextCursor: "51",
+					hasMore: true,
+					loadedPages: [
+						{ requestCursor: null, count: 50 },
+						{ requestCursor: "201", count: 50 },
+						{ requestCursor: "151", count: 50 },
+						{ requestCursor: "101", count: 50 },
+					],
+				},
+				evictSessionIds: [],
+			} as never);
+			await eviction;
+		});
+
+		expect(result.current.activeSession?.messages).toHaveLength(50);
+		expect(result.current.activeSession?.messages[0]?.id).toBe("m201");
+	});
+
+	it("evictOlderMessages leaves messages unchanged when Rust returns no active plan", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce({
+			session: chatSession("s1", messageRange(201, 250)),
+			turnPhase: "streaming",
+			selectedModel: null,
+			availableModels: [],
+			initialPage: {
+				nextCursor: "201",
+				hasMore: true,
+				totalCount: 250,
+			},
+		} as never);
+		vi.mocked(sessionStore.getSessionPage).mockImplementation(
+			async (_sessionId, cursor) => {
+				if (cursor === "201")
+					return pageResponse(messageRange(151, 200), "151", true);
+				if (cursor === "151")
+					return pageResponse(messageRange(101, 150), "101", true);
+				if (cursor === "101")
+					return pageResponse(messageRange(51, 100), "51", true);
+				if (cursor === "51")
+					return pageResponse(messageRange(1, 50), null, false);
+				throw new Error(`unexpected cursor ${cursor}`);
+			},
+		);
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+		await act(async () => {
+			await result.current.selectSession("s1");
+		});
+		for (let i = 0; i < 4; i++) {
+			await act(async () => {
+				await result.current.loadOlderMessages("s1");
+			});
+		}
+
+		await act(async () => {
+			await result.current.evictOlderMessages("s1", {
+				oldestVisibleIndex: 50,
+			});
+		});
+
+		expect(sessionStore.planAgentChatEviction).toHaveBeenCalledWith({
+			active: expect.objectContaining({
+				sessionId: "s1",
+				turnPhase: "streaming",
+			}),
+		});
+		expect(result.current.activeSession?.messages).toHaveLength(250);
+	});
+
+	it("does not surface eviction planning failures and retries on the next trigger", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			vi.mocked(sessionStore.getSession).mockResolvedValueOnce(
+				sessionResponse(chatSession("s1", messageRange(201, 250)), {
+					nextCursor: "201",
+					hasMore: true,
+					totalCount: 250,
+				}),
+			);
+			vi.mocked(sessionStore.getSessionPage).mockImplementation(
+				async (_sessionId, cursor) => {
+					if (cursor === "201")
+						return pageResponse(messageRange(151, 200), "151", true);
+					if (cursor === "151")
+						return pageResponse(messageRange(101, 150), "101", true);
+					if (cursor === "101")
+						return pageResponse(messageRange(51, 100), "51", true);
+					if (cursor === "51")
+						return pageResponse(messageRange(1, 50), null, false);
+					throw new Error(`unexpected cursor ${cursor}`);
+				},
+			);
+			const { result } = renderHook(() => useAgentChat("/repo"));
+			await act(async () => {
+				await result.current.selectSession("s1");
+			});
+			for (let i = 0; i < 4; i++) {
+				await act(async () => {
+					await result.current.loadOlderMessages("s1");
+				});
+			}
+			vi.mocked(sessionStore.planAgentChatEviction).mockClear();
+			vi.mocked(sessionStore.planAgentChatEviction)
+				.mockRejectedValueOnce(new Error("planner unavailable"))
+				.mockResolvedValueOnce({ active: null, evictSessionIds: [] });
+
+			await act(async () => {
+				await result.current.evictOlderMessages("s1", {
+					oldestVisibleIndex: 50,
+				});
+			});
+
+			expect(result.current.error).toBeNull();
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("メッセージ退避計画の取得に失敗"),
+			);
+
+			await act(async () => {
+				await result.current.evictOlderMessages("s1", {
+					oldestVisibleIndex: 50,
+				});
+			});
+
+			expect(sessionStore.planAgentChatEviction).toHaveBeenCalledTimes(2);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("keeps loaded page accounting aligned after new and duplicate SDK messages so eviction can proceed", async () => {
+		const { renderHook, act, waitFor } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		vi.mocked(sessionStore.getSession).mockResolvedValueOnce(
+			sessionResponse(chatSession("s1", messageRange(1, 201)), {
+				nextCursor: null,
+				hasMore: false,
+				totalCount: 201,
+			}),
+		);
+		vi.mocked(sessionStore.planAgentChatEviction).mockImplementation(
+			async (request) => {
+				const messageCount = request.active?.messageCount ?? 0;
+				return request.active
+					? {
+							active: {
+								sessionId: "s1",
+								direction: "older",
+								count: 50,
+								nextCursor: "51",
+								hasMore: true,
+								loadedPages: [
+									{ requestCursor: null, count: messageCount - 50 },
+								],
+							},
+							evictSessionIds: [],
+						}
+					: { active: null, evictSessionIds: [] };
+			},
+		);
+		const dateSpy = vi.spyOn(Date, "now").mockReturnValue(12345);
+		try {
+			const { result } = renderHook(() => useAgentChat("/repo"));
+			await act(async () => {
+				await result.current.selectSession("s1");
+			});
+			await waitFor(() => expect(result.current.activeSession?.id).toBe("s1"));
+			const emitSystemMessage = () =>
+				listenCallbacks.get("agent-sdk-message")?.({
+					payload: {
+						type: "system",
+						chat_session_id: "s1",
+						message: "background notice",
+					},
+				});
+
+			await act(async () => {
+				emitSystemMessage();
+			});
+			await waitFor(() =>
+				expect(result.current.activeSession?.messages).toHaveLength(202),
+			);
+			await act(async () => {
+				emitSystemMessage();
+			});
+			await waitFor(() =>
+				expect(result.current.activeSession?.messages).toHaveLength(202),
+			);
+			vi.mocked(sessionStore.planAgentChatEviction).mockClear();
+
+			await act(async () => {
+				await result.current.evictOlderMessages("s1", {
+					oldestVisibleIndex: 50,
+				});
+			});
+
+			expect(sessionStore.planAgentChatEviction).toHaveBeenCalledWith({
+				active: expect.objectContaining({
+					sessionId: "s1",
+					messageCount: 202,
+					loadedPages: [{ requestCursor: null, count: 202 }],
+				}),
+			});
+			expect(result.current.activeSession?.messages).toHaveLength(152);
+		} finally {
+			dateSpy.mockRestore();
+		}
+	});
+
+	it("does not replan inactive eviction when only an existing hydrated session message count changes", async () => {
+		const { renderHook, act, waitFor } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		vi.mocked(sessionStore.initAgentSessions).mockResolvedValueOnce({
+			sessions: [],
+			activeSession: sessionResponse(
+				chatSession("s1", [chatMessage("m1", "existing", 1001)]),
+				{
+					nextCursor: null,
+					hasMore: false,
+					totalCount: 1,
+				},
+			),
+		} as never);
+		const dateSpy = vi.spyOn(Date, "now").mockReturnValue(23456);
+		try {
+			const { result } = renderHook(() => useAgentChat("/repo"));
+			await waitFor(() => expect(result.current.activeSession?.id).toBe("s1"));
+			vi.mocked(sessionStore.planAgentChatEviction).mockClear();
+
+			await act(async () => {
+				listenCallbacks.get("agent-sdk-message")?.({
+					payload: {
+						type: "system",
+						chat_session_id: "s1",
+						message: "new visible message",
+					},
+				});
+			});
+			await waitFor(() =>
+				expect(result.current.activeSession?.messages).toHaveLength(2),
+			);
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			expect(sessionStore.planAgentChatEviction).not.toHaveBeenCalled();
+		} finally {
+			dateSpy.mockRestore();
+		}
+	});
+
+	it("replans inactive eviction when a session transitions from empty to hydrated", async () => {
+		const { renderHook, act, waitFor } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		const dateSpy = vi.spyOn(Date, "now").mockReturnValue(34567);
+		try {
+			const { result } = renderHook(() => useAgentChat("/repo"));
+			await waitFor(() => expect(result.current.activeSession?.id).toBe("s1"));
+			vi.mocked(sessionStore.planAgentChatEviction).mockClear();
+
+			await act(async () => {
+				listenCallbacks.get("agent-sdk-message")?.({
+					payload: {
+						type: "system",
+						chat_session_id: "s1",
+						message: "first visible message",
+					},
+				});
+			});
+
+			await waitFor(() => {
+				expect(sessionStore.planAgentChatEviction).toHaveBeenCalledWith({
+					sessions: expect.arrayContaining([
+						expect.objectContaining({
+							sessionId: "s1",
+							messageCount: 1,
+						}),
+					]),
+				});
+			});
+		} finally {
+			dateSpy.mockRestore();
+		}
+	});
+
+	it("evicts inactive session bodies above the hydrate cap and rehydrates on selection", async () => {
+		const { renderHook, act, waitFor } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		vi.mocked(sessionStore.initAgentSessions).mockResolvedValueOnce({
+			sessions: [],
+			activeSession: null,
+		} as never);
+		vi.mocked(sessionStore.getSession).mockImplementation(async (sessionId) =>
+			sessionResponse(chatSession(String(sessionId), messageRange(1, 50)), {
+				nextCursor: null,
+				hasMore: false,
+				totalCount: 50,
+			}),
+		);
+		vi.mocked(sessionStore.planAgentChatEviction).mockImplementation(
+			async (request) => {
+				const sessions = request.sessions ?? [];
+				const hydrated = sessions.filter((session) => session.messageCount > 0);
+				const candidates = hydrated
+					.filter((session) => !session.protected && !session.loading)
+					.sort(
+						(left, right) =>
+							left.evictionRank - right.evictionRank ||
+							left.sessionId.localeCompare(right.sessionId),
+					);
+				return {
+					active: null,
+					evictSessionIds:
+						hydrated.length > 3 && candidates[0]
+							? [candidates[0].sessionId]
+							: [],
+				};
+			},
+		);
+
+		const sessionIds = ["s1", "s2", "s3", "s4"];
+		const { result } = renderHook(() => useAgentChat("/repo"));
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		for (const sessionId of sessionIds) {
+			await act(async () => {
+				await result.current.selectSession(sessionId);
+			});
+		}
+
+		await waitFor(() => {
+			const hydratedCount = sessionIds.filter(
+				(sessionId) =>
+					(result.current.getSessionById(sessionId)?.messages.length ?? 0) > 0,
+			).length;
+			expect(hydratedCount).toBeLessThanOrEqual(3);
+		});
+		const inactiveRequests = vi
+			.mocked(sessionStore.planAgentChatEviction)
+			.mock.calls.map(([request]) => request)
+			.filter((request) => request.sessions);
+		const requestWithAllSessions = [...inactiveRequests]
+			.reverse()
+			.find((request) =>
+				sessionIds.every((sessionId) =>
+					request.sessions?.some((session) => session.sessionId === sessionId),
+				),
+			);
+		expect(requestWithAllSessions).toBeDefined();
+		const ranks = Object.fromEntries(
+			(requestWithAllSessions?.sessions ?? []).map((session) => [
+				session.sessionId,
+				session.evictionRank,
+			]),
+		) as Record<string, number>;
+		expect(ranks.s1).toBeLessThan(ranks.s2);
+		expect(ranks.s2).toBeLessThan(ranks.s3);
+		expect(ranks.s3).toBeLessThan(ranks.s4);
+		expect(result.current.getSessionById("s1")?.messages).toEqual([]);
+
+		await act(async () => {
+			await result.current.selectSession("s1");
+		});
+
+		expect(result.current.activeSession?.id).toBe("s1");
+		expect(result.current.activeSession?.messages).toHaveLength(50);
+	});
+
+	it("does not apply a stale inactive eviction plan to a session that becomes active", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		vi.mocked(sessionStore.initAgentSessions).mockResolvedValueOnce({
+			sessions: [],
+			activeSession: null,
+		} as never);
+		vi.mocked(sessionStore.getSession).mockImplementation(async (sessionId) =>
+			sessionResponse(chatSession(String(sessionId), messageRange(1, 50)), {
+				nextCursor: null,
+				hasMore: false,
+				totalCount: 50,
+			}),
+		);
+		vi.mocked(sessionStore.planAgentChatEviction).mockResolvedValue({
+			active: null,
+			evictSessionIds: [],
+		});
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+		for (const sessionId of ["s1", "s2", "s3", "s4"]) {
+			await act(async () => {
+				await result.current.selectSession(sessionId);
+			});
+		}
+
+		let resolvePlan: (value: never) => void = () => {};
+		let pendingIssued = false;
+		vi.mocked(sessionStore.planAgentChatEviction).mockImplementation(
+			(request) => {
+				if (!pendingIssued && request.sessions && request.sessions.length > 0) {
+					pendingIssued = true;
+					return new Promise((resolve) => {
+						resolvePlan = resolve;
+					}) as never;
+				}
+				return Promise.resolve({ active: null, evictSessionIds: [] });
+			},
+		);
+		vi.mocked(sessionStore.planAgentChatEviction).mockClear();
+
+		let cleanup: () => void = () => {};
+		await act(async () => {
+			cleanup = result.current.registerViewableSession("transient-session");
+		});
+		await act(async () => {
+			cleanup();
+		});
+		expect(sessionStore.planAgentChatEviction).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			await result.current.selectSession("s1");
+		});
+
+		await act(async () => {
+			resolvePlan({
+				active: null,
+				evictSessionIds: ["s1"],
+			} as never);
+			await Promise.resolve();
+		});
+
+		expect(result.current.activeSession?.id).toBe("s1");
+		expect(result.current.activeSession?.messages).toHaveLength(50);
+		expect(result.current.getSessionById("s1")?.messages).toHaveLength(50);
 	});
 
 	it("selectSession restores model selection from backend response", async () => {

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -33,6 +33,7 @@ import {
 } from "./deriveActivityStatus";
 import { useAgentSdkListeners } from "./useAgentSdkListeners";
 import {
+	type ActiveMessageEvictionPlan,
 	archiveOpenSession as archiveOpenSessionApi,
 	archiveSession as archiveSessionApi,
 	cancelAgentQueuedTurn,
@@ -42,9 +43,11 @@ import {
 	getSession,
 	getSessionPage,
 	initAgentSessions,
+	type LoadedMessagePage,
 	listAgentBackends,
 	listClosedSessions,
 	listSessions,
+	planAgentChatEviction,
 	restoreSession as restoreSessionApi,
 	sendAgentMessage,
 	sendWorkflowApprovalChatMessage,
@@ -75,6 +78,16 @@ type GetSessionInitialPage = {
 	nextCursor: string | null;
 	hasMore: boolean;
 	totalCount: number;
+};
+type SessionPageState = {
+	nextCursor: string | null;
+	hasMore: boolean;
+	loading: boolean;
+	loadedPages: LoadedMessagePage[];
+};
+export type OlderMessageEvictionOptions = {
+	oldestVisibleIndex?: number;
+	onEvicted?: (eviction: { count: number; direction: "older" }) => void;
 };
 
 /**
@@ -152,6 +165,11 @@ export interface UseAgentChatResult {
 	registerViewableSession: (sessionId: string) => () => void;
 	/** cursor paging で過去方向の message page を読み込む。*/
 	loadOlderMessages: (sessionId: string) => Promise<void>;
+	/** 可視範囲から離れた古い page を webview キャッシュから退避する。*/
+	evictOlderMessages: (
+		sessionId: string,
+		options?: OlderMessageEvictionOptions,
+	) => Promise<void>;
 	/** per-session lookup（既存）。*/
 	getSessionTurnPhase: (sessionId: string) => TurnPhase;
 	getSessionInterrupting: (sessionId: string) => boolean;
@@ -179,6 +197,55 @@ function startAgentProcess(
 	}).catch((e) => {
 		console.error(`Failed to start agent session ${chatSessionId}:`, e);
 	});
+}
+
+function loadedMessageCount(pages: LoadedMessagePage[]): number {
+	return pages.reduce((sum, page) => sum + page.count, 0);
+}
+
+function initialLoadedPages(count: number): LoadedMessagePage[] {
+	return count > 0 ? [{ requestCursor: null, count }] : [];
+}
+
+function loadedPagesEqual(
+	left: LoadedMessagePage[],
+	right: LoadedMessagePage[],
+): boolean {
+	if (left.length !== right.length) return false;
+	return left.every(
+		(page, index) =>
+			page.requestCursor === right[index]?.requestCursor &&
+			page.count === right[index]?.count,
+	);
+}
+
+type PageWindowSnapshot = {
+	messageCount: number;
+	nextCursor: string | null;
+	hasMore: boolean;
+	loadedPages: LoadedMessagePage[];
+};
+
+function pageWindowUnchanged(
+	currentPageState: SessionPageState,
+	currentSession: ChatSession,
+	snapshot: PageWindowSnapshot,
+	plan: ActiveMessageEvictionPlan,
+): boolean {
+	return (
+		!currentPageState.loading &&
+		currentSession.messages.length === snapshot.messageCount &&
+		currentPageState.nextCursor === snapshot.nextCursor &&
+		currentPageState.hasMore === snapshot.hasMore &&
+		loadedPagesEqual(currentPageState.loadedPages, snapshot.loadedPages) &&
+		loadedMessageCount(plan.loadedPages) === snapshot.messageCount - plan.count
+	);
+}
+
+function reportEvictionPlanSkipped(e: unknown): void {
+	console.warn(
+		`メッセージ退避計画の取得に失敗。退避をスキップし、次回トリガで再試行します: ${e}`,
+	);
 }
 
 function dispatchSessionMeta(
@@ -273,26 +340,34 @@ export function useAgentChat(
 	availableModelsRef.current = state.availableModels;
 	const sessionModelsRef = useRef(state.sessionModels);
 	sessionModelsRef.current = state.sessionModels;
-	const pageStateRef = useRef<
-		Record<
-			string,
-			{ nextCursor: string | null; hasMore: boolean; loading: boolean }
-		>
-	>({});
+	const pageStateRef = useRef<Record<string, SessionPageState>>({});
+	const evictInactiveSessionsRef = useRef<() => void>(() => {});
+	const activeMessageEvictionsRef = useRef<Set<string>>(new Set());
+	const sessionAccessSeqRef = useRef(0);
+	const sessionEvictionRanksRef = useRef<Record<string, number>>({});
+
+	const touchSessionAccess = useCallback((sessionId: string) => {
+		const nextRank = sessionAccessSeqRef.current + 1;
+		sessionAccessSeqRef.current = nextRank;
+		sessionEvictionRanksRef.current[sessionId] = nextRank;
+	}, []);
 
 	const rememberInitialPage = useCallback(
 		(response: {
 			session: ChatSession;
 			initialPage?: GetSessionInitialPage;
 		}) => {
+			touchSessionAccess(response.session.id);
 			const page = response.initialPage;
+			const loadedPages = initialLoadedPages(response.session.messages.length);
 			pageStateRef.current[response.session.id] = {
 				nextCursor: page?.nextCursor ?? null,
 				hasMore: page?.hasMore ?? false,
 				loading: false,
+				loadedPages,
 			};
 		},
-		[],
+		[touchSessionAccess],
 	);
 
 	// SDK listener gating: 表示中の session id 集合を管理する registry。
@@ -301,6 +376,7 @@ export function useAgentChat(
 	const viewableRegistry = useMemo<ViewableSessionRegistry>(
 		() => ({
 			register: (sessionId: string) => {
+				touchSessionAccess(sessionId);
 				const map = viewableIdsRef.current;
 				map.set(sessionId, (map.get(sessionId) ?? 0) + 1);
 				return () => {
@@ -308,6 +384,7 @@ export function useAgentChat(
 					const next = (m.get(sessionId) ?? 0) - 1;
 					if (next <= 0) {
 						m.delete(sessionId);
+						evictInactiveSessionsRef.current();
 					} else {
 						m.set(sessionId, next);
 					}
@@ -315,6 +392,149 @@ export function useAgentChat(
 			},
 			getIds: () => new Set(viewableIdsRef.current.keys()),
 		}),
+		[touchSessionAccess],
+	);
+
+	const dispatchWithMessageWindowTracking = useCallback(
+		(action: AgentChatAction) => {
+			if (action.type === "ADD_MESSAGE") {
+				const pageState = pageStateRef.current[action.sessionId];
+				const session = sessionsByIdRef.current[action.sessionId];
+				const alreadyLoaded =
+					session?.messages.some(
+						(message) => message.id === action.message.id,
+					) ?? false;
+				if (pageState && !alreadyLoaded && pageState.loadedPages.length > 0) {
+					const latestPage = pageState.loadedPages[0];
+					if (latestPage) {
+						pageStateRef.current[action.sessionId] = {
+							...pageState,
+							loadedPages: [
+								{ ...latestPage, count: latestPage.count + 1 },
+								...pageState.loadedPages.slice(1),
+							],
+						};
+					}
+				}
+			}
+			dispatch(action);
+		},
+		[],
+	);
+
+	const evictInactiveSessions = useCallback(async () => {
+		const protectedIds = new Set(viewableIdsRef.current.keys());
+		if (activeSessionIdRef.current) {
+			protectedIds.add(activeSessionIdRef.current);
+		}
+		const sessions = Object.entries(sessionsByIdRef.current).map(
+			([sessionId, session]) => ({
+				sessionId,
+				messageCount: session.messages.length,
+				evictionRank: sessionEvictionRanksRef.current[sessionId] ?? 0,
+				protected: protectedIds.has(sessionId),
+				loading: pageStateRef.current[sessionId]?.loading ?? false,
+			}),
+		);
+		if (!sessions.some((session) => session.messageCount > 0)) return;
+
+		try {
+			const plan = await planAgentChatEviction({ sessions });
+			for (const sessionId of plan.evictSessionIds) {
+				const session = sessionsByIdRef.current[sessionId];
+				if (!session || session.messages.length === 0) continue;
+				if (activeSessionIdRef.current === sessionId) continue;
+				if (viewableIdsRef.current.has(sessionId)) continue;
+				if (pageStateRef.current[sessionId]?.loading) continue;
+				dispatch({ type: "EVICT_SESSION_BODY", sessionId });
+				delete pageStateRef.current[sessionId];
+			}
+		} catch (e) {
+			reportEvictionPlanSkipped(e);
+		}
+	}, []);
+	evictInactiveSessionsRef.current = () => {
+		void evictInactiveSessions();
+	};
+
+	useEffect(() => {
+		for (const [sessionId, session] of Object.entries(state.sessionsById)) {
+			if (session.messages.length === 0) continue;
+			if (pageStateRef.current[sessionId]) continue;
+			pageStateRef.current[sessionId] = {
+				nextCursor: null,
+				hasMore: false,
+				loading: false,
+				loadedPages: initialLoadedPages(session.messages.length),
+			};
+		}
+	}, [state.sessionsById]);
+
+	const evictOlderMessages = useCallback(
+		async (sessionId: string, options: OlderMessageEvictionOptions = {}) => {
+			if (activeMessageEvictionsRef.current.has(sessionId)) return;
+			const pageState = pageStateRef.current[sessionId];
+			const session = sessionsByIdRef.current[sessionId];
+			if (!pageState || !session || pageState.loading) return;
+			const messageCount = session.messages.length;
+			if (messageCount === 0) return;
+			if (loadedMessageCount(pageState.loadedPages) !== messageCount) return;
+			const oldestVisibleIndex = options.oldestVisibleIndex ?? 0;
+			const snapshot = {
+				messageCount,
+				nextCursor: pageState.nextCursor,
+				hasMore: pageState.hasMore,
+				loadedPages: pageState.loadedPages,
+			};
+			activeMessageEvictionsRef.current.add(sessionId);
+			try {
+				const plan = await planAgentChatEviction({
+					active: {
+						sessionId,
+						messageCount,
+						oldestVisibleIndex,
+						loadedPages: pageState.loadedPages,
+						turnPhase: turnPhasesRef.current[sessionId] ?? "idle",
+					},
+				});
+				const activePlan = plan.active;
+				if (!activePlan || activePlan.count <= 0) return;
+				if (activePlan.sessionId !== sessionId) return;
+				const currentPageState = pageStateRef.current[sessionId];
+				const currentSession = sessionsByIdRef.current[sessionId];
+				if (!currentPageState || !currentSession) return;
+				if (
+					!pageWindowUnchanged(
+						currentPageState,
+						currentSession,
+						snapshot,
+						activePlan,
+					)
+				) {
+					return;
+				}
+				pageStateRef.current[sessionId] = {
+					...currentPageState,
+					nextCursor: activePlan.nextCursor,
+					hasMore: activePlan.hasMore,
+					loading: false,
+					loadedPages: activePlan.loadedPages,
+				};
+				dispatch({
+					type: "EVICT_OLDER_MESSAGES",
+					sessionId,
+					count: activePlan.count,
+				});
+				options.onEvicted?.({
+					count: activePlan.count,
+					direction: "older",
+				});
+			} catch (e) {
+				reportEvictionPlanSkipped(e);
+			} finally {
+				activeMessageEvictionsRef.current.delete(sessionId);
+			}
+		},
 		[],
 	);
 
@@ -438,40 +658,66 @@ export function useAgentChat(
 		[rememberInitialPage],
 	);
 
-	const loadOlderMessages = useCallback(async (sessionId: string) => {
-		const pageState = pageStateRef.current[sessionId];
-		if (!pageState?.hasMore || !pageState.nextCursor || pageState.loading) {
-			return;
-		}
-		pageState.loading = true;
-		try {
-			const page = await getSessionPage(sessionId, pageState.nextCursor);
-			if (!page) {
-				pageStateRef.current[sessionId] = {
-					nextCursor: null,
-					hasMore: false,
-					loading: false,
-				};
+	const loadOlderMessages = useCallback(
+		async (sessionId: string) => {
+			const pageState = pageStateRef.current[sessionId];
+			if (
+				!pageState?.hasMore ||
+				!pageState.nextCursor ||
+				pageState.loading ||
+				activeMessageEvictionsRef.current.has(sessionId)
+			) {
 				return;
 			}
-			dispatch({
-				type: "PREPEND_MESSAGES",
-				sessionId,
-				messages: page.messages,
-			});
-			pageStateRef.current[sessionId] = {
-				nextCursor: page.nextCursor,
-				hasMore: page.hasMore,
-				loading: false,
-			};
-		} catch (e) {
-			pageState.loading = false;
-			dispatch({
-				type: "SET_ERROR",
-				error: `過去メッセージの読み込みに失敗: ${e}`,
-			});
-		}
-	}, []);
+			touchSessionAccess(sessionId);
+			const requestCursor = pageState.nextCursor;
+			pageState.loading = true;
+			try {
+				const page = await getSessionPage(sessionId, requestCursor);
+				if (!page) {
+					pageStateRef.current[sessionId] = {
+						...pageState,
+						nextCursor: null,
+						hasMore: false,
+						loading: false,
+					};
+					return;
+				}
+				const existingIds = new Set(
+					(sessionsByIdRef.current[sessionId]?.messages ?? []).map(
+						(message) => message.id,
+					),
+				);
+				const newMessageCount = page.messages.filter(
+					(message) => !existingIds.has(message.id),
+				).length;
+				dispatch({
+					type: "PREPEND_MESSAGES",
+					sessionId,
+					messages: page.messages,
+				});
+				pageStateRef.current[sessionId] = {
+					nextCursor: page.nextCursor,
+					hasMore: page.hasMore,
+					loading: false,
+					loadedPages:
+						newMessageCount > 0
+							? [
+									...pageState.loadedPages,
+									{ requestCursor, count: newMessageCount },
+								]
+							: pageState.loadedPages,
+				};
+			} catch (e) {
+				pageState.loading = false;
+				dispatch({
+					type: "SET_ERROR",
+					error: `過去メッセージの読み込みに失敗: ${e}`,
+				});
+			}
+		},
+		[touchSessionAccess],
+	);
 
 	const interrupt = useCallback((sessionId: string) => {
 		if (!sessionId) return;
@@ -571,15 +817,16 @@ export function useAgentChat(
 										mentions,
 									);
 				const responseSessionId = response.session.id;
+				touchSessionAccess(responseSessionId);
 				dispatch({ type: "UPSERT_SESSION", session: response.session });
 				if (!response.queuedTurn) {
-					dispatch({
+					dispatchWithMessageWindowTracking({
 						type: "ADD_MESSAGE",
 						sessionId: responseSessionId,
 						message: response.humanMessage,
 					});
 					if (response.agentMessage) {
-						dispatch({
+						dispatchWithMessageWindowTracking({
 							type: "ADD_MESSAGE",
 							sessionId: responseSessionId,
 							message: response.agentMessage,
@@ -609,7 +856,7 @@ export function useAgentChat(
 				});
 			}
 		},
-		[],
+		[dispatchWithMessageWindowTracking, touchSessionAccess],
 	);
 
 	const cancelQueuedTurn = useCallback(
@@ -1038,7 +1285,7 @@ export function useAgentChat(
 		[],
 	);
 	useAgentSdkListeners({
-		dispatch,
+		dispatch: dispatchWithMessageWindowTracking,
 		viewableRegistry,
 		refreshSessions,
 		hasMessage,
@@ -1052,6 +1299,23 @@ export function useAgentChat(
 		const cleanup = viewableRegistry.register(state.activeSessionId);
 		return cleanup;
 	}, [state.activeSessionId, viewableRegistry]);
+
+	const hydratedSessionEvictionKey = useMemo(
+		() =>
+			[
+				state.activeSessionId ?? "",
+				...Object.entries(state.sessionsById)
+					.filter(([, session]) => session.messages.length > 0)
+					.map(([sessionId]) => sessionId)
+					.sort(),
+			].join("|"),
+		[state.activeSessionId, state.sessionsById],
+	);
+
+	useEffect(() => {
+		if (hydratedSessionEvictionKey.length === 0) return;
+		void evictInactiveSessions();
+	}, [evictInactiveSessions, hydratedSessionEvictionKey]);
 
 	const fetchBackends = useCallback(async () => {
 		try {
@@ -1191,7 +1455,9 @@ export function useAgentChat(
 	);
 
 	const registerViewableSession = useCallback(
-		(sessionId: string) => viewableRegistry.register(sessionId),
+		(sessionId: string) => {
+			return viewableRegistry.register(sessionId);
+		},
 		[viewableRegistry],
 	);
 
@@ -1241,6 +1507,7 @@ export function useAgentChat(
 		getSessionById,
 		registerViewableSession,
 		loadOlderMessages,
+		evictOlderMessages,
 		getSessionTurnPhase,
 		getSessionInterrupting,
 		getSessionSelectedModel,

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -404,17 +404,17 @@ export function useAgentChat(
 					session?.messages.some(
 						(message) => message.id === action.message.id,
 					) ?? false;
-				if (pageState && !alreadyLoaded && pageState.loadedPages.length > 0) {
+				if (pageState && !alreadyLoaded) {
 					const latestPage = pageState.loadedPages[0];
-					if (latestPage) {
-						pageStateRef.current[action.sessionId] = {
-							...pageState,
-							loadedPages: [
-								{ ...latestPage, count: latestPage.count + 1 },
-								...pageState.loadedPages.slice(1),
-							],
-						};
-					}
+					pageStateRef.current[action.sessionId] = {
+						...pageState,
+						loadedPages: latestPage
+							? [
+									{ ...latestPage, count: latestPage.count + 1 },
+									...pageState.loadedPages.slice(1),
+								]
+							: [{ requestCursor: null, count: 1 }],
+					};
 				}
 			}
 			dispatch(action);
@@ -674,9 +674,16 @@ export function useAgentChat(
 			pageState.loading = true;
 			try {
 				const page = await getSessionPage(sessionId, requestCursor);
+				const currentPageState = pageStateRef.current[sessionId];
+				if (
+					!currentPageState?.loading ||
+					currentPageState.nextCursor !== requestCursor
+				) {
+					return;
+				}
 				if (!page) {
 					pageStateRef.current[sessionId] = {
-						...pageState,
+						...currentPageState,
 						nextCursor: null,
 						hasMore: false,
 						loading: false,
@@ -703,10 +710,10 @@ export function useAgentChat(
 					loadedPages:
 						newMessageCount > 0
 							? [
-									...pageState.loadedPages,
+									...currentPageState.loadedPages,
 									{ requestCursor, count: newMessageCount },
 								]
-							: pageState.loadedPages,
+							: currentPageState.loadedPages,
 				};
 			} catch (e) {
 				pageState.loading = false;

--- a/src/hooks/useSessionStore.test.ts
+++ b/src/hooks/useSessionStore.test.ts
@@ -1,7 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LegacyChatMessage } from "@/types/session";
-import { getSession, getSessionPage, legacyToParts } from "./useSessionStore";
+import {
+	getSession,
+	getSessionPage,
+	legacyToParts,
+	planAgentChatEviction,
+} from "./useSessionStore";
 
 function makeLegacyMsg(
 	overrides?: Partial<LegacyChatMessage>,
@@ -220,5 +225,48 @@ describe("session paging", () => {
 			totalCount: 1,
 			latestTokenUsage: null,
 		});
+	});
+
+	it("planAgentChatEviction forwards request and returns the plan unchanged", async () => {
+		const request = {
+			active: {
+				sessionId: "s1",
+				messageCount: 250,
+				oldestVisibleIndex: 50,
+				loadedPages: [
+					{ requestCursor: null, count: 50 },
+					{ requestCursor: "201", count: 50 },
+				],
+				turnPhase: "idle" as const,
+			},
+			sessions: [
+				{
+					sessionId: "s2",
+					messageCount: 50,
+					evictionRank: 1,
+					protected: false,
+					loading: false,
+				},
+			],
+		};
+		const plan = {
+			active: {
+				sessionId: "s1",
+				direction: "older" as const,
+				count: 50,
+				nextCursor: "201",
+				hasMore: true,
+				loadedPages: [{ requestCursor: null, count: 50 }],
+			},
+			evictSessionIds: ["s2"],
+		};
+		vi.mocked(invoke).mockResolvedValueOnce(plan);
+
+		const response = await planAgentChatEviction(request);
+
+		expect(invoke).toHaveBeenCalledWith("plan_agent_chat_eviction", {
+			request,
+		});
+		expect(response).toBe(plan);
 	});
 });

--- a/src/hooks/useSessionStore.ts
+++ b/src/hooks/useSessionStore.ts
@@ -148,6 +148,42 @@ export interface GetSessionPageResponse {
 	latestTokenUsage: TokenUsage | null;
 }
 
+export interface LoadedMessagePage {
+	requestCursor: string | null;
+	count: number;
+}
+
+export interface AgentChatEvictionPlanRequest {
+	active?: {
+		sessionId: string;
+		messageCount: number;
+		oldestVisibleIndex: number;
+		loadedPages: LoadedMessagePage[];
+		turnPhase: TurnPhase;
+	} | null;
+	sessions?: Array<{
+		sessionId: string;
+		messageCount: number;
+		evictionRank: number;
+		protected: boolean;
+		loading: boolean;
+	}>;
+}
+
+export interface ActiveMessageEvictionPlan {
+	sessionId: string;
+	direction: "older";
+	count: number;
+	nextCursor: string | null;
+	hasMore: boolean;
+	loadedPages: LoadedMessagePage[];
+}
+
+export interface AgentChatEvictionPlan {
+	active?: ActiveMessageEvictionPlan | null;
+	evictSessionIds: string[];
+}
+
 interface RawGetSessionResponse {
 	// Flattened from Rust GetSessionResponse (#[serde(flatten)])
 	id: string;
@@ -233,6 +269,12 @@ export async function getSessionPage(
 		limit,
 	});
 	return raw ? convertRawSessionPage(raw) : null;
+}
+
+export async function planAgentChatEviction(
+	request: AgentChatEvictionPlanRequest,
+): Promise<AgentChatEvictionPlan> {
+	return invoke<AgentChatEvictionPlan>("plan_agent_chat_eviction", { request });
 }
 
 export async function getSession(


### PR DESCRIPTION
## 概要

`#1191` のメモリ枯渇広域調査で特定したフロント（webview）側の常駐型メモリ増幅（候補 **C6**）を是正する。`#1213`（M2: session storage の summary index + message paging 再設計）で初回 hydrate の有界化は完了済みだが、それでも残る次の2経路で webview メモリが無制限に増え続ける問題に対処する。

1. **アクティブ session のスクロールバック累積**: `getSessionPage` で過去方向に遡って `PREPEND_MESSAGES` した古い message が drop されず、会話を遡るほど `session.messages` が O(N) に積み上がる。
2. **非アクティブ session の常駐**: 開いた session の body は close/delete されるまで `sessionsById` に残り続け、同時に開く session 数だけ常駐量が倍増する。

## 対応

開いている agent チャット session の保持 message 量を、会話長・同時 session 数に対して線形に増え続けない構造へ是正。表示・履歴・既読の外部観測可能な振る舞いを変えずに、webview が保持する message body 量を有界化する。

- 可視範囲外 message の退避（ウィンドウ化／仮想化）
- 非アクティブ session の body 退避
- 退避範囲が再表示対象になった時点で `#1213` の `get_session_page` を用いて Rust 正本から再供給（新規 read API は追加しない）

## 関連

- 対象 ISSUE: #1195
- 関連: #1191（C6 の正本）, #1213（前提となる paging API）
- Spec: `docs/specs/issues-1195/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * エージェントチャットのメモリ最適化に関する仕様・設計ドキュメントを追加

* **パフォーマンス向上**
  * 長時間のチャットセッション利用時のメモリ消費を最適化。スクロール、メッセージ表示、履歴機能などのユーザー体験は変わりません。

* **テスト**
  * メモリ管理機能の包括的なテストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->