### PR TITLE
fix: Artifact の未宣言 field を受理する

### DIFF
--- a/docs/specs/milestone-82/design.md
+++ b/docs/specs/milestone-82/design.md
@@ -110,7 +110,6 @@ pub enum SchemaDef {
     Object {
         properties: BTreeMap<String, SchemaDef>,
         required: BTreeSet<String>,          // default 空
-        additional_properties: bool,          // default true（JSON Schema と同じ。未宣言 field は無視して通す）
     },
     Array { items: String },                 // 要素型は名前付き Contract 参照のみ。inline 不可
     String { r#enum: Option<Vec<String>> },
@@ -120,8 +119,8 @@ pub enum SchemaDef {
 }
 ```
 
-- YAML 表記は JSON Schema 風（`type: object` / `properties:` / `required:` / `items: <Contract名>` / `enum:` / `additionalProperties:`）。この subset 外のキーワード（`oneOf` / `format` / `pattern` / `default` 等）は WFS002。
-- `additionalProperties` の既定は **true**（JSON Schema の既定に合わせる）。閉じた検証が必要な Contract だけ `additionalProperties: false` を明示宣言する。
+- YAML 表記は JSON Schema 風（`type: object` / `properties:` / `required:` / `items: <Contract名>` / `enum:`）。この subset 外のキーワード（`oneOf` / `format` / `pattern` / `default` 等）は WFS002。
+- Object は未宣言 field を常に受理し、閉じた Object を設定するキーワードは持たない。
 - **検証エンジン** `contract_schema::validate(value: &serde_json::Value, schema: &SchemaDef, schemas: &Map) -> Result<(), Vec<Violation>>`。Violation は JSON path + 理由。repair prompt はこの Violation 一覧から生成する。
 - **routing 可能 field** の判定:
   - Object Contract の property `p` が routing 可能 ⇔ `p ∈ required` かつ型が `Boolean` または `String{enum: Some(_)}`。

--- a/docs/specs/milestone-82/goal-02-issue-1325.md
+++ b/docs/specs/milestone-82/goal-02-issue-1325.md
@@ -6,7 +6,7 @@
 
 ## 実装内容
 
-1. **schemas: セクション**（schema.rs + domain）: workflow 直下に `schemas: { <名前>: <JSON Schema subset> }` を追加。D2 の subset（type/properties/required/items/enum/additionalProperties、scalar string、配列要素は名前付き参照）を Rust の型として定義し、subset 外の構文は load 時 Diagnostic。
+1. **schemas: セクション**（schema.rs + domain）: workflow 直下に `schemas: { <名前>: <JSON Schema subset> }` を追加。D2 の subset（type/properties/required/items/enum、scalar string、配列要素は名前付き参照）を Rust の型として定義し、subset 外の構文は load 時 Diagnostic。Object の未宣言 field は常に受理する。
 2. **Contract 検証エンジン**（domain service）: JSON value を subset schema で検証する validator を新設。`domain/workflow/services/contract.rs` の contract-validation メタブロック解析・`spec-directory` ハードコード（52-67 行）を置換・撤去する（spec_dir の generic な後継は #1326 の inputs 参照）。
 3. **artifact: / input:**: node 共通 field `artifact: <Contract 名>` / `input: <Contract 名>` を実装。未定義 Contract 参照は Diagnostic。各 NodeExecution は最大 1 つの Contract 検証済み Artifact を産出し、**Node 名で参照**できるよう projection / state に artifact 保管を実装する（参照 path に Contract 名を出さない）。
 4. **提出経路の統一**: session の CLI submit（`workflow output submit`）と、（#1328 で実装される）command stdout-JSON が同じ Artifact 検証・保存経路を通る構造にする。OutputSubmitted event / repair 機構（ContractRepairRequested、StructuredOutputRepairPolicy）を schemas 検証に接続し、repair prompt の文面を schemas 語彙に更新する。P13: session + artifact は検証済み提出まで完了しない（既存挙動踏襲）。

--- a/docs/specs/milestone-82/goal-common.md
+++ b/docs/specs/milestone-82/goal-common.md
@@ -20,7 +20,7 @@ https://github.com/siro33950/releash/milestone/82 に従って移行する。各
 ## 確定済み設計判断（覆さないこと。詳細は plan.md §2〜§3）
 
 - **D1**: CLI の正は Tauri アプリ内に新設する最小 local API（localhost + 認証トークン）。#1332 で実装。
-- **D2**: `schemas:` は JSON Schema subset（`type`/`properties`/`required`/`items`/`enum`/`additionalProperties`）の自前実装。routing 参照 field は required かつ boolean/enum。scalar(string) Contract を許可（request 用）。配列要素型は inline 不可・名前付き Contract 参照（`items: <名前>`）。
+- **D2**: `schemas:` は JSON Schema subset（`type`/`properties`/`required`/`items`/`enum`）の自前実装。Object の未宣言 field は常に受理する。routing 参照 field は required かつ boolean/enum。scalar(string) Contract を許可（request 用）。配列要素型は inline 不可・名前付き Contract 参照（`items: <名前>`）。
 - **D3**: command の標準結果（`ok`/`exit_code`/`stdout`/`stderr`/`duration`）は Artifact の予約 field。`artifact:` Contract field と単一名前空間に合成し、予約名衝突は load 時 Diagnostic。
 - **D5**: session の permission 許可値は ask/edit/full の現行 3 値のまま。`read` は追加しない。
 - **D6**: `{{ project_name }}` / `{{ path_alias.* }}` / `{{ vars.* }}` / `{{ task }}` / workflow の `variables:` は全廃。template 参照は `{{ request }}` / `{{ <node>.<field> }}` / `{{ item.<field> }}` のみ。

--- a/docs/specs/milestone-82/plan.md
+++ b/docs/specs/milestone-82/plan.md
@@ -15,7 +15,7 @@ https://github.com/siro33950/releash/milestone/82
 | # | 論点 | 決定 |
 |---|---|---|
 | D1 | #1332 の local API | **最小 local API を新設**。Tauri アプリ内に localhost バインドの API サーバ（認証トークン付き）を立て、CLI の start/executions/status/logs/approve/abort/output をこれ経由に移行。file-direct/pending file は必要最小の adapter に縮退。#77-79 のデーモン化の土台。 |
-| D2 | `schemas:` の Contract dialect | **JSON Schema subset を自前実装**。`type`/`properties`/`required`/`items`/`enum`/`additionalProperties` に限定。routing 参照 field は required かつ boolean/enum を load 時 Diagnostic で強制。`request` 用に scalar（string）Contract を許可。配列要素型は inline 不可、名前付き Contract 参照（`items: <名前>`）。 |
+| D2 | `schemas:` の Contract dialect | **JSON Schema subset を自前実装**。`type`/`properties`/`required`/`items`/`enum` に限定し、Object の未宣言 field は常に受理する。routing 参照 field は required かつ boolean/enum を load 時 Diagnostic で強制。`request` 用に scalar（string）Contract を許可。配列要素型は inline 不可、名前付き Contract 参照（`items: <名前>`）。 |
 | D3 | command 標準結果と Artifact | **単一名前空間＋予約 field**。command node の Artifact は常に予約 field `ok`/`exit_code`/`stdout`/`stderr`/`duration` を持ち、`artifact:` Contract の field はそれに合成される。Contract が予約名を宣言したら load 時 Diagnostic。rules の `on:` は `ok` も Contract field も同じ規則で参照。 |
 | D4 | Codex /goal 分割 | **issue 単位で 14 goal**。wave 順（§5）に 1 goal = 1 PR で逐次実行。 |
 | D5 | session `permission` | **現行 3 値（ask/edit/full）のまま**。docs（full-pipeline.yml / syntax doc）の `permission: read` は #1337 の正本化で修正する。 |
@@ -38,7 +38,7 @@ https://github.com/siro33950/releash/milestone/82
 - **P11 (missing-field routing 意味論)**: `when`/`switch` の `on:` が参照する field が実行時に不在（command の artifact validation 失敗等）の場合は no-match とし、catch-all `next` に落ちる。網羅検証は「artifact 検証が失敗しうる node が Contract field を rules で参照する場合、`next` catch-all 必須」を要求する。command の `ok` は `exit_code==0 && (artifact 未指定 || validation 成功)` の合成とする（D3 と併せて #1327/#1328 で実装、#1337 で文書化）。
 - **P12 (workflow start の名前解決)**: `releash workflow start <workflow-name>` は WorkflowDefinition.name で解決する（name↔file の対応は loader が所有、名前重複は Diagnostic）。request 未指定は空文字列の request Artifact とする。
 - **P13 (session の artifact 提出)**: `session` + `artifact:` は Contract 検証済み提出まで node 完了しない（現行 repair 機構を踏襲、max_attempts 超過で失敗）。よって session node は完了時 artifact 存在が保証され、P11 の missing-field は実質 command node のみ。
-- **P14 (NodeExecution のアドレスと fanout leaf、設計検証で追加)**: fanout child は同名 NodeExecution が並走するため、engine 採番の `node_execution_id` を第一級識別子とし、approve / output submit は並走時にこれでアドレスする（session への env `RELEASH_NODE_EXECUTION_ID` 注入で agent 側は通常意識しない）。fanout child は leaf 専用（通常遷移の対象・entry になれない、fanout の入れ子不可 = WFC006）。child の Artifact は親 fanout の配列にのみ格納し node 名 map に載せない。明示 stop は typed command（`StopExecution`）として #1335 で追加。`additionalProperties` の既定は JSON Schema と同じ true。詳細は design.md §5/§6 R7/§8.5。
+- **P14 (NodeExecution のアドレスと fanout leaf、設計検証で追加)**: fanout child は同名 NodeExecution が並走するため、engine 採番の `node_execution_id` を第一級識別子とし、approve / output submit は並走時にこれでアドレスする（session への env `RELEASH_NODE_EXECUTION_ID` 注入で agent 側は通常意識しない）。fanout child は leaf 専用（通常遷移の対象・entry になれない、fanout の入れ子不可 = WFC006）。child の Artifact は親 fanout の配列にのみ格納し node 名 map に載せない。明示 stop は typed command（`StopExecution`）として #1335 で追加。詳細は design.md §5/§6 R7/§8.5。
 - **P15 (domain read model と Workspace UI projection の分離)**: WorkflowExecution / NodeExecution / Fanout は engine・event log・CLI/API の正規 read modelとして維持する。Rust が `Node | Workflow | Fanout` の再帰 tree summary と選択 Node detail に投影し、NodeExecutionの発生順を実行occurrenceの並びとして保持する。同じ定義Nodeのretry/loopもoccurrenceごとに別行とし、各行には後続occurrenceの追加で変化しないopaque IDを割り当てる。attempt / fanout 座標 / 内部 ID は UI に露出しない（#1454）。
 
 ## 3.5 実装原則（最優先）

--- a/docs/workflow-yaml-syntax.md
+++ b/docs/workflow-yaml-syntax.md
@@ -170,7 +170,6 @@ String はそのまま、それ以外の値は JSON serialize して置き換え
 - `required`
 - `items`
 - `enum`
-- `additionalProperties`
 
 対応する型は `object` / `array` / `string` / `boolean` / `integer` / `number`。`string` Contract は scalar `string` としても宣言できる。subset 外の keyword は受理しない。
 
@@ -187,7 +186,6 @@ schemas:
         type: string
         enum: [SHIP, HOLD]
     required: [path, approved, verdict]
-    additionalProperties: false
 
   work_items:
     type: array
@@ -199,7 +197,7 @@ schemas:
 - 配列の `items` は inline schema ではなく、同じ `schemas` 内の名前付き Contract を参照する。
 - `required` の各 field は `properties` に存在しなければならない。
 - `string` の `enum` は一つ以上の文字列を持つ。
-- `additionalProperties` の既定値は `true`。閉じた Object が必要な場合だけ `false` を明示する。
+- Object の `properties` にない field も受理する。`properties` は宣言済み field の型検証に使い、未宣言 field を拒否する設定は持たない。
 - routing が参照する Contract field は、`properties` への宣言に加えて **`required` に含まれていなければならない**。`when.on` は required boolean、`switch.on` は required string enum に限る。
 - command の予約 field `ok` は Contract 宣言なしで常に boolean routing field として使える。
 

--- a/src-tauri/src/adaptor/controller/api/mod.rs
+++ b/src-tauri/src/adaptor/controller/api/mod.rs
@@ -426,8 +426,7 @@ pub(crate) mod test_support {
                                 "properties": {
                                     "status": {"type": "string"}
                                 },
-                                "required": ["status"],
-                                "additionalProperties": false
+                                "required": ["status"]
                             }
                         },
                         "nodes": [{

--- a/src-tauri/src/adaptor/gateway/workflow/builtin.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin.rs
@@ -883,6 +883,7 @@ mod tests {
                     "00000000-0000-0000-0000-000000000000",
                     Some(TASK_TEXT),
                     &artifacts,
+                    &wf.schemas,
                 )
                 .expect("build_node_prompt must succeed");
                 for input in &node.inputs {
@@ -922,6 +923,7 @@ mod tests {
                     "00000000-0000-0000-0000-000000000000",
                     Some("issues-123"),
                     &HashMap::new(),
+                    &wf.schemas,
                 )
                 .expect("build_node_prompt must succeed");
 
@@ -971,6 +973,7 @@ mod tests {
             "00000000-0000-0000-0000-000000000000",
             Some(&evil),
             &HashMap::new(),
+            &wf.schemas,
         )
         .expect("build_node_prompt must succeed");
 

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_claude.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_claude.yml
@@ -8,7 +8,6 @@ schemas:
       spec_dir: string
     required:
     - spec_dir
-    additionalProperties: false
 nodes:
 - name: write_requirements
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_codex.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_codex.yml
@@ -8,7 +8,6 @@ schemas:
       spec_dir: string
     required:
     - spec_dir
-    additionalProperties: false
 nodes:
 - name: write_requirements
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_draft.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/01_authoring_draft.yml
@@ -8,7 +8,6 @@ schemas:
       spec_dir: string
     required:
     - spec_dir
-    additionalProperties: false
 nodes:
 - name: write_requirements
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement_claude.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement_claude.yml
@@ -14,7 +14,6 @@ schemas:
     required:
     - verdict
     - summary
-    additionalProperties: false
 nodes:
 - name: implement
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement_codex.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement_codex.yml
@@ -14,7 +14,6 @@ schemas:
     required:
     - verdict
     - summary
-    additionalProperties: false
 nodes:
 - name: implement
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/04_review-fix-policy.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/04_review-fix-policy.yml
@@ -14,7 +14,6 @@ schemas:
     required:
     - verdict
     - summary
-    additionalProperties: false
 nodes:
 - name: decide_policy
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix.yml
@@ -29,7 +29,6 @@ schemas:
     - problem
     - expected
     - actual
-    additionalProperties: false
   review-fix-tasks:
     type: object
     properties:
@@ -46,7 +45,6 @@ schemas:
     - verdict
     - tasks
     - summary
-    additionalProperties: false
 nodes:
 - name: check_and_make_tasks
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix_claude.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix_claude.yml
@@ -29,7 +29,6 @@ schemas:
     - problem
     - expected
     - actual
-    additionalProperties: false
   review-fix-tasks:
     type: object
     properties:
@@ -46,7 +45,6 @@ schemas:
     - verdict
     - tasks
     - summary
-    additionalProperties: false
 nodes:
 - name: check_and_make_tasks
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix_codex.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix_codex.yml
@@ -29,7 +29,6 @@ schemas:
     - problem
     - expected
     - actual
-    additionalProperties: false
   review-fix-tasks:
     type: object
     properties:
@@ -46,7 +45,6 @@ schemas:
     - verdict
     - tasks
     - summary
-    additionalProperties: false
 nodes:
 - name: check_and_make_tasks
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/06_verify-review-comments.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/06_verify-review-comments.yml
@@ -29,7 +29,6 @@ schemas:
     - problem
     - expected
     - actual
-    additionalProperties: false
   review-fix-tasks:
     type: object
     properties:
@@ -46,7 +45,6 @@ schemas:
     - verdict
     - tasks
     - summary
-    additionalProperties: false
 nodes:
 - name: import_pr_review_comments
   session:

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -2244,7 +2244,6 @@ nodes:
                 SchemaDef::Object {
                     properties: Default::default(),
                     required: Default::default(),
-                    additional_properties: false,
                 },
             )]
             .into_iter()
@@ -2678,7 +2677,6 @@ nodes:
                 SchemaDef::Object {
                     properties: Default::default(),
                     required: Default::default(),
-                    additional_properties: false,
                 },
             )]
             .into_iter()
@@ -2732,7 +2730,6 @@ nodes:
                         .into_iter()
                         .collect(),
                     required: ["path".to_string()].into_iter().collect(),
-                    additional_properties: false,
                 },
             )]
             .into_iter()

--- a/src-tauri/src/adaptor/gateway/workflow/domain_mapping.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/domain_mapping.rs
@@ -267,14 +267,12 @@ pub(crate) fn schema_def_to_domain(schema: &schema::SchemaDef) -> domain::Schema
         schema::SchemaDef::Object {
             properties,
             required,
-            additional_properties,
         } => domain::SchemaDef::Object {
             properties: properties
                 .iter()
                 .map(|(name, schema)| (name.clone(), schema_def_to_domain(schema)))
                 .collect(),
             required: required.clone(),
-            additional_properties: *additional_properties,
         },
         schema::SchemaDef::Array { items } => domain::SchemaDef::Array {
             items: items.clone(),

--- a/src-tauri/src/adaptor/gateway/workflow/facet.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/facet.rs
@@ -858,6 +858,7 @@ mod tests {
             "execution-1",
             task,
             &std::collections::HashMap::new(),
+            &std::collections::BTreeMap::new(),
         )
         .expect("prompt rendering");
         let rendered_instruction = prompt_rendering::render_node_workflow_instruction(

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC002_multiple-discriminators.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC002_multiple-discriminators.yml
@@ -14,7 +14,6 @@ schemas:
     required:
       - passed
       - decision
-    additionalProperties: false
 nodes:
   - name: judge
     artifact: verdict

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC003_exhaustive-switch-with-next.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC003_exhaustive-switch-with-next.yml
@@ -8,7 +8,6 @@ schemas:
         type: string
         enum: [SHIP, HOLD]
     required: [verdict]
-    additionalProperties: false
 nodes:
   - name: judge
     artifact: route

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC004_switch-missing-cases.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFC004_switch-missing-cases.yml
@@ -11,7 +11,6 @@ schemas:
           - fix
     required:
       - decision
-    additionalProperties: false
 nodes:
   - name: judge
     artifact: verdict

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR003_fanout-child-artifact-ref.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR003_fanout-child-artifact-ref.yml
@@ -7,7 +7,6 @@ schemas:
       verdict:
         type: string
     required: [verdict]
-    additionalProperties: false
 nodes:
   - name: fanout
     fanout:

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR003_invalid-fanout-items-ref.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR003_invalid-fanout-items-ref.yml
@@ -7,7 +7,6 @@ schemas:
       values:
         type: string
     required: [values]
-    additionalProperties: false
   target:
     type: string
 nodes:

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT001_when-on-enum.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT001_when-on-enum.yml
@@ -11,7 +11,6 @@ schemas:
           - retry
     required:
       - decision
-    additionalProperties: false
 nodes:
   - name: judge
     artifact: verdict

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT001_when-on-optional-boolean.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT001_when-on-optional-boolean.yml
@@ -6,7 +6,6 @@ schemas:
     properties:
       passed:
         type: boolean
-    additionalProperties: false
 nodes:
   - name: judge
     artifact: verdict

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT002_switch-on-boolean.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT002_switch-on-boolean.yml
@@ -8,7 +8,6 @@ schemas:
         type: boolean
     required:
       - passed
-    additionalProperties: false
 nodes:
   - name: judge
     artifact: verdict

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT002_switch-on-optional-enum.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT002_switch-on-optional-enum.yml
@@ -7,7 +7,6 @@ schemas:
       decision:
         type: string
         enum: [done, fix]
-    additionalProperties: false
 nodes:
   - name: judge
     artifact: verdict

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT005_reserved-artifact-field.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT005_reserved-artifact-field.yml
@@ -8,7 +8,6 @@ schemas:
         type: boolean
     required:
       - ok
-    additionalProperties: false
 nodes:
   - name: build
     artifact: output

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT006_fanout-discriminator.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFT006_fanout-discriminator.yml
@@ -8,7 +8,6 @@ schemas:
         type: boolean
     required:
       - passed
-    additionalProperties: false
 nodes:
   - name: fanout
     artifact: verdict

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/canonical-syntax-surface.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/canonical-syntax-surface.yml
@@ -16,7 +16,6 @@ schemas:
         type: array
         items: text
     required: [path, enabled, count, ratio, labels]
-    additionalProperties: false
   target-list:
     type: object
     properties:
@@ -24,7 +23,6 @@ schemas:
         type: array
         items: target
     required: [targets]
-    additionalProperties: false
   route:
     type: object
     properties:
@@ -32,7 +30,6 @@ schemas:
         type: string
         enum: [SHIP, HOLD]
     required: [verdict]
-    additionalProperties: false
 nodes:
   - name: prepare
     command: "printf '%s' '{{ request }}'"

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-command-reducer.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-command-reducer.yml
@@ -7,14 +7,12 @@ schemas:
       lgtm:
         type: boolean
     required: [lgtm]
-    additionalProperties: false
   judge-result:
     type: object
     properties:
       all_lgtm:
         type: boolean
     required: [all_lgtm]
-    additionalProperties: false
 nodes:
   - name: review
     fanout:

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-items-matrix.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-items-matrix.yml
@@ -7,7 +7,6 @@ schemas:
       path:
         type: string
     required: [path]
-    additionalProperties: false
 nodes:
   - name: fanout
     fanout:

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-items-reference.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-items-reference.yml
@@ -10,7 +10,6 @@ schemas:
         type: array
         items: target
     required: [targets]
-    additionalProperties: false
 nodes:
   - name: source
     artifact: source-output

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-session-reducer.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/fanout-session-reducer.yml
@@ -7,7 +7,6 @@ schemas:
       lgtm:
         type: boolean
     required: [lgtm]
-    additionalProperties: false
   review-decision:
     type: object
     properties:
@@ -15,7 +14,6 @@ schemas:
         type: string
         enum: [READY, NEEDS_FIX]
     required: [verdict]
-    additionalProperties: false
 nodes:
   - name: review
     fanout:

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/routed-switch.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/valid/routed-switch.yml
@@ -11,7 +11,6 @@ schemas:
           - retry
     required:
       - decision
-    additionalProperties: false
 nodes:
   - name: judge
     artifact: verdict

--- a/src-tauri/src/adaptor/gateway/workflow/mapper.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/mapper.rs
@@ -269,14 +269,12 @@ fn domain_schema_to_schema(
         domain::SchemaDef::Object {
             properties,
             required,
-            additional_properties,
         } => crate::adaptor::gateway::workflow::schema::SchemaDef::Object {
             properties: properties
                 .iter()
                 .map(|(name, schema)| (name.clone(), domain_schema_to_schema(schema)))
                 .collect(),
             required: required.clone(),
-            additional_properties: *additional_properties,
         },
         domain::SchemaDef::Array { items } => {
             crate::adaptor::gateway::workflow::schema::SchemaDef::Array {
@@ -473,7 +471,6 @@ mod tests {
                 domain::SchemaDef::Object {
                     properties: Default::default(),
                     required: Default::default(),
-                    additional_properties: false,
                 },
             )]
             .into_iter()
@@ -503,8 +500,7 @@ mod tests {
                 "builtin": false,
                 "schemas": {
                     "plan": {
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                     }
                 },
                 "nodes": [{

--- a/src-tauri/src/adaptor/gateway/workflow/output_submission.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/output_submission.rs
@@ -389,7 +389,6 @@ mod tests {
                 SchemaDef::Object {
                     properties: Default::default(),
                     required: Default::default(),
-                    additional_properties: false,
                 },
             )]
             .into_iter()
@@ -683,7 +682,6 @@ mod tests {
                     required: ["spec_dir".to_string(), "design".to_string()]
                         .into_iter()
                         .collect(),
-                    additional_properties: false,
                 },
             )]
             .into_iter()
@@ -720,7 +718,13 @@ mod tests {
             let validated = validate_submission_output_with_secrets(
                 &workflow,
                 "spec-directory",
-                serde_json::json!({"spec_dir": "docs/specs/issues-1327"}),
+                serde_json::json!({
+                    "spec_dir": "docs/specs/issues-1327",
+                    "spec_id": "issues-1327",
+                    "files": ["docs/specs/issues-1327/requirements.md"],
+                    "related_issue": 1327,
+                    "open_questions_resolved": true
+                }),
                 &[],
             )
             .unwrap();

--- a/src-tauri/src/adaptor/gateway/workflow/prompt_rendering.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/prompt_rendering.rs
@@ -1,11 +1,13 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde_json::Value;
 
+use crate::adaptor::gateway::workflow::domain_mapping::workflow_schemas_to_domain;
 use crate::adaptor::gateway::workflow::engine_error::WorkflowEngineError;
 use crate::adaptor::gateway::workflow::facet::FacetContents;
-use crate::adaptor::gateway::workflow::schema::NodeDefinition;
+use crate::adaptor::gateway::workflow::schema::{NodeDefinition, SchemaDef};
 use crate::adaptor::gateway::workflow::state::RuntimeArtifact;
+use crate::domain::workflow::services::contract as workflow_contract;
 use crate::domain::workflow::services::reference::{
     self, resolve_runtime_reference, REQUEST_ARTIFACT,
 };
@@ -172,6 +174,7 @@ pub(crate) fn render_fanout_child_workflow_instruction(
 pub(crate) fn append_artifact_completion_action(
     prompt: &mut String,
     artifact: Option<&str>,
+    schemas: &BTreeMap<String, SchemaDef>,
     execution_id: &str,
     node_name: &str,
     node_execution_id: Option<&str>,
@@ -179,6 +182,9 @@ pub(crate) fn append_artifact_completion_action(
     let Some(contract) = artifact else {
         return;
     };
+    let domain_schemas = workflow_schemas_to_domain(schemas);
+    let schema_guidance =
+        workflow_contract::render_contract_prompt_guidance(&domain_schemas, contract);
     let action = crate::adaptor::gateway::workflow::facet::artifact_completion_action(
         contract,
         execution_id,
@@ -186,6 +192,10 @@ pub(crate) fn append_artifact_completion_action(
         node_execution_id,
     );
     if !prompt.is_empty() {
+        prompt.push_str("\n\n");
+    }
+    if let Some(schema_guidance) = schema_guidance {
+        prompt.push_str(&schema_guidance);
         prompt.push_str("\n\n");
     }
     prompt.push_str(&action);
@@ -197,6 +207,7 @@ pub(crate) fn build_node_prompt(
     execution_id: &str,
     request: Option<&str>,
     artifacts: &HashMap<String, RuntimeArtifact>,
+    schemas: &BTreeMap<String, SchemaDef>,
 ) -> Result<(Option<String>, String), WorkflowEngineError> {
     if !node.has_facet_refs() {
         return Err(WorkflowEngineError::InvalidWorkflow(format!(
@@ -222,11 +233,27 @@ pub(crate) fn build_node_prompt(
     append_artifact_completion_action(
         &mut prompt,
         node.artifact.as_deref(),
+        schemas,
         execution_id,
         &node.name,
         None,
     );
     Ok((system_prompt, prompt))
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FanoutChildPromptContext<'a> {
+    item: Option<&'a Value>,
+    node_execution_id: &'a str,
+}
+
+impl<'a> FanoutChildPromptContext<'a> {
+    pub(crate) fn new(item: Option<&'a Value>, node_execution_id: &'a str) -> Self {
+        Self {
+            item,
+            node_execution_id,
+        }
+    }
 }
 
 pub(crate) fn build_fanout_child_prompt(
@@ -235,8 +262,8 @@ pub(crate) fn build_fanout_child_prompt(
     execution_id: &str,
     request: Option<&str>,
     artifacts: &HashMap<String, RuntimeArtifact>,
-    item: Option<&Value>,
-    node_execution_id: &str,
+    context: FanoutChildPromptContext<'_>,
+    schemas: &BTreeMap<String, SchemaDef>,
 ) -> Result<(Option<String>, String), WorkflowEngineError> {
     if node.has_facet_refs() && facet_contents.is_none_or(FacetContents::is_empty) {
         return Err(WorkflowEngineError::InvalidWorkflow(format!(
@@ -249,16 +276,17 @@ pub(crate) fn build_fanout_child_prompt(
     let composed = crate::adaptor::gateway::workflow::facet::compose_facets(facet_contents);
     let system_prompt = composed
         .system_prompt
-        .map(|content| render_prompt_content(&content, &artifacts, item));
-    let rendered_user = render_prompt_content(&composed.user_message, &artifacts, item);
+        .map(|content| render_prompt_content(&content, &artifacts, context.item));
+    let rendered_user = render_prompt_content(&composed.user_message, &artifacts, context.item);
     let rendered_user = inject_input_artifacts(&rendered_user, &node.inputs, &artifacts);
-    let mut user_message = inject_fanout_item(&rendered_user, node.input.as_deref(), item);
+    let mut user_message = inject_fanout_item(&rendered_user, node.input.as_deref(), context.item);
     append_artifact_completion_action(
         &mut user_message,
         node.artifact.as_deref(),
+        schemas,
         execution_id,
         &node.name,
-        Some(node_execution_id),
+        Some(context.node_execution_id),
     );
 
     Ok((system_prompt, user_message))
@@ -310,8 +338,15 @@ mod tests {
             ..NodeDefinition::default()
         };
 
-        let error = build_node_prompt(&node, None, "execution-1", None, &HashMap::new())
-            .expect_err("node without facet refs must be rejected");
+        let error = build_node_prompt(
+            &node,
+            None,
+            "execution-1",
+            None,
+            &HashMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect_err("node without facet refs must be rejected");
 
         assert!(matches!(
             error,
@@ -345,6 +380,7 @@ mod tests {
             "execution-1",
             Some("ship"),
             &outputs,
+            &BTreeMap::new(),
         )
         .unwrap();
 
@@ -373,8 +409,15 @@ mod tests {
             },
         )]);
 
-        let (_system, prompt) =
-            build_node_prompt(&node, Some(&resolved), "execution-1", Some(""), &outputs).unwrap();
+        let (_system, prompt) = build_node_prompt(
+            &node,
+            Some(&resolved),
+            "execution-1",
+            Some(""),
+            &outputs,
+            &BTreeMap::new(),
+        )
+        .unwrap();
 
         assert!(prompt.contains("Spec dir: docs/specs/foo"));
     }
@@ -392,8 +435,8 @@ mod tests {
             "execution-1",
             None,
             &HashMap::new(),
-            Some(&item),
-            "node-execution-1",
+            FanoutChildPromptContext::new(Some(&item), "node-execution-1"),
+            &BTreeMap::new(),
         )
         .unwrap();
 
@@ -429,8 +472,8 @@ mod tests {
             "execution-1",
             Some("ship"),
             &outputs,
-            Some(&item),
-            "node-execution-1",
+            FanoutChildPromptContext::new(Some(&item), "node-execution-1"),
+            &BTreeMap::new(),
         )
         .unwrap();
 
@@ -449,10 +492,29 @@ mod tests {
         node.artifact = Some("review-result".to_string());
         let resolved = instruction_contents("Review the change.");
 
-        let (_system, prompt) =
-            build_node_prompt(&node, Some(&resolved), "execution-1", None, &HashMap::new())
-                .unwrap();
+        let schemas = BTreeMap::from([(
+            "review-result".to_string(),
+            SchemaDef::Object {
+                properties: BTreeMap::from([(
+                    "verdict".to_string(),
+                    SchemaDef::String { r#enum: None },
+                )]),
+                required: ["verdict".to_string()].into_iter().collect(),
+            },
+        )]);
+        let (_system, prompt) = build_node_prompt(
+            &node,
+            Some(&resolved),
+            "execution-1",
+            None,
+            &HashMap::new(),
+            &schemas,
+        )
+        .unwrap();
 
+        assert!(prompt.contains("## Artifact contract"));
+        assert!(prompt.contains("\"verdict\": \"string\""));
+        assert!(prompt.contains("Fields not listed in `properties` are accepted"));
         assert!(prompt.contains("releash workflow output submit execution-1"));
         assert!(prompt.contains("--node review"));
         assert!(prompt.contains("--type review-result"));
@@ -475,8 +537,8 @@ mod tests {
             "execution-1",
             None,
             &HashMap::new(),
-            Some(&item),
-            "node-execution-1",
+            FanoutChildPromptContext::new(Some(&item), "node-execution-1"),
+            &BTreeMap::new(),
         )
         .unwrap();
 

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
@@ -3622,6 +3622,13 @@ impl WorkflowRuntimeService {
         let cli_alias = crate::infrastructure::platform::path_aliases::alias_name_for_profile(
             crate::infrastructure::platform::path_aliases::BuildProfile::current(),
         );
+        let schemas = {
+            let executions = self.executions.lock().await;
+            let execution = executions
+                .get(execution_id)
+                .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(execution_id.to_string()))?;
+            workflow_schemas_to_domain(&execution.workflow.schemas)
+        };
         let prompt = match (violation, schema_violations) {
             (SubmissionViolation::InvalidSubmitOutput, Some(violations)) => {
                 workflow_contract::build_schema_violation_repair_prompt(
@@ -3630,6 +3637,7 @@ impl WorkflowRuntimeService {
                     node_name,
                     contract,
                     violations,
+                    &schemas,
                 )
             }
             _ => workflow_contract::build_missing_artifact_repair_prompt(
@@ -3637,6 +3645,7 @@ impl WorkflowRuntimeService {
                 execution_id,
                 node_name,
                 contract,
+                &schemas,
             ),
         };
         let permission_mode = PermissionMode::parse_canonical(&session.permission_mode)
@@ -5083,6 +5092,7 @@ impl WorkflowRuntimeService {
             &execution_id_for_ref,
             task_clone.as_deref(),
             &artifacts_clone,
+            &workflow_clone.schemas,
         )?;
         let workflow_instruction = workflow_prompt::render_node_workflow_instruction(
             &node_clone,
@@ -5202,6 +5212,7 @@ impl WorkflowRuntimeService {
             execution_id,
             request,
             artifacts,
+            &BTreeMap::new(),
         )?;
         dispatch_session_start(
             gate,
@@ -5802,6 +5813,7 @@ impl WorkflowRuntimeService {
             &fanout_start,
             &prompt_inputs,
             &facet_contents,
+            &workflow_for_facets.schemas,
         )
         .await?;
 

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -589,7 +589,6 @@ fn object_schema_for_test(fields: &[&str]) -> SchemaDef {
             .map(|field| (field.to_string(), SchemaDef::String { r#enum: None }))
             .collect(),
         required: fields.iter().map(|field| field.to_string()).collect(),
-        additional_properties: false,
     }
 }
 
@@ -1803,7 +1802,6 @@ fn bool_object_schema(field: &str) -> SchemaDef {
             .into_iter()
             .collect(),
         required: [field.to_string()].into_iter().collect(),
-        additional_properties: true,
     }
 }
 
@@ -1818,7 +1816,6 @@ fn enum_object_schema(field: &str, values: &[&str]) -> SchemaDef {
         .into_iter()
         .collect(),
         required: [field.to_string()].into_iter().collect(),
-        additional_properties: true,
     }
 }
 
@@ -2730,6 +2727,7 @@ fn approved_policy_injected_output_uses_sanitized_contract_payload_without_globa
         "execution-1",
         None,
         &outputs,
+        &BTreeMap::new(),
     )
     .unwrap();
     assert!(prompt.contains("[REDACTED]"));
@@ -2799,6 +2797,7 @@ fn approved_policy_masks_raw_secrets_before_state_variables_history_and_injectio
         "execution-1",
         None,
         &exec.artifacts,
+        &exec.workflow.schemas,
     )
     .unwrap();
     assert!(prompt.contains("[REDACTED]"));
@@ -2953,6 +2952,7 @@ fn build_node_prompt_full_pipeline() {
         "00000000-0000-0000-0000-000000000000",
         Some("Fix bug"),
         &outputs,
+        &BTreeMap::new(),
     )
     .unwrap();
 
@@ -2998,6 +2998,7 @@ fn build_node_prompt_no_facet_refs_returns_error() {
         "00000000-0000-0000-0000-000000000000",
         None,
         &HashMap::new(),
+        &BTreeMap::new(),
     );
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -3022,6 +3023,7 @@ fn build_node_prompt_policy_only_system_prompt_set() {
         "00000000-0000-0000-0000-000000000000",
         None,
         &HashMap::new(),
+        &BTreeMap::new(),
     )
     .unwrap();
 
@@ -3053,6 +3055,7 @@ fn build_node_prompt_passes_composed_system_prompt_through() {
         "00000000-0000-0000-0000-000000000000",
         None,
         &HashMap::new(),
+        &BTreeMap::new(),
     )
     .unwrap();
 
@@ -3116,6 +3119,7 @@ fn build_node_prompt_expands_artifact_field_references_in_user_message() {
         "00000000-0000-0000-0000-000000000000",
         Some("implement the authored spec"),
         &outputs,
+        &BTreeMap::new(),
     )
     .unwrap();
     let instruction = workflow_prompt::render_node_workflow_instruction(
@@ -3253,6 +3257,7 @@ async fn dispatch_session_start_passes_composed_system_prompt_to_gate() {
         "00000000-0000-0000-0000-000000000000",
         None,
         &HashMap::new(),
+        &BTreeMap::new(),
     )
     .unwrap();
 
@@ -3375,6 +3380,7 @@ async fn dispatch_session_start_passes_none_when_no_facets() {
         "00000000-0000-0000-0000-000000000000",
         None,
         &HashMap::new(),
+        &BTreeMap::new(),
     )
     .unwrap();
 
@@ -3937,8 +3943,11 @@ fn build_fanout_child_prompt_splits_facets_into_system_and_user() {
         "11111111-1111-1111-1111-111111111111",
         None,
         &HashMap::new(),
-        None,
-        "22222222-2222-4222-8222-222222222222",
+        workflow_prompt::FanoutChildPromptContext::new(
+            None,
+            "22222222-2222-4222-8222-222222222222",
+        ),
+        &BTreeMap::new(),
     )
     .unwrap();
 
@@ -3989,8 +3998,11 @@ fn build_fanout_child_prompt_no_policy_or_contract_returns_none_system_prompt() 
         "11111111-1111-1111-1111-111111111111",
         None,
         &HashMap::new(),
-        None,
-        "22222222-2222-4222-8222-222222222222",
+        workflow_prompt::FanoutChildPromptContext::new(
+            None,
+            "22222222-2222-4222-8222-222222222222",
+        ),
+        &BTreeMap::new(),
     )
     .unwrap();
 
@@ -11449,6 +11461,7 @@ mod dispatch_boundary_tests {
             "session-reducer-execution",
             None,
             &outputs,
+            &BTreeMap::new(),
         )
         .unwrap();
         assert!(prompt.contains("## input: review"));

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
@@ -1,5 +1,8 @@
 use std::sync::Arc;
-use std::{collections::HashMap, path::Path};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::Path,
+};
 
 use tokio::sync::Mutex;
 
@@ -16,6 +19,7 @@ use crate::adaptor::gateway::workflow::node_settings::{
 };
 use crate::adaptor::gateway::workflow::prompt_rendering as workflow_prompt;
 use crate::adaptor::gateway::workflow::runtime_state::{SessionWorkflowRef, WorkflowExecution};
+use crate::adaptor::gateway::workflow::schema::SchemaDef;
 use crate::adaptor::gateway::workflow::state::RuntimeCommitSnapshot;
 use crate::domain::agent_session::PermissionMode;
 use crate::domain::workflow::{
@@ -284,9 +288,10 @@ pub(crate) async fn prepare_fanout_child_session_setups<R: tauri::Runtime>(
     fanout_start: &FanoutStartContext,
     prompt_inputs: &FanoutPromptInputs,
     facet_contents: &WorkflowFacetContents,
+    schemas: &BTreeMap<String, SchemaDef>,
 ) -> Result<Vec<FanoutChildSessionSetup>, WorkflowEngineError> {
     let prompt_plans =
-        prepare_fanout_child_prompt_plans(fanout_start, prompt_inputs, facet_contents)?;
+        prepare_fanout_child_prompt_plans(fanout_start, prompt_inputs, facet_contents, schemas)?;
     let creation_plans = prepare_fanout_child_creation_plans(registry, fanout_start, prompt_plans)?;
     let data_dir = crate::infrastructure::platform::app_data_dir::resolve_data_dir(app)
         .map_err(|e| WorkflowEngineError::SessionStore(format!("resolve_data_dir: {e}")))?;
@@ -365,6 +370,7 @@ fn prepare_fanout_child_prompt_plans(
     fanout_start: &FanoutStartContext,
     prompt_inputs: &FanoutPromptInputs,
     facet_contents: &WorkflowFacetContents,
+    schemas: &BTreeMap<String, SchemaDef>,
 ) -> Result<Vec<FanoutChildPromptPlan>, WorkflowEngineError> {
     fanout_start
         .children
@@ -378,8 +384,11 @@ fn prepare_fanout_child_prompt_plans(
                 &fanout_start.execution_id,
                 fanout_start.request.as_deref(),
                 &prompt_inputs.artifacts,
-                child.item.as_ref(),
-                &child.node_execution_id,
+                workflow_prompt::FanoutChildPromptContext::new(
+                    child.item.as_ref(),
+                    &child.node_execution_id,
+                ),
+                schemas,
             )?;
             Ok(FanoutChildPromptPlan {
                 expansion_index,
@@ -994,6 +1003,7 @@ mod tests {
             &fanout_start,
             &prompt_inputs,
             &WorkflowFacetContents::default(),
+            &exec.workflow.schemas,
         )
         .unwrap();
 

--- a/src-tauri/src/adaptor/gateway/workflow/schema.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/schema.rs
@@ -12,7 +12,6 @@ pub enum SchemaDef {
     Object {
         properties: BTreeMap<String, SchemaDef>,
         required: BTreeSet<String>,
-        additional_properties: bool,
     },
     Array {
         items: String,
@@ -54,14 +53,12 @@ fn schema_def_from_domain(schema: domain_workflow::SchemaDef) -> SchemaDef {
         domain_workflow::SchemaDef::Object {
             properties,
             required,
-            additional_properties,
         } => SchemaDef::Object {
             properties: properties
                 .into_iter()
                 .map(|(name, schema)| (name, schema_def_from_domain(schema)))
                 .collect(),
             required,
-            additional_properties,
         },
         domain_workflow::SchemaDef::Array { items } => SchemaDef::Array { items },
         domain_workflow::SchemaDef::String { r#enum } => SchemaDef::String { r#enum },
@@ -998,8 +995,7 @@ nodes:
             serde_json::json!({
                 "type": "object",
                 "properties": {"verdict": {"type": "string", "enum": ["LGTM"]}},
-                "required": ["verdict"],
-                "additionalProperties": false
+                "required": ["verdict"]
             }),
         ] {
             let gateway_schema: SchemaDef = serde_json::from_value(value.clone()).unwrap();
@@ -1023,6 +1019,19 @@ nodes:
         .unwrap_err();
 
         assert!(err.to_string().contains("array schema supports only items"));
+    }
+
+    #[test]
+    fn schemas_reject_retired_additional_properties_keyword() {
+        let err = serde_json::from_value::<SchemaDef>(serde_json::json!({
+            "type": "object",
+            "additionalProperties": false
+        }))
+        .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("object schema supports only properties and required"));
     }
 
     #[test]

--- a/src-tauri/src/cli/output.rs
+++ b/src-tauri/src/cli/output.rs
@@ -263,7 +263,6 @@ mod tests {
                         SchemaDef::String { r#enum: None },
                     )]),
                     required: BTreeSet::from(["verdict".to_string()]),
-                    additional_properties: false,
                 },
             )]),
             nodes: vec![NodeDefinition {

--- a/src-tauri/src/domain/workflow/services/contract.rs
+++ b/src-tauri/src/domain/workflow/services/contract.rs
@@ -60,15 +60,40 @@ pub fn validate_artifact_value(
     }
 }
 
+pub fn render_contract_prompt_guidance(
+    schemas: &BTreeMap<String, SchemaDef>,
+    contract: &str,
+) -> Option<String> {
+    let schema = schemas.get(contract)?;
+    let schema_json =
+        serde_json::to_string_pretty(&contract_schema::schema_def_to_json_value(schema))
+            .unwrap_or_else(|_| "null".to_string());
+    let additional_fields_guidance = matches!(schema, SchemaDef::Object { .. })
+        .then_some("\nFields not listed in `properties` are accepted, but omit fields that downstream nodes do not need.")
+        .unwrap_or_default();
+
+    Some(format!(
+        "## Artifact contract\n\n\
+The `--json` argument must be a JSON value matching the `{contract}` schema below. The schema itself is not the value to submit.\n\n\
+```json\n{schema_json}\n\
+```\
+{additional_fields_guidance}"
+    ))
+}
+
 pub fn build_missing_artifact_repair_prompt(
     cli_alias: &str,
     execution_id: &str,
     node_name: &str,
     contract: &str,
+    schemas: &BTreeMap<String, SchemaDef>,
 ) -> String {
+    let schema_guidance = render_contract_prompt_guidance(schemas, contract)
+        .map(|guidance| format!("\n\n{guidance}"))
+        .unwrap_or_default();
     format!(
         "The required Artifact for this workflow node has not been submitted.\n\n\
-Submit it by running this command with a JSON value that satisfies the `{contract}` schema:\n\n\
+Submit it by running this command with a JSON value that satisfies the `{contract}` schema:{schema_guidance}\n\n\
 ```sh\n\
 {cli_alias} workflow output submit {execution_id} \\\n  --node {node_name} \\\n  --type {contract} \\\n  --json '{{...}}'\n\
 ```\n\n\
@@ -82,11 +107,15 @@ pub fn build_schema_violation_repair_prompt(
     node_name: &str,
     contract: &str,
     violations: &[SchemaViolation],
+    schemas: &BTreeMap<String, SchemaDef>,
 ) -> String {
     let details = format_schema_violations(violations);
+    let schema_guidance = render_contract_prompt_guidance(schemas, contract)
+        .map(|guidance| format!("\n\n{guidance}"))
+        .unwrap_or_default();
     format!(
         "The submitted Artifact did not satisfy the `{contract}` schema.\n\n\
-Schema violations:\n{details}\n\n\
+Schema violations:\n{details}{schema_guidance}\n\n\
 Submit a corrected Artifact with:\n\n\
 ```sh\n\
 {cli_alias} workflow output submit {execution_id} \\\n  --node {node_name} \\\n  --type {contract} \\\n  --json '{{...}}'\n\
@@ -132,7 +161,6 @@ mod contract_service_tests {
                         },
                     )]),
                     required: BTreeSet::from(["verdict".to_string()]),
