### PR TITLE
feat(code): hunk stage/unstage を id-based 化し snapshot_version ガードを廃止 (#1212)

### DIFF
--- a/docs/specs/issues-1212/behavior.md
+++ b/docs/specs/issues-1212/behavior.md
@@ -1,0 +1,137 @@
+# Behavior
+
+Issue: #1212 「Hunk operation を id-based にし frontend patch 再生成を削除する」
+
+本書は `requirements.md` の要求 R1〜R5・決定事項 D1〜D3 を、実装詳細を含まない外部観測可能な振る舞いとして Gherkin で定義する。実装経路（snapshot 再計算の内部手順、patch 文字列の構築方法、id 生成アルゴリズム等）は対象外であり design で扱う。
+
+## 仮定
+
+requirements の仮定および本書作成時に置いた仮定。design で確定すべき詳細は振る舞いに持ち込まない。
+
+- **A1**: 安定 id は hunk / group の「内容」に紐づく値であり、同一内容を指す限り snapshot 再計算後も同じ値を返す。生成規則の詳細は design で確定する（本書は「同一内容なら同一 id・別内容なら別 id」という観測可能性のみを規定する）。
+- **A2**: stage / unstage は id + intent を渡す id-based operation 単一経路へ収束し、位置 index / `snapshot_version` を渡す旧経路は提供しない。コマンド命名・移行手順は design で確定する。
+- **A3**: 操作対象の語彙は既存を踏襲する。base は `head` / `branch-base`、section は `changes` / `staged`。本書ではこれらを所与とする。
+
+---
+
+```gherkin
+Feature: id-based な hunk / group の stage / unstage
+
+  レビュー（diff 表示）画面で、変更の一部（change group）を staged / unstage する操作を、
+  位置や snapshot version に依存しない安定 id で指定できるようにする。
+  file refresh をまたいでも、同一内容の対象は同じ id で指し続けられ、
+  対象が消失した場合は誤った範囲を適用せず安全に失敗する。
+
+  Background:
+    Given デスクトップアプリでリポジトリのレビュー画面を開いている
+    And 対象ファイルの text diff の read model が取得できている
+    And base は "head" を選択している
+
+  # --- R1: 安定 id の付与 ---
+
+  Rule: text diff の read model は各 hunk / change group に安定 id を含む
+
+    Scenario: read model が hunk_id と group_id を含む
+      When 対象ファイルの text diff を取得する
+      Then 各 hunk は安定 id（hunk_id）を持つ
+      And 各 change group は安定 id（group_id）を持つ
+
+    Scenario: 同一内容の対象は file refresh をまたいで同じ id を返す
+      Given ある change group の group_id を取得している
+      When 当該 change group の内容を変えずに snapshot を再計算（file refresh）する
+      Then 同じ change group は同じ group_id で取得できる
+
+    Scenario: 内容が異なる対象は異なる id を返す
+      Given ある change group の group_id を取得している
+      When 当該箇所の内容が変わった状態で snapshot を再計算する
+      Then 変化後の change group は元と異なる group_id になる
+
+  # --- R2 / D3: id + intent による stage / unstage ---
+
+  Rule: stage / unstage は対象 id と intent のみで実行する
+
+    Scenario: changes 区画の change group を id 指定で stage する
+      Given section は "changes" を選択している
+      And ある change group の group_id を取得している
+      When その group_id と intent=stage を指定して操作する
+      Then 当該 change group の範囲だけが staged になる
+      And version（snapshot_version）を渡さずに操作が成立する
+
+    Scenario: staged 区画の change group を id 指定で unstage する
+      Given section は "staged" を選択している
+      And staged の change group の group_id を取得している
+      When その group_id と intent=unstage を指定して操作する
+      Then 当該 change group の範囲だけが unstage される
+      And version（snapshot_version）を渡さずに操作が成立する
+
+    Scenario: 操作粒度は change group 単位を維持する
+      When stage / unstage を実行する
+      Then 操作の最小単位は change group であり
+      And hunk 全体を一括 stage する新規操作は提供されない
+
+  # --- 制約: branch-base では group / hunk 単位 stage / unstage を提供しない ---
+
+  Rule: group / hunk 単位の stage / unstage は head ベースのみ対象とする
+
+    Scenario: branch-base での id 指定 stage はエラーになる
+      Given base は "branch-base" を選択している
+      When change group を id 指定で stage しようとする
+      Then 操作はエラーになり
+      And staged の状態は変化しない
+
+  # --- R4: staged をベースにした安全な適用 ---
+
+  Rule: patch は staged 状態をベースに適用し、ベース不一致を起こさない
+
+    Scenario: 連続した stage 操作が staged の進行に追随する
+      Given section は "changes" の change group が複数ある
+      When 1 つ目の change group を stage する
+      And 続けて別の change group を stage する
+      Then いずれの操作も適用に失敗せず
+      And それぞれの change group の範囲だけが staged に反映される
+
+  # --- R5 / D2: file refresh 後の stable id の扱い ---
+
+  Rule: 解決できない id は誤適用せずエラーを返し、frontend が回復する
+
+    Scenario: 同一内容なら過去に払い出した id が引き続き有効
+      Given ある change group の group_id を取得している
+      And 内容を変えずに file refresh が発生した
+      When その group_id と intent を指定して操作する
+      Then 当該 change group に対して操作が成立する
+
+    Scenario: 対象が消失した id はエラーになり何も適用されない
+      Given ある change group の group_id を取得している
+      And file refresh により当該 change group が消失した（内容が変わって該当しなくなった）
+      When その group_id と intent を指定して操作する
+      Then 操作はエラーになり
+      And staged / unstage の状態は変化しない
+
+    Scenario: 解決失敗を frontend が捕捉して snapshot を refresh する
+      Given id 解決失敗のエラーが返る状況にある
+      When frontend がその操作を実行する
+      Then エラーは握りつぶされず捕捉され
+      And snapshot の refresh（または再取得の促し）が行われる
+
+  # --- R3: frontend からの patch generation 排除 ---
+
+  Rule: frontend は patch を生成せず id + intent のみを渡す
+
+    Scenario: frontend が stage / unstage で渡すのは id + intent と座標語彙のみ
+      When frontend が stage / unstage を実行する
+      Then frontend は full content から patch 文字列を生成しない
+      And frontend が渡すのは worktree / path / section / base / 対象 id / intent に限られる
+      And 位置 index と snapshot_version は渡さない
+```
+
+---
+
+## 主要観点の対応
+
+- 正常系: changes での stage / staged での unstage（id + intent、version なし）。
+- 異常系: branch-base 拒否、id 解決失敗時のエラーと no-op、frontend のエラー捕捉 + refresh。
+- 境界条件: file refresh をまたいだ id の安定性（同一内容で有効・消失で失敗）、連続 stage における staged ベース追随。
+
+## Open Questions
+
+なし（requirements の D1〜D3 で前提が確定しているため、振る舞いレベルの未確定事項はない。id 生成規則・コマンド命名・旧経路の死コード除去可否は design で確定する事項であり、観測可能な振る舞いには影響しない）。

--- a/docs/specs/issues-1212/design.md
+++ b/docs/specs/issues-1212/design.md
@@ -1,0 +1,233 @@
+# Design
+
+Issue: #1212 「Hunk operation を id-based にし frontend patch 再生成を削除する」
+
+本書は `requirements.md`（R1〜R5 / D1〜D3 / A1〜A2）と `behavior.md` の Gherkin を、実装方針・責務分割・データ構造・エラー処理・テスト方針として具体化する。requirements の仮定 A1（id 生成規則）/ A2（コマンド命名・移行）を本書で確定する。
+
+## 概要
+
+stage / unstage の対象指定を、位置依存の `group_index` + `snapshot_version` ガードから、**内容に紐づく安定 id（`hunk_id` / `group_id`）+ intent** へ置き換える。Rust 側は受け取った id を「現在の snapshot 上で再計算した change group 群」に解決し、解決できた場合のみ staged をベースに patch を再構築して `git apply --cached` で適用する。解決できなければ何も適用せずエラーを返す。frontend はそのエラーを捕捉して snapshot を refresh する。
+
+これにより、
+
+- read model（`ReviewTextDiffDto`）は file refresh をまたいで安定する id を返す（R1）。
+- frontend は `group_index` / `snapshot_version` を一切持ち回らず、id + intent + 座標語彙のみを渡す（R2 / R3 / D1）。
+- 整合性は version ガードではなく「id を現在 snapshot に解決できるか」で担保する（R4 / D1）。
+- 解決失敗は安全な no-op + エラー（R5 / D2）。
+
+## 変更対象
+
+### Rust（`src-tauri/src/`）
+
+| ファイル | 変更内容 |
+|---|---|
+| `domain/code/value_objects/hunk.rs` / `domain/code/services/hunk.rs` | `Hunk` に `hunk_id`、`ChangeGroup` に `group_id` を追加。id 算出純粋関数（`compute_hunk_id` / `compute_group_id`）と、review 操作で変化しない side の全文に対する occurrence で `group_id` を再付与する helper を新設。 |
+| `usecase/code_dto.rs` | `HunkDto` に `hunk_id`、`ChangeGroupDto` に `group_id` を追加。`hunk_to_dto` / `change_group_to_dto` / `hunk_dto_to_domain` / `change_group_dto_to_domain` の往復で id を維持。 |
+| `usecase/review_usecase.rs` | `generate_review_group_patch` を `group_index: u32` 引数から `group_id: &str` 引数へ変更し、`change_groups.iter().find(|g| g.group_id == group_id)` で解決。解決失敗時は専用エラー。`git_stage_review_group` / `git_unstage_review_group` のシグネチャを id ベースへ変更し `snapshot_version` 引数と `ensure_current_review_snapshot_version` 呼び出しを除去。 |
+| `usecase/review_usecase.rs` | `ensure_current_review_snapshot_version` を削除（D1）。 |
+| `adaptor/protocol/code.rs` | `ReviewGroupActionInput` から `group_index` / `snapshot_version` を除去し `group_id: String` を追加。 |
+| `adaptor/controller/command/code/review.rs` | `git_stage_review_group` / `git_unstage_review_group` コマンドの input マッピングを id ベースへ変更。コマンド名は据え置き（後述）。 |
+| `adaptor/controller/command/code/staging.rs` | patch 文字列を受け取る Tauri コマンド `git_stage_hunk` / `git_unstage_hunk` を**削除**（死コード確認済み。後述）。コマンド登録（`invoke_handler`）からも除去。 |
+
+### Frontend（`src/`）
+
+| ファイル | 変更内容 |
+|---|---|
+| `components/panels/useDiffOperations.ts` | `snapshotVersion` パラメータを除去。`applyGroupAction(command, groupIndex)` を `applyGroupAction(command, groupId)` へ変更し、input から `groupIndex` / `snapshotVersion` を除き `groupId` を渡す。`catch` の握りつぶしを解消し、解決失敗エラー時に snapshot refresh をトリガーする（後述）。 |
+| `components/panels/ReviewPanel.tsx` | `useDiffOperations` への `snapshotVersion` 受け渡しを除去。stage / unstage ハンドラへ渡す引数を `group_id` 由来へ変更。 |
+| `hooks/useGitActions.ts` | 死コードの `stageHunk` / `unstageHunk` を**削除**。 |
+| `types/`（該当 diff 型） | `ChangeGroup` / `Hunk` の TS 型に `groupId` / `hunkId` を追加（read model 表示用）。 |
+
+## アーキテクチャと責務分割
+
+レイヤー責務（`src-tauri/CLAUDE.md` の clean architecture）を踏襲する。
+
+- **domain（`hunk.rs`）**: id の算出は純粋計算。snapshot / git / I/O に依存しない。`Hunk` / `ChangeGroup` 値オブジェクトに id フィールドを持たせる。通常の `compute_change_groups` は diff 内容 hash を付与し、review 操作用の stable id は呼び出し元が渡す original / modified と stable side に基づいて再付与する。
+- **usecase（`review_usecase.rs`）**: 「id → 現在 snapshot 上の change group 解決 → patch 再構築 → 適用」の業務手順。version ガードは持たない。`changes` は modified/working tree 側、`staged` は original/HEAD 側を stable side として group id を生成する。
+- **adaptor/controller（`review.rs` / `protocol/code.rs`）**: frontend 境界の DTO（`ReviewGroupActionInput`）を id ベースへ。
+- **frontend（`useDiffOperations` / `ReviewPanel`）**: invoke と、解決失敗時の refresh ハンドリングのみ。patch 生成・座標/version 持ち回りを持たない。
+
+## データモデルまたは型
+
+### 安定 id の生成規則（A1 の確定）
+
+**決定: id は「対象の diff 内容」に紐づく content hash とし、同一内容が同一ファイル内に複数ある場合は出現順 ordinal で曖昧性を排除する。位置（行番号 / オフセット / `group_index`）は id に含めない。**
+
+理由:
+
+- behavior「同一内容なら同じ id・別内容なら別 id」を満たす最小条件は内容由来であること。
+- 位置を含めると、connected な連続 stage（behavior「連続した stage 操作が staged の進行に追随する」）で、先行操作により後続対象の行位置がずれた際に id が不一致になり解決失敗する。位置非依存にすることで、内容が変わらない限り refresh をまたいでも解決できる。
+- 解決時の patch 再構築に必要な位置情報は、解決先の「現在 snapshot 上で再計算した change group / hunk」から取得する。id は「どの group か」を指すだけで、位置は持たない。
+
+具体規則（domain の純粋関数）:
+
+- `compute_group_id(hunk, group, occurrence) -> String`:
+  - 対象 change group の diff 行（`hunk.lines[line_offset_start..=line_offset_end]`、prefix `+` / `-` / ` ` を含む生の行）に加え、境界 context（`GROUP_CONTEXT_RADIUS=1` の前後 context 行）を identity hash 入力へ含める。
+  - 境界 context を含める理由は、純削除 group は Modified/working 側に自身の行が射影されず、純挿入 group は Original 側に自身の行が射影されないため。context なしでは stable side occurrence の needle が空になり、現在残っている集合に依存する fallback occurrence に落ちてしまう。前後 context を identity に含めることで、挿入/削除だけの group も stable side の全文に anchor できる。
+  - 同一ファイル内で content が衝突する場合に備え、同一 content の出現順 `occurrence`（0 始まり）を加える。review 操作では、この occurrence は「現在残っている change group 集合」ではなく、操作で変化しない side の全文に現れる side-projected identity の出現順とする。`changes` は modified/working tree 側、`staged` は original/HEAD 側を使う。
+  - 形式（仮）: `g:{hex(hash(content))}:{occurrence}`。ハッシュは標準ライブラリの `std::hash`/`DefaultHasher` ではなく、安定性のため SHA-256 等の決定的ハッシュを用いる（プロセス間・version 間で安定する必要があるため。`DefaultHasher` は seed が安定する保証がないので不可）。依存追加可否は実装時に既存 `Cargo.toml` を確認し、既存クレートで賄えない場合は最小の決定的ハッシュ実装を `domain` 内に閉じる（仮定 A3）。
+- `compute_hunk_id(hunk, occurrence) -> String`:
+  - hunk の全 `lines` を改行連結したものをハッシュ入力とし、同一 content 出現順 `occurrence` を付す。
+  - 形式（仮）: `h:{hex(hash(content))}:{occurrence}`。
+- 通常の diff 計算では `compute_change_groups` / hunk 列挙の走査中に同一 content の出現回数をカウントして割り当てる。review 操作の read model / id 解決では、先に stage/unstage された同一局所 pattern が change group 集合から消えても後続 group の id が変わらないよう、stable side の全文に対する occurrence で再付与する。
+
+### 型定義の変更
+
+`domain/code/value_objects/hunk.rs`:
+
+```rust
+pub struct Hunk {
+    pub index: u32,
+    pub hunk_id: String,   // 追加
+    pub old_start: u32,
+    pub old_lines: u32,
+    pub new_start: u32,
+    pub new_lines: u32,
+    pub lines: Vec<String>,
+}
+
+pub struct ChangeGroup {
+    pub group_index: u32,  // 表示・整列用に残置（requirements S1）
+    pub group_id: String,  // 追加
+    pub hunk_index: u32,
+    pub new_start: u32,
+    pub new_end: u32,
+    pub line_offset_start: u32,
+    pub line_offset_end: u32,
+    pub is_staged: Option<bool>,
+}
+```
+
+`usecase/code_dto.rs`（serde camelCase）:
+
+```rust
+pub struct HunkDto {
+    pub index: u32,
+    pub hunk_id: String,        // camelCase: hunkId
+    // ...既存...
+}
+
+pub struct ChangeGroupDto {
+    pub group_index: u32,       // 残置
+    pub group_id: String,       // camelCase: groupId
+    pub hunk_index: u32,
+    // ...既存...
+}
+```
+
+`adaptor/protocol/code.rs`（frontend 境界）:
+
+```rust
+pub struct ReviewGroupActionInput {
+    pub worktree_path: String,
+    pub path: String,
+    pub section: String,
+    pub base: String,
+    pub group_id: String,   // group_index / snapshot_version を置換
+}
+```
+
+### コマンド命名と移行（A2 の確定）
+
+**決定: Tauri コマンド名は既存の `git_stage_review_group` / `git_unstage_review_group` を据え置き、引数（input DTO）のみを id ベースへ置き換える（並存させない）。**
+
+理由:
+
+- Issue 記載の `stage_hunk_by_id` / `unstage_hunk_by_id` は「id ベースにする」という意図の表現であり、コマンド名そのものの指定ではない。既存コマンドは既に review group 単位（= change group 単位、D3）で動作しており、命名 `*_review_group` は粒度として正確。
+- 改名は frontend invoke 文字列・コマンド登録・テストの広範な置換を生み、振る舞い不変のリネームは本 Issue の本質（id 化）と無関係なノイズになる。
+- 「id ベース operation」という意味は input の `group_id` で表現され、外部観測上 version / index を渡さないことで満たされる。
+
+> 別案として新コマンド `stage_review_group_by_id` を追加し旧コマンドを deprecated にする案もあるが、requirements D1（version ガード完全廃止・並存させない）に反するため採らない。
+
+### 死コードの扱い（S4 の確定）
+
+調査により以下が判明:
+
+- frontend `useGitActions.stageHunk` / `unstageHunk`（patch 文字列を `git_stage_hunk` / `git_unstage_hunk` へ渡す）は **呼び出し元なし（テスト除く）= 死コード**。→ 本 Issue で削除する。
+- Tauri コマンド `git_stage_hunk` / `git_unstage_hunk`（`staging.rs`、patch 文字列引数）は frontend からの上記経路のみが呼び元 = **死コード**。→ コマンド定義と `invoke_handler` 登録から削除する。
+- ただし usecase / gateway の `code.git_stage_hunk(worktree_path, &patch)`（`adaptor/gateway/code/staging.rs` の `git apply --cached`）は **id ベースの新経路が内部で利用し続ける**ため残置する。
+
+削除対象は「patch 文字列を frontend から直接受ける Tauri コマンドと frontend ラッパ」に限定し、内部 gateway の patch 適用は維持する。
+
+## 処理フロー
+
+### read model 取得（R1）
+
+1. `review_text_view`（`review_usecase.rs`）が snapshot から original / modified を select し `compute_diff_hunks` を呼ぶ。
+2. `compute_change_groups`（domain）が hunk / group 列挙時に `compute_hunk_id` / `compute_group_id` を計算し、review read model では `changes` / `staged` の stable side に基づいて `group_id` を再付与する。
+3. `ReviewTextDiffDto.hunks[].hunk_id` / `.change_groups[].group_id` として frontend へ返る。
+
+### id ベース stage / unstage（R2 / R4 / D1）
+
+1. frontend `useDiffOperations.applyGroupAction(command, groupId)` が `invoke(command, { input: { worktreePath, path, section, base, groupId } })`。
+2. controller が `ReviewGroupActionInput`（id ベース）を受け、usecase `git_stage_review_group(worktree, path, section, base, group_id)` を呼ぶ。
+3. usecase: `snapshot(worktree)` を取得（version ガードなし）。`generate_review_group_patch(..., group_id, snapshot)` を呼ぶ。
+4. `generate_review_group_patch`:
+   - branch-base なら従来どおり Rule エラー（behavior「branch-base での id 指定 stage はエラー」）。
+   - snapshot から original / modified を select し `compute_diff_hunks` で再計算。
+   - `change_groups.iter().find(|g| g.group_id == group_id)` で解決。**見つからなければ「id 解決失敗」エラー**（後述の専用エラー、D2）。
+   - 解決した group の `hunk_index` から hunk を引き、`generate_group_patch` で staged ベースの patch を再構築。
+5. usecase が `code.git_stage_hunk` / `code.git_unstage_hunk`（`git apply --cached` / `--reverse`）で適用。
+6. 成功時 frontend は `onGitChanged`（refresh）。
+
+### 解決失敗時の回復（R5 / D2）
+
+1. usecase が「id 解決失敗」エラーを返す。
+2. controller がエラーを `AppError` として frontend へ伝播。
+3. `useDiffOperations` の `catch` がエラー種別を判定し、**snapshot refresh をトリガー**（`onGitChanged` ないし専用の refresh コールバック）。握りつぶし（`console.error` のみ）はしない。
+
+## エラー処理
+
+- **branch-base 非対応**: 既存どおり `CodeError::Rule("review group actions are not available for branch-base diffs")`。挙動不変。
+- **id 解決失敗**（対象 group が現在 snapshot 上に存在しない）: 専用バリアントを用意する。既存は `CodeError::Rule` の文字列だが、frontend が「refresh で回復すべき失敗」と「それ以外」を区別できるよう、識別可能なエラーにする。
+  - 案: `CodeError` に `ReviewTargetStale`（または `ReviewGroupNotFound`）バリアントを追加し、`AppError` へのマッピングで安定した error code / kind を持たせる。frontend は code/kind で判定して refresh する。
+  - これにより behavior「解決失敗を frontend が捕捉して snapshot を refresh する」を、文字列マッチに頼らず満たす（仮定 A4: error code の表現方法は既存 `AppError` 整形に合わせて実装時確定）。
+- **適用失敗**（`git apply --cached` 失敗）: 既存どおり stderr を Rule エラーで返す。staged 状態は git 側で原子的に未適用（behavior「staged の状態は変化しない」）。
+- いずれも patch を適用する前に解決・branch-base 判定を行うため、エラー時に部分適用は発生しない（no-op 保証）。
+
+## テスト方針
+
+### Rust 単体（各 module 内 `#[cfg(test)]`）
+
+- **domain `hunk.rs`**:
+  - `compute_group_id` / `compute_hunk_id`: 同一内容 → 同一 id、別内容 → 別 id。
+  - 同一内容 group が複数 → occurrence で別 id になり衝突しない。
+  - 位置（new_start / old_start）だけが違い内容が同じ → 同一 id（位置非依存の確認、連続 stage 追随の根拠）。
+- **usecase `review_usecase.rs`**:
+  - id ベース `generate_review_group_patch`: 既存 group_index ベーステストを id ベースへ移行し、正しい group を解決して patch を生成すること。
+  - 解決失敗（存在しない group_id）→ 専用エラー、patch 未生成。
+  - branch-base → Rule エラー（挙動不変）。
+  - file refresh をまたいだ安定性: 同一内容で再計算後も同一 id で解決できる / 内容変更後は別 id になり旧 id は解決失敗（R5・behavior の同名 Scenario）。
+  - 連続 stage: changes に複数 group があるとき、1 つ目を stage 後に 2 つ目を旧 read model の id で stage しても解決・適用成功（staged ベース追随、`git apply --cached` ベース不一致なし。R4・受け入れ基準）。
+- **protocol `code.rs`**: `ReviewGroupActionInput` が `groupId` を camelCase で受理し、`group_index` / `snapshot_version` を含まないこと。
+
+### frontend（Vitest、Tauri invoke は `vi.mock`）
+
+- `useDiffOperations`: stage / unstage で invoke する input が `{ worktreePath, path, section, base, groupId }` のみ（`groupIndex` / `snapshotVersion` を含まない）であること（R3・behavior「frontend が渡すのは … に限られる」）。
+- 解決失敗エラーを受けたとき refresh がトリガーされ、握りつぶされないこと（D2・behavior「解決失敗を frontend が捕捉して snapshot を refresh する」）。
+
+### 回帰
+
+- 死コード削除後に `pnpm build` / `cargo clippy -D warnings` が通る（未使用警告も含む）。
+- 既存の group 単位 stage / unstage の振る舞い（changes で stage / staged で unstage / 粒度は change group）が id ベースで維持される（D3）。
+
+CI と同一コマンド（`pnpm lint` / `pnpm test` / `pnpm build`、`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`）で検証する。
+
+## リスクと代替案
+
+- **R1: content hash の衝突**。異なる内容が同一ハッシュになると誤解決する。SHA-256 等の十分な空間のハッシュを用い、さらに occurrence で同一ファイル内の同一内容を区別するため、実用上の誤解決は無視できる。代替: 内容 + 旧位置を含めるとより一意だが、連続 stage で位置がずれ解決失敗するため不採用（前述）。
+- **R2: 連続操作で内容が同一の別箇所がある場合の occurrence ずれ**。先行 stage / unstage で同一内容 group の集合が変化すると、現在の change group 集合だけを数えた occurrence はずれ得る。このため review 操作では `changes` は modified/working tree 側、`staged` は original/HEAD 側の全文に対する occurrence を使い、surviving group 集合に依存しないようにする。対象そのものが消失した場合は D2 の stale エラーで回復する。
+- **R3: 決定的ハッシュの依存追加**。`std` の `DefaultHasher` は version/プロセス間安定性が保証されないため使えない。既存依存に SHA 系があれば再利用、なければ最小実装を domain に閉じる（A3）。
+- **R4: error 種別の表現**。frontend が refresh すべき失敗を判別するためのエラー識別子は、既存 `AppError` 整形方式に依存（A4）。文字列マッチに退行させない。
+
+## 仮定
+
+requirements の A1 / A2 は本書で確定（id = 位置非依存の content hash + stable side occurrence、コマンド名据え置きで input のみ id 化）。本書で追加した仮定:
+
+- **A3**: 安定ハッシュは決定的アルゴリズム（SHA-256 等）を用いる。クレート選定は実装時に既存 `Cargo.toml` を確認し、最小追加または domain 内実装に閉じる。
+- **A4**: id 解決失敗エラーは frontend が判別可能な識別子（error code / kind）を持つ。具体的表現は既存 `AppError` / presenter の整形方式に合わせて実装時確定する。
+- **A5**: `group_index` / `index` / `hunk_index` は表示・整列用に read model へ残す（requirements S1）。stage / unstage の対象特定にはこれらを使わない。
+
+## Open Questions
+
+なし（requirements D1〜D3 で前提確定、A1 / A2 を本書で確定、残差 A3〜A5 は外部観測可能な振る舞いに影響しない実装内決定のため Open Question にしない）。

--- a/docs/specs/issues-1212/design.md
+++ b/docs/specs/issues-1212/design.md
@@ -208,7 +208,7 @@ pub struct ReviewGroupActionInput {
 
 ### 回帰
 
-- 死コード削除後に `pnpm build` / `cargo clippy -D warnings` が通る（未使用警告も含む）。
+- 死コード削除後に `pnpm build` / `cargo clippy -- -D warnings` が通る（未使用警告も含む）。
 - 既存の group 単位 stage / unstage の振る舞い（changes で stage / staged で unstage / 粒度は change group）が id ベースで維持される（D3）。
 
 CI と同一コマンド（`pnpm lint` / `pnpm test` / `pnpm build`、`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`）で検証する。

--- a/docs/specs/issues-1212/requirements.md
+++ b/docs/specs/issues-1212/requirements.md
@@ -1,0 +1,128 @@
+# Requirements
+
+Issue: #1212 「Hunk operation を id-based にし frontend patch 再生成を削除する」
+
+関連: #1211（ReviewSnapshot / ReviewFileView の追加・本 Issue の直接の前提・マージ済み commit `efdb90cf`）/ #1210（RepositoryStateService / versioned snapshot 基盤）/ #767 / #805 / `docs/releash-performance-architecture-audit.md` M1（正本ドキュメント, commit `b0c5e4c2`, マイルストーン: 性能・メモリ効率改善, 実装順 4-3）
+
+## Type
+
+リファクタリング / 性能・メモリ効率改善。マイルストーン M1「Git / Diff hot path を Rust read model に寄せる」の項目 4（`stage_hunk_by_id` / `unstage_hunk_by_id` を追加し、frontend から full content と patch generation を外す）。Issue コメントの実装順「4-3」に位置づけられ、#1211 で stable な file view / hunk が返るようになったことを前提に、stage / unstage を **id-based operation** へ変える仕上げ。
+
+## 背景と目的
+
+`docs/releash-performance-architecture-audit.md` M1 の結論にあるとおり、レビュー（diff 表示）経路の問題は「frontend が working tree を直接読み、diff 基準選択 / tree 化 / image base64 化 / patch generation 準備まで持っている」設計の広がりにある。本 Issue は、その最後に残る **hunk 単位 stage / unstage の patch 生成経路** を id-based に整理する。
+
+#1211 のマージにより、現状は既に次の状態にある（実装確認済み）。
+
+- frontend の full content based な patch 文字列生成（`generatePatch` 等）は撤去済みで、`src/lib/` に patch 生成関数は存在しない。
+- hunk / group 単位の stage / unstage は `useDiffOperations` 経由で Rust コマンド `git_stage_review_group` / `git_unstage_review_group` を呼ぶ。frontend が渡すのは `worktreePath` / `path` / `section` / `base` / `groupIndex` / `snapshotVersion` のみ。
+- Rust 側（`review_usecase::generate_review_group_patch`）が versioned snapshot を基に original / modified を select し、`compute_diff_hunks` で hunk / change group を再計算して patch を組み立て、`git apply --cached`（`git_stage_hunk` / `git_unstage_hunk`）で適用する。
+
+しかし、対象 hunk / group の指定が **位置依存の `group_index`（`ChangeGroupDto.group_index`）** であり、整合性は **`snapshot_version` ガード**（`ensure_current_review_snapshot_version`）に依存している。このため次の課題が残る。
+
+- `group_index` は snapshot を再計算するたびに意味が変わりうる位置 index であり、file refresh をまたいで安定しない。
+- frontend が version を持ち回り、snapshot が更新されると in-flight / 連続操作が version 不一致で弾かれる（Issue 受け入れ基準「file refresh 後も stable id の扱いが明確」を満たさない）。
+
+本 Issue の目的は、ReviewFileView / ReviewSnapshot が **安定した `hunk_id` / `group_id`** を返すようにし、stage / unstage を **id + intent だけ**を渡す id-based operation（`stage_hunk_by_id` / `unstage_hunk_by_id`）に置き換え、Rust 側が staged をベースに patch を再構築する構成へ収束させること。これにより file refresh をまたいだ stable id の扱いを明確にし、frontend から patch generation の痕跡（位置・version 持ち回り）を完全に外す。
+
+## 合意済みの前提
+
+- 本 Issue は #1211（ReviewSnapshot / ReviewFileView）と #1210（RepositoryStateService / versioned snapshot）が先行して存在することを前提とする（Issue コメント「順序 4-1 → 4-2 → 4-3」、#1211 はマージ済み）。
+- 対象は **デスクトップアプリのレビュー（diff 表示）経路**であり、ロジックは Rust（Tauri コマンド）に実装し frontend は表示・入力受付・invoke に徹する（`.claude/rules/rust-first-logic.md`）。
+- 既存の diff 基準語彙 `DiffBase`（`branch-base` | `head`）と区画語彙 `DiffSection`（`changes` | `staged`）を踏襲し、語彙そのものは変更しない。
+- group / hunk 単位の stage / unstage は `branch-base` では提供しない（現状 `generate_review_group_patch` が branch-base を拒否しているのを踏襲）。`head` ベースの `changes` / `staged` 区画のみ対象。
+- patch の適用は `git apply --cached` を用い、patch のベースは Staged 状態とする（`CLAUDE.md` の既知制約・現行 `git_stage_hunk` 実装を踏襲）。
+
+## スコープ
+
+### S1. ReviewFileView / ReviewSnapshot の read model に安定 id を追加する
+
+- text diff の read model（`ReviewTextDiffDto` の `hunks` / `change_groups`）に、対象 hunk / change group を一意に指す安定 id（`hunk_id` / `group_id`）を含める。
+- id は、同一内容の hunk / group を指す限り file refresh（snapshot 再計算）をまたいで安定する値とする。生成規則の詳細（内容ハッシュか、ファイル内オフセット由来か等）は design で確定する（仮定 A1）。
+- 既存の位置 index（`HunkDto.index` / `ChangeGroupDto.group_index` / `hunk_index`）は表示・整列用途として残してよいが、stage / unstage の対象特定には id を用いる。
+
+### S2. id-based の stage / unstage コマンドを追加する
+
+- 対象 hunk / change group を **id + intent（stage / unstage）** で指定する id-based operation を Rust の Tauri コマンドとして提供する。Issue 記載の `stage_hunk_by_id` / `unstage_hunk_by_id` に相当する。
+- 既存の `git_stage_review_group` / `git_unstage_review_group`（`group_index` + `snapshot_version` ベース）からの移行方法（置き換えか追加か、コマンド命名）は design で確定する（仮定 A2）。
+- frontend からは worktree / path / section / base / 対象 id / intent のみを渡す。位置 index と `snapshot_version` の持ち回りをやめる（決定事項 D1）。
+
+### S3. Rust 側で staged をベースに patch を再構築する
+
+- 対象 id から、現在の snapshot 上の change group を解決し、original / modified を select して patch を再構築する。
+- patch の適用ベースは Staged 状態とし、`git apply --cached` のベース不一致を起こさない（既知制約の踏襲）。
+- `snapshot_version` ガード（`ensure_current_review_snapshot_version`）は廃止し、整合性は対象 id を現在の snapshot 上の change group に解決できるか否かで担保する（決定事項 D1）。
+- 対象 id が現在の snapshot 上に解決できない（内容が変わって該当 group が消失した等）場合は、誤った範囲を stage / unstage せず **エラーを返す**。frontend はそれを捕捉し snapshot を refresh する（または再取得を促す）（決定事項 D2）。
+
+### S4. frontend から patch generation の痕跡を外す
+
+- frontend は id-based コマンドを invoke するだけにし、位置 index / `snapshot_version` の持ち回りを `useDiffOperations` から除去する。
+- id 解決失敗のエラーを `useDiffOperations`（または呼び出し元）で捕捉し、snapshot を refresh する（または再取得を促す）ハンドリングを追加する。現状の `catch (e) { console.error }` による握りつぶしのままにしない（決定事項 D2）。
+- `useGitActions` に残る patch 文字列を受け取る旧経路（`git_stage_hunk` / `git_unstage_hunk` を patch 引数で叩く `stageHunk` / `unstageHunk`）が未使用であれば撤去対象とする（design で死コード確認の上、本 Issue で除去するかを確定）。
+
+## 非スコープ
+
+- ReviewSnapshot / ReviewFileView 本体の追加（#1211 の範囲。本 Issue は既存 read model への id 付与と stage / unstage 経路の変更に限定）。
+- RepositoryStateService 本体（watcher / scan 集約 / versioned snapshot / debounce / cancel-supersede）の変更（#1210 の範囲）。
+- `DiffBase` / `DiffSection` の意味・選択肢そのものの変更。
+- `branch-base` での hunk / group 単位 stage / unstage の新規提供。
+- ファイル単位の stage / unstage（`git_stage` / `git_unstage`）の変更。
+- image / binary / large-file fallback の表示方式（#1211 の範囲）。
+- レビューコメント機能、検索、tokenization 表示そのものの仕様変更。
+- WebSocket（remote_access）経路への id-based stage / unstage の展開。
+- 性能数値の目標値設定・計測（#1209 / M0 の範囲）。
+
+## 要求事項
+
+### R1. 安定 id の付与
+
+- text diff の read model が、各 hunk / change group に対し file refresh をまたいで安定する id（`hunk_id` / `group_id`）を含むこと。
+- id は同一内容の hunk / group を指す限り、snapshot の再計算後も同じ値を返すこと。
+
+### R2. id-based stage / unstage コマンド
+
+- 対象を id + intent で指定して stage / unstage を行う Tauri コマンドを提供すること（`stage_hunk_by_id` / `unstage_hunk_by_id` 相当）。
+- frontend が渡す対象指定は安定 id とし、位置 index および `snapshot_version` による指定に依存しないこと（D1）。
+- 操作粒度は現行 UI の change group 単位を維持すること。hunk 全体単位の新規 stage 操作は追加しないこと（D3）。
+
+### R3. frontend の patch generation 排除
+
+- frontend が full content based の patch 文字列を生成しないこと（#1211 で既に達成済みの状態を維持し、本 Issue で id-based へ移行後も退行させないこと）。
+- frontend が stage / unstage のために渡すのは id + intent（および worktree / path / section / base）に限られること。
+
+### R4. staged ベースでの patch 再構築
+
+- Rust 側が対象 id から現在の staged 状態をベースに patch を再構築し、`git apply --cached` のベース不一致を起こさないこと。
+- 対象 id が現在の snapshot 上に存在しない場合に、誤った範囲を stage / unstage しないこと。
+
+### R5. file refresh 後の stable id の扱いの明確化
+
+- file refresh（snapshot 更新）後に、過去に払い出した id がどう扱われるか（同一内容なら有効、消失なら安全に失敗）が定義され、テストで担保されていること。
+
+## 受け入れ基準の概要
+
+- frontend の full content based patch generation が存在せず、stage / unstage が id + intent のみで実行できる（Issue 受け入れ基準）。
+- `git apply --cached` のベース不一致を避けることを確認するテストがある（Issue 受け入れ基準）。
+- file refresh 後の stable id の扱い（同一内容なら有効 / 消失時はエラー）がテストで担保されている（Issue 受け入れ基準、D2）。
+- `snapshot_version` ガードが廃止され、frontend が version を渡さずに stage / unstage できる（D1）。
+- id 解決失敗時に Rust がエラーを返し、frontend が refresh して回復できる（D2）。
+- 既存の group 単位 stage / unstage の振る舞い（`changes` で stage、`staged` で unstage、`branch-base` 非対応、操作粒度は change group 単位）が id-based でも維持される（D3）。
+
+## 仮定
+
+task とリポジトリ内の情報から置いた仮定。design で確定すべきものは Open Questions に分離する。
+
+- **A1**: 安定 id は、内容ハッシュ等によりファイル内の hunk / group 内容に紐づく値とし、snapshot 再計算後も同一内容なら同じ id を返す。生成規則の詳細（内容ハッシュかオフセット由来か等）は design で確定する。
+- **A2**: 新コマンドは Issue 記載の `stage_hunk_by_id` / `unstage_hunk_by_id` を基本名とし、既存の `git_stage_review_group` / `git_unstage_review_group` を id-based に置き換える（並存させない）。コマンド命名・移行手順の詳細は design で確定する。
+
+## 決定事項
+
+Open Questions は人間との確認により以下のとおり解消済み。
+
+- **D1**: id-based 化に伴い `snapshot_version` ガード（`ensure_current_review_snapshot_version`）を**完全に廃止**する。整合性は対象 id を現在の snapshot 上の change group に解決できるか否かで担保し、frontend は version を一切持ち回らない（id + intent のみ）。
+- **D2**: 対象 id が現在の snapshot 上に解決できない場合は、誤った範囲を適用せず **Rust がエラーを返す**。frontend はそのエラーを捕捉し、snapshot を refresh する（または再取得を促す）ハンドリングを本 Issue のスコープに含める。現状の握りつぶし（`catch` で `console.error` のみ）のままにしない。
+- **D3**: stage / unstage の操作粒度は現行 UI の **change group 単位を維持**する。`hunk_id` と `group_id` の双方に安定 id を払い出すが、hunk 全体単位の新規 stage 操作は追加しない。
+
+## Open Questions
+
+なし（D1〜D3 で解消済み）。

--- a/src-tauri/src/adaptor/controller/command/code/hunk.rs
+++ b/src-tauri/src/adaptor/controller/command/code/hunk.rs
@@ -4,37 +4,9 @@ use tauri::State;
 
 use super::run_blocking;
 use crate::adaptor::controller::state::AppState;
-use crate::adaptor::protocol::code::{ChangeGroupInput, HunkInput};
+use crate::adaptor::protocol::code::HunkInput;
 use crate::other::AppError;
-use crate::usecase::code_dto::{DiffHunksResultDto, HiddenRangeDto, VisibleBlockDto};
-
-#[tauri::command]
-pub async fn compute_diff_hunks(
-    state: State<'_, AppState>,
-    original: String,
-    modified: String,
-    file_path: Option<String>,
-) -> Result<DiffHunksResultDto, AppError> {
-    let uc = state.code_usecase.clone();
-    run_blocking(move || Ok(uc.compute_diff_hunks(&original, &modified, file_path.as_deref())))
-        .await
-}
-
-#[tauri::command]
-pub async fn generate_group_patch(
-    state: State<'_, AppState>,
-    file_path: String,
-    hunk: HunkInput,
-    group: ChangeGroupInput,
-) -> Result<String, AppError> {
-    let uc = state.code_usecase.clone();
-    run_blocking(move || {
-        let hunk = hunk.into_domain();
-        let group = group.into_domain();
-        Ok(uc.generate_group_patch(&file_path, &hunk, &group))
-    })
-    .await
-}
+use crate::usecase::code_dto::{HiddenRangeDto, VisibleBlockDto};
 
 #[tauri::command]
 pub async fn compute_hidden_ranges(

--- a/src-tauri/src/adaptor/controller/command/code/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/code/mod.rs
@@ -13,15 +13,25 @@ pub(crate) mod review;
 pub(crate) mod review_blob;
 pub(crate) mod staging;
 
+use crate::domain::code::CodeError;
 use crate::other::AppError;
 use crate::usecase::code_error::CodeUsecaseError;
 
+const STALE_REVIEW_GROUP_TARGET_ERROR_CODE: &str = "STALE_REVIEW_GROUP_TARGET";
+
 /// ユースケースエラー → アプリエラーの集約変換（adaptor 層が担う）。
 /// `#[error(transparent)]` な `CodeUsecaseError` の `Display` を保持するため、
-/// serialize 表現は移行前（`GitError` のプレーン文字列）と等価に保たれる。
+/// 通常エラーの serialize 表現は移行前（`GitError` のプレーン文字列）と等価に保たれる。
+/// frontend が回復判断を必要とする stale review group だけ機械可読 code を付ける。
 impl From<CodeUsecaseError> for AppError {
     fn from(e: CodeUsecaseError) -> Self {
-        AppError::Internal(e.to_string())
+        let message = e.to_string();
+        match &e {
+            CodeUsecaseError::Code(CodeError::StaleReviewGroupTarget { .. }) => {
+                AppError::coded(STALE_REVIEW_GROUP_TARGET_ERROR_CODE, message)
+            }
+            _ => AppError::Internal(message),
+        }
     }
 }
 
@@ -62,5 +72,22 @@ mod tests {
         let app_err = AppError::from(usecase_err);
         assert_eq!(app_err.to_string(), "git2 boom");
         assert_eq!(serde_json::to_string(&app_err).unwrap(), "\"git2 boom\"");
+    }
+
+    #[test]
+    fn stale_review_group_targetは機械可読codeを持つerrorとして返す() {
+        let usecase_err = CodeUsecaseError::Code(CodeError::StaleReviewGroupTarget {
+            group_id: "g:old:0".to_string(),
+        });
+        let app_err = AppError::from(usecase_err);
+
+        assert_eq!(app_err.to_string(), "review group target stale: g:old:0");
+        assert_eq!(
+            serde_json::to_value(&app_err).unwrap(),
+            serde_json::json!({
+                "code": STALE_REVIEW_GROUP_TARGET_ERROR_CODE,
+                "message": "review group target stale: g:old:0"
+            })
+        );
     }
 }

--- a/src-tauri/src/adaptor/controller/command/code/review.rs
+++ b/src-tauri/src/adaptor/controller/command/code/review.rs
@@ -57,8 +57,7 @@ pub async fn git_stage_review_group(
             &input.path,
             &input.section,
             &input.base,
-            input.group_index,
-            input.snapshot_version,
+            &input.group_id,
         )
     })
     .await
