### PR TITLE
fix(agent): Claude backend の Stop を turn のインタラプト境界として扱う (#1255)

### DIFF
--- a/docs/specs/issues-1255/behavior.md
+++ b/docs/specs/issues-1255/behavior.md
@@ -1,0 +1,131 @@
+# Behavior
+
+requirements.md の要求を、観測可能な振る舞いとして Gherkin で定義する。実装上の実現方式（turn generation / interrupt seq / session resume 方針など）は本書では規定せず、`design.md` で決定する。
+
+## 仮定
+
+- 対象 backend は Claude backend（`claude-sdk-bridge`）に限定する（requirements の仮定に従う）。以下のシナリオはすべて Claude backend の AgentChat session を前提とする。
+- 「Stop ボタンが送信ボタンに戻った後」とは、AgentChat の入力エリアが停止操作可能状態（Stop ボタン表示）から送信可能状態（送信ボタン表示）へ戻った状態を指す。
+- 「Stop 前 turn の続きを返さない」ことの外形的判定は、次送信後に返る応答が「新しいユーザー入力に対応した内容」であり、かつ「Stop 前 turn の未完了出力の継続ではない」ことで確認する（requirements の仮定に従う）。
+- 「late event（late stream / late result / late turn_complete）」とは、Stop によって中断した turn に由来し、Stop 操作より後に到着する出力・完了イベントを指す。
+- 「completed と誤認されない」とは、Stop で中断した turn の状態が、通常の正常完了 turn と同一の完了状態として表示・集約・通知されないことを指す。
+
+---
+
+## Feature: Stop を turn のインタラプト境界として扱う
+
+AgentChat（Claude backend）で応答中に Stop を行い、送信ボタンに戻った後に新しいメッセージを送ったとき、Stop 前 turn の続きではなく、新しいユーザー入力への応答が開始される。Stop された turn は通常完了 turn と区別され、Stop 以前の遅延イベントは次 turn に混入しない。
+
+### Background
+
+```gherkin
+Background:
+  Given Claude backend の AgentChat session が開いている
+  And ユーザーがメッセージを送信して turn が応答中（streaming）である
+```
+
+---
+
+### Rule: Stop 後の次送信は新しいユーザー入力への応答として開始される
+
+```gherkin
+Scenario: 送信ボタンに戻った後の次送信が Stop 前 turn の続きを返さない
+  Given ユーザーが応答中に Stop を行った
+  And 入力エリアが送信ボタン表示に戻っている
+  When ユーザーが新しいメッセージを送信する
+  Then 返る応答は新しいメッセージに対応した内容である
+  And Stop 前 turn の未完了出力は継続されない
+
+Scenario: 次送信で停止済み turn の成功完了 resume に起因する長時間待機が発生しない
+  Given ユーザーが応答中に Stop を行った
+  And 入力エリアが送信ボタン表示に戻っている
+  When ユーザーが新しいメッセージを送信する
+  Then 停止済み turn を成功完了として resume したことに起因する長時間待機は発生しない
+  And 応答は新しいメッセージへの応答として開始される
+```
+
+---
+
+### Rule: Stop された turn は通常完了 turn と区別される（interrupted 境界）
+
+```gherkin
+Scenario: Stop された turn が正常完了 turn として扱われない
+  Given ユーザーが応答中に Stop を行った
+  Then Stop された turn は interrupted（中断）として扱われる
+  And Stop された turn は正常完了（成功終了）turn として扱われない
+
+Scenario Outline: interrupted turn が completed と区別される観測面
+  Given ユーザーが応答中に Stop を行った
+  Then <観測面> において interrupted turn は通常の completed turn と区別される
+
+  Examples:
+    | 観測面               |
+    | pending queue        |
+    | workflow 通知        |
+    | status 遷移          |
+```
+
+---
+
+### Rule: Stop 以前に発生した late event は次 turn に混入しない
+
+```gherkin
+Scenario: Stop 前の late stream / late result が次 turn の agent message に混入しない
+  Given ユーザーが応答中に Stop を行った
+  And Stop で中断した turn に由来する late stream / late result が Stop 後に到着する
+  When ユーザーが新しいメッセージを送信する
+  Then late stream / late result は新しい turn の agent message に混入しない
+
+Scenario: Stop 後に到着した late turn_complete が新しい turn を完了扱いにしない
+  Given ユーザーが応答中に Stop を行った
+  When ユーザーが新しいメッセージを送信して新しい turn が応答中になる
+  And Stop で中断した turn に由来する遅延 turn_complete が到着する
+  Then 遅延 turn_complete は新しい turn を完了扱いにしない
+  And 新しい turn は自身の応答に基づいて完了する
+
+Scenario: Stop 後の次送信が旧 turn の pending / stream に混入しない
+  Given ユーザーが応答中に Stop を行った
+  When ユーザーが新しいメッセージを送信する
+  Then 新しい送信は旧 turn の pending / stream に混入しない
+```
+
+---
+
+### Rule: Stop 後の状態は completed と誤認されない
+
+```gherkin
+Scenario Outline: Stop 後の状態が completed と誤認されない
+  Given ユーザーが応答中に Stop を行った
+  Then <表示先> において Stop 後の状態は completed と誤認されない
+
+  Examples:
+    | 表示先              |
+    | UI                  |
+    | SessionStore        |
+    | AgentStatusCenter   |
+```
+
+---
+
+### Rule: 既存挙動を維持する
+
+```gherkin
+Scenario: 通常 turn 完了挙動を壊さない
+  Given Stop を行わず turn が最後まで応答した
+  Then turn は正常完了（completed）として扱われる
+  And 通常完了挙動は従来どおりである
+
+Scenario: stale timeout 挙動を壊さない
+  Given turn が応答中のまま stale timeout 条件に達した
+  Then 既存の stale timeout 挙動が従来どおり適用される
+
+Scenario: workflow step 実行挙動を壊さない
+  Given workflow step が実行されている
+  Then 既存の workflow step 実行挙動が従来どおり適用される
+```
+
+---
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1255/design.md
+++ b/docs/specs/issues-1255/design.md
@@ -1,0 +1,226 @@
+# Design
+
+requirements.md / behavior.md で確定した「Stop を turn のインタラプト境界として扱う」要求を、Claude backend（`claude-sdk-bridge`）の実装方針に落とす。本書は requirements の仮定が design に委ねた以下を確定させる。
+
+- interrupted turn の境界をどこでどう表現するか
+- late event（late stream / late result / late turn_complete）の fencing 方式
+- 停止済み `currentSessionId` の resume 方針（turn generation / turn token の導入）
+
+---
+
+## 概要
+
+### 現状の不具合連鎖（根本原因）
+
+調査により、Stop からバグ顕在化までの連鎖を以下の通り特定した。ファイルパス・行番号は調査時点のもの。
+
+1. ユーザーが応答中に Stop → フロント `useAgentChat.interrupt`（`src/hooks/useAgentChat.ts:737`）→ `invoke("interrupt_agent_query")` → Rust `interrupt_active_agent_turn`（`src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs:5878`）が bridge stdin に `{"type":"interrupt"}` を書き込む。
+2. bridge sidecar（`src-tauri/resources/claude-sdk-bridge.mjs:160`）が `currentAbortController.abort()` を実行。abort で結果（`result`）が出ないまま終わったループは **`turn_complete` を `exit_code: 0` で emit する**（同 `:320-326` / `:349-355`）。**この時点で interrupted turn は正常完了 turn と区別不能になる。**
+3. bridge は abort された turn の `currentSessionId`（中断済み SDK session）を保持し、次ループで `options.resume = currentSessionId` として再開する（同 `:264-266`）。
+4. Rust `turn_complete` ハンドラ（`bridge_common.rs:3706`）は `effect.was_streaming && exit_code == 0` を成功完了とみなし、`persist_agent_session_id` で**中断済み session id を resume ポイントとして永続化**。turn_phase → `Idle`、state → `Ready` に遷移。
+5. `emit_session_state_changed(Idle, Some(0))`（同 `:984`）→ フロント `useAgentSdkListeners`（`src/hooks/useAgentSdkListeners.ts:456`）が `MARK_AGENT_TURN_COMPLETED` + SessionState `done` を dispatch。UI は completed 扱いで送信ボタンへ戻る。
+6. ユーザーが新メッセージ送信 → 中断済み `currentSessionId` を resume → SDK が中断 turn の未完了 tail を継続 → **長時間待機の末、新入力ではなく Stop 前 turn の続きを返す。**
+
+### 修正方針
+
+Stop を「provider abort」から「turn のインタラプト境界」へ格上げするため、**interrupted を bridge → Rust → フロントへ一貫して伝播する第一級シグナル**として導入し、以下を成立させる。
+
+- **A. interrupted の真正シグナル化**: bridge が abort 由来の `turn_complete` に `interrupted: true` を付与する（`exit_code` の値に依存しない明示フラグ）。
+- **B. resume rollback**: interrupted 時、次 turn が中断 tail を継続しないよう、resume ポイントを「最後に `result` を出した正常完了 turn の session id」へ巻き戻す（bridge 内）と同時に、Rust が interrupted turn の session id を永続化しない。
+- **C. late event fencing**: Rust 発行の `turn_token` を `message` コマンドへ載せ、bridge が `turn_complete` / stream にエコーバックする。Rust は active turn の token と一致しないイベントを破棄する。
+- **D. completed 誤認の排除**: interrupted フラグを `agent-session-state-changed` ペイロードへ追加し、フロント・SessionStore・AgentStatusCenter で `completed` と区別する。
+
+### 参照: OpenCode の実装方針
+
+設計確定にあたり OpenCode（`packages/opencode`）の中断処理を調査し、以下を裏付けとした。
+
+- **中断は専用 status enum 値ではなく専用マーカーで表現する**: OpenCode は `status:"aborted"` のような enum 値を持たず、message に `AbortedError`（`"MessageAbortedError"`）という専用エラー型 + `time.completed` をセットして中断を表す。UI では `AbortedError.isInstance()` を判定し、通常エラーとも完了とも別扱いにする（`session/prompt.ts:1256` `finalizeInterruptedAssistant`、`session.ts:37` `AbortedError`）。→ 本設計の AgentState 表現を **(c)（新 enum 値を足さず独立フラグで区別）** に確定する根拠（後述）。
+- **late event fencing に seq を用いる**: `run-coordinator.ts:193` の `interruptSeq` が「古い wake を抑制し、seq の新しいものだけ通す」方式を採る。→ 本設計の `turn_token` fencing（C）と同型であり方針を裏付ける。
+- **中断 turn は履歴に残す**: OpenCode は中断 message を履歴に残し、次 turn を新規に開始する。ただし OpenCode は会話履歴を自前で provider へ渡すため、SDK 側 resume が中断 turn を継続する問題が構造的に起きない。releash は Claude Agent SDK の `resume` が SDK 内 transcript を継続するため、同じ「履歴保持」を素朴に採ると本不具合が再発する。この差分が resume 方針（B）を releash 固有の判断にする（リスクと代替案参照）。
+
+---
+
+## 変更対象
+
+| レイヤー | ファイル | 変更概要 |
+|---|---|---|
+| bridge sidecar | `src-tauri/resources/claude-sdk-bridge.mjs` | abort 由来 `turn_complete` に `interrupted: true` 付与 / resume rollback / `turn_token` エコー |
+| bridge sidecar util | `src-tauri/resources/bridge-utils.mjs` | abort 後の `turn_complete` 生成・resume 巻き戻し判定を純関数化（テスト容易化） |
+| Rust runtime | `src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs` | `turn_complete` の interrupted 分岐 / `persist_agent_session_id` 抑止 / `turn_token` fencing / `emit_session_state_changed` への interrupted 伝播 |
+| Rust usecase | `src-tauri/src/usecase/workflow/turn_complete.rs`（および `WorkflowTurnCompleteCommand`） | workflow 通知へ interrupted を伝播 |
+| Rust status | `src-tauri/src/usecase/agent_session/status.rs` / `src-tauri/src/protocol/agent.rs` | AgentState の interrupted 表現（Open Questions 参照） |
+| フロント | `src/hooks/useAgentSdkListeners.ts` | interrupted 受信時に `MARK_AGENT_TURN_COMPLETED` / `done` 化を抑止 |
+| フロント | `src/hooks/agentChatReducer.ts` | interrupted 状態の保持・表示用導出 |
+| フロント | `src/types/`（`SessionStateChanged` 型） | ペイロードに `interrupted` 追加 |
+
+非対象（requirements の非スコープに従う）: Codex 等他 backend の interrupt 経路、Stop ボタン UI、stale timeout / 通常完了 / workflow step の既存仕様。
+
+---
+
+## アーキテクチャと責務分割
+
+`rust-first-logic` に従い、interrupted 境界の判定・fencing・resume 方針はすべて bridge（Node sidecar）と Rust に置く。フロントは `interrupted` フラグを受けて表示状態を分岐するだけに徹する。
+
+```
+[Front]                [Rust runtime]                 [bridge sidecar (Node)]            [Claude SDK]
+ Stop ──invoke──▶ interrupt_active_agent_turn ──stdin {"type":"interrupt"}──▶ abort() ──▶ AbortController
+                                                                                  │
+                 turn_complete{interrupted,turn_token} ◀── stdout turn_complete ──┘ (resume rollback)
+                       │
+   ┌── interrupted? ──┤
+   │ yes              │ no
+   ▼                  ▼
+ 抑止:               従来:
+ - MARK_COMPLETED   - persist_agent_session_id
+ - done 化           - SessionState=done
+ 表示: 中断境界       - turn_complete 通知
+```
+
+### 各層の責務
+
+- **bridge sidecar**: turn のインタラプトを唯一知る層。abort 検知 → `interrupted: true` 付与、resume ポイント巻き戻し、`turn_token` エコー。
+- **Rust runtime（bridge_common）**: interrupted の中継と fencing の中枢。interrupted turn では (1) session id を永続化しない、(2) `turn_token` 不一致イベントを破棄、(3) `emit_session_state_changed` に interrupted を載せる、(4) workflow 通知へ interrupted を伝播。pending queue の drain 自体は従来どおり行う（Stop 後にキューされた新メッセージは新 turn として開始されるべきため）。
+- **Rust usecase / status**: interrupted を completed と区別した状態として集約。
+- **フロント**: interrupted を受けて `idle`（送信ボタン）には戻すが `done`/completed としては扱わない。
+
+---
+
+## データモデルまたは型
+
+### 1. bridge `turn_complete` メッセージ（拡張）
+
+```jsonc
+{
+  "type": "turn_complete",
+  "session_id": "<sdk session id or null>",
+  "exit_code": 0,
+  "interrupted": true,        // 追加: abort 由来の中断 turn のみ true
+  "turn_token": "<echo>"      // 追加: message コマンドで受け取った token をエコー
+}
+```
+
+- `interrupted` は **abort 経路でのみ** `true`。`result` を伴う自然完了・`exit_code:1` の自然エラー・stale timeout 経路は `false`（省略時は `false` 扱い）。
+- 既存の `exit_code` セマンティクスは変えない（中断は `exit_code:0` のまま）。判定は `interrupted` フラグを正とする。
+
+### 2. bridge `message` コマンド（拡張）
+
+```jsonc
+{ "type": "message", "prompt": "...", "images": [...], "turn_token": "<rust-issued>" }
+```
+
+bridge は受信時に `currentTurnToken = cmd.turn_token` を保持し、当該 turn の `turn_complete` / stream 系 emit にエコーする。
+
+### 3. `turn_token` の生成（Rust）
+
+- 既存の **agent message id**（turn ごとに新規採番される、`PreparedAgentTurn` / pending drain 時に生成）を `turn_token` として再利用する。新規 ID 体系は導入しない。
+- `AgentProcess` に `active_turn_token: Option<String>` を追加し、turn 開始時（`begin_turn_liveness` 近傍）にセット、turn_complete 確定時にクリアする。`turn_seq`（`bridge_common.rs:604`）は watchdog fencing 用に既存のまま併存させ、`turn_token` は late event（特に turn_complete）の同一性照合に用いる。
+
+### 4. `agent-session-state-changed` ペイロード（拡張）
+
+```jsonc
+{ "chat_session_id": "...", "turn_phase": "idle", "exit_code": 0, "completed_at": 123, "interrupted": true }
+```
+
+- フロント型 `SessionStateChanged`（`src/types/`）へ `interrupted?: boolean` を追加。
+
+### 5. SessionState / AgentState のマッピング
+
+- Rust `SessionState`（`usecase/agent_session/session/mod.rs:163`、`Active|Idle|Done|Error|Closed|Archived`）: interrupted turn → **`Idle`**（成功の `Done` でも `Error` でもない、入力待ち状態）。
+- フロント SessionState: interrupted → `idle`（`done`/`error` にしない）。
+- AgentState（`usecase/agent_session/status.rs:8`、`Running|Done|Error|Waiting`）: **新 variant を追加しない**。interrupted 時は `AgentStateSync`（worktree 単位 broadcast）を `Done` で発火**しない**。区別は session 単位の `agent-session-state-changed` の `interrupted` フラグで表現し、AgentStatusCenter はこのフラグで中断を分岐表示する。OpenCode が「中断専用の status enum 値を持たず専用マーカーで区別する」設計を採っていることに倣い、protocol への enum 追加（および WS クライアント deserialize 後方互換リスク）を回避する。
+
+---
+
+## 処理フロー
+
+### F1. Stop（応答中 → interrupt）
+
+1. フロント Stop → `interrupt_agent_query` → `interrupt_active_agent_turn` が `{"type":"interrupt"}` を bridge へ。
+2. bridge `abort()`。abort 検知ループが `turn_complete{interrupted:true, exit_code:0, turn_token}` を emit し、`currentSessionId` を最後の `result` 時点（`lastResultSessionId`）へ巻き戻す。
+3. Rust `turn_complete` ハンドラ:
+   - `interrupted == true` の場合、`persist_agent_session_id` を **呼ばない**（中断 session を resume ポイントにしない）。
+   - `run_turn_complete_transition_locked` で turn_phase → `Idle` へ（UI は送信ボタンへ戻る）。
+   - `emit_session_state_changed(Idle, exit_code, interrupted=true)` を発火。
+   - workflow 通知（`spawn_workflow_turn_complete_notification`）へ interrupted を伝播。
+4. フロント `useAgentSdkListeners`: `interrupted==true` のとき `turn_phase` のみ更新し、`MARK_AGENT_TURN_COMPLETED` と SessionState `done` 化は行わない。SessionState は `idle`。
+
+### F2. Stop 後の次送信（送信ボタン状態 → 新 turn）
+
+1. ユーザー送信。session は busy ではないため新 turn 経路（`bridge_common.rs:7619` 系）で human/agent message を生成、新 `turn_token`（= 新 agent message id）を採番し `message` コマンドへ載せる。
+2. bridge は `currentSessionId == lastResultSessionId`（中断 tail を含まない）から resume するため、**新入力に対する応答として turn を開始**。長時間待機は発生しない。
+
+### F3. Stop（interrupt 進行中）に重ねた送信（pending queue 経路）
+
+1. interrupt 飛行中に送信 → busy 判定で pending queue に積まれ（`bridge_common.rs:7583`）、`interrupt_active_agent_turn` が発火（同 `:7615`）。
+2. interrupted `turn_complete` 到着 → 従来どおり pending を drain し、**新 turn として** `start_pending_message_turn` で開始。drain される新 turn には新 `turn_token` を採番。
+3. workflow 通知は interrupted フラグ付きで送られ、completed turn と区別される。
+
+### F4. late event fencing
+
+- **late turn_complete**: 古い `turn_token` を持つ `turn_complete` は、active turn の `turn_token` と不一致なら破棄する。これにより「新 turn 応答中に遅延 turn_complete 到着 → 新 turn が誤って完了扱い」を防ぐ（behavior の該当 Scenario）。
+- **late stream / late result**: stream 系イベントも `turn_token` を照合し、active でない turn の delta は新 turn の agent message に flush しない。message id がそもそも turn ごとに異なるため、古い delta は古い（中断）message を更新するに留まり、新 message には混入しない（多重防御）。
+
+### F5. 既存経路（非回帰）
+
+- 通常完了（`result` あり、`interrupted=false`）: `persist_agent_session_id` → `Done` の従来挙動を維持。
+- stale timeout（`finalize_turn_as_timeout_locked` / `STALE_EXIT_CODE`、`bridge_common.rs:1459`）: `interrupted=false` のため従来どおり。
+- workflow step 実行: `interrupted=false` の通常 turn_complete として従来どおり。
+
+---
+
+## エラー処理
+
+- **interrupt 書き込み失敗**: 既存どおりフロントの楽観 `interrupting` フラグを戻す（`useAgentChat.ts:737` 周辺の既存処理を維持）。
+- **`interrupted` フラグ欠落（後方互換）**: フィールド未存在時は `false` 扱い。古い bridge と新 Rust の組合せでは従来挙動に縮退する（安全側）。
+- **`turn_token` 欠落**: token 不在の `turn_complete` は「token 照合をスキップして従来どおり処理」する（新規導入による既存経路の破壊を避けるフォールバック）。fencing は token を持つ新経路でのみ強制する。
+- **resume rollback 先が無い（初回 turn を中断）**: `lastResultSessionId` が未確定なら `currentSessionId` を `null`（新規 session）へ。中断 tail の継続を確実に避ける。
+- **interrupted turn の session id 永続化抑止に伴う context 復元**: 既存の `session_ready` resume mismatch 経路（`bridge_common.rs:3539` 周辺）は変更しない。interrupted では永続値を更新しないだけで、最後の正常完了 session id が resume ポイントとして残る。
+
+---
+
+## テスト方針
+
+### Rust 単体（`bridge_common.rs` の `#[cfg(test)]`）
+
+- interrupted `turn_complete` で `persist_agent_session_id` が呼ばれないこと。
+- interrupted `turn_complete` で `emit_session_state_changed` の interrupted フラグが立ち、SessionState が `Idle`（`Done` でない）こと。
+- `turn_token` 不一致の late `turn_complete` が破棄され、新 turn を完了扱いにしないこと（behavior: 遅延 turn_complete）。
+- `turn_token` 不一致の late stream/result が active turn の message に混入しないこと（behavior: late stream/result）。
+- interrupt 進行中送信 → pending drain で新 turn が開始され、workflow 通知に interrupted が伝播すること。
+- 非回帰: 通常完了で従来どおり永続化＋`Done`、stale timeout（`STALE_EXIT_CODE`）が `interrupted=false` で従来挙動、workflow step が従来挙動。
+
+### bridge sidecar（`bridge-utils.test.mjs`）
+
+- abort 後の `turn_complete` 生成が `interrupted:true` + `turn_token` エコーになること（純関数化した生成ロジックを対象）。
+- resume 巻き戻し判定: 中断時に resume ポイントが `lastResultSessionId` になること、初回中断時に `null` になること。
+
+### フロント（Vitest）
+
+- `useAgentSdkListeners.test.ts`: interrupted イベントで `MARK_AGENT_TURN_COMPLETED` が dispatch されず、SessionState が `done` 化しないこと。turn_phase は `idle` に戻ること。
+- `agentChatReducer.test.ts`: interrupted 状態が completed と区別して保持・導出されること。
+
+---
+
+## リスクと代替案
+
+- **resume rollback による中断 turn の履歴扱い**: 採用案は「中断 turn のユーザー入力＋部分出力を resume 履歴から落とす」。これにより「次送信は新入力への応答」を満たすが、会話履歴上は中断 turn が消える。OpenCode は逆に中断 message を履歴に残す（`AbortedError` マーカー付き）が、これは OpenCode が会話履歴を自前で provider へ渡し SDK-resume 継続が起きない構造だから成立する。releash は Claude Agent SDK の `resume` が中断 transcript を継続するため、履歴保持を素朴に採ると本不具合が再発する。**実装時に「Claude Agent SDK が abort 後に transcript をどう finalize するか」を実機確認すること**（リスク）。もし SDK が中断 turn を「停止済み」として clean に finalize できると確認できれば、OpenCode 同様に履歴保持（rollback なし）へ切り替える余地がある（代替案）。確認が取れるまでは、新入力への応答開始の確実性を優先し rollback を採用する。
+- **`turn_token` エコーの SDK 非対応**: token は bridge 自身が `turn_complete`/stream emit に付与するため SDK 側の対応は不要。SDK の `result` メッセージ自体には付かないが、bridge が turn 境界を握っているため問題ない。
+- **late event の実順序**: bridge は単一プロセスで abort → ループ `continue` → 次 query を直列化するため、現状でも late turn_complete のレースは限定的。ただし behavior が明示要求するため `turn_token` fencing を多重防御として実装する。
+- **AgentState protocol 拡張の影響**: 新 variant 追加は WS クライアントの deserialize に影響しうる（Open Questions 参照）。
+
+---
+
+## 仮定
+
+- 対象 backend は Claude backend（`claude-sdk-bridge`）に限定（requirements/behavior の仮定を継承）。
+- `turn_token` には既存の agent message id を再利用する（turn ごとに新規採番される既存資産）。新 ID 体系は導入しない。
+- interrupted turn の SessionState は `Idle`、SDK session の resume ポイントは「最後の正常完了 turn」とする。
+- `interrupted` / `turn_token` フィールドが欠落する組合せでは従来挙動に安全に縮退する（後方互換フォールバックを設ける）。
+
+---
+
+## Open Questions
+
+なし。
+
+（AgentState における interrupted の表現は、OpenCode が中断専用の status enum 値を持たず専用マーカーで区別している実装を確認したうえで、option (c)＝新 enum 値を追加せず session 単位の `interrupted` フラグで区別する方針に確定した。データモデル §5 参照。）

--- a/docs/specs/issues-1255/requirements.md
+++ b/docs/specs/issues-1255/requirements.md
@@ -1,0 +1,84 @@
+# Requirements
+
+## Type
+
+不具合修正。
+
+関連: #1255 / #1178 / #731 / #1192 / #1246
+
+## 背景と目的
+
+AgentChat の Claude backend で、応答中に Stop ボタンを押して停止し、UI が送信ボタンに戻った後に新しいメッセージを送ると、長時間待たされたうえで Stop 前の turn の続きが返ってくることがある。
+
+ユーザーは Stop 直後ではなく、送信ボタンへ戻った後に新しいメッセージを送っている。にもかかわらず、内部的には Stop 済みの Claude SDK session を成功終了扱いで resume して次 turn を投げるため、中断済み turn の状態が transcript / SDK session に残っている場合、新しい入力ではなく Stop 前 turn の続きを返してしまう。
+
+本変更の目的は、Stop を「単なる provider abort」ではなく「turn のインタラプト境界」として扱い、Stop 後の次送信が必ずユーザーの新しい入力への応答として開始されるようにすることである。
+
+## スコープ
+
+- Stop された turn を、通常完了（正常終了）turn と区別して扱う。
+- Stop 後の次送信が、停止済み turn の続きを再開せず、新しいユーザー入力への応答として開始されるようにする。
+- Stop 以前に発生した遅延イベント（late stream / late result / late turn_complete）を、次 turn の agent message に混入させない。
+- Stop 後の状態が UI / SessionStore / AgentStatusCenter で `completed` と誤認されないようにする。
+- 上記を Claude backend（claude-sdk-bridge）の経路で成立させる。
+
+## 非スコープ
+
+- Claude 以外の agent backend の Stop / interrupt 挙動の変更（本 Issue は Claude backend を対象とする。下記「仮定」参照）。
+- 通常 turn 完了、stale timeout、workflow step 実行といった既存挙動の仕様変更（これらは壊さないことが条件であり、変更対象ではない）。
+- Stop 操作自体の UI（ボタン位置・見た目・操作フロー）の変更。
+- 関連 Issue（#1178 / #731 / #1192 / #1246）が指す個別問題そのものの修正（本変更で副次的に改善する可能性はあるが、修正完了の責務には含めない）。
+
+## 要求事項
+
+### Stop 後の次送信
+
+- Stop ボタンが送信ボタンに戻った後に新しいメッセージを送った場合、Stop 前 turn の続きを返さないこと。
+- Stop 後の次送信は、ユーザーが送った新しい入力への応答として開始されること。
+- Stop 後の次送信で、停止済み turn を成功完了として resume したことに起因する長時間待機が発生しないこと。
+
+### Interrupted turn の区別
+
+- Stop された turn を、通常完了 turn と区別できる「interrupted（中断）」境界として扱うこと。
+- Stop された turn を、正常完了（成功終了）turn として扱わないこと。
+- pending queue / workflow 通知 / status 遷移において、interrupted turn を通常の completed turn と区別すること。
+
+### Late event の遮断
+
+- Stop 以前に発生した late stream / late result / late turn_complete が、次 turn の agent message に混入しないこと。
+- Stop 後に到着した遅延 turn_complete が、新しい turn を完了扱いにしないこと。
+- Stop 後の次送信が、旧 turn の pending / stream に混入しないこと。
+
+### 状態表示の整合
+
+- Stop 後の状態が UI で `completed` と誤認されないこと。
+- Stop 後の状態が SessionStore で `completed` と誤認されないこと。
+- Stop 後の状態が AgentStatusCenter で `completed` と誤認されないこと。
+
+### 既存挙動の維持
+
+- 既存の通常 turn 完了挙動を壊さないこと。
+- 既存の stale timeout 挙動を壊さないこと。
+- 既存の workflow step 実行挙動を壊さないこと。
+
+## 受け入れ基準の概要
+
+- Stop ボタンが送信ボタンに戻った後に新しいメッセージを送っても、Stop 前 turn の続きを返さない。
+- Stop 後の次送信が新しいユーザー入力への応答として開始される。
+- Stop 以前の late event が次 turn の agent message に混入しない。
+- Stop 後の状態が UI / SessionStore / AgentStatusCenter で `completed` と誤認されない。
+- 既存の通常 turn 完了、stale timeout、workflow step 実行を壊さない。
+- 単体テストまたは統合テストで以下を確認する。
+  - Stop 後の late `turn_complete` が新 turn を完了扱いにしないこと。
+  - Stop 後の次送信が旧 turn の pending / stream に混入しないこと。
+  - interrupted turn 後の Claude bridge / session 再利用ポリシーが期待どおりであること。
+
+## 仮定
+
+- 本変更の対象 backend は Claude backend（`claude-sdk-bridge`）に限定する。Issue の症状・調査メモ・関連箇所がすべて Claude 経路に閉じているため。他 backend への展開が必要な場合は別 Issue で扱う。
+- 「Stop 後の次送信が Stop 前 turn の続きを返さない」ことの外形的な判定は、新しいユーザー入力の内容に対応した応答が返ること、および Stop 前 turn の未完了出力が継続されないことで確認できるものとする。
+- interrupted turn の境界・late event の fencing・session 再利用ポリシーの具体的な実現方式（turn generation / interrupt seq の導入有無や、停止済み `currentSessionId` の resume 方針など）は本要求では確定させず、`design.md` で決定する。
+
+## Open Questions
+
+なし。

--- a/src-tauri/resources/bridge-utils.mjs
+++ b/src-tauri/resources/bridge-utils.mjs
@@ -44,3 +44,74 @@ export function shouldResolvePromptForCurrentQuery(state) {
 		state.hasPendingPromptResolver && !state.completedResultForCurrentQuery
 	);
 }
