### PR TITLE
fix: セッション終了時に進行中ターンを確実に終端 (#1405)

### DIFF
--- a/docs/specs/issues-1405/behavior.md
+++ b/docs/specs/issues-1405/behavior.md
@@ -1,0 +1,181 @@
+# Behavior
+
+関連: #1405 / requirements.md / milestone 84（Agentチャット安定化・Phase 0 / L4）/ 監査 RT-1 / 不変条件 I1（turn 終端保証）
+
+本書は「進行中 turn を持つセッションを、正常な close / backend 切替 / アプリ終了のいずれの経路で閉じても、その turn が必ず終端され、再オープン後に残骸（永久スピナー・永久確認待ち permission・欠落した本文・欠落した terminal event）が残らない」という外部から観測可能な振る舞いを定義する。
+
+内部の実行順序（flush → finalize → close）・drain の待機時間・emit 抑止の解除方式・永続表現の具体形は behavior の対象外とし、design.md で確定する。本書は「再オープン後・event log 上で何が観測できるか」という性質のみを固定する。
+
+## 仮定
+
+- 本書で「終了経路」と呼ぶのは、正常な `close_session`（タブを閉じる）・`set_session_backend`（backend 切替）・`close_all`（アプリ終了）の三経路を指す。プロセスクラッシュ・強制終了時の起動時 dangling turn 回収（`Crash` 理由）は本 Issue の非スコープ（RT-2 / #1407）であり、本書のシナリオ対象外とする。
+- 「進行中 turn」とは、`TurnStarted` 済みで terminal event（`TurnCompleted` / `TurnInterrupted`）を未記録の turn を指す。
+- 「中断チップ」とは、再オープンした会話ビュー上で当該 turn が中断されたことを示す表示であり、理由が `SessionClosed` であることを示す。表示文言・色・アイコン等の見た目は behavior の対象外とする。
+- 「残骸が無い」とは、再オープン後に (a) 永久に回転し続けるツール実行スピナー（background Task group を含む）が無く、(b) 操作しても必ず失敗する確認待ち permission ダイアログが無い状態を指す。
+- 「本文が flush 済みまで残る」とは、close 直前までのストリーミング本文（最後の定期スナップショット以降の増分と未 persist の pending parts を含む）が、再オープン後のメッセージに反映されている状態を指す。損失許容窓は現行の定期 flush 間隔（1 秒）に準ずるが、close 時は force flush によりこの窓内の本文まで確実に durable 化される。
+- `set_session_backend` は現行 UI 上「空セッション限定」で主経路ではないが、監査 RT-1 が同一経路と指摘するため終端保証の対象に含める。provider 切替に伴う configuration handoff の再設計は行わない。
+- frontend は終了経路を薄く invoke するだけであり、interrupt 判断・finalize は Rust（usecase / domain）が所有する（rust-first-logic）。
+- write-ahead 済み（`Responding` / `Resolving`）permission の扱いは既存 finalize 経路の規約に従う。本書は未送信 `Pending` の畳み込みのみを新規保証として固定する。
+
+## Feature: 進行中 turn を持つセッションの終了時の turn 終端保証
+
+### Background
+
+```gherkin
+Background:
+  Given ある Agent セッションで turn が進行中である
+  And その turn はストリーミング本文を出力し、ツール実行または permission 要求を含みうる
+```
+
+---
+
+### Rule: 進行中 turn を持つ終了経路は turn を必ず終端させる
+
+正常な close / backend 切替 / アプリ終了のいずれの経路でも、進行中 turn を持つセッションを閉じるときは、その turn が中断として終端される。どの経路でも観測結果は同一である。
+
+```gherkin
+Scenario Outline: どの終了経路でも進行中 turn は終端される
+  Given turn が進行中である
+  When 利用者または system が "<経路>" によってセッションを閉じる
+  Then その turn は中断理由 SessionClosed で終端される
+  And セッションを再オープンしても未終端の turn は残らない
+
+  Examples:
+    | 経路              |
+    | チャットタブを閉じる |
+    | backend を切り替える |
+    | アプリを終了する     |
+```
+
+```gherkin
+Scenario: 進行中 turn が無いセッションの終了は従来どおり
+  Given turn が進行中でない
+  When セッションを閉じる
+  Then 新たな中断 turn は生成されない
+  And 既存の会話履歴はそのまま保持される
+```
+
+---
+
+### Rule: 終了時に terminal event（SessionClosed）が必ず記録される
+
+進行中 turn を閉じると、その turn の terminal event（中断・理由 `SessionClosed`）が event log に記録される。既存の `SessionClosed` イベントとは別に、turn 単位の terminal event が残る。
+
+```gherkin
+Scenario: 閉じられた turn の terminal event が event log に残る
+  Given turn が進行中である
+  When セッションを閉じる
+  Then event log にその turn の中断 terminal event（理由 SessionClosed）が記録される
+
+Scenario: 再オープン後に中断チップ（SessionClosed）が表示される
+  Given 進行中 turn を持つセッションを閉じた
+  When セッションを再オープンする
+  Then その turn には中断チップが表示される
+  And 中断チップは理由が SessionClosed であることを示す
+```
+
+---
+
+### Rule: 終了前にストリーミング本文が flush 済みまで残る
+
+close 前にストリーミング本文が強制 flush されるため、再オープン後に close 直前までの本文が失われない。損失窓は定期 flush 間隔を超えない。
+
+```gherkin
+Scenario: close 直前までのストリーミング本文が再オープン後に残る
+  Given turn が最後の定期スナップショット以降にもストリーミング本文を出力している
+  When セッションを閉じて再オープンする
+  Then close 直前までのストリーミング本文がメッセージに反映されている
+  And 最後の定期スナップショットで失われるはずだった増分・未 persist の pending parts も残っている
+```
+
+---
+
+### Rule: 未送信 permission は解決済みに畳まれ、確認待ち残骸が残らない
+
+終了時、未送信（`Pending`）の permission 要求は取消（`Cancelled`・効果なし）として畳まれる。再オープン後に、操作しても必ず失敗する確認待ち permission ダイアログは残らない。
+
+```gherkin
+Scenario: 未送信 permission は取消に畳まれる
+  Given turn に未送信（Pending）の permission 要求がある
+  When セッションを閉じて再オープンする
+  Then その permission は取消（効果なし）として表示される
+  And 操作可能な確認待ち permission ダイアログは残らない
+
+Scenario: 書き込み済み permission は既存規約に従う
+  Given turn に write-ahead 済み（Responding / Resolving）の permission がある
+  When セッションを閉じて再オープンする
+  Then その permission の扱いは既存 finalize 経路の規約に従う
+```
+
+---
+
+### Rule: 進行中のツール実行は中断に畳まれ、永久スピナーが残らない
+
+終了時、進行中の ToolCall は中断（`Interrupted`）として畳まれる。background Task group を含め、再オープン後に永久に回転し続けるスピナーが残らない。
+
+```gherkin
+Scenario: 進行中 ToolCall は中断に畳まれる
+  Given turn に進行中の ToolCall がある
+  When セッションを閉じて再オープンする
+  Then その ToolCall は中断として表示される
+  And 実行中スピナーは残らない
+
+Scenario: background Task group にも永久スピナーが残らない
+  Given turn に完了していない background Task group がある
+  When セッションを閉じて再オープンする
+  Then その Task group に永久スピナーは残らない
+```
+
+---
+
+### Rule: 終了中に届く backend の最終イベントを回収する
+
+close 中に backend から届く最終イベント（result / turn completed）は、無言破棄されず、turn の終端に反映される。
+
+```gherkin
+Scenario: close と競合して届く最終イベントを取りこぼさない
+  Given セッションを閉じる処理の途中で backend が最終イベント（result / turn completed）を送る
+  When セッションを閉じる
+  Then その最終イベントは破棄されず turn の終端に反映される
+```
+
+---
+
+### Rule: アプリ終了→再起動でも終端が保たれる
+
+アプリ終了時に進行中 turn を閉じた場合も、再起動後に同じ終端保証が観測できる。
+
+```gherkin
+Scenario: アプリ終了→再起動後も残骸が無い
+  Given ストリーミング中の turn があるセッションが開いている
+  When アプリを終了し、再起動してセッションを再オープンする
+  Then その turn は中断（SessionClosed）で終端されている
+  And 中断チップが表示される
+  And 永久スピナー・確認待ち permission 残骸が無い
+  And close 直前までのストリーミング本文が残っている
+```
+
+---
+
+### Rule: SessionClosed は既存の中断理由と互換に共存する
+
+`InterruptReason` への `SessionClosed` 追加は additive であり、既存の中断理由・既存の永続化済みイベントの解釈を壊さない。`SessionClosed` は Crash 理由を上書きしない。
+
+```gherkin
+Scenario: 既存の中断理由が引き続き解釈できる
+  Given SessionClosed 追加前に記録された既存の中断 terminal event がある
+  When その event log を読み込む
+  Then 既存の中断理由はそのまま解釈される
+  And SessionClosed の追加によって解釈が変わらない
+
+Scenario: SessionClosed は Crash 理由を上書きしない
+  Given ある turn がクラッシュ回収（Crash）の対象である
+  When 正常な終了経路が関与しても
+  Then その turn の中断理由は SessionClosed で上書きされない
+```
+
+---
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1405/design.md
+++ b/docs/specs/issues-1405/design.md
@@ -1,0 +1,220 @@
+# Design
+
+関連: #1405 / requirements.md / behavior.md / milestone 84（Agentチャット安定化・Phase 0 / L4）/ 監査 RT-1 / 不変条件 I1（turn 終端保証）/ 語彙 V-D7（`InterruptReason::SessionClosed` の additive 追加）
+
+## 概要
+
+進行中 turn を持つ Agent セッションを、正常な `close_session`（タブを閉じる）・`set_session_backend`（backend 切替）・`close_all`（アプリ終了）のいずれで閉じても、その turn を必ず「streaming flush 強制 → `SessionClosed` 理由で finalize → runtime close」の順で終端させる（I1）。これにより再オープン後・再起動後に、本文欠落・permission 残骸・ツール実行残骸・terminal event 欠落（監査 RT-1）が残らないことを保証する。
+
+現行の `close_session` は sessions map から state を先に remove し、in-flight ランタイムイベントを epoch guard で捨てたうえで `runtime.close()` するだけであり、`flush_streaming_update` / finalize を一切呼ばない。本設計はこの終了順序を是正し、既存の finalize 経路（`complete_turn` → `terminal_projection` → `append_final_turn_events` → `finalize_turn`）を close 経路から再利用する。新規の修復経路は作らない。
+
+語彙面では domain / event log の両 `InterruptReason` に `SessionClosed` を additive で追加する（F3 additive 規約）。
+
+## 変更対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `src-tauri/src/domain/agent_session/entities/turn.rs` | `InterruptReason` に `SessionClosed` を追加 |
+| `src-tauri/src/usecase/agent_session/event_log/events.rs` | event log 側 `InterruptReason` に `SessionClosed`（serde: `"session_closed"`）を追加し、`label()` に対応を加える |
+| `src-tauri/src/usecase/agent_session/event_log/projector.rs` | `project_status` の `TerminalEvent::Interrupted` 分岐に `SessionClosed` を追加し、最新 turn の durable な中断情報を射影する read model を追加 |
+| `src-tauri/src/usecase/agent_session/session/mod.rs` | `SessionMeta` と `GetSessionResponse` に最新 turn の中断情報を追加 |
+| `src-tauri/src/usecase/agent_session/runtime/usecase.rs` | `terminal_projection` に `SessionClosed` の写像を追加。`close_session` / `close_all` / `set_session_backend` の終了順序を「flush → drain → finalize → runtime close → state remove」へ是正する共通ヘルパを追加 |
+| `src-tauri/src/usecase/application_lifecycle.rs` | agent finalize → workflow command shutdown → local API shutdown のアプリケーション終了順序と失敗時の短絡を port 境界で所有 |
+| `src-tauri/src/adaptor/gateway/agent_session/session_storage/event_store.rs` | terminal event batch を temp segment へ完全書込み後、atomic rename で commit する append-only batch 保存を追加 |
+| `src-tauri/src/adaptor/controller/application_lifecycle.rs` | lifecycle usecase の起動、成功後の process exit、失敗時の log に限定 |
+| `src/types/session.ts` / `src/hooks/useSessionStore.ts` / `src/components/panels/AgentChatPanel/ChatSessionView.tsx` | backend-owned の中断 read model を表示用型へ変換し、対象 agent message に中断チップを描画 |
+
+フロントエンドの close フローは変更せず、引き続き `close_session` を invoke する薄い経路のままにする。中断判定と reason は Rust の durable read model が所有し、フロントエンドは返された値を表示するだけとする（rust-first-logic）。
+
+## アーキテクチャと責務分割
+
+- **domain（`entities/turn.rs`）**: `InterruptReason` の語彙拡張のみ。外部依存なし。
+- **usecase / event_log（`finalization.rs` / `events.rs` / `projector.rs`）**: 中断 turn の畳み込みロジック（未解決 permission → `Cancelled`、未完了 ToolCall → `ToolCallFailed`、`TurnInterrupted` 記録）は既存 `finalize_turn` をそのまま再利用する。`SessionClosed` を新しい中断理由として通せるよう enum と写像だけを拡張する。
+- **usecase / runtime（`runtime/usecase.rs`）**: 終了手順の統一。`close_session` / `close_all` / `set_session_backend` が共通の「終端ヘルパ」を経由するようにする。ヘルパは進行中 turn の有無を判定し、進行中なら flush → drain → finalize → close → remove を実行する。finalize は既存 `complete_turn` を `TurnResult::Interrupted { reason: SessionClosed }` で呼ぶだけとし、terminal event 記録・permission 畳み込み・ToolCall 畳み込みは既存経路に委譲する。
+- **usecase / application lifecycle（`application_lifecycle.rs`）**: agent session、workflow command、local API の shutdown port を受け、agent finalize に失敗した場合は不可逆な後続 shutdown を呼ばない業務順序を所有する。controller は usecase の起動と process exit / log だけを担当する。
+- **usecase / session query**: event append 時に最新 turn terminal を `SessionMeta.last_turn_interruption` へ、最新 turn id を `SessionMeta.last_turn_id` へ射影する。`GetSessionResponse` は `TurnInterrupted` の場合だけ message id と reason を載せる。通常の turn id 採番と TurnStarted 射影は軽量 meta の bounded read/update で行い、query と start のたびに event history 全量をロードしない。旧 meta に `last_turn_id` が無い場合だけ互換 fallback として一度 event log から採番する。
+- **adaptor / gateway**: terminal event 群は既存 `events.json` を truncate/rewrite せず、session 単位の append-only batch segment として保存する。temp file の write/flush が完了した segment だけを atomic rename で公開し、未完 segment は read model から無視する。closed フラグによる emit 抑止（`claude/session.rs` / `codex/session.rs`）は変更しない。
+
+### 終了順序の是正（現状 → 是正後）
+
+現状（`close_session`, `runtime/usecase.rs:839`）:
+
+1. sessions map から state を remove（この時点で in-flight event は epoch/None guard で捨てられる）
+2. `runtime.close()`（closed フラグで backend の終了イベント emit を抑止）
+
+是正後（共通ヘルパ `finalize_and_close_session`）:
+
+1. 進行中 turn 判定（`state.phase != Idle`）。進行中でなければ 5〜6 のみ（従来どおり、新規中断 turn を作らない）。
+2. `flush_streaming_update(ctx, session_id, force_persist=true)`：最後の定期スナップショット以降のストリーミング本文・pending parts を durable 化する。
+3. **drain（有界待ち）**：runtime を開いたまま、event pump が既に emit 済みの最終イベント（`TurnCompleted` 等）を適用しきる短時間の窓を与える。窓内に backend の実 `TurnCompleted` が届いて `complete_turn` が phase を `Idle` に落とせば、次段の SessionClosed finalize は idempotent に no-op となる（最終イベントを取りこぼさない）。
+4. `complete_turn(ctx, session_id, None, TurnResult::Interrupted { reason: SessionClosed, error: None })`：既存 finalize 経路で terminal event 記録・permission/ToolCall 畳み込みを行う。terminal event 群は batch で原子的に append し、message parts と session state の永続化まで成功してから in-memory phase を `Idle` に落とす。途中で失敗した場合は runtime/state を保持し、同じ close を再試行できる。phase が既に `Idle` の場合は skip される（idempotent）。
+5. `runtime.close()`：closed フラグを立て process を shutdown。
+6. sessions map から state を remove。
+
+`close_all` は保持している各セッションについて同じヘルパを適用する。`set_session_backend` は既に内部で `close_session` を呼んでいるため（`runtime/usecase.rs:820`）、`close_session` の是正がそのまま反映される。
+
+### drain の設計
+
+- drain は「state を remove せず・runtime を close せず」に、event pump タスク（`spawn_event_pump_task`）が mpsc に積まれた既 emit 済みイベントを処理しきる猶予を与えるための有界待ちである。
+- 実装は sessions ロックを保持しない有界ループとする。上限 `CLOSE_DRAIN_TIMEOUT`（既定 200ms、`runtime/usecase.rs` 内の const）まで、短い間隔（例 10ms）で `state.phase` を再読して、`Idle` に落ちたら早期終了する。落ちなければ上限で打ち切って次段（SessionClosed finalize）へ進む。
+- drain 中に epoch guard（`apply_runtime_event` の `is_current_runtime`）は state 未 remove のため一致し続けるため、in-flight event は破棄されず適用される。これが RT-1 の「state 先行 remove により in-flight event を捨てる」経路の是正になる。
+- drain は backend の応答を無制限には待たない（有界）。上限到達時は SessionClosed で確定的に終端する。
+- closed フラグ（emit 抑止）は drain 前に立てない。runtime.close() は finalize の後に呼ぶため、drain 中は backend の最終イベントが正常に emit・適用される。
+
+## データモデルまたは型
+
+### domain `InterruptReason`（`entities/turn.rs`）
+
+```rust
+pub enum InterruptReason {
+    Abort,
+    Timeout,
+    Crash,
+    SessionClosed, // 追加: 正常な close / backend 切替 / アプリ終了で turn を終端した理由
+}
+```
+
+### event log `InterruptReason`（`event_log/events.rs`）
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InterruptReason {
+    Abort,
+    Timeout,
+    Crash,
+    SessionClosed, // serde 表現: "session_closed"
+}
+
+impl InterruptReason {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Abort => "abort",
+            Self::Timeout => "timeout",
+            Self::Crash => "crash",
+            Self::SessionClosed => "session_closed",
+        }
+    }
+}
+```
+
+- serde は `rename_all = "snake_case"` の unit variant であり、追加は additive。永続化済み event（`"abort"` / `"timeout"` / `"crash"`）の deserialize は影響を受けない（F3 additive 規約）。
+- `TurnInterrupted` イベントの永続表現は `"reason": "session_closed"` となる。
+
+### `terminal_projection` の写像（`runtime/usecase.rs`）
+
+`TurnResult::Interrupted { reason: DomainInterruptReason::SessionClosed, .. }` を次へ写像する:
+
+- `exit_code = 0`
+- `session_state = SessionState::Idle`
+- `interrupted = true`
+- `event = TerminalEventProjection::Interrupted { reason: EventInterruptReason::SessionClosed, error }`
+
+`SessionClosed` は利用者/システムによる正常な終了であり、`Abort` と同様にエラーではない扱い（exit_code 0 / Idle）とする（後述の仮定 A1）。
+
+### `project_status` の分岐（`event_log/projector.rs`）
+
+`TerminalEvent::Interrupted` の既存分岐に `SessionClosed` を追加し、`Abort` と同じく `SessionState::Idle` / `TurnPhase::Idle` に射影する。
+
+```rust
+TerminalEvent::Interrupted {
+    reason: InterruptReason::Abort | InterruptReason::SessionClosed,
+    ..
+} => ProjectedStatus { session_state: SessionState::Idle, turn_phase: TurnPhase::Idle },
+TerminalEvent::Interrupted { .. } => ProjectedStatus {
+    session_state: SessionState::Error, turn_phase: TurnPhase::Idle,
+},
+```
+
+## 処理フロー
+
+### close_session（是正後）
+
+1. session lock を blocking acquire し、進行中の `send_message` / `respond_permission` 等が完了するまで待つ。既に guard を持つ node lifecycle 経路は guard を解放してから public close を呼ぶ。
+2. sessions ロックを取り、`state.closing=true` として新しい外部操作を拒否し、`state.phase`・`state.runtime` を読む（remove しない）。
+3. `phase == Idle` かつ runtime なし → 従来どおり state remove のみで終了（新規中断 turn を作らない）。
+4. `phase != Idle`（進行中 turn あり）:
+   1. `flush_streaming_update(force_persist=true)`。
+   2. session lock を一時的に解放して drain（有界待ち、上限 `CLOSE_DRAIN_TIMEOUT`）。event pump だけが terminal event を適用でき、新しい外部操作は `closing` guard で拒否される。途中で `phase == Idle` になれば早期終了。
+   3. session lock を再取得し、`complete_turn(.., TurnResult::Interrupted { reason: SessionClosed, error: None })`。
+      - 内部で再度 `flush_streaming_update(force=true)` → `terminal_projection` → `append_final_turn_events` → （Interrupted 分岐で）`finalize_turn`。
+      - `finalize_turn` が未完了 ToolCall を `ToolCallFailed`（"session_closed により中断"）へ、未解決 permission を `PermissionResolved{ decision: Cancelled }` へ畳み、`TurnInterrupted { reason: SessionClosed, exit_code: 0 }` を記録。
+      - 既に terminal がある turn（drain 中に実 `TurnCompleted` が届いた等）は `has_turn_terminal` / phase==Idle で no-op。
+   4. `runtime.close()`。
+   5. sessions map から state remove。
+
+### close_all（アプリ終了）
+
+- `application_lifecycle.rs` の `shutdown_application_services` が `close_all().await` を `app.exit(0)` 前に await する（既存）。
+- 現行の `drain()` 一括 remove をやめ、保持セッションを列挙し、各セッションに対して close_session と同じ終端ヘルパを適用してから remove する。全セッション分の drain が直列だと終了が遅延しうるため、セッション単位の finalize は並行実行（`join_all` 等）し、各々の drain 上限は `CLOSE_DRAIN_TIMEOUT` で有界に保つ。
+
+### set_session_backend（backend 切替）
+
+- `set_session_backend` 全体を同じ per-session transition として直列化する。まず旧 runtime を close と同じ手順で finalize/remove し、その完了後にだけ新しい backend selection を永続化する。drain 中は session lock を一時解放するが `closing=true` により競合する `send_message` を拒否し、finalize/remove から backend selection 更新までは再取得した lock を保持する。
+- provider 切替に伴う configuration handoff の再設計は行わない（非スコープ）。
+
+### 再オープン時の観測
+
+- event log を `TurnEventLog::from_events(...).project()` で再構成すると、`TurnInterrupted { reason: SessionClosed }` が `TerminalEvent::Interrupted { reason: SessionClosed }` に射影され、status は `Idle`、ToolCall は失敗（中断）、permission は `Cancelled` として現れる。
+- terminal append と同時に `SessionMeta.last_turn_interruption` を更新する。`GetSessionResponse.lastTurnInterruption` はこの軽量 projection から、最新 turn が interrupted terminal を持つ場合だけ agent message id と reason を返す。再オープン・再起動後も durable meta から復元され、会話ビューは対象 message に中断チップを描画する。
+
+## エラー処理
+
+- `flush_streaming_update(force=true)` / terminal event batch append / terminal message parts / terminal session state のいずれかの永続化に失敗した場合、`complete_turn` から `close_session` / `set_session_backend` / `close_all` へエラーを伝播する。runtime close と state remove は行わず、in-memory turn state を保持して再試行可能にする。
+- terminal event 群は、test hook を全 event に事前適用した後、temp batch segment を完全書込みし、atomic rename で commit する。既存 event prefix は再構築しない。未 commit の temp segment は全体を不可視とし、batch commit 後の message/meta 更新に失敗した場合も、既存 terminal を検出して重複 append せず後続永続化だけを再試行する。
+- `close_all` の一部 session が失敗した場合は全 session の試行を完了した後に集約エラーを返す。application shutdown はエラー時に process exit へ進まず、terminal guarantee を silent success にしない。
+- drain の上限到達は正常系（エラーではない）。上限で打ち切って SessionClosed finalize に進む。
+- runtime が存在しない（既に閉じている）セッションでは finalize をスキップし、state remove のみ行う。
+- `complete_turn` は phase / generation / `has_turn_terminal` の各 guard により idempotent。二重終端・Crash 上書きは発生しない。
+
+## テスト方針
+
+Rust のシナリオテスト（`runtime/usecase.rs` の `#[cfg(test)]`、および `event_log` / `projector` の該当 module）で固定する。外部プロセスは起動せず、`AgentSessionRuntime` のテスト double（既存の fake runtime）と `SessionStore`（temp data_dir）を用いる。
+
+1. **streaming 中 close → 再オープン**（RT-1 主シナリオ / behavior Rule 群）:
+   - streaming 本文を出し、未完了 ToolCall と未送信 `Pending` permission を持つ turn を進行中にする。
+   - `close_session` を呼ぶ。
+   - event log を再ロード・project して検証:
+     - `TurnInterrupted { reason: SessionClosed }` が記録されている。
+     - `run_in_background=true` の未完了 Task が `ToolCallFailed` と `TaskStatusChanged(stopped)` に畳まれ、実行中スピナー相当が残らない。
+     - 未送信 permission が `PermissionResolved { decision: Cancelled }` に畳まれ、`latest_unresolved_permission_request` が `None`。
+     - 最後のスナップショット以降のストリーミング本文・pending parts がメッセージに反映されている（flush 済み）。
+     - status が `Idle`（`Active/Streaming` に残らない）で、query response に message id と `SessionClosed` reason が載る。
+2. **進行中 turn が無いセッションの close**: 新規中断 turn が生成されず、履歴が保持されること。
+3. **backend 切替（`set_session_backend`）**: 進行中 turn が finalize（reason=SessionClosed）されること。
+4. **アプリ終了（`close_all`）→ 再ロード**: 保持セッションの進行中 turn が finalize され、再構成後に残骸が無く中断（SessionClosed）で終端していること。
+5. **drain（close と競合する最終イベント）**: close 手順の途中で fake runtime に `TurnCompleted`（正常完了）を emit させ、drain 窓内に適用されて turn が正常 `Completed` で終端し、SessionClosed で上書きされないこと（idempotent）。
+6. **SessionClosed は Crash を上書きしない**: 既に `TurnInterrupted { reason: Crash }` を持つ turn に close 経路が関与しても reason が SessionClosed に変わらないこと（`has_turn_terminal` guard）。
+7. **event log 後方互換**: `"abort"` / `"timeout"` / `"crash"` を含む既存 event の deserialize / project が SessionClosed 追加後も不変であること（`event_log/tests.rs`）。
+8. `project_status` / `terminal_projection` の SessionClosed 分岐 unit test。
+9. `send_message` / `respond_permission` と close の競合で、close が先行操作の完了を待ち、確定済み応答を Cancelled で上書きしないこと。
+10. **backend 切替との競合**: transition 中の `send_message` が拒否され、旧 runtime の finalize/remove 前に新 backend metadata が公開されず、切替後の runtime state と durable backend が一致すること。
+11. **bounded query**: 長い event log を持つ session でも `get_session` が event history をロードせず、meta projection から `lastTurnInterruption` を返すこと。
+12. **永続化失敗の再試行**: force flush、terminal batch append、terminal commit 後の message parts persist をそれぞれ失敗注入し、close がエラーを返して runtime/state を保持すること。再試行後に terminal が一件だけ記録され close が完了すること。
+13. **session 間の分離**: 一方の session の TurnStarted 永続化を停止しても、他方の session が close/state 遷移できること。TurnStarted の採番・meta 射影で event history をロードせず、global sessions lock を保持しないこと。
+14. **application lifecycle 境界**: agent finalize → workflow command shutdown → local API shutdown の成功順序と、agent finalize 失敗時に後続 port を呼ばないこと。
+15. **terminal batch fault**: batch の各 event 境界で temp segment が途切れても新規 event は 0 件だけ可視であり、再試行 commit 後は全件が一度ずつ可視になること。
+
+CI 同一コマンド（`pnpm lint` / `pnpm test` / `pnpm build` / `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`）が通ること。
+
+## リスクと代替案
+
+- **drain 上限の妥当性**: 200ms は「短時間の有界待ち」の初期値。短すぎると競合最終イベントの取りこぼし（ただし SessionClosed finalize が保険）、長すぎるとアプリ終了が遅延する。`phase==Idle` 早期終了と `CLOSE_DRAIN_TIMEOUT` の const 化で調整可能にする。代替案として drain を「backend からの明示的 result 到達 or timeout の select」にする案もあるが、既 emit 済みイベントの適用は event pump タスク経由で非同期に進むため、phase ポーリングの方が結合が薄く堅い。
+- **emit 抑止の解除はしない**: closed フラグを触ると crash 検出（RT-2）や既存の abort 経路に影響が及ぶ。本設計は close 前に runtime を開いたまま finalize することで terminal event を確実に適用し、抑止解除を回避する。代替（抑止解除）は RT-2 / #1407 との干渉リスクが高く却下。
+- **`close_all` の並行 finalize**: 多数セッション時の終了遅延を避けるため finalize を並行化する。共有 `RuntimeContext` への並行アクセスは既存の per-session ロックで直列化されるため安全。
+- **中断チップの reason 表示粒度**: reason の判定は Rust read model が行い、フロントエンドは `SessionClosed` を表示用文言へ整形するだけとする。見た目は behavior の対象外。
+
+## 仮定
+
+- **A1**: `SessionClosed` は正常な利用者/システム操作による終了であり、`terminal_projection` / `project_status` では `Abort` と同様にエラー扱いしない（exit_code 0 / `SessionState::Idle`）。
+- **A2**: drain の上限は `CLOSE_DRAIN_TIMEOUT = 200ms`（ポーリング間隔 10ms）を初期値とする。無制限に close をブロックしない有界待ちである。
+- **A3**: closed フラグ（backend の terminal event emit 抑止）は変更しない。close 前に runtime を開いたまま finalize を済ませることで terminal event の適用を保証する。
+- **A4**: 対象は正常な `close_session` / `set_session_backend` / `close_all` の三経路に閉じる。プロセスクラッシュ・強制終了時の起動時 dangling turn 回収（`Crash` 理由）は RT-2 / #1407 の非スコープであり、`SessionClosed` は `has_turn_terminal` / phase guard により `Crash` 理由を上書きしない。
+- **A5**: streaming flush の損失許容窓は現行の定期 flush 間隔（1 秒）に準ずる。close 時は `force_persist=true` によりこの窓内までの本文を確実に durable 化する。
+- **A6**: write-ahead 済み（`Responding` / `Resolving`）permission の扱いは既存 `finalize_turn` 経路の規約に従う。本設計は未送信 `Pending` の `Cancelled` 畳み込みのみを新規保証として固定する。
+- **A7**: `set_session_backend` は現行 UI 上「空セッション限定」で主経路ではないが、監査 RT-1 の指摘に従い finalize 手順の適用対象に含める。provider 切替の configuration handoff 再設計は行わない。
+- **A8**: フロントエンドは `close_session` を invoke する薄い経路のままとし、interrupt 判断・finalize は Rust（usecase / domain）が所有する（rust-first-logic）。
+
+## Open Questions
+
+なし。

