### PR TITLE
feat(agent): add session event log persistence

### DIFF
--- a/docs/specs/issues-1247/behavior.md
+++ b/docs/specs/issues-1247/behavior.md
@@ -1,0 +1,164 @@
+# behavior — issues-1247
+
+`AgentSessionEventLog` / Projector による Agent session 保存正典の振る舞い定義。
+
+本変更は内部アーキテクチャの再定義であり、外部から観測可能な振る舞い（UI 表示・session 一覧・streaming 体験・workflow 完了判定の結果）は不変である（requirements R6）。
+そのため本ドキュメントの振る舞いは、UI 操作ではなく「durable event 列を正典として read model が決定的に導出される」というビジネスルールを、観測可能な結果（read model の状態）として定義する。
+
+Gherkin 中の用語:
+
+- **durable event**: replay 可能で session の事実を構成する最小語彙（`AgentSessionEvent`）。
+- **live-only delta**: 表示中のみ意味を持ち replay されない逐次差分（text / tool-input / reasoning の delta）。
+- **read model**: event 列から projection で導出される派生状態。本変更では少なくとも message page・session status・workflow turn-complete input を含む。
+- **session status**: 永続側 `SessionState`（Active / Idle / Done / Error / Closed / Archived）に加え、runtime 由来の遷移状態（streaming 中・permission 待ち）を含む実行フェーズ。
+
+---
+
+## Feature: durable event 列を正典とした read model の projection
+
+session の事実を durable event 列として append し、message page・session status・workflow turn-complete input を event 列から projection で導出する。read model は event 列の射影であり、event 列を唯一の正典とする。
+
+### Background:
+```gherkin
+Given Agent session の保存正典が durable event 列（AgentSessionEvent）である
+And read model（message page・session status・workflow turn-complete input）は event 列の projection として導出される
+And streaming の逐次差分は live-only delta として扱われ replay されない
+```
+
+---
+
+### Rule: durable event を append すると read model が event 列から導出される
+
+#### Scenario: prompt 投入から turn 完了までの event 列を message page へ projection する
+```gherkin
+Given 空の event 列を持つ Agent session
+When prompt 投入・tool 呼び出しの成功・turn 完了を表す durable event を順に append する
+Then message page は event 列を projection した結果として導出される
+And message page には投入された prompt と tool 呼び出しの結果が含まれる
+And read model に event 列に存在しない message は現れない
+```
+
+#### Scenario: 同一の event 列からは常に同一の read model が導出される
+```gherkin
+Given turn を 1 つ含む durable event 列
+When event 列から read model を 2 回 projection する
+Then 2 回の projection 結果は一致する
+```
+
+#### Scenario: live-only delta は read model の正典に含まれない
+```gherkin
+Given durable event 列と、それに付随する live-only delta（text / tool-input / reasoning の逐次差分）
+When event 列のみから read model を再構築する
+Then live-only delta を適用しなくても read model は完全に再構築できる
+And live-only delta は durable event 列の一部として永続化されない
+```
+
+---
+
+### Rule: session status は永続状態と runtime 遷移状態の双方を event 列から projection する
+
+#### Scenario Outline: 実行フェーズを event 列から projection で導出する
+```gherkin
+Given session に <events> を表す durable event が append されている
+When session status を projection する
+Then session status は <status> となる
+
+Examples:
+  | events                            | status        |
+  | turn 開始（user prompt 投入）      | streaming 中  |
+  | tool 呼び出しに対する permission 要求 | permission 待ち |
+  | turn 完了（中断・エラーなし）       | Idle          |
+  | session のクローズ                 | Closed        |
+```
+
+#### Scenario: runtime 由来の遷移状態が event 列のみから判定できる
+```gherkin
+Given streaming 中・permission 待ちを表す durable event が append された session
+When runtime memory を参照せず event 列のみから session status を projection する
+Then streaming 中・permission 待ちの遷移状態が判定できる
+And runtime memory が唯一の保持者である状態は存在しない
+```
+
+---
+
+### Rule: abort / timeout / bridge crash 時に partial 状態を残さない（finalization）
+
+#### Scenario Outline: 異常終端時に未完了の turn / tool call / permission を終端 event で閉じる
+```gherkin
+Given turn が進行中で、実行中の tool call と未解決の permission が存在する session
+When <trigger> が発生する
+Then 進行中の turn を終端する durable event が付与される
+And 実行中の tool call を終端する durable event が付与される
+And 未解決の permission を終端する durable event が付与される
+And read model に partial な turn / tool call / permission は残らない
+
+Examples:
+  | trigger      |
+  | abort（interrupt） |
+  | timeout       |
+  | bridge crash  |
+```
+
+#### Scenario: 異常終端後の read model から完了判定が一意に定まる
+```gherkin
+Given abort により終端 event が付与された session
+When read model から turn の完了状態を判定する
+Then turn は未完了（partial）ではなく終端済みとして判定される
+And 完了判定が runtime state と session JSON のどちらを見るかで揺れない
+```
+
+---
+
+### Rule: reconnect 時に read model を二重適用しない
+
+#### Scenario: 同一 event 列の再 projection で message が重複しない
+```gherkin
+Given turn を含む durable event 列から projection 済みの read model
+When UI reconnect により read model を event 列から再構築する
+Then message は二重適用されず、再構築前と同じ内容になる
+And 累積 parts の重複適用が発生しない
+```
+
+#### Scenario: abort / crash / reconnect の各シナリオで read model が決定的に再構築できる
+```gherkin
+Given abort / crash / reconnect のいずれかを経た session の durable event 列
+When event 列から read model を再構築する
+Then read model は event 列から決定的に再構築される
+And partial 残存・二重適用は発生しない
+```
+
+---
+
+### Rule: 既存の observable behavior を保持する（互換 projector）
+
+#### Scenario: event 列駆動へ置き換えても既存の永続構造へ projection できる
+```gherkin
+Given event 列駆動で処理される Agent session
+When read model を永続化する
+Then 既存の session 永続構造（meta.json / messages/{seq}.json / index.json）へ projection される
+And 既存の session 永続構造と矛盾するフォーマット変更は発生しない
+```
+
+#### Scenario: event 列駆動への置き換え後も UI 表示・session 一覧・streaming・workflow 完了判定の結果が変わらない
+```gherkin
+Given 既存の処理経路が durable event の append を介して read model へ反映される構造
+When 同一の入力（prompt・tool 呼び出し・turn 完了）を与える
+Then UI 表示内容は置き換え前と同じである
+And session 一覧の結果は置き換え前と同じである
+And streaming の見え方は置き換え前と同じである
+And workflow 完了判定の結果は置き換え前と同じである
+```
+
+---
+
+## 仮定（Assumptions）
+
+- **B1.** 本ドキュメントの Scenario は read model（observable な派生状態）に対する振る舞いを定義し、durable event の具体的な variant 名・projector の内部構造・モジュール配置は実装仕様（`design.md`）に委ねる。requirements の R1〜R7 に含まれる関数名・型名（`accumulate_sdk_message` 等）は Gherkin 本文に持ち込まない。
+- **B2.** 「streaming の見え方が変わらない」は cumulative snapshot 前提（#1214 の seq delta 移行は Non-goal）のもとでの不変を意味する。
+- **B3.** session status の Examples（streaming 中 / permission 待ち / Idle / Closed）は代表例であり、`SessionState` の全状態（Active / Idle / Done / Error / Closed / Archived）と runtime 遷移状態の網羅的な対応表は `design.md` で確定する。
+- **B4.** finalization の終端 event の具体的な variant（どの event でどう閉じるか）は `design.md` で定義する。本ドキュメントは「partial が残らない」という結果のみを規定する。
+- **B5.** workflow turn-complete input の projection は、turn 完了を表す durable event の有無から導出され、runtime state（`BridgeState::Streaming` 相当）の直接参照を正典としない。
+
+## Open Questions
+
+なし（requirements の Open Questions はすべて解消済み。behavior レベルで新たに人間の判断を要する未確定点は生じていない）。

--- a/docs/specs/issues-1247/design.md
+++ b/docs/specs/issues-1247/design.md
@@ -1,0 +1,417 @@
+# Design — issues-1247
+
+対象 Issue: #1247
+要求の正本: `requirements.md`（本ディレクトリ）
+振る舞いの正本: `behavior.md`（本ディレクトリ）
+
+本書は、Agent session の保存正典を **durable event 列（`AgentSessionEvent`）** へ収束させ、message page・session status・workflow turn-complete input を **projection（read model 反映）** で導出する構造の実装設計を定義する。`behavior.md` が `design.md` に委ねた durable event の variant 名・projector の内部構造・モジュール配置・session status の網羅的対応表・finalization の終端 event をここで確定する。
+
+本変更は内部アーキテクチャの再定義であり、外部から観測可能な振る舞いは不変（R6）である。
+
+---
+
+## 概要
+
+現状の Agent session の状態は複数の場所に分散している（`requirements.md` Background、本リポジトリ調査による事実）:
+
+- **永続層**: `usecase/agent_session/session/` の `ChatSession` / `ChatMessage` / `MessagePart` を、`adaptor/gateway/agent_session/session_storage/` が `meta.json` + `messages/{seq}.json` + `index.json`（#1213 導入）で保存する。
+- **runtime memory**: `infrastructure/agent_session/runtime/bridge_common.rs` の `AgentProcess` が `streaming_parts: Vec<MessagePart>` / `state: BridgeState` / `turn_phase: TurnPhase` を turn 中に保持する。
+- **streaming**: cumulative snapshot 方式。`accumulate_sdk_message()` が SDK メッセージを `MessagePart` vector に push し、`run_turn_complete_transition_locked()` で consolidate して永続化する。
+- **workflow handoff**: turn 完了判定を `run_turn_complete_transition_locked()` が返す `was_streaming`（= `proc.state == BridgeState::Streaming`）で gating し、`spawn_workflow_turn_complete_notification()` 経由で `WorkflowRuntimeUsecase::complete_turn()` を呼ぶ。
+
+本設計では「session の事実」を **append-only な `AgentSessionEvent` 列**として表現し、read model（message page・session status・workflow turn-complete input）を event 列の **projection** として導出する。
+
+- **durable event**: replay 可能で session の事実を構成する最小語彙。block 確定・tool 呼び出しの開始/成功/失敗・retry・permission 解決・turn 終端を表す。
+- **live-only delta**: 表示中のみ意味を持ち replay されない逐次差分（text / tool-input / reasoning の delta）。event 列には含めない。
+
+初期実装は **互換 projector**（A2）であり、event 列を独立した永続ファイルとして持たず、projection 結果を既存の `ChatSession` JSON 構造（`meta.json` / `messages/{seq}.json` / `index.json`）へ書き込む。event 列の独立永続化は将来拡張余地として扱う（後述「リスクと代替案」）。
+
+cumulative snapshot 前提（#1214 未完了）・`bridge_common.rs` 未分割（#1217 未完了）の現状コード上で成立させる。
+
+---
+
+## 変更対象
+
+### Rust（バックエンド）
+
+- `src-tauri/src/usecase/agent_session/event_log/`（**新規モジュール**）
+  - `AgentSessionEvent`（durable event 語彙）・`projector`（event 列 → read model）・`finalization`（異常終端ルール）を定義する。read model 型（`ChatSession` / `ChatMessage` / `MessagePart` / `SessionState`）と同じ usecase 層に置き、projector がそれらを直接構築できるようにする。live-only delta は現段階では `bridge_common.rs` の legacy accumulator 内の扱いに閉じ、`AgentSessionEvent` へは append しない。
+- `src-tauri/src/usecase/agent_session/session/mod.rs`
+  - projector の出力先である `ChatMessage` / `MessagePart` / `SessionState` は変更しない（serde 表現を維持、R6）。projector が参照するのみ。
+- `src-tauri/src/usecase/agent_session/status.rs`
+  - session status の read model（`TurnPhase` / `SessionStatus`）を projector の出力として接続する。型定義自体は維持。
+- `src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs`
+  - `AgentProcess` に per-turn の `TurnEventLog`（runtime 保持の event buffer）を追加する。
+  - `accumulate_sdk_message()` / `run_turn_complete_transition_locked()` / `run_bridge_error_transition_locked()` を、runtime memory を直接更新する経路から **durable event を append → projection で read model に反映する経路**へ置き換える（R7）。
+  - timeout（`finalize_turn_as_timeout_locked()`）/ interrupt（`interrupt_active_agent_turn()` 応答）も finalization event を append する経路に接続する。
+  - **`bridge_common.rs` のモジュール分割は行わない（#1217 が担当 / Non-goal）。** event 列駆動への差し替えは同ファイル内に閉じた `event_log` 利用として実装する。
+
+### フロントエンド
+
+- 変更なし。本変更は内部の保存正典の再定義に限定し、新規 Tauri コマンド・UI 要素は追加しない（A4）。projection 結果の `ChatSession` / `SessionStatus` の serde 表現が不変であるため、frontend からは何も変わらない（R6）。
+
+---
+
+## アーキテクチャと責務分割
+
+`.claude/rules/rust-first-logic.md` および `docs/architecture/` の依存方向（`infrastructure → adaptor/gateway → domain ← usecase ← adaptor/controller`）に従う。event 語彙・projection・finalization の判断はすべて Rust に置く。
+
+```text
+                event append              projection
+SDK / runtime ───────────────▶ AgentSessionEvent 列 ───────────────▶ read model
+ (bridge_common)               (TurnEventLog: runtime 保持)          ├─ message page (ChatMessage/MessagePart)
+                                                                     ├─ session status (SessionState + TurnPhase)
+                                                                     └─ workflow turn-complete input
+                                                                            │
+                                                            互換 projector で永続化
+                                                                            ▼
+                                          meta.json / messages/{seq}.json / index.json (#1213)
+```
+
+| レイヤー | 責務 |
+| --- | --- |
+| `usecase/agent_session/event_log` | `AgentSessionEvent` 語彙、durable / live-only の境界、projector（event 列 → read model）、finalization ルール。純粋ロジックでテスト可能 |
+| `usecase/agent_session/session` | projector の出力型（`ChatSession` / `ChatMessage` / `MessagePart` / `SessionState`）。serde 表現を維持 |
+| `usecase/agent_session/status` | projector が導出する session status（`SessionState` + `TurnPhase`）の read model 型 |
+| `adaptor/gateway/agent_session/session_storage` | 互換 projector の出力を既存 split layout（#1213）へ書き込む。本変更で構造は変えない |
+| `infrastructure/.../bridge_common` | `AgentProcess` の `TurnEventLog` 保持、3 経路での event append、projection 結果の read model 反映と永続化呼び出し |
+
+### 正典の再定義
+
+#1213 は「メタ = `meta.json`、message body = `messages/{seq}.json`、runtime 状態（`streaming_parts` / `turn_phase`）は非正典」と定義した。本変更はこれを次のように再定義する:
+
+- **session の事実の正典 = `AgentSessionEvent` 列**。message page・session status・workflow turn-complete input はすべてこの event 列の projection。
+- **永続層（`meta.json` / `messages/{seq}.json` / `index.json`）= event 列の projection 結果の保存先**（互換 projector の出力）。#1213 の構造をそのまま流用し、フォーマット破壊的変更はしない（R6 / 制約）。
+- **`streaming_parts` 等の runtime memory = projection の途中状態の保持器**であり、唯一の正典としては扱わない。session status（streaming 中・permission 待ち）は event 列から projection で導出する（R3）。
+
+> **接続点（R5）**: 本変更は #1213 が確立した split layout を projection の出力先として利用する。streaming は cumulative snapshot 前提のまま（#1214 が seq delta protocol を担当）であり、本変更が導入する durable / live-only の境界は #1214 の概念的下地となる。`bridge_common.rs` の event 駆動化は同ファイル内に閉じ、`event_log` モジュールという明確な seam を残すことで、#1217 の runtime / stream / persist / recovery 分割が後から接続しやすい形にする。この接続点はコード上のコメントとして `event_log/mod.rs` 冒頭にも記す。
+
+---
+
+## データモデルまたは型
+
+### durable event 語彙（`event_log/mod.rs`）
+
+OpenCode の durable event を参考にしつつ、Releash の既存 `MessagePart`（`Thinking` / `Text` / `ToolUse` / `ToolResult` / `Error` / `Permission` / `TaskStatus` / `TodoListSnapshot` / `SystemNotification` / `Image` / `ImageRef`）と整合する Releash 固有の語彙として定義する（A3）。
+
+```rust
+/// session の事実を構成する最小の durable event。replay 可能。
+/// turn_id は 1 回の user prompt 投入で開始する turn を識別する。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentSessionEvent {
+    /// user prompt 投入で turn を開始する。
+    TurnStarted {
+        turn_id: TurnId,
+        message_id: String,
+        prompt: PromptInput,      // text + mentions + 添付参照 + human message parts
+        at: f64,
+    },
+    /// 確定した assistant text block（live-only の text_delta を集約した最終形）。
+    TextRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        content: String,
+        parent_tool_use_id: Option<String>,
+    },
+    /// 確定した reasoning block（live-only の reasoning_delta を集約した最終形）。
+    ReasoningRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        content: String,
+        parent_tool_use_id: Option<String>,
+    },
+    /// tool 呼び出しの開始（input 確定後）。
+    ToolCallStarted {
+        turn_id: TurnId,
+        tool_use_id: String,
+        tool: String,
+        input: serde_json::Value,
+        parent_tool_use_id: Option<String>,
+    },
+    /// tool 呼び出しの成功。
+    ToolCallSucceeded {
+        turn_id: TurnId,
+        tool_use_id: String,
+        content: String,
+    },
+    /// tool 呼び出しの失敗。
+    ToolCallFailed {
+        turn_id: TurnId,
+        tool_use_id: String,
+        content: String,
+    },
+    /// tool 呼び出しの retry（再試行の記録）。
+    ToolCallRetried {
+        turn_id: TurnId,
+        tool_use_id: String,
+        attempt: u32,
+    },
+    /// permission 要求。
+    PermissionRequested {
+        turn_id: TurnId,
+        tool_use_id: Option<String>,
+        request: serde_json::Value,
+    },
+    /// permission 解決（許可 / 拒否 / 取消）。
+    PermissionResolved {
+        turn_id: TurnId,
+        tool_use_id: Option<String>,
+        decision: PermissionDecision, // Allowed | Denied | Cancelled
+        answers: Option<serde_json::Value>,
+    },
+    /// background task の状態変化（TaskStatus part 由来）。
+    TaskStatusChanged {
+        turn_id: TurnId,
+        message_id: String,
+        task_tool_use_id: String,
+        status: String,
+        description: Option<String>,
+        summary: Option<String>,
+    },
+    /// todo list snapshot。
+    TodoListSnapshotRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        items: Vec<TodoListItem>,
+    },
+    /// compaction 等の system notification。
+    SystemNotificationRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        notification_type: SystemNotificationType,
+        status: String,
+        label: String,
+        detail: Option<String>,
+        hook_id: Option<String>,
+    },
+    /// turn の正常終端（exit_code == 0）。
+    TurnCompleted {
+        turn_id: TurnId,
+        exit_code: i64,
+        token_usage: Option<TurnTokenUsage>,
+    },
+    /// turn の異常終端（finalization）。abort / timeout / bridge crash を一意に表す。
+    TurnInterrupted {
+        turn_id: TurnId,
+        reason: InterruptReason,  // Abort | Timeout | BridgeCrash
+        error: Option<String>,
+    },
+    /// session のクローズ。
+    SessionClosed { at: f64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InterruptReason { Abort, Timeout, BridgeCrash }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionDecision { Allowed, Denied, Cancelled }
+```
+
+`TurnId` は turn の単調増加識別子（既存 `AgentProcess::turn_seq` に対応づけ可能）。`PromptInput` / `TurnTokenUsage` / `TodoListItem` / `SystemNotificationType` は既存型を再利用または薄くラップする。
+
+### live-only delta（legacy accumulator 内の扱い）
+
+replay 不要で表示中のみ意味を持つ逐次差分は、durable event とは分離する。現段階では `LiveDelta` の公開 API は持たず、`text_delta` / `thinking_delta` / tool input partial は `bridge_common.rs` の既存 `accumulate_sdk_message()` 系が legacy live buffer（`streaming_parts`）へ反映する。**`AgentSessionEvent` 列には決して含めない**。
+
+terminal flush で確定した text / reasoning / error block だけを `PartEventMode::FinalLiveBlocks` として `TextRecorded` / `ReasoningRecorded` / `ErrorRecorded` へ変換する。将来 #1214 の seq-delta protocol で live delta API が必要になった場合は、この境界の外側に追加する。
+
+### durable / live-only の対応表（R2 の明文化）
+
+| SDK / 内部イベント | 分類 | event / delta |
+| --- | --- | --- |
+| `stream_event` の `text_delta` | live-only | legacy live buffer（`AgentSessionEvent` へ append しない） |
+| `stream_event` の `thinking_delta` | live-only | legacy live buffer（`AgentSessionEvent` へ append しない） |
+| tool input の partial（逐次） | live-only | legacy live buffer（`AgentSessionEvent` へ append しない） |
+| text block の確定（block 終端 / flush 境界） | durable | `TextRecorded` |
+| thinking block の確定 | durable | `ReasoningRecorded` |
+| `assistant` の tool_use ブロック（input 確定） | durable | `ToolCallStarted` |
+| 同一 turn / tool_use_id の再 tool_use ブロック | durable | `ToolCallRetried` + `ToolCallStarted` |
+| `user` の tool_result（is_error=false） | durable | `ToolCallSucceeded` |
+| `user` の tool_result（is_error=true） | durable | `ToolCallFailed` |
+| permission 要求 | durable | `PermissionRequested` |
+| permission 応答 | durable | `PermissionResolved` |
+| `turn_complete`（exit_code==0） | durable | `TurnCompleted` |
+| `turn_complete`（interrupted）/ `error` / timeout | durable | `TurnInterrupted` |
+
+live-only delta は「同じ block の最終形が durable event として必ず append される」ことを不変条件とする。よって event 列のみから read model は完全再構築でき、delta を適用しなくても欠落しない（behavior「live-only delta は read model の正典に含まれない」）。
+
+### read model（projector の出力）
+
+```rust
+/// event 列から projection した read model。
+pub struct SessionReadModel {
+    pub messages: Vec<ChatMessage>,                 // message page の元（既存型）
+    pub status: ProjectedStatus,                    // session status
+    pub workflow_turn_complete: Option<WorkflowTurnCompleteInput>,
+    pub tool_retries: Vec<ToolRetryProjection>,      // retry 履歴（UI 表示は変えない内部 read model）
+}
+
+pub struct ProjectedStatus {
+    pub session_state: SessionState,                // Active/Idle/Done/Error/Closed/Archived
+    pub turn_phase: TurnPhase,                      // Idle/Streaming/WaitingPermission（runtime 遷移状態）
+}
+
+pub struct ToolRetryProjection {
+    pub turn_id: TurnId,
+    pub tool_use_id: String,
+    pub attempt: u32,
+}
+
+/// workflow への turn 完了通知の入力。runtime state ではなく event 列から導出する（B5）。
+pub struct WorkflowTurnCompleteInput {
+    pub turn_id: TurnId,
+    pub exit_code: i64,
+    pub final_text_parts: Vec<String>,
+    pub token_usage: Option<TurnTokenUsage>,
+    pub interrupted: bool,
+}
+```
+
+---
+
+## 処理フロー
+
+### projector: event 列 → read model
+
+`project(events: &[AgentSessionEvent]) -> SessionReadModel` は純粋関数として実装する。
+
+1. **message page の構築**: event を順に fold する。
+   - `TurnStarted` → user role の `ChatMessage` を生成。
+   - `TextRecorded` / `ReasoningRecorded` → assistant message の `MessagePart::Text` / `Thinking` を追加。
+   - `ToolCallStarted` → `MessagePart::ToolUse`。`ToolCallSucceeded` / `ToolCallFailed` → 対応する `tool_use_id` の `MessagePart::ToolResult`（`is_error` を設定）。
+   - `ToolCallRetried` → UI の既存 `MessagePart` 形式は変えず、内部 read model の retry 履歴（`tool_retries`）へ反映する。
+   - `PermissionRequested` / `PermissionResolved` → `MessagePart::Permission`（`status` を解決状態に更新）。
+   - `TaskStatusChanged` / `TodoListSnapshotRecorded` / `SystemNotificationRecorded` → event の `turn_id` / `message_id` で明示された対象 message に対応 `MessagePart` を反映する。
+   - 同一 `tool_use_id` / `message_id` への後続 event は **in-place 更新**（重複 part を作らない）。これにより「同一 event 列の再 projection で message が重複しない」（behavior reconnect Rule）を保証する。
+2. **session status の導出**（後述の対応表）。
+3. **workflow turn-complete input の導出**: `TurnStarted` を持つ turn に `TurnCompleted` または `TurnInterrupted` が現れた時点で `Some` を返す。`final_text_parts` はその turn の `TextRecorded` から、`interrupted` は `TurnInterrupted` の有無から導出する（runtime `BridgeState::Streaming` の直接参照を正典としない / B5）。
+
+projection は event 列にのみ依存する純粋関数のため、**同一 event 列からは常に同一の read model が導出される**（behavior 決定性 Rule）。
+
+### session status の projection（R3 / B3 の網羅的対応表）
+
+session status = 永続側 `SessionState` ＋ runtime 由来の遷移状態 `TurnPhase` の二軸。event 列から両軸を導出する。
+
+| 直近の event 状態 | `SessionState` | `TurnPhase`（遷移状態） |
+| --- | --- | --- |
+| `TurnStarted` 後、終端 event なし | Active | Streaming |
+| `PermissionRequested` 後、対応 `PermissionResolved` なし | Active | WaitingPermission |
+| `TurnCompleted`（exit_code==0） | Idle | Idle |
+| `TurnInterrupted { reason: Abort }` | Idle | Idle |
+| `TurnInterrupted { reason: Timeout \| BridgeCrash }` | Error | Idle |
+| `SessionClosed` | Closed | Idle |
+| event なし（新規） | Idle | Idle |
+
+`Done` / `Archived` は session ライフサイクル操作（明示クローズ・アーカイブ）由来であり turn の event からは導出しない。これらは既存の `SessionState` 遷移経路を維持し、event 列の projection 結果に上書き合成する（projector は turn 由来の `SessionState` を提示し、ライフサイクル由来の `Done` / `Archived` は上位で優先）。
+
+これにより「runtime memory を参照せず event 列のみから streaming 中・permission 待ちが判定できる」「runtime memory が唯一の保持者である状態は存在しない」（behavior runtime 遷移状態 Rule / R3）を満たす。
+
+### finalization（R4 / abort・timeout・bridge crash）
+
+異常終端時に未完了の turn / tool call / permission を partial で残さないため、終端ルーチン `finalize_turn(log, reason)` が **明示的な終端 event を append** する（projector に推論を委ねず、event 列を自己完結させる）:
+
+1. 当該 turn の **未完了 tool call**（`ToolCallStarted` はあるが `ToolCallSucceeded` / `ToolCallFailed` がない `tool_use_id`）ごとに `ToolCallFailed { content: "<reason> により中断" }` を append。
+2. 当該 turn の **未解決 permission**（`PermissionRequested` はあるが `PermissionResolved` がない）ごとに `PermissionResolved { decision: Cancelled }` を append。
+3. 最後に `TurnInterrupted { reason }` を append。
+
+この順序により、projection 後の read model に partial な turn / tool call / permission は残らず、turn は「未完了」ではなく「終端済み」として一意に判定できる（behavior finalization Rule）。完了判定が runtime state と session JSON のどちらを見るかで揺れない（failure mode 1・3 の解消）。
+
+trigger との対応:
+
+| trigger | append 経路 |
+| --- | --- |
+| abort（interrupt） | `interrupt_active_agent_turn()` 応答の `turn_complete(interrupted=true)` → `finalize_turn(log, Abort)` |
+| timeout | `finalize_turn_as_timeout_locked()` → `finalize_turn(log, Timeout)` |
+| bridge crash | `run_bridge_error_transition_locked()` → `finalize_turn(log, BridgeCrash)` |
+
+### 3 経路の event 駆動への置き換え（R7）
+
+`AgentProcess` に per-turn の `TurnEventLog`（runtime 保持の `Vec<AgentSessionEvent>`）を追加し、既存 3 経路を次のように差し替える。**`streaming_parts` は廃止せず、`project(turn_event_log)` の結果（＋未確定の text delta tail）を保持する live 表示バッファとして再定義する**。cumulative snapshot の emit はこのバッファから従来どおり行うため、streaming の見え方は不変（B2 / R6）。
+
+- **`accumulate_sdk_message()`**: SDK メッセージ解析時、
+  - `text_delta` / `thinking_delta` / tool input partial → legacy live バッファを更新（event は append しない）。
+  - block 確定 / tool_use / tool_result / permission → 対応する `AgentSessionEvent` を `TurnEventLog` に append。
+  - emit する cumulative snapshot は `project(turn_event_log)`（＋ live tail）から生成。従来の `append_to_parts` / in-place 更新は projector 側の fold ロジックへ移す。
+- **`run_turn_complete_transition_locked()`**: flush 後に interrupt 指示なしなら exit_code に関わらず `TurnCompleted { exit_code }` を append し、abort / timeout / bridge crash の明示経路では finalization を呼ぶ。`final_parts` を `consolidate_parts_from_slice` ではなく `project(turn_event_log).messages` の最終 message から取得する。`was_streaming` 相当の判定は「当該 turn に `TurnStarted` があるか」で代替し、workflow 通知入力（`WorkflowTurnCompleteInput`）を projection から得る。
+- **`run_bridge_error_transition_locked()`**: `sdk_error_part_from_message()` で `MessagePart::Error` を直接 push する代わりに、`finalize_turn(log, BridgeCrash)` を呼ぶ（未完了 tool/permission も同時に終端）。その後 projection 結果を永続化する。
+
+永続化は従来どおり post-lock で `persist_streaming_parts()` 相当を呼ぶが、保存対象は `project(turn_event_log)` の message である。出力先は #1213 の split layout（`messages/{seq}.json` / `index.json` / `meta.json`）で不変（R6）。
+
+> observable behavior の不変は、terminal projection 時点で `project(turn_event_log)` が現行 `consolidate_parts_from_slice(&streaming_parts)` と同一の `Vec<MessagePart>` を生成することで担保する（テスト方針の golden 比較で検証）。mid-turn の durable-only projection では未確定の streamed text / thinking は event に含めないため、`project(turn_event_log)` と `consolidate_parts_from_slice(&streaming_parts)` は一致しない。
+
+### 復旧 / reconnect
+
+- **reconnect**: read model を `project(events)` で再構築する。projector は in-place 更新で重複を作らないため、累積 parts の二重適用は発生しない（failure mode 2 / behavior reconnect Rule）。
+- **crash / abort 後**: 終端 event が append 済みのため、再 projection で partial が残らない。互換 projector は projection 結果を `messages/{seq}.json` へ書くため、再起動後は永続化された projection（= 終端済み read model）を読む。決定的再構築は event 列に対する unit test で示す（A2 により event 列の独立永続化は将来拡張のため、crash 後の event 列そのものの復元は本変更の対象外。永続化されるのは projection 結果）。
+- **terminal 前 hard-crash**: streamed text / thinking は terminal の final live block で durable event 化する設計のため、terminal event 前に process / app が hard-crash した場合、mid-turn store に未確定 tail は含まれず、その text / thinking は復旧後の read model から失われ得る。これは mid-turn persist を durable event のみに限定して hot path と永続形式を保つための許容トレードオフであり、terminal 済み read model の reconnect 決定性とは矛盾しない。
+
+---
+
+## エラー処理
+
+- **projection の堅牢性**: 不整合な event 列（`ToolCallSucceeded` に対応する `ToolCallStarted` がない等）でも projector は panic せず、orphan event をスキップして warn ログに残す（#1213 の session 単位隔離方針を踏襲）。
+- **finalization の冪等性**: `finalize_turn()` は既に終端済みの tool call / permission を二重終端しない（未完了分のみ append）。`TurnInterrupted` が既にある turn への再 finalize は no-op。
+- **append 失敗の不在**: `TurnEventLog` は runtime memory（`Vec`）への push であり I/O を伴わないため append 自体は失敗しない。永続化（projection 結果書き込み）の失敗は従来どおり warn ログで継続し描画を妨げない（#1213 streaming persist 方針）。
+- **既存エラー文言の汎化**: フルパス・serde 生メッセージを API へ漏らさない既存方針を維持。
+
+---
+
+## テスト方針
+
+Rust は各モジュール `#[cfg(test)]`。CLAUDE.md / `docs/architecture/TEST.md` に従う。frontend 変更はないため frontend テストは追加しない。
+
+### projector / event_log（usecase, 純粋ロジック）
+
+- **append → projection の境界テスト**（受け入れ基準 2 / R3）: `TurnStarted` → `ToolCallStarted` → `ToolCallSucceeded` → `TurnCompleted` の event 列を project し、message page に prompt と tool 結果が含まれること。event 列に無い message が現れないこと。
+- **決定性**: 同一 event 列を 2 回 project して結果が一致すること。
+- **live-only 非依存**: event 列のみから read model が完全再構築でき、legacy live バッファを適用しなくても欠落しないこと。live-only delta が event 列に混入しないことを append API とテストで保証。
+- **session status の対応表**: 上記網羅表の各行（streaming 中 / permission 待ち / Idle / Error / Closed）を event 列から projection して期待 status になること（受け入れ基準 8 / R3）。
+- **runtime memory 非参照**: runtime を参照せず event 列のみで streaming 中・permission 待ちが判定できること。
+- **finalization**（受け入れ基準 5 / R4）: 進行中 turn ＋ 未完了 tool call ＋ 未解決 permission を持つ event 列に対し、abort / timeout / bridge crash それぞれで終端 event が付与され、projection 後に partial が残らないこと。終端後の完了判定が一意であること。
+- **reconnect 二重適用なし**: 同一 event 列の再 projection で message が重複しないこと。
+- **互換性（golden）**（受け入れ基準 6 / R6）: 代表的な SDK メッセージ列に対し、`project(turn_event_log)` の `Vec<MessagePart>` が現行 `consolidate_parts_from_slice` の出力と一致すること。
+
+### bridge_common（infrastructure, 経路置き換え）
+
+- **3 経路の event append**（受け入れ基準 7 / R7）: `accumulate_sdk_message` が durable event を append し live delta を分離すること。`run_turn_complete_transition_locked` が `TurnCompleted` を、`run_bridge_error_transition_locked` が finalization event を append すること。
+- **workflow 通知の event 由来**（B5）: `WorkflowTurnCompleteInput` が runtime `BridgeState` ではなく projection から導出されること。`TurnStarted` を持つ turn の終端でのみ通知されること。
+- **既存テスト維持**: turn-complete / bridge-error / timeout / interrupt の既存テスト群を新経路で通す。
+
+---
+
+## リスクと代替案
+
+### リスク
+
+- **`bridge_common.rs`（約 19,350 行）への侵襲**: 3 経路の差し替えは大規模ファイルの hot path に触れる。緩和: ロジックを `event_log` モジュール（純粋関数）へ寄せ、`bridge_common` 側は event append と projection 呼び出しに限定する。`event_log` を seam として残し #1217 の分割に備える。
+- **`project()` の呼び出し頻度**: streaming 中の毎 delta で全 event を再 project すると O(N²) になりうる。緩和: live バッファは incremental に更新し（直近確定 event のみ反映）、full projection は flush / turn 完了 / reconnect 等の境界に限定する。determinism テストは full projection で担保。
+- **golden 不一致の検出漏れ**: `project` と `consolidate_parts_from_slice` の出力差は observable behavior の破壊に直結する。緩和: 代表 SDK メッセージ列の golden 比較を必須テストとし、差分が出たら projector を修正する（実装を仕様に合わせる、CLAUDE.md 方針）。
+- **TurnPhase の二重定義**: infra `bridge_common::TurnPhase`（`Serialize` のみ）と usecase `status::TurnPhase`（`Serialize + Deserialize`）が併存する。projector は usecase 側を出力とし、infra 側は live 表示のために維持する（本変更で統合はしない / スコープ外）。
+
+### 代替案（不採用理由つき）
+
+- **event 列を独立ファイルへ即時永続化**: crash 後に event 列そのものから決定的再構築できる利点があるが、A2（初期は互換 projector）と R6（既存永続構造と矛盾しない）に照らし、新フォーマット導入は scope 過大。projection 結果を既存 split layout へ書く互換 projector を採用し、独立永続化は将来拡張余地とする。
+- **projector に finalization を推論させる（終端 event を append しない）**: event 列を小さく保てるが、「event 列が session の事実を自己完結して表す」という正典の不変条件が崩れ、projector の暗黙ルールに依存する。明示的終端 event の append を採用し、event 列だけで partial 不在を保証する。
+- **`streaming_parts` を完全廃止し projection 結果のみ保持**: 概念は綺麗だが cumulative snapshot の emit 経路を大幅に書き換え、#1214 のスコープに踏み込む。`streaming_parts` を「projection の保持器」として再定義する最小変更に留める。
+
+---
+
+## 仮定（Assumptions）
+
+`requirements.md` A1〜A5・`behavior.md` B1〜B5 を前提とする。本設計固有の仮定:
+
+- **D1.** event 列は初期実装では **runtime 保持（`AgentProcess::TurnEventLog`）** とし、独立永続化はしない。永続化されるのは projection 結果（既存 split layout）。crash 後の決定的再構築は「永続化済み projection を読む」＋「event 列に対する unit test で決定性を示す」で満たす（A2）。
+- **D2.** `AgentSessionEvent` の語彙は OpenCode をそのまま写すのではなく、既存 `MessagePart` / `BridgeState` / `TurnPhase` と整合する Releash 固有語彙とする（A3）。`MessagePart` の各 variant に projection で到達できることを最小要件とする。
+- **D3.** `project()` が現行 `consolidate_parts_from_slice` と同一の `Vec<MessagePart>` を生成することを observable behavior 不変の判定基準（golden）とする。
+- **D4.** `bridge_common.rs` は分割しない（#1217 / Non-goal）。event 駆動化は `event_log` モジュール利用として同ファイル内に閉じる。
+- **D5.** session status の `Done` / `Archived` は turn event からは導出せず、既存ライフサイクル遷移を維持して projection 結果へ上書き合成する。turn 由来は `Active` / `Idle` / `Error` / `Closed` と `TurnPhase` の二軸に限定する。
+- **D6.** frontend 変更・新規 Tauri コマンドは伴わない（A4）。projection 結果の serde 表現が不変のため frontend からは透過。
+
+---
+
+## Open Questions
+
+なし。`requirements.md` / `behavior.md` の Open Questions はすべて解消済みであり、本設計で新たに人間の判断を要する未確定点は生じていない。保存形式（互換 projector vs 独立永続化）は A2 により互換 projector と確定済み、語彙・projector 構造・モジュール配置・session status 対応表・finalization 終端 event は本書で確定した。

