### PR TITLE
feat(observability): add New Relic Terraform resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,10 @@ src-tauri/rust-codecov.json
 # Playwright
 test-results/
 playwright-report/
+
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example

--- a/docs/specs/issues-1258/behavior.md
+++ b/docs/specs/issues-1258/behavior.md
@@ -1,0 +1,155 @@
+# Behavior
+
+#1258: NewRelic 観測リソース（ダッシュボード / アラート / データ管理）の Terraform IaC 化。
+
+本書は観測可能な振る舞いのみを Gherkin で定義する。Terraform リソースの内部 HCL 構造や provider API 呼び出しの詳細は扱わず、「構成として何が固定されるか」「どの入力に対しどの結果が観測されるか」を記述する。
+
+## 用語
+
+- **観測者**: `infra/newrelic/` の Terraform 構成をレビュー・実行する人。
+- **クリーンな plan**: 作業者が `terraform plan` を実行し、HCP Terraform workspace 上でエラーなく完了すること。state とコードの差分有無自体は問わない（新規 apply 前は差分ありが正常）。
+- **許可属性 allowlist**: resource 属性 `service.version` / `os.type` / `releash.build_type` / `service.name` の4種（#1209 実装値、A2）。
+- **#1209 メトリクス集合**: requirements スコープ1 に列挙されたメトリクス名・属性キー（A1）。
+
+## 仮定（behavior レベルで確定したもの）
+
+- B1. アラートしきい値は audit M0 の性能予算（A5）を正本とし、以下を採用する。
+  - 性能予算逸脱（duration 系）: P95 集計で評価する。repo snapshot 系（`git.status_scan` / `session.list` / `session.get_*` / `session.load_full` 等）は **300ms**（M0「200ms 台」の上限）、diff open 系（`git.diff_stats` / `review.file_open`）は **500ms**（M0「500ms 未満」）を超過したら逸脱とみなす。
+  - streaming payload 異常: `releash.agent_stream.payload_bytes` が **65536 bytes（64KB）** を継続的に超過したら異常とみなす。
+- B2. 評価集計は P95、評価ウィンドウは一定時間内の継続（瞬間スパイクで誤検知しない）とする。具体的なウィンドウ長・継続条件の数値は design で確定する（OQ3 確定: behavior は「一定ウィンドウの継続超過で発火する」方針のみ固定し、ウィンドウ長・連続回数等の数値は design に委ねる）。なお B5 / B6 のカウント型アラートは「5 分間で N 件」を初期値として持つが、これも design でチューニング可能とする。
+- B5. crash 急増アラートは**固定の絶対値**で検知する（OQ1 確定）。初期値は「5 分間で 5 件以上の crash/exception 相当エラー」とする。audit M0 に根拠数値が無いため初期値であり、運用実績に応じた具体値は design でチューニングする。
+- B6. 接続・描画品質劣化アラートは**固定の絶対値**で検知する（OQ2 確定、B5 と方式を統一）。初期値は「5 分間で `releash.agent_stream.ws_reconnects` 合計 5 回以上、または `releash.agent_stream.dropped_frames` 合計 10 件以上」とする。根拠数値が無いため初期値であり、具体値は design でチューニングする。
+- B3. 無料枠前提のため、Advanced Compute の有料アドオンである Pipeline Control Cloud Rules は使わない。データ管理は次元付き Metric の高カーディナリティ属性を `newrelic_metric_pruning_rule` で削除する範囲に限定する（A2）。
+- B4. Terraform は自動実行環境に組み込まない。検証・plan・apply は作業者が CLI で手動実行する（A4 / R6）。
+
+---
+
+## Feature: NewRelic 観測リソースの Terraform IaC 化
+
+  #1258 の受け入れ基準に対応する。`infra/newrelic/` の Terraform 構成として、
+  ダッシュボード・アラート・データ管理・state backend・認証注入の各振る舞いを固定する。
+
+  Background:
+    Given アプリと同一リポジトリに `infra/newrelic/` の Terraform 構成が存在する
+    And provider は `newrelic/newrelic` である
+    And 観測対象メトリクスは #1209 メトリクス集合に揃っている
+    And 性能予算の正本は audit M0 である
+
+  ### Rule: ダッシュボードは #1209 の計測項目を可視化する（R1）
+
+    Scenario: hot path メトリクスがダッシュボードで可視化される
+      Given #1209 メトリクス集合が NewRelic に取り込まれている
+      When 観測者がダッシュボード構成を確認する
+      Then 起動・初期化（`releash.startup.duration_ms`）が可視化されている
+      And Git/Diff hot path（`releash.hot_path.duration_ms` の `git.status_scan` / `git.diff_stats` / `review.file_open`）が可視化されている
+      And AgentSession session IO（`releash.hot_path.duration_ms` の session 系操作 / `releash.session.save_bytes`）が可視化されている
+      And streaming/payload（`releash.agent_stream.payload_bytes` / `emit_interval_ms` / `dropped_frames` / `ws_reconnects`）が可視化されている
+      And リソース観測（`releash.process.rss_bytes` / `cpu_percent` / `releash.frontend.mounted_xterm_count` / `releash.pty.active_count`）が可視化されている
+      And 操作成否・利用イベント（`releash.operation.status` / `releash.usage.events`）が可視化されている
+
+    Scenario: 可視化メトリクス名が #1209 実装値と一致する
+      Given ダッシュボードが参照するメトリクス名・属性キーが構成に記述されている
+      When 観測者がメトリクス名を #1209 実装値（A1）と突き合わせる
+      Then 構成に存在しないメトリクス名・属性キーは参照されていない
+
+    Scenario: ダッシュボードのしきい値表現が性能予算と整合する
+      Given ダッシュボードが duration 系メトリクスを表示する
+      When 観測者が表示基準（目標線・閾値表示等）を確認する
+      Then その基準は audit M0 の性能予算（B1 の値）と整合している
+
+  ### Rule: アラート条件は予算逸脱・異常を検知する（R2）
+
+    Scenario Outline: 性能予算逸脱を検知するアラート条件が定義されている
+      Given duration メトリクス "<metric_op>" が NewRelic に取り込まれている
+      When その P95 が "<budget_ms>" ms を継続的に超過する
+      Then 当該観点のアラート条件が発火しうるよう構成に定義されている
+
+      Examples:
+        | metric_op                         | budget_ms |
+        | git.status_scan (repo snapshot)   | 300       |
+        | session.list (session IO)         | 300       |
+        | git.diff_stats (diff open)        | 500       |
+        | review.file_open (diff open)      | 500       |
+
+    Scenario: crash 急増を検知するアラート条件が定義されている
+      Given crash/exception 相当のエラーイベントが取り込まれている
+      When エラー発生数が 5 分間で 5 件以上に達する
+      Then crash 急増を検知するアラート条件が発火しうるよう構成に定義されている
+
+    Scenario: 接続・描画品質劣化を検知するアラート条件が定義されている
+      Given `releash.agent_stream.ws_reconnects` / `releash.agent_stream.dropped_frames` が取り込まれている
+      When 5 分間で ws_reconnects 合計が 5 回以上、または dropped_frames 合計が 10 件以上に達する
+      Then 接続・描画品質劣化を検知するアラート条件が発火しうるよう構成に定義されている
+
+    Scenario: streaming payload 異常を検知するアラート条件が定義されている
+      Given `releash.agent_stream.payload_bytes` が取り込まれている
+      When payload が 65536 bytes（64KB）を継続的に超過する
+      Then streaming payload 異常を検知するアラート条件が構成に定義されている
+
+    Scenario: アラート条件は policy に紐づくが通知連携は含まない
+      Given アラート条件群が定義されている
+      When 観測者が構成を確認する
+      Then 各条件は policy に紐づいている
+      And NewRelic workflow / destination（Slack / Discord / メール等）の通知連携は構成に含まれない
+
+  ### Rule: データ管理は無料枠と有料アドオン不使用を固定する（R3）
+
+    Scenario: 取り込み量制御ルールが定義されている
+      Given 無料枠は 100GB/月である
+      When 観測者がデータ管理構成を確認する
+      Then 次元付き Metric の高カーディナリティ属性を削除する `newrelic_metric_pruning_rule` が構成に定義されている
+
+    Scenario: 有料アドオンの Cloud Rules は使わない
+      Given Pipeline Control Cloud Rules は Advanced Compute の有料アドオンである
+      When 観測者がデータ管理構成を確認する
+      Then `newrelic_pipeline_cloud_rule` は構成に含まれない
+      And Log / Span の保存前 drop はこの Terraform 構成に含まれない
+
+    Scenario: Metric pruning はアプリ側 allowlist と衝突しない
+      Given #1209 の許可属性 allowlist が存在する
+      When 観測者が Metric pruning の削除対象を確認する
+      Then `service.version` / `os.type` / `releash.build_type` / `service.name` は削除対象に含まれない
+
+  ### Rule: state は HCP Terraform で管理される（R4）
+
+    Scenario: state backend が HCP Terraform に設定されている
+      Given Terraform 構成に cloud 設定が存在する
+      When 観測者が backend 種別を確認する
+      Then HCP Terraform organization は `releash` である
+      And workspace は `newrelic` である
+      And state はローカルファイルに固定されていない
+
+  ### Rule: 認証情報はコードに含まれず変数経由で供給される（R5）
+
+    Scenario: provider 認証情報が変数経由で注入される
+      Given Terraform 構成が NewRelic provider 認証を要求する
+      When 観測者が認証情報の供給経路を確認する
+      Then 認証情報（User API key 等）は Terraform 変数経由で注入される
+      And 認証情報のリテラル値はリポジトリにコミットされていない
+
+    Scenario: 認証変数が未供給だと plan は認証エラーになる
+      Given 認証変数が供給されていない
+      When 観測者が `terraform plan` を実行する
+      Then 認証情報不足に起因するエラーで失敗する
+
+  ### Rule: plan はクリーンに通り import は不要（R6）
+
+    Scenario: 認証変数を供給した plan がクリーンに通る
+      Given 必須変数（認証情報）が供給されている
+      And HCP Terraform workspace への認証と権限がある
+      And NewRelic アカウントに手動構築済みリソースは存在しない（A6）
+      When 観測者が `terraform plan` を実行する
+      Then plan は構文・参照エラーなく完了する
+      And 全リソースは新規作成（add）として計画される
+      And `terraform import` を必要とするリソースは存在しない
+
+    Scenario: 構成は静的検証を通過する
+      Given `infra/newrelic/` の Terraform 構成が存在する
+      When 観測者が `terraform validate` を実行する
+      Then 構文・型エラーなく成功する
+
+---
+
+## Open Questions
+
+なし（OQ1〜OQ3 は確定済み。確定内容は B5 / B6 / B2 へ反映済み）。

