### PR TITLE
feat: session runtime lock の保持規約明文化と prune 是正 (#1411)

### DIFF
--- a/docs/specs/issues-1411/behavior.md
+++ b/docs/specs/issues-1411/behavior.md
@@ -1,0 +1,147 @@
+# Behavior
+
+関連: #1411（milestone 84「Agentチャット安定化」／ Phase 0 ／ L10）
+
+正本参照:
+- 要求: `docs/specs/issues-1411/requirements.md`
+- 問題インベントリ: `specs/milestone-84-agent-chat-stabilization/agent-chat-instability-audit.md` の **ST-5**
+- ライフサイクル理想形: `specs/milestone-84-agent-chat-stabilization/agent-chat-ideal-lifecycle.md` の **I13**
+
+本文書は session runtime lock 機構（`SessionRuntimeLocks` / `acquire_session_runtime_lock` / `acquire_session_lock` / `SessionRuntimeLockGuard`）の観測可能な振る舞いを定義する。本変更は backend（Rust）内部完結であり、外部から観測可能な UI/CLI の振る舞いは追加・変更しない。ここでの「観測」は Rust ユニットテスト・ソース（rustdoc）・ビルド構成（test / production）からの観測を指す。
+
+## 仮定
+
+- 仮定1: 振る舞いは lock 機構の契約（per-session 排他の維持、prune の確実性、再入検出）として観測する。具体データ構造（pending 集合の持ち方等）は design.md で確定する実装詳細であり、本文書では規定しない。
+- 仮定2: 「未参照エントリ」とは、解放済みで他に保持者が無い lock エントリ（`Arc::strong_count == 1` 相当）を指す。
+- 仮定3: 再入検出の粒度は「別 session の lock を保持したまま acquire するケース」を最低限として design.md で確定する。本文書では「規約違反の再入がテストビルドで検出される」ことのみを要求する。
+- 仮定4: 既存経路の棚卸しで明確な違反が無ければ「違反なし」を棚卸し結果として記録する（requirements 仮定 A4 に従う）。
+- 仮定5: 外部（UI/CLI）から観測可能な振る舞いの変更は無い。既存の per-session 排他モデルは維持される。
+
+## Feature: session runtime lock の保持規約と確実な解放
+
+  session ごとの runtime 処理は per-session の排他ロックで直列化される。
+  本 feature は、その排他が維持されること、解放済み lock エントリが無期限に
+  蓄積しないこと、規約違反の lock 再入がテストビルドで検出されることを保証する。
+
+  Background:
+    Given session runtime lock 機構が初期化されている
+    And lock エントリを管理する map が存在する
+
+  Rule: 同一 session の runtime 処理は排他的に直列化される
+
+    Scenario: 同一 session に対する二重 acquire は直列化される
+      Given ある session の runtime lock が取得されている
+      When 同一 session の runtime lock を別のフローが取得しようとする
+      Then その取得は先行フローが lock を解放するまで待機する
+      And 先行フローの解放後に取得が完了する
+
+    Scenario: 異なる session の runtime lock は互いに独立して取得できる
+      Given ある session の runtime lock が取得されている
+      When 別の session の runtime lock を取得しようとする
+      Then その取得は先行フローの解放を待たずに完了する
+
+    Scenario: fan-out child の workflow activation は公開後の外部操作より先に予約される
+      Given 複数の child session を開始する fan-out がある
+      And 先頭 child の backend start が完了待ちで停止している
+      When 公開済みの後続 child に user turn または close 操作が行われる
+      Then 後続 child の workflow activation が先に session lock を取得している
+      And 外部操作は workflow prompt の開始を追い越さない
+
+    Scenario: fan-out activation の中断は child task の終了を待つ
+      Given 先頭 child の backend start が完了待ちで停止している
+      And 後続 child の activation task も session lock を予約している
+      When workflow が stop または abort される
+      Then cancel acknowledgment 後の decision 待ちでは全 child activation が静止している
+      And 全 child の activation task は abort され、終了確認後に中断処理が完了する
+      And 全 child の session lock は中断完了前に解放される
+      And terminal cleanup は全 child の終了確認後に実行される
+      And backend start の待機を解除しても中断後に後続 child の start は発生しない
+
+  Rule: lock 保持中の規約が rustdoc に明記される
+
+    Scenario: 公開 API に保持規約が記述されている
+      Given `acquire_session_lock` と `acquire_session_runtime_lock` の定義
+      Then rustdoc に「lock 保持中に別 session の runtime lock を取得しない」旨が明記されている
+      And rustdoc に「backend I/O の await は最小範囲に留める」旨が明記されている
+      And rustdoc に「UI/event への emit は lock 外で行う」旨が明記されている
+
+  Rule: 既存の lock 保持経路は規約に適合する（または違反が列挙される）
+
+    Scenario: 既存経路の棚卸しで違反が是正されている
+      Given lock を保持する既存の呼び出し経路群
+      When 各経路を規約 (a) 別 session lock 取得禁止 / (b) backend I/O await 最小 / (c) emit はロック外 に照らして棚卸しする
+      Then 規約違反は本 ISSUE のスコープ内で是正される
+      And 是正が過大な違反は違反一覧（ファイル・行・違反種別）として ISSUE に列挙され分割判断される
+
+    Scenario: 明確な違反が無い場合の棚卸し結果
+      Given 棚卸し対象の既存経路に明確な規約違反が無い
+      Then 棚卸し結果として「違反なし」が記録される
+
+  Rule: 解放済みの未参照 lock エントリは無期限に蓄積しない
+
+    Scenario: 解放後の未参照エントリは次回 acquire で除去される
+      Given ある session の runtime lock が取得され、その後解放されている
+      And その session の lock エントリを他に保持しているフローが無い
+      When 任意の session に対して次回 acquire_session_runtime_lock が実行される
+      Then 解放済みで未参照のエントリは map から除去されている
+
+    Scenario: 保持中のエントリは prune で除去されない
+      Given ある session の runtime lock が現在も保持されている
+      When 別のフローが acquire_session_runtime_lock を実行する
+      Then 保持中の session のエントリは map に残る
+
+    Scenario: prune はランタイムハンドルの有無に依存しない
+      Given tokio runtime handle を取得できない文脈で lock guard が drop される
+      When その後に acquire_session_runtime_lock が実行される
+      Then 解放済みで未参照のエントリは除去され、prune が skip されない
+
+    Scenario: 多数 session の取得と解放を繰り返してもエントリが無限蓄積しない
+      Given 多数の異なる session について lock の取得と解放を繰り返す
+      When 各解放後に後続の acquire が発生する
+      Then map のエントリ数は保持中の lock 数に相当する範囲に収束し、無期限には増加しない
+
+  Rule: 規約違反の lock 再入がテストビルドで検出される
+
+    Scenario: 別 session の lock を保持したまま acquire するとテストビルドで検出される
+      Given テストビルドである
+      And あるフローが session A の runtime lock を保持している
+      When 同一フローが解放前に session B の runtime lock を取得しようとする
+      Then 規約違反として test profile に依存せず検出される（`#[cfg(test)]` 内の `assert!` 等で失敗する）
+
+    Scenario: lock を保持していない状態での acquire は検出されない
+      Given テストビルドである
+      And 現在いずれの session lock も保持していない
+      When session の runtime lock を取得する
+      Then 再入としては検出されず、取得は正常に完了する
+
+    Scenario: 同一フローの acquire future を並行 poll すると取得待機中でも検出される
+      Given テストビルドである
+      And 別 task が session A と session B の runtime lock を保持している
+      When 同一フローが session A と session B の acquire future を join で並行 poll する
+      Then 2つ目の acquire は per-session lock の取得前に規約違反として検出される
+      And cancel または panic で破棄された取得前 owner 予約は残存しない
+
+    Scenario: 解放後の逐次 acquire は再入として検出されない
+      Given テストビルドである
+      And session A の lock を取得し解放した
+      When その後に session B の lock を取得する
+      Then 再入としては検出されず、取得は正常に完了する
+
+  Rule: production ビルドの挙動・性能は変わらない
+
+    Scenario: 再入検出の仕掛けは production ビルドに影響しない
+      Given production ビルドである
+      When session runtime lock の取得・解放が行われる
+      Then 再入検出のための挙動・性能上のオーバーヘッドは発生しない
+      And lock の排他・prune の振る舞いは従来どおりである
+
+  Rule: 外部から観測可能な振る舞いは変わらない
+
+    Scenario: UI/CLI から見た session の振る舞いは不変
+      Given 本変更の適用前後
+      When 通常の agent session 操作（turn 開始・完了・queue 処理等）が行われる
+      Then UI/CLI から観測可能な振る舞いに差異は無い
+
+## Open Questions
+
+なし

--- a/docs/specs/issues-1411/design.md
+++ b/docs/specs/issues-1411/design.md
@@ -1,0 +1,181 @@
+# Design
+
+関連: #1411（milestone 84「Agentチャット安定化」／ Phase 0 ／ L10）
+
+正本参照:
+- 要求: `docs/specs/issues-1411/requirements.md`
+- 振る舞い: `docs/specs/issues-1411/behavior.md`
+- 問題インベントリ: `specs/milestone-84-agent-chat-stabilization/agent-chat-instability-audit.md` の **ST-5**
+- ライフサイクル理想形: `specs/milestone-84-agent-chat-stabilization/agent-chat-ideal-lifecycle.md` の **I13**
+
+## 概要
+
+session runtime lock 機構（`SessionRuntimeLocks` / `acquire_session_runtime_lock` / `acquire_session_lock` / `SessionRuntimeLockGuard`）の構造的安定化を行う。backend（Rust）内部完結であり、外部から観測可能な UI/CLI の振る舞いは追加・変更しない。
+
+本変更は次の 4 点で構成する。
+
+1. **lock 保持規約の rustdoc 明文化**（R1）。
+2. **既存 lock 保持経路の棚卸しと是正／列挙**（R2）。
+3. **prune のランタイム非依存化**（R3・R4）: `Drop` の `Handle::try_current()` 依存を廃止し、解放時に prune 候補を同期的な pending 集合へ登録、次回 `acquire_session_runtime_lock` で未参照エントリを掃除する。
+4. **テストビルド限定の lock 再入検出**（R5）: `#[cfg(test)]` 限定の task owner keyed 共有 registry + `assert!`。
+
+既存の per-session 排他モデルは維持する。runtime 状態機械そのものの分解（ST-3 / #1412）は非スコープ。
+
+## 変更対象
+
+- `src-tauri/src/usecase/agent_session/runtime/usecase.rs`
+  - 型定義 `SessionRuntimeLock` / `SessionRuntimeLocks`（`:76-77`）
+  - `acquire_session_runtime_lock`（`:2153`）
+  - `SessionRuntimeLockGuard` と `Drop` 実装（`:2147-2196`）
+  - `acquire_session_lock` の rustdoc（`:1091`）
+  - `RuntimeContext.session_locks` フィールド（`:201`）と生成箇所
+  - lock 保持経路の呼び出し箇所（棚卸し対象: `:279` / `:284` / `:438` / `:484` / `:1826` / `:1880` / `:2087` / `:2259`）
+- `src-tauri/src/adaptor/gateway/workflow/runtime_session.rs`
+  - `start_fanout_child_sessions` の単一 task による複数 session guard 同時保持を、child ごとの reservation task に分離する
+  - 全 child の activation を予約してから snapshot / tab を公開し、外部操作に対する既存の起動順序を維持する
+  - reservation task は取得した guard を親 activation future へ順に引き渡し、`start_turn_locked` は親 future が実行する。これにより cancel decision 待ちでは child start も親とともに静止し、rollback 時は同じ future を再開できる
+  - reservation task の abort handle と完了通知を追跡し、commit 時に全 task の終了を確認してから terminal cleanup へ進む
+- `src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs`
+  - contract repair turn の開始結果取得直後に session guard を解放し、開始失敗時の永続化・workflow state broadcast を lock 外へ移す
+  - fan-out activation の cancel cleanup を activation lock の解放前に完了する
+
+frontend への変更は無い（R7、rust-first-logic）。
+
+## アーキテクチャと責務分割
+
+lock 機構は usecase 層の内部詳細であり、レイヤー境界は変えない。責務は次のとおり分割する。
+
+- **`SessionRuntimeLocks`（データ構造）**: per-session の `Arc<Mutex<()>>` を保持する map の source of truth。加えて、`Drop` から同期的に登録される prune 候補（pending 集合）を保持する。
+- **`acquire_session_runtime_lock`（取得）**: (1) テストビルドでは owner を RAII 予約、(2) pending 集合を掃除（未参照エントリ除去）、(3) 対象 session のエントリを取得または生成、(4) per-session lock を取得、(5) `SessionRuntimeLockGuard` へ owner 予約を移して返す。
+- **`SessionRuntimeLockGuard`（解放）**: `Drop` で per-session guard を落とし、自 session_id を pending 集合へ**同期的に**登録するだけ。tokio runtime handle には依存しない。実際の map からの除去は次回 `acquire` に委譲する。テストビルドでは内包する RAII owner 予約の `Drop` が共有 registry から owner を除去する。
+- **再入検出（テストビルド限定）**: process 共有の「owner → 予約中または保持中の session」registry。owner は Tokio task 内では `tokio::task::Id`、task 外では thread ID とする。per-session lock の await 前に RAII 予約を登録し、同じ owner の要素があれば規約違反として `assert!` で失敗させる。future の cancel / panic 時は RAII の `Drop` で予約を除去し、取得成功時は予約を guard へ移す。task が await 後に別 worker thread へ移動しても task ID は不変であり、Drop も取得 worker に依存せず同じ要素を除去できる。fan-out reservation task から親 future へ guard を引き渡す場合は registry の owner も受取側へ移し、受取側の再入を引き続き検出する。別 task の正当な待機は再入に数えない。production ビルドには一切コンパイルされない。
+- **fan-out activation task 所有**: 各 child reservation task は自身の session lock だけを取得し、開始指示を受けると guard を親 activation future へ返して終了する。親 future が guard と `start_turn_locked` future を所有するため、cancel acknowledgment から decision まで parent を poll しなければ activation tree 全体が静止し、rollback は同じ future を継続できる。共有 tracker は各 reservation task の `AbortHandle` と Drop ベースの完了通知を保持し、cancel commit 時は activation future を drop して全 handle を abort した後、全完了通知を待って activation lock を解放する。abort terminal cleanup はこの activation lock 取得後に行う。
+
+## データモデルまたは型
+
+現状:
+
+```rust
+type SessionRuntimeLock = Arc<Mutex<()>>;                              // tokio::sync::Mutex
+type SessionRuntimeLocks = Arc<Mutex<HashMap<String, SessionRuntimeLock>>>;
+```
+
+変更後（pending 集合を同居させる構造体へ）:
+
+```rust
+type SessionRuntimeLock = Arc<Mutex<()>>; // tokio::sync::Mutex（従来どおり）
+
+struct SessionRuntimeLockRegistry {
+    /// 各 session の排他 lock 本体。取得・生成・除去は async 文脈で行う。
+    map: Mutex<HashMap<String, SessionRuntimeLock>>, // tokio::sync::Mutex
+    /// Drop 時に同期登録される prune 候補。次回 acquire で掃除する。
+    /// std::sync::Mutex なので Drop（非 async / runtime 無し）から触れる。
+    pending_prune: std::sync::Mutex<HashSet<String>>,
+}
+
+type SessionRuntimeLocks = Arc<SessionRuntimeLockRegistry>;
+```
+
+`SessionRuntimeLockGuard` は production では現状の 3 フィールド（`session_id` / `guard: Option<OwnedMutexGuard<()>>` / `locks: SessionRuntimeLocks`）を維持する。`locks` の型は上記 `SessionRuntimeLocks`（`Arc<SessionRuntimeLockRegistry>`）に置き換わる。テストビルドだけ、取得前に registry entry を所有する `TestSessionRuntimeLockOwnerReservation` を持つ。
+
+テストビルド限定の再入検出用共有 registry:
+
+```rust
+#[cfg(test)]
+enum TestSessionRuntimeLockOwner {
+    Task(tokio::task::Id),
+    Thread(std::thread::ThreadId),
+}
+
+static HELD_SESSION_LOCKS: OnceLock<
+    std::sync::Mutex<HashMap<TestSessionRuntimeLockOwner, String>>
+>;
+```
+
+### pending 集合方式を採る理由（仮定 A2 の具体化）
+
+`Drop` は非 async かつ tokio runtime handle を前提にできない。`map`（tokio `Mutex`）を `Drop` 内で確実に掃除するには async lock か `try_lock` が要り、いずれも「runtime 有無」や「競合有無」に依存して skip し得る。そこで **除去処理そのものを次回 `acquire`（必ず async 文脈）へ委譲**し、`Drop` は `std::sync::Mutex<HashSet<String>>` への登録だけを同期実行する。これにより「runtime の有無に関わらず、解放済み未参照エントリが次回 acquire までに必ず掃除される」（R4／behavior「prune はランタイムハンドルの有無に依存しない」）を満たす。
+
+## 処理フロー
+
+### acquire（`acquire_session_runtime_lock`）
+
+1. **（テストビルドのみ）owner 予約と再入検出**: `tokio::task::try_id()` で取得フローを識別し、per-session lock の await 前に RAII 予約を共有 `HELD_SESSION_LOCKS` へ登録する。同じ owner が既に登録済みなら `assert!` で失敗させ、同一 owner の acquire future が並行 poll される場合も test profile や worker 移動に依存せず検出する。別 task は許可し、cancel / panic 時は RAII の `Drop` で予約を除去する。
+2. **pending 掃除**: `map` を async lock。`pending_prune`（std mutex）を lock して drain したうえで、各候補 id について `map.get(id)` が `Arc::strong_count == 1` なら `map.remove(id)`。保持中（strong_count > 1）や、掃除までに再取得された id は残す。
+   - 掃除は「対象 session に限らず、pending に溜まった全 id」を対象にする（多数 session 繰り返しでも収束させるため）。
+3. **エントリ取得**: `map.entry(session_id).or_insert_with(|| Arc::new(Mutex::new(()))).clone()`。
+4. `map` の async guard を drop（`clone` 済みの `Arc` のみ保持）。
+5. `lock.lock_owned().await` で per-session 排他を取得。
+6. **（テストビルドのみ）** 取得前の RAII owner 予約を `SessionRuntimeLockGuard` へ移す。
+7. `SessionRuntimeLockGuard` を返す。
+
+pending 掃除を acquire 冒頭（per-session lock 取得前）に置くことで、`map` の async lock 保持は最小範囲（掃除 + entry 取得）に留まり、per-session lock の待機（`lock_owned().await`）中は map lock を握らない。
+
+### 解放（`SessionRuntimeLockGuard::Drop`）
+
+1. `self.guard.take()` で `OwnedMutexGuard<()>` を drop（per-session 排他を解放し、この guard が握っていた `Arc` 参照を落とす）。
+2. `self.locks.pending_prune`（std mutex）を lock し、`self.session_id` を insert。`Handle::try_current()` / `spawn` は使わない。
+3. **（テストビルドのみ）** `HELD_SESSION_LOCKS` から取得時に保存した `(owner, session_id)` と一致する要素を除去する。
+
+手順 1 を手順 2 より先に行うことで、次回 acquire 時に他の保持者がいなければ `strong_count == 1`（map の 1 本のみ）となり除去対象になる。
+
+### 既存経路の棚卸し（R2）
+
+`acquire_session_lock` / `acquire_session_runtime_lock` を呼ぶ全経路（`:279` `:284` `:438` `:484` `:1826` `:1880` `:2087` `:2259`）を規約 (a)(b)(c) に照らして確認する。実装時に確定するが、コードリーディング時点の予備観察は次のとおり。
+
+- **(a) 別 session lock を保持中に取得**: `usecase.rs` 内の各経路は単一 session に対する guard を取り、その保持スコープ内で別 session の `acquire_*` を呼ばない（`:2259` の再取得は post-actions 実行後、先行 guard の外）。公開 `acquire_session_lock` の呼び出し元まで広げた棚卸しでは、`start_fanout_child_sessions` が単一 task で全 child session guard を取得していた。各 child 専用の reservation task が自身の guard だけを取得し、予約完了を親 task へ通知して start 指示を待ち、指示後は guard を親 activation future へ引き渡す構造へ是正する。親 future は全予約完了後に snapshot / tab を公開し、child を従来順に start するため、先頭 child の start 待機中も後続 child の外部操作は workflow activation を追い越さない。
+- **(b) backend I/O await の最小化**: lock 保持中に `ensure_runtime`（process spawn）や session store I/O、runtime への stdin write を await する経路が存在する（例: `start_session:438`, `send_message:279/284`）。これらは per-session 直列化のために保持が必要な範囲であり、別 session を巻き込まないため deadlock 要因ではない。過剰な await 範囲があれば縮小するが、**排他の正しさを崩す縮小はしない**。過大な是正が必要な箇所は列挙し分割判断する。
+- **(c) emit はロック外**: `emit_session_state_change` 等の通知が guard 保持中に呼ばれる箇所を確認する。lock 外へ移せるもの（通知が排他状態に依存しないもの）は移す。移動が状態順序を壊す恐れがある箇所は、違反一覧として列挙し分割判断する。
+
+棚卸し結果（是正 or「違反なし」or 列挙 + 分割判断）は本 ISSUE / requirements の棚卸し欄に追記する。
+
+## エラー処理
+
+- `pending_prune`（std `Mutex`）の lock は poisoning し得る。`lock().unwrap_or_else(|e| e.into_inner())` で poison を無視して継続する（保持データは単なる `HashSet<String>` で、途中 panic による不整合が排他の正しさに波及しない）。
+- prune の除去判定は `Arc::strong_count == 1` を唯一の基準にする。判定に失敗しても（該当 id が既に無い等）単に skip し、エラーにしない。prune は best-effort だが、pending に積まれた id は除去されるまで残り続けるため「無期限蓄積しない」保証は維持される。
+- 再入検出の `assert!` は `#[cfg(test)]` ブロック内にあり production ではコンパイルされない。検出発火は debug/release の両 test profile でテスト失敗として表面化し、runtime のエラー型（`AgentRuntimeError`）には載せない。
+
+## テスト方針
+
+`usecase.rs` 内 `#[cfg(test)] mod tests` と workflow runtime の既存テスト module に Rust テストを追加する（配置規約に従う）。再入・Drop は multi-thread runtime でも検証する。
+
+- **prune のランタイム非依存化（R3・behavior「prune はランタイムハンドルの有無に依存しない」）**
+  - guard を drop 後、次回 `acquire` で未参照エントリが map から除去されることを確認。
+  - guard 保持中は別 session の acquire を挟んでも保持中 session のエントリが残ることを確認。
+  - 多数 session の取得・解放を繰り返し、後続 acquire ごとに map サイズが保持中 lock 数相当に収束することを確認（無限蓄積しない）。
+- **prune の同期性**: `Handle::try_current()` に依存しない（Drop が spawn を要求しない）ことを、drop 直後に別スレッド/同一 runtime で acquire して除去される形で確認。
+- **再入検出（R5・behavior 該当 Rule）**
+  - session A の guard 保持中に session B を acquire → `assert!` 発火（`#[should_panic]`、debug/release test profile 共通）。
+  - multi-thread runtime の task でも同じ再入が検出されることを確認。
+  - guard を取得 worker とは別 thread で Drop しても owner が除去され、その後の逐次 acquire が成功することを確認。
+  - guard を別 task へ引き渡して owner を移した後、受取側での再入が検出されることを確認。
+  - 未保持状態からの acquire は検出されない・正常完了。
+  - A を取得・解放後に B を逐次取得 → 検出されない・正常完了。
+- **fan-out cancel lifecycle**: 先頭 child の backend start を停止して explicit stop し、stop が backend 待機の解除なしに完了すること、全 child lock が回収されること、待機解除後も後続 start が発生しないことを確認する。abort は cancel acknowledgment 後かつ durable decision 前に backend 待機を解除しても child start が進まず、commit 後の terminal cleanup が全 reservation task の終了確認後に行われ、live runtime が残らないことを確認する。
+- **排他の維持（behavior「同一 session は直列化 / 異なる session は独立」）**
+  - 既存の排他テストがあれば維持。無ければ、同一 session の二重 acquire が直列化され、異なる session は独立取得できることを確認。
+- **production 非影響（R5・behavior「production ビルドの挙動・性能は変わらない」）**
+  - 再入検出コードが `#[cfg(test)]` で隔離され、production ビルドに含まれないことをコード構造で担保（レビュー観点）。ランタイム挙動・排他・prune はビルド構成に依らず同一。
+
+CI 同等の `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`（`src-tauri/`）で AC4 を満たす。
+
+## リスクと代替案
+
+- **R-1: テスト専用共有 registry の残留**。panic や異なる worker での Drop でも owner を確実に除去する必要がある。
+  - 緩和: owner を guard 自体に保存し、Drop は current worker を再計算せず保存済み owner を共有 registry から除去する。multi-thread runtime と別 thread Drop のテストで検証する。production/dev には `#[cfg(test)]` によりコンパイルされない。
+- **R-2: pending 集合の遅延掃除**。除去は次回 acquire 時のため、acquire が全く起きない期間は解放済みエントリが pending に残る。これは「無期限蓄積」ではなく「次回 acquire まで」の有界遅延であり、要求（R4）を満たす。定期掃除タスクは非スコープ。
+  - 代替案: `Drop` 内で tokio `Mutex::try_lock()` を試し成功時は即時除去、失敗時のみ pending 登録するハイブリッド。即時性は上がるが「runtime 有無に非依存」を満たすうえで必須ではなく、経路が二重化して複雑になるため採らない。次回 acquire 委譲に一本化する。
+- **R-3: `SessionRuntimeLocks` の型変更（`Arc<Mutex<HashMap>>` → `Arc<struct>`）**が `RuntimeContext` 生成箇所や `Arc::clone` 箇所へ波及する。影響は同一ファイル内に閉じる見込み。コンパイラで網羅的に洗い出せる。
+- **R-4: 棚卸しで大きな違反が見つかった場合**のスコープ膨張。requirements の分割判断に従い、局所的な (a) 違反は本変更で是正し、状態機械や post-action 境界の変更が必要な (b)(c) は違反一覧（ファイル・関数・違反種別）を列挙して分割 ISSUE 化する。
+
+## 仮定
+
+- 仮定 D1: pending 掃除は `std::sync::Mutex<HashSet<String>>` を `SessionRuntimeLockRegistry` に同居させ、`Drop` は登録のみ・`acquire` が掃除を担う（requirements 仮定 A2 の「次回 acquire で掃除」案を採用）。
+- 仮定 D2: 再入検出は `#[cfg(test)]` 限定の task owner keyed 共有 registry と `assert!` で行い、検出粒度は「同一 task が lock を 1 つでも保持したまま acquire する」= 任意 session 保持中の同一実行フロー再入（同一/別 session を包含）とする。これは behavior 仮定 3 の最低要件「別 session の lock を保持したまま acquire」を包含し、別 taskの正当な待機を妨げず、test profile や worker 移動に依存しない。
+- 仮定 D3: 再入検出と guard Drop は current-thread と multi-thread の双方で検証する。
+- 仮定 D4: 実装時の棚卸しで `start_fanout_child_sessions` に単一 task による明確な (a) 別 session lock 同時保持を確認したため、child ごとの reservation task に分離する。全 activation を公開前に予約し、guard を親 activation future へ順に引き渡して child の start 順序と cancel/rollback の所有境界を維持する。(b)(c) の分割対象は requirements の棚卸し結果へ列挙する（requirements 仮定 A4）。
+- 仮定 D5: 外部（UI/CLI）から観測可能な振る舞い変更は無い（requirements 仮定 A5・behavior 仮定 5）。
+
+## Open Questions
+
+なし

--- a/docs/specs/issues-1411/requirements.md
+++ b/docs/specs/issues-1411/requirements.md
@@ -1,0 +1,106 @@
+# Requirements
+
+関連: #1411（milestone 84「Agentチャット安定化」／ Phase 0 ／ L10）
+
+正本参照:
+- 問題インベントリ: `specs/milestone-84-agent-chat-stabilization/agent-chat-instability-audit.md` の **ST-5**（session lock の二段取得と prune skip）
+- ライフサイクル理想形: `specs/milestone-84-agent-chat-stabilization/agent-chat-ideal-lifecycle.md` の **I13**（排他とロックの規約）
+
+## Type
+
+構造的安定化（backend／Rust 内部）。session runtime lock の保持規約を明文化し、既存経路の是正、prune の確実化、テストビルドでの再入検出を行う。外部から観測可能な UI/CLI の振る舞いは追加しない。
+
+## 背景と目的
+
+Agent session の runtime 処理は、session ごとの排他を `acquire_session_runtime_lock`（`src-tauri/src/usecase/agent_session/runtime/usecase.rs:2153`）で行う。この実装には次の構造的問題がある（ST-5、重大度 medium）。
+
+1. **二段ロックの規約未整備**: locks map の `Mutex<HashMap<..>>`（`SessionRuntimeLocks`）を取得して per-session の `Arc<Mutex<()>>` を取り出し、その `lock_owned()` を取る二段構造になっている。lock 保持中に許される await の範囲（別 session の lock 取得可否、backend I/O の await 範囲、emit のタイミング）が文書化も検査もされておらず、将来 lock 保持中に別 session の操作を await する経路が追加されると deadlock し得る温床になっている（現時点で deadlock の実績確認は無し）。
+
+2. **prune skip による lock エントリ蓄積**: `SessionRuntimeLockGuard` の `Drop` 実装が、解放時のエントリ掃除を `tokio::runtime::Handle::try_current()` に依存して `handle.spawn(...)` で行う（`usecase.rs:2172-2196`）。runtime handle を取得できない文脈（テスト・非 tokio スレッド上の Drop 等）では prune を skip し、`session_locks` HashMap にエントリが蓄積し得る。
+
+本変更の目的は、I13「session runtime lock の保持中に、別 session の lock・長時間 await（backend I/O）を行わない。lock の取得順序と保持範囲を規約として明文化し、prune はランタイムハンドル取得に依存しない方式にする」を満たすことである。これにより「チャットが応答しなくなる」系の将来 deadlock を作り込みにくくし、lock エントリの無限蓄積を無くす。
+
+## スコープ
+
+対象は `src-tauri/src/usecase/agent_session/runtime/usecase.rs` の session runtime lock 機構（`SessionRuntimeLocks` / `SessionRuntimeLock` / `acquire_session_runtime_lock` / `SessionRuntimeLockGuard`）と、その保持中に処理を行う既存呼び出し経路である。
+
+1. **lock 規約の明文化（rustdoc）**: `acquire_session_runtime_lock`（および公開 API の `acquire_session_lock`）に、lock 保持中の規約を rustdoc として記述する。少なくとも次を明記する。
+   - (a) lock 保持中に別 session の runtime lock を取得しない（取得順序・再入の禁止）。
+   - (b) backend I/O（backend への stdin write、process spawn 等）の await は最小範囲に留める。
+   - (c) UI/event への emit（`emit_session_state_change` 等の通知）は lock 外で行う。
+
+2. **既存違反の是正または列挙**: lock を保持する既存経路（`usecase.rs` 内の `acquire_session_lock` / `acquire_session_runtime_lock` 呼び出し箇所。現状 `279` / `284` / `438` / `484` / `1826` / `1880` / `2087` / `2259` 付近）を棚卸しし、上記規約 (a)〜(c) の違反を是正する。是正範囲が本 ISSUE のスコープとして過大になる場合は、違反箇所の一覧（ファイル・行・違反種別）を本 ISSUE に追記し、分割 ISSUE として切り出す判断を行う。
+
+3. **prune の確実化（ランタイム非依存化）**: `SessionRuntimeLockGuard` の `Drop` における `Handle::try_current()` 依存を廃止する。解放時に prune 候補を（同期的に取得可能な）キュー等へ登録し、次回 `acquire_session_runtime_lock` 時に未参照（`Arc::strong_count == 1` 相当）のエントリを掃除する方式へ変更する。これにより tokio runtime の有無に関わらず、lock エントリが `session_locks` に無期限蓄積しない。
+
+4. **テストビルドでの再入検出**: lock を保持したまま同一実行フローで別の（または同一 session の）runtime lock を取得する「再入」を、テストビルド限定で検出する仕掛け（task owner keyed な保持 registry + `assert!` 等）を入れる。production ビルドの挙動・性能には影響を与えない。
+
+5. **テスト**: prune がランタイム非依存で確実に行われること（エントリが蓄積しないこと）と、再入検出が働くことを Rust のユニットテストで検証する。
+
+## 非スコープ
+
+- runtime 状態機械そのものの module 分解・大規模リファクタ（ST-3 / L11 #1412 の対象）。本変更は lock 機構の規約化・prune 是正・再入検出に限定する。
+- lock 機構を跨いだ排他モデルの再設計（別 session 間で共有する新たなロック導入等）。既存の per-session 排他モデルは維持する。
+- `MessagePart` 二重定義など ST-6 以降の別問題。
+- frontend への変更。本変更は backend 内部完結とする（rust-first-logic に従う）。
+- lock 保持中の await 範囲を静的解析で恒久的に強制する仕組み（本変更は rustdoc 規約 + テストビルド限定の再入検出まで）。
+
+## 要求事項
+
+- R1: `acquire_session_runtime_lock` / `acquire_session_lock` に、lock 保持中の規約 (a) 別 session lock 取得禁止、(b) backend I/O await 最小化、(c) emit はロック外、を rustdoc で明記する。
+- R2: lock を保持する既存経路を棚卸しし、R1 の規約違反を是正する。是正が過大な場合は違反一覧を ISSUE に追記し分割判断する。
+- R3: `SessionRuntimeLockGuard` の `Drop` から `Handle::try_current()` 依存を除去し、次回 acquire 時に未参照エントリを掃除する方式へ変更する。prune を skip する経路を無くす。
+- R4: prune 変更後、`session_locks` HashMap にエントリが無期限蓄積しない（解放済み session の未参照エントリは次回 acquire で除去される）。
+- R5: テストビルド限定で lock 再入を検出する仕掛け（task owner keyed 共有 registry + `assert!` 等）を導入する。production ビルドの挙動・性能を変えない。
+- R6: R3・R4・R5 を検証する Rust ユニットテストを該当 module に追加する。
+- R7: 本変更は backend（Rust）内で完結し、frontend の変更を伴わない。
+
+## 実装時の lock 保持経路棚卸し
+
+- 規約 (a) について、`src-tauri/src/adaptor/gateway/workflow/runtime_session.rs` の `start_fanout_child_sessions` が、単一 task で fan-out の全 child session lock を先に取得して同時保持していた。child ごとの reservation task が自身の lock だけを取得し、全 child の予約後に snapshot / tab を公開して、開始対象の guard を親 activation future へ順に引き渡す構造へ変更した。`start_turn_locked` は親 future 自身が実行するため、cancel acknowledgment 後の decision 待ちでは child start も poll されず静止し、rollback 時は同じ future を安全に再開できる。commit 時は親 future の drop と共有 tracker による全 reservation task の終了確認を終えてから terminal cleanup を行う。これにより単一実行フローでの別 session lock 同時保持を解消しつつ、公開後の外部操作が workflow activation を追い越さない既存の排他順序を維持する。その他の `acquire_session_lock` / `acquire_session_runtime_lock` 呼び出し元には、lock 保持中の追加 acquire は無い。
+- 規約 (b) について、lock 保持中に残す backend / workflow notifier の await は次のとおりである。行番号は本 ISSUE 実装時点の行であり、各行の「guard 取得・保持範囲」と実際の await を対応付けている。いずれも同一 session の状態遷移順を守る範囲に限られ、別 session lock は取得しない。これらをさらに lock 外へ分離するには runtime 状態機械と post-action 境界の変更が必要なため、本 ISSUE では変更せず、全件を ST-3 / #1412 と併せた分割対象とする。
+
+  | 経路 | guard 取得・保持範囲 | lock 保持中の await（違反種別 (b)） |
+  |---|---|---|
+  | `send_message` | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:313-318` で取得し、`:463` または早期 return まで保持 | active turn への backend steer `:334-353`、および `start_turn_for_session` の await `:438-453`（配下の process open / turn start は `:1504-1576`） |
+  | `start_session` | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:472-498` | `ensure_runtime` `:497` から process open `:2073-2091` |
+  | `respond_permission` | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:518-656` | backend permission response `:531-534`、stall-clear workflow notifier `:587-590`、streaming delta retry `:617-627` |
+  | `start_turn_locked`（workflow 共通） | API 本体は `src-tauri/src/usecase/agent_session/runtime/usecase.rs:1146-1215`。production の guard 呼び出し元は `src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs:220-233`、`src-tauri/src/adaptor/gateway/workflow/runtime_session.rs:623-628,686-713`、`src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs:3644-3654` | `start_turn_for_session` `src-tauri/src/usecase/agent_session/runtime/usecase.rs:1199-1215`（配下の process open / turn start は `:1504-1576`） |
+  | stale watchdog | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:1930-2011`（`:1876-1923` の先行 guard 範囲には backend / notifier await 無し） | stall-observed workflow notifier `:2005-2009`。observe/clear の逆転防止のため保持中に直列化する既存契約がある |
+  | event pump | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:2137-2140` | `apply_runtime_event` `:2139`（本体 `:2500-2745`）と、その配下の stall-clear workflow notifier `:2665-2669,2864-2868`、stream flush `:2879-2880`、turn completion `:2672-2698,3281-3444` |
+  | queue drain | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:2388-2391` | `start_next_queued_turn` `:2390`（本体 `:3447-3734`）配下の process open `:3502-3533` と backend turn start `:3635-3654` |
+  | idle runtime close | `src-tauri/src/adaptor/gateway/workflow/node_lifecycle_adapters.rs:142-149,229-236` | idle 判定 `:32-52` と backend close `src-tauri/src/usecase/agent_session/runtime/usecase.rs:873-880` |
+
+- 規約 (c) について、lock 保持中に残す notifier / state-change emit は次のとおりである。usecase 内の経路はいずれも上表の guard 範囲内であり、単純に guard 外へ移すと turn 開始・完了、stall observe/clear、queue drain の通知順序を崩すため、post-action の拡張を伴う ST-3 / #1412 の分割対象とする。fan-out activation の公開経路は reservation task が guard を保持する間の emit として同じく列挙する。
+
+  | guard 保持経路 | lock 保持中の notifier / emit（違反種別 (c)） |
+  |---|---|
+  | `send_message` / `start_turn_locked` → `start_turn_for_session` | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:428-430,1188-1190` の turn-prepared notifier、`:1440-1445` の context-carry notifier、`:1539-1555,1584-1600,1633-1649` の開始失敗・開始成功 state-change emit |
+  | `respond_permission` | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:587-590` の stall-clear workflow notifier、`:617-627` の streaming-delta notifier、`:638-654` の state-change emit |
+  | stale watchdog | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:1997-2009` の stall-observed notifier / workflow notifier |
+  | event pump → `apply_runtime_event` | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:2166-2193,2520,2550-2555,2569-2574,2604-2620,2633-2649,2664-2669,2722-2738,2864-2868,2962-2968,3427-3443` の runtime event、context-carry、permission / command / token、stall-clear、streaming-delta、turn-complete state-change の各 notifier / emit |
+  | queue drain → `start_next_queued_turn` | `src-tauri/src/usecase/agent_session/runtime/usecase.rs:3513-3529,3597-3602,3674-3690,3702-3709,3716-3732` の reopen / turn-start state-change、context-carry、pending-message / turn-prepared notifier |
+  | `activate_fanout_child_sessions` → `broadcast_state` | `src-tauri/src/adaptor/gateway/workflow/runtime_session.rs:526-529`。全 child の reservation task が session guard を保持中に workflow state / agent status を emit する（違反種別 (c)） |
+
+  fan-out activation の `broadcast_state` で実害が無い根拠は、(1) emit する親 flow 自身は guard を保持せず、guard は各 reservation task 内で `JoinHandle` の出力として保持されること、(2) `broadcast_state` は session runtime lock を取得せず、deadlock や lock 保持時間延伸の要因にならないこと、(3) reservation を公開より先行させる順序は behavior.md:43-48 の「workflow activation は公開後の外部操作より先に予約」を満たすために意図されていることである。実 guard 保持と公開順を分離する opaque reservation 化は runtime 状態機械側の責務移動を伴うため、#1412/ST-3 の分割対象とし、本 ISSUE では既知経路の列挙に留める。
+
+  `src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs:3644-3655` の contract repair turn 開始失敗経路については、`start_turn_locked` の結果取得直後に guard を解放してから失敗確定・永続化・workflow state broadcast へ進むよう是正済みである。ただし、上表の `start_turn_locked` 共通処理内にある (b)(c) はこの呼び出し元にも適用され、分割対象として残る。以上で production の `acquire_session_lock` / `acquire_session_runtime_lock` 呼び出し元と、是正を見送る (b)(c) の対象箇所を一対一で確定する。本 ISSUE は lock 機構の runtime 非依存 prune と再入検出、および局所的に分離可能な (a)(c) 違反是正に限定する。
+
+## 受け入れ基準の概要
+
+- AC1（ISSUE 受け入れ基準）: lock 規約が rustdoc に明記され、既存違反が是正 または 列挙されている。
+- AC2（ISSUE 受け入れ基準）: prune skip 経路が無い（エントリが蓄積しない）。
+- AC3（ISSUE 受け入れ基準）: テストビルドで lock 再入が検出される。
+- AC4: `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`（`src-tauri/`）が通る。
+
+## 仮定
+
+- 仮定 A1: spec-id は既存慣習（`docs/specs/issues-<番号>/`）に合わせ `issues-1411` とする。
+- 仮定 A2: 「prune 候補キューへ登録し次回 acquire 時に掃除する」方式は、`Drop` から同期的に触れる共有状態（例: `session_locks` と同じ `Mutex` 配下に持つ pending 集合、または `Drop` 時に `try_lock` で除去し失敗時のみ pending 登録）で実現する。具体データ構造は design.md で確定する。本 requirements では「ランタイム非依存で、解放済み未参照エントリが次回 acquire までに必ず掃除される」ことのみを要求する。
+- 仮定 A3: 再入検出は task owner keyed な共有「現在保持中の session lock 集合（または保持フラグ）」を持ち、`acquire` 時に (a) 既に何らかの session lock を保持している場合を規約違反として、`#[cfg(test)]` 内の `assert!` で test profile や Tokio worker 移動に依存せず検出する。検出粒度（同一 session のみか、任意 session 保持中か）は design.md で確定するが、少なくとも「別 session の lock を保持したまま acquire する」ケースを検出する。
+- 仮定 A4: 既存経路の棚卸しで規約違反が見つかった場合、本 ISSUE のスコープ内で是正できる規模であれば是正し、過大なら列挙して分割する（ISSUE 記載の分割判断に従う）。現時点では deadlock の実績は無く、明確な違反が無ければ「違反なし」を棚卸し結果として記録する。
+- 仮定 A5: 外部から観測可能な UI/CLI の振る舞い変更は無い（内部の排他機構の是正のみ）。
+
+## Open Questions
+
+なし

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
@@ -11,8 +11,8 @@ mod lifecycle_commands;
 mod resume_orchestration;
 
 use activation::{
-    rollback_active_interruption, run_runtime_activation, InterruptionRollback,
-    RuntimeActivationGate,
+    rollback_active_interruption, run_runtime_activation,
+    run_runtime_activation_with_cancel_cleanup, InterruptionRollback, RuntimeActivationGate,
 };
 use command_preparation::{command_execution_input_is_current, CommandExecutionInput};
 
@@ -3650,7 +3650,7 @@ impl WorkflowRuntimeService {
         };
         let permission_mode = PermissionMode::parse_canonical(&session.permission_mode)
             .map_err(|e| WorkflowEngineError::InvalidWorkflow(e.to_string()))?;
-        let _runtime_guard = agent_runtime.acquire_session_lock(session_id).await;
+        let runtime_guard = agent_runtime.acquire_session_lock(session_id).await;
         let start_result = agent_runtime
             .start_turn_locked(
                 session_id,
@@ -3660,6 +3660,7 @@ impl WorkflowRuntimeService {
                 Vec::new(),
             )
             .await;
+        drop(runtime_guard);
         if let Err(err) = start_result {
             let error = WorkflowEngineError::with_agent_runtime_context(
                 "contract output repair turn failed to start",
@@ -6000,7 +6001,10 @@ impl WorkflowRuntimeService {
             return Ok(());
         }
 
-        run_runtime_activation(
+        let fanout_activation_tasks =
+            Arc::new(workflow_runtime_session::FanoutActivationTaskTracker::default());
+        let cancel_fanout_activation_tasks = Arc::clone(&fanout_activation_tasks);
+        run_runtime_activation_with_cancel_cleanup(
             &activation_gate,
             &fanout_start.execution_id,
             "fanout",
@@ -6013,7 +6017,11 @@ impl WorkflowRuntimeService {
                 worktree_path,
                 &child_setups,
                 snapshot,
+                fanout_activation_tasks,
             ),
+            async move {
+                cancel_fanout_activation_tasks.abort_and_wait().await;
+            },
         )
         .await?;
 

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/activation.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/activation.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use std::future::{ready, Future};
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
@@ -159,27 +159,48 @@ pub(super) async fn run_runtime_activation<F, T>(
 where
     F: Future<Output = Result<T, WorkflowEngineError>>,
 {
-    tokio::pin!(future);
+    run_runtime_activation_with_cancel_cleanup(
+        gate,
+        execution_id,
+        activation_kind,
+        future,
+        ready(()),
+    )
+    .await
+}
+
+pub(super) async fn run_runtime_activation_with_cancel_cleanup<F, C, T>(
+    gate: &RuntimeActivationGate,
+    execution_id: &str,
+    activation_kind: &str,
+    future: F,
+    cancel_cleanup: C,
+) -> Result<T, WorkflowEngineError>
+where
+    F: Future<Output = Result<T, WorkflowEngineError>>,
+    C: Future<Output = ()>,
+{
+    let mut future = Box::pin(future);
     loop {
         tokio::select! {
             biased;
             _ = gate.cancelled() => {
                 gate.acknowledge_cancel();
-                match gate.cancel_decision().await {
-                    ACTIVATION_CANCEL_COMMIT => {
-                        return Err(WorkflowEngineError::InvalidState(format!(
+                let error = match gate.cancel_decision().await {
+                    ACTIVATION_CANCEL_COMMIT => WorkflowEngineError::InvalidState(format!(
                             "execution {execution_id} {activation_kind} activation was cancelled"
-                        )));
-                    }
+                        )),
                     ACTIVATION_CANCEL_ROLLBACK => {
                         gate.reset_cancel();
+                        continue;
                     }
-                    decision => {
-                        return Err(WorkflowEngineError::InvalidState(format!(
+                    decision => WorkflowEngineError::InvalidState(format!(
                             "execution {execution_id} {activation_kind} activation received invalid cancellation decision {decision}"
-                        )));
-                    }
-                }
+                        )),
+                };
+                drop(future);
+                cancel_cleanup.await;
+                return Err(error);
             }
             result = &mut future => return result,
         }

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/lifecycle_commands.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/lifecycle_commands.rs
@@ -1,5 +1,26 @@
 use super::*;
 
+enum AbortCommit {
+    Aborted { session_ids: Vec<String> },
+    NotFound,
+    AlreadyTerminal,
+}
+
+fn abort_outcome_to_command_result(
+    outcome: AbortOutcome,
+    execution_id: &str,
+) -> Result<(), WorkflowEngineError> {
+    match outcome {
+        AbortOutcome::Aborted => Ok(()),
+        AbortOutcome::NotFound => Err(WorkflowEngineError::ExecutionNotFound(
+            execution_id.to_string(),
+        )),
+        AbortOutcome::AlreadyTerminal => Err(WorkflowEngineError::InvalidState(format!(
+            "execution {execution_id} is already terminal"
+        ))),
+    }
+}
+
 /// abort / stop / resume の execution ライフサイクル typed command 群。
 impl WorkflowRuntimeService {
     pub(crate) async fn abort_workflow_execution<R: tauri::Runtime>(
@@ -141,21 +162,28 @@ impl WorkflowRuntimeService {
         // execution 全体の Abort: NotFound / AlreadyTerminal は非受理として typed error
         // に射影する（Spec [04] Rule「対象不在 / 既に終了した command は受理されない」）。
         let abort_result = self
-            .abort_workflow_by_execution_id(
+            .commit_abort_workflow_by_execution_id(
                 app,
                 session_store,
-                agent_runtime,
                 execution_id,
                 expected_node_name,
             )
             .await;
         match abort_result {
-            Ok(AbortOutcome::Aborted) => {
+            Ok(AbortCommit::Aborted { session_ids }) => {
                 if activation_was_paused {
                     activation_gate.commit_cancel();
                     activation_guard = Some(activation_gate.lock.lock().await);
                 }
                 let _activation_guard = activation_guard;
+                self.finish_committed_abort(
+                    app,
+                    session_store,
+                    agent_runtime,
+                    execution_id,
+                    &session_ids,
+                )
+                .await;
                 self.execution_store
                     .finish_active_interruption(interruption_reservation)
                     .await
@@ -164,9 +192,9 @@ impl WorkflowRuntimeService {
                             "ExecutionStore abort reservation cleanup failed: {error}"
                         ))
                     })?;
-                Ok(())
+                abort_outcome_to_command_result(AbortOutcome::Aborted, execution_id)
             }
-            Ok(outcome) => {
+            Ok(AbortCommit::NotFound) => {
                 self.execution_store
                     .finish_active_interruption(interruption_reservation)
                     .await
@@ -180,15 +208,23 @@ impl WorkflowRuntimeService {
                 } else {
                     activation_gate.reset_cancel();
                 }
-                match outcome {
-                    AbortOutcome::NotFound => Err(WorkflowEngineError::ExecutionNotFound(
-                        execution_id.to_string(),
-                    )),
-                    AbortOutcome::AlreadyTerminal => Err(WorkflowEngineError::InvalidState(
-                        format!("execution {execution_id} is already terminal"),
-                    )),
-                    AbortOutcome::Aborted => unreachable!(),
+                abort_outcome_to_command_result(AbortOutcome::NotFound, execution_id)
+            }
+            Ok(AbortCommit::AlreadyTerminal) => {
+                self.execution_store
+                    .finish_active_interruption(interruption_reservation)
+                    .await
+                    .map_err(|error| {
+                        WorkflowEngineError::SessionStore(format!(
+                            "ExecutionStore abort reservation rollback failed: {error}"
+                        ))
+                    })?;
+                if activation_was_paused {
+                    activation_gate.rollback_cancel();
+                } else {
+                    activation_gate.reset_cancel();
                 }
+                abort_outcome_to_command_result(AbortOutcome::AlreadyTerminal, execution_id)
             }
             Err(error) => {
                 let reservation_result = self
@@ -322,6 +358,7 @@ impl WorkflowRuntimeService {
     ///
     /// 外部から直接呼ばれることはなく、`abort_workflow_execution*` runtime primitive 経路のみが
     /// 利用する（Spec [04]: 内部呼び出し元も engine の private method を直接叩かない）。
+    #[cfg(test)]
     pub(super) async fn abort_workflow_by_execution_id<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
@@ -330,17 +367,57 @@ impl WorkflowRuntimeService {
         execution_id: &str,
         expected_node_name: Option<&str>,
     ) -> Result<AbortOutcome, WorkflowEngineError> {
+        let commit = self
+            .commit_abort_workflow_by_execution_id(
+                app,
+                session_store,
+                execution_id,
+                expected_node_name,
+            )
+            .await?;
+        match commit {
+            AbortCommit::Aborted { session_ids } => {
+                self.finish_committed_abort(
+                    app,
+                    session_store,
+                    agent_runtime,
+                    execution_id,
+                    &session_ids,
+                )
+                .await;
+                Ok(AbortOutcome::Aborted)
+            }
+            AbortCommit::NotFound => Ok(AbortOutcome::NotFound),
+            AbortCommit::AlreadyTerminal => Ok(AbortOutcome::AlreadyTerminal),
+        }
+    }
+
+    async fn commit_abort_workflow_by_execution_id<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        execution_id: &str,
+        expected_node_name: Option<&str>,
+    ) -> Result<AbortCommit, WorkflowEngineError> {
         // 1. 対象 execution の存在 + active 性を判定。
         //    非受理経路 (NotFound / AlreadyTerminal) ではどんな外部副作用も発生させない。
         let lookup = self.abort_target_lookup(execution_id).await;
         let (current_node_session_id, fanout_session_ids) = match lookup {
-            AbortTargetLookup::NotFound => return Ok(AbortOutcome::NotFound),
-            AbortTargetLookup::AlreadyTerminal => return Ok(AbortOutcome::AlreadyTerminal),
+            AbortTargetLookup::NotFound => {
+                return Ok(AbortCommit::NotFound);
+            }
+            AbortTargetLookup::AlreadyTerminal => {
+                return Ok(AbortCommit::AlreadyTerminal);
+            }
             AbortTargetLookup::Active {
                 current_node_session_id,
                 fanout_session_ids,
             } => (current_node_session_id, fanout_session_ids),
         };
+        let mut session_ids = current_node_session_id.into_iter().collect::<Vec<_>>();
+        session_ids.extend(fanout_session_ids.into_iter().flatten());
+        session_ids.sort();
+        session_ids.dedup();
         #[cfg(test)]
         self.wait_abort_after_lookup_for_test().await;
 
@@ -357,13 +434,13 @@ impl WorkflowRuntimeService {
             let Some(exec) = execs.get_mut(execution_id) else {
                 drop(execs);
                 return Ok(if self.has_terminal_execution_record(execution_id).await {
-                    AbortOutcome::AlreadyTerminal
+                    AbortCommit::AlreadyTerminal
                 } else {
-                    AbortOutcome::NotFound
+                    AbortCommit::NotFound
                 });
             };
             if !exec.is_active() {
-                return Ok(AbortOutcome::AlreadyTerminal);
+                return Ok(AbortCommit::AlreadyTerminal);
             }
             if let Some(expected_node_name) = expected_node_name {
                 let current_node = exec
@@ -474,18 +551,23 @@ impl WorkflowRuntimeService {
             None,
         );
 
-        // 4. [04] post-commit: interrupt_agent / cleanup / broadcast。
-        //    ExecutionAborted event は append 済み。Execution Store / ChatSession は event 後の
-        //    projection として同期済み、または warn として観測済み。
+        Ok(AbortCommit::Aborted { session_ids })
+    }
+
+    async fn finish_committed_abort<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_store: &Arc<SessionStore>,
+        agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
+        execution_id: &str,
+        session_ids: &[String],
+    ) {
+        // ExecutionAborted is durable before this method is called. Runtime activation must be
+        // quiesced before entering this terminal cleanup so it cannot recreate a closed runtime.
         self.shutdown_active_commands_for_execution(execution_id)
             .await;
-        if let Some(ref node_session_id) = current_node_session_id {
-            workflow_runtime_session::interrupt_agent(agent_runtime, node_session_id).await;
-        }
-        if let Some(ref session_ids) = fanout_session_ids {
-            for sid in session_ids {
-                workflow_runtime_session::interrupt_agent(agent_runtime, sid).await;
-            }
+        for session_id in session_ids {
+            workflow_runtime_session::interrupt_agent(agent_runtime, session_id).await;
         }
         self.finalize_terminal_transition_after_required_append(
             app,
@@ -494,8 +576,6 @@ impl WorkflowRuntimeService {
             execution_id,
         )
         .await;
-
-        Ok(AbortOutcome::Aborted)
     }
 
     /// `abort_workflow_by_execution_id` の post-commit 区間。state は呼出し前に Aborted に

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -8851,6 +8851,373 @@ mod dispatch_boundary_tests {
         assert!(!engine.contains_execution_for_test(&execution_id).await);
     }
 
+    #[derive(Clone, Copy)]
+    enum PausedFanoutActivationWait {
+        StartTurn,
+        StartTurnPrompt,
+    }
+
+    struct PausedFanoutActivation {
+        app: DispatchTestApp,
+        engine: WorkflowRuntimeService,
+        session_store: Arc<SessionStore>,
+        agent_runtime: Arc<AgentSessionRuntimeUsecase>,
+        controller: crate::test_support::TestAgentRuntimeController,
+        execution_id: String,
+        child_session_ids: Vec<String>,
+        start_task: tokio::task::JoinHandle<Result<String, WorkflowEngineError>>,
+        _worktree: TempDir,
+    }
+
+    async fn setup_paused_fanout_activation(
+        wait_for: PausedFanoutActivationWait,
+    ) -> PausedFanoutActivation {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_execution_store_data_dir(data_dir.clone()).await;
+        let session_store = Arc::new(crate::test_support::build_session_store());
+        let (agent_runtime, controller) =
+            crate::test_support::build_agent_runtime_usecase_with_controller(
+                session_store.clone(),
+                data_dir,
+            );
+        controller.pause_start_turn();
+        let worktree = TempDir::new().unwrap();
+        let worktree_path = worktree.path().to_string_lossy().to_string();
+        let workflow = WorkflowDefinitionYaml {
+            name: "paused-fanout-activation".to_string(),
+            description: String::new(),
+            builtin: false,
+            schemas: Default::default(),
+            nodes: vec![
+                make_fanout_node("fanout-review", vec!["review-a", "review-b"]),
+                make_fanout_child("review-a"),
+                make_fanout_child("review-b"),
+            ],
+        };
+
+        let start_engine = engine.clone();
+        let start_app = app.handle().clone();
+        let start_session_store = session_store.clone();
+        let start_agent_runtime = agent_runtime.clone();
+        let start_worktree_path = worktree_path.clone();
+        let start_task = tokio::spawn(async move {
+            start_engine
+                .start_resolved_workflow(
+                    &start_app,
+                    &start_session_store,
+                    &start_agent_runtime,
+                    workflow,
+                    start_worktree_path,
+                    None,
+                    ExecutionOrigin::DesktopUi,
+                    PermissionMode::Edit,
+                )
+                .await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let reached_wait_point = controller.calls().iter().any(|call| match wait_for {
+                    PausedFanoutActivationWait::StartTurn => matches!(
+                        call.kind,
+                        crate::test_support::TestRuntimeCallKind::StartTurn
+                    ),
+                    PausedFanoutActivationWait::StartTurnPrompt => matches!(
+                        call.kind,
+                        crate::test_support::TestRuntimeCallKind::StartTurnPrompt { .. }
+                    ),
+                });
+                if reached_wait_point {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the first fanout child must reach the paused backend");
+
+        let (execution_id, child_session_ids) = {
+            let executions = engine.executions.lock().await;
+            let (execution_id, execution) = find_by_worktree(&executions, &worktree_path)
+                .expect("fanout execution must be visible before child activation completes");
+            let child_session_ids = execution
+                .fanout_runtime
+                .as_ref()
+                .expect("fanout runtime")
+                .children
+                .iter()
+                .map(|child| child.session_id.clone())
+                .collect::<Vec<_>>();
+            (execution_id.clone(), child_session_ids)
+        };
+        assert_eq!(child_session_ids.len(), 2);
+
+        PausedFanoutActivation {
+            app,
+            engine,
+            session_store,
+            agent_runtime,
+            controller,
+            execution_id,
+            child_session_ids,
+            start_task,
+            _worktree: worktree,
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_stop_aborts_stuck_fanout_activation_tasks_before_returning() {
+        let PausedFanoutActivation {
+            app,
+            engine,
+            session_store,
+            agent_runtime,
+            controller,
+            execution_id,
+            child_session_ids,
+            mut start_task,
+            _worktree,
+        } = setup_paused_fanout_activation(PausedFanoutActivationWait::StartTurn).await;
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            engine.stop_workflow_execution(
+                app.handle(),
+                &session_store,
+                &agent_runtime,
+                &execution_id,
+            ),
+        )
+        .await
+        .expect("stop must abort and join stuck fanout child activation tasks")
+        .expect("stop should succeed");
+
+        let started_execution_id =
+            tokio::time::timeout(std::time::Duration::from_secs(2), &mut start_task)
+                .await
+                .expect("workflow start must finish without releasing the backend gate")
+                .expect("workflow start task should join")
+                .expect("workflow start should remain accepted");
+        assert_eq!(started_execution_id, execution_id);
+        for session_id in &child_session_ids {
+            assert!(
+                !agent_runtime.session_runtime_lock_is_held_for_test(session_id),
+                "fanout child session lock must be released before stop returns: {session_id}"
+            );
+        }
+
+        let calls_after_stop = controller.calls();
+        controller.release_start_turn();
+        tokio::task::yield_now().await;
+        assert_eq!(controller.calls(), calls_after_stop);
+        assert_eq!(
+            calls_after_stop
+                .iter()
+                .filter(|call| matches!(
+                    call.kind,
+                    crate::test_support::TestRuntimeCallKind::StartTurnPrompt { .. }
+                ))
+                .count(),
+            1,
+            "the later fanout child must not start after interruption"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_abort_quiesces_fanout_children_before_terminal_cleanup() {
+        let PausedFanoutActivation {
+            app,
+            engine,
+            session_store,
+            agent_runtime,
+            controller,
+            execution_id,
+            child_session_ids,
+            mut start_task,
+            _worktree,
+        } = setup_paused_fanout_activation(PausedFanoutActivationWait::StartTurnPrompt).await;
+
+        let lookup_completed = Arc::new(tokio::sync::Notify::new());
+        let continue_precommit = Arc::new(tokio::sync::Notify::new());
+        engine
+            .pause_abort_after_lookup_for_test(lookup_completed.clone(), continue_precommit.clone())
+            .await;
+        let abort_engine = engine.clone();
+        let abort_app = app.handle().clone();
+        let abort_session_store = session_store.clone();
+        let abort_agent_runtime = agent_runtime.clone();
+        let abort_execution_id = execution_id.clone();
+        let abort_task = tokio::spawn(async move {
+            abort_engine
+                .abort_workflow_execution(
+                    &abort_app,
+                    &abort_session_store,
+                    &abort_agent_runtime,
+                    &abort_execution_id,
+                    None,
+                )
+                .await
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            lookup_completed.notified(),
+        )
+        .await
+        .expect("abort must acknowledge cancellation before pre-commit");
+        let starts_at_acknowledgement = controller
+            .calls()
+            .iter()
+            .filter(|call| {
+                matches!(
+                    call.kind,
+                    crate::test_support::TestRuntimeCallKind::StartTurnPrompt { .. }
+                )
+            })
+            .count();
+        assert_eq!(starts_at_acknowledgement, 1);
+
+        // Completing backend start while abort is deciding must not poll the quiesced parent
+        // activation or allow the later child to start.
+        controller.release_start_turn();
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert_eq!(
+            controller
+                .calls()
+                .iter()
+                .filter(|call| {
+                    matches!(
+                        call.kind,
+                        crate::test_support::TestRuntimeCallKind::StartTurnPrompt { .. }
+                    )
+                })
+                .count(),
+            starts_at_acknowledgement,
+            "cancel acknowledgement must quiesce every fanout child while abort is deciding"
+        );
+
+        continue_precommit.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(2), abort_task)
+            .await
+            .expect("abort must finish after the durable decision")
+            .expect("abort task should join")
+            .expect("abort should succeed");
+        let started_execution_id =
+            tokio::time::timeout(std::time::Duration::from_secs(2), &mut start_task)
+                .await
+                .expect("workflow start must finish after committed cancellation")
+                .expect("workflow start task should join")
+                .expect("workflow start should remain accepted");
+        assert_eq!(started_execution_id, execution_id);
+
+        let calls_after_abort = controller.calls();
+        assert_eq!(
+            calls_after_abort
+                .iter()
+                .filter(|call| {
+                    matches!(
+                        call.kind,
+                        crate::test_support::TestRuntimeCallKind::StartTurnPrompt { .. }
+                    )
+                })
+                .count(),
+            1,
+            "terminal cleanup must not be followed by another fanout child start"
+        );
+        for session_id in &child_session_ids {
+            assert!(
+                !agent_runtime.has_live_runtime(session_id).await,
+                "terminal cleanup must leave no live child runtime: {session_id}"
+            );
+            assert!(
+                !agent_runtime.session_runtime_lock_is_held_for_test(session_id),
+                "terminal cleanup must run after child activation lock release: {session_id}"
+            );
+        }
+        let metadata = engine
+            .execution_store()
+            .get_execution(&execution_id)
+            .await
+            .unwrap();
+        assert_eq!(metadata.status, ExecutionStatus::Aborted);
+        assert!(!engine.contains_execution_for_test(&execution_id).await);
+    }
+
+    #[tokio::test]
+    async fn stop_append_failure_resumes_the_quiesced_fanout_activation() {
+        let PausedFanoutActivation {
+            app,
+            engine,
+            session_store,
+            agent_runtime,
+            controller,
+            execution_id,
+            child_session_ids,
+            mut start_task,
+            _worktree,
+        } = setup_paused_fanout_activation(PausedFanoutActivationWait::StartTurnPrompt).await;
+
+        engine.fail_next_required_event_append_for_test();
+        let stop_error = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            engine.stop_workflow_execution(
+                app.handle(),
+                &session_store,
+                &agent_runtime,
+                &execution_id,
+            ),
+        )
+        .await
+        .expect("failed stop must decide rollback without waiting for backend start")
+        .expect_err("the injected append failure must reject stop");
+        assert!(matches!(stop_error, WorkflowEngineError::SessionStore(_)));
+        assert_eq!(
+            engine
+                .execution_store()
+                .get_execution(&execution_id)
+                .await
+                .unwrap()
+                .status,
+            ExecutionStatus::Running
+        );
+        for session_id in &child_session_ids {
+            assert!(
+                agent_runtime.session_runtime_lock_is_held_for_test(session_id),
+                "rollback must preserve the existing child reservation: {session_id}"
+            );
+        }
+
+        controller.release_start_turn();
+        let started_execution_id =
+            tokio::time::timeout(std::time::Duration::from_secs(2), &mut start_task)
+                .await
+                .expect("rolled-back fanout activation must resume")
+                .expect("workflow start task should join")
+                .expect("workflow start should remain accepted");
+        assert_eq!(started_execution_id, execution_id);
+        for session_id in &child_session_ids {
+            assert_eq!(
+                controller
+                    .call_kinds_for(session_id)
+                    .iter()
+                    .filter(|call| matches!(
+                        call,
+                        crate::test_support::TestRuntimeCallKind::StartTurnPrompt { .. }
+                    ))
+                    .count(),
+                1,
+                "rollback must resume each reserved child exactly once: {session_id}"
+            );
+        }
+
+        engine
+            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn stop_append_failure_resumes_the_paused_session_activation_and_restores_running() {
         let app = make_dispatch_app();
@@ -17932,6 +18299,16 @@ mod dispatch_boundary_tests {
         handles
             .insert_failing_runtime_state_for_test(session_id)
             .await;
+        let lock_states_at_broadcast = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let lock_states_for_listener = Arc::clone(&lock_states_at_broadcast);
+        let handles_for_listener = Arc::clone(&handles);
+        let session_id_for_listener = session_id.to_string();
+        app.listen("workflow-execution-changed", move |_| {
+            lock_states_for_listener.lock().unwrap().push(
+                handles_for_listener
+                    .session_runtime_lock_is_held_for_test(&session_id_for_listener),
+            );
+        });
 
         engine
             .handle_missing_required_output(
@@ -17952,6 +18329,17 @@ mod dispatch_boundary_tests {
             )
             .await
             .unwrap();
+
+        let lock_states_at_broadcast = lock_states_at_broadcast.lock().unwrap();
+        assert!(
+            !lock_states_at_broadcast.is_empty(),
+            "repair start failure must broadcast the terminal workflow state"
+        );
+        assert!(
+            lock_states_at_broadcast.iter().all(|is_held| !is_held),
+            "terminal workflow state must be broadcast after the session runtime lock is released"
+        );
+        drop(lock_states_at_broadcast);
 
         assert!(
             !engine.contains_execution_for_test(&execution_id).await,

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -10394,6 +10394,9 @@ mod dispatch_boundary_tests {
         lgtm: bool,
     ) {
         let children = wait_for_active_fanout_children(engine, execution_id, "review", 2).await;
+        for (_, session_id, _) in &children {
+            wait_for_stub_session_turn_activation(agent_runtime, session_id).await;
+        }
         for (node_name, _, node_execution_id) in &children {
             engine
                 .submit_workflow_output(
@@ -10410,7 +10413,6 @@ mod dispatch_boundary_tests {
                 .unwrap();
         }
         for (node_name, session_id, _) in children {
-            wait_for_stub_session_turn_activation(agent_runtime, &session_id).await;
             engine
                 .on_turn_complete(
                     app.handle(),

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::{
     collections::{BTreeMap, HashMap},
     path::Path,
 };
 
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
 
 use crate::adaptor::gateway::workflow::engine_error::WorkflowEngineError;
 use crate::adaptor::gateway::workflow::execution_registry::find_by_worktree;
@@ -27,6 +27,7 @@ use crate::domain::workflow::{
 };
 use crate::usecase::agent_session::backend_registry::AgentBackendRegistry;
 use crate::usecase::agent_session::context::BranchDiffContextPort;
+use crate::usecase::agent_session::runtime::usecase::SessionRuntimeLockGuard;
 use crate::usecase::agent_session::runtime::AgentSessionRuntimeUsecase;
 use crate::usecase::agent_session::session::{ChatSession, OpenTabRegistry, SessionStore};
 
@@ -529,55 +530,228 @@ pub(crate) async fn activate_fanout_child_sessions<R: tauri::Runtime>(
     worktree_path: &str,
     child_setups: &[FanoutChildSessionSetup],
     snapshot: RuntimeCommitSnapshot,
+    activation_tasks: Arc<FanoutActivationTaskTracker>,
 ) -> Result<(), WorkflowEngineError> {
+    let activations =
+        reserve_fanout_child_sessions(runtime, child_setups, &activation_tasks).await?;
     broadcast_state(app, worktree_path, snapshot).await;
-    start_fanout_child_sessions(runtime, open_tabs, child_setups).await
+    start_fanout_child_sessions(runtime, open_tabs, activations).await
+}
+
+#[derive(Default)]
+pub(crate) struct FanoutActivationTaskTracker {
+    tasks: StdMutex<Vec<FanoutActivationTaskCancellation>>,
+}
+
+struct FanoutActivationTaskCancellation {
+    abort: tokio::task::AbortHandle,
+    completed: oneshot::Receiver<()>,
+}
+
+impl FanoutActivationTaskTracker {
+    fn register(&self, abort: tokio::task::AbortHandle, completed: oneshot::Receiver<()>) {
+        self.tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(FanoutActivationTaskCancellation { abort, completed });
+    }
+
+    pub(crate) async fn abort_and_wait(&self) {
+        let tasks = {
+            let mut tasks = self
+                .tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::take(&mut *tasks)
+        };
+        for task in &tasks {
+            task.abort.abort();
+        }
+        for task in tasks {
+            let _ = task.completed.await;
+        }
+    }
+}
+
+struct FanoutActivationTaskCompletion(Option<oneshot::Sender<()>>);
+
+impl Drop for FanoutActivationTaskCompletion {
+    fn drop(&mut self) {
+        if let Some(completed) = self.0.take() {
+            let _ = completed.send(());
+        }
+    }
+}
+
+struct FanoutChildSessionActivation {
+    session_id: String,
+    node_name: String,
+    permission_mode: PermissionMode,
+    user_message: String,
+    system_prompt: Option<String>,
+    workflow_instructions: Vec<String>,
+    reserved: Option<oneshot::Receiver<()>>,
+    start: Option<oneshot::Sender<()>>,
+    task: Option<tokio::task::JoinHandle<Option<SessionRuntimeLockGuard>>>,
+}
+
+impl Drop for FanoutChildSessionActivation {
+    fn drop(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+async fn reserve_fanout_child_sessions(
+    runtime: &Arc<AgentSessionRuntimeUsecase>,
+    child_setups: &[FanoutChildSessionSetup],
+    activation_tasks: &FanoutActivationTaskTracker,
+) -> Result<Vec<FanoutChildSessionActivation>, WorkflowEngineError> {
+    let mut activations = Vec::with_capacity(child_setups.len());
+
+    for setup in child_setups {
+        let permission_mode = PermissionMode::parse_canonical(&setup.permission_mode)
+            .map_err(|e| WorkflowEngineError::InvalidWorkflow(e.to_string()))?;
+        let runtime = Arc::clone(runtime);
+        let session_id = setup.session_id.clone();
+        let session_id_for_task = session_id.clone();
+        let node_name = setup.node_name.clone();
+        let user_message = setup.user_message.clone();
+        let system_prompt = setup.system_prompt.clone();
+        let workflow_instructions = setup
+            .workflow_instruction
+            .clone()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let (reserved_tx, reserved_rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+        let (completed_tx, completed_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _completion = FanoutActivationTaskCompletion(Some(completed_tx));
+            let runtime_guard = runtime.acquire_session_lock(&session_id_for_task).await;
+            if reserved_tx.send(()).is_err() || start_rx.await.is_err() {
+                drop(runtime_guard);
+                return None;
+            }
+            Some(runtime_guard)
+        });
+        activation_tasks.register(task.abort_handle(), completed_rx);
+        activations.push(FanoutChildSessionActivation {
+            session_id,
+            node_name,
+            permission_mode,
+            user_message,
+            system_prompt,
+            workflow_instructions,
+            reserved: Some(reserved_rx),
+            start: Some(start_tx),
+            task: Some(task),
+        });
+    }
+
+    for activation in &mut activations {
+        let reserved = activation.reserved.take().ok_or_else(|| {
+            WorkflowEngineError::InvalidState(format!(
+                "fanout child '{}' activation reservation was already consumed",
+                activation.session_id
+            ))
+        })?;
+        reserved.await.map_err(|_| {
+            WorkflowEngineError::AgentSession(format!(
+                "fanout child '{}' activation task ended before reserving its session",
+                activation.session_id
+            ))
+        })?;
+    }
+
+    Ok(activations)
 }
 
 async fn start_fanout_child_sessions(
     runtime: &Arc<AgentSessionRuntimeUsecase>,
     open_tabs: &Arc<OpenTabRegistry>,
-    child_setups: &[FanoutChildSessionSetup],
+    mut activations: Vec<FanoutChildSessionActivation>,
 ) -> Result<(), WorkflowEngineError> {
-    let mut created_session_ids: Vec<String> = Vec::new();
-    let mut runtime_guards = Vec::new();
+    let created_session_ids = activations
+        .iter()
+        .map(|activation| activation.session_id.clone())
+        .collect::<Vec<_>>();
 
-    for setup in child_setups {
-        let runtime_guard = runtime.acquire_session_lock(&setup.session_id).await;
-        runtime_guards.push(runtime_guard);
-        open_tabs.add(&setup.session_id);
-        created_session_ids.push(setup.session_id.clone());
+    for activation in &activations {
+        open_tabs.add(&activation.session_id);
     }
 
-    for setup in child_setups {
-        let runtime_guard = runtime_guards.remove(0);
-        let permission_mode = PermissionMode::parse_canonical(&setup.permission_mode)
-            .map_err(|e| WorkflowEngineError::InvalidWorkflow(e.to_string()))?;
-        if let Err(e) = runtime
-            .start_turn_locked(
-                &setup.session_id,
-                permission_mode,
-                setup.user_message.clone(),
-                setup.system_prompt.clone(),
-                setup.workflow_instruction.clone().into_iter().collect(),
-            )
-            .await
-        {
+    for activation in &mut activations {
+        if let Err(error) = start_single_fanout_child(runtime, activation).await {
             for session_id in &created_session_ids {
                 interrupt_agent(runtime, session_id).await;
             }
-            return Err(WorkflowEngineError::with_agent_runtime_context(
-                format!(
-                    "Failed to start turn for fanout child '{}'",
-                    setup.node_name
-                ),
-                e,
-            ));
+            return Err(error);
         }
-        drop(runtime_guard);
     }
 
     Ok(())
+}
+
+async fn start_single_fanout_child(
+    runtime: &Arc<AgentSessionRuntimeUsecase>,
+    activation: &mut FanoutChildSessionActivation,
+) -> Result<(), WorkflowEngineError> {
+    let started = activation
+        .start
+        .take()
+        .is_some_and(|start| start.send(()).is_ok());
+    if !started {
+        return Err(WorkflowEngineError::AgentSession(format!(
+            "fanout child '{}' activation task ended before start",
+            activation.session_id
+        )));
+    }
+
+    let task = activation.task.take().ok_or_else(|| {
+        WorkflowEngineError::InvalidState(format!(
+            "fanout child '{}' activation task was already consumed",
+            activation.session_id
+        ))
+    })?;
+    let runtime_guard = task
+        .await
+        .map_err(|error| {
+            WorkflowEngineError::AgentSession(format!(
+                "fanout child '{}' activation task failed: {error}",
+                activation.session_id
+            ))
+        })?
+        .ok_or_else(|| {
+            WorkflowEngineError::AgentSession(format!(
+                "fanout child '{}' activation task ended before transferring its session reservation",
+                activation.session_id
+            ))
+        })?;
+    #[cfg(test)]
+    let mut runtime_guard = runtime_guard;
+    #[cfg(test)]
+    runtime_guard.adopt_for_current_test_flow();
+    let result = runtime
+        .start_turn_locked(
+            &activation.session_id,
+            activation.permission_mode,
+            std::mem::take(&mut activation.user_message),
+            activation.system_prompt.take(),
+            std::mem::take(&mut activation.workflow_instructions),
+        )
+        .await;
+    drop(runtime_guard);
+    result.map_err(|error| {
+        WorkflowEngineError::with_agent_runtime_context(
+            format!(
+                "Failed to start turn for fanout child '{}'",
+                activation.node_name
+            ),
+            error,
+        )
+    })
 }
 
 #[cfg(test)]
@@ -596,7 +770,11 @@ mod tests {
         BackendCapabilities, ModelDescriptor, ModelId, SkillEntry,
     };
     use crate::domain::workflow::NodeKindName;
+    use crate::test_support::TestRuntimeCallKind;
+    use crate::usecase::agent_session::runtime::SendAgentMessageRequest;
+    use crate::usecase::agent_session::session::SessionCreationAttributes;
     use async_trait::async_trait;
+    use std::time::Duration;
 
     struct RuntimeSessionMockBackend {
         id: &'static str,
@@ -1032,6 +1210,151 @@ mod tests {
         assert_eq!(
             creation_plans[0].workflow_node_context.node_name,
             "review-pending"
+        );
+    }
+
+    #[tokio::test]
+    async fn fanout_reserves_later_child_activation_before_publishing_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::test_support::build_session_store());
+        let (runtime, controller) =
+            crate::test_support::build_agent_runtime_usecase_with_controller(
+                Arc::clone(&session_store),
+                tmp.path(),
+            );
+        let worktree_path = tmp.path().to_string_lossy().to_string();
+        let first_session =
+            crate::usecase::agent_session::session::create_session_internal_with_attributes(
+                &session_store,
+                tmp.path(),
+                &worktree_path,
+                Some("codex".to_string()),
+                PermissionMode::Edit,
+                SessionCreationAttributes {
+                    selected_model: Some("gpt-5".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let second_session =
+            crate::usecase::agent_session::session::create_session_internal_with_attributes(
+                &session_store,
+                tmp.path(),
+                &worktree_path,
+                Some("codex".to_string()),
+                PermissionMode::Edit,
+                SessionCreationAttributes {
+                    selected_model: Some("gpt-5".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let setups = vec![
+            FanoutChildSessionSetup {
+                node_execution_id: "node-execution-first".to_string(),
+                node_name: "first".to_string(),
+                session_id: first_session.id.clone(),
+                system_prompt: None,
+                workflow_instruction: None,
+                user_message: "workflow-first".to_string(),
+                permission_mode: PermissionMode::Edit.as_str().to_string(),
+            },
+            FanoutChildSessionSetup {
+                node_execution_id: "node-execution-second".to_string(),
+                node_name: "second".to_string(),
+                session_id: second_session.id.clone(),
+                system_prompt: None,
+                workflow_instruction: None,
+                user_message: "workflow-second".to_string(),
+                permission_mode: PermissionMode::Edit.as_str().to_string(),
+            },
+        ];
+        controller.pause_start_turn();
+
+        let activation_tasks = FanoutActivationTaskTracker::default();
+        let activations = reserve_fanout_child_sessions(&runtime, &setups, &activation_tasks)
+            .await
+            .unwrap();
+        assert!(runtime.session_runtime_lock_is_held_for_test(&first_session.id));
+        assert!(runtime.session_runtime_lock_is_held_for_test(&second_session.id));
+
+        let open_tabs = Arc::new(OpenTabRegistry::default());
+        let start_runtime = Arc::clone(&runtime);
+        let start_open_tabs = Arc::clone(&open_tabs);
+        let start = tokio::spawn(async move {
+            start_fanout_child_sessions(&start_runtime, &start_open_tabs, activations).await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if controller
+                    .call_kinds_for(&first_session.id)
+                    .iter()
+                    .any(|call| {
+                        matches!(
+                            call,
+                            TestRuntimeCallKind::StartTurnPrompt { prompt }
+                                if prompt == "workflow-first"
+                        )
+                    })
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let send_runtime = Arc::clone(&runtime);
+        let second_session_id = second_session.id.clone();
+        let send_worktree_path = worktree_path.clone();
+        let mut send = tokio::spawn(async move {
+            send_runtime
+                .send_message(SendAgentMessageRequest {
+                    chat_session_id: Some(second_session_id),
+                    worktree_path: send_worktree_path,
+                    content: "user-second".to_string(),
+                    permission_mode: PermissionMode::Edit,
+                    plan_mode: false,
+                    backend_id: Some("codex".to_string()),
+                    model_id: Some("gpt-5".to_string()),
+                    images: None,
+                    mentions: None,
+                    editor_context: None,
+                })
+                .await
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut send)
+                .await
+                .is_err(),
+            "the later child operation must wait behind its reserved workflow activation"
+        );
+        assert!(controller
+            .call_kinds_for(&second_session.id)
+            .iter()
+            .all(|call| !matches!(call, TestRuntimeCallKind::StartTurnPrompt { .. })));
+
+        controller.release_start_turn();
+        start.await.unwrap().unwrap();
+        let send_response = send.await.unwrap().unwrap();
+
+        assert!(send_response.agent_message.is_none());
+        assert!(send_response.queued_turn.is_some());
+        assert_eq!(send_response.pending_queue_count, 1);
+        assert_eq!(
+            controller
+                .call_kinds_for(&second_session.id)
+                .into_iter()
+                .filter(|call| matches!(call, TestRuntimeCallKind::StartTurnPrompt { .. }))
+                .collect::<Vec<_>>(),
+            vec![TestRuntimeCallKind::StartTurnPrompt {
+                prompt: "workflow-second".to_string(),
+            }]
+        );
+        assert_eq!(
+            open_tabs.snapshot(),
+            [first_session.id, second_session.id].into_iter().collect()
         );
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
@@ -611,8 +611,14 @@ async fn reserve_fanout_child_sessions(
     let mut activations = Vec::with_capacity(child_setups.len());
 
     for setup in child_setups {
-        let permission_mode = PermissionMode::parse_canonical(&setup.permission_mode)
-            .map_err(|e| WorkflowEngineError::InvalidWorkflow(e.to_string()))?;
+        let permission_mode = match PermissionMode::parse_canonical(&setup.permission_mode) {
+            Ok(permission_mode) => permission_mode,
+            Err(error) => {
+                let error = WorkflowEngineError::InvalidWorkflow(error.to_string());
+                activation_tasks.abort_and_wait().await;
+                return Err(error);
+            }
+        };
         let runtime = Arc::clone(runtime);
         let session_id = setup.session_id.clone();
         let session_id_for_task = session_id.clone();
@@ -650,22 +656,38 @@ async fn reserve_fanout_child_sessions(
         });
     }
 
-    for activation in &mut activations {
-        let reserved = activation.reserved.take().ok_or_else(|| {
-            WorkflowEngineError::InvalidState(format!(
-                "fanout child '{}' activation reservation was already consumed",
-                activation.session_id
-            ))
-        })?;
-        reserved.await.map_err(|_| {
-            WorkflowEngineError::AgentSession(format!(
-                "fanout child '{}' activation task ended before reserving its session",
-                activation.session_id
-            ))
-        })?;
-    }
+    wait_for_fanout_child_session_reservations(&mut activations, activation_tasks).await?;
 
     Ok(activations)
+}
+
+async fn wait_for_fanout_child_session_reservations(
+    activations: &mut [FanoutChildSessionActivation],
+    activation_tasks: &FanoutActivationTaskTracker,
+) -> Result<(), WorkflowEngineError> {
+    for activation in activations.iter_mut() {
+        let reserved = match activation.reserved.take() {
+            Some(reserved) => reserved,
+            None => {
+                let error = WorkflowEngineError::InvalidState(format!(
+                    "fanout child '{}' activation reservation was already consumed",
+                    activation.session_id
+                ));
+                activation_tasks.abort_and_wait().await;
+                return Err(error);
+            }
+        };
+        if reserved.await.is_err() {
+            let error = WorkflowEngineError::AgentSession(format!(
+                "fanout child '{}' activation task ended before reserving its session",
+                activation.session_id
+            ));
+            activation_tasks.abort_and_wait().await;
+            return Err(error);
+        }
+    }
+
+    Ok(())
 }
 
 async fn start_fanout_child_sessions(
@@ -862,6 +884,45 @@ mod tests {
         }));
         registry.set_default(Some("codex".to_string()));
         registry
+    }
+
+    async fn register_held_session_lock(
+        runtime: &Arc<AgentSessionRuntimeUsecase>,
+        activation_tasks: &FanoutActivationTaskTracker,
+        session_id: &str,
+    ) {
+        let runtime = Arc::clone(runtime);
+        let session_id = session_id.to_string();
+        let (acquired_tx, acquired_rx) = oneshot::channel();
+        let (completed_tx, completed_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _completion = FanoutActivationTaskCompletion(Some(completed_tx));
+            let _runtime_guard = runtime.acquire_session_lock(&session_id).await;
+            let _ = acquired_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        activation_tasks.register(task.abort_handle(), completed_rx);
+        tokio::time::timeout(Duration::from_secs(1), acquired_rx)
+            .await
+            .expect("test session lock must be acquired")
+            .expect("test session lock task must remain active");
+    }
+
+    fn fanout_activation_with_reservation(
+        session_id: &str,
+        reserved: Option<oneshot::Receiver<()>>,
+    ) -> FanoutChildSessionActivation {
+        FanoutChildSessionActivation {
+            session_id: session_id.to_string(),
+            node_name: "child".to_string(),
+            permission_mode: PermissionMode::Edit,
+            user_message: "workflow-child".to_string(),
+            system_prompt: None,
+            workflow_instructions: Vec::new(),
+            reserved,
+            start: None,
+            task: None,
+        }
     }
 
     fn workflow_context_for_test() -> WorkflowNodeContext {
@@ -1211,6 +1272,105 @@ mod tests {
             creation_plans[0].workflow_node_context.node_name,
             "review-pending"
         );
+    }
+
+    #[tokio::test]
+    async fn invalid_fanout_permission_waits_for_activation_task_cleanup_before_returning() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::test_support::build_session_store());
+        let (runtime, _) = crate::test_support::build_agent_runtime_usecase_with_controller(
+            session_store,
+            tmp.path(),
+        );
+        let activation_tasks = FanoutActivationTaskTracker::default();
+        let held_session_id = "held-before-invalid-permission";
+        register_held_session_lock(&runtime, &activation_tasks, held_session_id).await;
+        let invalid_permission_mode = "invalid";
+        let setups = vec![FanoutChildSessionSetup {
+            node_execution_id: "node-execution-child".to_string(),
+            node_name: "child".to_string(),
+            session_id: "child-session".to_string(),
+            system_prompt: None,
+            workflow_instruction: None,
+            user_message: "workflow-child".to_string(),
+            permission_mode: invalid_permission_mode.to_string(),
+        }];
+
+        let error = match reserve_fanout_child_sessions(&runtime, &setups, &activation_tasks).await
+        {
+            Ok(_) => panic!("invalid permission mode must fail fanout reservation"),
+            Err(error) => error,
+        };
+
+        match error {
+            WorkflowEngineError::InvalidWorkflow(message) => assert_eq!(
+                message,
+                PermissionMode::parse_canonical(invalid_permission_mode)
+                    .unwrap_err()
+                    .to_string()
+            ),
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert!(!runtime.session_runtime_lock_is_held_for_test(held_session_id));
+    }
+
+    #[tokio::test]
+    async fn consumed_fanout_reservation_waits_for_activation_task_cleanup_before_returning() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::test_support::build_session_store());
+        let (runtime, _) = crate::test_support::build_agent_runtime_usecase_with_controller(
+            session_store,
+            tmp.path(),
+        );
+        let activation_tasks = FanoutActivationTaskTracker::default();
+        let held_session_id = "held-before-consumed-reservation";
+        register_held_session_lock(&runtime, &activation_tasks, held_session_id).await;
+        let mut activations = vec![fanout_activation_with_reservation("child-session", None)];
+
+        let error = wait_for_fanout_child_session_reservations(&mut activations, &activation_tasks)
+            .await
+            .unwrap_err();
+
+        match error {
+            WorkflowEngineError::InvalidState(message) => assert_eq!(
+                message,
+                "fanout child 'child-session' activation reservation was already consumed"
+            ),
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert!(!runtime.session_runtime_lock_is_held_for_test(held_session_id));
+    }
+
+    #[tokio::test]
+    async fn ended_fanout_reservation_task_waits_for_activation_task_cleanup_before_returning() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::test_support::build_session_store());
+        let (runtime, _) = crate::test_support::build_agent_runtime_usecase_with_controller(
+            session_store,
+            tmp.path(),
+        );
+        let activation_tasks = FanoutActivationTaskTracker::default();
+        let held_session_id = "held-before-ended-reservation";
+        register_held_session_lock(&runtime, &activation_tasks, held_session_id).await;
+        let (reserved_tx, reserved_rx) = oneshot::channel();
+        drop(reserved_tx);
+        let mut activations = vec![fanout_activation_with_reservation(
+            "child-session",
+            Some(reserved_rx),
+        )];
+
+        let error = wait_for_fanout_child_session_reservations(&mut activations, &activation_tasks)
+            .await
+            .unwrap_err();
+
+        match error {
+            WorkflowEngineError::AgentSession(message) => assert_eq!(
+                message,
+                "fanout child 'child-session' activation task ended before reserving its session"
+            ),
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert!(!runtime.session_runtime_lock_is_held_for_test(held_session_id));
     }
 
     #[tokio::test]

--- a/src-tauri/src/usecase/agent_session/runtime/usecase.rs
+++ b/src-tauri/src/usecase/agent_session/runtime/usecase.rs
@@ -1,6 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+#[cfg(test)]
+use std::sync::OnceLock;
+use std::sync::{Arc, Mutex as StdMutex, RwLock};
 use std::time::Duration;
 
 use futures_util::StreamExt;
@@ -77,7 +79,101 @@ use super::streaming::{
 };
 
 type SessionRuntimeLock = Arc<Mutex<()>>;
-type SessionRuntimeLocks = Arc<Mutex<HashMap<String, SessionRuntimeLock>>>;
+
+#[derive(Default)]
+struct SessionRuntimeLockRegistry {
+    // Acquired asynchronously and never held while waiting for a per-session lock.
+    map: Mutex<HashMap<String, SessionRuntimeLock>>,
+    // Synchronous so guard Drop can always enqueue cleanup without a Tokio runtime.
+    pending_prune: StdMutex<HashSet<String>>,
+}
+
+type SessionRuntimeLocks = Arc<SessionRuntimeLockRegistry>;
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum TestSessionRuntimeLockOwner {
+    Task(tokio::task::Id),
+    Thread(std::thread::ThreadId),
+}
+
+#[cfg(test)]
+impl TestSessionRuntimeLockOwner {
+    fn current() -> Self {
+        tokio::task::try_id()
+            .map(Self::Task)
+            .unwrap_or_else(|| Self::Thread(std::thread::current().id()))
+    }
+}
+
+#[cfg(test)]
+fn held_session_locks() -> &'static StdMutex<HashMap<TestSessionRuntimeLockOwner, String>> {
+    static HELD_SESSION_LOCKS: OnceLock<StdMutex<HashMap<TestSessionRuntimeLockOwner, String>>> =
+        OnceLock::new();
+    HELD_SESSION_LOCKS.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+struct TestSessionRuntimeLockOwnerReservation {
+    owner: TestSessionRuntimeLockOwner,
+    session_id: String,
+}
+
+#[cfg(test)]
+impl TestSessionRuntimeLockOwnerReservation {
+    fn reserve(session_id: &str) -> Self {
+        let owner = TestSessionRuntimeLockOwner::current();
+        let mut held = held_session_locks()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(
+            !held.contains_key(&owner),
+            "session runtime lock re-entry is forbidden: owner={owner:?}, held={held:?}, requested={session_id}"
+        );
+        held.insert(owner.clone(), session_id.to_string());
+        Self {
+            owner,
+            session_id: session_id.to_string(),
+        }
+    }
+
+    fn adopt_for_current_flow(&mut self) {
+        let current_owner = TestSessionRuntimeLockOwner::current();
+        if current_owner == self.owner {
+            return;
+        }
+        let mut held = held_session_locks()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(
+            held.get(&self.owner),
+            Some(&self.session_id),
+            "transferred session runtime lock must retain its acquiring test owner"
+        );
+        assert!(
+            !held.contains_key(&current_owner),
+            "session runtime lock transfer target must not already hold a lock: owner={current_owner:?}, held={held:?}"
+        );
+        held.remove(&self.owner);
+        held.insert(current_owner.clone(), self.session_id.clone());
+        self.owner = current_owner;
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestSessionRuntimeLockOwnerReservation {
+    fn drop(&mut self) {
+        let mut held = held_session_locks()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(
+            held.get(&self.owner),
+            Some(&self.session_id),
+            "session runtime lock must be released by its acquiring test flow"
+        );
+        held.remove(&self.owner);
+    }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -367,7 +463,7 @@ impl AgentSessionRuntimeUsecase {
                 instruction_source,
                 data_dir: Arc::new(data_dir),
                 sessions: Arc::new(Mutex::new(RuntimeSessionMap::new())),
-                session_locks: Arc::new(Mutex::new(HashMap::new())),
+                session_locks: Arc::new(SessionRuntimeLockRegistry::default()),
                 workflow_turn_complete_notifier: Arc::new(RwLock::new(None)),
                 workflow_stall_notifier: Arc::new(RwLock::new(None)),
             },
@@ -1235,8 +1331,25 @@ impl AgentSessionRuntimeUsecase {
         self.live_runtime(session_id).await.is_some()
     }
 
+    /// Acquires the per-session runtime lock.
+    ///
+    /// While the returned guard is held, callers must not acquire another session runtime lock,
+    /// including the same session recursively. Backend I/O awaits such as process startup and
+    /// stdin writes must be limited to the smallest range required for per-session ordering.
+    /// UI and event notifications, including session state-change emits, must run after the guard
+    /// is dropped.
     pub async fn acquire_session_lock(&self, session_id: &str) -> SessionRuntimeLockGuard {
         acquire_session_runtime_lock(&self.ctx.session_locks, session_id).await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn session_runtime_lock_is_held_for_test(&self, session_id: &str) -> bool {
+        let Ok(locks) = self.ctx.session_locks.map.try_lock() else {
+            return true;
+        };
+        locks
+            .get(session_id)
+            .is_some_and(|lock| lock.try_lock().is_err())
     }
 
     pub async fn start_turn_locked(
@@ -2436,14 +2549,57 @@ pub struct SessionRuntimeLockGuard {
     session_id: String,
     guard: Option<OwnedMutexGuard<()>>,
     locks: SessionRuntimeLocks,
+    #[cfg(test)]
+    test_owner_reservation: TestSessionRuntimeLockOwnerReservation,
 }
 
+#[cfg(test)]
+impl SessionRuntimeLockGuard {
+    pub(crate) fn adopt_for_current_test_flow(&mut self) {
+        self.test_owner_reservation.adopt_for_current_flow();
+    }
+}
+
+/// Acquires the per-session runtime lock used to serialize runtime state transitions.
+///
+/// While the returned guard is held, callers must not acquire another session runtime lock,
+/// including the same session recursively. Backend I/O awaits such as process startup and stdin
+/// writes must be limited to the smallest range required for per-session ordering. UI and event
+/// notifications, including session state-change emits, must run after the guard is dropped.
 async fn acquire_session_runtime_lock(
     session_locks: &SessionRuntimeLocks,
     session_id: &str,
 ) -> SessionRuntimeLockGuard {
+    #[cfg(test)]
+    let test_owner_reservation = TestSessionRuntimeLockOwnerReservation::reserve(session_id);
+
     let lock = {
-        let mut locks = session_locks.lock().await;
+        let mut locks = session_locks.map.lock().await;
+        let pending_prune = {
+            let mut pending = session_locks
+                .pending_prune
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::take(&mut *pending)
+        };
+        let mut still_referenced = HashSet::new();
+        for pending_session_id in pending_prune {
+            if locks
+                .get(&pending_session_id)
+                .is_some_and(|lock| Arc::strong_count(lock) == 1)
+            {
+                locks.remove(&pending_session_id);
+            } else if locks.contains_key(&pending_session_id) {
+                still_referenced.insert(pending_session_id);
+            }
+        }
+        if !still_referenced.is_empty() {
+            session_locks
+                .pending_prune
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .extend(still_referenced);
+        }
         locks
             .entry(session_id.to_string())
             .or_insert_with(|| Arc::new(Mutex::new(())))
@@ -2454,32 +2610,19 @@ async fn acquire_session_runtime_lock(
         session_id: session_id.to_string(),
         guard: Some(guard),
         locks: Arc::clone(session_locks),
+        #[cfg(test)]
+        test_owner_reservation,
     }
 }
 
 impl Drop for SessionRuntimeLockGuard {
     fn drop(&mut self) {
         self.guard.take();
-        let session_id = self.session_id.clone();
-        let locks = Arc::clone(&self.locks);
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => {
-                handle.spawn(async move {
-                    let mut locks = locks.lock().await;
-                    if locks
-                        .get(&session_id)
-                        .is_some_and(|lock| Arc::strong_count(lock) == 1)
-                    {
-                        locks.remove(&session_id);
-                    }
-                });
-            }
-            Err(_) => {
-                log::warn!(
-                    "skip prune_session_runtime_lock: no tokio runtime (session={session_id})"
-                );
-            }
-        }
+        self.locks
+            .pending_prune
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(self.session_id.clone());
     }
 }
 
@@ -4805,6 +4948,226 @@ mod tests {
         fn instruction_cache_key(&self, _worktree_root: &Path) -> Option<String> {
             None
         }
+    }
+
+    fn test_session_runtime_locks() -> SessionRuntimeLocks {
+        Arc::new(SessionRuntimeLockRegistry::default())
+    }
+
+    #[tokio::test]
+    async fn released_session_runtime_lock_is_pruned_on_the_next_acquire() {
+        let locks = test_session_runtime_locks();
+        let released = acquire_session_runtime_lock(&locks, "released").await;
+        assert!(locks.map.lock().await.contains_key("released"));
+
+        drop(released);
+        let active = acquire_session_runtime_lock(&locks, "active").await;
+
+        let map = locks.map.lock().await;
+        assert!(!map.contains_key("released"));
+        assert!(map.contains_key("active"));
+        drop(map);
+        drop(active);
+    }
+
+    #[test]
+    fn dropping_session_runtime_lock_without_a_runtime_still_schedules_prune() {
+        let locks = test_session_runtime_locks();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let released = runtime.block_on(acquire_session_runtime_lock(&locks, "released"));
+
+        drop(runtime);
+        drop(released);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let active = acquire_session_runtime_lock(&locks, "active").await;
+            let map = locks.map.lock().await;
+            assert!(!map.contains_key("released"));
+            assert!(map.contains_key("active"));
+            drop(map);
+            drop(active);
+        });
+    }
+
+    #[tokio::test]
+    async fn session_runtime_locks_serialize_one_session_and_keep_sessions_independent() {
+        let locks = test_session_runtime_locks();
+        let first = acquire_session_runtime_lock(&locks, "session-a").await;
+        let waiter_locks = Arc::clone(&locks);
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            runtime.block_on(async {
+                let guard = acquire_session_runtime_lock(&waiter_locks, "session-a").await;
+                acquired_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                drop(guard);
+            });
+        });
+
+        assert!(acquired_rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(first);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let other = acquire_session_runtime_lock(&locks, "session-b").await;
+        let map = locks.map.lock().await;
+        assert!(
+            map.get("session-a")
+                .is_some_and(|lock| lock.try_lock().is_err()),
+            "an actively held session lock must remain in the registry"
+        );
+        assert!(map.contains_key("session-b"));
+        drop(map);
+        drop(other);
+
+        release_tx.send(()).unwrap();
+        waiter.join().unwrap();
+
+        let final_guard = acquire_session_runtime_lock(&locks, "final").await;
+        assert!(!locks.map.lock().await.contains_key("session-a"));
+        drop(final_guard);
+    }
+
+    #[tokio::test]
+    async fn repeated_session_runtime_locks_do_not_accumulate_registry_entries() {
+        let locks = test_session_runtime_locks();
+
+        for index in 0..100 {
+            let guard = acquire_session_runtime_lock(&locks, &format!("session-{index}")).await;
+            assert_eq!(locks.map.lock().await.len(), 1);
+            drop(guard);
+        }
+
+        let final_guard = acquire_session_runtime_lock(&locks, "final").await;
+        let map = locks.map.lock().await;
+        assert_eq!(map.len(), 1);
+        assert!(map.contains_key("final"));
+        drop(map);
+        drop(final_guard);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "session runtime lock re-entry is forbidden")]
+    async fn session_runtime_lock_reentry_is_detected_in_tests() {
+        let locks = test_session_runtime_locks();
+        let _first = acquire_session_runtime_lock(&locks, "session-a").await;
+        let _second = acquire_session_runtime_lock(&locks, "session-b").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn session_runtime_lock_reentry_is_detected_on_a_multi_thread_runtime() {
+        let locks = test_session_runtime_locks();
+        let task = tokio::spawn(async move {
+            let _first = acquire_session_runtime_lock(&locks, "session-a").await;
+            tokio::task::yield_now().await;
+            let _second = acquire_session_runtime_lock(&locks, "session-b").await;
+        });
+
+        let error = task.await.expect_err("re-entry must panic");
+        assert!(error.is_panic());
+    }
+
+    #[tokio::test]
+    async fn concurrently_polled_session_runtime_lock_acquires_detect_reentry() {
+        let locks = test_session_runtime_locks();
+        let holder_a_locks = Arc::clone(&locks);
+        let holder_b_locks = Arc::clone(&locks);
+        let (holder_a_ready_tx, holder_a_ready_rx) = tokio::sync::oneshot::channel();
+        let (holder_b_ready_tx, holder_b_ready_rx) = tokio::sync::oneshot::channel();
+        let (release_holder_a_tx, release_holder_a_rx) = tokio::sync::oneshot::channel();
+        let (release_holder_b_tx, release_holder_b_rx) = tokio::sync::oneshot::channel();
+        let holder_a = tokio::spawn(async move {
+            let guard = acquire_session_runtime_lock(&holder_a_locks, "session-a").await;
+            holder_a_ready_tx.send(()).unwrap();
+            release_holder_a_rx.await.unwrap();
+            drop(guard);
+        });
+        let holder_b = tokio::spawn(async move {
+            let guard = acquire_session_runtime_lock(&holder_b_locks, "session-b").await;
+            holder_b_ready_tx.send(()).unwrap();
+            release_holder_b_rx.await.unwrap();
+            drop(guard);
+        });
+        holder_a_ready_rx.await.unwrap();
+        holder_b_ready_rx.await.unwrap();
+
+        let reentry_locks = Arc::clone(&locks);
+        let reentry = tokio::spawn(async move {
+            let acquire_a = acquire_session_runtime_lock(&reentry_locks, "session-a");
+            let acquire_b = acquire_session_runtime_lock(&reentry_locks, "session-b");
+            tokio::join!(acquire_a, acquire_b)
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !reentry.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("parallel re-entry must be detected before either session lock is released");
+
+        release_holder_a_tx.send(()).unwrap();
+        holder_a.await.unwrap();
+        release_holder_b_tx.send(()).unwrap();
+        holder_b.await.unwrap();
+
+        let error = match reentry.await {
+            Ok(_) => panic!("parallel re-entry must panic"),
+            Err(error) => error,
+        };
+        assert!(error.is_panic());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn session_runtime_lock_drop_removes_task_ownership_from_another_thread() {
+        let locks = test_session_runtime_locks();
+        let task = tokio::spawn(async move {
+            let first = acquire_session_runtime_lock(&locks, "session-a").await;
+            tokio::task::spawn_blocking(move || drop(first))
+                .await
+                .unwrap();
+
+            let second = acquire_session_runtime_lock(&locks, "session-b").await;
+            drop(second);
+        });
+
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "session runtime lock re-entry is forbidden")]
+    async fn transferred_session_runtime_lock_detects_reentry_in_the_receiving_flow() {
+        let locks = test_session_runtime_locks();
+        let task_locks = Arc::clone(&locks);
+        let mut first =
+            tokio::spawn(
+                async move { acquire_session_runtime_lock(&task_locks, "session-a").await },
+            )
+            .await
+            .unwrap();
+        first.adopt_for_current_test_flow();
+
+        let _second = acquire_session_runtime_lock(&locks, "session-b").await;
+    }
+
+    #[tokio::test]
+    async fn sequential_session_runtime_lock_acquires_are_not_reentry() {
+        let locks = test_session_runtime_locks();
+        let first = acquire_session_runtime_lock(&locks, "session-a").await;
+        drop(first);
+
+        let second = acquire_session_runtime_lock(&locks, "session-b").await;
+        drop(second);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1411 (milestone 84「Agentチャット安定化」/ Phase 0 / ST-5・I13)

## 概要

session runtime lock の保持規約を明文化し、既存経路の是正・prune のランタイム非依存化・テストビルドでの再入検出を行う。外部から観測可能な UI/CLI の振る舞いは変えない、backend 内部完結の構造的安定化。

## 変更点

- **lock 規約の rustdoc 明記**: `acquire_session_runtime_lock` / `acquire_session_lock` に、保持中の規約 (a) 別 session lock 取得禁止 / (b) backend I/O await 最小化 / (c) emit はロック外、を明記
- **prune のランタイム非依存化**: `SessionRuntimeLockGuard` の `Drop` から `Handle::try_current()` 依存を除去し、次回 acquire 時に未参照エントリを掃除する方式へ変更。prune skip 経路を撤廃し lock エントリの無期限蓄積を解消
- **再入検出**: テストビルド限定で task owner keyed な保持 registry を導入し、lock 保持中の別 session lock 取得を `assert!` で検出。production の挙動・性能には影響しない
- **fan-out の (a) 違反是正**: `start_fanout_child_sessions` を、child ごとの reservation task が自身の lock だけを取得する構造へ変更。単一実行フローでの別 session lock 同時保持を解消しつつ、公開順の排他契約は維持
- **contract repair turn の是正**: `start_turn_locked` 結果取得直後に guard を解放してから失敗確定・永続化・broadcast へ進むよう修正
- **テスト追加**: prune のランタイム非依存挙動・再入検出・fan-out 予約を検証する Rust ユニットテスト

## 棚卸し（(b)(c) の見送り分）

lock 保持中に残る backend I/O await / notifier emit のうち、runtime 状態機械と post-action 境界の変更を要する箇所は本 ISSUE スコープ外とし、requirements.md に経路を一対一で列挙のうえ ST-3 / #1412 の分割対象とした。

## 確認

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test`（src-tauri）✅ 2590 passed / 0 failed

## Spec

- `docs/specs/issues-1411/requirements.md`
- `docs/specs/issues-1411/design.md`
- `docs/specs/issues-1411/behavior.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ファンアウト実行の中断・キャンセル時の後処理を強化し、停止処理の安定性を向上しました。
  * セッション処理を適切に直列化し、不要なロック情報を自動的に整理するよう改善しました。
  * ワークフローの停止・中断時に、関連する子処理も確実に終了するようになりました。
  * 中断処理やセッション開始順序、ロック解放後の通知に関するテストを追加しました。

* **ドキュメント**
  * セッション実行ロックの動作、設計、要件を文書化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->