### PR TITLE
feat: app data GC を backend に実装し不要データを回収 (#1372)

### DIFF
--- a/docs/specs/issues-1372/behavior.md
+++ b/docs/specs/issues-1372/behavior.md
@@ -1,0 +1,158 @@
+# Behavior
+
+関連: #1372
+
+`requirements.md` の「削除ルール（正典）」を、外部から観測可能な振る舞いとして Gherkin で定義する。GC はアプリ起動時に 1 回実行する backend 内部処理であり、UI/CLI の新しい操作面は追加しない。観測点は「GC 実行後に app data が残っているか／削除されているか」と「backend log への削除件数・回収 byte 数の出力」である。
+
+## 仮定
+
+- ここでは各データの「状態」（削除済み Workspace / 使用中 Workspace / 削除済み・アーカイブ済み・使用中の Session/Workflow / 再生成 cache / 旧形式 / 参照切れ / stale process）を前提として振る舞いを記述する。状態を判定する具体的な source of truth・パス・時刻基準は `design.md` で確定する。
+- retention 境界（30 日 / 7 日）の起点時刻は対象データの更新時刻とする（正確な基準は `design.md`）。
+- 「削除」は app data 上の実体（ディレクトリ／ファイル）が GC 実行後に存在しなくなることを指す。
+- GC は保守的削除であり、ルールに合致すると確実に判定できたデータのみ削除し、判定できないデータは残す。
+
+## Feature: 起動時 backend GC による app data の容量回収
+
+Releash 起動時に backend が GC を実行し、削除ルール（正典）に従って不要な app data を削除し容量を回収する。実行中の作業とまだ参照されている生きたデータは壊さない。
+
+### Background
+
+```gherkin
+Background:
+  Given Releash の app data ディレクトリに session・workflow ログ／artifact・cache・comment/thread・process record が蓄積している
+  And backend が起動する
+  When GC が起動時に 1 回実行される
+```
+
+### Rule: 削除済み Workspace のログは削除する（ルール 1）
+
+```gherkin
+Scenario: worktree が存在しない Workspace に紐づくデータを削除する
+  Given ある Workspace の worktree が既に削除されている
+  And その Workspace に紐づく session 一式・workspace_state・workflow データと、worktree との対応付けが証明できる checkpoint が app data に残っている
+  When GC が実行される
+  Then その Workspace に紐づくデータは削除されている
+
+Scenario: worktree が現存する Workspace に紐づくデータは保持する
+  Given ある Workspace の worktree が現存している
+  And その Workspace に紐づくデータが app data にある
+  When GC が実行される
+  Then その Workspace に紐づくデータは残っている
+```
+
+### Rule: 使用中 Workspace のログは Session/Workflow の状態で判断する（ルール 2）
+
+```gherkin
+Scenario: 削除済みの Session/Workflow のログを削除する（ルール 2-1）
+  Given 使用中 Workspace に、削除済みの Session/Workflow のログが残っている
+  When GC が実行される
+  Then その削除済み Session/Workflow のログは削除されている
+
+Scenario Outline: アーカイブ済みの Session/Workflow のログは 30 日境界で判定する（ルール 2-2）
+  Given 使用中 Workspace に、アーカイブ済みの Session/Workflow のログがある
+  And そのログの更新から <経過> が経っている
+  When GC が実行される
+  Then そのログは <結果>
+
+  Examples:
+    | 経過      | 結果             |
+    | 31 日     | 削除されている   |
+    | 30 日以内 | 残っている       |
+
+Scenario: 使用中の Session/Workflow のログは削除しない（ルール 2-3）
+  Given 使用中 Workspace に、使用中の Session/Workflow のログがある
+  And そのログがどれだけ古くても
+  When GC が実行される
+  Then そのログは残っている
+
+Scenario Outline: 再生成可能な cache は状態問わず 7 日境界で判定する（ルール 2-4）
+  Given 再生成可能な cache（LSP workspace cache / TypeScript cache）がある
+  And その cache の更新から <経過> が経っている
+  When GC が実行される
+  Then その cache は <結果>
+
+  Examples:
+    | 経過     | 結果             |
+    | 8 日     | 削除されている   |
+    | 7 日以内 | 残っている       |
+```
+
+### Rule: 旧形式データは状態問わず全削除する
+
+```gherkin
+Scenario: 旧形式 comments / diff-comments / threads を全削除する
+  Given 旧形式の comments / diff-comments / threads が app data にある
+  And それらが使用中 Workspace 分の旧コメントを含んでいても
+  When GC が実行される
+  Then 旧形式の comments / diff-comments / threads は全て削除されている
+  And 現行 review-comments のデータは残っている
+```
+
+### Rule: 参照切れ blob は使用中 Session でもファイル単位で削除する（ルール 2-3 の例外）
+
+```gherkin
+Scenario: どの message からも参照されない tool_outputs / attachments を削除する
+  Given 使用中の Session に tool_outputs / attachments の blob がある
+  And その blob はその Session のどの message からも参照されていない
+  When GC が実行される
+  Then その参照切れ blob は削除されている
+  And 同じ Session の会話（messages）は残っている
+
+Scenario: message から参照されている blob は残す
+  Given 使用中の Session に tool_outputs / attachments の blob がある
+  And その blob はその Session のいずれかの message から参照されている
+  When GC が実行される
+  Then その blob は残っている
+```
+
+### Rule: pid が死んだ process/pid record は削除する
+
+```gherkin
+Scenario Outline: process/pid record を pid 生存で判定する
+  Given process record / pid registry がある
+  And 記録された pid のプロセスは <生存状態>
+  When GC が実行される
+  Then その record は <結果>
+
+  Examples:
+    | 生存状態     | 結果             |
+    | 死んでいる   | 削除されている   |
+    | 生存している | 残っている       |
+```
+
+### Rule: active session / running workflow に紐づくデータは削除しない（安全ガード）
+
+```gherkin
+Scenario: active session に紐づくデータは他のルールに合致しても保持する
+  Given active な session に紐づくデータがある
+  When GC が実行される
+  Then そのデータは残っている
+
+Scenario: running workflow に紐づくデータは他のルールに合致しても保持する
+  Given running な workflow に紐づくデータがある
+  When GC が実行される
+  Then そのデータは残っている
+```
+
+### Rule: GC は削除の結果を backend log に出力する
+
+```gherkin
+Scenario: 削除件数と回収 byte 数を log 出力する
+  Given GC の削除対象がある
+  When GC が実行される
+  Then backend log に削除件数が出力される
+  And backend log に回収 byte 数が出力される
+```
+
+### Rule: GC は起動処理を過度にブロックしない
+
+```gherkin
+Scenario: 大量の app data があっても起動が過度に阻害されない
+  Given app data に大量のデータ（数十 GB 規模）が蓄積している
+  When backend が起動し GC が実行される
+  Then backend の起動処理は過度にブロックされない
+```
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1372/design.md
+++ b/docs/specs/issues-1372/design.md
@@ -1,0 +1,225 @@
+# Design
+
+関連: #1372
+前提ドキュメント: [`requirements.md`](./requirements.md) / [`behavior.md`](./behavior.md)
+
+## 概要
+
+app data（`app_data_dir()` ＝ `com.releash.app` 配下）に無期限蓄積する session / workflow / cache / 旧形式 comment / process record を、`requirements.md` の「削除ルール（正典）」に従って backend 起動時に 1 回 GC する。ロジックは Rust の usecase 層に置き、frontend は関与しない。UI/CLI の新しい操作面は追加しない。観測点は「GC 実行後の app data の残存／削除」と「backend log への削除件数・回収 byte 数出力」。
+
+設計の中核方針:
+
+- **保守的削除**: 各ルールに合致すると確実に判定できたデータのみ削除する。判定不能・読み取り失敗は「残す」に倒す。
+- **安全ガード最優先**: active session / running workflow に紐づくデータは、どの経路でも削除しない。判定は削除実行の前段で確定させる。
+- **起動を過度にブロックしない**: GC は setup 内で同期実行せず、controller/wiring の composition root から background task として spawn する（既存の `cleanup_orphan_processes`（`lib.rs:74`）と同じ起動フックの直後に非同期で回す）。
+- **既存 storage の read-only 走査**: 既存のパス組み立て関数（`layout.rs` 等）と型を再利用し、フォーマットは変更しない。削除は `remove_file` / `remove_dir_all` に限定する。
+
+## 変更対象
+
+### 新規
+
+- `src-tauri/src/usecase/app_data_gc/mod.rs`（GC オーケストレーションとルール評価）
+  - サブモジュール分割案: `plan.rs`（削除対象の収集＝判定）/ `sweep.rs`（削除実行＋集計）/ `report.rs`（`GcReport` 型）/ `ports.rs`（協調オブジェクトの trait）。
+- `src-tauri/src/domain/app_data_gc/`（`GcReport` / `GcCategory` などの値オブジェクト。外部依存を持たない集計・境界判定のみ）
+- `src-tauri/src/adaptor/gateway/app_data_gc/`（filesystem 走査・ディレクトリサイズ計算・削除の具体実装。usecase の port trait 実装）
+
+### 変更
+
+- `src-tauri/src/lib.rs` の `.setup(...)` ブロック（`lib.rs:71` 以降）
+- `src-tauri/src/adaptor/controller/wiring.rs`
+  - `cleanup_orphan_processes`（`lib.rs:74-84`）の後に `spawn_startup_app_data_gc` を呼び、controller/wiring 側で `spawn_blocking`、request 構築、usecase 呼び出しを行う。`lib.rs` は `data_dir` と `SharedRepoPaths` を渡すだけに留める。
+
+### 参照のみ（再利用する既存資産）
+
+- `adaptor/gateway/agent_session/session_storage/layout.rs`（sessions レイアウト。`sessions_dir` / `session_dir` / `meta_file_in_dir` / `index_file_in_dir` / `tool_outputs_dir_in_dir` / `attachments_dir_in_dir` / `tool_output_file_in_dir` / `attachment_file_in_dir`）
+- `usecase/agent_session/session/mod.rs`（`SessionMeta` / `SessionState` / `MessageIndexEntry` / `ToolOutputRef` / `AttachmentRef`）
+- `adaptor/gateway/workflow/run.rs`（`WorkflowRun` / `RunStatus::is_terminal()` / `RunStore` / `resolve_worktree_by_run`）
+- `adaptor/gateway/workflow/archive_repository.rs`（`workflow_run_archives.json` / `WorkflowRunArchiveRecord.archived_at` / `WorkflowRunArchiveRepository`）
+- `infrastructure/process/pid_registry.rs`（`PidFileV1` / 記録 pid・pgid の liveness helper）
+- `adaptor/gateway/repository/worktree.rs`（`list_worktrees(repo_path)` → `Vec<Worktree>`、`Worktree.path`）
+- `adaptor/gateway/repository/repo_paths.rs`（`SharedRepoPaths = Arc<RwLock<Vec<String>>>`）
+- `adaptor/gateway/comment/mod.rs`（現行 `review-comments/` の safe key 生成 `worktree_storage_key()`。旧形式 `comments/` `diff-comments/` `threads/` は保存箇所を持たない廃止フォーマット）
+- `adaptor/gateway/workspace_state/repository_impl.rs`（`workspace_state/{worktree_name.replace(['/','\\'],"_")}.json`）
+
+## アーキテクチャと責務分割
+
+```
+lib.rs setup（起動フック）
+  └─ adaptor::controller::wiring::spawn_startup_app_data_gc
+       └─ spawn_blocking ─► gateway::app_data_gc::build_startup_gc_request
+                                   └─ usecase::app_data_gc::run_startup_gc(ctx)
+                                      ├─ plan:  ルールごとに削除候補を収集（read-only 走査）
+                                      ├─ guard: runtime protection snapshot で削除候補をフィルタ（安全ガード）
+                                      ├─ sweep: 確定した対象を削除しつつ byte / 件数を集計
+                                      └─ report: GcReport を backend log に出力
+```
+
+責務分割:
+
+- **domain（`domain/app_data_gc/`）**: 副作用なし。retention 境界判定（`now - updated_at > threshold`）、`GcReport` の集計、`GcCategory` の enum。時刻・閾値は引数で受け取り、`Clock` や fs には触れない。
+- **usecase（`usecase/app_data_gc/`）**: ルール評価のオーケストレーション。request から「生存 worktree resolution」「runtime protection snapshot」「process record」「現在時刻」を受け取り、port trait 経由の filesystem 走査・サイズ計測・削除で削除計画を組み立て、安全ガードでフィルタし、sweep を指示する。ここが本 Issue のロジックの中心。
+- **adaptor/gateway（`adaptor/gateway/app_data_gc/`）**: port trait の具体実装と request 用 read model の構築。`std::fs` によるディレクトリ列挙・`mtime` 取得・再帰サイズ計算・削除。live worktree 解決は `SharedRepoPaths` を読み各 repo で `list_worktrees()` を呼ぶ。active session / running workflow の保護判定は 1 つの runtime protection snapshot（active session id、running worktree path、storage key 保護集合）として構築し、全削除経路が同じ snapshot を使う。
+- **controller**: Tauri command / WebSocket handler は追加しない。起動 runner は controller/wiring の composition root に置き、`spawn_blocking`、panic 捕捉、gateway request 構築、usecase 呼び出しをここで配線する。
+
+port trait を挟む理由: GC ロジックを usecase 層で完結させ、tempdir + fake collaborator で単体テスト可能にするため（`docs/architecture/TEST.md` / USECASE 規約に沿う）。
+
+## データモデルまたは型
+
+### GC 入力コンテキスト（usecase 引数）
+
+```rust
+struct GcContext {
+    app_data_dir: PathBuf,
+    // 生存 worktree の絶対パス集合（正規化済み）と、list_worktrees 失敗 repo の保守スキップ情報。
+    live_worktrees: Option<LiveWorktreeResolution>,
+    // state=Active / live pid / running workflow から 1 回だけ構築した保護 snapshot。
+    runtime_protection: RuntimeProtection,
+    now: f64,                                // Unix 秒。domain の境界判定に渡す
+    retention: RetentionPolicy,              // archived_log=30d, cache=7d
+}
+```
+
+- `LiveWorktreeSet`: worktree 絶対パスの `HashSet`（`FsWorktreePathNormalizer` 相当で正規化）と、そこから派生する storage key（`workspace_state` 用 `name.replace(['/','\\'],"_")`、`review-comments` 用 `worktree_storage_key()`）の集合を保持。ファイル名ベースの領域はこの派生キー集合で「生存」を判定する。
+- `LiveWorktreeResolution`: 成功 repo の `LiveWorktreeSet` に加え、`list_worktrees()` に失敗した repo path と `workspace_state` 用 key prefix を保持する。metadata に `worktreePath` を持つ session / workflow は failed repo 配下なら保持し、それ以外は成功 repo の live 集合で判定を継続する。hash key で元 path へ戻せない `review-comments` は failed repo がある回の workspace cleanup を保守的にスキップする。
+- `RuntimeProtection`: `active_session_ids`（state=Active もしくは live pid を持つ session）、`running_worktrees`（running workflow が占有する worktree_path）、`protected_worktrees`（両者から派生した storage key 保護集合）をまとめた read model。session / workflow 本体、workspace_state、review-comments、worktree との対応付けが証明できる checkpoint はこの同じ snapshot を使って保護判定する。保護 source の読み取り・解析が不完全な場合は workspace-keyed cleanup を保守的にスキップする。
+- `RetentionPolicy { archived_log_secs: 30*86400, cache_secs: 7*86400 }`（定数。UI 設定は非スコープ）。
+
+### 判定に用いる既存型（再掲・確定事項）
+
+- `SessionMeta`（`usecase/agent_session/session/mod.rs`）: `worktreePath: String` / `state: SessionState` / `updatedAt: f64`。
+- `SessionState`（snake_case）: `active` / `idle` / `done` / `error` / `closed` / `archived`。soft-delete の `deleted` state は存在しない。requirements.md の正典に合わせ、session state は次のように扱う:
+  - **ルール2-3「使用中」（無期限保持）= `Active` / `Idle` / `Done` / `Error`**（`list_sessions()` に表示される使用中の session。古さに関わらず保持）。
+  - **ルール2-2「アーカイブ済み」（30日で削除）= `Archived`**（`meta.json` の `state = "archived"`。`updatedAt` から 30 日以内は保持、30 日超で削除）+ **復元可能な workflow archive**（`restore_manual`/`archived_at` を持つ。`archived_at` から 30 日超で削除）。
+  - `Closed` session は既存 UI の復元候補として残る棚上げ状態であり、破壊的即削除にはしない。容量回収上は `Archived` と同じ 30 日 retention の対象に含める。
+  - **ルール2-1「削除済み」（即削除）= 復帰不可の残骸**（物理削除の中途失敗・fork rollback 残骸・`meta.json` 欠落／解析不能な orphan session ディレクトリ）。
+- `ChatMessage`（`messages/*.json` の要素）: `MessagePart::ToolResult.content_ref.id` / `MessagePart::ImageRef.attachment.id`。参照集合は message 本体から union で得る。`index.json` は stale になり得るため、参照切れ blob 判定の source of truth にはしない。
+- `WorkflowRun`（`workflow_runs/{run_id}.json`）: `worktreePath: String` / `status: RunStatus` / `updatedAt: f64` / `completedAt: Option<f64>`。`RunStatus::is_terminal()` で running 判定。
+- `WorkflowRunArchiveRecord`（`workflow_run_archives.json`）: `archived_at: Option<f64>` / `restored_at: Option<f64>`。archive 判定と 2-2 の起点時刻に使用。
+- `PidFileV1`（`agent-processes/{session}.{backend}.{pid}.json`）: 記録された `pid` の liveness が `Live` / `Stale` / `Unknown` を返す。`Stale` を削除、`Unknown` は保守的に残す。legacy `pids/{session}.pid` は記録 pgid の liveness で判定する。
+
+### 出力型
+
+```rust
+struct GcReport {
+    categories: BTreeMap<GcCategory, CategoryStat>, // 件数 + 回収 byte
+    total_files: u64,
+    total_bytes: u64,
+    errors: u64,      // 削除失敗（残置）
+}
+struct CategoryStat { deleted: u64, reclaimed_bytes: u64 }
+enum GcCategory {
+    DeletedWorkspace,       // ルール1（worktree 消滅＝復帰不可）
+    UnrecoverableSession,   // ルール2-1（orphan 残骸）即削除
+    RecoverableExpired,     // ルール2-2（Archived/Closed session / archived workflow, 30日超）
+    RegenerableCache,       // ルール2-4
+    LegacyComments,         // 旧形式全削除
+    OrphanBlob,             // 参照切れ tool_outputs/attachments
+    StaleProcessRecord,     // stale pid
+}
+```
+
+## 処理フロー
+
+`run_startup_gc(ctx)` は以下を順に実行する。1〜6 で「削除候補」を集め、各段で安全ガードを適用し、最後に一括 sweep + log 出力。
+
+### 0. コンテキスト構築（保護集合の確定を最優先）
+
+1. `SharedRepoPaths` を読み、各 repo_path で `list_worktrees()` を呼び、生存 worktree 絶対パス集合 `live_worktrees` を構築（正規化）。派生 storage key 集合も生成。
+2. running workflow: `RunStore` の active 集合から `is_terminal()==false` の run の `worktree_path` を収集 → `running_worktrees`。
+3. active session: `sessions/` 各 session の `meta.json` を読み `state==Active` を収集。加えて `agent-processes/` を走査し、記録 pid が live な pid record が指す `session_id` も active 扱いで追加（保護を過剰側に倒す）。
+4. `now` を取得（`Clock`）。
+
+### 1. ルール1 — 削除済み Workspace のログ
+
+- `sessions/` 配下の各 session の `meta.json.worktreePath` が `live_worktrees` に無ければ、その session ディレクトリ一式を削除候補にする。
+- `workflow_runs/*.json` の `worktreePath` が `live_worktrees` に無ければ、その run の `workflow_runs/{id}.json` と `workflow_logs/{id}.json` を候補にする。
+- `workspace_state/*.json` / `review-comments/*` は、ファイル名の storage key が生存キー集合に無いものを候補にする。`agent-worktree-checkpoints`・`-backups` は命名規約から worktree との対応付けを確実に証明できるまで保守的にスキップする。
+- **ガード**: 候補 session が active_session_ids に含まれる、または候補 worktree が running_worktrees に含まれる場合は除外。
+
+### 2. ルール2 — 使用中 Workspace のログ（Session/Workflow 状態）
+
+生存 worktree に紐づく session / workflow に対して:
+
+- **2-1 削除済み（復帰不可＝即削除）**: `meta.json` 欠落／解析不能で active でもない orphan session ディレクトリなど、復帰不可と判定できる残骸を削除。workflow は削除経路が無いため 2-1-workflow は対象なし（log で 0 件を明示）。
+- **2-2 アーカイブ済み（30日猶予）**: session は `state==Archived` か `state==Closed` かつ `now - updatedAt > 30d` を削除、30 日以内は保持。workflow は `workflow_run_archives.json` に `archived_at` があり `restored_at` が無く `now - archived_at > 30d` の run（および対応 log）を削除。
+- **2-3 使用中（無期限保持）**: `state` が Active/Idle/Done/Error（`list_sessions` に表示される使用中）の session 本体は古さに関わらず保持。ただし参照切れ blob は 4 で例外的に削除。
+- **2-4 再生成 cache**: `lsp/`（`jdtls` / `jdtls-workspaces` / `typescript`）配下のエントリを、`mtime` が `now - 7d` より古ければ削除。7 日以内は保持。state に依存しない。
+
+#### retention 判定の詳細（30日 / 7日の測り方）
+
+- **時刻の単位**: app 内タイムスタンプ（`meta.updatedAt` / `createdAt` / `SessionClosed.at` / workflow `archived_at`）は `now_timestamp()` = `unix_timestamp_seconds()` による **Unix 秒（f64）**。GC の現在時刻も同関数で取得する。ファイル `mtime` は `std::fs::Metadata::modified()`（`SystemTime`）を `UNIX_EPOCH` からの秒に変換して同一軸で比較する。
+- **判定式**: `now_sec - 起点sec > 閾値sec`（30日 = `30*86400` = 2_592_000、7日 = `7*86400` = 604_800）。境界は「超えたら削除」（`>`）＝ちょうど 30日/7日は保持。
+- **now の固定**: GC 実行開始時に `now` を 1 回取得し、全判定で共有する（実行中の経過で境界がブレないようにする）。domain の境界判定は `fn is_expired(now: f64, at: f64, threshold: f64) -> bool` の純関数で、`Clock` にも fs にも触れない。
+- **起点時刻（category 別）**:
+  - 2-2 Archived/Closed session … `meta.updatedAt`。state 変更時に `set_session_state` で `updated_at = now_timestamp()`（`store.rs:686`）に更新されるため、実質「archive/close した時刻」を表す。restore されると Idle に戻り 2-2 対象から外れる。
+  - 2-2 archived workflow … `workflow_run_archives.json` の `archived_at`。`restored_at` が入っているものは復帰済みとして対象外。
+  - 2-4 cache … 対象エントリ（例: `lsp/jdtls-workspaces/{workspace}`, `lsp/typescript`）配下の**最新 mtime**を代表値に採る。一部だけ古いファイルがあっても、直近に更新があれば「使用中 cache」とみなして残す（誤削除防止）。エントリ全体の最新 mtime が 7日超で削除。
+- **updatedAt 更新タイミングの注意**: `set_session_state` は state 変更のたび `updated_at` を更新する。Archived/Closed 後に何らかの理由で `updated_at` が再更新されると 2-2 の起点が後ろへずれる（＝削除が遅れる方向＝安全側）。逆に「archive/close より後の最終活動」を起点にしたい場合も同義になり、いずれも保守的。
+
+### 3. 旧形式データの全削除
+
+- `comments/` / `diff-comments/` / `threads/` の各ディレクトリを丸ごと削除候補にする（状態・worktree に無関係）。`review-comments/` は対象外。
+
+### 4. 参照切れ blob（ルール2-3 の例外）
+
+- 生存・active を問わず全 session を対象に、その session の `messages/*.json` から `ToolOutputRef.id` ∪ attachment id を集める。
+- `tool_outputs/` / `attachments/` 配下の各ファイル id がその集合に無ければ、そのファイル単位で削除。messages / 会話本体には触れない。
+- `messages/` が存在しない session は参照 0 件として扱う。`messages/` の列挙が権限エラー・一時的 I/O error などで失敗した場合、または message が読めない／解析できない場合は、その session の参照切れ判定を保守的にスキップする。
+
+### 5. stale process / pid record
+
+- `agent-processes/*.json`（`PidFileV1`）は記録 `pid`、`pids/*.pid` は記録 pgid を走査し、`Stale` のレコードを削除。`Live` / `Unknown` は残す。
+
+### 6. sweep + 集計 + log
+
+- 1〜5 で確定した候補を安全ガードで最終フィルタし削除。各削除前にサイズ（ファイル or 再帰ディレクトリサイズ）を測り `GcReport` に加算。削除失敗は `errors` に計上し残置（保守的）。
+- 完了後、`cleanup_orphan_processes` と同様に `log::info!` で category 別件数・回収 byte・total を 1 行で出力。
+
+## エラー処理
+
+- **read-only 走査中の失敗**（ディレクトリ列挙・JSON 解析・mtime 取得の失敗）: そのエントリを「判定不能」として削除候補から除外し残す。GC 全体は継続。個別失敗は `warn` ログ。
+- **削除失敗**（`remove_file` / `remove_dir_all` のエラー）: `GcReport.errors` に加算し、他候補の処理を継続。
+- **collaborator 失敗**（`list_worktrees()` がある repo で失敗など）: その repo の worktree を「生存側」に倒せないため、**live 集合を過小に見積もると誤削除に繋がる**。よって repo 単位で `list_worktrees()` が失敗した場合は、その repo に属し得るデータ（判定に生存集合を要するルール1・2）の削除を**その回の GC ではスキップ**する（保守的）。成功した repo の live 集合では判定を継続する。参照切れ blob（4）・stale pid（5）・旧形式（3）・cache（2-4）は生存集合に依存しないため継続可能。
+- **原子性**: session ディレクトリ削除は `remove_dir_all` 一括。途中失敗で中途半端に残っても、次回起動時の GC が再度候補化して回収するため冪等。個別 blob / record 削除も冪等。
+- **起動処理保護**: GC は background task。setup 完了・UI 起動をブロックしない。panic は task 内で捕捉し log 出力（アプリ本体に伝播させない）。
+
+## テスト方針
+
+`usecase/app_data_gc` を tempdir + fake collaborator で単体テスト（`#[cfg(test)] mod tests`）。各ルールの削除／保持を fixture で検証:
+
+- ルール1: 生存 worktree に紐づく session/workflow/workspace_state を保持、非生存を削除。`list_worktrees()` 失敗時に該当 repo 分を削除しない（保守）ことを検証。
+- ルール2-1: `meta.json` 欠落の orphan dir を削除。
+- ルール2-2: `state==Archived` / `state==Closed` の session を updatedAt 31日で削除・30日で保持。archived workflow を `archived_at` 31日で削除・30日で保持。`restored_at` があるものは保持。
+- ルール2-3: 使用中（Active/Idle/Done/Error）の session を任意の古さで保持。
+- ルール2-4: `lsp/` cache を mtime 8日で削除・7日で保持。
+- 旧形式: `comments/`・`diff-comments/`・`threads/` を削除、`review-comments/` を保持。
+- 参照切れ: `messages/*.json` に無い id の blob を削除、参照中 blob を保持、`messages/` を保持。stale な `index.json` だけに残る id は参照中扱いにしない。
+- stale pid: 記録 pid/pgid liveness を fake で `Stale`→削除 / `Live`・`Unknown`→保持。
+- 安全ガード: active session・running workflow に紐づくデータが他ルールに合致しても保持。
+- 集計: `GcReport` の件数・回収 byte が実削除と一致。削除失敗が `errors` に計上され残置。
+
+domain の retention 境界判定は純関数として境界値テスト。`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` を通す。
+
+## リスクと代替案
+
+- **誤削除リスク（最重要）**: live worktree 集合の取りこぼしはルール1の誤爆に直結する。緩和として (a) `list_worktrees()` 失敗 repo はスキップ、(b) active/running 保護を過剰側（Idle・live pid も保護）に倒す、(c) 判定不能は残す、で多重に保守化。代替案として初回リリースを「削除件数のみ log 出力し実削除しない observe モード」から始める案があるが、`requirements.md` の非スコープ（dry-run 不要）と齟齬するため採用しない。
+- **session state の解釈**: `Archived` は requirements.md の「アーカイブ済み Session」として 30 日 retention の対象にする。`Closed` も既存 UI の復元候補として即削除せず、同じ 30 日 retention に含める。将来 state の意味や復元 UI が変わる場合は、本 GC 分類を見直す。
+- **`SharedRepoPaths` が起動直後は config 由来の `last_repo_paths` のみ**で、ユーザーがまだ開いていない既知リポジトリの worktree を取りこぼす可能性。→ その worktree に紐づくデータを「削除済み Workspace」と誤判定し得る。緩和: GC は setup 内で `shared_repo_paths` 初期化（`lib.rs:124-135`）の**後**に spawn する。なお UI 操作で後から repo が増えるが、GC は起動時 1 回のため、当該起動時点の既知集合で判定する（次回起動で是正）。誤判定を避けるため、`last_repo_paths` が空のときはルール1（生存集合を要する経路）を丸ごとスキップする。
+- **checkpoint ディレクトリの命名規約が Rust 層で未確認**（`agent-worktree-checkpoints/`）。実データには存在するが生成箇所が Rust に無い。→ 実装時にディレクトリ実体を走査してキー体系を確認し、確実に worktree と対応付けられる場合のみルール1対象にする。対応付け不能なら保守的にスキップ（残す）。
+- **`updatedAt` の単位/更新タイミング（確認済み）**: 単位は Unix 秒（`unix_timestamp_seconds()`）。state 変更は `set_session_state` を経由し `updated_at` を更新するため、Archived/Closed session の 2-2 起点＝archive/close 時刻として使える（`store.rs:483,686`）。archive/close 後に再更新された場合も起点が後ろへずれる＝削除が遅れる安全側。workflow は専用の `archived_at`。
+- **性能**: 数十 GB・多数ファイルの走査コスト。background task なので UI はブロックしないが、GC 自体は数秒〜数十秒かかり得る。参照切れ判定は `messages/*.json` の参照集合を source of truth とし、ディレクトリサイズ計算は削除対象のみに限定する。
+
+## 仮定
+
+- GC は起動時 1 回、background task で実行（同期実行しない）。二重起動時の排他は単一プロセス前提で不要とみなす（複数 Releash プロセス同時起動は既存 orphan cleanup と同様、レコード単位冪等でカバー）。
+- retention 閾値は定数（archived log 30 日 / cache 7 日）。UI 設定は非スコープ。
+- retention 起点時刻: 2-2 の Archived/Closed session は `meta.updatedAt`、archived workflow は `workflow_run_archives.json.archived_at`、cache はファイル `mtime`。
+- 参照切れ判定は `messages/*.json` の `ToolOutputRef.id` / attachment id の union を正とする。message が読めない session は保守的にスキップする。
+- active 判定は `state==Active` ∪ live pid record の session。running workflow は `RunStore` の非 terminal run。両者を保護集合とする。
+- 削除ルールの中核は復帰可能性で、spec のラベルはコード state 名と名前一致しない。**使用中（Active/Idle/Done/Error）は無期限保持（2-3）**、**Archived/Closed session と archived workflow は 30日で削除（2-2）**、**復帰不可の orphan 残骸は即削除（2-1）**。
+- 旧形式 `comments`/`diff-comments`/`threads` は移行せず全削除（使用中分の旧コメント喪失をユーザー承知）。
+- 生存 worktree 集合は「その起動時点の `SharedRepoPaths` × `list_worktrees()`」で確定。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1372/requirements.md
+++ b/docs/specs/issues-1372/requirements.md
@@ -1,0 +1,136 @@
+# Requirements
+
+関連: #1372
+
+## Type
+
+新機能（backend GC）。無期限に蓄積する app data を、削除ルール（削除済み Workspace・Session/Workflow 状態別のログ・再生成 cache・旧形式データ・参照切れファイル・stale process record）に従って削除し容量を回収する。外部から観測可能な UI/CLI の振る舞いは追加しない（アプリ起動時の内部処理）。
+
+## 背景と目的
+
+Releash は app data ディレクトリ（macOS では `~/Library/Application Support/com.releash.app`）配下に、session data・workflow log/artifact・LSP cache・comment/thread・checkpoint・process record・runtime file などを保存する。これらが無期限に蓄積し、通常利用だけで数十 GB の SSD 容量を消費する。
+
+実測（開発機、2026-07-05 時点）でも次のとおり `sessions` と `lsp` が支配的であり、放置されたデータが容量の大半を占める:
+
+- `sessions/` … 約 29 GB（最大要因。agent session 本体・`events.json`・`messages/`・`tool_outputs/`・`attachments/`）
+- `lsp/` … 約 1.4 GB（`jdtls` / `jdtls-workspaces` / `typescript` の再生成可能 cache）
+- `agent-worktree-checkpoints/` … 約 31 MB
+- `workflow_logs/` … 約 18 MB
+- `review-comments/` … 約 11 MB
+- ほか `comments/`・`diff-comments/`・`threads/`（旧形式）、`agent-processes/`・`pids/`（process/pid registry）、`workflow_runs/`・`workflow_pending/` 等
+
+本変更の目的は、プロダクト方針「全量を保持する設計を縮小する」に従い、**backend 側に GC を実装し、不要になった app data を安全に削除して容量を回収する**ことである。削除は「もう参照されていない／再生成可能である」ことが判定できるデータに限り、実行中の作業（active session / running workflow）や、まだ参照されている Workspace の生きたデータを壊さないことを最優先とする。
+
+### 削除ルール（正典）
+
+GC の削除判定は次の階層で行う。中核は**復帰可能性**であり、単純な古さ（保持日数）ではない。
+
+1. **削除済み Workspace のログ** — 復帰不可能なので削除する。
+2. **使用中 Workspace のログ** — 中の Session / Workflow の状態で判断する。
+   1. 削除済みの Session / Workflow のログ — 削除する。
+   2. アーカイブ済みの Session / Workflow のログ — 30 日を超えたら削除する。
+   3. 使用中の Session / Workflow のログ — 削除しない。
+   4. 再生成可能なキャッシュ — 状態に関わらず 7 日を超えたら削除する。
+
+上記のログ／キャッシュ判定に加えて、Issue #1372 が名指しする次の3種類を削除する。これらは「Session/Workflow のログ」でも「キャッシュ」でもないため、上の階層とは別軸で扱う。
+
+- **旧形式 `comments` / `diff-comments` / `threads`** — 現行 `review-comments/` に置換済みの廃止フォーマット。状態に関わらず全て削除する（新形式への移行はしないため、使用中 Workspace 分の旧コメントも失われる。ユーザー確認済み）。
+- **参照切れ `tool_outputs` / `attachments`** — Session が**使用中でも**、その Session のどの message からも参照されていない blob はファイル単位で削除する（ルール 2-3 の例外。生きている会話には触れず、誰も参照していない実体だけを消す）。
+- **stale な process / pid record** — `agent-processes/{session}.{backend}.{pid}.json` / `pids/` のうち、記録された pid のプロセスが既に死んでいるものを削除する。
+
+**安全ガード**: active session / running workflow に紐づくデータは、上記いずれの経路でも削除しない。
+
+#### 補足（実装調査による事実）
+
+- **Archived の定義**: session は `meta.json` の `state = "archived"`、workflow は run archive（`workflow_run_archives.json` / `archive_workspace_workflow_run`）。復帰されうるため、古くても本体は消さない（ログは 30 日 retention の対象）。
+- **worktree 削除は波及しない**: worktree（Workspace）の削除は紐づく session / workflow へ cascade しない（`adaptor/gateway/repository/worktree.rs` に session 掃除経路なし、`repository_state/worktree.rs` にも cascade なし）。そのため worktree 削除後、`meta.json` の `worktreePath` がその worktree を指す session 一式・checkpoint・`workspace_state`・workflow データが app data に取り残される。これがルール 1 の主対象であり、容量主因（`sessions/` 約 29 GB）の多くもここに該当すると見込まれる。checkpoint は命名規約から worktree との対応付けを確実に証明できる場合のみ削除対象にし、証明できない場合は保守的に残す。
+- **参照切れの判定**: 大きな tool 出力は `tool_outputs/{hash}` に blob として書き出し、message は `ToolOutputRef { id: hash }` で参照する（`tool_output_blob.rs`）。その Session の全 `messages/*.json` から参照 id を集め、`tool_outputs/` のファイル名(id)がその集合に無ければ参照切れ。`attachments/{id}` も同構図。fork（親 `tool_outputs/` を丸ごとコピー）や compaction・メッセージ作り直しで発生する。
+
+### app data の実ディレクトリ構成（GC の対象領域、コード・実データ調査による事実）
+
+app data ルートは Tauri の `app_data_dir()`（＝ `com.releash.app`）で、CLI 経路は環境変数 `RELEASH_DATA_DIR` でも解決される（`src-tauri/src/lib.rs:73`, `src-tauri/src/cli/common.rs:49-71`）。主要サブディレクトリと保存元:
+
+- `sessions/` — agent session。dir 形式 `sessions/{session_id}/`（`meta.json`・`index.json`・`private_context.json`・`events.json`・`messages/{seq}.json`・`attachments/{id}`・`tool_outputs/{id}`）と legacy flat（`{session_id}.json`）・legacy sidecar（`{session_id}.meta.json`）。パス定義は `adaptor/gateway/agent_session/session_storage/layout.rs`。`meta.json` は Workspace への紐付けキー `worktreePath`（絶対パス）と `state`（active/archived 等）を持つ。
+- `workflow_runs/` / `workflow_logs/` / `workflow_pending/` / `workflow/` / `workflow_run_archives.json` — workflow run・log・artifact・archive index。
+- `lsp/`（`jdtls` / `jdtls-workspaces` / `jdtls.version` / `typescript`）— LSP workspace cache と TypeScript cache。いずれも再生成可能。
+- `comments/` / `diff-comments/` / `threads/` — **旧形式**の comment/thread。現行の review comment 系は `review-comments/` に保存される。
+- `agent-processes/{session_id}.{backend}.{pid}.json` / `pids/` — process record・pid registry（`pid`・`pgid`・`owner_app_pid` 等を保持）。
+- `agent-worktree-checkpoints/` / `agent-worktree-checkpoint-backups/` — Workspace(worktree) 単位の checkpoint。
+- `workspace_state/{workspace_id}.json` — Workspace ごとの UI 状態（editor tab / layout）。
+- `plans/`・`shell-integration/`・`bin/`・`tls/`・`releash.toml`・`available_models*.json` — 設定・実行資材（本 GC の主対象ではない）。
+
+「参照されている Workspace」は git worktree 一覧（`adaptor/gateway/repository/worktree.rs` の `list_worktrees()`）から解決される worktree に対応する。session 等はその `worktreePath` を通じて Workspace に紐づく。
+
+## スコープ
+
+backend（Rust）に GC を実装し、上記「削除ルール（正典）」に従って app data を削除する。具体的には次を対象とする。
+
+1. **ルール 1 — 削除済み Workspace のログ**: worktree が存在しない Workspace に紐づく app data（session 一式・`workspace_state`・workflow データ等）を削除する。checkpoint は worktree との対応付けを確実に証明できる場合のみ削除し、証明できない場合は残す。
+2. **ルール 2 — 使用中 Workspace のログ（Session/Workflow 状態で判断）**:
+   - 2-1: 削除済みの Session / Workflow のログを削除する。
+   - 2-2: アーカイブ済みの Session / Workflow のログを 30 日超で削除する。
+   - 2-3: 使用中の Session / Workflow のログは削除しない。
+   - 2-4: 再生成可能なキャッシュ（LSP workspace cache `lsp/`、TypeScript cache `lsp/typescript`）を状態問わず 7 日超で削除する。
+3. **旧形式データの全削除**: `comments/` / `diff-comments/` / `threads/`（廃止フォーマット）を状態問わず全て削除する。
+4. **参照切れファイルの削除**: 使用中 Session を含め、どの message からも参照されていない `tool_outputs` / `attachments` の blob をファイル単位で削除する（ルール 2-3 の例外）。
+5. **stale process/pid record の削除**: `agent-processes/` / `pids/` のうち、記録 pid のプロセスが死んでいるレコードを削除する。
+6. **安全ガード**: active session / running workflow に紐づくデータは、上記いずれの経路でも削除しない。
+7. **可観測性**: GC の削除件数と回収 byte 数を backend log に出力する。
+8. GC ロジックは frontend ではなく Rust/backend 側に置く。
+9. **起動トリガ**: GC は backend（アプリ）起動時に 1 回実行する。
+
+## 非スコープ
+
+- Dry-run 機能。
+- 手動 cleanup を起動する UI / CLI コマンド。
+- 削除前の確認 UI・削除対象のプレビュー表示。
+- app data のディレクトリ構造・保存フォーマット自体の変更（既存構造の上で削除する）。
+- 旧形式データの新形式への移行（旧形式 `comments`/`diff-comments`/`threads` は移行ではなく削除する）。
+- 削除済みデータのゴミ箱・復元機構。
+- retention 期間（30 日 / 7 日）のユーザー設定 UI。
+
+## 要求事項
+
+- GC が backend（Rust）で動作し、frontend にロジックを持たないこと。
+- GC が backend（アプリ）起動時に実行されること。起動処理を過度にブロックしないこと。
+- **ルール 1**: worktree が存在しない Workspace に紐づく app data が削除されること。
+- **ルール 2-1**: 削除済みの Session / Workflow のログが削除されること。
+- **ルール 2-2**: アーカイブ済みの Session / Workflow のログが 30 日超で削除され、30 日以内は保持されること。
+- **ルール 2-3**: 使用中の Session / Workflow のログが削除されないこと。
+- **ルール 2-4**: 再生成可能 cache（LSP / TypeScript cache）が状態問わず 7 日超で削除され、7 日以内は保持されること。
+- **旧形式削除**: `comments` / `diff-comments` / `threads` が状態問わず全て削除されること。
+- **参照切れ削除**: 使用中 Session を含め、どの message からも参照されていない `tool_outputs` / `attachments` の blob が削除され、参照中の blob は残ること。
+- **stale process/pid 削除**: 記録 pid のプロセスが死んでいる process record / pid registry が削除され、生存中のものは残ること。
+- **安全ガード**: active session / running workflow に紐づくデータが、いずれの削除経路でも削除されないこと。
+- GC の削除件数と回収 byte 数が backend log に出力されること。
+- 上記を担保するテスト（各ルールの削除／保持、参照切れ判定、retention 境界、active/running 保護）が存在すること。
+
+## 受け入れ基準の概要
+
+- worktree が無い Workspace に紐づく app data が GC 実行後に削除されている（ルール 1）。
+- 削除済み Session / Workflow のログが削除される（ルール 2-1）。
+- アーカイブ済み Session / Workflow のログが 30 日境界で保持／削除される（ルール 2-2）。
+- 使用中 Session / Workflow のログが GC 実行後も残る（ルール 2-3）。
+- 再生成可能 cache（LSP / TypeScript）が 7 日境界で保持／削除される（ルール 2-4）。
+- 旧形式 `comments` / `diff-comments` / `threads` が状態問わず削除される。
+- 使用中 Session 内でも参照切れ `tool_outputs` / `attachments` が削除され、参照中の blob は残る。
+- pid が死んだ process / pid record が削除され、生存中は残る。
+- active session / running workflow に紐づくデータが GC 実行後も残る（安全ガード）。
+- GC 実行後、削除件数と回収 byte 数が backend log に出力される。
+- `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` が通る。
+
+## 仮定
+
+- 削除ルール（正典）はユーザー確定。中核は復帰可能性で、**古さ（保持日数）は使用中 Session/Workflow のログ本体の削除基準にはしない**（ルール 2-3）。30 日 / 7 日はそれぞれアーカイブ済みログ（2-2）・再生成 cache（2-4）にのみ適用する。
+- 「使用中 Workspace」は、既知リポジトリの git worktree 一覧（`list_worktrees()`）に現存する worktree として解決する想定。session は `meta.json` の `worktreePath` がいずれの現存 worktree とも一致しなければ「削除済み Workspace」（ルール 1）とみなす。厳密な判定境界（対象リポジトリ集合の決め方、絶対パスの正規化）は design.md で確定する。
+- worktree 削除は session / workflow へ波及しないため、GC 起動時点の worktree 現存集合と `worktreePath` を突き合わせてルール 1 の対象を判定する。
+- Session/Workflow の「使用中／アーカイブ済み／削除済み」区別: session は `meta.json` の `state`（`archived` はアーカイブ）、workflow は run archive（`workflow_run_archives.json`）で判定する想定。「削除済み」の表現（物理削除の取り残し／マーカー）と正確な source of truth は design.md で確定する。
+- retention（30 日 / 7 日）の起点時刻は対象データの更新時刻（ログは `meta.json` の `updatedAt` またはファイル mtime、cache はファイル mtime）を基準とする想定。正確な基準時刻は design.md で確定する。
+- 参照切れ判定は、対象 Session の全 `messages/*.json` から `ToolOutputRef.id`・attachment id を集め、`tool_outputs/` / `attachments/` の各ファイル id がその集合に無いものを参照切れとする想定。
+- active session / running workflow の判定は、backend が保持する実行中 registry と `agent-processes/` の pid 生存確認を用いる想定。判定の source of truth は design.md で確定する。
+- 旧形式 `comments` / `diff-comments` / `threads` は現行 `review-comments/` に置換済みで、移行せず全削除する（使用中 Workspace 分の旧コメントは失われることをユーザー承知）。
+- GC は破壊的操作のため、各ルールに合致すると確実に判定できたデータに限って削除し、判定できないデータは残す（保守的削除）方針とする。削除の原子性（途中終了時の中途半端な状態の許容度）は design.md で確定する。
+
+## Open Questions
+
+なし。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3750,6 +3750,7 @@ dependencies = [
  "bytes",
  "clap",
  "dirs 6.0.0",
+ "filetime",
  "fix-path-env",
  "flate2",
  "fs2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -85,6 +85,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = ["std", 
 vendored-openssl = ["git2/vendored-openssl"]
 
 [dev-dependencies]
+filetime = "0.2"
 opentelemetry_sdk = { version = "0.32", features = ["testing"] }
 # [04] / spec [04] テスト境界: production `WorkflowEngine::dispatch` を直接呼ぶ harness で
 # 実 `AppHandle` を構築するために tauri の test feature を有効化する。

--- a/src-tauri/src/adaptor/controller/wiring.rs
+++ b/src-tauri/src/adaptor/controller/wiring.rs
@@ -8,6 +8,7 @@
 //! repository / code / agent_session / workflow などの usecase builder を一元的に束ね、
 //! query service や gateway 協力者は対応する usecase の構築時に注入する。
 
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -325,4 +326,89 @@ pub(crate) fn build_workflow_step_lifecycle_usecase(
 
 pub(crate) fn spawn_workflow_pending_command_watcher(app: tauri::AppHandle, data_dir: PathBuf) {
     crate::adaptor::gateway::workflow::spawn_pending_command_watcher(app, data_dir);
+}
+
+pub(crate) fn spawn_startup_app_data_gc(
+    app_data_dir: PathBuf,
+    shared_repo_paths: crate::adaptor::gateway::repository::repo_paths::SharedRepoPaths,
+) {
+    spawn_startup_gc_with(
+        move || {
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                let fs = crate::adaptor::gateway::app_data_gc::StdGcFileSystem;
+                let archive_pruner = crate::adaptor::gateway::app_data_gc::StdWorkflowArchivePruner;
+                let revalidation_reader =
+                    crate::adaptor::gateway::app_data_gc::StdGcRevalidationReader;
+                let request = crate::adaptor::gateway::app_data_gc::build_startup_gc_request(
+                    app_data_dir,
+                    shared_repo_paths,
+                );
+                crate::usecase::app_data_gc::run_startup_gc(
+                    request,
+                    &fs,
+                    &archive_pruner,
+                    &revalidation_reader,
+                )
+            }));
+            if result.is_err() {
+                log::error!("app data gc task panicked");
+            }
+        },
+        |gc| {
+            tauri::async_runtime::spawn_blocking(gc);
+        },
+    );
+}
+
+fn spawn_startup_gc_with<F, S>(gc: F, spawn: S)
+where
+    F: FnOnce() + Send + 'static,
+    S: FnOnce(F),
+{
+    spawn(gc);
+}
+
+#[cfg(test)]
+mod startup_gc_spawn_tests {
+    use super::spawn_startup_gc_with;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{mpsc, Arc};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn startup_gc_runner_spawns_once() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_spawn = calls.clone();
+
+        spawn_startup_gc_with(
+            || panic!("gc body should not be run by this spawn stub"),
+            move |gc| {
+                calls_for_spawn.fetch_add(1, Ordering::SeqCst);
+                let _ = gc;
+            },
+        );
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn startup_gc_runner_does_not_wait_for_gc_body() {
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let started = Instant::now();
+
+        spawn_startup_gc_with(
+            move || {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            },
+            |gc| {
+                std::thread::spawn(gc);
+            },
+        );
+
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(started.elapsed() < Duration::from_millis(500));
+        release_tx.send(()).unwrap();
+    }
 }

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
@@ -13,6 +13,7 @@ use crate::usecase::agent_session::session::{
 mod attachment_blob;
 mod event_store;
 mod fork_copier;
+mod gc;
 mod layout;
 mod message_store;
 mod meta_repository;
@@ -22,6 +23,8 @@ mod tool_output_blob;
 
 #[cfg(test)]
 mod tests;
+
+pub(crate) use gc::SessionGcMetaRead;
 
 pub struct FileSessionStorage {
     pub(super) cache: RwLock<HashMap<String, SessionMeta>>,

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/gc.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/gc.rs
@@ -1,0 +1,383 @@
+use std::path::{Path, PathBuf};
+
+use super::layout::{
+    attachments_dir_in_dir, messages_dir_in_dir, meta_file_in_dir, sessions_dir,
+    tool_outputs_dir_in_dir,
+};
+use super::FileSessionStorage;
+use crate::usecase::agent_session::session::SessionState;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SessionGcMeta {
+    pub(crate) id: Option<String>,
+    pub(crate) worktree_path: Option<String>,
+    pub(crate) state: Option<SessionState>,
+    pub(crate) updated_at: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SessionGcRecordLayout {
+    pub(crate) id: String,
+    pub(crate) delete_paths: Vec<PathBuf>,
+    pub(crate) dir_path: Option<PathBuf>,
+    pub(crate) worktree_path: Option<String>,
+    pub(crate) state: Option<SessionState>,
+    pub(crate) updated_at: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionGcBlobStoreLayout {
+    pub(crate) session_dir: PathBuf,
+    pub(crate) messages_dir: PathBuf,
+    pub(crate) tool_outputs_dir: PathBuf,
+    pub(crate) attachments_dir: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SessionGcMetaScan {
+    pub(crate) items: Vec<SessionGcMeta>,
+    pub(crate) is_complete: bool,
+}
+
+impl Default for SessionGcMetaScan {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            is_complete: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SessionGcMetaRead {
+    Present(SessionGcMeta),
+    Missing,
+    Unavailable(String),
+}
+
+#[derive(Clone, Copy)]
+enum InvalidJsonPolicy {
+    DefaultMeta,
+    Error,
+}
+
+enum SessionGcMetaReadError {
+    NotFound,
+    Unavailable(String),
+}
+
+impl FileSessionStorage {
+    pub(crate) fn list_gc_session_records(
+        &self,
+        app_data_dir: &Path,
+    ) -> Vec<SessionGcRecordLayout> {
+        let sessions_dir = sessions_dir(app_data_dir);
+        let Ok(entries) = std::fs::read_dir(&sessions_dir) else {
+            return Vec::new();
+        };
+        let mut records = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                let Some(id) = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(str::to_string)
+                else {
+                    continue;
+                };
+                let meta = match read_gc_meta_or_default_on_missing(
+                    &meta_file_in_dir(&path),
+                    &id,
+                    InvalidJsonPolicy::DefaultMeta,
+                ) {
+                    Some(meta) => meta,
+                    None => continue,
+                };
+                records.push(session_record_layout(
+                    meta,
+                    &id,
+                    vec![path.clone()],
+                    Some(path),
+                ));
+                continue;
+            }
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            if stem.ends_with(".meta") {
+                continue;
+            }
+            let id = stem.to_string();
+            let sidecar = legacy_meta_file_in_sessions_dir(&sessions_dir, &id);
+            let meta_path = if sidecar.exists() { &sidecar } else { &path };
+            let meta = match read_gc_meta_or_default_on_missing(
+                meta_path,
+                &id,
+                InvalidJsonPolicy::DefaultMeta,
+            ) {
+                Some(meta) => meta,
+                None => continue,
+            };
+            let mut delete_paths = vec![path];
+            if sidecar.exists() {
+                delete_paths.push(sidecar);
+            }
+            records.push(session_record_layout(meta, &id, delete_paths, None));
+        }
+        records
+    }
+
+    pub(crate) fn list_gc_session_blob_stores(
+        &self,
+        app_data_dir: &Path,
+    ) -> Vec<SessionGcBlobStoreLayout> {
+        let sessions_dir = sessions_dir(app_data_dir);
+        let Ok(entries) = std::fs::read_dir(&sessions_dir) else {
+            return Vec::new();
+        };
+        entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir())
+            .map(|session_dir| SessionGcBlobStoreLayout {
+                messages_dir: messages_dir_in_dir(&session_dir),
+                tool_outputs_dir: tool_outputs_dir_in_dir(&session_dir),
+                attachments_dir: attachments_dir_in_dir(&session_dir),
+                session_dir,
+            })
+            .collect()
+    }
+
+    pub(crate) fn list_gc_session_protection_meta(&self, app_data_dir: &Path) -> SessionGcMetaScan {
+        let sessions_dir = sessions_dir(app_data_dir);
+        let entries = match std::fs::read_dir(&sessions_dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return SessionGcMetaScan {
+                    items: Vec::new(),
+                    is_complete: true,
+                };
+            }
+            Err(error) => {
+                log::warn!(
+                    "app data gc could not scan session protection metadata {}: {error}",
+                    sessions_dir.display()
+                );
+                return SessionGcMetaScan {
+                    items: Vec::new(),
+                    is_complete: false,
+                };
+            }
+        };
+        let mut items = Vec::new();
+        let mut is_complete = true;
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    log::warn!(
+                        "app data gc skipped session protection entry in {}: {error}",
+                        sessions_dir.display()
+                    );
+                    is_complete = false;
+                    continue;
+                }
+            };
+            let path = entry.path();
+            let Some((meta_path, fallback_id)) =
+                gc_meta_path_for_session_entry(&sessions_dir, path)
+            else {
+                continue;
+            };
+            match read_session_gc_meta_file(&meta_path, &fallback_id, InvalidJsonPolicy::Error) {
+                Ok(meta) => items.push(meta),
+                Err(SessionGcMetaReadError::NotFound) => {
+                    log::warn!(
+                        "app data gc could not read session protection metadata {}: not found",
+                        meta_path.display()
+                    );
+                    is_complete = false;
+                }
+                Err(SessionGcMetaReadError::Unavailable(error)) => {
+                    log::warn!(
+                        "app data gc could not read session protection metadata {}: {error}",
+                        meta_path.display()
+                    );
+                    is_complete = false;
+                }
+            }
+        }
+        SessionGcMetaScan { items, is_complete }
+    }
+
+    pub(crate) fn read_gc_session_meta_for_revalidation(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+    ) -> SessionGcMetaRead {
+        let sessions_dir = sessions_dir(app_data_dir);
+        let session_dir = sessions_dir.join(session_id);
+        if session_dir.is_dir() {
+            return read_gc_meta_for_revalidation(&meta_file_in_dir(&session_dir), session_id);
+        }
+        let session_file = sessions_dir.join(format!("{session_id}.json"));
+        let sidecar = legacy_meta_file_in_sessions_dir(&sessions_dir, session_id);
+        if sidecar.exists() {
+            return read_gc_meta_for_revalidation(&sidecar, session_id);
+        }
+        if session_file.exists() {
+            return read_gc_meta_for_revalidation(&session_file, session_id);
+        }
+        SessionGcMetaRead::Missing
+    }
+}
+
+fn gc_meta_path_for_session_entry(sessions_dir: &Path, path: PathBuf) -> Option<(PathBuf, String)> {
+    if path.is_dir() {
+        let id = path.file_name().and_then(|name| name.to_str())?.to_string();
+        return Some((meta_file_in_dir(&path), id));
+    }
+    if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+        return None;
+    }
+    let stem = path.file_stem().and_then(|stem| stem.to_str())?.to_string();
+    if stem.ends_with(".meta") {
+        return None;
+    }
+    let sidecar = legacy_meta_file_in_sessions_dir(sessions_dir, &stem);
+    if sidecar.exists() {
+        Some((sidecar, stem))
+    } else {
+        Some((path, stem))
+    }
+}
+
+fn session_record_layout(
+    meta: SessionGcMeta,
+    fallback_id: &str,
+    delete_paths: Vec<PathBuf>,
+    dir_path: Option<PathBuf>,
+) -> SessionGcRecordLayout {
+    SessionGcRecordLayout {
+        id: meta.id.unwrap_or_else(|| fallback_id.to_string()),
+        delete_paths,
+        dir_path,
+        worktree_path: meta.worktree_path,
+        state: meta.state,
+        updated_at: meta.updated_at,
+    }
+}
+
+fn read_gc_meta_for_revalidation(path: &Path, fallback_id: &str) -> SessionGcMetaRead {
+    match read_session_gc_meta_file(path, fallback_id, InvalidJsonPolicy::DefaultMeta) {
+        Ok(meta) => SessionGcMetaRead::Present(meta),
+        Err(SessionGcMetaReadError::NotFound) => SessionGcMetaRead::Present(SessionGcMeta {
+            id: Some(fallback_id.to_string()),
+            ..SessionGcMeta::default()
+        }),
+        Err(SessionGcMetaReadError::Unavailable(error)) => SessionGcMetaRead::Unavailable(error),
+    }
+}
+
+fn read_gc_meta_or_default_on_missing(
+    path: &Path,
+    fallback_id: &str,
+    invalid_json: InvalidJsonPolicy,
+) -> Option<SessionGcMeta> {
+    match read_session_gc_meta_file(path, fallback_id, invalid_json) {
+        Ok(meta) => Some(meta),
+        Err(SessionGcMetaReadError::NotFound) => Some(SessionGcMeta {
+            id: Some(fallback_id.to_string()),
+            ..SessionGcMeta::default()
+        }),
+        Err(SessionGcMetaReadError::Unavailable(error)) => {
+            log::warn!(
+                "app data gc skipped session {} because meta {} could not be read: {error}",
+                fallback_id,
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+fn read_session_gc_meta_file(
+    path: &Path,
+    fallback_id: &str,
+    invalid_json: InvalidJsonPolicy,
+) -> Result<SessionGcMeta, SessionGcMetaReadError> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SessionGcMetaReadError::NotFound);
+        }
+        Err(error) => return Err(SessionGcMetaReadError::Unavailable(error.to_string())),
+    };
+    let value = match serde_json::from_str::<serde_json::Value>(&content) {
+        Ok(value) => value,
+        Err(error) => match invalid_json {
+            InvalidJsonPolicy::DefaultMeta => {
+                log::warn!(
+                    "app data gc skipped unreadable session meta {}",
+                    path.display()
+                );
+                return Ok(SessionGcMeta {
+                    id: Some(fallback_id.to_string()),
+                    ..SessionGcMeta::default()
+                });
+            }
+            InvalidJsonPolicy::Error => {
+                return Err(SessionGcMetaReadError::Unavailable(error.to_string()));
+            }
+        },
+    };
+    if matches!(invalid_json, InvalidJsonPolicy::Error) {
+        validate_session_gc_meta_shape(&value).map_err(SessionGcMetaReadError::Unavailable)?;
+    }
+    Ok(session_gc_meta_from_value(&value, fallback_id))
+}
+
+fn validate_session_gc_meta_shape(value: &serde_json::Value) -> Result<(), String> {
+    if !value.is_object() {
+        return Err("session meta must be a JSON object".to_string());
+    }
+    validate_optional_string_field(value, "id")?;
+    validate_optional_string_field(value, "worktreePath")?;
+    Ok(())
+}
+
+fn validate_optional_string_field(value: &serde_json::Value, field: &str) -> Result<(), String> {
+    if value
+        .get(field)
+        .is_some_and(|value| !value.is_string() && !value.is_null())
+    {
+        return Err(format!("session meta field {field} must be a string"));
+    }
+    Ok(())
+}
+
+fn session_gc_meta_from_value(value: &serde_json::Value, fallback_id: &str) -> SessionGcMeta {
+    SessionGcMeta {
+        id: value
+            .get("id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .or_else(|| Some(fallback_id.to_string())),
+        worktree_path: value
+            .get("worktreePath")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        state: value
+            .get("state")
+            .and_then(|value| serde_json::from_value::<SessionState>(value.clone()).ok()),
+        updated_at: value.get("updatedAt").and_then(|value| value.as_f64()),
+    }
+}
+
+fn legacy_meta_file_in_sessions_dir(sessions_dir: &Path, session_id: &str) -> PathBuf {
+    sessions_dir.join(format!("{session_id}.meta.json"))
+}

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/gc.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/gc.rs
@@ -347,6 +347,8 @@ fn validate_session_gc_meta_shape(value: &serde_json::Value) -> Result<(), Strin
     }
     validate_optional_string_field(value, "id")?;
     validate_optional_string_field(value, "worktreePath")?;