+
+/**
+ * Build a bridge turn completion message. The interrupted flag is explicit so
+ * Rust does not need to infer user interrupts from exit codes.
+ *
+ * @param {{ sessionId?: string|null, exitCode: number, interrupted?: boolean, turnToken?: string|null }} state
+ * @returns {object}
+ */
+export function buildTurnCompleteMessage(state) {
+	const message = {
+		type: "turn_complete",
+		session_id: state.sessionId || null,
+		exit_code: state.exitCode,
+	};
+	if (state.interrupted) {
+		message.interrupted = true;
+	}
+	if (state.turnToken) {
+		message.turn_token = state.turnToken;
+	}
+	return message;
+}
+
+/**
+ * Build the completion state for an SDK result message. If the turn was already
+ * aborted, interruption wins over a successful result so the interrupted SDK
+ * session never becomes the clean resume point.
+ *
+ * @param {{ sessionId?: string|null, currentSessionId?: string|null, hasErrors: boolean, wasAborted: boolean, turnToken?: string|null }} state
+ * @returns {{ message: object, exitCode: number, completedSessionIdForResume: string|null }}
+ */
+export function buildResultTurnCompletion(state) {
+	const exitCode = state.wasAborted ? 0 : state.hasErrors ? 1 : 0;
+	const completedSessionIdForResume =
+		!state.wasAborted && exitCode === 0
+			? state.sessionId || state.currentSessionId || null
+			: null;
+	return {
+		message: buildTurnCompleteMessage({
+			sessionId: state.sessionId || null,
+			exitCode,
+			interrupted: state.wasAborted,
+			turnToken: state.turnToken,
+		}),
+		exitCode,
+		completedSessionIdForResume,
+	};
+}
+
+/**
+ * Abort rolls the SDK resume point back to the last cleanly completed result.
+ * If no clean result exists, the next query must start a fresh SDK session.
+ *
+ * @param {{ lastResultSessionId?: string|null }} state
+ * @returns {string|null}
+ */
+export function rollbackResumeSessionIdAfterInterrupt(state) {
+	return state.lastResultSessionId || null;
+}
+
+/**
+ * Echo the Rust-issued turn token on SDK events generated for that turn.
+ *
+ * @param {object} message
+ * @param {string|null|undefined} turnToken
+ * @returns {object}
+ */
+export function withTurnToken(message, turnToken) {
+	if (!turnToken) return message;
+	return { ...message, turn_token: turnToken };
+}

