### PR TITLE
fix(agent): interrupt 後の follow-up が hang する不具合を修正 (#1284)

### DIFF
--- a/src-tauri/resources/claude-sdk-bridge.mjs
+++ b/src-tauri/resources/claude-sdk-bridge.mjs
@@ -48,10 +48,19 @@ async function* promptGenerator(promptState) {
 			yield queued.message;
 			continue;
 		}
+		let myResolve;
 		const queued = await new Promise((resolve) => {
 			messageResolve = resolve;
+			myResolve = resolve;
 		});
-		messageResolve = null;
+		// Only clear the shared resolver if it is still ours. After a hard
+		// interrupt the next query's generator may have already installed its
+		// own resolver before this (old) generator's await settles; clearing it
+		// unconditionally here would strand the follow-up message in the queue
+		// (issues-1284).
+		if (messageResolve === myResolve) {
+			messageResolve = null;
+		}
 		if (queued === null) return;
 		if (promptState.completedResult) {
 			messageQueue.unshift(queued);


### PR DESCRIPTION
## 概要

interrupt（hard interrupt）後の follow-up メッセージが hang する不具合を修正します（#1284）。

## 原因

`claude-sdk-bridge.mjs` の `promptGenerator` で、`await` settle 後に共有リゾルバ `messageResolve` を無条件に `null` クリアしていました。hard interrupt 後、次の query のジェネレータが自身のリゾルバを既にインストールしているケースがあり、古いジェネレータ側がそれを上書きクリアしてしまうと、follow-up メッセージがキューに取り残され hang します。

## 修正

`messageResolve` が自分自身（`myResolve`）と一致する場合のみクリアするようガードを追加しました。

## 影響範囲

- `src-tauri/resources/claude-sdk-bridge.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)