+    validate_optional_session_state_field(value, "state")?;
+    validate_optional_number_field(value, "updatedAt")?;
     Ok(())
 }
 
@@ -356,6 +358,31 @@ fn validate_optional_string_field(value: &serde_json::Value, field: &str) -> Res
         .is_some_and(|value| !value.is_string() && !value.is_null())
     {
         return Err(format!("session meta field {field} must be a string"));
+    }
+    Ok(())
+}
+
+fn validate_optional_session_state_field(
+    value: &serde_json::Value,
+    field: &str,
+) -> Result<(), String> {
+    let Some(field_value) = value.get(field) else {
+        return Ok(());
+    };
+    if field_value.is_null() {
+        return Ok(());
+    }
+    serde_json::from_value::<SessionState>(field_value.clone())
+        .map_err(|_| format!("session meta field {field} must be a valid session state"))?;
+    Ok(())
+}
+
+fn validate_optional_number_field(value: &serde_json::Value, field: &str) -> Result<(), String> {
+    if value
+        .get(field)
+        .is_some_and(|value| !value.is_number() && !value.is_null())
+    {
+        return Err(format!("session meta field {field} must be a number"));
     }
     Ok(())
 }
@@ -380,4 +407,94 @@ fn session_gc_meta_from_value(value: &serde_json::Value, fallback_id: &str) -> S
 
 fn legacy_meta_file_in_sessions_dir(sessions_dir: &Path, session_id: &str) -> PathBuf {
     sessions_dir.join(format!("{session_id}.meta.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strict_meta_validation_rejects_invalid_state_and_updated_at_types() {
+        assert!(validate_session_gc_meta_shape(&serde_json::json!({
+            "state": "not_a_state"
+        }))
+        .is_err());
+        assert!(validate_session_gc_meta_shape(&serde_json::json!({
+            "state": true
+        }))
+        .is_err());
+        assert!(validate_session_gc_meta_shape(&serde_json::json!({
+            "updatedAt": "100"
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn strict_meta_validation_accepts_valid_state_updated_at_and_nulls() {
+        validate_session_gc_meta_shape(&serde_json::json!({
+            "state": "active",
+            "updatedAt": 100.5
+        }))
+        .unwrap();
+        validate_session_gc_meta_shape(&serde_json::json!({
+            "state": null,
+            "updatedAt": null
+        }))
+        .unwrap();
+    }
+
+    #[test]
+    fn protection_meta_scan_marks_invalid_meta_incomplete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions_dir = tmp.path().join("sessions");
+        std::fs::create_dir_all(sessions_dir.join("invalid-state")).unwrap();
+        std::fs::write(
+            sessions_dir.join("invalid-state/meta.json"),
+            serde_json::json!({
+                "id": "invalid-state",
+                "state": "not_a_state"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        std::fs::create_dir_all(sessions_dir.join("invalid-updated-at")).unwrap();
+        std::fs::write(
+            sessions_dir.join("invalid-updated-at/meta.json"),
+            serde_json::json!({
+                "id": "invalid-updated-at",
+                "updatedAt": "100"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let scan = FileSessionStorage::default().list_gc_session_protection_meta(tmp.path());
+
+        assert!(!scan.is_complete);
+        assert!(scan.items.is_empty());
+    }
+
+    #[test]
+    fn default_meta_policy_keeps_lenient_state_and_updated_at_behavior() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions_dir = tmp.path().join("sessions");
+        std::fs::create_dir_all(sessions_dir.join("session")).unwrap();
+        std::fs::write(
+            sessions_dir.join("session/meta.json"),
+            serde_json::json!({
+                "id": "session",
+                "state": "not_a_state",
+                "updatedAt": "100"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let records = FileSessionStorage::default().list_gc_session_records(tmp.path());
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].id, "session");
+        assert_eq!(records[0].state, None);
+        assert_eq!(records[0].updated_at, None);
+    }
 }

--- a/src-tauri/src/adaptor/gateway/app_data_gc/mod.rs
+++ b/src-tauri/src/adaptor/gateway/app_data_gc/mod.rs
@@ -1,0 +1,766 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use crate::adaptor::gateway::agent_session::session_storage::{
+    FileSessionStorage, SessionGcMetaRead,
+};
+use crate::adaptor::gateway::repository::repo_paths::SharedRepoPaths;
+use crate::adaptor::gateway::workflow::{
+    WorkflowRunArchiveFileRepository, WorkflowRunFileRepository,
+};
+use crate::domain::workflow::WorkflowRunArchiveRepository;
+use crate::infrastructure::process::pid_registry::{
+    process_group_status, read_pid_file, recorded_pid_status, ProcessStatus,
+};
+use crate::usecase::agent_session::session::SessionState;
+use crate::usecase::app_data_gc::{
+    CacheGcRecord, CurrentSessionState, CurrentWorkflowRunState, GcRevalidationReader,
+    GcWorktreePath, LiveWorktree, LiveWorktreeResolution, LiveWorktreeSet, ProcessRecord,
+    ProcessRecordStatus, RevalidationRead, ReviewCommentGcRecord, RuntimeProtection,
+    SessionBlobStore, SessionGcRecord, StartupGcRequest, WorkflowRunGcRecord,
+    WorkspaceStateGcRecord,
+};
+
+mod std_file_system;
+
+pub(crate) use std_file_system::{StdGcFileSystem, StdWorkflowArchivePruner};
+
+pub(crate) fn build_startup_gc_request(
+    app_data_dir: PathBuf,
+    shared_repo_paths: SharedRepoPaths,
+) -> StartupGcRequest {
+    let process_records = collect_process_records(&app_data_dir);
+    let runtime_protection = collect_runtime_protection(&app_data_dir, &process_records);
+    let session_records = collect_session_gc_records(&app_data_dir);
+    let workflow_runs = collect_workflow_run_gc_records(&app_data_dir);
+    StartupGcRequest {
+        app_data_dir: app_data_dir.clone(),
+        live_worktrees: resolve_live_worktrees(shared_repo_paths),
+        session_records,
+        workflow_runs,
+        workspace_state_records: collect_workspace_state_records(&app_data_dir),
+        review_comment_records: collect_review_comment_records(&app_data_dir),
+        checkpoint_paths: collect_checkpoint_paths(&app_data_dir),
+        cache_records: collect_cache_records(&app_data_dir),
+        legacy_comment_paths: collect_legacy_comment_paths(&app_data_dir),
+        session_blob_stores: collect_session_blob_stores(&app_data_dir),
+        process_records,
+        runtime_protection,
+        now_secs: crate::other::utils::unix_timestamp_seconds(),
+        retention: crate::domain::app_data_gc::RetentionPolicy::default(),
+    }
+}
+
+fn resolve_live_worktrees(shared_repo_paths: SharedRepoPaths) -> Option<LiveWorktreeResolution> {
+    let repo_paths = shared_repo_paths.read().clone();
+    if repo_paths.is_empty() {
+        return None;
+    }
+    let mut live_worktrees = Vec::new();
+    let mut unresolved_repo_paths = Vec::new();
+    let mut unresolved_workspace_state_key_prefixes = HashSet::new();
+    for repo_path in repo_paths {
+        let worktrees = match crate::adaptor::gateway::repository::worktree::list_worktrees(
+            &repo_path,
+        ) {
+            Ok(worktrees) => worktrees,
+            Err(error) => {
+                let normalized_repo_path = normalize_path(&repo_path);
+                log::warn!(
+                    "app data gc skipped workspace-dependent cleanup for data that may belong to {}: failed to list worktrees: {error}",
+                    repo_path
+                );
+                unresolved_workspace_state_key_prefixes
+                    .extend(workspace_state_key_prefixes(&repo_path));
+                unresolved_repo_paths.push(normalized_repo_path);
+                continue;
+            }
+        };
+        live_worktrees.extend(
+            worktrees
+                .into_iter()
+                .map(|worktree| live_worktree(worktree.name, worktree.path)),
+        );
+    }
+    Some(LiveWorktreeResolution::new(
+        LiveWorktreeSet::from_worktrees(live_worktrees),
+        unresolved_repo_paths,
+        unresolved_workspace_state_key_prefixes,
+    ))
+}
+
+fn collect_process_records(app_data_dir: &Path) -> Vec<ProcessRecord> {
+    let mut records = Vec::new();
+    records.extend(collect_agent_process_records(app_data_dir));
+    records.extend(collect_legacy_pid_records(app_data_dir));
+    records
+}
+
+fn collect_agent_process_records(app_data_dir: &Path) -> Vec<ProcessRecord> {
+    let mut records = Vec::new();
+    let dir = app_data_dir.join("agent-processes");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return records;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let record = match read_pid_file(&path) {
+            Ok(pid_file) => ProcessRecord {
+                path,
+                session_id: Some(pid_file.session_id.clone()),
+                status: process_status_to_gc(recorded_pid_status(&pid_file)),
+            },
+            Err(error) => {
+                log::warn!(
+                    "app data gc skipped unreadable process record {}: {error}",
+                    path.display()
+                );
+                ProcessRecord {
+                    path,
+                    session_id: None,
+                    status: ProcessRecordStatus::Unknown,
+                }
+            }
+        };
+        records.push(record);
+    }
+    records
+}
+
+fn collect_legacy_pid_records(app_data_dir: &Path) -> Vec<ProcessRecord> {
+    let mut records = Vec::new();
+    let dir = app_data_dir.join("pids");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return records;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|value| value.to_str()) != Some("pid") {
+            continue;
+        }
+        let session_id = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .map(str::to_string);
+        let status = match read_legacy_pid_value(&path) {
+            Ok(pgid) => process_status_to_gc(process_group_status(pgid)),
+            Err(error) => {
+                log::warn!(
+                    "app data gc skipped unreadable legacy pid record {}: {error}",
+                    path.display()
+                );
+                ProcessRecordStatus::Unknown
+            }
+        };
+        records.push(ProcessRecord {
+            path,
+            session_id,
+            status,
+        });
+    }
+    records
+}
+
+fn read_legacy_pid_value(path: &Path) -> Result<i32, String> {
+    let content = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    content
+        .trim()
+        .parse::<i32>()
+        .map_err(|error| error.to_string())
+}
+
+fn process_status_to_gc(status: ProcessStatus) -> ProcessRecordStatus {
+    match status {
+        ProcessStatus::Live => ProcessRecordStatus::Live,
+        ProcessStatus::Stale => ProcessRecordStatus::Stale,
+        ProcessStatus::Unknown => ProcessRecordStatus::Unknown,
+    }
+}
+
+fn collect_session_gc_records(app_data_dir: &Path) -> Vec<SessionGcRecord> {
+    FileSessionStorage::default()
+        .list_gc_session_records(app_data_dir)
+        .into_iter()
+        .map(|record| SessionGcRecord {
+            id: record.id,
+            delete_paths: record.delete_paths,
+            dir_path: record.dir_path,
+            worktree_path: record
+                .worktree_path
+                .as_deref()
+                .map(normalize_worktree_path_for_gc),
+            state: record.state,
+            updated_at: record.updated_at,
+        })
+        .collect()
+}
+
+fn collect_session_blob_stores(app_data_dir: &Path) -> Vec<SessionBlobStore> {
+    FileSessionStorage::default()
+        .list_gc_session_blob_stores(app_data_dir)
+        .into_iter()
+        .map(|store| SessionBlobStore {
+            session_dir: store.session_dir,
+            messages_dir: store.messages_dir,
+            tool_outputs_dir: store.tool_outputs_dir,
+            attachments_dir: store.attachments_dir,
+        })
+        .collect()
+}
+
+fn collect_workflow_run_gc_records(app_data_dir: &Path) -> Vec<WorkflowRunGcRecord> {
+    let archived_at_by_run = manual_archive_times(app_data_dir);
+    let runs = WorkflowRunFileRepository::new(app_data_dir);
+    runs.scan_gc_metadata()
+        .runs
+        .into_iter()
+        .map(|run| WorkflowRunGcRecord {
+            delete_paths: runs.gc_delete_paths(&run.run_id),
+            manual_archived_at: archived_at_by_run.get(&run.run_id).copied(),
+            is_terminal: run.status.is_terminal(),
+            worktree_path: normalize_worktree_path_for_gc(&run.worktree_path),
+            run_id: run.run_id,
+        })
+        .collect()
+}
+
+fn manual_archive_times(app_data_dir: &Path) -> std::collections::HashMap<String, f64> {
+    match WorkflowRunArchiveFileRepository::new(app_data_dir).manual_archive_records() {
+        Ok(records) => records
+            .into_iter()
+            .map(|record| (record.run_id, record.archived_at))
+            .collect(),
+        Err(error) => {
+            log::warn!("app data gc skipped workflow archive index: {error}");
+            std::collections::HashMap::new()
+        }
+    }
+}
+
+fn collect_workspace_state_records(app_data_dir: &Path) -> Vec<WorkspaceStateGcRecord> {
+    let dir = app_data_dir.join("workspace_state");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let key = path.file_stem().and_then(|stem| stem.to_str())?.to_string();
+            Some(WorkspaceStateGcRecord { path, key })
+        })
+        .collect()
+}
+
+fn collect_review_comment_records(app_data_dir: &Path) -> Vec<ReviewCommentGcRecord> {
+    let dir = app_data_dir.join("review-comments");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let name = path.file_name().and_then(|name| name.to_str())?;
+            let key = name
+                .strip_suffix(".events.json")
+                .or_else(|| name.strip_suffix(".events.lock"))?
+                .to_string();
+            Some(ReviewCommentGcRecord { path, key })
+        })
+        .collect()
+}
+
+fn collect_checkpoint_paths(app_data_dir: &Path) -> Vec<PathBuf> {
+    [
+        "agent-worktree-checkpoints",
+        "agent-worktree-checkpoint-backups",
+    ]
+    .into_iter()
+    .map(|dirname| app_data_dir.join(dirname))
+    .filter(|path| path.exists())
+    .collect()
+}
+
+fn collect_cache_records(app_data_dir: &Path) -> Vec<CacheGcRecord> {
+    let mut records = Vec::new();
+    let lsp_dir = app_data_dir.join("lsp");
+    for relative in ["jdtls", "typescript", "jdtls.version"] {
+        let path = lsp_dir.join(relative);
+        push_cache_record(&path, &mut records);
+    }
+    let jdtls_workspaces = lsp_dir.join("jdtls-workspaces");
+    if let Ok(entries) = std::fs::read_dir(&jdtls_workspaces) {
+        for entry in entries.flatten() {
+            push_cache_record(&entry.path(), &mut records);
+        }
+    }
+    records
+}
+
+fn push_cache_record(path: &Path, records: &mut Vec<CacheGcRecord>) {
+    if !path.exists() {
+        return;
+    }
+    match latest_mtime_secs(path) {
+        Ok(updated_at) => records.push(CacheGcRecord {
+            path: path.to_path_buf(),
+            updated_at,
+        }),
+        Err(error) => {
+            log::warn!(
+                "app data gc skipped cache entry {}: {error}",
+                path.display()
+            );
+        }
+    }
+}
+
+fn collect_legacy_comment_paths(app_data_dir: &Path) -> Vec<PathBuf> {
+    ["comments", "diff-comments", "threads"]
+        .into_iter()
+        .map(|dirname| app_data_dir.join(dirname))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+fn latest_mtime_secs(path: &Path) -> Result<f64, String> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    let mut latest = metadata
+        .modified()
+        .map_err(|error| error.to_string())?
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs_f64())
+        .map_err(|error| error.to_string())?;
+    if metadata.file_type().is_dir() {
+        for entry in std::fs::read_dir(path).map_err(|error| error.to_string())? {
+            latest = latest.max(latest_mtime_secs(
+                &entry.map_err(|error| error.to_string())?.path(),
+            )?);
+        }
+    }
+    Ok(latest)
+}
+
+#[derive(Debug, Default)]
+struct RunningWorkflowPathCollection {
+    paths: Vec<String>,
+    is_complete: bool,
+}
+
+fn collect_runtime_protection(
+    app_data_dir: &Path,
+    process_records: &[ProcessRecord],
+) -> RuntimeProtection {
+    let live_process_sessions = process_records
+        .iter()
+        .filter(|record| record.status == ProcessRecordStatus::Live)
+        .filter_map(|record| record.session_id.as_deref())
+        .collect::<HashSet<_>>();
+    let mut active_session_ids = live_process_sessions
+        .iter()
+        .map(|session_id| (*session_id).to_string())
+        .collect::<HashSet<_>>();
+    let mut worktree_paths = Vec::new();
+    let session_meta = FileSessionStorage::default().list_gc_session_protection_meta(app_data_dir);
+    for meta in session_meta.items {
+        let id_is_live = meta
+            .id
+            .as_deref()
+            .is_some_and(|id| live_process_sessions.contains(id));
+        let state_is_active = meta.state == Some(SessionState::Active);
+        if id_is_live || state_is_active {
+            if let Some(id) = meta.id {
+                active_session_ids.insert(id);
+            }
+            if let Some(path) = meta.worktree_path {
+                worktree_paths.push(path);
+            }
+        }
+    }
+    let running_workflows = collect_running_workflow_paths(app_data_dir);
+    let running_workflows_complete = running_workflows.is_complete;
+    let running_worktree_paths = running_workflows.paths;
+    worktree_paths.extend(running_worktree_paths.iter().cloned());
+    let protected_worktrees =
+        LiveWorktreeSet::from_worktrees(worktree_paths.into_iter().map(|path| {
+            let name = Path::new(&path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("worktree")
+                .to_string();
+            live_worktree(name, path)
+        }));
+    RuntimeProtection::new(
+        active_session_ids,
+        running_worktree_paths,
+        protected_worktrees,
+    )
+    .with_workspace_keyed_protection_complete(
+        session_meta.is_complete && running_workflows_complete,
+    )
+}
+
+fn collect_running_workflow_paths(app_data_dir: &Path) -> RunningWorkflowPathCollection {
+    let scan = WorkflowRunFileRepository::new(app_data_dir).scan_gc_metadata();
+    let mut result = Vec::new();
+    for run in scan.runs {
+        if !run.status.is_terminal() {
+            let normalized = normalize_path(&run.worktree_path);
+            let raw = run.worktree_path;
+            if raw != normalized {
+                result.push(raw);
+                result.push(normalized);
+            } else {
+                result.push(raw);
+            }
+        }
+    }
+    RunningWorkflowPathCollection {
+        paths: result,
+        is_complete: scan.is_complete,
+    }
+}
+
+fn live_worktree(name: String, path: String) -> LiveWorktree {
+    let normalized = normalize_path(&path);
+    LiveWorktree {
+        workspace_state_keys: workspace_state_keys(&name, &path),
+        review_comment_keys: review_comment_keys(&path),
+        path: normalized,
+    }
+}
+
+fn workspace_state_keys(name: &str, path: &str) -> Vec<String> {
+    let normalized = normalize_path(path);
+    let mut keys = vec![
+        crate::adaptor::gateway::workspace_state::storage_key(name),
+        crate::adaptor::gateway::workspace_state::storage_key(path),
+        crate::adaptor::gateway::workspace_state::storage_key(&normalized),
+    ];
+    if let Some(file_name) = Path::new(&normalized)
+        .file_name()
+        .and_then(|name| name.to_str())
+    {
+        keys.push(crate::adaptor::gateway::workspace_state::storage_key(
+            file_name,
+        ));
+    }
+    keys
+}
+
+fn workspace_state_key_prefixes(path: &str) -> HashSet<String> {
+    let normalized = normalize_path(path);
+    [
+        crate::adaptor::gateway::workspace_state::storage_key(path),
+        crate::adaptor::gateway::workspace_state::storage_key(&normalized),
+    ]
+    .into_iter()
+    .collect()
+}
+
+fn review_comment_keys(path: &str) -> Vec<String> {
+    let normalized = normalize_path(path);
+    vec![
+        crate::adaptor::gateway::comment::worktree_storage_key(path),
+        crate::adaptor::gateway::comment::worktree_storage_key(&normalized),
+    ]
+}
+
+fn normalize_path(path: &str) -> String {
+    let trimmed = trim_path_separators(path.trim());
+    Path::new(&trimmed)
+        .canonicalize()
+        .ok()
+        .and_then(|path| path.to_str().map(str::to_string))
+        .unwrap_or(trimmed)
+}
+
+fn normalize_worktree_path_for_gc(path: &str) -> GcWorktreePath {
+    let trimmed = trim_path_separators(path.trim());
+    match Path::new(&trimmed).canonicalize() {
+        Ok(path) => path
+            .to_str()
+            .map(|path| GcWorktreePath::resolved(path.to_string()))
+            .unwrap_or_else(|| GcWorktreePath::resolved(trimmed)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            GcWorktreePath::not_found(trimmed)
+        }
+        Err(error) => {
+            log::warn!("app data gc could not canonicalize worktree path {trimmed}: {error}");
+            GcWorktreePath::unresolved(trimmed)
+        }
+    }
+}
+
+fn trim_path_separators(path: &str) -> String {
+    let mut value = path.to_string();
+    while value.len() > 1 && (value.ends_with('/') || value.ends_with('\\')) {
+        value.pop();
+    }
+    value
+}
+
+pub(crate) struct StdGcRevalidationReader;
+
+impl GcRevalidationReader for StdGcRevalidationReader {
+    fn runtime_protection(
+        &self,
+        app_data_dir: &Path,
+        process_records: &[ProcessRecord],
+    ) -> RuntimeProtection {
+        collect_runtime_protection(app_data_dir, process_records)
+    }
+
+    fn session_state(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+    ) -> RevalidationRead<CurrentSessionState> {
+        current_session_state(app_data_dir, session_id)
+    }
+
+    fn workflow_run_state(
+        &self,
+        app_data_dir: &Path,
+        run_id: &str,
+    ) -> RevalidationRead<CurrentWorkflowRunState> {
+        current_workflow_run_state(app_data_dir, run_id)
+    }
+}
+
+fn current_session_state(
+    app_data_dir: &Path,
+    session_id: &str,
+) -> RevalidationRead<CurrentSessionState> {
+    match FileSessionStorage::default()
+        .read_gc_session_meta_for_revalidation(app_data_dir, session_id)
+    {
+        SessionGcMetaRead::Present(meta) => RevalidationRead::Present(CurrentSessionState {
+            worktree_path: meta
+                .worktree_path
+                .as_deref()
+                .map(normalize_worktree_path_for_gc),
+            state: meta.state,
+            updated_at: meta.updated_at,
+        }),
+        SessionGcMetaRead::Missing => RevalidationRead::Missing,
+        SessionGcMetaRead::Unavailable(error) => RevalidationRead::Unavailable(error),
+    }
+}
+
+fn current_workflow_run_state(
+    app_data_dir: &Path,
+    run_id: &str,
+) -> RevalidationRead<CurrentWorkflowRunState> {
+    let run = match WorkflowRunFileRepository::new(app_data_dir).read_gc_metadata(run_id) {
+        Ok(Some(run)) => run,
+        Ok(None) => return RevalidationRead::Missing,
+        Err(error) => return RevalidationRead::Unavailable(error),
+    };
+    let manual_archived_at = manual_archive_times(app_data_dir).get(&run.run_id).copied();
+    RevalidationRead::Present(CurrentWorkflowRunState {
+        worktree_path: normalize_worktree_path_for_gc(&run.worktree_path),
+        is_terminal: run.status.is_terminal(),
+        manual_archived_at,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::process::pid_registry::PidFileV1;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    #[test]
+    fn resolve_live_worktrees_returns_none_when_no_repo_paths_are_known() {
+        let shared: SharedRepoPaths = Arc::new(RwLock::new(Vec::new()));
+
+        assert!(resolve_live_worktrees(shared).is_none());
+    }
+
+    #[test]
+    fn resolve_live_worktrees_keeps_successful_repos_when_one_repo_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        git2::Repository::init(&repo_path).unwrap();
+        let missing_repo = tmp.path().join("missing-repo");
+        let shared: SharedRepoPaths = Arc::new(RwLock::new(vec![
+            repo_path.to_string_lossy().into_owned(),
+            missing_repo.to_string_lossy().into_owned(),
+        ]));
+
+        assert!(resolve_live_worktrees(shared).is_some());
+    }
+
+    #[test]
+    fn runtime_protection_collects_active_sessions_live_processes_and_running_workflows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_worktree = tempfile::tempdir().unwrap();
+        let pid_worktree = tempfile::tempdir().unwrap();
+        let running_worktree = tempfile::tempdir().unwrap();
+        let sessions_dir = tmp.path().join("sessions");
+        std::fs::create_dir_all(sessions_dir.join("active-session")).unwrap();
+        std::fs::write(
+            sessions_dir.join("active-session/meta.json"),
+            serde_json::json!({
+                "worktreePath": active_worktree.path().to_string_lossy(),
+                "state": "active"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        std::fs::create_dir_all(sessions_dir.join("pid-session")).unwrap();
+        std::fs::write(
+            sessions_dir.join("pid-session/meta.json"),
+            serde_json::json!({
+                "id": "pid-session",
+                "worktreePath": pid_worktree.path().to_string_lossy(),
+                "state": "archived"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        write_workflow_run_metadata(
+            tmp.path(),
+            "00000000-0000-4000-8000-000000000001",
+            running_worktree.path(),
+            "running",
+        )
+        .unwrap();
+
+        let protection = collect_runtime_protection(
+            tmp.path(),
+            &[ProcessRecord {
+                path: tmp.path().join("agent-processes/pid-session.json"),
+                session_id: Some("pid-session".to_string()),
+                status: ProcessRecordStatus::Live,
+            }],
+        );
+
+        assert!(protection.active_session_ids.contains("active-session"));
+        assert!(protection.active_session_ids.contains("pid-session"));
+        assert!(protection.running_worktrees.contains(
+            &running_worktree
+                .path()
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        ));
+        assert!(protection.workspace_keyed_protection_complete);
+    }
+
+    #[test]
+    fn runtime_protection_marks_incomplete_when_live_pid_session_meta_is_unreadable() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("sessions/pid-session/meta.json")).unwrap();
+
+        let protection = collect_runtime_protection(
+            tmp.path(),
+            &[ProcessRecord {
+                path: tmp.path().join("agent-processes/pid-session.json"),
+                session_id: Some("pid-session".to_string()),
+                status: ProcessRecordStatus::Live,
+            }],
+        );
+
+        assert!(protection.active_session_ids.contains("pid-session"));
+        assert!(!protection.workspace_keyed_protection_complete);
+    }
+
+    #[test]
+    fn runtime_protection_marks_incomplete_when_workflow_metadata_is_unreadable() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("workflow_runs/running.json")).unwrap();
+
+        let protection = collect_runtime_protection(tmp.path(), &[]);
+
+        assert!(!protection.workspace_keyed_protection_complete);
+    }
+
+    #[test]
+    fn collect_process_records_keeps_invalid_records_unknown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agent-processes");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("bad.json"), "{").unwrap();
+
+        let records = collect_process_records(tmp.path());
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, ProcessRecordStatus::Unknown);
+        assert_eq!(records[0].session_id, None);
+    }
+
+    #[test]
+    fn json_process_record_uses_recorded_pid_liveness_not_owner_liveness() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agent-processes");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("session.codex.999999.json"),
+            serde_json::to_string(&PidFileV1 {
+                version: 1,
+                session_id: "session".to_string(),
+                backend_id: "codex".to_string(),
+                pid: 999_999,
+                pgid: 999_999,
+                owner_app_pid: Some(std::process::id()),
+                owner_start_time: None,
+                created_at_ms: 1,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let records = collect_process_records(tmp.path());
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].session_id.as_deref(), Some("session"));
+        assert_eq!(records[0].status, ProcessRecordStatus::Stale);
+    }
+
+    #[test]
+    fn legacy_pid_file_is_collected_by_recorded_pgid_liveness() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("pids");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("session.pid"), "999999").unwrap();
+
+        let records = collect_process_records(tmp.path());
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].session_id.as_deref(), Some("session"));
+        assert_eq!(records[0].status, ProcessRecordStatus::Stale);
+    }
+
+    fn write_workflow_run_metadata(
+        app_data_dir: &std::path::Path,
+        run_id: &str,
+        worktree_path: &std::path::Path,
+        status: &str,
+    ) -> std::io::Result<()> {
+        let runs_dir = app_data_dir.join("workflow_runs");
+        std::fs::create_dir_all(&runs_dir)?;
+        std::fs::write(
+            runs_dir.join(format!("{run_id}.json")),
+            serde_json::json!({
+                "runId": run_id,
+                "workflowName": "wf",
+                "status": status,
+                "worktreePath": worktree_path.to_string_lossy(),
+                "triggerSource": "desktop_ui",
+                "startedAt": 1.0,
+                "updatedAt": 1.0
+            })
+            .to_string(),
+        )
+    }
+}

