### PR TITLE
feat: agent session の stdout 読み取りを共通 line reader に集約 (#1408)

### DIFF
--- a/docs/specs/issues-1408/behavior.md
+++ b/docs/specs/issues-1408/behavior.md
@@ -1,0 +1,210 @@
+# Behavior
+
+requirements.md の要求を、実装詳細を含まない観測可能な振る舞いとして Gherkin で定義する。
+本文書は「両 backend が同じ規約で stdout を読む」ことによって外部から観測できる結果だけを扱い、
+共通部品の内部構造・関数名・呼び出し経路には踏み込まない。
+
+## Feature
+
+```gherkin
+Feature: agent session backend の stdout 読み取り堅牢性の共通化
+  Claude / Codex いずれの backend でも、CLI プロセスが stdout に出す
+  「プロトコル外の 1 行」や「サイズ上限を超える巨大な 1 行」が原因で
+  agent session が突然死しないようにする。両 backend は同じ規約で
+  「行サイズ上限」「非 JSON 行の skip」「破棄・skip の可視化」を持ち、
+  セッションは継続する。
+```
+
+## Background
+
+```gherkin
+Background:
+  Given agent session が backend（Claude または Codex）の CLI を子プロセスとして起動している
+  And backend の stdout を行単位で読み取り、チャットへ反映している
+  And 破棄・skip の件数の source of truth は Rust 側の runtime state / read model にある
+  And frontend は runtime state / read model を表示するだけで、判断ロジックを持たない
+```
+
+## Rule: 非 JSON 行はセッションを終了させず skip され、件数がカウントされる
+
+両 backend で共通。CLI や注入環境が stdout に警告・診断ログ等の非 JSON 行を混ぜても、
+その行は捨てられ、セッションは読み取りを継続する。
+
+```gherkin
+Scenario Outline: 非 JSON 行が混ざってもセッションが継続する
+  Given <backend> のセッションが turn を実行中である
+  When backend が stdout に非 JSON 行を 1 行出力する
+  And 続けて正常な JSON 行を出力する
+  Then 非 JSON 行は skip される
+  And skip 件数がカウントされる
+  And 後続の正常な JSON 行は通常どおり処理される
+  And セッションは終了せず継続する
+
+  Examples:
+    | backend |
+    | Claude  |
+    | Codex   |
+```
+
+```gherkin
+Scenario: 非 JSON 行が連続してもセッションが継続する
+  Given Codex のセッションが turn を実行中である
+  When backend が stdout に非 JSON 行を複数行連続で出力する
+  And 続けて正常な JSON 行を出力する
+  Then 非 JSON 行はすべて skip され、その件数がカウントされる
+  And 後続の正常な JSON 行は通常どおり処理される
+  And セッションは終了せず継続する
+```
+
+## Rule: 1 行サイズ上限を超える行は保持されず読み捨てられ、破棄が可視化される
+
+両 backend で共通のサイズ上限（既存 Claude の 8MB を共通定数として踏襲）を持つ。
+上限を超える行は丸ごとメモリに蓄積されず読み捨てられ、破棄が可視化される。
+
+```gherkin
+Scenario Outline: サイズ上限超過行が読み捨てられ後続処理が継続する
+  Given <backend> のセッションが turn を実行中である
+  When backend が stdout に共通サイズ上限を超える巨大な 1 行を出力する
+  And 続けて正常な JSON 行を出力する
+  Then 上限超過行はメモリに丸ごと保持されず読み捨てられる
+  And 破棄が 1 件として可視化される（構造化 warn ログとカウント）
+  And 後続の正常な JSON 行は通常どおり処理される
+  And セッションは終了せず継続する
+
+  Examples:
+    | backend |
+    | Claude  |
+    | Codex   |
+```
+
+```gherkin
+Scenario Outline: 改行を伴わない上限超過行も破棄として可視化される
+  Given <backend> のセッションが turn を実行中である
+  When backend が改行で終端しないまま共通サイズ上限を超える出力を行い stdout が閉じる
+  Then 上限超過分は読み捨てられる
+  And 破棄が 1 件として可視化される
+
+  Examples:
+    | backend |
+    | Claude  |
+    | Codex   |
+```
+
+## Rule: 破棄・skip の件数はカウントとして可視化される
+
+破棄（oversize）・skip の発生件数は、両 backend で少なくとも構造化 warn ログとカウントで可視化される。
+巨大行そのものは保持せず、カウント等の summary だけを state に持つ（full-retention を増やさない）。
+
+```gherkin
+Scenario: 破棄件数がチャット上で可視化される
+  Given Claude のセッションで stdout の上限超過行が破棄された
+  Then 破棄が発生したことを示す Error part 相当の通知がチャットに現れる
+  And 破棄件数が runtime state に累積される
+  And 破棄件数の source of truth は Rust 側 runtime state / read model にある
+```
+
+```gherkin
+Scenario: turn が別要因で終了した場合に累積破棄件数が併記される
+  Given Claude のセッションで turn 実行中に stdout の上限超過行が 1 件以上破棄されている
+  When 同じ turn がクラッシュ等で終了する
+  Then 終了通知に累積した破棄件数（「サイズ超過破棄 N 件」相当）が併記される
+```
+
+## Rule: 応答必須の JSON-RPC response の decode 失敗は失敗として扱われる（Codex 例外条件）
+
+Codex は JSON-RPC の整合性を必要とする。非 JSON 行の一律 skip とは別に、
+応答待ちの request に対応する「応答必須の JSON-RPC response」の decode 失敗だけは、
+従来どおり失敗として扱ってよい。JSON-RPC 整合性の判断は backend 側の呼び出し層が担い、
+共通部品は「1 行が JSON か非 JSON か」「サイズ上限」だけを返す。
+
+```gherkin
+Scenario: 応答必須 request に対する非整合な response は失敗として扱われる
+  Given Codex のセッションが応答必須の JSON-RPC request を送り、その response を待っている
+  When その request に対応する response 行の decode に失敗する
+  Then その失敗は skip されず、失敗として扱われる（従来の失敗経路を維持してよい）
+```
+
+```gherkin
+Scenario: 応答を待っていない非 JSON 行は失敗にならず skip される
+  Given Codex のセッションが応答必須 request を待っていない
+  When stdout に非 JSON 行が出力される
+  Then その行は失敗として扱われず skip され、カウントされる
+  And セッションは終了せず継続する
+```
+
+## Rule: Claude の既存挙動は回帰しない
+
+共通部品への移行後も、Claude の既存の意図的仕様（非 JSON 行 skip、8MB 超破棄、
+破棄カウント表示、Error part 相当の可視化、セッション継続）は変わらない。
+
+```gherkin
+Scenario: Claude の既存の skip / 破棄 / カウント表示が維持される
+  Given Claude のセッションが turn を実行中である
+  When stdout に非 JSON 行と 8MB 超の巨大行が混ざる
+  Then 非 JSON 行は skip される
+  And 8MB 超の行は破棄され、破棄件数がカウント・可視化される
+  And セッションは終了せず継続する
+```
+
+## Rule: Claude の破棄時に破棄行の種別推定が付与される
+
+破棄行そのものは保持しないが、破棄の可視化に「破棄された行がどの種別だったか」の推定を添えて、
+可視化を改善する（推定手段は design.md で決める）。
+
+```gherkin
+Scenario: 破棄行の種別推定が可視化に添えられる
+  Given Claude のセッションで stdout の上限超過行が破棄される
+  When その破棄を可視化する
+  Then 破棄の通知に破棄行の種別推定が添えられる
+  And 種別推定のために巨大行全体を保持しない
+```
+
+## Rule: 破棄・skip の通知経路は後続 Notice へ接続できる拡張点を持つ
+
+本 ISSUE では `Notice` 語彙（S5 #1393）や `ProtocolIncompatible`（後続 Phase）へは接続しない。
+ただし破棄・skip の通知経路は、後続 ISSUE で無改造に近い形で `Notice` へ接続できる拡張点を持つ。
+
+```gherkin
+Scenario: 通知経路が後続の Notice 接続を阻害しない
+  Given 共通部品が破棄・skip を呼び出し側へ通知している
+  Then 通知は本 ISSUE では構造化 warn ログ＋既存の Error part 相当＋カウントで着地する
+  And その通知経路は後続 ISSUE で Notice へ接続できる拡張点を持つ
+  And 本 ISSUE では Notice / ProtocolIncompatible へは接続しない
+```
+
+## Rule: 非 JSON 行・巨大行を混ぜた fixture でセッション継続が固定される
+
+```gherkin
+Scenario Outline: fixture による回帰テストでセッション継続が固定される
+  Given 非 JSON 行と巨大行を混ぜた stdout の fixture がある
+  When <backend> のセッションがその fixture を読み取る
+  Then セッションは終了せず継続する
+  And 破棄・skip の件数がカウントされる
+  And この継続が自動テストで固定される
+
+  Examples:
+    | backend |
+    | Claude  |
+    | Codex   |
+```
+
+## 仮定
+
+- 共通行読み取り部品は `infrastructure/agent_session/` に配置し、Claude 既存の
+  `MAX_CLAUDE_STDOUT_LINE_BYTES = 8MB` を共通サイズ上限定数の初期値として踏襲する。
+  定数名・module 名は design.md で確定する。
+- 共通部品はバイト境界の読み取りを基準とし、Codex も現状の `BufReader::lines()`（文字列ベース）から
+  バイトベースへ寄せる。UTF-8 変換は非 JSON / JSON の分類後に行う。
+- 「応答必須 request に対する行だけ失敗を伝搬」する判定（in-flight request id の追跡）は、
+  共通部品ではなく Codex 側の呼び出し層で行う。共通部品は「JSON か非 JSON か」「サイズ上限」だけを返し、
+  JSON-RPC 整合性の判断は backend 側に置く。
+- 破棄・skip カウントは runtime state の既存 `oversize_dropped_count` 相当を拡張して持ち、
+  full-retention を増やさない。skip カウントの表示手段（Error part 相当の要否等）は design.md で決める。
+- 非 JSON 行の扱いは requirements.md 確定事項の案 A（暫定 skip＋継続）に従う。
+  `ProtocolIncompatible` による fail-closed は本 ISSUE では実装せず、後続 ISSUE に委ねる。
+- fixture の配置は F1（wire record/replay 回帰テスト基盤、#1383）への追加を第一候補とし、
+  F1 未整備時の代替配置は design.md で決める。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1408/design.md
+++ b/docs/specs/issues-1408/design.md
@@ -1,0 +1,206 @@
+# Design
+
+requirements.md / behavior.md を実装へ落とす設計。両 backend（Claude / Codex）の stdout 行読み取りを共通部品へ集約し、Codex の「非 JSON 行 1 行で即死」を解消する。Notice / ProtocolIncompatible への着地は本 ISSUE では扱わず（後続 Phase）、共通部品の導入・Codex 即死解消・可視化の対称化までを担う。
+
+## 概要
+
+- `infrastructure/agent_session/` に共通の stdout 行読み取り部品 `stdout_line_reader` を新設する。
+- 部品は「1 行サイズ上限（共通定数 8MB）」「上限超過行の読み捨て」「非 JSON 行の分類」「破棄・skip 行の種別推定（probe）」を提供し、バイト境界で読み取る。
+- Claude の既存 `next_stdout_item` / `read_stdout_line_limited` / `MAX_CLAUDE_STDOUT_LINE_BYTES` を共通部品へ移設し、挙動を回帰させない。
+- Codex の `BufReader::lines()` 経路を共通部品へ置換し、非 JSON 行を「decode 失敗 → Fatal → セッション即死」から「skip＋カウント＋継続」へ変える。JSON-RPC 整合性が必要な例外条件のみ backend 側で失敗を伝搬する。
+- 破棄（oversize）・skip の件数は Rust 側 runtime state に summary として持ち、構造化 warn ログとカウントで可視化する（full-retention を増やさない）。frontend は既存の read model 経由の表示のみ。
+
+## 変更対象
+
+- 新規: `src-tauri/src/infrastructure/agent_session/stdout_line_reader.rs`
+- 変更: `src-tauri/src/infrastructure/agent_session/mod.rs`（`pub(crate) mod stdout_line_reader;` 追加）
+- 変更: `src-tauri/src/infrastructure/agent_session/claude/process.rs`
+  - `MAX_CLAUDE_STDOUT_LINE_BYTES` / `ClaudeStdoutItem` / `ClaudeStdoutLine` / `read_stdout_line_limited` / `next_stdout_item` を共通部品へ移設・置換。
+- 変更: `src-tauri/src/infrastructure/agent_session/claude/session.rs`
+  - 共通 `StdoutDiagnostics` を runtime state に保持し、backend 固有の event 写像だけを行う。
+- 変更: `src-tauri/src/infrastructure/agent_session/codex/app_server.rs`
+  - `Lines<BufReader<ChildStdout>>` を共通 reader へ置換。`next_json` の戻り値を共通 `StdoutItem` に変更。
+- 変更: `src-tauri/src/infrastructure/agent_session/codex/session.rs`
+  - 共通 `StdoutDiagnostics` を runtime state に保持する。`read_loop` に oversize/非 JSON 行の skip＋カウント＋継続分岐を追加し、共有 response tracker の検証失敗を伝搬する。
+- 変更: `src-tauri/src/infrastructure/agent_session/codex/wire.rs`
+  - 応答必須 request id と method の所有、response の `result` / `error` 排他検証を `PendingClientRequests` に集約する。
+- 新規: fixture（配置は「テスト方針」参照）。
+
+frontend の変更は行わない（可視化は既存 Rust-owned read model 経由）。
+
+## アーキテクチャと責務分割
+
+レイヤーは全て `infrastructure/`（外部プロセス I/O）に閉じる。domain / usecase の型は変更しない。
+
+責務境界:
+
+- **共通部品 `stdout_line_reader`（新設）**: バイト単位で 1 行を読み、サイズ上限を適用し、行を「JSON / 非 JSON / oversize」に分類して返す。加えて `StdoutDiagnostics` がカウンタ更新・reset・構造化 warn ログ・共通上限を参照した oversize 表示文言を一元化する。JSON-RPC 整合性と in-flight request 追跡は持たない。ジェネリック reader（`tokio::io::AsyncBufRead`）で駆動でき、fixture テスト可能にする。
+- **backend 呼び出し層（`claude/*` `codex/*`）**: 共通部品の返す分類を受け、
+  - 共通 diagnostics の runtime state への保持、
+  - 共通文言から backend event（Error part 相当）への写像、
+  - JSON-RPC 整合性の判断（Codex の例外条件）、
+  を行う。Codex の in-flight request 追跡と `result` / `error` 排他検証は `codex/wire.rs` の `PendingClientRequests` に集約し、startup・turn・one-shot の全 request 経路で共有する（requirements 仮定に準拠し、共通 line reader には持ち込まない）。
+
+R7（Notice 拡張点）は、共通部品が返す分類 enum（`StdoutItem`）と probe をそのまま後続の `Notice(OversizeDropped / UnsupportedMessage / Diagnostic)` へ写像できる形にしておくことで満たす。本 ISSUE では Notice へは接続せず、backend 側で既存の warn ログ＋Error part＋カウントに着地させる。
+
+## データモデルまたは型
+
+### 共通部品（`stdout_line_reader.rs`）
+
+```rust
+/// 両 backend 共通の 1 行サイズ上限。Claude 既存の 8MB を踏襲する。
+pub(crate) const MAX_STDOUT_LINE_BYTES: usize = 8 * 1024 * 1024;
+
+/// 破棄・skip 行の種別推定。巨大行全体は保持せず、先頭数バイトのみから推定する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LineProbe {
+    /// 先頭バイトから推定した種別（例: JSON の "type" / "method" 値、非 JSON の場合は None）。
+    pub kind_hint: Option<String>,
+    /// 破棄・skip した論理行のバイト数。
+    pub bytes: usize,
+}
+
+/// 共通 reader が返す 1 件。
+#[derive(Debug)]
+pub(crate) enum StdoutItem {
+    /// JSON としてパースできた行。
+    Json(serde_json::Value),
+    /// JSON としてパースできなかった行（skip 対象）。
+    NonJson { probe: LineProbe },
+    /// サイズ上限を超えて読み捨てた行。
+    Oversize { probe: LineProbe },
+}
+
+pub(crate) struct StdoutLineReader<R> {
+    inner: R,
+}
+
+impl<R: tokio::io::AsyncBufRead + Unpin> StdoutLineReader<R> {
+    pub(crate) fn new(inner: R) -> Self { /* ... */ }
+    /// 次の 1 行を分類して返す。EOF で None。I/O エラーのみ Err。
+    pub(crate) async fn next(&mut self) -> Result<Option<StdoutItem>, String> { /* ... */ }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct StdoutDiagnostics {
+    oversize_dropped_count: u64,
+    skipped_non_json_count: u64,
+}
+```
+
+- `next()` は Claude 既存の `read_stdout_line_limited` を内包する。上限内の行は `serde_json::from_slice` で JSON 化し、成功なら `Json`、失敗なら `NonJson { probe }`。上限超過は `Oversize { probe }`。
+- probe の種別推定（R6）: oversize 行は先頭を読み捨てる前に、先頭 N バイト（例: 先頭 4KB）だけを別途保持し、`serde_json` の部分パースではなく軽量スキャン（`"type":"..."` / `"method":"..."` のキーを先頭領域から正規表現的に探索、または先頭を切り出して緩く JSON パース試行）で `kind_hint` を得る。巨大行全体は保持しない（R9）。非 JSON 行の probe は行が上限内なので全体を持てるが、`kind_hint` は原則 None（JSON でないため）。
+- **I/O エラーのみ** `Err` を返す。JSON パース失敗は `NonJson` であり `Err` にしない（これが Codex 即死解消の核）。
+
+### Claude 側
+
+- 既存 `ClaudeStdoutItem` は撤去し、`next_json()` は共通 `StdoutItem` を返す。`claude/session.rs::read_loop` を `Json` / `NonJson` / `Oversize` の 3 分岐へ更新。
+- `ClaudeRuntimeState` に `stdout_diagnostics: StdoutDiagnostics` を追加し、既存の破棄件数と新しい skip 件数を同じ共通型で保持する。
+
+### Codex 側
+
+- `CodexAppServerProcess.stdout` を `Lines<BufReader<ChildStdout>>` から `StdoutLineReader<BufReader<ChildStdout>>` に変更。`next_json()` は共通 `StdoutItem` を返す。
+- `CodexRuntimeState` に以下を追加:
+  ```rust
+  pending_client_requests: PendingClientRequests,
+  stdout_diagnostics: StdoutDiagnostics,
+  ```
+
+## 処理フロー
+
+### 共通 reader `next()`
+
+1. `read_stdout_line_limited` 相当でバイト行を読む。
+2. 上限超過なら残りを読み捨て、先頭保持分から probe を作り `Oversize { probe }`。
+3. 上限内の行を `serde_json::from_slice`:
+   - 成功 → `Json(value)`
+   - 失敗 → probe（`kind_hint = None`）を付け `NonJson { probe }`
+4. EOF は `None`。I/O エラーのみ `Err`。
+
+### Claude `read_loop`
+
+- `Json(value)` → 従来の `convert_claude_message` 経路（変更なし）。
+- `Oversize { probe }` → `StdoutDiagnostics::record_oversize_drop` で count・warn・共通文言を生成し、Claude 固有の `MessagePart::Error` event へ写像する。**種別推定を文言へ付与**（R6、例: 「backend からの応答 1 件がサイズ上限（8MB）を超えたため破棄しました（推定種別: <kind_hint>）」。`kind_hint` が None なら種別注記を省く）。
+- `NonJson { probe }` → `StdoutDiagnostics::record_non_json_skip` で warn ログ＋count を更新する（従来どおり継続。Error part は出さない）。
+- crash 時の併記（`emit_crash_if_unexpected`）は既存どおり `oversize_dropped_count` を使う（回帰させない、behavior「累積破棄件数が併記される」）。
+
+### Codex `read_loop`
+
+`process.next_json().await` の結果分岐:
+
+- `Ok(Some(StdoutItem::Json(message)))` → 従来の `message_kind` / `convert_jsonrpc_message` 経路。
+  - **例外条件（R2 の例外）**: `message_kind` が `Response { id }` かつ `PendingClientRequests` に `id` が存在するのに、`result` / `error` が排他的に存在しない場合は、従来の失敗経路（`Fatal` + `TurnCompleted(Crash)`）を維持する。純粋な非 JSON 行は id を取り出せないため、この例外には該当しない。
+- `Ok(Some(StdoutItem::NonJson { probe }))` → `skipped_non_json_count += 1`、warn ログ、**継続**（従来の Fatal を廃止）。応答待ちの有無に関わらず skip する（純粋な非 JSON 行は対応 request を特定できないため。behavior「応答を待っていない非 JSON 行は skip」を包含し、案 A に準拠）。
+- `Ok(Some(StdoutItem::Oversize { probe }))` → `oversize_dropped_count += 1`、warn ログ、Claude と対称に `MessagePart::Error` 相当を送出、**継続**。
+- `Ok(None)` / `Err(_)` → 従来どおり（プロセス終了 / I/O エラーは Crash）。
+
+Codex の可視化も共通 `StdoutDiagnostics` を使い、生成された共通文言だけを backend event へ写像する。oversize は Error part＋count、非 JSON skip は warn＋count に着地させる（R5）。one-shot 経路も同じ diagnostics を使う。
+
+## エラー処理
+
+- **I/O エラー**（`fill_buf` 失敗）: 共通部品が `Err(String)` を返し、backend 側で従来どおり Crash 扱い。
+- **JSON パース失敗**: `Err` にせず `NonJson` として分類。これにより Codex の即死を解消（R2）。
+- **サイズ上限超過**: `Err` にせず `Oversize` として読み捨て。メモリ肥大を防ぐ（R3 / R9）。両 backend に同一上限が効く。
+- **Codex 例外条件**: 応答必須の JSON-RPC response の整合性欠落のみ、backend 呼び出し層で失敗を伝搬（behavior「応答必須 request に対する非整合な response は失敗として扱われる」）。共通部品はこの判断を持たない。
+- **改行なし EOF の上限超過**（behavior 明記）: Claude 既存ロジックのとおり `Oversize` として可視化し、後続なしで `None` に至る。共通部品へ移設しても回帰させない。
+
+## テスト方針
+
+### 共通部品の単体テスト（`stdout_line_reader.rs` 内 `#[cfg(test)]`）
+
+`tokio::io::BufReader` にバイト列を流して駆動（Claude 既存テストの手法を踏襲）:
+
+- 上限未満の JSON 行 → `Json`。
+- 上限超過行 → `Oversize`、後続 JSON 行の処理継続（改行あり／改行なし EOF の両方）。
+- 非 JSON 行 → `NonJson`、後続 JSON 行の処理継続。
+- oversize probe の `kind_hint` が先頭バイトから推定される（R6）。
+- I/O エラーが `Err` として伝搬する。
+
+Claude 既存の `test_next_stdout_item_*`（`process.rs:485-537`）は共通部品テストへ移設し、意図的仕様を回帰させない（R4）。
+
+### Claude backend テスト（`claude/session.rs`）
+
+- 非 JSON 行 skip＋8MB 超破棄が混ざってもセッション継続、`oversize_dropped_count` カウント表示、Error part 可視化が維持される（R4、既存 `oversize_dropped_count` テストを維持・拡張）。
+- 破棄時に probe の種別推定が可視化文言へ付与される（R6）。
+
+### Codex backend テスト（`codex/session.rs`）
+
+- 非 JSON 行を含む stdout でセッション継続、`skipped_non_json_count` がカウントされる（R2 / R5）。
+- 非 JSON 行が複数連続しても継続（behavior）。
+- 上限超過行が読み捨てられ後続処理継続、`oversize_dropped_count` カウント（R3）。
+- 応答必須 request に対応する非整合 response の decode 失敗が従来どおり失敗として扱われる（R2 例外）。
+- 応答待ちでない非 JSON 行は失敗にならず skip される（behavior）。
+
+両 backend の production `read_loop` 自体を `AsyncBufRead` ジェネリックに保つ。fixture テストは writer を閉じない duplex stream の reader を注入し、プロセスを起動せずに実際の loop が後続 JSON event を処理して待機を継続することを検証する（外部プロセスをテストで実行しない方針に準拠）。
+
+### fixture（R8）
+
+- 内容: 非 JSON 行（警告ログ 1 行・複数行）＋上限超過行＋正常 JSON 行を混ぜた `.jsonl` バイト列。
+- 配置: **F1（wire record/replay 回帰テスト基盤 #1383）は agent_session 向けに未整備**（現状 fixtures は `adaptor/gateway/workflow/fixtures` のみ）。したがって本 ISSUEでは代替配置として `src-tauri/tests/fixtures/agent_session/mixed_stdout_{claude,codex}.jsonl` に置き、`include_bytes!` で読み込んで両 backend の production `read_loop` を駆動する回帰テストにする。F1 整備後に同 fixture を F1 へ移送できるよう、fixture はプレーンなバイト列に留める。
+- 固定内容: 両 backend でセッションが終了せず継続し、破棄・skip 件数がカウントされること。
+
+### 品質ゲート
+
+`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`。frontend 変更なしのため `pnpm` 系は既存が通ることのみ確認。
+
+## リスクと代替案
+
+- **リスク: Codex の JSON-RPC 整合性を壊す。** 非 JSON 行を一律 skip すると、本来失敗させるべき破損 response まで握り潰す懸念。→ `PendingClientRequests` が全 client request の id / method を所有し、対応する `Response{id}` の `result` / `error` 排他違反を startup・turn・one-shot で同じ失敗として扱う。純粋な非 JSON 行は id 不明で対応 request を特定できないため、この例外には該当しない（未応答のままなら既存の応答待ち timeout / crash 経路が働く）。
+- **リスク: oversize probe の種別推定コスト。** 先頭数 KB のみの軽量スキャンに限定し、巨大行全体のパースはしない（R9）。推定不能なら `kind_hint = None`。
+- **代替案 A（不採用）: Codex を Claude と同じ `ClaudeStdoutItem` に相乗り。** backend 固有名が漏れるため、backend 非依存の共通型 `StdoutItem` を新設する。
+- **代替案 B（不採用）: 共通 line reader に JSON-RPC 整合性や backend event 生成まで持たせる。** backend 固有契約が共通 reader へ漏れるため不採用。共通化対象は分類に加えて diagnostics の count・reset・ログ・表示文言までとし、JSON-RPC tracker は `codex/wire.rs`、event 写像は各 backend に置く。
+- **代替案 C（後続）: `ProtocolIncompatible` による fail-closed。** I10 の理想形だが Phase 0・依存なしの本 ISSUE では実装せず、S5 / 後続 ISSUE に委ねる（requirements 確定事項 Q1・案 A）。
+
+## 仮定
+
+- 共通部品の module 名は `stdout_line_reader`、共通定数名は `MAX_STDOUT_LINE_BYTES`（初期値 8MB、Claude 既存値を踏襲）。
+- 共通部品はバイト境界で読み取り、UTF-8 変換は不要（JSON パースは `serde_json::from_slice`、非 JSON 行は skip するため文字列化しない）。Codex も `Lines`（文字列ベース）からバイトベースへ寄せる。
+- Codex の「応答必須 response の整合失敗のみ失敗伝搬」は、`message_kind == Response{id}` かつ `PendingClientRequests` に `id` が残存し、`result` / `error` の排他条件を満たさないケースに限定する。純粋な非 JSON 行（id 不明）は常に skip＋継続とする（behavior の 2 シナリオ・案 A に整合）。
+- 破棄・skip カウントは runtime state に `u64` の delta として持ち、巨大行・skip 行の本体は保持しない（R9）。
+- 可視化は oversize を Error part 相当＋count、非 JSON skip を warn ログ＋count に着地させる。Codex も Claude と対称に oversize を Error part 化する（R5 の最低要件はログ＋count だが、UX 対称性のため Error part も出す）。
+- fixture は F1 未整備のため `src-tauri/tests/fixtures/agent_session/` に代替配置し、F1 整備後に移送可能なプレーンバイト列とする。
+- probe の種別推定は先頭数 KB の軽量スキャンで行い、巨大行全体は保持しない。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1408/requirements.md
+++ b/docs/specs/issues-1408/requirements.md
@@ -1,0 +1,100 @@
+# Requirements
+
+## Type
+
+信頼性改善（backend 間の非対称な stdout 処理の共通化）。
+
+agent session の backend（Claude / Codex）が CLI プロセスの stdout を読み取る経路を、共通の行読み取り部品へ集約する。現状は Claude と Codex で堅牢性が非対称であり、Codex は stdout に非 JSON 行が 1 行混ざるだけでセッションが即死する。この非対称を解消し、両 backend が同じ規約で「行サイズ上限」「非 JSON 行の扱い」「破棄・skip の可視化」を持つようにする。
+
+関連: #1408（本 ISSUE、L7）/ milestone 84「Agentチャット安定化」Phase 0（依存なし）/ 監査問題 **SD-3** / ライフサイクル理想形 **I10** / 親方針: `.claude/rules/rust-first-logic.md`、CLAUDE.md「full-retention 設計を避ける」。
+
+## 背景と目的
+
+Releash の agent session は Claude / Codex の CLI を子プロセスとして起動し、その stdout を行単位で読んで wire message へ decode している。監査（SD-3）により、この stdout 読み取りの堅牢性が両 backend で大きく非対称であることが確定している。
+
+### 現状のコード調査（実コードで確認済み）
+
+- **Claude は堅牢**:
+  - 非 JSON 行は warn ログを出して skip し、読み続ける（`claude/process.rs:181-186` の `next_stdout_item`）。
+  - 1 行のサイズ上限 `MAX_CLAUDE_STDOUT_LINE_BYTES = 8 * 1024 * 1024`（`claude/process.rs:22`）を持ち、上限超過行はバッファに保持せず読み捨てて `ClaudeStdoutLine::Oversize`（`ClaudeStdoutItem::OversizeDropped { bytes }`）にする（`claude/process.rs:211-266`, `:26-28`）。
+  - 破棄発生時は runtime state の `oversize_dropped_count` を加算し（`claude/session.rs:403-406`）、Error part 相当の可視化とカウント表示（「サイズ超過破棄 N 件」）を行い、セッションを継続する（`claude/session.rs:345-358`, `:546-556`）。
+  - この skip / oversize 挙動はテストで意図的仕様として固定されている（`claude/process.rs:487-534`）。
+- **Codex は脆い**:
+  - stdout 読み取りは `BufReader::lines()`（`codex/app_server.rs:108`）で、1 行のサイズ上限が無い。巨大な item 行（aggregatedOutput 等）を丸ごとメモリに蓄積しうる。
+  - `decode_jsonrpc_line` が非 JSON 行を `Err("invalid app-server JSON-RPC: ...")` にし（`codex/app_server.rs:138-140`）、`next_json` がそのまま伝播する（`codex/app_server.rs:115-126`）。
+  - read loop の Err 分岐が Fatal を送って break → `process.shutdown()` で app-server を kill するため、runtime は turn を Crash として complete しセッション実体が終了する（監査 SD-3 記載、`codex/session.rs:411-428` / `runtime/usecase.rs:2536-2564`）。
+
+結果として、「プロトコル外の 1 行」という同じ事象が Claude では無害な警告または 1 件破棄の通知で済むのに対し、Codex では致命的クラッシュ（turn=Crash、セッション終了）になる。CLI や注入環境が stdout に警告等を 1 行出すだけで Codex チャットが突然死する。
+
+本変更の目的は、この非対称を解消し、両 backend の stdout 読み取りに共通の堅牢性契約（サイズ上限・非 JSON 行の扱い・破棄/skip の可視化）を与えることである。
+
+### 正本ドキュメントとの関係
+
+- 監査 **SD-3**（`specs/milestone-84-agent-chat-stabilization/agent-chat-instability-audit.md:409`）が本 ISSUE の問題定義。
+- ライフサイクル **I10**（同 `agent-chat-ideal-lifecycle.md:108`）が最終的な理想形。I10 は「共通の分類契約」を掲げ、`Notice(Diagnostic / UnsupportedMessage)` への着地や、未分類・malformed・oversize を `ProtocolIncompatible` として fail-closed で新規 turn を block する将来像を含む。
+- ただし `Notice` 語彙（**S5 #1393**）と `ProtocolIncompatible` / schema・wire 基盤（**F 系 / D1 #1445**）は後続 Phase の成果物であり、本 ISSUE（Phase 0・依存なし）はそれらに依存できない。ISSUE 本文も「S5 で `Notice(OversizeDropped/UnsupportedMessage)` に接続。それまでは構造化 warn ログ＋Error part 相当の既存可視化を維持」と明記している。したがって本 Spec は、共通部品の導入と Codex 即死の解消までを担い、Notice / ProtocolIncompatible への着地は後続 ISSUE に委ねる。
+
+## スコープ
+
+- **R1（共通 line reader の新設）** `infrastructure/agent_session/` に、両 backend が使う共通の行読み取り部品を新設する。少なくとも次を持つ:
+  - 1 行のサイズ上限（既存 Claude の 8MB を踏襲し、共通定数として定義する）。
+  - 上限超過行はバッファに保持せず読み捨て、oversize を上位へ通知する。
+  - 非 JSON 行は skip し、skip 件数をカウントする。
+  - 破棄（oversize）・skip の発生を呼び出し側へ通知する hook / 戻り値を持つ（S5 で `Notice` へ接続できる形にしておく。それまでは構造化 warn ログ＋既存の Error part 相当の可視化を維持する）。
+- **R2（Codex への適用）** `codex/app_server.rs` の read_line 経路を共通部品へ置き換える。非 JSON 行での「decode 失敗 → Fatal → セッション即死」を、skip＋カウントによる継続へ変更する。ただし JSON-RPC の整合性が必要なため、応答待ちの request に対応する行（応答必須の JSON-RPC response）だけは失敗を伝搬してよい。
+- **R3（Claude への適用）** `claude/process.rs` / `claude/session.rs` の既存 skip・8MB 破棄経路を共通部品へ移す。破棄時に行種別の推定（先頭 bytes から type を覗く等）を付けて可視化を改善する。既存の意図的仕様（skip / OversizeDropped / カウント表示）は回帰させない。
+- **R4（fixture）** 非 JSON 行・巨大行を混ぜた fixture を追加し、両 backend でセッション継続を固定する回帰テストを持つ。fixture は F1（wire record/replay 回帰テスト基盤、#1383）に追加する方針だが、F1 未整備の場合の代替配置は design.md で決める。
+
+## 非スコープ
+
+- `Notice` 語彙（`Notice(OversizeDropped / UnsupportedMessage / Diagnostic)`）の導入と、それへの着地。→ **S5 #1393**。
+- `ProtocolIncompatible` / fail-closed による新規 turn block・durable 化・reconciliation。→ D1 #1445 / F 系 / 後続 ISSUE。I10 の「未分類・malformed・oversize は fail-closed」への完全収束は本 ISSUE では扱わない（後述 Open Questions Q1）。
+- wire message の typed 化・converter の語彙変更（**F4 #1386 / F5 #1387 / F6 #1388** 以降）。挙動等価の read 経路共通化に閉じ、message の意味変換は変更しない。
+- Codex の stall 誤検知・生存 signal（**SD-4 / S1 #1389**）、tool 出力 delta 写像（SD-5）等、stdout 読み取り以外の SD 問題。
+- runtime / usecase 側の turn 状態機械そのものの再設計。共通部品からの通知を受ける最小限の配線に留める。
+- frontend への新規ロジック追加。可視化は既存の Rust-owned read model 経由に留める。
+
+## 要求事項
+
+- **R1**: `infrastructure/agent_session/` に共通の stdout 行読み取り部品が存在し、両 backend がそれを使う。部品は「1 行サイズ上限（共通定数）」「上限超過行の読み捨て」「非 JSON 行の skip とカウント」「破棄/skip の呼び出し側通知」を提供すること。
+- **R2**: Codex の stdout に非 JSON 行（警告・診断ログ等）が 1 行以上混ざっても、セッションが即死せず継続すること。従来 Fatal で落ちていた経路が skip＋カウントに変わること。ただし応答必須の JSON-RPC response の decode 失敗は従来どおり失敗として扱ってよい。
+- **R3**: Codex の stdout 1 行に対し、Claude と同じ 1 行サイズ上限が効き、上限超過行でメモリが無制限に肥大しないこと。
+- **R4**: Claude の既存挙動（非 JSON 行 skip、8MB 超破棄、`oversize_dropped_count` によるカウント表示、Error part 相当の可視化、セッション継続）が回帰しないこと。
+- **R5**: 破棄（oversize）・skip の発生件数が、両 backend で可視化（少なくとも構造化 warn ログとカウント）されること。可視化の source of truth は Rust 側 runtime state / read model にあり、frontend は表示のみに留まること。
+- **R6**: Claude の破棄時に、破棄行の種別推定を付与して可視化が改善されること（先頭 bytes からの type 推定等、手段は design.md で決める）。
+- **R7**: 共通部品の破棄/skip 通知経路が、後続の S5（`Notice`）へ無改造に近い形で接続できる拡張点を持つこと（本 ISSUE では `Notice` に接続しない）。
+- **R8**: 非 JSON 行・巨大行を混ぜた fixture により、両 backend でセッションが継続することが自動テストで固定されること。
+- **R9**: full-retention / full-recompute 経路を新設しないこと。巨大行は保持せず読み捨て、カウント等の delta / summary のみを state に持つこと。
+
+## 受け入れ基準の概要
+
+- **Rust test**
+  - Codex: 非 JSON 行を含む stdout でセッションが継続し、skip がカウントされる（R2 / R5）。
+  - Codex: 1 行サイズ上限超過行が読み捨てられ、後続行の処理が継続する（R3）。
+  - Codex: 応答必須の JSON-RPC response の decode 失敗が従来どおり失敗として扱われる（R2 の例外条件）。
+  - Claude: 既存の skip / OversizeDropped / カウント表示テストが回帰しない（R4）。
+  - Claude: 破棄時に行種別推定が付与される（R6）。
+  - 共通部品の単体テスト（サイズ上限・非 JSON skip・通知 hook）（R1 / R7）。
+- **fixture / 回帰**
+  - 非 JSON 行・巨大行を混ぜた fixture で両 backend のセッション継続が固定される（R8）。
+- **ISSUE 記載の受け入れ基準**
+  - [ ] codex stdout に非 JSON 行が混ざってもセッションが継続する（R2）。
+  - [ ] 破棄・skip がカウント可視化される（R5）。
+  - [ ] 巨大行でメモリ肥大しない（上限が両 backend に効く）（R3）。
+- **品質ゲート**: `pnpm lint` / `pnpm test` / `pnpm build`（frontend 変更がある場合）/ `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` が通る。
+
+## 仮定
+
+- 本 ISSUE は milestone 84 Phase 0（依存なし）であり、`Notice` 語彙（S5 #1393）・`ProtocolIncompatible`・schema/wire 基盤（F 系 / D1 #1445）には依存しない。よって本 ISSUE の可視化は、既存の構造化 warn ログ＋Error part 相当＋カウント表示を維持し、`Notice` / `ProtocolIncompatible` への着地は後続 ISSUE で行う（ISSUE 本文の明記に基づく）。
+- 共通行読み取り部品の配置は `infrastructure/agent_session/`（例: 新規 module）とし、Claude 既存の `MAX_CLAUDE_STDOUT_LINE_BYTES = 8MB` を共通定数の初期値として踏襲する。定数名・module 名は design.md で確定する。
+- Codex 側は現状 `BufReader::lines()` を使っており文字列ベースだが、Claude 側はバイト境界でサイズ上限を扱う（8MB を超える行のメモリ肥大を防ぐため）。共通部品はバイト境界の読み取りを基準とし、Codex もバイトベースへ寄せる前提とする（UTF-8 変換は decode 前の分類後に行う）。詳細は design.md で決める。
+- Codex の「応答必須 request に対する行だけ失敗を伝搬」の判定（in-flight request id の追跡）は、共通部品ではなく Codex 側の呼び出し層で行う前提とする。共通部品は「1 行が JSON か非 JSON か」「サイズ上限」だけを返し、JSON-RPC 整合性の判断は backend 側に置く。
+- 破棄・skip カウントは runtime state の既存 `oversize_dropped_count` 相当を拡張して持ち、full-retention を増やさない。
+
+## 確定事項（旧 Open Questions）
+
+- **Q1（確定: 案 A）**: 本 ISSUE における「非 JSON 行の扱い」は **案 A（ISSUE 本文準拠 / 暫定 skip＋継続）** で確定する。非 JSON 行は種別を問わず skip＋カウントして継続し、Codex 即死を解消する。I10 が求める「未分類・malformed・oversize は `ProtocolIncompatible` として fail-closed で新規 turn を block」は本 ISSUE では実装せず、S5（#1393）/ `ProtocolIncompatible`（後続 Phase）導入時に後続 ISSUE で収束させる。この方針は Phase 0・依存なしという層化、および ISSUE 本文・受け入れ基準（「非 JSON 行が混ざってもセッションが継続する」）に整合する。
+
+## Open Questions
+
+なし。

--- a/src-tauri/src/infrastructure/agent_session/claude/process.rs
+++ b/src-tauri/src/infrastructure/agent_session/claude/process.rs
@@ -5,11 +5,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::Value;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::Mutex;
 
 use crate::domain::agent_session::gateway::SessionSpec;
+use crate::infrastructure::agent_session::stdout_line_reader::StdoutLineReader;
 use crate::infrastructure::process::child_env::AgentChildEnv;
 use crate::infrastructure::process::child_process::{configure_process_group, staged_shutdown};
 use crate::infrastructure::process::child_stderr::drain_child_stderr;
@@ -19,20 +20,7 @@ use crate::infrastructure::process::pid_registry::{
 
 use super::wire::{claude_wire_mode, ClaudeWireMode};
 
-pub(crate) const MAX_CLAUDE_STDOUT_LINE_BYTES: usize = 8 * 1024 * 1024;
 const CLAUDE_SCRUBBED_ENV: &[&str] = &["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"];
-
-#[derive(Debug)]
-pub(crate) enum ClaudeStdoutItem {
-    Json(Value),
-    OversizeDropped { bytes: usize },
-}
-
-#[derive(Debug)]
-enum ClaudeStdoutLine {
-    Line(Vec<u8>),
-    Oversize { bytes: usize },
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ClaudeProcessConfig {
@@ -64,7 +52,7 @@ pub(crate) struct ClaudeStdioHandle {
 
 pub(crate) struct ClaudeStdioProcess {
     handle: ClaudeStdioHandle,
-    stdout: BufReader<ChildStdout>,
+    stdout: StdoutLineReader<BufReader<ChildStdout>>,
     _system_prompt_file: Option<tempfile::NamedTempFile>,
 }
 
@@ -154,7 +142,7 @@ impl ClaudeStdioProcess {
                 stdin: Arc::new(Mutex::new(Some(stdin))),
                 pid_registration,
             },
-            stdout: BufReader::new(stdout),
+            stdout: StdoutLineReader::new(BufReader::new(stdout)),
             _system_prompt_file: system_prompt_file,
         })
     }
@@ -163,28 +151,8 @@ impl ClaudeStdioProcess {
         self.handle.clone()
     }
 
-    pub(crate) async fn next_json(&mut self) -> Result<Option<ClaudeStdoutItem>, String> {
-        next_stdout_item(&mut self.stdout).await
-    }
-}
-
-async fn next_stdout_item<R>(stdout: &mut R) -> Result<Option<ClaudeStdoutItem>, String>
-where
-    R: tokio::io::AsyncBufRead + Unpin,
-{
-    loop {
-        match read_stdout_line_limited(stdout).await? {
-            None => return Ok(None),
-            Some(ClaudeStdoutLine::Oversize { bytes }) => {
-                return Ok(Some(ClaudeStdoutItem::OversizeDropped { bytes }));
-            }
-            Some(ClaudeStdoutLine::Line(line)) => match serde_json::from_slice::<Value>(&line) {
-                Ok(value) => return Ok(Some(ClaudeStdoutItem::Json(value))),
-                Err(error) => {
-                    log::warn!("skipping non-json claude stdout line: {error}");
-                }
-            },
-        }
+    pub(crate) fn stdout_mut(&mut self) -> &mut StdoutLineReader<BufReader<ChildStdout>> {
+        &mut self.stdout
     }
 }
 
@@ -205,70 +173,6 @@ mod child_env_tests {
         assert!(env
             .scrub_envs()
             .contains(&"CLAUDE_CODE_ENTRYPOINT".to_string()));
-    }
-}
-
-async fn read_stdout_line_limited<R>(stdout: &mut R) -> Result<Option<ClaudeStdoutLine>, String>
-where
-    R: tokio::io::AsyncBufRead + Unpin,
-{
-    let mut line = Vec::new();
-    loop {
-        let available = stdout
-            .fill_buf()
-            .await
-            .map_err(|error| format!("failed to read claude stdout: {error}"))?;
-        if available.is_empty() {
-            return if line.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(ClaudeStdoutLine::Line(line)))
-            };
-        }
-        let take = available
-            .iter()
-            .position(|byte| *byte == b'\n')
-            .map(|index| index + 1)
-            .unwrap_or(available.len());
-        if line.len().saturating_add(take) > MAX_CLAUDE_STDOUT_LINE_BYTES {
-            log::warn!(
-                "claude stdout line exceeded {} bytes",
-                MAX_CLAUDE_STDOUT_LINE_BYTES
-            );
-            let mut dropped = line.len().saturating_add(take);
-            line.clear();
-            let reached_newline = available[..take].last() == Some(&b'\n');
-            stdout.consume(take);
-            if reached_newline {
-                return Ok(Some(ClaudeStdoutLine::Oversize { bytes: dropped - 1 }));
-            }
-            loop {
-                let available = stdout
-                    .fill_buf()
-                    .await
-                    .map_err(|error| format!("failed to read claude stdout: {error}"))?;
-                if available.is_empty() {
-                    return Ok(Some(ClaudeStdoutLine::Oversize { bytes: dropped }));
-                }
-                let take = available
-                    .iter()
-                    .position(|byte| *byte == b'\n')
-                    .map(|index| index + 1)
-                    .unwrap_or(available.len());
-                let reached_newline = available[..take].last() == Some(&b'\n');
-                dropped = dropped.saturating_add(take);
-                stdout.consume(take);
-                if reached_newline {
-                    return Ok(Some(ClaudeStdoutLine::Oversize { bytes: dropped - 1 }));
-                }
-            }
-        }
-        let reached_newline = available[..take].last() == Some(&b'\n');
-        line.extend_from_slice(&available[..take]);
-        stdout.consume(take);
-        if reached_newline {
-            return Ok(Some(ClaudeStdoutLine::Line(line)));
-        }
     }
 }
 
