### PR TITLE
docs: add domain glossary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,48 @@
 # Releash
 
-Tauri + React + Monaco Editor のデスクトップGitエディタ。
-WebSocketサーバーとremote_accessバックエンドは残存しているが、モバイル向けフロントremoteクライアントと専用ビルド経路は削除済み。
+Releash は、ソフトウェア開発のための **programmable agentic workflow workbench**。
 
-## アーキテクチャ
+プロダクトの中心は workflow である。開発者が agentic workflow を定義し、実行し、観測し、承認し、却下し、再指示し、その判断に必要な作業状態を同じ場所で扱えることを目指す。
 
-### ロジック配置の原則
-- **全てのロジックはRustに実装し、フロントエンドはインターフェースに徹する（例外なし）**
-- フロントエンドの責務: 表示、入力受付、Tauriコマンド呼び出し、表示用フォーマット
-- 新機能のロジックは必ずTauriコマンドとして実装し、フロントからは `invoke` で呼ぶ
+Releash は、特定の作業単位や特定の道具を主語にしない。コード、差分、terminal、テスト出力、review comment、agent session、workflow run、approval、実行履歴などを、workflow が扱う artifact として統合する。
 
-### デスクトップアプリ（メイン）
+## プロダクト方針
+
+- Releash は programmable agentic workflow の workbench であり、小さな IDE クローンではない。
+- 第一級の状態は workflow state である。
+- human checkpoint を第一級に扱う。観測、承認、却下、指示修正、再開を自然にできるようにする。
+- artifact は workflow の入力・出力・判断材料であり、プロダクトの主語ではない。
+- remote / mobile を扱う場合は、workflow 判断点への監督・介入を中心にする。
+- 実装は、実際の workflow action が軽くなる・信頼できるようになる薄い縦切りを優先する。
+
+## アーキテクチャ原則
+
+### Rust がロジックを所有する
+
+- **全てのアプリケーションロジックは Rust に置く。例外なし。**
+- フロントエンドの責務は、表示、入力受付、backend command 呼び出し、最小限の表示用フォーマットに限る。
+- 新しい振る舞いは Rust の usecase / query service / Tauri command の背後に実装し、frontend からは `invoke` で呼ぶ。
+- workflow、session、artifact、terminal、review、persistence のロジックを React hook や UI component に追加しない。
+- 触った frontend code に既存ロジックが残っている場合は、タスクのスコープ内で可能な範囲で Rust 境界へ移す。
+
+### 状態の所有者を明確にする
+
+- workflow runtime、workflow artifact、agent session state、review comment、terminal state、persistence の所有者を明確にする。
+- full-retention 設計を避ける。summary、page、id-based operation、delta で足りる場合に、session body、artifact、stream、workflow state 全体を clone / store / recompute / resend しない。
+- read model は、Tauri、WebSocket、将来の daemon / native client が同じ backend-owned state を読める形にする。
+- frontend state は UI に必要な状態の mirror に留め、domain behavior の source of truth にしない。
+
+### デスクトップアプリ
+
 - **フロントエンド**: React 19 + TypeScript + TailwindCSS 4 + Monaco Editor
-- **バックエンド**: Rust (Tauri 2) + git2 + tokio
-- **ビルド**: Vite + Biome (lint/format)
-
-### リモートアクセス（バックエンドのみ残存）
-- モバイル向けフロントremoteクライアントとremote専用ビルド経路は削除済み
-- デスクトップ側のWebSocketサーバー（`ws_server/`）と`ws_bridge.rs`は残存
-- `src-tauri/src/domain/remote_access/` と `src-tauri/src/usecase/remote_access/` にremote_accessバックエンドロジックが残存
-- WebSocketメッセージ型・認証・セッション管理は `protocol/` と `ws_server/` が担当
+- **バックエンド**: Rust (Tauri 2) + tokio
+- **ビルド**: Vite + Biome
 
 ### 通信レイヤー
-- `src-tauri/src/protocol/` — WebSocketメッセージの型定義（auth, git, pty, comment, agent等）
-- `src-tauri/src/ws_bridge.rs` — ブロードキャスター（PTY出力バッファリング含む）
-- `src-tauri/src/ws_server/` — セッション管理、認証、ルーティング、レート制限
+
+- `src-tauri/src/protocol/` - WebSocket message type / DTO
+- `src-tauri/src/ws_bridge.rs` - broadcaster / sync bridge
+- `src-tauri/src/ws_server/` - session、auth、routing、handler、rate limit
 
 ## ディレクトリ構造
 
@@ -32,40 +50,55 @@ WebSocketサーバーとremote_accessバックエンドは残存しているが�
 src/                        # フロントエンド
 ├── components/panels/      # EditorTabContent, FileTree, TerminalPanel, SourceControlPanel 等
 ├── components/layout/      # ActivityBar, StatusBar
-├── components/workspace/   # Worktree管理UI
-├── components/ui/          # shadcn/ui プリミティブ
-├── hooks/                  # カスタムフック（useFileContents, useGitStatus 等）
-├── lib/                    # ユーティリティ（computeHunks, generatePatch 等）
-├── contexts/               # EditorContext
+├── components/workspace/   # Worktree 管理 UI
+├── components/ui/          # shadcn/ui primitive
+├── hooks/                  # React hook。interface-oriented に保つ
+├── lib/                    # frontend utility。domain logic を追加しない
+├── contexts/               # EditorContext と UI context
 ├── screens/                # WorktreeView, WorkspaceManagerScreen
-└── types/                  # 型定義
+└── types/                  # frontend-facing type
 
 src-tauri/src/              # バックエンド
-├── domain/remote_access/   # リモートアクセス用ドメインロジック
-├── usecase/remote_access/  # リモートアクセス用ユースケース
-├── git/                    # Git操作（branch, commit, status, diff, stage, worktree, log）
-├── ws_server/              # WebSocketサーバー（handlers, session, auth, routing）
-├── protocol/               # 通信プロトコル型定義
-├── git_host/               # GitHub連携（PR取得等）
-├── pty.rs                  # 疑似端末管理
-├── config.rs               # アプリ設定（TOML）
-├── webhook.rs              # Slack/Discord Webhook通知
-├── watcher.rs              # ファイル変更監視
-└── shell_integration.rs    # Bash/Zsh/Fish シェル統合
+├── domain/                 # domain logic
+├── usecase/                # application workflow / usecase
+├── adaptor/                # controller, gateway, presenter, protocol adapter
+├── infrastructure/         # filesystem, process, network client 等
+├── protocol/               # WebSocket protocol type
+├── ws_server/              # WebSocket server
+├── ws_bridge.rs            # WebSocket / app bridge
+├── pty.rs                  # PTY management
+├── config.rs               # app config
+├── webhook.rs              # Slack / Discord webhook notification
+├── watcher.rs              # file watching
+└── shell_integration.rs    # Bash / Zsh / Fish shell integration
 ```
+
+バックエンドは clean architecture へ段階移行中。Rust layer の詳細な規約は `src-tauri/AGENTS.md` と `docs/architecture/` を参照。
 
 ## ビルド・テスト・Lint
 
-CIと同じコマンドを使うこと（`.github/workflows/ci.yml` 参照）。
+CI と同じコマンドを使う。`.github/workflows/ci.yml` を参照。
 
-### フロントエンド（プロジェクトルートで実行）
+### フロントエンド
+
+プロジェクトルートで実行:
+
 ```bash