--- a/docs/specs/issues-1258/design.md
+++ b/docs/specs/issues-1258/design.md
@@ -1,0 +1,241 @@
+# Design
+
+#1258: NewRelic 観測リソース（ダッシュボード / アラート / データ管理）の Terraform IaC 化。
+
+本書は `requirements.md` / `behavior.md` を実装に落とすための設計を定める。アプリ計装（#1209）は変更せず、観測先 SaaS（NewRelic）側の構成を `newrelic/newrelic` Terraform provider でコード化する。
+
+## 概要
+
+`infra/newrelic/` に Terraform 構成を新規作成し、以下を IaC 化する。
+
+1. **ダッシュボード** (`newrelic_one_dashboard`) — #1209 メトリクス集合の可視化（R1）
+2. **アラート** (`newrelic_alert_policy` + `newrelic_nrql_alert_condition`) — 性能予算逸脱 / crash 急増 / 接続品質劣化 / payload 異常の検知（R2）
+3. **データ管理** (`newrelic_metric_pruning_rule`) — 無料枠 100GB/月 の取り込み量 / カーディナリティ制御（R3）
+4. **リモート state backend** — HCP Terraform（organization `releash` / workspace `newrelic`）（R4）
+5. **認証注入** — provider 認証情報を変数経由で供給（R5）
+
+Terraform は自動実行環境に組み込まず、検証・plan・apply は作業者が CLI で手動実行する（B4 / A4）。
+
+## 変更対象
+
+新規ディレクトリ `infra/newrelic/` のみを追加する。アプリコード（`src-tauri/`, `src/`）は変更しない。
+
+```text
+infra/newrelic/
+├── versions.tf              # required_version / required_providers / backend 宣言
+├── backend.tf              # HCP Terraform cloud 設定（organization / workspace）
+├── providers.tf            # provider "newrelic"（認証は変数経由）
+├── variables.tf            # 入力変数（account_id / api_key / region 等）
+├── locals.tf               # メトリクス名・属性キー・しきい値・NRQL 断片の単一定義
+├── dashboards.tf           # newrelic_one_dashboard（R1）
+├── alerts.tf               # newrelic_alert_policy + newrelic_nrql_alert_condition（R2）
+├── data_management.tf      # metric pruning（取り込み量 / カーディナリティ制御）（R3）
+├── outputs.tf              # dashboard permalink / policy id 等（任意・参照用）
+├── terraform.tfvars.example# 変数サンプル（実値はコミットしない）
+└── README.md               # 認証・HCP Terraform・plan 手順
+```
+
+Terraform 用の GitHub Actions job は追加しない。
+
+## アーキテクチャと責務分割
+
+レイヤーではなくファイル単位で関心を分離する。`locals.tf` を**単一の真実源**とし、メトリクス名・属性キー・しきい値・許可属性 allowlist をここに集約する。ダッシュボード / アラート / metric pruning は `locals` を参照し、定義の重複を排除する。これにより #1209 実装値（A1 / A2）との突き合わせ（behavior「可視化メトリクス名が #1209 実装値と一致する」シナリオ）を `locals.tf` 1 箇所のレビューで担保できる。
+
+| ファイル | 責務 |
+|---|---|
+| `locals.tf` | #1209 メトリクス集合 / 属性キー / allowlist / 予算しきい値の定義。他ファイルはここを参照 |
+| `dashboards.tf` | `locals` のメトリクスを page / widget へ配置。表示基準（目標線）に予算値を埋める |
+| `alerts.tf` | `locals` の予算・初期値から NRQL 条件を生成。policy に紐付け、通知連携は持たない |
+| `data_management.tf` | `newrelic_metric_pruning_rule` による高カーディナリティ属性の削除 |
+| `providers.tf` / `variables.tf` / `backend.tf` / `versions.tf` | provider 認証・state backend・version pin |
+
+### provider / version pin（仮定 D1）
+
+- `required_version >= 1.10`（HCP Terraform cloud backend と `.terraform.lock.hcl` を安定利用するため）。
+- `newrelic/newrelic` provider はメジャー固定でピン留めする（例 `~> 3.x`）。具体版は実装時の最新安定版を `versions.tf` に固定し、`.terraform.lock.hcl` をコミットして再現性を担保する。
+
+## データモデルまたは型
+
+Terraform リソースとして固定する構成。
+
+### `locals.tf`（定義の単一源）
+
+```hcl
+locals {
+  # #1209 メトリクス集合（A1）。実装値: src-tauri/src/other/telemetry/
+  metrics = {
+    startup        = "releash.startup.duration_ms"
+    hot_path       = "releash.hot_path.duration_ms"
+    session_bytes  = "releash.session.save_bytes"
+    payload_bytes  = "releash.agent_stream.payload_bytes"
+    emit_interval  = "releash.agent_stream.emit_interval_ms"
+    dropped_frames = "releash.agent_stream.dropped_frames"
+    ws_reconnects  = "releash.agent_stream.ws_reconnects"
+    rss_bytes      = "releash.process.rss_bytes"
+    cpu_percent    = "releash.process.cpu_percent"
+    xterm_count    = "releash.frontend.mounted_xterm_count"
+    pty_count      = "releash.pty.active_count"
+    op_status      = "releash.operation.status"
+    usage_events   = "releash.usage.events"
+  }
+
+  # 属性キー（A1）
+  attr = {
+    operation   = "releash.operation"
+    status      = "releash.status"
+    channel     = "releash.channel"
+    usage_event = "releash.usage_event"
+  }
+
+  # 許可属性 allowlist（A2 / #1209 実装値）
+  allowed_resource_attrs = [
+    "service.version", "os.type", "releash.build_type", "service.name",
+  ]
+
+  # 予算しきい値（B1 / audit M0）
+  budget = {
+    repo_snapshot_p95_ms = 300    # M0「200ms 台」上限
+    diff_open_p95_ms     = 500    # M0「500ms 未満」
+    payload_bytes        = 65536  # 64KB
+  }
+
+  # カウント型アラート初期値（B5 / B6。design でチューニング可）
+  alert_counts = {
+    crash_window_min       = 5
+    crash_threshold        = 5
+    quality_window_min     = 5
+    ws_reconnects_threshold = 5
+    dropped_frames_threshold = 10
+  }
+}
+```
+
+`session.*` 系の repo-snapshot 相当 operation（`session.list` / `session.get_meta` / `session.get_page` / `session.load_full` / `session.append` / `session.persist_parts` / `session.save_full`）と diff-open 相当（`git.diff_stats` / `review.file_open`）、repo-snapshot 相当（`git.status_scan`）の振り分けは `locals` 内のリストで保持し、アラート生成を `for_each` で展開する。
+
+### ダッシュボード（`newrelic_one_dashboard`）
+
+behavior の可視化要件（6 群）に対応する page / widget を定義する。
+
+| ページ / 群 | widget 種別 | NRQL（例） |
+|---|---|---|
+| 起動・初期化 | line / billboard | `SELECT percentile(releash.startup.duration_ms, 95) FACET releash.operation` |
+| Git/Diff hot path | line | `SELECT percentile(releash.hot_path.duration_ms, 95) WHERE releash.operation IN ('git.status_scan','git.diff_stats','review.file_open') FACET releash.operation` |
+| AgentSession session IO | line / billboard | `releash.hot_path.duration_ms`（session 系 operation）+ `releash.session.save_bytes` |
+| streaming / payload | line | `releash.agent_stream.payload_bytes` / `emit_interval_ms` / `dropped_frames` / `ws_reconnects` |
+| リソース観測 | line | `releash.process.rss_bytes` / `cpu_percent` / `releash.frontend.mounted_xterm_count` / `releash.pty.active_count` |
+| 操作成否 / 利用イベント | billboard / bar | `releash.operation.status` FACET `releash.status` / `releash.usage.events` FACET `releash.usage_event` |
+
+duration 系 widget には予算値（`budget.repo_snapshot_p95_ms` / `budget.diff_open_p95_ms`）を threshold（critical/warning ライン）として埋め込み、behavior「ダッシュボードのしきい値表現が性能予算と整合する」を満たす。
+
+### アラート（`newrelic_alert_policy` + `newrelic_nrql_alert_condition`）
+
+policy 1 本に全条件を紐付け、通知連携（workflow / destination）は定義しない（behavior「通知連携は含まない」）。
+
+| 条件 | NRQL（query） | 閾値 / 評価 |
+|---|---|---|
+| repo snapshot 逸脱 | `SELECT percentile(releash.hot_path.duration_ms, 95) WHERE releash.operation IN (repo_snapshot 群)` | P95 > 300ms が一定ウィンドウ継続（B1/B2） |
+| diff open 逸脱 | `SELECT percentile(releash.hot_path.duration_ms, 95) WHERE releash.operation IN ('git.diff_stats','review.file_open')` | P95 > 500ms 継続 |
+| crash 急増 | crash/exception 相当エラーの `count` | 5 分で 5 件以上（B5、固定絶対値） |
+| 接続品質劣化 | `SELECT sum(releash.agent_stream.ws_reconnects)` / `sum(releash.agent_stream.dropped_frames)` | 5 分で reconnect ≥5 または dropped ≥10（B6） |
+| payload 異常 | `SELECT percentile(releash.agent_stream.payload_bytes, 95)`（または max） | 65536 bytes 継続超過（B1） |
+
+- duration / payload 系は `threshold_occurrences = "all"` + `threshold_duration`（ウィンドウ長）で「継続超過」を表現し、瞬間スパイクを除外（B2）。ウィンドウ長は初期値 5 分相当を `locals` 化してチューニング可能にする。
+- crash / 品質劣化はカウント型（`sum`/`count` を 5 分 window で評価）。
+- crash 条件の NRQL 対象は #1209 のエラー送出経路（exception / error log）に依存する。**仮定 D2**: crash は OTel ログ / span error として `Log` または `Span` に記録され、`WHERE` 句で error 種別を絞れるものとする。具体 NRQL は実装時に NewRelic 側データ型を確認して確定する（リスク参照）。
+
+### データ管理（metric pruning + 取り込み量制御）
+
+- **有料アドオン不使用**: NewRelic Pipeline Control Cloud Rules は Advanced Compute の有料アドオンであり、無料枠前提では使えない。したがって `newrelic_pipeline_cloud_rule` は定義しない。Log / Span の保存前 drop は本 Terraform 構成では行わない。
+- **取り込み量制御**: #1209 の高頻度テレメトリは次元付き `Metric` としてエクスポートされるため、`newrelic_metric_pruning_rule` で高カーディナリティな永続識別子・パス属性を Metric から削除する。**仮定 D3**: 無料枠のデータ保持期間（retention）はアカウント tier で固定され Terraform から変更不可のため、「取り込み量制御」は retention 変更ではなく metric pruning によるカーディナリティ制御で達成する。
+
+### backend（HCP Terraform）
+
+state backend と手動 CLI-driven run は **HCP Terraform** を採用する（OQ-D1 更新）。organization は `releash`、workspace は `newrelic` に固定する。
+
+```hcl
+# backend.tf
+terraform {
+  cloud {
+    organization = "releash"
+
+    workspaces {
+      name = "newrelic"
+    }
+  }
+}
+```
+
+- HCP Terraform 認証は `terraform login`、CLI config、または `TF_TOKEN_app_terraform_io` で供給し、リポジトリにコミットしない。
+- NewRelic 認証変数は作業者のローカル環境変数（`TF_VAR_*`）または HCP Terraform workspace variables / variable set で供給する。リポジトリには保存しない。
+
+## 処理フロー
+
+実装・運用フローは Terraform の標準フロー。
+
+1. `terraform init` — HCP Terraform cloud backend を初期化する。
+2. `terraform fmt -check` / `terraform validate` — 構文・型検証（認証不要、behavior「静的検証を通過する」）。
+3. `terraform plan` — 作業者が認証変数（`TF_VAR_newrelic_api_key` 等）供給下で手動実行する。全リソースが add として計画され、import 不要（R6 / A6）。
+4. `terraform apply` — 作業者が plan 確認後に手動実行する（自動 apply は行わない、A4）。
+
+認証変数の供給経路（behavior「認証変数が未供給だと plan は認証エラーになる」）:
+- `newrelic` provider の `api_key` / `account_id` を `variable` 化し、環境変数 `TF_VAR_newrelic_api_key` / `TF_VAR_newrelic_account_id` で注入。
+- 既定値を持たせず、未供給時は provider 認証エラーで `plan` 失敗（behavior 準拠）。
+- 値は 1Password CLI の `--account my.1password.com` を明示し、`op://releash/new-relic/account-id` / `op://releash/new-relic/user-key` 等から作業者のローカル環境変数へ読み込む。リポジトリにリテラルを置かない（R5）。
+
+## エラー処理
+
+Terraform 構成レベルの失敗モードを behavior に揃える。
+
+| 状況 | 期待挙動 | 根拠 |
+|---|---|---|
+| 認証変数 未供給 | `plan` が認証情報不足エラーで失敗 | behavior「認証変数が未供給だと plan は認証エラー」。変数に default を置かない |
+| HCP Terraform 認証不足 / workspace 権限不足 | `init` または `plan` が失敗 | R4 |
+| 構文・型エラー | `validate` が失敗 | behavior「静的検証を通過する」 |
+| 手動構築リソースとの衝突 | 発生しない（A6 で手動リソース無し前提） | R6。import 不要 |
+| provider / リソース参照誤り | `validate` / `plan` で参照エラー | behavior「構文・参照エラーなく完了」 |
+
+機微情報の漏洩防止: `api_key` 等は `variable` に `sensitive = true` を付与し、plan 出力・state での露出を抑える（key 値自体は #1258 非スコープのため Terraform で発行しない）。
+
+## テスト方針
+
+Terraform は自動実行環境から実行しない（B4）。検証・plan・apply は作業者が CLI で手動実行する。
+
+- **ローカル / レビュー**:
+  - `terraform fmt -check`（整形）
+  - `terraform validate`（構文・型・参照。認証不要）
+  - `terraform plan`（認証変数供給下。全 add・import 不要を確認）
+- **自動実行環境**:
+  - Terraform 用の GitHub Actions job は追加しない。
+- **手動 plan/apply**:
+  - 作業者が HCP Terraform token と NewRelic 認証変数を環境変数で供給する。
+  - `infra/newrelic` で `terraform init` / `terraform plan` / `terraform apply` を実行する。
+- **構成整合の確認**（behavior 準拠、人手レビュー + 可能なら軽量 grep）:
+  - ダッシュボード / アラート / metric pruning が参照するメトリクス名・属性キーが `locals.tf` 経由で #1209 実装値（A1/A2）に一致し、未定義名を参照しない。
+  - アラートしきい値が `locals.budget`（B1）と一致。
+  - metric pruning の削除対象が allowlist（A2）と衝突しない。
+
+## リスクと代替案
+
+- **R-1: Log / Span の保存前 drop は無料枠前提では Terraform 管理できない**。Pipeline Control Cloud Rules は Advanced Compute の有料アドオンであり、無料枠前提では使わない。
+  - 対策: PII / 絶対パスを送らない責務は #1209 のアプリ側 allowlist と path scrub に置く。NewRelic 側 Terraform は Metric pruning に限定し、高カーディナリティな Metric 属性削除だけを管理する。
+- **R-2: Metric pruning は Log / Span の PII 二次防御ではない**。Metric の属性削除には有効だが、Log / Span の保存前破棄は行わない。
+  - 対策: README と requirements にこの制約を明記し、`newrelic_pipeline_cloud_rule` を再導入しない。
+- **R-3: crash / exception の NRQL 対象データ型が #1209 実装に依存**。crash 急増条件の query は NewRelic 側で error がどの event 型（Log / Span / ErrorTrace）に入るかに依存する。
+  - 対策: #1209 のエラー送出経路を実装時に確認し NRQL を確定。確認できるまでは仮定 D2 を置く。
+- **R-4: plan/apply の実行には HCP Terraform 認証と NewRelic 認証が必要**。自動実行環境で secrets を扱うと運用経路が増える。
+  - 対策: Terraform は自動実行環境に組み込まず、plan/apply は作業者がローカル環境で手動実行する（仮定 D4）。
+- **代替案（backend ロック）**: S3 互換 backend + lock file を使う案は、状態管理と実行履歴を HCP Terraform に集約できないため不採用。HCP Terraform の workspace state / run 履歴を正とする。
+
+## 仮定
+
+requirements の A1〜A8、behavior の B1〜B6 を前提とする。本書で追加する設計仮定:
+
+- **D1**: `required_version >= 1.10`。`newrelic` provider はメジャー固定でピン留めし `.terraform.lock.hcl` をコミット。
+- **D2**: crash/exception は OTel ログまたは span error として NewRelic に記録され、NRQL の `WHERE` で error 種別を絞れる。具体 query は実装時に #1209 実装で確認して確定（R-3）。
+- **D3**: 無料枠の retention はアカウント tier 固定で Terraform 変更不可。取り込み量制御は Metric pruning によるカーディナリティ制御で達成する。
+- **D4**: Terraform は自動実行環境に組み込まない。`fmt -check` / `validate` / `terraform test` / `terraform plan` / `terraform apply` は作業者が CLI で手動実行する。
+- **D5**: `locals.tf` を定義の単一源とし、ダッシュボード / アラート / metric pruning は `locals` を参照して #1209 実装値との整合をレビューしやすくする。
+
+## Open Questions
+
+なし（OQ-D1 は更新済み。state backend は HCP Terraform organization `releash` / workspace `newrelic` を採用し、backend 設計へ反映済み）。