@@ -480,59 +384,5 @@ mod tests {
         assert_eq!(first_semver("Claude Code 2.1.3"), Some((2, 1, 3)));
         assert_eq!(first_semver("claude 2.0"), Some((2, 0, 0)));
         assert_eq!(first_semver("no version"), None);
-    }
-
-    #[tokio::test]
-    async fn test_next_stdout_item_8mb未満の巨大行を正常にパースする() {
-        let payload = "a".repeat(MAX_CLAUDE_STDOUT_LINE_BYTES - 1024);
-        let input = format!("{{\"data\":\"{payload}\"}}\n");
-        let mut reader = tokio::io::BufReader::with_capacity(64 * 1024, input.as_bytes());
-
-        let item = next_stdout_item(&mut reader).await.unwrap();
-
-        match item {
-            Some(ClaudeStdoutItem::Json(value)) => {
-                assert_eq!(value["data"].as_str().unwrap().len(), payload.len());
-            }
-            other => panic!("expected Json, got {other:?}"),
-        }
-        assert!(next_stdout_item(&mut reader).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn test_next_stdout_item_超過行はoversize_droppedを返し後続行の処理を継続する() {
-        let payload = "b".repeat(MAX_CLAUDE_STDOUT_LINE_BYTES + 1);
-        let input = format!("{{\"data\":\"{payload}\"}}\n{{\"ok\":true}}\n");
-        let mut reader = tokio::io::BufReader::with_capacity(64 * 1024, input.as_bytes());
-
-        let first = next_stdout_item(&mut reader).await.unwrap();
-        assert!(matches!(
-            first,
-            Some(ClaudeStdoutItem::OversizeDropped { bytes })
-                if bytes > MAX_CLAUDE_STDOUT_LINE_BYTES
-        ));
-
-        let second = next_stdout_item(&mut reader).await.unwrap();
-        match second {
-            Some(ClaudeStdoutItem::Json(value)) => {
-                assert_eq!(value["ok"], serde_json::json!(true));
-            }
-            other => panic!("expected Json, got {other:?}"),
-        }
-        assert!(next_stdout_item(&mut reader).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn test_next_stdout_item_改行なしeofの超過行もoversize_droppedとして可視化する() {
-        let payload = "c".repeat(MAX_CLAUDE_STDOUT_LINE_BYTES + 1);
-        let mut reader = tokio::io::BufReader::with_capacity(64 * 1024, payload.as_bytes());
-
-        let first = next_stdout_item(&mut reader).await.unwrap();
-        assert!(matches!(
-            first,
-            Some(ClaudeStdoutItem::OversizeDropped { bytes })
-                if bytes == MAX_CLAUDE_STDOUT_LINE_BYTES + 1
-        ));
-        assert!(next_stdout_item(&mut reader).await.unwrap().is_none());
     }
 }

--- a/src-tauri/src/infrastructure/agent_session/claude/session.rs
+++ b/src-tauri/src/infrastructure/agent_session/claude/session.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 
 use futures_util::stream::{self, Stream};
 use serde_json::Value;
+use tokio::io::AsyncBufRead;
 use tokio::sync::{mpsc, Mutex};
 
 use crate::domain::agent_session::entities::{
@@ -14,10 +15,13 @@ use crate::domain::agent_session::gateway::{
     AgentBackendError, AgentRuntimeEvent, AgentSessionRuntime, SessionSpec, TurnInput,
 };
 use crate::domain::agent_session::value_objects::{ModelId, PermissionMode};
+use crate::infrastructure::agent_session::stdout_line_reader::{
+    StdoutDiagnostics, StdoutItem, StdoutLineReader,
+};
 
 use super::convert::{convert_claude_message, ClaudeConvertState};
 use super::permission::claude_permission_response;
-use super::process::{ClaudeStdioHandle, ClaudeStdioProcess, ClaudeStdoutItem};
+use super::process::{ClaudeStdioHandle, ClaudeStdioProcess};
 use super::wire::{
     claude_wire_mode, control_request_subtype, initialize_request, interrupt_request, message_type,
     set_model_request, set_permission_mode_request, user_message, ClaudeWireMode,
@@ -45,6 +49,18 @@ struct ClaudeRuntimeProcess {
     closed: Arc<AtomicBool>,
 }
 
+#[async_trait::async_trait]
+trait ClaudeResponseWriter {
+    async fn write_json(&self, value: &Value) -> Result<(), String>;
+}
+
+#[async_trait::async_trait]
+impl ClaudeResponseWriter for ClaudeStdioHandle {
+    async fn write_json(&self, value: &Value) -> Result<(), String> {
+        ClaudeStdioHandle::write_json(self, value).await
+    }
+}
+
 #[derive(Debug)]
 struct ClaudeRuntimeState {
     session_id: String,
@@ -69,7 +85,7 @@ struct ClaudeRuntimeState {
     turn_generation: u64,
     synthetic_abort_turn_generation: Option<u64>,
     discarded_synthetic_abort_generations: HashSet<u64>,
-    oversize_dropped_count: u64,
+    stdout_diagnostics: StdoutDiagnostics,
 }
 
 impl ClaudeSessionRuntime {
@@ -146,7 +162,7 @@ impl ClaudeRuntimeState {
             turn_generation: 0,
             synthetic_abort_turn_generation: None,
             discarded_synthetic_abort_generations: HashSet::new(),
-            oversize_dropped_count: 0,
+            stdout_diagnostics: StdoutDiagnostics::default(),
         }
     }
 
@@ -311,7 +327,7 @@ async fn spawn_runtime_process(
     let read_handle = handle.clone();
     tokio::spawn(async move {
         read_loop(
-            &mut process,
+            process.stdout_mut(),
             read_handle,
             read_state,
             events_tx,
@@ -333,29 +349,44 @@ async fn spawn_runtime_process(
     Ok(ClaudeRuntimeProcess { handle, closed })
 }
 
-async fn read_loop(
-    process: &mut ClaudeStdioProcess,
-    handle: ClaudeStdioHandle,
+async fn read_loop<R, W>(
+    stdout: &mut StdoutLineReader<R>,
+    handle: W,
     state: Arc<Mutex<ClaudeRuntimeState>>,
     events_tx: mpsc::UnboundedSender<AgentRuntimeEvent>,
     closed: Arc<AtomicBool>,
     requested_resume_id: Option<String>,
     initial_wire_mode: super::wire::ClaudeWireMode,
-) {
+) where
+    R: AsyncBufRead + Unpin,
+    W: ClaudeResponseWriter,
+{
     let mut convert_state = ClaudeConvertState::new(requested_resume_id, initial_wire_mode);
     loop {
-        match process.next_json().await {
-            Ok(Some(ClaudeStdoutItem::OversizeDropped { bytes })) => {
+        match stdout.next().await {
+            Ok(Some(StdoutItem::Oversize { probe })) => {
                 if closed.load(Ordering::Relaxed) {
                     break;
                 }
                 let event = {
                     let mut state = state.lock().await;
-                    record_oversize_drop(&mut state, bytes)
+                    let content = state
+                        .stdout_diagnostics
+                        .record_oversize_drop("claude", &probe);
+                    oversize_drop_event(content)
                 };
                 let _ = events_tx.send(event);
             }
-            Ok(Some(ClaudeStdoutItem::Json(message))) => {
+            Ok(Some(StdoutItem::NonJson { probe })) => {
+                if closed.load(Ordering::Relaxed) {
+                    break;
+                }
+                let mut state = state.lock().await;
+                state
+                    .stdout_diagnostics
+                    .record_non_json_skip("claude", &probe);
+            }
+            Ok(Some(StdoutItem::Json(message))) => {
                 if closed.load(Ordering::Relaxed) {
                     break;
                 }
@@ -400,11 +431,9 @@ async fn read_loop(
     }
 }
 
-fn record_oversize_drop(state: &mut ClaudeRuntimeState, bytes: usize) -> AgentRuntimeEvent {
-    state.oversize_dropped_count = state.oversize_dropped_count.saturating_add(1);
-    log::warn!("claude stdout dropped an oversized line: {bytes} bytes");
+fn oversize_drop_event(content: String) -> AgentRuntimeEvent {
     AgentRuntimeEvent::PartsMerged(vec![MessagePart::Error {
-        content: "backend からの応答 1 件がサイズ上限（8MB）を超えたため破棄しました".to_string(),
+        content,
         parent_tool_use_id: None,
     }])
 }
@@ -550,7 +579,11 @@ async fn emit_crash_if_unexpected(
         state.turn_active = false;
         state.aborting = false;
         state.pending_inputs.clear();
-        (was_turn_active, aborting, state.oversize_dropped_count)
+        (
+            was_turn_active,
+            aborting,
+            state.stdout_diagnostics.oversize_dropped_count(),
+        )
     };
     let message = if oversize_dropped_count > 0 {
         format!("{message}（サイズ超過破棄 {oversize_dropped_count} 件）")
@@ -582,7 +615,7 @@ fn prepare_start_turn_state(
     state.synthetic_abort_turn_generation = None;
     state.turn_generation = state.turn_generation.saturating_add(1);
     state.turn_active = true;
-    state.oversize_dropped_count = 0;
+    state.stdout_diagnostics.reset();
     let next_wire_mode = claude_wire_mode(input.permission_mode, input.plan_mode);
     let replace_spec = if restart_after_synthetic_abort || state.system_prompt != system_prompt {
         let mut spec = state.session_spec_with_system_prompt(system_prompt);
@@ -615,6 +648,17 @@ mod tests {
         PermissionRequestStatus, TokenUsage, TurnStopReason,
     };
     use crate::domain::agent_session::value_objects::JsonPayload;
+    use crate::infrastructure::agent_session::stdout_line_reader::{LineProbe, StdoutLineReader};
+    use tokio::io::AsyncWriteExt;
+
+    struct NoopResponseWriter;
+
+    #[async_trait::async_trait]
+    impl ClaudeResponseWriter for NoopResponseWriter {
+        async fn write_json(&self, _value: &Value) -> Result<(), String> {
+            Ok(())
+        }
+    }
 
     #[cfg(unix)]
     fn write_fake_claude_cli(dir: &std::path::Path) -> std::path::PathBuf {
@@ -831,15 +875,28 @@ exec sleep 30
     #[test]
     fn test_record_oversize_dropは_error_partを合成しカウントを加算する() {
         let mut state = test_state();
+        let probe = LineProbe {
+            kind_hint: Some("assistant".to_string()),
+            bytes: 9 * 1024 * 1024,
+        };
 
-        let event = record_oversize_drop(&mut state, 9 * 1024 * 1024);
-        let _ = record_oversize_drop(&mut state, 10 * 1024 * 1024);
+        let content = state
+            .stdout_diagnostics
+            .record_oversize_drop("claude", &probe);
+        let event = oversize_drop_event(content);
+        let _ = state.stdout_diagnostics.record_oversize_drop(
+            "claude",
+            &LineProbe {
+                kind_hint: None,
+                bytes: 10 * 1024 * 1024,
+            },
+        );
 
-        assert_eq!(state.oversize_dropped_count, 2);
+        assert_eq!(state.stdout_diagnostics.oversize_dropped_count(), 2);
         assert_eq!(
             event,
             AgentRuntimeEvent::PartsMerged(vec![MessagePart::Error {
-                content: "backend からの応答 1 件がサイズ上限（8MB）を超えたため破棄しました"
+                content: "backend からの応答 1 件がサイズ上限（8MB）を超えたため破棄しました（推定種別: assistant）"
                     .to_string(),
                 parent_tool_use_id: None,
             }])
@@ -847,9 +904,108 @@ exec sleep 30
     }
 
     #[test]
+    fn test_record_non_json_skipは_skipカウントを加算する() {
+        let mut state = test_state();
+        let probe = LineProbe {
+            kind_hint: None,
+            bytes: 17,
+        };
+
+        state
+            .stdout_diagnostics
+            .record_non_json_skip("claude", &probe);
+        state
+            .stdout_diagnostics
+            .record_non_json_skip("claude", &probe);
+
+        assert_eq!(state.stdout_diagnostics.skipped_non_json_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_claude_read_loopは_mixed_stdout_fixture後も処理を継続する() {
+        let fixture =
+            include_bytes!("../../../../tests/fixtures/agent_session/mixed_stdout_claude.jsonl");
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        let mut stdout = StdoutLineReader::with_max_line_bytes(
+            tokio::io::BufReader::with_capacity(64, reader),
+            256,
+        );
+        let state = Arc::new(Mutex::new(test_state()));
+        let read_state = Arc::clone(&state);
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let read_closed = Arc::clone(&closed);
+        let read_task = tokio::spawn(async move {
+            read_loop(
+                &mut stdout,
+                NoopResponseWriter,
+                read_state,
+                events_tx,
+                read_closed,
+                None,
+                ClaudeWireMode::Default,
+            )
+            .await;
+        });
+
+        writer.write_all(fixture).await.unwrap();
+        let events = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            let mut events = Vec::new();
+            loop {
+                let event = events_rx.recv().await.unwrap();
+                let completed = matches!(event, AgentRuntimeEvent::TurnCompleted(_));
+                events.push(event);
+                if completed {
+                    return events;
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        let state = state.lock().await;
+        assert_eq!(state.stdout_diagnostics.skipped_non_json_count(), 2);
+        assert_eq!(state.stdout_diagnostics.oversize_dropped_count(), 1);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentRuntimeEvent::TurnCompleted(TurnResult::Completed { .. })
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentRuntimeEvent::PartsMerged(parts)
+                if parts.iter().any(|part| matches!(
+                    part,
+                    MessagePart::Error { content, .. }
+                        if content.contains("推定種別: assistant")
+                ))
+        )));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            AgentRuntimeEvent::Fatal { .. }
+                | AgentRuntimeEvent::TurnCompleted(TurnResult::Interrupted {
+                    reason: InterruptReason::Crash,
+                    ..
+                })
+        )));
+        assert!(!read_task.is_finished());
+        drop(state);
+        closed.store(true, Ordering::Relaxed);
+        read_task.abort();
+    }
+
+    #[test]
     fn test_prepare_start_turn_stateは_サイズ超過破棄カウントをリセットする() {
         let mut state = test_state();
-        state.oversize_dropped_count = 3;
+        let probe = LineProbe {
+            kind_hint: None,
+            bytes: 9 * 1024 * 1024,
+        };
+        let _ = state
+            .stdout_diagnostics
+            .record_oversize_drop("claude", &probe);
+        state
+            .stdout_diagnostics
+            .record_non_json_skip("claude", &probe);
 
         let input = TurnInput {
             prompt: "next".to_string(),
@@ -862,7 +1018,8 @@ exec sleep 30
         };
         prepare_start_turn_state(&mut state, &input, input.system_prompt.clone());
 
-        assert_eq!(state.oversize_dropped_count, 0);
+        assert_eq!(state.stdout_diagnostics.oversize_dropped_count(), 0);
+        assert_eq!(state.stdout_diagnostics.skipped_non_json_count(), 0);
     }
 
     #[tokio::test]
@@ -871,7 +1028,16 @@ exec sleep 30
         {
             let mut state = state.lock().await;
             state.turn_active = true;
-            state.oversize_dropped_count = 2;
+            let probe = LineProbe {
+                kind_hint: None,
+                bytes: 9 * 1024 * 1024,
+            };
+            let _ = state
+                .stdout_diagnostics
+                .record_oversize_drop("claude", &probe);
+            let _ = state
+                .stdout_diagnostics
+                .record_oversize_drop("claude", &probe);
         }
         let (tx, mut rx) = mpsc::unbounded_channel();
         let closed = AtomicBool::new(false);

--- a/src-tauri/src/infrastructure/agent_session/codex/app_server.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/app_server.rs
@@ -2,10 +2,11 @@ use serde_json::Value;
 use std::process::Stdio;
 use std::sync::Arc;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::Mutex;
 
+use crate::infrastructure::agent_session::stdout_line_reader::StdoutLineReader;
 use crate::infrastructure::process::child_env::AgentChildEnv;
 use crate::infrastructure::process::child_process::{configure_process_group, staged_shutdown};
 use crate::infrastructure::process::child_stderr::drain_child_stderr;
@@ -57,7 +58,7 @@ impl CodexAppServerHandle {
 
 pub(crate) struct CodexAppServerProcess {
     handle: CodexAppServerHandle,
-    stdout: Lines<BufReader<ChildStdout>>,
+    stdout: StdoutLineReader<BufReader<ChildStdout>>,
 }
 
 impl CodexAppServerProcess {
@@ -105,7 +106,7 @@ impl CodexAppServerProcess {
                 stdin: Arc::new(Mutex::new(Some(stdin))),
                 pid_registration,
             },
-            stdout: BufReader::new(stdout).lines(),
+            stdout: StdoutLineReader::new(BufReader::new(stdout)),
         })
     }
 
@@ -113,16 +114,8 @@ impl CodexAppServerProcess {
         self.handle.clone()
     }
 
-    pub(crate) async fn next_json(&mut self) -> Result<Option<Value>, String> {
-        let Some(line) = self
-            .stdout
-            .next_line()
-            .await
-            .map_err(|error| format!("failed to read codex app-server stdout: {error}"))?
-        else {
-            return Ok(None);
-        };
-        decode_jsonrpc_line(&line).map(Some)
+    pub(crate) fn stdout_mut(&mut self) -> &mut StdoutLineReader<BufReader<ChildStdout>> {
+        &mut self.stdout
     }
 
     pub(crate) async fn shutdown(self) {
@@ -136,20 +129,16 @@ pub(crate) fn encode_jsonl(message: &Value) -> Result<Vec<u8>, String> {
     Ok(line)
 }
 
-pub(crate) fn decode_jsonrpc_line(line: &str) -> Result<Value, String> {
-    serde_json::from_str::<Value>(line).map_err(|e| format!("invalid app-server JSON-RPC: {e}"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
     #[test]
-    fn test_jsonl_encode_decode() {
+    fn test_jsonl_encode() {
         let line = encode_jsonl(&json!({"id": 1, "result": {}})).unwrap();
         assert!(line.ends_with(b"\n"));
-        let decoded = decode_jsonrpc_line(std::str::from_utf8(&line).unwrap().trim()).unwrap();
+        let decoded = serde_json::from_slice::<Value>(&line).unwrap();
         assert_eq!(decoded["id"], 1);
     }
 

--- a/src-tauri/src/infrastructure/agent_session/codex/convert.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/convert.rs
@@ -12,12 +12,13 @@ use crate::domain::agent_session::value_objects::{
 };
 
 use super::wire::{
-    message_kind, AppServerMessageKind, METHOD_THREAD_RESUME, METHOD_THREAD_START,
-    METHOD_TURN_START, NOTIFY_AGENT_MESSAGE_DELTA, NOTIFY_COMMAND_OUTPUT_DELTA, NOTIFY_ERROR,
-    NOTIFY_FILE_CHANGE_OUTPUT_DELTA, NOTIFY_FILE_CHANGE_PATCH_UPDATED, NOTIFY_ITEM_COMPLETED,
-    NOTIFY_ITEM_STARTED, NOTIFY_THREAD_COMPACTED, NOTIFY_THREAD_STARTED,
-    NOTIFY_THREAD_TOKEN_USAGE_UPDATED, NOTIFY_TURN_COMPLETED, NOTIFY_TURN_STARTED,
-    REQUEST_COMMAND_APPROVAL, REQUEST_FILE_CHANGE_APPROVAL, REQUEST_PERMISSIONS_APPROVAL,
+    message_kind, AppServerMessageKind, METHOD_INITIALIZE, METHOD_THREAD_RESUME,
+    METHOD_THREAD_START, METHOD_TURN_START, NOTIFY_AGENT_MESSAGE_DELTA,
+    NOTIFY_COMMAND_OUTPUT_DELTA, NOTIFY_ERROR, NOTIFY_FILE_CHANGE_OUTPUT_DELTA,
+    NOTIFY_FILE_CHANGE_PATCH_UPDATED, NOTIFY_ITEM_COMPLETED, NOTIFY_ITEM_STARTED,
+    NOTIFY_THREAD_COMPACTED, NOTIFY_THREAD_STARTED, NOTIFY_THREAD_TOKEN_USAGE_UPDATED,
+    NOTIFY_TURN_COMPLETED, NOTIFY_TURN_STARTED, REQUEST_COMMAND_APPROVAL,
+    REQUEST_FILE_CHANGE_APPROVAL, REQUEST_PERMISSIONS_APPROVAL,
 };
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -56,7 +57,7 @@ fn convert_response(
     if let Some(error) = message.get("error") {
         if matches!(
             source_method.as_deref(),
-            Some(METHOD_THREAD_START | METHOD_THREAD_RESUME)
+            Some(METHOD_INITIALIZE | METHOD_THREAD_START | METHOD_THREAD_RESUME)
         ) {
             let mut events = Vec::new();
             if state.requested_resume_id.is_some() {
@@ -1087,6 +1088,35 @@ mod tests {
             vec![AgentRuntimeEvent::Fatal {
                 message: "bad api key".to_string(),
             }]
+        );
+    }
+
+    #[test]
+    fn test_initialize_response_errorは_fatalにする() {
+        let mut state = CodexConvertState {
+            requested_resume_id: Some("thread-old".to_string()),
+            ..CodexConvertState::default()
+        };
+        state
+            .client_response_methods
+            .insert(1, METHOD_INITIALIZE.to_string());
+
+        let events = convert_jsonrpc_message(
+            &json!({
+                "id": 1,
+                "error": { "message": "initialize failed" }
+            }),
+            &mut state,
+        );
+
+        assert_eq!(
+            events,
+            vec![
+                AgentRuntimeEvent::BackendSessionCleared,
+                AgentRuntimeEvent::Fatal {
+                    message: "initialize failed".to_string(),
+                },
+            ]
         );
     }
 

--- a/src-tauri/src/infrastructure/agent_session/codex/convert.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/convert.rs
@@ -12,21 +12,19 @@ use crate::domain::agent_session::value_objects::{
 };
 
 use super::wire::{
-    message_kind, AppServerMessageKind, METHOD_TURN_START, NOTIFY_AGENT_MESSAGE_DELTA,
-    NOTIFY_COMMAND_OUTPUT_DELTA, NOTIFY_ERROR, NOTIFY_FILE_CHANGE_OUTPUT_DELTA,
-    NOTIFY_FILE_CHANGE_PATCH_UPDATED, NOTIFY_ITEM_COMPLETED, NOTIFY_ITEM_STARTED,
-    NOTIFY_THREAD_COMPACTED, NOTIFY_THREAD_STARTED, NOTIFY_THREAD_TOKEN_USAGE_UPDATED,
-    NOTIFY_TURN_COMPLETED, NOTIFY_TURN_STARTED, REQUEST_COMMAND_APPROVAL,
-    REQUEST_FILE_CHANGE_APPROVAL, REQUEST_PERMISSIONS_APPROVAL,
+    message_kind, AppServerMessageKind, METHOD_THREAD_RESUME, METHOD_THREAD_START,
+    METHOD_TURN_START, NOTIFY_AGENT_MESSAGE_DELTA, NOTIFY_COMMAND_OUTPUT_DELTA, NOTIFY_ERROR,
+    NOTIFY_FILE_CHANGE_OUTPUT_DELTA, NOTIFY_FILE_CHANGE_PATCH_UPDATED, NOTIFY_ITEM_COMPLETED,
+    NOTIFY_ITEM_STARTED, NOTIFY_THREAD_COMPACTED, NOTIFY_THREAD_STARTED,
+    NOTIFY_THREAD_TOKEN_USAGE_UPDATED, NOTIFY_TURN_COMPLETED, NOTIFY_TURN_STARTED,
+    REQUEST_COMMAND_APPROVAL, REQUEST_FILE_CHANGE_APPROVAL, REQUEST_PERMISSIONS_APPROVAL,
 };
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct CodexConvertState {
-    pub thread_id: Option<String>,
     pub turn_id: Option<String>,
     pub latest_usage: Option<TokenUsage>,
     pub requested_resume_id: Option<String>,
-    pub startup_request_id: Option<u64>,
     pub client_response_methods: HashMap<u64, String>,
     pub compaction_in_progress: bool,
 }
@@ -56,7 +54,10 @@ fn convert_response(
 ) -> Vec<AgentRuntimeEvent> {
     let source_method = state.client_response_methods.remove(&id);
     if let Some(error) = message.get("error") {
-        if state.startup_request_id == Some(id) {
+        if matches!(
+            source_method.as_deref(),
+            Some(METHOD_THREAD_START | METHOD_THREAD_RESUME)
+        ) {
             let mut events = Vec::new();
             if state.requested_resume_id.is_some() {
                 events.push(AgentRuntimeEvent::BackendSessionCleared);
@@ -88,7 +89,6 @@ fn convert_response(
     }
     let result = message.get("result").unwrap_or(&Value::Null);
     if let Some(thread_id) = get_string(result, &["thread", "id"]) {
-        state.thread_id = Some(thread_id.to_string());
         return vec![AgentRuntimeEvent::SessionEstablished {
             backend_session_id: thread_id.to_string(),
             resume: resume_outcome(state.requested_resume_id.as_deref(), thread_id),
@@ -109,7 +109,6 @@ fn convert_notification(
     match method {
         NOTIFY_THREAD_STARTED => get_string(params, &["thread", "id"])
             .map(|thread_id| {
-                state.thread_id = Some(thread_id.to_string());
                 vec![AgentRuntimeEvent::SessionEstablished {
                     backend_session_id: thread_id.to_string(),
                     resume: resume_outcome(state.requested_resume_id.as_deref(), thread_id),
@@ -1070,9 +1069,11 @@ mod tests {
     #[test]
     fn test_startup_response_errorは新規threadでも_fatalにする() {
         let mut state = CodexConvertState {
-            startup_request_id: Some(2),
             ..CodexConvertState::default()
         };
+        state
+            .client_response_methods
+            .insert(2, METHOD_THREAD_START.to_string());
         let events = convert_jsonrpc_message(
             &json!({
                 "id": 2,
@@ -1093,9 +1094,11 @@ mod tests {
     fn test_startup_response_errorは_resume時だけ_backend_session_clearedを先行する() {
         let mut state = CodexConvertState {
             requested_resume_id: Some("thread-old".to_string()),
-            startup_request_id: Some(2),
             ..CodexConvertState::default()
         };
+        state
+            .client_response_methods
+            .insert(2, METHOD_THREAD_RESUME.to_string());
         let events = convert_jsonrpc_message(
             &json!({
                 "id": 2,

--- a/src-tauri/src/infrastructure/agent_session/codex/models.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/models.rs
@@ -250,11 +250,11 @@ where
         let Some(response) = pending_requests.take_response(&message)? else {
             continue;
         };
-        if response.id != expected_id {
-            continue;
-        }
         if let Some(error) = message.get("error") {
             return Err(error.to_string());
+        }
+        if response.id != expected_id {
+            continue;
         }
         return Ok(message
             .get("result")
@@ -369,6 +369,24 @@ mod tests {
             result,
             Err(message) if message.contains("expected exactly one of result or error")
         ));
+    }
+
+    #[tokio::test]
+    async fn test_one_shot_responseは_initialize_errorを期待応答より先に返す() {
+        let input = br#"{"id":1,"error":{"code":-32603,"message":"initialize failed"}}
+{"id":2,"result":{"skills":[]}}
+"#;
+        let mut stdout = StdoutLineReader::new(BufReader::new(&input[..]));
+        let mut pending = PendingClientRequests::default();
+        pending.register(1, METHOD_INITIALIZE);
+        pending.register(2, METHOD_SKILLS_LIST);
+
+        let result = read_one_shot_response(&mut stdout, pending, 2).await;
+
+        assert_eq!(
+            result.unwrap_err(),
+            json!({ "code": -32603, "message": "initialize failed" }).to_string()
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/infrastructure/agent_session/codex/models.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/models.rs
@@ -5,13 +5,17 @@ use crate::domain::agent_session::services::filter_agent_skills_for_query;
 use crate::domain::agent_session::value_objects::{
     BackendCapabilities, ModelDescriptor, ModelId, SkillEntry,
 };
+use crate::infrastructure::agent_session::stdout_line_reader::{
+    StdoutDiagnostics, StdoutItem, StdoutLineReader,
+};
 use serde_json::{json, Value};
+use tokio::io::AsyncBufRead;
 
 use super::app_server::CodexAppServerProcess;
 use super::wire::{
-    initialize_request, initialized_notification, message_kind, request, AppServerMessageKind,
-    METHOD_FUZZY_FILE_SEARCH, METHOD_SKILLS_LIST, METHOD_THREAD_ARCHIVE, METHOD_THREAD_FORK,
-    METHOD_THREAD_UNARCHIVE,
+    initialize_request, initialized_notification, request, PendingClientRequests,
+    METHOD_FUZZY_FILE_SEARCH, METHOD_INITIALIZE, METHOD_SKILLS_LIST, METHOD_THREAD_ARCHIVE,
+    METHOD_THREAD_FORK, METHOD_THREAD_UNARCHIVE,
 };
 
 pub(crate) const CODEX_BACKEND_ID: &str = "codex";
@@ -201,19 +205,13 @@ impl CodexBackend {
             return Err(AgentBackendError::Other(error));
         }
 
-        let response_result = tokio::time::timeout(std::time::Duration::from_secs(15), async {
-            loop {
-                let Some(message) = process.next_json().await? else {
-                    return Err("codex app-server exited before one-shot response".to_string());
-                };
-                if message_kind(&message) == Some(AppServerMessageKind::Response { id: 2 }) {
-                    if let Some(error) = message.get("error") {
-                        return Err(error.to_string());
-                    }
-                    return Ok(message.get("result").cloned().unwrap_or(Value::Null));
-                }
-            }
-        })
+        let mut pending_requests = PendingClientRequests::default();
+        pending_requests.register(1, METHOD_INITIALIZE);
+        pending_requests.register(2, method);
+        let response_result = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            read_one_shot_response(process.stdout_mut(), pending_requests, 2),
+        )
         .await;
         process.shutdown().await;
         response_result
@@ -222,6 +220,46 @@ impl CodexBackend {
                 max_retries: 0,
             })?
             .map_err(AgentBackendError::Other)
+    }
+}
+
+async fn read_one_shot_response<R>(
+    stdout: &mut StdoutLineReader<R>,
+    mut pending_requests: PendingClientRequests,
+    expected_id: u64,
+) -> Result<Value, String>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut diagnostics = StdoutDiagnostics::default();
+    loop {
+        let Some(item) = stdout.next().await? else {
+            return Err("codex app-server exited before one-shot response".to_string());
+        };
+        let message = match item {
+            StdoutItem::Json(message) => message,
+            StdoutItem::NonJson { probe } => {
+                diagnostics.record_non_json_skip("codex one-shot", &probe);
+                continue;
+            }
+            StdoutItem::Oversize { probe } => {
+                let _ = diagnostics.record_oversize_drop("codex one-shot", &probe);
+                continue;
+            }
+        };
+        let Some(response) = pending_requests.take_response(&message)? else {
+            continue;
+        };
+        if response.id != expected_id {
+            continue;
+        }
+        if let Some(error) = message.get("error") {
+            return Err(error.to_string());
+        }
+        return Ok(message
+            .get("result")
+            .cloned()
+            .expect("validated JSON-RPC response must contain result or error"));
     }
 }
 
@@ -297,6 +335,7 @@ fn result_array<'a>(result: &'a Value, key: &str) -> Vec<&'a Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::BufReader;
 
     #[test]
     fn test_codex_models_固定順と表示名を返す() {
@@ -314,6 +353,38 @@ mod tests {
 
         assert_eq!(ids, vec!["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",]);
         assert_eq!(names, vec!["GPT-5.6 Sol", "GPT-5.6 Terra", "GPT-5.6 Luna",]);
+    }
+
+    #[tokio::test]
+    async fn test_one_shot_response必須field欠落は失敗として扱う() {
+        let input = br#"{"id":2}
+"#;
+        let mut stdout = StdoutLineReader::new(BufReader::new(&input[..]));
+        let mut pending = PendingClientRequests::default();
+        pending.register(2, METHOD_SKILLS_LIST);
+
+        let result = read_one_shot_response(&mut stdout, pending, 2).await;
+
+        assert!(matches!(
+            result,
+            Err(message) if message.contains("expected exactly one of result or error")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_one_shot_responseは非jsonと上限超過行をskipして正常応答を返す() {
+        let payload = "x".repeat(64);
+        let input = format!(
+            "diagnostic output\n{{\"method\":\"ignored\",\"params\":{{\"data\":\"{payload}\"}}}}\n{{\"id\":2,\"result\":{{\"skills\":[]}}}}\n"
+        );
+        let mut stdout =
+            StdoutLineReader::with_max_line_bytes(BufReader::new(input.as_bytes()), 48);
+        let mut pending = PendingClientRequests::default();
+        pending.register(2, METHOD_SKILLS_LIST);
+
+        let result = read_one_shot_response(&mut stdout, pending, 2).await;
+
+        assert_eq!(result.unwrap(), json!({ "skills": [] }));
     }
 
     #[test]

--- a/src-tauri/src/infrastructure/agent_session/codex/session.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/session.rs
@@ -6,21 +6,25 @@ use std::time::Duration;
 
 use futures_util::stream::{self, Stream};
 use serde_json::{json, Value};
+use tokio::io::AsyncBufRead;
 use tokio::sync::{mpsc, Mutex};
 
-use crate::domain::agent_session::entities::{AttachmentPayload, PermissionResponse};
+use crate::domain::agent_session::entities::{AttachmentPayload, MessagePart, PermissionResponse};
 use crate::domain::agent_session::gateway::{
     AgentBackendError, AgentRuntimeEvent, AgentSessionRuntime, SessionSpec, TurnInput,
 };
 use crate::domain::agent_session::value_objects::{EditorContext, ModelId, PermissionMode};
+use crate::infrastructure::agent_session::stdout_line_reader::{
+    StdoutDiagnostics, StdoutItem, StdoutLineReader,
+};
 
 use super::app_server::{CodexAppServerHandle, CodexAppServerProcess};
 use super::convert::{convert_jsonrpc_message, CodexConvertState};
 use super::permission::{codex_permission_response, codex_permission_settings};
 use super::wire::{
     initialize_request, initialized_notification, message_kind, request, AppServerMessageKind,
-    METHOD_THREAD_RESUME, METHOD_THREAD_SETTINGS_UPDATE, METHOD_THREAD_START,
-    METHOD_TURN_INTERRUPT, METHOD_TURN_START,
+    PendingClientRequests, METHOD_INITIALIZE, METHOD_THREAD_NAME_SET, METHOD_THREAD_RESUME,
+    METHOD_THREAD_SETTINGS_UPDATE, METHOD_THREAD_START, METHOD_TURN_INTERRUPT, METHOD_TURN_START,
 };
 
 const AGENT_PROCESS_EXITED_UNEXPECTEDLY: &str = "Agent process exited unexpectedly";
@@ -40,11 +44,10 @@ struct CodexRuntimeState {
     startup_error: Option<String>,
     cwd: String,
     model: ModelId,
-    permission_mode: PermissionMode,
-    plan_mode: bool,
     permission_profile_id: Option<String>,
     pending_methods: HashMap<u64, String>,
-    pending_client_methods: HashMap<u64, String>,
+    pending_client_requests: PendingClientRequests,
+    stdout_diagnostics: StdoutDiagnostics,
 }
 
 impl CodexSessionRuntime {
@@ -79,7 +82,7 @@ impl CodexSessionRuntime {
     }
 
     async fn open_once(cli_path: String, spec: SessionSpec) -> Result<Self, AgentBackendError> {
-        let process = CodexAppServerProcess::spawn(
+        let mut process = CodexAppServerProcess::spawn(
             &cli_path,
             &spec.session_id,
             Some(&spec.cwd),
@@ -90,33 +93,40 @@ impl CodexSessionRuntime {
         .map_err(AgentBackendError::Other)?;
         let handle = process.handle();
         let (events_tx, events_rx) = mpsc::unbounded_channel();
+        let startup_request_id = 2;
+        let startup_method = if spec.resume.is_some() {
+            METHOD_THREAD_RESUME
+        } else {
+            METHOD_THREAD_START
+        };
+        let mut pending_client_requests = PendingClientRequests::default();
+        pending_client_requests.register(1, METHOD_INITIALIZE);
+        pending_client_requests.register(startup_request_id, startup_method);
         let state = Arc::new(Mutex::new(CodexRuntimeState {
             thread_id: None,
             turn_id: None,
             startup_error: None,
             cwd: spec.cwd.clone(),
             model: spec.model.clone(),
-            permission_mode: spec.permission_mode,
-            plan_mode: spec.plan_mode,
             permission_profile_id: spec.permission_profile_id.clone(),
             pending_methods: HashMap::new(),
-            pending_client_methods: HashMap::new(),
+            pending_client_requests,
+            stdout_diagnostics: StdoutDiagnostics::default(),
         }));
         let closed = Arc::new(AtomicBool::new(false));
         let read_state = Arc::clone(&state);
         let read_closed = Arc::clone(&closed);
         let requested_resume_id = spec.resume.clone();
-        let startup_request_id = 2;
         tokio::spawn(async move {
             read_loop(
-                process,
+                process.stdout_mut(),
                 read_state,
                 events_tx,
                 read_closed,
                 requested_resume_id,
-                startup_request_id,
             )
             .await;
+            process.shutdown().await;
         });
 
         if let Err(error) = handle
@@ -169,6 +179,28 @@ impl CodexSessionRuntime {
     fn next_request_id(&self) -> u64 {
         self.next_id.fetch_add(1, Ordering::Relaxed)
     }
+
+    async fn write_tracked_request(
+        &self,
+        request_id: u64,
+        method: &str,
+        value: &Value,
+    ) -> Result<(), AgentBackendError> {
+        self.state
+            .lock()
+            .await
+            .pending_client_requests
+            .register(request_id, method);
+        if let Err(error) = self.handle.write_json(value).await {
+            self.state
+                .lock()
+                .await
+                .pending_client_requests
+                .remove(request_id);
+            return Err(AgentBackendError::Other(error));
+        }
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -186,30 +218,12 @@ impl AgentSessionRuntime for CodexSessionRuntime {
         let request_id = self.next_request_id();
         let request = {
             let mut state = self.state.lock().await;
-            state.permission_mode = input.permission_mode;
-            state.plan_mode = input.plan_mode;
             state.permission_profile_id = input.permission_profile_id.clone();
-            let request = build_turn_start_request(request_id, &thread_id, &state, input)?;
-            state
-                .pending_client_methods
-                .insert(request_id, METHOD_TURN_START.to_string());
-            request
+            state.stdout_diagnostics.reset();
+            build_turn_start_request(request_id, &thread_id, &state, input)?
         };
-        if let Err(error) = self
-            .handle
-            .write_json(&request)
+        self.write_tracked_request(request_id, METHOD_TURN_START, &request)
             .await
-            .map_err(AgentBackendError::Other)
-        {
-            self.state
-                .lock()
-                .await
-                .pending_client_methods
-                .remove(&request_id);
-            Err(error)
-        } else {
-            Ok(())
-        }
     }
 
     async fn interrupt(&self) -> Result<(), AgentBackendError> {
@@ -223,18 +237,17 @@ impl AgentSessionRuntime for CodexSessionRuntime {
         let Some(turn_id) = turn_id else {
             return Ok(());
         };
+        let request_id = self.next_request_id();
         let value = request(
-            self.next_request_id(),
+            request_id,
             METHOD_TURN_INTERRUPT,
             json!({
                 "threadId": thread_id,
                 "turnId": turn_id,
             }),
         );
-        self.handle
-            .write_json(&value)
+        self.write_tracked_request(request_id, METHOD_TURN_INTERRUPT, &value)
             .await
-            .map_err(AgentBackendError::Other)
     }
 
     async fn respond_permission(
@@ -264,9 +277,7 @@ impl AgentSessionRuntime for CodexSessionRuntime {
         plan_mode: bool,
     ) -> Result<(), AgentBackendError> {
         let (thread_id, cwd, permission_profile_id) = {
-            let mut state = self.state.lock().await;
-            state.permission_mode = mode;
-            state.plan_mode = plan_mode;
+            let state = self.state.lock().await;
             (
                 state.thread_id.clone(),
                 state.cwd.clone(),
@@ -286,14 +297,10 @@ impl AgentSessionRuntime for CodexSessionRuntime {
         if let Some(sandbox_policy) = settings.sandbox_policy {
             params["sandboxPolicy"] = sandbox_policy;
         }
-        self.handle
-            .write_json(&request(
-                self.next_request_id(),
-                METHOD_THREAD_SETTINGS_UPDATE,
-                params,
-            ))
+        let request_id = self.next_request_id();
+        let value = request(request_id, METHOD_THREAD_SETTINGS_UPDATE, params);
+        self.write_tracked_request(request_id, METHOD_THREAD_SETTINGS_UPDATE, &value)
             .await
-            .map_err(AgentBackendError::Other)
     }
 
     async fn set_model(&self, model: &ModelId) -> Result<(), AgentBackendError> {
@@ -306,17 +313,17 @@ impl AgentSessionRuntime for CodexSessionRuntime {
         let Some(thread_id) = thread_id else {
             return Ok(());
         };
-        self.handle
-            .write_json(&request(
-                self.next_request_id(),
-                super::wire::METHOD_THREAD_NAME_SET,
-                json!({
-                    "threadId": thread_id,
-                    "name": title,
-                }),
-            ))
+        let request_id = self.next_request_id();
+        let value = request(
+            request_id,
+            METHOD_THREAD_NAME_SET,
+            json!({
+                "threadId": thread_id,
+                "name": title,
+            }),
+        );
+        self.write_tracked_request(request_id, METHOD_THREAD_NAME_SET, &value)
             .await
-            .map_err(AgentBackendError::Other)
     }
 
     async fn close(&self) {
@@ -334,22 +341,44 @@ fn take_pending_method(
     })
 }
 
-async fn read_loop(
-    mut process: CodexAppServerProcess,
+async fn read_loop<R>(
+    stdout: &mut StdoutLineReader<R>,
     state: Arc<Mutex<CodexRuntimeState>>,
     events_tx: mpsc::UnboundedSender<AgentRuntimeEvent>,
     closed: Arc<AtomicBool>,
     requested_resume_id: Option<String>,
-    startup_request_id: u64,
-) {
+) where
+    R: AsyncBufRead + Unpin,
+{
     let mut convert_state = CodexConvertState {
         requested_resume_id,
-        startup_request_id: Some(startup_request_id),
         ..CodexConvertState::default()
     };
     loop {
-        match process.next_json().await {
-            Ok(Some(message)) => {
+        match stdout.next().await {
+            Ok(Some(StdoutItem::NonJson { probe })) => {
+                if closed.load(Ordering::Relaxed) {
+                    break;
+                }
+                let mut state = state.lock().await;
+                state
+                    .stdout_diagnostics
+                    .record_non_json_skip("codex", &probe);
+            }
+            Ok(Some(StdoutItem::Oversize { probe })) => {
+                if closed.load(Ordering::Relaxed) {
+                    break;
+                }
+                let event = {
+                    let mut state = state.lock().await;
+                    let content = state
+                        .stdout_diagnostics
+                        .record_oversize_drop("codex", &probe);
+                    oversize_drop_event(content)
+                };
+                let _ = events_tx.send(event);
+            }
+            Ok(Some(StdoutItem::Json(message))) => {
                 if closed.load(Ordering::Relaxed) {
                     break;
                 }
@@ -357,10 +386,22 @@ async fn read_loop(
                     Some(AppServerMessageKind::Request { id, method }) => {
                         state.lock().await.pending_methods.insert(id, method);
                     }
-                    Some(AppServerMessageKind::Response { id }) => {
-                        if let Some(method) = state.lock().await.pending_client_methods.remove(&id)
-                        {
-                            convert_state.client_response_methods.insert(id, method);
+                    Some(AppServerMessageKind::Response { .. }) => {
+                        let pending_response = {
+                            let mut state = state.lock().await;
+                            state.pending_client_requests.take_response(&message)
+                        };
+                        match pending_response {
+                            Ok(Some(response)) => {
+                                convert_state
+                                    .client_response_methods
+                                    .insert(response.id, response.method);
+                            }
+                            Ok(None) => {}
+                            Err(error) => {
+                                emit_read_failure(&state, &events_tx, &closed, &error).await;
+                                break;
+                            }
                         }
                     }
                     _ => {}
@@ -392,41 +433,56 @@ async fn read_loop(
                 }
             }
             Ok(None) => {
-                if !closed.load(Ordering::Relaxed) {
-                    log::warn!("Codex app-server exited unexpectedly");
-                    if state.lock().await.turn_id.is_some() {
-                        let _ = events_tx.send(AgentRuntimeEvent::TurnCompleted(
-                            crate::domain::agent_session::entities::TurnResult::Interrupted {
-                                reason:
-                                    crate::domain::agent_session::entities::InterruptReason::Crash,
-                                error: Some(AGENT_PROCESS_EXITED_UNEXPECTEDLY.to_string()),
-                            },
-                        ));
-                    }
-                    let _ = events_tx.send(AgentRuntimeEvent::Fatal {
-                        message: AGENT_PROCESS_EXITED_UNEXPECTEDLY.to_string(),
-                    });
-                }
+                log::warn!("Codex app-server exited unexpectedly");
+                emit_read_failure(
+                    &state,
+                    &events_tx,
+                    &closed,
+                    AGENT_PROCESS_EXITED_UNEXPECTEDLY,
+                )
+                .await;
                 break;
             }
             Err(error) => {
-                if !closed.load(Ordering::Relaxed) {
-                    if state.lock().await.turn_id.is_some() {
-                        let _ = events_tx.send(AgentRuntimeEvent::TurnCompleted(
-                            crate::domain::agent_session::entities::TurnResult::Interrupted {
-                                reason:
-                                    crate::domain::agent_session::entities::InterruptReason::Crash,
-                                error: Some(error.clone()),
-                            },
-                        ));
-                    }
-                    let _ = events_tx.send(AgentRuntimeEvent::Fatal { message: error });
-                }
+                emit_read_failure(&state, &events_tx, &closed, &error).await;
                 break;
             }
         }
     }
-    process.shutdown().await;
+}
+
+fn oversize_drop_event(content: String) -> AgentRuntimeEvent {
+    AgentRuntimeEvent::PartsMerged(vec![MessagePart::Error {
+        content,
+        parent_tool_use_id: None,
+    }])
+}
+
+async fn emit_read_failure(
+    state: &Arc<Mutex<CodexRuntimeState>>,
+    events_tx: &mpsc::UnboundedSender<AgentRuntimeEvent>,
+    closed: &AtomicBool,
+    error: &str,
+) {
+    if closed.load(Ordering::Relaxed) {
+        return;
+    }
+    let turn_active = {
+        let mut state = state.lock().await;
+        state.startup_error = Some(error.to_string());
+        state.turn_id.is_some()
+    };
+    if turn_active {
+        let _ = events_tx.send(AgentRuntimeEvent::TurnCompleted(
+            crate::domain::agent_session::entities::TurnResult::Interrupted {
+                reason: crate::domain::agent_session::entities::InterruptReason::Crash,
+                error: Some(error.to_string()),
+            },
+        ));
+    }
+    let _ = events_tx.send(AgentRuntimeEvent::Fatal {
+        message: error.to_string(),
+    });
 }
 
 fn startup_timeout_for_spec(spec: &SessionSpec) -> Duration {
@@ -607,8 +663,11 @@ fn editor_context_value(context: Option<&EditorContext>) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::agent_session::entities::{InterruptReason, TurnResult};
     use crate::domain::agent_session::value_objects::ModelId;
     use crate::infrastructure::agent_session::codex::wire;
+    use crate::infrastructure::agent_session::stdout_line_reader::{LineProbe, StdoutLineReader};
+    use tokio::io::AsyncWriteExt;
 
     use super::*;
 
@@ -664,6 +723,20 @@ exec sleep 30
         }
     }
 
+    fn runtime_state() -> CodexRuntimeState {
+        CodexRuntimeState {
+            thread_id: Some("thread".to_string()),
+            turn_id: Some("turn".to_string()),
+            startup_error: None,
+            cwd: "/repo".to_string(),
+            model: ModelId::parse("gpt-5.6-sol").unwrap(),
+            permission_profile_id: None,
+            pending_methods: HashMap::new(),
+            pending_client_requests: PendingClientRequests::default(),
+            stdout_diagnostics: StdoutDiagnostics::default(),
+        }
+    }
+
     #[test]
     fn test_thread_start_planは検証済み_string_collaboration_modeを使う() {
         let value = build_thread_start_request(7, &spec(true)).unwrap();
@@ -677,18 +750,8 @@ exec sleep 30
 
     #[test]
     fn test_turn_start_imagesは_data_urlを使う() {
-        let state = CodexRuntimeState {
-            thread_id: Some("thread".to_string()),
-            turn_id: None,
-            startup_error: None,
-            cwd: "/repo".to_string(),
-            model: ModelId::parse("gpt-5.6-sol").unwrap(),
-            permission_mode: PermissionMode::Ask,
-            plan_mode: false,
-            permission_profile_id: None,
-            pending_methods: HashMap::new(),
-            pending_client_methods: HashMap::new(),
-        };
+        let mut state = runtime_state();
+        state.turn_id = None;
         let value = build_turn_start_request(
             8,
             "thread",
@@ -742,11 +805,10 @@ exec sleep 30
             startup_error: None,
             cwd: "/repo".to_string(),
             model: ModelId::parse("gpt-5.6-sol").unwrap(),
-            permission_mode: PermissionMode::Ask,
-            plan_mode: false,
             permission_profile_id: None,
             pending_methods: HashMap::new(),
-            pending_client_methods: HashMap::new(),
+            pending_client_requests: PendingClientRequests::default(),
+            stdout_diagnostics: StdoutDiagnostics::default(),
         };
 
         assert!(matches!(
@@ -760,6 +822,211 @@ exec sleep 30
             take_pending_method(&mut state, 7).unwrap(),
             wire::REQUEST_COMMAND_APPROVAL
         );
+    }
+
+    #[tokio::test]
+    async fn test_startup_response必須field欠落はread_loopで失敗する() {
+        let input = br#"{"id":2}
+"#;
+        let mut stdout = StdoutLineReader::new(tokio::io::BufReader::new(&input[..]));
+        let mut runtime_state = runtime_state();
+        runtime_state.thread_id = None;
+        runtime_state.turn_id = None;
+        runtime_state
+            .pending_client_requests
+            .register(2, METHOD_THREAD_START);
+        let state = Arc::new(Mutex::new(runtime_state));
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+
+        read_loop(
+            &mut stdout,
+            Arc::clone(&state),
+            events_tx,
+            Arc::new(AtomicBool::new(false)),
+            None,
+        )
+        .await;
+
+        assert!(state
+            .lock()
+            .await
+            .startup_error
+            .as_deref()
+            .is_some_and(|message| message.contains("expected exactly one")));
+        assert!(matches!(
+            events_rx.try_recv().unwrap(),
+            AgentRuntimeEvent::Fatal { message }
+                if message.contains("expected exactly one of result or error")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_turn_start_response必須field欠落はread_loopで失敗する() {
+        let input = br#"{"id":100}
+"#;
+        let mut stdout = StdoutLineReader::new(tokio::io::BufReader::new(&input[..]));
+        let mut runtime_state = runtime_state();
+        runtime_state
+            .pending_client_requests
+            .register(100, METHOD_TURN_START);
+        let state = Arc::new(Mutex::new(runtime_state));
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+
+        read_loop(
+            &mut stdout,
+            state,
+            events_tx,
+            Arc::new(AtomicBool::new(false)),
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            events_rx.try_recv().unwrap(),
+            AgentRuntimeEvent::TurnCompleted(TurnResult::Interrupted {
+                reason: InterruptReason::Crash,
+                error: Some(message),
+            }) if message.contains("expected exactly one of result or error")
+        ));
+        assert!(matches!(
+            events_rx.try_recv().unwrap(),
+            AgentRuntimeEvent::Fatal { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_codex_read_loopは_mixed_stdout_fixture後も処理を継続する() {
+        let fixture =
+            include_bytes!("../../../../tests/fixtures/agent_session/mixed_stdout_codex.jsonl");
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        let mut stdout = StdoutLineReader::with_max_line_bytes(
+            tokio::io::BufReader::with_capacity(64, reader),
+            256,
+        );
+        let state = Arc::new(Mutex::new(runtime_state()));
+        let read_state = Arc::clone(&state);
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let read_closed = Arc::clone(&closed);
+        let read_task = tokio::spawn(async move {
+            read_loop(&mut stdout, read_state, events_tx, read_closed, None).await;
+        });
+
+        writer.write_all(fixture).await.unwrap();
+        let events = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            let mut events = Vec::new();
+            loop {
+                let event = events_rx.recv().await.unwrap();
+                let processed_following_json = matches!(
+                    &event,
+                    AgentRuntimeEvent::PartsMerged(parts)
+                        if parts.iter().any(|part| matches!(
+                            part,
+                            MessagePart::Text { content, .. } if content == "ok"
+                        ))
+                );
+                events.push(event);
+                if processed_following_json {
+                    return events;
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        let state = state.lock().await;
+        assert_eq!(state.stdout_diagnostics.skipped_non_json_count(), 2);
+        assert_eq!(state.stdout_diagnostics.oversize_dropped_count(), 1);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentRuntimeEvent::PartsMerged(parts)
+                if parts.iter().any(|part| matches!(
+                    part,
+                    MessagePart::Error { content, .. }
+                        if content.contains("推定種別: item/agentMessage/delta")
+                ))
+        )));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            AgentRuntimeEvent::Fatal { .. }
+                | AgentRuntimeEvent::TurnCompleted(TurnResult::Interrupted {
+                    reason: InterruptReason::Crash,
+                    ..
+                })
+        )));
+        assert!(!read_task.is_finished());
+        drop(state);
+        closed.store(true, Ordering::Relaxed);
+        read_task.abort();
+    }
+
+    #[tokio::test]
+    async fn test_codex_read_loopは_pending中の非jsonをskipして応答と後続通知を処理する() {
+        let input = br#"diagnostic output while request is pending
+{"id":100,"result":{}}
+{"method":"item/agentMessage/delta","params":{"delta":"after pending response"}}
+"#;
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let mut stdout = StdoutLineReader::new(tokio::io::BufReader::new(reader));
+        let mut runtime_state = runtime_state();
+        runtime_state
+            .pending_client_requests
+            .register(100, METHOD_TURN_START);
+        let state = Arc::new(Mutex::new(runtime_state));
+        let read_state = Arc::clone(&state);
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let read_closed = Arc::clone(&closed);
+        let read_task = tokio::spawn(async move {
+            read_loop(&mut stdout, read_state, events_tx, read_closed, None).await;
+        });
+
+        writer.write_all(input).await.unwrap();
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), events_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(
+            event,
+            AgentRuntimeEvent::PartsMerged(parts)
+                if parts.iter().any(|part| matches!(
+                    part,
+                    MessagePart::Text { content, .. } if content == "after pending response"
+                ))
+        ));
+        assert!(events_rx.try_recv().is_err());
+        let mut state = state.lock().await;
+        assert_eq!(state.stdout_diagnostics.skipped_non_json_count(), 1);
+        assert!(state
+            .pending_client_requests
+            .take_response(&json!({ "id": 100, "result": {} }))
+            .unwrap()
+            .is_none());
+        assert!(!read_task.is_finished());
+        drop(state);
+        closed.store(true, Ordering::Relaxed);
+        read_task.abort();
+    }
+
+    #[test]
+    fn test_codex_stdout診断カウントは次turn開始時にリセットする() {
+        let mut state = runtime_state();
+        let probe = LineProbe {
+            kind_hint: None,
+            bytes: 9 * 1024 * 1024,
+        };
+        let _ = state
+            .stdout_diagnostics
+            .record_oversize_drop("codex", &probe);
+        state
+            .stdout_diagnostics
+            .record_non_json_skip("codex", &probe);
+
+        state.stdout_diagnostics.reset();
+
+        assert_eq!(state.stdout_diagnostics.oversize_dropped_count(), 0);
+        assert_eq!(state.stdout_diagnostics.skipped_non_json_count(), 0);
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/infrastructure/agent_session/codex/session.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/session.rs
@@ -433,6 +433,9 @@ async fn read_loop<R>(
                 }
             }
             Ok(None) => {
+                if closed.load(Ordering::Relaxed) {
+                    break;
+                }
                 log::warn!("Codex app-server exited unexpectedly");
                 emit_read_failure(
                     &state,
@@ -671,6 +674,36 @@ mod tests {
 
     use super::*;
 
+    struct ThreadLogCapture {
+        thread_id: StdMutex<Option<std::thread::ThreadId>>,
+        messages: StdMutex<Vec<String>>,
+    }
+
+    impl log::Log for ThreadLogCapture {
+        fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+            metadata.level() <= log::Level::Warn
+        }
+
+        fn log(&self, record: &log::Record<'_>) {
+            if self.enabled(record.metadata())
+                && self.thread_id.lock().unwrap().as_ref() == Some(&std::thread::current().id())
+            {
+                self.messages
+                    .lock()
+                    .unwrap()
+                    .push(record.args().to_string());
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    static TEST_LOG_CAPTURE: ThreadLogCapture = ThreadLogCapture {
+        thread_id: StdMutex::new(None),
+        messages: StdMutex::new(Vec::new()),
+    };
+    static TEST_LOG_CAPTURE_INIT: std::sync::Once = std::sync::Once::new();
+
     #[cfg(unix)]
     fn write_fake_codex_cli(dir: &std::path::Path) -> std::path::PathBuf {
         use std::os::unix::fs::PermissionsExt;
@@ -892,6 +925,63 @@ exec sleep 30
             events_rx.try_recv().unwrap(),
             AgentRuntimeEvent::Fatal { .. }
         ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_read_loop_eofは_closed状態に応じて予期しない終了を報告する() {
+        TEST_LOG_CAPTURE_INIT.call_once(|| {
+            log::set_logger(&TEST_LOG_CAPTURE).unwrap();
+            log::set_max_level(log::LevelFilter::Warn);
+        });
+        *TEST_LOG_CAPTURE.thread_id.lock().unwrap() = Some(std::thread::current().id());
+
+        let input = b"";
+        let mut stdout = StdoutLineReader::new(tokio::io::BufReader::new(&input[..]));
+        let state = Arc::new(Mutex::new(runtime_state()));
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        read_loop(
+            &mut stdout,
+            state,
+            events_tx,
+            Arc::new(AtomicBool::new(false)),
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            events_rx.try_recv().unwrap(),
+            AgentRuntimeEvent::TurnCompleted(TurnResult::Interrupted {
+                reason: InterruptReason::Crash,
+                ..
+            })
+        ));
+        assert!(matches!(
+            events_rx.try_recv().unwrap(),
+            AgentRuntimeEvent::Fatal { .. }
+        ));
+        assert!(TEST_LOG_CAPTURE
+            .messages
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|message| message == "Codex app-server exited unexpectedly"));
+
+        TEST_LOG_CAPTURE.messages.lock().unwrap().clear();
+        let mut stdout = StdoutLineReader::new(tokio::io::BufReader::new(&input[..]));
+        let state = Arc::new(Mutex::new(runtime_state()));
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        read_loop(
+            &mut stdout,
+            state,
+            events_tx,
+            Arc::new(AtomicBool::new(true)),
+            None,
+        )
+        .await;
+
+        assert!(events_rx.try_recv().is_err());
+        assert!(TEST_LOG_CAPTURE.messages.lock().unwrap().is_empty());
+        *TEST_LOG_CAPTURE.thread_id.lock().unwrap() = None;
     }
 
     #[tokio::test]

--- a/src-tauri/src/infrastructure/agent_session/codex/wire.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/wire.rs
@@ -29,6 +29,8 @@
 //! - `thread/settings/update` accepted
 //!   `{ threadId, permissions: null, approvalPolicy, sandboxPolicy }`.
 
+use std::collections::HashMap;
+
 use serde_json::{json, Value};
 
 pub(crate) const METHOD_INITIALIZE: &str = "initialize";
@@ -76,6 +78,47 @@ pub(crate) enum AppServerMessageKind {
     Response { id: u64 },
     Request { id: u64, method: String },
     Notification { method: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExpectedClientResponse {
+    pub id: u64,
+    pub method: String,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PendingClientRequests {
+    methods: HashMap<u64, String>,
+}
+
+impl PendingClientRequests {
+    pub(crate) fn register(&mut self, id: u64, method: impl Into<String>) {
+        self.methods.insert(id, method.into());
+    }
+
+    pub(crate) fn remove(&mut self, id: u64) {
+        self.methods.remove(&id);
+    }
+
+    pub(crate) fn take_response(
+        &mut self,
+        message: &Value,
+    ) -> Result<Option<ExpectedClientResponse>, String> {
+        let Some(AppServerMessageKind::Response { id }) = message_kind(message) else {
+            return Ok(None);
+        };
+        let Some(method) = self.methods.remove(&id) else {
+            return Ok(None);
+        };
+        let has_result = message.get("result").is_some();
+        let has_error = message.get("error").is_some();
+        if has_result == has_error {
+            return Err(format!(
+                "invalid Codex JSON-RPC response for {method}: expected exactly one of result or error"
+            ));
+        }
+        Ok(Some(ExpectedClientResponse { id, method }))
+    }
 }
 
 pub(crate) fn message_kind(message: &Value) -> Option<AppServerMessageKind> {
@@ -127,4 +170,53 @@ pub(crate) fn initialized_notification() -> Value {
 
 pub(crate) fn is_user_input_request_method(method: &str) -> bool {
     method == REQUEST_TOOL_USER_INPUT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_client_requests_rejects_response_without_result_or_error() {
+        let mut pending = PendingClientRequests::default();
+        pending.register(2, METHOD_THREAD_START);
+
+        let result = pending.take_response(&json!({ "id": 2 }));
+
+        assert!(matches!(
+            result,
+            Err(message) if message.contains("expected exactly one of result or error")
+        ));
+    }
+
+    #[test]
+    fn pending_client_requests_rejects_response_with_result_and_error() {
+        let mut pending = PendingClientRequests::default();
+        pending.register(2, METHOD_THREAD_START);
+
+        let result = pending.take_response(&json!({
+            "id": 2,
+            "result": {},
+            "error": { "message": "ambiguous" }
+        }));
+
+        assert!(matches!(
+            result,
+            Err(message) if message.contains("expected exactly one of result or error")
+        ));
+    }
+
+    #[test]
+    fn pending_client_requests_returns_expected_request_metadata() {
+        let mut pending = PendingClientRequests::default();
+        pending.register(2, METHOD_THREAD_START);
+
+        let response = pending
+            .take_response(&json!({ "id": 2, "result": {} }))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(response.id, 2);
+        assert_eq!(response.method, METHOD_THREAD_START);
+    }
 }

--- a/src-tauri/src/infrastructure/agent_session/mod.rs
+++ b/src-tauri/src/infrastructure/agent_session/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod claude;
 pub(crate) mod codex;
+pub(crate) mod stdout_line_reader;

--- a/src-tauri/src/infrastructure/agent_session/stdout_line_reader.rs
+++ b/src-tauri/src/infrastructure/agent_session/stdout_line_reader.rs
@@ -1,0 +1,385 @@
+use serde_json::Value;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+
+/// Shared stdout line limit for agent backends. This preserves Claude's existing 8 MB limit.
+pub(crate) const MAX_STDOUT_LINE_BYTES: usize = 8 * 1024 * 1024;
+
+const LINE_PROBE_BYTES: usize = 4 * 1024;
+const MAX_KIND_HINT_BYTES: usize = 256;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LineProbe {
+    pub kind_hint: Option<String>,
+    pub bytes: usize,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct StdoutDiagnostics {
+    oversize_dropped_count: u64,
+    skipped_non_json_count: u64,
+}
+
+impl StdoutDiagnostics {
+    pub(crate) fn reset(&mut self) {
+        self.oversize_dropped_count = 0;
+        self.skipped_non_json_count = 0;
+    }
+
+    pub(crate) fn record_non_json_skip(&mut self, backend: &str, probe: &LineProbe) {
+        self.skipped_non_json_count = self.skipped_non_json_count.saturating_add(1);
+        log::warn!(
+            "{backend} stdout skipped non-json line: bytes={} count={}",
+            probe.bytes,
+            self.skipped_non_json_count
+        );
+    }
+
+    pub(crate) fn record_oversize_drop(&mut self, backend: &str, probe: &LineProbe) -> String {
+        self.oversize_dropped_count = self.oversize_dropped_count.saturating_add(1);
+        log::warn!(
+            "{backend} stdout dropped oversized line: bytes={} kind_hint={} count={}",
+            probe.bytes,
+            probe.kind_hint.as_deref().unwrap_or("unknown"),
+            self.oversize_dropped_count
+        );
+        let kind_hint = probe
+            .kind_hint
+            .as_deref()
+            .map(|kind| format!("（推定種別: {kind}）"))
+            .unwrap_or_default();
+        format!(
+            "backend からの応答 1 件がサイズ上限（{}MB）を超えたため破棄しました{kind_hint}",
+            MAX_STDOUT_LINE_BYTES / (1024 * 1024)
+        )
+    }
+
+    pub(crate) fn oversize_dropped_count(&self) -> u64 {
+        self.oversize_dropped_count
+    }
+
+    #[cfg(test)]
+    pub(crate) fn skipped_non_json_count(&self) -> u64 {
+        self.skipped_non_json_count
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum StdoutItem {
+    Json(Value),
+    NonJson { probe: LineProbe },
+    Oversize { probe: LineProbe },
+}
+
+pub(crate) struct StdoutLineReader<R> {
+    inner: R,
+    max_line_bytes: usize,
+}
+
+impl<R: AsyncBufRead + Unpin> StdoutLineReader<R> {
+    pub(crate) fn new(inner: R) -> Self {
+        Self {
+            inner,
+            max_line_bytes: MAX_STDOUT_LINE_BYTES,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_max_line_bytes(inner: R, max_line_bytes: usize) -> Self {
+        Self {
+            inner,
+            max_line_bytes,
+        }
+    }
+
+    /// Reads and classifies one logical line. Only I/O failures are returned as errors.
+    pub(crate) async fn next(&mut self) -> Result<Option<StdoutItem>, String> {
+        let mut line = Vec::new();
+        let mut bytes = 0usize;
+        let mut oversize = false;
+        let mut oversize_kind_hint = None;
+
+        loop {
+            let available = self
+                .inner
+                .fill_buf()
+                .await
+                .map_err(|error| format!("failed to read agent stdout: {error}"))?;
+            if available.is_empty() {
+                if bytes == 0 {
+                    return Ok(None);
+                }
+                return Ok(Some(classify_line(
+                    line,
+                    bytes,
+                    oversize,
+                    oversize_kind_hint,
+                )));
+            }
+
+            let newline = available.iter().position(|byte| *byte == b'\n');
+            let content_bytes = newline.unwrap_or(available.len());
+
+            let next_bytes = bytes.saturating_add(content_bytes);
+            if !oversize && next_bytes <= self.max_line_bytes {
+                line.extend_from_slice(&available[..content_bytes]);
+            } else if !oversize {
+                oversize = true;
+                let remaining_probe_bytes = LINE_PROBE_BYTES.saturating_sub(line.len());
+                line.extend_from_slice(&available[..content_bytes.min(remaining_probe_bytes)]);
+                oversize_kind_hint = infer_kind_hint(&line[..line.len().min(LINE_PROBE_BYTES)]);
+                line.clear();
+            }
+            bytes = next_bytes;
+
+            let consumed = content_bytes + usize::from(newline.is_some());
+            self.inner.consume(consumed);
+            if newline.is_some() {
+                return Ok(Some(classify_line(
+                    line,
+                    bytes,
+                    oversize,
+                    oversize_kind_hint,
+                )));
+            }
+        }
+    }
+}
+
+fn classify_line(
+    line: Vec<u8>,
+    bytes: usize,
+    oversize: bool,
+    oversize_kind_hint: Option<String>,
+) -> StdoutItem {
+    if oversize {
+        return StdoutItem::Oversize {
+            probe: LineProbe {
+                kind_hint: oversize_kind_hint,
+                bytes,
+            },
+        };
+    }
+
+    match serde_json::from_slice::<Value>(&line) {
+        Ok(value) => StdoutItem::Json(value),
+        Err(_) => StdoutItem::NonJson {
+            probe: LineProbe {
+                kind_hint: None,
+                bytes,
+            },
+        },
+    }
+}
+
+fn infer_kind_hint(prefix: &[u8]) -> Option<String> {
+    find_json_string_field(prefix, b"\"type\"")
+        .or_else(|| find_json_string_field(prefix, b"\"method\""))
+}
+
+fn find_json_string_field(prefix: &[u8], key: &[u8]) -> Option<String> {
+    let mut offset = 0;
+    while offset + key.len() <= prefix.len() {
+        if &prefix[offset..offset + key.len()] != key {
+            offset += 1;
+            continue;
+        }
+
+        let mut cursor = offset + key.len();
+        skip_ascii_whitespace(prefix, &mut cursor);
+        if prefix.get(cursor) != Some(&b':') {
+            offset += 1;
+            continue;
+        }
+        cursor += 1;
+        skip_ascii_whitespace(prefix, &mut cursor);
+        if prefix.get(cursor) != Some(&b'"') {
+            offset += 1;
+            continue;
+        }
+
+        let value_start = cursor;
+        cursor += 1;
+        let mut escaped = false;
+        while let Some(byte) = prefix.get(cursor).copied() {
+            if !escaped && byte == b'"' {
+                if cursor.saturating_sub(value_start) > MAX_KIND_HINT_BYTES {
+                    return None;
+                }
+                return serde_json::from_slice::<String>(&prefix[value_start..=cursor]).ok();
+            }
+            escaped = !escaped && byte == b'\\';
+            cursor += 1;
+        }
+        return None;
+    }
+    None
+}
+
+fn skip_ascii_whitespace(bytes: &[u8], cursor: &mut usize) {
+    while bytes.get(*cursor).is_some_and(u8::is_ascii_whitespace) {
+        *cursor += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use tokio::io::{AsyncBufRead, AsyncRead, BufReader, ReadBuf};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_stdout_line_reader_json行を分類する() {
+        let input = b"{\"ok\":true}\n";
+        let mut reader = StdoutLineReader::new(BufReader::new(&input[..]));
+
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::Json(value)) if value["ok"] == serde_json::json!(true)
+        ));
+        assert!(reader.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_stdout_line_reader非json行を通知し後続jsonを処理する() {
+        let input = b"warning from injected environment\n{\"ok\":true}\n";
+        let mut reader = StdoutLineReader::new(BufReader::new(&input[..]));
+
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::NonJson { probe }) if probe.bytes == 33 && probe.kind_hint.is_none()
+        ));
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::Json(value)) if value["ok"] == serde_json::json!(true)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_stdout_line_reader上限超過行を保持せず後続jsonを処理する() {
+        let payload = "x".repeat(65);
+        let input = format!("{{\"type\":\"assistant\",\"data\":\"{payload}\"}}\n{{\"ok\":true}}\n");
+        let mut reader = StdoutLineReader::with_max_line_bytes(
+            BufReader::with_capacity(16, input.as_bytes()),
+            64,
+        );
+
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::Oversize { probe })
+                if probe.bytes > 64 && probe.kind_hint.as_deref() == Some("assistant")
+        ));
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::Json(value)) if value["ok"] == serde_json::json!(true)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_stdout_line_reader本番8mb上限を超える行を破棄する() {
+        let payload = "x".repeat(MAX_STDOUT_LINE_BYTES);
+        let input = format!(
+            "{{\"method\":\"item/agentMessage/delta\",\"data\":\"{payload}\"}}\n{{\"ok\":true}}\n"
+        );
+        let mut reader =
+            StdoutLineReader::new(BufReader::with_capacity(64 * 1024, input.as_bytes()));
+
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::Oversize { probe })
+                if probe.bytes > MAX_STDOUT_LINE_BYTES
+                    && probe.kind_hint.as_deref() == Some("item/agentMessage/delta")
+        ));
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::Json(value)) if value["ok"] == serde_json::json!(true)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_stdout_line_reader上限ちょうどの行は破棄しない() {
+        let input = b"0123456789";
+        let mut reader =
+            StdoutLineReader::with_max_line_bytes(BufReader::new(&input[..]), input.len());
+
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::NonJson { probe }) if probe.bytes == input.len()
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_stdout_line_reader改行なしeofの超過行も通知する() {
+        let input = b"01234567890";
+        let mut reader = StdoutLineReader::with_max_line_bytes(BufReader::new(&input[..]), 10);
+
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::Oversize { probe }) if probe.bytes == input.len()
+        ));
+        assert!(reader.next().await.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_stdout_line_reader共通上限は8mb() {
+        assert_eq!(MAX_STDOUT_LINE_BYTES, 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_stdout_diagnosticsは共通カウントと上限文言を生成してresetする() {
+        let mut diagnostics = StdoutDiagnostics::default();
+        let probe = LineProbe {
+            kind_hint: Some("assistant".to_string()),
+            bytes: 9 * 1024 * 1024,
+        };
+
+        diagnostics.record_non_json_skip("test", &probe);
+        let message = diagnostics.record_oversize_drop("test", &probe);
+
+        assert_eq!(diagnostics.skipped_non_json_count(), 1);
+        assert_eq!(diagnostics.oversize_dropped_count(), 1);
+        assert_eq!(
+            message,
+            "backend からの応答 1 件がサイズ上限（8MB）を超えたため破棄しました（推定種別: assistant）"
+        );
+
+        diagnostics.reset();
+        assert_eq!(diagnostics.skipped_non_json_count(), 0);
+        assert_eq!(diagnostics.oversize_dropped_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_stdout_line_readerioエラーのみをerrとして返す() {
+        let mut reader = StdoutLineReader::new(FailingReader);
+
+        assert!(matches!(
+            reader.next().await,
+            Err(message) if message.contains("injected read failure")
+        ));
+    }
+
+    struct FailingReader;
+
+    impl AsyncRead for FailingReader {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Err(std::io::Error::other("injected read failure")))
+        }
+    }
+
+    impl AsyncBufRead for FailingReader {
+        fn poll_fill_buf(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<&[u8]>> {
+            Poll::Ready(Err(std::io::Error::other("injected read failure")))
+        }
+
+        fn consume(self: Pin<&mut Self>, _amt: usize) {}
+    }
+}

--- a/src-tauri/tests/fixtures/agent_session/mixed_stdout_claude.jsonl
+++ b/src-tauri/tests/fixtures/agent_session/mixed_stdout_claude.jsonl
@@ -1,0 +1,4 @@
+warning from injected environment
+diagnostic output before response
+{"type":"assistant","message":{"content":[{"type":"text","text":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]}}
+{"type":"result","subtype":"success","is_error":false,"result":"ok","session_id":"fixture-claude","duration_ms":1,"duration_api_ms":1,"num_turns":1,"total_cost_usd":0}

--- a/src-tauri/tests/fixtures/agent_session/mixed_stdout_codex.jsonl
+++ b/src-tauri/tests/fixtures/agent_session/mixed_stdout_codex.jsonl
@@ -1,0 +1,4 @@
+warning from injected environment
+diagnostic output before response
+{"method":"item/agentMessage/delta","params":{"delta":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}
+{"method":"item/agentMessage/delta","params":{"delta":"ok"}}


### PR DESCRIPTION
## 概要

agent session の backend（Claude / Codex）が CLI プロセスの stdout を読み取る経路を、共通の行読み取り部品（`stdout_line_reader`）へ集約する。

現状は Claude と Codex で堅牢性が非対称であり、Codex は stdout に非 JSON 行が 1 行混ざるだけでセッションが即死していた（監査 **SD-3**）。この非対称を解消し、両 backend が同じ規約で以下を持つようにする。

- **行サイズ上限**: 既存 Claude の 8MB を共通定数として定義
- **非 JSON 行の扱い**: warn ログを出して skip し読み続ける
- **破棄・skip の可視化**: oversize 破棄件数のカウントと Error part 相当の表示

## 変更点

- `infrastructure/agent_session/stdout_line_reader.rs` を新設し、両 backend が使う共通の行読み取り部品を導入
- Claude / Codex の session・process を共通部品ベースに移行
- Codex 側の即死経路を解消（非 JSON 行 1 行でのクラッシュを回避）
- spec（requirements / behavior / design）と mixed stdout の fixture を追加

## 関連

- #1408（本 ISSUE / L7）
- milestone 84「Agentチャット安定化」Phase 0（依存なし）
- 監査問題 **SD-3** / ライフサイクル理想形 **I10**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- ClaudeおよびCodexのエージェントセッションで、標準出力の読み取りがより安定しました。
- 非JSON行やサイズ超過行をスキップしてセッションを継続します。
- スキップ・破棄された行の件数や推定種別を通知・ログで確認できます。
- 応答待ちのJSON-RPCエラーは従来どおり適切に処理されます。

## テスト
- 異常な出力を含むテストケースを追加し、セッション継続と診断情報の表示を検証しました。

## ドキュメント
- 標準出力処理の要件、仕様、設計を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->