--- a/src-tauri/resources/bridge-utils.test.mjs
+++ b/src-tauri/resources/bridge-utils.test.mjs
@@ -1,8 +1,14 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	buildResultTurnCompletion,
 	buildSystemPromptOption,
+	buildTurnCompleteMessage,
+	rollbackResumeSessionIdAfterInterrupt,
 	shouldContinueBridgeLoopAfterQueryEnd,
 	shouldResolvePromptForCurrentQuery,
+	withTurnToken,
 } from "./bridge-utils.mjs";
 
 describe("buildSystemPromptOption", () => {
@@ -102,5 +108,144 @@ describe("shouldResolvePromptForCurrentQuery", () => {
 				completedResultForCurrentQuery: false,
 			}),
 		).toBe(false);
+	});
+});
+
+describe("buildResultTurnCompletion", () => {
+	it("treats a result delivered after abort as interrupted", () => {
+		expect(
+			buildResultTurnCompletion({
+				sessionId: "sdk-interrupted",
+				currentSessionId: "sdk-interrupted",
+				hasErrors: false,
+				wasAborted: true,
+				turnToken: "agent-message-1",
+			}),
+		).toEqual({
+			message: {
+				type: "turn_complete",
+				session_id: "sdk-interrupted",
+				exit_code: 0,
+				interrupted: true,
+				turn_token: "agent-message-1",
+			},
+			exitCode: 0,
+			completedSessionIdForResume: null,
+		});
+	});
+
+	it("keeps a successful non-aborted result reusable for resume", () => {
+		expect(
+			buildResultTurnCompletion({
+				sessionId: "sdk-clean",
+				currentSessionId: "sdk-current",
+				hasErrors: false,
+				wasAborted: false,
+			}),
+		).toEqual({
+			message: {
+				type: "turn_complete",
+				session_id: "sdk-clean",
+				exit_code: 0,
+			},
+			exitCode: 0,
+			completedSessionIdForResume: "sdk-clean",
+		});
+	});
+
+	it("does not reuse errored result sessions for resume", () => {
+		expect(
+			buildResultTurnCompletion({
+				sessionId: "sdk-error",
+				currentSessionId: "sdk-current",
+				hasErrors: true,
+				wasAborted: false,
+			}),
+		).toEqual({
+			message: {
+				type: "turn_complete",
+				session_id: "sdk-error",
+				exit_code: 1,
+			},
+			exitCode: 1,
+			completedSessionIdForResume: null,
+		});
+	});
+});
+
+describe("buildTurnCompleteMessage", () => {
+	it("marks interrupted completions explicitly and echoes turn token", () => {
+		expect(
+			buildTurnCompleteMessage({
+				sessionId: "sdk-interrupted",
+				exitCode: 0,
+				interrupted: true,
+				turnToken: "agent-message-1",
+			}),
+		).toEqual({
+			type: "turn_complete",
+			session_id: "sdk-interrupted",
+			exit_code: 0,
+			interrupted: true,
+			turn_token: "agent-message-1",
+		});
+	});
+
+	it("keeps normal completions backward compatible", () => {
+		expect(
+			buildTurnCompleteMessage({
+				sessionId: "sdk-ok",
+				exitCode: 0,
+			}),
+		).toEqual({
+			type: "turn_complete",
+			session_id: "sdk-ok",
+			exit_code: 0,
+		});
+	});
+});
+
+describe("rollbackResumeSessionIdAfterInterrupt", () => {
+	it("rolls back to the last successful result session", () => {
+		expect(
+			rollbackResumeSessionIdAfterInterrupt({
+				lastResultSessionId: "sdk-clean",
+			}),
+		).toBe("sdk-clean");
+	});
+
+	it("starts fresh when the first turn was interrupted", () => {
+		expect(
+			rollbackResumeSessionIdAfterInterrupt({
+				lastResultSessionId: null,
+			}),
+		).toBeNull();
+	});
+});
+
+describe("withTurnToken", () => {
+	it("adds turn_token when present", () => {
+		expect(withTurnToken({ type: "assistant" }, "agent-message-1")).toEqual({
+			type: "assistant",
+			turn_token: "agent-message-1",
+		});
+	});
+
+	it("does not change tokenless messages", () => {
+		const message = { type: "assistant" };
+		expect(withTurnToken(message, null)).toBe(message);
+	});
+});
+
+describe("claude bridge permission requests", () => {
+	it("emits permission_request with the current turn token", () => {
+		const source = readFileSync(
+			join(process.cwd(), "src-tauri/resources/claude-sdk-bridge.mjs"),
+			"utf8",
+		);
+
+		expect(source).toMatch(
+			/emit\(\s*withTurnToken\(\s*\{\s*type: "permission_request"[\s\S]*?\},\s*currentTurnToken,\s*\),\s*\);/,
+		);
 	});
 });

--- a/src-tauri/resources/claude-sdk-bridge.mjs
+++ b/src-tauri/resources/claude-sdk-bridge.mjs
@@ -1,9 +1,13 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import crypto from "node:crypto";
 import {
+	buildResultTurnCompletion,
 	buildSystemPromptOption,
+	buildTurnCompleteMessage,
+	rollbackResumeSessionIdAfterInterrupt,
 	shouldContinueBridgeLoopAfterQueryEnd,
 	shouldResolvePromptForCurrentQuery,
+	withTurnToken,
 } from "./bridge-utils.mjs";
 
 const pendingPermissions = new Map();
@@ -11,6 +15,8 @@ const messageQueue = [];
 let currentQuery = null;
 let currentAbortController = null;
 let currentSessionId = null;
+let lastResultSessionId = null;
+let currentTurnToken = null;
 let messageResolve = null;
 let closed = false;
 let sessionReady = false;