@@ -76,8 +75,7 @@ pub async fn git_unstage_review_group(
             &input.path,
             &input.section,
             &input.base,
-            input.group_index,
-            input.snapshot_version,
+            &input.group_id,
         )
     })
     .await

--- a/src-tauri/src/adaptor/controller/command/code/staging.rs
+++ b/src-tauri/src/adaptor/controller/command/code/staging.rs
@@ -25,23 +25,3 @@ pub async fn git_unstage(
     let uc = state.code_usecase.clone();
     run_blocking(move || uc.git_unstage(&repo_path, paths)).await
 }
-
-#[tauri::command]
-pub async fn git_stage_hunk(
-    state: State<'_, AppState>,
-    repo_path: String,
-    patch: String,
-) -> Result<(), AppError> {
-    let uc = state.code_usecase.clone();
-    run_blocking(move || uc.git_stage_hunk(&repo_path, &patch)).await
-}
-
-#[tauri::command]
-pub async fn git_unstage_hunk(
-    state: State<'_, AppState>,
-    repo_path: String,
-    patch: String,
-) -> Result<(), AppError> {
-    let uc = state.code_usecase.clone();
-    run_blocking(move || uc.git_unstage_hunk(&repo_path, &patch)).await
-}

--- a/src-tauri/src/adaptor/controller/command/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/mod.rs
@@ -83,11 +83,9 @@ pub(crate) fn register_all(builder: tauri::Builder<tauri::Wry>) -> tauri::Builde
             crate::adaptor::controller::command::code::diff::get_head_diff_file_tree_snapshot,
             crate::adaptor::controller::command::code::diff::get_file_navigation,
             // Git: hunk/patch（code ドメイン）