--- a/docs/specs/issues-1258/requirements.md
+++ b/docs/specs/issues-1258/requirements.md
@@ -1,0 +1,119 @@
+# Requirements
+
+## Type
+
+新規。NewRelic の観測リソース（ダッシュボード / アラート / データ管理）を `newrelic/newrelic` Terraform provider で IaC 化する。アプリ計装ではなく**観測先 SaaS 側の構成**をコード化する Issue。
+
+関連: #1258 / #1209（テレメトリ計装の実装） / `docs/releash-performance-architecture-audit.md` M0
+
+## 背景と目的
+
+#1209 で OpenTelemetry → NewRelic への性能・crash・利用イベントテレメトリ送信を実装し、観測先 SaaS を NewRelic 無料枠に一本化した。一方で、送信先である NewRelic 側のリソース（ダッシュボード・アラート・データ管理ポリシー）は現状すべて**手動運用または未設定**であり、コード化されていない。
+
+このため次の課題がある。
+
+- ダッシュボード / アラートの定義がレビュー対象にならず、変更履歴も残らない。
+- 性能予算（audit M0）や #1209 の計測項目とダッシュボードの整合がコード上で担保されない。
+- 無料枠 100GB/月の取り込み量制御が明示的なルールとして固定されていない。
+- NewRelic Pipeline Control Cloud Rules は Advanced Compute の有料アドオンであり、無料枠前提では使えない。PII 非送信要件は #1209 のアプリ側一次防御（送らない）を正とし、NewRelic 側では次元付き Metric の高カーディナリティ属性削除に限定する。
+
+目的は、上記3種のリソースを `newrelic/newrelic` Terraform provider で IaC 化し、**レビュー可能・再現可能・履歴管理可能**な状態にすること。これにより、#1209 の計測項目および性能予算（audit M0）と整合する可視化・検知・データ管理を、コードとして固定する。
+
+## スコープ
+
+Terraform 管理対象は以下の3点に限定する。
+
+### 1. ダッシュボード
+
+#1209 で計測する hot path メトリクスを可視化する。可視化対象は #1209 実装で実際に送信している以下の OTel メトリクス名に揃える（仮定: メトリクス名は #1209 実装の現行値を正とする。下記「## 仮定」参照）。
+
+- 起動・初期化: `releash.startup.duration_ms`（`releash.operation` = `startup.app` / `startup.first_window_ready` / `startup.first_repo_snapshot_ready`）
+- Git / Diff hot path: `releash.hot_path.duration_ms`（`releash.operation` = `git.status_scan` / `git.diff_stats` / `review.file_open`）
+- AgentSession session IO: `releash.hot_path.duration_ms`（`releash.operation` = `session.list` / `session.get_meta` / `session.get_page` / `session.load_full` / `session.append` / `session.persist_parts` / `session.save_full`）、`releash.session.save_bytes`
+- AgentSession streaming / payload: `releash.agent_stream.payload_bytes`（`releash.channel` = `tauri_event` / `websocket`）、`releash.agent_stream.emit_interval_ms`、`releash.agent_stream.dropped_frames`、`releash.agent_stream.ws_reconnects`
+- リソース観測: `releash.process.rss_bytes`、`releash.process.cpu_percent`、`releash.frontend.mounted_xterm_count`、`releash.pty.active_count`
+- 操作成否 / 利用イベント: `releash.operation.status`（`releash.status` = `success` / `failure`）、`releash.usage.events`（`releash.usage_event` = `settings_saved` / `worktree_created` / `worktree_removed`）
+
+### 2. アラート / NRQL 条件
+
+性能予算逸脱・crash 急増・接続品質劣化を検知する NRQL アラート条件を定義する。検知観点（しきい値の具体値は behavior / design で確定。下記「## Open Questions」参照）:
+
+- 性能予算逸脱: repo snapshot / diff open / session IO 等の duration が audit M0 の予算（repo snapshot 中規模で 200ms 台、file diff open 小/中ファイル 500ms 未満 等）を逸脱
+- crash 急増: `releash.error`（Errors Inbox）相当のエラーログ / exception の急増
+- 接続・描画品質劣化: `releash.agent_stream.ws_reconnects` / `releash.agent_stream.dropped_frames` の増加
+- streaming payload 異常: `releash.agent_stream.payload_bytes` が通常 frame 予算（64KB 未満）を継続的に超過
+
+### 3. データ管理
+
+- アラート条件 / policy の定義までを本 Issue のスコープとし、通知先（NewRelic workflow / destination: Slack / Discord / メール等）の連携は含めない（Q2 確定）。
+- 取り込み量制御: 無料枠 100GB/月に収めるため、次元付き Metric の高カーディナリティ属性を `newrelic_metric_pruning_rule` で削除する。
+- 有料アドオンである Pipeline Control Cloud Rules / `newrelic_pipeline_cloud_rule` は定義しない。Log / Span の保存前 drop は本 Issue の Terraform 構成では行わない。
+
+### 配置 / 構成
+
+- Terraform コードはアプリと同リポジトリ内 `infra/newrelic/` に配置する。
+- state は **HCP Terraform** で管理する。organization は `releash`、workspace は `newrelic` とする（Q3 更新）。
+- NewRelic 認証情報（provider 認証用 User API key 等）は Terraform 変数経由で注入し、リポジトリにコミットしない。
+
+## 非スコープ
+
+- NewRelic アカウント自体の作成（Terraform で作成不可・手動）。
+- ライセンスキー / Ingest・API キーの発行・配布。現状の 1Password（`op://releash/new-relic/`）手動運用 → ローカル環境変数注入を継続する。Terraform でのキー発行はキー値が state に平文で残るため対象外。
+- アプリ側の計装実装（#1209 の範囲）。メトリクス名・属性・PII 一次防御の変更は本 Issue では行わない。
+- Terraform の自動実行環境への組み込み。検証・plan・apply は作業者が CLI で手動実行する。
+
+## 要求事項
+
+### R1. ダッシュボードの IaC 化
+
+- `infra/newrelic/` 配下に、上記スコープ1のメトリクスを可視化する `newrelic_one_dashboard`（または相当リソース）を Terraform で定義する。
+- ダッシュボードのメトリクス定義が #1209 の計測項目および性能予算（audit M0）と整合していること。
+
+### R2. アラート / NRQL 条件の IaC 化
+
+- 上記スコープ2の検知観点を `newrelic_nrql_alert_condition`（および policy）等で Terraform 定義する。
+- しきい値は audit M0 の性能予算および #1209 の payload 予算と整合させること。
+
+### R3. データ管理の IaC 化
+
+- 無料枠 100GB/月を超過しないため、次元付き Metric の高カーディナリティ属性を削除する `newrelic_metric_pruning_rule` を Terraform 定義する。
+- Advanced Compute の有料アドオンを必要とする Pipeline Control Cloud Rules / `newrelic_pipeline_cloud_rule` は Terraform 定義に含めない。
+
+### R4. HCP Terraform state
+
+- state が HCP Terraform organization `releash` / workspace `newrelic` で管理されていること。
+
+### R5. 認証情報の非コミット
+
+- provider 認証情報がコードに含まれず、Terraform 変数経由で供給されること。
+
+### R6. plan のクリーン通過と import 方針
+
+- `terraform plan` がクリーンに通ること。
+- NewRelic アカウントに手動構築済みリソースは存在しない（Q1 確定）ため、全リソースを Terraform で新規定義・apply する。`terraform import` は不要。
+
+## 受け入れ基準の概要
+
+Issue #1258 の完了条件に対応する。
+
+- [ ] `infra/newrelic/` に上記3スコープ（ダッシュボード / アラート / データ管理）を定義した Terraform 構成が存在する（R1 / R2 / R3）。
+- [ ] HCP Terraform organization `releash` / workspace `newrelic` が設定されている（R4）。
+- [ ] `terraform plan` がクリーンに通る（手動構築済みリソースは無いため新規 apply、import 不要）（R6）。
+- [ ] 有料アドオンを必要とする Pipeline Control Cloud Rules が Terraform 定義に含まれていない（R3）。
+- [ ] 認証情報がコードに含まれず、変数経由で供給される（R5）。
+- [ ] ダッシュボードのメトリクス定義が #1209 の計測項目および性能予算（audit M0）と整合している（R1）。
+
+## 仮定
+
+- A1. 可視化・アラート・metric pruning が参照するメトリクス名・属性キーは、#1209 実装の現行値（`releash.startup.duration_ms` / `releash.hot_path.duration_ms` / `releash.agent_stream.*` / `releash.session.save_bytes` / `releash.process.*` / `releash.frontend.mounted_xterm_count` / `releash.pty.active_count` / `releash.operation.status` / `releash.usage.events`、属性 `releash.operation` / `releash.status` / `releash.channel` / `releash.usage_event`）を正とする。これらは `src-tauri/src/other/telemetry/` から確認した実装値。
+- A2. 許可される resource 属性は `service.version` / `os.type` / `releash.build_type` / `service.name` の4種に限定される（#1209 の実装値）。NewRelic 側では Cloud Rules を使わず、Metric pruning の削除対象がこの allowlist と衝突しないことだけを担保する。
+- A3. 本 Issue のゴールは観測先（NewRelic 側）構成のコード化であり、アプリ計装は変更しない。
+- A4. Terraform は自動実行環境に組み込まない。`init -backend=false` / `fmt` / `validate` / `test` / `plan` / `apply` は作業者が CLI で手動実行する。
+- A5. 性能予算の正本は `docs/releash-performance-architecture-audit.md` M0 であり、アラートしきい値はこれに従う。
+- A6. NewRelic アカウントに手動構築済みリソースは存在しない（Q1 確定）。全リソースを Terraform で新規作成し、import は行わない。
+- A7. アラートの通知連携（NewRelic workflow / destination）は本 Issue のスコープ外（Q2 確定）。アラート条件 / policy の定義までを対象とする。
+- A8. リモート state backend は HCP Terraform（organization `releash` / workspace `newrelic`）を採用する（Q3 更新）。
+
+## Open Questions
+
+なし（Q1〜Q3 は確定済み。確定内容は「## 仮定」A6〜A8 および各要求事項へ反映済み）。

