### PR TITLE
feat: persist 失敗を可視化し event log を自己修復

### DIFF
--- a/docs/specs/issues-1409/behavior.md
+++ b/docs/specs/issues-1409/behavior.md
@@ -1,0 +1,71 @@
+# Behavior
+
+## Source
+- requirements.md
+
+## 仮定
+
+- 可視化は session-scoped バナー＋構造化ログとして観測する。バナーは backend-owned state から供給され、frontend は表示に徹する（requirements A2）。
+- リトライ回数・backoff 間隔の具体値は design node で確定するため、本振る舞いでは「短い backoff で有限回リトライ後にエラー伝搬」という観測可能な結果のみを固定する（requirements A4）。
+- RT-8 の対象は tool 使用等の durable part を含む turn で、最終永続化の append だけが失敗するケースとする。純テキスト turn は対象外（requirements A5）。
+- エラー注入・破損 fixture はテスト専用機構を用い、実 I/O 障害や外部プロセスはテストで発生させない（requirements A6）。
+
+## Behavior
+
+```gherkin
+# language: ja
+機能: persist 失敗の可視化と event log 自己修復
+
+  背景:
+    前提 Agent チャット（Claude / Codex）のセッションが永続化経路を持つ
+    かつ セッションのバナー状態は backend が所有し frontend へ供給される
+
+  ルール: 永続化失敗を無言に握りつぶさない（ST-4）
+
+    シナリオ: 一時的な永続化失敗はリトライで回復する
+      前提 セッションで永続化操作が発生する
+      もし 永続化が一時的に失敗した後、リトライ内で成功する
+      ならば その操作は成功として完了する
+      かつ ユーザー操作はエラーにならない
+
+    シナリオ: リトライ後も継続する永続化失敗は可視化されエラー伝搬する
+      前提 セッションで永続化操作が発生する
+      もし リトライを尽くしても永続化が失敗し続ける
+      ならば 失敗が呼び出し元へエラーとして伝搬し当該操作がエラー化する
+      かつ 失敗が session-scoped バナーとしてユーザーへ可視化される
+      かつ 失敗が構造化ログへ記録される
+
+    シナリオ: 永続化失敗が沈黙のまま状態を進めない
+      前提 セッションで永続化操作が失敗する
+      もし in-memory 状態のみが更新され durable 状態が更新されていない
+      ならば その乖離を無言のまま後続処理へ進めない
+
+  ルール: 破損した event log を append 側で自己修復する（RT-4）
+
+    シナリオ: 末尾破損した event log を持つセッションが送信可能へ回復する
+      前提 セッションの event log がクラッシュ等で末尾破損（欠け `]`・中途行）している
+      もし そのセッションで新たな append（メッセージ送信を含む）を行う
+      ならば event log が append 前に修復される
+      かつ 以降の append が通常どおり成功する
+      かつ 当該チャットでメッセージ送信が再び成功する
+
+    シナリオ: 修復の事実が観測できる
+      前提 破損した event log が修復される
+      もし 修復が行われる
+      ならば 修復の事実が構造化ログへ記録される
+      かつ 修復の事実がユーザーへ可視化される
+
+  ルール: 最終永続化失敗時に persist 済み本文を失わない（RT-8）
+
+    シナリオ: 最終永続化の失敗で本文が tool 履歴だけへ置換されない
+      前提 turn が Text / Thinking を含む本文を persist 済みである
+      かつ その turn が durable part（tool 使用等）を含む
+      もし turn 完了時の最終永続化（FinalPartsRecorded の append）が失敗する
+      ならば persist 済み本文が projection 由来の tool-only parts で上書きされない
+      かつ persist 済み本文を保持したまま再試行する
+      かつ reload しても本文が失われない
+```
+
+## Open Questions
+
+なし

