### PR TITLE
feat(repository): 状態スナップショットキャッシュを追加

### DIFF
--- a/docs/specs/issues-1210/behavior.md
+++ b/docs/specs/issues-1210/behavior.md
@@ -1,0 +1,240 @@
+# Behavior
+
+`RepositoryStateService` による watcher / git scan / read model 集約（#1210）の振る舞いを Gherkin で定義する。
+
+実装経路・モジュール名・command 名は本書に持ち込まず、外部から観測可能なビジネスルールに絞る。詳細な配置・技術選定は `design.md` で扱う。
+
+## 用語
+
+- **worktree**: 監視・走査の単位となる作業ツリー（repo）。1 worktree につき 1 系統の watcher と git scan を持つ。
+- **subscriber**: 同一 worktree の状態を必要とする利用側（status 表示 / diff tree / branch 一覧 / dirty count / ReviewPanel 等）。watcher を自前で起動せず、service の通知を購読する。
+- **snapshot**: 1 回の集約 scan に由来する versioned な状態。status / diff stats / branch cards / worktree dirty count / diff file tree を同一 snapshot から導出する。
+- **version**: snapshot に付与される単調増加シーケンス。subscriber は version で新旧を判定し、逆行は起きない。
+- **集約 read model**: snapshot から導出される観測対象 = Git status / diff stats / branch cards / worktree dirty count / diff file tree。
+- **invalidate**: ファイル変更通知（watcher の notify）を起点とする再走査要求。重い read model 生成を伴わず、再走査の予約だけを行う。
+- **debounce**: invalidate を受けてから実際の scan を始めるまでの待機（既存挙動踏襲 = 300ms 相当）。連続変更をまとめる。
+- **stale フラグ**: 返した snapshot が最新の変更をまだ反映していない（background refresh 中である）ことを示す。
+- **loading フラグ**: 初回 scan / 再 scan が進行中であることを示す。
+- **limited フラグ**: threshold により内容が省略・打ち切りされていることを示す。
+- **ignored files**: gitignore 対象ファイル。default snapshot には含めず、opt-in 経路でのみ取得する。
+
+## Feature: worktree ごとの単一 watcher と集約 scan
+
+同一 worktree に対する watcher と git scan を 1 系統に集約し、複数の subscriber が個別に watcher を起動しないようにする。
+
+### Background
+
+```gherkin
+Given ある worktree が開かれている
+And その worktree の状態を必要とする subscriber が複数存在しうる
+```
+
+### Rule: 同一 worktree の watcher と git scan は 1 系統に集約される
+
+```gherkin
+Scenario: 複数 subscriber が同一 worktree を購読しても watcher は重複起動しない
+  Given worktree W の状態を status 表示 / diff tree / branch 一覧 が必要としている
+  When それぞれが W の状態購読を開始する
+  Then W に対して起動される file watcher / Git dir watcher は 1 系統だけである
+  And 各 subscriber は同一の集約された通知から更新を受け取る
+```
+
+```gherkin
+Scenario: 集約 read model は 1 回の scan から導出される
+  Given worktree W の snapshot が生成されている
+  When status / diff stats / branch cards / worktree dirty count / diff file tree を参照する
+  Then それらはすべて同一 snapshot から導出される
+  And 参照ごとに別々の git2 走査が重複起動しない
+```
+
+```gherkin
+Scenario: 複数 worktree はそれぞれ独立した 1 系統を持つ
+  Given worktree W1 と worktree W2 が開かれている
+  When 双方の状態購読を開始する
+  Then W1 と W2 はそれぞれ独立に 1 系統ずつの watcher と scan を持つ
+  And 一方の変更が他方の snapshot version に影響しない
+```
+
+## Feature: versioned snapshot と状態フラグ
+
+snapshot に version と stale / loading / limited フラグを持たせ、subscriber が新旧と状態を判定できるようにする。
+
+### Background
+
+```gherkin
+Given worktree W の状態購読が確立している
+```
+
+### Rule: snapshot は version と状態フラグを伴って通知される
+
+```gherkin
+Scenario: subscriber は version で新旧を判定できる
+  Given subscriber が version N の snapshot を保持している
+  When service が version N+1 の snapshot を通知する
+  Then subscriber は N+1 を新しい snapshot として採用できる
+  And version は単調増加し逆行しない
+```
+
+```gherkin
+Scenario Outline: snapshot のフラグが状態を表現する
+  Given worktree W が "<状態>" にある
+  When subscriber が snapshot を受け取る
+  Then snapshot の "<フラグ>" が立っている
+
+  Examples:
+    | 状態                             | フラグ   |
+    | 最新変更を未反映で background refresh 中 | stale   |
+    | 初回 scan / 再 scan が進行中     | loading |
+    | threshold により内容が打ち切られた | limited |
+```
+
+### Rule: 初回購読時は loading を示し、完了で snapshot を通知する
+
+```gherkin
+Scenario: 初回購読では loading を経て最初の snapshot に到達する
+  Given worktree W の snapshot がまだ生成されていない
+  When subscriber が購読を開始する
+  Then loading 状態であることが分かる
+  And 初回 scan 完了時に version 付き snapshot が通知される
+```
+
+## Feature: 変更検知から snapshot 更新までの非同期経路
+
+watcher の notify callback で重い read model 生成を同期実行せず、invalidate → debounce → background worker の経路で snapshot を更新する。
+
+### Background
+
+```gherkin
+Given worktree W の状態購読が確立している
+And W の snapshot が version N で存在する
+```
+
+### Rule: notify callback は invalidate だけを発行する
+
+```gherkin
+Scenario: ファイル変更の通知では重い read model 生成を同期実行しない
+  Given W 内のファイルが変更される
+  When watcher がその変更を検知する
+  Then 検知の時点では branch 一覧生成や dirty count 等の重い走査を同期実行しない
+  And 再走査要求（invalidate）だけが発行される
+```
+
+```gherkin
+Scenario: 連続変更は debounce でまとめて 1 回の scan になる
+  Given debounce 期間内に W への変更が複数回発生する
+  When debounce 期間が満了する
+  Then それらの変更に対する scan が 1 回だけ実行される
+```
+
+### Rule: 中規模 repo では stale snapshot を即時に返しつつ background で更新する
+
+```gherkin
+Scenario: scan が長い場合は既存 snapshot を stale として返し、完了後に最新へ更新する
+  Given W の再 scan に時間がかかる
+  When subscriber が現在の状態を要求する
+  Then 既存（version N）の snapshot が stale フラグ付きで即時に返る
+  And background refresh が走り、完了時に version N+1 の snapshot が通知される
+  And N+1 の snapshot では stale フラグが下りている
+```
+
+## Feature: scan の cancel / supersede
+
+scan 実行中に次の変更が来たら、進行中の古い scan を打ち切り、最新状態に対する scan を優先する。
+
+### Background
+
+```gherkin
+Given worktree W の状態購読が確立している
+```
+
+### Rule: 進行中の scan は新しい変更で打ち切られ、古い結果で上書きしない
+
+```gherkin
+Scenario: scan 中の追加変更で古い scan が supersede される
+  Given W に対する scan が進行中である
+  When scan の完了前に W へ新たな変更が発生する
+  Then 進行中の古い scan は cancel / supersede される
+  And 最新状態に対する scan が優先して実行される
+```
+
+```gherkin
+Scenario: 古い scan の結果で新しい snapshot を上書きしない
+  Given 古い scan の完了より先に新しい scan が version N+1 の snapshot を通知している
+  When 打ち切られた古い scan の結果が遅れて到着する
+  Then その古い結果で version N+1 の snapshot を上書きしない
+  And version は逆行しない
+```
+
+## Feature: ignored files の既定除外と opt-in
+
+default snapshot では ignored files を返さず、必要な UI だけが opt-in で取得できるようにする。
+
+### Background
+
+```gherkin
+Given worktree W に gitignore 対象のファイルが存在する
+```
+
+### Rule: ignored files は default snapshot に含めず opt-in でのみ取得する
+
+```gherkin
+Scenario: default snapshot に ignored files は含まれない
+  Given subscriber が default の状態を購読している
+  When snapshot を参照する
+  Then ignored files は含まれない
+```
+
+```gherkin
+Scenario: ignored files が必要な UI は opt-in で取得できる
+  Given ignored files の表示を必要とする UI がある
+  When その UI が ignored files を含む取得を opt-in で要求する
+  Then ignored files を含む結果が得られる
+```
+
+## Feature: 既存表示挙動の非回帰
+
+集約後も、ユーザーから見える status / diff stats / branch cards / worktree dirty count / diff file tree の結果が、ignored 既定除外を除いて変わらない。
+
+### Background
+
+```gherkin
+Given worktree W が開かれている
+```
+
+### Rule: 集約への置き換え後も観測される結果に回帰がない
+
+```gherkin
+Scenario Outline: 集約 snapshot 由来の read model が従来結果と一致する
+  Given W の状態が確定している
+  When "<read model>" を参照する
+  Then 集約 snapshot から導出される結果は、従来経路の結果と一致する（ignored 既定除外を除く）
+
+  Examples:
+    | read model            |
+    | Git status            |
+    | diff stats            |
+    | branch cards          |
+    | worktree dirty count  |
+    | diff file tree        |
+```
+
+```gherkin
+Scenario: ignored 既定除外による差分は許容される
+  Given 従来は ignored files を含めて status を返していた
+  When 集約 snapshot 由来の default status を参照する
+  Then ignored files が含まれない点のみが従来と異なる
+  And それ以外の表示結果に差分はない
+```
+
+## 仮定
+
+`requirements.md` の仮定 A1〜A7 を前提とする。本書の振る舞いに直接関わる主なものは以下。
+
+- 本 Issue は service + 単一 watcher + 集約 scan + versioned snapshot + cancel/supersede + ignored opt-in までを担い、新 command 名 `get_review_snapshot` の導入と frontend 呼び出し置換は #1211 とする（A1）。本書の Scenario はいずれも内部 snapshot / 通知の観測可能な振る舞いとして記述し、新 command surface には言及しない。
+- subscriber への通知は version を含む event で届く（A5）。version の具体的な伝達方式は `design.md` で確定する。
+- `limited` の具体的な threshold 値は本 Issue では確定せず、「打ち切りを `limited` フラグで表現できること」だけを要求する（A6）。
+- debounce は既存の 300ms 相当を踏襲する（A7）。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1210/design.md
+++ b/docs/specs/issues-1210/design.md
@@ -1,0 +1,206 @@
+# Design
+
+`RepositoryStateService`（#1210）の実装方針を定める。`requirements.md` / `behavior.md` を前提とし、本書では配置・型・処理フロー・エラー処理・テスト方針まで具体化する。
+
+参照: `requirements.md`（仮定 A1〜A7）/ `behavior.md` / `docs/releash-performance-architecture-audit.md` M1。
+
+## 概要
+
+worktree（repo）ごとに分散している file watcher / Git dir watcher / git scan / read model 生成を、1 worktree につき 1 系統の `RepositoryStateService` に集約する。watcher の notify は invalidate（再走査要求）だけを発行し、debounce 後に background worker が 1 scan サイクル（read model 生成サイクル）を実行して versioned snapshot を生成する。status / diff stats / branch cards / worktree dirty count / diff file tree はこの単一 snapshot から導出する。ここでの「集約 scan」は全 linked worktree を物理的に 1 回の git2 走査へ統合する意味ではなく、current repo_path は 1 open の同一 `Repository` handle から status / diff stats / current dirty を導出し、別 linked worktree は workdir ごとに 1 dirty 走査を同じ scan サイクル内へ閉じる、という定義である。
+
+本 Issue では新 command 名 `get_review_snapshot` は導入せず（A1）、既存 command（`get_git_status` / `get_status_diff_stats` / `build_diff_file_tree` / `list_branches_with_status`）を service の snapshot cache を読む経路へ寄せ、watcher 重複と走査重複を解消する。
+
+## 変更対象
+
+### 新規
+
+- `src-tauri/src/usecase/repository_state/mod.rs` — モジュール公開
+- `src-tauri/src/usecase/repository_state/service.rs` — `RepositoryStateService`（worktree レジストリ・ensure_watching・get_snapshot）
+- `src-tauri/src/usecase/repository_state/worktree.rs` — `WorktreeState`（per-worktree の watcher / worker / snapshot 保持）
+- `src-tauri/src/usecase/repository_state/snapshot.rs` — `RepositorySnapshot` / フラグ / version
+- `src-tauri/src/usecase/repository_state/worker.rs` — invalidate → debounce → scan → supersede 判定
+- `src-tauri/src/usecase/repository_state/scanner.rs` — 1 scan サイクルの集約（status gateway の集約 scan と branch card snapshot から snapshot を組む）
+
+### 改修
+
+- `src-tauri/src/watcher.rs` — `start_watching` / `start_git_dir_watching` を service への委譲に置換。watcher 起動と debouncer 所有を service へ移動。`resolve_git_watch_paths` / `classify_git_dir_events` / `canonicalize_event_path` は service から再利用（pub(crate) 化）。callback 内の `build_branch_list_sync`（同期 `list_branches_with_status`）を撤去し invalidate 発行のみにする。
+- `src-tauri/src/lib.rs` — setup で `Arc<RepositoryStateService>` を構築し `app.manage`。既存 watcher への usecase 注入を service 構築に置換。
+- `src-tauri/src/adaptor/controller/state.rs` — `AppState` に `repository_state: Arc<RepositoryStateService>` を追加。
+- `src-tauri/src/adaptor/controller/command/repository/status.rs` — `get_git_status` / `get_status_diff_stats` を service snapshot 経由に変更。
+- `src-tauri/src/adaptor/controller/command/code/diff.rs` — `build_diff_file_tree` の供給元を snapshot 由来に寄せる（後述の互換方針）。
+- `src-tauri/src/adaptor/gateway/repository/status.rs` — `include_ignored(true)` を default で外し、ignored 取得を opt-in 引数化。
+
+### 変更しない
+
+- `behavior.md`
+- frontend の command surface（#1211 で置換）。本 Issue では frontend は既存 invoke と既存 event listen のままで、Rust 側が単一 service を裏に持つ。
+
+## アーキテクチャと責務分割
+
+層の責務は `rust-first-logic` と既存 clean architecture（A4）に従う。
+
+```
+lib.rs (composition root)
+  └─ Arc<RepositoryStateService>  ── app.manage / AppState に注入
+        │  worktree レジストリ: HashMap<PathBuf(正規化), Arc<WorktreeState>>
+        │
+        ├─ subscribe(path)              : 冪等。無ければ WorktreeState 生成し watcher 起動
+        ├─ get_snapshot(path, opts)     : 管理済みなら cache、未管理なら一時 scan の version 0 snapshot
+        └─ request_ignored(path)        : ignored opt-in 取得
+
+WorktreeState (per worktree, 1 系統)
+  ├─ watchers: 単一の file watcher(recursive workdir) + Git dir watcher(refs/heads, HEAD, index)
+  │     notify callback → invalidate チャンネルへ送信のみ（重い走査をしない）
+  ├─ snapshot: parking_lot::RwLock<Arc<RepositorySnapshot>>
+  ├─ version: AtomicU64 / requested_generation: AtomicU64（supersede 判定）
+  └─ worker(runtime port): invalidate 受信 → debounce(300ms) → scanner 実行 → supersede 判定 → snapshot 確定 → event emit
+
+scanner
+  └─ RepositoryUsecase / CodeUsecase へ委譲して 1 snapshot を構築
+       （status / diff stats / branch cards / dirty count / diff tree を 1 scan サイクル内で生成）
+```
+
+- **service**: worktree のライフサイクルと冪等な購読管理。複数 subscriber が同一 worktree を要求しても 1 つの `WorktreeState` を共有する（behavior「watcher 重複起動しない」）。read 経路だけでは `WorktreeState` / watcher を作らず、未管理 path は一時 scan 結果を返す。
+- **WorktreeState**: 1 worktree の watcher・snapshot・version・worker を所有。`Drop` で watcher と worker を停止。
+- **worker**: 非同期経路の中核。notify の同期実行禁止（behavior Rule「notify callback は invalidate だけ」）を担保。spawn / debounce sleep / blocking scan は `RepositoryStateWorkerRuntime` port で注入し、具体 Tokio 実装は gateway 側に置く。
+- **scanner**: read model 集約。status gateway の集約 scan で current repo_path を 1 回だけ `client::open` し、同一 `Repository` handle から `statuses()` 1 回、`diff_tree_to_index` 1 回、`diff_index_to_workdir` 1 回、`Patch::from_diff` による FileDiffStat を導出する。branch cards は同じ scan サイクル内で生成し、current worktree の dirty count は集約 scan の status 結果を再利用する。別 linked worktree の dirty count は workdir が異なるため個別走査になるが、同一 scan サイクル内で worktree ごとに 1 回だけ算出して snapshot に格納する。これにより各 read model が「個別 command から独立に git2 走査を起動」しない（requirements 要求 2）。`releash-base` GC は worker が snapshot commit 採用後に確定 branch names で実行し、read command では実行しない。
+
+scanner は usecase 層から既存 usecase（trait 経由の read model query）を呼ぶため、層の依存方向（usecase → gateway は trait 越し）を壊さない。
+
+## データモデルまたは型
+
+### RepositorySnapshot（snapshot.rs）
+
+```rust
+pub struct RepositorySnapshot {
+    pub version: u64,
+    pub flags: SnapshotFlags,
+    pub status: Vec<FileStatusDto>,        // ignored を含まない（default）
+    pub diff_stats: Vec<FileDiffStat>,
+    pub branch_cards: Vec<BranchCardDto>,  // worktree dirty count は dirty_count フィールドに内包
+    pub diff_file_tree: Vec<DiffTreeNodeDto>,
+}
+
+pub struct SnapshotFlags {
+    pub stale: bool,    // 最新変更を未反映で background refresh 中
+    pub loading: bool,  // 初回 / 再 scan 進行中
+    pub limited: bool,  // threshold による打ち切り（本 Issue では常に false 既定。閾値は #1211 で確定 = A6）
+}
+```
+
+- snapshot は `Arc` で共有し、worker が確定時に丸ごと差し替える（read 側はロック短時間）。
+- 初期状態（scan 未完了）: `version = 0`, `loading = true`, 各 read model は空。
+
+### 通知 event（A5）
+
+Tauri event を version 付きで emit する。
+
+```rust
+#[derive(Clone, Serialize)]
+pub struct RepositorySnapshotChangedEvent {
+    pub worktree_path: String,  // 正規化前の subscriber 識別子（呼び出し元と一致）
+    pub version: u64,
+    pub stale: bool,
+    pub loading: bool,
+    pub limited: bool,
+}
+```
+
+- event 名: `repository-snapshot-changed`。
+- 既存の `file-change` / `git-status-changed` / `branch-list-sync` は後方互換のため当面残すが、内部発火源は service の worker に一本化する。frontend の listen はそのまま機能する。
+- remote 向け `WsMessage::BranchListSync` は worker 確定時に従来同様 emit（ws bridge）。重い `list_branches_with_status` の同期実行を callback から worker へ移すだけで、外向き挙動は不変。
+
+### opt-in 取得オプション
+
+```rust
+pub struct SnapshotQueryOptions {
+    pub include_ignored: bool,  // default false
+}
+```
+
+`include_ignored = true` の取得は default snapshot を汚さず、ignored を含む status を別途算出して返す（snapshot cache は non-ignored を保持）。`status.rs` の `include_ignored(true)` は引数で制御する形に変更する。
+
+## 処理フロー
+
+### 初回購読 / 初回 scan（behavior「loading を経て最初の snapshot」）
+
+1. frontend が `start_watching` / `start_git_dir_watching` を invoke した場合だけ、service が `subscribe(path)` を呼ぶ。未登録なら `WorktreeState` を生成し watcher と worker を起動、`requested_generation` を 1 にして初回 invalidate を投入する。
+2. read command が `get_snapshot(path)` を呼んだ時、管理済み worktree があれば cache を返す。未管理 path では `WorktreeState` / watcher を作らず、scanner を同期実行した version 0 の ready snapshot を一時的に返す。
+3. 管理済み worktree の worker が初回 scan 完了で `version = 1` の snapshot を確定、`loading = false` で `repository-snapshot-changed` を emit。
+4. frontend は event を受けて再 invoke し、確定 snapshot 由来の結果を表示する。
+
+### 変更検知（behavior「invalidate → debounce → 1 回 scan」）
+
+1. file / Git dir watcher の notify callback が発火。callback は `requested_generation += 1` し invalidate チャンネルへ送信するだけ（重い走査をしない）。
+2. worker は invalidate を受け、300ms debounce（A7）でこの間の追加 invalidate を吸収（`requested_generation` が上がるだけ）。
+3. debounce 満了で `start_gen = requested_generation` を読み、scanner を実行（git2 は同期のため `tokio::task::spawn_blocking`）。
+4. scanner は current repo_path の status / diff stats / current dirty を status gateway の集約 scan から導出し、branch cards と diff tree を同じ scan サイクル内の snapshot parts として組み立てる。
+
+### stale 即時返却（behavior「scan が長い場合」）
+
+- background refresh 中（worker が新 scan 実行中で未確定）に `get_snapshot` が呼ばれたら、保持中の旧 snapshot を `stale = true` を立てたコピーとして即時返す。
+- 確定後、新 version の snapshot を `stale = false` で通知する。
+
+### cancel / supersede（behavior「古い scan を打ち切り、上書きしない」）
+
+git2 走査は途中キャンセルできないため、**完了時 supersede** を採る。
+
+1. worker は scan 後に `requested_generation == start_gen` を比較。
+2. 一致しなければ（scan 中に新 invalidate が来た）結果を破棄し、最新 generation で再 scan する（古い結果で snapshot を上書きしない）。
+3. 一致すれば `version += 1` で snapshot を確定し emit。
+4. `version` は worker 単一直列のため単調増加が保証され逆行しない。
+
+この方式は「進行中 scan の即時中断」ではなく「古い結果を採用せず最新で再走査」だが、外部観測（最終 snapshot が最新状態を反映・version 逆行なし）は behavior の Rule を満たす。中断不可である点は「仮定」に明記する。
+
+### diff file tree の供給（互換方針）
+
+現状 `build_diff_file_tree` は frontend が diff stats から組んだ entries を渡す pull 型。本 Issue では tree 構築を scanner 内（diff stats から `DiffTreeNodeDto` を組む既存ロジック流用）へ移し snapshot に含める。`build_diff_file_tree` command は当面 entries-only のシグネチャを維持し、統合 tree は `get_head_diff_file_tree_snapshot` の `combined_tree` から取得できるようにする（frontend 置換は #1211）。
+
+## エラー処理
+
+- **scan 失敗**（repo open 失敗 / git2 エラー）: worker は当該サイクルの snapshot 確定を行わず、直近の確定 snapshot を保持。`loading` を下げ、エラーは `tracing` でログ。frontend には version 更新を出さない（古い表示を維持）。リトライは次の invalidate / 再 scan に委ねる。
+- **worktree 削除 / パス消失**: watcher エラーを契機に `WorktreeState` を service レジストリから除去し worker を停止。
+- **command 経路**: `get_snapshot` は snapshot 未確定でもエラーにせず loading snapshot を返す（UI をブロックしない）。repo path 不正など回復不能な入力は従来どおり `AppError` を返す。
+- **エラー型**: service 専用に `RepositoryStateError`（usecase 層）を定義し、既存 `UsecaseError` / `AppError` へ `From` 変換。各モジュール専用エラー型の規約に従う。
+- **watcher 起動失敗**: `ensure_watching` はエラーを返すが、既存 `start_watching` の `Result<u64, String>` 互換を保つため文字列化して返す。
+
+## テスト方針
+
+Rust 単体テスト（`#[cfg(test)] mod tests`）。git2 は `git/mod.rs::test_helpers`（`create_test_repo` / `create_initial_commit` / `add_and_commit`）を再利用。tokio 非同期部は `#[tokio::test]`。
+
+- **集約 scan の正準性**: status gateway の集約 scan が既存経路（`get_git_status` / `get_status_diff_stats`）の結果と一致し、scanner snapshot が既存 `list_branches_with_status` / diff tree と一致する（ignored 既定除外を除く）。behavior「非回帰」Rule に対応。
+- **走査回数**: current repo_path の集約 scan が `statuses()` を 1 回だけ実行すること、branch cards 生成で current dirty を再走査せず、別 linked worktree dirty を worktree ごとに 1 回だけ走査することをカウンタで検証する。
+- **version 単調増加 / 逆行なし**: 連続 invalidate で version が増加のみすることを検証。
+- **supersede**: scan 中に generation を進めた場合、古い結果が採用されず再 scan され、最終 snapshot が最新 generation 由来であることを検証（scanner にフックを挟み generation を人工的に進める）。
+- **stale 遷移**: refresh 中の `get_snapshot` が旧 version を `stale = true` で返し、確定後に `stale = false` の新 version へ遷移。
+- **loading 遷移**: 初回購読で `loading = true` → 完了で `version >= 1`, `loading = false`。
+- **debounce 集約**: debounce 期間内の複数 invalidate が 1 回の scan に集約されること（scan 実行回数をカウンタで検証）。
+- **ignored opt-in**: default snapshot に ignored が含まれず、`include_ignored = true` で含まれる。
+- **watcher 単一性**: 同一 worktree への複数 `ensure_watching` でレジストリ entry / watcher が 1 つ（重複起動しない）。
+- **複数 worktree 独立**: W1 の invalidate が W2 の version に影響しない。
+
+debounce / 非同期タイミングはテスト安定化のため、debounce 値と「scan 実行関数」を注入可能にする（テストで 0ms 相当・同期スタブ scanner を差し込む）。
+
+## リスクと代替案
+
+- **R1: 既存 command を snapshot 経由へ寄せる際の回帰**。`get_git_status` 等が即時計算から snapshot 参照に変わるため、初回は loading 空 snapshot を返しうる。緩和: command は未確定時に同期で初回 scan を待つ同期パス（短時間 block）も用意するか、空 + event 通知で frontend 再取得に委ねる。本設計は後者を既定とし、UI が空表示を一瞬挟む可能性を `limited`/`loading` で表現。代替: 初回のみ同期 scan を待つ（実装はやや複雑、初回レイテンシ増）。
+- **R2: git2 scan の中断不可**。完了時 supersede のため、巨大 repo で無駄な完走が起きうる。緩和: debounce で invalidate を束ねる / 将来 scanner を段階分割。代替: scan を細粒度ステップ化しチェックポイントで generation 比較（#1211 の review file view と合わせて検討）。
+- **R3: snapshot メモリ常駐**。worktree 数 × snapshot サイズ分のメモリを保持。緩和: 非アクティブ worktree の `WorktreeState` を LRU / close で解放。
+- **R4: 二重通知**。新 `repository-snapshot-changed` と旧 event を併存させる間、frontend が二重 refresh しうる。緩和: 旧 event の発火も worker 一本化で重複を抑え、#1211 で旧 event を撤去。
+- **代替アーキテクチャ**: actor（mpsc コマンド）型 vs 共有状態（RwLock + Notify）型。本設計は per-worktree に worker タスク 1 本 + invalidate チャンネル + RwLock snapshot の折衷とする（実装が単純で version 直列化を自然に担保）。完全 actor 化は将来 M2/M3 の session/streaming read model と統合する際に再検討。
+
+## 仮定
+
+`requirements.md` A1〜A7 を前提とする。本設計で追加・具体化した仮定:
+
+- **D1: supersede は「完了時破棄＋再 scan」**。git2 走査の途中中断はしない。version 逆行なし・最終 snapshot 最新反映という外部挙動で behavior を満たす。
+- **D2: 通知は Tauri event `repository-snapshot-changed`（version 付き）を主とし、remote 向け `WsMessage::BranchListSync` は worker 確定時に従来同様 emit する**。既存 `file-change` / `git-status-changed` / `branch-list-sync` は本 Issue では互換のため残し、発火源を worker に一本化する（撤去は #1211）。
+- **D3: 既存 command は管理済み worktree では snapshot cache を読む。未管理 path では watcher を作らず一時 scan の version 0 ready snapshot を返す**。frontend は管理済み worktree の event で再取得する。
+- **D4: service は `Arc<RepositoryStateService>` として `app.manage` し、`AppState` からも参照する**。watcher の debouncer 所有は service（`WorktreeState`）へ移す。worker の spawn / sleep / blocking scan と path normalize は usecase port とし、具体 Tokio / filesystem 実装は gateway 側に置く。
+- **D5: scanner は `RepositoryUsecase` / `CodeUsecase` へ委譲して 1 snapshot を構築し、呼び出しを 1 scan サイクルに束ねる**。status gateway に current repo_path の集約 scan を置き、1 回の `client::open` で得た同一 `Repository` handle から `statuses()` / `diff_tree_to_index` / `diff_index_to_workdir` / `Patch::from_diff` を導出する。branch cards は scan サイクル内 snapshot として生成し、current worktree dirty は集約 scan の status 結果を再利用する。別 linked worktree dirty は別 workdir 走査が物理的に必要なため統合しないが、worktree ごとに 1 回だけ算出する。
+- **D6: `limited` は本 Issue では常に false 既定**（打ち切り表現の器だけ用意）。具体閾値は #1211 で確定（A6）。
+- **D7: worktree の同一性キーは `WorktreePathNormalizer` port で正規化した絶対パス**。subscriber へ返す `worktree_path` は呼び出し元と一致する文字列を保つ。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1210/requirements.md
+++ b/docs/specs/issues-1210/requirements.md
@@ -1,0 +1,112 @@
+# Requirements
+
+## Type
+
+新機能 / リファクタリング。性能・メモリ効率改善（マイルストーン M1「Git / Diff hot path を Rust read model に寄せる」）の基盤として、`RepositoryStateService` を導入し、worktree ごとに分散している watcher / git scan / read model 生成を 1 系統に集約する。
+
+関連: #1210（本 Issue）/ #1209（M0 計測, 先行）/ #1211 / #1212 / #767 / #866 / #894 / `docs/releash-performance-architecture-audit.md` M1（正本ドキュメント, commit `b0c5e4c2`）
+
+## 背景と目的
+
+現状、Git の read model 生成が component / hook ごとに分散している。
+
+- `useGitStatus` が `start_watching` で file watcher を起動し、status を取得する。
+- `useDiffFileTree` が status 後に `get_status_diff_stats` と `build_diff_file_tree` を別 command で呼ぶ。
+- `useGitEventRefresh` は caller ごとに `start_watching` を呼び、ReviewPanel と useGitStatus などで watcher が重複する。
+- `watcher.rs` の Git dir watcher は notify callback 内で `list_branches_with_status`（dirty count など重い read model 生成）を直接呼ぶ。
+
+結果として、同一 worktree に対して watcher と git scan が複数走り、status / diff stats / branch cards / worktree dirty count / diff tree がそれぞれ別経路で git2 を起動して同じ走査を重複生成する。`docs/releash-performance-architecture-audit.md` の結論にあるとおり、問題は個別機能の遅さではなく「全量を読む / 全量を再計算する」設計の広がりにある。
+
+本 Issue では、1 repo / worktree につき watcher と git scan を 1 系統へ集約する `RepositoryStateService` を Rust 側に追加し、status / diff stats / branch cards / worktree dirty count / diff tree を同一 cache / versioned snapshot から返す土台を作る。これは後続の #1211（ReviewSnapshot / ReviewFileView command）と #1212（hunk operation の id 化）が乗る基盤であり、M1 の最初に着手する位置づけ（Issue コメント「順序 4-1」）。
+
+## スコープ
+
+### RepositoryStateService の導入
+
+- worktree（repo）ごとに 1 つの service instance が watcher と git scan を所有する。
+- recursive file watcher と Git dir watcher を service へ集約し、worktree あたり 1 系統に統合する。
+- watcher の notify callback では重い read model 生成（`list_branches_with_status` 等）を直接行わず、invalidate（再走査要求）だけを発行する。実際の snapshot 生成は debounce 後に service の worker が行う。
+- 同一 worktree に対して、複数の subscriber（ReviewPanel / useGitStatus / diff tree など）が個別に watcher を起動しない。subscriber は service の snapshot / version 通知を購読する。
+
+### 集約する read model（同一 snapshot から提供）
+
+debounce 後に生成する versioned snapshot から、以下を同一 cache / snapshot 経由で提供する。
+
+- Git status（review に必要な file 集合）
+- diff stats（status と同一走査由来）
+- branch cards（`list_branches_with_status` 相当）
+- worktree dirty count
+- diff file tree（`build_diff_file_tree` 相当の tree 化）
+
+これらが、現状のように個別 command / 個別走査で都度生成されるのではなく、1 scan サイクル（debounce 後 worker の read model 生成サイクル）で作った versioned snapshot から導出される状態にする。ここでの「集約 scan」は「全 worktree を物理的に 1 回の git2 走査へ統合する」意味ではない。current repo_path は 1 回の `client::open` で得た同一 `Repository` handle から `statuses()` / `diff_tree_to_index` / `diff_index_to_workdir` / `Patch::from_diff` を導出し、別 linked worktree の dirty count は別 workdir 走査が必要なため worktree ごとに 1 回だけ scan サイクル内で算出する。
+
+### versioned snapshot とフラグ
+
+- snapshot は version（単調増加するシーケンス）を持ち、subscriber は version で新旧を判定できる。
+- snapshot は次のフラグを含む:
+  - `stale`: 現在の snapshot が最新の変更を反映していない（background refresh 中）。
+  - `loading`: 初回 scan / 再 scan が進行中。
+  - `limited`: threshold（後述）により内容が省略・打ち切りされている。
+- 中規模 repo で scan に時間がかかる場合、まず既存（stale）snapshot を返しつつ、background で refresh して新しい version を通知できる。
+
+### scan の cancel / supersede
+
+- scan 実行中に次の変更（invalidate）が来たら、進行中の古い scan を cancel / supersede し、最新状態に対する scan を優先する。
+- 古い scan の結果で新しい snapshot を上書きしない（version の逆行を防ぐ）。
+
+### ignored files の扱い
+
+- default の snapshot では ignored files を返さない（現状 `status.rs` の `include_ignored(true)` による無駄な転送・CPU を削減する）。
+- ignored files が必要な UI のみ opt-in で取得できる経路を残す。
+
+### 既存 watcher 駆動フローの置き換え
+
+- `useGitEventRefresh` / `useGitStatus` / `useDiffFileTree` 等が個別に `start_watching` する経路を、service が提供する単一 watcher + snapshot 通知へ寄せる。
+- `watcher.rs` の Git dir callback で行っている重い同期処理を、service の invalidate → debounce → background worker 経路へ移す。
+
+## 非スコープ
+
+- **`get_review_snapshot(worktree_path, base)` / `get_review_file_view(...)` という frontend 向け command surface の確定と、`useFileDiffContent` / `useImageDiff` の direct FS read 削除、image の blob ref / temp URL 化**。これは #1211 の範囲とする。本 Issue は service / cache / 単一 watcher / versioned snapshot という基盤と、既存の status / diff stats / branch / dirty count / diff tree 経路の集約に限定する（仮定 A1 参照。境界は Open Questions Q1）。
+- **hunk operation の id 化（`stage_hunk_by_id` / `unstage_hunk_by_id`）と frontend patch 再生成の削除**。#1212 の範囲。
+- **review file view（file open 時の hunk groups / line window / large-file fallback / tokenization status）**。#1211 の範囲。
+- **session / streaming / terminal / runtime lifecycle の read model**（M2 / M3）。
+- 計測・性能予算そのものの追加（#1209 / M0 で実施済み・別管理）。本 Issue は #1209 で入れた計測で改善効果を確認できる前提とする。
+
+## 要求事項
+
+1. worktree（repo）ごとに watcher と git scan が 1 系統に集約され、同一 worktree に対して watcher が重複起動しない。
+2. status / diff stats / branch cards / worktree dirty count / diff file tree が、同一の scan サイクルに由来する versioned snapshot から提供される（個別 command がそれぞれ独立に git2 走査を起動しない）。current repo_path の status / diff stats / current dirty は 1 回の `client::open` で得た同一 handle から導出し、別 linked worktree dirty は worktree ごとに 1 回だけ同一 scan サイクル内で算出する。
+3. snapshot は version と `stale` / `loading` / `limited` フラグを持ち、subscriber が新旧と状態を判定できる。
+4. 中規模 repo で scan が長い場合、stale snapshot を即時に返しつつ background で refresh し、完了時に新しい version を通知できる。
+5. scan 中に次の変更が来たら、古い scan を cancel / supersede し、古い結果で新しい snapshot を上書きしない。
+6. ignored files は default snapshot で返さず、必要な UI だけが opt-in で取得できる。
+7. 全ロジックは Rust（Tauri バックエンド）に実装する（プロジェクト方針 `rust-first-logic`）。frontend は service の snapshot / version 通知を購読して表示するだけで、Git orchestration（走査トリガ・tree 化・基準選択）を持たない。
+8. watcher の notify callback 内で重い read model 生成（branch list / dirty count 等）を同期実行せず、invalidate → debounce → background worker の経路に分離する。
+9. 既存の status / diff stats / branch / worktree dirty count / diff tree の表示挙動（ユーザーから見える結果）に、ignored 既定除外を除いて回帰がない。
+
+## 受け入れ基準の概要
+
+- ReviewPanel / useGitStatus / diff tree などが個別に watcher（`start_watching`）を開始せず、単一 watcher 由来の通知で更新される。
+- snapshot に version / stale / loading / limited フラグが含まれ、subscriber が参照できる。
+- 中規模 repo で、初回または変更後に stale snapshot を返しつつ background refresh が走り、完了後に最新 snapshot へ更新される。
+- scan 実行中に追加変更が発生した場合、古い scan が打ち切られ、最終 snapshot が最新状態を反映する（version が逆行しない）。
+- default snapshot に ignored files が含まれず、opt-in した経路でのみ取得できる。
+- status / diff stats / branch cards / worktree dirty count / diff tree が同一 snapshot から導出され、current repo_path の status / diff stats / current dirty の二重 open や、同一 linked worktree dirty の重複走査が起きない。
+- 既存の表示結果（status / diff stats / branch / diff tree）に回帰がない（ignored 既定除外を除く）。
+- 新規ロジックに対する Rust 単体テスト（正常系・cancel/supersede・stale/version 遷移・ignored opt-in）がある。
+
+## 仮定
+
+以下は Issue とリポジトリ現状から置いた仮定。誤りがあれば指摘で修正する。
+
+- **A1: 本 Issue と #1211 の境界（確定）**。本 Issue は `RepositoryStateService`（単一 watcher + 集約 scan + versioned snapshot cache + cancel/supersede + ignored opt-in）と、既存の status / diff stats / branch / dirty count / diff tree 経路の集約までを担う。本 Issue では新 command 名 `get_review_snapshot` を導入せず、既存 command を裏で単一 service 経由に寄せて watcher 重複を解消する。frontend 向けの `get_review_snapshot` / `get_review_file_view` command 名の確定と frontend 呼び出し置換・direct FS read 削除・image blob ref 化は #1211 とする（旧 Open Question Q1 の確定結果＝案 A）。
+- **A2: Spec ディレクトリ名**は `docs/specs/issues-1210` とする（先行 M0 Issue #1209 が `docs/specs/issues-1209` を用いた命名慣行に合わせる）。
+- **A3: 既存クレートの活用**。watcher は既存の `notify_debouncer_mini`、Git 操作は `git2`、非同期は `tokio`、共有状態は `parking_lot` / `Arc` を再利用し、新規の重い依存は追加しない。
+- **A4: service の所有場所**。`RepositoryStateService` は usecase 層に state service として置き、`watcher.rs` / `AppState` から利用する（既存 clean architecture 移行方針 M4 と整合）。具体配置は design.md で確定する。
+- **A5: subscriber 通知方式**。snapshot 更新は既存の Tauri event（`file-change` 相当の event emit）/ ws bridge と同様の event 通知で subscriber へ届ける。版管理のため event に version を含める。具体方式は design.md で確定する。
+- **A6: threshold（`limited` 条件）**。large file / many files / rename detection / untracked content 等の threshold 値は本 Issue では「`limited` フラグで打ち切りを表現できること」を要求し、具体閾値は #1211 の review file view と合わせて design.md / 後続で確定する。
+- **A7: debounce**。既存 `useGitEventRefresh` の 300ms debounce 相当を service 側へ移し、frontend 側の重複 debounce を不要にする。具体値は既存挙動を踏襲する。
+
+## Open Questions
+
+なし（Q1「本 Issue で `get_review_snapshot` command を導入するか」は確定: 案 A。本 Issue は service + 単一 watcher + 内部 snapshot/通知までとし、新 command 名 `get_review_snapshot` の導入と frontend 呼び出し置換は #1211 で行う。スコープ・非スコープ・A1 に反映済み）。

