### PR TITLE
feat: Fable 5 / Sonnet 5 をモデル一覧に追加し Sonnet 4.5 を削除

### DIFF
--- a/src-tauri/src/infrastructure/agent_session/claude/models.rs
+++ b/src-tauri/src/infrastructure/agent_session/claude/models.rs
@@ -9,9 +9,10 @@ pub(crate) const CLAUDE_BACKEND_ID: &str = "claude";
 
 const CLAUDE_FIXED_MODELS: &[(&str, &str)] = &[
     ("claude-opus-4-8", "Opus 4.8"),
+    ("claude-fable-5", "Fable 5"),
     ("claude-opus-4-7", "Opus 4.7"),
     ("opus[1m]", "Opus 1m"),
-    ("claude-sonnet-4-5", "Sonnet 4.5"),
+    ("claude-sonnet-5", "Sonnet 5"),
     ("claude-haiku-4-5-20251001", "Haiku 4.5"),
 ];
 
@@ -130,15 +131,23 @@ mod tests {
             ids,
             vec![
                 "claude-opus-4-8",
+                "claude-fable-5",
                 "claude-opus-4-7",
                 "opus[1m]",
-                "claude-sonnet-4-5",
+                "claude-sonnet-5",
                 "claude-haiku-4-5-20251001",
             ]
         );
         assert_eq!(
             names,
-            vec!["Opus 4.8", "Opus 4.7", "Opus 1m", "Sonnet 4.5", "Haiku 4.5"]
+            vec![
+                "Opus 4.8",
+                "Fable 5",
+                "Opus 4.7",
+                "Opus 1m",
+                "Sonnet 5",
+                "Haiku 4.5"
+            ]
         );
     }
 


### PR DESCRIPTION
## 概要

Claude のモデル一覧 (`CLAUDE_FIXED_MODELS`) に新モデルを追加し、旧モデルを整理する。

- 追加: **Fable 5** (`claude-fable-5`) — 最上位モデル
- 追加: **Sonnet 5** (`claude-sonnet-5`) — 2026-06-30 リリース、Sonnet 4.6 の後継
- 削除: **Sonnet 4.5** (`claude-sonnet-4-5`)

## 変更後のモデル一覧

```rust
("claude-opus-4-8", "Opus 4.8"),   // デフォルト（先頭）維持
("claude-fable-5", "Fable 5"),
("claude-opus-4-7", "Opus 4.7"),
("opus[1m]", "Opus 1m"),
("claude-sonnet-5", "Sonnet 5"),
("claude-haiku-4-5-20251001", "Haiku 4.5"),
```

## 補足

- モデル定義は Rust 側の単一ソース。frontend は `agent-models-updated` イベント経由で表示するだけのため、この配列変更のみで UI にも反映される。
- デフォルトモデル（`default_model_for` が返す配列先頭 = Opus 4.8）は意図的に維持。
- 順序検証テストも更新済み。

## 確認

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test`（該当テスト）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)