--- a/docs/specs/issues-1409/design.md
+++ b/docs/specs/issues-1409/design.md
@@ -1,0 +1,200 @@
+# Design: persist 失敗の可視化と event log 自己修復（#1409）
+
+## 概要
+
+milestone 84「Agent チャット安定化」Phase 0 として、Agent チャット（Claude / Codex）の永続化経路にある無言失敗を 3 件解消する。
+
+- **ST-4**: production 永続化経路の `let _ =` による失敗握りつぶしを廃し、「短い backoff で有限回リトライ → 継続失敗はエラー伝搬＋可視化＋構造化ログ」の統一挙動へ置換する。
+- **RT-4**: event log の append 経路に、読み取り側と同等の末尾破損自己修復を追加し、修復後は append を継続できるようにする。
+- **RT-8**: `complete_turn` の最終永続化で `FinalPartsRecorded` の append が失敗したとき、projection 由来の tool-only parts で persist 済み本文（Text/Thinking を含む）を上書きしない。
+
+可視化は本 ISSUE では **session-scoped バナー（transient 許容の唯一の例外）＋構造化ログ**に限定する。バナーは backend-owned state から供給し、frontend は表示に徹する（requirements A2、rust-first-logic）。`Notice(PersistFailure)` 語彙への置換は S5（#1393）が担当するため、その置換点となる **backend 側の単一の接合関数**を用意する。
+
+## 変更対象
+
+| 対象 | 種別 | 目的 |
+|---|---|---|
+| `usecase/agent_session/runtime/usecase.rs` | 修正 | ST-4（`:3378` / `:3534`）と RT-8（`complete_turn` / `append_final_turn_events`）の挙動置換、可視化呼び出し |
+| `usecase/agent_session/session/store.rs` | 追加/修正 | persist リトライヘルパの提供、または呼び出し側へのエラー返却経路の確認 |
+| `adaptor/gateway/agent_session/session_storage/event_store.rs` | 修正 | append 側の末尾破損自己修復（RT-4） |
+| `usecase/agent_session/status.rs`（または runtime/ports.rs） | 追加 | session-scoped notice（バナー）の backend-owned state と通知経路（S5 置換点） |
+| `protocol/` + `ws_bridge.rs` / `ws_server/`（該当 presenter/controller） | 追加 | notice を WebSocket / Tauri で frontend へ供給する DTO・配信 |
+| `src/`（該当 hook / component） | 追加 | notice バナーの表示のみ（ロジックなし） |
+| 各対象 module の `#[cfg(test)]` / 既存 `session_storage/event_store.rs::tests` / 既存 `test_support`（`set_append_event_hook_for_test`） | 追加 | R4 の固定テスト |
+
+非スコープ（requirements の非スコープに従う）:
+
+- RT-7 のキュー回収再設計（`:3378` は握りつぶし解消のみ）。
+- `Notice(PersistFailure)` 語彙の正式導入（S5）。
+- `event_log/projector.rs:632` の非 persist な `let _ =`、テストコード内 `let _ =`（`:4792`）。
+- frontend の恒久エラー表示・チャット内 Error block（FE-2 等別 ISSUE）。
+
+## アーキテクチャと責務分割
+
+レイヤー責務（`src-tauri/AGENTS.md`）に従う。
+
+- **domain**: 変更なし。破損検出・修復・リトライは「永続化 I/O の技術的関心事」であり domain ロジックではない。
+- **usecase（runtime/usecase.rs, session/store.rs）**: リトライ回数・backoff・エラー伝搬・可視化トリガーの業務手順を所有する。ST-4 / RT-8 の挙動はここで確定する。
+- **adaptor/gateway（event_store.rs）**: event log ファイルの物理修復（RT-4）を所有する。読み取り側の `recover_unclosed_session_events` を append 経路でも使えるようにする。
+- **adaptor/protocol・presenter・controller**: notice DTO と配信。
+- **frontend**: notice バナーの描画のみ。
+
+### 可視化（バナー）の所有と接合点
+
+- notice は backend が所有する。`AgentStatusCenter` に session-scoped の最新 notice を保持する `RwLock<HashMap<session_id, SessionNotice>>` を追加する（transient: durable 保存はしない。requirements の「唯一の例外」に一致）。
+- 供給は 2 経路:
+  - **push**: `AgentSessionEventNotifier` に `persist_notice(session_id, SessionNotice)` を追加し、発生時に即時配信する。
+  - **snapshot**: 既存 session status snapshot 読み取りに notice を同梱し、reconnect / 再オープン後も直近 notice を再取得できるようにする（backend-owned state を任意 client が読める形にする、という原則に沿う）。
+- **S5 置換点**: 発火は usecase 内の単一ヘルパ `report_persist_failure(session_id, ctx, PersistFailureKind)` に集約する。S5 ではこのヘルパ内部を `Notice(PersistFailure)` 生成へ差し替えれば済むようにし、呼び出し側（ST-4 / RT-4 / RT-8）は変更不要にする。
+
+### リトライの責務配置
+
+- `append_session_event_and_project_state` / `set_session_state` / `append_session_event`（`store.rs` / `event_store.rs`）は **単発の Result を返す責務のまま**にする（リトライを内部に隠さない）。
+- リトライは **async な呼び出し側（runtime/usecase.rs）** で行う。対象の store メソッドは sync だが呼び出し文脈は async のため、試行間の backoff は `tokio::time::sleep` で待機し、tokio worker をブロックしない。
+- 共通ヘルパ `persist_with_retry(op, kind, ctx, session_id)` を usecase に置く。`op: impl FnMut() -> Result<T, String>` を N 回試行し、成功で `Ok(T)`、全失敗で最後の Err を返す。全失敗時にヘルパ内で `report_persist_failure` を呼び、構造化ログを出す。
+- event append と meta projection は部分成功し得るため、retry 対象を分離する。event append が成功した後は、その event を再 append せず `set_session_state` のみを retry する。
+
+## データモデルまたは型
+
+### SessionNotice（新規・usecase）
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionNotice {
+    pub session_id: String,
+    pub kind: SessionNoticeKind,
+    pub message: String,
+    pub created_at: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionNoticeKind {
+    /// 永続化がリトライ後も失敗し操作がエラー化した（ST-4 / RT-8）
+    PersistFailure,
+    /// 破損 event log を append 前に自己修復した（RT-4）
+    EventLogRecovered,
+}
+```
+
+- S5 でこの `SessionNoticeKind::PersistFailure` が `Notice(PersistFailure)` 語彙へ吸収される前提。本 ISSUE では暫定表現とする。
+
+### PersistFailureKind（内部・可視化文言とログ dims の分岐用）
+
+```rust
+enum PersistFailureKind {
+    ReopenRuntime,        // usecase.rs:3378 相当
+    QueuedTurnInterrupt,  // usecase.rs:3534 相当
+    FinalPartsRecorded,   // complete_turn 相当（RT-8）
+}
+```
+
+### 変更する既存シグネチャ
+
+- `event_store.rs::append_session_event_to_dir` は gateway 内部の `AppendOutcome { recovered: bool }` を返す。domain の `AgentSessionWriter` は従来の汎用戻り値を維持し、JSON event log の物理修復詳細を持たない。
+- gateway から usecase へは専用の `SessionEventLogRecoverySignal` を介して修復事実を一度だけ伝え、`SessionStore` が `EventLogRecovered` notice を発火する。
+
+## 処理フロー
+
+### ST-4: reopen runtime 失敗時（usecase.rs:3378）
+
+1. `open_runtime_for_session` が Err。
+2. 現行の `let _ = set_session_state(Error)` を `persist_with_retry(|| set_session_state(..Error), ReopenRuntime, ..)` に置換。
+3. 全リトライ失敗時: `report_persist_failure` で `PersistFailure` バナー＋構造化ログ。in-memory の後続（`emit_session_state_change`）は現行どおり実行するが、durable 更新に失敗した事実を可視化した状態で進む（無言乖離をなくす）。
+   - RT-7 のキュー回収は非スコープ。ここでは「握りつぶしをなくす」のみ。
+
+### ST-4: queued turn の start_turn 失敗時（usecase.rs:3534）
+
+1. `runtime.start_turn` が Err。rollback 実行（現行どおり）。
+2. `let _ = append_session_event_and_project_state(TurnInterrupted)` を `persist_with_retry` に置換。
+3. 全失敗時: `report_persist_failure(QueuedTurnInterrupt)`。この関数自体はイベント発火型のため、失敗を呼び出し元へ伝搬すべき文脈（この関数は `-> ()` の spawn 経路）では、エラーを可視化＋ログで確実に露出させ、in-memory を無言で進めない。
+
+### RT-4: append 側自己修復（event_store.rs）
+
+1. `append_session_event_to_dir` で file を開き末尾非空白バイトを取得。
+2. `]` でない（＝末尾破損: 欠け `]`・中途行）場合:
+   a. file 全体を読み、`recover_unclosed_session_events(content)` で有効イベント列へ復元。
+   b. 復元できたら、有効な JSON 配列（`[ ... ]`）としてファイルを書き直す（既存の pretty + indent 形式で再シリアライズ）。復元不能なら現行どおり Err。
+   c. 修復後、通常の追記分岐（末尾 `]` を truncate → `,` 追記 → `]` 再クローズ）へ合流する。
+3. gateway 内部で `AppendOutcome { recovered: true }` を受け、専用 recovery signal を立てる。上位 usecase は signal を消費して `EventLogRecovered` バナーを発火する。修復事実は必ずログへ残す。
+4. 以降の append は通常成功する（読み取り側 `parse_session_events_content` も引き続き整合）。
+
+`recover_unclosed_session_events` は既存の private fn。append 経路から使えるよう可視性を `pub(super)` へ広げるか、`FileSessionStorage` の実装ブロック内から参照可能な位置へ配置する。
+
+### RT-8: FinalPartsRecorded 失敗時の本文保持（complete_turn）
+
+現行（usecase.rs:3224-3260）の問題:
+
+- `append_final_turn_events` が Err でも警告ログのみで継続。
+- 続く projection（`load_session_events` → `agent_parts_for_message`）は、FinalPartsRecorded が未追記のため tool イベントのみから tool-only parts を導出する。
+- `parts_to_persist` は「projection が非空なら projection、空なら live parts」。tool-only は非空になるため **live parts（Text/Thinking 含む）が捨てられ tool-only で上書き**される。
+
+変更:
+
+1. `append_final_turn_events` 内の `FinalPartsRecorded` append を `persist_with_retry(FinalPartsRecorded)` にする（短い backoff で有限回）。
+2. `append_final_turn_events` の成否を complete_turn 側で分岐する:
+   - **成功時**: 現行どおり projection 由来 parts を採用（FinalPartsRecorded が反映済みなので projection は Text/Thinking を含み、正しい）。
+   - **失敗時（リトライ尽き）**: projection 由来 parts で上書きしない。`parts_to_persist` に **live `parts`（完全な本文）** を用いる。つまり「projection が tool-only でも live を優先」する分岐にする。加えて `report_persist_failure(FinalPartsRecorded)` を発火し、persist 済み本文を保持する（`persist_message_parts` は live parts で上書き＝本文維持）。
+3. 結果として reload 後も本文（Text/Thinking）が残る。純テキスト turn は元々 live フォールバックで無傷（requirements A5）。
+
+要点: **「FinalPartsRecorded が durable に反映されたときだけ projection を信頼する」**。未反映なら live parts が唯一の完全な真実源であり、それを保持する。
+
+## エラー処理
+
+- store / event_store の各メソッドは従来どおり `Result<_, String>` を返す。握りつぶし（`let _ =`）を production 永続化経路から全廃する（R1 / 受け入れ基準）。
+- `persist_with_retry`: 各試行の Err はログ（`log::warn!`）に残し、最終失敗時のみ `report_persist_failure` を 1 回発火（バナー多重発火を避ける）。
+- 後続の persist 成功時は backend の `PersistFailure` notice を clear し、更新済み `SessionStatus` を push / snapshot の双方へ反映する。`EventLogRecovered` 等の別 kind は成功時に誤って clear しない。
+- `report_persist_failure`: `SessionNotice{ PersistFailure }` を status center へ格納し notifier で push、`log::error!` で構造化（session_id, kind, error, attempts）を残す。
+- RT-4 修復: 復元不能な破損（配列開始 `[` すら無い等）は Err のまま。既存 `invalid_sessions` 経路と整合させ、無限修復ループを作らない。
+- 可視化は transient。失敗が解消（次の成功 append 等）したときにバナーを消す/上書きする挙動は、status center の最新 notice 差し替えで表現する（恒久エラー表示は非スコープ）。
+
+## テスト方針
+
+配置は対象 module 隣接（Rust は `#[cfg(test)] mod tests`）。外部プロセス・実 I/O 障害は使わず、既存注入機構（`set_append_event_hook_for_test` 等）を利用（requirements A6）。
+
+### RT-4（event_store.rs::tests、既存 test 群へ追加）
+
+- `append_session_event_recovers_unclosed_log_then_appends`: 末尾 `]` 欠けの fixture を書き、append が成功し、読み戻すと元イベント＋新イベントが揃う。
+- `append_session_event_recovers_trailing_partial_event`: 中途行（壊れた末尾オブジェクト）を含む fixture で、壊れた末尾は落として有効分＋新規が揃う。
+- `append_session_event_returns_recovered_outcome`: gateway 内部では修復時 `AppendOutcome.recovered == true`、正常時 `false`。
+- 復元不能 fixture では従来どおり Err。
+
+### ST-4（runtime/usecase.rs::tests）
+
+- `reopen_runtime_persist_failure_is_visible_not_silent`: `set_session_state` を注入で失敗させ、リトライ後に notice（PersistFailure）が発火し `let _ =` 無言化しないことを固定。
+- `queued_turn_interrupt_append_retries_then_reports`: `append_event_hook` で TurnInterrupted append を失敗させ、リトライ→最終 report を固定。
+- `transient_failure_recovers_within_retry`: 1 回だけ失敗させ、リトライ内成功で操作が成功・notice 非発火（behavior「一時失敗はリトライで回復」）。
+- `persist_failure_then_success_clears_notice`: 継続失敗で表示された `PersistFailure` が次の成功 persist で backend snapshot と push の双方から消える。
+- `post_append_projection_failure_does_not_duplicate_event`: event append 成功後の meta projection を失敗注入し、projection retry 後も同一 event が durable log に 1 件だけ存在する。
+
+### RT-8（runtime/usecase.rs::tests）
+
+- `final_parts_append_failure_keeps_body_not_tool_only`: tool part を含む turn で FinalPartsRecorded の append のみ失敗注入。persist される parts が live（Text/Thinking 含む）で、tool-only へ置換されないこと、reload 相当（再 projection）で本文が残ることを固定。
+- 静的棚卸し確認: `rg '^\s*let _ = ' usecase/agent_session/` の production 永続化ヒットが 0 件（projector.rs:632・test 用は対象外として明記）。
+
+### 可視化配信
+
+- notice が status snapshot に含まれること・notifier push が呼ばれることを usecase テストで確認。protocol DTO の serialize 形状を presenter/protocol テストで確認。frontend は表示のみのため表示分岐の最小 component テスト。
+
+CI（`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` / `pnpm lint` / `pnpm test`）を通す。
+
+## リスクと代替案
+
+- **R-1: recovery signal の取りこぼし**。gateway 内部の修復 outcome を domain API に載せず専用 signal で伝えるため、signal は session_id 単位で保持し usecase が成功 append 直後に一度だけ消費する。これにより domain 境界を保ったまま R2 の可視化を満たす。
+- **R-2: リトライ中の backoff がユーザー体感遅延を増やす**。`tokio::time::sleep` で非ブロックにし、N と間隔を小さく保つ（下記 A-D2）。
+- **R-3: RT-8 で live parts を優先すると、正常時に projection の正規化（重複マージ等）を失う懸念**。→ 分岐は「append 失敗時のみ live 優先」。成功時は現行どおり projection を使うため正常系の挙動は不変。
+- **R-4: バナーの transient 設計が durable-first 原則に反する**。requirements A2 が「唯一の例外」として明示的に許容。S5 で `Notice` へ移行する接合点を残すことで技術的負債を局所化。
+- **R-5: 修復書き直し中のクラッシュで二重破損**。修復は truncate 前に有効イベント列を確定してから単一の書き直しを行い、既存の append と同じ file_lock 下で実行する。fsync までは要求しない（既存 append と同水準）。
+
+## 仮定
+
+- **A-D1（修復通知境界）**: `AppendOutcome` は gateway 内部に閉じ、domain の writer API は変更しない。修復事実は usecase port の `SessionEventLogRecoverySignal` で session_id 単位に伝える。いずれでも「修復はログに必ず残す」。
+- **A-D2（リトライ値）**: `persist_with_retry` は **最大 3 回リトライ（初回含め計 4 試行）**、backoff は **50ms → 100ms → 200ms の指数**。試行間は `tokio::time::sleep`。これは requirements A4 の「短い backoff で有限回」を満たす具体値であり、ローカル file I/O の一時失敗（ロック競合・瞬間的 EBUSY 等）を吸収する範囲。
+- **A-D3（可視化配信先）**: バナーは `AgentStatusCenter` が session-scoped に所有し、`AgentSessionEventNotifier` の新メソッドで push＋status snapshot に同梱する。frontend は表示のみ。
+- **A-D4（発火の集約）**: ST-4 / RT-4 / RT-8 の可視化は共通ヘルパ（`report_persist_failure` / notice 発火）に集約し、S5（#1393）ではヘルパ内部のみ差し替える。呼び出し側は不変。
+- requirements の A1〜A6 を前提として引き継ぐ。
+
+## Open Questions
+
+なし

--- a/docs/specs/issues-1409/requirements.md
+++ b/docs/specs/issues-1409/requirements.md
@@ -1,0 +1,94 @@
+# L8: persist 失敗の可視化と event log 自己修復（#1409）
+
+## 背景と目的
+
+Agent チャット（Claude / Codex セッション）の永続化経路には、失敗が無言で握りつぶされ、in-memory 状態と durable 状態が乖離したまま処理が進行する問題がある。milestone 84「Agent チャット安定化」の Phase 0（依存なし）として、監査で確定した以下 3 件を解消する。
+
+- **ST-4**: 永続化失敗が `let _ =` で握りつぶされ、in-memory と durable が乖離したまま進行する。RT-8 等の症状の残存パターン。
+- **RT-4**: event log への append がクラッシュで欠けた `]` を、append 側が自己修復しない。以後そのセッションの全 append（`TurnStarted` / `SessionClosed` / `PermissionResolved` 等）が恒久的に失敗し、当該チャットではメッセージ送信が二度と成功しなくなる。
+- **RT-8**: `FinalPartsRecorded` の append 失敗時に、projection 由来の（Text/Thinking を欠いた）tool-only parts で persist 済みの本文を上書きし得る。turn 完了の瞬間に本文がツール履歴だけのメッセージへ置き換わり、reload しても戻らない。
+
+目的は、これらの経路で発生する永続化失敗を **無言にせず**（リトライ → 継続失敗は可視化＋エラー伝搬）、破損した event log を **自己修復して送信可能な状態へ戻し**、失敗時に **persist 済みの本文を失わない** ことである。
+
+### 正本ドキュメント
+
+- 問題詳細: `specs/milestone-84-agent-chat-stabilization/agent-chat-instability-audit.md`（ST-4: L1120〜, RT-4: L701〜, RT-8: L765〜）
+- ライフサイクル: `specs/milestone-84-agent-chat-stabilization/agent-chat-ideal-lifecycle.md` I8（状態変更の ack 駆動と失敗の可視化、`PersistFailure` の transient 例外）
+
+## スコープ
+
+1. **`let _ =` による persist 失敗の握りつぶし全廃（ST-4）**
+   - `src/usecase/agent_session/` 配下を `rg '^\s*let _ = '` で棚卸しし、**永続化（session_store / event append / state 保存）の失敗を握りつぶしている production 経路**を対象に、次の統一挙動へ置換する。
+     - 短い backoff で N 回リトライする。
+     - 継続失敗時は呼び出し元へエラーを伝搬し、ユーザーへ可視化する。
+   - 現行コードで対象となる production 経路（監査記載の行は現状コードで移動済み）:
+     - `runtime/usecase.rs:3378` — queued turn の runtime 再オープン失敗時の `set_session_state(Error)`。
+     - `runtime/usecase.rs:3534` — `start_turn` 失敗時の `TurnInterrupted` append（`append_session_event_and_project_state`）。
+   - 可視化は、本 ISSUE 時点では **session-scoped バナー**（durable-first 原則の唯一の例外として transient 表示を許容）＋ **構造化ログ** で実装する。S5（#1393）で `Notice(PersistFailure)` に置換される前提で、そのための接合点を残す。
+
+2. **event log の append 側自己修復（RT-4）**
+   - event log 読み込み／追記経路（`adaptor/gateway/agent_session/session_storage/event_store.rs`）で、末尾破損（欠け `]`・中途行）を検出し修復する。
+   - 読み取り側の `recover_unclosed_session_events`（既存）に対し、**append 側でも修復してから追記を継続できる**ようにし、修復後は通常どおり append 可能に戻ること。
+   - 修復した事実を構造化ログ＋可視化（session バナー、将来は Notice）に残す。
+
+3. **`FinalPartsRecorded` append 失敗時の上書き防止（RT-8）**
+   - `complete_turn` の最終永続化経路で、`FinalPartsRecorded` の append に失敗した場合に、projection 由来の tool-only parts（Text/Thinking 欠落）で persist 済み本文を完全置換する経路を止める。
+   - durable 追記に失敗した場合は **persist 済み本文を保持したまま再試行** する挙動へ変更する。
+
+4. **テスト**
+   - 破損 event log fixture、および persist 失敗注入（既存の `test_support` のエラー注入を利用）で、無言乖離・本文喪失が起きないことを固定する。
+
+## 非スコープ
+
+- **RT-7 のキュー停止問題そのものの解消**（再オープン失敗後の自動再試行トリガー欠如、キュー未 pop）。本 ISSUE では `runtime/usecase.rs:3378` の **persist 失敗の握りつぶし解消（可視化・伝搬）** のみを扱い、キュー回収挙動の再設計は行わない。
+- **`Notice(PersistFailure)` 語彙の正式導入**。これは S5（#1393）の担当であり、本 ISSUE は暫定の session バナー＋構造化ログに留める。
+- **projection 内の非 persist な `let _ =`**（例: `event_log/projector.rs:632` の `apply_tool_result_update` の戻り値無視）。永続化失敗ではないため対象外。
+- **テストコード内の `let _ =`**（例: `runtime/usecase.rs:4792` の test 用 `ReentrantWorkflowNotifier`）。production 経路ではないため対象外。
+- RT-5 / RT-6 など、milestone 84 の別 ISSUE が担当する監査項目。
+- frontend の恒久的なエラー表示・チャット内 Error block 描画の追加（FE-2 等、別 ISSUE 担当）。本 ISSUE の可視化は session-scoped バナー＋ログに限定する。
+
+## 要求事項
+
+### R1: persist 失敗を無言にしない（ST-4）
+
+- 永続化失敗が発生した production 経路で、失敗を握りつぶさず、リトライ（短い backoff で N 回）を行う。
+- リトライ後も失敗が継続する場合、失敗を呼び出し元へエラーとして伝搬し、当該操作をエラー化する。
+- 失敗はユーザーに可視化する（session-scoped バナー）とともに、構造化ログへ記録する。
+- 棚卸しの結果、`src/usecase/agent_session/` 配下の production 永続化経路に `let _ =` による persist 失敗の握りつぶしが 0 件になる。
+
+### R2: event log の自己修復（RT-4）
+
+- 末尾破損（欠け `]`・中途行）した event log を持つセッションでも、読み込み・追記を再開できる。
+- append 側で修復を行い、修復後は以降の append（送信を含む）が通常どおり成功する。
+- 修復が行われた事実をログ＋可視化に残す。
+
+### R3: 本文の上書き防止（RT-8）
+
+- `FinalPartsRecorded` の append に失敗した場合でも、persist 済みの本文（Text/Thinking を含む parts）を tool-only parts で上書きしない。
+- durable 追記に失敗したときは persist 済み本文を保持し、再試行する。
+
+### R4: テストによる固定
+
+- 破損 event log fixture で、当該セッションが自己修復され送信可能になることを固定する。
+- persist 失敗注入で、失敗が無言にならず（可視化＋リトライ）、本文が tool 履歴だけのメッセージへ置換されないことを固定する。
+
+## 受け入れ基準の概要
+
+- [ ] 破損した event log のセッションが自己修復され、メッセージ送信が再び成功する。
+- [ ] persist 失敗が無言にならない（session バナーでの可視化＋リトライ＋継続失敗時のエラー伝搬）。
+- [ ] turn 完了時に本文が tool 履歴だけのメッセージへ置き換わる事象が再現しない。
+- [ ] `src/usecase/agent_session/` 配下 production 経路で `let _ =` による永続化失敗の握りつぶしが 0 件。
+- [ ] 上記を固定する unit / 統合テストが追加され、CI（`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`）が通る。
+
+## 仮定
+
+- **A1**: spec-id は既存命名慣習に合わせ `docs/specs/issues-1409/` とする。
+- **A2**: 可視化は本 ISSUE 時点では session-scoped バナー（transient 許容の唯一の例外）＋構造化ログで実装し、`Notice(PersistFailure)` への置換は S5（#1393）で行う。バナーは backend-owned state から供給し、frontend は表示に徹する（Rust-first 原則）。
+- **A3**: 監査文書が参照する行番号（usecase.rs:3366 / :3522 / :4755 等）は現行コードで移動しており、実装時は行番号ではなく `rg '^\s*let _ = '` による棚卸し結果を正とする。現時点の production 対象は `runtime/usecase.rs:3378` と `:3534` の 2 箇所。
+- **A4**: リトライ回数 N と backoff 間隔の具体値は design node で確定する。要求段階では「短い backoff で有限回リトライ後にエラー伝搬」という挙動のみを固定する。
+- **A5**: RT-8 の対象は tool 使用等の durable part を含む turn で、`FinalPartsRecorded` の append だけが mid-turn 失敗するケース（監査記載の発生条件）を主とする。純テキスト turn は live parts フォールバックで無傷のため対象外。
+- **A6**: エラー注入はテスト専用の既存 `test_support` 機構を利用し、外部プロセス・実 I/O 障害はテストで発生させない（プロジェクトのテスト方針に従う）。
+
+## Open Questions
+
+なし

--- a/src-tauri/src/adaptor/controller/event_log_recovery_wiring.rs
+++ b/src-tauri/src/adaptor/controller/event_log_recovery_wiring.rs
@@ -1,0 +1,45 @@
+use std::sync::{Arc, Weak};
+
+use crate::usecase::agent_session::runtime::AgentSessionRuntimeUsecase;
+use crate::usecase::agent_session::session::SessionStore;
+
+pub(crate) fn register_event_log_recovery_listener(
+    session_store: Arc<SessionStore>,
+    runtime_usecase: &Arc<AgentSessionRuntimeUsecase>,
+) {
+    let runtime_usecase = Arc::downgrade(runtime_usecase);
+    register_event_log_recovery_listener_with_weak(session_store, runtime_usecase);
+}
+
+fn register_event_log_recovery_listener_with_weak(
+    session_store: Arc<SessionStore>,
+    runtime_usecase: Weak<AgentSessionRuntimeUsecase>,
+) {
+    session_store.register_event_log_recovery_listener(Arc::new(move |session_id| {
+        if let Some(runtime_usecase) = runtime_usecase.upgrade() {
+            runtime_usecase.report_event_log_recovered(session_id);
+        }
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_listener_does_not_retain_runtime_usecase() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(crate::test_support::build_session_store());
+        let (runtime_usecase, _controller) =
+            crate::test_support::build_agent_runtime_usecase_with_controller(
+                session_store.clone(),
+                tmp.path(),
+            );
+        let runtime_usecase_weak = Arc::downgrade(&runtime_usecase);
+
+        drop(runtime_usecase);
+
+        assert!(runtime_usecase_weak.upgrade().is_none());
+        assert_eq!(Arc::strong_count(&session_store), 1);
+    }
+}

--- a/src-tauri/src/adaptor/controller/mod.rs
+++ b/src-tauri/src/adaptor/controller/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod agent_status_wiring;
 pub(crate) mod api;
 pub(crate) mod application_lifecycle;
 pub(crate) mod command;
+pub(crate) mod event_log_recovery_wiring;
 pub(crate) mod notification_wiring;
 pub(crate) mod state;
 pub(crate) mod wiring;

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
@@ -6,8 +6,9 @@ use parking_lot::RwLock;
 
 use crate::usecase::agent_session::event_log::AgentSessionEvent;
 use crate::usecase::agent_session::session::{
-    ChatMessage, ChatSession, MessagePart, PageCursor, SessionAttachment, SessionMeta, SessionPage,
-    SessionReviewContext, SessionReviewContextReader, SessionToolOutput,
+    ChatMessage, ChatSession, MessagePart, PageCursor, SessionAttachment,
+    SessionEventLogRecoverySignal, SessionMeta, SessionPage, SessionReviewContext,
+    SessionReviewContextReader, SessionToolOutput,
 };
 
 mod attachment_blob;
@@ -34,6 +35,7 @@ pub struct FileSessionStorage {
     pub(super) invalid_sessions: RwLock<HashMap<String, String>>,
     pub(super) file_lock: parking_lot::Mutex<()>,
     pub(super) loaded: AtomicBool,
+    pub(super) recovered_event_logs: RwLock<HashSet<String>>,
     #[cfg(test)]
     pub(super) message_read_count: std::sync::atomic::AtomicUsize,
 }
@@ -45,6 +47,7 @@ impl Default for FileSessionStorage {
             invalid_sessions: RwLock::new(HashMap::new()),
             file_lock: parking_lot::Mutex::new(()),
             loaded: AtomicBool::new(false),
+            recovered_event_logs: RwLock::new(HashSet::new()),
             #[cfg(test)]
             message_read_count: std::sync::atomic::AtomicUsize::new(0),
         }
@@ -154,6 +157,12 @@ impl SessionReviewContextReader for FileSessionStorage {
         session_id: &str,
     ) -> Result<Option<SessionReviewContext>, String> {
         FileSessionStorage::get_session_review_context(self, app_data_dir, session_id)
+    }
+}
+
+impl SessionEventLogRecoverySignal for FileSessionStorage {
+    fn take_event_log_recovered(&self, session_id: &str) -> bool {
+        self.recovered_event_logs.write().remove(session_id)
     }
 }
 

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/event_store.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/event_store.rs
@@ -5,6 +5,11 @@ use super::layout::{event_log_file_in_dir, session_dir};
 use super::FileSessionStorage;
 use crate::usecase::agent_session::event_log::AgentSessionEvent;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct AppendOutcome {
+    recovered: bool,
+}
+
 impl FileSessionStorage {
     pub fn load_session_events(
         &self,
@@ -37,7 +42,10 @@ impl FileSessionStorage {
         }
         let _lock = self.file_lock.lock();
         let dir = session_dir(app_data_dir, session_id)?;
-        self.append_session_event_to_dir(&dir, event)?;
+        let outcome = self.append_session_event_to_dir(&dir, event)?;
+        if outcome.recovered {
+            self.record_event_log_recovery(session_id);
+        }
         self.read_session_events_from_dir(&dir)
     }
 
@@ -56,7 +64,20 @@ impl FileSessionStorage {
         }
         let _lock = self.file_lock.lock();
         let dir = session_dir(app_data_dir, session_id)?;
-        self.append_session_event_to_dir(&dir, event)
+        let outcome = self.append_session_event_to_dir(&dir, event)?;
+        if outcome.recovered {
+            self.record_event_log_recovery(session_id);
+        }
+        Ok(())
+    }
+
+    fn record_event_log_recovery(&self, session_id: &str) {
+        self.recovered_event_logs
+            .write()
+            .insert(session_id.to_string());
+        log::warn!(
+            "agent_session_event_log_recovered session_id={session_id} recovery=tail_truncation"
+        );
     }
 
     pub(super) fn read_session_events_from_dir(
@@ -75,7 +96,7 @@ impl FileSessionStorage {
         &self,
         dir: &Path,
         event: &AgentSessionEvent,
-    ) -> Result<(), String> {
+    ) -> Result<AppendOutcome, String> {
         let path = event_log_file_in_dir(dir);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
@@ -99,12 +120,28 @@ impl FileSessionStorage {
                 .map_err(|e| format!("Failed to append session event: {e}"))?;
             file.flush()
                 .map_err(|e| format!("Failed to flush session event log: {e}"))?;
-            return Ok(());
+            return Ok(AppendOutcome::default());
         }
 
-        let Some((closing_pos, b']')) = last_non_whitespace_byte(&mut file, len)? else {
+        let mut recovered = false;
+        let mut closing = last_non_whitespace_byte(&mut file, len)?;
+        let needs_recovery = match closing {
+            Some((_, b']')) => !event_log_is_valid_json(&mut file)?,
+            _ => true,
+        };
+        if needs_recovery {
+            let events = recover_session_events_from_file(&mut file)?;
+            rewrite_session_events(&mut file, &events)?;
+            let repaired_len = file
+                .metadata()
+                .map_err(|e| format!("Failed to stat repaired session event log: {e}"))?
+                .len();
+            closing = last_non_whitespace_byte(&mut file, repaired_len)?;
+            recovered = true;
+        }
+        let Some((closing_pos, b']')) = closing else {
             return Err(
-                "Failed to append session event: event log does not end with a JSON array"
+                "Failed to append session event: repaired event log is not a JSON array"
                     .to_string(),
             );
         };
@@ -123,20 +160,44 @@ impl FileSessionStorage {
         write!(file, "\n]\n").map_err(|e| format!("Failed to close session event log: {e}"))?;
         file.flush()
             .map_err(|e| format!("Failed to flush session event log: {e}"))?;
-        Ok(())
+        Ok(AppendOutcome { recovered })
     }
+}
+
+fn recover_session_events_from_file(
+    file: &mut std::fs::File,
+) -> Result<Vec<AgentSessionEvent>, String> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|e| format!("Failed to seek damaged session event log: {e}"))?;
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .map_err(|e| format!("Failed to read damaged session event log: {e}"))?;
+    recover_unclosed_session_events(&content).map_err(|_| {
+        "Failed to append session event: event log tail could not be recovered".to_string()
+    })
+}
+
+fn rewrite_session_events(
+    file: &mut std::fs::File,
+    events: &[AgentSessionEvent],
+) -> Result<(), String> {
+    let payload = serde_json::to_string_pretty(events)
+        .map_err(|e| format!("Failed to serialize recovered session event log: {e}"))?;
+    file.set_len(0)
+        .map_err(|e| format!("Failed to truncate damaged session event log: {e}"))?;
+    file.seek(SeekFrom::Start(0))
+        .map_err(|e| format!("Failed to seek repaired session event log: {e}"))?;
+    writeln!(file, "{payload}")
+        .map_err(|e| format!("Failed to rewrite recovered session event log: {e}"))?;
+    file.flush()
+        .map_err(|e| format!("Failed to flush recovered session event log: {e}"))
 }
 
 fn parse_session_events_content(content: &str) -> Result<Vec<AgentSessionEvent>, String> {
     match serde_json::from_str(content) {
         Ok(events) => Ok(events),
-        Err(error) => {
-            if last_non_whitespace_char(content) == Some(']') {
-                return Err(format!("Failed to parse session event log: {error}"));
-            }
-            recover_unclosed_session_events(content)
-                .map_err(|_| format!("Failed to parse session event log: {error}"))
-        }
+        Err(error) => recover_unclosed_session_events(content)
+            .map_err(|_| format!("Failed to parse session event log: {error}")),
     }
 }
 
@@ -151,15 +212,50 @@ fn recover_unclosed_session_events(content: &str) -> Result<Vec<AgentSessionEven
         if let Some(stripped) = prefix.strip_suffix(',') {
             prefix = stripped.trim_end();
         }
-        let candidate = format!("{prefix}\n]\n");
-        if let Ok(events) = serde_json::from_str(&candidate) {
-            return Ok(events);
+        if let Some(candidate) = close_unclosed_json_containers(prefix) {
+            if let Ok(events) = serde_json::from_str(&candidate) {
+                return Ok(events);
+            }
         }
         if end == 0 {
             return Err(());
         }
         end = previous_char_boundary(content, end);
     }
+}
+
+fn close_unclosed_json_containers(prefix: &str) -> Option<String> {
+    let mut stack = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+    for ch in prefix.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '[' | '{' => stack.push(ch),
+            ']' if stack.pop() != Some('[') => return None,
+            '}' if stack.pop() != Some('{') => return None,
+            ']' | '}' => {}
+            _ => {}
+        }
+    }
+    if in_string {
+        return None;
+    }
+    let mut candidate = prefix.to_string();
+    for opening in stack.into_iter().rev() {
+        candidate.push(if opening == '[' { ']' } else { '}' });
+    }
+    Some(candidate)
 }
 
 fn previous_char_boundary(value: &str, end: usize) -> usize {
@@ -170,16 +266,18 @@ fn previous_char_boundary(value: &str, end: usize) -> usize {
     previous
 }
 
-fn last_non_whitespace_char(value: &str) -> Option<char> {
-    value.chars().rev().find(|ch| !ch.is_whitespace())
-}
-
 fn indent_json_payload(payload: &str) -> String {
     payload
         .lines()
         .map(|line| format!("  {line}"))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn event_log_is_valid_json(file: &mut std::fs::File) -> Result<bool, String> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|e| format!("Failed to seek session event log: {e}"))?;
+    Ok(serde_json::from_reader::<_, serde::de::IgnoredAny>(file).is_ok())
 }
 
 fn last_non_whitespace_byte(
@@ -205,7 +303,10 @@ fn last_non_whitespace_byte(
 mod tests {
     use super::*;
     use crate::usecase::agent_session::event_log::PromptInput;
+    use crate::usecase::agent_session::session::{ChatSession, MessagePart, SessionState};
     use std::io::BufReader;
+
+    const SESSION_ID: &str = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
 
     fn event(turn_id: u64) -> AgentSessionEvent {
         AgentSessionEvent::TurnStarted {
@@ -215,6 +316,56 @@ mod tests {
             prompt: PromptInput::default(),
             at: turn_id as f64,
         }
+    }
+
+    fn final_parts_event() -> AgentSessionEvent {
+        AgentSessionEvent::FinalPartsRecorded {
+            turn_id: 1,
+            message_id: "agent-1".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "completed response".to_string(),
+                parent_tool_use_id: None,
+            }],
+        }
+    }
+
+    fn session(session_id: &str, worktree_path: &Path) -> ChatSession {
+        ChatSession {
+            id: session_id.to_string(),
+            worktree_path: worktree_path.to_string_lossy().to_string(),
+            messages: Vec::new(),
+            state: SessionState::Active,
+            created_at: 1.0,
+            updated_at: 1.0,
+            agent_session_id: None,
+            context_carry: None,
+            permission_mode: "edit".to_string(),
+            plan_mode: false,
+            selected_model: None,
+            permission_profile_id: None,
+            backend_id: Some("claude".to_string()),
+            workflow_node_session: false,
+            workflow_node_context: None,
+            context_epoch: None,
+        }
+    }
+
+    fn torn_final_parts_fixture() -> String {
+        let content = serde_json::to_string_pretty(&vec![final_parts_event()]).unwrap();
+        let parts_start = content.find("\"parts\"").unwrap();
+        let parts_closing = parts_start + content[parts_start..].find(']').unwrap();
+        content[..=parts_closing].to_string()
+    }
+
+    fn storage_with_session(tmp: &tempfile::TempDir, session_id: &str) -> FileSessionStorage {
+        let storage = FileSessionStorage::default();
+        storage
+            .save_full_session_for_migration_or_restore(
+                tmp.path(),
+                &session(session_id, tmp.path()),
+            )
+            .unwrap();
+        storage
     }
 
     fn read_events(dir: &Path) -> Vec<AgentSessionEvent> {
@@ -229,10 +380,11 @@ mod tests {
         std::fs::create_dir_all(tmp.path()).unwrap();
         std::fs::write(event_log_file_in_dir(tmp.path()), "").unwrap();
 
-        storage
+        let outcome = storage
             .append_session_event_to_dir(tmp.path(), &event(1))
             .unwrap();
 
+        assert!(!outcome.recovered);
         let content = std::fs::read_to_string(event_log_file_in_dir(tmp.path())).unwrap();
         assert!(content.starts_with("[\n"));
         assert!(content.ends_with("\n]\n"));
@@ -271,16 +423,123 @@ mod tests {
     }
 
     #[test]
-    fn append_session_event_rejects_log_that_does_not_end_with_array() {
+    fn append_session_event_rejects_unrecoverable_log() {
         let tmp = tempfile::tempdir().unwrap();
         let storage = FileSessionStorage::default();
-        std::fs::write(event_log_file_in_dir(tmp.path()), "[{}").unwrap();
+        std::fs::write(event_log_file_in_dir(tmp.path()), "not a JSON array").unwrap();
 
         let error = storage
             .append_session_event_to_dir(tmp.path(), &event(1))
             .unwrap_err();
 
-        assert!(error.contains("does not end with a JSON array"));
+        assert!(error.contains("could not be recovered"));
+    }
+
+    #[test]
+    fn append_session_event_recovers_unclosed_log_then_appends() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = FileSessionStorage::default();
+        storage
+            .append_session_event_to_dir(tmp.path(), &event(1))
+            .unwrap();
+        storage
+            .append_session_event_to_dir(tmp.path(), &event(2))
+            .unwrap();
+        let path = event_log_file_in_dir(tmp.path());
+        let content = std::fs::read_to_string(&path).unwrap();
+        let closing_pos = content.rfind(']').unwrap();
+        std::fs::write(&path, &content[..closing_pos]).unwrap();
+
+        let outcome = storage
+            .append_session_event_to_dir(tmp.path(), &event(3))
+            .unwrap();
+
+        assert!(outcome.recovered);
+        assert_eq!(read_events(tmp.path()), vec![event(1), event(2), event(3)]);
+    }
+
+    #[test]
+    fn append_session_event_recovers_trailing_partial_event() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = FileSessionStorage::default();
+        storage
+            .append_session_event_to_dir(tmp.path(), &event(1))
+            .unwrap();
+        storage
+            .append_session_event_to_dir(tmp.path(), &event(2))
+            .unwrap();
+        let path = event_log_file_in_dir(tmp.path());
+        let content = std::fs::read_to_string(&path).unwrap();
+        let partial_event_pos = content.find("\"m-2\"").unwrap();
+        std::fs::write(&path, &content[..partial_event_pos]).unwrap();
+
+        let outcome = storage
+            .append_session_event_to_dir(tmp.path(), &event(3))
+            .unwrap();
+
+        assert!(outcome.recovered);
+        assert_eq!(read_events(tmp.path()), vec![event(1), event(3)]);
+    }
+
+    #[test]
+    fn append_session_event_recovers_final_parts_torn_after_inner_array() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_id = SESSION_ID;
+        let storage = storage_with_session(&tmp, session_id);
+        let dir = session_dir(tmp.path(), session_id).unwrap();
+        std::fs::write(event_log_file_in_dir(&dir), torn_final_parts_fixture()).unwrap();
+
+        let events = storage
+            .append_session_event(tmp.path(), session_id, &event(2))
+            .unwrap();
+
+        assert_eq!(
+            events
+                .iter()
+                .filter(|candidate| **candidate == event(2))
+                .count(),
+            1
+        );
+        assert!(events.contains(&final_parts_event()));
+        let content = std::fs::read_to_string(event_log_file_in_dir(&dir)).unwrap();
+        serde_json::from_str::<Vec<AgentSessionEvent>>(&content).unwrap();
+    }
+
+    #[test]
+    fn read_session_events_recovers_final_parts_torn_after_inner_array() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_id = SESSION_ID;
+        let storage = storage_with_session(&tmp, session_id);
+        let dir = session_dir(tmp.path(), session_id).unwrap();
+        std::fs::write(event_log_file_in_dir(&dir), torn_final_parts_fixture()).unwrap();
+
+        let events = storage.load_session_events(tmp.path(), session_id).unwrap();
+
+        assert_eq!(events, vec![final_parts_event()]);
+    }
+
+    #[test]
+    fn append_without_projection_repairs_final_parts_torn_after_inner_array() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_id = SESSION_ID;
+        let storage = storage_with_session(&tmp, session_id);
+        let dir = session_dir(tmp.path(), session_id).unwrap();
+        std::fs::write(event_log_file_in_dir(&dir), torn_final_parts_fixture()).unwrap();
+
+        storage
+            .append_session_event_without_projection(tmp.path(), session_id, &event(2))
+            .unwrap();
+
+        let content = std::fs::read_to_string(event_log_file_in_dir(&dir)).unwrap();
+        let events = serde_json::from_str::<Vec<AgentSessionEvent>>(&content).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|candidate| **candidate == event(2))
+                .count(),
+            1
+        );
+        assert!(events.contains(&final_parts_event()));
     }
 
     #[test]

