### PR TITLE
feat(workflow): workflow facet/schema/diagnostics の拡張

### DIFF
--- a/docs/examples/full-pipeline.yml
+++ b/docs/examples/full-pipeline.yml
@@ -144,7 +144,9 @@ nodes:
       gate: approval
       facets:
         policy: triage
-        knowledge: releash-thread
+        knowledge:
+          - releash-thread
+          - releash-review
         instruction: decide-thread-fix   # item（{{ item.thread_id }}）で参照
     input: thread                        # パラメータ。fanout の各要素が入る
     artifact: fix_result

--- a/docs/workflow-yaml-syntax.md
+++ b/docs/workflow-yaml-syntax.md
@@ -82,7 +82,9 @@ kind block が無い、または複数ある Node は parse / shape Diagnostic �
     gate: approval        # auto | approval
     facets:
       policy: reviewing
-      knowledge: releash-review
+      knowledge:
+        - releash-thread
+        - releash-review
       instruction: review-diff
   artifact: review_verdict
 ```
@@ -91,6 +93,8 @@ kind block が無い、または複数ある Node は parse / shape Diagnostic �
 - `permission`: 必須。許可値は `ask` / `edit` / `full` の三つ。
 - `gate`: 必須。`auto` または `approval`。
 - `facets`: `policy` / `knowledge` / `instruction` の名前参照。session は少なくとも一つの facet 参照を持つ。
+- `knowledge` は単一参照なら `knowledge: releash-review` の scalar、複数参照なら上の例のような配列で書ける。配列の宣言順は保持され、同じ参照を複数回書いた場合も重複排除しない。`policy` と `instruction` は単一の scalar 参照だけを受理する。
+- user message の facet 部分は、全 Knowledge 本文を宣言順に並べ、その後に Instruction 本文を置いて、それぞれを `\n\n` で連結する。つまり上の例は `releash-thread` の本文、`releash-review` の本文、`review-diff` の本文の順になる。
 - `artifact` がある session は、同じ Contract に対する検証済み Artifact の提出が完了するまで Node 完了にならない。提出と repair は共通の Contract 機構を使う。
 - `gate: auto` は Artifact 条件を満たした後に自動完了する。
 - `gate: approval` は Artifact 条件を満たした後も人間の承認まで `waiting_approval` に留まる。承認しない場合は同じ session に追加指示できる。別の却下・再実行操作は持たない。

--- a/src-tauri/src/adaptor/gateway/workflow/builtin.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin.rs
@@ -782,10 +782,16 @@ mod tests {
                 );
                 top_resolved_count += 1;
             }
-            if session.facets.knowledge.is_some() {
+            if !session.facets.knowledge.is_empty() {
                 assert!(
-                    contents.knowledge.is_some(),
-                    "node '{}' has knowledge ref but facet contents knowledge is None",
+                    !contents.knowledge.is_empty(),
+                    "node '{}' has knowledge refs but facet contents knowledge is empty",
+                    node.name
+                );
+                assert_eq!(
+                    contents.knowledge.len(),
+                    session.facets.knowledge.len(),
+                    "node '{}' must resolve every knowledge ref",
                     node.name
                 );
                 top_resolved_count += 1;

--- a/src-tauri/src/adaptor/gateway/workflow/definition_repository.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/definition_repository.rs
@@ -395,4 +395,45 @@ nodes:
         );
         assert!(!workflows.path().join("-invalid.yml").exists());
     }
+
+    #[test]
+    fn source_gateway_returns_structured_diagnostic_for_missing_knowledge() {
+        let workflows = TempDir::new().unwrap();
+        let facets = TempDir::new().unwrap();
+        let knowledge = facets.path().join("knowledge");
+        fs::create_dir_all(&knowledge).unwrap();
+        fs::write(knowledge.join("known.md"), "Known context.").unwrap();
+        let gateway = WorkflowDefinitionFileSourceGateway::new(workflows.path(), facets.path());
+        let source = r#"
+name: missing-knowledge
+description: missing knowledge diagnostic
+nodes:
+  - name: node
+    session:
+      permission: edit
+      gate: auto
+      facets:
+        knowledge: [known, missing-name]
+"#;
+
+        let error = gateway
+            .save_source_with_diagnostics(source, None)
+            .unwrap_err();
+        let WorkflowSourceSaveError::Diagnostics(items) = error else {
+            panic!("missing knowledge must remain a structured diagnostic");
+        };
+        let diagnostic = items
+            .iter()
+            .find(|item| item["code"] == "FAC002")
+            .expect("missing knowledge FAC002");
+        assert_eq!(diagnostic["workflow_name"], "missing-knowledge");
+        assert_eq!(diagnostic["node_name"], "node");
+        assert_eq!(diagnostic["facet_key"], "missing-name");
+        assert_eq!(diagnostic["facet_kind"], "knowledge");
+        assert_eq!(diagnostic["field"], "knowledge");
+        assert!(diagnostic["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("missing-name")));
+        assert!(!workflows.path().join("missing-knowledge.yml").exists());
+    }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -979,6 +979,84 @@ fn collect_all_facet_keys(base_dir: &Path) -> HashSet<String> {
     keys
 }
 
+fn collect_referenced_facet_keys(
+    workflow: &WorkflowDefinitionYaml,
+    base_dir: &Path,
+) -> Result<HashSet<String>, facet::FacetError> {
+    let mut checked = HashSet::new();
+    let mut existing = HashSet::new();
+    for node in &workflow.nodes {
+        let Some(session) = node.session() else {
+            continue;
+        };
+        if let Some(key) = session.facets.policy.as_deref() {
+            collect_existing_facet_key(
+                &mut checked,
+                &mut existing,
+                FacetKind::Policy,
+                key,
+                base_dir,
+            )?;
+        }
+        for key in &session.facets.knowledge {
+            collect_existing_facet_key(
+                &mut checked,
+                &mut existing,
+                FacetKind::Knowledge,
+                key,
+                base_dir,
+            )?;
+        }
+        if let Some(key) = session.facets.instruction.as_deref() {
+            collect_existing_facet_key(
+                &mut checked,
+                &mut existing,
+                FacetKind::Instruction,
+                key,
+                base_dir,
+            )?;
+        }
+    }
+    Ok(existing)
+}
+
+fn collect_existing_facet_key(
+    checked: &mut HashSet<String>,
+    existing: &mut HashSet<String>,
+    kind: FacetKind,
+    key: &str,
+    base_dir: &Path,
+) -> Result<(), facet::FacetError> {
+    let facet_id = format!("{}/{}", kind.canonical_name(), key);
+    if checked.insert(facet_id.clone()) && facet::facet_exists(kind, key, base_dir)? {
+        existing.insert(facet_id);
+    }
+    Ok(())
+}
+
+/// Load/save の解決前に、workflow が参照する facet の存在を構造化 Diagnostic として検査する。
+///
+/// `diagnose_all` と同じ FAC002 shape を返すことで、source editor と runtime loader の
+/// どちらでも欠損した参照名・node・slot を失わない。facet inventory 自体を読めない場合は
+/// I/O error を欠損参照へ誤分類せず、そのまま caller へ伝搬する。
+pub(crate) fn diagnose_workflow_facet_references(
+    workflow: &WorkflowDefinitionYaml,
+    facets_base_dir: &Path,
+) -> Result<Vec<DiagnosticItem>, facet::FacetError> {
+    let all_facet_keys = collect_referenced_facet_keys(workflow, facets_base_dir)?;
+    let mut items = Vec::new();
+    let mut workflow_summaries = HashMap::new();
+    let mut facet_usage = HashMap::new();
+    check_workflow_facet_references(
+        workflow,
+        &all_facet_keys,
+        &mut items,
+        &mut workflow_summaries,
+        &mut facet_usage,
+    );
+    Ok(items)
+}
+
 /// ディスク + builtin のワークフロー一覧を読み込み
 fn load_all_workflows(dir: &Path, facets_base_dir: &Path) -> Vec<NamedWorkflowDiagnostics> {
     let mut results = Vec::new();
@@ -1164,7 +1242,17 @@ fn diagnose_workflow(
         add_diagnostic(items, workflow_summaries, name, item);
     }
 
-    // 各nodeを診断
+    check_workflow_facet_references(wf, all_facet_keys, items, workflow_summaries, facet_usage);
+}
+
+fn check_workflow_facet_references(
+    wf: &WorkflowDefinitionYaml,
+    all_facet_keys: &HashSet<String>,
+    items: &mut Vec<DiagnosticItem>,
+    workflow_summaries: &mut HashMap<String, DiagnosticSummary>,
+    facet_usage: &mut HashMap<String, Vec<FacetUsageEntry>>,
+) {
+    let name = &wf.name;
     for node in &wf.nodes {
         // ファセット参照の存在チェック + usage 記録
         FacetRefCheckContext::new(name, all_facet_keys, items, workflow_summaries, facet_usage)
@@ -1176,7 +1264,8 @@ fn diagnose_workflow(
                         .and_then(|session| session.facets.policy.as_deref()),
                     knowledge: node
                         .session()
-                        .and_then(|session| session.facets.knowledge.as_deref()),
+                        .map(|session| session.facets.knowledge.as_slice())
+                        .unwrap_or_default(),
                     instruction: node
                         .session()
                         .and_then(|session| session.facets.instruction.as_deref()),
@@ -1187,7 +1276,7 @@ fn diagnose_workflow(
 
 struct FacetRefs<'a> {
     policy: Option<&'a str>,
-    knowledge: Option<&'a str>,
+    knowledge: &'a [String],
     instruction: Option<&'a str>,
 }
 
@@ -1263,19 +1352,14 @@ impl<'a> FacetRefCheckContext<'a> {
 
     /// 1 つの node が持つ全 facet ref を一括検査する。
     fn check_node(&mut self, node_name: &str, facet_refs: &FacetRefs<'_>) {
-        let singles: &[(&str, FacetKind, Option<&str>)] = &[
-            ("policy", FacetKind::Policy, facet_refs.policy),
-            ("knowledge", FacetKind::Knowledge, facet_refs.knowledge),
-            (
-                "instruction",
-                FacetKind::Instruction,
-                facet_refs.instruction,
-            ),
-        ];
-        for (slot, kind, key_opt) in singles {
-            if let Some(key) = key_opt {
-                self.check(node_name, slot, *kind, key);
-            }
+        if let Some(key) = facet_refs.policy {
+            self.check(node_name, "policy", FacetKind::Policy, key);
+        }
+        for key in facet_refs.knowledge {
+            self.check(node_name, "knowledge", FacetKind::Knowledge, key);
+        }
+        if let Some(key) = facet_refs.instruction {
+            self.check(node_name, "instruction", FacetKind::Instruction, key);
         }
     }
 }
@@ -1499,6 +1583,96 @@ mod tests {
         fs::create_dir_all(dir).unwrap();
         let content = serde_saphyr::to_string(wf).unwrap();
         fs::write(dir.join(format!("{}.yml", wf.name)), content).unwrap();
+    }
+
+    #[test]
+    fn collect_all_facet_keys_preserves_healthy_kinds_when_one_inventory_fails() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("policies"), "not a directory").unwrap();
+        setup_facet(tmp.path(), "knowledge", "known", "known content");
+
+        let keys = collect_all_facet_keys(tmp.path());
+
+        assert!(keys.contains("knowledge/known"));
+    }
+
+    #[test]
+    fn reference_diagnostics_ignore_unreferenced_broken_facet_inventory() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("policies"), "not a directory").unwrap();
+        setup_facet(tmp.path(), "knowledge", "known", "known content");
+        let workflow = WorkflowDefinitionYaml {
+            name: "knowledge-only".to_string(),
+            description: "knowledge-only diagnostic".to_string(),
+            nodes: vec![NodeDefinition {
+                name: "node".to_string(),
+                kind: NodeKind::Session(SessionSpec {
+                    facets: FacetRefs {
+                        knowledge: vec!["known".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let diagnostics = diagnose_workflow_facet_references(&workflow, tmp.path()).unwrap();
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reference_diagnostics_propagate_referenced_broken_facet_inventory_error() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("policies"), "not a directory").unwrap();
+        let workflow = WorkflowDefinitionYaml {
+            name: "custom-policy".to_string(),
+            description: "custom policy diagnostic".to_string(),
+            nodes: vec![NodeDefinition {
+                name: "node".to_string(),
+                kind: NodeKind::Session(SessionSpec {
+                    facets: FacetRefs {
+                        policy: Some("custom-policy".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let error = diagnose_workflow_facet_references(&workflow, tmp.path()).unwrap_err();
+
+        assert!(matches!(error, facet::FacetError::Io(_)));
+    }
+
+    #[test]
+    fn reference_diagnostics_short_circuit_broken_inventory_for_builtin_facet() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("knowledge"), "not a directory").unwrap();
+        let workflow = WorkflowDefinitionYaml {
+            name: "builtin-knowledge".to_string(),
+            description: "builtin knowledge diagnostic".to_string(),
+            nodes: vec![NodeDefinition {
+                name: "node".to_string(),
+                kind: NodeKind::Session(SessionSpec {
+                    facets: FacetRefs {
+                        knowledge: vec!["releash-thread-cli".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let diagnostics = diagnose_workflow_facet_references(&workflow, tmp.path()).unwrap();
+
+        assert!(diagnostics.is_empty());
     }
 
     fn fixture_dir(kind: &str) -> std::path::PathBuf {
@@ -2106,21 +2280,40 @@ nodes:
     fn diagnose_missing_facet_ref() {
         let tmp = TempDir::new().unwrap();
         let wf_dir = tmp.path();
+        setup_facet(wf_dir, "knowledge", "known", "known content");
 
         let wf = WorkflowDefinitionYaml {
             name: "test-wf".to_string(),
             description: "test".to_string(),
             builtin: false,
             schemas: Default::default(),
-            nodes: vec![make_node("node1", Some("nonexistent-instruction"))],
+            nodes: vec![NodeDefinition {
+                name: "node1".to_string(),
+                kind: NodeKind::Session(SessionSpec {
+                    permission: Some("edit".to_string()),
+                    facets: FacetRefs {
+                        knowledge: vec!["known".to_string(), "missing-knowledge".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
         };
         save_workflow_yaml(wf_dir, &wf);
 
         let report = diagnose_all(wf_dir, wf_dir);
-        assert!(report
+        let missing = report
             .items
             .iter()
-            .any(|i| i.severity == Severity::Error && i.message.contains("存在しないファセット")));
+            .find(|item| item.code == "FAC002")
+            .expect("missing knowledge FAC002");
+        assert_eq!(missing.workflow_name.as_deref(), Some("test-wf"));
+        assert_eq!(missing.node_name.as_deref(), Some("node1"));
+        assert_eq!(missing.facet_key.as_deref(), Some("missing-knowledge"));
+        assert_eq!(missing.facet_kind.as_deref(), Some("knowledge"));
+        assert_eq!(missing.field.as_deref(), Some("knowledge"));
+        assert!(missing.message.contains("missing-knowledge"));
     }
 
     #[test]
@@ -2530,6 +2723,46 @@ nodes:
         assert!(usage.is_some());
         assert_eq!(usage.unwrap().len(), 1);
         assert_eq!(usage.unwrap()[0].workflow_name, "test-wf");
+    }
+
+    #[test]
+    fn diagnose_tracks_each_knowledge_reference_usage() {
+        let tmp = TempDir::new().unwrap();
+        let wf_dir = tmp.path();
+        setup_facet(wf_dir, "knowledge", "first", "first content");
+        setup_facet(wf_dir, "knowledge", "second", "second content");
+
+        let wf = WorkflowDefinitionYaml {
+            name: "knowledge-usage".to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            schemas: Default::default(),
+            nodes: vec![NodeDefinition {
+                name: "node1".to_string(),
+                kind: NodeKind::Session(SessionSpec {
+                    permission: Some("edit".to_string()),
+                    facets: FacetRefs {
+                        knowledge: vec!["first".to_string(), "second".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+        };
+        save_workflow_yaml(wf_dir, &wf);
+
+        let report = diagnose_all(wf_dir, wf_dir);
+        for facet_id in ["knowledge/first", "knowledge/second"] {
+            let usages = report
+                .facet_usage
+                .get(facet_id)
+                .unwrap_or_else(|| panic!("missing usage for {facet_id}"));
+            assert_eq!(usages.len(), 1);
+            assert_eq!(usages[0].workflow_name, "knowledge-usage");
+            assert_eq!(usages[0].node_name, "node1");
+            assert_eq!(usages[0].slot, "knowledge");
+        }
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/domain_mapping.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/domain_mapping.rs
@@ -301,6 +301,7 @@ mod tests {
                 name: "implement".to_string(),
                 kind: schema::NodeKind::Session(schema::SessionSpec {
                     facets: schema::FacetRefs {
+                        knowledge: vec!["knowledge-a".to_string(), "knowledge-b".to_string()],
                         instruction: Some("inst".to_string()),
                         ..Default::default()
                     },
@@ -312,6 +313,10 @@ mod tests {
 
         let mapped = workflow_definition_to_domain(&workflow);
 
+        assert_eq!(
+            mapped.nodes[0].session().unwrap().facets.knowledge,
+            vec!["knowledge-a", "knowledge-b"]
+        );
         assert_eq!(
             mapped.nodes[0]
                 .session()

--- a/src-tauri/src/adaptor/gateway/workflow/event.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event.rs
@@ -332,6 +332,70 @@ mod tests {
     }
 
     #[test]
+    fn execution_started_reads_legacy_scalar_knowledge_snapshot() {
+        let event = WorkflowEvent::ExecutionStarted {
+            execution_id: "00000000-0000-4000-8000-000000000001".to_string(),
+            workflow_name: "wf".to_string(),
+            worktree_path: "/repo".to_string(),
+            created_from: ExecutionOrigin::Cli,
+            request: "review".to_string(),
+            permission_mode: crate::domain::agent_session::PermissionMode::EDIT.to_string(),
+            definition: minimal_workflow(),
+            timestamp: 1.0,
+        };
+        let mut value = serde_json::to_value(event).unwrap();
+        value["definition"]["nodes"][0]["session"]["facets"]["knowledge"] =
+            serde_json::json!("legacy-knowledge");
+
+        let restored = serde_json::from_value::<WorkflowEvent>(value).unwrap();
+        let WorkflowEvent::ExecutionStarted { definition, .. } = &restored else {
+            panic!("expected execution_started event");
+        };
+        assert_eq!(
+            definition.nodes[0].session().unwrap().facets.knowledge,
+            vec!["legacy-knowledge"]
+        );
+
+        let serialized = serde_json::to_value(restored).unwrap();
+        assert_eq!(
+            serialized["definition"]["nodes"][0]["session"]["facets"]["knowledge"],
+            serde_json::json!("legacy-knowledge")
+        );
+    }
+
+    #[test]
+    fn execution_started_round_trips_multiple_knowledge_snapshot() {
+        let mut definition = minimal_workflow();
+        definition.nodes[0].session_mut().unwrap().facets.knowledge =
+            vec!["knowledge-a".to_string(), "knowledge-b".to_string()];
+        let event = WorkflowEvent::ExecutionStarted {
+            execution_id: "00000000-0000-4000-8000-000000000001".to_string(),
+            workflow_name: "wf".to_string(),
+            worktree_path: "/repo".to_string(),
+            created_from: ExecutionOrigin::Cli,
+            request: "review".to_string(),
+            permission_mode: crate::domain::agent_session::PermissionMode::EDIT.to_string(),
+            definition,
+            timestamp: 1.0,
+        };
+
+        let serialized = serde_json::to_value(&event).unwrap();
+        assert_eq!(
+            serialized["definition"]["nodes"][0]["session"]["facets"]["knowledge"],
+            serde_json::json!(["knowledge-a", "knowledge-b"])
+        );
+
+        let restored = serde_json::from_value::<WorkflowEvent>(serialized).unwrap();
+        let WorkflowEvent::ExecutionStarted { definition, .. } = restored else {
+            panic!("expected execution_started event");
+        };
+        assert_eq!(
+            definition.nodes[0].session().unwrap().facets.knowledge,
+            vec!["knowledge-a", "knowledge-b"]
+        );
+    }
+
+    #[test]
     fn execution_started_without_permission_mode_is_rejected() {
         let event = WorkflowEvent::ExecutionStarted {
             execution_id: "00000000-0000-4000-8000-000000000001".to_string(),

--- a/src-tauri/src/adaptor/gateway/workflow/facet.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/facet.rs
@@ -129,13 +129,13 @@ pub struct ComposedPrompt {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FacetContents {
     pub policy: Option<String>,
-    pub knowledge: Option<String>,
+    pub knowledge: Vec<String>,
     pub instruction: Option<String>,
 }
 
 impl FacetContents {
     pub fn is_empty(&self) -> bool {
-        self.policy.is_none() && self.knowledge.is_none() && self.instruction.is_none()
+        self.policy.is_none() && self.knowledge.is_empty() && self.instruction.is_none()
     }
 }
 
@@ -211,6 +211,19 @@ pub fn load_facet(kind: FacetKind, key: &str, base_dir: &Path) -> Result<String,
         kind,
         key: key.to_string(),
     })
+}
+
+pub(crate) fn facet_exists(
+    kind: FacetKind,
+    key: &str,
+    base_dir: &Path,
+) -> Result<bool, FacetError> {
+    validate_facet_key(key)?;
+    if builtin::is_builtin_facet(kind, key) {
+        return Ok(true);
+    }
+    let path = base_dir.join(kind.dir_name()).join(format!("{key}.md"));
+    Ok(path.try_exists()?)
 }
 
 pub fn save_facet(
@@ -372,12 +385,9 @@ fn compose_from_parts(resolved: &FacetContents) -> ComposedPrompt {
         Some(system_parts.join("\n\n"))
     };
 
-    let mut user_parts: Vec<String> = Vec::new();
-    if let Some(ref content) = resolved.knowledge {
-        user_parts.push(content.clone());
-    }
-    if let Some(ref content) = resolved.instruction {
-        user_parts.push(content.clone());
+    let mut user_parts: Vec<&str> = resolved.knowledge.iter().map(String::as_str).collect();
+    if let Some(content) = resolved.instruction.as_deref() {
+        user_parts.push(content);
     }
     ComposedPrompt {
         system_prompt,
@@ -420,10 +430,11 @@ fn resolve_refs(facets: &FacetRefs, base_dir: &Path) -> Result<FacetContents, Fa
         Some(k) => Some(load_facet(FacetKind::Policy, k, base_dir)?),
         None => None,
     };
-    let resolved_knowledge = match facets.knowledge.as_deref() {
-        Some(k) => Some(load_facet(FacetKind::Knowledge, k, base_dir)?),
-        None => None,
-    };
+    let resolved_knowledge = facets
+        .knowledge
+        .iter()
+        .map(|key| load_facet(FacetKind::Knowledge, key, base_dir))
+        .collect::<Result<Vec<_>, _>>()?;
     let resolved_instruction = match facets.instruction.as_deref() {
         Some(k) => Some(load_facet(FacetKind::Instruction, k, base_dir)?),
         None => None,
@@ -467,7 +478,7 @@ mod tests {
 
     fn make_facet_node(
         policy: Option<&str>,
-        knowledge: Option<&str>,
+        knowledge: &[&str],
         instruction: Option<&str>,
     ) -> NodeDefinition {
         NodeDefinition {
@@ -475,7 +486,7 @@ mod tests {
             kind: NodeKind::Session(SessionSpec {
                 facets: FacetRefs {
                     policy: policy.map(String::from),
-                    knowledge: knowledge.map(String::from),
+                    knowledge: knowledge.iter().map(|key| (*key).to_string()).collect(),
                     instruction: instruction.map(String::from),
                 },
                 ..Default::default()
@@ -642,7 +653,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_facet_files(tmp.path());
 
-        let node = make_facet_node(Some("coding"), Some("architecture"), Some("implement"));
+        let node = make_facet_node(Some("coding"), &["architecture"], Some("implement"));
         let resolved = resolve_node_facets(&node, tmp.path()).unwrap();
         let result = compose_facets(Some(&resolved));
 
@@ -658,7 +669,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_facet_files(tmp.path());
 
-        let node = make_facet_node(Some("coding"), None, None);
+        let node = make_facet_node(Some("coding"), &[], None);
         let resolved = resolve_node_facets(&node, tmp.path()).unwrap();
         let result = compose_facets(Some(&resolved));
 
@@ -748,7 +759,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_facet_files(tmp.path());
 
-        let node = make_facet_node(None, Some("architecture"), Some("implement"));
+        let node = make_facet_node(None, &["architecture"], Some("implement"));
         let resolved = resolve_node_facets(&node, tmp.path()).unwrap();
         let result = compose_facets(Some(&resolved));
 
@@ -761,7 +772,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_facet_files(tmp.path());
 
-        let node = make_facet_node(None, Some("architecture"), Some("implement"));
+        let node = make_facet_node(None, &["architecture"], Some("implement"));
         let resolved = resolve_node_facets(&node, tmp.path()).unwrap();
         let result = compose_facets(Some(&resolved));
 
@@ -779,7 +790,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_facet_files(tmp.path());
 
-        let node = make_facet_node(Some("coding"), None, None);
+        let node = make_facet_node(Some("coding"), &[], None);
         let resolved = resolve_node_facets(&node, tmp.path()).unwrap();
         let result = compose_facets(Some(&resolved));
 
@@ -791,7 +802,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_facet_files(tmp.path());
 
-        let node = make_facet_node(Some("coding"), Some("architecture"), Some("implement"));
+        let node = make_facet_node(Some("coding"), &["architecture"], Some("implement"));
         let resolved = resolve_node_facets(&node, tmp.path()).unwrap();
         let result = compose_facets(Some(&resolved));
 
@@ -801,13 +812,63 @@ mod tests {
         assert!(result.user_message.contains("Implement the feature."));
     }
 
+    #[test]
+    fn compose_multiple_knowledge_in_declaration_order_before_instruction_once_each() {
+        let tmp = TempDir::new().unwrap();
+        let knowledge_dir = tmp.path().join("knowledge");
+        let instructions_dir = tmp.path().join("instructions");
+        fs::create_dir_all(&knowledge_dir).unwrap();
+        fs::create_dir_all(&instructions_dir).unwrap();
+        fs::write(knowledge_dir.join("knowledge-a.md"), "KNOWLEDGE_A").unwrap();
+        fs::write(knowledge_dir.join("knowledge-b.md"), "KNOWLEDGE_B").unwrap();
+        fs::write(instructions_dir.join("instruction.md"), "INSTRUCTION").unwrap();
+
+        let node = make_facet_node(None, &["knowledge-a", "knowledge-b"], Some("instruction"));
+        let resolved = resolve_node_facets(&node, tmp.path()).unwrap();
+        let result = compose_facets(Some(&resolved));
+
+        assert_eq!(
+            resolved.knowledge,
+            vec!["KNOWLEDGE_A".to_string(), "KNOWLEDGE_B".to_string()]
+        );
+        assert_eq!(
+            result.user_message,
+            "KNOWLEDGE_A\n\nKNOWLEDGE_B\n\nINSTRUCTION"
+        );
+        for sentinel in ["KNOWLEDGE_A", "KNOWLEDGE_B", "INSTRUCTION"] {
+            assert_eq!(
+                result.user_message.matches(sentinel).count(),
+                1,
+                "{sentinel} must be composed exactly once"
+            );
+        }
+    }
+
+    #[test]
+    fn compose_duplicate_knowledge_references_without_deduplication() {
+        let tmp = TempDir::new().unwrap();
+        let knowledge_dir = tmp.path().join("knowledge");
+        let instructions_dir = tmp.path().join("instructions");
+        fs::create_dir_all(&knowledge_dir).unwrap();
+        fs::create_dir_all(&instructions_dir).unwrap();
+        fs::write(knowledge_dir.join("repeated.md"), "KNOWLEDGE").unwrap();
+        fs::write(instructions_dir.join("instruction.md"), "INSTRUCTION").unwrap();
+
+        let node = make_facet_node(None, &["repeated", "repeated"], Some("instruction"));
+        let resolved = resolve_node_facets(&node, tmp.path()).unwrap();
+        let result = compose_facets(Some(&resolved));
+
+        assert_eq!(resolved.knowledge, vec!["KNOWLEDGE", "KNOWLEDGE"]);
+        assert_eq!(result.user_message, "KNOWLEDGE\n\nKNOWLEDGE\n\nINSTRUCTION");
+    }
+
     /// 解決経路における欠損 facet は load 時 (`resolve_refs`) で NotFound として
     /// 弾かれる。`compose_facets` 自体は I/O fallback を持たず、unresolved な node を
     /// 受け取った場合は空合成結果になる（実 production では load 経路で先に弾かれる）。
     #[test]
     fn resolve_with_missing_facet_returns_error() {
         let tmp = TempDir::new().unwrap();
-        let node = make_facet_node(Some("nonexistent"), None, None);
+        let node = make_facet_node(Some("nonexistent"), &[], None);
         let result = resolve_node_facets(&node, tmp.path());
         assert!(matches!(result.unwrap_err(), FacetError::NotFound { .. }));
     }
@@ -815,15 +876,42 @@ mod tests {
     #[test]
     fn resolve_with_missing_knowledge_returns_error() {
         let tmp = TempDir::new().unwrap();
-        let node = make_facet_node(None, Some("nonexistent"), None);
+        let node = make_facet_node(None, &["nonexistent"], None);
         let result = resolve_node_facets(&node, tmp.path());
         assert!(matches!(result.unwrap_err(), FacetError::NotFound { .. }));
     }
 
     #[test]
+    fn resolve_multiple_knowledge_reports_missing_second_key() {
+        let tmp = TempDir::new().unwrap();
+        setup_facet_files(tmp.path());
+        let node = make_facet_node(None, &["architecture", "missing-second"], None);
+
+        let error = resolve_node_facets(&node, tmp.path()).unwrap_err();
+
+        assert!(matches!(
+            error,
+            FacetError::NotFound {
+                kind: FacetKind::Knowledge,
+                key,
+            } if key == "missing-second"
+        ));
+    }
+
+    #[test]
+    fn facet_contents_with_knowledge_is_not_empty() {
+        assert!(FacetContents::default().is_empty());
+        assert!(!FacetContents {
+            knowledge: vec!["KNOWLEDGE".to_string()],
+            ..Default::default()
+        }
+        .is_empty());
+    }
+
+    #[test]
     fn resolve_with_missing_instruction_returns_error() {
         let tmp = TempDir::new().unwrap();
-        let node = make_facet_node(None, None, Some("nonexistent"));
+        let node = make_facet_node(None, &[], Some("nonexistent"));
         let result = resolve_node_facets(&node, tmp.path());
         assert!(matches!(result.unwrap_err(), FacetError::NotFound { .. }));
     }
@@ -846,7 +934,7 @@ mod tests {
         .unwrap();
         std::fs::write(instructions.join("impl.md"), "Task: {{ request }}").unwrap();
 
-        let node = make_facet_node(Some("coding"), None, Some("impl"));
+        let node = make_facet_node(Some("coding"), &[], Some("impl"));
         let resolved = resolve_node_facets(&node, tmp.path()).unwrap();
         let composed = compose_facets(Some(&resolved));
 

--- a/src-tauri/src/adaptor/gateway/workflow/mapper.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/mapper.rs
@@ -395,6 +395,11 @@ mod tests {
                 name: "node".to_string(),
                 kind: NodeKind::Session(SessionSpec {
                     facets: FacetRefs {
+                        knowledge: vec![
+                            "knowledge-a".to_string(),
+                            "knowledge-b".to_string(),
+                            "knowledge-a".to_string(),
+                        ],
                         instruction: Some("inst".to_string()),
                         ..Default::default()
                     },
@@ -406,6 +411,10 @@ mod tests {
 
         let schema = domain_workflow_to_schema(&definition).unwrap();
         assert_eq!(
+            schema.nodes[0].session().unwrap().facets.knowledge,
+            vec!["knowledge-a", "knowledge-b", "knowledge-a"]
+        );
+        assert_eq!(
             schema.nodes[0]
                 .session()
                 .unwrap()
@@ -416,6 +425,7 @@ mod tests {
         );
 
         let mapped = schema_workflow_to_domain(schema).unwrap();
+        assert_eq!(mapped, definition);
         assert_eq!(
             mapped.nodes[0]
                 .session()

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -3922,7 +3922,8 @@ fn build_fanout_child_prompt_splits_facets_into_system_and_user() {
     std::fs::create_dir_all(&instructions).unwrap();
     std::fs::create_dir_all(&contracts).unwrap();
     std::fs::write(policies.join("pol.md"), "FANOUT_POLICY_BODY").unwrap();
-    std::fs::write(knowledges.join("know.md"), "FANOUT_KNOWLEDGE_BODY").unwrap();
+    std::fs::write(knowledges.join("know-a.md"), "FANOUT_KNOWLEDGE_A_BODY").unwrap();
+    std::fs::write(knowledges.join("know-b.md"), "FANOUT_KNOWLEDGE_B_BODY").unwrap();
     std::fs::write(instructions.join("inst.md"), "FANOUT_INSTRUCTION_BODY").unwrap();
     std::fs::write(contracts.join("oc.md"), "FANOUT_CONTRACT_BODY").unwrap();
 
@@ -3931,7 +3932,7 @@ fn build_fanout_child_prompt_splits_facets_into_system_and_user() {
         &mut child,
         FacetRefs {
             policy: Some("pol".to_string()),
-            knowledge: Some("know".to_string()),
+            knowledge: vec!["know-a".to_string(), "know-b".to_string()],
             instruction: Some("inst".to_string()),
         },
     );
@@ -3954,11 +3955,23 @@ fn build_fanout_child_prompt_splits_facets_into_system_and_user() {
     let sp = system_prompt.expect("system_prompt must be set for fanout child with policy/oc");
     // policy の本文が system_prompt に集約される
     assert!(sp.contains("FANOUT_POLICY_BODY"));
-    assert!(!sp.contains("FANOUT_KNOWLEDGE_BODY"));
+    assert!(!sp.contains("FANOUT_KNOWLEDGE_A_BODY"));
+    assert!(!sp.contains("FANOUT_KNOWLEDGE_B_BODY"));
     assert!(!sp.contains("FANOUT_INSTRUCTION_BODY"));
 
     // knowledge / instruction と Artifact 由来の完了時アクションは user_message に集約される。
-    assert!(user_message.contains("FANOUT_KNOWLEDGE_BODY"));
+    let knowledge_a = user_message.find("FANOUT_KNOWLEDGE_A_BODY").unwrap();
+    let knowledge_b = user_message.find("FANOUT_KNOWLEDGE_B_BODY").unwrap();
+    let instruction_position = user_message.find("FANOUT_INSTRUCTION_BODY").unwrap();
+    assert!(knowledge_a < knowledge_b);
+    assert!(knowledge_b < instruction_position);
+    for sentinel in [
+        "FANOUT_KNOWLEDGE_A_BODY",
+        "FANOUT_KNOWLEDGE_B_BODY",
+        "FANOUT_INSTRUCTION_BODY",
+    ] {
+        assert_eq!(user_message.matches(sentinel).count(), 1);
+    }
     assert!(user_message.contains("FANOUT_INSTRUCTION_BODY"));
     let instruction = workflow_prompt::render_fanout_child_workflow_instruction(
         &child,

--- a/src-tauri/src/adaptor/gateway/workflow/schema.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/schema.rs
@@ -109,15 +109,20 @@ pub enum SessionGate {
 pub struct FacetRefs {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub knowledge: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_one_or_many_strings",
+        serialize_with = "serialize_one_or_many_strings",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub knowledge: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instruction: Option<String>,
 }
 
 impl FacetRefs {
     pub fn is_empty(&self) -> bool {
-        self.policy.is_none() && self.knowledge.is_none() && self.instruction.is_none()
+        self.policy.is_none() && self.knowledge.is_empty() && self.instruction.is_none()
     }
 }
 
@@ -137,8 +142,8 @@ pub struct SessionSpec {
 #[serde(deny_unknown_fields)]
 pub struct FanoutSpec {
     #[serde(
-        deserialize_with = "deserialize_fanout_children",
-        serialize_with = "serialize_fanout_children"
+        deserialize_with = "deserialize_one_or_many_strings",
+        serialize_with = "serialize_one_or_many_strings"
     )]
     pub child: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -153,28 +158,28 @@ pub enum ItemsSource {
 
 #[derive(Deserialize)]
 #[serde(untagged)]
-enum RawFanoutChildren {
+enum RawOneOrManyStrings {
     One(String),
     Many(Vec<String>),
 }
 
-fn deserialize_fanout_children<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+fn deserialize_one_or_many_strings<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    match RawFanoutChildren::deserialize(deserializer)? {
-        RawFanoutChildren::One(child) => Ok(vec![child]),
-        RawFanoutChildren::Many(children) => Ok(children),
+    match RawOneOrManyStrings::deserialize(deserializer)? {
+        RawOneOrManyStrings::One(value) => Ok(vec![value]),
+        RawOneOrManyStrings::Many(values) => Ok(values),
     }
 }
 
-fn serialize_fanout_children<S>(children: &[String], serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_one_or_many_strings<S>(values: &[String], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    match children {
-        [child] => serializer.serialize_str(child),
-        children => children.serialize(serializer),
+    match values {
+        [value] => serializer.serialize_str(value),
+        values => values.serialize(serializer),
     }
 }
 
@@ -577,6 +582,104 @@ nodes:
         assert_eq!(session.facets.instruction.as_deref(), Some("implement"));
         assert_eq!(session.facets.policy.as_deref(), Some("coding"));
         assert_eq!(session.gate, SessionGate::Auto);
+    }
+
+    #[test]
+    fn session_knowledge_accepts_scalar_and_sequence_and_preserves_order() {
+        let yaml = r#"
+name: knowledge-shapes
+description: knowledge scalar and sequence
+nodes:
+  - name: scalar
+    session:
+      gate: auto
+      facets:
+        knowledge: releash-thread-cli
+  - name: sequence
+    session:
+      gate: auto
+      facets:
+        knowledge:
+          - releash-thread-cli
+          - requirements-design
+"#;
+
+        let workflow = serde_saphyr::from_str::<WorkflowDefinitionYaml>(yaml).unwrap();
+
+        assert_eq!(
+            workflow.nodes[0].session().unwrap().facets.knowledge,
+            vec!["releash-thread-cli"]
+        );
+        assert_eq!(
+            workflow.nodes[1].session().unwrap().facets.knowledge,
+            vec!["releash-thread-cli", "requirements-design"]
+        );
+    }
+
+    #[test]
+    fn session_knowledge_serializes_one_as_scalar_and_many_as_sequence() {
+        let workflow = WorkflowDefinitionYaml {
+            name: "knowledge-shapes".to_string(),
+            description: String::new(),
+            nodes: vec![
+                NodeDefinition {
+                    name: "scalar".to_string(),
+                    kind: NodeKind::Session(SessionSpec {
+                        facets: FacetRefs {
+                            knowledge: vec!["releash-thread-cli".to_string()],
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                NodeDefinition {
+                    name: "sequence".to_string(),
+                    kind: NodeKind::Session(SessionSpec {
+                        facets: FacetRefs {
+                            knowledge: vec![
+                                "releash-thread-cli".to_string(),
+                                "requirements-design".to_string(),
+                            ],
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let serialized = serde_saphyr::to_string(&workflow).unwrap();
+        let value = serde_saphyr::from_str::<Value>(&serialized).unwrap();
+
+        assert_eq!(
+            value["nodes"][0]["session"]["facets"]["knowledge"],
+            Value::String("releash-thread-cli".to_string())
+        );
+        assert_eq!(
+            value["nodes"][1]["session"]["facets"]["knowledge"],
+            serde_json::json!(["releash-thread-cli", "requirements-design"])
+        );
+    }
+
+    #[test]
+    fn session_knowledge_rejects_non_string_sequence_elements() {
+        let yaml = r#"
+name: invalid-knowledge
+description: invalid knowledge element
+nodes:
+  - name: review
+    session:
+      gate: auto
+      facets:
+        knowledge:
+          - releash-thread-cli
+          - 42
+"#;
+
+        assert!(serde_saphyr::from_str::<WorkflowDefinitionYaml>(yaml).is_err());
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/storage.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/storage.rs
@@ -160,8 +160,7 @@ pub fn parse_workflow_source(
         )])
     })?;
     workflow.builtin = builtin::is_builtin_workflow(&workflow.name);
-    let facet_contents = facet::resolve_workflow_facets(&workflow, facets_base_dir)?;
-    validate_resolved_facet_references(&workflow, &facet_contents)?;
+    let _ = resolve_and_validate_workflow_facets(&workflow, facets_base_dir)?;
     Ok(workflow)
 }
 
@@ -224,8 +223,7 @@ pub fn load_workflow(
     })?;
     // YAMLの builtin フラグは無視し、コード側（builtin.rs）で判定する
     workflow.builtin = builtin::is_builtin_workflow(&workflow.name);
-    let facet_contents = facet::resolve_workflow_facets(&workflow, facets_base_dir)?;
-    validate_resolved_facet_references(&workflow, &facet_contents)?;
+    let _ = resolve_and_validate_workflow_facets(&workflow, facets_base_dir)?;
     Ok(workflow)
 }
 
@@ -337,6 +335,14 @@ pub(crate) fn resolve_and_validate_workflow_facets(
     workflow: &WorkflowDefinitionYaml,
     facets_base_dir: &Path,
 ) -> Result<facet::WorkflowFacetContents, StorageError> {
+    let reference_diagnostics =
+        diagnostics::diagnose_workflow_facet_references(workflow, facets_base_dir)?;
+    if reference_diagnostics
+        .iter()
+        .any(|item| item.severity == diagnostics::Severity::Error)
+    {
+        return Err(StorageError::Diagnostics(reference_diagnostics));
+    }
     let facet_contents = facet::resolve_workflow_facets(workflow, facets_base_dir)?;
     validate_resolved_facet_references(workflow, &facet_contents)?;
     Ok(facet_contents)
@@ -352,13 +358,11 @@ fn validate_resolved_facet_references(
             node.fanout()
                 .is_some_and(|fanout| fanout.child.iter().any(|child| child == node_name))
         });
-        for content in [
-            contents.policy.as_deref(),
-            contents.knowledge.as_deref(),
-            contents.instruction.as_deref(),
-        ]
-        .into_iter()
-        .flatten()
+        for content in contents
+            .policy
+            .iter()
+            .chain(contents.knowledge.iter())
+            .chain(contents.instruction.iter())
         {
             if let Some(err) =
                 validation::validate_template_references(&domain_workflow, content, allow_item)
@@ -780,6 +784,45 @@ nodes:
         }
     }
 
+    #[test]
+    fn parse_and_load_validate_every_resolved_knowledge_body() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let knowledge = dir.join("knowledge");
+        std::fs::create_dir_all(&knowledge).unwrap();
+        std::fs::write(knowledge.join("first.md"), "FIRST_OK").unwrap();
+        std::fs::write(
+            knowledge.join("second.md"),
+            "SECOND_USES_{{ missing.field }}",
+        )
+        .unwrap();
+
+        let yaml = r#"
+name: knowledge-reference-validation
+description: every knowledge body is validated
+nodes:
+  - name: implement
+    session:
+      permission: edit
+      gate: auto
+      facets:
+        knowledge: [first, second]
+"#;
+
+        for result in [parse_workflow_source(yaml, dir), {
+            let file_path = dir.join("knowledge-reference-validation.yml");
+            std::fs::write(&file_path, yaml).unwrap();
+            load_workflow(&file_path, dir)
+        }] {
+            assert!(matches!(
+                result.unwrap_err(),
+                StorageError::Validation(
+                    validation::ValidationError::InvalidArtifactReference { ref reference, .. }
+                ) if reference == "missing"
+            ));
+        }
+    }
+
     /// [02] schema 境界: 旧 `steps:` 表現で書かれた user-authored YAML は
     /// 新 schema (`nodes:` 必須 + `deny_unknown_fields`) として load に失敗する。
     /// これにより利用者は新表現で書き直さない限り実行に進めない。
@@ -819,10 +862,12 @@ steps:
             std::fs::create_dir_all(d).unwrap();
         }
         std::fs::write(policies.join("p.md"), "POLICY").unwrap();
-        std::fs::write(knowledge.join("k.md"), "KNOWLEDGE").unwrap();
+        std::fs::write(knowledge.join("k1.md"), "KNOWLEDGE_1").unwrap();
+        std::fs::write(knowledge.join("k2.md"), "KNOWLEDGE_2").unwrap();
         std::fs::write(instructions.join("i.md"), "INSTRUCTION").unwrap();
         std::fs::write(policies.join("pc.md"), "CHILD_POLICY").unwrap();
-        std::fs::write(knowledge.join("kc.md"), "CHILD_KNOWLEDGE").unwrap();
+        std::fs::write(knowledge.join("kc1.md"), "CHILD_KNOWLEDGE_1").unwrap();
+        std::fs::write(knowledge.join("kc2.md"), "CHILD_KNOWLEDGE_2").unwrap();
         std::fs::write(instructions.join("ic.md"), "CHILD_INSTRUCTION").unwrap();
 
         let yaml = r#"
@@ -835,7 +880,7 @@ nodes:
       gate: auto
       facets:
         policy: p
-        knowledge: k
+        knowledge: [k1, k2]
         instruction: i
     rules:
       - next: par
@@ -848,7 +893,7 @@ nodes:
       gate: auto
       facets:
         policy: pc
-        knowledge: kc
+        knowledge: [kc1, kc2]
         instruction: ic
   - name: c2
     session:
@@ -856,7 +901,7 @@ nodes:
       gate: auto
       facets:
         policy: pc
-        knowledge: kc
+        knowledge: [kc1, kc2]
         instruction: ic
 "#;
         let file_path = dir.join("facet-all.yml");
@@ -866,13 +911,22 @@ nodes:
 
         let lead_contents = resolved.for_node("lead").unwrap();
         assert_eq!(lead_contents.policy.as_deref(), Some("POLICY"));
-        assert_eq!(lead_contents.knowledge.as_deref(), Some("KNOWLEDGE"));
+        assert_eq!(
+            lead_contents.knowledge,
+            vec!["KNOWLEDGE_1".to_string(), "KNOWLEDGE_2".to_string()]
+        );
         assert_eq!(lead_contents.instruction.as_deref(), Some("INSTRUCTION"));
 
         for child_name in ["c1", "c2"] {
             let child_contents = resolved.for_node(child_name).unwrap();
             assert_eq!(child_contents.policy.as_deref(), Some("CHILD_POLICY"));
-            assert_eq!(child_contents.knowledge.as_deref(), Some("CHILD_KNOWLEDGE"));
+            assert_eq!(
+                child_contents.knowledge,
+                vec![
+                    "CHILD_KNOWLEDGE_1".to_string(),
+                    "CHILD_KNOWLEDGE_2".to_string()
+                ]
+            );
             assert_eq!(
                 child_contents.instruction.as_deref(),
                 Some("CHILD_INSTRUCTION")
@@ -880,27 +934,84 @@ nodes:
         }
     }
 
-    /// 欠損 facet を参照する workflow は load 段階で拒否される。
+    /// 各 kind の欠損 facet は load 段階で構造化 Diagnostic として拒否される。
     #[test]
     fn load_workflow_rejects_missing_facet() {
-        let tmp = TempDir::new().unwrap();
-        let dir = tmp.path();
-        let yaml = r#"
-name: missing-facet
-description: missing facet test
+        for (facet_kind, facet_key, facet_yaml) in [
+            ("policy", "missing-policy", "policy: missing-policy"),
+            (
+                "knowledge",
+                "missing-knowledge",
+                "knowledge: [missing-knowledge]",
+            ),
+            (
+                "instruction",
+                "missing-instruction",
+                "instruction: missing-instruction",
+            ),
+        ] {
+            let tmp = TempDir::new().unwrap();
+            let dir = tmp.path();
+            let workflow_name = format!("missing-{facet_kind}");
+            let yaml = format!(
+                r#"
+name: {workflow_name}
+description: missing {facet_kind} test
 nodes:
   - name: implement
     session:
       permission: edit
       gate: auto
       facets:
-        policy: nonexistent-policy
-        instruction: implement
+        {facet_yaml}
+"#
+            );
+            let file_path = dir.join(format!("{workflow_name}.yml"));
+            std::fs::write(&file_path, yaml).unwrap();
+
+            let result = load_workflow(&file_path, dir);
+
+            let Err(StorageError::Diagnostics(items)) = result else {
+                panic!("missing {facet_kind} must return structured diagnostics");
+            };
+            let missing = items
+                .iter()
+                .find(|item| item.code == "FAC002")
+                .unwrap_or_else(|| panic!("missing {facet_kind} FAC002"));
+            assert_eq!(
+                missing.workflow_name.as_deref(),
+                Some(workflow_name.as_str())
+            );
+            assert_eq!(missing.node_name.as_deref(), Some("implement"));
+            assert_eq!(missing.facet_key.as_deref(), Some(facet_key));
+            assert_eq!(missing.facet_kind.as_deref(), Some(facet_kind));
+            assert_eq!(missing.field.as_deref(), Some(facet_kind));
+            assert!(missing.message.contains(facet_key));
+        }
+    }
+
+    #[test]
+    fn load_workflow_resolves_builtin_facet_with_broken_inventory() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("knowledge"), "not a directory").unwrap();
+        let yaml = r#"
+name: builtin-facet-with-broken-inventory
+description: builtin facet load test
+nodes:
+  - name: implement
+    session:
+      permission: edit
+      gate: auto
+      facets:
+        knowledge: [releash-thread-cli]
 "#;
-        let file_path = dir.join("missing-facet.yml");
+        let file_path = dir.join("builtin-facet-with-broken-inventory.yml");
         std::fs::write(&file_path, yaml).unwrap();
-        let result = load_workflow(&file_path, dir);
-        assert!(matches!(result, Err(StorageError::FacetResolution(_))));
+
+        let workflow = load_workflow(&file_path, dir).unwrap();
+
+        assert_eq!(workflow.name, "builtin-facet-with-broken-inventory");
     }
 
     /// spec issues-1054 「未定義 workflow 変数の拒否」: facet 本文が宣言されていない

--- a/src-tauri/src/domain/workflow/value_objects/definition.rs
+++ b/src-tauri/src/domain/workflow/value_objects/definition.rs
@@ -77,13 +77,13 @@ pub enum SessionGate {
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct FacetRefs {
     pub policy: Option<String>,
-    pub knowledge: Option<String>,
+    pub knowledge: Vec<String>,
     pub instruction: Option<String>,
 }
 
 impl FacetRefs {
     pub fn is_empty(&self) -> bool {
-        self.policy.is_none() && self.knowledge.is_none() && self.instruction.is_none()
+        self.policy.is_none() && self.knowledge.is_empty() && self.instruction.is_none()
     }
 }
 
@@ -224,7 +224,7 @@ mod definition_tests {
         let mut node = NodeDefinition::default();
         assert!(!node.has_facet_refs());
         if let Some(session) = node.session_mut() {
-            session.facets.instruction = Some("spec-authoring".to_string());
+            session.facets.knowledge = vec!["releash-thread-cli".to_string()];
         }
         assert!(node.has_facet_refs());
     }

--- a/src-tauri/src/usecase/workflow/dto.rs
+++ b/src-tauri/src/usecase/workflow/dto.rs
@@ -29,8 +29,8 @@ pub(crate) enum NodeKindDto {
 pub(crate) struct FacetRefsDto {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub knowledge: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub knowledge: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instruction: Option<String>,
 }
@@ -432,6 +432,37 @@ mod tests {
                     "rules": [{"type": "next", "next": "done"}]
                 }]
             })
+        );
+    }
+
+    #[test]
+    fn workflow_to_dto_maps_knowledge_refs_to_ordered_json_array() {
+        let definition = domain::WorkflowDefinition {
+            name: "wf".to_string(),
+            description: String::new(),
+            nodes: vec![domain::NodeDefinition {
+                name: "review".to_string(),
+                kind: domain::NodeKind::Session(domain::SessionSpec {
+                    facets: domain::FacetRefs {
+                        knowledge: vec!["knowledge-a".to_string(), "knowledge-b".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let dto = workflow_to_dto(&definition);
+
+        assert_eq!(
+            dto.nodes[0].session.as_ref().unwrap().facets.knowledge,
+            vec!["knowledge-a", "knowledge-b"]
+        );
+        assert_eq!(
+            serde_json::to_value(dto).unwrap()["nodes"][0]["session"]["facets"]["knowledge"],
+            serde_json::json!(["knowledge-a", "knowledge-b"])
         );
     }
 

--- a/src/components/panels/automation/WorkflowDetail.test.tsx
+++ b/src/components/panels/automation/WorkflowDetail.test.tsx
@@ -32,7 +32,10 @@ const EMPTY_REPORT: DiagnosticReport = {
 	facet_usage: {},
 };
 
-function makeWorkflow(overrides?: { input?: string }): WorkflowDefinition {
+function makeWorkflow(overrides?: {
+	input?: string;
+	knowledge?: string[];
+}): WorkflowDefinition {
 	return {
 		name: "wf",
 		description: "test workflow",
@@ -46,7 +49,7 @@ function makeWorkflow(overrides?: { input?: string }): WorkflowDefinition {
 					permission: "edit",
 					facets: {
 						policy: "coding",
-						knowledge: "architecture",
+						knowledge: overrides?.knowledge ?? ["architecture"],
 						instruction: "implement",
 					},
 				},
@@ -102,6 +105,40 @@ describe("WorkflowDetail facet refs row", () => {
 
 		expect(screen.getByText(matchLabel("Input"))).toBeInTheDocument();
 		expect(screen.getByText("input-contract")).toBeInTheDocument();
+	});
+
+	it("displays multiple Knowledge refs in declaration order", async () => {
+		const user = userEvent.setup();
+		render(
+			<WorkflowDetail
+				workflow={makeWorkflow({
+					knowledge: ["architecture", "requirements-design"],
+				})}
+				report={EMPTY_REPORT}
+				onEdit={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByText("implement"));
+
+		expect(
+			screen.getByText(matchLabel("Knowledge")).parentElement,
+		).toHaveTextContent("Knowledge: architecture, requirements-design");
+	});
+
+	it("does not display Knowledge row for an empty ref list", async () => {
+		const user = userEvent.setup();
+		render(
+			<WorkflowDetail
+				workflow={makeWorkflow({ knowledge: [] })}
+				report={EMPTY_REPORT}
+				onEdit={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByText("implement"));
+
+		expect(screen.queryByText(matchLabel("Knowledge"))).not.toBeInTheDocument();
 	});
 
 	it("does not display Input row when input is undefined", async () => {

--- a/src/components/panels/automation/WorkflowDetail.tsx
+++ b/src/components/panels/automation/WorkflowDetail.tsx
@@ -318,6 +318,8 @@ function NodeCard({ node, index }: { node: NodeDefinition; index: number }) {
 	const facets = session?.facets;
 	const fanout = node.fanout;
 	const childCount = fanout?.child.length ?? 0;
+	const knowledgeRefs = facets?.knowledge ?? [];
+	const hasKnowledgeRefs = knowledgeRefs.length > 0;
 
 	return (
 		<div className="rounded-md border border-border">
@@ -377,7 +379,7 @@ function NodeCard({ node, index }: { node: NodeDefinition; index: number }) {
 
 					{/* Facet refs */}
 					{(facets?.policy ||
-						facets?.knowledge ||
+						hasKnowledgeRefs ||
 						facets?.instruction ||
 						node.artifact ||
 						(node.inputs && node.inputs.length > 0) ||
@@ -389,8 +391,11 @@ function NodeCard({ node, index }: { node: NodeDefinition; index: number }) {
 							{facets?.policy && (
 								<FacetRefRow label="Policy" value={facets.policy} />
 							)}
-							{facets?.knowledge && (
-								<FacetRefRow label="Knowledge" value={facets.knowledge} />
+							{hasKnowledgeRefs && (
+								<FacetRefRow
+									label="Knowledge"
+									value={knowledgeRefs.join(", ")}
+								/>
 							)}
 							{facets?.instruction && (
 								<FacetRefRow label="Instruction" value={facets.instruction} />

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -60,7 +60,7 @@ export type SessionGate = "auto" | "approval";
 
 export interface FacetRefs {
 	policy?: string;
-	knowledge?: string;
+	knowledge?: string[];
 	instruction?: string;
 }
 


### PR DESCRIPTION
## 概要

workflow の facet / schema / diagnostics 周りを拡張する。closes #1485

## 変更点

- `facet.rs` / `schema.rs` / `diagnostics.rs` の拡張
- `storage.rs` / `definition_repository.rs` / `event.rs` の追従
- `usecase/workflow/dto.rs`、`domain/workflow/value_objects/definition.rs` の対応
- frontend `WorkflowDetail.tsx` / `types/workflow.ts` の追従
- docs (`workflow-yaml-syntax.md`, `full-pipeline.yml`) の更新
- 関連テストの追加・更新

## テスト

- [ ] `cargo test`
- [ ] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)