### PR TITLE
feat(workspace): worktree ツリーの初期 loading と空状態を表示 (#1260)

### DIFF
--- a/docs/specs/issues-1260/behavior.md
+++ b/docs/specs/issues-1260/behavior.md
@@ -1,0 +1,100 @@
+# Behavior
+
+Issue #1260 / WorkspaceList の Worktree 展開ノード配下が空のときの明示表示。
+
+requirements.md の R1〜R4 を、実装詳細に踏み込まない観測可能な振る舞いとして Gherkin で定義する。
+
+## 仮定
+
+- **A1 (文言)**: Worktree 配下の空状態プレースホルダ文言は `No sessions or workflows` とする (requirements.md 仮定 A1)。本 behavior 内では当該文言を前提に記述する。
+- **A2 (対象範囲)**: 対象は Worktree 展開ノードの配下 (Session / Workflow) のみ。`RepoTreeSection` のブランチ一覧は対象外 (requirements.md 仮定 A2)。
+- **A3 (状態の供給元)**: 「読み込み中」「エラー」「完了かつ件数」は既存のツリーノード取得が返す状態 (loading / error / nodes) から判定でき、新たなバックエンド変更は不要 (requirements.md 仮定 A3)。
+
+## Feature
+
+```gherkin
+Feature: Worktree 展開ノードの空状態表示
+  WorkspaceList で Worktree を展開したとき、配下の Session / Workflow が
+  1 件も無い場合に「空である」ことを明示し、
+  「読み込み中」「エラー」と視覚的に区別できるようにする。
+
+  Background:
+    Given WorkspaceList に 1 件以上のリポジトリが表示されている
+    And そのリポジトリに 1 件以上の Worktree が表示されている
+    And ユーザーが対象の Worktree ノードを展開している
+
+  Rule: 配下が空のとき空状態プレースホルダを表示する
+
+    Scenario: 配下に Session も Workflow も無い場合は空状態を明示する
+      Given Worktree 配下のノード取得が正常に完了している
+      And 配下の Session が 0 件である
+      And 配下の Workflow が 0 件である
+      When 展開した Worktree ノードの配下が描画される
+      Then 空状態プレースホルダ "No sessions or workflows" が表示される
+      And Session 行も Workflow 行も 1 つも表示されない
+
+    Scenario: 配下に 1 件以上のノードがある場合は空状態を表示しない
+      Given Worktree 配下のノード取得が正常に完了している
+      And 配下に 1 件以上の Session または Workflow が存在する
+      When 展開した Worktree ノードの配下が描画される
+      Then 配下のノード一覧が従来どおり表示される
+      And 空状態プレースホルダ "No sessions or workflows" は表示されない
+
+  Rule: 空状態は読み込み中・エラーと排他であり混同させない
+
+    Scenario: 読み込み中は空状態プレースホルダを表示しない
+      Given Worktree 配下のノードを読み込み中である
+      When 展開した Worktree ノードの配下が描画される
+      Then 読み込み中表示 (スピナー) が表示される
+      And 空状態プレースホルダ "No sessions or workflows" は表示されない
+
+    Scenario: エラーかつ 0 件のときは空状態プレースホルダを表示しない
+      Given Worktree 配下のノード取得がエラーで終了している
+      And 配下のノードが 0 件である
+      When 展開した Worktree ノードの配下が描画される
+      Then エラー表示が表示される
+      And 空状態プレースホルダ "No sessions or workflows" は表示されない
+
+    Scenario Outline: 状態ごとに表示される要素が一意に定まる
+      Given Worktree 配下の状態が "<state>" である
+      When 展開した Worktree ノードの配下が描画される
+      Then "<visible>" が表示される
+      And それ以外の状態の表示要素は表示されない
+
+      Examples:
+        | state                | visible                   |
+        | 読み込み中           | スピナー                  |
+        | エラーかつ0件        | エラー表示                |
+        | 完了かつ0件          | 空状態プレースホルダ      |
+        | 完了かつ1件以上      | ノード一覧                |
+
+  Rule: 空状態表示は既存の空状態表示と一貫した見た目とする
+
+    Scenario: 空状態プレースホルダは控えめなスタイルで表示される
+      Given Worktree 配下のノード取得が正常に完了し配下が 0 件である
+      When 空状態プレースホルダが表示される
+      Then 文言は既存の空状態表示 (例 "No Repository") と同系統の英語短文である
+      And 控えめな配色 (muted-foreground 系) で表示される
+      And Worktree 配下ノードと同等のインデントで表示される
+
+  Rule: 折りたたみ時は空状態を含め配下を一切描画しない
+
+    Scenario: Worktree を折りたたんでいる場合は何も描画しない
+      Given ユーザーが対象の Worktree ノードを折りたたんでいる
+      And 配下の Session / Workflow が 0 件である
+      When Worktree ノードが描画される
+      Then 空状態プレースホルダを含め配下要素は一切表示されない
+```
+
+## 受け入れ条件 (検証観点)
+
+- Worktree 展開かつ完了かつ 0 件: `No sessions or workflows` が表示される。
+- Worktree 展開かつ完了かつ 1 件以上: ノード一覧が表示され、プレースホルダは出ない。
+- 読み込み中: スピナーのみ。プレースホルダは出ない。
+- エラーかつ 0 件: エラー表示のみ。プレースホルダは出ない。
+- 折りたたみ時: 配下は一切描画されない。
+- 上記をカバーする `WorkspaceList.test.tsx` を追加し、`pnpm lint` / `pnpm test` が通る。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1260/design.md
+++ b/docs/specs/issues-1260/design.md
@@ -1,0 +1,115 @@
+# Design
+
+Issue #1260 / `WorkspaceList` の Worktree 展開ノード配下が空のときの明示表示。
+
+requirements.md (R1〜R4) と behavior.md (Gherkin) を満たす実装方針を定義する。
+
+## 概要
+
+`WorkspaceList` の Worktree 展開ノード配下に、Session / Workflow が 1 件も存在しない場合の空状態プレースホルダ表示を追加する。
+
+`src/components/workspace/WorkspaceList.tsx` の `WorktreeTreeItem` コンポーネント内、展開時の配下描画ブロック (現状 839〜896 行付近) に、`treeLoading` / `treeError` のいずれでもない正常完了かつノード 0 件のときに限り、控えめなスタイルのプレースホルダ `No sessions or workflows` を描画する分岐を加える。
+
+ロジックは「受け取ったデータの表示条件判定 (件数が 0 か)」に該当し、フロントエンドで扱ってよい (rust-first-logic の許可範囲)。新たな Tauri コマンド・バックエンド変更は不要 (requirements 仮定 A3)。
+
+## 変更対象
+
+| ファイル | 変更内容 |
+| --- | --- |
+| `src/components/workspace/WorkspaceList.tsx` | `WorktreeTreeItem` の配下描画ブロックに空状態プレースホルダの分岐を追加 |
+| `src/components/workspace/WorkspaceList.test.tsx` | 空状態 / 1 件以上 / 読み込み中 / エラー / 折りたたみ の表示分岐をカバーするテストを追加 |
+
+上記以外 (`useWorkspaceTreeNodes` 等のフック、Rust 側、他階層の空表示) は変更しない (requirements 非スコープ)。
+
+## アーキテクチャと責務分割
+
+- **状態の供給元**: `useWorkspaceTreeNodes(branch.worktree_path)` が返す `nodes` / `loading (treeLoading)` / `error (treeError)` を唯一の情報源とする。
+- **表示用ノード**: 既存の `displayNodes` (live status を反映した `nodes` の派生) を空判定の対象とする。`nodes` ではなく `displayNodes` を判定対象にするのは、描画対象とプレースホルダ判定対象を一致させ「描画 0 件なのにプレースホルダが出ない」ズレを防ぐため。`displayNodes` は `nodes` を `map` した結果であり件数は常に一致する (仮定 B1)。
+- **責務分割**: 表示分岐の判定・描画は `WorktreeTreeItem` 内に閉じる。プレースホルダ専用の子コンポーネントは新設せず、既存の `treeLoading` / `treeError` 分岐と同じ階層に並べる (見た目・インデントの一貫性を保つため)。
+
+### 表示分岐の優先順位
+
+展開済み (`expanded && hasWorktree`) の配下は、次の排他的優先順位で 1 つの状態のみを描画する (behavior の Scenario Outline に対応)。
+
+1. `treeLoading` が真 → スピナー (既存)
+2. `treeError` が真かつ `nodes.length === 0` → エラー表示 (既存)
+3. 上記いずれでもなく `displayNodes.length === 0` → **空状態プレースホルダ (新規)**
+4. 上記いずれでもない → ノード一覧 (既存)
+
+現状コードは 1・2 を満たさない場合に常に 4 (`displayNodes.map(...)`) へ落ちるため、`displayNodes` が空のときは何も描画されない。本変更は 4 の手前に 3 を挿入する。
+
+折りたたみ時 (`expanded` が偽) は配下ブロック自体が描画されないため、プレースホルダも当然描画されない (behavior「折りたたみ時は配下を一切描画しない」を既存構造で満たす)。
+
+## データモデルまたは型
+
+新規の型・データ構造は追加しない。既存の `UseWorkspaceTreeNodesResult` (`nodes` / `loading` / `error`) と `displayNodes: WorkspaceWorkflowNode | WorkspaceSessionNode[]` をそのまま利用する。
+
+## 処理フロー
+
+```text
+WorktreeTreeItem render
+  └─ expanded && hasWorktree ?
+       ├─ treeLoading            → <Loader2 /> (スピナー)
+       ├─ treeError && nodes==0  → エラー表示
+       ├─ displayNodes.length==0 → "No sessions or workflows" (新規)
+       └─ else                   → displayNodes.map(node => Workflow/Session 行)
+  (workflowActionError は上記いずれの分岐でも従来どおり末尾に追記)
+```
+
+プレースホルダ要素 (案):
+
+```tsx
+<div
+  className="truncate py-1 text-xs text-muted-foreground"
+  style={{ paddingLeft: WORKTREE_NAME_INDENT_PX }}
+>
+  No sessions or workflows
+</div>
+```
+
+- `text-muted-foreground` + `text-xs`: 既存の空表示 (`No Repository`) およびエラー表示と同系統の控えめなスタイル (R3 / behavior「控えめな配色」)。
+- `paddingLeft: WORKTREE_NAME_INDENT_PX`: 既存の `treeLoading` / `treeError` 分岐と同じインデント定数を用い、配下ノードと同等の字下げにする (behavior「同等のインデント」)。
+- 文言は `No sessions or workflows` (requirements 仮定 A1)。
+
+`workflowActionError` の表示 (886〜894 行) は配下分岐の外側にあり、空状態分岐を追加しても従来どおり描画される。空状態と `workflowActionError` は独立に共存し得る (空状態時に過去の archive/stop が失敗していればエラーも併記される) が、これは既存挙動の踏襲であり本変更では変えない。
+
+## エラー処理
+
+- 新規のエラーパスは発生しない (表示分岐の追加のみ)。
+- `treeError` が真でも `nodes.length > 0` の場合は現状どおり分岐 2 を素通りし、ノード一覧 (分岐 4) を表示する。この場合は空状態プレースホルダの対象外 (`displayNodes` が非空)。本変更はこの既存挙動を変更しない。
+- 「エラーかつ 0 件」は分岐 2 で捕捉され、分岐 3 (空状態) には到達しない (R2 / behavior 該当 Scenario)。
+
+## テスト方針
+
+`WorkspaceList.test.tsx` に以下を追加する。既存テストのモック方式 (`vi.mock("@/hooks/useWorkspaceTreeNodes")` が `worktreePath` 別に状態を返す) を踏襲し、状態ごとに異なる `worktreePath` を持つ branch を `useWorktreeList` モックから供給するか、または既存の `useWorkspaceTreeNodes` モックを `worktreePath` → 状態のマップで切り替える形に拡張する (仮定 B2)。
+
+検証する振る舞い (behavior の各 Scenario に対応):
+
+1. **完了かつ 0 件**: `nodes: []`, `loading: false`, `error: null` の Worktree を展開 → `No sessions or workflows` が表示され、Session 行・Workflow 行が 1 つも無い。
+2. **完了かつ 1 件以上**: 既存の `/repo/wt` (ノードあり) を展開 → ノード一覧が表示され `No sessions or workflows` は表示されない。
+3. **読み込み中**: `loading: true` → スピナー (`Loader2`) が表示され `No sessions or workflows` は表示されない。
+4. **エラーかつ 0 件**: `error: "..."`, `nodes: []` → エラー文言が表示され `No sessions or workflows` は表示されない。
+5. **折りたたみ時**: Worktree ノードを折りたたむ (展開トグルをクリック) → `No sessions or workflows` を含め配下が描画されない。
+
+- スピナーは aria/role を持たないため、`Loader2` の描画は class などで確認するか、既存テストの判定手法に合わせる (仮定 B3)。
+- 実行コマンド: `pnpm lint` / `pnpm test` (CLAUDE.md / CI 準拠)。
+
+## リスクと代替案
+
+- **リスク 1 (判定対象の不一致)**: `nodes` と `displayNodes` で件数判定がずれると、描画は空なのにプレースホルダが出ない/逆が起きる。→ 判定対象を描画対象と同じ `displayNodes` に統一して回避 (仮定 B1)。
+- **リスク 2 (エラーかつ非空との競合)**: `treeError` かつ `nodes.length > 0` のケースは分岐 2 を通らずノード一覧を出す既存挙動。本変更はこの分岐を触らず、空状態は `displayNodes` が空のときのみ追加されるため競合しない。
+- **代替案 A (プレースホルダ子コンポーネント化)**: `WorktreeEmptyState` のような専用コンポーネントを新設する案。再利用予定が無く、既存の `treeLoading` / `treeError` がインライン `div` で書かれていることとの一貫性から、本設計ではインライン追加を採用する。
+- **代替案 B (空判定をフック側で算出)**: `useWorkspaceTreeNodes` に `isEmpty` を持たせる案。表示条件のための派生値であり、フックの責務 (データ取得) を超えるため不採用。表示側で `displayNodes.length === 0` を直接評価する。
+
+## 仮定
+
+- **A1 (文言)**: プレースホルダ文言は `No sessions or workflows` (requirements / behavior 仮定 A1)。
+- **A2 (対象範囲)**: 対象は Worktree 展開ノード配下のみ。`RepoTreeSection` のブランチ一覧は対象外 (requirements 仮定 A2)。
+- **A3 (バックエンド変更なし)**: 既存フックが返す `nodes` / `loading` / `error` で判定可能、Rust 変更不要 (requirements 仮定 A3)。
+- **B1 (判定対象)**: 空判定は `displayNodes.length === 0` で行う。`displayNodes` は `nodes` の `map` 結果のため件数は `nodes` と常に一致する。
+- **B2 (テストのモック拡張)**: 空状態テストは、空ノードを返す `worktreePath` を持つ branch を追加するか `useWorkspaceTreeNodes` モックを状態マップ化して供給する。既存テスト (`/repo/wt`) の挙動は変更しない。
+- **B3 (スピナー判定)**: 読み込み中の検証は `Loader2` (animate-spin) の描画有無で行う。既存テストの判定手法に合わせる。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1260/requirements.md
+++ b/docs/specs/issues-1260/requirements.md
@@ -1,0 +1,82 @@
+# Requirements
+
+## Type
+
+WorkspaceList の空状態 (empty state) 表示の追加。
+
+関連: #1260
+
+## 背景と目的
+
+Issue #1260 の要求:
+
+> WorkSpaceList で Worktree 等を開いているが空の時にはないことを明示する
+
+`WorkspaceList` は階層的に展開可能なツリー UI で構成されている。一部の階層には空のときの明示表示があるが、**Worktree を展開したときに配下のノード (Session / Workflow) が 1 件も無い場合は何も描画されない**ため、ユーザーは「中身が空である」のか「読み込みに失敗している / まだ読み込まれていない」のかを区別できない。
+
+現状の空状態表示の有無 (`src/components/workspace/WorkspaceList.tsx`):
+
+| 階層 / 場所 | 空のときの表示 | 状態 |
+| --- | --- | --- |
+| WorkspaceList トップ (リポジトリ 0 件) | `No Repository` | あり |
+| SessionHistory サブメニュー (閉じた Session 0 件) | `No closed sessions` | あり |
+| WorkflowHistory サブメニュー (履歴 0 件) | `No workflows` | あり |
+| NewWorkflow サブメニュー (定義 0 件) | `No workflows configured` | あり |
+| **Worktree 展開時の配下ノード (Session / Workflow 0 件)** | **なし (空白)** | **欠落** |
+| **RepoTreeSection 展開時のブランチ一覧 (0 件)** | **なし (空白)** | **欠落 (※後述の仮定参照)** |
+
+目的: Worktree を展開したときに配下のノードが空である場合、その旨を明示するプレースホルダ表示を追加し、「空である」状態を「読み込み中 / エラー」状態と明確に区別できるようにする。
+
+## スコープ
+
+- `WorkspaceList` の **Worktree 展開ノード**配下に、Session / Workflow が 1 件も存在しない場合の空状態プレースホルダ表示を追加する。
+- 空状態表示は、既存の **読み込み中 (`treeLoading`)** 表示および **エラー (`treeError`)** 表示と排他的に成立させる (空状態はそのどちらでもない正常完了かつ 0 件のときのみ表示)。
+- 既存の空状態表示 (`No Repository` 等) のラベル文言・スタイルと整合する見た目とする。
+
+## 非スコープ
+
+- 既に空状態表示を持つ階層 (WorkspaceList トップ / SessionHistory / WorkflowHistory / NewWorkflow サブメニュー) の文言・挙動の変更。
+- Session / Workflow ノードの取得ロジック (`useWorkspaceTreeNodes` 等) の変更。
+- 読み込み中 / エラー表示の挙動・文言の変更。
+- WorkspaceList のナビゲーション構造・ステータス表示・集約ロジックの変更 (#1259 等で扱う範囲)。
+- 中央パネル (Chat UI / Step 画面 / Editor / Terminal) の表示。
+
+## 要求事項
+
+### R1. Worktree 空状態の明示
+
+- Worktree を展開し、配下に Session も Workflow も存在しない (`displayNodes` が空) 場合に、空である旨を示すプレースホルダを表示すること。
+- このプレースホルダは、読み込み中 (`treeLoading`) でもエラー (`treeError`) でもない正常完了状態かつ 0 件のときにのみ表示すること。
+
+### R2. 読み込み中・エラーとの非混同
+
+- 読み込み中はプレースホルダを表示せず、既存の読み込み中表示 (スピナー) を維持すること。
+- エラー時 (かつノード 0 件) はプレースホルダを表示せず、既存のエラー表示を維持すること。
+- これにより「空」「読み込み中」「エラー」の 3 状態が視覚的に区別できること。
+
+### R3. 既存表示との一貫性
+
+- 空状態プレースホルダの文言・配色・インデントは、既存の空状態表示 (`No Repository` 等、`text-muted-foreground` 系の控えめなスタイル) と一貫した見た目とすること。
+- 文言は既存の英語短文ラベルに合わせる (仮定 A1 参照)。
+
+### R4. ロジック配置
+
+- 「空であるか」の判定 (ノード件数が 0 か) は表示条件であり、フロントエンドで扱ってよい (rust-first-logic の「受け取ったデータの表示条件」に該当)。新たな Tauri コマンド追加は不要とする。
+
+## 受け入れ基準の概要
+
+- Worktree を展開し配下に Session / Workflow が 1 件も無いとき、空である旨のプレースホルダが表示される。
+- 配下に 1 件以上のノードがあるときはプレースホルダが表示されず、従来どおりノード一覧が表示される。
+- 読み込み中はスピナーのみが表示され、空プレースホルダは表示されない。
+- エラー (かつ 0 件) 時はエラー表示のみで、空プレースホルダは表示されない。
+- 上記をカバーする `WorkspaceList.test.tsx` のテストが追加され、`pnpm lint` / `pnpm test` が通る。
+
+## 仮定
+
+- **A1 (文言)**: 空状態の文言は既存ラベルと同系統の英語短文とする。具体的には Worktree 配下の空表示を `No sessions or workflows` とする (確定は A1 のレビューで)。
+- **A2 (対象範囲)**: 本変更の主対象は Worktree 展開ノードの空状態とする。`RepoTreeSection` のブランチ一覧は、main worktree が常に 1 件存在するため実運用上 0 件になり得ず、空状態表示の追加対象外とする (Open Question Q1 で確認)。
+- **A3 (バックエンド変更なし)**: 既存の `useWorkspaceTreeNodes` が返す `nodes` / `loading` / `error` で判定可能なため、Rust 側の変更は不要とする。
+
+## Open Questions
+
+なし (Q1: 対象範囲は Worktree 展開ノードのみとすることで確定。RepoTreeSection 等は対象外。)

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -1,7 +1,21 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorktreeBranch } from "@/types/git";
+import type {
+	WorkspaceSessionHistoryItem,
+	WorkspaceTreeNode,
+	WorkspaceWorkflowHistoryItem,
+} from "@/types/workspace-tree";
 import { WorkspaceList } from "./WorkspaceList";
+
+type MockWorkspaceTreeState = {
+	nodes: WorkspaceTreeNode[];
+	closedSessions?: WorkspaceSessionHistoryItem[];
+	workflowHistory?: WorkspaceWorkflowHistoryItem[];
+	loading?: boolean;
+	error?: string | null;
+};
 
 const mocks = vi.hoisted(() => ({
 	invoke: vi.fn().mockResolvedValue([]),
@@ -12,6 +26,8 @@ const mocks = vi.hoisted(() => ({
 	restoreSession: vi.fn().mockResolvedValue(undefined),
 	refreshTree: vi.fn().mockResolvedValue(undefined),
 	refreshWorktrees: vi.fn().mockResolvedValue(undefined),
+	treeStateOverrides: new Map<string, MockWorkspaceTreeState>(),
+	worktreeBranches: [] as WorktreeBranch[],
 }));
 
 vi.mock("react-resizable-panels", () => {
@@ -54,6 +70,17 @@ vi.mock("@/hooks/useWorkflowConfig", () => ({
 }));
 vi.mock("@/hooks/useWorkspaceTreeNodes", () => ({
 	useWorkspaceTreeNodes: (worktreePath: string) => {
+		const override = mocks.treeStateOverrides.get(worktreePath);
+		if (override) {
+			return {
+				nodes: override.nodes,
+				closedSessions: override.closedSessions ?? [],
+				workflowHistory: override.workflowHistory ?? [],
+				loading: override.loading ?? false,
+				error: override.error ?? null,
+				refresh: mocks.refreshTree,
+			};
+		}
 		if (worktreePath !== "/repo/wt") {
 			return {
 				nodes: [],
@@ -204,33 +231,7 @@ vi.mock("@/hooks/useWorkspaceTreeNodes", () => ({
 }));
 vi.mock("@/hooks/useWorktreeList", () => ({
 	useWorktreeList: () => ({
-		branches: [
-			{
-				name: "main",
-				is_main_worktree: true,
-				worktree_path: "/repo/main",
-				dirty_count: 0,
-				is_merged: false,
-				ahead: 0,
-				behind: 0,
-				has_upstream: false,
-				base_ahead: 0,
-			},
-			{
-				name: "feature",
-				is_main_worktree: false,
-				worktree_path: "/repo/wt",
-				dirty_count: 0,
-				is_merged: false,
-				has_pr: true,
-				pr_number: 12,
-				pr_url: "https://example.test/pr/12",
-				ahead: 0,
-				behind: 0,
-				has_upstream: false,
-				base_ahead: 0,
-			},
-		],
+		branches: mocks.worktreeBranches,
 		loading: false,
 		refresh: mocks.refreshWorktrees,
 	}),
@@ -250,11 +251,56 @@ vi.mock("@/hooks/useWorktreeStepStatuses", () => ({
 	}),
 }));
 
+function makeBranch(overrides: Partial<WorktreeBranch>): WorktreeBranch {
+	return {
+		name: "feature",
+		is_main_worktree: false,
+		worktree_path: "/repo/wt",
+		dirty_count: 0,
+		is_merged: false,
+		ahead: 0,
+		behind: 0,
+		has_upstream: false,
+		base_ahead: 0,
+		...overrides,
+	};
+}
+
+const defaultWorktreeBranches = [
+	makeBranch({
+		name: "main",
+		is_main_worktree: true,
+		worktree_path: "/repo/main",
+	}),
+	makeBranch({
+		name: "feature",
+		is_main_worktree: false,
+		worktree_path: "/repo/wt",
+		has_pr: true,
+		pr_number: 12,
+		pr_url: "https://example.test/pr/12",
+	}),
+];
+
+function setSingleWorktree(
+	worktreePath: string,
+	state: MockWorkspaceTreeState,
+	name = "empty",
+) {
+	mocks.worktreeBranches = [
+		makeBranch({
+			name,
+			worktree_path: worktreePath,
+		}),
+	];
+	mocks.treeStateOverrides.set(worktreePath, state);
+}
+
 function renderWorkspaceList(
 	props: Partial<React.ComponentProps<typeof WorkspaceList>> = {},
 ) {
 	const onSelectWorktree = vi.fn();
-	render(
+	const renderResult = render(
 		<WorkspaceList
 			repoPaths={["/repo"]}
 			selectedRootPath="/repo/wt"
@@ -265,13 +311,26 @@ function renderWorkspaceList(
 			{...props}
 		/>,
 	);
-	return { onSelectWorktree };
+	return { onSelectWorktree, ...renderResult };
 }
 
 beforeEach(() => {
-	for (const mock of Object.values(mocks)) {
+	for (const mock of [
+		mocks.invoke,
+		mocks.emit,
+		mocks.openUrl,
+		mocks.archiveSession,
+		mocks.closeSession,
+		mocks.restoreSession,
+		mocks.refreshTree,
+		mocks.refreshWorktrees,
+	]) {
 		mock.mockClear();
 	}
+	mocks.treeStateOverrides.clear();
+	mocks.worktreeBranches = defaultWorktreeBranches.map((branch) => ({
+		...branch,
+	}));
 	mocks.invoke.mockResolvedValue([]);
 });
 
@@ -307,6 +366,98 @@ describe("WorkspaceList", () => {
 
 		expect(screen.queryByText("Direct session")).not.toBeInTheDocument();
 		expect(onSelectWorktree).not.toHaveBeenCalled();
+	});
+
+	it("shows an empty placeholder for an expanded Worktree with no sessions or workflows", () => {
+		setSingleWorktree("/repo/empty", {
+			nodes: [],
+			loading: false,
+			error: null,
+		});
+		renderWorkspaceList({ selectedRootPath: "/repo/empty" });
+
+		const placeholder = screen.getByText("No sessions or workflows");
+		expect(placeholder).toBeInTheDocument();
+		expect(placeholder).toHaveClass("text-muted-foreground");
+		expect(placeholder).toHaveStyle({ paddingLeft: "26px" });
+		expect(screen.queryByText("Direct session")).not.toBeInTheDocument();
+		expect(screen.queryByText("release")).not.toBeInTheDocument();
+	});
+
+	it("does not show the empty placeholder when the Worktree has nodes", () => {
+		mocks.worktreeBranches = [
+			makeBranch({
+				name: "feature",
+				worktree_path: "/repo/wt",
+				has_pr: true,
+				pr_number: 12,
+				pr_url: "https://example.test/pr/12",
+			}),
+		];
+		renderWorkspaceList();
+
+		expect(screen.getByText("Direct session")).toBeInTheDocument();
+		expect(screen.getByText("release")).toBeInTheDocument();
+		expect(
+			screen.queryByText("No sessions or workflows"),
+		).not.toBeInTheDocument();
+	});
+
+	it("keeps the empty placeholder hidden while Worktree nodes are loading", () => {
+		setSingleWorktree(
+			"/repo/loading",
+			{
+				nodes: [],
+				loading: true,
+				error: null,
+			},
+			"loading",
+		);
+		const { container } = renderWorkspaceList({
+			selectedRootPath: "/repo/loading",
+		});
+
+		expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+		expect(
+			screen.queryByText("No sessions or workflows"),
+		).not.toBeInTheDocument();
+	});
+
+	it("keeps the empty placeholder hidden when Worktree node loading fails with no nodes", () => {
+		setSingleWorktree(
+			"/repo/error",
+			{
+				nodes: [],
+				loading: false,
+				error: "Failed to load workspace tree",
+			},
+			"error",
+		);
+		renderWorkspaceList({ selectedRootPath: "/repo/error" });
+
+		expect(
+			screen.getByText("Failed to load workspace tree"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("No sessions or workflows"),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not render the empty placeholder for a collapsed Worktree", async () => {
+		const user = userEvent.setup();
+		setSingleWorktree("/repo/empty", {
+			nodes: [],
+			loading: false,
+			error: null,
+		});
+		renderWorkspaceList({ selectedRootPath: "/repo/empty" });
+
+		expect(screen.getByText("No sessions or workflows")).toBeInTheDocument();
+		await user.click(screen.getByTestId("worktree-item-empty"));
+
+		expect(
+			screen.queryByText("No sessions or workflows"),
+		).not.toBeInTheDocument();
 	});
 
 	it("emits an agentSession selection when a Session row is clicked", async () => {

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -852,6 +852,13 @@ function WorktreeTreeItem({
 						>
 							{treeError}
 						</div>
+					) : displayNodes.length === 0 ? (
+						<div
+							className="truncate py-1 text-xs text-muted-foreground"
+							style={{ paddingLeft: WORKTREE_NAME_INDENT_PX }}
+						>
+							No sessions or workflows
+						</div>
 					) : (
 						displayNodes.map((node) =>
 							node.kind === "workflow" ? (

--- a/src/hooks/useWorkspaceTreeNodes.test.ts
+++ b/src/hooks/useWorkspaceTreeNodes.test.ts
@@ -125,6 +125,57 @@ describe("useWorkspaceTreeNodes", () => {
 		});
 	});
 
+	it("marks a valid Worktree as loading before the first fetch completes", async () => {
+		const pending = deferred<WorkspaceTreeNode[]>();
+		treeResponses.push(pending.promise);
+
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+
+		expect(result.current.loading).toBe(true);
+
+		await act(async () => {
+			pending.resolve([]);
+			await pending.promise;
+		});
+
+		await waitFor(() => {
+			expect(result.current.loading).toBe(false);
+		});
+	});
+
+	it("marks a changed Worktree path as loading until that path has loaded", async () => {
+		const initial = [makeSessionNode("session-1")];
+		treeResponses.push(initial);
+
+		const { result, rerender } = renderHook(
+			({ worktreePath }: { worktreePath: string }) =>
+				useWorkspaceTreeNodes(worktreePath),
+			{ initialProps: { worktreePath: "/repo" } },
+		);
+
+		await waitFor(() => {
+			expect(result.current.nodes).toEqual(initial);
+		});
+		expect(result.current.loading).toBe(false);
+
+		const pending = deferred<WorkspaceTreeNode[]>();
+		treeResponses.push(pending.promise);
+
+		rerender({ worktreePath: "/repo/next" });
+
+		expect(result.current.loading).toBe(true);
+
+		await act(async () => {
+			pending.resolve([]);
+			await pending.promise;
+		});
+
+		await waitFor(() => {
+			expect(result.current.loading).toBe(false);
+		});
+		expect(result.current.nodes).toEqual([]);
+	});
+
 	it("unsubscribes listeners when cleanup runs after setup completes", async () => {
 		const unlistenStatus = vi.fn();
 		const unlistenWorkflow = vi.fn();

--- a/src/hooks/useWorkspaceTreeNodes.ts
+++ b/src/hooks/useWorkspaceTreeNodes.ts
@@ -33,11 +33,12 @@ export function useWorkspaceTreeNodes(
 	const [workflowHistory, setWorkflowHistory] = useState<
 		WorkspaceWorkflowHistoryItem[]
 	>([]);
-	const [loading, setLoading] = useState(false);
+	const [loading, setLoading] = useState(() => Boolean(worktreePath));
 	const [error, setError] = useState<string | null>(null);
 	const refreshTimerRef = useRef<number | null>(null);
 	const refreshSeqRef = useRef(0);
 	const loadedWorktreePathRef = useRef<string | null>(null);
+	const errorWorktreePathRef = useRef<string | null>(null);
 	const nodesRef = useRef<WorkspaceTreeNode[]>([]);
 
 	const updateNodes = useCallback((nextNodes: WorkspaceTreeNode[]) => {
@@ -54,6 +55,7 @@ export function useWorkspaceTreeNodes(
 		if (!worktreePath) {
 			refreshSeqRef.current += 1;
 			loadedWorktreePathRef.current = null;
+			errorWorktreePathRef.current = null;
 			nodesRef.current = [];
 			setNodes([]);
 			setClosedSessions([]);
@@ -81,6 +83,7 @@ export function useWorkspaceTreeNodes(
 				]);
 			if (seq !== refreshSeqRef.current) return;
 			loadedWorktreePathRef.current = worktreePath;
+			errorWorktreePathRef.current = null;
 			updateNodes(nextNodes);
 			setClosedSessions(
 				nextClosedSessions.filter((session) => !session.workflowStepSession),
@@ -94,6 +97,7 @@ export function useWorkspaceTreeNodes(
 				setClosedSessions([]);
 				setWorkflowHistory([]);
 			}
+			errorWorktreePathRef.current = worktreePath;
 			setError(String(e));
 		} finally {
 			if (seq === refreshSeqRef.current) {
@@ -197,5 +201,22 @@ export function useWorkspaceTreeNodes(
 		};
 	}, [hasSessionNode, scheduleRefresh, worktreePath]);
 
-	return { nodes, closedSessions, workflowHistory, loading, error, refresh };
+	const currentError =
+		errorWorktreePathRef.current === worktreePath ? error : null;
+	const currentLoading =
+		loading ||
+		Boolean(
+			worktreePath &&
+				!hasLoadedCurrentWorktree() &&
+				errorWorktreePathRef.current !== worktreePath,
+		);
+
+	return {
+		nodes,
+		closedSessions,
+		workflowHistory,
+		loading: currentLoading,
+		error: currentError,
+		refresh,
+	};
 }


### PR DESCRIPTION
## 概要

`WorkspaceList` で Worktree を展開したとき、配下に Session / Workflow が 1 件も無い場合に空である旨を明示するプレースホルダを表示する。あわせて初回ロード中の loading 状態を worktree 別に正しく追跡し、「空」「読み込み中」「エラー」の 3 状態を視覚的に区別できるようにする。

関連: #1260

## 変更内容

- `useWorkspaceTreeNodes.ts` — worktree 別に loading/error 状態を追跡。初回ロード中は loading を返し、error は対象 worktree のときのみ返す。
- `WorkspaceList.tsx` — Session / Workflow が空のとき `No sessions or workflows` を表示（読み込み中・エラーとは排他）。
- spec 3ファイル新規（requirements / behavior / design）。
- 対応するテストを `WorkspaceList.test.tsx` / `useWorkspaceTreeNodes.test.ts` に追加。

## テスト

- [ ] `pnpm lint`
- [ ] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワークツリーの展開時にセッション/ワークフローが0件の場合、「No sessions or workflows」のプレースホルダーを表示するようになりました。

* **ドキュメント**
  * Issue `#1260の要件仕様書`、設計書、動作仕様書を追加しました。

* **テスト**
  * ワークツリーの空状態表示、ローディング時、エラー時の表示制御に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->