--- a/src-tauri/src/adaptor/gateway/app_data_gc/mod.rs
+++ b/src-tauri/src/adaptor/gateway/app_data_gc/mod.rs
@@ -6,6 +6,7 @@ use crate::adaptor::gateway::agent_session::session_storage::{
     FileSessionStorage, SessionGcMetaRead,
 };
 use crate::adaptor::gateway::repository::repo_paths::SharedRepoPaths;
+use crate::adaptor::gateway::workflow::pending_command::PendingCommandStore;
 use crate::adaptor::gateway::workflow::{
     WorkflowRunArchiveFileRepository, WorkflowRunFileRepository,
 };
@@ -214,12 +215,14 @@ fn collect_session_blob_stores(app_data_dir: &Path) -> Vec<SessionBlobStore> {
 
 fn collect_workflow_run_gc_records(app_data_dir: &Path) -> Vec<WorkflowRunGcRecord> {
     let archived_at_by_run = manual_archive_times(app_data_dir);
+    let pending_paths_by_run = PendingCommandStore::new(app_data_dir).gc_delete_paths_by_run();
     let runs = WorkflowRunFileRepository::new(app_data_dir);
     runs.scan_gc_metadata()
         .runs
         .into_iter()
         .map(|run| WorkflowRunGcRecord {
-            delete_paths: runs.gc_delete_paths(&run.run_id),
+            delete_paths: runs
+                .gc_delete_paths_with_pending_index(&run.run_id, &pending_paths_by_run),
             manual_archived_at: archived_at_by_run.get(&run.run_id).copied(),
             is_terminal: run.status.is_terminal(),
             worktree_path: normalize_worktree_path_for_gc(&run.worktree_path),
@@ -250,6 +253,11 @@ fn collect_workspace_state_records(app_data_dir: &Path) -> Vec<WorkspaceStateGcR
         .flatten()
         .filter_map(|entry| {
             let path = entry.path();
+            if !path.is_file()
+                || path.extension().and_then(|extension| extension.to_str()) != Some("json")
+            {
+                return None;
+            }
             let key = path.file_stem().and_then(|stem| stem.to_str())?.to_string();
             Some(WorkspaceStateGcRecord { path, key })
         })
@@ -575,6 +583,7 @@ mod tests {
     use super::*;
     use crate::infrastructure::process::pid_registry::PidFileV1;
     use parking_lot::RwLock;
+    use std::collections::HashSet;
     use std::sync::Arc;
 
     #[test]
@@ -739,6 +748,103 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].session_id.as_deref(), Some("session"));
         assert_eq!(records[0].status, ProcessRecordStatus::Stale);
+    }
+
+    #[test]
+    fn collect_workspace_state_records_keeps_only_json_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("workspace_state");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("repo.json"), "{}").unwrap();
+        std::fs::write(dir.join("repo.tmp"), "{}").unwrap();
+        std::fs::create_dir_all(dir.join("nested.json")).unwrap();
+
+        let records = collect_workspace_state_records(tmp.path());
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].key, "repo");
+        assert_eq!(records[0].path, dir.join("repo.json"));
+    }
+
+    #[test]
+    fn collect_workflow_run_gc_records_uses_pending_index_for_all_pending_states() {
+        use crate::adaptor::gateway::workflow::pending_command::{
+            PendingCommand, PendingCommandPayload,
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let worktree = tempfile::tempdir().unwrap();
+        let run_id = "00000000-0000-4000-8000-000000000101";
+        let other_run_id = "00000000-0000-4000-8000-000000000102";
+        write_workflow_run_metadata(tmp.path(), run_id, worktree.path(), "completed").unwrap();
+        write_workflow_run_metadata(tmp.path(), other_run_id, worktree.path(), "completed")
+            .unwrap();
+        let store = PendingCommandStore::new(tmp.path());
+        let payload = PendingCommandPayload::Abort { node_name: None };
+        let pending = PendingCommand::new(run_id.to_string(), payload.clone(), 1.0);
+        let pending_path = store.write_pending(&pending).unwrap();
+        let processing = PendingCommand::new(run_id.to_string(), payload.clone(), 2.0);
+        store.write_pending(&processing).unwrap();
+        let processing_entry = store
+            .list_pending()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.command.id == processing.id)
+            .unwrap();
+        let processing_claim = store.claim_pending(&processing_entry).unwrap().unwrap();
+        let processing_path = processing_claim.entry.path.clone();
+        let processed = PendingCommand::new(other_run_id.to_string(), payload, 3.0);
+        store.write_pending(&processed).unwrap();
+        let processed_entry = store
+            .list_pending()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.command.id == processed.id)
+            .unwrap();
+        let processed_claim = store.claim_pending(&processed_entry).unwrap().unwrap();
+        let processed_file_name = processed_claim
+            .entry
+            .path
+            .file_name()
+            .unwrap()
+            .to_os_string();
+        store.mark_processed(&processed_claim.entry).unwrap();
+        let processed_path = tmp
+            .path()
+            .join("workflow_pending/processed")
+            .join(processed_file_name);
+        let pending_index = store.gc_delete_paths_by_run();
+        let runs = WorkflowRunFileRepository::new(tmp.path());
+        assert_eq!(
+            runs.gc_delete_paths_with_pending_index(run_id, &pending_index)
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            runs.gc_delete_paths(run_id)
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+        assert_eq!(
+            runs.gc_delete_paths_with_pending_index(other_run_id, &pending_index)
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            runs.gc_delete_paths(other_run_id)
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+
+        let records = collect_workflow_run_gc_records(tmp.path());
+
+        let record = records
+            .iter()
+            .find(|record| record.run_id == run_id)
+            .unwrap();
+        assert!(record.delete_paths.contains(&pending_path));
+        assert!(record.delete_paths.contains(&processing_path));
+        let other_record = records
+            .iter()
+            .find(|record| record.run_id == other_run_id)
+            .unwrap();
+        assert!(other_record.delete_paths.contains(&processed_path));
     }
 
     fn write_workflow_run_metadata(

--- a/src-tauri/src/adaptor/gateway/app_data_gc/std_file_system.rs
+++ b/src-tauri/src/adaptor/gateway/app_data_gc/std_file_system.rs
@@ -1,0 +1,84 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::adaptor::gateway::workflow::WorkflowRunArchiveFileRepository;
+use crate::usecase::app_data_gc::{
+    gc_file_system_error, GcFileSystem, GcFileSystemError, WorkflowArchivePruneResult,
+    WorkflowArchivePruner,
+};
+
+pub(crate) struct StdGcFileSystem;
+
+impl GcFileSystem for StdGcFileSystem {
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        std::fs::symlink_metadata(path)
+            .map(|metadata| metadata.file_type().is_file())
+            .unwrap_or(false)
+    }
+
+    fn read_dir(&self, path: &Path) -> Result<Vec<PathBuf>, GcFileSystemError> {
+        std::fs::read_dir(path)
+            .map_err(gc_file_system_error)?
+            .map(|entry| {
+                entry
+                    .map(|entry| entry.path())
+                    .map_err(gc_file_system_error)
+            })
+            .collect()
+    }
+
+    fn read_to_string(&self, path: &Path) -> Result<String, GcFileSystemError> {
+        std::fs::read_to_string(path).map_err(gc_file_system_error)
+    }
+
+    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error.to_string()),
+        };
+        if metadata.file_type().is_dir() {
+            std::fs::remove_dir_all(path).map_err(|error| error.to_string())?;
+        } else {
+            std::fs::remove_file(path).map_err(|error| error.to_string())?;
+        }
+        Ok(true)
+    }
+
+    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
+        let metadata = std::fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+        if metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+            return Ok(metadata.len());
+        }
+        if !metadata.file_type().is_dir() {
+            return Ok(0);
+        }
+        let mut size = 0;
+        for entry in self.read_dir(path).map_err(|error| error.to_string())? {
+            size += self.recursive_size(&entry)?;
+        }
+        Ok(size)
+    }
+}
+
+pub(crate) struct StdWorkflowArchivePruner;
+
+impl WorkflowArchivePruner for StdWorkflowArchivePruner {
+    fn prune_workflow_archive_records(
+        &self,
+        app_data_dir: &Path,
+        run_ids: &HashSet<String>,
+    ) -> Result<WorkflowArchivePruneResult, String> {
+        let result = WorkflowRunArchiveFileRepository::new(app_data_dir)
+            .prune_records(run_ids)
+            .map_err(|error| error.to_string())?;
+        Ok(WorkflowArchivePruneResult {
+            records_removed: result.records_removed,
+            reclaimed_bytes: result.reclaimed_bytes,
+        })
+    }
+}