-            crate::adaptor::controller::command::code::hunk::compute_diff_hunks,
             crate::adaptor::controller::command::code::hunk::compute_hidden_ranges,
             crate::adaptor::controller::command::code::hunk::compute_hidden_ranges_from_content,
             crate::adaptor::controller::command::code::hunk::compute_visible_markdown_blocks,
-            crate::adaptor::controller::command::code::hunk::generate_group_patch,
             crate::adaptor::controller::command::code::language::get_language_from_path,
             crate::adaptor::controller::command::code::diff::get_relative_path,
             // Git: ブランチ（repository ドメイン）
@@ -105,8 +103,6 @@ pub(crate) fn register_all(builder: tauri::Builder<tauri::Wry>) -> tauri::Builde
             // Git: ステージング（code ドメイン）
             crate::adaptor::controller::command::code::staging::git_stage,
             crate::adaptor::controller::command::code::staging::git_unstage,
-            crate::adaptor::controller::command::code::staging::git_stage_hunk,
-            crate::adaptor::controller::command::code::staging::git_unstage_hunk,
             // Git: ワークツリー（repository ドメイン）
             crate::adaptor::controller::command::repository::worktree::get_main_repo_path,
             crate::adaptor::controller::command::repository::worktree::get_worktree_dirty_count,

--- a/src-tauri/src/adaptor/gateway/code/diff_compute.rs
+++ b/src-tauri/src/adaptor/gateway/code/diff_compute.rs
@@ -49,6 +49,7 @@ pub(crate) fn diff_buffers(original: &str, modified: &str, file_path: Option<&st
 
             hunks.push(Hunk {
                 index: hunk_idx as u32,
+                hunk_id: String::new(),
                 old_start: hdr.old_start(),
                 old_lines: hdr.old_lines(),
                 new_start: hdr.new_start(),
@@ -75,7 +76,6 @@ mod diff_compute_gateway_tests {
     use super::*;
     use crate::domain::code::services::hunk::{
         compute_change_groups, compute_hidden_ranges, compute_visible_markdown_blocks,
-        mark_staged_groups,
     };
 
     // ── diff_buffers（git2 diff） ──
@@ -167,55 +167,6 @@ mod diff_compute_gateway_tests {
         assert_eq!(groups.len(), 2);
         assert_eq!(groups[0].group_index, 0);
         assert_eq!(groups[1].group_index, 1);
-    }
-
-    // ── mark_staged_groups（実 diff から hunk を生成） ──
-
-    #[test]
-    fn test_staged判定_部分staged() {
-        let head = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\n";
-        let working = head.replace("b\n", "B\n").replace("r\n", "R\n");
-        let staged = head.replace("b\n", "B\n");
-
-        let wt_hunks = diff_buffers(head, &working, None);
-        let wt_cg = compute_change_groups(&wt_hunks);
-        let st_hunks = diff_buffers(head, &staged, None);
-        let st_cg = compute_change_groups(&st_hunks);
-
-        let result = mark_staged_groups(&wt_cg, &st_cg, &wt_hunks, &st_hunks);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].is_staged, Some(true));
-        assert_eq!(result[1].is_staged, Some(false));
-    }
-
-    #[test]
-    fn test_staged判定_全staged() {
-        let head = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\n";
-        let working = head.replace("b\n", "B\n");
-
-        let wt_hunks = diff_buffers(head, &working, None);
-        let wt_cg = compute_change_groups(&wt_hunks);
-        let st_hunks = diff_buffers(head, &working, None);
-        let st_cg = compute_change_groups(&st_hunks);
-
-        let result = mark_staged_groups(&wt_cg, &st_cg, &wt_hunks, &st_hunks);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].is_staged, Some(true));
-    }
-
-    #[test]
-    fn test_staged判定_全unstaged() {
-        let head = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\n";
-        let working = head.replace("b\n", "B\n");
-
-        let wt_hunks = diff_buffers(head, &working, None);
-        let wt_cg = compute_change_groups(&wt_hunks);
-        let st_hunks = diff_buffers(head, head, None);
-        let st_cg = compute_change_groups(&st_hunks);
-
-        let result = mark_staged_groups(&wt_cg, &st_cg, &wt_hunks, &st_hunks);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].is_staged, Some(false));
     }
 
     // ── hidden ranges from content（diff_buffers + 純粋算出） ──

