### PR TITLE
feat(agent): startup orphan cleanup の non-blocking 化と skill catalog 追加 (#1216)

### DIFF
--- a/docs/specs/issues-1216/behavior.md
+++ b/docs/specs/issues-1216/behavior.md
@@ -1,0 +1,161 @@
+# Behavior
+
+Startup orphan cleanup を non-blocking service 化し、visible startup を cleanup でブロックしない・新規 spawn を誤 kill しない・cleanup を safe metadata として観測できる振る舞いを定義する。
+
+実装詳細（ordering 機構の具体構造・スレッド/async の選択・モジュール配置・経路）は含めず、外部から観測可能なビジネスルールとして記述する。具体的な観測フィールドの粒度・命名は design.md で確定する。
+
+## Feature: Startup orphan cleanup の non-blocking service 化
+
+アプリ起動時の orphan process cleanup を visible startup の critical path から外しつつ、新規 spawn したプロセスを誤って kill しない順序を Rust 側で保証し、cleanup の実行状態・失敗・対象数を user data を含まない safe metadata として観測できるようにする。既存の孤児回収と判定方針は維持する。
+
+Background:
+```gherkin
+Given Releash が unix プラットフォーム上で起動される
+And 孤児プロセスの cleanup は Rust 側のサービスとして実行される
+And cleanup の起動・順序保証・観測のロジックはすべて Rust 側に存在する
+```
+
+---
+
+## Rule R1: orphan cleanup は visible startup（first window ready）をブロックしない
+
+```gherkin
+Scenario: 多数の .pid ファイルがあっても first window ready が遅延しない
+  Given startup 時に多数の .pid ファイルや終了待ちの孤児プロセスが存在する
+  When アプリが起動し cleanup が実行される
+  Then first window ready は cleanup の所要時間（PID 走査・SIGTERM 後の sleep・SIGKILL）によって遅延しない
+  And cleanup は visible startup の critical path に乗らない
+
+Scenario: cleanup はバックグラウンドで起動時に 1 回実行される
+  Given アプリが起動する
+  When startup 経路が進行する
+  Then cleanup は起動時に 1 回バックグラウンドで実行される
+  And startup は cleanup の完了を待たずに先へ進む
+```
+
+仮定: cleanup は従来どおり起動時に 1 回起動するが、setup の同期経路（join）から外しバックグラウンドタスクとして走らせる（requirements 仮定「cleanup の起動タイミング」）。
+
+---
+
+## Rule R2: cleanup 完了前に spawn された新規プロセスを孤児として誤 kill しない
+
+```gherkin
+Scenario: cleanup 実行中に spawn された新規プロセスは kill されない
+  Given cleanup がバックグラウンドで実行中である
+  When その間に新規の agent / bridge プロセスが spawn される
+  Then その新規プロセスは cleanup によって孤児として kill されない
+
+Scenario: cleanup 完了前に spawn されたプロセスは cleanup 対象集合に含まれない
+  Given 自インスタンスの起動以降に新規プロセスが spawn された
+  When cleanup が孤児判定を行う
+  Then 自インスタンス起動以降に作成された PID は cleanup の対象集合に含まれない
+
+Scenario: 順序保証は setup の同期 join ではなく Rust の明示的機構で成立する
+  Given cleanup と新規 spawn の間に順序保証が必要である
+  When 新規 spawn が cleanup 完了前に発生する
+  Then 誤 kill 防止は setup でのブロッキング join に依存せず Rust 側の明示的な順序機構で成立する
+```
+
+仮定: 順序保証は cleanup の完了状態を表す共有状態（完了フラグ / 完了通知等）を Rust 側に持ち、自インスタンス起動以降に作成された PID を対象外とすることで担保する。具体方式は design.md で確定する。
+
+---
+
+## Rule R3: cleanup の実行状態・失敗・対象数を safe metadata として観測できる
+
+```gherkin
+Scenario: cleanup の完了が観測できる
+  Given cleanup がバックグラウンドで実行された
+  When cleanup が正常に完了する
+  Then cleanup の実行状態として「完了」が観測できる
+
+Scenario: cleanup の失敗が観測できる
+  Given cleanup の実行中に失敗が発生する
+  When cleanup が終了する
+  Then cleanup の実行状態として「失敗」が観測でき、完了と区別できる
+
+Scenario: cleanup の対象数が観測できる
+  Given cleanup が .pid ファイルを走査し孤児を処理する
+  When cleanup が完了または失敗する
+  Then 走査した PID 数と孤児として処理した（SIGTERM/SIGKILL を送った、または PID ファイルを除去した）数が観測できる
+
+Scenario: 観測は構造化ログと既存 telemetry 経路で公開される
+  Given cleanup の実行状態・失敗・対象数を観測する必要がある
+  When cleanup が状態を報告する
+  Then その metadata は構造化ログと既存の telemetry 経路で観測できる
+  And frontend / 運用向けの専用 read コマンドは追加されない
+```
+
+仮定: 観測公開先は構造化ログと既存 telemetry 経路（`other::telemetry`）で確定済み（requirements 合意済み）。対象数は最低限「走査した .pid ファイル数」と「孤児として処理した数」を含む。粒度は design.md で確定する。
+
+---
+
+## Rule R4: cleanup のログ・metadata に user data を含めない
+
+```gherkin
+Scenario: cleanup の observation に user data が含まれない
+  Given cleanup が状態・対象数を metadata / ログとして出力する
+  When その metadata / ログを参照する
+  Then command body・worktree path・session 本文などの user data は含まれない
+  And 含まれるのは状態・失敗の有無・対象数などの safe metadata のみである
+```
+
+---
+
+## Rule R5: non-blocking 化後も既存の孤児回収が維持される
+
+```gherkin
+Scenario: 停止した旧インスタンスのプロセス群が起動ごとに掃除される
+  Given 前回の Releash インスタンスが残した孤児プロセス群が存在する
+  When アプリが起動し cleanup が実行される
+  Then その孤児プロセス群は最終的に回収される
+  And non-blocking 化によって孤児が回収されないまま放置される状態を新たに作らない
+
+Scenario: 既存の孤児判定と保守的 skip が維持される
+  Given 所有者同一性 / PID 再利用検出で判定不能なプロセスが存在する
+  When cleanup が孤児判定を行う
+  Then 既存の所有者同一性判定・PID 再利用検出・保守的 skip 方針（issue #1024）が維持される
+  And SIGTERM → 最大待機 → SIGKILL の昇格手順は変更されない
+```
+
+仮定: 判定アルゴリズム（PID 再利用検出 / 所有者同一性 / 昇格手順）は本 Issue では変更しない（requirements 非スコープ）。
+
+---
+
+## Rule R6: cleanup の対象範囲は unix に限定される
+
+```gherkin
+Scenario: 非 unix プラットフォームでは cleanup を行わない
+  Given アプリが非 unix プラットフォームで起動される
+  When startup 経路が進行する
+  Then orphan cleanup は実行されない
+  And non-blocking 化やその他の変更によって非 unix の挙動は変わらない
+```
+
+仮定: 対象は現状どおり unix（`#[cfg(unix)]`）に限定する（requirements 仮定「プラットフォーム範囲」）。
+
+---
+
+## Rule R7: cleanup と新規 spawn の race が自動テストで検証される
+
+```gherkin
+Scenario: race を検証する自動テストが green である
+  Given cleanup と新規 process spawn の race を再現する状況
+  When cleanup 実行中／前後に新規プロセスを spawn する
+  Then 新規プロセスが誤って kill されないことを検証する自動テストが存在する
+  And そのテストは green である
+```
+
+---
+
+## 仮定（requirements.md より引き継ぎ）
+
+- cleanup は従来どおり起動時に 1 回起動するが、setup の同期経路（join）から外しバックグラウンドタスクとして走らせ、setup は完了を待たない。
+- 順序保証は cleanup の完了状態を表す共有状態を Rust 側に持ち、自インスタンス起動以降に作成された PID を cleanup 対象外とすることで担保する。具体方式は design.md で確定する。
+- 観測公開先は構造化ログと既存 telemetry 経路（`other::telemetry`）で確定（合意済み）。frontend / 運用向け専用 read コマンドは追加しない。
+- 対象は unix（`#[cfg(unix)]`）限定。非 unix では従来どおり cleanup を行わない。
+- 「対象数」は最低限、走査した .pid ファイル数と孤児として処理した数を指す。粒度は design.md で確定する。
+- 判定アルゴリズム（PID 再利用検出 / 所有者同一性 / SIGTERM→SIGKILL 昇格）は変更しない。
+
+## Open Questions
+
+なし（requirements.md ですべて解消済み。本振る舞い定義でも追加の未確定事項なし）。

--- a/docs/specs/issues-1216/design.md
+++ b/docs/specs/issues-1216/design.md
@@ -1,0 +1,208 @@
+# Design
+
+Startup orphan cleanup を non-blocking service 化する実装設計。requirements.md / behavior.md（Issue #1216）を実装方針・責務分割・データ構造・エラー処理・テスト方針へ落とし込む。
+
+正本: `docs/releash-performance-architecture-audit.md`（M3 / 項目 4）。
+
+## 概要
+
+- 現状、Tauri `setup` クロージャ（`src-tauri/src/lib.rs` 431-442）は `cleanup_orphan_processes` を別スレッドで `spawn` した直後に `.join()` しており、cleanup（PID 走査・SIGTERM・最大 2 秒 sleep・SIGKILL）の完了まで setup が同期ブロックされる。これが visible startup（first window ready）を遅延させうる。
+- 本設計では `.join()` を廃し、cleanup を **バックグラウンドタスク**として走らせて setup を即座に先へ進める。
+- cleanup と新規 spawn の順序保証は、setup のブロッキング join ではなく **Rust 側の明示的な完了ゲート（cleanup completion gate）** で担保する。新規 bridge プロセスの spawn は、cleanup 完了を待ってから OS に新しい pgid を確保させる。
+- cleanup の実行状態（完了 / 失敗）・対象数（走査数・処理数・skip 数・失敗数）を、user data を含まない safe metadata として構造化ログと既存 telemetry 経路（`other::telemetry`）に公開する。
+- 既存の孤児判定アルゴリズム（owner 同一性 / PID 再利用検出 / 保守的 skip / SIGTERM→SIGKILL 昇格）は変更しない（requirements 非スコープ）。
+
+### 順序保証の本質（設計の前提となる事実）
+
+実コードを確認した結果、`.join()` が守っている不変条件は「新規 spawn の保護」のうち **pgid 再利用レース** に限られることが分かった。
+
+- `cleanup_orphan_processes`（`bridge_common.rs` 1066-1167）は各 `.pid` ファイルについて `owner_app_pid` が alive かつ `owner_start_time` が一致すれば「live instance 所有」として skip する。現インスタンスが新規 spawn 時に書く PID ファイルは `owner_app_pid = std::process::id()`（=自分）・`owner_start_time`（=自分の起動時刻）を持つため、**既存の owner 同一性判定で既に skip される**。よって behavior R2 の「自インスタンス起動以降に作成された PID は対象集合に含まれない」は、新規ファイルそのものについては既存ロジックで成立している。
+- 一方、`.join()` が本質的に塞いでいるのは次のレースである:
+  1. 前回クラッシュした旧インスタンスの stale ファイル `S`（owner=死亡 PID, pgid=`PG`）が残る。
+  2. 旧プロセス群が既に終了し、OS が `PG` を解放する。
+  3. 現インスタンスが新規 bridge を spawn し、OS が偶然 `PG` を再割当する。
+  4. cleanup が `S` を処理 → owner 死亡なので孤児判定 → `killpg(PG, 0)` が alive（=新規プロセス群）→ SIGTERM/SIGKILL で**新規プロセス群を誤 kill**。
+- `.join()` はこのレースを「新規 spawn が起きる前に stale ファイルを全て除去し切る」ことで塞いでいた。non-blocking 化すると cleanup と spawn が並走しうるため、この順序を別機構で保証する必要がある（requirements 要求 2）。
+
+この事実から、本設計の順序機構は「新規 spawn 経路が cleanup 完了を待ってから pgid を確保する」**完了ゲート**を採用する（理由は「アーキテクチャと責務分割」§ ordering を参照）。
+
+## 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `src-tauri/src/lib.rs` | setup の cleanup spawn から `.join()` を除去。背景スレッドで cleanup を実行し、完了時に gate を開放 + telemetry/ログ記録。gate を managed state として登録。 |
+| `src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs` | `cleanup_orphan_processes` が `OrphanCleanupReport` を返すよう変更（集計）。spawn 経路（`spawn_bridge_process` / `register_external_agent_process`）に gate 待ちを挿入。`CleanupGate` 型を追加。 |
+| `src-tauri/src/infrastructure/agent_session/runtime/mod.rs` | `CleanupGate` / `OrphanCleanupReport` の re-export（必要に応じて）。 |
+| `src-tauri/src/other/telemetry/mod.rs` | cleanup 観測用の記録関数（counter）を追加。 |
+| `src-tauri/src/other/telemetry/attributes.rs` | cleanup 用の metric / attribute（status・count 種別）を追加。 |
+
+フロントエンドは変更しない（観測は safe metadata の提供までで UI 表示は非スコープ。requirements 非スコープ / `.claude/rules/rust-first-logic.md`）。
+
+## アーキテクチャと責務分割
+
+### レイヤー配置
+
+cleanup・gate・spawn 待ちは外部プロセス（OS シグナル / fork）を扱う低レベル処理であり、現状どおり `infrastructure/agent_session/runtime/`（`bridge_common.rs`）に置く。観測の公開は横断的関心事として `other/telemetry/` が担う。`setup`（composition root 相当）でのみ両者を配線する。本 Issue では `bridge_common.rs` の module 分割は行わない（requirements 非スコープ）。
+
+### non-blocking 化（Rule R1）
+
+`lib.rs` setup の `#[cfg(unix)]` ブロックを次のように変える:
+
+- `std::thread::spawn(...).join()` の `.join()` を除去し、JoinHandle は drop する（detach）。cleanup は背景スレッドで実行され、setup は完了を待たずに `record_startup(AppStartup)` 以降へ進む。
+- cleanup は引き続き起動時に 1 回だけ走る（behavior R1 Scenario 2）。
+- cleanup は同期実装（`std::thread::sleep` を使う）なので、async task ではなく **専用 std スレッド**で走らせる（tokio worker を 2 秒間占有しないため）。
+
+### ordering（Rule R2）— cleanup completion gate
+
+新しい型 `CleanupGate` を導入し、Tauri の managed state（`app.manage(Arc<CleanupGate>)`）として配線する。
+
+責務:
+- 背景 cleanup スレッドは、cleanup 完了時（成功 / 失敗を問わず）に gate を「開放」する。
+- 新規 bridge プロセスの spawn 経路は、**実際に子プロセスを `spawn()` する直前**（`bridge_common.rs` 3823 / 7xxx の `cmd.spawn()` 直前。`setsid` 後に新 pgid が確保される地点の手前）で gate の開放を待つ。これにより stale ファイルが残ったまま新 pgid が確保されることがなくなり、§「順序保証の本質」の pgid 再利用レースが構造的に消える。
+
+待ち地点を spawn 直前にする理由: behavior R2 が要求するのは「cleanup 完了前に spawn された新規プロセスを誤 kill しない」こと。新 pgid の確保（`cmd.spawn()`）を cleanup 完了後に直列化すれば、cleanup が走査する stale ファイルの pgid 集合と、新規プロセスの pgid が時間的に交わらない。owner 同一性判定（既存）と合わせ、新規プロセスは二重に保護される。
+
+待ち地点が visible startup の critical path に乗らない理由: `spawn_bridge_process` / `register_external_agent_process` は frontend からの `init_agent_sessions`（Tauri command）経由でのみ呼ばれ、これは first window ready 後にしか発火しない。よって gate 待ちは visible startup を遅延させない（Rule R1 と両立）。通常起動では孤児が無く cleanup は数 ms で完了するため、待ちは事実上ゼロ。孤児が多い場合のみ最初の session 起動が cleanup 完了（worst case 数秒）まで待つ。これは visible startup 外であり許容する（後述「仮定」）。
+
+ゲート同期プリミティブ: `tokio::sync::watch::<bool>`(初期値 `false`) を採用する。
+
+- `CleanupGate { tx: watch::Sender<bool>, rx: watch::Receiver<bool> }`（または `Sender` のみ保持し `subscribe()` で receiver を配る）。
+- 背景スレッドは完了時に `tx.send(true)`（sync 文脈から呼べる）。
+- spawn 経路（async）は `let mut rx = gate.subscribe(); if !*rx.borrow() { rx.wait_for(|v| *v).await; }` で待つ。
+- `watch` を使う理由: 「ワンショット完了を複数 async waiter へブロードキャスト」「sync スレッドから signal」「await 前後の取りこぼし（notify の lost-wakeup）が無い」を同時に満たすため。`Notify` だと create-future-before-check の取りこぼし対策が要るので避ける。
+- **開放保証**: cleanup スレッドは正常終了・panic 捕捉・スレッド起動失敗のいずれでも必ず `gate.open()` を呼ぶ。gate は cleanup 終了の事実だけで開き、時間経過では開かない。これにより cleanup が長時間かかる場合でも新規 pgid 確保と cleanup が並走しない。
+
+非 unix（Rule R6）: cleanup は元から `#[cfg(unix)]`。非 unix では gate を「最初から開放済み（`true`）」で構築し、spawn 経路の待ちは即座に通過する。`#[cfg(not(unix))]` 経路では cleanup spawn 自体を行わない。
+
+### observation（Rule R3 / R4）
+
+`cleanup_orphan_processes` を「副作用のみ・戻り値なし」から「集計レポートを返す」関数へ変更する:
+
+- 走査中に `OrphanCleanupReport` を組み立てて返す。判定・kill のロジック（owner 同一性 / PID 再利用 / SIGTERM→SIGKILL）は一切変えず、各分岐でカウンタを加算するだけにする。
+- 背景スレッドは戻り値レポートを受け取り、(1) 構造化ログを 1 行出力、(2) `other::telemetry` の新規記録関数へ渡す。
+- telemetry は既存 counter 方式（`is_performance_active()` ガード・`#[cfg(test)]` の `record_test_metric`）に倣う。観測値は **safe metadata（status と件数）のみ**。worktree path・session id・command body 等の user data は一切含めない。cleanup の individual ログ行も同じ境界に揃え、PID ファイルパス・session 派生値・PID/PGID 値を出さず、safe な reason と最終集計ログ（status / scanned / processed / skipped / failures）だけを出力する。
+
+## データモデルまたは型
+
+### `OrphanCleanupReport`（`bridge_common.rs`, `#[cfg(unix)]`）
+
+```rust
+#[cfg(unix)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct OrphanCleanupReport {
+    /// 走査した `.pid` ファイル数（拡張子 .pid のみ。.tmp 等は除外）。
+    pub scanned: usize,
+    /// 孤児として処理した数（SIGTERM/SIGKILL 送出、または PID ファイル除去）。
+    pub processed: usize,
+    /// live owner / 検証不能 / legacy format 等で保守的に skip した数（issue #1024）。
+    pub skipped: usize,
+    /// 読み取り失敗等で処理できなかった数。
+    pub failures: usize,
+}
+```
+
+- `scanned` `processed` `skipped` `failures` はいずれも件数のみで user data を含まない（Rule R4）。
+- `processed` の定義は requirements 仮定どおり「SIGTERM/SIGKILL を送った、または PID ファイルを除去した数」。invalid pgid の除去・孤児の kill+除去はいずれも `processed` に含める。
+- 状態（完了 / 失敗）は別途レポートとは独立に表現する: 関数が正常 return すれば「完了」、`failures > 0` でも関数自体は完走するので「完了（一部失敗あり）」とし、`failures` で失敗有無を区別する。スレッド自体が panic した場合は背景スレッド側で捕捉して「失敗」として記録する（後述エラー処理）。
+
+### `CleanupGate`（`bridge_common.rs`）
+
+```rust
+pub(crate) struct CleanupGate {
+    tx: tokio::sync::watch::Sender<bool>,
+}
+
+impl CleanupGate {
+    /// unix: 未完了(false)で構築。非 unix: 開放済み(true)で構築。
+    pub fn new(initially_open: bool) -> Self { /* watch::channel(initially_open) */ }
+    /// cleanup 完了時に背景スレッドから呼ぶ（sync 文脈可）。
+    pub fn open(&self) { let _ = self.tx.send(true); }
+    /// spawn 直前に await。開放済みなら即 return。cleanup 終了通知まで待つ。
+    pub async fn wait_until_open(&self) { /* subscribe → wait_for(|v| *v) */ }
+}
+```
+
+managed state として `app.manage(Arc::new(CleanupGate::new(cfg!(unix))))`（unix は false、非 unix は true）。spawn 経路では `app.try_state::<Arc<CleanupGate>>()` で取得し、取得できなければ（テスト等で未配線）待たずに継続する。
+
+### telemetry 追加（`attributes.rs` / `mod.rs`）
+
+- `attributes.rs`: cleanup 件数の種別を表す attribute（例 `KEY_OPERATION` 値 `"startup.orphan_cleanup"`、status は既存 `OpStatus::{Success, Failure}` を再利用）。件数は counter の値として記録するか、種別ごとに `OpStatus` 的な軽量 enum を足す。詳細命名:
+  - metric 名: `releash.startup.orphan_cleanup`（u64 counter）。
+  - attribute: `status`（`success` / `failure`、`failures>0 || panic` で `failure`）、`outcome`（`scanned` / `processed` / `skipped` / `failures` の件数種別）。各 outcome 種別ごとに件数を `add(n, attrs)` する。
+- `mod.rs`: `record_orphan_cleanup(report: &OrphanCleanupReport, failed: bool)` を追加。`is_performance_active()` ガード・`#[cfg(test)]` の `record_test_metric` 併記を既存関数（`record_hot_path_duration` 等）と同形で実装。
+
+> 命名・粒度は実装時に既存 attribute 規約（allowlist テスト `usage_events_are_allowlisted` 等）と整合させる。outcome を attribute で分けず 4 つの専用 counter にする案もあるが、既存が「1 counter + operation/status attribute」方式なので踏襲する。
+
+## 処理フロー
+
+### 起動時（unix）
+
+1. setup 開始時に `CleanupGate::new(false)` を `app.manage`。
+2. window 準備完了で `record_startup(FirstWindowReady)`（既存 `lib.rs` 299）。**ここまで cleanup は関与しない**（Rule R1）。
+3. `#[cfg(unix)]` ブロック: `data_dir` を clone し、専用 std スレッドを spawn（`.join()` しない）。
+4. setup は即座に `record_startup(AppStartup)` 以降へ進み完了。
+5. 背景スレッド内:
+   a. `let report = cleanup_orphan_processes(&data_dir);`（panic は `catch_unwind` で捕捉、捕捉時 `failed=true`・空レポート扱い）。
+   b. 構造化ログ 1 行（件数のみ）。
+   c. `telemetry::record_orphan_cleanup(&report, failed)`。
+   d. `gate.open()`（成功 / 失敗いずれでも必ず開放。失敗で開放しないと spawn が進まないため）。
+
+### 新規 bridge spawn 時（unix）
+
+1. `spawn_bridge_process` / `register_external_agent_process` が `cmd` を構築（env / `pre_exec(setsid)` 設定済み）。
+2. `cmd.spawn()` の**直前**で `if let Some(gate) = app.try_state::<Arc<CleanupGate>>() { gate.wait_until_open().await; }`。
+3. gate 開放後に `cmd.spawn()` → 新 pgid 確保 → `save_pgid`（既存どおり owner=自 pid を記録）。
+4. 以降は既存フロー。
+
+### 非 unix
+
+- cleanup スレッドを spawn しない。gate は `true` 構築で spawn 経路の待ちは即通過（Rule R6）。
+
+## エラー処理
+
+- **cleanup 内部の I/O / parse 失敗**: 既存方針を維持（ファイル読めない→warn ログして continue、legacy/unknown format→保守的 skip、invalid pgid→除去）。個別ログには PID ファイルパス・session 派生値・PID/PGID 値を含めず、safe な reason のみを出す。これらは `failures` / `skipped` / `processed` に計上するのみで関数は完走する。
+- **背景スレッドの panic**: `std::panic::catch_unwind` で捕捉。捕捉時は `failed=true` として telemetry に `status=failure` を記録し、**必ず `gate.open()` を呼ぶ**（spawn を無期限に塞がない）。
+- **gate が開かない異常**: cleanup panic / スレッド起動失敗は捕捉して `gate.open()` する。`CleanupGate` の sender が閉じるなど本来起きない状態では warn ログのうえ spawn を継続する。
+- **gate state 未配線（テスト/異常）**: `try_state` が `None` を返したら待たずに継続。
+- **telemetry 無効時**: 既存どおり `is_performance_active()` が false なら no-op。
+
+## テスト方針
+
+`#[cfg(test)] mod tests`（`bridge_common.rs` / `telemetry/mod.rs`）に追加。CI は `cargo clippy -- -D warnings` / `cargo test`。
+
+1. **Rule R7 / R2 — 順序保証（pgid 再利用レース）**:
+   - 既存の実プロセスを使うテスト（`cleanup_orphan_processes_kills_alive_process_group` 19580 付近）の構造を流用。
+   - 「現インスタンス所有」を表す PID ファイル（`owner_app_pid = std::process::id()`、`owner_start_time = get_process_start_time(自分)`）を置き、生きたプロセス群を指す状態で `cleanup_orphan_processes` を呼び、**そのプロセス群が kill されない**（owner 同一性 skip）ことを assert。これが「自インスタンスが spawn した新規プロセスは誤 kill されない」の核を検証する。
+   - `CleanupGate` の単体テスト: `tokio` test で、未開放時 `wait_until_open()` が pending（短い timeout で確認）、`open()` 後に即 return、複数 waiter 全てが解放されること、managed state に閉じた gate を置いた production spawn 直前 helper が fake spawn closure を実行しないこと。
+2. **Rule R3 / R4 — observation**:
+   - `cleanup_orphan_processes` の戻り `OrphanCleanupReport` のカウントを検証（空 dir → 全 0、stale 除去 → `processed` 加算、legacy format → `skipped` 加算、invalid pgid → `processed` 加算）。既存の `cleanup_orphan_processes_*` テスト群を report 返り値の assert に拡張。
+   - `telemetry::record_orphan_cleanup` を既存 test harness（`lock_test_telemetry` / `reset_test_metrics` / `test_metric_records`）で検証: `status=success/failure` と各 outcome 件数が記録されること、記録 attribute に user data キー（path/session 等）が**含まれない**こと（allowlist 的 assert）。
+   - cleanup 個別ログが PID ファイルパスや process id を format しないことを、cleanup 関数ソースの regression test で検証する。
+3. **Rule R5 — 孤児回収維持**:
+   - 既存の「stale ファイル除去」「live owner skip」「PID 再利用で proceed」「保守的 skip」テスト群がそのまま green であること（アルゴリズム不変の回帰防止）。SIGTERM→sleep→SIGKILL 昇格手順を変えていないことを既存テストで担保。
+4. **Rule R6 — 非 unix**:
+   - `#[cfg(not(unix))]` で gate が即開放であること（コンパイル経路の確認）。cleanup spawn が無いことは構造で担保。
+5. **Rule R1 — non-blocking**:
+   - 厳密な実時間 assert は単体テストに馴染まないため、構造で担保（setup から `.join()` を除去・cleanup を detach スレッド化・gate 待ちを spawn 経路のみに限定）。gate の単体テストで「visible startup 経路は gate を待たない」設計を間接的に裏付ける。
+
+## リスクと代替案
+
+- **pgid 再利用レースの残余（gate を採らない場合）**: 「snapshot で起動時の `.pid` ファイル集合だけを cleanup 対象にする」案単独では、stale ファイルの pgid が新規プロセス群へ再割当されるケースを塞げない（§「順序保証の本質」step 4）。よって gate（spawn を cleanup 完了後へ直列化）を採用する。snapshot 案は behavior R2 の文面（「自インスタンス起動以降に作成された PID は対象外」）と一致するが、それは既存 owner 同一性判定で既に満たされており、追加の安全性を生まないため不採用。
+- **最初の session 起動の遅延**: 孤児が多いと最初の `init_agent_sessions` 起因の spawn が cleanup 完了（worst case 数秒以上）まで待つ。visible startup 外なので requirements 上は許容。通常は孤児ゼロで待ち ≒ 0。cleanup 完了前に spawn を進める timeout は設けない。
+- **gate 配線漏れ**: managed state 未登録だと spawn が待たず pgid 再利用レースに戻る。setup で必ず `manage` し、`try_state` 失敗時はログを残す。
+- **telemetry 粒度**: outcome を attribute で分ける方式が既存 dashboards と噛み合うかは運用側に依存。既存 counter 方式を踏襲し、必要なら後続で粒度調整（本 Issue では最低限の件数を満たす）。
+- **代替: init_agent_sessions 全体を gate で待つ**: command 先頭で待つ案もあるが、待ちを「実 spawn 直前」に絞るほうが、session メタ取得など spawn を伴わない経路を不必要に遅延させない。後者を採用。
+
+## 仮定
+
+- cleanup は従来どおり起動時 1 回・専用 std スレッドで実行し、setup は完了を待たない（requirements 仮定「cleanup の起動タイミング」）。
+- 順序保証は `CleanupGate`（`tokio::sync::watch` ベースの完了ゲート）で担保し、新規 bridge の `cmd.spawn()` を cleanup 完了後へ直列化する。既存 owner 同一性判定と二重で新規プロセスを保護する。
+- gate 待ちは spawn 経路（`init_agent_sessions` 起点、visible startup 外）でのみ発生し、first window ready を遅延させない。
+- 観測は構造化ログ + 既存 telemetry 経路（`other::telemetry`、counter 方式）。frontend / 運用向け専用 read コマンドは追加しない（合意済み）。
+- 対象数 = `scanned`（走査 `.pid` 数）/ `processed`（kill 送出 or ファイル除去数）/ `skipped`（保守的 skip 数）/ `failures`（処理失敗数）。
+- 判定アルゴリズム（PID 再利用検出 / owner 同一性 / SIGTERM→最大 2 秒→SIGKILL 昇格 / 保守的 skip, issue #1024）は不変（requirements 非スコープ）。
+- 対象は unix（`#[cfg(unix)]`）限定。非 unix では cleanup を行わず gate は即開放。
+
+## Open Questions
+
+なし（requirements.md / behavior.md で全て解消済み。本設計で残る選択は仮定・リスクに明記し、設計判断として確定した）。

--- a/docs/specs/issues-1216/requirements.md
+++ b/docs/specs/issues-1216/requirements.md
@@ -1,0 +1,78 @@
+# Requirements
+
+## Type
+
+性能・起動経路改善（runtime lifecycle のリファクタリング）
+
+対象 Issue: #1216「Startup orphan cleanup を non-blocking service 化する」
+
+正本ドキュメント: `docs/releash-performance-architecture-audit.md`（M3 / 項目 4）
+マイルストーン: 性能・メモリ効率改善（#80）
+実装順: 7-2（Runtime lifecycle / startup）。#1215（runtime cap）と合わせて扱う。
+
+## 背景と目的
+
+`docs/releash-performance-architecture-audit.md` の M3「Runtime lifecycle を締める」の項目 4 として、`cleanup_orphan_processes` を startup の blocking path から外すことが挙げられている。
+
+現状の確認できている挙動は次のとおり:
+
+- アプリ起動時の Tauri `setup` クロージャ（`src-tauri/src/lib.rs` 422-433 付近）で、`cleanup_orphan_processes` を別スレッドで `spawn` した直後に `.join()` しており、**cleanup の完了まで setup が同期的にブロックされる**。`setup` 完了が遅れる分、visible startup（first window ready）が cleanup によって遅延しうる。
+- `cleanup_orphan_processes`（`src-tauri/src/infrastructure/agent_session/runtime/bridge_common.rs` 1066-1167）は、`~/.releash` 配下の `pids` ディレクトリの `*.pid` を走査し、孤児プロセスグループに `SIGTERM` → 最大 **2 秒 sleep** → 生存していれば `SIGKILL` を送る。`.pid` ファイル数や孤児プロセスの終了待ちに比例して所要時間が伸びる（最悪、孤児 1 群あたり 2 秒の sleep が直列に積み上がる）。
+- 既存コメント（`lib.rs` 422-423）は「`init_agent_sessions()` より前に完了しなければ、新規 spawn したプロセスを誤って kill しうる」と明記している。`init_agent_sessions`（`bridge_common.rs` 8552 付近）は Tauri command で、frontend から worktree 単位で呼ばれ、session / bridge プロセスの起動につながる。つまり cleanup と新規 spawn の間には**順序保証が必要**だが、現状は「setup 内で cleanup を join し切る」ことに依存しており、command 経由の新規 spawn との間に明示的な ordering 機構はない。
+- cleanup は `unix` 限定（`#[cfg(unix)]`）。プロセスの生存判定は `libc::kill(pid, 0)` / `libc::killpg(pgid, 0)`、所有者の同一性は `owner_app_pid` + `owner_start_time`（PID 再利用検出）で判定する。判定不能時は保守的に skip する既存方針（issue #1024）がある。
+- cleanup は `log::info!` / `log::warn!` で実行内容を出力するが、cleanup 全体の実行状態・失敗・対象数を**構造化された観測点**としては公開していない。
+
+本 Issue の目的は次の 3 点を満たすこと:
+
+1. orphan process cleanup を startup の blocking path（first window ready を遅延させる経路）から外す。
+2. 新規 spawn したプロセスを誤 kill しない順序を、Rust 側の service として保証する。
+3. cleanup の実行状態・失敗・対象数を、ユーザーデータを含まない safe metadata として観測できるようにする。
+
+## スコープ
+
+- **cleanup を non-blocking 化する**: `setup` クロージャ内の `.join()` による同期待ちを廃し、cleanup が first window ready をブロックしないようにする。cleanup 自体は引き続き起動時に実行されるが、visible startup の critical path から外す。
+- **cleanup と新規 spawn の ordering を Rust service として保証する**: 「cleanup 完了前に起動した新規プロセスを誤って kill しない」ことを、setup でのブロッキング join に依存せず、Rust 側の明示的な順序保証（cleanup 状態を参照する gate / ordering 機構）で担保する。具体的な機構は design で確定する。
+- **safe metadata の観測点を追加する**: cleanup の実行状態（未実行 / 実行中 / 完了 / 失敗）、失敗の有無、対象数（走査 PID 数 / 孤児として処理した数など）を、ユーザーデータを含まない形で観測できるようにする。観測の公開先（構造化ログ / telemetry / 内部 read API）は本書の Open Questions / design で確定する（仮定は後述）。
+- **race のテスト**: cleanup と新規 process spawn の race（cleanup が新規 spawn を誤 kill しない順序保証）を検証するテストを追加する。
+- **ロジックは Rust 側に置く**（`.claude/rules/rust-first-logic.md`）。non-blocking 化・ordering 保証・observation のロジックを frontend に持ち込まない。
+
+## 非スコープ
+
+- PTY / workflow / agent process の idle timeout / cap の enforce（#1215 / M3 項目 3 が担当）。本 Issue は startup orphan cleanup の non-blocking 化と ordering 保証に限定する。
+- terminal inactive tab の unmount、PTY lifecycle 分離（#1213 / M3 項目 2 が担当）。
+- `bridge_common.rs` の module 分割（M4 項目 2 / #1217 が担当）。本 Issue では cleanup / startup ロジックの module 分割そのものは目的としない。
+- cleanup の判定アルゴリズム（PID 再利用検出 / 所有者同一性判定 / SIGTERM→SIGKILL の昇格手順）の変更。既存の保守的 skip 方針（issue #1024）は維持する。
+- Windows など非 unix プラットフォームへの cleanup 対応拡張（現状 `#[cfg(unix)]` 限定の範囲を変えない）。
+- remote subscriber 向け buffer / broadcast の最小化（M3 項目 5 / 別 Issue）。
+- frontend UI への cleanup 状態の表示機能の追加（観測は safe metadata の提供までとし、UI 表示は本 Issue に含めない）。
+
+## 要求事項
+
+1. **non-blocking**: アプリ起動時に orphan cleanup が実行されても、first window ready（visible startup）が cleanup の所要時間（PID 走査・SIGTERM 後の sleep・SIGKILL を含む）によってブロックされないこと。
+2. **誤 kill 防止の順序保証**: cleanup 完了前に新規に spawn された agent / bridge プロセスを、cleanup が孤児として誤って kill しないこと。この順序保証が、setup での同期 join ではなく Rust 側の明示的な機構として成立すること。
+3. **観測可能性**: cleanup の実行状態（少なくとも 完了 / 失敗 が区別できること）、失敗の有無、対象数（走査・処理した PID 数）を、ユーザーデータを含まない safe metadata として観測できること。
+4. **ユーザーデータ非混入**: cleanup に関するログ・metadata に、command body・worktree path・session 本文などのユーザーデータを含めないこと。
+5. **race のテスト**: cleanup と新規 process spawn の race（順序保証が破れて新規プロセスを誤 kill しないこと）を検証する自動テストが存在すること。
+6. **既存挙動の保全**: 既存の孤児判定（所有者同一性 / PID 再利用検出 / 保守的 skip、issue #1024）と、孤児プロセスの確実な回収（最終的には起動ごとに孤児が掃除される）を壊さないこと。non-blocking 化により「孤児が回収されないまま放置される」状態を新たに作らない。
+7. **Rust-first**: 上記ロジックを Rust（Tauri バックエンド）側に実装し、frontend はインターフェースに徹すること。
+
+## 受け入れ基準の概要
+
+- **first window ready が block されない**: 多数の `.pid` ファイルや終了待ちの孤児プロセスが存在する状態でも、first window ready が orphan cleanup によって遅延しない（visible startup の critical path に cleanup が乗らない）ことを確認できる。
+- **cleanup と新規 spawn の race がテストされている**: cleanup 実行中／前後に新規プロセスを spawn する状況で、新規プロセスが誤って kill されないことを検証する自動テストが存在し、green であること。
+- **safe metadata の観測**: cleanup の実行状態・失敗・対象数を観測でき、その metadata・ログにユーザーデータ（command body / worktree path / session 本文）が含まれないことを確認できる。
+- **孤児回収の維持**: 既存の孤児プロセス回収（停止した旧インスタンスのプロセス群が起動時に掃除される）が、non-blocking 化後も成立することを確認できる。
+
+## 仮定
+
+本書では判断できる範囲について以下の仮定を置く。design で再検討・確定する。
+
+- **(仮定) cleanup の起動タイミング**: cleanup は従来どおりアプリ起動時に 1 回起動するが、`setup` の同期経路から外し、バックグラウンドタスク（専用スレッド / async task）として走らせる。`setup` は cleanup の完了を待たずに先へ進む。
+- **(仮定) ordering 機構**: 「新規 spawn を誤 kill しない」順序保証は、cleanup の完了状態を表す共有フラグ（例: `AtomicBool` / `OnceCell` / 完了通知）を Rust 側に持ち、cleanup が完了する前に spawn されたプロセスの PID は、その時点の cleanup 対象集合に含めない（または cleanup 側が「自インスタンス起動以降に作成された PID ファイルは対象外」と判定する）ことで担保する。具体方式は design で確定する。
+- **observation の公開先（合意済み）**: cleanup の実行状態・失敗・対象数は、構造化ログと既存の telemetry 経路（`other::telemetry`）で観測できるようにする。frontend / 運用向けの専用 read コマンド（Tauri command 等）は本 Issue では追加しない。
+- **(仮定) プラットフォーム範囲**: 対象は現状どおり unix（`#[cfg(unix)]`）に限定し、非 unix では従来どおり cleanup を行わない。
+- **(仮定) 対象数の定義**: 「対象数」は最低限、走査した `.pid` ファイル数と、孤児として SIGTERM/SIGKILL を送った（または PID ファイルを除去した）数を指す。粒度は design で確定する。
+
+## Open Questions
+
+なし

--- a/src-tauri/src/adaptor/controller/command/agent_session/action.rs
+++ b/src-tauri/src/adaptor/controller/command/agent_session/action.rs
@@ -1,195 +1,31 @@
-use crate::infrastructure::agent_session::runtime::codex::configured_cli_path;
-use crate::infrastructure::agent_session::runtime::codex_app_server::{
-    build_skills_list_request, CodexAppServerProcess,
-};
-use crate::infrastructure::agent_session::runtime::SkillEntry;
+use tauri::State;
+
+use crate::adaptor::controller::state::AppState;
+use crate::domain::agent_session::SkillEntry;
 
 #[tauri::command]
 pub async fn scan_agent_skills(
+    state: State<'_, AppState>,
     cwd: String,
     backend_id: Option<String>,
     query: Option<String>,
     limit: Option<usize>,
 ) -> Result<Vec<SkillEntry>, String> {
-    crate::infrastructure::agent_session::runtime::scan_agent_skills(cwd, backend_id, query, limit)
+    state
+        .agent_session_usecase
+        .scan_agent_skills(cwd, backend_id, query, limit)
         .await
-}
-
-fn codex_skill_scope(value: &str) -> String {
-    match value {
-        "user" => "personal".to_string(),
-        "repo" => "project".to_string(),
-        "system" | "admin" => value.to_string(),
-        _ => "project".to_string(),
-    }
-}
-
-fn parse_codex_skill_catalog(value: &serde_json::Value) -> Vec<SkillEntry> {
-    let mut skills = Vec::new();
-    let Some(entries) = value.get("data").and_then(serde_json::Value::as_array) else {
-        return skills;
-    };
-    for entry in entries {
-        let Some(items) = entry.get("skills").and_then(serde_json::Value::as_array) else {
-            continue;
-        };
-        for skill in items {
-            if !skill
-                .get("enabled")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(true)
-            {
-                continue;
-            }
-            let Some(name) = skill
-                .get("name")
-                .and_then(serde_json::Value::as_str)
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-            else {
-                continue;
-            };
-            let description = skill
-                .get("interface")
-                .and_then(|interface| interface.get("shortDescription"))
-                .and_then(serde_json::Value::as_str)
-                .or_else(|| {
-                    skill
-                        .get("shortDescription")
-                        .and_then(serde_json::Value::as_str)
-                })
-                .or_else(|| skill.get("description").and_then(serde_json::Value::as_str))
-                .unwrap_or("")
-                .trim()
-                .to_string();
-            let scope = skill
-                .get("scope")
-                .and_then(serde_json::Value::as_str)
-                .map(codex_skill_scope)
-                .unwrap_or_else(|| "project".to_string());
-            skills.push(SkillEntry {
-                name: name.to_string(),
-                description,
-                scope,
-            });
-        }
-    }
-    skills
 }
 
 #[tauri::command]
 pub async fn read_codex_skill_catalog(
-    app: tauri::AppHandle,
+    state: State<'_, AppState>,
     cwd: String,
     query: Option<String>,
     limit: Option<usize>,
 ) -> Result<Vec<SkillEntry>, String> {
-    let local_fallback = || {
-        crate::infrastructure::agent_session::runtime::scan_agent_skills(
-            cwd.clone(),
-            Some(crate::infrastructure::agent_session::runtime::CODEX_BACKEND_ID.to_string()),
-            query.clone(),
-            limit,
-        )
-    };
-    let cli_path = configured_cli_path(&app).unwrap_or_else(|| "codex".to_string());
-    let mut process = match CodexAppServerProcess::spawn(&cli_path) {
-        Ok(process) => process,
-        Err(_) => return local_fallback().await,
-    };
-    let result: Result<Vec<SkillEntry>, String> = async {
-        process.initialize(env!("CARGO_PKG_VERSION")).await?;
-        let id = process.next_request_id();
-        process
-            .send(&build_skills_list_request(id, &cwd, false))
-            .await?;
-        let response = process.read_response_result(id).await?;
-        Ok(
-            crate::infrastructure::agent_session::runtime::filter_agent_skills_for_query(
-                parse_codex_skill_catalog(&response),
-                query.as_deref(),
-                limit,
-            ),
-        )
-    }
-    .await;
-    process.shutdown().await;
-    match result {
-        Ok(skills) => Ok(skills),
-        Err(_) => local_fallback().await,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_codex_skill_catalog_enabled_scopes_and_short_description() {
-        let response = serde_json::json!({
-            "data": [
-                {
-                    "cwd": "/repo",
-                    "errors": [],
-                    "skills": [
-                        {
-                            "name": "review",
-                            "description": "Long review description",
-                            "enabled": true,
-                            "path": "/repo/.agents/skills/review/SKILL.md",
-                            "scope": "repo",
-                            "shortDescription": "Review changes",
-                            "interface": { "shortDescription": "Runtime review" }
-                        },
-                        {
-                            "name": "draft",
-                            "description": "Draft docs",
-                            "enabled": true,
-                            "path": "/home/.agents/skills/draft/SKILL.md",
-                            "scope": "user",
-                            "shortDescription": null,
-                            "interface": null
-                        },
-                        {
-                            "name": "disabled",
-                            "description": "Disabled",
-                            "enabled": false,
-                            "path": "/repo/.agents/skills/disabled/SKILL.md",
-                            "scope": "repo"
-                        },
-                        {
-                            "name": "builtin",
-                            "description": "Builtin",
-                            "enabled": true,
-                            "path": "/app/skills/builtin/SKILL.md",
-                            "scope": "system"
-                        }
-                    ]
-                }
-            ]
-        });
-
-        let skills = parse_codex_skill_catalog(&response);
-
-        assert_eq!(
-            skills,
-            vec![
-                SkillEntry {
-                    name: "review".to_string(),
-                    description: "Runtime review".to_string(),
-                    scope: "project".to_string(),
-                },
-                SkillEntry {
-                    name: "draft".to_string(),
-                    description: "Draft docs".to_string(),
-                    scope: "personal".to_string(),
-                },
-                SkillEntry {
-                    name: "builtin".to_string(),
-                    description: "Builtin".to_string(),
-                    scope: "system".to_string(),
-                },
-            ]
-        );
-    }
+    state
+        .agent_session_usecase
+        .read_codex_skill_catalog(cwd, query, limit)
+        .await
 }

--- a/src-tauri/src/adaptor/controller/command/code/mention.rs
+++ b/src-tauri/src/adaptor/controller/command/code/mention.rs
@@ -5,15 +5,10 @@
 
 use std::collections::HashMap;
 
-use serde_json::Value;
-use tauri::{AppHandle, State};
+use tauri::State;
 
 use crate::adaptor::controller::state::AppState;
 use crate::adaptor::protocol::mention::MentionReferenceInput;
-use crate::infrastructure::agent_session::runtime::codex::configured_cli_path;
-use crate::infrastructure::agent_session::runtime::codex_app_server::{
-    build_fuzzy_file_search_request, CodexAppServerProcess,
-};
 use crate::other::AppError;
 
 #[tauri::command]
@@ -28,82 +23,17 @@ pub fn list_mentionable_files(
         .map_err(AppError::from)
 }
 
-fn normalize_codex_fuzzy_path(root: &str, path: &str) -> Option<String> {
-    let root = root.trim_end_matches(['/', '\\']);
-    let mut path = path.trim().replace('\\', "/");
-    if path.is_empty() {
-        return None;
-    }
-    let normalized_root = root.replace('\\', "/");
-    if !normalized_root.is_empty() && path == normalized_root {
-        return None;
-    }
-    if !normalized_root.is_empty() {
-        if let Some(stripped) = path.strip_prefix(&(normalized_root.clone() + "/")) {
-            path = stripped.to_string();
-        }
-    }
-    if path.is_empty() {
-        None
-    } else {
-        Some(path)
-    }
-}
-
-pub(crate) fn codex_fuzzy_file_paths(response: &Value, root: &str, limit: usize) -> Vec<String> {
-    let mut seen = HashMap::<String, ()>::new();
-    let mut paths = Vec::new();
-    let Some(files) = response.get("files").and_then(Value::as_array) else {
-        return paths;
-    };
-    for item in files {
-        let match_type = item
-            .get("match_type")
-            .or_else(|| item.get("matchType"))
-            .and_then(Value::as_str);
-        if match_type.is_none_or(|value| value != "file" && value != "directory") {
-            continue;
-        }
-        let Some(path) = item.get("path").and_then(Value::as_str) else {
-            continue;
-        };
-        let Some(mut path) = normalize_codex_fuzzy_path(root, path) else {
-            continue;
-        };
-        if match_type.is_some_and(|value| value == "directory") {
-            path = format!("{}/", path.trim_end_matches('/'));
-        }
-        if seen.insert(path.clone(), ()).is_some() {
-            continue;
-        }
-        paths.push(path);
-        if paths.len() >= limit {
-            break;
-        }
-    }
-    paths
-}
-
 #[tauri::command]
 pub async fn read_codex_mentionable_files(
-    app: AppHandle,
+    state: State<'_, AppState>,
     worktree_path: String,
     query: String,
 ) -> Result<Vec<String>, String> {
-    let cli_path = configured_cli_path(&app).unwrap_or_else(|| "codex".to_string());
-    let mut process = CodexAppServerProcess::spawn(&cli_path)?;
-    let result = async {
-        process.initialize(env!("CARGO_PKG_VERSION")).await?;
-        let id = process.next_request_id();
-        process
-            .send(&build_fuzzy_file_search_request(id, &worktree_path, &query))
-            .await?;
-        let response = process.read_response_result(id).await?;
-        Ok(codex_fuzzy_file_paths(&response, &worktree_path, 50))
-    }
-    .await;
-    process.shutdown().await;
-    result
+    state
+        .code_usecase
+        .read_codex_mentionable_files(&worktree_path, &query, 50)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -348,39 +278,5 @@ mod tests {
             sync_mentions_with_text_inner("Check @b", &[mention("a")]),
             None
         );
-    }
-
-    #[test]
-    fn codex_fuzzy_file_paths_keeps_file_and_directory_matches_in_runtime_order() {
-        let result = codex_fuzzy_file_paths(
-            &serde_json::json!({
-                "files": [
-                    { "root": "/repo", "path": "/repo/src/main.rs", "match_type": "file" },
-                    { "root": "/repo", "path": "src", "match_type": "directory" },
-                    { "root": "/repo", "path": "src/main.rs", "match_type": "file" },
-                    { "root": "/repo", "path": "src/lib.rs", "matchType": "file" }
-                ]
-            }),
-            "/repo",
-            50,
-        );
-
-        assert_eq!(result, vec!["src/main.rs", "src/", "src/lib.rs"]);
-    }
-
-    #[test]
-    fn codex_fuzzy_file_paths_respects_limit() {
-        let result = codex_fuzzy_file_paths(
-            &serde_json::json!({
-                "files": [
-                    { "path": "a.rs", "match_type": "file" },
-                    { "path": "b.rs", "match_type": "file" }
-                ]
-            }),
-            "/repo",
-            1,
-        );
-
-        assert_eq!(result, vec!["a.rs"]);
     }
 }

--- a/src-tauri/src/adaptor/controller/command/workflow/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/mod.rs
@@ -2405,6 +2405,9 @@ mod tests {
             repo_paths_usecase,
             code_usecase,
             review_usecase,
+            agent_session_usecase: Arc::new(
+                crate::adaptor::controller::wiring::build_agent_session_usecase(app.handle().clone()),
+            ),
             workflow_usecase: Arc::new(
                 crate::adaptor::controller::wiring::build_workflow_usecase_with_repository_worktrees(
                     data_dir.clone(),

--- a/src-tauri/src/adaptor/controller/state.rs
+++ b/src-tauri/src/adaptor/controller/state.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use crate::usecase::agent_session::AgentSessionUsecase;
 use crate::usecase::code_usecase::CodeUsecase;
 use crate::usecase::repo_paths_usecase::RepoPathsUsecase;
 use crate::usecase::repository_state::RepositoryStateService;
@@ -18,5 +19,6 @@ pub struct AppState {
     pub repo_paths_usecase: Arc<RepoPathsUsecase>,
     pub code_usecase: Arc<CodeUsecase>,
     pub review_usecase: Arc<ReviewUsecase>,
+    pub agent_session_usecase: Arc<AgentSessionUsecase>,
     pub workflow_usecase: Arc<WorkflowUsecase>,
 }

--- a/src-tauri/src/adaptor/controller/wiring.rs
+++ b/src-tauri/src/adaptor/controller/wiring.rs
@@ -38,9 +38,15 @@ use crate::adaptor::gateway::workflow::{
     WorkflowRunArchiveFileRepository, WorkflowRunFileRepository, WorkflowSecretSourceConfigGateway,
     WorkflowStateProjectionLogRepository, WorkflowStepDetailProjectionLogRepository,
 };
+#[cfg(test)]
+use crate::domain::agent_session::SkillEntry;
 use crate::domain::app_config::{ConfigRepository, ConfigSecretRepository};
+#[cfg(test)]
+use crate::domain::code::CodeError;
 use crate::domain::workflow::{ManagedWorktreeGateway, SecretSourceGateway};
+use crate::infrastructure::agent_session::codex_fuzzy_file_search_gateway::TauriCodexFuzzyFileSearchGateway;
 use crate::infrastructure::agent_session::runtime::AgentProcessMap;
+use crate::infrastructure::agent_session::skill_catalog_gateway::TauriCodexSkillCatalogGateway;
 use crate::infrastructure::agent_session::thread_lifecycle_gateway::{
     CodexThreadLifecycleAppServerGateway, TauriAgentSessionRuntimeCloser,
 };
@@ -48,7 +54,10 @@ use crate::usecase::agent_session::session::{
     AgentPromptSuggestionUsecase, OpenTabRegistry, SessionReaderPort, SessionStore,
     StoredSessionLifecycleUsecase,
 };
-use crate::usecase::code_query_service::CodeQueryService;
+#[cfg(test)]
+use crate::usecase::agent_session::skill_catalog::CodexSkillCatalogGateway;
+use crate::usecase::agent_session::AgentSessionUsecase;
+use crate::usecase::code_query_service::{CodeQueryService, CodexFuzzyFileSearchGateway};
 use crate::usecase::code_usecase::CodeUsecase;
 use crate::usecase::repository_query_service::RepositoryQueryService;
 use crate::usecase::repository_usecase::RepositoryUsecase;
@@ -79,19 +88,88 @@ pub(crate) fn build_repository_usecase() -> RepositoryUsecase {
 /// staging（書き込み）は Command 側 Usecase が、ファイル内容参照・diff バッファ計算・
 /// branch diff・mention 候補列挙（読み取り）は `CodeQueryService` が各 gateway へ委譲する。
 /// いずれの gateway もステートレスのため、起動時に 1 度だけ組み立てて Arc 共有する。
-pub(crate) fn build_code_usecase() -> CodeUsecase {
+#[cfg(test)]
+struct UnavailableCodexFuzzyFileSearchGateway;
+
+#[cfg(test)]
+#[async_trait::async_trait]
+impl CodexFuzzyFileSearchGateway for UnavailableCodexFuzzyFileSearchGateway {
+    async fn search_files(
+        &self,
+        _worktree_path: &str,
+        _query: &str,
+        _limit: usize,
+    ) -> Result<Vec<String>, CodeError> {
+        Err(CodeError::External(
+            "Codex fuzzy file search gateway is not configured".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+struct UnavailableCodexSkillCatalogGateway;
+
+#[cfg(test)]
+#[async_trait::async_trait]
+impl CodexSkillCatalogGateway for UnavailableCodexSkillCatalogGateway {
+    async fn list_app_server_skills(
+        &self,
+        _cwd: &str,
+        _query: Option<&str>,
+        _limit: Option<usize>,
+    ) -> Result<Vec<SkillEntry>, String> {
+        Err("Codex skill catalog gateway is not configured".to_string())
+    }
+
+    async fn scan_local_skills(
+        &self,
+        _cwd: &str,
+        _backend_id: Option<&str>,
+        _query: Option<&str>,
+        _limit: Option<usize>,
+    ) -> Result<Vec<SkillEntry>, String> {
+        Err("Codex skill catalog gateway is not configured".to_string())
+    }
+}
+
+fn build_code_usecase_with_fuzzy_gateway(
+    codex_fuzzy_file_search: Arc<dyn CodexFuzzyFileSearchGateway>,
+) -> CodeUsecase {
     let query = CodeQueryService::new(
         Arc::new(FileContentGateway),
         Arc::new(DiffComputerGateway),
         Arc::new(BranchDiffGateway),
         Arc::new(MentionGateway),
         Arc::new(BranchBaseResolverGateway::new(Arc::new(GitConfigGateway))),
+        codex_fuzzy_file_search,
     );
     CodeUsecase::new(
         Arc::new(StagingGateway),
         query,
         Arc::new(ReviewBlobUrlGateway),
     )
+}
+
+#[cfg(test)]
+pub(crate) fn build_code_usecase() -> CodeUsecase {
+    build_code_usecase_with_fuzzy_gateway(Arc::new(UnavailableCodexFuzzyFileSearchGateway))
+}
+
+pub(crate) fn build_code_usecase_with_app<R: tauri::Runtime + 'static>(
+    app: tauri::AppHandle<R>,
+) -> CodeUsecase {
+    build_code_usecase_with_fuzzy_gateway(Arc::new(TauriCodexFuzzyFileSearchGateway::new(app)))
+}
+
+pub(crate) fn build_agent_session_usecase<R: tauri::Runtime + 'static>(
+    app: tauri::AppHandle<R>,
+) -> AgentSessionUsecase {
+    AgentSessionUsecase::new(Arc::new(TauriCodexSkillCatalogGateway::new(app)))
+}
+
+#[cfg(test)]
+pub(crate) fn build_agent_session_usecase_for_tests() -> AgentSessionUsecase {
+    AgentSessionUsecase::new(Arc::new(UnavailableCodexSkillCatalogGateway))
 }
 
 pub(crate) fn build_session_store() -> SessionStore {

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -6085,6 +6085,9 @@ mod dispatch_boundary_tests {
                 repo_paths_usecase,
                 code_usecase,
                 review_usecase,
+                agent_session_usecase: Arc::new(
+                    crate::adaptor::controller::wiring::build_agent_session_usecase_for_tests(),
+                ),
                 workflow_usecase,
             })
             .build(tauri::test::mock_context(tauri::test::noop_assets()))

--- a/src-tauri/src/domain/agent_session/mod.rs
+++ b/src-tauri/src/domain/agent_session/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod services;
 pub(crate) mod storage;
 pub(crate) mod value_objects;
 
@@ -5,5 +6,6 @@ pub(crate) use storage::{
     AgentSessionReader, AgentSessionStorage, AgentSessionStorageTypes, AgentSessionWriter,
 };
 pub(crate) use value_objects::{
-    model_entry_for_backend_model, model_entry_id, ModelId, CLAUDE_FIXED_MODELS, CODEX_FIXED_MODELS,
+    model_entry_for_backend_model, model_entry_id, ModelId, SkillEntry, CLAUDE_FIXED_MODELS,
+    CODEX_FIXED_MODELS,
 };

--- a/src-tauri/src/domain/agent_session/services.rs
+++ b/src-tauri/src/domain/agent_session/services.rs
@@ -1,0 +1,55 @@
+use super::SkillEntry;
+
+pub(crate) fn filter_agent_skills_for_query(
+    skills: Vec<SkillEntry>,
+    query: Option<&str>,
+    limit: Option<usize>,
+) -> Vec<SkillEntry> {
+    let needle = query.unwrap_or_default().trim().to_lowercase();
+    let max_results = limit.unwrap_or(usize::MAX);
+    skills
+        .into_iter()
+        .filter(|skill| {
+            needle.is_empty()
+                || skill.name.to_lowercase().contains(&needle)
+                || skill.description.to_lowercase().contains(&needle)
+        })
+        .take(max_results)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_agent_skills_filters_by_query_and_limit() {
+        let skills = vec![
+            SkillEntry {
+                name: "review".to_string(),
+                description: "Review code changes".to_string(),
+                scope: "project".to_string(),
+            },
+            SkillEntry {
+                name: "docs".to_string(),
+                description: "Write documentation".to_string(),
+                scope: "personal".to_string(),
+            },
+            SkillEntry {
+                name: "diagram".to_string(),
+                description: "Document architecture diagrams".to_string(),
+                scope: "project".to_string(),
+            },
+        ];
+
+        let result = filter_agent_skills_for_query(skills.clone(), Some("doc"), Some(1));
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "docs");
+
+        let result = filter_agent_skills_for_query(skills, Some("review"), Some(20));
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "review");
+    }
+}

--- a/src-tauri/src/domain/agent_session/value_objects/mod.rs
+++ b/src-tauri/src/domain/agent_session/value_objects/mod.rs
@@ -1,7 +1,9 @@
 mod agent_models;
 mod model_id;
+mod skill_entry;
 
 pub(crate) use agent_models::{
     model_entry_for_backend_model, model_entry_id, CLAUDE_FIXED_MODELS, CODEX_FIXED_MODELS,
 };
 pub(crate) use model_id::ModelId;
+pub(crate) use skill_entry::SkillEntry;

--- a/src-tauri/src/domain/agent_session/value_objects/skill_entry.rs
+++ b/src-tauri/src/domain/agent_session/value_objects/skill_entry.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillEntry {
+    pub name: String,
+    pub description: String,
+    pub scope: String,
+}

--- a/src-tauri/src/infrastructure/agent_session/codex_fuzzy_file_search_gateway.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex_fuzzy_file_search_gateway.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::domain::code::CodeError;
+use crate::infrastructure::agent_session::runtime::codex::configured_cli_path;
+use crate::infrastructure::agent_session::runtime::codex_app_server::{
+    build_fuzzy_file_search_request, CodexAppServerProcess,
+};
+use crate::usecase::code_query_service::CodexFuzzyFileSearchGateway;
+
+pub(crate) struct TauriCodexFuzzyFileSearchGateway<R: tauri::Runtime> {
+    app: tauri::AppHandle<R>,
+}
+
+impl<R: tauri::Runtime> TauriCodexFuzzyFileSearchGateway<R> {
+    pub(crate) fn new(app: tauri::AppHandle<R>) -> Self {
+        Self { app }
+    }
+}
+
+#[async_trait::async_trait]
+impl<R: tauri::Runtime + 'static> CodexFuzzyFileSearchGateway
+    for TauriCodexFuzzyFileSearchGateway<R>
+{
+    async fn search_files(
+        &self,
+        worktree_path: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<String>, CodeError> {
+        let cli_path = configured_cli_path(&self.app).unwrap_or_else(|| "codex".to_string());
+        let mut process = CodexAppServerProcess::spawn(&self.app, &cli_path)
+            .await
+            .map_err(CodeError::External)?;
+        let result = async {
+            process
+                .initialize(env!("CARGO_PKG_VERSION"))
+                .await
+                .map_err(CodeError::External)?;
+            let id = process.next_request_id();
+            process
+                .send(&build_fuzzy_file_search_request(id, worktree_path, query))
+                .await
+                .map_err(CodeError::External)?;
+            let response = process
+                .read_response_result(id)
+                .await
+                .map_err(CodeError::External)?;
+            Ok(codex_fuzzy_file_paths(&response, worktree_path, limit))
+        }
+        .await;
+        process.shutdown().await;
+        result
+    }
+}
+
+fn normalize_codex_fuzzy_path(root: &str, path: &str) -> Option<String> {
+    let root = root.trim_end_matches(['/', '\\']);
+    let mut path = path.trim().replace('\\', "/");
+    if path.is_empty() {
+        return None;
+    }
+    let normalized_root = root.replace('\\', "/");
+    if !normalized_root.is_empty() && path == normalized_root {
+        return None;
+    }
+    if !normalized_root.is_empty() {
+        if let Some(stripped) = path.strip_prefix(&(normalized_root.clone() + "/")) {
+            path = stripped.to_string();
+        }
+    }
+    if path.is_empty() {
+        None
+    } else {
+        Some(path)
+    }
+}
+
+fn codex_fuzzy_file_paths(response: &Value, root: &str, limit: usize) -> Vec<String> {
+    let mut seen = HashMap::<String, ()>::new();
+    let mut paths = Vec::new();
+    let Some(files) = response.get("files").and_then(Value::as_array) else {
+        return paths;
+    };
+    for item in files {
+        let match_type = item
+            .get("match_type")
+            .or_else(|| item.get("matchType"))
+            .and_then(Value::as_str);
+        if match_type.is_none_or(|value| value != "file" && value != "directory") {
+            continue;
+        }
+        let Some(path) = item.get("path").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(mut path) = normalize_codex_fuzzy_path(root, path) else {
+            continue;
+        };
+        if match_type.is_some_and(|value| value == "directory") {
+            path = format!("{}/", path.trim_end_matches('/'));
+        }
+        if seen.insert(path.clone(), ()).is_some() {
+            continue;
+        }
+        paths.push(path);
+        if paths.len() >= limit {
+            break;
+        }
+    }
+    paths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_fuzzy_file_paths_keeps_file_and_directory_matches_in_runtime_order() {
+        let result = codex_fuzzy_file_paths(
+            &serde_json::json!({
+                "files": [
+                    { "root": "/repo", "path": "/repo/src/main.rs", "match_type": "file" },
+                    { "root": "/repo", "path": "src", "match_type": "directory" },
+                    { "root": "/repo", "path": "src/main.rs", "match_type": "file" },
+                    { "root": "/repo", "path": "src/lib.rs", "matchType": "file" }
+                ]
+            }),
+            "/repo",
+            50,
+        );
+
+        assert_eq!(result, vec!["src/main.rs", "src/", "src/lib.rs"]);
+    }
+
+    #[test]
+    fn codex_fuzzy_file_paths_respects_limit() {
+        let result = codex_fuzzy_file_paths(
+            &serde_json::json!({
+                "files": [
+                    { "path": "a.rs", "match_type": "file" },
+                    { "path": "b.rs", "match_type": "file" }
+                ]
+            }),
+            "/repo",
+            1,
+        );
+
+        assert_eq!(result, vec!["a.rs"]);
+    }
+}

--- a/src-tauri/src/infrastructure/agent_session/mod.rs
+++ b/src-tauri/src/infrastructure/agent_session/mod.rs
@@ -1,3 +1,6 @@
+pub(crate) mod codex_fuzzy_file_search_gateway;
+pub(crate) mod resolver_ports;
 pub(crate) mod runtime;
 pub(crate) mod runtime_gateway;
+pub(crate) mod skill_catalog_gateway;
 pub(crate) mod thread_lifecycle_gateway;

--- a/src-tauri/src/infrastructure/agent_session/resolver_ports.rs
+++ b/src-tauri/src/infrastructure/agent_session/resolver_ports.rs
@@ -1,0 +1,32 @@
+use crate::domain::code::MentionReference;
+use crate::usecase::code_usecase::CodeUsecase;
+
+pub(crate) trait BaseBranchResolverPort: Send + Sync {
+    fn resolve_effective_base_branch_name(&self, cwd: &str) -> Option<String>;
+}
+
+pub(crate) trait MentionResolverPort: Send + Sync {
+    fn resolve_mentions_or_fallback(
+        &self,
+        worktree_path: &str,
+        content: &str,
+        mentions: &[MentionReference],
+    ) -> String;
+}
+
+impl BaseBranchResolverPort for CodeUsecase {
+    fn resolve_effective_base_branch_name(&self, cwd: &str) -> Option<String> {
+        self.resolve_effective_base_branch_name(cwd).ok().flatten()
+    }
+}
+
+impl MentionResolverPort for CodeUsecase {
+    fn resolve_mentions_or_fallback(
+        &self,
+        worktree_path: &str,
+        content: &str,
+        mentions: &[MentionReference],
+    ) -> String {
+        self.resolve_mentions_or_fallback(worktree_path, content, mentions)
+    }
+}

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/external_agent.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/external_agent.rs
@@ -6,7 +6,9 @@ use super::session_lifecycle::{
     prepare_pending_turn_messages, prompt_input_for_started_turn, start_pending_message_turn,
     sweep_process_group, take_pending_message,
 };
-use super::shared::{notify_status_transition, GENERATION_COUNTER};
+use super::shared::{
+    notify_status_transition, resolve_mentions_or_fallback_from_port, GENERATION_COUNTER,
+};
 use super::stream_emit::{emit_session_state_changed, spawn_streaming_timer};
 use super::turn_event_log::{begin_turn_event_log, projected_session_state_for_current_turn};
 use crate::app_data_dir::resolve_data_dir;
@@ -319,10 +321,12 @@ pub(crate) async fn prepare_external_pending_message_turn<R: tauri::Runtime>(
         );
     }
 
-    let prompt = app
-        .state::<crate::adaptor::controller::state::AppState>()
-        .code_usecase
-        .resolve_mentions_or_fallback(&pending.worktree_path, &pending.content, &pending.mentions);
+    let prompt = resolve_mentions_or_fallback_from_port(
+        app,
+        &pending.worktree_path,
+        &pending.content,
+        &pending.mentions,
+    );
 
     Ok(Some(ExternalPendingTurn {
         queued_turn_id: pending.id,

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/mod.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/mod.rs
@@ -24,7 +24,9 @@ pub(crate) use process_registry::make_test_agent_process;
 pub(crate) use process_registry::{AgentProcessMap, TurnPhase};
 #[cfg(test)]
 pub(crate) use process_registry::{BridgeState, PendingMessage};
-pub(crate) use recovery::cleanup_orphan_processes;
+#[cfg(unix)]
+pub(crate) use recovery::{cleanup_orphan_processes, OrphanCleanupReport};
+pub(crate) use recovery::{wait_for_startup_orphan_cleanup, CleanupGate};
 pub(crate) use sdk_message::handle_external_bridge_message;
 pub(crate) use session_lifecycle::{
     cancel_agent_queued_turn_internal, close_agent_session_internal, close_all_agent_sessions,
@@ -42,6 +44,5 @@ pub(crate) use shared::{
     DEFER_AGENT_SESSION_ID_PERSIST_ON_READY,
 };
 pub(crate) use skills::{
-    filter_agent_skills_for_query, prepare_image_attachment, prepare_image_attachments_from_paths,
-    scan_agent_skills, SkillEntry,
+    prepare_image_attachment, prepare_image_attachments_from_paths, scan_agent_skills_inner,
 };

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/recovery.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/recovery.rs
@@ -16,8 +16,8 @@ use super::session_persistence::{
 };
 use super::shared::{
     backend_runtime_config, build_init_cmd, compose_system_prompt, notify_status_transition,
-    resolve_bridge_script, session_specific_env_overrides, write_bridge_command_for_captured_turn,
-    BridgeInitOptions, GENERATION_COUNTER,
+    resolve_bridge_script, resolve_effective_base_branch_from_port, session_specific_env_overrides,
+    write_bridge_command_for_captured_turn, BridgeInitOptions, GENERATION_COUNTER,
 };
 use super::stream_emit::{emit_session_state_changed, emit_streaming_parts, enqueue_pending_delta};
 use crate::app_data_dir::resolve_data_dir;
@@ -41,7 +41,7 @@ use std::time::Instant;
 use tauri::Manager;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
-use tokio::sync::Mutex;
+use tokio::sync::{watch, Mutex};
 
 pub(super) const BRIDGE_EOF_ERROR_MESSAGE: &str = "Bridge process exited unexpectedly.";
 pub(super) const STALE_EXIT_CODE: i64 = 124;
@@ -91,6 +91,62 @@ pub(super) fn evaluate_turn_liveness(
         }
         TurnPhase::Idle | TurnPhase::WaitingPermission => None,
     }
+}
+
+#[derive(Debug)]
+pub(crate) struct CleanupGate {
+    tx: watch::Sender<bool>,
+}
+
+impl CleanupGate {
+    pub(crate) fn new(initially_open: bool) -> Self {
+        let (tx, _) = watch::channel(initially_open);
+        Self { tx }
+    }
+
+    pub(crate) fn open(&self) {
+        self.tx.send_replace(true);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_open(&self) -> bool {
+        *self.tx.borrow()
+    }
+
+    pub(crate) async fn wait_until_open(&self) {
+        if *self.tx.borrow() {
+            return;
+        }
+
+        let mut rx = self.tx.subscribe();
+        if *rx.borrow_and_update() {
+            return;
+        }
+
+        if rx.wait_for(|open| *open).await.is_err() {
+            log::warn!("startup orphan cleanup gate closed before opening; continuing spawn");
+        }
+    }
+}
+
+pub(crate) async fn wait_for_startup_orphan_cleanup<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    let Some(gate) = app
+        .try_state::<Arc<CleanupGate>>()
+        .map(|state| state.inner().clone())
+    else {
+        log::warn!("startup orphan cleanup gate state is not registered; continuing spawn");
+        return;
+    };
+    gate.wait_until_open().await;
+}
+
+#[cfg(unix)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct OrphanCleanupReport {
+    pub(crate) scanned: usize,
+    pub(crate) processed: usize,
+    pub(crate) skipped: usize,
+    pub(crate) failures: usize,
 }
 
 pub(super) fn pids_dir(app_data_dir: &Path) -> PathBuf {
@@ -236,22 +292,38 @@ pub(super) fn remove_pgid(app_data_dir: &Path, chat_session_id: &str) {
 }
 
 #[cfg(unix)]
-pub fn cleanup_orphan_processes(app_data_dir: &Path) {
+pub fn cleanup_orphan_processes(app_data_dir: &Path) -> OrphanCleanupReport {
+    let mut report = OrphanCleanupReport::default();
     let dir = pids_dir(app_data_dir);
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
-        Err(_) => return, // No pids dir — nothing to clean up
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return report,
+        Err(e) => {
+            report.failures += 1;
+            log::warn!("Failed to read startup orphan cleanup PID directory: {e}");
+            return report;
+        }
     };
 
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                report.failures += 1;
+                log::warn!("Failed to read startup orphan cleanup PID directory entry: {e}");
+                continue;
+            }
+        };
         let path = entry.path();
         if path.extension().is_none_or(|ext| ext != "pid") {
             continue;
         }
+        report.scanned += 1;
         let contents = match std::fs::read_to_string(&path) {
             Ok(s) => s,
             Err(e) => {
-                log::warn!("Failed to read PID file {}: {e}", path.display());
+                report.failures += 1;
+                log::warn!("Failed to read startup orphan PID file; counting failure: {e}");
                 continue;
             }
         };
@@ -261,21 +333,23 @@ pub fn cleanup_orphan_processes(app_data_dir: &Path) {
             Err(_) => {
                 // Legacy or unknown format. Conservatively skip — touching it
                 // could destroy a live owner's bookkeeping (issue #1024).
-                log::warn!(
-                    "PID file {} is not in PidFileV1 format; skipping cleanup",
-                    path.display()
-                );
+                log::warn!("Startup orphan cleanup skipped PID file with unsupported format");
+                report.skipped += 1;
                 continue;
             }
         };
 
         if parsed.pgid <= 1 {
-            log::warn!(
-                "Invalid PGID {} in {}, removing file",
-                parsed.pgid,
-                path.display()
-            );
-            let _ = std::fs::remove_file(&path);
+            log::warn!("Startup orphan cleanup removed PID file with invalid process group");
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    report.processed += 1;
+                }
+                Err(e) => {
+                    report.failures += 1;
+                    log::warn!("Failed to remove invalid startup orphan PID file: {e}");
+                }
+            }
             continue;
         }
 
@@ -286,29 +360,23 @@ pub fn cleanup_orphan_processes(app_data_dir: &Path) {
         if owner_alive {
             match get_process_start_time(parsed.owner_app_pid) {
                 Ok(current_start_time) if current_start_time == parsed.owner_start_time => {
-                    log::info!(
-                        "PID file {} is owned by live instance (pid={}); skipping cleanup",
-                        path.display(),
-                        parsed.owner_app_pid
-                    );
+                    log::info!("Startup orphan cleanup skipped PID file owned by a live instance");
+                    report.skipped += 1;
                     continue;
                 }
                 Ok(_) => {
                     log::info!(
-                        "PID file {} owner pid {} appears to have been reused; proceeding with cleanup",
-                        path.display(),
-                        parsed.owner_app_pid
+                        "Startup orphan cleanup found reused owner identity; proceeding with cleanup"
                     );
                 }
-                Err(e) => {
+                Err(_) => {
                     // live owner だが start_time を検証できない: 保守的に skip
                     // する（unsupported プラットフォームや一時的 I/O 失敗で他
                     // インスタンスの bridge を誤殺しないため: issue #1024）。
                     log::warn!(
-                        "Failed to read start_time for owner pid {} of {}: {e}; skipping cleanup",
-                        parsed.owner_app_pid,
-                        path.display()
+                        "Startup orphan cleanup skipped PID file because owner identity could not be verified"
                     );
+                    report.skipped += 1;
                     continue;
                 }
             }
@@ -318,10 +386,7 @@ pub fn cleanup_orphan_processes(app_data_dir: &Path) {
         let pgid = parsed.pgid;
         let alive = unsafe { libc::killpg(pgid, 0) } == 0;
         if alive {
-            log::info!(
-                "Cleaning up orphan process group {pgid} from {}",
-                path.display()
-            );
+            log::info!("Startup orphan cleanup is terminating an orphan process group");
             unsafe {
                 libc::killpg(pgid, libc::SIGTERM);
             }
@@ -329,14 +394,31 @@ pub fn cleanup_orphan_processes(app_data_dir: &Path) {
             std::thread::sleep(std::time::Duration::from_secs(2));
             let still_alive = unsafe { libc::killpg(pgid, 0) } == 0;
             if still_alive {
-                log::warn!("Orphan process group {pgid} did not exit, sending SIGKILL");
+                log::warn!(
+                    "Startup orphan cleanup orphan process group did not exit; sending SIGKILL"
+                );
                 unsafe {
                     libc::killpg(pgid, libc::SIGKILL);
                 }
             }
+            report.processed += 1;
+            if let Err(e) = std::fs::remove_file(&path) {
+                report.failures += 1;
+                log::warn!("Failed to remove orphan PID file after process cleanup: {e}");
+            }
+        } else {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    report.processed += 1;
+                }
+                Err(e) => {
+                    report.failures += 1;
+                    log::warn!("Failed to remove stale startup orphan PID file: {e}");
+                }
+            }
         }
-        let _ = std::fs::remove_file(&path);
     }
+    report
 }
 
 #[derive(Debug, Default)]
@@ -826,14 +908,9 @@ pub(super) async fn spawn_bridge_process<R: tauri::Runtime>(
     // spec issues-1022 "Agent process environment contract": agent process 自身が
     // 自分の chat_session_id を env 経由で参照できるよう、session 固有 env を
     // pure helper 経由で組み立てて設置する。
-    // 周辺入口（agent bridge）は gateway 実装へ直接依存せず、composition root が AppState へ
-    // 配線した code usecase を取得して base 名を解決する。エラーは移行前と同じく None に倒す。
-    let base_branch = app
-        .state::<crate::adaptor::controller::state::AppState>()
-        .code_usecase
-        .resolve_effective_base_branch_name(cwd)
-        .ok()
-        .flatten();
+    // 周辺入口（agent bridge）は code usecase へ直接依存せず、composition root が注入した
+    // narrow port 経由で base 名を解決する。エラーは移行前と同じく None に倒す。
+    let base_branch = resolve_effective_base_branch_from_port(app, cwd);
     for (k, v) in session_specific_env_overrides(chat_session_id, base_branch.as_deref()) {
         cmd.env(k, v);
     }
@@ -852,6 +929,7 @@ pub(super) async fn spawn_bridge_process<R: tauri::Runtime>(
         });
     }
 
+    wait_for_startup_orphan_cleanup(app).await;
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("Failed to spawn node process: {e}"))?;
@@ -1465,6 +1543,115 @@ pub(super) fn spawn_turn_watchdog<R: tauri::Runtime>(
             }
         }
     });
+}
+
+#[cfg(test)]
+mod cleanup_gate_tests {
+    use super::{wait_for_startup_orphan_cleanup, CleanupGate};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn cleanup_gate_waits_until_open_and_releases_all_waiters() {
+        let gate = Arc::new(CleanupGate::new(false));
+        let waiter_a = {
+            let gate = Arc::clone(&gate);
+            tokio::spawn(async move {
+                gate.wait_until_open().await;
+            })
+        };
+        let waiter_b = {
+            let gate = Arc::clone(&gate);
+            tokio::spawn(async move {
+                gate.wait_until_open().await;
+            })
+        };
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!waiter_a.is_finished());
+        assert!(!waiter_b.is_finished());
+
+        gate.open();
+
+        tokio::time::timeout(Duration::from_secs(1), waiter_a)
+            .await
+            .unwrap()
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), waiter_b)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(gate.is_open());
+    }
+
+    #[tokio::test]
+    async fn cleanup_gate_open_state_returns_immediately() {
+        let gate = CleanupGate::new(true);
+
+        tokio::time::timeout(Duration::from_millis(20), gate.wait_until_open())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cleanup_gate_open_without_waiters_is_durable() {
+        let gate = CleanupGate::new(false);
+
+        gate.open();
+
+        assert!(gate.is_open());
+        tokio::time::timeout(Duration::from_millis(20), gate.wait_until_open())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn closed_managed_cleanup_gate_blocks_spawn_closure_until_open() {
+        use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+
+        let gate = Arc::new(CleanupGate::new(false));
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&gate))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let spawn_called = Arc::new(AtomicBool::new(false));
+        let spawn_called_for_task = Arc::clone(&spawn_called);
+        let app_handle = app.handle().clone();
+
+        let task = tokio::spawn(async move {
+            wait_for_startup_orphan_cleanup(&app_handle).await;
+            spawn_called_for_task.store(true, AtomicOrdering::SeqCst);
+            "spawned"
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!task.is_finished());
+        assert!(!spawn_called.load(AtomicOrdering::SeqCst));
+
+        gate.open();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result, "spawned");
+        assert!(spawn_called.load(AtomicOrdering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn unregistered_cleanup_gate_returns_immediately() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let app_handle = app.handle().clone();
+
+        tokio::time::timeout(
+            Duration::from_millis(20),
+            wait_for_startup_orphan_cleanup(&app_handle),
+        )
+        .await
+        .expect("unregistered cleanup gate must not block spawn");
+    }
 }
 
 #[cfg(test)]
@@ -2279,7 +2466,7 @@ mod moved_tests {
         use super::super::super::shared::{CLAUDE_BACKEND_ID, CODEX_BACKEND_ID};
         use super::super::{
             cleanup_orphan_processes, get_process_start_time, pids_dir, remove_pgid, save_pgid,
-            PidFileV1,
+            wait_for_startup_orphan_cleanup, CleanupGate, OrphanCleanupReport, PidFileV1,
         };
         use crate::infrastructure::agent_session::runtime::{AgentBackendRegistry, ModelInfo};
         use crate::usecase::agent_session::event_log::TurnEventLog;
@@ -2288,7 +2475,7 @@ mod moved_tests {
         use std::os::unix::process::CommandExt as _;
         use std::path::Path;
         use std::sync::Arc;
-        use std::time::Instant;
+        use std::time::{Duration, Instant};
         use tokio::sync::Mutex;
 
         /// PID belonging to a process guaranteed not to exist. PIDs on Linux
@@ -2299,6 +2486,23 @@ mod moved_tests {
         /// Helper: serialize a PidFileV1 payload to the given path.
         fn write_pid_file_v1(path: &Path, payload: &PidFileV1) {
             std::fs::write(path, serde_json::to_string(payload).unwrap()).unwrap();
+        }
+
+        #[test]
+        fn cleanup_orphan_process_logs_do_not_format_pid_file_paths_or_process_ids() {
+            let source = include_str!("recovery.rs");
+            let (_, after_start) = source
+                .split_once("pub fn cleanup_orphan_processes")
+                .expect("cleanup function source should be present");
+            let (cleanup_source, _) = after_start
+                .split_once("\npub(super) struct BridgeEofCrashTransition")
+                .expect("cleanup function end marker should be present");
+
+            assert!(!cleanup_source.contains("path.display()"));
+            assert!(!cleanup_source.contains("pid={}"));
+            assert!(!cleanup_source.contains("owner pid"));
+            assert!(!cleanup_source.contains("{pgid}"));
+            assert!(!cleanup_source.contains("Invalid PGID {}"));
         }
 
         #[test]
@@ -2372,10 +2576,19 @@ mod moved_tests {
             );
             assert!(pid_file.exists());
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
 
             // PID file should be removed
             assert!(!pid_file.exists());
+            assert_eq!(
+                report,
+                OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 1,
+                    skipped: 0,
+                    failures: 0
+                }
+            );
         }
 
         #[test]
@@ -2385,7 +2598,8 @@ mod moved_tests {
             let dir = pids_dir(app_data_dir);
             std::fs::create_dir_all(&dir).unwrap();
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
+            assert_eq!(report, OrphanCleanupReport::default());
         }
 
         #[test]
@@ -2393,7 +2607,8 @@ mod moved_tests {
             let tmp = tempfile::tempdir().unwrap();
             let app_data_dir = tmp.path().join("nonexistent");
 
-            cleanup_orphan_processes(&app_data_dir);
+            let report = cleanup_orphan_processes(&app_data_dir);
+            assert_eq!(report, OrphanCleanupReport::default());
         }
 
         #[test]
@@ -2406,9 +2621,29 @@ mod moved_tests {
             let other_file = dir.join("notes.txt");
             std::fs::write(&other_file, "not a pid").unwrap();
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
 
             assert!(other_file.exists());
+            assert_eq!(report, OrphanCleanupReport::default());
+        }
+
+        #[test]
+        fn cleanup_orphan_processes_counts_read_failure_for_pid_directory() {
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path();
+            let dir = pids_dir(app_data_dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::create_dir(dir.join("unreadable.pid")).unwrap();
+
+            let report = cleanup_orphan_processes(app_data_dir);
+
+            assert_eq!(report.scanned, 1);
+            assert_eq!(report.processed, 0);
+            assert_eq!(report.skipped, 0);
+            assert!(
+                report.failures > 0,
+                "read_to_string failure for a .pid directory must be counted"
+            );
         }
 
         /// Spawn a process in a new process group via setsid(), verify it
@@ -2521,6 +2756,82 @@ mod moved_tests {
             (child, pgid)
         }
 
+        #[tokio::test]
+        async fn cleanup_gate_blocks_new_child_until_cleanup_finishes_and_self_owned_child_survives(
+        ) {
+            use tokio::sync::oneshot;
+            use tokio::sync::oneshot::error::TryRecvError;
+
+            let tmp = tempfile::tempdir().unwrap();
+            let app_data_dir = tmp.path().to_path_buf();
+            let dir = pids_dir(&app_data_dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            write_pid_file_v1(
+                &dir.join("stale-before-spawn.pid"),
+                &PidFileV1 {
+                    version: 1,
+                    pgid: 999_999_999,
+                    owner_app_pid: DEAD_OWNER_PID,
+                    owner_start_time: 0,
+                },
+            );
+
+            let gate = Arc::new(CleanupGate::new(false));
+            let app = tauri::test::mock_builder()
+                .manage(Arc::clone(&gate))
+                .build(tauri::test::mock_context(tauri::test::noop_assets()))
+                .unwrap();
+            let app_handle = app.handle().clone();
+            let (waiting_tx, waiting_rx) = oneshot::channel();
+            let (spawned_tx, mut spawned_rx) = oneshot::channel();
+            let app_data_dir_for_spawn = app_data_dir.clone();
+
+            let task = tokio::spawn(async move {
+                let _ = waiting_tx.send(());
+                wait_for_startup_orphan_cleanup(&app_handle).await;
+                let (child, pgid) = spawn_setsid_sleep();
+                save_pgid(&app_data_dir_for_spawn, "new-child", pgid as u32).unwrap();
+                let _ = spawned_tx.send((child, pgid));
+            });
+
+            waiting_rx.await.unwrap();
+            assert!(matches!(spawned_rx.try_recv(), Err(TryRecvError::Empty)));
+            assert!(!pids_dir(&app_data_dir).join("new-child.pid").exists());
+
+            let cleanup_before_spawn = cleanup_orphan_processes(&app_data_dir);
+            assert_eq!(cleanup_before_spawn.scanned, 1);
+            assert_eq!(cleanup_before_spawn.processed, 1);
+            assert_eq!(cleanup_before_spawn.failures, 0);
+
+            gate.open();
+            let (mut child, pgid) = tokio::time::timeout(Duration::from_secs(1), spawned_rx)
+                .await
+                .unwrap()
+                .unwrap();
+            task.await.unwrap();
+
+            let cleanup_after_spawn = cleanup_orphan_processes(&app_data_dir);
+            assert_eq!(
+                cleanup_after_spawn,
+                OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 0,
+                    skipped: 1,
+                    failures: 0,
+                }
+            );
+            assert_eq!(
+                unsafe { libc::killpg(pgid, 0) },
+                0,
+                "self-owned child spawned after gate open must survive cleanup"
+            );
+
+            unsafe {
+                libc::killpg(pgid, libc::SIGKILL);
+            }
+            let _ = child.wait();
+        }
+
         #[test]
         fn cleanup_orphan_processes_kills_alive_process_group() {
             let tmp = tempfile::tempdir().unwrap();
@@ -2549,7 +2860,7 @@ mod moved_tests {
                 "process group should be alive before cleanup"
             );
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
 
             // Reap the child to clear zombie state from process table.
             // cleanup_orphan_processes sends SIGTERM/SIGKILL via killpg, but without
@@ -2562,6 +2873,15 @@ mod moved_tests {
                 "process group should be terminated after cleanup"
             );
             assert!(!pid_file.exists());
+            assert_eq!(
+                report,
+                OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 1,
+                    skipped: 0,
+                    failures: 0
+                }
+            );
         }
 
         #[test]
@@ -2594,7 +2914,7 @@ mod moved_tests {
                 },
             );
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
 
             assert!(
                 pid_file.exists(),
@@ -2604,6 +2924,15 @@ mod moved_tests {
                 unsafe { libc::killpg(pgid, 0) },
                 0,
                 "bridge process group of a live instance must not be killed"
+            );
+            assert_eq!(
+                report,
+                OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 0,
+                    skipped: 1,
+                    failures: 0
+                }
             );
 
             // Tear down the helper process so it doesn't outlive the test run.
@@ -2636,7 +2965,7 @@ mod moved_tests {
                 },
             );
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
             let _ = child.wait();
 
             assert!(!pid_file.exists());
