### PR TITLE
feat: wire record/replay 回帰テスト基盤を追加 (#1383)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.golden text eol=lf

--- a/docs/specs/feat-issues-1383/behavior.md
+++ b/docs/specs/feat-issues-1383/behavior.md
@@ -1,0 +1,147 @@
+# Behavior — F1: wire record/replay 回帰テスト基盤
+
+対象 issue: [#1383](https://github.com/siro33950/releash/issues/1383)（milestone 84 Phase 0 / ST-7 前半）
+
+この文書は `requirements.md` の要求を、実装詳細を含まない観測可能な振る舞いとして定義する。振る舞いの主語は「開発者が record tap で fixture を採取する」「CI / 開発者が replay・統合 golden テストを実行する」の 2 つである。
+
+## Feature: wire record/replay 回帰テスト基盤
+
+agent chat（Claude / Codex）の wire メッセージを domain event / read model へ変換する経路の現状挙動を、実 wire ログ由来の fixture と golden ファイルで固定し、後続変更での回帰を機械的に検出できるようにする。
+
+### Background
+
+```gherkin
+Background:
+  Given リポジトリに Claude 用と Codex 用の wire fixture 置き場が存在する
+  And 各 fixture は実セッション由来の wire ログを 1 行 1 メッセージの JSONL として保持する
+  And 各 fixture には対応する golden ファイル（convert 層・read model 層）が併置される
+  And golden 比較は新規 crate 依存を追加せず自作の比較で行われる
+```
+
+### Rule: record tap は環境変数ゲートでのみ動作し、既定では本番挙動に影響しない
+
+```gherkin
+Scenario: 環境変数未設定では wire を採取しない
+  Given RELEASH_WIRE_RECORD が設定されていない
+  When Claude / Codex セッションが wire メッセージを受信する
+  Then wire 行はどこにも採取されない
+  And セッションの読み取り・変換・応答の挙動は tap 追加前と変わらない
+
+Scenario: 環境変数設定時に受信した wire 行を採取する
+  Given RELEASH_WIRE_RECORD=<dir> が設定されている
+  When Claude / Codex セッションが stdout から wire 行を受信する
+  Then 受信した生 wire 行が <dir> 配下へ 1 行 1 メッセージの JSONL として書き出される
+  And セッション本来の読み取り・変換・応答の挙動は変わらない
+
+Scenario: 採取は生 wire 行を対象とし drop も可能な範囲で残す
+  Given RELEASH_WIRE_RECORD=<dir> が設定されている
+  When パース失敗行やサイズ超過などで本来 drop される wire 行を受信する
+  Then その生行も可能な範囲で <dir> に採取される
+```
+
+### Rule: replay golden（convert 層）は現状の変換出力を固定する
+
+```gherkin
+Scenario: fixture を convert に通した出力が golden と一致する
+  Given Claude または Codex の fixture と対応する convert 層 golden が存在する
+  When fixture を先頭行から順に convert へ流す
+  Then 生成された AgentRuntimeEvent 列が golden と一致し、テストが通る
+  And Claude では AgentRuntimeEvent 列に加え auto_responses も golden 比較対象に含まれる
+
+Scenario: convert は fixture を通す間 state を引き継ぐ
+  Given 複数行にまたがる 1 turn の fixture が存在する
+  When fixture を 1 行ずつ順に convert へ流す
+  Then 変換 state は行をまたいで引き継がれ、turn 全体の出力が golden と一致する
+
+Scenario Outline: 代表 turn で replay テストが通る
+  Given <backend> の fixture が <要素> を含む通常 turn を保持する
+  When fixture を convert に流し golden と比較する
+  Then テストが通る
+
+  Examples:
+    | backend | 要素 |
+    | Claude  | text / thinking / tool_use / permission / result |
+    | Codex   | agentMessage / commandExecution / requestApproval / turn completed |
+
+Scenario: 出力が golden と異なると fail する
+  Given convert の出力が既存 golden と一致しない状態
+  When replay テストを実行する
+  Then テストは不一致を報告して fail する
+
+Scenario: UPDATE_GOLDEN で golden を更新できる
+  Given convert の出力を新しい正とみなしたい
+  When UPDATE_GOLDEN=1 を設定して replay テストを実行する
+  Then golden ファイルが現在の出力で上書きされ、テストが通る
+```
+
+### Rule: 統合 golden（read model 層）は projector までの現状挙動を固定する
+
+```gherkin
+Scenario: fixture を read model まで通した出力が golden と一致する
+  Given fixture と対応する read model 層 golden が存在する
+  When 同じ fixture を convert → 永続 event → projector（project()）まで流す
+  Then 得られた SessionReadModel スナップショットが golden と一致し、テストが通る
+
+Scenario: 統合 golden も UPDATE_GOLDEN で更新できる
+  Given read model の出力を新しい正とみなしたい
+  When UPDATE_GOLDEN=1 を設定して統合テストを実行する
+  Then read model 層 golden が現在の出力で上書きされ、テストが通る
+
+Scenario: read model 出力が golden と異なると fail する
+  Given projector 出力が既存 golden と一致しない状態
+  When 統合テストを実行する
+  Then テストは不一致を報告して fail する
+```
+
+### Rule: fixture はマスク済みの状態でリポジトリに存在する
+
+```gherkin
+Scenario: 秘匿情報がプレースホルダへ置換されている
+  Given リポジトリに commit された fixture
+  When fixture の内容を確認する
+  Then 絶対パス・ホームディレクトリ・トークン / API キー・メッセージ本文などの秘匿値が安定なプレースホルダへ置換されている
+  And type / subtype / フィールド構成 / イベント順序などの構造は保持されている
+```
+
+### Rule: テストは CI で実行され、本 issue は変換挙動を変えない
+
+```gherkin
+Scenario: replay / 統合 golden テストが CI で実行される
+  Given .github/workflows/ci.yml の Rust テスト経路
+  When cargo test を実行する
+  Then replay テストと統合 golden テストが実行される
+
+Scenario: 本 issue の変更で golden 内容が変わらない
+  Given 本 issue は record tap 追加とテスト基盤新設のみを行う
+  When convert / projector を通した出力を確認する
+  Then 生成される golden の内容は本 issue の変更前後で変わらない
+
+Scenario: 品質チェックが通る
+  When cargo fmt --check / cargo clippy -- -D warnings / cargo test を実行する
+  Then いずれも成功する
+```
+
+### Rule: golden 更新・採取・マスキング手順がドキュメント化されている
+
+```gherkin
+Scenario: fixture ディレクトリの README に手順が記載されている
+  Given fixture ディレクトリ
+  When README を参照する
+  Then record tap（RELEASH_WIRE_RECORD）による採取手順が記載されている
+  And マスキング方針が記載されている
+  And UPDATE_GOLDEN による golden 更新手順が記載されている
+```
+
+## 仮定
+
+`requirements.md` の「仮定」に従う。振る舞い上、特に前提とするもの:
+
+1. record tap は本 issue の成果物として production コードにマージするが、既定無効・非破壊とする。
+2. golden は fixture ごとに convert 層（events ＋ auto_responses）と read model 層（SessionReadModel）を pretty JSON で保存し、fixture と同じディレクトリ配下に置く。
+3. golden 更新は `UPDATE_GOLDEN=1`、採取は `RELEASH_WIRE_RECORD=<dir>` の環境変数で行う。
+4. AgentRuntimeEvent → 永続 event の写像は production の building block と turn 完了順序（`FinalPartsRecorded`、続いて terminal event）を利用する。
+5. golden crate（insta / goldenfile 等）は導入せず自作比較で行う。
+
+## Open Questions
+
+なし。

--- a/docs/specs/feat-issues-1383/design.md
+++ b/docs/specs/feat-issues-1383/design.md
@@ -1,0 +1,212 @@
+# Design — F1: wire record/replay 回帰テスト基盤
+
+対象 issue: [#1383](https://github.com/siro33950/releash/issues/1383)（milestone 84 Phase 0 / ST-7 前半）
+参照: [`requirements.md`](./requirements.md) / [`behavior.md`](./behavior.md)
+
+## 概要
+
+agent chat（Claude / Codex）の wire メッセージ → `AgentRuntimeEvent` → 永続 event → projector → `SessionReadModel` の変換経路について、実 wire ログ由来の fixture を golden と突き合わせる回帰テスト基盤を新設する。あわせて、fixture 採取のための record tap（環境変数ゲート、既定無効・非破壊）を production コードへ追加する。
+
+本 issue は「現状挙動を golden として固定する」ことだけを行い、convert / projector の出力（生成される golden の内容）は変えない。
+
+方針の骨子:
+
+- **record tap**: Claude / Codex が共有する `stdout_line_reader.rs` の生行分類境界に、`RELEASH_WIRE_RECORD=<dir>` 設定時のみ生 wire 行を process-owned writer thread の bounded channel へ `try_send` する tap を挿入する。各 process は backend 別 recorder を shared reader の生成時に渡す。既定では `std::env::var_os` が `None` を返し、channel 初期化もファイル I/O も行わない。reader 終了時は recorder を明示的に shutdown して queue を drain / join する。
+- **fixture 置き場**: `infrastructure/agent_session/fixtures/{claude,codex}/<turn名>/` に、マスク済み wire ログ（`wire.jsonl`）と golden 2 種を co-locate する。
+- **replay テスト（convert 層）**: fixture を `convert_claude_message` / `convert_jsonrpc_message` に流し、出力を golden と比較する。
+- **統合テスト（read model 層）**: crate 最外周の `test_support` で、同じ fixture を convert → 永続 event（既存の building block と production の完了順序を再利用したテスト reducer）→ `project()` まで流し、`SessionReadModel` を golden と比較する。
+- **golden 比較は自作**: 新規 crate 依存を追加せず、`UPDATE_GOLDEN=1` で更新できる共通ヘルパを実装する。
+
+## 変更対象
+
+### 新規
+
+| パス | 役割 |
+|---|---|
+| `src-tauri/src/infrastructure/agent_session/wire_record.rs` | record tap 本体（env ゲート・追記・エラー握りつぶし） |
+| `src-tauri/src/infrastructure/agent_session/fixtures/mod.rs` | `#[cfg(test)]` fixture ローダ・golden 比較ヘルパ・replay ドライバ |
+| `src-tauri/src/infrastructure/agent_session/fixtures/snapshot.rs` | domain 型へ serde を持ち込まない convert golden 用 snapshot DTO |
+| `src-tauri/src/infrastructure/agent_session/fixtures/README.md` | 採取手順・マスキング方針・golden 更新手順 |
+| `src-tauri/src/infrastructure/agent_session/fixtures/claude/normal_turn/wire.jsonl` | Claude 代表 turn のマスク済み wire ログ |
+| `src-tauri/src/infrastructure/agent_session/fixtures/claude/normal_turn/convert.golden` | Claude convert 層 golden |
+| `src-tauri/src/infrastructure/agent_session/fixtures/claude/normal_turn/read_model.golden` | Claude read model 層 golden |
+| `src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/wire.jsonl` | Codex 代表 turn のマスク済み wire ログ |
+| `src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/convert.golden` | Codex convert 層 golden |
+| `src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/read_model.golden` | Codex read model 層 golden |
+| `src-tauri/src/test_support/agent_session_wire_replay.rs` | convert から projector までを跨ぐ read model 統合 golden テスト |
+
+### 変更
+
+| パス | 変更内容 |
+|---|---|
+| `infrastructure/agent_session/stdout_line_reader.rs` | 生行の分類直前に optional recorder tap を挿入 |
+| `infrastructure/agent_session/claude/process.rs` | Claude recorder を shared reader の生成時に接続 |
+| `infrastructure/agent_session/codex/app_server.rs` | Codex recorder を shared reader の生成時に接続 |
+| `infrastructure/agent_session/mod.rs`（or 該当 `mod` 宣言箇所） | `wire_record` / `fixtures` module 宣言を追加 |
+| `test_support/mod.rs` | crate 最外周の read model 統合 golden テスト module を追加 |
+| `usecase/agent_session/event_log/projector.rs` | read model DTO の golden JSON 化に必要な `Serialize` を test build 限定で追加 |
+
+CI（`.github/workflows/ci.yml`）は既存の `cargo test` 経路で新テストを実行するため変更不要。
+
+## アーキテクチャと責務分割
+
+### record tap（`wire_record`）
+
+- `infrastructure` 層に閉じた薄い副作用ユーティリティ。domain / usecase には依存しない。
+- 公開 API（crate 内）:
+  - stdout process の生成時に `WireRecorder::from_env(WireBackend)` を生成し、shared reader へ渡す。`RELEASH_WIRE_RECORD` が未設定なら reader は recorder を保持せず、行コピーも行わない。
+  - 設定時は生 wire 行を所有権ごと writer thread へ渡す。channel は 256 件、queue が所有する wire 本文は合計 16 MiB を上限とし、どちらかを超えた行は `try_send` 前後で warning を残して best-effort drop する。
+  - writer thread が `<dir>/<backend>.jsonl` を一度 open して追記を直列実行するため、stdout を読む Tokio worker では directory 作成・file open・write を行わず、disk I/O 待ちもしない。
+  - recorder は stdout process が所有する。session の close / process 交換は child を停止した後に reader task を join し、reader task は recorder の shutdown で queue を drain、file を flush、writer thread を join してから終了する。
+  - writer 起動・channel 超過または切断・すべての I/O エラーは `log::warn!` で記録し、呼び出し元の戻り値・制御フローに影響を与えない（非破壊）。
+- 記録対象は**生 wire 行**。マスキングは行わない（後述のとおり fixture 化時に別途適用）。採取先 `<dir>` は開発者ローカルの一時ディレクトリを想定し、リポジトリには commit しない。
+
+### fixture / replay ハーネス（`fixtures`、`#[cfg(test)]`）
+
+- fixture ディレクトリを走査し、`wire.jsonl` を 1 行ずつ読む。
+- convert ドライバ:
+  - Claude: `ClaudeConvertState::new(None, ClaudeWireMode::…)` を 1 turn 分だけ生成し、各行を `convert_claude_message` に流して `events` と `auto_responses` を蓄積する（state は行をまたいで引き継ぐ）。
+  - Codex: `CodexConvertState::default()` を 1 turn 分生成し、各行を `convert_jsonrpc_message` に流す。
+- convert 層 golden の生成物と、read model 層テストへ渡す `Vec<AgentRuntimeEvent>` の両方をここで供給する。read model 層テスト（crate root の `test_support`）からは、この module の `#[cfg(test)] pub(crate)` ドライバを呼んで convert 結果を得る（convert を二重実行しない）。
+- golden 比較ヘルパ `assert_golden(path, actual: &str)`:
+  - `UPDATE_GOLDEN` が設定されていれば `path` を `actual` で上書きして pass。
+  - 未設定なら既存 golden を読み、不一致なら最初の相違行を含めて `panic!`。golden 不在時は「`UPDATE_GOLDEN=1` で生成せよ」と案内して fail。
+
+### read model 統合（crate root の `test_support`）
+
+- convert が返す `Vec<AgentRuntimeEvent>` を、**テスト reducer** で `Vec<AgentSessionEvent>` に写し、`project()` に渡して `SessionReadModel` を得る。
+- テスト reducer は production の `apply_runtime_event`（`runtime/usecase.rs`）を IO 抜きで縮約したもので、`event_log` の既存 building block（`TurnEventLog::begin_turn` / `append_part_events` / `finalize_turn`）をそのまま使う。projection ロジックは複製しない。
+- `PartsMerged` は production と同じ `merge_part` で最終 parts を累積し、terminal event の直前に `FinalPartsRecorded` を追加する。これにより projector の最終置換経路と parts の merge・順序を検証する。
+- convert は infrastructure、reducer + project は usecase にあるため、複数レイヤーを知る orchestration は crate 最外周の `#[cfg(test)] test_support` に置く。usecase の単体テストから infrastructure への逆依存は作らない。
+
+## データモデルまたは型
+
+### fixture ディレクトリ構成
+
+```
+infrastructure/agent_session/fixtures/
+  README.md
+  claude/
+    normal_turn/
+      wire.jsonl          # マスク済み生 wire 行（stream-json）
+      convert.golden      # convert 層 golden（events + auto_responses）
+      read_model.golden   # read model 層 golden（SessionReadModel）
+  codex/
+    normal_turn/
+      wire.jsonl          # マスク済み生 wire 行（JSON-RPC）
+      convert.golden
+      read_model.golden
+```
+
+- 1 fixture = 1 ディレクトリ。golden は fixture と同じディレクトリに co-locate する。
+- 命名は `<backend>/<turn名>/`。代表 turn は `normal_turn` とする。
+
+### record tap 型
+
+```rust
+pub(crate) enum WireBackend { Claude, Codex }
+
+impl WireBackend {
+    fn file_name(self) -> &'static str { … } // "claude.jsonl" / "codex.jsonl"
+}
+
+pub(crate) struct WireRecorder { … }
+
+impl WireRecorder {
+    pub(crate) fn from_env(backend: WireBackend) -> Self;
+    pub(crate) fn record(&self, raw_line: Vec<u8>);
+    pub(crate) async fn shutdown(&mut self);
+}
+```
+
+### golden テキスト形式
+
+- 各 golden は `serde_json::to_string_pretty` による pretty JSON として保存する（末尾改行あり、決定的）。
+- convert 層: `line_index` ごとに `events` と（Claude は）`auto_responses` を並べた構造を JSON 化する。fixture module 内で `#[derive(Serialize)]` した snapshot DTO（`ReplayLine` / `RuntimeEventSnapshot` と内包型）へ明示変換する。
+- read model 層: `SessionReadModel` を JSON 化する。
+- domain 型は転送形式から独立させ、`serde` を追加しない。convert golden の JSON 表現は fixture module 内の snapshot DTO だけが所有する。
+- read model は usecase の内部 DTO であるため、`SessionReadModel` と内包する projector DTO には `#[cfg_attr(test, derive(serde::Serialize))]` を追加し、golden 用の JSON 表現を test build に限定する。すでに `Serialize` を持つ `ChatMessage` 等はそのまま利用する。
+
+## 処理フロー
+
+### 採取（開発時）
+
+1. 開発者が `RELEASH_WIRE_RECORD=/tmp/wire cargo run …`（もしくは実バイナリ）で実セッションを実行。
+2. shared `StdoutLineReader` が上限内の wire 生行を分類する直前に、process-owned `WireRecorder` が生行を bounded channel へ `try_send` し、専用 thread が `/tmp/wire/{claude,codex}.jsonl` に追記。queue 超過時は本来の stdout 処理を止めず、その行だけを warning 付きで drop する。
+3. session / reader の終了時に recorder が queue を drain し、file flush と writer join を完了する。
+4. 開発者が README の手順でマスキングを適用し、`wire.jsonl` として fixture ディレクトリへ配置。
+5. `UPDATE_GOLDEN=1 cargo test` で golden を生成。差分を確認し commit。
+
+### replay（convert 層 / CI・開発時）
+
+1. `wire.jsonl` を 1 行ずつ読み、JSON へパース。
+2. backend 対応の convert に順に流し、`events`（+ Claude `auto_responses`）を蓄積。
+3. テキスト化して `convert.golden` と `assert_golden` で比較。
+
+### 統合（read model 層 / CI・開発時）
+
+1. 上と同じ convert 結果（`Vec<AgentRuntimeEvent>`）を取得。
+2. テスト reducer で `Vec<AgentSessionEvent>` に写像:
+   - 冒頭で `TurnStarted`（固定 `turn_id` / message id / `at`）を発行。
+   - `PartsMerged(parts)` → durable part event を `append_part_events` しつつ、domain の `merge_part` で最終 parts を累積。
+   - `PermissionRequested(req)` → production と同じ `DomainMessagePart::Permission` として最終 parts へ merge し、`append_part_events` で `PermissionRequested`（resolved 状態なら `PermissionResolved` も）を生成。
+   - `TokenUsageUpdated` → 保持し `TurnCompleted` に反映。
+   - `TurnCompleted(result)` → 累積済み最終 parts を `FinalPartsRecorded` として追加後、completed terminal event または `finalize_turn` を追加。
+   - `SessionEstablished` / `SlashCommandsUpdated` / `PermissionModeChanged` / `KeepAlive` / `BackendSessionCleared` は durable content を持たないため read model には寄与しない（no-op、記録のみ必要ならコメントで明示）。
+3. `project()` で `SessionReadModel` を得てテキスト化し、`read_model.golden` と比較。
+
+### tap 挿入点の詳細
+
+- **共通境界** (`stdout_line_reader.rs`): 上限内の生行を `Json` / `NonJson` へ分類する直前に、active recorder がある場合だけ行をコピーして `record` へ渡す。これにより正常行とパース失敗行の両方を採取する。
+- **backend 接続** (`claude/process.rs` / `codex/app_server.rs`): process 生成時に backend 別 `WireRecorder` を shared reader へ渡し、reader task 終了時に明示 shutdown する。`Oversize` は shared reader が生バイトを保持しないため「可能な範囲」で扱い、挙動不変を優先して記録をスキップする。
+
+いずれも tap は戻り値・分岐を変えない挿入のみで、既存の読み取りループ挙動を変更しない。
+
+## エラー処理
+
+- **record tap**: writer thread 起動・channel 上限超過または切断・ディレクトリ作成・ファイル open・write・flush / join の失敗はすべて `log::warn!` で記録して継続。通常の記録は bounded `try_send` のみとし、tap が原因で stdout 消費やセッションが停止・変質してはならない（要求 9 / behavior「挙動は変わらない」）。終了時だけは queue を drain して採取済み末尾を確定する。
+- **golden 比較**: 不一致は最初の相違を含めて `panic!`（test fail）。golden 不在は「`UPDATE_GOLDEN=1` を実行せよ」と案内して fail。
+- **fixture 不整合**: `wire.jsonl` のパース失敗など fixture 自体の破損はテストを明示的に fail させる（golden 差分と区別できるメッセージにする）。
+- **UPDATE_GOLDEN**: 設定時は比較せず上書きして pass（意図した golden 更新経路）。
+
+## テスト方針
+
+本 issue の成果物の中核がテストであり、以下を追加する。
+
+- **replay golden（convert 層）**: Claude / Codex の代表 turn fixture で `convert.golden` と一致することを検証する `#[test]`。
+  - Claude 代表 turn: text / thinking / tool_use / permission / result を含む。
+  - Codex 代表 turn: agentMessage / commandExecution / requestApproval / turn completed を含む。
+- **統合 golden（read model 層）**: 同 fixture を projector まで流し `read_model.golden` と一致することを検証する crate 最外周の `#[test]`（`test_support/agent_session_wire_replay.rs`）。
+- **tap gating の unit test**: `wire_record` を直接呼び、
+  - 環境変数未設定時にファイルが作られないこと、
+  - 設定時に writer channel の順序どおり `<dir>/<backend>.jsonl` へ 1 行 1 メッセージで追記されること、
+  - queue の件数上限・byte 上限を超えた行が enqueue されないこと、
+  - shutdown 後に enqueue 済みの末尾まで読み出せること、
+  を `tempdir` で検証する（外部プロセスは起動しない）。
+- **golden ヘルパの unit test**: `assert_golden` の一致 / 不一致 / `UPDATE_GOLDEN` 上書き / golden 不在時の挙動を `tempdir` で検証する。
+- 品質チェック: `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` を通す。
+
+## リスクと代替案
+
+- **テスト reducer と production 経路の乖離**: 統合 golden の reducer は `apply_runtime_event` の縮約であり、両者がずれると「read model の現状挙動を固定する」意図が損なわれる。緩和策として、reducer は projection を複製せず既存 building block（`merge_part` / `append_part_events` / `finalize_turn`）を再利用し、production と同じ `FinalPartsRecorded` → terminal event の順序を固定する。将来 T1（#1416）で production 経路を直接通す E2E に置き換える余地を残す。
+- **層またぎテストの依存**: convert と projector を跨ぐ orchestration は複数レイヤーを知る必要がある。内側の usecase test module には置かず、crate 最外周の `test_support` に閉じることで production とテストの双方で逆依存を作らない。
+- **golden の脆さ**: golden は決定的でなければならない。convert / read model の出力に非決定要素（HashMap 順序・タイムスタンプ・生成 id）が混ざると偽陽性になる。緩和策として reducer 側の `at` / message id は固定値、wire 由来の id はマスク済み安定値を使う。出力に map 由来の順序依存が無いことを実装時に確認する。
+- **tap による本番影響**: env 未設定時に channel 初期化も I/O も行わないこと、設定時は process-owned writer thread へ所有権を渡して stdout loop から blocking I/O を隔離し、失敗を握りつぶすことで非破壊を担保する。ホットパスに残る処理は byte reservation と bounded `try_send` だけであり、queue 超過時も stdout loop を待たせない。
+- **マスキングの網羅性**: マスク漏れで秘匿情報が commit されるリスク。緩和策として README にマスキング対象チェックリストを明記し、commit 前レビューで確認する（自動マスキングツールの整備は本 issue 非スコープ）。
+- **snapshot DTO の保守**: `AgentRuntimeEvent` の変種追加時は fixture module の snapshot DTO も明示更新が必要になる。domain へ転送形式を持ち込まない代わりに、網羅的な `match` をコンパイル時の更新点として使い、golden の JSON 表現を fixture 側へ閉じる。
+
+## 仮定
+
+`requirements.md` / `behavior.md` の仮定に加え、設計上以下を置く。いずれも本文中で扱いを明示済み。
+
+1. **record tap のファイル分割**: 採取先は backend ごとに `<dir>/claude.jsonl` / `<dir>/codex.jsonl` の 1 ファイルへ追記する。複数セッション同時採取時の行 interleave は開発時採取（単一セッション想定）では問題にしない。
+2. **tap は生 wire を採取しマスキングは行わない**: マスキングは fixture 化時に別途適用する（要求仮定 5）。採取先ディレクトリはリポジトリ外・gitignore 対象とし、マスク前データを commit しない運用とする。
+3. **代表 turn は各 backend 1 fixture（`normal_turn`）**: 受け入れ基準の要素を 1 turn で満たす。拡充は後続 issue の必要に応じて追加する（要求 非スコープ）。
+4. **統合 golden の写像はテスト reducer で行う**: `AgentRuntimeEvent → AgentSessionEvent` の pure な production 共有関数は存在しない（`apply_runtime_event` は runtime 状態に密結合）ため、既存 building block と production の `FinalPartsRecorded` → terminal event 順序を再利用したテスト reducer を crate 最外周に置く。
+5. **Oversize / drop 行の採取は best-effort**: Claude の oversize 行は生バイトを保持しないため採取をスキップする。パース失敗行は生行を保持するため採取する（behavior「可能な範囲で残す」）。
+6. **CI 変更不要**: 新テストは通常の `cargo test` で実行され、既存 CI 経路に含まれる。
+7. **golden は serde_json pretty JSON**: 要求仮定 4 どおり JSON を採用する（人間の合意により確定）。domain の転送形式非依存を保つため convert 出力は fixture 専用 snapshot DTO、read model は test build に限って usecase DTO 自身を serialize する。
+
+## Open Questions
+
+なし。

--- a/docs/specs/feat-issues-1383/requirements.md
+++ b/docs/specs/feat-issues-1383/requirements.md
@@ -1,0 +1,117 @@
+# Requirements — F1: wire record/replay 回帰テスト基盤
+
+対象 issue: [#1383](https://github.com/siro33950/releash/issues/1383)（milestone 84「Agentチャット安定化」／ Phase 0 ／依存なし）
+解消する監査問題: **ST-7（前半）** — 再発検出基盤の欠落（wire fixture replay テストが無い）
+
+## 背景と目的
+
+### 背景
+
+agent chat（Claude / Codex セッション）の wire メッセージを domain event / read model へ変換する経路には、現状 inline `json!` literal の単体テストしか存在しない。
+
+- Claude: `convert_claude_message`（`infrastructure/agent_session/claude/convert.rs:71`）が `&Value` を受け取り `ClaudeConversion { events: Vec<AgentRuntimeEvent>, auto_responses: Vec<Value> }` を返す。テストは 18 件すべて inline `json!`。
+- Codex: `convert_jsonrpc_message`（`infrastructure/agent_session/codex/convert.rs:34`）が `&Value` を受け取り `Vec<AgentRuntimeEvent>` を返す。テストは 22 件すべて inline `json!`。
+- `AgentRuntimeEvent` は `domain/agent_session/gateway.rs:57` に定義。durable 化された `AgentSessionEvent` は `event_log/projector.rs` の `project()` により `SessionReadModel`（messages / status / workflow_turn_complete / tool_retries）へ射影される。
+
+監査 ST-7 が指摘するとおり、CLI のバージョンアップや将来の変更で「無言破棄・扱いの差」が再発したとき、それを機械的に検出する手段が無い。監査で確定した多くの問題（CX-1 の wire 形式誤り、CX-4 のフィールド名不一致、CX-9 の dead code 化）は、実 wire ログを流すテストがあれば検出できたものである。
+
+### 目的
+
+実セッションの wire ログ（Claude の stream-json 行 / Codex の JSON-RPC 行）を fixture として `convert → AgentRuntimeEvent → 永続 event → projector → read model` に流し、出力を golden ファイルと比較する回帰テスト基盤を用意する。
+
+これにより:
+
+- **挙動等価の証明**: F4/F5（typed wire 置換）は「golden 不変」で変換挙動の等価を証明する。
+- **意図した差分のレビュー**: F6 以降（語彙変更）は「golden 差分が設計どおりか」をレビュー可能にする。
+- **milestone 84 全体の安全網**: 本 issue は Phase 0 の最初に実施し、以降の全 issue の回帰検出土台になる。
+
+wire 層の規範（`agent-chat-ideal-vocabulary.md` §12 / V-P1）に従い、content-plane の変換先の無い既知/未知メッセージ件数と control-plane の未対応件数を、将来の parity テスト（ST-7 後半 = T1 #1416）が別々に検証できる観測点をこの基盤で用意する。
+
+## スコープ
+
+1. **fixture 置き場と実 wire ログの格納**
+   - `src-tauri/src/infrastructure/agent_session/fixtures/{claude,codex}/` を新設し、実セッションから採取した wire ログ（Claude=stream-json 行、Codex=JSON-RPC 行）を JSONL として格納する。
+   - 秘匿情報（絶対パス・トークン・認証情報・メッセージ本文など）はマスキングして格納する。
+   - fixture は少なくとも受け入れ基準を満たす通常 turn を含む（後述）。
+
+2. **record tap（開発時採取機構）**
+   - Claude / Codex が共有する stdout line reader の生行分類境界に、環境変数ゲート `RELEASH_WIRE_RECORD=<dir>` の tap を追加し、各 backend process の生成時に対応する recorder を接続する。
+   - 既定（環境変数未設定）では無効で、本番挙動・パフォーマンスに影響しない。
+   - 採取した生行を `<dir>` 配下へ 1 行 1 メッセージの JSONL で書き出す。マスキング適用の有無は設計で定める（後述）。
+
+3. **replay テスト（convert → AgentRuntimeEvent の golden 比較）**
+   - fixture を 1 行ずつ `convert_claude_message` / `convert_jsonrpc_message` に流し、出力イベント列を `serde_json` 化して golden ファイルと比較するヘルパを実装する。
+   - Claude 側は `AgentRuntimeEvent` 列に加え `auto_responses`（control-plane の自動応答）も golden に含める。
+   - convert は stateful（`ClaudeConvertState` / `CodexConvertState`）であり、fixture を通す間 state を引き継ぐ。
+   - 新規依存を増やさず自作比較で行い、`UPDATE_GOLDEN=1` で golden を更新できる。
+
+4. **read model までの統合 golden**
+   - 同じ fixture を `AgentRuntimeEvent → 永続 event → event_apply → projector（`project()`）` まで通し、`SessionReadModel` のスナップショットも golden 比較する cross-layer テストを crate 最外周の `test_support` に追加する。
+
+5. **golden 更新手順のドキュメント**
+   - fixture ディレクトリに README を置き、record tap による採取手順・マスキング方針・`UPDATE_GOLDEN=1` による golden 更新手順を記載する。
+
+6. **CI 実行**
+   - replay / 統合 golden テストが `cargo test`（CI）で実行される。
+
+## 非スコープ
+
+- **監査 ST-7 後半に属する他テスト**: E2E turn ライフサイクルテスト、cross-backend parity テストは本 issue の対象外（T1 #1416）。本基盤はそれらが再利用できる形にとどめる。
+- **wire 変換の挙動変更・語彙変更**: convert / projector の出力を変える修正（CX-1 の wire 形式修正、CX-4 フィールド名、語彙拡張など）は F4/F5/F6 以降の各 issue の scope。本 issue は現状挙動を golden として固定するだけで、変換ロジックは変更しない。
+- **`codex/permission.rs` の誤挙動固定テスト（CX-1）の是正**: 誤った現行仕様を固定しているテストの修正は CX-1（F6 系）で扱う。
+- **frontend / playwright（`pnpm test:integration`）への追加**: agent chat の E2E は対象外。
+- **fixture の網羅的拡充**: 監査付録 A のすべての wire type を網羅する fixture 収集は行わない。受け入れ基準に挙げた代表 turn を満たす範囲にとどめ、拡充は各 issue の必要に応じて追加する。
+
+## 要求事項
+
+1. **fixture 基盤**: `infrastructure/agent_session/fixtures/{claude,codex}/` に、実セッション由来の wire ログを JSONL で格納できる。秘匿情報はマスキングされている。
+
+2. **record tap**: `RELEASH_WIRE_RECORD=<dir>` 設定時のみ、Claude / Codex の stdout 読み取り経路で受信した wire 行を `<dir>` に採取できる。未設定時は無効で本番挙動に影響しない。
+
+3. **replay golden（convert 層）**: fixture を convert に通して得た `AgentRuntimeEvent` 列（Claude は `auto_responses` 含む）を golden と比較し、不一致で fail する。`UPDATE_GOLDEN=1` で golden を更新できる。
+
+4. **統合 golden（read model 層）**: 同じ fixture を projector まで通した `SessionReadModel` スナップショットを golden と比較し、不一致で fail する。
+
+5. **自作比較・依存追加なし**: golden 比較は新規 crate 依存を追加せず自作する（既存 `cli/review.rs` の golden 前例と同方針）。
+
+6. **代表 turn の網羅**: Claude fixture は text / thinking / tool_use / permission / result を含む通常 turn を、Codex fixture は agentMessage / commandExecution / requestApproval / turn completed を含む通常 turn を対象に、それぞれ replay テストが通る。
+
+7. **ドキュメント**: fixture ディレクトリの README に golden 更新手順・採取手順・マスキング方針を記載する。
+
+8. **CI 統合**: 上記テストが `cargo test` で実行され、CI（`.github/workflows/ci.yml`）で走る。
+
+9. **挙動不変**: 本 issue の変更で convert / projector の出力（＝生成される golden）を変えない。record tap 追加は既存の読み取りループの挙動を変えない。
+
+## 受け入れ基準の概要
+
+- [ ] Claude fixture（text / thinking / tool_use / permission / result を含む通常 turn）で replay テストが通る。
+- [ ] Codex fixture（agentMessage / commandExecution / requestApproval / turn completed を含む通常 turn）で replay テストが通る。
+- [ ] convert 層 golden（`AgentRuntimeEvent` 列 ＋ Claude `auto_responses`）と read model 層 golden（`SessionReadModel`）の両方が比較対象になっている。
+- [ ] `RELEASH_WIRE_RECORD=<dir>` で実セッションから fixture を採取でき、未設定時は本番挙動に影響しない。
+- [ ] golden 更新手順（`UPDATE_GOLDEN=1` 等）が fixture ディレクトリの README に記載されている。
+- [ ] replay / 統合 golden テストが `cargo test`（CI）で実行される。
+- [ ] `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` が通る。
+
+## 仮定
+
+以下は本 issue と正本文書から判断できる範囲で置いた仮定。設計・実装で覆る場合は該当箇所を更新する。
+
+1. **spec-id / ディレクトリ**: ブランチ `feat/issues/1383` に対応し、spec ディレクトリは `docs/specs/feat-issues-1383/` とする。
+
+2. **record tap は本 issue の成果物に含める**: 受け入れ基準の「golden 更新手順を README に記載」は採取機構の存在を前提とするため、`RELEASH_WIRE_RECORD` tap を production コードとして実装・マージする。ただし既定無効・非破壊とする。
+
+3. **tap の挿入位置**: `stdout_line_reader.rs` が上限内の生行を `Json` / `NonJson` へ分類する直前に挿入し、Claude `process.rs` / Codex `app_server.rs` から backend 別 recorder を接続する。パース失敗行も記録し、8MB 超過行は shared reader が本文を保持しないため挙動不変を優先して記録対象外とする。
+
+4. **golden 形式**: golden は fixture ごとに、convert 層（events ＋ auto_responses）と read model 層（SessionReadModel）を `serde_json` の pretty JSON で保存する。golden ファイルは fixture と同じディレクトリ配下に置く。
+
+5. **マスキング方針**: 絶対パス・ホームディレクトリ・トークン / API キー・メッセージ本文などの秘匿値を安定なプレースホルダへ置換する。構造（type / subtype / フィールド構成 / イベント順序）は保持し、変換挙動の検証に必要な形状は壊さない。マスキングは fixture 格納時に確定させ、リポジトリにはマスク済みのみを commit する。
+
+6. **`UPDATE_GOLDEN` 環境変数**: golden 更新は `UPDATE_GOLDEN=1` を用いる（`cli/review.rs` に UPDATE_GOLDEN の前例は無いため本 issue で新規に導入する）。record tap は既存の環境変数取得方法に倣い `std::env::var_os` を用いる。
+
+7. **AgentRuntimeEvent → 永続 event の写像**: convert が返す `AgentRuntimeEvent` を durable な `AgentSessionEvent` へ写す際は、production の building block と turn 完了順序（最終 parts の `FinalPartsRecorded`、続いて terminal event）を統合 golden で再利用する。
+
+8. **依存追加なし**: `insta` / `goldenfile` 等の golden crate は導入しない（現状 `Cargo.toml` に無く、issue も自作比較を指定）。
+
+## Open Questions
+
+なし。

--- a/src-tauri/src/domain/agent_session/entities/mod.rs
+++ b/src-tauri/src/domain/agent_session/entities/mod.rs
@@ -5,6 +5,8 @@ mod permission_request;
 mod session;
 mod turn;
 
+#[cfg(test)]
+pub(crate) use attachment::Attachment;
 pub use attachment::AttachmentPayload;
 pub use message_part::{
     decide_tool_result_merge, merge_part, MessagePart, ToolResultMergeDecision, ToolResultUpdate,

--- a/src-tauri/src/infrastructure/agent_session/claude/process.rs
+++ b/src-tauri/src/infrastructure/agent_session/claude/process.rs
@@ -11,6 +11,7 @@ use tokio::sync::Mutex;
 
 use crate::domain::agent_session::gateway::SessionSpec;
 use crate::infrastructure::agent_session::stdout_line_reader::StdoutLineReader;
+use crate::infrastructure::agent_session::wire_record::{WireBackend, WireRecorder};
 use crate::infrastructure::process::child_env::AgentChildEnv;
 use crate::infrastructure::process::child_process::{configure_process_group, staged_shutdown};
 use crate::infrastructure::process::child_stderr::drain_child_stderr;
@@ -142,7 +143,10 @@ impl ClaudeStdioProcess {
                 stdin: Arc::new(Mutex::new(Some(stdin))),
                 pid_registration,
             },
-            stdout: StdoutLineReader::new(BufReader::new(stdout)),
+            stdout: StdoutLineReader::with_wire_recorder(
+                BufReader::new(stdout),
+                WireRecorder::from_env(WireBackend::Claude),
+            ),
             _system_prompt_file: system_prompt_file,
         })
     }
@@ -153,6 +157,10 @@ impl ClaudeStdioProcess {
 
     pub(crate) fn stdout_mut(&mut self) -> &mut StdoutLineReader<BufReader<ChildStdout>> {
         &mut self.stdout
+    }
+
+    pub(crate) async fn shutdown_wire_recorder(&mut self) {
+        self.stdout.shutdown_wire_recorder().await;
     }
 }
 

--- a/src-tauri/src/infrastructure/agent_session/claude/session.rs
+++ b/src-tauri/src/infrastructure/agent_session/claude/session.rs
@@ -47,6 +47,19 @@ pub(crate) struct ClaudeSessionRuntime {
 struct ClaudeRuntimeProcess {
     handle: ClaudeStdioHandle,
     closed: Arc<AtomicBool>,
+    read_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl ClaudeRuntimeProcess {
+    async fn shutdown(&mut self) {
+        self.closed.store(true, Ordering::Relaxed);
+        self.handle.shutdown().await;
+        if let Some(read_task) = self.read_task.take() {
+            if let Err(error) = read_task.await {
+                log::warn!("failed to join Claude stdout reader: {error}");
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -130,8 +143,7 @@ impl ClaudeSessionRuntime {
         )
         .await?;
         let mut process = self.process.lock().await;
-        process.closed.store(true, Ordering::Relaxed);
-        process.handle.shutdown().await;
+        process.shutdown().await;
         *process = replacement;
         Ok(())
     }
@@ -303,9 +315,7 @@ impl AgentSessionRuntime for ClaudeSessionRuntime {
     }
 
     async fn close(&self) {
-        let process = self.process.lock().await;
-        process.closed.store(true, Ordering::Relaxed);
-        process.handle.shutdown().await;
+        self.process.lock().await.shutdown().await;
     }
 }
 
@@ -325,7 +335,7 @@ async fn spawn_runtime_process(
     let initial_wire_mode = claude_wire_mode(spec.permission_mode, spec.plan_mode);
     let read_state = Arc::clone(&state);
     let read_handle = handle.clone();
-    tokio::spawn(async move {
+    let read_task = tokio::spawn(async move {
         read_loop(
             process.stdout_mut(),
             read_handle,
@@ -336,6 +346,7 @@ async fn spawn_runtime_process(
             initial_wire_mode,
         )
         .await;
+        process.shutdown_wire_recorder().await;
     });
 
     if let Err(error) = handle
@@ -344,9 +355,16 @@ async fn spawn_runtime_process(
     {
         closed.store(true, Ordering::Relaxed);
         handle.shutdown().await;
+        if let Err(join_error) = read_task.await {
+            log::warn!("failed to join Claude stdout reader: {join_error}");
+        }
         return Err(AgentBackendError::Other(error));
     }
-    Ok(ClaudeRuntimeProcess { handle, closed })
+    Ok(ClaudeRuntimeProcess {
+        handle,
+        closed,
+        read_task: Some(read_task),
+    })
 }
 
 async fn read_loop<R, W>(

--- a/src-tauri/src/infrastructure/agent_session/codex/app_server.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/app_server.rs
@@ -7,6 +7,7 @@ use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::Mutex;
 
 use crate::infrastructure::agent_session::stdout_line_reader::StdoutLineReader;
+use crate::infrastructure::agent_session::wire_record::{WireBackend, WireRecorder};
 use crate::infrastructure::process::child_env::AgentChildEnv;
 use crate::infrastructure::process::child_process::{configure_process_group, staged_shutdown};
 use crate::infrastructure::process::child_stderr::drain_child_stderr;
@@ -106,7 +107,10 @@ impl CodexAppServerProcess {
                 stdin: Arc::new(Mutex::new(Some(stdin))),
                 pid_registration,
             },
-            stdout: StdoutLineReader::new(BufReader::new(stdout)),
+            stdout: StdoutLineReader::with_wire_recorder(
+                BufReader::new(stdout),
+                WireRecorder::from_env(WireBackend::Codex),
+            ),
         })
     }
 
@@ -118,8 +122,9 @@ impl CodexAppServerProcess {
         &mut self.stdout
     }
 
-    pub(crate) async fn shutdown(self) {
+    pub(crate) async fn shutdown(mut self) {
         self.handle.shutdown().await;
+        self.stdout.shutdown_wire_recorder().await;
     }
 }
 

--- a/src-tauri/src/infrastructure/agent_session/codex/convert.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/convert.rs
@@ -656,7 +656,11 @@ fn question_from_value(value: &Value) -> PermissionQuestion {
 }
 
 fn token_usage_from_value(params: &Value) -> TokenUsage {
-    let usage = params.get("usage").unwrap_or(params);
+    let token_usage = params.get("tokenUsage");
+    let usage = token_usage
+        .and_then(|usage| usage.get("total"))
+        .or_else(|| params.get("usage"))
+        .unwrap_or(params);
     let input_tokens = usage
         .get("inputTokens")
         .or_else(|| usage.get("input_tokens"))
@@ -672,8 +676,9 @@ fn token_usage_from_value(params: &Value) -> TokenUsage {
         .or_else(|| usage.get("total_tokens"))
         .and_then(Value::as_u64)
         .or_else(|| Some(input_tokens + output_tokens));
-    let context_window_tokens = usage
-        .get("contextWindowTokens")
+    let context_window_tokens = token_usage
+        .and_then(|usage| usage.get("modelContextWindow"))
+        .or_else(|| usage.get("contextWindowTokens"))
         .or_else(|| usage.get("context_window_tokens"))
         .and_then(Value::as_u64);
     TokenUsage {
@@ -1033,7 +1038,16 @@ mod tests {
         let usage_events = convert_jsonrpc_message(
             &json!({
                 "method": "thread/tokenUsage/updated",
-                "params": { "inputTokens": 3, "outputTokens": 5, "totalTokens": 8 }
+                "params": {
+                    "tokenUsage": {
+                        "total": {
+                            "inputTokens": 4,
+                            "outputTokens": 6,
+                            "totalTokens": 10
+                        },
+                        "modelContextWindow": 128000
+                    }
+                }
             }),
             &mut state,
         );
@@ -1048,23 +1062,43 @@ mod tests {
         assert!(matches!(
             usage_events[0],
             AgentRuntimeEvent::TokenUsageUpdated(TokenUsage {
-                input_tokens: 3,
-                output_tokens: 5,
-                total_tokens: Some(8),
-                ..
+                input_tokens: 4,
+                output_tokens: 6,
+                total_tokens: Some(10),
+                context_window_tokens: Some(128000),
             })
         ));
         assert!(matches!(
             done_events[0],
             AgentRuntimeEvent::TurnCompleted(TurnResult::Completed {
                 token_usage: Some(TokenUsage {
-                    total_tokens: Some(8),
-                    ..
+                    input_tokens: 4,
+                    output_tokens: 6,
+                    total_tokens: Some(10),
+                    context_window_tokens: Some(128000),
                 }),
                 ..
             })
         ));
         assert_eq!(state.turn_id, None);
+    }
+
+    #[test]
+    fn test_token_usageのflat_schemaは後方互換として変換する() {
+        assert_eq!(
+            token_usage_from_value(&json!({
+                "inputTokens": 3,
+                "outputTokens": 5,
+                "totalTokens": 8,
+                "contextWindowTokens": 114000
+            })),
+            TokenUsage {
+                input_tokens: 3,
+                output_tokens: 5,
+                total_tokens: Some(8),
+                context_window_tokens: Some(114000),
+            }
+        );
     }
 
     #[test]

--- a/src-tauri/src/infrastructure/agent_session/codex/mod.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/mod.rs
@@ -6,4 +6,6 @@ mod session;
 mod skills;
 mod wire;
 
+#[cfg(test)]
+pub(crate) use convert::{convert_jsonrpc_message, CodexConvertState};
 pub(crate) use models::CodexBackend;

--- a/src-tauri/src/infrastructure/agent_session/codex/session.rs
+++ b/src-tauri/src/infrastructure/agent_session/codex/session.rs
@@ -33,6 +33,7 @@ pub(crate) struct CodexSessionRuntime {
     handle: CodexAppServerHandle,
     state: Arc<Mutex<CodexRuntimeState>>,
     events: StdMutex<Option<mpsc::UnboundedReceiver<AgentRuntimeEvent>>>,
+    read_task: StdMutex<Option<tokio::task::JoinHandle<()>>>,
     next_id: AtomicU64,
     closed: Arc<AtomicBool>,
 }
@@ -117,7 +118,7 @@ impl CodexSessionRuntime {
         let read_state = Arc::clone(&state);
         let read_closed = Arc::clone(&closed);
         let requested_resume_id = spec.resume.clone();
-        tokio::spawn(async move {
+        let mut read_task = Some(tokio::spawn(async move {
             read_loop(
                 process.stdout_mut(),
                 read_state,
@@ -127,27 +128,24 @@ impl CodexSessionRuntime {
             )
             .await;
             process.shutdown().await;
-        });
+        }));
 
         if let Err(error) = handle
             .write_json(&initialize_request(1, env!("CARGO_PKG_VERSION")))
             .await
         {
-            closed.store(true, Ordering::Relaxed);
-            handle.shutdown().await;
+            shutdown_opening_process(&handle, &closed, &mut read_task).await;
             return Err(AgentBackendError::Other(error));
         }
         if let Err(error) = handle.write_json(&initialized_notification()).await {
-            closed.store(true, Ordering::Relaxed);
-            handle.shutdown().await;
+            shutdown_opening_process(&handle, &closed, &mut read_task).await;
             return Err(AgentBackendError::Other(error));
         }
         let thread_request = if let Some(thread_id) = spec.resume.as_deref() {
             match build_thread_resume_request(startup_request_id, thread_id, &spec) {
                 Ok(request) => request,
                 Err(error) => {
-                    closed.store(true, Ordering::Relaxed);
-                    handle.shutdown().await;
+                    shutdown_opening_process(&handle, &closed, &mut read_task).await;
                     return Err(error);
                 }
             }
@@ -155,15 +153,13 @@ impl CodexSessionRuntime {
             match build_thread_start_request(startup_request_id, &spec) {
                 Ok(request) => request,
                 Err(error) => {
-                    closed.store(true, Ordering::Relaxed);
-                    handle.shutdown().await;
+                    shutdown_opening_process(&handle, &closed, &mut read_task).await;
                     return Err(error);
                 }
             }
         };
         if let Err(error) = handle.write_json(&thread_request).await {
-            closed.store(true, Ordering::Relaxed);
-            handle.shutdown().await;
+            shutdown_opening_process(&handle, &closed, &mut read_task).await;
             return Err(AgentBackendError::Other(error));
         }
 
@@ -171,6 +167,7 @@ impl CodexSessionRuntime {
             handle,
             state,
             events: StdMutex::new(Some(events_rx)),
+            read_task: StdMutex::new(read_task),
             next_id: AtomicU64::new(100),
             closed,
         })
@@ -329,6 +326,30 @@ impl AgentSessionRuntime for CodexSessionRuntime {
     async fn close(&self) {
         self.closed.store(true, Ordering::Relaxed);
         self.handle.shutdown().await;
+        let read_task = self
+            .read_task
+            .lock()
+            .ok()
+            .and_then(|mut read_task| read_task.take());
+        if let Some(read_task) = read_task {
+            if let Err(error) = read_task.await {
+                log::warn!("failed to join Codex stdout reader: {error}");
+            }
+        }
+    }
+}
+
+async fn shutdown_opening_process(
+    handle: &CodexAppServerHandle,
+    closed: &Arc<AtomicBool>,
+    read_task: &mut Option<tokio::task::JoinHandle<()>>,
+) {
+    closed.store(true, Ordering::Relaxed);
+    handle.shutdown().await;
+    if let Some(read_task) = read_task.take() {
+        if let Err(error) = read_task.await {
+            log::warn!("failed to join Codex stdout reader: {error}");
+        }
     }
 }
 

--- a/src-tauri/src/infrastructure/agent_session/fixtures/README.md
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/README.md
@@ -1,0 +1,38 @@
+# Agent session wire fixtures
+
+このディレクトリは、Claude の stream-json と Codex app-server の JSON-RPC を、1 行 1 メッセージの JSONL fixture として保持する。各 fixture ディレクトリには `wire.jsonl`、convert 層の `convert.golden`、projector 後の `read_model.golden` を併置する。
+
+## 採取
+
+リポジトリ外の一時ディレクトリを指定して、対象 backend の実セッションを実行する。
+
+```bash
+RELEASH_WIRE_RECORD=/tmp/releash-wire pnpm tauri:dev
+```
+
+受信した生行は `/tmp/releash-wire/claude.jsonl` または `/tmp/releash-wire/codex.jsonl` へ追記される。環境変数を設定しない通常実行ではファイル I/O は発生しない。対象セッションまたはアプリを通常終了し、終了時の queue drain / flush が完了してから採取ログをコピーする。tap は生データをマスクしないため、採取先をリポジトリ内に置いたり、そのまま commit したりしないこと。
+
+## マスキング
+
+採取ログから対象 turn だけを新しい fixture の `wire.jsonl` へコピーする前に、次を安定したプレースホルダへ置換する。
+
+- ホーム、worktree、リポジトリなどの絶対パス: `<WORKTREE>`、`<HOME>`
+- prompt、応答、thinking、tool output などの本文: `<USER_MESSAGE>`、`<ASSISTANT_TEXT>`、`<THINKING>`、`<TOOL_RESULT>`
+- token、API key、認証ヘッダー、URL query、環境変数のsecret: `<REDACTED>`
+- session、turn、item、tool、permissionなどのID: `<SESSION_ID>`、`<TURN_ID>`、`<TOOL_USE_ID>`
+- コマンドやファイル名に個人情報が含まれる場合: `<COMMAND>`、`<FILE_PATH>`
+
+`type`、`subtype`、`method`、フィールド構造、メッセージ順序は変えない。JSONL全体を検索し、実名、メールアドレス、ホスト名、絶対パス、token形式、実メッセージ本文が残っていないことをcommit前に確認する。
+
+## golden の更新
+
+fixtureを追加または意図的に変えた後、`src-tauri` で次を実行する。
+
+```bash
+UPDATE_GOLDEN=1 cargo test infrastructure::agent_session::fixtures
+UPDATE_GOLDEN=1 cargo test test_support::agent_session_wire_replay
+cargo test infrastructure::agent_session::fixtures
+cargo test test_support::agent_session_wire_replay
+```
+
+更新された両goldenをレビューし、convertの各行出力、Claudeの`auto_responses`、最終read modelの差分が意図どおりであることを確認する。通常の`cargo test`はgoldenを更新せず、不一致時に最初の相違行を報告して失敗する。

--- a/src-tauri/src/infrastructure/agent_session/fixtures/claude/normal_turn/convert.golden
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/claude/normal_turn/convert.golden
@@ -1,0 +1,175 @@
+[
+  {
+    "line_index": 1,
+    "events": [
+      {
+        "SessionEstablished": {
+          "backend_session_id": "<SESSION_ID>",
+          "resume": "NotRequested"
+        }
+      },
+      {
+        "SlashCommandsUpdated": [
+          {
+            "name": "/review",
+            "description": "<COMMAND_DESCRIPTION>",
+            "argument_hint": "<ARGUMENT_HINT>"
+          }
+        ]
+      }
+    ],
+    "auto_responses": []
+  },
+  {
+    "line_index": 2,
+    "events": [
+      {
+        "PartsMerged": [
+          {
+            "Thinking": {
+              "content": "<THINKING>",
+              "parent_tool_use_id": null
+            }
+          }
+        ]
+      }
+    ],
+    "auto_responses": []
+  },
+  {
+    "line_index": 3,
+    "events": [
+      {
+        "PartsMerged": [
+          {
+            "Text": {
+              "content": "<ASSISTANT_TEXT>",
+              "parent_tool_use_id": null
+            }
+          }
+        ]
+      }
+    ],
+    "auto_responses": []
+  },
+  {
+    "line_index": 4,
+    "events": [
+      {
+        "PartsMerged": [
+          {
+            "ToolUse": {
+              "id": "<TOOL_USE_ID>",
+              "tool": "Bash",
+              "input": "{\"command\":\"<COMMAND>\"}",
+              "parent_tool_use_id": null
+            }
+          }
+        ]
+      }
+    ],
+    "auto_responses": []
+  },
+  {
+    "line_index": 5,
+    "events": [],
+    "auto_responses": [
+      {
+        "response": {
+          "request_id": "<AUTO_PERMISSION_REQUEST_ID>",
+          "response": {
+            "behavior": "allow",
+            "updatedInput": {
+              "command": "<COMMAND>"
+            }
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    ]
+  },
+  {
+    "line_index": 6,
+    "events": [
+      {
+        "PartsMerged": [
+          {
+            "ToolResult": {
+              "content": "<TOOL_RESULT>",
+              "is_error": false,
+              "tool_use_id": "<TOOL_USE_ID>",
+              "parent_tool_use_id": null,
+              "content_ref": null,
+              "summary": null
+            }
+          }
+        ]
+      }
+    ],
+    "auto_responses": []
+  },
+  {
+    "line_index": 7,
+    "events": [
+      {
+        "PermissionRequested": {
+          "id": "<PERMISSION_REQUEST_ID>",
+          "tool_use_id": "<QUESTION_TOOL_USE_ID>",
+          "parent_tool_use_id": null,
+          "tool_name": "AskUserQuestion",
+          "body": {
+            "Question": {
+              "questions": [
+                {
+                  "question": "<QUESTION>",
+                  "header": "<HEADER>",
+                  "options": [
+                    {
+                      "label": "<OPTION>",
+                      "description": "<OPTION_DESCRIPTION>"
+                    }
+                  ],
+                  "multi_select": false
+                }
+              ]
+            }
+          },
+          "title": null,
+          "display_name": null,
+          "description": null,
+          "decision_reason": null,
+          "status": "Pending"
+        }
+      }
+    ],
+    "auto_responses": []
+  },
+  {
+    "line_index": 8,
+    "events": [
+      {
+        "TokenUsageUpdated": {
+          "input_tokens": 6,
+          "output_tokens": 5,
+          "total_tokens": 11,
+          "context_window_tokens": 200000
+        }
+      },
+      {
+        "TurnCompleted": {
+          "Completed": {
+            "stop_reason": null,
+            "token_usage": {
+              "input_tokens": 6,
+              "output_tokens": 5,
+              "total_tokens": 11,
+              "context_window_tokens": 200000
+            }
+          }
+        }
+      }
+    ],
+    "auto_responses": []
+  }
+]

--- a/src-tauri/src/infrastructure/agent_session/fixtures/claude/normal_turn/read_model.golden
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/claude/normal_turn/read_model.golden
@@ -1,0 +1,100 @@
+{
+  "messages": [
+    {
+      "id": "<PROMPT_MESSAGE_ID>",
+      "role": "human",
+      "content": "<USER_MESSAGE>",
+      "streamingFinalSeq": 0,
+      "timestamp": 1700000000.0
+    },
+    {
+      "id": "<ASSISTANT_MESSAGE_ID>",
+      "role": "agent",
+      "content": "<ASSISTANT_TEXT>",
+      "thinking": "<THINKING>",
+      "activities": [
+        {
+          "type": "tool_use",
+          "tool": "Bash",
+          "input": {
+            "command": "<COMMAND>"
+          },
+          "id": "<TOOL_USE_ID>"
+        },
+        {
+          "type": "tool_result",
+          "content": "<TOOL_RESULT>",
+          "isError": false,
+          "toolUseId": "<TOOL_USE_ID>"
+        }
+      ],
+      "parts": [
+        {
+          "type": "thinking",
+          "content": "<THINKING>"
+        },
+        {
+          "type": "text",
+          "content": "<ASSISTANT_TEXT>"
+        },
+        {
+          "type": "tool_use",
+          "tool": "Bash",
+          "input": {
+            "command": "<COMMAND>"
+          },
+          "id": "<TOOL_USE_ID>"
+        },
+        {
+          "type": "tool_result",
+          "content": "<TOOL_RESULT>",
+          "isError": false,
+          "toolUseId": "<TOOL_USE_ID>"
+        },
+        {
+          "type": "permission",
+          "request": {
+            "id": "<PERMISSION_REQUEST_ID>",
+            "toolUseId": "<QUESTION_TOOL_USE_ID>",
+            "toolName": "AskUserQuestion",
+            "kind": "question",
+            "questions": [
+              {
+                "question": "<QUESTION>",
+                "header": "<HEADER>",
+                "options": [
+                  {
+                    "label": "<OPTION>",
+                    "description": "<OPTION_DESCRIPTION>"
+                  }
+                ],
+                "multiSelect": false
+              }
+            ]
+          },
+          "status": "pending"
+        }
+      ],
+      "streamingFinalSeq": 0,
+      "timestamp": 1700000000.0
+    }
+  ],
+  "status": {
+    "session_state": "done",
+    "turn_phase": "idle"
+  },
+  "workflow_turn_complete": {
+    "turn_id": 1,
+    "exit_code": 0,
+    "final_text_parts": [
+      "<ASSISTANT_TEXT>"
+    ],
+    "failure_signal": null,
+    "token_usage": {
+      "inputTokens": 6,
+      "outputTokens": 5
+    },
+    "interrupted": false
+  },
+  "tool_retries": []
+}

--- a/src-tauri/src/infrastructure/agent_session/fixtures/claude/normal_turn/wire.jsonl
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/claude/normal_turn/wire.jsonl
@@ -1,0 +1,8 @@
+{"type":"system","subtype":"init","session_id":"<SESSION_ID>","commands":[{"name":"/review","description":"<COMMAND_DESCRIPTION>","argument_hint":"<ARGUMENT_HINT>"}]}
+{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"<THINKING>"}}}
+{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"<ASSISTANT_TEXT>"}}}
+{"type":"assistant","parent_tool_use_id":null,"message":{"role":"assistant","content":[{"type":"tool_use","id":"<TOOL_USE_ID>","name":"Bash","input":{"command":"<COMMAND>"}}]}}
+{"type":"control_request","request_id":"<AUTO_PERMISSION_REQUEST_ID>","request":{"subtype":"can_use_tool","tool_name":"Bash","tool_use_id":"<TOOL_USE_ID>","input":{"command":"<COMMAND>"}}}
+{"type":"user","parent_tool_use_id":null,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"<TOOL_USE_ID>","content":"<TOOL_RESULT>","is_error":false}]}}
+{"type":"control_request","request_id":"<PERMISSION_REQUEST_ID>","request":{"subtype":"can_use_tool","tool_name":"AskUserQuestion","tool_use_id":"<QUESTION_TOOL_USE_ID>","input":{"questions":[{"question":"<QUESTION>","header":"<HEADER>","options":[{"label":"<OPTION>","description":"<OPTION_DESCRIPTION>"}],"multiSelect":false}]}}}
+{"type":"result","subtype":"success","is_error":false,"result":"<RESULT>","modelUsage":{"<MODEL>":{"inputTokens":3,"outputTokens":5,"cacheReadInputTokens":2,"cacheCreationInputTokens":1,"contextWindow":200000}}}

--- a/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/convert.golden
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/convert.golden
@@ -112,10 +112,10 @@
     "events": [
       {
         "TokenUsageUpdated": {
-          "input_tokens": 0,
-          "output_tokens": 0,
-          "total_tokens": 0,
-          "context_window_tokens": null
+          "input_tokens": 4,
+          "output_tokens": 6,
+          "total_tokens": 10,
+          "context_window_tokens": 128000
         }
       }
     ]
@@ -128,10 +128,10 @@
           "Completed": {
             "stop_reason": null,
             "token_usage": {
-              "input_tokens": 0,
-              "output_tokens": 0,
-              "total_tokens": 0,
-              "context_window_tokens": null
+              "input_tokens": 4,
+              "output_tokens": 6,
+              "total_tokens": 10,
+              "context_window_tokens": 128000
             }
           }
         }

--- a/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/convert.golden
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/convert.golden
@@ -1,0 +1,141 @@
+[
+  {
+    "line_index": 1,
+    "events": [
+      {
+        "SessionEstablished": {
+          "backend_session_id": "<THREAD_ID>",
+          "resume": "NotRequested"
+        }
+      }
+    ]
+  },
+  {
+    "line_index": 2,
+    "events": []
+  },
+  {
+    "line_index": 3,
+    "events": [
+      {
+        "PartsMerged": [
+          {
+            "Text": {
+              "content": "<ASSISTANT_TEXT>",
+              "parent_tool_use_id": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "line_index": 4,
+    "events": [
+      {
+        "PartsMerged": [
+          {
+            "ToolUse": {
+              "id": "<COMMAND_ITEM_ID>",
+              "tool": "Bash",
+              "input": "{\"command\":\"<COMMAND>\",\"cwd\":\"<WORKTREE>\",\"status\":\"inProgress\"}",
+              "parent_tool_use_id": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "line_index": 5,
+    "events": [
+      {
+        "PermissionRequested": {
+          "id": "42",
+          "tool_use_id": "<COMMAND_ITEM_ID>",
+          "parent_tool_use_id": null,
+          "tool_name": "CodexCommand",
+          "body": {
+            "ToolApproval": {
+              "input": "{\"command\":\"<COMMAND>\",\"cwd\":\"<WORKTREE>\",\"itemId\":\"<COMMAND_ITEM_ID>\",\"threadId\":\"<THREAD_ID>\",\"turnId\":\"<TURN_ID>\"}"
+            }
+          },
+          "title": "Codex approval requested",
+          "display_name": "CodexCommand",
+          "description": "Command approval",
+          "decision_reason": null,
+          "status": "Pending"
+        }
+      }
+    ]
+  },
+  {
+    "line_index": 6,
+    "events": [
+      {
+        "PartsMerged": [
+          {
+            "ToolResult": {
+              "content": "<COMMAND_OUTPUT>",
+              "is_error": false,
+              "tool_use_id": "<COMMAND_ITEM_ID>",
+              "parent_tool_use_id": null,
+              "content_ref": null,
+              "summary": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "line_index": 7,
+    "events": [
+      {
+        "PartsMerged": [
+          {
+            "ToolResult": {
+              "content": "<TOOL_RESULT>",
+              "is_error": false,
+              "tool_use_id": "<COMMAND_ITEM_ID>",
+              "parent_tool_use_id": null,
+              "content_ref": null,
+              "summary": null
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "line_index": 8,
+    "events": [
+      {
+        "TokenUsageUpdated": {
+          "input_tokens": 0,
+          "output_tokens": 0,
+          "total_tokens": 0,
+          "context_window_tokens": null
+        }
+      }
+    ]
+  },
+  {
+    "line_index": 9,
+    "events": [
+      {
+        "TurnCompleted": {
+          "Completed": {
+            "stop_reason": null,
+            "token_usage": {
+              "input_tokens": 0,
+              "output_tokens": 0,
+              "total_tokens": 0,
+              "context_window_tokens": null
+            }
+          }
+        }
+      }
+    ]
+  }
+]

--- a/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/read_model.golden
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/read_model.golden
@@ -1,0 +1,96 @@
+{
+  "messages": [
+    {
+      "id": "<PROMPT_MESSAGE_ID>",
+      "role": "human",
+      "content": "<USER_MESSAGE>",
+      "streamingFinalSeq": 0,
+      "timestamp": 1700000000.0
+    },
+    {
+      "id": "<ASSISTANT_MESSAGE_ID>",
+      "role": "agent",
+      "content": "<ASSISTANT_TEXT>",
+      "activities": [
+        {
+          "type": "tool_use",
+          "tool": "Bash",
+          "input": {
+            "command": "<COMMAND>",
+            "cwd": "<WORKTREE>",
+            "status": "inProgress"
+          },
+          "id": "<COMMAND_ITEM_ID>"
+        },
+        {
+          "type": "tool_result",
+          "content": "<COMMAND_OUTPUT><TOOL_RESULT>",
+          "isError": false,
+          "toolUseId": "<COMMAND_ITEM_ID>"
+        }
+      ],
+      "parts": [
+        {
+          "type": "text",
+          "content": "<ASSISTANT_TEXT>"
+        },
+        {
+          "type": "tool_use",
+          "tool": "Bash",
+          "input": {
+            "command": "<COMMAND>",
+            "cwd": "<WORKTREE>",
+            "status": "inProgress"
+          },
+          "id": "<COMMAND_ITEM_ID>"
+        },
+        {
+          "type": "permission",
+          "request": {
+            "id": "42",
+            "toolUseId": "<COMMAND_ITEM_ID>",
+            "toolName": "CodexCommand",
+            "kind": "tool_approval",
+            "input": {
+              "command": "<COMMAND>",
+              "cwd": "<WORKTREE>",
+              "itemId": "<COMMAND_ITEM_ID>",
+              "threadId": "<THREAD_ID>",
+              "turnId": "<TURN_ID>"
+            },
+            "title": "Codex approval requested",
+            "displayName": "CodexCommand",
+            "description": "Command approval"
+          },
+          "status": "pending"
+        },
+        {
+          "type": "tool_result",
+          "content": "<COMMAND_OUTPUT><TOOL_RESULT>",
+          "isError": false,
+          "toolUseId": "<COMMAND_ITEM_ID>"
+        }
+      ],
+      "streamingFinalSeq": 0,
+      "timestamp": 1700000000.0
+    }
+  ],
+  "status": {
+    "session_state": "done",
+    "turn_phase": "idle"
+  },
+  "workflow_turn_complete": {
+    "turn_id": 1,
+    "exit_code": 0,
+    "final_text_parts": [
+      "<ASSISTANT_TEXT>"
+    ],
+    "failure_signal": null,
+    "token_usage": {
+      "inputTokens": 0,
+      "outputTokens": 0
+    },
+    "interrupted": false
+  },
+  "tool_retries": []
+}

--- a/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/read_model.golden
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/read_model.golden
@@ -87,8 +87,8 @@
     ],
     "failure_signal": null,
     "token_usage": {
-      "inputTokens": 0,
-      "outputTokens": 0
+      "inputTokens": 4,
+      "outputTokens": 6
     },
     "interrupted": false
   },

--- a/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/wire.jsonl
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/codex/normal_turn/wire.jsonl
@@ -1,0 +1,9 @@
+{"method":"thread/started","params":{"thread":{"id":"<THREAD_ID>"}}}
+{"method":"turn/started","params":{"turn":{"id":"<TURN_ID>"}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"<THREAD_ID>","turnId":"<TURN_ID>","itemId":"<AGENT_MESSAGE_ID>","delta":"<ASSISTANT_TEXT>"}}
+{"method":"item/started","params":{"threadId":"<THREAD_ID>","turnId":"<TURN_ID>","item":{"type":"commandExecution","id":"<COMMAND_ITEM_ID>","command":"<COMMAND>","cwd":"<WORKTREE>","status":"inProgress"}}}
+{"id":42,"method":"item/commandExecution/requestApproval","params":{"threadId":"<THREAD_ID>","turnId":"<TURN_ID>","itemId":"<COMMAND_ITEM_ID>","command":"<COMMAND>","cwd":"<WORKTREE>"}}
+{"method":"item/commandExecution/outputDelta","params":{"threadId":"<THREAD_ID>","turnId":"<TURN_ID>","itemId":"<COMMAND_ITEM_ID>","delta":"<COMMAND_OUTPUT>"}}
+{"method":"item/completed","params":{"threadId":"<THREAD_ID>","turnId":"<TURN_ID>","item":{"type":"commandExecution","id":"<COMMAND_ITEM_ID>","command":"<COMMAND>","cwd":"<WORKTREE>","status":"completed","aggregatedOutput":"<TOOL_RESULT>","exitCode":0}}}
+{"method":"thread/tokenUsage/updated","params":{"threadId":"<THREAD_ID>","turnId":"<TURN_ID>","tokenUsage":{"total":{"totalTokens":10,"inputTokens":4,"cachedInputTokens":0,"outputTokens":6,"reasoningOutputTokens":0},"last":{"totalTokens":10,"inputTokens":4,"cachedInputTokens":0,"outputTokens":6,"reasoningOutputTokens":0},"modelContextWindow":128000}}}
+{"method":"turn/completed","params":{"threadId":"<THREAD_ID>","turn":{"id":"<TURN_ID>","status":"completed"}}}

--- a/src-tauri/src/infrastructure/agent_session/fixtures/mod.rs
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/mod.rs
@@ -1,0 +1,323 @@
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::domain::agent_session::gateway::AgentRuntimeEvent;
+
+use super::claude::convert::{convert_claude_message, ClaudeConversion, ClaudeConvertState};
+use super::claude::wire::ClaudeWireMode;
+use super::codex::{convert_jsonrpc_message, CodexConvertState};
+
+mod snapshot;
+
+const FIXTURE_ROOT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/src/infrastructure/agent_session/fixtures"
+);
+const UPDATE_GOLDEN_ENV: &str = "UPDATE_GOLDEN";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FixtureBackend {
+    Claude,
+    Codex,
+}
+
+impl FixtureBackend {
+    fn directory_name(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ReplayedFixture {
+    pub backend: FixtureBackend,
+    pub name: String,
+    pub events: Vec<AgentRuntimeEvent>,
+    directory: PathBuf,
+    convert_output: String,
+}
+
+impl ReplayedFixture {
+    pub(crate) fn convert_golden_path(&self) -> PathBuf {
+        self.directory.join("convert.golden")
+    }
+
+    pub(crate) fn read_model_golden_path(&self) -> PathBuf {
+        self.directory.join("read_model.golden")
+    }
+
+    fn assert_convert_golden(&self) {
+        assert_golden(&self.convert_golden_path(), &self.convert_output);
+    }
+}
+
+#[derive(Serialize)]
+struct ReplayLine {
+    line_index: usize,
+    events: Vec<snapshot::RuntimeEventSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_responses: Option<Vec<Value>>,
+}
+
+pub(crate) fn replay_backend(backend: FixtureBackend) -> Vec<ReplayedFixture> {
+    let directories = fixture_directories(backend);
+    assert!(
+        !directories.is_empty(),
+        "no {} wire fixtures found under {FIXTURE_ROOT}",
+        backend.directory_name()
+    );
+    directories
+        .into_iter()
+        .map(|directory| replay_fixture(backend, directory))
+        .collect()
+}
+
+fn fixture_directories(backend: FixtureBackend) -> Vec<PathBuf> {
+    let backend_root = Path::new(FIXTURE_ROOT).join(backend.directory_name());
+    let mut directories = fs::read_dir(&backend_root)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to read fixture directory {}: {error}",
+                backend_root.display()
+            )
+        })
+        .map(|entry| entry.expect("failed to read fixture entry").path())
+        .filter(|path| path.is_dir() && path.join("wire.jsonl").is_file())
+        .collect::<Vec<_>>();
+    directories.sort();
+    directories
+}
+
+fn replay_fixture(backend: FixtureBackend, directory: PathBuf) -> ReplayedFixture {
+    let wire_path = directory.join("wire.jsonl");
+    let wire = fs::read_to_string(&wire_path)
+        .unwrap_or_else(|error| panic!("failed to read fixture {}: {error}", wire_path.display()));
+    assert!(!wire.is_empty(), "fixture {} is empty", wire_path.display());
+
+    let mut events = Vec::new();
+    let lines = match backend {
+        FixtureBackend::Claude => replay_claude_lines(&wire_path, &wire, &mut events),
+        FixtureBackend::Codex => replay_codex_lines(&wire_path, &wire, &mut events),
+    };
+    let name = directory
+        .file_name()
+        .and_then(OsStr::to_str)
+        .unwrap_or("fixture")
+        .to_string();
+    ReplayedFixture {
+        backend,
+        name,
+        events,
+        directory,
+        convert_output: pretty_json(&lines),
+    }
+}
+
+fn replay_claude_lines(
+    wire_path: &Path,
+    wire: &str,
+    all_events: &mut Vec<AgentRuntimeEvent>,
+) -> Vec<ReplayLine> {
+    let mut state = ClaudeConvertState::new(None, ClaudeWireMode::AcceptEdits);
+    wire.lines()
+        .enumerate()
+        .map(|(index, raw_line)| {
+            let message = parse_fixture_line(wire_path, index, raw_line);
+            let ClaudeConversion {
+                events,
+                auto_responses,
+            } = convert_claude_message(&message, &mut state);
+            let event_snapshots = events.iter().map(Into::into).collect();
+            all_events.extend(events.iter().cloned());
+            ReplayLine {
+                line_index: index + 1,
+                events: event_snapshots,
+                auto_responses: Some(auto_responses),
+            }
+        })
+        .collect()
+}
+
+fn replay_codex_lines(
+    wire_path: &Path,
+    wire: &str,
+    all_events: &mut Vec<AgentRuntimeEvent>,
+) -> Vec<ReplayLine> {
+    let mut state = CodexConvertState::default();
+    wire.lines()
+        .enumerate()
+        .map(|(index, raw_line)| {
+            let message = parse_fixture_line(wire_path, index, raw_line);
+            let events = convert_jsonrpc_message(&message, &mut state);
+            let event_snapshots = events.iter().map(Into::into).collect();
+            all_events.extend(events.iter().cloned());
+            ReplayLine {
+                line_index: index + 1,
+                events: event_snapshots,
+                auto_responses: None,
+            }
+        })
+        .collect()
+}
+
+fn parse_fixture_line(wire_path: &Path, index: usize, raw_line: &str) -> Value {
+    serde_json::from_str(raw_line).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSONL fixture {} line {}: {error}",
+            wire_path.display(),
+            index + 1
+        )
+    })
+}
+
+pub(crate) fn pretty_json<T: Serialize>(value: &T) -> String {
+    let mut output = serde_json::to_string_pretty(value).expect("golden value must serialize");
+    output.push('\n');
+    output
+}
+
+pub(crate) fn assert_golden(path: &Path, actual: &str) {
+    let update = update_golden_enabled(std::env::var_os(UPDATE_GOLDEN_ENV).as_deref());
+    assert_golden_with_update(path, actual, update);
+}
+
+fn update_golden_enabled(value: Option<&OsStr>) -> bool {
+    value == Some(OsStr::new("1"))
+}
+
+fn assert_golden_with_update(path: &Path, actual: &str, update: bool) {
+    if update {
+        fs::write(path, actual)
+            .unwrap_or_else(|error| panic!("failed to update golden {}: {error}", path.display()));
+        return;
+    }
+    let expected = fs::read_to_string(path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read golden {}: {error}; run with UPDATE_GOLDEN=1 to generate it",
+            path.display()
+        )
+    });
+    let expected = expected.replace("\r\n", "\n");
+    if expected != actual {
+        panic!(
+            "golden mismatch for {}\n{}\nrun with UPDATE_GOLDEN=1 after reviewing the change",
+            path.display(),
+            first_difference(&expected, actual)
+        );
+    }
+}
+
+fn first_difference(expected: &str, actual: &str) -> String {
+    let expected_lines = expected.lines().collect::<Vec<_>>();
+    let actual_lines = actual.lines().collect::<Vec<_>>();
+    let line_index = (0..expected_lines.len().max(actual_lines.len()))
+        .find(|index| expected_lines.get(*index) != actual_lines.get(*index))
+        .unwrap_or(0);
+    format!(
+        "first difference at line {}:\nexpected: {}\nactual:   {}",
+        line_index + 1,
+        expected_lines.get(line_index).copied().unwrap_or("<EOF>"),
+        actual_lines.get(line_index).copied().unwrap_or("<EOF>")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::panic::AssertUnwindSafe;
+
+    use super::*;
+
+    #[test]
+    fn claude_fixtures_match_convert_golden() {
+        for fixture in replay_backend(FixtureBackend::Claude) {
+            fixture.assert_convert_golden();
+        }
+    }
+
+    #[test]
+    fn codex_fixtures_match_convert_golden() {
+        for fixture in replay_backend(FixtureBackend::Codex) {
+            fixture.assert_convert_golden();
+        }
+    }
+
+    #[test]
+    fn golden_helper_accepts_matching_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fixture.golden");
+        fs::write(&path, "same\n").unwrap();
+
+        assert_golden_with_update(&path, "same\n", false);
+    }
+
+    #[test]
+    fn golden_helper_accepts_crlf_expected_for_lf_actual() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fixture.golden");
+        fs::write(&path, "first\r\nsecond\r\n").unwrap();
+
+        assert_golden_with_update(&path, "first\nsecond\n", false);
+    }
+
+    #[test]
+    fn golden_helper_reports_mismatch_and_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fixture.golden");
+        fs::write(&path, "before\n").unwrap();
+
+        let mismatch = panic_payload(std::panic::catch_unwind(AssertUnwindSafe(|| {
+            assert_golden_with_update(&path, "after\n", false);
+        })));
+        let missing = panic_payload(std::panic::catch_unwind(AssertUnwindSafe(|| {
+            assert_golden_with_update(&dir.path().join("missing.golden"), "value\n", false);
+        })));
+
+        assert!(mismatch.contains(&path.display().to_string()));
+        assert!(mismatch.contains("first difference at line 1:"));
+        assert!(mismatch.contains("expected: before"));
+        assert!(mismatch.contains("actual:   after"));
+        assert!(missing.contains("run with UPDATE_GOLDEN=1 to generate it"));
+    }
+
+    fn panic_payload(result: Result<(), Box<dyn Any + Send>>) -> String {
+        let payload = result.expect_err("golden assertion should panic");
+        payload
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| {
+                payload
+                    .downcast_ref::<&str>()
+                    .map(|message| (*message).to_string())
+            })
+            .expect("panic payload should be a string")
+    }
+
+    #[test]
+    fn update_golden_gate_accepts_only_one() {
+        assert_eq!(UPDATE_GOLDEN_ENV, "UPDATE_GOLDEN");
+        assert!(update_golden_enabled(Some(OsStr::new("1"))));
+        assert!(!update_golden_enabled(None));
+        for value in ["", "0", "true"] {
+            assert!(!update_golden_enabled(Some(OsStr::new(value))));
+        }
+    }
+
+    #[test]
+    fn golden_helper_update_overwrites_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fixture.golden");
+        fs::write(&path, "before\n").unwrap();
+
+        let update = update_golden_enabled(Some(OsStr::new("1")));
+        assert_golden_with_update(&path, "after\n", update);
+
+        assert_eq!(fs::read_to_string(path).unwrap(), "after\n");
+    }
+}

--- a/src-tauri/src/infrastructure/agent_session/fixtures/mod.rs
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/mod.rs
@@ -216,9 +216,23 @@ fn assert_golden_with_update(path: &Path, actual: &str, update: bool) {
 fn first_difference(expected: &str, actual: &str) -> String {
     let expected_lines = expected.lines().collect::<Vec<_>>();
     let actual_lines = actual.lines().collect::<Vec<_>>();
-    let line_index = (0..expected_lines.len().max(actual_lines.len()))
+    let Some(line_index) = (0..expected_lines.len().max(actual_lines.len()))
         .find(|index| expected_lines.get(*index) != actual_lines.get(*index))
-        .unwrap_or(0);
+    else {
+        return format!(
+            "trailing newline differs:\nexpected: {}\nactual:   {}",
+            if expected.ends_with('\n') {
+                "present"
+            } else {
+                "absent"
+            },
+            if actual.ends_with('\n') {
+                "present"
+            } else {
+                "absent"
+            }
+        );
+    };
     format!(
         "first difference at line {}:\nexpected: {}\nactual:   {}",
         line_index + 1,
@@ -284,6 +298,18 @@ mod tests {
         assert!(mismatch.contains("expected: before"));
         assert!(mismatch.contains("actual:   after"));
         assert!(missing.contains("run with UPDATE_GOLDEN=1 to generate it"));
+    }
+
+    #[test]
+    fn golden_helper_reports_trailing_newline_mismatch() {
+        assert_eq!(
+            first_difference("same", "same\n"),
+            "trailing newline differs:\nexpected: absent\nactual:   present"
+        );
+        assert_eq!(
+            first_difference("same\n", "same"),
+            "trailing newline differs:\nexpected: present\nactual:   absent"
+        );
     }
 
     fn panic_payload(result: Result<(), Box<dyn Any + Send>>) -> String {

--- a/src-tauri/src/infrastructure/agent_session/fixtures/snapshot.rs
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/snapshot.rs
@@ -1,0 +1,601 @@
+use serde::Serialize;
+
+use crate::domain::agent_session::entities::{
+    Attachment, InterruptReason, MessagePart, PermissionDecision, PermissionRequest,
+    PermissionRequestBody, PermissionRequestStatus, TokenUsage, TurnResult, TurnStopReason,
+};
+use crate::domain::agent_session::gateway::{AgentRuntimeEvent, ResumeOutcome};
+use crate::domain::agent_session::value_objects::{
+    PermissionMode, SlashCommand, SystemNotificationType, TodoListItem, ToolOutputRef,
+    ToolOutputSummary,
+};
+
+#[derive(Serialize)]
+pub(super) enum RuntimeEventSnapshot {
+    SessionEstablished {
+        backend_session_id: String,
+        resume: ResumeOutcomeSnapshot,
+    },
+    BackendSessionCleared,
+    PartsMerged(Vec<MessagePartSnapshot>),
+    PermissionRequested(PermissionRequestSnapshot),
+    PermissionModeChanged(PermissionModeSnapshot),
+    SlashCommandsUpdated(Vec<SlashCommandSnapshot>),
+    TokenUsageUpdated(TokenUsageSnapshot),
+    KeepAlive,
+    TurnCompleted(TurnResultSnapshot),
+    Fatal {
+        message: String,
+    },
+}
+
+impl From<&AgentRuntimeEvent> for RuntimeEventSnapshot {
+    fn from(event: &AgentRuntimeEvent) -> Self {
+        match event {
+            AgentRuntimeEvent::SessionEstablished {
+                backend_session_id,
+                resume,
+            } => Self::SessionEstablished {
+                backend_session_id: backend_session_id.clone(),
+                resume: resume.into(),
+            },
+            AgentRuntimeEvent::BackendSessionCleared => Self::BackendSessionCleared,
+            AgentRuntimeEvent::PartsMerged(parts) => {
+                Self::PartsMerged(parts.iter().map(MessagePartSnapshot::from).collect())
+            }
+            AgentRuntimeEvent::PermissionRequested(request) => {
+                Self::PermissionRequested(request.into())
+            }
+            AgentRuntimeEvent::PermissionModeChanged(mode) => {
+                Self::PermissionModeChanged((*mode).into())
+            }
+            AgentRuntimeEvent::SlashCommandsUpdated(commands) => Self::SlashCommandsUpdated(
+                commands
+                    .iter()
+                    .map(|command| {
+                        let SlashCommand {
+                            name,
+                            description,
+                            argument_hint,
+                        } = command;
+                        SlashCommandSnapshot {
+                            name: name.clone(),
+                            description: description.clone(),
+                            argument_hint: argument_hint.clone(),
+                        }
+                    })
+                    .collect(),
+            ),
+            AgentRuntimeEvent::TokenUsageUpdated(usage) => Self::TokenUsageUpdated(usage.into()),
+            AgentRuntimeEvent::KeepAlive => Self::KeepAlive,
+            AgentRuntimeEvent::TurnCompleted(result) => Self::TurnCompleted(result.into()),
+            AgentRuntimeEvent::Fatal { message } => Self::Fatal {
+                message: message.clone(),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) enum ResumeOutcomeSnapshot {
+    NotRequested,
+    Resumed,
+    Mismatch { actual: String },
+}
+
+impl From<&ResumeOutcome> for ResumeOutcomeSnapshot {
+    fn from(outcome: &ResumeOutcome) -> Self {
+        match outcome {
+            ResumeOutcome::NotRequested => Self::NotRequested,
+            ResumeOutcome::Resumed => Self::Resumed,
+            ResumeOutcome::Mismatch { actual } => Self::Mismatch {
+                actual: actual.clone(),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) enum MessagePartSnapshot {
+    Thinking {
+        content: String,
+        parent_tool_use_id: Option<String>,
+    },
+    Text {
+        content: String,
+        parent_tool_use_id: Option<String>,
+    },
+    ToolUse {
+        id: String,
+        tool: String,
+        input: String,
+        parent_tool_use_id: Option<String>,
+    },
+    ToolResult {
+        content: String,
+        is_error: bool,
+        tool_use_id: Option<String>,
+        parent_tool_use_id: Option<String>,
+        content_ref: Option<ToolOutputRefSnapshot>,
+        summary: Option<ToolOutputSummarySnapshot>,
+    },
+    Error {
+        content: String,
+        parent_tool_use_id: Option<String>,
+    },
+    Permission {
+        request: PermissionRequestSnapshot,
+    },
+    TaskStatus {
+        task_tool_use_id: String,
+        status: String,
+        description: Option<String>,
+        summary: Option<String>,
+    },
+    TodoListSnapshot {
+        items: Vec<TodoListItemSnapshot>,
+    },
+    SystemNotification {
+        notification_type: SystemNotificationTypeSnapshot,
+        status: String,
+        label: String,
+        detail: Option<String>,
+        hook_id: Option<String>,
+    },
+    Image {
+        data: String,
+        media_type: String,
+    },
+    ImageRef {
+        attachment: AttachmentSnapshot,
+    },
+}
+
+impl From<&MessagePart> for MessagePartSnapshot {
+    fn from(part: &MessagePart) -> Self {
+        match part {
+            MessagePart::Thinking {
+                content,
+                parent_tool_use_id,
+            } => Self::Thinking {
+                content: content.clone(),
+                parent_tool_use_id: parent_tool_use_id.clone(),
+            },
+            MessagePart::Text {
+                content,
+                parent_tool_use_id,
+            } => Self::Text {
+                content: content.clone(),
+                parent_tool_use_id: parent_tool_use_id.clone(),
+            },
+            MessagePart::ToolUse {
+                id,
+                tool,
+                input,
+                parent_tool_use_id,
+            } => Self::ToolUse {
+                id: id.clone(),
+                tool: tool.clone(),
+                input: input.as_str().to_string(),
+                parent_tool_use_id: parent_tool_use_id.clone(),
+            },
+            MessagePart::ToolResult {
+                content,
+                is_error,
+                tool_use_id,
+                parent_tool_use_id,
+                content_ref,
+                summary,
+            } => Self::ToolResult {
+                content: content.clone(),
+                is_error: *is_error,
+                tool_use_id: tool_use_id.clone(),
+                parent_tool_use_id: parent_tool_use_id.clone(),
+                content_ref: content_ref.as_ref().map(|output| {
+                    let ToolOutputRef { id, byte_size } = output;
+                    ToolOutputRefSnapshot {
+                        id: id.clone(),
+                        byte_size: *byte_size,
+                    }
+                }),
+                summary: summary.as_ref().map(|summary| {
+                    let ToolOutputSummary {
+                        line_count,
+                        byte_size,
+                        is_error,
+                        truncated,
+                    } = summary;
+                    ToolOutputSummarySnapshot {
+                        line_count: *line_count,
+                        byte_size: *byte_size,
+                        is_error: *is_error,
+                        truncated: *truncated,
+                    }
+                }),
+            },
+            MessagePart::Error {
+                content,
+                parent_tool_use_id,
+            } => Self::Error {
+                content: content.clone(),
+                parent_tool_use_id: parent_tool_use_id.clone(),
+            },
+            MessagePart::Permission { request } => Self::Permission {
+                request: request.into(),
+            },
+            MessagePart::TaskStatus {
+                task_tool_use_id,
+                status,
+                description,
+                summary,
+            } => Self::TaskStatus {
+                task_tool_use_id: task_tool_use_id.clone(),
+                status: status.clone(),
+                description: description.clone(),
+                summary: summary.clone(),
+            },
+            MessagePart::TodoListSnapshot { items } => Self::TodoListSnapshot {
+                items: items
+                    .iter()
+                    .map(|item| {
+                        let TodoListItem { text, completed } = item;
+                        TodoListItemSnapshot {
+                            text: text.clone(),
+                            completed: *completed,
+                        }
+                    })
+                    .collect(),
+            },
+            MessagePart::SystemNotification {
+                notification_type,
+                status,
+                label,
+                detail,
+                hook_id,
+            } => Self::SystemNotification {
+                notification_type: (*notification_type).into(),
+                status: status.clone(),
+                label: label.clone(),
+                detail: detail.clone(),
+                hook_id: hook_id.clone(),
+            },
+            MessagePart::Image { data, media_type } => Self::Image {
+                data: data.clone(),
+                media_type: media_type.clone(),
+            },
+            MessagePart::ImageRef { attachment } => {
+                let Attachment {
+                    id,
+                    media_type,
+                    byte_size,
+                } = attachment;
+                Self::ImageRef {
+                    attachment: AttachmentSnapshot {
+                        id: id.clone(),
+                        media_type: media_type.clone(),
+                        byte_size: *byte_size,
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) struct PermissionRequestSnapshot {
+    id: String,
+    tool_use_id: Option<String>,
+    parent_tool_use_id: Option<String>,
+    tool_name: String,
+    body: PermissionRequestBodySnapshot,
+    title: Option<String>,
+    display_name: Option<String>,
+    description: Option<String>,
+    decision_reason: Option<String>,
+    status: PermissionRequestStatusSnapshot,
+}
+
+impl From<&PermissionRequest> for PermissionRequestSnapshot {
+    fn from(request: &PermissionRequest) -> Self {
+        let PermissionRequest {
+            id,
+            tool_use_id,
+            parent_tool_use_id,
+            tool_name,
+            body,
+            title,
+            display_name,
+            description,
+            decision_reason,
+            status,
+        } = request;
+        Self {
+            id: id.clone(),
+            tool_use_id: tool_use_id.clone(),
+            parent_tool_use_id: parent_tool_use_id.clone(),
+            tool_name: tool_name.clone(),
+            body: body.into(),
+            title: title.clone(),
+            display_name: display_name.clone(),
+            description: description.clone(),
+            decision_reason: decision_reason.clone(),
+            status: status.into(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) enum PermissionRequestBodySnapshot {
+    ToolApproval {
+        input: String,
+    },
+    PlanApproval {
+        plan: String,
+        allowed_prompts: Vec<PermissionAllowedPromptSnapshot>,
+    },
+    Question {
+        questions: Vec<PermissionQuestionSnapshot>,
+    },
+    PermissionGrant {
+        requested: String,
+    },
+}
+
+impl From<&PermissionRequestBody> for PermissionRequestBodySnapshot {
+    fn from(body: &PermissionRequestBody) -> Self {
+        match body {
+            PermissionRequestBody::ToolApproval { input } => Self::ToolApproval {
+                input: input.as_str().to_string(),
+            },
+            PermissionRequestBody::PlanApproval {
+                plan,
+                allowed_prompts,
+            } => Self::PlanApproval {
+                plan: plan.clone(),
+                allowed_prompts: allowed_prompts
+                    .iter()
+                    .map(|prompt| PermissionAllowedPromptSnapshot {
+                        tool: prompt.tool.clone(),
+                        prompt: prompt.prompt.clone(),
+                    })
+                    .collect(),
+            },
+            PermissionRequestBody::Question { questions } => Self::Question {
+                questions: questions
+                    .iter()
+                    .map(|question| PermissionQuestionSnapshot {
+                        question: question.question.clone(),
+                        header: question.header.clone(),
+                        options: question
+                            .options
+                            .iter()
+                            .map(|option| PermissionQuestionOptionSnapshot {
+                                label: option.label.clone(),
+                                description: option.description.clone(),
+                            })
+                            .collect(),
+                        multi_select: question.multi_select,
+                    })
+                    .collect(),
+            },
+            PermissionRequestBody::PermissionGrant { requested } => Self::PermissionGrant {
+                requested: requested.as_str().to_string(),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) struct PermissionAllowedPromptSnapshot {
+    tool: String,
+    prompt: String,
+}
+
+#[derive(Serialize)]
+pub(super) struct PermissionQuestionSnapshot {
+    question: String,
+    header: Option<String>,
+    options: Vec<PermissionQuestionOptionSnapshot>,
+    multi_select: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct PermissionQuestionOptionSnapshot {
+    label: String,
+    description: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(super) enum PermissionRequestStatusSnapshot {
+    Pending,
+    Resolved {
+        decision: PermissionDecisionSnapshot,
+        answers: Option<String>,
+    },
+}
+
+impl From<&PermissionRequestStatus> for PermissionRequestStatusSnapshot {
+    fn from(status: &PermissionRequestStatus) -> Self {
+        match status {
+            PermissionRequestStatus::Pending => Self::Pending,
+            PermissionRequestStatus::Resolved { decision, answers } => Self::Resolved {
+                decision: (*decision).into(),
+                answers: answers.as_ref().map(|value| value.as_str().to_string()),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) enum PermissionDecisionSnapshot {
+    Allowed,
+    Denied,
+    Cancelled,
+}
+
+impl From<PermissionDecision> for PermissionDecisionSnapshot {
+    fn from(decision: PermissionDecision) -> Self {
+        match decision {
+            PermissionDecision::Allowed => Self::Allowed,
+            PermissionDecision::Denied => Self::Denied,
+            PermissionDecision::Cancelled => Self::Cancelled,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) enum PermissionModeSnapshot {
+    Ask,
+    Edit,
+    Full,
+}
+
+impl From<PermissionMode> for PermissionModeSnapshot {
+    fn from(mode: PermissionMode) -> Self {
+        match mode {
+            PermissionMode::Ask => Self::Ask,
+            PermissionMode::Edit => Self::Edit,
+            PermissionMode::Full => Self::Full,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) struct SlashCommandSnapshot {
+    name: String,
+    description: String,
+    argument_hint: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(super) enum TurnResultSnapshot {
+    Completed {
+        stop_reason: Option<TurnStopReasonSnapshot>,
+        token_usage: Option<TokenUsageSnapshot>,
+    },
+    Failed {
+        error: String,
+        token_usage: Option<TokenUsageSnapshot>,
+    },
+    Interrupted {
+        reason: InterruptReasonSnapshot,
+        error: Option<String>,
+    },
+}
+
+impl From<&TurnResult> for TurnResultSnapshot {
+    fn from(result: &TurnResult) -> Self {
+        match result {
+            TurnResult::Completed {
+                stop_reason,
+                token_usage,
+            } => Self::Completed {
+                stop_reason: (*stop_reason).map(TurnStopReasonSnapshot::from),
+                token_usage: token_usage.as_ref().map(TokenUsageSnapshot::from),
+            },
+            TurnResult::Failed { error, token_usage } => Self::Failed {
+                error: error.clone(),
+                token_usage: token_usage.as_ref().map(TokenUsageSnapshot::from),
+            },
+            TurnResult::Interrupted { reason, error } => Self::Interrupted {
+                reason: (*reason).into(),
+                error: error.clone(),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) enum TurnStopReasonSnapshot {
+    Refusal,
+}
+
+impl From<TurnStopReason> for TurnStopReasonSnapshot {
+    fn from(reason: TurnStopReason) -> Self {
+        match reason {
+            TurnStopReason::Refusal => Self::Refusal,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) enum InterruptReasonSnapshot {
+    Abort,
+    Timeout,
+    Crash,
+}
+
+impl From<InterruptReason> for InterruptReasonSnapshot {
+    fn from(reason: InterruptReason) -> Self {
+        match reason {
+            InterruptReason::Abort => Self::Abort,
+            InterruptReason::Timeout => Self::Timeout,
+            InterruptReason::Crash => Self::Crash,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) struct TokenUsageSnapshot {
+    input_tokens: u64,
+    output_tokens: u64,
+    total_tokens: Option<u64>,
+    context_window_tokens: Option<u64>,
+}
+
+impl From<&TokenUsage> for TokenUsageSnapshot {
+    fn from(usage: &TokenUsage) -> Self {
+        let TokenUsage {
+            input_tokens,
+            output_tokens,
+            total_tokens,
+            context_window_tokens,
+        } = usage;
+        Self {
+            input_tokens: *input_tokens,
+            output_tokens: *output_tokens,
+            total_tokens: *total_tokens,
+            context_window_tokens: *context_window_tokens,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) struct ToolOutputRefSnapshot {
+    id: String,
+    byte_size: u64,
+}
+
+#[derive(Serialize)]
+pub(super) struct ToolOutputSummarySnapshot {
+    line_count: u64,
+    byte_size: u64,
+    is_error: bool,
+    truncated: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct TodoListItemSnapshot {
+    text: String,
+    completed: bool,
+}
+
+#[derive(Serialize)]
+pub(super) enum SystemNotificationTypeSnapshot {
+    Compaction,
+}
+
+impl From<SystemNotificationType> for SystemNotificationTypeSnapshot {
+    fn from(notification_type: SystemNotificationType) -> Self {
+        match notification_type {
+            SystemNotificationType::Compaction => Self::Compaction,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) struct AttachmentSnapshot {
+    id: String,
+    media_type: String,
+    byte_size: u64,
+}

--- a/src-tauri/src/infrastructure/agent_session/mod.rs
+++ b/src-tauri/src/infrastructure/agent_session/mod.rs
@@ -1,3 +1,6 @@
 pub(crate) mod claude;
 pub(crate) mod codex;
+#[cfg(test)]
+pub(crate) mod fixtures;
 pub(crate) mod stdout_line_reader;
+mod wire_record;

--- a/src-tauri/src/infrastructure/agent_session/stdout_line_reader.rs
+++ b/src-tauri/src/infrastructure/agent_session/stdout_line_reader.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt};
 
+use super::wire_record::WireRecorder;
+
 /// Shared stdout line limit for agent backends. This preserves Claude's existing 8 MB limit.
 pub(crate) const MAX_STDOUT_LINE_BYTES: usize = 8 * 1024 * 1024;
 
@@ -73,13 +75,24 @@ pub(crate) enum StdoutItem {
 pub(crate) struct StdoutLineReader<R> {
     inner: R,
     max_line_bytes: usize,
+    wire_recorder: Option<WireRecorder>,
 }
 
 impl<R: AsyncBufRead + Unpin> StdoutLineReader<R> {
+    #[cfg(test)]
     pub(crate) fn new(inner: R) -> Self {
         Self {
             inner,
             max_line_bytes: MAX_STDOUT_LINE_BYTES,
+            wire_recorder: None,
+        }
+    }
+
+    pub(crate) fn with_wire_recorder(inner: R, wire_recorder: WireRecorder) -> Self {
+        Self {
+            inner,
+            max_line_bytes: MAX_STDOUT_LINE_BYTES,
+            wire_recorder: wire_recorder.is_active().then_some(wire_recorder),
         }
     }
 
@@ -88,6 +101,13 @@ impl<R: AsyncBufRead + Unpin> StdoutLineReader<R> {
         Self {
             inner,
             max_line_bytes,
+            wire_recorder: None,
+        }
+    }
+
+    pub(crate) async fn shutdown_wire_recorder(&mut self) {
+        if let Some(wire_recorder) = self.wire_recorder.as_mut() {
+            wire_recorder.shutdown().await;
         }
     }
 
@@ -107,6 +127,9 @@ impl<R: AsyncBufRead + Unpin> StdoutLineReader<R> {
             if available.is_empty() {
                 if bytes == 0 {
                     return Ok(None);
+                }
+                if !oversize {
+                    self.record_line(&line);
                 }
                 return Ok(Some(classify_line(
                     line,
@@ -134,6 +157,9 @@ impl<R: AsyncBufRead + Unpin> StdoutLineReader<R> {
             let consumed = content_bytes + usize::from(newline.is_some());
             self.inner.consume(consumed);
             if newline.is_some() {
+                if !oversize {
+                    self.record_line(&line);
+                }
                 return Ok(Some(classify_line(
                     line,
                     bytes,
@@ -141,6 +167,12 @@ impl<R: AsyncBufRead + Unpin> StdoutLineReader<R> {
                     oversize_kind_hint,
                 )));
             }
+        }
+    }
+
+    fn record_line(&self, line: &[u8]) {
+        if let Some(wire_recorder) = &self.wire_recorder {
+            wire_recorder.record(line.to_vec());
         }
     }
 }
@@ -229,6 +261,7 @@ mod tests {
     use tokio::io::{AsyncBufRead, AsyncRead, BufReader, ReadBuf};
 
     use super::*;
+    use crate::infrastructure::agent_session::wire_record::{WireBackend, WireRecorder};
 
     #[tokio::test]
     async fn test_stdout_line_reader_json行を分類する() {
@@ -255,6 +288,30 @@ mod tests {
             reader.next().await.unwrap(),
             Some(StdoutItem::Json(value)) if value["ok"] == serde_json::json!(true)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_stdout_line_readerは正常行と非json生行を記録する() {
+        let dir = tempfile::tempdir().unwrap();
+        let recorder = WireRecorder::for_test(dir.path().to_path_buf(), WireBackend::Claude);
+        let input = b"not-json\n{\"type\":\"result\"}\n";
+        let mut reader = StdoutLineReader::with_wire_recorder(BufReader::new(&input[..]), recorder);
+
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::NonJson { .. })
+        ));
+        assert!(matches!(
+            reader.next().await.unwrap(),
+            Some(StdoutItem::Json(value)) if value == serde_json::json!({"type": "result"})
+        ));
+        assert!(reader.next().await.unwrap().is_none());
+
+        reader.shutdown_wire_recorder().await;
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("claude.jsonl")).unwrap(),
+            "not-json\n{\"type\":\"result\"}\n"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/infrastructure/agent_session/wire_record.rs
+++ b/src-tauri/src/infrastructure/agent_session/wire_record.rs
@@ -46,12 +46,12 @@ impl WireRecorder {
         let Some(root) = std::env::var_os(WIRE_RECORD_ENV) else {
             return Self { active: None };
         };
-        Self::start(
-            PathBuf::from(root),
-            backend,
-            MAX_PENDING_RECORDS,
-            MAX_PENDING_BYTES,
-        )
+        let root = PathBuf::from(root);
+        if root.as_os_str().is_empty() {
+            log::warn!("{WIRE_RECORD_ENV} is empty; wire recording is disabled");
+            return Self { active: None };
+        }
+        Self::start(root, backend, MAX_PENDING_RECORDS, MAX_PENDING_BYTES)
     }
 
     fn start(
@@ -267,6 +267,17 @@ mod tests {
         recorder.record(br#"{"type":"result"}"#.to_vec());
 
         assert!(recorder.active.is_none());
+    }
+
+    #[test]
+    fn empty_environment_does_not_record() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::set_value(WIRE_RECORD_ENV, "");
+        let recorder = WireRecorder::from_env(WireBackend::Claude);
+
+        recorder.record(br#"{"type":"result"}"#.to_vec());
+
+        assert!(!recorder.is_active());
     }
 
     #[tokio::test]

--- a/src-tauri/src/infrastructure/agent_session/wire_record.rs
+++ b/src-tauri/src/infrastructure/agent_session/wire_record.rs
@@ -1,0 +1,412 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+const WIRE_RECORD_ENV: &str = "RELEASH_WIRE_RECORD";
+const MAX_PENDING_RECORDS: usize = 256;
+const MAX_PENDING_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WireBackend {
+    Claude,
+    Codex,
+}
+
+impl WireBackend {
+    fn file_name(self) -> &'static str {
+        match self {
+            Self::Claude => "claude.jsonl",
+            Self::Codex => "codex.jsonl",
+        }
+    }
+}
+
+struct QueuedRecord {
+    raw_line: Vec<u8>,
+    reserved_bytes: usize,
+}
+
+pub(crate) struct WireRecorder {
+    active: Option<ActiveRecorder>,
+}
+
+struct ActiveRecorder {
+    sender: SyncSender<QueuedRecord>,
+    pending_bytes: Arc<AtomicUsize>,
+    max_pending_bytes: usize,
+    writer: JoinHandle<()>,
+}
+
+impl WireRecorder {
+    pub(crate) fn from_env(backend: WireBackend) -> Self {
+        let Some(root) = std::env::var_os(WIRE_RECORD_ENV) else {
+            return Self { active: None };
+        };
+        Self::start(
+            PathBuf::from(root),
+            backend,
+            MAX_PENDING_RECORDS,
+            MAX_PENDING_BYTES,
+        )
+    }
+
+    fn start(
+        root: PathBuf,
+        backend: WireBackend,
+        max_pending_records: usize,
+        max_pending_bytes: usize,
+    ) -> Self {
+        Self::start_with_writer(
+            backend,
+            max_pending_records,
+            max_pending_bytes,
+            move |receiver, pending_bytes| {
+                writer_loop(receiver, pending_bytes, &root, backend);
+            },
+        )
+    }
+
+    fn start_with_writer<F>(
+        backend: WireBackend,
+        max_pending_records: usize,
+        max_pending_bytes: usize,
+        writer_loop: F,
+    ) -> Self
+    where
+        F: FnOnce(Receiver<QueuedRecord>, Arc<AtomicUsize>) + Send + 'static,
+    {
+        let (sender, receiver) = mpsc::sync_channel(max_pending_records);
+        let pending_bytes = Arc::new(AtomicUsize::new(0));
+        let writer_pending_bytes = Arc::clone(&pending_bytes);
+        let writer = match std::thread::Builder::new()
+            .name(format!("wire-record-{}", backend.file_name()))
+            .spawn(move || writer_loop(receiver, writer_pending_bytes))
+        {
+            Ok(writer) => writer,
+            Err(error) => {
+                log::warn!("failed to start wire record writer: {error}");
+                return Self { active: None };
+            }
+        };
+        Self {
+            active: Some(ActiveRecorder {
+                sender,
+                pending_bytes,
+                max_pending_bytes,
+                writer,
+            }),
+        }
+    }
+
+    pub(crate) fn record(&self, raw_line: Vec<u8>) {
+        let Some(active) = &self.active else {
+            return;
+        };
+        active.try_record(raw_line);
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.is_some()
+    }
+
+    pub(crate) async fn shutdown(&mut self) {
+        let Some(active) = self.active.take() else {
+            return;
+        };
+        match tokio::task::spawn_blocking(move || active.shutdown()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => log::warn!("failed to shut down wire record writer: {error}"),
+            Err(error) => log::warn!("failed to join wire record shutdown task: {error}"),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(root: PathBuf, backend: WireBackend) -> Self {
+        Self::start(root, backend, MAX_PENDING_RECORDS, MAX_PENDING_BYTES)
+    }
+}
+
+impl ActiveRecorder {
+    fn try_record(&self, mut raw_line: Vec<u8>) {
+        let append_newline = !raw_line.ends_with(b"\n");
+        let Some(reserved_bytes) = raw_line.len().checked_add(usize::from(append_newline)) else {
+            log::warn!("wire record line size overflow; dropping line");
+            return;
+        };
+        if self
+            .pending_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                current
+                    .checked_add(reserved_bytes)
+                    .filter(|next| *next <= self.max_pending_bytes)
+            })
+            .is_err()
+        {
+            log::warn!("wire record queue byte limit reached; dropping {reserved_bytes}-byte line");
+            return;
+        }
+        if append_newline {
+            raw_line.push(b'\n');
+        }
+
+        let record = QueuedRecord {
+            raw_line,
+            reserved_bytes,
+        };
+        match self.sender.try_send(record) {
+            Ok(()) => {}
+            Err(TrySendError::Full(record)) => {
+                self.release_bytes(record.reserved_bytes);
+                log::warn!("wire record queue item limit reached; dropping line");
+            }
+            Err(TrySendError::Disconnected(record)) => {
+                self.release_bytes(record.reserved_bytes);
+                log::warn!("wire record writer is unavailable; dropping line");
+            }
+        }
+    }
+
+    fn release_bytes(&self, bytes: usize) {
+        self.pending_bytes.fetch_sub(bytes, Ordering::AcqRel);
+    }
+
+    fn shutdown(self) -> Result<(), String> {
+        let Self {
+            sender,
+            pending_bytes: _,
+            max_pending_bytes: _,
+            writer,
+        } = self;
+        drop(sender);
+        writer
+            .join()
+            .map_err(|_| "wire record writer panicked".to_string())?;
+        Ok(())
+    }
+}
+
+fn writer_loop(
+    receiver: Receiver<QueuedRecord>,
+    pending_bytes: Arc<AtomicUsize>,
+    root: &Path,
+    backend: WireBackend,
+) {
+    let path = root.join(backend.file_name());
+    let mut file = open_wire_file(root, &path);
+    while let Ok(record) = receiver.recv() {
+        if let Some(open_file) = file.as_mut() {
+            if let Err(error) = open_file.write_all(&record.raw_line) {
+                log::warn!(
+                    "failed to append wire record file {}: {error}",
+                    path.display()
+                );
+                file = None;
+            }
+        }
+        pending_bytes.fetch_sub(record.reserved_bytes, Ordering::AcqRel);
+    }
+    if let Some(mut file) = file {
+        if let Err(error) = file.flush() {
+            log::warn!(
+                "failed to flush wire record file {}: {error}",
+                path.display()
+            );
+        }
+    }
+}
+
+fn open_wire_file(root: &Path, path: &Path) -> Option<File> {
+    if let Err(error) = fs::create_dir_all(root) {
+        log::warn!(
+            "failed to create wire record directory {}: {error}",
+            root.display()
+        );
+        return None;
+    }
+    match OpenOptions::new().create(true).append(true).open(path) {
+        Ok(file) => Some(file),
+        Err(error) => {
+            log::warn!(
+                "failed to open wire record file {}: {error}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::*;
+    use crate::test_support::{EnvVarGuard, TEST_ENV_LOCK};
+
+    struct EnvRestore(Option<OsString>);
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => std::env::set_var(WIRE_RECORD_ENV, value),
+                None => std::env::remove_var(WIRE_RECORD_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn unset_environment_does_not_record() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(std::env::var_os(WIRE_RECORD_ENV));
+        std::env::remove_var(WIRE_RECORD_ENV);
+        let recorder = WireRecorder::from_env(WireBackend::Claude);
+
+        recorder.record(br#"{"type":"result"}"#.to_vec());
+
+        assert!(recorder.active.is_none());
+    }
+
+    #[tokio::test]
+    async fn configured_environment_appends_one_message_per_line_in_order() {
+        let env_lock = TEST_ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let env_guard = EnvVarGuard::set_path(WIRE_RECORD_ENV, dir.path());
+        let mut claude = WireRecorder::from_env(WireBackend::Claude);
+        let mut codex = WireRecorder::from_env(WireBackend::Codex);
+
+        claude.record(br#"{"type":"system"}"#.to_vec());
+        claude.record(b"{\"type\":\"result\"}\n".to_vec());
+        codex.record(br#"{"method":"turn/completed"}"#.to_vec());
+        drop(env_guard);
+        drop(env_lock);
+        claude.shutdown().await;
+        codex.shutdown().await;
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join("claude.jsonl")).unwrap(),
+            "{\"type\":\"system\"}\n{\"type\":\"result\"}\n"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("codex.jsonl")).unwrap(),
+            "{\"method\":\"turn/completed\"}\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn io_failures_do_not_escape_the_tap() {
+        let env_lock = TEST_ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let invalid_root = dir.path().join("not-a-directory");
+        fs::write(&invalid_root, "occupied").unwrap();
+        let env_guard = EnvVarGuard::set_path(WIRE_RECORD_ENV, &invalid_root);
+        let mut recorder = WireRecorder::from_env(WireBackend::Claude);
+
+        recorder.record(br#"{"type":"result"}"#.to_vec());
+        drop(env_guard);
+        drop(env_lock);
+        recorder.shutdown().await;
+
+        assert_eq!(fs::read_to_string(invalid_root).unwrap(), "occupied");
+    }
+
+    #[tokio::test]
+    async fn queue_drops_records_beyond_item_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut recorder, start_writer) =
+            paused_recorder(dir.path().to_path_buf(), WireBackend::Claude, 1, 1024);
+        recorder.record(b"first\n".to_vec());
+        recorder.record(b"second\n".to_vec());
+
+        assert_eq!(pending_bytes(&recorder), b"first\n".len());
+        start_writer.send(()).unwrap();
+        recorder.shutdown().await;
+
+        assert_eq!(
+            fs::read(dir.path().join("claude.jsonl")).unwrap(),
+            b"first\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn queue_drops_records_beyond_byte_limit() {
+        assert_line_with_byte_limit(b"five!", 4, 6, false).await;
+    }
+
+    #[tokio::test]
+    async fn queue_byte_limit_boundary_with_existing_newline() {
+        assert_line_with_byte_limit(b"abc\n", 4, 4, true).await;
+        assert_line_with_byte_limit(b"abcd\n", 4, 5, false).await;
+    }
+
+    #[tokio::test]
+    async fn queue_byte_limit_boundary_with_appended_newline() {
+        assert_line_with_byte_limit(b"abc", 4, 4, true).await;
+        assert_line_with_byte_limit(b"abcd", 4, 5, false).await;
+    }
+
+    fn paused_recorder(
+        root: PathBuf,
+        backend: WireBackend,
+        max_pending_records: usize,
+        max_pending_bytes: usize,
+    ) -> (WireRecorder, mpsc::Sender<()>) {
+        let (start_writer, wait_for_start) = mpsc::channel();
+        let recorder = WireRecorder::start_with_writer(
+            backend,
+            max_pending_records,
+            max_pending_bytes,
+            move |receiver, pending_bytes| {
+                let _ = wait_for_start.recv();
+                writer_loop(receiver, pending_bytes, &root, backend);
+            },
+        );
+        (recorder, start_writer)
+    }
+
+    fn pending_bytes(recorder: &WireRecorder) -> usize {
+        recorder
+            .active
+            .as_ref()
+            .expect("test recorder should be active")
+            .pending_bytes
+            .load(Ordering::Acquire)
+    }
+
+    async fn assert_line_with_byte_limit(
+        raw_line: &[u8],
+        max_pending_bytes: usize,
+        expected_reserved_bytes: usize,
+        accepted: bool,
+    ) {
+        let reserved_bytes = raw_line.len() + usize::from(!raw_line.ends_with(b"\n"));
+        assert_eq!(reserved_bytes, expected_reserved_bytes);
+        let dir = tempfile::tempdir().unwrap();
+        let (mut recorder, start_writer) = paused_recorder(
+            dir.path().to_path_buf(),
+            WireBackend::Claude,
+            1,
+            max_pending_bytes,
+        );
+
+        recorder.record(raw_line.to_vec());
+
+        assert_eq!(
+            pending_bytes(&recorder),
+            if accepted { reserved_bytes } else { 0 }
+        );
+        start_writer.send(()).unwrap();
+        recorder.shutdown().await;
+
+        let mut expected = raw_line.to_vec();
+        if accepted && !expected.ends_with(b"\n") {
+            expected.push(b'\n');
+        }
+        assert_eq!(
+            fs::read(dir.path().join("claude.jsonl")).unwrap(),
+            if accepted { expected } else { Vec::new() }
+        );
+    }
+}

--- a/src-tauri/src/test_support/agent_session_wire_replay.rs
+++ b/src-tauri/src/test_support/agent_session_wire_replay.rs
@@ -1,0 +1,176 @@
+use crate::domain::agent_session::entities::{
+    merge_part, InterruptReason as DomainInterruptReason, MessagePart as DomainMessagePart,
+    TokenUsage as DomainTokenUsage, TurnResult as DomainTurnResult,
+    TurnStopReason as DomainTurnStopReason,
+};
+use crate::domain::agent_session::gateway::AgentRuntimeEvent;
+use crate::infrastructure::agent_session::fixtures::{
+    assert_golden, pretty_json, replay_backend, FixtureBackend, ReplayedFixture,
+};
+use crate::usecase::agent_session::event_log::{
+    AgentSessionEvent, InterruptReason, PartEventMode, PromptInput, TurnEventLog, TurnStopReason,
+    TurnTokenUsage,
+};
+use crate::usecase::agent_session::runtime::event_apply::parts_from_domain;
+
+const TURN_ID: u64 = 1;
+const ASSISTANT_MESSAGE_ID: &str = "<ASSISTANT_MESSAGE_ID>";
+
+#[test]
+fn claude_fixture_matches_read_model_golden() {
+    for fixture in replay_backend(FixtureBackend::Claude) {
+        assert_fixture_read_model(fixture);
+    }
+}
+
+#[test]
+fn codex_fixture_matches_read_model_golden() {
+    for fixture in replay_backend(FixtureBackend::Codex) {
+        assert_fixture_read_model(fixture);
+    }
+}
+
+fn assert_fixture_read_model(fixture: ReplayedFixture) {
+    let golden_path = fixture.read_model_golden_path();
+    let fixture_label = format!("{:?}/{}", fixture.backend, fixture.name);
+    let mut log = started_turn_log();
+    let mut final_domain_parts = Vec::new();
+    let mut latest_usage = None;
+    let mut completed = false;
+
+    for event in fixture.events {
+        match event {
+            AgentRuntimeEvent::PartsMerged(parts) => {
+                apply_domain_parts(&mut log, &mut final_domain_parts, parts);
+            }
+            AgentRuntimeEvent::PermissionRequested(request) => {
+                apply_domain_parts(
+                    &mut log,
+                    &mut final_domain_parts,
+                    vec![DomainMessagePart::Permission { request }],
+                );
+            }
+            AgentRuntimeEvent::TokenUsageUpdated(usage) => latest_usage = Some(usage),
+            AgentRuntimeEvent::TurnCompleted(result) => {
+                append_final_parts(&mut log, &final_domain_parts);
+                append_terminal_event(&mut log, result, latest_usage);
+                completed = true;
+            }
+            AgentRuntimeEvent::Fatal { message } => {
+                panic!("{fixture_label} emitted unsupported fatal event: {message}")
+            }
+            AgentRuntimeEvent::SessionEstablished { .. }
+            | AgentRuntimeEvent::BackendSessionCleared
+            | AgentRuntimeEvent::PermissionModeChanged(_)
+            | AgentRuntimeEvent::SlashCommandsUpdated(_)
+            | AgentRuntimeEvent::KeepAlive => {}
+        }
+    }
+
+    assert!(completed, "{fixture_label} did not complete its turn");
+    let read_model = log.project();
+    assert_golden(&golden_path, &pretty_json(&read_model));
+}
+
+fn apply_domain_parts(
+    log: &mut TurnEventLog,
+    final_domain_parts: &mut Vec<DomainMessagePart>,
+    parts: Vec<DomainMessagePart>,
+) {
+    for part in &parts {
+        merge_part(final_domain_parts, part.clone());
+    }
+    let durable_parts = parts_from_domain(parts);
+    log.append_part_events(
+        TURN_ID,
+        ASSISTANT_MESSAGE_ID,
+        &durable_parts,
+        PartEventMode::DurableOnly,
+    );
+}
+
+fn started_turn_log() -> TurnEventLog {
+    let mut log = TurnEventLog::default();
+    log.begin_turn(
+        TURN_ID,
+        "<PROMPT_MESSAGE_ID>".to_string(),
+        ASSISTANT_MESSAGE_ID.to_string(),
+        PromptInput {
+            content: "<USER_MESSAGE>".to_string(),
+            mentions: Vec::new(),
+            attachment_refs: Vec::new(),
+            parts: Vec::new(),
+        },
+        1_700_000_000.0,
+    );
+    log
+}
+
+fn append_final_parts(log: &mut TurnEventLog, final_domain_parts: &[DomainMessagePart]) {
+    log.append(AgentSessionEvent::FinalPartsRecorded {
+        turn_id: TURN_ID,
+        message_id: ASSISTANT_MESSAGE_ID.to_string(),
+        parts: parts_from_domain(final_domain_parts.to_vec()),
+    });
+}
+
+fn append_terminal_event(
+    log: &mut TurnEventLog,
+    result: DomainTurnResult,
+    latest_usage: Option<DomainTokenUsage>,
+) {
+    match result {
+        DomainTurnResult::Completed {
+            stop_reason,
+            token_usage,
+        } => log.append(AgentSessionEvent::TurnCompleted {
+            turn_id: TURN_ID,
+            exit_code: 0,
+            stop_reason: stop_reason.map(map_stop_reason),
+            token_usage: token_usage.or(latest_usage).map(map_token_usage),
+        }),
+        DomainTurnResult::Failed { token_usage, .. } => {
+            log.append(AgentSessionEvent::TurnCompleted {
+                turn_id: TURN_ID,
+                exit_code: 1,
+                stop_reason: None,
+                token_usage: token_usage.or(latest_usage).map(map_token_usage),
+            });
+        }
+        DomainTurnResult::Interrupted { reason, error } => log.finalize(
+            TURN_ID,
+            map_interrupt_reason(reason),
+            error,
+            interrupt_exit_code(reason),
+        ),
+    }
+}
+
+fn map_stop_reason(reason: DomainTurnStopReason) -> TurnStopReason {
+    match reason {
+        DomainTurnStopReason::Refusal => TurnStopReason::Refusal,
+    }
+}
+
+fn map_token_usage(usage: DomainTokenUsage) -> TurnTokenUsage {
+    TurnTokenUsage {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+    }
+}
+
+fn map_interrupt_reason(reason: DomainInterruptReason) -> InterruptReason {
+    match reason {
+        DomainInterruptReason::Abort => InterruptReason::Abort,
+        DomainInterruptReason::Timeout => InterruptReason::Timeout,
+        DomainInterruptReason::Crash => InterruptReason::Crash,
+    }
+}
+
+fn interrupt_exit_code(reason: DomainInterruptReason) -> i64 {
+    match reason {
+        DomainInterruptReason::Abort => 0,
+        DomainInterruptReason::Timeout => 124,
+        DomainInterruptReason::Crash => 1,
+    }
+}

--- a/src-tauri/src/test_support/mod.rs
+++ b/src-tauri/src/test_support/mod.rs
@@ -29,6 +29,8 @@ use crate::usecase::agent_session::status::{
 
 pub(crate) mod git;
 
+mod agent_session_wire_replay;
+
 pub(crate) static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 pub(crate) struct EnvVarGuard {

--- a/src-tauri/src/usecase/agent_session/event_log/projector.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/projector.rs
@@ -14,12 +14,14 @@ use crate::usecase::agent_session::session::{
 use crate::usecase::agent_session::status::TurnPhase;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct ProjectedStatus {
     pub session_state: SessionState,
     pub turn_phase: TurnPhase,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct WorkflowTurnCompleteInput {
     pub turn_id: TurnId,
     pub exit_code: i64,
@@ -30,11 +32,13 @@ pub struct WorkflowTurnCompleteInput {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub enum AgentTurnFailureSignal {
     ModelRefusal,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct ToolRetryProjection {
     pub turn_id: TurnId,
     pub tool_use_id: String,
@@ -42,6 +46,7 @@ pub struct ToolRetryProjection {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct SessionReadModel {
     pub messages: Vec<ChatMessage>,
     pub status: ProjectedStatus,


### PR DESCRIPTION
## 概要

Closes #1383

milestone 84「Agentチャット安定化」Phase 0。監査 **ST-7（前半）** を解消し、Claude / Codex の実 wire ログを convert から read model まで再生できる回帰テスト基盤を追加する。

後続の typed wire 置換では golden 不変による挙動等価の確認、語彙変更では意図した golden 差分のレビューに利用できる。

## 変更内容

- `RELEASH_WIRE_RECORD=<dir>` で Claude / Codex の stdout 生行を JSONL に採取する、既定無効の record tap を追加
- `main` で導入された共通 `StdoutLineReader` の分類境界へ tap を統合し、正常行と非JSON行を backend 別に記録
- bounded queue と writer thread により stdout 読み取りをブロックせず、終了時に queue drain / flush / join を実施
- Claude / Codex の通常 turn fixture と convert golden を追加
- 同じ fixture を durable event と projector へ流す read model golden テストを追加
- `UPDATE_GOLDEN=1` による更新、採取、マスキング手順を README に記載
- requirements / behavior / design を追加

## テスト

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`（2,593件成功）
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 開発時にワイヤログを記録し、エージェントセッションの動作を再現できる仕組みを追加しました。
  * Claude・Codexのイベント変換結果やセッション状態をゴールデンデータと比較できるようになりました。

* **品質改善**
  * エージェント終了時の処理を整理し、読み取り処理や記録データを確実に完了させます。

* **ドキュメント**
  * テスト用データの採取、秘匿情報のマスキング、更新手順を文書化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->