### PR TITLE
fix: 画像のみ送信時に空 text block を送らない (#1417)

### DIFF
--- a/docs/specs/issues-1417/behavior.md
+++ b/docs/specs/issues-1417/behavior.md
@@ -1,0 +1,77 @@
+# Behavior
+
+関連: #1417 ([Agentチャット安定化] X1: 画像のみ送信時の空 text block 修正)
+
+対象: Claude backend の turn 入力（user message wire）組立て。Codex backend の
+`codex_user_input` と論理的に対称な条件で text block を生成する。
+
+## Feature: 画像のみ送信時の空 text block を送らない
+
+  ユーザーが本文なしで画像だけを送信したとき、Claude backend が生成する user
+  message content に空の text block を含めない。これにより Codex backend と
+  「画像のみ送信」の成否が一致する。
+
+  Background:
+    Given ユーザーが Claude backend の agent session でメッセージを送信する
+    And 送信内容は prompt（本文文字列）と 0 個以上の画像から成る
+
+  Rule: prompt が非空、または画像がないときだけ text block を含める
+
+    Scenario: 空 prompt ＋ 画像あり（画像のみ送信）
+      Given prompt が空文字列である
+      And 1 個以上の画像が添付されている
+      When user message content を組み立てる
+      Then content に text block を含めない
+      And content は添付画像に対応する image block のみで構成される
+
+    Scenario: 非空 prompt ＋ 画像あり
+      Given prompt が非空文字列である
+      And 1 個以上の画像が添付されている
+      When user message content を組み立てる
+      Then content 先頭に prompt を内容とする text block を 1 つ含める
+      And text block の後ろに添付画像に対応する image block を並べる
+
+    Scenario: 非空 prompt ＋ 画像なし
+      Given prompt が非空文字列である
+      And 画像が添付されていない
+      When user message content を組み立てる
+      Then content は prompt を内容とする text block 1 つのみで構成される
+
+    Scenario: 空 prompt ＋ 画像なし（境界・現状維持）
+      Given prompt が空文字列である
+      And 画像が添付されていない
+      When user message content を組み立てる
+      Then content は空文字列を内容とする text block 1 つのみで構成される
+      # Codex `codex_user_input` と対称の挙動。送信可否の判断は frontend の既存
+      # 挙動に委ね、backend では送信拒否しない。
+
+  Rule: text block の生成条件は Codex backend と論理的に対称である
+
+    Scenario Outline: Claude と Codex で text block の有無が一致する
+      Given prompt が <prompt> である
+      And 画像が <images> である
+      When 両 backend が user message content を組み立てる
+      Then どちらも text block を <text_block> する
+
+      Examples:
+        | prompt | images | text_block |
+        | 空     | あり   | 含めない   |
+        | 非空   | あり   | 含める     |
+        | 非空   | なし   | 含める     |
+        | 空     | なし   | 含める     |
+
+## 仮定
+
+- 空 text block の生成箇所は `claude/wire.rs` の `user_message` のみであり、
+  `claude/session.rs` はこれを無加工で呼ぶだけである（監査 OB-7 の記述と一致）。
+- 空 prompt ＋ 画像なしのケースで空 text block を残す挙動は許容される。Codex も
+  同条件で空 text を送る対称挙動であり、frontend が本文・画像とも空の送信を通常
+  許可しないため実運用上到達しにくい。対称性の維持を優先し、backend 側での送信
+  拒否は本 Issue に含めない。
+- 「Anthropic API が空 text block を拒否し得る」挙動は非対称解消の根拠として扱い、
+  CLI のサニタイズ有無の外部検証は本変更の完了条件に含めない。
+- image block の並び順は「text の後に image」を従来どおり維持する。
+
+## Open Questions
+
+なし

--- a/docs/specs/issues-1417/design.md
+++ b/docs/specs/issues-1417/design.md
@@ -1,0 +1,136 @@
+# Design
+
+関連: #1417 ([Agentチャット安定化] X1: 画像のみ送信時の空 text block 修正)
+
+## 概要
+
+Claude backend の turn 入力（user message wire）組立てを Codex backend と論理的に対称化し、
+画像のみ（本文なし）送信時に空 text block を送らないようにする。
+
+現状 `claude/wire.rs` の `user_message` は prompt の空・非空に関わらず常に
+`{"type":"text","text":prompt}` を content 先頭へ push している。これを Codex の
+`codex_user_input`（`!prompt.is_empty() || images.is_empty()`）と同じ条件に揃え、
+**prompt が空かつ画像ありのときだけ text block を省略する**。それ以外の挙動は現状維持する。
+
+外部から観測可能な UI 追加はなく、変更は backend（Rust）に閉じる。
+
+## 変更対象
+
+- `src-tauri/src/infrastructure/agent_session/claude/wire.rs`
+  - `user_message`（現 `140-167`）の content 組立て条件を修正。
+  - `#[cfg(test)] mod tests`（現 `169-192`）にケースを追加。
+
+### 変更しないもの（非スコープ）
+
+- `claude/session.rs:212`（`user_message` を無加工で呼ぶだけ。呼び出しは変更しない）。
+- `codex/session.rs` の `codex_user_input`（既にガード済み。参照のみ）。
+- frontend（`MessageInput.tsx` / `useAgentChat.ts`）の送信バリデーション・UI。
+- usecase / adaptor 層の user prompt 空バリデーション（新規追加しない）。
+
+## アーキテクチャと責務分割
+
+- 修正ロジックは infrastructure 層の Claude wire 組立て（`claude/wire.rs`）に閉じる。
+  これは Anthropic の stream-json wire フォーマットへの変換責務そのものであり、
+  「空 text block を送らない」条件はこの変換の一部として妥当な配置である。
+- 呼び出し元（`claude/session.rs`）は wire 生成関数へ prompt / images を渡すだけの
+  責務に留め、条件分岐を持たせない（現状のまま）。
+- Codex 側と論理的対称であることが要件のため、判定条件は Codex の
+  `!prompt.is_empty() || images.is_empty()` と同一の真理値表を持つよう実装する。
+
+## データモデルまたは型
+
+`user_message` のシグネチャは現状維持する。
+
+```rust
+pub(crate) fn user_message(
+    prompt: &str,
+    images: impl IntoIterator<Item = (String, String)>,
+) -> Value
+```
+
+- `prompt: &str` — 本文。空文字列 `""` を取り得る。
+- `images: impl IntoIterator<Item = (String, String)>` — `(media_type, data)` の列。
+  Codex の `codex_user_input` は `&[AttachmentPayload]` を受け取り `images.is_empty()` を
+  直接判定できるが、Claude 側は `impl IntoIterator` のため長さを事前に知れない。
+
+**仮定（実装方針）**: シグネチャは変えず、関数内で `images` を一度 `Vec` に collect して
+`images.is_empty()` を判定する。これにより Codex と同じ条件式を使える。既存呼び出し
+（`claude/session.rs:212` の `claude_images(input.images)`）はイテレータを一度だけ消費する
+ため、collect による挙動変化はない。
+
+content の要素型（JSON）は現状と同一:
+
+- text block: `{"type":"text","text":<prompt>}`
+- image block: `{"type":"image","source":{"type":"base64","media_type":<m>,"data":<d>}}`
+
+## 処理フロー
+
+1. `images` を `Vec<(String, String)>` に collect する。
+2. `content: Vec<Value>` を空で初期化する。
+3. `!prompt.is_empty() || images.is_empty()` が真のとき、text block を push する。
+   （＝ prompt 空 かつ 画像あり のときだけ push しない）
+4. collect 済み `images` を順に image block として push する（順序は従来どおり text の後）。
+5. `{"type":TYPE_USER, "session_id":"", "parent_tool_use_id":null,
+   "message":{"role":"user","content":content}}` を返す。
+
+真理値表（Codex と一致）:
+
+| prompt | images | text block |
+|--------|--------|------------|
+| 空     | あり   | 含めない   |
+| 非空   | あり   | 含める     |
+| 非空   | なし   | 含める     |
+| 空     | なし   | 含める     |
+
+## エラー処理
+
+- 本変更でエラー経路は追加しない。`user_message` は `Value` を返す純粋関数であり、
+  失敗経路を持たない。
+- 監査が指摘する「Anthropic API が空 text block を `invalid_request_error` で拒否し得る」
+  点は、非対称解消の根拠として扱う。API エラーそのもののハンドリングや CLI サニタイズ
+  挙動の検証は本変更の完了条件に含めない（requirements の非スコープに準拠）。
+
+## テスト方針
+
+`claude/wire.rs` の `#[cfg(test)] mod tests` に unit test を追加し、4 ケースの content を固定する。
+
+1. **空 prompt ＋ 画像あり**: `content` に text block を含まず、image block のみ。
+   - `content[0]["type"] == "image"`、`content.as_array().len() == 画像数`。
+2. **非空 prompt ＋ 画像あり**（既存テスト `test_claude_user_message画像をstream_json形式にする`
+   を維持・活用）: `content[0]["text"] == prompt`、`content[1]["type"] == "image"`。
+3. **非空 prompt ＋ 画像なし**: `content` は text block 1 つのみ、`content[0]["text"] == prompt`。
+4. **空 prompt ＋ 画像なし（境界・現状維持）**: `content` は空文字 text block 1 つのみ、
+   `content[0]["text"] == ""`。
+
+- 外部プロセスは起動しない（純粋関数のテスト）。
+- Codex `codex_user_input` との対称性は同じ真理値表を満たすことで担保する
+  （Codex 側テストの有無に依存せず、Claude 側で 4 ケースを固定する）。
+- 完了条件として `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` を通す。
+
+## リスクと代替案
+
+- **リスク: collect による割当**。`images` を毎回 `Vec` へ collect するが、user message は
+  turn ごとに 1 回・画像数も少数であり、性能影響は無視できる。
+- **代替案 A: シグネチャを `&[(String, String)]` に変更**。呼び出し元で collect 済みを渡せば
+  関数内 collect を避けられるが、`claude/session.rs` 側の変更が波及し、スコープが広がる。
+  現状のイテレータ受け取りを維持し関数内 collect する方が変更が局所的で対称化の目的に十分。
+- **代替案 B: 空 prompt ＋ 画像なしでも text block を省く**。Codex と非対称になり、要件
+  （4 ケース目は空 text block を残す＝対称維持）に反するため採用しない。
+- **リスク: 空 prompt＋画像なしで空 text block が残る**。これは Codex と対称の意図的挙動。
+  frontend が本文・画像とも空の送信を通常許可しないため実運用上到達しにくい（requirements
+  の仮定に準拠）。backend での送信拒否は本 Issue に含めない。
+
+## 仮定
+
+- 空 text block の生成箇所は `claude/wire.rs` の `user_message` のみであり、
+  `claude/session.rs:212` はこれを無加工で呼ぶだけ（監査 OB-7・requirements と一致）。
+- `user_message` のシグネチャは変更せず、関数内で `images` を一度 collect して
+  空判定する（上記データモデル節の実装方針）。
+- 空 prompt ＋ 画像なしのケースで空 text block を残す挙動は許容される（Codex と対称）。
+- 「Anthropic API が空 text block を拒否し得る」挙動は非対称解消の根拠として扱い、
+  CLI サニタイズ有無の外部検証は完了条件に含めない。
+- image block の並び順は「text の後に image」を従来どおり維持する。
+
+## Open Questions
+
+なし

--- a/docs/specs/issues-1417/requirements.md
+++ b/docs/specs/issues-1417/requirements.md
@@ -1,0 +1,65 @@
+# Requirements
+
+関連: #1417 ([Agentチャット安定化] X1: 画像のみ送信時の空 text block 修正)
+
+## Type
+
+不具合修正（backend / Rust）。Claude backend の turn 入力（wire）組立てを Codex と対称化し、画像のみ（本文なし）送信時に空 text block を送らないようにする。外部から観測可能な UI の追加はなく、既存の「画像のみ送信」操作の成否を backend 間で一致させる。
+
+## 背景と目的
+
+milestone 84「Agentチャット安定化」の Phase 0（依存なし・即着手可）。監査ドキュメント `specs/milestone-84-agent-chat-stabilization/agent-chat-instability-audit.md` の **OB-7**（重大度 low / 種別: divergent）を解消する。
+
+現状、スクリーンショットだけを添付してテキストなしで送信すると、backend によって成否が分かれる非対称がある。
+
+- **Claude**: `user_message`（`claude/wire.rs:140-167`）が `prompt` の空・非空にかかわらず、常に `{"type":"text","text":""}` を content 先頭へ push する。Anthropic Messages API は空 text block を `invalid_request_error` で拒否する既知の挙動があり、画像のみ送信時に turn が API エラーで失敗し得る（claude CLI がこれをサニタイズするかはリポジトリ外の挙動のため未検証だが、非対称そのものが問題）。
+- **Codex**: `codex_user_input`（`codex/session.rs:574-586`）が `!prompt.is_empty() || images.is_empty()` の条件で text item を積み、画像のみ送信時は空 text を送らないよう明示的にガードしている。
+
+frontend は画像のみ（本文空）の送信を許可し（`MessageInput.tsx:437-439`）、backend の usecase / adaptor 層にも user prompt の空バリデーションはなく、`claude/session.rs:212` で `input.prompt` が無加工で `user_message` に渡る。結果、同じ「画像のみ送信」操作が Claude backend でだけ失敗し得る。
+
+本変更の目的は、この wire 生成の非対称を解消し、Claude backend でも画像のみ送信が Codex と同じく成功するようにすることである。
+
+### 修正方針（Issue・監査の指定）
+
+`claude/wire.rs` の `user_message` に Codex と同じ条件を入れる。すなわち **`prompt` が非空、または `images` が空のときだけ** text block を push する（画像ありかつ prompt 空のときは text block を省略する）。これにより両 backend の wire 生成条件が対称になる。
+
+## スコープ
+
+1. `claude/wire.rs` の `user_message` を修正し、`prompt` が空かつ `images` が非空のときは content 先頭の text block を生成しない（Codex `codex_user_input` と対称の条件 `!prompt.is_empty() || images.is_empty()`）。
+2. 次の 2 ケースの挙動をテストで固定する。
+   - 空 prompt ＋ 画像あり: text block を含まず image block のみの content になる。
+   - 空 prompt ＋ 画像なし: 既存挙動に従う（Codex と対称に、空 text block を 1 つ含む content になる。送信可否の判断は frontend 側の既存挙動に委ね、本 backend 修正では変更しない）。
+3. 修正ロジックは Rust/backend 側（`wire.rs`）に置く。frontend は変更しない。
+
+## 非スコープ
+
+- frontend（`MessageInput.tsx` / `useAgentChat.ts`）の送信バリデーションや UI の変更。画像のみ送信の許可可否は現状の frontend 挙動を維持する。
+- usecase / adaptor 層への user prompt 空バリデーションの新規追加。
+- Codex backend 側の挙動変更（既にガード済み）。
+- 空 text block 以外の Anthropic API エラー全般や、claude CLI のサニタイズ挙動そのものの検証・対処。
+- OB-7 以外の監査項目（OB-8 以降・RT 系など）の対応。
+
+## 要求事項
+
+1. Claude backend の turn 入力組立てにおいて、prompt が空かつ画像ありのとき、user message content に空 text block を含めない。
+2. prompt が非空のとき、または画像がないときは、従来どおり text block（内容は prompt 文字列、空文字を含む）を content 先頭に含める。
+3. 画像がある場合の image block の生成・並び順（text の後に image を並べる）は従来どおり維持する。
+4. 上記条件は Codex の `codex_user_input` と論理的に対称であること。
+5. 修正対象・追加テストは backend（Rust）に閉じ、frontend を変更しないこと。
+
+## 受け入れ基準の概要
+
+- スクリーンショットのみ（本文なし）の送信で、Claude backend が生成する user message content に空 text block が含まれない（image block のみになる）。
+- 空 prompt ＋ 画像あり、空 prompt ＋ 画像なしの 2 ケースが unit test（`wire.rs` の `#[cfg(test)]`）で固定され、Codex 側の条件と一致する。
+- 両 backend で「画像のみ送信」の成否が一致する（Claude でも API エラー要因の空 text block が送られない）。
+- `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` が通る。
+
+## 仮定
+
+- 「画像のみ送信」時に問題を起こす空 text block の生成箇所は `claude/wire.rs` の `user_message` のみであり、`claude/session.rs:212` はこれを無加工で呼ぶだけである（監査の記述と一致）。
+- 空 prompt ＋ 画像なしのケースで空 text block を残す挙動は許容される（Codex も同条件で空 text を送る対称挙動であり、かつ frontend が本文・画像とも空の送信を通常許可しないため実運用上到達しにくい）。この対称性の維持を優先し、backend 側での送信拒否は本 Issue に含めない。
+- 監査が指摘する「Anthropic API が空 text block を拒否し得る」挙動は、非対称解消の根拠として扱い、CLI のサニタイズ有無の外部検証は本変更の完了条件に含めない。
+
+## Open Questions
+
+なし

--- a/src-tauri/src/infrastructure/agent_session/claude/wire.rs
+++ b/src-tauri/src/infrastructure/agent_session/claude/wire.rs
@@ -141,10 +141,14 @@ pub(crate) fn user_message(
     prompt: &str,
     images: impl IntoIterator<Item = (String, String)>,
 ) -> Value {
-    let mut content = vec![json!({
-        "type": "text",
-        "text": prompt,
-    })];
+    let images = images.into_iter().collect::<Vec<_>>();
+    let mut content = Vec::new();
+    if !prompt.is_empty() || images.is_empty() {
+        content.push(json!({
+            "type": "text",
+            "text": prompt,
+        }));
+    }
     for (media_type, data) in images {
         content.push(json!({
             "type": "image",
@@ -181,12 +185,43 @@ mod tests {
     #[test]
     fn test_claude_user_message画像をstream_json形式にする() {
         let message = user_message("hello", [("image/png".to_string(), "abc".to_string())]);
+        let content = message["message"]["content"].as_array().unwrap();
 
         assert_eq!(message["type"], TYPE_USER);
-        assert_eq!(message["message"]["content"][0]["text"], "hello");
-        assert_eq!(
-            message["message"]["content"][1]["source"]["media_type"],
-            "image/png"
-        );
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "hello");
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["source"]["media_type"], "image/png");
+    }
+
+    #[test]
+    fn test_claude_user_message画像のみなら空text_blockを含めない() {
+        let message = user_message("", [("image/png".to_string(), "abc".to_string())]);
+        let content = message["message"]["content"].as_array().unwrap();
+
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "image");
+        assert_eq!(content[0]["source"]["media_type"], "image/png");
+    }
+
+    #[test]
+    fn test_claude_user_message本文のみならtext_blockだけを含める() {
+        let message = user_message("hello", []);
+        let content = message["message"]["content"].as_array().unwrap();
+
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "hello");
+    }
+
+    #[test]
+    fn test_claude_user_message本文も画像もなければ空text_blockを含める() {
+        let message = user_message("", []);
+        let content = message["message"]["content"].as_array().unwrap();
+
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "");
     }
 }


### PR DESCRIPTION
## 概要

Closes #1417 ([Agentチャット安定化] X1: 画像のみ送信時の空 text block 修正)

milestone 84「Agentチャット安定化」Phase 0。監査 **OB-7**（divergent / low）を解消する。

Claude backend の `user_message`（`claude/wire.rs`）は `prompt` の空・非空にかかわらず常に空 text block を content 先頭へ push していた。Anthropic Messages API は空 text block を拒否し得るため、画像のみ（本文なし）送信時に Claude だけ turn が失敗し得る非対称があった。Codex（`codex_user_input`）は既に `!prompt.is_empty() || images.is_empty()` でガード済み。

## 変更内容

- `claude/wire.rs` の `user_message` を Codex と対称の条件に修正。`prompt` が空かつ画像ありのときは content 先頭の text block を生成しない。
- unit test を追加し、4ケース（画像+本文 / 画像のみ / 本文のみ / 両方空）の挙動を固定。
- backend（Rust）に閉じた修正。frontend は変更なし。

## テスト

- `cargo test`（`wire.rs` の `#[cfg(test)]`）
- `cargo fmt --check` / `cargo clippy -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 画像のみを送信する場合、不要な空テキストを除外し、チャット送信時のエラーを防止しました。
  * 本文のみ、画像付き本文、本文・画像なしの場合も適切に処理されるようになりました。

* **ドキュメント**
  * チャット入力の仕様、設計方針、受け入れ条件を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->