--- a/docs/specs/issues-1405/requirements.md
+++ b/docs/specs/issues-1405/requirements.md
@@ -1,0 +1,91 @@
+# Requirements
+
+## Type
+
+不具合修正 / ライフサイクル信頼性保証（milestone 84「Agentチャット安定化」／ Phase 0 / L4 #1405）。
+
+close / backend 切替 / アプリ終了がターン進行中でも streaming を flush せず finalize もせず、backend の終了イベントも捨てているために、再オープン時にストリーミング本文が途切れ、ツール実行が結果不明のまま残り、permission カードが永久に確認待ちのまま残る問題（監査 RT-1、重大度 high）を解消する。
+
+関連: milestone 84 / 解消する問題: **RT-1** / 不変条件: **I1（turn 終端保証）** / 語彙: **V-D7 の `InterruptReason::SessionClosed` 追加**（F3 additive 規約の先行部分）。
+
+## 背景と目的
+
+### 現状の問題（監査 RT-1）
+
+ストリーミング中にチャットタブを閉じる・backend を切り替える・アプリを終了すると、その turn は flush も finalize もされず terminal event が永久に記録されない。結果として:
+
+1. **本文欠落**: 最後の streaming persist（1秒間隔スナップショット）以降のストリーミング本文と未 persist の pending parts がメッセージストアに書かれず消える。close は force persist しない。
+2. **terminal event 欠落**: event log には `TurnStarted` と durable part event（ToolCallStarted / PermissionRequested 等）と `SessionClosed` は残るが、その turn の terminal event（`TurnCompleted` / `TurnInterrupted`）は永久に記録されず、後から修復する経路も存在しない。
+3. **permission 残骸**: pending Permission part は `Pending` のまま永続化され、再オープン時に操作可能な permission ダイアログとして描画されるが、`respond_permission` は live runtime を必須とするため必ず失敗し、永久に解決不能になる。
+4. **ツール実行残骸**: background Task group が `isRunning = !isCompleted` により永久スピナーのまま残る。
+
+### 根本原因（現行コードの事実）
+
+- `AgentSessionRuntimeUsecase::close_session`（`runtime/usecase.rs:839`）は sessions map から state を remove してから `runtime.close()` するだけで、`flush_streaming_update(force_persist=true)` / `complete_turn` / `finalize_turn` を一切呼ばない。
+- state を先に消すため、close と競合する in-flight のランタイムイベントは `apply_runtime_event` の guard（`sessions.get→None`）で破棄される。
+- さらに Claude / Codex の infrastructure 層は closed フラグにより shutdown 起因の終了イベント（`TurnCompleted(Interrupted)` / `Crash`）の emit 自体を抑止する（`claude/session.rs`、`codex/session.rs`）。
+- `close_all`（アプリ終了: `application_lifecycle.rs`）と `set_session_backend`（`runtime/usecase.rs:801`）も同じ経路。frontend の tab close（`useAgentChat.ts`）も interrupt せず直接 `close_session` を呼ぶ。
+- `finalize_turn` の本番呼び出しは `complete_turn` 経由の1箇所のみで、閉じられた turn を後から修復する経路は存在しない。
+
+### 目的
+
+close / backend 切替 / アプリ終了のどの経路でも、進行中の turn を「streaming flush 強制 → `SessionClosed` 理由で finalize → runtime close」の順で必ず終端させ、再オープン後に本文が flush 済みまで残り、中断チップが表示され、スピナー・permission 残骸が残らない状態を保証する（I1）。
+
+## スコープ
+
+- **終了手順の統一（I1）**: `runtime/usecase.rs` の `close_session` / `set_session_backend`（backend 切替）/ `close_all`（アプリ終了 hook）で、進行中 turn がある場合に次の順序を必ず実行する。
+  1. **streaming flush 強制**: `flush_streaming_update(force_persist=true)` により最後のスナップショット以降のストリーミング本文・pending parts を durable 化する。
+  2. **finalize**: `TurnResult::Interrupted { reason: SessionClosed }` で finalize する。既存 finalize 経路を用いて、未解決 permission（未送信 `Pending`）の `Cancelled(effective=false)` 畳み込み、ToolCall の `Interrupted` 化を行う。
+  3. **runtime close**: 上記完了後に runtime を close し、state を remove する（state の先行 remove により in-flight event を捨てる現行順序を是正する）。
+- **語彙追加（V-D7 先行 / F3 additive）**: `InterruptReason` に `SessionClosed` を追加する。domain（`domain/agent_session/entities/turn.rs`）と event log（`usecase/agent_session/event_log/events.rs`）の両 `InterruptReason` に additive で加える。
+- **終了イベントの回収（drain）**: close 中に backend から届く最終イベント（result / turn completed）を、state 先行 remove と closed フラグにより捨てている経路（RT-1）を、finalize 前に短時間 drain して回収するよう修正する。
+- **finalize 経路の再利用**: 閉じられた turn を修復する新規経路を作るのではなく、`close_session` / `set_session_backend` / `close_all` から既存の finalize 経路を呼べるようにする。
+- **テスト**: streaming 中に close → 再オープンで「本文は flush 済みまで表示・スピナー / permission 残骸なし・中断チップ（SessionClosed）あり」をシナリオテストで固定する。アプリ終了→再起動でも同様であることを検証する。
+
+## 非スコープ
+
+- **crash / 強制終了時の dangling turn 回収**（RT-2、`Interrupted { reason: Crash }` での起動時 finalize）。これは別 Issue（L6 #1407 resume 回復の統一 / RT-2）に属する。本 Issue は正常な close / quit / backend 切替経路の finalize に閉じる。
+- **pending queue の永続化・取消**（RT-3 / L3 #1404）。
+- **ストリーミング本文の durable event 化**（RT-2 の Text/Thinking/Error を event 化する経路）。本 Issue は既存のメッセージストアへの force persist で flush を保証することに閉じ、durable event schema の拡張は行わない。
+- **V-D7 の TurnResult / TurnStopReason / TurnStats の全面改訂**。本 Issue は `InterruptReason::SessionClosed` の additive 追加のみを先行し、それ以外の語彙改訂は該当 Issue（S4 #1392 等）に委ねる。
+- **Agent 実行設定（mode / Goal / reasoning effort）の ack・reconciliation**（Phase 3 以降）。backend 切替（`set_session_backend`）については finalize 手順の適用に閉じ、provider 切替に伴う configuration handoff の再設計は行わない。
+- **frontend の tab close UI フローの再設計**。frontend は引き続き `close_session` を invoke する薄い経路のままとし、finalize 保証は Rust 側で担保する（rust-first-logic）。
+
+## 要求事項
+
+- `close_session` が、進行中 turn を持つセッションに対して「streaming flush 強制 → `SessionClosed` 理由で finalize → runtime close」の順を必ず実行すること。state の先行 remove により in-flight ランタイムイベントを捨てないこと。
+- `set_session_backend`（backend 切替）と `close_all`（アプリ終了 hook）も同じ finalize 手順を経ること。
+- finalize により、その turn の terminal event（`TurnInterrupted` 相当、reason=SessionClosed）が event log に必ず記録されること。
+- finalize により、未送信 `Pending` permission が `Cancelled(effective=false)` に畳まれ、再オープン後に操作可能な permission ダイアログとして残らないこと。write-ahead 済み `Responding` / `Resolving` の扱いは既存 finalize 経路の規約に従うこと。
+- finalize により、進行中の ToolCall が `Interrupted` に畳まれ、background Task group を含めて永久スピナーが残らないこと。
+- close 前に streaming flush が強制され、最後のスナップショット以降のストリーミング本文・pending parts が durable 化されること（損失窓が最大 flush 間隔を超えないこと）。
+- close 中に backend から届く最終イベント（result / turn completed）を、finalize 前に短時間 drain して回収し、無言破棄しないこと。
+- `InterruptReason` に `SessionClosed` が additive で追加され、既存の値・既存イベントの互換性を壊さないこと（F3 additive 規約）。
+- 再オープン時に中断チップ（SessionClosed 由来）が表示されること。
+- ロジックは Rust（usecase / domain）に置かれ、frontend は `close_session` を invoke するだけであること（rust-first-logic）。
+- 上記が Rust のシナリオテスト（streaming 中 close → 再オープン、アプリ終了→再起動）で検証されていること。
+
+## 受け入れ基準の概要
+
+- streaming 中にチャットタブを閉じて再オープンしても、永久スピナー・永久確認待ち permission といった残骸が無いこと。
+- 再オープン後に中断チップ（`SessionClosed`）が表示されること。
+- アプリ終了→再起動でも、streaming 中の turn が finalize されており同様に残骸が無く中断チップが出ること。
+- backend 切替（`set_session_backend`）経路でも進行中 turn が finalize されること。
+- close 前の streaming 本文が flush 済みまで再オープン後に残っていること。
+- event log に、閉じられた turn の terminal event（reason=SessionClosed）が記録されていること。
+- `pnpm lint` / `pnpm test` / `pnpm build` / `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` が通ること。
+
+## 仮定
+
+- spec ディレクトリ ID は `issues-1405`（ブランチ `feat/issues/1405` に対応）とする。
+- 本 Issue の対象経路は「正常な close_session / set_session_backend / close_all（アプリ終了 hook）」であり、プロセスクラッシュ・強制終了時の起動時 dangling turn 回収（`Crash` 理由）は RT-2 / L6 #1407 の非スコープとする。両者は独立して着地させ、SessionClosed が Crash 理由を上書きしない前提を保つ（I1 の `ReconciliationRequired` を Crash 理由で上書きしないという規約と整合）。
+- `set_session_backend` は現行 UI 上「空セッション限定」で主経路ではないが、監査 RT-1 が同一経路と指摘しているため、finalize 手順の適用対象に含める。provider 切替に伴う configuration handoff の再設計は行わず、finalize の適用のみとする。
+- streaming flush の損失許容窓は現行の定期 flush 間隔（1秒）に準ずる。close 時は force persist によりこの窓内までの本文を確実に durable 化する（I3）。
+- backend 終了イベントの drain は「短時間の有界待ち」で行い、無制限に close をブロックしない。drain の具体的な待機時間・打ち切り条件は design.md で確定する。
+- `InterruptReason::SessionClosed` の追加は domain・event log の両 enum に対する additive 変更とし、永続化済み event の後方互換を壊さない（既存 event の deserialize が影響を受けない）。event log 側の永続表現の具体形は design.md / behavior.md で確定する。
+- closed フラグにより backend infrastructure 層（Claude / Codex）が終了イベント emit を抑止している現行挙動を、finalize / drain と両立させる具体方式（emit 抑止の解除か、close 前 finalize による event 適用か）は design.md で確定する。本 requirements では「terminal event が必ず適用される」という性質のみを要求とする。
+- frontend の tab close は現行どおり `close_session` を invoke する薄い経路のままとし、interrupt 判断・finalize は Rust 側が所有する。
+
+## Open Questions
+
+なし。

