### PR TITLE
fix: stalled turn 中の送信でユーザー入力を失わない (#1403)

### DIFF
--- a/docs/specs/issues-1403/behavior.md
+++ b/docs/specs/issues-1403/behavior.md
@@ -1,0 +1,128 @@
+# Behavior
+
+要求（`requirements.md`）を、実装詳細を含まない観測可能な振る舞いとして定義する。対象は milestone 84 OB-2（stalled turn 中の送信でユーザー入力が失われる不具合）の解消。
+
+## Feature: stalled turn 中の送信でもユーザー入力が失われない
+
+Agent チャットで agent が長時間無反応（stall 判定中）のときにユーザーがメッセージを送信しても、送信操作は「turn 開始」または「queue 追加」のいずれかに収束し、入力テキスト・添付画像・mention が失われない。backend の内部エラー文言 `active-turn steering is not available` はユーザーに露出しない。
+
+### Background
+
+```gherkin
+Background:
+  Given ユーザーが Agent チャットセッションを開いている
+```
+
+## Rule: 実行中 turn への送信は成功以外の結果を持たない（I6）
+
+steering 非対応の backend に対する実行中 turn への送信は、エラーにならず pending queue へ積まれる。stall 判定中の送信も同一の queue 経路に載る。
+
+```gherkin
+Scenario: 実行中 turn への送信が queue に積まれる
+  Given agent が turn を実行中である
+  And backend は実行中 turn への steering に対応していない
+  When ユーザーが本文・添付画像・mention を含むメッセージを送信する
+  Then メッセージはエラーにならず pending queue に積まれる
+  And "active-turn steering is not available" エラーは返らない
+
+Scenario: stall 判定中の送信も queue に積まれる
+  Given agent が実行中 turn のまま stall 判定されている
+  And backend は実行中 turn への steering に対応していない
+  When ユーザーがメッセージを送信する
+  Then メッセージはエラーにならず pending queue に積まれる
+  And 送信操作は "turn 開始" または "queue 追加" のいずれかに収束する
+
+Scenario: queue に積んだメッセージが turn 終了後に実行される
+  Given stall 判定中の送信が pending queue に積まれている
+  When 実行中 turn が終了する
+  Then queue のメッセージが後続 turn として実行される
+```
+
+## Rule: queue に積むメッセージは欠落なく永続化される（R2）
+
+queue へ積む際、human message は永続化され queue entry と紐づく。実行中送信と同じ扱いとし、本文・添付画像・mention・editor_context を保全する。
+
+```gherkin
+Scenario: queue 投入時にメッセージ内容が保全される
+  Given ユーザーが本文・添付画像・mention・editor_context を含むメッセージを送信する
+  And その turn は stall 判定中である
+  When メッセージが pending queue に積まれる
+  Then 本文・添付画像・mention・editor_context が欠落なく保持される
+  And 永続化された human message が queue entry と紐づく
+```
+
+## Rule: 入力欄は送信成功時にのみクリアされる（P5 / R3・R4）
+
+送信ハンドラは送信の完了を待ち、成功応答を得たときにのみ入力欄・添付画像・pasted text・mention をクリアする。送信が失敗した場合はこれらを保持する。
+
+```gherkin
+Scenario: 送信成功後に入力欄がクリアされる
+  When ユーザーがメッセージを送信し、送信が成功応答を返す
+  Then 入力欄・添付画像・pasted text・mention がクリアされる
+
+Scenario: 送信失敗時に入力欄が保持される
+  When ユーザーがメッセージを送信し、送信が失敗する
+  Then 入力欄・添付画像・pasted text・mention は保持される
+  And ユーザーは失われていない入力から再送できる
+
+Scenario: 送信中に入力が即時破棄されない
+  When ユーザーが送信操作を行う
+  Then 送信の結果が確定するまで入力欄・添付は破棄されない
+
+Scenario: 送信待機中の追加入力が先行送信の成功で失われない
+  Given メッセージの送信結果が未確定である
+  When ユーザーが入力・添付を追加して再度送信操作を行う
+  Then 未確定のメッセージは重複送信されない
+  And 追加入力・添付は先行送信の成功後も保持される
+```
+
+## Rule: queue に積まれた送信はユーザーに見える（R5）
+
+stall 中の送信が queue チップとして UI に表示され、メッセージが失われていないことがユーザーから分かる。
+
+```gherkin
+Scenario: stall 中の送信が queue チップとして表示される
+  Given agent が stall 判定中である
+  And backend は実行中 turn への steering に対応していない
+  When ユーザーがメッセージを送信する
+  Then そのメッセージが queue チップとして UI に表示される
+  And ユーザーはメッセージが保持されていることを確認できる
+```
+
+## Rule: backend の生エラー文言はユーザーに露出しない（R6）
+
+`active-turn steering is not available` を含む backend 内部エラー文言は、ユーザー向け UI にそのまま表示されない。
+
+```gherkin
+Scenario: steering 非対応の生エラーがユーザーに露出しない
+  Given agent が実行中 turn または stall 判定中である
+  And backend は実行中 turn への steering に対応していない
+  When ユーザーがメッセージを送信する
+  Then "active-turn steering is not available" 文言はユーザー向け UI に表示されない
+```
+
+## 主要な境界条件
+
+```gherkin
+Scenario: stall 判定中の実 steer 対応 backend では steer 経路が優先される
+  Given agent が実行中 turn のまま stall 判定されている
+  And backend が実行中 turn への steering に対応している
+  When ユーザーが stalled turn へメッセージを送信する
+  Then 送信は steer 経路で処理され、queue フォールバックは適用されない
+
+Scenario: turn 非実行時の送信は通常どおり turn を開始する
+  Given agent が turn を実行していない
+  When ユーザーがメッセージを送信する
+  Then 送信は新しい turn を開始する
+```
+
+## 仮定
+
+- 「queue へ積む」対象は、steering 非対応 backend の実行中 turn（stall 判定中を含む）への送信とする。将来 backend が実 steer を実装した場合も、本 ISSUE で steer 優先を保証するのは stall 観測中の active turn に限る。通常の streaming turn は既存どおり queue へ積む。
+- queue 投入時の human message 永続化・queue 紐付けは、既存の実行中送信と同一の仕組みを再利用する（新規の永続化スキーマは追加しない）。
+- pending queue の永続化（session close / backend 切替 / 再起動での queue 消滅、OB-3）は本 ISSUE の対象外であり、振る舞いとして定義しない。
+- issues-1301 D16/F-2 の「stalled retry/continue must not be silently queued」仕様は本 ISSUE で反転され、stall 中の送信も queue へフォールバックする。当該テストは新仕様に合わせて更新／置換する。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1403/design.md
+++ b/docs/specs/issues-1403/design.md
@@ -1,0 +1,188 @@
+# Design
+
+`requirements.md` / `behavior.md` を満たす実装設計。対象は milestone 84 OB-2（stalled turn 中の送信でユーザー入力が失われる不具合）の解消。ideal lifecycle **I6**（送信は「turn 開始 or queue 追加」に収束）と ideal presentation **P5**（入力の保全）を実現する。
+
+## 概要
+
+現状、`send_message` は stall 観測中（`stall_observation_active`）かつ backend が steering 非対応のとき、`add_human_message_internal` に到達する前にエラー `active-turn steering is not available` を返す（`runtime/usecase.rs:293-297`）。Claude / Codex はいずれも `capabilities().steering == false` のため、stalled turn への送信は本番で常にこのエラーになり、メッセージは永続化されず失われる。frontend も送信直後に無条件で入力欄をクリアし（`MessageInput.tsx:455-457`）、`sendMessage` は catch でエラーを swallow する（`useAgentChat.ts:914-919`）ため、入力復元経路が存在しない。
+
+本設計では次の 2 点を変更する。
+
+- **backend（R1・R2・R6）**: stall 判定中の送信も、通常の実行中送信と同一の queue 経路（既存 `pending_queue` / `QueuedTurnInput`）へフォールバックさせる。steer 分岐は「backend が steering に対応している場合のみ」に限定し、非対応時は queue へ積む。`active-turn steering is not available` の早期エラー return を撤廃する。
+- **frontend（R3・R4）**: 送信ハンドラが送信 API の完了を待ち、成功時にのみ入力欄・添付・pasted text・mention をクリアする。失敗は入力保全の責務を持つ層（`MessageInput`）まで伝播させ、入力を保持する。
+
+R5（queue チップ表示）は既存の `pendingQueue` レンダリング（`ChatSessionView.tsx:1747`）で満たされるため、backend が queue へ積むようになれば追加実装なしに達成される。
+
+## 変更対象
+
+### backend（Rust）
+
+- `src-tauri/src/usecase/agent_session/runtime/usecase.rs`
+  - `send_message`（`274-431`）: steer 分岐のガードとフォールバック分岐の修正。早期エラー return（`293-297`）の撤廃。
+  - テスト `test_stale_watchdog_無進捗turnをstall_signalに留めruntimeを閉じない`（`7561-7651`）: 新仕様（stall 中も queue へフォールバック）に合わせて更新／置換（issues-1301 D16/F-2 の反転）。
+  - 新規テスト: stall 中送信 → queue 追加 → turn 終了後 drain の固定。
+
+### frontend（TypeScript）
+
+- `src/hooks/useAgentChat.ts`
+  - `sendMessage`（`792-927`）: 送信失敗を呼び出し側へ伝播する（catch で swallow せず、成功/失敗を返す）。
+- `src/components/panels/AgentChatPanel/MessageInput.tsx`
+  - `handleSubmit` / `submitContent`（`436-489`）: `onSend` の完了を待ち、成功時にのみ入力状態をクリアする。
+- 中間層（型シグネチャの伝播のみ）
+  - `src/components/panels/AgentChatPanel/BoundSessionChat.tsx` `handleSend`（`155-178`）
+  - `src/components/panels/AgentChatPanel/ChatSessionView.tsx` `handleComposerSend`（`1126-1137`）
+
+要求外（変更しない）: stall 判定ロジック、queue 永続化（OB-3）、`cancel_queued_turn`、Agent チャット以外の送信経路。
+
+## アーキテクチャと責務分割
+
+Rust-first 原則に従い、「送信を queue へ積むか turn を開始するか」の意思決定は **すべて backend（usecase）** が所有する。frontend は「送信結果に応じて入力欄をクリアするか保持するか」という UI 制御のみを担う。
+
+| 層 | 責務 | 変更 |
+|---|---|---|
+| `usecase/runtime` | queue 判定・queue 投入・human message 永続化・steer 分岐 | 分岐条件の修正（本設計の中心） |
+| `RuntimeSessionState.pending_queue` | pending queue の source of truth | 変更なし（既存経路を再利用） |
+| controller（Tauri command） | 入力を usecase 呼び出しへ変換 | 変更なし（`send_message` の戻り値は既存の `SendMessageResponse`） |
+| frontend `useAgentChat.sendMessage` | invoke 呼び出しと結果の mirror | 失敗を呼び出し側へ伝播 |
+| frontend `MessageInput` | 入力状態の所有・成功時クリア | 完了待ち＋成功時クリアへ変更 |
+
+backend の戻り値 `SendMessageResponse`（`queued_turn` / `pending_queue` を含む）は既存のまま Tauri command から返す。現行 protocol には WebSocket 経由の agent message 送信入口がないため、その inbound surface の追加は本 ISSUE の対象外とする。将来追加する場合も controller に分岐を複製せず、同じ usecase と応答型を再利用できる。
+
+## データモデルまたは型
+
+### backend
+
+新規スキーマは追加しない。既存を再利用する。
+
+- `QueuedTurnInput`（`runtime/queue.rs`）: queue entry。`existing_human_message_id` で永続化済み human message と紐づく（R2）。
+- `RuntimeSessionState.pending_queue: Vec<QueuedTurnInput>`: pending queue の所有者。
+- `SendMessageResponse`（`queued_turn: Option<QueuedAgentTurn>`, `pending_queue`, `pending_queue_count`, `human_message` 等）: 既存の応答型をそのまま使う。stall 中フォールバックは、既存の実行中 queue 分岐（`337-372`）と同じ応答形（`queued_turn = Some(..)`）になる。
+- queue 分岐では、失敗し得る session shell / session 一覧 / title projection を human message の永続化と queue 投入より前に解決する。storage の message append は index 修復を反映した canonical な post-write `SessionMeta` を返し、受理後はその meta から対象 summary を置換して再 sort する非 fallible 処理だけで応答を組み立てる。これにより queue 投入済みなのに frontend が `false` を受け取って再送する境界の曖昧さと、stale index 修復後の永続 count と応答 count の乖離を作らない。
+
+### frontend
+
+`sendMessage` の戻り値を、送信成否を呼び出し側が判定できる形へ変更する。
+
+- 推奨: `Promise<boolean>`（`true` = 送信成功。turn 開始・queue 追加のいずれも成功として `true`。失敗時 `false`）。
+  - 型定義 `UseAgentChatResult.sendMessage`（`useAgentChat.ts:120-126`）を `Promise<void>` → `Promise<boolean>` に更新。
+  - `BoundSessionChat.handleSend` / `ChatSessionView.handleComposerSend` は戻り値をそのまま伝播。
+- `MessageInput.onSend` の型は `Promise<boolean>` とし、`true` の場合だけ成功として入力状態をクリアする。
+- `queued_turn` の有無で「turn 開始」か「queue 追加」かを区別できるが、入力クリアの判定はどちらも成功扱いのため boolean で十分。
+
+（例外を投げる方式は「リスクと代替案」参照。既存の非 await 呼び出し側へ影響しない boolean 方式を採る。）
+
+## 処理フロー
+
+### backend: `send_message` の分岐（修正後）
+
+```
+resolve session / backend_id
+recover_queued_turn_if_idle_without_runtime
+
+steer_target =
+    if backend_supports_steering(backend_id):
+        stalled_active_turn_target(session_id)   // Some のとき steer 可能
+    else:
+        None                                     // 非対応 backend は steer しない
+
+if is_turn_busy(session_id):
+    if let Some(target) = steer_target:          // steering 対応 backend のみ
+        target.runtime.steer(TurnInput { .. })   // 失敗時は human message を保存せずエラー伝播（既存挙動維持）
+        human_message = add_human_message_internal(..)
+        return send_response(queued_turn = None, ..)
+    else:                                         // ← stall 中 / 非対応 backend はここへ落ちる（新経路）
+        (human_message, persisted_meta) = add_human_message_internal(..) // R2: 永続化後の canonical meta も取得
+        queued = QueuedTurnInput::new(.., editor_context)
+        queued.existing_human_message_id = Some(human_message.id)
+        state.pending_queue.push_back(queued)
+        return accepted_queue_response(
+            pre_commit_projection,
+            persisted_meta,
+            queued_turn = Some(view),
+            pending_queue,
+        ) // R1
+
+// turn 非実行時（Idle）は従来どおり新規 turn を開始
+human_message = add_human_message_internal(..)
+start_turn_for_session(..)
+return send_response(queued_turn = None, agent_message = Some(..), ..)
+```
+
+要点:
+
+- 早期エラー return（`293-297`）を削除する。stall 中でも `active-turn steering is not available` を返さない（R1・R6）。
+- steer 分岐を `backend_supports_steering` でガードする。これにより stalled + 非対応 backend は既存の queue 分岐（`337-372`）を再利用して積まれる（full-recompute 経路を新設しない）。
+- `stalled_active_turn_target` は steering 対応時のみ呼ぶ。非対応時は runtime 欠落による `No active agent runtime` エラー（`1642-1646`）にも到達しない。
+- 将来 backend が実 steer を実装した場合、stall 観測中は `steer_target` が Some になり steer 経路が優先される（behavior「stall 判定中の実 steer 対応 backend では steer 経路が優先」を満たす）。通常の streaming turn は `stalled_active_turn_target` が None のため、既存どおり queue へ積む。
+
+### backend: queue の実行（turn 終了後）
+
+既存経路をそのまま使う。turn 終了時に `start_next_queued_turn`（`recover_queued_turn_if_idle_without_runtime` 経由、`703-711`）が pending queue から次の turn を起動する。テストでは `drain_next_queued_turn_for_test`（`1246`）で確認する。
+
+### frontend: 送信と入力クリア
+
+```
+MessageInput.handleSubmit
+  submitContent(content):
+    mentions = syncMentionsForSubmit(..)
+    const ok = await onSend(content, images, mentions)   // 完了を待つ（R3）
+    if (ok === true) {                                   // 成功時のみクリア
+        clearSubmittedSnapshot()                         // 待機中の追加入力は保持
+    }
+    // 失敗時は入力状態を保持（P5 / R3）
+```
+
+- `onSend`（= `handleComposerSend` → `handleSend` → `sendMessage`）の Promise を `await` し、`true` の場合だけ成功として扱う。
+- 送信中は次の submit を受け付けず、同じ snapshot の重複送信を防ぐ。待機中に編集されたテキストや追加された添付は送信時 snapshot と区別し、成功時もクリアしない。
+- `sendMessage` は成功で `true`、失敗で `false` を返し、失敗を握りつぶさない（R4）。
+- backend が stall 中も成功応答（`queued_turn = Some`）を返すため、通常経路として `true` → クリアされ、queue チップに表示される（R5）。
+- 送信中（未確定）はクリアしない（behavior「送信中に入力が即時破棄されない」）。
+
+## エラー処理
+
+- **backend**: stall 中 / steering 非対応の送信はエラーを返さず `Ok(SendMessageResponse)`（R1）。永続化失敗（`add_human_message_internal` の I/O エラー）や `start_turn` 失敗は従来どおり `AgentRuntimeError` として伝播する（stall フォールバックが新たなエラーを握りつぶすことはしない）。steer 対応 backend での steer 失敗は human message を保存せずエラーを返す既存挙動を維持する（`test_stall_signal後のsteer失敗はhuman_messageを保存しない` を壊さない）。
+- **queue 受理境界**: session shell / session 一覧の読込失敗は queue commit 前に返す。human message 永続化・queue 投入後は取得済み projection から成功応答を構築するため、frontend の `false` は「queue に未投入」を意味し、同じ入力の再送で重複 queue を作らない。
+- **frontend**: `sendMessage` は送信失敗時、入力保全のため `false` を返す。ユーザー向けバナー（`SET_ERROR`）は残すが、`active-turn steering is not available` を含む backend 生エラーは backend 側で発生しなくなるため UI に露出しない（R6）。バナー文言に backend 内部文字列をそのまま埋め込まない方針を維持する。
+- 失敗時に入力を保持することで、ユーザーは失われていない入力から再送できる（behavior「送信失敗時に入力欄が保持される」）。
+
+## テスト方針
+
+### backend（`runtime/usecase.rs` の `#[cfg(test)]`）
+
+- **更新／置換**: `test_stale_watchdog_無進捗turnをstall_signalに留めruntimeを閉じない`（`7561-7651`）を新仕様へ反転する。
+  - 変更前: `send_message` が `active-turn steering is not available` で `expect_err`、`pending_queue` が空。
+  - 変更後: `send_message` が `Ok` を返し、`queued_turn` が `Some`、`pending_queue` が非空、`add_human_message_internal` により human message が永続化され `existing_human_message_id` で紐づく。watchdog の非破壊挙動（`Reconnect` あり / `Interrupt`・`Close` なし、phase = Streaming、SessionState = Active、stall 通知発火）は維持を確認する。
+- **新規**: stall 中送信 → queue 追加 → turn 終了後 drain。
+  - stall 観測中に `send_message` → `pending_queue.len() == 1`、本文・画像・mention・editor_context が欠落なく保持されること（R2）。
+  - `drain_next_queued_turn_for_test`（または turn 終了）で queue のメッセージが後続 turn として起動され、`pending_queue` が空になること（behavior「queue に積んだメッセージが turn 終了後に実行される」）。
+- **回帰**: steering 対応 backend では steer 経路が優先されること（`test_stall_signal後のsend_messageはactive_turnへsteerしqueueしない`、`7653-` を維持）。
+- **回帰**: stale index / orphan message chunk がある状態で queue を受理し、session 一覧 projection が後続読込不能になっても、commit 前に取得した projection と append が返す canonical meta から成功応答を返すこと。応答と永続状態の message count が一致し、human message と queue entry が 1 件だけ作られること。
+
+### frontend
+
+- `MessageInput.test.tsx`: `onSend` が `true` へ解決したときのみ送信対象の入力・添付・pasted text・mention がクリアされ、`onSend` が reject / `false` を返したときは入力状態が保持されることを検証（P5 / R3）。送信中（Promise pending）は破棄されず、待機中の追加入力・添付が成功後も保持され、二重 submit が直列化されること。
+- `useAgentChat` のテスト: `sendAgentMessage` が失敗したとき `sendMessage` が `false` を返し（swallow しない）、成功時 `true` を返すこと（R4）。`vi.mock("@tauri-apps/api")` で invoke を stub。
+
+### 品質チェック
+
+`pnpm lint` / `pnpm test` / `pnpm build`、`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`、`pnpm test:integration` を通過させる。
+
+## リスクと代替案
+
+- **意図的仕様の反転（issues-1301 D16/F-2）**: 「stalled retry/continue must not be silently queued」を反転する。requirements の Decisions で合意済み。ワークフロー node session の stall 中送信も queue へ積まれるようになるため、当該テストと関連する watchdog 挙動（非破壊 recovery）が維持されることをテストで固定する。
+- **frontend 戻り値方式（boolean vs 例外）**: 例外送出（rethrow）だと `sendMessageRef` 経由の非 await 呼び出し側（Workflow panel 等）に unhandled rejection を波及させうる。影響範囲を局所化するため、後方互換な `Promise<boolean>` を採用する。既存の戻り値未使用の呼び出し側は影響を受けない。
+- **queue と steer の同時対応 backend（将来）**: `steer_target` を `backend_supports_steering` でガードするため、実 steer 実装時は stall 観測中に steer 経路が優先される。stall 観測前の通常の streaming turn は既存の queue 経路を維持する。
+- **queue 非永続化（OB-3）**: session close / backend 切替 / 再起動で queue は消える。本 ISSUE の対象外（別 ISSUE）であり、振る舞いとして保証しない。
+
+## 仮定
+
+- spec-id は `issues-1403`（ブランチ `feat/issues/1403` に整合）。正本は `specs/milestone-84-agent-chat-stabilization/`（OB-2 / I6 / P5）。
+- 「queue へ積む」対象は steering 非対応 backend の実行中 turn（stall 判定中を含む）への送信。実 steer 実装時も、steer 経路を優先するのは stall 観測中の active turn に限る。
+- queue 投入時の human message 永続化・queue 紐付けは、既存の実行中 queue 分岐（`runtime/usecase.rs:337-372`）と同一の仕組みを再利用し、新規スキーマを追加しない。
+- frontend 改修は「クリアを成功応答後に移す／失敗を伝播させる」の最小範囲に限る。`MessageInput` の即時クリアと `useAgentChat` の catch swallow の 2 点が対象。
+- R5（queue チップ）は既存の `pendingQueue` レンダリングで満たされ、backend が queue へ積めば追加実装は不要。
+- `sendMessage` の戻り値は `Promise<boolean>`（成功=`true`）とし、turn 開始・queue 追加の双方を成功として扱う。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1403/requirements.md
+++ b/docs/specs/issues-1403/requirements.md
@@ -1,0 +1,97 @@
+# Requirements
+
+## Type
+
+不具合修正（Agent チャット安定化 / milestone 84・Phase 0・依存なし）
+
+## Goal
+
+stalled turn（agent が長時間無反応）中にユーザーがメッセージを送信したとき、入力テキスト・添付画像・mention が失われないことを保証する。
+
+送信操作の結果を「turn 開始 or queue 追加」の 2 つに収束させ（ideal lifecycle I6）、steer 非対応 backend への実行中送信・stall 判定中の送信のいずれでも `active-turn steering is not available` の生エラーがユーザーに露出せず、入力欄と添付が保全される状態を成功とする（OB-2 の解消）。
+
+## Background
+
+`specs/milestone-84-agent-chat-stabilization/agent-chat-instability-audit.md` の **OB-2**（severity: high, 種別: dropped）で報告された不具合。
+
+現状、`send_message` は stall 観測中（デフォルト 180 秒無出力、tool 実行中は 1800 秒へ延長）の turn に対し、backend が steering 非対応なら queue せずエラーを返す（`runtime/usecase.rs:292-297`）。Claude / Codex とも `capabilities().steering=false` で、どちらの `SessionRuntime` も `steer` をオーバーライドしていない（`gateway.rs:160-165` の既定が `Unavailable`）ため、steer 分岐は本番で到達不能であり、stalled turn への送信は常にこのエラーになる。この時点では `add_human_message_internal` 前のため、メッセージは永続化されず完全に失われる。
+
+frontend 側にも取りこぼしが重なっている:
+
+- `MessageInput.tsx:440-456` は `onSend` を await せず、送信直後に入力欄・添付画像・mention を即クリアする。
+- `useAgentChat.ts:913-919` の catch は `SET_ERROR` でバナー表示するのみでエラーを swallow するため、送信失敗を入力側へ伝播できず、入力を復元する経路が存在しない。
+- stall 中は `ChatSessionView.tsx` が「No agent output…」バナーを表示しつつ `MessageInput` を無効化しないため、まさにユーザーの追加指示を誘発した上で、本文と画像を復元不能に破棄する。
+
+これは通常の実行中なら queue に積まれる操作が、stall 中だけ入力ごと捨てられるという非対称であり、agent が無反応で追加指示を送りたい状況でこそ発火する。
+
+ideal lifecycle **I6（ユーザー入力の無損失）** は「送信操作は成功（turn 開始 or queue 追加）以外の結果を持たない。steer 非対応・stall 中・起動失敗のいずれでも入力テキスト・添付画像は失われない」と定義し、stalled 判定中も同一経路（queue）に載せることを要点とする。ideal presentation **P5（入力の保全）** は「送信失敗・queue 操作・stall のいずれでも入力欄の内容と添付は消えない」と定める。
+
+なお、backend が stall 中の送信でエラーを返す現挙動は、`runtime/usecase.rs:7568-7592` のテスト（`test_stale_watchdog_無進捗turnをstall_signalに留めruntimeを閉じない`）で「stalled retry/continue must not be silently queued」という意図的仕様として固定されている（issues-1301 D16/F-2）。本 ISSUE では、ideal lifecycle I6 を優先し、この既存の意図的仕様を反転させる（stall 中の送信も queue へフォールバックする）ことを合意済みとする。当該テストは新仕様に合わせて更新／置換する。
+
+## Users / Actors
+
+- Releash デスクトップアプリのエンドユーザー（Agent チャットで stalled 中に追加指示・催促を送るユーザー）
+- backend runtime（Claude / Codex agent session）
+- 本コードベースを保守する開発者
+
+## Scope
+
+- backend（`runtime/usecase.rs` の送信経路）: 実行中 turn への送信が steer 未対応（`steer` 既定 Err / steering 非対応 backend）となる場合に、エラーを返さず pending queue へ積む。stall 判定中の送信も同一経路に載せ、エラーにしない（I6）。
+- frontend の入力保全（P5）:
+  - 送信ハンドラが送信 API の完了を待ち、成功応答を得た場合にのみ入力欄・添付画像・mention をクリアする。
+  - 送信 API が失敗した場合は入力欄の内容・添付・mention を保持する（現状の即時・無条件クリアを撤廃）。
+  - stall 中の送信が queue チップとして表示され、失われないこと。
+- backend エラー文言 `active-turn steering is not available` がユーザー UI に露出しないこと。
+- テスト: stalled 状態を模擬し、送信 → queue 追加 → turn 終了後に queue が実行される流れを固定する（統合／backend テスト）。既存の相反テスト（issues-1301 D16/F-2、`runtime/usecase.rs:7568-7592`）は、新仕様（stall 中も queue へフォールバック）に合わせて更新／置換する。
+
+## Non-goals
+
+- pending queue の永続化（OB-3: session close / backend 切替 / 再起動での queue 消滅）。本 ISSUE では扱わない。
+- cancel 済みメッセージの transcript 復活（OB-4）、interrupt 後の無条件 drain（OB-5）、queue 起動失敗後の自動リトライ欠如（OB-6）、画像のみ送信時の wire 非対称（OB-7）。いずれも別 ISSUE。
+- turn/steer の将来対応そのもの（backend が実際に steering を実装すること）。本 ISSUE は「steer 非対応時のフォールバック」に限る。
+- WebSocket 経由で agent message を送信する inbound protocol / controller surface の追加。将来この surface を追加する場合は、同じ backend usecase と `SendMessageResponse` を再利用する。
+- stall 判定ロジック（無出力タイムアウト値・tool 実行中の延長）の変更。
+- Agent チャット以外の送信経路の変更。
+
+## Requirements
+
+- **R1（backend フォールバック）**: 実行中 turn への送信が steer 未対応となる場合、送信をエラーにせず pending queue へ積む。steering 非対応 backend（Claude / Codex）・stall 判定中のいずれでも同一の queue 経路に載せ、`active-turn steering is not available` エラーを返さない。
+- **R2（メッセージ永続化）**: queue へ積む際、human message を永続化し、queue entry と紐づける（既存の実行中送信と同じ扱い）。入力テキスト・添付画像・mention・editor_context を欠落なく保全する。
+- **R3（frontend クリアの成功条件化）**: 送信ハンドラは送信 API の完了を待ち、成功応答を得たときにのみ送信対象の入力欄・添付画像・pasted text・mention をクリアする。送信 API が失敗した場合と、送信待機中に追加された入力状態は保持する。同一の送信操作を完了前に重複送信しない。
+- **R4（失敗の伝播）**: 送信 API の失敗が送信ハンドラ（入力保全の責務を持つ層）へ伝播し、入力を復元／保持できること。エラーを swallow して入力復元経路を失わないこと。
+- **R5（queue チップ表示）**: stall 中の送信が queue チップとして UI に表示され、ユーザーから見て失われていないことが分かること。
+- **R6（生エラー非露出）**: `active-turn steering is not available` を含む backend 内部エラー文言が、ユーザー向け UI にそのまま露出しないこと。
+- **R7（テスト固定）**: stalled 状態での送信 → queue 追加 → turn 終了後の queue 実行、および送信失敗時の入力保全を、テストで固定する。
+- **Rust-first**: 送信の queue 判定・queue 投入・永続化ロジックは Rust（usecase）に置く。frontend は成功/失敗に応じた入力クリア／保持という UI 制御のみを担う。
+
+## Constraints
+
+- 全アプリケーションロジックは Rust に置く（`.claude/rules/rust-first-logic.md`）。queue 判定・フォールバックの意思決定を frontend に実装しない。frontend の変更は「送信結果に応じた入力欄クリア／保持」という UI 制御に限る。
+- pending queue の所有者は backend（`RuntimeSessionState.pending_queue`）である。frontend は queue 状態の mirror に留める。
+- full-retention / full-recompute 経路を新設しない。queue 投入は既存の QueuedTurnInput 経路を再利用する。
+- 送信結果は backend-owned な `SendMessageResponse` とし、現在の Tauri command 以外の将来 surface からも usecase を再利用できる境界を維持すること。
+- 既存 CI 品質チェック（`pnpm lint` / `pnpm test` / `pnpm build`、`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`、`pnpm test:integration`）が通過すること。
+
+## Success Criteria（受け入れ基準の概要）
+
+- stall 中の送信が queue チップとして表示され、メッセージ（本文・添付・mention）が失われない。
+- 送信失敗時も入力欄の内容と添付が残る。
+- 「steering is not available」エラーがユーザーに露出しない。
+- 上記を固定するテストが存在し、通過する。
+- CI 品質チェックが通過する。
+
+## Assumptions
+
+- spec-id は `issues-1403` とする（ブランチ `feat/issues/1403` および既存 `docs/specs/issues-<番号>/` 命名規約に整合）。
+- 本 ISSUE は milestone 84「Agent チャット安定化」Phase 0・依存なしで即着手可能であり、正本は `specs/milestone-84-agent-chat-stabilization/`（audit OB-2 / lifecycle I6 / presentation P5）である。
+- 「queue へ積む」対象は、backend が steering 非対応の実行中 turn（stall 判定中を含む）への送信とする。将来 backend が実 steer を実装した場合も、本 ISSUE で steer 経路を優先するのは stall 観測中の active turn に限り、通常の streaming turn は既存どおり queue へ積む。
+- frontend の送信ハンドラ改修は、`MessageInput.tsx` の即時クリアと `useAgentChat.ts` の catch swallow の 2 点が対象で、入力保全に必要な最小範囲に限る（クリアを成功応答後に移す／失敗を伝播させる）。
+- queue 投入時の human message 永続化・queue 紐付けは、既存の実行中送信（`runtime/usecase.rs` の queue 分岐）と同一の仕組みを再利用する（新規の永続化スキーマは追加しない）。
+
+## Decisions（解消済み）
+
+- **既存の意図的仕様（issues-1301 D16/F-2）の上書き**: ideal lifecycle I6 を優先し、stall 中の送信も queue へフォールバックする方針（R1）を採用する。これにより issues-1301 D16/F-2（「stalled retry/continue must not be silently queued」、`runtime/usecase.rs:7568-7592`）を反転させ、当該テストは新仕様に合わせて更新／置換する。audit の代替案（backend はエラー維持・frontend のみで保全）は採らない。
+
+## Open Questions
+
+なし。

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
@@ -202,7 +202,7 @@ impl crate::domain::agent_session::AgentSessionWriter for FileSessionStorage {
         app_data_dir: &Path,
         session_id: &str,
         message: &Self::Message,
-    ) -> Result<(), String> {
+    ) -> Result<Self::Meta, String> {
         FileSessionStorage::append_message(self, app_data_dir, session_id, message)
     }
 

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/message_store.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/message_store.rs
@@ -180,7 +180,7 @@ impl FileSessionStorage {
         app_data_dir: &Path,
         session_id: &str,
         message: &ChatMessage,
-    ) -> Result<(), String> {
+    ) -> Result<SessionMeta, String> {
         measure_save_result(
             crate::other::telemetry::HotPath::SessionAppend,
             || {
@@ -244,9 +244,11 @@ impl FileSessionStorage {
                 write_private_context_to_dir(&dir, &meta)?;
                 write_json_pretty_atomic(&index_file_in_dir(&dir), &index, "session index")?;
                 write_json_pretty_atomic(&meta_file_in_dir(&dir), &meta, "session meta")?;
-                self.cache.write().insert(session_id.to_string(), meta);
+                self.cache
+                    .write()
+                    .insert(session_id.to_string(), meta.clone());
                 self.invalid_sessions.write().remove(session_id);
-                Ok(())
+                Ok(meta)
             },
         )
     }

--- a/src-tauri/src/domain/agent_session/storage.rs
+++ b/src-tauri/src/domain/agent_session/storage.rs
@@ -111,7 +111,7 @@ pub trait AgentSessionWriter: AgentSessionStorageTypes {
         app_data_dir: &Path,
         session_id: &str,
         message: &Self::Message,
-    ) -> Result<(), String>;
+    ) -> Result<Self::Meta, String>;
 
     fn persist_message_parts(
         &self,

--- a/src-tauri/src/usecase/agent_session/runtime/usecase.rs
+++ b/src-tauri/src/usecase/agent_session/runtime/usecase.rs
@@ -29,10 +29,11 @@ use crate::usecase::agent_session::event_log::{
     WorkflowTurnCompleteInput,
 };
 use crate::usecase::agent_session::session::{
-    add_message_internal, apply_tool_result_update, create_session_with_model_and_plan_mode,
-    ChatMessage, ChatSession, ContextCarryState, GetSessionResponse, ImageAttachment,
-    InitialSessionPage, MessagePart, MessageRole, ModelInfo, OpenTabRegistry, PermissionRequestMsg,
-    QueuedAgentTurn, SessionState, SessionStore, SessionSummary, INITIAL_SESSION_PAGE_LIMIT,
+    add_message_internal, add_message_with_meta_internal, apply_tool_result_update,
+    create_session_with_model_and_plan_mode, ChatMessage, ChatSession, ContextCarryState,
+    GetSessionResponse, ImageAttachment, InitialSessionPage, MessagePart, MessageRole, ModelInfo,
+    OpenTabRegistry, PermissionRequestMsg, QueuedAgentTurn, SessionMeta, SessionState,
+    SessionStore, SessionSummary, INITIAL_SESSION_PAGE_LIMIT,
 };
 use crate::usecase::agent_session::status::{
     AgentStatusCenter, AgentStatusNotifier, SessionStatus, TurnPhase, TurnPhaseRepr,
@@ -168,6 +169,50 @@ pub struct SendMessageResponse {
     pub sessions: Vec<SessionSummary>,
 }
 
+struct SendResponseProjection {
+    session: ChatSession,
+    sessions: Vec<SessionSummary>,
+}
+
+impl SendResponseProjection {
+    fn into_accepted_queue_response(
+        mut self,
+        session_title: Option<String>,
+        human_message: ChatMessage,
+        persisted_meta: SessionMeta,
+        queued_turn: QueuedAgentTurn,
+        pending_queue: Vec<QueuedAgentTurn>,
+    ) -> SendMessageResponse {
+        self.session = persisted_meta.to_session(Vec::new());
+        let mut persisted_summary = persisted_meta.to_summary();
+        if let Some(title) = session_title {
+            persisted_summary.first_message = title;
+        }
+        if let Some(summary) = self
+            .sessions
+            .iter_mut()
+            .find(|summary| summary.id == self.session.id)
+        {
+            *summary = persisted_summary;
+        }
+        self.sessions.sort_by(|a, b| {
+            b.updated_at
+                .partial_cmp(&a.updated_at)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        SendMessageResponse {
+            session: self.session,
+            human_message,
+            agent_message: None,
+            queued_turn: Some(queued_turn),
+            pending_queue_count: pending_queue.len(),
+            pending_queue,
+            can_change_backend: false,
+            sessions: self.sessions,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelQueuedTurnResponse {
@@ -289,12 +334,11 @@ impl AgentSessionRuntimeUsecase {
         let backend_id = required_backend_id(&session)?;
         self.recover_queued_turn_if_idle_without_runtime(&session_id)
             .await;
-        let stalled_active_turn = self.stalled_active_turn_target(&session_id).await?;
-        if stalled_active_turn.is_some() && !self.backend_supports_steering(&backend_id) {
-            return Err(AgentRuntimeError::Other(format!(
-                "active-turn steering is not available for backend '{backend_id}'"
-            )));
-        }
+        let stalled_active_turn = if self.backend_supports_steering(&backend_id) {
+            self.stalled_active_turn_target(&session_id).await?
+        } else {
+            None
+        };
         if self.is_turn_busy(&session_id).await {
             if let Some(target) = stalled_active_turn {
                 target
@@ -317,7 +361,7 @@ impl AgentSessionRuntimeUsecase {
                     })
                     .await
                     .map_err(AgentRuntimeError::from)?;
-                let human_message = add_human_message_internal(
+                let (human_message, _) = add_human_message_internal(
                     &self.ctx.session_store,
                     &self.ctx.data_dir,
                     &session_id,
@@ -334,7 +378,17 @@ impl AgentSessionRuntimeUsecase {
                     self.pending_queue(&session_id).await,
                 );
             }
-            let human_message = add_human_message_internal(
+            // Resolve fallible read-model projections before accepting the message. Once the
+            // human message is persisted and queued, the command must return an accepted
+            // response so the composer cannot retain and resend an already-queued input.
+            let response_projection =
+                self.prepare_send_response_projection(&session_id, &session.worktree_path)?;
+            let session_title = self
+                .ctx
+                .session_store
+                .session_title(&self.ctx.data_dir, &session_id)
+                .map_err(AgentRuntimeError::Other)?;
+            let (human_message, persisted_meta) = add_human_message_internal(
                 &self.ctx.session_store,
                 &self.ctx.data_dir,
                 &session_id,
@@ -362,17 +416,16 @@ impl AgentSessionRuntimeUsecase {
                 state.pending_queue.push_back(queued);
                 pending_queue_view(state)
             };
-            return self.send_response(
-                &session_id,
-                &session.worktree_path,
+            return Ok(response_projection.into_accepted_queue_response(
+                session_title,
                 human_message,
-                None,
-                Some(queued_view),
+                persisted_meta,
+                queued_view,
                 pending_queue,
-            );
+            ));
         }
 
-        let human_message = add_human_message_internal(
+        let (human_message, _) = add_human_message_internal(
             &self.ctx.session_store,
             &self.ctx.data_dir,
             &session_id,
@@ -1681,6 +1734,24 @@ impl AgentSessionRuntimeUsecase {
         queued_turn: Option<QueuedAgentTurn>,
         pending_queue: Vec<QueuedAgentTurn>,
     ) -> Result<SendMessageResponse, AgentRuntimeError> {
+        let projection = self.prepare_send_response_projection(session_id, worktree_path)?;
+        Ok(SendMessageResponse {
+            session: projection.session,
+            human_message,
+            agent_message,
+            queued_turn,
+            pending_queue_count: pending_queue.len(),
+            pending_queue,
+            can_change_backend: false,
+            sessions: projection.sessions,
+        })
+    }
+
+    fn prepare_send_response_projection(
+        &self,
+        session_id: &str,
+        worktree_path: &str,
+    ) -> Result<SendResponseProjection, AgentRuntimeError> {
         let session = self
             .ctx
             .session_store
@@ -1692,16 +1763,7 @@ impl AgentSessionRuntimeUsecase {
             .session_store
             .list_sessions(&self.ctx.data_dir, worktree_path)
             .map_err(AgentRuntimeError::Other)?;
-        Ok(SendMessageResponse {
-            session,
-            human_message,
-            agent_message,
-            queued_turn,
-            pending_queue_count: pending_queue.len(),
-            pending_queue,
-            can_change_backend: false,
-            sessions,
-        })
+        Ok(SendResponseProjection { session, sessions })
     }
 
     fn available_models_for_session(
@@ -3717,9 +3779,9 @@ fn add_human_message_internal(
     content: &str,
     images: &[ImageAttachment],
     mentions: &[crate::domain::code::MentionReference],
-) -> Result<ChatMessage, AgentRuntimeError> {
+) -> Result<(ChatMessage, SessionMeta), AgentRuntimeError> {
     let parts = human_parts(content, images);
-    add_message_internal(
+    add_message_with_meta_internal(
         session_store,
         data_dir,
         session_id,
@@ -5776,6 +5838,152 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_send_message_queue受理後のprojection障害でも成功応答を返す() {
+        // Given: an active turn whose message index does not yet include an orphan chunk, and a
+        // projection store that becomes unreadable while the queued human message is persisted.
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            crate::test_support::build_agent_runtime_usecase_with_controller(
+                session_store.clone(),
+                tmp.path(),
+            );
+        let first = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = first.session.id;
+        wait_for_start_prompt_count(&controller, &session_id, 1).await;
+        let orphan = ChatMessage {
+            id: "orphan-agent-message".to_string(),
+            role: MessageRole::Agent,
+            content: "recovered orphan".to_string(),
+            thinking: None,
+            activities: None,
+            parts: None,
+            streaming_final_seq: 0,
+            timestamp: first.session.updated_at,
+            mentions: None,
+        };
+        let orphan_path = tmp
+            .path()
+            .join("sessions")
+            .join(&session_id)
+            .join("messages")
+            .join("3.json");
+        std::fs::write(
+            orphan_path,
+            serde_json::to_vec_pretty(&orphan).expect("orphan message must serialize"),
+        )
+        .unwrap();
+        let titles_path = tmp.path().join("session_titles.json");
+        session_store.set_append_message_hook_for_test(Arc::new(move |_, _| {
+            std::fs::write(&titles_path, "{").map_err(|error| error.to_string())
+        }));
+
+        // When: the follow-up is accepted into the pending queue.
+        let response = usecase
+            .send_message(SendAgentMessageRequest {
+                chat_session_id: Some(session_id.clone()),
+                worktree_path: tmp.path().to_string_lossy().to_string(),
+                content: "queue exactly once".to_string(),
+                permission_mode: PermissionMode::Edit,
+                plan_mode: false,
+                backend_id: Some("claude".to_string()),
+                model_id: None,
+                images: None,
+                mentions: None,
+                editor_context: None,
+            })
+            .await
+            .expect("accepted queue input must not fail during response projection");
+
+        // Then: the accepted response uses the append's repaired post-write meta even though a
+        // fresh all-session projection now fails, and the queued message exists exactly once.
+        assert!(response.queued_turn.is_some());
+        assert_eq!(response.pending_queue_count, 1);
+        let response_message_count = response
+            .sessions
+            .iter()
+            .find(|summary| summary.id == session_id)
+            .map(|summary| summary.message_count)
+            .expect("accepted session summary must be present");
+        assert!(session_store
+            .list_sessions(tmp.path(), tmp.path().to_string_lossy().as_ref())
+            .is_err());
+        let stored = session_store
+            .load_full_session_for_restore(tmp.path(), &session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(response_message_count, 4);
+        assert_eq!(response_message_count, stored.messages.len());
+        assert!(stored
+            .messages
+            .iter()
+            .any(|message| message.id == orphan.id));
+        assert_eq!(
+            stored
+                .messages
+                .iter()
+                .filter(|message| message.content == "queue exactly once")
+                .count(),
+            1
+        );
+        assert_eq!(usecase.pending_queue(&session_id).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_send_message_queue受理応答のsummaryにcustom_titleを再適用する() {
+        // Given: a busy session with an observed stall and a custom title.
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            crate::test_support::build_agent_runtime_usecase_with_controller(
+                session_store.clone(),
+                tmp.path(),
+            );
+        let first = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = first.session.id;
+        wait_for_start_prompt_count(&controller, &session_id, 1).await;
+        mark_stall_observation_active_for_test(&usecase, &session_id).await;
+        let custom_title = "Investigate queued follow-up";
+        session_store
+            .set_session_title(tmp.path(), &session_id, Some(custom_title))
+            .unwrap();
+
+        // When: the follow-up is accepted into the pending queue.
+        let response = usecase
+            .send_message(SendAgentMessageRequest {
+                chat_session_id: Some(session_id.clone()),
+                worktree_path: tmp.path().to_string_lossy().to_string(),
+                content: "queue this".to_string(),
+                permission_mode: PermissionMode::Edit,
+                plan_mode: false,
+                backend_id: Some("claude".to_string()),
+                model_id: None,
+                images: None,
+                mentions: None,
+                editor_context: None,
+            })
+            .await
+            .unwrap();
+
+        // Then: replacing the summary with post-write meta does not discard the custom title.
+        assert!(response.queued_turn.is_some());
+        assert_eq!(
+            response
+                .sessions
+                .iter()
+                .find(|summary| summary.id == session_id)
+                .map(|summary| summary.first_message.as_str()),
+            Some(custom_title)
+        );
+    }
+
+    #[tokio::test]
     async fn test_failed終端したturnの後も同一sessionへの次sendは新turnを開始できる() {
         // Given: a session whose turn ends as Failed (e.g. Codex remote compact failure).
         let tmp = tempfile::tempdir().unwrap();
@@ -7599,7 +7807,25 @@ mod tests {
             .await
             .unwrap();
         wait_for_stall_observation_count(&event_notifier, 1).await;
-        let send_error = tokio::time::timeout(
+        let images = vec![ImageAttachment {
+            data: "iVBORw==".to_string(),
+            media_type: "image/png".to_string(),
+        }];
+        let mentions = vec![crate::domain::code::MentionReference {
+            file_path: "src/main.rs".to_string(),
+            start_line: Some(10),
+            end_line: Some(20),
+        }];
+        let editor_context = AgentEditorContext {
+            active_editor_path: Some("src/main.rs".to_string()),
+            open_editor_paths: vec!["src/main.rs".to_string(), "README.md".to_string()],
+            selection: Some(AgentEditorSelection {
+                file_path: "src/main.rs".to_string(),
+                start_line: 10,
+                end_line: 20,
+            }),
+        };
+        let response = tokio::time::timeout(
             Duration::from_millis(200),
             usecase.send_message(SendAgentMessageRequest {
                 chat_session_id: Some(session.id.clone()),
@@ -7609,21 +7835,35 @@ mod tests {
                 plan_mode: false,
                 backend_id: Some("claude".to_string()),
                 model_id: None,
-                images: None,
-                mentions: None,
-                editor_context: None,
+                images: Some(images.clone()),
+                mentions: Some(mentions.clone()),
+                editor_context: Some(editor_context.clone()),
             }),
         )
         .await
         .expect("send_message must not wait for stale recovery")
-        .expect_err("stalled active turn on a non-steering backend must be explicit");
+        .expect("stalled active turn on a non-steering backend must queue");
         wait_for_workflow_stall_notification_count(&workflow_stall_notifier, 1).await;
 
-        // Then: the watchdog only emits a non-terminal signal and tries non-destructive recovery.
-        assert!(
-            format!("{send_error:?}").contains("active-turn steering is not available"),
-            "stalled retry/continue must not be silently queued: {send_error:?}"
-        );
+        // Then: the watchdog remains non-terminal and the follow-up is durably queued.
+        assert!(response.agent_message.is_none());
+        assert!(response.queued_turn.is_some());
+        assert_eq!(response.pending_queue_count, 1);
+        {
+            let sessions = usecase.ctx.sessions.lock().await;
+            let queued = sessions
+                .get(&session.id)
+                .and_then(|state| state.pending_queue.front())
+                .expect("stalled follow-up must remain in the pending queue");
+            assert_eq!(queued.content, "next");
+            assert_eq!(queued.images, images);
+            assert_eq!(queued.mentions, mentions);
+            assert_eq!(queued.editor_context, Some(editor_context));
+            assert_eq!(
+                queued.existing_human_message_id.as_deref(),
+                Some(response.human_message.id.as_str())
+            );
+        }
         let calls = controller.call_kinds_for(&session.id);
         assert!(calls.contains(&TestRuntimeCallKind::Reconnect));
         assert!(!calls.contains(&TestRuntimeCallKind::Interrupt));
@@ -7632,9 +7872,13 @@ mod tests {
             usecase.turn_phase(&session.id).await,
             Some(TurnPhase::Streaming)
         );
-        assert!(usecase.pending_queue(&session.id).await.is_empty());
         let loaded = usecase.get_session(&session.id).await.unwrap().unwrap();
         assert_eq!(loaded.session.state, SessionState::Active);
+        assert!(loaded
+            .session
+            .messages
+            .iter()
+            .any(|message| message.id == response.human_message.id));
         assert!(event_notifier.stall_observations().iter().any(|payload| {
             payload.chat_session_id == session.id
                 && payload.turn_phase == TurnPhase::Streaming
@@ -7648,6 +7892,24 @@ mod tests {
                     && payload.turn_phase == "streaming"
                     && payload.signal_count >= 1
             }));
+
+        // And: completion of the stalled turn drains the queued follow-up into a new turn.
+        controller
+            .emit(
+                &session.id,
+                AgentRuntimeEvent::TurnCompleted(TurnResult::Completed {
+                    stop_reason: None,
+                    token_usage: None,
+                }),
+            )
+            .unwrap();
+        wait_for_start_prompt_count(&controller, &session.id, 2).await;
+        assert!(usecase.pending_queue(&session.id).await.is_empty());
+        assert!(controller.call_kinds_for(&session.id).contains(
+            &TestRuntimeCallKind::StartTurnPrompt {
+                prompt: "next".to_string(),
+            }
+        ));
     }
 
     #[tokio::test]

--- a/src-tauri/src/usecase/agent_session/session/mod.rs
+++ b/src-tauri/src/usecase/agent_session/session/mod.rs
@@ -1478,6 +1478,27 @@ pub fn add_message_internal(
     parts: Option<Vec<MessagePart>>,
     mentions: Option<Vec<crate::domain::code::MentionReference>>,
 ) -> Result<ChatMessage, String> {
+    add_message_with_meta_internal(
+        session_store,
+        data_dir,
+        session_id,
+        role,
+        content,
+        parts,
+        mentions,
+    )
+    .map(|(message, _)| message)
+}
+
+pub(super) fn add_message_with_meta_internal(
+    session_store: &SessionStore,
+    data_dir: &std::path::Path,
+    session_id: &str,
+    role: MessageRole,
+    content: &str,
+    parts: Option<Vec<MessagePart>>,
+    mentions: Option<Vec<crate::domain::code::MentionReference>>,
+) -> Result<(ChatMessage, SessionMeta), String> {
     let now = now_timestamp();
     let mentions_for_persist = mentions.map(|v| {
         v.into_iter()
@@ -1495,8 +1516,8 @@ pub fn add_message_internal(
         timestamp: now,
         mentions: mentions_for_persist,
     };
-    session_store.append_message(data_dir, session_id, &message)?;
-    Ok(message)
+    let meta = session_store.append_message(data_dir, session_id, &message)?;
+    Ok((message, meta))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/usecase/agent_session/session/store.rs
+++ b/src-tauri/src/usecase/agent_session/session/store.rs
@@ -314,7 +314,6 @@ impl SessionStore {
         self.set_session_state(app_data_dir, session_id, SessionState::Archived)
     }
 
-    #[allow(dead_code)] // Search uses session_titles() to avoid N+1; single-title lookup is retained for focused callers.
     pub fn session_title(
         &self,
         app_data_dir: &Path,
@@ -868,7 +867,7 @@ impl SessionStore {
         app_data_dir: &Path,
         session_id: &str,
         message: &ChatMessage,
-    ) -> Result<(), String> {
+    ) -> Result<SessionMeta, String> {
         #[cfg(test)]
         if let Some(hook) = self.append_message_hook.read().clone() {
             hook(session_id, message)?;

--- a/src/components/panels/AgentChatPanel/BoundSessionChat.test.tsx
+++ b/src/components/panels/AgentChatPanel/BoundSessionChat.test.tsx
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 	loadOlderMessages: vi.fn().mockResolvedValue(undefined),
 	evictOlderMessages: vi.fn().mockResolvedValue(undefined),
 	registerViewableSession: vi.fn(() => vi.fn()),
-	sendMessage: vi.fn().mockResolvedValue(undefined),
+	sendMessage: vi.fn().mockResolvedValue(true),
 	interrupt: vi.fn(),
 	cancelQueuedTurn: vi.fn().mockResolvedValue(undefined),
 	setPermissionMode: vi.fn(),
@@ -46,7 +46,7 @@ vi.mock("./ChatSessionView", () => ({
 			allow: boolean,
 			updatedInput?: Record<string, unknown>,
 		) => void;
-		onSend: (content: string) => Promise<void>;
+		onSend: (content: string) => Promise<boolean>;
 		stallObservation?: AgentStallObservation | null;
 	}) => (
 		<div data-testid={`chat-${session.id}`}>

--- a/src/components/panels/AgentChatPanel/BoundSessionChat.tsx
+++ b/src/components/panels/AgentChatPanel/BoundSessionChat.tsx
@@ -155,7 +155,7 @@ export function BoundSessionChat({
 		) => {
 			const targetSessionId = options?.forkNewSession ? null : sessionId;
 			if (!targetSessionId && !options?.forkNewSession)
-				return Promise.resolve();
+				return Promise.resolve(false);
 			const sendOptions =
 				options?.activateNewSession === undefined && !options?.editorContext
 					? undefined

--- a/src/components/panels/AgentChatPanel/ChatSessionView.test.ts
+++ b/src/components/panels/AgentChatPanel/ChatSessionView.test.ts
@@ -6,6 +6,7 @@ import type {
 	AgentStallObservation,
 	ChatSession,
 	PermissionRequest,
+	QueuedAgentTurn,
 } from "@/types/session";
 import { ChatSessionView } from "./ChatSessionView";
 
@@ -109,6 +110,7 @@ interface RenderOptions {
 		onEvicted?: (eviction: { count: number; direction: "older" }) => void;
 	}) => void;
 	pendingPermission?: PermissionRequest | null;
+	pendingQueue?: QueuedAgentTurn[];
 	onRespondPermission?: (
 		requestId: string,
 		allow: boolean,
@@ -123,6 +125,7 @@ function chatSessionViewElement({
 	onLoadOlderMessages = vi.fn().mockResolvedValue(undefined),
 	onEvictOlderMessages,
 	pendingPermission = null,
+	pendingQueue = [],
 	onRespondPermission = vi.fn(),
 }: RenderOptions = {}) {
 	return createElement(ChatSessionView, {
@@ -137,12 +140,12 @@ function chatSessionViewElement({
 		backends: [],
 		selectedModel: "claude:sonnet",
 		pendingPermission,
-		pendingQueue: [],
+		pendingQueue,
 		stallObservation,
 		selectedBackendId: null,
 		canChangeBackend: false,
 		worktreePath: "/repo",
-		onSend: vi.fn().mockResolvedValue(undefined),
+		onSend: vi.fn().mockResolvedValue(true),
 		onInterrupt: vi.fn(),
 		onCancelQueuedTurn: vi.fn().mockResolvedValue(undefined),
 		onLoadOlderMessages,
@@ -227,6 +230,32 @@ describe("ChatSessionView session-local controls", () => {
 			},
 		],
 	};
+
+	it("renders text and image-only pending queue entries", () => {
+		renderChatSessionView({
+			pendingQueue: [
+				{
+					id: "queued-text",
+					contentPreview: "Review the failing logs",
+					createdAt: 1002,
+					permissionMode: "edit",
+					imageCount: 0,
+				},
+				{
+					id: "queued-image",
+					contentPreview: "",
+					createdAt: 1003,
+					permissionMode: "edit",
+					imageCount: 1,
+				},
+			],
+		});
+
+		expect(screen.getByText("Queued 1")).toBeInTheDocument();
+		expect(screen.getByText("Review the failing logs")).toBeInTheDocument();
+		expect(screen.getByText("Queued 2")).toBeInTheDocument();
+		expect(screen.getByText("[image]")).toBeInTheDocument();
+	});
 
 	it("keeps find and raw scrollback available from the toolbar", async () => {
 		const user = userEvent.setup();

--- a/src/components/panels/AgentChatPanel/ChatSessionView.tsx
+++ b/src/components/panels/AgentChatPanel/ChatSessionView.tsx
@@ -646,7 +646,7 @@ export interface ChatSessionViewProps {
 			forkNewSession?: boolean;
 			editorContext?: AgentEditorContext;
 		},
-	) => Promise<void>;
+	) => Promise<boolean>;
 	onInterrupt: () => void;
 	onCancelQueuedTurn: (queuedTurnId?: string | null) => Promise<void>;
 	onLoadOlderMessages?: () => Promise<void>;
@@ -1129,7 +1129,7 @@ export function ChatSessionView({
 			images?: ImageAttachment[],
 			mentions?: MentionReference[],
 		) => {
-			await onSend(content, images, mentions, {
+			return onSend(content, images, mentions, {
 				editorContext: currentEditorContext,
 			});
 		},
@@ -1353,10 +1353,12 @@ export function ChatSessionView({
 	// Expose sendMessage to parent via ref (without images parameter)
 	useEffect(() => {
 		if (sendMessageRef) {
-			sendMessageRef.current = (
+			sendMessageRef.current = async (
 				content: string,
 				mentions?: MentionReference[],
-			) => handleComposerSend(content, undefined, mentions);
+			) => {
+				await handleComposerSend(content, undefined, mentions);
+			};
 		}
 		return () => {
 			if (sendMessageRef) {

--- a/src/components/panels/AgentChatPanel/MessageInput.test.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.test.tsx
@@ -15,7 +15,7 @@ import { findMentionTrigger, findSkillTrigger } from "./popupInputUtils";
 const mockInvoke = vi.mocked(invoke);
 
 const defaultProps = {
-	onSend: vi.fn(),
+	onSend: vi.fn().mockResolvedValue(true),
 	onInterrupt: vi.fn(),
 	isStreaming: false,
 	mode: "edit" as const,
@@ -103,7 +103,7 @@ describe("MessageInput", () => {
 	});
 
 	it("calls onSend when send button is clicked", () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(<MessageInput {...defaultProps} onSend={onSend} />);
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "Hello" } });
@@ -111,18 +111,135 @@ describe("MessageInput", () => {
 		expect(onSend).toHaveBeenCalledWith("Hello", undefined, undefined);
 	});
 
-	it("clears input after sending", () => {
-		render(<MessageInput {...defaultProps} />);
+	it("clears input only after sending succeeds", async () => {
+		let resolveSend: ((value: boolean) => void) | undefined;
+		const onSend = vi.fn(
+			() =>
+				new Promise<boolean>((resolve) => {
+					resolveSend = resolve;
+				}),
+		);
+		render(<MessageInput {...defaultProps} onSend={onSend} />);
 		const textarea = screen.getByPlaceholderText(
 			"Send a message...",
 		) as HTMLTextAreaElement;
 		fireEvent.change(textarea, { target: { value: "Hello" } });
 		fireEvent.click(screen.getByLabelText("Send message"));
-		expect(textarea.value).toBe("");
+		expect(textarea.value).toBe("Hello");
+
+		await act(async () => resolveSend?.(true));
+		await waitFor(() => expect(textarea.value).toBe(""));
 	});
 
+	it("preserves input when sending fails or rejects", async () => {
+		const sendError = new Error("send failed");
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const onSend = vi
+			.fn()
+			.mockResolvedValueOnce(false)
+			.mockRejectedValueOnce(sendError);
+		render(<MessageInput {...defaultProps} onSend={onSend} />);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, { target: { value: "Keep this" } });
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+		expect(textarea.value).toBe("Keep this");
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2));
+		expect(textarea.value).toBe("Keep this");
+		await waitFor(() =>
+			expect(consoleError).toHaveBeenCalledWith(
+				"Message send failed:",
+				sendError,
+			),
+		);
+		consoleError.mockRestore();
+	});
+
+	it("serializes submissions and preserves edited input and attachments added in flight", async () => {
+		let resolveSend: ((value: boolean) => void) | undefined;
+		const onSend = vi.fn(
+			() =>
+				new Promise<boolean>((resolve) => {
+					resolveSend = resolve;
+				}),
+		);
+		const ref = createRef<MessageInputHandle>();
+		render(<MessageInput {...defaultProps} onSend={onSend} ref={ref} />);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		const firstImage = { data: "Zmlyc3Q=", mediaType: "image/png" };
+		const followUpImage = { data: "c2Vjb25k", mediaType: "image/png" };
+		act(() => ref.current?.addImageAttachments([firstImage]));
+		fireEvent.change(textarea, { target: { value: "First" } });
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+		fireEvent.change(textarea, { target: { value: "FirstFollow-up" } });
+		act(() => ref.current?.addImageAttachments([followUpImage]));
+		fireEvent.click(screen.getByLabelText("Send message"));
+
+		expect(onSend).toHaveBeenCalledTimes(1);
+		expect(onSend).toHaveBeenCalledWith("First", [firstImage], undefined);
+
+		await act(async () => resolveSend?.(true));
+		await waitFor(() => expect(textarea.value).toBe("FirstFollow-up"));
+		expect(screen.getAllByTestId("image-preview-item")).toHaveLength(1);
+		expect(screen.getByAltText("Attached").getAttribute("src")).toBe(
+			"data:image/png;base64,c2Vjb25k",
+		);
+	});
+
+	it.each([
+		{
+			draftChanges: ["google"],
+			expectedDraft: "google",
+			caseName: "prefix replacement",
+		},
+		{
+			draftChanges: ["cargo"],
+			expectedDraft: "cargo",
+			caseName: "suffix replacement",
+		},
+		{
+			draftChanges: ["google", "go"],
+			expectedDraft: "go",
+			caseName: "replacement edited back to the submitted value",
+		},
+	])(
+		"preserves a $caseName while sending",
+		async ({ draftChanges, expectedDraft }) => {
+			let resolveSend: ((value: boolean) => void) | undefined;
+			const onSend = vi.fn(
+				() =>
+					new Promise<boolean>((resolve) => {
+						resolveSend = resolve;
+					}),
+			);
+			render(<MessageInput {...defaultProps} onSend={onSend} />);
+			const textarea = screen.getByPlaceholderText(
+				"Send a message...",
+			) as HTMLTextAreaElement;
+			fireEvent.change(textarea, { target: { value: "go" } });
+
+			fireEvent.click(screen.getByLabelText("Send message"));
+			for (const draft of draftChanges) {
+				fireEvent.change(textarea, { target: { value: draft } });
+			}
+
+			await act(async () => resolveSend?.(true));
+			await waitFor(() => expect(textarea.value).toBe(expectedDraft));
+		},
+	);
+
 	it("sends on Cmd/Ctrl+Enter", () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(<MessageInput {...defaultProps} onSend={onSend} />);
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "Hello" } });
@@ -131,7 +248,7 @@ describe("MessageInput", () => {
 	});
 
 	it("does not send on Enter alone (Enter is reserved for newline)", () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(<MessageInput {...defaultProps} onSend={onSend} />);
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "Hello" } });
@@ -140,7 +257,7 @@ describe("MessageInput", () => {
 	});
 
 	it("does not send on Shift+Enter", () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(<MessageInput {...defaultProps} onSend={onSend} />);
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "Hello" } });
@@ -260,7 +377,7 @@ describe("MessageInput", () => {
 	});
 
 	it("does not send whitespace-only messages", () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(<MessageInput {...defaultProps} onSend={onSend} />);
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "   " } });
@@ -268,8 +385,8 @@ describe("MessageInput", () => {
 		expect(onSend).not.toHaveBeenCalled();
 	});
 
-	it("sends slash commands to the agent without native interception", () => {
-		const onSend = vi.fn();
+	it("sends slash commands to the agent without native interception", async () => {
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(<MessageInput {...defaultProps} onSend={onSend} />);
 		const textarea = screen.getByPlaceholderText(
 			"Send a message...",
@@ -282,11 +399,11 @@ describe("MessageInput", () => {
 			undefined,
 			undefined,
 		);
-		expect(textarea.value).toBe("");
+		await waitFor(() => expect(textarea.value).toBe(""));
 	});
 
 	it("sends unknown slash commands to the agent", () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(<MessageInput {...defaultProps} onSend={onSend} />);
 		const textarea = screen.getByPlaceholderText("Send a message...");
 		fireEvent.change(textarea, { target: { value: "/status" } });
@@ -295,8 +412,8 @@ describe("MessageInput", () => {
 		expect(onSend).toHaveBeenCalledWith("/status", undefined, undefined);
 	});
 
-	it("sends runtime slash commands to the SDK path without native handlers", () => {
-		const onSend = vi.fn();
+	it("sends runtime slash commands to the SDK path without native handlers", async () => {
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(
 			<MessageInput
 				{...defaultProps}
@@ -315,7 +432,7 @@ describe("MessageInput", () => {
 			undefined,
 			undefined,
 		);
-		expect(textarea.value).toBe("");
+		await waitFor(() => expect(textarea.value).toBe(""));
 	});
 
 	it("renders ModeSelector inside the input container", () => {
@@ -584,7 +701,7 @@ describe("MessageInput slash command popup", () => {
 	});
 
 	it("sends with Cmd+Enter even when popup is open", () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(
 			<MessageInput
 				{...defaultProps}
@@ -646,7 +763,7 @@ describe("MessageInput image attachments", () => {
 	});
 
 	it("sends images with onSend when images are attached", () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		const ref = createRef<MessageInputHandle>();
 		render(<MessageInput {...defaultProps} onSend={onSend} ref={ref} />);
 		act(() => {
@@ -663,7 +780,7 @@ describe("MessageInput image attachments", () => {
 	});
 
 	it("sends images only (no text) when text is empty", () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		const ref = createRef<MessageInputHandle>();
 		render(<MessageInput {...defaultProps} onSend={onSend} ref={ref} />);
 		act(() => {
@@ -673,7 +790,7 @@ describe("MessageInput image attachments", () => {
 		expect(onSend).toHaveBeenCalledWith("", [sampleAttachment], undefined);
 	});
 
-	it("clears image preview after sending", () => {
+	it("clears image preview after sending", async () => {
 		const ref = createRef<MessageInputHandle>();
 		render(<MessageInput {...defaultProps} ref={ref} />);
 		act(() => {
@@ -681,7 +798,31 @@ describe("MessageInput image attachments", () => {
 		});
 		expect(screen.getByTestId("image-preview-list")).toBeDefined();
 		fireEvent.click(screen.getByLabelText("Send message"));
-		expect(screen.queryByTestId("image-preview-list")).toBeNull();
+		await waitFor(() =>
+			expect(screen.queryByTestId("image-preview-list")).toBeNull(),
+		);
+	});
+
+	it("preserves attached images when sending fails", async () => {
+		const onSend = vi.fn().mockResolvedValue(false);
+		const ref = createRef<MessageInputHandle>();
+		render(<MessageInput {...defaultProps} onSend={onSend} ref={ref} />);
+		act(() => {
+			ref.current?.addImageAttachments([sampleAttachment]);
+		});
+		fireEvent.change(screen.getByPlaceholderText("Send a message..."), {
+			target: { value: "Keep the image" },
+		});
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+		expect(screen.getByTestId("image-preview-list")).toBeDefined();
+		expect(onSend).toHaveBeenCalledWith(
+			"Keep the image",
+			[sampleAttachment],
+			undefined,
+		);
 	});
 
 	it("supports multiple image attachments", () => {
@@ -778,7 +919,7 @@ describe("MessageInput image attachments", () => {
 			placeholder: "[Pasted text #1]",
 			content: longText,
 		};
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		mockInvoke.mockImplementation((command, args) => {
 			if (command === "prepare_pasted_text_block") {
 				expect(args).toEqual({ index: 1, content: longText });
@@ -816,6 +957,165 @@ describe("MessageInput image attachments", () => {
 				undefined,
 				undefined,
 			),
+		);
+	});
+
+	it("clears collapsed paste metadata after a successful send", async () => {
+		const longText = Array.from({ length: 24 }, (_, i) => `line ${i + 1}`).join(
+			"\n",
+		);
+		const block = {
+			id: 1,
+			placeholder: "[Pasted text #1]",
+			content: longText,
+		};
+		const onSend = vi.fn().mockResolvedValue(true);
+		const expand = vi.fn().mockResolvedValue("expanded prompt");
+		mockInvoke.mockImplementation((command) => {
+			if (command === "prepare_pasted_text_block") {
+				return Promise.resolve(block);
+			}
+			if (command === "expand_pasted_text_blocks") {
+				return expand();
+			}
+			return Promise.resolve([]);
+		});
+		render(<MessageInput {...defaultProps} onSend={onSend} />);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		const clipboardData = {
+			items: [],
+			getData: (type: string) => (type === "text/plain" ? longText : ""),
+		};
+
+		await act(async () => {
+			fireEvent.paste(textarea, { clipboardData });
+		});
+		await waitFor(() => expect(textarea.value).toBe(block.placeholder));
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await waitFor(() => expect(textarea.value).toBe(""));
+
+		fireEvent.change(textarea, { target: { value: "plain follow-up" } });
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2));
+
+		expect(expand).toHaveBeenCalledTimes(1);
+		expect(onSend).toHaveBeenLastCalledWith(
+			"plain follow-up",
+			undefined,
+			undefined,
+		);
+	});
+
+	it("preserves collapsed pasted text when sending fails", async () => {
+		const longText = Array.from({ length: 24 }, (_, i) => `line ${i + 1}`).join(
+			"\n",
+		);
+		const block = {
+			id: 1,
+			placeholder: "[Pasted text #1]",
+			content: longText,
+		};
+		const onSend = vi.fn().mockResolvedValue(false);
+		const expand = vi.fn().mockResolvedValue("expanded prompt");
+		mockInvoke.mockImplementation((command) => {
+			if (command === "prepare_pasted_text_block")
+				return Promise.resolve(block);
+			if (command === "expand_pasted_text_blocks") return expand();
+			return Promise.resolve([]);
+		});
+		render(<MessageInput {...defaultProps} onSend={onSend} />);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		const clipboardData = {
+			items: [],
+			getData: (type: string) => (type === "text/plain" ? longText : ""),
+		};
+		await act(async () => {
+			fireEvent.paste(textarea, { clipboardData });
+		});
+		await waitFor(() => expect(textarea.value).toBe("[Pasted text #1]"));
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+		expect(textarea.value).toBe("[Pasted text #1]");
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2));
+		expect(expand).toHaveBeenCalledTimes(2);
+	});
+
+	it("preserves collapsed paste metadata when the draft is edited in flight", async () => {
+		const longText = Array.from({ length: 24 }, (_, i) => `line ${i + 1}`).join(
+			"\n",
+		);
+		const block = {
+			id: 1,
+			placeholder: "[Pasted text #1]",
+			content: longText,
+		};
+		let resolveFirstSend: ((value: boolean) => void) | undefined;
+		const onSend = vi
+			.fn()
+			.mockImplementationOnce(
+				() =>
+					new Promise<boolean>((resolve) => {
+						resolveFirstSend = resolve;
+					}),
+			)
+			.mockResolvedValueOnce(true);
+		const expand = vi.fn((content: string) =>
+			Promise.resolve(
+				content === block.placeholder
+					? "expanded prompt"
+					: "expanded prompt follow-up",
+			),
+		);
+		mockInvoke.mockImplementation((command, args) => {
+			if (command === "prepare_pasted_text_block") {
+				return Promise.resolve(block);
+			}
+			if (command === "expand_pasted_text_blocks") {
+				expect(args).toEqual({
+					content: expect.any(String),
+					blocks: [block],
+				});
+				return expand((args as { content: string }).content);
+			}
+			return Promise.resolve([]);
+		});
+		render(<MessageInput {...defaultProps} onSend={onSend} />);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		const clipboardData = {
+			items: [],
+			getData: (type: string) => (type === "text/plain" ? longText : ""),
+		};
+		await act(async () => {
+			fireEvent.paste(textarea, { clipboardData });
+		});
+		await waitFor(() => expect(textarea.value).toBe(block.placeholder));
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+		fireEvent.change(textarea, {
+			target: { value: `${block.placeholder} follow-up` },
+		});
+		await act(async () => resolveFirstSend?.(true));
+		await waitFor(() =>
+			expect(textarea.value).toBe(`${block.placeholder} follow-up`),
+		);
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2));
+		expect(expand).toHaveBeenCalledTimes(2);
+		expect(onSend).toHaveBeenLastCalledWith(
+			"expanded prompt follow-up",
+			undefined,
+			undefined,
 		);
 	});
 });
@@ -1190,7 +1490,7 @@ describe("MessageInput mention popup", () => {
 	});
 
 	it("sends mentions with onSend after selecting a mention", async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		mockInvoke.mockImplementation((command, args) => {
 			if (command === "list_mentionable_files") {
 				return Promise.resolve(mentionFiles);
@@ -1240,8 +1540,293 @@ describe("MessageInput mention popup", () => {
 		]);
 	});
 
+	it("clears mention metadata after a successful send", async () => {
+		const onSend = vi.fn().mockResolvedValue(true);
+		const syncedMention = {
+			filePath: "src/main.rs",
+			startLine: undefined,
+			endLine: undefined,
+		};
+		const syncMentions = vi.fn().mockResolvedValue([syncedMention]);
+		mockInvoke.mockImplementation((command, args) => {
+			if (command === "list_mentionable_files") {
+				return Promise.resolve(mentionFiles);
+			}
+			if (command === "sync_mentions_with_text") {
+				return syncMentions(args);
+			}
+			return Promise.resolve([]);
+		});
+		render(
+			<MessageInput
+				{...defaultProps}
+				onSend={onSend}
+				worktreePath="/test/repo"
+			/>,
+		);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, {
+			target: { value: "@", selectionStart: 1 },
+		});
+		await act(() => vi.advanceTimersByTimeAsync(150));
+		fireEvent.keyDown(textarea, { key: "Enter" });
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		expect(textarea.value).toBe("");
+
+		fireEvent.change(textarea, {
+			target: { value: "plain follow-up", selectionStart: 15 },
+		});
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(syncMentions).toHaveBeenCalledTimes(1);
+		expect(onSend).toHaveBeenCalledTimes(2);
+		expect(onSend).toHaveBeenLastCalledWith(
+			"plain follow-up",
+			undefined,
+			undefined,
+		);
+	});
+
+	it("preserves input metadata and logs the stage when mention sync rejects", async () => {
+		const longText = Array.from({ length: 24 }, (_, i) => `line ${i + 1}`).join(
+			"\n",
+		);
+		const block = {
+			id: 1,
+			placeholder: "[Pasted text #1]",
+			content: longText,
+		};
+		const syncedMention = {
+			filePath: "src/main.rs",
+			startLine: undefined,
+			endLine: undefined,
+		};
+		const syncError = new Error("mention sync failed");
+		const syncMentions = vi
+			.fn()
+			.mockRejectedValueOnce(syncError)
+			.mockResolvedValueOnce([syncedMention]);
+		const expand = vi.fn().mockResolvedValue("expanded prompt @src/main.rs");
+		const onSend = vi.fn().mockResolvedValue(true);
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const ref = createRef<MessageInputHandle>();
+		mockInvoke.mockImplementation((command, args) => {
+			if (command === "prepare_pasted_text_block") {
+				return Promise.resolve(block);
+			}
+			if (command === "expand_pasted_text_blocks") {
+				return expand(args);
+			}
+			if (command === "list_mentionable_files") {
+				return Promise.resolve(mentionFiles);
+			}
+			if (command === "sync_mentions_with_text") {
+				return syncMentions(args);
+			}
+			return Promise.resolve([]);
+		});
+		render(
+			<MessageInput
+				{...defaultProps}
+				onSend={onSend}
+				ref={ref}
+				worktreePath="/test/repo"
+			/>,
+		);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		act(() => ref.current?.addImageAttachments([sampleAttachment]));
+		fireEvent.change(textarea, {
+			target: { value: "@", selectionStart: 1 },
+		});
+		await act(() => vi.advanceTimersByTimeAsync(150));
+		fireEvent.keyDown(textarea, { key: "Enter" });
+		await act(() => vi.advanceTimersByTimeAsync(0));
+		await act(async () => {
+			fireEvent.paste(textarea, {
+				clipboardData: {
+					items: [],
+					getData: (type: string) => (type === "text/plain" ? longText : ""),
+				},
+			});
+		});
+
+		await act(async () => {
+			fireEvent.click(screen.getByLabelText("Send message"));
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(onSend).not.toHaveBeenCalled();
+		expect(textarea.value).toBe(`@src/main.rs ${block.placeholder}`);
+		expect(screen.getByTestId("image-preview-list")).toBeDefined();
+		expect(screen.getByLabelText("Send message").hasAttribute("disabled")).toBe(
+			false,
+		);
+		expect(expand).toHaveBeenCalledTimes(1);
+		expect(syncMentions).toHaveBeenCalledWith({
+			text: "expanded prompt @src/main.rs",
+			refs: [syncedMention],
+		});
+		expect(consoleError).toHaveBeenCalledWith(
+			"Message pre-send processing failed:",
+			syncError,
+		);
+		expect(screen.queryByText("mention sync failed")).toBeNull();
+
+		await act(async () => {
+			fireEvent.click(screen.getByLabelText("Send message"));
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		expect(expand).toHaveBeenCalledTimes(2);
+		expect(syncMentions).toHaveBeenCalledTimes(2);
+		expect(onSend).toHaveBeenCalledWith(
+			"expanded prompt @src/main.rs",
+			[sampleAttachment],
+			[syncedMention],
+		);
+		consoleError.mockRestore();
+	});
+
+	it("preserves mention references when sending fails", async () => {
+		const onSend = vi.fn().mockResolvedValue(false);
+		const syncedMention = {
+			filePath: "src/main.rs",
+			startLine: undefined,
+			endLine: undefined,
+		};
+		mockInvoke.mockImplementation((command) => {
+			if (command === "list_mentionable_files") {
+				return Promise.resolve(mentionFiles);
+			}
+			if (command === "sync_mentions_with_text") {
+				return Promise.resolve([syncedMention]);
+			}
+			return Promise.resolve([]);
+		});
+		render(
+			<MessageInput
+				{...defaultProps}
+				onSend={onSend}
+				worktreePath="/test/repo"
+			/>,
+		);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, {
+			target: { value: "@", selectionStart: 1 },
+		});
+		await act(() => vi.advanceTimersByTimeAsync(150));
+		fireEvent.keyDown(textarea, { key: "Enter" });
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await act(async () => Promise.resolve());
+		expect(textarea.value).toBe("@src/main.rs ");
+		expect(onSend).toHaveBeenCalledWith("@src/main.rs", undefined, [
+			syncedMention,
+		]);
+
+		fireEvent.click(screen.getByLabelText("Send message"));
+		await act(async () => Promise.resolve());
+		expect(onSend).toHaveBeenCalledTimes(2);
+		expect(onSend).toHaveBeenLastCalledWith("@src/main.rs", undefined, [
+			syncedMention,
+		]);
+	});
+
+	it("preserves mention metadata when the draft is edited in flight", async () => {
+		let resolveFirstSend: ((value: boolean) => void) | undefined;
+		const onSend = vi
+			.fn()
+			.mockImplementationOnce(
+				() =>
+					new Promise<boolean>((resolve) => {
+						resolveFirstSend = resolve;
+					}),
+			)
+			.mockResolvedValueOnce(true);
+		const syncedMention = {
+			filePath: "src/main.rs",
+			startLine: undefined,
+			endLine: undefined,
+		};
+		const syncMentions = vi.fn().mockResolvedValue([syncedMention]);
+		mockInvoke.mockImplementation((command, args) => {
+			if (command === "list_mentionable_files") {
+				return Promise.resolve(mentionFiles);
+			}
+			if (command === "sync_mentions_with_text") {
+				return syncMentions(args);
+			}
+			return Promise.resolve([]);
+		});
+		render(
+			<MessageInput
+				{...defaultProps}
+				onSend={onSend}
+				worktreePath="/test/repo"
+			/>,
+		);
+		const textarea = screen.getByPlaceholderText(
+			"Send a message...",
+		) as HTMLTextAreaElement;
+		fireEvent.change(textarea, {
+			target: { value: "@", selectionStart: 1 },
+		});
+		await act(() => vi.advanceTimersByTimeAsync(150));
+		fireEvent.keyDown(textarea, { key: "Enter" });
+
+		await act(async () => {
+			fireEvent.click(screen.getByLabelText("Send message"));
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		expect(onSend).toHaveBeenCalledTimes(1);
+		fireEvent.change(textarea, {
+			target: {
+				value: "@src/main.rs follow-up",
+				selectionStart: 22,
+			},
+		});
+		await act(async () => resolveFirstSend?.(true));
+		expect(textarea.value).toBe("@src/main.rs follow-up");
+
+		await act(async () => {
+			fireEvent.click(screen.getByLabelText("Send message"));
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		expect(syncMentions).toHaveBeenCalledTimes(2);
+		expect(syncMentions).toHaveBeenLastCalledWith({
+			text: "@src/main.rs follow-up",
+			refs: [syncedMention],
+		});
+		expect(onSend).toHaveBeenLastCalledWith(
+			"@src/main.rs follow-up",
+			undefined,
+			[syncedMention],
+		);
+	});
+
 	it("sends quoted mention paths with spaces as structured mentions", async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		mockInvoke.mockImplementation((command, args) => {
 			if (command === "list_mentionable_files") {
 				return Promise.resolve(["docs/my file.md"]);
@@ -1296,7 +1881,7 @@ describe("MessageInput mention popup", () => {
 	});
 
 	it("excludes deleted mentions from onSend", async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		render(
 			<MessageInput
 				{...defaultProps}
@@ -1324,7 +1909,7 @@ describe("MessageInput mention popup", () => {
 	});
 
 	it("extracts line number from @filePath:L50 in text", async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		mockInvoke.mockImplementation((command, args) => {
 			if (command === "list_mentionable_files") {
 				return Promise.resolve(mentionFiles);
@@ -1379,7 +1964,7 @@ describe("MessageInput mention popup", () => {
 	});
 
 	it("extracts line range from @filePath:L10-L20 in text", async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn().mockResolvedValue(true);
 		mockInvoke.mockImplementation((command, args) => {
 			if (command === "list_mentionable_files") {
 				return Promise.resolve(mentionFiles);

--- a/src/components/panels/AgentChatPanel/MessageInput.tsx
+++ b/src/components/panels/AgentChatPanel/MessageInput.tsx
@@ -51,9 +51,6 @@ interface PastedTextBlock {
 
 export interface MessageInputHandle {
 	addImageAttachments: (attachments: ImageAttachment[]) => void;
-	setDraft: (content: string) => void;
-	getDraft: () => string;
-	clearDraft: () => void;
 }
 
 interface MessageInputProps {
@@ -61,7 +58,7 @@ interface MessageInputProps {
 		content: string,
 		images?: ImageAttachment[],
 		mentions?: MentionReference[],
-	) => void | Promise<void>;
+	) => Promise<boolean>;
 	onInterrupt: () => void;
 	isStreaming: boolean;
 	/** interrupt 要求済みで turn 終了待ちの楽観状態。停止ボタンを停止中表示にする。*/
@@ -108,7 +105,10 @@ export function MessageInput({
 }: MessageInputProps) {
 	const planModeSwitchId = useId();
 	const [value, setValue] = useState("");
+	const draftRevisionRef = useRef(0);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const isSubmittingRef = useRef(false);
 	const [slashPopupDismissed, setSlashPopupDismissed] = useState(false);
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
@@ -145,6 +145,7 @@ export function MessageInput({
 		return merged;
 	}, [runtimeSlashCommands]);
 	const setComposerValue = useCallback((nextValue: string) => {
+		draftRevisionRef.current += 1;
 		setValue(nextValue);
 		requestAnimationFrame(() => {
 			const el = textareaRef.current;
@@ -156,6 +157,7 @@ export function MessageInput({
 	}, []);
 	const setComposerValueWithCaret = useCallback(
 		(nextValue: string, caret: number) => {
+			draftRevisionRef.current += 1;
 			setValue(nextValue);
 			requestAnimationFrame(() => {
 				const el = textareaRef.current;
@@ -202,29 +204,8 @@ export function MessageInput({
 				const newImages = attachments.map(createAttachedImage);
 				setAttachedImages((prev) => [...prev, ...newImages]);
 			},
-			setDraft: (content: string) => {
-				setComposerValue(content);
-				setSlashPopupDismissed(false);
-				requestAnimationFrame(() => textareaRef.current?.focus());
-			},
-			getDraft: () => value,
-			clearDraft: () => {
-				setValue("");
-				setAttachedImages([]);
-				setPastedTextBlocks([]);
-				setMentionRefs([]);
-				setSlashPopupDismissed(false);
-				setSelectedIndex(0);
-				setMentionTrigger(null);
-				setMentionDismissed(false);
-				setMentionSelectedIndex(0);
-				setSkillTrigger(null);
-				setSkillDismissed(false);
-				setSkillSelectedIndex(0);
-				requestAnimationFrame(() => textareaRef.current?.focus());
-			},
 		}),
-		[createAttachedImage, setComposerValue, value],
+		[createAttachedImage],
 	);
 
 	const showSlashPopup =
@@ -334,7 +315,9 @@ export function MessageInput({
 	}, [skillQuery, skillDismissed, worktreePath, currentBackendId]);
 
 	const handleSelectCommand = useCallback((cmd: SlashCommand) => {
-		setValue(`/${cmd.name} `);
+		const nextValue = `/${cmd.name} `;
+		draftRevisionRef.current += 1;
+		setValue(nextValue);
 		setSlashPopupDismissed(true);
 		setSelectedIndex(0);
 		if (textareaRef.current) {
@@ -388,6 +371,7 @@ export function MessageInput({
 				mentionTrigger.start + 1 + mentionTrigger.query.length;
 			const after = value.slice(replacementEnd).replace(/^\s/, "");
 			const newValue = `${before}${token} ${after}`;
+			draftRevisionRef.current += 1;
 			setValue(newValue);
 			setMentionRefs((prev) => [
 				...prev,
@@ -417,6 +401,7 @@ export function MessageInput({
 				.replace(/^\s/, "");
 			const token = `/${skill.name}`;
 			const newValue = `${before}${token} ${after}`;
+			draftRevisionRef.current += 1;
 			setValue(newValue);
 			setSkillTrigger(null);
 			setSkillDismissed(true);
@@ -434,58 +419,102 @@ export function MessageInput({
 	);
 
 	const handleSubmit = useCallback(() => {
+		if (isSubmittingRef.current) return;
 		const trimmed = value.trim();
 		const hasImages = attachedImages.length > 0;
 		if (!trimmed && !hasImages) return;
 
-		const submitContent = async (submittedContent: string) => {
-			const currentMentions =
-				mentionRefs.length === 0
-					? undefined
-					: await syncMentionsForSubmit(submittedContent);
-			if (hasImages) {
-				onSend(
+		const submittedDraftRevision = draftRevisionRef.current;
+		const submittedImages = attachedImages;
+		const submittedImageIds = new Set(submittedImages.map((image) => image.id));
+		const submittedPastedTextIds = new Set(
+			pastedTextBlocks.map((block) => block.id),
+		);
+		const submittedMentions = mentionRefs;
+		isSubmittingRef.current = true;
+		setIsSubmitting(true);
+
+		const submitContent = async () => {
+			let failureStage: "pre-send processing" | "send" = "pre-send processing";
+			try {
+				let submittedContent = trimmed;
+				if (pastedTextBlocks.length > 0) {
+					try {
+						submittedContent = await expandSubmittedContent(trimmed);
+					} catch (error) {
+						console.error("Failed to expand pasted text blocks:", error);
+						return;
+					}
+				}
+				const currentMentions =
+					submittedMentions.length === 0
+						? undefined
+						: await syncMentionsForSubmit(submittedContent);
+				failureStage = "send";
+				const sent = await onSend(
 					submittedContent,
-					attachedImages.map((img) => img.attachment),
+					hasImages
+						? submittedImages.map((image) => image.attachment)
+						: undefined,
 					currentMentions,
 				);
-			} else {
-				onSend(submittedContent, undefined, currentMentions);
-			}
-			setValue("");
-			setAttachedImages([]);
-			setPastedTextBlocks([]);
-			setMentionRefs([]);
-			setSlashPopupDismissed(false);
-			setSelectedIndex(0);
-			setMentionTrigger(null);
-			setMentionDismissed(false);
-			setMentionSelectedIndex(0);
-			setSkillTrigger(null);
-			setSkillDismissed(false);
-			setSkillSelectedIndex(0);
-			if (textareaRef.current) {
-				textareaRef.current.style.height = "auto";
+				if (sent !== true) return;
+
+				const draftWasEdited =
+					draftRevisionRef.current !== submittedDraftRevision;
+				if (!draftWasEdited) {
+					setValue("");
+					setPastedTextBlocks((current) =>
+						current.filter((block) => !submittedPastedTextIds.has(block.id)),
+					);
+					setMentionRefs((current) => {
+						const remainingSubmitted = [...submittedMentions];
+						return current.filter((mention) => {
+							const submittedIndex = remainingSubmitted.findIndex(
+								(submitted) =>
+									submitted.filePath === mention.filePath &&
+									submitted.startLine === mention.startLine &&
+									submitted.endLine === mention.endLine,
+							);
+							if (submittedIndex === -1) return true;
+							remainingSubmitted.splice(submittedIndex, 1);
+							return false;
+						});
+					});
+				}
+				setAttachedImages((current) =>
+					current.filter((image) => !submittedImageIds.has(image.id)),
+				);
+				if (!draftWasEdited) {
+					setSlashPopupDismissed(false);
+					setSelectedIndex(0);
+					setMentionTrigger(null);
+					setMentionDismissed(false);
+					setMentionSelectedIndex(0);
+					setSkillTrigger(null);
+					setSkillDismissed(false);
+					setSkillSelectedIndex(0);
+					if (textareaRef.current) {
+						textareaRef.current.style.height = "auto";
+					}
+				}
+			} catch (error) {
+				console.error(`Message ${failureStage} failed:`, error);
+			} finally {
+				isSubmittingRef.current = false;
+				setIsSubmitting(false);
 			}
 		};
 
-		if (pastedTextBlocks.length > 0) {
-			void expandSubmittedContent(trimmed)
-				.then(submitContent)
-				.catch((e) => {
-					console.error("Failed to expand pasted text blocks:", e);
-				});
-			return;
-		}
-		void submitContent(trimmed);
+		void submitContent();
 	}, [
 		value,
 		onSend,
 		attachedImages,
 		expandSubmittedContent,
-		mentionRefs.length,
+		mentionRefs,
 		syncMentionsForSubmit,
-		pastedTextBlocks.length,
+		pastedTextBlocks,
 	]);
 
 	const handleKeyDown = useCallback(
@@ -604,6 +633,7 @@ export function MessageInput({
 	const handleChange = useCallback(
 		(e: React.ChangeEvent<HTMLTextAreaElement>) => {
 			const newValue = e.target.value;
+			draftRevisionRef.current += 1;
 			setValue(newValue);
 			setSlashPopupDismissed(false);
 			setSelectedIndex(0);
@@ -820,7 +850,7 @@ export function MessageInput({
 								size="icon"
 								className="h-7 w-7 shrink-0"
 								onClick={handleSubmit}
-								disabled={!canSend}
+								disabled={!canSend || isSubmitting}
 								aria-label={submitLabel}
 								title={submitLabel}
 							>

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -268,13 +268,15 @@ describe("useAgentChat", () => {
 
 		const { result } = renderHook(() => useAgentChat("/repo"));
 
+		let succeeded: boolean | undefined;
 		await act(async () => {
-			await result.current.sendMessage(
+			succeeded = await result.current.sendMessage(
 				result.current.activeSession?.id ?? null,
 				"hello",
 			);
 		});
 
+		expect(succeeded).toBe(true);
 		expect(sessionStore.sendAgentMessage).toHaveBeenCalledWith(
 			null,
 			"/repo",
@@ -285,6 +287,24 @@ describe("useAgentChat", () => {
 			undefined,
 			undefined,
 		);
+	});
+
+	it("sendMessage returns false when the send API fails", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		vi.mocked(sessionStore.sendAgentMessage).mockRejectedValueOnce(
+			new Error("send failed"),
+		);
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		let succeeded: boolean | undefined;
+		await act(async () => {
+			succeeded = await result.current.sendMessage(null, "keep this");
+		});
+
+		expect(succeeded).toBe(false);
+		expect(result.current.error).toContain("メッセージ送信に失敗");
 	});
 
 	it("sendMessage passes images to sendAgentMessage", async () => {
@@ -674,6 +694,51 @@ describe("useAgentChat", () => {
 		expect(
 			result.current.activeSession?.messages.map((message) => message.id),
 		).toEqual(["msg-1", "msg-2"]);
+	});
+
+	it("sendMessage mirrors a non-empty accepted pending queue", async () => {
+		const { renderHook, act } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const sessionStore = await import("./useSessionStore");
+		const pendingQueue = [
+			{
+				id: "queued-1",
+				contentPreview: "follow-up",
+				createdAt: 1002,
+				permissionMode: "edit" as const,
+				imageCount: 0,
+			},
+		];
+		vi.mocked(sessionStore.sendAgentMessage).mockResolvedValueOnce({
+			session: {
+				id: "s1",
+				worktreePath: "/repo",
+				messages: [],
+				state: "active",
+				createdAt: 1000,
+				updatedAt: 1002,
+				permissionMode: "edit",
+			},
+			humanMessage: {
+				id: "msg-queued",
+				role: "human",
+				parts: [{ type: "text", content: "follow-up" }],
+				timestamp: 1002,
+			},
+			agentMessage: null,
+			queuedTurn: pendingQueue[0],
+			pendingQueue,
+			pendingQueueCount: 1,
+			canChangeBackend: false,
+			sessions: [],
+		});
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		await act(async () => {
+			await result.current.sendMessage("s1", "follow-up");
+		});
+
+		expect(result.current.getSessionPendingQueue("s1")).toEqual(pendingQueue);
 	});
 
 	it("sendMessage can create a new session without activating it", async () => {

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -123,7 +123,7 @@ export interface UseAgentChatResult {
 		images?: ImageAttachment[],
 		mentions?: MentionReference[],
 		options?: SendMessageOptions,
-	) => Promise<void>;
+	) => Promise<boolean>;
 	interrupt: (sessionId: string) => void;
 	selectSession: (sessionId: string) => Promise<void>;
 	refreshSessions: (
@@ -798,7 +798,7 @@ export function useAgentChat(
 			options?: SendMessageOptions,
 		) => {
 			const trimmed = content.trim();
-			if (!trimmed && (!images || images.length === 0)) return;
+			if (!trimmed && (!images || images.length === 0)) return false;
 
 			try {
 				const wPath = worktreePathRef.current;
@@ -911,11 +911,13 @@ export function useAgentChat(
 				}
 				dispatch({ type: "SET_SESSIONS", sessions: response.sessions });
 				dispatchWorkspaceTreeRefresh(response.session.worktreePath);
+				return true;
 			} catch (e) {
 				dispatch({
 					type: "SET_ERROR",
 					error: `メッセージ送信に失敗: ${e}`,
 				});
+				return false;
 			}
 		},
 		[


### PR DESCRIPTION
## 概要

stalled turn（agent が長時間無反応）中にユーザーがメッセージを送信したとき、入力テキスト・添付画像・mention が失われる不具合を修正する（milestone 84 / OB-2, severity: high, 種別: dropped）。

送信操作の結果を「turn 開始 or queue 追加」の 2 つに収束させ（ideal lifecycle I6）、steer 非対応 backend への実行中送信・stall 判定中の送信のいずれでも `active-turn steering is not available` の生エラーがユーザーに露出せず、入力欄と添付が保全される状態にする。

Closes #1403

## 背景

- 現状 `send_message` は stall 観測中の turn に対し、backend が steering 非対応なら queue せずエラーを返していた。Claude / Codex とも `capabilities().steering=false` で `steer` 未オーバーライドのため、stalled turn への送信は常にこのエラーになり、`add_human_message_internal` 前のためメッセージが完全に失われていた。
- frontend も `MessageInput.tsx` が `onSend` を await せず即クリア、`useAgentChat.ts` の catch がエラーを swallow するため、入力復元経路が存在しなかった。

## 変更内容

### backend（Rust / usecase）
- 実行中 turn への送信が steer 未対応となる場合、エラーを返さず pending queue へフォールバック（R1）。stall 判定中も同一の queue 経路に載せる。
- queue 投入時に human message を永続化し queue entry と紐づけ、本文・添付・mention・editor_context を保全（R2）。既存の QueuedTurnInput 経路を再利用。
- `append_message` が `SessionMeta` を返すよう変更し、queue 紐付けに利用。
- 送信結果は backend-owned な `SendMessageResponse` として返す。

### frontend（UI 制御のみ）
- 送信ハンドラが送信 API の完了を待ち、成功応答時にのみ入力欄・添付・pasted text・mention をクリア（R3）。失敗時・待機中の追加入力は保持。
- catch の swallow を撤廃し、失敗を送信ハンドラへ伝播（R4）。生エラー文言を UI へ露出させない（R6）。

### テスト
- issues-1301 D16/F-2（「stalled retry/continue must not be silently queued」）の意図的仕様を I6 優先で反転し、該当テストを新仕様（stall 中も queue へフォールバック）に更新（R7）。
- stalled 送信 → queue 追加 → turn 終了後の queue 実行、送信失敗時の入力保全をテストで固定。

## Non-goals
- pending queue の永続化（OB-3）、cancel 済み transcript 復活（OB-4）ほかは別 ISSUE。
- backend の実 steer 実装そのものは対象外（steer 非対応時のフォールバックに限る）。

## 品質チェック
- ✅ `pnpm lint` / `pnpm test` (1300 passed) / `cargo fmt --check` / `cargo clippy -- -D warnings`
- ⚠️ `cargo test`: `test_streaming_delta_...coalesceする` が並列実行時に 1 件フレーク（33ms coalesce のタイミング依存、単独再実行で通過）。本変更は coalesce ロジックに無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 実行中のターンが停止状態でも、送信内容を保留キューに追加できるようになりました。
  * 保留中のメッセージが本文・画像・メンションなどを保持し、キューとして画面に表示されます。

* **不具合修正**
  * 停止中の送信で入力内容が失われる問題を修正しました。
  * 送信成功時のみ入力欄や添付ファイルをクリアし、失敗時は内容を保持します。
  * 送信中の重複送信や、送信中に追加した入力内容の消失を防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->