### PR TITLE
feat: WorkflowDefinition 検証を段階別 structured Diagnostic に統合

### DIFF
--- a/src-tauri/src/adaptor/controller/command/workflow/definition.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/definition.rs
@@ -2,6 +2,19 @@ use crate::adaptor::controller::state::AppState;
 use crate::usecase::workflow::dto::{
     workflow_summary_to_dto, workflow_to_dto, WorkflowDto, WorkflowSummaryDto,
 };
+use crate::usecase::workflow::ports::WorkflowSourceSaveError;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct SaveWorkflowSourceResultDto {
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workflow: Option<WorkflowDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    diagnostics: Vec<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
 
 #[tauri::command]
 pub async fn list_workflows(
@@ -65,13 +78,26 @@ pub async fn save_workflow_source(
     state: tauri::State<'_, AppState>,
     source: String,
     original_name: Option<String>,
-) -> Result<WorkflowDto, String> {
+) -> Result<SaveWorkflowSourceResultDto, String> {
     let usecase = state.workflow_usecase.clone();
     tokio::task::spawn_blocking(move || {
-        usecase
-            .save_workflow_source(&source, original_name.as_deref())
-            .map(|workflow| workflow_to_dto(&workflow))
-            .map_err(|e| e.to_string())
+        match usecase.save_workflow_source_with_diagnostics(&source, original_name.as_deref()) {
+            Ok(workflow) => Ok(SaveWorkflowSourceResultDto {
+                ok: true,
+                workflow: Some(workflow_to_dto(&workflow)),
+                diagnostics: Vec::new(),
+                error: None,
+            }),
+            Err(WorkflowSourceSaveError::Diagnostics(diagnostics)) => {
+                Ok(SaveWorkflowSourceResultDto {
+                    ok: false,
+                    workflow: None,
+                    diagnostics,
+                    error: Some("workflow_diagnostics".to_string()),
+                })
+            }
+            Err(WorkflowSourceSaveError::Workflow(error)) => Err(error.to_string()),
+        }
     })
     .await
     .map_err(|e| format!("task join error: {e}"))?

--- a/src-tauri/src/adaptor/gateway/workflow/builtin.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use super::diagnostics;
 use super::domain_mapping::workflow_definition_to_domain;
 use super::facet::{self, FacetError, FacetKind};
 use super::schema::{Summary, Workflow};
@@ -103,6 +104,10 @@ pub enum BuiltinError {
         filename: &'static str,
         message: String,
     },
+    Diagnostics {
+        filename: &'static str,
+        diagnostics: Vec<diagnostics::DiagnosticItem>,
+    },
     Validation {
         filename: &'static str,
         source: ValidationError,
@@ -118,6 +123,17 @@ impl fmt::Display for BuiltinError {
         match self {
             Self::YamlParse { filename, message } => {
                 write!(f, "Invalid builtin workflow '{filename}': {message}")
+            }
+            Self::Diagnostics {
+                filename,
+                diagnostics,
+            } => {
+                let messages = diagnostics
+                    .iter()
+                    .map(|item| format!("{}: {}", item.code, item.message))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                write!(f, "Invalid builtin workflow '{filename}': {messages}")
             }
             Self::Validation { filename, source } => write!(
                 f,
@@ -156,11 +172,17 @@ pub fn load_builtin_workflow_resolved(name: &str) -> Result<Option<Workflow>, Bu
     else {
         return Ok(None);
     };
-    let mut wf: Workflow =
-        serde_saphyr::from_str(entry.content).map_err(|err| BuiltinError::YamlParse {
+    let diagnosis = diagnostics::diagnose_workflow_source(entry.content, Some(name));
+    if diagnosis.has_errors() {
+        return Err(BuiltinError::Diagnostics {
             filename: entry.filename,
-            message: err.to_string(),
-        })?;
+            diagnostics: diagnosis.diagnostics,
+        });
+    }
+    let mut wf: Workflow = diagnosis.workflow.ok_or_else(|| BuiltinError::YamlParse {
+        filename: entry.filename,
+        message: "workflow source could not be parsed".to_string(),
+    })?;
     wf.builtin = true;
     validation::validate(&workflow_definition_to_domain(&wf)).map_err(|err| {
         BuiltinError::Validation {
@@ -179,10 +201,15 @@ pub fn load_builtin_workflow_resolved(name: &str) -> Result<Option<Workflow>, Bu
                 filename: entry.filename,
                 source,
             },
+            storage::StorageError::Diagnostics(diagnostics) => BuiltinError::Diagnostics {
+                filename: entry.filename,
+                diagnostics,
+            },
             other => BuiltinError::Validation {
                 filename: entry.filename,
                 source: validation::ValidationError::InvalidArtifactReference {
                     reference: entry.filename.to_string(),
+                    kind: validation::InvalidArtifactReferenceKind::InvalidInputRef,
                     reason: other.to_string(),
                 },
             },

--- a/src-tauri/src/adaptor/gateway/workflow/definition_repository.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/definition_repository.rs
@@ -5,7 +5,7 @@ use crate::adaptor::gateway::workflow::{builtin, storage};
 use crate::domain::workflow::{
     validation, WorkflowDefinition, WorkflowDefinitionRepository, WorkflowError, WorkflowSummary,
 };
-use crate::usecase::workflow::ports::WorkflowDefinitionSourceGateway;
+use crate::usecase::workflow::ports::{WorkflowDefinitionSourceGateway, WorkflowSourceSaveError};
 
 use super::mapper;
 
@@ -188,6 +188,36 @@ impl WorkflowDefinitionSourceGateway for WorkflowDefinitionFileSourceGateway {
         remove_renamed_workflow_file_after_success(&self.workflows_dir, &plan)?;
         mapper::legacy_workflow_to_domain(saved)
     }
+
+    fn save_source_with_diagnostics(
+        &self,
+        source: &str,
+        original_name: Option<&str>,
+    ) -> Result<WorkflowDefinition, WorkflowSourceSaveError> {
+        let workflow = storage::parse_workflow_source(source, &self.facets_base_dir)
+            .map_err(storage_error_to_source_save_error)?;
+        let plan = validate_and_prepare_save(&self.workflows_dir, &workflow.name, original_name)
+            .map_err(WorkflowSourceSaveError::Workflow)?;
+        let saved =
+            storage::save_workflow_source(&self.workflows_dir, &self.facets_base_dir, source)
+                .map_err(storage_error_to_source_save_error)?;
+        remove_renamed_workflow_file_after_success(&self.workflows_dir, &plan)
+            .map_err(WorkflowSourceSaveError::Workflow)?;
+        mapper::legacy_workflow_to_domain(saved).map_err(WorkflowSourceSaveError::Workflow)
+    }
+}
+
+fn storage_error_to_source_save_error(error: storage::StorageError) -> WorkflowSourceSaveError {
+    match error {
+        storage::StorageError::Diagnostics(items) => {
+            let diagnostics = items
+                .into_iter()
+                .map(|item| serde_json::to_value(item).unwrap_or(serde_json::Value::Null))
+                .collect();
+            WorkflowSourceSaveError::Diagnostics(diagnostics)
+        }
+        other => WorkflowSourceSaveError::Workflow(WorkflowError::external(other.to_string())),
+    }
 }
 
 #[cfg(test)]
@@ -308,7 +338,9 @@ nodes:
             .unwrap_err();
         let loaded = gateway.get_source("stable").unwrap().unwrap();
 
-        assert!(err.to_string().contains("YAMLパース失敗"));
+        assert!(
+            matches!(err, WorkflowError::External(message) if message.contains("workflow_diagnostics") && message.contains("WFS005"))
+        );
         assert_eq!(loaded, original);
     }
 
@@ -358,7 +390,9 @@ nodes:
 
         let err = gateway.save_source(&source("-invalid"), None).unwrap_err();
 
-        assert!(err.to_string().contains("ワークフロー名"));
+        assert!(
+            matches!(err, WorkflowError::External(message) if message.contains("workflow_diagnostics") && message.contains("WFS006"))
+        );
         assert!(!workflows.path().join("-invalid.yml").exists());
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -3,9 +3,13 @@ use crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_do
 use crate::adaptor::gateway::workflow::facet::{self, FacetKind};
 use crate::adaptor::gateway::workflow::prompt_rendering;
 use crate::adaptor::gateway::workflow::schema::{NodeDefinition, ReduceStrategy, Rule, Workflow};
+use crate::adaptor::gateway::workflow::span_map::YamlSpanMap;
 use crate::domain::workflow::validation;
+use crate::domain::workflow::validation::{
+    InvalidArtifactReferenceKind, InvalidRuleKind, InvalidSchemaKind,
+};
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
 
 const ALL_FACET_KINDS: [FacetKind; 3] = [
@@ -14,7 +18,7 @@ const ALL_FACET_KINDS: [FacetKind; 3] = [
     FacetKind::Instruction,
 ];
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     Error,
@@ -24,7 +28,11 @@ pub enum Severity {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DiagnosticItem {
+    pub code: String,
     pub severity: Severity,
+    pub stage: DiagnosticStage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<DiagnosticSpan>,
     pub message: String,
     /// 対象の workflow 名（ファセット診断の場合は None）
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -41,6 +49,90 @@ pub struct DiagnosticItem {
     /// 対象フィールド
     #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticStage {
+    ParseShape,
+    Resolve,
+    Typecheck,
+    ControlFlow,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct DiagnosticSpan {
+    pub start_line: usize,
+    pub start_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+}
+
+impl DiagnosticSpan {
+    fn from_location(location: serde_saphyr::Location) -> Self {
+        let line = usize::try_from(location.line()).unwrap_or(usize::MAX);
+        let col = usize::try_from(location.column()).unwrap_or(usize::MAX);
+        Self {
+            start_line: line,
+            start_col: col,
+            end_line: line,
+            end_col: col.saturating_add(1),
+        }
+    }
+
+    fn from_scan_error(error: &serde_saphyr::granit_parser::ScanError) -> Self {
+        let marker = error.marker();
+        Self {
+            start_line: marker.line(),
+            start_col: marker.col() + 1,
+            end_line: marker.line(),
+            end_col: marker.col() + 2,
+        }
+    }
+}
+
+impl DiagnosticItem {
+    pub(crate) fn new(
+        code: impl Into<String>,
+        severity: Severity,
+        stage: DiagnosticStage,
+        span: Option<DiagnosticSpan>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            severity,
+            stage,
+            span,
+            message: message.into(),
+            workflow_name: None,
+            step_name: None,
+            facet_key: None,
+            facet_kind: None,
+            field: None,
+        }
+    }
+
+    fn workflow(mut self, name: impl Into<String>) -> Self {
+        self.workflow_name = Some(name.into());
+        self
+    }
+
+    fn step(mut self, name: impl Into<String>) -> Self {
+        self.step_name = Some(name.into());
+        self
+    }
+
+    fn facet(mut self, key: impl Into<String>, kind: impl Into<String>) -> Self {
+        self.facet_key = Some(key.into());
+        self.facet_kind = Some(kind.into());
+        self
+    }
+
+    fn field(mut self, field: impl Into<String>) -> Self {
+        self.field = Some(field.into());
+        self
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Default)]
@@ -68,6 +160,726 @@ pub struct FacetUsageEntry {
     pub slot: String,
 }
 
+type LoadedWorkflowDiagnostics = Result<(Workflow, Vec<DiagnosticItem>), Vec<DiagnosticItem>>;
+type NamedWorkflowDiagnostics = (String, LoadedWorkflowDiagnostics);
+
+#[derive(Debug, Clone)]
+pub(crate) struct WorkflowSourceDiagnostics {
+    pub(crate) workflow: Option<Workflow>,
+    pub(crate) diagnostics: Vec<DiagnosticItem>,
+}
+
+impl WorkflowSourceDiagnostics {
+    pub(crate) fn has_errors(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|item| item.severity == Severity::Error)
+    }
+}
+
+pub(crate) fn diagnose_workflow_source(
+    source: &str,
+    workflow_name_hint: Option<&str>,
+) -> WorkflowSourceDiagnostics {
+    let span_map = match YamlSpanMap::parse(source) {
+        Ok(span_map) => span_map,
+        Err(error) => {
+            return WorkflowSourceDiagnostics {
+                workflow: None,
+                diagnostics: vec![DiagnosticItem::new(
+                    "WFS001",
+                    Severity::Error,
+                    DiagnosticStage::ParseShape,
+                    Some(DiagnosticSpan::from_scan_error(&error)),
+                    format!("YAML syntax error: {error}"),
+                )
+                .workflow(workflow_name_hint.unwrap_or("<unknown>"))],
+            };
+        }
+    };
+
+    let raw_value = serde_saphyr::from_str::<serde_json::Value>(source).ok();
+    let mut diagnostics = raw_value
+        .as_ref()
+        .map(|value| parse_shape_diagnostics(value, &span_map, workflow_name_hint))
+        .unwrap_or_default();
+
+    if diagnostics
+        .iter()
+        .any(|item| item.severity == Severity::Error)
+    {
+        normalize_invalid_source_workflow_name(&mut diagnostics, workflow_name_hint);
+        return WorkflowSourceDiagnostics {
+            workflow: None,
+            diagnostics,
+        };
+    }
+
+    let workflow = match serde_saphyr::from_str::<Workflow>(source) {
+        Ok(workflow) => workflow,
+        Err(error) => {
+            diagnostics.push(deserialize_error_diagnostic(
+                &error,
+                &span_map,
+                workflow_name_hint,
+            ));
+            return WorkflowSourceDiagnostics {
+                workflow: None,
+                diagnostics,
+            };
+        }
+    };
+
+    diagnostics.extend(diagnose_workflow_definition(&workflow, Some(&span_map)));
+    WorkflowSourceDiagnostics {
+        workflow: Some(workflow),
+        diagnostics,
+    }
+}
+
+pub(crate) fn diagnose_workflow_definition(
+    wf: &Workflow,
+    span_map: Option<&YamlSpanMap>,
+) -> Vec<DiagnosticItem> {
+    let mut items = Vec::new();
+    let workflow = workflow_definition_to_domain(wf);
+    for error in validation::validate_all(&workflow) {
+        items.push(validation_error_to_diagnostic(wf, &error, span_map));
+    }
+    items
+}
+
+fn normalize_invalid_source_workflow_name(
+    diagnostics: &mut [DiagnosticItem],
+    workflow_name_hint: Option<&str>,
+) {
+    let Some(name) = workflow_name_hint else {
+        return;
+    };
+    for item in diagnostics {
+        item.workflow_name = Some(name.to_string());
+    }
+}
+
+fn parse_shape_diagnostics(
+    value: &serde_json::Value,
+    span_map: &YamlSpanMap,
+    workflow_name_hint: Option<&str>,
+) -> Vec<DiagnosticItem> {
+    let mut diagnostics = Vec::new();
+    let workflow_name = value
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .or(workflow_name_hint)
+        .unwrap_or("<unknown>");
+    let Some(root) = value.as_object() else {
+        diagnostics.push(
+            DiagnosticItem::new(
+                "WFS002",
+                Severity::Error,
+                DiagnosticStage::ParseShape,
+                span_map.nearest_span(""),
+                "workflow YAML must be a mapping",
+            )
+            .workflow(workflow_name),
+        );
+        return diagnostics;
+    };
+
+    check_allowed_fields(
+        root,
+        "",
+        &["name", "description", "builtin", "schemas", "nodes"],
+        &["steps", "variables"],
+        span_map,
+        workflow_name,
+        None,
+        &mut diagnostics,
+    );
+
+    if let Some(name) = root.get("name").and_then(serde_json::Value::as_str) {
+        if validation::validate_name(name).is_err() {
+            diagnostics.push(
+                DiagnosticItem::new(
+                    "WFS006",
+                    Severity::Error,
+                    DiagnosticStage::ParseShape,
+                    span_map.field_span("name"),
+                    format!("workflow name '{name}' is not a safe identifier"),
+                )
+                .workflow(name)
+                .field("name"),
+            );
+        }
+    }
+
+    let Some(nodes) = root.get("nodes").and_then(serde_json::Value::as_array) else {
+        return diagnostics;
+    };
+    let mut names = BTreeSet::new();
+    for (index, node) in nodes.iter().enumerate() {
+        let node_path = format!("nodes[{index}]");
+        let Some(node_obj) = node.as_object() else {
+            diagnostics.push(
+                DiagnosticItem::new(
+                    "WFS002",
+                    Severity::Error,
+                    DiagnosticStage::ParseShape,
+                    span_map.nearest_span(&node_path),
+                    "node must be a mapping",
+                )
+                .workflow(workflow_name)
+                .field("nodes"),
+            );
+            continue;
+        };
+        let step_name = node_obj
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("<unknown>");
+        check_allowed_fields(
+            node_obj,
+            &node_path,
+            &[
+                "name", "command", "session", "fanout", "artifact", "input", "inputs", "collect",
+                "rules",
+            ],
+            &[
+                "type",
+                "mode",
+                "facets",
+                "prompt",
+                "inline_prompt",
+                "output_contract",
+                "input_contracts",
+                "pass_output_from",
+                "pass_previous_response",
+                "variables",
+                "cycle_guard",
+                "resets_cycle_for",
+            ],
+            span_map,
+            workflow_name,
+            Some(step_name),
+            &mut diagnostics,
+        );
+        let kind_count = ["command", "session", "fanout"]
+            .iter()
+            .filter(|key| node_obj.contains_key(**key))
+            .count();
+        if kind_count != 1 {
+            diagnostics.push(
+                DiagnosticItem::new(
+                    "WFS003",
+                    Severity::Error,
+                    DiagnosticStage::ParseShape,
+                    span_map.nearest_span(&node_path),
+                    format!(
+                        "node '{step_name}' must contain exactly one kind block: command, session, or fanout"
+                    ),
+                )
+                .workflow(workflow_name)
+                .step(step_name)
+                .field("kind"),
+            );
+        }
+        if step_name == "request" || step_name == "item" {
+            diagnostics.push(
+                DiagnosticItem::new(
+                    "WFR004",
+                    Severity::Error,
+                    DiagnosticStage::Resolve,
+                    span_map.field_span(&format!("{node_path}.name")),
+                    format!("node name '{step_name}' is reserved"),
+                )
+                .workflow(workflow_name)
+                .step(step_name)
+                .field("name"),
+            );
+        }
+        if step_name != "<unknown>"
+            && (validation::validate_name(step_name).is_err() || !names.insert(step_name))
+        {
+            diagnostics.push(
+                DiagnosticItem::new(
+                    "WFS006",
+                    Severity::Error,
+                    DiagnosticStage::ParseShape,
+                    span_map.field_span(&format!("{node_path}.name")),
+                    format!("node name '{step_name}' is duplicated or invalid"),
+                )
+                .workflow(workflow_name)
+                .step(step_name)
+                .field("name"),
+            );
+        }
+        if node_obj.contains_key("fanout") {
+            for field in ["inputs", "collect"] {
+                if node_obj.contains_key(field) {
+                    diagnostics.push(kind_disallowed_diagnostic(
+                        workflow_name,
+                        step_name,
+                        "fanout",
+                        field,
+                        span_map.field_span(&format!("{node_path}.{field}")),
+                    ));
+                }
+            }
+        }
+        if node_obj.contains_key("command") && node_obj.contains_key("collect") {
+            diagnostics.push(kind_disallowed_diagnostic(
+                workflow_name,
+                step_name,
+                "command",
+                "collect",
+                span_map.field_span(&format!("{node_path}.collect")),
+            ));
+        }
+        if let Some(session) = node_obj
+            .get("session")
+            .and_then(serde_json::Value::as_object)
+        {
+            check_allowed_fields(
+                session,
+                &format!("{node_path}.session"),
+                &["model", "permission", "gate", "facets"],
+                &["mode", "prompt", "inline_prompt"],
+                span_map,
+                workflow_name,
+                Some(step_name),
+                &mut diagnostics,
+            );
+            if let Some(facets) = session.get("facets").and_then(serde_json::Value::as_object) {
+                check_allowed_fields(
+                    facets,
+                    &format!("{node_path}.session.facets"),
+                    &["policy", "knowledge", "instruction"],
+                    &[],
+                    span_map,
+                    workflow_name,
+                    Some(step_name),
+                    &mut diagnostics,
+                );
+            }
+        }
+        if let Some(fanout) = node_obj
+            .get("fanout")
+            .and_then(serde_json::Value::as_object)
+        {
+            check_allowed_fields(
+                fanout,
+                &format!("{node_path}.fanout"),
+                &["parallel_children", "aggregate"],
+                &[],
+                span_map,
+                workflow_name,
+                Some(step_name),
+                &mut diagnostics,
+            );
+            if let Some(children) = fanout
+                .get("parallel_children")
+                .and_then(serde_json::Value::as_array)
+            {
+                for (child_index, child) in children.iter().enumerate() {
+                    let child_path = format!("{node_path}.fanout.parallel_children[{child_index}]");
+                    if let Some(child_obj) = child.as_object() {
+                        let child_name = child_obj
+                            .get("name")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("<unknown>");
+                        check_allowed_fields(
+                            child_obj,
+                            &child_path,
+                            &["name", "model", "permission", "facets", "artifact", "input"],
+                            &["type", "mode", "prompt", "inline_prompt", "output_contract"],
+                            span_map,
+                            workflow_name,
+                            Some(child_name),
+                            &mut diagnostics,
+                        );
+                    }
+                }
+            }
+        }
+        if let Some(rules) = node_obj.get("rules").and_then(serde_json::Value::as_array) {
+            for (rule_index, rule) in rules.iter().enumerate() {
+                let rule_path = format!("{node_path}.rules[{rule_index}]");
+                let Some(rule_obj) = rule.as_object() else {
+                    continue;
+                };
+                check_allowed_fields(
+                    rule_obj,
+                    &rule_path,
+                    &["when", "switch", "loop_guard", "next"],
+                    &["match", "cycle_guard", "resets_cycle_for"],
+                    span_map,
+                    workflow_name,
+                    Some(step_name),
+                    &mut diagnostics,
+                );
+                let discriminator_count = ["when", "switch", "loop_guard"]
+                    .iter()
+                    .filter(|key| rule_obj.contains_key(**key))
+                    .count();
+                if discriminator_count > 1 {
+                    diagnostics.push(
+                        DiagnosticItem::new(
+                            "WFS003",
+                            Severity::Error,
+                            DiagnosticStage::ParseShape,
+                            span_map.nearest_span(&rule_path),
+                            "rule discriminator keys when, switch, and loop_guard are mutually exclusive",
+                        )
+                        .workflow(workflow_name)
+                        .step(step_name)
+                        .field("rules"),
+                    );
+                }
+            }
+        }
+    }
+
+    diagnostics
+}
+
+#[allow(clippy::too_many_arguments)]
+fn check_allowed_fields(
+    map: &serde_json::Map<String, serde_json::Value>,
+    path: &str,
+    allowed: &[&str],
+    old_fields: &[&str],
+    span_map: &YamlSpanMap,
+    workflow_name: &str,
+    step_name: Option<&str>,
+    diagnostics: &mut Vec<DiagnosticItem>,
+) {
+    for key in map.keys() {
+        if allowed.contains(&key.as_str()) {
+            continue;
+        }
+        let field_path = if path.is_empty() {
+            key.to_string()
+        } else {
+            format!("{path}.{key}")
+        };
+        let (code, message) = if old_fields.contains(&key.as_str()) {
+            (
+                "WFS005",
+                format!(
+                    "field '{key}' belongs to the old workflow syntax and is no longer accepted"
+                ),
+            )
+        } else {
+            (
+                "WFS002",
+                format!("unknown workflow field '{key}' is not allowed here"),
+            )
+        };
+        let mut item = DiagnosticItem::new(
+            code,
+            Severity::Error,
+            DiagnosticStage::ParseShape,
+            span_map.field_span(&field_path),
+            message,
+        )
+        .workflow(workflow_name)
+        .field(key);
+        if let Some(step_name) = step_name {
+            item = item.step(step_name);
+        }
+        diagnostics.push(item);
+    }
+}
+
+fn kind_disallowed_diagnostic(
+    workflow_name: &str,
+    step_name: &str,
+    kind: &str,
+    field: &str,
+    span: Option<DiagnosticSpan>,
+) -> DiagnosticItem {
+    DiagnosticItem::new(
+        "WFS004",
+        Severity::Error,
+        DiagnosticStage::ParseShape,
+        span,
+        format!("node '{step_name}' ({kind}) cannot declare '{field}'"),
+    )
+    .workflow(workflow_name)
+    .step(step_name)
+    .field(field)
+}
+
+fn deserialize_error_diagnostic(
+    error: &serde_saphyr::Error,
+    span_map: &YamlSpanMap,
+    workflow_name_hint: Option<&str>,
+) -> DiagnosticItem {
+    let message = error.to_string();
+    let code = if message.contains("old workflow syntax") {
+        "WFS005"
+    } else if message.contains("unknown field") || message.contains("unknown variant") {
+        "WFS002"
+    } else if message.contains("kind block")
+        || message.contains("requires sibling next")
+        || message.contains("rule discriminator")
+        || message.contains("invalid rule shape")
+    {
+        "WFS003"
+    } else if message.contains("YAML") || message.contains("syntax") {
+        "WFS001"
+    } else {
+        "WFS002"
+    };
+    let span = error
+        .location()
+        .map(DiagnosticSpan::from_location)
+        .or_else(|| span_map.nearest_span(""));
+    DiagnosticItem::new(
+        code,
+        Severity::Error,
+        DiagnosticStage::ParseShape,
+        span,
+        format!("workflow shape error: {message}"),
+    )
+    .workflow(workflow_name_hint.unwrap_or("<unknown>"))
+}
+
+fn validation_error_to_diagnostic(
+    wf: &Workflow,
+    error: &validation::ValidationError,
+    span_map: Option<&YamlSpanMap>,
+) -> DiagnosticItem {
+    let (code, stage) = validation_error_code_stage(error);
+    let (step_name, field) = validation_error_context(error);
+    let span = span_map.and_then(|map| span_for_validation_error(wf, error, map));
+    let mut item = DiagnosticItem::new(code, Severity::Error, stage, span, error.to_string())
+        .workflow(wf.name.clone());
+    if let Some(step_name) = step_name {
+        item = item.step(step_name);
+    }
+    if let Some(field) = field {
+        item = item.field(field);
+    }
+    item
+}
+
+fn validation_error_code_stage(
+    error: &validation::ValidationError,
+) -> (&'static str, DiagnosticStage) {
+    use validation::ValidationError;
+    let code = match error {
+        ValidationError::EmptyName
+        | ValidationError::InvalidChars { .. }
+        | ValidationError::EmptySteps
+        | ValidationError::DuplicateStep { .. }
+        | ValidationError::ParallelChildNameConflict { .. }
+        | ValidationError::EmptyCommand { .. }
+        | ValidationError::DisallowedFieldForKind { .. }
+        | ValidationError::TooManyNodes { .. }
+        | ValidationError::TooManyParallelChildren { .. } => "WFS006",
+        ValidationError::UnknownRuleTarget { .. }
+        | ValidationError::AggregateUnknownTarget { .. }
+        | ValidationError::UnknownCollectFrom { .. } => "WFR001",
+        ValidationError::UnknownSchemaRef { .. } => "WFR002",
+        ValidationError::InvalidSchemaRef { .. } => "WFR002",
+        ValidationError::InvalidSchema { kind, .. } => match kind {
+            InvalidSchemaKind::UnknownSchemaReference => "WFR002",
+            InvalidSchemaKind::InvalidDeclaration => "WFS002",
+        },
+        ValidationError::InvalidArtifactReference { kind, .. } => match kind {
+            InvalidArtifactReferenceKind::ReservedArtifactName => "WFR004",
+            InvalidArtifactReferenceKind::ItemOutOfScope => "WFR005",
+            InvalidArtifactReferenceKind::InputsNotAllowedOnFanout => "WFS004",
+            InvalidArtifactReferenceKind::UnknownNode
+            | InvalidArtifactReferenceKind::UnavailableArtifact
+            | InvalidArtifactReferenceKind::UnknownField
+            | InvalidArtifactReferenceKind::InvalidInputRef => "WFR003",
+        },
+        ValidationError::InvalidArtifactSchema { .. } => "WFT004",
+        ValidationError::ReservedArtifactField { .. } => "WFT005",
+        ValidationError::InvalidRules { kind, .. } => match kind {
+            InvalidRuleKind::WhenFieldNotBoolean => "WFT001",
+            InvalidRuleKind::SwitchFieldNotEnum | InvalidRuleKind::SwitchUnknownCase => "WFT002",
+            InvalidRuleKind::DiscriminatorOnFanout
+            | InvalidRuleKind::DiscriminatorWithoutArtifact => "WFT006",
+            InvalidRuleKind::SwitchMissingCases => "WFC004",
+            InvalidRuleKind::LoopGuardMaxIterations | InvalidRuleKind::CycleWithoutLoopGuard => {
+                "WFC005"
+            }
+            InvalidRuleKind::MultipleNextCatchAll
+            | InvalidRuleKind::SwitchExhaustiveHasNext
+            | InvalidRuleKind::SwitchRequiresNext => "WFC003",
+            InvalidRuleKind::MultipleDiscriminators
+            | InvalidRuleKind::MultipleLoopGuards
+            | InvalidRuleKind::StandaloneNextWithDiscriminator => "WFC002",
+        },
+        ValidationError::UnreachableNode { .. } => "WFC001",
+        ValidationError::AggregateInvalidConfig { .. } => "WFC002",
+        ValidationError::MissingFacet { .. }
+        | ValidationError::ParallelChildMissingFacet { .. } => "WFR900",
+        ValidationError::InvalidPermissionMode { .. }
+        | ValidationError::MissingPermissionMode { .. }
+        | ValidationError::UnknownModel { .. }
+        | ValidationError::InvalidModelFormat { .. }
+        | ValidationError::ModelResolutionFailed { .. } => "WFT900",
+    };
+    (code, stage_for_code(code))
+}
+
+fn stage_for_code(code: &str) -> DiagnosticStage {
+    if code.starts_with("WFR") {
+        DiagnosticStage::Resolve
+    } else if code.starts_with("WFT") {
+        DiagnosticStage::Typecheck
+    } else if code.starts_with("WFC") {
+        DiagnosticStage::ControlFlow
+    } else {
+        DiagnosticStage::ParseShape
+    }
+}
+
+fn span_for_validation_error(
+    wf: &Workflow,
+    error: &validation::ValidationError,
+    span_map: &YamlSpanMap,
+) -> Option<DiagnosticSpan> {
+    use validation::ValidationError;
+    match error {
+        ValidationError::InvalidSchema { schema, .. } => span_map
+            .field_span(&format!("schemas.{schema}"))
+            .or_else(|| span_map.field_span("schemas")),
+        ValidationError::InvalidArtifactReference { reference, .. } => {
+            input_reference_path(wf, reference)
+                .and_then(|path| span_map.field_span(&path))
+                .or_else(|| span_map.field_span("nodes"))
+        }
+        ValidationError::InvalidRules { step, kind, .. } => invalid_rule_path(wf, step, *kind)
+            .and_then(|path| span_map.field_span(&path))
+            .or_else(|| {
+                step_base_path(wf, step)
+                    .and_then(|path| span_map.field_span(&format!("{path}.rules")))
+            }),
+        ValidationError::UnreachableNode { step } => {
+            step_base_path(wf, step).and_then(|path| span_map.nearest_span(&path))
+        }
+        _ => {
+            let (step_name, field) = validation_error_context(error);
+            match (step_name.as_deref(), field.as_deref()) {
+                (Some(step_name), Some(field)) => step_field_path(wf, step_name, field)
+                    .and_then(|path| span_map.field_span(&path)),
+                (Some(step_name), None) => {
+                    step_base_path(wf, step_name).and_then(|path| span_map.nearest_span(&path))
+                }
+                (None, Some(field)) => span_map.field_span(field),
+                (None, None) => span_map.nearest_span(""),
+            }
+        }
+    }
+}
+
+fn input_reference_path(wf: &Workflow, reference: &str) -> Option<String> {
+    for (index, node) in wf.nodes.iter().enumerate() {
+        for (input_index, input) in node.inputs.iter().enumerate() {
+            if input == reference {
+                return Some(format!("nodes[{index}].inputs[{input_index}]"));
+            }
+        }
+    }
+    None
+}
+
+fn invalid_rule_path(wf: &Workflow, step_name: &str, kind: InvalidRuleKind) -> Option<String> {
+    let (base, node) = step_base_path_with_node(wf, step_name)?;
+    let suffix = match kind {
+        InvalidRuleKind::WhenFieldNotBoolean => {
+            rule_index(node, |rule| matches!(rule, Rule::When { .. }))
+                .map(|index| format!("rules[{index}].when.on"))
+        }
+        InvalidRuleKind::SwitchFieldNotEnum
+        | InvalidRuleKind::SwitchUnknownCase
+        | InvalidRuleKind::SwitchMissingCases => {
+            rule_index(node, |rule| matches!(rule, Rule::Switch { .. }))
+                .map(|index| format!("rules[{index}].switch.on"))
+        }
+        InvalidRuleKind::SwitchExhaustiveHasNext | InvalidRuleKind::SwitchRequiresNext => {
+            rule_index(node, |rule| matches!(rule, Rule::Switch { .. }))
+                .map(|index| format!("rules[{index}].next"))
+        }
+        InvalidRuleKind::LoopGuardMaxIterations => {
+            rule_index(node, |rule| matches!(rule, Rule::LoopGuard { .. }))
+                .map(|index| format!("rules[{index}].loop_guard.max_iterations"))
+        }
+        InvalidRuleKind::DiscriminatorOnFanout | InvalidRuleKind::DiscriminatorWithoutArtifact => {
+            rule_index(node, |rule| {
+                matches!(rule, Rule::When { .. } | Rule::Switch { .. })
+            })
+            .map(|index| format!("rules[{index}]"))
+        }
+        InvalidRuleKind::MultipleDiscriminators
+        | InvalidRuleKind::MultipleLoopGuards
+        | InvalidRuleKind::MultipleNextCatchAll
+        | InvalidRuleKind::StandaloneNextWithDiscriminator
+        | InvalidRuleKind::CycleWithoutLoopGuard => Some("rules".to_string()),
+    }?;
+    Some(format!("{base}.{suffix}"))
+}
+
+fn step_base_path_with_node<'a>(
+    wf: &'a Workflow,
+    step_name: &str,
+) -> Option<(String, &'a NodeDefinition)> {
+    for (index, node) in wf.nodes.iter().enumerate() {
+        if node.name == step_name {
+            return Some((format!("nodes[{index}]"), node));
+        }
+    }
+    None
+}
+
+fn rule_index(node: &NodeDefinition, matches_rule: impl Fn(&Rule) -> bool) -> Option<usize> {
+    node.rules.iter().position(matches_rule)
+}
+
+fn step_base_path(wf: &Workflow, step_name: &str) -> Option<String> {
+    for (index, node) in wf.nodes.iter().enumerate() {
+        if node.name == step_name {
+            return Some(format!("nodes[{index}]"));
+        }
+        if let Some(fanout) = node.fanout() {
+            for (child_index, child) in fanout.parallel_children.iter().enumerate() {
+                if child.name == step_name {
+                    return Some(format!(
+                        "nodes[{index}].fanout.parallel_children[{child_index}]"
+                    ));
+                }
+            }
+        }
+    }
+    None
+}
+
+fn step_field_path(wf: &Workflow, step_name: &str, field: &str) -> Option<String> {
+    let base = step_base_path(wf, step_name)?;
+    let suffix = if base.contains("parallel_children") {
+        match field {
+            "permission" | "model" | "artifact" | "input" | "facets" => field.to_string(),
+            field => field.replace("parallel_children.", ""),
+        }
+    } else {
+        match field {
+            "permission" | "model" => format!("session.{field}"),
+            "facets" => "session.facets".to_string(),
+            "rules.next" => "rules".to_string(),
+            "parallel_children" | "parallel_children.facets" => {
+                "fanout.parallel_children".to_string()
+            }
+            field => field.to_string(),
+        }
+    };
+    Some(format!("{base}.{suffix}"))
+}
+
 /// 全ワークフロー・全ファセットを走査し診断結果を返す
 pub fn diagnose_all(workflows_dir: &Path, facets_base_dir: &Path) -> DiagnosticReport {
     let mut items = Vec::new();
@@ -82,19 +894,15 @@ pub fn diagnose_all(workflows_dir: &Path, facets_base_dir: &Path) -> DiagnosticR
     let workflows = load_all_workflows(workflows_dir, facets_base_dir);
     for (name, wf_result) in &workflows {
         match wf_result {
-            Err(msg) => {
-                let item = DiagnosticItem {
-                    severity: Severity::Error,
-                    message: format!("ワークフロー '{name}' の読み込みに失敗: {msg}"),
-                    workflow_name: Some(name.clone()),
-                    step_name: None,
-                    facet_key: None,
-                    facet_kind: None,
-                    field: None,
-                };
-                add_diagnostic(&mut items, &mut workflow_summaries, name, item);
+            Err(diagnostics) => {
+                for item in diagnostics {
+                    add_diagnostic(&mut items, &mut workflow_summaries, name, item.clone());
+                }
             }
-            Ok(wf) => {
+            Ok((wf, source_diagnostics)) => {
+                for item in source_diagnostics {
+                    add_diagnostic(&mut items, &mut workflow_summaries, name, item.clone());
+                }
                 diagnose_workflow(
                     wf,
                     &all_facet_keys,
@@ -105,6 +913,15 @@ pub fn diagnose_all(workflows_dir: &Path, facets_base_dir: &Path) -> DiagnosticR
             }
         }
     }
+    let workflow_lookup: HashMap<&str, &Workflow> = workflows
+        .iter()
+        .filter_map(|(_, result)| {
+            result
+                .as_ref()
+                .ok()
+                .map(|(workflow, _)| (workflow.name.as_str(), workflow))
+        })
+        .collect();
 
     // --- ファセット診断 ---
     for kind in &ALL_FACET_KINDS {
@@ -114,36 +931,35 @@ pub fn diagnose_all(workflows_dir: &Path, facets_base_dir: &Path) -> DiagnosticR
 
             // ファセットキー命名規則チェック
             if facet::validate_facet_key(&summary.key).is_err() {
-                let item = DiagnosticItem {
-                    severity: Severity::Error,
-                    message: format!(
+                let item = DiagnosticItem::new(
+                    "FAC001",
+                    Severity::Error,
+                    DiagnosticStage::Resolve,
+                    None,
+                    format!(
                         "ファセットキー '{}' が命名規則に違反しています",
                         summary.key
                     ),
-                    workflow_name: None,
-                    step_name: None,
-                    facet_key: Some(summary.key.clone()),
-                    facet_kind: Some(kind.dir_name().to_string()),
-                    field: Some("key".to_string()),
-                };
+                )
+                .facet(summary.key.clone(), kind.dir_name().to_string())
+                .field("key");
                 add_diagnostic(&mut items, &mut facet_summaries, &facet_id, item);
             }
 
             // ビルトイン info
             if summary.builtin {
-                let item = DiagnosticItem {
-                    severity: Severity::Info,
-                    message: format!(
+                let item = DiagnosticItem::new(
+                    "FAC000",
+                    Severity::Info,
+                    DiagnosticStage::Resolve,
+                    None,
+                    format!(
                         "ビルトインファセット '{}' ({})",
                         summary.key,
                         kind.dir_name()
                     ),
-                    workflow_name: None,
-                    step_name: None,
-                    facet_key: Some(summary.key.clone()),
-                    facet_kind: Some(kind.dir_name().to_string()),
-                    field: None,
-                };
+                )
+                .facet(summary.key.clone(), kind.dir_name().to_string());
                 add_diagnostic(&mut items, &mut facet_summaries, &facet_id, item);
             }
 
@@ -155,6 +971,17 @@ pub fn diagnose_all(workflows_dir: &Path, facets_base_dir: &Path) -> DiagnosticR
                     kind.dir_name(),
                     &facet_id,
                     &mut items,
+                    &mut facet_summaries,
+                );
+                check_facet_template_references(
+                    &content,
+                    &summary.key,
+                    kind.dir_name(),
+                    &facet_id,
+                    &workflow_lookup,
+                    &facet_usage,
+                    &mut items,
+                    &mut workflow_summaries,
                     &mut facet_summaries,
                 );
             }
@@ -183,10 +1010,7 @@ fn collect_all_facet_keys(base_dir: &Path) -> HashSet<String> {
 }
 
 /// ディスク + builtin のワークフロー一覧を読み込み
-fn load_all_workflows(
-    dir: &Path,
-    facets_base_dir: &Path,
-) -> Vec<(String, Result<Workflow, String>)> {
+fn load_all_workflows(dir: &Path, facets_base_dir: &Path) -> Vec<NamedWorkflowDiagnostics> {
     let mut results = Vec::new();
 
     // ディスク上のカスタムワークフロー（validate() をスキップし全件走査）
@@ -198,14 +1022,26 @@ fn load_all_workflows(
                 if path.extension().and_then(|e| e.to_str()) == Some("yml") {
                     if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
                         let name = stem.to_string();
-                        let result = std::fs::read_to_string(&path)
-                            .map_err(|e| e.to_string())
-                            .and_then(|content| {
-                                let workflow = serde_saphyr::from_str::<Workflow>(&content)
-                                    .map_err(|e| e.to_string())?;
-                                let _ = facet::resolve_workflow_facets(&workflow, facets_base_dir);
-                                Ok(workflow)
-                            });
+                        let result = match std::fs::read_to_string(&path) {
+                            Ok(content) => {
+                                let diagnosis = diagnose_workflow_source(&content, Some(&name));
+                                if let Some(workflow) = diagnosis.workflow {
+                                    let _ =
+                                        facet::resolve_workflow_facets(&workflow, facets_base_dir);
+                                    Ok((workflow, diagnosis.diagnostics))
+                                } else {
+                                    Err(diagnosis.diagnostics)
+                                }
+                            }
+                            Err(error) => Err(vec![DiagnosticItem::new(
+                                "WFS001",
+                                Severity::Error,
+                                DiagnosticStage::ParseShape,
+                                None,
+                                format!("ワークフロー '{name}' の読み込みに失敗: {error}"),
+                            )
+                            .workflow(name.clone())]),
+                        };
                         seen.insert(name.clone());
                         results.push((name, result));
                     }
@@ -218,38 +1054,37 @@ fn load_all_workflows(
     for summary in builtin::list_builtin_workflows() {
         if !seen.contains(&summary.name) {
             match builtin::load_builtin_workflow_resolved(&summary.name) {
-                Ok(Some(wf)) => results.push((summary.name, Ok(wf))),
+                Ok(Some(wf)) => results.push((summary.name, Ok((wf, Vec::new())))),
                 Ok(None) => results.push((
                     summary.name.clone(),
-                    Err(format!(
-                        "ビルトインワークフロー '{}' の読み込みに失敗",
-                        summary.name
-                    )),
+                    Err(vec![DiagnosticItem::new(
+                        "WFS001",
+                        Severity::Error,
+                        DiagnosticStage::ParseShape,
+                        None,
+                        format!("ビルトインワークフロー '{}' の読み込みに失敗", summary.name),
+                    )
+                    .workflow(summary.name.clone())]),
                 )),
                 Err(err) => results.push((
                     summary.name.clone(),
-                    Err(format!(
-                        "ビルトインワークフロー '{}' の読み込みに失敗: {err}",
-                        summary.name
-                    )),
+                    Err(vec![DiagnosticItem::new(
+                        "WFS001",
+                        Severity::Error,
+                        DiagnosticStage::ParseShape,
+                        None,
+                        format!(
+                            "ビルトインワークフロー '{}' の読み込みに失敗: {err}",
+                            summary.name
+                        ),
+                    )
+                    .workflow(summary.name.clone())]),
                 )),
             }
         }
     }
 
     results
-}
-
-/// validation::validate() のエラーのうち、diagnose_workflow 側で個別にチェック済みのものを判定
-fn is_covered_by_diagnostics(e: &validation::ValidationError) -> bool {
-    use validation::ValidationError;
-    matches!(
-        e,
-        ValidationError::EmptyName
-            | ValidationError::InvalidChars { .. }
-            | ValidationError::MissingFacet { .. }
-            | ValidationError::UnknownCollectFrom { .. }
-    )
 }
 
 /// ValidationError からステップ名とフィールド名を抽出
@@ -278,9 +1113,15 @@ fn validation_error_context(e: &validation::ValidationError) -> (Option<String>,
             // （新 schema の YAML キーは個別だが、`MissingFacet` 側も "facets" 表現）。
             Some("parallel_children.facets".to_string()),
         ),
-        ValidationError::UnknownRuleTarget { step, .. }
-        | ValidationError::InvalidRules { step, .. } => {
+        ValidationError::UnknownRuleTarget { step, .. } => {
             (Some(step.clone()), Some("rules.next".to_string()))
+        }
+        ValidationError::InvalidRules { step, kind, .. } => (
+            Some(step.clone()),
+            Some(invalid_rule_field_name(*kind).to_string()),
+        ),
+        ValidationError::UnreachableNode { step } => {
+            (Some(step.clone()), Some("nodes".to_string()))
         }
         ValidationError::MissingFacet { step } => (Some(step.clone()), Some("facets".to_string())),
         ValidationError::UnknownCollectFrom { step, .. } => {
@@ -322,80 +1163,22 @@ fn validation_error_context(e: &validation::ValidationError) -> (Option<String>,
     }
 }
 
-/// ステップが完了後に定義順で暗黙進行する経路はない。
-/// rules なしは終端 node として扱う。
-fn can_advance_sequentially(step: &NodeDefinition) -> bool {
-    let _ = step;
-    false
-}
-
-/// 到達可能性の計算結果。
-struct ReachabilityResult<'a> {
-    /// 明示的遷移（rules.next, aggregate.then/else）+ 最初のステップで到達可能
-    explicitly_reachable: HashSet<&'a str>,
-    /// 明示的遷移 + 暗黙的順次進行を含めた全到達可能
-    all_reachable: HashSet<&'a str>,
-}
-
-/// 到達可能なステップ名の集合を計算する。
-/// 明示的遷移と暗黙的順次進行を区別して返す。
-fn compute_reachable_steps<'a>(
-    wf: &'a Workflow,
-    step_names: &HashSet<&'a str>,
-) -> ReachabilityResult<'a> {
-    let mut explicitly_reachable: HashSet<&str> = HashSet::new();
-
-    if let Some(first) = wf.nodes.first() {
-        explicitly_reachable.insert(&first.name);
-    }
-
-    // 明示的遷移先を収集
-    for step in &wf.nodes {
-        for rule in &step.rules {
-            for target in schema_rule_targets(rule) {
-                if step_names.contains(target) {
-                    explicitly_reachable.insert(target);
-                }
-            }
-        }
-        if let Some(agg) = step.fanout().and_then(|fanout| fanout.aggregate.as_ref()) {
-            if step_names.contains(agg.then.as_str()) {
-                explicitly_reachable.insert(&agg.then);
-            }
-            if step_names.contains(agg.r#else.as_str()) {
-                explicitly_reachable.insert(&agg.r#else);
-            }
-        }
-    }
-
-    // 暗黙的順次進行を伝播（到達可能なステップから次ステップへ）
-    let mut all_reachable = explicitly_reachable.clone();
-    loop {
-        let mut added = false;
-        for (i, step) in wf.nodes.iter().enumerate() {
-            if !all_reachable.contains(step.name.as_str()) {
-                continue;
-            }
-            if i + 1 >= wf.nodes.len() {
-                continue;
-            }
-            let next = &wf.nodes[i + 1];
-            if all_reachable.contains(next.name.as_str()) {
-                continue;
-            }
-            if can_advance_sequentially(step) {
-                all_reachable.insert(&next.name);
-                added = true;
-            }
-        }
-        if !added {
-            break;
-        }
-    }
-
-    ReachabilityResult {
-        explicitly_reachable,
-        all_reachable,
+fn invalid_rule_field_name(kind: InvalidRuleKind) -> &'static str {
+    match kind {
+        InvalidRuleKind::WhenFieldNotBoolean => "rules.when.on",
+        InvalidRuleKind::SwitchFieldNotEnum
+        | InvalidRuleKind::SwitchUnknownCase
+        | InvalidRuleKind::SwitchMissingCases => "rules.switch.on",
+        InvalidRuleKind::SwitchExhaustiveHasNext
+        | InvalidRuleKind::SwitchRequiresNext
+        | InvalidRuleKind::MultipleNextCatchAll => "rules.next",
+        InvalidRuleKind::LoopGuardMaxIterations => "rules.loop_guard.max_iterations",
+        InvalidRuleKind::DiscriminatorOnFanout
+        | InvalidRuleKind::DiscriminatorWithoutArtifact
+        | InvalidRuleKind::MultipleDiscriminators
+        | InvalidRuleKind::MultipleLoopGuards
+        | InvalidRuleKind::StandaloneNextWithDiscriminator
+        | InvalidRuleKind::CycleWithoutLoopGuard => "rules",
     }
 }
 
@@ -408,90 +1191,22 @@ fn diagnose_workflow(
 ) {
     let name = &wf.name;
 
-    // バリデーション（validate_all）を実行し、
-    // 診断側で個別チェックしていない項目をエラーとして報告
-    let workflow = workflow_definition_to_domain(wf);
-    for e in validation::validate_all(&workflow) {
-        let (step_name, field) = validation_error_context(&e);
-        if !is_covered_by_diagnostics(&e) {
-            let item = DiagnosticItem {
-                severity: Severity::Error,
-                message: e.to_string(),
-                workflow_name: Some(name.clone()),
-                step_name,
-                facet_key: None,
-                facet_kind: None,
-                field,
-            };
-            add_diagnostic(items, workflow_summaries, name, item);
-        }
-    }
-
-    // workflow名の命名規則チェック
-    if validation::validate_name(name).is_err() {
-        let item = DiagnosticItem {
-            severity: Severity::Error,
-            message: format!("ワークフロー名 '{name}' が命名規則に違反しています"),
-            workflow_name: Some(name.clone()),
-            step_name: None,
-            facet_key: None,
-            facet_kind: None,
-            field: Some("name".to_string()),
-        };
-        add_diagnostic(items, workflow_summaries, name, item);
-    }
-
     // ビルトイン info
     if wf.builtin {
-        let item = DiagnosticItem {
-            severity: Severity::Info,
-            message: format!("ビルトインワークフロー '{name}'"),
-            workflow_name: Some(name.clone()),
-            step_name: None,
-            facet_key: None,
-            facet_kind: None,
-            field: None,
-        };
+        let item = DiagnosticItem::new(
+            "WFI000",
+            Severity::Info,
+            DiagnosticStage::Resolve,
+            None,
+            format!("ビルトインワークフロー '{name}'"),
+        )
+        .workflow(name.clone());
         add_diagnostic(items, workflow_summaries, name, item);
     }
-
-    // step名の集合（到達可能性チェック・遷移先チェック用、トップレベルstep名のみ）
-    let step_names: HashSet<&str> = wf.nodes.iter().map(|s| s.name.as_str()).collect();
-    // 先行step名の集合（collect.from のチェック用）
-    // validation.rs と同じロジック: collect.from は先行ステップのみ参照可能
-    let mut preceding_step_names: HashSet<&str> = HashSet::new();
-    let reachability = compute_reachable_steps(wf, &step_names);
 
     // 各stepを診断
     for step in &wf.nodes {
-        // collect.from 参照チェック（先行stepのみ参照可能）
         if let Some(ref collect) = step.collect {
-            for from in &collect.from {
-                if !preceding_step_names.contains(from.as_str()) {
-                    let msg = if step_names.contains(from.as_str()) {
-                        format!(
-                            "ステップ '{}' のcollect.fromがまだ定義されていないステップ '{}' を参照しています（先行ステップのみ参照可能）",
-                            step.name, from
-                        )
-                    } else {
-                        format!(
-                            "ステップ '{}' のcollect.fromが存在しないステップ '{}' を参照しています",
-                            step.name, from
-                        )
-                    };
-                    let item = DiagnosticItem {
-                        severity: Severity::Error,
-                        message: msg,
-                        workflow_name: Some(name.clone()),
-                        step_name: Some(step.name.clone()),
-                        facet_key: None,
-                        facet_kind: None,
-                        field: Some("collect.from".to_string()),
-                    };
-                    add_diagnostic(items, workflow_summaries, name, item);
-                }
-            }
-
             // collect元stepにrulesがないwarning
             if matches!(
                 collect.reduce,
@@ -500,18 +1215,19 @@ fn diagnose_workflow(
                 for from in &collect.from {
                     if let Some(source_step) = wf.nodes.iter().find(|s| s.name == *from) {
                         if source_step.rules.is_empty() && !source_step.is_fanout() {
-                            let item = DiagnosticItem {
-                                severity: Severity::Warning,
-                                message: format!(
+                            let item = DiagnosticItem::new(
+                                "WFC900",
+                                Severity::Warning,
+                                DiagnosticStage::ControlFlow,
+                                None,
+                                format!(
                                     "collect元ステップ '{}' にrulesが未設定です（{:?}リデュースで結果がNoneになる可能性）",
                                     from, collect.reduce
                                 ),
-                                workflow_name: Some(name.clone()),
-                                step_name: Some(step.name.clone()),
-                                facet_key: None,
-                                facet_kind: None,
-                                field: Some("collect.reduce".to_string()),
-                            };
+                            )
+                            .workflow(name.clone())
+                            .step(step.name.clone())
+                            .field("collect.reduce");
                             add_diagnostic(items, workflow_summaries, name, item);
                         }
                     }
@@ -536,20 +1252,6 @@ fn diagnose_workflow(
                 },
             );
 
-        // command/fanout は実行構造を kind block に持つため facet は不要。
-        if step.is_session() && step.collect.is_none() && !step.has_facet_refs() {
-            let item = DiagnosticItem {
-                severity: Severity::Error,
-                message: format!("ステップ '{}' にはファセット参照が必要です", step.name),
-                workflow_name: Some(name.clone()),
-                step_name: Some(step.name.clone()),
-                facet_key: None,
-                facet_kind: None,
-                field: Some("facets".to_string()),
-            };
-            add_diagnostic(items, workflow_summaries, name, item);
-        }
-
         // parallel block の子step 診断
         if let Some(fanout) = step.fanout() {
             let children = &fanout.parallel_children;
@@ -571,64 +1273,6 @@ fn diagnose_workflow(
                 );
             }
         }
-
-        // 到達可能性チェック（最初のstepを除く）
-        if wf.nodes.first().map(|s| &s.name) != Some(&step.name) {
-            let step_str = step.name.as_str();
-            if !reachability.all_reachable.contains(step_str) {
-                // 明示的にも暗黙的にも到達不能
-                let item = DiagnosticItem {
-                    severity: Severity::Warning,
-                    message: format!(
-                        "ステップ '{}' はどこからも遷移されません（到達不能）",
-                        step.name
-                    ),
-                    workflow_name: Some(name.clone()),
-                    step_name: Some(step.name.clone()),
-                    facet_key: None,
-                    facet_kind: None,
-                    field: None,
-                };
-                add_diagnostic(items, workflow_summaries, name, item);
-            } else if !reachability.explicitly_reachable.contains(step_str) {
-                // 暗黙的順次進行でのみ到達可能 → 明示的遷移を推奨
-                let item = DiagnosticItem {
-                    severity: Severity::Warning,
-                    message: format!(
-                        "ステップ '{}' への明示的な遷移が定義されていません（暗黙的な順次進行で到達）",
-                        step.name
-                    ),
-                    workflow_name: Some(name.clone()),
-                    step_name: Some(step.name.clone()),
-                    facet_key: None,
-                    facet_kind: None,
-                    field: None,
-                };
-                add_diagnostic(items, workflow_summaries, name, item);
-            }
-        }
-
-        // preceding_step_names を更新（validation.rs と同じロジック）
-        preceding_step_names.insert(&step.name);
-        if let Some(fanout) = step.fanout() {
-            let children = &fanout.parallel_children;
-            for child in children {
-                preceding_step_names.insert(&child.name);
-            }
-        }
-    }
-}
-
-fn schema_rule_targets(rule: &Rule) -> Vec<&str> {
-    match rule {
-        Rule::When { then, next, .. } => vec![then.as_str(), next.as_str()],
-        Rule::Switch { cases, next, .. } => cases
-            .values()
-            .map(String::as_str)
-            .chain(next.iter().map(String::as_str))
-            .collect(),
-        Rule::LoopGuard { on_exhausted, .. } => vec![on_exhausted.as_str()],
-        Rule::Next(next) => vec![next.as_str()],
     }
 }
 
@@ -683,20 +1327,22 @@ impl<'a> FacetRefCheckContext<'a> {
             });
 
         if !self.all_facet_keys.contains(&facet_id) {
-            let item = DiagnosticItem {
-                severity: Severity::Error,
-                message: format!(
+            let item = DiagnosticItem::new(
+                "FAC002",
+                Severity::Error,
+                DiagnosticStage::Resolve,
+                None,
+                format!(
                     "ステップ '{}' が存在しないファセット '{}' ({}) を参照しています",
                     step_name,
                     key,
                     kind.dir_name()
                 ),
-                workflow_name: Some(self.workflow_name.to_string()),
-                step_name: Some(step_name.to_string()),
-                facet_key: Some(key.to_string()),
-                facet_kind: Some(kind.dir_name().to_string()),
-                field: Some(slot.to_string()),
-            };
+            )
+            .workflow(self.workflow_name.to_string())
+            .step(step_name.to_string())
+            .facet(key.to_string(), kind.dir_name().to_string())
+            .field(slot.to_string());
             add_diagnostic(
                 self.items,
                 self.workflow_summaries,
@@ -734,20 +1380,112 @@ fn check_template_variables(
     facet_summaries: &mut HashMap<String, DiagnosticSummary>,
 ) {
     for var_name in prompt_rendering::find_undefined_template_variables(content) {
-        let item = DiagnosticItem {
-            severity: Severity::Error,
-            message: format!(
+        let item = DiagnosticItem::new(
+            "FAC003",
+            Severity::Error,
+            DiagnosticStage::Resolve,
+            None,
+            format!(
                 "ファセット '{}' に未定義のテンプレート変数 '{{{{{}}}}}' が含まれています",
                 facet_key, var_name
             ),
-            workflow_name: None,
-            step_name: None,
-            facet_key: Some(facet_key.to_string()),
-            facet_kind: Some(facet_kind_name.to_string()),
-            field: Some("content".to_string()),
-        };
+        )
+        .facet(facet_key.to_string(), facet_kind_name.to_string())
+        .field("content");
         add_diagnostic(items, facet_summaries, facet_id, item);
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn check_facet_template_references(
+    content: &str,
+    facet_key: &str,
+    facet_kind_name: &str,
+    facet_id: &str,
+    workflow_lookup: &HashMap<&str, &Workflow>,
+    facet_usage: &HashMap<String, Vec<FacetUsageEntry>>,
+    items: &mut Vec<DiagnosticItem>,
+    workflow_summaries: &mut HashMap<String, DiagnosticSummary>,
+    facet_summaries: &mut HashMap<String, DiagnosticSummary>,
+) {
+    let Some(usages) = facet_usage.get(facet_id) else {
+        return;
+    };
+    for usage in usages {
+        let Some(workflow) = workflow_lookup.get(usage.workflow_name.as_str()).copied() else {
+            continue;
+        };
+        let domain_workflow = workflow_definition_to_domain(workflow);
+        let allow_item = facet_usage_allows_item(workflow, &usage.step_name);
+        for error in validation::validate_template_references(&domain_workflow, content, allow_item)
+        {
+            let span = facet_template_error_span(content, &error);
+            let mut item = validation_error_to_diagnostic(workflow, &error, None)
+                .facet(facet_key.to_string(), facet_kind_name.to_string())
+                .step(usage.step_name.clone())
+                .field("content");
+            item.span = span;
+            add_diagnostic_to_workflow_and_facet(
+                items,
+                workflow_summaries,
+                &usage.workflow_name,
+                facet_summaries,
+                facet_id,
+                item,
+            );
+        }
+    }
+}
+
+fn facet_usage_allows_item(workflow: &Workflow, step_name: &str) -> bool {
+    workflow.nodes.iter().any(|node| {
+        node.fanout().is_some_and(|fanout| {
+            fanout
+                .parallel_children
+                .iter()
+                .any(|child| child.name == step_name)
+        })
+    })
+}
+
+fn facet_template_error_span(
+    content: &str,
+    error: &validation::ValidationError,
+) -> Option<DiagnosticSpan> {
+    let validation::ValidationError::InvalidArtifactReference { reference, .. } = error else {
+        return None;
+    };
+    template_reference_span(content, reference)
+}
+
+fn template_reference_span(content: &str, reference: &str) -> Option<DiagnosticSpan> {
+    for (line_index, line) in content.lines().enumerate() {
+        let mut search_start = 0usize;
+        while let Some(open_rel) = line[search_start..].find("{{") {
+            let open = search_start + open_rel;
+            let inner_start = open + 2;
+            let Some(close_rel) = line[inner_start..].find("}}") else {
+                break;
+            };
+            let close = inner_start + close_rel;
+            let template_reference = line[inner_start..close].trim();
+            if template_reference == reference
+                || template_reference
+                    .strip_prefix(reference)
+                    .is_some_and(|rest| rest.starts_with('.'))
+            {
+                let end = close + 2;
+                return Some(DiagnosticSpan {
+                    start_line: line_index + 1,
+                    start_col: line[..open].chars().count() + 1,
+                    end_line: line_index + 1,
+                    end_col: line[..end].chars().count() + 1,
+                });
+            }
+            search_start = close + 2;
+        }
+    }
+    None
 }
 
 fn add_diagnostic(
@@ -756,13 +1494,34 @@ fn add_diagnostic(
     key: &str,
     item: DiagnosticItem,
 ) {
+    increment_summary(summaries, key, item.severity);
+    items.push(item);
+}
+
+fn add_diagnostic_to_workflow_and_facet(
+    items: &mut Vec<DiagnosticItem>,
+    workflow_summaries: &mut HashMap<String, DiagnosticSummary>,
+    workflow_key: &str,
+    facet_summaries: &mut HashMap<String, DiagnosticSummary>,
+    facet_key: &str,
+    item: DiagnosticItem,
+) {
+    increment_summary(workflow_summaries, workflow_key, item.severity);
+    increment_summary(facet_summaries, facet_key, item.severity);
+    items.push(item);
+}
+
+fn increment_summary(
+    summaries: &mut HashMap<String, DiagnosticSummary>,
+    key: &str,
+    severity: Severity,
+) {
     let summary = summaries.entry(key.to_string()).or_default();
-    match item.severity {
+    match severity {
         Severity::Error => summary.error_count += 1,
         Severity::Warning => summary.warning_count += 1,
         Severity::Info => summary.info_count += 1,
     }
-    items.push(item);
 }
 
 #[cfg(test)]
@@ -833,6 +1592,468 @@ mod tests {
         fs::create_dir_all(dir).unwrap();
         let content = serde_saphyr::to_string(wf).unwrap();
         fs::write(dir.join(format!("{}.yml", wf.name)), content).unwrap();
+    }
+
+    fn fixture_dir(kind: &str) -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/adaptor/gateway/workflow/fixtures")
+            .join(kind)
+    }
+
+    fn expected_stage_for_code(code: &str) -> DiagnosticStage {
+        match &code[..3] {
+            "WFR" => DiagnosticStage::Resolve,
+            "WFT" => DiagnosticStage::Typecheck,
+            "WFC" => DiagnosticStage::ControlFlow,
+            _ => DiagnosticStage::ParseShape,
+        }
+    }
+
+    #[test]
+    fn workflow_fixture_suite_valid_has_no_error_diagnostics() {
+        for entry in fs::read_dir(fixture_dir("valid")).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("yml") {
+                continue;
+            }
+            let source = fs::read_to_string(&path).unwrap();
+            let diagnosis =
+                diagnose_workflow_source(&source, path.file_stem().and_then(|stem| stem.to_str()));
+            let errors = diagnosis
+                .diagnostics
+                .iter()
+                .filter(|item| item.severity == Severity::Error)
+                .collect::<Vec<_>>();
+            assert!(
+                errors.is_empty(),
+                "valid fixture {} produced errors: {errors:?}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn workflow_fixture_suite_invalid_fixes_expected_diagnostic_code() {
+        for entry in fs::read_dir(fixture_dir("invalid")).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("yml") {
+                continue;
+            }
+            let filename = path.file_name().and_then(|name| name.to_str()).unwrap();
+            let expected_code = filename.split('_').next().unwrap();
+            let source = fs::read_to_string(&path).unwrap();
+            let diagnosis = diagnose_workflow_source(&source, Some(filename));
+            let matching = diagnosis
+                .diagnostics
+                .iter()
+                .filter(|item| item.code == expected_code)
+                .collect::<Vec<_>>();
+            assert!(
+                !matching.is_empty(),
+                "invalid fixture {} did not produce expected code {expected_code}: {:?}",
+                path.display(),
+                diagnosis.diagnostics
+            );
+            assert!(
+                matching
+                    .iter()
+                    .any(|item| item.stage == expected_stage_for_code(expected_code)),
+                "fixture {} produced {expected_code} with wrong stage: {matching:?}",
+                path.display()
+            );
+            assert!(
+                matching.iter().any(|item| item.span.is_some()),
+                "fixture {} expected {expected_code} to carry a span: {matching:?}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_source_diagnostics_use_file_stem_workflow_key() {
+        let tmp = TempDir::new().unwrap();
+        let wf_dir = tmp.path();
+        fs::write(
+            wf_dir.join("file-stem.yml"),
+            r#"
+name: yaml-name
+description: invalid workflow with mismatched name
+nodes:
+  - name: implement
+    type: agent
+    session:
+      permission: edit
+      facets:
+        instruction: implement
+"#,
+        )
+        .unwrap();
+
+        let report = diagnose_all(wf_dir, wf_dir);
+        let summary = report
+            .workflow_summaries
+            .get("file-stem")
+            .expect("invalid workflow summary must use file stem");
+        let items = report
+            .items
+            .iter()
+            .filter(|item| item.workflow_name.as_deref() == Some("file-stem"))
+            .collect::<Vec<_>>();
+        assert_eq!(summary.error_count, items.len());
+        assert!(
+            !report
+                .items
+                .iter()
+                .any(|item| item.workflow_name.as_deref() == Some("yaml-name")),
+            "invalid source diagnostics must not be keyed by YAML name: {:?}",
+            report.items
+        );
+    }
+
+    #[test]
+    fn diagnose_all_validates_facet_templates_with_workflow_context() {
+        let tmp = TempDir::new().unwrap();
+        let wf_dir = tmp.path();
+        setup_facet(
+            wf_dir,
+            "instructions",
+            "bad",
+            "Use {{ missing_node }} and {{ item.path }}",
+        );
+        let wf = Workflow {
+            name: "semantic-template".to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            schemas: Default::default(),
+            nodes: vec![make_step("step1", Some("bad"))],
+        };
+        save_workflow_yaml(wf_dir, &wf);
+
+        let report = diagnose_all(wf_dir, wf_dir);
+        for code in ["WFR003", "WFR005"] {
+            assert!(
+                report.items.iter().any(|item| item.code == code
+                    && item.workflow_name.as_deref() == Some("semantic-template")
+                    && item.step_name.as_deref() == Some("step1")
+                    && item.facet_key.as_deref() == Some("bad")
+                    && item.field.as_deref() == Some("content")
+                    && item.span.is_some()),
+                "expected semantic facet diagnostic {code}, got: {:?}",
+                report.items
+            );
+        }
+        let workflow_summary = report
+            .workflow_summaries
+            .get("semantic-template")
+            .expect("semantic facet errors must count toward workflow summary");
+        assert!(workflow_summary.error_count >= 2);
+        let facet_summary = report
+            .facet_summaries
+            .get("instructions/bad")
+            .expect("semantic facet errors must count toward facet summary");
+        assert!(facet_summary.error_count >= 2);
+    }
+
+    #[test]
+    fn invalid_rule_span_points_to_specific_rule_field() {
+        let source =
+            fs::read_to_string(fixture_dir("invalid").join("WFT001_when-on-enum.yml")).unwrap();
+        let span_map = YamlSpanMap::parse(&source).unwrap();
+        let expected = span_map
+            .field_span("nodes[0].rules[0].when.on")
+            .expect("fixture must have when.on span");
+        let diagnosis = diagnose_workflow_source(&source, Some("WFT001_when-on-enum"));
+        let item = diagnosis
+            .diagnostics
+            .iter()
+            .find(|item| item.code == "WFT001")
+            .expect("fixture must produce WFT001");
+        assert_eq!(item.field.as_deref(), Some("rules.when.on"));
+        assert_eq!(item.span, Some(expected));
+    }
+
+    #[test]
+    fn unreachable_subgraph_targets_are_not_marked_reachable() {
+        let source =
+            fs::read_to_string(fixture_dir("invalid").join("WFC001_unreachable-subgraph.yml"))
+                .unwrap();
+        let diagnosis = diagnose_workflow_source(&source, Some("unreachable-subgraph"));
+        for step_name in ["orphan", "target"] {
+            assert!(
+                diagnosis
+                    .diagnostics
+                    .iter()
+                    .any(|item| item.code == "WFC001"
+                        && item.stage == DiagnosticStage::ControlFlow
+                        && item.step_name.as_deref() == Some(step_name)),
+                "expected WFC001 for {step_name}, got: {:?}",
+                diagnosis.diagnostics
+            );
+        }
+    }
+
+    #[test]
+    fn validation_error_code_stage_uses_typed_variants() {
+        let cases = vec![
+            (
+                validation::ValidationError::InvalidSchema {
+                    schema: "list".to_string(),
+                    kind: InvalidSchemaKind::UnknownSchemaReference,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFR002",
+                DiagnosticStage::Resolve,
+            ),
+            (
+                validation::ValidationError::InvalidSchema {
+                    schema: "bad".to_string(),
+                    kind: InvalidSchemaKind::InvalidDeclaration,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFS002",
+                DiagnosticStage::ParseShape,
+            ),
+            (
+                validation::ValidationError::InvalidArtifactReference {
+                    reference: "request".to_string(),
+                    kind: InvalidArtifactReferenceKind::ReservedArtifactName,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFR004",
+                DiagnosticStage::Resolve,
+            ),
+            (
+                validation::ValidationError::InvalidArtifactReference {
+                    reference: "item".to_string(),
+                    kind: InvalidArtifactReferenceKind::ItemOutOfScope,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFR005",
+                DiagnosticStage::Resolve,
+            ),
+            (
+                validation::ValidationError::InvalidArtifactReference {
+                    reference: "fanout".to_string(),
+                    kind: InvalidArtifactReferenceKind::InputsNotAllowedOnFanout,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFS004",
+                DiagnosticStage::ParseShape,
+            ),
+            (
+                validation::ValidationError::InvalidArtifactReference {
+                    reference: "missing".to_string(),
+                    kind: InvalidArtifactReferenceKind::UnknownNode,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFR003",
+                DiagnosticStage::Resolve,
+            ),
+            (
+                validation::ValidationError::InvalidArtifactReference {
+                    reference: "plan".to_string(),
+                    kind: InvalidArtifactReferenceKind::UnavailableArtifact,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFR003",
+                DiagnosticStage::Resolve,
+            ),
+            (
+                validation::ValidationError::InvalidArtifactReference {
+                    reference: "plan.field".to_string(),
+                    kind: InvalidArtifactReferenceKind::UnknownField,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFR003",
+                DiagnosticStage::Resolve,
+            ),
+            (
+                validation::ValidationError::InvalidArtifactReference {
+                    reference: "bad ref".to_string(),
+                    kind: InvalidArtifactReferenceKind::InvalidInputRef,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFR003",
+                DiagnosticStage::Resolve,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::WhenFieldNotBoolean,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFT001",
+                DiagnosticStage::Typecheck,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::SwitchFieldNotEnum,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFT002",
+                DiagnosticStage::Typecheck,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::SwitchUnknownCase,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFT002",
+                DiagnosticStage::Typecheck,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::DiscriminatorOnFanout,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFT006",
+                DiagnosticStage::Typecheck,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::DiscriminatorWithoutArtifact,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFT006",
+                DiagnosticStage::Typecheck,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::SwitchMissingCases,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFC004",
+                DiagnosticStage::ControlFlow,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::CycleWithoutLoopGuard,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFC005",
+                DiagnosticStage::ControlFlow,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::LoopGuardMaxIterations,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFC005",
+                DiagnosticStage::ControlFlow,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::SwitchRequiresNext,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFC003",
+                DiagnosticStage::ControlFlow,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::SwitchExhaustiveHasNext,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFC003",
+                DiagnosticStage::ControlFlow,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::MultipleNextCatchAll,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFC003",
+                DiagnosticStage::ControlFlow,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::MultipleDiscriminators,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFC002",
+                DiagnosticStage::ControlFlow,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::MultipleLoopGuards,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFC002",
+                DiagnosticStage::ControlFlow,
+            ),
+            (
+                validation::ValidationError::InvalidRules {
+                    step: "route".to_string(),
+                    kind: InvalidRuleKind::StandaloneNextWithDiscriminator,
+                    reason: "renamed wording".to_string(),
+                },
+                "WFC002",
+                DiagnosticStage::ControlFlow,
+            ),
+            (
+                validation::ValidationError::UnreachableNode {
+                    step: "orphan".to_string(),
+                },
+                "WFC001",
+                DiagnosticStage::ControlFlow,
+            ),
+        ];
+
+        for (error, expected_code, expected_stage) in cases {
+            let (code, stage) = validation_error_code_stage(&error);
+            assert_eq!(code, expected_code, "wrong code for {error:?}");
+            assert_eq!(stage, expected_stage, "wrong stage for {error:?}");
+        }
+    }
+
+    #[test]
+    fn deserialize_error_diagnostic_classifies_error_messages() {
+        let span_map = YamlSpanMap::parse("name: sample\nnodes: []\n").unwrap();
+        let cases = [
+            ("old workflow syntax field", "WFS005"),
+            ("unknown field `type`", "WFS002"),
+            ("when rule requires sibling next", "WFS003"),
+            ("YAML syntax problem", "WFS001"),
+            ("unclassified deserialize problem", "WFS002"),
+        ];
+
+        for (message, expected_code) in cases {
+            let error = <serde_saphyr::Error as serde::de::Error>::custom(message);
+            let item = deserialize_error_diagnostic(&error, &span_map, Some("sample"));
+            assert_eq!(item.code, expected_code, "wrong code for {message}");
+            assert_eq!(item.stage, DiagnosticStage::ParseShape);
+        }
+    }
+
+    #[test]
+    fn builtin_workflows_have_zero_validation_diagnostics() {
+        for summary in builtin::list_builtin_workflows() {
+            let workflow = builtin::load_builtin_workflow_resolved(&summary.name)
+                .unwrap_or_else(|error| panic!("builtin {} failed to load: {error}", summary.name))
+                .unwrap_or_else(|| panic!("builtin {} not found", summary.name));
+            let diagnostics = diagnose_workflow_definition(&workflow, None);
+            let errors = diagnostics
+                .iter()
+                .filter(|item| item.severity == Severity::Error)
+                .collect::<Vec<_>>();
+            assert!(
+                errors.is_empty(),
+                "builtin {} produced diagnostics: {errors:?}",
+                summary.name
+            );
+        }
     }
 
     #[test]
@@ -1148,10 +2369,11 @@ mod tests {
 
         let report = diagnose_all(wf_dir, wf_dir);
         assert!(
-            report.items.iter().any(|i| i.severity == Severity::Warning
-                && i.message.contains("到達不能")
+            report.items.iter().any(|i| i.code == "WFC001"
+                && i.severity == Severity::Error
+                && i.stage == DiagnosticStage::ControlFlow
                 && i.step_name.as_deref() == Some("orphan")),
-            "Expected unreachable warning for orphan, got: {:?}",
+            "Expected WFC001 for orphan, got: {:?}",
             report.items
         );
     }
@@ -1179,10 +2401,11 @@ mod tests {
         let report = diagnose_all(wf_dir, wf_dir);
         for step_name in ["step2", "step3"] {
             assert!(
-                report.items.iter().any(|i| i.severity == Severity::Warning
-                    && i.message.contains("到達不能")
+                report.items.iter().any(|i| i.code == "WFC001"
+                    && i.severity == Severity::Error
+                    && i.stage == DiagnosticStage::ControlFlow
                     && i.step_name.as_deref() == Some(step_name)),
-                "Expected unreachable warning for {step_name}, got: {:?}",
+                "Expected WFC001 for {step_name}, got: {:?}",
                 report.items
             );
         }
@@ -1339,10 +2562,10 @@ mod tests {
         fs::write(wf_dir.join("bad workflow.yml"), content).unwrap();
 
         let report = diagnose_all(wf_dir, wf_dir);
-        assert!(report
-            .items
-            .iter()
-            .any(|i| i.severity == Severity::Error && i.message.contains("命名規則に違反")));
+        assert!(report.items.iter().any(|i| i.code == "WFS006"
+            && i.severity == Severity::Error
+            && i.stage == DiagnosticStage::ParseShape
+            && i.field.as_deref() == Some("name")));
     }
 
     #[test]
@@ -1472,10 +2695,12 @@ nodes:
 
         let report = diagnose_all(wf_dir, wf_dir);
         assert!(
-            report.items.iter().any(|i| i.severity == Severity::Error
+            report.items.iter().any(|i| i.code == "WFS006"
+                && i.severity == Severity::Error
+                && i.stage == DiagnosticStage::ParseShape
                 && i.workflow_name.as_deref() == Some("dup-step")
-                && i.message.contains("重複")),
-            "Expected duplicate step error, got: {:?}",
+                && i.field.as_deref() == Some("name")),
+            "Expected WFS006 duplicate step error, got: {:?}",
             report.items
         );
     }
@@ -1552,11 +2777,12 @@ nodes:
 
         let report = diagnose_all(wf_dir, wf_dir);
         assert!(
-            report.items.iter().any(|i| i.severity == Severity::Error
+            report.items.iter().any(|i| i.code == "WFR001"
+                && i.severity == Severity::Error
+                && i.stage == DiagnosticStage::Resolve
                 && i.step_name.as_deref() == Some("step1")
-                && i.field.as_deref() == Some("collect.from")
-                && i.message.contains("まだ定義されていないステップ")),
-            "Expected subsequent step reference error for collect.from, got: {:?}",
+                && i.field.as_deref() == Some("collect.from")),
+            "Expected WFR001 for collect.from, got: {:?}",
             report.items
         );
     }

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC001_unreachable-node.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC001_unreachable-node.yml
@@ -1,0 +1,13 @@
+name: unreachable-node
+description: second node is not reachable without a rule
+nodes:
+  - name: entry
+    session:
+      permission: edit
+      facets:
+        instruction: entry
+  - name: orphan
+    session:
+      permission: edit
+      facets:
+        instruction: orphan

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC001_unreachable-subgraph.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC001_unreachable-subgraph.yml
@@ -1,0 +1,20 @@
+name: unreachable-subgraph
+description: unreachable subgraph edges do not make targets reachable
+nodes:
+  - name: entry
+    session:
+      permission: edit
+      facets:
+        instruction: entry
+  - name: orphan
+    session:
+      permission: edit
+      facets:
+        instruction: orphan
+    rules:
+      - next: target
+  - name: target
+    session:
+      permission: edit
+      facets:
+        instruction: target

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC002_multiple-discriminators.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC002_multiple-discriminators.yml
@@ -1,0 +1,44 @@
+name: multiple-discriminators
+description: only one discriminator rule is allowed
+schemas:
+  verdict:
+    type: object
+    properties:
+      passed:
+        type: boolean
+      decision:
+        type: string
+        enum:
+          - done
+          - fix
+    required:
+      - passed
+      - decision
+    additionalProperties: false
+nodes:
+  - name: judge
+    artifact: verdict
+    session:
+      permission: edit
+      facets:
+        instruction: judge
+    rules:
+      - when:
+          on: passed
+          then: done
+        next: fix
+      - switch:
+          on: decision
+          cases:
+            done: done
+            fix: fix
+  - name: done
+    session:
+      permission: edit
+      facets:
+        instruction: done
+  - name: fix
+    session:
+      permission: edit
+      facets:
+        instruction: fix

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC003_multiple-next-catch-all.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC003_multiple-next-catch-all.yml
@@ -1,0 +1,16 @@
+name: multiple-next-catch-all
+description: only one next catch-all is allowed
+nodes:
+  - name: route
+    session:
+      permission: edit
+      facets:
+        instruction: route
+    rules:
+      - next: done
+      - next: done
+  - name: done
+    session:
+      permission: edit
+      facets:
+        instruction: done

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC004_switch-missing-cases.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC004_switch-missing-cases.yml
@@ -1,0 +1,31 @@
+name: switch-missing-cases
+description: non-exhaustive switch requires next
+schemas:
+  verdict:
+    type: object
+    properties:
+      decision:
+        type: string
+        enum:
+          - done
+          - fix
+    required:
+      - decision
+    additionalProperties: false
+nodes:
+  - name: judge
+    artifact: verdict
+    session:
+      permission: edit
+      facets:
+        instruction: judge
+    rules:
+      - switch:
+          on: decision
+          cases:
+            done: done
+  - name: done
+    session:
+      permission: edit
+      facets:
+        instruction: done

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC005_cycle-without-loop-guard.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC005_cycle-without-loop-guard.yml
@@ -1,0 +1,17 @@
+name: cycle-without-loop-guard
+description: cycle must have loop_guard
+nodes:
+  - name: first
+    session:
+      permission: edit
+      facets:
+        instruction: first
+    rules:
+      - next: second
+  - name: second
+    session:
+      permission: edit
+      facets:
+        instruction: second
+    rules:
+      - next: first

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR001_unknown-rule-target.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR001_unknown-rule-target.yml
@@ -1,0 +1,10 @@
+name: unknown-rule-target
+description: next points to a missing node
+nodes:
+  - name: implement
+    session:
+      permission: edit
+      facets:
+        instruction: implement
+    rules:
+      - next: missing

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR002_unknown-schema-ref.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR002_unknown-schema-ref.yml
@@ -1,0 +1,9 @@
+name: unknown-schema-ref
+description: input references a missing schema
+nodes:
+  - name: consume
+    input: missing-contract
+    session:
+      permission: edit
+      facets:
+        instruction: consume

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR003_unknown-template-ref.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR003_unknown-template-ref.yml
@@ -1,0 +1,5 @@
+name: unknown-template-ref
+description: command template references a missing artifact node
+nodes:
+  - name: run
+    command: "echo {{ missing_node }}"

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR004_reserved-artifact-name.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR004_reserved-artifact-name.yml
@@ -1,0 +1,8 @@
+name: reserved-artifact-name
+description: request is reserved
+nodes:
+  - name: request
+    session:
+      permission: edit
+      facets:
+        instruction: request

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR005_item-out-of-scope.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR005_item-out-of-scope.yml
@@ -1,0 +1,5 @@
+name: item-out-of-scope
+description: item is only available in fanout child scope
+nodes:
+  - name: run
+    command: "echo {{ item.path }}"

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS003_missing-kind.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS003_missing-kind.yml
@@ -1,0 +1,5 @@
+name: missing-kind
+description: node without kind block
+nodes:
+  - name: implement
+    artifact: result

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS005_legacy-type-field.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS005_legacy-type-field.yml
@@ -1,0 +1,9 @@
+name: legacy-type-field
+description: old node type field
+nodes:
+  - name: implement
+    type: agent
+    session:
+      permission: edit
+      facets:
+        instruction: implement

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT001_when-on-enum.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT001_when-on-enum.yml
@@ -1,0 +1,31 @@
+name: when-on-enum
+description: when.on must be boolean
+schemas:
+  verdict:
+    type: object
+    properties:
+      decision:
+        type: string
+        enum:
+          - done
+          - retry
+    required:
+      - decision
+    additionalProperties: false
+nodes:
+  - name: judge
+    artifact: verdict
+    session:
+      permission: edit
+      facets:
+        instruction: judge
+    rules:
+      - when:
+          on: decision
+          then: done
+        next: done
+  - name: done
+    session:
+      permission: edit
+      facets:
+        instruction: done

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT002_switch-on-boolean.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT002_switch-on-boolean.yml
@@ -1,0 +1,29 @@
+name: switch-on-boolean
+description: switch.on must be enum
+schemas:
+  verdict:
+    type: object
+    properties:
+      passed:
+        type: boolean
+    required:
+      - passed
+    additionalProperties: false
+nodes:
+  - name: judge
+    artifact: verdict
+    session:
+      permission: edit
+      facets:
+        instruction: judge
+    rules:
+      - switch:
+          on: passed
+          cases:
+            "true": done
+        next: done
+  - name: done
+    session:
+      permission: edit
+      facets:
+        instruction: done

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT004_invalid-artifact-schema.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT004_invalid-artifact-schema.yml
@@ -1,0 +1,12 @@
+name: invalid-artifact-schema
+description: artifact must reference an object schema
+schemas:
+  verdict:
+    type: string
+nodes:
+  - name: judge
+    artifact: verdict
+    session:
+      permission: edit
+      facets:
+        instruction: judge

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT005_reserved-artifact-field.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT005_reserved-artifact-field.yml
@@ -1,0 +1,15 @@
+name: reserved-artifact-field
+description: command artifact schema cannot declare command reserved fields
+schemas:
+  output:
+    type: object
+    properties:
+      ok:
+        type: boolean
+    required:
+      - ok
+    additionalProperties: false
+nodes:
+  - name: build
+    artifact: output
+    command: cargo test

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT006_fanout-discriminator.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT006_fanout-discriminator.yml
@@ -1,0 +1,30 @@
+name: fanout-discriminator
+description: fanout nodes cannot use discriminator rules
+schemas:
+  verdict:
+    type: object
+    properties:
+      passed:
+        type: boolean
+    required:
+      - passed
+    additionalProperties: false
+nodes:
+  - name: fanout
+    artifact: verdict
+    fanout:
+      parallel_children:
+        - name: child
+          permission: edit
+          facets:
+            instruction: child
+    rules:
+      - when:
+          on: passed
+          then: done
+        next: done
+  - name: done
+    session:
+      permission: edit
+      facets:
+        instruction: done

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/minimal-session.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/minimal-session.yml
@@ -1,0 +1,8 @@
+name: minimal-session
+description: valid single node workflow
+nodes:
+  - name: implement
+    session:
+      permission: edit
+      facets:
+        instruction: implement

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/routed-switch.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/routed-switch.yml
@@ -1,0 +1,37 @@
+name: routed-switch
+description: valid switch routing
+schemas:
+  verdict:
+    type: object
+    properties:
+      decision:
+        type: string
+        enum:
+          - done
+          - retry
+    required:
+      - decision
+    additionalProperties: false
+nodes:
+  - name: judge
+    artifact: verdict
+    session:
+      permission: edit
+      facets:
+        instruction: judge
+    rules:
+      - switch:
+          on: decision
+          cases:
+            done: done
+            retry: retry
+  - name: done
+    session:
+      permission: edit
+      facets:
+        instruction: done
+  - name: retry
+    session:
+      permission: edit
+      facets:
+        instruction: retry

--- a/src-tauri/src/adaptor/gateway/workflow/mod.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/mod.rs
@@ -55,6 +55,7 @@ pub(crate) mod runtime_state;
 pub(crate) mod schema;
 pub(crate) mod secret_source;
 mod secret_source_gateway;
+pub(crate) mod span_map;
 pub(crate) mod state;
 mod state_notification_gateway;
 mod state_projection_repository;

--- a/src-tauri/src/adaptor/gateway/workflow/schema.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/schema.rs
@@ -199,10 +199,6 @@ impl NodeDefinition {
         self.kind.name()
     }
 
-    pub fn is_session(&self) -> bool {
-        matches!(self.kind, NodeKind::Session(_))
-    }
-
     pub fn is_approval_session(&self) -> bool {
         self.session()
             .is_some_and(|session| session.gate == SessionGate::Approval)

--- a/src-tauri/src/adaptor/gateway/workflow/span_map.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/span_map.rs
@@ -1,0 +1,306 @@
+use std::collections::BTreeMap;
+
+use serde_saphyr::granit_parser::{Event, Parser, ScanError, Span as ParserSpan};
+
+use super::diagnostics::DiagnosticSpan;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct YamlSpanMap {
+    value_spans: BTreeMap<String, DiagnosticSpan>,
+    key_spans: BTreeMap<String, DiagnosticSpan>,
+}
+
+impl YamlSpanMap {
+    pub(crate) fn parse(source: &str) -> Result<Self, ScanError> {
+        let mut parser = Parser::new_from_str(source);
+        let mut events = Vec::new();
+        while let Some(event) = parser.next_event() {
+            events.push(event?);
+        }
+        let mut cursor = EventCursor { events, index: 0 };
+        let mut map = Self::default();
+        while let Some((event, span)) = cursor.peek().cloned() {
+            match event {
+                Event::StreamStart
+                | Event::StreamEnd
+                | Event::DocumentStart(_, _)
+                | Event::DocumentEnd
+                | Event::Comment(_, _) => {
+                    cursor.bump();
+                }
+                _ => {
+                    parse_node(&mut cursor, String::new(), &mut map)?;
+                    if let Some(span) = diagnostic_span(&span) {
+                        map.value_spans.entry(String::new()).or_insert(span);
+                    }
+                }
+            }
+        }
+        Ok(map)
+    }
+
+    pub(crate) fn value_span(&self, path: &str) -> Option<DiagnosticSpan> {
+        self.value_spans.get(path).copied()
+    }
+
+    pub(crate) fn key_span(&self, path: &str) -> Option<DiagnosticSpan> {
+        self.key_spans.get(path).copied()
+    }
+
+    pub(crate) fn nearest_span(&self, path: &str) -> Option<DiagnosticSpan> {
+        let mut current = path.to_string();
+        loop {
+            if let Some(span) = self
+                .value_span(&current)
+                .or_else(|| self.key_span(&current))
+            {
+                return Some(span);
+            }
+            let Some(parent) = parent_path(&current) else {
+                break;
+            };
+            current = parent;
+        }
+        self.value_span("")
+    }
+
+    pub(crate) fn field_span(&self, path: &str) -> Option<DiagnosticSpan> {
+        self.key_span(path)
+            .or_else(|| self.value_span(path))
+            .or_else(|| self.nearest_span(path))
+    }
+}
+
+struct EventCursor<'input> {
+    events: Vec<(Event<'input>, ParserSpan)>,
+    index: usize,
+}
+
+impl<'input> EventCursor<'input> {
+    fn peek(&self) -> Option<&(Event<'input>, ParserSpan)> {
+        self.events.get(self.index)
+    }
+
+    fn bump(&mut self) -> Option<(Event<'input>, ParserSpan)> {
+        let event = self.events.get(self.index).cloned();
+        self.index += usize::from(event.is_some());
+        event
+    }
+}
+
+fn parse_node(
+    cursor: &mut EventCursor<'_>,
+    path: String,
+    map: &mut YamlSpanMap,
+) -> Result<(), ScanError> {
+    let Some((event, span)) = cursor.bump() else {
+        return Ok(());
+    };
+    if let Some(span) = diagnostic_span(&span) {
+        map.value_spans.entry(path.clone()).or_insert(span);
+    }
+    match event {
+        Event::MappingStart(_, _, _) => parse_mapping(cursor, path, map),
+        Event::SequenceStart(_, _, _) => parse_sequence(cursor, path, map),
+        Event::Alias(_)
+        | Event::Scalar(_, _, _, _)
+        | Event::Nothing
+        | Event::StreamStart
+        | Event::StreamEnd
+        | Event::DocumentStart(_, _)
+        | Event::DocumentEnd
+        | Event::SequenceEnd
+        | Event::MappingEnd
+        | Event::Comment(_, _) => Ok(()),
+    }
+}
+
+fn parse_mapping(
+    cursor: &mut EventCursor<'_>,
+    path: String,
+    map: &mut YamlSpanMap,
+) -> Result<(), ScanError> {
+    loop {
+        skip_presentation_events(cursor);
+        let Some((event, _)) = cursor.peek() else {
+            return Ok(());
+        };
+        if matches!(event, Event::MappingEnd) {
+            cursor.bump();
+            return Ok(());
+        }
+        let key = match cursor.bump() {
+            Some((Event::Scalar(value, _, _, _), span)) => {
+                let span = diagnostic_span(&span).expect("parser spans always have coordinates");
+                let child = child_path(&path, &value);
+                map.key_spans.insert(child.clone(), span);
+                (child, span)
+            }
+            Some((_, _)) => continue,
+            None => return Ok(()),
+        };
+        parse_node(cursor, key.0, map)?;
+    }
+}
+
+fn parse_sequence(
+    cursor: &mut EventCursor<'_>,
+    path: String,
+    map: &mut YamlSpanMap,
+) -> Result<(), ScanError> {
+    let mut index = 0usize;
+    loop {
+        skip_presentation_events(cursor);
+        let Some((event, _)) = cursor.peek() else {
+            return Ok(());
+        };
+        if matches!(event, Event::SequenceEnd) {
+            cursor.bump();
+            return Ok(());
+        }
+        parse_node(cursor, format!("{path}[{index}]"), map)?;
+        index += 1;
+    }
+}
+
+fn skip_presentation_events(cursor: &mut EventCursor<'_>) {
+    while let Some((event, _)) = cursor.peek() {
+        match event {
+            Event::Comment(_, _)
+            | Event::DocumentStart(_, _)
+            | Event::DocumentEnd
+            | Event::StreamStart
+            | Event::StreamEnd => {
+                cursor.bump();
+            }
+            _ => break,
+        }
+    }
+}
+
+fn child_path(parent: &str, key: &str) -> String {
+    if parent.is_empty() {
+        key.to_string()
+    } else {
+        format!("{parent}.{key}")
+    }
+}
+
+fn parent_path(path: &str) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
+    if let Some(prefix) = path.strip_suffix(']') {
+        let start = prefix.rfind('[')?;
+        return Some(prefix[..start].to_string());
+    }
+    path.rsplit_once('.')
+        .map(|(parent, _)| parent.to_string())
+        .or_else(|| Some(String::new()))
+}
+
+fn diagnostic_span(span: &ParserSpan) -> Option<DiagnosticSpan> {
+    Some(DiagnosticSpan {
+        start_line: span.start.line(),
+        start_col: span.start.col() + 1,
+        end_line: span.end.line(),
+        end_col: span.end.col() + 1,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE: &str = r#"name: span-test
+schemas:
+  review:
+    type: object
+nodes:
+  - name: entry
+    session:
+      permission: edit
+      facets:
+        instruction: entry
+    rules:
+      - when:
+          on: passed
+          then: done
+        next: done
+  - name: done
+    session:
+      permission: edit
+"#;
+
+    #[test]
+    fn field_span_uses_exact_key_coordinates_with_one_based_columns() {
+        let map = YamlSpanMap::parse(SOURCE).unwrap();
+
+        assert_eq!(
+            map.field_span("name"),
+            Some(DiagnosticSpan {
+                start_line: 1,
+                start_col: 1,
+                end_line: 1,
+                end_col: 5,
+            })
+        );
+        assert_eq!(
+            map.field_span("nodes[0].rules[0].when.on"),
+            Some(DiagnosticSpan {
+                start_line: 13,
+                start_col: 11,
+                end_line: 13,
+                end_col: 13,
+            })
+        );
+    }
+
+    #[test]
+    fn sequence_index_paths_are_recorded_for_nested_items() {
+        let map = YamlSpanMap::parse(SOURCE).unwrap();
+
+        assert_eq!(
+            map.key_span("nodes[1].name"),
+            Some(DiagnosticSpan {
+                start_line: 16,
+                start_col: 5,
+                end_line: 16,
+                end_col: 9,
+            })
+        );
+        assert!(map.value_span("nodes[0].rules[0]").is_some());
+        assert!(map.value_span("nodes[1]").is_some());
+    }
+
+    #[test]
+    fn nearest_span_falls_back_to_nearest_parent_not_root() {
+        let map = YamlSpanMap::parse(SOURCE).unwrap();
+        let nearest_parent = map.nearest_span("nodes[0].rules[0].when").unwrap();
+        let missing_child = map
+            .nearest_span("nodes[0].rules[0].when.missing_field")
+            .unwrap();
+
+        assert_eq!(missing_child, nearest_parent);
+        assert_ne!(missing_child, map.value_span("").unwrap());
+    }
+
+    #[test]
+    fn parent_path_handles_sequence_indices_and_dotted_keys() {
+        assert_eq!(parent_path("nodes[0]").as_deref(), Some("nodes"));
+        assert_eq!(
+            parent_path("nodes[0].rules[0]").as_deref(),
+            Some("nodes[0].rules")
+        );
+        assert_eq!(
+            parent_path("nodes[0].rules[0].when.on").as_deref(),
+            Some("nodes[0].rules[0].when")
+        );
+        assert_eq!(
+            parent_path("schemas.review.properties.status").as_deref(),
+            Some("schemas.review.properties")
+        );
+        assert_eq!(parent_path("name").as_deref(), Some(""));
+        assert_eq!(parent_path("").as_deref(), None);
+    }
+}

--- a/src-tauri/src/adaptor/gateway/workflow/storage.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/storage.rs
@@ -1,4 +1,5 @@
 use super::builtin;
+use super::diagnostics;
 use super::domain_mapping::workflow_definition_to_domain;
 use super::facet;
 use super::schema::{Summary, Workflow};
@@ -13,6 +14,7 @@ pub enum StorageError {
     Io(std::io::Error),
     YamlDeserialize(serde_saphyr::Error),
     YamlSerialize(serde_saphyr::ser::Error),
+    Diagnostics(Vec<diagnostics::DiagnosticItem>),
     Validation(ValidationError),
     FacetResolution(facet::FacetError),
     NotFound { name: String },
@@ -25,6 +27,14 @@ impl fmt::Display for StorageError {
             Self::Io(e) => write!(f, "I/Oエラー: {e}"),
             Self::YamlDeserialize(e) => write!(f, "YAMLパース失敗: {e}"),
             Self::YamlSerialize(e) => write!(f, "YAMLシリアライズ失敗: {e}"),
+            Self::Diagnostics(items) => {
+                let messages = items
+                    .iter()
+                    .map(|item| format!("{}: {}", item.code, item.message))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                write!(f, "workflow_diagnostics: {messages}")
+            }
             Self::Validation(e) => write!(f, "validation_error: {e}"),
             Self::FacetResolution(e) => write!(f, "facet解決失敗: {e}"),
             Self::NotFound { name } => {
@@ -43,6 +53,7 @@ impl std::error::Error for StorageError {
             Self::Io(e) => Some(e),
             Self::YamlDeserialize(e) => Some(e),
             Self::YamlSerialize(e) => Some(e),
+            Self::Diagnostics(_) => None,
             Self::Validation(e) => Some(e),
             Self::FacetResolution(e) => Some(e),
             Self::NotFound { .. } => None,
@@ -135,9 +146,20 @@ pub fn parse_workflow_source(
     content: &str,
     facets_base_dir: &Path,
 ) -> Result<Workflow, StorageError> {
-    let mut workflow: Workflow = serde_saphyr::from_str(content)?;
+    let diagnosis = diagnostics::diagnose_workflow_source(content, None);
+    if diagnosis.has_errors() {
+        return Err(StorageError::Diagnostics(diagnosis.diagnostics));
+    }
+    let mut workflow = diagnosis.workflow.ok_or_else(|| {
+        StorageError::Diagnostics(vec![diagnostics::DiagnosticItem::new(
+            "WFS001",
+            diagnostics::Severity::Error,
+            diagnostics::DiagnosticStage::ParseShape,
+            None,
+            "workflow source could not be parsed",
+        )])
+    })?;
     workflow.builtin = builtin::is_builtin_workflow(&workflow.name);
-    validate_workflow_definition(&workflow)?;
     let facet_contents = facet::resolve_workflow_facets(&workflow, facets_base_dir)?;
     validate_resolved_facet_references(&workflow, &facet_contents)?;
     Ok(workflow)
@@ -181,10 +203,24 @@ pub fn save_workflow_source(
 /// 実行系は resolved cache から直接合成する）。
 pub fn load_workflow(path: &Path, facets_base_dir: &Path) -> Result<Workflow, StorageError> {
     let content = fs::read_to_string(path)?;
-    let mut workflow: Workflow = serde_saphyr::from_str(&content)?;
+    let diagnosis = diagnostics::diagnose_workflow_source(
+        &content,
+        path.file_stem().and_then(|stem| stem.to_str()),
+    );
+    if diagnosis.has_errors() {
+        return Err(StorageError::Diagnostics(diagnosis.diagnostics));
+    }
+    let mut workflow = diagnosis.workflow.ok_or_else(|| {
+        StorageError::Diagnostics(vec![diagnostics::DiagnosticItem::new(
+            "WFS001",
+            diagnostics::Severity::Error,
+            diagnostics::DiagnosticStage::ParseShape,
+            None,
+            "workflow source could not be parsed",
+        )])
+    })?;
     // YAMLの builtin フラグは無視し、コード側（builtin.rs）で判定する
     workflow.builtin = builtin::is_builtin_workflow(&workflow.name);
-    validate_workflow_definition(&workflow)?;
     let facet_contents = facet::resolve_workflow_facets(&workflow, facets_base_dir)?;
     validate_resolved_facet_references(&workflow, &facet_contents)?;
     Ok(workflow)
@@ -236,9 +272,27 @@ pub fn list_workflows(dir: &Path) -> Result<Vec<Summary>, StorageError> {
     // facet 解決が必要な実行系経路は明示的に `load_workflow` を呼ぶ。
     let load_for_listing = |path: &Path| -> Result<Workflow, StorageError> {
         let content = fs::read_to_string(path)?;
-        let mut workflow: Workflow = serde_saphyr::from_str(&content)?;
+        let stem = path.file_stem().and_then(|stem| stem.to_str());
+        let diagnosis = diagnostics::diagnose_workflow_source(&content, stem);
+        if diagnosis.has_errors() {
+            return Ok(Workflow {
+                name: stem.unwrap_or("invalid").to_string(),
+                description: "Invalid workflow definition".to_string(),
+                builtin: false,
+                schemas: Default::default(),
+                nodes: Vec::new(),
+            });
+        }
+        let mut workflow = diagnosis.workflow.ok_or_else(|| {
+            StorageError::Diagnostics(vec![diagnostics::DiagnosticItem::new(
+                "WFS001",
+                diagnostics::Severity::Error,
+                diagnostics::DiagnosticStage::ParseShape,
+                None,
+                "workflow source could not be parsed",
+            )])
+        })?;
         workflow.builtin = builtin::is_builtin_workflow(&workflow.name);
-        validate_workflow_definition(&workflow)?;
         Ok(workflow)
     };
     let mut summaries = list_yml_summaries(
@@ -265,9 +319,15 @@ pub fn list_workflows(dir: &Path) -> Result<Vec<Summary>, StorageError> {
     Ok(summaries)
 }
 
-fn validate_workflow_definition(workflow: &Workflow) -> Result<(), ValidationError> {
-    let workflow = workflow_definition_to_domain(workflow);
-    validation::validate(&workflow)
+fn validate_workflow_definition(workflow: &Workflow) -> Result<(), StorageError> {
+    let diagnostics = diagnostics::diagnose_workflow_definition(workflow, None);
+    if diagnostics
+        .iter()
+        .any(|item| item.severity == diagnostics::Severity::Error)
+    {
+        return Err(StorageError::Diagnostics(diagnostics));
+    }
+    Ok(())
 }
 
 pub(crate) fn resolve_and_validate_workflow_facets(
@@ -465,6 +525,30 @@ mod tests {
         let disk_entry = list.iter().find(|s| s.name == "renamed").unwrap();
         // Summary.nameはファイルstem（renamed）であるべき、YAML本文（original）ではない
         assert_eq!(disk_entry.name, "renamed");
+    }
+
+    #[test]
+    fn list_workflows_keeps_invalid_files_as_diagnostic_only_summaries() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        fs::write(
+            dir.join("broken.yml"),
+            r#"
+name: broken
+description: invalid workflow
+nodes:
+  - name: step
+    type: agent
+    instruction: implement
+"#,
+        )
+        .unwrap();
+
+        let list = list_workflows(dir).unwrap();
+        let disk_entry = list.iter().find(|s| s.name == "broken").unwrap();
+
+        assert_eq!(disk_entry.description, "Invalid workflow definition");
+        assert!(!disk_entry.builtin);
     }
 
     #[test]
@@ -727,8 +811,8 @@ steps:
         std::fs::write(&file_path, yaml).unwrap();
         let result = load_workflow(&file_path, dir);
         assert!(
-            matches!(result, Err(StorageError::YamlDeserialize(_))),
-            "旧 steps YAML は load 段階で deserialize 失敗する"
+            matches!(result, Err(StorageError::Diagnostics(ref items)) if items.iter().any(|item| item.code == "WFS005")),
+            "旧 steps YAML は load 段階で WFS005 diagnostic になる"
         );
     }
 
@@ -763,6 +847,8 @@ nodes:
         policy: p
         knowledge: k
         instruction: i
+    rules:
+      - next: par
   - name: par
     fanout:
       parallel_children:
@@ -850,7 +936,9 @@ nodes:
         let file_path = dir.join("old-variables-section.yml");
         std::fs::write(&file_path, yaml).unwrap();
         let result = load_workflow(&file_path, dir);
-        assert!(matches!(result, Err(StorageError::YamlDeserialize(_))));
+        assert!(
+            matches!(result, Err(StorageError::Diagnostics(ref items)) if items.iter().any(|item| item.code == "WFS005"))
+        );
     }
 
     #[test]
@@ -878,7 +966,9 @@ nodes:
             let file_path = dir.join(format!("old-{field}.yml"));
             std::fs::write(&file_path, yaml).unwrap();
             let result = load_workflow(&file_path, dir);
-            assert!(matches!(result, Err(StorageError::YamlDeserialize(_))));
+            assert!(
+                matches!(result, Err(StorageError::Diagnostics(ref items)) if items.iter().any(|item| item.code == "WFS005"))
+            );
         }
     }
 

--- a/src-tauri/src/domain/workflow/services/routing.rs
+++ b/src-tauri/src/domain/workflow/services/routing.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 
 use serde_json::Value;
 
@@ -16,8 +16,63 @@ pub enum RouteDecision {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RoutingValidationError {
-    UnknownRuleTarget { step: String, target: String },
-    Invalid { step: String, reason: String },
+    UnknownRuleTarget {
+        step: String,
+        target: String,
+    },
+    MultipleDiscriminators {
+        step: String,
+    },
+    MultipleLoopGuards {
+        step: String,
+    },
+    MultipleNextCatchAll {
+        step: String,
+    },
+    StandaloneNextWithDiscriminator {
+        step: String,
+    },
+    WhenFieldNotBoolean {
+        step: String,
+        field: String,
+        reason: Option<String>,
+    },
+    SwitchFieldNotEnum {
+        step: String,
+        field: String,
+        reason: Option<String>,
+    },
+    SwitchUnknownCase {
+        step: String,
+        field: String,
+        case: String,
+    },
+    SwitchMissingCases {
+        step: String,
+        field: String,
+        missing: Vec<String>,
+    },
+    SwitchExhaustiveHasNext {
+        step: String,
+    },
+    SwitchRequiresNext {
+        step: String,
+    },
+    DiscriminatorOnFanout {
+        step: String,
+    },
+    DiscriminatorWithoutArtifact {
+        step: String,
+    },
+    LoopGuardMaxIterations {
+        step: String,
+    },
+    CycleWithoutLoopGuard {
+        step: String,
+    },
+    UnreachableNode {
+        step: String,
+    },
 }
 
 pub fn validate_rules(workflow: &WorkflowDefinition) -> Vec<RoutingValidationError> {
@@ -65,6 +120,60 @@ pub fn rule_targets(rule: &Rule) -> Vec<&str> {
     }
 }
 
+pub fn validate_reachability(workflow: &WorkflowDefinition) -> Vec<RoutingValidationError> {
+    let reachable = reachable_nodes_from_entry(workflow);
+    workflow
+        .nodes
+        .iter()
+        .skip(1)
+        .filter(|node| !reachable.contains(node.name.as_str()))
+        .map(|node| RoutingValidationError::UnreachableNode {
+            step: node.name.clone(),
+        })
+        .collect()
+}
+
+fn reachable_nodes_from_entry(workflow: &WorkflowDefinition) -> HashSet<&str> {
+    let node_by_name: BTreeMap<_, _> = workflow
+        .nodes
+        .iter()
+        .map(|node| (node.name.as_str(), node))
+        .collect();
+    let Some(entry) = workflow.nodes.first() else {
+        return HashSet::new();
+    };
+    let mut reachable = HashSet::new();
+    let mut queue = VecDeque::from([entry.name.as_str()]);
+    while let Some(current) = queue.pop_front() {
+        if !reachable.insert(current) {
+            continue;
+        }
+        let Some(node) = node_by_name.get(current).copied() else {
+            continue;
+        };
+        for target in explicit_targets(node) {
+            if node_by_name.contains_key(target) && !reachable.contains(target) {
+                queue.push_back(target);
+            }
+        }
+    }
+    reachable
+}
+
+fn explicit_targets(node: &NodeDefinition) -> Vec<&str> {
+    let mut targets = node.rules.iter().flat_map(rule_targets).collect::<Vec<_>>();
+    if let Some(aggregate) = node.fanout().and_then(|fanout| fanout.aggregate.as_ref()) {
+        targets.push(aggregate.then.as_str());
+        targets.push(aggregate.r#else.as_str());
+    }
+    targets
+}
+
+#[cfg(test)]
+fn reachable_node_names(workflow: &WorkflowDefinition) -> BTreeSet<&str> {
+    reachable_nodes_from_entry(workflow).into_iter().collect()
+}
+
 pub fn loop_guard(node: &NodeDefinition) -> Option<(u32, &str)> {
     node.rules.iter().find_map(|rule| match rule {
         Rule::LoopGuard {
@@ -99,10 +208,9 @@ fn validate_node_rules(
             Rule::LoopGuard { max_iterations, .. } => {
                 loop_guard_count += 1;
                 if *max_iterations == 0 {
-                    errors.push(invalid(
-                        node,
-                        "loop_guard.max_iterations must be greater than 0",
-                    ));
+                    errors.push(RoutingValidationError::LoopGuardMaxIterations {
+                        step: node.name.clone(),
+                    });
                 }
             }
             Rule::Next(_) => next_count += 1,
@@ -110,25 +218,24 @@ fn validate_node_rules(
     }
 
     if discriminator_count > 1 {
-        errors.push(invalid(
-            node,
-            "rules can contain at most one when or switch discriminator",
-        ));
+        errors.push(RoutingValidationError::MultipleDiscriminators {
+            step: node.name.clone(),
+        });
     }
     if loop_guard_count > 1 {
-        errors.push(invalid(node, "rules can contain at most one loop_guard"));
+        errors.push(RoutingValidationError::MultipleLoopGuards {
+            step: node.name.clone(),
+        });
     }
     if next_count > 1 {
-        errors.push(invalid(
-            node,
-            "rules can contain at most one next catch-all",
-        ));
+        errors.push(RoutingValidationError::MultipleNextCatchAll {
+            step: node.name.clone(),
+        });
     }
     if discriminator_count > 0 && next_count > 0 {
-        errors.push(invalid(
-            node,
-            "standalone next cannot be combined with when or switch",
-        ));
+        errors.push(RoutingValidationError::StandaloneNextWithDiscriminator {
+            step: node.name.clone(),
+        });
     }
 
     let discriminator = node
@@ -140,7 +247,11 @@ fn validate_node_rules(
             if let Err(reason) =
                 validate_routing_field(workflow, node, on, RoutingFieldKind::Boolean)
             {
-                errors.push(invalid(node, reason));
+                errors.push(RoutingValidationError::WhenFieldNotBoolean {
+                    step: node.name.clone(),
+                    field: on.clone(),
+                    reason: Some(reason),
+                });
             }
         }
         Some(Rule::Switch { on, cases, next }) => {
@@ -149,53 +260,52 @@ fn validate_node_rules(
                     let enum_set: BTreeSet<_> = enum_values.iter().map(String::as_str).collect();
                     let case_set: BTreeSet<_> = cases.keys().map(String::as_str).collect();
                     for case in case_set.difference(&enum_set) {
-                        errors.push(invalid(
-                            node,
-                            format!("switch case '{case}' is not declared in enum field '{on}'"),
-                        ));
+                        errors.push(RoutingValidationError::SwitchUnknownCase {
+                            step: node.name.clone(),
+                            field: on.clone(),
+                            case: (*case).to_string(),
+                        });
                     }
                     let missing: Vec<_> = enum_set.difference(&case_set).copied().collect();
                     let needs_p11_next = node.is_command() && node.artifact.is_some() && on != "ok";
                     if missing.is_empty() {
                         if next.is_some() && !needs_p11_next {
-                            errors.push(invalid(
-                                node,
-                                "exhaustive switch cannot also define next catch-all",
-                            ));
+                            errors.push(RoutingValidationError::SwitchExhaustiveHasNext {
+                                step: node.name.clone(),
+                            });
                         }
                         if needs_p11_next && next.is_none() {
-                            errors.push(invalid(
-                                node,
-                                "command artifact routing on Contract field requires next catch-all",
-                            ));
+                            errors.push(RoutingValidationError::SwitchRequiresNext {
+                                step: node.name.clone(),
+                            });
                         }
                     } else if next.is_none() {
-                        errors.push(invalid(
-                            node,
-                            format!(
-                                "switch on '{on}' is missing enum cases [{}] and requires next",
-                                missing.join(", ")
-                            ),
-                        ));
+                        errors.push(RoutingValidationError::SwitchMissingCases {
+                            step: node.name.clone(),
+                            field: on.clone(),
+                            missing: missing.into_iter().map(str::to_string).collect(),
+                        });
                     }
                 }
-                Err(reason) => errors.push(invalid(node, reason)),
+                Err(reason) => errors.push(RoutingValidationError::SwitchFieldNotEnum {
+                    step: node.name.clone(),
+                    field: on.clone(),
+                    reason: Some(reason),
+                }),
             }
         }
         _ => {}
     }
 
     if discriminator.is_some() && matches!(node.kind, NodeKind::Fanout(_)) {
-        errors.push(invalid(
-            node,
-            "fanout nodes cannot use when or switch rules",
-        ));
+        errors.push(RoutingValidationError::DiscriminatorOnFanout {
+            step: node.name.clone(),
+        });
     }
     if discriminator.is_some() && node.artifact.is_none() && !node.is_command() {
-        errors.push(invalid(
-            node,
-            "nodes without an artifact cannot use when or switch rules",
-        ));
+        errors.push(RoutingValidationError::DiscriminatorWithoutArtifact {
+            step: node.name.clone(),
+        });
     }
 
     errors
@@ -354,10 +464,9 @@ fn validate_cycles_have_loop_guard(workflow: &WorkflowDefinition) -> Vec<Routing
         if !has_guard_on_cycle {
             for name in component {
                 if let Some(node) = node_by_name.get(name).copied() {
-                    errors.push(invalid(
-                        node,
-                        "cycle reachable from this node has no loop_guard on cycle nodes",
-                    ));
+                    errors.push(RoutingValidationError::CycleWithoutLoopGuard {
+                        step: node.name.clone(),
+                    });
                 }
             }
         }
@@ -428,13 +537,6 @@ fn is_reachable<'a>(
         }
     }
     false
-}
-
-fn invalid(node: &NodeDefinition, reason: impl Into<String>) -> RoutingValidationError {
-    RoutingValidationError::Invalid {
-        step: node.name.clone(),
-        reason: reason.into(),
-    }
 }
 
 #[cfg(test)]
@@ -520,12 +622,59 @@ mod routing_tests {
     fn assert_invalid_reason(wf: &WorkflowDefinition, expected: &str) {
         let errors = validate_rules(wf);
         assert!(
-            errors.iter().any(|error| matches!(
-                error,
-                RoutingValidationError::Invalid { reason, .. } if reason.contains(expected)
-            )),
+            errors
+                .iter()
+                .any(|error| routing_error_test_reason(error).contains(expected)),
             "expected invalid reason containing '{expected}', got {errors:?}"
         );
+    }
+
+    fn routing_error_test_reason(error: &RoutingValidationError) -> String {
+        match error {
+            RoutingValidationError::MultipleDiscriminators { .. } => {
+                "rules can contain at most one when or switch discriminator".to_string()
+            }
+            RoutingValidationError::MultipleLoopGuards { .. } => {
+                "rules can contain at most one loop_guard".to_string()
+            }
+            RoutingValidationError::MultipleNextCatchAll { .. } => {
+                "rules can contain at most one next catch-all".to_string()
+            }
+            RoutingValidationError::StandaloneNextWithDiscriminator { .. } => {
+                "standalone next cannot be combined with when or switch".to_string()
+            }
+            RoutingValidationError::WhenFieldNotBoolean { reason, .. }
+            | RoutingValidationError::SwitchFieldNotEnum { reason, .. } => {
+                reason.clone().unwrap_or_default()
+            }
+            RoutingValidationError::SwitchUnknownCase { field, case, .. } => {
+                format!("switch case '{case}' is not declared in enum field '{field}'")
+            }
+            RoutingValidationError::SwitchMissingCases { field, missing, .. } => format!(
+                "switch on '{field}' is missing enum cases [{}] and requires next",
+                missing.join(", ")
+            ),
+            RoutingValidationError::SwitchExhaustiveHasNext { .. } => {
+                "exhaustive switch cannot also define next catch-all".to_string()
+            }
+            RoutingValidationError::SwitchRequiresNext { .. } => {
+                "command artifact routing on Contract field requires next catch-all".to_string()
+            }
+            RoutingValidationError::DiscriminatorOnFanout { .. } => {
+                "fanout nodes cannot use when or switch rules".to_string()
+            }
+            RoutingValidationError::DiscriminatorWithoutArtifact { .. } => {
+                "nodes without an artifact cannot use when or switch rules".to_string()
+            }
+            RoutingValidationError::LoopGuardMaxIterations { .. } => {
+                "loop_guard.max_iterations must be greater than 0".to_string()
+            }
+            RoutingValidationError::CycleWithoutLoopGuard { .. } => {
+                "cycle reachable from this node has no loop_guard on cycle nodes".to_string()
+            }
+            RoutingValidationError::UnknownRuleTarget { .. }
+            | RoutingValidationError::UnreachableNode { .. } => String::new(),
+        }
     }
 
     #[test]
@@ -873,6 +1022,57 @@ mod routing_tests {
         );
     }
 
+    #[test]
+    fn reachability_starts_at_entry_and_does_not_seed_unreachable_subgraph_edges() {
+        let wf = workflow(
+            vec![
+                session_node("entry", None, vec![]),
+                session_node("orphan", None, vec![Rule::Next("target".to_string())]),
+                session_node("target", None, vec![]),
+            ],
+            BTreeMap::new(),
+        );
+
+        assert_eq!(
+            reachable_node_names(&wf),
+            BTreeSet::from(["entry"]),
+            "unreachable subgraph edges must not mark their targets reachable"
+        );
+        let errors = validate_reachability(&wf);
+        for step in ["orphan", "target"] {
+            assert!(
+                errors.iter().any(|error| matches!(
+                    error,
+                    RoutingValidationError::UnreachableNode { step: found } if found == step
+                )),
+                "expected unreachable error for {step}, got {errors:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reachability_follows_explicit_rule_targets_from_reachable_nodes() {
+        let wf = workflow(
+            vec![
+                session_node("entry", None, vec![Rule::Next("target".to_string())]),
+                session_node("orphan", None, vec![]),
+                session_node("target", None, vec![]),
+            ],
+            BTreeMap::new(),
+        );
+
+        assert_eq!(
+            reachable_node_names(&wf),
+            BTreeSet::from(["entry", "target"])
+        );
+        let errors = validate_reachability(&wf);
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            &errors[0],
+            RoutingValidationError::UnreachableNode { step } if step == "orphan"
+        ));
+    }
+
     fn cycle_with_exit_guard_workflow(guard_on_cycle: bool) -> WorkflowDefinition {
         let mut node_b_rules = vec![Rule::Next("step_a".to_string())];
         if guard_on_cycle {
@@ -925,16 +1125,16 @@ mod routing_tests {
         assert!(
             errors.iter().any(|error| matches!(
                 error,
-                RoutingValidationError::Invalid { step, reason }
-                    if step == "step_a" && reason.contains("cycle reachable")
+                RoutingValidationError::CycleWithoutLoopGuard { step }
+                    if step == "step_a"
             )),
             "expected step_a cycle guard error, got {errors:?}"
         );
         assert!(
             errors.iter().any(|error| matches!(
                 error,
-                RoutingValidationError::Invalid { step, reason }
-                    if step == "step_b" && reason.contains("cycle reachable")
+                RoutingValidationError::CycleWithoutLoopGuard { step }
+                    if step == "step_b"
             )),
             "expected step_b cycle guard error, got {errors:?}"
         );

--- a/src-tauri/src/domain/workflow/services/validation.rs
+++ b/src-tauri/src/domain/workflow/services/validation.rs
@@ -10,6 +10,41 @@ use std::fmt;
 
 const ALLOWED_PERMISSION_MODES: &str = "ask, edit, full";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidSchemaKind {
+    InvalidDeclaration,
+    UnknownSchemaReference,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidArtifactReferenceKind {
+    ReservedArtifactName,
+    UnknownNode,
+    UnavailableArtifact,
+    UnknownField,
+    ItemOutOfScope,
+    InvalidInputRef,
+    InputsNotAllowedOnFanout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidRuleKind {
+    MultipleDiscriminators,
+    MultipleLoopGuards,
+    MultipleNextCatchAll,
+    StandaloneNextWithDiscriminator,
+    WhenFieldNotBoolean,
+    SwitchFieldNotEnum,
+    SwitchUnknownCase,
+    SwitchMissingCases,
+    SwitchExhaustiveHasNext,
+    SwitchRequiresNext,
+    DiscriminatorOnFanout,
+    DiscriminatorWithoutArtifact,
+    LoopGuardMaxIterations,
+    CycleWithoutLoopGuard,
+}
+
 #[derive(Debug)]
 pub enum ValidationError {
     EmptyName,
@@ -54,7 +89,12 @@ pub enum ValidationError {
     /// rules の順序非依存性・網羅性・型付き参照・loop guard が不正
     InvalidRules {
         step: String,
+        kind: InvalidRuleKind,
         reason: String,
+    },
+    /// entry node から到達できない node
+    UnreachableNode {
+        step: String,
     },
     /// 無効な permission mode が指定されている
     InvalidPermissionMode {
@@ -121,6 +161,7 @@ pub enum ValidationError {
     /// `schemas:` 内の宣言が JSON Schema subset として矛盾している。
     InvalidSchema {
         schema: String,
+        kind: InvalidSchemaKind,
         reason: String,
     },
     /// `artifact:` が Object 以外の Contract を参照している。
@@ -137,6 +178,7 @@ pub enum ValidationError {
     /// `inputs:` または `{{ ... }}` が解決できない Artifact 参照を含む。
     InvalidArtifactReference {
         reference: String,
+        kind: InvalidArtifactReferenceKind,
         reason: String,
     },
 }
@@ -181,8 +223,11 @@ impl fmt::Display for ValidationError {
                 f,
                 "node '{step}' のrulesが存在しないnode '{target}' を参照しています"
             ),
-            Self::InvalidRules { step, reason } => {
+            Self::InvalidRules { step, reason, .. } => {
                 write!(f, "node '{step}' のrulesが不正です: {reason}")
+            }
+            Self::UnreachableNode { step } => {
+                write!(f, "node '{step}' is unreachable from the workflow entrypoint")
             }
             Self::InvalidPermissionMode { step, value } => {
                 let display_value = if value.is_empty() {
@@ -268,7 +313,7 @@ impl fmt::Display for ValidationError {
                     "ステップ '{step}' の {slot} Contract 参照 '{key}' が不正です: {reason}"
                 )
             }
-            Self::InvalidSchema { schema, reason } => {
+            Self::InvalidSchema { schema, reason, .. } => {
                 write!(f, "schemas.{schema} の宣言が不正です: {reason}")
             }
             Self::InvalidArtifactSchema { step, contract } => {
@@ -287,7 +332,9 @@ impl fmt::Display for ValidationError {
                     "commandステップ '{step}' の artifact '{contract}' が予約 field '{field}' を宣言しています"
                 )
             }
-            Self::InvalidArtifactReference { reference, reason } => {
+            Self::InvalidArtifactReference {
+                reference, reason, ..
+            } => {
                 write!(f, "Artifact参照 '{reference}' が不正です: {reason}")
             }
         }
@@ -304,6 +351,7 @@ fn reference_error_to_validation_error(
         reference::ReferenceResolveError::ReservedNodeName { name } => {
             ValidationError::InvalidArtifactReference {
                 reference: name,
+                kind: InvalidArtifactReferenceKind::ReservedArtifactName,
                 reason: "`request` and `item` are reserved Artifact names and cannot be node names"
                     .to_string(),
             }
@@ -311,30 +359,35 @@ fn reference_error_to_validation_error(
         reference::ReferenceResolveError::UnknownNode { name } => {
             ValidationError::InvalidArtifactReference {
                 reference: name,
+                kind: InvalidArtifactReferenceKind::UnknownNode,
                 reason: "unknown Artifact-producing node".to_string(),
             }
         }
         reference::ReferenceResolveError::UnavailableArtifact { name } => {
             ValidationError::InvalidArtifactReference {
                 reference: name,
+                kind: InvalidArtifactReferenceKind::UnavailableArtifact,
                 reason: "the referenced node does not produce an Artifact".to_string(),
             }
         }
         reference::ReferenceResolveError::UnknownField { reference, field } => {
             ValidationError::InvalidArtifactReference {
                 reference: format!("{reference}.{field}"),
+                kind: InvalidArtifactReferenceKind::UnknownField,
                 reason: "unknown Artifact field".to_string(),
             }
         }
         reference::ReferenceResolveError::ItemOutOfScope => {
             ValidationError::InvalidArtifactReference {
                 reference: reference::ITEM_ARTIFACT.to_string(),
+                kind: InvalidArtifactReferenceKind::ItemOutOfScope,
                 reason: "`item` is only available inside fanout child scope".to_string(),
             }
         }
         reference::ReferenceResolveError::InvalidInputRef { value } => {
             ValidationError::InvalidArtifactReference {
                 reference: value,
+                kind: InvalidArtifactReferenceKind::InvalidInputRef,
                 reason: match context {
                     reference::ReferenceResolveContext::Inputs => {
                         "`inputs:` entries must be `request` or a top-level node Artifact name"
@@ -349,6 +402,7 @@ fn reference_error_to_validation_error(
         reference::ReferenceResolveError::InputsNotAllowedOnFanout { node } => {
             ValidationError::InvalidArtifactReference {
                 reference: node,
+                kind: InvalidArtifactReferenceKind::InputsNotAllowedOnFanout,
                 reason: "fanout nodes cannot declare `inputs:`".to_string(),
             }
         }
@@ -366,8 +420,119 @@ fn routing_error_to_validation_error(error: routing::RoutingValidationError) -> 
         routing::RoutingValidationError::UnknownRuleTarget { step, target } => {
             ValidationError::UnknownRuleTarget { step, target }
         }
-        routing::RoutingValidationError::Invalid { step, reason } => {
-            ValidationError::InvalidRules { step, reason }
+        routing::RoutingValidationError::MultipleDiscriminators { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::MultipleDiscriminators,
+                reason: "rules can contain at most one when or switch discriminator".to_string(),
+            }
+        }
+        routing::RoutingValidationError::MultipleLoopGuards { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::MultipleLoopGuards,
+                reason: "rules can contain at most one loop_guard".to_string(),
+            }
+        }
+        routing::RoutingValidationError::MultipleNextCatchAll { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::MultipleNextCatchAll,
+                reason: "rules can contain at most one next catch-all".to_string(),
+            }
+        }
+        routing::RoutingValidationError::StandaloneNextWithDiscriminator { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::StandaloneNextWithDiscriminator,
+                reason: "standalone next cannot be combined with when or switch".to_string(),
+            }
+        }
+        routing::RoutingValidationError::WhenFieldNotBoolean {
+            step,
+            field,
+            reason,
+        } => ValidationError::InvalidRules {
+            step,
+            kind: InvalidRuleKind::WhenFieldNotBoolean,
+            reason: reason
+                .unwrap_or_else(|| format!("when.on field '{field}' must be a required boolean")),
+        },
+        routing::RoutingValidationError::SwitchFieldNotEnum {
+            step,
+            field,
+            reason,
+        } => ValidationError::InvalidRules {
+            step,
+            kind: InvalidRuleKind::SwitchFieldNotEnum,
+            reason: reason
+                .unwrap_or_else(|| format!("switch.on field '{field}' must be a required enum")),
+        },
+        routing::RoutingValidationError::SwitchUnknownCase { step, field, case } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::SwitchUnknownCase,
+                reason: format!("switch case '{case}' is not declared in enum field '{field}'"),
+            }
+        }
+        routing::RoutingValidationError::SwitchMissingCases {
+            step,
+            field,
+            missing,
+        } => ValidationError::InvalidRules {
+            step,
+            kind: InvalidRuleKind::SwitchMissingCases,
+            reason: format!(
+                "switch on '{field}' is missing enum cases [{}] and requires next",
+                missing.join(", ")
+            ),
+        },
+        routing::RoutingValidationError::SwitchExhaustiveHasNext { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::SwitchExhaustiveHasNext,
+                reason: "exhaustive switch cannot also define next catch-all".to_string(),
+            }
+        }
+        routing::RoutingValidationError::SwitchRequiresNext { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::SwitchRequiresNext,
+                reason: "command artifact routing on Contract field requires next catch-all"
+                    .to_string(),
+            }
+        }
+        routing::RoutingValidationError::DiscriminatorOnFanout { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::DiscriminatorOnFanout,
+                reason: "fanout nodes cannot use when or switch rules".to_string(),
+            }
+        }
+        routing::RoutingValidationError::DiscriminatorWithoutArtifact { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::DiscriminatorWithoutArtifact,
+                reason: "nodes without an artifact cannot use when or switch rules".to_string(),
+            }
+        }
+        routing::RoutingValidationError::LoopGuardMaxIterations { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::LoopGuardMaxIterations,
+                reason: "loop_guard.max_iterations must be greater than 0".to_string(),
+            }
+        }
+        routing::RoutingValidationError::CycleWithoutLoopGuard { step } => {
+            ValidationError::InvalidRules {
+                step,
+                kind: InvalidRuleKind::CycleWithoutLoopGuard,
+                reason: "cycle reachable from this node has no loop_guard on cycle nodes"
+                    .to_string(),
+            }
+        }
+        routing::RoutingValidationError::UnreachableNode { step } => {
+            ValidationError::UnreachableNode { step }
         }
     }
 }
@@ -611,6 +776,7 @@ pub fn validate_schema_refs(workflow: &Workflow) -> Result<(), ValidationError> 
         if name == reference::REQUEST_ARTIFACT {
             return Err(ValidationError::InvalidArtifactReference {
                 reference: name.to_string(),
+                kind: InvalidArtifactReferenceKind::ReservedArtifactName,
                 reason: "`request` is a reserved Artifact name and cannot be declared in schemas"
                     .to_string(),
             });
@@ -618,6 +784,7 @@ pub fn validate_schema_refs(workflow: &Workflow) -> Result<(), ValidationError> 
         if !contract_schema::is_safe_identifier(name) {
             return Err(ValidationError::InvalidSchema {
                 schema: name.to_string(),
+                kind: InvalidSchemaKind::InvalidDeclaration,
                 reason: safe_identifier_message().to_string(),
             });
         }
@@ -678,6 +845,7 @@ fn validate_schema_def(
                 if !properties.contains_key(field) {
                     return Err(ValidationError::InvalidSchema {
                         schema: name.to_string(),
+                        kind: InvalidSchemaKind::InvalidDeclaration,
                         reason: format!("required field '{field}' is not declared in properties"),
                     });
                 }
@@ -694,12 +862,14 @@ fn validate_schema_def(
             if !contract_schema::is_safe_identifier(items) {
                 return Err(ValidationError::InvalidSchema {
                     schema: name.to_string(),
+                    kind: InvalidSchemaKind::InvalidDeclaration,
                     reason: safe_identifier_message().to_string(),
                 });
             }
             if !workflow.schemas.contains_key(items) {
                 return Err(ValidationError::InvalidSchema {
                     schema: name.to_string(),
+                    kind: InvalidSchemaKind::UnknownSchemaReference,
                     reason: format!("array.items references unknown schemas '{items}'"),
                 });
             }
@@ -708,6 +878,7 @@ fn validate_schema_def(
             if r#enum.as_ref().is_some_and(Vec::is_empty) {
                 return Err(ValidationError::InvalidSchema {
                     schema: name.to_string(),
+                    kind: InvalidSchemaKind::InvalidDeclaration,
                     reason: "enum must contain at least one value".to_string(),
                 });
             }
@@ -1022,6 +1193,11 @@ pub fn validate_all(workflow: &Workflow) -> Vec<ValidationError> {
     }
     errors.extend(
         routing::validate_rules(workflow)
+            .into_iter()
+            .map(routing_error_to_validation_error),
+    );
+    errors.extend(
+        routing::validate_reachability(workflow)
             .into_iter()
             .map(routing_error_to_validation_error),
     );
@@ -1384,7 +1560,7 @@ mod tests {
     }
 
     #[test]
-    fn routing_unknown_target_maps_by_variant_not_reason_text() {
+    fn routing_errors_map_by_variant_not_reason_text() {
         let err =
             routing_error_to_validation_error(routing::RoutingValidationError::UnknownRuleTarget {
                 step: "route".to_string(),
@@ -1396,14 +1572,15 @@ mod tests {
                 if step == "route" && target == "missing"
         ));
 
-        let err = routing_error_to_validation_error(routing::RoutingValidationError::Invalid {
-            step: "route".to_string(),
-            reason: "unknown rule target 'missing'".to_string(),
-        });
+        let err = routing_error_to_validation_error(
+            routing::RoutingValidationError::MultipleNextCatchAll {
+                step: "route".to_string(),
+            },
+        );
         assert!(matches!(
             err,
-            ValidationError::InvalidRules { ref step, ref reason }
-                if step == "route" && reason.contains("unknown rule target")
+            ValidationError::InvalidRules { ref step, kind, .. }
+                if step == "route" && kind == InvalidRuleKind::MultipleNextCatchAll
         ));
     }
 
@@ -1560,7 +1737,7 @@ mod tests {
 
         assert!(matches!(
             validate(&wf).unwrap_err(),
-            ValidationError::InvalidArtifactReference { ref reference, ref reason }
+            ValidationError::InvalidArtifactReference { ref reference, ref reason, .. }
                 if reference == "bad ref"
                     && reason == "`inputs:` entries must be `request` or a top-level node Artifact name"
         ));
@@ -1572,7 +1749,7 @@ mod tests {
 
         assert!(matches!(
             validate(&wf).unwrap_err(),
-            ValidationError::InvalidArtifactReference { ref reference, ref reason }
+            ValidationError::InvalidArtifactReference { ref reference, ref reason, .. }
                 if reference == "bad ref"
                     && reason.contains("{{ ... }}")
                     && !reason.contains("inputs:")
@@ -1586,7 +1763,7 @@ mod tests {
 
         assert!(matches!(
             errors.as_slice(),
-            [ValidationError::InvalidArtifactReference { reference, reason }]
+            [ValidationError::InvalidArtifactReference { reference, reason, .. }]
                 if reference == "bad ref"
                     && reason.contains("{{ ... }}")
                     && !reason.contains("inputs:")
@@ -1622,7 +1799,7 @@ mod tests {
 
         assert!(matches!(
             validate(&wf).unwrap_err(),
-            ValidationError::InvalidArtifactReference { ref reference, ref reason }
+            ValidationError::InvalidArtifactReference { ref reference, ref reason, .. }
                 if reference == "plan" && reason.contains("does not produce")
         ));
     }
@@ -1636,7 +1813,7 @@ mod tests {
 
         assert!(matches!(
             validate(&wf).unwrap_err(),
-            ValidationError::InvalidArtifactReference { ref reference, ref reason }
+            ValidationError::InvalidArtifactReference { ref reference, ref reason, .. }
                 if reference == "build.no_such_field" && reason.contains("unknown Artifact field")
         ));
     }
@@ -1657,7 +1834,7 @@ mod tests {
 
         assert!(matches!(
             validate(&wf).unwrap_err(),
-            ValidationError::InvalidArtifactReference { ref reference, ref reason }
+            ValidationError::InvalidArtifactReference { ref reference, ref reason, .. }
                 if reference == "plan.unknown_field" && reason.contains("unknown Artifact field")
         ));
     }
@@ -2458,7 +2635,7 @@ mod tests {
             .insert("request".to_string(), SchemaDef::String { r#enum: None });
         assert!(matches!(
             validate_schema_refs(&request_wf).unwrap_err(),
-            ValidationError::InvalidArtifactReference { ref reference, ref reason }
+            ValidationError::InvalidArtifactReference { ref reference, ref reason, .. }
                 if reference == "request" && reason.contains("reserved Artifact name")
         ));
 
@@ -2494,7 +2671,7 @@ mod tests {
 
         assert!(matches!(
             validate_schema_refs(&wf).unwrap_err(),
-            ValidationError::InvalidSchema { ref schema, ref reason }
+            ValidationError::InvalidSchema { ref schema, ref reason, .. }
                 if schema == "review; curl https://example.invalid #"
                     && reason.contains("must start with an ASCII alphanumeric")
         ));
@@ -2541,7 +2718,7 @@ mod tests {
 
         assert!(matches!(
             validate_schema_refs(&wf).unwrap_err(),
-            ValidationError::InvalidSchema { ref schema, ref reason }
+            ValidationError::InvalidSchema { ref schema, ref reason, .. }
                 if schema == "review-list"
                     && reason.contains("must start with an ASCII alphanumeric")
         ));
@@ -2561,7 +2738,7 @@ mod tests {
 
         assert!(matches!(
             validate_schema_refs(&wf).unwrap_err(),
-            ValidationError::InvalidSchema { ref schema, ref reason }
+            ValidationError::InvalidSchema { ref schema, ref reason, .. }
                 if schema == "review-output"
                     && reason == "required field 'verdict' is not declared in properties"
         ));
@@ -2579,7 +2756,7 @@ mod tests {
 
         assert!(matches!(
             validate_schema_refs(&wf).unwrap_err(),
-            ValidationError::InvalidSchema { ref schema, ref reason }
+            ValidationError::InvalidSchema { ref schema, ref reason, .. }
                 if schema == "review-output" && reason == "enum must contain at least one value"
         ));
     }
@@ -2596,7 +2773,7 @@ mod tests {
 
         assert!(matches!(
             validate_schema_refs(&wf).unwrap_err(),
-            ValidationError::InvalidSchema { ref schema, ref reason }
+            ValidationError::InvalidSchema { ref schema, ref reason, .. }
                 if schema == "review-list"
                     && reason == "array.items references unknown schemas 'missing-item'"
         ));

--- a/src-tauri/src/usecase/workflow/definition.rs
+++ b/src-tauri/src/usecase/workflow/definition.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::domain::workflow::{WorkflowDefinition, WorkflowDefinitionRepository, WorkflowError};
-use crate::usecase::workflow::ports::WorkflowDefinitionSourceGateway;
+use crate::usecase::workflow::ports::{WorkflowDefinitionSourceGateway, WorkflowSourceSaveError};
 
 #[derive(Clone)]
 pub struct WorkflowDefinitionUsecase {
@@ -20,12 +20,22 @@ impl WorkflowDefinitionUsecase {
         }
     }
 
+    #[cfg(test)]
     pub fn save_workflow_source(
         &self,
         source: &str,
         original_name: Option<&str>,
     ) -> Result<WorkflowDefinition, WorkflowError> {
         self.definition_sources.save_source(source, original_name)
+    }
+
+    pub fn save_workflow_source_with_diagnostics(
+        &self,
+        source: &str,
+        original_name: Option<&str>,
+    ) -> Result<WorkflowDefinition, WorkflowSourceSaveError> {
+        self.definition_sources
+            .save_source_with_diagnostics(source, original_name)
     }
 
     pub fn delete_workflow(&self, name: &str) -> Result<(), WorkflowError> {

--- a/src-tauri/src/usecase/workflow/mod.rs
+++ b/src-tauri/src/usecase/workflow/mod.rs
@@ -30,7 +30,7 @@ use crate::domain::workflow::{
 };
 use crate::usecase::workflow::ports::{
     ExternalEditorGateway, WorkflowConfigPathGateway, WorkflowDefinitionSourceGateway,
-    WorkflowDiagnosticsGateway,
+    WorkflowDiagnosticsGateway, WorkflowSourceSaveError,
 };
 
 use definition::WorkflowDefinitionUsecase;
@@ -205,6 +205,7 @@ impl WorkflowUsecase {
         self.query.list_facet_summaries(kind)
     }
 
+    #[cfg(test)]
     pub fn save_workflow_source(
         &self,
         source: &str,
@@ -212,6 +213,15 @@ impl WorkflowUsecase {
     ) -> Result<WorkflowDefinition, WorkflowError> {
         self.definition_commands
             .save_workflow_source(source, original_name)
+    }
+
+    pub fn save_workflow_source_with_diagnostics(
+        &self,
+        source: &str,
+        original_name: Option<&str>,
+    ) -> Result<WorkflowDefinition, WorkflowSourceSaveError> {
+        self.definition_commands
+            .save_workflow_source_with_diagnostics(source, original_name)
     }
 
     pub fn delete_workflow(&self, name: &str) -> Result<(), WorkflowError> {

--- a/src-tauri/src/usecase/workflow/ports.rs
+++ b/src-tauri/src/usecase/workflow/ports.rs
@@ -40,6 +40,20 @@ pub trait WorkflowDefinitionSourceGateway: Send + Sync {
         source: &str,
         original_name: Option<&str>,
     ) -> Result<WorkflowDefinition, WorkflowError>;
+    fn save_source_with_diagnostics(
+        &self,
+        source: &str,
+        original_name: Option<&str>,
+    ) -> Result<WorkflowDefinition, WorkflowSourceSaveError> {
+        self.save_source(source, original_name)
+            .map_err(WorkflowSourceSaveError::Workflow)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum WorkflowSourceSaveError {
+    Diagnostics(Vec<serde_json::Value>),
+    Workflow(WorkflowError),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/components/panels/AutomationSection.test.tsx
+++ b/src/components/panels/AutomationSection.test.tsx
@@ -4,6 +4,31 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { useAutomation } from "@/hooks/useAutomation";
 import { AutomationSection } from "./AutomationSection";
 
+const monacoMock = vi.hoisted(() => {
+	const model = {
+		getValue: vi.fn(() => "name: test-wf\nnodes: []\n"),
+		dispose: vi.fn(),
+	};
+	const editor = {
+		dispose: vi.fn(),
+		onDidChangeModelContent: vi.fn(() => ({ dispose: vi.fn() })),
+	};
+	return {
+		model,
+		editor,
+		module: {
+			MarkerSeverity: { Error: 8, Warning: 4, Info: 2 },
+			editor: {
+				createModel: vi.fn(() => model),
+				create: vi.fn(() => editor),
+				setModelMarkers: vi.fn(),
+			},
+		},
+	};
+});
+
+vi.mock("monaco-editor", () => monacoMock.module);
+
 // Radix UI pointer event polyfills
 beforeAll(() => {
 	HTMLElement.prototype.hasPointerCapture = vi.fn() as never;
@@ -41,6 +66,7 @@ function createMockAutomation(
 		error: null,
 		setError: vi.fn(),
 		selectedWorkflow: null,
+		selectedWorkflowName: null,
 		selectedWorkflowSource: null,
 		selectedFacetContent: null,
 		selectedFacetKey: null,
@@ -129,7 +155,7 @@ describe("AutomationSection", () => {
 		render(<AutomationSection automation={automation} />);
 		expect(screen.getByTitle("Duplicate as custom")).toBeInTheDocument();
 		expect(screen.queryByTitle("Delete")).not.toBeInTheDocument();
-		expect(screen.queryByTitle("Open in editor")).not.toBeInTheDocument();
+		expect(screen.queryByTitle("Edit")).not.toBeInTheDocument();
 	});
 
 	it("custom workflow shows edit and delete buttons", () => {
@@ -145,10 +171,10 @@ describe("AutomationSection", () => {
 		});
 		render(<AutomationSection automation={automation} />);
 		expect(screen.getByTitle("Delete")).toBeInTheDocument();
-		expect(screen.getByTitle("Open in editor")).toBeInTheDocument();
+		expect(screen.getByTitle("Edit")).toBeInTheDocument();
 	});
 
-	it("creates workflow from minimal source without node schema", async () => {
+	it("creates workflow from valid minimal source", async () => {
 		const user = userEvent.setup();
 		const saveWorkflowSource = vi.fn().mockResolvedValue({
 			ok: true,
@@ -173,14 +199,24 @@ describe("AutomationSection", () => {
 
 		await waitFor(() => {
 			expect(saveWorkflowSource).toHaveBeenCalledWith(
-				'name: new-wf\ndescription: ""\n',
+				[
+					"name: new-wf",
+					'description: ""',
+					"nodes:",
+					"  - name: start",
+					"    session:",
+					"      gate: auto",
+					"      permission: edit",
+					"      facets: {}",
+					"",
+				].join("\n"),
 			);
 		});
 		const source = saveWorkflowSource.mock.calls[0][0];
-		expect(source).not.toContain("nodes:");
-		expect(source).not.toContain("session:");
-		expect(source).not.toContain("permission:");
-		expect(source).not.toContain("facets:");
+		expect(source).toContain("nodes:");
+		expect(source).toContain("session:");
+		expect(source).toContain("permission: edit");
+		expect(source).toContain("facets: {}");
 		expect(source).not.toContain("instruction:");
 		expect(selectWorkflow).toHaveBeenCalledWith("new-wf");
 	});
@@ -490,10 +526,25 @@ describe("AutomationSection", () => {
 		});
 	});
 
-	it("workflow detail Edit opens workflow in external editor", async () => {
+	it("workflow detail Edit opens writable in-panel editor and surfaces save diagnostics", async () => {
 		const user = userEvent.setup();
-		const openWorkflowInEditor = vi.fn();
-		const saveWorkflowSource = vi.fn();
+		vi.clearAllMocks();
+		const diagnostics = [
+			{
+				code: "WFT001",
+				severity: "error" as const,
+				stage: "typecheck" as const,
+				span: { start_line: 3, start_col: 5, end_line: 3, end_col: 9 },
+				message: "when.on field must be boolean",
+				workflow_name: "test-wf",
+				field: "rules.when.on",
+			},
+		];
+		const saveWorkflowSource = vi.fn().mockResolvedValue({
+			ok: false,
+			error: "workflow_diagnostics",
+			diagnostics,
+		});
 		const automation = createMockAutomation({
 			selectedWorkflow: {
 				name: "test-wf",
@@ -501,7 +552,8 @@ describe("AutomationSection", () => {
 				builtin: false,
 				nodes: [SESSION_NODE],
 			},
-			openWorkflowInEditor,
+			selectedWorkflowName: "test-wf",
+			selectedWorkflowSource: "name: test-wf\nnodes: []\n",
 			saveWorkflowSource,
 		});
 
@@ -509,11 +561,23 @@ describe("AutomationSection", () => {
 
 		await user.click(screen.getByText("Edit"));
 
-		expect(openWorkflowInEditor).toHaveBeenCalledWith("test-wf");
-		expect(saveWorkflowSource).not.toHaveBeenCalled();
+		await waitFor(() => {
+			expect(screen.getByText("Workflow YAML")).toBeInTheDocument();
+		});
+		expect(monacoMock.module.editor.create).toHaveBeenCalled();
+
+		await user.click(screen.getByRole("button", { name: /Save/ }));
+
+		await waitFor(() => {
+			expect(saveWorkflowSource).toHaveBeenCalledWith(
+				"name: test-wf\nnodes: []\n",
+				"test-wf",
+			);
+		});
+		expect(screen.getByText("WFT001")).toBeInTheDocument();
 		expect(
-			screen.queryByRole("textbox", { name: "Workflow YAML" }),
-		).not.toBeInTheDocument();
+			screen.getByText("when.on field must be boolean"),
+		).toBeInTheDocument();
 	});
 
 	it("workflow detail shows step details when expanded", async () => {
@@ -596,13 +660,23 @@ describe("AutomationSection", () => {
 				...EMPTY_REPORT,
 				items: [
 					{
+						code: "WFR900",
 						severity: "error",
+						stage: "resolve",
+						span: {
+							start_line: 6,
+							start_col: 9,
+							end_line: 6,
+							end_col: 20,
+						},
 						message: "Step references missing facet",
 						workflow_name: "diag-wf",
 						step_name: "step-1",
 					},
 					{
+						code: "WFT004",
 						severity: "warning",
+						stage: "typecheck",
 						message: "Consider adding artifact schema",
 						workflow_name: "diag-wf",
 						step_name: "step-1",
@@ -615,6 +689,8 @@ describe("AutomationSection", () => {
 		expect(
 			screen.getByText("Step references missing facet"),
 		).toBeInTheDocument();
+		expect(screen.getByText("WFR900")).toBeInTheDocument();
+		expect(screen.getByText("6:9")).toBeInTheDocument();
 		expect(
 			screen.getByText("Consider adding artifact schema"),
 		).toBeInTheDocument();
@@ -680,7 +756,9 @@ describe("AutomationSection", () => {
 				...EMPTY_REPORT,
 				items: [
 					{
+						code: "FAC003",
 						severity: "warning",
+						stage: "resolve",
 						message: "Template variable not provided",
 						facet_key: "test-facet",
 						facet_kind: "policies",

--- a/src/components/panels/AutomationSection.tsx
+++ b/src/components/panels/AutomationSection.tsx
@@ -3,13 +3,17 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { FacetSubTab, useAutomation } from "@/hooks/useAutomation";
-import type { FacetKind } from "@/types/workflow";
+import type { DiagnosticItem, FacetKind } from "@/types/workflow";
 import { FacetDetail } from "./automation/FacetDetail";
 import { FacetEditor } from "./automation/FacetEditor";
 import { FacetList } from "./automation/FacetList";
 import { NameInputDialog } from "./automation/NameInputDialog";
 import { facetKindToDirName } from "./automation/utils";
-import { WorkflowDetail } from "./automation/WorkflowDetail";
+import {
+	WorkflowDetail,
+	WorkflowSourceDiagnosticDetail,
+	WorkflowSourceEditor,
+} from "./automation/WorkflowDetail";
 import { WorkflowList } from "./automation/WorkflowList";
 
 const FACET_SUB_TABS: { id: FacetSubTab; label: string }[] = [
@@ -32,6 +36,8 @@ export function AutomationSection({
 		externalChangeDetected,
 		clearExternalChange,
 		selectedWorkflow,
+		selectedWorkflowName,
+		selectedWorkflowSource,
 		selectedFacetContent,
 		selectedFacetKey,
 		selectedFacetKind,
@@ -40,7 +46,6 @@ export function AutomationSection({
 		saveWorkflowSource,
 		deleteWorkflow,
 		duplicateWorkflow,
-		openWorkflowInEditor,
 		selectFacet,
 		saveFacet,
 		deleteFacet,
@@ -55,6 +60,10 @@ export function AutomationSection({
 	const [tab, setTab] = useState<string>("workflows");
 	const [facetSubTab, setFacetSubTab] = useState<FacetSubTab>("policy");
 	const [editingFacet, setEditingFacet] = useState(false);
+	const [editingWorkflow, setEditingWorkflow] = useState(false);
+	const [workflowSaveDiagnostics, setWorkflowSaveDiagnostics] = useState<
+		DiagnosticItem[]
+	>([]);
 
 	// Dialogs
 	const [createWorkflowOpen, setCreateWorkflowOpen] = useState(false);
@@ -65,6 +74,7 @@ export function AutomationSection({
 		name: string;
 		kind?: FacetKind;
 	} | null>(null);
+	const activeWorkflowName = selectedWorkflow?.name ?? selectedWorkflowName;
 
 	// Load facets when switching to facets tab or changing sub-tab
 	useEffect(() => {
@@ -74,10 +84,35 @@ export function AutomationSection({
 	}, [tab, facetSubTab, fetchFacets]);
 
 	const handleEditWorkflow = useCallback(() => {
-		if (selectedWorkflow) {
-			void openWorkflowInEditor(selectedWorkflow.name);
-		}
-	}, [openWorkflowInEditor, selectedWorkflow]);
+		if (!activeWorkflowName) return;
+		setWorkflowSaveDiagnostics(
+			report.items.filter((item) => item.workflow_name === activeWorkflowName),
+		);
+		setEditingWorkflow(true);
+	}, [activeWorkflowName, report.items]);
+
+	const handleSaveWorkflow = useCallback(
+		async (content: string) => {
+			if (!activeWorkflowName) {
+				return { ok: false as const, error: "No workflow selected" };
+			}
+			const result = await saveWorkflowSource(content, activeWorkflowName);
+			if (result.ok) {
+				setEditingWorkflow(false);
+				setWorkflowSaveDiagnostics([]);
+				selectWorkflow(result.workflow.name);
+				return { ok: true as const, workflow: result.workflow };
+			}
+			const diagnostics = result.diagnostics ?? [];
+			setWorkflowSaveDiagnostics(diagnostics);
+			return {
+				ok: false as const,
+				error: result.error,
+				diagnostics,
+			};
+		},
+		[activeWorkflowName, saveWorkflowSource, selectWorkflow],
+	);
 
 	const handleEditFacet = useCallback(() => {
 		setEditingFacet(true);
@@ -104,7 +139,17 @@ export function AutomationSection({
 
 	const handleCreateWorkflow = useCallback(
 		async (name: string) => {
-			const source = [`name: ${name}`, 'description: ""', ""].join("\n");
+			const source = [
+				`name: ${name}`,
+				'description: ""',
+				"nodes:",
+				"  - name: start",
+				"    session:",
+				"      gate: auto",
+				"      permission: edit",
+				"      facets: {}",
+				"",
+			].join("\n");
 			const result = await saveWorkflowSource(source);
 			if (result.ok) {
 				selectWorkflow(name);
@@ -165,7 +210,7 @@ export function AutomationSection({
 		return facets.find((f) => f.key === selectedFacetKey)?.builtin ?? false;
 	}, [selectedFacetKey, facets]);
 
-	const isEditing = editingFacet;
+	const isEditing = editingFacet || editingWorkflow;
 
 	const handleReloadExternal = useCallback(() => {
 		clearExternalChange();
@@ -173,12 +218,20 @@ export function AutomationSection({
 			setEditingFacet(false);
 			selectFacet(selectedFacetKind, selectedFacetKey);
 		}
+		if (editingWorkflow && activeWorkflowName) {
+			setEditingWorkflow(false);
+			setWorkflowSaveDiagnostics([]);
+			selectWorkflow(activeWorkflowName);
+		}
 	}, [
 		clearExternalChange,
 		editingFacet,
+		editingWorkflow,
+		activeWorkflowName,
 		selectedFacetKind,
 		selectedFacetKey,
 		selectFacet,
+		selectWorkflow,
 	]);
 
 	if (loading) {
@@ -232,8 +285,12 @@ export function AutomationSection({
 							<WorkflowList
 								workflows={workflows}
 								report={report}
-								selectedName={selectedWorkflow?.name ?? null}
-								onSelect={selectWorkflow}
+								selectedName={activeWorkflowName}
+								onSelect={(name) => {
+									setEditingWorkflow(false);
+									setWorkflowSaveDiagnostics([]);
+									selectWorkflow(name);
+								}}
 								onDelete={(name) => {
 									const isRunning = workflows.some(
 										(w) => w.name === name && w.is_running,
@@ -242,6 +299,10 @@ export function AutomationSection({
 										? `ワークフロー '${name}' は現在実行中です。削除しますか？`
 										: `ワークフロー '${name}' を削除しますか？`;
 									if (!window.confirm(message)) return;
+									if (activeWorkflowName === name) {
+										setEditingWorkflow(false);
+										setWorkflowSaveDiagnostics([]);
+									}
 									deleteWorkflow(name);
 								}}
 								onDuplicate={(name) => {
@@ -251,17 +312,53 @@ export function AutomationSection({
 									});
 									setDuplicateDialogOpen(true);
 								}}
-								onOpenInEditor={openWorkflowInEditor}
+								onEdit={(name) => {
+									setEditingWorkflow(true);
+									setWorkflowSaveDiagnostics(
+										report.items.filter((item) => item.workflow_name === name),
+									);
+									if (activeWorkflowName !== name) {
+										selectWorkflow(name);
+									}
+								}}
 								onCreate={() => setCreateWorkflowOpen(true)}
 							/>
 						</div>
 
 						{/* Right: detail / editor */}
 						<div className="flex-1 min-w-0">
-							{selectedWorkflow ? (
+							{editingWorkflow &&
+							activeWorkflowName &&
+							selectedWorkflowSource ? (
+								<WorkflowSourceEditor
+									key={activeWorkflowName}
+									name={activeWorkflowName}
+									initialSource={selectedWorkflowSource}
+									diagnostics={
+										workflowSaveDiagnostics.length > 0
+											? workflowSaveDiagnostics
+											: report.items.filter(
+													(item) => item.workflow_name === activeWorkflowName,
+												)
+									}
+									onSave={handleSaveWorkflow}
+									onCancel={() => {
+										setEditingWorkflow(false);
+										setWorkflowSaveDiagnostics([]);
+									}}
+								/>
+							) : selectedWorkflow ? (
 								<WorkflowDetail
 									workflow={selectedWorkflow}
 									report={report}
+									source={selectedWorkflowSource}
+									onEdit={handleEditWorkflow}
+								/>
+							) : activeWorkflowName && selectedWorkflowSource ? (
+								<WorkflowSourceDiagnosticDetail
+									name={activeWorkflowName}
+									report={report}
+									source={selectedWorkflowSource}
 									onEdit={handleEditWorkflow}
 								/>
 							) : (

--- a/src/components/panels/SettingsModal.test.tsx
+++ b/src/components/panels/SettingsModal.test.tsx
@@ -10,6 +10,29 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { type AppSettings, DEFAULT_SETTINGS } from "@/types/settings";
 import { SettingsModal } from "./SettingsModal";
 
+const monacoMock = vi.hoisted(() => {
+	const model = {
+		getValue: vi.fn(() => "name: my-workflow\nnodes: []\n"),
+		dispose: vi.fn(),
+	};
+	const editor = {
+		dispose: vi.fn(),
+		onDidChangeModelContent: vi.fn(() => ({ dispose: vi.fn() })),
+	};
+	return {
+		module: {
+			MarkerSeverity: { Error: 8, Warning: 4, Info: 2 },
+			editor: {
+				createModel: vi.fn(() => model),
+				create: vi.fn(() => editor),
+				setModelMarkers: vi.fn(),
+			},
+		},
+	};
+});
+
+vi.mock("monaco-editor", () => monacoMock.module);
+
 // Radix UI uses pointer events; jsdom doesn't implement them
 beforeAll(() => {
 	HTMLElement.prototype.hasPointerCapture = vi.fn() as never;
@@ -683,7 +706,7 @@ describe("SettingsModal", () => {
 		});
 	});
 
-	it("should call open_workflow_in_editor for custom workflow", async () => {
+	it("should open custom workflow in the panel editor", async () => {
 		const user = userEvent.setup();
 		const { invoke } = await import("@tauri-apps/api/core");
 		const emptyReport = {
@@ -700,10 +723,18 @@ describe("SettingsModal", () => {
 							name: "my-workflow",
 							description: "カスタムワークフロー",
 							builtin: false,
+							is_running: false,
 						},
 					]);
-				case "open_workflow_in_editor":
-					return Promise.resolve(null);
+				case "get_workflow_source":
+					return Promise.resolve("name: my-workflow\nnodes: []\n");
+				case "get_workflow":
+					return Promise.resolve({
+						name: "my-workflow",
+						description: "カスタムワークフロー",
+						builtin: false,
+						nodes: [],
+					});
 				case "diagnose_all_cmd":
 					return Promise.resolve(emptyReport);
 				default:
@@ -718,11 +749,18 @@ describe("SettingsModal", () => {
 			expect(screen.getByText("my-workflow")).toBeInTheDocument();
 		});
 
-		await user.click(screen.getByTitle("Open in editor"));
+		await user.click(screen.getByTitle("Edit"));
 
-		expect(vi.mocked(invoke)).toHaveBeenCalledWith("open_workflow_in_editor", {
+		await waitFor(() => {
+			expect(screen.getByText("Workflow YAML")).toBeInTheDocument();
+		});
+		expect(vi.mocked(invoke)).toHaveBeenCalledWith("get_workflow_source", {
 			name: "my-workflow",
 		});
+		expect(vi.mocked(invoke)).not.toHaveBeenCalledWith(
+			"open_workflow_in_editor",
+			expect.anything(),
+		);
 	});
 
 	it("should call delete_workflow when Delete button is clicked", async () => {

--- a/src/components/panels/automation/DiagnosticBadge.test.tsx
+++ b/src/components/panels/automation/DiagnosticBadge.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { DiagnosticItem } from "@/types/workflow";
+import { DiagnosticItemRow } from "./DiagnosticBadge";
+
+function diagnostic(overrides: Partial<DiagnosticItem> = {}): DiagnosticItem {
+	return {
+		code: "WFT001",
+		severity: "error",
+		stage: "typecheck",
+		message: "when.on field must be boolean",
+		...overrides,
+	};
+}
+
+describe("DiagnosticItemRow", () => {
+	it("renders code, formatted stage, and span label when span is present", () => {
+		render(
+			<DiagnosticItemRow
+				item={diagnostic({
+					span: {
+						start_line: 12,
+						start_col: 7,
+						end_line: 12,
+						end_col: 11,
+					},
+				})}
+			/>,
+		);
+
+		expect(screen.getByText("WFT001")).toBeInTheDocument();
+		expect(screen.getByText("typecheck")).toBeInTheDocument();
+		expect(screen.getByText("12:7")).toBeInTheDocument();
+	});
+
+	it("omits span label when span is absent and formats snake_case stage", () => {
+		render(
+			<DiagnosticItemRow
+				item={diagnostic({
+					code: "WFR003",
+					stage: "parse_shape",
+					span: undefined,
+				})}
+			/>,
+		);
+
+		expect(screen.getByText("WFR003")).toBeInTheDocument();
+		expect(screen.getByText("parse shape")).toBeInTheDocument();
+		expect(screen.queryByText(/^\d+:\d+$/)).not.toBeInTheDocument();
+	});
+});

--- a/src/components/panels/automation/DiagnosticBadge.tsx
+++ b/src/components/panels/automation/DiagnosticBadge.tsx
@@ -38,11 +38,29 @@ export function DiagnosticItemRow({ item }: { item: DiagnosticItem }) {
 		) : (
 			<Info className="size-3 text-blue-500 shrink-0" />
 		);
+	const spanLabel = item.span
+		? `${item.span.start_line}:${item.span.start_col}`
+		: null;
 
 	return (
-		<div className="flex items-start gap-1.5 text-xs">
+		<div className="flex items-start gap-2 text-xs">
 			{icon}
-			<span className="text-muted-foreground">{item.message}</span>
+			<div className="min-w-0 flex-1">
+				<div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+					<span className="font-mono text-[10px] font-medium text-foreground">
+						{item.code}
+					</span>
+					{spanLabel && (
+						<span className="font-mono text-[10px] text-muted-foreground">
+							{spanLabel}
+						</span>
+					)}
+					<span className="text-[10px] text-muted-foreground">
+						{item.stage.replace("_", " ")}
+					</span>
+				</div>
+				<div className="break-words text-muted-foreground">{item.message}</div>
+			</div>
 		</div>
 	);
 }

--- a/src/components/panels/automation/FacetDetail.tsx
+++ b/src/components/panels/automation/FacetDetail.tsx
@@ -49,7 +49,7 @@ export function FacetDetail({
 					<span className="text-xs font-medium">Diagnostics</span>
 					{diagnosticItems.map((item) => (
 						<DiagnosticItemRow
-							key={`${item.severity}-${item.message}-${item.field ?? ""}`}
+							key={`${item.code}-${item.span?.start_line ?? "na"}-${item.span?.start_col ?? "na"}-${item.message}-${item.field ?? ""}`}
 							item={item}
 						/>
 					))}

--- a/src/components/panels/automation/WorkflowDetail.test.tsx
+++ b/src/components/panels/automation/WorkflowDetail.test.tsx
@@ -1,8 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { DiagnosticReport, Workflow } from "@/types/workflow";
-import { WorkflowDetail } from "./WorkflowDetail";
+import {
+	WorkflowDetail,
+	WorkflowSourceDiagnosticDetail,
+} from "./WorkflowDetail";
+
+const monacoMock = vi.hoisted(() => {
+	const model = { dispose: vi.fn() };
+	const editor = { dispose: vi.fn() };
+	return {
+		model,
+		module: {
+			MarkerSeverity: { Error: 8, Warning: 4, Info: 2 },
+			editor: {
+				createModel: vi.fn(() => model),
+				create: vi.fn(() => editor),
+				setModelMarkers: vi.fn(),
+			},
+		},
+	};
+});
+
+vi.mock("monaco-editor", () => monacoMock.module);
 
 const EMPTY_REPORT: DiagnosticReport = {
 	items: [],
@@ -96,5 +117,91 @@ describe("WorkflowDetail facet refs row", () => {
 		await user.click(screen.getByText("implement"));
 
 		expect(screen.queryByText(matchLabel("Input"))).not.toBeInTheDocument();
+	});
+});
+
+describe("WorkflowDetail Monaco diagnostics", () => {
+	it("sets workflow diagnostic markers from spanned items only", async () => {
+		vi.clearAllMocks();
+		const report: DiagnosticReport = {
+			items: [
+				{
+					code: "WFT001",
+					severity: "error",
+					stage: "typecheck",
+					span: {
+						start_line: 3,
+						start_col: 5,
+						end_line: 3,
+						end_col: 5,
+					},
+					message: "when.on field must be boolean",
+					workflow_name: "wf",
+				},
+				{
+					code: "WFR003",
+					severity: "warning",
+					stage: "resolve",
+					span: {
+						start_line: 4,
+						start_col: 2,
+						end_line: 4,
+						end_col: 8,
+					},
+					message: "unknown reference",
+					workflow_name: "wf",
+				},
+				{
+					code: "WFC001",
+					severity: "error",
+					stage: "control_flow",
+					message: "unreachable",
+					workflow_name: "wf",
+				},
+			],
+			workflow_summaries: {},
+			facet_summaries: {},
+			facet_usage: {},
+		};
+
+		render(
+			<WorkflowSourceDiagnosticDetail
+				name="wf"
+				report={report}
+				source={"name: wf\nnodes: []\n"}
+				onEdit={vi.fn()}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(monacoMock.module.editor.setModelMarkers).toHaveBeenCalled();
+		});
+		const markerCall = monacoMock.module.editor.setModelMarkers.mock.calls.find(
+			([, owner, markers]) =>
+				owner === "workflow-diagnostics" && markers.length > 0,
+		);
+		expect(markerCall).toBeTruthy();
+		expect(markerCall?.[0]).toBe(monacoMock.model);
+		expect(markerCall?.[1]).toBe("workflow-diagnostics");
+		expect(markerCall?.[2]).toEqual([
+			{
+				severity: 8,
+				message: "WFT001: when.on field must be boolean",
+				startLineNumber: 3,
+				startColumn: 5,
+				endLineNumber: 3,
+				endColumn: 6,
+				code: "WFT001",
+			},
+			{
+				severity: 4,
+				message: "WFR003: unknown reference",
+				startLineNumber: 4,
+				startColumn: 2,
+				endLineNumber: 4,
+				endColumn: 8,
+				code: "WFR003",
+			},
+		]);
 	});
 });

--- a/src/components/panels/automation/WorkflowDetail.tsx
+++ b/src/components/panels/automation/WorkflowDetail.tsx
@@ -1,8 +1,9 @@
-import { ChevronDown, ChevronRight } from "lucide-react";
-import { useState } from "react";
+import { ChevronDown, ChevronRight, Save, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import type {
+	DiagnosticItem,
 	DiagnosticReport,
 	NodeDefinition,
 	Workflow,
@@ -11,13 +12,19 @@ import { DiagnosticItemRow } from "./DiagnosticBadge";
 
 type WorkflowRule = NonNullable<NodeDefinition["rules"]>[number];
 
+type WorkflowSaveResult =
+	| { ok: true; workflow?: Workflow }
+	| { ok: false; error: string; diagnostics?: DiagnosticItem[] };
+
 export function WorkflowDetail({
 	workflow,
 	report,
+	source,
 	onEdit,
 }: {
 	workflow: Workflow;
 	report: DiagnosticReport;
+	source?: string | null;
 	onEdit: () => void;
 }) {
 	const items = report.items.filter((i) => i.workflow_name === workflow.name);
@@ -43,12 +50,14 @@ export function WorkflowDetail({
 					<span className="text-xs font-medium">Diagnostics</span>
 					{items.map((item) => (
 						<DiagnosticItemRow
-							key={`${item.severity}-${item.message}-${item.field ?? ""}`}
+							key={`${item.code}-${item.span?.start_line ?? "na"}-${item.span?.start_col ?? "na"}-${item.message}-${item.field ?? ""}`}
 							item={item}
 						/>
 					))}
 				</div>
 			)}
+
+			{source && <WorkflowSourcePane source={source} diagnostics={items} />}
 
 			<div className="flex flex-col gap-2">
 				<span className="text-xs font-medium text-muted-foreground">
@@ -60,6 +69,278 @@ export function WorkflowDetail({
 			</div>
 		</div>
 	);
+}
+
+export function WorkflowSourceDiagnosticDetail({
+	name,
+	report,
+	source,
+	onEdit,
+}: {
+	name: string;
+	report: DiagnosticReport;
+	source: string;
+	onEdit: () => void;
+}) {
+	const items = report.items.filter((i) => i.workflow_name === name);
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex items-center justify-between">
+				<div>
+					<h4 className="text-sm font-medium">{name}</h4>
+					<p className="text-xs text-muted-foreground">
+						Invalid workflow definition
+					</p>
+				</div>
+				<Button variant="outline" size="sm" onClick={onEdit}>
+					Edit
+				</Button>
+			</div>
+
+			{items.length > 0 && (
+				<div className="flex flex-col gap-1.5 rounded-md border border-border p-3">
+					<span className="text-xs font-medium">Diagnostics</span>
+					{items.map((item) => (
+						<DiagnosticItemRow
+							key={`${item.code}-${item.span?.start_line ?? "na"}-${item.span?.start_col ?? "na"}-${item.message}-${item.field ?? ""}`}
+							item={item}
+						/>
+					))}
+				</div>
+			)}
+
+			<WorkflowSourcePane source={source} diagnostics={items} />
+		</div>
+	);
+}
+
+export function WorkflowSourceEditor({
+	name,
+	initialSource,
+	diagnostics,
+	onSave,
+	onCancel,
+}: {
+	name: string;
+	initialSource: string;
+	diagnostics: DiagnosticItem[];
+	onSave: (source: string) => Promise<WorkflowSaveResult>;
+	onCancel: () => void;
+}) {
+	const hostRef = useRef<HTMLDivElement | null>(null);
+	const editorRef = useRef<
+		import("monaco-editor").editor.IStandaloneCodeEditor | null
+	>(null);
+	const modelRef = useRef<import("monaco-editor").editor.ITextModel | null>(
+		null,
+	);
+	const monacoRef = useRef<typeof import("monaco-editor") | null>(null);
+	const [content, setContent] = useState(initialSource);
+	const [saving, setSaving] = useState(false);
+	const [saveError, setSaveError] = useState<string | null>(null);
+	const markerDiagnostics = useMemo(
+		() => diagnostics.filter((item) => item.span),
+		[diagnostics],
+	);
+	const markerDiagnosticsRef = useRef(markerDiagnostics);
+
+	useEffect(() => {
+		setContent(initialSource);
+	}, [initialSource]);
+
+	useEffect(() => {
+		let disposed = false;
+		let cleanup: (() => void) | undefined;
+
+		void import("monaco-editor").then((monaco) => {
+			if (disposed || !hostRef.current) return;
+
+			monacoRef.current = monaco;
+			const model = monaco.editor.createModel(initialSource, "yaml");
+			modelRef.current = model;
+			const editor = monaco.editor.create(hostRef.current, {
+				model,
+				readOnly: false,
+				minimap: { enabled: false },
+				scrollBeyondLastLine: false,
+				automaticLayout: true,
+				lineNumbers: "on",
+				overviewRulerLanes: 2,
+				tabSize: 2,
+			});
+			const subscription = editor.onDidChangeModelContent(() => {
+				setContent(model.getValue());
+			});
+			editorRef.current = editor;
+			applyMonacoMarkers(monaco, model, markerDiagnosticsRef.current);
+			cleanup = () => {
+				monaco.editor.setModelMarkers(model, "workflow-diagnostics", []);
+				subscription.dispose();
+				editor.dispose();
+				model.dispose();
+				editorRef.current = null;
+				modelRef.current = null;
+				monacoRef.current = null;
+			};
+		});
+
+		return () => {
+			disposed = true;
+			cleanup?.();
+		};
+	}, [initialSource]);
+
+	useEffect(() => {
+		markerDiagnosticsRef.current = markerDiagnostics;
+		if (!monacoRef.current || !modelRef.current) return;
+		applyMonacoMarkers(monacoRef.current, modelRef.current, markerDiagnostics);
+	}, [markerDiagnostics]);
+
+	const handleSave = async () => {
+		setSaving(true);
+		setSaveError(null);
+		const result = await onSave(content);
+		setSaving(false);
+		if (!result.ok) {
+			setSaveError(result.error);
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div className="flex items-center justify-between">
+				<div>
+					<h4 className="text-sm font-medium">{name}</h4>
+					<p className="text-xs text-muted-foreground">Workflow YAML</p>
+				</div>
+				<div className="flex items-center gap-2">
+					<Button variant="outline" size="sm" onClick={onCancel}>
+						<X className="size-3.5" />
+						Cancel
+					</Button>
+					<Button size="sm" onClick={handleSave} disabled={saving}>
+						<Save className="size-3.5" />
+						{saving ? "Saving..." : "Save"}
+					</Button>
+				</div>
+			</div>
+
+			{saveError && <p className="text-xs text-destructive">{saveError}</p>}
+
+			{diagnostics.length > 0 && (
+				<div className="flex flex-col gap-1.5 rounded-md border border-border p-3">
+					<span className="text-xs font-medium">Diagnostics</span>
+					{diagnostics.map((item) => (
+						<DiagnosticItemRow
+							key={`${item.code}-${item.span?.start_line ?? "na"}-${item.span?.start_col ?? "na"}-${item.message}-${item.field ?? ""}`}
+							item={item}
+						/>
+					))}
+				</div>
+			)}
+
+			<div
+				ref={hostRef}
+				className="h-96 overflow-hidden rounded-md border border-border"
+			/>
+		</div>
+	);
+}
+
+function WorkflowSourcePane({
+	source,
+	diagnostics,
+}: {
+	source: string;
+	diagnostics: DiagnosticItem[];
+}) {
+	const hostRef = useRef<HTMLDivElement | null>(null);
+	const editorRef = useRef<
+		import("monaco-editor").editor.IStandaloneCodeEditor | null
+	>(null);
+	const modelRef = useRef<import("monaco-editor").editor.ITextModel | null>(
+		null,
+	);
+
+	const markerDiagnostics = useMemo(
+		() => diagnostics.filter((item) => item.span),
+		[diagnostics],
+	);
+
+	useEffect(() => {
+		let disposed = false;
+		let cleanup: (() => void) | undefined;
+
+		void import("monaco-editor").then((monaco) => {
+			if (disposed || !hostRef.current) return;
+
+			const model = monaco.editor.createModel(source, "yaml");
+			modelRef.current = model;
+			const editor = monaco.editor.create(hostRef.current, {
+				model,
+				readOnly: true,
+				minimap: { enabled: false },
+				scrollBeyondLastLine: false,
+				automaticLayout: true,
+				lineNumbers: "on",
+				renderLineHighlight: "none",
+				overviewRulerLanes: 2,
+			});
+			editorRef.current = editor;
+			applyMonacoMarkers(monaco, model, markerDiagnostics);
+			cleanup = () => {
+				monaco.editor.setModelMarkers(model, "workflow-diagnostics", []);
+				editor.dispose();
+				model.dispose();
+				editorRef.current = null;
+				modelRef.current = null;
+			};
+		});
+
+		return () => {
+			disposed = true;
+			cleanup?.();
+		};
+	}, [source, markerDiagnostics]);
+
+	return (
+		<div className="flex flex-col gap-1.5">
+			<span className="text-xs font-medium text-muted-foreground">YAML</span>
+			<div
+				ref={hostRef}
+				className="h-64 overflow-hidden rounded-md border border-border"
+			/>
+		</div>
+	);
+}
+
+function applyMonacoMarkers(
+	monaco: typeof import("monaco-editor"),
+	model: import("monaco-editor").editor.ITextModel,
+	diagnostics: DiagnosticItem[],
+) {
+	const markers = diagnostics.flatMap((item) => {
+		if (!item.span) return [];
+		const severity =
+			item.severity === "error"
+				? monaco.MarkerSeverity.Error
+				: item.severity === "warning"
+					? monaco.MarkerSeverity.Warning
+					: monaco.MarkerSeverity.Info;
+		return [
+			{
+				severity,
+				message: `${item.code}: ${item.message}`,
+				startLineNumber: item.span.start_line,
+				startColumn: item.span.start_col,
+				endLineNumber: item.span.end_line,
+				endColumn: Math.max(item.span.end_col, item.span.start_col + 1),
+				code: item.code,
+			},
+		];
+	});
+	monaco.editor.setModelMarkers(model, "workflow-diagnostics", markers);
 }
 
 function StepCard({ step, index }: { step: NodeDefinition; index: number }) {

--- a/src/components/panels/automation/WorkflowList.tsx
+++ b/src/components/panels/automation/WorkflowList.tsx
@@ -1,4 +1,4 @@
-import { Copy, ExternalLink, Plus, Trash2 } from "lucide-react";
+import { Copy, Pencil, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { DiagnosticReport, WorkflowSummary } from "@/types/workflow";
@@ -11,7 +11,7 @@ export function WorkflowList({
 	onSelect,
 	onDelete,
 	onDuplicate,
-	onOpenInEditor,
+	onEdit,
 	onCreate,
 }: {
 	workflows: WorkflowSummary[];
@@ -20,7 +20,7 @@ export function WorkflowList({
 	onSelect: (name: string) => void;
 	onDelete: (name: string) => void;
 	onDuplicate: (name: string) => void;
-	onOpenInEditor: (name: string) => void;
+	onEdit: (name: string) => void;
 	onCreate: () => void;
 }) {
 	return (
@@ -97,10 +97,10 @@ export function WorkflowList({
 										variant="ghost"
 										size="icon"
 										className="size-6"
-										onClick={() => onOpenInEditor(wf.name)}
-										title="Open in editor"
+										onClick={() => onEdit(wf.name)}
+										title="Edit"
 									>
-										<ExternalLink className="size-3" />
+										<Pencil className="size-3" />
 									</Button>
 									<Button
 										variant="ghost"

--- a/src/hooks/useAutomation.test.ts
+++ b/src/hooks/useAutomation.test.ts
@@ -76,7 +76,8 @@ describe("useAutomation", () => {
 			nodes: [sessionNode],
 		};
 		mockInvoke.mockImplementation((cmd: string) => {
-			if (cmd === "save_workflow_source") return Promise.resolve(savedWorkflow);
+			if (cmd === "save_workflow_source")
+				return Promise.resolve({ ok: true, workflow: savedWorkflow });
 			if (cmd === "list_workflows") return Promise.resolve([]);
 			if (cmd === "diagnose_all_cmd")
 				return Promise.resolve({
@@ -107,6 +108,56 @@ describe("useAutomation", () => {
 			originalName: "old-name",
 		});
 		expect(result.current.selectedWorkflow).toEqual(savedWorkflow);
+		expect(result.current.selectedWorkflowName).toBe("source-wf");
+	});
+
+	it("saveWorkflowSource returns structured diagnostics without stringifying them", async () => {
+		const diagnostics = [
+			{
+				code: "WFT001",
+				severity: "error",
+				stage: "typecheck",
+				span: { start_line: 3, start_col: 5, end_line: 3, end_col: 9 },
+				message: "when.on field must be boolean",
+				workflow_name: "source-wf",
+				field: "rules.when.on",
+			},
+		];
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "save_workflow_source")
+				return Promise.resolve({
+					ok: false,
+					error: "workflow_diagnostics",
+					diagnostics,
+				});
+			if (cmd === "list_workflows") return Promise.resolve([]);
+			if (cmd === "diagnose_all_cmd")
+				return Promise.resolve({
+					items: [],
+					workflow_summaries: {},
+					facet_summaries: {},
+					facet_usage: {},
+				});
+			return Promise.resolve(undefined);
+		});
+		const { result } = renderHook(() => useAutomation(true));
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("list_workflows");
+		});
+
+		let saveResult!: Awaited<
+			ReturnType<typeof result.current.saveWorkflowSource>
+		>;
+		await act(async () => {
+			saveResult = await result.current.saveWorkflowSource("bad", "source-wf");
+		});
+
+		expect(saveResult).toEqual({
+			ok: false,
+			error: "workflow_diagnostics",
+			diagnostics,
+		});
 	});
 
 	it("deleteWorkflow invokes delete_workflow and refetches", async () => {
@@ -261,9 +312,68 @@ describe("useAutomation", () => {
 			name: "test",
 		});
 		expect(result.current.selectedWorkflow).toEqual(mockWorkflow);
+		expect(result.current.selectedWorkflowName).toBe("test");
 		expect(result.current.selectedWorkflowSource).toBe(
 			"name: test\nnodes: []\n",
 		);
+	});
+
+	it("selectWorkflow keeps source when typed workflow load returns diagnostics", async () => {
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "get_workflow") {
+				return Promise.reject("workflow_diagnostics: WFS005: legacy field");
+			}
+			if (cmd === "get_workflow_source") {
+				return Promise.resolve("name: broken\nnodes:\n  - type: agent\n");
+			}
+			if (cmd === "list_workflows") return Promise.resolve([]);
+			if (cmd === "diagnose_all_cmd") {
+				return Promise.resolve({
+					items: [
+						{
+							code: "WFS005",
+							severity: "error",
+							stage: "parse_shape",
+							span: {
+								start_line: 3,
+								start_col: 5,
+								end_line: 3,
+								end_col: 15,
+							},
+							message: "legacy field",
+							workflow_name: "broken",
+						},
+					],
+					workflow_summaries: {
+						broken: { error_count: 1, warning_count: 0, info_count: 0 },
+					},
+					facet_summaries: {},
+					facet_usage: {},
+				});
+			}
+			return Promise.resolve(undefined);
+		});
+
+		const { result } = renderHook(() => useAutomation(true));
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith("list_workflows");
+		});
+
+		await act(async () => {
+			await result.current.selectWorkflow("broken");
+		});
+
+		expect(result.current.selectedWorkflow).toBeNull();
+		expect(result.current.selectedWorkflowName).toBe("broken");
+		expect(result.current.selectedWorkflowSource).toBe(
+			"name: broken\nnodes:\n  - type: agent\n",
+		);
+		expect(result.current.report.workflow_summaries.broken).toEqual({
+			error_count: 1,
+			warning_count: 0,
+			info_count: 0,
+		});
 	});
 
 	it("deleteFacet invokes delete_facet and refreshes", async () => {

--- a/src/hooks/useAutomation.ts
+++ b/src/hooks/useAutomation.ts
@@ -5,6 +5,7 @@ import type {
 	DiagnosticReport,
 	FacetKind,
 	FacetSummary,
+	SaveWorkflowSourceResponse,
 	Workflow,
 	WorkflowSummary,
 } from "@/types/workflow";
@@ -28,6 +29,9 @@ export function useAutomation(open: boolean) {
 	const [selectedWorkflow, setSelectedWorkflow] = useState<Workflow | null>(
 		null,
 	);
+	const [selectedWorkflowName, setSelectedWorkflowName] = useState<
+		string | null
+	>(null);
 	const [selectedWorkflowSource, setSelectedWorkflowSource] = useState<
 		string | null
 	>(null);
@@ -88,6 +92,7 @@ export function useAutomation(open: boolean) {
 		}
 		return () => {
 			setSelectedWorkflow(null);
+			setSelectedWorkflowName(null);
 			setSelectedWorkflowSource(null);
 			setSelectedFacetContent(null);
 			setSelectedFacetKey(null);
@@ -148,27 +153,50 @@ export function useAutomation(open: boolean) {
 
 	// --- Workflow operations ---
 
-	const selectWorkflow = useCallback(async (name: string) => {
-		try {
-			const [wf, source] = await Promise.all([
-				invoke<Workflow>("get_workflow", { name }),
-				invoke<string>("get_workflow_source", { name }),
-			]);
-			setSelectedWorkflow(wf);
-			setSelectedWorkflowSource(source);
-		} catch (e) {
-			setError(String(e));
-		}
-	}, []);
+	const selectWorkflow = useCallback(
+		async (name: string) => {
+			setSelectedWorkflowName(name);
+			setError(null);
+			try {
+				const source = await invoke<string>("get_workflow_source", { name });
+				setSelectedWorkflowSource(source);
+				try {
+					const wf = await invoke<Workflow>("get_workflow", { name });
+					setSelectedWorkflow(wf);
+				} catch (e) {
+					setSelectedWorkflow(null);
+					setError(String(e));
+					await refreshDiagnostics();
+				}
+			} catch (e) {
+				setSelectedWorkflow(null);
+				setSelectedWorkflowSource(null);
+				setError(String(e));
+			}
+		},
+		[refreshDiagnostics],
+	);
 
 	const saveWorkflowSource = useCallback(
 		async (source: string, originalName?: string) => {
 			try {
-				const workflow = await invoke<Workflow>("save_workflow_source", {
-					source,
-					originalName: originalName ?? null,
-				});
+				const response = await invoke<SaveWorkflowSourceResponse>(
+					"save_workflow_source",
+					{
+						source,
+						originalName: originalName ?? null,
+					},
+				);
+				if (!response.ok) {
+					return {
+						ok: false as const,
+						error: response.error ?? "workflow_diagnostics",
+						diagnostics: response.diagnostics,
+					};
+				}
+				const { workflow } = response;
 				setSelectedWorkflow(workflow);
+				setSelectedWorkflowName(workflow.name);
 				setSelectedWorkflowSource(source);
 				await fetchAll();
 				return { ok: true as const, workflow };
@@ -184,8 +212,9 @@ export function useAutomation(open: boolean) {
 		async (name: string) => {
 			try {
 				await invoke("delete_workflow", { name });
-				if (selectedWorkflow?.name === name) {
+				if ((selectedWorkflow?.name ?? selectedWorkflowName) === name) {
 					setSelectedWorkflow(null);
+					setSelectedWorkflowName(null);
 					setSelectedWorkflowSource(null);
 				}
 				await fetchAll();
@@ -193,7 +222,7 @@ export function useAutomation(open: boolean) {
 				setError(String(e));
 			}
 		},
-		[fetchAll, selectedWorkflow],
+		[fetchAll, selectedWorkflow, selectedWorkflowName],
 	);
 
 	const duplicateWorkflow = useCallback(
@@ -324,6 +353,7 @@ export function useAutomation(open: boolean) {
 		clearExternalChange,
 
 		selectedWorkflow,
+		selectedWorkflowName,
 		selectedWorkflowSource,
 		selectedFacetContent,
 		selectedFacetKey,

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -276,9 +276,20 @@ export interface FacetSummary {
 }
 
 type DiagnosticSeverity = "error" | "warning" | "info";
+type DiagnosticStage = "parse_shape" | "resolve" | "typecheck" | "control_flow";
+
+interface DiagnosticSpan {
+	start_line: number;
+	start_col: number;
+	end_line: number;
+	end_col: number;
+}
 
 export interface DiagnosticItem {
+	code: string;
 	severity: DiagnosticSeverity;
+	stage: DiagnosticStage;
+	span?: DiagnosticSpan;
 	message: string;
 	workflow_name?: string;
 	step_name?: string;
@@ -305,3 +316,17 @@ export interface DiagnosticReport {
 	facet_summaries: Record<string, DiagnosticSummary>;
 	facet_usage: Record<string, FacetUsageEntry[]>;
 }
+
+export type SaveWorkflowSourceResponse =
+	| {
+			ok: true;
+			workflow: Workflow;
+			diagnostics?: DiagnosticItem[];
+			error?: string;
+	  }
+	| {
+			ok: false;
+			workflow?: null;
+			diagnostics: DiagnosticItem[];
+			error?: string;
+	  };


### PR DESCRIPTION
## Summary
- WorkflowDefinition validation diagnostics are grouped into structured stage/code/severity data.
- Adds span mapping plus valid/invalid workflow fixtures for diagnostic coverage.
- Updates backend commands and Automation UI types/views to surface diagnostic details.

## Tests
- Not run in this PR creation pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ワークフローを設定画面内で直接編集・保存できるようになりました。
  * YAMLの診断結果をコード、検証ステージ、行・列位置付きで表示します。
  * 保存に失敗した場合も、具体的な診断内容を確認できます。
  * ワークフローの編集操作を「Edit」として利用できるようになりました。

* **改善**
  * 無効なワークフローも診断情報付きで一覧に保持し、問題箇所を確認しやすくしました。
  * ルーティングや参照エラーの検証メッセージを具体化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->