### PR TITLE
feat(pty): Terminal/PTY ライフサイクルに cap・eviction・idle timeout を導入 (#1215)

### DIFF
--- a/docs/specs/issues-1215/behavior.md
+++ b/docs/specs/issues-1215/behavior.md
@@ -1,0 +1,192 @@
+# Behavior
+
+Terminal / PTY ライフサイクルに cap・eviction・idle timeout を導入し、メモリ常駐量を境界づける振る舞いを定義する。
+
+実装詳細（具体的なデータ構造・モジュール配置・経路）は含めず、外部から観測可能なビジネスルールとして記述する。cap 値・idle 時間などの具体値は requirements.md の仮定 A2/A6/A7 に従う暫定値であり、design.md でチューニング可能なパラメータとして扱う。
+
+## Feature: Terminal / PTY ライフサイクル境界づけ
+
+inactive な terminal を軽量状態へ退避し、cap・idle timeout を超えたリソースを Rust 側のポリシーで解放することで、メモリ常駐量とピークを境界づける。同時に active terminal の UX は維持する。
+
+Background:
+```gherkin
+Given Releash のワークスペースが開かれている
+And terminal のライフサイクルポリシー（cap・idle timeout・LRU 単位）は Rust 側で enforce される
+And inactive terminal の復元元は Rust が保持する lightweight state である
+```
+
+---
+
+## Rule R1: inactive terminal の xterm は unmount され、mounted 数が hidden 数に比例しない
+
+```gherkin
+Scenario: active な terminal だけが mount される
+  Given 1 つの tab に 4 つの terminal pane があり、1 つだけが active である
+  When ユーザーがその tab を表示している
+  Then active な pane の xterm のみが DOM 上に mount されている
+  And inactive な 3 つの pane の xterm は DOM から unmount されている
+
+Scenario: hidden terminal を増やしても mounted 数が比例して増えない
+  Given 複数の tab と pane に terminal が存在する
+  When hidden（inactive）な terminal の数を増やす
+  Then mounted xterm 数は hidden terminal 数に比例して増え続けない
+```
+
+---
+
+## Rule R2: 再アクティブ化した terminal は直近スクロールバック・サイズ・カーソル状態を含めて復元される
+
+```gherkin
+Scenario: tab を切り替えて戻ると表示内容が復元される
+  Given active な terminal にスクロールバックが蓄積されている
+  When 別の tab に切り替え、その後元の tab に戻る
+  Then その terminal の xterm が再 mount される
+  And 直近スクロールバック・サイズ・カーソル状態が Rust の lightweight state から復元される
+  And 復元結果は切り替え前と同等の UX で表示される
+
+Scenario: 復元範囲は output buffer cap 相当の直近スクロールバックまで
+  Given terminal の出力が output buffer cap を超えて蓄積されている
+  When その terminal を unmount し再 mount する
+  Then 復元されるスクロールバックは output buffer cap 相当の直近分までである
+  And cap を超えた古い出力は復元対象に含まれない
+```
+
+仮定: フルスクロールバックの保持・復元は要求しない（A7）。
+
+---
+
+## Rule R3: terminal pane state は LRU / per-worktree cap / idle timeout で eviction される
+
+```gherkin
+Scenario: cap 到達時に最も古い idle terminal を LRU で eviction して新規を許可する
+  Given ある worktree の terminal pane state が per-worktree cap に達している
+  And cap 内に idle な terminal が少なくとも 1 つ存在する
+  When 新しい terminal pane state を追加しようとする
+  Then 最も古い idle terminal が LRU で自動 eviction される
+  And 新しい terminal pane state の追加が許可される
+
+Scenario: active terminal は eviction 対象から除外される
+  Given per-worktree cap に達しており、active terminal が含まれている
+  When cap 超過により eviction が発生する
+  Then active terminal は eviction されない
+  And eviction 対象は idle terminal の中から選ばれる
+
+Scenario: idle timeout を超えた pane state が eviction される
+  Given ある terminal pane state が idle timeout を超えて操作されていない
+  When idle 判定が行われる
+  Then その pane state は eviction 対象になり解放される
+```
+
+仮定: per-worktree cap 初期値は現行 MAX_PANES_PER_TAB×MAX_TABS 相当（A2/A5）。ポリシー値は design.md で定める。
+
+---
+
+## Rule R4: PTY は max panes（全体）・per-worktree cap・output buffer cap を Rust 側で enforce する
+
+```gherkin
+Scenario: per-worktree cap に達した状態で新規 PTY を要求する
+  Given ある worktree の alive PTY 数が per-worktree cap に達している
+  When その worktree で新しい terminal を開こうとする
+  Then Rust 側のポリシーに従って eviction または上限制御が行われる
+  And alive PTY 数が cap を超えて無制限に増えない
+
+Scenario: 全体 max panes に達した状態で新規 PTY を要求する
+  Given 全 worktree 合計の alive PTY 数が max panes に達している
+  When 新しい terminal を開こうとする
+  Then Rust 側のポリシーに従って上限制御が行われる
+  And alive PTY 数が max panes を超えない
+
+Scenario: output buffer は cap を超えて蓄積しない
+  Given ある PTY が継続的に出力している
+  When 出力量が output buffer cap を超える
+  Then 古い出力が破棄され、buffer は cap を超えて増えない
+```
+
+仮定: output buffer cap 初期値は 64KB（A2）。
+
+---
+
+## Rule R5: alive PTY に idle timeout を導入し、idle 超過 PTY を解放できる
+
+```gherkin
+Scenario: idle timeout を超えた alive PTY が解放される
+  Given alive な PTY が idle timeout を超えて入出力されていない
+  When idle 判定が行われる
+  Then その PTY は解放対象になる
+  And 関連する terminal リソースが解放される
+
+Scenario: idle timeout 内の PTY は解放されない
+  Given alive な PTY が idle timeout 内に入出力されている
+  When idle 判定が行われる
+  Then その PTY は解放されない
+```
+
+仮定: alive PTY idle timeout 初期値は 5 分（A2）。
+
+---
+
+## Rule R6: PTY output buffer の正本 owner は一意であり、二重保持が解消されている
+
+```gherkin
+Scenario: output buffer の owner は Rust runtime 側に一本化される
+  Given ある PTY が出力を生成している
+  When その出力のスクロールバックを参照する
+  Then output buffer の正本は Rust runtime 側に 1 つだけ存在する
+  And WS bridge は独立した output buffer を保持しない
+
+Scenario: スクロールバック取得は正本 owner から行われる
+  Given inactive terminal の復元または remote subscriber への供給が必要である
+  When スクロールバックを取得する
+  Then 正本 owner（Rust runtime buffer）から取得される
+```
+
+仮定: 正本 owner は Rust runtime 側に一本化（A3）。
+
+---
+
+## Rule R7: remote subscriber 不在時は remote 用 buffer 蓄積・broadcast を最小化する
+
+```gherkin
+Scenario: subscriber 不在時は remote 用 buffer 蓄積と broadcast を最小化する
+  Given WS remote subscriber が 1 つも接続していない
+  When PTY が出力を生成する
+  Then remote 用の buffer 蓄積と broadcast は最小化される
+
+Scenario: subscriber 接続時に必要なスクロールバックが供給される
+  Given subscriber が不在の状態で PTY が出力していた
+  When remote subscriber が新たに接続する
+  Then 接続時に必要なスクロールバックが正本 owner から供給される
+```
+
+---
+
+## Rule R8: cap / eviction / idle timeout 導入によって active terminal の UX が劣化しない
+
+```gherkin
+Scenario: cap・eviction・idle timeout 導入後も active terminal の入出力が劣化しない
+  Given cap・eviction・idle timeout が有効である
+  And ユーザーが active terminal を操作している
+  When inactive terminal の eviction や idle 解放がバックグラウンドで発生する
+  Then active terminal の入出力・履歴・サイズ追随が劣化しない
+  And active terminal は eviction や idle 解放の影響を受けない
+
+Scenario: active terminal はサイズ変更に追随する
+  Given active terminal が表示されている
+  When terminal を表示する領域のサイズが変わる
+  Then active terminal は新しいサイズに追随する
+```
+
+---
+
+## 仮定（requirements.md より引き継ぎ）
+
+- A2: cap / idle timeout の具体値は design.md でチューニング可能なパラメータとする。初期値は per-worktree cap = 現行 MAX_PANES_PER_TAB×MAX_TABS 相当、alive PTY idle timeout = 5 分、output buffer cap = 64KB。
+- A3: PTY output buffer の正本 owner は Rust runtime 側に一本化し、WS bridge は独立バッファを廃止する。
+- A4: lightweight state は Rust が保持する PTY output buffer ＋ pane のサイズ/メタ情報を基本とする。
+- A5: 既存上限定数（MAX_TABS=8 / MAX_PANES_PER_TAB=4）は維持しつつ、cap enforcement の正本を Rust 側へ移す。
+- A6: cap 到達時は LRU で最も古い idle terminal を自動 eviction し、active terminal は対象外とする。
+- A7: 再 mount 時の復元範囲は output buffer cap 相当の直近スクロールバックまで。フルスクロールバックの保持・復元は要求しない。
+
+## Open Questions
+
+なし（requirements.md ですべて解消済み。本振る舞い定義でも追加の未確定事項なし）。

--- a/docs/specs/issues-1215/design.md
+++ b/docs/specs/issues-1215/design.md
@@ -1,0 +1,281 @@
+# Design
+
+Terminal / PTY ライフサイクルに cap・eviction・idle timeout を導入し、メモリ常駐量とピークを境界づけるための実装設計。requirements.md / behavior.md の R1〜R8・AC1〜AC6 を満たす。
+
+cap 値・idle 時間などの具体値は requirements.md の A2/A5/A6/A7 に従う暫定値とし、本設計では Rust 側のチューニング可能なパラメータ（`PtyLifecycleConfig`）として扱う。
+
+---
+
+## 概要
+
+現状の課題（requirements.md 背景）に対し、以下の方針で対応する。
+
+- **境界づけの正本を Rust 側に置く**（`.claude/rules/rust-first-logic.md` 準拠）。cap / LRU eviction / idle timeout の判定・enforcement はすべて `domain` / `usecase` 層で行い、frontend は Rust が公開する状態・イベントを表示・反映するだけにする。
+- **frontend は inactive xterm を DOM から unmount する**。PTY 本体は Rust 側に session_key で生存し続けるため、再アクティブ化時は既存の `get_or_spawn_pty` 経路で `buffered_output`（直近スクロールバック）を取得して xterm へ書き戻して復元する。
+- **PTY output buffer の正本を Rust runtime 側に一本化**する（A3）。`ws_bridge.rs` の独立バッファ（`pty_output_buffers`）を廃止し、remote subscriber には接続時に runtime buffer からスクロールバックを供給する。
+
+新しいユーザー向け機能は追加しない。既存の PTY 生成・復帰・GC 経路（`get_or_spawn_pty` / `gc_ptys_for_worktree` / `kill_pty`）に lifecycle policy を組み込む。
+
+---
+
+## 変更対象
+
+### Backend (src-tauri/src)
+
+| パス | 変更概要 |
+| --- | --- |
+| `domain/pty_session/entities/pty_session_registry.rs` | activity 追跡・pinned 集合・active pin token・cap 判定・LRU/idle eviction 対象選定を追加 |
+| `domain/pty_session/value_objects/`（新規 `pty_lifecycle_config.rs`） | `PtyLifecycleConfig`（cap・idle timeout・buffer cap）を定義 |
+| `usecase/pty_session/spawn_usecase.rs` | spawn 前の cap enforcement（LRU eviction or 上限制御）を追加 |
+| `usecase/pty_session/lifecycle_usecase.rs` | `sweep_idle`（idle timeout eviction）・`record_activity`・active terminal 登録/解除を追加 |
+| `adaptor/gateway/pty_session/backend_impl.rs` | output 読み取り時の activity 記録、idle sweeper タスク起動、eviction 時のイベント emit、`buffered_output` を remote へ供給する経路 |
+| `adaptor/controller/command/pty_session/commands.rs` | `register_active_terminal` / `unregister_active_terminal` コマンド追加。`get_or_spawn_pty` に active/pinned 情報を渡す |
+| `ws_bridge.rs` | `pty_output_buffers` / `PTY_OUTPUT_BUFFER_SIZE` / `remove_pty_output_buffer` を削除。subscriber 不在時 broadcast を抑止 |
+| `ws_server/session.rs` | subscriber 接続時に alive PTY の `buffered_output` を runtime から取得して replay する |
+| `adaptor/protocol/pty.rs`・`protocol/mod.rs` | eviction 通知用 `PtyEvictedMsg` / `pty-evicted` を追加 |
+
+### Frontend (src)
+
+| パス | 変更概要 |
+| --- | --- |
+| `components/panels/TerminalTabPanel.tsx` | `forceMount` + `data-[state=inactive]:hidden` をやめ、active tab のみ条件マウントにする |
+| `components/panels/PaneLeafContainer.tsx` | active pane の xterm のみマウント、inactive pane は軽量プレースホルダ |
+| `hooks/useTerminal.ts` | remount 時に `get_or_spawn_pty` → `buffered_output` を write して復元。active pin token の登録/解除と `pty-evicted` リスナ追加 |
+| `hooks/useTerminalPanes.ts` | `pty-evicted` を受けて該当 pane を `tabStateCache` から除去。active tab/pane に応じた mount 状態を `useTerminal` へ反映 |
+
+---
+
+## アーキテクチャと責務分割
+
+レイヤ責務は既存のクリーンアーキテクチャ構成を踏襲する。
+
+```
+frontend (表示/入力/invoke)
+   │  invoke: get_or_spawn_pty / write_pty / resize_pty / register_active_terminal / unregister_active_terminal / kill_pty / gc_ptys_for_worktree
+   │  listen: pty-output / pty-exit / pty-evicted
+   ▼
+adaptor/controller/command  …… Tauri コマンド境界。DTO 変換のみ
+   ▼
+usecase/pty_session         …… spawn 時 cap enforcement・idle sweep・activity 記録のオーケストレーション
+   ▼
+domain/pty_session          …… registry の cap/LRU/idle 判定（純粋ロジック・clock 注入で決定論的）
+   ▲
+adaptor/gateway (backend_impl) …… 実 PTY 操作・output 読み取り・event emit・sweeper タスク・clock 供給
+```
+
+### 責務の置き場所（重要判断）
+
+- **「どの PTY を evict するか」の判定は domain（registry）に置く。** cap 超過判定・LRU 対象選定・idle 超過判定は `PtySessionRegistry` の純粋メソッドにし、時刻は引数（`now_ms`）で受け取る。これにより requirements の「ポリシーは Rust 側で enforce」を満たしつつ、PTY 実体なしで単体テスト可能にする。
+- **「いつ判定を回すか」「実際に kill する」は usecase/gateway に置く。** idle sweeper の周期実行とイベント emit は副作用なので gateway 側。
+- **frontend の `tabStateCache` はレイアウト UI 状態（tab/pane 構成・名前・sessionKey）のみを保持する。** これは表示状態であり rust-first-logic の例外には当たらない。pane の生存可否（cap/idle eviction）は Rust が決定し、frontend は `pty-evicted` を受けてキャッシュから当該 pane を除去するだけ（Rust が enforcement の正本、frontend は mirror）。
+
+### frontend remount と「lightweight state」（R1/R2）
+
+- inactive な tab/pane は xterm を **unmount** する（DOM から除去）。PTY は Rust に session_key で生存。
+- 再アクティブ化時、`useTerminal` は保持していた `sessionKey` で `get_or_spawn_pty` を呼ぶ。既存 PTY がヒットすれば `is_new=false` で `buffered_output`（runtime の 64KB ring 由来）が返るので、それを `terminal.write` して直近スクロールバックを復元する。
+- **カーソル状態**は output buffer 内の生バイト（ANSI 制御列含む）の replay により再現される（buffered_output を write すれば xterm が解釈してカーソル位置も再現）。
+- **サイズ**は remount 後の fit / `resize_pty` で active 領域に追随させる（R8 後段）。
+- 復元範囲は output buffer cap（既定 64KB ring）相当の直近分まで（A7）。フルスクロールバックは保持しない。
+
+---
+
+## データモデルまたは型
+
+### PtyLifecycleConfig（新規 value object）
+
+```rust
+pub struct PtyLifecycleConfig {
+    /// worktree ごとの alive PTY 上限。初期値 32 (= MAX_PANES_PER_TAB 4 × MAX_TABS 8, A2/A5)。
+    pub per_worktree_cap: usize,
+    /// 全 worktree 合計の alive PTY 上限。初期値 64（暫定, A2 に明示なし→仮定）。
+    pub max_panes_total: usize,
+    /// alive PTY の idle timeout。初期値 300 秒 (= 既存 delayed cleanup の 5 分, A2)。
+    pub idle_timeout: Duration,
+    /// output buffer cap（runtime ring）。初期値 64KB (= OUTPUT_BUFFER_CAPACITY, A2)。
+    pub output_buffer_cap: usize,
+    /// idle sweeper の実行周期。初期値 60 秒（暫定）。
+    pub sweep_interval: Duration,
+}
+```
+
+`output_buffer_cap` は既存 `OUTPUT_BUFFER_CAPACITY`（`backend_impl` services.rs）と統合し、定数の重複を解消する。
+
+### PtySessionRegistry（拡張）
+
+既存:
+
+```rust
+pub struct PtySessionRegistry {
+    sessions: HashMap<u64, PtySession>,
+    next_pty_id: u64,
+}
+```
+
+追加するフィールドとメソッド（`PtySession` 自体は `PartialEq/Eq` を維持するため activity は registry 側で持つ）:
+
+```rust
+    // pty_id -> 最終アクティビティ（論理 ms。clock は呼び出し側が注入）
+    activity: HashMap<u64, u64>,
+    // eviction 対象から除外する session_key 集合
+    pinned: HashSet<String>,
+    // mounted useTerminal instance ごとの active pin token
+    active_pin_tokens: HashMap<String, ActivePin>,
+    // unregister が先着した token の stale register を拒否する tombstone
+    retired_active_tokens: HashSet<String>,
+    config: PtyLifecycleConfig,
+```
+
+| メソッド | 用途 |
+| --- | --- |
+| `record_activity(pty_id, now_ms)` | 入出力/resize 時刻の更新 |
+| `register_active_terminal(worktree, session_key, token)` / `unregister_active_terminal(worktree, session_key, token)` | useTerminal instance 単位で active/可視端末を pin/unpin（R3/R8 の active 除外）。古い unregister は別 token の新しい mount を解除できない |
+| `count_for_worktree(worktree) -> usize` / `count_total() -> usize` | cap 判定 |
+| `select_evictable_for_worktree(worktree, now_ms) -> Option<u64>` | cap 超過時の LRU eviction 対象（pinned 除外・idle 優先・最も古い activity を選ぶ） |
+| `select_idle_timed_out(now_ms) -> Vec<u64>` | idle timeout 超過 PTY（pinned 除外） |
+| `would_exceed_worktree_cap(worktree)` / `would_exceed_total_cap()` | 新規許可可否 |
+
+「idle」の定義: `now_ms - activity[pty_id] >= idle_timeout`。入力（`write_pty`）・出力（reader）・`resize_pty` のいずれかで activity を更新する。pinned（可視 active）な PTY は idle 判定・LRU eviction の双方から除外する。
+
+### eviction 通知メッセージ（新規）
+
+```rust
+pub struct PtyEvictedMsg {
+    pub pty_id: u64,
+    pub session_key: String,
+    pub reason: PtyEvictReason, // Idle | CapExceeded
+}
+```
+
+`pty-exit`（プロセス終了 = pane を残し `[Process exited]` 表示）と、`pty-evicted`（lifecycle による解放 = pane 自体を除去）を区別する。frontend は両者で異なる UI 反応をするため、別イベントにする。
+
+---
+
+## 処理フロー
+
+### F1. spawn 時の cap enforcement（R3/R4, AC4）
+
+`usecase::spawn_usecase::get_or_spawn`:
+
+1. `session_key` 指定があり既存 PTY がヒット → 従来通り `buffered_output` を返す（`is_new=false`）。activity を更新。
+2. 新規 spawn 要求のとき、registry の `reserve_spawn_slot` で cap 判定・eviction target・spawn slot を単一境界で予約する。対象なし（全て pinned/非 idle）なら上限制御（spawn 拒否し `UsecaseError::CapReached` を返す）。
+3. runtime 作成・registry 挿入・reader 起動がすべて成功した後に、予約済み eviction target を kill（→ `pty-evicted` emit）して spawn slot を commit する。`spawn_backend` / reader 起動 / eviction revalidate が失敗した場合は予約を rollback し、作成済み新規 PTY は kill/remove して half-created session を残さない。
+4. spawn 後、新 PTY の activity を記録し、pinned 集合に追加（直後は可視のため）。
+
+frontend の `MAX_TABS` / `MAX_PANES_PER_TAB` は UI 上のガードとして残す（A5）が、最終的な cap enforcement は上記 Rust 経路が正本。
+
+### F2. idle sweep（R5, AC4）
+
+`backend_impl` 起動時に tokio タスクを 1 本起動:
+
+```
+loop {
+    sleep(config.sweep_interval)
+    let now_ms = clock.now_ms()
+    let targets = usecase::lifecycle_usecase::sweep_idle(gateway, now_ms) // = registry.select_idle_timed_out
+    for pty_id in targets { kill + emit pty-evicted(reason=Idle) }
+}
+```
+
+pinned（可視 active）は除外されるため、表示中の端末は idle でも解放されない（R8）。
+
+### F3. activity 記録
+
+- 入力: `write_pty` コマンド処理時に `record_activity`。
+- 出力: `spawn_output_reader` の読み取りループで chunk 受信時に `record_activity`。高頻度出力でのロック競合を避けるため、activity 更新は **最短 1 秒に 1 回へスロットル**する（前回更新からの差分が閾値未満ならスキップ）。
+- resize: `resize_pty` 時に `record_activity`。
+
+### F4. active/pinned の同期（R3/R8）
+
+frontend は `useTerminal` mount ごとに一意な active token を作り、PTY 確定時に `register_active_terminal(worktree_path, session_key, active_token)`、unmount / eviction / pending spawn 後の cleanup 時に `unregister_active_terminal(...)` を送る。Rust は token 単位で active pin を保持し、同じ session_key でも古い token の unregister が新しい mount の token を解除できないようにする。unregister が register より先着した token は retired として記録し、後着した stale register を拒否する。
+
+### F5. PTY output buffer 一本化（R6, AC3）
+
+- 正本: `PtyRuntime.output_buffer`（`VecDeque<u8>`, cap = `output_buffer_cap`）。
+- `ws_bridge.rs` の `pty_output_buffers` / `PTY_OUTPUT_BUFFER_SIZE` / `remove_pty_output_buffer` を削除。`WsBroadcaster::try_send` はバッファリングせず送信のみ行う。
+- スクロールバック取得は常に `gateway.buffered_output(pty_id)`（runtime ring）から行う。inactive 復元（F の get_or_spawn 経路）も remote 供給（F6）も同一ソース。
+
+### F6. remote subscriber 供給と最小化（R7, AC5）
+
+- **broadcast 抑止**: `spawn_output_reader` は出力を `app.emit("pty-output", ...)`（desktop 用、常時）し、WS 側は **subscriber が存在するときのみ** `ws.try_send` を呼ぶ。`WsBroadcaster` に `has_subscriber()`（`sender.is_some()`）を設け、不在時はバイト列の整形・送信自体をスキップする。runtime ring は subscriber 有無に関わらず維持されるため、buffer 蓄積は subscriber 有無で増えない（むしろ独立バッファ廃止でメモリ減）。
+- **接続時 replay**: `ws_server::session::handle_ws_authenticated` で subscriber 確立後、alive な terminal PTY を registry から列挙し、各 `gateway.buffered_output(pty_id)` を `PtyOutput` として初期 replay 送信する。これで subscriber は必要なスクロールバックを正本から受け取る。
+
+### F7. frontend remount / 復元（R1/R2, AC1/AC2）
+
+- `TerminalTabPanel`: active tab の `TabsContent` のみ子（端末）をマウント。inactive tab は子を描画しない。
+- `PaneLeafContainer`: active pane のみ `TerminalPanel` をマウント。inactive pane はプレースホルダ（クリックでアクティブ化）。
+- アクティブ化 → `useTerminal` が `get_or_spawn_pty(sessionKey=...)` → `buffered_output` を `terminal.write` → 直近スクロールバック・カーソルを復元 → fit/`resize_pty` でサイズ追随。
+
+---
+
+## エラー処理
+
+- **cap 到達かつ evict 対象なし**: `get_or_spawn` は `UsecaseError::CapReached` を返す。コマンド層は `Result<_, String>` でメッセージ化し、frontend は「上限に達したため新規端末を開けない」旨を表示（新規 pane を作らずロールバック）。
+- **eviction 対象が既に exited/不在**: kill はべき等に扱い、不在なら no-op（既存 `kill` 同様）。
+- **`pty-evicted` 受信時に該当 pane が既にない**: frontend はキャッシュ除去を no-op とする。
+- **buffered_output の UTF-8 境界**: 既存 `process_pty_output` の pending buffer（`MAX_PENDING_BYTES`）で部分 UTF-8 を保持する仕組みを維持し、ring 取り出し時は `from_utf8_lossy` で安全化（既存踏襲）。
+- **ロック poisoning**: 既存パターン `lock().unwrap_or_else(|e| e.into_inner())` を踏襲。
+- **idle 解放と再アクセスの競合**: evict 後に同 session_key で `get_or_spawn` が来た場合は `is_new=true`（buffered_output 空）で新規生成され、frontend は新しいプロンプトを表示する（仕様上許容、A6）。
+
+---
+
+## テスト方針
+
+### Rust（domain / usecase）
+
+- `PtySessionRegistry`（純粋・clock 注入で決定論的）:
+  - per-worktree cap / total cap の境界判定（cap-1, cap, cap+1）。
+  - `select_evictable_for_worktree`: pinned 除外・idle 優先・最古 activity 選択・全 pinned 時は `None`。
+  - `select_idle_timed_out`: idle timeout 直前/直後・pinned 除外。
+  - active terminal（pinned）が eviction されないこと（R3/R8）。
+- `spawn_usecase::get_or_spawn`（mock gateway）:
+  - cap 未達 → 通常 spawn。
+  - cap 到達かつ idle 有り → 1 件 evict して spawn 許可。
+  - cap 到達かつ evict 対象なし → `CapReached`。
+  - 既存 session_key ヒット → buffered_output 返却・activity 更新。
+- `lifecycle_usecase::sweep_idle`: idle 超過のみ対象、pinned 非対象。
+- output buffer 一本化: `buffered_output` が runtime ring から取得されること。ws_bridge に独立 buffer が存在しないこと（型・フィールド削除の回帰）。
+
+### Rust（ws / gateway）
+
+- subscriber 接続時に alive PTY の buffered_output が replay されること（R7）。
+- `has_subscriber()` false 時に `try_send` が整形・送信をスキップすること（R7）。
+
+### Frontend（Vitest, Tauri invoke は `vi.mock`）
+
+- `useTerminal`: remount 時に `get_or_spawn_pty` の `buffered_output` を `terminal.write` で復元すること（R2）。`pty-evicted` リスナの登録。
+- `useTerminalPanes`: `pty-evicted` 受信で該当 pane が `tabStateCache` から除去されること。active pane/tab の terminal mount に応じて `useTerminal` が active token を登録/解除すること。
+- `TerminalTabPanel` / `PaneLeafContainer`: inactive tab/pane の xterm が DOM にマウントされないこと（R1, AC1）。active のみマウント。
+- `react-resizable-panels` / `@tauri-apps/api` / Monaco は既存方針通り mock。
+
+### 非テスト（CLAUDE.md 方針）
+
+- 実 `git push` / 外部プロセス起動・実 PTY spawn の E2E は単体テスト対象外。idle sweeper の実時間待機はテストせず、判定ロジック（registry/usecase）を時刻注入でテストする。
+
+---
+
+## リスクと代替案
+
+- **R-1: inactive xterm の unmount による再レイアウト/ちらつき。** 復元は 64KB replay で高速だが、巨大出力直後は描画コストが出得る。代替案: #858 の `display:none` 保持方式（DOM 残置）。本 Issue は R1（unmount 必須）に従い unmount を採用、#858 は非スコープ。
+- **R-2: idle eviction による hidden 端末のプロセス kill。** 5 分 idle の hidden 端末はプロセスごと解放され、64KB を超える履歴は失われる。requirements A6/A7・R5 で明示的に許容済み。可視端末は pinned で保護。
+- **R-3: 継続出力する hidden 端末は idle にならず evict されない。** cap 到達時に全 PTY が非 idle/pinned だと新規 spawn が `CapReached` になる。behavior R4 の「eviction または上限制御」に合致（上限制御を選ぶ）。`log()` 相当で UI に上限到達を明示する。
+- **R-4: pinned 集合の同期漏れ。** frontend が active token の unregister/register を送り損ねると可視端末が evict され得る。緩和: `get_or_spawn` 直後に provisional pin、mount instance ごとの token 登録/解除、stale register を retired token で拒否、idle_timeout を十分長く（5 分）保つ。
+- **R-5: activity 記録のロック競合。** 高頻度出力で registry ロックが競合し得る。緩和: activity 更新を 1 秒スロットルし、ring 書き込み（runtime 内ロック）とは別経路にする。
+- **R-6: output buffer 一本化に伴う remote 回帰。** ws 独立バッファ削除で既存 remote 経路が壊れる懸念。緩和: F6 の replay と `has_subscriber()` ガードを ws テストで担保。
+
+---
+
+## 仮定
+
+- A2/A5/A6/A7: requirements.md を引き継ぐ。初期値 — per-worktree cap = 32（4×8）、idle timeout = 300 秒、output buffer cap = 64KB、復元範囲 = 64KB ring 相当。
+- A3: output buffer 正本は `PtyRuntime.output_buffer` に一本化し、`ws_bridge` 独立バッファを廃止する。
+- A4: lightweight state = runtime output ring（直近スクロールバック）＋ pane サイズ/メタ。frontend は復元時に invoke 取得し xterm へ write。
+- **D1（本設計の決定）**: lifecycle eviction の通知は `pty-exit`（プロセス終了）と別の `pty-evicted` イベントで行う。pane の扱い（残す/除去する）が異なるため。
+- **D2（本設計の決定）**: active/可視端末の保護は frontend → Rust の `register_active_terminal` / `unregister_active_terminal`（active pin token）で行う。
+- **D3（仮定・要確認の余地）**: 全体 max panes 初期値 = 64。A2 に明示がないため暫定値。`PtyLifecycleConfig` で変更可能。
+- **D4（本設計の決定）**: idle の定義は「入力・出力・resize のいずれも idle_timeout の間なし」。activity 更新は 1 秒スロットル。
+
+---
+
+## Open Questions
+
+なし（requirements.md / behavior.md ですべて解消済み。本設計で残る判断は D1〜D4 として仮定・決定で明示し、いずれもチューニング可能パラメータまたは内部設計に閉じるため、実装着手前のレビューで確認すれば足りる）。

--- a/docs/specs/issues-1215/requirements.md
+++ b/docs/specs/issues-1215/requirements.md
@@ -1,0 +1,97 @@
+# Requirements
+
+## Type
+
+性能・メモリ効率改善。マイルストーン「性能・メモリ効率改善（Workbench State / Read Model）」の M3「Runtime lifecycle を締める」の一部として、Terminal / PTY のライフサイクルに cap・eviction・idle timeout を導入する。
+
+関連: #1215 / #1196（CLOSED, workflow runtime 解放）/ #858（ワークスペース切替のコンポーネント保持方式）/ `docs/releash-performance-architecture-audit.md` M3（正本ドキュメント）
+
+## 背景と目的
+
+`docs/releash-performance-architecture-audit.md` の M3 で指摘された runtime lifecycle 課題のうち、Terminal / PTY 領域を対象とする。現状の調査で以下の無制限増大・二重保持が確認されている。
+
+- **frontend xterm の常時マウント**: `TerminalTabPanel.tsx`（L298）が inactive tab を `forceMount` し、`data-[state=inactive]:hidden` で隠すのみ。inactive な分割ペイン（`PaneLeafContainer.tsx` L186）も含め、xterm インスタンスが DOM 上に残り続ける。MAX_TABS=8 × MAX_PANES_PER_TAB=4（`useTerminalPanes.ts` L17-18）の上限まで mounted xterm が積み上がる。
+- **frontend cache の eviction 不在**: `useTerminal.ts` の `sessionKeyCache`（L31, `Map<cwd, sessionKey>`）に eviction 機構がなく、`tabStateCache`（`useTerminalPanes.ts` L45）にも明示的廃棄がない。
+- **PTY output buffer の二重保持**: Rust runtime 側（`backend_impl.rs` の `PtyRuntime.output_buffer`、`OUTPUT_BUFFER_CAPACITY = 64KB` リングバッファ）と WS bridge 側（`ws_bridge.rs` の `pty_output_buffers`、`PTY_OUTPUT_BUFFER_SIZE = 64KB` リングバッファ）が PTY ごとに独立して同一出力を保持している（合計 ~128KB/PTY）。
+- **PTY registry の cap 不在**: `PtySessionRegistry`（`pty_session_registry.rs`）は `HashMap<u64, PtySession>` で、max panes / per-worktree cap を持たない。GC は `gc_ptys_for_worktree`（keep_session_keys ベースの手動呼び出し）のみで、自動 eviction がない。
+- **idle timeout の不在**: alive な PTY への idle timeout はなく、プロセス終了後 5 分の delayed cleanup（`backend_impl.rs` L118-128）のみ存在する。
+- **remote subscriber 不在時の buffer 継続**: WS bridge の per-PTY buffer は subscriber がいなくても 64KB まで蓄積し続け、`remove_pty_output_buffer` の明示呼び出しでのみ解放される。
+
+本変更の目的は、Terminal / PTY のメモリ常駐量とピークを境界づけ、active terminal の UX を壊さずに inactive terminal を軽量状態へ退避・復元できるようにすること。
+
+## スコープ
+
+ロジックは Rust に集約し、frontend は表示・入力受付・invoke 呼び出しに徹する（`.claude/rules/rust-first-logic.md` 準拠）。cap / eviction / idle timeout の enforcement は Rust 側で行い、frontend は Rust が公開する状態を表示・復元する。
+
+### 1. frontend xterm の remount（mounted 数の境界づけ）
+
+- active tab / active pane 以外の xterm は DOM から unmount し、必要時（再アクティブ化時）に remount する。
+- mounted xterm 数が hidden terminal 数に比例して増え続けないことを保証する。
+- unmount された terminal は、再表示時に Rust が保持する lightweight state（後述）から見た目とスクロールバックを復元する。
+
+### 2. terminal pane state の lifecycle policy
+
+- terminal pane state に LRU / per-worktree cap / idle timeout を導入する。
+- inactive pane state を軽量表現へ退避し、cap 超過・idle 超過したものを eviction する。
+- lifecycle policy（cap 値・idle 時間・LRU の単位）は Rust 側で enforce する。
+
+### 3. PTY lifecycle の Rust 側 enforcement
+
+- max panes（全体）、per-worktree cap、output buffer cap を Rust 側で enforce する。
+- alive PTY に対する idle timeout を導入し、idle 超過 PTY を解放対象にする。
+- PTY output buffer の owner を一意に定め、Rust runtime と WS bridge の二重保持を解消する。
+
+### 4. remote buffer / broadcast の最小化
+
+- WS remote subscriber がいないときは、remote 用の PTY output buffer 蓄積 / broadcast を最小化する。
+- subscriber 接続時に必要なスクロールバックを供給できる前提を維持する。
+
+## 非スコープ
+
+- workflow runtime / WorkflowExecution の解放（#1196 で対応済み、CLOSED）。
+- agent process（agent チャット bridge）の idle timeout / cap。M3 では言及されるが本 Issue は Terminal / PTY に限定する。
+- `cleanup_orphan_processes` を startup blocking path から外す対応（M3 項目 4。別 Issue）。
+- ワークスペース切替方式そのものの変更（#858）。本 Issue は terminal/PTY のライフサイクルに限定し、#858 の display:none 方式採用可否には踏み込まない。
+- terminal の機能追加（新シェル統合、新ペイン操作 UI 等）。
+- agent チャット streaming / session storage の計測・最適化（#1209 / #1213 / #1195 の領域）。
+
+## 要求事項
+
+R1. inactive な terminal tab / pane の xterm は unmount され、mounted xterm 数が hidden terminal 数に比例して増え続けない。
+
+R2. unmount された terminal を再アクティブ化したとき、active terminal と同等の UX で（直近スクロールバック・サイズ・カーソル状態を含めて）復元できる。復元元は Rust が保持する lightweight state とする。
+
+R3. terminal pane state に LRU / per-worktree cap / idle timeout を導入し、cap・idle を超えた pane state を eviction する。cap 到達時は最も古い idle terminal を LRU で自動 eviction して新規を許可し、active terminal は eviction 対象から除外する。これらのポリシーは Rust 側で enforce する。
+
+R4. PTY に対して max panes（全体）、per-worktree cap、output buffer cap を Rust 側で enforce する。
+
+R5. alive PTY に idle timeout を導入し、idle 超過した PTY を解放できる。
+
+R6. PTY output buffer の正本 owner を一意に定め、Rust runtime と WS bridge の二重保持を解消する。buffer の所在と責務がコード上明確である。
+
+R7. WS remote subscriber がいないとき、remote 用 buffer 蓄積 / broadcast を最小化する。subscriber 接続時には必要なスクロールバックを供給できる。
+
+R8. active terminal の入出力・操作 UX を壊さない（cap / eviction / idle timeout 導入によって active terminal の応答性・履歴が劣化しない）。
+
+## 受け入れ基準の概要
+
+- AC1: hidden terminal を増やしても mounted xterm 数が比例して増え続けない（R1）。
+- AC2: tab / pane を切り替えて戻ったとき、terminal の表示内容（直近出力・サイズ）が失われず復元される（R2, R8）。
+- AC3: PTY output buffer の owner が単一で、Rust runtime と WS bridge の二重保持が解消されている（R6）。
+- AC4: per-worktree cap / max panes / idle timeout に到達したとき、Rust 側のポリシーに従って PTY と pane state が解放される（R3, R4, R5）。
+- AC5: remote subscriber が不在のとき remote 用 buffer / broadcast が最小化され、subscriber 接続時には必要なスクロールバックが供給される（R7）。
+- AC6: active terminal の UX（入出力・履歴・サイズ追随）が劣化しない（R8）。
+
+## 仮定
+
+- A1. spec ディレクトリは `docs/specs/issues-1215` とする（直近 Issue の命名慣例 `issues-NNN` に従う）。
+- A2.（合意済み）cap / idle timeout の具体値は design.md でチューニング可能なパラメータとして定める。初期値は暫定とし、per-worktree cap = 現行 MAX_PANES_PER_TAB×MAX_TABS 相当、alive PTY idle timeout = 5 分（既存 delayed cleanup を参考）、output buffer cap = 64KB を採用する。
+- A3.（合意済み）PTY output buffer の正本 owner は Rust runtime 側（`PtyRuntime.output_buffer`）に一本化する。WS bridge は独立バッファ（`pty_output_buffers`）を廃止し、subscriber 接続時に runtime buffer から取得・転送する。
+- A4. lightweight state（再 mount 時の復元元）は Rust が保持する PTY output buffer（リングバッファ）＋ pane のサイズ/メタ情報を基本とし、frontend は復元時にこれを invoke で取得して xterm に書き戻す。
+- A5. 既存上限定数（frontend の MAX_TABS=8 / MAX_PANES_PER_TAB=4）は維持しつつ、cap enforcement の正本を Rust 側へ移す。
+- A6.（合意済み）cap 到達時は LRU で最も古い idle terminal を自動 eviction（解放/kill）して新規を許可する。active terminal は eviction 対象から除外する。
+- A7.（合意済み）inactive terminal の再 mount 時の復元範囲は、output buffer cap（64KB ring）相当の直近スクロールバックまでとする。フルスクロールバックの保持・復元は要求しない。
+
+## Open Questions
+
+なし（すべて解消済み）。

--- a/src-tauri/src/adaptor/controller/command/pty_session/commands.rs
+++ b/src-tauri/src/adaptor/controller/command/pty_session/commands.rs
@@ -1,37 +1,35 @@
 use std::sync::Arc;
 
-use tauri::{AppHandle, Manager, State};
+use serde::Serialize;
+use tauri::{AppHandle, State};
 
 use crate::adaptor::gateway::pty_session::backend_impl::PtySessionRuntimeGateway;
 use crate::domain::pty_session::services::parse_pty_kind;
-use crate::usecase::pty_session::dto::{GetOrSpawnPtyResult, PtySessionInfo};
-use crate::ws_bridge::WsBroadcaster;
+use crate::usecase::pty_session::dto::{
+    GetOrSpawnPtyResult, GetPtyBufferedOutputResult, PtySessionInfo,
+};
+use crate::usecase::pty_session::error::UsecaseError;
 
-#[tauri::command]
-#[allow(clippy::too_many_arguments)]
-pub fn spawn_pty(
-    app: AppHandle,
-    state: State<'_, Arc<PtySessionRuntimeGateway>>,
-    rows: u16,
-    cols: u16,
-    cwd: Option<String>,
-    worktree_path: Option<String>,
-    label: Option<String>,
-    kind: Option<String>,
-) -> Result<u64, String> {
-    let pty_kind = parse_pty_kind(kind.as_deref());
-    let (pty_id, _session_key) = crate::usecase::pty_session::spawn_usecase::spawn(
-        state.inner().as_ref(),
-        &app,
-        rows,
-        cols,
-        cwd,
-        worktree_path,
-        label,
-        pty_kind,
-    )
-    .map_err(|e| e.to_string())?;
-    Ok(pty_id)
+const PTY_ERROR_CODE_CAP_REACHED: &str = "CAP_REACHED";
+const PTY_ERROR_CODE_GENERIC: &str = "PTY_ERROR";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PtyCommandError {
+    pub code: String,
+    pub message: String,
+}
+
+impl From<UsecaseError> for PtyCommandError {
+    fn from(error: UsecaseError) -> Self {
+        let code = match error {
+            UsecaseError::CapReached(_) => PTY_ERROR_CODE_CAP_REACHED,
+            UsecaseError::Gateway(_) => PTY_ERROR_CODE_GENERIC,
+        };
+        Self {
+            code: code.to_string(),
+            message: error.to_string(),
+        }
+    }
 }
 
 #[tauri::command]
@@ -61,17 +59,26 @@ pub fn list_pty_sessions(state: State<'_, Arc<PtySessionRuntimeGateway>>) -> Vec
 }
 
 #[tauri::command]
+pub fn get_pty_buffered_output(
+    state: State<'_, Arc<PtySessionRuntimeGateway>>,
+    session_key: String,
+    worktree_path: String,
+) -> Result<GetPtyBufferedOutputResult, PtyCommandError> {
+    crate::usecase::pty_session::query_service::get_buffered_output(
+        state.inner().as_ref(),
+        &session_key,
+        &worktree_path,
+    )
+    .map_err(PtyCommandError::from)
+}
+
+#[tauri::command]
 pub fn kill_pty(
-    app: AppHandle,
     state: State<'_, Arc<PtySessionRuntimeGateway>>,
     pty_id: u64,
 ) -> Result<(), String> {
     crate::usecase::pty_session::lifecycle_usecase::kill(state.inner().as_ref(), pty_id)
-        .map_err(|e| e.to_string())?;
-    if let Some(ws) = app.try_state::<Arc<WsBroadcaster>>() {
-        ws.remove_pty_output_buffer(pty_id);
-    }
-    Ok(())
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -86,7 +93,7 @@ pub fn get_or_spawn_pty(
     worktree_path: String,
     label: Option<String>,
     kind: Option<String>,
-) -> Result<GetOrSpawnPtyResult, String> {
+) -> Result<GetOrSpawnPtyResult, PtyCommandError> {
     let pty_kind = parse_pty_kind(kind.as_deref());
     crate::usecase::pty_session::spawn_usecase::get_or_spawn(
         state.inner().as_ref(),
@@ -99,43 +106,86 @@ pub fn get_or_spawn_pty(
         label,
         pty_kind,
     )
-    .map_err(|e| e.to_string())
+    .map_err(PtyCommandError::from)
 }
 
 #[tauri::command]
 pub fn kill_ptys_by_worktree(
-    app: AppHandle,
     state: State<'_, Arc<PtySessionRuntimeGateway>>,
     worktree_path: String,
 ) -> Result<(), String> {
-    let killed_ids = crate::usecase::pty_session::lifecycle_usecase::kill_by_worktree(
+    crate::usecase::pty_session::lifecycle_usecase::kill_by_worktree(
         state.inner().as_ref(),
         &worktree_path,
     );
-    if let Some(ws) = app.try_state::<Arc<WsBroadcaster>>() {
-        for pty_id in killed_ids {
-            ws.remove_pty_output_buffer(pty_id);
-        }
-    }
     Ok(())
 }
 
 #[tauri::command]
 pub fn gc_ptys_for_worktree(
-    app: AppHandle,
     state: State<'_, Arc<PtySessionRuntimeGateway>>,
     worktree_path: String,
     keep_session_keys: Vec<String>,
 ) -> Result<(), String> {
-    let killed_ids = crate::usecase::pty_session::lifecycle_usecase::gc_by_worktree(
+    crate::usecase::pty_session::lifecycle_usecase::gc_by_worktree(
         state.inner().as_ref(),
         &worktree_path,
         &keep_session_keys,
     );
-    if let Some(ws) = app.try_state::<Arc<WsBroadcaster>>() {
-        for pty_id in killed_ids {
-            ws.remove_pty_output_buffer(pty_id);
-        }
-    }
     Ok(())
+}
+
+#[tauri::command]
+pub fn register_active_terminal(
+    state: State<'_, Arc<PtySessionRuntimeGateway>>,
+    worktree_path: String,
+    session_key: String,
+    active_token: String,
+) -> Result<(), String> {
+    crate::usecase::pty_session::lifecycle_usecase::register_active_terminal(
+        state.inner().as_ref(),
+        &worktree_path,
+        &session_key,
+        &active_token,
+    );
+    Ok(())
+}
+
+#[tauri::command]
+pub fn unregister_active_terminal(
+    state: State<'_, Arc<PtySessionRuntimeGateway>>,
+    worktree_path: String,
+    session_key: String,
+    active_token: String,
+) -> Result<(), String> {
+    crate::usecase::pty_session::lifecycle_usecase::unregister_active_terminal(
+        state.inner().as_ref(),
+        &worktree_path,
+        &session_key,
+        &active_token,
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::pty_session::entities::PtySpawnReservationError;
+
+    #[test]
+    fn cap_reached_errors_map_to_stable_command_code() {
+        let worktree_error = UsecaseError::from(PtySpawnReservationError::WorktreeCapReached(
+            "/repo".to_string(),
+        ));
+        let total_error = UsecaseError::from(PtySpawnReservationError::TotalCapReached);
+
+        assert_eq!(
+            PtyCommandError::from(worktree_error).code,
+            PTY_ERROR_CODE_CAP_REACHED
+        );
+        assert_eq!(
+            PtyCommandError::from(total_error).code,
+            PTY_ERROR_CODE_CAP_REACHED
+        );
+    }
 }

--- a/src-tauri/src/adaptor/controller/command/pty_session/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/pty_session/mod.rs
@@ -1,14 +1,16 @@
 pub(crate) mod commands;
 
 const COMMAND_NAMES: &[&str] = &[
-    "spawn_pty",
     "write_pty",
     "resize_pty",
     "kill_pty",
     "list_pty_sessions",
+    "get_pty_buffered_output",
     "get_or_spawn_pty",
     "kill_ptys_by_worktree",
     "gc_ptys_for_worktree",
+    "register_active_terminal",
+    "unregister_active_terminal",
 ];
 
 pub(crate) fn register(router: &mut super::CommandRouter) {
@@ -18,13 +20,15 @@ pub(crate) fn register(router: &mut super::CommandRouter) {
 pub(crate) fn invoke_handler(
 ) -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Sync + 'static {
     tauri::generate_handler![
-        commands::spawn_pty,
         commands::write_pty,
         commands::resize_pty,
         commands::kill_pty,
         commands::list_pty_sessions,
+        commands::get_pty_buffered_output,
         commands::get_or_spawn_pty,
         commands::kill_ptys_by_worktree,
         commands::gc_ptys_for_worktree,
+        commands::register_active_terminal,
+        commands::unregister_active_terminal,
     ]
 }

--- a/src-tauri/src/adaptor/gateway/pty_session/backend_impl.rs
+++ b/src-tauri/src/adaptor/gateway/pty_session/backend_impl.rs
@@ -423,6 +423,12 @@ impl PtySessionGateway for PtySessionRuntimeGateway {
         self.registry.lock().pin_session_key(session_key);
     }
 
+    fn unpin_session_key_if_unused(&self, session_key: &str) {
+        self.registry
+            .lock()
+            .unpin_session_key_if_unused(session_key);
+    }
+
     fn register_active_terminal(&self, worktree_path: &str, session_key: &str, active_token: &str) {
         self.registry
             .lock()

--- a/src-tauri/src/adaptor/gateway/pty_session/backend_impl.rs
+++ b/src-tauri/src/adaptor/gateway/pty_session/backend_impl.rs
@@ -3,18 +3,23 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager};
 
-use crate::adaptor::protocol::pty::{PtyExitMsg, PtyOutputMsg};
-use crate::domain::pty_session::entities::{PtySession, PtySessionRegistry, PtySessionSnapshot};
-use crate::domain::pty_session::gateway::{PtyBackend, PtyResizer, SpawnConfig};
-use crate::domain::pty_session::services::{
-    append_output_to_ring_buffer, decode_utf8_chunk, OUTPUT_BUFFER_CAPACITY,
+use crate::adaptor::protocol::pty::{PtyEvictReasonMsg, PtyEvictedMsg, PtyExitMsg, PtyOutputMsg};
+use crate::domain::pty_session::entities::{
+    PtySession, PtySessionRegistry, PtySessionSnapshot, PtySpawnReservation,
+    PtySpawnReservationError,
 };
+use crate::domain::pty_session::gateway::{PtyBackend, PtyResizer, SpawnConfig};
+use crate::domain::pty_session::services::{append_output_to_ring_buffer, decode_utf8_chunk};
+use crate::domain::pty_session::{PtyEvictReason, PtyLifecycleConfig};
 use crate::protocol::WsMessage;
 use crate::usecase::pty_session::dto::FoundPtySession;
 use crate::usecase::pty_session::error::UsecaseError;
-use crate::usecase::pty_session::ports::{PtyBackendSpawnRequest, PtySessionGateway};
+use crate::usecase::pty_session::ports::{
+    PtyBackendSpawnRequest, PtySessionGateway, PtySessionReadGateway,
+};
 use crate::ws_bridge::WsBroadcaster;
 
 use super::direct::DirectPtyBackend;
@@ -23,9 +28,38 @@ pub(crate) struct PtyRuntime {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     killer: Arc<Mutex<Box<dyn portable_pty::ChildKiller + Send + Sync>>>,
     resizer: Arc<Mutex<Box<dyn PtyResizer + Send>>>,
-    output_buffer: Arc<Mutex<VecDeque<u8>>>,
+    output_buffer: Arc<Mutex<PtyOutputBuffer>>,
+    output_buffer_cap: usize,
     reader: Option<Box<dyn Read + Send>>,
     child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
+}
+
+struct PtyOutputBuffer {
+    bytes: VecDeque<u8>,
+    sequence: u64,
+}
+
+impl PtyOutputBuffer {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            bytes: VecDeque::with_capacity(capacity),
+            sequence: 0,
+        }
+    }
+
+    fn append(&mut self, output: &str, capacity: usize) -> u64 {
+        append_output_to_ring_buffer(&mut self.bytes, output, capacity);
+        self.sequence = self.sequence.saturating_add(1);
+        self.sequence
+    }
+
+    fn snapshot(&self) -> (String, u64) {
+        let (a, b) = self.bytes.as_slices();
+        let mut bytes = Vec::with_capacity(a.len() + b.len());
+        bytes.extend_from_slice(a);
+        bytes.extend_from_slice(b);
+        (String::from_utf8_lossy(&bytes).into_owned(), self.sequence)
+    }
 }
 
 pub struct PtySessionRuntimeGateway {
@@ -49,8 +83,9 @@ impl Default for PtySessionRuntimeGateway {
 fn process_pty_output(
     raw_chunk: &[u8],
     pending: &mut Vec<u8>,
-    output_buffer: &Mutex<VecDeque<u8>>,
-) -> Option<String> {
+    output_buffer: &Mutex<PtyOutputBuffer>,
+    output_buffer_cap: usize,
+) -> Option<(String, u64)> {
     let raw = decode_utf8_chunk(raw_chunk, pending)?;
     let result = crate::infrastructure::pty_session::shell_integration::strip_osc_cmd_done(&raw);
 
@@ -58,12 +93,19 @@ fn process_pty_output(
         return None;
     }
 
-    {
-        let mut ring = output_buffer.lock();
-        append_output_to_ring_buffer(&mut ring, &result.filtered_output, OUTPUT_BUFFER_CAPACITY);
-    }
+    let sequence = output_buffer
+        .lock()
+        .append(&result.filtered_output, output_buffer_cap);
 
-    Some(result.filtered_output)
+    Some((result.filtered_output, sequence))
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
 }
 
 fn spawn_output_reader(
@@ -71,32 +113,49 @@ fn spawn_output_reader(
     pty_id: u64,
     mut reader: Box<dyn Read + Send>,
     mut child: Box<dyn portable_pty::Child + Send + Sync>,
-    output_buffer: Arc<Mutex<VecDeque<u8>>>,
+    output_buffer: Arc<Mutex<PtyOutputBuffer>>,
+    output_buffer_cap: usize,
 ) {
     let rt = tokio::runtime::Handle::current();
     std::thread::spawn(move || {
         let ws = app.try_state::<Arc<WsBroadcaster>>();
         let mut buf = [0u8; 4096];
         let mut pending = Vec::new();
+        let mut last_activity_recorded_ms = 0;
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
-                    if let Some(filtered) =
-                        process_pty_output(&buf[..n], &mut pending, &output_buffer)
-                    {
+                    if let Some((filtered, sequence)) = process_pty_output(
+                        &buf[..n],
+                        &mut pending,
+                        &output_buffer,
+                        output_buffer_cap,
+                    ) {
+                        let current_ms = now_ms();
+                        if current_ms.saturating_sub(last_activity_recorded_ms) >= 1_000 {
+                            if let Some(gateway) = app.try_state::<Arc<PtySessionRuntimeGateway>>()
+                            {
+                                gateway.record_activity(pty_id, current_ms);
+                            }
+                            last_activity_recorded_ms = current_ms;
+                        }
                         let _ = app.emit(
                             "pty-output",
                             PtyOutput {
                                 pty_id,
                                 data: filtered.clone(),
+                                sequence,
                             },
                         );
                         if let Some(ws) = &ws {
-                            ws.try_send(WsMessage::PtyOutput(PtyOutputMsg {
-                                pty_id,
-                                data: filtered,
-                            }));
+                            if ws.has_subscriber() {
+                                ws.try_send(WsMessage::PtyOutput(PtyOutputMsg {
+                                    pty_id,
+                                    data: filtered,
+                                    sequence,
+                                }));
+                            }
                         }
                     }
                 }
@@ -106,8 +165,12 @@ fn spawn_output_reader(
         }
 
         let exit_code = child.wait().ok().map(|status| status.exit_code() as i32);
-        if let Some(gateway) = app.try_state::<Arc<PtySessionRuntimeGateway>>() {
-            gateway.mark_exited(pty_id, exit_code);
+        let should_emit_exit = app
+            .try_state::<Arc<PtySessionRuntimeGateway>>()
+            .is_none_or(|gateway| gateway.mark_exited(pty_id, exit_code));
+
+        if !should_emit_exit {
+            return;
         }
 
         let _ = app.emit("pty-exit", PtyExit { pty_id, exit_code });
@@ -140,29 +203,78 @@ impl PtySessionRuntimeGateway {
     }
 
     #[allow(dead_code)]
+    pub fn with_backend_and_config(
+        backend: Box<dyn PtyBackend>,
+        config: PtyLifecycleConfig,
+    ) -> Self {
+        Self {
+            registry: Mutex::new(PtySessionRegistry::with_config(config)),
+            runtimes: Mutex::new(HashMap::new()),
+            backend,
+        }
+    }
+
+    #[allow(dead_code)]
     pub fn backend_name(&self) -> &'static str {
         self.backend.backend_name()
     }
 
-    fn mark_exited(&self, pty_id: u64, exit_code: Option<i32>) {
-        self.registry.lock().mark_exited(pty_id, exit_code);
+    pub fn start_idle_sweeper(self: &Arc<Self>, app: AppHandle) {
+        let gateway = Arc::clone(self);
+        let interval = gateway.lifecycle_config().sweep_interval;
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(interval).await;
+                let now_ms = gateway.now_ms();
+                crate::usecase::pty_session::lifecycle_usecase::sweep_idle(
+                    gateway.as_ref(),
+                    &app,
+                    now_ms,
+                );
+            }
+        });
     }
 
-    fn buffered_output(&self, pty_id: u64) -> String {
+    fn lifecycle_config(&self) -> PtyLifecycleConfig {
+        self.registry.lock().config().clone()
+    }
+
+    fn mark_exited(&self, pty_id: u64, exit_code: Option<i32>) -> bool {
+        self.registry.lock().mark_exited(pty_id, exit_code)
+    }
+
+    fn buffered_output_snapshot(&self, pty_id: u64) -> (String, u64) {
         let Some(output_buffer) = self
             .runtimes
             .lock()
             .get(&pty_id)
             .map(|runtime| Arc::clone(&runtime.output_buffer))
         else {
-            return String::new();
+            return (String::new(), 0);
         };
-        let ring = output_buffer.lock();
-        let (a, b) = ring.as_slices();
-        let mut bytes = Vec::with_capacity(a.len() + b.len());
-        bytes.extend_from_slice(a);
-        bytes.extend_from_slice(b);
-        String::from_utf8_lossy(&bytes).into_owned()
+        let snapshot = output_buffer.lock().snapshot();
+        snapshot
+    }
+}
+
+impl PtySessionReadGateway for PtySessionRuntimeGateway {
+    fn find_by_session_key(&self, session_key: &str) -> Option<FoundPtySession> {
+        let snapshot = self
+            .registry
+            .lock()
+            .find_by_session_key(session_key)
+            .map(PtySession::snapshot)?;
+        let (buffered_output, buffered_output_sequence) =
+            self.buffered_output_snapshot(snapshot.pty_id);
+        Some(FoundPtySession {
+            snapshot,
+            buffered_output,
+            buffered_output_sequence,
+        })
+    }
+
+    fn list_snapshots(&self) -> Vec<PtySessionSnapshot> {
+        self.registry.lock().list_snapshots()
     }
 }
 
@@ -219,7 +331,10 @@ impl PtySessionGateway for PtySessionRuntimeGateway {
             writer: backend_session.writer,
             killer: Arc::new(Mutex::new(killer)),
             resizer: backend_session.resizer,
-            output_buffer: Arc::new(Mutex::new(VecDeque::with_capacity(OUTPUT_BUFFER_CAPACITY))),
+            output_buffer: Arc::new(Mutex::new(PtyOutputBuffer::with_capacity(
+                self.lifecycle_config().output_buffer_cap,
+            ))),
+            output_buffer_cap: self.lifecycle_config().output_buffer_cap,
             reader: Some(backend_session.reader),
             child: Some(backend_session.child),
         })
@@ -237,7 +352,7 @@ impl PtySessionGateway for PtySessionRuntimeGateway {
     }
 
     fn start_output_reader(&self, app: &Self::AppContext, pty_id: u64) -> Result<(), UsecaseError> {
-        let (reader, child, output_buffer) = {
+        let (reader, child, output_buffer, output_buffer_cap) = {
             let mut runtimes = self.runtimes.lock();
             let runtime = runtimes
                 .get_mut(&pty_id)
@@ -251,31 +366,26 @@ impl PtySessionGateway for PtySessionRuntimeGateway {
                     pty_id
                 ))
             })?;
-            (reader, child, Arc::clone(&runtime.output_buffer))
+            (
+                reader,
+                child,
+                Arc::clone(&runtime.output_buffer),
+                runtime.output_buffer_cap,
+            )
         };
-        spawn_output_reader(app.clone(), pty_id, reader, child, output_buffer);
+        spawn_output_reader(
+            app.clone(),
+            pty_id,
+            reader,
+            child,
+            output_buffer,
+            output_buffer_cap,
+        );
         Ok(())
-    }
-
-    fn find_by_session_key(&self, session_key: &str) -> Option<FoundPtySession> {
-        let snapshot = self
-            .registry
-            .lock()
-            .find_by_session_key(session_key)
-            .map(PtySession::snapshot)?;
-        let buffered_output = self.buffered_output(snapshot.pty_id);
-        Some(FoundPtySession {
-            snapshot,
-            buffered_output,
-        })
     }
 
     fn snapshot(&self, pty_id: u64) -> Option<PtySessionSnapshot> {
         self.registry.lock().get(pty_id).map(PtySession::snapshot)
-    }
-
-    fn list_snapshots(&self) -> Vec<PtySessionSnapshot> {
-        self.registry.lock().list_snapshots()
     }
 
     fn select_kill_targets_by_worktree(&self, worktree_path: &str) -> Vec<u64> {
@@ -301,6 +411,94 @@ impl PtySessionGateway for PtySessionRuntimeGateway {
         removed.map(|session| session.snapshot())
     }
 
+    fn now_ms(&self) -> u64 {
+        now_ms()
+    }
+
+    fn record_activity(&self, pty_id: u64, now_ms: u64) -> bool {
+        self.registry.lock().record_activity(pty_id, now_ms)
+    }
+
+    fn pin_session_key(&self, session_key: &str) {
+        self.registry.lock().pin_session_key(session_key);
+    }
+
+    fn register_active_terminal(&self, worktree_path: &str, session_key: &str, active_token: &str) {
+        self.registry
+            .lock()
+            .register_active_terminal(worktree_path, session_key, active_token);
+    }
+
+    fn unregister_active_terminal(
+        &self,
+        worktree_path: &str,
+        session_key: &str,
+        active_token: &str,
+    ) {
+        self.registry
+            .lock()
+            .unregister_active_terminal(worktree_path, session_key, active_token);
+    }
+
+    fn reserve_spawn_slot(
+        &self,
+        worktree_path: Option<&str>,
+        now_ms: u64,
+    ) -> Result<PtySpawnReservation, PtySpawnReservationError> {
+        self.registry
+            .lock()
+            .reserve_spawn_slot(worktree_path, now_ms)
+    }
+
+    fn complete_spawn_slot(&self, reservation: &PtySpawnReservation) {
+        self.registry.lock().complete_spawn_slot(reservation);
+    }
+
+    fn rollback_spawn_slot(&self, reservation: &PtySpawnReservation) {
+        self.registry.lock().rollback_spawn_slot(reservation);
+    }
+
+    fn select_idle_timed_out(&self, now_ms: u64) -> Vec<u64> {
+        self.registry.lock().select_idle_timed_out(now_ms)
+    }
+
+    fn snapshot_if_idle_evictable(&self, pty_id: u64, now_ms: u64) -> Option<PtySessionSnapshot> {
+        self.registry
+            .lock()
+            .snapshot_if_idle_evictable(pty_id, now_ms)
+    }
+
+    fn emit_evicted(
+        &self,
+        app: &Self::AppContext,
+        snapshot: &PtySessionSnapshot,
+        reason: PtyEvictReason,
+    ) {
+        let reason_msg = PtyEvictReasonMsg::from(reason);
+        let reason_wire = serde_json::to_value(reason_msg)
+            .expect("PtyEvictReasonMsg should serialize")
+            .as_str()
+            .expect("PtyEvictReasonMsg should serialize to a string")
+            .to_string();
+        let _ = app.emit(
+            "pty-evicted",
+            PtyEvicted {
+                pty_id: snapshot.pty_id,
+                session_key: snapshot.session_key.clone(),
+                reason: reason_wire,
+            },
+        );
+        if let Some(ws) = app.try_state::<Arc<WsBroadcaster>>() {
+            if ws.has_subscriber() {
+                ws.try_send(WsMessage::PtyEvicted(PtyEvictedMsg {
+                    pty_id: snapshot.pty_id,
+                    session_key: snapshot.session_key.clone(),
+                    reason: reason_msg,
+                }));
+            }
+        }
+    }
+
     fn write(&self, pty_id: u64, data: &str) -> Result<(), UsecaseError> {
         let writer = {
             let runtimes = self.runtimes.lock();
@@ -316,6 +514,7 @@ impl PtySessionGateway for PtySessionRuntimeGateway {
         writer
             .flush()
             .map_err(|e| UsecaseError::Gateway(format!("Failed to flush: {}", e)))?;
+        self.record_activity(pty_id, now_ms());
         Ok(())
     }
 
@@ -331,7 +530,9 @@ impl PtySessionGateway for PtySessionRuntimeGateway {
             Arc::clone(&runtime.resizer)
         };
         let result = resizer.lock().resize(rows, cols);
-        result.map_err(UsecaseError::from)
+        result.map_err(UsecaseError::from)?;
+        self.record_activity(pty_id, now_ms());
+        Ok(())
     }
 
     fn get_pty_size(&self, pty_id: u64) -> Result<(u16, u16), UsecaseError> {
@@ -361,6 +562,10 @@ impl PtySessionGateway for PtySessionRuntimeGateway {
         result
     }
 
+    fn remove_runtime(&self, pty_id: u64) {
+        self.runtimes.lock().remove(&pty_id);
+    }
+
     fn remove_if_exited(&self, pty_id: u64) {
         if self
             .snapshot(pty_id)
@@ -375,6 +580,7 @@ impl PtySessionGateway for PtySessionRuntimeGateway {
 pub struct PtyOutput {
     pub pty_id: u64,
     pub data: String,
+    pub sequence: u64,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -383,10 +589,17 @@ pub struct PtyExit {
     pub exit_code: Option<i32>,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PtyEvicted {
+    pub pty_id: u64,
+    pub session_key: String,
+    pub reason: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::pty_session::services::MAX_PENDING_BYTES;
+    use crate::domain::pty_session::services::{MAX_PENDING_BYTES, OUTPUT_BUFFER_CAPACITY};
     use crate::domain::pty_session::PtyKind;
 
     #[test]
@@ -441,68 +654,123 @@ mod tests {
     #[test]
     fn process_pty_output_valid_utf8() {
         let mut pending = Vec::new();
-        let output_buffer = Mutex::new(VecDeque::new());
-        let result = process_pty_output(b"hello world", &mut pending, &output_buffer);
-        assert_eq!(result.as_deref(), Some("hello world"));
+        let output_buffer = Mutex::new(PtyOutputBuffer::with_capacity(OUTPUT_BUFFER_CAPACITY));
+        let result = process_pty_output(
+            b"hello world",
+            &mut pending,
+            &output_buffer,
+            OUTPUT_BUFFER_CAPACITY,
+        );
+        assert_eq!(
+            result.as_ref().map(|(data, _)| data.as_str()),
+            Some("hello world")
+        );
+        assert_eq!(result.map(|(_, sequence)| sequence), Some(1));
         assert!(pending.is_empty());
-        assert_eq!(output_buffer.lock().len(), 11);
+        assert_eq!(output_buffer.lock().bytes.len(), 11);
     }
 
     #[test]
     fn process_pty_output_incomplete_utf8_pending() {
         let mut pending = Vec::new();
-        let output_buffer = Mutex::new(VecDeque::new());
-        assert!(process_pty_output(&[0xE3, 0x81], &mut pending, &output_buffer).is_none());
+        let output_buffer = Mutex::new(PtyOutputBuffer::with_capacity(OUTPUT_BUFFER_CAPACITY));
+        assert!(process_pty_output(
+            &[0xE3, 0x81],
+            &mut pending,
+            &output_buffer,
+            OUTPUT_BUFFER_CAPACITY,
+        )
+        .is_none());
         assert_eq!(pending.len(), 2);
-        let result = process_pty_output(&[0x82], &mut pending, &output_buffer);
-        assert_eq!(result.as_deref(), Some("あ"));
+        let result = process_pty_output(
+            &[0x82],
+            &mut pending,
+            &output_buffer,
+            OUTPUT_BUFFER_CAPACITY,
+        );
+        assert_eq!(result.as_ref().map(|(data, _)| data.as_str()), Some("あ"));
+        assert_eq!(result.map(|(_, sequence)| sequence), Some(1));
         assert!(pending.is_empty());
     }
 
     #[test]
     fn process_pty_output_max_pending_drop() {
         let mut pending = Vec::new();
-        let output_buffer = Mutex::new(VecDeque::new());
+        let output_buffer = Mutex::new(PtyOutputBuffer::with_capacity(OUTPUT_BUFFER_CAPACITY));
         let invalid_bytes = vec![0xFF; MAX_PENDING_BYTES + 1];
-        assert!(process_pty_output(&invalid_bytes, &mut pending, &output_buffer).is_none());
+        assert!(process_pty_output(
+            &invalid_bytes,
+            &mut pending,
+            &output_buffer,
+            OUTPUT_BUFFER_CAPACITY,
+        )
+        .is_none());
         assert!(pending.is_empty());
     }
 
     #[test]
     fn process_pty_output_invalid_below_max_pending_retained() {
         let mut pending = Vec::new();
-        let output_buffer = Mutex::new(VecDeque::new());
+        let output_buffer = Mutex::new(PtyOutputBuffer::with_capacity(OUTPUT_BUFFER_CAPACITY));
         let invalid_bytes = vec![0xFF; 10];
-        assert!(process_pty_output(&invalid_bytes, &mut pending, &output_buffer).is_none());
+        assert!(process_pty_output(
+            &invalid_bytes,
+            &mut pending,
+            &output_buffer,
+            OUTPUT_BUFFER_CAPACITY,
+        )
+        .is_none());
         assert_eq!(pending.len(), 10);
     }
 
     #[test]
     fn process_pty_output_ring_buffer_overflow() {
         let mut pending = Vec::new();
-        let output_buffer = Mutex::new(VecDeque::new());
+        let output_buffer = Mutex::new(PtyOutputBuffer::with_capacity(OUTPUT_BUFFER_CAPACITY));
         let data = "x".repeat(OUTPUT_BUFFER_CAPACITY - 10);
-        process_pty_output(data.as_bytes(), &mut pending, &output_buffer);
-        assert_eq!(output_buffer.lock().len(), OUTPUT_BUFFER_CAPACITY - 10);
+        process_pty_output(
+            data.as_bytes(),
+            &mut pending,
+            &output_buffer,
+            OUTPUT_BUFFER_CAPACITY,
+        );
+        assert_eq!(
+            output_buffer.lock().bytes.len(),
+            OUTPUT_BUFFER_CAPACITY - 10
+        );
         let data2 = "y".repeat(20);
-        process_pty_output(data2.as_bytes(), &mut pending, &output_buffer);
-        assert_eq!(output_buffer.lock().len(), OUTPUT_BUFFER_CAPACITY);
+        process_pty_output(
+            data2.as_bytes(),
+            &mut pending,
+            &output_buffer,
+            OUTPUT_BUFFER_CAPACITY,
+        );
+        let buffer = output_buffer.lock();
+        assert_eq!(buffer.bytes.len(), OUTPUT_BUFFER_CAPACITY);
+        assert_eq!(buffer.sequence, 2);
     }
 
     #[test]
     fn process_pty_output_exceeds_capacity() {
         let mut pending = Vec::new();
-        let output_buffer = Mutex::new(VecDeque::new());
+        let output_buffer = Mutex::new(PtyOutputBuffer::with_capacity(OUTPUT_BUFFER_CAPACITY));
         let data = "z".repeat(OUTPUT_BUFFER_CAPACITY + 100);
-        process_pty_output(data.as_bytes(), &mut pending, &output_buffer);
-        assert_eq!(output_buffer.lock().len(), OUTPUT_BUFFER_CAPACITY);
+        process_pty_output(
+            data.as_bytes(),
+            &mut pending,
+            &output_buffer,
+            OUTPUT_BUFFER_CAPACITY,
+        );
+        assert_eq!(output_buffer.lock().bytes.len(), OUTPUT_BUFFER_CAPACITY);
     }
 
     #[test]
     fn process_pty_output_empty_input() {
         let mut pending = Vec::new();
-        let output_buffer = Mutex::new(VecDeque::new());
-        assert!(process_pty_output(b"", &mut pending, &output_buffer).is_none());
+        let output_buffer = Mutex::new(PtyOutputBuffer::with_capacity(OUTPUT_BUFFER_CAPACITY));
+        assert!(
+            process_pty_output(b"", &mut pending, &output_buffer, OUTPUT_BUFFER_CAPACITY).is_none()
+        );
     }
 
     struct MockWriter(Arc<Mutex<Vec<u8>>>);
@@ -563,8 +831,12 @@ mod tests {
     ) -> Arc<std::sync::atomic::AtomicBool> {
         let written = Arc::new(Mutex::new(Vec::<u8>::new()));
         let killed = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let output_buffer = Arc::new(Mutex::new(VecDeque::new()));
-        output_buffer.lock().extend(b"buffered data");
+        let output_buffer = Arc::new(Mutex::new(PtyOutputBuffer::with_capacity(
+            OUTPUT_BUFFER_CAPACITY,
+        )));
+        output_buffer
+            .lock()
+            .append("buffered data", OUTPUT_BUFFER_CAPACITY);
         gateway.insert_session(
             PtySession::new(
                 pty_id,
@@ -580,6 +852,7 @@ mod tests {
                 }))),
                 resizer: Arc::new(Mutex::new(Box::new(MockResizer { rows: 24, cols: 80 }))),
                 output_buffer,
+                output_buffer_cap: OUTPUT_BUFFER_CAPACITY,
                 reader: None,
                 child: None,
             },
@@ -617,6 +890,7 @@ mod tests {
         assert_eq!(found.snapshot.pty_id, 1);
         assert_eq!(found.snapshot.label.as_deref(), Some("dev"));
         assert_eq!(found.buffered_output, "buffered data");
+        assert_eq!(found.buffered_output_sequence, 1);
     }
 
     #[test]
@@ -708,6 +982,15 @@ mod tests {
         assert!(gateway.snapshot(1).is_some());
         assert!(gateway.snapshot(2).is_none());
         assert!(gateway.snapshot(3).is_some());
+    }
+
+    #[test]
+    fn mark_exited_returns_false_after_session_removed() {
+        let gateway = PtySessionRuntimeGateway::default();
+        insert_test_session(&gateway, 1, "key-1", Some("/repo"), None, PtyKind::Terminal);
+        gateway.remove_session(1);
+
+        assert!(!gateway.mark_exited(1, Some(0)));
     }
 
     #[test]

--- a/src-tauri/src/adaptor/protocol/pty.rs
+++ b/src-tauri/src/adaptor/protocol/pty.rs
@@ -1,15 +1,41 @@
 use serde::{Deserialize, Serialize};
 
+use crate::domain::pty_session::PtyEvictReason;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyOutputMsg {
     pub pty_id: u64,
     pub data: String,
+    pub sequence: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyExitMsg {
     pub pty_id: u64,
     pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PtyEvictReasonMsg {
+    Idle,
+    CapExceeded,
+}
+
+impl From<PtyEvictReason> for PtyEvictReasonMsg {
+    fn from(reason: PtyEvictReason) -> Self {
+        match reason {
+            PtyEvictReason::Idle => Self::Idle,
+            PtyEvictReason::CapExceeded => Self::CapExceeded,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyEvictedMsg {
+    pub pty_id: u64,
+    pub session_key: String,
+    pub reason: PtyEvictReasonMsg,
 }
 
 #[cfg(test)]
@@ -21,11 +47,13 @@ mod tests {
         let msg = PtyOutputMsg {
             pty_id: 42,
             data: "hello".to_string(),
+            sequence: 7,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let deserialized: PtyOutputMsg = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.pty_id, 42);
         assert_eq!(deserialized.data, "hello");
+        assert_eq!(deserialized.sequence, 7);
     }
 
     #[test]
@@ -48,5 +76,32 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let deserialized: PtyExitMsg = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.exit_code, None);
+    }
+
+    #[test]
+    fn test_pty_evicted_msg_roundtrip() {
+        let msg = PtyEvictedMsg {
+            pty_id: 1,
+            session_key: "key".to_string(),
+            reason: PtyEvictReasonMsg::CapExceeded,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"reason\":\"cap_exceeded\""));
+        let deserialized: PtyEvictedMsg = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.pty_id, 1);
+        assert_eq!(deserialized.session_key, "key");
+        assert_eq!(deserialized.reason, PtyEvictReasonMsg::CapExceeded);
+    }
+
+    #[test]
+    fn pty_evict_reason_serializes_as_snake_case_wire_value() {
+        assert_eq!(
+            serde_json::to_value(PtyEvictReasonMsg::from(PtyEvictReason::Idle)).unwrap(),
+            "idle"
+        );
+        assert_eq!(
+            serde_json::to_value(PtyEvictReasonMsg::from(PtyEvictReason::CapExceeded)).unwrap(),
+            "cap_exceeded"
+        );
     }
 }

--- a/src-tauri/src/domain/pty_session/entities/mod.rs
+++ b/src-tauri/src/domain/pty_session/entities/mod.rs
@@ -2,4 +2,4 @@ mod pty_session;
 mod pty_session_registry;
 
 pub use pty_session::{PtySession, PtySessionSnapshot};
-pub use pty_session_registry::PtySessionRegistry;
+pub use pty_session_registry::{PtySessionRegistry, PtySpawnReservation, PtySpawnReservationError};

--- a/src-tauri/src/domain/pty_session/entities/pty_session_registry.rs
+++ b/src-tauri/src/domain/pty_session/entities/pty_session_registry.rs
@@ -1,22 +1,72 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::domain::pty_session::entities::{PtySession, PtySessionSnapshot};
+use crate::domain::pty_session::PtyLifecycleConfig;
 
 pub struct PtySessionRegistry {
     sessions: HashMap<u64, PtySession>,
+    activity: HashMap<u64, u64>,
+    pinned: HashSet<String>,
+    active_pin_tokens: HashMap<String, ActivePin>,
+    retired_active_tokens: HashMap<String, ActivePin>,
+    retired_active_token_order: VecDeque<String>,
+    reserved_evictions: HashSet<u64>,
+    reserved_spawn_total: usize,
+    reserved_spawn_by_worktree: HashMap<String, usize>,
     next_pty_id: u64,
+    config: PtyLifecycleConfig,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ActivePin {
+    worktree_path: String,
+    session_key: String,
+}
+
+const RETIRED_ACTIVE_TOKEN_CAP: usize = 128;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PtySpawnReservation {
+    pub worktree_path: Option<String>,
+    pub evict_targets: Vec<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PtySpawnReservationError {
+    WorktreeCapReached(String),
+    TotalCapReached,
 }
 
 impl Default for PtySessionRegistry {
     fn default() -> Self {
         Self {
             sessions: HashMap::new(),
+            activity: HashMap::new(),
+            pinned: HashSet::new(),
+            active_pin_tokens: HashMap::new(),
+            retired_active_tokens: HashMap::new(),
+            retired_active_token_order: VecDeque::new(),
+            reserved_evictions: HashSet::new(),
+            reserved_spawn_total: 0,
+            reserved_spawn_by_worktree: HashMap::new(),
             next_pty_id: 1,
+            config: PtyLifecycleConfig::default(),
         }
     }
 }
 
 impl PtySessionRegistry {
+    pub fn with_config(config: PtyLifecycleConfig) -> Self {
+        Self {
+            config,
+            ..Self::default()
+        }
+    }
+
+    pub fn config(&self) -> &PtyLifecycleConfig {
+        &self.config
+    }
+
     pub fn next_pty_id(&mut self) -> u64 {
         let pty_id = self.next_pty_id;
         self.next_pty_id += 1;
@@ -24,11 +74,22 @@ impl PtySessionRegistry {
     }
 
     pub fn insert(&mut self, session: PtySession) -> Option<PtySession> {
-        self.sessions.insert(session.pty_id, session)
+        let pty_id = session.pty_id;
+        self.activity.entry(pty_id).or_insert(0);
+        self.sessions.insert(pty_id, session)
     }
 
     pub fn remove(&mut self, pty_id: u64) -> Option<PtySession> {
-        self.sessions.remove(&pty_id)
+        self.activity.remove(&pty_id);
+        self.reserved_evictions.remove(&pty_id);
+        let removed = self.sessions.remove(&pty_id)?;
+        self.pinned.remove(&removed.session_key);
+        self.active_pin_tokens
+            .retain(|_, pin| pin.session_key != removed.session_key);
+        self.retired_active_tokens
+            .retain(|_, pin| pin.session_key != removed.session_key);
+        self.compact_retired_active_token_order();
+        Some(removed)
     }
 
     pub fn get(&self, pty_id: u64) -> Option<&PtySession> {
@@ -74,6 +135,326 @@ impl PtySessionRegistry {
 
     pub fn len(&self) -> usize {
         self.sessions.len()
+    }
+
+    #[cfg(test)]
+    pub fn count_total_alive(&self) -> usize {
+        self.sessions
+            .values()
+            .filter(|session| !session.exited)
+            .count()
+    }
+
+    #[cfg(test)]
+    pub fn count_alive_for_worktree(&self, worktree_path: &str) -> usize {
+        self.sessions
+            .values()
+            .filter(|session| {
+                !session.exited && session.worktree_path.as_deref() == Some(worktree_path)
+            })
+            .count()
+    }
+
+    #[cfg(test)]
+    pub fn would_exceed_worktree_cap(&self, worktree_path: &str) -> bool {
+        self.count_alive_for_worktree(worktree_path) >= self.config.per_worktree_cap
+    }
+
+    #[cfg(test)]
+    pub fn would_exceed_total_cap(&self) -> bool {
+        self.count_total_alive() >= self.config.max_panes_total
+    }
+
+    pub fn reserve_spawn_slot(
+        &mut self,
+        worktree_path: Option<&str>,
+        now_ms: u64,
+    ) -> Result<PtySpawnReservation, PtySpawnReservationError> {
+        let mut evict_targets = Vec::new();
+
+        if let Some(worktree_path) = worktree_path {
+            if self.effective_alive_for_worktree(worktree_path)
+                + self.reserved_spawn_for_worktree(worktree_path)
+                >= self.config.per_worktree_cap
+            {
+                let Some(target) = self.select_oldest_idle(now_ms, |session| {
+                    session.worktree_path.as_deref() == Some(worktree_path)
+                        && !self.reserved_evictions.contains(&session.pty_id)
+                }) else {
+                    return Err(PtySpawnReservationError::WorktreeCapReached(
+                        worktree_path.to_string(),
+                    ));
+                };
+                self.reserved_evictions.insert(target);
+                evict_targets.push(target);
+            }
+        }
+
+        if self.effective_total_alive() + self.reserved_spawn_total >= self.config.max_panes_total {
+            let Some(target) = self.select_oldest_idle(now_ms, |session| {
+                !self.reserved_evictions.contains(&session.pty_id)
+            }) else {
+                for target in &evict_targets {
+                    self.reserved_evictions.remove(target);
+                }
+                return Err(PtySpawnReservationError::TotalCapReached);
+            };
+            self.reserved_evictions.insert(target);
+            evict_targets.push(target);
+        }
+
+        self.reserved_spawn_total += 1;
+        if let Some(worktree_path) = worktree_path {
+            *self
+                .reserved_spawn_by_worktree
+                .entry(worktree_path.to_string())
+                .or_insert(0) += 1;
+        }
+
+        Ok(PtySpawnReservation {
+            worktree_path: worktree_path.map(str::to_string),
+            evict_targets,
+        })
+    }
+
+    pub fn complete_spawn_slot(&mut self, reservation: &PtySpawnReservation) {
+        self.release_spawn_slot(reservation);
+    }
+
+    pub fn rollback_spawn_slot(&mut self, reservation: &PtySpawnReservation) {
+        self.release_spawn_slot(reservation);
+    }
+
+    pub fn record_activity(&mut self, pty_id: u64, now_ms: u64) -> bool {
+        if !self.sessions.contains_key(&pty_id) {
+            return false;
+        }
+        self.activity.insert(pty_id, now_ms);
+        true
+    }
+
+    pub fn pin_session_key(&mut self, session_key: &str) {
+        if self
+            .sessions
+            .values()
+            .any(|session| session.session_key == session_key)
+        {
+            self.pinned.insert(session_key.to_string());
+        }
+    }
+
+    pub fn register_active_terminal(
+        &mut self,
+        worktree_path: &str,
+        session_key: &str,
+        active_token: &str,
+    ) -> bool {
+        if self.retired_active_tokens.remove(active_token).is_some() {
+            self.retired_active_token_order
+                .retain(|token| token != active_token);
+            return false;
+        }
+        if !self.session_key_belongs_to_worktree(worktree_path, session_key) {
+            return false;
+        }
+
+        let previous = self.active_pin_tokens.insert(
+            active_token.to_string(),
+            ActivePin {
+                worktree_path: worktree_path.to_string(),
+                session_key: session_key.to_string(),
+            },
+        );
+        self.pinned.insert(session_key.to_string());
+
+        if let Some(previous) = previous {
+            self.clear_pin_if_unused(&previous.session_key);
+        }
+
+        true
+    }
+
+    pub fn unregister_active_terminal(
+        &mut self,
+        worktree_path: &str,
+        session_key: &str,
+        active_token: &str,
+    ) -> bool {
+        if self.session_key_belongs_to_worktree(worktree_path, session_key) {
+            self.retire_active_token(
+                active_token,
+                ActivePin {
+                    worktree_path: worktree_path.to_string(),
+                    session_key: session_key.to_string(),
+                },
+            );
+        }
+        let removed = self.active_pin_tokens.get(active_token).is_some_and(|pin| {
+            pin.worktree_path == worktree_path && pin.session_key == session_key
+        });
+        if removed {
+            self.active_pin_tokens.remove(active_token);
+        }
+        self.clear_pin_if_unused(session_key);
+        removed
+    }
+
+    #[cfg(test)]
+    pub fn is_pinned(&self, pty_id: u64) -> bool {
+        self.sessions
+            .get(&pty_id)
+            .is_some_and(|session| self.pinned.contains(&session.session_key))
+    }
+
+    #[cfg(test)]
+    pub fn select_evictable_for_worktree(&self, worktree_path: &str, now_ms: u64) -> Option<u64> {
+        self.select_oldest_idle(now_ms, |session| {
+            session.worktree_path.as_deref() == Some(worktree_path)
+        })
+    }
+
+    pub fn select_idle_timed_out(&self, now_ms: u64) -> Vec<u64> {
+        self.sessions
+            .values()
+            .filter(|session| self.is_session_idle_evictable(session, now_ms))
+            .filter(|session| !self.reserved_evictions.contains(&session.pty_id))
+            .map(|session| session.pty_id)
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub fn is_idle_evictable(&self, pty_id: u64, now_ms: u64) -> bool {
+        self.sessions
+            .get(&pty_id)
+            .is_some_and(|session| self.is_session_idle_evictable(session, now_ms))
+    }
+
+    pub fn snapshot_if_idle_evictable(
+        &self,
+        pty_id: u64,
+        now_ms: u64,
+    ) -> Option<PtySessionSnapshot> {
+        let session = self.sessions.get(&pty_id)?;
+        if !self.is_session_idle_evictable(session, now_ms) {
+            return None;
+        }
+        Some(session.snapshot())
+    }
+
+    #[cfg(test)]
+    pub fn remove_if_idle_evictable(&mut self, pty_id: u64, now_ms: u64) -> Option<PtySession> {
+        if !self.is_idle_evictable(pty_id, now_ms) {
+            return None;
+        }
+        self.remove(pty_id)
+    }
+
+    fn release_spawn_slot(&mut self, reservation: &PtySpawnReservation) {
+        self.reserved_spawn_total = self.reserved_spawn_total.saturating_sub(1);
+        if let Some(worktree_path) = &reservation.worktree_path {
+            if let Some(count) = self.reserved_spawn_by_worktree.get_mut(worktree_path) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    self.reserved_spawn_by_worktree.remove(worktree_path);
+                }
+            }
+        }
+        for target in &reservation.evict_targets {
+            self.reserved_evictions.remove(target);
+        }
+    }
+
+    fn effective_total_alive(&self) -> usize {
+        self.sessions
+            .values()
+            .filter(|session| !session.exited && !self.reserved_evictions.contains(&session.pty_id))
+            .count()
+    }
+
+    fn effective_alive_for_worktree(&self, worktree_path: &str) -> usize {
+        self.sessions
+            .values()
+            .filter(|session| {
+                !session.exited
+                    && session.worktree_path.as_deref() == Some(worktree_path)
+                    && !self.reserved_evictions.contains(&session.pty_id)
+            })
+            .count()
+    }
+
+    fn reserved_spawn_for_worktree(&self, worktree_path: &str) -> usize {
+        self.reserved_spawn_by_worktree
+            .get(worktree_path)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    fn select_oldest_idle(
+        &self,
+        now_ms: u64,
+        predicate: impl Fn(&PtySession) -> bool,
+    ) -> Option<u64> {
+        self.sessions
+            .values()
+            .filter(|session| predicate(session))
+            .filter(|session| self.is_session_idle_evictable(session, now_ms))
+            .min_by_key(|session| self.activity.get(&session.pty_id).copied().unwrap_or(0))
+            .map(|session| session.pty_id)
+    }
+
+    fn is_session_idle_evictable(&self, session: &PtySession, now_ms: u64) -> bool {
+        if session.exited || self.pinned.contains(&session.session_key) {
+            return false;
+        }
+        let last_activity = self.activity.get(&session.pty_id).copied().unwrap_or(0);
+        now_ms.saturating_sub(last_activity) >= self.idle_timeout_ms()
+    }
+
+    fn session_key_belongs_to_worktree(&self, worktree_path: &str, session_key: &str) -> bool {
+        self.sessions.values().any(|session| {
+            session.session_key == session_key
+                && session.worktree_path.as_deref() == Some(worktree_path)
+        })
+    }
+
+    fn retire_active_token(&mut self, active_token: &str, pin: ActivePin) {
+        let token = active_token.to_string();
+        if self
+            .retired_active_tokens
+            .insert(token.clone(), pin)
+            .is_none()
+        {
+            self.retired_active_token_order.push_back(token);
+        }
+        while self.retired_active_tokens.len() > RETIRED_ACTIVE_TOKEN_CAP {
+            let Some(oldest) = self.retired_active_token_order.pop_front() else {
+                break;
+            };
+            self.retired_active_tokens.remove(&oldest);
+        }
+    }
+
+    fn compact_retired_active_token_order(&mut self) {
+        self.retired_active_token_order
+            .retain(|token| self.retired_active_tokens.contains_key(token));
+    }
+
+    fn clear_pin_if_unused(&mut self, session_key: &str) {
+        if self
+            .active_pin_tokens
+            .values()
+            .any(|pin| pin.session_key == session_key)
+        {
+            return;
+        }
+        self.pinned.remove(session_key);
+    }
+
+    fn idle_timeout_ms(&self) -> u64 {
+        self.config
+            .idle_timeout
+            .as_millis()
+            .min(u128::from(u64::MAX)) as u64
     }
 }
 
@@ -169,5 +550,303 @@ mod tests {
         assert!(snapshot.exited);
         assert_eq!(snapshot.exit_code, Some(42));
         assert!(!registry.mark_exited(999, None));
+    }
+
+    fn lifecycle_config() -> PtyLifecycleConfig {
+        PtyLifecycleConfig {
+            per_worktree_cap: 2,
+            max_panes_total: 3,
+            idle_timeout: std::time::Duration::from_millis(100),
+            output_buffer_cap: 64 * 1024,
+            sweep_interval: std::time::Duration::from_secs(60),
+        }
+    }
+
+    #[test]
+    fn cap_checks_count_alive_sessions_only() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.insert(session(3, "key-3", Some("/other"), None));
+
+        assert!(registry.would_exceed_worktree_cap("/repo"));
+        assert!(registry.would_exceed_total_cap());
+
+        registry.mark_exited(2, Some(0));
+
+        assert!(!registry.would_exceed_worktree_cap("/repo"));
+        assert!(!registry.would_exceed_total_cap());
+    }
+
+    #[test]
+    fn select_evictable_for_worktree_uses_oldest_idle_and_excludes_pinned() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.insert(session(3, "key-3", Some("/repo"), None));
+        registry.record_activity(1, 10);
+        registry.record_activity(2, 20);
+        registry.record_activity(3, 0);
+        registry.pin_session_key("key-3");
+
+        assert_eq!(
+            registry.select_evictable_for_worktree("/repo", 150),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn select_evictable_for_worktree_returns_none_when_no_idle_candidate() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.record_activity(1, 80);
+        registry.record_activity(2, 90);
+
+        assert_eq!(registry.select_evictable_for_worktree("/repo", 150), None);
+    }
+
+    #[test]
+    fn select_idle_timed_out_excludes_pinned_and_boundary_before_timeout() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.insert(session(3, "key-3", Some("/repo"), None));
+        registry.record_activity(1, 50);
+        registry.record_activity(2, 51);
+        registry.record_activity(3, 0);
+        registry.pin_session_key("key-3");
+
+        assert!(registry.select_idle_timed_out(149).is_empty());
+        assert_eq!(registry.select_idle_timed_out(150), vec![1]);
+    }
+
+    #[test]
+    fn is_idle_evictable_revalidates_activity_and_pinned_state() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.record_activity(1, 0);
+
+        assert!(registry.is_idle_evictable(1, 150));
+
+        registry.record_activity(1, 80);
+        assert!(!registry.is_idle_evictable(1, 150));
+
+        registry.record_activity(1, 0);
+        registry.pin_session_key("key-1");
+        assert!(!registry.is_idle_evictable(1, 150));
+    }
+
+    #[test]
+    fn remove_if_idle_evictable_revalidates_and_removes_atomically() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.record_activity(1, 0);
+        registry.record_activity(2, 80);
+
+        assert!(registry.remove_if_idle_evictable(2, 150).is_none());
+        assert!(registry.get(2).is_some());
+
+        let removed = registry.remove_if_idle_evictable(1, 150).unwrap();
+
+        assert_eq!(removed.pty_id, 1);
+        assert!(registry.get(1).is_none());
+    }
+
+    #[test]
+    fn remove_if_idle_evictable_does_not_remove_pinned_session() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.record_activity(1, 0);
+        registry.pin_session_key("key-1");
+
+        assert!(registry.remove_if_idle_evictable(1, 150).is_none());
+        assert!(registry.get(1).is_some());
+    }
+
+    #[test]
+    fn active_terminal_tokens_pin_until_their_own_token_is_removed() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+
+        assert!(registry.register_active_terminal("/repo", "key-1", "token-a"));
+        assert!(registry.register_active_terminal("/repo", "key-1", "token-b"));
+        assert!(registry.is_pinned(1));
+
+        assert!(registry.unregister_active_terminal("/repo", "key-1", "token-a"));
+        assert!(registry.is_pinned(1));
+
+        assert!(registry.unregister_active_terminal("/repo", "key-1", "token-b"));
+        assert!(!registry.is_pinned(1));
+    }
+
+    #[test]
+    fn stale_register_after_unregister_is_ignored() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.pin_session_key("key-1");
+
+        assert!(!registry.unregister_active_terminal("/repo", "key-1", "token-a"));
+        assert!(!registry.is_pinned(1));
+        assert!(!registry.register_active_terminal("/repo", "key-1", "token-a"));
+        assert!(!registry.is_pinned(1));
+        assert!(registry.retired_active_tokens.is_empty());
+    }
+
+    #[test]
+    fn stale_unregister_does_not_clear_new_active_token_for_same_session() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+
+        assert!(registry.register_active_terminal("/repo", "key-1", "new-token"));
+        assert!(!registry.unregister_active_terminal("/repo", "key-1", "old-token"));
+
+        assert!(registry.is_pinned(1));
+    }
+
+    #[test]
+    fn retired_active_tokens_are_bounded_during_mount_churn() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+
+        for index in 0..(RETIRED_ACTIVE_TOKEN_CAP * 3) {
+            let token = format!("token-{index}");
+            assert!(registry.register_active_terminal("/repo", "key-1", &token));
+            assert!(registry.unregister_active_terminal("/repo", "key-1", &token));
+            assert!(registry.retired_active_tokens.len() <= RETIRED_ACTIVE_TOKEN_CAP);
+        }
+
+        assert!(registry.retired_active_tokens.len() <= RETIRED_ACTIVE_TOKEN_CAP);
+    }
+
+    #[test]
+    fn remove_cleans_retired_active_tokens_for_session() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+
+        assert!(!registry.unregister_active_terminal("/repo", "key-1", "late-token"));
+        assert_eq!(registry.retired_active_tokens.len(), 1);
+
+        registry.remove(1);
+
+        assert!(registry.retired_active_tokens.is_empty());
+        assert!(registry.retired_active_token_order.is_empty());
+    }
+
+    #[test]
+    fn remove_cleans_activity_and_pinned_state() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.record_activity(1, 1);
+        registry.pin_session_key("key-1");
+
+        registry.remove(1);
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.record_activity(2, 0);
+
+        assert!(!registry.is_pinned(1));
+        assert_eq!(registry.select_idle_timed_out(150), vec![2]);
+    }
+
+    #[test]
+    fn reserve_spawn_slot_reserves_evict_targets_under_one_registry_lock() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.record_activity(1, 0);
+        registry.record_activity(2, 10);
+
+        let first = registry.reserve_spawn_slot(Some("/repo"), 200).unwrap();
+        let second = registry.reserve_spawn_slot(Some("/repo"), 200).unwrap();
+
+        assert_eq!(first.evict_targets, vec![1]);
+        assert_eq!(second.evict_targets, vec![2]);
+    }
+
+    #[test]
+    fn reserve_spawn_slot_rolls_back_pending_spawn_and_reserved_eviction() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.record_activity(1, 0);
+        registry.record_activity(2, 10);
+
+        let first = registry.reserve_spawn_slot(Some("/repo"), 200).unwrap();
+        registry.rollback_spawn_slot(&first);
+        let second = registry.reserve_spawn_slot(Some("/repo"), 200).unwrap();
+
+        assert_eq!(second.evict_targets, vec![1]);
+    }
+
+    #[test]
+    fn reserve_spawn_slot_returns_cap_error_when_no_idle_target_exists() {
+        let mut registry = PtySessionRegistry::with_config(lifecycle_config());
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.record_activity(1, 150);
+        registry.record_activity(2, 160);
+
+        assert_eq!(
+            registry.reserve_spawn_slot(Some("/repo"), 200),
+            Err(PtySpawnReservationError::WorktreeCapReached(
+                "/repo".to_string()
+            ))
+        );
+    }
+
+    fn total_cap_config(per_worktree_cap: usize, max_panes_total: usize) -> PtyLifecycleConfig {
+        PtyLifecycleConfig {
+            per_worktree_cap,
+            max_panes_total,
+            idle_timeout: std::time::Duration::from_millis(100),
+            output_buffer_cap: 64 * 1024,
+            sweep_interval: std::time::Duration::from_secs(60),
+        }
+    }
+
+    #[test]
+    fn reserve_spawn_slot_evicts_cross_worktree_oldest_idle_at_total_cap() {
+        let mut registry = PtySessionRegistry::with_config(total_cap_config(10, 2));
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/other"), None));
+        registry.record_activity(1, 50);
+        registry.record_activity(2, 0);
+
+        let reservation = registry.reserve_spawn_slot(Some("/repo"), 200).unwrap();
+
+        assert_eq!(reservation.evict_targets, vec![2]);
+    }
+
+    #[test]
+    fn reserve_spawn_slot_returns_total_cap_when_total_cap_has_no_idle_candidate() {
+        let mut registry = PtySessionRegistry::with_config(total_cap_config(10, 2));
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/other"), None));
+        registry.record_activity(1, 150);
+        registry.record_activity(2, 160);
+
+        assert_eq!(
+            registry.reserve_spawn_slot(Some("/third"), 200),
+            Err(PtySpawnReservationError::TotalCapReached)
+        );
+    }
+
+    #[test]
+    fn reserve_spawn_slot_rolls_back_worktree_eviction_when_total_cap_fails() {
+        let mut registry = PtySessionRegistry::with_config(total_cap_config(2, 1));
+        registry.insert(session(1, "key-1", Some("/repo"), None));
+        registry.insert(session(2, "key-2", Some("/repo"), None));
+        registry.record_activity(1, 0);
+        registry.record_activity(2, 150);
+
+        assert_eq!(
+            registry.reserve_spawn_slot(Some("/repo"), 200),
+            Err(PtySpawnReservationError::TotalCapReached)
+        );
+
+        assert!(registry.reserved_evictions.is_empty());
+        assert!(registry.get(1).is_some());
+        assert!(registry.get(2).is_some());
     }
 }

--- a/src-tauri/src/domain/pty_session/entities/pty_session_registry.rs
+++ b/src-tauri/src/domain/pty_session/entities/pty_session_registry.rs
@@ -243,6 +243,10 @@ impl PtySessionRegistry {
         }
     }
 
+    pub fn unpin_session_key_if_unused(&mut self, session_key: &str) {
+        self.clear_pin_if_unused(session_key);
+    }
+
     pub fn register_active_terminal(
         &mut self,
         worktree_path: &str,

--- a/src-tauri/src/domain/pty_session/mod.rs
+++ b/src-tauri/src/domain/pty_session/mod.rs
@@ -3,4 +3,4 @@ pub(crate) mod gateway;
 pub(crate) mod services;
 pub(crate) mod value_objects;
 
-pub use value_objects::PtyKind;
+pub use value_objects::{PtyEvictReason, PtyKind, PtyLifecycleConfig};

--- a/src-tauri/src/domain/pty_session/value_objects/mod.rs
+++ b/src-tauri/src/domain/pty_session/value_objects/mod.rs
@@ -1,3 +1,7 @@
+mod pty_evict_reason;
 mod pty_kind;
+mod pty_lifecycle_config;
 
+pub use pty_evict_reason::PtyEvictReason;
 pub use pty_kind::PtyKind;
+pub use pty_lifecycle_config::PtyLifecycleConfig;

--- a/src-tauri/src/domain/pty_session/value_objects/pty_evict_reason.rs
+++ b/src-tauri/src/domain/pty_session/value_objects/pty_evict_reason.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PtyEvictReason {
+    Idle,
+    CapExceeded,
+}

--- a/src-tauri/src/domain/pty_session/value_objects/pty_lifecycle_config.rs
+++ b/src-tauri/src/domain/pty_session/value_objects/pty_lifecycle_config.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+
+use crate::domain::pty_session::services::OUTPUT_BUFFER_CAPACITY;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PtyLifecycleConfig {
+    pub per_worktree_cap: usize,
+    pub max_panes_total: usize,
+    pub idle_timeout: Duration,
+    pub output_buffer_cap: usize,
+    pub sweep_interval: Duration,
+}
+
+impl Default for PtyLifecycleConfig {
+    fn default() -> Self {
+        Self {
+            per_worktree_cap: 32,
+            max_panes_total: 64,
+            idle_timeout: Duration::from_secs(300),
+            output_buffer_cap: OUTPUT_BUFFER_CAPACITY,
+            sweep_interval: Duration::from_secs(60),
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,6 +50,15 @@ pub fn run() {
     let _ = fix_path_env::fix();
 
     let ws_broadcaster = Arc::new(ws_bridge::WsBroadcaster::default());
+    let pty_gateway =
+        Arc::new(adaptor::gateway::pty_session::backend_impl::PtySessionRuntimeGateway::default());
+    let pty_gateway_for_setup = Arc::clone(&pty_gateway);
+    let pty_replay_reader: Arc<dyn usecase::pty_session::query_service::PtySessionReplayReader> =
+        Arc::new(
+            usecase::pty_session::query_service::PtySessionReplayQueryService::new(Arc::clone(
+                &pty_gateway,
+            )),
+        );
     let session_storage = Arc::new(adaptor::gateway::agent_session::FileSessionStorage::default());
     let session_store = Arc::new(usecase::agent_session::session::SessionStore::new(
         session_storage.clone(),
@@ -71,9 +80,8 @@ pub fn run() {
         .manage(Arc::new(review_comments::ReviewCommentStore::default()))
         .manage(session_store)
         .manage(prompt_suggestion_usecase)
-        .manage(Arc::new(
-            adaptor::gateway::pty_session::backend_impl::PtySessionRuntimeGateway::default(),
-        ))
+        .manage(Arc::clone(&pty_gateway))
+        .manage(pty_replay_reader)
         .manage(watcher::FileWatcherManager::default())
         .manage(Arc::clone(&ws_broadcaster))
         .manage(Arc::new(tokio::sync::Mutex::new(
@@ -89,6 +97,7 @@ pub fn run() {
             parking_lot::RwLock::new(Vec::new()),
         ))
         .setup(move |app| {
+            pty_gateway_for_setup.start_idle_sweeper(app.handle().clone());
             let data_dir = app.path().app_data_dir()?;
             app.manage(Arc::new(
                 adaptor::gateway::workspace_state::WorkspaceStateStore::new(data_dir.clone()),

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -10,7 +10,7 @@ pub use branch::*;
 pub use error::*;
 pub use worktree::*;
 
-use crate::adaptor::protocol::pty::{PtyExitMsg, PtyOutputMsg};
+use crate::adaptor::protocol::pty::{PtyEvictedMsg, PtyExitMsg, PtyOutputMsg};
 use crate::adaptor::protocol::workflow::WorkflowStateSync;
 use serde::{Deserialize, Serialize};
 
@@ -31,6 +31,8 @@ pub enum WsMessage {
     PtyOutput(PtyOutputMsg),
     #[serde(rename = "pty_exit")]
     PtyExit(PtyExitMsg),
+    #[serde(rename = "pty_evicted")]
+    PtyEvicted(PtyEvictedMsg),
 
     // Worktree / branch push
     #[serde(rename = "worktree_pr_status_sync")]
@@ -62,7 +64,9 @@ pub fn deserialize_message(json: &str) -> Result<WsMessage, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::adaptor::protocol::pty::{PtyExitMsg, PtyOutputMsg};
+    use crate::adaptor::protocol::pty::{
+        PtyEvictReasonMsg, PtyEvictedMsg, PtyExitMsg, PtyOutputMsg,
+    };
 
     #[test]
     fn serialize_auth_challenge() {
@@ -140,10 +144,16 @@ mod tests {
             WsMessage::PtyOutput(PtyOutputMsg {
                 pty_id: 1,
                 data: "d".to_string(),
+                sequence: 1,
             }),
             WsMessage::PtyExit(PtyExitMsg {
                 pty_id: 1,
                 exit_code: Some(0),
+            }),
+            WsMessage::PtyEvicted(PtyEvictedMsg {
+                pty_id: 1,
+                session_key: "key".to_string(),
+                reason: PtyEvictReasonMsg::Idle,
             }),
             WsMessage::WorktreePrStatusSync(WorktreePrStatusSync {
                 entries: vec![WorktreePrEntry {

--- a/src-tauri/src/usecase/pty_session/dto.rs
+++ b/src-tauri/src/usecase/pty_session/dto.rs
@@ -25,6 +25,24 @@ impl From<PtySessionSnapshot> for PtySessionInfo {
 pub struct FoundPtySession {
     pub snapshot: PtySessionSnapshot,
     pub buffered_output: String,
+    pub buffered_output_sequence: u64,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub struct GetPtyBufferedOutputResult {
+    pub pty_id: u64,
+    pub session_key: String,
+    pub buffered_output: String,
+    pub buffered_output_sequence: u64,
+    pub is_exited: bool,
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PtyReplayOutput {
+    pub pty_id: u64,
+    pub data: String,
+    pub sequence: u64,
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -32,6 +50,7 @@ pub struct GetOrSpawnPtyResult {
     pub pty_id: u64,
     pub session_key: String,
     pub buffered_output: String,
+    pub buffered_output_sequence: u64,
     pub is_new: bool,
     pub is_exited: bool,
     pub exit_code: Option<i32>,
@@ -57,6 +76,7 @@ mod tests {
             pty_id: 1,
             session_key: "key".to_string(),
             buffered_output: String::new(),
+            buffered_output_sequence: 0,
             is_new: true,
             is_exited: false,
             exit_code: None,

--- a/src-tauri/src/usecase/pty_session/error.rs
+++ b/src-tauri/src/usecase/pty_session/error.rs
@@ -1,11 +1,28 @@
+use crate::domain::pty_session::entities::PtySpawnReservationError;
+
 #[derive(Debug, thiserror::Error)]
 pub enum UsecaseError {
     #[error("{0}")]
     Gateway(String),
+    #[error("{0}")]
+    CapReached(String),
 }
 
 impl From<String> for UsecaseError {
     fn from(value: String) -> Self {
         Self::Gateway(value)
+    }
+}
+
+impl From<PtySpawnReservationError> for UsecaseError {
+    fn from(value: PtySpawnReservationError) -> Self {
+        match value {
+            PtySpawnReservationError::WorktreeCapReached(worktree_path) => {
+                Self::CapReached(format!("PTY cap reached for worktree {worktree_path}"))
+            }
+            PtySpawnReservationError::TotalCapReached => {
+                Self::CapReached("PTY total cap reached".to_string())
+            }
+        }
     }
 }

--- a/src-tauri/src/usecase/pty_session/lifecycle_usecase.rs
+++ b/src-tauri/src/usecase/pty_session/lifecycle_usecase.rs
@@ -1,7 +1,31 @@
+use crate::domain::pty_session::entities::PtySessionSnapshot;
+use crate::domain::pty_session::PtyEvictReason;
 use crate::usecase::pty_session::error::UsecaseError;
 use crate::usecase::pty_session::ports::PtySessionGateway;
 
 pub fn kill(manager: &impl PtySessionGateway, pty_id: u64) -> Result<(), UsecaseError> {
+    remove_and_kill(manager, pty_id)
+}
+
+pub fn evict<G: PtySessionGateway>(
+    manager: &G,
+    app: &G::AppContext,
+    pty_id: u64,
+    reason: PtyEvictReason,
+    now_ms: u64,
+) -> Result<Option<PtySessionSnapshot>, UsecaseError> {
+    let Some(snapshot) = manager.snapshot_if_idle_evictable(pty_id, now_ms) else {
+        return Ok(None);
+    };
+    if !snapshot.exited {
+        manager.kill_runtime(pty_id)?;
+    }
+    manager.remove_session(pty_id);
+    manager.emit_evicted(app, &snapshot, reason);
+    Ok(Some(snapshot))
+}
+
+fn remove_and_kill(manager: &impl PtySessionGateway, pty_id: u64) -> Result<(), UsecaseError> {
     let snapshot = manager
         .snapshot(pty_id)
         .ok_or_else(|| UsecaseError::Gateway(format!("PTY {} not found", pty_id)))?;
@@ -30,13 +54,307 @@ pub fn remove_if_exited(manager: &impl PtySessionGateway, pty_id: u64) {
     manager.remove_if_exited(pty_id);
 }
 
+pub fn register_active_terminal(
+    manager: &impl PtySessionGateway,
+    worktree_path: &str,
+    session_key: &str,
+    active_token: &str,
+) {
+    manager.register_active_terminal(worktree_path, session_key, active_token);
+}
+
+pub fn unregister_active_terminal(
+    manager: &impl PtySessionGateway,
+    worktree_path: &str,
+    session_key: &str,
+    active_token: &str,
+) {
+    manager.unregister_active_terminal(worktree_path, session_key, active_token);
+}
+
+pub fn sweep_idle<G: PtySessionGateway>(manager: &G, app: &G::AppContext, now_ms: u64) -> Vec<u64> {
+    let targets = manager.select_idle_timed_out(now_ms);
+    let mut evicted = Vec::with_capacity(targets.len());
+    for pty_id in targets {
+        match evict(manager, app, pty_id, PtyEvictReason::Idle, now_ms) {
+            Ok(Some(_)) => evicted.push(pty_id),
+            Ok(None) => {}
+            Err(e) => log::error!("Failed to evict idle PTY {}: {}", pty_id, e),
+        }
+    }
+    evicted
+}
+
 fn kill_targets(manager: &impl PtySessionGateway, targets: Vec<u64>) -> Vec<u64> {
     let mut killed = Vec::with_capacity(targets.len());
     for pty_id in targets {
-        match kill(manager, pty_id) {
+        match remove_and_kill(manager, pty_id) {
             Ok(()) => killed.push(pty_id),
             Err(e) => log::error!("Failed to kill PTY {}: {}", pty_id, e),
         }
     }
     killed
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::domain::pty_session::entities::{
+        PtySession, PtySessionSnapshot, PtySpawnReservation, PtySpawnReservationError,
+    };
+    use crate::domain::pty_session::PtyKind;
+    use crate::usecase::pty_session::dto::FoundPtySession;
+    use crate::usecase::pty_session::ports::{PtyBackendSpawnRequest, PtySessionReadGateway};
+
+    struct MockGateway {
+        snapshots: Mutex<Vec<PtySessionSnapshot>>,
+        idle_targets: Vec<u64>,
+        idle_evictable: Mutex<bool>,
+        fail_kill: Mutex<bool>,
+        killed: Mutex<Vec<u64>>,
+        removed: Mutex<Vec<u64>>,
+        emitted: Mutex<Vec<(u64, PtyEvictReason)>>,
+    }
+
+    impl MockGateway {
+        fn new(snapshot: PtySessionSnapshot) -> Self {
+            Self {
+                snapshots: Mutex::new(vec![snapshot]),
+                idle_targets: vec![1],
+                idle_evictable: Mutex::new(true),
+                fail_kill: Mutex::new(false),
+                killed: Mutex::new(Vec::new()),
+                removed: Mutex::new(Vec::new()),
+                emitted: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl PtySessionReadGateway for MockGateway {
+        fn find_by_session_key(&self, _session_key: &str) -> Option<FoundPtySession> {
+            None
+        }
+
+        fn list_snapshots(&self) -> Vec<PtySessionSnapshot> {
+            self.snapshots.lock().unwrap().clone()
+        }
+    }
+
+    impl PtySessionGateway for MockGateway {
+        type AppContext = ();
+        type Runtime = ();
+
+        fn next_pty_id(&self) -> u64 {
+            1
+        }
+
+        fn spawn_backend(
+            &self,
+            _app: &Self::AppContext,
+            _request: PtyBackendSpawnRequest,
+        ) -> Result<Self::Runtime, UsecaseError> {
+            Ok(())
+        }
+
+        fn insert_session(&self, _session: PtySession, _runtime: Self::Runtime) {}
+
+        fn start_output_reader(
+            &self,
+            _app: &Self::AppContext,
+            _pty_id: u64,
+        ) -> Result<(), UsecaseError> {
+            Ok(())
+        }
+
+        fn snapshot(&self, pty_id: u64) -> Option<PtySessionSnapshot> {
+            self.snapshots
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|snapshot| snapshot.pty_id == pty_id)
+                .cloned()
+        }
+
+        fn select_kill_targets_by_worktree(&self, _worktree_path: &str) -> Vec<u64> {
+            Vec::new()
+        }
+
+        fn select_gc_targets(
+            &self,
+            _worktree_path: &str,
+            _keep_session_keys: &[String],
+        ) -> Vec<u64> {
+            Vec::new()
+        }
+
+        fn remove_session(&self, pty_id: u64) -> Option<PtySessionSnapshot> {
+            self.removed.lock().unwrap().push(pty_id);
+            let mut snapshots = self.snapshots.lock().unwrap();
+            let index = snapshots
+                .iter()
+                .position(|snapshot| snapshot.pty_id == pty_id)?;
+            Some(snapshots.remove(index))
+        }
+
+        fn now_ms(&self) -> u64 {
+            200
+        }
+
+        fn record_activity(&self, _pty_id: u64, _now_ms: u64) -> bool {
+            true
+        }
+
+        fn pin_session_key(&self, _session_key: &str) {}
+
+        fn register_active_terminal(
+            &self,
+            _worktree_path: &str,
+            _session_key: &str,
+            _active_token: &str,
+        ) {
+        }
+
+        fn unregister_active_terminal(
+            &self,
+            _worktree_path: &str,
+            _session_key: &str,
+            _active_token: &str,
+        ) {
+        }
+
+        fn reserve_spawn_slot(
+            &self,
+            _worktree_path: Option<&str>,
+            _now_ms: u64,
+        ) -> Result<PtySpawnReservation, PtySpawnReservationError> {
+            Ok(PtySpawnReservation {
+                worktree_path: None,
+                evict_targets: Vec::new(),
+            })
+        }
+
+        fn complete_spawn_slot(&self, _reservation: &PtySpawnReservation) {}
+
+        fn rollback_spawn_slot(&self, _reservation: &PtySpawnReservation) {}
+
+        fn select_idle_timed_out(&self, _now_ms: u64) -> Vec<u64> {
+            *self.idle_evictable.lock().unwrap() = false;
+            self.idle_targets.clone()
+        }
+
+        fn snapshot_if_idle_evictable(
+            &self,
+            pty_id: u64,
+            _now_ms: u64,
+        ) -> Option<PtySessionSnapshot> {
+            if !*self.idle_evictable.lock().unwrap() {
+                return None;
+            }
+            self.snapshot(pty_id)
+        }
+
+        fn emit_evicted(
+            &self,
+            _app: &Self::AppContext,
+            snapshot: &PtySessionSnapshot,
+            reason: PtyEvictReason,
+        ) {
+            self.emitted.lock().unwrap().push((snapshot.pty_id, reason));
+        }
+
+        fn write(&self, _pty_id: u64, _data: &str) -> Result<(), UsecaseError> {
+            Ok(())
+        }
+
+        fn resize(&self, _pty_id: u64, _rows: u16, _cols: u16) -> Result<(), UsecaseError> {
+            Ok(())
+        }
+
+        fn get_pty_size(&self, _pty_id: u64) -> Result<(u16, u16), UsecaseError> {
+            Ok((80, 24))
+        }
+
+        fn kill_runtime(&self, pty_id: u64) -> Result<(), UsecaseError> {
+            self.killed.lock().unwrap().push(pty_id);
+            if *self.fail_kill.lock().unwrap() {
+                return Err(UsecaseError::Gateway("kill failed".to_string()));
+            }
+            Ok(())
+        }
+
+        fn remove_runtime(&self, _pty_id: u64) {}
+
+        fn remove_if_exited(&self, _pty_id: u64) {}
+    }
+
+    fn snapshot() -> PtySessionSnapshot {
+        PtySessionSnapshot {
+            pty_id: 1,
+            session_key: "key-1".to_string(),
+            worktree_path: Some("/repo".to_string()),
+            label: None,
+            kind: PtyKind::Terminal,
+            exited: false,
+            exit_code: None,
+        }
+    }
+
+    #[test]
+    fn sweep_idle_revalidates_target_before_kill() {
+        let gateway = MockGateway::new(snapshot());
+
+        let evicted = sweep_idle(&gateway, &(), 200);
+
+        assert!(evicted.is_empty());
+        assert!(gateway.killed.lock().unwrap().is_empty());
+        assert!(gateway.removed.lock().unwrap().is_empty());
+        assert!(gateway.emitted.lock().unwrap().is_empty());
+        assert!(gateway.snapshot(1).is_some());
+    }
+
+    #[test]
+    fn evict_removes_idle_target_then_kills_runtime_and_emits() {
+        let gateway = MockGateway::new(snapshot());
+
+        let removed = evict(&gateway, &(), 1, PtyEvictReason::Idle, 200)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(removed.pty_id, 1);
+        assert_eq!(*gateway.removed.lock().unwrap(), vec![1]);
+        assert_eq!(*gateway.killed.lock().unwrap(), vec![1]);
+        assert_eq!(
+            *gateway.emitted.lock().unwrap(),
+            vec![(1, PtyEvictReason::Idle)]
+        );
+        assert!(gateway.snapshot(1).is_none());
+    }
+
+    #[test]
+    fn evict_keeps_handles_when_kill_runtime_fails() {
+        let gateway = MockGateway::new(snapshot());
+        *gateway.fail_kill.lock().unwrap() = true;
+
+        let result = evict(&gateway, &(), 1, PtyEvictReason::Idle, 200);
+
+        assert!(matches!(result, Err(UsecaseError::Gateway(_))));
+        assert_eq!(*gateway.killed.lock().unwrap(), vec![1]);
+        assert!(gateway.removed.lock().unwrap().is_empty());
+        assert!(gateway.emitted.lock().unwrap().is_empty());
+        assert!(gateway.snapshot(1).is_some());
+
+        *gateway.fail_kill.lock().unwrap() = false;
+        let retry = evict(&gateway, &(), 1, PtyEvictReason::Idle, 200)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(retry.pty_id, 1);
+        assert_eq!(*gateway.removed.lock().unwrap(), vec![1]);
+        assert_eq!(
+            *gateway.emitted.lock().unwrap(),
+            vec![(1, PtyEvictReason::Idle)]
+        );
+    }
 }

--- a/src-tauri/src/usecase/pty_session/lifecycle_usecase.rs
+++ b/src-tauri/src/usecase/pty_session/lifecycle_usecase.rs
@@ -208,6 +208,8 @@ mod tests {
 
         fn pin_session_key(&self, _session_key: &str) {}
 
+        fn unpin_session_key_if_unused(&self, _session_key: &str) {}
+
         fn register_active_terminal(
             &self,
             _worktree_path: &str,

--- a/src-tauri/src/usecase/pty_session/ports.rs
+++ b/src-tauri/src/usecase/pty_session/ports.rs
@@ -1,4 +1,7 @@
-use crate::domain::pty_session::{entities::PtySession, entities::PtySessionSnapshot};
+use crate::domain::pty_session::{
+    entities::PtySession, entities::PtySessionSnapshot, entities::PtySpawnReservation,
+    entities::PtySpawnReservationError, PtyEvictReason,
+};
 use crate::usecase::pty_session::dto::FoundPtySession;
 use crate::usecase::pty_session::error::UsecaseError;
 
@@ -10,7 +13,12 @@ pub struct PtyBackendSpawnRequest {
     pub exec_command: Option<String>,
 }
 
-pub(crate) trait PtySessionGateway {
+pub(crate) trait PtySessionReadGateway {
+    fn find_by_session_key(&self, session_key: &str) -> Option<FoundPtySession>;
+    fn list_snapshots(&self) -> Vec<PtySessionSnapshot>;
+}
+
+pub(crate) trait PtySessionGateway: PtySessionReadGateway {
     type AppContext: ?Sized;
     type Runtime;
 
@@ -22,17 +30,41 @@ pub(crate) trait PtySessionGateway {
     ) -> Result<Self::Runtime, UsecaseError>;
     fn insert_session(&self, session: PtySession, runtime: Self::Runtime);
     fn start_output_reader(&self, app: &Self::AppContext, pty_id: u64) -> Result<(), UsecaseError>;
-    fn find_by_session_key(&self, session_key: &str) -> Option<FoundPtySession>;
     fn snapshot(&self, pty_id: u64) -> Option<PtySessionSnapshot>;
-    fn list_snapshots(&self) -> Vec<PtySessionSnapshot>;
     fn select_kill_targets_by_worktree(&self, worktree_path: &str) -> Vec<u64>;
     fn select_gc_targets(&self, worktree_path: &str, keep_session_keys: &[String]) -> Vec<u64>;
     fn remove_session(&self, pty_id: u64) -> Option<PtySessionSnapshot>;
+    fn now_ms(&self) -> u64;
+    fn record_activity(&self, pty_id: u64, now_ms: u64) -> bool;
+    fn pin_session_key(&self, session_key: &str);
+    fn register_active_terminal(&self, worktree_path: &str, session_key: &str, active_token: &str);
+    fn unregister_active_terminal(
+        &self,
+        worktree_path: &str,
+        session_key: &str,
+        active_token: &str,
+    );
+    fn reserve_spawn_slot(
+        &self,
+        worktree_path: Option<&str>,
+        now_ms: u64,
+    ) -> Result<PtySpawnReservation, PtySpawnReservationError>;
+    fn complete_spawn_slot(&self, reservation: &PtySpawnReservation);
+    fn rollback_spawn_slot(&self, reservation: &PtySpawnReservation);
+    fn select_idle_timed_out(&self, now_ms: u64) -> Vec<u64>;
+    fn snapshot_if_idle_evictable(&self, pty_id: u64, now_ms: u64) -> Option<PtySessionSnapshot>;
+    fn emit_evicted(
+        &self,
+        app: &Self::AppContext,
+        snapshot: &PtySessionSnapshot,
+        reason: PtyEvictReason,
+    );
 
     fn write(&self, pty_id: u64, data: &str) -> Result<(), UsecaseError>;
     fn resize(&self, pty_id: u64, rows: u16, cols: u16) -> Result<(), UsecaseError>;
     #[allow(dead_code)]
     fn get_pty_size(&self, pty_id: u64) -> Result<(u16, u16), UsecaseError>;
     fn kill_runtime(&self, pty_id: u64) -> Result<(), UsecaseError>;
+    fn remove_runtime(&self, pty_id: u64);
     fn remove_if_exited(&self, pty_id: u64);
 }

--- a/src-tauri/src/usecase/pty_session/ports.rs
+++ b/src-tauri/src/usecase/pty_session/ports.rs
@@ -37,6 +37,7 @@ pub(crate) trait PtySessionGateway: PtySessionReadGateway {
     fn now_ms(&self) -> u64;
     fn record_activity(&self, pty_id: u64, now_ms: u64) -> bool;
     fn pin_session_key(&self, session_key: &str);
+    fn unpin_session_key_if_unused(&self, session_key: &str);
     fn register_active_terminal(&self, worktree_path: &str, session_key: &str, active_token: &str);
     fn unregister_active_terminal(
         &self,

--- a/src-tauri/src/usecase/pty_session/query_service.rs
+++ b/src-tauri/src/usecase/pty_session/query_service.rs
@@ -1,10 +1,192 @@
-use crate::usecase::pty_session::dto::PtySessionInfo;
-use crate::usecase::pty_session::ports::PtySessionGateway;
+use std::sync::Arc;
 
-pub fn list(manager: &impl PtySessionGateway) -> Vec<PtySessionInfo> {
+use crate::domain::pty_session::PtyKind;
+use crate::usecase::pty_session::dto::{
+    GetPtyBufferedOutputResult, PtyReplayOutput, PtySessionInfo,
+};
+use crate::usecase::pty_session::error::UsecaseError;
+use crate::usecase::pty_session::ports::PtySessionReadGateway;
+
+pub fn list(manager: &impl PtySessionReadGateway) -> Vec<PtySessionInfo> {
     manager
         .list_snapshots()
         .into_iter()
         .map(PtySessionInfo::from)
         .collect()
+}
+
+pub fn get_buffered_output(
+    manager: &impl PtySessionReadGateway,
+    session_key: &str,
+    worktree_path: &str,
+) -> Result<GetPtyBufferedOutputResult, UsecaseError> {
+    let found = manager.find_by_session_key(session_key).ok_or_else(|| {
+        UsecaseError::Gateway(format!(
+            "PTY session {session_key} not found for worktree {worktree_path}"
+        ))
+    })?;
+
+    if found.snapshot.worktree_path.as_deref() != Some(worktree_path) {
+        return Err(UsecaseError::Gateway(format!(
+            "PTY session {session_key} not found for worktree {worktree_path}"
+        )));
+    }
+
+    Ok(GetPtyBufferedOutputResult {
+        pty_id: found.snapshot.pty_id,
+        session_key: found.snapshot.session_key,
+        buffered_output: found.buffered_output,
+        buffered_output_sequence: found.buffered_output_sequence,
+        is_exited: found.snapshot.exited,
+        exit_code: found.snapshot.exit_code,
+    })
+}
+
+pub(crate) trait PtySessionReplayReader: Send + Sync {
+    fn replay_outputs(&self) -> Vec<PtyReplayOutput>;
+}
+
+pub(crate) struct PtySessionReplayQueryService<G> {
+    gateway: Arc<G>,
+}
+
+impl<G> PtySessionReplayQueryService<G> {
+    pub(crate) fn new(gateway: Arc<G>) -> Self {
+        Self { gateway }
+    }
+}
+
+impl<G> PtySessionReplayReader for PtySessionReplayQueryService<G>
+where
+    G: PtySessionReadGateway + Send + Sync + 'static,
+{
+    fn replay_outputs(&self) -> Vec<PtyReplayOutput> {
+        replay_outputs(self.gateway.as_ref())
+    }
+}
+
+pub fn replay_outputs(manager: &impl PtySessionReadGateway) -> Vec<PtyReplayOutput> {
+    manager
+        .list_snapshots()
+        .into_iter()
+        .filter(|snapshot| !snapshot.exited && snapshot.kind == PtyKind::Terminal)
+        .filter_map(|snapshot| {
+            let found = manager.find_by_session_key(&snapshot.session_key)?;
+            if found.buffered_output.is_empty() {
+                return None;
+            }
+            Some(PtyReplayOutput {
+                pty_id: snapshot.pty_id,
+                data: found.buffered_output,
+                sequence: found.buffered_output_sequence,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::domain::pty_session::entities::PtySessionSnapshot;
+    use crate::usecase::pty_session::dto::FoundPtySession;
+
+    struct MockGateway {
+        snapshots: Vec<PtySessionSnapshot>,
+        outputs: HashMap<String, String>,
+    }
+
+    impl MockGateway {
+        fn new(snapshots: Vec<PtySessionSnapshot>, outputs: HashMap<String, String>) -> Self {
+            Self { snapshots, outputs }
+        }
+    }
+
+    impl PtySessionReadGateway for MockGateway {
+        fn find_by_session_key(&self, session_key: &str) -> Option<FoundPtySession> {
+            let snapshot = self
+                .snapshots
+                .iter()
+                .find(|snapshot| snapshot.session_key == session_key)?
+                .clone();
+            Some(FoundPtySession {
+                snapshot,
+                buffered_output: self.outputs.get(session_key).cloned().unwrap_or_default(),
+                buffered_output_sequence: 5,
+            })
+        }
+
+        fn list_snapshots(&self) -> Vec<PtySessionSnapshot> {
+            self.snapshots.clone()
+        }
+    }
+
+    fn snapshot(pty_id: u64, session_key: &str, kind: PtyKind, exited: bool) -> PtySessionSnapshot {
+        PtySessionSnapshot {
+            pty_id,
+            session_key: session_key.to_string(),
+            worktree_path: Some("/repo".to_string()),
+            label: None,
+            kind,
+            exited,
+            exit_code: None,
+        }
+    }
+
+    #[test]
+    fn replay_outputs_include_only_alive_terminal_sessions_with_buffered_output() {
+        let gateway = MockGateway::new(
+            vec![
+                snapshot(1, "terminal", PtyKind::Terminal, false),
+                snapshot(2, "empty", PtyKind::Terminal, false),
+                snapshot(3, "oneshot", PtyKind::OneShot, false),
+                snapshot(4, "exited", PtyKind::Terminal, true),
+            ],
+            HashMap::from([
+                ("terminal".to_string(), "buffered".to_string()),
+                ("empty".to_string(), String::new()),
+                ("oneshot".to_string(), "ignored".to_string()),
+                ("exited".to_string(), "ignored".to_string()),
+            ]),
+        );
+
+        assert_eq!(
+            replay_outputs(&gateway),
+            vec![PtyReplayOutput {
+                pty_id: 1,
+                data: "buffered".to_string(),
+                sequence: 5,
+            }]
+        );
+    }
+
+    #[test]
+    fn get_buffered_output_returns_snapshot_for_matching_worktree() {
+        let gateway = MockGateway::new(
+            vec![snapshot(7, "terminal", PtyKind::Terminal, false)],
+            HashMap::from([("terminal".to_string(), "buffered".to_string())]),
+        );
+
+        let output = get_buffered_output(&gateway, "terminal", "/repo").unwrap();
+
+        assert_eq!(output.pty_id, 7);
+        assert_eq!(output.session_key, "terminal");
+        assert_eq!(output.buffered_output, "buffered");
+        assert_eq!(output.buffered_output_sequence, 5);
+        assert!(!output.is_exited);
+        assert_eq!(output.exit_code, None);
+    }
+
+    #[test]
+    fn get_buffered_output_rejects_other_worktree() {
+        let gateway = MockGateway::new(
+            vec![snapshot(7, "terminal", PtyKind::Terminal, false)],
+            HashMap::from([("terminal".to_string(), "buffered".to_string())]),
+        );
+
+        let result = get_buffered_output(&gateway, "terminal", "/other");
+
+        assert!(matches!(result, Err(UsecaseError::Gateway(_))));
+    }
 }

--- a/src-tauri/src/usecase/pty_session/spawn_usecase.rs
+++ b/src-tauri/src/usecase/pty_session/spawn_usecase.rs
@@ -1,4 +1,4 @@
-use crate::domain::pty_session::{entities::PtySession, PtyKind};
+use crate::domain::pty_session::{entities::PtySession, PtyEvictReason, PtyKind};
 use crate::usecase::pty_session::dto::{pty_kind_to_wire, GetOrSpawnPtyResult};
 use crate::usecase::pty_session::error::UsecaseError;
 use crate::usecase::pty_session::ports::{PtyBackendSpawnRequest, PtySessionGateway};
@@ -14,9 +14,13 @@ pub fn spawn<G: PtySessionGateway>(
     label: Option<String>,
     kind: PtyKind,
 ) -> Result<(u64, String), UsecaseError> {
+    let reservation = manager
+        .reserve_spawn_slot(worktree_path.as_deref(), manager.now_ms())
+        .map_err(UsecaseError::from)?;
+
     let pty_id = manager.next_pty_id();
     let session_key = uuid::Uuid::new_v4().to_string();
-    let runtime = manager.spawn_backend(
+    let runtime = match manager.spawn_backend(
         app,
         PtyBackendSpawnRequest {
             pty_id,
@@ -25,15 +29,62 @@ pub fn spawn<G: PtySessionGateway>(
             cwd,
             exec_command: None,
         },
-    )?;
+    ) {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            manager.rollback_spawn_slot(&reservation);
+            return Err(error);
+        }
+    };
 
     manager.insert_session(
         PtySession::new(pty_id, session_key.clone(), worktree_path, label, kind),
         runtime,
     );
-    manager.start_output_reader(app, pty_id)?;
+    manager.record_activity(pty_id, manager.now_ms());
+    manager.pin_session_key(&session_key);
+    if let Err(error) = manager.start_output_reader(app, pty_id) {
+        cleanup_failed_spawn(manager, pty_id);
+        manager.rollback_spawn_slot(&reservation);
+        return Err(error);
+    }
+
+    for target in reservation.evict_targets.clone() {
+        match crate::usecase::pty_session::lifecycle_usecase::evict(
+            manager,
+            app,
+            target,
+            PtyEvictReason::CapExceeded,
+            manager.now_ms(),
+        ) {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                cleanup_failed_spawn(manager, pty_id);
+                manager.rollback_spawn_slot(&reservation);
+                return Err(UsecaseError::CapReached(
+                    "PTY cap reached; eviction target is no longer idle".to_string(),
+                ));
+            }
+            Err(error) => {
+                cleanup_failed_spawn(manager, pty_id);
+                manager.rollback_spawn_slot(&reservation);
+                return Err(error);
+            }
+        }
+    }
+
+    manager.complete_spawn_slot(&reservation);
 
     Ok((pty_id, session_key))
+}
+
+fn cleanup_failed_spawn(manager: &impl PtySessionGateway, pty_id: u64) {
+    if manager.snapshot(pty_id).is_some() {
+        let _ = manager.kill_runtime(pty_id);
+        manager.remove_session(pty_id);
+    } else {
+        manager.remove_runtime(pty_id);
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -50,10 +101,19 @@ pub fn get_or_spawn<G: PtySessionGateway>(
 ) -> Result<GetOrSpawnPtyResult, UsecaseError> {
     if let Some(key) = &session_key {
         if let Some(found) = manager.find_by_session_key(key) {
+            if found.snapshot.worktree_path.as_deref() != Some(worktree_path.as_str()) {
+                return Err(UsecaseError::Gateway(format!(
+                    "PTY session {} not found for worktree {}",
+                    key, worktree_path
+                )));
+            }
+            manager.record_activity(found.snapshot.pty_id, manager.now_ms());
+            manager.pin_session_key(&found.snapshot.session_key);
             return Ok(GetOrSpawnPtyResult {
                 pty_id: found.snapshot.pty_id,
                 session_key: found.snapshot.session_key,
                 buffered_output: found.buffered_output,
+                buffered_output_sequence: found.buffered_output_sequence,
                 is_new: false,
                 is_exited: found.snapshot.exited,
                 exit_code: found.snapshot.exit_code,
@@ -78,10 +138,540 @@ pub fn get_or_spawn<G: PtySessionGateway>(
         pty_id,
         session_key: new_session_key,
         buffered_output: String::new(),
+        buffered_output_sequence: 0,
         is_new: true,
         is_exited: false,
         exit_code: None,
         label,
         kind: pty_kind_to_wire(kind).to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::domain::pty_session::entities::{
+        PtySessionRegistry, PtySessionSnapshot, PtySpawnReservation, PtySpawnReservationError,
+    };
+    use crate::domain::pty_session::PtyLifecycleConfig;
+    use crate::usecase::pty_session::dto::FoundPtySession;
+    use crate::usecase::pty_session::ports::PtySessionReadGateway;
+
+    struct MockGateway {
+        registry: Mutex<PtySessionRegistry>,
+        now_ms: AtomicU64,
+        fail_spawn: AtomicBool,
+        fail_start_reader: AtomicBool,
+        pin_reserved_after_reserve: AtomicBool,
+        spawn_count: Mutex<usize>,
+        killed: Mutex<Vec<u64>>,
+        emitted: Mutex<Vec<(u64, PtyEvictReason)>>,
+    }
+
+    impl MockGateway {
+        fn new() -> Self {
+            Self {
+                registry: Mutex::new(PtySessionRegistry::with_config(PtyLifecycleConfig {
+                    per_worktree_cap: 2,
+                    max_panes_total: 3,
+                    idle_timeout: Duration::from_millis(100),
+                    output_buffer_cap: 64 * 1024,
+                    sweep_interval: Duration::from_secs(60),
+                })),
+                now_ms: AtomicU64::new(200),
+                fail_spawn: AtomicBool::new(false),
+                fail_start_reader: AtomicBool::new(false),
+                pin_reserved_after_reserve: AtomicBool::new(false),
+                spawn_count: Mutex::new(0),
+                killed: Mutex::new(Vec::new()),
+                emitted: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn insert_session_with_activity(
+            &self,
+            session_key: &str,
+            worktree_path: &str,
+            activity_ms: u64,
+        ) -> u64 {
+            let mut registry = self.registry.lock().unwrap();
+            let pty_id = registry.next_pty_id();
+            registry.insert(PtySession::new(
+                pty_id,
+                session_key.to_string(),
+                Some(worktree_path.to_string()),
+                None,
+                PtyKind::Terminal,
+            ));
+            registry.record_activity(pty_id, activity_ms);
+            pty_id
+        }
+
+        fn is_pinned(&self, pty_id: u64) -> bool {
+            self.registry.lock().unwrap().is_pinned(pty_id)
+        }
+    }
+
+    impl PtySessionReadGateway for MockGateway {
+        fn find_by_session_key(&self, session_key: &str) -> Option<FoundPtySession> {
+            let snapshot = self
+                .registry
+                .lock()
+                .unwrap()
+                .find_by_session_key(session_key)
+                .map(PtySession::snapshot)?;
+            Some(FoundPtySession {
+                snapshot,
+                buffered_output: "buffered".to_string(),
+                buffered_output_sequence: 9,
+            })
+        }
+
+        fn list_snapshots(&self) -> Vec<PtySessionSnapshot> {
+            self.registry.lock().unwrap().list_snapshots()
+        }
+    }
+
+    impl PtySessionGateway for MockGateway {
+        type AppContext = ();
+        type Runtime = ();
+
+        fn next_pty_id(&self) -> u64 {
+            self.registry.lock().unwrap().next_pty_id()
+        }
+
+        fn spawn_backend(
+            &self,
+            _app: &Self::AppContext,
+            _request: PtyBackendSpawnRequest,
+        ) -> Result<Self::Runtime, UsecaseError> {
+            *self.spawn_count.lock().unwrap() += 1;
+            if self.fail_spawn.load(Ordering::SeqCst) {
+                return Err(UsecaseError::Gateway("spawn failed".to_string()));
+            }
+            Ok(())
+        }
+
+        fn insert_session(&self, session: PtySession, _runtime: Self::Runtime) {
+            self.registry.lock().unwrap().insert(session);
+        }
+
+        fn start_output_reader(
+            &self,
+            _app: &Self::AppContext,
+            _pty_id: u64,
+        ) -> Result<(), UsecaseError> {
+            if self.fail_start_reader.load(Ordering::SeqCst) {
+                return Err(UsecaseError::Gateway("reader failed".to_string()));
+            }
+            Ok(())
+        }
+
+        fn snapshot(&self, pty_id: u64) -> Option<PtySessionSnapshot> {
+            self.registry
+                .lock()
+                .unwrap()
+                .get(pty_id)
+                .map(PtySession::snapshot)
+        }
+
+        fn select_kill_targets_by_worktree(&self, worktree_path: &str) -> Vec<u64> {
+            self.registry
+                .lock()
+                .unwrap()
+                .select_kill_targets_by_worktree(worktree_path)
+        }
+
+        fn select_gc_targets(&self, worktree_path: &str, keep_session_keys: &[String]) -> Vec<u64> {
+            self.registry
+                .lock()
+                .unwrap()
+                .select_gc_targets(worktree_path, keep_session_keys)
+        }
+
+        fn remove_session(&self, pty_id: u64) -> Option<PtySessionSnapshot> {
+            self.registry
+                .lock()
+                .unwrap()
+                .remove(pty_id)
+                .map(|session| session.snapshot())
+        }
+
+        fn now_ms(&self) -> u64 {
+            self.now_ms.load(Ordering::SeqCst)
+        }
+
+        fn record_activity(&self, pty_id: u64, now_ms: u64) -> bool {
+            self.registry
+                .lock()
+                .unwrap()
+                .record_activity(pty_id, now_ms)
+        }
+
+        fn pin_session_key(&self, session_key: &str) {
+            self.registry.lock().unwrap().pin_session_key(session_key);
+        }
+
+        fn register_active_terminal(
+            &self,
+            worktree_path: &str,
+            session_key: &str,
+            active_token: &str,
+        ) {
+            self.registry.lock().unwrap().register_active_terminal(
+                worktree_path,
+                session_key,
+                active_token,
+            );
+        }
+
+        fn unregister_active_terminal(
+            &self,
+            worktree_path: &str,
+            session_key: &str,
+            active_token: &str,
+        ) {
+            self.registry.lock().unwrap().unregister_active_terminal(
+                worktree_path,
+                session_key,
+                active_token,
+            );
+        }
+
+        fn reserve_spawn_slot(
+            &self,
+            worktree_path: Option<&str>,
+            now_ms: u64,
+        ) -> Result<PtySpawnReservation, PtySpawnReservationError> {
+            let mut registry = self.registry.lock().unwrap();
+            let reservation = registry.reserve_spawn_slot(worktree_path, now_ms)?;
+            if self.pin_reserved_after_reserve.load(Ordering::SeqCst) {
+                for target in &reservation.evict_targets {
+                    if let Some(session_key) = registry
+                        .get(*target)
+                        .map(|session| session.session_key.clone())
+                    {
+                        registry.pin_session_key(&session_key);
+                    }
+                }
+            }
+            Ok(reservation)
+        }
+
+        fn complete_spawn_slot(&self, reservation: &PtySpawnReservation) {
+            self.registry
+                .lock()
+                .unwrap()
+                .complete_spawn_slot(reservation);
+        }
+
+        fn rollback_spawn_slot(&self, reservation: &PtySpawnReservation) {
+            self.registry
+                .lock()
+                .unwrap()
+                .rollback_spawn_slot(reservation);
+        }
+
+        fn select_idle_timed_out(&self, now_ms: u64) -> Vec<u64> {
+            self.registry.lock().unwrap().select_idle_timed_out(now_ms)
+        }
+
+        fn snapshot_if_idle_evictable(
+            &self,
+            pty_id: u64,
+            now_ms: u64,
+        ) -> Option<PtySessionSnapshot> {
+            self.registry
+                .lock()
+                .unwrap()
+                .snapshot_if_idle_evictable(pty_id, now_ms)
+        }
+
+        fn emit_evicted(
+            &self,
+            _app: &Self::AppContext,
+            snapshot: &PtySessionSnapshot,
+            reason: PtyEvictReason,
+        ) {
+            self.emitted.lock().unwrap().push((snapshot.pty_id, reason));
+        }
+
+        fn write(&self, _pty_id: u64, _data: &str) -> Result<(), UsecaseError> {
+            Ok(())
+        }
+
+        fn resize(&self, _pty_id: u64, _rows: u16, _cols: u16) -> Result<(), UsecaseError> {
+            Ok(())
+        }
+
+        fn get_pty_size(&self, _pty_id: u64) -> Result<(u16, u16), UsecaseError> {
+            Ok((80, 24))
+        }
+
+        fn kill_runtime(&self, pty_id: u64) -> Result<(), UsecaseError> {
+            self.killed.lock().unwrap().push(pty_id);
+            Ok(())
+        }
+
+        fn remove_runtime(&self, _pty_id: u64) {}
+
+        fn remove_if_exited(&self, pty_id: u64) {
+            if self
+                .snapshot(pty_id)
+                .is_some_and(|snapshot| snapshot.exited)
+            {
+                self.remove_session(pty_id);
+            }
+        }
+    }
+
+    #[test]
+    fn get_or_spawn_spawns_when_caps_are_not_reached() {
+        let gateway = MockGateway::new();
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            None,
+            "/repo".to_string(),
+            Some("dev".to_string()),
+            PtyKind::Terminal,
+        )
+        .unwrap();
+
+        assert!(result.is_new);
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 1);
+        assert!(gateway.is_pinned(result.pty_id));
+    }
+
+    #[test]
+    fn cap_reached_evicts_oldest_idle_worktree_session_before_spawn() {
+        let gateway = MockGateway::new();
+        let first = gateway.insert_session_with_activity("key-1", "/repo", 0);
+        let second = gateway.insert_session_with_activity("key-2", "/repo", 50);
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            None,
+            "/repo".to_string(),
+            None,
+            PtyKind::Terminal,
+        )
+        .unwrap();
+
+        assert!(result.is_new);
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 1);
+        assert_eq!(*gateway.killed.lock().unwrap(), vec![first]);
+        assert_eq!(
+            *gateway.emitted.lock().unwrap(),
+            vec![(first, PtyEvictReason::CapExceeded)]
+        );
+        assert!(gateway.snapshot(first).is_none());
+        assert!(gateway.snapshot(second).is_some());
+    }
+
+    #[test]
+    fn cap_reached_without_idle_candidate_returns_cap_reached() {
+        let gateway = MockGateway::new();
+        gateway.insert_session_with_activity("key-1", "/repo", 150);
+        gateway.insert_session_with_activity("key-2", "/repo", 160);
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            None,
+            "/repo".to_string(),
+            None,
+            PtyKind::Terminal,
+        );
+
+        assert!(matches!(result, Err(UsecaseError::CapReached(_))));
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 0);
+        assert!(gateway.killed.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn cap_reached_does_not_evict_reserved_target_that_became_pinned() {
+        let gateway = MockGateway::new();
+        let first = gateway.insert_session_with_activity("key-1", "/repo", 0);
+        let second = gateway.insert_session_with_activity("key-2", "/repo", 50);
+        gateway
+            .pin_reserved_after_reserve
+            .store(true, Ordering::SeqCst);
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            None,
+            "/repo".to_string(),
+            None,
+            PtyKind::Terminal,
+        );
+
+        assert!(matches!(result, Err(UsecaseError::CapReached(_))));
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 1);
+        assert_eq!(*gateway.killed.lock().unwrap(), vec![3]);
+        assert!(gateway.emitted.lock().unwrap().is_empty());
+        assert!(gateway.snapshot(first).is_some());
+        assert!(gateway.snapshot(second).is_some());
+        assert!(gateway.is_pinned(first));
+        assert!(gateway.snapshot(3).is_none());
+    }
+
+    #[test]
+    fn spawn_failure_rolls_back_reserved_slot() {
+        let gateway = MockGateway::new();
+        gateway.fail_spawn.store(true, Ordering::SeqCst);
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            None,
+            "/repo".to_string(),
+            None,
+            PtyKind::Terminal,
+        );
+
+        assert!(matches!(result, Err(UsecaseError::Gateway(_))));
+        gateway.fail_spawn.store(false, Ordering::SeqCst);
+
+        let retry = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            None,
+            "/repo".to_string(),
+            None,
+            PtyKind::Terminal,
+        )
+        .unwrap();
+
+        assert!(retry.is_new);
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 2);
+    }
+
+    #[test]
+    fn cap_reached_spawn_failure_preserves_reserved_evict_target() {
+        let gateway = MockGateway::new();
+        let first = gateway.insert_session_with_activity("key-1", "/repo", 0);
+        let second = gateway.insert_session_with_activity("key-2", "/repo", 50);
+        gateway.fail_spawn.store(true, Ordering::SeqCst);
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            None,
+            "/repo".to_string(),
+            None,
+            PtyKind::Terminal,
+        );
+
+        assert!(matches!(result, Err(UsecaseError::Gateway(_))));
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 1);
+        assert!(gateway.killed.lock().unwrap().is_empty());
+        assert!(gateway.emitted.lock().unwrap().is_empty());
+        assert!(gateway.snapshot(first).is_some());
+        assert!(gateway.snapshot(second).is_some());
+    }
+
+    #[test]
+    fn start_reader_failure_cleans_up_new_session_and_preserves_evict_target() {
+        let gateway = MockGateway::new();
+        let first = gateway.insert_session_with_activity("key-1", "/repo", 0);
+        let second = gateway.insert_session_with_activity("key-2", "/repo", 50);
+        gateway.fail_start_reader.store(true, Ordering::SeqCst);
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            None,
+            "/repo".to_string(),
+            None,
+            PtyKind::Terminal,
+        );
+
+        assert!(matches!(result, Err(UsecaseError::Gateway(_))));
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 1);
+        assert_eq!(*gateway.killed.lock().unwrap(), vec![3]);
+        assert!(gateway.emitted.lock().unwrap().is_empty());
+        assert!(gateway.snapshot(first).is_some());
+        assert!(gateway.snapshot(second).is_some());
+        assert!(gateway.snapshot(3).is_none());
+    }
+
+    #[test]
+    fn existing_session_key_replays_buffer_and_does_not_spawn() {
+        let gateway = MockGateway::new();
+        let pty_id = gateway.insert_session_with_activity("key-1", "/repo", 0);
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            Some("key-1".to_string()),
+            "/repo".to_string(),
+            None,
+            PtyKind::Terminal,
+        )
+        .unwrap();
+
+        assert!(!result.is_new);
+        assert_eq!(result.pty_id, pty_id);
+        assert_eq!(result.buffered_output, "buffered");
+        assert_eq!(result.buffered_output_sequence, 9);
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 0);
+        assert!(gateway.is_pinned(pty_id));
+    }
+
+    #[test]
+    fn existing_session_key_for_other_worktree_is_rejected_without_replay_or_spawn() {
+        let gateway = MockGateway::new();
+        let pty_id = gateway.insert_session_with_activity("key-1", "/repo", 0);
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/other".to_string()),
+            Some("key-1".to_string()),
+            "/other".to_string(),
+            None,
+            PtyKind::Terminal,
+        );
+
+        assert!(matches!(result, Err(UsecaseError::Gateway(_))));
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 0);
+        assert!(!gateway.is_pinned(pty_id));
+    }
 }

--- a/src-tauri/src/usecase/pty_session/spawn_usecase.rs
+++ b/src-tauri/src/usecase/pty_session/spawn_usecase.rs
@@ -79,9 +79,20 @@ pub fn spawn<G: PtySessionGateway>(
 }
 
 fn cleanup_failed_spawn(manager: &impl PtySessionGateway, pty_id: u64) {
-    if manager.snapshot(pty_id).is_some() {
-        let _ = manager.kill_runtime(pty_id);
-        manager.remove_session(pty_id);
+    if let Some(snapshot) = manager.snapshot(pty_id) {
+        match manager.kill_runtime(pty_id) {
+            Ok(()) => {
+                manager.remove_session(pty_id);
+            }
+            Err(error) => {
+                manager.unpin_session_key_if_unused(&snapshot.session_key);
+                log::error!(
+                    "Failed to kill PTY {} during failed spawn cleanup: {}",
+                    pty_id,
+                    error
+                );
+            }
+        }
     } else {
         manager.remove_runtime(pty_id);
     }
@@ -166,6 +177,7 @@ mod tests {
         now_ms: AtomicU64,
         fail_spawn: AtomicBool,
         fail_start_reader: AtomicBool,
+        fail_kill_runtime: AtomicBool,
         pin_reserved_after_reserve: AtomicBool,
         spawn_count: Mutex<usize>,
         killed: Mutex<Vec<u64>>,
@@ -185,6 +197,7 @@ mod tests {
                 now_ms: AtomicU64::new(200),
                 fail_spawn: AtomicBool::new(false),
                 fail_start_reader: AtomicBool::new(false),
+                fail_kill_runtime: AtomicBool::new(false),
                 pin_reserved_after_reserve: AtomicBool::new(false),
                 spawn_count: Mutex::new(0),
                 killed: Mutex::new(Vec::new()),
@@ -316,6 +329,13 @@ mod tests {
             self.registry.lock().unwrap().pin_session_key(session_key);
         }
 
+        fn unpin_session_key_if_unused(&self, session_key: &str) {
+            self.registry
+                .lock()
+                .unwrap()
+                .unpin_session_key_if_unused(session_key);
+        }
+
         fn register_active_terminal(
             &self,
             worktree_path: &str,
@@ -414,6 +434,9 @@ mod tests {
 
         fn kill_runtime(&self, pty_id: u64) -> Result<(), UsecaseError> {
             self.killed.lock().unwrap().push(pty_id);
+            if self.fail_kill_runtime.load(Ordering::SeqCst) {
+                return Err(UsecaseError::Gateway("kill failed".to_string()));
+            }
             Ok(())
         }
 
@@ -625,6 +648,43 @@ mod tests {
         assert!(gateway.snapshot(first).is_some());
         assert!(gateway.snapshot(second).is_some());
         assert!(gateway.snapshot(3).is_none());
+    }
+
+    #[test]
+    fn start_reader_failure_keeps_new_session_evictable_when_cleanup_kill_fails() {
+        let gateway = MockGateway::new();
+        gateway.fail_start_reader.store(true, Ordering::SeqCst);
+        gateway.fail_kill_runtime.store(true, Ordering::SeqCst);
+
+        let result = get_or_spawn(
+            &gateway,
+            &(),
+            24,
+            80,
+            Some("/repo".to_string()),
+            None,
+            "/repo".to_string(),
+            None,
+            PtyKind::Terminal,
+        );
+
+        assert!(matches!(
+            result,
+            Err(UsecaseError::Gateway(message)) if message == "reader failed"
+        ));
+        assert_eq!(*gateway.spawn_count.lock().unwrap(), 1);
+        assert_eq!(*gateway.killed.lock().unwrap(), vec![1]);
+        assert!(gateway.snapshot(1).is_some());
+        assert!(!gateway.is_pinned(1));
+        assert_eq!(gateway.select_idle_timed_out(300), vec![1]);
+
+        gateway.fail_kill_runtime.store(false, Ordering::SeqCst);
+        let evicted =
+            crate::usecase::pty_session::lifecycle_usecase::sweep_idle(&gateway, &(), 300);
+
+        assert_eq!(evicted, vec![1]);
+        assert_eq!(*gateway.killed.lock().unwrap(), vec![1, 1]);
+        assert!(gateway.snapshot(1).is_none());
     }
 
     #[test]

--- a/src-tauri/src/ws_bridge.rs
+++ b/src-tauri/src/ws_bridge.rs
@@ -1,16 +1,13 @@
 use crate::protocol::{AgentStreamSync, WsMessage};
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, Notify};
 
 pub type WsSender = mpsc::UnboundedSender<WsMessage>;
 pub type WsReceiver = mpsc::UnboundedReceiver<WsMessage>;
 
-const PTY_OUTPUT_BUFFER_SIZE: usize = 64 * 1024;
-
 pub struct WsBroadcaster {
     sender: Mutex<Option<WsSender>>,
-    pty_output_buffers: Mutex<HashMap<u64, VecDeque<u8>>>,
     /// Latest cumulative `AgentStreamSync` snapshot per
     /// `(chat_session_id, message_id)`. The producer writes a fresh snapshot
     /// here on every flush; the consumer drains the slot when woken. This
@@ -29,7 +26,6 @@ impl Default for WsBroadcaster {
     fn default() -> Self {
         Self {
             sender: Mutex::new(None),
-            pty_output_buffers: Mutex::new(HashMap::new()),
             latest_stream_sync: Mutex::new(HashMap::new()),
             stream_sync_notify: Arc::new(Notify::new()),
         }
@@ -38,38 +34,9 @@ impl Default for WsBroadcaster {
 
 impl WsBroadcaster {
     pub fn try_send(&self, msg: WsMessage) {
-        if let WsMessage::PtyOutput(ref pty) = msg {
-            let mut buffers = self
-                .pty_output_buffers
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let buf = buffers.entry(pty.pty_id).or_default();
-            for byte in pty.data.as_bytes() {
-                if buf.len() >= PTY_OUTPUT_BUFFER_SIZE {
-                    buf.pop_front();
-                }
-                buf.push_back(*byte);
-            }
-        }
-
         let guard = self.sender.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(sender) = guard.as_ref() {
             let _ = sender.send(msg);
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn get_pty_output_buffer(&self, pty_id: u64) -> String {
-        let buffers = self
-            .pty_output_buffers
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        match buffers.get(&pty_id) {
-            Some(buf) => {
-                let bytes: Vec<u8> = buf.iter().copied().collect();
-                String::from_utf8_lossy(&bytes).to_string()
-            }
-            None => String::new(),
         }
     }
 
@@ -78,7 +45,6 @@ impl WsBroadcaster {
     /// when no sender is registered (no WS client to satisfy — not a failure),
     /// and `false` only when the sender is registered but `send` failed
     /// (i.e. the receiver was dropped).
-    #[allow(dead_code)]
     pub fn send_without_buffer(&self, msg: WsMessage) -> bool {
         let guard = self.sender.lock().unwrap_or_else(|e| e.into_inner());
         match guard.as_ref() {
@@ -170,12 +136,11 @@ impl WsBroadcaster {
         }
     }
 
-    pub fn remove_pty_output_buffer(&self, pty_id: u64) {
-        let mut buffers = self
-            .pty_output_buffers
+    pub fn has_subscriber(&self) -> bool {
+        self.sender
             .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        buffers.remove(&pty_id);
+            .unwrap_or_else(|e| e.into_inner())
+            .is_some()
     }
 
     pub fn create_channel() -> (WsSender, WsReceiver) {
@@ -189,131 +154,69 @@ mod tests {
     use crate::adaptor::protocol::pty::PtyOutputMsg;
 
     #[test]
-    fn empty_buffer_returns_empty_string() {
+    fn has_subscriber_tracks_registered_sender() {
         let broadcaster = WsBroadcaster::default();
-        assert_eq!(broadcaster.get_pty_output_buffer(1), "");
+        assert!(!broadcaster.has_subscriber());
+
+        let (tx, _rx) = WsBroadcaster::create_channel();
+        broadcaster.set_sender(Some(tx));
+        assert!(broadcaster.has_subscriber());
+
+        broadcaster.set_sender(None);
+        assert!(!broadcaster.has_subscriber());
     }
 
     #[test]
-    fn buffer_accumulates_pty_output() {
-        let broadcaster = WsBroadcaster::default();
-        broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
-            pty_id: 1,
-            data: "hello".to_string(),
-        }));
-        broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
-            pty_id: 1,
-            data: " world".to_string(),
-        }));
-        assert_eq!(broadcaster.get_pty_output_buffer(1), "hello world");
-    }
-
-    #[test]
-    fn buffer_ring_evicts_oldest_bytes() {
-        let broadcaster = WsBroadcaster::default();
-        let chunk = "A".repeat(PTY_OUTPUT_BUFFER_SIZE);
-        broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
-            pty_id: 1,
-            data: chunk,
-        }));
-        broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
-            pty_id: 1,
-            data: "B".to_string(),
-        }));
-        let buf = broadcaster.get_pty_output_buffer(1);
-        assert_eq!(buf.len(), PTY_OUTPUT_BUFFER_SIZE);
-        assert!(buf.starts_with('A'));
-        assert!(buf.ends_with('B'));
-    }
-
-    #[test]
-    fn non_pty_output_does_not_affect_buffer() {
-        let broadcaster = WsBroadcaster::default();
-        broadcaster.try_send(WsMessage::Error(crate::protocol::ErrorMsg {
-            code: "TEST".to_string(),
-            message: "test".to_string(),
-        }));
-        assert_eq!(broadcaster.get_pty_output_buffer(1), "");
-    }
-
-    #[test]
-    fn separate_buffers_per_pty_id() {
-        let broadcaster = WsBroadcaster::default();
-        broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
-            pty_id: 1,
-            data: "aaa".to_string(),
-        }));
-        broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
-            pty_id: 2,
-            data: "bbb".to_string(),
-        }));
-        assert_eq!(broadcaster.get_pty_output_buffer(1), "aaa");
-        assert_eq!(broadcaster.get_pty_output_buffer(2), "bbb");
-    }
-
-    #[test]
-    fn remove_pty_output_buffer_clears_entry() {
+    fn try_send_drops_pty_output_when_no_sender() {
         let broadcaster = WsBroadcaster::default();
         broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
             pty_id: 1,
             data: "hello".to_string(),
+            sequence: 1,
         }));
-        assert_eq!(broadcaster.get_pty_output_buffer(1), "hello");
-        broadcaster.remove_pty_output_buffer(1);
-        assert_eq!(broadcaster.get_pty_output_buffer(1), "");
+        assert!(!broadcaster.has_subscriber());
     }
 
     #[test]
-    fn remove_pty_output_buffer_nonexistent_is_noop() {
-        let broadcaster = WsBroadcaster::default();
-        broadcaster.remove_pty_output_buffer(999);
-        assert_eq!(broadcaster.get_pty_output_buffer(999), "");
-    }
-
-    #[test]
-    fn remove_pty_output_buffer_does_not_affect_other_ptys() {
-        let broadcaster = WsBroadcaster::default();
-        broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
-            pty_id: 1,
-            data: "aaa".to_string(),
-        }));
-        broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
-            pty_id: 2,
-            data: "bbb".to_string(),
-        }));
-        broadcaster.remove_pty_output_buffer(1);
-        assert_eq!(broadcaster.get_pty_output_buffer(1), "");
-        assert_eq!(broadcaster.get_pty_output_buffer(2), "bbb");
-    }
-
-    #[test]
-    fn send_without_buffer_does_not_affect_buffer() {
+    fn try_send_forwards_pty_output_to_registered_sender_without_buffering() {
         let broadcaster = WsBroadcaster::default();
         let (tx, mut rx) = WsBroadcaster::create_channel();
         broadcaster.set_sender(Some(tx));
 
         broadcaster.try_send(WsMessage::PtyOutput(PtyOutputMsg {
             pty_id: 1,
-            data: "original".to_string(),
+            data: "aaa".to_string(),
+            sequence: 1,
         }));
-        assert_eq!(broadcaster.get_pty_output_buffer(1), "original");
+
+        match rx.try_recv().unwrap() {
+            WsMessage::PtyOutput(msg) => {
+                assert_eq!(msg.pty_id, 1);
+                assert_eq!(msg.data, "aaa");
+            }
+            other => panic!("unexpected message: {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn send_without_buffer_sends_without_side_effects() {
+        let broadcaster = WsBroadcaster::default();
+        let (tx, mut rx) = WsBroadcaster::create_channel();
+        broadcaster.set_sender(Some(tx));
 
         let sent = broadcaster.send_without_buffer(WsMessage::PtyOutput(PtyOutputMsg {
             pty_id: 1,
             data: "original".to_string(),
+            sequence: 1,
         }));
         assert!(sent, "send must succeed when a receiver is registered");
-        assert_eq!(
-            broadcaster.get_pty_output_buffer(1),
-            "original",
-            "send_without_buffer must not append to buffer"
-        );
 
         let mut received = vec![];
         while let Ok(msg) = rx.try_recv() {
             received.push(msg);
         }
-        assert_eq!(received.len(), 2, "both messages should be sent to channel");
+        assert_eq!(received.len(), 1, "message should be sent to channel");
     }
 
     #[test]

--- a/src-tauri/src/ws_server/commands.rs
+++ b/src-tauri/src/ws_server/commands.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use tauri::{Emitter, Manager};
 
 use crate::domain::app_config::ConfigRepository;
+use crate::usecase::pty_session::query_service::PtySessionReplayReader;
 use crate::ws_bridge::WsBroadcaster;
 
 use super::http::start_ws_server;
@@ -24,6 +25,7 @@ pub async fn start_server_core(
     let handle = app.state::<WsServerHandle>();
     let config_state = app.state::<Arc<dyn ConfigRepository>>();
     let broadcaster = app.state::<Arc<WsBroadcaster>>();
+    let pty_replay_reader = app.state::<Arc<dyn PtySessionReplayReader>>();
 
     {
         let running = handle.running.lock();
@@ -69,6 +71,7 @@ pub async fn start_server_core(
 
     let server_state = Arc::new(WsServerState::new(
         Arc::clone(&broadcaster),
+        Arc::clone(&pty_replay_reader),
         Arc::clone(config_state.inner()),
         cfg.server.tls.enabled,
     ));

--- a/src-tauri/src/ws_server/mod.rs
+++ b/src-tauri/src/ws_server/mod.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::domain::app_config::ConfigRepository;
+use crate::usecase::pty_session::query_service::PtySessionReplayReader;
 use crate::ws_bridge::WsBroadcaster;
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -45,6 +46,7 @@ pub(crate) struct WsServerState {
     active_connection: Arc<Mutex<bool>>,
     rate_limits: Arc<Mutex<HashMap<std::net::IpAddr, rate_limit::RateLimitEntry>>>,
     broadcaster: Arc<WsBroadcaster>,
+    pty_replay_reader: Arc<dyn PtySessionReplayReader>,
     app_config: Arc<dyn ConfigRepository>,
     tls_enabled: bool,
 }
@@ -52,6 +54,7 @@ pub(crate) struct WsServerState {
 impl WsServerState {
     pub(crate) fn new(
         broadcaster: Arc<WsBroadcaster>,
+        pty_replay_reader: Arc<dyn PtySessionReplayReader>,
         app_config: Arc<dyn ConfigRepository>,
         tls_enabled: bool,
     ) -> Self {
@@ -59,6 +62,7 @@ impl WsServerState {
             active_connection: Arc::new(Mutex::new(false)),
             rate_limits: Arc::new(Mutex::new(HashMap::new())),
             broadcaster,
+            pty_replay_reader,
             app_config,
             tls_enabled,
         }

--- a/src-tauri/src/ws_server/session.rs
+++ b/src-tauri/src/ws_server/session.rs
@@ -6,6 +6,7 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::tungstenite::Message;
 
+use crate::adaptor::protocol::pty::PtyOutputMsg;
 use crate::protocol::*;
 use crate::ws_bridge::WsBroadcaster;
 
@@ -213,6 +214,8 @@ async fn handle_ws_authenticated<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
         write
     });
 
+    replay_pty_buffers(state);
+
     // --- メッセージルーティングフェーズ ---
     while let Some(msg) = read.next().await {
         let msg = match msg {
@@ -252,4 +255,211 @@ async fn handle_ws_authenticated<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
 
     log::info!("Client disconnected: {}", peer_addr);
     Ok(())
+}
+
+fn replay_pty_buffers(state: &WsServerState) {
+    for output in state.pty_replay_reader.replay_outputs() {
+        let sent = state
+            .broadcaster
+            .send_without_buffer(WsMessage::PtyOutput(PtyOutputMsg {
+                pty_id: output.pty_id,
+                data: output.data,
+                sequence: output.sequence,
+            }));
+        if !sent {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures_util::{SinkExt, StreamExt};
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha2::Sha256;
+    use tokio_tungstenite::tungstenite::protocol::Role;
+
+    use crate::domain::app_config::repository::ConfigUpdate;
+    use crate::domain::app_config::value_objects::{
+        AgentShortcutConfig, AppConfigDocument, AppSettings, ServerConfig, TelemetryConfig,
+        TlsConfig, WorkflowConfig,
+    };
+    use crate::domain::app_config::{AppConfigError, ConfigRepository};
+    use crate::domain::notification::{DesktopNotifyMode, NotifyConfig};
+    use crate::protocol::{deserialize_message, serialize_message, AuthResponse, WsMessage};
+    use crate::usecase::pty_session::dto::PtyReplayOutput;
+    use crate::usecase::pty_session::query_service::PtySessionReplayReader;
+
+    use super::*;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    struct MockReplayReader;
+
+    impl PtySessionReplayReader for MockReplayReader {
+        fn replay_outputs(&self) -> Vec<PtyReplayOutput> {
+            vec![PtyReplayOutput {
+                pty_id: 7,
+                data: "buffered output".to_string(),
+                sequence: 42,
+            }]
+        }
+    }
+
+    struct MockConfigRepository;
+
+    impl ConfigRepository for MockConfigRepository {
+        fn load(&self) -> Result<AppConfigDocument, AppConfigError> {
+            Ok(AppConfigDocument {
+                server: ServerConfig {
+                    bind: "127.0.0.1".to_string(),
+                    port: 0,
+                    hook_port: 0,
+                    token: "token".to_string(),
+                    tls: TlsConfig {
+                        enabled: false,
+                        cert: String::new(),
+                        key: String::new(),
+                    },
+                    notify: NotifyConfig {
+                        webhook_url: String::new(),
+                        on_running: false,
+                        on_done: false,
+                        on_error: false,
+                        on_waiting: false,
+                        desktop_mode: DesktopNotifyMode::Always,
+                        inactive_timeout_minutes: 0,
+                    },
+                },
+                telemetry: TelemetryConfig {
+                    crash_reporting: false,
+                    performance_telemetry: false,
+                },
+                app: AppSettings {
+                    close_to_tray: false,
+                    auto_launch: false,
+                    start_minimized: false,
+                    last_root_path: String::new(),
+                    last_repo_paths: Vec::new(),
+                    external_editor: String::new(),
+                    agent_shortcuts: AgentShortcutConfig::default(),
+                },
+                workflow: WorkflowConfig {
+                    approval_auto_approve: false,
+                },
+            })
+        }
+
+        fn save(&self, _config: AppConfigDocument) -> Result<(), AppConfigError> {
+            Ok(())
+        }
+
+        fn update(&self, _f: ConfigUpdate) -> Result<(), AppConfigError> {
+            Ok(())
+        }
+    }
+
+    fn hmac_response(challenge: &str, token: &str) -> String {
+        let mut mac = HmacSha256::new_from_slice(token.as_bytes()).unwrap();
+        mac.update(challenge.as_bytes());
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    #[test]
+    fn replay_pty_buffers_sends_buffered_output_to_subscriber() {
+        let broadcaster = Arc::new(WsBroadcaster::default());
+        let (tx, mut rx) = WsBroadcaster::create_channel();
+        broadcaster.set_sender(Some(tx));
+        let state = WsServerState::new(
+            broadcaster,
+            Arc::new(MockReplayReader),
+            Arc::new(MockConfigRepository),
+            false,
+        );
+
+        replay_pty_buffers(&state);
+
+        match rx.try_recv().unwrap() {
+            WsMessage::PtyOutput(output) => {
+                assert_eq!(output.pty_id, 7);
+                assert_eq!(output.data, "buffered output");
+                assert_eq!(output.sequence, 42);
+            }
+            other => panic!("unexpected replay message: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn authenticated_connection_replays_pty_buffers_to_websocket_client() {
+        let state = Arc::new(WsServerState::new(
+            Arc::new(WsBroadcaster::default()),
+            Arc::new(MockReplayReader),
+            Arc::new(MockConfigRepository),
+            false,
+        ));
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let server_ws =
+            tokio_tungstenite::WebSocketStream::from_raw_socket(server_io, Role::Server, None)
+                .await;
+        let mut client_ws =
+            tokio_tungstenite::WebSocketStream::from_raw_socket(client_io, Role::Client, None)
+                .await;
+        let peer_addr = "127.0.0.1:48121".parse().unwrap();
+        let server_state = Arc::clone(&state);
+        let server_task = tokio::spawn(async move {
+            handle_ws_authenticated(server_ws, peer_addr, "token", server_state.as_ref()).await
+        });
+
+        let challenge_text = match client_ws.next().await.unwrap().unwrap() {
+            Message::Text(text) => text,
+            other => panic!("unexpected challenge frame: {other:?}"),
+        };
+        let challenge = match deserialize_message(&challenge_text).unwrap() {
+            WsMessage::AuthChallenge(challenge) => challenge.challenge,
+            other => panic!("unexpected challenge message: {other:?}"),
+        };
+        let auth_response = WsMessage::AuthResponse(AuthResponse {
+            hmac: hmac_response(&challenge, "token"),
+        });
+        client_ws
+            .send(Message::text(serialize_message(&auth_response).unwrap()))
+            .await
+            .unwrap();
+
+        let auth_result_text = match client_ws.next().await.unwrap().unwrap() {
+            Message::Text(text) => text,
+            other => panic!("unexpected auth result frame: {other:?}"),
+        };
+        match deserialize_message(&auth_result_text).unwrap() {
+            WsMessage::AuthResult(result) => assert!(result.success),
+            other => panic!("unexpected auth result message: {other:?}"),
+        }
+
+        let replay_text = tokio::time::timeout(Duration::from_secs(1), async {
+            match client_ws.next().await.unwrap().unwrap() {
+                Message::Text(text) => text,
+                other => panic!("unexpected replay frame: {other:?}"),
+            }
+        })
+        .await
+        .expect("authenticated connection should receive PTY replay output");
+
+        match deserialize_message(&replay_text).unwrap() {
+            WsMessage::PtyOutput(output) => {
+                assert_eq!(output.pty_id, 7);
+                assert_eq!(output.data, "buffered output");
+                assert_eq!(output.sequence, 42);
+            }
+            other => panic!("unexpected replay message: {other:?}"),
+        }
+
+        client_ws.send(Message::Close(None)).await.unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), server_task)
+            .await
+            .expect("server task should stop after client close")
+            .unwrap();
+        assert!(result.is_ok());
+    }
 }

--- a/src/components/panels/PaneLeafContainer.tsx
+++ b/src/components/panels/PaneLeafContainer.tsx
@@ -1,4 +1,4 @@
-import { type DragEvent, useCallback, useRef } from "react";
+import { type DragEvent, useCallback } from "react";
 import { PANE_DRAG_TYPE, PaneDropZone } from "@/components/panels/PaneDropZone";
 import {
 	TerminalPanel,
@@ -22,6 +22,7 @@ interface PaneLeafContainerProps {
 		paneId: string,
 	) => (handle: TerminalPanelHandle | null) => void;
 	onPtyReady?: (paneId: string, ptyId: number, sessionKey: string) => void;
+	onPtyError?: (paneId: string, message: string) => void;
 	onDropTab?: (
 		tabId: string,
 		targetPaneId: string,
@@ -50,19 +51,17 @@ export function PaneLeafContainer({
 	onSplit,
 	setTerminalRef,
 	onPtyReady,
+	onPtyError,
 	onDropTab,
 	onDropPane,
 	onBreakToTab,
 	canBreakToTab,
 }: PaneLeafContainerProps) {
-	const localTerminalRef = useRef<TerminalPanelHandle | null>(null);
-
 	const handleFocus = useCallback(() => {
 		onFocus(pane.id);
 	}, [onFocus, pane.id]);
 
 	const handleClose = useCallback(() => {
-		localTerminalRef.current?.requestKill();
 		onClose(pane.id);
 	}, [onClose, pane.id]);
 
@@ -104,9 +103,15 @@ export function PaneLeafContainer({
 		[onPtyReady, pane.id],
 	);
 
+	const handlePtyError = useCallback(
+		(message: string) => {
+			onPtyError?.(pane.id, message);
+		},
+		[onPtyError, pane.id],
+	);
+
 	const localSetTerminalRef = useCallback(
 		(handle: TerminalPanelHandle | null) => {
-			localTerminalRef.current = handle;
 			setTerminalRef(pane.id)(handle);
 		},
 		[setTerminalRef, pane.id],
@@ -183,21 +188,33 @@ export function PaneLeafContainer({
 		>
 			{paneHeader}
 			<div className="flex-1 min-h-0">
-				<TerminalPanel
-					ref={localSetTerminalRef}
-					cwd={cwd}
-					theme={theme}
-					terminalStartupCommand={terminalStartupCommand}
-					label={pane.label}
-					sessionKey={pane.sessionKey ?? undefined}
-					onPtyReady={handlePtyReady}
-					onSplitVertical={handleSplitVertical}
-					onSplitHorizontal={handleSplitHorizontal}
-					onBreakToTab={handleBreakToTab}
-					onClosePane={handleClose}
-					canBreakToTab={canBreakToTab}
-					isOnlyPane={isOnlyPane}
-				/>
+				{isFocused ? (
+					<TerminalPanel
+						ref={localSetTerminalRef}
+						cwd={cwd}
+						theme={theme}
+						terminalStartupCommand={terminalStartupCommand}
+						label={pane.label}
+						sessionKey={pane.sessionKey ?? undefined}
+						onPtyReady={handlePtyReady}
+						onPtyError={handlePtyError}
+						onSplitVertical={handleSplitVertical}
+						onSplitHorizontal={handleSplitHorizontal}
+						onBreakToTab={handleBreakToTab}
+						onClosePane={handleClose}
+						canBreakToTab={canBreakToTab}
+						isOnlyPane={isOnlyPane}
+					/>
+				) : (
+					<button
+						type="button"
+						className="h-full w-full flex items-center justify-center bg-muted/10 text-xs text-muted-foreground hover:bg-muted/20 hover:text-foreground transition-colors"
+						onClick={handleFocus}
+						aria-label={`Focus ${pane.label}`}
+					>
+						<span className="truncate px-2">{pane.label}</span>
+					</button>
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/panels/PaneLeafContainer.tsx
+++ b/src/components/panels/PaneLeafContainer.tsx
@@ -23,6 +23,7 @@ interface PaneLeafContainerProps {
 	) => (handle: TerminalPanelHandle | null) => void;
 	onPtyReady?: (paneId: string, ptyId: number, sessionKey: string) => void;
 	onPtyError?: (paneId: string, message: string) => void;
+	consumePendingPaneKillRequest?: (paneId: string) => boolean;
 	onDropTab?: (
 		tabId: string,
 		targetPaneId: string,
@@ -52,6 +53,7 @@ export function PaneLeafContainer({
 	setTerminalRef,
 	onPtyReady,
 	onPtyError,
+	consumePendingPaneKillRequest,
 	onDropTab,
 	onDropPane,
 	onBreakToTab,
@@ -109,6 +111,10 @@ export function PaneLeafContainer({
 		},
 		[onPtyError, pane.id],
 	);
+
+	const shouldKillPendingPty = useCallback(() => {
+		return consumePendingPaneKillRequest?.(pane.id) ?? false;
+	}, [consumePendingPaneKillRequest, pane.id]);
 
 	const localSetTerminalRef = useCallback(
 		(handle: TerminalPanelHandle | null) => {
@@ -198,6 +204,7 @@ export function PaneLeafContainer({
 						sessionKey={pane.sessionKey ?? undefined}
 						onPtyReady={handlePtyReady}
 						onPtyError={handlePtyError}
+						shouldKillPendingPty={shouldKillPendingPty}
 						onSplitVertical={handleSplitVertical}
 						onSplitHorizontal={handleSplitHorizontal}
 						onBreakToTab={handleBreakToTab}

--- a/src/components/panels/PaneTreeRenderer.tsx
+++ b/src/components/panels/PaneTreeRenderer.tsx
@@ -19,6 +19,7 @@ interface PaneTreeRendererProps {
 		paneId: string,
 	) => (handle: TerminalPanelHandle | null) => void;
 	onPtyReady?: (paneId: string, ptyId: number, sessionKey: string) => void;
+	onPtyError?: (paneId: string, message: string) => void;
 	onDropTab?: (
 		tabId: string,
 		targetPaneId: string,
@@ -47,6 +48,7 @@ export function PaneTreeRenderer({
 	onSplit,
 	setTerminalRef,
 	onPtyReady,
+	onPtyError,
 	onDropTab,
 	onDropPane,
 	onBreakToTab,
@@ -66,6 +68,7 @@ export function PaneTreeRenderer({
 				onSplit={onSplit}
 				setTerminalRef={setTerminalRef}
 				onPtyReady={onPtyReady}
+				onPtyError={onPtyError}
 				onDropTab={onDropTab}
 				onDropPane={onDropPane}
 				onBreakToTab={onBreakToTab}
@@ -98,6 +101,7 @@ export function PaneTreeRenderer({
 					onSplit={onSplit}
 					setTerminalRef={setTerminalRef}
 					onPtyReady={onPtyReady}
+					onPtyError={onPtyError}
 					onDropTab={onDropTab}
 					onDropPane={onDropPane}
 					onBreakToTab={onBreakToTab}
@@ -125,6 +129,7 @@ interface PaneTreePanelProps {
 		paneId: string,
 	) => (handle: TerminalPanelHandle | null) => void;
 	onPtyReady?: (paneId: string, ptyId: number, sessionKey: string) => void;
+	onPtyError?: (paneId: string, message: string) => void;
 	onDropTab?: (
 		tabId: string,
 		targetPaneId: string,
@@ -155,6 +160,7 @@ function PaneTreePanel({
 	onSplit,
 	setTerminalRef,
 	onPtyReady,
+	onPtyError,
 	onDropTab,
 	onDropPane,
 	onBreakToTab,
@@ -175,6 +181,7 @@ function PaneTreePanel({
 					onSplit={onSplit}
 					setTerminalRef={setTerminalRef}
 					onPtyReady={onPtyReady}
+					onPtyError={onPtyError}
 					onDropTab={onDropTab}
 					onDropPane={onDropPane}
 					onBreakToTab={onBreakToTab}

--- a/src/components/panels/PaneTreeRenderer.tsx
+++ b/src/components/panels/PaneTreeRenderer.tsx
@@ -20,6 +20,7 @@ interface PaneTreeRendererProps {
 	) => (handle: TerminalPanelHandle | null) => void;
 	onPtyReady?: (paneId: string, ptyId: number, sessionKey: string) => void;
 	onPtyError?: (paneId: string, message: string) => void;
+	consumePendingPaneKillRequest?: (paneId: string) => boolean;
 	onDropTab?: (
 		tabId: string,
 		targetPaneId: string,
@@ -49,6 +50,7 @@ export function PaneTreeRenderer({
 	setTerminalRef,
 	onPtyReady,
 	onPtyError,
+	consumePendingPaneKillRequest,
 	onDropTab,
 	onDropPane,
 	onBreakToTab,
@@ -69,6 +71,7 @@ export function PaneTreeRenderer({
 				setTerminalRef={setTerminalRef}
 				onPtyReady={onPtyReady}
 				onPtyError={onPtyError}
+				consumePendingPaneKillRequest={consumePendingPaneKillRequest}
 				onDropTab={onDropTab}
 				onDropPane={onDropPane}
 				onBreakToTab={onBreakToTab}
@@ -102,6 +105,7 @@ export function PaneTreeRenderer({
 					setTerminalRef={setTerminalRef}
 					onPtyReady={onPtyReady}
 					onPtyError={onPtyError}
+					consumePendingPaneKillRequest={consumePendingPaneKillRequest}
 					onDropTab={onDropTab}
 					onDropPane={onDropPane}
 					onBreakToTab={onBreakToTab}
@@ -130,6 +134,7 @@ interface PaneTreePanelProps {
 	) => (handle: TerminalPanelHandle | null) => void;
 	onPtyReady?: (paneId: string, ptyId: number, sessionKey: string) => void;
 	onPtyError?: (paneId: string, message: string) => void;
+	consumePendingPaneKillRequest?: (paneId: string) => boolean;
 	onDropTab?: (
 		tabId: string,
 		targetPaneId: string,
@@ -161,6 +166,7 @@ function PaneTreePanel({
 	setTerminalRef,
 	onPtyReady,
 	onPtyError,
+	consumePendingPaneKillRequest,
 	onDropTab,
 	onDropPane,
 	onBreakToTab,
@@ -182,6 +188,7 @@ function PaneTreePanel({
 					setTerminalRef={setTerminalRef}
 					onPtyReady={onPtyReady}
 					onPtyError={onPtyError}
+					consumePendingPaneKillRequest={consumePendingPaneKillRequest}
 					onDropTab={onDropTab}
 					onDropPane={onDropPane}
 					onBreakToTab={onBreakToTab}

--- a/src/components/panels/TerminalPanel.test.tsx
+++ b/src/components/panels/TerminalPanel.test.tsx
@@ -38,6 +38,7 @@ describe("TerminalPanel", () => {
 			undefined,
 			undefined,
 			undefined,
+			undefined,
 		);
 	});
 
@@ -53,6 +54,7 @@ describe("TerminalPanel", () => {
 			undefined,
 			undefined,
 			onPtyReady,
+			undefined,
 		);
 	});
 });

--- a/src/components/panels/TerminalPanel.test.tsx
+++ b/src/components/panels/TerminalPanel.test.tsx
@@ -39,6 +39,7 @@ describe("TerminalPanel", () => {
 			undefined,
 			undefined,
 			undefined,
+			undefined,
 		);
 	});
 
@@ -54,6 +55,7 @@ describe("TerminalPanel", () => {
 			undefined,
 			undefined,
 			onPtyReady,
+			undefined,
 			undefined,
 		);
 	});

--- a/src/components/panels/TerminalPanel.tsx
+++ b/src/components/panels/TerminalPanel.tsx
@@ -33,6 +33,7 @@ export interface TerminalPanelProps {
 	sessionKey?: string;
 	label?: string;
 	onPtyReady?: (ptyId: number, sessionKey: string) => void;
+	onPtyError?: (message: string) => void;
 	onSplitVertical?: () => void;
 	onSplitHorizontal?: () => void;
 	onBreakToTab?: () => void;
@@ -52,6 +53,7 @@ export const TerminalPanel = forwardRef<
 		sessionKey,
 		label,
 		onPtyReady,
+		onPtyError,
 		onSplitVertical,
 		onSplitHorizontal,
 		onBreakToTab,
@@ -70,6 +72,7 @@ export const TerminalPanel = forwardRef<
 		sessionKey,
 		label,
 		onPtyReady,
+		onPtyError,
 	);
 	const [isDragOver, setIsDragOver] = useState(false);
 	const isDragOverRef = useRef(false);

--- a/src/components/panels/TerminalPanel.tsx
+++ b/src/components/panels/TerminalPanel.tsx
@@ -34,6 +34,7 @@ export interface TerminalPanelProps {
 	label?: string;
 	onPtyReady?: (ptyId: number, sessionKey: string) => void;
 	onPtyError?: (message: string) => void;
+	shouldKillPendingPty?: () => boolean;
 	onSplitVertical?: () => void;
 	onSplitHorizontal?: () => void;
 	onBreakToTab?: () => void;
@@ -54,6 +55,7 @@ export const TerminalPanel = forwardRef<
 		label,
 		onPtyReady,
 		onPtyError,
+		shouldKillPendingPty,
 		onSplitVertical,
 		onSplitHorizontal,
 		onBreakToTab,
@@ -73,6 +75,7 @@ export const TerminalPanel = forwardRef<
 		label,
 		onPtyReady,
 		onPtyError,
+		shouldKillPendingPty,
 	);
 	const [isDragOver, setIsDragOver] = useState(false);
 	const isDragOverRef = useRef(false);

--- a/src/components/panels/TerminalTabPanel.test.tsx
+++ b/src/components/panels/TerminalTabPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,13 +6,27 @@ import { _resetIdCounters } from "@/hooks/useTerminalPanes";
 import { _resetContainerIdCounter } from "@/lib/paneTree";
 import { TerminalTabPanel } from "./TerminalTabPanel";
 
+const mockTerminalHandle = vi.hoisted(() => ({
+	writeToTerminal: vi.fn(),
+	requestKill: vi.fn(),
+}));
+
 vi.mock("@tauri-apps/api/core", () => ({
 	invoke: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@/components/panels/TerminalPanel", () => ({
-	TerminalPanel: vi.fn(() => <div data-testid="terminal-panel" />),
-}));
+vi.mock("@/components/panels/TerminalPanel", async () => {
+	const React = await import("react");
+	return {
+		TerminalPanel: React.forwardRef(function MockTerminalPanel(
+			{ label }: { label?: string },
+			ref,
+		) {
+			React.useImperativeHandle(ref, () => mockTerminalHandle, []);
+			return <div data-testid="terminal-panel" data-label={label} />;
+		}),
+	};
+});
 
 vi.mock("react-resizable-panels", () => ({
 	Group: ({ children }: { children: React.ReactNode }) => (
@@ -67,6 +81,37 @@ describe("TerminalTabPanel", () => {
 			"aria-selected",
 			"true",
 		);
+	});
+
+	it("inactive tab の TerminalPanel は mount されない", async () => {
+		const user = userEvent.setup();
+		render(<TerminalTabPanel />);
+
+		expect(screen.getAllByTestId("terminal-panel")).toHaveLength(1);
+
+		await user.click(screen.getByLabelText("Add terminal tab"));
+		expect(screen.getAllByTestId("terminal-panel")).toHaveLength(1);
+
+		await user.click(screen.getByText("Terminal 1"));
+		expect(screen.getAllByTestId("terminal-panel")).toHaveLength(1);
+	});
+
+	it("inactive pane の TerminalPanel は mount されない", () => {
+		render(<TerminalTabPanel />);
+
+		fireEvent.keyDown(window, { key: "d", metaKey: true });
+
+		expect(screen.getAllByTestId("terminal-panel")).toHaveLength(1);
+		expect(screen.getByLabelText("Focus Terminal 1")).toBeInTheDocument();
+	});
+
+	it("pending の active pane を閉じる前に requestKill を呼ぶ", () => {
+		render(<TerminalTabPanel />);
+
+		fireEvent.keyDown(window, { key: "d", metaKey: true });
+		fireEvent.click(screen.getByLabelText("Close Terminal 2"));
+
+		expect(mockTerminalHandle.requestKill).toHaveBeenCalledTimes(1);
 	});
 
 	it("x ボタンでタブが閉じられる", async () => {

--- a/src/components/panels/TerminalTabPanel.test.tsx
+++ b/src/components/panels/TerminalTabPanel.test.tsx
@@ -10,6 +10,9 @@ const mockTerminalHandle = vi.hoisted(() => ({
 	writeToTerminal: vi.fn(),
 	requestKill: vi.fn(),
 }));
+const terminalPanelPropsByLabel = vi.hoisted(
+	() => new Map<string, { shouldKillPendingPty?: () => boolean }>(),
+);
 
 vi.mock("@tauri-apps/api/core", () => ({
 	invoke: vi.fn().mockResolvedValue(undefined),
@@ -19,10 +22,16 @@ vi.mock("@/components/panels/TerminalPanel", async () => {
 	const React = await import("react");
 	return {
 		TerminalPanel: React.forwardRef(function MockTerminalPanel(
-			{ label }: { label?: string },
+			{
+				label,
+				shouldKillPendingPty,
+			}: { label?: string; shouldKillPendingPty?: () => boolean },
 			ref,
 		) {
 			React.useImperativeHandle(ref, () => mockTerminalHandle, []);
+			if (label) {
+				terminalPanelPropsByLabel.set(label, { shouldKillPendingPty });
+			}
 			return <div data-testid="terminal-panel" data-label={label} />;
 		}),
 	};
@@ -41,6 +50,7 @@ vi.mock("react-resizable-panels", () => ({
 describe("TerminalTabPanel", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		terminalPanelPropsByLabel.clear();
 		_resetIdCounters();
 		_resetContainerIdCounter();
 	});
@@ -112,6 +122,19 @@ describe("TerminalTabPanel", () => {
 		fireEvent.click(screen.getByLabelText("Close Terminal 2"));
 
 		expect(mockTerminalHandle.requestKill).toHaveBeenCalledTimes(1);
+	});
+
+	it("ref がない pending pane は close 時に late spawn kill 要求を残す", () => {
+		render(<TerminalTabPanel />);
+
+		const terminal1Props = terminalPanelPropsByLabel.get("Terminal 1");
+		expect(terminal1Props?.shouldKillPendingPty?.()).toBe(false);
+
+		fireEvent.keyDown(window, { key: "d", metaKey: true });
+		fireEvent.click(screen.getByLabelText("Close Terminal 1"));
+
+		expect(mockTerminalHandle.requestKill).not.toHaveBeenCalled();
+		expect(terminal1Props?.shouldKillPendingPty?.()).toBe(true);
 	});
 
 	it("x ボタンでタブが閉じられる", async () => {

--- a/src/components/panels/TerminalTabPanel.tsx
+++ b/src/components/panels/TerminalTabPanel.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { X } from "lucide-react";
 import {
 	type DragEvent,
@@ -53,16 +54,24 @@ export const TerminalTabPanel = forwardRef<
 		movePaneToTab,
 		movePaneInTab,
 		updatePaneSessionKey,
+		markPendingPaneKill,
 		removePendingPane,
 		activeTab,
 	} = useTerminalPanes(tabPrefix, cwd ? `${cwd}::${tabPrefix}` : null);
 
 	const terminalRefs = useRef<Map<string, TerminalPanelHandle>>(new Map());
+	const pendingKillPaneIdsRef = useRef<Set<string>>(new Set());
 	const [terminalError, setTerminalError] = useState<string | null>(null);
 
 	const handlePtyReady = useCallback(
 		(paneId: string, ptyId: number, sessionKey: string) => {
 			setTerminalError(null);
+			if (pendingKillPaneIdsRef.current.delete(paneId)) {
+				invoke("kill_pty", { ptyId }).catch((error) => {
+					console.error("Failed to kill closed pending terminal PTY:", error);
+				});
+				return;
+			}
 			updatePaneSessionKey(paneId, sessionKey, ptyId);
 		},
 		[updatePaneSessionKey],
@@ -70,6 +79,7 @@ export const TerminalTabPanel = forwardRef<
 
 	const handlePtyError = useCallback(
 		(paneId: string, message: string) => {
+			pendingKillPaneIdsRef.current.delete(paneId);
 			setTerminalError(message);
 			removePendingPane(paneId);
 		},
@@ -105,10 +115,20 @@ export const TerminalTabPanel = forwardRef<
 				.flatMap((tab) => getAllLeaves(tab.paneTree))
 				.find((leaf) => leaf.id === paneId);
 			if (!pane || pane.ptyId !== null) return;
-			terminalRefs.current.get(paneId)?.requestKill();
+			const handle = terminalRefs.current.get(paneId);
+			if (handle) {
+				handle.requestKill();
+				return;
+			}
+			pendingKillPaneIdsRef.current.add(paneId);
+			markPendingPaneKill(paneId);
 		},
-		[tabs],
+		[markPendingPaneKill, tabs],
 	);
+
+	const consumePendingPaneKillRequest = useCallback((paneId: string) => {
+		return pendingKillPaneIdsRef.current.delete(paneId);
+	}, []);
 
 	const handleSplit = useCallback(
 		(paneId: string, direction: SplitDirection) => {
@@ -354,6 +374,7 @@ export const TerminalTabPanel = forwardRef<
 								setTerminalRef={setTerminalRef}
 								onPtyReady={handlePtyReady}
 								onPtyError={handlePtyError}
+								consumePendingPaneKillRequest={consumePendingPaneKillRequest}
 								onDropTab={handleDropTab}
 								onDropPane={handleDropPane}
 								onBreakToTab={handleBreakToTab}

--- a/src/components/panels/TerminalTabPanel.tsx
+++ b/src/components/panels/TerminalTabPanel.tsx
@@ -6,6 +6,7 @@ import {
 	useEffect,
 	useImperativeHandle,
 	useRef,
+	useState,
 } from "react";
 import { PANE_DRAG_TYPE } from "@/components/panels/PaneDropZone";
 import { PaneTreeRenderer } from "@/components/panels/PaneTreeRenderer";
@@ -52,15 +53,27 @@ export const TerminalTabPanel = forwardRef<
 		movePaneToTab,
 		movePaneInTab,
 		updatePaneSessionKey,
+		removePendingPane,
 		activeTab,
 	} = useTerminalPanes(tabPrefix, cwd ? `${cwd}::${tabPrefix}` : null);
 
 	const terminalRefs = useRef<Map<string, TerminalPanelHandle>>(new Map());
+	const [terminalError, setTerminalError] = useState<string | null>(null);
 
 	const handlePtyReady = useCallback(
-		(paneId: string, _ptyId: number, sessionKey: string) =>
-			updatePaneSessionKey(paneId, sessionKey),
+		(paneId: string, ptyId: number, sessionKey: string) => {
+			setTerminalError(null);
+			updatePaneSessionKey(paneId, sessionKey, ptyId);
+		},
 		[updatePaneSessionKey],
+	);
+
+	const handlePtyError = useCallback(
+		(paneId: string, message: string) => {
+			setTerminalError(message);
+			removePendingPane(paneId);
+		},
+		[removePendingPane],
 	);
 
 	useImperativeHandle(
@@ -86,26 +99,50 @@ export const TerminalTabPanel = forwardRef<
 		[],
 	);
 
+	const requestPendingPaneKill = useCallback(
+		(paneId: string) => {
+			const pane = tabs
+				.flatMap((tab) => getAllLeaves(tab.paneTree))
+				.find((leaf) => leaf.id === paneId);
+			if (!pane || pane.ptyId !== null) return;
+			terminalRefs.current.get(paneId)?.requestKill();
+		},
+		[tabs],
+	);
+
 	const handleSplit = useCallback(
 		(paneId: string, direction: SplitDirection) => {
+			setTerminalError(null);
 			setFocusedPane(paneId);
 			splitFocusedPane(direction);
 		},
 		[setFocusedPane, splitFocusedPane],
 	);
 
+	const handleAddTab = useCallback(() => {
+		setTerminalError(null);
+		addTab();
+	}, [addTab]);
+
 	const handleCloseTab = useCallback(
 		(tabId: string) => {
-			const tab = tabs.find((t) => t.id === tabId);
+			const tab = tabs.find((candidate) => candidate.id === tabId);
 			if (tab) {
-				const leaves = getAllLeaves(tab.paneTree);
-				for (const leaf of leaves) {
-					terminalRefs.current.get(leaf.id)?.requestKill();
+				for (const leaf of getAllLeaves(tab.paneTree)) {
+					requestPendingPaneKill(leaf.id);
 				}
 			}
 			closeTab(tabId);
 		},
-		[tabs, closeTab],
+		[closeTab, requestPendingPaneKill, tabs],
+	);
+
+	const handleClosePane = useCallback(
+		(paneId: string) => {
+			requestPendingPaneKill(paneId);
+			closeSpecificPane(paneId);
+		},
+		[closeSpecificPane, requestPendingPaneKill],
 	);
 
 	const isDraggingTabRef = useRef(false);
@@ -180,6 +217,7 @@ export const TerminalTabPanel = forwardRef<
 			// Cmd+D: 垂直分割
 			if (mod && !e.shiftKey && !e.altKey && key === "d") {
 				e.preventDefault();
+				setTerminalError(null);
 				splitFocusedPane("vertical");
 				return;
 			}
@@ -187,6 +225,7 @@ export const TerminalTabPanel = forwardRef<
 			// Cmd+Shift+D: 水平分割
 			if (mod && e.shiftKey && !e.altKey && key === "d") {
 				e.preventDefault();
+				setTerminalError(null);
 				splitFocusedPane("horizontal");
 				return;
 			}
@@ -282,7 +321,7 @@ export const TerminalTabPanel = forwardRef<
 					{tabs.length < MAX_TABS && (
 						<button
 							type="button"
-							onClick={addTab}
+							onClick={handleAddTab}
 							aria-label="Add terminal tab"
 							className="px-2 h-full text-sm text-muted-foreground hover:text-foreground transition-colors shrink-0"
 						>
@@ -290,13 +329,17 @@ export const TerminalTabPanel = forwardRef<
 						</button>
 					)}
 				</div>
+				{terminalError && (
+					<div className="shrink-0 border-b border-destructive/30 bg-destructive/10 px-3 py-1 text-xs text-destructive">
+						{terminalError}
+					</div>
+				)}
 				<div className="flex-1 relative" style={{ minHeight: 0 }}>
 					{tabs.map((tab) => (
 						<TabsContent
 							key={tab.id}
 							value={tab.id}
-							forceMount
-							className="absolute inset-0 m-0 data-[state=inactive]:hidden"
+							className="absolute inset-0 m-0"
 						>
 							<PaneTreeRenderer
 								node={tab.paneTree}
@@ -306,10 +349,11 @@ export const TerminalTabPanel = forwardRef<
 								theme={theme}
 								terminalStartupCommand={terminalStartupCommand}
 								onFocus={setFocusedPane}
-								onClose={closeSpecificPane}
+								onClose={handleClosePane}
 								onSplit={handleSplit}
 								setTerminalRef={setTerminalRef}
 								onPtyReady={handlePtyReady}
+								onPtyError={handlePtyError}
 								onDropTab={handleDropTab}
 								onDropPane={handleDropPane}
 								onBreakToTab={handleBreakToTab}

--- a/src/hooks/useTerminal.test.ts
+++ b/src/hooks/useTerminal.test.ts
@@ -168,6 +168,59 @@ describe("useTerminal", () => {
 		});
 	});
 
+	it("listen 解決前にアンマウントしても後続登録された listener を解除する", async () => {
+		type MockUnlisten = ReturnType<typeof vi.fn>;
+		let resolveOutput!: (value: MockUnlisten) => void;
+		let resolveExit!: (value: MockUnlisten) => void;
+		let resolveEvicted!: (value: MockUnlisten) => void;
+		mockListen.mockReset();
+		mockListen.mockImplementation((eventName: string) => {
+			return new Promise<MockUnlisten>((resolve) => {
+				if (eventName === "pty-output") {
+					resolveOutput = resolve;
+				} else if (eventName === "pty-exit") {
+					resolveExit = resolve;
+				} else if (eventName === "pty-evicted") {
+					resolveEvicted = resolve;
+				}
+			});
+		});
+
+		const { unmount } = renderHook(() => useTerminal(containerRef));
+
+		await waitFor(() => {
+			expect(mockListen).toHaveBeenCalledWith(
+				"pty-output",
+				expect.any(Function),
+			);
+		});
+		unmount();
+		expect(mockUnlistenOutput).not.toHaveBeenCalled();
+
+		resolveOutput(mockUnlistenOutput);
+		await waitFor(() => {
+			expect(mockListen).toHaveBeenCalledWith("pty-exit", expect.any(Function));
+		});
+		resolveExit(mockUnlistenExit);
+		await waitFor(() => {
+			expect(mockListen).toHaveBeenCalledWith(
+				"pty-evicted",
+				expect.any(Function),
+			);
+		});
+		resolveEvicted(mockUnlistenEvicted);
+
+		await waitFor(() => {
+			expect(mockUnlistenOutput).toHaveBeenCalledTimes(1);
+			expect(mockUnlistenExit).toHaveBeenCalledTimes(1);
+			expect(mockUnlistenEvicted).toHaveBeenCalledTimes(1);
+		});
+		expect(mockInvoke).not.toHaveBeenCalledWith(
+			"get_or_spawn_pty",
+			expect.any(Object),
+		);
+	});
+
 	it("PTY ready state is synced as active while mounted and cleared on unmount", async () => {
 		const { unmount } = renderHook(() => useTerminal(containerRef, "/repo"));
 
@@ -320,6 +373,9 @@ describe("useTerminal", () => {
 			activeToken: expect.any(String),
 		});
 		expect(mockInvoke).not.toHaveBeenCalledWith("kill_pty", expect.anything());
+		expect(mockUnlistenOutput).toHaveBeenCalledTimes(1);
+		expect(mockUnlistenExit).toHaveBeenCalledTimes(1);
+		expect(mockUnlistenEvicted).toHaveBeenCalledTimes(1);
 	});
 
 	it("pending kill callback kills a late managed PTY instead of reporting ready", async () => {
@@ -1024,6 +1080,16 @@ describe("useTerminal", () => {
 		expect(mockTerminalInstance.write).toHaveBeenCalledWith(
 			`backend replay ${MAX_INITIAL_REFETCH}`,
 		);
+		const writtenOutput = mockTerminalInstance.write.mock.calls.map(
+			([data]) => data as string,
+		);
+		const resyncWarningIndex = writtenOutput.findIndex((data) =>
+			data.includes("Terminal output may be incomplete"),
+		);
+		expect(resyncWarningIndex).toBeGreaterThanOrEqual(0);
+		expect(resyncWarningIndex).toBeLessThan(
+			writtenOutput.indexOf(`backend replay ${MAX_INITIAL_REFETCH}`),
+		);
 
 		mockOnDataCallback("after init");
 
@@ -1110,6 +1176,11 @@ describe("useTerminal", () => {
 		expect(mockTerminalInstance.write).toHaveBeenCalledWith(
 			"backend replay after drop",
 		);
+		expect(
+			mockTerminalInstance.write.mock.calls.some(([data]) =>
+				(data as string).includes("Terminal output may be incomplete"),
+			),
+		).toBe(false);
 	});
 
 	it("新規セッション（is_new: true）のとき起動コマンドが送信される", async () => {

--- a/src/hooks/useTerminal.test.ts
+++ b/src/hooks/useTerminal.test.ts
@@ -322,6 +322,72 @@ describe("useTerminal", () => {
 		expect(mockInvoke).not.toHaveBeenCalledWith("kill_pty", expect.anything());
 	});
 
+	it("pending kill callback kills a late managed PTY instead of reporting ready", async () => {
+		type SpawnResult = {
+			pty_id: number;
+			session_key: string;
+			buffered_output: string;
+			buffered_output_sequence: number;
+			is_new: boolean;
+			is_exited: boolean;
+			exit_code: number | null;
+		};
+		let resolveSpawn!: (value: SpawnResult) => void;
+		const pendingSpawn = new Promise<SpawnResult>((resolve) => {
+			resolveSpawn = resolve;
+		});
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") return pendingSpawn;
+			return Promise.resolve();
+		});
+		const onPtyReady = vi.fn();
+		const shouldKillPendingPty = vi.fn(() => false);
+
+		const { unmount } = renderHook(() =>
+			useTerminal(
+				containerRef,
+				"/repo",
+				undefined,
+				undefined,
+				undefined,
+				"repo terminal",
+				onPtyReady,
+				undefined,
+				shouldKillPendingPty,
+			),
+		);
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+		shouldKillPendingPty.mockReturnValue(true);
+		unmount();
+		mockInvoke.mockClear();
+
+		resolveSpawn({
+			pty_id: 7,
+			session_key: "late-session",
+			buffered_output: "",
+			buffered_output_sequence: 0,
+			is_new: true,
+			is_exited: false,
+			exit_code: null,
+		});
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("kill_pty", { ptyId: 7 });
+		});
+		expect(onPtyReady).not.toHaveBeenCalled();
+		expect(mockInvoke).toHaveBeenCalledWith("unregister_active_terminal", {
+			worktreePath: "/repo",
+			sessionKey: "late-session",
+			activeToken: expect.any(String),
+		});
+	});
+
 	it("requestKill() 後に get_or_spawn が解決した pending PTY は onPtyReady を呼ばない", async () => {
 		type SpawnResult = {
 			pty_id: number;

--- a/src/hooks/useTerminal.test.ts
+++ b/src/hooks/useTerminal.test.ts
@@ -1,6 +1,12 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useTerminal } from "./useTerminal";
+import {
+	createBoundedPtyOutputQueue,
+	MAX_INITIAL_REFETCH,
+	QUEUED_INITIAL_OUTPUT_MAX_BYTES,
+	QUEUED_INITIAL_OUTPUT_MAX_ITEMS,
+	useTerminal,
+} from "./useTerminal";
 
 const mockInvoke = vi.fn();
 const mockListen = vi.fn();
@@ -87,14 +93,18 @@ describe("useTerminal", () => {
 	let containerRef: { current: HTMLDivElement | null };
 	let mockUnlistenOutput: ReturnType<typeof vi.fn>;
 	let mockUnlistenExit: ReturnType<typeof vi.fn>;
+	let mockUnlistenEvicted: ReturnType<typeof vi.fn>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockInvoke.mockReset();
+		mockListen.mockReset();
 
 		containerRef = { current: document.createElement("div") };
 
 		mockUnlistenOutput = vi.fn();
 		mockUnlistenExit = vi.fn();
+		mockUnlistenEvicted = vi.fn();
 
 		mockInvoke.mockImplementation((cmd: string) => {
 			if (cmd === "get_or_spawn_pty") {
@@ -102,6 +112,7 @@ describe("useTerminal", () => {
 					pty_id: 1,
 					session_key: "test-uuid-1234",
 					buffered_output: "",
+					buffered_output_sequence: 0,
 					is_new: true,
 					is_exited: false,
 					exit_code: null,
@@ -111,7 +122,8 @@ describe("useTerminal", () => {
 		});
 		mockListen
 			.mockResolvedValueOnce(mockUnlistenOutput)
-			.mockResolvedValueOnce(mockUnlistenExit);
+			.mockResolvedValueOnce(mockUnlistenExit)
+			.mockResolvedValueOnce(mockUnlistenEvicted);
 	});
 
 	it("Terminal と FitAddon が正しく生成される", () => {
@@ -140,7 +152,7 @@ describe("useTerminal", () => {
 		});
 	});
 
-	it("pty-output と pty-exit のリスナーが登録される", async () => {
+	it("PTY event listeners are registered", async () => {
 		renderHook(() => useTerminal(containerRef));
 
 		await waitFor(() => {
@@ -149,7 +161,365 @@ describe("useTerminal", () => {
 				expect.any(Function),
 			);
 			expect(mockListen).toHaveBeenCalledWith("pty-exit", expect.any(Function));
+			expect(mockListen).toHaveBeenCalledWith(
+				"pty-evicted",
+				expect.any(Function),
+			);
 		});
+	});
+
+	it("PTY ready state is synced as active while mounted and cleared on unmount", async () => {
+		const { unmount } = renderHook(() => useTerminal(containerRef, "/repo"));
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("register_active_terminal", {
+				worktreePath: "/repo",
+				sessionKey: "test-uuid-1234",
+				activeToken: expect.any(String),
+			});
+		});
+		const registerCall = mockInvoke.mock.calls.find(
+			(call: unknown[]) => call[0] === "register_active_terminal",
+		) as [string, { activeToken: string }] | undefined;
+		const activeToken = registerCall?.[1].activeToken;
+
+		unmount();
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("unregister_active_terminal", {
+				worktreePath: "/repo",
+				sessionKey: "test-uuid-1234",
+				activeToken,
+			});
+		});
+	});
+
+	it("uses a new active token after remounting the same session", async () => {
+		mockListen.mockImplementation(() => Promise.resolve(vi.fn()));
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") {
+				return Promise.resolve({
+					pty_id: 1,
+					session_key: "same-session",
+					buffered_output: "",
+					buffered_output_sequence: 0,
+					is_new: false,
+					is_exited: false,
+					exit_code: null,
+				});
+			}
+			return Promise.resolve();
+		});
+
+		const first = renderHook(() =>
+			useTerminal(containerRef, "/repo", undefined, undefined, "same-session"),
+		);
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("register_active_terminal", {
+				worktreePath: "/repo",
+				sessionKey: "same-session",
+				activeToken: expect.any(String),
+			});
+		});
+		const firstRegister = mockInvoke.mock.calls.find(
+			(call: unknown[]) => call[0] === "register_active_terminal",
+		) as [string, { activeToken: string }] | undefined;
+		const firstToken = firstRegister?.[1].activeToken;
+
+		first.unmount();
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("unregister_active_terminal", {
+				worktreePath: "/repo",
+				sessionKey: "same-session",
+				activeToken: firstToken,
+			});
+		});
+
+		mockInvoke.mockClear();
+		const secondContainerRef = { current: document.createElement("div") };
+		renderHook(() =>
+			useTerminal(
+				secondContainerRef,
+				"/repo",
+				undefined,
+				undefined,
+				"same-session",
+			),
+		);
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("register_active_terminal", {
+				worktreePath: "/repo",
+				sessionKey: "same-session",
+				activeToken: expect.any(String),
+			});
+		});
+		const secondRegister = mockInvoke.mock.calls.find(
+			(call: unknown[]) => call[0] === "register_active_terminal",
+		) as [string, { activeToken: string }] | undefined;
+		expect(secondRegister?.[1].activeToken).not.toBe(firstToken);
+	});
+
+	it("get_or_spawn resolves after unmount still reports the session key for managed panes", async () => {
+		type SpawnResult = {
+			pty_id: number;
+			session_key: string;
+			buffered_output: string;
+			buffered_output_sequence: number;
+			is_new: boolean;
+			is_exited: boolean;
+			exit_code: number | null;
+		};
+		let resolveSpawn!: (value: SpawnResult) => void;
+		const pendingSpawn = new Promise<SpawnResult>((resolve) => {
+			resolveSpawn = resolve;
+		});
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") return pendingSpawn;
+			return Promise.resolve();
+		});
+		const onPtyReady = vi.fn();
+
+		const { unmount } = renderHook(() =>
+			useTerminal(
+				containerRef,
+				"/repo",
+				undefined,
+				undefined,
+				undefined,
+				"repo terminal",
+				onPtyReady,
+			),
+		);
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+		unmount();
+		mockInvoke.mockClear();
+
+		resolveSpawn({
+			pty_id: 7,
+			session_key: "late-session",
+			buffered_output: "",
+			buffered_output_sequence: 0,
+			is_new: true,
+			is_exited: false,
+			exit_code: null,
+		});
+
+		await waitFor(() => {
+			expect(onPtyReady).toHaveBeenCalledWith(7, "late-session");
+		});
+		expect(mockInvoke).toHaveBeenCalledWith("unregister_active_terminal", {
+			worktreePath: "/repo",
+			sessionKey: "late-session",
+			activeToken: expect.any(String),
+		});
+		expect(mockInvoke).not.toHaveBeenCalledWith("kill_pty", expect.anything());
+	});
+
+	it("requestKill() 後に get_or_spawn が解決した pending PTY は onPtyReady を呼ばない", async () => {
+		type SpawnResult = {
+			pty_id: number;
+			session_key: string;
+			buffered_output: string;
+			buffered_output_sequence: number;
+			is_new: boolean;
+			is_exited: boolean;
+			exit_code: number | null;
+		};
+		let resolveSpawn!: (value: SpawnResult) => void;
+		const pendingSpawn = new Promise<SpawnResult>((resolve) => {
+			resolveSpawn = resolve;
+		});
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") return pendingSpawn;
+			return Promise.resolve();
+		});
+		const onPtyReady = vi.fn();
+
+		const { result, unmount } = renderHook(() =>
+			useTerminal(
+				containerRef,
+				"/repo",
+				undefined,
+				undefined,
+				undefined,
+				"repo terminal",
+				onPtyReady,
+			),
+		);
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+		result.current.requestKill();
+		unmount();
+		mockInvoke.mockClear();
+
+		resolveSpawn({
+			pty_id: 7,
+			session_key: "late-session",
+			buffered_output: "",
+			buffered_output_sequence: 0,
+			is_new: true,
+			is_exited: false,
+			exit_code: null,
+		});
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("unregister_active_terminal", {
+				worktreePath: "/repo",
+				sessionKey: "late-session",
+				activeToken: expect.any(String),
+			});
+		});
+		expect(onPtyReady).not.toHaveBeenCalled();
+	});
+
+	it("requestKill() 後に get_or_spawn が解決した pending PTY を kill する", async () => {
+		type SpawnResult = {
+			pty_id: number;
+			session_key: string;
+			buffered_output: string;
+			buffered_output_sequence: number;
+			is_new: boolean;
+			is_exited: boolean;
+			exit_code: number | null;
+		};
+		let resolveSpawn!: (value: SpawnResult) => void;
+		const pendingSpawn = new Promise<SpawnResult>((resolve) => {
+			resolveSpawn = resolve;
+		});
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") return pendingSpawn;
+			return Promise.resolve();
+		});
+
+		const { result, unmount } = renderHook(() =>
+			useTerminal(containerRef, "/repo"),
+		);
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+		result.current.requestKill();
+		unmount();
+		mockInvoke.mockClear();
+
+		resolveSpawn({
+			pty_id: 7,
+			session_key: "late-session",
+			buffered_output: "",
+			buffered_output_sequence: 0,
+			is_new: true,
+			is_exited: false,
+			exit_code: null,
+		});
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("kill_pty", { ptyId: 7 });
+		});
+		expect(mockInvoke).toHaveBeenCalledWith("unregister_active_terminal", {
+			worktreePath: "/repo",
+			sessionKey: "late-session",
+			activeToken: expect.any(String),
+		});
+	});
+
+	it("PTY initialization failures are displayed and reported to the caller", async () => {
+		const onPtyError = vi.fn();
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") {
+				return Promise.reject({
+					code: "CAP_REACHED",
+					message: "PTY limit unavailable for worktree /repo",
+				});
+			}
+			return Promise.resolve();
+		});
+
+		renderHook(() =>
+			useTerminal(
+				containerRef,
+				"/repo",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				onPtyError,
+			),
+		);
+
+		await waitFor(() => {
+			expect(onPtyError).toHaveBeenCalledWith(
+				"Terminal limit reached: PTY limit unavailable for worktree /repo",
+			);
+		});
+		expect(mockTerminalInstance.write).toHaveBeenCalledWith(
+			"\r\n\x1b[31mTerminal limit reached: PTY limit unavailable for worktree /repo\x1b[0m\r\n",
+		);
+		expect(mockInvoke).not.toHaveBeenCalledWith(
+			"register_active_terminal",
+			expect.objectContaining({ sessionKey: "test-uuid-1234" }),
+		);
+	});
+
+	it("PTY cap-looking text without a stable code is treated as a generic init failure", async () => {
+		const onPtyError = vi.fn();
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") {
+				return Promise.reject("PTY cap reached for worktree /repo");
+			}
+			return Promise.resolve();
+		});
+
+		renderHook(() =>
+			useTerminal(
+				containerRef,
+				"/repo",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				onPtyError,
+			),
+		);
+
+		await waitFor(() => {
+			expect(onPtyError).toHaveBeenCalledWith(
+				"Failed to initialize terminal: PTY cap reached for worktree /repo",
+			);
+		});
+	});
+
+	it("initial output queue is bounded by item count and bytes", () => {
+		const queue = createBoundedPtyOutputQueue();
+		const payload = "x".repeat(1024);
+
+		for (
+			let sequence = 1;
+			sequence <= QUEUED_INITIAL_OUTPUT_MAX_ITEMS * 4;
+			sequence += 1
+		) {
+			queue.enqueue({ pty_id: 1, data: payload, sequence });
+		}
+
+		expect(queue.size()).toBeLessThanOrEqual(QUEUED_INITIAL_OUTPUT_MAX_ITEMS);
+		expect(queue.bytes()).toBeLessThanOrEqual(QUEUED_INITIAL_OUTPUT_MAX_BYTES);
+		expect(queue.hasDropped()).toBe(true);
 	});
 
 	it("ユーザー入力時に write_pty が呼び出される", async () => {
@@ -184,6 +554,7 @@ describe("useTerminal", () => {
 
 		expect(mockUnlistenOutput).toHaveBeenCalled();
 		expect(mockUnlistenExit).toHaveBeenCalled();
+		expect(mockUnlistenEvicted).toHaveBeenCalled();
 		expect(mockInvoke).not.toHaveBeenCalledWith("kill_pty", expect.anything());
 		expect(mockTerminalInstance.dispose).toHaveBeenCalled();
 	});
@@ -228,6 +599,38 @@ describe("useTerminal", () => {
 		expect(mockInvoke).not.toHaveBeenCalledWith("kill_pty", expect.anything());
 	});
 
+	it("pty-evicted for current PTY disables later writes", async () => {
+		renderHook(() => useTerminal(containerRef));
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+
+		const evictedListener = mockListen.mock.calls.find(
+			(call: unknown[]) => call[0] === "pty-evicted",
+		)?.[1] as (event: {
+			payload: { pty_id: number; session_key: string; reason: string };
+		}) => void;
+		evictedListener({
+			payload: {
+				pty_id: 1,
+				session_key: "test-uuid-1234",
+				reason: "idle",
+			},
+		});
+
+		mockInvoke.mockClear();
+		mockOnDataCallback("after eviction");
+
+		expect(mockTerminalInstance.write).toHaveBeenCalledWith(
+			"\r\n\x1b[90m[Terminal evicted]\x1b[0m\r\n",
+		);
+		expect(mockInvoke).not.toHaveBeenCalledWith("write_pty", expect.anything());
+	});
+
 	it("containerRef が null の場合は初期化されない", () => {
 		const nullContainerRef = { current: null };
 		const previousInstance = mockTerminalInstance;
@@ -245,6 +648,7 @@ describe("useTerminal", () => {
 					pty_id: 1,
 					session_key: "pre-spawned-key",
 					buffered_output: "previously buffered text\r\n$ ",
+					buffered_output_sequence: 3,
 					is_new: false,
 					is_exited: false,
 					exit_code: null,
@@ -260,6 +664,386 @@ describe("useTerminal", () => {
 				"previously buffered text\r\n$ ",
 			);
 		});
+	});
+
+	it("初期復元中に届いたlive outputをbuffered_output後に書き込む", async () => {
+		type SpawnResult = {
+			pty_id: number;
+			session_key: string;
+			buffered_output: string;
+			buffered_output_sequence: number;
+			is_new: boolean;
+			is_exited: boolean;
+			exit_code: number | null;
+		};
+		let resolveSpawn!: (value: SpawnResult) => void;
+		const pendingSpawn = new Promise<SpawnResult>((resolve) => {
+			resolveSpawn = resolve;
+		});
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") return pendingSpawn;
+			return Promise.resolve();
+		});
+
+		renderHook(() => useTerminal(containerRef));
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+		const outputListener = mockListen.mock.calls.find(
+			(call: unknown[]) => call[0] === "pty-output",
+		)?.[1] as (event: {
+			payload: { pty_id: number; data: string; sequence: number };
+		}) => void;
+		outputListener({
+			payload: { pty_id: 7, data: "live during init", sequence: 4 },
+		});
+
+		resolveSpawn({
+			pty_id: 7,
+			session_key: "pre-spawned-key",
+			buffered_output: "previously buffered text\r\n$ ",
+			buffered_output_sequence: 3,
+			is_new: false,
+			is_exited: false,
+			exit_code: null,
+		});
+
+		await waitFor(() => {
+			expect(mockTerminalInstance.write).toHaveBeenCalledWith(
+				"live during init",
+			);
+		});
+		expect(mockTerminalInstance.write.mock.calls.map(([data]) => data)).toEqual(
+			["previously buffered text\r\n$ ", "live during init"],
+		);
+	});
+
+	it("初期復元中に届いたsnapshot済みoutputは重複して書き込まない", async () => {
+		type SpawnResult = {
+			pty_id: number;
+			session_key: string;
+			buffered_output: string;
+			buffered_output_sequence: number;
+			is_new: boolean;
+			is_exited: boolean;
+			exit_code: number | null;
+		};
+		let resolveSpawn!: (value: SpawnResult) => void;
+		const pendingSpawn = new Promise<SpawnResult>((resolve) => {
+			resolveSpawn = resolve;
+		});
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") return pendingSpawn;
+			return Promise.resolve();
+		});
+
+		renderHook(() => useTerminal(containerRef));
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+		const outputListener = mockListen.mock.calls.find(
+			(call: unknown[]) => call[0] === "pty-output",
+		)?.[1] as (event: {
+			payload: { pty_id: number; data: string; sequence: number };
+		}) => void;
+		outputListener({
+			payload: { pty_id: 7, data: "already snapshotted", sequence: 3 },
+		});
+
+		resolveSpawn({
+			pty_id: 7,
+			session_key: "pre-spawned-key",
+			buffered_output: "previously buffered text\r\n$ already snapshotted",
+			buffered_output_sequence: 3,
+			is_new: false,
+			is_exited: false,
+			exit_code: null,
+		});
+
+		await waitFor(() => {
+			expect(mockTerminalInstance.write).toHaveBeenCalledWith(
+				"previously buffered text\r\n$ already snapshotted",
+			);
+		});
+		expect(mockTerminalInstance.write.mock.calls.map(([data]) => data)).toEqual(
+			["previously buffered text\r\n$ already snapshotted"],
+		);
+	});
+
+	it("初期復元queueでdropが起きた場合は最新buffered_outputを再取得して欠落を補う", async () => {
+		type SpawnResult = {
+			pty_id: number;
+			session_key: string;
+			buffered_output: string;
+			buffered_output_sequence: number;
+			is_new: boolean;
+			is_exited: boolean;
+			exit_code: number | null;
+		};
+		let resolveSpawn!: (value: SpawnResult) => void;
+		const pendingSpawn = new Promise<SpawnResult>((resolve) => {
+			resolveSpawn = resolve;
+		});
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") return pendingSpawn;
+			if (cmd === "get_pty_buffered_output") {
+				return Promise.resolve({
+					pty_id: 7,
+					session_key: "pre-spawned-key",
+					buffered_output: "backend replay through 256",
+					buffered_output_sequence: 256,
+					is_exited: false,
+					exit_code: null,
+				});
+			}
+			return Promise.resolve();
+		});
+
+		renderHook(() =>
+			useTerminal(
+				containerRef,
+				"/repo",
+				undefined,
+				undefined,
+				"pre-spawned-key",
+			),
+		);
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+		const outputListener = mockListen.mock.calls.find(
+			(call: unknown[]) => call[0] === "pty-output",
+		)?.[1] as (event: {
+			payload: { pty_id: number; data: string; sequence: number };
+		}) => void;
+
+		for (
+			let sequence = 1;
+			sequence <= QUEUED_INITIAL_OUTPUT_MAX_ITEMS + 4;
+			sequence += 1
+		) {
+			outputListener({
+				payload: { pty_id: 7, data: `chunk-${sequence}`, sequence },
+			});
+		}
+
+		resolveSpawn({
+			pty_id: 7,
+			session_key: "pre-spawned-key",
+			buffered_output: "stale backend replay",
+			buffered_output_sequence: 0,
+			is_new: false,
+			is_exited: false,
+			exit_code: null,
+		});
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("get_pty_buffered_output", {
+				sessionKey: "pre-spawned-key",
+				worktreePath: "/repo",
+			});
+		});
+		await waitFor(() => {
+			expect(mockTerminalInstance.write).toHaveBeenCalledWith("chunk-260");
+		});
+
+		expect(mockTerminalInstance.write.mock.calls.map(([data]) => data)).toEqual(
+			[
+				"backend replay through 256",
+				"chunk-257",
+				"chunk-258",
+				"chunk-259",
+				"chunk-260",
+			],
+		);
+	});
+
+	it("初期復元queueのdropが続いても最大refetch回数で終了して入力を受け付ける", async () => {
+		type SpawnResult = {
+			pty_id: number;
+			session_key: string;
+			buffered_output: string;
+			buffered_output_sequence: number;
+			is_new: boolean;
+			is_exited: boolean;
+			exit_code: number | null;
+		};
+		let resolveSpawn!: (value: SpawnResult) => void;
+		const pendingSpawn = new Promise<SpawnResult>((resolve) => {
+			resolveSpawn = resolve;
+		});
+		const oversizedOutput = "x".repeat(QUEUED_INITIAL_OUTPUT_MAX_BYTES + 1);
+		let outputListener: (event: {
+			payload: { pty_id: number; data: string; sequence: number };
+		}) => void = () => {};
+		let refetchCount = 0;
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") return pendingSpawn;
+			if (cmd === "get_pty_buffered_output") {
+				refetchCount += 1;
+				outputListener({
+					payload: {
+						pty_id: 7,
+						data: oversizedOutput,
+						sequence: 1000 + refetchCount,
+					},
+				});
+				return Promise.resolve({
+					pty_id: 7,
+					session_key: "pre-spawned-key",
+					buffered_output: `backend replay ${refetchCount}`,
+					buffered_output_sequence: 1000 + refetchCount,
+					is_exited: false,
+					exit_code: null,
+				});
+			}
+			return Promise.resolve();
+		});
+
+		const { result } = renderHook(() =>
+			useTerminal(
+				containerRef,
+				"/repo",
+				undefined,
+				undefined,
+				"pre-spawned-key",
+			),
+		);
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+		outputListener = mockListen.mock.calls.find(
+			(call: unknown[]) => call[0] === "pty-output",
+		)?.[1] as (event: {
+			payload: { pty_id: number; data: string; sequence: number };
+		}) => void;
+		outputListener({
+			payload: { pty_id: 7, data: oversizedOutput, sequence: 1 },
+		});
+
+		resolveSpawn({
+			pty_id: 7,
+			session_key: "pre-spawned-key",
+			buffered_output: "stale backend replay",
+			buffered_output_sequence: 0,
+			is_new: false,
+			is_exited: false,
+			exit_code: null,
+		});
+
+		await waitFor(() => {
+			expect(result.current.ptyIdRef.current).toBe(7);
+		});
+
+		const refetchCalls = mockInvoke.mock.calls.filter(
+			(call) => call[0] === "get_pty_buffered_output",
+		);
+		expect(refetchCalls).toHaveLength(MAX_INITIAL_REFETCH);
+		expect(mockTerminalInstance.write).toHaveBeenCalledWith(
+			`backend replay ${MAX_INITIAL_REFETCH}`,
+		);
+
+		mockOnDataCallback("after init");
+
+		expect(mockInvoke).toHaveBeenCalledWith("write_pty", {
+			ptyId: 7,
+			data: "after init",
+		});
+	});
+
+	it("初期復元queueのdropが解消したら最大refetch回数未満で終了する", async () => {
+		type SpawnResult = {
+			pty_id: number;
+			session_key: string;
+			buffered_output: string;
+			buffered_output_sequence: number;
+			is_new: boolean;
+			is_exited: boolean;
+			exit_code: number | null;
+		};
+		let resolveSpawn!: (value: SpawnResult) => void;
+		const pendingSpawn = new Promise<SpawnResult>((resolve) => {
+			resolveSpawn = resolve;
+		});
+		const oversizedOutput = "x".repeat(QUEUED_INITIAL_OUTPUT_MAX_BYTES + 1);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_or_spawn_pty") return pendingSpawn;
+			if (cmd === "get_pty_buffered_output") {
+				return Promise.resolve({
+					pty_id: 7,
+					session_key: "pre-spawned-key",
+					buffered_output: "backend replay after drop",
+					buffered_output_sequence: 256,
+					is_exited: false,
+					exit_code: null,
+				});
+			}
+			return Promise.resolve();
+		});
+
+		const { result } = renderHook(() =>
+			useTerminal(
+				containerRef,
+				"/repo",
+				undefined,
+				undefined,
+				"pre-spawned-key",
+			),
+		);
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith(
+				"get_or_spawn_pty",
+				expect.any(Object),
+			);
+		});
+		const outputListener = mockListen.mock.calls.find(
+			(call: unknown[]) => call[0] === "pty-output",
+		)?.[1] as (event: {
+			payload: { pty_id: number; data: string; sequence: number };
+		}) => void;
+		outputListener({
+			payload: { pty_id: 7, data: oversizedOutput, sequence: 1 },
+		});
+
+		resolveSpawn({
+			pty_id: 7,
+			session_key: "pre-spawned-key",
+			buffered_output: "stale backend replay",
+			buffered_output_sequence: 0,
+			is_new: false,
+			is_exited: false,
+			exit_code: null,
+		});
+
+		await waitFor(() => {
+			expect(result.current.ptyIdRef.current).toBe(7);
+		});
+
+		const refetchCalls = mockInvoke.mock.calls.filter(
+			(call) => call[0] === "get_pty_buffered_output",
+		);
+		expect(refetchCalls.length).toBeLessThan(MAX_INITIAL_REFETCH);
+		expect(refetchCalls).toHaveLength(1);
+		expect(mockTerminalInstance.write).toHaveBeenCalledWith(
+			"backend replay after drop",
+		);
 	});
 
 	it("新規セッション（is_new: true）のとき起動コマンドが送信される", async () => {
@@ -280,6 +1064,7 @@ describe("useTerminal", () => {
 					pty_id: 1,
 					session_key: "test-uuid-existing",
 					buffered_output: "",
+					buffered_output_sequence: 0,
 					is_new: false,
 					is_exited: false,
 					exit_code: null,

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -262,6 +262,7 @@ export function useTerminal(
 	label?: string,
 	onPtyReady?: (ptyId: number, sessionKey: string) => void,
 	onPtyError?: (message: string) => void,
+	shouldKillPendingPty?: () => boolean,
 ) {
 	const terminalRef = useRef<Terminal | null>(null);
 	const fitAddonRef = useRef<FitAddon | null>(null);
@@ -276,6 +277,8 @@ export function useTerminal(
 	onPtyReadyRef.current = onPtyReady;
 	const onPtyErrorRef = useRef(onPtyError);
 	onPtyErrorRef.current = onPtyError;
+	const shouldKillPendingPtyRef = useRef(shouldKillPendingPty);
+	shouldKillPendingPtyRef.current = shouldKillPendingPty;
 
 	useEffect(() => {
 		const container = containerRef.current;
@@ -403,9 +406,12 @@ export function useTerminal(
 			}
 
 			if (!isMounted) {
-				if (killOnUnmountRef.current && !result.is_exited) {
+				const shouldKillDetachedPty =
+					killOnUnmountRef.current ||
+					(shouldKillPendingPtyRef.current?.() ?? false);
+				if (shouldKillDetachedPty && !result.is_exited) {
 					invoke("kill_pty", { ptyId: result.pty_id }).catch(() => {});
-				} else if (!killOnUnmountRef.current) {
+				} else if (!shouldKillDetachedPty) {
 					onPtyReadyRef.current?.(result.pty_id, result.session_key);
 				}
 				unregisterActiveTerminal(

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -12,6 +12,7 @@ import type { Theme } from "@/types/settings";
 interface PtyOutput {
 	pty_id: number;
 	data: string;
+	sequence: number;
 }
 
 interface PtyExit {
@@ -19,16 +20,174 @@ interface PtyExit {
 	exit_code: number | null;
 }
 
+interface PtyEvicted {
+	pty_id: number;
+	session_key: string;
+	reason: string;
+}
+
 interface GetOrSpawnPtyResult {
 	pty_id: number;
 	session_key: string;
 	buffered_output: string;
+	buffered_output_sequence: number;
 	is_new: boolean;
 	is_exited: boolean;
 	exit_code: number | null;
 }
 
+interface GetPtyBufferedOutputResult {
+	pty_id: number;
+	session_key: string;
+	buffered_output: string;
+	buffered_output_sequence: number;
+	is_exited: boolean;
+	exit_code: number | null;
+}
+
+interface TauriCommandError {
+	code?: unknown;
+	message?: unknown;
+}
+
+export const QUEUED_INITIAL_OUTPUT_MAX_ITEMS = 256;
+export const QUEUED_INITIAL_OUTPUT_MAX_BYTES = 64 * 1024;
+export const MAX_INITIAL_REFETCH = 5;
+
+const TERMINAL_CAP_REACHED_CODE = "CAP_REACHED";
+const textEncoder = new TextEncoder();
+
 const sessionKeyCache = new Map<string, string>();
+let activeTerminalTokenCounter = 0;
+
+function removeCachedSessionKey(sessionKey: string): void {
+	for (const [cwd, cachedSessionKey] of sessionKeyCache.entries()) {
+		if (cachedSessionKey === sessionKey) {
+			sessionKeyCache.delete(cwd);
+		}
+	}
+}
+
+function createActiveTerminalToken(): string {
+	activeTerminalTokenCounter += 1;
+	return `terminal-${activeTerminalTokenCounter}`;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function getCommandError(error: unknown): TauriCommandError | null {
+	if (!isObject(error)) return null;
+	return error;
+}
+
+function getErrorMessage(error: unknown): string {
+	const commandError = getCommandError(error);
+	if (typeof commandError?.message === "string") {
+		return commandError.message;
+	}
+	if (error instanceof Error) {
+		return error.message;
+	}
+	return String(error);
+}
+
+function getErrorCode(error: unknown): string | null {
+	const commandError = getCommandError(error);
+	if (typeof commandError?.code === "string") {
+		return commandError.code;
+	}
+	return null;
+}
+
+export function createBoundedPtyOutputQueue(
+	maxItems = QUEUED_INITIAL_OUTPUT_MAX_ITEMS,
+	maxBytes = QUEUED_INITIAL_OUTPUT_MAX_BYTES,
+) {
+	let entries: Array<{ output: PtyOutput; bytes: number }> = [];
+	let totalBytes = 0;
+	let dropped = false;
+
+	return {
+		enqueue(output: PtyOutput) {
+			const bytes = textEncoder.encode(output.data).byteLength;
+			if (bytes > maxBytes) {
+				entries = [];
+				totalBytes = 0;
+				dropped = true;
+				return;
+			}
+
+			entries.push({ output, bytes });
+			totalBytes += bytes;
+
+			while (entries.length > maxItems || totalBytes > maxBytes) {
+				const droppedEntry = entries.shift();
+				if (!droppedEntry) break;
+				totalBytes -= droppedEntry.bytes;
+				dropped = true;
+			}
+		},
+		values(): PtyOutput[] {
+			return entries.map((entry) => entry.output);
+		},
+		clear() {
+			entries = [];
+			totalBytes = 0;
+			dropped = false;
+		},
+		size(): number {
+			return entries.length;
+		},
+		bytes(): number {
+			return totalBytes;
+		},
+		hasDropped(): boolean {
+			return dropped;
+		},
+		resetDropped() {
+			dropped = false;
+		},
+	};
+}
+
+function registerActiveTerminal(
+	worktreePath: string,
+	sessionKey: string,
+	activeToken: string,
+): void {
+	invoke("register_active_terminal", {
+		worktreePath,
+		sessionKey,
+		activeToken,
+	}).catch((error) => {
+		console.error("Failed to register active terminal:", error);
+	});
+}
+
+function unregisterActiveTerminal(
+	worktreePath: string | null,
+	sessionKey: string | null,
+	activeToken: string,
+): void {
+	if (worktreePath === null || sessionKey === null) return;
+	invoke("unregister_active_terminal", {
+		worktreePath,
+		sessionKey,
+		activeToken,
+	}).catch((error) => {
+		console.error("Failed to unregister active terminal:", error);
+	});
+}
+
+function formatTerminalInitError(error: unknown): string {
+	const message = getErrorMessage(error);
+	if (getErrorCode(error) === TERMINAL_CAP_REACHED_CODE) {
+		return `Terminal limit reached: ${message}`;
+	}
+	return `Failed to initialize terminal: ${message}`;
+}
 
 const terminalDarkTheme: ITheme = {
 	foreground: "#e0e0e0",
@@ -102,6 +261,7 @@ export function useTerminal(
 	sessionKey?: string,
 	label?: string,
 	onPtyReady?: (ptyId: number, sessionKey: string) => void,
+	onPtyError?: (message: string) => void,
 ) {
 	const terminalRef = useRef<Terminal | null>(null);
 	const fitAddonRef = useRef<FitAddon | null>(null);
@@ -114,6 +274,8 @@ export function useTerminal(
 	startupCommandRef.current = terminalStartupCommand;
 	const onPtyReadyRef = useRef(onPtyReady);
 	onPtyReadyRef.current = onPtyReady;
+	const onPtyErrorRef = useRef(onPtyError);
+	onPtyErrorRef.current = onPtyError;
 
 	useEffect(() => {
 		const container = containerRef.current;
@@ -158,10 +320,26 @@ export function useTerminal(
 
 		let unlistenOutput: UnlistenFn | null = null;
 		let unlistenExit: UnlistenFn | null = null;
+		let unlistenEvicted: UnlistenFn | null = null;
+		let registeredWorktreePath: string | null = null;
+		let registeredSessionKey: string | null = null;
+		const activeToken = createActiveTerminalToken();
+		let isInitializingPty = true;
+		let initializingPtyId: number | null = null;
+		const queuedInitialOutput = createBoundedPtyOutputQueue();
 
 		const initPty = async () => {
-			// 1. Register listeners first (ptyIdRef is still null so they won't fire yet)
+			// 1. Register listeners first and queue output until the PTY id is known.
 			unlistenOutput = await listen<PtyOutput>("pty-output", (event) => {
+				if (isInitializingPty) {
+					if (
+						initializingPtyId === null ||
+						event.payload.pty_id === initializingPtyId
+					) {
+						queuedInitialOutput.enqueue(event.payload);
+					}
+					return;
+				}
 				if (event.payload.pty_id === ptyIdRef.current) {
 					terminal.write(event.payload.data);
 				}
@@ -176,7 +354,26 @@ export function useTerminal(
 				}
 			});
 
-			if (!isMounted) return;
+			unlistenEvicted = await listen<PtyEvicted>("pty-evicted", (event) => {
+				removeCachedSessionKey(event.payload.session_key);
+				if (event.payload.pty_id === ptyIdRef.current) {
+					unregisterActiveTerminal(
+						registeredWorktreePath,
+						event.payload.session_key,
+						activeToken,
+					);
+					registeredWorktreePath = null;
+					registeredSessionKey = null;
+					terminal.write("\r\n\x1b[90m[Terminal evicted]\x1b[0m\r\n");
+					ptyIdRef.current = null;
+				}
+			});
+
+			if (!isMounted) {
+				isInitializingPty = false;
+				queuedInitialOutput.clear();
+				return;
+			}
 
 			// 2. Get or spawn PTY for this worktree
 			const { rows, cols } = terminal;
@@ -208,26 +405,86 @@ export function useTerminal(
 			if (!isMounted) {
 				if (killOnUnmountRef.current && !result.is_exited) {
 					invoke("kill_pty", { ptyId: result.pty_id }).catch(() => {});
+				} else if (!killOnUnmountRef.current) {
+					onPtyReadyRef.current?.(result.pty_id, result.session_key);
 				}
+				unregisterActiveTerminal(
+					worktreePath ?? "",
+					result.session_key,
+					activeToken,
+				);
+				isInitializingPty = false;
+				queuedInitialOutput.clear();
 				return;
 			}
 
+			let ptyId = result.pty_id;
+			initializingPtyId = ptyId;
+			let resolvedSessionKey = result.session_key;
+			let bufferedOutput = result.buffered_output;
+			let bufferedOutputSequence = result.buffered_output_sequence;
+			let isExited = result.is_exited;
+			let exitCode = result.exit_code;
+			let attempts = 0;
+
+			while (
+				!isExited &&
+				queuedInitialOutput.hasDropped() &&
+				attempts < MAX_INITIAL_REFETCH
+			) {
+				queuedInitialOutput.resetDropped();
+				const refreshed = await invoke<GetPtyBufferedOutputResult>(
+					"get_pty_buffered_output",
+					{
+						sessionKey: resolvedSessionKey,
+						worktreePath: worktreePath ?? "",
+					},
+				);
+				ptyId = refreshed.pty_id;
+				initializingPtyId = ptyId;
+				resolvedSessionKey = refreshed.session_key;
+				bufferedOutput = refreshed.buffered_output;
+				bufferedOutputSequence = refreshed.buffered_output_sequence;
+				isExited = refreshed.is_exited;
+				exitCode = refreshed.exit_code;
+				attempts += 1;
+			}
+
 			// 3. Replay buffered output
-			if (result.buffered_output) {
-				terminal.write(result.buffered_output);
+			if (bufferedOutput) {
+				terminal.write(bufferedOutput);
 			}
 
 			// 4. Handle already-exited session
-			if (result.is_exited) {
+			if (isExited) {
+				isInitializingPty = false;
+				queuedInitialOutput.clear();
 				terminal.write(
-					`\r\n\x1b[90m[Process exited with code ${result.exit_code ?? "unknown"}]\x1b[0m\r\n`,
+					`\r\n\x1b[90m[Process exited with code ${exitCode ?? "unknown"}]\x1b[0m\r\n`,
 				);
 				return;
 			}
 
-			// 5. Set ptyId (from here, real-time output starts flowing)
-			ptyIdRef.current = result.pty_id;
-			onPtyReadyRef.current?.(result.pty_id, result.session_key);
+			// 5. Set ptyId and flush output that arrived after the backend snapshot.
+			ptyIdRef.current = ptyId;
+			for (const output of queuedInitialOutput.values()) {
+				if (
+					output.pty_id === ptyId &&
+					output.sequence > bufferedOutputSequence
+				) {
+					terminal.write(output.data);
+				}
+			}
+			queuedInitialOutput.clear();
+			isInitializingPty = false;
+			registeredWorktreePath = worktreePath ?? "";
+			registeredSessionKey = resolvedSessionKey;
+			registerActiveTerminal(
+				registeredWorktreePath,
+				registeredSessionKey,
+				activeToken,
+			);
+			onPtyReadyRef.current?.(ptyId, resolvedSessionKey);
 
 			// 初回fit()が不正確だった場合のセーフティネット:
 			// PTYスポーン後に最新のサイズで再同期する
@@ -237,7 +494,7 @@ export function useTerminal(
 				const { rows, cols } = terminalRef.current;
 				if (rows > 0 && cols > 0) {
 					invoke("resize_pty", {
-						ptyId: result.pty_id,
+						ptyId: ptyId,
 						rows,
 						cols,
 					}).catch((error) => {
@@ -251,7 +508,7 @@ export function useTerminal(
 				const cmd = startupCommandRef.current.trim();
 				if (cmd) {
 					invoke("write_pty", {
-						ptyId: result.pty_id,
+						ptyId: ptyId,
 						data: `${cmd}\n`,
 					}).catch((error) => {
 						console.error("Failed to send startup command:", error);
@@ -262,6 +519,12 @@ export function useTerminal(
 
 		initPty().catch((error) => {
 			console.error("Failed to initialize PTY:", error);
+			isInitializingPty = false;
+			queuedInitialOutput.clear();
+			if (!isMounted) return;
+			const message = formatTerminalInitError(error);
+			terminal.write(`\r\n\x1b[31m${message}\x1b[0m\r\n`);
+			onPtyErrorRef.current?.(message);
 		});
 
 		terminal.onData((data) => {
@@ -337,9 +600,15 @@ export function useTerminal(
 			resizeObserver.disconnect();
 			unlistenOutput?.();
 			unlistenExit?.();
+			unlistenEvicted?.();
 			if (killOnUnmountRef.current && ptyIdRef.current !== null) {
 				invoke("kill_pty", { ptyId: ptyIdRef.current }).catch(() => {});
 			}
+			unregisterActiveTerminal(
+				registeredWorktreePath,
+				registeredSessionKey,
+				activeToken,
+			);
 			ptyIdRef.current = null;
 			terminal.dispose();
 			reportMountedXtermUnmounted();

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -55,6 +55,8 @@ export const QUEUED_INITIAL_OUTPUT_MAX_BYTES = 64 * 1024;
 export const MAX_INITIAL_REFETCH = 5;
 
 const TERMINAL_CAP_REACHED_CODE = "CAP_REACHED";
+const INITIAL_OUTPUT_RESYNC_FAILED_MESSAGE =
+	"\r\n\x1b[33m[Terminal output may be incomplete: unable to resynchronize buffered output]\x1b[0m\r\n";
 const textEncoder = new TextEncoder();
 
 const sessionKeyCache = new Map<string, string>();
@@ -331,6 +333,15 @@ export function useTerminal(
 		let initializingPtyId: number | null = null;
 		const queuedInitialOutput = createBoundedPtyOutputQueue();
 
+		const cleanupPtyListeners = () => {
+			unlistenOutput?.();
+			unlistenOutput = null;
+			unlistenExit?.();
+			unlistenExit = null;
+			unlistenEvicted?.();
+			unlistenEvicted = null;
+		};
+
 		const initPty = async () => {
 			// 1. Register listeners first and queue output until the PTY id is known.
 			unlistenOutput = await listen<PtyOutput>("pty-output", (event) => {
@@ -373,6 +384,7 @@ export function useTerminal(
 			});
 
 			if (!isMounted) {
+				cleanupPtyListeners();
 				isInitializingPty = false;
 				queuedInitialOutput.clear();
 				return;
@@ -419,6 +431,7 @@ export function useTerminal(
 					result.session_key,
 					activeToken,
 				);
+				cleanupPtyListeners();
 				isInitializingPty = false;
 				queuedInitialOutput.clear();
 				return;
@@ -454,6 +467,10 @@ export function useTerminal(
 				isExited = refreshed.is_exited;
 				exitCode = refreshed.exit_code;
 				attempts += 1;
+			}
+
+			if (attempts >= MAX_INITIAL_REFETCH && queuedInitialOutput.hasDropped()) {
+				terminal.write(INITIAL_OUTPUT_RESYNC_FAILED_MESSAGE);
 			}
 
 			// 3. Replay buffered output
@@ -604,9 +621,7 @@ export function useTerminal(
 				clearTimeout(resizeTimer);
 			}
 			resizeObserver.disconnect();
-			unlistenOutput?.();
-			unlistenExit?.();
-			unlistenEvicted?.();
+			cleanupPtyListeners();
 			if (killOnUnmountRef.current && ptyIdRef.current !== null) {
 				invoke("kill_pty", { ptyId: ptyIdRef.current }).catch(() => {});
 			}

--- a/src/hooks/useTerminalPanes.test.ts
+++ b/src/hooks/useTerminalPanes.test.ts
@@ -582,6 +582,23 @@ describe("useTerminalPanes", () => {
 			expect(result.current.tabs[0].id).not.toBe(inactiveTab.id);
 		});
 
+		it("markPendingPaneKill records a pending kill on the leaf until PTY ready", () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+			const paneId = result.current.tabs[0].focusedPaneId;
+
+			act(() => result.current.markPendingPaneKill(paneId));
+
+			let leaf = getAllLeaves(result.current.tabs[0].paneTree)[0];
+			expect(leaf.pendingKill).toBe(true);
+
+			act(() => result.current.updatePaneSessionKey(paneId, "key-active", 41));
+
+			leaf = getAllLeaves(result.current.tabs[0].paneTree)[0];
+			expect(leaf.pendingKill).toBe(false);
+		});
+
 		it("pty-evicted removes the matching inactive pane from cached state", async () => {
 			const { result } = renderHook(() =>
 				useTerminalPanes("Terminal", "/repo::Terminal"),
@@ -619,6 +636,78 @@ describe("useTerminalPanes", () => {
 			const remainingLeaves = getAllLeaves(result.current.tabs[0].paneTree);
 			expect(remainingLeaves).toHaveLength(1);
 			expect(remainingLeaves[0].sessionKey).toBe("key-active");
+		});
+
+		it("pty-evicted listener is not re-registered when active tab changes", async () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			await waitFor(() => {
+				expect(
+					mockListen.mock.calls.filter(
+						(call: unknown[]) => call[0] === "pty-evicted",
+					),
+				).toHaveLength(2);
+			});
+
+			act(() => result.current.addTab());
+
+			expect(
+				mockListen.mock.calls.filter(
+					(call: unknown[]) => call[0] === "pty-evicted",
+				),
+			).toHaveLength(2);
+		});
+
+		it("pty-evicted clears the latest active single-pane tab instead of removing it", async () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			await waitFor(() => {
+				expect(mockListen).toHaveBeenCalledWith(
+					"pty-evicted",
+					expect.any(Function),
+				);
+			});
+			const listener = mockListen.mock.calls.find(
+				(call: unknown[]) => call[0] === "pty-evicted",
+			)?.[1] as (event: {
+				payload: { pty_id: number; session_key: string; reason: string };
+			}) => void;
+
+			act(() => result.current.addTab());
+			const activeTab = result.current.activeTab;
+			if (!activeTab) throw new Error("active tab should exist");
+			const activePane = getAllLeaves(activeTab.paneTree)[0];
+			act(() =>
+				result.current.updatePaneSessionKey(
+					activePane.id,
+					"key-latest-active",
+					77,
+				),
+			);
+
+			act(() => {
+				listener({
+					payload: {
+						pty_id: 77,
+						session_key: "key-latest-active",
+						reason: "idle",
+					},
+				});
+			});
+
+			expect(result.current.tabs).toHaveLength(2);
+			expect(result.current.activeTabId).toBe(activeTab.id);
+			const remainingActiveTab = result.current.tabs.find(
+				(tab) => tab.id === activeTab.id,
+			);
+			if (!remainingActiveTab) throw new Error("active tab should remain");
+			const leaf = getAllLeaves(remainingActiveTab.paneTree)[0];
+			expect(leaf.ptyId).toBeNull();
+			expect(leaf.sessionKey).toBeNull();
 		});
 
 		it("global pty-evicted mirror removes cached panes while unmounted", async () => {

--- a/src/hooks/useTerminalPanes.test.ts
+++ b/src/hooks/useTerminalPanes.test.ts
@@ -1,17 +1,29 @@
 import { invoke } from "@tauri-apps/api/core";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { countLeaves, getAllLeaves } from "@/lib/paneTree";
-import { _resetIdCounters, useTerminalPanes } from "./useTerminalPanes";
+import {
+	_clearTabStateCache,
+	_resetIdCounters,
+	useTerminalPanes,
+} from "./useTerminalPanes";
+
+const mockListen = vi.fn();
 
 vi.mock("@tauri-apps/api/core", () => ({
 	invoke: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: (...args: unknown[]) => mockListen(...args),
+}));
+
 describe("useTerminalPanes", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockListen.mockResolvedValue(vi.fn());
 		_resetIdCounters();
+		_clearTabStateCache();
 	});
 
 	it("初期状態で1タブ1ペイン", () => {
@@ -506,6 +518,242 @@ describe("useTerminalPanes", () => {
 			);
 
 			expect(invoke).not.toHaveBeenCalledWith("kill_pty", expect.anything());
+		});
+	});
+
+	describe("Rust lifecycle mirror", () => {
+		it("updatePaneSessionKey stores the PTY id with the session key", () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+			const paneId = result.current.tabs[0].focusedPaneId;
+
+			act(() => result.current.updatePaneSessionKey(paneId, "key-active", 41));
+
+			const leaf = getAllLeaves(result.current.tabs[0].paneTree)[0];
+			expect(leaf.sessionKey).toBe("key-active");
+			expect(leaf.ptyId).toBe(41);
+		});
+
+		it("closeSpecificPane kills the PTY stored on an inactive pane", () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			act(() => result.current.splitFocusedPane("vertical"));
+			const leaves = getAllLeaves(result.current.tabs[0].paneTree);
+			act(() =>
+				result.current.updatePaneSessionKey(leaves[0].id, "key-old", 41),
+			);
+			act(() =>
+				result.current.updatePaneSessionKey(leaves[1].id, "key-active", 42),
+			);
+			vi.mocked(invoke).mockClear();
+
+			act(() => result.current.closeSpecificPane(leaves[0].id));
+
+			expect(invoke).toHaveBeenCalledWith("kill_pty", { ptyId: 41 });
+			const remainingLeaves = getAllLeaves(result.current.tabs[0].paneTree);
+			expect(remainingLeaves).toHaveLength(1);
+			expect(remainingLeaves[0].sessionKey).toBe("key-active");
+		});
+
+		it("closeTab kills PTYs stored on an inactive tab", () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			const inactiveTab = result.current.tabs[0];
+			const inactivePane = getAllLeaves(inactiveTab.paneTree)[0];
+			act(() =>
+				result.current.updatePaneSessionKey(
+					inactivePane.id,
+					"key-inactive-tab",
+					43,
+				),
+			);
+			act(() => result.current.addTab());
+			vi.mocked(invoke).mockClear();
+
+			act(() => result.current.closeTab(inactiveTab.id));
+
+			expect(invoke).toHaveBeenCalledWith("kill_pty", { ptyId: 43 });
+			expect(result.current.tabs).toHaveLength(1);
+			expect(result.current.tabs[0].id).not.toBe(inactiveTab.id);
+		});
+
+		it("pty-evicted removes the matching inactive pane from cached state", async () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			act(() => result.current.splitFocusedPane("vertical"));
+			const leaves = getAllLeaves(result.current.tabs[0].paneTree);
+			act(() => result.current.updatePaneSessionKey(leaves[0].id, "key-old"));
+			act(() =>
+				result.current.updatePaneSessionKey(leaves[1].id, "key-active"),
+			);
+
+			await waitFor(() => {
+				expect(mockListen).toHaveBeenCalledWith(
+					"pty-evicted",
+					expect.any(Function),
+				);
+			});
+			const listener = mockListen.mock.calls.find(
+				(call: unknown[]) => call[0] === "pty-evicted",
+			)?.[1] as (event: {
+				payload: { pty_id: number; session_key: string; reason: string };
+			}) => void;
+
+			act(() => {
+				listener({
+					payload: {
+						pty_id: 1,
+						session_key: "key-old",
+						reason: "idle",
+					},
+				});
+			});
+
+			const remainingLeaves = getAllLeaves(result.current.tabs[0].paneTree);
+			expect(remainingLeaves).toHaveLength(1);
+			expect(remainingLeaves[0].sessionKey).toBe("key-active");
+		});
+
+		it("global pty-evicted mirror removes cached panes while unmounted", async () => {
+			const { result, unmount } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			act(() => result.current.splitFocusedPane("vertical"));
+			const leaves = getAllLeaves(result.current.tabs[0].paneTree);
+			act(() => result.current.updatePaneSessionKey(leaves[0].id, "key-old"));
+			act(() =>
+				result.current.updatePaneSessionKey(leaves[1].id, "key-active"),
+			);
+
+			await waitFor(() => {
+				expect(
+					mockListen.mock.calls.filter(
+						(call: unknown[]) => call[0] === "pty-evicted",
+					),
+				).toHaveLength(2);
+			});
+			const listeners = mockListen.mock.calls
+				.filter((call: unknown[]) => call[0] === "pty-evicted")
+				.map((call: unknown[]) => call[1]) as Array<
+				(event: {
+					payload: { pty_id: number; session_key: string; reason: string };
+				}) => void
+			>;
+
+			unmount();
+			act(() => {
+				listeners[1]({
+					payload: {
+						pty_id: 1,
+						session_key: "key-old",
+						reason: "idle",
+					},
+				});
+			});
+
+			const { result: remounted } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+			const remainingLeaves = getAllLeaves(remounted.current.tabs[0].paneTree);
+			expect(remainingLeaves).toHaveLength(1);
+			expect(remainingLeaves[0].sessionKey).toBe("key-active");
+		});
+
+		it("mount reconciliation removes cached panes missing from Rust registry", async () => {
+			vi.mocked(invoke).mockImplementation((command) => {
+				if (command === "list_pty_sessions") {
+					return Promise.resolve([
+						{ session_key: "key-old" },
+						{ session_key: "key-active" },
+					]);
+				}
+				return Promise.resolve(undefined);
+			});
+
+			const { result, unmount } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			act(() => result.current.splitFocusedPane("vertical"));
+			const leaves = getAllLeaves(result.current.tabs[0].paneTree);
+			act(() => result.current.updatePaneSessionKey(leaves[0].id, "key-old"));
+			act(() =>
+				result.current.updatePaneSessionKey(leaves[1].id, "key-active"),
+			);
+			await waitFor(() => {
+				expect(invoke).toHaveBeenCalledWith("list_pty_sessions");
+			});
+			unmount();
+
+			vi.mocked(invoke).mockImplementation((command) => {
+				if (command === "list_pty_sessions") {
+					return Promise.resolve([{ session_key: "key-active" }]);
+				}
+				return Promise.resolve(undefined);
+			});
+
+			const { result: remounted } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			await waitFor(() => {
+				const remainingLeaves = getAllLeaves(
+					remounted.current.tabs[0].paneTree,
+				);
+				expect(remainingLeaves).toHaveLength(1);
+				expect(remainingLeaves[0].sessionKey).toBe("key-active");
+			});
+		});
+
+		it("removePendingPane rolls back a split pane before PTY initialization succeeds", () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			act(() => result.current.splitFocusedPane("vertical"));
+			const pendingPaneId = result.current.activeTab?.focusedPaneId;
+			expect(countLeaves(result.current.tabs[0].paneTree)).toBe(2);
+
+			act(() => result.current.removePendingPane(pendingPaneId ?? ""));
+
+			expect(countLeaves(result.current.tabs[0].paneTree)).toBe(1);
+		});
+
+		it("removePendingPane closes a pending tab when it was the only pane", () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+
+			act(() => result.current.addTab());
+			const pendingPaneId = result.current.activeTab?.focusedPaneId;
+			expect(result.current.tabs).toHaveLength(2);
+
+			act(() => result.current.removePendingPane(pendingPaneId ?? ""));
+
+			expect(result.current.tabs).toHaveLength(1);
+		});
+
+		it("removePendingPane keeps panes that already have a session key", () => {
+			const { result } = renderHook(() =>
+				useTerminalPanes("Terminal", "/repo::Terminal"),
+			);
+			const paneId = result.current.tabs[0].focusedPaneId;
+			act(() => result.current.updatePaneSessionKey(paneId, "key-active"));
+
+			act(() => result.current.removePendingPane(paneId));
+
+			expect(result.current.tabs).toHaveLength(1);
+			expect(getAllLeaves(result.current.tabs[0].paneTree)[0].sessionKey).toBe(
+				"key-active",
+			);
 		});
 	});
 });

--- a/src/hooks/useTerminalPanes.ts
+++ b/src/hooks/useTerminalPanes.ts
@@ -98,6 +98,7 @@ export interface UseTerminalPanesReturn {
 		sessionKey: string,
 		ptyId?: number,
 	) => void;
+	markPendingPaneKill: (paneId: string) => void;
 	removePendingPane: (paneId: string) => void;
 	activeTab: TerminalTab | undefined;
 }
@@ -178,7 +179,11 @@ export function useTerminalPanes(
 		listen<PtyEvicted>("pty-evicted", (event) => {
 			if (cancelled) return;
 			setTabs((prev) =>
-				removePaneBySessionKey(prev, event.payload.session_key, activeTabId),
+				removePaneBySessionKey(
+					prev,
+					event.payload.session_key,
+					activeTabIdRef.current,
+				),
 			);
 		})
 			.then((fn) => {
@@ -196,7 +201,7 @@ export function useTerminalPanes(
 			cancelled = true;
 			unlisten?.();
 		};
-	}, [cacheKey, activeTabId]);
+	}, [cacheKey]);
 
 	useEffect(() => {
 		if (!cacheKey) return;
@@ -536,6 +541,10 @@ export function useTerminalPanes(
 		[],
 	);
 
+	const markPendingPaneKill = useCallback((paneId: string) => {
+		setTabs((prev) => markPendingPaneKillById(prev, paneId));
+	}, []);
+
 	const removePendingPane = useCallback((paneId: string) => {
 		setTabs((prev) => removePendingPaneById(prev, paneId, setActiveTabId));
 	}, []);
@@ -555,6 +564,7 @@ export function useTerminalPanes(
 		movePaneToTab,
 		movePaneInTab,
 		updatePaneSessionKey,
+		markPendingPaneKill,
 		removePendingPane,
 		activeTab,
 	};
@@ -568,7 +578,12 @@ function updateNodeSessionKey(
 ): PaneNode {
 	if (node.type === "leaf") {
 		if (node.id === paneId) {
-			return { ...node, ptyId: ptyId ?? node.ptyId, sessionKey };
+			return {
+				...node,
+				ptyId: ptyId ?? node.ptyId,
+				sessionKey,
+				pendingKill: false,
+			};
 		}
 		return node;
 	}
@@ -713,6 +728,7 @@ function removePaneBySessionKeyFromState(
 				...target,
 				ptyId: null,
 				sessionKey: null,
+				pendingKill: false,
 			};
 			return {
 				tabs: [
@@ -723,7 +739,25 @@ function removePaneBySessionKeyFromState(
 			};
 		}
 		if (tab.id === activeTabId && !removeActiveSinglePaneTab) {
-			return { tabs, activeTabId, changed: false };
+			const clearedPane: PaneLeaf = {
+				...target,
+				ptyId: null,
+				sessionKey: null,
+				pendingKill: false,
+			};
+			return {
+				tabs: tabs.map((candidate, index) =>
+					index === tabIndex
+						? {
+								...candidate,
+								paneTree: clearedPane,
+								focusedPaneId: clearedPane.id,
+							}
+						: candidate,
+				),
+				activeTabId,
+				changed: true,
+			};
 		}
 		const nextTabs = tabs.filter((_, index) => index !== tabIndex);
 		const nextActiveTabId =
@@ -758,6 +792,34 @@ function removePaneBySessionKeyFromState(
 		activeTabId,
 		changed: true,
 	};
+}
+
+function markPendingPaneKillById(
+	tabs: TerminalTab[],
+	paneId: string,
+): TerminalTab[] {
+	let changed = false;
+	const nextTabs = tabs.map((tab) => {
+		const updated = markPendingPaneKillInTree(tab.paneTree, paneId);
+		if (updated === tab.paneTree) return tab;
+		changed = true;
+		return { ...tab, paneTree: updated };
+	});
+	return changed ? nextTabs : tabs;
+}
+
+function markPendingPaneKillInTree(node: PaneNode, paneId: string): PaneNode {
+	if (node.type === "leaf") {
+		if (node.id !== paneId || node.pendingKill) return node;
+		return { ...node, pendingKill: true };
+	}
+	let changed = false;
+	const children = node.children.map((child) => {
+		const updated = markPendingPaneKillInTree(child, paneId);
+		if (updated !== child) changed = true;
+		return updated;
+	});
+	return changed ? { ...node, children } : node;
 }
 
 function removePendingPaneById(

--- a/src/hooks/useTerminalPanes.ts
+++ b/src/hooks/useTerminalPanes.ts
@@ -1,3 +1,5 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	closePane,
@@ -42,11 +44,28 @@ interface CachedTabState {
 	paneNameCounter: number;
 }
 
+interface PtyEvicted {
+	pty_id: number;
+	session_key: string;
+	reason: string;
+}
+
+interface PtySessionInfo {
+	session_key: string;
+}
+
 const tabStateCache = new Map<string, CachedTabState>();
+let ptyEvictionMirrorPromise: Promise<() => void> | null = null;
+let ptyEvictionMirrorUnlisten: (() => void) | undefined;
+let ptyEvictionMirrorToken = 0;
 
 /** テスト用: キャッシュクリア */
 export function _clearTabStateCache(): void {
 	tabStateCache.clear();
+	ptyEvictionMirrorToken += 1;
+	ptyEvictionMirrorUnlisten?.();
+	ptyEvictionMirrorUnlisten = undefined;
+	ptyEvictionMirrorPromise = null;
 }
 
 type NavigationDirection = "left" | "right" | "up" | "down";
@@ -74,7 +93,12 @@ export interface UseTerminalPanesReturn {
 		direction: SplitDirection,
 		insertBefore?: boolean,
 	) => void;
-	updatePaneSessionKey: (paneId: string, sessionKey: string) => void;
+	updatePaneSessionKey: (
+		paneId: string,
+		sessionKey: string,
+		ptyId?: number,
+	) => void;
+	removePendingPane: (paneId: string) => void;
 	activeTab: TerminalTab | undefined;
 }
 
@@ -143,6 +167,73 @@ export function useTerminalPanes(
 	}, [cacheKey, tabs, activeTabId]);
 
 	const activeTab = tabs.find((t) => t.id === activeTabId);
+	const activeTabIdRef = useRef(activeTabId);
+	activeTabIdRef.current = activeTabId;
+
+	useEffect(() => {
+		if (!cacheKey) return;
+		let cancelled = false;
+		let unlisten: (() => void) | undefined;
+
+		listen<PtyEvicted>("pty-evicted", (event) => {
+			if (cancelled) return;
+			setTabs((prev) =>
+				removePaneBySessionKey(prev, event.payload.session_key, activeTabId),
+			);
+		})
+			.then((fn) => {
+				if (cancelled) {
+					fn();
+					return;
+				}
+				unlisten = fn;
+			})
+			.catch((error) => {
+				console.error("Failed to listen for PTY eviction:", error);
+			});
+
+		return () => {
+			cancelled = true;
+			unlisten?.();
+		};
+	}, [cacheKey, activeTabId]);
+
+	useEffect(() => {
+		if (!cacheKey) return;
+		ensurePtyEvictionMirror();
+	}, [cacheKey]);
+
+	useEffect(() => {
+		if (!cacheKey) return;
+		let cancelled = false;
+
+		invoke<PtySessionInfo[]>("list_pty_sessions")
+			.then((sessions) => {
+				if (cancelled || !Array.isArray(sessions)) return;
+				const liveSessionKeys = new Set(
+					sessions.map((session) => session.session_key),
+				);
+				setTabs((prev) => {
+					const result = removeStalePanes(
+						prev,
+						activeTabIdRef.current,
+						liveSessionKeys,
+					);
+					if (!result.changed) return prev;
+					if (result.activeTabId !== activeTabIdRef.current) {
+						setActiveTabId(result.activeTabId);
+					}
+					return result.tabs;
+				});
+			})
+			.catch((error) => {
+				console.error("Failed to reconcile PTY sessions:", error);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [cacheKey]);
 
 	const addTab = useCallback(() => {
 		if (tabsLengthRef.current >= MAX_TABS) return;
@@ -163,19 +254,25 @@ export function useTerminalPanes(
 		});
 	}, [tabPrefix, createLeaf]);
 
-	const closeTab = useCallback((tabId: string) => {
-		setTabs((prev) => {
-			if (prev.length <= 1) return prev;
-			const next = prev.filter((t) => t.id !== tabId);
-			setActiveTabId((currentActive) => {
-				if (currentActive !== tabId) return currentActive;
-				const idx = prev.findIndex((t) => t.id === tabId);
-				const fallback = prev[idx - 1] ?? prev[idx + 1];
-				return fallback?.id ?? currentActive;
+	const closeTab = useCallback(
+		(tabId: string) => {
+			const tab = tabs.find((t) => t.id === tabId);
+			if (!tab || tabs.length <= 1) return;
+			killPaneTreePtys(tab.paneTree);
+			setTabs((prev) => {
+				if (prev.length <= 1) return prev;
+				const next = prev.filter((t) => t.id !== tabId);
+				setActiveTabId((currentActive) => {
+					if (currentActive !== tabId) return currentActive;
+					const idx = prev.findIndex((t) => t.id === tabId);
+					const fallback = prev[idx - 1] ?? prev[idx + 1];
+					return fallback?.id ?? currentActive;
+				});
+				return next;
 			});
-			return next;
-		});
-	}, []);
+		},
+		[tabs],
+	);
 
 	const updateActiveTab = useCallback(
 		(updater: (tab: TerminalTab) => TerminalTab) => {
@@ -208,41 +305,58 @@ export function useTerminalPanes(
 		[updateActiveTab, createLeaf],
 	);
 
-	const closeSpecificPane = useCallback((paneId: string) => {
-		setTabs((prev) => {
-			const tabIndex = prev.findIndex((t) => findNode(t.paneTree, paneId));
-			if (tabIndex === -1) return prev;
-
-			const tab = prev[tabIndex];
-
-			const newTree = closePane(tab.paneTree, paneId);
-
-			if (newTree === null) {
-				// 最後のペイン → タブを閉じる
-				if (prev.length <= 1) return prev;
-				const next = prev.filter((_, i) => i !== tabIndex);
-				setActiveTabId((currentActive) => {
-					if (currentActive !== tab.id) return currentActive;
-					const fallback = prev[tabIndex - 1] ?? prev[tabIndex + 1];
-					return fallback?.id ?? currentActive;
-				});
-				return next;
+	const closeSpecificPane = useCallback(
+		(paneId: string) => {
+			const tabIndex = tabs.findIndex((t) => findNode(t.paneTree, paneId));
+			if (tabIndex === -1) return;
+			const tab = tabs[tabIndex];
+			const target = findNode(tab.paneTree, paneId);
+			if (target?.type !== "leaf") return;
+			const isLastPaneInLastTab =
+				countLeaves(tab.paneTree) <= 1 && tabs.length <= 1;
+			if (!isLastPaneInLastTab) {
+				killPanePty(target);
 			}
 
-			// フォーカスを兄弟に移動
-			let newFocused = tab.focusedPaneId;
-			if (paneId === tab.focusedPaneId) {
-				const leaves = getAllLeaves(newTree);
-				newFocused = leaves[0]?.id ?? tab.focusedPaneId;
-			}
+			setTabs((prev) => {
+				const currentTabIndex = prev.findIndex((t) =>
+					findNode(t.paneTree, paneId),
+				);
+				if (currentTabIndex === -1) return prev;
 
-			return prev.map((t, i) =>
-				i === tabIndex
-					? { ...t, paneTree: newTree, focusedPaneId: newFocused }
-					: t,
-			);
-		});
-	}, []);
+				const currentTab = prev[currentTabIndex];
+
+				const newTree = closePane(currentTab.paneTree, paneId);
+
+				if (newTree === null) {
+					// 最後のペイン → タブを閉じる
+					if (prev.length <= 1) return prev;
+					const next = prev.filter((_, i) => i !== currentTabIndex);
+					setActiveTabId((currentActive) => {
+						if (currentActive !== currentTab.id) return currentActive;
+						const fallback =
+							prev[currentTabIndex - 1] ?? prev[currentTabIndex + 1];
+						return fallback?.id ?? currentActive;
+					});
+					return next;
+				}
+
+				// フォーカスを兄弟に移動
+				let newFocused = currentTab.focusedPaneId;
+				if (paneId === currentTab.focusedPaneId) {
+					const leaves = getAllLeaves(newTree);
+					newFocused = leaves[0]?.id ?? currentTab.focusedPaneId;
+				}
+
+				return prev.map((t, i) =>
+					i === currentTabIndex
+						? { ...t, paneTree: newTree, focusedPaneId: newFocused }
+						: t,
+				);
+			});
+		},
+		[tabs],
+	);
 
 	const closeFocusedPane = useCallback(() => {
 		const tab = tabs.find((t) => t.id === activeTabId);
@@ -406,13 +520,14 @@ export function useTerminalPanes(
 	);
 
 	const updatePaneSessionKey = useCallback(
-		(paneId: string, sessionKey: string) => {
+		(paneId: string, sessionKey: string, ptyId?: number) => {
 			setTabs((prev) =>
 				prev.map((tab) => {
 					const updated = updateNodeSessionKey(
 						tab.paneTree,
 						paneId,
 						sessionKey,
+						ptyId,
 					);
 					return updated === tab.paneTree ? tab : { ...tab, paneTree: updated };
 				}),
@@ -420,6 +535,10 @@ export function useTerminalPanes(
 		},
 		[],
 	);
+
+	const removePendingPane = useCallback((paneId: string) => {
+		setTabs((prev) => removePendingPaneById(prev, paneId, setActiveTabId));
+	}, []);
 
 	return {
 		tabs,
@@ -436,6 +555,7 @@ export function useTerminalPanes(
 		movePaneToTab,
 		movePaneInTab,
 		updatePaneSessionKey,
+		removePendingPane,
 		activeTab,
 	};
 }
@@ -444,18 +564,242 @@ function updateNodeSessionKey(
 	node: PaneNode,
 	paneId: string,
 	sessionKey: string,
+	ptyId?: number,
 ): PaneNode {
 	if (node.type === "leaf") {
 		if (node.id === paneId) {
-			return { ...node, sessionKey };
+			return { ...node, ptyId: ptyId ?? node.ptyId, sessionKey };
 		}
 		return node;
 	}
 	let changed = false;
 	const newChildren = node.children.map((child) => {
-		const updated = updateNodeSessionKey(child, paneId, sessionKey);
+		const updated = updateNodeSessionKey(child, paneId, sessionKey, ptyId);
 		if (updated !== child) changed = true;
 		return updated;
 	});
 	return changed ? { ...node, children: newChildren } : node;
+}
+
+function killPaneTreePtys(node: PaneNode): void {
+	for (const leaf of getAllLeaves(node)) {
+		killPanePty(leaf);
+	}
+}
+
+function killPanePty(pane: PaneLeaf): void {
+	if (pane.ptyId === null) return;
+	invoke("kill_pty", { ptyId: pane.ptyId }).catch((error) => {
+		console.error("Failed to kill closed terminal PTY:", error);
+	});
+}
+
+function removePaneBySessionKey(
+	tabs: TerminalTab[],
+	sessionKey: string,
+	activeTabId: string,
+): TerminalTab[] {
+	return removePaneBySessionKeyFromState(tabs, sessionKey, activeTabId, false)
+		.tabs;
+}
+
+interface PaneRemovalResult {
+	tabs: TerminalTab[];
+	activeTabId: string;
+	changed: boolean;
+}
+
+function ensurePtyEvictionMirror(): void {
+	if (ptyEvictionMirrorPromise) return;
+	const token = ptyEvictionMirrorToken;
+	ptyEvictionMirrorPromise = listen<PtyEvicted>("pty-evicted", (event) => {
+		removeEvictedSessionFromTabStateCache(event.payload.session_key);
+	})
+		.then((unlisten) => {
+			if (token !== ptyEvictionMirrorToken) {
+				unlisten();
+				return unlisten;
+			}
+			ptyEvictionMirrorUnlisten = unlisten;
+			return unlisten;
+		})
+		.catch((error) => {
+			if (token === ptyEvictionMirrorToken) {
+				ptyEvictionMirrorPromise = null;
+			}
+			console.error("Failed to listen for global PTY eviction:", error);
+			return () => {};
+		});
+}
+
+function removeEvictedSessionFromTabStateCache(sessionKey: string): void {
+	for (const [key, cached] of tabStateCache) {
+		const result = removePaneBySessionKeyFromState(
+			cached.tabs,
+			sessionKey,
+			cached.activeTabId,
+			true,
+		);
+		if (!result.changed) continue;
+		tabStateCache.set(key, {
+			...cached,
+			tabs: result.tabs,
+			activeTabId: result.activeTabId,
+		});
+	}
+}
+
+function removeStalePanes(
+	tabs: TerminalTab[],
+	activeTabId: string,
+	liveSessionKeys: Set<string>,
+): PaneRemovalResult {
+	let currentTabs = tabs;
+	let currentActiveTabId = activeTabId;
+	let changed = false;
+
+	while (true) {
+		const staleLeaf = currentTabs
+			.flatMap((tab) => getAllLeaves(tab.paneTree))
+			.find(
+				(leaf) =>
+					leaf.sessionKey !== null && !liveSessionKeys.has(leaf.sessionKey),
+			);
+		if (!staleLeaf?.sessionKey) break;
+
+		const result = removePaneBySessionKeyFromState(
+			currentTabs,
+			staleLeaf.sessionKey,
+			currentActiveTabId,
+			true,
+		);
+		if (!result.changed) break;
+		currentTabs = result.tabs;
+		currentActiveTabId = result.activeTabId;
+		changed = true;
+	}
+
+	return {
+		tabs: currentTabs,
+		activeTabId: currentActiveTabId,
+		changed,
+	};
+}
+
+function removePaneBySessionKeyFromState(
+	tabs: TerminalTab[],
+	sessionKey: string,
+	activeTabId: string,
+	removeActiveSinglePaneTab: boolean,
+): PaneRemovalResult {
+	const tabIndex = tabs.findIndex((tab) =>
+		getAllLeaves(tab.paneTree).some((leaf) => leaf.sessionKey === sessionKey),
+	);
+	if (tabIndex === -1) {
+		return { tabs, activeTabId, changed: false };
+	}
+
+	const tab = tabs[tabIndex];
+	const target = getAllLeaves(tab.paneTree).find(
+		(leaf) => leaf.sessionKey === sessionKey,
+	);
+	if (!target) {
+		return { tabs, activeTabId, changed: false };
+	}
+
+	if (countLeaves(tab.paneTree) <= 1) {
+		if (tabs.length <= 1) {
+			const clearedPane: PaneLeaf = {
+				...target,
+				ptyId: null,
+				sessionKey: null,
+			};
+			return {
+				tabs: [
+					{ ...tab, paneTree: clearedPane, focusedPaneId: clearedPane.id },
+				],
+				activeTabId,
+				changed: true,
+			};
+		}
+		if (tab.id === activeTabId && !removeActiveSinglePaneTab) {
+			return { tabs, activeTabId, changed: false };
+		}
+		const nextTabs = tabs.filter((_, index) => index !== tabIndex);
+		const nextActiveTabId =
+			tab.id === activeTabId
+				? ((tabs[tabIndex - 1] ?? tabs[tabIndex + 1])?.id ??
+					nextTabs[0]?.id ??
+					activeTabId)
+				: activeTabId;
+		return {
+			tabs: nextTabs,
+			activeTabId: nextActiveTabId,
+			changed: true,
+		};
+	}
+
+	const newTree = closePane(tab.paneTree, target.id);
+	if (!newTree) {
+		return { tabs, activeTabId, changed: false };
+	}
+	const leaves = getAllLeaves(newTree);
+	const focusedPaneId =
+		tab.focusedPaneId === target.id
+			? (leaves[0]?.id ?? tab.focusedPaneId)
+			: tab.focusedPaneId;
+
+	return {
+		tabs: tabs.map((candidate, index) =>
+			index === tabIndex
+				? { ...candidate, paneTree: newTree, focusedPaneId }
+				: candidate,
+		),
+		activeTabId,
+		changed: true,
+	};
+}
+
+function removePendingPaneById(
+	tabs: TerminalTab[],
+	paneId: string,
+	setActiveTabId: (updater: (currentActive: string) => string) => void,
+): TerminalTab[] {
+	const tabIndex = tabs.findIndex((tab) => findNode(tab.paneTree, paneId));
+	if (tabIndex === -1) return tabs;
+
+	const tab = tabs[tabIndex];
+	const target = findNode(tab.paneTree, paneId);
+	if (
+		target?.type !== "leaf" ||
+		target.sessionKey !== null ||
+		target.ptyId !== null
+	) {
+		return tabs;
+	}
+
+	if (countLeaves(tab.paneTree) <= 1) {
+		if (tabs.length <= 1) return tabs;
+		const next = tabs.filter((_, index) => index !== tabIndex);
+		setActiveTabId((currentActive) => {
+			if (currentActive !== tab.id) return currentActive;
+			const fallback = tabs[tabIndex - 1] ?? tabs[tabIndex + 1];
+			return fallback?.id ?? currentActive;
+		});
+		return next;
+	}
+
+	const newTree = closePane(tab.paneTree, paneId);
+	if (!newTree) return tabs;
+	const leaves = getAllLeaves(newTree);
+	const focusedPaneId =
+		tab.focusedPaneId === paneId
+			? (leaves[0]?.id ?? tab.focusedPaneId)
+			: tab.focusedPaneId;
+
+	return tabs.map((candidate, index) =>
+		index === tabIndex
+			? { ...candidate, paneTree: newTree, focusedPaneId }
+			: candidate,
+	);
 }

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -6,6 +6,12 @@ export interface PtyExitMsg {
 	exit_code: number | null;
 }
 
+export interface PtyEvictedMsg {
+	pty_id: number;
+	session_key: string;
+	reason: "idle" | "cap_exceeded";
+}
+
 export interface WorktreePrEntry {
 	path: string;
 	pr_number: number;
@@ -178,8 +184,12 @@ export type WsMessage =
 	| { type: "auth_challenge"; payload: { challenge: string } }
 	| { type: "auth_response"; payload: { hmac: string } }
 	| { type: "auth_result"; payload: { success: boolean; message?: string } }
-	| { type: "pty_output"; payload: { pty_id: number; data: string } }
+	| {
+			type: "pty_output";
+			payload: { pty_id: number; data: string; sequence: number };
+	  }
 	| { type: "pty_exit"; payload: PtyExitMsg }
+	| { type: "pty_evicted"; payload: PtyEvictedMsg }
 	| { type: "worktree_pr_status_sync"; payload: WorktreePrStatusSync }
 	| { type: "branch_list_sync"; payload: BranchListSync }
 	| { type: "agent_state_sync"; payload: AgentStateSync }

--- a/src/types/terminal-pane.ts
+++ b/src/types/terminal-pane.ts
@@ -6,6 +6,7 @@ export interface PaneLeaf {
 	label: string;
 	ptyId: number | null;
 	sessionKey: string | null;
+	pendingKill?: boolean;
 }
 
 export interface PaneContainer {


### PR DESCRIPTION
## 概要

`docs/releash-performance-architecture-audit.md` M3「Runtime lifecycle を締める」の一部として、Terminal / PTY のライフサイクルに **cap・eviction・idle timeout** を導入する。Terminal / PTY のメモリ常駐量とピークを境界づけ、active terminal の UX を壊さずに inactive terminal を軽量状態へ退避・復元できるようにする。

関連: #1215 / #1196 / #858

## 背景

現状で以下の無制限増大・二重保持が確認されている。

- frontend xterm の常時マウント（inactive tab/pane も `forceMount`）
- frontend cache の eviction 不在（`sessionKeyCache` / `tabStateCache`）
- PTY output buffer の二重保持（runtime 側 + WS bridge 側、~128KB/PTY）
- PTY registry の cap 不在（自動 eviction なし）
- alive な PTY への idle timeout 不在
- remote subscriber 不在時の buffer 継続蓄積

## 変更内容

### Backend (Rust) — 境界づけの正本

- **`PtyLifecycleConfig`**（新規）: cap・idle timeout・buffer cap をチューニング可能なパラメータとして定義
- **`PtySessionRegistry`**: activity 追跡・pinned 集合・active pin token・cap 判定・LRU/idle eviction 対象選定を追加
- **`spawn_usecase`**: spawn 前の cap enforcement（LRU eviction or 上限制御）
- **`lifecycle_usecase`**: `sweep_idle`（idle timeout eviction）・`record_activity`・active terminal 登録/解除
- **output buffer の runtime 側一本化**: `ws_bridge.rs` の独立バッファを廃止し、remote subscriber には接続時に runtime buffer からスクロールバックを供給

### Frontend — 表示・復元に徹する

- active tab / active pane 以外の xterm を DOM から **unmount**、再アクティブ化時に Rust が保持する lightweight state から見た目とスクロールバックを **復元**
- mounted xterm 数が hidden terminal 数に比例して増え続けないことを保証

`.claude/rules/rust-first-logic.md` 準拠で、cap / eviction / idle timeout の enforcement はすべて Rust 側で行う。

## Spec

- `docs/specs/issues-1215/requirements.md`
- `docs/specs/issues-1215/behavior.md`
- `docs/specs/issues-1215/design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 非アクティブな端末の自動クリーンアップ機能を追加しました。アイドル状態の端末は自動的に終了し、メモリ使用量を最適化します。
  * 端末ペインの再アクティブ化時に、直近のスクロールバック履歴を自動復元するようになりました。
  * 端末のメモリ使用量に上限を設定し、ワークツリーごと・全体での端末数を制御できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->