-pnpm lint          # Biome check（失敗時は pnpm lint:fix で修正）
-pnpm test          # Vitest
-pnpm build         # TSC + Vite build + bridge生成
+pnpm lint
+pnpm test
+pnpm build
 ```
 
-### Rust（src-tauri/ ディレクトリで実行）
+format / import order で lint が落ちた場合:
+
+```bash
+pnpm lint:fix
+```
+
+### Rust
+
+`src-tauri/` で実行:
+
 ```bash
 cargo fmt --check
 cargo clippy -- -D warnings
@@ -73,46 +106,64 @@ cargo test
 ```
 
 ### 統合テスト
+
+プロジェクトルートで実行:
+
 ```bash
-pnpm test:integration   # Playwright
+pnpm test:integration
 ```
 
 ## テスト方針
 
 ### 配置
-- フロントエンド: ソースファイルと同じディレクトリに `*.test.tsx` / `*.test.ts`
-- Rust: 各モジュール内に `#[cfg(test)] mod tests { ... }`
 
-### 何をテストするか
-- 新規ロジックには必ずテストを書く
-- ユーティリティ関数（`lib/`）: 入出力の網羅テスト、境界値テスト
-- カスタムフック（`hooks/`）: 状態遷移と副作用のテスト
-- コンポーネント: ユーザーインタラクションと表示条件のテスト
-- Rustコマンド: 正常系・エラー系の両方
+- フロントエンドテストは対象ファイルの隣に `*.test.tsx` / `*.test.ts` として置く。
+- Rust テストは該当 module 内に `#[cfg(test)] mod tests { ... }` として置く。
 
-### モックの方針
-- `react-resizable-panels`: jsdomで動作しないため `vi.mock` 必須
-- Tauri API（`@tauri-apps/api`）: `vi.mock` でスタブ化
-- Monaco Editor: 命令型APIのため統合テストではなくロジックのみ単体テスト
-- 外部プロセス（`git push` 等）: テストでは実行しない
+### カバレッジ期待値
+
+- 新規ロジックにはテストを書く。
+- frontend utility は入出力と edge case をテストする。
+- hook は状態遷移と副作用をテストする。
+- component は user interaction と conditional rendering をテストする。
+- Rust command / usecase は正常系とエラー系をテストする。
+
+### モック方針
+
+- `react-resizable-panels` は jsdom で動作しないため `vi.mock` する。
+- `@tauri-apps/api` の Tauri API は `vi.mock` で stub する。
+- Monaco Editor は imperative API を持つため、Monaco 自体の integration test より周辺ロジックの unit test を優先する。
+- 外部プロセスはテストで実行しない。
 
 ## コーディング規約
 
 ### フロントエンド
-- インデント: Tab（Biome設定）
-- インポート整理: Biomeの自動整理に任せる
-- UIコンポーネント: shadcn/ui (Radix UI) ベース
-- スタイル: TailwindCSS
+
+- インデントは tab。Biome に従う。
+- import 整理は Biome に任せる。
+- UI component は shadcn/ui と Radix UI をベースにする。
+- styling は TailwindCSS。
+- React component は interface-oriented に保つ。domain decision を hook、reducer、view helper に埋め込まない。
 
 ### Rust
-- `git2` クレートでGit操作。pushのみ `std::process::Command` で `git push`
-- 非同期処理: tokio
-- エラー型: 各モジュールに専用エラー型
 
-## 既知の制約・注意点
+- async 処理は tokio を使う。
+- module ごとに専用 error type を使う。
+- domain code は infrastructure dependency を持たない。
+- controller は Tauri / WebSocket input を usecase call へ変換する。business behavior を controller に持たせない。
 
-- Monaco Editorのファイル切り替え: `key={filePath}` で再マウントすること（中間状態でフリーズする）
-- `git2` の UnbornBranch: `repo.head()` が `ErrorCode::UnbornBranch` → 初回コミット前の特別処理が必要
-- `git apply --cached`: パッチのベースはStagedにすること（HEADベースだとコンテキスト行不一致）
-- worktreeをリポジトリルート内に作るとBiomeがネスト設定エラーを起こす → worktreeは外部に配置
-- `ignore::WalkBuilder` はテストで `.git` ディレクトリが必要 → `git2::Repository::init()` で初期化
+## 既知の制約
+
+- Monaco Editor のファイル切り替えは `key={filePath}` で remount する。中間状態で freeze することがある。
+- worktree は repository root 内に作らない。Biome が nested config で失敗することがある。
+
+## レビュー観点
+
+Releash を変更するときは、次を確認する。
+
+- workflow action の定義、実行、観測、承認、却下、再指示のどれかが軽くなるか。
+- 新しいロジックは frontend ではなく Rust に置かれているか。
+- 変更した state の source of truth は明確か。
+- full-retention / full-recompute 経路を増やしていないか。
+- 同じ backend-owned state を Tauri、WebSocket、将来の client surface で再利用できるか。
+- artifact が workflow の判断材料として扱われているか。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,30 +1,48 @@
 # Releash
 
-Tauri + React + Monaco Editor のデスクトップGitエディタ。
-WebSocketサーバーとremote_accessバックエンドは残存しているが、モバイル向けフロントremoteクライアントと専用ビルド経路は削除済み。
+Releash は、ソフトウェア開発のための **programmable agentic workflow workbench**。
 
-## アーキテクチャ
+プロダクトの中心は workflow である。開発者が agentic workflow を定義し、実行し、観測し、承認し、却下し、再指示し、その判断に必要な作業状態を同じ場所で扱えることを目指す。
 
-### ロジック配置の原則
-- **全てのロジックはRustに実装し、フロントエンドはインターフェースに徹する（例外なし）**
-- フロントエンドの責務: 表示、入力受付、Tauriコマンド呼び出し、表示用フォーマット
-- 新機能のロジックは必ずTauriコマンドとして実装し、フロントからは `invoke` で呼ぶ
+Releash は、特定の作業単位や特定の道具を主語にしない。コード、差分、terminal、テスト出力、review comment、agent session、workflow run、approval、実行履歴などを、workflow が扱う artifact として統合する。
 