--- a/infra/newrelic/.terraform.lock.hcl
+++ b/infra/newrelic/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/newrelic/newrelic" {
+  version     = "3.93.2"
+  constraints = "~> 3.93"
+  hashes = [
+    "h1:30EYzRsKlFFuDpH9EgsVuYZjWLOOnYRhIsu8otvDkDY=",
+    "h1:gc0YLTPu3WieDRvQJ/q0DSDIOxh8/3sMoKbQAYKBrbU=",
+    "zh:0eed7e268e3a1e2bb77dd875f186818893c634374b573c8f3874708492ddfea8",
+    "zh:156a402a53f412e037b7b99b8863ad1569945d6cb7ce24919647113a27f065e3",
+    "zh:2a64d7f3cac4ae19dfd0c601bcb70296077a9977f27eaa8d63270d49aafab092",
+    "zh:4477b15f67755abc42b334b40efe6a9ed018855b91ae966db3808e5b115c94c4",
+    "zh:4b5f98c53bc60e38d4459a7e049c36b807346a4d0c4eed3da25b55acc8fd47c8",
+    "zh:4d44eb8c3817dc0afdae34dd6ab3f57e82e5a9d632e9f9555a66d5b3d26b0f51",
+    "zh:4e66b6dc0636943925bf4c627ae39545b1cc3e01fae1683a834d765dda28d1b6",
+    "zh:4f3c49eeac022a89eaeb2946df8381bedb81d15b4e42010f47d699c6e4bcbaf6",
+    "zh:74da9d1525b6ef4970957c8ae67e7f29388440f95e8061414cc1c5b30a8a66a9",
+    "zh:80102d80b33281f149d30a2496debb1e8867a6fc2443fb63be6c6677cfd96698",
+    "zh:8692274ab02e7cfd86fa85d5767f431041db937f6985364301ac92c60e3d6fb5",
+    "zh:8edf2dba3daa7a471ae280d67ca64978900b26194795d84a77b744f85aa5286f",
+    "zh:a67dce5be54a03e63b3167f6f774535393de0e754f5ba27c6542b4a34df6667a",
+    "zh:ba4c2c92c656267b068df97edba93b6e9c657cb3c2d7759080641b77996fbe15",
+    "zh:baf0437e1a582ac1d809666272045c412fd29d03837b5cec8dcd1bf10fd1eee7",
+    "zh:bdcbf226f353fda39523efb9dfede548afc2e93be8563156a1cc40ca0ff641ef",
+    "zh:dac32e25ddc2968c713985dbbbf4e50c696ba0cf15d09e55d1441e58c94f956d",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/infra/newrelic/README.md
+++ b/infra/newrelic/README.md
@@ -1,0 +1,85 @@
+# Releash New Relic Terraform
+
+このディレクトリは Releash の New Relic 側の観測リソースを管理する。
+
+- `newrelic_one_dashboard`: #1209 メトリクスと M0 性能予算のダッシュボード
+- `newrelic_alert_policy` / `newrelic_nrql_alert_condition`: 性能予算、クラッシュ、ストリーム品質、ペイロードのアラート
+- `newrelic_metric_pruning_rule`: メトリクス取り込み量 / カーディナリティ制御
+- HCP Terraform: リモート state と手動 CLI 実行
+
+アプリ側の計装はここでは変更しない。
+
+## 入力
+
+New Relic 認証情報と HCP Terraform トークンは 1Password CLI (`op`) から読み込む。1Password CLI のアカウントは `my.1password.com` を明示する。
+
+```bash
+export TF_TOKEN_app_terraform_io="$(op read --account my.1password.com op://releash/hcp-terraform/token)"
+export TF_VAR_newrelic_account_id="$(op read --account my.1password.com op://releash/new-relic/account-id)"
+export TF_VAR_newrelic_api_key="$(op read --account my.1password.com op://releash/new-relic/user-key)"
+```
+
+New Relic リージョンが `US` 以外の場合だけ指定する。
+
+```bash
+export TF_VAR_newrelic_region="EU"
+```
+
+実値を `*.tfvars`、HCP Terraform トークン、API キーとしてリポジトリへコミットしない。
+
+## バックエンド
+
+リモート state と手動 CLI 実行は HCP Terraform を使う。
+
+- 組織: `releash`
+- ワークスペース: `newrelic`
+
+`TF_TOKEN_app_terraform_io` を `op` から読み込んだうえで初期化する。
+
+```bash
+export TF_TOKEN_app_terraform_io="$(op read --account my.1password.com op://releash/hcp-terraform/token)"
+terraform init
+```
+
+## 手動検証
+
+バックエンド認証なしで構文・整形・テストだけ確認する場合:
+
+```bash
+terraform init -backend=false
+terraform fmt -check
+terraform validate
+terraform test
+```
+
+`terraform validate` / `terraform test` はプロバイダープラグインを起動するため、ローカル環境によっては Unix ソケット作成が許可される環境で実行する必要がある。
+
+## 手動 plan / apply
+
+`op` から必要な値を読み込み、HCP Terraform バックエンドを初期化してから plan / apply する。
+
+```bash
+export TF_TOKEN_app_terraform_io="$(op read --account my.1password.com op://releash/hcp-terraform/token)"
+export TF_VAR_newrelic_account_id="$(op read --account my.1password.com op://releash/new-relic/account-id)"
+export TF_VAR_newrelic_api_key="$(op read --account my.1password.com op://releash/new-relic/user-key)"
+
+terraform init
+terraform plan
+terraform apply
+```
+
+初回 plan は全リソースの新規作成になる想定。New Relic アカウントに手動構築済みリソースは存在しない前提なので、`terraform import` はこの展開では不要。
+
+Terraform は CI から実行しない。検証、plan、apply はこのディレクトリで作業者が手動実行する。
+
+## データ管理
+
+New Relic Pipeline Control Cloud Rules は Advanced Compute の有料アドオンなので、この Terraform では使わない。`newrelic_pipeline_cloud_rule` は定義しない。
+
+無料枠の保護は、次元付きメトリクス集計の高カーディナリティ属性を `newrelic_metric_pruning_rule` で削除することで行う。Log / Span の保存前 drop はこの構成では行わないため、PII / 絶対パスを送らない責務は #1209 のアプリ側 allowlist と path scrub が持つ。
+
+## 無料枠の取り込み制御
+
+#1209 は高頻度テレメトリを次元付き `Metric` としてエクスポートする。クラッシュ報告は `releash.error` ロガー経由で OTLP ログプロバイダーに接続されるが、通常の `log::debug!` 出力は New Relic ログエクスポーターに接続されていない。
+
+新しい PII / パス属性キーをメトリクスへ追加する場合は、同じ変更で `local.pii_attribute_keys` も更新する。

--- a/infra/newrelic/alerts.tf
+++ b/infra/newrelic/alerts.tf
@@ -1,0 +1,177 @@
+resource "newrelic_alert_policy" "releash" {
+  account_id          = var.newrelic_account_id
+  name                = "Releash observability"
+  incident_preference = "PER_CONDITION"
+}
+
+resource "newrelic_nrql_alert_condition" "repo_snapshot_budget" {
+  account_id                   = var.newrelic_account_id
+  policy_id                    = newrelic_alert_policy.releash.id
+  type                         = "static"
+  name                         = "Repo snapshot P95 over 300ms"
+  description                  = "Detects M0 repo snapshot budget violations for git.status_scan."
+  enabled                      = true
+  violation_time_limit_seconds = local.violation_time_limit_seconds
+  aggregation_window           = local.alert_counts.aggregation_window_seconds
+  aggregation_method           = "event_flow"
+  aggregation_delay            = local.alert_counts.aggregation_delay_seconds
+
+  nrql {
+    query = "FROM Metric SELECT percentile(`${local.metrics.hot_path}`, 95) WHERE ${local.operation_filter.repo_snapshot}"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = local.budget.repo_snapshot_p95_ms
+    threshold_duration    = local.alert_counts.sustained_window_seconds
+    threshold_occurrences = "ALL"
+  }
+}
+
+resource "newrelic_nrql_alert_condition" "session_io_budget" {
+  for_each = toset(local.session_io_operations)
+
+  account_id                   = var.newrelic_account_id
+  policy_id                    = newrelic_alert_policy.releash.id
+  type                         = "static"
+  name                         = "Session IO P95 over 300ms (${each.value})"
+  description                  = "Detects M0 AgentSession IO budget violations for ${each.value}."
+  enabled                      = true
+  violation_time_limit_seconds = local.violation_time_limit_seconds
+  aggregation_window           = local.alert_counts.aggregation_window_seconds
+  aggregation_method           = "event_flow"
+  aggregation_delay            = local.alert_counts.aggregation_delay_seconds
+
+  nrql {
+    query = "FROM Metric SELECT percentile(`${local.metrics.hot_path}`, 95) WHERE `${local.attr.operation}` = '${each.value}'"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = local.budget.repo_snapshot_p95_ms
+    threshold_duration    = local.alert_counts.sustained_window_seconds
+    threshold_occurrences = "ALL"
+  }
+}
+
+resource "newrelic_nrql_alert_condition" "diff_open_budget" {
+  for_each = toset(local.diff_open_operations)
+
+  account_id                   = var.newrelic_account_id
+  policy_id                    = newrelic_alert_policy.releash.id
+  type                         = "static"
+  name                         = "Diff open P95 over 500ms (${each.value})"
+  description                  = "Detects M0 diff open budget violations for ${each.value}."
+  enabled                      = true
+  violation_time_limit_seconds = local.violation_time_limit_seconds
+  aggregation_window           = local.alert_counts.aggregation_window_seconds
+  aggregation_method           = "event_flow"
+  aggregation_delay            = local.alert_counts.aggregation_delay_seconds
+
+  nrql {
+    query = "FROM Metric SELECT percentile(`${local.metrics.hot_path}`, 95) WHERE `${local.attr.operation}` = '${each.value}'"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = local.budget.diff_open_p95_ms
+    threshold_duration    = local.alert_counts.sustained_window_seconds
+    threshold_occurrences = "ALL"
+  }
+}
+
+resource "newrelic_nrql_alert_condition" "crash_spike" {
+  account_id                   = var.newrelic_account_id
+  policy_id                    = newrelic_alert_policy.releash.id
+  type                         = "static"
+  name                         = "Crash or exception spike"
+  description                  = "Detects at least five Releash crash or exception logs in five minutes."
+  enabled                      = true
+  violation_time_limit_seconds = local.violation_time_limit_seconds
+  aggregation_window           = local.alert_counts.crash_window_min * 60
+  aggregation_method           = "event_flow"
+  aggregation_delay            = local.alert_counts.aggregation_delay_seconds
+
+  nrql {
+    query = "FROM Log SELECT count(*) WHERE ${local.crash_error_filter}"
+  }
+
+  critical {
+    operator              = "above_or_equals"
+    threshold             = local.alert_counts.crash_threshold
+    threshold_duration    = local.alert_counts.crash_window_min * 60
+    threshold_occurrences = "AT_LEAST_ONCE"
+  }
+}
+
+resource "newrelic_nrql_alert_condition" "ws_reconnects" {
+  account_id                   = var.newrelic_account_id
+  policy_id                    = newrelic_alert_policy.releash.id
+  type                         = "static"
+  name                         = "WebSocket reconnect spike"
+  description                  = "Detects at least five agent stream WebSocket reconnects in five minutes."
+  enabled                      = true
+  violation_time_limit_seconds = local.violation_time_limit_seconds
+  aggregation_window           = local.alert_counts.quality_window_min * 60
+  aggregation_method           = "event_flow"
+  aggregation_delay            = local.alert_counts.aggregation_delay_seconds
+
+  nrql {
+    query = "FROM Metric SELECT sum(`${local.metrics.ws_reconnects}`)"
+  }
+
+  critical {
+    operator              = "above_or_equals"
+    threshold             = local.alert_counts.ws_reconnects_threshold
+    threshold_duration    = local.alert_counts.quality_window_min * 60
+    threshold_occurrences = "AT_LEAST_ONCE"
+  }
+}
+
+resource "newrelic_nrql_alert_condition" "dropped_frames" {
+  account_id                   = var.newrelic_account_id
+  policy_id                    = newrelic_alert_policy.releash.id
+  type                         = "static"
+  name                         = "Agent stream dropped frame spike"
+  description                  = "Detects at least ten dropped agent stream frames in five minutes."
+  enabled                      = true
+  violation_time_limit_seconds = local.violation_time_limit_seconds
+  aggregation_window           = local.alert_counts.quality_window_min * 60
+  aggregation_method           = "event_flow"
+  aggregation_delay            = local.alert_counts.aggregation_delay_seconds
+
+  nrql {
+    query = "FROM Metric SELECT sum(`${local.metrics.dropped_frames}`)"
+  }
+
+  critical {
+    operator              = "above_or_equals"
+    threshold             = local.alert_counts.dropped_frames_threshold
+    threshold_duration    = local.alert_counts.quality_window_min * 60
+    threshold_occurrences = "AT_LEAST_ONCE"
+  }
+}
+
+resource "newrelic_nrql_alert_condition" "payload_budget" {
+  account_id                   = var.newrelic_account_id
+  policy_id                    = newrelic_alert_policy.releash.id
+  type                         = "static"
+  name                         = "Agent stream payload P95 over 64KB"
+  description                  = "Detects sustained agent stream payload frames over the 64KB budget."
+  enabled                      = true
+  violation_time_limit_seconds = local.violation_time_limit_seconds
+  aggregation_window           = local.alert_counts.aggregation_window_seconds
+  aggregation_method           = "event_flow"
+  aggregation_delay            = local.alert_counts.aggregation_delay_seconds
+
+  nrql {
+    query = "FROM Metric SELECT percentile(`${local.metrics.payload_bytes}`, 95) WHERE `${local.attr.channel}` IN (${join(", ", [for channel in local.stream_channels : "'${channel}'"])})"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = local.budget.payload_bytes
+    threshold_duration    = local.alert_counts.sustained_window_seconds
+    threshold_occurrences = "ALL"
+  }
+}

--- a/infra/newrelic/backend.tf
+++ b/infra/newrelic/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "releash"
+
+    workspaces {
+      name = "newrelic"
+    }
+  }
+}

