### PR TITLE
feat: update Codex models to GPT-5.6

### DIFF
--- a/src-tauri/src/adaptor/gateway/workflow/builtin.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin.rs
@@ -5,17 +5,17 @@ use super::facet::{self, FacetError, FacetKind};
 use super::schema::{Summary, Workflow};
 use crate::domain::workflow::validation::{self, ValidationError};
 
-const BUILTIN_AUTHORING_GPT55: &str = include_str!("builtin/01_authoring_gpt55.yml");
-const BUILTIN_AUTHORING_OPUS48: &str = include_str!("builtin/01_authoring_opus48.yml");
+const BUILTIN_AUTHORING_CODEX: &str = include_str!("builtin/01_authoring_codex.yml");
+const BUILTIN_AUTHORING_CLAUDE: &str = include_str!("builtin/01_authoring_claude.yml");
 const BUILTIN_AUTHORING_DRAFT: &str = include_str!("builtin/01_authoring_draft.yml");
-const BUILTIN_IMPLEMENT_GPT55: &str = include_str!("builtin/02_implement_gpt55.yml");
-const BUILTIN_IMPLEMENT_OPUS48: &str = include_str!("builtin/02_implement_opus48.yml");
+const BUILTIN_IMPLEMENT_CODEX: &str = include_str!("builtin/02_implement_codex.yml");
+const BUILTIN_IMPLEMENT_CLAUDE: &str = include_str!("builtin/02_implement_claude.yml");
 const BUILTIN_FULL_REVIEW: &str = include_str!("builtin/03_full-review.yml");
 const BUILTIN_REVIEW: &str = include_str!("builtin/03_review.yml");
 const BUILTIN_REVIEW_FIX_POLICY: &str = include_str!("builtin/04_review-fix-policy.yml");
 const BUILTIN_REVIEW_FIX: &str = include_str!("builtin/05_review-fix.yml");