-                    additional_properties: true,
                 },
             )]),
             nodes: vec![
@@ -203,10 +231,18 @@ mod contract_service_tests {
 
     #[test]
     fn test_missing_artifact_repair_prompt_uses_schema_vocabulary_and_node_flag() {
-        let prompt =
-            build_missing_artifact_repair_prompt("releash-dev", "execution-1", "review", "review");
+        let workflow = workflow();
+        let prompt = build_missing_artifact_repair_prompt(
+            "releash-dev",
+            "execution-1",
+            "review",
+            "review",
+            &workflow.schemas,
+        );
         assert!(prompt.contains("Artifact"));
         assert!(prompt.contains("schema"));
+        assert!(prompt.contains("\"verdict\""));
+        assert!(prompt.contains("Fields not listed in `properties` are accepted"));
         assert!(prompt.contains(
             "```sh\nreleash-dev workflow output submit execution-1 \\\n  --node review \\\n  --type review \\\n  --json '{...}'\n```"
         ));
@@ -217,6 +253,7 @@ mod contract_service_tests {
 
     #[test]
     fn test_schema_violation_repair_prompt_contains_copyable_command() {
+        let workflow = workflow();
         let prompt = build_schema_violation_repair_prompt(
             "releash-dev",
             "execution-1",
@@ -226,15 +263,39 @@ mod contract_service_tests {
                 path: "$.verdict".to_string(),
                 reason: "expected one of [LGTM, FIX]".to_string(),
             }],
+            &workflow.schemas,
         );
 
         assert!(prompt.contains("- $.verdict: expected one of [LGTM, FIX]"));
+        assert!(prompt.contains("\"enum\": ["));
         assert!(prompt.contains(
             "```sh\nreleash-dev workflow output submit execution-1 \\\n  --node review \\\n  --type review \\\n  --json '{...}'\n```"
         ));
         assert!(!prompt.contains("\n+  --"));
         let deprecated_step_flag = ["--", "step"].concat();
         assert!(!prompt.contains(&deprecated_step_flag));
+    }
+
+    #[test]
+    fn test_contract_prompt_guidance_explains_object_schema_and_extra_fields() {
+        let schemas = BTreeMap::from([(
+            "spec-directory".to_string(),
+            SchemaDef::Object {
+                properties: BTreeMap::from([(
+                    "spec_dir".to_string(),
+                    SchemaDef::String { r#enum: None },
+                )]),
+                required: BTreeSet::from(["spec_dir".to_string()]),
+            },
+        )]);
+
+        let guidance = render_contract_prompt_guidance(&schemas, "spec-directory").unwrap();
+
+        assert!(guidance.contains("\"spec_dir\": \"string\""));
+        assert!(guidance.contains("\"required\": ["));
+        assert!(!guidance.contains("additionalProperties"));
+        assert!(guidance.contains("Fields not listed in `properties` are accepted"));
+        assert!(render_contract_prompt_guidance(&schemas, "missing").is_none());
     }
 
     #[test]

--- a/src-tauri/src/domain/workflow/services/contract_schema.rs
+++ b/src-tauri/src/domain/workflow/services/contract_schema.rs
@@ -48,8 +48,8 @@ pub fn schema_def_from_json(value: &Value) -> Result<SchemaDef, String> {
         "object" => {
             reject_schema_keywords(
                 object.keys().map(String::as_str),
-                &["type", "properties", "required", "additionalProperties"],
-                "object schema supports only properties, required, and additionalProperties",
+                &["type", "properties", "required"],
+                "object schema supports only properties and required",
             )?;
             let properties = match object.get("properties") {
                 Some(value) => value
@@ -68,19 +68,9 @@ pub fn schema_def_from_json(value: &Value) -> Result<SchemaDef, String> {
                 Some(value) => parse_string_array(value, "required")?.into_iter().collect(),
                 None => BTreeSet::new(),
             };
-            let additional_properties = object
-                .get("additionalProperties")
-                .map(|value| {
-                    value
-                        .as_bool()
-                        .ok_or_else(|| "additionalProperties must be a boolean".to_string())
-                })
-                .transpose()?
-                .unwrap_or(true);
             Ok(SchemaDef::Object {
                 properties,
                 required,
-                additional_properties,
             })
         }
         "array" => {
@@ -122,7 +112,6 @@ pub fn schema_def_to_json_value(schema: &SchemaDef) -> Value {
         SchemaDef::Object {
             properties,
             required,
-            additional_properties,
         } => {
             let mut object = serde_json::Map::new();
             object.insert("type".to_string(), Value::String("object".to_string()));
@@ -144,9 +133,6 @@ pub fn schema_def_to_json_value(schema: &SchemaDef) -> Value {
                     "required".to_string(),
                     Value::Array(required.iter().cloned().map(Value::String).collect()),
                 );
-            }
-            if !additional_properties {
-                object.insert("additionalProperties".to_string(), Value::Bool(false));
             }
             Value::Object(object)
         }
@@ -244,7 +230,6 @@ fn validate_at(
         SchemaDef::Object {
             properties,
             required,
-            additional_properties,
         } => {
             let Some(object) = value.as_object() else {
                 push(violations, path, "expected object");
@@ -268,17 +253,6 @@ fn validate_at(
                         &format!("{path}.{field}"),
                         violations,
                     );
-                }
-            }
-            if !additional_properties {
-                for field in object.keys() {
-                    if !properties.contains_key(field) {
-                        push(
-                            violations,
-                            &format!("{path}.{field}"),
-                            "additional property not allowed",
-                        );
-                    }
                 }
             }
         }
@@ -391,7 +365,6 @@ mod contract_schema_tests {
         SchemaDef::Object {
             properties,
             required: required.iter().map(|value| (*value).to_string()).collect(),
-            additional_properties: false,
         }
     }
 
@@ -423,7 +396,26 @@ mod contract_schema_tests {
         .unwrap_err();
         assert!(violations.iter().any(|v| v.path == "$.ok"));
         assert!(violations.iter().any(|v| v.path == "$.verdict"));
-        assert!(violations.iter().any(|v| v.path == "$.extra"));
+        assert!(!violations.iter().any(|v| v.path == "$.extra"));
+    }
+
+    #[test]
+    fn test_schema検証_objectは未宣言fieldを受理する() {
+        let schema = object(
+            BTreeMap::from([("spec_dir".to_string(), SchemaDef::String { r#enum: None })]),
+            &["spec_dir"],
+        );
+
+        assert!(validate(
+            &serde_json::json!({
+                "spec_dir": "docs/specs/issues-1469",
+                "spec_id": "issues-1469",
+                "metadata": {"source": "agent"}
+            }),
+            &schema,
+            &BTreeMap::new(),
+        )
+        .is_ok());
     }
 
     #[test]
@@ -503,17 +495,10 @@ mod contract_schema_tests {
         let object_schema = schema_def_from_json(&serde_json::json!({
             "type": "object",
             "properties": {"verdict": {"type": "string", "enum": ["LGTM"]}},
-            "required": ["verdict"],
-            "additionalProperties": false
+            "required": ["verdict"]
         }))
         .unwrap();
-        assert!(matches!(
-            object_schema,
-            SchemaDef::Object {
-                additional_properties: false,
-                ..
-            }
-        ));
+        assert!(matches!(object_schema, SchemaDef::Object { .. }));
     }
 
     #[test]
@@ -537,7 +522,11 @@ mod contract_schema_tests {
             ),
             (
                 serde_json::json!({"type": "object", "items": "x"}),
-                "object schema supports only properties, required, and additionalProperties",
+                "object schema supports only properties and required",
+            ),
+            (
+                serde_json::json!({"type": "object", "additionalProperties": false}),
+                "object schema supports only properties and required",
             ),
             (
                 serde_json::json!({"type": "boolean", "enum": ["yes"]}),
@@ -571,8 +560,7 @@ mod contract_schema_tests {
                 "properties": {
                     "verdict": {"type": "string", "enum": ["LGTM"]}
                 },
-                "required": ["verdict"],
-                "additionalProperties": false
+                "required": ["verdict"]
             })
         );
     }
@@ -591,7 +579,6 @@ mod contract_schema_tests {
                 ("note".to_string(), SchemaDef::String { r#enum: None }),
             ]),
             required: BTreeSet::from(["flag".to_string(), "verdict".to_string()]),
-            additional_properties: true,
         };
         assert_eq!(
             routing_field_kind(&schema, "flag"),

--- a/src-tauri/src/domain/workflow/services/routing.rs
+++ b/src-tauri/src/domain/workflow/services/routing.rs
@@ -635,7 +635,6 @@ mod routing_tests {
         SchemaDef::Object {
             properties: BTreeMap::from([(field.to_string(), SchemaDef::Boolean)]),
             required: BTreeSet::from([field.to_string()]),
-            additional_properties: true,
         }
     }
 
@@ -648,7 +647,6 @@ mod routing_tests {
                 },
             )]),
             required: BTreeSet::from([field.to_string()]),
-            additional_properties: true,
         }
     }
 
@@ -659,7 +657,6 @@ mod routing_tests {
                 .map(|(name, schema)| (name.to_string(), schema))
                 .collect(),
             required: required.iter().map(|value| (*value).to_string()).collect(),
-            additional_properties: true,
         }
     }
 

--- a/src-tauri/src/domain/workflow/services/validation.rs
+++ b/src-tauri/src/domain/workflow/services/validation.rs
@@ -1326,7 +1326,6 @@ mod tests {
                 .map(|field| ((*field).to_string(), SchemaDef::String { r#enum: None }))
                 .collect(),
             required: BTreeSet::new(),
-            additional_properties: false,
         }
     }
 
@@ -1434,7 +1433,6 @@ mod tests {
                 SchemaDef::Object {
                     properties: BTreeMap::from([("ok".to_string(), SchemaDef::Boolean)]),
                     required: BTreeSet::from(["ok".to_string()]),
-                    additional_properties: true,
                 },
             )]),
         );
@@ -1943,7 +1941,6 @@ mod tests {
                             },
                         )]),
                         required: BTreeSet::from(["targets".to_string()]),