--- a/src-tauri/src/adaptor/controller/command/code/diff.rs
+++ b/src-tauri/src/adaptor/controller/command/code/diff.rs
@@ -7,6 +7,7 @@ use crate::adaptor::controller::state::AppState;
 use crate::adaptor::protocol::code::{DiffFileEntryInput, DiffTreeNodeInput};
 use crate::other::AppError;
 use crate::usecase::code_dto::{BranchDiffSummaryDto, DiffTreeNodeDto, FileNavigationResultDto};
+use crate::usecase::repository_state::snapshot::RepositoryHeadDiffFileTreeSnapshotDto;
 
 #[tauri::command]
 pub async fn build_diff_file_tree(
@@ -20,6 +21,18 @@ pub async fn build_diff_file_tree(
             .map(DiffFileEntryInput::into_domain)
             .collect();
         Ok(uc.build_diff_file_tree(entries))
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn get_head_diff_file_tree_snapshot(
+    state: State<'_, AppState>,
+    repo_path: String,
+) -> Result<RepositoryHeadDiffFileTreeSnapshotDto, AppError> {
+    let service = state.repository_state.clone();
+    super::super::repository::run_repository_state(move || {
+        service.get_head_diff_file_tree_snapshot(&repo_path)
     })
     .await
 }

--- a/src-tauri/src/adaptor/controller/command/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/mod.rs
@@ -76,6 +76,7 @@ pub(crate) fn register_all(builder: tauri::Builder<tauri::Wry>) -> tauri::Builde
             crate::adaptor::controller::command::code::file_content::get_review_image_diff,
             crate::adaptor::controller::command::code::diff::get_branch_diff_summary,
             crate::adaptor::controller::command::code::diff::build_diff_file_tree,
+            crate::adaptor::controller::command::code::diff::get_head_diff_file_tree_snapshot,
             crate::adaptor::controller::command::code::diff::get_file_navigation,
             // Git: hunk/patch（code ドメイン）
             crate::adaptor::controller::command::code::hunk::compute_diff_hunks,
@@ -93,7 +94,9 @@ pub(crate) fn register_all(builder: tauri::Builder<tauri::Wry>) -> tauri::Builde
             crate::adaptor::controller::command::repository::branch::delete_branch,
             // Git: ステータス（repository ドメイン）
             crate::adaptor::controller::command::repository::status::get_git_status,
+            crate::adaptor::controller::command::repository::status::get_git_status_snapshot,
             crate::adaptor::controller::command::repository::status::get_status_diff_stats,
+            crate::adaptor::controller::command::repository::status::get_status_diff_stats_snapshot,
             crate::adaptor::controller::command::repository::log::get_git_log,
             // Git: ステージング（code ドメイン）
             crate::adaptor::controller::command::code::staging::git_stage,
@@ -105,6 +108,7 @@ pub(crate) fn register_all(builder: tauri::Builder<tauri::Wry>) -> tauri::Builde
             crate::adaptor::controller::command::repository::worktree::get_worktree_dirty_count,
             crate::adaptor::controller::command::repository::worktree::list_worktrees,
             crate::adaptor::controller::command::repository::worktree::list_branches_with_status,
+            crate::adaptor::controller::command::repository::worktree::list_branches_with_status_snapshot,
             crate::adaptor::controller::command::repository::worktree::create_worktree,
             crate::adaptor::controller::command::repository::worktree::remove_worktree,
             // Git: 設定・ユーティリティ（repository ドメイン）

--- a/src-tauri/src/adaptor/controller/command/repository/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/repository/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod worktree;
 
 use crate::other::AppError;
 use crate::usecase::repository_error::UsecaseError;
+use crate::usecase::repository_state::RepositoryStateError;
 
 /// ユースケースエラー → アプリエラーの集約変換（adaptor 層が担う）。
 /// `#[error(transparent)]` な `UsecaseError` の `Display` を保持するため、
@@ -24,12 +25,29 @@ impl From<UsecaseError> for AppError {
     }
 }
 
+impl From<RepositoryStateError> for AppError {
+    fn from(e: RepositoryStateError) -> Self {
+        AppError::Internal(e.to_string())
+    }
+}
+
 /// ユースケース呼び出しを `spawn_blocking` 上で実行し、結果を `AppError`
 /// に集約する共通ヘルパー。join 失敗時のメッセージは移行前と等価に保つ。
 pub(super) async fn run_blocking<T, F>(f: F) -> Result<T, AppError>
 where
     T: Send + 'static,
     F: FnOnce() -> Result<T, UsecaseError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| AppError::new(format!("task join error: {e}")))?