--- a/infra/newrelic/dashboards.tf
+++ b/infra/newrelic/dashboards.tf
@@ -1,0 +1,222 @@
+resource "newrelic_one_dashboard" "releash" {
+  name        = "Releash observability"
+  permissions = var.dashboard_permissions
+
+  page {
+    name        = "Performance and reliability"
+    description = "Releash desktop app hot paths, agent streaming, resource pressure, and usage signals."
+
+    widget_line {
+      title  = "Startup P95 by operation"
+      row    = 1
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT percentile(`${local.metrics.startup}`, 95) WHERE ${local.operation_filter.startup} FACET `${local.attr.operation}` TIMESERIES"
+      }
+
+      legend_enabled   = true
+      y_axis_left_zero = true
+      units {
+        unit = "ms"
+      }
+    }
+
+    widget_line {
+      title            = "Repo snapshot and session IO P95"
+      row              = 1
+      column           = 7
+      width            = 6
+      height           = 3
+      is_label_visible = true
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT percentile(`${local.metrics.hot_path}`, 95) WHERE (${local.operation_filter.repo_snapshot} OR ${local.operation_filter.session_io}) FACET `${local.attr.operation}` TIMESERIES"
+      }
+
+      threshold {
+        name     = "M0 budget 300ms"
+        from     = local.budget.repo_snapshot_p95_ms
+        to       = 100000
+        severity = "critical"
+      }
+
+      legend_enabled   = true
+      y_axis_left_zero = true
+      units {
+        unit = "ms"
+      }
+    }
+
+    widget_line {
+      title            = "Diff open P95"
+      row              = 4
+      column           = 1
+      width            = 6
+      height           = 3
+      is_label_visible = true
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT percentile(`${local.metrics.hot_path}`, 95) WHERE ${local.operation_filter.diff_open} FACET `${local.attr.operation}` TIMESERIES"
+      }
+
+      threshold {
+        name     = "M0 budget 500ms"
+        from     = local.budget.diff_open_p95_ms
+        to       = 100000
+        severity = "critical"
+      }
+
+      legend_enabled   = true
+      y_axis_left_zero = true
+      units {
+        unit = "ms"
+      }
+    }
+
+    widget_line {
+      title  = "Session save bytes P95"
+      row    = 4
+      column = 7
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT percentile(`${local.metrics.session_bytes}`, 95) WHERE ${local.operation_filter.session_io} FACET `${local.attr.operation}` TIMESERIES"
+      }
+
+      legend_enabled   = true
+      y_axis_left_zero = true
+      units {
+        unit = "bytes"
+      }
+    }
+
+    widget_line {
+      title            = "Agent stream payload P95"
+      row              = 7
+      column           = 1
+      width            = 6
+      height           = 3
+      is_label_visible = true
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT percentile(`${local.metrics.payload_bytes}`, 95) WHERE `${local.attr.channel}` IN (${join(", ", [for channel in local.stream_channels : "'${channel}'"])}) FACET `${local.attr.channel}` TIMESERIES"
+      }
+
+      threshold {
+        name     = "64KB frame budget"
+        from     = local.budget.payload_bytes
+        to       = 104857600
+        severity = "critical"
+      }
+
+      legend_enabled   = true
+      y_axis_left_zero = true
+      units {
+        unit = "bytes"
+      }
+    }
+
+    widget_line {
+      title  = "Agent stream quality"
+      row    = 7
+      column = 7
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT percentile(`${local.metrics.emit_interval}`, 95) AS 'emit interval p95 ms' TIMESERIES"
+      }
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT sum(`${local.metrics.dropped_frames}`) AS 'dropped frames' TIMESERIES"
+      }
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT sum(`${local.metrics.ws_reconnects}`) AS 'ws reconnects' TIMESERIES"
+      }
+
+      legend_enabled   = true
+      y_axis_left_zero = true
+    }
+
+    widget_line {
+      title  = "Process resources"
+      row    = 10
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT average(`${local.metrics.rss_bytes}`) AS 'rss bytes' TIMESERIES"
+      }
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT average(`${local.metrics.cpu_percent}`) AS 'cpu percent' TIMESERIES"
+      }
+
+      legend_enabled   = true
+      y_axis_left_zero = true
+    }
+
+    widget_line {
+      title  = "Terminal pressure"
+      row    = 10
+      column = 7
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT average(`${local.metrics.xterm_count}`) AS 'mounted xterms' TIMESERIES"
+      }
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT average(`${local.metrics.pty_count}`) AS 'active ptys' TIMESERIES"
+      }
+
+      legend_enabled   = true
+      y_axis_left_zero = true
+    }
+
+    widget_bar {
+      title  = "Operation status"
+      row    = 13
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT sum(`${local.metrics.op_status}`) FACET `${local.attr.status}`"
+      }
+    }
+
+    widget_bar {
+      title  = "Usage events"
+      row    = 13
+      column = 7
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.newrelic_account_id
+        query      = "FROM Metric SELECT sum(`${local.metrics.usage_events}`) WHERE `${local.attr.usage_event}` IN (${join(", ", [for event in local.usage_events : "'${event}'"])}) FACET `${local.attr.usage_event}`"
+      }
+    }
+  }
+}