@@ -32,19 +38,22 @@ async function* promptGenerator(promptState) {
 	while (!closed) {
 		if (promptState.completedResult) return;
 		if (messageQueue.length > 0) {
-			yield messageQueue.shift();
+			const queued = messageQueue.shift();
+			currentTurnToken = queued.turnToken;
+			yield queued.message;
 			continue;
 		}
-		const prompt = await new Promise((resolve) => {
+		const queued = await new Promise((resolve) => {
 			messageResolve = resolve;
 		});
 		messageResolve = null;
-		if (prompt === null) return;
+		if (queued === null) return;
 		if (promptState.completedResult) {
-			messageQueue.unshift(prompt);
+			messageQueue.unshift(queued);
 			return;
 		}
-		yield prompt;
+		currentTurnToken = queued.turnToken;
+		yield queued.message;
 	}
 }
 
@@ -143,6 +152,13 @@ function handleCommand(cmd) {
 			break;
 		case "message": {
 			const msg = toUserMessage(applyRestoreContext(cmd.prompt), cmd.images);
+			const queued = {
+				message: msg,
+				turnToken:
+					typeof cmd.turn_token === "string" && cmd.turn_token.length > 0
+						? cmd.turn_token
+						: null,
+			};
 			if (
 				shouldResolvePromptForCurrentQuery({
 					hasPendingPromptResolver: Boolean(messageResolve),
@@ -151,9 +167,9 @@ function handleCommand(cmd) {
 					),
 				})
 			) {
-				messageResolve(msg);
+				messageResolve(queued);
 			} else {
-				messageQueue.push(msg);
+				messageQueue.push(queued);
 			}
 			break;
 		}
@@ -238,20 +254,26 @@ async function handleInit(cmd) {
 		return new Promise((resolve) => {
 			const requestId = crypto.randomUUID();
 			pendingPermissions.set(requestId, { resolve, input });
-			emit({
-				type: "permission_request",
-				request_id: requestId,
-				tool_name: toolName,
-				input,
-				tool_use_id: meta.toolUseID,
-				title: meta.title,
-				display_name: meta.displayName,
-				description: meta.description,
-				decision_reason: meta.decisionReason,
-			});
+			emit(
+				withTurnToken(
+					{
+						type: "permission_request",
+						request_id: requestId,
+						tool_name: toolName,
+						input,
+						tool_use_id: meta.toolUseID,
+						title: meta.title,
+						display_name: meta.displayName,
+						description: meta.description,
+						decision_reason: meta.decisionReason,
+					},
+					currentTurnToken,
+				),
+			);
 		});
 	};
 
+	lastResultSessionId = cmd.sessionId || null;
 	if (cmd.sessionId) {
 		options.resume = cmd.sessionId;
 	}
@@ -294,22 +316,33 @@ async function handleInit(cmd) {
 			for await (const message of currentQuery) {
 				if (message.session_id && message.session_id !== currentSessionId) {
 					currentSessionId = message.session_id;
-					emit({ type: "session_ready", session_id: message.session_id });
+					emit(
+						withTurnToken(
+							{ type: "session_ready", session_id: message.session_id },
+							currentTurnToken,
+						),
+					);
 					sessionReady = true;
 				}
-				emit(message);
+				emit(withTurnToken(message, currentTurnToken));
 
 				if (message.type === "result") {
 					gotResult = true;
 					promptState.completedResult = true;
 					const hasErrors =
 						message.errors && Array.isArray(message.errors) && message.errors.length > 0;
-					turnExitCode = hasErrors ? 1 : 0;
-					emit({
-						type: "turn_complete",
-						session_id: message.session_id || null,
-						exit_code: turnExitCode,
+					const completion = buildResultTurnCompletion({
+						sessionId: message.session_id || null,
+						currentSessionId,
+						hasErrors,
+						wasAborted: Boolean(currentAbortController.signal.aborted),
+						turnToken: currentTurnToken,
 					});
+					turnExitCode = completion.exitCode;
+					if (completion.completedSessionIdForResume) {
+						lastResultSessionId = completion.completedSessionIdForResume;
+					}
+					emit(completion.message);
 					closePendingPromptForCurrentQuery();
 				}
 			}
@@ -319,12 +352,18 @@ async function handleInit(cmd) {
 				closePendingPromptForCurrentQuery();
 				if (!gotResult) {
 					turnExitCode = 0;
-					emit({
-						type: "turn_complete",
-						session_id: currentSessionId || null,
-						exit_code: 0,
-					});
+					emit(
+						buildTurnCompleteMessage({
+							sessionId: currentSessionId || null,
+							exitCode: 0,
+							interrupted: true,
+							turnToken: currentTurnToken,
+						}),
+					);
 				}
+				currentSessionId = rollbackResumeSessionIdAfterInterrupt({
+					lastResultSessionId,
+				});
 				if (shouldContinueBridgeLoopAfterQueryEnd({ closed, turnExitCode })) {
 					continue;
 				}
@@ -335,11 +374,13 @@ async function handleInit(cmd) {
 				continue;
 			}
 			if (!closed && !gotResult) {
-				emit({
-					type: "turn_complete",
-					session_id: currentSessionId || null,
-					exit_code: 1,
-				});
+				emit(
+					buildTurnCompleteMessage({
+						sessionId: currentSessionId || null,
+						exitCode: 1,
+						turnToken: currentTurnToken,
+					}),
+				);
 			}
 			break;
 		} catch (e) {
@@ -348,12 +389,18 @@ async function handleInit(cmd) {
 				closePendingPromptForCurrentQuery();
 				if (!gotResult) {
 					turnExitCode = 0;
-					emit({
-						type: "turn_complete",
-						session_id: currentSessionId || null,
-						exit_code: 0,
-					});
+					emit(
+						buildTurnCompleteMessage({
+							sessionId: currentSessionId || null,
+							exitCode: 0,
+							interrupted: true,
+							turnToken: currentTurnToken,
+						}),
+					);
 				}
+				currentSessionId = rollbackResumeSessionIdAfterInterrupt({
+					lastResultSessionId,
+				});
 				if (shouldContinueBridgeLoopAfterQueryEnd({ closed, turnExitCode })) {
 					continue;
 				}

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
@@ -9199,7 +9199,6 @@ mod tests {
             &pending.content,
             &agent_msg.id,
             &pending.images,
-            TurnOrigin::Desktop,
             {
                 let spawn_count = Arc::clone(&spawn_count);
                 move || async move {

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
@@ -96,6 +96,12 @@ pub struct AgentProcess {
     #[cfg(unix)]
     pub pgid: Option<u32>,
     pub streaming_message_id: Option<String>,
+    /// Rust-issued per-turn token echoed by the Claude bridge. Uses the agent
+    /// message id so stale bridge events cannot complete or mutate a later turn.
+    pub active_turn_token: Option<String>,
+    /// Token for the most recent normally completed turn. Kept only while
+    /// `last_message_id` can accept post-turn background task updates.
+    post_turn_message_token: Option<String>,
     pub streaming_parts: Vec<MessagePart>,
     /// Retained after turn_complete so post-turn background task events
     /// can still be accumulated and emitted via `agent-streaming-updated`.
@@ -176,6 +182,8 @@ pub(crate) fn make_test_agent_process() -> AgentProcess {
         #[cfg(unix)]
         pgid: None,
         streaming_message_id: None,
+        active_turn_token: None,
+        post_turn_message_token: None,
         streaming_parts: Vec::new(),
         last_message_id: None,
         post_turn_base_untrusted_message_id: None,
@@ -561,6 +569,7 @@ impl AgentProcess {
         self.pending_stream_bytes = 0;
         self.last_stream_emit_at = None;
         self.last_message_id = None;
+        self.post_turn_message_token = None;
         self.post_turn_base_untrusted_message_id = None;
         self.task_id_map.clear();
     }
@@ -951,6 +960,7 @@ fn emit_session_state_changed<R: tauri::Runtime>(
     chat_session_id: &str,
     turn_phase: TurnPhase,
     exit_code: Option<i64>,
+    interrupted: bool,
 ) {
     use tauri::Emitter;
     let completed_at = exit_code.map(|_| now_timestamp());
@@ -961,8 +971,33 @@ fn emit_session_state_changed<R: tauri::Runtime>(
             "turn_phase": turn_phase,
             "exit_code": exit_code,
             "completed_at": completed_at,
+            "interrupted": interrupted,
         }),
     );
+}
+
+fn bridge_message_turn_token(msg: &serde_json::Value) -> Option<&str> {
+    msg.get("turn_token")
+        .and_then(|v| v.as_str())
+        .filter(|token| !token.is_empty())
+}
+
+/// Accept token-bearing events for the active turn, or for the retained
+/// normally completed turn while post-turn background task updates are allowed.
+fn bridge_message_is_stale_for_active_turn(proc: &AgentProcess, msg: &serde_json::Value) -> bool {
+    let Some(turn_token) = bridge_message_turn_token(msg) else {
+        return false;
+    };
+    if proc.active_turn_token.as_deref() == Some(turn_token) {
+        return false;
+    }
+    if proc.active_turn_token.is_none()
+        && proc.last_message_id.is_some()
+        && proc.post_turn_message_token.as_deref() == Some(turn_token)
+    {
+        return false;
+    }
+    true
 }
 
 /// Emit the cumulative `streaming_parts` payload over both delivery channels.
@@ -1411,6 +1446,12 @@ where
     let turn_token_usage = proc.last_result_token_usage.take();
     let final_parts = consolidate_parts_from_slice(&proc.streaming_parts);
     let final_msg_id = proc.streaming_message_id.take();
+    let completed_turn_token = proc.active_turn_token.take();
+    proc.post_turn_message_token = if exit_code == 0 && final_msg_id.is_some() {
+        completed_turn_token
+    } else {
+        None
+    };
     if final_msg_id.is_some() {
         proc.last_message_id.clone_from(&final_msg_id);
     }
@@ -3445,6 +3486,8 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                 #[cfg(unix)]
                 pgid,
                 streaming_message_id: None,
+                active_turn_token: None,
+                post_turn_message_token: None,
                 streaming_parts: Vec::new(),
                 last_message_id: None,
                 post_turn_base_untrusted_message_id: None,
@@ -3514,50 +3557,64 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                             context_carry_on_ready,
                             resume_mismatch,
                             requeue_candidate,
+                            stale_event,
                         ) = {
                             let mut map = handles_stdout.lock().await;
                             if let Some(proc) = map.get_mut(&csid_stdout) {
-                                // Only transition to Ready if still Initializing (not already Streaming)
-                                let was_initializing = proc.state == BridgeState::Initializing;
-                                if was_initializing {
-                                    proc.state = BridgeState::Ready;
-                                }
-                                let ready_session_id =
-                                    msg.get("session_id").and_then(|v| v.as_str());
-                                let requested_resume_id = proc.sdk_session_id.clone();
-                                let context_carry_on_ready = proc.context_carry_on_ready.take();
-                                let resume_mismatch = session_ready_resume_mismatch(
-                                    context_carry_on_ready.as_ref(),
-                                    requested_resume_id.as_deref(),
-                                    ready_session_id,
-                                );
-                                let requeue_candidate = if resume_mismatch {
-                                    streaming_turn_requeue_candidate(proc)
+                                if bridge_message_is_stale_for_active_turn(proc, &msg) {
+                                    (false, None, false, None, true)
                                 } else {
-                                    None
-                                };
-                                if let Some(sid) = ready_session_id {
-                                    proc.sdk_session_id = Some(sid.to_string());
-                                    if !resume_mismatch && !defer_agent_session_id_persist_on_ready
-                                    {
-                                        persist_agent_session_id(
-                                            &app_stdout,
-                                            &session_store_clone,
-                                            &csid_stdout,
-                                            sid,
-                                        );
+                                    // Only transition to Ready if still Initializing (not already Streaming)
+                                    let was_initializing = proc.state == BridgeState::Initializing;
+                                    if was_initializing {
+                                        proc.state = BridgeState::Ready;
                                     }
+                                    let ready_session_id =
+                                        msg.get("session_id").and_then(|v| v.as_str());
+                                    let requested_resume_id = proc.sdk_session_id.clone();
+                                    let context_carry_on_ready = proc.context_carry_on_ready.take();
+                                    let resume_mismatch = session_ready_resume_mismatch(
+                                        context_carry_on_ready.as_ref(),
+                                        requested_resume_id.as_deref(),
+                                        ready_session_id,
+                                    );
+                                    let requeue_candidate = if resume_mismatch {
+                                        streaming_turn_requeue_candidate(proc)
+                                    } else {
+                                        None
+                                    };
+                                    if let Some(sid) = ready_session_id {
+                                        proc.sdk_session_id = Some(sid.to_string());
+                                        let defer_streaming_claude_session_id = proc.backend_id
+                                            == CLAUDE_BACKEND_ID
+                                            && proc.turn_phase != TurnPhase::Idle;
+                                        if !resume_mismatch
+                                            && !defer_agent_session_id_persist_on_ready
+                                            && !defer_streaming_claude_session_id
+                                        {
+                                            persist_agent_session_id(
+                                                &app_stdout,
+                                                &session_store_clone,
+                                                &csid_stdout,
+                                                sid,
+                                            );
+                                        }
+                                    }
+                                    (
+                                        was_initializing,
+                                        context_carry_on_ready,
+                                        resume_mismatch,
+                                        requeue_candidate,
+                                        false,
+                                    )
                                 }
-                                (
-                                    was_initializing,
-                                    context_carry_on_ready,
-                                    resume_mismatch,
-                                    requeue_candidate,
-                                )
                             } else {
-                                (false, None, false, None)
+                                (false, None, false, None, false)
                             }
                         };
+                        if stale_event {
+                            continue;
+                        }
                         if resume_mismatch {
                             let requeued_streaming_turn = if let Some(candidate) = requeue_candidate
                             {
@@ -3589,6 +3646,7 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                                     &csid_stdout,
                                     TurnPhase::Idle,
                                     None,
+                                    false,
                                 );
                                 notify_status_transition(
                                     &app_stdout,
@@ -3668,6 +3726,15 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                         let _ = app_stdout.emit("agent-sdk-message", &msg);
                     }
                     "result" => {
+                        let stale_event = {
+                            let map = handles_stdout.lock().await;
+                            map.get(&csid_stdout).is_some_and(|proc| {
+                                bridge_message_is_stale_for_active_turn(proc, &msg)
+                            })
+                        };
+                        if stale_event {
+                            continue;
+                        }
                         if let Some(token_usage) = token_usage_from_result_message(&msg) {
                             let mut map = handles_stdout.lock().await;
                             if let Some(proc) = map.get_mut(&csid_stdout) {
@@ -3681,53 +3748,85 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                     }
                     "turn_complete" => {
                         let exit_code = msg.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(0);
+                        let interrupted = msg
+                            .get("interrupted")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        let completed_session_id = msg
+                            .get("session_id")
+                            .and_then(|v| v.as_str())
+                            .map(ToString::to_string);
+                        let rollback_sdk_session_id = if interrupted {
+                            load_persisted_agent_session_id_for_resume(
+                                &app_stdout,
+                                &session_store_clone,
+                                &csid_stdout,
+                            )
+                        } else {
+                            None
+                        };
                         // session_runtime_lock の保持はローカル proc 状態遷移の
                         // 区間に限定する。workflow turn-complete usecase や pending
                         // message 消費は lock を保持しない経路で行い、それらが必要に応じ
                         // 自前で lock を取得する設計とする（再入デッドロックを防ぐ）。
-                        let (effect, context_restore_failed_on_init) = {
+                        let (effect, context_restore_failed_on_init, stale_event) = {
                             let _runtime_guard = acquire_session_runtime_lock(&csid_stdout).await;
                             let mut map = handles_stdout.lock().await;
                             if let Some(proc) = map.get_mut(&csid_stdout) {
-                                // Run the in-lock transition through the shared
-                                // helper so production and unit tests exercise the
-                                // exact same flush → state-mutation order. Flush
-                                // failure is best-effort — we still mutate state so
-                                // turn_complete notification fires.
-                                let effect = run_turn_complete_transition_locked(
-                                    proc,
-                                    &csid_stdout,
-                                    exit_code,
-                                    |mid, parts| {
-                                        emit_streaming_parts(
-                                            &app_stdout,
-                                            &csid_stdout,
-                                            mid,
-                                            parts.to_vec(),
-                                        )
-                                    },
-                                );
-                                let context_restore_failed_on_init = !effect.was_streaming
-                                    && exit_code != 0
-                                    && proc.context_carry_on_ready.take().is_some();
-
-                                // User turn succeeded: persist agent_session_id to SessionStore
-                                if effect.was_streaming && exit_code == 0 {
-                                    if let Some(sid) = &proc.sdk_session_id {
-                                        persist_agent_session_id(
-                                            &app_stdout,
-                                            &session_store_clone,
-                                            &csid_stdout,
-                                            sid,
-                                        );
+                                if bridge_message_is_stale_for_active_turn(proc, &msg) {
+                                    (TurnCompleteTransition::default(), false, true)
+                                } else {
+                                    // Run the in-lock transition through the shared
+                                    // helper so production and unit tests exercise the
+                                    // exact same flush → state-mutation order. Flush
+                                    // failure is best-effort — we still mutate state so
+                                    // turn_complete notification fires.
+                                    let effect = run_turn_complete_transition_locked(
+                                        proc,
+                                        &csid_stdout,
+                                        exit_code,
+                                        |mid, parts| {
+                                            emit_streaming_parts(
+                                                &app_stdout,
+                                                &csid_stdout,
+                                                mid,
+                                                parts.to_vec(),
+                                            )
+                                        },
+                                    );
+                                    if interrupted {
+                                        proc.sdk_session_id = rollback_sdk_session_id.clone();
+                                        proc.post_turn_message_token = None;
                                     }
+                                    let context_restore_failed_on_init = !effect.was_streaming
+                                        && exit_code != 0
+                                        && proc.context_carry_on_ready.take().is_some();
+
+                                    // User turn succeeded: persist agent_session_id to SessionStore
+                                    if effect.was_streaming && exit_code == 0 && !interrupted {
+                                        let sid = completed_session_id
+                                            .clone()
+                                            .or_else(|| proc.sdk_session_id.clone());
+                                        if let Some(sid) = sid {
+                                            proc.sdk_session_id = Some(sid.clone());
+                                            persist_agent_session_id(
+                                                &app_stdout,
+                                                &session_store_clone,
+                                                &csid_stdout,
+                                                &sid,
+                                            );
+                                        }
+                                    }
+                                    (effect, context_restore_failed_on_init, false)
                                 }
-                                (effect, context_restore_failed_on_init)
                             } else {
-                                (TurnCompleteTransition::default(), false)
+                                (TurnCompleteTransition::default(), false, false)
                             }
                             // _runtime_guard はこのスコープを抜けて drop される
                         };
+                        if stale_event {
+                            continue;
+                        }
 
                         // Resume failure (error during init) → clear stale agent_session_id
                         if !effect.was_streaming && exit_code != 0 {
@@ -3748,7 +3847,10 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                             &csid_stdout,
                             exit_code,
                             effect,
-                            true,
+                            TurnCompletePostOptions {
+                                consume_pending: true,
+                                interrupted,
+                            },
                         )
                         .await;
                     }
@@ -3793,7 +3895,10 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                             &csid_stdout,
                             1,
                             turn_complete,
-                            true,
+                            TurnCompletePostOptions {
+                                consume_pending: true,
+                                interrupted: false,
+                            },
                         )
                         .await;
                         if was_initializing {
@@ -3834,6 +3939,15 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                         }
                     }
                     _ => {
+                        let stale_event = {
+                            let map = handles_stdout.lock().await;
+                            map.get(&csid_stdout).is_some_and(|proc| {
+                                bridge_message_is_stale_for_active_turn(proc, &msg)
+                            })
+                        };
+                        if stale_event {
+                            continue;
+                        }
                         // Accumulate into streaming buffer, enqueue delta into the
                         // coalescing buffer, and flush when warranted. We hold the
                         // lock across the flush so the emit observes consistent
@@ -3942,6 +4056,7 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                                 &csid_stdout,
                                 TurnPhase::WaitingPermission,
                                 None,
+                                false,
                             );
                             notify_status_transition(
                                 &app_stdout,
@@ -4016,7 +4131,10 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                 &csid_stdout,
                 -1,
                 effect,
-                true,
+                TurnCompletePostOptions {
+                    consume_pending: true,
+                    interrupted: false,
+                },
             )
             .await;
         } else if was_initializing {
@@ -4088,6 +4206,12 @@ fn try_mark_turn_watchdog_active(proc: &mut AgentProcess) -> bool {
     true
 }
 
+#[derive(Debug, Clone, Copy)]
+struct TurnCompletePostOptions {
+    consume_pending: bool,
+    interrupted: bool,
+}
+
 async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     session_store: &Arc<SessionStore>,
@@ -4095,11 +4219,12 @@ async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
     chat_session_id: &str,
     exit_code: i64,
     effect: TurnCompleteTransition,
-    consume_pending: bool,
+    options: TurnCompletePostOptions,
 ) {
     if !effect.was_streaming {
         return;
     }
+    let interrupted = options.interrupted;
 
     if let Some(ref mid) = effect.final_msg_id {
         if !effect.final_parts.is_empty() {
@@ -4118,12 +4243,32 @@ async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
         }
     }
 
-    emit_session_state_changed(app, chat_session_id, TurnPhase::Idle, Some(exit_code));
-    let override_state = if exit_code != 0 {
+    emit_session_state_changed(
+        app,
+        chat_session_id,
+        TurnPhase::Idle,
+        Some(exit_code),
+        interrupted,
+    );
+    let override_state = if interrupted {
+        Some(crate::usecase::agent_session::session::SessionState::Idle)
+    } else if exit_code != 0 {
         Some(crate::usecase::agent_session::session::SessionState::Error)
     } else {
         None
     };
+    if interrupted {
+        if let Ok(data_dir) = resolve_data_dir(app) {
+            if let Err(e) = crate::usecase::agent_session::session::update_session_state_in_data_dir(
+                session_store,
+                &data_dir,
+                chat_session_id,
+                crate::usecase::agent_session::session::SessionState::Idle,
+            ) {
+                log::warn!("Failed to mark interrupted session idle for {chat_session_id}: {e}");
+            }
+        }
+    }
     notify_status_transition(
         app,
         session_store,
@@ -4132,7 +4277,7 @@ async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
         override_state,
     );
 
-    let pending = if consume_pending {
+    let pending = if options.consume_pending {
         take_pending_message(handles, chat_session_id).await
     } else {
         None
@@ -4146,6 +4291,7 @@ async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
         effect.final_parts,
         effect.turn_token_usage,
         pending,
+        interrupted,
     );
 }
 
@@ -4263,7 +4409,10 @@ async fn finalize_timed_out_turn<R: tauri::Runtime>(
         chat_session_id,
         STALE_EXIT_CODE,
         effect,
-        true,
+        TurnCompletePostOptions {
+            consume_pending: true,
+            interrupted: false,
+        },
     )
     .await;
 
@@ -5330,6 +5479,43 @@ fn persist_agent_session_id<R: tauri::Runtime>(
     }
 }
 
+fn load_persisted_agent_session_id_for_resume<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    session_store: &SessionStore,
+    chat_session_id: &str,
+) -> Option<String> {
+    let data_dir = match resolve_data_dir(app) {
+        Ok(data_dir) => data_dir,
+        Err(e) => {
+            log::warn!(
+                "Failed to resolve data dir for interrupted resume rollback \
+                 (session {chat_session_id}): {e}"
+            );
+            return None;
+        }
+    };
+    let session = match session_store.load_full_session_for_restore(&data_dir, chat_session_id) {
+        Ok(Some(session)) => session,
+        Ok(None) => {
+            log::warn!(
+                "Session not found for interrupted resume rollback: session {chat_session_id}"
+            );
+            return None;
+        }
+        Err(e) => {
+            log::warn!(
+                "Failed to load session for interrupted resume rollback \
+                 (session {chat_session_id}): {e}"
+            );
+            return None;
+        }
+    };
+    session.agent_session_id.and_then(|sid| match sid.trim() {
+        "" => None,
+        trimmed => Some(trimmed.to_string()),
+    })
+}
+
 fn should_mark_context_carry_failed_after_init_error(
     context_carry: Option<&ContextCarryState>,
     force_context_carry_failed: bool,
@@ -5528,7 +5714,7 @@ pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
     .await?;
 
     // Emit state change so frontend can track turn phase
-    emit_session_state_changed(app, chat_session_id, TurnPhase::Streaming, None);
+    emit_session_state_changed(app, chat_session_id, TurnPhase::Streaming, None, false);
     notify_status_transition(
         app,
         session_store,
@@ -5605,7 +5791,7 @@ async fn start_agent_turn_locked<R: tauri::Runtime>(
     .await?;
 
     // Emit state change so frontend can track turn phase
-    emit_session_state_changed(app, chat_session_id, TurnPhase::Streaming, None);
+    emit_session_state_changed(app, chat_session_id, TurnPhase::Streaming, None, false);
     notify_status_transition(
         app,
         session_store,
@@ -5713,7 +5899,7 @@ where
     // Even if a message is sent while the SDK is still processing an interrupt,
     // the Bridge's promptGenerator queues it and only yields after the current turn completes.
     // The SDK calls generator.next() only when ready for the next turn, providing ordering guarantee.
-    let msg_cmd = build_message_cmd(prompt, images);
+    let msg_cmd = build_message_cmd(prompt, images, Some(streaming_message_id));
     let data = format!("{}\n", msg_cmd);
 
     {
@@ -5725,6 +5911,7 @@ where
             proc.state = BridgeState::Streaming;
             proc.turn_phase = TurnPhase::Streaming;
             proc.streaming_message_id = Some(streaming_message_id.to_string());
+            proc.active_turn_token = Some(streaming_message_id.to_string());
             proc.reset_streaming_state_for_new_turn();
             proc.begin_turn_liveness();
             proc.stdin
@@ -6650,7 +6837,7 @@ pub async fn respond_agent_permission_internal(
 
     // Emit state change only if we actually transitioned: WaitingPermission → Streaming
     if did_transition_to_streaming {
-        emit_session_state_changed(app, &chat_session_id, TurnPhase::Streaming, None);
+        emit_session_state_changed(app, &chat_session_id, TurnPhase::Streaming, None, false);
         notify_status_transition(
             app,
             session_store,
@@ -6696,10 +6883,11 @@ pub(crate) async fn start_external_agent_turn_state<R: tauri::Runtime>(
         proc.state = BridgeState::Streaming;
         proc.turn_phase = TurnPhase::Streaming;
         proc.streaming_message_id = Some(streaming_message_id.to_string());
+        proc.active_turn_token = Some(streaming_message_id.to_string());
         proc.reset_streaming_state_for_new_turn();
         spawn_streaming_timer(app, handles, chat_session_id, proc);
     }
-    emit_session_state_changed(app, chat_session_id, TurnPhase::Streaming, None);
+    emit_session_state_changed(app, chat_session_id, TurnPhase::Streaming, None, false);
     notify_status_transition(
         app,
         session_store,
@@ -6769,6 +6957,8 @@ pub(crate) async fn register_external_agent_process<R: tauri::Runtime>(
                 #[cfg(unix)]
                 pgid,
                 streaming_message_id: None,
+                active_turn_token: None,
+                post_turn_message_token: None,
                 streaming_parts: Vec::new(),
                 last_message_id: None,
                 post_turn_base_untrusted_message_id: None,
@@ -6955,6 +7145,7 @@ fn spawn_workflow_turn_complete_notification<R: tauri::Runtime>(
     final_parts: Vec<MessagePart>,
     token_usage: Option<(u64, u64)>,
     pending: Option<PendingMessage>,
+    interrupted: bool,
 ) {
     let workflow_runtime: Option<Arc<crate::usecase::workflow::WorkflowRuntimeUsecase>> = app
         .try_state::<Arc<crate::usecase::workflow::WorkflowRuntimeUsecase>>()
@@ -6971,12 +7162,14 @@ fn spawn_workflow_turn_complete_notification<R: tauri::Runtime>(
                             output_tokens,
                         }
                     });
-                    let command = crate::usecase::workflow::ports::WorkflowTurnCompleteCommand {
-                        chat_session_id: chat_session_id.clone(),
-                        exit_code,
-                        final_text_parts,
-                        token_usage,
-                    };
+                    let command =
+                        crate::usecase::workflow::ports::WorkflowTurnCompleteNotification {
+                            chat_session_id: chat_session_id.clone(),
+                            exit_code,
+                            final_text_parts,
+                            token_usage,
+                            interrupted,
+                        };
                     if let Err(e) = runtime.complete_turn(command).await {
                         log::error!("Workflow turn completion error for {chat_session_id}: {e}");
                     }
@@ -7014,31 +7207,38 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
 
     match msg_type {
         "session_ready" => {
-            let (context_carry_on_ready, resume_mismatch) = {
+            let (context_carry_on_ready, resume_mismatch, stale_event) = {
                 let mut map = handles.lock().await;
                 if let Some(proc) = map.get_mut(chat_session_id) {
-                    if proc.state == BridgeState::Initializing {
-                        proc.state = BridgeState::Ready;
-                    }
-                    let ready_session_id = msg.get("session_id").and_then(|v| v.as_str());
-                    let requested_resume_id = proc.sdk_session_id.clone();
-                    let context_carry_on_ready = proc.context_carry_on_ready.take();
-                    let resume_mismatch = session_ready_resume_mismatch(
-                        context_carry_on_ready.as_ref(),
-                        requested_resume_id.as_deref(),
-                        ready_session_id,
-                    );
-                    if let Some(sid) = ready_session_id {
-                        proc.sdk_session_id = Some(sid.to_string());
-                        if !resume_mismatch && !defer_agent_session_id_persist_on_ready {
-                            persist_agent_session_id(app, session_store, chat_session_id, sid);
+                    if bridge_message_is_stale_for_active_turn(proc, &msg) {
+                        (None, false, true)
+                    } else {
+                        if proc.state == BridgeState::Initializing {
+                            proc.state = BridgeState::Ready;
                         }
+                        let ready_session_id = msg.get("session_id").and_then(|v| v.as_str());
+                        let requested_resume_id = proc.sdk_session_id.clone();
+                        let context_carry_on_ready = proc.context_carry_on_ready.take();
+                        let resume_mismatch = session_ready_resume_mismatch(
+                            context_carry_on_ready.as_ref(),
+                            requested_resume_id.as_deref(),
+                            ready_session_id,
+                        );
+                        if let Some(sid) = ready_session_id {
+                            proc.sdk_session_id = Some(sid.to_string());
+                            if !resume_mismatch && !defer_agent_session_id_persist_on_ready {
+                                persist_agent_session_id(app, session_store, chat_session_id, sid);
+                            }
+                        }
+                        (context_carry_on_ready, resume_mismatch, false)
                     }
-                    (context_carry_on_ready, resume_mismatch)
                 } else {
-                    (None, false)
+                    (None, false, false)
                 }
             };
+            if stale_event {
+                return;
+            }
             if resume_mismatch {
                 persist_resume_mismatch_for_reinject(app, session_store, chat_session_id);
                 crash_agent_process_for_context_reinject(app, handles, chat_session_id).await;
@@ -7049,6 +7249,14 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
             let _ = app.emit("agent-sdk-message", &msg);
         }
         "result" => {
+            let stale_event = {
+                let map = handles.lock().await;
+                map.get(chat_session_id)
+                    .is_some_and(|proc| bridge_message_is_stale_for_active_turn(proc, &msg))
+            };
+            if stale_event {
+                return;
+            }
             if let Some(token_usage) = token_usage_from_result_message(&msg) {
                 let mut map = handles.lock().await;
                 if let Some(proc) = map.get_mut(chat_session_id) {
@@ -7061,30 +7269,50 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
         }
         "turn_complete" => {
             let exit_code = msg.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(0);
+            let interrupted = msg
+                .get("interrupted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             let completed_session_id = msg
                 .get("session_id")
                 .and_then(|v| v.as_str())
                 .map(ToString::to_string);
-            let (effect, context_restore_failed_on_init) = {
+            let rollback_sdk_session_id = if interrupted {
+                load_persisted_agent_session_id_for_resume(app, session_store, chat_session_id)
+            } else {
+                None
+            };
+            let (effect, context_restore_failed_on_init, stale_event) = {
                 let _runtime_guard = acquire_session_runtime_lock(chat_session_id).await;
                 let mut map = handles.lock().await;
                 if let Some(proc) = map.get_mut(chat_session_id) {
-                    let effect = run_turn_complete_transition_locked(
-                        proc,
-                        chat_session_id,
-                        exit_code,
-                        |mid, parts| {
-                            emit_streaming_parts(app, chat_session_id, mid, parts.to_vec())
-                        },
-                    );
-                    let context_restore_failed_on_init = !effect.was_streaming
-                        && exit_code != 0
-                        && proc.context_carry_on_ready.take().is_some();
-                    (Some(effect), context_restore_failed_on_init)
+                    if bridge_message_is_stale_for_active_turn(proc, &msg) {
+                        (None, false, true)
+                    } else {
+                        let effect = run_turn_complete_transition_locked(
+                            proc,
+                            chat_session_id,
+                            exit_code,
+                            |mid, parts| {
+                                emit_streaming_parts(app, chat_session_id, mid, parts.to_vec())
+                            },
+                        );
+                        if interrupted {
+                            proc.sdk_session_id = rollback_sdk_session_id.clone();
+                            proc.post_turn_message_token = None;
+                        }
+                        let context_restore_failed_on_init = !effect.was_streaming
+                            && exit_code != 0
+                            && proc.context_carry_on_ready.take().is_some();
+                        (Some(effect), context_restore_failed_on_init, false)
+                    }
                 } else {
-                    (None, false)
+                    (None, false, false)
                 }
             };
+            if stale_event {
+                return;
+            }
 
             let Some(effect) = effect else {
                 return;
@@ -7097,7 +7325,7 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                 released_streaming_parts,
             } = effect;
             if was_streaming {
-                if exit_code == 0 {
+                if exit_code == 0 && !interrupted {
                     if let Some(sid) = completed_session_id.as_deref() {
                         persist_agent_session_id(app, session_store, chat_session_id, sid);
                     }
@@ -7123,8 +7351,32 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     }
                 }
                 drop(released_streaming_parts);
-                emit_session_state_changed(app, chat_session_id, TurnPhase::Idle, Some(exit_code));
-                let override_state = if exit_code != 0 {
+                if interrupted {
+                    if let Ok(data_dir) = resolve_data_dir(app) {
+                        if let Err(e) =
+                            crate::usecase::agent_session::session::update_session_state_in_data_dir(
+                                session_store,
+                                &data_dir,
+                                chat_session_id,
+                                crate::usecase::agent_session::session::SessionState::Idle,
+                            )
+                        {
+                            log::warn!(
+                                "Failed to mark interrupted session idle for {chat_session_id}: {e}"
+                            );
+                        }
+                    }
+                }
+                emit_session_state_changed(
+                    app,
+                    chat_session_id,
+                    TurnPhase::Idle,
+                    Some(exit_code),
+                    interrupted,
+                );
+                let override_state = if interrupted {
+                    Some(crate::usecase::agent_session::session::SessionState::Idle)
+                } else if exit_code != 0 {
                     Some(crate::usecase::agent_session::session::SessionState::Error)
                 } else {
                     None
@@ -7162,6 +7414,7 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     final_parts,
                     turn_token_usage,
                     pending,
+                    interrupted,
                 );
             } else if exit_code != 0 {
                 persist_context_carry_failed_after_init_error(
@@ -7208,7 +7461,7 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                         }
                     }
                 }
-                emit_session_state_changed(app, chat_session_id, TurnPhase::Idle, Some(1));
+                emit_session_state_changed(app, chat_session_id, TurnPhase::Idle, Some(1), false);
                 notify_status_transition(
                     app,
                     session_store,
@@ -7237,6 +7490,7 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     effect.final_parts,
                     effect.turn_token_usage,
                     pending,
+                    false,
                 );
             } else if transition.was_initializing {
                 notify_status_transition(
@@ -7275,6 +7529,14 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
             }
         }
         _ => {
+            let stale_event = {
+                let map = handles.lock().await;
+                map.get(chat_session_id)
+                    .is_some_and(|proc| bridge_message_is_stale_for_active_turn(proc, &msg))
+            };
+            if stale_event {
+                return;
+            }
             let elapsed_persist = state.last_persist_time.elapsed().as_millis() as u64;
             let mut effect = accumulate_stream_or_post_turn_message(
                 app,
@@ -7336,6 +7598,7 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     chat_session_id,
                     TurnPhase::WaitingPermission,
                     None,
+                    false,
                 );
                 notify_status_transition(
                     app,
@@ -8117,8 +8380,12 @@ fn build_init_cmd(
     Ok(cmd)
 }
 
-fn build_message_cmd(prompt: &str, images: &[ImageAttachment]) -> serde_json::Value {
-    if images.is_empty() {
+fn build_message_cmd(
+    prompt: &str,
+    images: &[ImageAttachment],
+    turn_token: Option<&str>,
+) -> serde_json::Value {
+    let mut cmd = if images.is_empty() {
         serde_json::json!({
             "type": "message",
             "prompt": prompt,
@@ -8138,7 +8405,11 @@ fn build_message_cmd(prompt: &str, images: &[ImageAttachment]) -> serde_json::Va
             "prompt": prompt,
             "images": img_blocks,
         })
+    };
+    if let Some(turn_token) = turn_token.filter(|value| !value.is_empty()) {
+        cmd["turn_token"] = serde_json::Value::String(turn_token.to_string());
     }
+    cmd
 }
 
 /// Validate and encode an image from raw bytes.
@@ -8374,6 +8645,34 @@ mod tests {
         }
 
         async fn close_session(&self, _session: &SessionHandle) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingWorkflowTurnCompleteGateway {
+        session_running: bool,
+        calls: std::sync::Mutex<Vec<&'static str>>,
+    }
+
+    #[async_trait]
+    impl crate::usecase::workflow::ports::WorkflowTurnCompleteGateway
+        for RecordingWorkflowTurnCompleteGateway
+    {
+        async fn is_session_running(&self, _chat_session_id: &str) -> bool {
+            self.calls.lock().unwrap().push("is_running");
+            self.session_running
+        }
+
+        async fn pickup_pending_submit_outputs(&self) {
+            self.calls.lock().unwrap().push("pickup_pending");
+        }
+
+        async fn complete_turn(
+            &self,
+            _command: crate::usecase::workflow::ports::WorkflowTurnCompleteCommand,
+        ) -> Result<(), crate::domain::workflow::WorkflowError> {
+            self.calls.lock().unwrap().push("complete_turn");
             Ok(())
         }
     }
@@ -8624,6 +8923,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_session_ready_token_does_not_update_resume_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let mut session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        session.agent_session_id = Some("previous-good-session".to_string());
+        session.context_carry = Some(ContextCarryState::Resumed);
+        store
+            .save_full_session_for_migration_or_restore(temp.path(), &session)
+            .unwrap();
+
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let mut proc = make_test_agent_process();
+        proc.backend_id = CLAUDE_BACKEND_ID.to_string();
+        proc.state = BridgeState::Streaming;
+        proc.turn_phase = TurnPhase::Streaming;
+        proc.active_turn_token = Some("new-agent-message".to_string());
+        proc.sdk_session_id = Some("new-sdk-session".to_string());
+        proc.context_carry_on_ready = Some(ContextCarryState::Resumed);
+        handles.lock().await.insert(session.id.clone(), proc);
+        let mut state = ExternalBridgeMessageState::default();
+
+        handle_external_bridge_message(
+            &app.handle(),
+            &store,
+            &handles,
+            &session.id,
+            serde_json::json!({
+                "type": "session_ready",
+                "session_id": "old-sdk-session",
+                "turn_token": "old-agent-message",
+            }),
+            &mut state,
+        )
+        .await;
+
+        let loaded = store
+            .load_full_session_for_restore(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            loaded.agent_session_id.as_deref(),
+            Some("previous-good-session")
+        );
+        assert_eq!(loaded.context_carry, Some(ContextCarryState::Resumed));
+        let removed = handles.lock().await.remove(&session.id);
+        if let Some(mut proc) = removed {
+            assert_eq!(proc.state, BridgeState::Streaming);
+            assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+            assert_eq!(proc.sdk_session_id.as_deref(), Some("new-sdk-session"));
+            assert_eq!(proc.active_turn_token.as_deref(), Some("new-agent-message"));
+            assert_eq!(
+                proc.context_carry_on_ready,
+                Some(ContextCarryState::Resumed)
+            );
+            let _ = proc.child.kill().await;
+        }
+    }
+
+    #[tokio::test]
     async fn external_turn_complete_persists_successful_session_id() {
         let temp = tempfile::tempdir().unwrap();
         let app = tauri::test::mock_builder()
@@ -8668,6 +9036,509 @@ mod tests {
         let removed = handles.lock().await.remove(&session.id);
         if let Some(mut proc) = removed {
             assert_eq!(proc.state, BridgeState::Ready);
+            let _ = proc.child.kill().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn interrupted_turn_complete_does_not_persist_session_id_and_marks_idle() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let mut session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        session.agent_session_id = Some("previous-good-session".to_string());
+        session.state = crate::usecase::agent_session::session::SessionState::Done;
+        store
+            .save_full_session_for_migration_or_restore(temp.path(), &session)
+            .unwrap();
+
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let mut proc = make_test_agent_process();
+        proc.backend_id = CLAUDE_BACKEND_ID.to_string();
+        proc.state = BridgeState::Streaming;
+        proc.turn_phase = TurnPhase::Streaming;
+        proc.streaming_message_id = Some("agent-message-1".to_string());
+        proc.active_turn_token = Some("agent-message-1".to_string());
+        proc.sdk_session_id = Some("interrupted-sdk-session".to_string());
+        handles.lock().await.insert(session.id.clone(), proc);
+        let mut state = ExternalBridgeMessageState::default();
+
+        handle_external_bridge_message(
+            &app.handle(),
+            &store,
+            &handles,
+            &session.id,
+            serde_json::json!({
+                "type": "turn_complete",
+                "session_id": "interrupted-sdk-session",
+                "exit_code": 0,
+                "interrupted": true,
+                "turn_token": "agent-message-1",
+            }),
+            &mut state,
+        )
+        .await;
+
+        let loaded = store
+            .load_full_session_for_restore(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            loaded.agent_session_id.as_deref(),
+            Some("previous-good-session")
+        );
+        assert_eq!(
+            loaded.state,
+            crate::usecase::agent_session::session::SessionState::Idle
+        );
+        let removed = handles.lock().await.remove(&session.id);
+        if let Some(mut proc) = removed {
+            assert_eq!(proc.state, BridgeState::Ready);
+            assert_eq!(proc.turn_phase, TurnPhase::Idle);
+            assert_eq!(
+                proc.sdk_session_id.as_deref(),
+                Some("previous-good-session")
+            );
+            assert!(proc.active_turn_token.is_none());
+            assert!(proc.post_turn_message_token.is_none());
+            let _ = proc.child.kill().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn interrupted_turn_complete_drains_pending_starts_new_turn_and_fences_old_token() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let mut session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        session.agent_session_id = Some("previous-good-session".to_string());
+        store
+            .save_full_session_for_migration_or_restore(temp.path(), &session)
+            .unwrap();
+
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let old_turn_token = "old-agent-message";
+        let mut proc = make_test_agent_process();
+        proc.backend_id = CLAUDE_BACKEND_ID.to_string();
+        proc.state = BridgeState::Streaming;
+        proc.turn_phase = TurnPhase::Streaming;
+        proc.streaming_message_id = Some(old_turn_token.to_string());
+        proc.active_turn_token = Some(old_turn_token.to_string());
+        proc.sdk_session_id = Some("interrupted-sdk-session".to_string());
+        proc.streaming_parts.push(MessagePart::Text {
+            content: "old response".to_string(),
+            parent_tool_use_id: None,
+        });
+        proc.pending_messages
+            .push_back(test_pending_message("queued-followup", "next prompt"));
+        handles.lock().await.insert(session.id.clone(), proc);
+
+        let interrupted = true;
+        let (final_parts, turn_token_usage) = {
+            let mut map = handles.lock().await;
+            let proc = map.get_mut(&session.id).unwrap();
+            let effect =
+                run_turn_complete_transition_locked(proc, &session.id, 0, |_mid, _parts| {
+                    (true, true)
+                });
+            proc.sdk_session_id = Some("previous-good-session".to_string());
+            proc.post_turn_message_token = None;
+            assert!(effect.was_streaming);
+            assert_eq!(proc.state, BridgeState::Ready);
+            assert_eq!(proc.turn_phase, TurnPhase::Idle);
+            assert!(proc.active_turn_token.is_none());
+            (effect.final_parts, effect.turn_token_usage)
+        };
+
+        let loaded = store
+            .load_full_session_for_restore(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            loaded.agent_session_id.as_deref(),
+            Some("previous-good-session")
+        );
+
+        let pending = take_pending_message(&handles, &session.id)
+            .await
+            .expect("pending follow-up turn should be drained");
+        assert!(!agent_session_has_pending_message(&handles, &session.id).await);
+
+        let (_human_msg, agent_msg, emit_consumed_messages) =
+            prepare_pending_turn_messages(&store, temp.path(), &session.id, &pending).unwrap();
+        assert!(emit_consumed_messages);
+        assert_ne!(agent_msg.id, old_turn_token);
+
+        let spawn_count = Arc::new(AtomicUsize::new(0));
+        start_agent_turn_with_runtime_spawner(
+            None::<&tauri::AppHandle>,
+            None,
+            &handles,
+            &session.id,
+            &pending.permission_mode,
+            &pending.content,
+            &agent_msg.id,
+            &pending.images,
+            TurnOrigin::Desktop,
+            {
+                let spawn_count = Arc::clone(&spawn_count);
+                move || async move {
+                    spawn_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            spawn_count.load(Ordering::SeqCst),
+            0,
+            "existing bridge runtime should be reused for the pending turn"
+        );
+        {
+            let map = handles.lock().await;
+            let proc = map.get(&session.id).unwrap();
+            assert_eq!(proc.state, BridgeState::Streaming);
+            assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+            assert_eq!(
+                proc.streaming_message_id.as_deref(),
+                Some(agent_msg.id.as_str())
+            );
+            assert_eq!(
+                proc.active_turn_token.as_deref(),
+                Some(agent_msg.id.as_str())
+            );
+            assert!(proc.streaming_parts.is_empty());
+        }
+
+        let mut state = ExternalBridgeMessageState::default();
+        handle_external_bridge_message(
+            &app.handle(),
+            &store,
+            &handles,
+            &session.id,
+            serde_json::json!({
+                "type": "stream_event",
+                "turn_token": old_turn_token,
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": " stale tail"}
+                }
+            }),
+            &mut state,
+        )
+        .await;
+        {
+            let map = handles.lock().await;
+            let proc = map.get(&session.id).unwrap();
+            assert!(
+                proc.streaming_parts.is_empty(),
+                "old token stream must not append to the new turn"
+            );
+            assert_eq!(
+                proc.active_turn_token.as_deref(),
+                Some(agent_msg.id.as_str())
+            );
+        }
+
+        handle_external_bridge_message(
+            &app.handle(),
+            &store,
+            &handles,
+            &session.id,
+            serde_json::json!({
+                "type": "turn_complete",
+                "session_id": "old-sdk-session",
+                "exit_code": 0,
+                "turn_token": old_turn_token,
+            }),
+            &mut state,
+        )
+        .await;
+        {
+            let map = handles.lock().await;
+            let proc = map.get(&session.id).unwrap();
+            assert_eq!(proc.state, BridgeState::Streaming);
+            assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+            assert_eq!(
+                proc.active_turn_token.as_deref(),
+                Some(agent_msg.id.as_str())
+            );
+        }
+
+        let workflow_gateway = Arc::new(RecordingWorkflowTurnCompleteGateway {
+            session_running: true,
+            ..Default::default()
+        });
+        let workflow = crate::usecase::workflow::turn_complete::WorkflowTurnCompleteUsecase::new(
+            workflow_gateway.clone(),
+        );
+        workflow
+            .complete_turn(
+                crate::usecase::workflow::ports::WorkflowTurnCompleteNotification {
+                    chat_session_id: session.id.clone(),
+                    exit_code: 0,
+                    final_text_parts: workflow_final_text_parts(&final_parts),
+                    token_usage: turn_token_usage.map(|(input_tokens, output_tokens)| {
+                        crate::usecase::workflow::ports::WorkflowTurnTokenUsage {
+                            input_tokens,
+                            output_tokens,
+                        }
+                    }),
+                    interrupted,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            workflow_gateway.calls.lock().unwrap().as_slice(),
+            ["is_running"],
+            "interrupted workflow notification must not complete the workflow turn"
+        );
+
+        clear_pending_turn_starting(&session.id).await;
+        let removed = handles.lock().await.remove(&session.id);
+        if let Some(mut proc) = removed {
+            let _ = proc.child.kill().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_turn_complete_token_does_not_complete_active_turn() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let mut session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        session.agent_session_id = Some("previous-good-session".to_string());
+        store
+            .save_full_session_for_migration_or_restore(temp.path(), &session)
+            .unwrap();
+
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let mut proc = make_test_agent_process();
+        proc.backend_id = CLAUDE_BACKEND_ID.to_string();
+        proc.state = BridgeState::Streaming;
+        proc.turn_phase = TurnPhase::Streaming;
+        proc.streaming_message_id = Some("new-agent-message".to_string());
+        proc.active_turn_token = Some("new-agent-message".to_string());
+        proc.sdk_session_id = Some("new-sdk-session".to_string());
+        handles.lock().await.insert(session.id.clone(), proc);
+        let mut state = ExternalBridgeMessageState::default();
+
+        handle_external_bridge_message(
+            &app.handle(),
+            &store,
+            &handles,
+            &session.id,
+            serde_json::json!({
+                "type": "turn_complete",
+                "session_id": "old-sdk-session",
+                "exit_code": 0,
+                "turn_token": "old-agent-message",
+            }),
+            &mut state,
+        )
+        .await;
+
+        let loaded = store
+            .load_full_session_for_restore(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            loaded.agent_session_id.as_deref(),
+            Some("previous-good-session")
+        );
+        let removed = handles.lock().await.remove(&session.id);
+        if let Some(mut proc) = removed {
+            assert_eq!(proc.state, BridgeState::Streaming);
+            assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+            assert_eq!(
+                proc.streaming_message_id.as_deref(),
+                Some("new-agent-message")
+            );
+            assert_eq!(proc.active_turn_token.as_deref(), Some("new-agent-message"));
+            let _ = proc.child.kill().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_stream_token_does_not_append_to_active_message() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let mut proc = make_test_agent_process();
+        proc.backend_id = CLAUDE_BACKEND_ID.to_string();
+        proc.state = BridgeState::Streaming;
+        proc.turn_phase = TurnPhase::Streaming;
+        proc.streaming_message_id = Some("new-agent-message".to_string());
+        proc.active_turn_token = Some("new-agent-message".to_string());
+        handles.lock().await.insert(session.id.clone(), proc);
+        let mut state = ExternalBridgeMessageState::default();
+
+        handle_external_bridge_message(
+            &app.handle(),
+            &store,
+            &handles,
+            &session.id,
+            serde_json::json!({
+                "type": "stream_event",
+                "turn_token": "old-agent-message",
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "old tail"}
+                }
+            }),
+            &mut state,
+        )
+        .await;
+
+        let removed = handles.lock().await.remove(&session.id);
+        if let Some(mut proc) = removed {
+            assert!(proc.streaming_parts.is_empty());
+            assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+            let _ = proc.child.kill().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn permission_request_token_fence_rejects_stale_and_accepts_active_turn() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let mut proc = make_test_agent_process();
+        proc.backend_id = CLAUDE_BACKEND_ID.to_string();
+        proc.state = BridgeState::Streaming;
+        proc.turn_phase = TurnPhase::Streaming;
+        proc.streaming_message_id = Some("new-agent-message".to_string());
+        proc.active_turn_token = Some("new-agent-message".to_string());
+        handles.lock().await.insert(session.id.clone(), proc);
+        let mut state = ExternalBridgeMessageState::default();
+
+        handle_external_bridge_message(
+            &app.handle(),
+            &store,
+            &handles,
+            &session.id,
+            serde_json::json!({
+                "type": "permission_request",
+                "request_id": "stale-permission",
+                "tool_name": "Edit",
+                "input": {},
+                "tool_use_id": "toolu_stale",
+                "turn_token": "old-agent-message",
+            }),
+            &mut state,
+        )
+        .await;
+
+        {
+            let map = handles.lock().await;
+            let proc = map.get(&session.id).unwrap();
+            assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+            assert_eq!(proc.active_turn_token.as_deref(), Some("new-agent-message"));
+            assert!(
+                !proc.streaming_parts.iter().any(|part| matches!(
+                    part,
+                    MessagePart::Permission {
+                        status,
+                        request,
+                        ..
+                    } if status == "pending"
+                        && request.get("request_id").and_then(|v| v.as_str())
+                            == Some("stale-permission")
+                )),
+                "stale permission_request must not create pending permission state"
+            );
+        }
+
+        handle_external_bridge_message(
+            &app.handle(),
+            &store,
+            &handles,
+            &session.id,
+            serde_json::json!({
+                "type": "permission_request",
+                "request_id": "active-permission",
+                "tool_name": "Edit",
+                "input": {},
+                "tool_use_id": "toolu_active",
+                "turn_token": "new-agent-message",
+            }),
+            &mut state,
+        )
+        .await;
+
+        let removed = handles.lock().await.remove(&session.id);
+        if let Some(mut proc) = removed {
+            assert_eq!(proc.turn_phase, TurnPhase::WaitingPermission);
+            assert_eq!(proc.active_turn_token.as_deref(), Some("new-agent-message"));
+            assert!(
+                proc.streaming_parts.iter().any(|part| matches!(
+                    part,
+                    MessagePart::Permission {
+                        status,
+                        request,
+                        ..
+                    } if status == "pending"
+                        && request.get("request_id").and_then(|v| v.as_str())
+                            == Some("active-permission")
+                )),
+                "matching permission_request should keep entering WaitingPermission"
+            );
             let _ = proc.child.kill().await;
         }
     }
@@ -10440,6 +11311,55 @@ mod tests {
                 exit_code: Some(exit_code),
             });
         }
+    }
+
+    #[tokio::test]
+    async fn normal_turn_complete_allows_same_token_post_turn_updates() {
+        let mut proc = make_streaming_test_process();
+        proc.streaming_message_id = Some("agent-message-1".to_string());
+        proc.active_turn_token = Some("agent-message-1".to_string());
+
+        let mut events = Vec::new();
+        drive_turn_complete_path(&mut proc, "csid", 0, &mut events);
+
+        assert!(proc.active_turn_token.is_none());
+        assert_eq!(
+            proc.post_turn_message_token.as_deref(),
+            Some("agent-message-1")
+        );
+        assert_eq!(proc.last_message_id.as_deref(), Some("agent-message-1"));
+
+        let post_turn_msg = serde_json::json!({
+            "type": "stream_event",
+            "turn_token": "agent-message-1",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "background task update"}
+            }
+        });
+        assert!(!bridge_message_is_stale_for_active_turn(
+            &proc,
+            &post_turn_msg
+        ));
+    }
+
+    #[tokio::test]
+    async fn nonzero_turn_complete_does_not_allow_post_turn_token() {
+        let mut proc = make_streaming_test_process();
+        proc.streaming_message_id = Some("agent-message-1".to_string());
+        proc.active_turn_token = Some("agent-message-1".to_string());
+
+        let mut events = Vec::new();
+        drive_turn_complete_path(&mut proc, "csid", 1, &mut events);
+
+        assert!(proc.active_turn_token.is_none());
+        assert!(proc.post_turn_message_token.is_none());
+
+        let late_msg = serde_json::json!({
+            "type": "stream_event",
+            "turn_token": "agent-message-1",
+        });
+        assert!(bridge_message_is_stale_for_active_turn(&proc, &late_msg));
     }
 
     #[test]
@@ -13338,6 +14258,8 @@ mod tests {
                 #[cfg(unix)]
                 pgid: None,
                 streaming_message_id: None,
+                active_turn_token: None,
+                post_turn_message_token: None,
                 streaming_parts: Vec::new(),
                 last_message_id: None,
                 post_turn_base_untrusted_message_id: None,
@@ -16287,6 +17209,8 @@ mod tests {
             #[cfg(unix)]
             pgid: None,
             streaming_message_id: None,
+            active_turn_token: None,
+            post_turn_message_token: None,
             streaming_parts: Vec::new(),
             last_message_id: None,
             post_turn_base_untrusted_message_id: None,
@@ -16510,10 +17434,11 @@ mod tests {
 
     #[test]
     fn build_message_cmd_text_only() {
-        let cmd = build_message_cmd("hello", &[]);
+        let cmd = build_message_cmd("hello", &[], None);
         assert_eq!(cmd["type"], "message");
         assert_eq!(cmd["prompt"], "hello");
         assert!(cmd.get("images").is_none());
+        assert!(cmd.get("turn_token").is_none());
     }
 
     #[test]
@@ -16522,9 +17447,10 @@ mod tests {
             data: "base64data".to_string(),
             media_type: "image/png".to_string(),
         }];
-        let cmd = build_message_cmd("check this", &images);
+        let cmd = build_message_cmd("check this", &images, Some("agent-message-1"));
         assert_eq!(cmd["type"], "message");
         assert_eq!(cmd["prompt"], "check this");
+        assert_eq!(cmd["turn_token"], "agent-message-1");
         let imgs = cmd["images"].as_array().unwrap();
         assert_eq!(imgs.len(), 1);
         assert_eq!(imgs[0]["data"], "base64data");
@@ -16998,6 +17924,8 @@ mod tests {
                 generation_id: 1,
                 pgid,
                 streaming_message_id: None,
+                active_turn_token: None,
+                post_turn_message_token: None,
                 streaming_parts: Vec::new(),
                 last_message_id: None,
                 post_turn_base_untrusted_message_id: None,

--- a/src-tauri/src/usecase/workflow/command/preflight.rs
+++ b/src-tauri/src/usecase/workflow/command/preflight.rs
@@ -5,7 +5,7 @@ use crate::domain::workflow::{
 
 use super::{AbortRunCommand, ApprovalCommand, StartRunCommand, SubmitOutputCommand};
 use crate::usecase::workflow::ports::{
-    PendingRuntimeCommand, PendingRuntimeCommandPayload, WorkflowTurnCompleteCommand,
+    PendingRuntimeCommand, PendingRuntimeCommandPayload, WorkflowTurnCompleteNotification,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -94,7 +94,7 @@ impl WorkflowRuntimeCommandPreflight {
 
     pub(crate) fn validate_turn_complete(
         &self,
-        command: &WorkflowTurnCompleteCommand,
+        command: &WorkflowTurnCompleteNotification,
     ) -> Result<(), WorkflowError> {
         if command.chat_session_id.trim().is_empty() {
             return Err(WorkflowError::validation(

--- a/src-tauri/src/usecase/workflow/ports.rs
+++ b/src-tauri/src/usecase/workflow/ports.rs
@@ -176,6 +176,15 @@ pub struct WorkflowTurnCompleteCommand {
     pub token_usage: Option<WorkflowTurnTokenUsage>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowTurnCompleteNotification {
+    pub chat_session_id: String,
+    pub exit_code: i64,
+    pub final_text_parts: Vec<String>,
+    pub token_usage: Option<WorkflowTurnTokenUsage>,
+    pub interrupted: bool,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct PendingRuntimeCommand {
     pub run_id: String,

--- a/src-tauri/src/usecase/workflow/runtime_command.rs
+++ b/src-tauri/src/usecase/workflow/runtime_command.rs
@@ -14,7 +14,8 @@ use super::ports::{
     PendingRuntimeCommandPayload, WorkflowAbortRunGateway, WorkflowApprovalChatGateway,
     WorkflowApprovalGateway, WorkflowPendingRuntimeCommandGateway, WorkflowRuntimeCommandGateway,
     WorkflowRuntimeStateGateway, WorkflowStartRunGateway, WorkflowSubmitOutputGateway,
-    WorkflowTurnCompleteCommand, WorkflowTurnCompleteGateway, WorkflowTurnTokenUsage,
+    WorkflowTurnCompleteCommand, WorkflowTurnCompleteGateway, WorkflowTurnCompleteNotification,
+    WorkflowTurnTokenUsage,
 };
 use super::turn_complete::WorkflowTurnCompleteUsecase;
 
@@ -71,7 +72,7 @@ impl WorkflowRuntimeUsecase {
 
     pub async fn complete_turn(
         &self,
-        command: WorkflowTurnCompleteCommand,
+        command: WorkflowTurnCompleteNotification,
     ) -> Result<(), WorkflowError> {
         self.turn_complete.complete_turn(command).await
     }
@@ -295,7 +296,7 @@ mod tests {
             .await;
         assert_eq!(pending, PendingRuntimeCommandOutcome::Accepted);
         usecase
-            .complete_turn(WorkflowTurnCompleteCommand {
+            .complete_turn(WorkflowTurnCompleteNotification {
                 chat_session_id: "chat".to_string(),
                 exit_code: 0,
                 final_text_parts: vec!["ok".to_string()],
@@ -303,6 +304,7 @@ mod tests {
                     input_tokens: 1,
                     output_tokens: 2,
                 }),
+                interrupted: false,
             })
             .await
             .unwrap();
@@ -343,11 +345,12 @@ mod tests {
         let usecase = WorkflowRuntimeUsecase::new(gateway.clone());
 
         usecase
-            .complete_turn(WorkflowTurnCompleteCommand {
+            .complete_turn(WorkflowTurnCompleteNotification {
                 chat_session_id: "chat".to_string(),
                 exit_code: 0,
                 final_text_parts: Vec::new(),
                 token_usage: None,
+                interrupted: false,
             })
             .await
             .unwrap();

--- a/src-tauri/src/usecase/workflow/turn_complete.rs
+++ b/src-tauri/src/usecase/workflow/turn_complete.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use crate::domain::workflow::WorkflowError;
 use crate::usecase::workflow::command::WorkflowRuntimeCommandPreflight;
-use crate::usecase::workflow::ports::{WorkflowTurnCompleteCommand, WorkflowTurnCompleteGateway};
+use crate::usecase::workflow::ports::{
+    WorkflowTurnCompleteCommand, WorkflowTurnCompleteGateway, WorkflowTurnCompleteNotification,
+};
 
 #[derive(Clone)]
 pub struct WorkflowTurnCompleteUsecase {
@@ -29,7 +31,7 @@ impl WorkflowTurnCompleteUsecase {
 
     pub async fn complete_turn(
         &self,
-        command: WorkflowTurnCompleteCommand,
+        command: WorkflowTurnCompleteNotification,
     ) -> Result<(), WorkflowError> {
         self.preflight.validate_turn_complete(&command)?;
         if !self
@@ -39,8 +41,18 @@ impl WorkflowTurnCompleteUsecase {
         {
             return Ok(());
         }
+        if command.interrupted {
+            return Ok(());
+        }
         self.runtime.pickup_pending_submit_outputs().await;
-        self.runtime.complete_turn(command).await
+        self.runtime
+            .complete_turn(WorkflowTurnCompleteCommand {
+                chat_session_id: command.chat_session_id,
+                exit_code: command.exit_code,
+                final_text_parts: command.final_text_parts,
+                token_usage: command.token_usage,
+            })
+            .await
     }
 }
 
@@ -81,11 +93,12 @@ mod tests {
         let usecase = WorkflowTurnCompleteUsecase::new(gateway.clone());
 
         let err = usecase
-            .complete_turn(WorkflowTurnCompleteCommand {
+            .complete_turn(WorkflowTurnCompleteNotification {
                 chat_session_id: " ".to_string(),
                 exit_code: 0,
                 final_text_parts: Vec::new(),
                 token_usage: None,
+                interrupted: false,
             })
             .await
             .unwrap_err();
@@ -100,11 +113,12 @@ mod tests {
         let usecase = WorkflowTurnCompleteUsecase::new(gateway.clone());
 
         usecase
-            .complete_turn(WorkflowTurnCompleteCommand {
+            .complete_turn(WorkflowTurnCompleteNotification {
                 chat_session_id: "chat".to_string(),
                 exit_code: 0,
                 final_text_parts: Vec::new(),
                 token_usage: None,
+                interrupted: false,
             })
             .await
             .unwrap();
@@ -121,11 +135,12 @@ mod tests {
         let usecase = WorkflowTurnCompleteUsecase::new(gateway.clone());
 
         usecase
-            .complete_turn(WorkflowTurnCompleteCommand {
+            .complete_turn(WorkflowTurnCompleteNotification {
                 chat_session_id: "chat".to_string(),
                 exit_code: 0,
                 final_text_parts: vec!["done".to_string()],
                 token_usage: None,
+                interrupted: false,
             })
             .await
             .unwrap();
@@ -134,5 +149,27 @@ mod tests {
             gateway.calls.lock().unwrap().as_slice(),
             ["is_running", "pickup_pending", "complete_turn"]
         );
+    }
+
+    #[tokio::test]
+    async fn interrupted_turn_skips_normal_completion() {
+        let gateway = Arc::new(FakeRuntimeGateway {
+            session_running: true,
+            ..Default::default()
+        });
+        let usecase = WorkflowTurnCompleteUsecase::new(gateway.clone());
+
+        usecase
+            .complete_turn(WorkflowTurnCompleteNotification {
+                chat_session_id: "chat".to_string(),
+                exit_code: 0,
+                final_text_parts: Vec::new(),
+                token_usage: None,
+                interrupted: true,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(gateway.calls.lock().unwrap().as_slice(), ["is_running"]);
     }
 }

--- a/src/hooks/useAgentSdkListeners.test.ts
+++ b/src/hooks/useAgentSdkListeners.test.ts
@@ -337,6 +337,53 @@ describe("agent-session-state-changed event", () => {
 		});
 	});
 
+	it("keeps interrupted idle events distinct from completed turns", () => {
+		listenResolvers = [];
+		listenCallbacks.clear();
+		const refs = makeRefs();
+		setViewable(refs, "session-1");
+
+		renderHook(() => useAgentSdkListeners(refs));
+
+		for (const { resolve } of listenResolvers) {
+			resolve(vi.fn());
+		}
+
+		const cb = listenCallbacks.get("agent-session-state-changed");
+		expect(cb).toBeDefined();
+
+		cb?.({
+			payload: {
+				chat_session_id: "session-1",
+				turn_phase: "idle",
+				exit_code: 0,
+				completed_at: 1234,
+				interrupted: true,
+			},
+		});
+
+		expect(refs.dispatch).toHaveBeenCalledWith({
+			type: "SET_TURN_PHASE",
+			sessionId: "session-1",
+			turnPhase: "idle",
+		});
+		expect(refs.dispatch).toHaveBeenCalledWith({
+			type: "SET_PENDING_PERMISSION",
+			sessionId: "session-1",
+			request: null,
+		});
+		expect(refs.dispatch).toHaveBeenCalledWith({
+			type: "UPDATE_SESSION_STATE",
+			sessionId: "session-1",
+			state: "idle",
+		});
+		expect(refs.dispatch).not.toHaveBeenCalledWith({
+			type: "MARK_AGENT_TURN_COMPLETED",
+			sessionId: "session-1",
+			completedAt: 1234,
+		});
+	});
+
 	it("dispatches SET_PENDING_PERMISSION when permission_request is received", () => {
 		listenResolvers = [];
 		listenCallbacks.clear();

--- a/src/hooks/useAgentSdkListeners.ts
+++ b/src/hooks/useAgentSdkListeners.ts
@@ -47,6 +47,7 @@ interface SessionStateChanged {
 	turn_phase: TurnPhase;
 	exit_code: number | null;
 	completed_at?: number | null;
+	interrupted?: boolean;
 }
 
 interface StreamingMessageUpdated {
@@ -454,8 +455,13 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 		let cancelled = false;
 
 		listen<SessionStateChanged>("agent-session-state-changed", (event) => {
-			const { chat_session_id, turn_phase, exit_code, completed_at } =
-				event.payload;
+			const {
+				chat_session_id,
+				turn_phase,
+				exit_code,
+				completed_at,
+				interrupted,
+			} = event.payload;
 
 			dispatch({
 				type: "SET_TURN_PHASE",
@@ -465,7 +471,11 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 
 			// Turn completed (idle with exit_code): update session state and clear permissions
 			if (turn_phase === "idle" && exit_code != null) {
-				if (typeof completed_at === "number" && Number.isFinite(completed_at)) {
+				if (
+					!interrupted &&
+					typeof completed_at === "number" &&
+					Number.isFinite(completed_at)
+				) {
 					dispatch({
 						type: "MARK_AGENT_TURN_COMPLETED",
 						sessionId: chat_session_id,
@@ -479,7 +489,11 @@ export function useAgentSdkListeners(refs: AgentSdkListenerRefs): void {
 					request: null,
 				});
 
-				const newState: SessionState = exit_code === 0 ? "done" : "error";
+				const newState: SessionState = interrupted
+					? "idle"
+					: exit_code === 0
+						? "done"
+						: "error";
 				if (isViewable(chat_session_id, viewableRegistry)) {
 					dispatch({
 						type: "UPDATE_SESSION_STATE",


### PR DESCRIPTION
## 概要

AgentChat の Claude backend で、応答中に Stop して送信ボタンへ戻った後に新しいメッセージを送ると、長時間待たされたうえで Stop 前 turn の続きが返ってくる不具合を修正する。Stop を「単なる provider abort」ではなく「turn のインタラプト境界」として扱い、Stop 後の次送信が必ず新しいユーザー入力への応答として開始されるようにする。

関連: #1255 / #1178 / #731 / #1192 / #1246

## 変更内容

- Stop された turn を通常完了 turn と区別する「interrupted（中断）」境界として扱う
- Stop 後の次送信が停止済み turn を resume せず、新しい入力への応答として開始されるようにする
- Stop 以前の遅延イベント（late stream / late result / late turn_complete）が次 turn の agent message に混入しないよう fencing
- Stop 後の状態が UI / SessionStore / AgentStatusCenter で `completed` と誤認されないようにする

## スコープ

- 対象 backend は Claude backend（`claude-sdk-bridge`）に限定
- 通常 turn 完了 / stale timeout / workflow step 実行といった既存挙動は変更せず維持

## テスト

- [ ] `cargo test` / `pnpm test`
- Stop 後の late `turn_complete` が新 turn を完了扱いにしないこと
- Stop 後の次送信が旧 turn の pending / stream に混入しないこと
- interrupted turn 後の Claude bridge / session 再利用ポリシーが期待どおりであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