@@ -2644,6 +2973,15 @@ mod moved_tests {
                 unsafe { libc::killpg(pgid, 0) },
                 0,
                 "stale-owner bridge group should be terminated"
+            );
+            assert_eq!(
+                report,
+                OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 1,
+                    skipped: 0,
+                    failures: 0
+                }
             );
         }
 
@@ -2661,9 +2999,18 @@ mod moved_tests {
             let pid_file = dir.join("legacy.pid");
             std::fs::write(&pid_file, "999999999").unwrap();
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
 
             assert!(pid_file.exists());
+            assert_eq!(
+                report,
+                OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 0,
+                    skipped: 1,
+                    failures: 0
+                }
+            );
         }
 
         #[test]
@@ -2685,9 +3032,18 @@ mod moved_tests {
                 },
             );
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
 
             assert!(!pid_file.exists());
+            assert_eq!(
+                report,
+                OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 1,
+                    skipped: 0,
+                    failures: 0
+                }
+            );
         }
 
         #[test]
@@ -2709,9 +3065,18 @@ mod moved_tests {
                 },
             );
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
 
             assert!(!pid_file.exists());
+            assert_eq!(
+                report,
+                OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 1,
+                    skipped: 0,
+                    failures: 0
+                }
+            );
         }
 
         #[test]