+        .map_err(AppError::from)
+}
+
+pub(super) async fn run_repository_state<T, F>(f: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, RepositoryStateError> + Send + 'static,
 {
     tokio::task::spawn_blocking(f)
         .await

--- a/src-tauri/src/adaptor/controller/command/repository/status.rs
+++ b/src-tauri/src/adaptor/controller/command/repository/status.rs
@@ -1,21 +1,31 @@
 use tauri::State;
 
-use super::run_blocking;
+use super::run_repository_state;
 use crate::adaptor::controller::state::AppState;
 use crate::other::AppError;
 use crate::usecase::repository_dto::{FileDiffStatDto, FileStatusDto};
+use crate::usecase::repository_state::snapshot::{
+    RepositoryDiffStatsSnapshotDto, RepositoryStatusSnapshotDto,
+};
 
 #[tauri::command]
 pub async fn get_git_status(
     state: State<'_, AppState>,
     repo_path: String,
+    include_ignored: Option<bool>,
 ) -> Result<Vec<FileStatusDto>, AppError> {
-    let uc = state.repository_usecase.clone();
-    run_blocking(move || {
-        uc.get_git_status(&repo_path)
-            .map(|statuses| statuses.into_iter().map(Into::into).collect())
-    })
-    .await
+    let service = state.repository_state.clone();
+    run_repository_state(move || service.get_status(&repo_path, include_ignored.unwrap_or(false)))
+        .await
+}
+
+#[tauri::command]
+pub async fn get_git_status_snapshot(
+    state: State<'_, AppState>,
+    repo_path: String,
+) -> Result<RepositoryStatusSnapshotDto, AppError> {
+    let service = state.repository_state.clone();
+    run_repository_state(move || service.get_status_snapshot(&repo_path)).await
 }
 
 #[tauri::command]
@@ -23,10 +33,15 @@ pub async fn get_status_diff_stats(
     state: State<'_, AppState>,
     repo_path: String,
 ) -> Result<Vec<FileDiffStatDto>, AppError> {
-    let uc = state.repository_usecase.clone();
-    run_blocking(move || {
-        uc.get_status_diff_stats(&repo_path)
-            .map(|stats| stats.into_iter().map(Into::into).collect())
-    })
-    .await
+    let service = state.repository_state.clone();
+    run_repository_state(move || service.get_diff_stats(&repo_path)).await
+}
+
+#[tauri::command]
+pub async fn get_status_diff_stats_snapshot(
+    state: State<'_, AppState>,
+    repo_path: String,
+) -> Result<RepositoryDiffStatsSnapshotDto, AppError> {
+    let service = state.repository_state.clone();
+    run_repository_state(move || service.get_diff_stats_snapshot(&repo_path)).await
 }

--- a/src-tauri/src/adaptor/controller/command/repository/worktree.rs
+++ b/src-tauri/src/adaptor/controller/command/repository/worktree.rs
@@ -1,9 +1,10 @@
 use tauri::State;
 
-use super::run_blocking;
+use super::{run_blocking, run_repository_state};
 use crate::adaptor::controller::state::AppState;
 use crate::other::AppError;
 use crate::usecase::repository_dto::{BranchCardDto, WorktreeEntryDto};
+use crate::usecase::repository_state::snapshot::RepositoryBranchCardsSnapshotDto;
 
 #[tauri::command]
 pub async fn get_main_repo_path(
@@ -19,8 +20,8 @@ pub async fn get_worktree_dirty_count(
     state: State<'_, AppState>,
     worktree_path: String,
 ) -> Result<u32, AppError> {
-    let uc = state.repository_usecase.clone();
-    run_blocking(move || uc.get_worktree_dirty_count(&worktree_path)).await
+    let service = state.repository_state.clone();
+    run_repository_state(move || service.get_worktree_dirty_count(&worktree_path)).await
 }
 
 #[tauri::command]
@@ -37,8 +38,17 @@ pub async fn list_branches_with_status(
     state: State<'_, AppState>,
     repo_path: String,
 ) -> Result<Vec<BranchCardDto>, AppError> {
-    let uc = state.repository_usecase.clone();
-    run_blocking(move || uc.list_branches_with_status(&repo_path)).await
+    let service = state.repository_state.clone();
+    run_repository_state(move || service.list_branches_with_status(&repo_path)).await
+}
+
+#[tauri::command]
+pub async fn list_branches_with_status_snapshot(
+    state: State<'_, AppState>,
+    repo_path: String,
+) -> Result<RepositoryBranchCardsSnapshotDto, AppError> {
+    let service = state.repository_state.clone();
+    run_repository_state(move || service.list_branches_with_status_snapshot(&repo_path)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/adaptor/controller/command/workflow/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/mod.rs
@@ -2380,10 +2380,26 @@ mod tests {
                 Arc::new(repo_paths_gateway),
                 Arc::new(NoopRepoPathsNotifier),
             ));
+        let code_usecase = Arc::new(crate::adaptor::controller::wiring::build_code_usecase());
+        let repository_state = Arc::new(
+            crate::usecase::repository_state::RepositoryStateService::new(
+                repository_usecase.clone(),
+                code_usecase.clone(),
+                Arc::new(crate::usecase::repository_state::worktree::NoopRepositoryStateNotifier),
+                Arc::new(crate::usecase::repository_state::worktree::NoopRepositoryStateWatcher),
+                Arc::new(
+                    crate::usecase::repository_state::runtime::tests_support::TestRepositoryStateWorkerRuntime,
+                ),
+                Arc::new(
+                    crate::usecase::repository_state::runtime::tests_support::IdentityWorktreePathNormalizer,
+                ),
+            ),
+        );
         app.manage(AppState {
             repository_usecase: repository_usecase.clone(),
+            repository_state,
             repo_paths_usecase,
-            code_usecase: Arc::new(crate::adaptor::controller::wiring::build_code_usecase()),
+            code_usecase,
             workflow_usecase: Arc::new(
                 crate::adaptor::controller::wiring::build_workflow_usecase_with_repository_worktrees(
                     data_dir.clone(),

--- a/src-tauri/src/adaptor/controller/state.rs
+++ b/src-tauri/src/adaptor/controller/state.rs
@@ -7,11 +7,13 @@ use std::sync::Arc;
 
 use crate::usecase::code_usecase::CodeUsecase;
 use crate::usecase::repo_paths_usecase::RepoPathsUsecase;
+use crate::usecase::repository_state::RepositoryStateService;
 use crate::usecase::repository_usecase::RepositoryUsecase;
 use crate::usecase::workflow::WorkflowUsecase;
 
 pub struct AppState {
     pub repository_usecase: Arc<RepositoryUsecase>,
+    pub repository_state: Arc<RepositoryStateService>,
     pub repo_paths_usecase: Arc<RepoPathsUsecase>,
     pub code_usecase: Arc<CodeUsecase>,
     pub workflow_usecase: Arc<WorkflowUsecase>,

--- a/src-tauri/src/adaptor/gateway/repository/branch_card.rs
+++ b/src-tauri/src/adaptor/gateway/repository/branch_card.rs
@@ -5,7 +5,7 @@
 //! Command 側（`WorktreeRepository` 等の単一集約 I/O）とはファイルを分離する（CQRS）。
 
 use super::util::resolve_branch_base;
-use super::worktree::{each_worktree, get_dirty_count_for_path};
+use super::worktree::each_worktree;
 use crate::domain::repository::RepositoryError;
 use crate::infrastructure::git::client;
 use crate::infrastructure::git::helpers::{detect_default_branch, get_branch_name_for_repo};
@@ -14,6 +14,53 @@ use crate::usecase::repository_query_service::BranchCardQuery;
 use git2::{BranchType, Oid, Repository};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+
+#[cfg(test)]
+thread_local! {
+    static DIRTY_WORKTREE_SCAN_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+fn normalize_worktree_path(path: &str) -> String {
+    path.trim_end_matches('/').to_string()
+}
+
+struct DirtyCountSnapshot {
+    counts_by_path: HashMap<String, usize>,
+}
+
+impl DirtyCountSnapshot {
+    fn empty() -> Self {
+        Self {
+            counts_by_path: HashMap::new(),
+        }
+    }
+
+    fn with_current(current_workdir: Option<&str>, current_dirty_count: usize) -> Self {
+        let mut snapshot = Self::empty();
+        if let Some(path) = current_workdir {
+            snapshot
+                .counts_by_path
+                .insert(normalize_worktree_path(path), current_dirty_count);
+        }
+        snapshot
+    }
+
+    fn dirty_count_for_path(&mut self, path: &str) -> usize {
+        let key = normalize_worktree_path(path);
+        if let Some(count) = self.counts_by_path.get(&key) {
+            return *count;
+        }
+        let count = calculate_dirty_count_for_path(Path::new(path)) as usize;
+        self.counts_by_path.insert(key, count);
+        count
+    }
+}
+
+fn calculate_dirty_count_for_path(path: &Path) -> u32 {
+    #[cfg(test)]
+    DIRTY_WORKTREE_SCAN_COUNT.with(|count| count.set(count.get() + 1));
+    super::worktree::get_dirty_count_for_path(path)
+}
 
 fn is_on_first_parent_line(repo: &Repository, ancestor_oid: Oid, descendant_oid: Oid) -> bool {
     let mut current = descendant_oid;
@@ -100,18 +147,23 @@ fn resolve_base_target_oid(
 
 /// ローカルブランチ 1 件分のカードを構築する（worktree マッチ・dirty・is_merged・
 /// ahead/behind・base_ahead・main_worktree 判定）。
+struct BranchCardBuildContext<'a> {
+    repo: &'a Repository,
+    wt_map: &'a HashMap<String, String>,
+    config: Option<&'a git2::Config>,
+    base_target_oid: Option<Oid>,
+    main_workdir: Option<&'a str>,
+}
+
 fn build_branch_card(
-    repo: &Repository,
     branch: &git2::Branch,
     name: String,
-    wt_map: &HashMap<String, String>,
-    config: Option<&git2::Config>,
-    base_target_oid: Option<Oid>,
-    main_workdir: Option<&str>,
+    context: &BranchCardBuildContext,
+    dirty_counts: &mut DirtyCountSnapshot,
 ) -> BranchCardDto {
-    let (worktree_path, dirty_count) = match wt_map.get(&name) {
+    let (worktree_path, dirty_count) = match context.wt_map.get(&name) {
         Some(path) => {
-            let dirty = get_dirty_count_for_path(Path::new(path)) as usize;
+            let dirty = dirty_counts.dirty_count_for_path(path);
             (Some(path.clone()), dirty)
         }
         None => (None, 0),
@@ -120,7 +172,7 @@ fn build_branch_card(
     let is_merged = branch
         .get()
         .target()
-        .map(|oid| compute_is_merged(repo, oid, base_target_oid))
+        .map(|oid| compute_is_merged(context.repo, oid, context.base_target_oid))
         .unwrap_or(false);
 
     let upstream = branch.upstream().ok();
@@ -129,7 +181,7 @@ fn build_branch_card(
         .and_then(|u| {
             let local_oid = branch.get().target()?;
             let remote_oid = u.get().target()?;
-            repo.graph_ahead_behind(local_oid, remote_oid).ok()
+            context.repo.graph_ahead_behind(local_oid, remote_oid).ok()
         })
         .unwrap_or((0, 0));
 
@@ -137,19 +189,22 @@ fn build_branch_card(
         .get()
         .target()
         .and_then(|branch_oid| {
-            let base_name = resolve_branch_base(repo, config, &name)?;
-            let base_oid = repo
+            let base_name = resolve_branch_base(context.repo, context.config, &name)?;
+            let base_oid = context
+                .repo
                 .find_branch(&base_name, BranchType::Local)
                 .ok()?
                 .get()
                 .target()?;
-            repo.graph_ahead_behind(branch_oid, base_oid)
+            context
+                .repo
+                .graph_ahead_behind(branch_oid, base_oid)
                 .ok()
                 .map(|(a, _)| a)
         })
         .unwrap_or(0);
 
-    let is_main_wt = worktree_path.as_deref() == main_workdir;
+    let is_main_wt = worktree_path.as_deref() == context.main_workdir;
     BranchCardDto {
         name,
         is_main_worktree: is_main_wt,
@@ -168,8 +223,9 @@ fn build_unmatched_worktree_card(
     wt_branch_name: &str,
     wt_path: &str,
     main_workdir: Option<&str>,
+    dirty_counts: &mut DirtyCountSnapshot,
 ) -> BranchCardDto {
-    let dirty_count = get_dirty_count_for_path(Path::new(wt_path)) as usize;
+    let dirty_count = dirty_counts.dirty_count_for_path(wt_path);
     let is_main_wt = main_workdir == Some(wt_path);
     BranchCardDto {
         name: wt_branch_name.to_string(),
@@ -188,7 +244,29 @@ pub(crate) fn list_branches_with_status(
     repo_path: &str,
 ) -> Result<Vec<BranchCardDto>, RepositoryError> {
     let repo = client::open(repo_path)?;
-    let default_branch = detect_default_branch(&repo);
+    list_branches_with_status_for_repo(&repo, DirtyCountSnapshot::empty())
+}
+
+pub(crate) fn list_branches_with_status_for_scan(
+    repo_path: &str,
+    current_dirty_count: usize,
+) -> Result<Vec<BranchCardDto>, RepositoryError> {
+    let repo = client::open(repo_path)?;
+    let current_workdir = repo
+        .workdir()
+        .and_then(|path| path.to_str())
+        .map(normalize_worktree_path);
+    list_branches_with_status_for_repo(
+        &repo,
+        DirtyCountSnapshot::with_current(current_workdir.as_deref(), current_dirty_count),
+    )
+}
+
+fn list_branches_with_status_for_repo(
+    repo: &Repository,
+    mut dirty_counts: DirtyCountSnapshot,
+) -> Result<Vec<BranchCardDto>, RepositoryError> {
+    let default_branch = detect_default_branch(repo);
 
     let default_oid = default_branch.as_ref().and_then(|name| {
         repo.find_branch(name, BranchType::Local)
@@ -197,11 +275,18 @@ pub(crate) fn list_branches_with_status(
             .target()
     });
 
-    let (wt_map, main_workdir) = build_worktree_map(&repo);
+    let (wt_map, main_workdir) = build_worktree_map(repo);
 
     let local_branches = repo.branches(Some(BranchType::Local))?;
     let config = repo.config().ok();
-    let base_target_oid = resolve_base_target_oid(&repo, config.as_ref(), default_oid);
+    let base_target_oid = resolve_base_target_oid(repo, config.as_ref(), default_oid);
+    let context = BranchCardBuildContext {
+        repo,
+        wt_map: &wt_map,
+        config: config.as_ref(),
+        base_target_oid,
+        main_workdir: main_workdir.as_deref(),
+    };
 
     let mut cards = Vec::new();
     let mut matched_wt_keys: HashSet<String> = HashSet::new();
@@ -217,13 +302,10 @@ pub(crate) fn list_branches_with_status(
         }
 
         cards.push(build_branch_card(
-            &repo,
             &branch,
             name,
-            &wt_map,
-            config.as_ref(),
-            base_target_oid,
-            main_workdir.as_deref(),
+            &context,
+            &mut dirty_counts,
         ));
     }
 
@@ -237,6 +319,7 @@ pub(crate) fn list_branches_with_status(
             wt_branch_name,
             wt_path,
             main_workdir.as_deref(),
+            &mut dirty_counts,
         ));
     }
 
@@ -249,6 +332,14 @@ pub struct BranchCardGateway;
 impl BranchCardQuery for BranchCardGateway {
     fn list_branch_cards(&self, repo_path: &str) -> Result<Vec<BranchCardDto>, RepositoryError> {
         list_branches_with_status(repo_path)
+    }
+
+    fn list_branch_cards_for_scan(
+        &self,
+        repo_path: &str,
+        current_dirty_count: usize,
+    ) -> Result<Vec<BranchCardDto>, RepositoryError> {
+        list_branches_with_status_for_scan(repo_path, current_dirty_count)
     }
 }
 
@@ -295,6 +386,14 @@ mod branch_card_gateway_tests {
         p.to_str().unwrap().to_string()
     }
 
+    fn reset_dirty_scan_count() {
+        DIRTY_WORKTREE_SCAN_COUNT.with(|count| count.set(0));
+    }
+
+    fn dirty_scan_count() -> usize {
+        DIRTY_WORKTREE_SCAN_COUNT.with(|count| count.get())
+    }
+
     #[test]
     fn test_ブランチカード一覧_既定を含む() {
         let (dir, repo) = create_test_repo();
@@ -337,6 +436,25 @@ mod branch_card_gateway_tests {
         let feat_card = cards.iter().find(|c| c.name == "feat-wt").unwrap();
         assert!(feat_card.worktree_path.is_some());
         assert_eq!(feat_card.dirty_count, 1);
+    }
+
+    #[test]
+    fn list_branches_for_scan_reuses_current_dirty_and_scans_each_linked_worktree_once() {
+        let (_parent, repo_dir, repo) = create_test_repo_with_parent();
+        create_initial_commit(&repo);
+
+        fs::write(repo_dir.join("main-dirty.txt"), "dirty").unwrap();
+        let wt_path = create_worktree_helper(&repo, _parent.path(), "wt-feat", "feat-wt");
+        fs::write(wt_path.join("linked-dirty.txt"), "dirty").unwrap();
+
+        reset_dirty_scan_count();
+        let cards = list_branches_with_status_for_scan(repo_dir.to_str().unwrap(), 1).unwrap();
+
+        let main_card = cards.iter().find(|card| card.is_main_worktree).unwrap();
+        let linked_card = cards.iter().find(|card| card.name == "feat-wt").unwrap();
+        assert_eq!(main_card.dirty_count, 1);
+        assert_eq!(linked_card.dirty_count, 1);
+        assert_eq!(dirty_scan_count(), 1);
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/repository/mod.rs
+++ b/src-tauri/src/adaptor/gateway/repository/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod git_config;
 pub(crate) mod log;
 pub(crate) mod notify;
 pub(crate) mod repo_paths;
+pub(crate) mod state;
 pub(crate) mod status;
 pub(crate) mod util;
+pub(crate) mod watch;
 pub(crate) mod worktree;

--- a/src-tauri/src/adaptor/gateway/repository/state.rs
+++ b/src-tauri/src/adaptor/gateway/repository/state.rs
@@ -1,0 +1,492 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use notify_debouncer_mini::notify::RecursiveMode;
+use notify_debouncer_mini::{new_debouncer, DebouncedEvent};
+use tauri::{Emitter, Runtime};
+
+use crate::protocol::{BranchCardMsg, BranchListSync, WsMessage};
+use crate::usecase::repository_state::runtime::{
+    RepositoryStateInvalidationReceiver, RepositoryStateInvalidationSender,
+    RepositoryStateWorkerFuture, RepositoryStateWorkerRuntime, WorktreePathNormalizer,
+};
+use crate::usecase::repository_state::scanner::RepositoryScanner;
+use crate::usecase::repository_state::snapshot::RepositorySnapshotChangedEvent;
+use crate::usecase::repository_state::snapshot::RepositorySnapshotParts;
+use crate::usecase::repository_state::worker::InvalidateReason;
+use crate::usecase::repository_state::worktree::{
+    RepositoryStateNotifier, RepositoryStateWatchSession, RepositoryStateWatcher,
+    SnapshotNotification, SnapshotNotificationPhase, WorktreeState,
+};
+use crate::usecase::repository_state::RepositoryStateError;
+use crate::usecase::repository_usecase::RepositoryUsecase;
+use crate::ws_bridge::WsBroadcaster;
+
+use super::watch::{
+    canonicalize_event_path, classify_git_dir_events, generate_watcher_id,
+    resolve_file_watch_paths, resolve_git_watch_paths, FileChangeEvent, GitStatusChangedEvent,
+};
+
+type RecommendedDebouncer =
+    notify_debouncer_mini::Debouncer<notify_debouncer_mini::notify::RecommendedWatcher>;
+
+struct RepositoryStateWatcherHandles {
+    _file_debouncer: RecommendedDebouncer,
+    _git_debouncer: RecommendedDebouncer,
+}
+
+pub struct NotifyRepositoryStateWatcher {
+    repository: Arc<RepositoryUsecase>,
+}
+
+impl NotifyRepositoryStateWatcher {
+    pub fn new(repository: Arc<RepositoryUsecase>) -> Self {
+        Self { repository }
+    }
+}
+
+impl RepositoryStateWatcher for NotifyRepositoryStateWatcher {
+    fn next_watcher_id(&self) -> u64 {
+        generate_watcher_id()
+    }
+
+    fn start_watchers(
+        &self,
+        state: Arc<WorktreeState>,
+    ) -> Result<Box<dyn RepositoryStateWatchSession>, RepositoryStateError> {
+        let file_debouncer = start_file_watcher(state.clone(), &self.repository)?;
+        let git_debouncer = start_git_watcher(state, &self.repository)?;
+        Ok(Box::new(RepositoryStateWatcherHandles {
+            _file_debouncer: file_debouncer,
+            _git_debouncer: git_debouncer,
+        }))
+    }
+}
+
+fn start_file_watcher(
+    state: Arc<WorktreeState>,
+    repository: &RepositoryUsecase,
+) -> Result<RecommendedDebouncer, RepositoryStateError> {
+    let watch_paths = resolve_file_watch_paths(repository, state.worktree_path());
+    let debouncer = new_debouncer(
+        Duration::from_millis(100),
+        move |res: Result<
+            Vec<notify_debouncer_mini::DebouncedEvent>,
+            notify_debouncer_mini::notify::Error,
+        >| match res {
+            Ok(events) => handle_file_events(state.as_ref(), events),
+            Err(err) => {
+                log::warn!("file watcher error for {}: {err:?}", state.worktree_path());
+            }
+        },
+    )
+    .map_err(|err| RepositoryStateError::Watcher(format!("Failed to create debouncer: {err}")))?;
+
+    let mut debouncer = debouncer;
+    for watch_path in watch_paths {
+        debouncer
+            .watcher()
+            .watch(&watch_path, RecursiveMode::Recursive)
+            .map_err(|err| {
+                RepositoryStateError::Watcher(format!(
+                    "Failed to watch path {}: {err}",
+                    watch_path.display()
+                ))
+            })?;
+    }
+    Ok(debouncer)
+}
+
+fn start_git_watcher(
+    state: Arc<WorktreeState>,
+    repository: &RepositoryUsecase,
+) -> Result<RecommendedDebouncer, RepositoryStateError> {
+    let paths = resolve_git_watch_paths(repository, state.worktree_path())
+        .map_err(RepositoryStateError::Watcher)?;
+    log::debug!("starting git watcher for main repo {}", paths.main_repo);
+    let debouncer = new_debouncer(
+        Duration::from_millis(100),
+        move |res: Result<
+            Vec<notify_debouncer_mini::DebouncedEvent>,
+            notify_debouncer_mini::notify::Error,
+        >| {
+            let events = match res {
+                Ok(events) => events,
+                Err(err) => {
+                    log::warn!(
+                        "git dir watcher error for {}: {err:?}",
+                        state.worktree_path()
+                    );
+                    return;
+                }
+            };
+            handle_git_events(state.as_ref(), &events);
+        },
+    )
+    .map_err(|err| RepositoryStateError::Watcher(format!("Failed to create debouncer: {err}")))?;
+
+    let mut debouncer = debouncer;
+    if paths.refs_heads.exists() {
+        debouncer
+            .watcher()
+            .watch(&paths.refs_heads, RecursiveMode::Recursive)
+            .map_err(|err| {
+                RepositoryStateError::Watcher(format!("Failed to watch refs/heads: {err}"))
+            })?;
+    }
+    if paths.head_file.exists() {
+        debouncer
+            .watcher()
+            .watch(&paths.head_file, RecursiveMode::NonRecursive)
+            .map_err(|err| RepositoryStateError::Watcher(format!("Failed to watch HEAD: {err}")))?;
+    }
+    if let Some(git_dir) = paths.index_file.parent() {
+        debouncer
+            .watcher()
+            .watch(git_dir, RecursiveMode::NonRecursive)
+            .map_err(|err| {
+                RepositoryStateError::Watcher(format!("Failed to watch .git dir: {err}"))
+            })?;
+    }
+    if paths.worktrees_dir.exists() {
+        debouncer
+            .watcher()
+            .watch(&paths.worktrees_dir, RecursiveMode::Recursive)
+            .map_err(|err| {
+                RepositoryStateError::Watcher(format!("Failed to watch worktrees: {err}"))
+            })?;
+    }
+    Ok(debouncer)
+}
+
+fn handle_file_events(state: &WorktreeState, events: Vec<DebouncedEvent>) {
+    for event in events {
+        let event_path = canonicalize_event_path(&event.path)
+            .unwrap_or_else(|| event.path.to_string_lossy().to_string());
+        state.invalidate(InvalidateReason::file(Some(event_path)));
+    }
+}
+
+fn handle_git_events(state: &WorktreeState, events: &[DebouncedEvent]) {
+    let (branch_change, index_change) = classify_git_dir_events(events);
+    if branch_change || index_change {
+        state.invalidate(InvalidateReason::git(branch_change));
+    }
+}
+
+pub struct TokioRepositoryStateWorkerRuntime;
+
+struct TokioInvalidationSender(tokio::sync::mpsc::UnboundedSender<InvalidateReason>);
+
+impl RepositoryStateInvalidationSender for TokioInvalidationSender {
+    fn send(&self, reason: InvalidateReason) -> Result<(), ()> {
+        self.0.send(reason).map_err(|_| ())
+    }
+}
+
+struct TokioInvalidationReceiver(tokio::sync::mpsc::UnboundedReceiver<InvalidateReason>);
+
+#[async_trait::async_trait]
+impl RepositoryStateInvalidationReceiver for TokioInvalidationReceiver {
+    async fn recv(&mut self) -> Option<InvalidateReason> {
+        self.0.recv().await
+    }
+
+    fn try_recv(&mut self) -> Option<InvalidateReason> {
+        self.0.try_recv().ok()
+    }
+}
+
+#[async_trait::async_trait]
+impl RepositoryStateWorkerRuntime for TokioRepositoryStateWorkerRuntime {
+    fn invalidation_channel(
+        &self,
+    ) -> (
+        Box<dyn RepositoryStateInvalidationSender>,
+        Box<dyn RepositoryStateInvalidationReceiver>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (
+            Box::new(TokioInvalidationSender(tx)),
+            Box::new(TokioInvalidationReceiver(rx)),
+        )
+    }
+
+    fn spawn_worker(&self, future: RepositoryStateWorkerFuture) {
+        tokio::spawn(future);
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        tokio::time::sleep(duration).await;
+    }
+
+    async fn scan(
+        &self,
+        scanner: Arc<dyn RepositoryScanner>,
+        repo_path: String,
+    ) -> Result<RepositorySnapshotParts, RepositoryStateError> {
+        let scan_repo_path = repo_path.clone();
+        tokio::task::spawn_blocking(move || scanner.scan(&scan_repo_path))
+            .await
+            .map_err(|err| {
+                RepositoryStateError::Watcher(format!(
+                    "repository snapshot worker failed for {repo_path}: {err}"
+                ))
+            })?
+    }
+}
+
+pub struct FsWorktreePathNormalizer;
+
+impl WorktreePathNormalizer for FsWorktreePathNormalizer {
+    fn normalize(&self, worktree_path: &str) -> Result<PathBuf, RepositoryStateError> {
+        let path = Path::new(worktree_path);
+        path.canonicalize().map_err(|err| {
+            RepositoryStateError::Watcher(format!(
+                "Failed to canonicalize worktree path {}: {err}",
+                path.display()
+            ))
+        })
+    }
+}
+
+pub struct TauriRepositoryStateNotifier<R: Runtime> {
+    app: tauri::AppHandle<R>,
+    ws: Arc<WsBroadcaster>,
+}
+
+impl<R: Runtime> TauriRepositoryStateNotifier<R> {
+    pub fn new(app: tauri::AppHandle<R>, ws: Arc<WsBroadcaster>) -> Self {
+        Self { app, ws }
+    }
+}
+
+impl<R: Runtime> RepositoryStateNotifier for TauriRepositoryStateNotifier<R> {
+    fn snapshot_changed(&self, notification: SnapshotNotification) {
+        for worktree_path in &notification.worktree_paths {
+            let event = RepositorySnapshotChangedEvent::from_snapshot(
+                worktree_path.clone(),
+                &notification.snapshot,
+            );
+            let _ = self.app.emit("repository-snapshot-changed", event);
+        }
+
+        if notification.phase == SnapshotNotificationPhase::RefreshStarted {
+            return;
+        }
+
+        for worktree_path in &notification.worktree_paths {
+            let _ = self.app.emit(
+                "git-status-changed",
+                GitStatusChangedEvent {
+                    repo_path: worktree_path.clone(),
+                },
+            );
+        }
+
+        let _ = self.app.emit("branch-list-sync", ());
+        let branch_msgs: Vec<BranchCardMsg> = notification
+            .snapshot
+            .branch_cards
+            .iter()
+            .cloned()
+            .map(BranchCardMsg::from)
+            .collect();
+        self.ws.try_send(WsMessage::BranchListSync(BranchListSync {
+            branches: branch_msgs,
+        }));
+
+        if notification.reason.file_change {
+            let path = notification.reason.path.unwrap_or_else(|| {
+                notification
+                    .worktree_paths
+                    .first()
+                    .cloned()
+                    .unwrap_or_default()
+            });
+            for watcher_id in notification.file_watcher_ids {
+                let _ = self.app.emit(
+                    "file-change",
+                    FileChangeEvent {
+                        watcher_id,
+                        path: path.clone(),
+                        kind: "change".to_string(),
+                    },
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::usecase::repository_dto::{BranchCardDto, FileStatusDto};
+    use crate::usecase::repository_state::runtime::{
+        RepositoryStateInvalidationReceiver, RepositoryStateInvalidationSender,
+    };
+    use crate::usecase::repository_state::snapshot::RepositorySnapshotParts;
+    use crate::usecase::repository_state::worktree::RepositoryStateNotifier;
+    use notify_debouncer_mini::DebouncedEventKind;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct InertSender;
+
+    impl RepositoryStateInvalidationSender for InertSender {
+        fn send(&self, _reason: InvalidateReason) -> Result<(), ()> {
+            Ok(())
+        }
+    }
+
+    struct InertReceiver;
+
+    #[async_trait::async_trait]
+    impl RepositoryStateInvalidationReceiver for InertReceiver {
+        async fn recv(&mut self) -> Option<InvalidateReason> {
+            None
+        }
+
+        fn try_recv(&mut self) -> Option<InvalidateReason> {
+            None
+        }
+    }
+
+    struct InertRuntime;
+
+    #[async_trait::async_trait]
+    impl RepositoryStateWorkerRuntime for InertRuntime {
+        fn invalidation_channel(
+            &self,
+        ) -> (
+            Box<dyn RepositoryStateInvalidationSender>,
+            Box<dyn RepositoryStateInvalidationReceiver>,
+        ) {
+            (Box::new(InertSender), Box::new(InertReceiver))
+        }
+
+        fn spawn_worker(&self, _future: RepositoryStateWorkerFuture) {}
+
+        async fn sleep(&self, _duration: Duration) {}
+
+        async fn scan(
+            &self,
+            _scanner: Arc<dyn RepositoryScanner>,
+            _repo_path: String,
+        ) -> Result<RepositorySnapshotParts, RepositoryStateError> {
+            Err(RepositoryStateError::Watcher(
+                "inert runtime does not scan".to_string(),
+            ))
+        }
+    }
+
+    struct EmptyScanner;
+
+    impl RepositoryScanner for EmptyScanner {
+        fn scan(&self, _repo_path: &str) -> Result<RepositorySnapshotParts, RepositoryStateError> {
+            Ok(RepositorySnapshotParts {
+                status: Vec::new(),
+                diff_stats: Vec::new(),
+                branch_cards: Vec::new(),
+                diff_file_tree: Vec::new(),
+                staged_diff_file_tree: Vec::new(),
+                changes_diff_file_tree: Vec::new(),
+                limited: false,
+            })
+        }
+
+        fn status_with_ignored(
+            &self,
+            _repo_path: &str,
+        ) -> Result<Vec<FileStatusDto>, RepositoryStateError> {
+            Ok(Vec::new())
+        }
+
+        fn prune_stale_branch_bases(
+            &self,
+            _repo_path: &str,
+            _existing_branches: &[String],
+        ) -> Result<(), RepositoryStateError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingNotifier {
+        refresh_started: AtomicUsize,
+        snapshot_committed: AtomicUsize,
+    }
+
+    impl RepositoryStateNotifier for CountingNotifier {
+        fn snapshot_changed(&self, notification: SnapshotNotification) {
+            match notification.phase {
+                SnapshotNotificationPhase::RefreshStarted => {
+                    self.refresh_started.fetch_add(1, Ordering::SeqCst);
+                }
+                SnapshotNotificationPhase::SnapshotCommitted => {
+                    self.snapshot_committed.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }
+    }
+
+    fn event(path: &std::path::Path) -> DebouncedEvent {
+        DebouncedEvent {
+            path: path.to_path_buf(),
+            kind: DebouncedEventKind::Any,
+        }
+    }
+
+    fn state_with_notifier(notifier: Arc<CountingNotifier>) -> Arc<WorktreeState> {
+        WorktreeState::new(
+            "/repo".to_string(),
+            Arc::new(EmptyScanner),
+            notifier,
+            Arc::new(InertRuntime),
+            Duration::ZERO,
+        )
+    }
+
+    #[test]
+    fn watcher_callbacks_only_invalidate_until_worker_commit() {
+        let notifier = Arc::new(CountingNotifier::default());
+        let state = state_with_notifier(notifier.clone());
+        let dir = tempfile::TempDir::new().unwrap();
+        let file_path = dir.path().join("file.txt");
+        std::fs::write(&file_path, "content").unwrap();
+
+        handle_file_events(state.as_ref(), vec![event(&file_path)]);
+        handle_git_events(state.as_ref(), &[event(&PathBuf::from("/repo/.git/HEAD"))]);
+        handle_git_events(state.as_ref(), &[event(&PathBuf::from("/repo/.git/index"))]);
+
+        assert_eq!(state.requested_generation(), 3);
+        assert_eq!(notifier.refresh_started.load(Ordering::SeqCst), 0);
+        assert_eq!(notifier.snapshot_committed.load(Ordering::SeqCst), 0);
+
+        let snapshot = state.commit_snapshot(
+            RepositorySnapshotParts {
+                status: Vec::new(),
+                diff_stats: Vec::new(),
+                branch_cards: vec![BranchCardDto {
+                    name: "main".to_string(),
+                    is_main_worktree: true,
+                    worktree_path: Some("/repo".to_string()),
+                    dirty_count: 0,
+                    is_merged: false,
+                    ahead: 0,
+                    behind: 0,
+                    has_upstream: false,
+                    base_ahead: 0,
+                }],
+                diff_file_tree: Vec::new(),
+                staged_diff_file_tree: Vec::new(),
+                changes_diff_file_tree: Vec::new(),
+                limited: false,
+            },
+            state.requested_generation(),
+        );
+        state.notify_snapshot_changed(snapshot, InvalidateReason::git(true));
+
+        assert_eq!(notifier.snapshot_committed.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src-tauri/src/adaptor/gateway/repository/status.rs
+++ b/src-tauri/src/adaptor/gateway/repository/status.rs
@@ -1,9 +1,26 @@
 //! status 責務の gateway 実装。git2 による作業ツリー状態取得を封じ込める。
 
-use crate::domain::repository::{FileDiffStat, FileStatus, RepositoryError, StatusRepository};
+use crate::domain::repository::{
+    FileDiffStat, FileStatus, RepositoryError, RepositoryStatusScan, StatusRepository,
+};
 use crate::infrastructure::git::client;
-use git2::{ErrorCode, StatusOptions};
+use git2::{ErrorCode, Repository, StatusOptions};
 use std::collections::HashMap;
+
+#[cfg(test)]
+thread_local! {
+    static STATUS_WALK_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_status_walk_count_for_tests() {
+    STATUS_WALK_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn status_walk_count_for_tests() -> usize {
+    STATUS_WALK_COUNT.with(|count| count.get())
+}
 
 fn index_status_from_flags(status: git2::Status) -> &'static str {
     if status.contains(git2::Status::CONFLICTED) {
@@ -43,10 +60,18 @@ fn worktree_status_from_flags(status: git2::Status) -> &'static str {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn get_git_status(repo_path: &str) -> Result<Vec<FileStatus>, RepositoryError> {
+    get_git_status_with_options(repo_path, false)
+}
+
+pub(crate) fn get_git_status_with_options(
+    repo_path: &str,
+    include_ignored: bool,
+) -> Result<Vec<FileStatus>, RepositoryError> {
     let result = crate::other::telemetry::measure_result(
         crate::other::telemetry::HotPath::GitStatusScan,
-        || get_git_status_inner(repo_path),
+        || get_git_status_inner(repo_path, include_ignored),
     );
     if result.is_ok() {
         crate::other::telemetry::record_first_repo_snapshot_ready();
@@ -54,14 +79,26 @@ pub(crate) fn get_git_status(repo_path: &str) -> Result<Vec<FileStatus>, Reposit
     result
 }
 
-fn get_git_status_inner(repo_path: &str) -> Result<Vec<FileStatus>, RepositoryError> {
+fn get_git_status_inner(
+    repo_path: &str,
+    include_ignored: bool,
+) -> Result<Vec<FileStatus>, RepositoryError> {
     let repo = client::open(repo_path)?;
+    collect_git_status(&repo, include_ignored)
+}
 
+fn collect_git_status(
+    repo: &Repository,
+    include_ignored: bool,
+) -> Result<Vec<FileStatus>, RepositoryError> {
     let mut opts = StatusOptions::new();
-    opts.include_untracked(true)
-        .recurse_untracked_dirs(true)
-        .include_ignored(true);
+    opts.include_untracked(true).recurse_untracked_dirs(true);
+    if include_ignored {
+        opts.include_ignored(true);
+    }
 
+    #[cfg(test)]
+    STATUS_WALK_COUNT.with(|count| count.set(count.get() + 1));
     let statuses = repo.statuses(Some(&mut opts))?;
 
     let result: Vec<FileStatus> = statuses
@@ -133,15 +170,20 @@ fn collect_diff_stats(diff: &git2::Diff) -> HashMap<String, (u32, u32)> {
     map
 }
 
+#[cfg(test)]
 pub(crate) fn get_status_diff_stats(repo_path: &str) -> Result<Vec<FileDiffStat>, RepositoryError> {
     crate::other::telemetry::measure_result(crate::other::telemetry::HotPath::DiffStats, || {
         get_status_diff_stats_inner(repo_path)
     })
 }
 
+#[cfg(test)]
 fn get_status_diff_stats_inner(repo_path: &str) -> Result<Vec<FileDiffStat>, RepositoryError> {
     let repo = client::open(repo_path)?;
+    collect_status_diff_stats(&repo)
+}
 
+fn collect_status_diff_stats(repo: &Repository) -> Result<Vec<FileDiffStat>, RepositoryError> {
     // HEAD tree (may not exist for unborn branch)
     let head_tree = match repo.head() {
         Ok(head) => Some(head.peel_to_tree()?),
@@ -189,15 +231,53 @@ fn get_status_diff_stats_inner(repo_path: &str) -> Result<Vec<FileDiffStat>, Rep
     Ok(result)
 }
 
+pub(crate) fn get_repository_status_scan(
+    repo_path: &str,
+) -> Result<RepositoryStatusScan, RepositoryError> {
+    let result = crate::other::telemetry::measure_result(
+        crate::other::telemetry::HotPath::GitStatusScan,
+        || get_repository_status_scan_inner(repo_path),
+    );
+    if result.is_ok() {
+        crate::other::telemetry::record_first_repo_snapshot_ready();
+    }
+    result
+}
+
+fn get_repository_status_scan_inner(
+    repo_path: &str,
+) -> Result<RepositoryStatusScan, RepositoryError> {
+    let repo = client::open(repo_path)?;
+    let status = collect_git_status(&repo, false)?;
+    let dirty_count = status
+        .iter()
+        .filter(|entry| entry.worktree_status != "ignored")
+        .count();
+    let diff_stats = crate::other::telemetry::measure_result(
+        crate::other::telemetry::HotPath::DiffStats,
+        || collect_status_diff_stats(&repo),
+    )?;
+
+    Ok(RepositoryStatusScan {
+        status,
+        diff_stats,
+        dirty_count,
+    })
+}
+
 /// `StatusRepository` の git2 実装。
 pub struct StatusGateway;
 
 impl StatusRepository for StatusGateway {
-    fn status(&self, repo_path: &str) -> Result<Vec<FileStatus>, RepositoryError> {
-        get_git_status(repo_path)
+    fn status_with_options(
+        &self,
+        repo_path: &str,
+        include_ignored: bool,
+    ) -> Result<Vec<FileStatus>, RepositoryError> {
+        get_git_status_with_options(repo_path, include_ignored)
     }
-    fn diff_stats(&self, repo_path: &str) -> Result<Vec<FileDiffStat>, RepositoryError> {
-        get_status_diff_stats(repo_path)
+    fn status_scan(&self, repo_path: &str) -> Result<RepositoryStatusScan, RepositoryError> {
+        get_repository_status_scan(repo_path)
     }
 }
 
@@ -294,7 +374,7 @@ mod status_gateway_tests {
     }
 
     #[test]
-    fn test_状態取得_無視ファイル() {
+    fn test_状態取得_無視ファイルはdefaultで除外する() {
         let (dir, repo) = create_test_repo();
         create_initial_commit(&repo);
 
@@ -315,6 +395,36 @@ mod status_gateway_tests {
 
         let result = get_git_status(dir.path().to_str().unwrap()).unwrap();
 
+        assert!(
+            result.iter().all(|e| e.worktree_status != "ignored"),
+            "ignored entries should not appear in default status"
+        );
+        assert!(result.iter().all(|e| e.path != "ignored.txt"));
+        assert!(result.iter().all(|e| e.path != "build"));
+    }
+
+    #[test]
+    fn test_状態取得_無視ファイルはopt_inで含める() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+
+        fs::write(dir.path().join(".gitignore"), "ignored.txt\nbuild/\n").unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new(".gitignore")).unwrap();
+        index.write().unwrap();
+        let sig = git2::Signature::now("Test User", "test@example.com").unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "add gitignore", &tree, &[&parent])
+            .unwrap();
+
+        fs::write(dir.path().join("ignored.txt"), "should be ignored").unwrap();
+        fs::create_dir(dir.path().join("build")).unwrap();
+        fs::write(dir.path().join("build").join("output.js"), "built").unwrap();
+
+        let result = get_git_status_with_options(dir.path().to_str().unwrap(), true).unwrap();
+
         let ignored_file = result.iter().find(|e| e.path == "ignored.txt");
         assert!(
             ignored_file.is_some(),
@@ -326,6 +436,56 @@ mod status_gateway_tests {
         let ignored_dir = result.iter().find(|e| e.path == "build");
         assert!(ignored_dir.is_some(), "build dir should appear in status");
         assert_eq!(ignored_dir.unwrap().worktree_status, "ignored");
+    }
+
+    #[test]
+    fn status_gateway_status_with_options_include_ignored_returns_ignored_entries() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+
+        fs::write(dir.path().join(".gitignore"), "ignored.txt\n").unwrap();
+        fs::write(dir.path().join("ignored.txt"), "should be ignored").unwrap();
+
+        let gateway = StatusGateway;
+        let result = <StatusGateway as StatusRepository>::status_with_options(
+            &gateway,
+            dir.path().to_str().unwrap(),
+            true,
+        )
+        .unwrap();
+
+        assert!(result
+            .iter()
+            .any(|entry| entry.path == "ignored.txt" && entry.worktree_status == "ignored"));
+    }
+
+    #[test]
+    fn repository_status_scan_matches_legacy_status_and_diff_stats_with_one_status_walk() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        add_and_commit(&repo, "staged.txt", "before\n", "add staged");
+        add_and_commit(&repo, "changed.txt", "before\n", "add changed");
+
+        fs::write(dir.path().join("staged.txt"), "before\nafter\n").unwrap();
+        {
+            let mut index = repo.index().unwrap();
+            index.add_path(Path::new("staged.txt")).unwrap();
+            index.write().unwrap();
+        }
+        fs::write(dir.path().join("changed.txt"), "changed\n").unwrap();
+        fs::write(dir.path().join("untracked.txt"), "new\n").unwrap();
+
+        let repo_path = dir.path().to_str().unwrap();
+        let expected_status = get_git_status(repo_path).unwrap();
+        let expected_diff_stats = get_status_diff_stats(repo_path).unwrap();
+
+        reset_status_walk_count_for_tests();
+        let scan = get_repository_status_scan(repo_path).unwrap();
+
+        assert_eq!(scan.status, expected_status);
+        assert_eq!(scan.diff_stats, expected_diff_stats);
+        assert_eq!(scan.dirty_count, expected_status.len());
+        assert_eq!(status_walk_count_for_tests(), 1);
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/repository/watch.rs
+++ b/src-tauri/src/adaptor/gateway/repository/watch.rs
@@ -1,0 +1,292 @@
+use notify_debouncer_mini::DebouncedEvent;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::usecase::repository_usecase::RepositoryUsecase;
+
+pub(crate) struct GitWatchPaths {
+    pub(crate) main_repo: String,
+    pub(crate) refs_heads: PathBuf,
+    pub(crate) head_file: PathBuf,
+    pub(crate) index_file: PathBuf,
+    pub(crate) worktrees_dir: PathBuf,
+}
+
+pub(crate) fn resolve_git_watch_paths(
+    usecase: &RepositoryUsecase,
+    repo_path: &str,
+) -> Result<GitWatchPaths, String> {
+    let main_repo = usecase
+        .get_main_repo_path(repo_path)
+        .map_err(|e| format!("Failed to resolve main repo: {e}"))?;
+    let git_dir = git2::Repository::open(&main_repo)
+        .map_err(|e| format!("Failed to open repo: {e}"))?
+        .path()
+        .to_path_buf();
+
+    Ok(GitWatchPaths {
+        main_repo,
+        refs_heads: git_dir.join("refs").join("heads"),
+        head_file: git_dir.join("HEAD"),
+        index_file: git_dir.join("index"),
+        worktrees_dir: git_dir.join("worktrees"),
+    })
+}
+
+pub(crate) fn resolve_file_watch_paths(
+    _usecase: &RepositoryUsecase,
+    repo_path: &str,
+) -> Vec<PathBuf> {
+    let path = PathBuf::from(repo_path);
+    vec![path.canonicalize().unwrap_or(path)]
+}
+
+pub(crate) fn canonicalize_event_path(path: &Path) -> Option<String> {
+    if let Ok(canonical) = path.canonicalize() {
+        return Some(canonical.to_string_lossy().to_string());
+    }
+    let parent = path.parent()?;
+    let file_name = path.file_name()?;
+    let canonical_parent = parent.canonicalize().ok()?;
+    Some(
+        canonical_parent
+            .join(file_name)
+            .to_string_lossy()
+            .to_string(),
+    )
+}
+
+static WATCHER_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) fn generate_watcher_id() -> u64 {
+    WATCHER_ID_COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct FileChangeEvent {
+    pub watcher_id: u64,
+    pub path: String,
+    pub kind: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GitStatusChangedEvent {
+    pub repo_path: String,
+}
+
+pub(crate) fn classify_git_dir_events(events: &[DebouncedEvent]) -> (bool, bool) {
+    let has_branch_change = events.iter().any(|e| {
+        let p = e.path.to_string_lossy().replace('\\', "/");
+        p.contains("/refs/heads/") || e.path.file_name().is_some_and(|n| n == "HEAD")
+    });
+    let has_index_change = events.iter().any(|e| {
+        let file_name = e
+            .path
+            .file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_default();
+        file_name == "index" || file_name == "index.lock" || file_name == "COMMIT_EDITMSG"
+    });
+    (has_branch_change, has_index_change)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::test_helpers::*;
+    use notify_debouncer_mini::DebouncedEventKind;
+
+    fn test_usecase() -> RepositoryUsecase {
+        crate::adaptor::controller::wiring::build_repository_usecase()
+    }
+
+    #[test]
+    fn test_resolve_git_watch_paths_main_repo() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+
+        let repo_path = dir.path().to_str().unwrap();
+        let paths = resolve_git_watch_paths(&test_usecase(), repo_path).unwrap();
+
+        assert_eq!(
+            PathBuf::from(&paths.main_repo).canonicalize().unwrap(),
+            dir.path().canonicalize().unwrap()
+        );
+        assert!(paths.refs_heads.ends_with("refs/heads"));
+        assert!(paths.head_file.ends_with("HEAD"));
+        assert!(paths.worktrees_dir.ends_with("worktrees"));
+        assert!(paths.refs_heads.exists());
+        assert!(paths.head_file.exists());
+    }
+
+    fn create_worktree(repo: &git2::Repository) -> (String, PathBuf, tempfile::TempDir) {
+        static WT_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let id = WT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let wt_name = format!("wt-test-{}", id);
+        let wt_dir = tempfile::TempDir::new().unwrap();
+        let wt_path = wt_dir.path().join(&wt_name);
+        repo.worktree(&wt_name, &wt_path, None).unwrap();
+        (wt_name, wt_path, wt_dir)
+    }
+
+    #[test]
+    fn test_resolve_git_watch_paths_with_worktree() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        add_and_commit(&repo, "file.txt", "content", "add file");
+
+        let (wt_name, _wt_path, _wt_dir) = create_worktree(&repo);
+
+        let repo_path = dir.path().to_str().unwrap();
+        let paths = resolve_git_watch_paths(&test_usecase(), repo_path).unwrap();
+
+        assert!(paths.worktrees_dir.exists());
+        assert!(paths.worktrees_dir.join(&wt_name).exists());
+    }
+
+    #[test]
+    fn test_resolve_git_watch_paths_from_worktree() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        add_and_commit(&repo, "file.txt", "content", "add file");
+
+        let (_wt_name, wt_path, _wt_dir) = create_worktree(&repo);
+
+        let main_repo_path = dir.path().to_str().unwrap();
+        let paths_from_wt =
+            resolve_git_watch_paths(&test_usecase(), wt_path.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            PathBuf::from(&paths_from_wt.main_repo)
+                .canonicalize()
+                .unwrap(),
+            PathBuf::from(main_repo_path).canonicalize().unwrap()
+        );
+        assert!(paths_from_wt.refs_heads.exists());
+    }
+
+    #[test]
+    fn test_resolve_git_watch_paths_invalid() {
+        let result = resolve_git_watch_paths(&test_usecase(), "/nonexistent/path");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_file_watch_paths_uses_only_current_worktree() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        add_and_commit(&repo, "file.txt", "content", "add file");
+        let (_wt_name, wt_path, _wt_dir) = create_worktree(&repo);
+
+        let paths = resolve_file_watch_paths(&test_usecase(), dir.path().to_str().unwrap());
+
+        assert_eq!(paths, vec![dir.path().canonicalize().unwrap()]);
+        assert!(!paths.contains(&wt_path.canonicalize().unwrap()));
+    }
+
+    fn make_event(path: &str) -> DebouncedEvent {
+        DebouncedEvent {
+            path: PathBuf::from(path),
+            kind: DebouncedEventKind::Any,
+        }
+    }
+
+    #[test]
+    fn classify_index_change() {
+        let events = vec![make_event("/repo/.git/index")];
+        let (branch, index) = classify_git_dir_events(&events);
+        assert!(!branch);
+        assert!(index);
+    }
+
+    #[test]
+    fn classify_index_lock() {
+        let events = vec![make_event("/repo/.git/index.lock")];
+        let (branch, index) = classify_git_dir_events(&events);
+        assert!(!branch);
+        assert!(index);
+    }
+
+    #[test]
+    fn classify_head_change() {
+        let events = vec![make_event("/repo/.git/HEAD")];
+        let (branch, index) = classify_git_dir_events(&events);
+        assert!(branch);
+        assert!(!index);
+    }
+
+    #[test]
+    fn classify_refs_heads_change() {
+        let events = vec![make_event("/repo/.git/refs/heads/main")];
+        let (branch, index) = classify_git_dir_events(&events);
+        assert!(branch);
+        assert!(!index);
+    }
+
+    #[test]
+    fn classify_commit_editmsg() {
+        let events = vec![make_event("/repo/.git/COMMIT_EDITMSG")];
+        let (branch, index) = classify_git_dir_events(&events);
+        assert!(!branch);
+        assert!(index);
+    }
+
+    #[test]
+    fn classify_mixed_events() {
+        let events = vec![
+            make_event("/repo/.git/refs/heads/feature"),
+            make_event("/repo/.git/index"),
+        ];
+        let (branch, index) = classify_git_dir_events(&events);
+        assert!(branch);
+        assert!(index);
+    }
+
+    #[test]
+    fn classify_unrelated_event() {
+        let events = vec![make_event("/repo/.git/config")];
+        let (branch, index) = classify_git_dir_events(&events);
+        assert!(!branch);
+        assert!(!index);
+    }
+
+    #[test]
+    fn classify_worktree_index() {
+        let events = vec![make_event("/repo/.git/worktrees/feat/index")];
+        let (branch, index) = classify_git_dir_events(&events);
+        assert!(!branch);
+        assert!(index);
+    }
+
+    #[test]
+    fn canonicalize_existing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file_path = dir.path().join("test.txt");
+        std::fs::write(&file_path, "hello").unwrap();
+
+        let result = canonicalize_event_path(&file_path);
+        assert!(result.is_some());
+        let canonical = result.unwrap();
+        assert!(canonical.ends_with("test.txt"));
+        assert!(!canonical.contains(".."));
+    }
+
+    #[test]
+    fn canonicalize_deleted_file_falls_back_to_parent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file_path = dir.path().join("deleted.txt");
+
+        let result = canonicalize_event_path(&file_path);
+        assert!(result.is_some());
+        let canonical = result.unwrap();
+        assert!(canonical.ends_with("deleted.txt"));
+    }
+
+    #[test]
+    fn canonicalize_nonexistent_parent_returns_none() {
+        let path = PathBuf::from("/nonexistent/parent/file.txt");
+        let result = canonicalize_event_path(&path);
+        assert!(result.is_none());
+    }
+}

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -6051,6 +6051,20 @@ mod dispatch_boundary_tests {
                 repo_paths_notifier,
             ));
         let code_usecase = Arc::new(crate::adaptor::controller::wiring::build_code_usecase());
+        let repository_state = Arc::new(
+            crate::usecase::repository_state::RepositoryStateService::new(
+                repository_usecase.clone(),
+                code_usecase.clone(),
+                Arc::new(crate::usecase::repository_state::worktree::NoopRepositoryStateNotifier),
+                Arc::new(crate::usecase::repository_state::worktree::NoopRepositoryStateWatcher),
+                Arc::new(
+                    crate::usecase::repository_state::runtime::tests_support::TestRepositoryStateWorkerRuntime,
+                ),
+                Arc::new(
+                    crate::usecase::repository_state::runtime::tests_support::IdentityWorktreePathNormalizer,
+                ),
+            ),
+        );
         let workflow_usecase = Arc::new(
             crate::adaptor::controller::wiring::build_workflow_usecase(data_dir.clone()),
         );
@@ -6063,6 +6077,7 @@ mod dispatch_boundary_tests {
             .manage(registry)
             .manage(crate::adaptor::controller::state::AppState {
                 repository_usecase,
+                repository_state,
                 repo_paths_usecase,
                 code_usecase,
                 workflow_usecase,

--- a/src-tauri/src/domain/repository/entities/file_status.rs
+++ b/src-tauri/src/domain/repository/entities/file_status.rs
@@ -15,3 +15,11 @@ pub struct FileDiffStat {
     pub wt_additions: u32,
     pub wt_deletions: u32,
 }
+
+/// 1 scan サイクル内で同一 repository handle から導出した status 系 read model。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryStatusScan {
+    pub status: Vec<FileStatus>,
+    pub diff_stats: Vec<FileDiffStat>,
+    pub dirty_count: usize,
+}

--- a/src-tauri/src/domain/repository/entities/mod.rs
+++ b/src-tauri/src/domain/repository/entities/mod.rs
@@ -5,5 +5,5 @@ pub mod worktree;
 
 pub use branch::Branch;
 pub use commit::Commit;
-pub use file_status::{FileDiffStat, FileStatus};
+pub use file_status::{FileDiffStat, FileStatus, RepositoryStatusScan};
 pub use worktree::Worktree;

--- a/src-tauri/src/domain/repository/mod.rs
+++ b/src-tauri/src/domain/repository/mod.rs
@@ -6,7 +6,7 @@ pub mod error;
 pub mod repository;
 pub mod value_objects;
 
-pub use entities::{Branch, Commit, FileDiffStat, FileStatus, Worktree};
+pub use entities::{Branch, Commit, FileDiffStat, FileStatus, RepositoryStatusScan, Worktree};
 pub use error::RepositoryError;
 pub use repository::{
     BranchRepository, GitConfigRepository, LogRepository, RepoLocator, RepoPathsNotifier,

--- a/src-tauri/src/domain/repository/repository.rs
+++ b/src-tauri/src/domain/repository/repository.rs
@@ -7,7 +7,7 @@
 //! （`spawn_blocking`）は controller 層で被せる方針のため、各 trait の
 //! メソッドは同期シグネチャで定義する。
 
-use super::entities::{Branch, Commit, FileDiffStat, FileStatus, Worktree};
+use super::entities::{Branch, Commit, FileStatus, RepositoryStatusScan, Worktree};
 use super::error::RepositoryError;
 
 /// ブランチの参照・作成・削除。
@@ -28,8 +28,12 @@ pub trait LogRepository: Send + Sync {
 
 /// 作業ツリー状態の読み取り。
 pub trait StatusRepository: Send + Sync {
-    fn status(&self, repo_path: &str) -> Result<Vec<FileStatus>, RepositoryError>;
-    fn diff_stats(&self, repo_path: &str) -> Result<Vec<FileDiffStat>, RepositoryError>;
+    fn status_with_options(
+        &self,
+        repo_path: &str,
+        include_ignored: bool,
+    ) -> Result<Vec<FileStatus>, RepositoryError>;
+    fn status_scan(&self, repo_path: &str) -> Result<RepositoryStatusScan, RepositoryError>;
 }
 
 /// ワークツリーの参照・作成・削除。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -182,6 +182,27 @@ pub fn run() {
 
                 // code ドメインの DI 配線（gateway 実装はステートレス）。
                 let code_usecase = Arc::new(adaptor::controller::wiring::build_code_usecase());
+                let repository_state =
+                    Arc::new(usecase::repository_state::RepositoryStateService::new(
+                        repository_usecase.clone(),
+                        code_usecase.clone(),
+                        Arc::new(
+                            adaptor::gateway::repository::state::TauriRepositoryStateNotifier::new(
+                                app.handle().clone(),
+                                ws_broadcaster.clone(),
+                            ),
+                        ),
+                        Arc::new(
+                            adaptor::gateway::repository::state::NotifyRepositoryStateWatcher::new(
+                                repository_usecase.clone(),
+                            ),
+                        ),
+                        Arc::new(
+                            adaptor::gateway::repository::state::TokioRepositoryStateWorkerRuntime,
+                        ),
+                        Arc::new(adaptor::gateway::repository::state::FsWorktreePathNormalizer),
+                    ));
+                app.manage(repository_state.clone());
                 let workflow_usecase = Arc::new(
                     adaptor::controller::wiring::build_workflow_usecase_with_repository_worktrees(
                         data_dir.clone(),
@@ -194,6 +215,7 @@ pub fn run() {
 
                 app.manage(AppState {
                     repository_usecase: repository_usecase.clone(),
+                    repository_state,
                     repo_paths_usecase,
                     code_usecase,
                     workflow_usecase,

--- a/src-tauri/src/usecase/mod.rs
+++ b/src-tauri/src/usecase/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod repo_paths_usecase;
 pub(crate) mod repository_dto;
 pub(crate) mod repository_error;
 pub(crate) mod repository_query_service;
+pub(crate) mod repository_state;
 pub(crate) mod repository_usecase;
 pub(crate) mod workspace_state;
 // #1034 staged workflow migration: controller wiring switches to this module in #1037.

--- a/src-tauri/src/usecase/repository_query_service.rs
+++ b/src-tauri/src/usecase/repository_query_service.rs
@@ -19,6 +19,15 @@ use super::repository_error::UsecaseError;
 /// 中間 Entity を介さず直接組み立てる。
 pub trait BranchCardQuery: Send + Sync {
     fn list_branch_cards(&self, repo_path: &str) -> Result<Vec<BranchCardDto>, RepositoryError>;
+
+    fn list_branch_cards_for_scan(
+        &self,
+        repo_path: &str,
+        current_dirty_count: usize,
+    ) -> Result<Vec<BranchCardDto>, RepositoryError> {
+        let _ = current_dirty_count;
+        self.list_branch_cards(repo_path)
+    }
 }
 
 /// read model（`BranchCardDto`）を構築する読み取りクエリサービス。
@@ -33,11 +42,24 @@ impl RepositoryQueryService {
         Self { branch_card_query }
     }
 
+    #[cfg(test)]
     pub fn list_branches_with_status(
         &self,
         repo_path: &str,
     ) -> Result<Vec<BranchCardDto>, UsecaseError> {
         let mut cards = self.branch_card_query.list_branch_cards(repo_path)?;
+        cards.sort_by_key(|card| !card.is_main_worktree);
+        Ok(cards)
+    }
+
+    pub fn list_branches_with_status_for_scan(
+        &self,
+        repo_path: &str,
+        current_dirty_count: usize,
+    ) -> Result<Vec<BranchCardDto>, UsecaseError> {
+        let mut cards = self
+            .branch_card_query
+            .list_branch_cards_for_scan(repo_path, current_dirty_count)?;
         cards.sort_by_key(|card| !card.is_main_worktree);
         Ok(cards)
     }

--- a/src-tauri/src/usecase/repository_state/error.rs
+++ b/src-tauri/src/usecase/repository_state/error.rs
@@ -1,0 +1,12 @@
+use crate::usecase::code_error::CodeUsecaseError;
+use crate::usecase::repository_error::UsecaseError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RepositoryStateError {
+    #[error(transparent)]
+    Repository(#[from] UsecaseError),
+    #[error(transparent)]
+    Code(#[from] CodeUsecaseError),
+    #[error("{0}")]
+    Watcher(String),
+}

--- a/src-tauri/src/usecase/repository_state/mod.rs
+++ b/src-tauri/src/usecase/repository_state/mod.rs
@@ -1,0 +1,10 @@
+pub(crate) mod error;
+pub(crate) mod runtime;
+pub(crate) mod scanner;
+pub(crate) mod service;
+pub(crate) mod snapshot;
+pub(crate) mod worker;
+pub(crate) mod worktree;
+
+pub(crate) use error::RepositoryStateError;
+pub(crate) use service::RepositoryStateService;

--- a/src-tauri/src/usecase/repository_state/runtime.rs
+++ b/src-tauri/src/usecase/repository_state/runtime.rs
@@ -1,0 +1,131 @@
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::error::RepositoryStateError;
+use super::scanner::RepositoryScanner;
+use super::snapshot::RepositorySnapshotParts;
+use super::worker::InvalidateReason;
+
+pub type RepositoryStateWorkerFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+pub trait RepositoryStateInvalidationSender: Send + Sync {
+    fn send(&self, reason: InvalidateReason) -> Result<(), ()>;
+}
+
+#[async_trait::async_trait]
+pub trait RepositoryStateInvalidationReceiver: Send {
+    async fn recv(&mut self) -> Option<InvalidateReason>;
+    fn try_recv(&mut self) -> Option<InvalidateReason>;
+}
+
+#[async_trait::async_trait]
+pub trait RepositoryStateWorkerRuntime: Send + Sync {
+    fn invalidation_channel(
+        &self,
+    ) -> (
+        Box<dyn RepositoryStateInvalidationSender>,
+        Box<dyn RepositoryStateInvalidationReceiver>,
+    );
+
+    fn spawn_worker(&self, future: RepositoryStateWorkerFuture);
+
+    async fn sleep(&self, duration: Duration);
+
+    async fn scan(
+        &self,
+        scanner: Arc<dyn RepositoryScanner>,
+        repo_path: String,
+    ) -> Result<RepositorySnapshotParts, RepositoryStateError>;
+}
+
+pub trait WorktreePathNormalizer: Send + Sync {
+    fn normalize(&self, worktree_path: &str) -> Result<PathBuf, RepositoryStateError>;
+}
+
+#[cfg(test)]
+pub(crate) mod tests_support {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    pub(crate) struct TestRepositoryStateWorkerRuntime;
+
+    struct TokioInvalidationSender(mpsc::UnboundedSender<InvalidateReason>);
+
+    impl RepositoryStateInvalidationSender for TokioInvalidationSender {
+        fn send(&self, reason: InvalidateReason) -> Result<(), ()> {
+            self.0.send(reason).map_err(|_| ())
+        }
+    }
+
+    struct TokioInvalidationReceiver(mpsc::UnboundedReceiver<InvalidateReason>);
+
+    #[async_trait::async_trait]
+    impl RepositoryStateInvalidationReceiver for TokioInvalidationReceiver {
+        async fn recv(&mut self) -> Option<InvalidateReason> {
+            self.0.recv().await
+        }
+
+        fn try_recv(&mut self) -> Option<InvalidateReason> {
+            self.0.try_recv().ok()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RepositoryStateWorkerRuntime for TestRepositoryStateWorkerRuntime {
+        fn invalidation_channel(
+            &self,
+        ) -> (
+            Box<dyn RepositoryStateInvalidationSender>,
+            Box<dyn RepositoryStateInvalidationReceiver>,
+        ) {
+            let (tx, rx) = mpsc::unbounded_channel();
+            (
+                Box::new(TokioInvalidationSender(tx)),
+                Box::new(TokioInvalidationReceiver(rx)),
+            )
+        }
+
+        fn spawn_worker(&self, future: RepositoryStateWorkerFuture) {
+            tokio::spawn(future);
+        }
+
+        async fn sleep(&self, duration: Duration) {
+            tokio::time::sleep(duration).await;
+        }
+
+        async fn scan(
+            &self,
+            scanner: Arc<dyn RepositoryScanner>,
+            repo_path: String,
+        ) -> Result<RepositorySnapshotParts, RepositoryStateError> {
+            tokio::task::spawn_blocking(move || scanner.scan(&repo_path))
+                .await
+                .map_err(|err| RepositoryStateError::Watcher(format!("test scan failed: {err}")))?
+        }
+    }
+
+    pub(crate) struct IdentityWorktreePathNormalizer;
+
+    impl WorktreePathNormalizer for IdentityWorktreePathNormalizer {
+        fn normalize(&self, worktree_path: &str) -> Result<PathBuf, RepositoryStateError> {
+            Ok(PathBuf::from(worktree_path))
+        }
+    }
+
+    pub(crate) struct CanonicalWorktreePathNormalizer;
+
+    impl WorktreePathNormalizer for CanonicalWorktreePathNormalizer {
+        fn normalize(&self, worktree_path: &str) -> Result<PathBuf, RepositoryStateError> {
+            let path = PathBuf::from(worktree_path);
+            path.canonicalize().map_err(|err| {
+                RepositoryStateError::Watcher(format!(
+                    "Failed to canonicalize worktree path {}: {err}",
+                    path.display()
+                ))
+            })
+        }
+    }
+}

--- a/src-tauri/src/usecase/repository_state/scanner.rs
+++ b/src-tauri/src/usecase/repository_state/scanner.rs
@@ -1,0 +1,328 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::domain::code::DiffFileEntry;
+use crate::usecase::code_usecase::CodeUsecase;
+use crate::usecase::repository_dto::{FileDiffStatDto, FileStatusDto};
+use crate::usecase::repository_usecase::RepositoryUsecase;
+
+use super::error::RepositoryStateError;
+use super::snapshot::RepositorySnapshotParts;
+
+pub trait RepositoryScanner: Send + Sync {
+    fn scan(&self, repo_path: &str) -> Result<RepositorySnapshotParts, RepositoryStateError>;
+
+    fn status_with_ignored(
+        &self,
+        repo_path: &str,
+    ) -> Result<Vec<FileStatusDto>, RepositoryStateError>;
+
+    fn prune_stale_branch_bases(
+        &self,
+        repo_path: &str,
+        existing_branches: &[String],
+    ) -> Result<(), RepositoryStateError>;
+}
+
+pub struct DefaultRepositoryScanner {
+    repository: Arc<RepositoryUsecase>,
+    code: Arc<CodeUsecase>,
+}
+
+impl DefaultRepositoryScanner {
+    pub fn new(repository: Arc<RepositoryUsecase>, code: Arc<CodeUsecase>) -> Self {
+        Self { repository, code }
+    }
+}
+
+impl RepositoryScanner for DefaultRepositoryScanner {
+    fn scan(&self, repo_path: &str) -> Result<RepositorySnapshotParts, RepositoryStateError> {
+        let status_scan = self.repository.get_repository_status_scan(repo_path)?;
+        let current_dirty_count = status_scan.dirty_count;
+        let status: Vec<FileStatusDto> = status_scan.status.into_iter().map(Into::into).collect();
+        let diff_stats: Vec<FileDiffStatDto> =
+            status_scan.diff_stats.into_iter().map(Into::into).collect();
+        let branch_cards = self
+            .repository
+            .list_branches_with_status_for_scan(repo_path, current_dirty_count)?;
+        let diff_file_tree = self
+            .code
+            .build_diff_file_tree(diff_tree_entries(&status, &diff_stats));
+        let staged_diff_file_tree = self
+            .code
+            .build_diff_file_tree(staged_diff_tree_entries(&status, &diff_stats));
+        let changes_diff_file_tree = self
+            .code
+            .build_diff_file_tree(changes_diff_tree_entries(&status, &diff_stats));
+
+        Ok(RepositorySnapshotParts {
+            status,
+            diff_stats,
+            branch_cards,
+            diff_file_tree,
+            staged_diff_file_tree,
+            changes_diff_file_tree,
+            // Thresholds are defined by the later review snapshot work. This issue
+            // only carries the flag through the snapshot contract.
+            limited: false,
+        })
+    }
+
+    fn status_with_ignored(
+        &self,
+        repo_path: &str,
+    ) -> Result<Vec<FileStatusDto>, RepositoryStateError> {
+        Ok(self
+            .repository
+            .get_git_status_include_ignored(repo_path)?
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+
+    fn prune_stale_branch_bases(
+        &self,
+        repo_path: &str,
+        existing_branches: &[String],
+    ) -> Result<(), RepositoryStateError> {
+        Ok(self
+            .repository
+            .prune_stale_branch_bases(repo_path, existing_branches)?)
+    }
+}
+
+fn stats_by_path(diff_stats: &[FileDiffStatDto]) -> HashMap<&str, &FileDiffStatDto> {
+    diff_stats
+        .iter()
+        .map(|stat| (stat.path.as_str(), stat))
+        .collect()
+}
+
+fn diff_tree_entries(
+    status: &[FileStatusDto],
+    diff_stats: &[FileDiffStatDto],
+) -> Vec<DiffFileEntry> {
+    let stats_by_path = stats_by_path(diff_stats);
+
+    status
+        .iter()
+        .filter(|entry| entry.worktree_status != "ignored")
+        .map(|entry| {
+            let stat = stats_by_path.get(entry.path.as_str()).copied();
+            DiffFileEntry {
+                path: entry.path.clone(),
+                status: diff_tree_status(entry).to_string(),
+                additions: stat
+                    .map(|stat| stat.index_additions + stat.wt_additions)
+                    .unwrap_or(0),
+                deletions: stat
+                    .map(|stat| stat.index_deletions + stat.wt_deletions)
+                    .unwrap_or(0),
+            }
+        })
+        .collect()
+}
+
+fn staged_diff_tree_entries(
+    status: &[FileStatusDto],
+    diff_stats: &[FileDiffStatDto],
+) -> Vec<DiffFileEntry> {
+    let stats_by_path = stats_by_path(diff_stats);
+
+    status
+        .iter()
+        .filter(|entry| entry.index_status != "none")
+        .map(|entry| {
+            let stat = stats_by_path.get(entry.path.as_str()).copied();
+            DiffFileEntry {
+                path: entry.path.clone(),
+                status: entry.index_status.clone(),
+                additions: stat.map(|stat| stat.index_additions).unwrap_or(0),
+                deletions: stat.map(|stat| stat.index_deletions).unwrap_or(0),
+            }
+        })
+        .collect()
+}
+
+fn changes_diff_tree_entries(
+    status: &[FileStatusDto],
+    diff_stats: &[FileDiffStatDto],
+) -> Vec<DiffFileEntry> {
+    let stats_by_path = stats_by_path(diff_stats);
+
+    status
+        .iter()
+        .filter(|entry| entry.worktree_status != "none" && entry.worktree_status != "ignored")
+        .map(|entry| {
+            let stat = stats_by_path.get(entry.path.as_str()).copied();
+            DiffFileEntry {
+                path: entry.path.clone(),
+                status: entry.worktree_status.clone(),
+                additions: stat.map(|stat| stat.wt_additions).unwrap_or(0),
+                deletions: stat.map(|stat| stat.wt_deletions).unwrap_or(0),
+            }
+        })
+        .collect()
+}
+
+fn diff_tree_status(entry: &FileStatusDto) -> &str {
+    if entry.index_status != "none" {
+        entry.index_status.as_str()
+    } else {
+        entry.worktree_status.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diff_tree_entries_use_index_status_before_worktree_status() {
+        let status = vec![FileStatusDto {
+            path: "src/lib.rs".to_string(),
+            index_status: "modified".to_string(),
+            worktree_status: "deleted".to_string(),
+        }];
+        let stats = vec![FileDiffStatDto {
+            path: "src/lib.rs".to_string(),
+            index_additions: 2,
+            index_deletions: 1,
+            wt_additions: 3,
+            wt_deletions: 4,
+        }];
+
+        let entries = diff_tree_entries(&status, &stats);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].status, "modified");
+        assert_eq!(entries[0].additions, 5);
+        assert_eq!(entries[0].deletions, 5);
+    }
+
+    #[test]
+    fn diff_tree_entries_skip_ignored_status() {
+        let status = vec![FileStatusDto {
+            path: "target".to_string(),
+            index_status: "none".to_string(),
+            worktree_status: "ignored".to_string(),
+        }];
+
+        assert!(diff_tree_entries(&status, &[]).is_empty());
+    }
+
+    #[test]
+    fn staged_and_changes_entries_are_split_from_same_status_and_stats() {
+        let status = vec![
+            FileStatusDto {
+                path: "both.rs".to_string(),
+                index_status: "modified".to_string(),
+                worktree_status: "deleted".to_string(),
+            },
+            FileStatusDto {
+                path: "ignored".to_string(),
+                index_status: "none".to_string(),
+                worktree_status: "ignored".to_string(),
+            },
+        ];
+        let stats = vec![FileDiffStatDto {
+            path: "both.rs".to_string(),
+            index_additions: 2,
+            index_deletions: 1,
+            wt_additions: 0,
+            wt_deletions: 4,
+        }];
+
+        let staged = staged_diff_tree_entries(&status, &stats);
+        let changes = changes_diff_tree_entries(&status, &stats);
+
+        assert_eq!(staged.len(), 1);
+        assert_eq!(staged[0].status, "modified");
+        assert_eq!(staged[0].additions, 2);
+        assert_eq!(staged[0].deletions, 1);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].status, "deleted");
+        assert_eq!(changes[0].additions, 0);
+        assert_eq!(changes[0].deletions, 4);
+    }
+
+    #[test]
+    fn default_scanner_matches_existing_usecase_read_models_for_real_repo() {
+        let (dir, repo) = crate::git::test_helpers::create_test_repo();
+        crate::git::test_helpers::create_initial_commit(&repo);
+        crate::git::test_helpers::add_and_commit(&repo, "staged.txt", "before\n", "add staged");
+        crate::git::test_helpers::add_and_commit(&repo, "unstaged.txt", "before\n", "add unstaged");
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("feature", &head, false).unwrap();
+
+        std::fs::write(dir.path().join("staged.txt"), "before\nafter\n").unwrap();
+        {
+            let mut index = repo.index().unwrap();
+            index.add_path(std::path::Path::new("staged.txt")).unwrap();
+            index.write().unwrap();
+        }
+        std::fs::write(dir.path().join("unstaged.txt"), "changed\n").unwrap();
+        std::fs::write(dir.path().join("untracked.txt"), "new\n").unwrap();
+
+        let repository = Arc::new(crate::adaptor::controller::wiring::build_repository_usecase());
+        let code = Arc::new(crate::adaptor::controller::wiring::build_code_usecase());
+        let scanner = DefaultRepositoryScanner::new(repository.clone(), code.clone());
+        let repo_path = dir.path().to_str().unwrap();
+
+        crate::adaptor::gateway::repository::status::reset_status_walk_count_for_tests();
+        let snapshot = scanner.scan(repo_path).unwrap();
+        assert_eq!(
+            crate::adaptor::gateway::repository::status::status_walk_count_for_tests(),
+            1
+        );
+
+        let expected_status: Vec<FileStatusDto> =
+            crate::adaptor::gateway::repository::status::get_git_status(repo_path)
+                .unwrap()
+                .into_iter()
+                .map(Into::into)
+                .collect();
+        let expected_diff_stats: Vec<FileDiffStatDto> =
+            crate::adaptor::gateway::repository::status::get_status_diff_stats(repo_path)
+                .unwrap()
+                .into_iter()
+                .map(Into::into)
+                .collect();
+        let expected_branch_cards = repository
+            .list_branches_with_status_read_only(repo_path)
+            .unwrap();
+
+        assert_eq!(snapshot.status, expected_status);
+        assert_eq!(snapshot.diff_stats, expected_diff_stats);
+        assert_eq!(
+            serde_json::to_value(&snapshot.branch_cards).unwrap(),
+            serde_json::to_value(&expected_branch_cards).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_value(&snapshot.diff_file_tree).unwrap(),
+            serde_json::to_value(
+                code.build_diff_file_tree(diff_tree_entries(
+                    &expected_status,
+                    &expected_diff_stats,
+                ))
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            serde_json::to_value(&snapshot.staged_diff_file_tree).unwrap(),
+            serde_json::to_value(code.build_diff_file_tree(staged_diff_tree_entries(
+                &expected_status,
+                &expected_diff_stats,
+            )))
+            .unwrap()
+        );
+        assert_eq!(
+            serde_json::to_value(&snapshot.changes_diff_file_tree).unwrap(),
+            serde_json::to_value(code.build_diff_file_tree(changes_diff_tree_entries(
+                &expected_status,
+                &expected_diff_stats,
+            )))
+            .unwrap()
+        );
+    }
+}

--- a/src-tauri/src/usecase/repository_state/service.rs
+++ b/src-tauri/src/usecase/repository_state/service.rs
@@ -1,0 +1,937 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::RwLock;
+
+use crate::usecase::code_usecase::CodeUsecase;
+use crate::usecase::repository_dto::{BranchCardDto, FileDiffStatDto, FileStatusDto};
+use crate::usecase::repository_usecase::RepositoryUsecase;
+
+use super::error::RepositoryStateError;
+use super::runtime::{RepositoryStateWorkerRuntime, WorktreePathNormalizer};
+use super::scanner::{DefaultRepositoryScanner, RepositoryScanner};
+use super::snapshot::{
+    RepositoryBranchCardsSnapshotDto, RepositoryDiffStatsSnapshotDto,
+    RepositoryHeadDiffFileTreeSnapshotDto, RepositorySnapshot, RepositoryStatusSnapshotDto,
+};
+use super::worktree::WatchSubscriptionKind;
+use super::worktree::{RepositoryStateNotifier, RepositoryStateWatcher, WorktreeState};
+
+const DEFAULT_DEBOUNCE: Duration = Duration::from_millis(300);
+
+pub struct RepositoryStateService {
+    repository: Arc<RepositoryUsecase>,
+    scanner: Arc<dyn RepositoryScanner>,
+    notifier: Arc<dyn RepositoryStateNotifier>,
+    watcher: Arc<dyn RepositoryStateWatcher>,
+    runtime: Arc<dyn RepositoryStateWorkerRuntime>,
+    path_normalizer: Arc<dyn WorktreePathNormalizer>,
+    debounce: Duration,
+    worktrees: RwLock<HashMap<PathBuf, Arc<WorktreeState>>>,
+}
+
+impl RepositoryStateService {
+    pub fn new(
+        repository: Arc<RepositoryUsecase>,
+        code: Arc<CodeUsecase>,
+        notifier: Arc<dyn RepositoryStateNotifier>,
+        watcher: Arc<dyn RepositoryStateWatcher>,
+        runtime: Arc<dyn RepositoryStateWorkerRuntime>,
+        path_normalizer: Arc<dyn WorktreePathNormalizer>,
+    ) -> Self {
+        let scanner = Arc::new(DefaultRepositoryScanner::new(repository.clone(), code));
+        Self::new_with_scanner(
+            repository,
+            scanner,
+            notifier,
+            watcher,
+            runtime,
+            path_normalizer,
+            DEFAULT_DEBOUNCE,
+        )
+    }
+
+    pub fn new_with_scanner(
+        repository: Arc<RepositoryUsecase>,
+        scanner: Arc<dyn RepositoryScanner>,
+        notifier: Arc<dyn RepositoryStateNotifier>,
+        watcher: Arc<dyn RepositoryStateWatcher>,
+        runtime: Arc<dyn RepositoryStateWorkerRuntime>,
+        path_normalizer: Arc<dyn WorktreePathNormalizer>,
+        debounce: Duration,
+    ) -> Self {
+        Self {
+            repository,
+            scanner,
+            notifier,
+            watcher,
+            runtime,
+            path_normalizer,
+            debounce,
+            worktrees: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn start_file_watching_if_repository(
+        &self,
+        path: &str,
+    ) -> Result<Option<u64>, RepositoryStateError> {
+        if self.repository.get_main_repo_path(path).is_err() {
+            return Ok(None);
+        }
+        Ok(Some(self.subscribe(path, WatchSubscriptionKind::File)?))
+    }
+
+    pub fn start_git_dir_watching(&self, repo_path: &str) -> Result<u64, RepositoryStateError> {
+        self.subscribe(repo_path, WatchSubscriptionKind::Git)
+    }
+
+    pub fn get_snapshot(
+        &self,
+        worktree_path: &str,
+    ) -> Result<Arc<RepositorySnapshot>, RepositoryStateError> {
+        let key = self.canonical_worktree_key(worktree_path)?;
+        if let Some(existing) = self.worktrees.read().get(&key) {
+            return Ok(existing.snapshot_for_read());
+        }
+
+        let canonical_path = key.to_string_lossy().to_string();
+        let snapshot = self.scanner.scan(&canonical_path)?.into_snapshot(0);
+        Ok(Arc::new(snapshot))
+    }
+
+    pub fn get_status(
+        &self,
+        worktree_path: &str,
+        include_ignored: bool,
+    ) -> Result<Vec<FileStatusDto>, RepositoryStateError> {
+        if include_ignored {
+            return self.scanner.status_with_ignored(worktree_path);
+        }
+        Ok(self.get_snapshot(worktree_path)?.status.clone())
+    }
+
+    pub fn get_status_snapshot(
+        &self,
+        worktree_path: &str,
+    ) -> Result<RepositoryStatusSnapshotDto, RepositoryStateError> {
+        let snapshot = self.get_snapshot(worktree_path)?;
+        Ok(RepositoryStatusSnapshotDto::from_snapshot(
+            snapshot.as_ref(),
+        ))
+    }
+
+    pub fn get_diff_stats(
+        &self,
+        worktree_path: &str,
+    ) -> Result<Vec<FileDiffStatDto>, RepositoryStateError> {
+        Ok(self.get_snapshot(worktree_path)?.diff_stats.clone())
+    }
+
+    pub fn get_diff_stats_snapshot(
+        &self,
+        worktree_path: &str,
+    ) -> Result<RepositoryDiffStatsSnapshotDto, RepositoryStateError> {
+        let snapshot = self.get_snapshot(worktree_path)?;
+        Ok(RepositoryDiffStatsSnapshotDto::from_snapshot(
+            snapshot.as_ref(),
+        ))
+    }
+
+    pub fn get_head_diff_file_tree_snapshot(
+        &self,
+        worktree_path: &str,
+    ) -> Result<RepositoryHeadDiffFileTreeSnapshotDto, RepositoryStateError> {
+        let snapshot = self.get_snapshot(worktree_path)?;
+        Ok(RepositoryHeadDiffFileTreeSnapshotDto::from_snapshot(
+            snapshot.as_ref(),
+        ))
+    }
+
+    pub fn list_branches_with_status(
+        &self,
+        repo_path: &str,
+    ) -> Result<Vec<BranchCardDto>, RepositoryStateError> {
+        Ok(self.get_snapshot(repo_path)?.branch_cards.clone())
+    }
+
+    pub fn list_branches_with_status_snapshot(
+        &self,
+        repo_path: &str,
+    ) -> Result<RepositoryBranchCardsSnapshotDto, RepositoryStateError> {
+        let snapshot = self.get_snapshot(repo_path)?;
+        Ok(RepositoryBranchCardsSnapshotDto::from_snapshot(
+            snapshot.as_ref(),
+        ))
+    }
+
+    pub fn get_worktree_dirty_count(
+        &self,
+        worktree_path: &str,
+    ) -> Result<u32, RepositoryStateError> {
+        Ok(self.get_snapshot(worktree_path)?.status.len() as u32)
+    }
+
+    pub fn stop_watching(&self, watcher_id: u64) -> Result<bool, RepositoryStateError> {
+        let mut worktrees = self.worktrees.write();
+        let mut empty_key = None;
+        let mut found = false;
+
+        for (key, state) in worktrees.iter() {
+            if state.release_subscription(watcher_id) {
+                found = true;
+                if state.subscriber_count() == 0 {
+                    empty_key = Some(key.clone());
+                }
+                break;
+            }
+        }
+
+        if let Some(key) = empty_key {
+            if let Some(state) = worktrees.remove(&key) {
+                state.shutdown();
+            }
+        }
+
+        Ok(found)
+    }
+
+    fn subscribe(
+        &self,
+        worktree_path: &str,
+        kind: WatchSubscriptionKind,
+    ) -> Result<u64, RepositoryStateError> {
+        let subscription_id = self.watcher.next_watcher_id();
+        self.ensure_watching_with_subscription(worktree_path, Some((subscription_id, kind)))?;
+        Ok(subscription_id)
+    }
+
+    #[cfg(test)]
+    fn ensure_watching(
+        &self,
+        worktree_path: &str,
+    ) -> Result<Arc<WorktreeState>, RepositoryStateError> {
+        self.ensure_watching_with_subscription(worktree_path, None)
+    }
+
+    fn ensure_watching_with_subscription(
+        &self,
+        worktree_path: &str,
+        subscription: Option<(u64, WatchSubscriptionKind)>,
+    ) -> Result<Arc<WorktreeState>, RepositoryStateError> {
+        let key = self.canonical_worktree_key(worktree_path)?;
+        if let Some(existing) = self.worktrees.read().get(&key) {
+            if let Some((id, kind)) = subscription {
+                existing.add_subscription(id, kind, worktree_path.to_string());
+            }
+            return Ok(existing.clone());
+        }
+
+        let mut worktrees = self.worktrees.write();
+        if let Some(existing) = worktrees.get(&key) {
+            if let Some((id, kind)) = subscription {
+                existing.add_subscription(id, kind, worktree_path.to_string());
+            }
+            return Ok(existing.clone());
+        }
+
+        let canonical_path = key.to_string_lossy().to_string();
+        let state = WorktreeState::new(
+            canonical_path,
+            self.scanner.clone(),
+            self.notifier.clone(),
+            self.runtime.clone(),
+            self.debounce,
+        );
+        if let Some((id, kind)) = subscription {
+            state.add_subscription(id, kind, worktree_path.to_string());
+        }
+        if let Err(err) = state.start_watchers(self.watcher.as_ref()) {
+            state.shutdown();
+            return Err(err);
+        }
+        worktrees.insert(key, state.clone());
+        Ok(state)
+    }
+
+    #[cfg(test)]
+    fn ensure_for_tests(&self, worktree_path: &str) -> Arc<WorktreeState> {
+        let key = PathBuf::from(worktree_path);
+        if let Some(existing) = self.worktrees.read().get(&key) {
+            return existing.clone();
+        }
+        let mut worktrees = self.worktrees.write();
+        if let Some(existing) = worktrees.get(&key) {
+            return existing.clone();
+        }
+        let state = WorktreeState::new(
+            worktree_path.to_string(),
+            self.scanner.clone(),
+            self.notifier.clone(),
+            self.runtime.clone(),
+            self.debounce,
+        );
+        worktrees.insert(key, state.clone());
+        state
+    }
+
+    #[cfg(test)]
+    fn worktree_count(&self) -> usize {
+        self.worktrees.read().len()
+    }
+
+    fn canonical_worktree_key(&self, worktree_path: &str) -> Result<PathBuf, RepositoryStateError> {
+        self.path_normalizer.normalize(worktree_path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::usecase::repository_dto::{BranchCardDto, FileDiffStatDto, FileStatusDto};
+    use crate::usecase::repository_state::runtime::tests_support::{
+        CanonicalWorktreePathNormalizer, IdentityWorktreePathNormalizer,
+        TestRepositoryStateWorkerRuntime,
+    };
+    use crate::usecase::repository_state::snapshot::RepositorySnapshotParts;
+    use crate::usecase::repository_state::worker::InvalidateReason;
+    use crate::usecase::repository_state::worktree::{
+        NoopRepositoryStateNotifier, NoopRepositoryStateWatcher, SnapshotNotification,
+    };
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+    struct EmptyScanner {
+        ignored_calls: AtomicUsize,
+    }
+
+    impl RepositoryScanner for EmptyScanner {
+        fn scan(&self, _repo_path: &str) -> Result<RepositorySnapshotParts, RepositoryStateError> {
+            Ok(RepositorySnapshotParts {
+                status: Vec::new(),
+                diff_stats: Vec::new(),
+                branch_cards: Vec::new(),
+                diff_file_tree: Vec::new(),
+                staged_diff_file_tree: Vec::new(),
+                changes_diff_file_tree: Vec::new(),
+                limited: false,
+            })
+        }
+
+        fn status_with_ignored(
+            &self,
+            _repo_path: &str,
+        ) -> Result<Vec<FileStatusDto>, RepositoryStateError> {
+            self.ignored_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![FileStatusDto {
+                path: "ignored.txt".to_string(),
+                index_status: "none".to_string(),
+                worktree_status: "ignored".to_string(),
+            }])
+        }
+
+        fn prune_stale_branch_bases(
+            &self,
+            _repo_path: &str,
+            _existing_branches: &[String],
+        ) -> Result<(), RepositoryStateError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingScanner {
+        scans: AtomicUsize,
+        prunes: parking_lot::Mutex<Vec<Vec<String>>>,
+        status: parking_lot::Mutex<Vec<FileStatusDto>>,
+        diff_stats: parking_lot::Mutex<Vec<FileDiffStatDto>>,
+        branch_cards: parking_lot::Mutex<Vec<BranchCardDto>>,
+    }
+
+    impl CountingScanner {
+        fn with_status(status: Vec<FileStatusDto>) -> Self {
+            Self {
+                status: parking_lot::Mutex::new(status),
+                ..Self::default()
+            }
+        }
+
+        fn scan_count(&self) -> usize {
+            self.scans.load(Ordering::SeqCst)
+        }
+
+        fn prune_calls(&self) -> Vec<Vec<String>> {
+            self.prunes.lock().clone()
+        }
+
+        fn set_branch_cards(&self, branch_cards: Vec<BranchCardDto>) {
+            *self.branch_cards.lock() = branch_cards;
+        }
+    }
+
+    impl RepositoryScanner for CountingScanner {
+        fn scan(&self, _repo_path: &str) -> Result<RepositorySnapshotParts, RepositoryStateError> {
+            self.scans.fetch_add(1, Ordering::SeqCst);
+            Ok(RepositorySnapshotParts {
+                status: self.status.lock().clone(),
+                diff_stats: self.diff_stats.lock().clone(),
+                branch_cards: self.branch_cards.lock().clone(),
+                diff_file_tree: Vec::new(),
+                staged_diff_file_tree: Vec::new(),
+                changes_diff_file_tree: Vec::new(),
+                limited: false,
+            })
+        }
+
+        fn status_with_ignored(
+            &self,
+            _repo_path: &str,
+        ) -> Result<Vec<FileStatusDto>, RepositoryStateError> {
+            let mut status = self.status.lock().clone();
+            status.push(FileStatusDto {
+                path: "ignored.txt".to_string(),
+                index_status: "none".to_string(),
+                worktree_status: "ignored".to_string(),
+            });
+            Ok(status)
+        }
+
+        fn prune_stale_branch_bases(
+            &self,
+            _repo_path: &str,
+            existing_branches: &[String],
+        ) -> Result<(), RepositoryStateError> {
+            self.prunes.lock().push(existing_branches.to_vec());
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingRepositoryStateWatcher {
+        next_id: AtomicU64,
+        started_paths: parking_lot::Mutex<Vec<String>>,
+    }
+
+    impl CountingRepositoryStateWatcher {
+        fn start_count(&self) -> usize {
+            self.started_paths.lock().len()
+        }
+
+        fn started_paths(&self) -> Vec<String> {
+            self.started_paths.lock().clone()
+        }
+    }
+
+    impl RepositoryStateWatcher for CountingRepositoryStateWatcher {
+        fn next_watcher_id(&self) -> u64 {
+            self.next_id.fetch_add(1, Ordering::SeqCst) + 1
+        }
+
+        fn start_watchers(
+            &self,
+            state: Arc<WorktreeState>,
+        ) -> Result<
+            Box<dyn crate::usecase::repository_state::worktree::RepositoryStateWatchSession>,
+            RepositoryStateError,
+        > {
+            self.started_paths
+                .lock()
+                .push(state.worktree_path().to_string());
+            Ok(Box::new(()))
+        }
+    }
+
+    fn test_service(scanner: Arc<EmptyScanner>) -> RepositoryStateService {
+        RepositoryStateService::new_with_scanner(
+            Arc::new(crate::adaptor::controller::wiring::build_repository_usecase()),
+            scanner,
+            Arc::new(NoopRepositoryStateNotifier),
+            Arc::new(NoopRepositoryStateWatcher),
+            Arc::new(TestRepositoryStateWorkerRuntime),
+            Arc::new(CanonicalWorktreePathNormalizer),
+            Duration::ZERO,
+        )
+    }
+
+    fn test_service_with_notifier(
+        scanner: Arc<EmptyScanner>,
+        notifier: Arc<dyn RepositoryStateNotifier>,
+    ) -> RepositoryStateService {
+        RepositoryStateService::new_with_scanner(
+            Arc::new(crate::adaptor::controller::wiring::build_repository_usecase()),
+            scanner,
+            notifier,
+            Arc::new(NoopRepositoryStateWatcher),
+            Arc::new(TestRepositoryStateWorkerRuntime),
+            Arc::new(CanonicalWorktreePathNormalizer),
+            Duration::ZERO,
+        )
+    }
+
+    fn counting_service(
+        scanner: Arc<CountingScanner>,
+        watcher: Arc<dyn RepositoryStateWatcher>,
+    ) -> RepositoryStateService {
+        RepositoryStateService::new_with_scanner(
+            Arc::new(crate::adaptor::controller::wiring::build_repository_usecase()),
+            scanner,
+            Arc::new(NoopRepositoryStateNotifier),
+            watcher,
+            Arc::new(TestRepositoryStateWorkerRuntime),
+            Arc::new(IdentityWorktreePathNormalizer),
+            Duration::ZERO,
+        )
+    }
+
+    #[derive(Default)]
+    struct CapturingNotifier {
+        notifications: parking_lot::Mutex<Vec<SnapshotNotification>>,
+    }
+
+    impl CapturingNotifier {
+        fn take(&self) -> Vec<SnapshotNotification> {
+            std::mem::take(&mut *self.notifications.lock())
+        }
+    }
+
+    impl RepositoryStateNotifier for CapturingNotifier {
+        fn snapshot_changed(&self, notification: SnapshotNotification) {
+            self.notifications.lock().push(notification);
+        }
+    }
+
+    #[tokio::test]
+    async fn same_worktree_reuses_one_state() {
+        let service = test_service(Arc::new(EmptyScanner {
+            ignored_calls: AtomicUsize::new(0),
+        }));
+
+        let first = service.ensure_for_tests("/repo");
+        let second = service.ensure_for_tests("/repo");
+
+        assert_eq!(service.worktree_count(), 1);
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn unmanaged_read_returns_ephemeral_snapshot_without_creating_worktree_or_watcher() {
+        let scanner = Arc::new(CountingScanner::with_status(vec![FileStatusDto {
+            path: "changed.txt".to_string(),
+            index_status: "none".to_string(),
+            worktree_status: "modified".to_string(),
+        }]));
+        let watcher = Arc::new(CountingRepositoryStateWatcher::default());
+        let service = counting_service(scanner.clone(), watcher.clone());
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let snapshot = service.get_snapshot(dir.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(snapshot.version, 0);
+        assert!(!snapshot.flags.loading);
+        assert_eq!(snapshot.status.len(), 1);
+        assert_eq!(scanner.scan_count(), 1);
+        assert_eq!(service.worktree_count(), 0);
+        assert_eq!(watcher.start_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn unmanaged_reads_for_distinct_paths_do_not_accumulate_workers_or_watchers() {
+        let scanner = Arc::new(CountingScanner::default());
+        let watcher = Arc::new(CountingRepositoryStateWatcher::default());
+        let service = counting_service(scanner.clone(), watcher.clone());
+        let dirs = [
+            tempfile::TempDir::new().unwrap(),
+            tempfile::TempDir::new().unwrap(),
+            tempfile::TempDir::new().unwrap(),
+        ];
+
+        for dir in &dirs {
+            service.get_snapshot(dir.path().to_str().unwrap()).unwrap();
+        }
+
+        assert_eq!(scanner.scan_count(), 3);
+        assert_eq!(service.worktree_count(), 0);
+        assert_eq!(watcher.start_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn managed_worktree_read_uses_cached_snapshot_without_rescanning() {
+        let scanner = Arc::new(CountingScanner::with_status(vec![FileStatusDto {
+            path: "worker.txt".to_string(),
+            index_status: "none".to_string(),
+            worktree_status: "modified".to_string(),
+        }]));
+        let watcher = Arc::new(CountingRepositoryStateWatcher::default());
+        let service = counting_service(scanner.clone(), watcher);
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        service
+            .subscribe(path, WatchSubscriptionKind::File)
+            .unwrap();
+        for _ in 0..100 {
+            if service.get_snapshot(path).unwrap().version >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let scan_count = scanner.scan_count();
+
+        let snapshot = service.get_snapshot(path).unwrap();
+
+        assert!(snapshot.version >= 1);
+        assert_eq!(snapshot.status[0].path, "worker.txt");
+        assert_eq!(scanner.scan_count(), scan_count);
+        assert_eq!(service.worktree_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn snapshot_dtos_are_derived_from_same_cached_version() {
+        let scanner = Arc::new(CountingScanner::with_status(vec![FileStatusDto {
+            path: "changed.txt".to_string(),
+            index_status: "none".to_string(),
+            worktree_status: "modified".to_string(),
+        }]));
+        scanner.set_branch_cards(vec![BranchCardDto {
+            name: "main".to_string(),
+            is_main_worktree: true,
+            worktree_path: Some("/repo".to_string()),
+            dirty_count: 1,
+            is_merged: false,
+            ahead: 0,
+            behind: 0,
+            has_upstream: false,
+            base_ahead: 0,
+        }]);
+        let service =
+            counting_service(scanner, Arc::new(CountingRepositoryStateWatcher::default()));
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        service
+            .subscribe(path, WatchSubscriptionKind::File)
+            .unwrap();
+        for _ in 0..100 {
+            if service.get_status_snapshot(path).unwrap().version >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let status = service.get_status_snapshot(path).unwrap();
+        let diff_stats = service.get_diff_stats_snapshot(path).unwrap();
+        let branch_cards = service.list_branches_with_status_snapshot(path).unwrap();
+        let head_tree = service.get_head_diff_file_tree_snapshot(path).unwrap();
+        let dirty_count = service.get_worktree_dirty_count(path).unwrap();
+
+        assert!(status.version >= 1);
+        assert_eq!(diff_stats.version, status.version);
+        assert_eq!(branch_cards.version, status.version);
+        assert_eq!(head_tree.version, status.version);
+        assert_eq!(dirty_count as usize, status.status.len());
+    }
+
+    #[tokio::test]
+    async fn watcher_creation_happens_only_through_subscribe_paths() {
+        let scanner = Arc::new(CountingScanner::default());
+        let watcher = Arc::new(CountingRepositoryStateWatcher::default());
+        let service = counting_service(scanner, watcher.clone());
+        let (dir, repo) = crate::git::test_helpers::create_test_repo();
+        crate::git::test_helpers::create_initial_commit(&repo);
+        let path = dir.path().to_str().unwrap();
+
+        service.get_status_snapshot(path).unwrap();
+        service.get_diff_stats_snapshot(path).unwrap();
+        service.get_head_diff_file_tree_snapshot(path).unwrap();
+
+        assert_eq!(watcher.start_count(), 0);
+        assert_eq!(service.worktree_count(), 0);
+
+        service.start_file_watching_if_repository(path).unwrap();
+        assert_eq!(watcher.start_count(), 1);
+        assert_eq!(service.worktree_count(), 1);
+
+        let git_dir = tempfile::TempDir::new().unwrap();
+        let git_path = git_dir.path().to_str().unwrap();
+        service.start_git_dir_watching(git_path).unwrap();
+        assert_eq!(watcher.start_count(), 2);
+        assert_eq!(service.worktree_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn file_change_in_one_worktree_does_not_update_other_worktree_snapshot_version() {
+        let scanner = Arc::new(CountingScanner::default());
+        let service = counting_service(scanner, Arc::new(NoopRepositoryStateWatcher));
+
+        let first = service.ensure_for_tests("/repo-one");
+        let second = service.ensure_for_tests("/repo-two");
+        first.commit_snapshot(
+            RepositorySnapshotParts {
+                status: Vec::new(),
+                diff_stats: Vec::new(),
+                branch_cards: Vec::new(),
+                diff_file_tree: Vec::new(),
+                staged_diff_file_tree: Vec::new(),
+                changes_diff_file_tree: Vec::new(),
+                limited: false,
+            },
+            0,
+        );
+        second.commit_snapshot(
+            RepositorySnapshotParts {
+                status: Vec::new(),
+                diff_stats: Vec::new(),
+                branch_cards: Vec::new(),
+                diff_file_tree: Vec::new(),
+                staged_diff_file_tree: Vec::new(),
+                changes_diff_file_tree: Vec::new(),
+                limited: false,
+            },
+            0,
+        );
+
+        first.invalidate(InvalidateReason::file(Some("a.txt".to_string())));
+
+        for _ in 0..100 {
+            if first.snapshot_for_read().version >= 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert!(first.snapshot_for_read().version >= 2);
+        assert_eq!(second.snapshot_for_read().version, 1);
+    }
+
+    #[tokio::test]
+    async fn same_canonical_worktree_multiple_subscriptions_start_watchers_once() {
+        let scanner = Arc::new(CountingScanner::default());
+        let watcher = Arc::new(CountingRepositoryStateWatcher::default());
+        let service = counting_service(scanner, watcher.clone());
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        service
+            .subscribe(path, WatchSubscriptionKind::File)
+            .unwrap();
+        service.subscribe(path, WatchSubscriptionKind::Git).unwrap();
+        service
+            .subscribe(path, WatchSubscriptionKind::File)
+            .unwrap();
+
+        assert_eq!(watcher.start_count(), 1);
+        assert_eq!(service.worktree_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn different_worktrees_start_one_watcher_each_without_duplicate_paths() {
+        let scanner = Arc::new(CountingScanner::default());
+        let watcher = Arc::new(CountingRepositoryStateWatcher::default());
+        let service = counting_service(scanner, watcher.clone());
+        let first = tempfile::TempDir::new().unwrap();
+        let second = tempfile::TempDir::new().unwrap();
+        let first_path = first.path().to_str().unwrap();
+        let second_path = second.path().to_str().unwrap();
+
+        service
+            .subscribe(first_path, WatchSubscriptionKind::File)
+            .unwrap();
+        service
+            .subscribe(second_path, WatchSubscriptionKind::Git)
+            .unwrap();
+
+        let started_paths = watcher.started_paths();
+        assert_eq!(started_paths.len(), 2);
+        assert!(started_paths.contains(&first_path.to_string()));
+        assert!(started_paths.contains(&second_path.to_string()));
+    }
+
+    #[test]
+    fn dirty_count_uses_default_snapshot_status_and_excludes_ignored_opt_in_status() {
+        let scanner = Arc::new(CountingScanner::with_status(vec![
+            FileStatusDto {
+                path: "modified.txt".to_string(),
+                index_status: "none".to_string(),
+                worktree_status: "modified".to_string(),
+            },
+            FileStatusDto {
+                path: "staged.txt".to_string(),
+                index_status: "modified".to_string(),
+                worktree_status: "none".to_string(),
+            },
+        ]));
+        let service = counting_service(scanner.clone(), Arc::new(NoopRepositoryStateWatcher));
+
+        assert_eq!(service.get_worktree_dirty_count("/repo").unwrap(), 2);
+        assert_eq!(service.get_status("/repo", true).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn list_branches_with_status_is_pure_read_and_does_not_prune() {
+        let scanner = Arc::new(CountingScanner::default());
+        scanner.set_branch_cards(vec![BranchCardDto {
+            name: "main".to_string(),
+            is_main_worktree: true,
+            worktree_path: Some("/repo".to_string()),
+            dirty_count: 0,
+            is_merged: false,
+            ahead: 0,
+            behind: 0,
+            has_upstream: false,
+            base_ahead: 0,
+        }]);
+        let service = counting_service(scanner.clone(), Arc::new(NoopRepositoryStateWatcher));
+
+        let cards = service.list_branches_with_status("/repo").unwrap();
+
+        assert_eq!(cards.len(), 1);
+        assert!(scanner.prune_calls().is_empty());
+    }
+
+    #[test]
+    fn real_repo_dirty_count_matches_legacy_count_for_untracked_rename_and_typechange() {
+        let (dir, repo) = crate::git::test_helpers::create_test_repo();
+        crate::git::test_helpers::create_initial_commit(&repo);
+        crate::git::test_helpers::add_and_commit(&repo, "rename-old.txt", "old", "add old");
+        crate::git::test_helpers::add_and_commit(&repo, "typechange", "file", "add typechange");
+
+        std::fs::create_dir_all(dir.path().join("untracked-dir").join("nested")).unwrap();
+        std::fs::write(
+            dir.path()
+                .join("untracked-dir")
+                .join("nested")
+                .join("file.txt"),
+            "new",
+        )
+        .unwrap();
+        std::fs::rename(
+            dir.path().join("rename-old.txt"),
+            dir.path().join("rename-new.txt"),
+        )
+        .unwrap();
+        std::fs::remove_file(dir.path().join("typechange")).unwrap();
+        std::fs::create_dir(dir.path().join("typechange")).unwrap();
+        std::fs::write(dir.path().join("typechange").join("child.txt"), "child").unwrap();
+
+        let service = RepositoryStateService::new(
+            Arc::new(crate::adaptor::controller::wiring::build_repository_usecase()),
+            Arc::new(crate::adaptor::controller::wiring::build_code_usecase()),
+            Arc::new(NoopRepositoryStateNotifier),
+            Arc::new(NoopRepositoryStateWatcher),
+            Arc::new(TestRepositoryStateWorkerRuntime),
+            Arc::new(IdentityWorktreePathNormalizer),
+        );
+        let path = dir.path().to_str().unwrap();
+
+        let legacy =
+            crate::adaptor::gateway::repository::worktree::get_worktree_dirty_count(path).unwrap();
+        let snapshot_count = service.get_worktree_dirty_count(path).unwrap();
+
+        assert_eq!(snapshot_count, legacy);
+    }
+
+    #[tokio::test]
+    async fn subscriptions_share_state_but_get_distinct_release_ids() {
+        let service = test_service(Arc::new(EmptyScanner {
+            ignored_calls: AtomicUsize::new(0),
+        }));
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        let first = service
+            .subscribe(path, WatchSubscriptionKind::File)
+            .unwrap();
+        let second = service.subscribe(path, WatchSubscriptionKind::Git).unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(service.worktree_count(), 1);
+        assert!(service.stop_watching(first).unwrap());
+        assert_eq!(service.worktree_count(), 1);
+        assert!(service.stop_watching(second).unwrap());
+        assert_eq!(service.worktree_count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn canonical_state_notifies_each_subscriber_path_alias() {
+        let scanner = Arc::new(EmptyScanner {
+            ignored_calls: AtomicUsize::new(0),
+        });
+        let notifier = Arc::new(CapturingNotifier::default());
+        let service = test_service_with_notifier(scanner, notifier.clone());
+        let dir = tempfile::TempDir::new().unwrap();
+        let alias_parent = tempfile::TempDir::new().unwrap();
+        let alias = alias_parent.path().join("alias");
+        std::os::unix::fs::symlink(dir.path(), &alias).unwrap();
+
+        let original_path = dir.path().to_str().unwrap();
+        let alias_path = alias.to_str().unwrap();
+        service
+            .subscribe(original_path, WatchSubscriptionKind::File)
+            .unwrap();
+        service
+            .subscribe(alias_path, WatchSubscriptionKind::Git)
+            .unwrap();
+        let state = service.ensure_watching(original_path).unwrap();
+        notifier.take();
+
+        state.invalidate(InvalidateReason::git(false));
+
+        for _ in 0..100 {
+            let notifications = notifier.take();
+            if let Some(committed) = notifications.iter().find(|n| {
+                n.phase == super::super::worktree::SnapshotNotificationPhase::SnapshotCommitted
+            }) {
+                assert!(committed
+                    .worktree_paths
+                    .iter()
+                    .any(|path| path == original_path));
+                assert!(committed
+                    .worktree_paths
+                    .iter()
+                    .any(|path| path == alias_path));
+                assert_eq!(committed.file_watcher_ids.len(), 1);
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        panic!("timed out waiting for alias notification");
+    }
+
+    #[tokio::test]
+    async fn multiple_worktrees_are_independent_entries() {
+        let service = test_service(Arc::new(EmptyScanner {
+            ignored_calls: AtomicUsize::new(0),
+        }));
+
+        let first = service.ensure_for_tests("/repo-one");
+        let second = service.ensure_for_tests("/repo-two");
+
+        assert_eq!(service.worktree_count(), 2);
+        assert!(!Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn ignored_status_is_opt_in_and_not_cached_in_default_snapshot() {
+        let scanner = Arc::new(EmptyScanner {
+            ignored_calls: AtomicUsize::new(0),
+        });
+        let service = test_service(scanner.clone());
+        let state = service.ensure_for_tests("/repo");
+        state.invalidate(InvalidateReason::initial());
+
+        for _ in 0..100 {
+            if state.snapshot_for_read().version >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert!(state.snapshot_for_read().status.is_empty());
+        let ignored = service.get_status("/repo", true).unwrap();
+        assert_eq!(ignored[0].worktree_status, "ignored");
+        assert_eq!(scanner.ignored_calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src-tauri/src/usecase/repository_state/snapshot.rs
+++ b/src-tauri/src/usecase/repository_state/snapshot.rs
@@ -1,0 +1,302 @@
+use serde::{Deserialize, Serialize};
+
+use crate::usecase::code_dto::DiffTreeNodeDto;
+use crate::usecase::repository_dto::{BranchCardDto, FileDiffStatDto, FileStatusDto};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SnapshotFlags {
+    pub stale: bool,
+    pub loading: bool,
+    pub limited: bool,
+}
+
+impl SnapshotFlags {
+    pub fn loading() -> Self {
+        Self {
+            stale: false,
+            loading: true,
+            limited: false,
+        }
+    }
+
+    pub fn ready() -> Self {
+        Self {
+            stale: false,
+            loading: false,
+            limited: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepositorySnapshot {
+    pub version: u64,
+    pub flags: SnapshotFlags,
+    pub status: Vec<FileStatusDto>,
+    pub diff_stats: Vec<FileDiffStatDto>,
+    pub branch_cards: Vec<BranchCardDto>,
+    pub diff_file_tree: Vec<DiffTreeNodeDto>,
+    pub staged_diff_file_tree: Vec<DiffTreeNodeDto>,
+    pub changes_diff_file_tree: Vec<DiffTreeNodeDto>,
+}
+
+impl RepositorySnapshot {
+    pub fn loading() -> Self {
+        Self {
+            version: 0,
+            flags: SnapshotFlags::loading(),
+            status: Vec::new(),
+            diff_stats: Vec::new(),
+            branch_cards: Vec::new(),
+            diff_file_tree: Vec::new(),
+            staged_diff_file_tree: Vec::new(),
+            changes_diff_file_tree: Vec::new(),
+        }
+    }
+
+    pub fn with_read_flags(&self, stale: bool, loading: bool) -> Self {
+        let mut snapshot = self.clone();
+        snapshot.flags.stale = stale;
+        snapshot.flags.loading = loading;
+        snapshot
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RepositorySnapshotParts {
+    pub status: Vec<FileStatusDto>,
+    pub diff_stats: Vec<FileDiffStatDto>,
+    pub branch_cards: Vec<BranchCardDto>,
+    pub diff_file_tree: Vec<DiffTreeNodeDto>,
+    pub staged_diff_file_tree: Vec<DiffTreeNodeDto>,
+    pub changes_diff_file_tree: Vec<DiffTreeNodeDto>,
+    pub limited: bool,
+}
+
+impl RepositorySnapshotParts {
+    pub fn into_snapshot(self, version: u64) -> RepositorySnapshot {
+        RepositorySnapshot {
+            version,
+            flags: SnapshotFlags {
+                limited: self.limited,
+                ..SnapshotFlags::ready()
+            },
+            status: self.status,
+            diff_stats: self.diff_stats,
+            branch_cards: self.branch_cards,
+            diff_file_tree: self.diff_file_tree,
+            staged_diff_file_tree: self.staged_diff_file_tree,
+            changes_diff_file_tree: self.changes_diff_file_tree,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepositoryStatusSnapshotDto {
+    pub version: u64,
+    pub stale: bool,
+    pub loading: bool,
+    pub limited: bool,
+    pub status: Vec<FileStatusDto>,
+}
+
+impl RepositoryStatusSnapshotDto {
+    pub fn from_snapshot(snapshot: &RepositorySnapshot) -> Self {
+        Self {
+            version: snapshot.version,
+            stale: snapshot.flags.stale,
+            loading: snapshot.flags.loading,
+            limited: snapshot.flags.limited,
+            status: snapshot.status.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepositoryDiffStatsSnapshotDto {
+    pub version: u64,
+    pub stale: bool,
+    pub loading: bool,
+    pub limited: bool,
+    pub diff_stats: Vec<FileDiffStatDto>,
+}
+
+impl RepositoryDiffStatsSnapshotDto {
+    pub fn from_snapshot(snapshot: &RepositorySnapshot) -> Self {
+        Self {
+            version: snapshot.version,
+            stale: snapshot.flags.stale,
+            loading: snapshot.flags.loading,
+            limited: snapshot.flags.limited,
+            diff_stats: snapshot.diff_stats.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepositoryBranchCardsSnapshotDto {
+    pub version: u64,
+    pub stale: bool,
+    pub loading: bool,
+    pub limited: bool,
+    pub branches: Vec<BranchCardDto>,
+}
+
+impl RepositoryBranchCardsSnapshotDto {
+    pub fn from_snapshot(snapshot: &RepositorySnapshot) -> Self {
+        Self {
+            version: snapshot.version,
+            stale: snapshot.flags.stale,
+            loading: snapshot.flags.loading,
+            limited: snapshot.flags.limited,
+            branches: snapshot.branch_cards.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepositoryHeadDiffFileTreeSnapshotDto {
+    pub version: u64,
+    pub stale: bool,
+    pub loading: bool,
+    pub limited: bool,
+    pub combined_tree: Vec<DiffTreeNodeDto>,
+    pub staged_tree: Vec<DiffTreeNodeDto>,
+    pub changes_tree: Vec<DiffTreeNodeDto>,
+    pub staged_file_count: usize,
+    pub changes_file_count: usize,
+}
+
+impl RepositoryHeadDiffFileTreeSnapshotDto {
+    pub fn from_snapshot(snapshot: &RepositorySnapshot) -> Self {
+        let staged_file_count = snapshot
+            .status
+            .iter()
+            .filter(|entry| entry.index_status != "none")
+            .count();
+        let changes_file_count = snapshot
+            .status
+            .iter()
+            .filter(|entry| entry.worktree_status != "none" && entry.worktree_status != "ignored")
+            .count();
+        Self {
+            version: snapshot.version,
+            stale: snapshot.flags.stale,
+            loading: snapshot.flags.loading,
+            limited: snapshot.flags.limited,
+            combined_tree: snapshot.diff_file_tree.clone(),
+            staged_tree: snapshot.staged_diff_file_tree.clone(),
+            changes_tree: snapshot.changes_diff_file_tree.clone(),
+            staged_file_count,
+            changes_file_count,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status(path: &str, index_status: &str, worktree_status: &str) -> FileStatusDto {
+        FileStatusDto {
+            path: path.to_string(),
+            index_status: index_status.to_string(),
+            worktree_status: worktree_status.to_string(),
+        }
+    }
+
+    fn node(path: &str) -> DiffTreeNodeDto {
+        DiffTreeNodeDto {
+            id: path.to_string(),
+            name: path.to_string(),
+            path: path.to_string(),
+            node_type: "file".to_string(),
+            status: Some("modified".to_string()),
+            additions: Some(1),
+            deletions: Some(0),
+            children: Vec::new(),
+        }
+    }
+
+    fn parts(limited: bool) -> RepositorySnapshotParts {
+        RepositorySnapshotParts {
+            status: Vec::new(),
+            diff_stats: Vec::new(),
+            branch_cards: Vec::new(),
+            diff_file_tree: vec![node("combined.rs")],
+            staged_diff_file_tree: vec![node("staged.rs")],
+            changes_diff_file_tree: vec![node("changes.rs")],
+            limited,
+        }
+    }
+
+    #[test]
+    fn head_diff_file_tree_dto_exposes_combined_tree_from_snapshot() {
+        let snapshot = parts(false).into_snapshot(7);
+
+        let dto = RepositoryHeadDiffFileTreeSnapshotDto::from_snapshot(&snapshot);
+
+        assert_eq!(dto.version, 7);
+        assert_eq!(dto.combined_tree.len(), 1);
+        assert_eq!(dto.combined_tree[0].path, "combined.rs");
+        assert_eq!(dto.staged_tree[0].path, "staged.rs");
+        assert_eq!(dto.changes_tree[0].path, "changes.rs");
+    }
+
+    #[test]
+    fn head_diff_file_tree_counts_staged_changes_and_ignored_boundaries() {
+        let mut snapshot = parts(false).into_snapshot(3);
+        snapshot.status = vec![
+            status("staged-only.rs", "modified", "none"),
+            status("changes-only.rs", "none", "modified"),
+            status("both.rs", "new", "deleted"),
+            status("ignored", "none", "ignored"),
+            status("clean.rs", "none", "none"),
+        ];
+
+        let dto = RepositoryHeadDiffFileTreeSnapshotDto::from_snapshot(&snapshot);
+
+        assert_eq!(dto.staged_file_count, 2);
+        assert_eq!(dto.changes_file_count, 2);
+    }
+
+    #[test]
+    fn limited_flag_is_carried_into_snapshot() {
+        assert!(parts(true).into_snapshot(1).flags.limited);
+        assert!(!parts(false).into_snapshot(1).flags.limited);
+    }
+
+    #[test]
+    fn limited_flag_is_carried_into_all_snapshot_dtos_and_event() {
+        let snapshot = parts(true).into_snapshot(9);
+
+        assert!(RepositoryStatusSnapshotDto::from_snapshot(&snapshot).limited);
+        assert!(RepositoryDiffStatsSnapshotDto::from_snapshot(&snapshot).limited);
+        assert!(RepositoryBranchCardsSnapshotDto::from_snapshot(&snapshot).limited);
+        assert!(RepositoryHeadDiffFileTreeSnapshotDto::from_snapshot(&snapshot).limited);
+        assert!(
+            RepositorySnapshotChangedEvent::from_snapshot("/repo".to_string(), &snapshot).limited
+        );
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepositorySnapshotChangedEvent {
+    pub worktree_path: String,
+    pub version: u64,
+    pub stale: bool,
+    pub loading: bool,
+    pub limited: bool,
+}
+
+impl RepositorySnapshotChangedEvent {
+    pub fn from_snapshot(worktree_path: String, snapshot: &RepositorySnapshot) -> Self {
+        Self {
+            worktree_path,
+            version: snapshot.version,
+            stale: snapshot.flags.stale,
+            loading: snapshot.flags.loading,
+            limited: snapshot.flags.limited,
+        }
+    }
+}

--- a/src-tauri/src/usecase/repository_state/worker.rs
+++ b/src-tauri/src/usecase/repository_state/worker.rs
@@ -1,0 +1,168 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::runtime::{RepositoryStateInvalidationReceiver, RepositoryStateWorkerRuntime};
+use super::scanner::RepositoryScanner;
+use super::worktree::WorktreeState;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InvalidateReason {
+    pub file_change: bool,
+    pub git_change: bool,
+    pub branch_change: bool,
+    pub shutdown: bool,
+    pub path: Option<String>,
+}
+
+impl InvalidateReason {
+    pub fn initial() -> Self {
+        Self {
+            git_change: true,
+            branch_change: true,
+            ..Self::default()
+        }
+    }
+
+    pub fn file(path: Option<String>) -> Self {
+        Self {
+            file_change: true,
+            path,
+            ..Self::default()
+        }
+    }
+
+    pub fn git(branch_change: bool) -> Self {
+        Self {
+            git_change: true,
+            branch_change,
+            ..Self::default()
+        }
+    }
+
+    pub fn shutdown() -> Self {
+        Self {
+            shutdown: true,
+            ..Self::default()
+        }
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        self.file_change |= other.file_change;
+        self.git_change |= other.git_change;
+        self.branch_change |= other.branch_change;
+        self.shutdown |= other.shutdown;
+        if self.path.is_none() {
+            self.path = other.path;
+        }
+    }
+}
+
+pub(crate) async fn run_worker(
+    state: Arc<WorktreeState>,
+    scanner: Arc<dyn RepositoryScanner>,
+    runtime: Arc<dyn RepositoryStateWorkerRuntime>,
+    mut rx: Box<dyn RepositoryStateInvalidationReceiver>,
+    debounce: Duration,
+) {
+    while let Some(first_reason) = rx.recv().await {
+        if state.is_shutdown() || first_reason.shutdown {
+            break;
+        }
+        let mut reason =
+            collect_debounced_reasons(first_reason, rx.as_mut(), runtime.as_ref(), debounce).await;
+
+        loop {
+            if state.is_shutdown() || reason.shutdown {
+                return;
+            }
+            let start_generation = state.requested_generation();
+            state.mark_refresh_started(&reason);
+
+            let repo_path = state.worktree_path().to_string();
+            let scanner = scanner.clone();
+            let scan_result = runtime.scan(scanner.clone(), repo_path).await;
+
+            let current_generation = state.requested_generation();
+            if state.is_shutdown() {
+                return;
+            }
+            if current_generation != start_generation {
+                reason.merge(collect_pending_reasons(rx.as_mut()));
+                if debounce > Duration::ZERO {
+                    reason =
+                        collect_debounced_reasons(reason, rx.as_mut(), runtime.as_ref(), debounce)
+                            .await;
+                }
+                continue;
+            }
+
+            state.set_refreshing(false);
+
+            match scan_result {
+                Ok(parts) => {
+                    let snapshot = state.commit_snapshot(parts, start_generation);
+                    let names: Vec<String> = snapshot
+                        .branch_cards
+                        .iter()
+                        .map(|card| card.name.clone())
+                        .collect();
+                    if let Err(err) =
+                        scanner.prune_stale_branch_bases(state.worktree_path(), &names)
+                    {
+                        log::warn!(
+                            "repository snapshot branch base GC failed for {}: {err}",
+                            state.worktree_path()
+                        );
+                    }
+                    state.notify_snapshot_changed(snapshot, reason);
+                }
+                Err(err) => {
+                    log::warn!(
+                        "repository snapshot scan failed for {}: {err}",
+                        state.worktree_path()
+                    );
+                    state.mark_scan_failed();
+                }
+            }
+            break;
+        }
+    }
+}
+
+async fn collect_debounced_reasons(
+    mut reason: InvalidateReason,
+    rx: &mut dyn RepositoryStateInvalidationReceiver,
+    runtime: &dyn RepositoryStateWorkerRuntime,
+    debounce: Duration,
+) -> InvalidateReason {
+    if debounce > Duration::ZERO {
+        runtime.sleep(debounce).await;
+    }
+    reason.merge(collect_pending_reasons(rx));
+    reason
+}
+
+fn collect_pending_reasons(rx: &mut dyn RepositoryStateInvalidationReceiver) -> InvalidateReason {
+    let mut reason = InvalidateReason::default();
+    while let Some(next) = rx.try_recv() {
+        reason.merge(next);
+    }
+    reason
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasons_merge_flags_and_keep_first_path() {
+        let mut a = InvalidateReason::file(Some("a.txt".to_string()));
+        a.merge(InvalidateReason::git(true));
+        a.merge(InvalidateReason::file(Some("b.txt".to_string())));
+
+        assert!(a.file_change);
+        assert!(a.git_change);
+        assert!(a.branch_change);
+        assert_eq!(a.path.as_deref(), Some("a.txt"));
+    }
+}

--- a/src-tauri/src/usecase/repository_state/worktree.rs
+++ b/src-tauri/src/usecase/repository_state/worktree.rs
@@ -1,0 +1,637 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::{Mutex, RwLock};
+
+use super::error::RepositoryStateError;
+use super::runtime::{RepositoryStateInvalidationSender, RepositoryStateWorkerRuntime};
+use super::scanner::RepositoryScanner;
+use super::snapshot::{RepositorySnapshot, RepositorySnapshotParts};
+use super::worker::{run_worker, InvalidateReason};
+
+pub trait RepositoryStateWatchSession: Send + Sync {}
+
+impl<T> RepositoryStateWatchSession for T where T: Send + Sync {}
+
+pub trait RepositoryStateWatcher: Send + Sync {
+    fn next_watcher_id(&self) -> u64;
+
+    fn start_watchers(
+        &self,
+        state: Arc<WorktreeState>,
+    ) -> Result<Box<dyn RepositoryStateWatchSession>, RepositoryStateError>;
+}
+
+#[derive(Clone)]
+pub struct SnapshotNotification {
+    pub worktree_paths: Vec<String>,
+    pub snapshot: Arc<RepositorySnapshot>,
+    pub file_watcher_ids: Vec<u64>,
+    pub reason: InvalidateReason,
+    pub phase: SnapshotNotificationPhase,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotNotificationPhase {
+    RefreshStarted,
+    SnapshotCommitted,
+}
+
+pub trait RepositoryStateNotifier: Send + Sync {
+    fn snapshot_changed(&self, notification: SnapshotNotification);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatchSubscriptionKind {
+    File,
+    Git,
+}
+
+#[derive(Debug, Clone)]
+struct WatchSubscription {
+    id: u64,
+    kind: WatchSubscriptionKind,
+    worktree_path: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct NotificationTargets {
+    worktree_paths: Vec<String>,
+    file_watcher_ids: Vec<u64>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+pub struct NoopRepositoryStateNotifier;
+
+#[cfg(test)]
+impl RepositoryStateNotifier for NoopRepositoryStateNotifier {
+    fn snapshot_changed(&self, _notification: SnapshotNotification) {}
+}
+
+#[cfg(test)]
+#[derive(Default)]
+pub struct NoopRepositoryStateWatcher;
+
+#[cfg(test)]
+impl RepositoryStateWatcher for NoopRepositoryStateWatcher {
+    fn next_watcher_id(&self) -> u64 {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        NEXT_ID.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn start_watchers(
+        &self,
+        _state: Arc<WorktreeState>,
+    ) -> Result<Box<dyn RepositoryStateWatchSession>, RepositoryStateError> {
+        Ok(Box::new(()))
+    }
+}
+
+pub struct WorktreeState {
+    worktree_path: String,
+    snapshot: RwLock<Arc<RepositorySnapshot>>,
+    version: AtomicU64,
+    requested_generation: AtomicU64,
+    applied_generation: AtomicU64,
+    refreshing: AtomicBool,
+    shutdown: AtomicBool,
+    invalidate_tx: Box<dyn RepositoryStateInvalidationSender>,
+    watchers: Mutex<Option<Box<dyn RepositoryStateWatchSession>>>,
+    subscriptions: Mutex<HashMap<u64, WatchSubscription>>,
+    notifier: Arc<dyn RepositoryStateNotifier>,
+}
+
+impl WorktreeState {
+    pub fn new(
+        worktree_path: String,
+        scanner: Arc<dyn RepositoryScanner>,
+        notifier: Arc<dyn RepositoryStateNotifier>,
+        runtime: Arc<dyn RepositoryStateWorkerRuntime>,
+        debounce: Duration,
+    ) -> Arc<Self> {
+        let (invalidate_tx, invalidate_rx) = runtime.invalidation_channel();
+        let state = Arc::new(Self {
+            worktree_path,
+            snapshot: RwLock::new(Arc::new(RepositorySnapshot::loading())),
+            version: AtomicU64::new(0),
+            requested_generation: AtomicU64::new(0),
+            applied_generation: AtomicU64::new(0),
+            refreshing: AtomicBool::new(false),
+            shutdown: AtomicBool::new(false),
+            invalidate_tx,
+            watchers: Mutex::new(None),
+            subscriptions: Mutex::new(HashMap::new()),
+            notifier,
+        });
+        runtime.spawn_worker(Box::pin(run_worker(
+            state.clone(),
+            scanner,
+            runtime.clone(),
+            invalidate_rx,
+            debounce,
+        )));
+        state
+    }
+
+    pub fn worktree_path(&self) -> &str {
+        &self.worktree_path
+    }
+
+    pub fn requested_generation(&self) -> u64 {
+        self.requested_generation.load(Ordering::SeqCst)
+    }
+
+    pub fn is_shutdown(&self) -> bool {
+        self.shutdown.load(Ordering::SeqCst)
+    }
+
+    pub fn set_refreshing(&self, refreshing: bool) {
+        self.refreshing.store(refreshing, Ordering::SeqCst);
+    }
+
+    pub fn add_subscription(&self, id: u64, kind: WatchSubscriptionKind, worktree_path: String) {
+        self.subscriptions.lock().insert(
+            id,
+            WatchSubscription {
+                id,
+                kind,
+                worktree_path,
+            },
+        );
+    }
+
+    pub fn release_subscription(&self, id: u64) -> bool {
+        self.subscriptions.lock().remove(&id).is_some()
+    }
+
+    pub fn subscriber_count(&self) -> usize {
+        self.subscriptions.lock().len()
+    }
+
+    pub fn shutdown(&self) {
+        if self.shutdown.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        self.watchers.lock().take();
+        let _ = self.invalidate_tx.send(InvalidateReason::shutdown());
+    }
+
+    pub fn start_watchers(
+        self: &Arc<Self>,
+        watcher: &dyn RepositoryStateWatcher,
+    ) -> Result<(), RepositoryStateError> {
+        let mut watchers = self.watchers.lock();
+        if watchers.is_some() {
+            return Ok(());
+        }
+
+        *watchers = Some(watcher.start_watchers(self.clone())?);
+        drop(watchers);
+
+        self.invalidate(InvalidateReason::initial());
+        Ok(())
+    }
+
+    pub fn invalidate(&self, reason: InvalidateReason) {
+        if self.is_shutdown() {
+            return;
+        }
+        self.requested_generation.fetch_add(1, Ordering::SeqCst);
+        if self.invalidate_tx.send(reason).is_err() {
+            log::warn!(
+                "repository snapshot worker is stopped for {}",
+                self.worktree_path
+            );
+        }
+    }
+
+    pub fn snapshot_for_read(&self) -> Arc<RepositorySnapshot> {
+        let snapshot = self.snapshot.read().clone();
+        if self.refreshing.load(Ordering::SeqCst) {
+            let stale = snapshot.version > 0;
+            return Arc::new(snapshot.with_read_flags(stale, true));
+        }
+        snapshot
+    }
+
+    pub(crate) fn mark_refresh_started(&self, reason: &InvalidateReason) {
+        self.refreshing.store(true, Ordering::SeqCst);
+        let snapshot = self.snapshot_for_read();
+        let targets = self.notification_targets();
+        self.notifier.snapshot_changed(SnapshotNotification {
+            worktree_paths: targets.worktree_paths,
+            snapshot,
+            file_watcher_ids: targets.file_watcher_ids,
+            reason: reason.clone(),
+            phase: SnapshotNotificationPhase::RefreshStarted,
+        });
+    }
+
+    pub(crate) fn commit_snapshot(
+        &self,
+        parts: RepositorySnapshotParts,
+        generation: u64,
+    ) -> Arc<RepositorySnapshot> {
+        let version = self.version.fetch_add(1, Ordering::SeqCst) + 1;
+        let snapshot = Arc::new(parts.into_snapshot(version));
+        *self.snapshot.write() = snapshot.clone();
+        self.applied_generation.store(generation, Ordering::SeqCst);
+        snapshot
+    }
+
+    pub(crate) fn notify_snapshot_changed(
+        &self,
+        snapshot: Arc<RepositorySnapshot>,
+        reason: InvalidateReason,
+    ) {
+        let targets = self.notification_targets();
+        self.notifier.snapshot_changed(SnapshotNotification {
+            worktree_paths: targets.worktree_paths,
+            snapshot,
+            file_watcher_ids: targets.file_watcher_ids,
+            reason,
+            phase: SnapshotNotificationPhase::SnapshotCommitted,
+        });
+    }
+
+    pub(crate) fn mark_scan_failed(&self) {
+        self.refreshing.store(false, Ordering::SeqCst);
+        let current = self.snapshot.read().clone();
+        if current.version == 0 && current.flags.loading {
+            *self.snapshot.write() = Arc::new(current.with_read_flags(false, false));
+        }
+    }
+
+    fn notification_targets(&self) -> NotificationTargets {
+        let subscriptions = self.subscriptions.lock();
+        let mut targets = NotificationTargets::default();
+        for subscription in subscriptions.values() {
+            if !targets
+                .worktree_paths
+                .iter()
+                .any(|path| path == &subscription.worktree_path)
+            {
+                targets
+                    .worktree_paths
+                    .push(subscription.worktree_path.clone());
+            }
+            if subscription.kind == WatchSubscriptionKind::File {
+                targets.file_watcher_ids.push(subscription.id);
+            }
+        }
+        if targets.worktree_paths.is_empty() {
+            targets.worktree_paths.push(self.worktree_path.clone());
+        }
+        targets
+    }
+}
+
+impl Drop for WorktreeState {
+    fn drop(&mut self) {
+        self.watchers.lock().take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::usecase::repository_dto::{BranchCardDto, FileDiffStatDto, FileStatusDto};
+    use crate::usecase::repository_state::runtime::tests_support::TestRepositoryStateWorkerRuntime;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
+    use std::sync::mpsc as std_mpsc;
+
+    #[derive(Default)]
+    struct CapturingNotifier {
+        notifications: parking_lot::Mutex<Vec<SnapshotNotification>>,
+    }
+
+    impl CapturingNotifier {
+        fn take(&self) -> Vec<SnapshotNotification> {
+            std::mem::take(&mut *self.notifications.lock())
+        }
+    }
+
+    impl RepositoryStateNotifier for CapturingNotifier {
+        fn snapshot_changed(&self, notification: SnapshotNotification) {
+            self.notifications.lock().push(notification);
+        }
+    }
+
+    struct FakeScanner {
+        scans: AtomicUsize,
+        value: parking_lot::Mutex<String>,
+        fail: AtomicBool,
+        prunes: parking_lot::Mutex<Vec<Vec<String>>>,
+        sleep: Duration,
+        on_scan: parking_lot::Mutex<Option<Box<dyn Fn(usize) + Send + Sync>>>,
+    }
+
+    impl FakeScanner {
+        fn new(value: &str) -> Self {
+            Self {
+                scans: AtomicUsize::new(0),
+                value: parking_lot::Mutex::new(value.to_string()),
+                fail: AtomicBool::new(false),
+                prunes: parking_lot::Mutex::new(Vec::new()),
+                sleep: Duration::ZERO,
+                on_scan: parking_lot::Mutex::new(None),
+            }
+        }
+
+        fn with_sleep(mut self, sleep: Duration) -> Self {
+            self.sleep = sleep;
+            self
+        }
+
+        fn set_value(&self, value: &str) {
+            *self.value.lock() = value.to_string();
+        }
+
+        fn scan_count(&self) -> usize {
+            self.scans.load(Ordering::SeqCst)
+        }
+
+        fn set_fail(&self, fail: bool) {
+            self.fail.store(fail, Ordering::SeqCst);
+        }
+
+        fn take_prune_calls(&self) -> Vec<Vec<String>> {
+            std::mem::take(&mut *self.prunes.lock())
+        }
+
+        fn set_on_scan(&self, f: impl Fn(usize) + Send + Sync + 'static) {
+            *self.on_scan.lock() = Some(Box::new(f));
+        }
+    }
+
+    impl RepositoryScanner for FakeScanner {
+        fn scan(&self, _repo_path: &str) -> Result<RepositorySnapshotParts, RepositoryStateError> {
+            let call = self.scans.fetch_add(1, Ordering::SeqCst) + 1;
+            if let Some(on_scan) = self.on_scan.lock().as_ref() {
+                on_scan(call);
+            }
+            let value = self.value.lock().clone();
+            if self.sleep > Duration::ZERO {
+                std::thread::sleep(self.sleep);
+            }
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(RepositoryStateError::Watcher("scan failed".to_string()));
+            }
+            Ok(RepositorySnapshotParts {
+                status: vec![FileStatusDto {
+                    path: value,
+                    index_status: "none".to_string(),
+                    worktree_status: "modified".to_string(),
+                }],
+                diff_stats: vec![FileDiffStatDto {
+                    path: "file.txt".to_string(),
+                    index_additions: 0,
+                    index_deletions: 0,
+                    wt_additions: 1,
+                    wt_deletions: 0,
+                }],
+                branch_cards: vec![BranchCardDto {
+                    name: "main".to_string(),
+                    is_main_worktree: true,
+                    worktree_path: Some("/repo".to_string()),
+                    dirty_count: 1,
+                    is_merged: false,
+                    ahead: 0,
+                    behind: 0,
+                    has_upstream: false,
+                    base_ahead: 0,
+                }],
+                diff_file_tree: Vec::new(),
+                staged_diff_file_tree: Vec::new(),
+                changes_diff_file_tree: Vec::new(),
+                limited: false,
+            })
+        }
+
+        fn status_with_ignored(
+            &self,
+            _repo_path: &str,
+        ) -> Result<Vec<FileStatusDto>, RepositoryStateError> {
+            Ok(vec![FileStatusDto {
+                path: "ignored.txt".to_string(),
+                index_status: "none".to_string(),
+                worktree_status: "ignored".to_string(),
+            }])
+        }
+
+        fn prune_stale_branch_bases(
+            &self,
+            _repo_path: &str,
+            existing_branches: &[String],
+        ) -> Result<(), RepositoryStateError> {
+            self.prunes.lock().push(existing_branches.to_vec());
+            Ok(())
+        }
+    }
+
+    fn test_state(scanner: Arc<dyn RepositoryScanner>, debounce: Duration) -> Arc<WorktreeState> {
+        WorktreeState::new(
+            "/repo".to_string(),
+            scanner,
+            Arc::new(NoopRepositoryStateNotifier),
+            Arc::new(TestRepositoryStateWorkerRuntime),
+            debounce,
+        )
+    }
+
+    fn test_state_with_notifier(
+        scanner: Arc<dyn RepositoryScanner>,
+        notifier: Arc<dyn RepositoryStateNotifier>,
+    ) -> Arc<WorktreeState> {
+        WorktreeState::new(
+            "/repo".to_string(),
+            scanner,
+            notifier,
+            Arc::new(TestRepositoryStateWorkerRuntime),
+            Duration::ZERO,
+        )
+    }
+
+    async fn wait_for_version(state: &WorktreeState, version: u64) -> Arc<RepositorySnapshot> {
+        for _ in 0..100 {
+            let snapshot = state.snapshot_for_read();
+            if snapshot.version >= version && !snapshot.flags.loading {
+                return snapshot;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out waiting for version {version}");
+    }
+
+    #[tokio::test]
+    async fn loading_snapshot_becomes_ready_after_scan() {
+        let scanner = Arc::new(FakeScanner::new("file.txt"));
+        let state = test_state(scanner.clone(), Duration::ZERO);
+
+        let initial = state.snapshot_for_read();
+        assert_eq!(initial.version, 0);
+        assert!(initial.flags.loading);
+
+        state.invalidate(InvalidateReason::initial());
+        let ready = wait_for_version(&state, 1).await;
+
+        assert_eq!(ready.version, 1);
+        assert!(!ready.flags.loading);
+        assert!(!ready.flags.stale);
+        assert_eq!(scanner.take_prune_calls(), vec![vec!["main".to_string()]]);
+    }
+
+    #[tokio::test]
+    async fn snapshot_is_stale_while_refresh_is_running() {
+        let scanner = Arc::new(FakeScanner::new("first.txt").with_sleep(Duration::from_millis(80)));
+        let state = test_state(scanner.clone(), Duration::ZERO);
+
+        state.invalidate(InvalidateReason::initial());
+        let first = wait_for_version(&state, 1).await;
+        assert_eq!(first.status[0].path, "first.txt");
+
+        scanner.set_value("second.txt");
+        state.invalidate(InvalidateReason::git(false));
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let stale = state.snapshot_for_read();
+        assert_eq!(stale.version, 1);
+        assert!(stale.flags.loading);
+        assert!(stale.flags.stale);
+
+        let second = wait_for_version(&state, 2).await;
+        assert_eq!(second.status[0].path, "second.txt");
+        assert!(!second.flags.stale);
+    }
+
+    #[tokio::test]
+    async fn refresh_start_notification_exposes_loading_and_stale_flags() {
+        let scanner = Arc::new(FakeScanner::new("first.txt").with_sleep(Duration::from_millis(80)));
+        let notifier = Arc::new(CapturingNotifier::default());
+        let state = test_state_with_notifier(scanner.clone(), notifier.clone());
+
+        state.invalidate(InvalidateReason::initial());
+        wait_for_version(&state, 1).await;
+        notifier.take();
+
+        scanner.set_value("second.txt");
+        state.invalidate(InvalidateReason::git(false));
+
+        for _ in 0..100 {
+            let notifications = notifier.take();
+            if let Some(started) = notifications
+                .iter()
+                .find(|n| n.phase == SnapshotNotificationPhase::RefreshStarted)
+            {
+                assert_eq!(started.snapshot.version, 1);
+                assert!(started.snapshot.flags.loading);
+                assert!(started.snapshot.flags.stale);
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        panic!("timed out waiting for refresh start notification");
+    }
+
+    #[tokio::test]
+    async fn debounce_groups_multiple_invalidations_into_one_scan() {
+        let scanner = Arc::new(FakeScanner::new("file.txt"));
+        let state = test_state(scanner.clone(), Duration::from_millis(40));
+
+        state.invalidate(InvalidateReason::file(None));
+        state.invalidate(InvalidateReason::file(None));
+        state.invalidate(InvalidateReason::git(false));
+        wait_for_version(&state, 1).await;
+
+        assert_eq!(scanner.scan_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn superseded_scan_result_is_not_committed() {
+        let scanner = Arc::new(FakeScanner::new("old.txt").with_sleep(Duration::from_millis(80)));
+        let state = test_state(scanner.clone(), Duration::ZERO);
+
+        state.invalidate(InvalidateReason::initial());
+        wait_for_version(&state, 1).await;
+
+        let (tx, rx) = std_mpsc::channel();
+        scanner.set_on_scan(move |call| {
+            if call == 2 {
+                tx.send(()).unwrap();
+            }
+        });
+
+        state.invalidate(InvalidateReason::git(false));
+        tokio::task::spawn_blocking(move || rx.recv_timeout(Duration::from_secs(1)))
+            .await
+            .unwrap()
+            .unwrap();
+        scanner.set_value("new.txt");
+        state.invalidate(InvalidateReason::file(None));
+
+        let latest = wait_for_version(&state, 2).await;
+        assert_eq!(latest.status[0].path, "new.txt");
+        assert!(scanner.scan_count() >= 3);
+        assert_eq!(scanner.take_prune_calls().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_scan_is_not_pruned_or_committed() {
+        let scanner = Arc::new(FakeScanner::new("file.txt"));
+        scanner.set_fail(true);
+        let state = test_state(scanner.clone(), Duration::ZERO);
+
+        state.invalidate(InvalidateReason::initial());
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let snapshot = state.snapshot_for_read();
+        assert_eq!(snapshot.version, 0);
+        assert!(!snapshot.flags.loading);
+        assert!(scanner.take_prune_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cold_start_gc_runs_after_committed_scan_with_complete_branch_names() {
+        let (dir, repo) = crate::git::test_helpers::create_test_repo();
+        crate::git::test_helpers::create_initial_commit(&repo);
+        let branch_name = repo.head().unwrap().shorthand().unwrap().to_string();
+        {
+            let mut config = repo.config().unwrap();
+            config
+                .set_str(&format!("branch.{branch_name}.releash-base"), "main")
+                .unwrap();
+            config
+                .set_str("branch.deleted.releash-base", "main")
+                .unwrap();
+        }
+
+        let repository = Arc::new(crate::adaptor::controller::wiring::build_repository_usecase());
+        let code = Arc::new(crate::adaptor::controller::wiring::build_code_usecase());
+        let scanner = Arc::new(super::super::scanner::DefaultRepositoryScanner::new(
+            repository, code,
+        ));
+        let state = WorktreeState::new(
+            dir.path().to_str().unwrap().to_string(),
+            scanner,
+            Arc::new(NoopRepositoryStateNotifier),
+            Arc::new(TestRepositoryStateWorkerRuntime),
+            Duration::ZERO,
+        );
+
+        state.invalidate(InvalidateReason::initial());
+        wait_for_version(&state, 1).await;
+
+        let config = repo.config().unwrap();
+        assert_eq!(
+            config
+                .get_string(&format!("branch.{branch_name}.releash-base"))
+                .unwrap(),
+            "main"
+        );
+        assert!(config.get_string("branch.deleted.releash-base").is_err());
+    }
+}

--- a/src-tauri/src/usecase/repository_usecase.rs
+++ b/src-tauri/src/usecase/repository_usecase.rs
@@ -9,8 +9,8 @@
 use std::sync::Arc;
 
 use crate::domain::repository::{
-    Branch, BranchRepository, Commit, FileDiffStat, FileStatus, GitConfigRepository, LogRepository,
-    RepoLocator, StatusRepository, WorktreeRepository,
+    Branch, BranchRepository, Commit, FileStatus, GitConfigRepository, LogRepository, RepoLocator,
+    RepositoryStatusScan, StatusRepository, WorktreeRepository,
 };
 
 use super::repository_dto::{BranchCardDto, WorktreeEntryDto};
@@ -136,25 +136,24 @@ impl RepositoryUsecase {
 
     // ── status（読み取り） ──
 
-    pub fn get_git_status(&self, repo_path: &str) -> Result<Vec<FileStatus>, UsecaseError> {
-        Ok(self.status.status(repo_path)?)
-    }
-
-    pub fn get_status_diff_stats(
+    pub fn get_git_status_include_ignored(
         &self,
         repo_path: &str,
-    ) -> Result<Vec<FileDiffStat>, UsecaseError> {
-        Ok(self.status.diff_stats(repo_path)?)
+    ) -> Result<Vec<FileStatus>, UsecaseError> {
+        Ok(self.status.status_with_options(repo_path, true)?)
+    }
+
+    pub fn get_repository_status_scan(
+        &self,
+        repo_path: &str,
+    ) -> Result<RepositoryStatusScan, UsecaseError> {
+        Ok(self.status.status_scan(repo_path)?)
     }
 
     // ── worktree（読み取り） ──
 
     pub fn get_main_repo_path(&self, any_path: &str) -> Result<String, UsecaseError> {
         Ok(self.worktree.main_repo_path(any_path)?)
-    }
-
-    pub fn get_worktree_dirty_count(&self, worktree_path: &str) -> Result<u32, UsecaseError> {
-        Ok(self.worktree.dirty_count(worktree_path)?)
     }
 
     /// worktree 一覧の read model を組み立てる。worktree 識別情報（worktree 集約）に
@@ -181,20 +180,6 @@ impl RepositoryUsecase {
             });
         }
         Ok(entries)
-    }
-
-    /// worktree のパス一覧のみを返す軽量読み取り。存在判定など、表示用の
-    /// `dirty_count`（status 全走査）/ `base_branch`（git_config 読み）を必要としない
-    /// 用途のために、worktree 集約の slim な一覧だけを取得する（[`list_worktrees`] の
-    /// 重い合成を避ける）。
-    #[allow(dead_code)]
-    pub fn list_worktree_paths(&self, repo_path: &str) -> Result<Vec<String>, UsecaseError> {
-        Ok(self
-            .worktree
-            .list(repo_path)?
-            .into_iter()
-            .map(|wt| wt.path)
-            .collect())
     }
 
     // ── worktree（書き込み） ──
@@ -304,26 +289,32 @@ impl RepositoryUsecase {
         Ok(self.locator.git_dir(file_path)?)
     }
 
-    // ── read model（read + GC のオーケストレーション） ──
-
-    /// ブランチカード一覧を取得する。read model（DTO）の構築は読み取りクエリサービスへ
-    /// 委譲し、取得後に現存しないブランチの `releash-base` を GC する（read + write の
-    /// オーケストレーションは usecase の責務）。
-    pub fn list_branches_with_status(
+    /// ブランチカード read model を副作用なしで取得する。
+    ///
+    /// snapshot scanner は watcher invalidate から実行される read model 更新経路なので、
+    /// config GC のような書き込みを伴う [`list_branches_with_status`] ではなくこちらを使う。
+    #[cfg(test)]
+    pub fn list_branches_with_status_read_only(
         &self,
         repo_path: &str,
     ) -> Result<Vec<BranchCardDto>, UsecaseError> {
-        let cards = self.query.list_branches_with_status(repo_path)?;
-        let names: Vec<String> = cards.iter().map(|c| c.name.clone()).collect();
-        self.prune_stale_branch_bases(repo_path, &names)?;
-        Ok(cards)
+        self.query.list_branches_with_status(repo_path)
+    }
+
+    pub fn list_branches_with_status_for_scan(
+        &self,
+        repo_path: &str,
+        current_dirty_count: usize,
+    ) -> Result<Vec<BranchCardDto>, UsecaseError> {
+        self.query
+            .list_branches_with_status_for_scan(repo_path, current_dirty_count)
     }
 }
 
 #[cfg(test)]
 mod repository_usecase_tests {
     use super::*;
-    use crate::domain::repository::{RepositoryError, Worktree};
+    use crate::domain::repository::{RepositoryError, RepositoryStatusScan, Worktree};
     use crate::usecase::repository_query_service::BranchCardQuery;
     use parking_lot::Mutex;
 
@@ -381,11 +372,20 @@ mod repository_usecase_tests {
     }
 
     impl StatusRepository for FakeRepo {
-        fn status(&self, _repo_path: &str) -> Result<Vec<FileStatus>, RepositoryError> {
+        fn status_with_options(
+            &self,
+            _repo_path: &str,
+            include_ignored: bool,
+        ) -> Result<Vec<FileStatus>, RepositoryError> {
+            let _ = include_ignored;
             Ok(Vec::new())
         }
-        fn diff_stats(&self, _repo_path: &str) -> Result<Vec<FileDiffStat>, RepositoryError> {
-            Ok(Vec::new())
+        fn status_scan(&self, _repo_path: &str) -> Result<RepositoryStatusScan, RepositoryError> {
+            Ok(RepositoryStatusScan {
+                status: Vec::new(),
+                diff_stats: Vec::new(),
+                dirty_count: 0,
+            })
         }
     }
 
@@ -608,18 +608,6 @@ mod repository_usecase_tests {
     }
 
     #[test]
-    fn test_worktreeパス一覧はパスのみを返す() {
-        // 軽量読み取りは worktree 集約の path のみを返し、dirty_count（status）/
-        // base_branch（git_config）の合成を行わない。
-        let fake = Arc::new(FakeRepo {
-            worktrees: vec![wt("/wt-main", "main", true), wt("/wt-feat", "feat", false)],
-            ..<FakeRepo as Default>::default()
-        });
-        let paths = usecase(fake).list_worktree_paths("/r").unwrap();
-        assert_eq!(paths, vec!["/wt-main".to_string(), "/wt-feat".to_string()]);
-    }
-
-    #[test]
     fn test_worktree作成エラーをusecaseエラーへ変換する() {
         let fake = Arc::new(FakeRepo {
             fail_create_worktree: true,
@@ -741,12 +729,11 @@ mod repository_usecase_tests {
     }
 
     #[test]
-    fn test_ブランチカード一覧取得後にgcする() {
+    fn test_read_onlyブランチカード一覧取得ではgcしない() {
         let fake = Arc::new(<FakeRepo as Default>::default());
         usecase(fake.clone())
-            .list_branches_with_status("/r")
+            .list_branches_with_status_read_only("/r")
             .unwrap();
-        // read model は空でも、取得後に現存ブランチ名（空）で GC が走る
-        assert_eq!(*fake.prune_calls.lock(), vec![Vec::<String>::new()]);
+        assert!(fake.prune_calls.lock().is_empty());
     }
 }

--- a/src-tauri/src/usecase/workflow/mod.rs
+++ b/src-tauri/src/usecase/workflow/mod.rs
@@ -950,9 +950,14 @@ mod tests {
             "std::net::",
             "std::process::",
             "use std::fs",
+            "canonicalize(",
         ];
         assert_no_forbidden_production_patterns("domain/workflow", &external_dependency_patterns);
         assert_no_forbidden_production_patterns("usecase/workflow", &external_dependency_patterns);
+        assert_no_forbidden_production_patterns(
+            "usecase/repository_state",
+            &external_dependency_patterns,
+        );
     }
 
     #[test]

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -1,80 +1,15 @@
 use notify_debouncer_mini::notify::RecursiveMode;
 use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
 use parking_lot::Mutex;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::adaptor::controller::state::AppState;
-use crate::protocol::{BranchCardMsg, BranchListSync, WsMessage};
-use crate::usecase::repository_usecase::RepositoryUsecase;
-use crate::ws_bridge::WsBroadcaster;
-
-struct GitWatchPaths {
-    main_repo: String,
-    refs_heads: PathBuf,
-    head_file: PathBuf,
-    index_file: PathBuf,
-    worktrees_dir: PathBuf,
-}
-
-fn resolve_git_watch_paths(
-    usecase: &RepositoryUsecase,
-    repo_path: &str,
-) -> Result<GitWatchPaths, String> {
-    let main_repo = usecase
-        .get_main_repo_path(repo_path)
-        .map_err(|e| format!("Failed to resolve main repo: {e}"))?;
-    let git_dir = git2::Repository::open(&main_repo)
-        .map_err(|e| format!("Failed to open repo: {e}"))?
-        .path()
-        .to_path_buf();
-
-    Ok(GitWatchPaths {
-        main_repo,
-        refs_heads: git_dir.join("refs").join("heads"),
-        head_file: git_dir.join("HEAD"),
-        index_file: git_dir.join("index"),
-        worktrees_dir: git_dir.join("worktrees"),
-    })
-}
-
-fn canonicalize_event_path(path: &std::path::Path) -> Option<String> {
-    if let Ok(canonical) = path.canonicalize() {
-        return Some(canonical.to_string_lossy().to_string());
-    }
-    let parent = path.parent()?;
-    let file_name = path.file_name()?;
-    let canonical_parent = parent.canonicalize().ok()?;
-    Some(
-        canonical_parent
-            .join(file_name)
-            .to_string_lossy()
-            .to_string(),
-    )
-}
-
-static WATCHER_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
-
-fn generate_watcher_id() -> u64 {
-    WATCHER_ID_COUNTER.fetch_add(1, Ordering::SeqCst)
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct FileChangeEvent {
-    pub watcher_id: u64,
-    pub path: String,
-    pub kind: String,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct GitStatusChangedEvent {
-    pub repo_path: String,
-}
+use crate::adaptor::gateway::repository::watch::{
+    canonicalize_event_path, generate_watcher_id, FileChangeEvent,
+};
 
 struct WatcherSession {
     _debouncer: notify_debouncer_mini::Debouncer<notify_debouncer_mini::notify::RecommendedWatcher>,
@@ -91,6 +26,17 @@ pub fn start_watching(
     state: State<'_, FileWatcherManager>,
     path: String,
 ) -> Result<u64, String> {
+    if let Some(app_state) = app.try_state::<AppState>() {
+        match app_state
+            .repository_state
+            .start_file_watching_if_repository(&path)
+        {
+            Ok(Some(watcher_id)) => return Ok(watcher_id),
+            Ok(None) => {}
+            Err(err) => return Err(err.to_string()),
+        }
+    }
+
     let watcher_id = generate_watcher_id();
     let watch_path = PathBuf::from(&path);
 
@@ -150,321 +96,35 @@ pub fn start_watching(
     Ok(watcher_id)
 }
 
-fn classify_git_dir_events(events: &[notify_debouncer_mini::DebouncedEvent]) -> (bool, bool) {
-    let has_branch_change = events.iter().any(|e| {
-        let p = e.path.to_string_lossy().replace('\\', "/");
-        p.contains("/refs/heads/") || e.path.file_name().is_some_and(|n| n == "HEAD")
-    });
-    let has_index_change = events.iter().any(|e| {
-        let file_name = e
-            .path
-            .file_name()
-            .map(|n| n.to_string_lossy())
-            .unwrap_or_default();
-        file_name == "index" || file_name == "index.lock" || file_name == "COMMIT_EDITMSG"
-    });
-    (has_branch_change, has_index_change)
-}
-
-fn build_branch_list_sync(usecase: &RepositoryUsecase, repo_path: &str) -> Option<WsMessage> {
-    // ブランチ一覧取得後の GC（現存しないブランチの releash-base 掃除）は
-    // usecase の list_branches_with_status が内包する。
-    let branches = usecase.list_branches_with_status(repo_path).ok()?;
-    let branch_msgs: Vec<BranchCardMsg> = branches.into_iter().map(BranchCardMsg::from).collect();
-    Some(WsMessage::BranchListSync(BranchListSync {
-        branches: branch_msgs,
-    }))
-}
-
 #[tauri::command]
 pub fn start_git_dir_watching(
     app: AppHandle,
-    state: State<'_, FileWatcherManager>,
+    _state: State<'_, FileWatcherManager>,
     repo_path: String,
 ) -> Result<u64, String> {
-    let watcher_id = generate_watcher_id();
-
-    // composition root（lib.rs）で組み立てた repository usecase を AppState から
-    // 受け取って再利用する（controller 配線を watcher へ漏らさない）。
-    let usecase = app.state::<AppState>().repository_usecase.clone();
-
-    let paths = resolve_git_watch_paths(&usecase, &repo_path)?;
-
-    if !paths.refs_heads.exists() {
-        return Err(format!(
-            "refs/heads not found: {}",
-            paths.refs_heads.display()
-        ));
-    }
-
-    let app_clone = app.clone();
-    let main_repo_clone = paths.main_repo.clone();
-    let repo_path_clone = repo_path;
-    let usecase_for_events: Arc<RepositoryUsecase> = usecase;
-
-    let debouncer = new_debouncer(
-        Duration::from_millis(500),
-        move |res: Result<
-            Vec<notify_debouncer_mini::DebouncedEvent>,
-            notify_debouncer_mini::notify::Error,
-        >| {
-            let events = match res {
-                Ok(events) => events,
-                Err(e) => {
-                    eprintln!("Git dir watcher error: {:?}", e);
-                    return;
-                }
-            };
-            let (has_branch_change, has_index_change) = classify_git_dir_events(&events);
-
-            if has_branch_change {
-                if let Some(sync_msg) =
-                    build_branch_list_sync(&usecase_for_events, &main_repo_clone)
-                {
-                    let _ = app_clone.emit("branch-list-sync", ());
-                    if let Some(ws) = app_clone.try_state::<std::sync::Arc<WsBroadcaster>>() {
-                        ws.try_send(sync_msg);
-                    }
-                }
-            }
-
-            if has_index_change || has_branch_change {
-                let _ = app_clone.emit(
-                    "git-status-changed",
-                    GitStatusChangedEvent {
-                        repo_path: repo_path_clone.clone(),
-                    },
-                );
-            }
-        },
-    )
-    .map_err(|e| format!("Failed to create debouncer: {e}"))?;
-
-    let mut debouncer = debouncer;
-    debouncer
-        .watcher()
-        .watch(&paths.refs_heads, RecursiveMode::Recursive)
-        .map_err(|e| format!("Failed to watch refs/heads: {e}"))?;
-    if paths.head_file.exists() {
-        debouncer
-            .watcher()
-            .watch(&paths.head_file, RecursiveMode::NonRecursive)
-            .map_err(|e| format!("Failed to watch HEAD: {e}"))?;
-    }
-    if let Some(git_dir) = paths.index_file.parent() {
-        debouncer
-            .watcher()
-            .watch(git_dir, RecursiveMode::NonRecursive)
-            .map_err(|e| format!("Failed to watch .git dir: {e}"))?;
-    }
-    if paths.worktrees_dir.exists() {
-        debouncer
-            .watcher()
-            .watch(&paths.worktrees_dir, RecursiveMode::Recursive)
-            .map_err(|e| format!("Failed to watch worktrees: {e}"))?;
-    }
-
-    let session = WatcherSession {
-        _debouncer: debouncer,
-    };
-    state.sessions.lock().insert(watcher_id, session);
-
-    Ok(watcher_id)
+    app.state::<AppState>()
+        .repository_state
+        .start_git_dir_watching(&repo_path)
+        .map_err(|err| err.to_string())
 }
 
 #[tauri::command]
-pub fn stop_watching(state: State<'_, FileWatcherManager>, watcher_id: u64) -> Result<(), String> {
+pub fn stop_watching(
+    app: AppHandle,
+    state: State<'_, FileWatcherManager>,
+    watcher_id: u64,
+) -> Result<(), String> {
+    if let Some(app_state) = app.try_state::<AppState>() {
+        match app_state.repository_state.stop_watching(watcher_id) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(err) => return Err(err.to_string()),
+        }
+    }
+
     let mut sessions = state.sessions.lock();
     sessions
         .remove(&watcher_id)
         .ok_or_else(|| format!("Watcher {} not found", watcher_id))?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::git::test_helpers::*;
-    use notify_debouncer_mini::DebouncedEvent;
-    use std::path::PathBuf;
-
-    fn test_usecase() -> RepositoryUsecase {
-        crate::adaptor::controller::wiring::build_repository_usecase()
-    }
-
-    #[test]
-    fn test_resolve_git_watch_paths_main_repo() {
-        let (dir, repo) = create_test_repo();
-        create_initial_commit(&repo);
-
-        let repo_path = dir.path().to_str().unwrap();
-        let paths = resolve_git_watch_paths(&test_usecase(), repo_path).unwrap();
-
-        assert_eq!(
-            PathBuf::from(&paths.main_repo).canonicalize().unwrap(),
-            dir.path().canonicalize().unwrap()
-        );
-        assert!(paths.refs_heads.ends_with("refs/heads"));
-        assert!(paths.head_file.ends_with("HEAD"));
-        assert!(paths.worktrees_dir.ends_with("worktrees"));
-        assert!(paths.refs_heads.exists());
-        assert!(paths.head_file.exists());
-    }
-
-    fn create_worktree(repo: &git2::Repository) -> (String, PathBuf, tempfile::TempDir) {
-        static WT_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-        let id = WT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        let wt_name = format!("wt-test-{}", id);
-        let wt_dir = tempfile::TempDir::new().unwrap();
-        let wt_path = wt_dir.path().join(&wt_name);
-        repo.worktree(&wt_name, &wt_path, None).unwrap();
-        (wt_name, wt_path, wt_dir)
-    }
-
-    #[test]
-    fn test_resolve_git_watch_paths_with_worktree() {
-        let (dir, repo) = create_test_repo();
-        create_initial_commit(&repo);
-        add_and_commit(&repo, "file.txt", "content", "add file");
-
-        let (wt_name, _wt_path, _wt_dir) = create_worktree(&repo);
-
-        let repo_path = dir.path().to_str().unwrap();
-        let paths = resolve_git_watch_paths(&test_usecase(), repo_path).unwrap();
-
-        assert!(paths.worktrees_dir.exists());
-        assert!(paths.worktrees_dir.join(&wt_name).exists());
-    }
-
-    #[test]
-    fn test_resolve_git_watch_paths_from_worktree() {
-        let (dir, repo) = create_test_repo();
-        create_initial_commit(&repo);
-        add_and_commit(&repo, "file.txt", "content", "add file");
-
-        let (_wt_name, wt_path, _wt_dir) = create_worktree(&repo);
-
-        let main_repo_path = dir.path().to_str().unwrap();
-        let paths_from_wt =
-            resolve_git_watch_paths(&test_usecase(), wt_path.to_str().unwrap()).unwrap();
-
-        assert_eq!(
-            PathBuf::from(&paths_from_wt.main_repo)
-                .canonicalize()
-                .unwrap(),
-            PathBuf::from(main_repo_path).canonicalize().unwrap()
-        );
-        assert!(paths_from_wt.refs_heads.exists());
-    }
-
-    #[test]
-    fn test_resolve_git_watch_paths_invalid() {
-        let result = resolve_git_watch_paths(&test_usecase(), "/nonexistent/path");
-        assert!(result.is_err());
-    }
-
-    fn make_event(path: &str) -> DebouncedEvent {
-        DebouncedEvent {
-            path: PathBuf::from(path),
-            kind: DebouncedEventKind::Any,
-        }
-    }
-
-    #[test]
-    fn classify_index_change() {
-        let events = vec![make_event("/repo/.git/index")];
-        let (branch, index) = classify_git_dir_events(&events);
-        assert!(!branch);
-        assert!(index);
-    }
-
-    #[test]
-    fn classify_index_lock() {
-        let events = vec![make_event("/repo/.git/index.lock")];
-        let (branch, index) = classify_git_dir_events(&events);
-        assert!(!branch);
-        assert!(index);
-    }
-
-    #[test]
-    fn classify_head_change() {
-        let events = vec![make_event("/repo/.git/HEAD")];
-        let (branch, index) = classify_git_dir_events(&events);
-        assert!(branch);
-        assert!(!index);
-    }
-
-    #[test]
-    fn classify_refs_heads_change() {
-        let events = vec![make_event("/repo/.git/refs/heads/main")];
-        let (branch, index) = classify_git_dir_events(&events);
-        assert!(branch);
-        assert!(!index);
-    }
-
-    #[test]
-    fn classify_commit_editmsg() {
-        let events = vec![make_event("/repo/.git/COMMIT_EDITMSG")];
-        let (branch, index) = classify_git_dir_events(&events);
-        assert!(!branch);
-        assert!(index);
-    }
-
-    #[test]
-    fn classify_mixed_events() {
-        let events = vec![
-            make_event("/repo/.git/refs/heads/feature"),
-            make_event("/repo/.git/index"),
-        ];
-        let (branch, index) = classify_git_dir_events(&events);
-        assert!(branch);
-        assert!(index);
-    }
-
-    #[test]
-    fn classify_unrelated_event() {
-        let events = vec![make_event("/repo/.git/config")];
-        let (branch, index) = classify_git_dir_events(&events);
-        assert!(!branch);
-        assert!(!index);
-    }
-
-    #[test]
-    fn classify_worktree_index() {
-        let events = vec![make_event("/repo/.git/worktrees/feat/index")];
-        let (branch, index) = classify_git_dir_events(&events);
-        assert!(!branch);
-        assert!(index);
-    }
-
-    #[test]
-    fn canonicalize_existing_file() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let file_path = dir.path().join("test.txt");
-        std::fs::write(&file_path, "hello").unwrap();
-
-        let result = canonicalize_event_path(&file_path);
-        assert!(result.is_some());
-        let canonical = result.unwrap();
-        assert!(canonical.ends_with("test.txt"));
-        assert!(!canonical.contains(".."));
-    }
-
-    #[test]
-    fn canonicalize_deleted_file_falls_back_to_parent() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let file_path = dir.path().join("deleted.txt");
-
-        let result = canonicalize_event_path(&file_path);
-        assert!(result.is_some());
-        let canonical = result.unwrap();
-        assert!(canonical.ends_with("deleted.txt"));
-    }
-
-    #[test]
-    fn canonicalize_nonexistent_parent_returns_none() {
-        let path = PathBuf::from("/nonexistent/parent/file.txt");
-        let result = canonicalize_event_path(&path);
-        assert!(result.is_none());
-    }
 }

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -190,6 +190,7 @@ export function ReviewPanel({
 	const {
 		stagedFiles,
 		changedFiles,
+		version: gitStatusVersion,
 		refresh: refreshGitStatus,
 	} = useGitStatus(rootPath, gitRefreshKey);
 
@@ -207,6 +208,7 @@ export function ReviewPanel({
 		stagedFiles,
 		changedFiles,
 		rootPath,
+		gitStatusVersion,
 	);
 
 	const totalFileCount =

--- a/src/components/workspace/CreateWorktreeModal.tsx
+++ b/src/components/workspace/CreateWorktreeModal.tsx
@@ -66,6 +66,14 @@ function notionTaskToBranchName(title: string): string {
 
 type CreateMode = "plain" | "branch" | "issue" | "notion";
 
+interface BranchCardsSnapshot {
+	version: number;
+	stale: boolean;
+	loading: boolean;
+	limited: boolean;
+	branches: WorktreeBranch[];
+}
+
 interface CreateWorktreeModalProps {
 	open: boolean;
 	repoPaths: string[];
@@ -132,11 +140,11 @@ export function CreateWorktreeModal({
 				setLocalBranches([]);
 				setBaseBranch("HEAD");
 			});
-		invoke<WorktreeBranch[]>("list_branches_with_status", {
+		invoke<BranchCardsSnapshot>("list_branches_with_status_snapshot", {
 			repoPath: selectedRepoPath,
 		})
 			.then((result) => {
-				if (alive) setAllBranches(result);
+				if (alive) setAllBranches(result.branches);
 			})
 			.catch(() => {
 				if (alive) setAllBranches([]);

--- a/src/hooks/__tests__/useDiffFileTree.test.ts
+++ b/src/hooks/__tests__/useDiffFileTree.test.ts
@@ -124,25 +124,17 @@ describe("useDiffFileTree", () => {
 			},
 		];
 
-		mockInvoke
-			.mockResolvedValueOnce([
-				{
-					path: "a.ts",
-					index_additions: 10,
-					index_deletions: 3,
-					wt_additions: 1,
-					wt_deletions: 0,
-				},
-				{
-					path: "b.ts",
-					index_additions: 0,
-					index_deletions: 0,
-					wt_additions: 1,
-					wt_deletions: 0,
-				},
-			]) // get_status_diff_stats
-			.mockResolvedValueOnce(mockStagedTree) // build_diff_file_tree for staged
-			.mockResolvedValueOnce(mockChangesTree); // build_diff_file_tree for changes
+		mockInvoke.mockResolvedValueOnce({
+			version: 7,
+			stale: false,
+			loading: false,
+			limited: false,
+			combined_tree: [...mockStagedTree, ...mockChangesTree],
+			staged_tree: mockStagedTree,
+			changes_tree: mockChangesTree,
+			staged_file_count: 1,
+			changes_file_count: 1,
+		});
 
 		const staged: GitFileStatus[] = [
 			{ path: "a.ts", index_status: "modified", worktree_status: "none" },
@@ -160,9 +152,12 @@ describe("useDiffFileTree", () => {
 			expect(result.current.changesTree).toEqual(mockChangesTree);
 		});
 
-		expect(mockInvoke).toHaveBeenCalledWith("get_status_diff_stats", {
-			repoPath: "/repo",
-		});
+		expect(mockInvoke).toHaveBeenCalledWith(
+			"get_head_diff_file_tree_snapshot",
+			{
+				repoPath: "/repo",
+			},
+		);
 		expect(result.current.stagedFileCount).toBe(1);
 		expect(result.current.changesFileCount).toBe(1);
 		unmount();
@@ -182,11 +177,17 @@ describe("useDiffFileTree", () => {
 			},
 		];
 
-		// get_status_diff_stats, then build_diff_file_tree for changes only
-		// (staged entries are empty so buildTreeFromEntries returns [] without invoking)
-		mockInvoke
-			.mockResolvedValueOnce([]) // get_status_diff_stats returns empty
-			.mockResolvedValueOnce(mockTree); // build_diff_file_tree for changes
+		mockInvoke.mockResolvedValueOnce({
+			version: 1,
+			stale: false,
+			loading: false,
+			limited: false,
+			combined_tree: mockTree,
+			staged_tree: [],
+			changes_tree: mockTree,
+			staged_file_count: 0,
+			changes_file_count: 1,
+		});
 
 		const changed: GitFileStatus[] = [
 			{ path: "README.md", index_status: "none", worktree_status: "modified" },
@@ -206,56 +207,14 @@ describe("useDiffFileTree", () => {
 			expect(result.current.changesTree).toEqual(mockTree);
 		});
 
-		expect(mockInvoke).toHaveBeenCalledWith("get_status_diff_stats", {
-			repoPath: "/repo",
-		});
+		expect(mockInvoke).toHaveBeenCalledWith(
+			"get_head_diff_file_tree_snapshot",
+			{
+				repoPath: "/repo",
+			},
+		);
 		expect(result.current.stagedFileCount).toBe(0);
 		expect(result.current.changesFileCount).toBe(1);
-		unmount();
-	});
-
-	it("head mode merges wt stats from get_status_diff_stats for changes", async () => {
-		const mockTree: DiffTreeNode[] = [];
-		// get_status_diff_stats, then build_diff_file_tree for changes only
-		// (staged entries are empty so buildTreeFromEntries returns [] without invoking)
-		mockInvoke
-			.mockResolvedValueOnce([
-				{
-					path: "file.ts",
-					index_additions: 0,
-					index_deletions: 0,
-					wt_additions: 5,
-					wt_deletions: 2,
-				},
-			])
-			.mockResolvedValueOnce(mockTree); // changes tree
-
-		const changed: GitFileStatus[] = [
-			{ path: "file.ts", index_status: "none", worktree_status: "modified" },
-		];
-
-		const { unmount } = renderHook(() =>
-			useDiffFileTree(
-				"head",
-				EMPTY_BRANCH_FILES,
-				EMPTY_STAGED,
-				changed,
-				"/repo",
-			),
-		);
-
-		await waitFor(() => {
-			expect(mockInvoke).toHaveBeenCalledWith("build_diff_file_tree", {
-				entries: [
-					{
-						path: "file.ts",
-						status: "modified",
-						additions: 5,
-						deletions: 2,
-					},
-				],
-			});
-		});
 		unmount();
 	});
 
@@ -273,19 +232,17 @@ describe("useDiffFileTree", () => {
 			},
 		];
 
-		// get_status_diff_stats, then build_diff_file_tree for staged only
-		// (changes entries are empty so buildTreeFromEntries returns [] without invoking)
-		mockInvoke
-			.mockResolvedValueOnce([
-				{
-					path: "a.ts",
-					index_additions: 3,
-					index_deletions: 1,
-					wt_additions: 0,
-					wt_deletions: 0,
-				},
-			]) // get_status_diff_stats
-			.mockResolvedValueOnce(mockStagedTree); // build_diff_file_tree for staged
+		mockInvoke.mockResolvedValueOnce({
+			version: 2,
+			stale: false,
+			loading: false,
+			limited: false,
+			combined_tree: mockStagedTree,
+			staged_tree: mockStagedTree,
+			changes_tree: [],
+			staged_file_count: 1,
+			changes_file_count: 0,
+		});
 
 		const staged: GitFileStatus[] = [
 			{ path: "a.ts", index_status: "modified", worktree_status: "none" },
@@ -307,6 +264,93 @@ describe("useDiffFileTree", () => {
 
 		expect(result.current.stagedFileCount).toBe(1);
 		expect(result.current.changesFileCount).toBe(0);
+		unmount();
+	});
+
+	it("head mode refetches when status version changes without status list changes", async () => {
+		const firstTree: DiffTreeNode[] = [
+			{
+				id: "file:a.ts",
+				name: "a.ts",
+				path: "a.ts",
+				node_type: "file",
+				status: "modified",
+				additions: 1,
+				deletions: 0,
+				children: [],
+			},
+		];
+		const secondTree: DiffTreeNode[] = [
+			{
+				id: "file:a.ts",
+				name: "a.ts",
+				path: "a.ts",
+				node_type: "file",
+				status: "modified",
+				additions: 2,
+				deletions: 1,
+				children: [],
+			},
+		];
+		mockInvoke
+			.mockResolvedValueOnce({
+				version: 1,
+				stale: false,
+				loading: false,
+				limited: false,
+				combined_tree: firstTree,
+				staged_tree: [],
+				changes_tree: firstTree,
+				staged_file_count: 0,
+				changes_file_count: 1,
+			})
+			.mockResolvedValueOnce({
+				version: 2,
+				stale: false,
+				loading: false,
+				limited: false,
+				combined_tree: secondTree,
+				staged_tree: [],
+				changes_tree: secondTree,
+				staged_file_count: 0,
+				changes_file_count: 1,
+			});
+
+		const changed: GitFileStatus[] = [
+			{ path: "a.ts", index_status: "none", worktree_status: "modified" },
+		];
+
+		const { result, rerender, unmount } = renderHook(
+			({ statusVersion }: { statusVersion: number }) =>
+				useDiffFileTree(
+					"head",
+					EMPTY_BRANCH_FILES,
+					EMPTY_STAGED,
+					changed,
+					"/repo",
+					statusVersion,
+				),
+			{ initialProps: { statusVersion: 1 } },
+		);
+
+		await waitFor(() => {
+			expect(result.current.changesTree).toEqual(firstTree);
+		});
+
+		rerender({ statusVersion: 2 });
+
+		await waitFor(() => {
+			expect(result.current.changesTree).toEqual(secondTree);
+		});
+
+		expect(mockInvoke).toHaveBeenCalledTimes(2);
+		expect(mockInvoke).toHaveBeenNthCalledWith(
+			2,
+			"get_head_diff_file_tree_snapshot",
+			{
+				repoPath: "/repo",
+			},
+		);
 		unmount();
 	});
 

--- a/src/hooks/useDiffFileTree.ts
+++ b/src/hooks/useDiffFileTree.ts
@@ -22,14 +22,6 @@ export interface DiffTreeNode {
 	children: DiffTreeNode[];
 }
 
-interface StatusFileStat {
-	path: string;
-	index_additions: number;
-	index_deletions: number;
-	wt_additions: number;
-	wt_deletions: number;
-}
-
 export interface UseDiffFileTreeResult {
 	stagedTree: DiffTreeNode[];
 	changesTree: DiffTreeNode[];
@@ -38,6 +30,25 @@ export interface UseDiffFileTreeResult {
 	branchBaseTree: DiffTreeNode[];
 	branchBaseFileCount: number;
 	loading: boolean;
+}
+
+interface HeadDiffFileTreeSnapshot {
+	version: number;
+	stale: boolean;
+	loading: boolean;
+	limited: boolean;
+	combined_tree: DiffTreeNode[];
+	staged_tree: DiffTreeNode[];
+	changes_tree: DiffTreeNode[];
+	staged_file_count: number;
+	changes_file_count: number;
+}
+
+async function buildTreeFromEntries(
+	entries: DiffFileEntry[],
+): Promise<DiffTreeNode[]> {
+	if (entries.length === 0) return [];
+	return invoke<DiffTreeNode[]>("build_diff_file_tree", { entries });
 }
 
 function branchDiffToEntries(files: BranchDiffChangedFile[]): DiffFileEntry[] {
@@ -49,49 +60,13 @@ function branchDiffToEntries(files: BranchDiffChangedFile[]): DiffFileEntry[] {
 	}));
 }
 
-function stagedToIndexEntries(
-	stagedFiles: GitFileStatus[],
-	statsMap: Map<string, StatusFileStat>,
-): DiffFileEntry[] {
-	return stagedFiles.map((f) => {
-		const stat = statsMap.get(f.path);
-		return {
-			path: f.path,
-			status: f.index_status,
-			additions: stat?.index_additions ?? 0,
-			deletions: stat?.index_deletions ?? 0,
-		};
-	});
-}
-
-function changedToWtEntries(
-	changedFiles: GitFileStatus[],
-	statsMap: Map<string, StatusFileStat>,
-): DiffFileEntry[] {
-	return changedFiles.map((f) => {
-		const stat = statsMap.get(f.path);
-		return {
-			path: f.path,
-			status: f.worktree_status,
-			additions: stat?.wt_additions ?? 0,
-			deletions: stat?.wt_deletions ?? 0,
-		};
-	});
-}
-
-async function buildTreeFromEntries(
-	entries: DiffFileEntry[],
-): Promise<DiffTreeNode[]> {
-	if (entries.length === 0) return [];
-	return invoke<DiffTreeNode[]>("build_diff_file_tree", { entries });
-}
-
 export function useDiffFileTree(
 	diffBase: DiffBase,
 	branchDiffFiles: BranchDiffChangedFile[],
 	stagedFiles: GitFileStatus[],
 	changedFiles: GitFileStatus[],
 	rootPath?: string,
+	statusVersion?: number,
 ): UseDiffFileTreeResult {
 	const [stagedTree, setStagedTree] = useState<DiffTreeNode[]>([]);
 	const [changesTree, setChangesTree] = useState<DiffTreeNode[]>([]);
@@ -101,9 +76,11 @@ export function useDiffFileTree(
 	const [branchBaseFileCount, setBranchBaseFileCount] = useState(0);
 	const [loading, setLoading] = useState(false);
 	const requestIdRef = useRef(0);
+	const headStatusVersion = diffBase === "head" ? statusVersion : undefined;
 
 	const buildTree = useCallback(async () => {
 		const requestId = ++requestIdRef.current;
+		const requestedStatusVersion = headStatusVersion;
 
 		if (diffBase === "branch-base") {
 			// Branch Base mode: single tree
@@ -139,53 +116,54 @@ export function useDiffFileTree(
 			setBranchBaseTree([]);
 			setBranchBaseFileCount(0);
 
-			let statsMap = new Map<string, StatusFileStat>();
-			if (rootPath && (stagedFiles.length > 0 || changedFiles.length > 0)) {
-				try {
-					const stats = await invoke<StatusFileStat[]>(
-						"get_status_diff_stats",
-						{ repoPath: rootPath },
-					);
-					if (requestId !== requestIdRef.current) return;
-					statsMap = new Map(stats.map((s) => [s.path, s]));
-				} catch {
-					// Fall back to 0 stats
-				}
-				if (requestId !== requestIdRef.current) return;
-			}
-
-			const stagedEntries = stagedToIndexEntries(stagedFiles, statsMap);
-			const changesEntries = changedToWtEntries(changedFiles, statsMap);
-			setStagedFileCount(stagedEntries.length);
-			setChangesFileCount(changesEntries.length);
-
-			if (stagedEntries.length === 0 && changesEntries.length === 0) {
+			if (
+				!rootPath ||
+				(stagedFiles.length === 0 && changedFiles.length === 0)
+			) {
 				setStagedTree([]);
 				setChangesTree([]);
+				setStagedFileCount(0);
+				setChangesFileCount(0);
 				setLoading(false);
 				return;
 			}
 
 			setLoading(true);
 			try {
-				const [sTree, cTree] = await Promise.all([
-					buildTreeFromEntries(stagedEntries),
-					buildTreeFromEntries(changesEntries),
-				]);
+				const snapshot = await invoke<HeadDiffFileTreeSnapshot>(
+					"get_head_diff_file_tree_snapshot",
+					{ repoPath: rootPath },
+				);
 				if (requestId !== requestIdRef.current) return;
-				setStagedTree(sTree);
-				setChangesTree(cTree);
+				if (
+					requestedStatusVersion != null &&
+					snapshot.version < requestedStatusVersion
+				)
+					return;
+				setStagedTree(snapshot.staged_tree);
+				setChangesTree(snapshot.changes_tree);
+				setStagedFileCount(snapshot.staged_file_count);
+				setChangesFileCount(snapshot.changes_file_count);
 			} catch {
 				if (requestId !== requestIdRef.current) return;
 				setStagedTree([]);
 				setChangesTree([]);
+				setStagedFileCount(0);
+				setChangesFileCount(0);
 			} finally {
 				if (requestId === requestIdRef.current) {
 					setLoading(false);
 				}
 			}
 		}
-	}, [diffBase, branchDiffFiles, stagedFiles, changedFiles, rootPath]);
+	}, [
+		diffBase,
+		branchDiffFiles,
+		stagedFiles,
+		changedFiles,
+		rootPath,
+		headStatusVersion,
+	]);
 
 	useEffect(() => {
 		buildTree();

--- a/src/hooks/useGitStatus.test.ts
+++ b/src/hooks/useGitStatus.test.ts
@@ -15,8 +15,19 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 
 function gitStatusCallCount(): number {
-	return mockInvoke.mock.calls.filter((call) => call[0] === "get_git_status")
-		.length;
+	return mockInvoke.mock.calls.filter(
+		(call) => call[0] === "get_git_status_snapshot",
+	).length;
+}
+
+function statusSnapshot(status: GitFileStatus[], version = 1) {
+	return {
+		version,
+		stale: false,
+		loading: false,
+		limited: false,
+		status,
+	};
 }
 
 describe("useGitStatus", () => {
@@ -49,7 +60,8 @@ describe("useGitStatus", () => {
 			{ path: "staged.txt", index_status: "new", worktree_status: "none" },
 		];
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot(mockEntries));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -78,7 +90,8 @@ describe("useGitStatus", () => {
 			{ path: "deleted.txt", index_status: "none", worktree_status: "deleted" },
 		];
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot(mockEntries));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -114,7 +127,8 @@ describe("useGitStatus", () => {
 			},
 		];
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot(mockEntries));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -151,7 +165,8 @@ describe("useGitStatus", () => {
 			},
 		];
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot(mockEntries));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -175,7 +190,7 @@ describe("useGitStatus", () => {
 
 	it("should handle invoke error gracefully", async () => {
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status")
+			if (cmd === "get_git_status_snapshot")
 				return Promise.reject(new Error("not a git repo"));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
@@ -198,7 +213,8 @@ describe("useGitStatus", () => {
 
 		const WATCHER_ID = 42;
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot([]));
 			if (cmd === "start_watching") return Promise.resolve(WATCHER_ID);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -256,7 +272,8 @@ describe("useGitStatus", () => {
 
 		const WATCHER_ID = 42;
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot([]));
 			if (cmd === "start_watching") return Promise.resolve(WATCHER_ID);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -311,7 +328,8 @@ describe("useGitStatus", () => {
 			},
 		];
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot(mockEntries));
 			if (cmd === "start_watching") return Promise.resolve(WATCHER_ID);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -367,7 +385,8 @@ describe("useGitStatus", () => {
 
 	it("should re-fetch when refresh is called", async () => {
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot([]));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -388,7 +407,7 @@ describe("useGitStatus", () => {
 		});
 	});
 
-	it("should skip state update when entries are identical to previous fetch", async () => {
+	it("should update state when version increases even if entries are identical", async () => {
 		const mockEntries: GitFileStatus[] = [
 			{
 				path: "src/main.ts",
@@ -396,8 +415,10 @@ describe("useGitStatus", () => {
 				worktree_status: "modified",
 			},
 		];
+		let version = 0;
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve(mockEntries);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot(mockEntries, ++version));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -408,9 +429,61 @@ describe("useGitStatus", () => {
 		await waitFor(() => {
 			expect(result.current.statusMap.size).toBe(1);
 		});
+		expect(result.current.version).toBe(1);
 
 		const firstStatusMap = result.current.statusMap;
+		const firstStagedFiles = result.current.stagedFiles;
 		const firstChangedFiles = result.current.changedFiles;
+
+		act(() => {
+			result.current.refresh();
+		});
+
+		await waitFor(() => {
+			expect(result.current.version).toBe(2);
+		});
+
+		expect(gitStatusCallCount()).toBe(2);
+		expect(result.current.statusMap).not.toBe(firstStatusMap);
+		expect(result.current.stagedFiles).not.toBe(firstStagedFiles);
+		expect(result.current.changedFiles).not.toBe(firstChangedFiles);
+		expect(result.current.statusMap.size).toBe(1);
+	});
+
+	it("should ignore snapshots whose version does not increase", async () => {
+		const initialEntries: GitFileStatus[] = [
+			{
+				path: "src/main.ts",
+				index_status: "none",
+				worktree_status: "modified",
+			},
+		];
+		let nextSnapshot = statusSnapshot(initialEntries, 3);
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(nextSnapshot);
+			if (cmd === "start_watching") return Promise.resolve(1);
+			if (cmd === "stop_watching") return Promise.resolve();
+			return Promise.resolve([]);
+		});
+
+		const { result } = renderHook(() => useGitStatus("/test/repo"));
+
+		await waitFor(() => {
+			expect(result.current.version).toBe(3);
+		});
+
+		const firstStatusMap = result.current.statusMap;
+		nextSnapshot = statusSnapshot(
+			[
+				{
+					path: "src/older.ts",
+					index_status: "none",
+					worktree_status: "new",
+				},
+			],
+			2,
+		);
 
 		act(() => {
 			result.current.refresh();
@@ -419,9 +492,13 @@ describe("useGitStatus", () => {
 		await waitFor(() => {
 			expect(gitStatusCallCount()).toBe(2);
 		});
+		await act(async () => {
+			await Promise.resolve();
+		});
 
+		expect(result.current.version).toBe(3);
 		expect(result.current.statusMap).toBe(firstStatusMap);
-		expect(result.current.changedFiles).toBe(firstChangedFiles);
+		expect(result.current.statusMap.has("/test/repo/src/older.ts")).toBe(false);
 	});
 
 	it("should update state when entries change between fetches", async () => {
@@ -432,8 +509,10 @@ describe("useGitStatus", () => {
 				worktree_status: "modified",
 			},
 		];
+		let version = 0;
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve(initialEntries);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot(initialEntries, ++version));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -460,7 +539,8 @@ describe("useGitStatus", () => {
 			},
 		];
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve(updatedEntries);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot(updatedEntries, ++version));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -480,7 +560,8 @@ describe("useGitStatus", () => {
 	it("should debounce refresh on git-status-changed events", async () => {
 		vi.useFakeTimers();
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot([]));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);
@@ -523,7 +604,8 @@ describe("useGitStatus", () => {
 	it("should ignore git-status-changed events from different repo_path", async () => {
 		vi.useFakeTimers();
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "get_git_status") return Promise.resolve([]);
+			if (cmd === "get_git_status_snapshot")
+				return Promise.resolve(statusSnapshot([]));
 			if (cmd === "start_watching") return Promise.resolve(1);
 			if (cmd === "stop_watching") return Promise.resolve();
 			return Promise.resolve([]);

--- a/src/hooks/useGitStatus.ts
+++ b/src/hooks/useGitStatus.ts
@@ -4,6 +4,14 @@ import type { FileStatus } from "@/types/file-tree";
 import type { GitFileStatus } from "@/types/git";
 import { useGitEventRefresh } from "./useGitEventRefresh";
 
+interface GitStatusSnapshot {
+	version: number;
+	stale: boolean;
+	loading: boolean;
+	limited: boolean;
+	status: GitFileStatus[];
+}
+
 function toFileStatus(entry: GitFileStatus): FileStatus {
 	if (entry.worktree_status === "ignored") return "ignored";
 	if (entry.worktree_status === "new") return "untracked";
@@ -25,24 +33,33 @@ export function useGitStatus(
 	);
 	const [stagedFiles, setStagedFiles] = useState<GitFileStatus[]>([]);
 	const [changedFiles, setChangedFiles] = useState<GitFileStatus[]>([]);
-	const prevEntriesRef = useRef<string>("");
+	const [version, setVersion] = useState(0);
+	const acceptedVersionRef = useRef<number | null>(null);
 
 	const fetchStatus = useCallback(async () => {
 		if (!rootPath) {
 			setStatusMap(new Map());
 			setStagedFiles([]);
 			setChangedFiles([]);
-			prevEntriesRef.current = "";
+			setVersion(0);
+			acceptedVersionRef.current = null;
 			return;
 		}
 		try {
-			const entries = await invoke<GitFileStatus[]>("get_git_status", {
-				repoPath: rootPath,
-			});
-
-			const serialized = JSON.stringify(entries);
-			if (serialized === prevEntriesRef.current) return;
-			prevEntriesRef.current = serialized;
+			const snapshot = await invoke<GitStatusSnapshot>(
+				"get_git_status_snapshot",
+				{
+					repoPath: rootPath,
+				},
+			);
+			if (
+				acceptedVersionRef.current != null &&
+				snapshot.version <= acceptedVersionRef.current
+			) {
+				return;
+			}
+			acceptedVersionRef.current = snapshot.version;
+			const entries = snapshot.status;
 
 			const map = new Map<string, FileStatus>();
 			const staged: GitFileStatus[] = [];
@@ -62,11 +79,13 @@ export function useGitStatus(
 			setStatusMap(map);
 			setStagedFiles(staged);
 			setChangedFiles(changed);
+			setVersion(snapshot.version);
 		} catch {
 			setStatusMap(new Map());
 			setStagedFiles([]);
 			setChangedFiles([]);
-			prevEntriesRef.current = "";
+			setVersion(0);
+			acceptedVersionRef.current = null;
 		}
 	}, [rootPath]);
 
@@ -86,5 +105,5 @@ export function useGitStatus(
 
 	useGitEventRefresh(rootPath, fetchStatus);
 
-	return { statusMap, stagedFiles, changedFiles, refresh };
+	return { statusMap, stagedFiles, changedFiles, version, refresh };
 }

--- a/src/hooks/useWorktreeList.test.ts
+++ b/src/hooks/useWorktreeList.test.ts
@@ -36,7 +36,14 @@ function setupMockInvoke(branches: WorktreeBranch[]) {
 	mockInvoke.mockImplementation((cmd: string) => {
 		if (cmd === "start_git_dir_watching") return Promise.resolve(42);
 		if (cmd === "stop_watching") return Promise.resolve();
-		if (cmd === "list_branches_with_status") return Promise.resolve(branches);
+		if (cmd === "list_branches_with_status_snapshot")
+			return Promise.resolve({
+				version: 1,
+				stale: false,
+				loading: false,
+				limited: false,
+				branches,
+			});
 		if (cmd === "list_workspace_statuses") return Promise.resolve([]);
 		if (cmd === "get_cached_pr_status")
 			return Promise.resolve({ open_prs: {}, merged_branches: [] });
@@ -94,7 +101,14 @@ describe("useWorktreeList", () => {
 			if (cmd === "start_git_dir_watching")
 				return Promise.resolve(nextWatcherId);
 			if (cmd === "stop_watching") return Promise.resolve();
-			if (cmd === "list_branches_with_status") return Promise.resolve([]);
+			if (cmd === "list_branches_with_status_snapshot")
+				return Promise.resolve({
+					version: 1,
+					stale: false,
+					loading: false,
+					limited: false,
+					branches: [],
+				});
 			if (cmd === "get_cached_pr_status")
 				return Promise.resolve({ open_prs: {}, merged_branches: [] });
 			if (cmd === "list_workspace_statuses") return Promise.resolve([]);
@@ -120,7 +134,14 @@ describe("useWorktreeList", () => {
 		mockInvoke.mockImplementation((cmd: string) => {
 			if (cmd === "start_git_dir_watching")
 				return Promise.reject(new Error("repo not found"));
-			if (cmd === "list_branches_with_status") return Promise.resolve([]);
+			if (cmd === "list_branches_with_status_snapshot")
+				return Promise.resolve({
+					version: 1,
+					stale: false,
+					loading: false,
+					limited: false,
+					branches: [],
+				});
 			if (cmd === "get_cached_pr_status")
 				return Promise.resolve({ open_prs: {}, merged_branches: [] });
 			if (cmd === "list_workspace_statuses") return Promise.resolve([]);
@@ -148,14 +169,17 @@ describe("useWorktreeList", () => {
 
 		await act(async () => {
 			await vi.waitFor(() => {
-				expect(mockInvoke).toHaveBeenCalledWith("list_branches_with_status", {
-					repoPath: "/test/repo",
-				});
+				expect(mockInvoke).toHaveBeenCalledWith(
+					"list_branches_with_status_snapshot",
+					{
+						repoPath: "/test/repo",
+					},
+				);
 			});
 		});
 
 		const callCountBefore = mockInvoke.mock.calls.filter(
-			(c) => c[0] === "list_branches_with_status",
+			(c) => c[0] === "list_branches_with_status_snapshot",
 		).length;
 
 		await act(async () => {
@@ -163,7 +187,7 @@ describe("useWorktreeList", () => {
 		});
 
 		const callCountAfter30s = mockInvoke.mock.calls.filter(
-			(c) => c[0] === "list_branches_with_status",
+			(c) => c[0] === "list_branches_with_status_snapshot",
 		).length;
 		expect(callCountAfter30s).toBe(callCountBefore);
 
@@ -172,7 +196,7 @@ describe("useWorktreeList", () => {
 		});
 
 		const callCountAfter120s = mockInvoke.mock.calls.filter(
-			(c) => c[0] === "list_branches_with_status",
+			(c) => c[0] === "list_branches_with_status_snapshot",
 		).length;
 		expect(callCountAfter120s).toBe(callCountBefore + 1);
 
@@ -188,7 +212,14 @@ describe("useWorktreeList", () => {
 				});
 			}
 			if (cmd === "stop_watching") return Promise.resolve();
-			if (cmd === "list_branches_with_status") return Promise.resolve([]);
+			if (cmd === "list_branches_with_status_snapshot")
+				return Promise.resolve({
+					version: 1,
+					stale: false,
+					loading: false,
+					limited: false,
+					branches: [],
+				});
 			if (cmd === "get_cached_pr_status")
 				return Promise.resolve({ open_prs: {}, merged_branches: [] });
 			if (cmd === "list_workspace_statuses") return Promise.resolve([]);

--- a/src/hooks/useWorktreeList.ts
+++ b/src/hooks/useWorktreeList.ts
@@ -7,6 +7,14 @@ import type { WorkspaceStatus } from "@/types/session";
 
 const POLL_INTERVAL = 120_000;
 
+interface BranchCardsSnapshot {
+	version: number;
+	stale: boolean;
+	loading: boolean;
+	limited: boolean;
+	branches: WorktreeBranch[];
+}
+
 export function useWorktreeList(repoPath: string) {
 	const [branches, setBranches] = useState<WorktreeBranch[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -49,12 +57,13 @@ export function useWorktreeList(repoPath: string) {
 			const seq = ++refreshSeqRef.current;
 			if (!options?.silent) setLoading(true);
 			try {
-				const cards = await invoke<WorktreeBranch[]>(
-					"list_branches_with_status",
+				const snapshot = await invoke<BranchCardsSnapshot>(
+					"list_branches_with_status_snapshot",
 					{
 						repoPath,
 					},
 				);
+				const cards = snapshot.branches;
 				const enriched = await enrichWithPrStatus(cards);
 				// list_workspace_statuses の失敗では既存 ref を保持し、
 				// 全 agent_state を失わないようにする（一時的な invoke 失敗で UI が

--- a/tests/helpers/tauri-mock.ts
+++ b/tests/helpers/tauri-mock.ts
@@ -65,6 +65,24 @@ export async function setupTauriMock(page: Page, config: MockConfig) {
 				return;
 			}
 
+			// list_branches_with_status_snapshot は明示ハンドラが無い場合、
+			// list_branches_with_status の配列を BranchCardsSnapshot 形に
+			// ラップして返す（既存フィクスチャの override をそのまま活かす）。
+			if (
+				cmd === "list_branches_with_status_snapshot" &&
+				!(cmd in cfg.ipcHandler) &&
+				"list_branches_with_status" in cfg.ipcHandler
+			) {
+				const branches = cfg.ipcHandler.list_branches_with_status;
+				return {
+					version: 1,
+					stale: false,
+					loading: false,
+					limited: false,
+					branches: Array.isArray(branches) ? branches : [],
+				};
+			}
+
 			// ユーザー定義コマンド
 			if (cmd in cfg.ipcHandler) {
 				const value = cfg.ipcHandler[cmd];


### PR DESCRIPTION
## Summary
- repository_state service/worker を追加して status/diff/branch card を worktree 単位の snapshot から読む
- file/git watcher の invalidation と snapshot changed event を追加
- React hooks を versioned snapshot command に対応し、Issue 1210 specs/tests を更新

## Tests
- pnpm lint