--- a/src-tauri/src/adaptor/gateway/app_data_gc/std_file_system.rs
+++ b/src-tauri/src/adaptor/gateway/app_data_gc/std_file_system.rs
@@ -35,22 +35,22 @@ impl GcFileSystem for StdGcFileSystem {
         std::fs::read_to_string(path).map_err(gc_file_system_error)
     }
 
-    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+    fn remove_path(&self, path: &Path) -> Result<bool, GcFileSystemError> {
         let metadata = match std::fs::symlink_metadata(path) {
             Ok(metadata) => metadata,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-            Err(error) => return Err(error.to_string()),
+            Err(error) => return Err(gc_file_system_error(error)),
         };
         if metadata.file_type().is_dir() {
-            std::fs::remove_dir_all(path).map_err(|error| error.to_string())?;
+            std::fs::remove_dir_all(path).map_err(gc_file_system_error)?;
         } else {
-            std::fs::remove_file(path).map_err(|error| error.to_string())?;
+            std::fs::remove_file(path).map_err(gc_file_system_error)?;
         }
         Ok(true)
     }
 
-    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
-        let metadata = std::fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    fn recursive_size(&self, path: &Path) -> Result<u64, GcFileSystemError> {
+        let metadata = std::fs::symlink_metadata(path).map_err(gc_file_system_error)?;
         if metadata.file_type().is_file() || metadata.file_type().is_symlink() {
             return Ok(metadata.len());
         }
@@ -58,7 +58,7 @@ impl GcFileSystem for StdGcFileSystem {
             return Ok(0);
         }
         let mut size = 0;
-        for entry in self.read_dir(path).map_err(|error| error.to_string())? {
+        for entry in self.read_dir(path)? {
             size += self.recursive_size(&entry)?;
         }
         Ok(size)
@@ -72,10 +72,10 @@ impl WorkflowArchivePruner for StdWorkflowArchivePruner {
         &self,
         app_data_dir: &Path,
         run_ids: &HashSet<String>,
-    ) -> Result<WorkflowArchivePruneResult, String> {
+    ) -> Result<WorkflowArchivePruneResult, GcFileSystemError> {
         let result = WorkflowRunArchiveFileRepository::new(app_data_dir)
             .prune_records(run_ids)
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| GcFileSystemError::other(error.to_string()))?;
         Ok(WorkflowArchivePruneResult {
             records_removed: result.records_removed,
             reclaimed_bytes: result.reclaimed_bytes,

--- a/src-tauri/src/adaptor/gateway/comment/mod.rs
+++ b/src-tauri/src/adaptor/gateway/comment/mod.rs
@@ -404,7 +404,7 @@ pub(crate) fn state_dir(app_data_dir: &Path) -> PathBuf {
     app_data_dir.join("review-comments")
 }
 
-fn worktree_storage_key(worktree: &str) -> String {
+pub(crate) fn worktree_storage_key(worktree: &str) -> String {
     let trimmed = worktree.trim();
     let canonical = Path::new(trimmed)
         .canonicalize()

--- a/src-tauri/src/adaptor/gateway/mod.rs
+++ b/src-tauri/src/adaptor/gateway/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod agent_session;
 pub(crate) mod app_config;
+pub(crate) mod app_data_gc;
 pub(crate) mod code;
 pub(crate) mod comment;
 pub(crate) mod external_editor;

--- a/src-tauri/src/adaptor/gateway/workflow/archive_repository.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/archive_repository.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -35,6 +35,12 @@ struct WorkflowRunArchiveIndex {
 pub(crate) struct WorkflowRunArchiveFileRepository {
     data_dir: PathBuf,
     lock: Mutex<()>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct WorkflowRunArchivePruneResult {
+    pub(crate) records_removed: u64,
+    pub(crate) reclaimed_bytes: u64,
 }
 
 impl WorkflowRunArchiveFileRepository {
@@ -87,6 +93,48 @@ impl WorkflowRunArchiveFileRepository {
         let mut index = self.load_index_unlocked()?;
         update(&mut index);
         self.save_index_unlocked(&index)
+    }
+
+    pub(crate) fn prune_records(
+        &self,
+        run_ids: &HashSet<String>,
+    ) -> Result<WorkflowRunArchivePruneResult, WorkflowError> {
+        if run_ids.is_empty() {
+            return Ok(WorkflowRunArchivePruneResult::default());
+        }
+        let _guard = self
+            .lock
+            .lock()
+            .map_err(|_| WorkflowError::external("workflow run archive lock poisoned"))?;
+        let path = self.archive_index_path();
+        let before = match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_file() => metadata.len(),
+            Ok(_) => 0,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(error) => {
+                return Err(WorkflowError::external(format!(
+                    "Failed to read workflow run archives metadata: {error}"
+                )));
+            }
+        };
+        let mut index = self.load_index_unlocked()?;
+        let mut removed = 0;
+        for run_id in run_ids {
+            if index.runs.remove(run_id).is_some() {
+                removed += 1;
+            }
+        }
+        if removed == 0 {
+            return Ok(WorkflowRunArchivePruneResult::default());
+        }
+        self.save_index_unlocked(&index)?;
+        let after = fs::symlink_metadata(&path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        Ok(WorkflowRunArchivePruneResult {
+            records_removed: removed,
+            reclaimed_bytes: before.saturating_sub(after),
+        })
     }
 }
 
@@ -235,5 +283,25 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["22222222-2222-4222-8222-222222222222", "slow-run"]
         );
+    }
+
+    #[test]
+    fn prune_records_removes_selected_runs_with_atomic_index_update() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = WorkflowRunArchiveFileRepository::new(temp.path());
+        let keep_run_id = RunId::new("11111111-1111-4111-8111-111111111111".to_string()).unwrap();
+        let prune_run_id = RunId::new("22222222-2222-4222-8222-222222222222".to_string()).unwrap();
+        repo.archive_manual(&keep_run_id, 10.0).unwrap();
+        repo.archive_manual(&prune_run_id, 20.0).unwrap();
+
+        let result = repo
+            .prune_records(&HashSet::from([prune_run_id.to_string()]))
+            .unwrap();
+
+        assert_eq!(result.records_removed, 1);
+        assert!(result.reclaimed_bytes > 0);
+        let index = repo.load_index_unlocked().unwrap();
+        assert!(index.runs.contains_key(keep_run_id.as_str()));
+        assert!(!index.runs.contains_key(prune_run_id.as_str()));
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/log.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/log.rs
@@ -54,6 +54,13 @@ impl WorkflowEventLog {
         self.log_dir.join(format!("{run_id}.ndjson"))
     }
 
+    pub(crate) fn gc_delete_paths(&self, run_id: &str) -> Vec<PathBuf> {
+        vec![
+            self.log_path(run_id),
+            self.log_dir.join(format!("{run_id}.json")),
+        ]
+    }
+
     /// イベントをNDJSON形式でログファイルに追記する。
     ///
     /// [08] production の単発 append は `write_log_required` → `append_batch` 経路に

--- a/src-tauri/src/adaptor/gateway/workflow/pending_command.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/pending_command.rs
@@ -445,6 +445,32 @@ impl PendingCommandStore {
         }
         Ok(())
     }
+
+    pub(crate) fn gc_delete_paths_for_run(&self, run_id: &str) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        for dir in [&self.pending_dir, &self.processing_dir, &self.processed_dir] {
+            let Ok(entries) = fs::read_dir(dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !is_candidate_pending_file(&path) {
+                    continue;
+                }
+                match read_pending_file(&path) {
+                    Ok(command) if command.run_id == run_id => paths.push(path),
+                    Ok(_) => {}
+                    Err(error) => {
+                        log::warn!(
+                            "app data gc skipped unreadable pending workflow command {}: {error}",
+                            path.display()
+                        );
+                    }
+                }
+            }
+        }
+        paths
+    }
 }
 
 fn read_pending_file(path: &Path) -> io::Result<PendingCommand> {

--- a/src-tauri/src/adaptor/gateway/workflow/pending_command.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/pending_command.rs
@@ -13,6 +13,7 @@
 //! 担当しない: engine 内部 state mutation、runtime primitive 呼び出し、
 //! event 発行（これらは dispatcher adapter / engine 側）。
 
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
@@ -446,6 +447,7 @@ impl PendingCommandStore {
         Ok(())
     }
 
+    #[cfg(test)]
     pub(crate) fn gc_delete_paths_for_run(&self, run_id: &str) -> Vec<PathBuf> {
         let mut paths = Vec::new();
         for dir in [&self.pending_dir, &self.processing_dir, &self.processed_dir] {
@@ -470,6 +472,33 @@ impl PendingCommandStore {
             }
         }
         paths
+    }
+
+    pub(crate) fn gc_delete_paths_by_run(&self) -> HashMap<String, Vec<PathBuf>> {
+        let mut paths_by_run: HashMap<String, Vec<PathBuf>> = HashMap::new();
+        for dir in [&self.pending_dir, &self.processing_dir, &self.processed_dir] {
+            let Ok(entries) = fs::read_dir(dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !is_candidate_pending_file(&path) {
+                    continue;
+                }
+                match read_pending_file(&path) {
+                    Ok(command) => {
+                        paths_by_run.entry(command.run_id).or_default().push(path);
+                    }
+                    Err(error) => {
+                        log::warn!(
+                            "app data gc skipped unreadable pending workflow command {}: {error}",
+                            path.display()
+                        );
+                    }
+                }
+            }
+        }
+        paths_by_run
     }
 }
 

--- a/src-tauri/src/adaptor/gateway/workflow/run.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/run.rs
@@ -162,6 +162,10 @@ fn run_file_path(data_dir: &Path, run_id: &str) -> PathBuf {
     runs_dir(data_dir).join(format!("{run_id}.json"))
 }
 
+pub(crate) fn workflow_run_metadata_path(data_dir: &Path, run_id: &str) -> PathBuf {
+    run_file_path(data_dir, run_id)
+}
+
 /// `run_id` を UUID として検証する。Run Store のすべての lookup/read 経路で path traversal
 /// を防ぐ目的で利用する（Spec issues-1011: 信頼境界・run_id の形式検証）。
 fn is_valid_run_id(run_id: &str) -> bool {
@@ -285,20 +289,47 @@ pub(crate) fn sort_summaries_active_first(summaries: &mut [WorkflowRunSummary]) 
     });
 }
 
-pub(crate) fn iter_valid_run_metadata(data_dir: &Path) -> Vec<WorkflowRun> {
+#[derive(Debug, Clone)]
+pub(crate) struct WorkflowRunMetadataScan {
+    pub(crate) runs: Vec<WorkflowRun>,
+    pub(crate) is_complete: bool,
+}
+
+impl Default for WorkflowRunMetadataScan {
+    fn default() -> Self {
+        Self {
+            runs: Vec::new(),
+            is_complete: true,
+        }
+    }
+}
+
+pub(crate) fn scan_valid_run_metadata(data_dir: &Path) -> WorkflowRunMetadataScan {
     let runs_dir = runs_dir(data_dir);
     if !runs_dir.exists() {
-        return Vec::new();
+        return WorkflowRunMetadataScan::default();
     }
     let entries = match fs::read_dir(&runs_dir) {
         Ok(entries) => entries,
         Err(e) => {
             log::warn!("RunStore: failed to read runs dir: {e}");
-            return Vec::new();
+            return WorkflowRunMetadataScan {
+                runs: Vec::new(),
+                is_complete: false,
+            };
         }
     };
     let mut runs = Vec::new();
-    for entry in entries.flatten() {
+    let mut is_complete = true;
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                log::warn!("RunStore: failed to read run metadata entry: {e}");
+                is_complete = false;
+                continue;
+            }
+        };
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) != Some("json") {
             continue;
@@ -310,9 +341,30 @@ pub(crate) fn iter_valid_run_metadata(data_dir: &Path) -> Vec<WorkflowRun> {
                     "RunStore: skip corrupted run metadata at {}: {e}",
                     path.display()
                 );
+                is_complete = false;
             }
         }
     }
+    WorkflowRunMetadataScan { runs, is_complete }
+}
+
+pub(crate) fn read_valid_run_metadata(
+    data_dir: &Path,
+    run_id: &str,
+) -> Result<Option<WorkflowRun>, String> {
+    if !is_valid_run_id(run_id) {
+        return Err("invalid run_id".to_string());
+    }
+    let runs_dir = runs_dir(data_dir);
+    let path = run_file_path(data_dir, run_id);
+    if !path.exists() {
+        return Ok(None);
+    }
+    load_validated_metadata_entry(&runs_dir, &path).map(Some)
+}
+
+pub(crate) fn iter_valid_run_metadata(data_dir: &Path) -> Vec<WorkflowRun> {
+    let WorkflowRunMetadataScan { runs, .. } = scan_valid_run_metadata(data_dir);
     runs
 }
 

--- a/src-tauri/src/adaptor/gateway/workflow/run_repository.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/run_repository.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 #[cfg(test)]
 use std::fs::{self, OpenOptions};
 #[cfg(test)]
@@ -7,6 +8,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use crate::adaptor::gateway::workflow::log::WorkflowEventLog;
+#[cfg(test)]
 use crate::adaptor::gateway::workflow::pending_command::PendingCommandStore;
 use crate::adaptor::gateway::workflow::run as legacy_run;
 #[cfg(test)]
@@ -43,6 +45,7 @@ impl WorkflowRunFileRepository {
         legacy_run::read_valid_run_metadata(&self.data_dir, run_id)
     }
 