@@ -2732,9 +3097,18 @@ mod moved_tests {
                 },
             );
 
-            cleanup_orphan_processes(app_data_dir);
+            let report = cleanup_orphan_processes(app_data_dir);
 
             assert!(!pid_file.exists());
+            assert_eq!(
+                report,
+                OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 1,
+                    skipped: 0,
+                    failures: 0
+                }
+            );
         }
 
         fn make_dummy_agent_process(

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/session_lifecycle.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/session_lifecycle.rs
@@ -14,7 +14,8 @@ use super::session_persistence::{
 };
 use super::shared::{
     build_message_cmd, consolidate_parts_from_slice, fallback_prompt_message_id,
-    notify_status_transition, write_bridge_command, CLAUDE_BACKEND_ID, CODEX_BACKEND_ID,
+    notify_status_transition, resolve_mentions_or_fallback_from_port, write_bridge_command,
+    CLAUDE_BACKEND_ID, CODEX_BACKEND_ID,
 };
 use super::stream_emit::{
     emit_session_state_changed, flush_streaming_before_transition,
@@ -26,6 +27,7 @@ use super::turn_event_log::{
     projected_session_state_for_current_turn,
 };
 use crate::app_data_dir::resolve_data_dir;
+use crate::infrastructure::agent_session::resolver_ports::MentionResolverPort;
 use crate::infrastructure::agent_session::runtime::runtime_coordinator::acquire_session_runtime_lock;
 use crate::infrastructure::agent_session::runtime::runtime_coordinator::acquire_spawn_session_guard;
 use crate::infrastructure::agent_session::runtime::runtime_coordinator::clear_pending_turn_starting;
@@ -1388,10 +1390,12 @@ pub(super) async fn start_pending_message_turn<R: tauri::Runtime>(
         );
     }
 
-    let resolved_prompt = app
-        .state::<crate::adaptor::controller::state::AppState>()
-        .code_usecase
-        .resolve_mentions_or_fallback(&pending.worktree_path, &pending.content, &pending.mentions);
+    let resolved_prompt = resolve_mentions_or_fallback_from_port(
+        app,
+        &pending.worktree_path,
+        &pending.content,
+        &pending.mentions,
+    );
 
     if let Err(_e) = start_agent_turn(
         app,
@@ -1665,7 +1669,7 @@ pub(super) enum PreparedAgentRuntimeInput {
 
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn prepare_send_agent_message_internal(
-    code_usecase: &crate::usecase::code_usecase::CodeUsecase,
+    mention_resolver: &dyn MentionResolverPort,
     session_store: &Arc<SessionStore>,
     registry: &Arc<crate::infrastructure::agent_session::runtime::AgentBackendRegistry>,
     handles: &Arc<Mutex<AgentProcessMap>>,
@@ -1812,7 +1816,7 @@ pub(super) async fn prepare_send_agent_message_internal(
                 human_parts.clone(),
                 human_mentions.clone(),
             )?;
-            let resolved_prompt = code_usecase.resolve_mentions_or_fallback(
+            let resolved_prompt = mention_resolver.resolve_mentions_or_fallback(
                 &session_worktree_path,
                 &content,
                 &mentions,
@@ -1894,8 +1898,11 @@ pub(super) async fn prepare_send_agent_message_internal(
             None,
             None,
         )?;
-        let resolved_prompt =
-            code_usecase.resolve_mentions_or_fallback(&session_worktree_path, &content, &mentions);
+        let resolved_prompt = mention_resolver.resolve_mentions_or_fallback(
+            &session_worktree_path,
+            &content,
+            &mentions,
+        );
         let turn = PreparedAgentTurn {
             session_id: sid.clone(),
             backend_id: session
@@ -2039,14 +2046,14 @@ pub async fn send_agent_message_internal(
         .map(str::to_string)
         .unwrap_or_else(|| format!("new-session:{worktree_path}"));
     let data_dir = resolve_data_dir(app)?;
-    let code_usecase = Arc::clone(
-        &app.state::<crate::adaptor::controller::state::AppState>()
-            .code_usecase,
-    );
+    let mention_resolver = app
+        .try_state::<Arc<dyn MentionResolverPort>>()
+        .map(|state| state.inner().clone())
+        .ok_or_else(|| "MentionResolverPort is not registered".to_string())?;
     let (response, prepared_input) = {
         let _send_guard = acquire_session_runtime_lock(&lock_key).await;
         prepare_send_agent_message_internal(
-            &code_usecase,
+            mention_resolver.as_ref(),
             session_store,
             registry,
             handles,

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/shared.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/shared.rs
@@ -1,4 +1,7 @@
 use super::process_registry::{AgentProcessMap, BridgeState, TurnPhase};
+use crate::infrastructure::agent_session::resolver_ports::{
+    BaseBranchResolverPort, MentionResolverPort,
+};
 use crate::infrastructure::agent_session::runtime::context_restore::RestoreContextPayload;
 use crate::infrastructure::agent_session::runtime::runtime_coordinator::is_pending_turn_starting;
 use crate::infrastructure::agent_session::runtime::BackendRuntimeConfig;
@@ -373,6 +376,36 @@ pub(crate) fn session_specific_env_overrides(
         env.push(("RELEASH_BASE_BRANCH", b.to_string()));
     }
     env
+}
+
+pub(super) fn resolve_effective_base_branch_from_port<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    cwd: &str,
+) -> Option<String> {
+    let Some(resolver) = app
+        .try_state::<Arc<dyn BaseBranchResolverPort>>()
+        .map(|state| state.inner().clone())
+    else {
+        log::warn!("base branch resolver port is not registered; continuing without base branch");
+        return None;
+    };
+    resolver.resolve_effective_base_branch_name(cwd)
+}
+
+pub(super) fn resolve_mentions_or_fallback_from_port<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    worktree_path: &str,
+    content: &str,
+    mentions: &[crate::domain::code::MentionReference],
+) -> String {
+    let Some(resolver) = app
+        .try_state::<Arc<dyn MentionResolverPort>>()
+        .map(|state| state.inner().clone())
+    else {
+        log::warn!("mention resolver port is not registered; continuing without resolved mentions");
+        return content.to_string();
+    };
+    resolver.resolve_mentions_or_fallback(worktree_path, content, mentions)
 }
 
 /// ユーザー指定の system_prompt に Releash CLI の long help を append する。

--- a/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/skills.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/bridge_common/skills.rs
@@ -1,8 +1,7 @@
 use super::shared::{CLAUDE_BACKEND_ID, CODEX_BACKEND_ID};
+use crate::domain::agent_session::SkillEntry;
 use crate::infrastructure::agent_session::runtime::ImageAttachment;
 use crate::usecase::agent_session::session::validate_image_bytes;
-use serde::Deserialize;
-use serde::Serialize;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -57,14 +56,6 @@ pub(super) fn supported_commands_from_bridge_message(
             })
         })
         .collect()
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SkillEntry {
-    pub name: String,
-    pub description: String,
-    pub scope: String,
 }
 
 /// Parse SKILL.md frontmatter (delimited by `---`) and extract `name` / `description` fields.
@@ -125,7 +116,7 @@ pub(super) fn agent_skill_dirs_for_backend(
     dirs
 }
 
-pub(super) fn scan_agent_skills_inner(
+pub(crate) fn scan_agent_skills_inner(
     cwd: &Path,
     backend_id: Option<&str>,
     home: Option<PathBuf>,
@@ -153,38 +144,6 @@ pub(super) fn scan_agent_skills_inner(
         }
     }
     skills
-}
-
-pub(crate) fn filter_agent_skills_for_query(
-    skills: Vec<SkillEntry>,
-    query: Option<&str>,
-    limit: Option<usize>,
-) -> Vec<SkillEntry> {
-    let needle = query.unwrap_or_default().trim().to_lowercase();
-    let max_results = limit.unwrap_or(usize::MAX);
-    skills
-        .into_iter()
-        .filter(|skill| {
-            needle.is_empty()
-                || skill.name.to_lowercase().contains(&needle)
-                || skill.description.to_lowercase().contains(&needle)
-        })
-        .take(max_results)
-        .collect()
-}
-
-pub async fn scan_agent_skills(
-    cwd: String,
-    backend_id: Option<String>,
-    query: Option<String>,
-    limit: Option<usize>,
-) -> Result<Vec<SkillEntry>, String> {
-    let home = dirs::home_dir();
-    Ok(filter_agent_skills_for_query(
-        scan_agent_skills_inner(&PathBuf::from(cwd), backend_id.as_deref(), home),
-        query.as_deref(),
-        limit,
-    ))
 }
 
 // --- Image attachment support ---
@@ -337,59 +296,6 @@ mod moved_tests {
         assert_eq!(matches[0].scope, "personal");
         assert_eq!(matches[1].description, "Repo review");
         assert_eq!(matches[1].scope, "project");
-    }
-
-    #[tokio::test]
-    async fn scan_agent_skills_returns_project_skills() {
-        let tmp = tempfile::tempdir().unwrap();
-        let skill_dir = tmp.path().join(".claude").join("skills").join("reviewer");
-        std::fs::create_dir_all(&skill_dir).unwrap();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "---\nname: reviewer\ndescription: Review focused changes\n---\nBody",
-        )
-        .unwrap();
-
-        let result = scan_agent_skills(tmp.path().to_string_lossy().to_string(), None, None, None)
-            .await
-            .unwrap();
-
-        let skill = result.iter().find(|skill| skill.name == "reviewer");
-        assert!(skill.is_some(), "project skill should be included");
-        let skill = skill.unwrap();
-        assert_eq!(skill.description, "Review focused changes");
-        assert_eq!(skill.scope, "project");
-    }
-
-    #[test]
-    fn scan_agent_skills_filters_by_query_and_limit_in_rust() {
-        let skills = vec![
-            SkillEntry {
-                name: "review".to_string(),
-                description: "Review code changes".to_string(),
-                scope: "project".to_string(),
-            },
-            SkillEntry {
-                name: "docs".to_string(),
-                description: "Write documentation".to_string(),
-                scope: "personal".to_string(),
-            },
-            SkillEntry {
-                name: "diagram".to_string(),
-                description: "Document architecture diagrams".to_string(),
-                scope: "project".to_string(),
-            },
-        ];
-
-        let result = filter_agent_skills_for_query(skills.clone(), Some("doc"), Some(1));
-
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].name, "docs");
-
-        let result = filter_agent_skills_for_query(skills, Some("review"), Some(20));
-
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].name, "review");
     }
 
     #[test]