--- a/infra/newrelic/data_management.tf
+++ b/infra/newrelic/data_management.tf
@@ -1,0 +1,5 @@
+resource "newrelic_metric_pruning_rule" "pii_metric_aggregates" {
+  account_id  = var.newrelic_account_id
+  description = "Prunes high-cardinality PII/path attributes from #1209 Releash dimensional metric aggregates, the exported high-volume signal used for free-tier ingest control."
+  nrql        = "SELECT ${local.pii_delete_clause} FROM Metric WHERE ${local.metric_releash_scope}"
+}

--- a/infra/newrelic/data_management.tftest.hcl
+++ b/infra/newrelic/data_management.tftest.hcl
@@ -1,0 +1,105 @@
+mock_provider "newrelic" {}
+
+variables {
+  newrelic_account_id = 123456
+  newrelic_api_key    = "test-key"
+}
+
+run "metric_pruning_denylist_preserves_allowed_resource_attributes" {
+  command = plan
+
+  assert {
+    condition = length(local.allowed_resource_attrs) == 4 && toset(local.allowed_resource_attrs) == toset([
+      "service.version",
+      "os.type",
+      "releash.build_type",
+      "service.name",
+    ])
+
+    error_message = "Allowed resource attributes must stay fixed to the #1209 allowlist."
+  }
+
+  assert {
+    condition = length(setintersection(toset(local.allowed_resource_attrs), toset(local.pii_attribute_keys))) == 0
+
+    error_message = "Metric pruning deny-list must not drop allowed resource attributes."
+  }
+}
+
+run "metric_pruning_rule_is_scoped_to_releash" {
+  command = plan
+
+  assert {
+    condition = newrelic_metric_pruning_rule.pii_metric_aggregates.nrql == "SELECT ${local.pii_delete_clause} FROM Metric WHERE ${local.metric_releash_scope}"
+
+    error_message = "Metric pruning must be scoped to Releash metrics."
+  }
+}
+
+run "metric_pruning_targets_exported_high_volume_signal" {
+  command = plan
+
+  assert {
+    condition = newrelic_metric_pruning_rule.pii_metric_aggregates.nrql == "SELECT ${local.pii_delete_clause} FROM Metric WHERE ${local.metric_releash_scope}"
+
+    error_message = "Free-tier ingest control must target the Metric signal exported by #1209."
+  }
+
+  assert {
+    condition = strcontains(newrelic_metric_pruning_rule.pii_metric_aggregates.description, "#1209 Releash dimensional metric aggregates") && strcontains(newrelic_metric_pruning_rule.pii_metric_aggregates.description, "free-tier ingest control")
+
+    error_message = "Metric pruning must document that exported metric aggregates, not unexported debug logs, carry the free-tier ingest control responsibility."
+  }
+}
+
+run "duration_budget_alerts_are_scoped_per_operation" {
+  command = plan
+
+  assert {
+    condition = toset(keys(newrelic_nrql_alert_condition.session_io_budget)) == toset(local.session_io_operations)
+
+    error_message = "Session IO budget alerts must be generated for every session operation."
+  }
+
+  assert {
+    condition = alltrue([
+      for op in local.session_io_operations :
+      newrelic_nrql_alert_condition.session_io_budget[op].nrql[0].query == "FROM Metric SELECT percentile(`${local.metrics.hot_path}`, 95) WHERE `${local.attr.operation}` = '${op}'"
+    ])
+
+    error_message = "Session IO budget alerts must evaluate exactly one operation per condition."
+  }
+
+  assert {
+    condition = alltrue([
+      for op in local.session_io_operations :
+      newrelic_nrql_alert_condition.session_io_budget[op].critical[0].threshold == local.budget.repo_snapshot_p95_ms
+    ])
+
+    error_message = "Session IO budget alerts must keep the 300ms repo snapshot/session IO budget."
+  }
+
+  assert {
+    condition = toset(keys(newrelic_nrql_alert_condition.diff_open_budget)) == toset(local.diff_open_operations)
+
+    error_message = "Diff open budget alerts must be generated for every diff open operation."
+  }
+
+  assert {
+    condition = alltrue([
+      for op in local.diff_open_operations :
+      newrelic_nrql_alert_condition.diff_open_budget[op].nrql[0].query == "FROM Metric SELECT percentile(`${local.metrics.hot_path}`, 95) WHERE `${local.attr.operation}` = '${op}'"
+    ])
+
+    error_message = "Diff open budget alerts must evaluate exactly one operation per condition."
+  }
+
+  assert {
+    condition = alltrue([
+      for op in local.diff_open_operations :
+      newrelic_nrql_alert_condition.diff_open_budget[op].critical[0].threshold == local.budget.diff_open_p95_ms
+    ])
+
+    error_message = "Diff open budget alerts must keep the 500ms diff open budget."
+  }
+}