+    #[cfg(test)]
     pub(crate) fn gc_delete_paths(&self, run_id: &str) -> Vec<PathBuf> {
         let mut paths = vec![legacy_run::workflow_run_metadata_path(
             &self.data_dir,
@@ -51,6 +54,23 @@ impl WorkflowRunFileRepository {
         paths.extend(WorkflowEventLog::new(&self.data_dir).gc_delete_paths(run_id));
         paths.extend(legacy_workflow_artifact_paths(&self.data_dir, run_id));
         paths.extend(PendingCommandStore::new(&self.data_dir).gc_delete_paths_for_run(run_id));
+        paths
+    }
+
+    pub(crate) fn gc_delete_paths_with_pending_index(
+        &self,
+        run_id: &str,
+        pending_paths_by_run: &HashMap<String, Vec<PathBuf>>,
+    ) -> Vec<PathBuf> {
+        let mut paths = vec![legacy_run::workflow_run_metadata_path(
+            &self.data_dir,
+            run_id,
+        )];
+        paths.extend(WorkflowEventLog::new(&self.data_dir).gc_delete_paths(run_id));
+        paths.extend(legacy_workflow_artifact_paths(&self.data_dir, run_id));
+        if let Some(pending_paths) = pending_paths_by_run.get(run_id) {
+            paths.extend(pending_paths.iter().cloned());
+        }
         paths
     }
 

--- a/src-tauri/src/adaptor/gateway/workflow/run_repository.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/run_repository.rs
@@ -6,6 +6,8 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
+use crate::adaptor::gateway::workflow::log::WorkflowEventLog;
+use crate::adaptor::gateway::workflow::pending_command::PendingCommandStore;
 use crate::adaptor::gateway::workflow::run as legacy_run;
 #[cfg(test)]
 use crate::domain::workflow::WorkflowRunRecord;
@@ -28,6 +30,28 @@ impl WorkflowRunFileRepository {
         Self {
             data_dir: data_dir.into(),
         }
+    }
+
+    pub(crate) fn scan_gc_metadata(&self) -> legacy_run::WorkflowRunMetadataScan {
+        legacy_run::scan_valid_run_metadata(&self.data_dir)
+    }
+
+    pub(crate) fn read_gc_metadata(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<legacy_run::WorkflowRun>, String> {
+        legacy_run::read_valid_run_metadata(&self.data_dir, run_id)
+    }
+
+    pub(crate) fn gc_delete_paths(&self, run_id: &str) -> Vec<PathBuf> {
+        let mut paths = vec![legacy_run::workflow_run_metadata_path(
+            &self.data_dir,
+            run_id,
+        )];
+        paths.extend(WorkflowEventLog::new(&self.data_dir).gc_delete_paths(run_id));
+        paths.extend(legacy_workflow_artifact_paths(&self.data_dir, run_id));
+        paths.extend(PendingCommandStore::new(&self.data_dir).gc_delete_paths_for_run(run_id));
+        paths
     }
 
     #[cfg(test)]
@@ -54,6 +78,18 @@ impl WorkflowRunFileRepository {
             WorkflowError::external(format!("failed to write workflow run metadata: {e}"))
         })
     }
+}
+
+fn legacy_workflow_artifact_paths(data_dir: &std::path::Path, run_id: &str) -> Vec<PathBuf> {
+    let workflow_dir = data_dir.join("workflow");
+    [
+        workflow_dir.join(run_id),
+        workflow_dir.join(format!("{run_id}.json")),
+        workflow_dir.join(format!("{run_id}.ndjson")),
+    ]
+    .into_iter()
+    .filter(|path| path.exists())
+    .collect()
 }
 
 impl WorkflowRunRepository for WorkflowRunFileRepository {

--- a/src-tauri/src/adaptor/gateway/workspace_state/mod.rs
+++ b/src-tauri/src/adaptor/gateway/workspace_state/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod repository_impl;
 
+pub(crate) use repository_impl::storage_key;
 pub use repository_impl::WorkspaceStateStore;

--- a/src-tauri/src/adaptor/gateway/workspace_state/repository_impl.rs
+++ b/src-tauri/src/adaptor/gateway/workspace_state/repository_impl.rs
@@ -28,8 +28,12 @@ fn state_dir(app_data_dir: &Path) -> PathBuf {
     app_data_dir.join("workspace_state")
 }
 
+pub(crate) fn storage_key(worktree_name: &str) -> String {
+    worktree_name.replace(['/', '\\'], "_")
+}
+
 fn state_file(app_data_dir: &Path, worktree_name: &str) -> PathBuf {
-    let safe_name = worktree_name.replace(['/', '\\'], "_");
+    let safe_name = storage_key(worktree_name);
     state_dir(app_data_dir).join(format!("{safe_name}.json"))
 }
 

--- a/src-tauri/src/domain/app_data_gc/mod.rs
+++ b/src-tauri/src/domain/app_data_gc/mod.rs
@@ -1,0 +1,141 @@
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum GcCategory {
+    DeletedWorkspace,
+    UnrecoverableSession,
+    RecoverableExpired,
+    RegenerableCache,
+    LegacyComments,
+    OrphanBlob,
+    StaleProcessRecord,
+}
+
+impl GcCategory {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::DeletedWorkspace => "deleted_workspace",
+            Self::UnrecoverableSession => "unrecoverable_session",
+            Self::RecoverableExpired => "recoverable_expired",
+            Self::RegenerableCache => "regenerable_cache",
+            Self::LegacyComments => "legacy_comments",
+            Self::OrphanBlob => "orphan_blob",
+            Self::StaleProcessRecord => "stale_process_record",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RetentionPolicy {
+    pub(crate) archived_log_secs: u64,
+    pub(crate) cache_secs: u64,
+}
+
+impl Default for RetentionPolicy {
+    fn default() -> Self {
+        Self {
+            archived_log_secs: 30 * 24 * 60 * 60,
+            cache_secs: 7 * 24 * 60 * 60,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CategoryStat {
+    pub(crate) deleted: u64,
+    pub(crate) reclaimed_bytes: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct GcReport {
+    pub(crate) categories: BTreeMap<GcCategory, CategoryStat>,
+    pub(crate) total_files: u64,
+    pub(crate) total_bytes: u64,
+    pub(crate) errors: u64,
+}
+
+impl GcReport {
+    pub(crate) fn record_deleted(&mut self, category: GcCategory, reclaimed_bytes: u64) {
+        let stat = self.categories.entry(category).or_default();
+        stat.deleted += 1;
+        stat.reclaimed_bytes += reclaimed_bytes;
+        self.total_files += 1;
+        self.total_bytes += reclaimed_bytes;
+    }
+
+    pub(crate) fn record_error(&mut self) {
+        self.errors += 1;
+    }
+
+    pub(crate) fn log_summary(&self) -> String {
+        let categories = self
+            .categories
+            .iter()
+            .map(|(category, stat)| {
+                format!(
+                    "{}:deleted={},bytes={}",
+                    category.as_str(),
+                    stat.deleted,
+                    stat.reclaimed_bytes
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!(
+            "app data gc deleted={} reclaimed_bytes={} errors={} categories=[{}]",
+            self.total_files, self.total_bytes, self.errors, categories
+        )
+    }
+}
+
+pub(crate) fn is_expired(now_secs: f64, updated_at_secs: f64, threshold_secs: u64) -> bool {
+    if !now_secs.is_finite() || !updated_at_secs.is_finite() {
+        return false;
+    }
+    now_secs - updated_at_secs > threshold_secs as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_expired_uses_strict_boundary() {
+        assert!(!is_expired(130.0, 100.0, 30));
+        assert!(is_expired(130.001, 100.0, 30));
+    }
+
+    #[test]
+    fn report_tracks_category_and_total() {
+        let mut report = GcReport::default();
+        report.record_deleted(GcCategory::LegacyComments, 10);
+        report.record_deleted(GcCategory::LegacyComments, 5);
+        report.record_deleted(GcCategory::OrphanBlob, 7);
+        report.record_error();
+
+        assert_eq!(report.total_files, 3);
+        assert_eq!(report.total_bytes, 22);
+        assert_eq!(report.errors, 1);
+        assert_eq!(
+            report.categories[&GcCategory::LegacyComments],
+            CategoryStat {
+                deleted: 2,
+                reclaimed_bytes: 15
+            }
+        );
+    }
+
+    #[test]
+    fn log_summary_includes_deleted_count_and_reclaimed_bytes() {
+        let mut report = GcReport::default();
+        report.record_deleted(GcCategory::LegacyComments, 10);
+        report.record_deleted(GcCategory::OrphanBlob, 7);
+
+        let summary = report.log_summary();
+
+        assert_eq!(report.total_files, 2);
+        assert_eq!(report.total_bytes, 17);
+        assert!(summary.contains("deleted=2"));
+        assert!(summary.contains("reclaimed_bytes=17"));
+    }
+}

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod agent_session;
 pub(crate) mod app_config;
+pub(crate) mod app_data_gc;
 pub(crate) mod code;
 pub(crate) mod comment;
 pub(crate) mod external_editor;

--- a/src-tauri/src/infrastructure/process/pid_registry.rs
+++ b/src-tauri/src/infrastructure/process/pid_registry.rs
@@ -251,7 +251,7 @@ fn write_pid_file(path: &Path, file: &PidFileV1) -> Result<(), String> {
         .map_err(|error| format!("failed to rename pid file {}: {error}", path.display()))
 }
 
-fn read_pid_file(path: &Path) -> Result<PidFileV1, String> {
+pub(crate) fn read_pid_file(path: &Path) -> Result<PidFileV1, String> {
     let content = std::fs::read_to_string(path)
         .map_err(|error| format!("failed to read pid file: {error}"))?;
     let file: PidFileV1 =
@@ -288,6 +288,13 @@ enum OwnerStatus {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProcessStatus {
+    Live,
+    Stale,
+    Unknown,
+}
+
 fn owner_status(file: &PidFileV1) -> OwnerStatus {
     let (Some(owner_pid), Some(owner_start_time)) = (file.owner_app_pid, file.owner_start_time)
     else {
@@ -300,6 +307,44 @@ fn owner_status(file: &PidFileV1) -> OwnerStatus {
         Some(start_time) if start_time == owner_start_time => OwnerStatus::Live,
         Some(_) => OwnerStatus::Stale,
         None => OwnerStatus::Stale,
+    }
+}
+
+pub(crate) fn recorded_pid_status(file: &PidFileV1) -> ProcessStatus {
+    pid_status(file.pid)
+}
+
+pub(crate) fn pid_status(pid: u32) -> ProcessStatus {
+    if pid <= 1 {
+        return ProcessStatus::Unknown;
+    }
+    if process_start_time(pid).is_some() {
+        ProcessStatus::Live
+    } else {
+        ProcessStatus::Stale
+    }
+}
+
+pub(crate) fn process_group_status(pgid: i32) -> ProcessStatus {
+    if pgid <= 1 {
+        return ProcessStatus::Unknown;
+    }
+    #[cfg(unix)]
+    {
+        let result = unsafe { libc::kill(-pgid, 0) };
+        if result == 0 {
+            return ProcessStatus::Live;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => ProcessStatus::Stale,
+            Some(libc::EPERM) => ProcessStatus::Live,
+            _ => ProcessStatus::Unknown,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pgid;
+        ProcessStatus::Unknown
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,6 +133,10 @@ pub fn run() {
                     *shared_repo_paths.write() = paths;
                 }
             }
+            adaptor::controller::wiring::spawn_startup_app_data_gc(
+                data_dir.clone(),
+                shared_repo_paths.clone(),
+            );
 
             // repository ドメインの DI 配線（起動時に AppState を組み立てて manage）。
             // git ベースの usecase / query service はステートレス、repo_paths は

--- a/src-tauri/src/usecase/app_data_gc/mod.rs
+++ b/src-tauri/src/usecase/app_data_gc/mod.rs
@@ -1,0 +1,84 @@
+mod plan;
+mod ports;
+mod request;
+mod sweep;
+
+#[cfg(test)]
+mod test_fixtures;
+#[cfg(test)]
+mod tests;
+
+pub(crate) use ports::gc_file_system_error;
+pub(crate) use ports::{
+    CurrentSessionState, CurrentWorkflowRunState, GcFileSystem, GcFileSystemError,
+    GcRevalidationReader, RevalidationRead, WorkflowArchivePruner,
+};
+pub(crate) use request::{
+    CacheGcRecord, GcWorktreePath, LiveWorktree, LiveWorktreeResolution, LiveWorktreeSet,
+    ProcessRecord, ProcessRecordStatus, ReviewCommentGcRecord, RuntimeProtection, SessionBlobStore,
+    SessionGcRecord, StartupGcRequest, WorkflowArchivePruneResult, WorkflowRunGcRecord,
+    WorkspaceStateGcRecord,
+};
+
+use crate::domain::app_data_gc::GcReport;
+
+use plan::{
+    collect_cache_deletions, collect_legacy_comment_deletions, collect_orphan_blob_deletions,
+    collect_session_deletions, collect_stale_process_deletions, collect_workflow_deletions,
+    collect_workspace_keyed_deletions, DeletionPlan, SessionDeletionContext,
+};
+use sweep::sweep;
+
+pub(crate) fn run_startup_gc(
+    request: StartupGcRequest,
+    fs: &dyn GcFileSystem,
+    archive_pruner: &dyn WorkflowArchivePruner,
+    revalidation_reader: &dyn GcRevalidationReader,
+) -> GcReport {
+    let mut plan = DeletionPlan::new(request.app_data_dir.clone());
+
+    if let Some(live_worktree_resolution) = request.live_worktrees.as_ref() {
+        let session_context = SessionDeletionContext {
+            live_worktrees: live_worktree_resolution,
+            session_records: &request.session_records,
+            active_session_ids: &request.runtime_protection.active_session_ids,
+            running_worktrees: &request.runtime_protection.running_worktrees,
+            now_secs: request.now_secs,
+            retention: request.retention,
+        };
+        collect_session_deletions(&session_context, &mut plan);
+        collect_workflow_deletions(
+            &request.workflow_runs,
+            live_worktree_resolution,
+            request.now_secs,
+            request.retention,
+            &mut plan,
+        );
+        collect_workspace_keyed_deletions(
+            &request.workspace_state_records,
+            &request.review_comment_records,
+            &request.checkpoint_paths,
+            live_worktree_resolution,
+            &request.runtime_protection,
+            &mut plan,
+        );
+    } else {
+        log::info!(
+            "app data gc skipped workspace-dependent rules because live worktrees were unavailable"
+        );
+    }
+
+    collect_cache_deletions(
+        &request.cache_records,
+        request.now_secs,
+        request.retention,
+        &mut plan,
+    );
+    collect_legacy_comment_deletions(&request.legacy_comment_paths, &mut plan);
+    collect_orphan_blob_deletions(&request.session_blob_stores, fs, &mut plan);
+    collect_stale_process_deletions(&request.process_records, &mut plan);
+
+    let report = sweep(plan, fs, archive_pruner, revalidation_reader, &request);
+    log::info!("{}", report.log_summary());
+    report
+}

--- a/src-tauri/src/usecase/app_data_gc/plan.rs
+++ b/src-tauri/src/usecase/app_data_gc/plan.rs
@@ -1,0 +1,427 @@
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use crate::domain::app_data_gc::{is_expired, GcCategory, RetentionPolicy};
+use crate::usecase::agent_session::session::{ChatMessage, MessagePart, SessionState};
+
+use super::ports::GcFileSystem;
+use super::request::{
+    CacheGcRecord, LiveWorktreeResolution, LiveWorktreeSet, ProcessRecord, ProcessRecordStatus,
+    ReviewCommentGcRecord, RuntimeProtection, SessionBlobStore, SessionGcRecord,
+    WorkflowRunGcRecord, WorkspaceStateGcRecord,
+};
+
+pub(super) struct SessionDeletionContext<'a> {
+    pub(super) live_worktrees: &'a LiveWorktreeResolution,
+    pub(super) session_records: &'a [SessionGcRecord],
+    pub(super) active_session_ids: &'a HashSet<String>,
+    pub(super) running_worktrees: &'a HashSet<String>,
+    pub(super) now_secs: f64,
+    pub(super) retention: RetentionPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum DeletionRevalidation {
+    None,
+    Session { session_id: String },
+    WorkflowRun { run_id: String },
+    WorkspaceState { key: String },
+    ReviewComment { key: String },
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct DeletionCandidate {
+    pub(super) path: PathBuf,
+    pub(super) category: GcCategory,
+    pub(super) workflow_run_id: Option<String>,
+    pub(super) revalidation: DeletionRevalidation,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct DeletionPlan {
+    pub(super) app_data_dir: PathBuf,
+    pub(super) candidates: Vec<DeletionCandidate>,
+    paths: HashSet<PathBuf>,
+    pub(super) workflow_archive_records: BTreeMap<GcCategory, HashSet<String>>,
+}
+
+impl DeletionPlan {
+    pub(super) fn new(app_data_dir: PathBuf) -> Self {
+        Self {
+            app_data_dir,
+            candidates: Vec::new(),
+            paths: HashSet::new(),
+            workflow_archive_records: BTreeMap::new(),
+        }
+    }
+
+    fn add(&mut self, path: PathBuf, category: GcCategory) {
+        self.add_with_revalidation(path, category, DeletionRevalidation::None);
+    }
+
+    fn add_with_revalidation(
+        &mut self,
+        path: PathBuf,
+        category: GcCategory,
+        revalidation: DeletionRevalidation,
+    ) {
+        if self.paths.insert(path.clone()) {
+            self.candidates.push(DeletionCandidate {
+                path,
+                category,
+                workflow_run_id: None,
+                revalidation,
+            });
+        }
+    }
+
+    fn add_workflow_path(&mut self, path: PathBuf, category: GcCategory, run_id: &str) {
+        if self.paths.insert(path.clone()) {
+            self.candidates.push(DeletionCandidate {
+                path,
+                category,
+                workflow_run_id: Some(run_id.to_string()),
+                revalidation: DeletionRevalidation::WorkflowRun {
+                    run_id: run_id.to_string(),
+                },
+            });
+        }
+    }
+
+    fn add_workflow_archive_record(&mut self, run_id: String, category: GcCategory) {
+        self.workflow_archive_records
+            .entry(category)
+            .or_default()
+            .insert(run_id);
+    }
+}
+
+pub(super) fn collect_session_deletions(
+    context: &SessionDeletionContext<'_>,
+    plan: &mut DeletionPlan,
+) {
+    for record in context.session_records {
+        if context.active_session_ids.contains(&record.id) {
+            continue;
+        }
+        let Some(worktree_path) = record.worktree_path.as_ref() else {
+            add_session_delete(plan, record, GcCategory::UnrecoverableSession);
+            continue;
+        };
+        if worktree_path.is_unresolved() {
+            continue;
+        }
+        if context.running_worktrees.contains(worktree_path.key()) {
+            continue;
+        }
+        if !context.live_worktrees.contains_worktree_path(worktree_path) {
+            if context
+                .live_worktrees
+                .worktree_path_may_be_unresolved(worktree_path)
+            {
+                continue;
+            }
+            add_session_delete(plan, record, GcCategory::DeletedWorkspace);
+            continue;
+        }
+        if session_is_recoverable_expired(record.state.as_ref(), record.updated_at, context) {
+            add_session_delete(plan, record, GcCategory::RecoverableExpired);
+        }
+    }
+}
+
+fn session_is_recoverable_expired(
+    state: Option<&SessionState>,
+    updated_at: Option<f64>,
+    context: &SessionDeletionContext<'_>,
+) -> bool {
+    matches!(state, Some(SessionState::Archived | SessionState::Closed))
+        && updated_at.is_some_and(|updated_at| {
+            is_expired(
+                context.now_secs,
+                updated_at,
+                context.retention.archived_log_secs,
+            )
+        })
+}
+
+fn add_session_delete(plan: &mut DeletionPlan, record: &SessionGcRecord, category: GcCategory) {
+    for path in &record.delete_paths {
+        plan.add_with_revalidation(
+            path.clone(),
+            category,
+            DeletionRevalidation::Session {
+                session_id: record.id.clone(),
+            },
+        );
+    }
+}
+
+pub(super) fn collect_workflow_deletions(
+    workflow_runs: &[WorkflowRunGcRecord],
+    live_worktrees: &LiveWorktreeResolution,
+    now_secs: f64,
+    retention: RetentionPolicy,
+    plan: &mut DeletionPlan,
+) {
+    for run in workflow_runs {
+        if !run.is_terminal || run.worktree_path.is_unresolved() {
+            continue;
+        }
+        if !live_worktrees.contains_worktree_path(&run.worktree_path) {
+            if live_worktrees.worktree_path_may_be_unresolved(&run.worktree_path) {
+                continue;
+            }
+            add_workflow_run_delete(run, GcCategory::DeletedWorkspace, plan);
+            continue;
+        }
+        if run.manual_archived_at.is_some_and(|archived_at| {
+            is_expired(now_secs, archived_at, retention.archived_log_secs)
+        }) {
+            add_workflow_run_delete(run, GcCategory::RecoverableExpired, plan);
+        }
+    }
+}
+
+fn add_workflow_run_delete(
+    run: &WorkflowRunGcRecord,
+    category: GcCategory,
+    plan: &mut DeletionPlan,
+) {
+    for path in &run.delete_paths {
+        plan.add_workflow_path(path.clone(), category, &run.run_id);
+    }
+    plan.add_workflow_archive_record(run.run_id.clone(), category);
+}
+
+pub(super) fn collect_workspace_keyed_deletions(
+    workspace_state_records: &[WorkspaceStateGcRecord],
+    review_comment_records: &[ReviewCommentGcRecord],
+    checkpoint_paths: &[PathBuf],
+    live_worktrees: &LiveWorktreeResolution,
+    runtime_protection: &RuntimeProtection,
+    plan: &mut DeletionPlan,
+) {
+    if !runtime_protection.workspace_keyed_protection_complete {
+        log::info!(
+            "app data gc skipped workspace-keyed cleanup because runtime protection metadata was incomplete"
+        );
+        return;
+    }
+    let protected_worktrees = &runtime_protection.protected_worktrees;
+    collect_workspace_state_deletions(
+        workspace_state_records,
+        live_worktrees,
+        protected_worktrees,
+        plan,
+    );
+    collect_review_comment_deletions(
+        review_comment_records,
+        live_worktrees,
+        protected_worktrees,
+        plan,
+    );
+    skip_checkpoint_deletions(checkpoint_paths);
+}
+
+fn collect_workspace_state_deletions(
+    records: &[WorkspaceStateGcRecord],
+    live_worktrees: &LiveWorktreeResolution,
+    protected_worktrees: &LiveWorktreeSet,
+    plan: &mut DeletionPlan,
+) {
+    if live_worktrees.has_unresolved_repos() {
+        log::info!(
+            "app data gc skipped workspace-state cleanup because some repo worktrees were unavailable"
+        );
+        return;
+    }
+    for record in records {
+        if !live_worktrees.contains_workspace_state_key(&record.key)
+            && !protected_worktrees.contains_workspace_state_key(&record.key)
+            && !live_worktrees.workspace_state_key_may_be_unresolved(&record.key)
+        {
+            plan.add_with_revalidation(
+                record.path.clone(),
+                GcCategory::DeletedWorkspace,
+                DeletionRevalidation::WorkspaceState {
+                    key: record.key.clone(),
+                },
+            );
+        }
+    }
+}
+
+fn collect_review_comment_deletions(
+    records: &[ReviewCommentGcRecord],
+    live_worktrees: &LiveWorktreeResolution,
+    protected_worktrees: &LiveWorktreeSet,
+    plan: &mut DeletionPlan,
+) {
+    if live_worktrees.has_unresolved_repos() {
+        log::info!(
+            "app data gc skipped review-comment workspace cleanup because some repo worktrees were unavailable"
+        );
+        return;
+    }
+    for record in records {
+        if !live_worktrees.contains_review_comment_key(&record.key)
+            && !protected_worktrees.contains_review_comment_key(&record.key)
+        {
+            plan.add_with_revalidation(
+                record.path.clone(),
+                GcCategory::DeletedWorkspace,
+                DeletionRevalidation::ReviewComment {
+                    key: record.key.clone(),
+                },
+            );
+        }
+    }
+}
+
+fn skip_checkpoint_deletions(checkpoint_paths: &[PathBuf]) {
+    for path in checkpoint_paths {
+        log::info!(
+            "app data gc skipped checkpoint cleanup for {} because checkpoint worktree mapping is not verified",
+            path.display()
+        );
+    }
+}
+
+pub(super) fn collect_cache_deletions(
+    cache_records: &[CacheGcRecord],
+    now_secs: f64,
+    retention: RetentionPolicy,
+    plan: &mut DeletionPlan,
+) {
+    for record in cache_records {
+        if is_expired(now_secs, record.updated_at, retention.cache_secs) {
+            plan.add(record.path.clone(), GcCategory::RegenerableCache);
+        }
+    }
+}
+
+pub(super) fn collect_legacy_comment_deletions(
+    legacy_comment_paths: &[PathBuf],
+    plan: &mut DeletionPlan,
+) {
+    for path in legacy_comment_paths {
+        plan.add(path.clone(), GcCategory::LegacyComments);
+    }
+}
+
+pub(super) fn collect_orphan_blob_deletions(
+    session_blob_stores: &[SessionBlobStore],
+    fs: &dyn GcFileSystem,
+    plan: &mut DeletionPlan,
+) {
+    for store in session_blob_stores {
+        let Some((tool_output_refs, attachment_refs)) =
+            read_message_blob_refs(&store.messages_dir, fs)
+        else {
+            continue;
+        };
+        collect_unreferenced_files(&store.tool_outputs_dir, &tool_output_refs, fs, plan);
+        collect_unreferenced_files(&store.attachments_dir, &attachment_refs, fs, plan);
+    }
+}
+
+fn collect_unreferenced_files(
+    dir: &Path,
+    referenced: &HashSet<String>,
+    fs: &dyn GcFileSystem,
+    plan: &mut DeletionPlan,
+) {
+    let Ok(entries) = fs.read_dir(dir) else {
+        return;
+    };
+    for path in entries {
+        if !fs.is_file(&path) {
+            continue;
+        }
+        let Some(id) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !referenced.contains(id) {
+            plan.add(path, GcCategory::OrphanBlob);
+        }
+    }
+}
+
+pub(super) fn collect_stale_process_deletions(
+    process_records: &[ProcessRecord],
+    plan: &mut DeletionPlan,
+) {
+    for record in process_records {
+        if record.status == ProcessRecordStatus::Stale {
+            plan.add(record.path.clone(), GcCategory::StaleProcessRecord);
+        }
+    }
+}
+
+fn read_message_blob_refs(
+    messages_dir: &Path,
+    fs: &dyn GcFileSystem,
+) -> Option<(HashSet<String>, HashSet<String>)> {
+    let mut tool_outputs = HashSet::new();
+    let mut attachments = HashSet::new();
+    let entries = match fs.read_dir(messages_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.is_not_found() => return Some((tool_outputs, attachments)),
+        Err(error) => {
+            log::warn!(
+                "app data gc skipped orphan blob cleanup for unreadable messages dir {}: {error}",
+                messages_dir.display()
+            );
+            return None;
+        }
+    };
+    for path in entries {
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let content = match fs.read_to_string(&path) {
+            Ok(content) => content,
+            Err(error) => {
+                log::warn!(
+                    "app data gc skipped orphan blob cleanup for unreadable message {}: {error}",
+                    path.display()
+                );
+                return None;
+            }
+        };
+        let message: ChatMessage = match serde_json::from_str(&content) {
+            Ok(message) => message,
+            Err(error) => {
+                log::warn!(
+                    "app data gc skipped orphan blob cleanup for invalid message {}: {error}",
+                    path.display()
+                );
+                return None;
+            }
+        };
+        collect_blob_refs_from_message(&message, &mut tool_outputs, &mut attachments);
+    }
+    Some((tool_outputs, attachments))
+}
+
+fn collect_blob_refs_from_message(
+    message: &ChatMessage,
+    tool_outputs: &mut HashSet<String>,
+    attachments: &mut HashSet<String>,
+) {
+    for part in message.parts.as_deref().unwrap_or_default() {
+        match part {
+            MessagePart::ToolResult {
+                content_ref: Some(content_ref),
+                ..
+            } => {
+                tool_outputs.insert(content_ref.id.clone());
+            }
+            MessagePart::ImageRef { attachment } => {
+                attachments.insert(attachment.id.clone());
+            }
+            _ => {}
+        }
+    }
+}

--- a/src-tauri/src/usecase/app_data_gc/ports.rs
+++ b/src-tauri/src/usecase/app_data_gc/ports.rs
@@ -12,8 +12,8 @@ pub(crate) trait GcFileSystem {
     fn is_file(&self, path: &Path) -> bool;
     fn read_dir(&self, path: &Path) -> Result<Vec<PathBuf>, GcFileSystemError>;
     fn read_to_string(&self, path: &Path) -> Result<String, GcFileSystemError>;
-    fn remove_path(&self, path: &Path) -> Result<bool, String>;
-    fn recursive_size(&self, path: &Path) -> Result<u64, String>;
+    fn remove_path(&self, path: &Path) -> Result<bool, GcFileSystemError>;
+    fn recursive_size(&self, path: &Path) -> Result<u64, GcFileSystemError>;
 }
 
 pub(crate) trait WorkflowArchivePruner {
@@ -21,7 +21,7 @@ pub(crate) trait WorkflowArchivePruner {
         &self,
         app_data_dir: &Path,
         run_ids: &std::collections::HashSet<String>,
-    ) -> Result<WorkflowArchivePruneResult, String>;
+    ) -> Result<WorkflowArchivePruneResult, GcFileSystemError>;
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src-tauri/src/usecase/app_data_gc/ports.rs
+++ b/src-tauri/src/usecase/app_data_gc/ports.rs
@@ -1,0 +1,118 @@
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::request::{
+    GcWorktreePath, ProcessRecord, RuntimeProtection, WorkflowArchivePruneResult,
+};
+use crate::usecase::agent_session::session::SessionState;
+
+pub(crate) trait GcFileSystem {
+    fn exists(&self, path: &Path) -> bool;
+    fn is_file(&self, path: &Path) -> bool;
+    fn read_dir(&self, path: &Path) -> Result<Vec<PathBuf>, GcFileSystemError>;
+    fn read_to_string(&self, path: &Path) -> Result<String, GcFileSystemError>;
+    fn remove_path(&self, path: &Path) -> Result<bool, String>;
+    fn recursive_size(&self, path: &Path) -> Result<u64, String>;
+}
+
+pub(crate) trait WorkflowArchivePruner {
+    fn prune_workflow_archive_records(
+        &self,
+        app_data_dir: &Path,
+        run_ids: &std::collections::HashSet<String>,
+    ) -> Result<WorkflowArchivePruneResult, String>;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CurrentSessionState {
+    pub(crate) worktree_path: Option<GcWorktreePath>,
+    pub(crate) state: Option<SessionState>,
+    pub(crate) updated_at: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CurrentWorkflowRunState {
+    pub(crate) worktree_path: GcWorktreePath,
+    pub(crate) is_terminal: bool,
+    pub(crate) manual_archived_at: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum RevalidationRead<T> {
+    Present(T),
+    Missing,
+    Unavailable(String),
+}
+
+pub(crate) trait GcRevalidationReader {
+    fn runtime_protection(
+        &self,
+        app_data_dir: &Path,
+        process_records: &[ProcessRecord],
+    ) -> RuntimeProtection;
+
+    fn session_state(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+    ) -> RevalidationRead<CurrentSessionState>;
+
+    fn workflow_run_state(
+        &self,
+        app_data_dir: &Path,
+        run_id: &str,
+    ) -> RevalidationRead<CurrentWorkflowRunState>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GcFileSystemErrorKind {
+    NotFound,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GcFileSystemError {
+    kind: GcFileSystemErrorKind,
+    message: String,
+}
+
+impl GcFileSystemError {
+    pub(crate) fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            kind: GcFileSystemErrorKind::NotFound,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn other(message: impl Into<String>) -> Self {
+        Self {
+            kind: GcFileSystemErrorKind::Other,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn is_not_found(&self) -> bool {
+        self.kind == GcFileSystemErrorKind::NotFound
+    }
+}
+
+impl fmt::Display for GcFileSystemError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.message.fmt(formatter)
+    }
+}
+
+impl From<io::Error> for GcFileSystemError {
+    fn from(error: io::Error) -> Self {
+        gc_file_system_error(error)
+    }
+}
+
+pub(crate) fn gc_file_system_error(error: io::Error) -> GcFileSystemError {
+    if error.kind() == io::ErrorKind::NotFound {
+        GcFileSystemError::not_found(error.to_string())
+    } else {
+        GcFileSystemError::other(error.to_string())
+    }
+}

--- a/src-tauri/src/usecase/app_data_gc/request.rs
+++ b/src-tauri/src/usecase/app_data_gc/request.rs
@@ -1,0 +1,272 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use crate::domain::app_data_gc::RetentionPolicy;
+use crate::usecase::agent_session::session::SessionState;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LiveWorktree {
+    pub(crate) path: String,
+    pub(crate) workspace_state_keys: Vec<String>,
+    pub(crate) review_comment_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct LiveWorktreeSet {
+    paths: HashSet<String>,
+    workspace_state_keys: HashSet<String>,
+    review_comment_keys: HashSet<String>,
+}
+
+impl LiveWorktreeSet {
+    pub(crate) fn from_worktrees(worktrees: impl IntoIterator<Item = LiveWorktree>) -> Self {
+        let mut set = Self::default();
+        for worktree in worktrees {
+            set.paths.insert(worktree_path_key(&worktree.path));
+            set.workspace_state_keys
+                .extend(worktree.workspace_state_keys);
+            set.review_comment_keys.extend(worktree.review_comment_keys);
+        }
+        set
+    }
+
+    pub(super) fn contains_worktree_path(&self, worktree_path: &str) -> bool {
+        self.paths.contains(&worktree_path_key(worktree_path))
+    }
+
+    pub(super) fn contains_workspace_state_key(&self, key: &str) -> bool {
+        self.workspace_state_keys.contains(key)
+    }
+
+    pub(super) fn contains_review_comment_key(&self, key: &str) -> bool {
+        self.review_comment_keys.contains(key)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GcWorktreePath {
+    Resolved(String),
+    NotFound(String),
+    Unresolved(String),
+}
+
+impl GcWorktreePath {
+    pub(crate) fn resolved(path: impl Into<String>) -> Self {
+        Self::Resolved(worktree_path_key(&path.into()))
+    }
+
+    pub(crate) fn not_found(path: impl Into<String>) -> Self {
+        Self::NotFound(worktree_path_key(&path.into()))
+    }
+
+    pub(crate) fn unresolved(path: impl Into<String>) -> Self {
+        Self::Unresolved(worktree_path_key(&path.into()))
+    }
+
+    pub(crate) fn key(&self) -> &str {
+        match self {
+            Self::Resolved(path) | Self::NotFound(path) | Self::Unresolved(path) => path,
+        }
+    }
+
+    pub(crate) fn is_unresolved(&self) -> bool {
+        matches!(self, Self::Unresolved(_))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LiveWorktreeResolution {
+    live_worktrees: LiveWorktreeSet,
+    unresolved_repo_paths: Vec<String>,
+    unresolved_workspace_state_key_prefixes: HashSet<String>,
+}
+
+impl LiveWorktreeResolution {
+    pub(crate) fn new(
+        live_worktrees: LiveWorktreeSet,
+        unresolved_repo_paths: Vec<String>,
+        unresolved_workspace_state_key_prefixes: HashSet<String>,
+    ) -> Self {
+        let mut normalized_unresolved_repo_paths = Vec::new();
+        for path in unresolved_repo_paths {
+            normalized_unresolved_repo_paths.push(worktree_path_key(&path));
+        }
+        Self {
+            live_worktrees,
+            unresolved_repo_paths: normalized_unresolved_repo_paths,
+            unresolved_workspace_state_key_prefixes,
+        }
+    }
+
+    pub(super) fn contains_worktree_path(&self, worktree_path: &GcWorktreePath) -> bool {
+        if worktree_path.is_unresolved() {
+            return false;
+        }
+        self.live_worktrees
+            .contains_worktree_path(worktree_path.key())
+    }
+
+    pub(super) fn contains_workspace_state_key(&self, key: &str) -> bool {
+        self.live_worktrees.contains_workspace_state_key(key)
+    }
+
+    pub(super) fn contains_review_comment_key(&self, key: &str) -> bool {
+        self.live_worktrees.contains_review_comment_key(key)
+    }
+
+    pub(super) fn worktree_path_may_be_unresolved(&self, worktree_path: &GcWorktreePath) -> bool {
+        let normalized = worktree_path.key();
+        self.unresolved_repo_paths
+            .iter()
+            .any(|repo_path| normalized.starts_with(repo_path))
+    }
+
+    pub(super) fn workspace_state_key_may_be_unresolved(&self, key: &str) -> bool {
+        self.unresolved_workspace_state_key_prefixes
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+    }
+
+    pub(super) fn has_unresolved_repos(&self) -> bool {
+        !self.unresolved_repo_paths.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeProtection {
+    pub(crate) active_session_ids: HashSet<String>,
+    pub(crate) running_worktrees: HashSet<String>,
+    pub(crate) protected_worktrees: LiveWorktreeSet,
+    pub(crate) workspace_keyed_protection_complete: bool,
+}
+
+impl Default for RuntimeProtection {
+    fn default() -> Self {
+        Self {
+            active_session_ids: HashSet::new(),
+            running_worktrees: HashSet::new(),
+            protected_worktrees: LiveWorktreeSet::default(),
+            workspace_keyed_protection_complete: true,
+        }
+    }
+}
+
+impl RuntimeProtection {
+    pub(crate) fn new(
+        active_session_ids: HashSet<String>,
+        running_worktrees: impl IntoIterator<Item = String>,
+        protected_worktrees: LiveWorktreeSet,
+    ) -> Self {
+        Self {
+            active_session_ids,
+            running_worktrees: running_worktrees
+                .into_iter()
+                .map(|path| worktree_path_key(&path))
+                .collect(),
+            protected_worktrees,
+            workspace_keyed_protection_complete: true,
+        }
+    }
+
+    pub(crate) fn with_workspace_keyed_protection_complete(mut self, complete: bool) -> Self {
+        self.workspace_keyed_protection_complete = complete;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SessionGcRecord {
+    pub(crate) id: String,
+    pub(crate) delete_paths: Vec<PathBuf>,
+    pub(crate) dir_path: Option<PathBuf>,
+    pub(crate) worktree_path: Option<GcWorktreePath>,
+    pub(crate) state: Option<SessionState>,
+    pub(crate) updated_at: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionBlobStore {
+    pub(crate) session_dir: PathBuf,
+    pub(crate) messages_dir: PathBuf,
+    pub(crate) tool_outputs_dir: PathBuf,
+    pub(crate) attachments_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct WorkflowRunGcRecord {
+    pub(crate) run_id: String,
+    pub(crate) worktree_path: GcWorktreePath,
+    pub(crate) is_terminal: bool,
+    pub(crate) manual_archived_at: Option<f64>,
+    pub(crate) delete_paths: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceStateGcRecord {
+    pub(crate) path: PathBuf,
+    pub(crate) key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReviewCommentGcRecord {
+    pub(crate) path: PathBuf,
+    pub(crate) key: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CacheGcRecord {
+    pub(crate) path: PathBuf,
+    pub(crate) updated_at: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProcessRecordStatus {
+    Live,
+    Stale,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProcessRecord {
+    pub(crate) path: PathBuf,
+    pub(crate) session_id: Option<String>,
+    pub(crate) status: ProcessRecordStatus,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct WorkflowArchivePruneResult {
+    pub(crate) records_removed: u64,
+    pub(crate) reclaimed_bytes: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StartupGcRequest {
+    pub(crate) app_data_dir: PathBuf,
+    /// None means the live worktree set could not be resolved reliably. In that
+    /// mode, workspace-dependent whole-log deletion is skipped for safety.
+    pub(crate) live_worktrees: Option<LiveWorktreeResolution>,
+    pub(crate) session_records: Vec<SessionGcRecord>,
+    pub(crate) workflow_runs: Vec<WorkflowRunGcRecord>,
+    pub(crate) workspace_state_records: Vec<WorkspaceStateGcRecord>,
+    pub(crate) review_comment_records: Vec<ReviewCommentGcRecord>,
+    pub(crate) checkpoint_paths: Vec<PathBuf>,
+    pub(crate) cache_records: Vec<CacheGcRecord>,
+    pub(crate) legacy_comment_paths: Vec<PathBuf>,
+    pub(crate) session_blob_stores: Vec<SessionBlobStore>,
+    pub(crate) process_records: Vec<ProcessRecord>,
+    pub(crate) runtime_protection: RuntimeProtection,
+    pub(crate) now_secs: f64,
+    pub(crate) retention: RetentionPolicy,
+}
+
+pub(super) fn worktree_path_key(path: &str) -> String {
+    trim_path_separators(path.trim())
+}
+
+fn trim_path_separators(path: &str) -> String {
+    let mut value = path.to_string();
+    while value.len() > 1 && (value.ends_with('/') || value.ends_with('\\')) {
+        value.pop();
+    }
+    value
+}

--- a/src-tauri/src/usecase/app_data_gc/request.rs
+++ b/src-tauri/src/usecase/app_data_gc/request.rs
@@ -118,13 +118,13 @@ impl LiveWorktreeResolution {
         let normalized = worktree_path.key();
         self.unresolved_repo_paths
             .iter()
-            .any(|repo_path| normalized.starts_with(repo_path))
+            .any(|repo_path| prefix_matches_at_boundary(normalized, repo_path, &['/', '\\']))
     }
 
     pub(super) fn workspace_state_key_may_be_unresolved(&self, key: &str) -> bool {
         self.unresolved_workspace_state_key_prefixes
             .iter()
-            .any(|prefix| key.starts_with(prefix))
+            .any(|prefix| prefix_matches_at_boundary(key, prefix, &['_']))
     }
 
     pub(super) fn has_unresolved_repos(&self) -> bool {
@@ -263,10 +263,58 @@ pub(super) fn worktree_path_key(path: &str) -> String {
     trim_path_separators(path.trim())
 }
 
+fn prefix_matches_at_boundary(value: &str, prefix: &str, boundary_chars: &[char]) -> bool {
+    if value == prefix {
+        return true;
+    }
+    if prefix.is_empty() {
+        return false;
+    }
+    value
+        .strip_prefix(prefix)
+        .and_then(|suffix| suffix.chars().next())
+        .is_some_and(|ch| boundary_chars.contains(&ch))
+}
+
 fn trim_path_separators(path: &str) -> String {
     let mut value = path.to_string();
     while value.len() > 1 && (value.ends_with('/') || value.ends_with('\\')) {
         value.pop();
     }
     value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn unresolved_worktree_path_matching_requires_path_boundary() {
+        let resolution = LiveWorktreeResolution::new(
+            LiveWorktreeSet::default(),
+            vec!["/repo".to_string()],
+            HashSet::new(),
+        );
+
+        assert!(resolution.worktree_path_may_be_unresolved(&GcWorktreePath::not_found("/repo")));
+        assert!(resolution
+            .worktree_path_may_be_unresolved(&GcWorktreePath::not_found("/repo/worktree")));
+        assert!(resolution
+            .worktree_path_may_be_unresolved(&GcWorktreePath::not_found("/repo\\worktree")));
+        assert!(!resolution.worktree_path_may_be_unresolved(&GcWorktreePath::not_found("/repo2")));
+    }
+
+    #[test]
+    fn unresolved_workspace_state_key_matching_requires_key_boundary() {
+        let resolution = LiveWorktreeResolution::new(
+            LiveWorktreeSet::default(),
+            Vec::new(),
+            HashSet::from(["_repo".to_string()]),
+        );
+
+        assert!(resolution.workspace_state_key_may_be_unresolved("_repo"));
+        assert!(resolution.workspace_state_key_may_be_unresolved("_repo_worktree"));
+        assert!(!resolution.workspace_state_key_may_be_unresolved("_repo2"));
+    }
 }

--- a/src-tauri/src/usecase/app_data_gc/sweep.rs
+++ b/src-tauri/src/usecase/app_data_gc/sweep.rs
@@ -1,0 +1,307 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Component, Path};
+
+use crate::domain::app_data_gc::{is_expired, GcCategory, GcReport};
+use crate::usecase::agent_session::session::SessionState;
+
+use super::plan::{DeletionCandidate, DeletionPlan, DeletionRevalidation};
+use super::ports::{
+    CurrentSessionState, CurrentWorkflowRunState, GcFileSystem, GcRevalidationReader,
+    RevalidationRead, WorkflowArchivePruner,
+};
+use super::request::{LiveWorktreeResolution, RuntimeProtection, StartupGcRequest};
+
+pub(super) fn sweep(
+    plan: DeletionPlan,
+    fs: &dyn GcFileSystem,
+    archive_pruner: &dyn WorkflowArchivePruner,
+    revalidation_reader: &dyn GcRevalidationReader,
+    request: &StartupGcRequest,
+) -> GcReport {
+    let mut report = GcReport::default();
+    let mut failed_workflow_run_deletions: BTreeMap<GcCategory, HashSet<String>> = BTreeMap::new();
+    let mut workflow_revalidation = HashMap::new();
+    for candidate in plan.candidates {
+        if !candidate_is_contained(&plan.app_data_dir, &candidate.path) {
+            mark_workflow_candidate_failed(&candidate, &mut failed_workflow_run_deletions);
+            log::info!(
+                "app data gc skipped {} because deletion candidate is outside app data dir",
+                candidate.path.display()
+            );
+            continue;
+        }
+        if !candidate_still_valid(
+            &candidate,
+            request,
+            revalidation_reader,
+            &mut workflow_revalidation,
+        ) {
+            mark_workflow_candidate_failed(&candidate, &mut failed_workflow_run_deletions);
+            log::info!(
+                "app data gc skipped {} because deletion candidate is no longer eligible",
+                candidate.path.display()
+            );
+            continue;
+        }
+        let reclaimed_bytes = if fs.exists(&candidate.path) {
+            match fs.recursive_size(&candidate.path) {
+                Ok(size) => size,
+                Err(error) => {
+                    log::warn!(
+                        "app data gc could not measure {}: {error}",
+                        candidate.path.display()
+                    );
+                    0
+                }
+            }
+        } else {
+            0
+        };
+        match fs.remove_path(&candidate.path) {
+            Ok(true) => report.record_deleted(candidate.category, reclaimed_bytes),
+            Ok(false) => {}
+            Err(error) => {
+                report.record_error();
+                mark_workflow_candidate_failed(&candidate, &mut failed_workflow_run_deletions);
+                log::warn!(
+                    "app data gc failed to remove {}: {error}",
+                    candidate.path.display()
+                );
+            }
+        }
+    }
+    for (category, run_ids) in plan.workflow_archive_records {
+        let failed_run_ids = failed_workflow_run_deletions
+            .get(&category)
+            .cloned()
+            .unwrap_or_default();
+        let prune_run_ids = run_ids
+            .difference(&failed_run_ids)
+            .cloned()
+            .collect::<HashSet<_>>();
+        if prune_run_ids.is_empty() {
+            continue;
+        }
+        match archive_pruner.prune_workflow_archive_records(&plan.app_data_dir, &prune_run_ids) {
+            Ok(result) => {
+                for _ in 0..result.records_removed {
+                    report.record_deleted(category, 0);
+                }
+                if result.reclaimed_bytes > 0 {
+                    if let Some(stat) = report.categories.get_mut(&category) {
+                        stat.reclaimed_bytes += result.reclaimed_bytes;
+                    }
+                    report.total_bytes += result.reclaimed_bytes;
+                }
+            }
+            Err(error) => {
+                report.record_error();
+                log::warn!("app data gc failed to prune workflow archive records: {error}");
+            }
+        }
+    }
+    report
+}
+
+fn candidate_is_contained(app_data_dir: &Path, path: &Path) -> bool {
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir
+        )
+    }) && path.is_relative()
+    {
+        return false;
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return false;
+    }
+    path.starts_with(app_data_dir)
+}
+
+fn mark_workflow_candidate_failed(
+    candidate: &DeletionCandidate,
+    failed_workflow_run_deletions: &mut BTreeMap<GcCategory, HashSet<String>>,
+) {
+    if let Some(run_id) = candidate.workflow_run_id.as_ref() {
+        failed_workflow_run_deletions
+            .entry(candidate.category)
+            .or_default()
+            .insert(run_id.clone());
+    }
+}
+
+fn candidate_still_valid(
+    candidate: &DeletionCandidate,
+    request: &StartupGcRequest,
+    reader: &dyn GcRevalidationReader,
+    workflow_revalidation: &mut HashMap<String, RevalidationRead<CurrentWorkflowRunState>>,
+) -> bool {
+    match &candidate.revalidation {
+        DeletionRevalidation::None => true,
+        DeletionRevalidation::Session { session_id } => {
+            let runtime =
+                reader.runtime_protection(&request.app_data_dir, &request.process_records);
+            session_candidate_still_valid(candidate.category, session_id, request, &runtime, reader)
+        }
+        DeletionRevalidation::WorkflowRun { run_id } => {
+            let runtime =
+                reader.runtime_protection(&request.app_data_dir, &request.process_records);
+            let state = workflow_revalidation
+                .entry(run_id.clone())
+                .or_insert_with(|| reader.workflow_run_state(&request.app_data_dir, run_id));
+            workflow_candidate_still_valid(candidate.category, run_id, request, &runtime, state)
+        }
+        DeletionRevalidation::WorkspaceState { key } => {
+            let runtime =
+                reader.runtime_protection(&request.app_data_dir, &request.process_records);
+            workspace_state_candidate_still_valid(key, request.live_worktrees.as_ref(), &runtime)
+        }
+        DeletionRevalidation::ReviewComment { key } => {
+            let runtime =
+                reader.runtime_protection(&request.app_data_dir, &request.process_records);
+            review_comment_candidate_still_valid(key, request.live_worktrees.as_ref(), &runtime)
+        }
+    }
+}
+
+fn session_candidate_still_valid(
+    category: GcCategory,
+    session_id: &str,
+    request: &StartupGcRequest,
+    runtime: &RuntimeProtection,
+    reader: &dyn GcRevalidationReader,
+) -> bool {
+    if runtime.active_session_ids.contains(session_id) {
+        return false;
+    }
+    let Some(live_worktrees) = request.live_worktrees.as_ref() else {
+        return false;
+    };
+    match reader.session_state(&request.app_data_dir, session_id) {
+        RevalidationRead::Present(state) => {
+            session_state_matches_category(category, &state, live_worktrees, runtime, request)
+        }
+        RevalidationRead::Missing => false,
+        RevalidationRead::Unavailable(error) => {
+            log::warn!("app data gc skipped session {session_id} during revalidation: {error}");
+            false
+        }
+    }
+}
+
+fn session_state_matches_category(
+    category: GcCategory,
+    state: &CurrentSessionState,
+    live_worktrees: &LiveWorktreeResolution,
+    runtime: &RuntimeProtection,
+    request: &StartupGcRequest,
+) -> bool {
+    let Some(worktree_path) = state.worktree_path.as_ref() else {
+        return category == GcCategory::UnrecoverableSession;
+    };
+    if worktree_path.is_unresolved() || runtime.running_worktrees.contains(worktree_path.key()) {
+        return false;
+    }
+    if !live_worktrees.contains_worktree_path(worktree_path) {
+        return !live_worktrees.worktree_path_may_be_unresolved(worktree_path)
+            && category == GcCategory::DeletedWorkspace;
+    }
+    category == GcCategory::RecoverableExpired
+        && matches!(
+            state.state.as_ref(),
+            Some(SessionState::Archived | SessionState::Closed)
+        )
+        && state.updated_at.is_some_and(|updated_at| {
+            is_expired(
+                request.now_secs,
+                updated_at,
+                request.retention.archived_log_secs,
+            )
+        })
+}
+
+fn workflow_candidate_still_valid(
+    category: GcCategory,
+    run_id: &str,
+    request: &StartupGcRequest,
+    runtime: &RuntimeProtection,
+    state: &RevalidationRead<CurrentWorkflowRunState>,
+) -> bool {
+    let Some(live_worktrees) = request.live_worktrees.as_ref() else {
+        return false;
+    };
+    match state {
+        RevalidationRead::Present(state) => {
+            workflow_state_matches_category(category, state, live_worktrees, runtime, request)
+        }
+        RevalidationRead::Missing => false,
+        RevalidationRead::Unavailable(error) => {
+            log::warn!("app data gc skipped workflow run {run_id} during revalidation: {error}");
+            false
+        }
+    }
+}
+
+fn workflow_state_matches_category(
+    category: GcCategory,
+    state: &CurrentWorkflowRunState,
+    live_worktrees: &LiveWorktreeResolution,
+    runtime: &RuntimeProtection,
+    request: &StartupGcRequest,
+) -> bool {
+    if !state.is_terminal
+        || state.worktree_path.is_unresolved()
+        || runtime
+            .running_worktrees
+            .contains(state.worktree_path.key())
+    {
+        return false;
+    }
+    if !live_worktrees.contains_worktree_path(&state.worktree_path) {
+        return !live_worktrees.worktree_path_may_be_unresolved(&state.worktree_path)
+            && category == GcCategory::DeletedWorkspace;
+    }
+    category == GcCategory::RecoverableExpired
+        && state.manual_archived_at.is_some_and(|archived_at| {
+            is_expired(
+                request.now_secs,
+                archived_at,
+                request.retention.archived_log_secs,
+            )
+        })
+}
+
+fn workspace_state_candidate_still_valid(
+    key: &str,
+    live_worktrees: Option<&LiveWorktreeResolution>,
+    runtime: &RuntimeProtection,
+) -> bool {
+    let Some(live_worktrees) = live_worktrees else {
+        return false;
+    };
+    runtime.workspace_keyed_protection_complete
+        && !live_worktrees.has_unresolved_repos()
+        && !live_worktrees.contains_workspace_state_key(key)
+        && !runtime
+            .protected_worktrees
+            .contains_workspace_state_key(key)
+        && !live_worktrees.workspace_state_key_may_be_unresolved(key)
+}
+
+fn review_comment_candidate_still_valid(
+    key: &str,
+    live_worktrees: Option<&LiveWorktreeResolution>,
+    runtime: &RuntimeProtection,
+) -> bool {
+    let Some(live_worktrees) = live_worktrees else {
+        return false;
+    };
+    runtime.workspace_keyed_protection_complete
+        && !live_worktrees.has_unresolved_repos()
+        && !live_worktrees.contains_review_comment_key(key)
+        && !runtime.protected_worktrees.contains_review_comment_key(key)
+}

--- a/src-tauri/src/usecase/app_data_gc/sweep.rs
+++ b/src-tauri/src/usecase/app_data_gc/sweep.rs
@@ -21,6 +21,8 @@ pub(super) fn sweep(
     let mut report = GcReport::default();
     let mut failed_workflow_run_deletions: BTreeMap<GcCategory, HashSet<String>> = BTreeMap::new();
     let mut workflow_revalidation = HashMap::new();
+    let runtime_protection =
+        revalidation_reader.runtime_protection(&request.app_data_dir, &request.process_records);
     for candidate in plan.candidates {
         if !candidate_is_contained(&plan.app_data_dir, &candidate.path) {
             mark_workflow_candidate_failed(&candidate, &mut failed_workflow_run_deletions);
@@ -34,6 +36,7 @@ pub(super) fn sweep(
             &candidate,
             request,
             revalidation_reader,
+            &runtime_protection,
             &mut workflow_revalidation,
         ) {
             mark_workflow_candidate_failed(&candidate, &mut failed_workflow_run_deletions);
@@ -138,32 +141,25 @@ fn candidate_still_valid(
     candidate: &DeletionCandidate,
     request: &StartupGcRequest,
     reader: &dyn GcRevalidationReader,
+    runtime: &RuntimeProtection,
     workflow_revalidation: &mut HashMap<String, RevalidationRead<CurrentWorkflowRunState>>,
 ) -> bool {
     match &candidate.revalidation {
         DeletionRevalidation::None => true,
         DeletionRevalidation::Session { session_id } => {
-            let runtime =
-                reader.runtime_protection(&request.app_data_dir, &request.process_records);
-            session_candidate_still_valid(candidate.category, session_id, request, &runtime, reader)
+            session_candidate_still_valid(candidate.category, session_id, request, runtime, reader)
         }
         DeletionRevalidation::WorkflowRun { run_id } => {
-            let runtime =
-                reader.runtime_protection(&request.app_data_dir, &request.process_records);
             let state = workflow_revalidation
                 .entry(run_id.clone())
                 .or_insert_with(|| reader.workflow_run_state(&request.app_data_dir, run_id));
-            workflow_candidate_still_valid(candidate.category, run_id, request, &runtime, state)
+            workflow_candidate_still_valid(candidate.category, run_id, request, runtime, state)
         }
         DeletionRevalidation::WorkspaceState { key } => {
-            let runtime =
-                reader.runtime_protection(&request.app_data_dir, &request.process_records);
-            workspace_state_candidate_still_valid(key, request.live_worktrees.as_ref(), &runtime)
+            workspace_state_candidate_still_valid(key, request.live_worktrees.as_ref(), runtime)
         }
         DeletionRevalidation::ReviewComment { key } => {
-            let runtime =
-                reader.runtime_protection(&request.app_data_dir, &request.process_records);
-            review_comment_candidate_still_valid(key, request.live_worktrees.as_ref(), &runtime)
+            review_comment_candidate_still_valid(key, request.live_worktrees.as_ref(), runtime)
         }
     }
 }

--- a/src-tauri/src/usecase/app_data_gc/test_fixtures.rs
+++ b/src-tauri/src/usecase/app_data_gc/test_fixtures.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-use crate::adaptor::gateway::workflow::run::RunStatus;
 use crate::domain::app_data_gc::{GcReport, RetentionPolicy};
 use crate::domain::workflow::WORKFLOW_ARCHIVE_REASON_MANUAL;
 use crate::usecase::agent_session::session::{ChatMessage, MessagePart, MessageRole, SessionState};
@@ -38,24 +37,24 @@ impl GcFileSystem for TestFs {
         fs::read_to_string(path).map_err(gc_file_system_error)
     }
 
-    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+    fn remove_path(&self, path: &Path) -> Result<bool, GcFileSystemError> {
         if !path.exists() {
             return Ok(false);
         }
         if path.is_dir() {
-            fs::remove_dir_all(path).map_err(|error| error.to_string())?;
+            fs::remove_dir_all(path).map_err(gc_file_system_error)?;
         } else {
-            fs::remove_file(path).map_err(|error| error.to_string())?;
+            fs::remove_file(path).map_err(gc_file_system_error)?;
         }
         Ok(true)
     }
 
-    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
+    fn recursive_size(&self, path: &Path) -> Result<u64, GcFileSystemError> {
         if path.is_file() {
-            return Ok(path.metadata().map_err(|error| error.to_string())?.len());
+            return Ok(path.metadata().map_err(gc_file_system_error)?.len());
         }
         let mut size = 0;
-        for entry in self.read_dir(path).map_err(|error| error.to_string())? {
+        for entry in self.read_dir(path)? {
             size += self.recursive_size(&entry)?;
         }
         Ok(size)
@@ -69,15 +68,15 @@ impl WorkflowArchivePruner for TestArchivePruner {
         &self,
         app_data_dir: &Path,
         run_ids: &HashSet<String>,
-    ) -> Result<WorkflowArchivePruneResult, String> {
+    ) -> Result<WorkflowArchivePruneResult, GcFileSystemError> {
         let path = app_data_dir.join("workflow_run_archives.json");
         if !path.exists() {
             return Ok(WorkflowArchivePruneResult::default());
         }
-        let before = path.metadata().map_err(|error| error.to_string())?.len();
-        let content = fs::read_to_string(&path).map_err(|error| error.to_string())?;
-        let mut value: serde_json::Value =
-            serde_json::from_str(&content).map_err(|error| error.to_string())?;
+        let before = path.metadata().map_err(gc_file_system_error)?.len();
+        let content = fs::read_to_string(&path).map_err(gc_file_system_error)?;
+        let mut value: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|error| GcFileSystemError::other(error.to_string()))?;
         let Some(runs) = value.get_mut("runs").and_then(|runs| runs.as_object_mut()) else {
             return Ok(WorkflowArchivePruneResult::default());
         };
@@ -90,9 +89,10 @@ impl WorkflowArchivePruner for TestArchivePruner {
         if removed == 0 {
             return Ok(WorkflowArchivePruneResult::default());
         }
-        let json = serde_json::to_string(&value).map_err(|error| error.to_string())?;
-        fs::write(&path, json).map_err(|error| error.to_string())?;
-        let after = path.metadata().map_err(|error| error.to_string())?.len();
+        let json = serde_json::to_string(&value)
+            .map_err(|error| GcFileSystemError::other(error.to_string()))?;
+        fs::write(&path, json).map_err(gc_file_system_error)?;
+        let after = path.metadata().map_err(gc_file_system_error)?.len();
         Ok(WorkflowArchivePruneResult {
             records_removed: removed,
             reclaimed_bytes: before.saturating_sub(after),
@@ -124,11 +124,11 @@ impl GcFileSystem for FailingReadDirFs {
         TestFs.read_to_string(path)
     }
 
-    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+    fn remove_path(&self, path: &Path) -> Result<bool, GcFileSystemError> {
         TestFs.remove_path(path)
     }
 
-    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
+    fn recursive_size(&self, path: &Path) -> Result<u64, GcFileSystemError> {
         TestFs.recursive_size(path)
     }
 }
@@ -157,11 +157,11 @@ impl GcFileSystem for FailingReadFileFs {
         TestFs.read_to_string(path)
     }
 
-    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+    fn remove_path(&self, path: &Path) -> Result<bool, GcFileSystemError> {
         TestFs.remove_path(path)
     }
 
-    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
+    fn recursive_size(&self, path: &Path) -> Result<u64, GcFileSystemError> {
         TestFs.recursive_size(path)
     }
 }
@@ -187,14 +187,14 @@ impl GcFileSystem for FailingRemoveFs {
         TestFs.read_to_string(path)
     }
 
-    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+    fn remove_path(&self, path: &Path) -> Result<bool, GcFileSystemError> {
         if path == self.failing_path {
-            return Err("permission denied".to_string());
+            return Err(GcFileSystemError::other("permission denied"));
         }
         TestFs.remove_path(path)
     }
 
-    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
+    fn recursive_size(&self, path: &Path) -> Result<u64, GcFileSystemError> {
         TestFs.recursive_size(path)
     }
 }
@@ -463,8 +463,27 @@ fn collect_test_workflow_runs(app_data_dir: &Path) -> Vec<WorkflowRunGcRecord> {
 #[serde(rename_all = "camelCase")]
 struct TestWorkflowRunMeta {
     run_id: String,
-    status: RunStatus,
+    status: TestWorkflowRunStatus,
     worktree_path: String,
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TestWorkflowRunStatus {
+    Running,
+    WaitingApproval,
+    Completed,
+    Failed,
+    Aborted,
+}
+
+impl TestWorkflowRunStatus {
+    fn is_terminal(self) -> bool {
+        match self {
+            Self::Completed | Self::Failed | Self::Aborted => true,
+            Self::Running | Self::WaitingApproval => false,
+        }
+    }
 }
 
 fn test_manual_archive_times(app_data_dir: &Path) -> HashMap<String, f64> {
@@ -552,6 +571,11 @@ fn collect_test_workspace_state_records(app_data_dir: &Path) -> Vec<WorkspaceSta
         .flatten()
         .filter_map(|entry| {
             let path = entry.path();
+            if !path.is_file()
+                || path.extension().and_then(|extension| extension.to_str()) != Some("json")
+            {
+                return None;
+            }
             let key = path.file_stem().and_then(|stem| stem.to_str())?.to_string();
             Some(WorkspaceStateGcRecord { path, key })
         })

--- a/src-tauri/src/usecase/app_data_gc/test_fixtures.rs
+++ b/src-tauri/src/usecase/app_data_gc/test_fixtures.rs
@@ -1,0 +1,908 @@
+use super::*;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use crate::adaptor::gateway::workflow::run::RunStatus;
+use crate::domain::app_data_gc::{GcReport, RetentionPolicy};
+use crate::domain::workflow::WORKFLOW_ARCHIVE_REASON_MANUAL;
+use crate::usecase::agent_session::session::{ChatMessage, MessagePart, MessageRole, SessionState};
+use sha2::{Digest, Sha256};
+
+pub(super) const NOW: f64 = 10_000_000.0;
+
+pub(super) struct TestFs;
+
+impl GcFileSystem for TestFs {
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        path.is_file()
+    }
+
+    fn read_dir(&self, path: &Path) -> Result<Vec<PathBuf>, GcFileSystemError> {
+        fs::read_dir(path)
+            .map_err(gc_file_system_error)?
+            .map(|entry| {
+                entry
+                    .map(|entry| entry.path())
+                    .map_err(gc_file_system_error)
+            })
+            .collect()
+    }
+
+    fn read_to_string(&self, path: &Path) -> Result<String, GcFileSystemError> {
+        fs::read_to_string(path).map_err(gc_file_system_error)
+    }
+
+    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+        if !path.exists() {
+            return Ok(false);
+        }
+        if path.is_dir() {
+            fs::remove_dir_all(path).map_err(|error| error.to_string())?;
+        } else {
+            fs::remove_file(path).map_err(|error| error.to_string())?;
+        }
+        Ok(true)
+    }
+
+    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
+        if path.is_file() {
+            return Ok(path.metadata().map_err(|error| error.to_string())?.len());
+        }
+        let mut size = 0;
+        for entry in self.read_dir(path).map_err(|error| error.to_string())? {
+            size += self.recursive_size(&entry)?;
+        }
+        Ok(size)
+    }
+}
+
+pub(super) struct TestArchivePruner;
+
+impl WorkflowArchivePruner for TestArchivePruner {
+    fn prune_workflow_archive_records(
+        &self,
+        app_data_dir: &Path,
+        run_ids: &HashSet<String>,
+    ) -> Result<WorkflowArchivePruneResult, String> {
+        let path = app_data_dir.join("workflow_run_archives.json");
+        if !path.exists() {
+            return Ok(WorkflowArchivePruneResult::default());
+        }
+        let before = path.metadata().map_err(|error| error.to_string())?.len();
+        let content = fs::read_to_string(&path).map_err(|error| error.to_string())?;
+        let mut value: serde_json::Value =
+            serde_json::from_str(&content).map_err(|error| error.to_string())?;
+        let Some(runs) = value.get_mut("runs").and_then(|runs| runs.as_object_mut()) else {
+            return Ok(WorkflowArchivePruneResult::default());
+        };
+        let mut removed = 0;
+        for run_id in run_ids {
+            if runs.remove(run_id).is_some() {
+                removed += 1;
+            }
+        }
+        if removed == 0 {
+            return Ok(WorkflowArchivePruneResult::default());
+        }
+        let json = serde_json::to_string(&value).map_err(|error| error.to_string())?;
+        fs::write(&path, json).map_err(|error| error.to_string())?;
+        let after = path.metadata().map_err(|error| error.to_string())?.len();
+        Ok(WorkflowArchivePruneResult {
+            records_removed: removed,
+            reclaimed_bytes: before.saturating_sub(after),
+        })
+    }
+}
+
+pub(super) struct FailingReadDirFs {
+    pub(super) failing_dir: PathBuf,
+}
+
+impl GcFileSystem for FailingReadDirFs {
+    fn exists(&self, path: &Path) -> bool {
+        TestFs.exists(path)
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        TestFs.is_file(path)
+    }
+
+    fn read_dir(&self, path: &Path) -> Result<Vec<PathBuf>, GcFileSystemError> {
+        if path == self.failing_dir {
+            return Err(GcFileSystemError::other("permission denied"));
+        }
+        TestFs.read_dir(path)
+    }
+
+    fn read_to_string(&self, path: &Path) -> Result<String, GcFileSystemError> {
+        TestFs.read_to_string(path)
+    }
+
+    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+        TestFs.remove_path(path)
+    }
+
+    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
+        TestFs.recursive_size(path)
+    }
+}
+
+pub(super) struct FailingReadFileFs {
+    pub(super) failing_file: PathBuf,
+}
+
+impl GcFileSystem for FailingReadFileFs {
+    fn exists(&self, path: &Path) -> bool {
+        TestFs.exists(path)
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        TestFs.is_file(path)
+    }
+
+    fn read_dir(&self, path: &Path) -> Result<Vec<PathBuf>, GcFileSystemError> {
+        TestFs.read_dir(path)
+    }
+
+    fn read_to_string(&self, path: &Path) -> Result<String, GcFileSystemError> {
+        if path == self.failing_file {
+            return Err(GcFileSystemError::other("permission denied"));
+        }
+        TestFs.read_to_string(path)
+    }
+
+    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+        TestFs.remove_path(path)
+    }
+
+    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
+        TestFs.recursive_size(path)
+    }
+}
+
+pub(super) struct FailingRemoveFs {
+    pub(super) failing_path: PathBuf,
+}
+
+impl GcFileSystem for FailingRemoveFs {
+    fn exists(&self, path: &Path) -> bool {
+        TestFs.exists(path)
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        TestFs.is_file(path)
+    }
+
+    fn read_dir(&self, path: &Path) -> Result<Vec<PathBuf>, GcFileSystemError> {
+        TestFs.read_dir(path)
+    }
+
+    fn read_to_string(&self, path: &Path) -> Result<String, GcFileSystemError> {
+        TestFs.read_to_string(path)
+    }
+
+    fn remove_path(&self, path: &Path) -> Result<bool, String> {
+        if path == self.failing_path {
+            return Err("permission denied".to_string());
+        }
+        TestFs.remove_path(path)
+    }
+
+    fn recursive_size(&self, path: &Path) -> Result<u64, String> {
+        TestFs.recursive_size(path)
+    }
+}
+
+pub(super) fn modified_secs(path: &Path) -> Result<f64, String> {
+    path.metadata()
+        .map_err(|error| error.to_string())?
+        .modified()
+        .map_err(|error| error.to_string())?
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs_f64())
+        .map_err(|error| error.to_string())
+}
+
+pub(super) fn set_mtime(path: &Path, secs: f64) {
+    let time = filetime::FileTime::from_unix_time(secs as i64, 0);
+    filetime::set_file_mtime(path, time).unwrap();
+}
+
+pub(super) fn run_gc(
+    app_data_dir: &Path,
+    live_worktrees: Option<LiveWorktreeSet>,
+    process_records: Vec<ProcessRecord>,
+    now_secs: f64,
+) -> GcReport {
+    run_startup_gc(
+        startup_gc_request(
+            app_data_dir,
+            live_worktrees.map(full_resolution),
+            RuntimeProtection::default(),
+            process_records,
+            now_secs,
+        ),
+        &TestFs,
+        &TestArchivePruner,
+        &TestRevalidationReader,
+    )
+}
+
+pub(super) fn run_gc_with_runtime_protection(
+    app_data_dir: &Path,
+    live_worktrees: Option<LiveWorktreeSet>,
+    runtime_protection: RuntimeProtection,
+    process_records: Vec<ProcessRecord>,
+    now_secs: f64,
+) -> GcReport {
+    run_startup_gc(
+        startup_gc_request(
+            app_data_dir,
+            live_worktrees.map(full_resolution),
+            runtime_protection,
+            process_records,
+            now_secs,
+        ),
+        &TestFs,
+        &TestArchivePruner,
+        &TestRevalidationReader,
+    )
+}
+
+pub(super) fn run_gc_with_resolution(
+    app_data_dir: &Path,
+    live_worktrees: Option<LiveWorktreeResolution>,
+    runtime_protection: RuntimeProtection,
+    now_secs: f64,
+) -> GcReport {
+    run_startup_gc(
+        startup_gc_request(
+            app_data_dir,
+            live_worktrees,
+            runtime_protection,
+            Vec::new(),
+            now_secs,
+        ),
+        &TestFs,
+        &TestArchivePruner,
+        &TestRevalidationReader,
+    )
+}
+
+pub(super) fn startup_gc_request(
+    app_data_dir: &Path,
+    live_worktrees: Option<LiveWorktreeResolution>,
+    runtime_protection: RuntimeProtection,
+    process_records: Vec<ProcessRecord>,
+    now_secs: f64,
+) -> StartupGcRequest {
+    StartupGcRequest {
+        app_data_dir: app_data_dir.to_path_buf(),
+        live_worktrees,
+        session_records: collect_test_session_records(app_data_dir),
+        workflow_runs: collect_test_workflow_runs(app_data_dir),
+        workspace_state_records: collect_test_workspace_state_records(app_data_dir),
+        review_comment_records: collect_test_review_comment_records(app_data_dir),
+        checkpoint_paths: collect_test_checkpoint_paths(app_data_dir),
+        cache_records: collect_test_cache_records(app_data_dir),
+        legacy_comment_paths: collect_test_legacy_comment_paths(app_data_dir),
+        session_blob_stores: collect_test_session_blob_stores(app_data_dir),
+        process_records,
+        runtime_protection,
+        now_secs,
+        retention: RetentionPolicy::default(),
+    }
+}
+
+fn collect_test_session_records(app_data_dir: &Path) -> Vec<SessionGcRecord> {
+    let sessions_dir = app_data_dir.join("sessions");
+    let Ok(entries) = fs::read_dir(&sessions_dir) else {
+        return Vec::new();
+    };
+    let mut records = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let Some(id) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let Some(meta) = parse_test_session_meta(&path.join("meta.json"), id) else {
+                continue;
+            };
+            records.push(SessionGcRecord {
+                id: meta.id.unwrap_or_else(|| id.to_string()),
+                delete_paths: vec![path.clone()],
+                dir_path: Some(path),
+                worktree_path: meta.worktree_path,
+                state: meta.state,
+                updated_at: meta.updated_at,
+            });
+            continue;
+        }
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        if stem.ends_with(".meta") {
+            continue;
+        }
+        let id = stem.to_string();
+        let sidecar = sessions_dir.join(format!("{id}.meta.json"));
+        let Some(meta) = (if sidecar.exists() {
+            parse_test_session_meta(&sidecar, &id)
+        } else {
+            parse_test_session_meta(&path, &id)
+        }) else {
+            continue;
+        };
+        let mut delete_paths = vec![path];
+        if sidecar.exists() {
+            delete_paths.push(sidecar);
+        }
+        records.push(SessionGcRecord {
+            id: meta.id.unwrap_or(id),
+            delete_paths,
+            dir_path: None,
+            worktree_path: meta.worktree_path,
+            state: meta.state,
+            updated_at: meta.updated_at,
+        });
+    }
+    records
+}
+
+#[derive(Default)]
+struct TestSessionMeta {
+    id: Option<String>,
+    worktree_path: Option<GcWorktreePath>,
+    state: Option<SessionState>,
+    updated_at: Option<f64>,
+}
+
+fn parse_test_session_meta(path: &Path, fallback_id: &str) -> Option<TestSessionMeta> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Some(TestSessionMeta {
+                id: Some(fallback_id.to_string()),
+                ..TestSessionMeta::default()
+            });
+        }
+        Err(error) => {
+            log::warn!(
+                "app data gc skipped session {} because meta {} could not be read: {error}",
+                fallback_id,
+                path.display()
+            );
+            return None;
+        }
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return Some(TestSessionMeta {
+            id: Some(fallback_id.to_string()),
+            ..TestSessionMeta::default()
+        });
+    };
+    Some(test_session_meta_from_value(&value, fallback_id))
+}
+
+fn test_session_meta_from_value(value: &serde_json::Value, fallback_id: &str) -> TestSessionMeta {
+    TestSessionMeta {
+        id: value
+            .get("id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .or_else(|| Some(fallback_id.to_string())),
+        worktree_path: value
+            .get("worktreePath")
+            .and_then(|value| value.as_str())
+            .map(normalized_gc_worktree_path),
+        state: value
+            .get("state")
+            .and_then(|value| serde_json::from_value::<SessionState>(value.clone()).ok()),
+        updated_at: value.get("updatedAt").and_then(|value| value.as_f64()),
+    }
+}
+
+fn collect_test_session_blob_stores(app_data_dir: &Path) -> Vec<SessionBlobStore> {
+    let sessions_dir = app_data_dir.join("sessions");
+    let Ok(entries) = fs::read_dir(&sessions_dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .map(|session_dir| SessionBlobStore {
+            messages_dir: session_dir.join("messages"),
+            tool_outputs_dir: session_dir.join("tool_outputs"),
+            attachments_dir: session_dir.join("attachments"),
+            session_dir,
+        })
+        .collect()
+}
+
+fn collect_test_workflow_runs(app_data_dir: &Path) -> Vec<WorkflowRunGcRecord> {
+    let archived_at_by_run = test_manual_archive_times(app_data_dir);
+    let runs_dir = app_data_dir.join("workflow_runs");
+    let Ok(entries) = fs::read_dir(&runs_dir) else {
+        return Vec::new();
+    };
+    let mut records = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(run) = serde_json::from_str::<TestWorkflowRunMeta>(&content) else {
+            continue;
+        };
+        records.push(WorkflowRunGcRecord {
+            run_id: run.run_id.clone(),
+            worktree_path: normalized_gc_worktree_path(&run.worktree_path),
+            is_terminal: run.status.is_terminal(),
+            manual_archived_at: archived_at_by_run.get(&run.run_id).copied(),
+            delete_paths: test_workflow_run_delete_paths(app_data_dir, &run.run_id),
+        });
+    }
+    records
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TestWorkflowRunMeta {
+    run_id: String,
+    status: RunStatus,
+    worktree_path: String,
+}
+
+fn test_manual_archive_times(app_data_dir: &Path) -> HashMap<String, f64> {
+    let path = app_data_dir.join("workflow_run_archives.json");
+    let Ok(content) = fs::read_to_string(path) else {
+        return HashMap::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return HashMap::new();
+    };
+    let Some(runs) = value.get("runs").and_then(|runs| runs.as_object()) else {
+        return HashMap::new();
+    };
+    runs.iter()
+        .filter_map(|(run_id, record)| {
+            let archived_at = record.get("archivedAt").and_then(|value| value.as_f64())?;
+            let reason = record.get("archiveReason").and_then(|value| value.as_str());
+            let restored_at = record.get("restoredAt").and_then(|value| value.as_f64());
+            (reason == Some(WORKFLOW_ARCHIVE_REASON_MANUAL) && restored_at.is_none())
+                .then(|| (run_id.clone(), archived_at))
+        })
+        .collect()
+}
+
+fn test_workflow_run_delete_paths(app_data_dir: &Path, run_id: &str) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    paths.push(
+        app_data_dir
+            .join("workflow_runs")
+            .join(format!("{run_id}.json")),
+    );
+    for extension in ["ndjson", "json"] {
+        paths.push(
+            app_data_dir
+                .join("workflow_logs")
+                .join(format!("{run_id}.{extension}")),
+        );
+    }
+    let workflow_dir = app_data_dir.join("workflow");
+    for path in [
+        workflow_dir.join(run_id),
+        workflow_dir.join(format!("{run_id}.json")),
+        workflow_dir.join(format!("{run_id}.ndjson")),
+    ] {
+        if path.exists() {
+            paths.push(path);
+        }
+    }
+    for subdir in ["pending", "processing", "processed"] {
+        let dir = app_data_dir.join("workflow_pending").join(subdir);
+        let Ok(entries) = fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Ok(content) = fs::read_to_string(&path) else {
+                continue;
+            };
+            if test_pending_command_run_id(&content).as_deref() == Some(run_id) {
+                paths.push(path);
+            }
+        }
+    }
+    paths
+}
+
+fn test_pending_command_run_id(content: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(content).ok()?;
+    value
+        .get("run_id")
+        .or_else(|| value.get("runId"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+fn collect_test_workspace_state_records(app_data_dir: &Path) -> Vec<WorkspaceStateGcRecord> {
+    let dir = app_data_dir.join("workspace_state");
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let key = path.file_stem().and_then(|stem| stem.to_str())?.to_string();
+            Some(WorkspaceStateGcRecord { path, key })
+        })
+        .collect()
+}
+
+fn collect_test_review_comment_records(app_data_dir: &Path) -> Vec<ReviewCommentGcRecord> {
+    let dir = app_data_dir.join("review-comments");
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let name = path.file_name().and_then(|name| name.to_str())?;
+            let key = name
+                .strip_suffix(".events.json")
+                .or_else(|| name.strip_suffix(".events.lock"))?
+                .to_string();
+            Some(ReviewCommentGcRecord { path, key })
+        })
+        .collect()
+}
+
+fn collect_test_checkpoint_paths(app_data_dir: &Path) -> Vec<PathBuf> {
+    [
+        "agent-worktree-checkpoints",
+        "agent-worktree-checkpoint-backups",
+    ]
+    .into_iter()
+    .map(|dirname| app_data_dir.join(dirname))
+    .filter(|path| path.exists())
+    .collect()
+}
+
+fn collect_test_cache_records(app_data_dir: &Path) -> Vec<CacheGcRecord> {
+    let mut records = Vec::new();
+    let lsp_dir = app_data_dir.join("lsp");
+    for relative in ["jdtls", "typescript", "jdtls.version"] {
+        push_test_cache_record(&lsp_dir.join(relative), &mut records);
+    }
+    let jdtls_workspaces = lsp_dir.join("jdtls-workspaces");
+    if let Ok(entries) = fs::read_dir(jdtls_workspaces) {
+        for entry in entries.flatten() {
+            push_test_cache_record(&entry.path(), &mut records);
+        }
+    }
+    records
+}
+
+fn push_test_cache_record(path: &Path, records: &mut Vec<CacheGcRecord>) {
+    if path.exists() {
+        records.push(CacheGcRecord {
+            path: path.to_path_buf(),
+            updated_at: latest_mtime_secs(path).unwrap_or(NOW),
+        });
+    }
+}
+
+fn latest_mtime_secs(path: &Path) -> Result<f64, String> {
+    let mut latest = modified_secs(path)?;
+    if path.is_dir() {
+        for entry in fs::read_dir(path).map_err(|error| error.to_string())? {
+            latest = latest.max(latest_mtime_secs(
+                &entry.map_err(|error| error.to_string())?.path(),
+            )?);
+        }
+    }
+    Ok(latest)
+}
+
+fn collect_test_legacy_comment_paths(app_data_dir: &Path) -> Vec<PathBuf> {
+    ["comments", "diff-comments", "threads"]
+        .into_iter()
+        .map(|dirname| app_data_dir.join(dirname))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+pub(super) fn full_resolution(live_worktrees: LiveWorktreeSet) -> LiveWorktreeResolution {
+    LiveWorktreeResolution::new(live_worktrees, Vec::new(), HashSet::new())
+}
+
+pub(super) fn partial_resolution(
+    live_worktrees: LiveWorktreeSet,
+    unresolved_repo_paths: Vec<String>,
+    unresolved_workspace_state_key_prefixes: HashSet<String>,
+) -> LiveWorktreeResolution {
+    LiveWorktreeResolution::new(
+        live_worktrees,
+        unresolved_repo_paths,
+        unresolved_workspace_state_key_prefixes,
+    )
+}
+
+pub(super) fn live_set(worktrees: &[(&str, &Path)]) -> LiveWorktreeSet {
+    LiveWorktreeSet::from_worktrees(worktrees.iter().map(|(name, path)| LiveWorktree {
+        path: normalized_worktree_path(&path.to_string_lossy()),
+        workspace_state_keys: workspace_state_keys(name, path),
+        review_comment_keys: review_comment_keys(path),
+    }))
+}
+
+fn workspace_state_keys(name: &str, path: &Path) -> Vec<String> {
+    let path_string = path.to_string_lossy();
+    let normalized = normalized_worktree_path(&path_string);
+    let mut keys = vec![
+        workspace_state_storage_key(name),
+        workspace_state_storage_key(&path_string),
+        workspace_state_storage_key(&normalized),
+    ];
+    if let Some(file_name) = Path::new(&normalized)
+        .file_name()
+        .and_then(|name| name.to_str())
+    {
+        keys.push(workspace_state_storage_key(file_name));
+    }
+    keys
+}
+
+fn review_comment_keys(path: &Path) -> Vec<String> {
+    let path_string = path.to_string_lossy();
+    vec![
+        review_comment_storage_key(&path_string),
+        review_comment_storage_key(&normalized_worktree_path(&path_string)),
+    ]
+}
+
+pub(super) fn normalized_worktree_path(path: &str) -> String {
+    let mut trimmed = path.trim().to_string();
+    while trimmed.len() > 1 && (trimmed.ends_with('/') || trimmed.ends_with('\\')) {
+        trimmed.pop();
+    }
+    Path::new(&trimmed)
+        .canonicalize()
+        .ok()
+        .and_then(|path| path.to_str().map(str::to_string))
+        .unwrap_or(trimmed)
+}
+
+pub(super) fn normalized_gc_worktree_path(path: &str) -> GcWorktreePath {
+    let mut trimmed = path.trim().to_string();
+    while trimmed.len() > 1 && (trimmed.ends_with('/') || trimmed.ends_with('\\')) {
+        trimmed.pop();
+    }
+    match Path::new(&trimmed).canonicalize() {
+        Ok(path) => path
+            .to_str()
+            .map(|path| GcWorktreePath::resolved(path.to_string()))
+            .unwrap_or_else(|| GcWorktreePath::resolved(trimmed)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            GcWorktreePath::not_found(trimmed)
+        }
+        Err(_) => GcWorktreePath::unresolved(trimmed),
+    }
+}
+
+pub(super) struct TestRevalidationReader;
+
+impl GcRevalidationReader for TestRevalidationReader {
+    fn runtime_protection(
+        &self,
+        _app_data_dir: &Path,
+        _process_records: &[ProcessRecord],
+    ) -> RuntimeProtection {
+        RuntimeProtection::default()
+    }
+
+    fn session_state(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+    ) -> RevalidationRead<CurrentSessionState> {
+        let sessions_dir = app_data_dir.join("sessions");
+        let session_dir = sessions_dir.join(session_id);
+        if session_dir.is_dir() {
+            return read_current_test_session_meta(&session_dir.join("meta.json"), session_id);
+        }
+        let session_file = sessions_dir.join(format!("{session_id}.json"));
+        let sidecar = sessions_dir.join(format!("{session_id}.meta.json"));
+        if sidecar.exists() {
+            return read_current_test_session_meta(&sidecar, session_id);
+        }
+        if session_file.exists() {
+            return read_current_test_session_meta(&session_file, session_id);
+        }
+        RevalidationRead::Missing
+    }
+
+    fn workflow_run_state(
+        &self,
+        app_data_dir: &Path,
+        run_id: &str,
+    ) -> RevalidationRead<CurrentWorkflowRunState> {
+        let path = app_data_dir
+            .join("workflow_runs")
+            .join(format!("{run_id}.json"));
+        let content = match fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return RevalidationRead::Missing;
+            }
+            Err(error) => return RevalidationRead::Unavailable(error.to_string()),
+        };
+        let run: TestWorkflowRunMeta = match serde_json::from_str(&content) {
+            Ok(run) => run,
+            Err(error) => return RevalidationRead::Unavailable(error.to_string()),
+        };
+        RevalidationRead::Present(CurrentWorkflowRunState {
+            worktree_path: normalized_gc_worktree_path(&run.worktree_path),
+            is_terminal: run.status.is_terminal(),
+            manual_archived_at: test_manual_archive_times(app_data_dir).get(run_id).copied(),
+        })
+    }
+}
+
+fn read_current_test_session_meta(
+    path: &Path,
+    fallback_id: &str,
+) -> RevalidationRead<CurrentSessionState> {
+    match parse_test_session_meta(path, fallback_id) {
+        Some(meta) => RevalidationRead::Present(CurrentSessionState {
+            worktree_path: meta.worktree_path,
+            state: meta.state,
+            updated_at: meta.updated_at,
+        }),
+        None => RevalidationRead::Unavailable("session meta could not be read".to_string()),
+    }
+}
+
+pub(super) fn workspace_state_storage_key(worktree_name: &str) -> String {
+    worktree_name.replace(['/', '\\'], "_")
+}
+
+pub(super) fn review_comment_storage_key(worktree: &str) -> String {
+    let trimmed = worktree.trim();
+    let canonical = Path::new(trimmed)
+        .canonicalize()
+        .ok()
+        .and_then(|path| path.to_str().map(str::to_string))
+        .unwrap_or_else(|| trimmed.to_string());
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let digest = hex::encode(hasher.finalize());
+    let label = Path::new(&canonical)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("worktree")
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!("{label}-{}", &digest[..24])
+}
+
+pub(super) fn write_session(
+    app_data_dir: &Path,
+    id: &str,
+    worktree_path: &Path,
+    state: &str,
+    updated_at: f64,
+) -> PathBuf {
+    let dir = app_data_dir.join("sessions").join(id);
+    fs::create_dir_all(dir.join("messages")).unwrap();
+    fs::write(dir.join("index.json"), "[]").unwrap();
+    fs::write(
+        dir.join("meta.json"),
+        serde_json::json!({
+            "id": id,
+            "worktreePath": worktree_path.to_string_lossy(),
+            "state": state,
+            "updatedAt": updated_at
+        })
+        .to_string(),
+    )
+    .unwrap();
+    dir
+}
+
+pub(super) fn write_message(session_dir: &Path, seq: u64, parts: Vec<MessagePart>) {
+    fs::write(
+        session_dir.join("messages").join(format!("{seq}.json")),
+        serde_json::to_string(&ChatMessage {
+            id: format!("m{seq}"),
+            role: MessageRole::Agent,
+            content: String::new(),
+            thinking: None,
+            activities: None,
+            parts: Some(parts),
+            streaming_final_seq: 0,
+            timestamp: NOW,
+            mentions: None,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+pub(super) fn write_workflow_run(
+    app_data_dir: &Path,
+    id: &str,
+    worktree_path: &Path,
+    status: &str,
+) {
+    fs::create_dir_all(app_data_dir.join("workflow_runs")).unwrap();
+    fs::create_dir_all(app_data_dir.join("workflow_logs")).unwrap();
+    fs::write(
+        app_data_dir
+            .join("workflow_runs")
+            .join(format!("{id}.json")),
+        serde_json::json!({
+            "runId": id,
+            "status": status,
+            "worktreePath": worktree_path.to_string_lossy()
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        app_data_dir
+            .join("workflow_logs")
+            .join(format!("{id}.ndjson")),
+        "log",
+    )
+    .unwrap();
+}
+
+pub(super) fn write_archive_index(app_data_dir: &Path, entries: &[(&str, f64, Option<f64>)]) {
+    let runs = entries
+        .iter()
+        .map(|(id, archived_at, restored_at)| {
+            (
+                (*id).to_string(),
+                serde_json::json!({
+                    "archivedAt": archived_at,
+                    "archiveReason": WORKFLOW_ARCHIVE_REASON_MANUAL,
+                    "restoredAt": restored_at
+                }),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
+    fs::write(
+        app_data_dir.join("workflow_run_archives.json"),
+        serde_json::json!({ "runs": runs }).to_string(),
+    )
+    .unwrap();
+}

--- a/src-tauri/src/usecase/app_data_gc/tests.rs
+++ b/src-tauri/src/usecase/app_data_gc/tests.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::collections::HashSet;
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -980,6 +981,34 @@ fn sweep_revalidation_keeps_candidate_that_enters_runtime_protection() {
     assert!(session.exists());
 }
 
+#[test]
+fn sweep_collects_runtime_protection_once_per_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let deleted = tmp.path().join("deleted-worktree");
+    write_session(tmp.path(), "session", &deleted, "idle", NOW);
+    write_workflow_run(tmp.path(), "workflow-run", &deleted, "completed");
+    fs::create_dir_all(tmp.path().join("workspace_state")).unwrap();
+    fs::write(tmp.path().join("workspace_state/deleted.json"), "{}").unwrap();
+    fs::create_dir_all(tmp.path().join("review-comments")).unwrap();
+    fs::write(tmp.path().join("review-comments/deleted.events.json"), "[]").unwrap();
+    let request = startup_gc_request(
+        tmp.path(),
+        Some(full_resolution(live_set(&[("live", live.path())]))),
+        RuntimeProtection::default(),
+        Vec::new(),
+        NOW,
+    );
+    let reader = CountingRuntimeProtectionReader {
+        runtime_protection: RuntimeProtection::default(),
+        calls: Cell::new(0),
+    };
+
+    run_startup_gc(request, &TestFs, &TestArchivePruner, &reader);
+
+    assert_eq!(reader.calls.get(), 1);
+}
+
 struct RuntimeProtectionTestReader {
     runtime_protection: RuntimeProtection,
 }
@@ -990,6 +1019,38 @@ impl GcRevalidationReader for RuntimeProtectionTestReader {
         _app_data_dir: &std::path::Path,
         _process_records: &[ProcessRecord],
     ) -> RuntimeProtection {
+        self.runtime_protection.clone()
+    }
+
+    fn session_state(
+        &self,
+        app_data_dir: &std::path::Path,
+        session_id: &str,
+    ) -> RevalidationRead<CurrentSessionState> {
+        TestRevalidationReader.session_state(app_data_dir, session_id)
+    }
+
+    fn workflow_run_state(
+        &self,
+        app_data_dir: &std::path::Path,
+        run_id: &str,
+    ) -> RevalidationRead<CurrentWorkflowRunState> {
+        TestRevalidationReader.workflow_run_state(app_data_dir, run_id)
+    }
+}
+
+struct CountingRuntimeProtectionReader {
+    runtime_protection: RuntimeProtection,
+    calls: Cell<usize>,
+}
+
+impl GcRevalidationReader for CountingRuntimeProtectionReader {
+    fn runtime_protection(
+        &self,
+        _app_data_dir: &std::path::Path,
+        _process_records: &[ProcessRecord],
+    ) -> RuntimeProtection {
+        self.calls.set(self.calls.get() + 1);
         self.runtime_protection.clone()
     }
 

--- a/src-tauri/src/usecase/app_data_gc/tests.rs
+++ b/src-tauri/src/usecase/app_data_gc/tests.rs
@@ -1,0 +1,1051 @@
+use std::collections::HashSet;
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::domain::app_data_gc::{GcCategory, RetentionPolicy};
+use crate::usecase::agent_session::session::{AttachmentRef, MessagePart, ToolOutputRef};
+
+use super::test_fixtures::*;
+use super::{
+    run_startup_gc, CurrentSessionState, CurrentWorkflowRunState, GcRevalidationReader,
+    GcWorktreePath, ProcessRecord, ProcessRecordStatus, RevalidationRead, RuntimeProtection,
+};
+
+#[test]
+fn deleted_workspace_session_workflow_and_workspace_state_are_removed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let deleted = tmp.path().join("deleted-worktree");
+    let live_session = write_session(tmp.path(), "live-session", live.path(), "idle", NOW);
+    let deleted_session = write_session(tmp.path(), "deleted-session", &deleted, "idle", NOW);
+    write_workflow_run(tmp.path(), "deleted-run", &deleted, "completed");
+    write_workflow_run(tmp.path(), "live-run", live.path(), "completed");
+    fs::create_dir_all(tmp.path().join("workspace_state")).unwrap();
+    fs::write(
+        tmp.path()
+            .join("workspace_state")
+            .join(format!("{}.json", workspace_state_storage_key("live"))),
+        "{}",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("workspace_state").join("deleted.json"),
+        "{}",
+    )
+    .unwrap();
+    fs::create_dir_all(tmp.path().join("review-comments")).unwrap();
+    let live_review_key = review_comment_storage_key(&live.path().to_string_lossy());
+    fs::write(
+        tmp.path()
+            .join("review-comments")
+            .join(format!("{live_review_key}.events.json")),
+        "[]",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path()
+            .join("review-comments/deleted-review.events.json"),
+        "[]",
+    )
+    .unwrap();
+    fs::create_dir_all(tmp.path().join("agent-worktree-checkpoints")).unwrap();
+    fs::write(
+        tmp.path()
+            .join("agent-worktree-checkpoints")
+            .join(format!("{}.json", workspace_state_storage_key("live"))),
+        "{}",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("agent-worktree-checkpoints/deleted.json"),
+        "{}",
+    )
+    .unwrap();
+
+    run_gc(
+        tmp.path(),
+        Some(live_set(&[("live", live.path())])),
+        vec![],
+        NOW,
+    );
+
+    assert!(live_session.exists());
+    assert!(!deleted_session.exists());
+    assert!(!tmp.path().join("workflow_runs/deleted-run.json").exists());
+    assert!(!tmp.path().join("workflow_logs/deleted-run.ndjson").exists());
+    assert!(tmp.path().join("workflow_runs/live-run.json").exists());
+    assert!(tmp
+        .path()
+        .join("workspace_state")
+        .join(format!("{}.json", workspace_state_storage_key("live")))
+        .exists());
+    assert!(!tmp.path().join("workspace_state/deleted.json").exists());
+    assert!(tmp
+        .path()
+        .join("review-comments")
+        .join(format!("{live_review_key}.events.json"))
+        .exists());
+    assert!(!tmp
+        .path()
+        .join("review-comments/deleted-review.events.json")
+        .exists());
+    assert!(tmp
+        .path()
+        .join("agent-worktree-checkpoints")
+        .join(format!("{}.json", workspace_state_storage_key("live")))
+        .exists());
+    assert!(tmp
+        .path()
+        .join("agent-worktree-checkpoints/deleted.json")
+        .exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_live_worktree_keeps_in_use_sessions_and_workflow() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let real_worktree = root.path().join("real-worktree");
+    let symlink_worktree = root.path().join("symlink-worktree");
+    fs::create_dir_all(&real_worktree).unwrap();
+    std::os::unix::fs::symlink(&real_worktree, &symlink_worktree).unwrap();
+    let idle = write_session(tmp.path(), "idle-session", &symlink_worktree, "idle", NOW);
+    let done = write_session(tmp.path(), "done-session", &symlink_worktree, "done", NOW);
+    let error = write_session(tmp.path(), "error-session", &symlink_worktree, "error", NOW);
+    write_workflow_run(tmp.path(), "completed-run", &symlink_worktree, "completed");
+
+    run_gc(
+        tmp.path(),
+        Some(live_set(&[("live", &real_worktree)])),
+        vec![],
+        NOW,
+    );
+
+    assert!(idle.exists());
+    assert!(done.exists());
+    assert!(error.exists());
+    assert!(tmp.path().join("workflow_runs/completed-run.json").exists());
+}
+
+#[test]
+fn unresolved_worktree_path_keeps_session_and_workflow_conservatively() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("blocked-worktree");
+    let session = write_session(tmp.path(), "session", &missing, "idle", NOW);
+    write_workflow_run(tmp.path(), "completed-run", &missing, "completed");
+    let mut request = startup_gc_request(
+        tmp.path(),
+        Some(full_resolution(live_set(&[("live", live.path())]))),
+        RuntimeProtection::default(),
+        Vec::new(),
+        NOW,
+    );
+    for record in &mut request.session_records {
+        record.worktree_path = Some(GcWorktreePath::unresolved(missing.to_string_lossy()));
+    }
+    for run in &mut request.workflow_runs {
+        run.worktree_path = GcWorktreePath::unresolved(missing.to_string_lossy());
+    }
+
+    run_startup_gc(
+        request,
+        &TestFs,
+        &TestArchivePruner,
+        &TestRevalidationReader,
+    );
+
+    assert!(session.exists());
+    assert!(tmp.path().join("workflow_runs/completed-run.json").exists());
+}
+
+#[test]
+fn session_state_rules_keep_archived_until_retention_expires() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let archived_old = write_session(
+        tmp.path(),
+        "archived-old",
+        live.path(),
+        "archived",
+        NOW - RetentionPolicy::default().archived_log_secs as f64 - 1.0,
+    );
+    let archived_boundary = write_session(
+        tmp.path(),
+        "archived-boundary",
+        live.path(),
+        "archived",
+        NOW - RetentionPolicy::default().archived_log_secs as f64,
+    );
+    let closed_old = write_session(
+        tmp.path(),
+        "closed-old",
+        live.path(),
+        "closed",
+        NOW - RetentionPolicy::default().archived_log_secs as f64 - 1.0,
+    );
+    let closed_boundary = write_session(
+        tmp.path(),
+        "closed-boundary",
+        live.path(),
+        "closed",
+        NOW - RetentionPolicy::default().archived_log_secs as f64,
+    );
+    let idle_old = write_session(
+        tmp.path(),
+        "idle-old",
+        live.path(),
+        "idle",
+        NOW - RetentionPolicy::default().archived_log_secs as f64 - 1000.0,
+    );
+
+    run_gc(
+        tmp.path(),
+        Some(live_set(&[("live", live.path())])),
+        vec![],
+        NOW,
+    );
+
+    assert!(!archived_old.exists());
+    assert!(archived_boundary.exists());
+    assert!(!closed_old.exists());
+    assert!(closed_boundary.exists());
+    assert!(idle_old.exists());
+}
+
+#[test]
+fn workflow_archive_retention_and_running_protection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    write_workflow_run(tmp.path(), "old-archive", live.path(), "completed");
+    write_workflow_run(tmp.path(), "boundary-archive", live.path(), "completed");
+    write_workflow_run(tmp.path(), "restored-archive", live.path(), "completed");
+    write_workflow_run(tmp.path(), "running-archive", live.path(), "running");
+    fs::create_dir_all(tmp.path().join("workflow/old-archive")).unwrap();
+    fs::write(tmp.path().join("workflow/old-archive/artifact.json"), "{}").unwrap();
+    fs::create_dir_all(tmp.path().join("workflow_pending/pending")).unwrap();
+    fs::create_dir_all(tmp.path().join("workflow_pending/processed")).unwrap();
+    fs::write(
+        tmp.path().join("workflow_pending/pending/old-command.json"),
+        serde_json::json!({"id": "cmd-1", "run_id": "old-archive"}).to_string(),
+    )
+    .unwrap();
+    fs::write(
+        tmp.path()
+            .join("workflow_pending/processed/boundary-command.json"),
+        serde_json::json!({"id": "cmd-2", "runId": "boundary-archive"}).to_string(),
+    )
+    .unwrap();
+    write_archive_index(
+        tmp.path(),
+        &[
+            (
+                "old-archive",
+                NOW - RetentionPolicy::default().archived_log_secs as f64 - 1.0,
+                None,
+            ),
+            (
+                "boundary-archive",
+                NOW - RetentionPolicy::default().archived_log_secs as f64,
+                None,
+            ),
+            (
+                "restored-archive",
+                NOW - RetentionPolicy::default().archived_log_secs as f64 - 1.0,
+                Some(NOW - 1.0),
+            ),
+            (
+                "running-archive",
+                NOW - RetentionPolicy::default().archived_log_secs as f64 - 1.0,
+                None,
+            ),
+        ],
+    );
+
+    run_gc(
+        tmp.path(),
+        Some(live_set(&[("live", live.path())])),
+        vec![],
+        NOW,
+    );
+
+    assert!(!tmp.path().join("workflow_runs/old-archive.json").exists());
+    assert!(!tmp.path().join("workflow/old-archive").exists());
+    assert!(!tmp
+        .path()
+        .join("workflow_pending/pending/old-command.json")
+        .exists());
+    assert!(tmp
+        .path()
+        .join("workflow_pending/processed/boundary-command.json")
+        .exists());
+    assert!(tmp
+        .path()
+        .join("workflow_runs/boundary-archive.json")
+        .exists());
+    assert!(tmp
+        .path()
+        .join("workflow_runs/restored-archive.json")
+        .exists());
+    assert!(tmp
+        .path()
+        .join("workflow_runs/running-archive.json")
+        .exists());
+    let archive_index: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(tmp.path().join("workflow_run_archives.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(archive_index["runs"].get("old-archive").is_none());
+    assert!(archive_index["runs"].get("boundary-archive").is_some());
+}
+
+#[test]
+fn workflow_archive_record_is_kept_when_run_deletion_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    write_workflow_run(tmp.path(), "old-archive", live.path(), "completed");
+    write_archive_index(
+        tmp.path(),
+        &[(
+            "old-archive",
+            NOW - RetentionPolicy::default().archived_log_secs as f64 - 1.0,
+            None,
+        )],
+    );
+
+    let report = run_startup_gc(
+        startup_gc_request(
+            tmp.path(),
+            Some(full_resolution(live_set(&[("live", live.path())]))),
+            RuntimeProtection::default(),
+            Vec::new(),
+            NOW,
+        ),
+        &FailingRemoveFs {
+            failing_path: tmp.path().join("workflow_runs/old-archive.json"),
+        },
+        &TestArchivePruner,
+        &TestRevalidationReader,
+    );
+
+    assert_eq!(report.errors, 1);
+    assert!(tmp.path().join("workflow_runs/old-archive.json").exists());
+    let archive_index: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(tmp.path().join("workflow_run_archives.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(archive_index["runs"].get("old-archive").is_some());
+}
+
+#[test]
+fn sweep_skips_workflow_candidate_outside_app_data_dir() {
+    let root = tempfile::tempdir().unwrap();
+    let app_data_dir = root.path().join("app-data");
+    let live = tempfile::tempdir().unwrap();
+    let deleted = root.path().join("deleted-worktree");
+    fs::create_dir_all(app_data_dir.join("workflow_runs")).unwrap();
+    fs::create_dir_all(root.path().join("outside")).unwrap();
+    let outside = root.path().join("outside/target.json");
+    fs::write(&outside, "outside").unwrap();
+    fs::write(
+        app_data_dir.join("workflow_runs/malicious.json"),
+        serde_json::json!({
+            "runId": "../../outside/target",
+            "status": "completed",
+            "worktreePath": deleted.to_string_lossy()
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_workflow_run(&app_data_dir, "normal-run", &deleted, "completed");
+
+    run_gc(
+        &app_data_dir,
+        Some(live_set(&[("live", live.path())])),
+        vec![],
+        NOW,
+    );
+
+    assert!(outside.exists());
+    assert!(!app_data_dir.join("workflow_runs/normal-run.json").exists());
+}
+
+#[test]
+fn cache_uses_strict_seven_day_boundary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache = tmp.path().join("lsp/typescript");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("cache.bin"), "cache").unwrap();
+    let mtime = modified_secs(&cache).unwrap();
+
+    run_gc(
+        tmp.path(),
+        None,
+        vec![],
+        mtime + RetentionPolicy::default().cache_secs as f64,
+    );
+    assert!(cache.exists());
+
+    run_gc(
+        tmp.path(),
+        None,
+        vec![],
+        mtime + RetentionPolicy::default().cache_secs as f64 + 1.0,
+    );
+    assert!(!cache.exists());
+}
+
+#[test]
+fn jdtls_workspaces_are_collected_per_workspace_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let old_workspace = tmp.path().join("lsp/jdtls-workspaces/old-workspace");
+    let fresh_workspace = tmp.path().join("lsp/jdtls-workspaces/fresh-workspace");
+    fs::create_dir_all(&old_workspace).unwrap();
+    fs::create_dir_all(&fresh_workspace).unwrap();
+    fs::write(old_workspace.join("state"), "old").unwrap();
+    fs::write(fresh_workspace.join("state"), "fresh").unwrap();
+    let old_mtime = NOW - RetentionPolicy::default().cache_secs as f64 - 1.0;
+    set_mtime(&old_workspace.join("state"), old_mtime);
+    set_mtime(&old_workspace, old_mtime);
+    set_mtime(&fresh_workspace.join("state"), NOW);
+    set_mtime(&fresh_workspace, NOW);
+
+    run_gc(tmp.path(), None, vec![], NOW);
+
+    assert!(!old_workspace.exists());
+    assert!(fresh_workspace.exists());
+    assert!(tmp.path().join("lsp/jdtls-workspaces").exists());
+}
+
+#[test]
+fn legacy_comments_are_removed_and_review_comments_are_kept() {
+    let tmp = tempfile::tempdir().unwrap();
+    for dir in ["comments", "diff-comments", "threads", "review-comments"] {
+        fs::create_dir_all(tmp.path().join(dir)).unwrap();
+        fs::write(tmp.path().join(dir).join("entry.json"), "{}").unwrap();
+    }
+
+    run_gc(tmp.path(), None, vec![], NOW);
+
+    assert!(!tmp.path().join("comments").exists());
+    assert!(!tmp.path().join("diff-comments").exists());
+    assert!(!tmp.path().join("threads").exists());
+    assert!(tmp.path().join("review-comments").exists());
+}
+
+#[test]
+fn orphan_blobs_are_removed_without_touching_messages_or_referenced_blobs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let session_dir = write_session(tmp.path(), "active-session", live.path(), "active", NOW);
+    write_message(
+        &session_dir,
+        1,
+        vec![
+            MessagePart::ToolResult {
+                content: String::new(),
+                is_error: false,
+                tool_use_id: None,
+                parent_tool_use_id: None,
+                content_ref: Some(ToolOutputRef {
+                    id: "kept-tool".to_string(),
+                    byte_size: 1,
+                }),
+                summary: None,
+            },
+            MessagePart::ImageRef {
+                attachment: AttachmentRef {
+                    id: "kept-attachment".to_string(),
+                    media_type: "image/png".to_string(),
+                    byte_size: 1,
+                },
+            },
+        ],
+    );
+    fs::create_dir_all(session_dir.join("tool_outputs")).unwrap();
+    fs::create_dir_all(session_dir.join("attachments")).unwrap();
+    fs::write(session_dir.join("tool_outputs/kept-tool"), "keep").unwrap();
+    fs::write(session_dir.join("tool_outputs/orphan-tool"), "delete").unwrap();
+    fs::write(session_dir.join("attachments/kept-attachment"), "keep").unwrap();
+    fs::write(session_dir.join("attachments/orphan-attachment"), "delete").unwrap();
+
+    run_gc(tmp.path(), None, vec![], NOW);
+
+    assert!(session_dir.join("messages/1.json").exists());
+    assert!(session_dir.join("tool_outputs/kept-tool").exists());
+    assert!(!session_dir.join("tool_outputs/orphan-tool").exists());
+    assert!(session_dir.join("attachments/kept-attachment").exists());
+    assert!(!session_dir.join("attachments/orphan-attachment").exists());
+}
+
+#[test]
+fn stale_index_refs_do_not_keep_unreferenced_blobs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let session_dir = write_session(tmp.path(), "session", live.path(), "idle", NOW);
+    fs::write(
+        session_dir.join("index.json"),
+        serde_json::json!([{
+            "id": "stale",
+            "seq": 1,
+            "role": "agent",
+            "timestamp": NOW,
+            "contentHash": "stale",
+            "toolOutputRefs": [{"id": "stale-index-tool", "byteSize": 1}],
+            "attachmentRefs": [{"id": "stale-index-attachment", "mediaType": "image/png", "byteSize": 1}]
+        }])
+        .to_string(),
+    )
+    .unwrap();
+    write_message(&session_dir, 1, Vec::new());
+    fs::create_dir_all(session_dir.join("tool_outputs")).unwrap();
+    fs::create_dir_all(session_dir.join("attachments")).unwrap();
+    fs::write(session_dir.join("tool_outputs/stale-index-tool"), "delete").unwrap();
+    fs::write(
+        session_dir.join("attachments/stale-index-attachment"),
+        "delete",
+    )
+    .unwrap();
+
+    run_gc(tmp.path(), None, vec![], NOW);
+
+    assert!(!session_dir.join("tool_outputs/stale-index-tool").exists());
+    assert!(!session_dir
+        .join("attachments/stale-index-attachment")
+        .exists());
+}
+
+#[test]
+fn missing_messages_dir_is_treated_as_empty_refs_for_blob_cleanup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let session_dir = write_session(tmp.path(), "session", live.path(), "idle", NOW);
+    fs::remove_dir_all(session_dir.join("messages")).unwrap();
+    fs::create_dir_all(session_dir.join("tool_outputs")).unwrap();
+    fs::write(session_dir.join("tool_outputs/orphan-tool"), "delete").unwrap();
+
+    run_gc(tmp.path(), None, vec![], NOW);
+
+    assert!(!session_dir.join("tool_outputs/orphan-tool").exists());
+}
+
+#[test]
+fn orphan_blob_cleanup_runs_even_when_session_meta_read_model_is_unavailable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let session_dir = write_session(tmp.path(), "session", live.path(), "idle", NOW);
+    fs::create_dir_all(session_dir.join("tool_outputs")).unwrap();
+    fs::write(session_dir.join("tool_outputs/orphan-tool"), "delete").unwrap();
+    let mut request = startup_gc_request(
+        tmp.path(),
+        Some(full_resolution(live_set(&[("live", live.path())]))),
+        RuntimeProtection::default(),
+        Vec::new(),
+        NOW,
+    );
+    request.session_records.clear();
+
+    run_startup_gc(
+        request,
+        &TestFs,
+        &TestArchivePruner,
+        &TestRevalidationReader,
+    );
+
+    assert!(session_dir.exists());
+    assert!(!session_dir.join("tool_outputs/orphan-tool").exists());
+}
+
+#[test]
+fn unreadable_messages_dir_skips_orphan_blob_cleanup_for_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let session_dir = write_session(tmp.path(), "session", live.path(), "idle", NOW);
+    fs::create_dir_all(session_dir.join("tool_outputs")).unwrap();
+    fs::write(session_dir.join("tool_outputs/orphan-tool"), "keep").unwrap();
+
+    run_startup_gc(
+        startup_gc_request(
+            tmp.path(),
+            None,
+            RuntimeProtection::default(),
+            Vec::new(),
+            NOW,
+        ),
+        &FailingReadDirFs {
+            failing_dir: session_dir.join("messages"),
+        },
+        &TestArchivePruner,
+        &TestRevalidationReader,
+    );
+
+    assert!(session_dir.join("tool_outputs/orphan-tool").exists());
+}
+
+#[test]
+fn session_meta_read_error_keeps_whole_session_cleanup_from_deleting_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let session_dir = write_session(tmp.path(), "session", live.path(), "idle", NOW);
+
+    let mut request = startup_gc_request(
+        tmp.path(),
+        Some(full_resolution(live_set(&[("live", live.path())]))),
+        RuntimeProtection::default(),
+        Vec::new(),
+        NOW,
+    );
+    request.session_records.clear();
+    run_startup_gc(
+        request,
+        &FailingReadFileFs {
+            failing_file: session_dir.join("meta.json"),
+        },
+        &TestArchivePruner,
+        &TestRevalidationReader,
+    );
+
+    assert!(session_dir.exists());
+}
+
+#[test]
+fn missing_session_meta_deletes_orphan_session_as_unrecoverable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let session_dir = tmp.path().join("sessions/orphan-session");
+    fs::create_dir_all(session_dir.join("messages")).unwrap();
+
+    let report = run_gc(
+        tmp.path(),
+        Some(live_set(&[("live", live.path())])),
+        vec![],
+        NOW,
+    );
+
+    assert!(!session_dir.exists());
+    assert_eq!(
+        report.categories[&GcCategory::UnrecoverableSession].deleted,
+        1
+    );
+}
+
+#[test]
+fn stale_process_records_are_removed_and_live_unknown_are_kept() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("agent-processes");
+    fs::create_dir_all(&dir).unwrap();
+    let stale = dir.join("stale.json");
+    let live = dir.join("live.json");
+    let unknown = dir.join("unknown.json");
+    fs::write(&stale, "stale").unwrap();
+    fs::write(&live, "live").unwrap();
+    fs::write(&unknown, "unknown").unwrap();
+
+    run_gc(
+        tmp.path(),
+        None,
+        vec![
+            ProcessRecord {
+                path: stale.clone(),
+                session_id: Some("s1".to_string()),
+                status: ProcessRecordStatus::Stale,
+            },
+            ProcessRecord {
+                path: live.clone(),
+                session_id: Some("s2".to_string()),
+                status: ProcessRecordStatus::Live,
+            },
+            ProcessRecord {
+                path: unknown.clone(),
+                session_id: Some("s3".to_string()),
+                status: ProcessRecordStatus::Unknown,
+            },
+        ],
+        NOW,
+    );
+
+    assert!(!stale.exists());
+    assert!(live.exists());
+    assert!(unknown.exists());
+}
+
+#[test]
+fn workspace_dependent_rules_skip_when_live_worktrees_unavailable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("missing-worktree");
+    let archived = write_session(tmp.path(), "archived", &missing, "archived", NOW);
+    write_workflow_run(tmp.path(), "deleted-run", &missing, "completed");
+
+    run_gc(tmp.path(), None, vec![], NOW);
+
+    assert!(archived.exists());
+    assert!(tmp.path().join("workflow_runs/deleted-run.json").exists());
+}
+
+#[test]
+fn partial_live_worktree_resolution_keeps_only_unresolved_repo_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let failed_repo = tmp.path().join("failed-repo");
+    fs::create_dir_all(&failed_repo).unwrap();
+    let failed_repo_worktree = failed_repo.join("maybe-live-worktree");
+    let deleted_worktree = tmp.path().join("deleted-worktree");
+
+    let deleted_session = write_session(
+        tmp.path(),
+        "deleted-session",
+        &deleted_worktree,
+        "idle",
+        NOW,
+    );
+    let unresolved_session = write_session(
+        tmp.path(),
+        "unresolved-session",
+        &failed_repo_worktree,
+        "idle",
+        NOW,
+    );
+    let expired_live_session = write_session(
+        tmp.path(),
+        "expired-live-session",
+        live.path(),
+        "archived",
+        NOW - RetentionPolicy::default().archived_log_secs as f64 - 1.0,
+    );
+    write_workflow_run(tmp.path(), "deleted-run", &deleted_worktree, "completed");
+    write_workflow_run(
+        tmp.path(),
+        "unresolved-run",
+        &failed_repo_worktree,
+        "completed",
+    );
+
+    fs::create_dir_all(tmp.path().join("workspace_state")).unwrap();
+    let unresolved_workspace_key =
+        workspace_state_storage_key(&failed_repo_worktree.to_string_lossy());
+    fs::write(
+        tmp.path()
+            .join("workspace_state")
+            .join(format!("{unresolved_workspace_key}.json")),
+        "{}",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("workspace_state/deleted-workspace.json"),
+        "{}",
+    )
+    .unwrap();
+
+    let resolution = partial_resolution(
+        live_set(&[("live", live.path())]),
+        vec![failed_repo.to_string_lossy().into_owned()],
+        HashSet::from([workspace_state_storage_key(&failed_repo.to_string_lossy())]),
+    );
+
+    run_gc_with_resolution(
+        tmp.path(),
+        Some(resolution),
+        RuntimeProtection::default(),
+        NOW,
+    );
+
+    assert!(!deleted_session.exists());
+    assert!(unresolved_session.exists());
+    assert!(!expired_live_session.exists());
+    assert!(!tmp.path().join("workflow_runs/deleted-run.json").exists());
+    assert!(tmp
+        .path()
+        .join("workflow_runs/unresolved-run.json")
+        .exists());
+    assert!(tmp
+        .path()
+        .join("workspace_state")
+        .join(format!("{unresolved_workspace_key}.json"))
+        .exists());
+    assert!(tmp
+        .path()
+        .join("workspace_state/deleted-workspace.json")
+        .exists());
+}
+
+#[test]
+fn unresolved_repo_keeps_basename_workspace_state_key() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let failed_repo = tmp.path().join("failed-repo");
+    fs::create_dir_all(&failed_repo).unwrap();
+    fs::create_dir_all(tmp.path().join("workspace_state")).unwrap();
+    fs::write(
+        tmp.path().join("workspace_state/maybe-live-worktree.json"),
+        "{}",
+    )
+    .unwrap();
+
+    let resolution = partial_resolution(
+        live_set(&[("live", live.path())]),
+        vec![failed_repo.to_string_lossy().into_owned()],
+        HashSet::new(),
+    );
+
+    run_gc_with_resolution(
+        tmp.path(),
+        Some(resolution),
+        RuntimeProtection::default(),
+        NOW,
+    );
+
+    assert!(tmp
+        .path()
+        .join("workspace_state/maybe-live-worktree.json")
+        .exists());
+}
+
+#[test]
+fn workspace_keyed_cleanup_skips_when_runtime_protection_is_incomplete() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("workspace_state")).unwrap();
+    fs::write(tmp.path().join("workspace_state/deleted.json"), "{}").unwrap();
+    fs::create_dir_all(tmp.path().join("review-comments")).unwrap();
+    fs::write(tmp.path().join("review-comments/deleted.events.json"), "[]").unwrap();
+
+    run_gc_with_resolution(
+        tmp.path(),
+        Some(full_resolution(live_set(&[("live", live.path())]))),
+        RuntimeProtection::default().with_workspace_keyed_protection_complete(false),
+        NOW,
+    );
+
+    assert!(tmp.path().join("workspace_state/deleted.json").exists());
+    assert!(tmp
+        .path()
+        .join("review-comments/deleted.events.json")
+        .exists());
+}
+
+#[test]
+fn checkpoint_cleanup_is_skipped_without_verified_worktree_mapping() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    for dirname in [
+        "agent-worktree-checkpoints",
+        "agent-worktree-checkpoint-backups",
+    ] {
+        fs::create_dir_all(tmp.path().join(dirname)).unwrap();
+        fs::write(tmp.path().join(dirname).join("deleted.json"), "{}").unwrap();
+    }
+
+    run_gc(
+        tmp.path(),
+        Some(live_set(&[("live", live.path())])),
+        vec![],
+        NOW,
+    );
+
+    assert!(tmp
+        .path()
+        .join("agent-worktree-checkpoints/deleted.json")
+        .exists());
+    assert!(tmp
+        .path()
+        .join("agent-worktree-checkpoint-backups/deleted.json")
+        .exists());
+}
+
+#[test]
+fn active_session_and_running_workflow_guard_whole_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("missing-worktree");
+    let active = write_session(tmp.path(), "active", &missing, "active", NOW);
+    let pid_live_archived = write_session(tmp.path(), "pid-live", live.path(), "archived", NOW);
+    write_workflow_run(tmp.path(), "running-run", &missing, "running");
+    let protected = live_set(&[("missing-worktree", &missing)]);
+    let protected_workspace_key = workspace_state_storage_key("missing-worktree");
+    let protected_review_key = review_comment_storage_key(&missing.to_string_lossy());
+    fs::create_dir_all(tmp.path().join("workspace_state")).unwrap();
+    fs::write(
+        tmp.path()
+            .join("workspace_state")
+            .join(format!("{protected_workspace_key}.json")),
+        "{}",
+    )
+    .unwrap();
+    fs::create_dir_all(tmp.path().join("review-comments")).unwrap();
+    fs::write(
+        tmp.path()
+            .join("review-comments")
+            .join(format!("{protected_review_key}.events.json")),
+        "[]",
+    )
+    .unwrap();
+    fs::create_dir_all(tmp.path().join("agent-worktree-checkpoints")).unwrap();
+    fs::write(
+        tmp.path()
+            .join("agent-worktree-checkpoints")
+            .join(format!("{protected_workspace_key}.json")),
+        "{}",
+    )
+    .unwrap();
+
+    run_gc_with_runtime_protection(
+        tmp.path(),
+        Some(live_set(&[("live", live.path())])),
+        RuntimeProtection::new(
+            HashSet::from(["active".to_string(), "pid-live".to_string()]),
+            [missing.to_string_lossy().into_owned()],
+            protected,
+        ),
+        vec![ProcessRecord {
+            path: tmp.path().join("agent-processes/pid-live.json"),
+            session_id: Some("pid-live".to_string()),
+            status: ProcessRecordStatus::Live,
+        }],
+        NOW,
+    );
+
+    assert!(active.exists());
+    assert!(pid_live_archived.exists());
+    assert!(tmp.path().join("workflow_runs/running-run.json").exists());
+    assert!(tmp
+        .path()
+        .join("workspace_state")
+        .join(format!("{protected_workspace_key}.json"))
+        .exists());
+    assert!(tmp
+        .path()
+        .join("review-comments")
+        .join(format!("{protected_review_key}.events.json"))
+        .exists());
+    assert!(tmp
+        .path()
+        .join("agent-worktree-checkpoints")
+        .join(format!("{protected_workspace_key}.json"))
+        .exists());
+}
+
+#[test]
+fn sweep_revalidation_keeps_session_restored_after_plan() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let session = write_session(
+        tmp.path(),
+        "archived-session",
+        live.path(),
+        "archived",
+        NOW - RetentionPolicy::default().archived_log_secs as f64 - 1.0,
+    );
+    let request = startup_gc_request(
+        tmp.path(),
+        Some(full_resolution(live_set(&[("live", live.path())]))),
+        RuntimeProtection::default(),
+        Vec::new(),
+        NOW,
+    );
+    write_session(tmp.path(), "archived-session", live.path(), "idle", NOW);
+
+    run_startup_gc(
+        request,
+        &TestFs,
+        &TestArchivePruner,
+        &TestRevalidationReader,
+    );
+
+    assert!(session.exists());
+}
+
+#[test]
+fn sweep_revalidation_keeps_candidate_that_enters_runtime_protection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let live = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("missing-worktree");
+    let session = write_session(tmp.path(), "session", &missing, "idle", NOW);
+    let request = startup_gc_request(
+        tmp.path(),
+        Some(full_resolution(live_set(&[("live", live.path())]))),
+        RuntimeProtection::default(),
+        Vec::new(),
+        NOW,
+    );
+    let reader = RuntimeProtectionTestReader {
+        runtime_protection: RuntimeProtection::new(
+            HashSet::from(["session".to_string()]),
+            Vec::<String>::new(),
+            live_set(&[("missing", &missing)]),
+        ),
+    };
+
+    run_startup_gc(request, &TestFs, &TestArchivePruner, &reader);
+
+    assert!(session.exists());
+}
+
+struct RuntimeProtectionTestReader {
+    runtime_protection: RuntimeProtection,
+}
+
+impl GcRevalidationReader for RuntimeProtectionTestReader {
+    fn runtime_protection(
+        &self,
+        _app_data_dir: &std::path::Path,
+        _process_records: &[ProcessRecord],
+    ) -> RuntimeProtection {
+        self.runtime_protection.clone()
+    }
+
+    fn session_state(
+        &self,
+        app_data_dir: &std::path::Path,
+        session_id: &str,
+    ) -> RevalidationRead<CurrentSessionState> {
+        TestRevalidationReader.session_state(app_data_dir, session_id)
+    }
+
+    fn workflow_run_state(
+        &self,
+        app_data_dir: &std::path::Path,
+        run_id: &str,
+    ) -> RevalidationRead<CurrentWorkflowRunState> {
+        TestRevalidationReader.workflow_run_state(app_data_dir, run_id)
+    }
+}
+
+#[test]
+fn report_counts_deleted_entries_and_reclaimed_bytes() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("comments")).unwrap();
+    fs::write(tmp.path().join("comments/a.json"), "12345").unwrap();
+
+    let report = run_gc(tmp.path(), None, vec![], NOW);
+
+    assert_eq!(report.total_files, 1);
+    assert_eq!(report.total_bytes, 5);
+    assert_eq!(report.errors, 0);
+    assert_eq!(
+        report.categories[&GcCategory::LegacyComments].reclaimed_bytes,
+        5
+    );
+}
+
+#[test]
+fn fixture_normalized_worktree_path_trims_trailing_separators() {
+    let path = format!("{}///", std::env::temp_dir().display());
+    assert_eq!(
+        normalized_worktree_path(&path),
+        std::env::temp_dir()
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+    );
+}
+
+#[test]
+fn latest_mtime_uses_system_time() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(tmp.path().join("file"), "x").unwrap();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs_f64();
+    assert!(modified_secs(&tmp.path().join("file")).unwrap() <= now + 1.0);
+}

--- a/src-tauri/src/usecase/mod.rs
+++ b/src-tauri/src/usecase/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod agent_session;
 pub(crate) mod app_config;
+pub(crate) mod app_data_gc;
 pub(crate) mod code_dto;
 pub(crate) mod code_error;
 pub(crate) mod code_query_service;


### PR DESCRIPTION
## 概要

無期限に蓄積する app data を、復帰可能性ベースの削除ルールに従って安全に回収する backend GC を実装する。外部から観測可能な UI/CLI の振る舞いは追加せず、アプリ起動時の内部処理として動作する。

関連: #1372

## 削除対象

- 削除済み Workspace のログ（復帰不可のため削除）
- 使用中 Workspace のログ … Session/Workflow の状態別に判断
  - 削除済み Session/Workflow のログ → 削除
  - アーカイブ済み Session/Workflow のログ → 30 日超で削除
  - 使用中 → 削除しない
  - 再生成可能な cache → 状態に関わらず 7 日超で削除
- 旧形式 `comments` / `diff-comments` / `threads`（全削除）
- 参照切れ `tool_outputs` / `attachments` blob（ファイル単位で削除）
- stale な process / pid record（記録 pid が既に死んでいるもの）

## 実装

- `domain/app_data_gc` … 削除ルールの中核 domain logic
- `usecase/app_data_gc` … plan / sweep / request / ports
- `adaptor/gateway/app_data_gc` … filesystem 実装と wiring
- spec: `docs/specs/issues-1372/`（requirements / behavior / design）

## テスト

- `usecase/app_data_gc/tests.rs`・`test_fixtures.rs` で正常系/エラー系を網羅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 起動時にアプリ内データの不要ファイルを自動整理する仕組みを追加しました。
  * 削除件数や回収容量をログで確認できるようになりました。

* **改善**
  * 使用中のセッションやワークフロー、関連データはより安全に保持されるようになりました。
  * 期限切れのキャッシュや古いコメント、参照されなくなったファイルをより適切に削除します。

* **安定性向上**
  * 起動処理が長時間止まりにくいように見直しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->