-### デスクトップアプリ（メイン）
+## プロダクト方針
+
+- Releash は programmable agentic workflow の workbench であり、小さな IDE クローンではない。
+- 第一級の状態は workflow state である。
+- human checkpoint を第一級に扱う。観測、承認、却下、指示修正、再開を自然にできるようにする。
+- artifact は workflow の入力・出力・判断材料であり、プロダクトの主語ではない。
+- remote / mobile を扱う場合は、workflow 判断点への監督・介入を中心にする。
+- 実装は、実際の workflow action が軽くなる・信頼できるようになる薄い縦切りを優先する。
+
+## アーキテクチャ原則
+
+### Rust がロジックを所有する
+
+- **全てのアプリケーションロジックは Rust に置く。例外なし。**
+- フロントエンドの責務は、表示、入力受付、backend command 呼び出し、最小限の表示用フォーマットに限る。
+- 新しい振る舞いは Rust の usecase / query service / Tauri command の背後に実装し、frontend からは `invoke` で呼ぶ。
+- workflow、session、artifact、terminal、review、persistence のロジックを React hook や UI component に追加しない。
+- 触った frontend code に既存ロジックが残っている場合は、タスクのスコープ内で可能な範囲で Rust 境界へ移す。
+
+### 状態の所有者を明確にする
+
+- workflow runtime、workflow artifact、agent session state、review comment、terminal state、persistence の所有者を明確にする。
+- full-retention 設計を避ける。summary、page、id-based operation、delta で足りる場合に、session body、artifact、stream、workflow state 全体を clone / store / recompute / resend しない。
+- read model は、Tauri、WebSocket、将来の daemon / native client が同じ backend-owned state を読める形にする。
+- frontend state は UI に必要な状態の mirror に留め、domain behavior の source of truth にしない。
+
+### デスクトップアプリ
+
 - **フロントエンド**: React 19 + TypeScript + TailwindCSS 4 + Monaco Editor
-- **バックエンド**: Rust (Tauri 2) + git2 + tokio
-- **ビルド**: Vite + Biome (lint/format)
-
-### リモートアクセス（バックエンドのみ残存）
-- モバイル向けフロントremoteクライアントとremote専用ビルド経路は削除済み
-- デスクトップ側のWebSocketサーバー（`ws_server/`）と`ws_bridge.rs`は残存
-- `src-tauri/src/domain/remote_access/` と `src-tauri/src/usecase/remote_access/` にremote_accessバックエンドロジックが残存
-- WebSocketメッセージ型・認証・セッション管理は `protocol/` と `ws_server/` が担当
+- **バックエンド**: Rust (Tauri 2) + tokio
+- **ビルド**: Vite + Biome
 
 ### 通信レイヤー
-- `src-tauri/src/protocol/` — WebSocketメッセージの型定義（auth, git, pty, comment, agent等）
-- `src-tauri/src/ws_bridge.rs` — ブロードキャスター（PTY出力バッファリング含む）
-- `src-tauri/src/ws_server/` — セッション管理、認証、ルーティング、レート制限
+
+- `src-tauri/src/protocol/` - WebSocket message type / DTO
+- `src-tauri/src/ws_bridge.rs` - broadcaster / sync bridge
+- `src-tauri/src/ws_server/` - session、auth、routing、handler、rate limit
 
 ## ディレクトリ構造
 
@@ -32,40 +50,55 @@ WebSocketサーバーとremote_accessバックエンドは残存しているが�
 src/                        # フロントエンド
 ├── components/panels/      # EditorTabContent, FileTree, TerminalPanel, SourceControlPanel 等
 ├── components/layout/      # ActivityBar, StatusBar
-├── components/workspace/   # Worktree管理UI
-├── components/ui/          # shadcn/ui プリミティブ
-├── hooks/                  # カスタムフック（useFileContents, useGitStatus 等）
-├── lib/                    # ユーティリティ（computeHunks, generatePatch 等）
-├── contexts/               # EditorContext
+├── components/workspace/   # Worktree 管理 UI
+├── components/ui/          # shadcn/ui primitive
+├── hooks/                  # React hook。interface-oriented に保つ
+├── lib/                    # frontend utility。domain logic を追加しない
+├── contexts/               # EditorContext と UI context
 ├── screens/                # WorktreeView, WorkspaceManagerScreen
-└── types/                  # 型定義
+└── types/                  # frontend-facing type
 
 src-tauri/src/              # バックエンド
-├── domain/remote_access/   # リモートアクセス用ドメインロジック
-├── usecase/remote_access/  # リモートアクセス用ユースケース
-├── git/                    # Git操作（branch, commit, status, diff, stage, worktree, log）
-├── ws_server/              # WebSocketサーバー（handlers, session, auth, routing）
-├── protocol/               # 通信プロトコル型定義
-├── git_host/               # GitHub連携（PR取得等）
-├── pty.rs                  # 疑似端末管理
-├── config.rs               # アプリ設定（TOML）
-├── webhook.rs              # Slack/Discord Webhook通知
-├── watcher.rs              # ファイル変更監視
-└── shell_integration.rs    # Bash/Zsh/Fish シェル統合
+├── domain/                 # domain logic
+├── usecase/                # application workflow / usecase
+├── adaptor/                # controller, gateway, presenter, protocol adapter
+├── infrastructure/         # filesystem, process, network client 等
+├── protocol/               # WebSocket protocol type
+├── ws_server/              # WebSocket server
+├── ws_bridge.rs            # WebSocket / app bridge
+├── pty.rs                  # PTY management
+├── config.rs               # app config
+├── webhook.rs              # Slack / Discord webhook notification
+├── watcher.rs              # file watching
+└── shell_integration.rs    # Bash / Zsh / Fish shell integration
 ```
+
+バックエンドは clean architecture へ段階移行中。Rust layer の詳細な規約は `src-tauri/AGENTS.md` と `docs/architecture/` を参照。
 
 ## ビルド・テスト・Lint
 
-CIと同じコマンドを使うこと（`.github/workflows/ci.yml` 参照）。
+CI と同じコマンドを使う。`.github/workflows/ci.yml` を参照。
 
-### フロントエンド（プロジェクトルートで実行）
+### フロントエンド
+
+プロジェクトルートで実行:
+
 ```bash