-const BUILTIN_REVIEW_FIX_GPT55: &str = include_str!("builtin/05_review-fix_gpt55.yml");
-const BUILTIN_REVIEW_FIX_OPUS48: &str = include_str!("builtin/05_review-fix_opus48.yml");
+const BUILTIN_REVIEW_FIX_CODEX: &str = include_str!("builtin/05_review-fix_codex.yml");
+const BUILTIN_REVIEW_FIX_CLAUDE: &str = include_str!("builtin/05_review-fix_claude.yml");
 const BUILTIN_VERIFY_REVIEW_COMMENTS: &str = include_str!("builtin/06_verify-review-comments.yml");
 
 struct BuiltinEntry {
@@ -26,13 +26,13 @@ struct BuiltinEntry {
 
 const BUILTINS: &[BuiltinEntry] = &[
     BuiltinEntry {
-        filename: "01_authoring_gpt55.yml",
-        content: BUILTIN_AUTHORING_GPT55,
+        filename: "01_authoring_codex.yml",
+        content: BUILTIN_AUTHORING_CODEX,
         description: "ユーザーとの対話を通じて requirements / behavior / design の Spec 3 文書をGPT系モデルで構築する。レビューループは行わない。",
     },
     BuiltinEntry {
-        filename: "01_authoring_opus48.yml",
-        content: BUILTIN_AUTHORING_OPUS48,
+        filename: "01_authoring_claude.yml",
+        content: BUILTIN_AUTHORING_CLAUDE,
         description: "ユーザーとの対話を通じて requirements / behavior / design の Spec 3 文書をClaude系モデルで構築する。レビューループは行わない。",
     },
     BuiltinEntry {
@@ -41,24 +41,24 @@ const BUILTINS: &[BuiltinEntry] = &[
         description: "requirements / behavior / design を文書ごとに Claude 系モデルで draft 方式（finalize なし）で一括作成し、Open Questions 解消後に人間のレビューを待つ。",
     },
     BuiltinEntry {
-        filename: "02_implement_gpt55.yml",
-        content: BUILTIN_IMPLEMENT_GPT55,
+        filename: "02_implement_codex.yml",
+        content: BUILTIN_IMPLEMENT_CODEX,
         description: "Spec を元にGPT系モデルで実装し、軽量レビューループ（最大 5 周、Human-in-the-Loop なし）で Spec 充足と規約適合を保証する。",
     },
     BuiltinEntry {
-        filename: "02_implement_opus48.yml",
-        content: BUILTIN_IMPLEMENT_OPUS48,
+        filename: "02_implement_claude.yml",
+        content: BUILTIN_IMPLEMENT_CLAUDE,
         description: "Spec を元にClaude系モデルで実装し、軽量レビューループ（最大 5 周、Human-in-the-Loop なし）で Spec 充足と規約適合を保証する。",
     },
     BuiltinEntry {
         filename: "03_full-review.yml",
         content: BUILTIN_FULL_REVIEW,
-        description: "全観点を claude-opus-4-8 / gpt-5.5 でレビューし、モデル単位の妥当性チェックを行う。Summary 段では各 Open Thread の reviewer 指摘と verifier 分類を Thread 単位でまとめて人間に報告する（議論・Thread 投稿は行わない）。",
+        description: "全観点を claude-opus-4-8 / gpt-5.6-sol でレビューし、モデル単位の妥当性チェックを行う。Summary 段では各 Open Thread の reviewer 指摘と verifier 分類を Thread 単位でまとめて人間に報告する（議論・Thread 投稿は行わない）。",
     },
     BuiltinEntry {
         filename: "03_review.yml",
         content: BUILTIN_REVIEW,
-        description: "Claude 系モデルと GPT-5.5 がそれぞれ 6 観点すべてを確認し、Summary 段では各 Open Thread の reviewer 指摘を Thread 単位でまとめて人間に報告する（議論・Thread 投稿は行わない）。",
+        description: "Claude 系モデルと GPT-5.6 Sol がそれぞれ 6 観点すべてを確認し、Summary 段では各 Open Thread の reviewer 指摘を Thread 単位でまとめて人間に報告する（議論・Thread 投稿は行わない）。",
     },
     BuiltinEntry {
         filename: "04_review-fix-policy.yml",
@@ -71,13 +71,13 @@ const BUILTINS: &[BuiltinEntry] = &[
         description: "フルレビューで残った Open Thread の [FIX_POLICY_APPROVED] 方針と実装差分を確認して不足を Task 化し、Task 実装ループで方針との合致を保証する。最後に人間が承認した Thread を resolve する。",
     },
     BuiltinEntry {
-        filename: "05_review-fix_gpt55.yml",
-        content: BUILTIN_REVIEW_FIX_GPT55,
+        filename: "05_review-fix_codex.yml",
+        content: BUILTIN_REVIEW_FIX_CODEX,
         description: "フルレビューで残った Open Thread の [FIX_POLICY_APPROVED] 方針と実装差分を GPT 系モデルで確認して不足を Task 化し、Task 実装ループで方針との合致を保証する。最後に人間が承認した Thread を resolve する。",
     },
     BuiltinEntry {
-        filename: "05_review-fix_opus48.yml",
-        content: BUILTIN_REVIEW_FIX_OPUS48,
+        filename: "05_review-fix_claude.yml",
+        content: BUILTIN_REVIEW_FIX_CLAUDE,
         description: "フルレビューで残った Open Thread の [FIX_POLICY_APPROVED] 方針と実装差分を確認して不足を Task 化し、Claude 系モデルで Task を実装するループで方針との合致を保証する。最後に人間が承認した Thread を resolve する。",
     },
     BuiltinEntry {

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_claude.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_claude.yml
@@ -1,4 +1,4 @@
-name: 01_authoring_opus48
+name: 01_authoring_claude
 description: ユーザーとの対話を通じて requirements / behavior / design の Spec 3 文書をClaude系モデルで構築する。レビューループは行わない。
 builtin: true
 

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_codex.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_codex.yml
@@ -1,11 +1,11 @@
-name: 01_authoring_gpt55
+name: 01_authoring_codex
 description: ユーザーとの対話を通じて requirements / behavior / design の Spec 3 文書をGPT系モデルで構築する。レビューループは行わない。
 builtin: true
 
 nodes:
   - name: write_requirements
     type: approval
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: edit
     instruction: spec-authoring-write-requirements
     policy: planning
@@ -13,7 +13,7 @@ nodes:
 
   - name: write_behavior
     type: approval
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: edit
     instruction: spec-authoring-write-behavior
     policy: planning
@@ -24,7 +24,7 @@ nodes:
 
   - name: write_design
     type: approval
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: edit
     instruction: spec-authoring-write-design
     policy: planning
@@ -35,7 +35,7 @@ nodes:
 
   - name: spec_finalize
     type: approval
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: edit
     instruction: spec-authoring-finalize
     policy: planning

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement_claude.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement_claude.yml
@@ -1,4 +1,4 @@
-name: 02_implement_opus48
+name: 02_implement_claude
 description: Spec を元にClaude系モデルで実装し、軽量レビューループ（最大 5 周、Human-in-the-Loop なし）で Spec 充足と規約適合を保証する。
 builtin: true
 
@@ -15,14 +15,14 @@ nodes:
     parallel_children:
       - name: review_spec
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: edit
         instruction: spec-implement-review-spec
         policy: reviewing
         knowledge: releash-thread-cli
       - name: review_design
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: edit
         instruction: spec-implement-review-design
         policy: reviewing

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement_codex.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement_codex.yml
@@ -1,11 +1,11 @@
-name: 02_implement_gpt55
+name: 02_implement_codex
 description: Spec を元にGPT系モデルで実装し、軽量レビューループ（最大 5 周、Human-in-the-Loop なし）で Spec 充足と規約適合を保証する。
 builtin: true
 
 nodes:
   - name: implement
     type: agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: edit
     instruction: implement
     policy: coding
@@ -15,14 +15,14 @@ nodes:
     parallel_children:
       - name: review_spec
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         instruction: spec-implement-review-spec
         policy: reviewing
         knowledge: releash-thread-cli
       - name: review_design
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         instruction: spec-implement-review-design
         policy: reviewing
@@ -30,7 +30,7 @@ nodes:
 
   - name: fix
     type: agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: full
     instruction: spec-implement-fix
     policy: coding
@@ -47,7 +47,7 @@ nodes:
 
   - name: report
     type: approval
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: full
     instruction: spec-implement-report
     knowledge: releash-thread-cli

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/03_full-review.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/03_full-review.yml
@@ -1,5 +1,5 @@
 name: 03_full-review
-description: 全観点を claude-opus-4-8 / gpt-5.5 でレビューし、モデル単位の妥当性チェックを行う。Summary 段では各 Open Thread の reviewer 指摘と verifier 分類を Thread 単位でまとめて人間に報告する（議論・Thread 投稿は行わない）。
+description: 全観点を claude-opus-4-8 / gpt-5.6-sol でレビューし、モデル単位の妥当性チェックを行う。Summary 段では各 Open Thread の reviewer 指摘と verifier 分類を Thread 単位でまとめて人間に報告する（議論・Thread 投稿は行わない）。
 builtin: true
 
 nodes:
@@ -16,7 +16,7 @@ nodes:
         instruction: review-acceptance
       - name: review-acceptance-gpt55
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         policy: reviewing
         knowledge: releash-thread-cli
@@ -30,7 +30,7 @@ nodes:
         instruction: review-structure
       - name: review-structure-gpt55
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         policy: reviewing
         knowledge: releash-thread-cli
@@ -44,7 +44,7 @@ nodes:
         instruction: review-quality
       - name: review-quality-gpt55
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         policy: reviewing
         knowledge: releash-thread-cli
@@ -58,7 +58,7 @@ nodes:
         instruction: review-test
       - name: review-test-gpt55
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         policy: reviewing
         knowledge: releash-thread-cli
@@ -72,7 +72,7 @@ nodes:
         instruction: review-security
       - name: review-security-gpt55
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         policy: reviewing
         knowledge: releash-thread-cli
@@ -86,7 +86,7 @@ nodes:
         instruction: review-architecture
       - name: review-architecture-gpt55
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         policy: reviewing
         knowledge: releash-thread-cli
@@ -112,7 +112,7 @@ nodes:
         instruction: full-review-verify-and-classify
       - name: verify-gpt55
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         policy: reviewing
         knowledge: releash-thread-cli

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/03_review.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/03_review.yml
@@ -1,5 +1,5 @@
 name: 03_review
-description: Claude 系モデルと GPT-5.5 がそれぞれ 6 観点すべてを確認し、Summary 段では各 Open Thread の reviewer 指摘を Thread 単位でまとめて人間に報告する（議論・Thread 投稿は行わない）。
+description: Claude 系モデルと GPT-5.6 Sol がそれぞれ 6 観点すべてを確認し、Summary 段では各 Open Thread の reviewer 指摘を Thread 単位でまとめて人間に報告する（議論・Thread 投稿は行わない）。
 builtin: true
 
 nodes:
@@ -16,7 +16,7 @@ nodes:
 
       - name: review-gpt55
         type: agent
-        model: gpt-5.5
+        model: gpt-5.6-sol
         permission: full
         instruction: review-all
         policy: reviewing
@@ -28,7 +28,7 @@ nodes:
 
   - name: reporting
     type: approval
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: edit
     policy: reporting
     knowledge: releash-thread-cli

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/04_review-fix-policy.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/04_review-fix-policy.yml
@@ -13,7 +13,7 @@ nodes:
 
   - name: policy_consistency_review
     type: agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: full
     instruction: review-fix-policy-consistency
     policy: reviewing

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix.yml
@@ -5,7 +5,7 @@ builtin: true
 nodes:
   - name: check_and_make_tasks
     type: agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: full
     instruction: review-fix-check-tasks
     output_contract: review-fix-tasks
@@ -19,7 +19,7 @@ nodes:
 
   - name: implement_tasks
     type: agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: full
     instruction: review-fix
     policy: coding

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix_claude.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix_claude.yml
@@ -1,11 +1,11 @@
-name: 05_review-fix_gpt55
-description: フルレビューで残った Open Thread の [FIX_POLICY_APPROVED] 方針と実装差分を GPT 系モデルで確認して不足を Task 化し、Task 実装ループで方針との合致を保証する。最後に人間が承認した Thread を resolve する。
+name: 05_review-fix_claude
+description: フルレビューで残った Open Thread の [FIX_POLICY_APPROVED] 方針と実装差分を確認して不足を Task 化し、Claude 系モデルで Task を実装するループで方針との合致を保証する。最後に人間が承認した Thread を resolve する。
 builtin: true
 
 nodes:
   - name: check_and_make_tasks
     type: agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: full
     instruction: review-fix-check-tasks
     output_contract: review-fix-tasks
@@ -19,8 +19,8 @@ nodes:
 
   - name: implement_tasks
     type: agent
-    model: gpt-5.5
-    permission: full
+    model: claude-opus-4-8
+    permission: edit
     instruction: review-fix
     policy: coding
     pass_output_from:
@@ -34,7 +34,7 @@ nodes:
 
   - name: report
     type: approval
-    model: gpt-5.5
-    permission: full
+    model: claude-opus-4-8
+    permission: edit
     instruction: review-fix-report
     knowledge: releash-thread-cli

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix_codex.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix_codex.yml
@@ -1,11 +1,11 @@
-name: 05_review-fix_opus48
-description: フルレビューで残った Open Thread の [FIX_POLICY_APPROVED] 方針と実装差分を確認して不足を Task 化し、Claude 系モデルで Task を実装するループで方針との合致を保証する。最後に人間が承認した Thread を resolve する。
+name: 05_review-fix_codex
+description: フルレビューで残った Open Thread の [FIX_POLICY_APPROVED] 方針と実装差分を GPT 系モデルで確認して不足を Task 化し、Task 実装ループで方針との合致を保証する。最後に人間が承認した Thread を resolve する。
 builtin: true
 
 nodes:
   - name: check_and_make_tasks
     type: agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: full
     instruction: review-fix-check-tasks
     output_contract: review-fix-tasks
@@ -19,8 +19,8 @@ nodes:
 
   - name: implement_tasks
     type: agent
-    model: claude-opus-4-8
-    permission: edit
+    model: gpt-5.6-sol
+    permission: full
     instruction: review-fix
     policy: coding
     pass_output_from:
@@ -34,7 +34,7 @@ nodes:
 
   - name: report
     type: approval
-    model: claude-opus-4-8
-    permission: edit
+    model: gpt-5.6-sol
+    permission: full
     instruction: review-fix-report
     knowledge: releash-thread-cli

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/06_verify-review-comments.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/06_verify-review-comments.yml
@@ -5,7 +5,7 @@ builtin: true
 nodes:
   - name: import_pr_review_comments
     type: agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: full
     instruction: verify-review-comments-import
     policy: reviewing
@@ -35,7 +35,7 @@ nodes:
 
   - name: implement_tasks
     type: agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     permission: full
     instruction: review-fix
     policy: coding

--- a/src-tauri/src/adaptor/gateway/workflow/failure_policy_config.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/failure_policy_config.rs
@@ -4,19 +4,19 @@ use crate::domain::workflow::{NodeType, TimeoutPolicy};
 
 const EXTENDED_STALE_TIMEOUT: Duration = Duration::from_secs(600);
 
-const EXTENDED_STALE_MODELS: &[&str] = &["claude-opus-4-8", "gpt-5.5"];
+const EXTENDED_STALE_MODELS: &[&str] = &["claude-opus-4-8", "gpt-5.6-sol"];
 
 const EXTENDED_STALE_NODE_KINDS: &[NodeType] = &[NodeType::Approval];
 
 const EXTENDED_STALE_TEMPLATES: &[&str] = &[
-    "02_implement_gpt55",
-    "02_implement_opus48",
+    "02_implement_codex",
+    "02_implement_claude",
     "03_review",
     "03_full-review",
     "04_review-fix-policy",
     "05_review-fix",
-    "05_review-fix_gpt55",
-    "05_review-fix_opus48",
+    "05_review-fix_codex",
+    "05_review-fix_claude",
     "06_verify-review-comments",
 ];
 
@@ -48,7 +48,7 @@ mod tests {
 
         assert_eq!(
             policy.stale_timeout(&TimeoutContext::new(
-                Some("gpt-5.5".to_string()),
+                Some("gpt-5.6-sol".to_string()),
                 NodeType::Agent,
                 None
             )),
@@ -58,7 +58,7 @@ mod tests {
             policy.stale_timeout(&TimeoutContext::new(
                 None,
                 NodeType::Agent,
-                Some("05_review-fix_gpt55".to_string())
+                Some("05_review-fix_codex".to_string())
             )),
             EXTENDED_STALE_TIMEOUT
         );
@@ -72,9 +72,9 @@ mod tests {
         );
         assert_eq!(
             TimeoutPolicy::default().stale_timeout(&TimeoutContext::new(
-                Some("gpt-5.5".to_string()),
+                Some("gpt-5.6-sol".to_string()),
                 NodeType::Approval,
-                Some("05_review-fix_gpt55".to_string())
+                Some("05_review-fix_codex".to_string())
             )),
             Duration::from_secs(180)
         );

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -6718,7 +6718,7 @@ mod dispatch_boundary_tests {
 
     /// 実バックエンドと同じ供給経路（`fixed_models()`）でモデル一覧を返す
     /// dispatch テスト用 backend。claude / codex の固定モデル定数をそのまま供給し、
-    /// builtin workflow が使う `claude-opus-4-8` / `gpt-5.5` を production と同一経路で
+    /// builtin workflow が使う `claude-opus-4-8` / `gpt-5.6-sol` を production と同一経路で
     /// 解決できるようにする（dispatch フロー検証の本来意図を維持）。
     struct DispatchMockBackend {
         backend_id: String,
@@ -6943,7 +6943,7 @@ mod dispatch_boundary_tests {
         ));
         // 実 backend と同じ供給経路（fixed_models()）で claude / codex の固定モデルを
         // 供給する mock backend を登録する。builtin workflow が使う claude-opus-4-8 /
-        // gpt-5.5 が production と同一経路で解決され、dispatch フロー検証を維持できる。
+        // gpt-5.6-sol が production と同一経路で解決され、dispatch フロー検証を維持できる。
         let mut registry = AgentBackendRegistry::new();
         let claude_models = crate::infrastructure::agent_session::claude::ClaudeBackend::new(None)
             .available_models()

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
@@ -936,7 +936,7 @@ mod tests {
         };
         let context = WorkflowStepContext {
             run_id: "run-1".to_string(),
-            workflow_name: "05_review-fix_gpt55".to_string(),
+            workflow_name: "05_review-fix_codex".to_string(),
             step_name: "review".to_string(),
             run_index: 1,
             parent_step_name: None,
@@ -967,7 +967,7 @@ mod tests {
         };
         let context = WorkflowStepContext {
             run_id: "run-1".to_string(),
-            workflow_name: "05_review-fix_gpt55".to_string(),
+            workflow_name: "05_review-fix_codex".to_string(),
             step_name: "review".to_string(),
             run_index: 1,
             parent_step_name: None,

--- a/src-tauri/src/infrastructure/agent_session/codex/models.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/models.rs
@@ -17,9 +17,9 @@ use super::wire::{
 pub(crate) const CODEX_BACKEND_ID: &str = "codex";
 
 const CODEX_FIXED_MODELS: &[(&str, &str)] = &[
-    ("gpt-5.5", "GPT-5.5"),
-    ("gpt-5.4", "GPT-5.4"),
-    ("gpt-5.4-mini", "GPT-5.4 Mini"),
+    ("gpt-5.6-sol", "GPT-5.6 Sol"),
+    ("gpt-5.6-terra", "GPT-5.6 Terra"),
+    ("gpt-5.6-luna", "GPT-5.6 Luna"),
 ];
 
 #[derive(Debug, Clone)]
@@ -312,8 +312,8 @@ mod tests {
             .map(|model| model.display_name.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(ids, vec!["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]);
-        assert_eq!(names, vec!["GPT-5.5", "GPT-5.4", "GPT-5.4 Mini"]);
+        assert_eq!(ids, vec!["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",]);
+        assert_eq!(names, vec!["GPT-5.6 Sol", "GPT-5.6 Terra", "GPT-5.6 Luna",]);
     }
 
     #[test]

--- a/src-tauri/src/test_support/mod.rs
+++ b/src-tauri/src/test_support/mod.rs
@@ -101,7 +101,13 @@ pub(crate) fn build_agent_runtime_usecase_with_controller_and_notifiers(
     registry.register(Arc::new(TestAgentBackend {
         id: "codex",
         name: "Codex",
-        models: vec!["gpt-5", "gpt-5.5"],
+        models: vec![
+            "gpt-5",
+            "gpt-5.5",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+        ],
         controller: controller.clone(),
     }));
     let usecase = Arc::new(AgentSessionRuntimeUsecase::new(


### PR DESCRIPTION
## Summary
- limit the Codex model catalog to GPT-5.6 Sol, Terra, and Luna
- migrate active built-in workflows from GPT-5.5 to GPT-5.6 Sol
- rename model-version-specific built-in workflow IDs to Codex and Claude provider names
- update timeout policy and test registries for the new model and workflow IDs

## Testing
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test (2533 passed)