--- a/src-tauri/src/adaptor/gateway/code/staging.rs
+++ b/src-tauri/src/adaptor/gateway/code/staging.rs
@@ -195,9 +195,36 @@ impl StagingRepository for StagingGateway {
 #[cfg(test)]
 mod staging_gateway_tests {
     use super::*;
+    use crate::adaptor::gateway::code::diff_compute;
     use crate::adaptor::gateway::repository::status::get_git_status;
+    use crate::domain::code::services::hunk as hunk_service;
+    use crate::domain::code::{ChangeGroup, Hunk};
     use crate::git::test_helpers::*;
     use std::fs;
+    use std::path::Path;
+
+    fn index_file_content(repo: &Repository, path: &str) -> String {
+        let mut index = repo.index().unwrap();
+        index.read(true).unwrap();
+        let entry = index.get_path(Path::new(path), 0).unwrap();
+        let blob = repo.find_blob(entry.id).unwrap();
+        std::str::from_utf8(blob.content()).unwrap().to_string()
+    }
+
+    fn diff_hunks_and_groups(original: &str, modified: &str) -> (Vec<Hunk>, Vec<ChangeGroup>) {
+        let raw_hunks = diff_compute::diff_buffers(original, modified, Some("file.txt"));
+        let hunks = hunk_service::assign_hunk_ids(&raw_hunks);
+        let groups = hunk_service::compute_change_groups(&hunks);
+        (hunks, groups)
+    }
+
+    fn group_patch(file_path: &str, hunks: &[Hunk], group: &ChangeGroup) -> String {
+        let hunk = hunks
+            .iter()
+            .find(|hunk| hunk.index == group.hunk_index)
+            .unwrap();
+        hunk_service::generate_group_patch(file_path, hunk, group)
+    }
 
     #[test]
     fn test_stage_特定ファイル() {
@@ -328,6 +355,40 @@ mod staging_gateway_tests {
 
         let statuses = get_git_status(dir.path().to_str().unwrap()).unwrap();
         assert!(statuses.iter().any(|s| s.index_status == "modified"));
+    }
+
+    #[test]
+    fn test_stage_hunk_連続適用はstaged内容で再計算したpatchなら成功する() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        let original = "line1\nline2\nline3\nline4\n";
+        let modified = "line1\nchanged2\nline3\nchanged4\n";
+        add_and_commit(&repo, "file.txt", original, "add file");
+        fs::write(dir.path().join("file.txt"), modified).unwrap();
+
+        let (hunks, groups) =
+            diff_hunks_and_groups(&index_file_content(&repo, "file.txt"), modified);
+        assert_eq!(groups.len(), 2);
+        let first_group = groups[0].clone();
+        let second_group_id = groups[1].group_id.clone();
+
+        let first_patch = group_patch("file.txt", &hunks, &first_group);
+        git_stage_hunk(dir.path().to_str().unwrap(), &first_patch).unwrap();
+        assert_eq!(
+            index_file_content(&repo, "file.txt"),
+            "line1\nchanged2\nline3\nline4\n"
+        );
+
+        let staged = index_file_content(&repo, "file.txt");
+        let (hunks_after_stage, groups_after_stage) = diff_hunks_and_groups(&staged, modified);
+        let second_group = groups_after_stage
+            .iter()
+            .find(|group| group.group_id == second_group_id)
+            .unwrap();
+        let second_patch = group_patch("file.txt", &hunks_after_stage, second_group);
+        git_stage_hunk(dir.path().to_str().unwrap(), &second_patch).unwrap();
+
+        assert_eq!(index_file_content(&repo, "file.txt"), modified);
     }
 
     #[test]

--- a/src-tauri/src/adaptor/protocol/code.rs
+++ b/src-tauri/src/adaptor/protocol/code.rs
@@ -6,13 +6,15 @@
 
 use serde::Deserialize;
 
-use crate::domain::code::{ChangeGroup, DiffFileEntry, DiffTreeNode, Hunk};
+use crate::domain::code::{DiffFileEntry, DiffTreeNode, Hunk};
 
-/// `generate_group_patch` / `compute_hidden_ranges` のコマンド引数として受け取る hunk。
+/// `compute_hidden_ranges` のコマンド引数として受け取る hunk。
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HunkInput {
     pub index: u32,
+    #[serde(default)]
+    pub hunk_id: String,
     pub old_start: u32,
     pub old_lines: u32,
     pub new_start: u32,
@@ -24,39 +26,12 @@ impl HunkInput {
     pub fn into_domain(self) -> Hunk {
         Hunk {
             index: self.index,
+            hunk_id: self.hunk_id,
             old_start: self.old_start,
             old_lines: self.old_lines,
             new_start: self.new_start,
             new_lines: self.new_lines,
             lines: self.lines,
-        }
-    }
-}
-
-/// `generate_group_patch` のコマンド引数として受け取る change group。
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ChangeGroupInput {
-    pub group_index: u32,
-    pub hunk_index: u32,
-    pub new_start: u32,
-    pub new_end: u32,
-    pub line_offset_start: u32,
-    pub line_offset_end: u32,
-    #[serde(default)]
-    pub is_staged: Option<bool>,
-}
-
-impl ChangeGroupInput {
-    pub fn into_domain(self) -> ChangeGroup {
-        ChangeGroup {
-            group_index: self.group_index,
-            hunk_index: self.hunk_index,
-            new_start: self.new_start,
-            new_end: self.new_end,
-            line_offset_start: self.line_offset_start,
-            line_offset_end: self.line_offset_end,
-            is_staged: self.is_staged,
         }
     }
 }
@@ -151,8 +126,7 @@ pub struct ReviewGroupActionInput {
     pub path: String,
     pub section: String,
     pub base: String,
-    pub group_index: u32,
-    pub snapshot_version: u64,
+    pub group_id: String,
 }
 
 #[cfg(test)]
@@ -168,38 +142,12 @@ mod protocol_code_tests {
         let input: HunkInput = serde_json::from_str(json).unwrap();
         let h = input.into_domain();
         assert_eq!(h.index, 0);
+        assert_eq!(h.hunk_id, "");
         assert_eq!(h.old_start, 1);
         assert_eq!(h.old_lines, 2);
         assert_eq!(h.new_start, 3);
         assert_eq!(h.new_lines, 4);
         assert_eq!(h.lines, vec!["-a".to_string(), "+b".to_string()]);
-    }
-
-    #[test]
-    fn test_change_group_input_is_stagedの省略_null_true_false() {
-        let base = r#""groupIndex":0,"hunkIndex":1,"newStart":2,"newEnd":3,"lineOffsetStart":4,"lineOffsetEnd":5"#;
-
-        // 省略時は #[serde(default)] により None。
-        let omitted = format!("{{{base}}}");
-        let i: ChangeGroupInput = serde_json::from_str(&omitted).unwrap();
-        assert_eq!(i.into_domain().is_staged, None);
-
-        // 明示 null も None。
-        let null = format!("{{{base},\"isStaged\":null}}");
-        let i: ChangeGroupInput = serde_json::from_str(&null).unwrap();
-        assert_eq!(i.into_domain().is_staged, None);
-
-        // true / false はそのまま。
-        let t = format!("{{{base},\"isStaged\":true}}");
-        let i: ChangeGroupInput = serde_json::from_str(&t).unwrap();
-        let d = i.into_domain();
-        assert_eq!(d.is_staged, Some(true));
-        assert_eq!(d.group_index, 0);
-        assert_eq!(d.line_offset_end, 5);
-
-        let f = format!("{{{base},\"isStaged\":false}}");
-        let i: ChangeGroupInput = serde_json::from_str(&f).unwrap();
-        assert_eq!(i.into_domain().is_staged, Some(false));
     }
 
     #[test]
@@ -263,8 +211,7 @@ mod protocol_code_tests {
             "path": "src/main.rs",
             "section": "changes",
             "base": "head",
-            "groupIndex": 2,
-            "snapshotVersion": 12
+            "groupId": "g:abc:0"
         }"#;
 
         let input: ReviewGroupActionInput = serde_json::from_str(json).unwrap();
@@ -273,8 +220,7 @@ mod protocol_code_tests {
         assert_eq!(input.path, "src/main.rs");
         assert_eq!(input.section, "changes");
         assert_eq!(input.base, "head");
-        assert_eq!(input.group_index, 2);
-        assert_eq!(input.snapshot_version, 12);
+        assert_eq!(input.group_id, "g:abc:0");
     }
 
     #[test]

--- a/src-tauri/src/domain/code/error.rs
+++ b/src-tauri/src/domain/code/error.rs
@@ -16,6 +16,8 @@ pub enum CodeError {
     Rule(String),
     /// review-blob URI が参照する snapshot version が現在の snapshot と一致しない。
     StaleReviewBlobVersion { requested: u64, current: u64 },
+    /// review group action の stable id が現在の snapshot 上で解決できない。
+    StaleReviewGroupTarget { group_id: String },
 }
 
 impl std::fmt::Display for CodeError {
@@ -26,6 +28,9 @@ impl std::fmt::Display for CodeError {
                 f,
                 "stale review blob version: requested {requested}, current {current}"
             ),
+            Self::StaleReviewGroupTarget { group_id } => {
+                write!(f, "review group target stale: {group_id}")
+            }
         }
     }
 }

--- a/src-tauri/src/domain/code/services/hunk.rs
+++ b/src-tauri/src/domain/code/services/hunk.rs
@@ -3,7 +3,393 @@
 //! diff バッファの計算（git2 依存）は `DiffComputer`（gateway）が担い、本サービスは
 //! 生成済みの `Hunk` を入力に純粋計算を行う。
 
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write as _;
+
 use crate::domain::code::value_objects::{ChangeGroup, HiddenRange, Hunk, VisibleBlock};
+use sha2::{Digest, Sha256};
+
+const GROUP_CONTEXT_RADIUS: usize = 1;
+
+/// ReviewBlobSide は review blob URL の content-source 選択軸であるのに対し、
+/// StableGroupIdSide は hunk の old/new 行射影軸を表すため別型として扱う。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StableGroupIdSide {
+    Original,
+    Modified,
+}
+
+#[derive(Debug, Clone)]
+struct SideLine {
+    offset: usize,
+    line_number: usize,
+    content: String,
+    is_context: bool,
+}
+
+fn stable_lines_hash<'a>(lines: impl IntoIterator<Item = &'a str>) -> String {
+    let mut hasher = Sha256::new();
+    for line in lines {
+        hasher.update((line.len() as u64).to_be_bytes());
+        hasher.update(b":");
+        hasher.update(line.as_bytes());
+        hasher.update(b"\n");
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest.iter() {
+        write!(&mut hex, "{byte:02x}").expect("writing sha256 digest hex to string cannot fail");
+    }
+    hex
+}
+
+fn hunk_content_hash(hunk: &Hunk) -> String {
+    stable_lines_hash(hunk.lines.iter().map(String::as_str))
+}
+
+fn group_identity_hash(hunk: &Hunk, group: &ChangeGroup) -> String {
+    let start = group.line_offset_start as usize;
+    let end = (group.line_offset_end as usize + 1).min(hunk.lines.len());
+    let mut identity_lines = Vec::new();
+
+    // design.md A1: 境界 context は純削除/純挿入 group を stable side へ anchorable にするため identity に含める。
+    let mut before_context: Vec<&str> = hunk.lines[..start]
+        .iter()
+        .rev()
+        .filter_map(|line| {
+            line.as_bytes()
+                .first()
+                .copied()
+                .filter(|prefix| *prefix == b' ')
+                .map(|_| line.as_str())
+        })
+        .take(GROUP_CONTEXT_RADIUS)
+        .collect();
+    before_context.reverse();
+    for line in before_context {
+        identity_lines.push(format!("before:{line}"));
+    }
+
+    identity_lines.push("group:".to_string());
+    identity_lines.extend(
+        hunk.lines[start..end]
+            .iter()
+            .map(|line| format!("change:{line}")),
+    );
+
+    for line in hunk.lines[end..]
+        .iter()
+        .filter_map(|line| {
+            line.as_bytes()
+                .first()
+                .copied()
+                .filter(|prefix| *prefix == b' ')
+                .map(|_| line.as_str())
+        })
+        .take(GROUP_CONTEXT_RADIUS)
+    {
+        identity_lines.push(format!("after:{line}"));
+    }
+
+    stable_lines_hash(identity_lines.iter().map(String::as_str))
+}
+
+fn line_content(line: &str) -> &str {
+    line.get(1..).unwrap_or("")
+}
+
+fn hunk_side_lines(hunk: &Hunk, side: StableGroupIdSide) -> Vec<SideLine> {
+    let mut old_line = hunk.old_start as usize;
+    let mut new_line = hunk.new_start as usize;
+    let mut lines = Vec::new();
+
+    for (offset, line) in hunk.lines.iter().enumerate() {
+        let prefix = line.as_bytes().first().copied().unwrap_or(b' ');
+        match prefix {
+            b' ' => {
+                let line_number = match side {
+                    StableGroupIdSide::Original => old_line,
+                    StableGroupIdSide::Modified => new_line,
+                };
+                lines.push(SideLine {
+                    offset,
+                    line_number,
+                    content: line_content(line).to_string(),
+                    is_context: true,
+                });
+                old_line += 1;
+                new_line += 1;
+            }
+            b'-' => {
+                if side == StableGroupIdSide::Original {
+                    lines.push(SideLine {
+                        offset,
+                        line_number: old_line,
+                        content: line_content(line).to_string(),
+                        is_context: false,
+                    });
+                }
+                old_line += 1;
+            }
+            b'+' => {
+                if side == StableGroupIdSide::Modified {
+                    lines.push(SideLine {
+                        offset,
+                        line_number: new_line,
+                        content: line_content(line).to_string(),
+                        is_context: false,
+                    });
+                }
+                new_line += 1;
+            }
+            b'\\' => {}
+            _ => {
+                let line_number = match side {
+                    StableGroupIdSide::Original => old_line,
+                    StableGroupIdSide::Modified => new_line,
+                };
+                lines.push(SideLine {
+                    offset,
+                    line_number,
+                    content: line.to_string(),
+                    is_context: true,
+                });
+                old_line += 1;
+                new_line += 1;
+            }
+        }
+    }
+
+    lines
+}
+
+fn group_side_identity(
+    hunk: &Hunk,
+    group: &ChangeGroup,
+    side: StableGroupIdSide,
+) -> Option<(Vec<String>, usize)> {
+    let start = group.line_offset_start as usize;
+    let end = group.line_offset_end as usize;
+    let side_lines = hunk_side_lines(hunk, side);
+    let mut identity_lines = Vec::new();
+
+    let mut before_context: Vec<SideLine> = side_lines
+        .iter()
+        .rev()
+        .filter(|line| line.offset < start && line.is_context)
+        .take(GROUP_CONTEXT_RADIUS)
+        .cloned()
+        .collect();
+    before_context.reverse();
+    identity_lines.extend(before_context);
+
+    identity_lines.extend(
+        side_lines
+            .iter()
+            .filter(|line| line.offset >= start && line.offset <= end && !line.is_context)
+            .cloned(),
+    );
+
+    identity_lines.extend(
+        side_lines
+            .iter()
+            .filter(|line| line.offset > end && line.is_context)
+            .take(GROUP_CONTEXT_RADIUS)
+            .cloned(),
+    );
+
+    let first_line = identity_lines.first()?.line_number.saturating_sub(1);
+    Some((
+        identity_lines
+            .into_iter()
+            .map(|line| line.content)
+            .collect(),
+        first_line,
+    ))
+}
+
+fn side_occurrence(content: &str, identity_lines: &[String], expected_start: usize) -> Option<u32> {
+    if identity_lines.is_empty() {
+        return None;
+    }
+
+    let file_lines: Vec<&str> = content.lines().collect();
+    if identity_lines.len() > file_lines.len() {
+        return None;
+    }
+
+    let mut occurrence = 0;
+    for start in 0..=file_lines.len() - identity_lines.len() {
+        if file_lines[start..start + identity_lines.len()]
+            .iter()
+            .zip(identity_lines)
+            .all(|(actual, expected)| *actual == expected)
+        {
+            if start == expected_start {
+                return Some(occurrence);
+            }
+            occurrence += 1;
+        }
+    }
+
+    None
+}
+
+fn stable_side_occurrence(
+    hunk: &Hunk,
+    group: &ChangeGroup,
+    original: &str,
+    modified: &str,
+    side: StableGroupIdSide,
+) -> Option<u32> {
+    let (identity_lines, expected_start) = group_side_identity(hunk, group, side)?;
+    let content = match side {
+        StableGroupIdSide::Original => original,
+        StableGroupIdSide::Modified => modified,
+    };
+    side_occurrence(content, &identity_lines, expected_start)
+}
+
+fn hunk_side_identity(hunk: &Hunk, side: StableGroupIdSide) -> Option<(Vec<String>, usize)> {
+    let side_lines = hunk_side_lines(hunk, side);
+    let first_line = side_lines.first()?.line_number.saturating_sub(1);
+    Some((
+        side_lines.into_iter().map(|line| line.content).collect(),
+        first_line,
+    ))
+}
+
+fn stable_side_hunk_occurrence(
+    hunk: &Hunk,
+    original: &str,
+    modified: &str,
+    side: StableGroupIdSide,
+) -> Option<u32> {
+    let (identity_lines, expected_start) = hunk_side_identity(hunk, side)?;
+    let content = match side {
+        StableGroupIdSide::Original => original,
+        StableGroupIdSide::Modified => modified,
+    };
+    side_occurrence(content, &identity_lines, expected_start)
+}
+
+fn assign_stable_ids_for_side<T, Candidate, MakeId, AssignId>(
+    items: &[T],
+    mut candidate: Candidate,
+    mut make_id: MakeId,
+    mut assign_id: AssignId,
+) -> Vec<T>
+where
+    T: Clone,
+    Candidate: FnMut(&T) -> Option<(String, Option<u32>)>,
+    MakeId: FnMut(&T, u32) -> String,
+    AssignId: FnMut(&T, String) -> T,
+{
+    let mut fallback_occurrences: HashMap<String, u32> = HashMap::new();
+    let mut used_ids: HashSet<String> = HashSet::new();
+
+    items
+        .iter()
+        .map(|item| {
+            let Some((hash, stable_occurrence)) = candidate(item) else {
+                return item.clone();
+            };
+            let mut occurrence = stable_occurrence.unwrap_or_else(|| {
+                let occurrence = fallback_occurrences.entry(hash.clone()).or_insert(0);
+                let current = *occurrence;
+                *occurrence += 1;
+                current
+            });
+            let mut id = make_id(item, occurrence);
+            while used_ids.contains(&id) {
+                occurrence += 1;
+                id = make_id(item, occurrence);
+            }
+            used_ids.insert(id.clone());
+            assign_id(item, id)
+        })
+        .collect()
+}
+
+/// hunk の内容由来 stable id を算出する。
+pub fn compute_hunk_id(hunk: &Hunk, occurrence: u32) -> String {
+    format!("h:{}:{occurrence}", hunk_content_hash(hunk))
+}
+
+/// change group の内容由来 stable id を算出する。
+pub fn compute_group_id(hunk: &Hunk, group: &ChangeGroup, occurrence: u32) -> String {
+    format!("g:{}:{occurrence}", group_identity_hash(hunk, group))
+}
+
+/// review 操作で変化しない side の全文に対する出現順で group id を再付与する。
+pub fn assign_stable_group_ids_for_side(
+    hunks: &[Hunk],
+    groups: &[ChangeGroup],
+    original: &str,
+    modified: &str,
+    side: StableGroupIdSide,
+) -> Vec<ChangeGroup> {
+    assign_stable_ids_for_side(
+        groups,
+        |group| {
+            let hunk = hunks.iter().find(|hunk| hunk.index == group.hunk_index)?;
+            let hash = group_identity_hash(hunk, group);
+            let occurrence = stable_side_occurrence(hunk, group, original, modified, side);
+            Some((hash, occurrence))
+        },
+        |group, occurrence| {
+            let hunk = hunks
+                .iter()
+                .find(|hunk| hunk.index == group.hunk_index)
+                .expect("hunk resolved while building stable group id candidate");
+            compute_group_id(hunk, group, occurrence)
+        },
+        |group, group_id| ChangeGroup {
+            group_id,
+            ..group.clone()
+        },
+    )
+}
+
+/// review 操作で変化しない side の全文に対する出現順で hunk id を再付与する。
+pub fn assign_stable_hunk_ids_for_side(
+    hunks: &[Hunk],
+    original: &str,
+    modified: &str,
+    side: StableGroupIdSide,
+) -> Vec<Hunk> {
+    assign_stable_ids_for_side(
+        hunks,
+        |hunk| {
+            let hash = hunk_content_hash(hunk);
+            let occurrence = stable_side_hunk_occurrence(hunk, original, modified, side);
+            Some((hash, occurrence))
+        },
+        compute_hunk_id,
+        |hunk, hunk_id| Hunk {
+            hunk_id,
+            ..hunk.clone()
+        },
+    )
+}
+
+/// hunk 群へ内容由来 stable id を付与する。
+pub fn assign_hunk_ids(hunks: &[Hunk]) -> Vec<Hunk> {
+    let mut occurrences: HashMap<String, u32> = HashMap::new();
+    hunks
+        .iter()
+        .map(|hunk| {
+            let hash = hunk_content_hash(hunk);
+            let occurrence = occurrences.entry(hash).or_insert(0);
+            let hunk_id = compute_hunk_id(hunk, *occurrence);
+            *occurrence += 1;
+            Hunk {
+                hunk_id,
+                ..hunk.clone()
+            }
+        })
+        .collect()
+}
 
 /// hunk を連続する change group に分割する。
 ///
@@ -47,6 +433,7 @@ fn split_hunk_into_groups(hunk: &Hunk, start_group_index: u32) -> Vec<ChangeGrou
                 };
                 groups.push(ChangeGroup {
                     group_index: start_group_index + groups.len() as u32,
+                    group_id: String::new(),
                     hunk_index: hunk.index,
                     new_start: if has_plus {
                         group_new_start
@@ -72,6 +459,7 @@ fn split_hunk_into_groups(hunk: &Hunk, start_group_index: u32) -> Vec<ChangeGrou
         };
         groups.push(ChangeGroup {
             group_index: start_group_index + groups.len() as u32,
+            group_id: String::new(),
             hunk_index: hunk.index,
             new_start: if has_plus {
                 group_new_start
@@ -91,68 +479,20 @@ fn split_hunk_into_groups(hunk: &Hunk, start_group_index: u32) -> Vec<ChangeGrou
 /// hunk 群から change group 群を算出する。
 pub fn compute_change_groups(hunks: &[Hunk]) -> Vec<ChangeGroup> {
     let mut groups: Vec<ChangeGroup> = Vec::new();
+    let mut occurrences: HashMap<String, u32> = HashMap::new();
     for hunk in hunks {
-        groups.extend(split_hunk_into_groups(hunk, groups.len() as u32));
+        let hunk_groups = split_hunk_into_groups(hunk, groups.len() as u32)
+            .into_iter()
+            .map(|group| {
+                let hash = group_identity_hash(hunk, &group);
+                let occurrence = occurrences.entry(hash).or_insert(0);
+                let group_id = compute_group_id(hunk, &group, *occurrence);
+                *occurrence += 1;
+                ChangeGroup { group_id, ..group }
+            });
+        groups.extend(hunk_groups);
     }
     groups
-}
-
-/// change group に属する行を hunk から取り出す。
-#[allow(dead_code)]
-fn extract_group_lines(group: &ChangeGroup, hunks: &[Hunk]) -> Vec<String> {
-    let Some(hunk) = hunks.iter().find(|h| h.index == group.hunk_index) else {
-        return Vec::new();
-    };
-    let start = group.line_offset_start as usize;
-    let end = (group.line_offset_end as usize + 1).min(hunk.lines.len());
-    hunk.lines[start..end].to_vec()
-}
-
-/// change group の開始に対応する旧ファイルの行位置を得る。
-#[allow(dead_code)]
-fn get_group_old_position(group: &ChangeGroup, hunks: &[Hunk]) -> i64 {
-    let Some(hunk) = hunks.iter().find(|h| h.index == group.hunk_index) else {
-        return -1;
-    };
-    let mut old_line = hunk.old_start as i64;
-    for i in 0..group.line_offset_start as usize {
-        if let Some(line) = hunk.lines.get(i) {
-            let prefix = line.as_bytes().first().copied().unwrap_or(b' ');
-            if prefix == b'-' || prefix == b' ' {
-                old_line += 1;
-            }
-        }
-    }
-    old_line
-}
-
-/// staged 側の diff group と比較して change group の staged 状態を付与する。
-#[allow(dead_code)]
-pub fn mark_staged_groups(
-    groups: &[ChangeGroup],
-    staged_groups: &[ChangeGroup],
-    hunks: &[Hunk],
-    staged_hunks: &[Hunk],
-) -> Vec<ChangeGroup> {
-    let mut staged_keys = std::collections::HashSet::new();
-    for sg in staged_groups {
-        let lines = extract_group_lines(sg, staged_hunks);
-        let pos = get_group_old_position(sg, staged_hunks);
-        staged_keys.insert(format!("{pos}:{}", lines.join("\n")));
-    }
-
-    groups
-        .iter()
-        .map(|g| {
-            let lines = extract_group_lines(g, hunks);
-            let pos = get_group_old_position(g, hunks);
-            let key = format!("{pos}:{}", lines.join("\n"));
-            ChangeGroup {
-                is_staged: Some(staged_keys.contains(&key)),
-                ..g.clone()
-            }
-        })
-        .collect()
 }
 
 /// hunk 内の単一 change group に対する unified-diff patch を生成する。
@@ -204,32 +544,6 @@ pub fn generate_group_patch(file_path: &str, hunk: &Hunk, group: &ChangeGroup) -
     output.extend(result_lines);
 
     format!("{}\n", output.join("\n"))
-}
-
-/// 選択した hunk 群から unified-diff patch を生成する。
-#[allow(dead_code)]
-pub fn generate_patch(file_path: &str, hunks: &[Hunk], selected_indices: &[u32]) -> String {
-    let selected: Vec<&Hunk> = hunks
-        .iter()
-        .filter(|h| selected_indices.contains(&h.index))
-        .collect();
-    if selected.is_empty() {
-        return String::new();
-    }
-
-    let mut lines = Vec::new();
-    lines.push(format!("--- a/{file_path}"));
-    lines.push(format!("+++ b/{file_path}"));
-
-    for hunk in selected {
-        lines.push(format!(
-            "@@ -{},{} +{},{} @@",
-            hunk.old_start, hunk.old_lines, hunk.new_start, hunk.new_lines
-        ));
-        lines.extend(hunk.lines.iter().cloned());
-    }
-
-    format!("{}\n", lines.join("\n"))
 }
 
 /// 各 hunk に context 行を付与して可視範囲を算出し、隣接範囲をマージする。
@@ -386,6 +700,7 @@ mod hunk_service_tests {
     ) -> Hunk {
         Hunk {
             index,
+            hunk_id: String::new(),
             old_start,
             old_lines,
             new_start,
@@ -403,6 +718,7 @@ mod hunk_service_tests {
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].group_index, 0);
         assert_eq!(groups[0].hunk_index, 0);
+        assert!(groups[0].group_id.starts_with("g:"));
     }
 
     #[test]
@@ -415,33 +731,238 @@ mod hunk_service_tests {
         assert_eq!(groups[1].group_index, 1);
     }
 
-    // ── mark_staged_groups（hardcoded hunk 入力） ──
-
     #[test]
-    fn test_staged判定_キー一致でstaged() {
-        let h = hunk(0, 1, 3, 1, 3, &[" a", "-b", "+B", " c"]);
-        let hunks = std::slice::from_ref(&h);
-        let groups = compute_change_groups(hunks);
-        // staged 側に同一 group が存在 → is_staged: true
-        let result = mark_staged_groups(&groups, &groups, hunks, hunks);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].is_staged, Some(true));
+    fn test_hunk_idは同一内容なら位置に依存しない() {
+        let h0 = hunk(0, 1, 1, 1, 1, &["-a", "+A"]);
+        let h1 = hunk(0, 20, 1, 30, 1, &["-a", "+A"]);
+
+        let first = assign_hunk_ids(&[h0]);
+        let second = assign_hunk_ids(&[h1]);
+
+        assert_eq!(first[0].hunk_id, second[0].hunk_id);
     }
 
     #[test]
-    fn test_staged判定_staged無しでfalse() {
-        let h = hunk(0, 1, 3, 1, 3, &[" a", "-b", "+B", " c"]);
-        let hunks = std::slice::from_ref(&h);
-        let groups = compute_change_groups(hunks);
-        let result = mark_staged_groups(&groups, &[], hunks, &[]);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].is_staged, Some(false));
+    fn test_group_idは同一内容なら位置に依存しない() {
+        let h0 = hunk(0, 1, 1, 1, 1, &["-a", "+A"]);
+        let h1 = hunk(0, 20, 1, 30, 1, &["-a", "+A"]);
+
+        let first = compute_change_groups(&[h0]);
+        let second = compute_change_groups(&[h1]);
+
+        assert_eq!(first[0].group_id, second[0].group_id);
     }
 
     #[test]
-    fn test_staged判定_空入力は空() {
-        let result = mark_staged_groups(&[], &[], &[], &[]);
-        assert!(result.is_empty());
+    fn test_group_idは異なる内容なら異なる() {
+        let h0 = hunk(0, 1, 1, 1, 1, &["-a", "+A"]);
+        let h1 = hunk(0, 1, 1, 1, 1, &["-b", "+B"]);
+
+        let first = compute_change_groups(&[h0]);
+        let second = compute_change_groups(&[h1]);
+
+        assert_ne!(first[0].group_id, second[0].group_id);
+    }
+
+    #[test]
+    fn test_hunk_idは同一内容の複数出現をordinalで区別する() {
+        let h0 = hunk(0, 1, 1, 1, 1, &["-a", "+A"]);
+        let h1 = hunk(1, 10, 1, 10, 1, &["-a", "+A"]);
+
+        let hunks = assign_hunk_ids(&[h0, h1]);
+
+        assert_ne!(hunks[0].hunk_id, hunks[1].hunk_id);
+        assert!(hunks[0].hunk_id.ends_with(":0"));
+        assert!(hunks[1].hunk_id.ends_with(":1"));
+    }
+
+    #[test]
+    fn test_stable_side_hunk_idは前方の同一hunkが消えても後続hunkで変わらない() {
+        let original = "x\na\ny\nmid\nx\na\ny\n";
+        let working = "x\nA\ny\nmid\nx\nA\ny\n";
+        let staged_after_first = "x\nA\ny\nmid\nx\na\ny\n";
+        let first = hunk(0, 1, 3, 1, 3, &[" x", "-a", "+A", " y"]);
+        let second = hunk(1, 5, 3, 5, 3, &[" x", "-a", "+A", " y"]);
+        let refreshed_second = hunk(0, 5, 3, 5, 3, &[" x", "-a", "+A", " y"]);
+
+        let initial_hunks = assign_stable_hunk_ids_for_side(
+            &[first, second],
+            original,
+            working,
+            StableGroupIdSide::Modified,
+        );
+        let refreshed_hunks = assign_stable_hunk_ids_for_side(
+            &[refreshed_second],
+            staged_after_first,
+            working,
+            StableGroupIdSide::Modified,
+        );
+
+        assert_ne!(initial_hunks[0].hunk_id, initial_hunks[1].hunk_id);
+        assert_eq!(initial_hunks[1].hunk_id, refreshed_hunks[0].hunk_id);
+    }
+
+    #[test]
+    fn test_original_side_hunk_idはunstageで前方同一hunkが消えても後続hunkで変わらない() {
+        let head = "x\na\ny\nmid\nx\na\ny\n";
+        let staged = "x\nA\ny\nmid\nx\nA\ny\n";
+        let staged_after_first_unstage = "x\na\ny\nmid\nx\nA\ny\n";
+        let first = hunk(0, 1, 3, 1, 3, &[" x", "-a", "+A", " y"]);
+        let second = hunk(1, 5, 3, 5, 3, &[" x", "-a", "+A", " y"]);
+        let refreshed_second = hunk(0, 5, 3, 5, 3, &[" x", "-a", "+A", " y"]);
+
+        let initial_hunks = assign_stable_hunk_ids_for_side(
+            &[first, second],
+            head,
+            staged,
+            StableGroupIdSide::Original,
+        );
+        let refreshed_hunks = assign_stable_hunk_ids_for_side(
+            &[refreshed_second],
+            head,
+            staged_after_first_unstage,
+            StableGroupIdSide::Original,
+        );
+
+        assert_ne!(initial_hunks[0].hunk_id, initial_hunks[1].hunk_id);
+        assert_eq!(initial_hunks[1].hunk_id, refreshed_hunks[0].hunk_id);
+    }
+
+    #[test]
+    fn test_group_idは隣接contextで同一内容の複数出現を区別する() {
+        let h = hunk(
+            0,
+            1,
+            7,
+            1,
+            7,
+            &[" alpha", "-a", "+A", " beta", "-a", "+A", " gamma"],
+        );
+
+        let groups = compute_change_groups(&[h]);
+
+        assert_eq!(groups.len(), 2);
+        assert_ne!(groups[0].group_id, groups[1].group_id);
+    }
+
+    #[test]
+    fn test_group_idは同一hunk内の同じ局所patternをordinalで区別する() {
+        let h = hunk(
+            0,
+            1,
+            8,
+            1,
+            8,
+            &[" x", "-a", "+A", " y", " x", "-a", "+A", " y"],
+        );
+
+        let groups = compute_change_groups(&[h]);
+
+        assert_eq!(groups.len(), 2);
+        assert_ne!(groups[0].group_id, groups[1].group_id);
+        assert!(groups[0].group_id.ends_with(":0"));
+        assert!(groups[1].group_id.ends_with(":1"));
+    }
+
+    #[test]
+    fn test_group_idは前方の同一内容groupが消えても後続groupで変わらない() {
+        let initial = hunk(
+            0,
+            1,
+            7,
+            1,
+            7,
+            &[" alpha", "-a", "+A", " beta", "-a", "+A", " gamma"],
+        );
+        let refreshed = hunk(
+            0,
+            1,
+            6,
+            1,
+            6,
+            &[" alpha", " A", " beta", "-a", "+A", " gamma"],
+        );
+
+        let initial_groups = compute_change_groups(&[initial]);
+        let refreshed_groups = compute_change_groups(&[refreshed]);
+
+        assert_eq!(initial_groups.len(), 2);
+        assert_eq!(refreshed_groups.len(), 1);
+        assert_eq!(initial_groups[1].group_id, refreshed_groups[0].group_id);
+    }
+
+    #[test]
+    fn test_stable_side_group_idは前方の同一局所patternが消えても後続groupで変わらない() {
+        let original = "x\na\ny\nx\na\ny\n";
+        let working = "x\nA\ny\nx\nA\ny\n";
+        let staged_after_first = "x\nA\ny\nx\na\ny\n";
+        let initial = hunk(
+            0,
+            1,
+            6,
+            1,
+            6,
+            &[" x", "-a", "+A", " y", " x", "-a", "+A", " y"],
+        );
+        let refreshed = hunk(0, 1, 6, 1, 6, &[" x", " A", " y", " x", "-a", "+A", " y"]);
+
+        let initial_groups = compute_change_groups(std::slice::from_ref(&initial));
+        let refreshed_groups = compute_change_groups(std::slice::from_ref(&refreshed));
+        let initial_groups = assign_stable_group_ids_for_side(
+            &[initial],
+            &initial_groups,
+            original,
+            working,
+            StableGroupIdSide::Modified,
+        );
+        let refreshed_groups = assign_stable_group_ids_for_side(
+            &[refreshed],
+            &refreshed_groups,
+            staged_after_first,
+            working,
+            StableGroupIdSide::Modified,
+        );
+
+        assert_eq!(initial_groups.len(), 2);
+        assert_eq!(refreshed_groups.len(), 1);
+        assert_eq!(initial_groups[1].group_id, refreshed_groups[0].group_id);
+    }
+
+    #[test]
+    fn test_original_side_group_idはunstageで前方同一patternが消えても後続groupで変わらない() {
+        let head = "x\na\ny\nx\na\ny\n";
+        let staged = "x\nA\ny\nx\nA\ny\n";
+        let staged_after_first_unstage = "x\na\ny\nx\nA\ny\n";
+        let initial = hunk(
+            0,
+            1,
+            6,
+            1,
+            6,
+            &[" x", "-a", "+A", " y", " x", "-a", "+A", " y"],
+        );
+        let refreshed = hunk(0, 1, 6, 1, 6, &[" x", " a", " y", " x", "-a", "+A", " y"]);
+
+        let initial_groups = compute_change_groups(std::slice::from_ref(&initial));
+        let refreshed_groups = compute_change_groups(std::slice::from_ref(&refreshed));
+        let initial_groups = assign_stable_group_ids_for_side(
+            &[initial],
+            &initial_groups,
+            head,
+            staged,
+            StableGroupIdSide::Original,
+        );
+        let refreshed_groups = assign_stable_group_ids_for_side(
+            &[refreshed],
+            &refreshed_groups,
+            head,
+            staged_after_first_unstage,
+            StableGroupIdSide::Original,
+        );
+
+        assert_eq!(initial_groups.len(), 2);
+        assert_eq!(refreshed_groups.len(), 1);
+        assert_eq!(initial_groups[1].group_id, refreshed_groups[0].group_id);
     }
 
     // ── generate_group_patch ──
@@ -458,6 +979,7 @@ mod hunk_service_tests {
         );
         let group = ChangeGroup {
             group_index: 0,
+            group_id: "g:test:0".to_string(),
             hunk_index: 0,
             new_start: 2,
             new_end: 2,
@@ -472,75 +994,6 @@ mod hunk_service_tests {
         assert!(patch.contains("-original"));
         assert!(patch.contains("+modified"));
         assert!(patch.ends_with('\n'));
-    }
-
-    // ── generate_patch ──
-
-    #[test]
-    fn test_patch生成_単一hunk選択() {
-        let hunks = vec![
-            hunk(
-                0,
-                1,
-                3,
-                1,
-                3,
-                &[" line1", "-original", "+modified", " line3"],
-            ),
-            hunk(
-                1,
-                8,
-                3,
-                8,
-                4,
-                &[" line8", "-old9", "+new9", "+new10", " line11"],
-            ),
-        ];
-
-        let patch = generate_patch("src/file.ts", &hunks, &[0]);
-        assert!(patch.contains("--- a/src/file.ts"));
-        assert!(patch.contains("+++ b/src/file.ts"));
-        assert!(patch.contains("@@ -1,3 +1,3 @@"));
-        assert!(patch.contains("+modified"));
-        assert!(!patch.contains("+new9"));
-    }
-
-    #[test]
-    fn test_patch生成_複数hunk選択() {
-        let hunks = vec![
-            hunk(
-                0,
-                1,
-                3,
-                1,
-                3,
-                &[" line1", "-original", "+modified", " line3"],
-            ),
-            hunk(
-                1,
-                8,
-                3,
-                8,
-                4,
-                &[" line8", "-old9", "+new9", "+new10", " line11"],
-            ),
-        ];
-
-        let patch = generate_patch("src/file.ts", &hunks, &[0, 1]);
-        assert!(patch.contains("@@ -1,3 +1,3 @@"));
-        assert!(patch.contains("@@ -8,3 +8,4 @@"));
-    }
-
-    #[test]
-    fn test_patch生成_空選択() {
-        let hunks = vec![hunk(0, 1, 1, 1, 1, &["-a", "+b"])];
-        assert_eq!(generate_patch("f.ts", &hunks, &[]), "");
-    }
-
-    #[test]
-    fn test_patch生成_無効インデックス() {
-        let hunks = vec![hunk(0, 1, 1, 1, 1, &["-a", "+b"])];
-        assert_eq!(generate_patch("f.ts", &hunks, &[99]), "");
     }
 
     // ── compute_hidden_ranges ──

--- a/src-tauri/src/domain/code/value_objects/hunk.rs
+++ b/src-tauri/src/domain/code/value_objects/hunk.rs
@@ -2,6 +2,7 @@
 #[derive(Debug, Clone)]
 pub struct Hunk {
     pub index: u32,
+    pub hunk_id: String,
     pub old_start: u32,
     pub old_lines: u32,
     pub new_start: u32,
@@ -13,6 +14,7 @@ pub struct Hunk {
 #[derive(Debug, Clone)]
 pub struct ChangeGroup {
     pub group_index: u32,
+    pub group_id: String,
     pub hunk_index: u32,
     pub new_start: u32,
     pub new_end: u32,

--- a/src-tauri/src/other/error.rs
+++ b/src-tauri/src/other/error.rs
@@ -1,20 +1,30 @@
+use serde::ser::SerializeStruct;
 use serde::Serialize;
 
 /// アプリ横断のエラー型。adaptor 層（Tauri コマンド / WebSocket ハンドラ）の
 /// 戻り値で用いる。
 ///
-/// フロント／リモートへ返却される serialize 表現は、移行前の `GitError`
-/// （プレーン文字列）と等価であることを契約とする。そのため variant は
-/// 文字列メッセージのみを保持し、`serialize_str` で文字列として返す。
+/// フロント／リモートへ返却される serialize 表現は、通常エラーでは移行前の
+/// `GitError`（プレーン文字列）と等価であることを契約とする。特定の回復可能な
+/// エラーだけ、表示文言とは別の機械可読 code を持つ object として返す。
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
     #[error("{0}")]
     Internal(String),
+    #[error("{message}")]
+    Coded { code: String, message: String },
 }
 
 impl AppError {
     pub fn new(message: impl Into<String>) -> Self {
         Self::Internal(message.into())
+    }
+
+    pub fn coded(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Coded {
+            code: code.into(),
+            message: message.into(),
+        }
     }
 }
 
@@ -23,7 +33,15 @@ impl Serialize for AppError {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        match self {
+            Self::Internal(message) => serializer.serialize_str(message),
+            Self::Coded { code, message } => {
+                let mut state = serializer.serialize_struct("AppError", 2)?;
+                state.serialize_field("code", code)?;
+                state.serialize_field("message", message)?;
+                state.end()
+            }
+        }
     }
 }
 
@@ -44,5 +62,17 @@ mod tests {
     fn displayはメッセージそのもの() {
         let err = AppError::new("boom");
         assert_eq!(err.to_string(), "boom");
+    }
+
+    #[test]
+    fn coded_errorはcodeとmessageを返す() {
+        let err = AppError::coded(
+            "STALE_REVIEW_GROUP_TARGET",
+            "review group target stale: g:old",
+        );
+        let json = serde_json::to_value(&err).unwrap();
+        assert_eq!(json["code"], "STALE_REVIEW_GROUP_TARGET");
+        assert_eq!(json["message"], "review group target stale: g:old");
+        assert_eq!(err.to_string(), "review group target stale: g:old");
     }
 }

--- a/src-tauri/src/usecase/code_dto.rs
+++ b/src-tauri/src/usecase/code_dto.rs
@@ -41,6 +41,7 @@ pub struct BranchDiffSummaryDto {
 #[serde(rename_all = "camelCase")]
 pub struct HunkDto {
     pub index: u32,
+    pub hunk_id: String,
     pub old_start: u32,
     pub old_lines: u32,
     pub new_start: u32,
@@ -53,6 +54,7 @@ pub struct HunkDto {
 #[serde(rename_all = "camelCase")]
 pub struct ChangeGroupDto {
     pub group_index: u32,
+    pub group_id: String,
     pub hunk_index: u32,
     pub new_start: u32,
     pub new_end: u32,
@@ -244,6 +246,7 @@ mod code_dto_serialize_tests {
     fn test_hunk_dtoはcamelcaseで出力する() {
         let dto = HunkDto {
             index: 0,
+            hunk_id: "h:abc:0".to_string(),
             old_start: 1,
             old_lines: 2,
             new_start: 3,
@@ -254,6 +257,7 @@ mod code_dto_serialize_tests {
             serde_json::to_value(&dto).unwrap(),
             json!({
                 "index": 0,
+                "hunkId": "h:abc:0",
                 "oldStart": 1,
                 "oldLines": 2,
                 "newStart": 3,
@@ -267,6 +271,7 @@ mod code_dto_serialize_tests {
     fn test_change_group_dto_is_staged_noneは省略する() {
         let dto = ChangeGroupDto {
             group_index: 0,
+            group_id: "g:abc:0".to_string(),
             hunk_index: 1,
             new_start: 2,
             new_end: 3,
@@ -279,6 +284,7 @@ mod code_dto_serialize_tests {
             v,
             json!({
                 "groupIndex": 0,
+                "groupId": "g:abc:0",
                 "hunkIndex": 1,
                 "newStart": 2,
                 "newEnd": 3,
@@ -293,6 +299,7 @@ mod code_dto_serialize_tests {
     fn test_change_group_dto_is_staged_someは出力する() {
         let dto = ChangeGroupDto {
             group_index: 0,
+            group_id: "g:abc:0".to_string(),
             hunk_index: 1,
             new_start: 2,
             new_end: 3,
@@ -422,6 +429,7 @@ mod code_dto_serialize_tests {
             source: ReviewTextSource::Diff,
             hunks: vec![HunkDto {
                 index: 0,
+                hunk_id: "h:old-new:0".to_string(),
                 old_start: 1,
                 old_lines: 1,
                 new_start: 1,
@@ -430,6 +438,7 @@ mod code_dto_serialize_tests {
             }],
             change_groups: vec![ChangeGroupDto {
                 group_index: 0,
+                group_id: "g:old-new:0".to_string(),
                 hunk_index: 0,
                 new_start: 1,
                 new_end: 1,
@@ -458,6 +467,7 @@ mod code_dto_serialize_tests {
                 "source": "diff",
                 "hunks": [{
                     "index": 0,
+                    "hunkId": "h:old-new:0",
                     "oldStart": 1,
                     "oldLines": 1,
                     "newStart": 1,
@@ -466,6 +476,7 @@ mod code_dto_serialize_tests {
                 }],
                 "changeGroups": [{
                     "groupIndex": 0,
+                    "groupId": "g:old-new:0",
                     "hunkIndex": 0,
                     "newStart": 1,
                     "newEnd": 1,

--- a/src-tauri/src/usecase/code_query_service.rs
+++ b/src-tauri/src/usecase/code_query_service.rs
@@ -284,6 +284,7 @@ impl CodeQueryService {
         let hunks = self
             .diff_computer
             .diff_buffers(original, modified, file_path);
+        let hunks = services::hunk::assign_hunk_ids(&hunks);
         let change_groups = services::hunk::compute_change_groups(&hunks);
         DiffHunksResultDto {
             hunks: hunks.iter().map(hunk_to_dto).collect(),
@@ -390,6 +391,7 @@ impl CodeQueryService {
 fn hunk_to_dto(h: &Hunk) -> HunkDto {
     HunkDto {
         index: h.index,
+        hunk_id: h.hunk_id.clone(),
         old_start: h.old_start,
         old_lines: h.old_lines,
         new_start: h.new_start,
@@ -401,6 +403,7 @@ fn hunk_to_dto(h: &Hunk) -> HunkDto {
 fn change_group_to_dto(g: &ChangeGroup) -> ChangeGroupDto {
     ChangeGroupDto {
         group_index: g.group_index,
+        group_id: g.group_id.clone(),
         hunk_index: g.hunk_index,
         new_start: g.new_start,
         new_end: g.new_end,
@@ -545,6 +548,7 @@ mod code_query_service_tests {
         ) -> Vec<Hunk> {
             vec![Hunk {
                 index: 0,
+                hunk_id: String::new(),
                 old_start: 1,
                 old_lines: 1,
                 new_start: 1,

--- a/src-tauri/src/usecase/review_usecase.rs
+++ b/src-tauri/src/usecase/review_usecase.rs
@@ -7,6 +7,9 @@ use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
+use crate::domain::code::services::hunk::{
+    assign_stable_group_ids_for_side, assign_stable_hunk_ids_for_side, StableGroupIdSide,
+};
 use crate::domain::code::{
     ChangeGroup, CodeError, DiffFileEntry, Hunk, ReviewBase, ReviewBlobContentType, ReviewBlobSide,
     ReviewLimitReason, ReviewSection, ReviewSideBytes, ReviewSideMetadata, ReviewThresholds,
@@ -50,6 +53,13 @@ struct ReviewTextSides {
     original: String,
     modified: String,
     source: ReviewTextSource,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StableDiffSources<'a> {
+    original: &'a str,
+    modified: &'a str,
+    line_offset: u32,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -326,6 +336,7 @@ impl ReviewUsecase {
             &relative_path,
             version,
             stale,
+            section,
             ReviewTextSides {
                 original,
                 modified,
@@ -341,17 +352,15 @@ impl ReviewUsecase {
         path: &str,
         section: &str,
         base: &str,
-        group_index: u32,
-        snapshot_version: u64,
+        group_id: &str,
     ) -> Result<(), CodeUsecaseError> {
         let snapshot = self.snapshot(worktree_path)?;
-        ensure_current_review_snapshot_version(snapshot.as_ref(), snapshot_version)?;
         let patch = self.generate_review_group_patch(
             worktree_path,
             path,
             section,
             base,
-            group_index,
+            group_id,
             snapshot.as_ref(),
         )?;
         self.code.git_stage_hunk(worktree_path, &patch)
@@ -363,17 +372,15 @@ impl ReviewUsecase {
         path: &str,
         section: &str,
         base: &str,
-        group_index: u32,
-        snapshot_version: u64,
+        group_id: &str,
     ) -> Result<(), CodeUsecaseError> {
         let snapshot = self.snapshot(worktree_path)?;
-        ensure_current_review_snapshot_version(snapshot.as_ref(), snapshot_version)?;
         let patch = self.generate_review_group_patch(
             worktree_path,
             path,
             section,
             base,
-            group_index,
+            group_id,
             snapshot.as_ref(),
         )?;
         self.code.git_unstage_hunk(worktree_path, &patch)
@@ -532,6 +539,7 @@ impl ReviewUsecase {
         relative_path: &str,
         version: u64,
         stale: bool,
+        section: ReviewSection,
         sides: ReviewTextSides,
         viewport: Option<ReviewViewport>,
     ) -> Result<ReviewFileViewDto, CodeUsecaseError> {
@@ -545,11 +553,23 @@ impl ReviewUsecase {
         let modified_lines = line_count(&modified);
         let total_lines = original_lines.max(modified_lines);
 
-        if viewport.is_some() {
-            let (original, modified, viewport) = apply_viewport(original, modified, viewport);
-            let hunks = self
-                .code
-                .compute_diff_hunks(&original, &modified, Some(relative_path));
+        if let Some(requested_viewport) = viewport {
+            let stable_original = original.clone();
+            let stable_modified = modified.clone();
+            let stable_line_offset = requested_viewport.start_line.max(1).saturating_sub(1);
+            let (original, modified, viewport) =
+                apply_viewport(original, modified, Some(requested_viewport));
+            let hunks = self.compute_review_diff_hunks_with_stable_sources(
+                &original,
+                &modified,
+                StableDiffSources {
+                    original: &stable_original,
+                    modified: &stable_modified,
+                    line_offset: stable_line_offset,
+                },
+                Some(relative_path),
+                section,
+            );
             return Ok(ReviewFileViewDto::TextDiff(ReviewTextDiffDto {
                 version,
                 stale,
@@ -578,9 +598,8 @@ impl ReviewUsecase {
             ));
         }
 
-        let hunks = self
-            .code
-            .compute_diff_hunks(&original, &modified, Some(relative_path));
+        let hunks =
+            self.compute_review_diff_hunks(&original, &modified, Some(relative_path), section);
         if let Some(reason) = thresholds.hunk_count_limit(hunks.hunks.len()) {
             return Ok(fallback_view(
                 relative_path,
@@ -668,13 +687,92 @@ impl ReviewUsecase {
         })
     }
 
+    fn compute_review_diff_hunks(
+        &self,
+        original: &str,
+        modified: &str,
+        file_path: Option<&str>,
+        section: ReviewSection,
+    ) -> DiffHunksResultDto {
+        self.compute_review_diff_hunks_with_stable_sources(
+            original,
+            modified,
+            StableDiffSources {
+                original,
+                modified,
+                line_offset: 0,
+            },
+            file_path,
+            section,
+        )
+    }
+
+    fn compute_review_diff_hunks_with_stable_sources(
+        &self,
+        original: &str,
+        modified: &str,
+        stable_sources: StableDiffSources<'_>,
+        file_path: Option<&str>,
+        section: ReviewSection,
+    ) -> DiffHunksResultDto {
+        let mut result = self.code.compute_diff_hunks(original, modified, file_path);
+        let hunks: Vec<Hunk> = result.hunks.iter().map(hunk_dto_to_domain).collect();
+        let groups: Vec<ChangeGroup> = result
+            .change_groups
+            .iter()
+            .map(change_group_dto_to_domain)
+            .collect();
+        let stable_source_hunks = if stable_sources.line_offset == 0 {
+            hunks.clone()
+        } else {
+            hunks
+                .iter()
+                .map(|hunk| offset_hunk_coordinates(hunk, stable_sources.line_offset))
+                .collect()
+        };
+        let stable_side = stable_group_id_side(section);
+        let stable_hunks = assign_stable_hunk_ids_for_side(
+            &stable_source_hunks,
+            stable_sources.original,
+            stable_sources.modified,
+            stable_side,
+        );
+        let hunk_ids: HashMap<u32, String> = stable_hunks
+            .iter()
+            .map(|hunk| (hunk.index, hunk.hunk_id.clone()))
+            .collect();
+        let display_hunks: Vec<Hunk> = hunks
+            .iter()
+            .map(|hunk| Hunk {
+                hunk_id: hunk_ids
+                    .get(&hunk.index)
+                    .cloned()
+                    .unwrap_or_else(|| hunk.hunk_id.clone()),
+                ..hunk.clone()
+            })
+            .collect();
+        let stable_groups = assign_stable_group_ids_for_side(
+            &stable_source_hunks,
+            &groups,
+            stable_sources.original,
+            stable_sources.modified,
+            stable_side,
+        );
+        result.hunks = display_hunks.iter().map(hunk_domain_to_dto).collect();
+        result.change_groups = stable_groups
+            .iter()
+            .map(change_group_domain_to_dto)
+            .collect();
+        result
+    }
+
     fn generate_review_group_patch(
         &self,
         worktree_path: &str,
         path: &str,
         section: &str,
         base: &str,
-        group_index: u32,
+        group_id: &str,
         snapshot: &RepositorySnapshot,
     ) -> Result<String, CodeUsecaseError> {
         let section = ReviewSection::parse(section)?;
@@ -689,7 +787,12 @@ impl ReviewUsecase {
         let review_snapshot = self.review_snapshot_from_snapshot(worktree_path, base, snapshot)?;
         let relative_path =
             resolve_review_target(worktree_path, &ReviewTarget::Path(path.to_string()))?;
-        ensure_review_target_in_snapshot(&review_snapshot, &relative_path, section, base)?;
+        if !review_snapshot_contains_target(&review_snapshot, &relative_path, section, base) {
+            return Err(CodeError::StaleReviewGroupTarget {
+                group_id: group_id.to_string(),
+            }
+            .into());
+        }
         let file_path = absolute_review_file_path(worktree_path, &relative_path)?;
         let original_source = self.code.select_review_side_source(
             &file_path,
@@ -713,15 +816,14 @@ impl ReviewUsecase {
                 .code
                 .read_review_source_bytes(&file_path, modified_source.source)?,
         )?;
-        let result = self
-            .code
-            .compute_diff_hunks(&original, &modified, Some(&relative_path));
+        let result =
+            self.compute_review_diff_hunks(&original, &modified, Some(&relative_path), section);
         let group = result
             .change_groups
             .iter()
-            .find(|group| group.group_index == group_index)
-            .ok_or_else(|| {
-                CodeError::Rule(format!("review change group not found: {group_index}"))
+            .find(|group| group.group_id == group_id)
+            .ok_or_else(|| CodeError::StaleReviewGroupTarget {
+                group_id: group_id.to_string(),
             })?;
         let hunk = result
             .hunks
@@ -737,27 +839,6 @@ impl ReviewUsecase {
             &change_group_dto_to_domain(group),
         ))
     }
-}
-
-fn ensure_current_review_snapshot_version(
-    snapshot: &RepositorySnapshot,
-    expected_version: u64,
-) -> Result<(), CodeUsecaseError> {
-    if snapshot.flags.stale {
-        return Err(CodeError::Rule(format!(
-            "stale review snapshot version: current {} is refreshing",
-            snapshot.version
-        ))
-        .into());
-    }
-    if expected_version != snapshot.version {
-        return Err(CodeError::Rule(format!(
-            "stale review snapshot version: requested {expected_version}, current {}",
-            snapshot.version
-        ))
-        .into());
-    }
-    Ok(())
 }
 
 fn ensure_current_review_blob_version(
@@ -970,6 +1051,7 @@ impl ReviewSideMetadata {
 fn hunk_dto_to_domain(h: &HunkDto) -> Hunk {
     Hunk {
         index: h.index,
+        hunk_id: h.hunk_id.clone(),
         old_start: h.old_start,
         old_lines: h.old_lines,
         new_start: h.new_start,
@@ -978,15 +1060,65 @@ fn hunk_dto_to_domain(h: &HunkDto) -> Hunk {
     }
 }
 
+fn hunk_domain_to_dto(h: &Hunk) -> HunkDto {
+    HunkDto {
+        index: h.index,
+        hunk_id: h.hunk_id.clone(),
+        old_start: h.old_start,
+        old_lines: h.old_lines,
+        new_start: h.new_start,
+        new_lines: h.new_lines,
+        lines: h.lines.clone(),
+    }
+}
+
+fn offset_hunk_coordinates(hunk: &Hunk, line_offset: u32) -> Hunk {
+    Hunk {
+        old_start: if hunk.old_start == 0 {
+            0
+        } else {
+            hunk.old_start.saturating_add(line_offset)
+        },
+        new_start: if hunk.new_start == 0 {
+            0
+        } else {
+            hunk.new_start.saturating_add(line_offset)
+        },
+        ..hunk.clone()
+    }
+}
+
 fn change_group_dto_to_domain(g: &ChangeGroupDto) -> ChangeGroup {
     ChangeGroup {
         group_index: g.group_index,
+        group_id: g.group_id.clone(),
         hunk_index: g.hunk_index,
         new_start: g.new_start,
         new_end: g.new_end,
         line_offset_start: g.line_offset_start,
         line_offset_end: g.line_offset_end,
         is_staged: g.is_staged,
+    }
+}
+
+fn change_group_domain_to_dto(g: &ChangeGroup) -> ChangeGroupDto {
+    ChangeGroupDto {
+        group_index: g.group_index,
+        group_id: g.group_id.clone(),
+        hunk_index: g.hunk_index,
+        new_start: g.new_start,
+        new_end: g.new_end,
+        line_offset_start: g.line_offset_start,
+        line_offset_end: g.line_offset_end,
+        is_staged: g.is_staged,
+    }
+}
+
+fn stable_group_id_side(section: ReviewSection) -> StableGroupIdSide {
+    if section.is_staged() {
+        StableGroupIdSide::Original
+    } else {
+        StableGroupIdSide::Modified
     }
 }
 
@@ -1260,10 +1392,12 @@ mod tests {
         branch_summary: BranchDiffSummaryDto,
         source_metadata: HashMap<(String, &'static str), ReviewSideMetadata>,
         source_bytes: HashMap<(String, &'static str), ReviewSideBytes>,
+        source_byte_sequences: Mutex<HashMap<(String, &'static str), VecDeque<ReviewSideBytes>>>,
         binary_attributes: HashMap<String, bool>,
         hunk_count_by_path: HashMap<String, usize>,
         hunk_indexes_by_path: HashMap<String, Vec<u32>>,
         change_groups_by_path: HashMap<String, Vec<ChangeGroupDto>>,
+        real_diff: bool,
     }
 
     impl FakeReviewCode {
@@ -1286,10 +1420,12 @@ mod tests {
                 },
                 source_metadata: HashMap::new(),
                 source_bytes: HashMap::new(),
+                source_byte_sequences: Mutex::new(HashMap::new()),
                 binary_attributes: HashMap::new(),
                 hunk_count_by_path: HashMap::new(),
                 hunk_indexes_by_path: HashMap::new(),
                 change_groups_by_path: HashMap::new(),
+                real_diff: false,
             }
         }
 
@@ -1305,6 +1441,19 @@ mod tests {
         ) -> Self {
             self.source_bytes
                 .insert((file_path.to_string(), review_source_key(source)), bytes);
+            self
+        }
+
+        fn with_source_byte_sequence(
+            mut self,
+            file_path: &str,
+            source: ReviewContentSource,
+            bytes: Vec<ReviewSideBytes>,
+        ) -> Self {
+            self.source_byte_sequences.get_mut().unwrap().insert(
+                (file_path.to_string(), review_source_key(source)),
+                bytes.into(),
+            );
             self
         }
 
@@ -1327,6 +1476,11 @@ mod tests {
         fn with_hunk_count(mut self, file_path: &str, hunk_count: usize) -> Self {
             self.hunk_count_by_path
                 .insert(file_path.to_string(), hunk_count);
+            self
+        }
+
+        fn with_real_diff(mut self) -> Self {
+            self.real_diff = true;
             self
         }
 
@@ -1357,6 +1511,20 @@ mod tests {
 
         fn metadata_for(&self, file_path: &str, source: ReviewContentSource) -> ReviewSideMetadata {
             let key = (file_path.to_string(), review_source_key(source));
+            if let Some(bytes) = self
+                .source_byte_sequences
+                .lock()
+                .unwrap()
+                .get(&key)
+                .and_then(|sequence| sequence.front())
+            {
+                return match bytes {
+                    ReviewSideBytes::Present(bytes) => ReviewSideMetadata::Present {
+                        size_bytes: bytes.len() as u64,
+                    },
+                    ReviewSideBytes::Missing => ReviewSideMetadata::Missing,
+                };
+            }
             self.source_metadata.get(&key).copied().unwrap_or_else(|| {
                 match self.source_bytes.get(&key) {
                     Some(ReviewSideBytes::Present(bytes)) => ReviewSideMetadata::Present {
@@ -1421,9 +1589,21 @@ mod tests {
             file_path: &str,
             source: ReviewContentSource,
         ) -> Result<ReviewSideBytes, CodeUsecaseError> {
+            let key = (file_path.to_string(), review_source_key(source));
+            {
+                let mut sequences = self.source_byte_sequences.lock().unwrap();
+                if let Some(sequence) = sequences.get_mut(&key) {
+                    if sequence.len() > 1 {
+                        return Ok(sequence.pop_front().unwrap());
+                    }
+                    if let Some(bytes) = sequence.front() {
+                        return Ok(bytes.clone());
+                    }
+                }
+            }
             Ok(self
                 .source_bytes
-                .get(&(file_path.to_string(), review_source_key(source)))
+                .get(&key)
                 .cloned()
                 .unwrap_or(ReviewSideBytes::Missing))
         }
@@ -1462,6 +1642,16 @@ mod tests {
             modified: &str,
             file_path: Option<&str>,
         ) -> DiffHunksResultDto {
+            let has_fixed_diff = file_path
+                .map(|path| {
+                    self.hunk_indexes_by_path.contains_key(path)
+                        || self.hunk_count_by_path.contains_key(path)
+                        || self.change_groups_by_path.contains_key(path)
+                })
+                .unwrap_or(false);
+            if self.real_diff && !has_fixed_diff {
+                return real_diff_hunks_result(original, modified, file_path);
+            }
             let hunk_indexes = file_path
                 .and_then(|path| self.hunk_indexes_by_path.get(path).cloned())
                 .unwrap_or_else(|| {
@@ -1478,6 +1668,7 @@ mod tests {
                     .into_iter()
                     .map(|index| HunkDto {
                         index,
+                        hunk_id: format!("h:{index}"),
                         old_start: 1,
                         old_lines: 1,
                         new_start: 1,
@@ -1601,12 +1792,52 @@ mod tests {
     fn change_group(group_index: u32, hunk_index: u32) -> ChangeGroupDto {
         ChangeGroupDto {
             group_index,
+            group_id: format!("g:{group_index}"),
             hunk_index,
             new_start: 1,
             new_end: 1,
             line_offset_start: 0,
             line_offset_end: 0,
             is_staged: None,
+        }
+    }
+
+    fn real_diff_hunks_result(
+        original: &str,
+        modified: &str,
+        file_path: Option<&str>,
+    ) -> DiffHunksResultDto {
+        let raw_hunks = crate::adaptor::gateway::code::diff_compute::diff_buffers(
+            original, modified, file_path,
+        );
+        let hunks = crate::domain::code::services::hunk::assign_hunk_ids(&raw_hunks);
+        let change_groups = crate::domain::code::services::hunk::compute_change_groups(&hunks);
+        DiffHunksResultDto {
+            hunks: hunks
+                .iter()
+                .map(|hunk| HunkDto {
+                    index: hunk.index,
+                    hunk_id: hunk.hunk_id.clone(),
+                    old_start: hunk.old_start,
+                    old_lines: hunk.old_lines,
+                    new_start: hunk.new_start,
+                    new_lines: hunk.new_lines,
+                    lines: hunk.lines.clone(),
+                })
+                .collect(),
+            change_groups: change_groups
+                .iter()
+                .map(|group| ChangeGroupDto {
+                    group_index: group.group_index,
+                    group_id: group.group_id.clone(),
+                    hunk_index: group.hunk_index,
+                    new_start: group.new_start,
+                    new_end: group.new_end,
+                    line_offset_start: group.line_offset_start,
+                    line_offset_end: group.line_offset_end,
+                    is_staged: group.is_staged,
+                })
+                .collect(),
         }
     }
 
@@ -1674,6 +1905,74 @@ mod tests {
                 .into_iter()
                 .collect(),
         )
+    }
+
+    fn group_action_section(action: &str) -> &'static str {
+        match action {
+            "stage" => "changes",
+            "unstage" => "staged",
+            _ => unreachable!("unknown group action"),
+        }
+    }
+
+    fn group_action_sources(
+        action: &str,
+    ) -> (
+        ReviewContentSource,
+        ReviewContentSource,
+        &'static str,
+        &'static str,
+    ) {
+        match action {
+            "stage" => (
+                ReviewContentSource::Staged,
+                ReviewContentSource::WorkingTree,
+                "none",
+                "modified",
+            ),
+            "unstage" => (
+                ReviewContentSource::Head,
+                ReviewContentSource::Staged,
+                "modified",
+                "none",
+            ),
+            _ => unreachable!("unknown group action"),
+        }
+    }
+
+    fn snapshot_for_group_action(version: u64, path: &str, action: &str) -> RepositorySnapshot {
+        let (_, _, index_status, worktree_status) = group_action_sources(action);
+        snapshot_with_single_status(version, path, index_status, worktree_status)
+    }
+
+    fn fake_code_for_group_action_content(
+        action: &str,
+        file_path: &str,
+        original: &str,
+        modified: &str,
+    ) -> FakeReviewCode {
+        let (original_source, modified_source, _, _) = group_action_sources(action);
+        FakeReviewCode::new()
+            .with_real_diff()
+            .with_source_bytes(file_path, original_source, present_text(original))
+            .with_source_bytes(file_path, modified_source, present_text(modified))
+    }
+
+    fn fake_code_for_group_action_content_sequence(
+        action: &str,
+        file_path: &str,
+        original: &str,
+        modified_reads: Vec<&str>,
+    ) -> FakeReviewCode {
+        let (original_source, modified_source, _, _) = group_action_sources(action);
+        FakeReviewCode::new()
+            .with_real_diff()
+            .with_source_bytes(file_path, original_source, present_text(original))
+            .with_source_byte_sequence(
+                file_path,
+                modified_source,
+                modified_reads.into_iter().map(present_text).collect(),
+            )
     }
 
     fn usecase_with_code(
@@ -1985,6 +2284,91 @@ mod tests {
             })
         );
         assert_eq!(view.total_lines, 4);
+    }
+
+    #[test]
+    fn review_file_view_viewport_stable_ids_use_full_file_occurrence_for_group_actions() {
+        let path = "/repo/file.txt";
+        let relative_path = "file.txt";
+        let original = concat!(
+            "c1\n", "c2\n", "c3\n", "a\n", "c4\n", "c5\n", "c6\n", "gap1\n", "gap2\n", "gap3\n",
+            "gap4\n", "gap5\n", "gap6\n", "gap7\n", "c1\n", "c2\n", "c3\n", "a\n", "c4\n", "c5\n",
+            "c6\n",
+        );
+        let working = concat!(
+            "c1\n", "c2\n", "c3\n", "A\n", "c4\n", "c5\n", "c6\n", "gap1\n", "gap2\n", "gap3\n",
+            "gap4\n", "gap5\n", "gap6\n", "gap7\n", "c1\n", "c2\n", "c3\n", "A\n", "c4\n", "c5\n",
+            "c6\n",
+        );
+        let code = Arc::new(
+            FakeReviewCode::new()
+                .with_real_diff()
+                .with_source_bytes(path, ReviewContentSource::Staged, present_text(original))
+                .with_source_bytes(
+                    path,
+                    ReviewContentSource::WorkingTree,
+                    present_text(working),
+                ),
+        );
+        let usecase = ReviewUsecase::new_with_ports(
+            Arc::new(FakeSnapshotProvider::new(vec![
+                snapshot_for_group_action(1, relative_path, "stage"),
+                snapshot_for_group_action(2, relative_path, "stage"),
+                snapshot_for_group_action(3, relative_path, "stage"),
+            ])),
+            code.clone(),
+        );
+
+        let viewport_view = text_view(
+            usecase
+                .get_review_file_view(
+                    "/repo",
+                    ReviewTarget::Path(relative_path.to_string()),
+                    "changes",
+                    "head",
+                    Some(ReviewViewport {
+                        start_line: 15,
+                        end_line: 21,
+                    }),
+                    Some(1),
+                )
+                .unwrap(),
+        );
+        let full_view = text_view(
+            usecase
+                .get_review_file_view(
+                    "/repo",
+                    ReviewTarget::Path(relative_path.to_string()),
+                    "changes",
+                    "head",
+                    None,
+                    Some(2),
+                )
+                .unwrap(),
+        );
+
+        assert_eq!(viewport_view.hunks.len(), 1);
+        assert_eq!(viewport_view.change_groups.len(), 1);
+        assert_eq!(full_view.hunks.len(), 2);
+        assert_eq!(full_view.change_groups.len(), 2);
+        assert_eq!(viewport_view.hunks[0].hunk_id, full_view.hunks[1].hunk_id);
+        assert_eq!(
+            viewport_view.change_groups[0].group_id,
+            full_view.change_groups[1].group_id
+        );
+
+        let group_id = viewport_view.change_groups[0].group_id.clone();
+        usecase
+            .git_stage_review_group("/repo", relative_path, "changes", "head", &group_id)
+            .unwrap();
+
+        assert_eq!(
+            code.calls(),
+            vec![
+                "generate-patch:file.txt:1:1".to_string(),
+                "stage-hunk:/repo".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -2390,23 +2774,6 @@ mod tests {
     }
 
     #[test]
-    fn review_stage_group_rejects_stale_version_before_code_port() {
-        let provider = Arc::new(FakeSnapshotProvider::new(vec![repository_snapshot(
-            8, false,
-        )]));
-        let code = Arc::new(FakeReviewCode::new());
-        let usecase = ReviewUsecase::new_with_ports(provider, code.clone());
-
-        let err = usecase
-            .git_stage_review_group("/repo", "file.txt", "changes", "head", 0, 7)
-            .unwrap_err()
-            .to_string();
-
-        assert!(err.contains("stale review snapshot version: requested 7, current 8"));
-        assert!(code.calls().is_empty());
-    }
-
-    #[test]
     fn review_stage_group_generates_patch_and_delegates_for_head_diff() {
         let path = "/repo/file.txt";
         let code = Arc::new(
@@ -2422,12 +2789,26 @@ mod tests {
         let usecase = ReviewUsecase::new_with_ports(
             Arc::new(FakeSnapshotProvider::new(vec![
                 snapshot_with_single_status(1, "file.txt", "modified", "modified"),
+                snapshot_with_single_status(2, "file.txt", "modified", "modified"),
             ])),
             code.clone(),
         );
+        let view = text_view(
+            usecase
+                .get_review_file_view(
+                    "/repo",
+                    ReviewTarget::Path("file.txt".to_string()),
+                    "changes",
+                    "head",
+                    None,
+                    Some(1),
+                )
+                .unwrap(),
+        );
+        let group_id = view.change_groups[0].group_id.clone();
 
         usecase
-            .git_stage_review_group("/repo", "file.txt", "changes", "head", 0, 1)
+            .git_stage_review_group("/repo", "file.txt", "changes", "head", &group_id)
             .unwrap();
 
         assert_eq!(
@@ -2448,12 +2829,26 @@ mod tests {
         let usecase = ReviewUsecase::new_with_ports(
             Arc::new(FakeSnapshotProvider::new(vec![
                 snapshot_with_single_status(1, "file.txt", "modified", "none"),
+                snapshot_with_single_status(2, "file.txt", "modified", "none"),
             ])),
             code.clone(),
         );
+        let view = text_view(
+            usecase
+                .get_review_file_view(
+                    "/repo",
+                    ReviewTarget::Path("file.txt".to_string()),
+                    "staged",
+                    "head",
+                    None,
+                    Some(1),
+                )
+                .unwrap(),
+        );
+        let group_id = view.change_groups[0].group_id.clone();
 
         usecase
-            .git_unstage_review_group("/repo", "file.txt", "staged", "head", 0, 1)
+            .git_unstage_review_group("/repo", "file.txt", "staged", "head", &group_id)
             .unwrap();
 
         assert_eq!(
@@ -2479,16 +2874,14 @@ mod tests {
                     "file.txt",
                     "changes",
                     "branch-base",
-                    0,
-                    1,
+                    "g:0",
                 ),
                 "unstage" => usecase.git_unstage_review_group(
                     "/repo",
                     "file.txt",
                     "changes",
                     "branch-base",
-                    0,
-                    1,
+                    "g:0",
                 ),
                 _ => unreachable!(),
             }
@@ -2524,20 +2917,386 @@ mod tests {
             );
 
             let err = match action {
-                "stage" => {
-                    usecase.git_stage_review_group("/repo", "file.txt", "changes", "head", 7, 1)
-                }
-                "unstage" => {
-                    usecase.git_unstage_review_group("/repo", "file.txt", "changes", "head", 7, 1)
-                }
+                "stage" => usecase.git_stage_review_group(
+                    "/repo",
+                    "file.txt",
+                    "changes",
+                    "head",
+                    "missing-group",
+                ),
+                "unstage" => usecase.git_unstage_review_group(
+                    "/repo",
+                    "file.txt",
+                    "changes",
+                    "head",
+                    "missing-group",
+                ),
                 _ => unreachable!(),
             }
             .unwrap_err()
             .to_string();
 
             assert!(
-                err.contains("review change group not found: 7"),
+                err.contains("review group target stale: missing-group"),
                 "unexpected {action} error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn review_group_action_missing_group_uses_typed_stale_target_error() {
+        let path = "/repo/file.txt";
+        let code = Arc::new(
+            FakeReviewCode::new()
+                .with_source_bytes(path, ReviewContentSource::Staged, present_text("old\n"))
+                .with_source_bytes(
+                    path,
+                    ReviewContentSource::WorkingTree,
+                    present_text("new\n"),
+                ),
+        );
+        let usecase = ReviewUsecase::new_with_ports(
+            Arc::new(FakeSnapshotProvider::new(vec![
+                snapshot_with_single_status(1, "file.txt", "modified", "modified"),
+            ])),
+            code,
+        );
+
+        let err = usecase
+            .git_stage_review_group("/repo", "file.txt", "changes", "head", "missing-group")
+            .unwrap_err();
+
+        match err {
+            CodeUsecaseError::Code(CodeError::StaleReviewGroupTarget { group_id }) => {
+                assert_eq!(group_id, "missing-group");
+            }
+            other => panic!("expected stale review group target, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn review_group_actions_report_missing_snapshot_target_as_typed_stale_target_error() {
+        for action in ["stage", "unstage"] {
+            let path = "/repo/file.txt";
+            let relative_path = "file.txt";
+            let code = Arc::new(fake_code_for_group_action_content(
+                action,
+                path,
+                "old\nsame\n",
+                "new\nsame\n",
+            ));
+            let usecase = ReviewUsecase::new_with_ports(
+                Arc::new(FakeSnapshotProvider::new(vec![
+                    snapshot_for_group_action(1, relative_path, action),
+                    repository_snapshot(2, false),
+                ])),
+                code.clone(),
+            );
+            let section = group_action_section(action);
+            let view = text_view(
+                usecase
+                    .get_review_file_view(
+                        "/repo",
+                        ReviewTarget::Path(relative_path.to_string()),
+                        section,
+                        "head",
+                        None,
+                        Some(1),
+                    )
+                    .unwrap(),
+            );
+            let group_id = view.change_groups[0].group_id.clone();
+
+            let err = match action {
+                "stage" => usecase.git_stage_review_group(
+                    "/repo",
+                    relative_path,
+                    section,
+                    "head",
+                    &group_id,
+                ),
+                "unstage" => usecase.git_unstage_review_group(
+                    "/repo",
+                    relative_path,
+                    section,
+                    "head",
+                    &group_id,
+                ),
+                _ => unreachable!(),
+            }
+            .unwrap_err();
+
+            match err {
+                CodeUsecaseError::Code(CodeError::StaleReviewGroupTarget { group_id: stale }) => {
+                    assert_eq!(stale, group_id);
+                }
+                other => panic!("expected stale review group target, got {other:?}"),
+            }
+            assert!(
+                code.calls().is_empty(),
+                "{action} should stop before patch generation and index mutation"
+            );
+        }
+    }
+
+    #[test]
+    fn review_group_actions_accept_previous_group_id_after_snapshot_refresh_when_content_matches() {
+        for action in ["stage", "unstage"] {
+            let path = "/repo/file.txt";
+            let relative_path = "file.txt";
+            let code = Arc::new(fake_code_for_group_action_content(
+                action,
+                path,
+                "old\nsame\n",
+                "new\nsame\n",
+            ));
+            let usecase = ReviewUsecase::new_with_ports(
+                Arc::new(FakeSnapshotProvider::new(vec![
+                    snapshot_for_group_action(1, relative_path, action),
+                    snapshot_for_group_action(2, relative_path, action),
+                ])),
+                code.clone(),
+            );
+            let section = group_action_section(action);
+            let view = text_view(
+                usecase
+                    .get_review_file_view(
+                        "/repo",
+                        ReviewTarget::Path(relative_path.to_string()),
+                        section,
+                        "head",
+                        None,
+                        Some(1),
+                    )
+                    .unwrap(),
+            );
+            let group_id = view.change_groups[0].group_id.clone();
+
+            match action {
+                "stage" => usecase.git_stage_review_group(
+                    "/repo",
+                    relative_path,
+                    section,
+                    "head",
+                    &group_id,
+                ),
+                "unstage" => usecase.git_unstage_review_group(
+                    "/repo",
+                    relative_path,
+                    section,
+                    "head",
+                    &group_id,
+                ),
+                _ => unreachable!(),
+            }
+            .unwrap();
+
+            let apply_call = match action {
+                "stage" => "stage-hunk:/repo",
+                "unstage" => "unstage-hunk:/repo",
+                _ => unreachable!(),
+            };
+            assert_eq!(
+                code.calls(),
+                vec![
+                    "generate-patch:file.txt:0:0".to_string(),
+                    apply_call.to_string(),
+                ],
+                "unexpected calls for {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn review_group_action_accepts_later_duplicate_group_id_after_earlier_duplicate_disappears() {
+        let path = "/repo/file.txt";
+        let relative_path = "file.txt";
+        let original = "x\na\ny\nx\na\ny\n";
+        let staged_after_first = "x\nA\ny\nx\na\ny\n";
+        let working = "x\nA\ny\nx\nA\ny\n";
+        let code = Arc::new(
+            FakeReviewCode::new()
+                .with_real_diff()
+                .with_source_byte_sequence(
+                    path,
+                    ReviewContentSource::Staged,
+                    vec![present_text(original), present_text(staged_after_first)],
+                )
+                .with_source_bytes(
+                    path,
+                    ReviewContentSource::WorkingTree,
+                    present_text(working),
+                ),
+        );
+        let usecase = ReviewUsecase::new_with_ports(
+            Arc::new(FakeSnapshotProvider::new(vec![
+                snapshot_for_group_action(1, relative_path, "stage"),
+                snapshot_for_group_action(2, relative_path, "stage"),
+            ])),
+            code.clone(),
+        );
+        let view = text_view(
+            usecase
+                .get_review_file_view(
+                    "/repo",
+                    ReviewTarget::Path(relative_path.to_string()),
+                    "changes",
+                    "head",
+                    None,
+                    Some(1),
+                )
+                .unwrap(),
+        );
+        assert_eq!(view.change_groups.len(), 2);
+        let later_group_id = view.change_groups[1].group_id.clone();
+
+        usecase
+            .git_stage_review_group("/repo", relative_path, "changes", "head", &later_group_id)
+            .unwrap();
+
+        assert_eq!(
+            code.calls(),
+            vec![
+                "generate-patch:file.txt:0:0".to_string(),
+                "stage-hunk:/repo".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn review_file_view_keeps_later_duplicate_hunk_id_after_earlier_duplicate_disappears() {
+        let path = "/repo/file.txt";
+        let relative_path = "file.txt";
+        let original = concat!(
+            "c1\n", "c2\n", "c3\n", "a\n", "c4\n", "c5\n", "c6\n", "gap1\n", "gap2\n", "gap3\n",
+            "gap4\n", "gap5\n", "gap6\n", "gap7\n", "c1\n", "c2\n", "c3\n", "a\n", "c4\n", "c5\n",
+            "c6\n",
+        );
+        let staged_after_first = concat!(
+            "c1\n", "c2\n", "c3\n", "A\n", "c4\n", "c5\n", "c6\n", "gap1\n", "gap2\n", "gap3\n",
+            "gap4\n", "gap5\n", "gap6\n", "gap7\n", "c1\n", "c2\n", "c3\n", "a\n", "c4\n", "c5\n",
+            "c6\n",
+        );
+        let working = concat!(
+            "c1\n", "c2\n", "c3\n", "A\n", "c4\n", "c5\n", "c6\n", "gap1\n", "gap2\n", "gap3\n",
+            "gap4\n", "gap5\n", "gap6\n", "gap7\n", "c1\n", "c2\n", "c3\n", "A\n", "c4\n", "c5\n",
+            "c6\n",
+        );
+        let code = Arc::new(
+            FakeReviewCode::new()
+                .with_real_diff()
+                .with_source_byte_sequence(
+                    path,
+                    ReviewContentSource::Staged,
+                    vec![present_text(original), present_text(staged_after_first)],
+                )
+                .with_source_bytes(
+                    path,
+                    ReviewContentSource::WorkingTree,
+                    present_text(working),
+                ),
+        );
+        let usecase = ReviewUsecase::new_with_ports(
+            Arc::new(FakeSnapshotProvider::new(vec![
+                snapshot_for_group_action(1, relative_path, "stage"),
+                snapshot_for_group_action(2, relative_path, "stage"),
+            ])),
+            code,
+        );
+
+        let initial_view = text_view(
+            usecase
+                .get_review_file_view(
+                    "/repo",
+                    ReviewTarget::Path(relative_path.to_string()),
+                    "changes",
+                    "head",
+                    None,
+                    Some(1),
+                )
+                .unwrap(),
+        );
+        assert_eq!(initial_view.hunks.len(), 2);
+        let later_hunk_id = initial_view.hunks[1].hunk_id.clone();
+        let refreshed_view = text_view(
+            usecase
+                .get_review_file_view(
+                    "/repo",
+                    ReviewTarget::Path(relative_path.to_string()),
+                    "changes",
+                    "head",
+                    None,
+                    Some(2),
+                )
+                .unwrap(),
+        );
+
+        assert_eq!(refreshed_view.hunks.len(), 1);
+        assert_eq!(later_hunk_id, refreshed_view.hunks[0].hunk_id);
+    }
+
+    #[test]
+    fn review_group_actions_reject_previous_group_id_after_snapshot_refresh_when_target_disappears()
+    {
+        for action in ["stage", "unstage"] {
+            let path = "/repo/file.txt";
+            let relative_path = "file.txt";
+            let code = Arc::new(fake_code_for_group_action_content_sequence(
+                action,
+                path,
+                "old\nsame\n",
+                vec!["new\nsame\n", "old\nsame\n"],
+            ));
+            let usecase = ReviewUsecase::new_with_ports(
+                Arc::new(FakeSnapshotProvider::new(vec![
+                    snapshot_for_group_action(1, relative_path, action),
+                    snapshot_for_group_action(2, relative_path, action),
+                ])),
+                code.clone(),
+            );
+            let section = group_action_section(action);
+            let view = text_view(
+                usecase
+                    .get_review_file_view(
+                        "/repo",
+                        ReviewTarget::Path(relative_path.to_string()),
+                        section,
+                        "head",
+                        None,
+                        Some(1),
+                    )
+                    .unwrap(),
+            );
+            let group_id = view.change_groups[0].group_id.clone();
+
+            let err = match action {
+                "stage" => usecase.git_stage_review_group(
+                    "/repo",
+                    relative_path,
+                    section,
+                    "head",
+                    &group_id,
+                ),
+                "unstage" => usecase.git_unstage_review_group(
+                    "/repo",
+                    relative_path,
+                    section,
+                    "head",
+                    &group_id,
+                ),
+                _ => unreachable!(),
+            }
+            .unwrap_err();
+
+            match err {
+                CodeUsecaseError::Code(CodeError::StaleReviewGroupTarget { group_id: stale }) => {
+                    assert_eq!(stale, group_id);
+                }
+                other => panic!("expected stale review group target, got {other:?}"),
+            }
+            assert!(
+                code.calls().is_empty(),
+                "{action} should stop before patch generation and index mutation"
             );
         }
     }
@@ -2563,40 +3322,22 @@ mod tests {
                 code,
             );
 
-            let err = match action {
-                "stage" => {
-                    usecase.git_stage_review_group("/repo", "file.txt", "changes", "head", 0, 1)
+            let err =
+                match action {
+                    "stage" => usecase
+                        .git_stage_review_group("/repo", "file.txt", "changes", "head", "g:0"),
+                    "unstage" => usecase
+                        .git_unstage_review_group("/repo", "file.txt", "changes", "head", "g:0"),
+                    _ => unreachable!(),
                 }
-                "unstage" => {
-                    usecase.git_unstage_review_group("/repo", "file.txt", "changes", "head", 0, 1)
-                }
-                _ => unreachable!(),
-            }
-            .unwrap_err()
-            .to_string();
+                .unwrap_err()
+                .to_string();
 
             assert!(
                 err.contains("review hunk not found: 99"),
                 "unexpected {action} error: {err}"
             );
         }
-    }
-
-    #[test]
-    fn review_unstage_group_rejects_stale_version_before_code_port() {
-        let provider = Arc::new(FakeSnapshotProvider::new(vec![repository_snapshot(
-            8, false,
-        )]));
-        let code = Arc::new(FakeReviewCode::new());
-        let usecase = ReviewUsecase::new_with_ports(provider, code.clone());
-
-        let err = usecase
-            .git_unstage_review_group("/repo", "file.txt", "staged", "head", 0, 7)
-            .unwrap_err()
-            .to_string();
-
-        assert!(err.contains("stale review snapshot version: requested 7, current 8"));
-        assert!(code.calls().is_empty());
     }
 
     #[test]

--- a/src/components/panels/AgentChatPanel/ActivityLog.test.tsx
+++ b/src/components/panels/AgentChatPanel/ActivityLog.test.tsx
@@ -136,20 +136,6 @@ beforeEach(() => {
 		if (command === "get_language_from_path") {
 			return Promise.resolve("typescript");
 		}
-		if (command === "compute_diff_hunks") {
-			return Promise.resolve({
-				hunks: [
-					{
-						index: 0,
-						oldStart: 1,
-						oldLines: 1,
-						newStart: 1,
-						newLines: 1,
-						lines: ["-old", "+new"],
-					},
-				],
-			});
-		}
 		if (command === "build_agent_edit_preview") {
 			const input = (
 				args as {
@@ -715,20 +701,6 @@ describe("ToolActivity", () => {
 				}
 				if (command === "get_language_from_path") {
 					return Promise.resolve("typescript");
-				}
-				if (command === "compute_diff_hunks") {
-					return Promise.resolve({
-						hunks: [
-							{
-								index: 0,
-								oldStart: 1,
-								oldLines: 1,
-								newStart: 1,
-								newLines: 1,
-								lines: ["-old", "+new"],
-							},
-						],
-					});
 				}
 				if (command !== "build_agent_edit_preview") {
 					return Promise.resolve(null);

--- a/src/components/panels/AgentChatPanel/AgentEditPreviewPanel.tsx
+++ b/src/components/panels/AgentChatPanel/AgentEditPreviewPanel.tsx
@@ -143,6 +143,7 @@ function previewHunksToDiffHunks(hunks: AgentEditPreviewHunk[]): Hunk[] {
 
 		return {
 			index,
+			hunkId: `agent-preview:${index}`,
 			oldStart: hunk.oldStart,
 			oldLines,
 			newStart: hunk.newStart,

--- a/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
+++ b/src/components/panels/AgentChatPanel/PermissionDialog.test.tsx
@@ -113,24 +113,6 @@ function mockPermissionPresentation(command: string, args: unknown) {
 	if (command === "get_language_from_path") {
 		return resolvedInvoke("typescript");
 	}
-	if (command === "compute_diff_hunks") {
-		const { original, modified } = args as {
-			original: string;
-			modified: string;
-		};
-		return resolvedInvoke({
-			hunks: [
-				{
-					index: 0,
-					oldStart: 1,
-					oldLines: original ? 1 : 0,
-					newStart: 1,
-					newLines: modified ? 1 : 0,
-					lines: original ? [`-${original}`, `+${modified}`] : [`+${modified}`],
-				},
-			],
-		});
-	}
 	return null;
 }
 

--- a/src/components/panels/CodeDiffViewer.test.tsx
+++ b/src/components/panels/CodeDiffViewer.test.tsx
@@ -21,6 +21,7 @@ describe("CodeDiffViewer", () => {
 		const hunks: Hunk[] = [
 			{
 				index: 3,
+				hunkId: "h:provided:0",
 				oldStart: 1,
 				oldLines: 1,
 				newStart: 1,

--- a/src/components/panels/CodeDiffViewer.tsx
+++ b/src/components/panels/CodeDiffViewer.tsx
@@ -14,7 +14,7 @@ export interface CodeDiffViewerProps {
 	filePath?: string;
 	hunks: Hunk[];
 	changeGroups?: ChangeGroup[];
-	onStageGroup?: (groupIndex: number) => void;
+	onStageGroup?: (groupId: string) => void;
 	groupActionLabel?: string;
 	comments?: ReviewDiscussionThread[];
 	onAddComment?: (lineNumber: number, content: string) => Promise<void>;

--- a/src/components/panels/DiffViewerSection.tsx
+++ b/src/components/panels/DiffViewerSection.tsx
@@ -26,7 +26,7 @@ export interface DiffViewerSectionProps {
 	filePath?: string;
 	hunks: Hunk[] | null;
 	changeGroups?: ChangeGroup[];
-	onStageGroup?: (groupIndex: number) => void;
+	onStageGroup?: (groupId: string) => void;
 	groupActionLabel?: string;
 	comments?: ReviewDiscussionThread[];
 	onAddComment?: (lineNumber: number, content: string) => Promise<void>;

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -407,10 +407,6 @@ export function ReviewPanel({
 		filePath: selectedFile,
 		section: selectedSection,
 		base: diffBase,
-		snapshotVersion:
-			reviewFileView?.kind === "textDiff" && !reviewFileView.stale
-				? reviewFileView.version
-				: null,
 		onGitChanged: refreshAfterAction,
 	});
 

--- a/src/components/panels/ShikiDiffViewer.test.tsx
+++ b/src/components/panels/ShikiDiffViewer.test.tsx
@@ -48,6 +48,7 @@ const baseProps = {
 	hunks: [
 		{
 			index: 0,
+			hunkId: "h:base:0",
 			oldStart: 1,
 			oldLines: 3,
 			newStart: 1,
@@ -115,6 +116,7 @@ describe("ShikiDiffViewer", () => {
 				changeGroups={[
 					{
 						groupIndex: 0,
+						groupId: "g:stage:0",
 						hunkIndex: 0,
 						newStart: 2,
 						newEnd: 2,
@@ -139,6 +141,7 @@ describe("ShikiDiffViewer", () => {
 				changeGroups={[
 					{
 						groupIndex: 0,
+						groupId: "g:unstage:0",
 						hunkIndex: 0,
 						newStart: 2,
 						newEnd: 2,
@@ -187,6 +190,7 @@ describe("ShikiDiffViewer", () => {
 			hunks: [
 				{
 					index: 0,
+					hunkId: "h:delete-only:0",
 					oldStart: 1,
 					oldLines: 3,
 					newStart: 1,
@@ -210,6 +214,7 @@ describe("ShikiDiffViewer", () => {
 			hunks: [
 				{
 					index: 0,
+					hunkId: "h:delete:0",
 					oldStart: 1,
 					oldLines: 3,
 					newStart: 1,
@@ -255,6 +260,7 @@ describe("ShikiDiffViewer", () => {
 			hunks: [
 				{
 					index: 0,
+					hunkId: "h:delete-bar:0",
 					oldStart: 1,
 					oldLines: 3,
 					newStart: 1,
@@ -313,7 +319,7 @@ describe("ShikiDiffViewer", () => {
 		}
 	});
 
-	it("calls onStageGroup with correct groupIndex when stage button is clicked", () => {
+	it("calls onStageGroup with correct groupId when stage button is clicked", () => {
 		const onStage = vi.fn();
 		const { container } = render(
 			<ShikiDiffViewer
@@ -322,6 +328,7 @@ describe("ShikiDiffViewer", () => {
 				changeGroups={[
 					{
 						groupIndex: 2,
+						groupId: "g:click:0",
 						hunkIndex: 0,
 						newStart: 2,
 						newEnd: 2,
@@ -336,7 +343,72 @@ describe("ShikiDiffViewer", () => {
 		const stageButton = container.querySelector(".hunk-stage") as HTMLElement;
 		expect(stageButton).not.toBeNull();
 		fireEvent.click(stageButton);
-		expect(onStage).toHaveBeenCalledWith(2);
+		expect(onStage).toHaveBeenCalledWith("g:click:0");
+	});
+
+	it("renders one stage button per change group in a single hunk and delegates each groupId", () => {
+		const onStage = vi.fn();
+		const multiGroupProps = {
+			originalContent: "ctx1\nold a\nctx2\nold b\nctx3\n",
+			modifiedContent: "ctx1\nnew a\nctx2\nnew b\nctx3\n",
+			language: "typescript",
+			hunks: [
+				{
+					index: 0,
+					hunkId: "h:multi:0",
+					oldStart: 1,
+					oldLines: 5,
+					newStart: 1,
+					newLines: 5,
+					lines: [
+						" ctx1",
+						"-old a",
+						"+new a",
+						" ctx2",
+						"-old b",
+						"+new b",
+						" ctx3",
+					],
+				},
+			],
+		};
+
+		const { container } = render(
+			<ShikiDiffViewer
+				{...multiGroupProps}
+				diffMode="inline"
+				changeGroups={[
+					{
+						groupIndex: 0,
+						groupId: "g:first",
+						hunkIndex: 0,
+						newStart: 2,
+						newEnd: 2,
+						lineOffsetStart: 1,
+						lineOffsetEnd: 2,
+					},
+					{
+						groupIndex: 1,
+						groupId: "g:second",
+						hunkIndex: 0,
+						newStart: 4,
+						newEnd: 4,
+						lineOffsetStart: 4,
+						lineOffsetEnd: 5,
+					},
+				]}
+				onStageGroup={onStage}
+				groupActionLabel="Stage"
+			/>,
+		);
+		const stageButtons = container.querySelectorAll(".hunk-stage");
+		expect(stageButtons).toHaveLength(2);
+
+		fireEvent.click(stageButtons[1]);
+		fireEvent.click(stageButtons[0]);
+
+		expect(onStage).toHaveBeenNthCalledWith(1, "g:second");
+		expect(onStage).toHaveBeenNthCalledWith(2, "g:first");
 	});
 
 	it("shows hidden lines banner when diffOnlyMode is true", async () => {
@@ -347,6 +419,7 @@ describe("ShikiDiffViewer", () => {
 		const longHunks = [
 			{
 				index: 0,
+				hunkId: "h:hidden:0",
 				oldStart: 5,
 				oldLines: 1,
 				newStart: 5,

--- a/src/components/panels/ShikiDiffViewer.tsx
+++ b/src/components/panels/ShikiDiffViewer.tsx
@@ -61,7 +61,7 @@ export interface ShikiDiffViewerProps {
 	hunks: Hunk[];
 	filePath?: string;
 	changeGroups?: ChangeGroup[];
-	onStageGroup?: (groupIndex: number) => void;
+	onStageGroup?: (groupId: string) => void;
 	groupActionLabel?: string;
 	comments?: ReviewDiscussionThread[];
 	onAddComment?: (lineNumber: number, content: string) => Promise<void>;
@@ -229,7 +229,7 @@ const DiffLineRow = React.memo(function DiffLineRow({
 
 interface GutterDiffLine extends DiffLine {
 	hasDeleteMarker?: boolean;
-	changeGroupIndex?: number;
+	changeGroupId?: string;
 	isGroupStart?: boolean;
 	_source?: DiffLine;
 }
@@ -255,7 +255,7 @@ function buildGutterLines(blocks: DiffBlock[]): GutterDiffLine[] {
 			} else {
 				const gutterLine: GutterDiffLine = {
 					...line,
-					changeGroupIndex: block.changeGroupIndex,
+					changeGroupId: block.changeGroupId,
 					_source: line,
 				};
 				if (pendingDeleteMarker) {
@@ -282,7 +282,7 @@ function buildGutterLines(blocks: DiffBlock[]): GutterDiffLine[] {
 				tokens: [],
 				content: "",
 				hasDeleteMarker: true,
-				changeGroupIndex: block.changeGroupIndex,
+				changeGroupId: block.changeGroupId,
 				isGroupStart: true,
 			});
 		}
@@ -400,7 +400,7 @@ type FlatInlineItem =
 			kind: "line";
 			line: DiffLine;
 			showStageButton: boolean;
-			changeGroupIndex?: number;
+			changeGroupId?: string;
 	  }
 	| { kind: "hidden"; range: HiddenRange }
 	| { kind: "comment"; comment: ReviewDiscussionThread }
@@ -410,7 +410,7 @@ interface FlatSplitRow {
 	left: DiffLine | null;
 	right: DiffLine | null;
 	showStageButton: boolean;
-	changeGroupIndex?: number;
+	changeGroupId?: string;
 }
 
 type FlatSplitItem =
@@ -439,7 +439,7 @@ interface CommentCallbacks {
 interface VirtualViewProps extends CommentCallbacks {
 	visibleBlocks: VisibleItem[];
 	changeGroups?: ChangeGroup[];
-	onStageGroup?: (groupIndex: number) => void;
+	onStageGroup?: (groupId: string) => void;
 	groupActionLabel?: string;
 	containerRef: React.RefObject<HTMLDivElement | null>;
 	scrollToLine?: number | null;
@@ -453,28 +453,37 @@ function flattenWithGroups(
 	changeGroups: ChangeGroup[],
 ): { blocksWithGroups: DiffBlock[]; blockOrder: VisibleItem[] } {
 	const diffBlocks: DiffBlock[] = [];
+	const blockOrder: VisibleItem[] = [];
 	for (const item of visibleBlocks) {
-		if (item.type !== "hidden") {
-			diffBlocks.push(item as DiffBlock);
+		if (item.type === "hidden") {
+			blockOrder.push(item);
+			continue;
+		}
+		const blocks = assignChangeGroupsToBlocks(
+			[item as DiffBlock],
+			changeGroups,
+		);
+		for (const block of blocks) {
+			diffBlocks.push(block);
+			blockOrder.push(block);
 		}
 	}
-	const blocksWithGroups = assignChangeGroupsToBlocks(diffBlocks, changeGroups);
-	return { blocksWithGroups, blockOrder: visibleBlocks };
+	return { blocksWithGroups: diffBlocks, blockOrder };
 }
 
 function useDelegatedClick(
-	onStageGroup: ((groupIndex: number) => void) | undefined,
+	onStageGroup: ((groupId: string) => void) | undefined,
 	onExpandRange: (range: HiddenRange) => void,
 ): (e: React.MouseEvent<HTMLDivElement>) => void {
 	return useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
 			const target = e.target as HTMLElement;
 
-			const stageBtn = target.closest<HTMLElement>("[data-group-index]");
+			const stageBtn = target.closest<HTMLElement>("[data-group-id]");
 			if (stageBtn && onStageGroup) {
-				const idx = Number(stageBtn.dataset.groupIndex);
-				if (!Number.isNaN(idx)) {
-					onStageGroup(idx);
+				const groupId = stageBtn.dataset.groupId;
+				if (groupId) {
+					onStageGroup(groupId);
 				}
 				return;
 			}
@@ -743,17 +752,17 @@ function HiddenBanner({ range }: { range: HiddenRange }) {
 }
 
 function GroupStageButton({
-	groupIndex,
+	groupId,
 	label,
 }: {
-	groupIndex: number;
+	groupId: string;
 	label: string;
 }) {
 	return (
 		<button
 			type="button"
 			className="hunk-seg-btn hunk-stage absolute right-2 top-0 z-10"
-			data-group-index={groupIndex}
+			data-group-id={groupId}
 		>
 			{label}
 		</button>
@@ -934,10 +943,10 @@ function GutterView({
 								}}
 							>
 								{item.line.isGroupStart &&
-									item.line.changeGroupIndex != null &&
+									item.line.changeGroupId != null &&
 									onStageGroup && (
 										<GroupStageButton
-											groupIndex={item.line.changeGroupIndex}
+											groupId={item.line.changeGroupId}
 											label={groupActionLabel ?? "Stage"}
 										/>
 									)}
@@ -1025,8 +1034,8 @@ function InlineView({
 					result.push({
 						kind: "line",
 						line,
-						showStageButton: isFirst && block.changeGroupIndex != null,
-						changeGroupIndex: block.changeGroupIndex,
+						showStageButton: isFirst && block.changeGroupId != null,
+						changeGroupId: block.changeGroupId,
 					});
 					isFirst = false;
 
@@ -1158,10 +1167,10 @@ function InlineView({
 								}}
 							>
 								{item.showStageButton &&
-									item.changeGroupIndex != null &&
+									item.changeGroupId != null &&
 									onStageGroup && (
 										<GroupStageButton
-											groupIndex={item.changeGroupIndex}
+											groupId={item.changeGroupId}
 											label={groupActionLabel ?? "Stage"}
 										/>
 									)}
@@ -1279,8 +1288,8 @@ function SplitView({
 							row: {
 								left: deleted[i] ?? null,
 								right: added[i] ?? null,
-								showStageButton: i === 0 && block.changeGroupIndex != null,
-								changeGroupIndex: block.changeGroupIndex,
+								showStageButton: i === 0 && block.changeGroupId != null,
+								changeGroupId: block.changeGroupId,
 							},
 						});
 						const rightLine = added[i];
@@ -1423,10 +1432,10 @@ function SplitView({
 								}}
 							>
 								{item.row.showStageButton &&
-									item.row.changeGroupIndex != null &&
+									item.row.changeGroupId != null &&
 									onStageGroup && (
 										<GroupStageButton
-											groupIndex={item.row.changeGroupIndex}
+											groupId={item.row.changeGroupId}
 											label={groupActionLabel ?? "Stage"}
 										/>
 									)}

--- a/src/components/panels/useDiffOperations.test.ts
+++ b/src/components/panels/useDiffOperations.test.ts
@@ -24,13 +24,12 @@ describe("useDiffOperations", () => {
 				filePath: "relative/path.ts",
 				section: "changes",
 				base: "head",
-				snapshotVersion: 17,
 				onGitChanged,
 			}),
 		);
 
 		await act(async () => {
-			await result.current.handleStageGroup(2);
+			await result.current.handleStageGroup("g:stage:0");
 		});
 
 		expect(mockInvoke).toHaveBeenCalledWith("git_stage_review_group", {
@@ -39,8 +38,7 @@ describe("useDiffOperations", () => {
 				path: "relative/path.ts",
 				section: "changes",
 				base: "head",
-				groupIndex: 2,
-				snapshotVersion: 17,
+				groupId: "g:stage:0",
 			},
 		});
 		expect(onGitChanged).toHaveBeenCalled();
@@ -56,13 +54,12 @@ describe("useDiffOperations", () => {
 				filePath: "relative/path.ts",
 				section: "staged",
 				base: "head",
-				snapshotVersion: 23,
 				onGitChanged,
 			}),
 		);
 
 		await act(async () => {
-			await result.current.handleUnstageGroup(0);
+			await result.current.handleUnstageGroup("g:unstage:0");
 		});
 
 		expect(mockInvoke).toHaveBeenCalledWith("git_unstage_review_group", {
@@ -71,8 +68,7 @@ describe("useDiffOperations", () => {
 				path: "relative/path.ts",
 				section: "staged",
 				base: "head",
-				groupIndex: 0,
-				snapshotVersion: 23,
+				groupId: "g:unstage:0",
 			},
 		});
 		expect(onGitChanged).toHaveBeenCalled();
@@ -85,32 +81,54 @@ describe("useDiffOperations", () => {
 				filePath: null,
 				section: "changes",
 				base: "head",
-				snapshotVersion: 1,
 			}),
 		);
 
 		await act(async () => {
-			await result.current.handleStageGroup(0);
+			await result.current.handleStageGroup("g:0");
 		});
 
 		expect(mockInvoke).not.toHaveBeenCalled();
 	});
 
-	it("does nothing when snapshot version is missing", async () => {
+	it("does nothing when group id is missing", async () => {
 		const { result } = renderHook(() =>
 			useDiffOperations({
 				rootPath: "/repo",
 				filePath: "relative/path.ts",
 				section: "changes",
 				base: "head",
-				snapshotVersion: null,
 			}),
 		);
 
 		await act(async () => {
-			await result.current.handleStageGroup(0);
+			await result.current.handleStageGroup("");
 		});
 
 		expect(mockInvoke).not.toHaveBeenCalled();
+	});
+
+	it("refreshes when the Rust command reports a stale review group target", async () => {
+		const onGitChanged = vi.fn();
+		mockInvoke.mockRejectedValue({
+			code: "STALE_REVIEW_GROUP_TARGET",
+			message: "review group target stale: g:old:0",
+		});
+
+		const { result } = renderHook(() =>
+			useDiffOperations({
+				rootPath: "/repo",
+				filePath: "relative/path.ts",
+				section: "changes",
+				base: "head",
+				onGitChanged,
+			}),
+		);
+
+		await act(async () => {
+			await result.current.handleStageGroup("g:old:0");
+		});
+
+		expect(onGitChanged).toHaveBeenCalled();
 	});
 });

--- a/src/components/panels/useDiffOperations.ts
+++ b/src/components/panels/useDiffOperations.ts
@@ -7,13 +7,22 @@ export interface UseDiffOperationsParams {
 	filePath: string | null;
 	section: DiffSection;
 	base: DiffBase;
-	snapshotVersion: number | null;
 	onGitChanged?: () => void;
 }
 
 export interface UseDiffOperationsResult {
-	handleStageGroup: (groupIndex: number) => Promise<void>;
-	handleUnstageGroup: (groupIndex: number) => Promise<void>;
+	handleStageGroup: (groupId: string) => Promise<void>;
+	handleUnstageGroup: (groupId: string) => Promise<void>;
+}
+
+const STALE_REVIEW_GROUP_TARGET_CODE = "STALE_REVIEW_GROUP_TARGET";
+
+function isObject(error: unknown): error is Record<string, unknown> {
+	return typeof error === "object" && error !== null;
+}
+
+function isStaleReviewGroupTarget(error: unknown): boolean {
+	return isObject(error) && error.code === STALE_REVIEW_GROUP_TARGET_CODE;
 }
 
 export function useDiffOperations({
@@ -21,12 +30,11 @@ export function useDiffOperations({
 	filePath,
 	section,
 	base,
-	snapshotVersion,
 	onGitChanged,
 }: UseDiffOperationsParams): UseDiffOperationsResult {
 	const applyGroupAction = useCallback(
-		async (command: string, groupIndex: number) => {
-			if (!rootPath || !filePath || snapshotVersion == null) return;
+		async (command: string, groupId: string) => {
+			if (!rootPath || !filePath || !groupId) return;
 
 			try {
 				await invoke(command, {
@@ -35,27 +43,29 @@ export function useDiffOperations({
 						path: filePath,
 						section,
 						base,
-						groupIndex,
-						snapshotVersion,
+						groupId,
 					},
 				});
 				onGitChanged?.();
 			} catch (e) {
+				if (isStaleReviewGroupTarget(e)) {
+					console.warn("Review group target is stale; refreshing snapshot:", e);
+					onGitChanged?.();
+					return;
+				}
 				console.error("Group action failed:", e);
 			}
 		},
-		[rootPath, filePath, section, base, snapshotVersion, onGitChanged],
+		[rootPath, filePath, section, base, onGitChanged],
 	);
 
 	const handleStageGroup = useCallback(
-		(groupIndex: number) =>
-			applyGroupAction("git_stage_review_group", groupIndex),
+		(groupId: string) => applyGroupAction("git_stage_review_group", groupId),
 		[applyGroupAction],
 	);
 
 	const handleUnstageGroup = useCallback(
-		(groupIndex: number) =>
-			applyGroupAction("git_unstage_review_group", groupIndex),
+		(groupId: string) => applyGroupAction("git_unstage_review_group", groupId),
 		[applyGroupAction],
 	);
 

--- a/src/hooks/useDiffTokens.test.ts
+++ b/src/hooks/useDiffTokens.test.ts
@@ -28,6 +28,7 @@ describe("computeDiffBlocks", () => {
 		const hunks = [
 			{
 				index: 0,
+				hunkId: "h:added:0",
 				oldStart: 1,
 				oldLines: 2,
 				newStart: 1,
@@ -57,6 +58,7 @@ describe("computeDiffBlocks", () => {
 		const hunks = [
 			{
 				index: 0,
+				hunkId: "h:deleted:0",
 				oldStart: 1,
 				oldLines: 3,
 				newStart: 1,
@@ -105,6 +107,7 @@ describe("computeDiffBlocks", () => {
 		const hunks = [
 			{
 				index: 0,
+				hunkId: "h:file-deleted:0",
 				oldStart: 1,
 				oldLines: 1,
 				newStart: 0,
@@ -127,6 +130,7 @@ describe("computeDiffBlocks", () => {
 		const hunks = [
 			{
 				index: 0,
+				hunkId: "h:no-newline:0",
 				oldStart: 1,
 				oldLines: 1,
 				newStart: 1,
@@ -164,7 +168,7 @@ describe("assignChangeGroupsToBlocks", () => {
 		expect(result).toEqual(blocks);
 	});
 
-	it("assigns change group index to matching change block", () => {
+	it("assigns change group id to matching change block by hunk offset", () => {
 		const blocks = [
 			{
 				type: "change" as const,
@@ -175,13 +179,88 @@ describe("assignChangeGroupsToBlocks", () => {
 						newLineNumber: 5,
 						tokens: [],
 						content: "new line",
+						hunkIndex: 0,
+						hunkLineOffset: 0,
 					},
 				],
 			},
 		];
-		const changeGroups = [{ groupIndex: 0, newStart: 5, newEnd: 5 }];
+		const changeGroups = [
+			{
+				groupIndex: 0,
+				groupId: "g:matching:0",
+				hunkIndex: 0,
+				newStart: 5,
+				newEnd: 5,
+				lineOffsetStart: 0,
+				lineOffsetEnd: 0,
+			},
+		];
 		const result = assignChangeGroupsToBlocks(blocks, changeGroups);
-		expect(result[0].changeGroupIndex).toBe(0);
+		expect(result[0].changeGroupId).toBe("g:matching:0");
+	});
+
+	it("splits one hunk change block into all matching change groups", () => {
+		const hunks = [
+			{
+				index: 0,
+				hunkId: "h:multi:0",
+				oldStart: 1,
+				oldLines: 5,
+				newStart: 1,
+				newLines: 5,
+				lines: [
+					" ctx1",
+					"-old a",
+					"+new a",
+					" ctx2",
+					"-old b",
+					"+new b",
+					" ctx3",
+				],
+			},
+		];
+		const { blocks } = computeDiffBlocks(
+			hunks,
+			null,
+			null,
+			"ctx1\nold a\nctx2\nold b\nctx3\n",
+			"ctx1\nnew a\nctx2\nnew b\nctx3\n",
+		);
+
+		const result = assignChangeGroupsToBlocks(blocks, [
+			{
+				groupIndex: 0,
+				groupId: "g:first",
+				hunkIndex: 0,
+				newStart: 2,
+				newEnd: 2,
+				lineOffsetStart: 1,
+				lineOffsetEnd: 2,
+			},
+			{
+				groupIndex: 1,
+				groupId: "g:second",
+				hunkIndex: 0,
+				newStart: 4,
+				newEnd: 4,
+				lineOffsetStart: 4,
+				lineOffsetEnd: 5,
+			},
+		]);
+
+		const changeBlocks = result.filter((block) => block.type === "change");
+		expect(changeBlocks).toHaveLength(2);
+		expect(changeBlocks.map((block) => block.changeGroupId)).toEqual([
+			"g:first",
+			"g:second",
+		]);
+		expect(
+			changeBlocks.map((block) => block.lines.map((line) => line.content)),
+		).toEqual([
+			["old a", "new a"],
+			["old b", "new b"],
+		]);
 	});
 });
 
@@ -219,6 +298,7 @@ describe("progressive rendering fallback", () => {
 		const hunks = [
 			{
 				index: 0,
+				hunkId: "h:fallback:0",
 				oldStart: 1,
 				oldLines: 1,
 				newStart: 1,

--- a/src/hooks/useDiffTokens.ts
+++ b/src/hooks/useDiffTokens.ts
@@ -9,12 +9,14 @@ export interface DiffLine {
 	newLineNumber: number | null;
 	tokens: TokenizedLine["tokens"];
 	content: string;
+	hunkIndex?: number;
+	hunkLineOffset?: number;
 }
 
 export interface DiffBlock {
 	type: "change" | "context";
 	lines: DiffLine[];
-	changeGroupIndex?: number;
+	changeGroupId?: string;
 }
 
 function splitContentToLines(content: string): string[] {
@@ -99,7 +101,12 @@ export function computeDiffBlocks(
 		}
 
 		const changeLines: DiffLine[] = [];
-		for (const rawLine of hunk.lines) {
+		for (
+			let hunkLineOffset = 0;
+			hunkLineOffset < hunk.lines.length;
+			hunkLineOffset++
+		) {
+			const rawLine = hunk.lines[hunkLineOffset];
 			const prefix = rawLine[0];
 			const content = rawLine.slice(1);
 
@@ -113,6 +120,8 @@ export function computeDiffBlocks(
 					newLineNumber: null,
 					tokens: getTokensForLine(originalTokens, oldIdx, content),
 					content,
+					hunkIndex: hunk.index,
+					hunkLineOffset,
 				});
 				currentOldLine++;
 			} else if (prefix === "+") {
@@ -123,6 +132,8 @@ export function computeDiffBlocks(
 					newLineNumber: currentNewLine,
 					tokens: getTokensForLine(modifiedTokens, newIdx, content),
 					content,
+					hunkIndex: hunk.index,
+					hunkLineOffset,
 				});
 				currentNewLine++;
 			} else {
@@ -133,6 +144,8 @@ export function computeDiffBlocks(
 					newLineNumber: currentNewLine,
 					tokens: getTokensForLine(modifiedTokens, newIdx, content),
 					content,
+					hunkIndex: hunk.index,
+					hunkLineOffset,
 				});
 				currentOldLine++;
 				currentNewLine++;
@@ -169,37 +182,64 @@ export function computeDiffBlocks(
 
 export function assignChangeGroupsToBlocks(
 	blocks: DiffBlock[],
-	changeGroups: { groupIndex: number; newStart: number; newEnd: number }[],
+	changeGroups: {
+		groupIndex: number;
+		groupId: string;
+		hunkIndex: number;
+		newStart: number;
+		newEnd: number;
+		lineOffsetStart: number;
+		lineOffsetEnd: number;
+	}[],
 ): DiffBlock[] {
 	if (changeGroups.length === 0) return blocks;
 
-	return blocks.map((block) => {
+	return blocks.flatMap((block) => {
 		if (block.type !== "change") return block;
 
-		const firstNewLine = block.lines.find(
-			(l) => l.newLineNumber != null,
-		)?.newLineNumber;
-		const lastNewLine = [...block.lines]
-			.reverse()
-			.find((l) => l.newLineNumber != null)?.newLineNumber;
-		const firstOldLine = block.lines.find(
-			(l) => l.oldLineNumber != null,
-		)?.oldLineNumber;
+		const lineGroups = block.lines.map((line) =>
+			changeGroups.find(
+				(cg) =>
+					line.hunkIndex === cg.hunkIndex &&
+					line.hunkLineOffset != null &&
+					line.hunkLineOffset >= cg.lineOffsetStart &&
+					line.hunkLineOffset <= cg.lineOffsetEnd,
+			),
+		);
 
-		for (const cg of changeGroups) {
-			if (firstNewLine != null && lastNewLine != null) {
-				if (cg.newStart >= firstNewLine && cg.newEnd <= lastNewLine) {
-					return { ...block, changeGroupIndex: cg.groupIndex };
+		if (lineGroups.some((group) => group != null)) {
+			const result: DiffBlock[] = [];
+			let currentLines: DiffLine[] = [];
+			let currentGroup = lineGroups[0];
+			const flush = () => {
+				if (currentLines.length === 0) return;
+				if (currentGroup != null) {
+					result.push({
+						type: "change",
+						lines: currentLines,
+						changeGroupId: currentGroup.groupId,
+					});
+				} else {
+					result.push({
+						type: currentLines.some((line) => line.type !== "context")
+							? "change"
+							: "context",
+						lines: currentLines,
+					});
 				}
-				if (firstNewLine >= cg.newStart && firstNewLine <= cg.newEnd) {
-					return { ...block, changeGroupIndex: cg.groupIndex };
+				currentLines = [];
+			};
+
+			for (let i = 0; i < block.lines.length; i++) {
+				const group = lineGroups[i];
+				if (group?.groupId !== currentGroup?.groupId) {
+					flush();
+					currentGroup = group;
 				}
+				currentLines.push(block.lines[i]);
 			}
-			if (firstNewLine == null && firstOldLine != null) {
-				if (cg.newStart <= (firstOldLine ?? 0)) {
-					return { ...block, changeGroupIndex: cg.groupIndex };
-				}
-			}
+			flush();
+			return result;
 		}
 
 		return block;

--- a/src/hooks/useGitActions.ts
+++ b/src/hooks/useGitActions.ts
@@ -10,14 +10,6 @@ export function useGitActions() {
 		await invoke("git_unstage", { repoPath, paths });
 	}, []);
 
-	const stageHunk = useCallback(async (repoPath: string, patch: string) => {
-		await invoke("git_stage_hunk", { repoPath, patch });
-	}, []);
-
-	const unstageHunk = useCallback(async (repoPath: string, patch: string) => {
-		await invoke("git_unstage_hunk", { repoPath, patch });
-	}, []);
-
 	const createBranch = useCallback(
 		async (repoPath: string, branchName: string) => {
 			await invoke("git_create_branch", { repoPath, branchName });
@@ -28,8 +20,6 @@ export function useGitActions() {
 	return {
 		stage,
 		unstage,
-		stageHunk,
-		unstageHunk,
 		createBranch,
 	};
 }

--- a/src/lib/computeHunks.ts
+++ b/src/lib/computeHunks.ts
@@ -1,5 +1,6 @@
 export interface Hunk {
 	index: number;
+	hunkId: string;
 	oldStart: number;
 	oldLines: number;
 	newStart: number;
@@ -9,6 +10,7 @@ export interface Hunk {
 
 export interface ChangeGroup {
 	groupIndex: number;
+	groupId: string;
 	hunkIndex: number;
 	newStart: number;
 	newEnd: number;


### PR DESCRIPTION
## 概要

Issue #1212「Hunk operation を id-based にし frontend patch 再生成を削除する」の実装。

`docs/releash-performance-architecture-audit.md` M1（実装順 4-3）に位置づけられる、レビュー（diff 表示）経路のリファクタリング / 性能・メモリ効率改善。#1211（ReviewSnapshot / ReviewFileView）を前提に、stage / unstage 経路を **id-based operation** へ収束させる。

## 変更内容

- **S1 安定 id の付与**: `ReviewTextDiffDto` の `hunks` / `change_groups` に file refresh をまたいで安定する `hunk_id` / `group_id` を付与。
- **S2 id-based コマンド**: stage / unstage を id + intent で指定する Tauri コマンドに置き換え（`git_stage_review_group` / `git_unstage_review_group` の id-based 化）。frontend が渡すのは worktree / path / section / base / 対象 id / intent のみ。
- **S3 staged ベースの patch 再構築**: 対象 id から現在の snapshot 上の change group を解決し、staged をベースに patch を再構築。`snapshot_version` ガード（`ensure_current_review_snapshot_version`）を廃止し、整合性は id 解決可否で担保。解決できない場合はエラーを返す。
- **S4 frontend の整理**: `useDiffOperations` から位置 index / `snapshot_version` の持ち回りを除去。id 解決失敗時は snapshot refresh で回復するハンドリングを追加（握りつぶしを廃止）。

## 受け入れ基準

- [x] stage / unstage が id + intent のみで実行できる（位置 index / version の持ち回りなし）
- [x] `git apply --cached` のベース不一致を避けることをテストで確認
- [x] file refresh 後の stable id の扱い（同一内容なら有効 / 消失時はエラー）をテストで担保
- [x] `snapshot_version` ガードの廃止
- [x] id 解決失敗時に Rust がエラーを返し frontend が refresh で回復
- [x] 既存の group 単位 stage / unstage の振る舞い維持（`changes` で stage / `staged` で unstage / `branch-base` 非対応 / change group 単位）

Spec: `docs/specs/issues-1212/{requirements,design,behavior}.md`

Closes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 差分の各ハンク/変更グループに安定したIDが付くようになり、再読み込み後も同じ対象を扱いやすくなりました。
  * ステージ/アンステージ操作が、位置情報ではなくグループIDで行われるようになりました。
  * 差分ビューで、ステージ対象の識別と表示の安定性が向上しました。

* **不具合修正**
  * 差分更新後に別の対象へ誤って操作してしまう問題を防ぎました。
  * 対象が見つからない場合はエラーとして扱い、画面更新を促すようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->