--- a/src-tauri/src/adaptor/presenter/agent_session.rs
+++ b/src-tauri/src/adaptor/presenter/agent_session.rs
@@ -10,7 +10,7 @@ use crate::usecase::agent_session::session::{
     project_tool_output_parts_for_stream, ChatMessage, ChatSession, ContextCarryState, ModelInfo,
     PermissionRequestMsg, SessionState, TokenUsage,
 };
-use crate::usecase::agent_session::status::TurnPhase;
+use crate::usecase::agent_session::status::{SessionNotice, TurnPhase};
 
 pub(crate) struct TauriAgentSessionEventNotifier {
     app: tauri::AppHandle,
@@ -95,6 +95,10 @@ struct AgentPendingMessageConsumedPayload {
 }
 
 impl AgentSessionEventNotifier for TauriAgentSessionEventNotifier {
+    fn persist_notice(&self, notice: SessionNotice) {
+        let _ = self.app.emit("agent-session-notice", notice);
+    }
+
     fn session_state_changed(&self, payload: AgentSessionStateChangedPayload) {
         let _ = self.app.emit(
             "agent-session-state-changed",

--- a/src-tauri/src/adaptor/presenter/agent_status.rs
+++ b/src-tauri/src/adaptor/presenter/agent_status.rs
@@ -155,6 +155,7 @@ mod tests {
             workflow_execution_id: Some("exec-1".to_string()),
             node_execution_id: Some(session_id.to_string()),
             workflow_attempt: Some(1),
+            notice: None,
             workflow_node_progress: Some(progress),
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -339,7 +339,7 @@ pub fn run() {
                     .path()
                     .app_data_dir()
                     .expect("failed to resolve app data directory");
-                app.manage(Arc::new(
+                let runtime_usecase = Arc::new(
                     usecase::agent_session::runtime::AgentSessionRuntimeUsecase::new(
                         runtime_session_store.clone(),
                         runtime_registry,
@@ -351,7 +351,12 @@ pub fn run() {
                         runtime_instruction_source,
                         runtime_data_dir,
                     ),
-                ));
+                );
+                adaptor::controller::event_log_recovery_wiring::register_event_log_recovery_listener(
+                    runtime_session_store.clone(),
+                    &runtime_usecase,
+                );
+                app.manage(runtime_usecase);
                 let stored_lifecycle_registry = app
                     .state::<Arc<usecase::agent_session::backend_registry::AgentBackendRegistry>>()
                     .inner()

--- a/src-tauri/src/test_support/mod.rs
+++ b/src-tauri/src/test_support/mod.rs
@@ -111,7 +111,7 @@ pub(crate) fn build_agent_runtime_usecase_with_controller_and_notifiers(
         controller: controller.clone(),
     }));
     let usecase = Arc::new(AgentSessionRuntimeUsecase::new(
-        session_store,
+        session_store.clone(),
         Arc::new(registry),
         Arc::new(AgentStatusCenter::new()),
         status_notifier,
@@ -121,6 +121,10 @@ pub(crate) fn build_agent_runtime_usecase_with_controller_and_notifiers(
         Arc::new(EmptyInstructionSource),
         data_dir.into(),
     ));
+    crate::adaptor::controller::event_log_recovery_wiring::register_event_log_recovery_listener(
+        session_store,
+        &usecase,
+    );
     (usecase, controller)
 }
 
@@ -129,6 +133,7 @@ pub(crate) struct TestAgentRuntimeController {
     senders: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<AgentRuntimeEvent>>>>,
     calls: Arc<Mutex<Vec<TestRuntimeCall>>>,
     start_turn_gate: Arc<Mutex<Option<Arc<Notify>>>>,
+    open_session_failures: Arc<Mutex<usize>>,
     start_turn_failures: Arc<Mutex<usize>>,
     respond_permission_failures: Arc<Mutex<usize>>,
     steer_failures: Arc<Mutex<usize>>,
@@ -194,6 +199,19 @@ impl TestAgentRuntimeController {
 
     pub(crate) fn fail_next_start_turn(&self) {
         *self.start_turn_failures.lock().unwrap() += 1;
+    }
+
+    pub(crate) fn fail_next_open_session(&self) {
+        *self.open_session_failures.lock().unwrap() += 1;
+    }
+
+    fn should_fail_open_session(&self) -> bool {
+        let mut failures = self.open_session_failures.lock().unwrap();
+        if *failures == 0 {
+            return false;
+        }
+        *failures -= 1;
+        true
     }
 
     fn should_fail_start_turn(&self) -> bool {
@@ -341,6 +359,11 @@ impl AgentBackend for TestAgentBackend {
                 stale_timeout_ms: spec.stale_timeout.map(|value| value.as_millis()),
             },
         );
+        if self.controller.should_fail_open_session() {
+            return Err(AgentBackendError::Other(
+                "injected test open session failure".to_string(),
+            ));
+        }
         self.controller.register(spec.session_id.clone(), sender);
         Ok(Box::new(TestAgentRuntime {
             session_id: spec.session_id,
@@ -534,6 +557,8 @@ impl AgentTaskSpawner for TokioTestAgentTaskSpawner {
 struct NoopAgentSessionEventNotifier;
 
 impl AgentSessionEventNotifier for NoopAgentSessionEventNotifier {
+    fn persist_notice(&self, _notice: crate::usecase::agent_session::status::SessionNotice) {}
+
     fn session_state_changed(&self, _payload: AgentSessionStateChangedPayload) {}
 
     fn stall_observed(&self, _payload: AgentStallObservedPayload) {}

--- a/src-tauri/src/usecase/agent_session/runtime/ports.rs
+++ b/src-tauri/src/usecase/agent_session/runtime/ports.rs
@@ -7,7 +7,7 @@ use crate::usecase::agent_session::session::{
     ChatMessage, ChatSession, ContextCarryState, ModelInfo, PermissionRequestMsg, SessionState,
     TokenUsage,
 };
-use crate::usecase::agent_session::status::TurnPhase;
+use crate::usecase::agent_session::status::{SessionNotice, TurnPhase};
 use crate::usecase::workflow::ports::{
     WorkflowStallClearedNotification, WorkflowStallObservedNotification,
     WorkflowTurnCompleteNotification,
@@ -48,6 +48,8 @@ pub(crate) struct AgentStallObservedPayload {
 }
 
 pub(crate) trait AgentSessionEventNotifier: Send + Sync {
+    fn persist_notice(&self, notice: SessionNotice);
+
     fn session_state_changed(&self, payload: AgentSessionStateChangedPayload);
 
     fn stall_observed(&self, payload: AgentStallObservedPayload);

--- a/src-tauri/src/usecase/agent_session/runtime/usecase.rs
+++ b/src-tauri/src/usecase/agent_session/runtime/usecase.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -36,7 +37,8 @@ use crate::usecase::agent_session::session::{
     SessionStore, SessionSummary, INITIAL_SESSION_PAGE_LIMIT,
 };
 use crate::usecase::agent_session::status::{
-    AgentStatusCenter, AgentStatusNotifier, SessionStatus, TurnPhase, TurnPhaseRepr,
+    AgentStatusCenter, AgentStatusNotifier, SessionNotice, SessionNoticeKind, SessionStatus,
+    TurnPhase, TurnPhaseRepr,
 };
 use crate::usecase::agent_session::system_prompt::{
     build_session_system_prompt, persist_session_system_prompt_build,
@@ -248,6 +250,89 @@ struct RuntimeContext {
     workflow_stall_notifier: Arc<RwLock<Option<Arc<dyn WorkflowStallNotifier>>>>,
 }
 
+const PERSIST_MAX_ATTEMPTS: usize = 4;
+const PERSIST_RETRY_BACKOFFS: [Duration; PERSIST_MAX_ATTEMPTS - 1] = [
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(200),
+];
+
+#[derive(Debug, Clone, Copy)]
+enum PersistFailureKind {
+    ReopenRuntime,
+    QueuedTurnInterrupt,
+    FinalPartsRecorded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PersistenceLogRecord {
+    EventLogRecovered {
+        session_id: String,
+        kind: &'static str,
+    },
+    PersistFailure {
+        session_id: String,
+        kind: &'static str,
+        attempts: usize,
+        error: String,
+    },
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static PERSISTENCE_LOG_RECORDS: std::cell::RefCell<Vec<PersistenceLogRecord>> =
+        std::cell::RefCell::new(Vec::new());
+}
+
+fn emit_persistence_log_record(record: PersistenceLogRecord) {
+    match &record {
+        PersistenceLogRecord::EventLogRecovered { session_id, kind } => {
+            log::warn!("agent_session_persist_notice session_id={session_id} kind={kind}");
+        }
+        PersistenceLogRecord::PersistFailure {
+            session_id,
+            kind,
+            attempts,
+            error,
+        } => {
+            log::error!(
+                "agent_session_persist_failure session_id={session_id} kind={kind} attempts={attempts} error={error}"
+            );
+        }
+    }
+    #[cfg(test)]
+    PERSISTENCE_LOG_RECORDS.with(|records| records.borrow_mut().push(record));
+}
+
+#[cfg(test)]
+fn take_persistence_log_records() -> Vec<PersistenceLogRecord> {
+    PERSISTENCE_LOG_RECORDS.with(|records| std::mem::take(&mut *records.borrow_mut()))
+}
+
+impl PersistFailureKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ReopenRuntime => "reopen_runtime",
+            Self::QueuedTurnInterrupt => "queued_turn_interrupt",
+            Self::FinalPartsRecorded => "final_parts_recorded",
+        }
+    }
+
+    fn notice_message(self) -> &'static str {
+        match self {
+            Self::ReopenRuntime => {
+                "Failed to save the session error state after retrying."
+            }
+            Self::QueuedTurnInterrupt => {
+                "Failed to save the queued turn failure after retrying."
+            }
+            Self::FinalPartsRecorded => {
+                "Failed to save the completed response after retrying. The existing response body was preserved."
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 struct StalledActiveTurnTarget {
     runtime: Arc<dyn AgentSessionRuntime>,
@@ -287,6 +372,15 @@ impl AgentSessionRuntimeUsecase {
                 workflow_stall_notifier: Arc::new(RwLock::new(None)),
             },
         }
+    }
+
+    pub(crate) fn report_event_log_recovered(&self, session_id: &str) {
+        report_event_log_recovered(
+            &self.ctx.status_center,
+            &self.ctx.status_notifier,
+            &self.ctx.notifier,
+            session_id,
+        );
     }
 
     pub fn set_workflow_turn_complete_notifier(
@@ -1301,6 +1395,17 @@ impl AgentSessionRuntimeUsecase {
     }
 
     #[cfg(test)]
+    pub(crate) async fn prepare_queued_runtime_reopen_for_test(&self, session_id: &str) {
+        let mut sessions = self.ctx.sessions.lock().await;
+        let state = sessions
+            .get_mut(session_id)
+            .expect("queued runtime state must exist");
+        assert!(!state.pending_queue.is_empty());
+        state.runtime = None;
+        state.phase = RuntimeSessionPhase::Idle;
+    }
+
+    #[cfg(test)]
     pub(crate) async fn stream_emit_failure_state_for_test(
         &self,
         session_id: &str,
@@ -1809,6 +1914,127 @@ impl AgentSessionRuntimeUsecase {
         .map_err(AgentRuntimeError::Other)?;
         Ok(prompt)
     }
+}
+
+fn publish_session_notice(
+    status_center: &Arc<AgentStatusCenter>,
+    status_notifier: &Arc<dyn AgentStatusNotifier>,
+    notifier: &Arc<dyn AgentSessionEventNotifier>,
+    notice: SessionNotice,
+) {
+    status_notifier.status_changed(status_center.record_session_notice(notice.clone()));
+    notifier.persist_notice(notice);
+}
+
+fn report_event_log_recovered(
+    status_center: &Arc<AgentStatusCenter>,
+    status_notifier: &Arc<dyn AgentStatusNotifier>,
+    notifier: &Arc<dyn AgentSessionEventNotifier>,
+    session_id: &str,
+) {
+    emit_persistence_log_record(PersistenceLogRecord::EventLogRecovered {
+        session_id: session_id.to_string(),
+        kind: "event_log_recovered",
+    });
+    publish_session_notice(
+        status_center,
+        status_notifier,
+        notifier,
+        SessionNotice {
+            session_id: session_id.to_string(),
+            kind: SessionNoticeKind::EventLogRecovered,
+            message: "Recovered a damaged session event log. New messages can be saved again."
+                .to_string(),
+            created_at: crate::usecase::agent_session::session::now_timestamp(),
+        },
+    );
+}
+
+fn report_persist_failure(
+    ctx: &RuntimeContext,
+    session_id: &str,
+    kind: PersistFailureKind,
+    error: &str,
+) {
+    emit_persistence_log_record(PersistenceLogRecord::PersistFailure {
+        session_id: session_id.to_string(),
+        kind: kind.as_str(),
+        attempts: PERSIST_MAX_ATTEMPTS,
+        error: error.to_string(),
+    });
+    publish_session_notice(
+        &ctx.status_center,
+        &ctx.status_notifier,
+        &ctx.notifier,
+        SessionNotice {
+            session_id: session_id.to_string(),
+            kind: SessionNoticeKind::PersistFailure,
+            message: kind.notice_message().to_string(),
+            created_at: crate::usecase::agent_session::session::now_timestamp(),
+        },
+    );
+}
+
+fn clear_persist_failure(ctx: &RuntimeContext, session_id: &str) {
+    let changes = ctx
+        .status_center
+        .clear_session_notice(session_id, SessionNoticeKind::PersistFailure);
+    if !changes.is_empty() {
+        ctx.status_notifier.status_changed(changes);
+    }
+}
+
+async fn persist_with_retry<T>(
+    ctx: &RuntimeContext,
+    session_id: &str,
+    kind: PersistFailureKind,
+    mut operation: impl FnMut() -> Result<T, String>,
+) -> Result<T, String> {
+    let mut last_error = None;
+    for attempt in 1..=PERSIST_MAX_ATTEMPTS {
+        match operation() {
+            Ok(value) => {
+                clear_persist_failure(ctx, session_id);
+                return Ok(value);
+            }
+            Err(error) => {
+                log::warn!(
+                    "agent_session_persist_retry session_id={} kind={} attempt={} max_attempts={} error={}",
+                    session_id,
+                    kind.as_str(),
+                    attempt,
+                    PERSIST_MAX_ATTEMPTS,
+                    error
+                );
+                last_error = Some(error);
+                if let Some(backoff) = PERSIST_RETRY_BACKOFFS.get(attempt - 1) {
+                    tokio::time::sleep(*backoff).await;
+                }
+            }
+        }
+    }
+    let error = last_error.expect("persist retry must execute at least once");
+    report_persist_failure(ctx, session_id, kind, &error);
+    Err(error)
+}
+
+async fn append_session_event_and_project_state_with_retry(
+    ctx: &RuntimeContext,
+    session_id: &str,
+    kind: PersistFailureKind,
+    event: AgentSessionEvent,
+) -> Result<SessionState, String> {
+    let projected_state = persist_with_retry(ctx, session_id, kind, || {
+        ctx.session_store
+            .append_session_event_and_project(&ctx.data_dir, session_id, event.clone())
+    })
+    .await?;
+    persist_with_retry(ctx, session_id, kind, || {
+        ctx.session_store
+            .set_session_state(&ctx.data_dir, session_id, projected_state.clone())
+    })
+    .await?;
+    Ok(projected_state)
 }
 
 #[cfg(not(test))]
@@ -3285,17 +3511,14 @@ async fn complete_turn(
     };
     let mut projected = None;
     if let (Some(turn_id), Some(message_id)) = (turn_id, message_id.clone()) {
-        if let Err(error) = append_final_turn_events(
-            &ctx.session_store,
-            &ctx.data_dir,
-            session_id,
-            turn_id,
-            &message_id,
-            &parts,
-            &terminal,
-        ) {
+        let final_events_persisted = if let Err(error) =
+            append_final_turn_events(ctx, session_id, turn_id, &message_id, &parts, &terminal).await
+        {
             log::warn!("failed to record terminal turn events for {session_id}: {error}");
-        }
+            false
+        } else {
+            true
+        };
         projected = ctx
             .session_store
             .load_session_events(&ctx.data_dir, session_id)
@@ -3305,11 +3528,15 @@ async fn complete_turn(
                 error
             })
             .ok();
-        let parts_to_persist = projected
-            .as_ref()
-            .map(|model| model.agent_parts_for_message(&message_id))
-            .filter(|parts| !parts.is_empty())
-            .unwrap_or_else(|| parts.clone());
+        let parts_to_persist = if final_events_persisted {
+            projected
+                .as_ref()
+                .map(|model| model.agent_parts_for_message(&message_id))
+                .filter(|parts| !parts.is_empty())
+                .unwrap_or_else(|| parts.clone())
+        } else {
+            parts.clone()
+        };
         if let Err(error) = ctx.session_store.persist_message_parts(
             &ctx.data_dir,
             session_id,
@@ -3437,11 +3664,20 @@ async fn start_next_queued_turn(ctx: &RuntimeContext, session_id: &str) {
             Ok(runtime) => runtime,
             Err(error) => {
                 log::warn!("failed to reopen runtime for queued turn {session_id}: {error}");
-                let _ = ctx.session_store.set_session_state(
-                    &ctx.data_dir,
-                    session_id,
-                    SessionState::Error,
-                );
+                if let Err(persist_error) =
+                    persist_with_retry(ctx, session_id, PersistFailureKind::ReopenRuntime, || {
+                        ctx.session_store.set_session_state(
+                            &ctx.data_dir,
+                            session_id,
+                            SessionState::Error,
+                        )
+                    })
+                    .await
+                {
+                    log::error!(
+                        "failed to persist queued runtime reopen error for {session_id}: {persist_error}"
+                    );
+                }
                 emit_session_state_change(
                     &ctx.session_store,
                     &ctx.notifier,
@@ -3593,16 +3829,23 @@ async fn start_next_queued_turn(ctx: &RuntimeContext, session_id: &str) {
                 }
             }
         }
-        let _ = ctx.session_store.append_session_event_and_project_state(
-            &ctx.data_dir,
+        if let Err(persist_error) = append_session_event_and_project_state_with_retry(
+            ctx,
             session_id,
+            PersistFailureKind::QueuedTurnInterrupt,
             AgentSessionEvent::TurnInterrupted {
                 turn_id,
                 reason: EventInterruptReason::Crash,
                 exit_code: 1,
                 error: Some(error.to_string()),
             },
-        );
+        )
+        .await
+        {
+            log::error!(
+                "failed to persist queued turn interruption for {session_id}: {persist_error}"
+            );
+        }
         emit_session_state_change(
             &ctx.session_store,
             &ctx.notifier,
@@ -4123,42 +4366,47 @@ async fn resync_permission_mode(
     Some(saved_mode)
 }
 
-fn append_final_turn_events(
-    session_store: &Arc<SessionStore>,
-    data_dir: &Path,
+async fn append_final_turn_events(
+    ctx: &RuntimeContext,
     session_id: &str,
     turn_id: u64,
     message_id: &str,
     parts: &[MessagePart],
     terminal: &TerminalProjection,
 ) -> Result<(), String> {
-    session_store.append_session_event_and_project_state(
-        data_dir,
+    append_session_event_and_project_state_with_retry(
+        ctx,
         session_id,
+        PersistFailureKind::FinalPartsRecorded,
         AgentSessionEvent::FinalPartsRecorded {
             turn_id,
             message_id: message_id.to_string(),
             parts: parts.to_vec(),
         },
-    )?;
+    )
+    .await?;
     match &terminal.event {
         TerminalEventProjection::Completed {
             stop_reason,
             token_usage,
         } => {
-            session_store.append_session_event_and_project_state(
-                data_dir,
+            append_session_event_and_project_state_with_retry(
+                ctx,
                 session_id,
+                PersistFailureKind::FinalPartsRecorded,
                 AgentSessionEvent::TurnCompleted {
                     turn_id,
                     exit_code: terminal.exit_code,
                     stop_reason: *stop_reason,
                     token_usage: *token_usage,
                 },
-            )?;
+            )
+            .await?;
         }
         TerminalEventProjection::Interrupted { reason, error } => {
-            let mut events = session_store.load_session_events(data_dir, session_id)?;
+            let mut events = ctx
+                .session_store
+                .load_session_events(&ctx.data_dir, session_id)?;
             let before = events.len();
             finalize_turn(
                 &mut events,
@@ -4168,8 +4416,13 @@ fn append_final_turn_events(
                 terminal.exit_code,
             );
             for event in events.into_iter().skip(before) {
-                session_store
-                    .append_session_event_and_project_state(data_dir, session_id, event)?;
+                append_session_event_and_project_state_with_retry(
+                    ctx,
+                    session_id,
+                    PersistFailureKind::FinalPartsRecorded,
+                    event,
+                )
+                .await?;
             }
         }
     }
@@ -4364,6 +4617,7 @@ fn publish_status_change(
             .as_ref()
             .map(|context| context.node_execution_id.clone()),
         workflow_attempt: workflow_context.as_ref().map(|context| context.attempt),
+        notice: None,
         workflow_node_progress: None,
     };
     status_notifier.status_changed(status_center.update_session(status));
@@ -4695,6 +4949,7 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingAgentNotifier {
+        notices: Mutex<Vec<SessionNotice>>,
         state_changes: Mutex<Vec<AgentSessionStateChangedPayload>>,
         stall_observations: Mutex<Vec<AgentStallObservedPayload>>,
         stall_clears: Mutex<Vec<String>>,
@@ -4706,6 +4961,10 @@ mod tests {
     }
 
     impl RecordingAgentNotifier {
+        fn notices(&self) -> Vec<SessionNotice> {
+            self.notices.lock().unwrap().clone()
+        }
+
         fn state_changes(&self) -> Vec<AgentSessionStateChangedPayload> {
             self.state_changes.lock().unwrap().clone()
         }
@@ -4740,6 +4999,10 @@ mod tests {
     }
 
     impl AgentSessionEventNotifier for RecordingAgentNotifier {
+        fn persist_notice(&self, notice: SessionNotice) {
+            self.notices.lock().unwrap().push(notice);
+        }
+
         fn session_state_changed(&self, payload: AgentSessionStateChangedPayload) {
             self.state_changes.lock().unwrap().push(payload);
         }
@@ -6079,6 +6342,412 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn damaged_event_log_is_recovered_and_next_message_send_succeeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let event_notifier = Arc::new(RecordingAgentNotifier::default());
+        let status_notifier = Arc::new(RecordingStatusNotifier::default());
+        let (usecase, controller) = build_agent_runtime_usecase_with_controller_and_notifiers(
+            session_store.clone(),
+            tmp.path(),
+            event_notifier.clone(),
+            status_notifier,
+        );
+        let first = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = first.session.id;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::TurnCompleted(TurnResult::Completed {
+                    stop_reason: None,
+                    token_usage: None,
+                }),
+            )
+            .unwrap();
+        wait_for_turn_phase(&usecase, &session_id, TurnPhase::Idle).await;
+        let event_log_path = tmp
+            .path()
+            .join("sessions")
+            .join(&session_id)
+            .join("events.json");
+        let content = std::fs::read_to_string(&event_log_path).unwrap();
+        let closing_pos = content.rfind(']').expect("event log closing bracket");
+        std::fs::write(&event_log_path, &content[..closing_pos]).unwrap();
+        take_persistence_log_records();
+
+        let second = usecase
+            .send_message(SendAgentMessageRequest {
+                chat_session_id: Some(session_id.clone()),
+                worktree_path: tmp.path().to_string_lossy().to_string(),
+                content: "continue after recovery".to_string(),
+                permission_mode: PermissionMode::Edit,
+                plan_mode: false,
+                backend_id: Some("claude".to_string()),
+                model_id: None,
+                images: None,
+                mentions: None,
+                editor_context: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(second.agent_message.is_some());
+        assert!(event_notifier.notices().iter().any(|notice| {
+            notice.session_id == session_id && notice.kind == SessionNoticeKind::EventLogRecovered
+        }));
+        let repaired_events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert!(repaired_events
+            .iter()
+            .any(|event| matches!(event, AgentSessionEvent::TurnStarted { turn_id: 2, .. })));
+        let records = take_persistence_log_records();
+        assert!(records.iter().any(|record| matches!(
+            record,
+            PersistenceLogRecord::EventLogRecovered {
+                session_id: logged_session_id,
+                kind: "event_log_recovered",
+            } if logged_session_id == &session_id
+        )));
+    }
+
+    #[tokio::test]
+    async fn reopen_runtime_persist_failure_retries_reports_and_returns_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let event_notifier = Arc::new(RecordingAgentNotifier::default());
+        let status_notifier = Arc::new(RecordingStatusNotifier::default());
+        let (usecase, _controller) = build_agent_runtime_usecase_with_controller_and_notifiers(
+            session_store.clone(),
+            tmp.path(),
+            event_notifier.clone(),
+            status_notifier,
+        );
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        session_store.set_state_hook_for_test({
+            let attempts = attempts.clone();
+            Arc::new(move |_, _| {
+                attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err("injected session state failure".to_string())
+            })
+        });
+        take_persistence_log_records();
+
+        let result = persist_with_retry(
+            &usecase.ctx,
+            &session_id,
+            PersistFailureKind::ReopenRuntime,
+            || session_store.set_session_state(tmp.path(), &session_id, SessionState::Error),
+        )
+        .await;
+
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            PERSIST_MAX_ATTEMPTS
+        );
+        assert_eq!(result.unwrap_err(), "injected session state failure");
+        assert!(event_notifier.notices().iter().any(|notice| {
+            notice.session_id == session_id && notice.kind == SessionNoticeKind::PersistFailure
+        }));
+        assert_eq!(
+            usecase
+                .ctx
+                .status_center
+                .get_session(&session_id)
+                .and_then(|status| status.notice)
+                .map(|notice| notice.kind),
+            Some(SessionNoticeKind::PersistFailure)
+        );
+        let records = take_persistence_log_records();
+        assert!(records.iter().any(|record| matches!(
+            record,
+            PersistenceLogRecord::PersistFailure {
+                session_id: logged_session_id,
+                kind: "reopen_runtime",
+                attempts: PERSIST_MAX_ATTEMPTS,
+                error,
+            } if logged_session_id == &session_id && error == "injected session state failure"
+        )));
+    }
+
+    #[tokio::test]
+    async fn queued_runtime_reopen_failure_retries_and_stays_visible() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let event_notifier = Arc::new(RecordingAgentNotifier::default());
+        let status_notifier = Arc::new(RecordingStatusNotifier::default());
+        let (usecase, controller) = build_agent_runtime_usecase_with_controller_and_notifiers(
+            session_store.clone(),
+            tmp.path(),
+            event_notifier.clone(),
+            status_notifier.clone(),
+        );
+        let session_id = enqueue_second_turn_for_test(
+            &usecase,
+            &controller,
+            tmp.path().to_string_lossy().to_string(),
+        )
+        .await;
+        usecase
+            .prepare_queued_runtime_reopen_for_test(&session_id)
+            .await;
+        controller.fail_next_open_session();
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        session_store.set_state_hook_for_test({
+            let attempts = attempts.clone();
+            Arc::new(move |_, state| {
+                if *state == SessionState::Error {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    return Err("injected queued reopen state failure".to_string());
+                }
+                Ok(())
+            })
+        });
+        take_persistence_log_records();
+
+        usecase.drain_next_queued_turn_for_test(&session_id).await;
+
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            PERSIST_MAX_ATTEMPTS
+        );
+        assert_eq!(usecase.pending_queue(&session_id).await.len(), 1);
+        assert_eq!(usecase.turn_phase(&session_id).await, Some(TurnPhase::Idle));
+        assert_eq!(
+            controller
+                .call_kinds_for(&session_id)
+                .iter()
+                .filter(|kind| matches!(kind, TestRuntimeCallKind::OpenSession { .. }))
+                .count(),
+            2
+        );
+        assert_eq!(
+            controller
+                .call_kinds_for(&session_id)
+                .iter()
+                .filter(|kind| matches!(kind, TestRuntimeCallKind::StartTurnPrompt { .. }))
+                .count(),
+            1
+        );
+        assert!(event_notifier.notices().iter().any(|notice| {
+            notice.session_id == session_id && notice.kind == SessionNoticeKind::PersistFailure
+        }));
+        assert!(event_notifier.state_changes().iter().any(|change| {
+            change.chat_session_id == session_id
+                && change.turn_phase == TurnPhase::Idle
+                && change.session_state == Some(SessionState::Error)
+        }));
+        let snapshot = usecase
+            .ctx
+            .status_center
+            .get_session(&session_id)
+            .expect("status snapshot");
+        assert_eq!(snapshot.session_state, SessionState::Error);
+        assert_eq!(
+            snapshot.notice.map(|notice| notice.kind),
+            Some(SessionNoticeKind::PersistFailure)
+        );
+        assert!(status_notifier.changes().iter().any(|changes| {
+            changes.session.as_ref().is_some_and(|status| {
+                status.chat_session_id == session_id
+                    && status
+                        .notice
+                        .as_ref()
+                        .is_some_and(|notice| notice.kind == SessionNoticeKind::PersistFailure)
+            })
+        }));
+        assert_eq!(
+            session_store
+                .get_session_shell(tmp.path(), &session_id)
+                .unwrap()
+                .expect("durable session")
+                .state,
+            SessionState::Active
+        );
+        let records = take_persistence_log_records();
+        assert!(records.iter().any(|record| matches!(
+            record,
+            PersistenceLogRecord::PersistFailure {
+                session_id: logged_session_id,
+                kind: "reopen_runtime",
+                attempts: PERSIST_MAX_ATTEMPTS,
+                error,
+            } if logged_session_id == &session_id
+                && error == "injected queued reopen state failure"
+        )));
+    }
+
+    #[tokio::test]
+    async fn transient_persist_failure_recovers_without_notice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let event_notifier = Arc::new(RecordingAgentNotifier::default());
+        let status_notifier = Arc::new(RecordingStatusNotifier::default());
+        let (usecase, _controller) = build_agent_runtime_usecase_with_controller_and_notifiers(
+            session_store.clone(),
+            tmp.path(),
+            event_notifier.clone(),
+            status_notifier,
+        );
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        session_store.set_state_hook_for_test({
+            let attempts = attempts.clone();
+            Arc::new(move |_, _| {
+                if attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                    Err("transient session state failure".to_string())
+                } else {
+                    Ok(())
+                }
+            })
+        });
+
+        persist_with_retry(
+            &usecase.ctx,
+            &session_id,
+            PersistFailureKind::ReopenRuntime,
+            || session_store.set_session_state(tmp.path(), &session_id, SessionState::Error),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert!(event_notifier.notices().is_empty());
+    }
+
+    #[tokio::test]
+    async fn successful_persist_clears_previous_failure_notice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let event_notifier = Arc::new(RecordingAgentNotifier::default());
+        let status_notifier = Arc::new(RecordingStatusNotifier::default());
+        let (usecase, _controller) = build_agent_runtime_usecase_with_controller_and_notifiers(
+            session_store.clone(),
+            tmp.path(),
+            event_notifier,
+            status_notifier.clone(),
+        );
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        session_store.set_state_hook_for_test(Arc::new(|_, _| {
+            Err("injected session state failure".to_string())
+        }));
+        persist_with_retry(
+            &usecase.ctx,
+            &session_id,
+            PersistFailureKind::ReopenRuntime,
+            || session_store.set_session_state(tmp.path(), &session_id, SessionState::Error),
+        )
+        .await
+        .unwrap_err();
+        assert!(usecase
+            .ctx
+            .status_center
+            .get_session(&session_id)
+            .and_then(|status| status.notice)
+            .is_some());
+
+        session_store.set_state_hook_for_test(Arc::new(|_, _| Ok(())));
+        persist_with_retry(
+            &usecase.ctx,
+            &session_id,
+            PersistFailureKind::ReopenRuntime,
+            || session_store.set_session_state(tmp.path(), &session_id, SessionState::Error),
+        )
+        .await
+        .unwrap();
+
+        assert!(usecase
+            .ctx
+            .status_center
+            .get_session(&session_id)
+            .and_then(|status| status.notice)
+            .is_none());
+        assert!(status_notifier.changes().iter().any(|changes| {
+            changes.session.as_ref().is_some_and(|status| {
+                status.chat_session_id == session_id && status.notice.is_none()
+            })
+        }));
+    }
+
+    #[tokio::test]
+    async fn projection_retry_does_not_append_event_twice_after_partial_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let event_notifier = Arc::new(RecordingAgentNotifier::default());
+        let status_notifier = Arc::new(RecordingStatusNotifier::default());
+        let (usecase, _controller) = build_agent_runtime_usecase_with_controller_and_notifiers(
+            session_store.clone(),
+            tmp.path(),
+            event_notifier,
+            status_notifier,
+        );
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let state_attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        session_store.set_state_hook_for_test({
+            let state_attempts = state_attempts.clone();
+            Arc::new(move |_, _| {
+                state_attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err("injected post-append projection failure".to_string())
+            })
+        });
+        let event = AgentSessionEvent::FinalPartsRecorded {
+            turn_id: 1,
+            message_id: "agent-message".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "durable once".to_string(),
+                parent_tool_use_id: None,
+            }],
+        };
+
+        let result = append_session_event_and_project_state_with_retry(
+            &usecase.ctx,
+            &session_id,
+            PersistFailureKind::FinalPartsRecorded,
+            event.clone(),
+        )
+        .await;
+
+        assert_eq!(
+            result.unwrap_err(),
+            "injected post-append projection failure"
+        );
+        assert_eq!(
+            state_attempts.load(std::sync::atomic::Ordering::SeqCst),
+            PERSIST_MAX_ATTEMPTS
+        );
+        let events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|candidate| **candidate == event)
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn queued_turn_append_message_failure_preserves_queue_and_retries() {
         let tmp = tempfile::tempdir().unwrap();
         let session_store = Arc::new(build_session_store());
@@ -6209,6 +6878,267 @@ mod tests {
         usecase.drain_next_queued_turn_for_test(&session_id).await;
         wait_for_start_prompt_count(&controller, &session_id, 3).await;
         assert!(usecase.pending_queue(&session_id).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn queued_turn_interrupt_append_retries_then_reports() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let event_notifier = Arc::new(RecordingAgentNotifier::default());
+        let status_notifier = Arc::new(RecordingStatusNotifier::default());
+        let (usecase, controller) = build_agent_runtime_usecase_with_controller_and_notifiers(
+            session_store.clone(),
+            tmp.path(),
+            event_notifier.clone(),
+            status_notifier,
+        );
+        let session_id = enqueue_second_turn_for_test(
+            &usecase,
+            &controller,
+            tmp.path().to_string_lossy().to_string(),
+        )
+        .await;
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        session_store.set_append_event_hook_for_test({
+            let attempts = attempts.clone();
+            Arc::new(move |_, event| {
+                if matches!(event, AgentSessionEvent::TurnInterrupted { .. }) {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    return Err("injected turn interruption failure".to_string());
+                }
+                Ok(())
+            })
+        });
+        controller.fail_next_start_turn();
+
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::TurnCompleted(TurnResult::Completed {
+                    stop_reason: None,
+                    token_usage: None,
+                }),
+            )
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if attempts.load(std::sync::atomic::Ordering::SeqCst) == PERSIST_MAX_ATTEMPTS
+                    && event_notifier.notices().iter().any(|notice| {
+                        notice.session_id == session_id
+                            && notice.kind == SessionNoticeKind::PersistFailure
+                    })
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("queued interruption persistence should exhaust retries");
+
+        assert_eq!(usecase.pending_queue(&session_id).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn turn_completed_append_failure_retries_and_keeps_notice_visible() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let event_notifier = Arc::new(RecordingAgentNotifier::default());
+        let status_notifier = Arc::new(RecordingStatusNotifier::default());
+        let (usecase, controller) = build_agent_runtime_usecase_with_controller_and_notifiers(
+            session_store.clone(),
+            tmp.path(),
+            event_notifier.clone(),
+            status_notifier.clone(),
+        );
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        session_store.set_append_event_hook_for_test({
+            let attempts = attempts.clone();
+            Arc::new(move |_, event| {
+                if matches!(event, AgentSessionEvent::TurnCompleted { .. }) {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    return Err("injected turn completed failure".to_string());
+                }
+                Ok(())
+            })
+        });
+
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::TurnCompleted(TurnResult::Completed {
+                    stop_reason: None,
+                    token_usage: None,
+                }),
+            )
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if attempts.load(std::sync::atomic::Ordering::SeqCst) == PERSIST_MAX_ATTEMPTS
+                    && event_notifier.notices().iter().any(|notice| {
+                        notice.session_id == session_id
+                            && notice.kind == SessionNoticeKind::PersistFailure
+                    })
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("turn completion persistence should exhaust retries");
+        wait_for_turn_phase(&usecase, &session_id, TurnPhase::Idle).await;
+
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            PERSIST_MAX_ATTEMPTS
+        );
+        let events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, AgentSessionEvent::FinalPartsRecorded { .. })));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, AgentSessionEvent::TurnCompleted { .. })));
+        assert_eq!(
+            usecase
+                .ctx
+                .status_center
+                .get_session(&session_id)
+                .and_then(|status| status.notice)
+                .map(|notice| notice.kind),
+            Some(SessionNoticeKind::PersistFailure)
+        );
+        assert!(status_notifier.changes().iter().any(|changes| {
+            changes.session.as_ref().is_some_and(|status| {
+                status.chat_session_id == session_id
+                    && status
+                        .notice
+                        .as_ref()
+                        .is_some_and(|notice| notice.kind == SessionNoticeKind::PersistFailure)
+            })
+        }));
+    }
+
+    #[tokio::test]
+    async fn final_parts_append_failure_keeps_body_not_tool_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let event_notifier = Arc::new(RecordingAgentNotifier::default());
+        let status_notifier = Arc::new(RecordingStatusNotifier::default());
+        let (usecase, controller) = build_agent_runtime_usecase_with_controller_and_notifiers(
+            session_store.clone(),
+            tmp.path(),
+            event_notifier.clone(),
+            status_notifier,
+        );
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::PartsMerged(vec![
+                    DomainMessagePart::Text {
+                        content: "persisted response body".to_string(),
+                        parent_tool_use_id: None,
+                    },
+                    DomainMessagePart::ToolUse {
+                        id: "tool-1".to_string(),
+                        tool: "Bash".to_string(),
+                        input:
+                            crate::domain::agent_session::value_objects::JsonPayload::new_unchecked(
+                                "{}".to_string(),
+                            ),
+                        parent_tool_use_id: None,
+                    },
+                ]),
+            )
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let parts = usecase.streaming_parts(&session_id).await;
+                if parts
+                    .iter()
+                    .any(|part| matches!(part, MessagePart::Text { .. }))
+                    && parts
+                        .iter()
+                        .any(|part| matches!(part, MessagePart::ToolUse { .. }))
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("streaming body and tool part should be applied");
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        session_store.set_append_event_hook_for_test({
+            let attempts = attempts.clone();
+            Arc::new(move |_, event| {
+                if matches!(event, AgentSessionEvent::FinalPartsRecorded { .. }) {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    return Err("injected final parts failure".to_string());
+                }
+                Ok(())
+            })
+        });
+
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::TurnCompleted(TurnResult::Completed {
+                    stop_reason: None,
+                    token_usage: None,
+                }),
+            )
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if attempts.load(std::sync::atomic::Ordering::SeqCst) == PERSIST_MAX_ATTEMPTS
+                    && event_notifier.notices().iter().any(|notice| {
+                        notice.session_id == session_id
+                            && notice.kind == SessionNoticeKind::PersistFailure
+                    })
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("final parts persistence should exhaust retries");
+        wait_for_turn_phase(&usecase, &session_id, TurnPhase::Idle).await;
+
+        let fresh_store = build_session_store();
+        let reloaded = fresh_store
+            .load_full_session_for_restore(tmp.path(), &session_id)
+            .unwrap()
+            .expect("reloaded session");
+        let agent_parts = reloaded
+            .messages
+            .iter()
+            .rev()
+            .find(|message| message.role == MessageRole::Agent)
+            .and_then(|message| message.parts.as_ref())
+            .expect("agent message parts");
+        assert!(agent_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Text { content, .. } if content == "persisted response body"
+        )));
+        assert!(agent_parts
+            .iter()
+            .any(|part| matches!(part, MessagePart::ToolUse { .. })));
     }
 
     #[tokio::test]

--- a/src-tauri/src/usecase/agent_session/session/mod.rs
+++ b/src-tauri/src/usecase/agent_session/session/mod.rs
@@ -45,6 +45,7 @@ pub(crate) use read_paths::{
     agent_read_paths_from_message, agent_read_paths_from_messages, agent_read_paths_from_parts,
     merge_agent_read_paths,
 };
+pub(crate) use store::SessionEventLogRecoverySignal;
 pub use store::{SessionReaderPort, SessionReviewContextReader, SessionStore};
 pub(crate) use stored_lifecycle::{
     AgentSessionBackendLifecycleGateway, AgentSessionRuntimeCloser, BackendSessionLifecycleRequest,

--- a/src-tauri/src/usecase/agent_session/session/store.rs
+++ b/src-tauri/src/usecase/agent_session/session/store.rs
@@ -21,6 +21,7 @@ use super::{
 /// 引数は `(session_id, worktree_path, new_state)`。
 pub type SessionStateChangeListener =
     Arc<dyn Fn(&str, &str, &SessionState) + Send + Sync + 'static>;
+pub type SessionEventLogRecoveryListener = Arc<dyn Fn(&str) + Send + Sync + 'static>;
 
 pub trait SessionReviewContextReader: Send + Sync {
     fn get_session_review_context(
@@ -28,6 +29,12 @@ pub trait SessionReviewContextReader: Send + Sync {
         app_data_dir: &Path,
         session_id: &str,
     ) -> Result<Option<SessionReviewContext>, String>;
+}
+
+/// Gateway が物理 event log を修復した事実を usecase へ一度だけ伝える signal。
+/// 修復方式や storage format は domain の writer API へ露出させない。
+pub(crate) trait SessionEventLogRecoverySignal: Send + Sync {
+    fn take_event_log_recovered(&self, session_id: &str) -> bool;
 }
 
 pub trait SessionStoragePort:
@@ -42,6 +49,7 @@ pub trait SessionStoragePort:
         ToolOutput = SessionToolOutput,
         Event = AgentSessionEvent,
     > + SessionReviewContextReader
+    + SessionEventLogRecoverySignal
     + Send
     + Sync
 {
@@ -59,6 +67,7 @@ impl<T> SessionStoragePort for T where
             ToolOutput = SessionToolOutput,
             Event = AgentSessionEvent,
         > + SessionReviewContextReader
+        + SessionEventLogRecoverySignal
         + Send
         + Sync
 {
@@ -91,10 +100,14 @@ pub(crate) type SessionPersistPartsHook =
 #[cfg(test)]
 pub(crate) type SessionAppendEventHook =
     Arc<dyn Fn(&str, &AgentSessionEvent) -> Result<(), String> + Send + Sync>;
+#[cfg(test)]
+pub(crate) type SessionSetStateHook =
+    Arc<dyn Fn(&str, &SessionState) -> Result<(), String> + Send + Sync>;
 
 pub struct SessionStore {
     storage: Arc<dyn SessionStoragePort>,
     state_change_listeners: RwLock<Vec<SessionStateChangeListener>>,
+    event_log_recovery_listeners: RwLock<Vec<SessionEventLogRecoveryListener>>,
     #[cfg(test)]
     save_hook: RwLock<Option<SessionSaveHook>>,
     #[cfg(test)]
@@ -103,6 +116,8 @@ pub struct SessionStore {
     persist_parts_hook: RwLock<Option<SessionPersistPartsHook>>,
     #[cfg(test)]
     append_event_hook: RwLock<Option<SessionAppendEventHook>>,
+    #[cfg(test)]
+    set_state_hook: RwLock<Option<SessionSetStateHook>>,
 }
 
 fn compact_session_title(title: &str) -> String {
@@ -217,6 +232,7 @@ impl SessionStore {
         Self {
             storage,
             state_change_listeners: RwLock::new(Vec::new()),
+            event_log_recovery_listeners: RwLock::new(Vec::new()),
             #[cfg(test)]
             save_hook: RwLock::new(None),
             #[cfg(test)]
@@ -225,6 +241,8 @@ impl SessionStore {
             persist_parts_hook: RwLock::new(None),
             #[cfg(test)]
             append_event_hook: RwLock::new(None),
+            #[cfg(test)]
+            set_state_hook: RwLock::new(None),
         }
     }
 
@@ -246,6 +264,11 @@ impl SessionStore {
     #[cfg(test)]
     pub(crate) fn set_append_event_hook_for_test(&self, hook: SessionAppendEventHook) {
         *self.append_event_hook.write() = Some(hook);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_state_hook_for_test(&self, hook: SessionSetStateHook) {
+        *self.set_state_hook.write() = Some(hook);
     }
 
     pub fn list_sessions(
@@ -469,6 +492,18 @@ impl SessionStore {
         session_id: &str,
         event: AgentSessionEvent,
     ) -> Result<SessionState, String> {
+        let projected_state =
+            self.append_session_event_and_project(app_data_dir, session_id, event)?;
+        self.set_session_state(app_data_dir, session_id, projected_state.clone())?;
+        Ok(projected_state)
+    }
+
+    pub fn append_session_event_and_project(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        event: AgentSessionEvent,
+    ) -> Result<SessionState, String> {
         #[cfg(test)]
         if let Some(hook) = self.append_event_hook.read().clone() {
             hook(session_id, &event)?;
@@ -476,11 +511,13 @@ impl SessionStore {
         let events = self
             .storage
             .append_session_event(app_data_dir, session_id, &event)?;
+        if self.storage.take_event_log_recovered(session_id) {
+            self.notify_event_log_recovered(session_id);
+        }
         let projected_state = TurnEventLog::from_events(events)
             .project()
             .status
             .session_state;
-        self.set_session_state(app_data_dir, session_id, projected_state.clone())?;
         Ok(projected_state)
     }
 
@@ -495,7 +532,11 @@ impl SessionStore {
             hook(session_id, &event)?;
         }
         self.storage
-            .append_session_event_without_projection(app_data_dir, session_id, &event)
+            .append_session_event_without_projection(app_data_dir, session_id, &event)?;
+        if self.storage.take_event_log_recovered(session_id) {
+            self.notify_event_log_recovered(session_id);
+        }
+        Ok(())
     }
 
     pub fn load_previous_human_message_before_agent(
@@ -608,10 +649,21 @@ impl SessionStore {
         self.state_change_listeners.write().push(listener);
     }
 
+    pub fn register_event_log_recovery_listener(&self, listener: SessionEventLogRecoveryListener) {
+        self.event_log_recovery_listeners.write().push(listener);
+    }
+
     fn notify_state_change(&self, session_id: &str, worktree_path: &str, new_state: &SessionState) {
         let listeners = self.state_change_listeners.read().clone();
         for listener in listeners {
             listener(session_id, worktree_path, new_state);
+        }
+    }
+
+    fn notify_event_log_recovered(&self, session_id: &str) {
+        let listeners = self.event_log_recovery_listeners.read().clone();
+        for listener in listeners {
+            listener(session_id);
         }
     }
 
@@ -680,6 +732,10 @@ impl SessionStore {
         session_id: &str,
         state: SessionState,
     ) -> Result<(), String> {
+        #[cfg(test)]
+        if let Some(hook) = self.set_state_hook.read().clone() {
+            hook(session_id, &state)?;
+        }
         let state_for_notify = state.clone();
         let change = self.update_meta_only(app_data_dir, session_id, |meta| {
             meta.state = state;

--- a/src-tauri/src/usecase/agent_session/status.rs
+++ b/src-tauri/src/usecase/agent_session/status.rs
@@ -38,6 +38,22 @@ pub enum TurnPhase {
     WaitingPermission,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionNoticeKind {
+    PersistFailure,
+    EventLogRecovered,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionNotice {
+    pub session_id: String,
+    pub kind: SessionNoticeKind,
+    pub message: String,
+    pub created_at: f64,
+}
+
 /// 1 つの ChatSession に対する状態スナップショット。
 /// AgentState は turn_phase / session_state から算出した派生値。
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -57,6 +73,7 @@ pub struct SessionStatus {
     pub workflow_execution_id: Option<String>,
     pub node_execution_id: Option<String>,
     pub workflow_attempt: Option<u32>,
+    pub notice: Option<SessionNotice>,
     #[serde(skip_serializing)]
     pub workflow_node_progress: Option<NodeProgress>,
 }
@@ -221,6 +238,10 @@ pub struct AgentStateChange {
 /// Session / Workspace の状態を集中管理し、フロント・WS にブロードキャストする中央管理。
 pub struct AgentStatusCenter {
     sessions: RwLock<HashMap<String, SessionStatus>>,
+    notices: RwLock<HashMap<String, SessionNotice>>,
+    #[cfg(test)]
+    update_session_notice_sync_hook:
+        RwLock<Option<std::sync::Arc<dyn Fn() + Send + Sync + 'static>>>,
     workspaces: RwLock<HashMap<String, WorkspaceStatus>>,
     workflow_node_status: RwLock<WorkflowNodeStatusState>,
     pending_workflow_node_sessions: RwLock<HashMap<String, PendingWorkflowNodeSessionStatus>>,
@@ -233,6 +254,9 @@ impl AgentStatusCenter {
     pub fn new() -> Self {
         Self {
             sessions: RwLock::new(HashMap::new()),
+            notices: RwLock::new(HashMap::new()),
+            #[cfg(test)]
+            update_session_notice_sync_hook: RwLock::new(None),
             workspaces: RwLock::new(HashMap::new()),
             workflow_node_status: RwLock::new(WorkflowNodeStatusState::default()),
             pending_workflow_node_sessions: RwLock::new(HashMap::new()),
@@ -297,6 +321,7 @@ impl AgentStatusCenter {
             && a.workflow_execution_id == b.workflow_execution_id
             && a.node_execution_id == b.node_execution_id
             && a.workflow_attempt == b.workflow_attempt
+            && a.notice == b.notice
             && a.workflow_node_progress == b.workflow_node_progress
     }
 
@@ -815,16 +840,31 @@ impl AgentStatusCenter {
     /// 4. 呼び出し側が transport 層で通知できるよう変更結果を返す
     pub fn update_session(&self, mut status: SessionStatus) -> AgentStatusChanges {
         Self::normalize_session_paths(&mut status);
-        let prev = self.sessions.read().get(&status.chat_session_id).cloned();
-        if prev.is_none() {
-            self.apply_pending_workflow_node_session_status(&mut status);
-        }
-
-        // 1. dedup
-        if let Some(prev) = prev {
-            if Self::is_session_state_equivalent(&prev, &status) {
-                return AgentStatusChanges::default();
+        {
+            // notices is the source of truth. Hold its read lock through the session
+            // insert so record/clear always observes the same notices -> sessions order.
+            let notices = self.notices.read();
+            status.notice = notices.get(&status.chat_session_id).cloned();
+            let prev = self.sessions.read().get(&status.chat_session_id).cloned();
+            if prev.is_none() {
+                self.apply_pending_workflow_node_session_status(&mut status);
             }
+
+            // 1. dedup
+            if let Some(prev) = prev {
+                if Self::is_session_state_equivalent(&prev, &status) {
+                    return AgentStatusChanges::default();
+                }
+            }
+
+            #[cfg(test)]
+            if let Some(hook) = self.update_session_notice_sync_hook.read().clone() {
+                hook();
+            }
+
+            // 2. sessions マップ反映
+            let mut sessions = self.sessions.write();
+            sessions.insert(status.chat_session_id.clone(), status.clone());
         }
 
         let worktree_id = status.worktree_id.clone();
@@ -833,12 +873,6 @@ impl AgentStatusCenter {
         let chat_session_id = status.chat_session_id.clone();
         let pty_id = status.pty_id.clone();
         let agent_state = status.agent_state.clone();
-
-        // 2. sessions マップ反映
-        {
-            let mut sessions = self.sessions.write();
-            sessions.insert(chat_session_id.clone(), status.clone());
-        }
 
         // 3. workspace 再集約（aggregate 内で Closed は集約対象から除外される）
         let workflow_snapshot = self.workflow_agg_snapshot_for(&worktree_path);
@@ -1149,6 +1183,59 @@ impl AgentStatusCenter {
         self.sessions.read().get(chat_session_id).cloned()
     }
 
+    fn replace_session_notice(
+        &self,
+        session_id: &str,
+        notice: Option<SessionNotice>,
+        expected_kind: Option<SessionNoticeKind>,
+    ) -> AgentStatusChanges {
+        let mut notices = self.notices.write();
+        if expected_kind.is_some_and(|kind| {
+            !notices
+                .get(session_id)
+                .is_some_and(|notice| notice.kind == kind)
+        }) {
+            return AgentStatusChanges::default();
+        }
+        match &notice {
+            Some(notice) => {
+                notices.insert(session_id.to_string(), notice.clone());
+            }
+            None => {
+                notices.remove(session_id);
+            }
+        }
+        let session = self.sessions.write().get_mut(session_id).map(|status| {
+            status.notice = notice;
+            status.clone()
+        });
+        AgentStatusChanges {
+            session,
+            ..Default::default()
+        }
+    }
+
+    pub fn record_session_notice(&self, notice: SessionNotice) -> AgentStatusChanges {
+        let session_id = notice.session_id.clone();
+        self.replace_session_notice(&session_id, Some(notice), None)
+    }
+
+    pub fn clear_session_notice(
+        &self,
+        session_id: &str,
+        kind: SessionNoticeKind,
+    ) -> AgentStatusChanges {
+        self.replace_session_notice(session_id, None, Some(kind))
+    }
+
+    #[cfg(test)]
+    fn set_update_session_notice_sync_hook_for_test(
+        &self,
+        hook: std::sync::Arc<dyn Fn() + Send + Sync + 'static>,
+    ) {
+        *self.update_session_notice_sync_hook.write() = Some(hook);
+    }
+
     pub fn get_workspace(&self, worktree_id: &str) -> Option<WorkspaceStatus> {
         self.workspaces
             .read()
@@ -1200,6 +1287,7 @@ mod tests {
             workflow_execution_id: None,
             node_execution_id: None,
             workflow_attempt: None,
+            notice: None,
             workflow_node_progress: None,
         }
     }
@@ -1572,6 +1660,298 @@ mod tests {
         assert_eq!(value["workflow_attempt"], 3);
         assert!(value.get("workflow_node_execution_id").is_none());
         assert!(value.get("workflow_node_progress").is_none());
+    }
+
+    #[test]
+    fn session_notice_serialization_uses_frontend_wire_shape() {
+        for (kind, expected_kind) in [
+            (SessionNoticeKind::PersistFailure, "persist_failure"),
+            (SessionNoticeKind::EventLogRecovered, "event_log_recovered"),
+        ] {
+            let value = serde_json::to_value(SessionNotice {
+                session_id: "session-1".to_string(),
+                kind,
+                message: "Notice message".to_string(),
+                created_at: 42.0,
+            })
+            .expect("session notice serializes");
+
+            assert_eq!(
+                value,
+                serde_json::json!({
+                    "sessionId": "session-1",
+                    "kind": expected_kind,
+                    "message": "Notice message",
+                    "createdAt": 42.0,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn session_status_serialization_nests_notice_wire_shape() {
+        let mut status = mk_session("session-1", "/repo", TurnPhase::Idle, SessionState::Idle);
+        status.notice = Some(SessionNotice {
+            session_id: "session-1".to_string(),
+            kind: SessionNoticeKind::EventLogRecovered,
+            message: "Recovered".to_string(),
+            created_at: 7.0,
+        });
+
+        let value = serde_json::to_value(status).expect("session status serializes");
+
+        assert_eq!(
+            value["notice"],
+            serde_json::json!({
+                "sessionId": "session-1",
+                "kind": "event_log_recovered",
+                "message": "Recovered",
+                "createdAt": 7.0,
+            })
+        );
+    }
+
+    #[test]
+    fn session_notice_is_retained_in_status_snapshot() {
+        let center = mk_center();
+        center.update_session(mk_session(
+            "session-1",
+            "/repo",
+            TurnPhase::Idle,
+            SessionState::Idle,
+        ));
+        center.record_session_notice(SessionNotice {
+            session_id: "session-1".to_string(),
+            kind: SessionNoticeKind::PersistFailure,
+            message: "Persistence failed".to_string(),
+            created_at: 42.0,
+        });
+
+        let status = center.get_session("session-1").expect("session status");
+
+        assert_eq!(
+            status.notice,
+            Some(SessionNotice {
+                session_id: "session-1".to_string(),
+                kind: SessionNoticeKind::PersistFailure,
+                message: "Persistence failed".to_string(),
+                created_at: 42.0,
+            })
+        );
+    }
+
+    #[test]
+    fn session_notice_recorded_before_status_is_applied_to_first_snapshot() {
+        let center = mk_center();
+        center.record_session_notice(SessionNotice {
+            session_id: "session-1".to_string(),
+            kind: SessionNoticeKind::EventLogRecovered,
+            message: "Recovered".to_string(),
+            created_at: 7.0,
+        });
+
+        let changes = center.update_session(mk_session(
+            "session-1",
+            "/repo",
+            TurnPhase::Idle,
+            SessionState::Idle,
+        ));
+
+        assert_eq!(
+            changes
+                .session
+                .and_then(|status| status.notice)
+                .map(|notice| notice.kind),
+            Some(SessionNoticeKind::EventLogRecovered)
+        );
+    }
+
+    #[test]
+    fn session_notice_clear_updates_backend_snapshot() {
+        let center = mk_center();
+        center.update_session(mk_session(
+            "session-1",
+            "/repo",
+            TurnPhase::Idle,
+            SessionState::Idle,
+        ));
+        center.record_session_notice(SessionNotice {
+            session_id: "session-1".to_string(),
+            kind: SessionNoticeKind::PersistFailure,
+            message: "Persistence failed".to_string(),
+            created_at: 42.0,
+        });
+
+        let changes = center.clear_session_notice("session-1", SessionNoticeKind::PersistFailure);
+
+        assert_eq!(
+            changes
+                .session
+                .as_ref()
+                .and_then(|status| status.notice.as_ref()),
+            None
+        );
+        assert_eq!(
+            center
+                .get_session("session-1")
+                .and_then(|status| status.notice),
+            None
+        );
+    }
+
+    #[test]
+    fn session_notice_clear_keeps_a_different_notice_kind() {
+        let center = mk_center();
+        center.update_session(mk_session(
+            "session-1",
+            "/repo",
+            TurnPhase::Idle,
+            SessionState::Idle,
+        ));
+        let notice = SessionNotice {
+            session_id: "session-1".to_string(),
+            kind: SessionNoticeKind::EventLogRecovered,
+            message: "Recovered".to_string(),
+            created_at: 7.0,
+        };
+        center.record_session_notice(notice.clone());
+
+        let changes = center.clear_session_notice("session-1", SessionNoticeKind::PersistFailure);
+
+        assert_eq!(changes, AgentStatusChanges::default());
+        assert_eq!(
+            center
+                .get_session("session-1")
+                .and_then(|status| status.notice),
+            Some(notice)
+        );
+    }
+
+    #[test]
+    fn update_session_and_record_notice_keep_both_maps_consistent() {
+        let center = std::sync::Arc::new(mk_center());
+        center.update_session(mk_session(
+            "session-1",
+            "/repo",
+            TurnPhase::Idle,
+            SessionState::Idle,
+        ));
+        let entered = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let release = std::sync::Arc::new(std::sync::Barrier::new(2));
+        center.set_update_session_notice_sync_hook_for_test({
+            let entered = entered.clone();
+            let release = release.clone();
+            std::sync::Arc::new(move || {
+                entered.wait();
+                release.wait();
+            })
+        });
+        let updater = {
+            let center = center.clone();
+            std::thread::spawn(move || {
+                let mut status =
+                    mk_session("session-1", "/repo", TurnPhase::Idle, SessionState::Idle);
+                status.pty_id = Some("pty-1".to_string());
+                center.update_session(status);
+            })
+        };
+        entered.wait();
+        let notice = SessionNotice {
+            session_id: "session-1".to_string(),
+            kind: SessionNoticeKind::PersistFailure,
+            message: "Persistence failed".to_string(),
+            created_at: 42.0,
+        };
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+        let recorder = {
+            let center = center.clone();
+            let notice = notice.clone();
+            std::thread::spawn(move || {
+                center.record_session_notice(notice);
+                completed_tx.send(()).unwrap();
+            })
+        };
+
+        let record_was_blocked = completed_rx
+            .recv_timeout(std::time::Duration::from_millis(50))
+            .is_err();
+        release.wait();
+        updater.join().unwrap();
+        recorder.join().unwrap();
+
+        assert!(record_was_blocked);
+        assert_eq!(center.notices.read().get("session-1"), Some(&notice));
+        assert_eq!(
+            center
+                .sessions
+                .read()
+                .get("session-1")
+                .and_then(|status| status.notice.as_ref()),
+            Some(&notice)
+        );
+    }
+
+    #[test]
+    fn update_session_and_clear_notice_keep_both_maps_consistent() {
+        let center = std::sync::Arc::new(mk_center());
+        center.update_session(mk_session(
+            "session-1",
+            "/repo",
+            TurnPhase::Idle,
+            SessionState::Idle,
+        ));
+        center.record_session_notice(SessionNotice {
+            session_id: "session-1".to_string(),
+            kind: SessionNoticeKind::PersistFailure,
+            message: "Persistence failed".to_string(),
+            created_at: 42.0,
+        });
+        let entered = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let release = std::sync::Arc::new(std::sync::Barrier::new(2));
+        center.set_update_session_notice_sync_hook_for_test({
+            let entered = entered.clone();
+            let release = release.clone();
+            std::sync::Arc::new(move || {
+                entered.wait();
+                release.wait();
+            })
+        });
+        let updater = {
+            let center = center.clone();
+            std::thread::spawn(move || {
+                let mut status =
+                    mk_session("session-1", "/repo", TurnPhase::Idle, SessionState::Idle);
+                status.pty_id = Some("pty-1".to_string());
+                center.update_session(status);
+            })
+        };
+        entered.wait();
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+        let clearer = {
+            let center = center.clone();
+            std::thread::spawn(move || {
+                center.clear_session_notice("session-1", SessionNoticeKind::PersistFailure);
+                completed_tx.send(()).unwrap();
+            })
+        };
+
+        let clear_was_blocked = completed_rx
+            .recv_timeout(std::time::Duration::from_millis(50))
+            .is_err();
+        release.wait();
+        updater.join().unwrap();
+        clearer.join().unwrap();
+
+        assert!(clear_was_blocked);
+        assert!(!center.notices.read().contains_key("session-1"));
+        assert_eq!(
+            center
+                .sessions
+                .read()
+                .get("session-1")
+                .and_then(|status| status.notice.as_ref()),
+            None
+        );
     }
 
     #[test]
@@ -2248,6 +2628,7 @@ mod tests {
             workflow_execution_id: Some("exec-other".to_string()),
             node_execution_id: Some("deploy-1".to_string()),
             workflow_attempt: Some(1),
+            notice: None,
             workflow_node_progress: Some(NodeProgress::Running),
         });
 

--- a/src/components/panels/AgentChatPanel/BoundSessionChat.test.tsx
+++ b/src/components/panels/AgentChatPanel/BoundSessionChat.test.tsx
@@ -6,6 +6,7 @@ import type {
 	PermissionMode,
 	PermissionRequest,
 	PlanMode,
+	SessionNotice,
 } from "@/types/session";
 
 const mocks = vi.hoisted(() => ({
@@ -36,6 +37,7 @@ vi.mock("./ChatSessionView", () => ({
 		onRespondPermission,
 		onSend,
 		stallObservation,
+		notice,
 	}: {
 		session: ChatSession;
 		permissionMode: PermissionMode;
@@ -48,6 +50,7 @@ vi.mock("./ChatSessionView", () => ({
 		) => void;
 		onSend: (content: string) => Promise<boolean>;
 		stallObservation?: AgentStallObservation | null;
+		notice?: SessionNotice | null;
 	}) => (
 		<div data-testid={`chat-${session.id}`}>
 			<span data-testid={`permission-${session.id}`}>{permissionMode}</span>
@@ -75,6 +78,9 @@ vi.mock("./ChatSessionView", () => ({
 				{stallObservation
 					? `${stallObservation.turnPhase}:${stallObservation.idleSecs}`
 					: "none"}
+			</span>
+			<span data-testid={`notice-${session.id}`}>
+				{notice?.message ?? "none"}
 			</span>
 		</div>
 	),
@@ -113,6 +119,7 @@ function setContext(
 	sessionsById: Record<string, ChatSession>,
 	pendingPermissions: Record<string, PermissionRequest | null> = {},
 	stallObservations: Record<string, AgentStallObservation | null> = {},
+	notices: Record<string, SessionNotice | null> = {},
 ) {
 	mocks.useAgentChatContext.mockReturnValue({
 		getSessionById: (sessionId: string | null | undefined) =>
@@ -134,6 +141,7 @@ function setContext(
 		getSessionPendingQueue: vi.fn().mockReturnValue([]),
 		getSessionStallObservation: (sessionId: string) =>
 			stallObservations[sessionId] ?? null,
+		getSessionNotice: (sessionId: string) => notices[sessionId] ?? null,
 		getSessionRuntimeSlashCommands: vi.fn().mockReturnValue([]),
 		availableModels: [],
 		availableModelsByBackend: {},
@@ -258,6 +266,46 @@ describe("BoundSessionChat", () => {
 
 		expect(screen.getByTestId("stall-session-a")).toHaveTextContent(
 			"streaming:181",
+		);
+	});
+
+	it("passes only the selected session notice to ChatSessionView", () => {
+		setContext(
+			{
+				"session-a": makeSession("session-a", "edit", false),
+				"session-b": makeSession("session-b", "edit", false),
+			},
+			{},
+			{},
+			{
+				"session-a": {
+					sessionId: "session-a",
+					kind: "persist_failure",
+					message: "Session A notice",
+					createdAt: 2_000,
+				},
+				"session-b": {
+					sessionId: "session-b",
+					kind: "event_log_recovered",
+					message: "Session B notice",
+					createdAt: 3_000,
+				},
+			},
+		);
+
+		render(
+			<BoundSessionChat
+				sessionId="session-a"
+				worktreePath="/repo"
+				skipInitialLoad
+			/>,
+		);
+
+		expect(screen.getByTestId("notice-session-a")).toHaveTextContent(
+			"Session A notice",
+		);
+		expect(screen.getByTestId("notice-session-a")).not.toHaveTextContent(
+			"Session B notice",
 		);
 	});
 

--- a/src/components/panels/AgentChatPanel/BoundSessionChat.tsx
+++ b/src/components/panels/AgentChatPanel/BoundSessionChat.tsx
@@ -73,6 +73,7 @@ export function BoundSessionChat({
 		getSessionPendingPermission,
 		getSessionPendingQueue = () => [],
 		getSessionStallObservation = () => null,
+		getSessionNotice = () => null,
 		getSessionRuntimeSlashCommands = () => [],
 		availableModels,
 		backends,
@@ -234,6 +235,7 @@ export function BoundSessionChat({
 	const pendingPermission = getSessionPendingPermission(session.id);
 	const pendingQueue = getSessionPendingQueue(session.id);
 	const stallObservation = getSessionStallObservation(session.id);
+	const notice = getSessionNotice(session.id);
 	const runtimeSlashCommands = getSessionRuntimeSlashCommands(session.id);
 	const permissionMode = getSessionPermissionMode(session.id);
 	const planMode = getSessionPlanMode(session.id);
@@ -253,6 +255,7 @@ export function BoundSessionChat({
 			pendingPermission={pendingPermission}
 			pendingQueue={pendingQueue}
 			stallObservation={stallObservation}
+			notice={notice}
 			runtimeSlashCommands={runtimeSlashCommands}
 			selectedBackendId={session.backendId ?? null}
 			canChangeBackend={canChangeBackend}

--- a/src/components/panels/AgentChatPanel/ChatSessionView.test.ts
+++ b/src/components/panels/AgentChatPanel/ChatSessionView.test.ts
@@ -7,6 +7,7 @@ import type {
 	ChatSession,
 	PermissionRequest,
 	QueuedAgentTurn,
+	SessionNotice,
 } from "@/types/session";
 import { ChatSessionView } from "./ChatSessionView";
 
@@ -111,6 +112,7 @@ interface RenderOptions {
 	}) => void;
 	pendingPermission?: PermissionRequest | null;
 	pendingQueue?: QueuedAgentTurn[];
+	notice?: SessionNotice | null;
 	onRespondPermission?: (
 		requestId: string,
 		allow: boolean,
@@ -126,6 +128,7 @@ function chatSessionViewElement({
 	onEvictOlderMessages,
 	pendingPermission = null,
 	pendingQueue = [],
+	notice = null,
 	onRespondPermission = vi.fn(),
 }: RenderOptions = {}) {
 	return createElement(ChatSessionView, {
@@ -142,6 +145,7 @@ function chatSessionViewElement({
 		pendingPermission,
 		pendingQueue,
 		stallObservation,
+		notice,
 		selectedBackendId: null,
 		canChangeBackend: false,
 		worktreePath: "/repo",
@@ -230,7 +234,6 @@ describe("ChatSessionView session-local controls", () => {
 			},
 		],
 	};
-
 	it("renders text and image-only pending queue entries", () => {
 		renderChatSessionView({
 			pendingQueue: [
@@ -255,6 +258,38 @@ describe("ChatSessionView session-local controls", () => {
 		expect(screen.getByText("Review the failing logs")).toBeInTheDocument();
 		expect(screen.getByText("Queued 2")).toBeInTheDocument();
 		expect(screen.getByText("[image]")).toBeInTheDocument();
+	});
+
+	it("renders the backend-owned persist notice as a session alert", () => {
+		renderChatSessionView({
+			notice: {
+				sessionId: session.id,
+				kind: "persist_failure",
+				message: "Failed to save the completed response.",
+				createdAt: 1_001,
+			},
+		});
+
+		expect(screen.getByTestId("session-notice-banner")).toHaveTextContent(
+			"Failed to save the completed response.",
+		);
+		expect(screen.getByRole("alert")).toBeInTheDocument();
+	});
+
+	it("renders an event log recovery notice as status without alert exposure", () => {
+		renderChatSessionView({
+			notice: {
+				sessionId: session.id,
+				kind: "event_log_recovered",
+				message: "Recovered the damaged event log.",
+				createdAt: 1_002,
+			},
+		});
+
+		const banner = screen.getByTestId("session-notice-banner");
+		expect(banner).toHaveTextContent("Recovered the damaged event log.");
+		expect(screen.getByRole("status")).toBe(banner);
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 	});
 
 	it("keeps find and raw scrollback available from the toolbar", async () => {

--- a/src/components/panels/AgentChatPanel/ChatSessionView.tsx
+++ b/src/components/panels/AgentChatPanel/ChatSessionView.tsx
@@ -38,6 +38,7 @@ import type {
 	PermissionRequest,
 	PlanMode,
 	QueuedAgentTurn,
+	SessionNotice,
 	SlashCommand,
 } from "@/types/session";
 import { getTextContent } from "@/types/session";
@@ -629,6 +630,7 @@ export interface ChatSessionViewProps {
 	pendingPermission: PermissionRequest | null;
 	pendingQueue: QueuedAgentTurn[];
 	stallObservation?: AgentStallObservation | null;
+	notice?: SessionNotice | null;
 	runtimeSlashCommands?: SlashCommand[];
 	selectedBackendId: string | null;
 	canChangeBackend: boolean;
@@ -699,6 +701,7 @@ export function ChatSessionView({
 	pendingPermission,
 	pendingQueue,
 	stallObservation,
+	notice,
 	runtimeSlashCommands = [],
 	selectedBackendId,
 	canChangeBackend,
@@ -1716,6 +1719,22 @@ export function ChatSessionView({
 					<div className="px-2 pb-2">
 						<div className="bg-destructive/10 text-destructive rounded-lg px-3 py-2 text-sm">
 							{error}
+						</div>
+					</div>
+				)}
+				{notice && (
+					<div className="px-2 pb-2">
+						<div
+							className={
+								notice.kind === "persist_failure"
+									? "flex items-start gap-2 rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+									: "flex items-start gap-2 rounded border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300"
+							}
+							role={notice.kind === "persist_failure" ? "alert" : "status"}
+							data-testid="session-notice-banner"
+						>
+							<AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+							<span>{notice.message}</span>
 						</div>
 					</div>
 				)}

--- a/src/hooks/useAgentChat.test.ts
+++ b/src/hooks/useAgentChat.test.ts
@@ -256,6 +256,40 @@ describe("useAgentChat", () => {
 		expect(typeof mod.useAgentChat).toBe("function");
 	});
 
+	it("returns the backend-owned notice for the requested session", async () => {
+		const { renderHook, waitFor } = await import("@testing-library/react");
+		const { useAgentChat } = await import("./useAgentChat");
+		const notice = {
+			sessionId: "session-with-notice",
+			kind: "persist_failure",
+			message: "Unable to save the session.",
+			createdAt: 2_000,
+		} as const;
+		mockInvoke.mockResolvedValueOnce([
+			{
+				chat_session_id: "session-with-notice",
+				worktree_id: "/repo",
+				worktree_path: "/repo",
+				pty_id: null,
+				agent_state: "error",
+				turn_phase: "idle",
+				session_state: "error",
+				pending_permission: false,
+				last_activity_at: 1_000,
+				notice,
+			},
+		]);
+
+		const { result } = renderHook(() => useAgentChat("/repo"));
+
+		await waitFor(() => {
+			expect(result.current.getSessionNotice("session-with-notice")).toEqual(
+				notice,
+			);
+		});
+		expect(result.current.getSessionNotice("other-session")).toBeNull();
+	});
+
 	it("should not export buildClaudeCommand (removed)", async () => {
 		const mod = await import("./useAgentChat");
 		expect((mod as Record<string, unknown>).buildClaudeCommand).toBeUndefined();

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -13,6 +13,7 @@ import type {
 	PermissionRequest,
 	PlanMode,
 	QueuedAgentTurn,
+	SessionNotice,
 	SessionSummary,
 	SlashCommand,
 	TokenUsage,
@@ -184,6 +185,7 @@ export interface UseAgentChatResult {
 	getSessionStallObservation: (
 		sessionId: string,
 	) => AgentStallObservation | null;
+	getSessionNotice: (sessionId: string) => SessionNotice | null;
 	getSessionLatestTokenUsage: (sessionId: string) => TokenUsage | null;
 	getSessionRuntimeSlashCommands: (sessionId: string) => SlashCommand[];
 	cancelQueuedTurn: (
@@ -1517,6 +1519,11 @@ export function useAgentChat(
 		}
 		return map;
 	}, [worktreeSessionStatuses]);
+	const getSessionNotice = useCallback(
+		(sessionId: string): SessionNotice | null =>
+			worktreeSessionStatuses.get(sessionId)?.notice ?? null,
+		[worktreeSessionStatuses],
+	);
 
 	const activityStatus = useMemo(
 		() => deriveActivityStatus(activeSession?.messages, activeTurnPhase),
@@ -1665,6 +1672,7 @@ export function useAgentChat(
 		getSessionPendingPermission,
 		getSessionPendingQueue,
 		getSessionStallObservation,
+		getSessionNotice,
 		getSessionLatestTokenUsage,
 		getSessionRuntimeSlashCommands,
 		cancelQueuedTurn,

--- a/src/hooks/useWorktreeSessionStatuses.test.ts
+++ b/src/hooks/useWorktreeSessionStatuses.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { SessionStatus } from "@/types/session";
+import type { SessionNotice, SessionStatus } from "@/types/session";
 import { useWorktreeSessionStatuses } from "./useWorktreeSessionStatuses";
 
 const mockInvoke = vi.fn();
@@ -110,6 +110,140 @@ describe("useWorktreeSessionStatuses", () => {
 
 		expect(result.current.size).toBe(1);
 		expect(result.current.get("z")).toBeUndefined();
+	});
+
+	it("merges session-scoped notice events into the backend status snapshot", async () => {
+		mockInvoke.mockResolvedValue([makeStatus()]);
+		type EventPayload = SessionStatus | SessionNotice;
+		type Cb = (event: { payload: EventPayload }) => void;
+		const callbacks: Record<string, Cb> = {};
+		mockListen.mockImplementation((event: string, fn: Cb) => {
+			callbacks[event] = fn;
+			return Promise.resolve(vi.fn());
+		});
+		const { result } = renderHook(() => useWorktreeSessionStatuses("/tmp/wt"));
+		await waitFor(() => {
+			expect(result.current.has("session-1")).toBe(true);
+		});
+		const notice: SessionNotice = {
+			sessionId: "session-1",
+			kind: "persist_failure",
+			message: "Unable to save the session.",
+			createdAt: 2_000,
+		};
+
+		await act(async () => {
+			callbacks["agent-session-notice"]?.({ payload: notice });
+		});
+
+		expect(result.current.get("session-1")?.notice).toEqual(notice);
+	});
+
+	it("keeps a notice pushed while the initial status snapshot is pending", async () => {
+		type EventPayload = SessionStatus | SessionNotice;
+		type Cb = (event: { payload: EventPayload }) => void;
+		const callbacks: Record<string, Cb> = {};
+		mockListen.mockImplementation((event: string, fn: Cb) => {
+			callbacks[event] = fn;
+			return Promise.resolve(vi.fn());
+		});
+		let resolveInitial: ((statuses: SessionStatus[]) => void) | undefined;
+		mockInvoke.mockImplementation(
+			() =>
+				new Promise<SessionStatus[]>((resolve) => {
+					resolveInitial = resolve;
+				}),
+		);
+		const { result } = renderHook(() => useWorktreeSessionStatuses("/tmp/wt"));
+		await waitFor(() => {
+			expect(callbacks["agent-session-notice"]).toBeDefined();
+		});
+		const notice: SessionNotice = {
+			sessionId: "session-1",
+			kind: "persist_failure",
+			message: "Unable to save the session.",
+			createdAt: 2_000,
+		};
+
+		await act(async () => {
+			callbacks["session-status-changed"]?.({
+				payload: makeStatus({ notice: null, last_activity_at: 1_000 }),
+			});
+			callbacks["agent-session-notice"]?.({ payload: notice });
+			resolveInitial?.([makeStatus({ notice: null, last_activity_at: 1_000 })]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.get("session-1")?.notice).toEqual(notice);
+		});
+	});
+
+	it("keeps a newer snapshot notice over an older pending push", async () => {
+		type EventPayload = SessionStatus | SessionNotice;
+		type Cb = (event: { payload: EventPayload }) => void;
+		const callbacks: Record<string, Cb> = {};
+		mockListen.mockImplementation((event: string, fn: Cb) => {
+			callbacks[event] = fn;
+			return Promise.resolve(vi.fn());
+		});
+		let resolveInitial: ((statuses: SessionStatus[]) => void) | undefined;
+		mockInvoke.mockImplementation(
+			() =>
+				new Promise<SessionStatus[]>((resolve) => {
+					resolveInitial = resolve;
+				}),
+		);
+		const { result } = renderHook(() => useWorktreeSessionStatuses("/tmp/wt"));
+		await waitFor(() => {
+			expect(callbacks["agent-session-notice"]).toBeDefined();
+		});
+		const pendingNotice: SessionNotice = {
+			sessionId: "session-1",
+			kind: "persist_failure",
+			message: "Older pending notice",
+			createdAt: 2_000,
+		};
+		const snapshotNotice: SessionNotice = {
+			sessionId: "session-1",
+			kind: "event_log_recovered",
+			message: "Newer snapshot notice",
+			createdAt: 3_000,
+		};
+
+		await act(async () => {
+			callbacks["agent-session-notice"]?.({ payload: pendingNotice });
+			resolveInitial?.([makeStatus({ notice: snapshotNotice })]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.get("session-1")?.notice).toEqual(snapshotNotice);
+		});
+	});
+
+	it("applies a backend status push that clears a persist notice", async () => {
+		const notice: SessionNotice = {
+			sessionId: "session-1",
+			kind: "persist_failure",
+			message: "Unable to save the session.",
+			createdAt: 2_000,
+		};
+		mockInvoke.mockResolvedValue([makeStatus({ notice })]);
+		type Cb = (event: { payload: SessionStatus }) => void;
+		let statusChanged: Cb | undefined;
+		mockListen.mockImplementation((event: string, fn: Cb) => {
+			if (event === "session-status-changed") statusChanged = fn;
+			return Promise.resolve(vi.fn());
+		});
+		const { result } = renderHook(() => useWorktreeSessionStatuses("/tmp/wt"));
+		await waitFor(() => {
+			expect(result.current.get("session-1")?.notice).toEqual(notice);
+		});
+
+		await act(async () => {
+			statusChanged?.({ payload: makeStatus({ notice: null }) });
+		});
+
+		expect(result.current.get("session-1")?.notice).toBeNull();
 	});
 
 	it("returns empty Map when invoke fails", async () => {

--- a/src/hooks/useWorktreeSessionStatuses.ts
+++ b/src/hooks/useWorktreeSessionStatuses.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useEffect, useState } from "react";
-import type { SessionStatus } from "@/types/session";
+import type { SessionNotice, SessionStatus } from "@/types/session";
 
 /**
  * 指定 worktree に属する全 ChatSession の SessionStatus を Map で取得する。
@@ -24,27 +24,75 @@ export function useWorktreeSessionStatuses(
 		}
 
 		let mounted = true;
-		let unlisten: UnlistenFn | null = null;
+		const unlisteners: UnlistenFn[] = [];
+		const pendingNotices = new Map<string, SessionNotice>();
+		const knownSessionIds = new Set<string>();
+		let loadingInitial = true;
+
+		const mergePendingNotice = (
+			status: SessionStatus,
+			pendingNotice: SessionNotice | undefined,
+		): SessionStatus => {
+			if (!pendingNotice) return status;
+			if (status.notice && status.notice.createdAt > pendingNotice.createdAt) {
+				return status;
+			}
+			return { ...status, notice: pendingNotice };
+		};
 
 		const subscribe = async () => {
 			let subscribed = false;
 			try {
-				unlisten = await listen<SessionStatus>(
+				const unlistenStatus = await listen<SessionStatus>(
 					"session-status-changed",
 					(event) => {
 						if (!mounted) return;
 						if (event.payload.worktree_id !== worktreePath) return;
+						knownSessionIds.add(event.payload.chat_session_id);
 						setStatuses((prev) => {
 							const next = new Map(prev);
 							next.set(event.payload.chat_session_id, event.payload);
 							return next;
 						});
+						// A live backend status push is newer than any queued notice push and
+						// can explicitly clear notice with `null`.
+						pendingNotices.delete(event.payload.chat_session_id);
 					},
 				);
+				unlisteners.push(unlistenStatus);
 				subscribed = true;
 
+				try {
+					const unlistenNotice = await listen<SessionNotice>(
+						"agent-session-notice",
+						(event) => {
+							if (!mounted) return;
+							pendingNotices.set(event.payload.sessionId, event.payload);
+							setStatuses((prev) => {
+								const current = prev.get(event.payload.sessionId);
+								if (!current) return prev;
+								const next = new Map(prev);
+								next.set(event.payload.sessionId, {
+									...current,
+									notice: event.payload,
+								});
+								return next;
+							});
+							if (
+								!loadingInitial &&
+								knownSessionIds.has(event.payload.sessionId)
+							) {
+								pendingNotices.delete(event.payload.sessionId);
+							}
+						},
+					);
+					unlisteners.push(unlistenNotice);
+				} catch {
+					// Snapshot remains authoritative if the transient push channel is unavailable.
+				}
+
 				if (!mounted) {
-					unlisten?.();
+					for (const unlisten of unlisteners) unlisten();
 					return;
 				}
 
@@ -53,19 +101,38 @@ export function useWorktreeSessionStatuses(
 					// listen 登録後・invoke await 中に届いた最新イベントを尊重するため、
 					// 既存 state と last_activity_at で比較し、エントリごとに新しい方を採用する。
 					const initialList = Array.isArray(initial) ? initial : [];
+					const pendingAtBootstrap = new Map(pendingNotices);
+					for (const status of initialList) {
+						if (status.worktree_id === worktreePath) {
+							knownSessionIds.add(status.chat_session_id);
+						}
+					}
 					setStatuses((prev) => {
 						const next = new Map(prev);
 						for (const s of initialList) {
 							if (s.worktree_id !== worktreePath) continue;
 							const current = next.get(s.chat_session_id);
-							if (!current || current.last_activity_at <= s.last_activity_at) {
-								next.set(s.chat_session_id, s);
-							}
+							const newest =
+								!current || current.last_activity_at < s.last_activity_at
+									? s
+									: current;
+							next.set(
+								s.chat_session_id,
+								mergePendingNotice(
+									newest,
+									pendingAtBootstrap.get(s.chat_session_id),
+								),
+							);
 						}
 						return next;
 					});
+					loadingInitial = false;
+					for (const sessionId of knownSessionIds) {
+						pendingNotices.delete(sessionId);
+					}
 				}
 			} catch {
+				loadingInitial = false;
 				// listen が成功した後の invoke 失敗では listener が入れた最新 state を
 				// 消さないために state を触らない。listen そのものが失敗した場合のみ
 				// 空にリセットする。
@@ -79,7 +146,7 @@ export function useWorktreeSessionStatuses(
 
 		return () => {
 			mounted = false;
-			unlisten?.();
+			for (const unlisten of unlisteners) unlisten();
 		};
 	}, [worktreePath]);
 

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -343,6 +343,15 @@ export interface TokenUsage {
 	contextWindowTokens?: number;
 }
 
+export type SessionNoticeKind = "persist_failure" | "event_log_recovered";
+
+export interface SessionNotice {
+	sessionId: string;
+	kind: SessionNoticeKind;
+	message: string;
+	createdAt: number;
+}
+
 /**
  * Rust の `agent_status::SessionStatus` に対応するステータス。
  * ChatSession 単位で Rust が算出する派生ステータスをそのまま消費する。
@@ -363,6 +372,7 @@ export interface SessionStatus {
 	workflow_node?: string | null;
 	workflow_attempt?: number | null;
 	workflow_execution_status?: string | null;
+	notice?: SessionNotice | null;
 }
 
 /**


### PR DESCRIPTION
## 概要

- Agent session の persist 失敗を有限回リトライし、継続失敗を session-scoped notice と構造化ログで可視化する
- 末尾が破損した event log を append 前に自己修復し、セッションを送信可能な状態へ戻す
- FinalPartsRecorded の永続化失敗時に、保存済み本文が tool-only parts で上書きされることを防ぐ

## 主な変更

- backend-owned な SessionNotice と Tauri / frontend への配信経路を追加
- event log の破損検出・修復・通知 wiring を追加
- persist リトライ、エラー伝搬、本文保持のテストを追加
- Issue 1409 の requirements / design / behavior spec を追加

## 確認

- git diff --check

Closes #1409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 永続化に失敗した際、セッション画面に通知バナーを表示するようになりました。
  * 一時的な永続化失敗を自動で再試行し、成功時は通知を解除します。
  * イベントログの破損を検知・修復し、復旧結果を画面に通知します。
  * 最終保存に失敗しても、作成済みの本文が失われないようになりました。
* **ドキュメント**
  * 永続化失敗、イベントログ復旧、本文保持に関する仕様と設計を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->