-pnpm lint          # Biome check（失敗時は pnpm lint:fix で修正）
-pnpm test          # Vitest
-pnpm build         # TSC + Vite build + bridge生成
+pnpm lint
+pnpm test
+pnpm build
 ```
 
-### Rust（src-tauri/ ディレクトリで実行）
+format / import order で lint が落ちた場合:
+
+```bash
+pnpm lint:fix
+```
+
+### Rust
+
+`src-tauri/` で実行:
+
 ```bash
 cargo fmt --check
 cargo clippy -- -D warnings
@@ -73,46 +106,64 @@ cargo test
 ```
 
 ### 統合テスト
+
+プロジェクトルートで実行:
+
 ```bash
-pnpm test:integration   # Playwright
+pnpm test:integration
 ```
 
 ## テスト方針
 
 ### 配置
-- フロントエンド: ソースファイルと同じディレクトリに `*.test.tsx` / `*.test.ts`
-- Rust: 各モジュール内に `#[cfg(test)] mod tests { ... }`
 
-### 何をテストするか
-- 新規ロジックには必ずテストを書く
-- ユーティリティ関数（`lib/`）: 入出力の網羅テスト、境界値テスト
-- カスタムフック（`hooks/`）: 状態遷移と副作用のテスト
-- コンポーネント: ユーザーインタラクションと表示条件のテスト
-- Rustコマンド: 正常系・エラー系の両方
+- フロントエンドテストは対象ファイルの隣に `*.test.tsx` / `*.test.ts` として置く。
+- Rust テストは該当 module 内に `#[cfg(test)] mod tests { ... }` として置く。
 
-### モックの方針
-- `react-resizable-panels`: jsdomで動作しないため `vi.mock` 必須
-- Tauri API（`@tauri-apps/api`）: `vi.mock` でスタブ化
-- Monaco Editor: 命令型APIのため統合テストではなくロジックのみ単体テスト
-- 外部プロセス（`git push` 等）: テストでは実行しない
+### カバレッジ期待値
+
+- 新規ロジックにはテストを書く。
+- frontend utility は入出力と edge case をテストする。
+- hook は状態遷移と副作用をテストする。
+- component は user interaction と conditional rendering をテストする。
+- Rust command / usecase は正常系とエラー系をテストする。
+
+### モック方針
+
+- `react-resizable-panels` は jsdom で動作しないため `vi.mock` する。
+- `@tauri-apps/api` の Tauri API は `vi.mock` で stub する。
+- Monaco Editor は imperative API を持つため、Monaco 自体の integration test より周辺ロジックの unit test を優先する。
+- 外部プロセスはテストで実行しない。
 
 ## コーディング規約
 
 ### フロントエンド
-- インデント: Tab（Biome設定）
-- インポート整理: Biomeの自動整理に任せる
-- UIコンポーネント: shadcn/ui (Radix UI) ベース
-- スタイル: TailwindCSS
+
+- インデントは tab。Biome に従う。
+- import 整理は Biome に任せる。
+- UI component は shadcn/ui と Radix UI をベースにする。
+- styling は TailwindCSS。
+- React component は interface-oriented に保つ。domain decision を hook、reducer、view helper に埋め込まない。
 
 ### Rust
-- `git2` クレートでGit操作。pushのみ `std::process::Command` で `git push`
-- 非同期処理: tokio
-- エラー型: 各モジュールに専用エラー型
 
-## 既知の制約・注意点
+- async 処理は tokio を使う。
+- module ごとに専用 error type を使う。
+- domain code は infrastructure dependency を持たない。
+- controller は Tauri / WebSocket input を usecase call へ変換する。business behavior を controller に持たせない。
 
-- Monaco Editorのファイル切り替え: `key={filePath}` で再マウントすること（中間状態でフリーズする）
-- `git2` の UnbornBranch: `repo.head()` が `ErrorCode::UnbornBranch` → 初回コミット前の特別処理が必要
-- `git apply --cached`: パッチのベースはStagedにすること（HEADベースだとコンテキスト行不一致）
-- worktreeをリポジトリルート内に作るとBiomeがネスト設定エラーを起こす → worktreeは外部に配置
-- `ignore::WalkBuilder` はテストで `.git` ディレクトリが必要 → `git2::Repository::init()` で初期化
+## 既知の制約
+
+- Monaco Editor のファイル切り替えは `key={filePath}` で remount する。中間状態で freeze することがある。
+- worktree は repository root 内に作らない。Biome が nested config で失敗することがある。
+
+## レビュー観点
+
+Releash を変更するときは、次を確認する。
+
+- workflow action の定義、実行、観測、承認、却下、再指示のどれかが軽くなるか。
+- 新しいロジックは frontend ではなく Rust に置かれているか。
+- 変更した state の source of truth は明確か。
+- full-retention / full-recompute 経路を増やしていないか。
+- 同じ backend-owned state を Tauri、WebSocket、将来の client surface で再利用できるか。
+- artifact が workflow の判断材料として扱われているか。

--- a/docs/architecture/GLOSSARY.md
+++ b/docs/architecture/GLOSSARY.md
@@ -78,8 +78,7 @@ Workspace
   │         └─ Attachment
   ├─ Command
   ├─ Thread
-  │    ├─ Comment
-  │    └─ CodeAnchor
+  │    └─ Comment
   └─ WorkspaceState
 ```
 
@@ -89,13 +88,15 @@ Workspace
 - Task / Artifact / NodeExecution は WorkflowExecution に属する。
 - Fanout は親 NodeExecution と子 NodeExecution 群を束ねる。
 - PermissionRequest は Turn に属する。
-- Thread は CodeAnchor に紐づくが、WorkflowExecution / NodeExecution には属さない。
+- Thread は CodeAnchor を参照できるが、CodeAnchor を所有しない。
+- Thread は WorkflowExecution / NodeExecution には属さない。
 
 ### Worktree / Repository / Code
 
 ```text
 Worktree
   ├─ Code
+  │    └─ CodeAnchor
   └─ Diff
 
 Repository
@@ -104,8 +105,10 @@ Repository
 
 - Worktree は Repository の特定 checkout / working tree。
 - Code は Worktree 内のファイル内容。
+- CodeAnchor は Code 上の位置への参照。
 - Diff は Worktree / Repository の状態から計算される。
 - Worktree / Repository / Code / Diff は Releash が所有する状態ではない。
+- CodeAnchor は Code 本体ではなく、Thread などから参照される位置情報。
 
 ### Operation Surface
 

