### PR TITLE
feat(workspace): worktree workflow 行のステータスアイコンを専用コンポーネントに分離 (#1268)

### DIFF
--- a/docs/specs/issues-1268/behavior.md
+++ b/docs/specs/issues-1268/behavior.md
@@ -1,0 +1,181 @@
+# Behavior
+
+Issue: #1268 「Workflow のステータスをアイコンで表現する」
+
+本書は `requirements.md` の要求を、実装詳細を含まない観測可能な振る舞いとして Gherkin で定義する。対象は **WorkspaceList の Workflow 行（`WorktreeWorkflowRow`）のステータスアイコン表現**に限定する。
+
+## 仮定
+
+requirements.md の仮定を踏襲する。本書のシナリオはこれらを前提とする。
+
+- **仮定A1（配色の流用）**: Workflow 行アイコンの色は、既存 `workflowStepIconClasses` の配色をそのまま用いる。
+  - `queued` → ミュート色 / `running` → 青 / `failed` → 赤 / `error` → destructive 色 / `waiting` → 黄 / `aborted` → ミュート色 / `completed` → 緑。
+- **仮定A2（pulse 対象）**: `AgentStateIcon` に倣い、進行中／注目が必要な状態である `running` と `waiting` にのみ pulse アニメーションを適用する。それ以外の状態には pulse を適用しない。
+- **仮定A3（レイアウト）**: アイコンサイズ・コンテナのレイアウトは現行 Workflow 行の見た目（`size-5` コンテナ内に `size-3` 程度のアイコン）を踏襲する。
+- **仮定A4（Step 行の据え置き）**: Workflow 行配下の Step 行は現行表現を維持し、本 Issue では変更しない。
+- **仮定A5（代表ステータスの利用）**: 表示に用いる代表ステータスは、Rust 側で導出・配信済みの `WorkspaceWorkflowNode.status` および live 更新値をそのまま用いる。フロントエンドは導出を行わず、色へのマッピングのみを担う。
+- **仮定A6（フォールバック色）**: 代表ステータスが既知の `WorkspaceStepStatus` 値のいずれにも該当しない／未確定の場合、`AgentStateIcon` の `null` 時に倣いミュート色（フォールバック色）を用いる。
+
+## Feature: WorkspaceList の Workflow 行ステータスを固定形状アイコン＋色で表現する
+
+WorkspaceList のツリーにおいて、Workflow 行は「Workflow である」ことを常に同一形状のアイコン（lucide `Workflow` アイコン）で識別でき、その代表ステータスは Session 行（`AgentStateIcon`）と同じ方式（同一形状＋色、稼働中は pulse）で表現される。
+
+### Background
+
+```gherkin
+Background:
+  Given WorkspaceList のツリーに少なくとも 1 つの Workflow 行が表示されている
+  And その Workflow 行には Rust 側で導出された代表ステータス（WorkspaceWorkflowNode.status）が割り当てられている
+```
+
+### Rule: Workflow 行アイコンはステータスによらず常に同一形状である（R1）
+
+```gherkin
+Scenario Outline: 代表ステータスが何であってもアイコン形状は Workflow アイコンで一定である
+  Given Workflow 行の代表ステータスが "<status>" である
+  When Workflow 行が描画される
+  Then Workflow 行のステータスアイコンは lucide "Workflow" アイコンの形状で表示される
+  And ステータスごとに形状が切り替わる表現（Loader2 / CheckCircle2 / AlertTriangle / Clock / Ban / Circle 等）は用いられない
+
+  Examples:
+    | status    |
+    | queued    |
+    | running   |
+    | failed    |
+    | error     |
+    | waiting   |
+    | aborted   |
+    | completed |
+```
+
+```gherkin
+Scenario: ツリー上で Workflow 行を形状で識別できる
+  Given 同一ツリー内に Workflow 行と Step 行と Session 行が混在している
+  When ツリーが描画される
+  Then Workflow 行は常に "Workflow" アイコンの形状で表示され、種別として一意に識別できる
+```
+
+### Rule: 代表ステータスをアイコンの色で表現する（R2）
+
+```gherkin
+Scenario Outline: 代表ステータスに応じてアイコンの色が決まる
+  Given Workflow 行の代表ステータスが "<status>" である
+  When Workflow 行が描画される
+  Then Workflow アイコンには "<color>" 系統の色が適用される
+  And 形状は変化しない
+
+  Examples:
+    | status    | color           |
+    | queued    | ミュート色       |
+    | running   | 青              |
+    | failed    | 赤              |
+    | error     | destructive 色   |
+    | waiting   | 黄              |
+    | aborted   | ミュート色       |
+    | completed | 緑              |
+```
+
+```gherkin
+Scenario Outline: 稼働中・注目が必要な状態は pulse アニメーションで強調される（仮定A2）
+  Given Workflow 行の代表ステータスが "<status>" である
+  When Workflow 行が描画される
+  Then Workflow アイコンに pulse アニメーションが "<pulse>"
+
+  Examples:
+    | status    | pulse      |
+    | running   | 適用される   |
+    | waiting   | 適用される   |
+    | queued    | 適用されない |
+    | failed    | 適用されない |
+    | error     | 適用されない |
+    | aborted   | 適用されない |
+    | completed | 適用されない |
+```
+
+```gherkin
+Scenario: 代表ステータスが未確定・不明な場合はフォールバック色を用いる（仮定A6）
+  Given Workflow 行の代表ステータスが既知の WorkspaceStepStatus 値のいずれにも該当しない
+  When Workflow 行が描画される
+  Then Workflow アイコンにはフォールバックのミュート色が適用される
+  And pulse アニメーションは適用されない
+```
+
+### Rule: 代表ステータスは Rust 側の値をそのまま利用し、フロントエンドは導出しない（R3）
+
+```gherkin
+Scenario: フロントエンドは代表ステータスを導出せず色へマッピングするだけである
+  Given Workflow 行に Rust 側で配信された代表ステータスが与えられている
+  When Workflow 行が描画される
+  Then フロントエンドはステータスの導出・集約・優先順位判定を行わない
+  And 与えられた代表ステータスを色クラスへ対応付ける表示用フォーマットのみを行う
+```
+
+```gherkin
+Scenario: 代表ステータスの live 更新に色がリアルタイムで追従する
+  Given Workflow 行が代表ステータス "running"（青・pulse あり）で表示されている
+  When 代表ステータスが live 更新（workflow-step-status-changed 経路）で "completed" に変化する
+  Then 既存の live 更新経路を通じて Workflow 行に "completed" の代表ステータスが反映される
+  And アイコンの形状は "Workflow" のまま変化しない
+  And アイコンの色が緑へ変化し、pulse アニメーションが解除される
+```
+
+### Rule: 状態識別性とステータス確認手段を維持する（R4）
+
+```gherkin
+Scenario: 各ステータスが色（および pulse の有無）で相互に区別できる
+  Given Workflow 行が取りうる各 WorkspaceStepStatus 値
+  When それぞれの値で Workflow 行が描画される
+  Then 色と pulse の有無の組み合わせにより各ステータスが相互に区別可能である
+```
+
+```gherkin
+Scenario Outline: ホバー等で現在のステータスを確認できる
+  Given Workflow 行の代表ステータスが "<status>" である
+  When Workflow 行のアイコンにポインタを合わせる
+  Then 現在のステータス "<status>" を示す title 属性が提示される
+
+  Examples:
+    | status    |
+    | queued    |
+    | running   |
+    | completed |
+    | error     |
+```
+
+### Rule: 本変更は Workflow 行のアイコンに限定し、他の表現を変えない（非スコープ）
+
+```gherkin
+Scenario: Step 行のアイコン表現は変更されない
+  Given Workflow 行配下に Step 行が表示されている
+  When ツリーが描画される
+  Then Step 行のステータスアイコンは本変更前と同じ形＋色の表現（WorkflowStepStatusIcon）のまま維持される
+```
+
+```gherkin
+Scenario: Session 行および中央パネル WorkflowView の表現は変更されない
+  Given Session 行（AgentStateIcon）と中央パネル WorkflowView の Step ヘッダーが表示されている
+  When それらが描画される
+  Then それぞれのアイコン表現は本変更の前後で変化しない
+```
+
+```gherkin
+Scenario: ステータスの導出・集約ロジックおよび通信経路は変更されない
+  Given 既存の代表ステータス導出（Rust 側）と配信経路が存在する
+  When 本変更を適用する
+  Then 新規 Tauri コマンド・WebSocket メッセージ・イベントは追加されない
+  And ステータス導出・集約ロジックおよび WorkspaceStepStatus の語彙は変更されない
+```
+
+## 受け入れ基準（観測可能な確認項目）
+
+- WorkspaceList の Workflow 行のアイコンが、全ステータスにおいて lucide `Workflow` アイコンの形状で表示される。
+- 代表ステータスが変化すると、アイコンの形状は変わらず色（および pulse の有無）のみが変化する。
+- `running` / `waiting` で pulse アニメーションが適用され、それ以外では適用されない。
+- 代表ステータスが live 更新された際、色がリアルタイムに追従する。
+- Step 行・Session 行・WorkflowView のアイコン表現は本変更前後で変わらない。
+- フロントエンドにステータス導出ロジックが追加されていない（色マッピングのみ）。
+- `pnpm lint` / `pnpm test` / `pnpm build` が通る。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1268/design.md
+++ b/docs/specs/issues-1268/design.md
@@ -1,0 +1,181 @@
+# Design
+
+Issue: #1268 「Workflow のステータスをアイコンで表現する」
+
+本書は `requirements.md` / `behavior.md` を実装方針へ落とし込む設計文書である。対象は **WorkspaceList の Workflow 行（`WorktreeWorkflowRow`）のステータスアイコン表現**に限定する。
+
+## 概要
+
+WorkspaceList の Workflow 行は現在 `WorkflowStepStatusIcon`（ステータスごとに**形状が変わる**: Loader2/CheckCircle2/AlertTriangle/Clock/Ban/Circle）で描画されている。これを **#1259 以前の固定 `Workflow`（lucide）アイコン**へ戻し、ステータスは `AgentStateIcon`（Session 行）と同じ方式 ── **同一形状＋色（＋稼働中の pulse）** ── で表現する。
+
+これにより、
+
+- Workflow 行が「Workflow である」ことを形状で一意に識別できる（R1）。
+- Session 行と Workflow 行のステータス表現方式が「色で表す」方式に統一される（R2）。
+
+ステータスの導出・集約・配信は Rust 側の既存実装（`WorkspaceWorkflowNode.status` および live 更新）をそのまま利用し、フロントエンドは**色クラスへのマッピングという表示用フォーマットのみ**を担う（R3 / rust-first-logic 準拠）。
+
+## 変更対象
+
+| ファイル | 変更内容 | 区分 |
+| --- | --- | --- |
+| `src/components/workspace/WorkflowRowStatusIcon.tsx` | **新規作成**。固定 `Workflow` アイコン＋色＋pulse＋title を描画するコンポーネント。 | 追加 |
+| `src/components/workspace/WorkflowRowStatusIcon.test.tsx` | **新規作成**。新規コンポーネントの単体テスト。 | 追加 |
+| `src/components/workspace/WorkspaceList.tsx` | `WorktreeWorkflowRow`（Workflow 行）の `WorkflowStepStatusIcon` 呼び出しを `WorkflowRowStatusIcon` に差し替え。import 追加。 | 変更 |
+| `src/components/workspace/WorkflowStepStatusIcon.tsx` | `workflowStepIconClasses`（既に `export` 済み）を新規コンポーネントから再利用。**本体は変更しない**（Step 行・WorkflowView で継続使用）。 | 参照のみ |
+
+### 変更しない箇所（非スコープの担保）
+
+- `WorktreeWorkflowStepRow`（Step 行, `WorkspaceList.tsx:366`）の `WorkflowStepStatusIcon` 呼び出し。
+- `WorkflowView.tsx`（中央パネル）の Step ヘッダー / `AgentStateIcon`。
+- `WorktreeSessionRow`（Session 行, `WorkspaceList.tsx:209`）の `AgentStateIcon`。
+- Rust 側のステータス導出・集約（`status_aggregation.rs` 等）、`WorkspaceStepStatus` の語彙、Tauri コマンド・WS メッセージ・イベント。
+- live 更新経路（`useWorktreeStepStatuses` / `applyLiveWorkflowStatuses` / `workflow-step-status-changed`）。
+
+## アーキテクチャと責務分割
+
+### 設計判断: 新規コンポーネント方式を採用する（requirements A5 の確定）
+
+requirements A5 が design へ委ねた「新規コンポーネント化 or 既存への分岐追加」は、**新規コンポーネント `WorkflowRowStatusIcon` の作成**で確定する。
+
+- 採用理由:
+  - `WorkflowStepStatusIcon`（形で表す）と `WorkflowRowStatusIcon`（色で表す）は表現方式が本質的に異なる。1 コンポーネントに分岐フラグを足すと、両方式が 1 箇所に同居し責務が曖昧になる。
+  - Step 行・WorkflowView が使う `WorkflowStepStatusIcon` の挙動を一切変えず据え置ける（非スコープ担保が明快）。
+  - `AgentStateIcon` が Session 行専用の小コンポーネントとして独立しているのと対称的で、サイドバーのアイコン構成が把握しやすい。
+- 配置: `WorkspaceStepStatus` を扱うため、`WorkflowStepStatusIcon.tsx` と同じ `src/components/workspace/` に置く（`AgentStateIcon` は汎用 UI のため `ui/` だが、本コンポーネントは workspace ドメインに固有）。
+
+### 各層の責務
+
+- **Rust（変更なし）**: 代表ステータスの導出・集約・配信。`WorkspaceWorkflowNode.status` と live 更新値の供給源。
+- **`useWorktreeStepStatuses` / `applyLiveWorkflowStatuses`（変更なし）**: live 更新を `node.status` へ反映し `WorktreeWorkflowRow` へ渡す。
+- **`WorktreeWorkflowRow`（呼び出し差し替えのみ）**: `node.status` を `WorkflowRowStatusIcon` へ渡す。
+- **`WorkflowRowStatusIcon`（新規）**: 受け取った `WorkspaceStepStatus` を色クラス＋pulse の有無＋title へマッピングし、固定 `Workflow` アイコンを描画する**表示用フォーマット責務のみ**。導出・集約・優先順位判定は行わない。
+
+## データモデルまたは型
+
+新規の型・WS メッセージ・Tauri コマンドは追加しない。既存型をそのまま利用する。
+
+- `WorkspaceStepStatus`（`src/types/workspace-tree.ts`）: `"queued" | "running" | "failed" | "error" | "waiting" | "aborted" | "completed"`。
+- `WorkspaceWorkflowNode.status: WorkspaceStepStatus`（同上）。
+
+### `WorkflowRowStatusIcon` の Props
+
+```tsx
+interface WorkflowRowStatusIconProps {
+    status: WorkspaceStepStatus;
+    containerClassName?: string;
+    iconClassName?: string;
+}
+```
+
+- `circleClassName` は持たない（`queued` 用 `Circle` 形状を使わず、形状は常に `Workflow` で固定のため）。
+- 呼び出し側（`WorktreeWorkflowRow`）は現行レイアウトを踏襲して `containerClassName="flex size-5 shrink-0 items-center justify-center"` / `iconClassName="size-3"` を渡す（仮定 A3）。
+
+### 色・pulse マッピング
+
+- **色**: `WorkflowStepStatusIcon.tsx` が `export` 済みの `workflowStepIconClasses: Record<WorkspaceStepStatus, string>` を **import して再利用**する（仮定 A1。配色定義を二重に持たない）。
+  - `queued`→`text-muted-foreground` / `running`→`text-blue-600 dark:text-blue-300` / `failed`→`text-red-600 dark:text-red-300` / `error`→`text-destructive` / `waiting`→`text-yellow-600 dark:text-yellow-300` / `aborted`→`text-muted-foreground` / `completed`→`text-green-600 dark:text-green-300`。
+- **pulse**: `running` と `waiting` にのみ `animate-pulse` を付与する（仮定 A2、`AgentStateIcon` に倣う）。コンポーネント内に対象集合を持つ。
+
+  ```tsx
+  const pulseStatuses: ReadonlySet<WorkspaceStepStatus> = new Set(["running", "waiting"]);
+  ```
+
+- **フォールバック色（仮定 A6）**: `status` が既知値に該当しない場合は `text-muted-foreground`、pulse なし。`AgentStateIcon` の `null` 時に倣う。
+  - 型上は `WorkspaceStepStatus` で網羅されるが、`workflowStepIconClasses[status]` の参照結果が未定義となる事態（将来の語彙追加・実行時の想定外値）に備え、`workflowStepIconClasses[status] ?? "text-muted-foreground"` の形でフォールバックする。これは導出ではなく表示用フォーマットの防御的既定値。
+
+## 処理フロー
+
+1. Rust が代表ステータスを導出・配信 → `WorkspaceWorkflowNode.status`。
+2. `useWorktreeStepStatuses` が `workflow-step-status-changed` を購読し、`applyLiveWorkflowStatuses` が `node.status` を最新値へ上書きして `displayNodes` を生成。
+3. `WorktreeWorkflowRow` が `node.status` を `WorkflowRowStatusIcon` の `status` へ渡す。
+4. `WorkflowRowStatusIcon` が以下を計算して描画:
+   - 色クラス = `workflowStepIconClasses[status] ?? "text-muted-foreground"`
+   - pulse = `pulseStatuses.has(status)` のとき `animate-pulse`
+   - `title = status`（ホバー時にステータス確認、R4）
+   - 形状 = 常に lucide `Workflow`
+5. live 更新でステータスが変わると `displayNodes` 再計算 → 再レンダリングされ、**形状は `Workflow` のまま、色と pulse のみ追従**する。
+
+### 描画構造（概略）
+
+```tsx
+import { Workflow } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { WorkspaceStepStatus } from "@/types/workspace-tree";
+import { workflowStepIconClasses } from "./WorkflowStepStatusIcon";
+
+const pulseStatuses: ReadonlySet<WorkspaceStepStatus> = new Set(["running", "waiting"]);
+
+export function WorkflowRowStatusIcon({
+    status,
+    containerClassName,
+    iconClassName,
+}: WorkflowRowStatusIconProps) {
+    const colorClass = workflowStepIconClasses[status] ?? "text-muted-foreground";
+    const pulse = pulseStatuses.has(status) ? "animate-pulse" : undefined;
+    return (
+        <span title={status} className={containerClassName}>
+            <Workflow className={cn("size-3.5 shrink-0", colorClass, pulse, iconClassName)} />
+        </span>
+    );
+}
+```
+
+（最終的な className 合成順・既定サイズは実装時に既存 2 コンポーネントと揃える。`AgentStateIcon` が `size-3.5` 既定、Workflow 行呼び出しが `size-3` 上書きである点を踏襲。）
+
+## エラー処理
+
+- 本変更は表示専用で I/O・非同期処理を持たないため、新規のエラー型・例外処理は不要。
+- 想定外の `status` 値は前述のフォールバック色（muted・pulse なし）で安全に描画する（クラッシュさせない）。
+
+## テスト方針
+
+CLAUDE.md のテスト配置に従い、コンポーネントと同階層に `*.test.tsx` を置く。
+
+### 新規 `WorkflowRowStatusIcon.test.tsx`（単体テスト）
+
+`behavior.md` の Rule を網羅する:
+
+- **形状一定（R1）**: 全 `WorkspaceStepStatus` 値で描画し、lucide `Workflow` アイコン（`svg.lucide-workflow` クラス）が表示され、Loader2/CheckCircle2/AlertTriangle/Clock/Ban/Circle が現れないこと。
+- **色マッピング（R2）**: 各ステータスで `workflowStepIconClasses` に対応する色クラスが付与されること（render 結果の className を検証）。
+- **pulse（仮定 A2）**: `running` / `waiting` で `animate-pulse` が付与され、`queued`/`failed`/`error`/`aborted`/`completed` で付与されないこと。
+- **フォールバック（仮定 A6）**: 既知値以外（実行時の想定外値）を渡したとき `text-muted-foreground`・pulse なしになること。
+- **title（R4）**: `title={status}` が提示されること（`getByTitle`）。
+
+### 既存 `WorkspaceList.test.tsx`（統合テスト・確認/最小追記）
+
+- Workflow 行が `Workflow` アイコン形状で描画されることの確認を追加。
+- 既存の live 代表ステータス検証（`useWorktreeStepStatuses` モックで `workflows: Map([["run-1","failed"]])`、`getAllByTitle("failed")` 等）が、アイコン差し替え後も通ることを確認。title 属性は新コンポーネントでも維持するため既存アサーションは原則そのまま通る見込み。
+- Step 行（`WorkflowStepStatusIcon`）・Session 行（`AgentStateIcon`）の表現が不変であることを担保する既存テストを壊さない。
+
+### 既存テストへの影響確認
+
+- Step 行は title=ステータス、Workflow 行も title=ステータスで、形状以外の DOM テキスト/title 構造は維持されるため、title ベースの既存アサーションへの破壊的影響はない見込み。実装時に `WorkspaceList.test.tsx` を実行して確認する。
+
+### 品質チェック
+
+- `pnpm lint` / `pnpm test` / `pnpm build` を通す（受け入れ基準）。
+
+## リスクと代替案
+
+- **リスク 1: 既存 `WorkspaceList.test.tsx` のアイコン関連アサーション破壊**
+  - 既存テストは title 属性（`getAllByTitle`）で検証しており、形状クラスに依存していないため影響は小さい見込み。実装時にテスト実行で確証する。
+- **リスク 2: `workflowStepIconClasses` の import による結合**
+  - Workflow 行アイコン（色のみ）と Step 行アイコン（形＋色）が同じ配色定義を共有する。これは仮定 A1（配色流用）の意図そのもので、配色変更時に両者を一括で揃えられる利点となる。将来 Workflow 行だけ配色を変えたくなった場合は、その時点で定義を分離する。
+- **代替案 A（不採用）: `WorkflowStepStatusIcon` に `variant`/`fixedShape` プロップを足して分岐**
+  - 1 コンポーネントに「形で表す」「色で表す」両方式が同居し責務が肥大化。Step 行・WorkflowView への波及リスクも増えるため不採用。
+- **代替案 B（不採用）: `AgentStateIcon` を汎用化して Workflow にも流用**
+  - `AgentState`（`running|done|error|waiting`）と `WorkspaceStepStatus`（7 値）は語彙が異なり、アイコン形状も Bot↔Workflow で別。汎用化は両者の差異を吸収する分岐を生むだけで利得が薄く、非スコープ（Session 行不変）にも抵触しうるため不採用。
+
+## 仮定
+
+requirements / behavior の仮定（A1〜A6）を踏襲する。本設計で追加・確定した仮定は以下。
+
+- **D1**: requirements A5 の未確定点を「新規コンポーネント `WorkflowRowStatusIcon` 作成」で確定する（上記「設計判断」参照）。
+- **D2**: 新規コンポーネントは `src/components/workspace/` に配置する（`WorkspaceStepStatus` を扱う workspace ドメイン固有のため）。
+- **D3**: 配色定義は `WorkflowStepStatusIcon.tsx` の `export` 済み `workflowStepIconClasses` を import 再利用し、定義を二重化しない。
+- **D4**: コンポーネント名は `WorkflowRowStatusIcon`（`WorkflowStepStatusIcon` と並列・対比が明確な命名）。実装時に既存命名規約と齟齬があれば調整しうる。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1268/design.md
+++ b/docs/specs/issues-1268/design.md
@@ -69,7 +69,8 @@ interface WorkflowRowStatusIconProps {
 ```
 
 - `circleClassName` は持たない（`queued` 用 `Circle` 形状を使わず、形状は常に `Workflow` で固定のため）。
-- 呼び出し側（`WorktreeWorkflowRow`）は現行レイアウトを踏襲して `containerClassName="flex size-5 shrink-0 items-center justify-center"` / `iconClassName="size-3"` を渡す（仮定 A3）。
+- 呼び出し側（`WorktreeWorkflowRow`）は **Session 行（`AgentStateIcon`）と同一のアイコン配置に揃える**。すなわち `containerClassName` を渡さず（ラップ `span` はサイズ指定なし）、既定の `iconClassName="size-3.5 shrink-0"` をそのまま用いる（仮定 A3 改訂）。
+  - 当初は旧 `WorkflowStepStatusIcon`（Step 行）のレイアウト（`containerClassName="flex size-5 shrink-0 items-center justify-center"` / `iconClassName="size-3"`）を踏襲したが、Workflow 行はサイドバー上で Step 行ではなく **Session 行と縦に並ぶ**。`AgentStateIcon` は 14px (`size-3.5`) アイコンをサイズ指定なしの `span` で左端に置くのに対し、size-5 (20px) ボックス中央寄せ＋12px アイコンでは左余白とボックス幅の差でアイコン・ラベルが右へずれる。R2（Session 行と表現方式を統一）の観点からも `AgentStateIcon` に揃えるのが正しい。
 
 ### 色・pulse マッピング
 
@@ -115,13 +116,13 @@ export function WorkflowRowStatusIcon({
     const pulse = pulseStatuses.has(status) ? "animate-pulse" : undefined;
     return (
         <span title={status} className={containerClassName}>
-            <Workflow className={cn("size-3.5 shrink-0", colorClass, pulse, iconClassName)} />
+            <Workflow className={cn(iconClassName, colorClass, pulse)} />
         </span>
     );
 }
 ```
 
-（最終的な className 合成順・既定サイズは実装時に既存 2 コンポーネントと揃える。`AgentStateIcon` が `size-3.5` 既定、Workflow 行呼び出しが `size-3` 上書きである点を踏襲。）
+（既定サイズは `AgentStateIcon` と揃え `iconClassName="size-3.5 shrink-0"`。`WorktreeWorkflowRow` は `containerClassName`/`iconClassName` を渡さず既定のまま用いるため、ラップ `span` はサイズ指定なし・アイコンは 14px となり Session 行と一致する。）
 
 ## エラー処理
 

--- a/docs/specs/issues-1268/requirements.md
+++ b/docs/specs/issues-1268/requirements.md
@@ -1,0 +1,97 @@
+# Requirements
+
+Issue: #1268 「Workflow のステータスをアイコンで表現する」
+
+関連: #1259 (Workflow/Step/Session ステータス集約) / #1242 (Workflow パネル再編) / #1220 (Workspace サイドバー 4 階層ツリー化)
+
+## Type
+
+WorkspaceList における **Workflow 行のステータス表示の見直し**（UI 表現の変更）。
+
+## 背景と目的
+
+GitHub Issue #1268 は本文が空のため、要求の確定はユーザーへのヒアリングに基づく（下記「合意済みの前提」参照）。
+
+### 経緯
+
+- #1220 以前の WorkspaceList では、Workflow 行は固定の `Workflow`（lucide）アイコン＋静的なミュート色 (`text-muted-foreground/80`) で表示されていた（形は常に同一で、Workflow という「種別」を表すアイコン）。
+- #1259 で Workflow 行・Step 行のアイコンが `WorkflowStepStatusIcon` に置き換えられた。これはステータスごとに**アイコンの形そのものが変化する**（`running`→Loader2 / `completed`→CheckCircle2 / `failed`・`error`→AlertTriangle / `waiting`→Clock / `aborted`→Ban / `queued`→Circle）。
+- 一方、Session 行のステータス表示 `AgentStateIcon` は、**常に同一の Bot アイコン**を用い、**色（および稼働中の pulse アニメーション）で状態を表現**している（`running`: info + pulse / `done`: success / `waiting`: warning + pulse / `error`: destructive）。
+
+### 課題
+
+- Workflow 行のアイコンは #1259 で「形が状態ごとに変わる」表現になったため、行が「Workflow である」という種別の識別性が失われた。状態によってアイコン形状が切り替わると、ツリー上で Workflow 行を一目で見分けにくい。
+- Session 行（`AgentStateIcon`）とステータス表現の方式が不統一（Session は色で表現、Workflow は形で表現）であり、サイドバー全体の見た目に一貫性がない。
+
+### 目的
+
+WorkspaceList の Workflow 行を、**#1259 以前の固定 `Workflow` アイコンに戻した上で**、`AgentStateIcon` と同じ方式（同一形状のアイコンを保ち、**色**でステータスを表現、稼働中は pulse）で Workflow の代表ステータスを表現する。これにより「Workflow 行であること」の識別性とサイドバー全体のステータス表現の一貫性を両立させる。
+
+## 合意済みの前提
+
+- 本変更の対象は **WorkspaceList の Workflow 行のアイコン**に限定する（ユーザー確認済み）。
+- 「元のアイコン」とは #1259 以前に Workflow 行で使われていた lucide の `Workflow` アイコンを指す。
+- 表現方式は `AgentStateIcon`（Session 行）と同様、**単一アイコン形状＋色（＋稼働中の pulse）**とする。
+
+## スコープ
+
+- WorkspaceList の Workflow 行（`WorktreeWorkflowRow`）のステータスアイコンを、固定の `Workflow`（lucide）アイコンに戻す。
+- 上記アイコンの**色**で Workflow の代表ステータス（`node.status`: `WorkspaceStepStatus`）を表現する。`AgentStateIcon` と同様に、稼働中（`running` 等）は pulse アニメーションで強調する。
+- 表示に使う代表ステータス値は、既に Rust 側で導出・配信済みの `WorkspaceWorkflowNode.status`（および live 更新値）をそのまま用いる。
+- 上記表現に必要なフロントエンドの表示用色マッピング（`WorkspaceStepStatus` → 色クラス）の定義。
+
+## 非スコープ
+
+- Workflow 行の **Step 行**（`WorktreeWorkflowStepRow`）のアイコン表現の変更。Step 行は現行の `WorkflowStepStatusIcon`（形＋色）を維持する。
+- 中央パネル `WorkflowView` の Step ヘッダーのアイコン表現の変更。
+- Session 行（`AgentStateIcon`）の表現変更。
+- ステータスの**導出・集約ロジック**（Rust 側 `status_aggregation.rs` / `workspace_tree.rs` / `agent_session/status.rs`、優先順位、`WorkspaceStepStatus` の語彙）の変更。#1259 で確定したものをそのまま用いる。
+- 新規 Tauri コマンド・WebSocket メッセージ・イベントの追加。
+- Workflow engine の実行モデル・YAML schema・ナビゲーション構造の変更。
+
+## 要求事項
+
+### R1. Workflow 行アイコンを固定形状へ戻す
+
+- WorkspaceList の Workflow 行のステータスアイコンは、ステータスによらず**常に同一形状**（lucide `Workflow` アイコン）で表示すること。
+- これにより、ツリー上で Workflow 行が「Workflow である」ことを形状で一意に識別できること。
+
+### R2. ステータスを色で表現する
+
+- Workflow の代表ステータス（`WorkspaceStepStatus`）を、`Workflow` アイコンの**色**で表現すること。
+- 色付けは `AgentStateIcon` と同じ方式に揃えること。すなわち:
+  - 同一アイコン形状を保ったまま色のみでステータスを区別する。
+  - 稼働中（`running`）など「処理が進行している」状態は pulse アニメーションで強調する（`AgentStateIcon` の `running` / `waiting` における `animate-pulse` に倣う）。
+- 代表ステータスが未確定／不明な場合のフォールバック色を定めること（`AgentStateIcon` が `null` 時に `text-muted-foreground` を用いるのに倣う）。
+
+### R3. 既存の代表ステータスをそのまま利用する
+
+- 表示に用いるステータス値は、既に Rust 側で導出・配信されている `WorkspaceWorkflowNode.status` および live 更新値（`useWorktreeStepStatuses` 経由）を用いること。
+- フロントエンドはステータスの導出・集約を行わず、受け取った代表ステータスを色へマッピングする表示用フォーマットのみを担うこと（rust-first-logic 準拠）。
+
+### R4. 状態識別性の維持
+
+- 各 `WorkspaceStepStatus`（`queued` / `running` / `failed` / `error` / `waiting` / `aborted` / `completed`）が、色（および pulse の有無）で相互に区別可能であること。
+- ホバー時等に現在のステータスを確認できる手段（`title` 属性等）を維持すること（現行 `WorkflowStepStatusIcon` / `AgentStateIcon` が `title` を持つことに倣う）。
+
+## 受け入れ基準の概要
+
+- WorkspaceList の Workflow 行のアイコンが、全ステータスにおいて lucide `Workflow` アイコンの形状で表示される。
+- Workflow の代表ステータスが変化すると、アイコンの形状は変わらず**色**（および pulse の有無）のみが変化する。
+- `running` 等の稼働中ステータスで pulse アニメーションが適用される。
+- 代表ステータスが live 更新（`workflow-step-status-changed`）された際、色がリアルタイムに追従する（既存の live 更新経路を踏襲）。
+- Step 行・Session 行・WorkflowView のアイコン表現は本変更前後で変わらない。
+- フロントエンドにステータス導出ロジックが追加されていない（色マッピングのみ）。
+- `pnpm lint` / `pnpm test` / `pnpm build` が通る。
+
+## 仮定
+
+- A1. 色マッピングは、既存 `workflowStepIconClasses`（`WorkflowStepStatusIcon.tsx`）の配色をそのまま流用する（ユーザー確認済み）。すなわち `queued`→`text-muted-foreground` / `running`→`text-blue-600 dark:text-blue-300` / `failed`→`text-red-600 dark:text-red-300` / `error`→`text-destructive` / `waiting`→`text-yellow-600 dark:text-yellow-300` / `aborted`→`text-muted-foreground` / `completed`→`text-green-600 dark:text-green-300`。形状のみ `Workflow` アイコンへ固定し、配色は据え置く。
+- A2. pulse を付与する対象は、`AgentStateIcon` に倣い「進行中／注目が必要」な状態とし、`running` と `waiting` に `animate-pulse` を適用する。
+- A3. アイコンサイズ・コンテナのレイアウトは現行 Workflow 行の見た目（`size-5` コンテナ内に `size-3` 程度）を踏襲する。
+- A4. Step 行は現行 `WorkflowStepStatusIcon` を維持し、本 Issue では変更しない（ユーザーが対象を「Workflow 行」と明示したため）。
+- A5. 既存コンポーネント `WorkflowStepStatusIcon` 自体は Step 行・WorkflowView で引き続き使用されるため削除しない。Workflow 行用には新たな表示（例: `Workflow` アイコン＋色マッピング）を用意する想定。具体的な実装方式（新規コンポーネント化 or 既存への分岐追加）は design.md で確定する。
+
+## Open Questions
+
+なし。

--- a/src/components/workspace/WorkflowRowStatusIcon.test.tsx
+++ b/src/components/workspace/WorkflowRowStatusIcon.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { WorkspaceStepStatus } from "@/types/workspace-tree";
+import { WorkflowRowStatusIcon } from "./WorkflowRowStatusIcon";
+import { workflowStepIconClasses } from "./WorkflowStepStatusIcon";
+
+const statuses: WorkspaceStepStatus[] = [
+	"queued",
+	"running",
+	"failed",
+	"error",
+	"waiting",
+	"aborted",
+	"completed",
+];
+
+function renderIcon(status: WorkspaceStepStatus) {
+	return render(
+		<WorkflowRowStatusIcon
+			status={status}
+			containerClassName="flex size-5 shrink-0 items-center justify-center"
+			iconClassName="size-3"
+		/>,
+	);
+}
+
+describe("WorkflowRowStatusIcon", () => {
+	it.each(statuses)("keeps the Workflow icon shape for %s", (status) => {
+		const { container } = renderIcon(status);
+
+		expect(container.querySelectorAll("svg")).toHaveLength(1);
+		expect(container.querySelector("svg.lucide-workflow")).toBeInTheDocument();
+	});
+
+	it.each(statuses)("uses the workflow step status color for %s", (status) => {
+		const { container } = renderIcon(status);
+		const icon = container.querySelector("svg.lucide-workflow");
+
+		expect(icon).toHaveClass(...workflowStepIconClasses[status].split(" "));
+	});
+
+	it("pulses only running and waiting statuses", () => {
+		for (const status of statuses) {
+			const { container, unmount } = renderIcon(status);
+			const icon = container.querySelector("svg.lucide-workflow");
+
+			if (status === "running" || status === "waiting") {
+				expect(icon).toHaveClass("animate-pulse");
+			} else {
+				expect(icon).not.toHaveClass("animate-pulse");
+			}
+
+			unmount();
+		}
+	});
+
+	it.each([
+		"queued",
+		"running",
+		"completed",
+		"error",
+	] as const)("exposes %s as the title", (status) => {
+		renderIcon(status);
+
+		expect(screen.getByTitle(status)).toBeInTheDocument();
+	});
+
+	it("falls back to muted color without pulse for an unknown runtime status", () => {
+		const { container } = renderIcon("future-status" as WorkspaceStepStatus);
+		const icon = container.querySelector("svg.lucide-workflow");
+
+		expect(screen.getByTitle("future-status")).toBeInTheDocument();
+		expect(icon).toHaveClass("text-muted-foreground");
+		expect(icon).not.toHaveClass("animate-pulse");
+	});
+});

--- a/src/components/workspace/WorkflowRowStatusIcon.test.tsx
+++ b/src/components/workspace/WorkflowRowStatusIcon.test.tsx
@@ -15,13 +15,7 @@ const statuses: WorkspaceStepStatus[] = [
 ];
 
 function renderIcon(status: WorkspaceStepStatus) {
-	return render(
-		<WorkflowRowStatusIcon
-			status={status}
-			containerClassName="flex size-5 shrink-0 items-center justify-center"
-			iconClassName="size-3"
-		/>,
-	);
+	return render(<WorkflowRowStatusIcon status={status} />);
 }
 
 describe("WorkflowRowStatusIcon", () => {

--- a/src/components/workspace/WorkflowRowStatusIcon.tsx
+++ b/src/components/workspace/WorkflowRowStatusIcon.tsx
@@ -1,0 +1,31 @@
+import { Workflow } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { WorkspaceStepStatus } from "@/types/workspace-tree";
+import { workflowStepIconClasses } from "./WorkflowStepStatusIcon";
+
+const pulseStatuses: ReadonlySet<WorkspaceStepStatus> =
+	new Set<WorkspaceStepStatus>(["running", "waiting"]);
+
+interface WorkflowRowStatusIconProps {
+	status: WorkspaceStepStatus;
+	containerClassName?: string;
+	iconClassName?: string;
+}
+
+export function WorkflowRowStatusIcon({
+	status,
+	containerClassName,
+	iconClassName = "size-3.5 shrink-0",
+}: WorkflowRowStatusIconProps) {
+	const colorClassName =
+		workflowStepIconClasses[status] ?? "text-muted-foreground";
+	const pulseClassName = pulseStatuses.has(status)
+		? "animate-pulse"
+		: undefined;
+
+	return (
+		<span className={containerClassName} title={status}>
+			<Workflow className={cn(iconClassName, colorClassName, pulseClassName)} />
+		</span>
+	);
+}

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -569,6 +569,21 @@ describe("WorkspaceList", () => {
 		expect(screen.getAllByTitle("completed").length).toBeGreaterThanOrEqual(1);
 	});
 
+	it("uses a fixed Workflow icon for Workflow rows and keeps Step row status icons", () => {
+		renderWorkspaceList();
+
+		const workflowButton = screen.getByText("release").closest("button");
+		const stepButton = screen.getByText("Build step").closest("button");
+
+		expect(
+			workflowButton?.querySelector('[title="failed"] svg.lucide-workflow'),
+		).toBeInTheDocument();
+		expect(
+			stepButton?.querySelector('[title="waiting"] svg.lucide-clock'),
+		).toBeInTheDocument();
+		expect(stepButton?.querySelector("svg.lucide-workflow")).toBeNull();
+	});
+
 	it("does not enable Stop from a live representative status on a terminal Workflow", async () => {
 		const user = userEvent.setup();
 		renderWorkspaceList();

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -264,11 +264,7 @@ function WorktreeWorkflowRow({
 					className="flex min-w-0 flex-1 items-center gap-2 text-left"
 					onClick={() => setExpanded((prev) => !prev)}
 				>
-					<WorkflowRowStatusIcon
-						status={node.status}
-						containerClassName="flex size-5 shrink-0 items-center justify-center"
-						iconClassName="size-3"
-					/>
+					<WorkflowRowStatusIcon status={node.status} />
 					<span className="min-w-0 truncate">{workflowLabel}</span>
 					{expanded ? (
 						<ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -68,6 +68,7 @@ import type {
 } from "@/types/workspace-tree";
 import { CreateWorktreeModal } from "./CreateWorktreeModal";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
+import { WorkflowRowStatusIcon } from "./WorkflowRowStatusIcon";
 import { WorkflowStepStatusIcon } from "./WorkflowStepStatusIcon";
 
 interface WorkspaceListProps {
@@ -263,11 +264,10 @@ function WorktreeWorkflowRow({
 					className="flex min-w-0 flex-1 items-center gap-2 text-left"
 					onClick={() => setExpanded((prev) => !prev)}
 				>
-					<WorkflowStepStatusIcon
+					<WorkflowRowStatusIcon
 						status={node.status}
 						containerClassName="flex size-5 shrink-0 items-center justify-center"
 						iconClassName="size-3"
-						circleClassName="size-2"
 					/>
 					<span className="min-w-0 truncate">{workflowLabel}</span>
 					{expanded ? (


### PR DESCRIPTION
## 概要

`WorktreeWorkflowRow` のステータス表示を、circle ベースの `WorkflowStepStatusIcon` から Workflow アイコンベースの新規 `WorkflowRowStatusIcon` コンポーネントに分離する。

Closes #1268

## 変更内容

- `WorkflowRowStatusIcon` を新規追加（`lucide-react` の `Workflow` アイコン + ステータス別カラー、`running`/`waiting` は pulse アニメーション）
- `WorkspaceList` の workflow 行で `WorkflowStepStatusIcon` から `WorkflowRowStatusIcon` へ置き換え
- spec（requirements / behavior / design）を `docs/specs/issues-1268/` に追加
- `WorkflowRowStatusIcon` / `WorkspaceList` のテストを追加

## テスト

- [ ] `pnpm lint`
- [ ] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * ワークフローステータス表現に関する要求仕様、設計、動作仕様書を追加

* **New Features**
  * WorkspaceListのワークフロー行ステータスアイコンを改善。固定形状のアイコンで、ステータスは色とアニメーション（実行中・待機中のみ）で表現

<!-- end of auto-generated comment: release notes by coderabbit.ai -->