### PR TITLE
feat(agent): 権限承認待ちのタイムアウトを撤廃し無限待機にする (#1252)

### DIFF
--- a/docs/specs/issues-1252/behavior.md
+++ b/docs/specs/issues-1252/behavior.md
@@ -1,0 +1,94 @@
+# Behavior
+
+関連: #1252
+
+requirements.md の要求を、実装詳細を含まない観測可能な振る舞いとして定義する。
+
+## 仮定
+
+- watchdog は `evaluate_turn_liveness` の戻り値（`Some(timeout)` / `None`）でターンを中断するかどうかを決める。`None` が返る限りターンは中断されない。本振る舞い定義では `evaluate_turn_liveness` の判定結果＝「watchdog がターンを中断するか否か」という外部観測可能なルールとして扱う。
+- ターン中断時には、対応するエラー文言が利用者に表示される。
+- permission timeout の撤去は origin（`Desktop` / `Headless`）に依らず適用する（requirements 案 A）。本振る舞いでは origin による分岐は存在しないものとして記述する。
+
+## Feature: 権限承認待ちはタイムアウトしない
+
+Agent session のターンが権限承認待ち（`WaitingPermission`）にある間は、経過時間に関わらず watchdog によって中断されない。一方、Streaming 中の応答停止（stale）検知は従来どおり維持される。
+
+### Background
+
+```gherkin
+Given Agent session のターンが進行している
+And watchdog が一定間隔でターンの liveness を評価する
+```
+
+### Rule: 権限承認待ちは経過時間で中断されない
+
+```gherkin
+Scenario: 承認待ちが従来のタイムアウト閾値を大幅に超過しても中断されない
+  Given ターンが権限承認待ち（WaitingPermission）にある
+  When 承認待ちのまま、従来の打ち切り閾値を大幅に超える時間が経過する
+  Then watchdog はターンを中断しない
+  And 「権限承認の待機がタイムアウトしたため中断しました。」のエラーは表示されない
+
+Scenario: 承認待ち中はどれだけ待っても中断されない
+  Given ターンが権限承認待ち（WaitingPermission）にある
+  When 利用者が承認も拒否もせず待機を続ける
+  Then watchdog は経過時間を理由にターンを中断しない
+
+Scenario Outline: origin に依らず承認待ちは中断されない
+  Given ターンが権限承認待ち（WaitingPermission）にあり、origin が <origin> である
+  When 承認待ちのまま長時間が経過する
+  Then watchdog はターンを中断しない
+
+  Examples:
+    | origin   |
+    | Desktop  |
+    | Headless |
+```
+
+### Rule: Streaming 中の応答停止検知は従来どおり維持される
+
+```gherkin
+Scenario: Streaming 応答が停止閾値を超えて停止すると中断される
+  Given ターンが Streaming 中である
+  When 応答が stale 検知の閾値（STALE_TIMEOUT_SECS）を超えて更新されない
+  Then watchdog はターンを中断する
+  And 「Claude 応答が停止したため中断しました。もう一度お試しください。」のエラーが表示される
+
+Scenario: Streaming 応答が閾値内で更新され続ける限り中断されない
+  Given ターンが Streaming 中である
+  When 応答が stale 検知の閾値を超えない間隔で更新され続ける
+  Then watchdog はターンを中断しない
+```
+
+### Rule: アイドル状態は中断されない
+
+```gherkin
+Scenario: Idle フェーズは liveness 判定で中断されない
+  Given ターンが Idle 状態である
+  When 時間が経過する
+  Then watchdog はターンを中断しない
+```
+
+## 主要な境界条件
+
+```gherkin
+Scenario: 承認直後に Streaming へ遷移したターンには stale 検知が適用される
+  Given ターンが権限承認待ち（WaitingPermission）にあった
+  And 利用者が承認した
+  When ターンが Streaming に遷移し、応答が stale 閾値を超えて停止する
+  Then watchdog はターンを中断する
+  And 「Claude 応答が停止したため中断しました。もう一度お試しください。」のエラーが表示される
+```
+
+## 非機能・整理に関する振る舞い
+
+これらは Gherkin で表す利用者向け振る舞いではなく、requirements の受け入れ基準（コードベース品質）として満たすべき制約である。design.md / 実装で担保する。
+
+- permission timeout 撤去により未使用となったシンボルがコードベースに残存しないこと（デッドコードを残さない）。
+- `cargo clippy -- -D warnings` / `cargo fmt --check` / `cargo test` が通ること。
+- 上記の承認待ち無中断・stale 維持の挙動を担保するテストが存在すること。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1252/design.md
+++ b/docs/specs/issues-1252/design.md
@@ -1,0 +1,128 @@
+# Design
+
+関連: #1252
+
+requirements.md / behavior.md（いずれも案 A: origin に依らず permission timeout を全面撤去）を実装方針へ落とし込む。
+
+## 概要
+
+Agent session ランタイムの watchdog から「権限承認待ち（`TurnPhase::WaitingPermission`）のタイムアウト打ち切り」を撤去する。`evaluate_turn_liveness` の `WaitingPermission` 分岐から permission timeout 判定を削除し、承認待ちは経過時間に関わらず `None`（＝中断しない）を返すようにする。
+
+permission timeout は現状 `TurnOrigin::Headless`（= workflow step session）でのみ発火し、その判定のためだけに `TurnOrigin` の区別が存在する。判定撤去によって `TurnOrigin` 系の仕組み（enum・フィールド・helper・引数経路）はすべて未使用になるため、デッドコードを残さない方針（requirements 受け入れ基準）に従い連鎖的に撤去する。
+
+Streaming 中の stale 検知（`STALE_TIMEOUT_SECS` / `TurnLivenessTimeout::Stale`）は別役割のため一切変更しない。
+
+## 変更対象
+
+すべて単一ファイル `src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs` 内で完結する。他ファイルからの参照は存在しない（`grep` で確認済み: permission timeout / `TurnOrigin` 系シンボルの参照は本ファイルのみ）。
+
+撤去・変更する主なシンボルと位置（行は調査時点の目安）:
+
+| シンボル | 現状 | 変更 |
+|---|---|---|
+| `PERMISSION_TIMEOUT_SECS`（444） | 承認待ち打ち切り閾値 const | 削除 |
+| `PERMISSION_TIMEOUT_ERROR_MESSAGE`（448） | 中断時エラー文言 const | 削除 |
+| `TurnLivenessTimeout::PermissionTimeout`（468） | liveness 判定バリアント | 削除（`user_message` の対応 arm も削除） |
+| `TurnOrigin` enum（71-76） | `Desktop` / `Headless` | 削除 |
+| `TurnOrigin::permission_timeout_applies`（78-82） | Headless 判定 | 削除 |
+| `turn_origin_for_session`（84-90） | flag→origin 変換 | 削除 |
+| `turn_origin_for_chat_session`（5463-5473） | session meta→origin 解決 | 削除 |
+| `AgentProcess.turn_origin` フィールド（173） | ターン origin 保持 | 削除 |
+| `evaluate_turn_liveness`（480-499） | `turn_origin` 引数で分岐 | `turn_origin` 引数を削除し `WaitingPermission` を常に `None` に |
+| `begin_turn_liveness(origin)`（602-608） | origin を受けて格納 | `origin` 引数を削除 |
+| `start_agent_turn` / `_locked` / `_with_runtime_spawner` / `_locked`（5476-5752） | `origin` を生成・スレッド | `origin` 生成と引数受け渡しを削除 |
+| `turn_watchdog_decision`（4084-4106） | `proc.turn_origin` を渡す | `turn_origin` 引数渡しを削除 |
+| `AgentProcess` 構造体リテラル（218, 3487, 6803, 13281, 16231, 16943 等） | `turn_origin: TurnOrigin::Desktop` | 当該行を削除 |
+| 既存テスト（10383-10570 周辺ほか） | `TurnOrigin` を参照 | 後述の通り更新・削除 |
+
+変更しないもの（非スコープ）: `STALE_TIMEOUT_SECS`、`TurnLivenessTimeout::Stale`、`STALE_ERROR_MESSAGE`、`WATCHDOG_TICK_SECS`、`turn_phase_since` フィールドそのもの、`ChatSession.workflow_step_session`（session meta 側のフィールドは他用途のため残す）。
+
+## アーキテクチャと責務分割
+
+レイヤー的にはすべて `infrastructure/agent_session/runtime` 内の ランタイム watchdog ロジックであり、ドメイン／ユースケース層の変更は不要。Tauri コマンド・プロトコル・フロントエンドへの影響はない（liveness 判定は完全にバックエンド内部の関心事で、外部公開 API のシグネチャに `TurnOrigin` は出ていない）。
+
+責務の流れ（変更後）:
+
+- `evaluate_turn_liveness(turn_phase, last_progress_at, turn_phase_since, now)` — 純関数。`Streaming` のみ stale 判定し、`WaitingPermission` / `Idle` は常に `None`。
+- `turn_watchdog_decision` — `proc` の状態から上記を呼ぶ。origin を一切参照しない。
+- `start_agent_turn*` 経路 — origin の解決・受け渡しを行わず、`begin_turn_liveness()` を引数なしで呼ぶ。
+
+## データモデルまたは型
+
+- `TurnPhase`（`Idle` / `Streaming` / `WaitingPermission`）は変更しない。`WaitingPermission` 状態自体は SDK の `canUseTool` 待ちを表す正当な状態として残る。watchdog がそれを打ち切らなくなるだけ。
+- `TurnLivenessTimeout` は `Stale` のみの単一バリアント enum になる。
+
+  - 単一バリアントになっても enum 形のまま残す（`turn_watchdog_decision` の `Timeout(TurnLivenessTimeout)` / `finalize_turn_as_timeout_locked` 等が値として扱っており、将来の timeout 種別追加余地もあるため）。`#[derive(Debug, Clone, Copy, PartialEq, Eq)]` と `user_message` は維持し、`Stale` arm のみ残す。
+- `TurnOrigin` 型は完全に削除する（`Default` 実装含む）。
+
+## 処理フロー
+
+変更後の `evaluate_turn_liveness`:
+
+```rust
+fn evaluate_turn_liveness(
+    turn_phase: TurnPhase,
+    last_progress_at: Option<Instant>,
+    turn_phase_since: Instant,
+    now: Instant,
+) -> Option<TurnLivenessTimeout> {
+    match turn_phase {
+        TurnPhase::Streaming => {
+            let base = last_progress_at.unwrap_or(turn_phase_since);
+            (now.duration_since(base) > Duration::from_secs(STALE_TIMEOUT_SECS))
+                .then_some(TurnLivenessTimeout::Stale)
+        }
+        TurnPhase::Idle | TurnPhase::WaitingPermission => None,
+    }
+}
+```
+
+watchdog（`WATCHDOG_TICK_SECS = 5` ごと）は従来どおり tick するが、`WaitingPermission` では常に `Continue` を返し続け、承認・拒否・別要因（generation/turn_seq 変化、`Crashed`）でループを抜けるまで中断しない。
+
+`start_agent_turn` 系は `turn_origin_for_chat_session(...)` の呼び出しと `origin` 引数の受け渡しを削除し、`proc.begin_turn_liveness()` を引数なしで呼ぶ。`begin_turn_liveness` は `turn_seq` インクリメント・`last_progress_at` / `turn_phase_since` 更新のみ行う（`turn_origin` 代入を削除）。
+
+## エラー処理
+
+- 撤去対象は「正常待機を誤って中断していた」経路のため、新たなエラー経路は発生しない。
+- `PERMISSION_TIMEOUT_ERROR_MESSAGE`（「権限承認の待機がタイムアウトしたため中断しました。」）は表示されなくなる。
+- stale 経路のエラー（`STALE_ERROR_MESSAGE`）と finalize 処理（`finalize_turn_as_timeout_locked`）は不変。`TurnLivenessTimeout::Stale` のみを扱うようになる。
+
+## テスト方針
+
+`#[cfg(test)] mod tests`（同ファイル内）を更新する。
+
+更新:
+- `liveness_marks_streaming_stale_after_last_progress_timeout` / `liveness_keeps_streaming_alive_when_progress_is_recent` — `evaluate_turn_liveness` の引数から `TurnOrigin::Desktop` を除去（挙動アサーションは不変）。
+- `begin_turn_liveness(TurnOrigin::Desktop)` を呼ぶテスト（`timeout_finalize_*` / `finalize_timeout_*` / `late_turn_complete_*` ほか）— 引数なし呼び出しに修正。
+
+削除:
+- `liveness_permission_timeout_applies_only_to_headless` — 撤去対象の挙動を検証するテストのため削除。
+- `turn_origin_is_derived_from_session_workflow_step_flag` — `turn_origin_for_session` 削除に伴い削除。
+
+追加（behavior.md の受け入れ基準を担保）:
+- `WaitingPermission` で `PERMISSION_TIMEOUT_SECS`（=300）相当を大幅に超える経過（例: `turn_phase_since = now - 3600s`）でも `evaluate_turn_liveness` が `None` を返すことを検証するテスト。撤去後の閾値定数に依存しないよう、十分大きい固定秒数（例: `3600`）を直接用いる。
+- behavior「Streaming 維持」「Idle 無中断」に対応する既存テスト（stale 系・idle 系）が継続して通ることを確認する（必要なら明示テストを補う）。
+
+既存の Streaming stale テスト群は stale 維持の受け入れ基準をカバーするため、撤去後もそのまま意味を持つ。
+
+検証コマンド（`src-tauri/` で実行）:
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`（デッドコード残存ゼロをここで担保）
+- `cargo test`
+
+## リスクと代替案
+
+- リスク: 単一バリアント enum `TurnLivenessTimeout` に対し clippy が改善提案を出す可能性。`#[allow]` ではなく、`Timeout(TurnLivenessTimeout)` の保持型として実害なく残せるため許容する。問題が出れば該当箇所のみ最小対応する（スコープ内）。
+- リスク: `turn_origin` フィールド削除に伴う `AgentProcess` 構造体リテラルの修正漏れ。コンパイルエラーで即検出されるため低リスク。`grep "turn_origin"` で全箇所を網羅して潰す。
+- 代替案 B（Headless のみ打ち切り維持）: requirements で「承認者不在の独立 headless 実行経路は現状存在しない」「origin による分岐を設けない」と確定済みのため不採用。
+- 代替案 C（閾値を極端に大きくするだけ）: デッドコードを残し「無限待機」という要求と不一致のため不採用。
+
+## 仮定
+
+- `TurnOrigin` は permission timeout 判定専用であり、撤去後に他用途がない（調査で確認: 参照は `evaluate_turn_liveness` / `begin_turn_liveness` / 構造体初期化 / テストのみ）。
+- `TurnLivenessTimeout` は enum 形を維持する（単一バリアント化しても型は残す）。これは finalize 経路の API 形状を変えない最小変更とするため。
+- 本変更は単一ファイルに閉じ、クリーンアーキテクチャ上のレイヤー移行は伴わない（既存配置のまま修正）。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1252/requirements.md
+++ b/docs/specs/issues-1252/requirements.md
@@ -1,0 +1,78 @@
+# Requirements
+
+## Type
+
+Agent session ランタイムの挙動変更。
+
+関連: #1252
+
+## 背景と目的
+
+Agent session ランタイムには「権限承認待ちのタイムアウト」が実装されている。`canUseTool` による承認待ち（`TurnPhase::WaitingPermission`）のまま一定時間（現状 5 分 = `PERMISSION_TIMEOUT_SECS = 300`）が経過すると、watchdog がターンを強制中断し、以下のエラーを表示する。
+
+> 権限承認の待機がタイムアウトしたため中断しました。もう一度お試しください。
+
+承認操作は人間の任意のタイミングに依存する。承認待ちは「進捗が止まったハング」ではなく「人間の入力待ち」であり、固定時間で打ち切るのは不適切である。本変更の目的は、**権限承認待ちをタイムアウトさせず無限に待機させる**ことで、人間の承認タイミングに依存する正常な待機を中断しないようにすることである。
+
+なお、Streaming 中の応答停止検知（`STALE_TIMEOUT_SECS = 180`）は「ハング検知」という別の役割を持つため、本変更の対象外であり従来どおり維持する。
+
+## 現状の実装
+
+対象ファイル: `src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs`
+
+- `const PERMISSION_TIMEOUT_SECS: u64 = 300;` — 承認待ちを 5 分で打ち切る閾値。
+- `const PERMISSION_TIMEOUT_ERROR_MESSAGE` — 中断時のエラー文言。
+- `evaluate_turn_liveness()` — `WaitingPermission` フェーズで `turn_phase_since` から `PERMISSION_TIMEOUT_SECS` 超過時に `TurnLivenessTimeout::PermissionTimeout` を返す。
+- `TurnLivenessTimeout::PermissionTimeout` — liveness 判定結果のバリアント。
+- `TurnOrigin::permission_timeout_applies()` — `Headless` のときのみ `true`。
+- `turn_origin_for_session(workflow_step_session)` — workflow step session のとき `Headless`、それ以外は `Desktop`。
+- watchdog は `WATCHDOG_TICK_SECS = 5` 秒ごとに `evaluate_turn_liveness` を評価する。
+
+現状、permission timeout が実際に発火するのは `Headless`（= workflow step session、逐次 workflow 実行）のみであり、通常のデスクトップ agent チャット（`Desktop`）には適用されていない。
+
+## スコープ
+
+- `evaluate_turn_liveness` の `WaitingPermission` 分岐から permission timeout 判定を撤去し、承認待ちが経過時間によって中断されないようにする。
+- permission timeout 撤去に伴い未使用となる定義（`PERMISSION_TIMEOUT_SECS` / `PERMISSION_TIMEOUT_ERROR_MESSAGE` / `TurnLivenessTimeout::PermissionTimeout` / `TurnOrigin::permission_timeout_applies()` 等）を整理する。
+- `evaluate_turn_liveness` 関連の既存テストを本変更後の挙動に合わせて更新する。
+
+## 非スコープ
+
+- Streaming 応答停止検知（`STALE_TIMEOUT_SECS` / `TurnLivenessTimeout::Stale`）の挙動変更。従来どおり維持する。
+- watchdog のティック間隔（`WATCHDOG_TICK_SECS`）の変更。
+- 承認 UI／承認フロー自体の変更。
+- workflow エンジンの実行モデルやスケジューリングの変更。
+- 承認待ちのタイムアウトを設定値で可変にする等、新たな設定項目の追加。
+
+## 要求事項
+
+- 権限承認待ち（`TurnPhase::WaitingPermission`）の状態は、経過時間に関わらず watchdog によって中断されないこと。
+- 「権限承認の待機がタイムアウトしたため中断しました。」のエラーが発生しないこと。
+- Streaming 応答停止（stale）検知の挙動が従来どおり維持されること（`STALE_TIMEOUT_SECS` での中断と `STALE_ERROR_MESSAGE` の表示）。
+- permission timeout 撤去により未使用になったコードが残存しないこと（デッドコードを残さない）。
+- 上記挙動を担保するテストが存在すること。
+
+- permission timeout の撤去は origin（`Desktop` / `Headless`）に依らず適用し、origin による permission timeout 分岐を設けないこと。`Headless` 限定で打ち切りを残すような分岐を導入しないこと。
+
+## 受け入れ基準の概要
+
+- `WaitingPermission` フェーズで `PERMISSION_TIMEOUT_SECS` を大幅に超過しても `evaluate_turn_liveness` が `PermissionTimeout` を返さない（中断されない）ことがテストで確認できる。
+- `Streaming` フェーズで `STALE_TIMEOUT_SECS` 超過時に従来どおり `Stale` で中断されることがテストで確認できる。
+- 撤去対象シンボルがコードベースから参照されておらず、`cargo clippy -- -D warnings` が通る。
+- `cargo fmt --check` / `cargo test` が通る。
+
+## 仮定
+
+- 本変更の本質は「承認待ちを無限に待機させる」ことであり、Issue タイトル・受け入れ条件（「経過時間に関わらず中断されない」）に従い、`WaitingPermission` の permission timeout 判定を全面撤去する方針とする。
+- permission timeout は現状 `Headless` のみで発火するため、撤去によって挙動が実際に変わるのは workflow step session である。`Desktop` は元々適用外のため挙動は変わらない。
+- `TurnOrigin` 自体（`Desktop` / `Headless` の区別）は permission timeout 以外で用途がなくなる場合、未使用整理の対象になりうる。`turn_origin_for_session` / `turn_origin_for_chat_session` を含め、実際の参照状況は design.md で精査する。
+- 「Headless で承認者不在の永久滞留」は現アーキテクチャでは実体のないシナリオである。コード調査により以下を確認済み:
+  - `TurnOrigin::Headless` は `turn_origin_for_session(workflow_step_session)` で `workflow_step_session == true` のときにのみ設定される。
+  - workflow step session は workflow engine（`create_step_session_from_resolved_settings`、`workflow_step_session: true`）のみが生成し、`create_step_session_with_settings(app: &tauri::AppHandle<R>, ...)` 経由でデスクトップ Tauri アプリのバックエンドプロセス内で実行される。
+  - `releash` CLI の `workflow` サブコマンドは read-only 観測のみで workflow を実行せず、CLI 経由の headless 実行経路は存在しない。
+  - したがって Headless Session は常にデスクトップ利用者の手元で動き、その利用者が承認 UI から承認できる。承認者不在の独立した headless/server 実行経路は現状存在しない。
+  - 以上より、permission timeout は Headless 限定の打ち切りを残す必要はなく、origin に依らず全面撤去する（案 A）。
+
+## Open Questions
+
+なし。

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
@@ -68,27 +68,6 @@ pub enum TurnPhase {
     WaitingPermission,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-enum TurnOrigin {
-    #[default]
-    Desktop,
-    Headless,
-}
-
-impl TurnOrigin {
-    fn permission_timeout_applies(self) -> bool {
-        matches!(self, Self::Headless)
-    }
-}
-
-fn turn_origin_for_session(workflow_step_session: bool) -> TurnOrigin {
-    if workflow_step_session {
-        TurnOrigin::Headless
-    } else {
-        TurnOrigin::Desktop
-    }
-}
-
 /// A message queued while the agent is streaming, consumed on turn_complete.
 pub struct PendingMessage {
     pub id: String,
@@ -167,10 +146,8 @@ pub struct AgentProcess {
     streaming_timer_active: bool,
     /// Last meaningful SDK/bridge progress observed for the current turn.
     pub last_progress_at: Option<Instant>,
-    /// Timestamp of the current turn phase; used for permission wait timeout.
+    /// Timestamp of the current turn phase; used as the streaming stale fallback.
     pub turn_phase_since: Instant,
-    /// Origin of the current turn. Headless turns apply permission timeout.
-    turn_origin: TurnOrigin,
     /// Monotonic per-process turn sequence. Watchdogs capture it to avoid
     /// acting on a later turn that reused the same bridge process.
     pub turn_seq: u64,
@@ -215,7 +192,6 @@ pub(crate) fn make_test_agent_process() -> AgentProcess {
         streaming_timer_active: false,
         last_progress_at: None,
         turn_phase_since: Instant::now(),
-        turn_origin: TurnOrigin::Desktop,
         turn_seq: 0,
         turn_watchdog_active: false,
     }
@@ -441,12 +417,9 @@ const PERSIST_INTERVAL_MS: u64 = 1000;
 const BRIDGE_EOF_ERROR_MESSAGE: &str = "Bridge process exited unexpectedly.";
 pub(crate) const STALE_EXIT_CODE: i64 = 124;
 const STALE_TIMEOUT_SECS: u64 = 180;
-const PERMISSION_TIMEOUT_SECS: u64 = 300;
 const STALE_RECOVERY_GRACE_SECS: u64 = 10;
 const WATCHDOG_TICK_SECS: u64 = 5;
 const STALE_ERROR_MESSAGE: &str = "Claude 応答が停止したため中断しました。もう一度お試しください。";
-const PERMISSION_TIMEOUT_ERROR_MESSAGE: &str =
-    "権限承認の待機がタイムアウトしたため中断しました。もう一度お試しください。";
 
 /// Aggregation interval for `agent-streaming-updated` / `AgentStreamSync`.
 /// Roughly 30fps — balances UI smoothness against re-render cost.
@@ -465,21 +438,18 @@ const STREAMING_PENDING_BYTE_LIMIT: usize = 256 * 1024;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TurnLivenessTimeout {
     Stale,
-    PermissionTimeout,
 }
 
 impl TurnLivenessTimeout {
     fn user_message(self) -> &'static str {
         match self {
             Self::Stale => STALE_ERROR_MESSAGE,
-            Self::PermissionTimeout => PERMISSION_TIMEOUT_ERROR_MESSAGE,
         }
     }
 }
 
 fn evaluate_turn_liveness(
     turn_phase: TurnPhase,
-    turn_origin: TurnOrigin,
     last_progress_at: Option<Instant>,
     turn_phase_since: Instant,
     now: Instant,
@@ -489,10 +459,6 @@ fn evaluate_turn_liveness(
             let base = last_progress_at.unwrap_or(turn_phase_since);
             (now.duration_since(base) > Duration::from_secs(STALE_TIMEOUT_SECS))
                 .then_some(TurnLivenessTimeout::Stale)
-        }
-        TurnPhase::WaitingPermission if turn_origin.permission_timeout_applies() => {
-            (now.duration_since(turn_phase_since) > Duration::from_secs(PERMISSION_TIMEOUT_SECS))
-                .then_some(TurnLivenessTimeout::PermissionTimeout)
         }
         TurnPhase::Idle | TurnPhase::WaitingPermission => None,
     }
@@ -599,10 +565,9 @@ impl AgentProcess {
         self.task_id_map.clear();
     }
 
-    fn begin_turn_liveness(&mut self, origin: TurnOrigin) {
+    fn begin_turn_liveness(&mut self) {
         let now = Instant::now();
         self.turn_seq = self.turn_seq.saturating_add(1);
-        self.turn_origin = origin;
         self.last_progress_at = Some(now);
         self.turn_phase_since = now;
     }
@@ -3484,7 +3449,6 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                 streaming_timer_active: false,
                 last_progress_at: None,
                 turn_phase_since: Instant::now(),
-                turn_origin: TurnOrigin::Desktop,
                 turn_seq: 0,
                 turn_watchdog_active: false,
             },
@@ -4095,7 +4059,6 @@ fn turn_watchdog_decision(
     }
     match evaluate_turn_liveness(
         proc.turn_phase,
-        proc.turn_origin,
         proc.last_progress_at,
         proc.turn_phase_since,
         now,
@@ -4920,7 +4883,36 @@ fn get_persisted_spawn_info<R: tauri::Runtime>(
     )
 }
 
-fn get_persisted_spawn_info_before_turn<R: tauri::Runtime>(
+fn require_session_meta_for_turn(
+    session_store: &SessionStore,
+    data_dir: &Path,
+    chat_session_id: &str,
+) -> Result<SessionMeta, String> {
+    session_store
+        .get_session_meta(data_dir, chat_session_id)?
+        .ok_or_else(|| format!("Session not found: {chat_session_id}"))
+}
+
+fn get_required_persisted_spawn_info_for_turn<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    session_store: &SessionStore,
+    chat_session_id: &str,
+) -> Result<PersistedSpawnInfo, String> {
+    let data_dir = resolve_data_dir(app)?;
+    let registry =
+        app.try_state::<Arc<crate::infrastructure::agent_session::runtime::AgentBackendRegistry>>();
+    let meta = require_session_meta_for_turn(session_store, &data_dir, chat_session_id)?;
+    resolve_spawn_info_from_meta_or_full(
+        session_store,
+        &data_dir,
+        chat_session_id,
+        Some(meta),
+        registry.as_deref(),
+        None,
+    )
+}
+
+fn get_required_persisted_spawn_info_before_turn<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     session_store: &SessionStore,
     chat_session_id: &str,
@@ -4929,12 +4921,12 @@ fn get_persisted_spawn_info_before_turn<R: tauri::Runtime>(
     let data_dir = resolve_data_dir(app)?;
     let registry =
         app.try_state::<Arc<crate::infrastructure::agent_session::runtime::AgentBackendRegistry>>();
-    let meta = session_store.get_session_meta(&data_dir, chat_session_id)?;
+    let meta = require_session_meta_for_turn(session_store, &data_dir, chat_session_id)?;
     resolve_spawn_info_from_meta_or_full(
         session_store,
         &data_dir,
         chat_session_id,
-        meta,
+        Some(meta),
         registry.as_deref(),
         Some(streaming_agent_message_id),
     )
@@ -5458,20 +5450,6 @@ pub(crate) async fn start_agent_session_internal<R: tauri::Runtime>(
     .await
 }
 
-/// Core logic for starting a new agent turn: spawn Bridge if needed, send prompt.
-/// Used by send_agent_message and pending message consumption.
-fn turn_origin_for_chat_session<R: tauri::Runtime>(
-    app: &tauri::AppHandle<R>,
-    session_store: &SessionStore,
-    chat_session_id: &str,
-) -> Result<TurnOrigin, String> {
-    let data_dir = resolve_data_dir(app)?;
-    let meta = session_store
-        .get_session_meta(&data_dir, chat_session_id)?
-        .ok_or_else(|| format!("Session not found: {chat_session_id}"))?;
-    Ok(turn_origin_for_session(meta.workflow_step_session))
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
@@ -5485,8 +5463,8 @@ pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
     streaming_message_id: &str,
     images: &[ImageAttachment],
 ) -> Result<(), String> {
-    let origin = turn_origin_for_chat_session(app, session_store, chat_session_id)?;
-    let spawn_info = get_persisted_spawn_info(app, session_store, chat_session_id)?;
+    let spawn_info =
+        get_required_persisted_spawn_info_for_turn(app, session_store, chat_session_id)?;
     if spawn_info.backend_id == CODEX_BACKEND_ID {
         return start_codex_backend_turn(
             app,
@@ -5509,10 +5487,9 @@ pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
         prompt,
         streaming_message_id,
         images,
-        origin,
         || async {
             wait_until_session_close_finished(chat_session_id).await;
-            let spawn_info = get_persisted_spawn_info_before_turn(
+            let spawn_info = get_required_persisted_spawn_info_before_turn(
                 app,
                 session_store,
                 chat_session_id,
@@ -5564,8 +5541,8 @@ async fn start_agent_turn_locked<R: tauri::Runtime>(
     streaming_message_id: &str,
     images: &[ImageAttachment],
 ) -> Result<(), String> {
-    let origin = turn_origin_for_chat_session(app, session_store, chat_session_id)?;
-    let spawn_info = get_persisted_spawn_info(app, session_store, chat_session_id)?;
+    let spawn_info =
+        get_required_persisted_spawn_info_for_turn(app, session_store, chat_session_id)?;
     if spawn_info.backend_id == CODEX_BACKEND_ID {
         return start_codex_backend_turn(
             app,
@@ -5588,9 +5565,8 @@ async fn start_agent_turn_locked<R: tauri::Runtime>(
         prompt,
         streaming_message_id,
         images,
-        origin,
         || async {
-            let spawn_info = get_persisted_spawn_info_before_turn(
+            let spawn_info = get_required_persisted_spawn_info_before_turn(
                 app,
                 session_store,
                 chat_session_id,
@@ -5679,7 +5655,6 @@ async fn start_agent_turn_with_runtime_spawner<R: tauri::Runtime, F, Fut>(
     prompt: &str,
     streaming_message_id: &str,
     images: &[ImageAttachment],
-    origin: TurnOrigin,
     spawn_runtime: F,
 ) -> Result<(), String>
 where
@@ -5697,7 +5672,6 @@ where
         prompt,
         streaming_message_id,
         images,
-        origin,
         spawn_runtime,
     )
     .await
@@ -5713,7 +5687,6 @@ async fn start_agent_turn_with_runtime_spawner_locked<R: tauri::Runtime, F, Fut>
     prompt: &str,
     streaming_message_id: &str,
     images: &[ImageAttachment],
-    origin: TurnOrigin,
     spawn_runtime: F,
 ) -> Result<(), String>
 where
@@ -5741,7 +5714,7 @@ where
             proc.turn_phase = TurnPhase::Streaming;
             proc.streaming_message_id = Some(streaming_message_id.to_string());
             proc.reset_streaming_state_for_new_turn();
-            proc.begin_turn_liveness(origin);
+            proc.begin_turn_liveness();
             proc.stdin
                 .write_all(data.as_bytes())
                 .await
@@ -6800,7 +6773,6 @@ pub(crate) async fn register_external_agent_process<R: tauri::Runtime>(
                 streaming_timer_active: false,
                 last_progress_at: None,
                 turn_phase_since: Instant::now(),
-                turn_origin: TurnOrigin::Desktop,
                 turn_seq: 0,
                 turn_watchdog_active: false,
             },
@@ -10385,7 +10357,6 @@ mod tests {
         let now = Instant::now();
         let timeout = evaluate_turn_liveness(
             TurnPhase::Streaming,
-            TurnOrigin::Desktop,
             Some(now - Duration::from_secs(STALE_TIMEOUT_SECS + 1)),
             now - Duration::from_secs(STALE_TIMEOUT_SECS + 1),
             now,
@@ -10399,7 +10370,6 @@ mod tests {
         let now = Instant::now();
         let timeout = evaluate_turn_liveness(
             TurnPhase::Streaming,
-            TurnOrigin::Desktop,
             Some(now - Duration::from_secs(STALE_TIMEOUT_SECS - 1)),
             now - Duration::from_secs(STALE_TIMEOUT_SECS + 10),
             now,
@@ -10409,48 +10379,23 @@ mod tests {
     }
 
     #[test]
-    fn liveness_permission_timeout_applies_only_to_headless() {
+    fn liveness_keeps_waiting_permission_alive_after_long_wait() {
         let now = Instant::now();
-        let since = now - Duration::from_secs(PERMISSION_TIMEOUT_SECS + 1);
+        let since = now - Duration::from_secs(3600);
 
         assert_eq!(
-            evaluate_turn_liveness(
-                TurnPhase::WaitingPermission,
-                TurnOrigin::Headless,
-                None,
-                since,
-                now,
-            ),
-            Some(TurnLivenessTimeout::PermissionTimeout)
-        );
-        assert_eq!(
-            evaluate_turn_liveness(
-                TurnPhase::WaitingPermission,
-                TurnOrigin::Desktop,
-                None,
-                since,
-                now,
-            ),
+            evaluate_turn_liveness(TurnPhase::WaitingPermission, None, since, now),
             None
         );
     }
 
     #[test]
-    fn turn_origin_is_derived_from_session_workflow_step_flag() {
-        let data_dir = tempfile::tempdir().unwrap();
-        let session_store = Arc::new(crate::test_support::build_session_store());
-        let mut session =
-            create_session_internal(&session_store, data_dir.path(), "/repo", None).unwrap();
+    fn liveness_keeps_idle_alive() {
+        let now = Instant::now();
 
         assert_eq!(
-            turn_origin_for_session(session.workflow_step_session),
-            TurnOrigin::Desktop
-        );
-
-        session.workflow_step_session = true;
-        assert_eq!(
-            turn_origin_for_session(session.workflow_step_session),
-            TurnOrigin::Headless
+            evaluate_turn_liveness(TurnPhase::Idle, None, now - Duration::from_secs(3600), now),
+            None
         );
     }
 
@@ -10478,7 +10423,7 @@ mod tests {
     async fn timeout_finalize_rechecks_liveness_and_continues_when_progress_arrives_after_decision()
     {
         let mut proc = make_streaming_test_process();
-        proc.begin_turn_liveness(TurnOrigin::Desktop);
+        proc.begin_turn_liveness();
         proc.turn_watchdog_active = true;
         let captured_gen_id = proc.generation_id;
         let captured_turn_seq = proc.turn_seq;
@@ -10516,7 +10461,7 @@ mod tests {
     #[tokio::test]
     async fn finalize_timeout_adds_error_part_and_completes_as_failure() {
         let mut proc = make_streaming_test_process();
-        proc.begin_turn_liveness(TurnOrigin::Desktop);
+        proc.begin_turn_liveness();
         let partial = MessagePart::Text {
             content: "partial response".to_string(),
             parent_tool_use_id: None,
@@ -10553,7 +10498,7 @@ mod tests {
     #[tokio::test]
     async fn late_turn_complete_after_timeout_does_not_restore_ready_state() {
         let mut proc = make_streaming_test_process();
-        proc.begin_turn_liveness(TurnOrigin::Desktop);
+        proc.begin_turn_liveness();
         let _ = finalize_turn_as_timeout_locked(
             &mut proc,
             "csid",
@@ -12761,6 +12706,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn turn_start_requires_existing_session_meta() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(
+                data_dir.path().to_path_buf(),
+            ))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let session_store = Arc::new(crate::test_support::build_session_store());
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+
+        let err = start_agent_turn(
+            app.handle(),
+            &handles,
+            &session_store,
+            "missing-turn",
+            "/repo",
+            "edit",
+            false,
+            "hello",
+            "agent-msg-1",
+            &[],
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, "Session not found: missing-turn");
+
+        let err = start_agent_turn_locked(
+            app.handle(),
+            &handles,
+            &session_store,
+            "missing-locked-turn",
+            "/repo",
+            "edit",
+            false,
+            "hello",
+            "agent-msg-2",
+            &[],
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, "Session not found: missing-locked-turn");
+        assert!(handles.lock().await.is_empty());
+    }
+
+    #[tokio::test]
     async fn stopped_workflow_step_turn_start_spawns_resume_runtime_once() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -12777,7 +12768,6 @@ mod tests {
             "resume step",
             "agent-msg-1",
             &[],
-            TurnOrigin::Desktop,
             {
                 let handles = Arc::clone(&handles);
                 let session_id = session_id.clone();
@@ -12824,7 +12814,6 @@ mod tests {
             "continue step",
             "agent-msg-2",
             &[],
-            TurnOrigin::Desktop,
             {
                 let spawn_count = Arc::clone(&spawn_count);
                 move || async move {
@@ -12863,7 +12852,6 @@ mod tests {
                     "resume step",
                     "agent-msg-locked",
                     &[],
-                    TurnOrigin::Desktop,
                     {
                         let handles = Arc::clone(&handles);
                         let session_id = session_id.clone();
@@ -12920,7 +12908,6 @@ mod tests {
                     "first",
                     "agent-msg-1",
                     &[],
-                    TurnOrigin::Desktop,
                     {
                         let handles = Arc::clone(&handles);
                         let session_id = session_id.clone();
@@ -12952,7 +12939,6 @@ mod tests {
                     "second",
                     "agent-msg-2",
                     &[],
-                    TurnOrigin::Desktop,
                     {
                         let handles = Arc::clone(&handles);
                         let session_id = session_id.clone();
@@ -13278,7 +13264,6 @@ mod tests {
                 streaming_timer_active: false,
                 last_progress_at: None,
                 turn_phase_since: Instant::now(),
-                turn_origin: TurnOrigin::Desktop,
                 turn_seq: 0,
                 turn_watchdog_active: false,
             },
@@ -16228,7 +16213,6 @@ mod tests {
             streaming_timer_active: false,
             last_progress_at: None,
             turn_phase_since: Instant::now(),
-            turn_origin: TurnOrigin::Desktop,
             turn_seq: 0,
             turn_watchdog_active: false,
         };
@@ -16940,7 +16924,6 @@ mod tests {
                 streaming_timer_active: false,
                 last_progress_at: None,
                 turn_phase_since: Instant::now(),
-                turn_origin: TurnOrigin::Desktop,
                 turn_seq: 0,
                 turn_watchdog_active: false,
             }


### PR DESCRIPTION
## 概要

`canUseTool` による承認待ち (`TurnPhase::WaitingPermission`) は「進捗が止まったハング」ではなく「人間の入力待ち」であり、固定時間 (5分) で打ち切るのは不適切。permission timeout 判定を撤去し、承認待ちを無限に待機させる。

関連: #1252

## 変更内容

- `evaluate_turn_liveness` の `WaitingPermission` 分岐から timeout 判定を削除
- 未使用となる定義を整理
  - `PERMISSION_TIMEOUT_SECS` / `PERMISSION_TIMEOUT_ERROR_MESSAGE`
  - `TurnLivenessTimeout::PermissionTimeout`
  - `TurnOrigin` 系 (`permission_timeout_applies` / `turn_origin_for_session` 等)
- turn 開始時に session meta の存在を必須化する経路へ集約
- 関連テストを新挙動に合わせて更新

## 非対象

- Streaming 中の応答停止検知 (`STALE_TIMEOUT_SECS = 180`) は「ハング検知」という別役割のため従来どおり維持

## Spec

- `docs/specs/issues-1252/requirements.md`
- `docs/specs/issues-1252/behavior.md`
- `docs/specs/issues-1252/design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 権限承認待機（WaitingPermission）の仕様に関する詳細ドキュメントを追加しました。権限待機中は経過時間に関わらず中断されず、ストリーミング中の停止検知は維持されることを明文化しています。

* **Bug Fixes**
  * 権限承認待機中の不要なタイムアウト処理を削除し、無限待機に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->