--- a/src-tauri/src/adaptor/controller/application_lifecycle.rs
+++ b/src-tauri/src/adaptor/controller/application_lifecycle.rs
@@ -2,18 +2,18 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::usecase::application_lifecycle::{
-    AgentSessionShutdownPort, ApplicationLifecycleUsecase, LocalApiShutdownPort,
-    WorkflowCommandShutdownPort,
+    AgentSessionShutdownPort, ApplicationLifecycleError, ApplicationLifecycleUsecase,
+    LocalApiShutdownPort, WorkflowCommandShutdownPort,
 };
 
 #[async_trait::async_trait]
 impl AgentSessionShutdownPort
     for crate::usecase::agent_session::runtime::AgentSessionRuntimeUsecase
 {
-    async fn close_all(&self) -> Result<(), String> {
+    async fn close_all(&self) -> Result<(), ApplicationLifecycleError> {
         crate::usecase::agent_session::runtime::AgentSessionRuntimeUsecase::close_all(self)
             .await
-            .map_err(|error| error.to_string())
+            .map_err(|error| ApplicationLifecycleError::AgentSessionShutdown(error.to_string()))
     }
 }
 
@@ -79,8 +79,10 @@ mod tests {
 
     #[async_trait::async_trait]
     impl AgentSessionShutdownPort for FailingShutdown {
-        async fn close_all(&self) -> Result<(), String> {
-            Err("injected shutdown failure".to_string())
+        async fn close_all(&self) -> Result<(), ApplicationLifecycleError> {
+            Err(ApplicationLifecycleError::AgentSessionShutdown(
+                "injected shutdown failure".to_string(),
+            ))
         }
     }
 
@@ -98,18 +100,13 @@ mod tests {
         let shutdown = FailingShutdown;
         let lifecycle = ApplicationLifecycleUsecase::new(&shutdown, &shutdown, &shutdown);
         let exited = AtomicBool::new(false);
-        {
-            let _guard = crate::infrastructure::platform::tray::QUIT_REQUESTED_TEST_LOCK
-                .lock()
-                .unwrap();
-            crate::infrastructure::platform::tray::mark_quit_requested();
-        }
-
-        shutdown_application(&lifecycle, || exited.store(true, Ordering::SeqCst)).await;
-
         let _guard = crate::infrastructure::platform::tray::QUIT_REQUESTED_TEST_LOCK
             .lock()
             .unwrap();
+        crate::infrastructure::platform::tray::mark_quit_requested();
+
+        shutdown_application(&lifecycle, || exited.store(true, Ordering::SeqCst)).await;
+
         assert!(!exited.load(Ordering::SeqCst));
         assert!(!crate::infrastructure::platform::tray::QUIT_REQUESTED.load(Ordering::SeqCst));
         assert!(crate::infrastructure::platform::window_lifecycle::should_prevent_exit());

--- a/src-tauri/src/adaptor/controller/application_lifecycle.rs
+++ b/src-tauri/src/adaptor/controller/application_lifecycle.rs
@@ -1,26 +1,35 @@
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-#[async_trait::async_trait]
-trait AgentSessionShutdown {
-    async fn close_all(&self);
-}
+use crate::usecase::application_lifecycle::{
+    AgentSessionShutdownPort, ApplicationLifecycleUsecase, LocalApiShutdownPort,
+    WorkflowCommandShutdownPort,
+};
 
 #[async_trait::async_trait]
-impl AgentSessionShutdown for crate::usecase::agent_session::runtime::AgentSessionRuntimeUsecase {
-    async fn close_all(&self) {
-        crate::usecase::agent_session::runtime::AgentSessionRuntimeUsecase::close_all(self).await;
+impl AgentSessionShutdownPort
+    for crate::usecase::agent_session::runtime::AgentSessionRuntimeUsecase
+{
+    async fn close_all(&self) -> Result<(), String> {
+        crate::usecase::agent_session::runtime::AgentSessionRuntimeUsecase::close_all(self)
+            .await
+            .map_err(|error| error.to_string())
     }
 }
 
 #[async_trait::async_trait]
-trait WorkflowCommandShutdown {
-    async fn shutdown_active_commands(&self);
-}
-
-#[async_trait::async_trait]
-impl WorkflowCommandShutdown for crate::usecase::workflow::WorkflowRuntimeUsecase {
+impl WorkflowCommandShutdownPort for crate::usecase::workflow::WorkflowRuntimeUsecase {
     async fn shutdown_active_commands(&self) {
         crate::usecase::workflow::WorkflowRuntimeUsecase::shutdown_active_commands(self).await;
+    }
+}
+
+impl<F> LocalApiShutdownPort for F
+where
+    F: Fn() + Send + Sync,
+{
+    fn shutdown(&self) {
+        self();
     }
 }
 
@@ -30,67 +39,83 @@ pub(crate) fn request_application_quit_with_runtime<F>(
     workflow_runtime: Arc<crate::usecase::workflow::WorkflowRuntimeUsecase>,
     shutdown_local_api: F,
 ) where
-    F: FnOnce() + Send + 'static,
+    F: Fn() + Send + Sync + 'static,
 {
     tauri::async_runtime::spawn(async move {
-        shutdown_local_api();
-        shutdown_application_services(workflow_runtime.as_ref(), runtime.as_ref()).await;
-        app.exit(0);
+        let lifecycle = ApplicationLifecycleUsecase::new(
+            runtime.as_ref(),
+            workflow_runtime.as_ref(),
+            &shutdown_local_api,
+        );
+        shutdown_application(&lifecycle, || app.exit(0)).await;
     });
 }
 
-async fn shutdown_application_services<W, A>(workflow_runtime: &W, runtime: &A)
-where
-    W: WorkflowCommandShutdown + Sync,
-    A: AgentSessionShutdown + Sync,
+async fn shutdown_application<A, W, L, F>(
+    lifecycle: &ApplicationLifecycleUsecase<'_, A, W, L>,
+    exit: F,
+) where
+    A: AgentSessionShutdownPort,
+    W: WorkflowCommandShutdownPort,
+    L: LocalApiShutdownPort,
+    F: FnOnce(),
 {
-    workflow_runtime.shutdown_active_commands().await;
-    // Kill all agent sessions before stopping the server.
-    runtime.close_all().await;
+    match lifecycle.shutdown().await {
+        Ok(()) => exit(),
+        Err(error) => {
+            crate::infrastructure::platform::tray::QUIT_REQUESTED.store(false, Ordering::SeqCst);
+            log::error!("application shutdown aborted: {error}");
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use tokio::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
 
-    #[derive(Clone)]
-    struct RecordingShutdown {
-        calls: Arc<Mutex<Vec<&'static str>>>,
-    }
+    struct FailingShutdown;
 
     #[async_trait::async_trait]
-    impl WorkflowCommandShutdown for RecordingShutdown {
-        async fn shutdown_active_commands(&self) {
-            self.calls.lock().await.push("shutdown_active_commands");
+    impl AgentSessionShutdownPort for FailingShutdown {
+        async fn close_all(&self) -> Result<(), String> {
+            Err("injected shutdown failure".to_string())
         }
     }
 
     #[async_trait::async_trait]
-    impl AgentSessionShutdown for RecordingShutdown {
-        async fn close_all(&self) {
-            self.calls.lock().await.push("close_all");
-        }
+    impl WorkflowCommandShutdownPort for FailingShutdown {
+        async fn shutdown_active_commands(&self) {}
+    }
+
+    impl LocalApiShutdownPort for FailingShutdown {
+        fn shutdown(&self) {}
     }
 
     #[tokio::test]
-    async fn application_quit_shuts_down_workflow_commands_before_agent_sessions() {
-        let calls = Arc::new(Mutex::new(Vec::new()));
-        let workflow_runtime = RecordingShutdown {
-            calls: calls.clone(),
-        };
-        let runtime = RecordingShutdown {
-            calls: calls.clone(),
-        };
+    async fn shutdown_failure_restores_exit_protection_and_allows_tray_retry() {
+        let shutdown = FailingShutdown;
+        let lifecycle = ApplicationLifecycleUsecase::new(&shutdown, &shutdown, &shutdown);
+        let exited = AtomicBool::new(false);
+        {
+            let _guard = crate::infrastructure::platform::tray::QUIT_REQUESTED_TEST_LOCK
+                .lock()
+                .unwrap();
+            crate::infrastructure::platform::tray::mark_quit_requested();
+        }
 
-        shutdown_application_services(&workflow_runtime, &runtime).await;
+        shutdown_application(&lifecycle, || exited.store(true, Ordering::SeqCst)).await;
 
-        assert_eq!(
-            calls.lock().await.as_slice(),
-            ["shutdown_active_commands", "close_all"]
-        );
+        let _guard = crate::infrastructure::platform::tray::QUIT_REQUESTED_TEST_LOCK
+            .lock()
+            .unwrap();
+        assert!(!exited.load(Ordering::SeqCst));
+        assert!(!crate::infrastructure::platform::tray::QUIT_REQUESTED.load(Ordering::SeqCst));
+        assert!(crate::infrastructure::platform::window_lifecycle::should_prevent_exit());
+
+        crate::infrastructure::platform::tray::mark_quit_requested();
+        assert!(!crate::infrastructure::platform::window_lifecycle::should_prevent_exit());
+        crate::infrastructure::platform::tray::QUIT_REQUESTED.store(false, Ordering::SeqCst);
     }
 }

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage.rs
@@ -57,6 +57,10 @@ pub struct FileSessionStorage {
     transaction_apply_hook: RwLock<Option<transaction::TransactionApplyHook>>,
     #[cfg(test)]
     pub(super) projection_commit_hook: RwLock<Option<ProjectionCommitHook>>,
+    #[cfg(test)]
+    pub(super) event_read_count: std::sync::atomic::AtomicUsize,
+    #[cfg(test)]
+    pub(super) event_batch_directory_scan_count: std::sync::atomic::AtomicUsize,
 }
 
 impl Default for FileSessionStorage {
@@ -76,6 +80,10 @@ impl Default for FileSessionStorage {
             transaction_apply_hook: RwLock::new(None),
             #[cfg(test)]
             projection_commit_hook: RwLock::new(None),
+            #[cfg(test)]
+            event_read_count: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            event_batch_directory_scan_count: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 }

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/event_store.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/event_store.rs
@@ -63,7 +63,11 @@ impl FileSessionStorage {
         }
         let _lock = self.file_lock.lock();
         let dir = session_dir(app_data_dir, session_id)?;
-        self.append_session_events_to_dir(&dir, new_events)
+        let outcome = self.append_session_events_to_dir(&dir, new_events)?;
+        if outcome.recovered {
+            self.record_event_log_recovery(session_id);
+        }
+        Ok(())
     }
 
     pub fn append_session_event_without_projection(
@@ -201,8 +205,13 @@ impl FileSessionStorage {
         &self,
         dir: &Path,
         events: &[AgentSessionEvent],
-    ) -> Result<(), String> {
-        self.publish_event_batch_to_dir(dir, events)
+    ) -> Result<AppendOutcome, String> {
+        let legacy_outcome = self.repair_event_array_if_needed(&event_log_file_in_dir(dir))?;
+        let tail_outcome = self.repair_event_array_if_needed(&event_tail_file_in_dir(dir))?;
+        self.publish_event_batch_to_dir(dir, events)?;
+        Ok(AppendOutcome {
+            recovered: legacy_outcome.recovered || tail_outcome.recovered,
+        })
     }
 
     fn publish_event_batch_to_dir(
@@ -367,7 +376,7 @@ impl FileSessionStorage {
 }
 
 fn canonicalize_event_array(path: &Path) -> Result<Vec<AgentSessionEvent>, TransactionApplyError> {
-    let content = match std::fs::read_to_string(&path) {
+    let content = match std::fs::read_to_string(path) {
         Ok(content) => content,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(error) => {
@@ -378,7 +387,7 @@ fn canonicalize_event_array(path: &Path) -> Result<Vec<AgentSessionEvent>, Trans
     };
     let events = parse_session_events_content(&content).map_err(TransactionApplyError::corrupt)?;
     if serde_json::from_str::<Vec<AgentSessionEvent>>(&content).is_err() {
-        write_json_pretty_atomic_durable(&path, &events, "session event log")
+        write_json_pretty_atomic_durable(path, &events, "session event log")
             .map_err(TransactionApplyError::retryable)?;
     }
     Ok(events)
@@ -548,7 +557,9 @@ fn last_non_whitespace_byte(
 mod tests {
     use super::*;
     use crate::usecase::agent_session::event_log::PromptInput;
-    use crate::usecase::agent_session::session::{ChatSession, MessagePart, SessionState};
+    use crate::usecase::agent_session::session::{
+        ChatSession, MessagePart, SessionEventLogRecoverySignal, SessionState,
+    };
     use std::io::BufReader;
 
     const SESSION_ID: &str = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
@@ -722,6 +733,55 @@ mod tests {
             vec![event(1), event(2), event(3), event(4)]
         );
         assert_eq!(committed_event_batch_paths(tmp.path()).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn batch_append_repairs_event_arrays_before_tail_rotation_and_records_recovery() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = storage_with_session(&tmp, SESSION_ID);
+        let dir = session_dir(tmp.path(), SESSION_ID).unwrap();
+        storage
+            .append_session_event_to_dir(&dir, &event(1))
+            .unwrap();
+        storage
+            .append_session_events_to_dir(&dir, &[event(2)])
+            .unwrap();
+        storage
+            .append_session_event_to_dir(&dir, &event(3))
+            .unwrap();
+        for path in [event_log_file_in_dir(&dir), event_tail_file_in_dir(&dir)] {
+            let content = std::fs::read_to_string(&path).unwrap();
+            let closing_pos = content.rfind(']').unwrap();
+            std::fs::write(path, &content[..closing_pos]).unwrap();
+        }
+
+        storage
+            .append_session_events(tmp.path(), SESSION_ID, &[event(4), event(5)])
+            .unwrap();
+
+        let legacy_content = std::fs::read_to_string(event_log_file_in_dir(&dir)).unwrap();
+        assert_eq!(
+            serde_json::from_str::<Vec<AgentSessionEvent>>(&legacy_content).unwrap(),
+            vec![event(1)]
+        );
+        let batch_paths = committed_event_batch_paths(&dir).unwrap();
+        assert_eq!(batch_paths.len(), 3);
+        for path in &batch_paths {
+            let content = std::fs::read_to_string(path).unwrap();
+            serde_json::from_str::<Vec<AgentSessionEvent>>(&content).unwrap();
+        }
+        assert_eq!(
+            serde_json::from_str::<Vec<AgentSessionEvent>>(
+                &std::fs::read_to_string(&batch_paths[1]).unwrap()
+            )
+            .unwrap(),
+            vec![event(3)]
+        );
+        assert_eq!(
+            storage.read_session_events_from_dir(&dir).unwrap(),
+            (1..=5).map(event).collect::<Vec<_>>()
+        );
+        assert!(storage.take_event_log_recovered(SESSION_ID));
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/event_store.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/event_store.rs
@@ -1,7 +1,10 @@
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
-use super::layout::{event_log_file_in_dir, session_dir, write_json_pretty_atomic_durable};
+use super::layout::{
+    event_batches_dir_in_dir, event_log_file_in_dir, event_tail_file_in_dir, session_dir,
+    write_json_pretty_atomic, write_json_pretty_atomic_durable,
+};
 use super::transaction::TransactionApplyError;
 use super::FileSessionStorage;
 use crate::usecase::agent_session::event_log::AgentSessionEvent;
@@ -20,6 +23,7 @@ impl FileSessionStorage {
         if !self.reconcile_session_transaction(app_data_dir, session_id)? {
             return Err(format!("Session not found: {session_id}"));
         }
+        let _lock = self.file_lock.lock();
         let dir = session_dir(app_data_dir, session_id)?;
         self.read_session_events_from_dir(&dir)
     }
@@ -41,6 +45,25 @@ impl FileSessionStorage {
             self.record_event_log_recovery(session_id);
         }
         self.read_session_events_from_dir(&dir)
+    }
+
+    #[cfg(test)]
+    pub fn append_session_events(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        new_events: &[AgentSessionEvent],
+    ) -> Result<(), String> {
+        self.ensure_loaded(app_data_dir)?;
+        if let Some(err) = self.invalid_sessions.read().get(session_id) {
+            return Err(err.clone());
+        }
+        if !self.cache.read().contains_key(session_id) {
+            return Err(format!("Session not found: {session_id}"));
+        }
+        let _lock = self.file_lock.lock();
+        let dir = session_dir(app_data_dir, session_id)?;
+        self.append_session_events_to_dir(&dir, new_events)
     }
 
     pub fn append_session_event_without_projection(
@@ -75,35 +98,87 @@ impl FileSessionStorage {
         &self,
         dir: &Path,
     ) -> Result<Vec<AgentSessionEvent>, String> {
+        #[cfg(test)]
+        self.event_read_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let path = event_log_file_in_dir(dir);
-        match std::fs::read_to_string(&path) {
+        let mut events = match std::fs::read_to_string(&path) {
             Ok(content) => parse_session_events_content(&content),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
             Err(e) => Err(format!("Failed to read session event log: {e}")),
+        }?;
+        for batch_path in self.committed_event_batch_paths(dir)? {
+            let content = std::fs::read_to_string(&batch_path)
+                .map_err(|e| format!("Failed to read session event batch: {e}"))?;
+            let mut batch = serde_json::from_str::<Vec<AgentSessionEvent>>(&content)
+                .map_err(|e| format!("Failed to parse session event batch: {e}"))?;
+            events.append(&mut batch);
         }
+        let tail_path = event_tail_file_in_dir(dir);
+        match std::fs::read_to_string(&tail_path) {
+            Ok(content) => events.extend(parse_session_events_content(&content)?),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(format!("Failed to read session event tail: {error}")),
+        }
+        Ok(events)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reset_event_read_count(&self) {
+        self.event_read_count
+            .store(0, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn event_read_count(&self) -> usize {
+        self.event_read_count
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reset_event_batch_directory_scan_count(&self) {
+        self.event_batch_directory_scan_count
+            .store(0, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn event_batch_directory_scan_count(&self) -> usize {
+        self.event_batch_directory_scan_count
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     pub(super) fn canonicalize_session_events_from_dir(
         &self,
         dir: &Path,
     ) -> Result<Vec<AgentSessionEvent>, TransactionApplyError> {
-        let path = event_log_file_in_dir(dir);
-        let content = match std::fs::read_to_string(&path) {
-            Ok(content) => content,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-            Err(error) => {
-                return Err(TransactionApplyError::retryable(format!(
-                    "Failed to read session event log: {error}"
-                )))
-            }
-        };
-        let events =
-            parse_session_events_content(&content).map_err(TransactionApplyError::corrupt)?;
-        if serde_json::from_str::<Vec<AgentSessionEvent>>(&content).is_err() {
-            write_json_pretty_atomic_durable(&path, &events, "session event log")
-                .map_err(TransactionApplyError::retryable)?;
+        let mut events = canonicalize_event_array(&event_log_file_in_dir(dir))?;
+        for batch_path in self
+            .committed_event_batch_paths(dir)
+            .map_err(TransactionApplyError::retryable)?
+        {
+            let content = std::fs::read_to_string(&batch_path).map_err(|error| {
+                TransactionApplyError::retryable(format!(
+                    "Failed to read session event batch: {error}"
+                ))
+            })?;
+            let mut batch =
+                serde_json::from_str::<Vec<AgentSessionEvent>>(&content).map_err(|error| {
+                    TransactionApplyError::corrupt(format!(
+                        "Failed to parse session event batch: {error}"
+                    ))
+                })?;
+            events.append(&mut batch);
         }
+        events.extend(canonicalize_event_array(&event_tail_file_in_dir(dir))?);
         Ok(events)
+    }
+
+    pub(super) fn event_append_file_in_dir(dir: &Path) -> std::path::PathBuf {
+        if event_batches_dir_in_dir(dir).exists() || event_tail_file_in_dir(dir).exists() {
+            event_tail_file_in_dir(dir)
+        } else {
+            event_log_file_in_dir(dir)
+        }
     }
 
     pub(super) fn append_session_event_to_dir(
@@ -111,7 +186,75 @@ impl FileSessionStorage {
         dir: &Path,
         event: &AgentSessionEvent,
     ) -> Result<AppendOutcome, String> {
+        if event_batches_dir_in_dir(dir).exists() || event_tail_file_in_dir(dir).exists() {
+            let legacy_outcome = self.repair_event_array_if_needed(&event_log_file_in_dir(dir))?;
+            let tail_outcome = self.append_event_to_array(&event_tail_file_in_dir(dir), event)?;
+            Ok(AppendOutcome {
+                recovered: legacy_outcome.recovered || tail_outcome.recovered,
+            })
+        } else {
+            self.append_event_to_legacy_array(dir, event)
+        }
+    }
+
+    pub(super) fn append_session_events_to_dir(
+        &self,
+        dir: &Path,
+        events: &[AgentSessionEvent],
+    ) -> Result<(), String> {
+        self.publish_event_batch_to_dir(dir, events)
+    }
+
+    fn publish_event_batch_to_dir(
+        &self,
+        dir: &Path,
+        events: &[AgentSessionEvent],
+    ) -> Result<(), String> {
+        if events.is_empty() {
+            return Ok(());
+        }
+        let batches_dir = event_batches_dir_in_dir(dir);
+        std::fs::create_dir_all(&batches_dir)
+            .map_err(|e| format!("Failed to create session event batch dir: {e}"))?;
+        let mut next_sequence = self
+            .committed_event_batch_paths(dir)?
+            .iter()
+            .filter_map(|path| {
+                path.file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .and_then(|stem| stem.parse::<u64>().ok())
+            })
+            .max()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or_else(|| "Failed to allocate session event batch sequence".to_string())?;
+        let tail_path = event_tail_file_in_dir(dir);
+        if tail_path.exists() {
+            let rotated_tail_path = batches_dir.join(format!("{next_sequence:020}.json"));
+            std::fs::rename(&tail_path, &rotated_tail_path)
+                .map_err(|e| format!("Failed to rotate session event tail: {e}"))?;
+            next_sequence = next_sequence
+                .checked_add(1)
+                .ok_or_else(|| "Failed to allocate session event batch sequence".to_string())?;
+        }
+        let path = batches_dir.join(format!("{next_sequence:020}.json"));
+        write_json_pretty_atomic(&path, &events, "session event batch")
+    }
+
+    fn append_event_to_legacy_array(
+        &self,
+        dir: &Path,
+        event: &AgentSessionEvent,
+    ) -> Result<AppendOutcome, String> {
         let path = event_log_file_in_dir(dir);
+        self.append_event_to_array(&path, event)
+    }
+
+    fn append_event_to_array(
+        &self,
+        path: &Path,
+        event: &AgentSessionEvent,
+    ) -> Result<AppendOutcome, String> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("Failed to create session event log dir: {e}"))?;
@@ -121,16 +264,17 @@ impl FileSessionStorage {
             .write(true)
             .create(true)
             .truncate(false)
-            .open(&path)
+            .open(path)
             .map_err(|e| format!("Failed to open session event log: {e}"))?;
         let payload = serde_json::to_string_pretty(event)
+            .map(|payload| indent_json_payload(&payload))
             .map_err(|e| format!("Failed to serialize session event: {e}"))?;
         let len = file
             .metadata()
             .map_err(|e| format!("Failed to stat session event log: {e}"))?
             .len();
         if len == 0 {
-            write!(file, "[\n{}\n]\n", indent_json_payload(&payload))
+            write!(file, "[\n{payload}\n]\n")
                 .map_err(|e| format!("Failed to append session event: {e}"))?;
             file.flush()
                 .map_err(|e| format!("Failed to flush session event log: {e}"))?;
@@ -165,17 +309,104 @@ impl FileSessionStorage {
             .map_err(|e| format!("Failed to truncate session event log: {e}"))?;
         file.seek(SeekFrom::End(0))
             .map_err(|e| format!("Failed to seek session event log: {e}"))?;
-        if is_empty_array {
-            write!(file, "\n{}", indent_json_payload(&payload))
+        let suffix = if is_empty_array {
+            format!("\n{payload}\n]\n")
         } else {
-            write!(file, ",\n{}", indent_json_payload(&payload))
-        }
-        .map_err(|e| format!("Failed to append session event: {e}"))?;
-        write!(file, "\n]\n").map_err(|e| format!("Failed to close session event log: {e}"))?;
+            format!(",\n{payload}\n]\n")
+        };
+        file.write_all(suffix.as_bytes())
+            .map_err(|e| format!("Failed to append session events: {e}"))?;
         file.flush()
             .map_err(|e| format!("Failed to flush session event log: {e}"))?;
         Ok(AppendOutcome { recovered })
     }
+
+    fn repair_event_array_if_needed(&self, path: &Path) -> Result<AppendOutcome, String> {
+        let mut file = match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(AppendOutcome::default());
+            }
+            Err(error) => return Err(format!("Failed to open session event log: {error}")),
+        };
+        let len = file
+            .metadata()
+            .map_err(|error| format!("Failed to stat session event log: {error}"))?
+            .len();
+        let valid = if len == 0 {
+            false
+        } else {
+            matches!(last_non_whitespace_byte(&mut file, len)?, Some((_, b']')))
+                && event_log_is_valid_json(&mut file)?
+        };
+        if valid {
+            return Ok(AppendOutcome::default());
+        }
+        let events = if len == 0 {
+            Vec::new()
+        } else {
+            recover_session_events_from_file(&mut file)?
+        };
+        rewrite_session_events(&mut file, &events)?;
+        Ok(AppendOutcome { recovered: true })
+    }
+
+    pub(super) fn committed_event_batch_paths(
+        &self,
+        dir: &Path,
+    ) -> Result<Vec<std::path::PathBuf>, String> {
+        #[cfg(test)]
+        self.event_batch_directory_scan_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        committed_event_batch_paths(dir)
+    }
+}
+
+fn canonicalize_event_array(path: &Path) -> Result<Vec<AgentSessionEvent>, TransactionApplyError> {
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(TransactionApplyError::retryable(format!(
+                "Failed to read session event log: {error}"
+            )))
+        }
+    };
+    let events = parse_session_events_content(&content).map_err(TransactionApplyError::corrupt)?;
+    if serde_json::from_str::<Vec<AgentSessionEvent>>(&content).is_err() {
+        write_json_pretty_atomic_durable(&path, &events, "session event log")
+            .map_err(TransactionApplyError::retryable)?;
+    }
+    Ok(events)
+}
+
+fn committed_event_batch_paths(dir: &Path) -> Result<Vec<std::path::PathBuf>, String> {
+    let batches_dir = event_batches_dir_in_dir(dir);
+    let entries = match std::fs::read_dir(&batches_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(format!("Failed to read session event batch dir: {error}")),
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        let path = entry
+            .map_err(|error| format!("Failed to read session event batch entry: {error}"))?
+            .path();
+        if path.extension().and_then(|extension| extension.to_str()) == Some("json")
+            && path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .is_some_and(|stem| stem.parse::<u64>().is_ok())
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
 }
 
 fn recover_session_events_from_file(
@@ -435,6 +666,62 @@ mod tests {
             .unwrap();
 
         assert_eq!(read_events(tmp.path()), vec![event(1), event(2)]);
+    }
+
+    #[test]
+    fn committed_batches_and_following_events_preserve_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = FileSessionStorage::default();
+
+        storage
+            .append_session_event_to_dir(tmp.path(), &event(1))
+            .unwrap();
+        storage
+            .append_session_events_to_dir(tmp.path(), &[event(2), event(3)])
+            .unwrap();
+        storage
+            .append_session_event_to_dir(tmp.path(), &event(4))
+            .unwrap();
+
+        assert_eq!(
+            storage.read_session_events_from_dir(tmp.path()).unwrap(),
+            vec![event(1), event(2), event(3), event(4)]
+        );
+    }
+
+    #[test]
+    fn incomplete_batch_segments_are_invisible_and_retry_commits_each_event_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = FileSessionStorage::default();
+        let batch = vec![event(2), event(3), event(4)];
+        storage
+            .append_session_event_to_dir(tmp.path(), &event(1))
+            .unwrap();
+        let batches_dir = event_batches_dir_in_dir(tmp.path());
+        std::fs::create_dir_all(&batches_dir).unwrap();
+        let temp_path = batches_dir.join("00000000000000000001.json.tmp");
+
+        for completed_event_count in 0..batch.len() {
+            let mut partial =
+                serde_json::to_string_pretty(&batch[..completed_event_count]).unwrap();
+            partial.truncate(partial.rfind(']').unwrap());
+            std::fs::write(&temp_path, partial).unwrap();
+
+            assert_eq!(
+                storage.read_session_events_from_dir(tmp.path()).unwrap(),
+                vec![event(1)]
+            );
+        }
+
+        storage
+            .append_session_events_to_dir(tmp.path(), &batch)
+            .unwrap();
+
+        assert_eq!(
+            storage.read_session_events_from_dir(tmp.path()).unwrap(),
+            vec![event(1), event(2), event(3), event(4)]
+        );
+        assert_eq!(committed_event_batch_paths(tmp.path()).unwrap().len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/layout.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/layout.rs
@@ -62,6 +62,14 @@ pub(super) fn meta_event_transaction_file_in_dir(session_dir: &Path) -> PathBuf 
     session_dir.join("meta_event_transaction.json")
 }
 
+pub(super) fn event_batches_dir_in_dir(session_dir: &Path) -> PathBuf {
+    session_dir.join("event_batches")
+}
+
+pub(super) fn event_tail_file_in_dir(session_dir: &Path) -> PathBuf {
+    session_dir.join("events_tail.json")
+}
+
 pub(super) fn messages_dir_in_dir(session_dir: &Path) -> PathBuf {
     session_dir.join("messages")
 }

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/message_store.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/message_store.rs
@@ -675,8 +675,9 @@ impl FileSessionStorage {
             .as_ref()
             .map(|meta| meta.provider_session_generation)
             .unwrap_or_default();
-        let context_reinjection_generation =
-            preserved_recovery_meta.and_then(|meta| meta.context_reinjection_generation);
+        let context_reinjection_generation = preserved_recovery_meta
+            .as_ref()
+            .and_then(|meta| meta.context_reinjection_generation);
         std::fs::create_dir_all(messages_dir_in_dir(dir))
             .map_err(|e| format!("Failed to create messages dir: {e}"))?;
         std::fs::create_dir_all(attachments_dir_in_dir(dir))
@@ -743,6 +744,10 @@ impl FileSessionStorage {
         meta.provider_session_generation = provider_session_generation;
         meta.context_reinjection_generation = context_reinjection_generation;
         meta.state_revision = state_revision;
+        if let Some(previous) = preserved_recovery_meta {
+            meta.last_turn_interruption = previous.last_turn_interruption;
+            meta.last_turn_id = previous.last_turn_id;
+        }
         meta.body_format_version = SESSION_BODY_FORMAT_VERSION;
         write_private_context_to_dir(dir, &meta)?;
         write_json_pretty_atomic(&meta_file_in_dir(dir), &meta, "session meta")?;

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/projection_commit.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/projection_commit.rs
@@ -1,8 +1,10 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use super::layout::{
-    event_log_file_in_dir, index_file_in_dir, meta_file_in_dir, private_context_file_in_dir,
-    session_dir, write_binary_atomic, write_json_pretty_atomic,
+    event_batches_dir_in_dir, event_log_file_in_dir, event_tail_file_in_dir, index_file_in_dir,
+    meta_file_in_dir, private_context_file_in_dir, session_dir, write_binary_atomic,
+    write_json_pretty_atomic,
 };
 use super::private_context::write_private_context_to_dir;
 use super::FileSessionStorage;
@@ -54,6 +56,74 @@ impl FileSnapshot {
     }
 }
 
+struct EventLogSnapshot {
+    files: Vec<FileSnapshot>,
+    batch_paths: HashSet<PathBuf>,
+    batches_dir_existed: bool,
+}
+
+impl EventLogSnapshot {
+    fn capture(storage: &FileSessionStorage, dir: &Path) -> Result<Self, String> {
+        let files = [event_log_file_in_dir(dir), event_tail_file_in_dir(dir)]
+            .into_iter()
+            .map(FileSnapshot::capture)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            files,
+            batch_paths: storage
+                .committed_event_batch_paths(dir)?
+                .into_iter()
+                .collect(),
+            batches_dir_existed: event_batches_dir_in_dir(dir).exists(),
+        })
+    }
+
+    fn restore(&self, storage: &FileSessionStorage, dir: &Path) -> Result<(), String> {
+        let mut errors = Vec::new();
+        let current_batch_paths = match storage.committed_event_batch_paths(dir) {
+            Ok(paths) => paths,
+            Err(error) => {
+                errors.push(error);
+                Vec::new()
+            }
+        };
+        errors.extend(
+            current_batch_paths
+                .into_iter()
+                .filter(|path| !self.batch_paths.contains(path))
+                .filter_map(|path| {
+                    std::fs::remove_file(&path).err().map(|error| {
+                        format!(
+                            "Failed to remove rolled-back session event batch {}: {error}",
+                            path.display()
+                        )
+                    })
+                }),
+        );
+        errors.extend(
+            self.files
+                .iter()
+                .filter_map(|snapshot| snapshot.restore().err()),
+        );
+        if !self.batches_dir_existed {
+            let batches_dir = event_batches_dir_in_dir(dir);
+            if let Err(error) = std::fs::remove_dir(&batches_dir) {
+                if error.kind() != std::io::ErrorKind::NotFound {
+                    errors.push(format!(
+                        "Failed to remove rolled-back session event batch dir {}: {error}",
+                        batches_dir.display()
+                    ));
+                }
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("; "))
+        }
+    }
+}
+
 impl FileSessionStorage {
     pub fn commit_session_projection(
         &self,
@@ -96,8 +166,8 @@ impl FileSessionStorage {
                 Self::message_path_for_persist(&dir, &index, session_id, message_id)?
             }
         };
+        let event_log_snapshot = EventLogSnapshot::capture(self, &dir)?;
         let snapshots = [
-            event_log_file_in_dir(&dir),
             message_path.clone(),
             index_file_in_dir(&dir),
             meta_file_in_dir(&dir),
@@ -109,9 +179,7 @@ impl FileSessionStorage {
 
         let mut recovered_event_log = false;
         let commit = (|| {
-            for event in events {
-                recovered_event_log |= self.append_session_event_to_dir(&dir, event)?.recovered;
-            }
+            recovered_event_log = self.append_session_events_to_dir(&dir, events)?.recovered;
             self.run_projection_commit_hook(ProjectionCommitStage::Events)?;
 
             let (meta, persisted_parts) = match prepared.message {
@@ -152,11 +220,14 @@ impl FileSessionStorage {
                 Ok(parts)
             }
             Err(error) => {
-                let restore_errors = snapshots
+                let mut restore_errors = snapshots
                     .iter()
                     .rev()
                     .filter_map(|snapshot| snapshot.restore().err())
                     .collect::<Vec<_>>();
+                if let Err(restore_error) = event_log_snapshot.restore(self, &dir) {
+                    restore_errors.push(restore_error);
+                }
                 if restore_errors.is_empty() {
                     Err(error)
                 } else {

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/tests.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/tests.rs
@@ -1,9 +1,9 @@
 use super::layout::{
-    attachment_file_in_dir, attachments_dir_in_dir, content_hash, event_log_file_in_dir,
-    index_file_in_dir, legacy_meta_file, message_file_in_dir, meta_event_transaction_file_in_dir,
-    meta_file_in_dir, private_context_file_in_dir, session_dir, session_file, sessions_dir,
-    tool_output_file_in_dir, tool_outputs_dir_in_dir, write_json_pretty_atomic,
-    write_json_pretty_atomic_durable,
+    attachment_file_in_dir, attachments_dir_in_dir, content_hash, event_batches_dir_in_dir,
+    event_log_file_in_dir, event_tail_file_in_dir, index_file_in_dir, legacy_meta_file,
+    message_file_in_dir, meta_event_transaction_file_in_dir, meta_file_in_dir,
+    private_context_file_in_dir, session_dir, session_file, sessions_dir, tool_output_file_in_dir,
+    tool_outputs_dir_in_dir, write_json_pretty_atomic, write_json_pretty_atomic_durable,
 };
 use super::transaction::{SessionMetaEventTransaction, TransactionApplyStep};
 use super::*;
@@ -91,6 +91,16 @@ fn message(id: &str, content: &str, timestamp: f64) -> ChatMessage {
     }
 }
 
+fn turn_started_event(turn_id: u64) -> AgentSessionEvent {
+    AgentSessionEvent::TurnStarted {
+        turn_id,
+        message_id: format!("human-{turn_id}"),
+        assistant_message_id: Some(format!("agent-{turn_id}")),
+        prompt: PromptInput::default(),
+        at: turn_id as f64,
+    }
+}
+
 fn png_bytes(payload: &[u8]) -> Vec<u8> {
     let mut bytes = vec![0x89, 0x50, 0x4E, 0x47];
     bytes.extend_from_slice(payload);
@@ -169,6 +179,236 @@ fn save_and_load_session() {
     let loaded = loaded.unwrap();
     assert_eq!(loaded.id, UUID1);
     assert_eq!(loaded.messages.len(), 1);
+}
+
+#[test]
+fn terminal_batch_append_does_not_read_or_rewrite_existing_event_history() {
+    let tmp = TempDir::new().unwrap();
+    let store = FileSessionStorage::default();
+    let session = make_session(UUID1, "/repo");
+    store
+        .save_full_session_for_migration_or_restore(tmp.path(), &session)
+        .unwrap();
+    for turn_id in 1..=128 {
+        store
+            .append_session_event_without_projection(
+                tmp.path(),
+                UUID1,
+                &turn_started_event(turn_id),
+            )
+            .unwrap();
+    }
+    store.reset_event_read_count();
+    let tail = [turn_started_event(129), turn_started_event(130)];
+
+    store
+        .append_session_events(tmp.path(), UUID1, &tail)
+        .unwrap();
+
+    assert_eq!(store.event_read_count(), 0);
+    let events = store.load_session_events(tmp.path(), UUID1).unwrap();
+    assert_eq!(events.len(), 130);
+    assert_eq!(&events[128..], tail.as_slice());
+}
+
+#[test]
+fn normal_events_after_terminal_batch_use_one_bounded_tail_without_directory_scans() {
+    let tmp = TempDir::new().unwrap();
+    let store = FileSessionStorage::default();
+    store
+        .save_full_session_for_migration_or_restore(tmp.path(), &make_session(UUID1, "/repo"))
+        .unwrap();
+    store
+        .append_session_event_without_projection(tmp.path(), UUID1, &turn_started_event(1))
+        .unwrap();
+    store
+        .append_session_events(
+            tmp.path(),
+            UUID1,
+            &[turn_started_event(2), turn_started_event(3)],
+        )
+        .unwrap();
+    store.reset_event_batch_directory_scan_count();
+
+    for turn_id in 4..=203 {
+        store
+            .append_session_event_without_projection(
+                tmp.path(),
+                UUID1,
+                &turn_started_event(turn_id),
+            )
+            .unwrap();
+    }
+
+    assert_eq!(store.event_batch_directory_scan_count(), 0);
+    let dir = session_dir(tmp.path(), UUID1).unwrap();
+    assert_eq!(
+        std::fs::read_dir(event_batches_dir_in_dir(&dir))
+            .unwrap()
+            .count(),
+        1
+    );
+    assert!(event_tail_file_in_dir(&dir).exists());
+    let events = store.load_session_events(tmp.path(), UUID1).unwrap();
+    assert_eq!(events.len(), 203);
+    assert_eq!(
+        events,
+        (1..=203).map(turn_started_event).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn turn_id_allocation_and_start_projection_stay_bounded_and_survive_full_save() {
+    let tmp = TempDir::new().unwrap();
+    let storage = Arc::new(FileSessionStorage::default());
+    let store = crate::usecase::agent_session::session::SessionStore::new(storage.clone());
+    let session = make_session(UUID1, "/repo");
+    store
+        .save_full_session_for_migration_or_restore(tmp.path(), &session)
+        .unwrap();
+    store
+        .append_turn_started_and_project_state(tmp.path(), UUID1, turn_started_event(1))
+        .unwrap();
+    for index in 0..500 {
+        store
+            .append_session_event_without_projection(
+                tmp.path(),
+                UUID1,
+                AgentSessionEvent::TextRecorded {
+                    turn_id: 1,
+                    message_id: "agent-1".to_string(),
+                    content: format!("chunk-{index}"),
+                    parent_tool_use_id: None,
+                },
+            )
+            .unwrap();
+    }
+    storage.reset_event_read_count();
+
+    assert_eq!(store.next_turn_id(tmp.path(), UUID1).unwrap(), 2);
+    store
+        .append_turn_started_and_project_state(tmp.path(), UUID1, turn_started_event(2))
+        .unwrap();
+    assert_eq!(storage.event_read_count(), 0);
+
+    let restored = store
+        .load_full_session_for_restore(tmp.path(), UUID1)
+        .unwrap()
+        .unwrap();
+    store
+        .save_full_session_for_migration_or_restore(tmp.path(), &restored)
+        .unwrap();
+    let meta = store.get_session_meta(tmp.path(), UUID1).unwrap().unwrap();
+    assert_eq!(meta.last_turn_id, Some(2));
+    assert_eq!(store.next_turn_id(tmp.path(), UUID1).unwrap(), 3);
+    assert_eq!(storage.event_read_count(), 0);
+}
+
+#[test]
+fn legacy_meta_without_turn_id_projection_falls_back_to_event_history() {
+    let tmp = TempDir::new().unwrap();
+    let storage = Arc::new(FileSessionStorage::default());
+    let store = crate::usecase::agent_session::session::SessionStore::new(storage);
+    store
+        .save_full_session_for_migration_or_restore(tmp.path(), &make_session(UUID1, "/repo"))
+        .unwrap();
+    store
+        .append_session_event_without_projection(tmp.path(), UUID1, turn_started_event(9))
+        .unwrap();
+    let meta_path = meta_file_in_dir(&session_dir(tmp.path(), UUID1).unwrap());
+    let mut meta =
+        serde_json::from_str::<serde_json::Value>(&std::fs::read_to_string(&meta_path).unwrap())
+            .unwrap();
+    meta.as_object_mut().unwrap().remove("lastTurnId");
+    std::fs::write(&meta_path, serde_json::to_vec_pretty(&meta).unwrap()).unwrap();
+    drop(store);
+
+    let storage = Arc::new(FileSessionStorage::default());
+    let store = crate::usecase::agent_session::session::SessionStore::new(storage.clone());
+    store.get_session_meta(tmp.path(), UUID1).unwrap().unwrap();
+    storage.reset_event_read_count();
+
+    assert_eq!(store.next_turn_id(tmp.path(), UUID1).unwrap(), 10);
+    assert_eq!(storage.event_read_count(), 1);
+}
+
+#[test]
+fn turn_start_projection_rejects_non_start_event_without_appending_it() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_session_store();
+    store
+        .save_full_session_for_migration_or_restore(tmp.path(), &make_session(UUID1, "/repo"))
+        .unwrap();
+
+    let error = store
+        .append_turn_started_and_project_state(
+            tmp.path(),
+            UUID1,
+            AgentSessionEvent::TextRecorded {
+                turn_id: 1,
+                message_id: "agent-1".to_string(),
+                content: "not a turn start".to_string(),
+                parent_tool_use_id: None,
+            },
+        )
+        .unwrap_err();
+
+    assert!(error.contains("requires a TurnStarted event"));
+    assert!(store
+        .load_session_events(tmp.path(), UUID1)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn turn_start_projection_failure_recovers_committed_id_before_retry() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_session_store();
+    store
+        .save_full_session_for_migration_or_restore(tmp.path(), &make_session(UUID1, "/repo"))
+        .unwrap();
+    let fail_once = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    store.set_event_projection_hook_for_test({
+        let fail_once = Arc::clone(&fail_once);
+        Arc::new(move |_, last_turn_id| {
+            if last_turn_id == Some(1) && fail_once.swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                Err("injected turn projection failure".to_string())
+            } else {
+                Ok(())
+            }
+        })
+    });
+
+    let error = store
+        .append_turn_started_and_project_state(tmp.path(), UUID1, turn_started_event(1))
+        .unwrap_err();
+
+    assert!(error.contains("injected turn projection failure"));
+    assert_eq!(
+        store
+            .get_session_meta(tmp.path(), UUID1)
+            .unwrap()
+            .unwrap()
+            .last_turn_id,
+        Some(1)
+    );
+    assert_eq!(store.next_turn_id(tmp.path(), UUID1).unwrap(), 2);
+
+    store
+        .append_turn_started_and_project_state(tmp.path(), UUID1, turn_started_event(2))
+        .unwrap();
+    let started_turn_ids = store
+        .load_session_events(tmp.path(), UUID1)
+        .unwrap()
+        .into_iter()
+        .filter_map(|event| match event {
+            AgentSessionEvent::TurnStarted { turn_id, .. } => Some(turn_id),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(started_turn_ids, vec![1, 2]);
+    assert_eq!(store.next_turn_id(tmp.path(), UUID1).unwrap(), 3);
 }
 
 #[test]
@@ -2651,6 +2891,8 @@ fn list_sessions_ignores_legacy_flat_json_and_sidecar() {
         workflow_instructions: Vec::new(),
         agent_read_paths: None,
         context_epoch: None,
+        last_turn_interruption: None,
+        last_turn_id: Some(0),
         first_message_preview: "Hello legacy".to_string(),
         message_count: 1,
         body_format_version: SESSION_BODY_FORMAT_VERSION,

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/tests.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/tests.rs
@@ -2486,6 +2486,63 @@ fn committed_meta_event_transaction_recovers_all_participants_after_restart() {
 }
 
 #[test]
+fn committed_meta_event_transaction_replays_after_an_event_batch() {
+    let tmp = TempDir::new().unwrap();
+    let store = FileSessionStorage::default();
+    store
+        .save_full_session_for_migration_or_restore(tmp.path(), &make_session(UUID1, "/repo"))
+        .unwrap();
+    let base_event = AgentSessionEvent::BackendSessionRecoveryStarted {
+        recovery_id: "recovery-base".to_string(),
+        old_provider_session_generation: 0,
+        reason: BackendSessionRecoveryReason::BackendSessionLost,
+        at: 1001.0,
+    };
+    store
+        .append_session_events(tmp.path(), UUID1, std::slice::from_ref(&base_event))
+        .unwrap();
+    let committed_event = AgentSessionEvent::SessionConfigurationReactivated {
+        recovery_id: "recovery-base".to_string(),
+        provider_session_generation: 1,
+        consumed_observation_id: None,
+        at: 1002.0,
+    };
+    let mut committed_meta = store.get_session_meta(tmp.path(), UUID1).unwrap().unwrap();
+    committed_meta.provider_session_generation = 1;
+    let transaction = SessionMetaEventTransaction::new(
+        UUID1,
+        1,
+        committed_meta,
+        std::slice::from_ref(&committed_event),
+    );
+    let dir = session_dir(tmp.path(), UUID1).unwrap();
+    write_json_pretty_atomic(
+        &meta_event_transaction_file_in_dir(&dir),
+        &transaction,
+        "test session meta/event transaction",
+    )
+    .unwrap();
+    drop(store);
+
+    let reopened = FileSessionStorage::default();
+    assert_eq!(
+        reopened.load_session_events(tmp.path(), UUID1).unwrap(),
+        vec![base_event, committed_event]
+    );
+    assert_eq!(
+        reopened
+            .get_session_meta(tmp.path(), UUID1)
+            .unwrap()
+            .unwrap()
+            .provider_session_generation,
+        1
+    );
+    assert!(event_batches_dir_in_dir(&dir).exists());
+    assert!(event_tail_file_in_dir(&dir).exists());
+    assert!(!meta_event_transaction_file_in_dir(&dir).exists());
+}
+
+#[test]
 fn committed_meta_event_transaction_repairs_interrupted_event_append_after_restart() {
     for partial_trailing_event in [false, true] {
         let tmp = TempDir::new().unwrap();

--- a/src-tauri/src/adaptor/gateway/agent_session/session_storage/transaction.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/session_storage/transaction.rs
@@ -4,9 +4,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use super::layout::{
-    event_log_file_in_dir, meta_event_transaction_file_in_dir, meta_file_in_dir,
-    sync_file_and_parent, sync_parent_dir, validate_meta, write_json_pretty_atomic,
-    write_json_pretty_atomic_durable,
+    meta_event_transaction_file_in_dir, meta_file_in_dir, sync_file_and_parent, sync_parent_dir,
+    validate_meta, write_json_pretty_atomic, write_json_pretty_atomic_durable,
 };
 use super::FileSessionStorage;
 use crate::usecase::agent_session::event_log::AgentSessionEvent;
@@ -185,7 +184,7 @@ impl FileSessionStorage {
                 .map_err(TransactionApplyError::retryable)?;
         }
         if !transaction.events.is_empty() {
-            sync_file_and_parent(&event_log_file_in_dir(dir), "session event log")
+            sync_file_and_parent(&Self::event_append_file_in_dir(dir), "session event log")
                 .map_err(TransactionApplyError::retryable)?;
         }
         #[cfg(test)]

--- a/src-tauri/src/adaptor/gateway/workflow/node_lifecycle_adapters.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/node_lifecycle_adapters.rs
@@ -1,4 +1,3 @@
-use std::future::Future;
 use std::sync::Arc;
 
 use crate::infrastructure::platform::app_data_dir::resolve_data_dir;
@@ -29,42 +28,22 @@ pub(crate) fn resolve_node_session_with_data_dir(
     }))
 }
 
-pub(crate) async fn close_idle_node_runtime_state<F, Fut>(
+pub(crate) async fn close_idle_node_runtime_state(
     runtime: &AgentSessionRuntimeUsecase,
     session_id: &str,
-    close_runtime: F,
-) -> Result<(), NodeExecutionLifecycleError>
-where
-    F: FnOnce() -> Fut,
-    Fut: Future<Output = Result<(), NodeExecutionLifecycleError>>,
-{
-    if should_release_runtime_on_tab_close(runtime, session_id).await {
-        close_runtime().await?;
-    }
-    Ok(())
-}
-
-pub(crate) async fn should_release_runtime_on_tab_close(
-    runtime: &AgentSessionRuntimeUsecase,
-    session_id: &str,
-) -> bool {
-    runtime.has_live_runtime(session_id).await && !runtime.is_runtime_busy(session_id).await
+) -> Result<(), NodeExecutionLifecycleError> {
+    runtime
+        .close_session_if_idle(session_id)
+        .await
+        .map(|_| ())
+        .map_err(|e| NodeExecutionLifecycleError::AgentSession(e.to_string()))
 }
 
 async fn close_idle_node_runtime_with_session_lock(
     runtime: &AgentSessionRuntimeUsecase,
     session_id: &str,
 ) -> Result<(), NodeExecutionLifecycleError> {
-    let _lifecycle_guard = runtime
-        .acquire_session_control_after_recovery(session_id)
-        .await;
-    close_idle_node_runtime_state(runtime, session_id, || async {
-        runtime
-            .force_close_session(session_id)
-            .await
-            .map_err(|error| NodeExecutionLifecycleError::AgentSession(error.to_string()))
-    })
-    .await
+    close_idle_node_runtime_state(runtime, session_id).await
 }
 
 pub(crate) fn open_node_session_tab_state(
@@ -144,13 +123,12 @@ pub(crate) fn try_close_node_session_tab_state(
     Ok(true)
 }
 
-struct TauriNodeExecutionRuntimeGateway<'a, R: tauri::Runtime> {
-    app: &'a tauri::AppHandle<R>,
+struct TauriNodeExecutionRuntimeGateway<'a> {
     runtime: &'a AgentSessionRuntimeUsecase,
 }
 
 #[async_trait::async_trait]
-impl<R: tauri::Runtime> NodeExecutionRuntimeGateway for TauriNodeExecutionRuntimeGateway<'_, R> {
+impl NodeExecutionRuntimeGateway for TauriNodeExecutionRuntimeGateway<'_> {
     async fn close_idle_runtime_on_tab_close(
         &self,
         session_id: &str,
@@ -162,7 +140,6 @@ impl<R: tauri::Runtime> NodeExecutionRuntimeGateway for TauriNodeExecutionRuntim
         &self,
         session_id: &str,
     ) -> Result<(), NodeExecutionLifecycleError> {
-        let _ = self.app;
         self.runtime
             .force_close_session(session_id)
             .await
@@ -253,18 +230,14 @@ pub(crate) fn mark_started_node_tab_open(open_tabs: &OpenTabRegistry, session_id
     open_tabs.add(session_id);
 }
 
-pub(crate) async fn release_node_runtime_on_done<R: tauri::Runtime>(
-    app: &tauri::AppHandle<R>,
-    session_store: &Arc<SessionStore>,
+pub(crate) async fn release_node_runtime_on_done(
     runtime: &Arc<AgentSessionRuntimeUsecase>,
     session_id: &str,
 ) {
     let runtime_gateway = TauriNodeExecutionRuntimeGateway {
-        app,
         runtime: runtime.as_ref(),
     };
     release_node_runtime_on_done_with_gateways(&runtime_gateway, session_id).await;
-    let _ = (app, session_store);
 }
 
 #[cfg(test)]
@@ -487,7 +460,11 @@ mod tests {
         let handles = runtime_for_test();
         insert_runtime(&handles, "node", TurnPhase::Idle, false).await;
 
-        assert!(should_release_runtime_on_tab_close(&handles, "node").await);
+        close_idle_node_runtime_state(&handles, "node")
+            .await
+            .unwrap();
+
+        assert!(!handles.has_live_runtime("node").await);
     }
 
     #[tokio::test]
@@ -510,15 +487,24 @@ mod tests {
     async fn tab_close_runtime_policy_keeps_busy_runtime() {
         let handles = runtime_for_test();
         insert_runtime(&handles, "node", TurnPhase::Streaming, false).await;
-        assert!(!should_release_runtime_on_tab_close(&handles, "node").await);
+        close_idle_node_runtime_state(&handles, "node")
+            .await
+            .unwrap();
+        assert!(handles.has_live_runtime("node").await);
 
-        handles.close_session("node").await.unwrap();
+        handles.force_close_session("node").await.unwrap();
         insert_runtime(&handles, "node", TurnPhase::WaitingPermission, false).await;
-        assert!(!should_release_runtime_on_tab_close(&handles, "node").await);
+        close_idle_node_runtime_state(&handles, "node")
+            .await
+            .unwrap();
+        assert!(handles.has_live_runtime("node").await);
 
-        handles.close_session("node").await.unwrap();
+        handles.force_close_session("node").await.unwrap();
         insert_runtime(&handles, "node", TurnPhase::Idle, true).await;
-        assert!(!should_release_runtime_on_tab_close(&handles, "node").await);
+        close_idle_node_runtime_state(&handles, "node")
+            .await
+            .unwrap();
+        assert!(handles.has_live_runtime("node").await);
     }
 
     #[tokio::test]

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_command_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_command_gateway.rs
@@ -185,12 +185,7 @@ impl WorkflowAbortExecutionGateway for TauriWorkflowRuntimeCommandGateway {
 impl WorkflowStopExecutionGateway for TauriWorkflowRuntimeCommandGateway {
     async fn stop_execution(&self, command: StopExecutionCommand) -> Result<(), WorkflowError> {
         self.engine
-            .stop_workflow_execution(
-                &self.app,
-                &self.session_store,
-                &self.agent_runtime,
-                &command.execution_id,
-            )
+            .stop_workflow_execution(&self.app, &self.agent_runtime, &command.execution_id)
             .await
             .map_err(workflow_engine_error_to_workflow_error)
     }

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine.rs
@@ -61,7 +61,6 @@ pub(crate) trait WorkflowRuntimeEngine: Send + Sync {
     async fn stop_workflow_execution(
         &self,
         app: &tauri::AppHandle,
-        session_store: &Arc<SessionStore>,
         agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
         execution_id: &str,
     ) -> Result<(), WorkflowEngineError>;
@@ -235,18 +234,11 @@ impl WorkflowRuntimeEngine for WorkflowRuntimeService {
     async fn stop_workflow_execution(
         &self,
         app: &tauri::AppHandle,
-        session_store: &Arc<SessionStore>,
         agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
         execution_id: &str,
     ) -> Result<(), WorkflowEngineError> {
-        WorkflowRuntimeService::stop_workflow_execution(
-            self,
-            app,
-            session_store,
-            agent_runtime,
-            execution_id,
-        )
-        .await
+        WorkflowRuntimeService::stop_workflow_execution(self, app, agent_runtime, execution_id)
+            .await
     }
 
     async fn resume_workflow_execution(

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
@@ -1609,7 +1609,6 @@ impl WorkflowRuntimeService {
             let _ = self
                 .interrupt_active_execution(
                     app,
-                    session_store,
                     agent_runtime,
                     &execution_id,
                     ExecutionInterruptionReason::Crash,
@@ -2111,7 +2110,6 @@ impl WorkflowRuntimeService {
             if let Some(reason) = interruption_reason {
                 self.interrupt_active_execution(
                     app,
-                    session_store,
                     agent_runtime,
                     &session_ref.execution_id,
                     reason,
@@ -2380,8 +2378,6 @@ impl WorkflowRuntimeService {
         .await?;
 
         workflow_runtime_session::release_completed_node_sessions(
-            app,
-            session_store,
             agent_runtime,
             &completed_node_session_ids,
         )
@@ -2701,8 +2697,6 @@ impl WorkflowRuntimeService {
         // broadcast / terminal log / cleanup / 次 node 起動 / auto-approve primitive は
         // ここで実行する。
         workflow_runtime_session::release_completed_node_sessions(
-            app,
-            session_store,
             agent_runtime,
             &completed_node_session_ids,
         )
@@ -3296,7 +3290,6 @@ impl WorkflowRuntimeService {
                 if let NodeOutcome::Persist(snapshot) = outcome {
                     self.persist_release_and_broadcast(
                         app,
-                        session_store,
                         agent_runtime,
                         worktree_path,
                         snapshot,
@@ -3366,8 +3359,6 @@ impl WorkflowRuntimeService {
         }
 
         workflow_runtime_session::release_completed_node_sessions(
-            app,
-            session_store,
             agent_runtime,
             &completed_node_session_ids,
         )
@@ -4259,7 +4250,6 @@ impl WorkflowRuntimeService {
                     let _ = self
                         .interrupt_current_command_node(
                             app,
-                            session_store,
                             agent_runtime,
                             &failure_input,
                             ExecutionInterruptionReason::Crash,
@@ -4277,7 +4267,6 @@ impl WorkflowRuntimeService {
                     if let Err(error) = self
                         .interrupt_current_command_node(
                             app,
-                            session_store,
                             agent_runtime,
                             &input,
                             ExecutionInterruptionReason::Crash,
@@ -4296,7 +4285,6 @@ impl WorkflowRuntimeService {
                 let _ = self
                     .interrupt_current_command_node(
                         app,
-                        session_store,
                         agent_runtime,
                         &input,
                         ExecutionInterruptionReason::Crash,
@@ -4610,7 +4598,6 @@ impl WorkflowRuntimeService {
     async fn interrupt_active_execution<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
         agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
         execution_id: &str,
         reason: ExecutionInterruptionReason,
@@ -4804,13 +4791,8 @@ impl WorkflowRuntimeService {
         for session_id in &session_ids {
             workflow_runtime_session::interrupt_agent(agent_runtime, session_id).await;
         }
-        workflow_runtime_session::release_completed_node_sessions(
-            app,
-            session_store,
-            agent_runtime,
-            &session_ids,
-        )
-        .await;
+        workflow_runtime_session::release_completed_node_sessions(agent_runtime, &session_ids)
+            .await;
         self.cleanup_session_workflow_refs_by_execution_id(execution_id)
             .await;
         workflow_runtime_session::broadcast_state(app, &worktree_path, snapshot).await;
@@ -4834,7 +4816,6 @@ impl WorkflowRuntimeService {
     async fn interrupt_current_command_node<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
         agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
         input: &CommandExecutionInput,
         reason: ExecutionInterruptionReason,
@@ -4856,14 +4837,8 @@ impl WorkflowRuntimeService {
             true
         };
         if is_current {
-            self.interrupt_active_execution(
-                app,
-                session_store,
-                agent_runtime,
-                &input.execution_id,
-                reason,
-            )
-            .await?;
+            self.interrupt_active_execution(app, agent_runtime, &input.execution_id, reason)
+                .await?;
         }
         Ok(())
     }
@@ -5354,10 +5329,8 @@ impl WorkflowRuntimeService {
     /// `persist_release_and_broadcast` 呼び出し）専用に温存する。
     /// 本 issue scope の command 受理 handler は required event append 前の rollback 可能な
     /// projection と post-commit `release_completed_node_sessions` の組み合わせを使う。
-    async fn sync_persist_release<R: tauri::Runtime>(
+    async fn sync_persist_release(
         &self,
-        app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
         agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
         snapshot: &RuntimeCommitSnapshot,
         completed_node_session_ids: &[String],
@@ -5380,8 +5353,6 @@ impl WorkflowRuntimeService {
             return Err(e);
         }
         workflow_runtime_session::release_completed_node_sessions(
-            app,
-            session_store,
             agent_runtime,
             completed_node_session_ids,
         )
@@ -5437,20 +5408,13 @@ impl WorkflowRuntimeService {
     async fn persist_release_and_broadcast<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
         agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
         worktree_path: &str,
         snapshot: RuntimeCommitSnapshot,
         completed_node_session_ids: &[String],
     ) -> Result<RuntimeCommitSnapshot, WorkflowEngineError> {
-        self.sync_persist_release(
-            app,
-            session_store,
-            agent_runtime,
-            &snapshot,
-            completed_node_session_ids,
-        )
-        .await?;
+        self.sync_persist_release(agent_runtime, &snapshot, completed_node_session_ids)
+            .await?;
         self.finalize_after_commit(app, &snapshot, worktree_path, true)
             .await;
         Ok(snapshot)
@@ -5518,8 +5482,6 @@ impl WorkflowRuntimeService {
             )
             .await?;
             workflow_runtime_session::release_completed_node_sessions(
-                app,
-                session_store,
                 agent_runtime,
                 &completed_node_session_ids,
             )
@@ -5527,8 +5489,6 @@ impl WorkflowRuntimeService {
         } else {
             // 必須 event 無し: 従来通り sync_persist_release のみ。
             self.sync_persist_release(
-                app,
-                session_store,
                 agent_runtime,
                 &snapshot_for_commit,
                 &completed_node_session_ids,
@@ -5607,7 +5567,6 @@ impl WorkflowRuntimeService {
                     let _ = self
                         .interrupt_active_execution(
                             app,
-                            session_store,
                             agent_runtime,
                             &snapshot.execution_id,
                             ExecutionInterruptionReason::Crash,
@@ -5635,7 +5594,6 @@ impl WorkflowRuntimeService {
                     let _ = self
                         .interrupt_active_execution(
                             app,
-                            session_store,
                             agent_runtime,
                             &snapshot.execution_id,
                             ExecutionInterruptionReason::Crash,
@@ -5663,7 +5621,6 @@ impl WorkflowRuntimeService {
                     let _ = self
                         .interrupt_active_execution(
                             app,
-                            session_store,
                             agent_runtime,
                             &snapshot.execution_id,
                             ExecutionInterruptionReason::Crash,

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/lifecycle_commands.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/lifecycle_commands.rs
@@ -176,14 +176,8 @@ impl WorkflowRuntimeService {
                     activation_guard = Some(activation_gate.lock.lock().await);
                 }
                 let _activation_guard = activation_guard;
-                self.finish_committed_abort(
-                    app,
-                    session_store,
-                    agent_runtime,
-                    execution_id,
-                    &session_ids,
-                )
-                .await;
+                self.finish_committed_abort(app, agent_runtime, execution_id, &session_ids)
+                    .await;
                 self.execution_store
                     .finish_active_interruption(interruption_reservation)
                     .await
@@ -251,7 +245,6 @@ impl WorkflowRuntimeService {
     pub(crate) async fn stop_workflow_execution<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
         agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
         execution_id: &str,
     ) -> Result<(), WorkflowEngineError> {
@@ -268,7 +261,6 @@ impl WorkflowRuntimeService {
         if !self
             .interrupt_active_execution(
                 app,
-                session_store,
                 agent_runtime,
                 execution_id,
                 ExecutionInterruptionReason::Stop,
@@ -377,14 +369,8 @@ impl WorkflowRuntimeService {
             .await?;
         match commit {
             AbortCommit::Aborted { session_ids } => {
-                self.finish_committed_abort(
-                    app,
-                    session_store,
-                    agent_runtime,
-                    execution_id,
-                    &session_ids,
-                )
-                .await;
+                self.finish_committed_abort(app, agent_runtime, execution_id, &session_ids)
+                    .await;
                 Ok(AbortOutcome::Aborted)
             }
             AbortCommit::NotFound => Ok(AbortOutcome::NotFound),
@@ -557,7 +543,6 @@ impl WorkflowRuntimeService {
     async fn finish_committed_abort<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
         agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
         execution_id: &str,
         session_ids: &[String],
@@ -569,13 +554,8 @@ impl WorkflowRuntimeService {
         for session_id in session_ids {
             workflow_runtime_session::interrupt_agent(agent_runtime, session_id).await;
         }
-        self.finalize_terminal_transition_after_required_append(
-            app,
-            session_store,
-            agent_runtime,
-            execution_id,
-        )
-        .await;
+        self.finalize_terminal_transition_after_required_append(app, agent_runtime, execution_id)
+            .await;
     }
 
     /// `abort_workflow_by_execution_id` の post-commit 区間。state は呼出し前に Aborted に
@@ -590,7 +570,6 @@ impl WorkflowRuntimeService {
     pub(super) async fn finalize_terminal_transition_after_required_append<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
-        session_store: &Arc<SessionStore>,
         agent_runtime: &Arc<AgentSessionRuntimeUsecase>,
         execution_id: &str,
     ) {
@@ -605,8 +584,6 @@ impl WorkflowRuntimeService {
         // terminal session の release と refs cleanup。
         let terminal_session_ids = workflow_runtime_commit::terminal_node_session_ids(&snapshot);
         workflow_runtime_session::release_completed_node_sessions(
-            app,
-            session_store,
             agent_runtime,
             &terminal_session_ids,
         )

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/resume_orchestration.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/resume_orchestration.rs
@@ -441,7 +441,6 @@ pub(super) async fn resume_workflow_execution<R: tauri::Runtime + 'static>(
         if let Err(interrupt_error) = engine
             .interrupt_active_execution(
                 app,
-                session_store,
                 agent_runtime,
                 execution_id,
                 ExecutionInterruptionReason::Crash,

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -7974,23 +7974,12 @@ mod dispatch_boundary_tests {
 
         if reason == ExecutionInterruptionReason::Stop {
             engine
-                .stop_workflow_execution(
-                    app.handle(),
-                    &session_store,
-                    &agent_runtime,
-                    &execution_id,
-                )
+                .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
                 .await
                 .unwrap();
         } else {
             assert!(engine
-                .interrupt_active_execution(
-                    app.handle(),
-                    &session_store,
-                    &agent_runtime,
-                    &execution_id,
-                    reason,
-                )
+                .interrupt_active_execution(app.handle(), &agent_runtime, &execution_id, reason,)
                 .await
                 .unwrap());
         }
@@ -8109,7 +8098,7 @@ mod dispatch_boundary_tests {
         append_resumable_two_node_events(&data_dir, &exec);
         insert_execution_and_register_active(&engine, exec, ExecutionOrigin::DesktopUi).await;
         engine
-            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
             .await
             .unwrap();
         let checkpoint_before = engine
@@ -8206,7 +8195,7 @@ mod dispatch_boundary_tests {
         append_resumable_two_node_events(&data_dir, &exec);
         insert_execution_and_register_active(&engine, exec, ExecutionOrigin::DesktopUi).await;
         engine
-            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
             .await
             .unwrap();
 
@@ -8279,7 +8268,7 @@ mod dispatch_boundary_tests {
         append_resumable_two_node_events(&data_dir, &exec);
         insert_execution_and_register_active(&engine, exec, ExecutionOrigin::DesktopUi).await;
         engine
-            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
             .await
             .unwrap();
 
@@ -8705,7 +8694,7 @@ mod dispatch_boundary_tests {
         let engine = WorkflowRuntimeService::new_for_test();
         let data_dir = dispatch_data_dir(app.handle());
         engine.set_execution_store_data_dir(data_dir.clone()).await;
-        let (session_store, agent_runtime) = make_dispatch_deps(data_dir.clone());
+        let (_session_store, agent_runtime) = make_dispatch_deps(data_dir.clone());
         let execution_id = uuid::Uuid::new_v4().to_string();
         let worktree = TempDir::new().unwrap();
         let exec = make_waiting_approval_execution(
@@ -8716,7 +8705,7 @@ mod dispatch_boundary_tests {
         insert_execution_and_register_active(&engine, exec, ExecutionOrigin::DesktopUi).await;
 
         engine
-            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
             .await
             .unwrap();
 
@@ -8822,17 +8811,11 @@ mod dispatch_boundary_tests {
 
         let stop_engine = engine.clone();
         let stop_app = app.handle().clone();
-        let stop_session_store = session_store.clone();
         let stop_agent_runtime = agent_runtime.clone();
         let stop_execution_id = execution_id.clone();
         let mut stop_task = tokio::spawn(async move {
             stop_engine
-                .stop_workflow_execution(
-                    &stop_app,
-                    &stop_session_store,
-                    &stop_agent_runtime,
-                    &stop_execution_id,
-                )
+                .stop_workflow_execution(&stop_app, &stop_agent_runtime, &stop_execution_id)
                 .await
         });
         tokio::time::timeout(std::time::Duration::from_secs(2), &mut stop_task)
@@ -8987,7 +8970,7 @@ mod dispatch_boundary_tests {
         let PausedFanoutActivation {
             app,
             engine,
-            session_store,
+            session_store: _,
             agent_runtime,
             controller,
             execution_id,
@@ -8998,12 +8981,7 @@ mod dispatch_boundary_tests {
 
         tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            engine.stop_workflow_execution(
-                app.handle(),
-                &session_store,
-                &agent_runtime,
-                &execution_id,
-            ),
+            engine.stop_workflow_execution(app.handle(), &agent_runtime, &execution_id),
         )
         .await
         .expect("stop must abort and join stuck fanout child activation tasks")
@@ -9165,7 +9143,7 @@ mod dispatch_boundary_tests {
         let PausedFanoutActivation {
             app,
             engine,
-            session_store,
+            session_store: _,
             agent_runtime,
             controller,
             execution_id,
@@ -9177,12 +9155,7 @@ mod dispatch_boundary_tests {
         engine.fail_next_required_event_append_for_test();
         let stop_error = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            engine.stop_workflow_execution(
-                app.handle(),
-                &session_store,
-                &agent_runtime,
-                &execution_id,
-            ),
+            engine.stop_workflow_execution(app.handle(), &agent_runtime, &execution_id),
         )
         .await
         .expect("failed stop must decide rollback without waiting for backend start")
@@ -9228,7 +9201,7 @@ mod dispatch_boundary_tests {
         }
 
         engine
-            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
             .await
             .unwrap();
     }
@@ -9307,12 +9280,7 @@ mod dispatch_boundary_tests {
             .fail_next_active_interruption_rollback_for_test();
         let stop_error = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            engine.stop_workflow_execution(
-                app.handle(),
-                &session_store,
-                &agent_runtime,
-                &execution_id,
-            ),
+            engine.stop_workflow_execution(app.handle(), &agent_runtime, &execution_id),
         )
         .await
         .expect("failed stop append must roll back without waiting for the paused backend")
@@ -9361,7 +9329,7 @@ mod dispatch_boundary_tests {
         assert_eq!(started_execution_id, execution_id);
 
         engine
-            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
             .await
             .unwrap();
         assert!(controller
@@ -9606,7 +9574,7 @@ mod dispatch_boundary_tests {
 
         assert!(matches!(
             engine
-                .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &missing_id,)
+                .stop_workflow_execution(app.handle(), &agent_runtime, &missing_id,)
                 .await,
             Err(WorkflowEngineError::ExecutionNotFound(_))
         ));
@@ -9717,7 +9685,7 @@ mod dispatch_boundary_tests {
             .unwrap();
         assert!(matches!(
             engine
-                .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &running_id,)
+                .stop_workflow_execution(app.handle(), &agent_runtime, &running_id,)
                 .await,
             Err(WorkflowEngineError::InvalidState(_))
         ));
@@ -9779,12 +9747,7 @@ mod dispatch_boundary_tests {
         ));
         assert!(matches!(
             engine
-                .stop_workflow_execution(
-                    app.handle(),
-                    &session_store,
-                    &agent_runtime,
-                    &completed_id,
-                )
+                .stop_workflow_execution(app.handle(), &agent_runtime, &completed_id,)
                 .await,
             Err(WorkflowEngineError::InvalidState(_))
         ));
@@ -9830,12 +9793,7 @@ mod dispatch_boundary_tests {
             .unwrap();
         assert!(matches!(
             mismatch_engine
-                .stop_workflow_execution(
-                    app.handle(),
-                    &session_store,
-                    &agent_runtime,
-                    &mismatch_id,
-                )
+                .stop_workflow_execution(app.handle(), &agent_runtime, &mismatch_id,)
                 .await,
             Err(WorkflowEngineError::UnauthorizedWorktree(_))
         ));
@@ -11506,7 +11464,7 @@ mod dispatch_boundary_tests {
         let engine = WorkflowRuntimeService::new_for_test();
         let data_dir = dispatch_data_dir(app.handle());
         engine.set_execution_store_data_dir(data_dir.clone()).await;
-        let (session_store, handles) = make_dispatch_deps(data_dir.clone());
+        let (_session_store, handles) = make_dispatch_deps(data_dir.clone());
         let received_payloads: Arc<std::sync::Mutex<Vec<String>>> =
             Arc::new(std::sync::Mutex::new(Vec::new()));
         let received_for_listener = Arc::clone(&received_payloads);
@@ -11594,7 +11552,6 @@ mod dispatch_boundary_tests {
         assert!(engine
             .interrupt_active_execution(
                 app.handle(),
-                &session_store,
                 &handles,
                 &execution_id,
                 ExecutionInterruptionReason::Crash,
@@ -11999,10 +11956,10 @@ mod dispatch_boundary_tests {
         wait_for_active_command(&engine, &execution_id).await;
         let child_pid = wait_for_pid_file(&worktree.path().join("child.pid")).await;
         let data_dir = dispatch_data_dir(app.handle());
-        let (session_store, agent_runtime) = make_dispatch_deps(data_dir);
+        let (_session_store, agent_runtime) = make_dispatch_deps(data_dir);
 
         engine
-            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
             .await
             .unwrap();
 
@@ -12057,7 +12014,7 @@ mod dispatch_boundary_tests {
         let (session_store, agent_runtime) = make_dispatch_deps(data_dir);
 
         engine
-            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
             .await
             .unwrap();
         wait_for_inactive_command(&engine, &execution_id).await;
@@ -12139,10 +12096,10 @@ mod dispatch_boundary_tests {
         let metadata_dir = data_dir.join("workflow_executions");
         std::fs::remove_dir_all(&metadata_dir).unwrap();
         std::fs::write(&metadata_dir, b"block metadata persistence").unwrap();
-        let (session_store, agent_runtime) = make_dispatch_deps(data_dir);
+        let (_session_store, agent_runtime) = make_dispatch_deps(data_dir);
 
         engine
-            .stop_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .stop_workflow_execution(app.handle(), &agent_runtime, &execution_id)
             .await
             .expect("the durable stop fact remains accepted");
 

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
@@ -253,29 +253,19 @@ pub(crate) async fn interrupt_agent(runtime: &Arc<AgentSessionRuntimeUsecase>, s
     }
 }
 
-pub(crate) async fn release_completed_node_session<R: tauri::Runtime>(
-    app: &tauri::AppHandle<R>,
-    session_store: &Arc<SessionStore>,
+pub(crate) async fn release_completed_node_session(
     runtime: &Arc<AgentSessionRuntimeUsecase>,
     session_id: &str,
 ) {
-    crate::adaptor::gateway::workflow::release_node_runtime_on_done(
-        app,
-        session_store,
-        runtime,
-        session_id,
-    )
-    .await;
+    crate::adaptor::gateway::workflow::release_node_runtime_on_done(runtime, session_id).await;
 }
 
-pub(crate) async fn release_completed_node_sessions<R: tauri::Runtime>(
-    app: &tauri::AppHandle<R>,
-    session_store: &Arc<SessionStore>,
+pub(crate) async fn release_completed_node_sessions(
     runtime: &Arc<AgentSessionRuntimeUsecase>,
     session_ids: &[String],
 ) {
     for session_id in session_ids {
-        release_completed_node_session(app, session_store, runtime, session_id).await;
+        release_completed_node_session(runtime, session_id).await;
     }
 }
 

--- a/src-tauri/src/domain/agent_session/entities/turn.rs
+++ b/src-tauri/src/domain/agent_session/entities/turn.rs
@@ -31,6 +31,7 @@ pub enum InterruptReason {
     // Stale watchdog no longer synthesizes timeout interrupts, but the domain boundary keeps the explicit backend/tool timeout vocabulary.
     Timeout,
     Crash,
+    SessionClosed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src-tauri/src/infrastructure/agent_session/fixtures/snapshot.rs
+++ b/src-tauri/src/infrastructure/agent_session/fixtures/snapshot.rs
@@ -523,6 +523,7 @@ pub(super) enum InterruptReasonSnapshot {
     Abort,
     Timeout,
     Crash,
+    SessionClosed,
 }
 
 impl From<InterruptReason> for InterruptReasonSnapshot {
@@ -531,6 +532,7 @@ impl From<InterruptReason> for InterruptReasonSnapshot {
             InterruptReason::Abort => Self::Abort,
             InterruptReason::Timeout => Self::Timeout,
             InterruptReason::Crash => Self::Crash,
+            InterruptReason::SessionClosed => Self::SessionClosed,
         }
     }
 }

--- a/src-tauri/src/infrastructure/platform/tray.rs
+++ b/src-tauri/src/infrastructure/platform/tray.rs
@@ -9,6 +9,12 @@ use tauri::{
 };
 
 pub static QUIT_REQUESTED: AtomicBool = AtomicBool::new(false);
+#[cfg(test)]
+pub(crate) static QUIT_REQUESTED_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+pub(crate) fn mark_quit_requested() {
+    QUIT_REQUESTED.store(true, Ordering::SeqCst);
+}
 
 pub mod ids {
     pub const SHOW_WINDOW: &str = "tray-show-window";
@@ -69,7 +75,7 @@ fn handle_menu_event(
             }
         }
         ids::QUIT => {
-            QUIT_REQUESTED.store(true, Ordering::SeqCst);
+            mark_quit_requested();
             on_quit_requested(app.clone());
         }
         _ => {}

--- a/src-tauri/src/infrastructure/platform/window_lifecycle.rs
+++ b/src-tauri/src/infrastructure/platform/window_lifecycle.rs
@@ -99,7 +99,7 @@ fn startup_visibility_action(close_to_tray: bool) -> StartupVisibilityAction {
     }
 }
 
-fn should_prevent_exit() -> bool {
+pub(crate) fn should_prevent_exit() -> bool {
     !super::tray::QUIT_REQUESTED.load(Ordering::SeqCst)
 }
 
@@ -198,6 +198,7 @@ mod tests {
 
     #[test]
     fn exit_is_prevented_until_tray_quit_is_requested() {
+        let _guard = super::super::tray::QUIT_REQUESTED_TEST_LOCK.lock().unwrap();
         super::super::tray::QUIT_REQUESTED.store(false, Ordering::SeqCst);
         assert!(should_prevent_exit());
 

--- a/src-tauri/src/test_support/agent_session_wire_replay.rs
+++ b/src-tauri/src/test_support/agent_session_wire_replay.rs
@@ -164,6 +164,7 @@ fn map_interrupt_reason(reason: DomainInterruptReason) -> InterruptReason {
         DomainInterruptReason::Abort => InterruptReason::Abort,
         DomainInterruptReason::Timeout => InterruptReason::Timeout,
         DomainInterruptReason::Crash => InterruptReason::Crash,
+        DomainInterruptReason::SessionClosed => InterruptReason::SessionClosed,
     }
 }
 
@@ -172,5 +173,6 @@ fn interrupt_exit_code(reason: DomainInterruptReason) -> i64 {
         DomainInterruptReason::Abort => 0,
         DomainInterruptReason::Timeout => 124,
         DomainInterruptReason::Crash => 1,
+        DomainInterruptReason::SessionClosed => 0,
     }
 }

--- a/src-tauri/src/test_support/mod.rs
+++ b/src-tauri/src/test_support/mod.rs
@@ -136,6 +136,7 @@ pub(crate) struct TestAgentRuntimeController {
     calls: Arc<Mutex<Vec<TestRuntimeCall>>>,
     start_turn_gate: Arc<Mutex<Option<Arc<Notify>>>>,
     open_session_failures: Arc<Mutex<usize>>,
+    respond_permission_gate: Arc<Mutex<Option<Arc<Notify>>>>,
     start_turn_failures: Arc<Mutex<usize>>,
     respond_permission_failures: Arc<Mutex<usize>>,
     steer_failures: Arc<Mutex<usize>>,
@@ -233,6 +234,20 @@ impl TestAgentRuntimeController {
 
     pub(crate) fn fail_next_respond_permission(&self) {
         *self.respond_permission_failures.lock().unwrap() += 1;
+    }
+
+    pub(crate) fn pause_respond_permission(&self) {
+        *self.respond_permission_gate.lock().unwrap() = Some(Arc::new(Notify::new()));
+    }
+
+    pub(crate) fn release_respond_permission(&self) {
+        if let Some(gate) = self.respond_permission_gate.lock().unwrap().take() {
+            gate.notify_waiters();
+        }
+    }
+
+    fn respond_permission_gate(&self) -> Option<Arc<Notify>> {
+        self.respond_permission_gate.lock().unwrap().clone()
     }
 
     fn should_fail_respond_permission(&self) -> bool {
@@ -585,6 +600,9 @@ impl AgentSessionRuntime for TestAgentRuntime {
                 request_id: response.request_id,
             },
         );
+        if let Some(gate) = self.controller.respond_permission_gate() {
+            gate.notified().await;
+        }
         if self.controller.should_fail_respond_permission() {
             return Err(AgentBackendError::Other(
                 "injected test permission response failure".to_string(),

--- a/src-tauri/src/usecase/agent_session/event_log/events.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/events.rs
@@ -53,6 +53,34 @@ pub enum InterruptReason {
     Abort,
     Timeout,
     Crash,
+    SessionClosed,
+}
+
+pub(super) fn assistant_message_id_for_turn(
+    events: &[AgentSessionEvent],
+    turn_id: TurnId,
+) -> Option<String> {
+    events.iter().find_map(|event| match event {
+        AgentSessionEvent::TurnStarted {
+            turn_id: id,
+            message_id,
+            assistant_message_id,
+            ..
+        } if *id == turn_id => Some(assistant_message_id_for_started_turn(
+            message_id,
+            assistant_message_id.as_deref(),
+        )),
+        _ => None,
+    })
+}
+
+pub(super) fn assistant_message_id_for_started_turn(
+    message_id: &str,
+    assistant_message_id: Option<&str>,
+) -> String {
+    assistant_message_id
+        .map(str::to_owned)
+        .unwrap_or_else(|| format!("{message_id}:agent"))
 }
 
 impl InterruptReason {
@@ -61,6 +89,7 @@ impl InterruptReason {
             Self::Abort => "abort",
             Self::Timeout => "timeout",
             Self::Crash => "crash",
+            Self::SessionClosed => "session_closed",
         }
     }
 }

--- a/src-tauri/src/usecase/agent_session/event_log/finalization.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/finalization.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 
-use super::events::{AgentSessionEvent, InterruptReason, PermissionDecision, TurnId};
+use super::events::{
+    assistant_message_id_for_turn, AgentSessionEvent, InterruptReason, PermissionDecision, TurnId,
+};
 use super::part_events::permission_request_id;
 use crate::usecase::agent_session::session::PermissionRequestMsg;
 
@@ -16,6 +18,20 @@ pub fn finalize_turn(
     }
 
     let interrupted_content = interruption_content(reason, error.as_deref());
+    if reason == InterruptReason::SessionClosed {
+        if let Some(message_id) = assistant_message_id_for_turn(events, turn_id) {
+            for task_tool_use_id in active_background_tasks(events, turn_id) {
+                events.push(AgentSessionEvent::TaskStatusChanged {
+                    turn_id,
+                    message_id: message_id.clone(),
+                    task_tool_use_id,
+                    status: "stopped".to_string(),
+                    description: None,
+                    summary: Some(interrupted_content.clone()),
+                });
+            }
+        }
+    }
     for tool_use_id in unfinished_tool_calls(events, turn_id) {
         events.push(AgentSessionEvent::ToolCallFailed {
             turn_id,
@@ -123,6 +139,43 @@ fn unfinished_tool_calls(events: &[AgentSessionEvent], turn_id: TurnId) -> Vec<S
     started
         .into_iter()
         .filter(|tool_use_id| !finished.contains(tool_use_id))
+        .collect()
+}
+
+fn active_background_tasks(events: &[AgentSessionEvent], turn_id: TurnId) -> Vec<String> {
+    let mut started = Vec::new();
+    let mut terminal = HashSet::new();
+    for event in events {
+        match event {
+            AgentSessionEvent::ToolCallStarted {
+                turn_id: id,
+                tool_use_id,
+                input,
+                ..
+            } if *id == turn_id
+                && input
+                    .get("run_in_background")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false) =>
+            {
+                started.push(tool_use_id.clone());
+            }
+            AgentSessionEvent::TaskStatusChanged {
+                turn_id: id,
+                task_tool_use_id,
+                status,
+                ..
+            } if *id == turn_id
+                && matches!(status.as_str(), "completed" | "failed" | "stopped") =>
+            {
+                terminal.insert(task_tool_use_id.clone());
+            }
+            _ => {}
+        }
+    }
+    started
+        .into_iter()
+        .filter(|tool_use_id| !terminal.contains(tool_use_id))
         .collect()
 }
 

--- a/src-tauri/src/usecase/agent_session/event_log/log.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/log.rs
@@ -3,9 +3,9 @@ use std::cell::Cell;
 
 use serde::{Deserialize, Serialize};
 
-use super::events::{AgentSessionEvent, TurnId};
+use super::events::AgentSessionEvent;
 #[cfg(test)]
-use super::events::{InterruptReason, PromptInput};
+use super::events::{InterruptReason, PromptInput, TurnId};
 #[cfg(test)]
 use super::finalization::finalize_turn;
 #[cfg(test)]
@@ -75,13 +75,6 @@ impl TurnEventLog {
             prompt,
             at,
         });
-    }
-
-    pub fn current_turn_id(&self) -> Option<TurnId> {
-        self.events.iter().rev().find_map(|event| match event {
-            AgentSessionEvent::TurnStarted { turn_id, .. } => Some(*turn_id),
-            _ => None,
-        })
     }
 
     pub fn project(&self) -> SessionReadModel {

--- a/src-tauri/src/usecase/agent_session/event_log/mod.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/mod.rs
@@ -32,7 +32,8 @@ pub use part_events::PartEventMode;
 pub(crate) use projector::session_error_message;
 pub(crate) use projector::SessionReadModel;
 pub use projector::{
-    AgentTurnFailureSignal, BackendSessionRecoveryProjection, WorkflowTurnCompleteInput,
+    latest_turn_interruption, AgentTurnFailureSignal, BackendSessionRecoveryProjection,
+    WorkflowTurnCompleteInput,
 };
 
 #[cfg(test)]

--- a/src-tauri/src/usecase/agent_session/event_log/projector.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/projector.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use super::events::{
-    AgentSessionEvent, BackendSessionRecoveryReason, InterruptReason, PromptInput, TurnId,
-    TurnStopReason, TurnTokenUsage,
+    assistant_message_id_for_started_turn, assistant_message_id_for_turn, AgentSessionEvent,
+    BackendSessionRecoveryReason, InterruptReason, PromptInput, TurnId, TurnStopReason,
+    TurnTokenUsage,
 };
 use super::finalization::has_unresolved_permissions;
 use super::part_events::{permission_request_id, permission_tool_use_id};
@@ -10,7 +11,7 @@ use crate::domain::agent_session::entities::ToolResultUpdate;
 use crate::usecase::agent_session::session::{
     apply_tool_result_update, parts_to_legacy, ChatMessage, MessagePart, MessageRole,
     PermissionPartStatus, PermissionRequestMsg, SessionState, SystemNotificationType, TodoListItem,
-    ToolOutputRef, ToolOutputSummary,
+    ToolOutputRef, ToolOutputSummary, TurnInterruption, TurnInterruptionReason,
 };
 use crate::usecase::agent_session::status::TurnPhase;
 
@@ -19,6 +20,39 @@ use crate::usecase::agent_session::status::TurnPhase;
 pub struct ProjectedStatus {
     pub session_state: SessionState,
     pub turn_phase: TurnPhase,
+}
+
+pub fn latest_turn_interruption(events: &[AgentSessionEvent]) -> Option<TurnInterruption> {
+    let turn_id = events.iter().rev().find_map(|event| match event {
+        AgentSessionEvent::TurnStarted { turn_id, .. } => Some(*turn_id),
+        _ => None,
+    })?;
+    let message_id = assistant_message_id_for_turn(events, turn_id)?;
+
+    events.iter().rev().find_map(|event| match event {
+        AgentSessionEvent::TurnInterrupted {
+            turn_id: terminal_turn_id,
+            reason,
+            ..
+        } if *terminal_turn_id == turn_id => Some(Some(TurnInterruption {
+            message_id: message_id.clone(),
+            reason: interruption_reason(*reason),
+        })),
+        AgentSessionEvent::TurnCompleted {
+            turn_id: terminal_turn_id,
+            ..
+        } if *terminal_turn_id == turn_id => Some(None),
+        _ => None,
+    })?
+}
+
+fn interruption_reason(reason: InterruptReason) -> TurnInterruptionReason {
+    match reason {
+        InterruptReason::Abort => TurnInterruptionReason::Abort,
+        InterruptReason::Timeout => TurnInterruptionReason::Timeout,
+        InterruptReason::Crash => TurnInterruptionReason::Crash,
+        InterruptReason::SessionClosed => TurnInterruptionReason::SessionClosed,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -147,9 +181,10 @@ pub fn project(events: &[AgentSessionEvent]) -> SessionReadModel {
                     turns.push(TurnProjection::new(
                         *turn_id,
                         message_id.clone(),
-                        assistant_message_id
-                            .clone()
-                            .unwrap_or_else(|| format!("{message_id}:agent")),
+                        assistant_message_id_for_started_turn(
+                            message_id,
+                            assistant_message_id.as_deref(),
+                        ),
                         prompt.clone(),
                         *at,
                         event_order,
@@ -980,7 +1015,7 @@ fn project_status(
                 turn_phase: TurnPhase::Idle,
             },
             TerminalEvent::Interrupted {
-                reason: InterruptReason::Abort,
+                reason: InterruptReason::Abort | InterruptReason::SessionClosed,
                 ..
             } => ProjectedStatus {
                 session_state: SessionState::Idle,

--- a/src-tauri/src/usecase/agent_session/event_log/tests.rs
+++ b/src-tauri/src/usecase/agent_session/event_log/tests.rs
@@ -5,7 +5,7 @@ use crate::usecase::agent_session::event_log::AgentTurnFailureSignal;
 use crate::usecase::agent_session::session::{
     AttachmentRef, MessageMention, MessagePart, PermissionPartStatus, PermissionRequestKindMsg,
     PermissionRequestMsg, SessionState, SystemNotificationType, TodoListItem, ToolOutputRef,
-    ToolOutputSummary,
+    ToolOutputSummary, TurnInterruption, TurnInterruptionReason,
 };
 use crate::usecase::agent_session::status::TurnPhase;
 
@@ -1053,19 +1053,21 @@ fn a_later_turn_start_clears_current_error_but_preserves_error_history() {
 }
 
 #[test]
-fn terminal_status_projection_marks_abort_as_idle() {
-    let read_model = project(&[
-        start_event(),
-        AgentSessionEvent::TurnInterrupted {
-            turn_id: 1,
-            reason: InterruptReason::Abort,
-            exit_code: 1,
-            error: None,
-        },
-    ]);
+fn terminal_status_projection_marks_abort_and_session_closed_as_idle() {
+    for reason in [InterruptReason::Abort, InterruptReason::SessionClosed] {
+        let read_model = project(&[
+            start_event(),
+            AgentSessionEvent::TurnInterrupted {
+                turn_id: 1,
+                reason,
+                exit_code: 0,
+                error: None,
+            },
+        ]);
 
-    assert_eq!(read_model.status.session_state, SessionState::Idle);
-    assert_eq!(read_model.status.turn_phase, TurnPhase::Idle);
+        assert_eq!(read_model.status.session_state, SessionState::Idle);
+        assert_eq!(read_model.status.turn_phase, TurnPhase::Idle);
+    }
 }
 
 #[test]
@@ -1074,6 +1076,7 @@ fn finalization_closes_tools_permissions_and_turn() {
         InterruptReason::Abort,
         InterruptReason::Timeout,
         InterruptReason::Crash,
+        InterruptReason::SessionClosed,
     ] {
         let mut events = vec![
             start_event(),
@@ -1127,6 +1130,92 @@ fn finalization_closes_tools_permissions_and_turn() {
             })
         );
     }
+}
+
+#[test]
+fn session_closed_finalization_stops_active_background_task_after_launch_result() {
+    let mut events = vec![
+        start_event(),
+        AgentSessionEvent::ToolCallStarted {
+            turn_id: 1,
+            tool_use_id: "background-task".to_string(),
+            tool: "Task".to_string(),
+            input: serde_json::json!({ "run_in_background": true }),
+            parent_tool_use_id: None,
+        },
+        AgentSessionEvent::ToolCallSucceeded {
+            turn_id: 1,
+            tool_use_id: "background-task".to_string(),
+            content: "background task launched".to_string(),
+            content_ref: None,
+            summary: None,
+        },
+    ];
+
+    finalize_turn(&mut events, 1, InterruptReason::SessionClosed, None, 0);
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AgentSessionEvent::TaskStatusChanged {
+            task_tool_use_id,
+            status,
+            ..
+        } if task_tool_use_id == "background-task" && status == "stopped"
+    )));
+    assert!(project(&events)
+        .agent_parts_for_message("agent-1")
+        .iter()
+        .any(|part| matches!(
+            part,
+            MessagePart::TaskStatus {
+                task_tool_use_id,
+                status,
+                ..
+            } if task_tool_use_id == "background-task" && status == "stopped"
+        )));
+}
+
+#[test]
+fn latest_turn_interruption_exposes_message_and_session_closed_reason() {
+    let events = vec![
+        start_event(),
+        AgentSessionEvent::TurnInterrupted {
+            turn_id: 1,
+            reason: InterruptReason::SessionClosed,
+            exit_code: 0,
+            error: None,
+        },
+    ];
+
+    assert_eq!(
+        latest_turn_interruption(&events),
+        Some(TurnInterruption {
+            message_id: "agent-1".to_string(),
+            reason: TurnInterruptionReason::SessionClosed,
+        })
+    );
+}
+
+#[test]
+fn latest_turn_interruption_ignores_an_older_interrupted_turn() {
+    let events = vec![
+        start_event(),
+        AgentSessionEvent::TurnInterrupted {
+            turn_id: 1,
+            reason: InterruptReason::SessionClosed,
+            exit_code: 0,
+            error: None,
+        },
+        turn_started_event(2),
+        AgentSessionEvent::TurnCompleted {
+            turn_id: 2,
+            exit_code: 0,
+            stop_reason: None,
+            token_usage: None,
+        },
+    ];
+
+    assert_eq!(latest_turn_interruption(&events), None);
 }
 
 #[test]
@@ -1228,6 +1317,7 @@ fn finalization_uses_reason_label_when_error_is_none() {
         (InterruptReason::Abort, "abort により中断"),
         (InterruptReason::Timeout, "timeout により中断"),
         (InterruptReason::Crash, "crash により中断"),
+        (InterruptReason::SessionClosed, "session_closed により中断"),
     ] {
         let mut events = vec![
             start_event(),
@@ -1345,4 +1435,30 @@ fn projector_restores_unfinished_recovery_and_its_reconciliation_terminal() {
         at: 11.0,
     };
     assert!(project(&[started, completed]).backend_recovery.is_none());
+}
+
+#[test]
+fn session_closed_does_not_overwrite_existing_crash_terminal() {
+    let mut events = vec![start_event()];
+    finalize_turn(&mut events, 1, InterruptReason::Crash, None, 1);
+    let crashed = events.clone();
+
+    finalize_turn(&mut events, 1, InterruptReason::SessionClosed, None, 0);
+
+    assert_eq!(events, crashed);
+}
+
+#[test]
+fn interrupt_reason_deserialization_remains_backward_compatible() {
+    for (serialized, expected) in [
+        ("\"abort\"", InterruptReason::Abort),
+        ("\"timeout\"", InterruptReason::Timeout),
+        ("\"crash\"", InterruptReason::Crash),
+        ("\"session_closed\"", InterruptReason::SessionClosed),
+    ] {
+        assert_eq!(
+            serde_json::from_str::<InterruptReason>(serialized).unwrap(),
+            expected
+        );
+    }
 }

--- a/src-tauri/src/usecase/agent_session/runtime/session_state.rs
+++ b/src-tauri/src/usecase/agent_session/runtime/session_state.rs
@@ -33,6 +33,7 @@ impl From<RuntimeSessionPhase> for TurnPhase {
 pub(crate) struct RuntimeSessionState {
     pub backend_id: String,
     pub runtime: Option<Arc<dyn AgentSessionRuntime>>,
+    pub closing: bool,
     pub phase: RuntimeSessionPhase,
     pub streaming_message_id: Option<String>,
     pub last_agent_message_id: Option<String>,
@@ -55,6 +56,7 @@ pub(crate) struct RuntimeSessionState {
     pub pending_trailing_fatal_message: Option<String>,
     pub current_turn_id: Option<u64>,
     pub last_turn_id: Option<u64>,
+    pub terminal_turn_id: Option<u64>,
     pub pending_permission_request: Option<PermissionRequestMsg>,
     pub pending_queue: VecDeque<QueuedTurnInput>,
     pub current_turn_input: Option<QueuedTurnInput>,
@@ -117,6 +119,7 @@ impl RuntimeSessionState {
         Self {
             backend_id,
             runtime: None,
+            closing: false,
             phase: RuntimeSessionPhase::Idle,
             streaming_message_id: None,
             last_agent_message_id: None,
@@ -138,6 +141,7 @@ impl RuntimeSessionState {
             pending_trailing_fatal_message: None,
             current_turn_id: None,
             last_turn_id: None,
+            terminal_turn_id: None,
             pending_permission_request: None,
             pending_queue: VecDeque::new(),
             current_turn_input: None,
@@ -184,6 +188,7 @@ impl RuntimeSessionState {
         self.pending_trailing_fatal_message = None;
         self.current_turn_id = Some(turn_id);
         self.last_turn_id = Some(turn_id);
+        self.terminal_turn_id = None;
         self.clear_pending_permission_request();
         self.current_turn_input = None;
         let now = Instant::now();
@@ -215,6 +220,7 @@ impl RuntimeSessionState {
         self.phase = RuntimeSessionPhase::Idle;
         self.streaming_message_id = None;
         self.current_turn_id = None;
+        self.terminal_turn_id = None;
         self.clear_pending_permission_request();
         self.current_turn_input = None;
         self.domain_streaming_parts.clear();

--- a/src-tauri/src/usecase/agent_session/runtime/usecase.rs
+++ b/src-tauri/src/usecase/agent_session/runtime/usecase.rs
@@ -8389,7 +8389,6 @@ mod tests {
             .await
             .unwrap();
         controller.pause_start_turn();
-        let transition_guard = usecase.acquire_session_lock(&session.id).await;
         let send_task = tokio::spawn({
             let usecase = Arc::clone(&usecase);
             let session_id = session.id.clone();
@@ -8411,15 +8410,13 @@ mod tests {
                     .await
             }
         });
-        tokio::task::yield_now().await;
+        wait_for_call(&controller, &session.id, TestRuntimeCallKind::StartTurn).await;
         let close_task = tokio::spawn({
             let usecase = Arc::clone(&usecase);
             let session_id = session.id.clone();
             async move { usecase.close_session_if_idle(&session_id).await }
         });
         tokio::task::yield_now().await;
-        drop(transition_guard);
-        wait_for_call(&controller, &session.id, TestRuntimeCallKind::StartTurn).await;
         assert!(!close_task.is_finished());
 
         controller.release_start_turn();
@@ -13739,6 +13736,11 @@ mod tests {
             SessionCreationAttributes::default(),
         )
         .unwrap();
+        let normal_before_recovery = session_store
+            .get_session_meta(tmp.path(), &normal_session.id)
+            .unwrap()
+            .unwrap()
+            .to_summary();
         usecase
             .start_session(
                 &session.id,
@@ -13853,10 +13855,13 @@ mod tests {
             .iter()
             .find(|summary| summary.id == normal_session.id)
             .unwrap();
-        assert_eq!(tauri_normal.state, normal_session.state);
-        assert_eq!(tauri_normal.updated_at, normal_session.updated_at);
+        assert_eq!(tauri_normal.state, normal_before_recovery.state);
+        assert_eq!(tauri_normal.updated_at, normal_before_recovery.updated_at);
         assert_eq!(workspace_normal.state, WorkspaceSessionState::Active);
-        assert_eq!(workspace_normal.updated_at, normal_session.updated_at);
+        assert_eq!(
+            workspace_normal.updated_at,
+            normal_before_recovery.updated_at
+        );
 
         let events_during_recovery = session_store
             .load_session_events(tmp.path(), &session.id)

--- a/src-tauri/src/usecase/agent_session/runtime/usecase.rs
+++ b/src-tauri/src/usecase/agent_session/runtime/usecase.rs
@@ -82,7 +82,29 @@ use super::streaming::{
     StreamingFlushDecision,
 };
 
-type SessionRuntimeLock = Arc<Mutex<()>>;
+struct SessionTransitionOwner {
+    lock: Arc<Mutex<()>>,
+    durable_turn_start: parking_lot::Mutex<Option<DurableTurnStart>>,
+}
+
+impl Default for SessionTransitionOwner {
+    fn default() -> Self {
+        Self {
+            lock: Arc::new(Mutex::new(())),
+            durable_turn_start: parking_lot::Mutex::new(None),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct DurableTurnStart {
+    backend_id: String,
+    turn_id: u64,
+    agent_message_id: String,
+    current_turn_input: QueuedTurnInput,
+}
+
+type SessionRuntimeLock = Arc<SessionTransitionOwner>;
 
 #[derive(Default)]
 struct SessionRuntimeLockRegistry {
@@ -176,6 +198,98 @@ impl Drop for TestSessionRuntimeLockOwnerReservation {
             "session runtime lock must be released by its acquiring test flow"
         );
         held.remove(&self.owner);
+    }
+}
+
+const CLOSE_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(200);
+const CLOSE_DRAIN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+
+#[derive(Default)]
+struct ShutdownAdmissionState {
+    shutting_down: bool,
+    active_operations: usize,
+}
+
+#[derive(Default)]
+struct ShutdownAdmission {
+    state: std::sync::Mutex<ShutdownAdmissionState>,
+    idle: tokio::sync::Notify,
+}
+
+impl ShutdownAdmission {
+    fn admit(self: &Arc<Self>) -> Result<ShutdownAdmissionGuard, AgentRuntimeError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.shutting_down {
+            return Err(AgentRuntimeError::Other(
+                "Agent session runtime is shutting down".to_string(),
+            ));
+        }
+        state.active_operations += 1;
+        Ok(ShutdownAdmissionGuard {
+            admission: Arc::clone(self),
+        })
+    }
+
+    fn begin_shutdown(&self) {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .shutting_down = true;
+    }
+
+    fn cancel_shutdown(&self) {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .shutting_down = false;
+    }
+
+    async fn wait_for_idle(&self) {
+        loop {
+            let notified = self.idle.notified();
+            if self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .active_operations
+                == 0
+            {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    #[cfg(test)]
+    fn is_shutting_down(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .shutting_down
+    }
+}
+
+struct ShutdownAdmissionGuard {
+    admission: Arc<ShutdownAdmission>,
+}
+
+impl Drop for ShutdownAdmissionGuard {
+    fn drop(&mut self) {
+        let became_idle = {
+            let mut state = self
+                .admission
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.active_operations -= 1;
+            state.active_operations == 0
+        };
+        if became_idle {
+            self.admission.idle.notify_one();
+        }
     }
 }
 
@@ -362,6 +476,7 @@ struct RuntimeContext {
     data_dir: Arc<PathBuf>,
     sessions: Arc<Mutex<RuntimeSessionMap>>,
     session_locks: SessionRuntimeLocks,
+    shutdown_admission: Arc<ShutdownAdmission>,
     workflow_turn_complete_notifier: Arc<RwLock<Option<Arc<dyn WorkflowTurnCompleteNotifier>>>>,
     workflow_stall_notifier: Arc<RwLock<Option<Arc<dyn WorkflowStallNotifier>>>>,
 }
@@ -454,6 +569,12 @@ struct StalledActiveTurnTarget {
     runtime: Arc<dyn AgentSessionRuntime>,
 }
 
+#[derive(Clone, Copy)]
+enum SessionCloseMode {
+    Always,
+    IfIdle,
+}
+
 pub struct AgentSessionRuntimeUsecase {
     ctx: RuntimeContext,
 }
@@ -484,6 +605,7 @@ impl AgentSessionRuntimeUsecase {
                 data_dir: Arc::new(data_dir),
                 sessions: Arc::new(Mutex::new(RuntimeSessionMap::new())),
                 session_locks: Arc::new(SessionRuntimeLockRegistry::default()),
+                shutdown_admission: Arc::new(ShutdownAdmission::default()),
                 workflow_turn_complete_notifier: Arc::new(RwLock::new(None)),
                 workflow_stall_notifier: Arc::new(RwLock::new(None)),
             },
@@ -530,12 +652,16 @@ impl AgentSessionRuntimeUsecase {
         &self,
         req: SendAgentMessageRequest,
     ) -> Result<SendMessageResponse, AgentRuntimeError> {
+        let _admission_guard = self.ctx.shutdown_admission.admit()?;
         let mut session_guard = match req.chat_session_id.as_deref() {
             Some(session_id) => {
                 Some(acquire_session_control_after_recovery(&self.ctx, session_id).await)
             }
             None => None,
         };
+        if let Some(session_id) = req.chat_session_id.as_deref() {
+            self.ensure_session_not_closing(session_id).await?;
+        }
         let session = self.resolve_or_create_session(&req).await?;
         if session_guard.is_none() {
             session_guard =
@@ -701,8 +827,10 @@ impl AgentSessionRuntimeUsecase {
         session_id: &str,
         opts: StartSessionOptions,
     ) -> Result<(), AgentRuntimeError> {
+        let _admission_guard = self.ctx.shutdown_admission.admit()?;
         let _session_guard = acquire_session_control_after_recovery(&self.ctx, session_id).await;
         ensure_backend_recovery_operation_allowed(&self.ctx, session_id)?;
+        self.ensure_session_not_closing(session_id).await?;
         let mut session = self
             .ctx
             .session_store
@@ -763,6 +891,7 @@ impl AgentSessionRuntimeUsecase {
             .acquire_session_control_after_recovery(session_id)
             .await;
         ensure_backend_recovery_operation_allowed(&self.ctx, session_id)?;
+        self.ensure_session_not_closing(session_id).await?;
         let pending = self
             .pending_permission_for_response(session_id, &response)
             .await?;
@@ -1094,21 +1223,24 @@ impl AgentSessionRuntimeUsecase {
         session_id: &str,
         backend_id: &str,
     ) -> Result<GetSessionResponse, AgentRuntimeError> {
-        let session_guard = acquire_session_control_after_recovery(&self.ctx, session_id).await;
-        ensure_backend_recovery_operation_allowed(&self.ctx, session_id)?;
         let selected_model = self
             .ctx
             .registry
             .default_model_for(backend_id)
             .map_err(AgentRuntimeError::Other)?;
-        self.apply_backend_selection_locked(
-            session_id,
-            backend_id.to_string(),
-            Some(selected_model),
-            true,
-        )
+        self.run_session_close(session_id, SessionCloseMode::Always, || async {
+            ensure_backend_recovery_operation_allowed(&self.ctx, session_id)?;
+            self.ctx
+                .session_store
+                .update_backend_selection(
+                    &self.ctx.data_dir,
+                    session_id,
+                    backend_id.to_string(),
+                    Some(selected_model),
+                )
+                .map_err(AgentRuntimeError::Other)
+        })
         .await?;
-        drop(session_guard);
         self.get_session(session_id)
             .await?
             .ok_or_else(|| AgentRuntimeError::Other(format!("Session not found: {session_id}")))
@@ -1149,7 +1281,8 @@ impl AgentSessionRuntimeUsecase {
             .update_backend_selection(&self.ctx.data_dir, session_id, backend_id, selected_model)
             .map_err(AgentRuntimeError::Other)?;
         if backend_changed || restart_same_backend {
-            self.close_session_locked(session_id).await?;
+            self.begin_session_close_locked(session_id).await?;
+            self.close_session_runtime_locked(session_id).await;
         }
         Ok(backend_changed)
     }
@@ -1173,22 +1306,197 @@ impl AgentSessionRuntimeUsecase {
     /// event log before returning session control, including persisting an
     /// interrupted recovery failure and publishing its user-facing error part.
     pub async fn close_session(&self, session_id: &str) -> Result<(), AgentRuntimeError> {
-        let _session_guard = acquire_session_control_after_recovery(&self.ctx, session_id).await;
-        self.close_session_locked(session_id).await
+        self.run_session_close(session_id, SessionCloseMode::Always, || async { Ok(()) })
+            .await?;
+        Ok(())
     }
 
-    /// Closes the runtime without acquiring session control or waiting for recovery.
-    /// Callers must already own the per-session control guard or intentionally use
-    /// the force-close semantics exposed by [`Self::force_close_session`].
-    async fn close_session_locked(&self, session_id: &str) -> Result<(), AgentRuntimeError> {
-        let runtime = {
+    pub async fn close_session_if_idle(&self, session_id: &str) -> Result<bool, AgentRuntimeError> {
+        Ok(self
+            .run_session_close(session_id, SessionCloseMode::IfIdle, || async { Ok(()) })
+            .await?
+            .is_some())
+    }
+
+    async fn run_session_close<T, F, Fut>(
+        &self,
+        session_id: &str,
+        mode: SessionCloseMode,
+        after_finish: F,
+    ) -> Result<Option<T>, AgentRuntimeError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, AgentRuntimeError>>,
+    {
+        let session_guard = acquire_session_control_after_recovery(&self.ctx, session_id).await;
+        let should_drain = match mode {
+            SessionCloseMode::Always => self.begin_session_close_locked(session_id).await?,
+            SessionCloseMode::IfIdle => {
+                let mut sessions = self.ctx.sessions.lock().await;
+                let Some(state) = sessions.get_mut(session_id) else {
+                    return Ok(None);
+                };
+                if state.runtime.is_none()
+                    || state.phase != RuntimeSessionPhase::Idle
+                    || !state.pending_queue.is_empty()
+                {
+                    return Ok(None);
+                }
+                state.closing = true;
+                false
+            }
+        };
+        let session_guard = match mode {
+            SessionCloseMode::Always => {
+                drop(session_guard);
+                if should_drain {
+                    self.drain_closing_turn(session_id).await;
+                }
+                let guard = acquire_session_runtime_lock(&self.ctx.session_locks, session_id).await;
+                publish_durable_turn_start(&self.ctx, session_id, &guard.owner).await;
+                guard
+            }
+            SessionCloseMode::IfIdle => session_guard,
+        };
+        let workflow_notification = self.finalize_session_close_locked(session_id).await?;
+        let output = match after_finish().await {
+            Ok(output) => output,
+            Err(error) => {
+                if let Some(state) = self.ctx.sessions.lock().await.get_mut(session_id) {
+                    state.closing = false;
+                }
+                drop(session_guard);
+                if let Some(workflow_notification) = workflow_notification {
+                    dispatch_workflow_turn_complete_notification(
+                        &self.ctx.workflow_turn_complete_notifier,
+                        workflow_notification,
+                    )
+                    .await;
+                }
+                return Err(error);
+            }
+        };
+        self.close_session_runtime_locked(session_id).await;
+        drop(session_guard);
+        if let Some(workflow_notification) = workflow_notification {
+            dispatch_workflow_turn_complete_notification(
+                &self.ctx.workflow_turn_complete_notifier,
+                workflow_notification,
+            )
+            .await;
+        }
+        Ok(Some(output))
+    }
+
+    pub async fn close_all(&self) -> Result<(), AgentRuntimeError> {
+        self.ctx.shutdown_admission.begin_shutdown();
+        self.ctx.shutdown_admission.wait_for_idle().await;
+        let mut session_ids = {
+            let sessions = self.ctx.sessions.lock().await;
+            sessions.keys().cloned().collect::<Vec<_>>()
+        };
+        let pending_session_ids = {
+            let session_locks = self.ctx.session_locks.map.lock().await;
+            session_locks
+                .iter()
+                .filter(|(_, owner)| owner.durable_turn_start.lock().is_some())
+                .map(|(session_id, _)| session_id.clone())
+                .collect::<Vec<_>>()
+        };
+        for session_id in pending_session_ids {
+            if !session_ids.contains(&session_id) {
+                session_ids.push(session_id);
+            }
+        }
+        let results = futures_util::future::join_all(
+            session_ids
+                .iter()
+                .map(|session_id| self.close_session(session_id)),
+        )
+        .await;
+        let errors = session_ids
+            .iter()
+            .zip(results)
+            .filter_map(|(session_id, result)| {
+                result.err().map(|error| format!("{session_id}: {error}"))
+            })
+            .collect::<Vec<_>>();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            {
+                let mut sessions = self.ctx.sessions.lock().await;
+                for state in sessions.values_mut() {
+                    state.closing = false;
+                }
+            }
+            self.ctx.shutdown_admission.cancel_shutdown();
+            Err(AgentRuntimeError::Other(format!(
+                "Failed to close agent sessions: {}",
+                errors.join("; ")
+            )))
+        }
+    }
+
+    async fn begin_session_close_locked(
+        &self,
+        session_id: &str,
+    ) -> Result<bool, AgentRuntimeError> {
+        let should_finalize = {
             let mut sessions = self.ctx.sessions.lock().await;
-            sessions.remove(session_id).and_then(|state| state.runtime)
+            let Some(state) = sessions.get_mut(session_id) else {
+                return Ok(false);
+            };
+            state.closing = true;
+            state.phase != RuntimeSessionPhase::Idle
+        };
+        if should_finalize {
+            flush_streaming_update(&self.ctx, session_id, true)
+                .await
+                .map_err(AgentRuntimeError::Other)?;
+        }
+        Ok(should_finalize)
+    }
+
+    async fn finalize_session_close_locked(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<WorkflowTurnCompleteNotification>, AgentRuntimeError> {
+        let should_finalize = {
+            let sessions = self.ctx.sessions.lock().await;
+            sessions
+                .get(session_id)
+                .is_some_and(|state| state.phase != RuntimeSessionPhase::Idle)
+        };
+        let workflow_notification = if should_finalize {
+            complete_turn(
+                &self.ctx,
+                session_id,
+                None,
+                TurnResult::Interrupted {
+                    reason: DomainInterruptReason::SessionClosed,
+                    error: None,
+                },
+            )
+            .await
+            .map_err(AgentRuntimeError::Other)?
+        } else {
+            None
+        };
+        Ok(workflow_notification)
+    }
+
+    async fn close_session_runtime_locked(&self, session_id: &str) {
+        let runtime = {
+            let sessions = self.ctx.sessions.lock().await;
+            sessions
+                .get(session_id)
+                .and_then(|state| state.runtime.clone())
         };
         if let Some(runtime) = runtime {
             runtime.close().await;
         }
-        Ok(())
+        self.ctx.sessions.lock().await.remove(session_id);
     }
 
     /// Closes the live runtime immediately without waiting for backend recovery.
@@ -1199,19 +1507,28 @@ impl AgentSessionRuntimeUsecase {
         &self,
         session_id: &str,
     ) -> Result<(), AgentRuntimeError> {
-        self.close_session_locked(session_id).await
+        self.close_session_runtime_locked(session_id).await;
+        Ok(())
     }
 
-    pub async fn close_all(&self) {
-        let runtimes = {
-            let mut sessions = self.ctx.sessions.lock().await;
-            sessions
-                .drain()
-                .filter_map(|(_, state)| state.runtime)
-                .collect::<Vec<_>>()
-        };
-        for runtime in runtimes {
-            runtime.close().await;
+    async fn drain_closing_turn(&self, session_id: &str) {
+        let deadline = tokio::time::Instant::now() + CLOSE_DRAIN_TIMEOUT;
+        loop {
+            let still_active = {
+                let sessions = self.ctx.sessions.lock().await;
+                sessions
+                    .get(session_id)
+                    .is_some_and(|state| state.phase != RuntimeSessionPhase::Idle)
+            };
+            if !still_active {
+                return;
+            }
+
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return;
+            }
+            tokio::time::sleep(CLOSE_DRAIN_POLL_INTERVAL.min(deadline - now)).await;
         }
     }
 
@@ -1308,7 +1625,7 @@ impl AgentSessionRuntimeUsecase {
         session_id: &str,
     ) -> Result<Option<GetSessionResponse>, AgentRuntimeError> {
         let _session_guard = acquire_session_control_after_recovery(&self.ctx, session_id).await;
-        let Some((session, page)) = self
+        let Some((session, page, last_turn_interruption)) = self
             .ctx
             .session_store
             .get_session_with_latest_page(
@@ -1365,6 +1682,7 @@ impl AgentSessionRuntimeUsecase {
                 total_count,
             }),
             latest_token_usage: latest_token_usage.or(page.latest_token_usage),
+            last_turn_interruption,
         };
         Ok(Some(response))
     }
@@ -1432,12 +1750,19 @@ impl AgentSessionRuntimeUsecase {
         })
     }
 
-    pub async fn is_runtime_busy(&self, session_id: &str) -> bool {
-        self.is_turn_busy(session_id).await
-    }
-
+    #[cfg(test)]
     pub async fn has_live_runtime(&self, session_id: &str) -> bool {
         self.live_runtime(session_id).await.is_some()
+    }
+
+    async fn ensure_session_not_closing(&self, session_id: &str) -> Result<(), AgentRuntimeError> {
+        let sessions = self.ctx.sessions.lock().await;
+        if sessions.get(session_id).is_some_and(|state| state.closing) {
+            return Err(AgentRuntimeError::Other(format!(
+                "Agent session is closing: {session_id}"
+            )));
+        }
+        Ok(())
     }
 
     /// Acquires the per-session runtime lock.
@@ -1448,7 +1773,9 @@ impl AgentSessionRuntimeUsecase {
     /// UI and event notifications, including session state-change emits, must run after the guard
     /// is dropped.
     pub async fn acquire_session_lock(&self, session_id: &str) -> SessionRuntimeLockGuard {
-        acquire_session_runtime_lock(&self.ctx.session_locks, session_id).await
+        let guard = acquire_session_runtime_lock(&self.ctx.session_locks, session_id).await;
+        publish_durable_turn_start(&self.ctx, session_id, &guard.owner).await;
+        guard
     }
 
     /// Waits for backend recovery and acquires exclusive session control.
@@ -1480,7 +1807,7 @@ impl AgentSessionRuntimeUsecase {
         };
         locks
             .get(session_id)
-            .is_some_and(|lock| lock.try_lock().is_err())
+            .is_some_and(|owner| owner.lock.try_lock().is_err())
     }
 
     pub async fn start_turn_locked(
@@ -1491,7 +1818,9 @@ impl AgentSessionRuntimeUsecase {
         base_system_prompt: Option<String>,
         workflow_instructions: Vec<String>,
     ) -> Result<(), AgentRuntimeError> {
+        let _admission_guard = self.ctx.shutdown_admission.admit()?;
         ensure_backend_recovery_operation_allowed(&self.ctx, session_id)?;
+        self.ensure_session_not_closing(session_id).await?;
         let mut session = self
             .ctx
             .session_store
@@ -1825,9 +2154,22 @@ impl AgentSessionRuntimeUsecase {
             )
             .map_err(AgentRuntimeError::Other)?
             .unwrap_or_else(|| human_message.clone());
+        let transition_owner = session_transition_owner(&self.ctx.session_locks, &session.id).await;
+        let mut current_turn_input = QueuedTurnInput::new(
+            payload.prompt.clone(),
+            payload.permission_mode,
+            payload.plan_mode,
+            payload.permission_profile_id.clone(),
+            payload.images.clone(),
+            session.worktree_path.clone(),
+            payload.mentions.clone(),
+            payload.editor_context.clone(),
+        );
+        current_turn_input.existing_human_message_id = Some(human_message.id.clone());
+        current_turn_input.existing_agent_message_id = Some(agent_message_id.clone());
         self.ctx
             .session_store
-            .append_session_event_and_project_state(
+            .append_turn_started_and_project_state(
                 &self.ctx.data_dir,
                 &session.id,
                 AgentSessionEvent::TurnStarted {
@@ -1839,27 +2181,15 @@ impl AgentSessionRuntimeUsecase {
                 },
             )
             .map_err(AgentRuntimeError::Other)?;
-        let generation = {
-            let mut sessions = self.ctx.sessions.lock().await;
-            let state = sessions
-                .entry(session.id.clone())
-                .or_insert_with(|| RuntimeSessionState::new(backend_id.clone()));
-            state.reset_for_turn(turn_id, agent_message_id.clone());
-            let mut current_turn_input = QueuedTurnInput::new(
-                payload.prompt.clone(),
-                payload.permission_mode,
-                payload.plan_mode,
-                payload.permission_profile_id.clone(),
-                payload.images.clone(),
-                session.worktree_path.clone(),
-                payload.mentions.clone(),
-                payload.editor_context.clone(),
-            );
-            current_turn_input.existing_human_message_id = Some(human_message.id.clone());
-            current_turn_input.existing_agent_message_id = state.streaming_message_id.clone();
-            state.current_turn_input = Some(current_turn_input);
-            state.generation
-        };
+        *transition_owner.durable_turn_start.lock() = Some(DurableTurnStart {
+            backend_id,
+            turn_id,
+            agent_message_id: agent_message_id.clone(),
+            current_turn_input,
+        });
+        let generation = publish_durable_turn_start(&self.ctx, &session.id, &transition_owner)
+            .await
+            .expect("durable turn start must be published by its transition owner");
         let runtime = match self
             .ensure_runtime(session, payload.system_prompt.clone())
             .await
@@ -3008,6 +3338,7 @@ async fn acquire_session_control_after_recovery(
                 .is_some_and(|state| state.backend_recovery.is_some())
         };
         if !recovery_started {
+            publish_durable_turn_start(ctx, session_id, &guard.owner).await;
             reconcile_incomplete_backend_recovery(ctx, session_id).await;
             return guard;
         }
@@ -3081,6 +3412,7 @@ async fn reconcile_incomplete_backend_recovery(ctx: &RuntimeContext, session_id:
 pub struct SessionRuntimeLockGuard {
     session_id: String,
     guard: Option<OwnedMutexGuard<()>>,
+    owner: SessionRuntimeLock,
     locks: SessionRuntimeLocks,
     #[cfg(test)]
     test_owner_reservation: TestSessionRuntimeLockOwnerReservation,
@@ -3099,6 +3431,41 @@ impl SessionRuntimeLockGuard {
 /// including the same session recursively. Backend I/O awaits such as process startup and stdin
 /// writes must be limited to the smallest range required for per-session ordering. UI and event
 /// notifications, including session state-change emits, must run after the guard is dropped.
+async fn session_transition_owner(
+    session_locks: &SessionRuntimeLocks,
+    session_id: &str,
+) -> SessionRuntimeLock {
+    let mut locks = session_locks.map.lock().await;
+    let pending_prune = {
+        let mut pending = session_locks
+            .pending_prune
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        std::mem::take(&mut *pending)
+    };
+    let mut still_referenced = HashSet::new();
+    for pending_session_id in pending_prune {
+        if locks.get(&pending_session_id).is_some_and(|owner| {
+            Arc::strong_count(owner) == 1 && owner.durable_turn_start.lock().is_none()
+        }) {
+            locks.remove(&pending_session_id);
+        } else if locks.contains_key(&pending_session_id) {
+            still_referenced.insert(pending_session_id);
+        }
+    }
+    if !still_referenced.is_empty() {
+        session_locks
+            .pending_prune
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .extend(still_referenced);
+    }
+    locks
+        .entry(session_id.to_string())
+        .or_insert_with(|| Arc::new(SessionTransitionOwner::default()))
+        .clone()
+}
+
 async fn acquire_session_runtime_lock(
     session_locks: &SessionRuntimeLocks,
     session_id: &str,
@@ -3106,46 +3473,34 @@ async fn acquire_session_runtime_lock(
     #[cfg(test)]
     let test_owner_reservation = TestSessionRuntimeLockOwnerReservation::reserve(session_id);
 
-    let lock = {
-        let mut locks = session_locks.map.lock().await;
-        let pending_prune = {
-            let mut pending = session_locks
-                .pending_prune
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            std::mem::take(&mut *pending)
-        };
-        let mut still_referenced = HashSet::new();
-        for pending_session_id in pending_prune {
-            if locks
-                .get(&pending_session_id)
-                .is_some_and(|lock| Arc::strong_count(lock) == 1)
-            {
-                locks.remove(&pending_session_id);
-            } else if locks.contains_key(&pending_session_id) {
-                still_referenced.insert(pending_session_id);
-            }
-        }
-        if !still_referenced.is_empty() {
-            session_locks
-                .pending_prune
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .extend(still_referenced);
-        }
-        locks
-            .entry(session_id.to_string())
-            .or_insert_with(|| Arc::new(Mutex::new(())))
-            .clone()
-    };
-    let guard = lock.lock_owned().await;
+    let owner = session_transition_owner(session_locks, session_id).await;
+    let guard = Arc::clone(&owner.lock).lock_owned().await;
     SessionRuntimeLockGuard {
         session_id: session_id.to_string(),
         guard: Some(guard),
+        owner,
         locks: Arc::clone(session_locks),
         #[cfg(test)]
         test_owner_reservation,
     }
+}
+
+async fn publish_durable_turn_start(
+    ctx: &RuntimeContext,
+    session_id: &str,
+    owner: &SessionTransitionOwner,
+) -> Option<u64> {
+    if owner.durable_turn_start.lock().is_none() {
+        return None;
+    }
+    let mut sessions = ctx.sessions.lock().await;
+    let pending = owner.durable_turn_start.lock().take()?;
+    let state = sessions
+        .entry(session_id.to_string())
+        .or_insert_with(|| RuntimeSessionState::new(pending.backend_id));
+    state.reset_for_turn(pending.turn_id, pending.agent_message_id);
+    state.current_turn_input = Some(pending.current_turn_input);
+    Some(state.generation)
 }
 
 impl Drop for SessionRuntimeLockGuard {
@@ -3506,15 +3861,29 @@ async fn apply_runtime_event(
     runtime_epoch: u64,
     event: AgentRuntimeEvent,
 ) -> RuntimeEventPostActions {
-    let is_current_runtime = {
+    let (is_current_runtime, terminal_committed) = {
         let sessions = ctx.sessions.lock().await;
-        sessions
-            .get(session_id)
-            .is_some_and(|state| state.runtime_epoch == runtime_epoch)
+        sessions.get(session_id).map_or((false, false), |state| {
+            (
+                state.runtime_epoch == runtime_epoch,
+                state.phase != RuntimeSessionPhase::Idle
+                    && state
+                        .current_turn_id
+                        .or(state.last_turn_id)
+                        .is_some_and(|turn_id| state.terminal_turn_id == Some(turn_id)),
+            )
+        })
     };
     if !is_current_runtime {
         log::debug!(
             "dropping {} from stale runtime epoch {runtime_epoch} for {session_id}",
+            runtime_event_kind(&event)
+        );
+        return RuntimeEventPostActions::default();
+    }
+    if terminal_committed && runtime_event_targets_current_turn(&event) {
+        log::debug!(
+            "dropping {} after durable terminal commit for {session_id}",
             runtime_event_kind(&event)
         );
         return RuntimeEventPostActions::default();
@@ -3721,7 +4090,13 @@ async fn apply_runtime_event(
             } else {
                 false
             };
-            let workflow_notification = complete_turn(ctx, session_id, None, result).await;
+            let workflow_notification = match complete_turn(ctx, session_id, None, result).await {
+                Ok(notification) => notification,
+                Err(error) => {
+                    log::warn!("failed to durably complete turn for {session_id}: {error}");
+                    return RuntimeEventPostActions::default();
+                }
+            };
             if wait_for_trailing_fatal {
                 let mut sessions = ctx.sessions.lock().await;
                 if let Some(state) = sessions.get_mut(session_id) {
@@ -3771,8 +4146,9 @@ async fn apply_runtime_event(
                     })
             };
             let mut actions = RuntimeEventPostActions::default();
+            let mut crash_persistence_failed = false;
             if should_complete_crash {
-                actions.workflow_notification = complete_turn(
+                match complete_turn(
                     ctx,
                     session_id,
                     None,
@@ -3781,7 +4157,14 @@ async fn apply_runtime_event(
                         error: Some(message.clone()),
                     },
                 )
-                .await;
+                .await
+                {
+                    Ok(notification) => actions.workflow_notification = notification,
+                    Err(error) => {
+                        log::warn!("failed to durably record fatal turn for {session_id}: {error}");
+                        crash_persistence_failed = true;
+                    }
+                }
             }
             let runtime = {
                 let mut sessions = ctx.sessions.lock().await;
@@ -3793,8 +4176,12 @@ async fn apply_runtime_event(
             {
                 let mut sessions = ctx.sessions.lock().await;
                 if let Some(state) = sessions.get_mut(session_id) {
-                    state.phase = RuntimeSessionPhase::Idle;
-                    state.stall_observation_active = false;
+                    if crash_persistence_failed {
+                        state.rollback_started_turn();
+                    } else {
+                        state.phase = RuntimeSessionPhase::Idle;
+                        state.stall_observation_active = false;
+                    }
                 }
             }
             if !should_complete_crash && !trailing_completed_crash {
@@ -3871,6 +4258,18 @@ async fn apply_runtime_event(
         }
     };
     RuntimeEventPostActions::default()
+}
+
+fn runtime_event_targets_current_turn(event: &AgentRuntimeEvent) -> bool {
+    matches!(
+        event,
+        AgentRuntimeEvent::PartsMerged(_)
+            | AgentRuntimeEvent::PermissionRequested(_)
+            | AgentRuntimeEvent::TokenUsageUpdated(_)
+            | AgentRuntimeEvent::KeepAlive
+            | AgentRuntimeEvent::TurnCompleted(_)
+            | AgentRuntimeEvent::Fatal { .. }
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4006,7 +4405,9 @@ async fn apply_parts(
         );
     }
     if emit_now {
-        flush_streaming_update(ctx, session_id, false).await;
+        if let Err(error) = flush_streaming_update(ctx, session_id, false).await {
+            log::warn!("failed to persist coalesced streaming parts for {session_id}: {error}");
+        }
     } else if let Some(delay) = schedule_delay {
         spawn_delayed_stream_flush(ctx, session_id.to_string(), delay);
     }
@@ -4022,32 +4423,35 @@ fn spawn_delayed_stream_flush(
     spawner.spawn(Box::pin(async move {
         tokio::time::sleep(delay).await;
         let _session_guard = acquire_session_runtime_lock(&ctx.session_locks, &session_id).await;
-        flush_streaming_update(&ctx, &session_id, false).await;
+        if let Err(error) = flush_streaming_update(&ctx, &session_id, false).await {
+            log::warn!("failed to persist delayed streaming parts for {session_id}: {error}");
+        }
     }));
 }
 
-async fn flush_streaming_update(ctx: &RuntimeContext, session_id: &str, force_persist: bool) {
+async fn flush_streaming_update(
+    ctx: &RuntimeContext,
+    session_id: &str,
+    force_persist: bool,
+) -> Result<(), String> {
     let now = std::time::Instant::now();
     let (payload, persist_snapshot, emit_suppressed) = {
         let mut sessions = ctx.sessions.lock().await;
         let Some(state) = sessions.get_mut(session_id) else {
-            return;
+            return Ok(());
         };
         state.stream_flush_scheduled = false;
+        let message_id = state
+            .streaming_message_id
+            .clone()
+            .or_else(|| state.last_agent_message_id.clone());
         let retry = state.retry_stream_delta.take();
         let payload = if let Some(retry) = retry {
-            retry
-        } else {
-            let message_id = state
-                .streaming_message_id
-                .clone()
-                .or_else(|| state.last_agent_message_id.clone());
-            let Some(message_id) = message_id else {
-                return;
+            Some(retry)
+        } else if state.pending_stream_snapshot || !state.pending_stream_parts.is_empty() {
+            let Some(message_id) = message_id.clone() else {
+                return Ok(());
             };
-            if !state.pending_stream_snapshot && state.pending_stream_parts.is_empty() {
-                return;
-            }
             let snapshot = state.pending_stream_snapshot || state.streaming_delta_seq == 0;
             let parts = if snapshot {
                 state.streaming_parts.clone()
@@ -4056,39 +4460,57 @@ async fn flush_streaming_update(ctx: &RuntimeContext, session_id: &str, force_pe
             };
             state.pending_stream_bytes = 0;
             state.pending_stream_snapshot = false;
-            PendingStreamDelta {
+            Some(PendingStreamDelta {
                 message_id,
                 seq: state.streaming_delta_seq.saturating_add(1),
                 snapshot,
                 parts,
                 message: None,
                 authoritative: false,
-            }
+            })
+        } else {
+            None
         };
-        let persist =
+        let persist = message_id.and_then(|message_id| {
             should_persist_streaming_snapshot(state.last_stream_persist_at, now, force_persist)
                 .then(|| {
-                    state.last_stream_persist_at = Some(now);
-                    state.streaming_parts.clone()
-                });
+                    let seq = payload
+                        .as_ref()
+                        .map(|payload| payload.seq)
+                        .unwrap_or_else(|| state.streaming_delta_seq.saturating_add(1));
+                    (message_id, seq, state.streaming_parts.clone())
+                })
+        });
         (payload, persist, state.stream_emit_suppressed)
     };
 
-    if let Some(parts) = persist_snapshot {
-        if let Err(error) = ctx.session_store.persist_message_parts(
+    let persist_result = if let Some((message_id, seq, parts)) = persist_snapshot {
+        match ctx.session_store.persist_message_parts(
             &ctx.data_dir,
             session_id,
-            &payload.message_id,
+            &message_id,
             &parts,
-            payload.seq,
+            seq,
             None,
         ) {
-            log::warn!("failed to persist coalesced streaming parts for {session_id}: {error}");
+            Ok(_) => {
+                if let Some(state) = ctx.sessions.lock().await.get_mut(session_id) {
+                    state.last_stream_persist_at = Some(now);
+                }
+                Ok(())
+            }
+            Err(error) => Err(error),
         }
-    }
+    } else {
+        Ok(())
+    };
+
+    let Some(payload) = payload else {
+        return persist_result;
+    };
 
     if emit_suppressed {
-        return;
+        return persist_result;
     }
 
     let emitted = ctx
@@ -4099,7 +4521,7 @@ async fn flush_streaming_update(ctx: &RuntimeContext, session_id: &str, force_pe
     {
         let mut sessions = ctx.sessions.lock().await;
         let Some(state) = sessions.get_mut(session_id) else {
-            return;
+            return persist_result;
         };
         if emitted {
             state.streaming_delta_seq = state.streaming_delta_seq.max(payload.seq);
@@ -4112,6 +4534,7 @@ async fn flush_streaming_update(ctx: &RuntimeContext, session_id: &str, force_pe
     if let Some(delay) = retry_delay {
         spawn_delayed_stream_flush(ctx, session_id.to_string(), delay);
     }
+    persist_result
 }
 
 async fn emit_streaming_delta_or_retry(
@@ -4582,7 +5005,7 @@ async fn complete_turn(
     session_id: &str,
     expected_generation: Option<u64>,
     result: crate::domain::agent_session::entities::TurnResult,
-) -> Option<WorkflowTurnCompleteNotification> {
+) -> Result<Option<WorkflowTurnCompleteNotification>, String> {
     let emit_crash_snapshot = matches!(
         &result,
         TurnResult::Interrupted {
@@ -4601,34 +5024,125 @@ async fn complete_turn(
         log::debug!(
             "skipping turn completion for {session_id}: turn already completed or generation mismatch (expected={expected_generation:?})"
         );
-        return None;
+        return Ok(None);
     }
-    flush_streaming_update(ctx, session_id, true).await;
+    flush_streaming_update(ctx, session_id, true).await?;
     let completed_at = crate::usecase::agent_session::session::now_timestamp();
     let terminal = terminal_projection(&result);
-    let (
-        message_id,
-        parts,
-        seq,
-        turn_id,
-        started_at,
-        telemetry_dims,
-        pending_permission_state_revision,
-    ) = {
-        let mut sessions = ctx.sessions.lock().await;
-        let state = sessions.get_mut(session_id)?;
+    let (message_id, parts, seq, turn_id, started_at, telemetry_dims) = {
+        let sessions = ctx.sessions.lock().await;
+        let Some(state) = sessions.get(session_id) else {
+            return Ok(None);
+        };
         if state.phase == RuntimeSessionPhase::Idle
             || expected_generation.is_some_and(|generation| state.generation != generation)
         {
-            return None;
+            return Ok(None);
+        }
+        let message_id = state.streaming_message_id.clone();
+        let turn_id = state.current_turn_id.or(state.last_turn_id);
+        let started_at = state.turn_started_at;
+        let telemetry_dims =
+            session_telemetry_dimensions(&ctx.session_store, &ctx.data_dir, session_id);
+        (
+            message_id,
+            state.streaming_parts.clone(),
+            state.streaming_delta_seq,
+            turn_id,
+            started_at,
+            telemetry_dims,
+        )
+    };
+    let mut projected = None;
+    let mut crash_snapshot = None;
+    if let (Some(turn_id), Some(message_id)) = (turn_id, message_id.clone()) {
+        let final_seq = if emit_crash_snapshot {
+            seq.saturating_add(1)
+        } else {
+            seq
+        };
+        let events = final_turn_events(
+            &ctx.session_store,
+            &ctx.data_dir,
+            session_id,
+            turn_id,
+            &message_id,
+            &parts,
+            &terminal,
+        )?;
+        let (model, persisted_parts) = persist_with_retry(
+            ctx,
+            session_id,
+            PersistFailureKind::FinalPartsRecorded,
+            || {
+                ctx.session_store.append_terminal_events_and_materialize(
+                    &ctx.data_dir,
+                    session_id,
+                    &events,
+                    &message_id,
+                    final_seq,
+                    completed_at,
+                )
+            },
+        )
+        .await?;
+        {
+            let mut sessions = ctx.sessions.lock().await;
+            if let Some(state) = sessions.get_mut(session_id) {
+                if state.current_turn_id.or(state.last_turn_id) == Some(turn_id) {
+                    state.terminal_turn_id = Some(turn_id);
+                }
+            }
+        }
+        if emit_crash_snapshot {
+            crash_snapshot = Some(PendingStreamDelta {
+                message_id,
+                seq: final_seq,
+                snapshot: true,
+                parts: persisted_parts,
+                message: None,
+                authoritative: true,
+            });
+        }
+        projected = Some(model);
+    }
+    if let Some(snapshot) = crash_snapshot {
+        emit_streaming_delta_or_retry(ctx, session_id, snapshot).await;
+    }
+    let session_state = projected
+        .as_ref()
+        .map(|model| model.status.session_state.clone())
+        .or_else(|| (!emit_crash_snapshot).then(|| terminal.session_state.clone()));
+    if let Some(projected_state) = session_state.as_ref() {
+        let (exit_code, interrupted) = match projected_state {
+            SessionState::Idle => (0, true),
+            SessionState::Done => (0, false),
+            SessionState::Error => (terminal.exit_code.max(1), terminal.interrupted),
+            _ => (terminal.exit_code, terminal.interrupted),
+        };
+        let lifecycle =
+            crate::usecase::agent_session::session::lifecycle_controller::SessionLifecycleController {
+                session_store: &ctx.session_store,
+                data_dir: &ctx.data_dir,
+            };
+        lifecycle.complete_turn_state(session_id, exit_code, interrupted)?;
+    }
+    let pending_permission_state_revision = {
+        let mut sessions = ctx.sessions.lock().await;
+        let Some(state) = sessions.get_mut(session_id) else {
+            return Ok(None);
+        };
+        if state.phase == RuntimeSessionPhase::Idle
+            || expected_generation.is_some_and(|generation| state.generation != generation)
+        {
+            return Ok(None);
         }
         state.phase = RuntimeSessionPhase::Idle;
         let pending_permission_state_revision = state.clear_pending_permission_request();
         state.permission_wait_started_at = None;
         state.permission_wait_diagnostic_emitted = false;
         state.stall_observation_active = false;
-        let message_id = state.streaming_message_id.clone();
-        state.last_agent_message_id = message_id.clone();
+        state.last_agent_message_id = message_id;
         let usage = match &result {
             crate::domain::agent_session::entities::TurnResult::Completed {
                 token_usage, ..
@@ -4641,108 +5155,17 @@ async fn complete_turn(
         if let Some(usage) = usage {
             state.latest_token_usage = Some(usage);
         }
-        let turn_id = state.current_turn_id.or(state.last_turn_id);
-        let started_at = state.turn_started_at.take();
+        state.turn_started_at = None;
         state.streaming_message_id = None;
         state.current_turn_id = None;
         state.current_turn_input = None;
-        let telemetry_dims =
-            session_telemetry_dimensions(&ctx.session_store, &ctx.data_dir, session_id);
-        (
-            message_id,
-            state.streaming_parts.clone(),
-            state.streaming_delta_seq,
-            turn_id,
-            started_at,
-            telemetry_dims,
-            pending_permission_state_revision,
-        )
+        state.domain_streaming_parts.clear();
+        state.streaming_parts.clear();
+        state.streaming_delta_seq = 0;
+        state.stream_emit_failure_count = 0;
+        state.stream_emit_suppressed = false;
+        pending_permission_state_revision
     };
-    let mut projected = None;
-    let mut crash_snapshot = None;
-    if let (Some(turn_id), Some(message_id)) = (turn_id, message_id.clone()) {
-        let final_seq = if emit_crash_snapshot {
-            seq.saturating_add(1)
-        } else {
-            seq
-        };
-        let materialized = match final_turn_events(
-            &ctx.session_store,
-            &ctx.data_dir,
-            session_id,
-            turn_id,
-            &message_id,
-            &parts,
-            &terminal,
-        ) {
-            Ok(events) => {
-                persist_with_retry(
-                    ctx,
-                    session_id,
-                    PersistFailureKind::FinalPartsRecorded,
-                    || {
-                        ctx.session_store.append_terminal_events_and_materialize(
-                            &ctx.data_dir,
-                            session_id,
-                            &events,
-                            &message_id,
-                            final_seq,
-                            completed_at,
-                        )
-                    },
-                )
-                .await
-            }
-            Err(error) => Err(error),
-        };
-        match materialized {
-            Ok((model, persisted_parts)) => {
-                projected = Some(model);
-                if emit_crash_snapshot {
-                    crash_snapshot = Some(PendingStreamDelta {
-                        message_id,
-                        seq: final_seq,
-                        snapshot: true,
-                        parts: persisted_parts,
-                        message: None,
-                        authoritative: true,
-                    });
-                }
-            }
-            Err(error) => {
-                log::warn!("failed to materialize terminal turn for {session_id}: {error}");
-            }
-        }
-    }
-    if let Some(snapshot) = crash_snapshot {
-        emit_streaming_delta_or_retry(ctx, session_id, snapshot).await;
-    }
-    {
-        let mut sessions = ctx.sessions.lock().await;
-        if let Some(state) = sessions.get_mut(session_id) {
-            state.domain_streaming_parts.clear();
-            state.streaming_parts.clear();
-            state.streaming_delta_seq = 0;
-            state.stream_emit_failure_count = 0;
-            state.stream_emit_suppressed = false;
-        }
-    };
-    let session_state = projected
-        .as_ref()
-        .map(|model| model.status.session_state.clone())
-        .or_else(|| (!emit_crash_snapshot).then(|| terminal.session_state.clone()));
-    let lifecycle =
-        crate::usecase::agent_session::session::lifecycle_controller::SessionLifecycleController {
-            session_store: &ctx.session_store,
-            data_dir: &ctx.data_dir,
-        };
-    if projected.is_some() || !emit_crash_snapshot {
-        if let Err(error) =
-            lifecycle.complete_turn_state(session_id, terminal.exit_code, terminal.interrupted)
-        {
-            log::warn!("failed to persist terminal session state for {session_id}: {error}");
-        }
-    }
     if let (Some(started_at), Some(dims)) = (started_at, telemetry_dims) {
         crate::other::telemetry::record_agent_turn_duration(
             crate::other::telemetry::AgentTurn::Complete,
@@ -4771,25 +5194,25 @@ async fn complete_turn(
             session_state,
         },
     );
-    workflow_notification
+    Ok(workflow_notification)
 }
 
 async fn start_next_queued_turn(ctx: &RuntimeContext, session_id: &str) {
-    let (queued, runtime) = {
+    let (queued, runtime, backend_id) = {
         let sessions = ctx.sessions.lock().await;
         let Some(state) = sessions.get(session_id) else {
             return;
         };
-        if state.backend_recovery.is_some() {
-            return;
-        }
-        if state.phase != RuntimeSessionPhase::Idle {
+        if state.closing
+            || state.backend_recovery.is_some()
+            || state.phase != RuntimeSessionPhase::Idle
+        {
             return;
         }
         let Some(queued) = state.pending_queue.front().cloned() else {
             return;
         };
-        (queued, state.runtime.clone())
+        (queued, state.runtime.clone(), state.backend_id.clone())
     };
 
     let Some(session) = (match ctx
@@ -4965,7 +5388,8 @@ async fn start_next_queued_turn(ctx: &RuntimeContext, session_id: &str) {
         }
     }
     let prompt = apply_restore_prompt_prefix(queued.content.clone(), &restore_plan);
-    if let Err(error) = ctx.session_store.append_session_event_and_project_state(
+    let transition_owner = session_transition_owner(&ctx.session_locks, session_id).await;
+    if let Err(error) = ctx.session_store.append_turn_started_and_project_state(
         &ctx.data_dir,
         session_id,
         AgentSessionEvent::TurnStarted {
@@ -4979,14 +5403,15 @@ async fn start_next_queued_turn(ctx: &RuntimeContext, session_id: &str) {
         log::warn!("failed to append queued TurnStarted for {session_id}: {error}");
         return;
     }
-    let generation = {
-        let mut sessions = ctx.sessions.lock().await;
-        let Some(state) = sessions.get_mut(session_id) else {
-            return;
-        };
-        state.reset_for_turn(turn_id, agent_message.id.clone());
-        state.current_turn_input = Some(queued_for_turn.clone());
-        state.generation
+    *transition_owner.durable_turn_start.lock() = Some(DurableTurnStart {
+        backend_id,
+        turn_id,
+        agent_message_id: agent_message.id.clone(),
+        current_turn_input: queued_for_turn.clone(),
+    });
+    let Some(generation) = publish_durable_turn_start(ctx, session_id, &transition_owner).await
+    else {
+        return;
     };
     if let Err(error) = runtime
         .start_turn(TurnInput {
@@ -5353,11 +5778,7 @@ fn next_turn_id(
     data_dir: &Path,
     session_id: &str,
 ) -> Result<u64, String> {
-    let events = session_store.load_session_events(data_dir, session_id)?;
-    Ok(TurnEventLog::from_events(events)
-        .current_turn_id()
-        .unwrap_or(0)
-        .saturating_add(1))
+    session_store.next_turn_id(data_dir, session_id)
 }
 
 struct PendingPermissionForResponse {
@@ -5566,6 +5987,16 @@ fn final_turn_events(
     parts: &[MessagePart],
     terminal: &TerminalProjection,
 ) -> Result<Vec<AgentSessionEvent>, String> {
+    let existing_events = session_store.load_session_events(data_dir, session_id)?;
+    if existing_events.iter().any(|event| {
+        matches!(
+            event,
+            AgentSessionEvent::TurnCompleted { turn_id: id, .. }
+                | AgentSessionEvent::TurnInterrupted { turn_id: id, .. } if *id == turn_id
+        )
+    }) {
+        return Ok(Vec::new());
+    }
     let mut appended = vec![AgentSessionEvent::FinalPartsRecorded {
         turn_id,
         message_id: message_id.to_string(),
@@ -5584,7 +6015,7 @@ fn final_turn_events(
             });
         }
         TerminalEventProjection::Interrupted { reason, error } => {
-            let mut events = session_store.load_session_events(data_dir, session_id)?;
+            let mut events = existing_events;
             events.extend(appended.iter().cloned());
             let before = events.len();
             finalize_turn(
@@ -5633,6 +6064,9 @@ fn terminal_projection(result: &TurnResult) -> TerminalProjection {
                 }
                 DomainInterruptReason::Crash => {
                     (1, SessionState::Error, EventInterruptReason::Crash)
+                }
+                DomainInterruptReason::SessionClosed => {
+                    (0, SessionState::Idle, EventInterruptReason::SessionClosed)
                 }
             };
             TerminalProjection {
@@ -5921,6 +6355,7 @@ impl AgentSessionRuntime for TestFailingAgentRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adaptor::gateway::agent_session::FileSessionStorage;
     use crate::adaptor::gateway::workflow::StoredWorkspaceSessionGateway;
     use crate::domain::agent_session::gateway::{
         AgentBackend, AgentSessionRuntime, ForkSessionRequest,
@@ -5954,7 +6389,7 @@ mod tests {
     use std::path::Path;
     use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Barrier, Mutex};
     use std::time::Duration;
     use tokio::sync::Notify;
 
@@ -6056,7 +6491,7 @@ mod tests {
         let map = locks.map.lock().await;
         assert!(
             map.get("session-a")
-                .is_some_and(|lock| lock.try_lock().is_err()),
+                .is_some_and(|owner| owner.lock.try_lock().is_err()),
             "an actively held session lock must remain in the registry"
         );
         assert!(map.contains_key("session-b"));
@@ -6799,6 +7234,1488 @@ mod tests {
         pending_permission_request_msg(&permission_request(id)).unwrap()
     }
 
+    #[test]
+    fn terminal_projection_maps_session_closed_to_idle_interruption() {
+        let projection = terminal_projection(&TurnResult::Interrupted {
+            reason: DomainInterruptReason::SessionClosed,
+            error: None,
+        });
+
+        assert_eq!(projection.exit_code, 0);
+        assert!(projection.interrupted);
+        assert_eq!(projection.session_state, SessionState::Idle);
+        assert!(matches!(
+            projection.event,
+            TerminalEventProjection::Interrupted {
+                reason: EventInterruptReason::SessionClosed,
+                error: None,
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn close_session_finalizes_streaming_turn_and_persists_terminal_projection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id.clone();
+        let agent_message_id = response.agent_message.unwrap().id;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::PartsMerged(vec![DomainMessagePart::Text {
+                    content: "persisted prefix".to_string(),
+                    parent_tool_use_id: None,
+                }]),
+            )
+            .unwrap();
+        wait_for_persisted_text(
+            &session_store,
+            tmp.path(),
+            &session_id,
+            &agent_message_id,
+            "persisted prefix",
+        )
+        .await;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::PartsMerged(vec![
+                    DomainMessagePart::Text {
+                        content: "close tail".to_string(),
+                        parent_tool_use_id: None,
+                    },
+                    DomainMessagePart::ToolUse {
+                        id: "toolu-1".to_string(),
+                        tool: "Task".to_string(),
+                        input:
+                            crate::domain::agent_session::value_objects::JsonPayload::new_unchecked(
+                                r#"{"run_in_background":true}"#.to_string(),
+                            ),
+                        parent_tool_use_id: None,
+                    },
+                    DomainMessagePart::ToolResult {
+                        content: "background task launched".to_string(),
+                        is_error: false,
+                        tool_use_id: Some("toolu-1".to_string()),
+                        parent_tool_use_id: None,
+                        content_ref: None,
+                        summary: None,
+                    },
+                    DomainMessagePart::ToolUse {
+                        id: "toolu-2".to_string(),
+                        tool: "Read".to_string(),
+                        input:
+                            crate::domain::agent_session::value_objects::JsonPayload::new_unchecked(
+                                "{}".to_string(),
+                            ),
+                        parent_tool_use_id: None,
+                    },
+                ]),
+            )
+            .unwrap();
+        wait_for_streaming_text(&usecase, &session_id, "close tail").await;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::PermissionRequested(permission_request("perm-close")),
+            )
+            .unwrap();
+        wait_for_turn_phase(&usecase, &session_id, TurnPhase::WaitingPermission).await;
+        let before_close_parts =
+            persisted_message_parts(&session_store, tmp.path(), &session_id, &agent_message_id);
+        assert!(before_close_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Text { content, .. } if content.contains("persisted prefix")
+        )));
+        assert!(!before_close_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Text { content, .. } if content.contains("close tail")
+        )));
+        assert!(!before_close_parts
+            .iter()
+            .any(|part| matches!(part, MessagePart::Permission { .. })));
+
+        usecase.close_session(&session_id).await.unwrap();
+
+        let events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::TurnInterrupted {
+                reason: EventInterruptReason::SessionClosed,
+                exit_code: 0,
+                ..
+            }
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::ToolCallFailed { tool_use_id, .. } if tool_use_id == "toolu-2"
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::TaskStatusChanged {
+                task_tool_use_id,
+                status,
+                ..
+            } if task_tool_use_id == "toolu-1" && status == "stopped"
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::PermissionResolved {
+                request_id: Some(request_id),
+                decision: crate::usecase::agent_session::event_log::PermissionDecision::Cancelled,
+                ..
+            } if request_id == "perm-close"
+        )));
+        assert!(latest_unresolved_permission_request(&events).is_none());
+        let projected = TurnEventLog::from_events(events).project();
+        assert_eq!(projected.status.session_state, SessionState::Idle);
+        assert_eq!(projected.status.turn_phase, TurnPhase::Idle);
+
+        let reopened = usecase
+            .get_session(&session_id)
+            .await
+            .unwrap()
+            .expect("reopened session");
+        assert_eq!(reopened.turn_phase, TurnPhase::Idle);
+        assert!(reopened.pending_permission_request.is_none());
+        assert_eq!(
+            reopened.last_turn_interruption,
+            Some(crate::usecase::agent_session::session::TurnInterruption {
+                message_id: agent_message_id.clone(),
+                reason:
+                    crate::usecase::agent_session::session::TurnInterruptionReason::SessionClosed,
+            })
+        );
+        let parts = reopened
+            .session
+            .messages
+            .iter()
+            .find(|message| message.id == agent_message_id)
+            .and_then(|message| message.parts.as_ref())
+            .expect("persisted agent parts");
+        assert!(parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Text { content, .. } if content.contains("close tail")
+        )));
+        assert!(parts.iter().any(|part| matches!(
+            part,
+            MessagePart::ToolResult {
+                tool_use_id: Some(tool_use_id),
+                is_error: true,
+                ..
+            } if tool_use_id == "toolu-2"
+        )));
+        assert!(parts.iter().any(|part| matches!(
+            part,
+            MessagePart::ToolResult {
+                tool_use_id: Some(tool_use_id),
+                is_error: false,
+                ..
+            } if tool_use_id == "toolu-1"
+        )));
+        assert!(parts.iter().any(|part| matches!(
+            part,
+            MessagePart::TaskStatus {
+                task_tool_use_id,
+                status,
+                ..
+            } if task_tool_use_id == "toolu-1" && status == "stopped"
+        )));
+        assert!(parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Permission {
+                status: PermissionPartStatus::Cancelled,
+                ..
+            }
+        )));
+        assert!(controller
+            .call_kinds_for(&session_id)
+            .contains(&TestRuntimeCallKind::Close));
+    }
+
+    #[tokio::test]
+    async fn close_session_without_active_turn_does_not_create_interruption() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let session = create_session_internal_with_attributes(
+            &session_store,
+            tmp.path(),
+            tmp.path().to_string_lossy().as_ref(),
+            Some("claude".to_string()),
+            PermissionMode::Edit,
+            SessionCreationAttributes {
+                selected_model: Some("claude-4-sonnet".to_string()),
+                plan_mode: false,
+                workflow_node_session: false,
+                workflow_node_context: None,
+            },
+        )
+        .unwrap();
+        usecase
+            .start_session(
+                &session.id,
+                StartSessionOptions {
+                    permission_mode: PermissionMode::Edit,
+                    plan_mode: false,
+                },
+            )
+            .await
+            .unwrap();
+        let events_before = session_store
+            .load_session_events(tmp.path(), &session.id)
+            .unwrap();
+
+        usecase.close_session(&session.id).await.unwrap();
+
+        assert_eq!(
+            session_store
+                .load_session_events(tmp.path(), &session.id)
+                .unwrap(),
+            events_before
+        );
+        assert!(controller
+            .call_kinds_for(&session.id)
+            .contains(&TestRuntimeCallKind::Close));
+    }
+
+    #[tokio::test]
+    async fn close_session_keeps_runtime_state_when_force_flush_fails_and_can_retry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let fail_once = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        session_store.set_persist_parts_hook_for_test({
+            let fail_once = Arc::clone(&fail_once);
+            Arc::new(move |_, _, _| {
+                if fail_once.swap(false, std::sync::atomic::Ordering::SeqCst) {
+                    Err("injected close flush failure".to_string())
+                } else {
+                    Ok(())
+                }
+            })
+        });
+
+        let error = usecase.close_session(&session_id).await.unwrap_err();
+
+        assert!(error.to_string().contains("injected close flush failure"));
+        assert!(usecase.has_live_runtime(&session_id).await);
+        assert_eq!(
+            usecase.turn_phase(&session_id).await,
+            Some(TurnPhase::Streaming)
+        );
+        assert!(!controller
+            .call_kinds_for(&session_id)
+            .contains(&TestRuntimeCallKind::Close));
+        assert!(!session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap()
+            .iter()
+            .any(|event| matches!(event, AgentSessionEvent::TurnInterrupted { .. })));
+
+        usecase.close_session(&session_id).await.unwrap();
+        assert!(!usecase.has_live_runtime(&session_id).await);
+    }
+
+    #[tokio::test]
+    async fn close_all_failure_reopens_admission_and_session_transition() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let failed_session_id = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap()
+            .session
+            .id;
+        let successful_session_id = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap()
+            .session
+            .id;
+        let fail_once = Arc::new(AtomicBool::new(true));
+        session_store.set_persist_parts_hook_for_test({
+            let fail_once = Arc::clone(&fail_once);
+            let failed_session_id = failed_session_id.clone();
+            Arc::new(move |session_id, _, _| {
+                if session_id == failed_session_id && fail_once.swap(false, Ordering::SeqCst) {
+                    Err("injected application close flush failure".to_string())
+                } else {
+                    Ok(())
+                }
+            })
+        });
+
+        let error = usecase.close_all().await.unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("injected application close flush failure"));
+        assert!(error.to_string().contains(&failed_session_id));
+        assert!(!usecase.has_live_runtime(&successful_session_id).await);
+        assert!(controller
+            .call_kinds_for(&successful_session_id)
+            .contains(&TestRuntimeCallKind::Close));
+        assert_eq!(
+            session_store
+                .load_session_events(tmp.path(), &successful_session_id)
+                .unwrap()
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    AgentSessionEvent::TurnInterrupted {
+                        reason: EventInterruptReason::SessionClosed,
+                        ..
+                    }
+                ))
+                .count(),
+            1
+        );
+        assert!(usecase.has_live_runtime(&failed_session_id).await);
+        assert!(!session_store
+            .load_session_events(tmp.path(), &failed_session_id)
+            .unwrap()
+            .iter()
+            .any(|event| matches!(event, AgentSessionEvent::TurnInterrupted { .. })));
+        assert!(!usecase.ctx.shutdown_admission.is_shutting_down());
+        assert!(
+            !usecase
+                .ctx
+                .sessions
+                .lock()
+                .await
+                .get(&failed_session_id)
+                .expect("failed session remains")
+                .closing
+        );
+        usecase
+            .send_message(SendAgentMessageRequest {
+                chat_session_id: Some(failed_session_id),
+                worktree_path: tmp.path().to_string_lossy().to_string(),
+                content: "accepted after failed application shutdown".to_string(),
+                permission_mode: PermissionMode::Edit,
+                plan_mode: false,
+                backend_id: Some("claude".to_string()),
+                model_id: None,
+                images: None,
+                mentions: None,
+                editor_context: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn close_all_finalizes_every_active_session_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let mut session_ids = Vec::new();
+        for _ in 0..2 {
+            session_ids.push(
+                usecase
+                    .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+                    .await
+                    .unwrap()
+                    .session
+                    .id,
+            );
+        }
+
+        usecase.close_all().await.unwrap();
+
+        for session_id in session_ids {
+            assert!(!usecase.has_live_runtime(&session_id).await);
+            assert!(controller
+                .call_kinds_for(&session_id)
+                .contains(&TestRuntimeCallKind::Close));
+            assert_eq!(
+                session_store
+                    .load_session_events(tmp.path(), &session_id)
+                    .unwrap()
+                    .iter()
+                    .filter(|event| matches!(
+                        event,
+                        AgentSessionEvent::TurnInterrupted {
+                            reason: EventInterruptReason::SessionClosed,
+                            ..
+                        }
+                    ))
+                    .count(),
+                1
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn close_session_appends_terminal_batch_atomically_and_can_retry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let terminal_failures = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        session_store.set_append_event_hook_for_test({
+            let terminal_failures = Arc::clone(&terminal_failures);
+            Arc::new(move |_, event| {
+                if matches!(event, AgentSessionEvent::TurnInterrupted { .. })
+                    && terminal_failures.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                        < PERSIST_MAX_ATTEMPTS
+                {
+                    Err("injected terminal append failure".to_string())
+                } else {
+                    Ok(())
+                }
+            })
+        });
+
+        let error = usecase.close_session(&session_id).await.unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("injected terminal append failure"));
+        assert!(usecase.has_live_runtime(&session_id).await);
+        assert_eq!(
+            usecase.turn_phase(&session_id).await,
+            Some(TurnPhase::Streaming)
+        );
+        assert!(!controller
+            .call_kinds_for(&session_id)
+            .contains(&TestRuntimeCallKind::Close));
+        let failed_events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert!(!failed_events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::FinalPartsRecorded { .. }
+                | AgentSessionEvent::TurnInterrupted { .. }
+        )));
+
+        usecase.close_session(&session_id).await.unwrap();
+        let events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, AgentSessionEvent::TurnInterrupted { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn close_session_rolls_back_terminal_when_message_persist_fails_and_can_retry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let agent_message_id = response.agent_message.unwrap().id;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::PartsMerged(vec![DomainMessagePart::Text {
+                    content: "text committed before terminal".to_string(),
+                    parent_tool_use_id: None,
+                }]),
+            )
+            .unwrap();
+        wait_for_streaming_text(&usecase, &session_id, "text committed before terminal").await;
+        let persist_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        session_store.set_persist_parts_hook_for_test({
+            let persist_count = Arc::clone(&persist_count);
+            Arc::new(move |_, _, _| {
+                let call = persist_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if (2..2 + PERSIST_MAX_ATTEMPTS).contains(&call) {
+                    Err("injected final message persist failure".to_string())
+                } else {
+                    Ok(())
+                }
+            })
+        });
+
+        let error = usecase.close_session(&session_id).await.unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("injected final message persist failure"));
+        assert!(usecase.has_live_runtime(&session_id).await);
+        assert_eq!(
+            usecase.turn_phase(&session_id).await,
+            Some(TurnPhase::Streaming)
+        );
+        assert!(!controller
+            .call_kinds_for(&session_id)
+            .contains(&TestRuntimeCallKind::Close));
+        let events_after_terminal = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert_eq!(
+            events_after_terminal
+                .iter()
+                .filter(|event| matches!(event, AgentSessionEvent::TurnInterrupted { .. }))
+                .count(),
+            0
+        );
+
+        usecase.close_session(&session_id).await.unwrap();
+        assert!(!usecase.has_live_runtime(&session_id).await);
+        let events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, AgentSessionEvent::TurnInterrupted { .. }))
+                .count(),
+            1
+        );
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::PermissionRequested { request, .. }
+                if request.id == "late-permission"
+        )));
+        let persisted_parts =
+            persisted_message_parts(&session_store, tmp.path(), &session_id, &agent_message_id);
+        assert!(persisted_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Text { content, .. } if content.contains("text committed before terminal")
+        )));
+    }
+
+    #[tokio::test]
+    async fn set_session_backend_finalizes_active_turn_before_runtime_close() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+
+        let switched = usecase
+            .set_session_backend(&session_id, "codex")
+            .await
+            .unwrap();
+
+        assert_eq!(switched.session.backend_id.as_deref(), Some("codex"));
+        let events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::TurnInterrupted {
+                reason: EventInterruptReason::SessionClosed,
+                ..
+            }
+        )));
+        assert!(controller
+            .call_kinds_for(&session_id)
+            .contains(&TestRuntimeCallKind::Close));
+    }
+
+    #[tokio::test]
+    async fn set_session_backend_serializes_competing_send_with_runtime_transition() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, _controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let switch_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session_id.clone();
+            async move { usecase.set_session_backend(&session_id, "codex").await }
+        });
+        wait_for_session_closing(&usecase, &session_id).await;
+
+        let during_transition = session_store
+            .get_session_meta(tmp.path(), &session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(during_transition.backend_id, "claude");
+        let send_error = usecase
+            .send_message(SendAgentMessageRequest {
+                chat_session_id: Some(session_id.clone()),
+                worktree_path: tmp.path().to_string_lossy().to_string(),
+                content: "competing backend send".to_string(),
+                permission_mode: PermissionMode::Edit,
+                plan_mode: false,
+                backend_id: Some("claude".to_string()),
+                model_id: None,
+                images: None,
+                mentions: None,
+                editor_context: None,
+            })
+            .await
+            .unwrap_err();
+        assert!(send_error.to_string().contains("Agent session is closing"));
+
+        let switched = switch_task.await.unwrap().unwrap();
+        assert_eq!(switched.session.backend_id.as_deref(), Some("codex"));
+        assert!(!usecase.has_live_runtime(&session_id).await);
+        let resumed = usecase
+            .send_message(SendAgentMessageRequest {
+                chat_session_id: Some(session_id.clone()),
+                worktree_path: tmp.path().to_string_lossy().to_string(),
+                content: "send after backend switch".to_string(),
+                permission_mode: PermissionMode::Edit,
+                plan_mode: false,
+                backend_id: Some("codex".to_string()),
+                model_id: None,
+                images: None,
+                mentions: None,
+                editor_context: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(resumed.session.backend_id.as_deref(), Some("codex"));
+        let sessions = usecase.ctx.sessions.lock().await;
+        assert_eq!(
+            sessions
+                .get(&session_id)
+                .map(|state| state.backend_id.as_str()),
+            Some("codex")
+        );
+    }
+
+    #[tokio::test]
+    async fn close_all_finalizes_active_turn_for_fresh_runtime_restore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let agent_message_id = response.agent_message.unwrap().id;
+        let session_id = response.session.id;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::PartsMerged(vec![DomainMessagePart::Text {
+                    content: "persisted prefix".to_string(),
+                    parent_tool_use_id: None,
+                }]),
+            )
+            .unwrap();
+        wait_for_persisted_text(
+            &session_store,
+            tmp.path(),
+            &session_id,
+            &agent_message_id,
+            "persisted prefix",
+        )
+        .await;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::PartsMerged(vec![
+                    DomainMessagePart::Text {
+                        content: "shutdown tail".to_string(),
+                        parent_tool_use_id: None,
+                    },
+                    DomainMessagePart::ToolUse {
+                        id: "toolu-shutdown".to_string(),
+                        tool: "Task".to_string(),
+                        input:
+                            crate::domain::agent_session::value_objects::JsonPayload::new_unchecked(
+                                r#"{"run_in_background":true}"#.to_string(),
+                            ),
+                        parent_tool_use_id: None,
+                    },
+                    DomainMessagePart::ToolResult {
+                        content: "background task launched".to_string(),
+                        is_error: false,
+                        tool_use_id: Some("toolu-shutdown".to_string()),
+                        parent_tool_use_id: None,
+                        content_ref: None,
+                        summary: None,
+                    },
+                ]),
+            )
+            .unwrap();
+        wait_for_streaming_text(&usecase, &session_id, "shutdown tail").await;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::PermissionRequested(permission_request("perm-shutdown")),
+            )
+            .unwrap();
+        wait_for_turn_phase(&usecase, &session_id, TurnPhase::WaitingPermission).await;
+        let before_shutdown_parts =
+            persisted_message_parts(&session_store, tmp.path(), &session_id, &agent_message_id);
+        assert!(before_shutdown_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Text { content, .. } if content.contains("persisted prefix")
+        )));
+        assert!(!before_shutdown_parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Text { content, .. } if content.contains("shutdown tail")
+        )));
+        assert!(!before_shutdown_parts
+            .iter()
+            .any(|part| matches!(part, MessagePart::Permission { .. })));
+
+        usecase.close_all().await.unwrap();
+        drop(usecase);
+        let restarted =
+            crate::test_support::build_agent_runtime_usecase(session_store.clone(), tmp.path());
+
+        let reopened = restarted
+            .get_session(&session_id)
+            .await
+            .unwrap()
+            .expect("restored session");
+        assert_eq!(reopened.turn_phase, TurnPhase::Idle);
+        assert_eq!(
+            reopened.last_turn_interruption,
+            Some(crate::usecase::agent_session::session::TurnInterruption {
+                message_id: agent_message_id.clone(),
+                reason:
+                    crate::usecase::agent_session::session::TurnInterruptionReason::SessionClosed,
+            })
+        );
+        assert!(reopened.pending_permission_request.is_none());
+        assert!(reopened.session.messages.iter().any(|message| {
+            message.parts.as_ref().is_some_and(|parts| {
+                parts.iter().any(|part| {
+                    matches!(
+                        part,
+                        MessagePart::Text { content, .. } if content.contains("shutdown tail")
+                    )
+                })
+            })
+        }));
+        let parts = reopened
+            .session
+            .messages
+            .iter()
+            .find(|message| message.id == agent_message_id)
+            .and_then(|message| message.parts.as_ref())
+            .expect("persisted shutdown parts");
+        assert!(parts.iter().any(|part| matches!(
+            part,
+            MessagePart::TaskStatus {
+                task_tool_use_id,
+                status,
+                ..
+            } if task_tool_use_id == "toolu-shutdown" && status == "stopped"
+        )));
+        assert!(parts.iter().any(|part| matches!(
+            part,
+            MessagePart::Permission {
+                status: PermissionPartStatus::Cancelled,
+                ..
+            }
+        )));
+        let events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::TurnInterrupted {
+                reason: EventInterruptReason::SessionClosed,
+                ..
+            }
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::TaskStatusChanged {
+                task_tool_use_id,
+                status,
+                ..
+            } if task_tool_use_id == "toolu-shutdown" && status == "stopped"
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::PermissionResolved {
+                request_id: Some(request_id),
+                decision: crate::usecase::agent_session::event_log::PermissionDecision::Cancelled,
+                ..
+            } if request_id == "perm-shutdown"
+        )));
+        assert!(latest_unresolved_permission_request(&events).is_none());
+        assert!(controller
+            .call_kinds_for(&session_id)
+            .contains(&TestRuntimeCallKind::Close));
+    }
+
+    #[tokio::test]
+    async fn close_session_drains_competing_backend_completion_without_overwrite() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let close_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session_id.clone();
+            async move { usecase.close_session(&session_id).await }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!close_task.is_finished());
+
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::TurnCompleted(TurnResult::Completed {
+                    stop_reason: None,
+                    token_usage: None,
+                }),
+            )
+            .unwrap();
+        close_task.await.unwrap().unwrap();
+
+        let events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, AgentSessionEvent::TurnCompleted { .. })));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::TurnInterrupted {
+                reason: EventInterruptReason::SessionClosed,
+                ..
+            }
+        )));
+    }
+
+    #[tokio::test]
+    async fn close_session_waits_for_competing_send_message_before_finalizing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let session = create_session_internal_with_attributes(
+            &session_store,
+            tmp.path(),
+            tmp.path().to_string_lossy().as_ref(),
+            Some("claude".to_string()),
+            PermissionMode::Edit,
+            SessionCreationAttributes {
+                selected_model: Some("claude-4-sonnet".to_string()),
+                plan_mode: false,
+                workflow_node_session: false,
+                workflow_node_context: None,
+            },
+        )
+        .unwrap();
+        controller.pause_start_turn();
+        let send_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session.id.clone();
+            let worktree_path = tmp.path().to_string_lossy().to_string();
+            async move {
+                usecase
+                    .send_message(SendAgentMessageRequest {
+                        chat_session_id: Some(session_id),
+                        worktree_path,
+                        content: "competing send".to_string(),
+                        permission_mode: PermissionMode::Edit,
+                        plan_mode: false,
+                        backend_id: Some("claude".to_string()),
+                        model_id: None,
+                        images: None,
+                        mentions: None,
+                        editor_context: None,
+                    })
+                    .await
+            }
+        });
+        wait_for_call(&controller, &session.id, TestRuntimeCallKind::StartTurn).await;
+
+        let close_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session.id.clone();
+            async move { usecase.close_session(&session_id).await }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!close_task.is_finished());
+
+        controller.release_start_turn();
+        send_task.await.unwrap().unwrap();
+        close_task.await.unwrap().unwrap();
+
+        assert!(!usecase.has_live_runtime(&session.id).await);
+        assert!(session_store
+            .load_session_events(tmp.path(), &session.id)
+            .unwrap()
+            .iter()
+            .any(|event| matches!(
+                event,
+                AgentSessionEvent::TurnInterrupted {
+                    reason: EventInterruptReason::SessionClosed,
+                    ..
+                }
+            )));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocked_turn_start_does_not_block_other_session_and_remains_terminalizable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = Arc::new(FileSessionStorage::default());
+        let session_store = Arc::new(SessionStore::new(storage.clone()));
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let session = create_session_internal_with_attributes(
+            &session_store,
+            tmp.path(),
+            tmp.path().to_string_lossy().as_ref(),
+            Some("claude".to_string()),
+            PermissionMode::Edit,
+            SessionCreationAttributes {
+                selected_model: Some("claude-4-sonnet".to_string()),
+                plan_mode: false,
+                workflow_node_session: true,
+                workflow_node_context: None,
+            },
+        )
+        .unwrap();
+        let unrelated_session = create_session_internal_with_attributes(
+            &session_store,
+            tmp.path(),
+            tmp.path().to_string_lossy().as_ref(),
+            Some("claude".to_string()),
+            PermissionMode::Edit,
+            SessionCreationAttributes {
+                selected_model: Some("claude-4-sonnet".to_string()),
+                plan_mode: false,
+                workflow_node_session: false,
+                workflow_node_context: None,
+            },
+        )
+        .unwrap();
+        usecase
+            .start_session(
+                &unrelated_session.id,
+                StartSessionOptions {
+                    permission_mode: PermissionMode::Edit,
+                    plan_mode: false,
+                },
+            )
+            .await
+            .unwrap();
+        storage.reset_event_read_count();
+        let hook_entered = Arc::new(Barrier::new(2));
+        let release_hook = Arc::new(Barrier::new(2));
+        let global_registry_was_available = Arc::new(AtomicBool::new(false));
+        session_store.set_appended_event_hook_for_test({
+            let sessions = Arc::clone(&usecase.ctx.sessions);
+            let session_id = session.id.clone();
+            let hook_entered = Arc::clone(&hook_entered);
+            let release_hook = Arc::clone(&release_hook);
+            let global_registry_was_available = Arc::clone(&global_registry_was_available);
+            Arc::new(move |event_session_id, event| {
+                if event_session_id == session_id
+                    && matches!(event, AgentSessionEvent::TurnStarted { .. })
+                {
+                    global_registry_was_available
+                        .store(sessions.try_lock().is_ok(), Ordering::SeqCst);
+                    hook_entered.wait();
+                    release_hook.wait();
+                }
+            })
+        });
+        controller.pause_start_turn();
+        let start_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session.id.clone();
+            async move {
+                let _session_guard = usecase.acquire_session_lock(&session_id).await;
+                usecase
+                    .start_turn_locked(
+                        &session_id,
+                        PermissionMode::Edit,
+                        "cancel during durable start".to_string(),
+                        None,
+                        Vec::new(),
+                    )
+                    .await
+            }
+        });
+
+        hook_entered.wait();
+        assert_eq!(storage.event_read_count(), 0);
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            usecase.close_session(&unrelated_session.id),
+        )
+        .await
+        .expect("unrelated session close must not wait for another session's append")
+        .unwrap();
+        let global_registry_guard = usecase.ctx.sessions.lock().await;
+        start_task.abort();
+        release_hook.wait();
+        assert!(start_task.await.unwrap_err().is_cancelled());
+        drop(global_registry_guard);
+        assert!(global_registry_was_available.load(Ordering::SeqCst));
+
+        usecase.close_all().await.unwrap();
+
+        let events = session_store
+            .load_session_events(tmp.path(), &session.id)
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    AgentSessionEvent::TurnInterrupted {
+                        reason: EventInterruptReason::SessionClosed,
+                        ..
+                    }
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn conditional_idle_close_keeps_turn_that_wins_session_transition() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let session = create_session_internal_with_attributes(
+            &session_store,
+            tmp.path(),
+            tmp.path().to_string_lossy().as_ref(),
+            Some("claude".to_string()),
+            PermissionMode::Edit,
+            SessionCreationAttributes {
+                selected_model: Some("claude-4-sonnet".to_string()),
+                plan_mode: false,
+                workflow_node_session: true,
+                workflow_node_context: None,
+            },
+        )
+        .unwrap();
+        usecase
+            .start_session(
+                &session.id,
+                StartSessionOptions {
+                    permission_mode: PermissionMode::Edit,
+                    plan_mode: false,
+                },
+            )
+            .await
+            .unwrap();
+        controller.pause_start_turn();
+        let transition_guard = usecase.acquire_session_lock(&session.id).await;
+        let send_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session.id.clone();
+            let worktree_path = tmp.path().to_string_lossy().to_string();
+            async move {
+                usecase
+                    .send_message(SendAgentMessageRequest {
+                        chat_session_id: Some(session_id),
+                        worktree_path,
+                        content: "turn wins transition".to_string(),
+                        permission_mode: PermissionMode::Edit,
+                        plan_mode: false,
+                        backend_id: Some("claude".to_string()),
+                        model_id: None,
+                        images: None,
+                        mentions: None,
+                        editor_context: None,
+                    })
+                    .await
+            }
+        });
+        tokio::task::yield_now().await;
+        let close_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session.id.clone();
+            async move { usecase.close_session_if_idle(&session_id).await }
+        });
+        tokio::task::yield_now().await;
+        drop(transition_guard);
+        wait_for_call(&controller, &session.id, TestRuntimeCallKind::StartTurn).await;
+        assert!(!close_task.is_finished());
+
+        controller.release_start_turn();
+        send_task.await.unwrap().unwrap();
+        assert!(!close_task.await.unwrap().unwrap());
+
+        assert!(usecase.has_live_runtime(&session.id).await);
+        assert_eq!(
+            usecase.turn_phase(&session.id).await,
+            Some(TurnPhase::Streaming)
+        );
+        assert!(!session_store
+            .load_session_events(tmp.path(), &session.id)
+            .unwrap()
+            .iter()
+            .any(|event| matches!(
+                event,
+                AgentSessionEvent::TurnInterrupted {
+                    reason: EventInterruptReason::SessionClosed,
+                    ..
+                }
+            )));
+        usecase.close_session(&session.id).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn close_all_waits_for_admitted_send_before_snapshotting_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let session = create_session_internal_with_attributes(
+            &session_store,
+            tmp.path(),
+            tmp.path().to_string_lossy().as_ref(),
+            Some("claude".to_string()),
+            PermissionMode::Edit,
+            SessionCreationAttributes {
+                selected_model: Some("claude-4-sonnet".to_string()),
+                plan_mode: false,
+                workflow_node_session: false,
+                workflow_node_context: None,
+            },
+        )
+        .unwrap();
+        let hook_entered = Arc::new(Barrier::new(2));
+        let release_hook = Arc::new(Barrier::new(2));
+        let blocked = Arc::new(AtomicBool::new(false));
+        session_store.set_append_event_hook_for_test({
+            let session_id = session.id.clone();
+            let hook_entered = Arc::clone(&hook_entered);
+            let release_hook = Arc::clone(&release_hook);
+            let blocked = Arc::clone(&blocked);
+            Arc::new(move |event_session_id, event| {
+                if event_session_id == session_id
+                    && matches!(event, AgentSessionEvent::TurnStarted { .. })
+                    && !blocked.swap(true, Ordering::SeqCst)
+                {
+                    hook_entered.wait();
+                    release_hook.wait();
+                }
+                Ok(())
+            })
+        });
+        controller.pause_start_turn();
+        let send_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session.id.clone();
+            let worktree_path = tmp.path().to_string_lossy().to_string();
+            async move {
+                usecase
+                    .send_message(SendAgentMessageRequest {
+                        chat_session_id: Some(session_id),
+                        worktree_path,
+                        content: "admitted before shutdown".to_string(),
+                        permission_mode: PermissionMode::Edit,
+                        plan_mode: false,
+                        backend_id: Some("claude".to_string()),
+                        model_id: None,
+                        images: None,
+                        mentions: None,
+                        editor_context: None,
+                    })
+                    .await
+            }
+        });
+
+        hook_entered.wait();
+        let close_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            async move { usecase.close_all().await }
+        });
+        let shutdown_deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while !usecase.ctx.shutdown_admission.is_shutting_down() {
+            assert!(std::time::Instant::now() < shutdown_deadline);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(!close_task.is_finished());
+        release_hook.wait();
+
+        let send_error = usecase
+            .send_message(SendAgentMessageRequest {
+                chat_session_id: Some(session.id.clone()),
+                worktree_path: tmp.path().to_string_lossy().to_string(),
+                content: "rejected after shutdown".to_string(),
+                permission_mode: PermissionMode::Edit,
+                plan_mode: false,
+                backend_id: Some("claude".to_string()),
+                model_id: None,
+                images: None,
+                mentions: None,
+                editor_context: None,
+            })
+            .await
+            .unwrap_err();
+        assert!(send_error.to_string().contains("runtime is shutting down"));
+        let start_error = usecase
+            .start_session(
+                &session.id,
+                StartSessionOptions {
+                    permission_mode: PermissionMode::Edit,
+                    plan_mode: false,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(start_error.to_string().contains("runtime is shutting down"));
+
+        wait_for_call(&controller, &session.id, TestRuntimeCallKind::StartTurn).await;
+        assert!(!close_task.is_finished());
+        controller.release_start_turn();
+        send_task.await.unwrap().unwrap();
+        close_task.await.unwrap().unwrap();
+
+        let events = session_store
+            .load_session_events(tmp.path(), &session.id)
+            .unwrap();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::TurnInterrupted {
+                reason: EventInterruptReason::SessionClosed,
+                ..
+            }
+        )));
+        assert!(controller
+            .call_kinds_for(&session.id)
+            .contains(&TestRuntimeCallKind::Close));
+    }
+
+    #[tokio::test]
+    async fn close_session_waits_for_competing_permission_response_before_finalizing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        controller
+            .emit(
+                &session_id,
+                AgentRuntimeEvent::PermissionRequested(permission_request("perm-close-race")),
+            )
+            .unwrap();
+        wait_for_turn_phase(&usecase, &session_id, TurnPhase::WaitingPermission).await;
+        controller.pause_respond_permission();
+        let response_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session_id.clone();
+            async move {
+                usecase
+                    .respond_permission(
+                        &session_id,
+                        PermissionResponse {
+                            request_id: "perm-close-race".to_string(),
+                            decision: PermissionResponseDecision::Allow {
+                                updated_input: None,
+                                answers: None,
+                            },
+                        },
+                    )
+                    .await
+            }
+        });
+        wait_for_call(
+            &controller,
+            &session_id,
+            TestRuntimeCallKind::RespondPermission {
+                request_id: "perm-close-race".to_string(),
+            },
+        )
+        .await;
+
+        let close_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session_id.clone();
+            async move { usecase.close_session(&session_id).await }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!close_task.is_finished());
+
+        controller.release_respond_permission();
+        response_task.await.unwrap().unwrap();
+        close_task.await.unwrap().unwrap();
+
+        let events = session_store
+            .load_session_events(tmp.path(), &session_id)
+            .unwrap();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::PermissionResolved {
+                request_id: Some(request_id),
+                decision: crate::usecase::agent_session::event_log::PermissionDecision::Allowed,
+                ..
+            } if request_id == "perm-close-race"
+        )));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            AgentSessionEvent::PermissionResolved {
+                request_id: Some(request_id),
+                decision: crate::usecase::agent_session::event_log::PermissionDecision::Cancelled,
+                ..
+            } if request_id == "perm-close-race"
+        )));
+    }
+
+    #[tokio::test]
+    async fn close_session_rejects_new_send_while_event_drain_is_active() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(build_session_store());
+        let (usecase, _controller) =
+            build_agent_runtime_usecase_with_controller(session_store, tmp.path());
+        let response = usecase
+            .send_message(send_request(tmp.path().to_string_lossy().to_string()))
+            .await
+            .unwrap();
+        let session_id = response.session.id;
+        let close_task = tokio::spawn({
+            let usecase = Arc::clone(&usecase);
+            let session_id = session_id.clone();
+            async move { usecase.close_session(&session_id).await }
+        });
+        wait_for_session_closing(&usecase, &session_id).await;
+
+        let error = usecase
+            .send_message(SendAgentMessageRequest {
+                chat_session_id: Some(session_id.clone()),
+                worktree_path: tmp.path().to_string_lossy().to_string(),
+                content: "too late".to_string(),
+                permission_mode: PermissionMode::Edit,
+                plan_mode: false,
+                backend_id: Some("claude".to_string()),
+                model_id: None,
+                images: None,
+                mentions: None,
+                editor_context: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("Agent session is closing"));
+        close_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_session_reads_interruption_projection_without_loading_long_event_log() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = Arc::new(FileSessionStorage::default());
+        let session_store = Arc::new(SessionStore::new(storage.clone()));
+        let (usecase, _controller) =
+            build_agent_runtime_usecase_with_controller(session_store.clone(), tmp.path());
+        let session = create_session_internal_with_attributes(
+            &session_store,
+            tmp.path(),
+            tmp.path().to_string_lossy().as_ref(),
+            Some("claude".to_string()),
+            PermissionMode::Edit,
+            SessionCreationAttributes {
+                selected_model: Some("claude-4-sonnet".to_string()),
+                plan_mode: false,
+                workflow_node_session: false,
+                workflow_node_context: None,
+            },
+        )
+        .unwrap();
+        session_store
+            .append_session_event_and_project_state(
+                tmp.path(),
+                &session.id,
+                AgentSessionEvent::TurnStarted {
+                    turn_id: 1,
+                    message_id: "human-long".to_string(),
+                    assistant_message_id: Some("agent-long".to_string()),
+                    prompt: PromptInput::default(),
+                    at: 1.0,
+                },
+            )
+            .unwrap();
+        for index in 0..500 {
+            session_store
+                .append_session_event_without_projection(
+                    tmp.path(),
+                    &session.id,
+                    AgentSessionEvent::TextRecorded {
+                        turn_id: 1,
+                        message_id: "agent-long".to_string(),
+                        content: format!("chunk-{index}"),
+                        parent_tool_use_id: None,
+                    },
+                )
+                .unwrap();
+        }
+        session_store
+            .append_session_event_and_project_state(
+                tmp.path(),
+                &session.id,
+                AgentSessionEvent::TurnInterrupted {
+                    turn_id: 1,
+                    reason: EventInterruptReason::SessionClosed,
+                    exit_code: 0,
+                    error: None,
+                },
+            )
+            .unwrap();
+        storage.reset_event_read_count();
+
+        let response = usecase
+            .get_session(&session.id)
+            .await
+            .unwrap()
+            .expect("session response");
+
+        assert_eq!(
+            response.last_turn_interruption,
+            Some(crate::usecase::agent_session::session::TurnInterruption {
+                message_id: "agent-long".to_string(),
+                reason:
+                    crate::usecase::agent_session::session::TurnInterruptionReason::SessionClosed,
+            })
+        );
+        assert_eq!(storage.event_read_count(), 0);
+    }
+
     #[tokio::test]
     async fn get_session_returns_in_memory_pending_permission_request() {
         let tmp = tempfile::tempdir().unwrap();
@@ -7503,6 +9420,83 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
                 if usecase.turn_phase(session_id).await == Some(phase) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    fn persisted_message_parts(
+        session_store: &SessionStore,
+        data_dir: &Path,
+        session_id: &str,
+        message_id: &str,
+    ) -> Vec<MessagePart> {
+        session_store
+            .load_full_session_for_restore(data_dir, session_id)
+            .unwrap()
+            .expect("persisted session")
+            .messages
+            .into_iter()
+            .find(|message| message.id == message_id)
+            .and_then(|message| message.parts)
+            .unwrap_or_default()
+    }
+
+    async fn wait_for_persisted_text(
+        session_store: &SessionStore,
+        data_dir: &Path,
+        session_id: &str,
+        message_id: &str,
+        expected: &str,
+    ) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if persisted_message_parts(session_store, data_dir, session_id, message_id)
+                    .iter()
+                    .any(|part| {
+                        matches!(part, MessagePart::Text { content, .. } if content.contains(expected))
+                    })
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn wait_for_streaming_text(
+        usecase: &AgentSessionRuntimeUsecase,
+        session_id: &str,
+        expected: &str,
+    ) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if usecase.streaming_parts(session_id).await.iter().any(|part| {
+                    matches!(part, MessagePart::Text { content, .. } if content.contains(expected))
+                }) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn wait_for_session_closing(usecase: &AgentSessionRuntimeUsecase, session_id: &str) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let closing = {
+                    let sessions = usecase.ctx.sessions.lock().await;
+                    sessions.get(session_id).is_some_and(|state| state.closing)
+                };
+                if closing {
                     break;
                 }
                 tokio::time::sleep(Duration::from_millis(5)).await;
@@ -8517,7 +10511,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn turn_completed_append_failure_retries_and_keeps_notice_visible() {
+    async fn turn_completed_append_failure_retries_and_keeps_turn_retryable() {
         let tmp = tempfile::tempdir().unwrap();
         let session_store = Arc::new(build_session_store());
         let event_notifier = Arc::new(RecordingAgentNotifier::default());
@@ -8569,7 +10563,10 @@ mod tests {
         })
         .await
         .expect("turn completion persistence should exhaust retries");
-        wait_for_turn_phase(&usecase, &session_id, TurnPhase::Idle).await;
+        assert_eq!(
+            usecase.turn_phase(&session_id).await,
+            Some(TurnPhase::Streaming)
+        );
 
         assert_eq!(
             attempts.load(std::sync::atomic::Ordering::SeqCst),
@@ -8694,7 +10691,10 @@ mod tests {
         })
         .await
         .expect("final parts persistence should exhaust retries");
-        wait_for_turn_phase(&usecase, &session_id, TurnPhase::Idle).await;
+        assert_eq!(
+            usecase.turn_phase(&session_id).await,
+            Some(TurnPhase::Streaming)
+        );
 
         let fresh_store = build_session_store();
         let reloaded = fresh_store
@@ -9936,7 +11936,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn backend_selection_mutations_reject_each_locked_session_state() {
+    async fn cross_backend_set_model_rejects_each_locked_session_state() {
         #[derive(Clone, Copy)]
         enum LockedState {
             Messages,
@@ -9949,7 +11949,7 @@ mod tests {
             LockedState::AgentSessionId,
             LockedState::ActiveTurn,
         ] {
-            for use_set_model in [false, true] {
+            {
                 let tmp = tempfile::tempdir().unwrap();
                 let session_store = Arc::new(build_session_store());
                 let (usecase, controller) =
@@ -10009,17 +12009,10 @@ mod tests {
                     }
                 }
 
-                let result = if use_set_model {
-                    usecase
-                        .set_model(&session.id, "codex:gpt-5")
-                        .await
-                        .map(|_| ())
-                } else {
-                    usecase
-                        .set_session_backend(&session.id, "codex")
-                        .await
-                        .map(|_| ())
-                };
+                let result = usecase
+                    .set_model(&session.id, "codex:gpt-5")
+                    .await
+                    .map(|_| ());
 
                 assert_eq!(result, Err(AgentRuntimeError::BackendSelectionLocked));
                 let saved = session_store

--- a/src-tauri/src/usecase/agent_session/runtime/usecase.rs
+++ b/src-tauri/src/usecase/agent_session/runtime/usecase.rs
@@ -288,7 +288,7 @@ impl Drop for ShutdownAdmissionGuard {
             state.active_operations == 0
         };
         if became_idle {
-            self.admission.idle.notify_one();
+            self.admission.idle.notify_waiters();
         }
     }
 }
@@ -3361,6 +3361,9 @@ fn ensure_backend_recovery_operation_allowed(
     ctx: &RuntimeContext,
     session_id: &str,
 ) -> Result<(), AgentRuntimeError> {
+    if !backend_recovery_may_be_incomplete(ctx, session_id)? {
+        return Ok(());
+    }
     match backend_recovery_projection(ctx, session_id)? {
         Some(BackendSessionRecoveryProjection::Recovering { .. }) => Err(AgentRuntimeError::Other(
             "backend session recovery is still in progress".to_string(),
@@ -3374,11 +3377,36 @@ fn ensure_backend_recovery_operation_allowed(
     }
 }
 
+fn backend_recovery_may_be_incomplete(
+    ctx: &RuntimeContext,
+    session_id: &str,
+) -> Result<bool, AgentRuntimeError> {
+    Ok(ctx
+        .session_store
+        .get_session_meta(&ctx.data_dir, session_id)
+        .map_err(AgentRuntimeError::Other)?
+        .is_some_and(|meta| {
+            meta.agent_session_id.is_none()
+                && meta.context_carry == Some(ContextCarryState::Failed)
+                && meta.context_reinjection_generation.is_none()
+        }))
+}
+
 async fn reconcile_incomplete_backend_recovery(ctx: &RuntimeContext, session_id: &str) {
     if let Err(error) = reconcile_pending_recovery_message(ctx, session_id).await {
         log::warn!(
             "failed to reconcile pending backend recovery message for {session_id}: {error}"
         );
+    }
+    let recovery_may_be_incomplete = match backend_recovery_may_be_incomplete(ctx, session_id) {
+        Ok(recovery_may_be_incomplete) => recovery_may_be_incomplete,
+        Err(error) => {
+            log::warn!("failed to load backend recovery metadata for {session_id}: {error}");
+            return;
+        }
+    };
+    if !recovery_may_be_incomplete {
+        return;
     }
     let projection = match backend_recovery_projection(ctx, session_id) {
         Ok(projection) => projection,
@@ -6419,6 +6447,27 @@ mod tests {
 
     fn test_session_runtime_locks() -> SessionRuntimeLocks {
         Arc::new(SessionRuntimeLockRegistry::default())
+    }
+
+    #[tokio::test]
+    async fn shutdown_admission_notifies_all_registered_idle_waiters() {
+        let admission = Arc::new(ShutdownAdmission::default());
+        let guard = admission.admit().unwrap();
+        let first_waiter = admission.idle.notified();
+        let second_waiter = admission.idle.notified();
+        tokio::pin!(first_waiter);
+        tokio::pin!(second_waiter);
+        first_waiter.as_mut().enable();
+        second_waiter.as_mut().enable();
+
+        drop(guard);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            first_waiter.await;
+            second_waiter.await;
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test]

--- a/src-tauri/src/usecase/agent_session/session/mod.rs
+++ b/src-tauri/src/usecase/agent_session/session/mod.rs
@@ -54,6 +54,22 @@ pub(crate) use stored_lifecycle::{
     StoredSessionLifecycleUsecase, WorkflowNodeSessionRestorer,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnInterruptionReason {
+    Abort,
+    Timeout,
+    Crash,
+    SessionClosed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnInterruption {
+    pub message_id: String,
+    pub reason: TurnInterruptionReason,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TodoListItem {
@@ -643,6 +659,10 @@ pub struct SessionMeta {
     pub agent_read_paths: Option<Vec<PathBuf>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub context_epoch: Option<ContextEpochMeta>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub last_turn_interruption: Option<TurnInterruption>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub last_turn_id: Option<u64>,
     pub first_message_preview: String,
     pub message_count: usize,
     pub body_format_version: u32,
@@ -979,6 +999,8 @@ pub struct GetSessionResponse {
     pub initial_page: Option<InitialSessionPage>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub latest_token_usage: Option<TokenUsage>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub last_turn_interruption: Option<TurnInterruption>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1105,6 +1127,8 @@ impl SessionMeta {
             workflow_instructions: Vec::new(),
             agent_read_paths: Some(agent_read_paths_from_messages(&session.messages)),
             context_epoch: session.context_epoch.clone(),
+            last_turn_interruption: None,
+            last_turn_id: Some(0),
             first_message_preview: first_message_preview(&session.messages),
             message_count: session.messages.len(),
             body_format_version: SESSION_BODY_FORMAT_VERSION,
@@ -1932,6 +1956,7 @@ mod tests {
             pending_permission_state_revision: 0,
             initial_page: None,
             latest_token_usage: None,
+            last_turn_interruption: None,
         };
 
         let response_value = serde_json::to_value(&response).unwrap();
@@ -3506,5 +3531,21 @@ mod workflow_node_context_meta_tests {
         let meta = SessionMeta::from_session(&session_with_context(None));
         assert!(meta.workflow_node_context.is_none());
         assert_eq!(meta.to_summary().workflow_node_context, None);
+    }
+
+    #[test]
+    fn turn_interruption_read_model_keeps_existing_wire_vocabulary() {
+        let interruption = TurnInterruption {
+            message_id: "agent-1".to_string(),
+            reason: TurnInterruptionReason::SessionClosed,
+        };
+
+        let json = serde_json::to_string(&interruption).unwrap();
+
+        assert_eq!(json, r#"{"messageId":"agent-1","reason":"session_closed"}"#);
+        assert_eq!(
+            serde_json::from_str::<TurnInterruption>(&json).unwrap(),
+            interruption
+        );
     }
 }

--- a/src-tauri/src/usecase/agent_session/session/prompt_suggestion.rs
+++ b/src-tauri/src/usecase/agent_session/session/prompt_suggestion.rs
@@ -270,6 +270,8 @@ mod tests {
                 workflow_instructions: Vec::new(),
                 agent_read_paths: None,
                 context_epoch: None,
+                last_turn_interruption: None,
+                last_turn_id: Some(0),
                 first_message_preview: "Implementation is done.".to_string(),
                 message_count: 200,
                 body_format_version: SESSION_BODY_FORMAT_VERSION,

--- a/src-tauri/src/usecase/agent_session/session/store.rs
+++ b/src-tauri/src/usecase/agent_session/session/store.rs
@@ -11,14 +11,15 @@ use crate::domain::agent_session::{
 use crate::domain::path::same_worktree_path;
 use crate::usecase::agent_session::context_meta::ContextEpochMeta;
 use crate::usecase::agent_session::event_log::{
-    AgentSessionEvent, BackendSessionRecoveryProjection, BackendSessionRecoveryReason,
-    GoalReactivationOutcome, SessionReadModel, TurnEventLog,
+    latest_turn_interruption, AgentSessionEvent, BackendSessionRecoveryProjection,
+    BackendSessionRecoveryReason, GoalReactivationOutcome, SessionReadModel, TurnEventLog,
 };
 
 use super::{
     error_reason_for_state, now_timestamp, ChatMessage, ChatSession, ContextCarryState,
     MessagePart, MessageRole, PageCursor, PendingRecoveryMessage, SessionAttachment, SessionMeta,
     SessionPage, SessionReviewContext, SessionState, SessionSummary, SessionToolOutput,
+    TurnInterruption,
 };
 
 /// `SessionState` の遷移を観測する購読者向けコールバック。
@@ -123,6 +124,11 @@ pub(crate) type SessionSetStateHook =
 #[cfg(test)]
 pub(crate) type SessionProjectionHook =
     Arc<dyn Fn(&str, &SessionState, Option<&str>) -> Result<(), String> + Send + Sync>;
+#[cfg(test)]
+pub(crate) type SessionAppendedEventHook = Arc<dyn Fn(&str, &AgentSessionEvent) + Send + Sync>;
+#[cfg(test)]
+pub(crate) type SessionEventProjectionHook =
+    Arc<dyn Fn(&str, Option<u64>) -> Result<(), String> + Send + Sync>;
 
 pub struct SessionStore {
     storage: Arc<dyn SessionStoragePort>,
@@ -141,6 +147,10 @@ pub struct SessionStore {
     set_state_hook: RwLock<Option<SessionSetStateHook>>,
     #[cfg(test)]
     projection_hook: RwLock<Option<SessionProjectionHook>>,
+    #[cfg(test)]
+    appended_event_hook: RwLock<Option<SessionAppendedEventHook>>,
+    #[cfg(test)]
+    event_projection_hook: RwLock<Option<SessionEventProjectionHook>>,
 }
 
 fn compact_session_title(title: &str) -> String {
@@ -269,6 +279,10 @@ impl SessionStore {
             set_state_hook: RwLock::new(None),
             #[cfg(test)]
             projection_hook: RwLock::new(None),
+            #[cfg(test)]
+            appended_event_hook: RwLock::new(None),
+            #[cfg(test)]
+            event_projection_hook: RwLock::new(None),
         }
     }
 
@@ -300,6 +314,16 @@ impl SessionStore {
     #[cfg(test)]
     pub(crate) fn set_projection_hook_for_test(&self, hook: SessionProjectionHook) {
         *self.projection_hook.write() = Some(hook);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_appended_event_hook_for_test(&self, hook: SessionAppendedEventHook) {
+        *self.appended_event_hook.write() = Some(hook);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_event_projection_hook_for_test(&self, hook: SessionEventProjectionHook) {
+        *self.event_projection_hook.write() = Some(hook);
     }
 
     pub fn list_sessions(
@@ -492,6 +516,8 @@ impl SessionStore {
         forked_meta.provider_session_generation = 0;
         forked_meta.context_reinjection_generation = None;
         forked_meta.context_carry = None;
+        forked_meta.last_turn_interruption = None;
+        forked_meta.last_turn_id = Some(0);
         forked_meta.workflow_node_session = false;
 
         self.storage
@@ -534,7 +560,7 @@ impl SessionStore {
         app_data_dir: &Path,
         session_id: &str,
         limit: usize,
-    ) -> Result<Option<(ChatSession, SessionPage)>, String> {
+    ) -> Result<Option<(ChatSession, SessionPage, Option<TurnInterruption>)>, String> {
         let Some(meta) = self.storage.get_session_meta(app_data_dir, session_id)? else {
             return Ok(None);
         };
@@ -550,7 +576,7 @@ impl SessionStore {
                 latest_token_usage: None,
             });
         let session = meta.to_session(page.messages.clone());
-        Ok(Some((session, page)))
+        Ok(Some((session, page, meta.last_turn_interruption)))
     }
 
     pub fn get_session_meta(
@@ -613,10 +639,11 @@ impl SessionStore {
         if self.storage.take_event_log_recovered(session_id) {
             self.notify_event_log_recovered(session_id);
         }
-        Ok(TurnEventLog::from_events(events)
-            .project()
-            .status
-            .session_state)
+        #[cfg(test)]
+        if let Some(hook) = self.appended_event_hook.read().clone() {
+            hook(session_id, &event);
+        }
+        self.project_session_events(app_data_dir, session_id, &events)
     }
 
     pub(crate) fn append_session_event_and_project_read_model(
@@ -635,13 +662,18 @@ impl SessionStore {
         if self.storage.take_event_log_recovered(session_id) {
             self.notify_event_log_recovered(session_id);
         }
-        let projected = TurnEventLog::from_events(events).project();
+        let projected = TurnEventLog::from_events(events.clone()).project();
         let projected_state = projected.status.session_state.clone();
-        self.set_session_projection(
+        self.set_event_projection(
             app_data_dir,
             session_id,
             projected_state.clone(),
             projected.error_reason.clone(),
+            latest_turn_interruption(&events),
+            events.iter().rev().find_map(|event| match event {
+                AgentSessionEvent::TurnStarted { turn_id, .. } => Some(*turn_id),
+                _ => None,
+            }),
         )?;
         Ok(projected)
     }
@@ -759,7 +791,7 @@ impl SessionStore {
             let mut prepare = |all_events: &[AgentSessionEvent], meta: &SessionMeta| {
                 let projected = TurnEventLog::from_events(all_events.to_vec()).project();
                 let mut projected_meta =
-                    self.projected_meta_for_commit(session_id, meta, &projected)?;
+                    self.projected_meta_for_commit(session_id, meta, all_events, &projected)?;
                 projected_meta.state_revision = meta.state_revision.saturating_add(1);
                 previous_projection = Some(PreviousSessionProjection {
                     state: meta.state.clone(),
@@ -791,6 +823,7 @@ impl SessionStore {
         &self,
         _session_id: &str,
         meta: &SessionMeta,
+        events: &[AgentSessionEvent],
         projected: &SessionReadModel,
     ) -> Result<SessionMeta, String> {
         #[cfg(test)]
@@ -805,6 +838,15 @@ impl SessionStore {
         projected_meta.state = projected.status.session_state.clone();
         projected_meta.error_reason =
             error_reason_for_state(&projected_meta.state, &projected.error_reason);
+        projected_meta.last_turn_interruption = latest_turn_interruption(events);
+        projected_meta.last_turn_id = events.iter().rev().find_map(|event| match event {
+            AgentSessionEvent::TurnStarted { turn_id, .. } => Some(*turn_id),
+            _ => None,
+        });
+        #[cfg(test)]
+        if let Some(hook) = self.event_projection_hook.read().clone() {
+            hook(_session_id, projected_meta.last_turn_id)?;
+        }
         Ok(projected_meta)
     }
 
@@ -828,6 +870,86 @@ impl SessionStore {
                 previous.state_revision,
             );
         }
+    }
+
+    pub fn append_turn_started_and_project_state(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        event: AgentSessionEvent,
+    ) -> Result<(), String> {
+        let turn_id = match &event {
+            AgentSessionEvent::TurnStarted { turn_id, .. } => *turn_id,
+            _ => return Err("Turn start projection requires a TurnStarted event".to_string()),
+        };
+        self.append_session_event_without_projection(app_data_dir, session_id, event.clone())?;
+        if let Err(projection_error) = self.set_event_projection(
+            app_data_dir,
+            session_id,
+            SessionState::Active,
+            None,
+            None,
+            Some(turn_id),
+        ) {
+            let recovery = self
+                .load_session_events(app_data_dir, session_id)
+                .and_then(|events| {
+                    self.project_session_events(app_data_dir, session_id, &events)
+                        .map(|_| ())
+                });
+            return match recovery {
+                Ok(()) => Err(projection_error),
+                Err(recovery_error) => Err(format!(
+                    "{projection_error}; failed to recover committed turn projection: {recovery_error}"
+                )),
+            };
+        }
+        #[cfg(test)]
+        if let Some(hook) = self.appended_event_hook.read().clone() {
+            hook(session_id, &event);
+        }
+        Ok(())
+    }
+
+    pub fn project_session_events(
+        &self,
+        app_data_dir: &Path,
+        session_id: &str,
+        events: &[AgentSessionEvent],
+    ) -> Result<SessionState, String> {
+        let last_turn_interruption = latest_turn_interruption(events);
+        let last_turn_id = events.iter().rev().find_map(|event| match event {
+            AgentSessionEvent::TurnStarted { turn_id, .. } => Some(*turn_id),
+            _ => None,
+        });
+        let projected = TurnEventLog::from_events(events.to_vec()).project();
+        let projected_state = projected.status.session_state.clone();
+        self.set_event_projection(
+            app_data_dir,
+            session_id,
+            projected_state.clone(),
+            projected.error_reason,
+            last_turn_interruption,
+            last_turn_id,
+        )?;
+        Ok(projected_state)
+    }
+
+    pub fn next_turn_id(&self, app_data_dir: &Path, session_id: &str) -> Result<u64, String> {
+        let meta = self.require_meta(app_data_dir, session_id)?;
+        let last_turn_id = match meta.last_turn_id {
+            Some(turn_id) => turn_id,
+            None => self
+                .load_session_events(app_data_dir, session_id)?
+                .iter()
+                .rev()
+                .find_map(|event| match event {
+                    AgentSessionEvent::TurnStarted { turn_id, .. } => Some(*turn_id),
+                    _ => None,
+                })
+                .unwrap_or(0),
+        };
+        Ok(last_turn_id.saturating_add(1))
     }
 
     pub fn append_session_event_without_projection(
@@ -1258,43 +1380,43 @@ impl SessionStore {
         Ok(())
     }
 
-    fn set_session_projection(
+    fn set_event_projection(
         &self,
         app_data_dir: &Path,
         session_id: &str,
         state: SessionState,
         error_reason: Option<String>,
+        last_turn_interruption: Option<TurnInterruption>,
+        last_turn_id: Option<u64>,
     ) -> Result<(), String> {
         #[cfg(test)]
         if let Some(hook) = self.projection_hook.read().clone() {
             hook(session_id, &state, error_reason.as_deref())?;
         }
+        #[cfg(test)]
+        if let Some(hook) = self.event_projection_hook.read().clone() {
+            hook(session_id, last_turn_id)?;
+        }
         let state_for_notify = state.clone();
         let projected_error_reason = error_reason_for_state(&state, &error_reason);
         let mut previous_error_reason = None;
-        let mut worktree_path = None;
         let (meta, state_changed) = self.update_meta_only(app_data_dir, session_id, |meta| {
             previous_error_reason = Some(meta.error_reason.clone());
-            worktree_path = Some(meta.worktree_path.clone());
-            meta.error_reason = projected_error_reason.clone();
             meta.state = state;
+            meta.error_reason = projected_error_reason.clone();
+            meta.last_turn_interruption = last_turn_interruption;
+            meta.last_turn_id = last_turn_id;
             meta.updated_at = now_timestamp();
             Ok(())
         })?;
-        if state_changed {
-            self.notify_state_change(
-                session_id,
-                &meta.worktree_path,
-                &state_for_notify,
-                meta.state_revision,
-            );
-        } else if previous_error_reason
-            .expect("update_session_meta must invoke closure before returning Ok")
-            != projected_error_reason
+        if state_changed
+            || previous_error_reason
+                .expect("update_session_meta must invoke closure before returning Ok")
+                != projected_error_reason
         {
             self.notify_state_change(
                 session_id,
-                &worktree_path.expect("session meta must include a worktree path"),
+                &meta.worktree_path,
                 &state_for_notify,
                 meta.state_revision,
             );

--- a/src-tauri/src/usecase/application_lifecycle.rs
+++ b/src-tauri/src/usecase/application_lifecycle.rs
@@ -1,0 +1,124 @@
+#[async_trait::async_trait]
+pub(crate) trait AgentSessionShutdownPort: Send + Sync {
+    async fn close_all(&self) -> Result<(), String>;
+}
+
+#[async_trait::async_trait]
+pub(crate) trait WorkflowCommandShutdownPort: Send + Sync {
+    async fn shutdown_active_commands(&self);
+}
+
+pub(crate) trait LocalApiShutdownPort: Send + Sync {
+    fn shutdown(&self);
+}
+
+pub(crate) struct ApplicationLifecycleUsecase<'a, A, W, L> {
+    agent_sessions: &'a A,
+    workflow_commands: &'a W,
+    local_api: &'a L,
+}
+
+impl<'a, A, W, L> ApplicationLifecycleUsecase<'a, A, W, L>
+where
+    A: AgentSessionShutdownPort,
+    W: WorkflowCommandShutdownPort,
+    L: LocalApiShutdownPort,
+{
+    pub(crate) fn new(agent_sessions: &'a A, workflow_commands: &'a W, local_api: &'a L) -> Self {
+        Self {
+            agent_sessions,
+            workflow_commands,
+            local_api,
+        }
+    }
+
+    pub(crate) async fn shutdown(&self) -> Result<(), String> {
+        self.agent_sessions.close_all().await?;
+        self.workflow_commands.shutdown_active_commands().await;
+        self.local_api.shutdown();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct RecordingShutdown {
+        calls: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl WorkflowCommandShutdownPort for RecordingShutdown {
+        async fn shutdown_active_commands(&self) {
+            self.calls.lock().unwrap().push("shutdown_active_commands");
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AgentSessionShutdownPort for RecordingShutdown {
+        async fn close_all(&self) -> Result<(), String> {
+            self.calls.lock().unwrap().push("close_all");
+            Ok(())
+        }
+    }
+
+    impl LocalApiShutdownPort for RecordingShutdown {
+        fn shutdown(&self) {
+            self.calls.lock().unwrap().push("shutdown_local_api");
+        }
+    }
+
+    struct FailingAgentShutdown {
+        calls: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl AgentSessionShutdownPort for FailingAgentShutdown {
+        async fn close_all(&self) -> Result<(), String> {
+            self.calls.lock().unwrap().push("close_all");
+            Err("injected close_all failure".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_orders_agent_finalize_before_irreversible_services() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let shutdown = RecordingShutdown {
+            calls: calls.clone(),
+        };
+        let usecase = ApplicationLifecycleUsecase::new(&shutdown, &shutdown, &shutdown);
+
+        usecase.shutdown().await.unwrap();
+
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            [
+                "close_all",
+                "shutdown_active_commands",
+                "shutdown_local_api"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_finalize_failure_keeps_irreversible_services_running() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let workflow_and_api = RecordingShutdown {
+            calls: calls.clone(),
+        };
+        let agent = FailingAgentShutdown {
+            calls: calls.clone(),
+        };
+        let usecase =
+            ApplicationLifecycleUsecase::new(&agent, &workflow_and_api, &workflow_and_api);
+
+        let error = usecase.shutdown().await.unwrap_err();
+
+        assert_eq!(error, "injected close_all failure");
+        assert_eq!(calls.lock().unwrap().as_slice(), ["close_all"]);
+    }
+}

--- a/src-tauri/src/usecase/application_lifecycle.rs
+++ b/src-tauri/src/usecase/application_lifecycle.rs
@@ -1,6 +1,12 @@
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum ApplicationLifecycleError {
+    #[error("{0}")]
+    AgentSessionShutdown(String),
+}
+
 #[async_trait::async_trait]
 pub(crate) trait AgentSessionShutdownPort: Send + Sync {
-    async fn close_all(&self) -> Result<(), String>;
+    async fn close_all(&self) -> Result<(), ApplicationLifecycleError>;
 }
 
 #[async_trait::async_trait]
@@ -32,7 +38,7 @@ where
         }
     }
 
-    pub(crate) async fn shutdown(&self) -> Result<(), String> {
+    pub(crate) async fn shutdown(&self) -> Result<(), ApplicationLifecycleError> {
         self.agent_sessions.close_all().await?;
         self.workflow_commands.shutdown_active_commands().await;
         self.local_api.shutdown();
@@ -60,7 +66,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl AgentSessionShutdownPort for RecordingShutdown {
-        async fn close_all(&self) -> Result<(), String> {
+        async fn close_all(&self) -> Result<(), ApplicationLifecycleError> {
             self.calls.lock().unwrap().push("close_all");
             Ok(())
         }
@@ -78,9 +84,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl AgentSessionShutdownPort for FailingAgentShutdown {
-        async fn close_all(&self) -> Result<(), String> {
+        async fn close_all(&self) -> Result<(), ApplicationLifecycleError> {
             self.calls.lock().unwrap().push("close_all");
-            Err("injected close_all failure".to_string())
+            Err(ApplicationLifecycleError::AgentSessionShutdown(
+                "injected close_all failure".to_string(),
+            ))
         }
     }
 
@@ -118,7 +126,12 @@ mod tests {
 
         let error = usecase.shutdown().await.unwrap_err();
 
-        assert_eq!(error, "injected close_all failure");
+        assert_eq!(
+            error,
+            ApplicationLifecycleError::AgentSessionShutdown(
+                "injected close_all failure".to_string()
+            )
+        );
         assert_eq!(calls.lock().unwrap().as_slice(), ["close_all"]);
     }
 }

--- a/src-tauri/src/usecase/mod.rs
+++ b/src-tauri/src/usecase/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod agent_session;
 pub(crate) mod app_config;
 pub(crate) mod app_data_gc;
+pub(crate) mod application_lifecycle;
 pub(crate) mod code_dto;
 pub(crate) mod code_error;
 pub(crate) mod code_query_service;

--- a/src/components/panels/AgentChatPanel/ChatSessionView.test.ts
+++ b/src/components/panels/AgentChatPanel/ChatSessionView.test.ts
@@ -332,6 +332,22 @@ describe("ChatSessionView session-local controls", () => {
 		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 	});
 
+	it("shows the durable SessionClosed interruption on the reopened agent turn", () => {
+		renderChatSessionView({
+			testSession: {
+				...sessionWithAgentResponse,
+				lastTurnInterruption: {
+					messageId: "m2",
+					reason: "session_closed",
+				},
+			},
+		});
+
+		expect(screen.getByTestId("turn-interruption-chip")).toHaveTextContent(
+			"Interrupted: Session closed",
+		);
+	});
+
 	it("keeps find and raw scrollback available from the toolbar", async () => {
 		const user = userEvent.setup();
 		renderChatSessionView({ testSession: sessionWithAgentResponse });

--- a/src/components/panels/AgentChatPanel/ChatSessionView.tsx
+++ b/src/components/panels/AgentChatPanel/ChatSessionView.tsx
@@ -40,6 +40,7 @@ import type {
 	QueuedAgentTurn,
 	SessionNotice,
 	SlashCommand,
+	TurnInterruption,
 } from "@/types/session";
 import { getTextContent } from "@/types/session";
 import {
@@ -354,17 +355,32 @@ function ThinkingPart({
 function AgentMessageMeta({
 	msg,
 	isStreaming,
+	interruption,
 }: {
 	msg: ChatMessage;
 	isStreaming: boolean;
+	interruption?: TurnInterruption | null;
 }) {
 	if (isStreaming) return null;
 	const formattedTime = formatMessageTime(msg.timestamp);
 	const copyableText = getTextContent(msg.parts).trim();
-	if (!formattedTime && !copyableText) return null;
+	if (!formattedTime && !copyableText && !interruption) return null;
+	const interruptionReason = interruption
+		? interruption.reason === "session_closed"
+			? "Session closed"
+			: interruption.reason
+		: null;
 
 	return (
 		<div className="flex items-center gap-1 px-5 pb-1 text-[11px] text-muted-foreground">
+			{interruptionReason && (
+				<span
+					className="rounded-full border border-border bg-muted/60 px-2 py-0.5"
+					data-testid="turn-interruption-chip"
+				>
+					Interrupted: {interruptionReason}
+				</span>
+			)}
 			{formattedTime && <span>{formattedTime}</span>}
 			{copyableText && (
 				<MessageCopyButton
@@ -1498,6 +1514,11 @@ export function ChatSessionView({
 								<AgentMessageMeta
 									msg={msg}
 									isStreaming={isLastAgentStreaming}
+									interruption={
+										session.lastTurnInterruption?.messageId === msg.id
+											? session.lastTurnInterruption
+											: null
+									}
 								/>
 							</div>
 						);

--- a/src/hooks/useSessionStore.test.ts
+++ b/src/hooks/useSessionStore.test.ts
@@ -74,6 +74,10 @@ describe("session paging", () => {
 			},
 			pendingPermissionStateRevision: 4,
 			latestTokenUsage: { inputTokens: 1, outputTokens: 2 },
+			lastTurnInterruption: {
+				messageId: "agent-1",
+				reason: "session_closed",
+			},
 		});
 
 		const response = await getSession("s1");
@@ -108,6 +112,10 @@ describe("session paging", () => {
 		expect(response?.latestTokenUsage).toEqual({
 			inputTokens: 1,
 			outputTokens: 2,
+		});
+		expect(response?.session.lastTurnInterruption).toEqual({
+			messageId: "agent-1",
+			reason: "session_closed",
 		});
 	});
 

--- a/src/hooks/useSessionStore.ts
+++ b/src/hooks/useSessionStore.ts
@@ -18,6 +18,7 @@ import {
 	type SessionSummary,
 	type SessionToolOutput,
 	type TokenUsage,
+	type TurnInterruption,
 	type TurnPhase,
 } from "@/types/session";
 
@@ -261,6 +262,7 @@ interface RawGetSessionResponse {
 	latestTokenUsage?: TokenUsage | null;
 	workflowNodeSession?: boolean;
 	turnPhase: TurnPhase;
+	lastTurnInterruption?: TurnInterruption | null;
 	initialPage?: {
 		nextCursor?: string | null;
 		hasMore: boolean;
@@ -272,22 +274,25 @@ function convertRawGetSessionResponse(
 	raw: RawGetSessionResponse,
 ): GetSessionResponse {
 	return {
-		session: convertLegacySession({
-			id: raw.id,
-			worktreePath: raw.worktreePath,
-			messages: raw.messages,
-			state: raw.state,
-			errorReason: raw.errorReason,
-			createdAt: raw.createdAt,
-			updatedAt: raw.updatedAt,
-			agentSessionId: raw.agentSessionId,
-			contextCarry: raw.contextCarry,
-			permissionMode: raw.permissionMode,
-			planMode: raw.planMode,
-			permissionProfileId: raw.permissionProfileId,
-			backendId: raw.backendId,
-			workflowNodeSession: raw.workflowNodeSession,
-		}),
+		session: {
+			...convertLegacySession({
+				id: raw.id,
+				worktreePath: raw.worktreePath,
+				messages: raw.messages,
+				state: raw.state,
+				errorReason: raw.errorReason,
+				createdAt: raw.createdAt,
+				updatedAt: raw.updatedAt,
+				agentSessionId: raw.agentSessionId,
+				contextCarry: raw.contextCarry,
+				permissionMode: raw.permissionMode,
+				planMode: raw.planMode,
+				permissionProfileId: raw.permissionProfileId,
+				backendId: raw.backendId,
+				workflowNodeSession: raw.workflowNodeSession,
+			}),
+			lastTurnInterruption: raw.lastTurnInterruption ?? null,
+		},
 		turnPhase: raw.turnPhase,
 		selectedModel: raw.selectedModel,
 		availableModels: raw.availableModels ?? [],

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -132,6 +132,17 @@ export type ContextCarryState = "resumed" | "reinjected" | "failed";
 
 export type TurnPhase = "idle" | "streaming" | "waiting_permission";
 
+export type TurnInterruptionReason =
+	| "abort"
+	| "timeout"
+	| "crash"
+	| "session_closed";
+
+export interface TurnInterruption {
+	messageId: string;
+	reason: TurnInterruptionReason;
+}
+
 export interface AgentStallObservation {
 	turnPhase: TurnPhase;
 	idleSecs: number;
@@ -292,6 +303,7 @@ export interface ChatSession {
 	backendId?: string | null;
 	workflowNodeSession?: boolean;
 	workflowNodeContext?: WorkflowNodeContext | null;
+	lastTurnInterruption?: TurnInterruption | null;
 }
 
 export function getTextContent(parts: MessagePart[]): string {


### PR DESCRIPTION
## 概要

Agent セッションのターン進行中にタブを閉じる・backend を切り替える・アプリを終了した場合でも、ターンを確実に終端する。

終了処理を「streaming flush 強制 → backend 最終イベントの有界 drain → `SessionClosed` 理由で finalize → runtime close」の順に統一し、再オープン後に本文欠落・永久スピナー・操作不能な permission が残る問題（RT-1）を解消する。

## 変更点

- `close_session` / `set_session_backend` / `close_all` の終了手順を Rust usecase に統一
- `InterruptReason::SessionClosed` を domain / event log に additive で追加
- 未解決 permission と進行中 ToolCall を既存 finalize 経路で終端
- terminal event batch を append-only segment と atomic rename で永続化
- backend-owned の中断 read model を追加し、対象メッセージに中断チップを表示
- application lifecycle の shutdown 順序を usecase 境界へ移動
- close・backend 切替・アプリ終了・再オープンを含むシナリオテストと spec を追加

## 関連

- Closes #1405
- milestone 84「Agentチャット安定化」Phase 0 / L4
- 監査問題 **RT-1** / 不変条件 **I1（turn 終端保証）**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * セッション終了中の進行中ターンを安全に中断し、再オープン後も本文や終了状態を保持できるようになりました。
  * セッション終了による中断理由「セッション終了」を表示できるようになりました。
  * 終了時に権限確認やバックグラウンド処理が残らず、再起動後も状態が復元されます。

* **バグ修正**
  * アプリ終了時にストリーミング内容が欠落したり、スピナーが残り続けたりする問題を改善しました。
  * 終了処理に失敗した場合、アプリを終了せず再試行できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->