### PR TITLE
feat: aggregate 廃止と reducer node 移行 (#1330)

### DIFF
--- a/docs/domain-model/current-state.md
+++ b/docs/domain-model/current-state.md
@@ -66,7 +66,6 @@ Issue [#1176](https://github.com/siro33950/releash/issues/1176) のスコープ�
 | `ParallelRunState` | Fanout | legacy_name | parallel 系語彙は Fanout に吸収する。 |
 | `ParallelChildRun` | NodeExecution / Fanout | legacy_name | fanout child も NodeExecution。 |
 | `ParallelChildState` | NodeExecution / Fanout | legacy_name | fanout child の状態。 |
-| `ParallelAggregate` | Fanout | legacy_name | fanout 集約設定/処理として扱う。 |
 | `ParallelStepState` | Fanout | read_model | UI/API 用 state。 |
 | `NodeCompletion` | NodeExecution | internal | NodeExecution 完了時の処理入力。 |
 | `ParallelChildCompletion` | NodeExecution | internal | child NodeExecution 完了時の処理入力。 |
@@ -99,8 +98,6 @@ Issue [#1176](https://github.com/siro33950/releash/issues/1176) のスコープ�
 | `ApprovalTargetSnapshot` | なし | internal | approval 対象検証用 snapshot。 |
 | `TransitionRule` | なし | internal | engine の transition 設定。 |
 | `CycleGuard` | なし | internal | engine の安全設定。 |
-| `CollectConfig` | なし | internal | engine の collect 設定。 |
-| `ReduceStrategy` | なし | internal | engine の reduce 設定。 |
 
 ### workflow contract / output
 
@@ -117,7 +114,6 @@ Issue [#1176](https://github.com/siro33950/releash/issues/1176) のスコープ�
 | `ConditionalArrayRule` | Contract | internal | validation rule。 |
 | `WorkflowValidateOutputResult` | Contract / Diagnostic | internal | output validation result。 |
 | `SubmitOutputCommand` | Command | internal | usecase command input。 |
-| `CollectedOutputEntry` | Artifact | internal | collect 処理の内部 entry。 |
 | `StepOutput` | Artifact | legacy_name | NodeExecution output の現行表現。 |
 | `StepHistoryEntry` | NodeExecution / Artifact | legacy_name | history/output の現行表現。 |
 | `ChildOutputSnapshot` | Fanout / Artifact | legacy_name | fanout child output snapshot。 |

--- a/src-tauri/src/adaptor/controller/command/workflow/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/mod.rs
@@ -680,7 +680,6 @@ mod tests {
                 WorkflowEvent::RunFailed { .. } => "RunFailed",
                 WorkflowEvent::RunAborted { .. } => "RunAborted",
                 WorkflowEvent::RunInterrupted { .. } => "RunInterrupted",
-                WorkflowEvent::OutputCollected { .. } => "OutputCollected",
                 WorkflowEvent::ContractRepairRequested { .. } => "ContractRepairRequested",
                 WorkflowEvent::CliMutationRequested { .. } => "CliMutationRequested",
                 WorkflowEvent::ArtifactProduced { .. } => "ArtifactProduced",

--- a/src-tauri/src/adaptor/gateway/workflow/builtin.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin.rs
@@ -509,6 +509,41 @@ mod tests {
     }
 
     #[test]
+    fn review_builtins_route_fanouts_with_next_rules() {
+        let cases = [
+            ("03_review", "review-parallel", "reporting"),
+            ("03_full-review", "review-parallel", "verify-and-classify"),
+            ("03_full-review", "verify-and-classify", "reporting"),
+        ];
+
+        for (workflow_name, fanout_name, expected_next) in cases {
+            let workflow = load_builtin_workflow_resolved(workflow_name)
+                .unwrap_or_else(|err| panic!("builtin '{workflow_name}' must load: {err}"))
+                .unwrap_or_else(|| panic!("builtin '{workflow_name}' must exist"));
+            let fanout = workflow
+                .nodes
+                .iter()
+                .find(|node| node.name == fanout_name)
+                .unwrap_or_else(|| {
+                    panic!("builtin '{workflow_name}' must contain fanout '{fanout_name}'")
+                });
+
+            assert!(
+                fanout.fanout().is_some(),
+                "builtin '{workflow_name}' node '{fanout_name}' must remain a fanout"
+            );
+            assert!(
+                matches!(
+                    fanout.rules.as_slice(),
+                    [crate::adaptor::gateway::workflow::schema::Rule::Next(next)]
+                        if next == expected_next
+                ),
+                "builtin '{workflow_name}' fanout '{fanout_name}' must route directly to '{expected_next}'"
+            );
+        }
+    }
+
+    #[test]
     fn draft_authoring_workflow_is_document_steps() {
         let name = "01_authoring_draft";
         let wf = load_builtin_workflow_resolved(name)

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/03_full-review.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/03_full-review.yml
@@ -17,10 +17,8 @@ nodes:
     - review-security-gpt55
     - review-architecture-opus
     - review-architecture-gpt55
-    aggregate:
-      all_match: ".*"
-      then: verify-and-classify
-      else: verify-and-classify
+  rules:
+  - next: verify-and-classify
 - name: review-acceptance-opus
   session:
     model: claude-opus-4-8
@@ -134,10 +132,8 @@ nodes:
     child:
     - verify-opus
     - verify-gpt55
-    aggregate:
-      all_match: ".*"
-      then: reporting
-      else: reporting
+  rules:
+  - next: reporting
 - name: verify-opus
   session:
     model: claude-opus-4-8

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/03_review.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/03_review.yml
@@ -7,10 +7,8 @@ nodes:
     child:
     - review-opus
     - review-gpt55
-    aggregate:
-      all_match: ".*"
-      then: reporting
-      else: reporting
+  rules:
+  - next: reporting
 - name: review-opus
   session:
     model: claude-opus-4-8

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -2,7 +2,7 @@ use crate::adaptor::gateway::workflow::builtin;
 use crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_domain;
 use crate::adaptor::gateway::workflow::facet::{self, FacetKind};
 use crate::adaptor::gateway::workflow::prompt_rendering;
-use crate::adaptor::gateway::workflow::schema::{NodeDefinition, ReduceStrategy, Rule, Workflow};
+use crate::adaptor::gateway::workflow::schema::{NodeDefinition, Rule, Workflow};
 use crate::adaptor::gateway::workflow::span_map::YamlSpanMap;
 use crate::domain::workflow::validation;
 use crate::domain::workflow::validation::{
@@ -22,7 +22,6 @@ const ALL_FACET_KINDS: [FacetKind; 3] = [
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     Error,
-    Warning,
     Info,
 }
 
@@ -341,8 +340,7 @@ fn parse_shape_diagnostics(
             node_obj,
             &node_path,
             &[
-                "name", "command", "session", "fanout", "artifact", "input", "inputs", "collect",
-                "rules",
+                "name", "command", "session", "fanout", "artifact", "input", "inputs", "rules",
             ],
             &[
                 "type",
@@ -357,6 +355,7 @@ fn parse_shape_diagnostics(
                 "variables",
                 "cycle_guard",
                 "resets_cycle_for",
+                "collect",
             ],
             span_map,
             workflow_name,
@@ -413,26 +412,13 @@ fn parse_shape_diagnostics(
                 .field("name"),
             );
         }
-        if node_obj.contains_key("fanout") {
-            for field in ["inputs", "collect"] {
-                if node_obj.contains_key(field) {
-                    diagnostics.push(kind_disallowed_diagnostic(
-                        workflow_name,
-                        step_name,
-                        "fanout",
-                        field,
-                        span_map.field_span(&format!("{node_path}.{field}")),
-                    ));
-                }
-            }
-        }
-        if node_obj.contains_key("command") && node_obj.contains_key("collect") {
+        if node_obj.contains_key("fanout") && node_obj.contains_key("inputs") {
             diagnostics.push(kind_disallowed_diagnostic(
                 workflow_name,
                 step_name,
-                "command",
-                "collect",
-                span_map.field_span(&format!("{node_path}.collect")),
+                "fanout",
+                "inputs",
+                span_map.field_span(&format!("{node_path}.inputs")),
             ));
         }
         if let Some(session) = node_obj
@@ -483,13 +469,28 @@ fn parse_shape_diagnostics(
             check_allowed_fields(
                 fanout,
                 &format!("{node_path}.fanout"),
-                &["child", "items", "aggregate"],
-                &["parallel_children"],
+                &["child", "items"],
+                &["parallel_children", "aggregate", "all_match", "any_match"],
                 span_map,
                 workflow_name,
                 Some(step_name),
                 &mut diagnostics,
             );
+            if let Some(aggregate) = fanout
+                .get("aggregate")
+                .and_then(serde_json::Value::as_object)
+            {
+                check_allowed_fields(
+                    aggregate,
+                    &format!("{node_path}.fanout.aggregate"),
+                    &[],
+                    &["all_match", "any_match", "then", "else"],
+                    span_map,
+                    workflow_name,
+                    Some(step_name),
+                    &mut diagnostics,
+                );
+            }
         }
         if let Some(rules) = node_obj.get("rules").and_then(serde_json::Value::as_array) {
             for (rule_index, rule) in rules.iter().enumerate() {
@@ -665,13 +666,11 @@ fn validation_error_code_stage(
         | ValidationError::DuplicateStep { .. }
         | ValidationError::EmptyFanoutChildren { .. }
         | ValidationError::EmptyCommand { .. }
-        | ValidationError::DisallowedFieldForKind { .. }
         | ValidationError::TooManyNodes { .. }
         | ValidationError::TooManyFanoutChildren { .. } => "WFS006",
-        ValidationError::UnknownRuleTarget { .. }
-        | ValidationError::UnknownFanoutChild { .. }
-        | ValidationError::AggregateUnknownTarget { .. }
-        | ValidationError::UnknownCollectFrom { .. } => "WFR001",
+        ValidationError::UnknownRuleTarget { .. } | ValidationError::UnknownFanoutChild { .. } => {
+            "WFR001"
+        }
         ValidationError::InvalidFanoutItemsReference { .. } => "WFR003",
         ValidationError::FanoutInputMismatch { .. } => "WFT003",
         ValidationError::FanoutChildLeafViolation { .. } => "WFC006",
@@ -709,7 +708,6 @@ fn validation_error_code_stage(
             | InvalidRuleKind::StandaloneNextWithDiscriminator => "WFC002",
         },
         ValidationError::UnreachableNode { .. } => "WFC001",
-        ValidationError::AggregateInvalidConfig { .. } => "WFC002",
         ValidationError::MissingFacet { .. } => "WFR900",
         ValidationError::InvalidPermissionMode { .. }
         | ValidationError::MissingPermissionMode { .. }
@@ -1086,12 +1084,6 @@ fn validation_error_context(e: &validation::ValidationError) -> (Option<String>,
         ValidationError::FanoutChildLeafViolation { step, .. } => {
             (Some(step.clone()), Some("fanout.child".to_string()))
         }
-        ValidationError::AggregateInvalidConfig { step, .. } => {
-            (Some(step.clone()), Some("aggregate".to_string()))
-        }
-        ValidationError::AggregateUnknownTarget { step, .. } => {
-            (Some(step.clone()), Some("aggregate".to_string()))
-        }
         ValidationError::UnknownRuleTarget { step, .. } => {
             (Some(step.clone()), Some("rules.next".to_string()))
         }
@@ -1103,9 +1095,6 @@ fn validation_error_context(e: &validation::ValidationError) -> (Option<String>,
             (Some(step.clone()), Some("nodes".to_string()))
         }
         ValidationError::MissingFacet { step } => (Some(step.clone()), Some("facets".to_string())),
-        ValidationError::UnknownCollectFrom { step, .. } => {
-            (Some(step.clone()), Some("collect.from".to_string()))
-        }
         ValidationError::InvalidArtifactReference { .. } => (None, Some("inputs".to_string())),
         ValidationError::InvalidPermissionMode { step, .. } => {
             (Some(step.clone()), Some("permission".to_string()))
@@ -1123,9 +1112,6 @@ fn validation_error_context(e: &validation::ValidationError) -> (Option<String>,
             (Some(step.clone()), Some("model".to_string()))
         }
         ValidationError::EmptyCommand { step } => (Some(step.clone()), Some("command".to_string())),
-        ValidationError::DisallowedFieldForKind { step, field, .. } => {
-            (Some(step.clone()), Some(field.to_string()))
-        }
         ValidationError::TooManyNodes { .. } => (None, Some("nodes".to_string())),
         ValidationError::TooManyFanoutChildren { step, .. } => {
             (Some(step.clone()), Some("fanout.child".to_string()))
@@ -1185,35 +1171,6 @@ fn diagnose_workflow(
 
     // 各stepを診断
     for step in &wf.nodes {
-        if let Some(ref collect) = step.collect {
-            // collect元stepにrulesがないwarning
-            if matches!(
-                collect.reduce,
-                ReduceStrategy::AnyNeedsFix | ReduceStrategy::AllPassed
-            ) {
-                for from in &collect.from {
-                    if let Some(source_step) = wf.nodes.iter().find(|s| s.name == *from) {
-                        if source_step.rules.is_empty() && !source_step.is_fanout() {
-                            let item = DiagnosticItem::new(
-                                "WFC900",
-                                Severity::Warning,
-                                DiagnosticStage::ControlFlow,
-                                None,
-                                format!(
-                                    "collect元ステップ '{}' にrulesが未設定です（{:?}リデュースで結果がNoneになる可能性）",
-                                    from, collect.reduce
-                                ),
-                            )
-                            .workflow(name.clone())
-                            .step(step.name.clone())
-                            .field("collect.reduce");
-                            add_diagnostic(items, workflow_summaries, name, item);
-                        }
-                    }
-                }
-            }
-        }
-
         // ファセット参照の存在チェック + usage 記録
         FacetRefCheckContext::new(name, all_facet_keys, items, workflow_summaries, facet_usage)
             .check_step(
@@ -1472,7 +1429,6 @@ fn increment_summary(
     let summary = summaries.entry(key.to_string()).or_default();
     match severity {
         Severity::Error => summary.error_count += 1,
-        Severity::Warning => summary.warning_count += 1,
         Severity::Info => summary.info_count += 1,
     }
 }
@@ -1481,8 +1437,8 @@ fn increment_summary(
 mod tests {
     use super::*;
     use crate::adaptor::gateway::workflow::schema::{
-        CollectConfig, CommandSpec, FacetRefs, FanoutSpec, ItemsSource, NodeKind, ReduceStrategy,
-        Rule, SchemaDef, SessionSpec, Workflow,
+        CommandSpec, FacetRefs, FanoutSpec, ItemsSource, NodeKind, Rule, SchemaDef, SessionSpec,
+        Workflow,
     };
     use std::fs;
     use tempfile::TempDir;
@@ -1523,7 +1479,6 @@ mod tests {
             kind: NodeKind::Fanout(FanoutSpec {
                 child: children.into_iter().map(str::to_string).collect(),
                 items: None,
-                aggregate: None,
             }),
             ..NodeDefinition::default()
         }
@@ -2264,40 +2219,6 @@ nodes:
     }
 
     #[test]
-    fn diagnose_collect_warning() {
-        let tmp = TempDir::new().unwrap();
-        let wf_dir = tmp.path();
-        setup_facet(wf_dir, "instructions", "review", "content");
-
-        let wf = Workflow {
-            name: "test-wf".to_string(),
-            description: "test".to_string(),
-            builtin: false,
-            schemas: Default::default(),
-            nodes: vec![
-                NodeDefinition {
-                    // source step without rules
-                    ..make_step("review-step", Some("review"))
-                },
-                NodeDefinition {
-                    collect: Some(CollectConfig {
-                        from: vec!["review-step".to_string()],
-                        reduce: ReduceStrategy::AnyNeedsFix,
-                    }),
-                    ..make_step("collect-step", None)
-                },
-            ],
-        };
-        save_workflow_yaml(wf_dir, &wf);
-
-        let report = diagnose_all(wf_dir, wf_dir);
-        assert!(report
-            .items
-            .iter()
-            .any(|i| i.severity == Severity::Warning && i.message.contains("rulesが未設定")));
-    }
-
-    #[test]
     fn diagnose_unreachable_step() {
         let tmp = TempDir::new().unwrap();
         let wf_dir = tmp.path();
@@ -2522,39 +2443,6 @@ nodes:
     }
 
     #[test]
-    fn diagnose_collect_warning_all_passed() {
-        let tmp = TempDir::new().unwrap();
-        let wf_dir = tmp.path();
-        setup_facet(wf_dir, "instructions", "review", "content");
-
-        let wf = Workflow {
-            name: "test-wf".to_string(),
-            description: "test".to_string(),
-            builtin: false,
-            schemas: Default::default(),
-            nodes: vec![
-                NodeDefinition {
-                    ..make_step("review-step", Some("review"))
-                },
-                NodeDefinition {
-                    collect: Some(CollectConfig {
-                        from: vec!["review-step".to_string()],
-                        reduce: ReduceStrategy::AllPassed,
-                    }),
-                    ..make_step("collect-step", None)
-                },
-            ],
-        };
-        save_workflow_yaml(wf_dir, &wf);
-
-        let report = diagnose_all(wf_dir, wf_dir);
-        assert!(report
-            .items
-            .iter()
-            .any(|i| i.severity == Severity::Warning && i.message.contains("rulesが未設定")));
-    }
-
-    #[test]
     fn diagnose_invalid_facet_key_via_diagnose_all() {
         let tmp = TempDir::new().unwrap();
         let wf_dir = tmp.path();
@@ -2700,43 +2588,6 @@ nodes:
                 .iter()
                 .any(|i| i.severity == Severity::Error && i.field.as_deref() == Some("inputs")),
             "Artifact input reference should not be an error, got: {:?}",
-            report.items
-        );
-    }
-
-    #[test]
-    fn diagnose_collect_from_subsequent_step() {
-        let tmp = TempDir::new().unwrap();
-        let wf_dir = tmp.path();
-        setup_facet(wf_dir, "instructions", "task", "content");
-
-        // step1 が後続の step2 を collect.from で参照 → エラーになるべき
-        let wf = Workflow {
-            name: "subsequent-collect".to_string(),
-            description: "test".to_string(),
-            builtin: false,
-            schemas: Default::default(),
-            nodes: vec![
-                NodeDefinition {
-                    collect: Some(CollectConfig {
-                        from: vec!["step2".to_string()],
-                        reduce: ReduceStrategy::Concat,
-                    }),
-                    ..make_step("step1", None)
-                },
-                make_step("step2", Some("task")),
-            ],
-        };
-        save_workflow_yaml(wf_dir, &wf);
-
-        let report = diagnose_all(wf_dir, wf_dir);
-        assert!(
-            report.items.iter().any(|i| i.code == "WFR001"
-                && i.severity == Severity::Error
-                && i.stage == DiagnosticStage::Resolve
-                && i.step_name.as_deref() == Some("step1")
-                && i.field.as_deref() == Some("collect.from")),
-            "Expected WFR001 for collect.from, got: {:?}",
             report.items
         );
     }

--- a/src-tauri/src/adaptor/gateway/workflow/domain_mapping.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/domain_mapping.rs
@@ -190,7 +190,6 @@ pub(crate) fn node_definition_to_domain(node: &schema::NodeDefinition) -> domain
         artifact: node.artifact.clone(),
         input: node.input.clone(),
         inputs: node.inputs.clone(),
-        collect: node.collect.as_ref().map(collect_config_to_domain),
         rules: node.rules.iter().map(rule_to_domain).collect(),
     }
 }
@@ -209,7 +208,6 @@ pub(crate) fn node_kind_to_domain(kind: &schema::NodeKind) -> domain::NodeKind {
         schema::NodeKind::Fanout(spec) => domain::NodeKind::Fanout(domain::FanoutSpec {
             child: spec.child.clone(),
             items: spec.items.as_ref().map(items_source_to_domain),
-            aggregate: spec.aggregate.as_ref().map(parallel_aggregate_to_domain),
         }),
     }
 }
@@ -236,34 +234,6 @@ fn items_source_to_domain(items: &schema::ItemsSource) -> domain::ItemsSource {
             node: node.clone(),
             field: field.clone(),
         },
-    }
-}
-
-pub(crate) fn collect_config_to_domain(collect: &schema::CollectConfig) -> domain::CollectConfig {
-    domain::CollectConfig {
-        from: collect.from.clone(),
-        reduce: reduce_strategy_to_domain(&collect.reduce),
-    }
-}
-
-fn reduce_strategy_to_domain(reduce: &schema::ReduceStrategy) -> domain::ReduceStrategy {
-    match reduce {
-        schema::ReduceStrategy::Last => domain::ReduceStrategy::Last,
-        schema::ReduceStrategy::Concat => domain::ReduceStrategy::Concat,
-        schema::ReduceStrategy::Grouped => domain::ReduceStrategy::Grouped,
-        schema::ReduceStrategy::AnyNeedsFix => domain::ReduceStrategy::AnyNeedsFix,
-        schema::ReduceStrategy::AllPassed => domain::ReduceStrategy::AllPassed,
-    }
-}
-
-pub(crate) fn parallel_aggregate_to_domain(
-    aggregate: &schema::ParallelAggregate,
-) -> domain::ParallelAggregate {
-    domain::ParallelAggregate {
-        all_match: aggregate.all_match.clone(),
-        any_match: aggregate.any_match.clone(),
-        then: aggregate.then.clone(),
-        r#else: aggregate.r#else.clone(),
     }
 }
 
@@ -368,7 +338,6 @@ mod tests {
                         node: "plan".to_string(),
                         field: "targets".to_string(),
                     }),
-                    aggregate: None,
                 }),
                 ..Default::default()
             }],

--- a/src-tauri/src/adaptor/gateway/workflow/event.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event.rs
@@ -230,19 +230,6 @@ pub enum WorkflowEvent {
         reason: String,
         timestamp: f64,
     },
-    /// collect step の reduce 結果。
-    OutputCollected {
-        run_id: String,
-        workflow_name: String,
-        node_name: String,
-        node_outputs: Vec<CollectedOutputEntry>,
-        reduce_strategy: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reduce_result: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reduce_structured_output: Option<serde_json::Value>,
-        timestamp: f64,
-    },
     /// artifact_contract repair prompt が送信された。
     ContractRepairRequested {
         run_id: String,
@@ -393,17 +380,6 @@ pub enum CliMutationRejectionReason {
     Other,
 }
 
-/// collect step の各子要素出力エントリ。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CollectedOutputEntry {
-    pub node_name: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub result: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub structured_output: Option<serde_json::Value>,
-}
-
 impl WorkflowEvent {
     /// event の primary key となる `run_id` を返す。
     pub fn run_id(&self) -> &str {
@@ -421,7 +397,6 @@ impl WorkflowEvent {
             | Self::RunFailed { run_id, .. }
             | Self::RunAborted { run_id, .. }
             | Self::RunInterrupted { run_id, .. }
-            | Self::OutputCollected { run_id, .. }
             | Self::ContractRepairRequested { run_id, .. }
             | Self::CliMutationRequested { run_id, .. }
             | Self::ArtifactProduced { run_id, .. }

--- a/src-tauri/src/adaptor/gateway/workflow/event_projection.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event_projection.rs
@@ -13,7 +13,7 @@ use crate::adaptor::gateway::workflow::domain_mapping::{
 };
 #[cfg(test)]
 use crate::adaptor::gateway::workflow::event::{
-    CliMutationRejectionReason, CliMutationRequestRecord, CollectedOutputEntry, FanoutParentRef,
+    CliMutationRejectionReason, CliMutationRequestRecord, FanoutParentRef,
 };
 use crate::adaptor::gateway::workflow::event::{
     RunAbortedChildOutcome, RunAbortedChildOutputSnapshot, RunAbortedStepSnapshot,
@@ -319,19 +319,6 @@ pub enum WorkflowEventView {
         #[serde(rename = "timestampMs")]
         timestamp_ms: f64,
     },
-    OutputCollected {
-        run_id: String,
-        workflow_name: String,
-        node_name: String,
-        node_outputs: Vec<CollectedOutputEntry>,
-        reduce_strategy: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reduce_result: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reduce_structured_output: Option<serde_json::Value>,
-        #[serde(rename = "timestampMs")]
-        timestamp_ms: f64,
-    },
     ContractRepairRequested {
         run_id: String,
         workflow_name: String,
@@ -588,25 +575,6 @@ impl From<WorkflowEvent> for WorkflowEventView {
                 run_id,
                 workflow_name,
                 reason,
-                timestamp_ms: seconds_to_ms(timestamp),
-            },
-            WorkflowEvent::OutputCollected {
-                run_id,
-                workflow_name,
-                node_name,
-                node_outputs,
-                reduce_strategy,
-                reduce_result,
-                reduce_structured_output,
-                timestamp,
-            } => WorkflowEventView::OutputCollected {
-                run_id,
-                workflow_name,
-                node_name,
-                node_outputs,
-                reduce_strategy,
-                reduce_result,
-                reduce_structured_output,
                 timestamp_ms: seconds_to_ms(timestamp),
             },
             WorkflowEvent::ContractRepairRequested {
@@ -1514,9 +1482,6 @@ pub(crate) fn reconstruct_state_from_events(
                 stall_observations.clear();
                 updated_at = *timestamp;
             }
-            WorkflowEvent::OutputCollected { timestamp, .. } => {
-                updated_at = *timestamp;
-            }
             WorkflowEvent::ContractRepairRequested { timestamp, .. } => {
                 updated_at = *timestamp;
             }
@@ -1553,7 +1518,7 @@ pub(crate) fn reconstruct_state_from_events(
                 // [08] CLI / in-process 経由で確定した step output を state に復元する。
                 // 後続 step が `input_reference` で経路非依存に参照できる shape に揃える。
                 // `result` は engine の live state と同じ値（contract validator の戻り値）
-                // を再導出する。これにより live と reload 経路で aggregate 評価が乖離しない。
+                // を再導出し、live と reload の Artifact projection を一致させる。
                 if is_fanout_child {
                     // fanout child Artifact は NodeExecution にだけ保持し、node-name map
                     // には載せない。親 fanout の ArtifactProduced(array) が唯一の参照面。
@@ -1571,8 +1536,7 @@ pub(crate) fn reconstruct_state_from_events(
                         ContractValidationResult::Valid { result, .. } => result,
                         // append-only ログに記録された ArtifactProduced は engine 側で validator を
                         // 通過しているため通常ここには到達しない。validator が将来変更されて
-                        // 不適合判定になっても、result を None にして live と同等に振る舞う
-                        // （aggregate 評価では match なしになるだけ）。
+                        // 不適合判定になっても、result を None にして live と同等に振る舞う。
                         ContractValidationResult::Invalid(_) => None,
                     }
                 } else {
@@ -2040,7 +2004,6 @@ mod tests {
         workflow.nodes[0].kind = NodeKind::Fanout(FanoutSpec {
             child: vec!["review".to_string()],
             items: None,
-            aggregate: None,
         });
         workflow.nodes[1].kind = approval_session_kind("review the diff");
         let events = vec![
@@ -2783,7 +2746,7 @@ mod tests {
             state.node_executions[2].artifact,
             Some(serde_json::json!({"value": 20}))
         );
-        assert!(state.step_outputs.get("worker").is_none());
+        assert!(!state.step_outputs.contains_key("worker"));
         assert_eq!(
             state
                 .step_outputs
@@ -2810,7 +2773,6 @@ mod tests {
         workflow.nodes[0].kind = NodeKind::Fanout(FanoutSpec {
             child: vec!["review-a".to_string(), "review-b".to_string()],
             items: None,
-            aggregate: None,
         });
         let mut events = vec![
             run_started(run_id, workflow),

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS005_legacy-aggregate-all-match.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS005_legacy-aggregate-all-match.yml
@@ -1,0 +1,16 @@
+name: legacy-aggregate-all-match
+description: aggregate and all_match were removed
+nodes:
+  - name: review
+    fanout:
+      child: reviewer
+      aggregate:
+        all_match: LGTM
+        then: done
+        else: fix
+  - name: reviewer
+    command: printf review
+  - name: done
+    command: printf done
+  - name: fix
+    command: printf fix

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS005_legacy-aggregate-any-match.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS005_legacy-aggregate-any-match.yml
@@ -1,0 +1,16 @@
+name: legacy-aggregate-any-match
+description: aggregate and any_match were removed
+nodes:
+  - name: review
+    fanout:
+      child: reviewer
+      aggregate:
+        any_match: NEEDS_FIX
+        then: fix
+        else: done
+  - name: reviewer
+    command: printf review
+  - name: done
+    command: printf done
+  - name: fix
+    command: printf fix

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS005_legacy-collect.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFS005_legacy-collect.yml
@@ -1,0 +1,14 @@
+name: legacy-collect
+description: collect and reduce strategies were removed
+nodes:
+  - name: source
+    command: printf source
+    rules:
+      - next: reducer
+  - name: reducer
+    session:
+      permission: edit
+      gate: auto
+    collect:
+      from: [source]
+      reduce: grouped

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-command-reducer.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-command-reducer.yml
@@ -1,0 +1,42 @@
+name: fanout-command-reducer
+description: command reducer folds a fanout Artifact array into a boolean Artifact
+schemas:
+  review-verdict:
+    type: object
+    properties:
+      lgtm:
+        type: boolean
+    required: [lgtm]
+    additionalProperties: false
+  judge-result:
+    type: object
+    properties:
+      all_lgtm:
+        type: boolean
+    required: [all_lgtm]
+    additionalProperties: false
+nodes:
+  - name: review
+    fanout:
+      child: [review-a, review-b]
+    rules:
+      - next: judge
+  - name: review-a
+    command: >-
+      printf '{"lgtm":true}'
+    artifact: review-verdict
+  - name: review-b
+    command: >-
+      printf '{"lgtm":false}'
+    artifact: review-verdict
+  - name: judge
+    command: "echo '{{ review }}' | jq '{all_lgtm: all(.[]; .lgtm)}'"
+    inputs: [review]
+    artifact: judge-result
+    rules:
+      - when: { on: all_lgtm, then: ready }
+        next: fix
+  - name: ready
+    command: printf ready
+  - name: fix
+    command: printf fix

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-session-reducer.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-session-reducer.yml
@@ -1,0 +1,50 @@
+name: fanout-session-reducer
+description: session reducer folds a fanout Artifact array into an enum Artifact
+schemas:
+  review-verdict:
+    type: object
+    properties:
+      lgtm:
+        type: boolean
+    required: [lgtm]
+    additionalProperties: false
+  review-decision:
+    type: object
+    properties:
+      verdict:
+        type: string
+        enum: [READY, NEEDS_FIX]
+    required: [verdict]
+    additionalProperties: false
+nodes:
+  - name: review
+    fanout:
+      child: [review-a, review-b]
+    rules:
+      - next: judge
+  - name: review-a
+    command: >-
+      printf '{"lgtm":true}'
+    artifact: review-verdict
+  - name: review-b
+    command: >-
+      printf '{"lgtm":false}'
+    artifact: review-verdict
+  - name: judge
+    session:
+      permission: edit
+      gate: auto
+      facets:
+        instruction: reduce-review-verdicts
+    inputs: [review]
+    artifact: review-decision
+    rules:
+      - switch:
+          on: verdict
+          cases:
+            READY: ready
+            NEEDS_FIX: fix
+  - name: ready
+    command: printf ready
+  - name: fix
+    command: printf fix

--- a/src-tauri/src/adaptor/gateway/workflow/log.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/log.rs
@@ -290,7 +290,6 @@ fn validate_log_run_id(run_id: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::adaptor::gateway::workflow::event::CollectedOutputEntry;
     use crate::adaptor::gateway::workflow::event_projection::reconstruct_state_from_events;
     use crate::adaptor::gateway::workflow::schema::Workflow;
     use crate::adaptor::gateway::workflow::state::{TokenUsage, WorkflowExecutionState};
@@ -766,20 +765,6 @@ mod tests {
                 aborted_step: None,
                 timestamp: 7.0,
             },
-            WorkflowEvent::OutputCollected {
-                run_id: "00000000-0000-0000-0000-000000000911".to_string(),
-                workflow_name: "wf".to_string(),
-                node_name: "collect".to_string(),
-                node_outputs: vec![CollectedOutputEntry {
-                    node_name: "s1".to_string(),
-                    result: Some("LGTM".to_string()),
-                    structured_output: None,
-                }],
-                reduce_strategy: "AnyNeedsFix".to_string(),
-                reduce_result: Some("LGTM".to_string()),
-                reduce_structured_output: None,
-                timestamp: 8.0,
-            },
             WorkflowEvent::NodeStarted {
                 run_id: "00000000-0000-0000-0000-000000000911".to_string(),
                 workflow_name: "wf".to_string(),
@@ -996,21 +981,6 @@ mod tests {
             timestamp: 1004.0,
         })
         .unwrap();
-        log.append(&WorkflowEvent::OutputCollected {
-            run_id: "00000000-0000-0000-0000-000000000906".to_string(),
-            workflow_name: "test-wf".to_string(),
-            node_name: "collect".to_string(),
-            node_outputs: vec![CollectedOutputEntry {
-                node_name: "plan".to_string(),
-                result: Some("done".to_string()),
-                structured_output: None,
-            }],
-            reduce_strategy: "Last".to_string(),
-            reduce_result: Some("done".to_string()),
-            reduce_structured_output: None,
-            timestamp: 1004.5,
-        })
-        .unwrap();
         log.append(&WorkflowEvent::RunCompleted {
             run_id: "00000000-0000-0000-0000-000000000906".to_string(),
             workflow_name: "test-wf".to_string(),
@@ -1125,7 +1095,7 @@ mod tests {
     fn reconstruct_state_fanout_uses_node_executions_without_child_name_outputs() {
         use crate::adaptor::gateway::workflow::event::FanoutParentRef;
         use crate::adaptor::gateway::workflow::schema::{
-            FanoutSpec, NodeDefinition, NodeKind, NodeKindName, ParallelAggregate,
+            FanoutSpec, NodeDefinition, NodeKind, NodeKindName,
         };
 
         let tmp = TempDir::new().unwrap();
@@ -1135,12 +1105,6 @@ mod tests {
             kind: NodeKind::Fanout(FanoutSpec {
                 child: vec!["arch-review".to_string(), "security-review".to_string()],
                 items: None,
-                aggregate: Some(ParallelAggregate {
-                    all_match: Some("LGTM".to_string()),
-                    any_match: None,
-                    then: "_complete".to_string(),
-                    r#else: "_complete".to_string(),
-                }),
             }),
             ..NodeDefinition::default()
         };

--- a/src-tauri/src/adaptor/gateway/workflow/mapper.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/mapper.rs
@@ -147,7 +147,6 @@ fn domain_node_to_legacy(
         artifact: node.artifact.clone(),
         input: node.input.clone(),
         inputs: node.inputs.clone(),
-        collect: node.collect.as_ref().map(domain_collect_to_legacy),
         rules: node
             .rules
             .iter()
@@ -183,7 +182,6 @@ fn domain_kind_to_legacy(
                 crate::adaptor::gateway::workflow::schema::FanoutSpec {
                     child: spec.child.clone(),
                     items: spec.items.as_ref().map(domain_items_source_to_schema),
-                    aggregate: spec.aggregate.as_ref().map(domain_aggregate_to_legacy),
                 },
             )
         }
@@ -224,42 +222,6 @@ fn domain_items_source_to_schema(
                 field: field.clone(),
             }
         }
-    }
-}
-
-fn domain_collect_to_legacy(
-    collect: &domain::CollectConfig,
-) -> crate::adaptor::gateway::workflow::schema::CollectConfig {
-    crate::adaptor::gateway::workflow::schema::CollectConfig {
-        from: collect.from.clone(),
-        reduce: match collect.reduce {
-            domain::ReduceStrategy::Last => {
-                crate::adaptor::gateway::workflow::schema::ReduceStrategy::Last
-            }
-            domain::ReduceStrategy::Concat => {
-                crate::adaptor::gateway::workflow::schema::ReduceStrategy::Concat
-            }
-            domain::ReduceStrategy::Grouped => {
-                crate::adaptor::gateway::workflow::schema::ReduceStrategy::Grouped
-            }
-            domain::ReduceStrategy::AnyNeedsFix => {
-                crate::adaptor::gateway::workflow::schema::ReduceStrategy::AnyNeedsFix
-            }
-            domain::ReduceStrategy::AllPassed => {
-                crate::adaptor::gateway::workflow::schema::ReduceStrategy::AllPassed
-            }
-        },
-    }
-}
-
-fn domain_aggregate_to_legacy(
-    aggregate: &domain::ParallelAggregate,
-) -> crate::adaptor::gateway::workflow::schema::ParallelAggregate {
-    crate::adaptor::gateway::workflow::schema::ParallelAggregate {
-        all_match: aggregate.all_match.clone(),
-        any_match: aggregate.any_match.clone(),
-        then: aggregate.then.clone(),
-        r#else: aggregate.r#else.clone(),
     }
 }
 
@@ -660,7 +622,6 @@ mod tests {
                     items: Some(ItemsSource::Literal(vec![serde_json::json!({
                         "path": "src/lib.rs"
                     })])),
-                    aggregate: None,
                 }),
                 ..Default::default()
             }],

--- a/src-tauri/src/adaptor/gateway/workflow/output_submission.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/output_submission.rs
@@ -404,7 +404,6 @@ mod tests {
                     kind: NodeKind::Fanout(FanoutSpec {
                         child: vec!["review-a".to_string(), "review-b".to_string()],
                         items: None,
-                        aggregate: None,
                     }),
                     ..Default::default()
                 },
@@ -460,7 +459,6 @@ mod tests {
         exec.parallel_run = Some(ParallelRunState {
             parent_step_name: "fanout-review".to_string(),
             parent_node_execution_id: "00000000-0000-4000-8000-000000000200".to_string(),
-            aggregate: None,
             children: vec![
                 ParallelChildRun {
                     node_execution_id: "00000000-0000-4000-8000-000000000201".to_string(),

--- a/src-tauri/src/adaptor/gateway/workflow/parallel_runtime.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/parallel_runtime.rs
@@ -1,26 +1,17 @@
 use std::collections::HashMap;
 
-use tokio::sync::Mutex;
-
-#[cfg(test)]
-use crate::adaptor::gateway::workflow::domain_mapping::step_output_to_domain;
 use crate::adaptor::gateway::workflow::domain_mapping::{
-    collect_config_to_domain, parallel_aggregate_to_domain, step_history_entry_from_domain,
-    step_output_from_domain, step_outputs_to_domain, token_usage_to_domain,
-    workflow_definition_to_domain,
+    step_history_entry_from_domain, step_output_from_domain, step_outputs_to_domain,
+    token_usage_to_domain, workflow_definition_to_domain,
 };
 use crate::adaptor::gateway::workflow::engine_error::{
     workflow_error_to_engine_error, WorkflowEngineError,
 };
-use crate::adaptor::gateway::workflow::event::{
-    CollectedOutputEntry, FanoutParentRef, WorkflowEvent,
-};
-use crate::adaptor::gateway::workflow::execution_registry::find_by_worktree_mut;
-use crate::adaptor::gateway::workflow::runtime_commit::StepOutcome;
+use crate::adaptor::gateway::workflow::event::FanoutParentRef;
 use crate::adaptor::gateway::workflow::runtime_state::{
     ParallelChildRun, ParallelChildState, ParallelRunState, WorkflowExecution,
 };
-use crate::adaptor::gateway::workflow::schema::{CollectConfig, NodeDefinition, ParallelAggregate};
+use crate::adaptor::gateway::workflow::schema::NodeDefinition;
 use crate::adaptor::gateway::workflow::state::{StepOutput, TokenUsage, WorkflowState};
 use crate::adaptor::gateway::workflow::step_settings::WorkflowDefaults;
 use crate::domain::workflow::services::parallel as workflow_parallel;
@@ -41,7 +32,6 @@ pub(crate) struct FanoutStartContext {
     pub(crate) parent_step_name: String,
     pub(crate) parent_run_index: u32,
     pub(crate) order: u32,
-    pub(crate) aggregate: Option<ParallelAggregate>,
     pub(crate) execution_id: String,
     pub(crate) workflow_name: String,
     pub(crate) task: Option<String>,
@@ -154,18 +144,11 @@ pub(crate) fn prepare_fanout_start_context(
             })
         })
         .collect::<Result<Vec<_>, WorkflowEngineError>>()?;
-    // Zero-item fanout is a normal successful parent completion with no children. Do not carry
-    // the temporary aggregate compatibility route into that completion: the parent node's
-    // ordinary rules own the next transition for this case.
-    let aggregate = (!children.is_empty())
-        .then(|| fanout.aggregate.clone())
-        .flatten();
     Ok(FanoutStartContext {
         parent_step_name: step.name.clone(),
         parent_run_index,
         order: exec.step_history.len() as u32,
         children,
-        aggregate,
         execution_id: exec.id.clone(),
         workflow_name: exec.workflow.name.clone(),
         task: exec.task.clone(),
@@ -248,148 +231,26 @@ pub(crate) fn apply_fanout_run_state(
     exec.parallel_run = Some(ParallelRunState {
         parent_step_name: fanout_start.parent_step_name.clone(),
         parent_node_execution_id,
-        aggregate: fanout_start.aggregate.clone(),
         children,
     });
     exec.updated_at = timestamp;
     Ok(exec.to_workflow_state())
 }
 
-pub(crate) struct ReduceTransitionResult {
-    pub(crate) next_outcome: StepOutcome,
-    pub(crate) output_collected_event: WorkflowEvent,
-    pub(crate) snapshot_before: WorkflowExecution,
-}
-
-pub(crate) enum FanoutParentCompletionTransition {
-    Advance,
-    TransitionTo { target_node_name: String },
-}
-
 pub(crate) struct FanoutParentCompletionPlan {
     pub(crate) parent_step_output: StepOutput,
     pub(crate) history_entry: crate::adaptor::gateway::workflow::state::StepHistoryEntry,
-    pub(crate) transition: FanoutParentCompletionTransition,
-}
-
-/// reduce処理の結果。
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct ReduceResult {
-    pub result: Option<String>,
-    pub structured_output: Option<serde_json::Value>,
-}
-
-/// Legacy schema/state を domain の parallel service に接続する境界。
-pub(crate) fn apply_reduce(
-    collect: &CollectConfig,
-    step_outputs: &HashMap<String, StepOutput>,
-) -> ReduceResult {
-    let collect = collect_config_to_domain(collect);
-    let step_outputs = step_outputs_to_domain(step_outputs);
-    let result = workflow_parallel::apply_reduce(&collect, &step_outputs);
-    ReduceResult {
-        result: result.result,
-        structured_output: result.structured_output,
-    }
-}
-
-pub(crate) fn apply_reduce_transition(
-    exec: &mut WorkflowExecution,
-    snapshot: &WorkflowState,
-) -> Result<ReduceTransitionResult, WorkflowEngineError> {
-    let step = &exec.workflow.nodes[exec.current_step_index];
-    let collect = step
-        .collect
-        .clone()
-        .expect("ReduceAndTransition requires collect config");
-    let reduce_result = apply_reduce(&collect, &exec.step_outputs);
-    let snapshot_before = exec.clone();
-
-    let entry = exec.make_step_history_entry(
-        reduce_result.result.clone(),
-        reduce_result.structured_output.clone(),
-        None,
-    );
-    exec.step_history.push(entry);
-
-    let step_name = exec.workflow.nodes[exec.current_step_index].name.clone();
-    let execution_id = exec.id.clone();
-    let workflow_name = exec.workflow.name.clone();
-
-    log::info!(
-        "OutputCollected: step='{}', strategy={:?}, from={:?}",
-        step_name,
-        collect.reduce,
-        collect.from,
-    );
-
-    let next_outcome = exec.apply_advance();
-
-    let node_outputs: Vec<CollectedOutputEntry> = collect
-        .from
-        .iter()
-        .map(|name| {
-            let output = snapshot.step_outputs.get(name);
-            CollectedOutputEntry {
-                node_name: name.clone(),
-                result: output.and_then(|o| o.result.clone()),
-                structured_output: output.and_then(|o| o.structured_output.clone()),
-            }
-        })
-        .collect();
-    let output_collected_event = WorkflowEvent::OutputCollected {
-        run_id: execution_id,
-        workflow_name,
-        node_name: step_name,
-        node_outputs,
-        reduce_strategy: format!("{:?}", collect.reduce),
-        reduce_result: reduce_result.result,
-        reduce_structured_output: reduce_result.structured_output,
-        timestamp: crate::usecase::agent_session::session::now_timestamp(),
-    };
-
-    Ok(ReduceTransitionResult {
-        next_outcome,
-        output_collected_event,
-        snapshot_before,
-    })
-}
-
-pub(crate) async fn apply_reduce_transition_by_worktree(
-    executions: &Mutex<HashMap<String, WorkflowExecution>>,
-    worktree_path: &str,
-    snapshot: &WorkflowState,
-) -> Result<ReduceTransitionResult, WorkflowEngineError> {
-    let mut execs = executions.lock().await;
-    let exec = find_by_worktree_mut(&mut execs, worktree_path)
-        .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(worktree_path.to_string()))?;
-    apply_reduce_transition(exec, snapshot)
-}
-
-/// aggregate条件を評価する。trueなら`then`、falseなら`else`。
-#[cfg(test)]
-pub(crate) fn evaluate_aggregate(
-    aggregate: &ParallelAggregate,
-    step_outputs: &HashMap<String, StepOutput>,
-    child_step_names: &[String],
-) -> bool {
-    let aggregate = parallel_aggregate_to_domain(aggregate);
-    let step_outputs = step_outputs_to_domain(step_outputs);
-    workflow_parallel::evaluate_aggregate(&aggregate, &step_outputs, child_step_names)
 }
 
 pub(crate) fn plan_fanout_parent_completion(
     parent_step_name: &str,
     parent_run_index: u32,
-    aggregate: Option<&ParallelAggregate>,
     children: &[ParallelChildRun],
     timestamp: f64,
 ) -> FanoutParentCompletionPlan {
-    let aggregate = aggregate.map(parallel_aggregate_to_domain);
     let children: Vec<workflow_parallel::FanoutChildCompletionInput> = children
         .iter()
         .map(|child| workflow_parallel::FanoutChildCompletionInput {
-            node_execution_id: child.node_execution_id.clone(),
             node_name: child.step_name.clone(),
             session_id: (!child.session_id.is_empty()).then(|| child.session_id.clone()),
             result: child.result.clone(),
@@ -415,46 +276,20 @@ pub(crate) fn plan_fanout_parent_completion(
     let plan = workflow_parallel::plan_fanout_parent_completion(
         parent_step_name,
         parent_run_index,
-        aggregate.as_ref(),
         &children,
         timestamp,
     );
-    let transition = match plan.transition {
-        workflow_parallel::FanoutParentTransitionPlan::Advance => {
-            FanoutParentCompletionTransition::Advance
-        }
-        workflow_parallel::FanoutParentTransitionPlan::TransitionTo {
-            target_node_name, ..
-        } => FanoutParentCompletionTransition::TransitionTo { target_node_name },
-    };
     FanoutParentCompletionPlan {
         parent_step_output: step_output_from_domain(plan.parent_step_output),
         history_entry: step_history_entry_from_domain(plan.history_entry),
-        transition,
     }
-}
-
-#[cfg(test)]
-pub(crate) fn collect_step_output_entries(
-    from: &[String],
-    step_outputs: &HashMap<String, StepOutput>,
-) -> Vec<serde_json::Value> {
-    let step_outputs = step_outputs_to_domain(step_outputs);
-    workflow_parallel::collect_step_output_entries(from, &step_outputs)
-}
-
-#[cfg(test)]
-pub(crate) fn resolve_step_result(output: &StepOutput) -> Option<String> {
-    let output = step_output_to_domain(output);
-    workflow_parallel::resolve_step_result(&output)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::adaptor::gateway::workflow::schema::{
-        CommandSpec, FanoutSpec, ItemsSource, NodeDefinition, NodeKind, ReduceStrategy,
-        SessionSpec, Workflow,
+        CommandSpec, FanoutSpec, ItemsSource, NodeDefinition, NodeKind, SessionSpec, Workflow,
     };
     use crate::adaptor::gateway::workflow::state::WorkflowExecutionState;
 
@@ -507,7 +342,6 @@ mod tests {
             kind: NodeKind::Fanout(FanoutSpec {
                 child: children.iter().map(|name| (*name).to_string()).collect(),
                 items,
-                aggregate: None,
             }),
             ..Default::default()
         }
@@ -775,7 +609,6 @@ mod tests {
         let context = prepare_fanout_start_context(&exec).unwrap();
 
         assert!(context.children.is_empty());
-        assert!(context.aggregate.is_none());
     }
 
     #[test]
@@ -809,51 +642,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn apply_reduce_transition_by_worktree_updates_active_execution() {
-        let mut exec = workflow_execution_fixture(NodeDefinition {
-            name: "collect-reviews".to_string(),
-            collect: Some(make_collect(
-                vec!["review-a", "review-b"],
-                ReduceStrategy::Concat,
-            )),
-            ..Default::default()
-        });
-        exec.step_outputs = make_outputs(vec![
-            ("review-a", "first", None),
-            ("review-b", "second", None),
-        ]);
-        let snapshot = exec.to_workflow_state();
-        let executions = Mutex::new(HashMap::from([("run-1".to_string(), exec)]));
-
-        let result = apply_reduce_transition_by_worktree(&executions, "/tmp/repo", &snapshot)
-            .await
-            .unwrap();
-
-        assert!(matches!(
-            result.next_outcome,
-            StepOutcome::Persist(state) if matches!(state.state, WorkflowExecutionState::Completed)
-        ));
-        assert!(matches!(
-            result.output_collected_event,
-            WorkflowEvent::OutputCollected {
-                node_name,
-                node_outputs,
-                reduce_strategy,
-                ..
-            } if node_name == "collect-reviews"
-                && node_outputs.len() == 2
-                && node_outputs[0].node_name == "review-a"
-                && node_outputs[1].node_name == "review-b"
-                && reduce_strategy == "Concat"
-        ));
-
-        let execs = executions.lock().await;
-        let exec = execs.get("run-1").unwrap();
-        assert_eq!(exec.step_history.len(), 1);
-        assert_eq!(exec.step_history[0].step_name, "collect-reviews");
-    }
-
     fn make_step_output(step_name: &str, text: &str, result: Option<&str>) -> StepOutput {
         StepOutput {
             step_name: step_name.to_string(),
@@ -865,482 +653,5 @@ mod tests {
             token_usage: None,
             completed_at: 1000.0,
         }
-    }
-
-    fn make_collect(from: Vec<&str>, reduce: ReduceStrategy) -> CollectConfig {
-        CollectConfig {
-            from: from.iter().map(|s| s.to_string()).collect(),
-            reduce,
-        }
-    }
-
-    fn make_outputs(entries: Vec<(&str, &str, Option<&str>)>) -> HashMap<String, StepOutput> {
-        let mut map = HashMap::new();
-        for (name, text, result) in entries {
-            map.insert(name.to_string(), make_step_output(name, text, result));
-        }
-        map
-    }
-
-    fn aggregate(all_match: Option<&str>, any_match: Option<&str>) -> ParallelAggregate {
-        ParallelAggregate {
-            all_match: all_match.map(str::to_string),
-            any_match: any_match.map(str::to_string),
-            then: "then-step".to_string(),
-            r#else: "else-step".to_string(),
-        }
-    }
-
-    #[test]
-    fn evaluate_aggregate_all_match_all_children_match() {
-        let aggregate = aggregate(Some("LGTM"), None);
-        let mut outputs = make_outputs(vec![
-            ("arch-review", "looks good", Some("LGTM")),
-            ("security-review", "no issues", Some("LGTM")),
-        ]);
-        outputs.insert(
-            "implement".to_string(),
-            make_step_output("implement", "done", Some("DONE")),
-        );
-        let children = vec!["arch-review".to_string(), "security-review".to_string()];
-
-        assert!(evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_all_match_one_child_mismatch() {
-        let aggregate = aggregate(Some("LGTM"), None);
-        let outputs = make_outputs(vec![
-            ("arch-review", "ok", Some("LGTM")),
-            ("security-review", "problems", Some("NEEDS_FIX")),
-        ]);
-        let children = vec!["arch-review".to_string(), "security-review".to_string()];
-
-        assert!(!evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_any_match_one_child_matches() {
-        let aggregate = aggregate(None, Some("NEEDS_FIX"));
-        let outputs = make_outputs(vec![
-            ("arch-review", "ok", Some("LGTM")),
-            ("security-review", "problems", Some("NEEDS_FIX")),
-        ]);
-        let children = vec!["arch-review".to_string(), "security-review".to_string()];
-
-        assert!(evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_any_match_no_child_matches() {
-        let aggregate = aggregate(None, Some("NEEDS_FIX"));
-        let outputs = make_outputs(vec![
-            ("arch-review", "ok", Some("LGTM")),
-            ("security-review", "ok", Some("LGTM")),
-        ]);
-        let children = vec!["arch-review".to_string(), "security-review".to_string()];
-
-        assert!(!evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_no_condition_returns_true() {
-        let aggregate = aggregate(None, None);
-        let outputs = HashMap::new();
-        let children: Vec<String> = vec![];
-
-        assert!(evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_result_none_does_not_match() {
-        let aggregate = aggregate(Some("LGTM"), None);
-        let outputs = make_outputs(vec![
-            ("arch-review", "Review result: LGTM", None),
-            ("security-review", "All good. LGTM", None),
-        ]);
-        let children = vec!["arch-review".to_string(), "security-review".to_string()];
-
-        assert!(!evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_filters_only_child_steps() {
-        let aggregate = aggregate(Some("LGTM"), None);
-        let mut outputs = make_outputs(vec![("arch-review", "", Some("LGTM"))]);
-        outputs.insert(
-            "implement".to_string(),
-            make_step_output("implement", "done", Some("DONE")),
-        );
-        let children = vec!["arch-review".to_string()];
-
-        assert!(evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_all_match_missing_child_output_returns_false() {
-        let aggregate = aggregate(Some("LGTM"), None);
-        let outputs = make_outputs(vec![("arch-review", "ok", Some("LGTM"))]);
-        let children = vec!["arch-review".to_string(), "security-review".to_string()];
-
-        assert!(!evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_invalid_regex_falls_back_to_contains() {
-        let aggregate = aggregate(Some("[invalid(regex"), None);
-        let outputs = make_outputs(vec![("arch-review", "text", Some("[invalid(regex"))]);
-        let children = vec!["arch-review".to_string()];
-
-        assert!(evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_invalid_regex_contains_no_match() {
-        let aggregate = aggregate(Some("[invalid(regex"), None);
-        let outputs = make_outputs(vec![("arch-review", "LGTM text", Some("LGTM"))]);
-        let children = vec!["arch-review".to_string()];
-
-        assert!(!evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_empty_children_all_match_returns_true() {
-        let aggregate = aggregate(Some("LGTM"), None);
-        let outputs = HashMap::new();
-        let children: Vec<String> = vec![];
-
-        assert!(evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn evaluate_aggregate_child_without_artifact_contract_has_no_step_output() {
-        let aggregate = aggregate(Some("LGTM"), None);
-        let outputs = make_outputs(vec![("arch-review", "ok", Some("LGTM"))]);
-        let children = vec!["arch-review".to_string(), "test-step".to_string()];
-
-        assert!(!evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn reduce_last_returns_latest_completed_entry() {
-        let collect = make_collect(vec!["a", "b", "c"], ReduceStrategy::Last);
-        let mut outputs = HashMap::new();
-        outputs.insert(
-            "a".to_string(),
-            StepOutput {
-                completed_at: 1000.0,
-                ..make_step_output("a", "text_a", Some("LGTM"))
-            },
-        );
-        outputs.insert(
-            "b".to_string(),
-            StepOutput {
-                completed_at: 3000.0,
-                ..make_step_output("b", "text_b", Some("NEEDS_FIX"))
-            },
-        );
-        outputs.insert(
-            "c".to_string(),
-            StepOutput {
-                completed_at: 2000.0,
-                ..make_step_output("c", "text_c", Some("LGTM"))
-            },
-        );
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert_eq!(reduced.result, Some("NEEDS_FIX".to_string()));
-        assert_eq!(reduced.structured_output.unwrap()["text"], "text_b");
-    }
-
-    #[test]
-    fn reduce_concat_joins_all() {
-        let collect = make_collect(vec!["a", "b"], ReduceStrategy::Concat);
-        let outputs = make_outputs(vec![
-            ("a", "output from a", None),
-            ("b", "output from b", None),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert!(reduced.result.is_none());
-        let structured_output = reduced.structured_output.unwrap();
-        let entries = structured_output.as_array().unwrap();
-        assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0]["stepName"], "a");
-        assert_eq!(entries[0]["output"]["text"], "output from a");
-        assert_eq!(entries[1]["stepName"], "b");
-        assert_eq!(entries[1]["output"]["text"], "output from b");
-    }
-
-    #[test]
-    fn reduce_grouped_groups_by_result() {
-        let collect = make_collect(vec!["a", "b", "c"], ReduceStrategy::Grouped);
-        let outputs = make_outputs(vec![
-            ("a", "text_a", Some("LGTM")),
-            ("b", "text_b", Some("NEEDS_FIX")),
-            ("c", "text_c", Some("LGTM")),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert!(reduced.result.is_none());
-        let structured_output = reduced.structured_output.unwrap();
-        let lgtm = structured_output["LGTM"].as_array().unwrap();
-        assert!(lgtm.contains(&serde_json::Value::String("a".to_string())));
-        assert!(lgtm.contains(&serde_json::Value::String("c".to_string())));
-        let needs_fix = structured_output["NEEDS_FIX"].as_array().unwrap();
-        assert!(needs_fix.contains(&serde_json::Value::String("b".to_string())));
-    }
-
-    #[test]
-    fn reduce_any_needs_fix_one_needs_fix() {
-        let collect = make_collect(vec!["a", "b", "c"], ReduceStrategy::AnyNeedsFix);
-        let outputs = make_outputs(vec![
-            ("a", "text_a", Some("LGTM")),
-            ("b", "text_b", Some("NEEDS_FIX")),
-            ("c", "text_c", Some("LGTM")),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert_eq!(reduced.result, Some("NEEDS_FIX".to_string()));
-    }
-
-    #[test]
-    fn reduce_any_needs_fix_all_lgtm() {
-        let collect = make_collect(vec!["a", "b", "c"], ReduceStrategy::AnyNeedsFix);
-        let outputs = make_outputs(vec![
-            ("a", "text_a", Some("LGTM")),
-            ("b", "text_b", Some("LGTM")),
-            ("c", "text_c", Some("LGTM")),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert_eq!(reduced.result, Some("LGTM".to_string()));
-    }
-
-    #[test]
-    fn reduce_any_needs_fix_no_result_treated_as_lgtm() {
-        let collect = make_collect(vec!["a", "b"], ReduceStrategy::AnyNeedsFix);
-        let outputs = make_outputs(vec![
-            ("a", "Everything looks good", None),
-            ("b", "Found issues text", None),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert_eq!(reduced.result, Some("LGTM".to_string()));
-    }
-
-    #[test]
-    fn reduce_all_passed_all_pass() {
-        let collect = make_collect(vec!["a", "b"], ReduceStrategy::AllPassed);
-        let outputs = make_outputs(vec![
-            ("a", "text_a", Some("PASSED")),
-            ("b", "text_b", Some("PASSED")),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert_eq!(reduced.result, Some("PASSED".to_string()));
-    }
-
-    #[test]
-    fn reduce_all_passed_one_failed() {
-        let collect = make_collect(vec!["a", "b"], ReduceStrategy::AllPassed);
-        let outputs = make_outputs(vec![
-            ("a", "text_a", Some("PASSED")),
-            ("b", "text_b", Some("FAILED")),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert_eq!(reduced.result, Some("FAILED".to_string()));
-    }
-
-    #[test]
-    fn reduce_all_passed_no_result_treated_as_failed() {
-        let collect = make_collect(vec!["a", "b"], ReduceStrategy::AllPassed);
-        let outputs = make_outputs(vec![
-            ("a", "All tests ran", None),
-            ("b", "Some tests ran", None),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert_eq!(reduced.result, Some("FAILED".to_string()));
-    }
-
-    #[test]
-    fn reduce_any_needs_fix_structured_output_is_array() {
-        let collect = make_collect(vec!["a", "b"], ReduceStrategy::AnyNeedsFix);
-        let outputs = make_outputs(vec![
-            ("a", "text_a", Some("LGTM")),
-            ("b", "text_b", Some("NEEDS_FIX")),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert_eq!(reduced.result, Some("NEEDS_FIX".to_string()));
-        let structured_output = reduced.structured_output.unwrap();
-        let entries = structured_output.as_array().unwrap();
-        assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0]["stepName"], "a");
-        assert_eq!(entries[0]["output"]["text"], "text_a");
-        assert_eq!(entries[1]["stepName"], "b");
-        assert_eq!(entries[1]["output"]["text"], "text_b");
-    }
-
-    #[test]
-    fn reduce_all_passed_structured_output_is_array() {
-        let collect = make_collect(vec!["a", "b"], ReduceStrategy::AllPassed);
-        let outputs = make_outputs(vec![
-            ("a", "text_a", Some("PASSED")),
-            ("b", "text_b", Some("PASSED")),
-        ]);
-
-        let reduced = apply_reduce(&collect, &outputs);
-
-        assert_eq!(reduced.result, Some("PASSED".to_string()));
-        let structured_output = reduced.structured_output.unwrap();
-        let entries = structured_output.as_array().unwrap();
-        assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0]["stepName"], "a");
-        assert_eq!(entries[1]["stepName"], "b");
-    }
-
-    #[test]
-    fn collect_step_output_entries_returns_array_with_step_name_and_output() {
-        let outputs = make_outputs(vec![
-            ("s1", "out1", Some("LGTM")),
-            ("s2", "out2", Some("NEEDS_FIX")),
-        ]);
-        let from = vec!["s1".to_string(), "s2".to_string()];
-
-        let entries = collect_step_output_entries(&from, &outputs);
-
-        assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0]["stepName"], "s1");
-        assert_eq!(entries[0]["output"]["text"], "out1");
-        assert_eq!(entries[1]["stepName"], "s2");
-        assert_eq!(entries[1]["output"]["text"], "out2");
-    }
-
-    #[test]
-    fn collect_step_output_entries_skips_missing_outputs() {
-        let outputs = make_outputs(vec![("s1", "out1", None)]);
-        let from = vec!["s1".to_string(), "s2".to_string()];
-
-        let entries = collect_step_output_entries(&from, &outputs);
-
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0]["stepName"], "s1");
-    }
-
-    #[test]
-    fn collect_step_output_entries_skips_none_structured_output() {
-        let mut outputs = HashMap::new();
-        outputs.insert(
-            "s1".to_string(),
-            StepOutput {
-                structured_output: None,
-                ..make_step_output("s1", "text", None)
-            },
-        );
-        let from = vec!["s1".to_string()];
-
-        let entries = collect_step_output_entries(&from, &outputs);
-
-        assert!(entries.is_empty());
-    }
-
-    #[test]
-    fn resolve_step_result_returns_result_field() {
-        let output = make_step_output("s", "output with NEEDS_FIX text", Some("LGTM"));
-
-        let result = resolve_step_result(&output);
-
-        assert_eq!(result, Some("LGTM".to_string()));
-    }
-
-    #[test]
-    fn resolve_step_result_none_when_no_result() {
-        let output = make_step_output("s", "found NEEDS_FIX issue", None);
-
-        let result = resolve_step_result(&output);
-
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn resolve_step_result_no_match_returns_none() {
-        let output = make_step_output("s", "everything is fine", None);
-
-        let result = resolve_step_result(&output);
-
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn resolve_step_result_prefers_structured_verdict() {
-        let output = StepOutput {
-            step_name: "s".to_string(),
-            run_index: 0,
-            session_id: None,
-            result: Some("LGTM".to_string()),
-            structured_output: Some(serde_json::json!({
-                "verdict": "NEEDS_FIX",
-                "findings": [{ "severity": "error", "message": "bug" }],
-            })),
-            artifact_contract: None,
-            token_usage: None,
-            completed_at: 1000.0,
-        };
-
-        let result = resolve_step_result(&output);
-
-        assert_eq!(result, Some("NEEDS_FIX".to_string()));
-    }
-
-    #[test]
-    fn resolve_step_result_prefers_structured_status() {
-        let output = StepOutput {
-            step_name: "s".to_string(),
-            run_index: 0,
-            session_id: None,
-            result: None,
-            structured_output: Some(serde_json::json!({"status": "FIXED"})),
-            artifact_contract: None,
-            token_usage: None,
-            completed_at: 1000.0,
-        };
-
-        let result = resolve_step_result(&output);
-
-        assert_eq!(result, Some("FIXED".to_string()));
-    }
-
-    #[test]
-    fn resolve_step_result_verdict_over_status() {
-        let output = StepOutput {
-            step_name: "s".to_string(),
-            run_index: 0,
-            session_id: None,
-            result: None,
-            structured_output: Some(serde_json::json!({
-                "verdict": "LGTM",
-                "status": "FIXED",
-            })),
-            artifact_contract: None,
-            token_usage: None,
-            completed_at: 1000.0,
-        };
-
-        let result = resolve_step_result(&output);
-
-        assert_eq!(result, Some("LGTM".to_string()));
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_commit.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_commit.rs
@@ -67,8 +67,6 @@ pub(crate) enum StepOutcome {
     },
     /// 次のステップに遷移し、AgentSession を起動する
     TransitionAndStart(WorkflowState),
-    /// collect仮想stepに遷移し、reduce処理を実行する
-    ReduceAndTransition(WorkflowState),
     /// 並列ブロックに遷移し、子ステップを並列起動する
     StartParallel(WorkflowState),
 }
@@ -79,7 +77,6 @@ impl StepOutcome {
             Self::Persist(snapshot)
             | Self::RetryCurrentStep { snapshot, .. }
             | Self::TransitionAndStart(snapshot)
-            | Self::ReduceAndTransition(snapshot)
             | Self::StartParallel(snapshot) => snapshot,
         }
     }
@@ -104,9 +101,9 @@ impl StepOutcome {
                 completed_session_id,
                 ..
             } => completed_session_id.iter().cloned().collect(),
-            Self::TransitionAndStart(snapshot)
-            | Self::ReduceAndTransition(snapshot)
-            | Self::StartParallel(snapshot) => completed_step_session_ids(snapshot),
+            Self::TransitionAndStart(snapshot) | Self::StartParallel(snapshot) => {
+                completed_step_session_ids(snapshot)
+            }
         }
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
@@ -15,7 +15,7 @@ use super::step_session_boundary::{dispatch_session_start, SessionStartGate};
 use super::step_session_boundary::{RealStepSessionDeps, StepSessionDeps};
 use crate::adaptor::gateway::workflow::approval_runtime as workflow_approval_runtime;
 use crate::adaptor::gateway::workflow::domain_mapping::{
-    node_kind_to_domain, parallel_aggregate_to_domain, workflow_schemas_to_domain,
+    node_kind_to_domain, workflow_schemas_to_domain,
 };
 use crate::adaptor::gateway::workflow::engine_error::WorkflowEngineError;
 use crate::adaptor::gateway::workflow::engine_start_guard as workflow_engine_start_guard;
@@ -86,8 +86,7 @@ use crate::domain::agent_session::PermissionMode;
 use crate::domain::workflow::services::contract as workflow_contract;
 use crate::domain::workflow::services::contract_schema as workflow_contract_schema;
 use crate::domain::workflow::services::failure_policy::{
-    ParallelFailurePolicy, ParallelPropagation, RepairDecision, RetryPolicy,
-    StructuredOutputRepairPolicy,
+    RepairDecision, RetryPolicy, StructuredOutputRepairPolicy,
 };
 use crate::domain::workflow::services::history::RuntimeStartFailureKind;
 use crate::domain::workflow::services::secret_masker as workflow_secret_masker;
@@ -199,6 +198,9 @@ impl ManagedWorktreeResolver for PassthroughManagedWorktreeResolver {
     }
 }
 
+#[cfg(test)]
+type AbortAfterLookupGate = Arc<Mutex<Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>>>;
+
 /// ワークフローのステップを順次実行するステートマシンエンジン。
 #[derive(Clone)]
 pub struct WorkflowRuntimeService {
@@ -229,8 +231,7 @@ pub struct WorkflowRuntimeService {
     #[cfg(test)]
     fail_next_required_event_append: Arc<AtomicBool>,
     #[cfg(test)]
-    abort_after_lookup_gate:
-        Arc<Mutex<Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>>>,
+    abort_after_lookup_gate: AbortAfterLookupGate,
 }
 
 struct FanoutChildStartedLogObserver<'a, R: tauri::Runtime> {
@@ -458,11 +459,6 @@ fn complete_fanout_parent_after_all_children(
             "parallel parent completion requires an active parallel run".to_string(),
         ));
     };
-    // An empty items expansion is an ordinary successful fanout completion. The temporary
-    // aggregate compatibility block must not route the zero-child case; parent rules do.
-    let aggregate = (!parallel_run.children.is_empty())
-        .then(|| parallel_run.aggregate.clone())
-        .flatten();
     let parent_step_name = parallel_run.parent_step_name.clone();
     let parent_node_execution_id = parallel_run.parent_node_execution_id.clone();
     let parent_run_index = exec
@@ -474,7 +470,6 @@ fn complete_fanout_parent_after_all_children(
     let completion_plan = workflow_parallel_runtime::plan_fanout_parent_completion(
         &parent_step_name,
         parent_run_index,
-        aggregate.as_ref(),
         &parallel_run.children,
         completed_at,
     );
@@ -510,15 +505,7 @@ fn complete_fanout_parent_after_all_children(
     exec.current_session_id = None;
     exec.step_history.push(completion_plan.history_entry);
 
-    let outcome = match completion_plan.transition {
-        workflow_parallel_runtime::FanoutParentCompletionTransition::Advance => {
-            exec.apply_advance()
-        }
-        workflow_parallel_runtime::FanoutParentCompletionTransition::TransitionTo {
-            target_node_name,
-            ..
-        } => exec.apply_transition(&target_node_name)?,
-    };
+    let outcome = exec.apply_advance();
 
     Ok(ParallelChildCompletionCommit {
         all_completed: true,
@@ -2675,7 +2662,7 @@ impl WorkflowRuntimeService {
                     attempt,
                     session_id.as_deref(),
                     None,
-                    None,
+                    Some(node_execution_id),
                     SubmissionViolation::MissingSubmitOutput,
                     None,
                 )
@@ -3334,160 +3321,102 @@ impl WorkflowRuntimeService {
 
             if child_failed {
                 let failure_kind = parallel_child_failure_kind(exit_code, failure_signal);
-                let aggregate = pr.aggregate.as_ref().map(parallel_aggregate_to_domain);
-                let propagation =
-                    ParallelFailurePolicy.on_child_failure(failure_kind, aggregate.as_ref());
                 child.state = ParallelChildState::Failed;
                 child.failure_kind = Some(failure_kind);
-                child.failure_disposition =
-                    if propagation == ParallelPropagation::DelegateToAggregate {
-                        Some(FailureDisposition::Partial)
-                    } else {
-                        None
-                    };
+                child.failure_disposition = None;
                 let child_name = child.step_name.clone();
                 let child_node_execution_id = child.node_execution_id.clone();
                 let child_token_usage = child.token_usage.clone();
-                if propagation == ParallelPropagation::DelegateToAggregate {
-                    child.result = Some(failure_kind.as_str().to_string());
-                    child.structured_output = None;
-                    child.completed_at = Some(current_timestamp());
-                    if let Some(execution) = exec
-                        .node_executions
-                        .iter_mut()
-                        .find(|execution| execution.id == child_node_execution_id)
-                    {
-                        execution.status = NodeExecutionStatus::Failed;
-                        execution.token_usage = Some(child_token_usage.clone());
-                        execution.failure = Some(
-                            crate::adaptor::gateway::workflow::state::NodeExecutionFailure {
-                                reason: format!("fanout child failed with exit code {exit_code}"),
-                                kind: failure_kind,
-                            },
-                        );
-                        execution.completed_at = child.completed_at;
+                let timestamp = current_timestamp();
+                child.result = Some(failure_kind.as_str().to_string());
+                child.structured_output = None;
+                child.completed_at = Some(timestamp);
+                let parent_node_execution_id = pr.parent_node_execution_id.clone();
+                let mut interrupted_session_ids = Vec::new();
+                let mut interrupted_command_ids = Vec::new();
+                let mut interrupted_execution_ids = Vec::new();
+                for sibling in &mut pr.children {
+                    if sibling.state != ParallelChildState::Running {
+                        continue;
                     }
-                    clear_stall_observations_for_session(
-                        &mut exec.current_stall_observations,
-                        session_id,
-                    );
-                    let progress_events = vec![WorkflowEvent::NodeFailed {
-                        run_id: exec.id.clone(),
-                        workflow_name: exec.workflow.name.clone(),
-                        node_execution_id: child_node_execution_id,
-                        node_name: child_name,
-                        reason: format!("fanout child failed with exit code {exit_code}"),
-                        failure_kind,
-                        retry_count: None,
-                        timestamp: current_timestamp(),
-                    }];
-                    break 'state_update (
-                        finalize_child_terminal_state(
-                            exec,
-                            exec_snapshot_before,
-                            progress_events,
-                            true,
-                            Some(FailureClassification::with_disposition(
-                                failure_kind,
-                                FailureDisposition::Partial,
-                            )),
-                        )?,
-                        Vec::new(),
-                        Vec::new(),
-                    );
-                } else {
-                    let timestamp = current_timestamp();
-                    child.result = Some(failure_kind.as_str().to_string());
-                    child.structured_output = None;
-                    child.completed_at = Some(timestamp);
-                    let parent_node_execution_id = pr.parent_node_execution_id.clone();
-                    let mut interrupted_session_ids = Vec::new();
-                    let mut interrupted_command_ids = Vec::new();
-                    let mut interrupted_execution_ids = Vec::new();
-                    for sibling in &mut pr.children {
-                        if sibling.state != ParallelChildState::Running {
-                            continue;
-                        }
-                        sibling.state = ParallelChildState::Interrupted;
-                        sibling.completed_at = Some(timestamp);
-                        interrupted_execution_ids.push(sibling.node_execution_id.clone());
-                        if sibling.session_id.is_empty() {
-                            interrupted_command_ids.push(sibling.node_execution_id.clone());
-                        } else {
-                            interrupted_session_ids.push(sibling.session_id.clone());
-                        }
+                    sibling.state = ParallelChildState::Interrupted;
+                    sibling.completed_at = Some(timestamp);
+                    interrupted_execution_ids.push(sibling.node_execution_id.clone());
+                    if sibling.session_id.is_empty() {
+                        interrupted_command_ids.push(sibling.node_execution_id.clone());
+                    } else {
+                        interrupted_session_ids.push(sibling.session_id.clone());
                     }
+                }
 
-                    let reason = format!(
-                        "fanout child '{}' failed (exit_code: {})",
-                        child_name, exit_code
-                    );
-                    exec.fail_node_execution(
-                        &child_node_execution_id,
-                        reason.clone(),
-                        failure_kind,
-                        timestamp,
-                    );
+                let reason = format!(
+                    "fanout child '{}' failed (exit_code: {})",
+                    child_name, exit_code
+                );
+                exec.fail_node_execution(
+                    &child_node_execution_id,
+                    reason.clone(),
+                    failure_kind,
+                    timestamp,
+                );
+                if let Some(node_execution) = exec
+                    .node_executions
+                    .iter_mut()
+                    .find(|execution| execution.id == child_node_execution_id)
+                {
+                    node_execution.token_usage = Some(child_token_usage);
+                }
+                for execution_id in interrupted_execution_ids {
                     if let Some(node_execution) = exec
                         .node_executions
                         .iter_mut()
-                        .find(|execution| execution.id == child_node_execution_id)
+                        .find(|execution| execution.id == execution_id)
                     {
-                        node_execution.token_usage = Some(child_token_usage);
+                        node_execution.status = NodeExecutionStatus::Aborted;
+                        node_execution.completed_at = Some(timestamp);
                     }
-                    for execution_id in interrupted_execution_ids {
-                        if let Some(node_execution) = exec
-                            .node_executions
-                            .iter_mut()
-                            .find(|execution| execution.id == execution_id)
-                        {
-                            node_execution.status = NodeExecutionStatus::Aborted;
-                            node_execution.completed_at = Some(timestamp);
-                        }
-                    }
-                    exec.fail_node_execution(
-                        &parent_node_execution_id,
-                        reason.clone(),
-                        failure_kind,
-                        timestamp,
-                    );
-                    exec.current_stall_observations.clear();
-                    exec.state = WorkflowExecutionState::Failed {
-                        reason: reason.clone(),
-                        kind: failure_kind,
-                        retry_count: None,
-                    };
-                    let history_entry =
-                        exec.make_step_history_entry(Some(reason.clone()), None, None);
-                    exec.step_history.push(history_entry);
-                    exec.parallel_run = None;
-                    exec.updated_at = timestamp;
-                    let progress_events = vec![WorkflowEvent::NodeFailed {
-                        run_id: exec.id.clone(),
-                        workflow_name: exec.workflow.name.clone(),
-                        node_execution_id: child_node_execution_id,
-                        node_name: child_name,
-                        reason,
-                        failure_kind,
-                        retry_count: None,
-                        timestamp,
-                    }];
-                    break 'state_update (
-                        ParallelChildCompletionCommit {
-                            all_completed: true,
-                            outcome: Some(StepOutcome::Persist(exec.to_workflow_state())),
-                            snapshot_before: exec_snapshot_before,
-                            progress_events,
-                            required_progress_events: true,
-                            failure_telemetry: Some(FailureClassification::with_disposition(
-                                failure_kind,
-                                FailureDisposition::Terminal,
-                            )),
-                        },
-                        interrupted_session_ids,
-                        interrupted_command_ids,
-                    );
                 }
+                exec.fail_node_execution(
+                    &parent_node_execution_id,
+                    reason.clone(),
+                    failure_kind,
+                    timestamp,
+                );
+                exec.current_stall_observations.clear();
+                exec.state = WorkflowExecutionState::Failed {
+                    reason: reason.clone(),
+                    kind: failure_kind,
+                    retry_count: None,
+                };
+                let history_entry = exec.make_step_history_entry(Some(reason.clone()), None, None);
+                exec.step_history.push(history_entry);
+                exec.parallel_run = None;
+                exec.updated_at = timestamp;
+                let progress_events = vec![WorkflowEvent::NodeFailed {
+                    run_id: exec.id.clone(),
+                    workflow_name: exec.workflow.name.clone(),
+                    node_execution_id: child_node_execution_id,
+                    node_name: child_name,
+                    reason,
+                    failure_kind,
+                    retry_count: None,
+                    timestamp,
+                }];
+                break 'state_update (
+                    ParallelChildCompletionCommit {
+                        all_completed: true,
+                        outcome: Some(StepOutcome::Persist(exec.to_workflow_state())),
+                        snapshot_before: exec_snapshot_before,
+                        progress_events,
+                        required_progress_events: true,
+                        failure_telemetry: Some(FailureClassification::with_disposition(
+                            failure_kind,
+                            FailureDisposition::Terminal,
+                        )),
+                    },
+                    interrupted_session_ids,
+                    interrupted_command_ids,
+                );
             }
 
             // 成功
@@ -5095,15 +5024,10 @@ impl WorkflowRuntimeService {
             }
             let snapshot_before = execution.clone();
             let workflow_name = execution.workflow.name.clone();
-            let (delegates_to_aggregate, parent_node_execution_id) = execution
+            let parent_node_execution_id = execution
                 .parallel_run
                 .as_ref()
-                .map(|run| {
-                    (
-                        run.aggregate.is_some(),
-                        run.parent_node_execution_id.clone(),
-                    )
-                })
+                .map(|run| run.parent_node_execution_id.clone())
                 .ok_or_else(|| {
                     WorkflowEngineError::InvalidState(
                         "fanout command failure requires an active fanout run".to_string(),
@@ -5127,8 +5051,7 @@ impl WorkflowRuntimeService {
             child.result = Some(failure_kind.as_str().to_string());
             child.structured_output = None;
             child.failure_kind = Some(failure_kind);
-            child.failure_disposition =
-                delegates_to_aggregate.then_some(FailureDisposition::Partial);
+            child.failure_disposition = None;
             child.completed_at = Some(timestamp);
             execution.fail_node_execution(
                 &input.node_execution_id,
@@ -5147,95 +5070,78 @@ impl WorkflowRuntimeService {
                 timestamp,
             }];
 
-            if delegates_to_aggregate {
-                (
-                    finalize_child_terminal_state(
-                        execution,
-                        snapshot_before,
-                        progress_events,
-                        true,
-                        Some(FailureClassification::with_disposition(
-                            failure_kind,
-                            FailureDisposition::Partial,
-                        )),
-                    )?,
-                    Vec::new(),
-                    Vec::new(),
-                )
-            } else {
-                let (interrupted_session_ids, interrupted_command_ids, interrupted_execution_ids) =
-                    execution
-                        .parallel_run
-                        .as_mut()
-                        .map(|run| {
-                            let mut sessions = Vec::new();
-                            let mut commands = Vec::new();
-                            let mut execution_ids = Vec::new();
-                            for child in &mut run.children {
-                                if child.node_execution_id == input.node_execution_id
-                                    || child.state != ParallelChildState::Running
-                                {
-                                    continue;
-                                }
-                                child.state = ParallelChildState::Interrupted;
-                                execution_ids.push(child.node_execution_id.clone());
-                                if child.session_id.is_empty() {
-                                    commands.push(child.node_execution_id.clone());
-                                } else {
-                                    sessions.push(child.session_id.clone());
-                                }
+            let (interrupted_session_ids, interrupted_command_ids, interrupted_execution_ids) =
+                execution
+                    .parallel_run
+                    .as_mut()
+                    .map(|run| {
+                        let mut sessions = Vec::new();
+                        let mut commands = Vec::new();
+                        let mut execution_ids = Vec::new();
+                        for child in &mut run.children {
+                            if child.node_execution_id == input.node_execution_id
+                                || child.state != ParallelChildState::Running
+                            {
+                                continue;
                             }
-                            (sessions, commands, execution_ids)
-                        })
-                        .unwrap_or_default();
-                for execution_id in interrupted_execution_ids {
-                    if let Some(node_execution) = execution
-                        .node_executions
-                        .iter_mut()
-                        .find(|candidate| candidate.id == execution_id)
-                    {
-                        node_execution.status = NodeExecutionStatus::Aborted;
-                        node_execution.completed_at = Some(timestamp);
-                    }
+                            child.state = ParallelChildState::Interrupted;
+                            execution_ids.push(child.node_execution_id.clone());
+                            if child.session_id.is_empty() {
+                                commands.push(child.node_execution_id.clone());
+                            } else {
+                                sessions.push(child.session_id.clone());
+                            }
+                        }
+                        (sessions, commands, execution_ids)
+                    })
+                    .unwrap_or_default();
+            for execution_id in interrupted_execution_ids {
+                if let Some(node_execution) = execution
+                    .node_executions
+                    .iter_mut()
+                    .find(|candidate| candidate.id == execution_id)
+                {
+                    node_execution.status = NodeExecutionStatus::Aborted;
+                    node_execution.completed_at = Some(timestamp);
                 }
-                execution.fail_node_execution(
-                    &parent_node_execution_id,
-                    format!("fanout child '{}' failed: {reason}", input.node_name),
-                    failure_kind,
-                    timestamp,
-                );
-                let entry = execution.make_step_history_entry(
-                    Some(format!(
-                        "fanout child '{}' failed: {reason}",
-                        input.node_name
-                    )),
-                    None,
-                    None,
-                );
-                execution.step_history.push(entry);
-                execution.state = WorkflowExecutionState::Failed {
-                    reason: format!("fanout child '{}' failed: {reason}", input.node_name),
-                    kind: failure_kind,
-                    retry_count: None,
-                };
-                execution.parallel_run = None;
-                execution.updated_at = timestamp;
-                (
-                    ParallelChildCompletionCommit {
-                        all_completed: true,
-                        outcome: Some(StepOutcome::Persist(execution.to_workflow_state())),
-                        snapshot_before,
-                        progress_events,
-                        required_progress_events: true,
-                        failure_telemetry: Some(FailureClassification::with_disposition(
-                            failure_kind,
-                            FailureDisposition::Terminal,
-                        )),
-                    },
-                    interrupted_session_ids,
-                    interrupted_command_ids,
-                )
             }
+            execution.fail_node_execution(
+                &parent_node_execution_id,
+                format!("fanout child '{}' failed: {reason}", input.node_name),
+                failure_kind,
+                timestamp,
+            );
+            let entry = execution.make_step_history_entry(
+                Some(format!(
+                    "fanout child '{}' failed: {reason}",
+                    input.node_name
+                )),
+                None,
+                None,
+            );
+            execution.step_history.push(entry);
+            execution.state = WorkflowExecutionState::Failed {
+                reason: format!("fanout child '{}' failed: {reason}", input.node_name),
+                kind: failure_kind,
+                retry_count: None,
+            };
+            execution.parallel_run = None;
+            execution.updated_at = timestamp;
+            (
+                ParallelChildCompletionCommit {
+                    all_completed: true,
+                    outcome: Some(StepOutcome::Persist(execution.to_workflow_state())),
+                    snapshot_before,
+                    progress_events,
+                    required_progress_events: true,
+                    failure_telemetry: Some(FailureClassification::with_disposition(
+                        failure_kind,
+                        FailureDisposition::Terminal,
+                    )),
+                },
+                interrupted_session_ids,
+                interrupted_command_ids,
+            )
         };
 
         if let Some(outcome) = completion.outcome {
@@ -6113,36 +6019,6 @@ impl WorkflowRuntimeService {
                 }
                 Ok(())
             }
-            StepOutcome::ReduceAndTransition(snapshot) => {
-                self.emit_post_commit_progress_events(
-                    app,
-                    commit_mode,
-                    workflow_runtime_events::PostCommitProgressEventPlan::ReduceAndTransition,
-                    &snapshot,
-                )?;
-
-                let reduce_transition =
-                    workflow_parallel_runtime::apply_reduce_transition_by_worktree(
-                        &self.executions,
-                        worktree_path,
-                        &snapshot,
-                    )
-                    .await?;
-                self.write_log(app, reduce_transition.output_collected_event);
-
-                // 次 outcome は新たな state mutation なので、再度 sync+persist が必要。
-                // execute_outcome 経由でフル経路を回す（spec [04] post-commit 内で発生する
-                // 派生 mutation も同じ atomic 境界に乗せる）。
-                Box::pin(self.execute_outcome(
-                    app,
-                    session_store,
-                    agent_runtime,
-                    worktree_path,
-                    reduce_transition.next_outcome,
-                    reduce_transition.snapshot_before,
-                ))
-                .await
-            }
             StepOutcome::StartParallel(snapshot) => {
                 self.emit_post_commit_progress_events(
                     app,
@@ -6641,7 +6517,6 @@ impl WorkflowRuntimeService {
                 }),
                 artifact: Some("approved-fix-policy".to_string()),
                 rules: vec![],
-                collect: None,
                 ..Default::default()
             }],
         };

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
@@ -199,7 +199,8 @@ impl ManagedWorktreeResolver for PassthroughManagedWorktreeResolver {
 }
 
 #[cfg(test)]
-type AbortAfterLookupGate = Arc<Mutex<Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>>>;
+type AbortAfterLookupGate =
+    Arc<Mutex<Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>>>;
 
 /// ワークフローのステップを順次実行するステートマシンエンジン。
 #[derive(Clone)]
@@ -248,6 +249,22 @@ struct ParallelChildCompletionCommit {
     progress_events: Vec<WorkflowEvent>,
     required_progress_events: bool,
     failure_telemetry: Option<FailureClassification>,
+}
+
+struct FanoutChildFailureCommit {
+    completion: ParallelChildCompletionCommit,
+    interrupted_session_ids: Vec<String>,
+    interrupted_command_ids: Vec<String>,
+}
+
+struct FanoutChildFailureInput {
+    child_node_execution_id: String,
+    child_failure_reason: String,
+    terminal_reason: String,
+    failure_kind: WorkflowStepFailureKind,
+    retry_count: Option<u32>,
+    timestamp: f64,
+    record_child_token_usage: bool,
 }
 
 #[derive(Clone)]
@@ -556,6 +573,153 @@ fn finalize_child_terminal_state(
         required_progress_events,
         failure_telemetry,
     )
+}
+
+fn finalize_fanout_child_failure_state(
+    exec: &mut WorkflowExecution,
+    snapshot_before: WorkflowExecution,
+    input: FanoutChildFailureInput,
+) -> Result<FanoutChildFailureCommit, WorkflowEngineError> {
+    let workflow_name = exec.workflow.name.clone();
+    let run_id = exec.id.clone();
+    let failure_kind = input.failure_kind;
+    let retry_count = input.retry_count;
+    let timestamp = input.timestamp;
+    let (
+        parent_node_execution_id,
+        child_name,
+        child_token_usage,
+        interrupted_session_ids,
+        interrupted_command_ids,
+        interrupted_execution_ids,
+    ) = {
+        let Some(parallel_run) = exec.parallel_run.as_mut() else {
+            return Err(WorkflowEngineError::InvalidState(
+                "fanout child failure requires an active fanout run".to_string(),
+            ));
+        };
+        let Some(child_index) = parallel_run
+            .children
+            .iter()
+            .position(|child| child.node_execution_id == input.child_node_execution_id)
+        else {
+            return Err(WorkflowEngineError::InvalidState(format!(
+                "fanout child failure references unknown child '{}'",
+                input.child_node_execution_id
+            )));
+        };
+        let parent_node_execution_id = parallel_run.parent_node_execution_id.clone();
+        let mut child_name = String::new();
+        let mut child_token_usage = None;
+        let mut interrupted_session_ids = Vec::new();
+        let mut interrupted_command_ids = Vec::new();
+        let mut interrupted_execution_ids = Vec::new();
+
+        for (index, child) in parallel_run.children.iter_mut().enumerate() {
+            if index == child_index {
+                child.state = ParallelChildState::Failed;
+                child.result = Some(failure_kind.as_str().to_string());
+                child.structured_output = None;
+                child.failure_kind = Some(failure_kind);
+                child.failure_disposition = None;
+                child.completed_at = Some(timestamp);
+                child_name = child.step_name.clone();
+                if input.record_child_token_usage {
+                    child_token_usage = Some(child.token_usage.clone());
+                }
+                continue;
+            }
+            if child.state != ParallelChildState::Running {
+                continue;
+            }
+            child.state = ParallelChildState::Interrupted;
+            child.completed_at = Some(timestamp);
+            interrupted_execution_ids.push(child.node_execution_id.clone());
+            if child.session_id.is_empty() {
+                interrupted_command_ids.push(child.node_execution_id.clone());
+            } else {
+                interrupted_session_ids.push(child.session_id.clone());
+            }
+        }
+
+        (
+            parent_node_execution_id,
+            child_name,
+            child_token_usage,
+            interrupted_session_ids,
+            interrupted_command_ids,
+            interrupted_execution_ids,
+        )
+    };
+
+    exec.fail_node_execution(
+        &input.child_node_execution_id,
+        input.child_failure_reason.clone(),
+        failure_kind,
+        timestamp,
+    );
+    if let Some(child_token_usage) = child_token_usage {
+        if let Some(node_execution) = exec
+            .node_executions
+            .iter_mut()
+            .find(|execution| execution.id == input.child_node_execution_id)
+        {
+            node_execution.token_usage = Some(child_token_usage);
+        }
+    }
+    for execution_id in interrupted_execution_ids {
+        if let Some(node_execution) = exec
+            .node_executions
+            .iter_mut()
+            .find(|execution| execution.id == execution_id)
+        {
+            node_execution.status = NodeExecutionStatus::Aborted;
+            node_execution.completed_at = Some(timestamp);
+        }
+    }
+    exec.fail_node_execution(
+        &parent_node_execution_id,
+        input.terminal_reason.clone(),
+        failure_kind,
+        timestamp,
+    );
+    exec.current_stall_observations.clear();
+    exec.state = WorkflowExecutionState::Failed {
+        reason: input.terminal_reason.clone(),
+        kind: failure_kind,
+        retry_count,
+    };
+    let history_entry =
+        exec.make_step_history_entry(Some(input.terminal_reason.clone()), None, None);
+    exec.step_history.push(history_entry);
+    exec.parallel_run = None;
+    exec.updated_at = timestamp;
+    let progress_events = vec![WorkflowEvent::NodeFailed {
+        run_id,
+        workflow_name,
+        node_execution_id: input.child_node_execution_id,
+        node_name: child_name,
+        reason: input.child_failure_reason,
+        failure_kind,
+        retry_count,
+        timestamp,
+    }];
+
+    Ok(FanoutChildFailureCommit {
+        completion: ParallelChildCompletionCommit {
+            all_completed: true,
+            outcome: Some(StepOutcome::Persist(exec.to_workflow_state())),
+            snapshot_before,
+            progress_events,
+            required_progress_events: true,
+            failure_telemetry: Some(FailureClassification::with_disposition(
+                failure_kind,
+                FailureDisposition::Terminal,
+            )),
+        },
+        interrupted_session_ids,
+        interrupted_command_ids,
+    })
 }
 
 impl<R: tauri::Runtime> workflow_runtime_session::FanoutChildTurnObserver
@@ -3321,101 +3485,29 @@ impl WorkflowRuntimeService {
 
             if child_failed {
                 let failure_kind = parallel_child_failure_kind(exit_code, failure_signal);
-                child.state = ParallelChildState::Failed;
-                child.failure_kind = Some(failure_kind);
-                child.failure_disposition = None;
                 let child_name = child.step_name.clone();
                 let child_node_execution_id = child.node_execution_id.clone();
-                let child_token_usage = child.token_usage.clone();
-                let timestamp = current_timestamp();
-                child.result = Some(failure_kind.as_str().to_string());
-                child.structured_output = None;
-                child.completed_at = Some(timestamp);
-                let parent_node_execution_id = pr.parent_node_execution_id.clone();
-                let mut interrupted_session_ids = Vec::new();
-                let mut interrupted_command_ids = Vec::new();
-                let mut interrupted_execution_ids = Vec::new();
-                for sibling in &mut pr.children {
-                    if sibling.state != ParallelChildState::Running {
-                        continue;
-                    }
-                    sibling.state = ParallelChildState::Interrupted;
-                    sibling.completed_at = Some(timestamp);
-                    interrupted_execution_ids.push(sibling.node_execution_id.clone());
-                    if sibling.session_id.is_empty() {
-                        interrupted_command_ids.push(sibling.node_execution_id.clone());
-                    } else {
-                        interrupted_session_ids.push(sibling.session_id.clone());
-                    }
-                }
-
                 let reason = format!(
                     "fanout child '{}' failed (exit_code: {})",
                     child_name, exit_code
                 );
-                exec.fail_node_execution(
-                    &child_node_execution_id,
-                    reason.clone(),
-                    failure_kind,
-                    timestamp,
-                );
-                if let Some(node_execution) = exec
-                    .node_executions
-                    .iter_mut()
-                    .find(|execution| execution.id == child_node_execution_id)
-                {
-                    node_execution.token_usage = Some(child_token_usage);
-                }
-                for execution_id in interrupted_execution_ids {
-                    if let Some(node_execution) = exec
-                        .node_executions
-                        .iter_mut()
-                        .find(|execution| execution.id == execution_id)
-                    {
-                        node_execution.status = NodeExecutionStatus::Aborted;
-                        node_execution.completed_at = Some(timestamp);
-                    }
-                }
-                exec.fail_node_execution(
-                    &parent_node_execution_id,
-                    reason.clone(),
-                    failure_kind,
-                    timestamp,
-                );
-                exec.current_stall_observations.clear();
-                exec.state = WorkflowExecutionState::Failed {
-                    reason: reason.clone(),
-                    kind: failure_kind,
-                    retry_count: None,
-                };
-                let history_entry = exec.make_step_history_entry(Some(reason.clone()), None, None);
-                exec.step_history.push(history_entry);
-                exec.parallel_run = None;
-                exec.updated_at = timestamp;
-                let progress_events = vec![WorkflowEvent::NodeFailed {
-                    run_id: exec.id.clone(),
-                    workflow_name: exec.workflow.name.clone(),
-                    node_execution_id: child_node_execution_id,
-                    node_name: child_name,
-                    reason,
-                    failure_kind,
-                    retry_count: None,
-                    timestamp,
-                }];
-                break 'state_update (
-                    ParallelChildCompletionCommit {
-                        all_completed: true,
-                        outcome: Some(StepOutcome::Persist(exec.to_workflow_state())),
-                        snapshot_before: exec_snapshot_before,
-                        progress_events,
-                        required_progress_events: true,
-                        failure_telemetry: Some(FailureClassification::with_disposition(
-                            failure_kind,
-                            FailureDisposition::Terminal,
-                        )),
+                let failure_commit = finalize_fanout_child_failure_state(
+                    exec,
+                    exec_snapshot_before,
+                    FanoutChildFailureInput {
+                        child_node_execution_id,
+                        child_failure_reason: reason.clone(),
+                        terminal_reason: reason,
+                        failure_kind,
+                        retry_count: None,
+                        timestamp: current_timestamp(),
+                        record_child_token_usage: true,
                     },
-                    interrupted_session_ids,
-                    interrupted_command_ids,
+                )?;
+                break 'state_update (
+                    failure_commit.completion,
+                    failure_commit.interrupted_session_ids,
+                    failure_commit.interrupted_command_ids,
                 );
             }
 
@@ -5023,124 +5115,24 @@ impl WorkflowRuntimeService {
                 return Ok(());
             }
             let snapshot_before = execution.clone();
-            let workflow_name = execution.workflow.name.clone();
-            let parent_node_execution_id = execution
-                .parallel_run
-                .as_ref()
-                .map(|run| run.parent_node_execution_id.clone())
-                .ok_or_else(|| {
-                    WorkflowEngineError::InvalidState(
-                        "fanout command failure requires an active fanout run".to_string(),
-                    )
-                })?;
-            let child = execution
-                .parallel_run
-                .as_mut()
-                .and_then(|run| {
-                    run.children
-                        .iter_mut()
-                        .find(|child| child.node_execution_id == input.node_execution_id)
-                })
-                .ok_or_else(|| {
-                    WorkflowEngineError::InvalidState(format!(
-                        "fanout command child '{}' disappeared",
-                        input.node_execution_id
-                    ))
-                })?;
-            child.state = ParallelChildState::Failed;
-            child.result = Some(failure_kind.as_str().to_string());
-            child.structured_output = None;
-            child.failure_kind = Some(failure_kind);
-            child.failure_disposition = None;
-            child.completed_at = Some(timestamp);
-            execution.fail_node_execution(
-                &input.node_execution_id,
-                reason.to_string(),
-                failure_kind,
-                timestamp,
-            );
-            let progress_events = vec![WorkflowEvent::NodeFailed {
-                run_id: input.run_id.clone(),
-                workflow_name,
-                node_execution_id: input.node_execution_id.clone(),
-                node_name: input.node_name.clone(),
-                reason: reason.to_string(),
-                failure_kind,
-                retry_count: None,
-                timestamp,
-            }];
-
-            let (interrupted_session_ids, interrupted_command_ids, interrupted_execution_ids) =
-                execution
-                    .parallel_run
-                    .as_mut()
-                    .map(|run| {
-                        let mut sessions = Vec::new();
-                        let mut commands = Vec::new();
-                        let mut execution_ids = Vec::new();
-                        for child in &mut run.children {
-                            if child.node_execution_id == input.node_execution_id
-                                || child.state != ParallelChildState::Running
-                            {
-                                continue;
-                            }
-                            child.state = ParallelChildState::Interrupted;
-                            execution_ids.push(child.node_execution_id.clone());
-                            if child.session_id.is_empty() {
-                                commands.push(child.node_execution_id.clone());
-                            } else {
-                                sessions.push(child.session_id.clone());
-                            }
-                        }
-                        (sessions, commands, execution_ids)
-                    })
-                    .unwrap_or_default();
-            for execution_id in interrupted_execution_ids {
-                if let Some(node_execution) = execution
-                    .node_executions
-                    .iter_mut()
-                    .find(|candidate| candidate.id == execution_id)
-                {
-                    node_execution.status = NodeExecutionStatus::Aborted;
-                    node_execution.completed_at = Some(timestamp);
-                }
-            }
-            execution.fail_node_execution(
-                &parent_node_execution_id,
-                format!("fanout child '{}' failed: {reason}", input.node_name),
-                failure_kind,
-                timestamp,
-            );
-            let entry = execution.make_step_history_entry(
-                Some(format!(
-                    "fanout child '{}' failed: {reason}",
-                    input.node_name
-                )),
-                None,
-                None,
-            );
-            execution.step_history.push(entry);
-            execution.state = WorkflowExecutionState::Failed {
-                reason: format!("fanout child '{}' failed: {reason}", input.node_name),
-                kind: failure_kind,
-                retry_count: None,
-            };
-            execution.parallel_run = None;
-            execution.updated_at = timestamp;
-            (
-                ParallelChildCompletionCommit {
-                    all_completed: true,
-                    outcome: Some(StepOutcome::Persist(execution.to_workflow_state())),
-                    snapshot_before,
-                    progress_events,
-                    required_progress_events: true,
-                    failure_telemetry: Some(FailureClassification::with_disposition(
-                        failure_kind,
-                        FailureDisposition::Terminal,
-                    )),
+            let terminal_reason = format!("fanout child '{}' failed: {reason}", input.node_name);
+            let failure_commit = finalize_fanout_child_failure_state(
+                execution,
+                snapshot_before,
+                FanoutChildFailureInput {
+                    child_node_execution_id: input.node_execution_id.clone(),
+                    child_failure_reason: reason.to_string(),
+                    terminal_reason,
+                    failure_kind,
+                    retry_count: None,
+                    timestamp,
+                    record_child_token_usage: false,
                 },
-                interrupted_session_ids,
-                interrupted_command_ids,
+            )?;
+            (
+                failure_commit.completion,
+                failure_commit.interrupted_session_ids,
+                failure_commit.interrupted_command_ids,
             )
         };
 

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -578,9 +578,7 @@ async fn retry_current_step_outcome_releases_previous_session_only() {
         vec!["stale-session".to_string()]
     );
 }
-use crate::adaptor::gateway::workflow::schema::{
-    CollectConfig, ParallelAggregate, ReduceStrategy, Rule, SchemaDef, Workflow,
-};
+use crate::adaptor::gateway::workflow::schema::{Rule, SchemaDef, Workflow};
 
 fn object_schema_for_test(fields: &[&str]) -> SchemaDef {
     SchemaDef::Object {
@@ -671,7 +669,6 @@ fn current_step_for_stall_observation_ignores_terminal_fanout_children() {
     exec.parallel_run = Some(ParallelRunState {
         parent_step_name: "parallel-review".to_string(),
         parent_node_execution_id: "node-execution-parallel-review".to_string(),
-        aggregate: None,
         children: vec![
             ParallelChildRun {
                 node_execution_id: "node-execution-running-child".to_string(),
@@ -1145,7 +1142,7 @@ fn make_test_step(
     NodeDefinition {
         name: name.to_string(),
         kind: test_node_kind(kind, instruction),
-        rules: rules,
+        rules,
         ..NodeDefinition::default()
     }
 }
@@ -1154,17 +1151,12 @@ fn make_approval_gated_session(name: &str, instruction: &str, rules: Vec<Rule>) 
     make_test_step(name, TestKind::ApprovalSession, instruction, rules, None)
 }
 
-fn make_fanout_step(
-    name: &str,
-    children: Vec<&str>,
-    aggregate: Option<ParallelAggregate>,
-) -> NodeDefinition {
+fn make_fanout_step(name: &str, children: Vec<&str>) -> NodeDefinition {
     NodeDefinition {
         name: name.to_string(),
         kind: NodeKind::Fanout(FanoutSpec {
             child: children.into_iter().map(str::to_string).collect(),
             items: None,
-            aggregate,
         }),
         ..Default::default()
     }
@@ -4540,16 +4532,7 @@ fn auto_approve_persist_target_applies_latest_policy_and_advances_once() {
                     step
                 },
                 make_test_step("fix", TestKind::Session, "Fix", vec![], None),
-                make_fanout_step(
-                    "code_review_parallel",
-                    vec![],
-                    Some(ParallelAggregate {
-                        all_match: Some("LGTM".to_string()),
-                        any_match: None,
-                        then: "fix".to_string(),
-                        r#else: "implementation_fix_policy".to_string(),
-                    }),
-                ),
+                make_fanout_step("code_review_parallel", vec![]),
             ],
         },
         state: WorkflowExecutionState::WaitingApproval,
@@ -4636,11 +4619,7 @@ async fn execute_outcome_auto_approve_persist_adopts_policy_and_starts_fix_once(
     let worktree_path = "/repo";
     let policy_session_id = uuid::Uuid::new_v4().to_string();
 
-    let mut fix_step = make_test_step("fix", TestKind::Session, "Fix", vec![], None);
-    fix_step.collect = Some(CollectConfig {
-        from: vec!["implementation_fix_policy".to_string()],
-        reduce: ReduceStrategy::Last,
-    });
+    let fix_step = make_test_step("fix", TestKind::Session, "Fix", vec![], None);
     let exec = WorkflowExecution {
         id: "exec-auto-approve".to_string(),
         workflow: Workflow {
@@ -4649,16 +4628,7 @@ async fn execute_outcome_auto_approve_persist_adopts_policy_and_starts_fix_once(
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step(
-                    "code_review_parallel",
-                    vec![],
-                    Some(ParallelAggregate {
-                        all_match: Some("LGTM".to_string()),
-                        any_match: None,
-                        then: "done".to_string(),
-                        r#else: "implementation_fix_policy".to_string(),
-                    }),
-                ),
+                make_fanout_step("code_review_parallel", vec![]),
                 {
                     let mut step = make_approval_gated_session(
                         "implementation_fix_policy",
@@ -4709,7 +4679,7 @@ async fn execute_outcome_auto_approve_persist_adopts_policy_and_starts_fix_once(
 
     let execs = engine.executions.lock().await;
     let (_, exec) = find_by_worktree(&execs, worktree_path).unwrap();
-    assert!(matches!(outcome, StepOutcome::ReduceAndTransition(_)));
+    assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
     assert_eq!(exec.step_execution_counts.get("fix"), Some(&1));
     assert_eq!(
         exec.step_history
@@ -4796,7 +4766,13 @@ fn make_normal_step_exec_with_stall_observation() -> WorkflowExecution {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_test_step("plan", TestKind::Session, "plan", vec![], None),
+                make_test_step(
+                    "plan",
+                    TestKind::Session,
+                    "plan",
+                    vec![Rule::Next("implement".to_string())],
+                    None,
+                ),
                 make_test_step("implement", TestKind::Session, "implement", vec![], None),
             ],
         },
@@ -4839,7 +4815,7 @@ fn normal_step_completion_retry_and_transition_clear_stall_observations() {
     assert!(retry_snapshot.stall_observations.is_empty());
 
     let mut transitioned = make_normal_step_exec_with_stall_observation();
-    let transition_snapshot = match transitioned.apply_transition("implement").unwrap() {
+    let transition_snapshot = match transitioned.apply_advance() {
         StepOutcome::TransitionAndStart(snapshot) => snapshot,
         _ => panic!("unexpected transition outcome"),
     };
@@ -4934,7 +4910,7 @@ fn make_step_history_entry_no_structured_output_no_step_output() {
     assert!(!exec.step_outputs.contains_key("plan"));
 }
 
-// ---- on_exhausted: apply_transition テスト ----
+// ---- on_exhausted: production routing テスト ----
 
 fn make_on_exhausted_workflow() -> Workflow {
     Workflow {
@@ -5000,8 +4976,8 @@ fn on_exhausted_transitions_to_fallback_step() {
         },
     };
 
-    // fix への遷移を試みる → ガード超過 → on_exhausted で approval へ
-    let outcome = exec.apply_transition("fix").unwrap();
+    // review の next=fix → ガード超過 → on_exhausted で approval へ
+    let outcome = exec.apply_advance();
     assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
     assert_eq!(
         exec.workflow.nodes[exec.current_step_index].name,
@@ -5052,13 +5028,20 @@ fn check_loop_guard_exceeded_with_on_exhausted() {
 
 #[test]
 fn on_exhausted_chain_transitions() {
-    // step_a → (exhausted) → step_b → (exhausted) → step_c
+    // start → step_a → (exhausted) → step_b → (exhausted) → step_c
     let wf = Workflow {
         name: "chain-test".to_string(),
         description: "test".to_string(),
         builtin: false,
         schemas: Default::default(),
         nodes: vec![
+            make_test_step(
+                "start",
+                TestKind::Session,
+                "Start",
+                vec![Rule::Next("step_a".to_string())],
+                None,
+            ),
             make_test_step(
                 "step_a",
                 TestKind::Session,
@@ -5110,8 +5093,8 @@ fn on_exhausted_chain_transitions() {
         },
     };
 
-    // step_a → exhausted → step_b → exhausted → step_c
-    let outcome = exec.apply_transition("step_a").unwrap();
+    // start の next=step_a → exhausted → step_b → exhausted → step_c
+    let outcome = exec.apply_advance();
     assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
     assert_eq!(exec.workflow.nodes[exec.current_step_index].name, "step_c");
 }
@@ -5186,25 +5169,6 @@ fn decide_next_step_fails_on_on_exhausted_chain_depth_exceeded() {
     ));
 }
 
-#[test]
-fn apply_transition_fails_on_on_exhausted_chain_depth_exceeded() {
-    let mut exec = workflow_exec(make_on_exhausted_depth_exceeded_workflow(), 0);
-    exec.step_execution_counts =
-        HashMap::from([("step_a".to_string(), 1), ("step_b".to_string(), 1)]);
-
-    let outcome = exec.apply_transition("step_a").unwrap();
-
-    assert!(matches!(outcome, StepOutcome::Persist(_)));
-    assert!(matches!(
-        exec.state,
-        WorkflowExecutionState::Failed {
-            ref reason,
-            kind: WorkflowStepFailureKind::ValidationFailure,
-            ..
-        } if reason == "validation_error: loop_guard on_exhausted chain depth exceeded"
-    ));
-}
-
 // ---- step が新しい実行を開始する瞬間に step_outputs から前回値を破棄する（Spec issues-989） ----
 
 fn make_step_output_fixture(step_name: &str, run_index: u32) -> StepOutput {
@@ -5246,7 +5210,7 @@ fn apply_advance_clears_step_outputs_for_new_step() {
 }
 
 #[test]
-fn apply_transition_clears_step_outputs_for_target_step() {
+fn apply_advance_clears_step_outputs_for_loop_target_step() {
     // ループで前ステップ（review）に戻る遷移でも、遷移先の前回出力が破棄される。
     let mut exec = make_exec(2); // review
     exec.current_session_id = Some("review-session".to_string());
@@ -5255,7 +5219,7 @@ fn apply_transition_clears_step_outputs_for_target_step() {
         make_step_output_fixture("implement", 1),
     );
 
-    let outcome = exec.apply_transition("implement").unwrap();
+    let outcome = exec.apply_advance();
     assert!(matches!(outcome, StepOutcome::TransitionAndStart(_)));
     assert_eq!(
         exec.workflow.nodes[exec.current_step_index].name,
@@ -5266,12 +5230,11 @@ fn apply_transition_clears_step_outputs_for_target_step() {
 }
 
 #[test]
-fn apply_transition_to_fanout_clears_parent_output_without_child_map_entries() {
+fn apply_advance_to_fanout_clears_parent_output_without_child_map_entries() {
     // fanout child artifact は親配列だけに保持されるため、node 名 output map では親だけを消す。
     let fanout = make_fanout_step(
         "code_review_parallel",
         vec!["review_security", "review_style"],
-        None,
     );
     let wf = Workflow {
         name: "loop-parallel".to_string(),
@@ -5279,7 +5242,13 @@ fn apply_transition_to_fanout_clears_parent_output_without_child_map_entries() {
         builtin: false,
         schemas: Default::default(),
         nodes: vec![
-            make_test_step("fix", TestKind::Session, "Fix", vec![], None),
+            make_test_step(
+                "fix",
+                TestKind::Session,
+                "Fix",
+                vec![Rule::Next("code_review_parallel".to_string())],
+                None,
+            ),
             fanout,
             make_fanout_child("review_security"),
             make_fanout_child("review_style"),
@@ -5316,7 +5285,7 @@ fn apply_transition_to_fanout_clears_parent_output_without_child_map_entries() {
         },
     };
 
-    let outcome = exec.apply_transition("code_review_parallel").unwrap();
+    let outcome = exec.apply_advance();
     assert!(matches!(outcome, StepOutcome::StartParallel(_)));
     assert!(!exec.step_outputs.contains_key("code_review_parallel"));
     assert!(!exec.step_outputs.contains_key("review_security"));
@@ -7065,11 +7034,7 @@ mod dispatch_boundary_tests {
         }
     }
 
-    fn install_test_fanout_run(
-        exec: &mut WorkflowExecution,
-        children: Vec<ParallelChildRun>,
-        aggregate: Option<ParallelAggregate>,
-    ) {
+    fn install_test_fanout_run(exec: &mut WorkflowExecution, children: Vec<ParallelChildRun>) {
         let parent = exec
             .node_executions
             .first_mut()
@@ -7121,7 +7086,6 @@ mod dispatch_boundary_tests {
         exec.parallel_run = Some(ParallelRunState {
             parent_step_name: parent_node,
             parent_node_execution_id,
-            aggregate,
             children,
         });
     }
@@ -7183,7 +7147,6 @@ mod dispatch_boundary_tests {
                     1,
                 ),
             ],
-            None,
         );
         exec.node_executions
             .iter_mut()
@@ -8193,7 +8156,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("commands", vec!["print_child_env"], None),
+                make_fanout_step("commands", vec!["print_child_env"]),
                 command_step(
                     "print_child_env",
                     "printf '%s' \"$RELEASH_NODE_EXECUTION_ID\"",
@@ -8267,11 +8230,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step(
-                    "parallel-review",
-                    vec!["review-session", "shell-command"],
-                    None,
-                ),
+                make_fanout_step("parallel-review", vec!["review-session", "shell-command"]),
                 make_fanout_child("review-session"),
                 command_step(
                     "shell-command",
@@ -8332,6 +8291,152 @@ mod dispatch_boundary_tests {
             "command standard result must include duration: {}",
             values[1]
         );
+    }
+
+    #[tokio::test]
+    async fn fanout_command_reducer_fixture_routes_on_boolean_artifact() {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let worktree = TempDir::new().unwrap();
+        let workflow: Workflow =
+            serde_saphyr::from_str(include_str!("../fixtures/valid/fanout-command-reducer.yml"))
+                .unwrap();
+
+        let run_id =
+            start_command_workflow_for_test(&app, &engine, workflow, worktree.path()).await;
+        let run = engine.run_store().get_run(&run_id).await.unwrap();
+        assert_eq!(run.status, RunStatus::Completed);
+
+        let events = read_dispatch_events(&app, &run_id);
+        let (_, fanout_value) = artifact_event_for_node(&events, "review");
+        assert_eq!(
+            fanout_value
+                .as_array()
+                .expect("fanout Artifact must be a child Artifact array")
+                .iter()
+                .map(|value| value["lgtm"].as_bool())
+                .collect::<Vec<_>>(),
+            vec![Some(true), Some(false)]
+        );
+        let (_, judge_value) = artifact_event_for_node(&events, "judge");
+        assert_eq!(judge_value["all_lgtm"], false);
+
+        let completed = completed_node_names(&events);
+        assert!(completed.iter().any(|name| name == "fix"));
+        assert!(completed.iter().all(|name| name != "ready"));
+    }
+
+    #[tokio::test]
+    async fn fanout_session_reducer_fixture_receives_array_and_routes_on_enum_artifact() {
+        let app = make_dispatch_app();
+        let engine = Arc::new(WorkflowRuntimeService::new_for_test());
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps(data_dir);
+        let worktree = TempDir::new().unwrap();
+        let workflow: Workflow =
+            serde_saphyr::from_str(include_str!("../fixtures/valid/fanout-session-reducer.yml"))
+                .unwrap();
+        let judge_index = workflow
+            .nodes
+            .iter()
+            .position(|node| node.name == "judge")
+            .unwrap();
+        let judge = workflow.nodes[judge_index].clone();
+        let fanout_value = serde_json::json!([
+            {"lgtm": true},
+            {"lgtm": false}
+        ]);
+        let review_output = StepOutput {
+            step_name: "review".to_string(),
+            run_index: 1,
+            session_id: None,
+            result: None,
+            structured_output: Some(fanout_value),
+            artifact_contract: None,
+            token_usage: None,
+            completed_at: 1000.0,
+        };
+        let outputs = HashMap::from([("review".to_string(), review_output.clone())]);
+        let (_, prompt) = workflow_prompt::build_step_prompt(
+            &judge,
+            Some(&instruction_contents("Reduce the review verdicts.")),
+            "session-reducer-run",
+            None,
+            &outputs,
+        )
+        .unwrap();
+        assert!(prompt.contains("## input: review"));
+        assert!(prompt.contains("\"lgtm\": true"));
+        assert!(prompt.contains("\"lgtm\": false"));
+
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let judge_session_id = "session-reducer-judge";
+        let mut execution = make_waiting_approval_execution_with_workflow(
+            &run_id,
+            &worktree.path().to_string_lossy(),
+            workflow,
+        );
+        execution.state = WorkflowExecutionState::Running;
+        execution.current_step_index = judge_index;
+        execution.current_session_id = Some(judge_session_id.to_string());
+        execution.step_execution_counts =
+            HashMap::from([("review".to_string(), 1), ("judge".to_string(), 1)]);
+        execution.step_outputs = HashMap::from([("review".to_string(), review_output)]);
+        execution.node_executions = vec![node_execution_fixture(
+            &run_id,
+            "session-reducer-judge-execution",
+            "judge",
+            1,
+            NodeExecutionStatus::Running,
+            Some(judge_session_id),
+            None,
+        )];
+        insert_execution_and_active_run(&engine, execution, TriggerSource::DesktopUi).await;
+        engine.session_workflow_refs.lock().await.insert(
+            judge_session_id.to_string(),
+            SessionWorkflowRef {
+                run_id: run_id.clone(),
+            },
+        );
+
+        submit_output_for_test_with_deps(
+            &engine,
+            app.handle(),
+            &session_store,
+            &handles,
+            &run_id,
+            "judge",
+            "review-decision",
+            serde_json::json!({"verdict": "NEEDS_FIX"}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        engine
+            .on_turn_complete(
+                app.handle(),
+                &session_store,
+                &handles,
+                judge_session_id,
+                0,
+                None,
+                &[],
+                None,
+            )
+            .await
+            .unwrap();
+        wait_for_run_terminal(&app, &engine, &run_id).await;
+
+        let run = engine.run_store().get_run(&run_id).await.unwrap();
+        assert_eq!(run.status, RunStatus::Completed);
+        let events = read_dispatch_events(&app, &run_id);
+        let (_, judge_value) = artifact_event_for_node(&events, "judge");
+        assert_eq!(judge_value["verdict"], "NEEDS_FIX");
+        let completed = completed_node_names(&events);
+        assert!(completed.iter().any(|name| name == "fix"));
+        assert!(completed.iter().all(|name| name != "ready"));
     }
 
     #[tokio::test]
@@ -8452,7 +8557,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("commands", vec!["long-child"], None),
+                make_fanout_step("commands", vec!["long-child"]),
                 command_step("long-child", "sleep 30", vec![]),
             ],
         };
@@ -8721,7 +8826,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("parallel-review", vec!["missing-facet-child"], None),
+                make_fanout_step("parallel-review", vec!["missing-facet-child"]),
                 child,
             ],
         };
@@ -8803,7 +8908,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("parallel-review", vec!["review-a", "review-b"], None),
+                make_fanout_step("parallel-review", vec!["review-a", "review-b"]),
                 make_fanout_child("review-a"),
                 make_fanout_child("review-b"),
             ],
@@ -8881,7 +8986,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("fanout-review", vec!["review-a", "review-b"], None),
+                make_fanout_step("fanout-review", vec!["review-a", "review-b"]),
                 make_fanout_child("review-a"),
                 make_fanout_child("review-b"),
             ],
@@ -9734,7 +9839,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("parallel-review", vec!["review-a", "review-b"], None),
+                make_fanout_step("parallel-review", vec!["review-a", "review-b"]),
                 make_fanout_child("review-a"),
                 make_fanout_child("review-b"),
             ],
@@ -9765,7 +9870,6 @@ mod dispatch_boundary_tests {
                     1,
                 ),
             ],
-            None,
         );
         let fanout_run = exec.parallel_run.as_ref().expect("fanout run");
         let parent_node_execution_id = fanout_run.parent_node_execution_id.clone();
@@ -9864,7 +9968,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("parallel-review", vec!["review-a", "review-b"], None),
+                make_fanout_step("parallel-review", vec!["review-a", "review-b"]),
                 make_fanout_child("review-a"),
                 make_fanout_child("review-b"),
             ],
@@ -9899,7 +10003,6 @@ mod dispatch_boundary_tests {
                     1,
                 ),
             ],
-            None,
         );
         insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
         engine.session_workflow_refs.lock().await.insert(
@@ -9949,125 +10052,7 @@ mod dispatch_boundary_tests {
     }
 
     #[tokio::test]
-    async fn parallel_success_after_delegated_failure_completes_parent() {
-        let app = make_dispatch_app();
-        let engine = WorkflowRuntimeService::new_for_test();
-        let data_dir = dispatch_data_dir(app.handle());
-        engine.set_run_store_data_dir(data_dir.clone()).await;
-        let (session_store, handles) = make_dispatch_deps(dispatch_data_dir(app.handle()));
-
-        let run_id = uuid::Uuid::new_v4().to_string();
-        let worktree_path = "/wt/parallel-delegated-failure";
-        let successful_child_session_id = "parallel-child-success-session";
-        let workflow = Workflow {
-            name: "parallel-delegated-wf".to_string(),
-            description: "test".to_string(),
-            builtin: false,
-            schemas: Default::default(),
-            nodes: vec![
-                make_fanout_step("parallel-review", vec!["review-a", "review-b"], None),
-                make_fanout_child("review-a"),
-                make_fanout_child("review-b"),
-            ],
-        };
-        let mut exec =
-            make_waiting_approval_execution_with_workflow(&run_id, worktree_path, workflow);
-        exec.state = WorkflowExecutionState::Running;
-        exec.current_step_index = 0;
-        exec.current_session_id = None;
-        exec.step_execution_counts = HashMap::from([
-            ("parallel-review".to_string(), 1),
-            ("review-a".to_string(), 1),
-            ("review-b".to_string(), 1),
-        ]);
-        exec.step_outputs.insert(
-            "review-a".to_string(),
-            StepOutput {
-                step_name: "review-a".to_string(),
-                run_index: 1,
-                session_id: Some("parallel-child-refusal-session".to_string()),
-                result: Some("model_refusal".to_string()),
-                structured_output: Some(serde_json::json!({
-                    "failureKind": "model_refusal",
-                    "disposition": "partial",
-                    "exitCode": 1,
-                })),
-                artifact_contract: None,
-                token_usage: Some(TokenUsage::default()),
-                completed_at: 1001.0,
-            },
-        );
-        let mut failed_child = test_fanout_child_run(
-            "review-a",
-            "parallel-child-refusal-session",
-            ParallelChildState::Failed,
-            0,
-        );
-        failed_child.result = Some("model_refusal".to_string());
-        failed_child.structured_output = Some(serde_json::json!({
-            "failureKind": "model_refusal",
-            "disposition": "partial",
-            "exitCode": 1,
-        }));
-        failed_child.failure_kind = Some(WorkflowStepFailureKind::ModelRefusal);
-        failed_child.failure_disposition = Some(FailureDisposition::Partial);
-        install_test_fanout_run(
-            &mut exec,
-            vec![
-                failed_child,
-                test_fanout_child_run(
-                    "review-b",
-                    successful_child_session_id,
-                    ParallelChildState::Running,
-                    1,
-                ),
-            ],
-            None,
-        );
-        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
-        engine.session_workflow_refs.lock().await.insert(
-            successful_child_session_id.to_string(),
-            SessionWorkflowRef {
-                run_id: run_id.clone(),
-            },
-        );
-
-        engine
-            .on_turn_complete(
-                app.handle(),
-                &session_store,
-                &handles,
-                successful_child_session_id,
-                0,
-                None,
-                &[MessagePart::Text {
-                    content: "LGTM".to_string(),
-                    parent_tool_use_id: None,
-                }],
-                None,
-            )
-            .await
-            .unwrap();
-
-        let events = WorkflowEventLog::new(&data_dir).read_log(&run_id).unwrap();
-        assert!(
-            events
-                .iter()
-                .any(|event| matches!(
-                    event,
-                    WorkflowEvent::ArtifactProduced { node_name, value, .. }
-                        if node_name == "parallel-review" && value.is_array()
-                )),
-            "fanout parent must produce its artifact once all children are terminal; got {events:?}"
-        );
-        assert!(
-            !engine.contains_execution_for_test(&run_id).await,
-            "single-node parent advance should complete and release the run"
-        );
-    }
-
-    #[tokio::test]
-    async fn parallel_zero_exit_model_refusal_is_partial_failure_before_contract_repair() {
+    async fn parallel_zero_exit_model_refusal_fails_parent_before_contract_repair() {
         let app = make_dispatch_app();
         let engine = WorkflowRuntimeService::new_for_test();
         let data_dir = dispatch_data_dir(app.handle());
@@ -10086,7 +10071,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("parallel-review", vec!["review-a", "review-b"], None),
+                make_fanout_step("parallel-review", vec!["review-a", "review-b"]),
                 review_a,
                 make_fanout_child("review-b"),
             ],
@@ -10123,7 +10108,6 @@ mod dispatch_boundary_tests {
                     1,
                 ),
             ],
-            None,
         );
         insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
         engine.session_workflow_refs.lock().await.insert(
@@ -10167,29 +10151,20 @@ mod dispatch_boundary_tests {
             .await
             .unwrap();
 
-        let execs = engine.executions.lock().await;
-        let exec = execs.get(&run_id).expect("run must stay active");
-        let child = exec
-            .parallel_run
-            .as_ref()
-            .expect("parallel run must stay active")
-            .children
-            .iter()
-            .find(|child| child.step_name == "review-a")
-            .expect("refused child");
-        assert!(matches!(child.state, ParallelChildState::Failed));
-        assert_eq!(
-            child.failure_kind,
-            Some(WorkflowStepFailureKind::ModelRefusal)
+        assert!(
+            !engine.contains_execution_for_test(&run_id).await,
+            "model refusal must fail and release the fanout execution"
         );
-        assert_eq!(child.failure_disposition, Some(FailureDisposition::Partial));
-        assert_eq!(child.result.as_deref(), Some("model_refusal"));
-        assert_eq!(exec.current_stall_observations.len(), 1);
+        let stored = engine
+            .run_store
+            .get_run(&run_id)
+            .await
+            .expect("RunStore must keep terminal run metadata");
+        assert_eq!(stored.status, RunStatus::Failed);
         assert_eq!(
-            exec.current_stall_observations[0].session_id, waiting_child_session_id,
-            "partial failure child stall observation must be removed while running sibling remains"
+            stored.error_reason.as_deref(),
+            Some("fanout child 'review-a' failed (exit_code: 0)")
         );
-        drop(execs);
 
         let events = WorkflowEventLog::new(&data_dir).read_log(&run_id).unwrap();
         assert!(
@@ -10201,8 +10176,19 @@ mod dispatch_boundary_tests {
                     ..
                 } if node_name == "review-a"
             )),
-            "zero-exit model refusal must be recorded as partial child failure; got {events:?}"
+            "zero-exit model refusal must be recorded as a normal node failure; got {events:?}"
         );
+        assert!(events.iter().any(|event| matches!(
+            event,
+            WorkflowEvent::RunFailed {
+                failure_kind: WorkflowStepFailureKind::ModelRefusal,
+                ..
+            }
+        )));
+        assert!(events.iter().all(|event| !matches!(
+            event,
+            WorkflowEvent::ArtifactProduced { node_name, .. } if node_name == "parallel-review"
+        )));
         assert!(
             events
                 .iter()
@@ -10212,7 +10198,7 @@ mod dispatch_boundary_tests {
     }
 
     #[tokio::test]
-    async fn parallel_partial_failure_append_failure_rolls_back_child_state_and_run_store() {
+    async fn parallel_terminal_failure_append_failure_rolls_back_child_state_and_run_store() {
         let app = make_dispatch_app();
         let engine = WorkflowRuntimeService::new_for_test();
         let data_dir = dispatch_data_dir(app.handle());
@@ -10220,16 +10206,16 @@ mod dispatch_boundary_tests {
         let (session_store, handles) = make_dispatch_deps(dispatch_data_dir(app.handle()));
 
         let run_id = uuid::Uuid::new_v4().to_string();
-        let worktree_path = "/wt/parallel-partial-append-failure";
+        let worktree_path = "/wt/parallel-terminal-append-failure";
         let refused_child_session_id = "parallel-child-refusal-append-failure-session";
         let waiting_child_session_id = "parallel-child-still-running-session";
         let workflow = Workflow {
-            name: "parallel-partial-append-failure-wf".to_string(),
+            name: "parallel-terminal-append-failure-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("parallel-review", vec!["review-a", "review-b"], None),
+                make_fanout_step("parallel-review", vec!["review-a", "review-b"]),
                 make_fanout_child("review-a"),
                 make_fanout_child("review-b"),
             ],
@@ -10261,7 +10247,6 @@ mod dispatch_boundary_tests {
                     1,
                 ),
             ],
-            None,
         );
         insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
         let stored_before = engine
@@ -10289,7 +10274,7 @@ mod dispatch_boundary_tests {
                 None,
             )
             .await
-            .expect_err("partial child failure event append failure must abort commit");
+            .expect_err("terminal child failure event append failure must abort commit");
         assert!(
             format!("{err:?}").contains("parallel child progress event append failed"),
             "append failure context must be surfaced; got {err:?}"
@@ -10313,7 +10298,7 @@ mod dispatch_boundary_tests {
         assert_eq!(child.failure_disposition, None);
         assert!(
             !exec.step_outputs.contains_key("review-a"),
-            "synthetic partial StepOutput must not remain after rollback"
+            "failed child StepOutput must not remain after rollback"
         );
         drop(execs);
 
@@ -10340,7 +10325,7 @@ mod dispatch_boundary_tests {
                     ..
                 } if node_name == "review-a"
             )),
-            "partial failure event must not be present when required append fails; got {events:?}"
+            "terminal failure event must not be present when required append fails; got {events:?}"
         );
     }
 
@@ -10374,7 +10359,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("parallel-review", vec!["review-a", "review-b"], None),
+                make_fanout_step("parallel-review", vec!["review-a", "review-b"]),
                 review_a,
                 make_fanout_child("review-b"),
             ],
@@ -10407,7 +10392,6 @@ mod dispatch_boundary_tests {
                     1,
                 ),
             ],
-            None,
         );
         append_started_events_for_execution(&data_dir, &exec);
         insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
@@ -10515,6 +10499,195 @@ mod dispatch_boundary_tests {
     }
 
     #[tokio::test]
+    async fn approval_fanout_child_missing_output_after_repair_limit_fails_child_siblings_and_parent_with_child_node_failed(
+    ) {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps(data_dir.clone());
+        let received_payloads: Arc<std::sync::Mutex<Vec<String>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let received_for_listener = Arc::clone(&received_payloads);
+        app.listen("workflow-state-changed", move |event| {
+            received_for_listener
+                .lock()
+                .unwrap()
+                .push(event.payload().to_string());
+        });
+
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/approval-fanout-missing-output-repair-limit";
+        let approval_child_session_id = "approval-fanout-missing-output-limit-session";
+        let sibling_session_id = "approval-fanout-missing-output-limit-sibling-session";
+        let mut review_a = make_approval_gated_session("review-a", "review-a", vec![]);
+        review_a.artifact = Some("review-verdict".to_string());
+        let workflow = Workflow {
+            name: "approval-fanout-missing-output-limit-wf".to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            schemas: Default::default(),
+            nodes: vec![
+                make_fanout_step("parallel-review", vec!["review-a", "review-b"]),
+                review_a,
+                make_fanout_child("review-b"),
+            ],
+        };
+        let mut exec =
+            make_waiting_approval_execution_with_workflow(&run_id, worktree_path, workflow);
+        exec.state = WorkflowExecutionState::Running;
+        exec.current_step_index = 0;
+        exec.current_session_id = None;
+        exec.step_execution_counts = HashMap::from([
+            ("parallel-review".to_string(), 1),
+            ("review-a".to_string(), 1),
+            ("review-b".to_string(), 1),
+        ]);
+        let mut approval_child = test_fanout_child_run(
+            "review-a",
+            approval_child_session_id,
+            ParallelChildState::Running,
+            0,
+        );
+        approval_child.artifact_contract = Some("review-verdict".to_string());
+        install_test_fanout_run(
+            &mut exec,
+            vec![
+                approval_child,
+                test_fanout_child_run(
+                    "review-b",
+                    sibling_session_id,
+                    ParallelChildState::Running,
+                    1,
+                ),
+            ],
+        );
+        let fanout_run = exec.parallel_run.as_ref().expect("fanout run");
+        let parent_node_execution_id = fanout_run.parent_node_execution_id.clone();
+        let approval_child_node_execution_id = fanout_run.children[0].node_execution_id.clone();
+        let sibling_node_execution_id = fanout_run.children[1].node_execution_id.clone();
+        let approval_node_execution = exec
+            .node_executions
+            .iter_mut()
+            .find(|execution| execution.id == approval_child_node_execution_id)
+            .expect("approval child node execution");
+        approval_node_execution.status = NodeExecutionStatus::WaitingApproval;
+        append_started_events_for_execution(&data_dir, &exec);
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        engine.session_workflow_refs.lock().await.insert(
+            approval_child_session_id.to_string(),
+            SessionWorkflowRef {
+                run_id: run_id.clone(),
+            },
+        );
+        handles
+            .insert_runtime_state_for_test(
+                approval_child_session_id,
+                crate::usecase::agent_session::status::TurnPhase::Idle,
+                false,
+            )
+            .await;
+
+        let log = WorkflowEventLog::new(&data_dir);
+        for attempt in 1..=2 {
+            log.append(&WorkflowEvent::ContractRepairRequested {
+                run_id: run_id.clone(),
+                workflow_name: "approval-fanout-missing-output-limit-wf".to_string(),
+                node_name: "review-a".to_string(),
+                run_index: 1,
+                request_id: None,
+                attempt,
+                violation_reason: submission_violation_reason(
+                    SubmissionViolation::MissingSubmitOutput,
+                )
+                .to_string(),
+                timestamp: 1000.0 + f64::from(attempt),
+            })
+            .unwrap();
+        }
+
+        let result = engine
+            .resolve_workflow_approval(
+                app.handle(),
+                &session_store,
+                &handles,
+                &run_id,
+                None,
+                "review-a",
+                Some(&approval_child_node_execution_id),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(WorkflowEngineError::ValidationError(message))
+                if message == "required structured output has not been submitted"
+        ));
+        assert!(
+            !engine.contains_execution_for_test(&run_id).await,
+            "repair limit approval fanout missing-output failure must release the terminal run"
+        );
+        let live_payload = received_payloads
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .expect("terminal failure must broadcast live snapshot");
+        let live_json: serde_json::Value = serde_json::from_str(&live_payload).unwrap();
+        let live_node_executions = live_json["workflowState"]["nodeExecutions"]
+            .as_array()
+            .expect("live payload must expose node executions");
+        let live_status_by_id = |node_execution_id: &str| {
+            live_node_executions
+                .iter()
+                .find(|execution| execution["id"] == node_execution_id)
+                .and_then(|execution| execution["status"].as_str())
+                .expect("node execution status must be present")
+        };
+        assert_eq!(live_status_by_id(&parent_node_execution_id), "failed");
+        assert_eq!(
+            live_status_by_id(&approval_child_node_execution_id),
+            "failed"
+        );
+        assert_eq!(live_status_by_id(&sibling_node_execution_id), "aborted");
+
+        let events = read_dispatch_events(&app, &run_id);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            WorkflowEvent::NodeFailed {
+                node_execution_id,
+                node_name,
+                failure_kind: WorkflowStepFailureKind::StructuredOutputMismatch,
+                ..
+            } if node_execution_id == &approval_child_node_execution_id
+                && node_name == "review-a"
+        )));
+        let projected = reconstruct_state_from_events(&run_id, &events)
+            .unwrap()
+            .unwrap();
+        let projected_status_by_id = |node_execution_id: &str| {
+            projected
+                .node_executions
+                .iter()
+                .find(|execution| execution.id == node_execution_id)
+                .map(|execution| execution.status)
+                .expect("projected node execution must exist")
+        };
+        assert_eq!(
+            projected_status_by_id(&parent_node_execution_id),
+            NodeExecutionStatus::Failed
+        );
+        assert_eq!(
+            projected_status_by_id(&approval_child_node_execution_id),
+            NodeExecutionStatus::Failed
+        );
+        assert_eq!(
+            projected_status_by_id(&sibling_node_execution_id),
+            NodeExecutionStatus::Aborted
+        );
+    }
+
+    #[tokio::test]
     async fn fanout_child_missing_output_repair_start_failure_fails_child_siblings_and_parent_in_live_and_replay(
     ) {
         let app = make_dispatch_app();
@@ -10544,7 +10717,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("parallel-review", vec!["review-a", "review-b"], None),
+                make_fanout_step("parallel-review", vec!["review-a", "review-b"]),
                 review_a,
                 make_fanout_child("review-b"),
             ],
@@ -10577,7 +10750,6 @@ mod dispatch_boundary_tests {
                     1,
                 ),
             ],
-            None,
         );
         append_started_events_for_execution(&data_dir, &exec);
         insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
@@ -11664,7 +11836,7 @@ mod dispatch_boundary_tests {
             description: String::new(),
             builtin: false,
             schemas: Default::default(),
-            nodes: vec![make_fanout_step("parallel-review", vec![], None)],
+            nodes: vec![make_fanout_step("parallel-review", vec![])],
         };
         let mut exec =
             make_waiting_approval_execution_with_workflow("exec-abort-parallel", "/wt", workflow);
@@ -11674,7 +11846,7 @@ mod dispatch_boundary_tests {
             test_fanout_child_run("child-a", "session-a", ParallelChildState::Completed, 0);
         child_a.result = Some("LGTM".to_string());
         let child_b = test_fanout_child_run("child-b", "session-b", ParallelChildState::Running, 1);
-        install_test_fanout_run(&mut exec, vec![child_a, child_b], None);
+        install_test_fanout_run(&mut exec, vec![child_a, child_b]);
 
         let entry = exec
             .make_aborted_parallel_history_entry(123.0)
@@ -13702,16 +13874,7 @@ mod dispatch_boundary_tests {
 
         let run_id = uuid::Uuid::new_v4().to_string();
         let worktree_path = "/wt/fanout-empty-items";
-        let mut fanout = make_fanout_step(
-            "fanout-empty",
-            vec!["review-child"],
-            Some(ParallelAggregate {
-                all_match: Some("LGTM".to_string()),
-                any_match: None,
-                then: "aggregate-target".to_string(),
-                r#else: "aggregate-target".to_string(),
-            }),
-        );
+        let mut fanout = make_fanout_step("fanout-empty", vec!["review-child"]);
         fanout.rules = vec![Rule::Next("after-empty".to_string())];
         let NodeKind::Fanout(spec) = &mut fanout.kind else {
             panic!("fanout test fixture must contain a fanout node");
@@ -13733,7 +13896,6 @@ mod dispatch_boundary_tests {
                 fanout,
                 child,
                 make_approval_gated_session("after-empty", "review-summary", vec![]),
-                make_approval_gated_session("aggregate-target", "review-summary", vec![]),
             ],
         };
         engine
@@ -13831,7 +13993,7 @@ mod dispatch_boundary_tests {
         let run_id = uuid::Uuid::new_v4().to_string();
         let worktree_path = "/wt/fanout-child-rules-ignored";
         let child_session_id = "fanout-child-rules-session";
-        let mut fanout = make_fanout_step("fanout-review", vec!["review-child"], None);
+        let mut fanout = make_fanout_step("fanout-review", vec!["review-child"]);
         fanout.rules = vec![Rule::Next("parent-next".to_string())];
         let mut child = make_fanout_child("review-child");
         child.rules = vec![Rule::Next("child-next".to_string())];
@@ -13860,7 +14022,6 @@ mod dispatch_boundary_tests {
                 ParallelChildState::Running,
                 0,
             )],
-            None,
         );
         insert_execution_and_active_run(&engine, execution, TriggerSource::DesktopUi).await;
         engine.session_workflow_refs.lock().await.insert(
@@ -13959,7 +14120,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("fanout-review", vec!["review-a", "review-b"], None),
+                make_fanout_step("fanout-review", vec!["review-a", "review-b"]),
                 make_fanout_child("review-a"),
                 make_fanout_child("review-b"),
             ],
@@ -14047,7 +14208,7 @@ mod dispatch_boundary_tests {
             builtin: false,
             schemas: Default::default(),
             nodes: vec![
-                make_fanout_step("fanout-review", vec!["review-child"], None),
+                make_fanout_step("fanout-review", vec!["review-child"]),
                 make_fanout_child("review-child"),
             ],
         };
@@ -14064,7 +14225,6 @@ mod dispatch_boundary_tests {
                 ParallelChildState::Running,
                 0,
             )],
-            None,
         );
         let parent_node_execution_id = execution.node_executions[0].id.clone();
         let child_node_execution_id = execution.node_executions[1].id.clone();

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -8217,6 +8217,203 @@ mod dispatch_boundary_tests {
     }
 
     #[tokio::test]
+    async fn fanout_command_failure_clears_stall_observations_and_aborts_sibling_in_live_and_replay(
+    ) {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_run_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps(data_dir.clone());
+        let received_payloads: Arc<std::sync::Mutex<Vec<String>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let received_for_listener = Arc::clone(&received_payloads);
+        app.listen("workflow-state-changed", move |event| {
+            received_for_listener
+                .lock()
+                .unwrap()
+                .push(event.payload().to_string());
+        });
+
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/fanout-command-failure-stall";
+        let sibling_session_id = "fanout-command-failure-sibling-session";
+        let workflow = Workflow {
+            name: "fanout-command-failure-stall-wf".to_string(),
+            description: "fanout command failure stall".to_string(),
+            builtin: false,
+            schemas: Default::default(),
+            nodes: vec![
+                make_fanout_step("parallel-review", vec!["shell-command", "review-b"]),
+                command_step("shell-command", "false", vec![]),
+                make_fanout_child("review-b"),
+            ],
+        };
+        let mut exec =
+            make_waiting_approval_execution_with_workflow(&run_id, worktree_path, workflow);
+        exec.state = WorkflowExecutionState::Running;
+        exec.current_step_index = 0;
+        exec.current_session_id = None;
+        exec.step_execution_counts = HashMap::from([
+            ("parallel-review".to_string(), 1),
+            ("shell-command".to_string(), 1),
+            ("review-b".to_string(), 1),
+        ]);
+        exec.current_stall_observations = vec![workflow_stall_observation_fixture(
+            sibling_session_id,
+            "review-b",
+        )];
+        install_test_fanout_run(
+            &mut exec,
+            vec![
+                test_fanout_child_run("shell-command", "", ParallelChildState::Running, 0),
+                test_fanout_child_run(
+                    "review-b",
+                    sibling_session_id,
+                    ParallelChildState::Running,
+                    1,
+                ),
+            ],
+        );
+        let fanout_run = exec.parallel_run.as_ref().expect("fanout run");
+        let parent_node_execution_id = fanout_run.parent_node_execution_id.clone();
+        let command_node_execution_id = fanout_run.children[0].node_execution_id.clone();
+        let sibling_node_execution_id = fanout_run.children[1].node_execution_id.clone();
+        let command_node_execution = exec
+            .node_executions
+            .iter_mut()
+            .find(|execution| execution.id == command_node_execution_id)
+            .expect("command child node execution");
+        command_node_execution.kind = NodeKindName::Command;
+        command_node_execution.session_id = None;
+        append_started_events_for_execution(&data_dir, &exec);
+        WorkflowEventLog::new(&data_dir)
+            .append(&WorkflowEvent::WorkflowStallObserved {
+                run_id: run_id.clone(),
+                workflow_name: "fanout-command-failure-stall-wf".to_string(),
+                chat_session_id: sibling_session_id.to_string(),
+                step_name: "review-b".to_string(),
+                run_index: 1,
+                turn_phase: "streaming".to_string(),
+                idle_secs: 181,
+                signal_count: 1,
+                cap_reached: false,
+                timestamp: 1003.0,
+            })
+            .unwrap();
+        insert_execution_and_active_run(&engine, exec, TriggerSource::DesktopUi).await;
+        engine.session_workflow_refs.lock().await.insert(
+            sibling_session_id.to_string(),
+            SessionWorkflowRef {
+                run_id: run_id.clone(),
+            },
+        );
+
+        let input = CommandExecutionInput {
+            run_id: run_id.clone(),
+            node_execution_id: command_node_execution_id.clone(),
+            node_name: "shell-command".to_string(),
+            run_index: 1,
+            worktree_path: worktree_path.to_string(),
+            command: "false".to_string(),
+            artifact_contract: None,
+            schemas: BTreeMap::new(),
+            fanout_parent: Some("parallel-review".to_string()),
+        };
+        engine
+            .fail_command_execution(
+                app.handle(),
+                &session_store,
+                &handles,
+                &input,
+                "command exited with status 1",
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !engine.contains_execution_for_test(&run_id).await,
+            "terminal fanout command failure must release the run"
+        );
+        let run = engine
+            .run_store()
+            .get_run(&run_id)
+            .await
+            .expect("terminal run metadata must be stored");
+        assert_eq!(run.status, RunStatus::Failed);
+        assert_eq!(
+            run.error_reason.as_deref(),
+            Some("fanout child 'shell-command' failed: command exited with status 1")
+        );
+
+        let live_payload = received_payloads
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .expect("terminal failure must broadcast live snapshot");
+        let live_json: serde_json::Value = serde_json::from_str(&live_payload).unwrap();
+        let live_stall_observations = live_json["workflowState"]["stallObservations"].as_array();
+        assert!(
+            live_stall_observations.map_or(true, |observations| observations.is_empty()),
+            "terminal fanout command failure must clear live stall observations: {live_json}"
+        );
+        let live_node_executions = live_json["workflowState"]["nodeExecutions"]
+            .as_array()
+            .expect("live payload must expose node executions");
+        let live_status_by_id = |node_execution_id: &str| {
+            live_node_executions
+                .iter()
+                .find(|execution| execution["id"] == node_execution_id)
+                .and_then(|execution| execution["status"].as_str())
+                .expect("node execution status must be present")
+        };
+        assert_eq!(live_status_by_id(&parent_node_execution_id), "failed");
+        assert_eq!(live_status_by_id(&command_node_execution_id), "failed");
+        assert_eq!(live_status_by_id(&sibling_node_execution_id), "aborted");
+
+        let events = read_dispatch_events(&app, &run_id);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            WorkflowEvent::NodeFailed {
+                node_execution_id,
+                node_name,
+                reason,
+                failure_kind: WorkflowStepFailureKind::InfrastructureCrash,
+                ..
+            } if node_execution_id == &command_node_execution_id
+                && node_name == "shell-command"
+                && reason == "command exited with status 1"
+        )));
+        let projected = reconstruct_state_from_events(&run_id, &events)
+            .unwrap()
+            .unwrap();
+        assert!(
+            projected.stall_observations.is_empty(),
+            "RunFailed replay must clear stall observations"
+        );
+        let projected_status_by_id = |node_execution_id: &str| {
+            projected
+                .node_executions
+                .iter()
+                .find(|execution| execution.id == node_execution_id)
+                .map(|execution| execution.status)
+                .expect("projected node execution must exist")
+        };
+        assert_eq!(
+            projected_status_by_id(&parent_node_execution_id),
+            NodeExecutionStatus::Failed
+        );
+        assert_eq!(
+            projected_status_by_id(&command_node_execution_id),
+            NodeExecutionStatus::Failed
+        );
+        assert_eq!(
+            projected_status_by_id(&sibling_node_execution_id),
+            NodeExecutionStatus::Aborted
+        );
+    }
+
+    #[tokio::test]
     async fn fanout_parent_artifact_preserves_null_session_and_command_result_order() {
         let app = make_dispatch_app();
         let engine = WorkflowRuntimeService::new_for_test();

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_events.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_events.rs
@@ -319,7 +319,7 @@ pub(crate) fn pre_commit_required_events_for_outcome(
         StepOutcome::RetryCurrentStep { snapshot, .. } => {
             events.push(node_started_event_for_snapshot(snapshot)?);
         }
-        StepOutcome::TransitionAndStart(_) | StepOutcome::ReduceAndTransition(_) => {
+        StepOutcome::TransitionAndStart(_) => {
             if let Some(ev) = last_step_completed_event_for_snapshot(&mut snapshot)? {
                 events.push(ev);
             }
@@ -465,7 +465,6 @@ pub(crate) fn node_session_started_event_for_snapshot(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PostCommitProgressEventPlan {
     TransitionAndStart,
-    ReduceAndTransition,
     StartParallel,
 }
 
@@ -473,7 +472,6 @@ impl PostCommitProgressEventPlan {
     fn outcome_label(self) -> &'static str {
         match self {
             Self::TransitionAndStart => "TransitionAndStart",
-            Self::ReduceAndTransition => "ReduceAndTransition",
             Self::StartParallel => "StartParallel",
         }
     }
@@ -495,7 +493,6 @@ impl PostCommitProgressEventPlan {
         match self {
             Self::TransitionAndStart => node_started_event_for_snapshot(snapshot).map(Some),
             Self::StartParallel => fanout_parent_started_event_for_snapshot(snapshot).map(Some),
-            Self::ReduceAndTransition => Ok(None),
         }
     }
 }
@@ -615,12 +612,6 @@ pub(crate) fn required_events_for_approval_commit(
             }
             events.push(node_started_event_for_snapshot(snapshot)?);
         }
-        StepOutcome::ReduceAndTransition(snapshot) => {
-            if let Some(event) = last_step_completed_event_for_snapshot(snapshot)? {
-                events.push(event);
-            }
-            events.push(node_started_event_for_snapshot(snapshot)?);
-        }
         StepOutcome::StartParallel(snapshot) => {
             if let Some(event) = last_step_completed_event_for_snapshot(snapshot)? {
                 events.push(event);
@@ -696,7 +687,6 @@ pub(crate) fn workflow_event_timestamp(event: &WorkflowEvent) -> f64 {
         | WorkflowEvent::RunFailed { timestamp, .. }
         | WorkflowEvent::RunAborted { timestamp, .. }
         | WorkflowEvent::RunInterrupted { timestamp, .. }
-        | WorkflowEvent::OutputCollected { timestamp, .. }
         | WorkflowEvent::ContractRepairRequested { timestamp, .. }
         | WorkflowEvent::CliMutationRequested { timestamp, .. }
         | WorkflowEvent::ArtifactProduced { timestamp, .. }
@@ -719,7 +709,6 @@ pub(crate) fn set_workflow_event_timestamp(event: &mut WorkflowEvent, commit_tim
         | WorkflowEvent::RunFailed { timestamp, .. }
         | WorkflowEvent::RunAborted { timestamp, .. }
         | WorkflowEvent::RunInterrupted { timestamp, .. }
-        | WorkflowEvent::OutputCollected { timestamp, .. }
         | WorkflowEvent::ContractRepairRequested { timestamp, .. }
         | WorkflowEvent::CliMutationRequested { timestamp, .. }
         | WorkflowEvent::ArtifactProduced { timestamp, .. }
@@ -1046,10 +1035,6 @@ mod tests {
                 && fanout_parent.is_none()
                 && (timestamp - 42.0).abs() < f64::EPSILON
         ));
-        assert!(PostCommitProgressEventPlan::ReduceAndTransition
-            .followup_event(&snapshot)
-            .unwrap()
-            .is_none());
         assert!(matches!(
             PostCommitProgressEventPlan::StartParallel
                 .followup_event(&fanout_snapshot)

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
@@ -1166,7 +1166,6 @@ mod tests {
             kind: NodeKind::Fanout(FanoutSpec {
                 child: vec!["review-a".to_string()],
                 items: None,
-                aggregate: None,
             }),
             ..Default::default()
         };

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_state.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_state.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
 use crate::adaptor::gateway::workflow::domain_mapping::{
-    node_definition_to_domain, parallel_aggregate_to_domain, step_history_entries_to_domain,
-    step_history_entry_from_domain, step_output_from_domain, step_outputs_to_domain,
-    token_usage_from_domain, token_usage_to_domain, workflow_definition_to_domain,
-    workflow_execution_state_to_domain,
+    node_definition_to_domain, step_history_entries_to_domain, step_history_entry_from_domain,
+    step_output_from_domain, step_outputs_to_domain, token_usage_from_domain,
+    token_usage_to_domain, workflow_definition_to_domain, workflow_execution_state_to_domain,
 };
 use crate::adaptor::gateway::workflow::engine_error::{
     workflow_error_to_engine_error, WorkflowEngineError,
@@ -12,7 +11,7 @@ use crate::adaptor::gateway::workflow::engine_error::{
 use crate::adaptor::gateway::workflow::engine_start_guard;
 use crate::adaptor::gateway::workflow::event::FanoutParentRef;
 use crate::adaptor::gateway::workflow::runtime_commit::StepOutcome;
-use crate::adaptor::gateway::workflow::schema::{NodeKindName, ParallelAggregate, Workflow};
+use crate::adaptor::gateway::workflow::schema::{NodeKindName, Workflow};
 use crate::adaptor::gateway::workflow::state::{
     ApprovalOperations, NodeExecution, NodeExecutionFailure, NodeExecutionStatus, StepHistoryEntry,
     StepOutput, TokenUsage, WorkflowExecutionState, WorkflowStallObservation, WorkflowState,
@@ -68,7 +67,6 @@ pub(crate) struct WorkflowExecution {
 pub(crate) struct ParallelRunState {
     pub(crate) parent_step_name: String,
     pub(crate) parent_node_execution_id: String,
-    pub(crate) aggregate: Option<ParallelAggregate>,
     pub(crate) children: Vec<ParallelChildRun>,
 }
 
@@ -334,10 +332,6 @@ impl WorkflowExecution {
             .as_ref()
             .map(|parallel_run| workflow_domain::ParallelRunState {
                 parent_step_name: parallel_run.parent_step_name.clone(),
-                aggregate: parallel_run
-                    .aggregate
-                    .as_ref()
-                    .map(parallel_aggregate_to_domain),
                 children: parallel_run
                     .children
                     .iter()
@@ -496,8 +490,7 @@ impl WorkflowExecution {
     /// 親ブロック名と全子 step 名を一括で削除する。
     ///
     /// 同一 step がループで再実行される際、前回値が残ったままになると
-    /// `evaluate_aggregate` / `input_reference` / `apply_reduce` /
-    /// `inject_step_outputs` が前回値を引いてしまい、新しい実行で
+    /// `input_reference` / `inject_step_outputs` が前回値を引いてしまい、新しい実行で
     /// `structured_output` が更新されないケースや LLM が前回ターンの
     /// `<workflow_output>` を引用してきたケースで Contract 違反が
     /// 「正常完了（Done）」扱いされる不具合の原因となる。
@@ -551,49 +544,6 @@ impl WorkflowExecution {
         }
     }
 
-    /// ロック内で指定ステップへの遷移を適用する（サイクルガード検証含む）。
-    pub(crate) fn apply_transition(
-        &mut self,
-        target_step_name: &str,
-    ) -> Result<StepOutcome, WorkflowEngineError> {
-        if self.is_terminal() {
-            return Ok(StepOutcome::Persist(self.to_workflow_state()));
-        }
-
-        self.apply_transition_inner(target_step_name)
-    }
-
-    fn apply_transition_inner(
-        &mut self,
-        target_step_name: &str,
-    ) -> Result<StepOutcome, WorkflowEngineError> {
-        let workflow = workflow_definition_to_domain(&self.workflow);
-        match workflow_routing::guarded_target(
-            &workflow,
-            target_step_name.to_string(),
-            &self.step_execution_counts,
-        ) {
-            Ok(workflow_routing::RouteDecision::TransitionTo(name)) => {
-                let Some(idx) = self
-                    .workflow
-                    .nodes
-                    .iter()
-                    .position(|step| step.name == name)
-                else {
-                    return Ok(self.fail_validation(format!("node not found: {name}")));
-                };
-                self.apply_transition_index(idx, &name);
-                Ok(self.step_outcome_for_current_step())
-            }
-            Ok(workflow_routing::RouteDecision::Completed) => {
-                self.state = WorkflowExecutionState::Completed;
-                self.updated_at = current_timestamp();
-                Ok(StepOutcome::Persist(self.to_workflow_state()))
-            }
-            Err(err) => Ok(self.fail_validation(err.to_string())),
-        }
-    }
-
     fn fail_validation(&mut self, reason: impl Into<String>) -> StepOutcome {
         self.state = WorkflowExecutionState::Failed {
             reason: reason.into(),
@@ -622,8 +572,6 @@ impl WorkflowExecution {
         let step = &self.workflow.nodes[self.current_step_index];
         if step.is_fanout() {
             StepOutcome::StartParallel(self.to_workflow_state())
-        } else if step.collect.is_some() {
-            StepOutcome::ReduceAndTransition(self.to_workflow_state())
         } else {
             StepOutcome::TransitionAndStart(self.to_workflow_state())
         }

--- a/src-tauri/src/adaptor/gateway/workflow/schema.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/schema.rs
@@ -155,8 +155,6 @@ pub struct FanoutSpec {
     pub child: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub items: Option<ItemsSource>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub aggregate: Option<ParallelAggregate>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -264,7 +262,6 @@ pub struct NodeDefinition {
     pub artifact: Option<String>,
     pub input: Option<String>,
     pub inputs: Vec<String>,
-    pub collect: Option<CollectConfig>,
     pub rules: Vec<Rule>,
 }
 
@@ -333,8 +330,6 @@ struct RawNodeDefinition {
     input: Option<String>,
     #[serde(default)]
     inputs: Vec<String>,
-    #[serde(default)]
-    collect: Option<CollectConfig>,
     #[serde(default, rename = "rules")]
     rules: Vec<Rule>,
 }
@@ -369,7 +364,6 @@ impl<'de> Deserialize<'de> for NodeDefinition {
             artifact: raw.artifact,
             input: raw.input,
             inputs: raw.inputs,
-            collect: raw.collect,
             rules: raw.rules,
         })
     }
@@ -392,7 +386,6 @@ impl Serialize for NodeDefinition {
         if !self.inputs.is_empty() {
             map.serialize_entry("inputs", &self.inputs)?;
         }
-        serialize_option(&mut map, "collect", &self.collect)?;
         if !self.rules.is_empty() {
             map.serialize_entry("rules", &self.rules)?;
         }
@@ -409,18 +402,6 @@ where
         map.serialize_entry(key, value)?;
     }
     Ok(())
-}
-
-/// fanout node 完了後の集約条件（#1330 まで fanout block 内で暫定維持）。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct ParallelAggregate {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub all_match: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub any_match: Option<String>,
-    pub then: String,
-    pub r#else: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -565,23 +546,6 @@ impl Serialize for Rule {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct CollectConfig {
-    pub from: Vec<String>,
-    pub reduce: ReduceStrategy,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum ReduceStrategy {
-    Last,
-    Concat,
-    Grouped,
-    AnyNeedsFix,
-    AllPassed,
-}
-
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct Summary {
     pub name: String,
@@ -685,7 +649,7 @@ nodes:
     }
 
     #[test]
-    fn parse_fanout_node_with_aggregate() {
+    fn parse_fanout_node_with_artifact_items() {
         let yaml = r#"
 name: fanout
 description: fanout test
@@ -694,10 +658,6 @@ nodes:
     fanout:
       child: [arch-review, security-review]
       items: plan.targets
-      aggregate:
-        all_match: LGTM
-        then: report
-        else: implement
 "#;
         let wf: Workflow = serde_saphyr::from_str(yaml).unwrap();
         let fanout = wf.nodes[0].fanout().unwrap();
@@ -712,12 +672,6 @@ nodes:
                 field: "targets".to_string(),
             })
         );
-        let agg = fanout.aggregate.as_ref().unwrap();
-        assert_eq!(agg.all_match.as_deref(), Some("LGTM"));
-        assert!(agg.any_match.is_none());
-        assert_eq!(agg.then, "report");
-        assert_eq!(agg.r#else, "implement");
-
         let serialized = serde_saphyr::to_string(&wf).unwrap();
         let serialized_value: Value = serde_saphyr::from_str(&serialized).unwrap();
         assert_eq!(

--- a/src-tauri/src/adaptor/presenter/workflow.rs
+++ b/src-tauri/src/adaptor/presenter/workflow.rs
@@ -191,7 +191,6 @@ fn workflow_node_to_view(
         artifact: node.artifact,
         input: node.input,
         inputs: node.inputs,
-        collect: node.collect.map(collect_config_to_view),
         rules: node.rules.into_iter().map(rule_to_view).collect(),
     }
 }
@@ -209,7 +208,6 @@ fn fanout_spec_to_view(spec: workflow::FanoutSpec) -> workflow_wire::WorkflowFan
     workflow_wire::WorkflowFanoutSpecView {
         child: spec.child,
         items: spec.items.map(items_source_to_view),
-        aggregate: spec.aggregate.map(aggregate_config_to_view),
     }
 }
 
@@ -255,40 +253,6 @@ fn rule_to_view(rule: workflow::Rule) -> workflow_wire::WorkflowRuleView {
             on_exhausted,
         },
         workflow::Rule::Next(next) => workflow_wire::WorkflowRuleView::Next { next },
-    }
-}
-
-fn collect_config_to_view(
-    collect: workflow::CollectConfig,
-) -> workflow_wire::WorkflowCollectConfigView {
-    workflow_wire::WorkflowCollectConfigView {
-        from: collect.from,
-        reduce: reduce_strategy_to_view(collect.reduce),
-    }
-}
-
-fn reduce_strategy_to_view(
-    reduce: workflow::ReduceStrategy,
-) -> workflow_wire::WorkflowReduceStrategyView {
-    match reduce {
-        workflow::ReduceStrategy::Last => workflow_wire::WorkflowReduceStrategyView::Last,
-        workflow::ReduceStrategy::Concat => workflow_wire::WorkflowReduceStrategyView::Concat,
-        workflow::ReduceStrategy::Grouped => workflow_wire::WorkflowReduceStrategyView::Grouped,
-        workflow::ReduceStrategy::AnyNeedsFix => {
-            workflow_wire::WorkflowReduceStrategyView::AnyNeedsFix
-        }
-        workflow::ReduceStrategy::AllPassed => workflow_wire::WorkflowReduceStrategyView::AllPassed,
-    }
-}
-
-fn aggregate_config_to_view(
-    aggregate: workflow::ParallelAggregate,
-) -> workflow_wire::WorkflowAggregateConfigView {
-    workflow_wire::WorkflowAggregateConfigView {
-        all_match: aggregate.all_match,
-        any_match: aggregate.any_match,
-        then: aggregate.then,
-        r#else: aggregate.r#else,
     }
 }
 
@@ -708,7 +672,6 @@ mod tests {
                         node: "scan".to_string(),
                         field: "items".to_string(),
                     }),
-                    aggregate: None,
                 }),
                 ..NodeDefinition::default()
             }],

--- a/src-tauri/src/adaptor/protocol/workflow.rs
+++ b/src-tauri/src/adaptor/protocol/workflow.rs
@@ -175,8 +175,6 @@ pub struct WorkflowFanoutSpecView {
     pub child: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub items: Option<WorkflowItemsSourceView>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub aggregate: Option<WorkflowAggregateConfigView>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -202,21 +200,9 @@ pub struct WorkflowNodeDefinitionView {
     pub input: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inputs: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub collect: Option<WorkflowCollectConfigView>,
     // 共通: rules は空配列でも送る（frontend では非 optional として扱う）
     #[serde(default)]
     pub rules: Vec<WorkflowRuleView>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct WorkflowAggregateConfigView {
-    #[serde(default)]
-    pub all_match: Option<String>,
-    #[serde(default)]
-    pub any_match: Option<String>,
-    pub then: String,
-    pub r#else: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -240,22 +226,6 @@ pub enum WorkflowRuleView {
     Next {
         next: String,
     },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct WorkflowCollectConfigView {
-    pub from: Vec<String>,
-    pub reduce: WorkflowReduceStrategyView,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum WorkflowReduceStrategyView {
-    Last,
-    Concat,
-    Grouped,
-    AnyNeedsFix,
-    AllPassed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -477,7 +447,6 @@ mod tests {
                 serde_json::json!("first"),
                 serde_json::json!("second"),
             ])),
-            aggregate: None,
         };
         assert_eq!(
             serde_json::to_value(literal).unwrap(),
@@ -489,7 +458,6 @@ mod tests {
             items: Some(WorkflowItemsSourceView::ArtifactField(
                 "scan.items".to_string(),
             )),
-            aggregate: None,
         };
         assert_eq!(
             serde_json::to_value(reference).unwrap(),

--- a/src-tauri/src/cli/output.rs
+++ b/src-tauri/src/cli/output.rs
@@ -954,7 +954,6 @@ mod tests {
                 artifact: None,
                 input: None,
                 inputs: Vec::new(),
-                collect: None,
                 rules: Vec::new(),
             }],
         };

--- a/src-tauri/src/cli/workflow.rs
+++ b/src-tauri/src/cli/workflow.rs
@@ -412,7 +412,6 @@ fn event_kind_display_name(kind: &str) -> &str {
         "run_failed" => "RunFailed",
         "run_aborted" => "RunAborted",
         "run_interrupted" => "RunInterrupted",
-        "output_collected" => "OutputCollected",
         "contract_repair_requested" => "ContractRepairRequested",
         "cli_mutation_requested" => "CliMutationRequested",
         "artifact_produced" => "ArtifactProduced",

--- a/src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs
+++ b/src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs
@@ -13,7 +13,7 @@ use crate::domain::workflow::value_objects::{
     ApprovalOperations, NodeDefinition, RunId, StepOutput, WorkflowStateSnapshot, WorktreePath,
 };
 use crate::domain::workflow::value_objects::{
-    ParallelAggregate, StepHistoryEntry, TokenUsage, WorkflowDefinition, WorkflowExecutionState,
+    StepHistoryEntry, TokenUsage, WorkflowDefinition, WorkflowExecutionState,
     WorkflowStepFailureKind, STEP_STATE_COMPLETED, STEP_STATE_PENDING,
 };
 use crate::domain::workflow::FailureDisposition;
@@ -44,7 +44,6 @@ pub struct WorkflowExecution {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParallelRunState {
     pub parent_step_name: String,
-    pub aggregate: Option<ParallelAggregate>,
     pub children: Vec<ParallelChildRun>,
 }
 
@@ -225,7 +224,6 @@ impl WorkflowExecution {
         &mut self,
         parent_node_name: &str,
         child_node_names: Vec<String>,
-        aggregate: Option<ParallelAggregate>,
         timestamp: f64,
     ) -> Result<(), WorkflowError> {
         self.current_step_index = self.node_index(parent_node_name)?;
@@ -249,7 +247,6 @@ impl WorkflowExecution {
             .collect();
         self.parallel_run = Some(ParallelRunState {
             parent_step_name: parent_node_name.to_string(),
-            aggregate,
             children,
         });
         self.updated_at = timestamp;
@@ -517,7 +514,6 @@ mod aggregate_tests {
             TestNodeKind::Fanout => NodeKind::Fanout(FanoutSpec {
                 child: vec!["a".to_string(), "b".to_string()],
                 items: None,
-                aggregate: None,
             }),
         };
         NodeDefinition {
@@ -616,7 +612,6 @@ mod aggregate_tests {
         exec.start_parallel(
             "parallel-review",
             vec!["a".to_string(), "b".to_string()],
-            None,
             1.1,
         )
         .unwrap();

--- a/src-tauri/src/domain/workflow/mod.rs
+++ b/src-tauri/src/domain/workflow/mod.rs
@@ -30,14 +30,14 @@ pub use services::{
 #[cfg(test)]
 pub use value_objects::WorkflowRunRecord;
 pub use value_objects::{
-    ApprovalOperations, ChildOutputSnapshot, CollectConfig, CommandSpec, ContractType,
-    ContractValidationResult, FacetKey, FacetKind, FacetRefs, FacetSummary, FailureClassification,
-    FailureDisposition, FanoutParentRef, FanoutSpec, ItemsSource, NodeDefinition, NodeExecution,
-    NodeExecutionFailure, NodeExecutionStatus, NodeKind, NodeKindName, NodeName, OutcomeCommitMode,
-    ParallelAggregate, ReduceStrategy, Rule, RunId, RunListFilter, RunStatus, RunStatusFilter,
-    SchemaDef, SessionGate, SessionSpec, StepHistoryEntry, StepOutput, TimeoutKind, TokenUsage,
-    TriggerSource, WorkflowDefinition, WorkflowExecutionState, WorkflowName, WorkflowRunSummary,
-    WorkflowStallObservation, WorkflowStateSnapshot, WorkflowStepContext, WorkflowStepFailureKind,
-    WorkflowSummary, WorktreePath, STEP_STATE_ABORTED, STEP_STATE_COMPLETED, STEP_STATE_FAILED,
+    ApprovalOperations, ChildOutputSnapshot, CommandSpec, ContractType, ContractValidationResult,
+    FacetKey, FacetKind, FacetRefs, FacetSummary, FailureClassification, FailureDisposition,
+    FanoutParentRef, FanoutSpec, ItemsSource, NodeDefinition, NodeExecution, NodeExecutionFailure,
+    NodeExecutionStatus, NodeKind, NodeKindName, NodeName, OutcomeCommitMode, Rule, RunId,
+    RunListFilter, RunStatus, RunStatusFilter, SchemaDef, SessionGate, SessionSpec,
+    StepHistoryEntry, StepOutput, TimeoutKind, TokenUsage, TriggerSource, WorkflowDefinition,
+    WorkflowExecutionState, WorkflowName, WorkflowRunSummary, WorkflowStallObservation,
+    WorkflowStateSnapshot, WorkflowStepContext, WorkflowStepFailureKind, WorkflowSummary,
+    WorktreePath, STEP_STATE_ABORTED, STEP_STATE_COMPLETED, STEP_STATE_FAILED,
     STEP_STATE_INTERRUPTED, STEP_STATE_PENDING, STEP_STATE_RUNNING, STEP_STATE_WAITING_APPROVAL,
 };

--- a/src-tauri/src/domain/workflow/services/contract.rs
+++ b/src-tauri/src/domain/workflow/services/contract.rs
@@ -144,7 +144,6 @@ mod contract_service_tests {
                     kind: NodeKind::Fanout(FanoutSpec {
                         child: vec!["child".to_string()],
                         items: None,
-                        aggregate: None,
                     }),
                     ..Default::default()
                 },

--- a/src-tauri/src/domain/workflow/services/failure_policy.rs
+++ b/src-tauri/src/domain/workflow/services/failure_policy.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use crate::domain::workflow::value_objects::{
-    NodeKindName, ParallelAggregate, WorkflowStepFailureKind,
-};
+use crate::domain::workflow::value_objects::{NodeKindName, WorkflowStepFailureKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RetryPolicy {
@@ -140,29 +138,6 @@ impl Default for TimeoutPolicy {
             stale_timeout_by_node_kind: HashMap::new(),
             stale_timeout_for_approval_session: None,
             stale_timeout_by_template: HashMap::new(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ParallelPropagation {
-    FailWorkflow,
-    DelegateToAggregate,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ParallelFailurePolicy;
-
-impl ParallelFailurePolicy {
-    pub fn on_child_failure(
-        &self,
-        kind: WorkflowStepFailureKind,
-        _aggregate: Option<&ParallelAggregate>,
-    ) -> ParallelPropagation {
-        if kind == WorkflowStepFailureKind::ModelRefusal {
-            ParallelPropagation::DelegateToAggregate
-        } else {
-            ParallelPropagation::FailWorkflow
         }
     }
 }
@@ -341,48 +316,6 @@ mod tests {
                 Some("heavy-review".to_string())
             )),
             Duration::from_secs(600)
-        );
-    }
-
-    fn aggregate() -> ParallelAggregate {
-        ParallelAggregate {
-            all_match: Some("LGTM".to_string()),
-            any_match: None,
-            then: "done".to_string(),
-            r#else: "fix".to_string(),
-        }
-    }
-
-    #[test]
-    fn parallel_failure_policy_delegates_model_refusal_with_or_without_aggregate() {
-        let policy = ParallelFailurePolicy;
-        let aggregate = aggregate();
-
-        assert_eq!(
-            policy.on_child_failure(WorkflowStepFailureKind::ModelRefusal, Some(&aggregate)),
-            ParallelPropagation::DelegateToAggregate
-        );
-        assert_eq!(
-            policy.on_child_failure(WorkflowStepFailureKind::ModelRefusal, None),
-            ParallelPropagation::DelegateToAggregate
-        );
-    }
-
-    #[test]
-    fn parallel_failure_policy_fails_non_model_refusal_with_or_without_aggregate() {
-        let policy = ParallelFailurePolicy;
-        let aggregate = aggregate();
-
-        assert_eq!(
-            policy.on_child_failure(
-                WorkflowStepFailureKind::InfrastructureCrash,
-                Some(&aggregate)
-            ),
-            ParallelPropagation::FailWorkflow
-        );
-        assert_eq!(
-            policy.on_child_failure(WorkflowStepFailureKind::InfrastructureCrash, None),
-            ParallelPropagation::FailWorkflow
         );
     }
 

--- a/src-tauri/src/domain/workflow/services/history.rs
+++ b/src-tauri/src/domain/workflow/services/history.rs
@@ -254,7 +254,6 @@ mod tests {
         let entry = aborted_parallel_history_entry(
             &ParallelRunState {
                 parent_step_name: "parallel-review".to_string(),
-                aggregate: None,
                 children: vec![
                     ParallelChildRun {
                         step_name: "child-a".to_string(),

--- a/src-tauri/src/domain/workflow/services/parallel.rs
+++ b/src-tauri/src/domain/workflow/services/parallel.rs
@@ -1,21 +1,12 @@
-//! Pure fanout/collect reduce rules.
+//! Pure fanout expansion and parent-completion rules.
 
 use std::collections::HashMap;
 
-use regex::RegexBuilder;
-
 use crate::domain::workflow::value_objects::{
-    default_step_entry_state, ChildOutputSnapshot, CollectConfig, FailureDisposition, ItemsSource,
-    ParallelAggregate, ReduceStrategy, StepHistoryEntry, StepOutput, TokenUsage,
-    WorkflowDefinition, WorkflowStepFailureKind,
+    default_step_entry_state, ChildOutputSnapshot, FailureDisposition, ItemsSource,
+    StepHistoryEntry, StepOutput, TokenUsage, WorkflowDefinition, WorkflowStepFailureKind,
 };
 use crate::domain::workflow::WorkflowError;
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct ParallelReduceResult {
-    pub result: Option<String>,
-    pub structured_output: Option<serde_json::Value>,
-}
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg(test)]
@@ -26,7 +17,6 @@ pub struct FanoutChildOutputMerge {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FanoutChildCompletionInput {
-    pub node_execution_id: String,
     pub node_name: String,
     pub session_id: Option<String>,
     pub result: Option<String>,
@@ -40,21 +30,10 @@ pub struct FanoutChildCompletionInput {
     pub failure_disposition: Option<FailureDisposition>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FanoutParentTransitionPlan {
-    Advance,
-    TransitionTo {
-        target_node_name: String,
-        aggregate_result: String,
-    },
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct FanoutParentCompletionPlan {
-    pub child_node_names: Vec<String>,
     pub parent_step_output: StepOutput,
     pub history_entry: StepHistoryEntry,
-    pub transition: FanoutParentTransitionPlan,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -80,103 +59,6 @@ pub fn merge_fanout_child_completion_output(
     FanoutChildOutputMerge {
         structured_output: completed_structured_output.or(prior_structured_output),
         artifact_contract: prior_artifact_contract,
-    }
-}
-
-pub fn apply_reduce(
-    collect: &CollectConfig,
-    step_outputs: &HashMap<String, StepOutput>,
-) -> ParallelReduceResult {
-    match collect.reduce {
-        ReduceStrategy::Last => {
-            let last_output = collect
-                .from
-                .iter()
-                .filter_map(|name| step_outputs.get(name.as_str()))
-                .max_by(|a, b| {
-                    a.completed_at
-                        .partial_cmp(&b.completed_at)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                });
-            match last_output {
-                Some(output) => ParallelReduceResult {
-                    result: output.result.clone(),
-                    structured_output: output.structured_output.clone(),
-                },
-                None => ParallelReduceResult {
-                    result: None,
-                    structured_output: None,
-                },
-            }
-        }
-        ReduceStrategy::Concat => {
-            let entries = collect_step_output_entries(&collect.from, step_outputs);
-            ParallelReduceResult {
-                result: None,
-                structured_output: non_empty_array(entries),
-            }
-        }
-        ReduceStrategy::Grouped => {
-            let mut groups: HashMap<String, Vec<String>> = HashMap::new();
-            for step_name in &collect.from {
-                if let Some(output) = step_outputs.get(step_name.as_str()) {
-                    let key = output
-                        .result
-                        .clone()
-                        .unwrap_or_else(|| "unknown".to_string());
-                    groups.entry(key).or_default().push(step_name.clone());
-                }
-            }
-            let grouped_json: serde_json::Map<String, serde_json::Value> = groups
-                .into_iter()
-                .map(|(key, values)| {
-                    (
-                        key,
-                        serde_json::Value::Array(
-                            values.into_iter().map(serde_json::Value::String).collect(),
-                        ),
-                    )
-                })
-                .collect();
-            ParallelReduceResult {
-                result: None,
-                structured_output: if grouped_json.is_empty() {
-                    None
-                } else {
-                    Some(serde_json::Value::Object(grouped_json))
-                },
-            }
-        }
-        ReduceStrategy::AnyNeedsFix => {
-            let any_needs_fix = collect.from.iter().any(|step_name| {
-                if let Some(output) = step_outputs.get(step_name.as_str()) {
-                    matches!(
-                        resolve_step_result(output).as_deref(),
-                        Some("NEEDS_FIX") | Some("needs_fix")
-                    )
-                } else {
-                    true
-                }
-            });
-            let entries = collect_step_output_entries(&collect.from, step_outputs);
-            ParallelReduceResult {
-                result: Some(if any_needs_fix { "NEEDS_FIX" } else { "LGTM" }.to_string()),
-                structured_output: non_empty_array(entries),
-            }
-        }
-        ReduceStrategy::AllPassed => {
-            let all_passed = collect.from.iter().all(|step_name| {
-                step_outputs
-                    .get(step_name.as_str())
-                    .and_then(resolve_step_result)
-                    .is_some_and(|result| matches!(result.as_str(), "PASSED" | "passed" | "LGTM"))
-            });
-            let entries = collect_step_output_entries(&collect.from, step_outputs);
-            ParallelReduceResult {
-                result: Some(if all_passed { "PASSED" } else { "FAILED" }.to_string()),
-                structured_output: non_empty_array(entries),
-            }
-        }
     }
 }
 
@@ -290,14 +172,9 @@ pub fn plan_fanout_expansion(
 pub fn plan_fanout_parent_completion(
     parent_node_name: &str,
     parent_attempt: u32,
-    aggregate: Option<&ParallelAggregate>,
     children: &[FanoutChildCompletionInput],
     timestamp: f64,
 ) -> FanoutParentCompletionPlan {
-    let child_node_names: Vec<String> = children
-        .iter()
-        .map(|child| child.node_name.clone())
-        .collect();
     let mut combined_tokens = TokenUsage::default();
     for child in children {
         combined_tokens.add(&child.token_usage);
@@ -326,27 +203,7 @@ pub fn plan_fanout_parent_completion(
         })
         .collect();
 
-    let (transition, history_result) = if let Some(aggregate) = aggregate {
-        let agg_result = evaluate_fanout_aggregate(aggregate, children);
-        let aggregate_result = if agg_result { "then" } else { "else" }.to_string();
-        let target_node_name = if agg_result {
-            aggregate.then.clone()
-        } else {
-            aggregate.r#else.clone()
-        };
-        (
-            FanoutParentTransitionPlan::TransitionTo {
-                target_node_name,
-                aggregate_result: aggregate_result.clone(),
-            },
-            aggregate_result,
-        )
-    } else {
-        (FanoutParentTransitionPlan::Advance, "complete".to_string())
-    };
-
     FanoutParentCompletionPlan {
-        child_node_names,
         parent_step_output: StepOutput {
             step_name: parent_node_name.to_string(),
             run_index: parent_attempt,
@@ -360,7 +217,7 @@ pub fn plan_fanout_parent_completion(
         history_entry: StepHistoryEntry {
             step_name: parent_node_name.to_string(),
             completed_at: timestamp,
-            result: Some(history_result),
+            result: Some("complete".to_string()),
             session_id: None,
             token_usage: Some(combined_tokens),
             structured_output: Some(parent_artifact),
@@ -368,130 +225,6 @@ pub fn plan_fanout_parent_completion(
             child_outputs: Some(child_outputs),
             state: default_step_entry_state(),
         },
-        transition,
-    }
-}
-
-pub fn evaluate_fanout_aggregate(
-    aggregate: &ParallelAggregate,
-    children: &[FanoutChildCompletionInput],
-) -> bool {
-    if let Some(pattern) = aggregate.all_match.as_deref() {
-        let regex = RegexBuilder::new(pattern).size_limit(1 << 20).build().ok();
-        children
-            .iter()
-            .all(|child| matches_result_pattern(child.result.as_deref(), pattern, &regex))
-    } else if let Some(pattern) = aggregate.any_match.as_deref() {
-        let regex = RegexBuilder::new(pattern).size_limit(1 << 20).build().ok();
-        children
-            .iter()
-            .any(|child| matches_result_pattern(child.result.as_deref(), pattern, &regex))
-    } else {
-        true
-    }
-}
-
-fn matches_result_pattern(
-    result: Option<&str>,
-    pattern: &str,
-    regex: &Option<regex::Regex>,
-) -> bool {
-    let Some(result) = result else {
-        return false;
-    };
-    if let Some(regex) = regex {
-        regex.is_match(result)
-    } else {
-        result.contains(pattern)
-    }
-}
-
-fn non_empty_array(entries: Vec<serde_json::Value>) -> Option<serde_json::Value> {
-    if entries.is_empty() {
-        None
-    } else {
-        Some(serde_json::Value::Array(entries))
-    }
-}
-
-pub fn collect_step_output_entries(
-    from: &[String],
-    step_outputs: &HashMap<String, StepOutput>,
-) -> Vec<serde_json::Value> {
-    let mut entries = Vec::new();
-    for step_name in from {
-        if let Some(output) = step_outputs.get(step_name.as_str()) {
-            if let Some(structured_output) = &output.structured_output {
-                entries.push(serde_json::json!({
-                    "stepName": step_name,
-                    "output": structured_output,
-                }));
-            }
-        }
-    }
-    entries
-}
-
-pub fn resolve_step_result(output: &StepOutput) -> Option<String> {
-    if let Some(structured_output) = &output.structured_output {
-        if let Some(verdict) = structured_output
-            .get("verdict")
-            .and_then(|value| value.as_str())
-        {
-            return Some(verdict.to_string());
-        }
-        if let Some(status) = structured_output
-            .get("status")
-            .and_then(|value| value.as_str())
-        {
-            return Some(status.to_string());
-        }
-    }
-    output.result.clone()
-}
-
-#[cfg(test)]
-pub fn evaluate_aggregate(
-    aggregate: &ParallelAggregate,
-    step_outputs: &HashMap<String, StepOutput>,
-    child_step_names: &[String],
-) -> bool {
-    let child_outputs: Vec<&StepOutput> = child_step_names
-        .iter()
-        .filter_map(|name| step_outputs.get(name))
-        .collect();
-
-    if let Some(pattern) = aggregate.all_match.as_deref() {
-        if child_outputs.len() != child_step_names.len() {
-            return false;
-        }
-        let regex = RegexBuilder::new(pattern).size_limit(1 << 20).build().ok();
-        child_outputs
-            .iter()
-            .all(|output| matches_aggregate_pattern(output, pattern, &regex))
-    } else if let Some(pattern) = aggregate.any_match.as_deref() {
-        let regex = RegexBuilder::new(pattern).size_limit(1 << 20).build().ok();
-        child_outputs
-            .iter()
-            .any(|output| matches_aggregate_pattern(output, pattern, &regex))
-    } else {
-        true
-    }
-}
-
-#[cfg(test)]
-fn matches_aggregate_pattern(
-    output: &StepOutput,
-    pattern: &str,
-    regex: &Option<regex::Regex>,
-) -> bool {
-    let Some(result) = output.result.as_ref() else {
-        return false;
-    };
-    if let Some(regex) = regex {
-        regex.is_match(result)
-    } else {
-        result.contains(pattern)
     }
 }
 
@@ -499,22 +232,8 @@ fn matches_aggregate_pattern(
 mod parallel_tests {
     use super::*;
 
-    fn output(step_name: &str, result: Option<&str>, completed_at: f64) -> StepOutput {
-        StepOutput {
-            step_name: step_name.to_string(),
-            run_index: 0,
-            session_id: None,
-            result: result.map(str::to_string),
-            structured_output: None,
-            artifact_contract: None,
-            token_usage: None,
-            completed_at,
-        }
-    }
-
     fn completed_child(step_name: &str, result: Option<&str>) -> FanoutChildCompletionInput {
         FanoutChildCompletionInput {
-            node_execution_id: format!("execution-{step_name}"),
             node_name: step_name.to_string(),
             session_id: Some(format!("session-{step_name}")),
             result: result.map(str::to_string),
@@ -615,45 +334,15 @@ mod parallel_tests {
     }
 
     #[test]
-    fn test_reduce_last_最新completed_atの出力を選ぶ() {
-        let collect = CollectConfig {
-            from: vec!["a".to_string(), "b".to_string()],
-            reduce: ReduceStrategy::Last,
-        };
-        let outputs = HashMap::from([
-            ("a".to_string(), output("a", Some("old"), 1.0)),
-            ("b".to_string(), output("b", Some("new"), 2.0)),
-        ]);
-        assert_eq!(
-            apply_reduce(&collect, &outputs).result.as_deref(),
-            Some("new")
-        );
-    }
-
-    #[test]
-    fn plan_fanout_parent_completion_builds_ordered_array_and_then_transition() {
-        let aggregate = ParallelAggregate {
-            all_match: Some("LGTM".to_string()),
-            any_match: None,
-            then: "ship".to_string(),
-            r#else: "fix".to_string(),
-        };
+    fn plan_fanout_parent_completion_builds_ordered_artifact_array() {
         let children = vec![
             completed_child("review-a", Some("LGTM")),
             completed_child("review-b", Some("LGTM")),
         ];
-        let plan =
-            plan_fanout_parent_completion("parallel-review", 2, Some(&aggregate), &children, 12.0);
+        let plan = plan_fanout_parent_completion("parallel-review", 2, &children, 12.0);
 
-        assert_eq!(
-            plan.transition,
-            FanoutParentTransitionPlan::TransitionTo {
-                target_node_name: "ship".to_string(),
-                aggregate_result: "then".to_string()
-            }
-        );
         assert_eq!(plan.history_entry.step_name, "parallel-review");
-        assert_eq!(plan.history_entry.result.as_deref(), Some("then"));
+        assert_eq!(plan.history_entry.result.as_deref(), Some("complete"));
         assert_eq!(
             plan.history_entry
                 .token_usage
@@ -676,15 +365,6 @@ mod parallel_tests {
                 { "node": "review-b" }
             ]))
         );
-    }
-
-    #[test]
-    fn plan_fanout_parent_completion_without_aggregate_advances() {
-        let children = vec![completed_child("review-a", Some("LGTM"))];
-        let plan = plan_fanout_parent_completion("parallel-review", 1, None, &children, 12.0);
-
-        assert_eq!(plan.transition, FanoutParentTransitionPlan::Advance);
-        assert_eq!(plan.history_entry.result.as_deref(), Some("complete"));
     }
 
     #[test]
@@ -715,59 +395,5 @@ mod parallel_tests {
             Some(serde_json::json!({ "verdict": "NEEDS_FIX" }))
         );
         assert_eq!(merge.artifact_contract.as_deref(), Some("review-contract"));
-    }
-
-    #[test]
-    fn test_reduce_any_needs_fix_未完了stepはneeds_fix扱い() {
-        let collect = CollectConfig {
-            from: vec!["a".to_string(), "missing".to_string()],
-            reduce: ReduceStrategy::AnyNeedsFix,
-        };
-        let outputs = HashMap::from([("a".to_string(), output("a", Some("LGTM"), 1.0))]);
-        assert_eq!(
-            apply_reduce(&collect, &outputs).result.as_deref(),
-            Some("NEEDS_FIX")
-        );
-    }
-
-    #[test]
-    fn test_reduce_any_needs_fix_resultなしの完了出力はneeds_fix扱いしない() {
-        let collect = CollectConfig {
-            from: vec!["a".to_string()],
-            reduce: ReduceStrategy::AnyNeedsFix,
-        };
-        let outputs = HashMap::from([("a".to_string(), output("a", None, 1.0))]);
-        assert_eq!(
-            apply_reduce(&collect, &outputs).result.as_deref(),
-            Some("LGTM")
-        );
-    }
-
-    #[test]
-    fn test_evaluate_aggregate_all_match_requires_all_child_outputs() {
-        let aggregate = ParallelAggregate {
-            all_match: Some("LGTM".to_string()),
-            any_match: None,
-            then: "report".to_string(),
-            r#else: "fix".to_string(),
-        };
-        let outputs = HashMap::from([("a".to_string(), output("a", Some("LGTM"), 1.0))]);
-        let children = vec!["a".to_string(), "missing".to_string()];
-
-        assert!(!evaluate_aggregate(&aggregate, &outputs, &children));
-    }
-
-    #[test]
-    fn test_evaluate_aggregate_invalid_regex_falls_back_to_contains() {
-        let aggregate = ParallelAggregate {
-            all_match: Some("[invalid(regex".to_string()),
-            any_match: None,
-            then: "report".to_string(),
-            r#else: "fix".to_string(),
-        };
-        let outputs = HashMap::from([("a".to_string(), output("a", Some("[invalid(regex"), 1.0))]);
-        let children = vec!["a".to_string()];
-
-        assert!(evaluate_aggregate(&aggregate, &outputs, &children));
     }
 }

--- a/src-tauri/src/domain/workflow/services/reference.rs
+++ b/src-tauri/src/domain/workflow/services/reference.rs
@@ -386,7 +386,6 @@ mod tests {
             kind: NodeKind::Fanout(FanoutSpec {
                 child: vec![child.to_string()],
                 items: None,
-                aggregate: None,
             }),
             ..Default::default()
         }

--- a/src-tauri/src/domain/workflow/services/routing.rs
+++ b/src-tauri/src/domain/workflow/services/routing.rs
@@ -178,10 +178,6 @@ fn explicit_targets<'a>(
     if let Some(fanout) = node.fanout() {
         targets.extend(fanout.child.iter().map(String::as_str));
     }
-    if let Some(aggregate) = node.fanout().and_then(|fanout| fanout.aggregate.as_ref()) {
-        targets.push(aggregate.then.as_str());
-        targets.push(aggregate.r#else.as_str());
-    }
     targets
 }
 
@@ -235,13 +231,7 @@ fn validate_fanout_child_leaf_constraints(
     }
 
     for source in &workflow.nodes {
-        for target in source.rules.iter().flat_map(rule_targets).chain(
-            source
-                .fanout()
-                .and_then(|fanout| fanout.aggregate.as_ref())
-                .into_iter()
-                .flat_map(|aggregate| [aggregate.then.as_str(), aggregate.r#else.as_str()]),
-        ) {
+        for target in source.rules.iter().flat_map(rule_targets) {
             let Some(parent) = parent_by_child.get(target).copied() else {
                 continue;
             };
@@ -708,7 +698,6 @@ mod routing_tests {
             kind: NodeKind::Fanout(FanoutSpec {
                 child: children.iter().map(|child| (*child).to_string()).collect(),
                 items: None,
-                aggregate: None,
             }),
             rules,
             ..Default::default()

--- a/src-tauri/src/domain/workflow/services/submission.rs
+++ b/src-tauri/src/domain/workflow/services/submission.rs
@@ -36,7 +36,6 @@ mod submission_tests {
             kind: NodeKind::Fanout(FanoutSpec {
                 child: children.into_iter().map(str::to_string).collect(),
                 items: None,
-                aggregate: None,
             }),
             ..Default::default()
         }

--- a/src-tauri/src/domain/workflow/services/validation.rs
+++ b/src-tauri/src/domain/workflow/services/validation.rs
@@ -1,10 +1,9 @@
 use crate::domain::workflow::services::{contract_schema, reference, routing};
 use crate::domain::workflow::value_objects::{MAX_FANOUT_CHILDREN, MAX_NODES_PER_WORKFLOW};
 use crate::domain::workflow::{
-    ItemsSource, NodeDefinition, NodeKindName, ReduceStrategy, SchemaDef,
-    WorkflowDefinition as Workflow, WorkflowError, WorkflowName,
+    ItemsSource, NodeDefinition, NodeKindName, SchemaDef, WorkflowDefinition as Workflow,
+    WorkflowError, WorkflowName,
 };
-use regex::RegexBuilder;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
@@ -58,10 +57,6 @@ pub enum ValidationError {
     MissingFacet {
         step: String,
     },
-    UnknownCollectFrom {
-        step: String,
-        reference: String,
-    },
     EmptyFanoutChildren {
         step: String,
     },
@@ -87,16 +82,6 @@ pub enum ValidationError {
         step: String,
         child: String,
         reason: String,
-    },
-    /// aggregate 設定が不正（all_match/any_match 排他違反等）
-    AggregateInvalidConfig {
-        step: String,
-        reason: String,
-    },
-    /// aggregate の遷移先が存在しない
-    AggregateUnknownTarget {
-        step: String,
-        target: String,
     },
     /// rules の遷移先が存在しない node を参照
     UnknownRuleTarget {
@@ -125,12 +110,6 @@ pub enum ValidationError {
     /// command 種別 node の `command` が空文字
     EmptyCommand {
         step: String,
-    },
-    /// node 種別ごとに許可されないフィールドが指定されている
-    DisallowedFieldForKind {
-        step: String,
-        field: &'static str,
-        kind: &'static str,
     },
     /// `nodes` の総数が DoS 防御の上限を超えた
     TooManyNodes {
@@ -213,15 +192,8 @@ impl fmt::Display for ValidationError {
                 write!(f, "ステップ名 '{name}' が重複しています")
             }
             Self::MissingFacet { step } => {
-                write!(
-                    f,
-                    "ステップ '{step}' にはファセット参照が必要です（collectステップのみ省略可）"
-                )
+                write!(f, "ステップ '{step}' にはファセット参照が必要です")
             }
-            Self::UnknownCollectFrom { step, reference } => write!(
-                f,
-                "ステップ '{step}' のcollect.fromが存在しないステップ '{reference}' を参照しています"
-            ),
             Self::EmptyFanoutChildren { step } => {
                 write!(f, "fanout node '{step}' must reference at least one child")
             }
@@ -258,13 +230,6 @@ impl fmt::Display for ValidationError {
                     "fanout node '{step}' child '{child}' violates leaf constraints: {reason}"
                 )
             }
-            Self::AggregateInvalidConfig { step, reason } => {
-                write!(f, "ステップ '{step}' のaggregate設定が不正です: {reason}")
-            }
-            Self::AggregateUnknownTarget { step, target } => write!(
-                f,
-                "ステップ '{step}' のaggregateが存在しないステップ '{target}' を参照しています"
-            ),
             Self::UnknownRuleTarget { step, target } => write!(
                 f,
                 "node '{step}' のrulesが存在しないnode '{target}' を参照しています"
@@ -308,14 +273,6 @@ impl fmt::Display for ValidationError {
                     "commandステップ '{step}' の command は空にできません"
                 )
             }
-            Self::DisallowedFieldForKind {
-                step,
-                field,
-                kind,
-            } => write!(
-                f,
-                "ステップ '{step}' ({kind}) には '{field}' を指定できません"
-            ),
             Self::UnknownModel { step, value } => {
                 write!(
                     f,
@@ -783,10 +740,10 @@ pub fn validate(workflow: &Workflow) -> Result<(), ValidationError> {
         return Err(reference_diagnostic_to_validation_error(err));
     }
 
-    // 遷移先・fanout child は共に top-level node 名前空間を参照する。
-    let mut transition_target_names = HashSet::new();
+    // 重複ステップ名を検出する。
+    let mut seen_names = HashSet::new();
     for step in &workflow.nodes {
-        if !transition_target_names.insert(step.name.as_str()) {
+        if !seen_names.insert(step.name.as_str()) {
             return Err(ValidationError::DuplicateStep {
                 name: step.name.clone(),
             });
@@ -802,120 +759,14 @@ pub fn validate(workflow: &Workflow) -> Result<(), ValidationError> {
         return Err(routing_error_to_validation_error(err));
     }
 
-    // 各ステップより前に定義されたステップ名を追跡（collect.from検証用）
-    let mut preceding_step_names: HashSet<&str> = HashSet::new();
-
     for step in &workflow.nodes {
         validate_node_kind_fields(step)?;
-        if step.is_fanout() {
-            // aggregate バリデーション
-            if let Some(agg) = step.fanout().and_then(|fanout| fanout.aggregate.as_ref()) {
-                // all_match と any_match の排他チェック
-                match (&agg.all_match, &agg.any_match) {
-                    (Some(_), Some(_)) => {
-                        return Err(ValidationError::AggregateInvalidConfig {
-                            step: step.name.clone(),
-                            reason: "all_matchとany_matchは同時に指定できません".to_string(),
-                        });
-                    }
-                    (None, None) => {
-                        return Err(ValidationError::AggregateInvalidConfig {
-                            step: step.name.clone(),
-                            reason: "all_matchまたはany_matchのいずれかが必要です".to_string(),
-                        });
-                    }
-                    _ => {}
-                }
-
-                // regex妥当性チェック
-                if let Some(ref pattern) = agg.all_match {
-                    if RegexBuilder::new(pattern)
-                        .size_limit(1 << 20)
-                        .build()
-                        .is_err()
-                    {
-                        return Err(ValidationError::AggregateInvalidConfig {
-                            step: step.name.clone(),
-                            reason: format!("all_matchのパターンが不正な正規表現です: {pattern}"),
-                        });
-                    }
-                }
-                if let Some(ref pattern) = agg.any_match {
-                    if RegexBuilder::new(pattern)
-                        .size_limit(1 << 20)
-                        .build()
-                        .is_err()
-                    {
-                        return Err(ValidationError::AggregateInvalidConfig {
-                            step: step.name.clone(),
-                            reason: format!("any_matchのパターンが不正な正規表現です: {pattern}"),
-                        });
-                    }
-                }
-
-                // then/else の遷移先存在チェック（トップレベルstepのみ）
-                if !transition_target_names.contains(agg.then.as_str()) {
-                    return Err(ValidationError::AggregateUnknownTarget {
-                        step: step.name.clone(),
-                        target: agg.then.clone(),
-                    });
-                }
-                if !transition_target_names.contains(agg.r#else.as_str()) {
-                    return Err(ValidationError::AggregateUnknownTarget {
-                        step: step.name.clone(),
-                        target: agg.r#else.clone(),
-                    });
-                }
-            }
-        } else {
-            // --- 通常step のバリデーション ---
-            // 新 schema では kind が型レベルで必須・列挙のため、
-            // 旧 schema の MissingMode / InteractiveModeNotAllowed 検査は
-            // YAML deserialize 段階で吸収される（[02] 範囲外）。
-            // permission の妥当性チェック（必須）
-            if step.is_session() {
-                validate_required_permission(&step.name, step.permission())?;
-            }
-
-            if let Some(err) = check_missing_facet(step) {
-                return Err(err);
-            }
-
-            // collect.from の参照先 step 名が先行stepに存在するか検証（並列子stepも参照可）
-            if let Some(ref collect) = step.collect {
-                for r in &collect.from {
-                    if !preceding_step_names.contains(r.as_str()) {
-                        return Err(ValidationError::UnknownCollectFrom {
-                            step: step.name.clone(),
-                            reference: r.clone(),
-                        });
-                    }
-                }
-
-                // any_needs_fix / all_passed 使用時に参照先 step の rules 未定義を警告
-                if matches!(
-                    collect.reduce,
-                    ReduceStrategy::AnyNeedsFix | ReduceStrategy::AllPassed
-                ) {
-                    for r in &collect.from {
-                        let referenced_step = workflow.nodes.iter().find(|s| s.name == *r);
-                        if let Some(rs) = referenced_step {
-                            if rs.rules.is_empty() && !rs.is_fanout() {
-                                log::warn!(
-                                    "collect step '{}' uses {:?} reducer but source step '{}' has no rules defined (result may be None)",
-                                    step.name,
-                                    collect.reduce,
-                                    r
-                                );
-                            }
-                        }
-                    }
-                }
-            }
+        if step.is_session() {
+            validate_required_permission(&step.name, step.permission())?;
         }
-
-        // 次のステップのvalidationで使えるよう、このステップ名を追加
-        preceding_step_names.insert(&step.name);
+        if let Some(err) = check_missing_facet(step) {
+            return Err(err);
+        }
     }
 
     Ok(())
@@ -1132,13 +983,13 @@ fn collect_node_count_errors(workflow: &Workflow) -> Vec<ValidationError> {
     errors
 }
 
-/// session (collect なし) に facet 参照が無い場合に
+/// session に facet 参照が無い場合に
 /// `MissingFacet` を返す。command node は `command` を持つため facet が
 /// 不要であり、この検査の対象外（必須フィールドは `validate_node_kind_fields` で検証済み）。
 ///
 /// `validate` / `validate_all` の両経路で同じ判定を行うため共通化する。
 fn check_missing_facet(step: &NodeDefinition) -> Option<ValidationError> {
-    if step.is_session() && step.collect.is_none() && !step.has_facet_refs() {
+    if step.is_session() && !step.has_facet_refs() {
         Some(ValidationError::MissingFacet {
             step: step.name.clone(),
         })
@@ -1149,13 +1000,6 @@ fn check_missing_facet(step: &NodeDefinition) -> Option<ValidationError> {
 
 /// node kind ごとの許可フィールドを検証する。
 fn validate_node_kind_fields(step: &NodeDefinition) -> Result<(), ValidationError> {
-    let kind_name = step.kind_name().as_str();
-    let disallow = |field: &'static str| ValidationError::DisallowedFieldForKind {
-        step: step.name.clone(),
-        field,
-        kind: kind_name,
-    };
-
     match step.kind_name() {
         NodeKindName::Command => {
             let command = step
@@ -1166,16 +1010,8 @@ fn validate_node_kind_fields(step: &NodeDefinition) -> Result<(), ValidationErro
                     step: step.name.clone(),
                 });
             }
-            if step.collect.is_some() {
-                return Err(disallow("collect"));
-            }
         }
-        NodeKindName::Session => {}
-        NodeKindName::Fanout => {
-            if step.collect.is_some() {
-                return Err(disallow("collect"));
-            }
-        }
+        NodeKindName::Session | NodeKindName::Fanout => {}
     }
     Ok(())
 }
@@ -1295,11 +1131,11 @@ pub fn validate_all(workflow: &Workflow) -> Vec<ValidationError> {
             .map(reference_diagnostic_to_validation_error),
     );
 
-    // 名前空間構築: 重複があれば蓄積するが、以降のチェックは続行
-    let mut transition_target_names = HashSet::new();
+    // 重複ステップ名を検出し、あれば蓄積するが、以降のチェックは続行
+    let mut seen_names = HashSet::new();
     let mut has_dup = false;
     for step in &workflow.nodes {
-        if !transition_target_names.insert(step.name.as_str()) {
+        if !seen_names.insert(step.name.as_str()) {
             errors.push(ValidationError::DuplicateStep {
                 name: step.name.clone(),
             });
@@ -1322,90 +1158,18 @@ pub fn validate_all(workflow: &Workflow) -> Vec<ValidationError> {
             .map(routing_error_to_validation_error),
     );
 
-    let mut preceding_step_names: HashSet<&str> = HashSet::new();
-
     for step in &workflow.nodes {
         if let Err(e) = validate_node_kind_fields(step) {
             errors.push(e);
         }
-        if step.is_fanout() {
-            if let Some(agg) = step.fanout().and_then(|fanout| fanout.aggregate.as_ref()) {
-                match (&agg.all_match, &agg.any_match) {
-                    (Some(_), Some(_)) => {
-                        errors.push(ValidationError::AggregateInvalidConfig {
-                            step: step.name.clone(),
-                            reason: "all_matchとany_matchは同時に指定できません".to_string(),
-                        });
-                    }
-                    (None, None) => {
-                        errors.push(ValidationError::AggregateInvalidConfig {
-                            step: step.name.clone(),
-                            reason: "all_matchまたはany_matchのいずれかが必要です".to_string(),
-                        });
-                    }
-                    _ => {}
-                }
-                if let Some(ref pattern) = agg.all_match {
-                    if RegexBuilder::new(pattern)
-                        .size_limit(1 << 20)
-                        .build()
-                        .is_err()
-                    {
-                        errors.push(ValidationError::AggregateInvalidConfig {
-                            step: step.name.clone(),
-                            reason: format!("all_matchのパターンが不正な正規表現です: {pattern}"),
-                        });
-                    }
-                }
-                if let Some(ref pattern) = agg.any_match {
-                    if RegexBuilder::new(pattern)
-                        .size_limit(1 << 20)
-                        .build()
-                        .is_err()
-                    {
-                        errors.push(ValidationError::AggregateInvalidConfig {
-                            step: step.name.clone(),
-                            reason: format!("any_matchのパターンが不正な正規表現です: {pattern}"),
-                        });
-                    }
-                }
-                if !transition_target_names.contains(agg.then.as_str()) {
-                    errors.push(ValidationError::AggregateUnknownTarget {
-                        step: step.name.clone(),
-                        target: agg.then.clone(),
-                    });
-                }
-                if !transition_target_names.contains(agg.r#else.as_str()) {
-                    errors.push(ValidationError::AggregateUnknownTarget {
-                        step: step.name.clone(),
-                        target: agg.r#else.clone(),
-                    });
-                }
-            }
-        } else {
-            // 新 schema では kind が型レベルで必須・列挙のため、旧 schema の
-            // MissingMode / InteractiveModeNotAllowed 検査は YAML deserialize 段階で吸収される。
-            if step.is_session() {
-                if let Err(e) = validate_required_permission(&step.name, step.permission()) {
-                    errors.push(e);
-                }
-            }
-            if let Some(err) = check_missing_facet(step) {
-                errors.push(err);
-            }
-            if let Some(ref collect) = step.collect {
-                for r in &collect.from {
-                    if !preceding_step_names.contains(r.as_str()) {
-                        errors.push(ValidationError::UnknownCollectFrom {
-                            step: step.name.clone(),
-                            reference: r.clone(),
-                        });
-                    }
-                }
+        if step.is_session() {
+            if let Err(e) = validate_required_permission(&step.name, step.permission()) {
+                errors.push(e);
             }
         }
-
-        preceding_step_names.insert(&step.name);
+        if let Some(err) = check_missing_facet(step) {
+            errors.push(err);
+        }
     }
 
     errors
@@ -1415,8 +1179,8 @@ pub fn validate_all(workflow: &Workflow) -> Vec<ValidationError> {
 mod tests {
     use super::*;
     use crate::domain::workflow::{
-        CollectConfig, CommandSpec, FacetRefs, FanoutSpec, ItemsSource, NodeKind,
-        ParallelAggregate, Rule, SchemaDef, SessionGate, SessionSpec,
+        CommandSpec, FacetRefs, FanoutSpec, ItemsSource, NodeKind, Rule, SchemaDef, SessionGate,
+        SessionSpec,
     };
     use std::collections::{BTreeMap, BTreeSet};
 
@@ -1483,7 +1247,7 @@ mod tests {
         NodeDefinition {
             name: name.to_string(),
             kind: node_kind,
-            rules: rules,
+            rules,
             ..NodeDefinition::default()
         }
     }
@@ -1492,17 +1256,12 @@ mod tests {
         name.to_string()
     }
 
-    fn make_parallel_block(
-        name: &str,
-        children: Vec<String>,
-        aggregate: Option<ParallelAggregate>,
-    ) -> NodeDefinition {
+    fn make_parallel_block(name: &str, children: Vec<String>) -> NodeDefinition {
         NodeDefinition {
             name: name.to_string(),
             kind: NodeKind::Fanout(FanoutSpec {
                 child: children,
                 items: None,
-                aggregate,
             }),
             ..NodeDefinition::default()
         }
@@ -1756,7 +1515,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_facet_without_collect_fails() {
+    fn missing_facet_fails() {
         let wf = make_workflow(vec![without_session_facets(make_step(
             "step1",
             TestKind::Session,
@@ -1778,21 +1537,6 @@ mod tests {
                 ..Default::default()
             },
         )]);
-        assert!(validate(&wf).is_ok());
-    }
-
-    #[test]
-    fn collect_step_without_facets_passes() {
-        let wf = make_workflow(vec![
-            make_step("review_a", TestKind::Session, vec![]),
-            NodeDefinition {
-                collect: Some(CollectConfig {
-                    from: vec!["review_a".to_string()],
-                    reduce: ReduceStrategy::Concat,
-                }),
-                ..without_session_facets(make_step("collect_reviews", TestKind::Session, vec![]))
-            },
-        ]);
         assert!(validate(&wf).is_ok());
     }
 
@@ -1956,21 +1700,6 @@ mod tests {
     }
 
     #[test]
-    fn unknown_collect_from_fails() {
-        let wf = make_workflow(vec![NodeDefinition {
-            collect: Some(CollectConfig {
-                from: vec!["nonexistent".to_string()],
-                reduce: ReduceStrategy::Concat,
-            }),
-            ..without_session_facets(make_step("step1", TestKind::Session, vec![]))
-        }]);
-        assert!(matches!(
-            validate(&wf).unwrap_err(),
-            ValidationError::UnknownCollectFrom { ref reference, .. } if reference == "nonexistent"
-        ));
-    }
-
-    #[test]
     fn valid_input_reference_passes() {
         let wf = make_workflow(vec![
             make_step("step_a", TestKind::Session, vec![]),
@@ -1993,29 +1722,6 @@ mod tests {
                     make_parallel_step("arch-review"),
                     make_parallel_step("security-review"),
                 ],
-                Some(ParallelAggregate {
-                    all_match: Some("LGTM".to_string()),
-                    any_match: None,
-                    then: "report".to_string(),
-                    r#else: "implement".to_string(),
-                }),
-            ),
-            make_step("report", TestKind::Session, vec![]),
-        ]);
-        assert!(validate(&wf).is_ok());
-    }
-
-    #[test]
-    fn parallel_block_without_aggregate_passes() {
-        let wf = make_workflow(vec![
-            make_step("implement", TestKind::Session, vec![]),
-            make_parallel_block(
-                "parallel-review",
-                vec![
-                    make_parallel_step("arch-review"),
-                    make_parallel_step("security-review"),
-                ],
-                None,
             ),
             make_step("report", TestKind::Session, vec![]),
         ]);
@@ -2025,7 +1731,7 @@ mod tests {
     #[test]
     fn fanout_child_is_an_ordinary_top_level_node_reference() {
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("conflict")], None),
+            make_parallel_block("par", vec![make_parallel_step("conflict")]),
             make_step("conflict", TestKind::Session, vec![]),
         ]);
         assert!(validate(&wf).is_ok());
@@ -2036,7 +1742,6 @@ mod tests {
         let wf = make_workflow_exact(vec![make_parallel_block(
             "par",
             vec!["missing".to_string()],
-            None,
         )]);
 
         assert!(matches!(
@@ -2047,71 +1752,10 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_both_match_fails() {
-        let wf = make_workflow(vec![
-            make_step("target", TestKind::Session, vec![]),
-            make_parallel_block(
-                "par",
-                vec![make_parallel_step("child1")],
-                Some(ParallelAggregate {
-                    all_match: Some("LGTM".to_string()),
-                    any_match: Some("NEEDS_FIX".to_string()),
-                    then: "target".to_string(),
-                    r#else: "target".to_string(),
-                }),
-            ),
-        ]);
-        assert!(matches!(
-            validate(&wf).unwrap_err(),
-            ValidationError::AggregateInvalidConfig { ref step, .. } if step == "par"
-        ));
-    }
-
-    #[test]
-    fn aggregate_no_match_fails() {
-        let wf = make_workflow(vec![
-            make_step("target", TestKind::Session, vec![]),
-            make_parallel_block(
-                "par",
-                vec![make_parallel_step("child1")],
-                Some(ParallelAggregate {
-                    all_match: None,
-                    any_match: None,
-                    then: "target".to_string(),
-                    r#else: "target".to_string(),
-                }),
-            ),
-        ]);
-        assert!(matches!(
-            validate(&wf).unwrap_err(),
-            ValidationError::AggregateInvalidConfig { ref step, .. } if step == "par"
-        ));
-    }
-
-    #[test]
-    fn aggregate_unknown_target_fails() {
-        let wf = make_workflow(vec![make_parallel_block(
-            "par",
-            vec![make_parallel_step("child1")],
-            Some(ParallelAggregate {
-                all_match: Some("LGTM".to_string()),
-                any_match: None,
-                then: "nonexistent".to_string(),
-                r#else: "par".to_string(),
-            }),
-        )]);
-        assert!(matches!(
-            validate(&wf).unwrap_err(),
-            ValidationError::AggregateUnknownTarget { ref target, .. } if target == "nonexistent"
-        ));
-    }
-
-    #[test]
     fn fanout_inputs_are_rejected() {
         let mut fanout = make_parallel_block(
             "par",
             vec![make_parallel_step("child1"), make_parallel_step("child2")],
-            None,
         );
         fanout.inputs = vec!["request".to_string()];
         let wf = make_workflow(vec![fanout]);
@@ -2125,7 +1769,7 @@ mod tests {
     fn fanout_child_missing_facet_uses_normal_node_validation() {
         let child = without_session_facets(make_step("child1", TestKind::Session, vec![]));
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("child1")], None),
+            make_parallel_block("par", vec![make_parallel_step("child1")]),
             child,
         ]);
         assert!(matches!(
@@ -2141,7 +1785,7 @@ mod tests {
     fn fanout_child_reference_valid_global_step() {
         let wf = make_workflow(vec![
             make_step("plan", TestKind::Session, vec![]),
-            make_parallel_block("par", vec![make_parallel_step("child1")], None),
+            make_parallel_block("par", vec![make_parallel_step("child1")]),
         ]);
         assert!(validate(&wf).is_ok());
     }
@@ -2151,7 +1795,7 @@ mod tests {
         let mut child = make_step("arch-review", TestKind::Session, vec![]);
         child.artifact = Some("review-output".to_string());
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("arch-review")], None),
+            make_parallel_block("par", vec![make_parallel_step("arch-review")]),
             child,
             command_step("consume", "echo {{ arch-review.verdict }}"),
         ]);
@@ -2174,7 +1818,7 @@ mod tests {
     fn empty_fanout_children_fails() {
         let wf = make_workflow(vec![
             make_step("implement", TestKind::Session, vec![]),
-            make_parallel_block("parallel-review", vec![], None),
+            make_parallel_block("parallel-review", vec![]),
             make_step("report", TestKind::Session, vec![]),
         ]);
         let err = validate(&wf).unwrap_err();
@@ -2188,7 +1832,7 @@ mod tests {
     #[test]
     fn fanout_without_items_rejects_child_input() {
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("child")], None),
+            make_parallel_block("par", vec![make_parallel_step("child")]),
             with_input(make_step("child", TestKind::Session, vec![]), "target"),
         ]);
         let wf = workflow_with_schemas(
@@ -2206,7 +1850,7 @@ mod tests {
     #[test]
     fn fanout_with_items_requires_child_input() {
         let parent = with_fanout_items(
-            make_parallel_block("par", vec![make_parallel_step("child")], None),
+            make_parallel_block("par", vec![make_parallel_step("child")]),
             ItemsSource::Literal(vec![]),
         );
         let wf = make_workflow(vec![parent, make_step("child", TestKind::Session, vec![])]);
@@ -2221,7 +1865,7 @@ mod tests {
     #[test]
     fn fanout_literal_items_must_match_child_input_contract() {
         let parent = with_fanout_items(
-            make_parallel_block("par", vec![make_parallel_step("child")], None),
+            make_parallel_block("par", vec![make_parallel_step("child")]),
             ItemsSource::Literal(vec![serde_json::Value::String(
                 "not-an-integer".to_string(),
             )]),
@@ -2247,7 +1891,7 @@ mod tests {
         let mut source = make_step("source", TestKind::Session, vec![]);
         source.artifact = Some("source-output".to_string());
         let parent = with_fanout_items(
-            make_parallel_block("par", vec![make_parallel_step("child")], None),
+            make_parallel_block("par", vec![make_parallel_step("child")]),
             ItemsSource::ArtifactField {
                 node: "source".to_string(),
                 field: "targets".to_string(),
@@ -2290,86 +1934,10 @@ mod tests {
     }
 
     #[test]
-    fn invalid_regex_all_match_fails() {
-        let wf = make_workflow(vec![
-            make_step("implement", TestKind::Session, vec![]),
-            make_parallel_block(
-                "parallel-review",
-                vec![
-                    make_parallel_step("arch-review"),
-                    make_parallel_step("security-review"),
-                ],
-                Some(ParallelAggregate {
-                    all_match: Some("[invalid(regex".to_string()),
-                    any_match: None,
-                    then: "report".to_string(),
-                    r#else: "implement".to_string(),
-                }),
-            ),
-            make_step("report", TestKind::Session, vec![]),
-        ]);
-        let err = validate(&wf).unwrap_err();
-        assert!(matches!(
-            err,
-            ValidationError::AggregateInvalidConfig { ref reason, .. }
-                if reason.contains("不正な正規表現")
-        ));
-    }
-
-    #[test]
-    fn invalid_regex_any_match_fails() {
-        let wf = make_workflow(vec![
-            make_step("implement", TestKind::Session, vec![]),
-            make_parallel_block(
-                "parallel-review",
-                vec![
-                    make_parallel_step("arch-review"),
-                    make_parallel_step("security-review"),
-                ],
-                Some(ParallelAggregate {
-                    all_match: None,
-                    any_match: Some("(unclosed".to_string()),
-                    then: "report".to_string(),
-                    r#else: "implement".to_string(),
-                }),
-            ),
-            make_step("report", TestKind::Session, vec![]),
-        ]);
-        let err = validate(&wf).unwrap_err();
-        assert!(matches!(
-            err,
-            ValidationError::AggregateInvalidConfig { ref reason, .. }
-                if reason.contains("不正な正規表現")
-        ));
-    }
-
-    #[test]
-    fn valid_regex_aggregate_passes() {
-        let wf = make_workflow(vec![
-            make_step("implement", TestKind::Session, vec![]),
-            make_parallel_block(
-                "parallel-review",
-                vec![
-                    make_parallel_step("arch-review"),
-                    make_parallel_step("security-review"),
-                ],
-                Some(ParallelAggregate {
-                    all_match: Some(r"<decision>(LGTM|APPROVED)</decision>".to_string()),
-                    any_match: None,
-                    then: "report".to_string(),
-                    r#else: "implement".to_string(),
-                }),
-            ),
-            make_step("report", TestKind::Session, vec![]),
-        ]);
-        assert!(validate(&wf).is_ok());
-    }
-
-    #[test]
     fn fanout_child_may_be_declared_after_parent() {
         let wf = make_workflow(vec![
             make_step("plan", TestKind::Session, vec![]),
-            make_parallel_block("par", vec![make_parallel_step("child1")], None),
+            make_parallel_block("par", vec![make_parallel_step("child1")]),
             make_step("report", TestKind::Session, vec![]),
         ]);
         assert!(validate(&wf).is_ok());
@@ -2380,7 +1948,7 @@ mod tests {
         let wf = make_workflow(vec![
             NodeDefinition {
                 rules: vec![Rule::Next("done".to_string())],
-                ..make_parallel_block("par", vec![make_parallel_step("child1")], None)
+                ..make_parallel_block("par", vec![make_parallel_step("child1")])
             },
             NodeDefinition {
                 rules: vec![Rule::Next("par".to_string())],
@@ -2394,8 +1962,8 @@ mod tests {
     #[test]
     fn nested_fanout_child_fails() {
         let wf = make_workflow(vec![
-            make_parallel_block("outer", vec![make_parallel_step("inner")], None),
-            make_parallel_block("inner", vec![make_parallel_step("leaf")], None),
+            make_parallel_block("outer", vec![make_parallel_step("inner")]),
+            make_parallel_block("inner", vec![make_parallel_step("leaf")]),
             make_step("leaf", TestKind::Session, vec![]),
         ]);
         assert!(matches!(
@@ -2409,7 +1977,7 @@ mod tests {
     fn fanout_child_cannot_be_workflow_entry() {
         let wf = make_workflow(vec![
             make_step("child", TestKind::Session, vec![]),
-            make_parallel_block("par", vec![make_parallel_step("child")], None),
+            make_parallel_block("par", vec![make_parallel_step("child")]),
         ]);
 
         assert!(matches!(
@@ -2422,7 +1990,7 @@ mod tests {
     #[test]
     fn fanout_child_cannot_be_normal_transition_target() {
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("child")], None),
+            make_parallel_block("par", vec![make_parallel_step("child")]),
             make_step("child", TestKind::Session, vec![]),
             make_step(
                 "source",
@@ -2620,7 +2188,7 @@ mod tests {
             Some("acceptEdits"),
         );
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("child1")], None),
+            make_parallel_block("par", vec![make_parallel_step("child1")]),
             child,
         ]);
         let err = validate(&wf).unwrap_err();
@@ -2636,7 +2204,7 @@ mod tests {
         let child =
             with_session_permission(make_step("child1", TestKind::Session, vec![]), Some("full"));
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("child1")], None),
+            make_parallel_block("par", vec![make_parallel_step("child1")]),
             child,
         ]);
         assert!(validate(&wf).is_ok());
@@ -2660,7 +2228,7 @@ mod tests {
     fn parallel_child_without_permission_fails() {
         let child = with_session_permission(make_step("child1", TestKind::Session, vec![]), None);
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("child1")], None),
+            make_parallel_block("par", vec![make_parallel_step("child1")]),
             child,
         ]);
         let err = validate(&wf).unwrap_err();
@@ -2673,7 +2241,7 @@ mod tests {
     #[test]
     fn parallel_block_without_permission_passes_when_children_have_permission() {
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("child1")], None),
+            make_parallel_block("par", vec![make_parallel_step("child1")]),
             with_session_permission(make_step("child1", TestKind::Session, vec![]), Some("edit")),
         ]);
         assert!(validate(&wf).is_ok());
@@ -2710,7 +2278,7 @@ mod tests {
     #[test]
     fn validate_models_unknown_model_on_parallel_child_fails() {
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("child1")], None),
+            make_parallel_block("par", vec![make_parallel_step("child1")]),
             with_session_model(
                 make_step("child1", TestKind::Session, vec![]),
                 Some("unknown-model"),
@@ -2754,7 +2322,7 @@ mod tests {
     #[test]
     fn validate_models_valid_model_on_parallel_child_passes() {
         let wf = make_workflow(vec![
-            make_parallel_block("par", vec![make_parallel_step("child1")], None),
+            make_parallel_block("par", vec![make_parallel_step("child1")]),
             with_session_model(
                 make_step("child1", TestKind::Session, vec![]),
                 Some("haiku"),
@@ -3017,7 +2585,7 @@ mod tests {
 
     #[test]
     fn fanout_node_rejects_artifact_declaration() {
-        let mut fanout = make_parallel_block("review", vec![make_parallel_step("review-a")], None);
+        let mut fanout = make_parallel_block("review", vec![make_parallel_step("review-a")]);
         fanout.artifact = Some("review-output".to_string());
         let mut wf = make_workflow(vec![fanout]);
         wf.schemas
@@ -3070,7 +2638,6 @@ mod tests {
         let wf = make_workflow(vec![make_parallel_block(
             "par",
             vec![make_parallel_step("child")],
-            None,
         )]);
 
         assert_eq!(total_node_count(&wf), 2);
@@ -3081,16 +2648,7 @@ mod tests {
         let children: Vec<String> = (0..MAX_FANOUT_CHILDREN + 1)
             .map(|i| make_parallel_step(&format!("c{i}")))
             .collect();
-        let wf = make_workflow(vec![make_parallel_block(
-            "par",
-            children,
-            Some(ParallelAggregate {
-                all_match: Some("LGTM".to_string()),
-                any_match: None,
-                then: "par".to_string(),
-                r#else: "par".to_string(),
-            }),
-        )]);
+        let wf = make_workflow(vec![make_parallel_block("par", children)]);
         assert!(matches!(
             validate(&wf).unwrap_err(),
             ValidationError::TooManyFanoutChildren { ref step, .. } if step == "par"
@@ -3103,16 +2661,7 @@ mod tests {
             input: Some("nope".to_string()),
             ..make_step("child1", TestKind::Session, vec![])
         };
-        let par = make_parallel_block(
-            "par",
-            vec![make_parallel_step("child1")],
-            Some(ParallelAggregate {
-                all_match: Some("LGTM".to_string()),
-                any_match: None,
-                then: "par".to_string(),
-                r#else: "par".to_string(),
-            }),
-        );
+        let par = make_parallel_block("par", vec![make_parallel_step("child1")]);
         let wf = make_workflow(vec![par, child]);
         let err = validate_schema_refs(&wf).unwrap_err();
         assert!(matches!(

--- a/src-tauri/src/domain/workflow/value_objects/definition.rs
+++ b/src-tauri/src/domain/workflow/value_objects/definition.rs
@@ -110,7 +110,6 @@ pub struct SessionSpec {
 pub struct FanoutSpec {
     pub child: Vec<String>,
     pub items: Option<ItemsSource>,
-    pub aggregate: Option<ParallelAggregate>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -126,7 +125,6 @@ pub struct NodeDefinition {
     pub artifact: Option<String>,
     pub input: Option<String>,
     pub inputs: Vec<String>,
-    pub collect: Option<CollectConfig>,
     pub rules: Vec<Rule>,
 }
 
@@ -201,14 +199,6 @@ impl NodeDefinition {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct ParallelAggregate {
-    pub all_match: Option<String>,
-    pub any_match: Option<String>,
-    pub then: String,
-    pub r#else: String,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Rule {
     When {
@@ -226,21 +216,6 @@ pub enum Rule {
         on_exhausted: String,
     },
     Next(String),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct CollectConfig {
-    pub from: Vec<String>,
-    pub reduce: ReduceStrategy,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum ReduceStrategy {
-    Last,
-    Concat,
-    Grouped,
-    AnyNeedsFix,
-    AllPassed,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src-tauri/src/domain/workflow/value_objects/mod.rs
+++ b/src-tauri/src/domain/workflow/value_objects/mod.rs
@@ -12,9 +12,9 @@ mod workflow_step_context;
 
 pub use contract::{ContractType, ContractValidationResult, ContractViolation};
 pub use definition::{
-    CollectConfig, CommandSpec, FacetRefs, FanoutSpec, ItemsSource, NodeDefinition, NodeKind,
-    NodeKindName, ParallelAggregate, ReduceStrategy, Rule, SchemaDef, SessionGate, SessionSpec,
-    WorkflowDefinition, WorkflowSummary, MAX_FANOUT_CHILDREN, MAX_NODES_PER_WORKFLOW,
+    CommandSpec, FacetRefs, FanoutSpec, ItemsSource, NodeDefinition, NodeKind, NodeKindName, Rule,
+    SchemaDef, SessionGate, SessionSpec, WorkflowDefinition, WorkflowSummary, MAX_FANOUT_CHILDREN,
+    MAX_NODES_PER_WORKFLOW,
 };
 pub use facet::{FacetKey, FacetKind, FacetSummary};
 pub use failure::{

--- a/src-tauri/src/usecase/workflow/dto.rs
+++ b/src-tauri/src/usecase/workflow/dto.rs
@@ -58,8 +58,6 @@ pub(crate) struct FanoutSpecDto {
     pub child: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub items: Option<ItemsSourceDto>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub aggregate: Option<ParallelAggregateDto>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -86,21 +84,8 @@ pub(crate) struct NodeDefinitionDto {
     pub input: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inputs: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub collect: Option<CollectConfigDto>,
     #[serde(default, rename = "rules", skip_serializing_if = "Vec::is_empty")]
     pub rules: Vec<RuleDto>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct ParallelAggregateDto {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub all_match: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub any_match: Option<String>,
-    pub then: String,
-    pub r#else: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -124,23 +109,6 @@ pub(crate) enum RuleDto {
     Next {
         next: String,
     },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct CollectConfigDto {
-    pub from: Vec<String>,
-    pub reduce: ReduceStrategyDto,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum ReduceStrategyDto {
-    Last,
-    Concat,
-    Grouped,
-    AnyNeedsFix,
-    AllPassed,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -263,7 +231,6 @@ fn node_to_dto(node: &domain::NodeDefinition) -> NodeDefinitionDto {
         artifact: node.artifact.clone(),
         input: node.input.clone(),
         inputs: node.inputs.clone(),
-        collect: node.collect.as_ref().map(collect_to_dto),
         rules: node.rules.iter().map(rule_to_dto).collect(),
     }
 }
@@ -281,7 +248,6 @@ fn fanout_to_dto(fanout: &domain::FanoutSpec) -> FanoutSpecDto {
     FanoutSpecDto {
         child: fanout.child.clone(),
         items: fanout.items.as_ref().map(items_source_to_dto),
-        aggregate: fanout.aggregate.as_ref().map(aggregate_to_dto),
     }
 }
 
@@ -314,32 +280,6 @@ fn facet_refs_to_dto(facets: &domain::FacetRefs) -> FacetRefsDto {
         policy: facets.policy.clone(),
         knowledge: facets.knowledge.clone(),
         instruction: facets.instruction.clone(),
-    }
-}
-
-fn collect_to_dto(collect: &domain::CollectConfig) -> CollectConfigDto {
-    CollectConfigDto {
-        from: collect.from.clone(),
-        reduce: reduce_strategy_to_dto(&collect.reduce),
-    }
-}
-
-fn reduce_strategy_to_dto(reduce: &domain::ReduceStrategy) -> ReduceStrategyDto {
-    match reduce {
-        domain::ReduceStrategy::Last => ReduceStrategyDto::Last,
-        domain::ReduceStrategy::Concat => ReduceStrategyDto::Concat,
-        domain::ReduceStrategy::Grouped => ReduceStrategyDto::Grouped,
-        domain::ReduceStrategy::AnyNeedsFix => ReduceStrategyDto::AnyNeedsFix,
-        domain::ReduceStrategy::AllPassed => ReduceStrategyDto::AllPassed,
-    }
-}
-
-fn aggregate_to_dto(aggregate: &domain::ParallelAggregate) -> ParallelAggregateDto {
-    ParallelAggregateDto {
-        all_match: aggregate.all_match.clone(),
-        any_match: aggregate.any_match.clone(),
-        then: aggregate.then.clone(),
-        r#else: aggregate.r#else.clone(),
     }
 }
 
@@ -465,7 +405,6 @@ mod tests {
             items: Some(ItemsSourceDto::Literal(vec![serde_json::json!({
                 "thread_id": "thread-1"
             })])),
-            aggregate: None,
         };
         assert_eq!(
             serde_json::to_value(literal).unwrap(),
@@ -478,7 +417,6 @@ mod tests {
         let reference = FanoutSpecDto {
             child: vec!["review-opus".to_string(), "review-gpt".to_string()],
             items: Some(ItemsSourceDto::ArtifactField("scan.threads".to_string())),
-            aggregate: None,
         };
         assert_eq!(
             serde_json::to_value(reference).unwrap(),

--- a/src/components/panels/AutomationSection.test.tsx
+++ b/src/components/panels/AutomationSection.test.tsx
@@ -594,12 +594,6 @@ describe("AutomationSection", () => {
 						fanout: {
 							child: ["child-1", "child-2"],
 							items: "scan.items",
-							aggregate: {
-								all_match: "pass",
-								// biome-ignore lint/suspicious/noThenProperty: AggregateConfig uses then/else fields
-								then: "step-done",
-								else: "step-fail",
-							},
 						},
 						artifact: "json-schema",
 						inputs: ["step-0"],
@@ -611,10 +605,6 @@ describe("AutomationSection", () => {
 								on_exhausted: "fallback-step",
 							},
 						],
-						collect: {
-							from: ["step-a", "step-b"],
-							reduce: "concat" as const,
-						},
 					},
 				],
 			},

--- a/src/components/panels/automation/WorkflowDetail.tsx
+++ b/src/components/panels/automation/WorkflowDetail.tsx
@@ -454,17 +454,6 @@ function StepCard({ step, index }: { step: NodeDefinition; index: number }) {
 						</div>
 					)}
 
-					{/* Collect */}
-					{step.collect && (
-						<div className="flex flex-col gap-1">
-							<span className="font-medium text-muted-foreground">Collect</span>
-							<div className="text-muted-foreground">
-								From: {step.collect.from.join(", ")} | Reduce:{" "}
-								{step.collect.reduce}
-							</div>
-						</div>
-					)}
-
 					{/* Fanout children */}
 					{fanout && (
 						<div className="flex flex-col gap-1">
@@ -481,20 +470,6 @@ function StepCard({ step, index }: { step: NodeDefinition; index: number }) {
 									label="Items"
 									value={formatFanoutItems(fanout.items)}
 								/>
-							)}
-							{fanout.aggregate && (
-								<div className="mt-1">
-									<span className="font-medium text-muted-foreground">
-										Aggregate:{" "}
-									</span>
-									<span className="text-muted-foreground">
-										{fanout.aggregate.all_match
-											? `all_match("${fanout.aggregate.all_match}")`
-											: `any_match("${fanout.aggregate.any_match}")`}{" "}
-										→ then: {fanout.aggregate.then}, else:{" "}
-										{fanout.aggregate.else}
-									</span>
-								</div>
 							)}
 						</div>
 					)}

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -101,13 +101,6 @@ type Rule =
 export type NodeKind = "command" | "session" | "fanout";
 export type SessionGate = "auto" | "approval";
 
-interface AggregateConfig {
-	all_match?: string;
-	any_match?: string;
-	then: string;
-	else: string;
-}
-
 export interface FacetRefs {
 	policy?: string;
 	knowledge?: string;
@@ -128,7 +121,6 @@ export type FanoutItemsSource = JsonValue[] | string;
 interface FanoutSpec {
 	child: string[];
 	items?: FanoutItemsSource;
-	aggregate?: AggregateConfig;
 }
 
 export interface NodeDefinition {
@@ -140,23 +132,10 @@ export interface NodeDefinition {
 	artifact?: string;
 	input?: string;
 	inputs?: string[];
-	collect?: CollectConfig;
 	// 共通: rules は省略時 undefined（Rust 側で serde default 経路を持つが、frontend
 	// fixture では空配列を毎回書かなくて済むよう optional とする）
 	rules?: Rule[];
 }
-
-interface CollectConfig {
-	from: string[];
-	reduce: ReduceStrategy;
-}
-
-export type ReduceStrategy =
-	| "last"
-	| "concat"
-	| "grouped"
-	| "any_needs_fix"
-	| "all_passed";
 
 export interface Workflow {
 	name: string;


### PR DESCRIPTION
## 概要

fanout / rules から集約機構（aggregate / collect）を完全に排除し、fanout 完了後の遷移を fanout node 自身の通常 `rules` に一本化する。子 Artifact 配列の畳み込みは reducer node パターン（command / session）で行う。

Closes #1330

## 変更内容

- **aggregate 削除**: `all_match` / `any_match` / `then` / `else` / `ParallelAggregate` を schema / domain / mapper / runtime / event（`FanoutCompleted` の aggregate_result）/ DTO / protocol / frontend から削除
- **collect / ReduceStrategy 削除**: `CollectConfig`（`Last` / `Concat` / `Grouped` / `AnyNeedsFix` / `AllPassed`）、`OutputCollected` event、関連 runtime を削除
- **遷移の一本化**: test 専用 `apply_transition` を廃止し `apply_advance` に統一。fanout 完了後は fanout node の通常 `rules`（next）で分岐
- **失敗時の扱い**: aggregate 委譲していた `ModelRefusal` を通常の node 失敗として扱う（子の一部失敗は #1335 の resume に委ねる）
- **reducer node パターン**: jq を使う command reducer / session reducer の両方を fixture 化
- **built-in 移行**: 03_review / 03_full-review を reducer 構成へ移行

## テスト

- fanout 結果（子 Artifact 配列）を command / session reducer で boolean / enum に畳み、通常 rules で分岐できること
- 旧 `aggregate` / `all_match` / `any_match` / `collect` を受理しない WFS005 regression fixture を追加
- built-in（レビュー系）が reducer 構成で load / 実行できること

## 品質ゲート

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `pnpm lint` ✅
- `cargo test --lib workflow` ✅（1152 passed / 0 failed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更点**
  * ワークフローから、廃止された Collect／Aggregate 設定の表示・定義を削除しました。
  * ファンアウト後の遷移を、より明確な次ステップ指定で処理できるよう更新しました。
  * ファンアウト完了時の出力と履歴を簡素化し、子ステップの結果を安定して確認できるようにしました。
  * 実行失敗時の状態記録と中断処理を整理しました。

* **バグ修正**
  * ワークフロー詳細画面や実行履歴で、廃止済み設定が表示される問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->