--- a/docs/specs/issues-1247/requirements.md
+++ b/docs/specs/issues-1247/requirements.md
@@ -1,0 +1,136 @@
+# requirements — issues-1247
+
+`AgentSessionEventLog` / Projector を導入し、Agent session の保存正典（source of truth）を定義する。
+
+## Type
+
+改善 / リファクタリング（内部アーキテクチャ整備、observable behavior は不変）
+
+## Goal
+
+Agent session の保存正典を、現在分散している `ChatSession` JSON / runtime memory（`AgentProcess` 等）/ streaming parts / workflow handoff から、単一の **durable event 列（`AgentSessionEventLog`）** へ収束させる。event 列を唯一の事実とし、message page・session status・workflow turn-complete input を **projection（read model 反映）** で導出できる構造を確立する。これにより streaming / persistence / recovery / workflow integration を同じ事実列から一貫して扱えるようにする。
+
+完了時に成功と判断する状態:
+
+- Agent session の durable event の最小語彙（`AgentSessionEvent`）が型として定義されている。
+- 永続化すべき durable event と、replay 不要な live-only delta（text/tool-input/reasoning の逐次 delta）が明文化されて区別されている。
+- 「event を append → read model へ projection する」境界が存在し、その境界テストがある。
+- abort / timeout / bridge crash 時に、turn / tool call / permission が未完了状態（partial）のまま残らない finalization ルールが定義されている。
+- 既存の外部から観測可能な振る舞い（UI 表示・session 一覧・streaming 体験・workflow 完了判定の結果）は変わらない。
+
+## Background
+
+現状の Agent session の状態は複数の場所に分散して保持されている（本リポジトリ調査による事実）:
+
+- **永続層（JSON session store）**: `src-tauri/src/usecase/agent_session/session/store.rs` および `adaptor/gateway/agent_session/session_storage/` が、`sessions/{id}/meta.json` + `messages/{seq}.json` + `index.json` のディレクトリ構造で `ChatSession` / `ChatMessage` / `MessagePart` を保存する（#1213 で導入された summary index + message paging 構造）。
+- **runtime memory**: `infrastructure/agent_session/runtime/bridge_common.rs` の `AgentProcess` が `streaming_parts: Vec<MessagePart>`・`BridgeState`・`TurnPhase` を turn 中に保持する。
+- **streaming parts**: streaming は cumulative snapshot 方式。`accumulate_sdk_message()` が SDK メッセージを `MessagePart` vector に push し、per-delta では差分 slice を emit、`run_turn_complete_transition_locked()` で consolidate して最終版を永続化する。
+- **workflow handoff**: turn 完了判定は `proc.state == BridgeState::Streaming`（user turn が実行されたか）を唯一の基準とし、workflow turn-complete 通知もこの runtime state で gating している。
+
+このため「session の正典がどこにあるか」が曖昧で、永続層・runtime・read model のどれを見るべきかが処理ごとに異なる。OpenCode は durable event（`Prompted` / `Tool.Called` / `Tool.Success` / `Tool.Failed` / `Retried` / `Compaction.*` 等）と ephemeral live delta（`Text.Delta` / `Tool.Input.Delta` / `Reasoning.Delta`）を分離し、durable event を projector で `SessionTable` / `MessageTable` / `PartTable` 等の read model へ反映している（issue 参照リンク）。この境界を Releash にも導入することが本変更の主旨である。
+
+### 改善対象の failure mode
+
+1. abort 後に partial stream / running tool call が read model に残る。
+2. UI reconnect 時に累積 parts が二重適用される。
+3. workflow step の完了判定が runtime state と session JSON のどちらを見ればよいか曖昧。
+4. permission / tool call / retry の履歴が read model にしか残らず、復旧時に再構築できない。
+
+## Users / Actors
+
+- **Releash 本体の開発者**: session 保存・streaming・recovery・workflow 統合を、分散した状態ではなく単一の event 列から扱えるようになる（直接の受益者）。
+- **エンドユーザー**: 間接的受益者。abort / crash / reconnect 時の表示破綻（partial / 二重適用）が解消されることで体験が改善するが、新たに操作する UI 機能は本変更では追加しない。
+
+## Scope
+
+- `AgentSessionEvent`（durable event）の最小語彙を Rust 型として定義する。
+- durable event と live-only delta の区別を型・ドキュメントの両面で明文化する。
+- event を append し read model（message page / session status / workflow turn-complete input）へ projection する境界（projector）を定義する。
+- 上記境界に対する単体／境界テストを追加する。
+- abort / timeout / bridge crash 時に turn / tool call / permission を未完了で残さない finalization ルールを定義し、event 列上で表現できるようにする。
+- 既存の実処理経路（`accumulate_sdk_message` / `run_turn_complete_transition_locked` / `run_bridge_error_transition_locked`）を event 列駆動へ置き換える（R7）。
+- session status の projection 対象に、永続側 `SessionState` だけでなく runtime 由来の遷移状態（streaming 中・permission 待ち）も含める（R3）。
+- 本変更が #1213（summary index + message paging）/ #1214（seq delta streaming）/ #1217（bridge_common.rs 分割）のどこに接続するかを設計コメントまたは docs に明記する。
+
+## Non-goals
+
+- streaming protocol を cumulative snapshot から seq delta protocol へ移行すること（#1214 が担当）。本変更は cumulative snapshot 前提のまま、event/delta の概念境界のみ導入する。
+- `bridge_common.rs` を runtime / stream / persist / recovery へモジュール分割すること（#1217 が担当）。
+- 既存の外部から観測可能な振る舞い（UI 表示内容・session 一覧 API の結果・streaming の見え方・workflow 完了の結果）を変更すること。本変更は内部の保存正典の再定義に限定する。
+- workflow / session の UI 再編（#1220 / #1242）や telemetry 計装（#1209）。
+- 既存永続データ（`messages/{seq}.json` 等）のフォーマット破壊的変更を伴うマイグレーション（互換 projector で吸収する。仮定を参照）。
+
+## Requirements
+
+### R1. durable event 語彙の定義
+- `AgentSessionEvent` を、session の事実列を構成する最小語彙として定義する。
+- 語彙は OpenCode の durable event を参考にしつつ、Releash の既存 `MessagePart`（`Thinking` / `Text` / `ToolUse` / `ToolResult` / `Error` / `Permission` / `TaskStatus` / `TodoListSnapshot` / `SystemNotification` / `Image` / `ImageRef`）と整合する範囲で定める。少なくとも、prompt 投入・tool 呼び出しの開始/成功/失敗・retry・turn 完了・interrupt（abort）・permission 解決を表現できること。
+
+### R2. durable / live-only の分離
+- replay 可能な durable event と、replay 不要で表示中のみ意味を持つ live-only delta（`Text.Delta` / `Tool.Input.Delta` / `Reasoning.Delta` 相当）を明確に区別する。
+- どの SDK メッセージ／内部イベントが durable event になり、どれが live-only に留まるかを明文化する。
+
+### R3. append → projection 境界
+- durable event を append すると、read model（少なくとも message page・session status・workflow turn-complete input）が event 列から導出される境界を定義する。
+- read model は event 列の projection であり、event 列を正典とする。
+- **session status の projection 対象は、永続側の `SessionState`（Active / Idle / Done / Error / Closed / Archived）に加え、runtime 由来の遷移状態（streaming 中・permission 待ち、現状 `BridgeState` / `TurnPhase` 相当）も含める。** すなわち「session が今どの実行フェーズにあるか」を event 列から projection で導出できること。runtime memory が唯一の保持者である状態を残さない。
+
+### R4. finalization ルール
+- abort（interrupt）/ timeout / bridge crash の各ケースで、turn / 実行中 tool call / 未解決 permission を未完了状態のまま残さない終端 event を必ず付与するルールを定義する。
+- このルールにより failure mode 1（partial 残存）・3（完了判定の曖昧さ）が event 列上で一意に解決されること。
+
+### R5. 既存接続点の明記
+- 本変更が #1213 / #1214 / #1217 のどこに接続・依存するかを、設計コメントまたは docs として残す。
+
+### R6. observable behavior の保持
+- 既存の外部から観測可能な振る舞いを変えない。初期実装は、既存の `ChatSession` JSON 構造へ projection する **互換 projector** でよい。
+
+### R7. 既存処理経路の event 列駆動への置き換え
+- 本変更のスコープとして、既存の実処理経路（`accumulate_sdk_message` / `run_turn_complete_transition_locked` / `run_bridge_error_transition_locked`）を event 列駆動へ置き換える。これらの経路が runtime memory を直接更新するのではなく、durable event の append を介して read model に反映される構造にする。
+- これにより保存正典の一本化を、語彙・境界の定義に留めず実際の処理経路まで貫徹する。
+- ただし observable behavior は不変（R6）を維持し、cumulative snapshot 前提・`bridge_common.rs` 未分割の現状コード上で成立させる（#1214 / #1217 の完了を前提にしない）。`bridge_common.rs` のモジュール分割そのものは Non-goal（#1217 が担当）であり、本変更は分割せずに経路を event 駆動へ差し替える。
+
+## 受け入れ基準の概要
+
+issue の受け入れ基準に対応する:
+
+1. `AgentSessionEvent` の最小語彙が型として定義されている。（R1）
+2. 「append event → project read model」の境界テストが存在する。（R3）
+3. live-only delta と replay 可能な durable event の区別が明文化されている。（R2）
+4. #1213 / #1214 / #1217 のどこに接続するかが設計コメントまたは docs に明記されている。（R5）
+5. abort / timeout / bridge crash 時に turn / tool call / permission が未完了で残らない finalization ルールが定義されている。（R4）
+6. 既存の observable behavior が変わらない。初期実装は互換 projector で可。（R6）
+7. 既存の実処理経路（accumulate / turn-complete / bridge-error）が event 列駆動へ置き換えられている。（R7）
+8. session status の projection に runtime 由来の遷移状態（streaming 中・permission 待ち）が含まれる。（R3）
+
+詳細な Gherkin 形式の受け入れ基準は `behavior.md` で定義する。
+
+## Constraints
+
+- 全ロジックは Rust（Tauri バックエンド）側に実装する。フロントエンドはインターフェースに徹する（`.claude/rules/rust-first-logic.md`）。
+- 既存の session 永続構造（#1213 で導入された `meta.json` / `messages/{seq}.json` / `index.json`）と矛盾しない。互換 projector で既存構造へ反映できること。
+- #1214 / #1217 がまだ未完了（OPEN）であるため、本変更はそれらの完了を前提にしない。cumulative snapshot 前提・`bridge_common.rs` 未分割の現状コード上で成立すること。
+- CI と同一のチェック（`cargo fmt --check`・`cargo clippy -- -D warnings`・`cargo test`）を通す。
+
+## Success Criteria
+
+- 上記受け入れ基準 1〜6 をすべて満たす。
+- 新規ロジック（event 語彙・projector・finalization）に単体／境界テストがある。
+- abort / crash / reconnect の各シナリオで、read model が event 列から決定的に再構築でき、partial / 二重適用が発生しないことがテストで示される。
+
+## 仮定（Assumptions）
+
+- **A1.** Spec ディレクトリ名は `docs/specs/issues-1247` とする（既存の `issues-1209` 等の命名規約に合わせる。`feat-issues-1213` 形式も併存するが、新しい番号付きディレクトリは `issues-NNN` 形式を採用する）。
+- **A2.** 本ステップ（requirements）では、event 列を独立した永続ファイルとして持つか、既存 JSON 構造へ互換 projection するに留めるかという保存形式の選択は確定しない。issue が「初期実装は互換 projector でもよい」と許容しているため、初期実装は **互換 projector**（既存 `ChatSession` JSON 構造へ projection）を前提とし、event 列の独立永続化は将来拡張余地として扱う。具体的な保存形式は `design.md` で決める。
+- **A3.** durable event の最小語彙は、OpenCode の語彙そのままではなく、Releash の既存 `MessagePart` / `BridgeState` / `TurnPhase` と整合する Releash 固有の語彙として定義する。
+- **A4.** 本変更は内部リファクタリングであり、新たな Tauri コマンドや UI 要素の追加は伴わない（observable behavior 不変の制約による）。
+- **A5.** 関連 issue #767 の扱いは、本変更の前提・依存には含めない（参考関連のみ）。
+
+## Open Questions
+
+なし（すべて解消済み）。
+
+解消済みの決定事項:
+
+- session status の projection 対象は、永続側 `SessionState` に加え runtime 由来の遷移状態（streaming 中・permission 待ち）も含める → R3 に反映。
+- 本変更のスコープは語彙・境界・finalization の定義に留めず、既存の実処理経路（accumulate / turn-complete / bridge-error）を event 列駆動へ置き換えるところまで含める → R7 に反映。

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
@@ -4,11 +4,13 @@ use std::sync::atomic::AtomicBool;
 
 use parking_lot::RwLock;
 
+use crate::usecase::agent_session::event_log::AgentSessionEvent;
 use crate::usecase::agent_session::session::{
     ChatMessage, ChatSession, MessagePart, PageCursor, SessionAttachment, SessionMeta, SessionPage,
 };
 
 mod attachment_blob;
+mod event_store;
 mod fork_copier;
 mod layout;
 mod legacy;
@@ -52,6 +54,7 @@ impl crate::domain::agent_session::AgentSessionStorageTypes for FileSessionStora
     type Message = ChatMessage;
     type MessagePart = MessagePart;
     type Attachment = SessionAttachment;
+    type Event = AgentSessionEvent;
 }
 
 impl crate::domain::agent_session::AgentSessionReader for FileSessionStorage {
@@ -83,6 +86,20 @@ impl crate::domain::agent_session::AgentSessionReader for FileSessionStorage {
         FileSessionStorage::load_full_session_for_restore(self, app_data_dir, session_id)
     }
 
+    fn load_previous_human_message_before_agent(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        agent_message_id: &str,
+    ) -> Result<Option<Self::Message>, String> {
+        FileSessionStorage::load_previous_human_message_before_agent(
+            self,
+            app_data_dir,
+            session_id,
+            agent_message_id,
+        )
+    }
+
     fn get_session_page(
         &self,
         app_data_dir: &Path,
@@ -100,6 +117,14 @@ impl crate::domain::agent_session::AgentSessionReader for FileSessionStorage {
         attachment_id: &str,
     ) -> Result<Option<Self::Attachment>, String> {
         FileSessionStorage::get_session_attachment(self, app_data_dir, session_id, attachment_id)
+    }
+
+    fn load_session_events(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+    ) -> Result<Vec<Self::Event>, String> {
+        FileSessionStorage::load_session_events(self, app_data_dir, session_id)
     }
 }
 
@@ -168,5 +193,14 @@ impl crate::domain::agent_session::AgentSessionWriter for FileSessionStorage {
             parts,
             completed_at,
         )
+    }
+
+    fn append_session_event(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        event: &Self::Event,
+    ) -> Result<Vec<Self::Event>, String> {
+        FileSessionStorage::append_session_event(self, app_data_dir, session_id, event)
     }
 }

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/event_store.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/event_store.rs
@@ -1,0 +1,60 @@
+use std::io::BufReader;
+use std::path::Path;
+
+use super::layout::{event_log_file_in_dir, session_dir, write_json_pretty_atomic};
+use super::FileSessionStorage;
+use crate::usecase::agent_session::event_log::AgentSessionEvent;
+
+impl FileSessionStorage {
+    pub fn load_session_events(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+    ) -> Result<Vec<AgentSessionEvent>, String> {
+        self.ensure_loaded(app_data_dir)?;
+        if let Some(err) = self.invalid_sessions.read().get(session_id) {
+            return Err(err.clone());
+        }
+        if !self.cache.read().contains_key(session_id) {
+            return Err(format!("Session not found: {session_id}"));
+        }
+        self.ensure_session_layout(app_data_dir, session_id)?;
+        let dir = session_dir(app_data_dir, session_id)?;
+        self.read_session_events_from_dir(&dir)
+    }
+
+    pub fn append_session_event(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        event: &AgentSessionEvent,
+    ) -> Result<Vec<AgentSessionEvent>, String> {
+        self.ensure_loaded(app_data_dir)?;
+        if let Some(err) = self.invalid_sessions.read().get(session_id) {
+            return Err(err.clone());
+        }
+        if !self.cache.read().contains_key(session_id) {
+            return Err(format!("Session not found: {session_id}"));
+        }
+        self.ensure_session_layout(app_data_dir, session_id)?;
+        let _lock = self.file_lock.lock();
+        let dir = session_dir(app_data_dir, session_id)?;
+        let mut events = self.read_session_events_from_dir(&dir)?;
+        events.push(event.clone());
+        write_json_pretty_atomic(&event_log_file_in_dir(&dir), &events, "session event log")?;
+        Ok(events)
+    }
+
+    pub(super) fn read_session_events_from_dir(
+        &self,
+        dir: &Path,
+    ) -> Result<Vec<AgentSessionEvent>, String> {
+        let path = event_log_file_in_dir(dir);
+        match std::fs::File::open(&path) {
+            Ok(file) => serde_json::from_reader(BufReader::new(file))
+                .map_err(|e| format!("Failed to parse session event log: {e}")),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+            Err(e) => Err(format!("Failed to read session event log: {e}")),
+        }
+    }
+}

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/layout.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/layout.rs
@@ -50,6 +50,10 @@ pub(super) fn index_file_in_dir(session_dir: &Path) -> PathBuf {
     session_dir.join("index.json")
 }
 
+pub(super) fn event_log_file_in_dir(session_dir: &Path) -> PathBuf {
+    session_dir.join("events.json")
+}
+
 pub(super) fn messages_dir_in_dir(session_dir: &Path) -> PathBuf {
     session_dir.join("messages")
 }

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/message_store.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/message_store.rs
@@ -10,8 +10,8 @@ use super::layout::{
 use super::FileSessionStorage;
 use crate::usecase::agent_session::session::{
     first_message_preview, now_timestamp, parts_to_legacy, ChatMessage, ChatSession,
-    MessageIndexEntry, MessagePageMetadata, MessagePart, PageCursor, SessionMeta, SessionPage,
-    MAX_SESSION_PAGE_LIMIT, SESSION_BODY_FORMAT_VERSION,
+    MessageIndexEntry, MessagePageMetadata, MessagePart, MessageRole, PageCursor, SessionMeta,
+    SessionPage, MAX_SESSION_PAGE_LIMIT, SESSION_BODY_FORMAT_VERSION,
 };
 
 fn measure_save_result<T, F, S>(
@@ -49,6 +49,45 @@ impl FileSessionStorage {
                 self.ensure_session_layout(app_data_dir, session_id)?;
                 self.load_full_session_from_layout(app_data_dir, session_id)
                     .map(Some)
+            },
+        )
+    }
+
+    pub fn load_previous_human_message_before_agent(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        agent_message_id: &str,
+    ) -> Result<Option<ChatMessage>, String> {
+        crate::other::telemetry::measure_result(
+            crate::other::telemetry::HotPath::SessionGetPage,
+            || {
+                self.ensure_loaded(app_data_dir)?;
+                if let Some(err) = self.invalid_sessions.read().get(session_id) {
+                    return Err(err.clone());
+                }
+                if !self.cache.read().contains_key(session_id) {
+                    return Ok(None);
+                }
+                self.ensure_session_layout(app_data_dir, session_id)?;
+                let dir = session_dir(app_data_dir, session_id)?;
+                let index = self.read_consistent_index_from_dir(&dir, session_id)?;
+                let Some(agent_entry) = index
+                    .iter()
+                    .find(|entry| entry.id == agent_message_id && entry.role == MessageRole::Agent)
+                else {
+                    return Ok(None);
+                };
+                let Some(human_entry) = index
+                    .iter()
+                    .rev()
+                    .find(|entry| entry.seq < agent_entry.seq && entry.role == MessageRole::Human)
+                else {
+                    return Ok(None);
+                };
+                let message =
+                    self.read_message_file(&message_file_in_dir(&dir, human_entry.seq))?;
+                self.hydrate_message_attachments(&dir, message).map(Some)
             },
         )
     }

