### PR TITLE
feat(workflow): worktree 単位の workflow ステップステータス集約を追加 (#1259)

### DIFF
--- a/docs/specs/issues-1259/behavior.md
+++ b/docs/specs/issues-1259/behavior.md
@@ -1,0 +1,175 @@
+# Behavior
+
+Issue #1259: WorkspaceList のステータス表示・集約ロジック再設計の振る舞い定義。
+
+requirements.md の「確定ステータス仕様」を、実装詳細を含まない観測可能な振る舞いとして Gherkin で定義する。
+
+## 用語
+
+- **Step 進行ステータス**: Step そのものの進行状態。`failed / waiting_approval / running / aborted / completed / queued` のいずれか。
+- **Session 稼働ステータス**: 1 つの Session の稼働状態。`running`(動作中=streaming) / `waiting`(承認・入力・許可待ち) / `done`(ターン完了) / `error`(実行時エラー) のいずれか。
+- **代表ステータス**: 集約後にユーザーへ提示される 7 種の状態。`running / failed / error / waiting / aborted / completed / queued`。
+- **優先度**: 代表ステータスの強さの順序。`running > failed > error > waiting > aborted > completed > queued`（左ほど強い＝優先度 1 に近い）。
+
+---
+
+```gherkin
+Feature: WorkspaceList のステータス集約と Session 稼働可視化
+  WorkspaceList 上で、各 Session が動作中(streaming)か停止中かを判別でき、
+  複数 Session を含む Step・複数 Step を含む Workflow の代表ステータスが
+  「ユーザーが次に注目すべき状態」になるよう優先度で集約される。
+
+  Background:
+    Given WorkspaceList が Workflow / Step / Session を階層表示している
+    And 代表ステータスの優先度が "running > failed > error > waiting > aborted > completed > queued" と定義されている
+
+  # =========================================================================
+  # Rule 1: Session 1 個の結果ステータス（Step 進行 × Session 稼働）
+  # =========================================================================
+  Rule: 1 つの Session の結果ステータスは Step 進行ステータスと Session 稼働ステータスの組み合わせで一意に決まる
+
+    Scenario: Session が動作中なら Step 進行を問わず結果は running
+      Given Session の稼働ステータスが "running" である
+      When その Session の結果ステータスを導出する
+      Then Step 進行ステータスが何であっても結果ステータスは "running" になる
+
+    Scenario Outline: Step 進行 × Session 稼働 から結果ステータスを導出する
+      Given Step 進行ステータスが "<step>" である
+      And その Session の稼働ステータスが "<session>" である
+      When その Session の結果ステータスを導出する
+      Then 結果ステータスは "<result>" になる
+
+      Examples: Session 稼働 = running（常に running）
+        | step             | session | result  |
+        | failed           | running | running |
+        | waiting_approval | running | running |
+        | running          | running | running |
+        | aborted          | running | running |
+        | completed        | running | running |
+        | queued           | running | running |
+
+      Examples: Session 稼働 = waiting
+        | step             | session | result  |
+        | failed           | waiting | failed  |
+        | waiting_approval | waiting | waiting |
+        | running          | waiting | waiting |
+        | aborted          | waiting | waiting |
+        | completed        | waiting | waiting |
+        | queued           | waiting | waiting |
+
+      Examples: Session 稼働 = done
+        | step             | session | result    |
+        | failed           | done    | failed    |
+        | waiting_approval | done    | waiting   |
+        | running          | done    | running   |
+        | aborted          | done    | aborted   |
+        | completed        | done    | completed |
+        | queued           | done    | queued    |
+
+      Examples: Session 稼働 = error
+        | step             | session | result  |
+        | failed           | error   | failed  |
+        | waiting_approval | error   | error   |
+        | running          | error   | error   |
+        | aborted          | error   | error   |
+        | completed        | error   | error   |
+        | queued           | error   | error   |
+
+  # =========================================================================
+  # Rule 2: Parallel Step（複数 Session）の集約
+  # =========================================================================
+  Rule: Step の代表ステータスは配下 Session の結果のうち最も優先度が強いものになる
+
+    Scenario: Parallel Step に動作中の Session が 1 つでもあれば代表は running
+      Given Step に複数の Session が属している
+      And いずれか 1 つの Session の結果ステータスが "running" である
+      When その Step の代表ステータスを集約する
+      Then 代表ステータスは "running" になる
+
+    Scenario Outline: 複数 Session の結果から最強優先度を代表ステータスにする
+      Given Step 配下の Session 結果ステータスの集合が "<results>" である
+      When その Step の代表ステータスを集約する
+      Then 代表ステータスは "<representative>" になる
+
+      Examples:
+        | results                   | representative |
+        | running, waiting, completed | running      |
+        | failed, waiting, completed  | failed       |
+        | error, waiting, queued      | error        |
+        | waiting, completed, queued  | waiting      |
+        | aborted, completed, queued  | aborted      |
+        | completed, queued           | completed    |
+        | queued, queued              | queued       |
+
+    Scenario: 単一 Session の Step は その Session の結果がそのまま代表になる
+      Given Step に Session が 1 つだけ属している
+      When その Step の代表ステータスを集約する
+      Then 代表ステータスはその Session の結果ステータスと一致する
+
+  # =========================================================================
+  # Rule 3: Workflow（複数 Step）の集約
+  # =========================================================================
+  Rule: Workflow の代表ステータスは配下 Step の代表のうち最も優先度が強いものになる
+
+    Scenario Outline: 複数 Step の代表から最強優先度を Workflow 代表にする
+      Given Workflow 配下の Step 代表ステータスの集合が "<steps>" である
+      When その Workflow の代表ステータスを集約する
+      Then 代表ステータスは "<representative>" になる
+
+      Examples:
+        | steps                       | representative |
+        | running, waiting, completed | running        |
+        | completed, failed, queued   | failed         |
+        | waiting, error, completed   | error          |
+        | waiting, aborted, completed | waiting        |
+        | aborted, completed, queued  | aborted        |
+        | completed, completed        | completed      |
+        | queued, queued              | queued         |
+
+  # =========================================================================
+  # Rule 4: 稼働中 / 停止中の視覚的区別
+  # =========================================================================
+  Rule: WorkspaceList 上で動作中の Session を含む状態と停止系状態を視覚的に区別できる
+
+    Scenario: 動作中の Session を含む Step と全 Session 停止の Step を区別できる
+      Given ある Step は配下に "running" の Session を含む
+      And 別の Step は配下の全 Session が停止系（waiting / done / error / aborted / completed / queued）である
+      When WorkspaceList を表示する
+      Then 動作中の Session を含む Step は「動作中(running)」として、もう一方とは視覚的に区別して表示される
+
+    Scenario: 代表ステータスは 7 種に統一される
+      When WorkspaceList で代表ステータスを表示する
+      Then 表示される代表ステータスは "running / failed / error / waiting / aborted / completed / queued" の 7 種のいずれかである
+      And 従来の Step "waiting_approval" と Session の入力・許可待ちは 1 つの "waiting" に統合される
+
+  # =========================================================================
+  # Rule 5: リアルタイム更新
+  # =========================================================================
+  Rule: Session 稼働状態の変化は新たなポーリングを増やさずリアルタイムに反映される
+
+    Scenario: Session が streaming を開始すると WorkspaceList の代表が更新される
+      Given WorkspaceList を表示している
+      And ある Step の代表ステータスが "queued" である
+      When 配下の Session が streaming（稼働 "running"）を開始する
+      Then 追加のポーリングなしに、その Step の代表ステータスが "running" に更新される
+
+    Scenario: Session が承認待ちになると waiting が反映される
+      Given WorkspaceList を表示している
+      And ある Step に動作中の Session が存在しない
+      When 配下の Session が承認・入力・許可待ち（稼働 "waiting"）になる
+      Then 追加のポーリングなしに、その Step の代表ステータスに "waiting" が反映される
+```
+
+---
+
+## 仮定
+
+- (A1) Session の稼働判定は既存の `AgentState`（`running = streaming` / `waiting = 承認・入力・許可待ち` / `done = ターン完了` / `error = 実行時エラー`）を用い、本 Issue では新たな稼働状態は追加しない。
+- (A2) Step の進行ステータス（`failed / waiting_approval / running / aborted / completed / queued`）は既存の Step 状態定義を踏襲する。`waiting_approval` は集約後の代表ステータスでは `waiting` に統合される。
+- (A3) Workflow / Step / Session の階層構造（Session・Step を選択単位とし、Parallel を 1 Step として扱う #1242 の構造）は変更しない。本 Issue はその上のステータス集約・表示のみを対象とする。
+- (A4) 集約対象に含めない Session（クローズ済み等）の扱いは既存の集約ロジックの除外条件を踏襲し、本振る舞い定義の対象外とする。
+- (A5) 「視覚的に区別」の具体的なアイコン・色のデザインは表示層の裁量とし、本振る舞い定義では「動作中と停止系が区別できること」のみを要求する。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1259/design.md
+++ b/docs/specs/issues-1259/design.md
@@ -1,0 +1,286 @@
+# Design
+
+Issue #1259: WorkspaceList のステータス表示・集約ロジック再設計の実装仕様。
+
+`requirements.md` の「確定ステータス仕様」と `behavior.md` の Gherkin を満たす実装方針を定義する。本書は `design.md` のみを対象とし、`requirements.md` / `behavior.md` は変更しない。
+
+---
+
+## 1. 概要
+
+WorkspaceList 上で、各 Session の **稼働中(streaming) / 停止中** を判別可能にし、Step・Workflow の代表ステータスを新しい優先順位（`running > failed > error > waiting > aborted > completed > queued`）で集約する。
+
+新規となる中核ロジックは次の 3 つで、いずれも Rust 側の純粋関数として実装する（rust-first-logic, 例外なし）。
+
+1. **Session 結果導出**: `Step 進行ステータス × Session 稼働ステータス(AgentState) → 7 種代表ステータス`（`behavior.md` Rule 1 のクロス表）。
+2. **Step 集約**: Step 配下 Session の結果のうち最強優先度を Step 代表とする（Rule 2）。
+3. **Workflow 集約**: Step 代表のうち最強優先度を Workflow 代表とする（Rule 3）。
+
+現状の課題は、Session 稼働状態（`AgentState`、`session-status-changed` で配信）が Step/Workflow 代表ステータスへ反映される経路が存在しないこと。本設計はこの経路を新設し、リアルタイム更新（R5）を既存イベント購読の枠内で満たす。
+
+---
+
+## 2. 現状整理（変更前）
+
+| 関心事 | 実装 | データ源 | 更新契機 |
+|---|---|---|---|
+| Step 進行ステータス | `usecase/workflow/workspace_tree.rs::step_status_for_group` | `WorkflowStateSnapshot`（永続 NDJSON） | `list_workspace_worktree_nodes` 再フェッチ（`workflow-state-changed` / Session 増減） |
+| Session 稼働ステータス | `usecase/agent_session/status.rs::derive_agent_state` | `AgentStatusCenter`（インメモリ） | `session-status-changed` イベント |
+| Workspace 集約 | `usecase/agent_session/status.rs::aggregate*` | 同上 | `workspace-status-changed` イベント |
+
+現状の集約優先順位（変更対象）:
+
+- Step (`step_status_for_group`): `failed > aborted > waiting_approval > running > completed > queued`
+- Workspace (`aggregate`): `error > waiting > running > done`
+
+いずれも本 Issue の新優先順位（`running` 最強・`waiting_approval`→`waiting` 統合・`failed/error/aborted` を明示分離）とは一致せず、かつ Step 集約は Session の稼働状態を一切見ていない。
+
+---
+
+## 3. 変更対象
+
+### Rust (`src-tauri/src/`)
+
+| ファイル | 変更内容 |
+|---|---|
+| `domain/workflow/status_aggregation.rs`（新規）<br>※配置は「仮定 A6」参照 | 代表ステータス enum・Session 稼働入力 enum・クロス表・集約の純粋関数群。`behavior.md` の表を単一の真実として実装。 |
+| `usecase/agent_session/status.rs` | `SessionStatus` に Step 進行ステータス（とグループキー）を追加。`AgentStatusCenter` に Step/Workflow 代表の算出・差分検出を追加。`aggregate*` の優先順位を新仕様へ更新。 |
+| `agent_status_events.rs` | Step/Workflow 代表ステータスの emit を追加（新イベント `workflow-step-status-changed`）。 |
+| `adaptor/gateway/workflow/state_notification_gateway.rs` | `WorkflowStateSnapshot` 反映時に、各 Session の Step 進行ステータス・グループキーを `SessionStatus` へ供給。 |
+| `usecase/workflow/workspace_tree.rs` | DTO の `status` を 7 種代表ステータス語彙へ統一（`waiting_approval`→`waiting` 等の写像）。`step_status_for_group` の出力写像を `status_aggregation` 経由に揃える。Workflow 操作用に raw run lifecycle 由来の `canStop` を返す。 |
+| `adaptor/controller/command/agent_session/status.rs` 他 | 必要に応じ DTO/型公開。 |
+
+### フロント (`src/`)
+
+| ファイル | 変更内容 |
+|---|---|
+| `types/workspace-tree.ts` | `WorkspaceStepStatus` を 7 種代表ステータスへ更新。 |
+| `components/workspace/RepresentativeStatusIcon.tsx`（新規 or `WorkflowStepStatusIcon` 拡張） | 7 種すべてのアイコン・色マッピング。 |
+| `components/workspace/WorkspaceList.tsx` | Step 行・Workflow 行の代表ステータス表示を、新イベント購読値で上書き（live 優先・無ければ DTO 値）。 |
+| `hooks/useWorktreeStepStatuses.ts`（新規 or 既存フック拡張） | `workflow-step-status-changed` 購読。 |
+| `components/ui/agent-state-icon.tsx` | 変更最小（Session 行は raw `AgentState` 継続表示・「仮定 A4」）。 |
+
+---
+
+## 4. アーキテクチャと責務分割
+
+### 4.1 ロジック配置（rust-first-logic）
+
+- **クロス表・優先順位・集約は 100% Rust の純粋関数**（`status_aggregation.rs`）。フロントは一切合成しない。
+- フロントは「Rust が算出済みの代表ステータス値を、アイコン・色へ写像して表示する」のみ。
+
+### 4.2 代表ステータス算出の所有とリアルタイム経路（中核設計）
+
+採用方針（**確定 = 案 A**, push イベント配信）:
+
+- `AgentStatusCenter` を **Session→Workspace 集約に加えて Step/Workflow 代表集約も所有**する単一アグリゲータへ拡張する。
+- `SessionStatus` に、その Session が属する Step の **進行ステータス**と**グループキー（worktree_path + execution_id + step_name + run_index）** を保持させる。
+  - これらは `state_notification_gateway` が `WorkflowStateSnapshot` 反映時に供給（`workflow-state-changed` 系の更新）。
+  - Session の純粋な稼働トグル（`session-status-changed`：Streaming↔Idle）では Step 進行は変わらないため、`SessionStatus` に保持済みの値を再利用する。これによりスナップショット非同伴のイベントでも正しく再算出できる。
+- `AgentStatusCenter` は、いずれかの入力（`agent_state` または Step 進行）が変化した時に、影響する Step グループと Workflow について代表ステータスを再算出し、差分があれば emit する。
+- 配信は新イベント **`workflow-step-status-changed`**（push）。フロントは購読して表示するのみ（新規ポーリングなし → R5 充足）。
+
+この経路により、Session が streaming を開始/停止すると `session-status-changed` の発火と同じパイプライン内で Step/Workflow 代表が再算出・配信され、追加ポーリングなしに WorkspaceList が更新される（`behavior.md` Rule 5）。
+
+### 4.3 静的ツリーとの統合（フォールバック）
+
+- 開いている Session を持たない Step（履歴・完了済みで Session が Closed）は live 算出対象外（Closed は集約から除外＝既存方針）。これらは `list_workspace_worktree_nodes` の DTO `status`（`workspace_tree.rs` が `WorkflowStateSnapshot` から算出、7 種語彙へ写像済み）を表示源とする。
+- 開いている Session を持つ Step は、`workflow-step-status-changed` の live 値が DTO 値を上書きする。
+- フロントの統合規則: **Step グループキー一致の live 値があれば live 値、無ければ DTO `status`** を表示。両チャネルとも同じ 7 種語彙で揃えるため、フロントは単純な「あれば差し替え」だけで済む（合成ロジックを持たない）。
+
+---
+
+## 5. データモデル / 型
+
+### 5.1 代表ステータス（Rust 新規）
+
+```rust
+// domain/workflow/status_aggregation.rs
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepresentativeStatus {
+    Running,    // 優先度 1（最強）
+    Failed,     // 2
+    Error,      // 3
+    Waiting,    // 4
+    Aborted,    // 5
+    Completed,  // 6
+    Queued,     // 7（最弱）
+}
+
+impl RepresentativeStatus {
+    pub fn priority(self) -> u8 { /* 1..=7 */ }
+    pub fn as_str(self) -> &'static str { /* "running" 等。serde/DTO と一致 */ }
+}
+```
+
+- `priority()` 昇順が「強さ」。集約は「最小 priority」を選ぶ。
+- 文字列表現はフロント `WorkspaceStepStatus`（7 種）と一致させ、serde で素直にシリアライズ。
+
+### 5.2 Step 進行ステータス（既存の語彙を enum 化）
+
+クロス表の入力に使う Step 進行ステータス（`behavior.md` の `step`）:
+
+```rust
+pub enum StepProgress { Failed, WaitingApproval, Running, Aborted, Completed, Queued }
+```
+
+既存の文字列定数（`STEP_STATE_*`、`WorkflowExecutionState`）からの写像を一箇所に集約する。
+
+### 5.3 Session 稼働ステータス
+
+既存 `AgentState`（`Running / Waiting / Done / Error`、`usecase/agent_session/status.rs`）を入力元として使い、`AgentStatusCenter` が domain 側の `SessionActivity`（`Running / Waiting / Done / Error`）へ変換してから `status_aggregation` に渡す。新たな稼働状態は追加しない。
+
+### 5.4 `SessionStatus` への追加フィールド（Rust）
+
+```rust
+pub struct SessionStatus {
+    // 既存: chat_session_id, worktree_id, worktree_path, agent_state,
+    //       turn_phase, session_state, pending_permission, last_activity_at,
+    //       workflow_step, workflow_execution_state ...
+    pub workflow_step_progress: Option<StepProgressRepr>, // 追加: その Session の Step 進行
+    pub workflow_run_index: Option<u32>,                  // 追加: parallel グループ識別
+    pub workflow_execution_id: Option<String>,           // 追加（既存に無ければ）: グループキー用
+}
+```
+
+- グループキー = `(worktree_path, workflow_execution_id, workflow_step, workflow_run_index)`。
+- これらは表示用フィールドではなく集約用の内部入力。フロントへ露出しても良いが、フロントは利用しない。
+
+### 5.5 配信ペイロード（新イベント）
+
+`workflow-step-status-changed`（Step 単位）:
+
+```jsonc
+{
+  "worktreePath": "…",
+  "executionId": "…",
+  "stepName": "…",
+  "runIndex": 0,            // parallel 識別、無ければ null
+  "representative": "running" // 7 種のいずれか
+}
+```
+
+Workflow 代表は、Step 代表群から導出してフロントで「あれば差し替え」する設計とし、必要なら同イベントに `workflowRepresentative` を併載 or 別イベント `workflow-status-changed` 拡張で配信する（実装時に粒度確定。テストはどちらでも Rust 純粋関数で担保）。
+
+### 5.6 フロント型
+
+```ts
+// types/workspace-tree.ts
+export type WorkspaceStepStatus =
+  | "running" | "failed" | "error" | "waiting"
+  | "aborted" | "completed" | "queued";
+```
+
+`AgentState`（`running | done | error | waiting`）は Session 行用に維持（仮定 A4）。Workflow 行の Stop 可否は代表ステータスではなく、DTO の `canStop`（raw `RunStatus::Running | WaitingApproval`）を用いる。
+
+---
+
+## 6. 処理フロー
+
+### 6.1 Session 結果導出（Rule 1, 純粋関数）
+
+```rust
+pub fn session_result(step: StepProgress, activity: SessionActivity) -> RepresentativeStatus
+```
+
+`behavior.md` の Examples をそのまま分岐:
+
+- `agent == Running` → 常に `Running`（Step 不問）。
+- `agent == Waiting`: `Failed→Failed`、それ以外（`WaitingApproval/Running/Aborted/Completed/Queued`）→ `Waiting`。
+- `agent == Done`: `Failed→Failed, WaitingApproval→Waiting, Running→Running, Aborted→Aborted, Completed→Completed, Queued→Queued`。
+- `agent == Error`: `Failed→Failed`、それ以外 → `Error`。
+
+### 6.2 Step 集約（Rule 2）
+
+```rust
+pub fn aggregate(results: impl IntoIterator<Item = RepresentativeStatus>) -> Option<RepresentativeStatus>
+```
+
+- 各 `RepresentativeStatus.priority()` が最小（最強）のものを返す。
+- 空集合 → `None`（live 算出では emit しない＝DTO フォールバック）。
+- 単一 Session の Step はその結果がそのまま代表（Rule 2 の単一ケース）。
+
+### 6.3 Workflow 集約（Rule 3）
+
+Step 代表群に同じ `aggregate` を適用して最強を Workflow 代表とする。
+
+### 6.4 リアルタイム更新パイプライン（Rule 5）
+
+1. Session の `turn_phase`/`session_state` 変化 → `AgentStatusCenter::update_session`（既存）。
+2. 同 worktree の Workspace 集約（既存）に加え、当該 Session のグループキーから **Step 代表**を再算出。`SessionStatus.workflow_step_progress`（前回スナップショットで供給済み）と新 `agent_state` を `session_result` に通し、同 Step グループの全 open Session で `aggregate`。
+3. さらに当該 Workflow の全 Step 代表で `aggregate` し **Workflow 代表**を更新。
+4. 差分があれば `workflow-step-status-changed`（必要なら Workflow 代表も）を emit。
+5. `WorkflowStateSnapshot` 変化時（`state_notification_gateway`）は、各 Session の `workflow_step_progress`/グループキーを更新 → 同様に再算出・emit。
+6. フロント `useWorktreeStepStatuses` が購読し、`WorkspaceList` の Step/Workflow 行へ live 値を反映。
+
+---
+
+## 7. エラー処理
+
+- **クロス表は全域関数**: `StepProgress × SessionActivity` の全組み合わせを網羅（戻り値必ず確定）。`match` を網羅的にし `_` フォールバックを置かない（仕様逸脱をコンパイル時に検出）。
+- **空集約**: open Session の無い Step/Workflow は `aggregate` が `None` → emit せず DTO フォールバック。フロントは live 不在時に DTO 値を使う既定経路で安全。
+- **未知文字列の写像**: 既存 `STEP_STATE_*` / `WorkflowExecutionState` から `StepProgress` への写像で未知値が来た場合は保守的に `Queued`（最弱）へ寄せる。ログは既存方針に従い過剰出力しない。
+- **Closed/Archived Session**: 既存どおり集約対象外（仮定 A4 / `behavior.md` A4）。
+- **イベント取りこぼし**: live 値が来ない Step は DTO フォールバックで表示が破綻しない（縮退して整合）。
+
+---
+
+## 8. テスト方針
+
+### 8.1 Rust 単体（`status_aggregation.rs`）— `behavior.md` の表を直接検証
+
+- `session_result`: `behavior.md` Rule 1 の 4 つの Examples（running/waiting/done/error × 6 Step）= 24 ケースを表駆動テストで全網羅。
+- `aggregate`（Step, Rule 2）: Examples の `results → representative`（7 ケース）+ 単一 Session ケース + 空集合 `None`。
+- `aggregate`（Workflow, Rule 3）: Examples の `steps → representative`（7 ケース）。
+- 優先順位: `running > failed > error > waiting > aborted > completed > queued` を `priority()` 昇順で検証。
+
+### 8.2 Rust 単体（`agent_session/status.rs` / `workspace_tree.rs`）
+
+- `AgentStatusCenter`: Session 稼働トグル（Streaming↔Idle）で Step/Workflow 代表が再算出・差分 emit されること。Step 進行非同伴イベントで保持済み `workflow_step_progress` を再利用すること。
+- Parallel Step: 1 つでも `running` の Session があれば代表 `running`（Rule 2 シナリオ）。
+- `workspace_tree.rs`: DTO `status` が 7 種語彙へ写像されること（`waiting_approval`→`waiting` 等）。既存テスト `workflow_step_status_uses_ref_state_priority_*` を新優先順位・新語彙へ更新。
+
+### 8.3 フロント（Vitest）
+
+- `RepresentativeStatusIcon`: 7 種それぞれのアイコン・色マッピング、`running` が「動作中」として停止系と視覚的に区別される（Rule 4）。
+- `WorkspaceList` 統合表示: live 値が DTO 値を上書きすること、live 不在時に DTO 値が出ること（Tauri `listen` をモック）。
+- `useWorktreeStepStatuses`: `workflow-step-status-changed` 購読での Map 更新と worktree フィルタ。
+
+### 8.4 受け入れ確認（requirements 受け入れ基準）
+
+- `cargo clippy -- -D warnings` / `cargo test` / `pnpm lint` / `pnpm test` 通過。
+- `behavior.md` Rule 1 の各セルが実装と一致（8.1 で機械的に担保）。
+
+---
+
+## 9. リスクと代替案
+
+### リスク
+
+- **R-1 結合増加**: `AgentStatusCenter`（`usecase/agent_session`）が Step 進行という Workflow 由来の情報を保持する。依存方向は「gateway が snapshot から `SessionStatus` へ値を流し込む」形にし、status center 側は domain の純粋関数にのみ依存する（純粋関数 `status_aggregation` は `SessionActivity` + `StepProgress` enum のみを入力に取る）。
+- **R-2 parallel run_index の整合**: グループキーの `run_index` 取り違えで別グループの Session を混在集約する恐れ。`collect_step_session_refs`（既存）と同じグループ定義（`group_step_name` + `group_run_index`）を `SessionStatus` 供給時に厳密適用する。
+- **R-3 履歴 Step と live のフォールバック境界**: open Session の有無で表示源が切り替わる。切替時の一瞬の不整合を避けるため、フロントは「live があれば live、無ければ DTO」を単純規則で適用し、両者を同語彙に揃える。
+- **R-4 アイコン語彙の移行**: 現状 `WorkflowStepStatusIcon`(error 無し) と `AgentStateIcon`(failed/aborted/queued 無し) が分離。7 種統一アイコンを新設し Step/Workflow 行で使用、Session 行は raw `AgentState` 用に `AgentStateIcon` 継続。
+
+### 代替案
+
+- **代替-B（pull 型コマンド・不採用）**: クロス表・集約を Tauri コマンドとして公開し、フロントが `session-status-changed` 毎に invoke して再計算。ロジックは Rust に残るが、フロントが「いつ何を invoke するか」を統制する点で表示専従から逸脱気味。新規ポーリングではないため R5 は満たすが、push（案 A）の方が責務分割が明快なため不採用。
+- **代替-C（ツリー再フェッチ）**: `session-status-changed` で `list_workspace_worktree_nodes` を毎回再フェッチして DTO 側で集約。実装は最小だが、稼働トグルのたびに全ツリー再構築＝既存の最適化（status 更新では refetch しない）を逆行させ、重い。不採用。
+
+---
+
+## 10. 仮定
+
+- (A1) Session 稼働判定は既存 `AgentState` を使用（`running = Streaming` / `waiting = 承認・入力・許可待ち` / `done = ターン完了` / `error = 実行時エラー`）。新稼働状態は追加しない。
+- (A2) Spec ディレクトリは `docs/specs/issues-1259`。
+- (A3) #1242 で確定した WorkspaceList のナビゲーション構造（Session/Step を選択単位・Parallel は 1 Step）は変更しない。
+- (A4) **Session 行は raw `AgentState`（4 種、running=streaming を pulse 強調）を継続表示**し、「中の Session が動いているか」を直接示す。クロス表の「1 Session の結果ステータス（7 種）」は Step/Workflow 集約の内部入力として用い、Session 行表示には用いない。Step・Workflow 行は 7 種代表ステータスを表示。
+- (A5) Closed/Archived Session は live 集約対象外（既存除外条件を踏襲）。
+- (A6) `status_aggregation` の配置は `domain/workflow/` 配下とする。純粋関数は domain の `SessionActivity` と `StepProgress` enum のみに依存し、`AgentState` から `SessionActivity` への型変換は呼び出し側（status center）が担う。これにより `agent_session` と `workflow` の usecase 間依存を作らない。
+- (A7) リアルタイム配信は push 型新イベント `workflow-step-status-changed` を採用（案 A 確定）。`AgentStatusCenter` を拡張し、Step 進行を `SessionStatus` に保持、稼働変化時に Step/Workflow 代表を再算出して push 配信する。フロントは表示専従。
+
+---
+
+## 11. Open Questions
+
+なし。

--- a/docs/specs/issues-1259/requirements.md
+++ b/docs/specs/issues-1259/requirements.md
@@ -1,0 +1,126 @@
+# Requirements
+
+## Type
+
+WorkspaceList のステータス表示・集約ロジックの再設計。
+
+関連: #1259 / #1242 / #1220
+
+## 背景と目的
+
+Issue #1259 の要求:
+
+> Step の状態も見たいが、それ以上に中の Session が動いてるのか止まっているのかも見たい。
+> 優先順位を設定し適切なステータスになるようにする。
+
+現状、WorkspaceList では次の 2 系統のステータスが別々に表示されている。
+
+- **Step ステータス** (`WorkspaceStepStatus`): `queued / running / waiting_approval / completed / failed / aborted`
+  - `WorkflowStepStatusIcon` でアイコン + 色表示。
+  - Parallel Step では複数 Session を `failed > aborted > waiting_approval > running > completed > queued` の優先順位で 1 つに集約 (`step_status_for_group`)。
+- **Session ステータス** (`AgentState`): `running / done / error / waiting`
+  - `AgentStateIcon` で Bot アイコン + 色表示。
+  - `running` = モデル応答の streaming 中、`waiting` = 承認待ち / idle、`done` = 完了、`error` = エラー。
+
+現状の課題:
+
+- Step の集約ステータスを見ても、その Step 配下の Session が **実際に処理を進めている (動いている)** のか、**入力待ち / 承認待ちで停止している (止まっている)** のかが直感的に分からない。`running` という Step ステータスが、streaming 中なのか単にアクティブなだけなのかを区別しない。
+- 集約の優先順位が「異常・完了状態」中心 (`failed > aborted > waiting_approval > running > completed`) であり、「今この Workspace に人の操作が必要か / 自動で進んでいるか」という観点でユーザーが知りたい代表ステータスと一致しないことがある。
+
+目的: WorkspaceList 上で、Step ステータスに加えて **配下の Session が動作中か停止中か** を一目で判別できるようにし、複数 Session/Step を集約する際の優先順位を「ユーザーが次に注目すべき状態」が代表ステータスになるよう再設計する。
+
+## スコープ
+
+- WorkspaceList における Step 行・Session 行・Workflow 行のステータス表示の再設計。
+- 「Session が動いている (streaming) / 止まっている (idle・承認待ち・完了・エラー)」を判別できる表示の追加。
+- 複数 Session を含む Step、複数 Step を含む Workflow のステータス集約優先順位の再定義。
+- 上記に必要な Rust 側のステータス導出・集約ロジック (`workspace_tree.rs` / `agent_session/status.rs`) の変更。
+
+## 非スコープ
+
+- Workflow engine の実行モデル・実行順序の変更。
+- Workflow 定義や YAML schema の変更。
+- 中央パネル (Chat UI / Step 画面) の表示内容の再設計。
+- WorkspaceList のナビゲーション構造 (Session/Step の選択単位) 自体の変更 (#1242 で確定済みの構造を維持)。
+- Source Control / Editor / Terminal など Workflow 以外の画面。
+
+## 要求事項
+
+### R1. Session の稼働状態の可視化
+
+- WorkspaceList 上で、各 Session について **動作中 (streaming)** か **停止中** かを判別できること。
+- 「動作中」「停止中」の判定は Rust 側で導出し、フロントは表示に徹すること (rust-first-logic)。
+
+### R2. Step の稼働状態の反映
+
+- Step 行のステータス表示で、配下に動作中の Session があるか否かを判別できること。
+- Parallel Step の場合も、配下のいずれかの Session が動作中であることが分かること。
+
+### R3. 集約優先順位の再定義
+
+- 複数 Session を含む Step、複数 Step を含む Workflow の代表ステータスを決める優先順位を、下記「確定ステータス仕様」のとおりに定義すること。
+- 優先順位は Rust 側の単一ロジックで一貫して適用され、フロントの表示と乖離しないこと。
+
+### R4. 既存ステータス種別との整合
+
+- 代表ステータスは下記の 7 種 (`running / failed / error / waiting / aborted / completed / queued`) に統一する。`waiting` は従来の Step `waiting_approval` と Session の入力/許可待ち (`AgentState == waiting`) を 1 つに統合したものとする。
+- 既存の `WorkflowStepStatusIcon` / `AgentStateIcon` の表示は、この 7 種の代表ステータスに整合させること。
+
+### R5. リアルタイム更新
+
+- Session の稼働状態は `session-status-changed` イベント購読 (`useWorktreeSessionStatuses`) によりリアルタイムに更新されること。新たなポーリング機構を追加しないこと。
+
+## 確定ステータス仕様
+
+### 1. 状態一覧（強い順 = 優先度）
+
+| 優先 | 状態 | 意味 |
+|---|---|---|
+| 1 | `running` | Session が動作中 (streaming) |
+| 2 | `failed` | 失敗 |
+| 3 | `error` | 実行時エラー |
+| 4 | `waiting` | 承認待ち・入力待ち・許可待ち |
+| 5 | `aborted` | 中止 |
+| 6 | `completed` | 完了 |
+| 7 | `queued` | 未着手・順番待ち |
+
+### 2. Session 1 個の結果（Step 進行 × Session 稼働）
+
+縦 = Step 進行ステータス、横 = その Session の稼働ステータス (`AgentState`)。セル = その Session の結果ステータス。
+
+| Step ↓ \ Session → | `running` | `waiting` | `done` | `error` |
+|---|---|---|---|---|
+| `failed` | running | failed | failed | failed |
+| `waiting_approval` | running | waiting | waiting | error |
+| `running` | running | waiting | running | error |
+| `aborted` | running | waiting | aborted | error |
+| `completed` | running | waiting | completed | error |
+| `queued` | running | waiting | queued | error |
+
+- Session 稼働が `running` の場合、Step 進行が何であれ結果は常に `running`。
+
+### 3. 複数 Session（Parallel Step）の集約
+
+各 Session を上記「2.」の表に通して結果を求め、その中で**優先度が一番強い（1 に近い）もの**を Step の代表ステータスとする。
+
+### 4. Workflow の集約
+
+配下の全 Step の代表ステータスを集め、同じく**優先度が一番強いもの**を Workflow の代表ステータスとする。
+
+## 受け入れ基準の概要
+
+- WorkspaceList で、`running` の Session を含む Step と、全 Session が停止系状態の Step を視覚的に区別できる。
+- Parallel Step 配下に 1 つでも `running` の Session があれば、その Step の代表は `running` になる。
+- 集約優先順位 (`running > failed > error > waiting > aborted > completed > queued`) が Rust 側テスト (`workspace_tree.rs` / `status.rs` の単体テスト) で検証され、確定仕様どおりに代表ステータスが決まる。
+- 「確定ステータス仕様 2.」の Step × Session の各セルの結果が、実装と一致する。
+- `cargo clippy -- -D warnings` / `cargo test` / `pnpm lint` / `pnpm test` が通る。
+
+## 仮定
+
+- (A1) Session 稼働の判定は既存の `AgentState` を用いる。`running` = `turn_phase == Streaming`、`waiting` = 承認/入力/許可待ち、`done` = ターン完了、`error` = 実行時エラー。
+- (A2) Spec ディレクトリ名は既存慣習に合わせ `docs/specs/issues-1259` とする。
+- (A3) #1242 で確定した WorkspaceList のナビゲーション構造 (Session/Step を選択単位とし、Parallel は 1 Step として扱う) は変更しない。本 Issue はその上のステータス表示・集約のみを対象とする。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1259/requirements.md
+++ b/docs/specs/issues-1259/requirements.md
@@ -64,11 +64,14 @@ Issue #1259 の要求:
 ### R4. 既存ステータス種別との整合
 
 - 代表ステータスは下記の 7 種 (`running / failed / error / waiting / aborted / completed / queued`) に統一する。`waiting` は従来の Step `waiting_approval` と Session の入力/許可待ち (`AgentState == waiting`) を 1 つに統合したものとする。
-- 既存の `WorkflowStepStatusIcon` / `AgentStateIcon` の表示は、この 7 種の代表ステータスに整合させること。
+- Session 行の `AgentStateIcon` は既存どおり raw `AgentState` を表示し、7 種の代表ステータス集約の対象外とすること。
+- Step / Workflow 行の `WorkflowStepStatusIcon` の表示は、この 7 種の代表ステータスに整合させること。
 
 ### R5. リアルタイム更新
 
-- Session の稼働状態は `session-status-changed` イベント購読 (`useWorktreeSessionStatuses`) によりリアルタイムに更新されること。新たなポーリング機構を追加しないこと。
+- Session の稼働状態は `session-status-changed` イベント購読 (`useWorktreeSessionStatuses`) によりリアルタイムに更新されること。
+- Step / Workflow の代表ステータスは `workflow-step-status-changed` イベント購読 (`useWorktreeStepStatuses`) によりリアルタイムに更新されること。
+- 新たなポーリング機構を追加しないこと。
 
 ## 確定ステータス仕様
 

--- a/src-tauri/src/adaptor/controller/command/agent_session/status.rs
+++ b/src-tauri/src/adaptor/controller/command/agent_session/status.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use tauri::State;
 
-use crate::usecase::agent_session::status::{AgentStatusCenter, SessionStatus, WorkspaceStatus};
+use crate::usecase::agent_session::status::{
+    AgentStatusCenter, SessionStatus, WorkflowStepStatusChange, WorkspaceStatus,
+};
 
 #[tauri::command]
 pub fn get_session_status(
@@ -28,4 +30,11 @@ pub fn list_workspace_statuses(center: State<'_, Arc<AgentStatusCenter>>) -> Vec
 #[tauri::command]
 pub fn list_session_statuses(center: State<'_, Arc<AgentStatusCenter>>) -> Vec<SessionStatus> {
     center.list_sessions()
+}
+
+#[tauri::command]
+pub fn list_workflow_step_statuses(
+    center: State<'_, Arc<AgentStatusCenter>>,
+) -> Vec<WorkflowStepStatusChange> {
+    center.list_workflow_step_statuses()
 }

--- a/src-tauri/src/adaptor/controller/command/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/mod.rs
@@ -130,6 +130,7 @@ pub(crate) fn register_all(builder: tauri::Builder<tauri::Wry>) -> tauri::Builde
             crate::adaptor::controller::command::agent_session::status::get_workspace_status,
             crate::adaptor::controller::command::agent_session::status::list_workspace_statuses,
             crate::adaptor::controller::command::agent_session::status::list_session_statuses,
+            crate::adaptor::controller::command::agent_session::status::list_workflow_step_statuses,
             // Repo paths（repository ドメイン）
             crate::adaptor::controller::command::repository::repo_paths::get_repo_paths,
             crate::adaptor::controller::command::repository::repo_paths::add_repo_path,

--- a/src-tauri/src/adaptor/gateway/workflow/state_notification_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/state_notification_gateway.rs
@@ -126,6 +126,11 @@ pub(crate) async fn emit_workflow_state_from_snapshot<R: tauri::Runtime>(
     open_tabs: &OpenTabRegistry,
 ) {
     let execution_id = state.execution_id.clone();
+    let workflow_execution_state = state.state.as_str().to_string();
+    let step_session_projections =
+        crate::domain::workflow::services::session_projection::collect_step_session_projections(
+            &state,
+        );
     let workflow_agent_state =
         crate::usecase::agent_session::status::AgentStatusCenter::workflow_execution_state_to_agent_state(
             &state.state,
@@ -139,6 +144,18 @@ pub(crate) async fn emit_workflow_state_from_snapshot<R: tauri::Runtime>(
     if let Some(center) =
         app.try_state::<Arc<crate::usecase::agent_session::status::AgentStatusCenter>>()
     {
+        for changes in center.sync_workflow_step_session_statuses(
+            worktree_path,
+            &execution_id,
+            &workflow_execution_state,
+            step_session_projections,
+        ) {
+            crate::agent_status_events::emit_agent_status_changes(
+                app,
+                broadcaster.as_deref(),
+                changes,
+            );
+        }
         let changes = center.update_workflow_snapshot(
             worktree_path,
             &execution_id,
@@ -177,19 +194,18 @@ pub(crate) async fn emit_workflow_state_snapshot<R: tauri::Runtime>(
     );
     let view = workflow_state_view_from_projection(projection);
     emit_workflow_state_view(app, worktree_path, &view);
-
-    for status in center.list_sessions() {
-        if status.worktree_path == worktree_path {
-            let mut updated = status;
-            updated.workflow_step = Some(workflow_state.current_step_name.clone());
-            updated.workflow_execution_state = Some(workflow_state.state.as_str().to_string());
-            let changes = center.update_session(updated);
-            crate::agent_status_events::emit_agent_status_changes(
-                app,
-                broadcaster.as_deref(),
-                changes,
-            );
-        }
+    let workflow_execution_state = workflow_state.state.as_str().to_string();
+    let step_session_projections =
+        crate::domain::workflow::services::session_projection::collect_step_session_projections(
+            &workflow_state,
+        );
+    for changes in center.sync_workflow_step_session_statuses(
+        worktree_path,
+        &workflow_state.execution_id,
+        &workflow_execution_state,
+        step_session_projections,
+    ) {
+        crate::agent_status_events::emit_agent_status_changes(app, broadcaster.as_deref(), changes);
     }
 
     let workflow_agent_state =

--- a/src-tauri/src/agent_status_events.rs
+++ b/src-tauri/src/agent_status_events.rs
@@ -28,6 +28,9 @@ pub(crate) fn emit_agent_status_changes<R: tauri::Runtime>(
     if let Some(workspace) = changes.workspace {
         let _ = app.emit("workspace-status-changed", workspace);
     }
+    for workflow_step in changes.workflow_steps {
+        let _ = app.emit("workflow-step-status-changed", workflow_step);
+    }
     if let Some(agent_state) = changes.agent_state {
         let payload = AgentStateSync {
             worktree_path: agent_state.worktree_path,

--- a/src-tauri/src/domain/workflow/mod.rs
+++ b/src-tauri/src/domain/workflow/mod.rs
@@ -11,6 +11,7 @@ pub mod gateway;
 #[allow(clippy::module_inception)]
 pub mod repository;
 pub mod services;
+pub mod status_aggregation;
 pub mod value_objects;
 
 pub use entities::workflow_execution::{

--- a/src-tauri/src/domain/workflow/services/session_projection.rs
+++ b/src-tauri/src/domain/workflow/services/session_projection.rs
@@ -1,20 +1,129 @@
 use std::collections::HashSet;
 
+use crate::domain::workflow::status_aggregation::{RepresentativeStatus, StepProgress};
 use crate::domain::workflow::WorkflowStateSnapshot;
 
-pub fn collect_step_session_ids(state: &WorkflowStateSnapshot) -> HashSet<String> {
-    let mut ids = HashSet::new();
-    if let Some(session_id) = state.current_session_id.as_ref() {
-        ids.insert(session_id.clone());
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepSessionProjection {
+    pub session_id: Option<String>,
+    pub step_name: String,
+    pub run_index: Option<u32>,
+    pub group_step_name: String,
+    pub group_run_index: Option<u32>,
+    pub progress: StepProgress,
+    pub representative: RepresentativeStatus,
+    pub order: usize,
+}
+
+pub fn current_run_index(state: &WorkflowStateSnapshot) -> Option<u32> {
+    state
+        .step_execution_counts
+        .get(&state.current_step_name)
+        .copied()
+        .or(Some(1))
+}
+
+fn projection(
+    session_id: Option<String>,
+    step_name: String,
+    run_index: Option<u32>,
+    group_step_name: String,
+    group_run_index: Option<u32>,
+    status: &str,
+    order: usize,
+) -> StepSessionProjection {
+    StepSessionProjection {
+        session_id,
+        step_name,
+        run_index,
+        group_step_name,
+        group_run_index,
+        progress: StepProgress::from_status_str(status),
+        representative: RepresentativeStatus::from_status_str(status),
+        order,
     }
+}
+
+pub fn collect_step_session_projections(
+    state: &WorkflowStateSnapshot,
+) -> Vec<StepSessionProjection> {
+    let mut projections = Vec::new();
+    let mut next_order = 0usize;
+
     for entry in &state.step_history {
-        if let Some(session_id) = entry.session_id.as_ref() {
-            ids.insert(session_id.clone());
-        }
+        let order = next_order;
+        next_order += 1;
+        projections.push(projection(
+            entry.session_id.clone(),
+            entry.step_name.clone(),
+            Some(entry.run_index),
+            entry.step_name.clone(),
+            Some(entry.run_index),
+            &entry.state,
+            order,
+        ));
         if let Some(children) = entry.child_outputs.as_ref() {
-            ids.extend(children.iter().filter_map(|child| child.session_id.clone()));
+            for child in children {
+                projections.push(projection(
+                    child.session_id.clone(),
+                    child.step_name.clone(),
+                    Some(child.run_index),
+                    entry.step_name.clone(),
+                    Some(entry.run_index),
+                    &child.state,
+                    order,
+                ));
+            }
         }
     }
+
+    if state.current_session_id.is_some() || state.state.is_active() {
+        let order = next_order;
+        let run_index = current_run_index(state);
+        projections.push(projection(
+            state.current_session_id.clone(),
+            state.current_step_name.clone(),
+            run_index,
+            state.current_step_name.clone(),
+            run_index,
+            state.state.as_str(),
+            order,
+        ));
+        for step in &state.active_parallel_steps {
+            projections.push(projection(
+                step.session_id.clone(),
+                step.step_name.clone(),
+                Some(step.run_index),
+                state.current_step_name.clone(),
+                run_index,
+                &step.state,
+                order,
+            ));
+        }
+    }
+
+    retain_unique_step_session_projections(&mut projections);
+    projections
+}
+
+fn retain_unique_step_session_projections(projections: &mut Vec<StepSessionProjection>) {
+    let mut seen = HashSet::new();
+    projections.retain(|projection| {
+        seen.insert((
+            projection.session_id.clone(),
+            projection.step_name.clone(),
+            projection.run_index,
+            projection.group_step_name.clone(),
+            projection.group_run_index,
+        ))
+    });
+}
+
+pub fn collect_step_session_ids(state: &WorkflowStateSnapshot) -> HashSet<String> {
+    let mut ids = collect_step_session_projections(state)
+        .into_iter()
+        .filter_map(|projection| projection.session_id)
+        .collect::<HashSet<_>>();
     ids.extend(
         state
             .active_parallel_steps
@@ -129,6 +238,59 @@ mod tests {
         assert!(ids.contains("child-session"));
         assert!(ids.contains("parallel-session"));
         assert!(!ids.contains("regular-chat-session"));
+    }
+
+    #[test]
+    fn projects_group_key_run_index_progress_and_order_from_snapshot() {
+        let projections = collect_step_session_projections(&state());
+
+        let done = projections
+            .iter()
+            .find(|projection| projection.session_id.as_deref() == Some("done-session"))
+            .expect("done session projection");
+        assert_eq!(done.step_name, "done");
+        assert_eq!(done.run_index, Some(1));
+        assert_eq!(done.group_step_name, "done");
+        assert_eq!(done.group_run_index, Some(1));
+        assert_eq!(done.progress, StepProgress::Completed);
+        assert_eq!(done.representative, RepresentativeStatus::Completed);
+        assert_eq!(done.order, 0);
+
+        let child = projections
+            .iter()
+            .find(|projection| projection.session_id.as_deref() == Some("child-session"))
+            .expect("child session projection");
+        assert_eq!(child.step_name, "child");
+        assert_eq!(child.run_index, Some(1));
+        assert_eq!(child.group_step_name, "done");
+        assert_eq!(child.group_run_index, Some(1));
+        assert_eq!(child.progress, StepProgress::Completed);
+        assert_eq!(child.representative, RepresentativeStatus::Completed);
+        assert_eq!(child.order, 0);
+
+        let current = projections
+            .iter()
+            .find(|projection| projection.session_id.as_deref() == Some("current-session"))
+            .expect("current session projection");
+        assert_eq!(current.step_name, "current");
+        assert_eq!(current.group_step_name, "current");
+        assert_eq!(current.run_index, Some(1));
+        assert_eq!(current.group_run_index, Some(1));
+        assert_eq!(current.progress, StepProgress::Running);
+        assert_eq!(current.representative, RepresentativeStatus::Running);
+        assert_eq!(current.order, 1);
+
+        let parallel = projections
+            .iter()
+            .find(|projection| projection.session_id.as_deref() == Some("parallel-session"))
+            .expect("parallel session projection");
+        assert_eq!(parallel.step_name, "running-child");
+        assert_eq!(parallel.run_index, Some(1));
+        assert_eq!(parallel.group_step_name, "current");
+        assert_eq!(parallel.group_run_index, Some(1));
+        assert_eq!(parallel.progress, StepProgress::Running);
+        assert_eq!(parallel.representative, RepresentativeStatus::Running);
+        assert_eq!(parallel.order, 1);
     }
 
     #[test]

--- a/src-tauri/src/domain/workflow/status_aggregation.rs
+++ b/src-tauri/src/domain/workflow/status_aggregation.rs
@@ -1,0 +1,227 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RepresentativeStatus {
+    Running,
+    Failed,
+    Error,
+    Waiting,
+    Aborted,
+    Completed,
+    Queued,
+}
+
+impl RepresentativeStatus {
+    pub(crate) fn priority(self) -> u8 {
+        match self {
+            Self::Running => 1,
+            Self::Failed => 2,
+            Self::Error => 3,
+            Self::Waiting => 4,
+            Self::Aborted => 5,
+            Self::Completed => 6,
+            Self::Queued => 7,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Failed => "failed",
+            Self::Error => "error",
+            Self::Waiting => "waiting",
+            Self::Aborted => "aborted",
+            Self::Completed => "completed",
+            Self::Queued => "queued",
+        }
+    }
+
+    pub(crate) fn from_status_str(status: &str) -> Self {
+        match status {
+            "running" => Self::Running,
+            "failed" => Self::Failed,
+            "error" => Self::Error,
+            "waiting" | "waiting_approval" => Self::Waiting,
+            "aborted" => Self::Aborted,
+            "completed" => Self::Completed,
+            "queued" | "pending" => Self::Queued,
+            _ => Self::Queued,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StepProgress {
+    Failed,
+    WaitingApproval,
+    Running,
+    Aborted,
+    Completed,
+    Queued,
+}
+
+impl StepProgress {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Failed => "failed",
+            Self::WaitingApproval => "waiting_approval",
+            Self::Running => "running",
+            Self::Aborted => "aborted",
+            Self::Completed => "completed",
+            Self::Queued => "queued",
+        }
+    }
+
+    pub(crate) fn from_status_str(status: &str) -> Self {
+        match status {
+            "failed" => Self::Failed,
+            "waiting_approval" | "waiting" => Self::WaitingApproval,
+            "running" => Self::Running,
+            "aborted" => Self::Aborted,
+            "completed" => Self::Completed,
+            "pending" | "queued" => Self::Queued,
+            _ => Self::Queued,
+        }
+    }
+
+    pub(crate) fn representative(self) -> RepresentativeStatus {
+        match self {
+            Self::Failed => RepresentativeStatus::Failed,
+            Self::WaitingApproval => RepresentativeStatus::Waiting,
+            Self::Running => RepresentativeStatus::Running,
+            Self::Aborted => RepresentativeStatus::Aborted,
+            Self::Completed => RepresentativeStatus::Completed,
+            Self::Queued => RepresentativeStatus::Queued,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SessionActivity {
+    Running,
+    Waiting,
+    Done,
+    Error,
+}
+
+pub(crate) fn session_result(
+    step: StepProgress,
+    activity: SessionActivity,
+) -> RepresentativeStatus {
+    match activity {
+        SessionActivity::Running => RepresentativeStatus::Running,
+        SessionActivity::Waiting => match step {
+            StepProgress::Failed => RepresentativeStatus::Failed,
+            StepProgress::WaitingApproval
+            | StepProgress::Running
+            | StepProgress::Aborted
+            | StepProgress::Completed
+            | StepProgress::Queued => RepresentativeStatus::Waiting,
+        },
+        SessionActivity::Done => match step {
+            StepProgress::Failed => RepresentativeStatus::Failed,
+            StepProgress::WaitingApproval => RepresentativeStatus::Waiting,
+            StepProgress::Running => RepresentativeStatus::Running,
+            StepProgress::Aborted => RepresentativeStatus::Aborted,
+            StepProgress::Completed => RepresentativeStatus::Completed,
+            StepProgress::Queued => RepresentativeStatus::Queued,
+        },
+        SessionActivity::Error => match step {
+            StepProgress::Failed => RepresentativeStatus::Failed,
+            StepProgress::WaitingApproval
+            | StepProgress::Running
+            | StepProgress::Aborted
+            | StepProgress::Completed
+            | StepProgress::Queued => RepresentativeStatus::Error,
+        },
+    }
+}
+
+pub(crate) fn aggregate_representative_statuses(
+    statuses: impl IntoIterator<Item = RepresentativeStatus>,
+) -> Option<RepresentativeStatus> {
+    statuses.into_iter().min_by_key(|status| status.priority())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn priority_matches_spec_order() {
+        assert_eq!(
+            [
+                RepresentativeStatus::Running,
+                RepresentativeStatus::Failed,
+                RepresentativeStatus::Error,
+                RepresentativeStatus::Waiting,
+                RepresentativeStatus::Aborted,
+                RepresentativeStatus::Completed,
+                RepresentativeStatus::Queued,
+            ]
+            .map(RepresentativeStatus::priority),
+            [1, 2, 3, 4, 5, 6, 7]
+        );
+    }
+
+    #[test]
+    fn session_result_matches_step_by_agent_cross_table() {
+        use RepresentativeStatus as R;
+        use SessionActivity::{Done, Error, Running, Waiting};
+        use StepProgress as S;
+
+        let cases = [
+            (S::Failed, Running, R::Running),
+            (S::WaitingApproval, Running, R::Running),
+            (S::Running, Running, R::Running),
+            (S::Aborted, Running, R::Running),
+            (S::Completed, Running, R::Running),
+            (S::Queued, Running, R::Running),
+            (S::Failed, Waiting, R::Failed),
+            (S::WaitingApproval, Waiting, R::Waiting),
+            (S::Running, Waiting, R::Waiting),
+            (S::Aborted, Waiting, R::Waiting),
+            (S::Completed, Waiting, R::Waiting),
+            (S::Queued, Waiting, R::Waiting),
+            (S::Failed, Done, R::Failed),
+            (S::WaitingApproval, Done, R::Waiting),
+            (S::Running, Done, R::Running),
+            (S::Aborted, Done, R::Aborted),
+            (S::Completed, Done, R::Completed),
+            (S::Queued, Done, R::Queued),
+            (S::Failed, Error, R::Failed),
+            (S::WaitingApproval, Error, R::Error),
+            (S::Running, Error, R::Error),
+            (S::Aborted, Error, R::Error),
+            (S::Completed, Error, R::Error),
+            (S::Queued, Error, R::Error),
+        ];
+
+        for (step, activity, expected) in cases {
+            assert_eq!(session_result(step, activity), expected);
+        }
+    }
+
+    #[test]
+    fn aggregate_returns_strongest_priority() {
+        use RepresentativeStatus as R;
+        for (statuses, expected) in [
+            (vec![R::Running, R::Waiting, R::Completed], R::Running),
+            (vec![R::Failed, R::Waiting, R::Completed], R::Failed),
+            (vec![R::Error, R::Waiting, R::Queued], R::Error),
+            (vec![R::Waiting, R::Completed, R::Queued], R::Waiting),
+            (vec![R::Aborted, R::Completed, R::Queued], R::Aborted),
+            (vec![R::Completed, R::Queued], R::Completed),
+            (vec![R::Queued, R::Queued], R::Queued),
+        ] {
+            assert_eq!(aggregate_representative_statuses(statuses), Some(expected));
+        }
+    }
+
+    #[test]
+    fn aggregate_single_and_empty_inputs() {
+        assert_eq!(
+            aggregate_representative_statuses([RepresentativeStatus::Waiting]),
+            Some(RepresentativeStatus::Waiting)
+        );
+        assert_eq!(aggregate_representative_statuses(std::iter::empty()), None);
+    }
+}

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
@@ -2264,10 +2264,18 @@ pub(crate) fn notify_status_transition<R: tauri::Runtime>(
         AgentStatusCenter::derive_agent_state(status_turn_phase, session_state.clone());
 
     if let Some(center) = app.try_state::<Arc<AgentStatusCenter>>() {
-        let (wf_step, wf_state) = center
+        let (wf_step, wf_state, wf_execution_id, wf_run_index, wf_step_progress) = center
             .get_session(chat_session_id)
-            .map(|s| (s.workflow_step, s.workflow_execution_state))
-            .unwrap_or((None, None));
+            .map(|s| {
+                (
+                    s.workflow_step,
+                    s.workflow_execution_state,
+                    s.workflow_execution_id,
+                    s.workflow_run_index,
+                    s.workflow_step_progress,
+                )
+            })
+            .unwrap_or((None, None, None, None, None));
         let status = SessionStatus {
             chat_session_id: chat_session_id.to_string(),
             worktree_id: worktree_path.clone(),
@@ -2280,6 +2288,9 @@ pub(crate) fn notify_status_transition<R: tauri::Runtime>(
             last_activity_at: current_timestamp(),
             workflow_step: wf_step,
             workflow_execution_state: wf_state,
+            workflow_execution_id: wf_execution_id,
+            workflow_run_index: wf_run_index,
+            workflow_step_progress: wf_step_progress,
         };
         let changes = center.update_session(status);
         let broadcaster = app

--- a/src-tauri/src/usecase/agent_session/status.rs
+++ b/src-tauri/src/usecase/agent_session/status.rs
@@ -6,7 +6,7 @@ use crate::domain::workflow::status_aggregation::{
 use crate::usecase::agent_session::session::SessionState;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -136,6 +136,14 @@ struct WorkflowStepSessionStatusInput {
     progress: StepProgress,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingWorkflowStepSessionStatus {
+    worktree_path: String,
+    execution_id: String,
+    workflow_execution_state: String,
+    input: WorkflowStepSessionStatusInput,
+}
+
 /// 各 worktree の「アクティブな Workflow 実行」の集約用スナップショット。
 /// Workspace 集約に Workflow 自体の状態（WaitingApproval 等）を反映するために保持する。
 /// 現状 1 worktree = 1 active run 前提のためフラット HashMap で管理する。
@@ -178,6 +186,7 @@ pub struct AgentStatusCenter {
     workspaces: RwLock<HashMap<String, WorkspaceStatus>>,
     workflow_steps: RwLock<HashMap<WorkflowStepKey, WorkflowStatusEntry>>,
     workflow_step_baselines: RwLock<HashMap<WorkflowStepKey, RepresentativeStatus>>,
+    pending_workflow_step_sessions: RwLock<HashMap<String, PendingWorkflowStepSessionStatus>>,
     workflow_status_version: AtomicU64,
     /// key: worktree_path（= worktree_id と同値で運用）
     workflows: RwLock<HashMap<String, WorkflowAggSnapshot>>,
@@ -190,6 +199,7 @@ impl AgentStatusCenter {
             workspaces: RwLock::new(HashMap::new()),
             workflow_steps: RwLock::new(HashMap::new()),
             workflow_step_baselines: RwLock::new(HashMap::new()),
+            pending_workflow_step_sessions: RwLock::new(HashMap::new()),
             workflow_status_version: AtomicU64::new(0),
             workflows: RwLock::new(HashMap::new()),
         }
@@ -588,19 +598,96 @@ impl AgentStatusCenter {
             .collect()
     }
 
+    fn apply_workflow_step_session_status(
+        status: &mut SessionStatus,
+        execution_id: &str,
+        workflow_execution_state: &str,
+        input: &WorkflowStepSessionStatusInput,
+    ) {
+        status.workflow_step = Some(input.step_name.clone());
+        status.workflow_execution_state = Some(workflow_execution_state.to_string());
+        status.workflow_execution_id = Some(execution_id.to_string());
+        status.workflow_run_index = input.run_index;
+        status.workflow_step_progress = Some(input.progress);
+    }
+
+    fn clear_workflow_step_session_status(status: &mut SessionStatus) {
+        status.workflow_step = None;
+        status.workflow_execution_state = None;
+        status.workflow_execution_id = None;
+        status.workflow_run_index = None;
+        status.workflow_step_progress = None;
+    }
+
+    fn apply_pending_workflow_step_session_status(&self, status: &mut SessionStatus) {
+        let pending = {
+            let mut pending = self.pending_workflow_step_sessions.write();
+            pending.remove(&status.chat_session_id)
+        };
+        let Some(pending) = pending else {
+            return;
+        };
+        if pending.worktree_path != status.worktree_path || status.workflow_execution_id.is_some() {
+            return;
+        }
+        Self::apply_workflow_step_session_status(
+            status,
+            &pending.execution_id,
+            &pending.workflow_execution_state,
+            &pending.input,
+        );
+    }
+
+    fn update_pending_workflow_step_session_statuses(
+        &self,
+        worktree_path: &str,
+        execution_id: &str,
+        workflow_execution_state: &str,
+        inputs: &HashMap<String, WorkflowStepSessionStatusInput>,
+        existing_session_ids: &HashSet<String>,
+    ) {
+        let mut pending = self.pending_workflow_step_sessions.write();
+        pending.retain(|session_id, pending| {
+            !(pending.worktree_path == worktree_path
+                && pending.execution_id == execution_id
+                && !inputs.contains_key(session_id))
+        });
+        for (session_id, input) in inputs {
+            if existing_session_ids.contains(session_id) {
+                if pending.get(session_id).is_some_and(|pending| {
+                    pending.worktree_path == worktree_path && pending.execution_id == execution_id
+                }) {
+                    pending.remove(session_id);
+                }
+                continue;
+            }
+            pending.insert(
+                session_id.clone(),
+                PendingWorkflowStepSessionStatus {
+                    worktree_path: worktree_path.to_string(),
+                    execution_id: execution_id.to_string(),
+                    workflow_execution_state: workflow_execution_state.to_string(),
+                    input: input.clone(),
+                },
+            );
+        }
+    }
+
     /// Session 状態を更新する。
     /// 1. dedup（前回と等価なら何もしない）
     /// 2. sessions マップに反映
     /// 3. 同 worktree の全 SessionStatus から WorkspaceStatus を再計算
     /// 4. 呼び出し側が transport 層で通知できるよう変更結果を返す
-    pub fn update_session(&self, status: SessionStatus) -> AgentStatusChanges {
+    pub fn update_session(&self, mut status: SessionStatus) -> AgentStatusChanges {
+        let prev = self.sessions.read().get(&status.chat_session_id).cloned();
+        if prev.is_none() {
+            self.apply_pending_workflow_step_session_status(&mut status);
+        }
+
         // 1. dedup
-        {
-            let prev = self.sessions.read().get(&status.chat_session_id).cloned();
-            if let Some(prev) = prev {
-                if Self::is_session_state_equivalent(&prev, &status) {
-                    return AgentStatusChanges::default();
-                }
+        if let Some(prev) = prev {
+            if Self::is_session_state_equivalent(&prev, &status) {
+                return AgentStatusChanges::default();
             }
         }
 
@@ -727,24 +814,34 @@ impl AgentStatusCenter {
             .collect::<HashMap<_, _>>();
 
         let mut changes = Vec::new();
+        let sessions = self.list_sessions();
+        let existing_session_ids = sessions
+            .iter()
+            .filter(|status| status.worktree_path == worktree_path)
+            .map(|status| status.chat_session_id.clone())
+            .collect::<HashSet<_>>();
+        self.update_pending_workflow_step_session_statuses(
+            worktree_path,
+            execution_id,
+            workflow_execution_state,
+            &inputs,
+            &existing_session_ids,
+        );
 
-        for status in self.list_sessions() {
+        for status in sessions {
             if status.worktree_path != worktree_path {
                 continue;
             }
             let mut updated = status;
             if let Some(input) = inputs.get(&updated.chat_session_id) {
-                updated.workflow_step = Some(input.step_name.clone());
-                updated.workflow_execution_state = Some(workflow_execution_state.to_string());
-                updated.workflow_execution_id = Some(execution_id.to_string());
-                updated.workflow_run_index = input.run_index;
-                updated.workflow_step_progress = Some(input.progress);
+                Self::apply_workflow_step_session_status(
+                    &mut updated,
+                    execution_id,
+                    workflow_execution_state,
+                    input,
+                );
             } else if updated.workflow_execution_id.as_deref() == Some(execution_id) {
-                updated.workflow_step = None;
-                updated.workflow_execution_state = None;
-                updated.workflow_execution_id = None;
-                updated.workflow_run_index = None;
-                updated.workflow_step_progress = None;
+                Self::clear_workflow_step_session_status(&mut updated);
             } else {
                 continue;
             }
@@ -1684,6 +1781,88 @@ mod tests {
         assert_eq!(changes.workflow_steps[0].representative, None);
         assert!(changes.workflow_steps[0].version > 0);
         assert!(center.list_workflow_step_statuses().is_empty());
+    }
+
+    #[test]
+    fn pending_workflow_projection_applies_to_first_session_status() {
+        let center = mk_center();
+        let sync_changes = center.sync_workflow_step_session_statuses(
+            "/repo",
+            "exec-1",
+            "running",
+            vec![projection(
+                Some("step-late"),
+                "build",
+                Some(2),
+                RepresentativeStatus::Running,
+                StepProgress::Running,
+            )],
+        );
+        assert!(sync_changes.is_empty());
+
+        let mut initial = mk_session(
+            "step-late",
+            "/repo",
+            TurnPhase::Streaming,
+            SessionState::Active,
+        );
+        initial.last_activity_at = 10.0;
+        let changes = center.update_session(initial);
+
+        let session = changes.session.expect("session change emitted");
+        assert_eq!(session.workflow_step.as_deref(), Some("build"));
+        assert_eq!(session.workflow_execution_state.as_deref(), Some("running"));
+        assert_eq!(session.workflow_execution_id.as_deref(), Some("exec-1"));
+        assert_eq!(session.workflow_run_index, Some(2));
+        assert_eq!(session.workflow_step_progress, Some(StepProgress::Running));
+        assert_eq!(changes.workflow_steps.len(), 1);
+        assert_eq!(
+            changes.workflow_steps[0].representative.as_deref(),
+            Some(RepresentativeStatus::Running.as_str())
+        );
+        assert_eq!(
+            changes.workflow_steps[0].workflow_representative.as_deref(),
+            Some(RepresentativeStatus::Running.as_str())
+        );
+        assert_eq!(
+            center
+                .get_session("step-late")
+                .expect("session registered")
+                .workflow_execution_id
+                .as_deref(),
+            Some("exec-1")
+        );
+    }
+
+    #[test]
+    fn pending_workflow_projection_is_removed_when_snapshot_no_longer_references_session() {
+        let center = mk_center();
+        center.sync_workflow_step_session_statuses(
+            "/repo",
+            "exec-1",
+            "running",
+            vec![projection(
+                Some("step-late"),
+                "build",
+                Some(2),
+                RepresentativeStatus::Queued,
+                StepProgress::Queued,
+            )],
+        );
+        center.sync_workflow_step_session_statuses("/repo", "exec-1", "running", Vec::new());
+
+        let changes = center.update_session(mk_session(
+            "step-late",
+            "/repo",
+            TurnPhase::Idle,
+            SessionState::Done,
+        ));
+
+        let session = changes.session.expect("session change emitted");
+        assert_eq!(session.workflow_step, None);
+        assert_eq!(session.workflow_execution_state, None);
+        assert_eq!(session.workflow_execution_id, None);
+        assert!(changes.workflow_steps.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/usecase/agent_session/status.rs
+++ b/src-tauri/src/usecase/agent_session/status.rs
@@ -1,7 +1,13 @@
+use crate::domain::workflow::services::session_projection::StepSessionProjection;
+use crate::domain::workflow::status_aggregation::{
+    aggregate_representative_statuses, session_result, RepresentativeStatus, SessionActivity,
+    StepProgress,
+};
 use crate::usecase::agent_session::session::SessionState;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -10,6 +16,17 @@ pub enum AgentState {
     Done,
     Error,
     Waiting,
+}
+
+impl From<AgentState> for SessionActivity {
+    fn from(value: AgentState) -> Self {
+        match value {
+            AgentState::Running => Self::Running,
+            AgentState::Done => Self::Done,
+            AgentState::Error => Self::Error,
+            AgentState::Waiting => Self::Waiting,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -35,6 +52,12 @@ pub struct SessionStatus {
     pub last_activity_at: f64,
     pub workflow_step: Option<String>,
     pub workflow_execution_state: Option<String>,
+    #[serde(skip_serializing)]
+    pub workflow_execution_id: Option<String>,
+    #[serde(skip_serializing)]
+    pub workflow_run_index: Option<u32>,
+    #[serde(skip_serializing)]
+    pub workflow_step_progress: Option<StepProgress>,
 }
 
 /// `TurnPhase` は `agent_sdk` 側で `Copy + Serialize` だが `Eq` を持たないため、
@@ -80,6 +103,39 @@ pub struct WorkspaceStatus {
     pub last_activity_at: f64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct WorkflowStepKey {
+    worktree_path: String,
+    execution_id: String,
+    step_name: String,
+    run_index: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowStepStatusChange {
+    pub worktree_path: String,
+    pub execution_id: String,
+    pub step_name: String,
+    pub run_index: Option<u32>,
+    pub representative: Option<String>,
+    pub workflow_representative: Option<String>,
+    pub version: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WorkflowStatusEntry {
+    representative: RepresentativeStatus,
+    version: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkflowStepSessionStatusInput {
+    step_name: String,
+    run_index: Option<u32>,
+    progress: StepProgress,
+}
+
 /// 各 worktree の「アクティブな Workflow 実行」の集約用スナップショット。
 /// Workspace 集約に Workflow 自体の状態（WaitingApproval 等）を反映するために保持する。
 /// 現状 1 worktree = 1 active run 前提のためフラット HashMap で管理する。
@@ -95,11 +151,15 @@ pub struct AgentStatusChanges {
     pub session: Option<SessionStatus>,
     pub workspace: Option<WorkspaceStatus>,
     pub agent_state: Option<AgentStateChange>,
+    pub workflow_steps: Vec<WorkflowStepStatusChange>,
 }
 
 impl AgentStatusChanges {
     pub fn is_empty(&self) -> bool {
-        self.session.is_none() && self.workspace.is_none() && self.agent_state.is_none()
+        self.session.is_none()
+            && self.workspace.is_none()
+            && self.agent_state.is_none()
+            && self.workflow_steps.is_empty()
     }
 }
 
@@ -116,6 +176,9 @@ pub struct AgentStateChange {
 pub struct AgentStatusCenter {
     sessions: RwLock<HashMap<String, SessionStatus>>,
     workspaces: RwLock<HashMap<String, WorkspaceStatus>>,
+    workflow_steps: RwLock<HashMap<WorkflowStepKey, WorkflowStatusEntry>>,
+    workflow_step_baselines: RwLock<HashMap<WorkflowStepKey, RepresentativeStatus>>,
+    workflow_status_version: AtomicU64,
     /// key: worktree_path（= worktree_id と同値で運用）
     workflows: RwLock<HashMap<String, WorkflowAggSnapshot>>,
 }
@@ -125,6 +188,9 @@ impl AgentStatusCenter {
         Self {
             sessions: RwLock::new(HashMap::new()),
             workspaces: RwLock::new(HashMap::new()),
+            workflow_steps: RwLock::new(HashMap::new()),
+            workflow_step_baselines: RwLock::new(HashMap::new()),
+            workflow_status_version: AtomicU64::new(0),
             workflows: RwLock::new(HashMap::new()),
         }
     }
@@ -172,6 +238,9 @@ impl AgentStatusCenter {
             && a.pending_permission == b.pending_permission
             && a.workflow_step == b.workflow_step
             && a.workflow_execution_state == b.workflow_execution_state
+            && a.workflow_execution_id == b.workflow_execution_id
+            && a.workflow_run_index == b.workflow_run_index
+            && a.workflow_step_progress == b.workflow_step_progress
     }
 
     fn is_workspace_state_equivalent(a: &WorkspaceStatus, b: &WorkspaceStatus) -> bool {
@@ -184,8 +253,8 @@ impl AgentStatusCenter {
             && a.session_count == b.session_count
     }
 
-    /// Workspace の集約規則: Error > Waiting > Running > Done。
-    /// `SessionState::Closed`（タブを閉じた Session）はオープン中でないため集約対象から除外する。
+    /// Workspace の集約規則: Running > Error > Waiting > Done。
+    /// Closed/Archived Session はオープン中でないため集約対象から除外する。
     /// 全てフィルタされて 0 件になった場合は `aggregated_state: Done` / `session_count: 0` で表現する
     /// （= 集約対象なし）。
     ///
@@ -202,7 +271,7 @@ impl AgentStatusCenter {
         let open_sessions: Vec<&SessionStatus> = sessions
             .iter()
             .copied()
-            .filter(|s| s.session_state != SessionState::Closed)
+            .filter(|s| Self::is_live_session_state(&s.session_state))
             .collect();
 
         let mut running_count = 0usize;
@@ -227,12 +296,12 @@ impl AgentStatusCenter {
             }
         }
 
-        let aggregated_state = if error_count > 0 {
+        let aggregated_state = if running_count > 0 {
+            AgentState::Running
+        } else if error_count > 0 {
             AgentState::Error
         } else if waiting_count > 0 {
             AgentState::Waiting
-        } else if running_count > 0 {
-            AgentState::Running
         } else {
             AgentState::Done
         };
@@ -249,6 +318,10 @@ impl AgentStatusCenter {
         }
     }
 
+    fn is_live_session_state(state: &SessionState) -> bool {
+        !matches!(state, SessionState::Closed | SessionState::Archived)
+    }
+
     /// Workspace 集約時の `last_activity_at` は、Open session と集約対象 Workflow の最大値にする。
     /// `agent_state=None` の Workflow snapshot（aborted 等）は集約にも timestamp にも寄与させない。
     fn aggregate_with_workflow_snapshot(
@@ -261,7 +334,7 @@ impl AgentStatusCenter {
         let open_session_last_activity_at = sessions
             .iter()
             .copied()
-            .filter(|s| s.session_state != SessionState::Closed)
+            .filter(|s| Self::is_live_session_state(&s.session_state))
             .map(|s| s.last_activity_at)
             .reduce(f64::max);
         let workflow_last_activity_at = workflow_snapshot
@@ -286,6 +359,233 @@ impl AgentStatusCenter {
     /// 当該 worktree でアクティブな Workflow の集約用 snapshot を取り出す。
     fn workflow_agg_snapshot_for(&self, worktree_path: &str) -> Option<WorkflowAggSnapshot> {
         self.workflows.read().get(worktree_path).cloned()
+    }
+
+    fn session_workflow_step_key(status: &SessionStatus) -> Option<WorkflowStepKey> {
+        Some(WorkflowStepKey {
+            worktree_path: status.worktree_path.clone(),
+            execution_id: status.workflow_execution_id.clone()?,
+            step_name: status.workflow_step.clone()?,
+            run_index: status.workflow_run_index,
+        })
+    }
+
+    fn next_workflow_status_version(&self) -> u64 {
+        self.workflow_status_version.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    fn change_for_step(
+        key: &WorkflowStepKey,
+        representative: Option<RepresentativeStatus>,
+        workflow_representative: Option<RepresentativeStatus>,
+        version: u64,
+    ) -> WorkflowStepStatusChange {
+        WorkflowStepStatusChange {
+            worktree_path: key.worktree_path.clone(),
+            execution_id: key.execution_id.clone(),
+            step_name: key.step_name.clone(),
+            run_index: key.run_index,
+            representative: representative.map(|status| status.as_str().to_string()),
+            workflow_representative: workflow_representative
+                .map(|status| status.as_str().to_string()),
+            version,
+        }
+    }
+
+    fn is_same_workflow(left: &WorkflowStepKey, right: &WorkflowStepKey) -> bool {
+        left.worktree_path == right.worktree_path && left.execution_id == right.execution_id
+    }
+
+    fn workflow_has_live_status(
+        workflow_key: &WorkflowStepKey,
+        live_steps: &HashMap<WorkflowStepKey, WorkflowStatusEntry>,
+    ) -> bool {
+        live_steps
+            .keys()
+            .any(|key| Self::is_same_workflow(key, workflow_key))
+    }
+
+    fn workflow_representative_for_key(
+        workflow_key: &WorkflowStepKey,
+        live_steps: &HashMap<WorkflowStepKey, WorkflowStatusEntry>,
+        baselines: &HashMap<WorkflowStepKey, RepresentativeStatus>,
+    ) -> Option<RepresentativeStatus> {
+        if !Self::workflow_has_live_status(workflow_key, live_steps) {
+            return None;
+        }
+
+        let baseline_statuses = baselines
+            .iter()
+            .filter(|(key, _)| Self::is_same_workflow(key, workflow_key))
+            .map(|(key, baseline)| {
+                live_steps
+                    .get(key)
+                    .map(|entry| entry.representative)
+                    .unwrap_or(*baseline)
+            });
+        let live_only_statuses = live_steps
+            .iter()
+            .filter(|(key, _)| {
+                Self::is_same_workflow(key, workflow_key) && !baselines.contains_key(*key)
+            })
+            .map(|(_, entry)| entry.representative);
+
+        aggregate_representative_statuses(baseline_statuses.chain(live_only_statuses))
+    }
+
+    fn update_workflow_step_baselines(
+        &self,
+        worktree_path: &str,
+        execution_id: &str,
+        projections: &[StepSessionProjection],
+    ) -> Vec<WorkflowStepStatusChange> {
+        let mut grouped: HashMap<WorkflowStepKey, Vec<RepresentativeStatus>> = HashMap::new();
+        for projection in projections {
+            let key = WorkflowStepKey {
+                worktree_path: worktree_path.to_string(),
+                execution_id: execution_id.to_string(),
+                step_name: projection.group_step_name.clone(),
+                run_index: projection.group_run_index,
+            };
+            grouped
+                .entry(key)
+                .or_default()
+                .push(projection.representative);
+        }
+        let next_baselines = grouped
+            .into_iter()
+            .filter_map(|(key, statuses)| {
+                aggregate_representative_statuses(statuses)
+                    .map(|representative| (key, representative))
+            })
+            .collect::<HashMap<_, _>>();
+
+        let changed = {
+            let mut baselines = self.workflow_step_baselines.write();
+            let previous_keys = baselines
+                .keys()
+                .filter(|key| {
+                    key.worktree_path == worktree_path && key.execution_id == execution_id
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            let mut changed = false;
+            for key in previous_keys {
+                if next_baselines.contains_key(&key) {
+                    continue;
+                }
+                baselines.remove(&key);
+                changed = true;
+            }
+            for (key, representative) in next_baselines {
+                if baselines.insert(key, representative) != Some(representative) {
+                    changed = true;
+                }
+            }
+            changed
+        };
+
+        if !changed {
+            return Vec::new();
+        }
+
+        let version = self.next_workflow_status_version();
+        let live_steps = self.workflow_steps.read();
+        let baselines = self.workflow_step_baselines.read();
+        live_steps
+            .iter()
+            .filter(|(key, _)| {
+                key.worktree_path == worktree_path && key.execution_id == execution_id
+            })
+            .map(|(key, entry)| {
+                let workflow_representative =
+                    Self::workflow_representative_for_key(key, &live_steps, &baselines);
+                Self::change_for_step(
+                    key,
+                    Some(entry.representative),
+                    workflow_representative,
+                    version,
+                )
+            })
+            .collect()
+    }
+
+    fn reaggregate_workflow_steps_for_worktree(
+        &self,
+        worktree_path: &str,
+    ) -> Vec<WorkflowStepStatusChange> {
+        let mut grouped: HashMap<WorkflowStepKey, Vec<RepresentativeStatus>> = HashMap::new();
+        {
+            let sessions = self.sessions.read();
+            for status in sessions.values() {
+                if status.worktree_path != worktree_path {
+                    continue;
+                }
+                if !Self::is_live_session_state(&status.session_state) {
+                    continue;
+                }
+                let Some(key) = Self::session_workflow_step_key(status) else {
+                    continue;
+                };
+                let Some(step_progress) = status.workflow_step_progress else {
+                    continue;
+                };
+                grouped.entry(key).or_default().push(session_result(
+                    step_progress,
+                    SessionActivity::from(status.agent_state.clone()),
+                ));
+            }
+        }
+
+        let next_steps = grouped
+            .into_iter()
+            .filter_map(|(key, statuses)| {
+                aggregate_representative_statuses(statuses)
+                    .map(|representative| (key, representative))
+            })
+            .collect::<HashMap<_, _>>();
+
+        let mut changed_steps = Vec::new();
+        let version = self.next_workflow_status_version();
+        let mut step_statuses = self.workflow_steps.write();
+
+        let previous_step_keys = step_statuses
+            .keys()
+            .filter(|key| key.worktree_path == worktree_path)
+            .cloned()
+            .collect::<Vec<_>>();
+        for key in previous_step_keys {
+            if next_steps.contains_key(&key) {
+                continue;
+            }
+            step_statuses.remove(&key);
+            changed_steps.push((key, None));
+        }
+
+        for (key, representative) in next_steps {
+            let previous = step_statuses
+                .insert(
+                    key.clone(),
+                    WorkflowStatusEntry {
+                        representative,
+                        version,
+                    },
+                )
+                .map(|entry| entry.representative);
+            if previous != Some(representative) {
+                changed_steps.push((key, Some(representative)));
+            }
+        }
+
+        let baselines = self.workflow_step_baselines.read();
+        changed_steps
+            .into_iter()
+            .map(|(key, representative)| {
+                let workflow_representative =
+                    Self::workflow_representative_for_key(&key, &step_statuses, &baselines);
+                Self::change_for_step(&key, representative, workflow_representative, version)
+            })
+            .collect()
     }
 
     /// Session 状態を更新する。
@@ -344,6 +644,7 @@ impl AgentStatusCenter {
             workspaces.insert(worktree_id.clone(), new_workspace.clone());
             changed
         };
+        let workflow_steps = self.reaggregate_workflow_steps_for_worktree(&worktree_path);
 
         AgentStatusChanges {
             session: Some(status),
@@ -355,6 +656,7 @@ impl AgentStatusCenter {
                 session_id: Some(chat_session_id),
                 pty_id,
             }),
+            workflow_steps,
         }
     }
 
@@ -398,6 +700,69 @@ impl AgentStatusCenter {
             workspace: self.reaggregate_workspace(worktree_path, last_activity_at),
             ..Default::default()
         }
+    }
+
+    pub fn sync_workflow_step_session_statuses(
+        &self,
+        worktree_path: &str,
+        execution_id: &str,
+        workflow_execution_state: &str,
+        projections: Vec<StepSessionProjection>,
+    ) -> Vec<AgentStatusChanges> {
+        let baseline_changes =
+            self.update_workflow_step_baselines(worktree_path, execution_id, &projections);
+        let inputs = projections
+            .into_iter()
+            .filter_map(|projection| {
+                let session_id = projection.session_id?;
+                Some((
+                    session_id,
+                    WorkflowStepSessionStatusInput {
+                        step_name: projection.group_step_name,
+                        run_index: projection.group_run_index,
+                        progress: projection.progress,
+                    },
+                ))
+            })
+            .collect::<HashMap<_, _>>();
+
+        let mut changes = Vec::new();
+
+        for status in self.list_sessions() {
+            if status.worktree_path != worktree_path {
+                continue;
+            }
+            let mut updated = status;
+            if let Some(input) = inputs.get(&updated.chat_session_id) {
+                updated.workflow_step = Some(input.step_name.clone());
+                updated.workflow_execution_state = Some(workflow_execution_state.to_string());
+                updated.workflow_execution_id = Some(execution_id.to_string());
+                updated.workflow_run_index = input.run_index;
+                updated.workflow_step_progress = Some(input.progress);
+            } else if updated.workflow_execution_id.as_deref() == Some(execution_id) {
+                updated.workflow_step = None;
+                updated.workflow_execution_state = None;
+                updated.workflow_execution_id = None;
+                updated.workflow_run_index = None;
+                updated.workflow_step_progress = None;
+            } else {
+                continue;
+            }
+
+            let update_changes = self.update_session(updated);
+            if !update_changes.is_empty() {
+                changes.push(update_changes);
+            }
+        }
+
+        if !baseline_changes.is_empty() {
+            changes.push(AgentStatusChanges {
+                workflow_steps: baseline_changes,
+                ..Default::default()
+            });
+        }
+
+        changes
     }
 
     /// 当該 worktree の WorkspaceStatus を再集約し、前回と差分があれば
@@ -481,8 +846,8 @@ impl AgentStatusCenter {
 
     /// SessionStore からの `SessionState` 変更通知を受け取り、保持している
     /// `SessionStatus` の `session_state` を最新化した上で再集約する。
-    /// Closed への遷移は `aggregate` 段階で集約対象から外れ、Closed → 他状態の
-    /// 復帰では再び集約対象に戻る。
+    /// Closed/Archived への遷移は `aggregate` 段階で集約対象から外れ、
+    /// 復帰時は再び集約対象に戻る。
     pub fn on_session_state_changed(
         &self,
         chat_session_id: &str,
@@ -513,7 +878,10 @@ impl AgentStatusCenter {
         if existing.session_state == new_state {
             return None;
         }
-        let normalize_to_idle = matches!(new_state, SessionState::Closed | SessionState::Idle);
+        let normalize_to_idle = matches!(
+            new_state,
+            SessionState::Closed | SessionState::Archived | SessionState::Idle
+        );
         let (turn_phase_repr, pending_permission) = if normalize_to_idle {
             (TurnPhaseRepr::Idle, false)
         } else {
@@ -546,6 +914,24 @@ impl AgentStatusCenter {
     pub fn list_sessions(&self) -> Vec<SessionStatus> {
         self.sessions.read().values().cloned().collect()
     }
+
+    pub fn list_workflow_step_statuses(&self) -> Vec<WorkflowStepStatusChange> {
+        let step_statuses = self.workflow_steps.read();
+        let baselines = self.workflow_step_baselines.read();
+        step_statuses
+            .iter()
+            .map(|(key, entry)| {
+                let workflow_representative =
+                    Self::workflow_representative_for_key(key, &step_statuses, &baselines);
+                Self::change_for_step(
+                    key,
+                    Some(entry.representative),
+                    workflow_representative,
+                    entry.version,
+                )
+            })
+            .collect()
+    }
 }
 
 pub fn current_timestamp() -> f64 {
@@ -575,6 +961,45 @@ mod tests {
             last_activity_at: 0.0,
             workflow_step: None,
             workflow_execution_state: None,
+            workflow_execution_id: None,
+            workflow_run_index: None,
+            workflow_step_progress: None,
+        }
+    }
+
+    fn workflow_session(
+        id: &str,
+        step: &str,
+        run_index: Option<u32>,
+        progress: StepProgress,
+        agent_state: AgentState,
+    ) -> SessionStatus {
+        let mut session = mk_session("unused", "/repo", TurnPhase::Idle, SessionState::Done);
+        session.chat_session_id = id.to_string();
+        session.agent_state = agent_state;
+        session.workflow_execution_id = Some("exec-1".to_string());
+        session.workflow_step = Some(step.to_string());
+        session.workflow_run_index = run_index;
+        session.workflow_step_progress = Some(progress);
+        session
+    }
+
+    fn projection(
+        session_id: Option<&str>,
+        step_name: &str,
+        run_index: Option<u32>,
+        representative: RepresentativeStatus,
+        progress: StepProgress,
+    ) -> StepSessionProjection {
+        StepSessionProjection {
+            session_id: session_id.map(str::to_string),
+            step_name: step_name.to_string(),
+            run_index,
+            group_step_name: step_name.to_string(),
+            group_run_index: run_index,
+            progress,
+            representative,
+            order: 0,
         }
     }
 
@@ -674,7 +1099,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_waiting_dominates_running() {
+    fn aggregate_running_dominates_waiting() {
         let s1 = mk_session("a", "/repo", TurnPhase::Streaming, SessionState::Active);
         let s2 = mk_session(
             "b",
@@ -683,7 +1108,7 @@ mod tests {
             SessionState::Active,
         );
         let ws = AgentStatusCenter::aggregate("/repo", "/repo", &[&s1, &s2], None, 0.0);
-        assert_eq!(ws.aggregated_state, AgentState::Waiting);
+        assert_eq!(ws.aggregated_state, AgentState::Running);
         assert_eq!(ws.waiting_count, 1);
         assert_eq!(ws.running_count, 1);
     }
@@ -705,6 +1130,25 @@ mod tests {
             None,
             0.0,
         );
+        assert_eq!(ws.aggregated_state, AgentState::Done);
+        assert_eq!(ws.error_count, 0);
+        assert_eq!(ws.session_count, 1);
+    }
+
+    #[test]
+    fn aggregate_excludes_archived_sessions() {
+        let open_done = mk_session("a", "/repo", TurnPhase::Idle, SessionState::Done);
+        let mut archived_with_error_history =
+            mk_session("b", "/repo", TurnPhase::Idle, SessionState::Archived);
+        archived_with_error_history.agent_state = AgentState::Error;
+        let ws = AgentStatusCenter::aggregate(
+            "/repo",
+            "/repo",
+            &[&open_done, &archived_with_error_history],
+            None,
+            0.0,
+        );
+
         assert_eq!(ws.aggregated_state, AgentState::Done);
         assert_eq!(ws.error_count, 0);
         assert_eq!(ws.session_count, 1);
@@ -740,7 +1184,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_error_dominates_all() {
+    fn aggregate_running_dominates_error_and_waiting() {
         let s1 = mk_session("a", "/repo", TurnPhase::Streaming, SessionState::Active);
         let s2 = mk_session(
             "b",
@@ -750,7 +1194,7 @@ mod tests {
         );
         let s3 = mk_session("c", "/repo", TurnPhase::Idle, SessionState::Error);
         let ws = AgentStatusCenter::aggregate("/repo", "/repo", &[&s1, &s2, &s3], None, 0.0);
-        assert_eq!(ws.aggregated_state, AgentState::Error);
+        assert_eq!(ws.aggregated_state, AgentState::Running);
         assert_eq!(ws.error_count, 1);
         assert_eq!(ws.waiting_count, 1);
         assert_eq!(ws.running_count, 1);
@@ -794,6 +1238,25 @@ mod tests {
             let back = TurnPhase::from(repr);
             assert_eq!(tp, back);
         }
+    }
+
+    #[test]
+    fn session_status_serialization_omits_internal_workflow_aggregation_inputs() {
+        let status = workflow_session(
+            "step-a",
+            "build",
+            Some(3),
+            StepProgress::Running,
+            AgentState::Running,
+        );
+
+        let value = serde_json::to_value(status).expect("session status serializes");
+
+        assert!(value.get("workflow_step").is_some());
+        assert!(value.get("workflow_execution_state").is_some());
+        assert!(value.get("workflow_execution_id").is_none());
+        assert!(value.get("workflow_run_index").is_none());
+        assert!(value.get("workflow_step_progress").is_none());
     }
 
     // ---- on_session_state_changed core (build_state_transition) ----
@@ -986,12 +1449,12 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_with_workflow_waiting_outranks_running_sessions() {
-        // Session=Running、Workflow=Waiting → Workspace=Waiting（Waiting 優先）
+    fn aggregate_with_running_session_outranks_workflow_waiting() {
+        // Session=Running、Workflow=Waiting → Workspace=Running
         let s = mk_session("a", "/repo", TurnPhase::Streaming, SessionState::Active);
         let ws =
             AgentStatusCenter::aggregate("/repo", "/repo", &[&s], Some(AgentState::Waiting), 0.0);
-        assert_eq!(ws.aggregated_state, AgentState::Waiting);
+        assert_eq!(ws.aggregated_state, AgentState::Running);
         assert_eq!(ws.running_count, 1);
         assert_eq!(ws.waiting_count, 1);
         assert_eq!(ws.session_count, 1);
@@ -1139,6 +1602,23 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_excludes_archived_session_timestamp() {
+        let center = mk_center();
+        let mut open_session = mk_session("open", "/repo", TurnPhase::Idle, SessionState::Done);
+        open_session.last_activity_at = 80.0;
+        center.update_session(open_session);
+
+        let mut archived_session =
+            mk_session("archived", "/repo", TurnPhase::Idle, SessionState::Archived);
+        archived_session.last_activity_at = 200.0;
+        center.update_session(archived_session);
+
+        let ws = center.get_workspace("/repo").expect("workspace tracked");
+        assert_eq!(ws.session_count, 1);
+        assert_eq!(ws.last_activity_at, 80.0);
+    }
+
+    #[test]
     fn update_workflow_snapshot_without_any_sessions_creates_workspace_entry() {
         // Session が一切登録されていない worktree でも Workflow 状態から WorkspaceStatus を作る。
         let center = mk_center();
@@ -1152,5 +1632,193 @@ mod tests {
         assert_eq!(ws.session_count, 0);
         assert_eq!(ws.worktree_id, "/repo");
         assert_eq!(ws.worktree_path, "/repo");
+    }
+
+    #[test]
+    fn workflow_step_representative_updates_when_session_starts_streaming() {
+        let center = mk_center();
+        let queued = workflow_session(
+            "step-a",
+            "build",
+            Some(1),
+            StepProgress::Queued,
+            AgentState::Done,
+        );
+        let initial = center.update_session(queued);
+        assert_eq!(
+            initial.workflow_steps[0].representative.as_deref(),
+            Some(RepresentativeStatus::Queued.as_str())
+        );
+        let initial_version = initial.workflow_steps[0].version;
+
+        let running = workflow_session(
+            "step-a",
+            "build",
+            Some(1),
+            StepProgress::Queued,
+            AgentState::Running,
+        );
+        let changes = center.update_session(running);
+
+        assert_eq!(
+            changes.workflow_steps[0].representative.as_deref(),
+            Some(RepresentativeStatus::Running.as_str())
+        );
+        assert!(changes.workflow_steps[0].version > initial_version);
+    }
+
+    #[test]
+    fn workflow_step_representative_is_removed_when_session_is_archived() {
+        let center = mk_center();
+        center.update_session(workflow_session(
+            "step-a",
+            "build",
+            Some(1),
+            StepProgress::Queued,
+            AgentState::Done,
+        ));
+
+        let changes = center.on_session_state_changed("step-a", SessionState::Archived);
+
+        assert_eq!(changes.workflow_steps.len(), 1);
+        assert_eq!(changes.workflow_steps[0].representative, None);
+        assert!(changes.workflow_steps[0].version > 0);
+        assert!(center.list_workflow_step_statuses().is_empty());
+    }
+
+    #[test]
+    fn parallel_step_running_session_dominates_stopped_sessions() {
+        let center = mk_center();
+        center.update_session(workflow_session(
+            "step-a",
+            "parallel-review",
+            Some(1),
+            StepProgress::Completed,
+            AgentState::Done,
+        ));
+        let changes = center.update_session(workflow_session(
+            "step-b",
+            "parallel-review",
+            Some(1),
+            StepProgress::Completed,
+            AgentState::Running,
+        ));
+
+        assert_eq!(
+            changes.workflow_steps[0].representative.as_deref(),
+            Some(RepresentativeStatus::Running.as_str())
+        );
+    }
+
+    #[test]
+    fn list_workflow_step_statuses_returns_step_and_workflow_representatives() {
+        let center = mk_center();
+        center.update_session(workflow_session(
+            "step-a",
+            "plan",
+            Some(1),
+            StepProgress::Completed,
+            AgentState::Done,
+        ));
+        let changes = center.update_session(workflow_session(
+            "step-b",
+            "test",
+            Some(1),
+            StepProgress::WaitingApproval,
+            AgentState::Error,
+        ));
+
+        assert_eq!(
+            changes.workflow_steps[0].representative.as_deref(),
+            Some(RepresentativeStatus::Error.as_str())
+        );
+
+        let listed = center.list_workflow_step_statuses();
+        assert_eq!(listed.len(), 2);
+        assert!(listed.iter().any(|change| {
+            change.step_name == "plan"
+                && change.representative.as_deref()
+                    == Some(RepresentativeStatus::Completed.as_str())
+        }));
+        assert!(listed.iter().any(|change| {
+            change.step_name == "test"
+                && change.representative.as_deref() == Some(RepresentativeStatus::Error.as_str())
+                && change.workflow_representative.as_deref()
+                    == Some(RepresentativeStatus::Error.as_str())
+        }));
+    }
+
+    #[test]
+    fn workflow_representative_aggregates_live_steps_with_snapshot_baselines() {
+        let center = mk_center();
+        center.sync_workflow_step_session_statuses(
+            "/repo",
+            "exec-1",
+            "running",
+            vec![
+                projection(
+                    Some("step-live"),
+                    "live",
+                    Some(1),
+                    RepresentativeStatus::Queued,
+                    StepProgress::Queued,
+                ),
+                projection(
+                    None,
+                    "failed-history",
+                    Some(1),
+                    RepresentativeStatus::Failed,
+                    StepProgress::Failed,
+                ),
+            ],
+        );
+
+        let live_waiting = workflow_session(
+            "step-live",
+            "live",
+            Some(1),
+            StepProgress::Queued,
+            AgentState::Waiting,
+        );
+        let changes = center.update_session(live_waiting);
+
+        assert_eq!(
+            changes.workflow_steps[0].representative.as_deref(),
+            Some(RepresentativeStatus::Waiting.as_str())
+        );
+        assert_eq!(
+            changes.workflow_steps[0].workflow_representative.as_deref(),
+            Some(RepresentativeStatus::Failed.as_str())
+        );
+    }
+
+    #[test]
+    fn workflow_representative_clears_when_last_live_step_is_removed() {
+        let center = mk_center();
+        center.sync_workflow_step_session_statuses(
+            "/repo",
+            "exec-1",
+            "running",
+            vec![projection(
+                Some("step-live"),
+                "live",
+                Some(1),
+                RepresentativeStatus::Queued,
+                StepProgress::Queued,
+            )],
+        );
+        center.update_session(workflow_session(
+            "step-live",
+            "live",
+            Some(1),
+            StepProgress::Queued,
+            AgentState::Running,
+        ));
+
+        let changes = center.on_session_state_changed("step-live", SessionState::Archived);
+
+        assert_eq!(changes.workflow_steps.len(), 1);
+        assert_eq!(changes.workflow_steps[0].representative, None);
+        assert_eq!(changes.workflow_steps[0].workflow_representative, None);
     }
 }

--- a/src-tauri/src/usecase/workflow/workspace_tree.rs
+++ b/src-tauri/src/usecase/workflow/workspace_tree.rs
@@ -2,13 +2,17 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use serde::Serialize;
 
+use crate::domain::workflow::services::session_projection;
+use crate::domain::workflow::status_aggregation::{
+    aggregate_representative_statuses, session_result, RepresentativeStatus, SessionActivity,
+    StepProgress,
+};
 use crate::usecase::workflow::query_service::WorkflowQueryService;
 use crate::{
     domain::workflow::{
         NodeType, RunId, RunListFilter, RunStatus, WorkflowError, WorkflowRunManualArchiveRecord,
-        WorkflowRunSummary, WorkflowStateSnapshot, WorkflowStepContext, STEP_STATE_ABORTED,
-        STEP_STATE_COMPLETED, STEP_STATE_FAILED, STEP_STATE_PENDING, STEP_STATE_RUNNING,
-        STEP_STATE_WAITING_APPROVAL, WORKFLOW_ARCHIVE_REASON_MANUAL,
+        WorkflowRunSummary, WorkflowStateSnapshot, WorkflowStepContext,
+        WORKFLOW_ARCHIVE_REASON_MANUAL,
     },
     other::utils::unix_timestamp_seconds,
 };
@@ -87,6 +91,7 @@ pub(crate) struct WorkspaceWorkflowNodeDto {
     pub workflow_name: String,
     pub title: String,
     pub status: String,
+    pub can_stop: bool,
     pub updated_at: f64,
     pub steps: Vec<WorkspaceWorkflowStepNodeDto>,
 }
@@ -334,13 +339,18 @@ fn workflow_node(
     state: Option<&WorkflowStateSnapshot>,
 ) -> WorkspaceWorkflowNodeDto {
     let steps = workflow_steps(&run, workflow_sessions, &step_refs, state);
+    let status = workflow_status_for_steps(&steps)
+        .unwrap_or_else(|| run_status_representative(run.status))
+        .as_str()
+        .to_string();
 
     WorkspaceWorkflowNodeDto {
         run_id: run.run_id.clone(),
         worktree_path: run.worktree_path.clone(),
         workflow_name: run.workflow_name.clone(),
         title: workflow_title(&run),
-        status: run_status_label(run.status).to_string(),
+        status,
+        can_stop: workflow_can_stop(run.status),
         updated_at: run.updated_at,
         steps,
     }
@@ -428,14 +438,35 @@ fn state_ref_for_session<'a>(
         .find(|step_ref| step_ref.session_id.as_deref() == Some(session_id))
 }
 
+fn retain_unique_step_refs(refs: &mut Vec<StepSessionRef>) {
+    let mut seen = HashSet::new();
+    refs.retain(|step_ref| {
+        seen.insert((
+            step_ref.session_id.clone(),
+            step_ref.step_name.clone(),
+            step_ref.run_index,
+            step_ref.group_step_name.clone(),
+            step_ref.group_run_index,
+        ))
+    });
+}
+
 fn step_status_from_session_lifecycle(state: &WorkspaceSessionState) -> &'static str {
+    session_result(
+        StepProgress::Completed,
+        session_activity_from_workspace_lifecycle(state),
+    )
+    .as_str()
+}
+
+fn session_activity_from_workspace_lifecycle(state: &WorkspaceSessionState) -> SessionActivity {
     match state {
-        WorkspaceSessionState::Active => STEP_STATE_RUNNING,
-        WorkspaceSessionState::Error => STEP_STATE_FAILED,
-        WorkspaceSessionState::Idle
-        | WorkspaceSessionState::Done
+        WorkspaceSessionState::Active => SessionActivity::Running,
+        WorkspaceSessionState::Idle => SessionActivity::Waiting,
+        WorkspaceSessionState::Error => SessionActivity::Error,
+        WorkspaceSessionState::Done
         | WorkspaceSessionState::Closed
-        | WorkspaceSessionState::Archived => STEP_STATE_COMPLETED,
+        | WorkspaceSessionState::Archived => SessionActivity::Done,
     }
 }
 
@@ -518,84 +549,18 @@ fn workflow_title(run: &WorkflowRunSummary) -> String {
 }
 
 fn collect_step_session_refs(state: &WorkflowStateSnapshot) -> Vec<StepSessionRef> {
-    let mut refs = Vec::new();
-    let mut next_order = 0usize;
-    for entry in &state.step_history {
-        let order = next_order;
-        next_order += 1;
-        refs.push(StepSessionRef {
-            session_id: entry.session_id.clone(),
-            step_name: entry.step_name.clone(),
-            run_index: Some(entry.run_index),
-            group_step_name: entry.step_name.clone(),
-            group_run_index: Some(entry.run_index),
-            state: normalize_step_status(&entry.state).to_string(),
-            order,
-        });
-        if let Some(children) = entry.child_outputs.as_ref() {
-            refs.extend(children.iter().map(|child| StepSessionRef {
-                session_id: child.session_id.clone(),
-                step_name: child.step_name.clone(),
-                run_index: Some(child.run_index),
-                group_step_name: entry.step_name.clone(),
-                group_run_index: Some(entry.run_index),
-                state: normalize_step_status(&child.state).to_string(),
-                order,
-            }));
-        }
-    }
-    if state.current_session_id.is_some()
-        || matches!(
-            state.state,
-            crate::domain::workflow::WorkflowExecutionState::Running
-                | crate::domain::workflow::WorkflowExecutionState::WaitingApproval
-        )
-    {
-        let order = next_order;
-        let run_index = state
-            .step_execution_counts
-            .get(&state.current_step_name)
-            .copied()
-            .or(Some(1));
-        refs.push(StepSessionRef {
-            session_id: state.current_session_id.clone(),
-            step_name: state.current_step_name.clone(),
-            run_index,
-            group_step_name: state.current_step_name.clone(),
-            group_run_index: run_index,
-            state: workflow_execution_state_label(&state.state).to_string(),
-            order,
-        });
-        refs.extend(
-            state
-                .active_parallel_steps
-                .iter()
-                .map(|step| StepSessionRef {
-                    session_id: step.session_id.clone(),
-                    step_name: step.step_name.clone(),
-                    run_index: Some(step.run_index),
-                    group_step_name: state.current_step_name.clone(),
-                    group_run_index: run_index,
-                    state: normalize_step_status(&step.state).to_string(),
-                    order,
-                }),
-        );
-    }
-    retain_unique_step_refs(&mut refs);
-    refs
-}
-
-fn retain_unique_step_refs(refs: &mut Vec<StepSessionRef>) {
-    let mut seen = HashSet::new();
-    refs.retain(|step_ref| {
-        seen.insert((
-            step_ref.session_id.clone(),
-            step_ref.step_name.clone(),
-            step_ref.run_index,
-            step_ref.group_step_name.clone(),
-            step_ref.group_run_index,
-        ))
-    });
+    session_projection::collect_step_session_projections(state)
+        .into_iter()
+        .map(|projection| StepSessionRef {
+            session_id: projection.session_id,
+            step_name: projection.step_name,
+            run_index: projection.run_index,
+            group_step_name: projection.group_step_name,
+            group_run_index: projection.group_run_index,
+            state: projection.representative.as_str().to_string(),
+            order: projection.order,
+        })
+        .collect()
 }
 
 fn workflow_steps(
@@ -679,43 +644,24 @@ fn step_status_for_group(
     refs: &[&StepSessionRef],
     state: Option<&WorkflowStateSnapshot>,
 ) -> &'static str {
+    let mut candidates = refs
+        .iter()
+        .map(|step_ref| RepresentativeStatus::from_status_str(&step_ref.state))
+        .collect::<Vec<_>>();
+
     if let Some(state) = state {
         if state.current_step_name == step_name {
-            if current_run_index(state) == run_index {
-                return workflow_execution_state_label(&state.state);
+            if session_projection::current_run_index(state) == run_index {
+                candidates.push(workflow_execution_state_representative(&state.state));
             }
         } else if let Some(step_state) = state.step_states.get(step_name) {
-            return normalize_step_status(step_state);
+            candidates.push(StepProgress::from_status_str(step_state).representative());
         }
     }
-    if refs
-        .iter()
-        .any(|step_ref| step_ref.state == STEP_STATE_FAILED)
-    {
-        return STEP_STATE_FAILED;
-    }
-    if refs
-        .iter()
-        .any(|step_ref| step_ref.state == STEP_STATE_ABORTED)
-    {
-        return STEP_STATE_ABORTED;
-    }
-    if refs
-        .iter()
-        .any(|step_ref| step_ref.state == STEP_STATE_WAITING_APPROVAL)
-    {
-        return STEP_STATE_WAITING_APPROVAL;
-    }
-    if refs
-        .iter()
-        .any(|step_ref| step_ref.state == STEP_STATE_RUNNING)
-    {
-        return STEP_STATE_RUNNING;
-    }
-    if !refs.is_empty() {
-        return STEP_STATE_COMPLETED;
-    }
-    "queued"
+
+    aggregate_representative_statuses(candidates)
+        .unwrap_or(RepresentativeStatus::Queued)
+        .as_str()
 }
 
 fn step_type_for_group(step_name: &str, state: Option<&WorkflowStateSnapshot>) -> &'static str {
@@ -749,7 +695,7 @@ fn step_can_reject(
     if state.current_step_name != step_name {
         return None;
     }
-    if current_run_index(state) != run_index {
+    if session_projection::current_run_index(state) != run_index {
         return None;
     }
     if !matches!(
@@ -766,38 +712,26 @@ fn step_can_reject(
     )
 }
 
-fn current_run_index(state: &WorkflowStateSnapshot) -> Option<u32> {
-    state
-        .step_execution_counts
-        .get(&state.current_step_name)
-        .copied()
-        .or(Some(1))
-}
-
-fn workflow_execution_state_label(
+fn workflow_execution_state_representative(
     state: &crate::domain::workflow::WorkflowExecutionState,
-) -> &'static str {
+) -> RepresentativeStatus {
     match state {
-        crate::domain::workflow::WorkflowExecutionState::Running => STEP_STATE_RUNNING,
+        crate::domain::workflow::WorkflowExecutionState::Running => RepresentativeStatus::Running,
         crate::domain::workflow::WorkflowExecutionState::WaitingApproval => {
-            STEP_STATE_WAITING_APPROVAL
+            RepresentativeStatus::Waiting
         }
-        crate::domain::workflow::WorkflowExecutionState::Completed => STEP_STATE_COMPLETED,
-        crate::domain::workflow::WorkflowExecutionState::Failed { .. } => STEP_STATE_FAILED,
-        crate::domain::workflow::WorkflowExecutionState::Aborted => STEP_STATE_ABORTED,
+        crate::domain::workflow::WorkflowExecutionState::Completed => {
+            RepresentativeStatus::Completed
+        }
+        crate::domain::workflow::WorkflowExecutionState::Failed { .. } => {
+            RepresentativeStatus::Failed
+        }
+        crate::domain::workflow::WorkflowExecutionState::Aborted => RepresentativeStatus::Aborted,
     }
 }
 
 fn normalize_step_status(status: &str) -> &'static str {
-    match status {
-        STEP_STATE_RUNNING => STEP_STATE_RUNNING,
-        STEP_STATE_WAITING_APPROVAL => STEP_STATE_WAITING_APPROVAL,
-        STEP_STATE_COMPLETED => STEP_STATE_COMPLETED,
-        STEP_STATE_FAILED => STEP_STATE_FAILED,
-        STEP_STATE_ABORTED => STEP_STATE_ABORTED,
-        STEP_STATE_PENDING => "queued",
-        _ => "queued",
-    }
+    RepresentativeStatus::from_status_str(status).as_str()
 }
 
 fn compare_session_nodes(
@@ -814,13 +748,31 @@ fn compare_titles(a: &str, b: &str) -> std::cmp::Ordering {
 }
 
 fn run_status_label(status: RunStatus) -> &'static str {
+    run_status_representative(status).as_str()
+}
+
+fn run_status_representative(status: RunStatus) -> RepresentativeStatus {
     match status {
-        RunStatus::Running => STEP_STATE_RUNNING,
-        RunStatus::WaitingApproval => "waiting_approval",
-        RunStatus::Completed => "completed",
-        RunStatus::Failed => "failed",
-        RunStatus::Aborted => "aborted",
+        RunStatus::Running => RepresentativeStatus::Running,
+        RunStatus::WaitingApproval => RepresentativeStatus::Waiting,
+        RunStatus::Completed => RepresentativeStatus::Completed,
+        RunStatus::Failed => RepresentativeStatus::Failed,
+        RunStatus::Aborted => RepresentativeStatus::Aborted,
     }
+}
+
+fn workflow_can_stop(status: RunStatus) -> bool {
+    !status.is_terminal()
+}
+
+fn workflow_status_for_steps(
+    steps: &[WorkspaceWorkflowStepNodeDto],
+) -> Option<RepresentativeStatus> {
+    aggregate_representative_statuses(
+        steps
+            .iter()
+            .map(|step| RepresentativeStatus::from_status_str(&step.status)),
+    )
 }
 
 #[cfg(test)]
@@ -829,8 +781,8 @@ mod tests {
     use crate::domain::workflow::{
         ApprovalOperations, ChildOutputSnapshot, NodeDefinition, NodeType, ParallelStepState,
         StepHistoryEntry, TriggerSource, WorkflowDefinition, WorkflowExecutionState,
-        STEP_STATE_ABORTED, STEP_STATE_COMPLETED, STEP_STATE_FAILED, STEP_STATE_RUNNING,
-        STEP_STATE_WAITING_APPROVAL,
+        STEP_STATE_ABORTED, STEP_STATE_COMPLETED, STEP_STATE_FAILED, STEP_STATE_PENDING,
+        STEP_STATE_RUNNING, STEP_STATE_WAITING_APPROVAL,
     };
 
     fn session(id: &str, title: &str, workflow_step_session: bool) -> WorkspaceSessionInput {
@@ -1260,9 +1212,12 @@ mod tests {
     #[test]
     fn explicit_context_without_state_ref_uses_session_lifecycle_for_step_status() {
         for (session_state, expected_status) in [
-            (WorkspaceSessionState::Error, STEP_STATE_FAILED),
             (WorkspaceSessionState::Active, STEP_STATE_RUNNING),
+            (WorkspaceSessionState::Idle, "waiting"),
+            (WorkspaceSessionState::Error, "error"),
+            (WorkspaceSessionState::Done, STEP_STATE_COMPLETED),
             (WorkspaceSessionState::Closed, STEP_STATE_COMPLETED),
+            (WorkspaceSessionState::Archived, STEP_STATE_COMPLETED),
         ] {
             let archives = Vec::new();
             let mut step_session = session_with_context(
@@ -1377,7 +1332,7 @@ mod tests {
         assert_eq!(previous.step_type, "approval");
         assert_eq!(previous.can_reject, None);
         assert_eq!(previous.sessions[0].id, "review-1");
-        assert_eq!(current.status, STEP_STATE_WAITING_APPROVAL);
+        assert_eq!(current.status, "waiting");
         assert_eq!(current.step_type, "approval");
         assert_eq!(current.can_reject, Some(true));
         assert_eq!(current.sessions[0].id, "review-2");
@@ -1513,19 +1468,27 @@ mod tests {
                     STEP_STATE_WAITING_APPROVAL,
                     STEP_STATE_RUNNING,
                 ],
+                STEP_STATE_RUNNING,
+            ),
+            (
+                vec![STEP_STATE_FAILED, "error", STEP_STATE_WAITING_APPROVAL],
                 STEP_STATE_FAILED,
+            ),
+            (
+                vec!["error", STEP_STATE_WAITING_APPROVAL, STEP_STATE_ABORTED],
+                "error",
             ),
             (
                 vec![
                     STEP_STATE_ABORTED,
                     STEP_STATE_WAITING_APPROVAL,
-                    STEP_STATE_RUNNING,
+                    STEP_STATE_COMPLETED,
                 ],
-                STEP_STATE_ABORTED,
+                "waiting",
             ),
             (
-                vec![STEP_STATE_WAITING_APPROVAL, STEP_STATE_RUNNING],
-                STEP_STATE_WAITING_APPROVAL,
+                vec![STEP_STATE_ABORTED, STEP_STATE_COMPLETED],
+                STEP_STATE_ABORTED,
             ),
             (vec![STEP_STATE_RUNNING], STEP_STATE_RUNNING),
         ] {
@@ -1554,6 +1517,29 @@ mod tests {
             matches!(&nodes[0], WorkspaceTreeNodeDto::Workflow(node) if node.run_id == "run-1")
         );
         assert!(archives.is_empty());
+    }
+
+    #[test]
+    fn workflow_can_stop_comes_from_run_lifecycle_status() {
+        for (status, expected) in [
+            (RunStatus::Running, true),
+            (RunStatus::WaitingApproval, true),
+            (RunStatus::Completed, false),
+            (RunStatus::Failed, false),
+            (RunStatus::Aborted, false),
+        ] {
+            let nodes = project_workspace_tree_nodes(
+                vec![],
+                vec![run_with_status("run-1", "Lifecycle", status)],
+                HashMap::new(),
+                &[],
+            );
+
+            let WorkspaceTreeNodeDto::Workflow(workflow) = &nodes[0] else {
+                panic!("expected workflow node");
+            };
+            assert_eq!(workflow.can_stop, expected);
+        }
     }
 
     #[test]
@@ -1595,7 +1581,7 @@ mod tests {
         );
         assert_eq!(
             normalize_step_status(STEP_STATE_WAITING_APPROVAL),
-            STEP_STATE_WAITING_APPROVAL
+            "waiting"
         );
         assert_eq!(
             normalize_step_status(STEP_STATE_COMPLETED),

--- a/src/components/panels/WorkflowView/WorkflowView.test.tsx
+++ b/src/components/panels/WorkflowView/WorkflowView.test.tsx
@@ -287,7 +287,7 @@ describe("WorkflowView", () => {
 	it("keeps Reject hidden when the approval step cannot reject", () => {
 		useWorkspaceWorkflowStepDetailMock.mockReturnValue(
 			stepDetailState({
-				status: "waiting_approval",
+				status: "waiting",
 				canReject: false,
 				sessions: [stepDetail().sessions[0]],
 			}),
@@ -302,7 +302,7 @@ describe("WorkflowView", () => {
 	it("submits Approve from the Step header", async () => {
 		useWorkspaceWorkflowStepDetailMock.mockReturnValue(
 			stepDetailState({
-				status: "waiting_approval",
+				status: "waiting",
 				canReject: true,
 				sessions: [stepDetail().sessions[0]],
 			}),
@@ -326,7 +326,7 @@ describe("WorkflowView", () => {
 	it("requires a comment before submitting Reject", async () => {
 		useWorkspaceWorkflowStepDetailMock.mockReturnValue(
 			stepDetailState({
-				status: "waiting_approval",
+				status: "waiting",
 				canReject: true,
 				sessions: [stepDetail().sessions[0]],
 			}),
@@ -358,7 +358,7 @@ describe("WorkflowView", () => {
 	it("closes Reject comment input without submitting when Cancel is clicked", async () => {
 		useWorkspaceWorkflowStepDetailMock.mockReturnValue(
 			stepDetailState({
-				status: "waiting_approval",
+				status: "waiting",
 				canReject: true,
 				sessions: [stepDetail().sessions[0]],
 			}),
@@ -383,7 +383,7 @@ describe("WorkflowView", () => {
 	it("keeps the action error icon after closing the error popup", async () => {
 		useWorkspaceWorkflowStepDetailMock.mockReturnValue(
 			stepDetailState({
-				status: "waiting_approval",
+				status: "waiting",
 				canReject: true,
 				sessions: [stepDetail().sessions[0]],
 			}),

--- a/src/components/panels/WorkflowView/WorkflowView.tsx
+++ b/src/components/panels/WorkflowView/WorkflowView.tsx
@@ -227,7 +227,8 @@ function WorkflowStepHeaderContent({
 }) {
 	const [rejectOpen, setRejectOpen] = useState(false);
 	const [rejectComment, setRejectComment] = useState("");
-	const canRespondApproval = step.status === "waiting_approval";
+	const canRespondApproval =
+		step.status === "waiting" && step.canReject != null;
 	const canReject = canRespondApproval && step.canReject !== false;
 	const canSubmitReject =
 		rejectComment.trim().length > 0 && pendingAction == null;

--- a/src/components/workspace/WorkflowStepStatusIcon.tsx
+++ b/src/components/workspace/WorkflowStepStatusIcon.tsx
@@ -12,10 +12,11 @@ import type { WorkspaceStepStatus } from "@/types/workspace-tree";
 export const workflowStepIconClasses: Record<WorkspaceStepStatus, string> = {
 	queued: "text-muted-foreground",
 	running: "text-blue-600 dark:text-blue-300",
-	waiting_approval: "text-yellow-600 dark:text-yellow-300",
-	completed: "text-green-600 dark:text-green-300",
 	failed: "text-red-600 dark:text-red-300",
+	error: "text-destructive",
+	waiting: "text-yellow-600 dark:text-yellow-300",
 	aborted: "text-muted-foreground",
+	completed: "text-green-600 dark:text-green-300",
 };
 
 interface WorkflowStepStatusIconProps {
@@ -39,9 +40,9 @@ export function WorkflowStepStatusIcon({
 			<Loader2 className={cn(baseIconClassName, "animate-spin")} />
 		) : status === "completed" ? (
 			<CheckCircle2 className={baseIconClassName} />
-		) : status === "failed" ? (
+		) : status === "failed" || status === "error" ? (
 			<AlertTriangle className={baseIconClassName} />
-		) : status === "waiting_approval" ? (
+		) : status === "waiting" ? (
 			<Clock className={baseIconClassName} />
 		) : status === "aborted" ? (
 			<Ban className={baseIconClassName} />
@@ -53,5 +54,9 @@ export function WorkflowStepStatusIcon({
 		return icon;
 	}
 
-	return <span className={cn(containerClassName, colorClassName)}>{icon}</span>;
+	return (
+		<span className={cn(containerClassName, colorClassName)} title={status}>
+			{icon}
+		</span>
+	);
 }

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -93,6 +93,7 @@ vi.mock("@/hooks/useWorkspaceTreeNodes", () => ({
 					workflowName: "release",
 					title: "Deploy workflow",
 					status: "running",
+					canStop: true,
 					updatedAt: 1100,
 					steps: [
 						{
@@ -127,7 +128,8 @@ vi.mock("@/hooks/useWorkspaceTreeNodes", () => ({
 					worktreePath: "/repo/wt",
 					workflowName: "waiting-flow",
 					title: "Waiting workflow",
-					status: "waiting_approval",
+					status: "waiting",
+					canStop: true,
 					updatedAt: 1101,
 					steps: [],
 				},
@@ -138,6 +140,7 @@ vi.mock("@/hooks/useWorkspaceTreeNodes", () => ({
 					workflowName: "completed-flow",
 					title: "Completed workflow",
 					status: "completed",
+					canStop: false,
 					updatedAt: 1102,
 					steps: [],
 				},
@@ -148,6 +151,7 @@ vi.mock("@/hooks/useWorkspaceTreeNodes", () => ({
 					workflowName: "failed-flow",
 					title: "Failed workflow",
 					status: "failed",
+					canStop: false,
 					updatedAt: 1103,
 					steps: [],
 				},
@@ -158,6 +162,7 @@ vi.mock("@/hooks/useWorkspaceTreeNodes", () => ({
 					workflowName: "aborted-flow",
 					title: "Aborted workflow",
 					status: "aborted",
+					canStop: false,
 					updatedAt: 1104,
 					steps: [],
 				},
@@ -232,6 +237,17 @@ vi.mock("@/hooks/useWorktreeList", () => ({
 }));
 vi.mock("@/hooks/useWorktreeSessionStatuses", () => ({
 	useWorktreeSessionStatuses: () => new Map(),
+}));
+vi.mock("@/hooks/useWorktreeStepStatuses", () => ({
+	workflowStepStatusKey: (
+		executionId: string,
+		stepName: string,
+		runIndex?: number | null,
+	) => `${executionId}:${stepName}:${runIndex ?? 1}`,
+	useWorktreeStepStatuses: () => ({
+		steps: new Map([["run-1:Build step:1", "waiting"]]),
+		workflows: new Map([["run-1", "failed"]]),
+	}),
 }));
 
 function renderWorkspaceList(
@@ -392,6 +408,29 @@ describe("WorkspaceList", () => {
 				runId: "run-waiting",
 			});
 		});
+	});
+
+	it("uses live representative statuses for Step and Workflow rows", () => {
+		renderWorkspaceList();
+
+		expect(screen.getAllByTitle("waiting").length).toBeGreaterThanOrEqual(2);
+		expect(screen.getAllByTitle("failed").length).toBeGreaterThanOrEqual(2);
+		expect(screen.getAllByTitle("completed").length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("does not enable Stop from a live representative status on a terminal Workflow", async () => {
+		const user = userEvent.setup();
+		renderWorkspaceList();
+
+		await user.click(screen.getByLabelText("Open menu for completed-flow"));
+		const stop = await screen.findByRole("menuitem", { name: /Stop/ });
+		expect(stop).toHaveAttribute("aria-disabled", "true");
+		fireEvent.click(stop);
+
+		expect(mocks.invoke).not.toHaveBeenCalledWith(
+			"abort_workflow",
+			expect.anything(),
+		);
 	});
 
 	it.each([

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -51,6 +51,11 @@ import { useWorkflowConfig } from "@/hooks/useWorkflowConfig";
 import { useWorkspaceTreeNodes } from "@/hooks/useWorkspaceTreeNodes";
 import { useWorktreeList } from "@/hooks/useWorktreeList";
 import { useWorktreeSessionStatuses } from "@/hooks/useWorktreeSessionStatuses";
+import {
+	useWorktreeStepStatuses,
+	type WorktreeStepStatuses,
+	workflowStepStatusKey,
+} from "@/hooks/useWorktreeStepStatuses";
 import { trackEvent } from "@/lib/telemetry";
 import type { WorktreeBranch } from "@/types/git";
 import type {
@@ -82,6 +87,23 @@ interface WorkspaceListProps {
 const WORKTREE_NAME_INDENT_PX = 26;
 const WORKFLOW_NAME_OFFSET_PX = 22;
 const DEFAULT_SESSION_TITLE = "NewSession";
+
+function applyLiveWorkflowStatuses(
+	node: WorkspaceWorkflowNode,
+	stepStatuses: WorktreeStepStatuses,
+): WorkspaceWorkflowNode {
+	return {
+		...node,
+		status: stepStatuses.workflows.get(node.runId) ?? node.status,
+		steps: node.steps.map((step) => ({
+			...step,
+			status:
+				stepStatuses.steps.get(
+					workflowStepStatusKey(node.runId, step.title, step.runIndex),
+				) ?? step.status,
+		})),
+	};
+}
 
 function repoNameFromPath(path: string): string {
 	return path.split("/").filter(Boolean).pop() ?? path;
@@ -227,8 +249,7 @@ function WorktreeWorkflowRow({
 	const [expanded, setExpanded] = useState(true);
 	const [workflowMenuOpen, setWorkflowMenuOpen] = useState(false);
 	const steps = node.steps;
-	const canStop =
-		node.status === "running" || node.status === "waiting_approval";
+	const canStop = node.canStop;
 	const actionControlsVisible = workflowMenuOpen;
 	const workflowLabel = node.workflowName.trim() || node.title;
 	return (
@@ -242,7 +263,12 @@ function WorktreeWorkflowRow({
 					className="flex min-w-0 flex-1 items-center gap-2 text-left"
 					onClick={() => setExpanded((prev) => !prev)}
 				>
-					<Workflow className="size-3.5 shrink-0 text-muted-foreground/80" />
+					<WorkflowStepStatusIcon
+						status={node.status}
+						containerClassName="flex size-5 shrink-0 items-center justify-center"
+						iconClassName="size-3"
+						circleClassName="size-2"
+					/>
 					<span className="min-w-0 truncate">{workflowLabel}</span>
 					{expanded ? (
 						<ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
@@ -400,6 +426,7 @@ function WorktreeTreeItem({
 		error: workflowsError,
 	} = useWorkflowConfig(createMenuOpen);
 	const sessionStatuses = useWorktreeSessionStatuses(branch.worktree_path);
+	const liveWorkflowStatuses = useWorktreeStepStatuses(branch.worktree_path);
 	const sessionAgentStates = useMemo(() => {
 		const map = new Map<string, WorkspaceSessionNode["agentState"]>();
 		for (const [sessionId, status] of sessionStatuses) {
@@ -407,6 +434,15 @@ function WorktreeTreeItem({
 		}
 		return map;
 	}, [sessionStatuses]);
+	const displayNodes = useMemo(
+		() =>
+			nodes.map((node) =>
+				node.kind === "workflow"
+					? applyLiveWorkflowStatuses(node, liveWorkflowStatuses)
+					: node,
+			),
+		[nodes, liveWorkflowStatuses],
+	);
 
 	const selectCenter = useCallback(
 		(centerSelection: CenterSelection) => {
@@ -817,7 +853,7 @@ function WorktreeTreeItem({
 							{treeError}
 						</div>
 					) : (
-						nodes.map((node) =>
+						displayNodes.map((node) =>
 							node.kind === "workflow" ? (
 								<WorktreeWorkflowRow
 									key={node.runId}

--- a/src/hooks/useWorkspaceTreeNodes.test.ts
+++ b/src/hooks/useWorkspaceTreeNodes.test.ts
@@ -293,6 +293,7 @@ describe("useWorkspaceTreeNodes", () => {
 				workflowName: "workflow",
 				title: "workflow",
 				status: "running",
+				canStop: true,
 				updatedAt: 1_000,
 				steps: [
 					{
@@ -379,6 +380,7 @@ describe("useWorkspaceTreeNodes", () => {
 				workflowName: "workflow",
 				title: "workflow",
 				status: "running",
+				canStop: true,
 				updatedAt: 1_000,
 				steps: [],
 			},
@@ -419,6 +421,7 @@ describe("useWorkspaceTreeNodes", () => {
 				workflowName: "workflow",
 				title: "workflow",
 				status: "running",
+				canStop: true,
 				updatedAt: 1_000,
 				steps: [],
 			},
@@ -440,7 +443,8 @@ describe("useWorkspaceTreeNodes", () => {
 				worktreePath: "/repo",
 				workflowName: "workflow",
 				title: "workflow",
-				status: "waiting_approval",
+				status: "waiting",
+				canStop: true,
 				updatedAt: 2_000,
 				steps: [],
 			},

--- a/src/hooks/useWorkspaceWorkflowStepDetail.test.ts
+++ b/src/hooks/useWorkspaceWorkflowStepDetail.test.ts
@@ -121,7 +121,7 @@ describe("useWorkspaceWorkflowStepDetail", () => {
 	});
 
 	it("reloads the selected Step detail when its workflow state changes", async () => {
-		responses.push(stepDetail(), stepDetail({ status: "waiting_approval" }));
+		responses.push(stepDetail(), stepDetail({ status: "waiting" }));
 		const { result } = renderHook(() =>
 			useWorkspaceWorkflowStepDetail({
 				worktreePath: "/repo",
@@ -144,7 +144,7 @@ describe("useWorkspaceWorkflowStepDetail", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.detail?.status).toBe("waiting_approval");
+			expect(result.current.detail?.status).toBe("waiting");
 		});
 		expect(mockInvoke).toHaveBeenCalledTimes(2);
 	});

--- a/src/hooks/useWorktreeStepStatuses.test.ts
+++ b/src/hooks/useWorktreeStepStatuses.test.ts
@@ -1,0 +1,176 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkflowStepStatusChange } from "@/types/workspace-tree";
+import {
+	useWorktreeStepStatuses,
+	workflowStepStatusKey,
+} from "./useWorktreeStepStatuses";
+
+const mockInvoke = vi.fn();
+const mockListen = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: (...args: unknown[]) => mockListen(...args),
+}));
+
+function change(
+	overrides: Partial<WorkflowStepStatusChange> = {},
+): WorkflowStepStatusChange {
+	return {
+		worktreePath: "/tmp/wt",
+		executionId: "run-1",
+		stepName: "build",
+		runIndex: 1,
+		representative: "running",
+		workflowRepresentative: "running",
+		version: 1,
+		...overrides,
+	};
+}
+
+describe("useWorktreeStepStatuses", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockListen.mockResolvedValue(vi.fn());
+	});
+
+	it("returns empty maps when worktreePath is null", () => {
+		const { result } = renderHook(() => useWorktreeStepStatuses(null));
+		expect(result.current.steps.size).toBe(0);
+		expect(result.current.workflows.size).toBe(0);
+		expect(mockInvoke).not.toHaveBeenCalled();
+	});
+
+	it("filters initial statuses by worktreePath", async () => {
+		mockInvoke.mockResolvedValue([
+			change(),
+			change({
+				worktreePath: "/tmp/other",
+				executionId: "run-other",
+				stepName: "test",
+			}),
+		]);
+
+		const { result } = renderHook(() => useWorktreeStepStatuses("/tmp/wt"));
+
+		await waitFor(() => {
+			expect(result.current.steps.size).toBe(1);
+		});
+		expect(result.current.steps.get("run-1:build:1")).toBe("running");
+		expect(result.current.workflows.get("run-1")).toBe("running");
+	});
+
+	it("applies matching live changes and removals", async () => {
+		mockInvoke.mockResolvedValue([change({ representative: "queued" })]);
+		type Cb = (event: { payload: WorkflowStepStatusChange }) => void;
+		let cb: Cb | null = null;
+		mockListen.mockImplementation((event: string, fn: Cb) => {
+			if (event === "workflow-step-status-changed") cb = fn;
+			return Promise.resolve(vi.fn());
+		});
+
+		const { result } = renderHook(() => useWorktreeStepStatuses("/tmp/wt"));
+		await waitFor(() => {
+			expect(result.current.steps.get("run-1:build:1")).toBe("queued");
+		});
+
+		await act(async () => {
+			cb?.({ payload: change({ representative: "waiting" }) });
+		});
+		expect(result.current.steps.get("run-1:build:1")).toBe("waiting");
+		expect(result.current.workflows.get("run-1")).toBe("running");
+
+		await act(async () => {
+			cb?.({
+				payload: change({
+					representative: null,
+					workflowRepresentative: null,
+				}),
+			});
+		});
+		expect(result.current.steps.get("run-1:build:1")).toBeUndefined();
+		expect(result.current.workflows.get("run-1")).toBeUndefined();
+	});
+
+	it("does not restore older initial statuses after a newer removal event", async () => {
+		type Cb = (event: { payload: WorkflowStepStatusChange }) => void;
+		let cb: Cb | null = null;
+		let resolveInitial: ((value: WorkflowStepStatusChange[]) => void) | null =
+			null;
+		mockInvoke.mockReturnValue(
+			new Promise<WorkflowStepStatusChange[]>((resolve) => {
+				resolveInitial = resolve;
+			}),
+		);
+		mockListen.mockImplementation((event: string, fn: Cb) => {
+			if (event === "workflow-step-status-changed") cb = fn;
+			return Promise.resolve(vi.fn());
+		});
+
+		const { result } = renderHook(() => useWorktreeStepStatuses("/tmp/wt"));
+		await waitFor(() => {
+			expect(cb).not.toBeNull();
+		});
+
+		await act(async () => {
+			cb?.({
+				payload: change({
+					representative: null,
+					workflowRepresentative: null,
+					version: 2,
+				}),
+			});
+		});
+
+		await act(async () => {
+			resolveInitial?.([
+				change({
+					representative: "queued",
+					version: 1,
+				}),
+			]);
+		});
+
+		expect(result.current.steps.get("run-1:build:1")).toBeUndefined();
+		expect(result.current.workflows.get("run-1")).toBeUndefined();
+	});
+
+	it("ignores live changes for other worktrees", async () => {
+		mockInvoke.mockResolvedValue([change()]);
+		type Cb = (event: { payload: WorkflowStepStatusChange }) => void;
+		let cb: Cb | null = null;
+		mockListen.mockImplementation((event: string, fn: Cb) => {
+			if (event === "workflow-step-status-changed") cb = fn;
+			return Promise.resolve(vi.fn());
+		});
+
+		const { result } = renderHook(() => useWorktreeStepStatuses("/tmp/wt"));
+		await waitFor(() => {
+			expect(result.current.steps.size).toBe(1);
+		});
+
+		await act(async () => {
+			cb?.({
+				payload: change({
+					worktreePath: "/tmp/other",
+					executionId: "run-other",
+					stepName: "test",
+					representative: "failed",
+				}),
+			});
+		});
+
+		expect(result.current.steps.size).toBe(1);
+		expect(result.current.steps.get("run-other:test:1")).toBeUndefined();
+		expect(result.current.workflows.get("run-other")).toBeUndefined();
+	});
+
+	it("builds keys with run index fallback", () => {
+		expect(workflowStepStatusKey("run", "step", null)).toBe("run:step:1");
+		expect(workflowStepStatusKey("run", "step", 3)).toBe("run:step:3");
+	});
+});

--- a/src/hooks/useWorktreeStepStatuses.ts
+++ b/src/hooks/useWorktreeStepStatuses.ts
@@ -1,0 +1,139 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useEffect, useRef, useState } from "react";
+import type {
+	WorkflowStepStatusChange,
+	WorkspaceStepStatus,
+} from "@/types/workspace-tree";
+
+export interface WorktreeStepStatuses {
+	steps: Map<string, WorkspaceStepStatus>;
+	workflows: Map<string, WorkspaceStepStatus>;
+}
+
+export function workflowStepStatusKey(
+	executionId: string,
+	stepName: string,
+	runIndex?: number | null,
+): string {
+	return `${executionId}:${stepName}:${runIndex ?? 1}`;
+}
+
+function applyStatusChange(
+	prev: WorktreeStepStatuses,
+	change: WorkflowStepStatusChange,
+	stepVersions: Map<string, number>,
+	workflowVersions: Map<string, number>,
+): WorktreeStepStatuses {
+	const steps = new Map(prev.steps);
+	const workflows = new Map(prev.workflows);
+	const key = workflowStepStatusKey(
+		change.executionId,
+		change.stepName,
+		change.runIndex,
+	);
+	const previousStepVersion = stepVersions.get(key) ?? -1;
+	if (change.version >= previousStepVersion) {
+		stepVersions.set(key, change.version);
+		if (change.representative) {
+			steps.set(key, change.representative);
+		} else {
+			steps.delete(key);
+		}
+	}
+	const previousWorkflowVersion =
+		workflowVersions.get(change.executionId) ?? -1;
+	if (change.version >= previousWorkflowVersion) {
+		workflowVersions.set(change.executionId, change.version);
+		if (change.workflowRepresentative) {
+			workflows.set(change.executionId, change.workflowRepresentative);
+		} else {
+			workflows.delete(change.executionId);
+		}
+	}
+	return { steps, workflows };
+}
+
+export function useWorktreeStepStatuses(
+	worktreePath: string | null,
+): WorktreeStepStatuses {
+	const [statuses, setStatuses] = useState<WorktreeStepStatuses>({
+		steps: new Map(),
+		workflows: new Map(),
+	});
+	const stepVersions = useRef(new Map<string, number>());
+	const workflowVersions = useRef(new Map<string, number>());
+
+	useEffect(() => {
+		if (!worktreePath) {
+			stepVersions.current = new Map();
+			workflowVersions.current = new Map();
+			setStatuses({ steps: new Map(), workflows: new Map() });
+			return;
+		}
+
+		let mounted = true;
+		let unlisten: UnlistenFn | null = null;
+		stepVersions.current = new Map();
+		workflowVersions.current = new Map();
+		setStatuses({ steps: new Map(), workflows: new Map() });
+
+		const subscribe = async () => {
+			let subscribed = false;
+			try {
+				unlisten = await listen<WorkflowStepStatusChange>(
+					"workflow-step-status-changed",
+					(event) => {
+						if (!mounted) return;
+						if (event.payload.worktreePath !== worktreePath) return;
+						setStatuses((prev) =>
+							applyStatusChange(
+								prev,
+								event.payload,
+								stepVersions.current,
+								workflowVersions.current,
+							),
+						);
+					},
+				);
+				subscribed = true;
+
+				if (!mounted) {
+					unlisten?.();
+					return;
+				}
+
+				const initial = await invoke<WorkflowStepStatusChange[]>(
+					"list_workflow_step_statuses",
+				);
+				if (!mounted) return;
+				setStatuses((prev) => {
+					let merged = prev;
+					for (const status of Array.isArray(initial) ? initial : []) {
+						if (status.worktreePath !== worktreePath) continue;
+						merged = applyStatusChange(
+							merged,
+							status,
+							stepVersions.current,
+							workflowVersions.current,
+						);
+					}
+					return merged;
+				});
+			} catch {
+				if (mounted && !subscribed) {
+					setStatuses({ steps: new Map(), workflows: new Map() });
+				}
+			}
+		};
+
+		subscribe();
+
+		return () => {
+			mounted = false;
+			unlisten?.();
+		};
+	}, [worktreePath]);
+
+	return statuses;
+}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -323,6 +323,8 @@ export interface SessionStatus {
 	session_state: SessionState;
 	pending_permission: boolean;
 	last_activity_at: number;
+	workflow_step?: string | null;
+	workflow_execution_state?: string | null;
 }
 
 /**

--- a/src/types/workspace-tree.ts
+++ b/src/types/workspace-tree.ts
@@ -42,10 +42,11 @@ export interface WorkspaceSessionNode {
 export type WorkspaceStepStatus =
 	| "queued"
 	| "running"
-	| "waiting_approval"
-	| "completed"
 	| "failed"
-	| "aborted";
+	| "error"
+	| "waiting"
+	| "aborted"
+	| "completed";
 
 export type WorkspaceStepType = "agent" | "bash" | "approval" | "parallel";
 
@@ -71,7 +72,8 @@ export interface WorkspaceWorkflowNode {
 	worktreePath: string;
 	workflowName: string;
 	title: string;
-	status: WorkflowRunSummary["status"];
+	status: WorkspaceStepStatus;
+	canStop: boolean;
 	updatedAt: number;
 	steps: WorkspaceWorkflowStepNode[];
 }
@@ -80,7 +82,7 @@ export interface WorkspaceWorkflowHistoryItem {
 	runId: string;
 	worktreePath: string;
 	title: string;
-	status: WorkflowRunSummary["status"];
+	status: WorkspaceStepStatus | WorkflowRunSummary["status"];
 	updatedAt: number;
 	archivedAt: number;
 	archiveReason: "auto_no_sessions" | "manual" | string;
@@ -89,3 +91,13 @@ export interface WorkspaceWorkflowHistoryItem {
 export type WorkspaceTreeNode = WorkspaceSessionNode | WorkspaceWorkflowNode;
 
 export type WorkspaceSessionHistoryItem = SessionSummary;
+
+export interface WorkflowStepStatusChange {
+	worktreePath: string;
+	executionId: string;
+	stepName: string;
+	runIndex?: number | null;
+	representative?: WorkspaceStepStatus | null;
+	workflowRepresentative?: WorkspaceStepStatus | null;
+	version: number;
+}


### PR DESCRIPTION
## 概要

worktree 単位で workflow ステップのステータスを集約する機能を追加します (#1259)。

各 worktree に紐づく agent session のステップ実行状況を集約し、Workflow パネル／Workspace 一覧で worktree ごとのステップステータスを表示できるようにします。

## 主な変更

- `domain/workflow/status_aggregation.rs` — worktree 単位のステップステータス集約ロジックを新規追加
- `domain/workflow/services/session_projection.rs` — session projection の拡張
- `usecase/agent_session/status.rs` / `usecase/workflow/workspace_tree.rs` — 集約結果の usecase 統合
- `adaptor` / `gateway` — controller・state notification gateway の対応
- フロント: `useWorktreeStepStatuses` フックを新規追加し、`WorkspaceList` / `WorkflowView` / `WorkflowStepStatusIcon` で worktree 単位のステータスを表示
- spec: `docs/specs/issues-1259/` に requirements / behavior / design を追加

## テスト

- Rust: `status_aggregation` / `usecase/agent_session/status` 等にユニットテスト追加
- フロント: `useWorktreeStepStatuses.test.ts` 等を追加・更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * ワークフロー状態表示・集約ロジック再設計の仕様書を追加（要件・設計・振る舞い定義）

* **New Features**
  * ワークフローステップの状態タイプを7種に統一（running / failed / error / waiting / aborted / completed / queued）
  * リアルタイムステップ状態更新を実装（追加ポーリング不要）
  * セッション稼働状態をワークフロー代表状態に反映

* **Improvements**
  * 「待機承認」状態を「待機」に統合
  * ステップ停止可能性をライブ状態に基づいて判定

<!-- end of auto-generated comment: release notes by coderabbit.ai -->