--- a/infra/newrelic/locals.tf
+++ b/infra/newrelic/locals.tf
@@ -1,0 +1,133 @@
+locals {
+  service_name = "releash"
+
+  metrics = {
+    startup        = "releash.startup.duration_ms"
+    hot_path       = "releash.hot_path.duration_ms"
+    session_bytes  = "releash.session.save_bytes"
+    payload_bytes  = "releash.agent_stream.payload_bytes"
+    emit_interval  = "releash.agent_stream.emit_interval_ms"
+    dropped_frames = "releash.agent_stream.dropped_frames"
+    ws_reconnects  = "releash.agent_stream.ws_reconnects"
+    rss_bytes      = "releash.process.rss_bytes"
+    cpu_percent    = "releash.process.cpu_percent"
+    xterm_count    = "releash.frontend.mounted_xterm_count"
+    pty_count      = "releash.pty.active_count"
+    op_status      = "releash.operation.status"
+    usage_events   = "releash.usage.events"
+  }
+
+  attr = {
+    operation   = "releash.operation"
+    status      = "releash.status"
+    channel     = "releash.channel"
+    usage_event = "releash.usage_event"
+  }
+
+  allowed_resource_attrs = [
+    "service.version",
+    "os.type",
+    "releash.build_type",
+    "service.name",
+  ]
+
+  startup_operations = [
+    "startup.app",
+    "startup.first_window_ready",
+    "startup.first_repo_snapshot_ready",
+  ]
+
+  repo_snapshot_operations = [
+    "git.status_scan",
+  ]
+
+  diff_open_operations = [
+    "git.diff_stats",
+    "review.file_open",
+  ]
+
+  session_io_operations = [
+    "session.list",
+    "session.get_meta",
+    "session.get_page",
+    "session.load_full",
+    "session.append",
+    "session.persist_parts",
+    "session.save_full",
+  ]
+
+  stream_channels = [
+    "tauri_event",
+    "websocket",
+  ]
+
+  usage_events = [
+    "settings_saved",
+    "worktree_created",
+    "worktree_removed",
+  ]
+
+  budget = {
+    repo_snapshot_p95_ms = 300
+    diff_open_p95_ms     = 500
+    payload_bytes        = 65536
+  }
+
+  alert_counts = {
+    crash_window_min           = 5
+    crash_threshold            = 5
+    quality_window_min         = 5
+    ws_reconnects_threshold    = 5
+    dropped_frames_threshold   = 10
+    sustained_window_seconds   = 300
+    aggregation_window_seconds = 60
+    aggregation_delay_seconds  = 120
+  }
+
+  violation_time_limit_seconds = 86400
+
+  operation_filter = {
+    startup       = "`${local.attr.operation}` IN (${join(", ", [for op in local.startup_operations : "'${op}'"])})"
+    repo_snapshot = "`${local.attr.operation}` IN (${join(", ", [for op in local.repo_snapshot_operations : "'${op}'"])})"
+    diff_open     = "`${local.attr.operation}` IN (${join(", ", [for op in local.diff_open_operations : "'${op}'"])})"
+    session_io    = "`${local.attr.operation}` IN (${join(", ", [for op in local.session_io_operations : "'${op}'"])})"
+  }
+
+  pii_attribute_keys = [
+    "device.id",
+    "device_id",
+    "deviceId",
+    "session.id",
+    "session_id",
+    "sessionId",
+    "user.id",
+    "user_id",
+    "userId",
+    "user.email",
+    "user.name",
+    "email",
+    "username",
+    "path",
+    "file.path",
+    "file_path",
+    "repo.path",
+    "repo_path",
+    "repository.path",
+    "repository_path",
+    "worktree.path",
+    "worktree_path",
+    "cwd",
+    "current_dir",
+    "directory",
+    "home",
+    "process.command_line",
+  ]
+
+  pii_delete_clause = join(", ", [
+    for attr in local.pii_attribute_keys : strcontains(attr, ".") ? "`${attr}`" : attr
+  ])
+
+  metric_releash_scope = "(`service.name` = '${local.service_name}' OR metricName LIKE '${local.service_name}.%')"
+
+  crash_error_filter = "(`service.name` = '${local.service_name}') AND (`event.name` = 'exception' OR eventName = 'exception' OR logger.name = 'releash.error' OR `exception.type` IS NOT NULL)"
+}