-                        additional_properties: false,
                     },
                 ),
                 ("target".to_string(), SchemaDef::String { r#enum: None }),
@@ -2426,7 +2423,6 @@ mod tests {
                 .map(|field| ((*field).to_string(), SchemaDef::String { r#enum: None }))
                 .collect(),
             required: required.iter().map(|field| (*field).to_string()).collect(),
-            additional_properties: true,
         }
     }
 
@@ -2551,7 +2547,6 @@ mod tests {
             SchemaDef::Object {
                 properties: BTreeMap::new(),
                 required: BTreeSet::from(["verdict".to_string()]),
-                additional_properties: true,
             },
         );
 
@@ -2640,7 +2635,6 @@ mod tests {
             SchemaDef::Object {
                 properties: BTreeMap::from([("ok".to_string(), SchemaDef::Boolean)]),
                 required: BTreeSet::from(["ok".to_string()]),
-                additional_properties: true,
             },
         );
 

--- a/src-tauri/src/domain/workflow/value_objects/definition.rs
+++ b/src-tauri/src/domain/workflow/value_objects/definition.rs
@@ -19,7 +19,6 @@ pub enum SchemaDef {
     Object {
         properties: BTreeMap<String, SchemaDef>,
         required: BTreeSet<String>,
-        additional_properties: bool,
     },
     Array {
         items: String,

--- a/src-tauri/src/usecase/workflow/dto.rs
+++ b/src-tauri/src/usecase/workflow/dto.rs
@@ -380,8 +380,7 @@ mod tests {
                 serde_json::json!({
                     "type": "object",
                     "properties": {},
-                    "required": [],
-                    "additionalProperties": false
+                    "required": []
                 }),
             )]
             .into_iter()
@@ -416,8 +415,7 @@ mod tests {
                     "plan": {
                         "type": "object",
                         "properties": {},
-                        "required": [],
-                        "additionalProperties": false
+                        "required": []
                     }
                 },
                 "nodes": [{

--- a/src-tauri/src/usecase/workflow/output.rs
+++ b/src-tauri/src/usecase/workflow/output.rs
@@ -340,7 +340,6 @@ mod tests {
                         SchemaDef::String { r#enum: None },
                     )]),
                     required: BTreeSet::from(["status".to_string()]),
-                    additional_properties: true,
                 },
             )]),
             nodes: vec![NodeDefinition {


### PR DESCRIPTION
## 概要

- Workflow schema DSL から additionalProperties を廃止
- Object の properties にない field を Artifact 提出時に常に受理
- Agent の初回・再提出 prompt に実際の Artifact schema を提示
- 組み込み Workflow、fixture、syntax document を新しい仕様へ移行
- 廃止された additionalProperties を使用した定義は読み込み時に拒否

## 検証

- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --quiet（2,552件成功）
- git diff --check

Closes #1469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * アーティファクト修復・完了時のプロンプトに、該当するスキーマのガイダンスを追加しました。
  * レビューコメントから修正タスクを生成し、実装・再確認・報告まで行うワークフローを追加しました。

* **仕様変更**
  * Objectスキーマの未宣言フィールドを常に受理するよう変更しました。
  * `additionalProperties` キーワードをサポート対象外とし、閉じたObjectを設定する機能を廃止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->