--- a/src-tauri/src/domain/agent_session/storage.rs
+++ b/src-tauri/src/domain/agent_session/storage.rs
@@ -8,6 +8,7 @@ pub trait AgentSessionStorageTypes: Send + Sync {
     type Message;
     type MessagePart;
     type Attachment;
+    type Event;
 }
 
 pub trait AgentSessionReader: AgentSessionStorageTypes {
@@ -31,6 +32,13 @@ pub trait AgentSessionReader: AgentSessionStorageTypes {
         session_id: &str,
     ) -> Result<Option<Self::Session>, String>;
 
+    fn load_previous_human_message_before_agent(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        agent_message_id: &str,
+    ) -> Result<Option<Self::Message>, String>;
+
     fn get_session_page(
         &self,
         app_data_dir: &Path,
@@ -45,6 +53,12 @@ pub trait AgentSessionReader: AgentSessionStorageTypes {
         session_id: &str,
         attachment_id: &str,
     ) -> Result<Option<Self::Attachment>, String>;
+
+    fn load_session_events(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+    ) -> Result<Vec<Self::Event>, String>;
 }
 
 pub trait AgentSessionWriter: AgentSessionStorageTypes {
@@ -96,6 +110,13 @@ pub trait AgentSessionWriter: AgentSessionStorageTypes {
         parts: &[Self::MessagePart],
         completed_at: Option<f64>,
     ) -> Result<(), String>;
+
+    fn append_session_event(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        event: &Self::Event,
+    ) -> Result<Vec<Self::Event>, String>;
 }
 
 pub trait AgentSessionStorage: AgentSessionReader + AgentSessionWriter {}

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs
@@ -27,6 +27,10 @@ use crate::infrastructure::agent_session::runtime::{
     AgentEditorContext, AgentMessage, BackendRuntimeConfig, ImageAttachment, ModelInfo,
     SessionConfig, SessionHandle,
 };
+use crate::usecase::agent_session::event_log::{
+    human_parts_from_content_images, AgentSessionEvent, InterruptReason, PartEventMode,
+    PermissionDecision, PromptInput, TurnEventLog, TurnTokenUsage, WorkflowTurnCompleteInput,
+};
 #[cfg(test)]
 use crate::usecase::agent_session::session::create_session_internal;
 #[cfg(test)]
@@ -35,8 +39,8 @@ use crate::usecase::agent_session::session::validate_image_bytes;
 use crate::usecase::agent_session::session::{
     add_message_internal, now_timestamp, parts_to_legacy, ChatMessage, ChatSession,
     ContextCarryState, GetSessionResponse, InitialSessionPage, MessagePart, MessageRole,
-    PageCursor, SessionMeta, SessionPage, SessionStore, SessionSummary, SystemNotificationType,
-    TokenUsage, INITIAL_SESSION_PAGE_LIMIT,
+    PageCursor, SessionMeta, SessionPage, SessionState, SessionStore, SessionSummary,
+    SystemNotificationType, TokenUsage, INITIAL_SESSION_PAGE_LIMIT,
 };
 
 pub(crate) use crate::infrastructure::agent_session::runtime::runtime_coordinator::acquire_session_runtime_lock;
@@ -103,6 +107,9 @@ pub struct AgentProcess {
     /// `last_message_id` can accept post-turn background task updates.
     post_turn_message_token: Option<String>,
     pub streaming_parts: Vec<MessagePart>,
+    /// Per-turn durable event buffer. This is the fact stream used by projection;
+    /// `streaming_parts` remains only as the existing cumulative live buffer.
+    pub turn_event_log: TurnEventLog,
     /// Retained after turn_complete so post-turn background task events
     /// can still be accumulated and emitted via `agent-streaming-updated`.
     pub last_message_id: Option<String>,
@@ -185,6 +192,7 @@ pub(crate) fn make_test_agent_process() -> AgentProcess {
         active_turn_token: None,
         post_turn_message_token: None,
         streaming_parts: Vec::new(),
+        turn_event_log: TurnEventLog::default(),
         last_message_id: None,
         post_turn_base_untrusted_message_id: None,
         task_id_map: HashMap::new(),
@@ -211,23 +219,39 @@ pub type AgentProcessMap = HashMap<String, AgentProcess>;
 /// drain 時に永続化する人間メッセージの parts を pending から構築する。
 /// 画像が無ければ None（content は add_message_internal が text として扱う）。
 fn pending_human_parts(pending: &PendingMessage) -> Option<Vec<MessagePart>> {
-    if pending.images.is_empty() {
-        return None;
+    let parts = human_parts_from_content_images(
+        &pending.content,
+        pending
+            .images
+            .iter()
+            .map(|image| (image.data.clone(), image.media_type.clone())),
+    );
+    (!parts.is_empty()).then_some(parts)
+}
+
+struct StartedTurnPrompt {
+    message_id: String,
+    prompt: PromptInput,
+}
+
+fn fallback_prompt_message_id(streaming_message_id: &str) -> String {
+    format!("{streaming_message_id}:prompt")
+}
+
+fn started_turn_prompt_from_fallback(
+    streaming_message_id: &str,
+    content: &str,
+    images: &[ImageAttachment],
+) -> StartedTurnPrompt {
+    StartedTurnPrompt {
+        message_id: fallback_prompt_message_id(streaming_message_id),
+        prompt: PromptInput::from_content_images(
+            content,
+            images
+                .iter()
+                .map(|image| (image.data.clone(), image.media_type.clone())),
+        ),
     }
-    let mut p: Vec<MessagePart> = Vec::new();
-    if !pending.content.is_empty() {
-        p.push(MessagePart::Text {
-            content: pending.content.clone(),
-            parent_tool_use_id: None,
-        });
-    }
-    for img in &pending.images {
-        p.push(MessagePart::Image {
-            data: img.data.clone(),
-            media_type: img.media_type.clone(),
-        });
-    }
-    Some(p)
 }
 
 fn pending_message_to_queued_turn(
@@ -565,6 +589,7 @@ impl AgentProcess {
     /// would block the first emit of the new turn from firing immediately.
     fn reset_streaming_state_for_new_turn(&mut self) {
         self.streaming_parts.clear();
+        self.turn_event_log.clear();
         self.pending_stream_part_count = 0;
         self.pending_stream_bytes = 0;
         self.last_stream_emit_at = None;
@@ -613,8 +638,269 @@ fn release_completed_turn_streaming_buffer(proc: &mut AgentProcess) -> Vec<Messa
     released_parts
 }
 
+fn from_projected_turn_phase(phase: crate::usecase::agent_session::status::TurnPhase) -> TurnPhase {
+    match phase {
+        crate::usecase::agent_session::status::TurnPhase::Idle => TurnPhase::Idle,
+        crate::usecase::agent_session::status::TurnPhase::Streaming => TurnPhase::Streaming,
+        crate::usecase::agent_session::status::TurnPhase::WaitingPermission => {
+            TurnPhase::WaitingPermission
+        }
+    }
+}
+
+fn event_turn_id(proc: &AgentProcess) -> u64 {
+    proc.turn_event_log
+        .current_turn_id()
+        .unwrap_or(proc.turn_seq)
+}
+
+fn begin_turn_event_log(
+    proc: &mut AgentProcess,
+    prompt_message_id: &str,
+    prompt: PromptInput,
+    assistant_message_id: &str,
+    at: f64,
+) {
+    proc.turn_event_log.begin_turn(
+        proc.turn_seq,
+        prompt_message_id.to_string(),
+        assistant_message_id.to_string(),
+        prompt,
+        at,
+    );
+    proc.turn_phase = from_projected_turn_phase(proc.turn_event_log.project().status.turn_phase);
+}
+
+fn projected_session_state_for_current_turn(proc: &AgentProcess) -> Option<SessionState> {
+    proc.turn_event_log.current_turn_id()?;
+    Some(proc.turn_event_log.project().status.session_state)
+}
+
+fn ensure_turn_event_log_started(proc: &mut AgentProcess) {
+    if proc.turn_event_log.current_turn_id().is_some() {
+        return;
+    }
+    let Some(message_id) = proc
+        .streaming_message_id
+        .clone()
+        .or_else(|| proc.last_message_id.clone())
+    else {
+        return;
+    };
+    let prompt_message_id = fallback_prompt_message_id(&message_id);
+    begin_turn_event_log(
+        proc,
+        &prompt_message_id,
+        PromptInput::default(),
+        &message_id,
+        now_timestamp(),
+    );
+}
+
+fn record_durable_parts_for_current_turn(
+    proc: &mut AgentProcess,
+    message_id: &str,
+    parts: &[MessagePart],
+) -> usize {
+    ensure_turn_event_log_started(proc);
+    let turn_id = event_turn_id(proc);
+    let appended = proc.turn_event_log.append_part_events(
+        turn_id,
+        message_id,
+        parts,
+        PartEventMode::DurableOnly,
+    );
+    if appended == 0 {
+        return 0;
+    }
+    let read_model = proc.turn_event_log.project();
+    if parts
+        .iter()
+        .any(|part| matches!(part, MessagePart::ToolUse { .. }))
+    {
+        if let Some(retry) = read_model.tool_retries.last() {
+            log::trace!(
+                "agent session event log recorded tool retry: turn={} tool_use_id={} attempt={}",
+                retry.turn_id,
+                retry.tool_use_id,
+                retry.attempt
+            );
+        }
+    }
+    proc.turn_phase = from_projected_turn_phase(read_model.status.turn_phase);
+    appended
+}
+
+fn record_permission_resolution_for_current_turn(
+    proc: &mut AgentProcess,
+    request_id: &str,
+    behavior: &str,
+    answers: Option<serde_json::Value>,
+) {
+    ensure_turn_event_log_started(proc);
+    let decision = if behavior == "allow" {
+        PermissionDecision::Allowed
+    } else {
+        PermissionDecision::Denied
+    };
+    let turn_id = event_turn_id(proc);
+    proc.turn_event_log
+        .append(AgentSessionEvent::PermissionResolved {
+            turn_id,
+            tool_use_id: None,
+            request_id: Some(request_id.to_string()),
+            decision,
+            answers,
+        });
+    proc.turn_phase = from_projected_turn_phase(proc.turn_event_log.project().status.turn_phase);
+}
+
+fn workflow_token_usage(token_usage: Option<(u64, u64)>) -> Option<TurnTokenUsage> {
+    token_usage.map(|(input_tokens, output_tokens)| TurnTokenUsage {
+        input_tokens,
+        output_tokens,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct ProjectedTurnTerminal {
+    final_parts: Vec<MessagePart>,
+    workflow_turn_complete: Option<WorkflowTurnCompleteInput>,
+    session_state: SessionState,
+    turn_completed: bool,
+}
+
+fn append_terminal_events_and_project(
+    proc: &mut AgentProcess,
+    message_id: &str,
+    exit_code: i64,
+    interrupt: Option<(InterruptReason, Option<String>)>,
+    token_usage: Option<(u64, u64)>,
+) -> Option<ProjectedTurnTerminal> {
+    let turn_id = proc.turn_event_log.current_turn_id()?;
+    let final_live_parts = consolidate_parts_from_slice(&proc.streaming_parts);
+    append_terminal_part_events_in_order(proc, turn_id, message_id, &final_live_parts);
+    if interrupt.is_none() && !final_live_parts.is_empty() {
+        proc.turn_event_log
+            .append(AgentSessionEvent::FinalPartsRecorded {
+                turn_id,
+                message_id: message_id.to_string(),
+                parts: final_live_parts.clone(),
+            });
+    }
+
+    match interrupt {
+        Some((reason, error)) => proc
+            .turn_event_log
+            .finalize(turn_id, reason, error, exit_code),
+        None => proc
+            .turn_event_log
+            .append(AgentSessionEvent::TurnCompleted {
+                turn_id,
+                exit_code,
+                token_usage: workflow_token_usage(token_usage),
+            }),
+    }
+
+    let read_model = proc.turn_event_log.project();
+    proc.turn_phase = from_projected_turn_phase(read_model.status.turn_phase);
+    let final_parts = read_model.agent_parts_for_message(message_id);
+    let session_state = read_model.status.session_state;
+    let workflow_turn_complete = read_model.workflow_turn_complete;
+    let turn_completed = workflow_turn_complete
+        .as_ref()
+        .is_some_and(|input| input.turn_id == turn_id);
+    Some(ProjectedTurnTerminal {
+        final_parts,
+        workflow_turn_complete,
+        session_state,
+        turn_completed,
+    })
+}
+
+fn append_terminal_part_events_in_order(
+    proc: &mut AgentProcess,
+    turn_id: u64,
+    message_id: &str,
+    final_parts: &[MessagePart],
+) {
+    let projected_parts = proc
+        .turn_event_log
+        .project()
+        .agent_parts_for_message(message_id);
+    let mut consumed_projected = vec![false; projected_parts.len()];
+    for part in final_parts {
+        if let Some(index) =
+            projected_parts
+                .iter()
+                .enumerate()
+                .find_map(|(index, projected_part)| {
+                    (!consumed_projected[index] && projected_part == part).then_some(index)
+                })
+        {
+            consumed_projected[index] = true;
+            continue;
+        }
+
+        let mode = if terminal_part_has_live_final_event(part) {
+            PartEventMode::FinalLiveBlocks
+        } else {
+            PartEventMode::DurableOnly
+        };
+        proc.turn_event_log.append_part_events(
+            turn_id,
+            message_id,
+            std::slice::from_ref(part),
+            mode,
+        );
+    }
+}
+
+fn terminal_part_has_live_final_event(part: &MessagePart) -> bool {
+    matches!(
+        part,
+        MessagePart::Text { .. } | MessagePart::Thinking { .. } | MessagePart::Error { .. }
+    )
+}
+
 fn mark_post_turn_store_base_untrusted(proc: &mut AgentProcess, message_id: &str) {
     proc.post_turn_base_untrusted_message_id = Some(message_id.to_string());
+}
+
+fn append_parts_to_event_log_in_order(
+    log: &mut TurnEventLog,
+    turn_id: u64,
+    message_id: &str,
+    parts: &[MessagePart],
+) {
+    for (index, part) in parts.iter().enumerate() {
+        if text_is_projected_by_following_todo_snapshot(part, parts.get(index + 1)) {
+            continue;
+        }
+        let mode = if terminal_part_has_live_final_event(part) {
+            PartEventMode::FinalLiveBlocks
+        } else {
+            PartEventMode::DurableOnly
+        };
+        log.append_part_events(turn_id, message_id, std::slice::from_ref(part), mode);
+    }
+}
+
+fn text_is_projected_by_following_todo_snapshot(
+    part: &MessagePart,
+    next: Option<&MessagePart>,
+) -> bool {
+    let MessagePart::Text {
+        content,
+        parent_tool_use_id: None,
+    } = part
+    else {
+        return false;
+    };
+    let Some(MessagePart::TodoListSnapshot { items }) = next else {
+        return false;
+    };
+    content == &todo_update_log(items)
 }
 
 fn clear_post_turn_store_base_untrusted_after_persist_success(
@@ -1360,14 +1646,14 @@ fn flush_streaming_before_transition<F>(
 where
     F: FnMut(&str, &[MessagePart]) -> (bool, bool),
 {
-    let was_streaming = proc.state == BridgeState::Streaming;
+    let turn_completed = proc.state == BridgeState::Streaming;
     let Some(mid) = proc.streaming_message_id.clone() else {
-        return was_streaming;
+        return turn_completed;
     };
     let _ = force_flush_pending_streaming(proc, chat_session_id, &mid, |parts| {
         emit_stream(&mid, parts)
     });
-    was_streaming
+    turn_completed
 }
 
 /// Effect returned by `run_permission_request_transition_locked`. The caller
@@ -1377,6 +1663,7 @@ where
 #[derive(Debug, Default, PartialEq, Eq)]
 struct PermissionRequestTransition {
     did_transition: bool,
+    projected_session_state: Option<SessionState>,
 }
 
 /// Run the in-lock part of the `permission_request` transition: force-flush
@@ -1393,26 +1680,28 @@ fn run_permission_request_transition_locked<F>(
 where
     F: FnMut(&str, &[MessagePart]) -> (bool, bool),
 {
-    let was_streaming = flush_streaming_before_transition(proc, chat_session_id, emit_stream);
-    if was_streaming {
+    let turn_completed = flush_streaming_before_transition(proc, chat_session_id, emit_stream);
+    if turn_completed {
         proc.turn_phase = TurnPhase::WaitingPermission;
         proc.mark_turn_phase_since_now();
     }
     PermissionRequestTransition {
-        did_transition: was_streaming,
+        did_transition: turn_completed,
+        projected_session_state: projected_session_state_for_current_turn(proc),
     }
 }
 
 /// Effect returned by `run_turn_complete_transition_locked`. Carries the
 /// data the caller needs to perform the post-lock follow-ups: state-change
-/// emission, message persistence, and workflow hooks. `was_streaming` gates
+/// emission, message persistence, and workflow hooks. `turn_completed` gates
 /// the `agent-session-state-changed(Idle)` emission.
 #[derive(Debug, Default)]
 struct TurnCompleteTransition {
-    was_streaming: bool,
+    turn_completed: bool,
     final_msg_id: Option<String>,
     final_parts: Vec<MessagePart>,
-    turn_token_usage: Option<(u64, u64)>,
+    workflow_turn_complete: Option<WorkflowTurnCompleteInput>,
+    projected_session_state: Option<SessionState>,
     released_streaming_parts: Vec<MessagePart>,
 }
 
@@ -1421,6 +1710,7 @@ struct TurnCompleteTransition {
 /// snapshot the data the caller needs after releasing the lock. Mirrors the
 /// production stdout reader so tests can drive the exact same code path
 /// (instead of mirroring prepare/apply inline).
+#[cfg(test)]
 fn run_turn_complete_transition_locked<F>(
     proc: &mut AgentProcess,
     chat_session_id: &str,
@@ -1430,10 +1720,35 @@ fn run_turn_complete_transition_locked<F>(
 where
     F: FnMut(&str, &[MessagePart]) -> (bool, bool),
 {
+    run_turn_complete_transition_locked_with_interrupt(
+        proc,
+        chat_session_id,
+        exit_code,
+        None,
+        None,
+        emit_stream,
+    )
+}
+
+fn run_turn_complete_transition_locked_with_interrupt<F>(
+    proc: &mut AgentProcess,
+    chat_session_id: &str,
+    exit_code: i64,
+    interrupt_reason: Option<InterruptReason>,
+    interrupt_error: Option<String>,
+    emit_stream: F,
+) -> TurnCompleteTransition
+where
+    F: FnMut(&str, &[MessagePart]) -> (bool, bool),
+{
     if proc.turn_phase == TurnPhase::Idle && proc.state != BridgeState::Initializing {
         return TurnCompleteTransition::default();
     }
-    let was_streaming = flush_streaming_before_transition(proc, chat_session_id, emit_stream);
+    debug_assert_eq!(
+        proc.state == BridgeState::Streaming,
+        proc.streaming_message_id.is_some()
+    );
+    let _flushed_streaming = flush_streaming_before_transition(proc, chat_session_id, emit_stream);
     proc.state = if exit_code == 0 {
         BridgeState::Ready
     } else {
@@ -1444,8 +1759,28 @@ where
     proc.last_progress_at = None;
     proc.turn_watchdog_active = false;
     let turn_token_usage = proc.last_result_token_usage.take();
-    let final_parts = consolidate_parts_from_slice(&proc.streaming_parts);
     let final_msg_id = proc.streaming_message_id.take();
+    let projected_terminal = final_msg_id.as_ref().and_then(|message_id| {
+        append_terminal_events_and_project(
+            proc,
+            message_id,
+            exit_code,
+            interrupt_reason.map(|reason| (reason, interrupt_error.clone())),
+            turn_token_usage,
+        )
+    });
+    let final_parts = projected_terminal
+        .as_ref()
+        .map(|terminal| terminal.final_parts.clone())
+        .unwrap_or_else(|| consolidate_parts_from_slice(&proc.streaming_parts));
+    let turn_completed = projected_terminal
+        .as_ref()
+        .is_some_and(|terminal| terminal.turn_completed);
+    let projected_session_state = projected_terminal
+        .as_ref()
+        .map(|terminal| terminal.session_state.clone());
+    let workflow_turn_complete =
+        projected_terminal.and_then(|terminal| terminal.workflow_turn_complete);
     let completed_turn_token = proc.active_turn_token.take();
     proc.post_turn_message_token = if exit_code == 0 && final_msg_id.is_some() {
         completed_turn_token
@@ -1455,7 +1790,7 @@ where
     if final_msg_id.is_some() {
         proc.last_message_id.clone_from(&final_msg_id);
     }
-    if was_streaming && !final_parts.is_empty() {
+    if turn_completed && !final_parts.is_empty() {
         if let Some(ref mid) = final_msg_id {
             mark_post_turn_store_base_untrusted(proc, mid);
         }
@@ -1466,10 +1801,11 @@ where
         Vec::new()
     };
     TurnCompleteTransition {
-        was_streaming,
+        turn_completed,
         final_msg_id,
         final_parts,
-        turn_token_usage,
+        workflow_turn_complete,
+        projected_session_state,
         released_streaming_parts,
     }
 }
@@ -1492,7 +1828,14 @@ where
     };
     proc.streaming_parts.push(error_part.clone());
     enqueue_pending_delta(proc, &[error_part]);
-    run_turn_complete_transition_locked(proc, chat_session_id, STALE_EXIT_CODE, emit_stream)
+    run_turn_complete_transition_locked_with_interrupt(
+        proc,
+        chat_session_id,
+        STALE_EXIT_CODE,
+        Some(InterruptReason::Timeout),
+        Some(timeout.user_message().to_string()),
+        emit_stream,
+    )
 }
 
 #[derive(Debug, Default)]
@@ -1519,8 +1862,18 @@ where
         proc.streaming_parts.push(part.clone());
         enqueue_pending_delta(proc, std::slice::from_ref(&part));
     }
-    let turn_complete = run_turn_complete_transition_locked(proc, chat_session_id, 1, emit_stream);
-    let context_restore_failed_on_init = !turn_complete.was_streaming
+    let turn_complete = run_turn_complete_transition_locked_with_interrupt(
+        proc,
+        chat_session_id,
+        1,
+        Some(InterruptReason::BridgeCrash),
+        Some(match sdk_error_part_from_message(msg) {
+            MessagePart::Error { content, .. } => content,
+            _ => "Error: Unknown bridge error".to_string(),
+        }),
+        emit_stream,
+    );
+    let context_restore_failed_on_init = !turn_complete.turn_completed
         && was_initializing
         && proc.context_carry_on_ready.take().is_some();
 
@@ -1538,6 +1891,7 @@ where
 #[derive(Debug, Default, PartialEq, Eq)]
 struct PermissionResponseTransition {
     did_transition: bool,
+    projected_session_state: Option<SessionState>,
 }
 
 /// Run the in-lock part of `respond_agent_permission`: flip `turn_phase`
@@ -1594,7 +1948,16 @@ where
             emit_stream(&mid, parts)
         });
     }
-    PermissionResponseTransition { did_transition }
+    record_permission_resolution_for_current_turn(
+        proc,
+        request_id,
+        behavior,
+        answers_value.cloned(),
+    );
+    PermissionResponseTransition {
+        did_transition,
+        projected_session_state: projected_session_state_for_current_turn(proc),
+    }
 }
 
 /// Per-delta flush decision used by the stdout reader. `post_turn` is true
@@ -1765,7 +2128,18 @@ fn accumulate_loaded_post_turn_base_without_streaming_state<F>(
 where
     F: FnMut(&str, &[MessagePart]) -> (bool, bool),
 {
-    let mut parts = base_parts;
+    let old_turn_id = 1;
+    let mut old_message_log = TurnEventLog::default();
+    old_message_log.begin_turn(
+        old_turn_id,
+        fallback_prompt_message_id(&base_mid),
+        base_mid.clone(),
+        PromptInput::default(),
+        now_timestamp(),
+    );
+    append_parts_to_event_log_in_order(&mut old_message_log, old_turn_id, &base_mid, &base_parts);
+
+    let mut parts = base_parts.clone();
     let mut task_id_map = task_id_map_from_parts(&parts);
     let prev_parts = parts.clone();
     let (acc, updated_parts) = accumulate_sdk_message(msg, &mut parts, &mut task_id_map);
@@ -1785,7 +2159,8 @@ where
         };
     }
 
-    let persist_parts = consolidate_parts_from_slice(&parts);
+    append_parts_to_event_log_in_order(&mut old_message_log, old_turn_id, &base_mid, &delta);
+    let persist_parts = old_message_log.project().agent_parts_for_message(&base_mid);
     let _ = emit_stream(&base_mid, &persist_parts);
 
     log::warn!(
@@ -1906,6 +2281,7 @@ where
     let acc = accumulation.handled;
     let updated_parts = accumulation.updated_parts;
     if !acc {
+        proc.streaming_parts.truncate(prev_len);
         if post_turn {
             let start_streaming_timer = proc.pending_stream_part_count > 0;
             let released_streaming_parts = if !start_streaming_timer {
@@ -1954,6 +2330,11 @@ where
         };
     }
 
+    let durable_parts_appended = if let Some(ref mid) = mid {
+        record_durable_parts_for_current_turn(proc, mid, &delta) > 0
+    } else {
+        false
+    };
     enqueue_pending_delta(proc, &delta);
 
     if should_flush_per_delta(proc, &delta, post_turn) {
@@ -1964,12 +2345,28 @@ where
         }
     }
 
-    let should_persist = post_turn || elapsed_persist_ms >= PERSIST_INTERVAL_MS;
+    let mut should_persist = post_turn || elapsed_persist_ms >= PERSIST_INTERVAL_MS;
+    if in_streaming && !durable_parts_appended {
+        should_persist = false;
+    }
     let persist_parts = if should_persist {
-        consolidate_parts_from_slice(&proc.streaming_parts)
+        if in_streaming {
+            mid.as_ref()
+                .map(|message_id| {
+                    proc.turn_event_log
+                        .project()
+                        .agent_parts_for_message(message_id)
+                })
+                .unwrap_or_default()
+        } else {
+            consolidate_parts_from_slice(&proc.streaming_parts)
+        }
     } else {
         Vec::new()
     };
+    if in_streaming && persist_parts.is_empty() {
+        should_persist = false;
+    }
     if post_turn && should_persist {
         if let Some(ref mid) = mid {
             mark_post_turn_store_base_untrusted(proc, mid);
@@ -2146,18 +2543,18 @@ where
         return BridgeEofCrashTransition::default();
     }
 
-    let was_streaming = proc.state == BridgeState::Streaming;
+    let turn_completed = proc.state == BridgeState::Streaming;
     let was_initializing = proc.state == BridgeState::Initializing;
     // Ready/Idle EOF: the turn already completed but the child exited, so the
     // process is no longer reusable and must be evicted before the next send.
     let should_evict = proc.state == BridgeState::Ready && proc.turn_phase == TurnPhase::Idle;
-    let sdk_error_message = if was_streaming || was_initializing {
+    let sdk_error_message = if turn_completed || was_initializing {
         Some(format!("{}: {BRIDGE_EOF_ERROR_MESSAGE}", proc.backend_id))
     } else {
         None
     };
 
-    if was_streaming {
+    if turn_completed {
         let part = MessagePart::Error {
             content: format!("Error: {BRIDGE_EOF_ERROR_MESSAGE}"),
             parent_tool_use_id: None,
@@ -2166,12 +2563,19 @@ where
         enqueue_pending_delta(proc, &[part]);
     }
 
-    let turn_complete = if was_streaming || was_initializing {
-        run_turn_complete_transition_locked(proc, chat_session_id, -1, emit_stream)
+    let turn_complete = if turn_completed || was_initializing {
+        run_turn_complete_transition_locked_with_interrupt(
+            proc,
+            chat_session_id,
+            -1,
+            Some(InterruptReason::BridgeCrash),
+            Some(format!("Error: {BRIDGE_EOF_ERROR_MESSAGE}")),
+            emit_stream,
+        )
     } else {
         TurnCompleteTransition::default()
     };
-    let context_restore_failed_on_init = !turn_complete.was_streaming
+    let context_restore_failed_on_init = !turn_complete.turn_completed
         && was_initializing
         && proc.context_carry_on_ready.take().is_some();
 
@@ -2275,7 +2679,15 @@ pub(crate) fn notify_status_transition<R: tauri::Runtime>(
         _ => return,
     };
     let worktree_path = meta.worktree_path.clone();
-    let session_state = session_state_override.unwrap_or_else(|| meta.state.clone());
+    let session_state = match (&meta.state, session_state_override) {
+        (
+            crate::usecase::agent_session::session::SessionState::Done
+            | crate::usecase::agent_session::session::SessionState::Archived,
+            _,
+        ) => meta.state.clone(),
+        (_, Some(projected)) => projected,
+        (_, None) => meta.state.clone(),
+    };
 
     let status_turn_phase = to_status_turn_phase(turn_phase);
     let agent_state =
@@ -2709,7 +3121,11 @@ fn push_or_update_tool_result(
             };
             let mut delta_content = String::new();
             if !content.is_empty() {
-                if content.contains(existing.as_str()) || existing.is_empty() {
+                if *existing_error && !is_error {
+                    delta_content = content.clone();
+                    *existing = content;
+                    *existing_error = false;
+                } else if content.contains(existing.as_str()) || existing.is_empty() {
                     delta_content = content.clone();
                     *existing = content;
                 } else {
@@ -3500,6 +3916,7 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                 active_turn_token: None,
                 post_turn_message_token: None,
                 streaming_parts: Vec::new(),
+                turn_event_log: TurnEventLog::default(),
                 last_message_id: None,
                 post_turn_base_untrusted_message_id: None,
                 task_id_map: HashMap::new(),
@@ -3792,10 +4209,13 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                                     // exact same flush → state-mutation order. Flush
                                     // failure is best-effort — we still mutate state so
                                     // turn_complete notification fires.
-                                    let effect = run_turn_complete_transition_locked(
+                                    let effect = run_turn_complete_transition_locked_with_interrupt(
                                         proc,
                                         &csid_stdout,
                                         exit_code,
+                                        interrupted.then_some(InterruptReason::Abort),
+                                        interrupted
+                                            .then(|| "Turn interrupted by abort".to_string()),
                                         |mid, parts| {
                                             emit_streaming_parts(
                                                 &app_stdout,
@@ -3809,12 +4229,12 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                                         proc.sdk_session_id = rollback_sdk_session_id.clone();
                                         proc.post_turn_message_token = None;
                                     }
-                                    let context_restore_failed_on_init = !effect.was_streaming
+                                    let context_restore_failed_on_init = !effect.turn_completed
                                         && exit_code != 0
                                         && proc.context_carry_on_ready.take().is_some();
 
                                     // User turn succeeded: persist agent_session_id to SessionStore
-                                    if effect.was_streaming && exit_code == 0 && !interrupted {
+                                    if effect.turn_completed && exit_code == 0 && !interrupted {
                                         let sid = completed_session_id
                                             .clone()
                                             .or_else(|| proc.sdk_session_id.clone());
@@ -3840,7 +4260,7 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                         }
 
                         // Resume failure (error during init) → clear stale agent_session_id
-                        if !effect.was_streaming && exit_code != 0 {
+                        if !effect.turn_completed && exit_code != 0 {
                             persist_context_carry_failed_after_init_error(
                                 &app_stdout,
                                 &session_store_clone,
@@ -3856,11 +4276,9 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                             &session_store_clone,
                             &handles_stdout,
                             &csid_stdout,
-                            exit_code,
                             effect,
                             TurnCompletePostOptions {
                                 consume_pending: true,
-                                interrupted,
                             },
                         )
                         .await;
@@ -3904,11 +4322,9 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                             &session_store_clone,
                             &handles_stdout,
                             &csid_stdout,
-                            1,
                             turn_complete,
                             TurnCompletePostOptions {
                                 consume_pending: true,
-                                interrupted: false,
                             },
                         )
                         .await;
@@ -4032,10 +4448,10 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                         // accumulated text before SET_PENDING_PERMISSION dispatches
                         // and the WaitingPermission state notification fires.
                         // Order: buffer flush → state notify → followup.
-                        let permission_did_transition = if msg_type == "permission_request" {
+                        let permission_transition = if msg_type == "permission_request" {
                             let mut map = handles_stdout.lock().await;
                             if let Some(proc) = map.get_mut(&csid_stdout) {
-                                let effect = run_permission_request_transition_locked(
+                                run_permission_request_transition_locked(
                                     proc,
                                     &csid_stdout,
                                     |mid, parts| {
@@ -4046,13 +4462,12 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                                             parts.to_vec(),
                                         )
                                     },
-                                );
-                                effect.did_transition
+                                )
                             } else {
-                                false
+                                PermissionRequestTransition::default()
                             }
                         } else {
-                            false
+                            PermissionRequestTransition::default()
                         };
 
                         // Forward non-accumulated messages (meta events) as agent-sdk-message.
@@ -4061,7 +4476,7 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                             let _ = app_stdout.emit("agent-sdk-message", &msg);
                         }
 
-                        if permission_did_transition {
+                        if permission_transition.did_transition {
                             emit_session_state_changed(
                                 &app_stdout,
                                 &csid_stdout,
@@ -4074,7 +4489,7 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
                                 &session_store_clone,
                                 &csid_stdout,
                                 TurnPhase::WaitingPermission,
-                                None,
+                                permission_transition.projected_session_state,
                             );
                         }
                     }
@@ -4134,17 +4549,15 @@ async fn spawn_bridge_process<R: tauri::Runtime>(
         }
         let was_initializing = transition.was_initializing;
         let effect = transition.turn_complete;
-        if effect.was_streaming {
+        if effect.turn_completed {
             complete_streaming_turn_post_lock(
                 &app_stdout,
                 &session_store_clone,
                 &handles_stdout,
                 &csid_stdout,
-                -1,
                 effect,
                 TurnCompletePostOptions {
                     consume_pending: true,
-                    interrupted: false,
                 },
             )
             .await;
@@ -4220,7 +4633,6 @@ fn try_mark_turn_watchdog_active(proc: &mut AgentProcess) -> bool {
 #[derive(Debug, Clone, Copy)]
 struct TurnCompletePostOptions {
     consume_pending: bool,
-    interrupted: bool,
 }
 
 async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
@@ -4228,14 +4640,17 @@ async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
     session_store: &Arc<SessionStore>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     chat_session_id: &str,
-    exit_code: i64,
     effect: TurnCompleteTransition,
     options: TurnCompletePostOptions,
 ) {
-    if !effect.was_streaming {
+    if !effect.turn_completed {
         return;
     }
-    let interrupted = options.interrupted;
+    let Some(projected_turn_complete) = effect.workflow_turn_complete.as_ref() else {
+        return;
+    };
+    let interrupted = projected_turn_complete.interrupted;
+    let projected_exit_code = projected_turn_complete.exit_code;
 
     if let Some(ref mid) = effect.final_msg_id {
         if !effect.final_parts.is_empty() {
@@ -4258,34 +4673,15 @@ async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
         app,
         chat_session_id,
         TurnPhase::Idle,
-        Some(exit_code),
+        Some(projected_exit_code),
         interrupted,
     );
-    let override_state = if interrupted {
-        Some(crate::usecase::agent_session::session::SessionState::Idle)
-    } else if exit_code != 0 {
-        Some(crate::usecase::agent_session::session::SessionState::Error)
-    } else {
-        None
-    };
-    if interrupted {
-        if let Ok(data_dir) = resolve_data_dir(app) {
-            if let Err(e) = crate::usecase::agent_session::session::update_session_state_in_data_dir(
-                session_store,
-                &data_dir,
-                chat_session_id,
-                crate::usecase::agent_session::session::SessionState::Idle,
-            ) {
-                log::warn!("Failed to mark interrupted session idle for {chat_session_id}: {e}");
-            }
-        }
-    }
     notify_status_transition(
         app,
         session_store,
         chat_session_id,
         TurnPhase::Idle,
-        override_state,
+        effect.projected_session_state.clone(),
     );
 
     let pending = if options.consume_pending {
@@ -4298,11 +4694,8 @@ async fn complete_streaming_turn_post_lock<R: tauri::Runtime>(
         Arc::clone(session_store),
         Arc::clone(handles),
         chat_session_id.to_string(),
-        exit_code,
-        effect.final_parts,
-        effect.turn_token_usage,
+        effect.workflow_turn_complete,
         pending,
-        interrupted,
     );
 }
 
@@ -4405,7 +4798,7 @@ async fn finalize_timed_out_turn<R: tauri::Runtime>(
         };
     };
 
-    if !effect.was_streaming {
+    if !effect.turn_completed {
         return TimeoutFinalizeOutcome {
             completed: false,
             continue_watchdog: false,
@@ -4418,11 +4811,9 @@ async fn finalize_timed_out_turn<R: tauri::Runtime>(
         session_store,
         handles,
         chat_session_id,
-        STALE_EXIT_CODE,
         effect,
         TurnCompletePostOptions {
             consume_pending: true,
-            interrupted: false,
         },
     )
     .await;
@@ -5687,7 +6078,7 @@ pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
         .await;
     }
 
-    start_agent_turn_with_runtime_spawner(
+    let projected_session_state = start_agent_turn_with_runtime_spawner(
         Some(app),
         Some(session_store),
         handles,
@@ -5731,7 +6122,7 @@ pub(crate) async fn start_agent_turn<R: tauri::Runtime>(
         session_store,
         chat_session_id,
         TurnPhase::Streaming,
-        None,
+        projected_session_state,
     );
 
     Ok(())
@@ -5765,7 +6156,7 @@ async fn start_agent_turn_locked<R: tauri::Runtime>(
         .await;
     }
 
-    start_agent_turn_with_runtime_spawner_locked(
+    let projected_session_state = start_agent_turn_with_runtime_spawner_locked(
         Some(app),
         Some(session_store),
         handles,
@@ -5808,7 +6199,7 @@ async fn start_agent_turn_locked<R: tauri::Runtime>(
         session_store,
         chat_session_id,
         TurnPhase::Streaming,
-        None,
+        projected_session_state,
     );
 
     Ok(())
@@ -5865,7 +6256,7 @@ async fn start_agent_turn_with_runtime_spawner<R: tauri::Runtime, F, Fut>(
     streaming_message_id: &str,
     images: &[ImageAttachment],
     spawn_runtime: F,
-) -> Result<(), String>
+) -> Result<Option<SessionState>, String>
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<(), String>>,
@@ -5886,6 +6277,53 @@ where
     .await
 }
 
+fn prompt_input_for_started_turn<R: tauri::Runtime>(
+    app: Option<&tauri::AppHandle<R>>,
+    session_store: Option<&Arc<SessionStore>>,
+    chat_session_id: &str,
+    streaming_message_id: &str,
+    fallback_prompt: &str,
+    fallback_images: &[ImageAttachment],
+) -> StartedTurnPrompt {
+    let fallback = || {
+        started_turn_prompt_from_fallback(streaming_message_id, fallback_prompt, fallback_images)
+    };
+    let Some(app) = app else {
+        return fallback();
+    };
+    let Some(session_store) = session_store else {
+        return fallback();
+    };
+    let data_dir = match resolve_data_dir(app) {
+        Ok(data_dir) => data_dir,
+        Err(e) => {
+            log::warn!("Failed to resolve data dir for turn event prompt input: {e}");
+            return fallback();
+        }
+    };
+    let human_message = match session_store.load_previous_human_message_before_agent(
+        &data_dir,
+        chat_session_id,
+        streaming_message_id,
+    ) {
+        Ok(Some(message)) => message,
+        Ok(None) => {
+            return fallback();
+        }
+        Err(e) => {
+            log::warn!("Failed to load session for turn event prompt input: {e}");
+            return fallback();
+        }
+    };
+    if human_message.role != MessageRole::Human {
+        return fallback();
+    }
+    StartedTurnPrompt {
+        message_id: human_message.id.clone(),
+        prompt: PromptInput::from_human_message(&human_message),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn start_agent_turn_with_runtime_spawner_locked<R: tauri::Runtime, F, Fut>(
     app: Option<&tauri::AppHandle<R>>,
@@ -5897,7 +6335,7 @@ async fn start_agent_turn_with_runtime_spawner_locked<R: tauri::Runtime, F, Fut>
     streaming_message_id: &str,
     images: &[ImageAttachment],
     spawn_runtime: F,
-) -> Result<(), String>
+) -> Result<Option<SessionState>, String>
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<(), String>>,
@@ -5905,6 +6343,14 @@ where
     let canonical_permission_mode =
         crate::permission::PermissionMode::parse(permission_mode).map_err(|e| e.to_string())?;
     ensure_runtime_for_turn(handles, chat_session_id, spawn_runtime).await?;
+    let started_turn_prompt = prompt_input_for_started_turn(
+        app,
+        session_store,
+        chat_session_id,
+        streaming_message_id,
+        prompt,
+        images,
+    );
 
     // Send message command.
     // Even if a message is sent while the SDK is still processing an interrupt,
@@ -5913,7 +6359,7 @@ where
     let msg_cmd = build_message_cmd(prompt, images, Some(streaming_message_id));
     let data = format!("{}\n", msg_cmd);
 
-    {
+    let projected_session_state = {
         let mut map = handles.lock().await;
         if let Some(proc) = map.get_mut(chat_session_id) {
             proc.sync_pre_turn_settings(permission_mode).await?;
@@ -5925,6 +6371,13 @@ where
             proc.active_turn_token = Some(streaming_message_id.to_string());
             proc.reset_streaming_state_for_new_turn();
             proc.begin_turn_liveness();
+            begin_turn_event_log(
+                proc,
+                &started_turn_prompt.message_id,
+                started_turn_prompt.prompt,
+                streaming_message_id,
+                now_timestamp(),
+            );
             proc.stdin
                 .write_all(data.as_bytes())
                 .await
@@ -5939,12 +6392,13 @@ where
                     spawn_turn_watchdog(app, handles, session_store, chat_session_id, proc);
                 }
             }
+            projected_session_state_for_current_turn(proc)
         } else {
             return Err(format!("No agent process for session {chat_session_id}"));
         }
-    }
+    };
 
-    Ok(())
+    Ok(projected_session_state)
 }
 
 async fn ensure_runtime_for_turn<F, Fut>(
@@ -6803,7 +7257,7 @@ pub async fn respond_agent_permission_internal(
             .await?;
     }
 
-    let did_transition_to_streaming;
+    let permission_transition;
     {
         let mut map = handles.lock().await;
         if let Some(proc) = map.get_mut(&chat_session_id) {
@@ -6831,12 +7285,12 @@ pub async fn respond_agent_permission_internal(
                 answers_value.as_ref(),
                 |mid, parts| emit_streaming_parts(app, &chat_session_id, mid, parts.to_vec()),
             );
-            did_transition_to_streaming = effect.did_transition;
+            permission_transition = effect;
 
             // Resuming the turn: restart the per-turn auxiliary timer if it
             // has already exited (turn left Streaming when WaitingPermission
             // was entered). Idempotent — no-op if a timer is still alive.
-            if did_transition_to_streaming {
+            if permission_transition.did_transition {
                 spawn_streaming_timer(app, handles, &chat_session_id, proc);
             }
         } else {
@@ -6847,14 +7301,14 @@ pub async fn respond_agent_permission_internal(
     }
 
     // Emit state change only if we actually transitioned: WaitingPermission → Streaming
-    if did_transition_to_streaming {
+    if permission_transition.did_transition {
         emit_session_state_changed(app, &chat_session_id, TurnPhase::Streaming, None, false);
         notify_status_transition(
             app,
             session_store,
             &chat_session_id,
             TurnPhase::Streaming,
-            None,
+            permission_transition.projected_session_state,
         );
     }
 
@@ -6875,17 +7329,32 @@ impl Default for ExternalBridgeMessageState {
 }
 
 #[allow(dead_code)]
+pub(crate) struct ExternalAgentTurnStart<'a> {
+    pub permission_mode: &'a str,
+    pub streaming_message_id: &'a str,
+    pub prompt: &'a str,
+    pub images: &'a [ImageAttachment],
+}
+
+#[allow(dead_code)]
 pub(crate) async fn start_external_agent_turn_state<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     session_store: &Arc<SessionStore>,
     handles: &Arc<Mutex<AgentProcessMap>>,
     chat_session_id: &str,
-    permission_mode: &str,
-    streaming_message_id: &str,
+    turn: ExternalAgentTurnStart<'_>,
 ) -> Result<(), String> {
-    let canonical_permission_mode =
-        crate::permission::PermissionMode::parse(permission_mode).map_err(|e| e.to_string())?;
-    {
+    let canonical_permission_mode = crate::permission::PermissionMode::parse(turn.permission_mode)
+        .map_err(|e| e.to_string())?;
+    let started_turn_prompt = prompt_input_for_started_turn(
+        Some(app),
+        Some(session_store),
+        chat_session_id,
+        turn.streaming_message_id,
+        turn.prompt,
+        turn.images,
+    );
+    let projected_session_state = {
         let mut map = handles.lock().await;
         let proc = map
             .get_mut(chat_session_id)
@@ -6893,18 +7362,27 @@ pub(crate) async fn start_external_agent_turn_state<R: tauri::Runtime>(
         proc.current_permission_mode = canonical_permission_mode.as_str().to_string();
         proc.state = BridgeState::Streaming;
         proc.turn_phase = TurnPhase::Streaming;
-        proc.streaming_message_id = Some(streaming_message_id.to_string());
-        proc.active_turn_token = Some(streaming_message_id.to_string());
+        proc.streaming_message_id = Some(turn.streaming_message_id.to_string());
+        proc.active_turn_token = Some(turn.streaming_message_id.to_string());
         proc.reset_streaming_state_for_new_turn();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(
+            proc,
+            &started_turn_prompt.message_id,
+            started_turn_prompt.prompt,
+            turn.streaming_message_id,
+            now_timestamp(),
+        );
         spawn_streaming_timer(app, handles, chat_session_id, proc);
-    }
+        projected_session_state_for_current_turn(proc)
+    };
     emit_session_state_changed(app, chat_session_id, TurnPhase::Streaming, None, false);
     notify_status_transition(
         app,
         session_store,
         chat_session_id,
         TurnPhase::Streaming,
-        None,
+        projected_session_state,
     );
     Ok(())
 }
@@ -6971,6 +7449,7 @@ pub(crate) async fn register_external_agent_process<R: tauri::Runtime>(
                 active_turn_token: None,
                 post_turn_message_token: None,
                 streaming_parts: Vec::new(),
+                turn_event_log: TurnEventLog::default(),
                 last_message_id: None,
                 post_turn_base_untrusted_message_id: None,
                 task_id_map: HashMap::new(),
@@ -7123,6 +7602,7 @@ pub(crate) async fn finish_external_pending_message_turn_start(chat_session_id: 
     clear_pending_turn_starting(chat_session_id).await;
 }
 
+#[cfg(test)]
 fn workflow_final_text_parts(final_parts: &[MessagePart]) -> Vec<String> {
     final_parts
         .iter()
@@ -7152,11 +7632,8 @@ fn spawn_workflow_turn_complete_notification<R: tauri::Runtime>(
     session_store: Arc<SessionStore>,
     handles: Arc<Mutex<AgentProcessMap>>,
     chat_session_id: String,
-    exit_code: i64,
-    final_parts: Vec<MessagePart>,
-    token_usage: Option<(u64, u64)>,
+    workflow_turn_complete: Option<WorkflowTurnCompleteInput>,
     pending: Option<PendingMessage>,
-    interrupted: bool,
 ) {
     let workflow_runtime: Option<Arc<crate::usecase::workflow::WorkflowRuntimeUsecase>> = app
         .try_state::<Arc<crate::usecase::workflow::WorkflowRuntimeUsecase>>()
@@ -7164,22 +7641,22 @@ fn spawn_workflow_turn_complete_notification<R: tauri::Runtime>(
     let handle = tokio::runtime::Handle::current();
     std::thread::spawn(move || {
         handle.block_on(async move {
-            if let Some(runtime) = workflow_runtime {
+            if let (Some(runtime), Some(projected)) = (workflow_runtime, workflow_turn_complete) {
                 if runtime.is_session_running(&chat_session_id).await {
-                    let final_text_parts = workflow_final_text_parts(&final_parts);
-                    let token_usage = token_usage.map(|(input_tokens, output_tokens)| {
+                    let final_text_parts = projected.final_text_parts.clone();
+                    let token_usage = projected.token_usage.map(|usage| {
                         crate::usecase::workflow::ports::WorkflowTurnTokenUsage {
-                            input_tokens,
-                            output_tokens,
+                            input_tokens: usage.input_tokens,
+                            output_tokens: usage.output_tokens,
                         }
                     });
                     let command =
                         crate::usecase::workflow::ports::WorkflowTurnCompleteNotification {
                             chat_session_id: chat_session_id.clone(),
-                            exit_code,
+                            exit_code: projected.exit_code,
                             final_text_parts,
                             token_usage,
-                            interrupted,
+                            interrupted: projected.interrupted,
                         };
                     if let Err(e) = runtime.complete_turn(command).await {
                         log::error!("Workflow turn completion error for {chat_session_id}: {e}");
@@ -7300,10 +7777,12 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     if bridge_message_is_stale_for_active_turn(proc, &msg) {
                         (None, false, true)
                     } else {
-                        let effect = run_turn_complete_transition_locked(
+                        let effect = run_turn_complete_transition_locked_with_interrupt(
                             proc,
                             chat_session_id,
                             exit_code,
+                            interrupted.then_some(InterruptReason::Abort),
+                            interrupted.then(|| "Turn interrupted by abort".to_string()),
                             |mid, parts| {
                                 emit_streaming_parts(app, chat_session_id, mid, parts.to_vec())
                             },
@@ -7312,7 +7791,7 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                             proc.sdk_session_id = rollback_sdk_session_id.clone();
                             proc.post_turn_message_token = None;
                         }
-                        let context_restore_failed_on_init = !effect.was_streaming
+                        let context_restore_failed_on_init = !effect.turn_completed
                             && exit_code != 0
                             && proc.context_carry_on_ready.take().is_some();
                         (Some(effect), context_restore_failed_on_init, false)
@@ -7329,13 +7808,14 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                 return;
             };
             let TurnCompleteTransition {
-                was_streaming,
+                turn_completed,
                 final_msg_id,
                 final_parts,
-                turn_token_usage,
+                workflow_turn_complete,
+                projected_session_state,
                 released_streaming_parts,
             } = effect;
-            if was_streaming {
+            if turn_completed {
                 if exit_code == 0 && !interrupted {
                     if let Some(sid) = completed_session_id.as_deref() {
                         persist_agent_session_id(app, session_store, chat_session_id, sid);
@@ -7362,42 +7842,22 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     }
                 }
                 drop(released_streaming_parts);
-                if interrupted {
-                    if let Ok(data_dir) = resolve_data_dir(app) {
-                        if let Err(e) =
-                            crate::usecase::agent_session::session::update_session_state_in_data_dir(
-                                session_store,
-                                &data_dir,
-                                chat_session_id,
-                                crate::usecase::agent_session::session::SessionState::Idle,
-                            )
-                        {
-                            log::warn!(
-                                "Failed to mark interrupted session idle for {chat_session_id}: {e}"
-                            );
-                        }
-                    }
-                }
+                let Some(projected_turn_complete) = workflow_turn_complete.as_ref() else {
+                    return;
+                };
                 emit_session_state_changed(
                     app,
                     chat_session_id,
                     TurnPhase::Idle,
-                    Some(exit_code),
-                    interrupted,
+                    Some(projected_turn_complete.exit_code),
+                    projected_turn_complete.interrupted,
                 );
-                let override_state = if interrupted {
-                    Some(crate::usecase::agent_session::session::SessionState::Idle)
-                } else if exit_code != 0 {
-                    Some(crate::usecase::agent_session::session::SessionState::Error)
-                } else {
-                    None
-                };
                 notify_status_transition(
                     app,
                     session_store,
                     chat_session_id,
                     TurnPhase::Idle,
-                    override_state,
+                    projected_session_state,
                 );
                 // Codex app-server は独自の pending キュー
                 // (`start_next_app_server_pending_turn`) で follow-up turn を起動するため、
@@ -7421,11 +7881,8 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     Arc::clone(session_store),
                     Arc::clone(handles),
                     chat_session_id.to_string(),
-                    exit_code,
-                    final_parts,
-                    turn_token_usage,
+                    workflow_turn_complete,
                     pending,
-                    interrupted,
                 );
             } else if exit_code != 0 {
                 persist_context_carry_failed_after_init_error(
@@ -7451,7 +7908,7 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
 
             let transition = transition.unwrap_or_default();
             let effect = transition.turn_complete;
-            if effect.was_streaming {
+            if effect.turn_completed {
                 if let Some(ref mid) = effect.final_msg_id {
                     if !effect.final_parts.is_empty() {
                         let persisted = persist_streaming_parts(
@@ -7472,13 +7929,22 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                         }
                     }
                 }
-                emit_session_state_changed(app, chat_session_id, TurnPhase::Idle, Some(1), false);
+                let Some(projected_turn_complete) = effect.workflow_turn_complete.as_ref() else {
+                    return;
+                };
+                emit_session_state_changed(
+                    app,
+                    chat_session_id,
+                    TurnPhase::Idle,
+                    Some(projected_turn_complete.exit_code),
+                    projected_turn_complete.interrupted,
+                );
                 notify_status_transition(
                     app,
                     session_store,
                     chat_session_id,
                     TurnPhase::Idle,
-                    Some(crate::usecase::agent_session::session::SessionState::Error),
+                    effect.projected_session_state.clone(),
                 );
                 let pending = {
                     let is_legacy_bridge = {
@@ -7497,11 +7963,8 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     Arc::clone(session_store),
                     Arc::clone(handles),
                     chat_session_id.to_string(),
-                    1,
-                    effect.final_parts,
-                    effect.turn_token_usage,
+                    effect.workflow_turn_complete,
                     pending,
-                    false,
                 );
             } else if transition.was_initializing {
                 notify_status_transition(
@@ -7582,28 +8045,23 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
             }
             drop(std::mem::take(&mut effect.released_streaming_parts));
 
-            let permission_did_transition = if msg_type == "permission_request" {
+            let permission_transition = if msg_type == "permission_request" {
                 let mut map = handles.lock().await;
                 if let Some(proc) = map.get_mut(chat_session_id) {
-                    let effect = run_permission_request_transition_locked(
-                        proc,
-                        chat_session_id,
-                        |mid, parts| {
-                            emit_streaming_parts(app, chat_session_id, mid, parts.to_vec())
-                        },
-                    );
-                    effect.did_transition
+                    run_permission_request_transition_locked(proc, chat_session_id, |mid, parts| {
+                        emit_streaming_parts(app, chat_session_id, mid, parts.to_vec())
+                    })
                 } else {
-                    false
+                    PermissionRequestTransition::default()
                 }
             } else {
-                false
+                PermissionRequestTransition::default()
             };
 
             if should_forward_sdk_message(effect.accumulated, msg_type) {
                 let _ = app.emit("agent-sdk-message", &msg);
             }
-            if permission_did_transition {
+            if permission_transition.did_transition {
                 emit_session_state_changed(
                     app,
                     chat_session_id,
@@ -7616,7 +8074,7 @@ pub(crate) async fn handle_external_bridge_message<R: tauri::Runtime>(
                     session_store,
                     chat_session_id,
                     TurnPhase::WaitingPermission,
-                    None,
+                    permission_transition.projected_session_state,
                 );
             }
         }
@@ -8520,12 +8978,14 @@ pub(crate) async fn start_agent_turn_internal_locked<R: tauri::Runtime>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adaptor::gateway::agent_session::FileSessionStorage;
     use crate::adaptor::gateway::workflow::state::WorkflowExecutionState;
     use crate::adaptor::gateway::workflow::test_support::TestRuntimeKernel;
     use crate::infrastructure::agent_session::runtime::{
         AgentBackend, AgentBackendRegistry, AgentMessage, PermissionResponse, SessionConfig,
         SessionHandle,
     };
+    use crate::usecase::agent_session::session::{AttachmentRef, MessageMention};
     use async_trait::async_trait;
 
     fn approved_fix_policy_output(policy: &str, review_step: &str) -> String {
@@ -8552,6 +9012,494 @@ mod tests {
 
     fn test_pending_message(id: &str, content: &str) -> PendingMessage {
         pending_message_for_test(id, content, 1.0)
+    }
+
+    fn test_prompt_input(content: &str) -> PromptInput {
+        PromptInput::from_content_images(content, std::iter::empty::<(String, String)>())
+    }
+
+    fn begin_test_turn_event_log(proc: &mut AgentProcess) {
+        let assistant_message_id = proc
+            .streaming_message_id
+            .as_deref()
+            .unwrap_or("m1")
+            .to_string();
+        begin_turn_event_log(
+            proc,
+            "human-1",
+            test_prompt_input("prompt"),
+            &assistant_message_id,
+            1.0,
+        );
+    }
+
+    fn assert_started_turn_prompt_matches_fallback(
+        started_turn_prompt: StartedTurnPrompt,
+        streaming_message_id: &str,
+        fallback_prompt: &str,
+        fallback_images: &[ImageAttachment],
+    ) {
+        let expected = started_turn_prompt_from_fallback(
+            streaming_message_id,
+            fallback_prompt,
+            fallback_images,
+        );
+        assert_eq!(started_turn_prompt.message_id, expected.message_id);
+        assert_eq!(started_turn_prompt.prompt, expected.prompt);
+    }
+
+    #[test]
+    fn prompt_input_from_human_message_preserves_mentions_and_prompt_parts() {
+        let attachment = AttachmentRef {
+            id: "att-1".to_string(),
+            media_type: "image/png".to_string(),
+            byte_size: 42,
+        };
+        let parts = vec![
+            MessagePart::Text {
+                content: "inspect this".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::ImageRef {
+                attachment: attachment.clone(),
+            },
+        ];
+        let mentions = vec![MessageMention {
+            file_path: "src/main.rs".to_string(),
+            start_line: Some(7),
+            end_line: Some(9),
+        }];
+        let message = ChatMessage {
+            id: "human-1".to_string(),
+            role: MessageRole::Human,
+            content: "inspect this".to_string(),
+            thinking: None,
+            activities: None,
+            parts: Some(parts.clone()),
+            timestamp: 1.0,
+            mentions: Some(mentions.clone()),
+        };
+
+        let prompt = PromptInput::from_human_message(&message);
+
+        assert_eq!(prompt.content, "inspect this");
+        assert_eq!(prompt.mentions, mentions);
+        assert_eq!(prompt.attachment_refs, vec![attachment]);
+        assert_eq!(prompt.parts, parts);
+    }
+
+    #[test]
+    fn started_turn_prompt_uses_saved_human_message_id_and_parts() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let parts = vec![MessagePart::Text {
+            content: "inspect this".to_string(),
+            parent_tool_use_id: None,
+        }];
+        let mentions = vec![crate::domain::code::MentionReference {
+            file_path: "src/main.rs".to_string(),
+            start_line: Some(7),
+            end_line: Some(9),
+        }];
+        let human_message = add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Human,
+            "inspect this",
+            Some(parts.clone()),
+            Some(mentions),
+        )
+        .unwrap();
+        let agent_message = add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Agent,
+            "",
+            None,
+            None,
+        )
+        .unwrap();
+
+        let started_turn_prompt = prompt_input_for_started_turn(
+            Some(&app.handle()),
+            Some(&store),
+            &session.id,
+            &agent_message.id,
+            "fallback",
+            &[],
+        );
+
+        assert_eq!(started_turn_prompt.message_id, human_message.id.as_str());
+        assert_eq!(
+            started_turn_prompt.prompt,
+            PromptInput::from_human_message(&human_message)
+        );
+    }
+
+    #[test]
+    fn started_turn_prompt_selects_previous_human_before_target_agent_with_single_message_read() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let storage = Arc::new(FileSessionStorage::default());
+        let store = Arc::new(SessionStore::new(storage.clone()));
+        let session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Human,
+            "first",
+            None,
+            None,
+        )
+        .unwrap();
+        add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Agent,
+            "first answer",
+            None,
+            None,
+        )
+        .unwrap();
+        let expected_human = add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Human,
+            "second",
+            None,
+            None,
+        )
+        .unwrap();
+        let target_agent = add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Agent,
+            "",
+            None,
+            None,
+        )
+        .unwrap();
+
+        storage.reset_message_read_count();
+        let started_turn_prompt = prompt_input_for_started_turn(
+            Some(&app.handle()),
+            Some(&store),
+            &session.id,
+            &target_agent.id,
+            "fallback",
+            &[],
+        );
+
+        assert_eq!(storage.message_read_count(), 1);
+        assert_eq!(started_turn_prompt.message_id, expected_human.id);
+        assert_eq!(started_turn_prompt.prompt.content, "second");
+    }
+
+    #[test]
+    fn started_turn_prompt_falls_back_when_target_or_previous_human_is_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let agent_without_human = add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Agent,
+            "",
+            None,
+            None,
+        )
+        .unwrap();
+
+        for streaming_message_id in [&agent_without_human.id, "missing-agent"] {
+            let started_turn_prompt = prompt_input_for_started_turn(
+                Some(&app.handle()),
+                Some(&store),
+                &session.id,
+                streaming_message_id,
+                "fallback",
+                &[],
+            );
+
+            assert_eq!(
+                started_turn_prompt.message_id,
+                fallback_prompt_message_id(streaming_message_id)
+            );
+            assert_eq!(started_turn_prompt.prompt.content, "fallback");
+        }
+    }
+
+    #[test]
+    fn started_turn_prompt_falls_back_when_app_store_or_lightweight_load_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let fallback_images = vec![ImageAttachment {
+            data: "encoded".to_string(),
+            media_type: "image/png".to_string(),
+        }];
+
+        let missing_app = prompt_input_for_started_turn::<tauri::test::MockRuntime>(
+            None,
+            Some(&store),
+            "session-1",
+            "agent-1",
+            "fallback",
+            &fallback_images,
+        );
+        assert_started_turn_prompt_matches_fallback(
+            missing_app,
+            "agent-1",
+            "fallback",
+            &fallback_images,
+        );
+
+        let missing_store = prompt_input_for_started_turn(
+            Some(&app.handle()),
+            None,
+            "session-1",
+            "agent-2",
+            "fallback",
+            &fallback_images,
+        );
+        assert_started_turn_prompt_matches_fallback(
+            missing_store,
+            "agent-2",
+            "fallback",
+            &fallback_images,
+        );
+
+        let broken_data_dir = tempfile::tempdir().unwrap();
+        std::fs::write(broken_data_dir.path().join("sessions"), "not a directory").unwrap();
+        let broken_app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(
+                broken_data_dir.path().to_path_buf(),
+            ))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let broken_store = Arc::new(SessionStore::new(Arc::new(FileSessionStorage::default())));
+        let storage_failure = prompt_input_for_started_turn(
+            Some(&broken_app.handle()),
+            Some(&broken_store),
+            "session-1",
+            "agent-3",
+            "fallback",
+            &fallback_images,
+        );
+        assert_started_turn_prompt_matches_fallback(
+            storage_failure,
+            "agent-3",
+            "fallback",
+            &fallback_images,
+        );
+    }
+
+    #[test]
+    fn started_turn_prompt_hydrates_saved_human_like_full_restore() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let storage = Arc::new(FileSessionStorage::default());
+        let store = Arc::new(SessionStore::new(storage.clone()));
+        let session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CLAUDE_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let image =
+            validate_and_encode_image(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]).unwrap();
+        let parts = vec![
+            MessagePart::Text {
+                content: "inspect image".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::Image {
+                data: image.data.clone(),
+                media_type: image.media_type.clone(),
+            },
+        ];
+        let mentions = vec![crate::domain::code::MentionReference {
+            file_path: "src/lib.rs".to_string(),
+            start_line: Some(2),
+            end_line: Some(4),
+        }];
+        let human_message = add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Human,
+            "inspect image",
+            Some(parts),
+            Some(mentions),
+        )
+        .unwrap();
+        let agent_message = add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Agent,
+            "",
+            None,
+            None,
+        )
+        .unwrap();
+        let full_session = store
+            .load_full_session_for_restore(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        let full_human = full_session
+            .messages
+            .iter()
+            .find(|message| message.id == human_message.id)
+            .unwrap();
+        let expected_prompt = PromptInput::from_human_message(full_human);
+
+        storage.reset_message_read_count();
+        let started_turn_prompt = prompt_input_for_started_turn(
+            Some(&app.handle()),
+            Some(&store),
+            &session.id,
+            &agent_message.id,
+            "fallback",
+            &[],
+        );
+
+        assert_eq!(storage.message_read_count(), 1);
+        assert_eq!(started_turn_prompt.message_id, human_message.id);
+        assert_eq!(started_turn_prompt.prompt, expected_prompt);
+    }
+
+    #[tokio::test]
+    async fn external_agent_turn_state_records_saved_human_prompt_input() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let session = create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some(CODEX_BACKEND_ID.to_string()),
+        )
+        .unwrap();
+        let image =
+            validate_and_encode_image(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]).unwrap();
+        let parts = vec![
+            MessagePart::Text {
+                content: "saved prompt".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::Image {
+                data: image.data.clone(),
+                media_type: image.media_type.clone(),
+            },
+        ];
+        let mentions = vec![crate::domain::code::MentionReference {
+            file_path: "src/lib.rs".to_string(),
+            start_line: Some(2),
+            end_line: Some(4),
+        }];
+        let human_message = add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Human,
+            "saved prompt",
+            Some(parts.clone()),
+            Some(mentions),
+        )
+        .unwrap();
+        let agent_message = add_message_internal(
+            &store,
+            temp.path(),
+            &session.id,
+            MessageRole::Agent,
+            "",
+            None,
+            None,
+        )
+        .unwrap();
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let mut proc = make_test_agent_process();
+        proc.backend_id = CODEX_BACKEND_ID.to_string();
+        handles.lock().await.insert(session.id.clone(), proc);
+
+        start_external_agent_turn_state(
+            &app.handle(),
+            &store,
+            &handles,
+            &session.id,
+            ExternalAgentTurnStart {
+                permission_mode: "edit",
+                streaming_message_id: &agent_message.id,
+                prompt: "fallback prompt",
+                images: std::slice::from_ref(&image),
+            },
+        )
+        .await
+        .unwrap();
+
+        let read_model = {
+            let map = handles.lock().await;
+            map.get(&session.id).unwrap().turn_event_log.project()
+        };
+        let human = read_model
+            .messages
+            .iter()
+            .find(|message| message.role == MessageRole::Human)
+            .expect("projected human message");
+        assert_eq!(human.id.as_str(), human_message.id.as_str());
+        assert_eq!(human.content, "saved prompt");
+        assert_eq!(human.mentions.as_ref(), human_message.mentions.as_ref());
+        assert_eq!(human.parts.as_ref(), human_message.parts.as_ref());
+
+        let mut proc = handles.lock().await.remove(&session.id).unwrap();
+        let _ = proc.child.kill().await;
     }
 
     struct MockModelBackend {
@@ -9022,6 +9970,9 @@ mod tests {
         proc.backend_id = CODEX_BACKEND_ID.to_string();
         proc.state = BridgeState::Streaming;
         proc.turn_phase = TurnPhase::Streaming;
+        proc.streaming_message_id = Some("agent-message-1".to_string());
+        proc.active_turn_token = Some("agent-message-1".to_string());
+        begin_test_turn_event_log(&mut proc);
         handles.lock().await.insert(session.id.clone(), proc);
         let mut state = ExternalBridgeMessageState::default();
 
@@ -9034,6 +9985,7 @@ mod tests {
                 "type": "turn_complete",
                 "session_id": "new-codex-thread",
                 "exit_code": 0,
+                "turn_token": "agent-message-1",
             }),
             &mut state,
         )
@@ -9052,7 +10004,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn interrupted_turn_complete_does_not_persist_session_id_and_marks_idle() {
+    async fn interrupted_turn_complete_does_not_persist_session_id_or_overwrite_done_state() {
         let temp = tempfile::tempdir().unwrap();
         let app = tauri::test::mock_builder()
             .manage(crate::app_data_dir::TestDataDir(temp.path().to_path_buf()))
@@ -9109,7 +10061,7 @@ mod tests {
         );
         assert_eq!(
             loaded.state,
-            crate::usecase::agent_session::session::SessionState::Idle
+            crate::usecase::agent_session::session::SessionState::Done
         );
         let removed = handles.lock().await.remove(&session.id);
         if let Some(mut proc) = removed {
@@ -9160,12 +10112,19 @@ mod tests {
             content: "old response".to_string(),
             parent_tool_use_id: None,
         });
+        begin_turn_event_log(
+            &mut proc,
+            "human-old",
+            test_prompt_input("old prompt"),
+            old_turn_token,
+            1.0,
+        );
         proc.pending_messages
             .push_back(test_pending_message("queued-followup", "next prompt"));
         handles.lock().await.insert(session.id.clone(), proc);
 
         let interrupted = true;
-        let (final_parts, turn_token_usage) = {
+        let (final_parts, workflow_turn_complete) = {
             let mut map = handles.lock().await;
             let proc = map.get_mut(&session.id).unwrap();
             let effect =
@@ -9174,11 +10133,11 @@ mod tests {
                 });
             proc.sdk_session_id = Some("previous-good-session".to_string());
             proc.post_turn_message_token = None;
-            assert!(effect.was_streaming);
+            assert!(effect.turn_completed);
             assert_eq!(proc.state, BridgeState::Ready);
             assert_eq!(proc.turn_phase, TurnPhase::Idle);
             assert!(proc.active_turn_token.is_none());
-            (effect.final_parts, effect.turn_token_usage)
+            (effect.final_parts, effect.workflow_turn_complete)
         };
 
         let loaded = store
@@ -9310,11 +10269,13 @@ mod tests {
                     chat_session_id: session.id.clone(),
                     exit_code: 0,
                     final_text_parts: workflow_final_text_parts(&final_parts),
-                    token_usage: turn_token_usage.map(|(input_tokens, output_tokens)| {
-                        crate::usecase::workflow::ports::WorkflowTurnTokenUsage {
-                            input_tokens,
-                            output_tokens,
-                        }
+                    token_usage: workflow_turn_complete.and_then(|input| {
+                        input.token_usage.map(|usage| {
+                            crate::usecase::workflow::ports::WorkflowTurnTokenUsage {
+                                input_tokens: usage.input_tokens,
+                                output_tokens: usage.output_tokens,
+                            }
+                        })
                     }),
                     interrupted,
                 },
@@ -10529,13 +11490,15 @@ mod tests {
             }],
         );
         let snapshot = prepare_streaming_flush(&proc).expect("snapshot");
+        let records_before = crate::other::telemetry::test_metric_records();
 
         let ok = apply_streaming_emit_result(&mut proc, "csid", "mid", &snapshot, false, true);
 
         assert!(!ok);
-        assert!(!crate::other::telemetry::test_metric_records()
-            .iter()
-            .any(|record| record.name == "releash.agent_stream.emit_interval_ms"));
+        assert_eq!(
+            crate::other::telemetry::test_metric_records(),
+            records_before
+        );
         crate::other::telemetry::reset_test_metrics();
     }
 
@@ -11315,7 +12278,7 @@ mod tests {
             exit_code,
             recording_emit(events),
         );
-        if effect.was_streaming {
+        if effect.turn_completed {
             events.push(RecordedEmit::StateChanged {
                 phase: TurnPhase::Idle,
                 exit_code: Some(exit_code),
@@ -11482,6 +12445,7 @@ mod tests {
     async fn finalize_timeout_adds_error_part_and_completes_as_failure() {
         let mut proc = make_streaming_test_process();
         proc.begin_turn_liveness();
+        begin_test_turn_event_log(&mut proc);
         let partial = MessagePart::Text {
             content: "partial response".to_string(),
             parent_tool_use_id: None,
@@ -11497,7 +12461,7 @@ mod tests {
             recording_emit(&mut events),
         );
 
-        assert!(effect.was_streaming);
+        assert!(effect.turn_completed);
         assert_eq!(proc.state, BridgeState::Crashed);
         assert_eq!(proc.turn_phase, TurnPhase::Idle);
         assert_eq!(effect.final_msg_id.as_deref(), Some("m1"));
@@ -11529,7 +12493,7 @@ mod tests {
         let effect =
             run_turn_complete_transition_locked(&mut proc, "csid", 0, |_mid, _parts| (true, true));
 
-        assert!(!effect.was_streaming);
+        assert!(!effect.turn_completed);
         assert_eq!(proc.state, BridgeState::Crashed);
         assert_eq!(proc.turn_phase, TurnPhase::Idle);
         let _ = proc.child.kill().await;
@@ -11653,6 +12617,7 @@ mod tests {
         // Spec: ターン完了時に未配信バッファを強制配信する。
         // streaming emit が state emit (Idle) より前に観測される。
         let mut proc = make_streaming_test_process();
+        begin_test_turn_event_log(&mut proc);
         let delta = vec![MessagePart::Text {
             content: "tail-before-idle".to_string(),
             parent_tool_use_id: None,
@@ -11690,6 +12655,7 @@ mod tests {
     async fn turn_complete_with_nonzero_exit_code_still_flushes_before_state() {
         // 失敗終了 (exit_code != 0) でも emit 順序は同じ: streaming → state。
         let mut proc = make_streaming_test_process();
+        begin_test_turn_event_log(&mut proc);
         let delta = vec![MessagePart::Text {
             content: "tail-error".to_string(),
             parent_tool_use_id: None,
@@ -11712,8 +12678,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn turn_complete_without_turn_started_flushes_but_skips_projection_followup_gate() {
+        for backend_id in [CLAUDE_BACKEND_ID, CODEX_BACKEND_ID] {
+            let mut proc = make_streaming_test_process();
+            proc.backend_id = backend_id.to_string();
+            let delta = vec![MessagePart::Text {
+                content: format!("tail-{backend_id}"),
+                parent_tool_use_id: None,
+            }];
+            proc.streaming_parts.extend(delta.clone());
+            enqueue_pending_delta(&mut proc, &delta);
+
+            let mut events = Vec::new();
+            let effect = run_turn_complete_transition_locked(
+                &mut proc,
+                "csid",
+                0,
+                recording_emit(&mut events),
+            );
+
+            assert!(!effect.turn_completed);
+            assert!(effect.workflow_turn_complete.is_none());
+            assert!(effect.projected_session_state.is_none());
+            assert_eq!(
+                events.len(),
+                1,
+                "stream snapshot still flushes for {backend_id}"
+            );
+            assert!(matches!(events[0], RecordedEmit::StreamingFlush { .. }));
+            assert_eq!(proc.turn_event_log.current_turn_id(), None);
+            assert!(proc
+                .turn_event_log
+                .project()
+                .workflow_turn_complete
+                .is_none());
+            assert_eq!(proc.state, BridgeState::Ready);
+            assert_eq!(proc.turn_phase, TurnPhase::Idle);
+            let _ = proc.child.kill().await;
+        }
+    }
+
+    #[tokio::test]
     async fn turn_complete_releases_streaming_parts_after_final_snapshot() {
         let mut proc = make_streaming_test_process();
+        begin_test_turn_event_log(&mut proc);
         proc.task_id_map
             .insert("background-1".to_string(), "tool-1".to_string());
         let raw_parts = vec![
@@ -11738,7 +12746,7 @@ mod tests {
         let effect =
             run_turn_complete_transition_locked(&mut proc, "csid", 0, |_mid, _parts| (true, true));
 
-        assert!(effect.was_streaming);
+        assert!(effect.turn_completed);
         assert_eq!(effect.final_msg_id.as_deref(), Some("m1"));
         assert_eq!(effect.final_parts, consolidate_parts_from_slice(&raw_parts));
         assert_eq!(effect.released_streaming_parts, raw_parts);
@@ -11763,8 +12771,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn permission_request_transition_carries_projected_active_session_state() {
+        let mut proc = make_streaming_test_process();
+        begin_test_turn_event_log(&mut proc);
+        let permission_part = MessagePart::Permission {
+            request: serde_json::json!({ "request_id": "req-1" }),
+            status: "pending".to_string(),
+            answers: None,
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(permission_part.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&permission_part));
+        record_durable_parts_for_current_turn(
+            &mut proc,
+            "m1",
+            std::slice::from_ref(&permission_part),
+        );
+
+        let effect = run_permission_request_transition_locked(&mut proc, "csid", |_mid, _parts| {
+            (true, true)
+        });
+
+        assert!(effect.did_transition);
+        assert_eq!(
+            effect.projected_session_state,
+            Some(crate::usecase::agent_session::session::SessionState::Active)
+        );
+        assert_eq!(proc.turn_phase, TurnPhase::WaitingPermission);
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
     async fn post_turn_skips_stale_store_base_when_final_persist_failed() {
         let mut proc = make_streaming_test_process();
+        begin_test_turn_event_log(&mut proc);
         let fresh_parts = vec![
             MessagePart::Text {
                 content: "fresh base".to_string(),
@@ -11834,6 +12874,7 @@ mod tests {
     #[tokio::test]
     async fn turn_complete_emit_failure_retains_retry_state_until_timer_drains() {
         let mut proc = make_streaming_test_process();
+        begin_test_turn_event_log(&mut proc);
         let raw_parts = vec![MessagePart::Text {
             content: "tail".to_string(),
             parent_tool_use_id: None,
@@ -11844,7 +12885,7 @@ mod tests {
         let effect =
             run_turn_complete_transition_locked(&mut proc, "csid", 0, |_mid, _parts| (false, true));
 
-        assert!(effect.was_streaming);
+        assert!(effect.turn_completed);
         assert_eq!(effect.final_msg_id.as_deref(), Some("m1"));
         assert_eq!(effect.final_parts, consolidate_parts_from_slice(&raw_parts));
         assert!(effect.released_streaming_parts.is_empty());
@@ -11877,6 +12918,7 @@ mod tests {
     #[tokio::test]
     async fn turn_complete_nonzero_exit_code_emit_failure_releases_after_final_snapshot() {
         let mut proc = make_streaming_test_process();
+        begin_test_turn_event_log(&mut proc);
         let raw_parts = vec![MessagePart::Text {
             content: "tail-before-crash".to_string(),
             parent_tool_use_id: None,
@@ -11890,7 +12932,7 @@ mod tests {
             (false, true)
         });
 
-        assert!(effect.was_streaming);
+        assert!(effect.turn_completed);
         assert_eq!(effect.final_msg_id.as_deref(), Some("m1"));
         assert_eq!(effect.final_parts, consolidate_parts_from_slice(&raw_parts));
         assert_eq!(effect.released_streaming_parts, raw_parts);
@@ -12158,6 +13200,14 @@ mod tests {
         proc.turn_phase = TurnPhase::Streaming;
         proc.streaming_message_id = Some("new-message".to_string());
         proc.reset_streaming_state_for_new_turn();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(
+            &mut proc,
+            "new-human",
+            test_prompt_input("new prompt"),
+            "new-message",
+            2.0,
+        );
         let new_turn_parts = vec![MessagePart::Text {
             content: "new turn".to_string(),
             parent_tool_use_id: None,
@@ -12223,6 +13273,109 @@ mod tests {
             proc.task_id_map.get("new-task").map(String::as_str),
             Some("new-tool")
         );
+        assert!(
+            proc.turn_event_log
+                .project()
+                .agent_parts_for_message("new-message")
+                .iter()
+                .all(|part| !matches!(
+                    part,
+                    MessagePart::ToolResult {
+                        content,
+                        tool_use_id: Some(id),
+                        ..
+                    } if id == "tool-1" && content == "late"
+                )),
+            "stale post-turn delta must not be appended to the active turn event log"
+        );
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
+    async fn post_turn_loaded_base_preserves_projected_todo_text_without_reprojection_duplication()
+    {
+        let mut proc = make_test_agent_process();
+        proc.state = BridgeState::Streaming;
+        proc.turn_phase = TurnPhase::Streaming;
+        proc.streaming_message_id = Some("new-message".to_string());
+        proc.begin_turn_liveness();
+        begin_turn_event_log(
+            &mut proc,
+            "new-human",
+            test_prompt_input("new prompt"),
+            "new-message",
+            2.0,
+        );
+
+        let items = vec![crate::usecase::agent_session::session::TodoListItem {
+            text: "ship fix".to_string(),
+            completed: true,
+        }];
+        let todo_text = MessagePart::Text {
+            content: todo_update_log(&items),
+            parent_tool_use_id: None,
+        };
+        let todo_snapshot = MessagePart::TodoListSnapshot {
+            items: items.clone(),
+        };
+        let tool_use = MessagePart::ToolUse {
+            tool: "Bash".to_string(),
+            input: serde_json::json!({ "cmd": "date" }),
+            id: "tool-1".to_string(),
+            parent_tool_use_id: None,
+        };
+        let base_parts = vec![todo_text.clone(), todo_snapshot.clone(), tool_use.clone()];
+        let expected_parts = vec![
+            todo_text.clone(),
+            todo_snapshot,
+            tool_use,
+            MessagePart::ToolResult {
+                content: "done".to_string(),
+                is_error: false,
+                tool_use_id: Some("tool-1".to_string()),
+                parent_tool_use_id: None,
+            },
+        ];
+        let mut emitted = Vec::new();
+
+        let effect = accumulate_stream_or_post_turn_message_locked(
+            &mut proc,
+            "csid",
+            &post_turn_tool_result_message("tool-1", "done"),
+            0,
+            |mid, parts| {
+                emitted.push((mid.to_string(), parts.to_vec()));
+                (true, true)
+            },
+            Some(("old-message".to_string(), base_parts)),
+        );
+
+        assert!(effect.accumulated);
+        assert_eq!(effect.emit_msg_id.as_deref(), Some("old-message"));
+        assert!(effect.should_persist);
+        assert_eq!(effect.persist_parts, expected_parts);
+        assert_eq!(
+            effect
+                .persist_parts
+                .iter()
+                .filter(|part| matches!(
+                    part,
+                    MessagePart::Text { content, .. } if content == &todo_update_log(&items)
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            emitted,
+            vec![("old-message".to_string(), effect.persist_parts.clone())]
+        );
+        assert!(
+            proc.turn_event_log
+                .project()
+                .agent_parts_for_message("new-message")
+                .is_empty(),
+            "loaded old-message parts must not be reprojected into the active turn"
+        );
         let _ = proc.child.kill().await;
     }
 
@@ -12232,6 +13385,14 @@ mod tests {
         proc.state = BridgeState::Streaming;
         proc.turn_phase = TurnPhase::Streaming;
         proc.streaming_message_id = Some("new-message".to_string());
+        proc.begin_turn_liveness();
+        begin_turn_event_log(
+            &mut proc,
+            "new-human",
+            test_prompt_input("new prompt"),
+            "new-message",
+            2.0,
+        );
         let new_turn_parts = vec![MessagePart::Text {
             content: "new turn".to_string(),
             parent_tool_use_id: None,
@@ -12284,6 +13445,20 @@ mod tests {
             Some("new-tool")
         );
         assert!(!proc.task_id_map.contains_key("old-task"));
+        assert!(
+            proc.turn_event_log
+                .project()
+                .agent_parts_for_message("new-message")
+                .iter()
+                .all(|part| !matches!(
+                    part,
+                    MessagePart::TaskStatus {
+                        task_tool_use_id,
+                        ..
+                    } if task_tool_use_id == "old-tool"
+                )),
+            "old task status must not be appended to the active turn event log"
+        );
         let _ = proc.child.kill().await;
     }
 
@@ -12667,6 +13842,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn respond_permission_transition_carries_projected_active_session_state() {
+        let mut proc = make_process_waiting_for_permission("req-1");
+        begin_test_turn_event_log(&mut proc);
+        let permission_part = proc
+            .streaming_parts
+            .iter()
+            .find(|part| matches!(part, MessagePart::Permission { .. }))
+            .cloned()
+            .expect("permission part");
+        record_durable_parts_for_current_turn(
+            &mut proc,
+            "m1",
+            std::slice::from_ref(&permission_part),
+        );
+
+        let effect = apply_respond_permission_locked(
+            &mut proc,
+            "csid",
+            "req-1",
+            "allow",
+            None,
+            |_mid, _parts| (true, true),
+        );
+
+        assert!(effect.did_transition);
+        assert_eq!(
+            effect.projected_session_state,
+            Some(crate::usecase::agent_session::session::SessionState::Active)
+        );
+        assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
     async fn respond_permission_no_transition_when_not_waiting() {
         // 直前に WaitingPermission でなかった場合、state は変更されず、
         // 後続の state-changed emit も発火しないこと。
@@ -12703,7 +13912,7 @@ mod tests {
         });
         let transition =
             run_bridge_error_transition_locked(proc, chat_session_id, &msg, recording_emit(events));
-        if transition.turn_complete.was_streaming {
+        if transition.turn_complete.turn_completed {
             events.push(RecordedEmit::StateChanged {
                 phase: TurnPhase::Idle,
                 exit_code: Some(1),
@@ -12726,7 +13935,7 @@ mod tests {
             chat_session_id,
             recording_emit(events),
         );
-        if transition.turn_complete.was_streaming {
+        if transition.turn_complete.turn_completed {
             events.push(RecordedEmit::StateChanged {
                 phase: TurnPhase::Idle,
                 exit_code: Some(-1),
@@ -12860,6 +14069,7 @@ mod tests {
         let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
         let mut proc = make_streaming_test_process();
         proc.backend_id = CODEX_BACKEND_ID.to_string();
+        begin_test_turn_event_log(&mut proc);
         let streaming_parts = vec![MessagePart::Text {
             content: "before error".to_string(),
             parent_tool_use_id: None,
@@ -12905,6 +14115,7 @@ mod tests {
         //   未配信 delta + 合成 error part が同一 cumulative payload として
         //   state 通知 (Idle) より前にフロントエンドへ配信されること。
         let mut proc = make_streaming_test_process();
+        begin_test_turn_event_log(&mut proc);
         // 未配信 text が pending に残っている状態でクラッシュが起こる。
         let pending_text = MessagePart::Text {
             content: "tail-before-crash".to_string(),
@@ -12918,7 +14129,7 @@ mod tests {
             drive_bridge_error_path(&mut proc, "csid", "bridge reported failure", &mut events);
 
         assert_eq!(events.len(), 2, "flush emit then state emit");
-        assert!(transition.turn_complete.was_streaming);
+        assert!(transition.turn_complete.turn_completed);
         assert!(transition
             .turn_complete
             .final_parts
@@ -12955,6 +14166,628 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn accumulate_records_durable_events_but_keeps_text_delta_live_only() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+
+        let text_delta = serde_json::json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "hello"}
+            }
+        });
+        let effect = accumulate_stream_or_post_turn_message_locked(
+            &mut proc,
+            "csid",
+            &text_delta,
+            0,
+            |_mid, _parts| (true, true),
+            None,
+        );
+
+        assert!(effect.accumulated);
+        assert!(
+            proc.turn_event_log
+                .project()
+                .agent_parts_for_message("m1")
+                .is_empty(),
+            "text_delta must remain live-only until the terminal flush records the final block"
+        );
+
+        let tool_use = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "name": "Read",
+                    "input": {"file_path": "src/lib.rs"},
+                    "id": "tool-1"
+                }]
+            }
+        });
+        let effect = accumulate_stream_or_post_turn_message_locked(
+            &mut proc,
+            "csid",
+            &tool_use,
+            0,
+            |_mid, _parts| (true, true),
+            None,
+        );
+
+        assert!(effect.accumulated);
+        let projected_parts = proc.turn_event_log.project().agent_parts_for_message("m1");
+        assert!(projected_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::ToolUse { id, tool, .. } if id == "tool-1" && tool == "Read"
+        )));
+
+        let retried_tool_use = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "name": "Read",
+                    "input": {"file_path": "src/main.rs"},
+                    "id": "tool-1"
+                }]
+            }
+        });
+        let effect = accumulate_stream_or_post_turn_message_locked(
+            &mut proc,
+            "csid",
+            &retried_tool_use,
+            0,
+            |_mid, _parts| (true, true),
+            None,
+        );
+
+        assert!(effect.accumulated);
+        let projected = proc.turn_event_log.project();
+        assert_eq!(projected.tool_retries.len(), 1);
+        assert_eq!(projected.tool_retries[0].tool_use_id, "tool-1");
+        assert_eq!(projected.tool_retries[0].attempt, 2);
+    }
+
+    #[tokio::test]
+    async fn live_only_durable_record_skips_projection_and_durable_part_updates_phase() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+        proc.turn_phase = TurnPhase::WaitingPermission;
+
+        record_durable_parts_for_current_turn(
+            &mut proc,
+            "m1",
+            &[MessagePart::Text {
+                content: "live".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+
+        assert_eq!(proc.turn_phase, TurnPhase::WaitingPermission);
+        assert!(proc
+            .turn_event_log
+            .project()
+            .agent_parts_for_message("m1")
+            .is_empty());
+
+        record_durable_parts_for_current_turn(
+            &mut proc,
+            "m1",
+            &[MessagePart::ToolUse {
+                tool: "Read".to_string(),
+                input: serde_json::json!({}),
+                id: "tool-1".to_string(),
+                parent_tool_use_id: None,
+            }],
+        );
+
+        assert_eq!(proc.turn_phase, TurnPhase::Streaming);
+        assert!(proc
+            .turn_event_log
+            .project()
+            .agent_parts_for_message("m1")
+            .iter()
+            .any(|part| matches!(part, MessagePart::ToolUse { id, .. } if id == "tool-1")));
+    }
+
+    #[tokio::test]
+    async fn turn_complete_appends_terminal_event_and_projects_workflow_input() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+        proc.last_result_token_usage = Some((11, 13));
+        let final_text = MessagePart::Text {
+            content: "final text".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(final_text.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&final_text));
+
+        let effect =
+            run_turn_complete_transition_locked(&mut proc, "csid", 0, |_mid, _parts| (true, true));
+
+        assert!(effect.turn_completed);
+        assert_eq!(effect.final_parts, vec![final_text]);
+        assert_eq!(
+            effect.workflow_turn_complete,
+            Some(WorkflowTurnCompleteInput {
+                turn_id: 1,
+                exit_code: 0,
+                final_text_parts: vec!["final text".to_string()],
+                token_usage: Some(TurnTokenUsage {
+                    input_tokens: 11,
+                    output_tokens: 13,
+                }),
+                interrupted: false,
+            })
+        );
+        assert_eq!(
+            proc.turn_event_log.project().status.turn_phase,
+            crate::usecase::agent_session::status::TurnPhase::Idle
+        );
+    }
+
+    #[tokio::test]
+    async fn nonzero_turn_complete_without_interrupt_projects_completed_workflow_input() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+        let final_text = MessagePart::Text {
+            content: "failed but complete".to_string(),
+            parent_tool_use_id: None,
+        };
+        proc.streaming_parts.push(final_text.clone());
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&final_text));
+
+        let effect =
+            run_turn_complete_transition_locked(&mut proc, "csid", 7, |_mid, _parts| (true, true));
+        let projected = proc.turn_event_log.project();
+
+        assert!(effect.turn_completed);
+        assert_eq!(
+            effect.workflow_turn_complete,
+            Some(WorkflowTurnCompleteInput {
+                turn_id: 1,
+                exit_code: 7,
+                final_text_parts: vec!["failed but complete".to_string()],
+                token_usage: None,
+                interrupted: false,
+            })
+        );
+        assert_eq!(
+            projected.status.session_state,
+            crate::usecase::agent_session::session::SessionState::Error
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_interrupt_paths_project_interrupted_workflow_input() {
+        for reason in [
+            InterruptReason::Abort,
+            InterruptReason::Timeout,
+            InterruptReason::BridgeCrash,
+        ] {
+            let mut proc = make_streaming_test_process();
+            proc.begin_turn_liveness();
+            begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+
+            let effect = run_turn_complete_transition_locked_with_interrupt(
+                &mut proc,
+                "csid",
+                1,
+                Some(reason),
+                Some("stopped".to_string()),
+                |_mid, _parts| (true, true),
+            );
+
+            assert_eq!(
+                effect.workflow_turn_complete,
+                Some(WorkflowTurnCompleteInput {
+                    turn_id: 1,
+                    exit_code: 1,
+                    final_text_parts: Vec::new(),
+                    token_usage: None,
+                    interrupted: true,
+                })
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn turn_complete_does_not_record_terminal_text_already_projected_from_durable_event() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+        let items = vec![crate::usecase::agent_session::session::TodoListItem {
+            text: "ship fix".to_string(),
+            completed: true,
+        }];
+        let todo_text = MessagePart::Text {
+            content: "TODO を更新しました（1/1 完了）".to_string(),
+            parent_tool_use_id: None,
+        };
+        let todo_snapshot = MessagePart::TodoListSnapshot {
+            items: items.clone(),
+        };
+        record_durable_parts_for_current_turn(
+            &mut proc,
+            "m1",
+            std::slice::from_ref(&todo_snapshot),
+        );
+        proc.streaming_parts
+            .extend([todo_text.clone(), todo_snapshot.clone()]);
+        enqueue_pending_delta(&mut proc, &[todo_text, todo_snapshot]);
+
+        let effect =
+            run_turn_complete_transition_locked(&mut proc, "csid", 0, |_mid, _parts| (true, true));
+
+        assert_eq!(
+            effect
+                .final_parts
+                .iter()
+                .filter(|part| matches!(
+                    part,
+                    MessagePart::Text { content, .. }
+                        if content == "TODO を更新しました（1/1 完了）"
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            proc.turn_event_log
+                .project()
+                .agent_parts_for_message("m1")
+                .iter()
+                .filter(|part| matches!(
+                    part,
+                    MessagePart::Text { content, .. }
+                        if content == "TODO を更新しました（1/1 完了）"
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_complete_preserves_non_adjacent_duplicate_part_occurrences() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+        let final_parts = vec![
+            MessagePart::Text {
+                content: "ok".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::ToolUse {
+                tool: "Read".to_string(),
+                input: serde_json::json!({"file_path": "a"}),
+                id: "tool-1".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::Text {
+                content: "ok".to_string(),
+                parent_tool_use_id: None,
+            },
+        ];
+        proc.streaming_parts = final_parts.clone();
+        enqueue_pending_delta(&mut proc, &final_parts);
+
+        let effect =
+            run_turn_complete_transition_locked(&mut proc, "csid", 0, |_mid, _parts| (true, true));
+        let projected_parts = proc.turn_event_log.project().agent_parts_for_message("m1");
+
+        assert_eq!(effect.final_parts, final_parts);
+        assert_eq!(projected_parts, final_parts);
+    }
+
+    #[tokio::test]
+    async fn turn_complete_does_not_append_preexisting_projected_occurrence_twice() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+        let tool_use = MessagePart::ToolUse {
+            tool: "Read".to_string(),
+            input: serde_json::json!({"file_path": "a"}),
+            id: "tool-1".to_string(),
+            parent_tool_use_id: None,
+        };
+        record_durable_parts_for_current_turn(&mut proc, "m1", std::slice::from_ref(&tool_use));
+        proc.streaming_parts = vec![tool_use.clone()];
+        enqueue_pending_delta(&mut proc, std::slice::from_ref(&tool_use));
+
+        let effect =
+            run_turn_complete_transition_locked(&mut proc, "csid", 0, |_mid, _parts| (true, true));
+        let projected_parts = proc.turn_event_log.project().agent_parts_for_message("m1");
+
+        assert_eq!(effect.final_parts, vec![tool_use.clone()]);
+        assert_eq!(projected_parts, vec![tool_use]);
+    }
+
+    #[tokio::test]
+    async fn representative_sdk_sequence_projects_same_parts_as_legacy_consolidation() {
+        let sdk_messages = vec![
+            serde_json::json!({
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "hello "}
+                }
+            }),
+            serde_json::json!({
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "thinking_delta", "thinking": "think"}
+                }
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "content": [{
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "src/lib.rs"},
+                        "id": "tool-1"
+                    }]
+                }
+            }),
+            serde_json::json!({
+                "type": "user",
+                "message": {
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": "tool-1",
+                        "content": "contents agentId: task-1",
+                        "is_error": false
+                    }]
+                }
+            }),
+            serde_json::json!({
+                "type": "user",
+                "message": {
+                    "content": [{
+                        "type": "tool_result",
+                        "content": "standalone",
+                        "is_error": true
+                    }]
+                }
+            }),
+            serde_json::json!({
+                "type": "permission_request",
+                "request_id": "req-1",
+                "tool_use_id": "tool-1",
+                "tool_name": "Edit"
+            }),
+            serde_json::json!({
+                "type": "permission_denied",
+                "request_id": "req-1",
+                "tool_use_id": "tool-1",
+                "tool_name": "Edit",
+                "message": "denied"
+            }),
+            serde_json::json!({
+                "type": "todo_list_snapshot",
+                "items": [{"text": "ship", "completed": true}]
+            }),
+            serde_json::json!({
+                "type": "system",
+                "status": "compacting"
+            }),
+            serde_json::json!({
+                "type": "system",
+                "subtype": "compact_boundary",
+                "compact_metadata": {
+                    "trigger": "manual",
+                    "pre_summary_token_count": 123
+                }
+            }),
+            serde_json::json!({
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "done"}
+                }
+            }),
+        ];
+
+        let mut legacy_parts = Vec::new();
+        let mut legacy_task_id_map = HashMap::new();
+        for message in &sdk_messages {
+            let _ = accumulate_sdk_message(message, &mut legacy_parts, &mut legacy_task_id_map);
+        }
+        let expected = consolidate_parts_from_slice(&legacy_parts);
+
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+        for message in &sdk_messages {
+            let prev_len = proc.streaming_parts.len();
+            let accumulation = accumulate_sdk_message_with_liveness(
+                message,
+                &mut proc.streaming_parts,
+                &mut proc.task_id_map,
+            );
+            assert!(accumulation.handled);
+            let mut delta = proc.streaming_parts[prev_len..].to_vec();
+            if let Some(updated) = accumulation.updated_parts {
+                delta.extend(updated);
+            }
+            record_durable_parts_for_current_turn(&mut proc, "m1", &delta);
+        }
+        let terminal =
+            append_terminal_events_and_project(&mut proc, "m1", 0, None, None).expect("terminal");
+        let projected = terminal.final_parts;
+
+        assert_eq!(projected, expected);
+    }
+
+    #[tokio::test]
+    async fn streaming_periodic_persist_uses_durable_projection_not_live_text_buffer() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+        proc.turn_event_log.reset_project_call_count();
+        proc.turn_phase = TurnPhase::WaitingPermission;
+
+        let text_delta = serde_json::json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "live only"}
+            }
+        });
+        let effect = accumulate_stream_or_post_turn_message_locked(
+            &mut proc,
+            "csid",
+            &text_delta,
+            PERSIST_INTERVAL_MS,
+            |_mid, _parts| (true, true),
+            None,
+        );
+        assert!(effect.accumulated);
+        assert!(!effect.should_persist);
+        assert!(effect.persist_parts.is_empty());
+        assert_eq!(
+            proc.turn_event_log.project_call_count(),
+            0,
+            "live-only periodic persist must not project the durable event log"
+        );
+        assert_eq!(
+            proc.turn_phase,
+            TurnPhase::WaitingPermission,
+            "skipping live-only projection must preserve the current turn phase"
+        );
+
+        let tool_use = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "name": "Read",
+                    "input": {"file_path": "src/lib.rs"},
+                    "id": "tool-1"
+                }]
+            }
+        });
+        let effect = accumulate_stream_or_post_turn_message_locked(
+            &mut proc,
+            "csid",
+            &tool_use,
+            PERSIST_INTERVAL_MS,
+            |_mid, _parts| (true, true),
+            None,
+        );
+
+        assert!(effect.should_persist);
+        assert!(
+            proc.turn_event_log.project_call_count() > 0,
+            "durable deltas still project for phase and persist parts"
+        );
+        assert_eq!(effect.persist_parts.len(), 1);
+        assert!(matches!(
+            effect.persist_parts.as_slice(),
+            [MessagePart::ToolUse { id, tool, .. }] if id == "tool-1" && tool == "Read"
+        ));
+    }
+
+    #[tokio::test]
+    async fn bridge_error_finalizes_partial_tool_and_permission_events() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+        record_durable_parts_for_current_turn(
+            &mut proc,
+            "m1",
+            &[
+                MessagePart::ToolUse {
+                    tool: "Edit".to_string(),
+                    input: serde_json::json!({}),
+                    id: "tool-1".to_string(),
+                    parent_tool_use_id: None,
+                },
+                MessagePart::Permission {
+                    request: serde_json::json!({
+                        "request_id": "req-1",
+                        "tool_use_id": "tool-1",
+                        "tool_name": "Edit",
+                    }),
+                    status: "pending".to_string(),
+                    answers: None,
+                    parent_tool_use_id: None,
+                },
+            ],
+        );
+
+        let transition = run_bridge_error_transition_locked(
+            &mut proc,
+            "csid",
+            &serde_json::json!({"type": "error", "message": "bridge failed"}),
+            |_mid, _parts| (true, true),
+        );
+        let projected = proc.turn_event_log.project();
+        let projected_parts = projected.agent_parts_for_message("m1");
+
+        assert!(transition.turn_complete.turn_completed);
+        assert!(projected_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::ToolResult {
+                tool_use_id: Some(id),
+                is_error: true,
+                content,
+                ..
+            } if id == "tool-1" && content == "Error: bridge failed により中断"
+        )));
+        assert!(projected_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Permission { status, .. } if status == "cancelled"
+        )));
+        assert_eq!(
+            projected.status.session_state,
+            crate::usecase::agent_session::session::SessionState::Error
+        );
+        assert_eq!(
+            projected.status.turn_phase,
+            crate::usecase::agent_session::status::TurnPhase::Idle
+        );
+        assert_eq!(
+            transition.turn_complete.workflow_turn_complete,
+            Some(WorkflowTurnCompleteInput {
+                turn_id: 1,
+                exit_code: 1,
+                final_text_parts: Vec::new(),
+                token_usage: None,
+                interrupted: true,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn eof_crash_workflow_exit_code_is_projected_from_interrupted_event() {
+        let mut proc = make_streaming_test_process();
+        proc.begin_turn_liveness();
+        begin_turn_event_log(&mut proc, "human-1", test_prompt_input("prompt"), "m1", 1.0);
+
+        let transition =
+            run_bridge_eof_crash_transition_locked(true, &mut proc, "csid", |_mid, _parts| {
+                (true, true)
+            });
+
+        assert_eq!(
+            transition.turn_complete.workflow_turn_complete,
+            Some(WorkflowTurnCompleteInput {
+                turn_id: 1,
+                exit_code: -1,
+                final_text_parts: Vec::new(),
+                token_usage: None,
+                interrupted: true,
+            })
+        );
+    }
+
+    #[tokio::test]
     async fn bridge_eof_crash_emits_pending_before_state_change() {
         // Spec (Rule: ターン完了・状態遷移時には未配信バッファを強制配信する,
         //  Examples ストリーミング → クラッシュ):
@@ -12962,6 +14795,7 @@ mod tests {
         //   part が同一 cumulative payload として state 通知 (Idle) より前に
         //   フロントエンドへ配信されること。
         let mut proc = make_streaming_test_process();
+        begin_test_turn_event_log(&mut proc);
         let pending_text = MessagePart::Text {
             content: "tail-before-eof".to_string(),
             parent_tool_use_id: None,
@@ -13065,6 +14899,7 @@ mod tests {
         proc.state = BridgeState::Streaming;
         proc.turn_phase = TurnPhase::Streaming;
         proc.streaming_message_id = Some("message-1".to_string());
+        begin_test_turn_event_log(&mut proc);
         proc.streaming_parts.push(MessagePart::Text {
             content: "partial".to_string(),
             parent_tool_use_id: None,
@@ -13077,7 +14912,7 @@ mod tests {
 
         assert_eq!(proc.state, BridgeState::Crashed);
         assert_eq!(proc.turn_phase, TurnPhase::Idle);
-        assert!(transition.turn_complete.was_streaming);
+        assert!(transition.turn_complete.turn_completed);
         assert_eq!(
             transition.turn_complete.final_msg_id.as_deref(),
             Some("message-1")
@@ -13814,6 +15649,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn turn_start_transition_carries_projected_active_session_state() {
+        let handles = Arc::new(Mutex::new(AgentProcessMap::new()));
+        let session_id = "projected-start".to_string();
+
+        let projected_session_state = start_agent_turn_with_runtime_spawner(
+            None::<&tauri::AppHandle>,
+            None,
+            &handles,
+            &session_id,
+            "edit",
+            "start turn",
+            "agent-msg-1",
+            &[],
+            {
+                let handles = Arc::clone(&handles);
+                let session_id = session_id.clone();
+                move || async move {
+                    handles
+                        .lock()
+                        .await
+                        .insert(session_id, make_test_agent_process());
+                    Ok(())
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            projected_session_state,
+            Some(crate::usecase::agent_session::session::SessionState::Active)
+        );
+        let mut proc = handles.lock().await.remove(&session_id).unwrap();
+        let _ = proc.child.kill().await;
+    }
+
+    #[tokio::test]
     async fn running_workflow_step_turn_start_reuses_existing_runtime_without_spawn() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -14271,6 +16143,7 @@ mod tests {
                 active_turn_token: None,
                 post_turn_message_token: None,
                 streaming_parts: Vec::new(),
+                turn_event_log: TurnEventLog::default(),
                 last_message_id: None,
                 post_turn_base_untrusted_message_id: None,
                 task_id_map: HashMap::new(),
@@ -17222,6 +19095,7 @@ mod tests {
             active_turn_token: None,
             post_turn_message_token: None,
             streaming_parts: Vec::new(),
+            turn_event_log: TurnEventLog::default(),
             last_message_id: None,
             post_turn_base_untrusted_message_id: None,
             task_id_map: HashMap::new(),
@@ -17937,6 +19811,7 @@ mod tests {
                 active_turn_token: None,
                 post_turn_message_token: None,
                 streaming_parts: Vec::new(),
+                turn_event_log: TurnEventLog::default(),
                 last_message_id: None,
                 post_turn_base_untrusted_message_id: None,
                 task_id_map: HashMap::new(),

--- a/src-tauri/src/infrastructure/agent_session/runtime/codex.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/codex.rs
@@ -13,7 +13,7 @@ use crate::infrastructure::agent_session::runtime::bridge_common::{
     handle_external_bridge_message, persist_context_carry_failed_after_init_error,
     persist_context_carry_state, prepare_external_pending_message_turn,
     register_external_agent_process, session_specific_env_overrides,
-    start_external_agent_turn_state, write_bridge_command, AgentProcessMap,
+    start_external_agent_turn_state, write_bridge_command, AgentProcessMap, ExternalAgentTurnStart,
     ExternalBridgeMessageState, CODEX_BACKEND_ID, DEFER_AGENT_SESSION_ID_PERSIST_ON_READY,
 };
 use crate::infrastructure::agent_session::runtime::codex_app_server::{
@@ -691,8 +691,12 @@ impl AppServerCodexRuntime {
             &self.session_store,
             &self.handles,
             turn.chat_session_id,
-            turn.permission_mode,
-            turn.streaming_message_id,
+            ExternalAgentTurnStart {
+                permission_mode: turn.permission_mode,
+                streaming_message_id: turn.streaming_message_id,
+                prompt: turn.prompt,
+                images: turn.images,
+            },
         )
         .await?;
         let id = Self::next_request_id(turn.state).await;
@@ -785,8 +789,12 @@ async fn start_next_app_server_pending_turn(
             session_store,
             handles,
             chat_session_id,
-            &pending.permission_mode,
-            &pending.agent_message_id,
+            ExternalAgentTurnStart {
+                permission_mode: &pending.permission_mode,
+                streaming_message_id: &pending.agent_message_id,
+                prompt: &pending.prompt,
+                images: &pending.images,
+            },
         )
         .await?;
         let id = AppServerCodexRuntime::next_request_id(&state).await;
@@ -1226,6 +1234,7 @@ impl AgentBackend for CodexBackend {
 mod tests {
     use super::*;
     use crate::domain::agent_session::{AgentSessionReader, AgentSessionStorageTypes};
+    use crate::usecase::agent_session::event_log::AgentSessionEvent;
     use crate::usecase::agent_session::session::{
         ChatMessage, ChatSession, MessagePart, PageCursor, SessionAttachment, SessionPage,
         SessionState, SESSION_BODY_FORMAT_VERSION,
@@ -1245,6 +1254,7 @@ mod tests {
         type Message = ChatMessage;
         type MessagePart = MessagePart;
         type Attachment = SessionAttachment;
+        type Event = AgentSessionEvent;
     }
 
     impl AgentSessionReader for CountingRestoreStorage {
@@ -1277,6 +1287,15 @@ mod tests {
             Ok(Some(self.meta.to_session(Vec::new())))
         }
 
+        fn load_previous_human_message_before_agent(
+            &self,
+            _app_data_dir: &Path,
+            _session_id: &str,
+            _agent_message_id: &str,
+        ) -> Result<Option<Self::Message>, String> {
+            Ok(None)
+        }
+
         fn get_session_page(
             &self,
             _app_data_dir: &Path,
@@ -1294,6 +1313,14 @@ mod tests {
             _attachment_id: &str,
         ) -> Result<Option<Self::Attachment>, String> {
             Ok(None)
+        }
+
+        fn load_session_events(
+            &self,
+            _app_data_dir: &Path,
+            _session_id: &str,
+        ) -> Result<Vec<Self::Event>, String> {
+            Ok(Vec::new())
         }
     }
 

--- a/src-tauri/src/other/telemetry/mod.rs
+++ b/src-tauri/src/other/telemetry/mod.rs
@@ -38,6 +38,22 @@ pub(crate) struct TestMetricRecord {
 static TEST_METRIC_RECORDS: Mutex<Vec<TestMetricRecord>> = Mutex::new(Vec::new());
 #[cfg(test)]
 static TEST_TELEMETRY_LOCK: Mutex<()> = Mutex::new(());
+#[cfg(test)]
+thread_local! {
+    static TEST_TELEMETRY_RECORDING_ENABLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(crate) struct TestTelemetryGuard {
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl Drop for TestTelemetryGuard {
+    fn drop(&mut self) {
+        TEST_TELEMETRY_RECORDING_ENABLED.with(|enabled| enabled.set(false));
+    }
+}
 
 struct Metrics {
     hot_path_duration: Histogram<f64>,
@@ -188,6 +204,9 @@ pub(crate) fn record_first_repo_snapshot_ready() {
 
 #[cfg(test)]
 fn record_test_metric(name: &'static str, value: f64, attrs: &[KeyValue]) {
+    if !TEST_TELEMETRY_RECORDING_ENABLED.with(|enabled| enabled.get()) {
+        return;
+    }
     TEST_METRIC_RECORDS
         .lock()
         .unwrap_or_else(|e| e.into_inner())
@@ -227,10 +246,12 @@ pub(crate) fn first_repo_snapshot_recorded_for_tests() -> bool {
 }
 
 #[cfg(test)]
-pub(crate) fn lock_test_telemetry() -> std::sync::MutexGuard<'static, ()> {
-    TEST_TELEMETRY_LOCK
+pub(crate) fn lock_test_telemetry() -> TestTelemetryGuard {
+    let guard = TEST_TELEMETRY_LOCK
         .lock()
-        .unwrap_or_else(|e| e.into_inner())
+        .unwrap_or_else(|e| e.into_inner());
+    TEST_TELEMETRY_RECORDING_ENABLED.with(|enabled| enabled.set(true));
+    TestTelemetryGuard { _guard: guard }
 }
 
 pub(crate) fn measure_result<T, E, F>(metric: HotPathMetric, f: F) -> Result<T, E>

--- a/src-tauri/src/usecase/agent_session/event_log/events.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/events.rs
@@ -1,0 +1,267 @@
+use serde::{Deserialize, Serialize};
+
+use crate::usecase::agent_session::session::{
+    AttachmentRef, ChatMessage, MessageMention, MessagePart, SystemNotificationType, TodoListItem,
+};
+
+pub type TurnId = u64;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptInput {
+    pub content: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mentions: Vec<MessageMention>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachment_refs: Vec<AttachmentRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parts: Vec<MessagePart>,
+}
+
+impl PromptInput {
+    pub fn from_human_message(message: &ChatMessage) -> Self {
+        let parts = message.parts.clone().unwrap_or_default();
+        Self {
+            content: message.content.clone(),
+            mentions: message.mentions.clone().unwrap_or_default(),
+            attachment_refs: attachment_refs_from_parts(&parts),
+            parts,
+        }
+    }
+
+    pub fn from_content_images<I>(content: &str, images: I) -> Self
+    where
+        I: IntoIterator<Item = (String, String)>,
+    {
+        let parts = human_parts_from_content_images(content, images);
+        Self {
+            content: content.to_string(),
+            mentions: Vec::new(),
+            attachment_refs: attachment_refs_from_parts(&parts),
+            parts,
+        }
+    }
+}
+
+pub fn human_parts_from_content_images<I>(content: &str, images: I) -> Vec<MessagePart>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut images = images.into_iter().peekable();
+    if images.peek().is_none() {
+        return Vec::new();
+    }
+
+    let mut parts = Vec::new();
+    if !content.is_empty() {
+        parts.push(MessagePart::Text {
+            content: content.to_string(),
+            parent_tool_use_id: None,
+        });
+    }
+    parts.extend(images.map(|(data, media_type)| MessagePart::Image { data, media_type }));
+    parts
+}
+
+pub fn attachment_refs_from_parts(parts: &[MessagePart]) -> Vec<AttachmentRef> {
+    parts
+        .iter()
+        .filter_map(|part| match part {
+            MessagePart::ImageRef { attachment } => Some(attachment.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InterruptReason {
+    Abort,
+    Timeout,
+    BridgeCrash,
+}
+
+impl InterruptReason {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Abort => "abort",
+            Self::Timeout => "timeout",
+            Self::BridgeCrash => "bridge crash",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionDecision {
+    Allowed,
+    Denied,
+    Cancelled,
+}
+
+impl PermissionDecision {
+    pub fn from_status(status: &str) -> Option<Self> {
+        match status {
+            "allowed" | "allow" => Some(Self::Allowed),
+            "denied" | "deny" => Some(Self::Denied),
+            "cancelled" | "canceled" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+
+    pub fn status(self) -> &'static str {
+        match self {
+            Self::Allowed => "allowed",
+            Self::Denied => "denied",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnTokenUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentSessionEvent {
+    TurnStarted {
+        turn_id: TurnId,
+        message_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        assistant_message_id: Option<String>,
+        prompt: PromptInput,
+        at: f64,
+    },
+    TextRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        content: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_tool_use_id: Option<String>,
+    },
+    ReasoningRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        content: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_tool_use_id: Option<String>,
+    },
+    ErrorRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        content: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_tool_use_id: Option<String>,
+    },
+    ToolCallStarted {
+        turn_id: TurnId,
+        tool_use_id: String,
+        tool: String,
+        input: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_tool_use_id: Option<String>,
+    },
+    ToolCallSucceeded {
+        turn_id: TurnId,
+        tool_use_id: String,
+        content: String,
+    },
+    ToolCallFailed {
+        turn_id: TurnId,
+        tool_use_id: String,
+        content: String,
+    },
+    ToolResultRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        content: String,
+        is_error: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_use_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_tool_use_id: Option<String>,
+    },
+    ToolCallRetried {
+        turn_id: TurnId,
+        tool_use_id: String,
+        attempt: u32,
+    },
+    PermissionRequested {
+        turn_id: TurnId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_use_id: Option<String>,
+        request: serde_json::Value,
+    },
+    PermissionResolved {
+        turn_id: TurnId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_use_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        decision: PermissionDecision,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        answers: Option<serde_json::Value>,
+    },
+    TaskStatusChanged {
+        turn_id: TurnId,
+        message_id: String,
+        task_tool_use_id: String,
+        status: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        summary: Option<String>,
+    },
+    TodoListSnapshotRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        items: Vec<TodoListItem>,
+    },
+    SystemNotificationRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        notification_type: SystemNotificationType,
+        status: String,
+        label: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hook_id: Option<String>,
+    },
+    ImageRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        data: String,
+        media_type: String,
+    },
+    ImageRefRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        attachment: AttachmentRef,
+    },
+    FinalPartsRecorded {
+        turn_id: TurnId,
+        message_id: String,
+        parts: Vec<MessagePart>,
+    },
+    TurnCompleted {
+        turn_id: TurnId,
+        exit_code: i64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        token_usage: Option<TurnTokenUsage>,
+    },
+    TurnInterrupted {
+        turn_id: TurnId,
+        reason: InterruptReason,
+        exit_code: i64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    SessionClosed {
+        at: f64,
+    },
+}

--- a/src-tauri/src/usecase/agent_session/event_log/finalization.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/finalization.rs
@@ -1,0 +1,144 @@
+use std::collections::HashSet;
+
+use super::events::{AgentSessionEvent, InterruptReason, PermissionDecision, TurnId};
+use super::part_events::permission_request_id;
+
+pub fn finalize_turn(
+    events: &mut Vec<AgentSessionEvent>,
+    turn_id: TurnId,
+    reason: InterruptReason,
+    error: Option<String>,
+    exit_code: i64,
+) {
+    if has_turn_terminal(events, turn_id) {
+        return;
+    }
+
+    let interrupted_content = interruption_content(reason, error.as_deref());
+    for tool_use_id in unfinished_tool_calls(events, turn_id) {
+        events.push(AgentSessionEvent::ToolCallFailed {
+            turn_id,
+            tool_use_id,
+            content: interrupted_content.clone(),
+        });
+    }
+
+    for permission in unresolved_permissions(events, turn_id) {
+        events.push(AgentSessionEvent::PermissionResolved {
+            turn_id,
+            tool_use_id: permission.tool_use_id,
+            request_id: permission.request_id,
+            decision: PermissionDecision::Cancelled,
+            answers: None,
+        });
+    }
+
+    events.push(AgentSessionEvent::TurnInterrupted {
+        turn_id,
+        reason,
+        exit_code,
+        error,
+    });
+}
+
+pub(super) fn has_unresolved_permissions(events: &[AgentSessionEvent], turn_id: TurnId) -> bool {
+    !unresolved_permissions(events, turn_id).is_empty()
+}
+
+fn interruption_content(reason: InterruptReason, error: Option<&str>) -> String {
+    let detail = error
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| reason.label());
+    if detail.contains("中断") || detail.contains("interrupted") {
+        detail.to_string()
+    } else {
+        format!("{detail} により中断")
+    }
+}
+
+fn has_turn_terminal(events: &[AgentSessionEvent], turn_id: TurnId) -> bool {
+    events.iter().any(|event| {
+        matches!(
+            event,
+            AgentSessionEvent::TurnCompleted { turn_id: id, .. }
+                | AgentSessionEvent::TurnInterrupted { turn_id: id, .. } if *id == turn_id
+        )
+    })
+}
+
+fn unfinished_tool_calls(events: &[AgentSessionEvent], turn_id: TurnId) -> Vec<String> {
+    let mut started = Vec::new();
+    let mut finished = HashSet::new();
+    for event in events {
+        match event {
+            AgentSessionEvent::ToolCallStarted {
+                turn_id: id,
+                tool_use_id,
+                ..
+            } if *id == turn_id => started.push(tool_use_id.clone()),
+            AgentSessionEvent::ToolCallSucceeded {
+                turn_id: id,
+                tool_use_id,
+                ..
+            }
+            | AgentSessionEvent::ToolCallFailed {
+                turn_id: id,
+                tool_use_id,
+                ..
+            } if *id == turn_id => {
+                finished.insert(tool_use_id.clone());
+            }
+            _ => {}
+        }
+    }
+    started
+        .into_iter()
+        .filter(|tool_use_id| !finished.contains(tool_use_id))
+        .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PermissionKey {
+    tool_use_id: Option<String>,
+    request_id: Option<String>,
+}
+
+fn unresolved_permissions(events: &[AgentSessionEvent], turn_id: TurnId) -> Vec<PermissionKey> {
+    let mut requested = Vec::new();
+    let mut resolved = HashSet::new();
+    for event in events {
+        match event {
+            AgentSessionEvent::PermissionRequested {
+                turn_id: id,
+                tool_use_id,
+                request,
+            } if *id == turn_id => requested.push(PermissionKey {
+                tool_use_id: tool_use_id.clone(),
+                request_id: permission_request_id(request),
+            }),
+            AgentSessionEvent::PermissionResolved {
+                turn_id: id,
+                tool_use_id,
+                request_id,
+                ..
+            } if *id == turn_id => {
+                resolved.insert(PermissionKey {
+                    tool_use_id: tool_use_id.clone(),
+                    request_id: request_id.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+    requested
+        .into_iter()
+        .filter(|key| {
+            !resolved.contains(key)
+                && !resolved.iter().any(|resolved_key| {
+                    key.request_id.is_some() && key.request_id == resolved_key.request_id
+                        || key.tool_use_id.is_some() && key.tool_use_id == resolved_key.tool_use_id
+                })
+        })
+        .collect()
+}

--- a/src-tauri/src/usecase/agent_session/event_log/log.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/log.rs
@@ -1,0 +1,103 @@
+#[cfg(test)]
+use std::cell::Cell;
+
+use serde::{Deserialize, Serialize};
+
+use super::events::{AgentSessionEvent, InterruptReason, PromptInput, TurnId};
+use super::finalization::finalize_turn;
+use super::part_events::{append_part_events, PartEventMode};
+use super::projector::{project, SessionReadModel};
+use crate::usecase::agent_session::session::MessagePart;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TurnEventLog {
+    events: Vec<AgentSessionEvent>,
+    #[cfg(test)]
+    #[serde(skip)]
+    project_call_count: Cell<usize>,
+}
+
+impl PartialEq for TurnEventLog {
+    fn eq(&self, other: &Self) -> bool {
+        self.events == other.events
+    }
+}
+
+impl TurnEventLog {
+    pub fn from_events(events: Vec<AgentSessionEvent>) -> Self {
+        Self {
+            events,
+            #[cfg(test)]
+            project_call_count: Cell::new(0),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.events.clear();
+    }
+
+    pub fn append(&mut self, event: AgentSessionEvent) {
+        self.events.push(event);
+    }
+
+    pub fn append_part_events(
+        &mut self,
+        turn_id: TurnId,
+        message_id: &str,
+        parts: &[MessagePart],
+        mode: PartEventMode,
+    ) -> usize {
+        append_part_events(&mut self.events, turn_id, message_id, parts, mode)
+    }
+
+    pub fn begin_turn(
+        &mut self,
+        turn_id: TurnId,
+        prompt_message_id: String,
+        assistant_message_id: String,
+        prompt: PromptInput,
+        at: f64,
+    ) {
+        self.append(AgentSessionEvent::TurnStarted {
+            turn_id,
+            message_id: prompt_message_id,
+            assistant_message_id: Some(assistant_message_id),
+            prompt,
+            at,
+        });
+    }
+
+    pub fn current_turn_id(&self) -> Option<TurnId> {
+        self.events.iter().rev().find_map(|event| match event {
+            AgentSessionEvent::TurnStarted { turn_id, .. } => Some(*turn_id),
+            _ => None,
+        })
+    }
+
+    pub fn project(&self) -> SessionReadModel {
+        #[cfg(test)]
+        self.project_call_count
+            .set(self.project_call_count.get().saturating_add(1));
+        project(&self.events)
+    }
+
+    #[cfg(test)]
+    pub fn project_call_count(&self) -> usize {
+        self.project_call_count.get()
+    }
+
+    #[cfg(test)]
+    pub fn reset_project_call_count(&self) {
+        self.project_call_count.set(0);
+    }
+
+    pub fn finalize(
+        &mut self,
+        turn_id: TurnId,
+        reason: InterruptReason,
+        error: Option<String>,
+        exit_code: i64,
+    ) {
+        finalize_turn(&mut self.events, turn_id, reason, error, exit_code);
+    }
+}

--- a/src-tauri/src/usecase/agent_session/event_log/mod.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/mod.rs
@@ -1,0 +1,30 @@
+//! Durable event log and projector for agent sessions.
+//!
+//! Connection points for adjacent work:
+//! - issues-1213: this projector writes the same read model that the existing
+//!   split session layout (`meta.json` + `messages/{seq}.json` + `index.json`)
+//!   stores, so the storage format stays compatible.
+//! - issues-1214: live-only deltas are kept out of `AgentSessionEvent`, leaving
+//!   a clear boundary for a future seq-delta streaming protocol. The current
+//!   bridge integration keeps live-only SDK deltas inside the legacy streaming
+//!   accumulator; only durable parts and terminal live blocks are appended here.
+//! - issues-1217: runtime integration remains in `bridge_common.rs`; this
+//!   pure module can move behind a later runtime/stream/persist split without
+//!   changing the event vocabulary.
+
+mod events;
+mod finalization;
+mod log;
+mod part_events;
+mod projector;
+
+pub use events::{
+    human_parts_from_content_images, AgentSessionEvent, InterruptReason, PermissionDecision,
+    PromptInput, TurnTokenUsage,
+};
+pub use log::TurnEventLog;
+pub use part_events::PartEventMode;
+pub use projector::WorkflowTurnCompleteInput;
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/usecase/agent_session/event_log/part_events.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/part_events.rs
@@ -1,0 +1,237 @@
+use super::events::{AgentSessionEvent, PermissionDecision, TurnId};
+use crate::usecase::agent_session::session::MessagePart;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PartEventMode {
+    DurableOnly,
+    FinalLiveBlocks,
+}
+
+pub fn append_part_events(
+    events: &mut Vec<AgentSessionEvent>,
+    turn_id: TurnId,
+    message_id: &str,
+    parts: &[MessagePart],
+    mode: PartEventMode,
+) -> usize {
+    let before_len = events.len();
+    for part in parts {
+        match part {
+            MessagePart::Text {
+                content,
+                parent_tool_use_id,
+            } if mode == PartEventMode::FinalLiveBlocks => {
+                events.push(AgentSessionEvent::TextRecorded {
+                    turn_id,
+                    message_id: message_id.to_string(),
+                    content: content.clone(),
+                    parent_tool_use_id: parent_tool_use_id.clone(),
+                });
+            }
+            MessagePart::Thinking {
+                content,
+                parent_tool_use_id,
+            } if mode == PartEventMode::FinalLiveBlocks => {
+                events.push(AgentSessionEvent::ReasoningRecorded {
+                    turn_id,
+                    message_id: message_id.to_string(),
+                    content: content.clone(),
+                    parent_tool_use_id: parent_tool_use_id.clone(),
+                });
+            }
+            MessagePart::Error {
+                content,
+                parent_tool_use_id,
+            } if mode == PartEventMode::FinalLiveBlocks => {
+                events.push(AgentSessionEvent::ErrorRecorded {
+                    turn_id,
+                    message_id: message_id.to_string(),
+                    content: content.clone(),
+                    parent_tool_use_id: parent_tool_use_id.clone(),
+                });
+            }
+            MessagePart::ToolUse {
+                tool,
+                input,
+                id,
+                parent_tool_use_id,
+            } if mode == PartEventMode::DurableOnly => {
+                if let Some(attempt) = next_tool_retry_attempt(events, turn_id, id) {
+                    events.push(AgentSessionEvent::ToolCallRetried {
+                        turn_id,
+                        tool_use_id: id.clone(),
+                        attempt,
+                    });
+                }
+                events.push(AgentSessionEvent::ToolCallStarted {
+                    turn_id,
+                    tool_use_id: id.clone(),
+                    tool: tool.clone(),
+                    input: input.clone(),
+                    parent_tool_use_id: parent_tool_use_id.clone(),
+                });
+            }
+            MessagePart::ToolResult {
+                content,
+                is_error,
+                tool_use_id: Some(tool_use_id),
+                ..
+            } if mode == PartEventMode::DurableOnly => {
+                events.push(if *is_error {
+                    AgentSessionEvent::ToolCallFailed {
+                        turn_id,
+                        tool_use_id: tool_use_id.clone(),
+                        content: content.clone(),
+                    }
+                } else {
+                    AgentSessionEvent::ToolCallSucceeded {
+                        turn_id,
+                        tool_use_id: tool_use_id.clone(),
+                        content: content.clone(),
+                    }
+                });
+            }
+            MessagePart::ToolResult {
+                content,
+                is_error,
+                tool_use_id: None,
+                parent_tool_use_id,
+            } if mode == PartEventMode::DurableOnly => {
+                events.push(AgentSessionEvent::ToolResultRecorded {
+                    turn_id,
+                    message_id: message_id.to_string(),
+                    content: content.clone(),
+                    is_error: *is_error,
+                    tool_use_id: None,
+                    parent_tool_use_id: parent_tool_use_id.clone(),
+                });
+            }
+            MessagePart::Permission {
+                request,
+                status,
+                answers,
+                parent_tool_use_id,
+            } if mode == PartEventMode::DurableOnly => {
+                let tool_use_id = request
+                    .get("tool_use_id")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.is_empty())
+                    .map(ToString::to_string)
+                    .or_else(|| parent_tool_use_id.clone());
+                if status == "pending" {
+                    events.push(AgentSessionEvent::PermissionRequested {
+                        turn_id,
+                        tool_use_id,
+                        request: request.clone(),
+                    });
+                } else if let Some(decision) = PermissionDecision::from_status(status) {
+                    events.push(AgentSessionEvent::PermissionRequested {
+                        turn_id,
+                        tool_use_id: tool_use_id.clone(),
+                        request: request.clone(),
+                    });
+                    events.push(AgentSessionEvent::PermissionResolved {
+                        turn_id,
+                        tool_use_id,
+                        request_id: permission_request_id(request),
+                        decision,
+                        answers: answers.clone(),
+                    });
+                }
+            }
+            MessagePart::TaskStatus {
+                task_tool_use_id,
+                status,
+                description,
+                summary,
+            } if mode == PartEventMode::DurableOnly => {
+                events.push(AgentSessionEvent::TaskStatusChanged {
+                    turn_id,
+                    message_id: message_id.to_string(),
+                    task_tool_use_id: task_tool_use_id.clone(),
+                    status: status.clone(),
+                    description: description.clone(),
+                    summary: summary.clone(),
+                });
+            }
+            MessagePart::TodoListSnapshot { items } if mode == PartEventMode::DurableOnly => {
+                events.push(AgentSessionEvent::TodoListSnapshotRecorded {
+                    turn_id,
+                    message_id: message_id.to_string(),
+                    items: items.clone(),
+                });
+            }
+            MessagePart::SystemNotification {
+                notification_type,
+                status,
+                label,
+                detail,
+                hook_id,
+            } if mode == PartEventMode::DurableOnly => {
+                events.push(AgentSessionEvent::SystemNotificationRecorded {
+                    turn_id,
+                    message_id: message_id.to_string(),
+                    notification_type: notification_type.clone(),
+                    status: status.clone(),
+                    label: label.clone(),
+                    detail: detail.clone(),
+                    hook_id: hook_id.clone(),
+                });
+            }
+            MessagePart::Image { data, media_type } if mode == PartEventMode::DurableOnly => {
+                events.push(AgentSessionEvent::ImageRecorded {
+                    turn_id,
+                    message_id: message_id.to_string(),
+                    data: data.clone(),
+                    media_type: media_type.clone(),
+                });
+            }
+            MessagePart::ImageRef { attachment } if mode == PartEventMode::DurableOnly => {
+                events.push(AgentSessionEvent::ImageRefRecorded {
+                    turn_id,
+                    message_id: message_id.to_string(),
+                    attachment: attachment.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+    events.len().saturating_sub(before_len)
+}
+
+fn next_tool_retry_attempt(
+    events: &[AgentSessionEvent],
+    turn_id: TurnId,
+    tool_use_id: &str,
+) -> Option<u32> {
+    let prior_starts = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                AgentSessionEvent::ToolCallStarted {
+                    turn_id: id,
+                    tool_use_id: existing_id,
+                    ..
+                } if *id == turn_id && existing_id == tool_use_id
+            )
+        })
+        .count();
+    (prior_starts > 0).then_some(prior_starts.saturating_add(1) as u32)
+}
+
+pub(super) fn permission_request_id(request: &serde_json::Value) -> Option<String> {
+    request
+        .get("request_id")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+pub(super) fn permission_tool_use_id(request: &serde_json::Value) -> Option<String> {
+    request
+        .get("tool_use_id")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}

--- a/src-tauri/src/usecase/agent_session/event_log/projector.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/projector.rs
@@ -1,0 +1,894 @@
+use std::collections::HashMap;
+
+use super::events::{AgentSessionEvent, InterruptReason, PromptInput, TurnId, TurnTokenUsage};
+use super::finalization::has_unresolved_permissions;
+use super::part_events::{permission_request_id, permission_tool_use_id};
+use crate::usecase::agent_session::session::{
+    parts_to_legacy, ChatMessage, MessagePart, MessageRole, SessionState, SystemNotificationType,
+    TodoListItem,
+};
+use crate::usecase::agent_session::status::TurnPhase;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedStatus {
+    pub session_state: SessionState,
+    pub turn_phase: TurnPhase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowTurnCompleteInput {
+    pub turn_id: TurnId,
+    pub exit_code: i64,
+    pub final_text_parts: Vec<String>,
+    pub token_usage: Option<TurnTokenUsage>,
+    pub interrupted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolRetryProjection {
+    pub turn_id: TurnId,
+    pub tool_use_id: String,
+    pub attempt: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionReadModel {
+    pub messages: Vec<ChatMessage>,
+    pub status: ProjectedStatus,
+    pub workflow_turn_complete: Option<WorkflowTurnCompleteInput>,
+    pub tool_retries: Vec<ToolRetryProjection>,
+}
+
+impl SessionReadModel {
+    pub fn agent_parts_for_message(&self, message_id: &str) -> Vec<MessagePart> {
+        self.messages
+            .iter()
+            .find(|message| message.id == message_id && message.role == MessageRole::Agent)
+            .and_then(|message| message.parts.clone())
+            .unwrap_or_default()
+    }
+}
+
+pub fn project(events: &[AgentSessionEvent]) -> SessionReadModel {
+    let mut turns: Vec<TurnProjection> = Vec::new();
+    let mut turn_index: HashMap<TurnId, usize> = HashMap::new();
+    let mut terminal_by_turn: HashMap<TurnId, TerminalEvent> = HashMap::new();
+    let mut tool_retries = Vec::new();
+    let mut session_closed = false;
+
+    for event in events {
+        match event {
+            AgentSessionEvent::TurnStarted {
+                turn_id,
+                message_id,
+                assistant_message_id,
+                prompt,
+                at,
+            } => {
+                let index = *turn_index.entry(*turn_id).or_insert_with(|| {
+                    turns.push(TurnProjection::new(
+                        *turn_id,
+                        message_id.clone(),
+                        assistant_message_id
+                            .clone()
+                            .unwrap_or_else(|| format!("{message_id}:agent")),
+                        prompt.clone(),
+                        *at,
+                    ));
+                    turns.len() - 1
+                });
+                turns[index].prompt = prompt.clone();
+                turns[index].prompt_message_id = message_id.clone();
+                if let Some(assistant_message_id) = assistant_message_id {
+                    turns[index].assistant_message_id = assistant_message_id.clone();
+                }
+                turns[index].started_at = *at;
+            }
+            AgentSessionEvent::TextRecorded {
+                turn_id,
+                message_id,
+                content,
+                parent_tool_use_id,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    push_consolidated_text(
+                        &mut turn.assistant_parts,
+                        content,
+                        parent_tool_use_id,
+                        false,
+                    );
+                }
+            }
+            AgentSessionEvent::ReasoningRecorded {
+                turn_id,
+                message_id,
+                content,
+                parent_tool_use_id,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    push_consolidated_text(
+                        &mut turn.assistant_parts,
+                        content,
+                        parent_tool_use_id,
+                        true,
+                    );
+                }
+            }
+            AgentSessionEvent::ErrorRecorded {
+                turn_id,
+                message_id,
+                content,
+                parent_tool_use_id,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    push_unique_error(&mut turn.assistant_parts, content, parent_tool_use_id);
+                }
+            }
+            AgentSessionEvent::ToolCallStarted {
+                turn_id,
+                tool_use_id,
+                tool,
+                input,
+                parent_tool_use_id,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    push_or_update_tool_use(
+                        &mut turn.assistant_parts,
+                        tool_use_id,
+                        tool,
+                        input,
+                        parent_tool_use_id,
+                    );
+                }
+            }
+            AgentSessionEvent::ToolCallSucceeded {
+                turn_id,
+                tool_use_id,
+                content,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    let parent_tool_use_id =
+                        parent_tool_use_id_for_tool(&turn.assistant_parts, tool_use_id);
+                    push_or_update_tool_result(
+                        &mut turn.assistant_parts,
+                        tool_use_id,
+                        content,
+                        false,
+                        parent_tool_use_id,
+                    );
+                }
+            }
+            AgentSessionEvent::ToolCallFailed {
+                turn_id,
+                tool_use_id,
+                content,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    let parent_tool_use_id =
+                        parent_tool_use_id_for_tool(&turn.assistant_parts, tool_use_id);
+                    push_or_update_tool_result(
+                        &mut turn.assistant_parts,
+                        tool_use_id,
+                        content,
+                        true,
+                        parent_tool_use_id,
+                    );
+                }
+            }
+            AgentSessionEvent::ToolResultRecorded {
+                turn_id,
+                message_id,
+                content,
+                is_error,
+                tool_use_id,
+                parent_tool_use_id,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    match tool_use_id {
+                        Some(tool_use_id) => {
+                            let parent_tool_use_id = parent_tool_use_id.clone().or_else(|| {
+                                parent_tool_use_id_for_tool(&turn.assistant_parts, tool_use_id)
+                            });
+                            push_or_update_tool_result(
+                                &mut turn.assistant_parts,
+                                tool_use_id,
+                                content,
+                                *is_error,
+                                parent_tool_use_id,
+                            );
+                        }
+                        None => {
+                            turn.assistant_parts.push(MessagePart::ToolResult {
+                                content: content.clone(),
+                                is_error: *is_error,
+                                tool_use_id: None,
+                                parent_tool_use_id: parent_tool_use_id.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+            AgentSessionEvent::ToolCallRetried {
+                turn_id,
+                tool_use_id,
+                attempt,
+            } => {
+                if turn_index.contains_key(turn_id) {
+                    tool_retries.push(ToolRetryProjection {
+                        turn_id: *turn_id,
+                        tool_use_id: tool_use_id.clone(),
+                        attempt: *attempt,
+                    });
+                } else {
+                    log::warn!("agent session event projector saw orphan event for turn {turn_id}");
+                }
+            }
+            AgentSessionEvent::PermissionRequested {
+                turn_id,
+                tool_use_id,
+                request,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    push_or_update_permission(
+                        &mut turn.assistant_parts,
+                        request.clone(),
+                        "pending",
+                        None,
+                        tool_use_id.clone(),
+                    );
+                }
+            }
+            AgentSessionEvent::PermissionResolved {
+                turn_id,
+                tool_use_id,
+                request_id,
+                decision,
+                answers,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    resolve_permission(
+                        &mut turn.assistant_parts,
+                        tool_use_id.as_deref(),
+                        request_id.as_deref(),
+                        *decision,
+                        answers.clone(),
+                    );
+                }
+            }
+            AgentSessionEvent::TaskStatusChanged {
+                turn_id,
+                message_id,
+                task_tool_use_id,
+                status,
+                description,
+                summary,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    push_or_update_task_status(
+                        &mut turn.assistant_parts,
+                        task_tool_use_id,
+                        status,
+                        description,
+                        summary,
+                    );
+                }
+            }
+            AgentSessionEvent::TodoListSnapshotRecorded {
+                turn_id,
+                message_id,
+                items,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    push_todo_snapshot(&mut turn.assistant_parts, items.clone());
+                }
+            }
+            AgentSessionEvent::SystemNotificationRecorded {
+                turn_id,
+                message_id,
+                notification_type,
+                status,
+                label,
+                detail,
+                hook_id,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    push_or_update_system_notification(
+                        &mut turn.assistant_parts,
+                        notification_type,
+                        status,
+                        label,
+                        detail,
+                        hook_id,
+                    );
+                }
+            }
+            AgentSessionEvent::ImageRecorded {
+                turn_id,
+                message_id,
+                data,
+                media_type,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    turn.assistant_parts.push(MessagePart::Image {
+                        data: data.clone(),
+                        media_type: media_type.clone(),
+                    });
+                }
+            }
+            AgentSessionEvent::ImageRefRecorded {
+                turn_id,
+                message_id,
+                attachment,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    turn.assistant_parts.push(MessagePart::ImageRef {
+                        attachment: attachment.clone(),
+                    });
+                }
+            }
+            AgentSessionEvent::FinalPartsRecorded {
+                turn_id,
+                message_id,
+                parts,
+            } => {
+                if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                    turn.assistant_message_id = message_id.clone();
+                    turn.assistant_parts = parts.clone();
+                }
+            }
+            AgentSessionEvent::TurnCompleted {
+                turn_id,
+                exit_code,
+                token_usage,
+            } => {
+                terminal_by_turn.insert(
+                    *turn_id,
+                    TerminalEvent::Completed {
+                        exit_code: *exit_code,
+                        token_usage: *token_usage,
+                    },
+                );
+            }
+            AgentSessionEvent::TurnInterrupted {
+                turn_id,
+                reason,
+                exit_code,
+                error,
+            } => {
+                if let Some(error) = error {
+                    if let Some(turn) = turn_mut(&mut turns, &turn_index, *turn_id) {
+                        push_unique_error(&mut turn.assistant_parts, error, &None);
+                    }
+                }
+                terminal_by_turn.insert(
+                    *turn_id,
+                    TerminalEvent::Interrupted {
+                        reason: *reason,
+                        exit_code: *exit_code,
+                    },
+                );
+            }
+            AgentSessionEvent::SessionClosed { .. } => {
+                session_closed = true;
+            }
+        }
+    }
+
+    let messages = turns
+        .iter()
+        .flat_map(|turn| turn.to_messages())
+        .collect::<Vec<_>>();
+    let status = project_status(events, session_closed, &terminal_by_turn);
+    let workflow_turn_complete = project_workflow_turn_complete(&turns, &terminal_by_turn);
+
+    SessionReadModel {
+        messages,
+        status,
+        workflow_turn_complete,
+        tool_retries,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TurnProjection {
+    turn_id: TurnId,
+    prompt_message_id: String,
+    assistant_message_id: String,
+    prompt: PromptInput,
+    started_at: f64,
+    assistant_parts: Vec<MessagePart>,
+}
+
+impl TurnProjection {
+    fn new(
+        turn_id: TurnId,
+        prompt_message_id: String,
+        assistant_message_id: String,
+        prompt: PromptInput,
+        started_at: f64,
+    ) -> Self {
+        Self {
+            turn_id,
+            prompt_message_id,
+            assistant_message_id,
+            prompt,
+            started_at,
+            assistant_parts: Vec::new(),
+        }
+    }
+
+    fn to_messages(&self) -> Vec<ChatMessage> {
+        let mut messages = Vec::with_capacity(2);
+        let prompt_parts = prompt_parts_for_message(&self.prompt);
+        messages.push(ChatMessage {
+            id: self.prompt_message_id.clone(),
+            role: MessageRole::Human,
+            content: self.prompt.content.clone(),
+            thinking: None,
+            activities: None,
+            parts: (!prompt_parts.is_empty()).then_some(prompt_parts),
+            timestamp: self.started_at,
+            mentions: (!self.prompt.mentions.is_empty()).then_some(self.prompt.mentions.clone()),
+        });
+
+        let (content, thinking, activities) = parts_to_legacy(&self.assistant_parts);
+        messages.push(ChatMessage {
+            id: self.assistant_message_id.clone(),
+            role: MessageRole::Agent,
+            content,
+            thinking,
+            activities,
+            parts: (!self.assistant_parts.is_empty()).then_some(self.assistant_parts.clone()),
+            timestamp: self.started_at,
+            mentions: None,
+        });
+
+        messages
+    }
+}
+
+fn prompt_parts_for_message(prompt: &PromptInput) -> Vec<MessagePart> {
+    if !prompt.parts.is_empty() {
+        return prompt.parts.clone();
+    }
+
+    if prompt.attachment_refs.is_empty() {
+        return Vec::new();
+    }
+
+    let mut parts = Vec::with_capacity(prompt.attachment_refs.len() + 1);
+    if !prompt.content.is_empty() {
+        parts.push(MessagePart::Text {
+            content: prompt.content.clone(),
+            parent_tool_use_id: None,
+        });
+    }
+    parts.extend(
+        prompt
+            .attachment_refs
+            .iter()
+            .cloned()
+            .map(|attachment| MessagePart::ImageRef { attachment }),
+    );
+    parts
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TerminalEvent {
+    Completed {
+        exit_code: i64,
+        token_usage: Option<TurnTokenUsage>,
+    },
+    Interrupted {
+        reason: InterruptReason,
+        exit_code: i64,
+    },
+}
+
+fn turn_mut<'a>(
+    turns: &'a mut [TurnProjection],
+    turn_index: &HashMap<TurnId, usize>,
+    turn_id: TurnId,
+) -> Option<&'a mut TurnProjection> {
+    let Some(index) = turn_index.get(&turn_id) else {
+        log::warn!("agent session event projector saw orphan event for turn {turn_id}");
+        return None;
+    };
+    turns.get_mut(*index)
+}
+
+fn push_consolidated_text(
+    parts: &mut Vec<MessagePart>,
+    content: &str,
+    parent_tool_use_id: &Option<String>,
+    thinking: bool,
+) {
+    match (thinking, parts.last_mut()) {
+        (
+            false,
+            Some(MessagePart::Text {
+                content: existing,
+                parent_tool_use_id: existing_parent,
+            }),
+        ) if existing_parent == parent_tool_use_id => existing.push_str(content),
+        (
+            true,
+            Some(MessagePart::Thinking {
+                content: existing,
+                parent_tool_use_id: existing_parent,
+            }),
+        ) if existing_parent == parent_tool_use_id => existing.push_str(content),
+        (false, _) => parts.push(MessagePart::Text {
+            content: content.to_string(),
+            parent_tool_use_id: parent_tool_use_id.clone(),
+        }),
+        (true, _) => parts.push(MessagePart::Thinking {
+            content: content.to_string(),
+            parent_tool_use_id: parent_tool_use_id.clone(),
+        }),
+    }
+}
+
+fn push_unique_error(
+    parts: &mut Vec<MessagePart>,
+    content: &str,
+    parent_tool_use_id: &Option<String>,
+) {
+    if parts.iter().any(|part| {
+        matches!(
+            part,
+            MessagePart::Error {
+                content: existing,
+                parent_tool_use_id: existing_parent,
+            } if existing == content && existing_parent == parent_tool_use_id
+        )
+    }) {
+        return;
+    }
+    parts.push(MessagePart::Error {
+        content: content.to_string(),
+        parent_tool_use_id: parent_tool_use_id.clone(),
+    });
+}
+
+fn push_or_update_tool_use(
+    parts: &mut Vec<MessagePart>,
+    tool_use_id: &str,
+    tool: &str,
+    input: &serde_json::Value,
+    parent_tool_use_id: &Option<String>,
+) {
+    if let Some(existing) = parts.iter_mut().rev().find(|part| {
+        matches!(
+            part,
+            MessagePart::ToolUse { id, .. } if id == tool_use_id
+        )
+    }) {
+        *existing = MessagePart::ToolUse {
+            tool: tool.to_string(),
+            input: input.clone(),
+            id: tool_use_id.to_string(),
+            parent_tool_use_id: parent_tool_use_id.clone(),
+        };
+        return;
+    }
+    parts.push(MessagePart::ToolUse {
+        tool: tool.to_string(),
+        input: input.clone(),
+        id: tool_use_id.to_string(),
+        parent_tool_use_id: parent_tool_use_id.clone(),
+    });
+}
+
+fn push_or_update_tool_result(
+    parts: &mut Vec<MessagePart>,
+    tool_use_id: &str,
+    content: &str,
+    is_error: bool,
+    parent_tool_use_id: Option<String>,
+) {
+    if let Some(existing) = parts.iter_mut().rev().find(|part| {
+        matches!(
+            part,
+            MessagePart::ToolResult {
+                tool_use_id: Some(id),
+                ..
+            } if id == tool_use_id
+        )
+    }) {
+        let MessagePart::ToolResult {
+            content: existing_content,
+            is_error: existing_error,
+            parent_tool_use_id: existing_parent_tool_use_id,
+            ..
+        } = existing
+        else {
+            return;
+        };
+        if existing_parent_tool_use_id.is_none() {
+            *existing_parent_tool_use_id = parent_tool_use_id;
+        }
+        if *existing_error && !is_error {
+            *existing_content = content.to_string();
+            *existing_error = false;
+        } else if content.contains(existing_content.as_str()) || existing_content.is_empty() {
+            *existing_content = content.to_string();
+        } else {
+            existing_content.push_str(content);
+        }
+        *existing_error = *existing_error || is_error;
+        return;
+    }
+    parts.push(MessagePart::ToolResult {
+        content: content.to_string(),
+        is_error,
+        tool_use_id: Some(tool_use_id.to_string()),
+        parent_tool_use_id,
+    });
+}
+
+fn parent_tool_use_id_for_tool(parts: &[MessagePart], tool_use_id: &str) -> Option<String> {
+    parts.iter().rev().find_map(|part| match part {
+        MessagePart::ToolUse {
+            id,
+            parent_tool_use_id,
+            ..
+        } if id == tool_use_id => parent_tool_use_id.clone(),
+        _ => None,
+    })
+}
+
+fn push_or_update_permission(
+    parts: &mut Vec<MessagePart>,
+    request: serde_json::Value,
+    status: &str,
+    answers: Option<serde_json::Value>,
+    tool_use_id: Option<String>,
+) {
+    let request_id = permission_request_id(&request);
+    if let Some(existing) = parts.iter_mut().rev().find(|part| match part {
+        MessagePart::Permission {
+            request: existing_request,
+            ..
+        } => {
+            permission_request_id(existing_request) == request_id
+                || permission_tool_use_id(existing_request) == tool_use_id
+        }
+        _ => false,
+    }) {
+        *existing = MessagePart::Permission {
+            request,
+            status: status.to_string(),
+            answers,
+            parent_tool_use_id: tool_use_id,
+        };
+        return;
+    }
+    parts.push(MessagePart::Permission {
+        request,
+        status: status.to_string(),
+        answers,
+        parent_tool_use_id: tool_use_id,
+    });
+}
+
+fn resolve_permission(
+    parts: &mut [MessagePart],
+    tool_use_id: Option<&str>,
+    request_id: Option<&str>,
+    decision: super::events::PermissionDecision,
+    answers: Option<serde_json::Value>,
+) {
+    if let Some(MessagePart::Permission {
+        status,
+        answers: existing_answers,
+        ..
+    }) = parts.iter_mut().rev().find(|part| match part {
+        MessagePart::Permission { request, .. } => {
+            request_id.is_some_and(|id| permission_request_id(request).as_deref() == Some(id))
+                || tool_use_id
+                    .is_some_and(|id| permission_tool_use_id(request).as_deref() == Some(id))
+                || (request_id.is_none() && tool_use_id.is_none())
+        }
+        _ => false,
+    }) {
+        *status = decision.status().to_string();
+        *existing_answers = answers;
+    }
+}
+
+fn push_or_update_task_status(
+    parts: &mut Vec<MessagePart>,
+    task_tool_use_id: &str,
+    status: &str,
+    description: &Option<String>,
+    summary: &Option<String>,
+) {
+    if let Some(MessagePart::TaskStatus {
+        status: existing_status,
+        description: existing_description,
+        summary: existing_summary,
+        ..
+    }) = parts.iter_mut().rev().find(|part| {
+        matches!(
+            part,
+            MessagePart::TaskStatus {
+                task_tool_use_id: existing_id,
+                ..
+            } if existing_id == task_tool_use_id
+        )
+    }) {
+        *existing_status = status.to_string();
+        if description.is_some() {
+            *existing_description = description.clone();
+        }
+        if summary.is_some() {
+            *existing_summary = summary.clone();
+        }
+        return;
+    }
+    parts.push(MessagePart::TaskStatus {
+        task_tool_use_id: task_tool_use_id.to_string(),
+        status: status.to_string(),
+        description: description.clone(),
+        summary: summary.clone(),
+    });
+}
+
+fn push_todo_snapshot(parts: &mut Vec<MessagePart>, items: Vec<TodoListItem>) {
+    let completed = items.iter().filter(|item| item.completed).count();
+    parts.push(MessagePart::Text {
+        content: format!("TODO を更新しました（{completed}/{} 完了）", items.len()),
+        parent_tool_use_id: None,
+    });
+    if let Some(existing) = parts
+        .iter_mut()
+        .rev()
+        .find(|part| matches!(part, MessagePart::TodoListSnapshot { .. }))
+    {
+        *existing = MessagePart::TodoListSnapshot { items };
+    } else {
+        parts.push(MessagePart::TodoListSnapshot { items });
+    }
+}
+
+fn push_or_update_system_notification(
+    parts: &mut Vec<MessagePart>,
+    notification_type: &SystemNotificationType,
+    status: &str,
+    label: &str,
+    detail: &Option<String>,
+    hook_id: &Option<String>,
+) {
+    if let Some(existing) = parts.iter_mut().rev().find(|part| {
+        matches!(
+            part,
+            MessagePart::SystemNotification {
+                notification_type: existing_type,
+                status: existing_status,
+                ..
+            } if existing_type == notification_type && existing_status == "in_progress"
+        )
+    }) {
+        *existing = MessagePart::SystemNotification {
+            notification_type: notification_type.clone(),
+            status: status.to_string(),
+            label: label.to_string(),
+            detail: detail.clone(),
+            hook_id: hook_id.clone(),
+        };
+        return;
+    }
+    parts.push(MessagePart::SystemNotification {
+        notification_type: notification_type.clone(),
+        status: status.to_string(),
+        label: label.to_string(),
+        detail: detail.clone(),
+        hook_id: hook_id.clone(),
+    });
+}
+
+fn project_status(
+    events: &[AgentSessionEvent],
+    session_closed: bool,
+    terminal_by_turn: &HashMap<TurnId, TerminalEvent>,
+) -> ProjectedStatus {
+    if session_closed {
+        return ProjectedStatus {
+            session_state: SessionState::Closed,
+            turn_phase: TurnPhase::Idle,
+        };
+    }
+    let Some(turn_id) = events.iter().rev().find_map(|event| match event {
+        AgentSessionEvent::TurnStarted { turn_id, .. } => Some(*turn_id),
+        _ => None,
+    }) else {
+        return ProjectedStatus {
+            session_state: SessionState::Idle,
+            turn_phase: TurnPhase::Idle,
+        };
+    };
+
+    if let Some(terminal) = terminal_by_turn.get(&turn_id) {
+        return match terminal {
+            TerminalEvent::Completed { exit_code, .. } if *exit_code == 0 => ProjectedStatus {
+                session_state: SessionState::Idle,
+                turn_phase: TurnPhase::Idle,
+            },
+            TerminalEvent::Completed { .. } => ProjectedStatus {
+                session_state: SessionState::Error,
+                turn_phase: TurnPhase::Idle,
+            },
+            TerminalEvent::Interrupted {
+                reason: InterruptReason::Abort,
+                ..
+            } => ProjectedStatus {
+                session_state: SessionState::Idle,
+                turn_phase: TurnPhase::Idle,
+            },
+            TerminalEvent::Interrupted { .. } => ProjectedStatus {
+                session_state: SessionState::Error,
+                turn_phase: TurnPhase::Idle,
+            },
+        };
+    }
+
+    if has_unresolved_permissions(events, turn_id) {
+        return ProjectedStatus {
+            session_state: SessionState::Active,
+            turn_phase: TurnPhase::WaitingPermission,
+        };
+    }
+
+    ProjectedStatus {
+        session_state: SessionState::Active,
+        turn_phase: TurnPhase::Streaming,
+    }
+}
+
+fn project_workflow_turn_complete(
+    turns: &[TurnProjection],
+    terminal_by_turn: &HashMap<TurnId, TerminalEvent>,
+) -> Option<WorkflowTurnCompleteInput> {
+    let turn = turns
+        .iter()
+        .rev()
+        .find(|turn| terminal_by_turn.contains_key(&turn.turn_id))?;
+    let terminal = terminal_by_turn.get(&turn.turn_id)?;
+    let final_text_parts = turn
+        .assistant_parts
+        .iter()
+        .filter_map(|part| match part {
+            MessagePart::Text { content, .. } => Some(content.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    match terminal {
+        TerminalEvent::Completed {
+            exit_code,
+            token_usage,
+        } => Some(WorkflowTurnCompleteInput {
+            turn_id: turn.turn_id,
+            exit_code: *exit_code,
+            final_text_parts,
+            token_usage: *token_usage,
+            interrupted: false,
+        }),
+        TerminalEvent::Interrupted { exit_code, .. } => Some(WorkflowTurnCompleteInput {
+            turn_id: turn.turn_id,
+            exit_code: *exit_code,
+            final_text_parts,
+            token_usage: None,
+            interrupted: true,
+        }),
+    }
+}

--- a/src-tauri/src/usecase/agent_session/event_log/tests.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/tests.rs
@@ -1,0 +1,765 @@
+use super::finalization::finalize_turn;
+use super::projector::{project, ProjectedStatus};
+use super::*;
+use crate::usecase::agent_session::session::{
+    AttachmentRef, MessageMention, MessagePart, SessionState, SystemNotificationType, TodoListItem,
+};
+use crate::usecase::agent_session::status::TurnPhase;
+
+fn start_event() -> AgentSessionEvent {
+    AgentSessionEvent::TurnStarted {
+        turn_id: 1,
+        message_id: "human-1".to_string(),
+        assistant_message_id: Some("agent-1".to_string()),
+        prompt: PromptInput {
+            content: "please read".to_string(),
+            mentions: Vec::new(),
+            attachment_refs: Vec::new(),
+            parts: Vec::new(),
+        },
+        at: 10.0,
+    }
+}
+
+#[test]
+fn append_events_project_message_page_and_workflow_input() {
+    let events = vec![
+        start_event(),
+        AgentSessionEvent::ToolCallStarted {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            tool: "Read".to_string(),
+            input: serde_json::json!({"file_path": "src/lib.rs"}),
+            parent_tool_use_id: None,
+        },
+        AgentSessionEvent::ToolCallSucceeded {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            content: "contents".to_string(),
+        },
+        AgentSessionEvent::TextRecorded {
+            turn_id: 1,
+            message_id: "agent-1".to_string(),
+            content: "done".to_string(),
+            parent_tool_use_id: None,
+        },
+        AgentSessionEvent::TurnCompleted {
+            turn_id: 1,
+            exit_code: 0,
+            token_usage: Some(TurnTokenUsage {
+                input_tokens: 3,
+                output_tokens: 5,
+            }),
+        },
+    ];
+
+    let read_model = project(&events);
+
+    assert_eq!(read_model.messages.len(), 2);
+    assert_eq!(read_model.messages[0].content, "please read");
+    let agent_parts = read_model.agent_parts_for_message("agent-1");
+    assert!(agent_parts.iter().any(|part| matches!(
+        part,
+        MessagePart::ToolResult {
+            content,
+            tool_use_id: Some(id),
+            is_error: false,
+            ..
+        } if id == "tool-1" && content == "contents"
+    )));
+    assert_eq!(
+        read_model.status,
+        ProjectedStatus {
+            session_state: SessionState::Idle,
+            turn_phase: TurnPhase::Idle,
+        }
+    );
+    assert_eq!(
+        read_model.workflow_turn_complete,
+        Some(WorkflowTurnCompleteInput {
+            turn_id: 1,
+            exit_code: 0,
+            final_text_parts: vec!["done".to_string()],
+            token_usage: Some(TurnTokenUsage {
+                input_tokens: 3,
+                output_tokens: 5,
+            }),
+            interrupted: false,
+        })
+    );
+}
+
+#[test]
+fn projection_is_deterministic_and_reconnect_does_not_duplicate() {
+    let events = vec![
+        start_event(),
+        AgentSessionEvent::ToolCallStarted {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            tool: "Read".to_string(),
+            input: serde_json::json!({}),
+            parent_tool_use_id: None,
+        },
+        AgentSessionEvent::ToolCallStarted {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            tool: "Read".to_string(),
+            input: serde_json::json!({"path": "updated"}),
+            parent_tool_use_id: None,
+        },
+    ];
+
+    let first = project(&events).agent_parts_for_message("agent-1");
+    let second = project(&events).agent_parts_for_message("agent-1");
+
+    assert_eq!(first, second);
+    assert_eq!(
+        first
+            .iter()
+            .filter(|part| matches!(part, MessagePart::ToolUse { id, .. } if id == "tool-1"))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn repeated_tool_use_appends_retry_event_and_projector_recovers_history() {
+    let mut log = TurnEventLog::default();
+    log.begin_turn(
+        1,
+        "human-1".to_string(),
+        "agent-1".to_string(),
+        PromptInput::default(),
+        10.0,
+    );
+    log.append_part_events(
+        1,
+        "agent-1",
+        &[MessagePart::ToolUse {
+            tool: "Read".to_string(),
+            input: serde_json::json!({"file_path": "src/lib.rs"}),
+            id: "tool-1".to_string(),
+            parent_tool_use_id: None,
+        }],
+        PartEventMode::DurableOnly,
+    );
+    log.append_part_events(
+        1,
+        "agent-1",
+        &[MessagePart::ToolUse {
+            tool: "Read".to_string(),
+            input: serde_json::json!({"file_path": "src/main.rs"}),
+            id: "tool-1".to_string(),
+            parent_tool_use_id: None,
+        }],
+        PartEventMode::DurableOnly,
+    );
+
+    let read_model = log.project();
+
+    assert_eq!(read_model.tool_retries.len(), 1);
+    assert_eq!(read_model.tool_retries[0].turn_id, 1);
+    assert_eq!(read_model.tool_retries[0].tool_use_id, "tool-1");
+    assert_eq!(read_model.tool_retries[0].attempt, 2);
+    assert!(read_model
+        .agent_parts_for_message("agent-1")
+        .iter()
+        .any(|part| matches!(
+            part,
+            MessagePart::ToolUse { id, input, .. }
+                if id == "tool-1" && input == &serde_json::json!({"file_path": "src/main.rs"})
+        )));
+}
+
+#[test]
+fn background_events_project_to_explicit_message_target_not_last_turn() {
+    let mut second_turn = start_event();
+    if let AgentSessionEvent::TurnStarted {
+        turn_id,
+        message_id,
+        assistant_message_id,
+        prompt,
+        at,
+    } = &mut second_turn
+    {
+        *turn_id = 2;
+        *message_id = "human-2".to_string();
+        *assistant_message_id = Some("agent-2".to_string());
+        prompt.content = "second".to_string();
+        *at = 20.0;
+    }
+    let events = vec![
+        start_event(),
+        second_turn,
+        AgentSessionEvent::TaskStatusChanged {
+            turn_id: 1,
+            message_id: "agent-1".to_string(),
+            task_tool_use_id: "task-1".to_string(),
+            status: "completed".to_string(),
+            description: None,
+            summary: Some("done".to_string()),
+        },
+        AgentSessionEvent::TodoListSnapshotRecorded {
+            turn_id: 1,
+            message_id: "agent-1".to_string(),
+            items: vec![TodoListItem {
+                text: "ship".to_string(),
+                completed: true,
+            }],
+        },
+        AgentSessionEvent::SystemNotificationRecorded {
+            turn_id: 1,
+            message_id: "agent-1".to_string(),
+            notification_type: SystemNotificationType::Compaction,
+            status: "completed".to_string(),
+            label: "Compacted".to_string(),
+            detail: Some("done".to_string()),
+            hook_id: None,
+        },
+    ];
+
+    let read_model = project(&events);
+    let first_parts = read_model.agent_parts_for_message("agent-1");
+    let second_parts = read_model.agent_parts_for_message("agent-2");
+
+    assert!(first_parts.iter().any(|part| matches!(
+        part,
+        MessagePart::TaskStatus {
+            task_tool_use_id,
+            status,
+            summary,
+            ..
+        } if task_tool_use_id == "task-1"
+            && status == "completed"
+            && summary.as_deref() == Some("done")
+    )));
+    assert!(first_parts
+        .iter()
+        .any(|part| matches!(part, MessagePart::TodoListSnapshot { .. })));
+    assert!(first_parts.iter().any(|part| matches!(
+        part,
+        MessagePart::SystemNotification {
+            notification_type: SystemNotificationType::Compaction,
+            status,
+            ..
+        } if status == "completed"
+    )));
+    assert!(second_parts.is_empty());
+}
+
+#[test]
+fn later_tool_success_replaces_interrupted_failure_content() {
+    let events = vec![
+        start_event(),
+        AgentSessionEvent::ToolCallStarted {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            tool: "Read".to_string(),
+            input: serde_json::json!({}),
+            parent_tool_use_id: None,
+        },
+        AgentSessionEvent::ToolCallFailed {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            content: "bridge crash により中断".to_string(),
+        },
+        AgentSessionEvent::ToolCallSucceeded {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            content: "late result".to_string(),
+        },
+    ];
+
+    let parts = project(&events).agent_parts_for_message("agent-1");
+
+    assert!(parts.iter().any(|part| matches!(
+        part,
+        MessagePart::ToolResult {
+            content,
+            is_error: false,
+            tool_use_id: Some(id),
+            ..
+        } if id == "tool-1" && content == "late result"
+    )));
+}
+
+#[test]
+fn later_tool_success_replaces_content_when_new_content_contains_existing() {
+    let events = vec![
+        start_event(),
+        AgentSessionEvent::ToolCallStarted {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            tool: "Read".to_string(),
+            input: serde_json::json!({}),
+            parent_tool_use_id: None,
+        },
+        AgentSessionEvent::ToolCallSucceeded {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            content: "partial".to_string(),
+        },
+        AgentSessionEvent::ToolCallSucceeded {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            content: "partial result".to_string(),
+        },
+    ];
+
+    let parts = project(&events).agent_parts_for_message("agent-1");
+
+    assert!(parts.iter().any(|part| matches!(
+        part,
+        MessagePart::ToolResult {
+            content,
+            is_error: false,
+            tool_use_id: Some(id),
+            ..
+        } if id == "tool-1" && content == "partial result"
+    )));
+}
+
+#[test]
+fn later_tool_success_appends_content_when_new_content_does_not_contain_existing() {
+    let events = vec![
+        start_event(),
+        AgentSessionEvent::ToolCallStarted {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            tool: "Read".to_string(),
+            input: serde_json::json!({}),
+            parent_tool_use_id: None,
+        },
+        AgentSessionEvent::ToolCallSucceeded {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            content: "first".to_string(),
+        },
+        AgentSessionEvent::ToolCallSucceeded {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            content: " second".to_string(),
+        },
+    ];
+
+    let parts = project(&events).agent_parts_for_message("agent-1");
+
+    assert!(parts.iter().any(|part| matches!(
+        part,
+        MessagePart::ToolResult {
+            content,
+            is_error: false,
+            tool_use_id: Some(id),
+            ..
+        } if id == "tool-1" && content == "first second"
+    )));
+}
+
+#[test]
+fn tool_result_restores_parent_from_tool_call_started() {
+    let events = vec![
+        start_event(),
+        AgentSessionEvent::ToolCallStarted {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            tool: "Read".to_string(),
+            input: serde_json::json!({}),
+            parent_tool_use_id: Some("parent-1".to_string()),
+        },
+        AgentSessionEvent::ToolCallSucceeded {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            content: "done".to_string(),
+        },
+    ];
+
+    let parts = project(&events).agent_parts_for_message("agent-1");
+
+    assert!(parts.iter().any(|part| matches!(
+        part,
+        MessagePart::ToolResult {
+            content,
+            is_error: false,
+            tool_use_id: Some(id),
+            parent_tool_use_id: Some(parent),
+        } if id == "tool-1" && parent == "parent-1" && content == "done"
+    )));
+}
+
+#[test]
+fn tool_result_without_tool_use_id_round_trips_through_part_events() {
+    let mut log = TurnEventLog::default();
+    log.begin_turn(
+        1,
+        "human-1".to_string(),
+        "agent-1".to_string(),
+        PromptInput::default(),
+        10.0,
+    );
+    let part = MessagePart::ToolResult {
+        content: "standalone".to_string(),
+        is_error: true,
+        tool_use_id: None,
+        parent_tool_use_id: Some("parent-1".to_string()),
+    };
+
+    let appended = log.append_part_events(
+        1,
+        "agent-1",
+        std::slice::from_ref(&part),
+        PartEventMode::DurableOnly,
+    );
+
+    assert_eq!(appended, 1);
+    assert_eq!(log.project().agent_parts_for_message("agent-1"), vec![part]);
+}
+
+#[test]
+fn orphan_turn_events_are_skipped_without_synthetic_messages() {
+    let read_model = project(&[AgentSessionEvent::ToolCallSucceeded {
+        turn_id: 99,
+        tool_use_id: "tool-1".to_string(),
+        content: "orphan".to_string(),
+    }]);
+
+    assert!(read_model.messages.is_empty());
+    assert_eq!(
+        read_model.status,
+        ProjectedStatus {
+            session_state: SessionState::Idle,
+            turn_phase: TurnPhase::Idle,
+        }
+    );
+    assert!(read_model.workflow_turn_complete.is_none());
+}
+
+#[test]
+fn live_only_delta_is_not_part_of_durable_event_log() {
+    let events = vec![
+        start_event(),
+        AgentSessionEvent::TextRecorded {
+            turn_id: 1,
+            message_id: "agent-1".to_string(),
+            content: "final".to_string(),
+            parent_tool_use_id: None,
+        },
+    ];
+
+    let parts = project(&events).agent_parts_for_message("agent-1");
+
+    assert_eq!(
+        parts,
+        vec![MessagePart::Text {
+            content: "final".to_string(),
+            parent_tool_use_id: None,
+        }]
+    );
+}
+
+#[test]
+fn turn_started_projects_prompt_mentions_and_parts() {
+    let attachment = AttachmentRef {
+        id: "att-1".to_string(),
+        media_type: "image/png".to_string(),
+        byte_size: 42,
+    };
+    let prompt_parts = vec![
+        MessagePart::Text {
+            content: "inspect this".to_string(),
+            parent_tool_use_id: None,
+        },
+        MessagePart::ImageRef {
+            attachment: attachment.clone(),
+        },
+    ];
+    let events = vec![AgentSessionEvent::TurnStarted {
+        turn_id: 1,
+        message_id: "human-1".to_string(),
+        assistant_message_id: Some("agent-1".to_string()),
+        prompt: PromptInput {
+            content: "inspect this".to_string(),
+            mentions: vec![MessageMention {
+                file_path: "src/main.rs".to_string(),
+                start_line: Some(3),
+                end_line: Some(5),
+            }],
+            attachment_refs: vec![attachment],
+            parts: prompt_parts.clone(),
+        },
+        at: 10.0,
+    }];
+
+    let read_model = project(&events);
+    let human = read_model
+        .messages
+        .iter()
+        .find(|message| message.id == "human-1")
+        .expect("human message");
+
+    assert_eq!(human.content, "inspect this");
+    assert_eq!(
+        human.mentions,
+        Some(vec![MessageMention {
+            file_path: "src/main.rs".to_string(),
+            start_line: Some(3),
+            end_line: Some(5),
+        }])
+    );
+    assert_eq!(human.parts, Some(prompt_parts));
+}
+
+#[test]
+fn turn_started_projects_attachment_refs_as_prompt_parts() {
+    let attachment = AttachmentRef {
+        id: "att-1".to_string(),
+        media_type: "image/png".to_string(),
+        byte_size: 42,
+    };
+    let read_model = project(&[AgentSessionEvent::TurnStarted {
+        turn_id: 1,
+        message_id: "human-1".to_string(),
+        assistant_message_id: Some("agent-1".to_string()),
+        prompt: PromptInput {
+            content: "inspect this".to_string(),
+            mentions: Vec::new(),
+            attachment_refs: vec![attachment.clone()],
+            parts: Vec::new(),
+        },
+        at: 10.0,
+    }]);
+
+    let human = read_model
+        .messages
+        .iter()
+        .find(|message| message.id == "human-1")
+        .expect("human message");
+
+    assert_eq!(
+        human.parts,
+        Some(vec![
+            MessagePart::Text {
+                content: "inspect this".to_string(),
+                parent_tool_use_id: None,
+            },
+            MessagePart::ImageRef { attachment },
+        ])
+    );
+}
+
+#[test]
+fn status_projection_covers_runtime_transition_states() {
+    let streaming = project(&[start_event()]);
+    assert_eq!(streaming.status.session_state, SessionState::Active);
+    assert_eq!(streaming.status.turn_phase, TurnPhase::Streaming);
+
+    let waiting = project(&[
+        start_event(),
+        AgentSessionEvent::PermissionRequested {
+            turn_id: 1,
+            tool_use_id: Some("tool-1".to_string()),
+            request: serde_json::json!({"request_id": "req-1", "tool_use_id": "tool-1"}),
+        },
+    ]);
+    assert_eq!(waiting.status.session_state, SessionState::Active);
+    assert_eq!(waiting.status.turn_phase, TurnPhase::WaitingPermission);
+
+    let closed = project(&[start_event(), AgentSessionEvent::SessionClosed { at: 11.0 }]);
+    assert_eq!(closed.status.session_state, SessionState::Closed);
+    assert_eq!(closed.status.turn_phase, TurnPhase::Idle);
+}
+
+#[test]
+fn terminal_status_projection_marks_nonzero_completed_as_error() {
+    let read_model = project(&[
+        start_event(),
+        AgentSessionEvent::TurnCompleted {
+            turn_id: 1,
+            exit_code: 2,
+            token_usage: None,
+        },
+    ]);
+
+    assert_eq!(read_model.status.session_state, SessionState::Error);
+    assert_eq!(read_model.status.turn_phase, TurnPhase::Idle);
+}
+
+#[test]
+fn terminal_status_projection_marks_timeout_and_bridge_crash_as_error() {
+    for reason in [InterruptReason::Timeout, InterruptReason::BridgeCrash] {
+        let read_model = project(&[
+            start_event(),
+            AgentSessionEvent::TurnInterrupted {
+                turn_id: 1,
+                reason,
+                exit_code: 1,
+                error: None,
+            },
+        ]);
+
+        assert_eq!(read_model.status.session_state, SessionState::Error);
+        assert_eq!(read_model.status.turn_phase, TurnPhase::Idle);
+    }
+}
+
+#[test]
+fn terminal_status_projection_marks_abort_as_idle() {
+    let read_model = project(&[
+        start_event(),
+        AgentSessionEvent::TurnInterrupted {
+            turn_id: 1,
+            reason: InterruptReason::Abort,
+            exit_code: 1,
+            error: None,
+        },
+    ]);
+
+    assert_eq!(read_model.status.session_state, SessionState::Idle);
+    assert_eq!(read_model.status.turn_phase, TurnPhase::Idle);
+}
+
+#[test]
+fn finalization_closes_tools_permissions_and_turn() {
+    for reason in [
+        InterruptReason::Abort,
+        InterruptReason::Timeout,
+        InterruptReason::BridgeCrash,
+    ] {
+        let mut events = vec![
+            start_event(),
+            AgentSessionEvent::ToolCallStarted {
+                turn_id: 1,
+                tool_use_id: "tool-1".to_string(),
+                tool: "Edit".to_string(),
+                input: serde_json::json!({}),
+                parent_tool_use_id: None,
+            },
+            AgentSessionEvent::PermissionRequested {
+                turn_id: 1,
+                tool_use_id: Some("tool-1".to_string()),
+                request: serde_json::json!({"request_id": "req-1", "tool_use_id": "tool-1"}),
+            },
+        ];
+
+        finalize_turn(
+            &mut events,
+            1,
+            reason,
+            Some("bridge failed".to_string()),
+            -1,
+        );
+        let read_model = project(&events);
+        let agent_parts = read_model.agent_parts_for_message("agent-1");
+
+        assert!(agent_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::ToolResult {
+                tool_use_id: Some(id),
+                is_error: true,
+                content,
+                ..
+            } if id == "tool-1" && content == "bridge failed により中断"
+        )));
+        assert!(agent_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Permission { status, .. } if status == "cancelled"
+        )));
+        assert_eq!(read_model.status.turn_phase, TurnPhase::Idle);
+        assert_eq!(
+            read_model.workflow_turn_complete,
+            Some(WorkflowTurnCompleteInput {
+                turn_id: 1,
+                exit_code: -1,
+                final_text_parts: Vec::new(),
+                token_usage: None,
+                interrupted: true,
+            })
+        );
+    }
+}
+
+#[test]
+fn finalization_uses_reason_label_when_error_is_none() {
+    for (reason, expected) in [
+        (InterruptReason::Abort, "abort により中断"),
+        (InterruptReason::Timeout, "timeout により中断"),
+        (InterruptReason::BridgeCrash, "bridge crash により中断"),
+    ] {
+        let mut events = vec![
+            start_event(),
+            AgentSessionEvent::ToolCallStarted {
+                turn_id: 1,
+                tool_use_id: "tool-1".to_string(),
+                tool: "Edit".to_string(),
+                input: serde_json::json!({}),
+                parent_tool_use_id: None,
+            },
+        ];
+
+        finalize_turn(&mut events, 1, reason, None, -1);
+        let agent_parts = project(&events).agent_parts_for_message("agent-1");
+
+        assert!(agent_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::ToolResult {
+                tool_use_id: Some(id),
+                is_error: true,
+                content,
+                ..
+            } if id == "tool-1" && content == expected
+        )));
+    }
+}
+
+#[test]
+fn finalization_keeps_existing_interrupted_detail_without_double_suffix() {
+    for detail in ["already interrupted", "すでに中断しました"] {
+        let mut events = vec![
+            start_event(),
+            AgentSessionEvent::ToolCallStarted {
+                turn_id: 1,
+                tool_use_id: "tool-1".to_string(),
+                tool: "Edit".to_string(),
+                input: serde_json::json!({}),
+                parent_tool_use_id: None,
+            },
+        ];
+
+        finalize_turn(
+            &mut events,
+            1,
+            InterruptReason::BridgeCrash,
+            Some(detail.to_string()),
+            -1,
+        );
+        let agent_parts = project(&events).agent_parts_for_message("agent-1");
+
+        assert!(agent_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::ToolResult {
+                tool_use_id: Some(id),
+                is_error: true,
+                content,
+                ..
+            } if id == "tool-1" && content == detail
+        )));
+    }
+}
+
+#[test]
+fn finalization_is_idempotent() {
+    let mut events = vec![
+        start_event(),
+        AgentSessionEvent::ToolCallStarted {
+            turn_id: 1,
+            tool_use_id: "tool-1".to_string(),
+            tool: "Edit".to_string(),
+            input: serde_json::json!({}),
+            parent_tool_use_id: None,
+        },
+    ];
+    finalize_turn(&mut events, 1, InterruptReason::Abort, None, 1);
+    let once = events.clone();
+    finalize_turn(&mut events, 1, InterruptReason::Abort, None, 1);
+
+    assert_eq!(events, once);
+}

--- a/src-tauri/src/usecase/agent_session/mod.rs
+++ b/src-tauri/src/usecase/agent_session/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod event_log;
 pub(crate) mod session;
 pub(crate) mod status;

--- a/src-tauri/src/usecase/agent_session/session/lifecycle_controller.rs
+++ b/src-tauri/src/usecase/agent_session/session/lifecycle_controller.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use super::{ChatSession, RestoreSessionResponse, SessionState, SessionStore};
+use crate::usecase::agent_session::event_log::{AgentSessionEvent, TurnEventLog};
+
+use super::{now_timestamp, ChatSession, RestoreSessionResponse, SessionState, SessionStore};
 
 pub struct SessionLifecycleController<'a> {
     pub session_store: &'a Arc<SessionStore>,
@@ -10,18 +12,40 @@ pub struct SessionLifecycleController<'a> {
 impl<'a> SessionLifecycleController<'a> {
     pub fn close_session_state(&self, session_id: &str) -> Result<(), String> {
         self.session_store
-            .set_session_state(self.data_dir, session_id, SessionState::Closed)
+            .append_session_event_and_project_state(
+                self.data_dir,
+                session_id,
+                AgentSessionEvent::SessionClosed {
+                    at: now_timestamp(),
+                },
+            )
+            .map(|_| ())
     }
 
     pub fn restore_session_state(
         &self,
         session: ChatSession,
     ) -> Result<RestoreSessionResponse, String> {
+        let projected_state = self.project_session_state(&session.id)?;
+        if projected_state != session.state {
+            self.session_store
+                .set_session_state(self.data_dir, &session.id, projected_state)?;
+        }
         self.session_store
             .set_session_state(self.data_dir, &session.id, SessionState::Idle)?;
         Ok(RestoreSessionResponse {
             restored_workflow_step: false,
         })
+    }
+
+    fn project_session_state(&self, session_id: &str) -> Result<SessionState, String> {
+        let events = self
+            .session_store
+            .load_session_events(self.data_dir, session_id)?;
+        Ok(TurnEventLog::from_events(events)
+            .project()
+            .status
+            .session_state)
     }
 }
 
@@ -52,6 +76,54 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(loaded.state, SessionState::Closed);
+
+        let events = store.load_session_events(temp.path(), &session.id).unwrap();
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, AgentSessionEvent::SessionClosed { .. })));
+        let projected_state = TurnEventLog::from_events(events)
+            .project()
+            .status
+            .session_state;
+        assert_eq!(projected_state, SessionState::Closed);
+    }
+
+    #[test]
+    fn close_session_state_persists_closed_projection_for_fresh_store_restore() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = Arc::new(SessionStore::new(Arc::new(
+            crate::adaptor::gateway::agent_session::FileSessionStorage::default(),
+        )));
+        let session = super::super::create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some("claude".to_string()),
+        )
+        .unwrap();
+
+        let controller = SessionLifecycleController {
+            session_store: &store,
+            data_dir: temp.path(),
+        };
+        controller.close_session_state(&session.id).unwrap();
+
+        let fresh_store = SessionStore::new(Arc::new(
+            crate::adaptor::gateway::agent_session::FileSessionStorage::default(),
+        ));
+        let loaded = fresh_store
+            .load_full_session_for_restore(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.state, SessionState::Closed);
+        let events = fresh_store
+            .load_session_events(temp.path(), &session.id)
+            .unwrap();
+        let projected_state = TurnEventLog::from_events(events)
+            .project()
+            .status
+            .session_state;
+        assert_eq!(projected_state, SessionState::Closed);
     }
 
     #[test]
@@ -94,6 +166,59 @@ mod tests {
         assert_eq!(loaded.context_carry, None);
         assert_eq!(loaded.messages.len(), 1);
         assert_eq!(loaded.messages[0].content, "remember alpha");
+    }
+
+    #[test]
+    fn restore_session_state_recovers_closed_from_event_projection_before_idle() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = Arc::new(crate::test_support::build_session_store());
+        let session = super::super::create_session_internal(
+            &store,
+            temp.path(),
+            "/repo",
+            Some("claude".to_string()),
+        )
+        .unwrap();
+
+        let controller = SessionLifecycleController {
+            session_store: &store,
+            data_dir: temp.path(),
+        };
+        controller.close_session_state(&session.id).unwrap();
+        store
+            .set_session_state(temp.path(), &session.id, SessionState::Active)
+            .unwrap();
+        let session = store
+            .load_full_session_for_restore(temp.path(), &session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.state, SessionState::Active);
+        let session_id = session.id.clone();
+
+        let projected_state =
+            TurnEventLog::from_events(store.load_session_events(temp.path(), &session_id).unwrap())
+                .project()
+                .status
+                .session_state;
+        assert_eq!(projected_state, SessionState::Closed);
+
+        let captured = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let captured_for_listener = captured.clone();
+        store.register_state_change_listener(Arc::new(move |_, _, state| {
+            captured_for_listener.lock().push(state.clone());
+        }));
+
+        controller.restore_session_state(session).unwrap();
+
+        let loaded = store
+            .load_full_session_for_restore(temp.path(), &session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.state, SessionState::Idle);
+        assert_eq!(
+            captured.lock().as_slice(),
+            [SessionState::Closed, SessionState::Idle]
+        );
     }
 
     #[test]

--- a/src-tauri/src/usecase/agent_session/session/prompt_suggestion.rs
+++ b/src-tauri/src/usecase/agent_session/session/prompt_suggestion.rs
@@ -202,6 +202,7 @@ pub(crate) fn build_agent_prompt_suggestion_with_git(
 mod tests {
     use super::*;
     use crate::domain::agent_session::{AgentSessionReader, AgentSessionStorageTypes};
+    use crate::usecase::agent_session::event_log::AgentSessionEvent;
     use crate::usecase::agent_session::session::{
         ChatSession, ContextCarryState, MessagePageMetadata, PageCursor, SessionAttachment,
         SessionMeta, SessionPage, SessionState, SESSION_BODY_FORMAT_VERSION,
@@ -217,6 +218,7 @@ mod tests {
         type Message = ChatMessage;
         type MessagePart = MessagePart;
         type Attachment = SessionAttachment;
+        type Event = AgentSessionEvent;
     }
 
     impl AgentSessionReader for PromptSuggestionStorage {
@@ -266,6 +268,15 @@ mod tests {
             panic!("prompt suggestion must not full-load session body")
         }
 
+        fn load_previous_human_message_before_agent(
+            &self,
+            _app_data_dir: &Path,
+            _session_id: &str,
+            _agent_message_id: &str,
+        ) -> Result<Option<Self::Message>, String> {
+            panic!("prompt suggestion must not load prompt message")
+        }
+
         fn get_session_page(
             &self,
             _app_data_dir: &Path,
@@ -294,6 +305,14 @@ mod tests {
             _attachment_id: &str,
         ) -> Result<Option<Self::Attachment>, String> {
             Ok(None)
+        }
+
+        fn load_session_events(
+            &self,
+            _app_data_dir: &Path,
+            _session_id: &str,
+        ) -> Result<Vec<Self::Event>, String> {
+            Ok(Vec::new())
         }
     }
 

--- a/src-tauri/src/usecase/agent_session/session/store.rs
+++ b/src-tauri/src/usecase/agent_session/session/store.rs
@@ -6,6 +6,7 @@ use parking_lot::RwLock;
 use crate::domain::agent_session::{
     AgentSessionReader, AgentSessionStorage, AgentSessionStorageTypes,
 };
+use crate::usecase::agent_session::event_log::{AgentSessionEvent, TurnEventLog};
 
 use super::{
     now_timestamp, ChatMessage, ChatSession, ContextCarryState, MessagePart, PageCursor,
@@ -25,6 +26,7 @@ pub type SessionStoragePort = dyn AgentSessionStorage<
         Message = ChatMessage,
         MessagePart = MessagePart,
         Attachment = SessionAttachment,
+        Event = AgentSessionEvent,
     > + Send
     + Sync;
 
@@ -36,6 +38,7 @@ pub type SessionReaderPort = dyn AgentSessionReader<
         Message = ChatMessage,
         MessagePart = MessagePart,
         Attachment = SessionAttachment,
+        Event = AgentSessionEvent,
     > + Send
     + Sync;
 
@@ -68,6 +71,7 @@ impl AgentSessionStorageTypes for SessionStore {
     type Message = ChatMessage;
     type MessagePart = MessagePart;
     type Attachment = SessionAttachment;
+    type Event = AgentSessionEvent;
 }
 
 impl AgentSessionReader for SessionStore {
@@ -100,6 +104,19 @@ impl AgentSessionReader for SessionStore {
             .load_full_session_for_restore(app_data_dir, session_id)
     }
 
+    fn load_previous_human_message_before_agent(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        agent_message_id: &str,
+    ) -> Result<Option<Self::Message>, String> {
+        self.storage.load_previous_human_message_before_agent(
+            app_data_dir,
+            session_id,
+            agent_message_id,
+        )
+    }
+
     fn get_session_page(
         &self,
         app_data_dir: &Path,
@@ -119,6 +136,14 @@ impl AgentSessionReader for SessionStore {
     ) -> Result<Option<Self::Attachment>, String> {
         self.storage
             .get_session_attachment(app_data_dir, session_id, attachment_id)
+    }
+
+    fn load_session_events(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+    ) -> Result<Vec<Self::Event>, String> {
+        self.storage.load_session_events(app_data_dir, session_id)
     }
 }
 
@@ -329,6 +354,44 @@ impl SessionStore {
     ) -> Result<Option<ChatSession>, String> {
         self.storage
             .load_full_session_for_restore(app_data_dir, session_id)
+    }
+
+    pub fn load_session_events(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+    ) -> Result<Vec<AgentSessionEvent>, String> {
+        self.storage.load_session_events(app_data_dir, session_id)
+    }
+
+    pub fn append_session_event_and_project_state(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        event: AgentSessionEvent,
+    ) -> Result<SessionState, String> {
+        let events = self
+            .storage
+            .append_session_event(app_data_dir, session_id, &event)?;
+        let projected_state = TurnEventLog::from_events(events)
+            .project()
+            .status
+            .session_state;
+        self.set_session_state(app_data_dir, session_id, projected_state.clone())?;
+        Ok(projected_state)
+    }
+
+    pub fn load_previous_human_message_before_agent(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        agent_message_id: &str,
+    ) -> Result<Option<ChatMessage>, String> {
+        self.storage.load_previous_human_message_before_agent(
+            app_data_dir,
+            session_id,
+            agent_message_id,
+        )
     }
 
     /// workflow step session のセットアップ失敗時に、作成済みの子 session を


### PR DESCRIPTION
## Summary
- Add persisted event-log storage for agent session events.
- Add event projection/finalization logic and tests.
- Add issue 1247 requirements, design, and behavior specs.

## Checks
- git diff --cached --check
- cargo fmt --check