--- a/infra/newrelic/outputs.tf
+++ b/infra/newrelic/outputs.tf
@@ -1,0 +1,14 @@
+output "dashboard_guid" {
+  description = "GUID of the Releash New Relic dashboard."
+  value       = newrelic_one_dashboard.releash.guid
+}
+
+output "dashboard_permalink" {
+  description = "Permalink for the Releash New Relic dashboard."
+  value       = newrelic_one_dashboard.releash.permalink
+}
+
+output "alert_policy_id" {
+  description = "ID of the Releash New Relic alert policy."
+  value       = newrelic_alert_policy.releash.id
+}

--- a/infra/newrelic/providers.tf
+++ b/infra/newrelic/providers.tf
@@ -1,0 +1,5 @@
+provider "newrelic" {
+  account_id = var.newrelic_account_id
+  api_key    = var.newrelic_api_key
+  region     = upper(var.newrelic_region)
+}

--- a/infra/newrelic/terraform.tfvars.example
+++ b/infra/newrelic/terraform.tfvars.example
@@ -1,0 +1,5 @@
+newrelic_account_id = 12345678
+newrelic_api_key    = "NRAK-REPLACE-ME"
+newrelic_region     = "US"
+
+dashboard_permissions = "private"

--- a/infra/newrelic/variables.tf
+++ b/infra/newrelic/variables.tf
@@ -1,0 +1,36 @@
+variable "newrelic_account_id" {
+  description = "New Relic account ID that owns the Releash observability resources."
+  type        = number
+}
+
+variable "newrelic_api_key" {
+  description = "New Relic User API key. Supply via TF_VAR_newrelic_api_key or CI secrets."
+  type        = string
+  sensitive   = true
+}
+
+variable "newrelic_region" {
+  description = "New Relic account region."
+  type        = string
+  default     = "US"
+
+  validation {
+    condition     = contains(["US", "EU", "JP"], upper(var.newrelic_region))
+    error_message = "newrelic_region must be one of US, EU, or JP."
+  }
+}
+
+variable "dashboard_permissions" {
+  description = "Visibility for the Releash New Relic dashboard."
+  type        = string
+  default     = "private"
+
+  validation {
+    condition = contains([
+      "private",
+      "public_read_only",
+      "public_read_write",
+    ], var.dashboard_permissions)
+    error_message = "dashboard_permissions must be private, public_read_only, or public_read_write."
+  }
+}

--- a/infra/newrelic/versions.tf
+++ b/infra/newrelic/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = "~> 3.93"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add #1258 requirements, behavior, and design specs for New Relic observability IaC
- Add Terraform configuration for New Relic dashboards, NRQL alert conditions, metric pruning, and HCP Terraform state
- Add Terraform tests for metric pruning allowlist behavior and per-operation budget alerts

## Verification
- terraform -chdir=infra/newrelic fmt -check
- terraform -chdir=infra/newrelic test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * New Relic の可観測性リソース（ダッシュボード、アラート、データ管理ルール）をコード経由で管理できるようになりました。

* **ドキュメント**
  * New Relic インフラストラクチャ管理に関する要件、設計、仕様ドキュメントおよび運用ガイドを追加しました。

* **雑務**
  * .gitignore に Terraform 関連ファイルの除外ルールを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->