--- a/docs/architecture/GLOSSARY.md
+++ b/docs/architecture/GLOSSARY.md
@@ -1,0 +1,194 @@
+# Releash GLOSSARY
+
+## 目的
+
+Releash のドメイン横断ユビキタス言語を定義する。
+このドキュメントは [#1176](https://github.com/siro33950/releash/issues/1176) の正規成果物であり、設計、レビュー、移行作業で参照する canonical vocabulary として扱う。
+
+このドキュメントは現行実装の棚卸しではなく、Releash で使う正しい語彙と構造を定義する。
+
+## 正規語一覧
+
+| 正規語 | 定義 | 所属ドメイン | 使用禁止語 | 備考 |
+|---|---|---|---|---|
+| WorkflowDefinition | workflow の定義。NodeDefinition の構成、順序、条件、入力を持つ。 | workflow | Workflow, WorkflowBundle | 実行状態は持たない。 |
+| NodeDefinition | WorkflowDefinition 内の作業単位の定義。 | workflow | StepDefinition, ChildNodeDefinition, NodeType | 何を扱うかは構成・参照先・実行内容から決まる。 |
+| WorkflowExecution | WorkflowDefinition の一回の実行。 | workflow | WorkflowRun, Run | `status` を持つ。 |
+| NodeExecution | NodeDefinition の一回の実行。 | workflow | StepExecution, WorkflowStep | Session / Command / Fanout を扱うことがある。 |
+| Fanout | 親 NodeExecution から展開された子 NodeExecution 群を束ねる実体。 | workflow | ParallelRun, ParallelChildRun, ParallelStep | `parallel` 系語彙は Fanout に吸収する。 |
+| Task | WorkflowExecution 内で Node 間を跨ぐ作業情報。 | workflow | MainTask, SubTask | main / sub の区別は持たない。 |
+| Artifact | WorkflowExecution / NodeExecution の間で生成・参照される判断材料、成果物、中間出力。 | workflow | StepOutput, ArtifactSnapshot, ArtifactLineage | 状態は持たない。 |
+| Facet | NodeDefinition から参照される再利用可能な補助部品。 | workflow | ResolvedFacets | 主要 Entity ではない。 |
+| Contract | NodeDefinition の output contract や Artifact/output validation に関わる補助語彙。 | workflow | ContractValidationMetadata | 主要 Entity ではない。 |
+| Diagnostic | 定義や参照の構文・validation error。 | workflow | lifecycle state | lifecycle state ではない。 |
+| Workspace | Releash 側の作業コンテキスト。Worktree を参照するが同一ではない。 | workspace_state | Worktree | Releash 所有状態の帰属先。 |
+| WorkspaceState | Workspace の UI state。 | workspace_state | WorkspaceTabsState, WorkspaceLayoutState, WorkspaceTabEntry | editor tabs / layout / selected diff file など。 |
+| Worktree | Repository の特定 checkout / working tree。 | repository | Workspace | 外部実体。Releash は所有しない。 |
+| Repository | Worktree の背後にある履歴・remote・branch のまとまり。 | repository | Repo | Releash は所有しない。 |
+| Code | Worktree 内のファイル内容。 | code | FileContent | Releash は所有せず、参照・表示・操作する。 |
+| Diff | Worktree / Repository の状態から計算される差分。 | code | CodeDiff | Releash が生み出すものではない。固定した判断材料は Artifact にできる。 |
+| CodeAnchor | Code 上の位置への参照。 | code | HunkRef, MentionReference | 命名は仮。Code 本体ではない。 |
+| Session | Agent との継続的な対話・実行単位。 | agent_session | ChatSession | Workspace に属する。 |
+| Turn | Session 内の一回の agent interaction / execution。 | agent_session | AgentTurn | PermissionRequest は Turn に属する。 |
+| Message | Session / Turn 内の message。 | agent_session | ChatMessage | MessageRole / MessagePart を持つ。 |
+| MessagePart | Message の部分表現。 | agent_session | ActivityEntry | variant は独立語彙にしない。 |
+| MessageRole | Message の役割。 | agent_session | Role | human / agent / system。 |
+| PermissionRequest | Turn に属する個別の許可要求。 | agent_session | ApprovalDecision | PermissionDecision は解決結果の属性として扱う。 |
+| Attachment | Message に添付される入力・参照。 | agent_session | AttachmentRef, SessionAttachment, ImageAttachment | Artifact とは別。 |
+| Thread | Workspace に属する会話・作業履歴・文脈。 | comment | ReviewThread | WorkflowExecution / NodeExecution には属さない。 |
+| Comment | Thread 配下の comment。 | comment | ReviewComment | review comment / discussion comment を吸収する。 |
+| Command | Session と対比される non-interactive な一回の command 実行単位。 | workflow | CommandExecution, ShellCommand, RunCommand | 命名は暫定。 |
+| Terminal | ユーザーが操作する interactive shell session。 | pty_session | PtySession, Command | Workspace に属する。workflow / node が直接触るものではない。 |
+| UI | 人間が画面から操作・観測する面。 | operation_surface | FrontendDomain | Operation Surface。 |
+| CLI | command line から操作・観測する面。 | operation_surface | CliMutationRequestRecord | Operation Surface。 |
+| API | 外部 system、automation、remote client が programmatic に操作・観測する面。 | operation_surface | ProtocolDomain | Operation Surface。 |
+
+## 構造
+
+### Global / App
+
+```text
+Global / App
+  └─ WorkflowDefinition
+       └─ NodeDefinition
+```
+
+- WorkflowDefinition は Global / App に属する。
+- NodeDefinition は WorkflowDefinition に属する。
+- NodeDefinition は standalone では存在しない。
+
+### Workspace
+
+```text
+Workspace
+  ├─ targets Worktree
+  ├─ Terminal
+  ├─ WorkflowExecution
+  │    ├─ Task
+  │    ├─ Artifact
+  │    └─ NodeExecution
+  │         └─ Fanout
+  │              ├─ parent NodeExecution
+  │              └─ child NodeExecution[]
+  │
+  ├─ Session
+  │    ├─ Turn
+  │    │    └─ PermissionRequest
+  │    └─ Message
+  │         └─ Attachment
+  ├─ Command
+  ├─ Thread
+  │    ├─ Comment
+  │    └─ CodeAnchor
+  └─ WorkspaceState
+```
+
+- Workspace は Releash 側の作業コンテキスト。
+- Workspace は Worktree を参照するが、Worktree そのものではない。
+- WorkflowExecution / Session / Command / Terminal / Thread / WorkspaceState は Workspace に属する。
+- Task / Artifact / NodeExecution は WorkflowExecution に属する。
+- Fanout は親 NodeExecution と子 NodeExecution 群を束ねる。
+- PermissionRequest は Turn に属する。
+- Thread は CodeAnchor に紐づくが、WorkflowExecution / NodeExecution には属さない。
+
+### Worktree / Repository / Code
+
+```text
+Worktree
+  ├─ Code
+  └─ Diff
+
+Repository
+  └─ Worktree
+```
+
+- Worktree は Repository の特定 checkout / working tree。
+- Code は Worktree 内のファイル内容。
+- Diff は Worktree / Repository の状態から計算される。
+- Worktree / Repository / Code / Diff は Releash が所有する状態ではない。
+
+### Operation Surface
+
+```text
+Operation Surface
+  ├─ UI
+  ├─ CLI
+  └─ API
+```
+
+- UI / CLI / API は domain entity ではなく操作・観測の入口。
+- Operation Surface は domain state を所有しない。
+
+## 状態所有
+
+### 状態を持つ
+
+- Workspace
+- WorkflowExecution
+- NodeExecution
+- Fanout
+- Task
+- Session
+- Turn
+- PermissionRequest
+- Command
+- Terminal
+- Thread
+- WorkspaceState
+- WorkflowDefinition（管理状態）
+
+### 状態を持たない
+
+- Artifact
+- Worktree（Releash 側の状態は持たない）
+- Repository（Releash 側の状態は持たない）
+- Code（Releash 側の状態は持たない）
+- Diff（Releash 側の状態は持たない）
+- NodeDefinition
+
+### Diagnostic
+
+- WorkflowDefinition の構文・validation error
+- NodeDefinition の構文・参照・遷移 error
+
+構文エラー、validation error、参照エラーは lifecycle state ではなく Diagnostic として扱う。
+
+## 外部実体との境界
+
+- Workspace は Worktree を参照するが、Worktree と同一ではない。
+- Worktree / Repository / Code / Diff は外部 repository 側の実体または派生 view。
+- Releash が固定した判断材料として保持したい場合は Artifact にする。
+- PR / Issue / Notion / external editor / remote access / notification は、それぞれ外部 system または integration の情報であり、現時点では core domain entity として扱わない。
+
+## 使用禁止語一覧
+
+| 使用禁止語 | 正規語 | 理由 |
+|---|---|---|
+| WorkflowRun | WorkflowExecution | `Run` は旧実装語彙。定義の一回の実行は WorkflowExecution と呼ぶ。 |
+| Run | WorkflowExecution | 同上。 |
+| RunId | WorkflowExecution.id | id 属性として扱う。 |
+| RunStatus | WorkflowExecution.status | status 属性として扱う。 |
+| TerminalRunStatus | WorkflowExecution.status | 終了状態だけを切り出した実装型。 |
+| TriggerSource | WorkflowExecution.created_from | 起動元属性として扱う。 |
+| WorkflowName | WorkflowDefinition.name | name 属性として扱う。 |
+| NodeName | NodeDefinition.name | name 属性として扱う。 |
+| WorktreePath | Workspace.worktree_ref.path | Worktree 参照の path 属性として扱う。 |
+| NodeType | なし | NodeDefinition の構成・参照先・実行内容から判断する。 |
+| ChildNodeDefinition | NodeDefinition | fanout 先も通常の NodeDefinition として扱う。 |
+| StepExecution | NodeExecution | step ではなく node execution と呼ぶ。 |
+| WorkflowStep | NodeExecution / NodeDefinition | 文脈に応じて定義か実行に分ける。 |
+| ParallelRun | Fanout | parallel 系語彙は Fanout に吸収する。 |
+| ParallelChildRun | Fanout / NodeExecution | fanout child も NodeExecution。 |
+| ParallelStep | Fanout / NodeExecution | parallel ではなく fanout として扱う。 |
+| ChatSession | Session | session の UI/DTO 名として扱い、正規語は Session。 |
+| ChatMessage | Message | message の UI/DTO 名として扱い、正規語は Message。 |
+| ActivityEntry | MessagePart | MessagePart の内部表現。 |
+| AttachmentRef | Attachment | 参照表現であり、正規語は Attachment。 |
+| SessionAttachment | Attachment | 同上。 |
+| ImageAttachment | Attachment | 同上。 |
+| ReviewThread | Thread | review 固有に分けず Thread に吸収する。 |
+| ReviewComment | Comment | review 固有に分けず Comment に吸収する。 |
+| PtySession | Terminal | backend 実装語彙。product/domain 語彙は Terminal。 |
+| WorkflowEvent | なし | 現時点では domain entity として採用しない。 |
+| ActionPlan | なし | 合意済み語彙ではない。 |
+| Notification | なし | 今は Entity にしない。 |

--- a/docs/domain-model/current-state.md
+++ b/docs/domain-model/current-state.md
@@ -1,0 +1,217 @@
+# Releash ドメインモデル Current State Snapshot
+
+## 目的
+
+現行コードに存在する語彙と、正規語との差分を記録する。
+正規語・構造・状態所有・境界の定義は [../architecture/GLOSSARY.md](../architecture/GLOSSARY.md) を参照する。
+
+このドキュメントは定義ではなく、現行実装スナップショットである。
+
+## 対象
+
+Issue [#1176](https://github.com/siro33950/releash/issues/1176) のスコープに合わせ、主に以下を対象にする。
+
+- `src-tauri/src/domain/workflow`
+- `src-tauri/src/domain/code`
+- `src-tauri/src/domain/repository`
+- `src-tauri/src/domain/agent_session`
+
+ただし、語彙の揺れが強く関係するため、必要に応じて `workspace_state`、`pty_session`、review/comment DTO、config/integration 由来の語彙も含める。
+
+## 分類
+
+| 分類 | 意味 |
+|---|---|
+| canonical | 正規語として採用する |
+| legacy_name | 現行実装名または旧語彙。正規語へ読み替える |
+| internal | engine / service / validation などの内部語彙 |
+| read_model | UI/API/一覧/同期/projection 用の表現 |
+| external | 外部 repository / integration / hosting service 側の情報 |
+| attribute | Entity ではなく属性として扱う |
+| not_adopted | 正規語として採用しない |
+
+## 現行コード上の主要語彙
+
+### workflow
+
+| 現行語彙 | 正規語 | 分類 | 理由 |
+|---|---|---|---|
+| `WorkflowDefinition` | WorkflowDefinition | canonical | workflow の定義。 |
+| `NodeDefinition` | NodeDefinition | canonical | WorkflowDefinition 内の作業単位の定義。 |
+| `WorkflowExecution` | WorkflowExecution | canonical | WorkflowDefinition の一回の実行。 |
+| `WorkflowRun` | WorkflowExecution | legacy_name | `Run` は旧実装語彙。 |
+| `WorkflowRunRecord` | WorkflowExecution | legacy_name | 永続化表現。正規語は WorkflowExecution。 |
+| `WorkflowRunSummary` | WorkflowExecution | read_model | 一覧用 summary。Entity ではない。 |
+| `RunId` | `WorkflowExecution.id` | attribute | id 属性として扱う。 |
+| `RunStatus` | `WorkflowExecution.status` | attribute | status 属性として扱う。 |
+| `TerminalRunStatus` | `WorkflowExecution.status` | internal | 終了状態だけを切り出した実装型。 |
+| `TriggerSource` | `WorkflowExecution.created_from` | attribute | 起動元属性として扱う。 |
+| `WorkflowName` | `WorkflowDefinition.name` | attribute | name 属性として扱う。 |
+| `NodeName` | `NodeDefinition.name` | attribute | name 属性として扱う。 |
+| `WorktreePath` | `Workspace.worktree_ref.path` | attribute | Worktree 参照の path。 |
+| `NodeType` | なし | not_adopted | NodeDefinition の構成・参照先・実行内容から判断する。 |
+| `ChildNodeDefinition` | NodeDefinition | legacy_name | fanout 先も通常の NodeDefinition として扱う。 |
+| `WorkflowExecutionState` | `WorkflowExecution.status` | attribute | lifecycle status として扱う。 |
+| `WorkflowSummary` | WorkflowDefinition | read_model | WorkflowDefinition の summary。 |
+| `WorkflowStateSnapshot` | なし | read_model | snapshot 実装。 |
+| `WorkflowEvent` | なし | not_adopted | 現時点では domain entity として採用しない。 |
+| `WorkflowStepContext` | なし | internal | NodeExecution が Session / Command に渡す実行 context。 |
+| `workflow_variables` | なし | internal | 実行時の変数展開用 data。 |
+
+### workflow fanout / parallel
+
+| 現行語彙 | 正規語 | 分類 | 理由 |
+|---|---|---|---|
+| `ParallelRunState` | Fanout | legacy_name | parallel 系語彙は Fanout に吸収する。 |
+| `ParallelChildRun` | NodeExecution / Fanout | legacy_name | fanout child も NodeExecution。 |
+| `ParallelChildState` | NodeExecution / Fanout | legacy_name | fanout child の状態。 |
+| `ParallelAggregate` | Fanout | legacy_name | fanout 集約設定/処理として扱う。 |
+| `ParallelStepState` | Fanout | read_model | UI/API 用 state。 |
+| `NodeCompletion` | NodeExecution | internal | NodeExecution 完了時の処理入力。 |
+| `ParallelChildCompletion` | NodeExecution | internal | child NodeExecution 完了時の処理入力。 |
+| `ParallelReduceResult` | Fanout | internal | fanout 集約処理結果。 |
+| `ParallelChildOutputMerge` | Fanout | internal | fanout child output merge 処理。 |
+| `ParallelChildCompletionInput` | Fanout | internal | fanout child completion 入力。 |
+| `ParallelParentTransitionPlan` | Fanout | internal | fanout parent 遷移処理計画。 |
+| `ParallelParentCompletionPlan` | Fanout | internal | fanout parent completion 処理計画。 |
+| `SubmissionParallelRun` | Fanout | internal | output submission 判定用表現。 |
+| `SubmissionParallelChild` | Fanout | internal | output submission 判定用表現。 |
+| `SubmissionParallelChildState` | Fanout | internal | output submission 判定用表現。 |
+
+### workflow engine internal
+
+| 現行語彙 | 正規語 | 分類 | 理由 |
+|---|---|---|---|
+| `NextNodeDecision` | なし | internal | engine の内部判断結果。 |
+| `CycleGuardDecision` | なし | internal | engine の内部安全判定結果。 |
+| `TurnCompleteDecision` | なし | internal | Turn 完了時の内部判断結果。 |
+| `TurnCompleteMutationPlan` | なし | internal | engine の内部 mutation plan。 |
+| `ApprovalTransitionDecision` | なし | internal | approval 遷移判断。 |
+| `ApprovalApplication` | なし | internal | approval 適用処理表現。 |
+| `ApprovalCompletion` | なし | internal | approval completion 表現。 |
+| `ApprovalApplicationTransition` | なし | internal | approval 遷移表現。 |
+| `ApprovalApplicationPlan` | なし | internal | approval 適用計画。 |
+| `ApprovalInputError` | Diagnostic | internal | validation error。 |
+| `ApprovalRuleError` | Diagnostic | internal | validation error。 |
+| `ApprovalChatInstructionContext` | なし | internal | approval chat 処理用 context。 |
+| `ApprovalChatSessionSnapshot` | なし | internal | approval chat 処理用 snapshot。 |
+| `ApprovalTargetSnapshot` | なし | internal | approval 対象検証用 snapshot。 |
+| `TransitionRule` | なし | internal | engine の transition 設定。 |
+| `CycleGuard` | なし | internal | engine の安全設定。 |
+| `CollectConfig` | なし | internal | engine の collect 設定。 |
+| `ReduceStrategy` | なし | internal | engine の reduce 設定。 |
+
+### workflow contract / output
+
+| 現行語彙 | 正規語 | 分類 | 理由 |
+|---|---|---|---|
+| `FacetKind` / `FacetKey` / `FacetSummary` | Facet | canonical | NodeDefinition から参照される補助部品。 |
+| `ResolvedFacets` | Facet | internal | Facet の解決状態。 |
+| `ContractType` | Contract | canonical | output contract の型表現。 |
+| `ContractValidationResult` | Contract | internal | validation result。 |
+| `ContractViolation` | Contract / Diagnostic | internal | contract validation のエラー詳細。 |
+| `ContractLookupError` | Diagnostic | internal | contract lookup error。 |
+| `OutputSubmittedSnapshot` | Artifact | internal | output submit 処理用 snapshot。 |
+| `ContractValidationMetadata` | Contract | internal | validation metadata。 |
+| `ConditionalArrayRule` | Contract | internal | validation rule。 |
+| `WorkflowValidateOutputResult` | Contract / Diagnostic | internal | output validation result。 |
+| `SubmitOutputCommand` | Command | internal | usecase command input。 |
+| `CollectedOutputEntry` | Artifact | internal | collect 処理の内部 entry。 |
+| `StepOutput` | Artifact | legacy_name | NodeExecution output の現行表現。 |
+| `StepHistoryEntry` | NodeExecution / Artifact | legacy_name | history/output の現行表現。 |
+| `ChildOutputSnapshot` | Fanout / Artifact | legacy_name | fanout child output snapshot。 |
+| `TokenUsage` | なし | internal | measurement。 |
+
+### code
+
+| 現行語彙 | 正規語 | 分類 | 理由 |
+|---|---|---|---|
+| `Hunk` | CodeAnchor / Diff | read_model | Diff 表示・参照用の範囲表現。 |
+| `ChangeGroup` | Diff | read_model | Diff 表示用 grouping。 |
+| `HiddenRange` | Diff | read_model | 表示用 range。 |
+| `VisibleBlock` | Diff | read_model | 表示用 block。 |
+| `DiffFileEntry` | Diff | read_model | diff tree 表示用 entry。 |
+| `DiffTreeNode` | Diff | read_model | diff tree 表示用 node。 |
+| `MentionReference` | CodeAnchor | legacy_name | code 位置参照。 |
+| `ReviewBase` | Diff | read_model | review view の表示条件。 |
+| `ReviewSection` | Diff | read_model | review view の表示条件。 |
+| `ReviewLimitReason` | Diff | read_model | review view の表示制限理由。 |
+| `ReviewBlobContentType` | Code | read_model | review view の表示判定。 |
+| `ReviewThresholds` | Diff | read_model | review view の表示閾値。 |
+
+### repository
+
+| 現行語彙 | 正規語 | 分類 | 理由 |
+|---|---|---|---|
+| `Worktree` | Worktree | canonical | Repository の特定 checkout / working tree。 |
+| `Branch` | Repository | external | repository 側の情報。 |
+| `Commit` | Repository | external | repository 側の情報。 |
+| `FileStatus` | Diff / Repository | read_model | repository status の表示用情報。 |
+| `FileDiffStat` | Diff / Repository | read_model | diff stat。 |
+| `RepositoryStatusScan` | Repository | read_model | status scan result。 |
+| `WorktreePrEntry` | なし | external | external repository/hosting service 側の情報。 |
+| `WorktreePrStatusSync` | なし | external | external repository/hosting service 側の sync message。 |
+| `PrInfo` / `PrStatus` / `PrDetail` | なし | external | external repository/hosting service 側の情報。 |
+| `PrReview` / `PrComment` / `PrAuthor` | なし | external | external repository/hosting service 側の情報。 |
+| `IssueInfo` / `IssueLabel` / `Milestone` | なし | external | external issue tracker 側の情報。 |
+| `AheadBehind` / `ProviderStatus` | なし | external | external repository/hosting service 側の情報。 |
+
+### agent_session
+
+| 現行語彙 | 正規語 | 分類 | 理由 |
+|---|---|---|---|
+| `ChatSession` | Session | legacy_name | 正規語は Session。 |
+| `ChatMessage` | Message | legacy_name | 正規語は Message。 |
+| `MessageRole` | MessageRole | canonical | Message の role。 |
+| `MessagePart` | MessagePart | canonical | Message の部分表現。 |
+| `PermissionRequest` | PermissionRequest | canonical | Turn に属する許可要求。 |
+| `AttachmentRef` | Attachment | legacy_name | Attachment の参照表現。 |
+| `SessionAttachment` | Attachment | legacy_name | Attachment に吸収。 |
+| `ImageAttachment` | Attachment | legacy_name | Attachment に吸収。 |
+| `ActivityEntry` | MessagePart | legacy_name | MessagePart の内部表現。 |
+| `QueuedAgentTurn` | Turn | read_model | queued turn の表示/管理表現。 |
+| `TurnPhase` | Turn | read_model | Turn の表示用 phase。 |
+| `TurnEventLog` | Turn | read_model | Turn の event log 実装。 |
+| `SessionState` | Session | read_model | 実装上の状態分類。 |
+| `PlanMode` | Session | attribute | Session UI/agent 実行設定。 |
+| `PermissionMode` | `Session.permission_mode` | attribute | Session の許可モード。 |
+| `LegacyPermissionMode` | `Session.permission_mode` | legacy_name | legacy compatibility。 |
+| `ContextCarryState` | Session | internal | Session 復元/再注入の内部状態。 |
+| `AgentEditorContext` / `AgentEditorSelection` | Session | internal | agent input 用 editor context。 |
+| `ModelInfo` / `ModelId` / `ModelEntry` | なし | external | agent backend/model metadata。 |
+| `SkillEntry` / `SlashCommand` | なし | external | agent runtime/UI command metadata。 |
+
+### workspace_state / terminal / review / integration
+
+| 現行語彙 | 正規語 | 分類 | 理由 |
+|---|---|---|---|
+| `WorkspaceState` | WorkspaceState | canonical | Workspace の UI state。 |
+| `WorkspaceTabsState` | WorkspaceState | read_model | WorkspaceState の内部表現。 |
+| `WorkspaceLayoutState` | WorkspaceState | read_model | WorkspaceState の内部表現。 |
+| `WorkspaceTabEntry` | WorkspaceState | read_model | WorkspaceState の内部表現。 |
+| `PtySession` | Terminal | legacy_name | product/domain 語彙は Terminal。 |
+| `PtySessionRegistry` | Terminal | internal | Terminal backend 管理実装。 |
+| `PtyKind` / `PtyEvictReason` / `PtyLifecycleConfig` | Terminal | internal | Terminal backend 実装語彙。 |
+| `ReviewThread` | Thread | legacy_name | Thread に吸収。 |
+| `ReviewComment` | Comment | legacy_name | Comment に吸収。 |
+| `NotificationEvent` / `NotifyConfig` / `DesktopNotifyMode` | なし | external | notification integration の event/config。 |
+| `RemoteAccess` / `DetectedInterface` / `VpnInterface` / `QrCodeResult` | なし | external | remote access integration。 |
+| `HooksStatus` | なし | external | hooks integration。 |
+| `ExternalEditor` / `EditorInfo` | なし | external | external editor integration。 |
+| `NotionRepoConfig` / `NotionPropertyMapping` | なし | external | Notion integration config。 |
+
+## 正規語に未対応の主要概念
+
+| 正規語 | 現行状態 |
+|---|---|
+| NodeExecution | 未実装。現行は WorkflowExecution 内の step state / history として表現されている。 |
+| Fanout | 未実装。現行は parallel 系語彙で表現されている。 |
+| Task | 未実装。 |
+| Artifact | 未実装。現行は StepOutput / StepHistoryEntry / ChildOutputSnapshot などで部分的に表現されている。 |
+| Workspace | 独立 entity としては未実装。現行は `workspace_id ≒ worktree_path`。 |
+| Command | 未実装。 |
+| Thread / Comment | 正規語としては未実装。現行は review DTO 名で表現されている。 |
+
+## 未合意語彙
+
+現時点ではなし。


### PR DESCRIPTION
## Summary
- add docs/architecture/GLOSSARY.md as the canonical domain glossary for #1176
- add docs/domain-model/current-state.md as the current implementation vocabulary snapshot
- separate canonical definitions from current-state mapping

Closes #1176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * プロダクト方針とアーキテクチャ原則を整理し、状態管理・責務分離・通信レイヤーの考え方を明確化しました。
  * ドメイン用語集を追加し、正規語と禁止語の対応を一覧化しました。
  * 現行実装の語彙対応状況をスナップショットとして追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->