--- a/src-tauri/src/infrastructure/agent_session/runtime/codex.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/codex.rs
@@ -8,6 +8,7 @@ use tokio::time::{sleep, Duration};
 
 use crate::app_data_dir::resolve_data_dir;
 use crate::domain::agent_session::CODEX_FIXED_MODELS;
+use crate::infrastructure::agent_session::resolver_ports::BaseBranchResolverPort;
 use crate::infrastructure::agent_session::runtime::bridge_common::{
     close_external_agent_process, finish_external_pending_message_turn_start,
     handle_external_bridge_message, persist_context_carry_failed_after_init_error,
@@ -355,11 +356,18 @@ impl AppServerCodexRuntime {
         .map_err(|e| format!("failed to prepare alias child env for codex app-server: {e}"))?;
         let base_branch = self
             .app
-            .state::<crate::adaptor::controller::state::AppState>()
-            .code_usecase
-            .resolve_effective_base_branch_name(&config.cwd)
-            .ok()
-            .flatten();
+            .try_state::<Arc<dyn BaseBranchResolverPort>>()
+            .map(|state| {
+                state
+                    .inner()
+                    .resolve_effective_base_branch_name(&config.cwd)
+            })
+            .unwrap_or_else(|| {
+                log::warn!(
+                    "base branch resolver port is not registered; continuing without base branch"
+                );
+                None
+            });
         for (key, value) in
             session_specific_env_overrides(&config.chat_session_id, base_branch.as_deref())
         {
@@ -413,7 +421,13 @@ impl AppServerCodexRuntime {
             .filter(|value| !value.is_empty())
             .map(ToString::to_string);
 
-        let parts = spawn_app_server_process_parts(&self.cli_path, Some(&config.cwd), &child_envs)?;
+        let parts = spawn_app_server_process_parts(
+            &self.app,
+            &self.cli_path,
+            Some(&config.cwd),
+            &child_envs,
+        )
+        .await?;
         register_external_agent_process(
             &self.app,
             &self.session_store,

--- a/src-tauri/src/infrastructure/agent_session/runtime/codex_app_server.rs
+++ b/src-tauri/src/infrastructure/agent_session/runtime/codex_app_server.rs
@@ -11,6 +11,7 @@ use tokio::time::{timeout, Duration};
 use crate::infrastructure::agent_session::runtime::permission_flags::{
     codex_approval_policy_from_mode, codex_sandbox_mode_from_mode,
 };
+use crate::infrastructure::agent_session::runtime::wait_for_startup_orphan_cleanup;
 use crate::infrastructure::agent_session::runtime::{AgentEditorContext, ImageAttachment};
 use crate::permission::PermissionMode;
 
@@ -149,7 +150,7 @@ fn app_server_args() -> [&'static str; 3] {
     ["app-server", "--listen", "stdio://"]
 }
 
-pub(crate) fn spawn_app_server_process_parts(
+fn spawn_app_server_process_parts_raw(
     cli_path: &str,
     cwd: Option<&str>,
     envs: &[(String, String)],
@@ -198,6 +199,16 @@ pub(crate) fn spawn_app_server_process_parts(
         #[cfg(unix)]
         pgid,
     })
+}
+
+pub(crate) async fn spawn_app_server_process_parts<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    cli_path: &str,
+    cwd: Option<&str>,
+    envs: &[(String, String)],
+) -> Result<CodexAppServerProcessParts, String> {
+    wait_for_startup_orphan_cleanup(app).await;
+    spawn_app_server_process_parts_raw(cli_path, cwd, envs)
 }
 
 pub(crate) fn encode_jsonl(message: &Value) -> Result<Vec<u8>, String> {
@@ -1137,8 +1148,11 @@ pub(crate) fn app_server_message_to_bridge_messages(
 }
 
 impl CodexAppServerProcess {
-    pub(crate) fn spawn(cli_path: &str) -> Result<Self, String> {
-        let parts = spawn_app_server_process_parts(cli_path, None, &[])?;
+    pub(crate) async fn spawn<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+        cli_path: &str,
+    ) -> Result<Self, String> {
+        let parts = spawn_app_server_process_parts(app, cli_path, None, &[]).await?;
         Ok(Self {
             child: parts.child,
             stdin: parts.stdin,
@@ -1865,12 +1879,60 @@ mod tests {
         std::fs::set_permissions(&script, perms).unwrap();
 
         let envs = vec![("RELEASH_SESSION_ID".to_string(), "sid-xyz".to_string())];
-        let mut parts = spawn_app_server_process_parts(script.to_str().unwrap(), None, &envs)
+        let mut parts = spawn_app_server_process_parts_raw(script.to_str().unwrap(), None, &envs)
             .expect("spawn fake cli");
         parts.child.wait().await.expect("wait fake cli");
 
         let contents = std::fs::read_to_string(&out).expect("read env out");
         assert_eq!(contents.trim(), "sid-xyz");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_app_server_process_parts_waits_for_startup_orphan_cleanup_gate() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::Arc;
+
+        use crate::infrastructure::agent_session::runtime::CleanupGate;
+
+        let gate = Arc::new(CleanupGate::new(false));
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&gate))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let app_handle = app.handle().clone();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("spawned.out");
+        let script = dir.path().join("fake-cli.sh");
+        std::fs::write(
+            &script,
+            format!("#!/bin/sh\nprintf spawned > \"{}\"\n", out.display()),
+        )
+        .expect("write script");
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+        let cli_path = script.to_str().unwrap().to_string();
+
+        let task = tokio::spawn(async move {
+            spawn_app_server_process_parts(&app_handle, &cli_path, None, &[]).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!task.is_finished());
+        assert!(!out.exists());
+
+        gate.open();
+
+        let mut parts = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        parts.child.wait().await.expect("wait fake cli");
+        let contents = std::fs::read_to_string(&out).expect("read spawn out");
+        assert_eq!(contents, "spawned");
     }
 
     #[test]

--- a/src-tauri/src/infrastructure/agent_session/skill_catalog_gateway.rs
+++ b/src-tauri/src/infrastructure/agent_session/skill_catalog_gateway.rs
@@ -1,0 +1,296 @@
+use std::path::Path;
+
+use crate::domain::agent_session::{services::filter_agent_skills_for_query, SkillEntry};
+use crate::infrastructure::agent_session::runtime::codex::configured_cli_path;
+use crate::infrastructure::agent_session::runtime::codex_app_server::{
+    build_skills_list_request, CodexAppServerProcess,
+};
+use crate::infrastructure::agent_session::runtime::scan_agent_skills_inner;
+use crate::usecase::agent_session::skill_catalog::CodexSkillCatalogGateway;
+
+pub(crate) struct TauriCodexSkillCatalogGateway<R: tauri::Runtime> {
+    app: tauri::AppHandle<R>,
+}
+
+impl<R: tauri::Runtime> TauriCodexSkillCatalogGateway<R> {
+    pub(crate) fn new(app: tauri::AppHandle<R>) -> Self {
+        Self { app }
+    }
+}
+
+#[async_trait::async_trait]
+impl<R: tauri::Runtime + 'static> CodexSkillCatalogGateway for TauriCodexSkillCatalogGateway<R> {
+    async fn list_app_server_skills(
+        &self,
+        cwd: &str,
+        query: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<SkillEntry>, String> {
+        let cli_path = configured_cli_path(&self.app).unwrap_or_else(|| "codex".to_string());
+        let mut process = CodexAppServerProcess::spawn(&self.app, &cli_path).await?;
+        let result = async {
+            process.initialize(env!("CARGO_PKG_VERSION")).await?;
+            let id = process.next_request_id();
+            process
+                .send(&build_skills_list_request(id, cwd, false))
+                .await?;
+            let response = process.read_response_result(id).await?;
+            Ok(filter_agent_skills_for_query(
+                parse_codex_skill_catalog(&response),
+                query,
+                limit,
+            ))
+        }
+        .await;
+        process.shutdown().await;
+        result
+    }
+
+    async fn scan_local_skills(
+        &self,
+        cwd: &str,
+        backend_id: Option<&str>,
+        query: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<SkillEntry>, String> {
+        Ok(filter_agent_skills_for_query(
+            scan_agent_skills_inner(Path::new(cwd), backend_id, dirs::home_dir()),
+            query,
+            limit,
+        ))
+    }
+}
+
+fn codex_skill_scope(value: &str) -> String {
+    match value {
+        "user" => "personal".to_string(),
+        "repo" => "project".to_string(),
+        "system" | "admin" => value.to_string(),
+        _ => "project".to_string(),
+    }
+}
+
+fn parse_codex_skill_catalog(value: &serde_json::Value) -> Vec<SkillEntry> {
+    let mut skills = Vec::new();
+    let Some(entries) = value.get("data").and_then(serde_json::Value::as_array) else {
+        return skills;
+    };
+    for entry in entries {
+        let Some(items) = entry.get("skills").and_then(serde_json::Value::as_array) else {
+            continue;
+        };
+        for skill in items {
+            if !skill
+                .get("enabled")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true)
+            {
+                continue;
+            }
+            let Some(name) = skill
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            else {
+                continue;
+            };
+            let description = skill
+                .get("interface")
+                .and_then(|interface| interface.get("shortDescription"))
+                .and_then(serde_json::Value::as_str)
+                .or_else(|| {
+                    skill
+                        .get("shortDescription")
+                        .and_then(serde_json::Value::as_str)
+                })
+                .or_else(|| skill.get("description").and_then(serde_json::Value::as_str))
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let scope = skill
+                .get("scope")
+                .and_then(serde_json::Value::as_str)
+                .map(codex_skill_scope)
+                .unwrap_or_else(|| "project".to_string());
+            skills.push(SkillEntry {
+                name: name.to_string(),
+                description,
+                scope,
+            });
+        }
+    }
+    skills
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::agent_session::runtime::{CLAUDE_BACKEND_ID, CODEX_BACKEND_ID};
+
+    #[test]
+    fn parses_codex_skill_catalog_enabled_scopes_and_short_description() {
+        let response = serde_json::json!({
+            "data": [
+                {
+                    "cwd": "/repo",
+                    "errors": [],
+                    "skills": [
+                        {
+                            "name": "review",
+                            "description": "Long review description",
+                            "enabled": true,
+                            "path": "/repo/.agents/skills/review/SKILL.md",
+                            "scope": "repo",
+                            "shortDescription": "Review changes",
+                            "interface": { "shortDescription": "Runtime review" }
+                        },
+                        {
+                            "name": "draft",
+                            "description": "Draft docs",
+                            "enabled": true,
+                            "path": "/home/.agents/skills/draft/SKILL.md",
+                            "scope": "user",
+                            "shortDescription": null,
+                            "interface": null
+                        },
+                        {
+                            "name": "disabled",
+                            "description": "Disabled",
+                            "enabled": false,
+                            "path": "/repo/.agents/skills/disabled/SKILL.md",
+                            "scope": "repo"
+                        },
+                        {
+                            "name": "builtin",
+                            "description": "Builtin",
+                            "enabled": true,
+                            "path": "/app/skills/builtin/SKILL.md",
+                            "scope": "system"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let skills = parse_codex_skill_catalog(&response);
+
+        assert_eq!(
+            skills,
+            vec![
+                SkillEntry {
+                    name: "review".to_string(),
+                    description: "Runtime review".to_string(),
+                    scope: "project".to_string(),
+                },
+                SkillEntry {
+                    name: "draft".to_string(),
+                    description: "Draft docs".to_string(),
+                    scope: "personal".to_string(),
+                },
+                SkillEntry {
+                    name: "builtin".to_string(),
+                    description: "Builtin".to_string(),
+                    scope: "system".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn scan_agent_skills_switches_directories_by_backend() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let cwd = tmp.path().join("repo");
+        let claude_skill = cwd.join(".claude").join("skills").join("claude-review");
+        std::fs::create_dir_all(&claude_skill).unwrap();
+        std::fs::write(
+            claude_skill.join("SKILL.md"),
+            "---\nname: claude-review\ndescription: Claude review\n---\nBody",
+        )
+        .unwrap();
+        let codex_skill = cwd.join(".agents").join("skills").join("codex-review");
+        std::fs::create_dir_all(&codex_skill).unwrap();
+        std::fs::write(
+            codex_skill.join("SKILL.md"),
+            "---\nname: codex-review\ndescription: Codex review\n---\nBody",
+        )
+        .unwrap();
+
+        let claude = scan_agent_skills_inner(&cwd, Some(CLAUDE_BACKEND_ID), Some(home.clone()));
+        let codex = scan_agent_skills_inner(&cwd, Some(CODEX_BACKEND_ID), Some(home));
+
+        assert!(claude.iter().any(|skill| skill.name == "claude-review"));
+        assert!(!claude.iter().any(|skill| skill.name == "codex-review"));
+        let codex_skill = codex
+            .iter()
+            .find(|skill| skill.name == "codex-review")
+            .expect("Codex project skill should be included");
+        assert_eq!(codex_skill.scope, "project");
+        assert!(!codex.iter().any(|skill| skill.name == "claude-review"));
+    }
+
+    #[test]
+    fn scan_agent_skills_preserves_duplicate_codex_skill_names_across_scopes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let cwd = tmp.path().join("repo");
+        let personal_skill = home.join(".agents").join("skills").join("shared-review");
+        std::fs::create_dir_all(&personal_skill).unwrap();
+        std::fs::write(
+            personal_skill.join("SKILL.md"),
+            "---\nname: shared-review\ndescription: Personal review\n---\nBody",
+        )
+        .unwrap();
+        let repo_skill = cwd.join(".agents").join("skills").join("shared-review");
+        std::fs::create_dir_all(&repo_skill).unwrap();
+        std::fs::write(
+            repo_skill.join("SKILL.md"),
+            "---\nname: shared-review\ndescription: Repo review\n---\nBody",
+        )
+        .unwrap();
+
+        let codex = scan_agent_skills_inner(&cwd, Some(CODEX_BACKEND_ID), Some(home));
+
+        let matches = codex
+            .iter()
+            .filter(|skill| skill.name == "shared-review")
+            .collect::<Vec<_>>();
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].description, "Personal review");
+        assert_eq!(matches[0].scope, "personal");
+        assert_eq!(matches[1].description, "Repo review");
+        assert_eq!(matches[1].scope, "project");
+    }
+
+    #[tokio::test]
+    async fn scan_local_skills_returns_filtered_project_skills() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join(".claude").join("skills").join("reviewer");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: unique-reviewer-xyz\ndescription: Unique focused changes\n---\nBody",
+        )
+        .unwrap();
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let gateway = TauriCodexSkillCatalogGateway::new(app.handle().clone());
+
+        let result = gateway
+            .scan_local_skills(
+                tmp.path().to_string_lossy().as_ref(),
+                None,
+                Some("unique-reviewer-xyz"),
+                Some(10),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "unique-reviewer-xyz");
+        assert_eq!(result[0].description, "Unique focused changes");
+        assert_eq!(result[0].scope, "project");
+    }
+}

--- a/src-tauri/src/infrastructure/agent_session/thread_lifecycle_gateway.rs
+++ b/src-tauri/src/infrastructure/agent_session/thread_lifecycle_gateway.rs
@@ -32,24 +32,25 @@ impl CodexThreadLifecycleAppServerGateway {
 #[async_trait::async_trait]
 impl CodexThreadLifecycleGateway for CodexThreadLifecycleAppServerGateway {
     async fn archive_thread(&self, thread_id: &str) -> Result<(), String> {
-        send_codex_thread_archive_request(&self.cli_path(), thread_id, true).await
+        send_codex_thread_archive_request(&self.app, &self.cli_path(), thread_id, true).await
     }
 
     async fn unarchive_thread(&self, thread_id: &str) -> Result<(), String> {
-        send_codex_thread_archive_request(&self.cli_path(), thread_id, false).await
+        send_codex_thread_archive_request(&self.app, &self.cli_path(), thread_id, false).await
     }
 
     async fn fork_thread(&self, request: CodexThreadForkRequest) -> Result<String, String> {
-        fork_codex_thread(&self.cli_path(), request).await
+        fork_codex_thread(&self.app, &self.cli_path(), request).await
     }
 }
 
 async fn send_codex_thread_archive_request(
+    app: &tauri::AppHandle,
     cli_path: &str,
     thread_id: &str,
     archive: bool,
 ) -> Result<(), String> {
-    let mut process = CodexAppServerProcess::spawn(cli_path)?;
+    let mut process = CodexAppServerProcess::spawn(app, cli_path).await?;
     let result = async {
         process.initialize(env!("CARGO_PKG_VERSION")).await?;
         let id = process.next_request_id();
@@ -68,10 +69,11 @@ async fn send_codex_thread_archive_request(
 }
 
 async fn fork_codex_thread(
+    app: &tauri::AppHandle,
     cli_path: &str,
     request: CodexThreadForkRequest,
 ) -> Result<String, String> {
-    let mut process = CodexAppServerProcess::spawn(cli_path)?;
+    let mut process = CodexAppServerProcess::spawn(app, cli_path).await?;
     let result = async {
         process.initialize(env!("CARGO_PKG_VERSION")).await?;
         let id = process.next_request_id();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,82 @@ use domain::app_config::{
 use tauri::Manager;
 use tokio::sync::Mutex;
 
+#[cfg(all(unix, test))]
+static STARTUP_ORPHAN_CLEANUP_TELEMETRY_CALLS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+#[cfg(all(unix, test))]
+static STARTUP_ORPHAN_CLEANUP_SUCCESS_TELEMETRY_CALLS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(unix)]
+fn record_startup_orphan_cleanup(
+    report: &infrastructure::agent_session::runtime::OrphanCleanupReport,
+    failed: bool,
+) {
+    other::telemetry::record_orphan_cleanup_counts(
+        report.scanned,
+        report.processed,
+        report.skipped,
+        report.failures,
+        failed,
+    );
+    #[cfg(test)]
+    {
+        let status = other::telemetry::orphan_cleanup_status(report.failures, failed);
+        STARTUP_ORPHAN_CLEANUP_TELEMETRY_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if status == other::telemetry::orphan_cleanup_status(0, false) {
+            STARTUP_ORPHAN_CLEANUP_SUCCESS_TELEMETRY_CALLS
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn spawn_startup_orphan_cleanup<F>(
+    data_dir: std::path::PathBuf,
+    cleanup_gate: Arc<infrastructure::agent_session::runtime::CleanupGate>,
+    cleanup_fn: F,
+) where
+    F: FnOnce(&std::path::Path) -> infrastructure::agent_session::runtime::OrphanCleanupReport
+        + Send
+        + 'static,
+{
+    let thread_gate = Arc::clone(&cleanup_gate);
+    let spawn_result = std::thread::Builder::new()
+        .name("releash-startup-orphan-cleanup".to_string())
+        .spawn(move || {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                cleanup_fn(&data_dir)
+            }));
+            let (report, failed) = match result {
+                Ok(report) => (report, false),
+                Err(_) => {
+                    log::warn!("startup orphan cleanup panicked");
+                    (
+                        infrastructure::agent_session::runtime::OrphanCleanupReport::default(),
+                        true,
+                    )
+                }
+            };
+            let status = other::telemetry::orphan_cleanup_status(report.failures, failed).as_str();
+            log::info!(
+                "startup orphan cleanup finished status={status} scanned={} processed={} skipped={} failures={}",
+                report.scanned,
+                report.processed,
+                report.skipped,
+                report.failures
+            );
+            record_startup_orphan_cleanup(&report, failed);
+            thread_gate.open();
+        });
+    if let Err(e) = spawn_result {
+        let report = infrastructure::agent_session::runtime::OrphanCleanupReport::default();
+        log::warn!("failed to start startup orphan cleanup thread: {e}");
+        record_startup_orphan_cleanup(&report, true);
+        cleanup_gate.open();
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let startup_started = Instant::now();
@@ -66,6 +142,11 @@ pub fn run() {
     let prompt_suggestion_usecase = Arc::new(
         adaptor::controller::wiring::build_agent_prompt_suggestion_usecase(session_storage),
     );
+    let cleanup_gate = Arc::new(infrastructure::agent_session::runtime::CleanupGate::new(
+        !cfg!(unix),
+    ));
+    #[cfg(unix)]
+    let cleanup_gate_for_setup = Arc::clone(&cleanup_gate);
 
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -93,6 +174,7 @@ pub fn run() {
         .manage(ws_server::WsServerHandle::default())
         .manage(Arc::new(git_host::PrCache::new()))
         .manage(Arc::new(git_host::IssueCache::new()))
+        .manage(cleanup_gate)
         .manage::<adaptor::gateway::repository::repo_paths::SharedRepoPaths>(Arc::new(
             parking_lot::RwLock::new(Vec::new()),
         ))
@@ -190,7 +272,20 @@ pub fn run() {
                 ));
 
                 // code ドメインの DI 配線（gateway 実装はステートレス）。
-                let code_usecase = Arc::new(adaptor::controller::wiring::build_code_usecase());
+                let code_usecase = Arc::new(
+                    adaptor::controller::wiring::build_code_usecase_with_app(app.handle().clone()),
+                );
+                let base_branch_resolver: Arc<
+                    dyn infrastructure::agent_session::resolver_ports::BaseBranchResolverPort,
+                > = code_usecase.clone();
+                let mention_resolver: Arc<
+                    dyn infrastructure::agent_session::resolver_ports::MentionResolverPort,
+                > = code_usecase.clone();
+                app.manage(base_branch_resolver);
+                app.manage(mention_resolver);
+                let agent_session_usecase = Arc::new(
+                    adaptor::controller::wiring::build_agent_session_usecase(app.handle().clone()),
+                );
                 let repository_state =
                     Arc::new(usecase::repository_state::RepositoryStateService::new(
                         repository_usecase.clone(),
@@ -232,6 +327,7 @@ pub fn run() {
                     repo_paths_usecase,
                     code_usecase,
                     review_usecase,
+                    agent_session_usecase,
                     workflow_usecase,
                 });
             }
@@ -433,17 +529,15 @@ pub fn run() {
                 }
             }
 
-            // Clean up orphan agent processes from previous crashes.
-            // Must complete before init_agent_sessions() to prevent killing newly spawned processes.
+            // Clean up orphan agent processes from previous crashes in the background.
+            // Agent process spawn paths wait on cleanup_gate just before OS spawn.
             #[cfg(unix)]
             {
-                let data_dir_clone = data_dir.clone();
-                let _ = std::thread::spawn(move || {
-                    infrastructure::agent_session::runtime::cleanup_orphan_processes(
-                        &data_dir_clone,
-                    );
-                })
-                .join();
+                spawn_startup_orphan_cleanup(
+                    data_dir.clone(),
+                    Arc::clone(&cleanup_gate_for_setup),
+                    infrastructure::agent_session::runtime::cleanup_orphan_processes,
+                );
             }
 
             other::telemetry::record_startup_from_origin(other::telemetry::Startup::AppStartup);
@@ -505,5 +599,69 @@ mod tests {
         let handle = tokio::spawn(async { 42 });
         let result = runtime.block_on(handle).unwrap();
         assert_eq!(result, 42);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawn_startup_orphan_cleanup_is_non_blocking_and_records_after_completion() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::mpsc;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let gate = Arc::new(crate::infrastructure::agent_session::runtime::CleanupGate::new(false));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (returned_tx, returned_rx) = mpsc::channel();
+        let calls_for_cleanup = Arc::clone(&calls);
+        let gate_for_spawn = Arc::clone(&gate);
+        let data_dir_for_spawn = data_dir.path().to_path_buf();
+        let telemetry_calls_before =
+            super::STARTUP_ORPHAN_CLEANUP_TELEMETRY_CALLS.load(Ordering::SeqCst);
+        let success_calls_before =
+            super::STARTUP_ORPHAN_CLEANUP_SUCCESS_TELEMETRY_CALLS.load(Ordering::SeqCst);
+
+        std::thread::spawn(move || {
+            super::spawn_startup_orphan_cleanup(data_dir_for_spawn, gate_for_spawn, move |_| {
+                calls_for_cleanup.fetch_add(1, Ordering::SeqCst);
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                crate::infrastructure::agent_session::runtime::OrphanCleanupReport {
+                    scanned: 1,
+                    processed: 0,
+                    skipped: 0,
+                    failures: 0,
+                }
+            });
+            returned_tx.send(()).unwrap();
+        });
+
+        returned_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("startup cleanup launcher must return before cleanup finishes");
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("fake cleanup should start exactly once");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(!gate.is_open());
+
+        release_tx.send(()).unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime
+            .block_on(async {
+                tokio::time::timeout(Duration::from_secs(1), gate.wait_until_open()).await
+            })
+            .expect("cleanup completion must open the gate");
+
+        assert_eq!(
+            super::STARTUP_ORPHAN_CLEANUP_TELEMETRY_CALLS.load(Ordering::SeqCst),
+            telemetry_calls_before + 1
+        );
+        assert_eq!(
+            super::STARTUP_ORPHAN_CLEANUP_SUCCESS_TELEMETRY_CALLS.load(Ordering::SeqCst),
+            success_calls_before + 1
+        );
     }
 }

--- a/src-tauri/src/other/telemetry/attributes.rs
+++ b/src-tauri/src/other/telemetry/attributes.rs
@@ -1,5 +1,6 @@
 pub(crate) const KEY_OPERATION: &str = "releash.operation";
 pub(crate) const KEY_STATUS: &str = "releash.status";
+pub(crate) const KEY_OUTCOME: &str = "releash.outcome";
 pub(crate) const KEY_CHANNEL: &str = "releash.channel";
 pub(crate) const KEY_USAGE_EVENT: &str = "releash.usage_event";
 

--- a/src-tauri/src/other/telemetry/mod.rs
+++ b/src-tauri/src/other/telemetry/mod.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use attributes::{
     usage_event_allowed, HotPathMetric, OpStatus, PayloadChannel, StartupMetric, KEY_CHANNEL,
-    KEY_OPERATION, KEY_STATUS, KEY_USAGE_EVENT,
+    KEY_OPERATION, KEY_OUTCOME, KEY_STATUS, KEY_USAGE_EVENT,
 };
 use opentelemetry::global;
 use opentelemetry::metrics::{Counter, Histogram, ObservableGauge};
@@ -72,6 +72,7 @@ struct Metrics {
     stream_emit_interval_ms: Histogram<f64>,
     session_save_bytes: Histogram<f64>,
     operation_status: Counter<u64>,
+    orphan_cleanup: Counter<u64>,
     dropped_stream_frames: Counter<u64>,
     ws_reconnects: Counter<u64>,
     usage_events: Counter<u64>,
@@ -226,6 +227,7 @@ pub(crate) fn install_metrics() {
             .with_unit("By")
             .build(),
         operation_status: meter.u64_counter("releash.operation.status").build(),
+        orphan_cleanup: meter.u64_counter("releash.startup.orphan_cleanup").build(),
         dropped_stream_frames: meter
             .u64_counter("releash.agent_stream.dropped_frames")
             .build(),
@@ -501,6 +503,54 @@ pub(crate) fn record_startup(metric: StartupMetric, elapsed: Duration) {
         .record(elapsed.as_secs_f64() * 1000.0, &attrs);
 }
 
+pub(crate) fn orphan_cleanup_status(failures: usize, failed: bool) -> OpStatus {
+    if failed || failures > 0 {
+        OpStatus::Failure
+    } else {
+        OpStatus::Success
+    }
+}
+
+pub(crate) fn record_orphan_cleanup_counts(
+    scanned: usize,
+    processed: usize,
+    skipped: usize,
+    failures: usize,
+    failed: bool,
+) {
+    if !is_performance_active() {
+        return;
+    }
+    let status = orphan_cleanup_status(failures, failed);
+    let status_attrs = [
+        KeyValue::new(KEY_OPERATION, "startup.orphan_cleanup"),
+        KeyValue::new(KEY_STATUS, status.as_str()),
+    ];
+    #[cfg(test)]
+    record_test_metric("releash.operation.status", 1.0, &status_attrs);
+    if let Some(metrics) = METRICS.get() {
+        metrics.operation_status.add(1, &status_attrs);
+    }
+
+    for (outcome, count) in [
+        ("scanned", scanned),
+        ("processed", processed),
+        ("skipped", skipped),
+        ("failures", failures),
+    ] {
+        let attrs = [
+            KeyValue::new(KEY_OPERATION, "startup.orphan_cleanup"),
+            KeyValue::new(KEY_STATUS, status.as_str()),
+            KeyValue::new(KEY_OUTCOME, outcome),
+        ];
+        #[cfg(test)]
+        record_test_metric("releash.startup.orphan_cleanup", count as f64, &attrs);
+        if let Some(metrics) = METRICS.get() {
+            metrics.orphan_cleanup.add(count as u64, &attrs);
+        }
+    }
+}
+
 pub(crate) fn record_usage_event(name: &str) {
     if !is_performance_active() || !usage_event_allowed(name) {
         return;
@@ -623,6 +673,82 @@ mod tests {
                 && has_attr(record, KEY_USAGE_EVENT, "settings_saved")
         }));
         reset_test_metrics();
+    }
+
+    #[test]
+    fn record_orphan_cleanup_captures_safe_counts_and_status() {
+        let _guard = lock_test_telemetry();
+        reset_test_metrics();
+        set_active(true);
+
+        record_orphan_cleanup_counts(3, 2, 1, 0, false);
+
+        let status_records = records_named("releash.operation.status");
+        assert!(status_records.iter().any(|record| {
+            has_attr(record, KEY_OPERATION, "startup.orphan_cleanup")
+                && has_attr(record, KEY_STATUS, "success")
+        }));
+
+        let cleanup_records = records_named("releash.startup.orphan_cleanup");
+        assert_eq!(cleanup_records.len(), 4);
+        assert!(cleanup_records.iter().any(|record| {
+            record.value == 3.0
+                && has_attr(record, KEY_OUTCOME, "scanned")
+                && has_attr(record, KEY_STATUS, "success")
+        }));
+        assert!(cleanup_records.iter().any(|record| {
+            record.value == 2.0
+                && has_attr(record, KEY_OUTCOME, "processed")
+                && has_attr(record, KEY_STATUS, "success")
+        }));
+        assert!(cleanup_records.iter().any(|record| {
+            record.value == 1.0
+                && has_attr(record, KEY_OUTCOME, "skipped")
+                && has_attr(record, KEY_STATUS, "success")
+        }));
+        assert!(cleanup_records.iter().any(|record| {
+            record.value == 0.0
+                && has_attr(record, KEY_OUTCOME, "failures")
+                && has_attr(record, KEY_STATUS, "success")
+        }));
+        for record in cleanup_records {
+            let keys: Vec<_> = record
+                .attributes
+                .iter()
+                .map(|(key, _)| key.as_str())
+                .collect();
+            assert_eq!(
+                keys,
+                vec![KEY_OPERATION, KEY_STATUS, KEY_OUTCOME],
+                "orphan cleanup telemetry must contain only safe metadata"
+            );
+        }
+        reset_test_metrics();
+    }
+
+    #[test]
+    fn record_orphan_cleanup_marks_failure_on_failures_or_panic_flag() {
+        let _guard = lock_test_telemetry();
+        reset_test_metrics();
+        set_active(true);
+
+        record_orphan_cleanup_counts(1, 0, 0, 1, false);
+        record_orphan_cleanup_counts(0, 0, 0, 0, true);
+
+        let status_records = records_named("releash.operation.status");
+        assert_eq!(status_records.len(), 2);
+        assert!(status_records.iter().all(|record| {
+            has_attr(record, KEY_OPERATION, "startup.orphan_cleanup")
+                && has_attr(record, KEY_STATUS, "failure")
+        }));
+        reset_test_metrics();
+    }
+
+    #[test]
+    fn orphan_cleanup_status_marks_failures_and_success() {
+        assert_eq!(orphan_cleanup_status(1, false), OpStatus::Failure);
+        assert_eq!(orphan_cleanup_status(0, true), OpStatus::Failure);
+        assert_eq!(orphan_cleanup_status(0, false), OpStatus::Success);
     }
 
     #[test]

--- a/src-tauri/src/usecase/agent_session/mod.rs
+++ b/src-tauri/src/usecase/agent_session/mod.rs
@@ -1,3 +1,6 @@
 pub(crate) mod event_log;
 pub(crate) mod session;
+pub(crate) mod skill_catalog;
 pub(crate) mod status;
+
+pub(crate) use skill_catalog::AgentSessionUsecase;

--- a/src-tauri/src/usecase/agent_session/skill_catalog.rs
+++ b/src-tauri/src/usecase/agent_session/skill_catalog.rs
@@ -1,0 +1,155 @@
+use std::sync::Arc;
+
+use crate::domain::agent_session::SkillEntry;
+
+const CODEX_BACKEND_ID: &str = "codex";
+
+#[async_trait::async_trait]
+pub(crate) trait CodexSkillCatalogGateway: Send + Sync {
+    async fn list_app_server_skills(
+        &self,
+        cwd: &str,
+        query: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<SkillEntry>, String>;
+
+    async fn scan_local_skills(
+        &self,
+        cwd: &str,
+        backend_id: Option<&str>,
+        query: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<SkillEntry>, String>;
+}
+
+#[derive(Clone)]
+pub(crate) struct AgentSessionUsecase {
+    skill_catalog: Arc<dyn CodexSkillCatalogGateway>,
+}
+
+impl AgentSessionUsecase {
+    pub(crate) fn new(skill_catalog: Arc<dyn CodexSkillCatalogGateway>) -> Self {
+        Self { skill_catalog }
+    }
+
+    pub(crate) async fn scan_agent_skills(
+        &self,
+        cwd: String,
+        backend_id: Option<String>,
+        query: Option<String>,
+        limit: Option<usize>,
+    ) -> Result<Vec<SkillEntry>, String> {
+        self.skill_catalog
+            .scan_local_skills(&cwd, backend_id.as_deref(), query.as_deref(), limit)
+            .await
+    }
+
+    pub(crate) async fn read_codex_skill_catalog(
+        &self,
+        cwd: String,
+        query: Option<String>,
+        limit: Option<usize>,
+    ) -> Result<Vec<SkillEntry>, String> {
+        match self
+            .skill_catalog
+            .list_app_server_skills(&cwd, query.as_deref(), limit)
+            .await
+        {
+            Ok(skills) => Ok(skills),
+            Err(_) => {
+                self.skill_catalog
+                    .scan_local_skills(&cwd, Some(CODEX_BACKEND_ID), query.as_deref(), limit)
+                    .await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct FakeSkillCatalogGateway {
+        app_server_result: Mutex<Option<Result<Vec<SkillEntry>, String>>>,
+        scan_result: Mutex<Result<Vec<SkillEntry>, String>>,
+        scan_backend_ids: Mutex<Vec<Option<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl CodexSkillCatalogGateway for FakeSkillCatalogGateway {
+        async fn list_app_server_skills(
+            &self,
+            _cwd: &str,
+            _query: Option<&str>,
+            _limit: Option<usize>,
+        ) -> Result<Vec<SkillEntry>, String> {
+            self.app_server_result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or_else(|| Ok(Vec::new()))
+        }
+
+        async fn scan_local_skills(
+            &self,
+            _cwd: &str,
+            backend_id: Option<&str>,
+            _query: Option<&str>,
+            _limit: Option<usize>,
+        ) -> Result<Vec<SkillEntry>, String> {
+            self.scan_backend_ids
+                .lock()
+                .unwrap()
+                .push(backend_id.map(ToString::to_string));
+            self.scan_result.lock().unwrap().clone()
+        }
+    }
+
+    fn skill(name: &str) -> SkillEntry {
+        SkillEntry {
+            name: name.to_string(),
+            description: format!("{name} description"),
+            scope: "project".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_codex_skill_catalog_returns_app_server_skills() {
+        let gateway = Arc::new(FakeSkillCatalogGateway {
+            app_server_result: Mutex::new(Some(Ok(vec![skill("review")]))),
+            scan_result: Mutex::new(Ok(vec![skill("fallback")])),
+            scan_backend_ids: Mutex::new(Vec::new()),
+        });
+        let usecase = AgentSessionUsecase::new(gateway.clone());
+
+        let result = usecase
+            .read_codex_skill_catalog("/repo".to_string(), None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result, vec![skill("review")]);
+        assert!(gateway.scan_backend_ids.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_codex_skill_catalog_falls_back_to_local_codex_scan() {
+        let gateway = Arc::new(FakeSkillCatalogGateway {
+            app_server_result: Mutex::new(Some(Err("app-server unavailable".to_string()))),
+            scan_result: Mutex::new(Ok(vec![skill("fallback")])),
+            scan_backend_ids: Mutex::new(Vec::new()),
+        });
+        let usecase = AgentSessionUsecase::new(gateway.clone());
+
+        let result = usecase
+            .read_codex_skill_catalog("/repo".to_string(), Some("fall".to_string()), Some(10))
+            .await
+            .unwrap();
+
+        assert_eq!(result, vec![skill("fallback")]);
+        assert_eq!(
+            gateway.scan_backend_ids.lock().unwrap().as_slice(),
+            &[Some(CODEX_BACKEND_ID.to_string())]
+        );
+    }
+}

--- a/src-tauri/src/usecase/code_query_service.rs
+++ b/src-tauri/src/usecase/code_query_service.rs
@@ -37,6 +37,16 @@ pub trait BranchDiffQuery: Send + Sync {
     ) -> Result<BranchDiffSummaryDto, crate::domain::code::CodeError>;
 }
 
+#[async_trait::async_trait]
+pub trait CodexFuzzyFileSearchGateway: Send + Sync {
+    async fn search_files(
+        &self,
+        worktree_path: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<String>, crate::domain::code::CodeError>;
+}
+
 /// read model 構築・純粋算出を担う読み取りクエリサービス。
 #[derive(Clone)]
 pub struct CodeQueryService {
@@ -45,6 +55,7 @@ pub struct CodeQueryService {
     branch_diff: Arc<dyn BranchDiffQuery>,
     mention: Arc<dyn MentionRepository>,
     branch_base: Arc<dyn BranchBaseResolver>,
+    codex_fuzzy_file_search: Arc<dyn CodexFuzzyFileSearchGateway>,
 }
 
 impl CodeQueryService {
@@ -54,6 +65,7 @@ impl CodeQueryService {
         branch_diff: Arc<dyn BranchDiffQuery>,
         mention: Arc<dyn MentionRepository>,
         branch_base: Arc<dyn BranchBaseResolver>,
+        codex_fuzzy_file_search: Arc<dyn CodexFuzzyFileSearchGateway>,
     ) -> Self {
         Self {
             file_content,
@@ -61,6 +73,7 @@ impl CodeQueryService {
             branch_diff,
             mention,
             branch_base,
+            codex_fuzzy_file_search,
         }
     }
 
@@ -346,6 +359,18 @@ impl CodeQueryService {
         Ok(self.mention.list_mentionable_files(worktree_path, query)?)
     }
 
+    pub async fn read_codex_mentionable_files(
+        &self,
+        worktree_path: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<String>, CodeUsecaseError> {
+        Ok(self
+            .codex_fuzzy_file_search
+            .search_files(worktree_path, query, limit)
+            .await?)
+    }
+
     /// 構造化メンション参照を解決し file_context を前置する。失敗時のフォールバック方針は
     /// 呼び出し元（`CodeUsecase`）が決めるため、ここでは解決結果／エラーをそのまま返す。
     pub fn resolve_mentions(
@@ -597,6 +622,19 @@ mod code_query_service_tests {
         }
     }
 
+    struct FakeCodexFuzzyFileSearch;
+    #[async_trait::async_trait]
+    impl CodexFuzzyFileSearchGateway for FakeCodexFuzzyFileSearch {
+        async fn search_files(
+            &self,
+            _worktree_path: &str,
+            _query: &str,
+            _limit: usize,
+        ) -> Result<Vec<String>, CodeError> {
+            Ok(vec!["src/main.rs".to_string()])
+        }
+    }
+
     fn service() -> CodeQueryService {
         CodeQueryService::new(
             Arc::new(FakeFileContent),
@@ -604,6 +642,7 @@ mod code_query_service_tests {
             Arc::new(FakeBranchDiff),
             Arc::new(FakeMention),
             Arc::new(FakeBranchBase),
+            Arc::new(FakeCodexFuzzyFileSearch),
         )
     }
 

--- a/src-tauri/src/usecase/code_usecase.rs
+++ b/src-tauri/src/usecase/code_usecase.rs
@@ -319,6 +319,17 @@ impl CodeUsecase {
         self.query.list_mentionable_files(worktree_path, query)
     }
 
+    pub async fn read_codex_mentionable_files(
+        &self,
+        worktree_path: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<String>, CodeUsecaseError> {
+        self.query
+            .read_codex_mentionable_files(worktree_path, query, limit)
+            .await
+    }
+
     /// 構造化メンション参照を解決し file_context を本文先頭へ前置する。メンションが空、
     /// または解決失敗時は警告ログを出して本文をそのまま返す（移行前のフォールバック挙動を維持）。
     pub fn resolve_mentions_or_fallback(
@@ -345,7 +356,7 @@ mod code_usecase_tests {
     use crate::domain::code::{
         BranchBaseResolver, CodeError, DiffComputer, FileContentRepository, MentionRepository,
     };
-    use crate::usecase::code_query_service::BranchDiffQuery;
+    use crate::usecase::code_query_service::{BranchDiffQuery, CodexFuzzyFileSearchGateway};
     use std::sync::Mutex;
 
     struct RecordingStaging {
@@ -669,6 +680,19 @@ mod code_usecase_tests {
         }
     }
 
+    struct StubCodexFuzzyFileSearch;
+    #[async_trait::async_trait]
+    impl CodexFuzzyFileSearchGateway for StubCodexFuzzyFileSearch {
+        async fn search_files(
+            &self,
+            _worktree_path: &str,
+            _query: &str,
+            _limit: usize,
+        ) -> Result<Vec<String>, CodeError> {
+            Ok(vec!["src/main.rs".to_string()])
+        }
+    }
+
     fn usecase(staging: Arc<RecordingStaging>) -> CodeUsecase {
         let query = CodeQueryService::new(
             Arc::new(StubFileContent),
@@ -676,6 +700,7 @@ mod code_usecase_tests {
             Arc::new(StubBranchDiff),
             Arc::new(StubMention),
             Arc::new(StubBranchBase),
+            Arc::new(StubCodexFuzzyFileSearch),
         );
         CodeUsecase::new(staging, query, Arc::new(StubBlobUrls))
     }
@@ -687,6 +712,7 @@ mod code_usecase_tests {
             Arc::new(StubBranchDiff),
             Arc::new(StubMention),
             Arc::new(StubBranchBase),
+            Arc::new(StubCodexFuzzyFileSearch),
         );
         CodeUsecase::new(
             Arc::new(RecordingStaging {
@@ -707,6 +733,7 @@ mod code_usecase_tests {
             Arc::new(StubBranchDiff),
             mention,
             Arc::new(StubBranchBase),
+            Arc::new(StubCodexFuzzyFileSearch),
         );
         CodeUsecase::new(
             Arc::new(RecordingStaging {
@@ -812,6 +839,21 @@ mod code_usecase_tests {
         }
 
         assert_eq!(file_content.calls(), expected_calls);
+    }
+
+    #[tokio::test]
+    async fn read_codex_mentionable_files_delegates_to_fuzzy_gateway() {
+        let staging = Arc::new(RecordingStaging {
+            calls: Mutex::new(Vec::new()),
+        });
+        let uc = usecase(staging);
+
+        let files = uc
+            .read_codex_mentionable_files("/repo", "main", 50)
+            .await
+            .unwrap();
+
+        assert_eq!(files, vec!["src/main.rs"]);
     }
 
     // ── mention 参照解決のフォールバック挙動（usecase 層の責務）──


### PR DESCRIPTION
## 概要

agent startup の orphan cleanup を non-blocking 化し、skill catalog / fuzzy file search gateway を追加します（#1216）。

## 変更内容

- orphan cleanup を setup の blocking join から外し、background task 化
- cleanup と新規 spawn の誤 kill 防止を Rust service の ordering 機構で保証
- cleanup の実行状態・失敗・対象数を safe metadata として telemetry / 構造化ログに公開
- skill catalog / fuzzy file search gateway を追加

## Spec

- `docs/specs/issues-1216/requirements.md`
- `docs/specs/issues-1216/behavior.md`
- `docs/specs/issues-1216/design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
