### PR TITLE
feat(workflow): loop_guardに実行回数のリセット境界を指定できるようにする

### DIFF
--- a/docs/specs/issues-1489/requirements.md
+++ b/docs/specs/issues-1489/requirements.md
@@ -1,0 +1,125 @@
+# Requirements
+
+関連: #1489（loop_guard に実行回数のリセット境界を指定できるようにする）
+
+## Type
+
+Workflow routing 機能拡張。
+
+`loop_guard` が参照する対象 Node の実行回数を、Workflow 実行全体の累計だけでなく、同じ Workflow 内の指定 Node が直近に正常完了した時点を境界として数えられるようにする。
+
+## 背景と目的
+
+現行の `loop_guard` は、対象 Node が同一 Workflow 実行内で開始された累計回数を `max_iterations` と比較する。外側の処理ラウンドを表す Node が再度正常完了しても累計回数はリセットされない。
+
+このため、外側の処理を複数回行い、その各回で内側の確認・修正ループを一定回数だけ許可する制約を表現できない。たとえば、Full Review を最大 3 回行い、各 Full Review で整合性確認・修正を最大 2 回許可したい場合、現行構文では「全 Full Review を通して最大 2 回」または「1 回の Full Review で最大 6 回」のいずれかになり、「各 Full Review で最大 2 回」を表現できない。
+
+本変更の目的は、`loop_guard` に任意の `reset_on` を追加し、指定 Node の正常完了ごとに新しいカウント範囲を開始できるようにすることである。
+
+```yaml
+- name: check_fix_policy_consistency
+  rules:
+  - loop_guard:
+      max_iterations: 2
+      on_exhausted: create_fix_plan
+      reset_on: full_review_fanout
+```
+
+この例では、`full_review_fanout` が正常完了するたびに `check_fix_policy_consistency` の新しいカウント範囲を開始する。
+
+## 用語
+
+- **guard 対象 Node**: `loop_guard` を持ち、遷移可否を実行回数で制限される Node。
+- **リセット境界 Node**: `loop_guard.reset_on` が参照する Node。
+- **正常完了**: Node の実行が成功として完了したこと。失敗、中断、abort、実行開始だけでは正常完了に含めない。
+- **カウント範囲**: Workflow 開始、またはリセット境界 Node の直近の正常完了より後から、現在の routing 判定までの区間。
+- **範囲内実行回数**: カウント範囲内で guard 対象 Node の実行が開始された回数。retry または中断後の resume により新しい attempt が開始された場合も、既存 `loop_guard` の回数単位に従って含める。
+
+## スコープ
+
+1. `loop_guard` に、同じ Workflow 内の Node 名を指定する任意 field `reset_on` を追加する。
+2. `reset_on` を指定した guard では、リセット境界 Node の直近の正常完了より後に開始された guard 対象 Node の実行回数だけを `max_iterations` と比較する。
+3. リセット境界 Node がまだ正常完了していない場合は、Workflow 開始以降の実行回数を使用する。
+4. リセット境界 Node が複数回正常完了した場合は、その都度新しいカウント範囲を開始する。
+5. fanout Node を `reset_on` に指定した場合は、全 child の完了を含む既存の fanout 正常完了条件が成立した時点を境界とする。
+6. Workflow の中断・再開および永続イベント履歴からの再生後も、同じカウント範囲と範囲内実行回数を復元する。
+7. Workflow の load、保存、実行開始、永続化、再生、既存 DTO 取得経路の全てで `reset_on` を欠落させず保持する。
+8. `docs/workflow-yaml-syntax.md` に構文と意味論を記載する。
+
+## 非スコープ
+
+- CLI または UI から、実行中 Workflow の loop guard 回数を手動で変更・リセットする機能。
+- 実行中の Workflow 定義または `reset_on` を変更する機能。
+- `max_iterations` および `on_exhausted` の既存の意味や上限判定を変更すること。
+- Workflow 実行をまたいでカウント範囲または実行回数を共有すること。
+- `reset_on` 専用の Workflow 編集 UI、入力補完 UI、または実行回数表示 UI の追加。
+- 既存 builtin Workflow へ `reset_on` を一括適用すること。
+
+## 要求事項
+
+- **R1: 構文**
+  `loop_guard` は任意の `reset_on: <node-name>` を受け付けること。`reset_on` には同じ Workflow 定義内の Node 名を指定できること。
+
+- **R2: リセット境界の成立条件**
+  `reset_on` に指定された Node が正常完了するたびに、その正常完了より後を新しいカウント範囲とすること。指定 Node の開始、失敗、中断または abort では新しいカウント範囲を開始しないこと。
+
+- **R3: 範囲内回数による routing**
+  `reset_on` を持つ `loop_guard` への遷移判定では、現在のカウント範囲内で開始された guard 対象 Node の実行回数を `max_iterations` と比較すること。`max_iterations: 2` の場合、各カウント範囲で guard 対象 Node へ最大 2 回遷移できること。
+
+- **R4: 境界未到達時の初期範囲**
+  `reset_on` に指定した Node がまだ正常完了していない場合、Workflow 開始をカウント範囲の始点とすること。
+
+- **R5: 複数回の境界到達**
+  リセット境界 Node が複数回正常完了した場合、routing 判定は常に直近の正常完了より後の範囲内実行回数を使用すること。以前のカウント範囲で消費した回数は新しい範囲へ持ち越さないこと。
+
+- **R6: 上限到達時の互換性**
+  現在のカウント範囲で実行回数が `max_iterations` に到達している場合、guard 対象 Node を開始せず、既存と同じく `on_exhausted` に遷移すること。`on_exhausted` の chain 処理を含む既存 routing の意味を変更しないこと。
+
+- **R7: `reset_on` 省略時の後方互換性**
+  `reset_on` を省略した既存 Workflow は、Workflow 実行全体の累計実行回数を使用する現行挙動を維持すること。既存 YAML および `reset_on` を持たない永続済み Workflow 定義を引き続き読み込めること。
+
+- **R8: 参照検証と Diagnostic**
+  `reset_on` が同じ Workflow 内に存在しない Node 名を参照した場合、Workflow load 時に定義を拒否し、参照された Node 名と `loop_guard.reset_on` が原因であることを識別できる Diagnostic を返すこと。`reset_on` は routing edge ではないため、到達可能性または cycle の遷移先として扱わないこと。
+
+- **R9: fanout 境界**
+  fanout Node を `reset_on` に指定した場合、個々の child の開始または完了ではリセットせず、全 child の完了を含む fanout Node 自体の正常完了を境界とすること。
+
+- **R10: 中断・再開とイベント再生**
+  Workflow の中断・再開後、および永続イベント履歴から同じ Workflow 実行を再生した後も、直近の正常完了境界と範囲内実行回数が中断前と一致し、同じ routing 判定になること。
+
+- **R11: 定義表現の保持**
+  schema、domain、runtime routing、永続化・再生、Workflow 定義 DTO の各経路で `reset_on` を保持すること。既存 DTO が `loop_guard` を返す場合、指定済みの `reset_on` も返すこと。
+
+- **R12: Rust 所有**
+  カウント範囲、正常完了境界、範囲内実行回数および routing 判定の source of truth は Rust backend が所有すること。frontend に Workflow runtime の回数計算またはリセット判断を追加しないこと。
+
+- **R13: ドキュメント**
+  `docs/workflow-yaml-syntax.md` に `reset_on` の構文、正常完了だけが境界になること、境界未到達時の範囲、fanout の成立条件、および省略時の後方互換性を記載すること。
+
+## 受け入れ基準の概要
+
+- `loop_guard.reset_on` に同じ Workflow 内の通常 Node または fanout Node を指定できる。
+- 通常 Node が正常完了するたびに新しいカウント範囲が開始され、`max_iterations: 2` なら各範囲で最大 2 回 guard 対象 Node を開始できる。
+- 境界 Node が未到達の場合は Workflow 開始以降の回数を使用する。
+- 境界 Node が複数回正常完了した場合は、直近の正常完了以降だけを数える。
+- 境界 Node の失敗、中断または abort ではカウント範囲を更新しない。
+- fanout Node は全 child の完了を含む fanout 自体の正常完了時だけ境界になる。
+- 各カウント範囲で上限へ到達すると、既存どおり `on_exhausted` へ遷移する。
+- `reset_on` を省略した既存 Workflow の累計回数による挙動が変わらない。
+- 存在しない Node 名を `reset_on` に指定すると、Node 名を含む Diagnostic が Workflow load 時に返る。
+- 中断・再開およびイベント履歴からの再生後も、カウント範囲、範囲内実行回数、routing 結果が一致する。
+- YAML、domain、永続化された Workflow 定義、再生、DTO の往復で `reset_on` が欠落しない。
+- 通常 Node 境界、fanout Node 境界、境界未到達、複数回到達、非正常終了、中断・再開、存在しない参照、および `reset_on` 省略時の互換性を検証する Rust テストが追加される。
+- `docs/workflow-yaml-syntax.md` に R13 の内容が記載される。
+- `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` が通る。frontend の DTO 型または表示を変更した場合は `pnpm lint` / `pnpm test` / `pnpm build` も通る。
+
+## 仮定
+
+- `max_iterations` が数える実行単位は現行 `loop_guard` の意味を維持し、Node の新しい attempt が開始された回数とする。
+- `reset_on` はリセット境界への参照であり、Workflow の control-flow edge を新設しない。
+- Workflow 実行中は、実行開始時に確定した Workflow 定義を使用し続ける。
+- 既存の Workflow event 履歴は、正常完了境界と実行回数を一意に復元できる順序を保持している。
+
+## Open Questions
+
+なし

--- a/docs/workflow-yaml-syntax.md
+++ b/docs/workflow-yaml-syntax.md
@@ -251,11 +251,18 @@ rules:
 
 ```yaml
 rules:
-  - loop_guard: { max_iterations: 3, on_exhausted: give_up }
+  - loop_guard:
+      max_iterations: 3
+      on_exhausted: give_up
+      reset_on: review_round
   - next: run_tests
 ```
 
-`max_iterations` は 1 以上。遷移先 Node に guard がある場合、既完了実行回数が上限に達していれば、その Node を再実行せず `on_exhausted` へ進む。cycle には、その cycle 上で到達可能な `loop_guard` が少なくとも一つ必要。
+`max_iterations` は 1 以上。遷移先 Node に guard がある場合、対象 Node の開始された実行回数（開始済み attempt 数）が上限に達していれば、その Node を再実行せず `on_exhausted` へ進む。cycle には、その cycle 上で到達可能な `loop_guard` が少なくとも一つ必要。
+
+`reset_on` は任意で、同じ Workflow 内の Node 名を指定する。指定 Node が正常完了するたびに新しいカウント範囲を開始し、guard 対象 Node への遷移可否は、直近の正常完了より後に開始された同 Node の実行回数だけで判定する。指定 Node がまだ正常完了していない場合は Workflow 開始以降を範囲とする。失敗、中断、abort、実行開始だけでは範囲をリセットしない。
+
+fanout Node を `reset_on` に指定した場合は、個々の child の完了ではなく、全 child の完了を含む fanout Node 自体の正常完了を境界とする。`reset_on` を省略した既存構文は、Workflow 実行全体の累計回数を使う従来の挙動を維持する。
 
 ### control-flow の制約
 

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -659,9 +659,9 @@ fn validation_error_code_stage(
         | ValidationError::EmptyCommand { .. }
         | ValidationError::TooManyNodes { .. }
         | ValidationError::TooManyFanoutChildren { .. } => "WFS006",
-        ValidationError::UnknownRuleTarget { .. } | ValidationError::UnknownFanoutChild { .. } => {
-            "WFR001"
-        }
+        ValidationError::UnknownRuleTarget { .. }
+        | ValidationError::UnknownLoopGuardResetNode { .. }
+        | ValidationError::UnknownFanoutChild { .. } => "WFR001",
         ValidationError::InvalidFanoutItemsReference { .. } => "WFR003",
         ValidationError::FanoutInputMismatch { .. } => "WFT003",
         ValidationError::FanoutChildLeafViolation { .. } => "WFC006",
@@ -742,6 +742,14 @@ fn span_for_validation_error(
                 node_base_path(wf, node)
                     .and_then(|path| span_map.field_span(&format!("{path}.rules")))
             }),
+        ValidationError::UnknownLoopGuardResetNode { node, .. } => {
+            loop_guard_reset_on_path(wf, node)
+                .and_then(|path| span_map.field_span(&path))
+                .or_else(|| {
+                    node_base_path(wf, node)
+                        .and_then(|path| span_map.field_span(&format!("{path}.rules")))
+                })
+        }
         ValidationError::UnreachableNode { node } => {
             node_base_path(wf, node).and_then(|path| span_map.nearest_span(&path))
         }
@@ -812,6 +820,12 @@ fn invalid_rule_path(
         | InvalidRuleKind::CycleWithoutLoopGuard => Some("rules".to_string()),
     }?;
     Some(format!("{base}.{suffix}"))
+}
+
+fn loop_guard_reset_on_path(wf: &WorkflowDefinitionYaml, node_name: &str) -> Option<String> {
+    let (base, node) = node_base_path_with_node(wf, node_name)?;
+    rule_index(node, |rule| matches!(rule, Rule::LoopGuard { .. }))
+        .map(|index| format!("{base}.rules[{index}].loop_guard.reset_on"))
 }
 
 fn node_base_path_with_node<'a>(
@@ -1160,6 +1174,10 @@ fn validation_error_context(e: &validation::ValidationError) -> (Option<String>,
         ValidationError::UnknownRuleTarget { node, .. } => {
             (Some(node.clone()), Some("rules.next".to_string()))
         }
+        ValidationError::UnknownLoopGuardResetNode { node, .. } => (
+            Some(node.clone()),
+            Some("rules.loop_guard.reset_on".to_string()),
+        ),
         ValidationError::InvalidRules { node, kind, .. } => (
             Some(node.clone()),
             Some(invalid_rule_field_name(*kind).to_string()),
@@ -1861,6 +1879,29 @@ mod tests {
                 path.display()
             );
         }
+    }
+
+    #[test]
+    fn unknown_loop_guard_reset_node_diagnostic_identifies_reference() {
+        let source = fs::read_to_string(
+            fixture_dir("invalid").join("WFR001_unknown-loop-guard-reset-node.yml"),
+        )
+        .unwrap();
+
+        let diagnosis = diagnose_workflow_source(&source, Some("unknown-loop-guard-reset-node"));
+        let diagnostic = diagnosis
+            .diagnostics
+            .iter()
+            .find(|item| item.code == "WFR001")
+            .expect("unknown reset_on node must produce WFR001");
+
+        assert_eq!(diagnostic.node_name.as_deref(), Some("fix"));
+        assert_eq!(
+            diagnostic.field.as_deref(),
+            Some("rules.loop_guard.reset_on")
+        );
+        assert!(diagnostic.message.contains("missing-boundary"));
+        assert!(diagnostic.span.is_some());
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/domain_mapping.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/domain_mapping.rs
@@ -254,9 +254,11 @@ pub(crate) fn rule_to_domain(rule: &schema::Rule) -> domain::Rule {
         schema::Rule::LoopGuard {
             max_iterations,
             on_exhausted,
+            reset_on,
         } => domain::Rule::LoopGuard {
             max_iterations: *max_iterations,
             on_exhausted: on_exhausted.clone(),
+            reset_on: reset_on.clone(),
         },
         schema::Rule::Next(next) => domain::Rule::Next(next.clone()),
     }

--- a/src-tauri/src/adaptor/gateway/workflow/event.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event.rs
@@ -332,6 +332,45 @@ mod tests {
     }
 
     #[test]
+    fn execution_started_round_trips_loop_guard_reset_on() {
+        let mut definition = minimal_workflow();
+        definition.nodes[0].rules =
+            vec![crate::adaptor::gateway::workflow::schema::Rule::LoopGuard {
+                max_iterations: 2,
+                on_exhausted: "review".to_string(),
+                reset_on: Some("review".to_string()),
+            }];
+        let event = WorkflowEvent::ExecutionStarted {
+            execution_id: "00000000-0000-4000-8000-000000000001".to_string(),
+            workflow_name: "wf".to_string(),
+            worktree_path: "/repo".to_string(),
+            created_from: ExecutionOrigin::Cli,
+            request: "review".to_string(),
+            permission_mode: crate::domain::agent_session::PermissionMode::EDIT.to_string(),
+            definition,
+            timestamp: 1.0,
+        };
+
+        let serialized = serde_json::to_value(event).unwrap();
+        assert_eq!(
+            serialized["definition"]["nodes"][0]["rules"][0]["loop_guard"]["reset_on"],
+            "review"
+        );
+
+        let restored = serde_json::from_value::<WorkflowEvent>(serialized).unwrap();
+        let WorkflowEvent::ExecutionStarted { definition, .. } = restored else {
+            panic!("expected execution_started event");
+        };
+        assert!(matches!(
+            &definition.nodes[0].rules[0],
+            crate::adaptor::gateway::workflow::schema::Rule::LoopGuard {
+                reset_on: Some(reset_on),
+                ..
+            } if reset_on == "review"
+        ));
+    }
+
+    #[test]
     fn execution_started_reads_legacy_scalar_knowledge_snapshot() {
         let event = WorkflowEvent::ExecutionStarted {
             execution_id: "00000000-0000-4000-8000-000000000001".to_string(),

--- a/src-tauri/src/adaptor/gateway/workflow/event_projection.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event_projection.rs
@@ -6,10 +6,11 @@ use crate::adaptor::gateway::workflow::event::{
     FanoutParentRef as EventFanoutParentRef, TokenUsage as EventTokenUsage, WorkflowEvent,
 };
 use crate::adaptor::gateway::workflow::schema::NodeKindName as EventNodeKindName;
-use crate::domain::workflow::services::routing::{self, RouteDecision};
+use crate::domain::workflow::services::routing::{self, LoopGuardResetBaselines, RouteDecision};
 use crate::domain::workflow::{
     ApprovalTarget, Artifact, ExecutionStatus, Fanout, FanoutParentRef, NodeExecution,
-    NodeExecutionFailure, NodeExecutionStatus, NodeKindName, TokenUsage, WorkflowExecution,
+    NodeExecutionFailure, NodeExecutionStatus, NodeKindName, TokenUsage, WorkflowDefinition,
+    WorkflowExecution,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -21,6 +22,49 @@ pub(crate) struct DerivedWorkflowExecutionFields {
     pub(crate) fanouts: Vec<Fanout>,
 }
 
+#[derive(Debug)]
+pub(crate) struct RetainedWorkflowExecutionProjection {
+    pub(crate) execution: WorkflowExecution,
+    pub(crate) node_execution_counts: HashMap<String, u32>,
+    pub(crate) loop_guard_reset_baselines: LoopGuardResetBaselines,
+}
+
+struct RoutingReplayState {
+    workflow: WorkflowDefinition,
+    node_execution_counts: HashMap<String, u32>,
+    loop_guard_reset_baselines: LoopGuardResetBaselines,
+}
+
+impl RoutingReplayState {
+    fn new(definition: &crate::adaptor::gateway::workflow::schema::WorkflowDefinitionYaml) -> Self {
+        Self {
+            workflow:
+                crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_domain(
+                    definition,
+                ),
+            node_execution_counts: HashMap::new(),
+            loop_guard_reset_baselines: LoopGuardResetBaselines::default(),
+        }
+    }
+
+    fn record_node_started(&mut self, node_name: &str, attempt: u32) {
+        self.node_execution_counts
+            .entry(node_name.to_string())
+            .and_modify(|current| *current = (*current).max(attempt))
+            .or_insert(attempt);
+    }
+
+    fn record_node_completed(&mut self, node_name: &str) {
+        self.loop_guard_reset_baselines
+            .record_successful_completion(&self.workflow, node_name, &self.node_execution_counts);
+    }
+}
+
+struct ProjectedWorkflowExecution {
+    execution: WorkflowExecution,
+    routing_replay: Option<RoutingReplayState>,
+}
+
 /// Projects one public workflow execution read model from its event stream.
 ///
 /// An empty stream (or an audit-only stream without `ExecutionStarted`) means the
@@ -29,11 +73,31 @@ pub fn project_workflow_execution(
     execution_id: &str,
     events: &[WorkflowEvent],
 ) -> Result<Option<WorkflowExecution>, String> {
+    project_retained_workflow_execution(execution_id, events)
+        .map(|projection| projection.map(|projection| projection.execution))
+}
+
+pub(crate) fn project_retained_workflow_execution(
+    execution_id: &str,
+    events: &[WorkflowEvent],
+) -> Result<Option<RetainedWorkflowExecutionProjection>, String> {
     project_workflow_execution_with_payload_policy(
         execution_id,
         events,
         ProjectionPayloadPolicy::Retained,
     )
+    .map(|projection| {
+        projection.map(|projection| {
+            let routing_replay = projection
+                .routing_replay
+                .expect("retained projection must construct routing replay state");
+            RetainedWorkflowExecutionProjection {
+                execution: projection.execution,
+                node_execution_counts: routing_replay.node_execution_counts,
+                loop_guard_reset_baselines: routing_replay.loop_guard_reset_baselines,
+            }
+        })
+    })
 }
 
 /// Projects the canonical execution state without requiring retained body
@@ -54,6 +118,7 @@ pub(crate) fn project_payload_stripped_workflow_execution(
         events,
         ProjectionPayloadPolicy::Stripped,
     )
+    .map(|projection| projection.map(|projection| projection.execution))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -66,7 +131,7 @@ fn project_workflow_execution_with_payload_policy(
     execution_id: &str,
     events: &[WorkflowEvent],
     payload_policy: ProjectionPayloadPolicy,
-) -> Result<Option<WorkflowExecution>, String> {
+) -> Result<Option<ProjectedWorkflowExecution>, String> {
     for event in events {
         if event.execution_id() != execution_id {
             return Err(format!(
@@ -134,6 +199,10 @@ fn project_workflow_execution_with_payload_policy(
         approval_target: None,
     };
     let mut authoritative_total_usage = None;
+    let mut routing_replay = match payload_policy {
+        ProjectionPayloadPolicy::Retained => Some(RoutingReplayState::new(definition)),
+        ProjectionPayloadPolicy::Stripped => None,
+    };
 
     for event in events {
         execution.updated_at = execution.updated_at.max(event.timestamp());
@@ -149,6 +218,9 @@ fn project_workflow_execution_with_payload_policy(
                 timestamp,
                 ..
             } => {
+                if let Some(routing_replay) = routing_replay.as_mut() {
+                    routing_replay.record_node_started(node_name, *attempt);
+                }
                 if execution
                     .node_executions
                     .iter()
@@ -231,6 +303,9 @@ fn project_workflow_execution_with_payload_policy(
                 node.token_usage = token_usage.as_ref().map(token_usage_to_domain);
                 node.failure = None;
                 node.completed_at = Some(*timestamp);
+                if let Some(routing_replay) = routing_replay.as_mut() {
+                    routing_replay.record_node_completed(node_name);
+                }
             }
             WorkflowEvent::NodeFailed {
                 node_execution_id,
@@ -330,7 +405,15 @@ fn project_workflow_execution_with_payload_policy(
                 }
                 let resume_from_node = match payload_policy {
                     ProjectionPayloadPolicy::Retained => {
-                        derive_resume_from_node(definition, &execution.node_executions)?
+                        let routing_replay = routing_replay
+                            .as_ref()
+                            .expect("retained projection must construct routing replay state");
+                        derive_resume_from_node(
+                            &routing_replay.workflow,
+                            &execution.node_executions,
+                            &routing_replay.node_execution_counts,
+                            &routing_replay.loop_guard_reset_baselines,
+                        )?
                     }
                     ProjectionPayloadPolicy::Stripped => None,
                 };
@@ -390,23 +473,25 @@ fn project_workflow_execution_with_payload_policy(
     execution.approval_target = derived.approval_target;
     execution.artifacts = derived.artifacts;
     execution.fanouts = derived.fanouts;
-    Ok(Some(execution))
+    Ok(Some(ProjectedWorkflowExecution {
+        execution,
+        routing_replay,
+    }))
 }
 
 fn derive_resume_from_node(
-    definition: &crate::adaptor::gateway::workflow::schema::WorkflowDefinitionYaml,
+    workflow: &WorkflowDefinition,
     nodes: &[NodeExecution],
+    node_execution_counts: &HashMap<String, u32>,
+    loop_guard_reset_baselines: &LoopGuardResetBaselines,
 ) -> Result<Option<String>, String> {
     let Some(latest) = nodes.iter().rev().find(|node| node.fanout_parent.is_none()) else {
-        return Ok(definition.nodes.first().map(|node| node.name.clone()));
+        return Ok(workflow.nodes.first().map(|node| node.name.clone()));
     };
     if latest.status != NodeExecutionStatus::Succeeded {
         return Ok(Some(latest.node_name.clone()));
     }
 
-    let workflow = crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_domain(
-        definition,
-    );
     let current_index = workflow
         .nodes
         .iter()
@@ -417,20 +502,19 @@ fn derive_resume_from_node(
                 latest.node_name
             )
         })?;
-    let mut attempts = HashMap::new();
-    for node in nodes {
-        attempts
-            .entry(node.node_name.clone())
-            .and_modify(|attempt: &mut u32| *attempt = (*attempt).max(node.attempt))
-            .or_insert(node.attempt);
-    }
     let artifact = latest.artifact.as_ref().map(|artifact| &artifact.value);
-    routing::route(&workflow, current_index, artifact, &attempts)
-        .map_err(|error| error.to_string())
-        .map(|decision| match decision {
-            RouteDecision::TransitionTo(node) => Some(node),
-            RouteDecision::Completed => None,
-        })
+    routing::route_with_reset_baselines(
+        workflow,
+        current_index,
+        artifact,
+        node_execution_counts,
+        loop_guard_reset_baselines,
+    )
+    .map_err(|error| error.to_string())
+    .map(|decision| match decision {
+        RouteDecision::TransitionTo(node) => Some(node),
+        RouteDecision::Completed => None,
+    })
 }
 
 fn node_mut<'a>(
@@ -1191,6 +1275,294 @@ mod tests {
         assert_eq!(
             execution.node_executions[0].status,
             NodeExecutionStatus::Succeeded
+        );
+    }
+
+    #[test]
+    fn interrupted_projection_routes_with_replayed_loop_guard_reset_baseline() {
+        use crate::adaptor::gateway::workflow::schema::Rule;
+
+        let workflow = WorkflowDefinitionYaml {
+            name: "reset-replay".to_string(),
+            nodes: vec![
+                NodeDefinition {
+                    name: "round".to_string(),
+                    rules: vec![Rule::Next("fix".to_string())],
+                    ..Default::default()
+                },
+                NodeDefinition {
+                    name: "fix".to_string(),
+                    rules: vec![Rule::LoopGuard {
+                        max_iterations: 2,
+                        on_exhausted: "done".to_string(),
+                        reset_on: Some("round".to_string()),
+                    }],
+                    ..Default::default()
+                },
+                NodeDefinition {
+                    name: "done".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let mut fix_second_start = node_started("fix-2", "fix", EventNodeKindName::Session);
+        if let WorkflowEvent::NodeStarted {
+            attempt, timestamp, ..
+        } = &mut fix_second_start
+        {
+            *attempt = 2;
+            *timestamp = 4.0;
+        }
+        let events = vec![
+            WorkflowEvent::ExecutionStarted {
+                execution_id: EXECUTION_ID.to_string(),
+                workflow_name: "reset-replay".to_string(),
+                worktree_path: "/repo".to_string(),
+                created_from: ExecutionOrigin::Cli,
+                request: "review".to_string(),
+                permission_mode: "ask".to_string(),
+                definition: workflow,
+                timestamp: 1.0,
+            },
+            node_started("fix-1", "fix", EventNodeKindName::Session),
+            WorkflowEvent::NodeCompleted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "fix-1".to_string(),
+                node_name: "fix".to_string(),
+                attempt: 1,
+                result_summary: None,
+                token_usage: None,
+                timestamp: 3.0,
+            },
+            fix_second_start,
+            WorkflowEvent::NodeCompleted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "fix-2".to_string(),
+                node_name: "fix".to_string(),
+                attempt: 2,
+                result_summary: None,
+                token_usage: None,
+                timestamp: 5.0,
+            },
+            WorkflowEvent::NodeStarted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "round-1".to_string(),
+                node_name: "round".to_string(),
+                kind: EventNodeKindName::Session,
+                attempt: 1,
+                fanout_parent: None,
+                timestamp: 6.0,
+            },
+            WorkflowEvent::NodeCompleted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "round-1".to_string(),
+                node_name: "round".to_string(),
+                attempt: 1,
+                result_summary: None,
+                token_usage: None,
+                timestamp: 7.0,
+            },
+            WorkflowEvent::ExecutionInterrupted {
+                execution_id: EXECUTION_ID.to_string(),
+                reason: ExecutionInterruptionReason::Crash,
+                timestamp: 8.0,
+            },
+        ];
+
+        let retained = project_workflow_execution_with_payload_policy(
+            EXECUTION_ID,
+            &events,
+            ProjectionPayloadPolicy::Retained,
+        )
+        .unwrap()
+        .unwrap();
+        let execution = retained.execution;
+
+        assert_eq!(execution.resume_from_node.as_deref(), Some("fix"));
+        assert!(retained.routing_replay.is_some());
+
+        let stripped = project_workflow_execution_with_payload_policy(
+            EXECUTION_ID,
+            &events,
+            ProjectionPayloadPolicy::Stripped,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(stripped.execution.status, ExecutionStatus::Interrupted);
+        assert_eq!(stripped.execution.resume_from_node, None);
+        assert_eq!(
+            stripped.execution.node_executions[2].status,
+            NodeExecutionStatus::Succeeded
+        );
+        assert!(stripped.routing_replay.is_none());
+    }
+
+    #[test]
+    fn fanout_child_completion_does_not_reset_a_guard_bound_to_the_parent() {
+        use crate::adaptor::gateway::workflow::schema::{FanoutSpec, Rule};
+
+        let workflow = WorkflowDefinitionYaml {
+            name: "fanout-parent-reset-replay".to_string(),
+            nodes: vec![
+                NodeDefinition {
+                    name: "round".to_string(),
+                    kind: NodeKind::Fanout(FanoutSpec {
+                        child: vec!["worker".to_string()],
+                        items: None,
+                    }),
+                    rules: vec![Rule::Next("fix".to_string())],
+                    ..Default::default()
+                },
+                NodeDefinition {
+                    name: "worker".to_string(),
+                    ..Default::default()
+                },
+                NodeDefinition {
+                    name: "fix".to_string(),
+                    rules: vec![Rule::LoopGuard {
+                        max_iterations: 2,
+                        on_exhausted: "done".to_string(),
+                        reset_on: Some("round".to_string()),
+                    }],
+                    ..Default::default()
+                },
+                NodeDefinition {
+                    name: "done".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let start = WorkflowEvent::ExecutionStarted {
+            execution_id: EXECUTION_ID.to_string(),
+            workflow_name: workflow.name.clone(),
+            worktree_path: "/repo".to_string(),
+            created_from: ExecutionOrigin::Cli,
+            request: "review".to_string(),
+            permission_mode: "ask".to_string(),
+            definition: workflow.clone(),
+            timestamp: 1.0,
+        };
+        let mut events_before_child_completion = vec![start];
+        for (id, attempt, started_at, completed_at) in
+            [("fix-1", 1, 2.0, 3.0), ("fix-2", 2, 4.0, 5.0)]
+        {
+            events_before_child_completion.extend([
+                WorkflowEvent::NodeStarted {
+                    execution_id: EXECUTION_ID.to_string(),
+                    node_execution_id: id.to_string(),
+                    node_name: "fix".to_string(),
+                    kind: EventNodeKindName::Session,
+                    attempt,
+                    fanout_parent: None,
+                    timestamp: started_at,
+                },
+                WorkflowEvent::NodeCompleted {
+                    execution_id: EXECUTION_ID.to_string(),
+                    node_execution_id: id.to_string(),
+                    node_name: "fix".to_string(),
+                    attempt,
+                    result_summary: None,
+                    token_usage: None,
+                    timestamp: completed_at,
+                },
+            ]);
+        }
+        events_before_child_completion.extend([
+            WorkflowEvent::NodeStarted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "round-1".to_string(),
+                node_name: "round".to_string(),
+                kind: EventNodeKindName::Fanout,
+                attempt: 1,
+                fanout_parent: None,
+                timestamp: 6.0,
+            },
+            WorkflowEvent::NodeStarted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "worker-1".to_string(),
+                node_name: "worker".to_string(),
+                kind: EventNodeKindName::Session,
+                attempt: 1,
+                fanout_parent: Some(EventFanoutParentRef {
+                    parent_node: "round".to_string(),
+                    parent_attempt: 1,
+                    item_index: Some(0),
+                    child_index: 0,
+                }),
+                timestamp: 7.0,
+            },
+        ]);
+        let mut events_after_child_completion = events_before_child_completion.clone();
+        events_after_child_completion.push(WorkflowEvent::NodeCompleted {
+            execution_id: EXECUTION_ID.to_string(),
+            node_execution_id: "worker-1".to_string(),
+            node_name: "worker".to_string(),
+            attempt: 1,
+            result_summary: None,
+            token_usage: None,
+            timestamp: 8.0,
+        });
+        let mut events_after_parent_completion = events_after_child_completion.clone();
+        events_after_parent_completion.push(WorkflowEvent::NodeCompleted {
+            execution_id: EXECUTION_ID.to_string(),
+            node_execution_id: "round-1".to_string(),
+            node_name: "round".to_string(),
+            attempt: 1,
+            result_summary: None,
+            token_usage: None,
+            timestamp: 9.0,
+        });
+
+        let replay = |events: &[WorkflowEvent]| {
+            project_retained_workflow_execution(EXECUTION_ID, events)
+                .unwrap()
+                .unwrap()
+        };
+        let before_child = replay(&events_before_child_completion);
+        let after_child = replay(&events_after_child_completion);
+        let after_parent = replay(&events_after_parent_completion);
+        let domain_workflow =
+            crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_domain(
+                &workflow,
+            );
+        let route = |projection: &RetainedWorkflowExecutionProjection| {
+            routing::route_with_reset_baselines(
+                &domain_workflow,
+                0,
+                None,
+                &projection.node_execution_counts,
+                &projection.loop_guard_reset_baselines,
+            )
+            .unwrap()
+        };
+        let in_range_count = |projection: &RetainedWorkflowExecutionProjection| {
+            projection.loop_guard_reset_baselines.execution_count(
+                "fix",
+                projection.node_execution_counts["fix"],
+                Some("round"),
+            )
+        };
+
+        assert_eq!(before_child.node_execution_counts["fix"], 2);
+        assert_eq!(after_child.node_execution_counts["fix"], 2);
+        assert_eq!(in_range_count(&before_child), 2);
+        assert_eq!(in_range_count(&after_child), 2);
+        assert_eq!(
+            route(&before_child),
+            RouteDecision::TransitionTo("done".into())
+        );
+        assert_eq!(
+            route(&after_child),
+            RouteDecision::TransitionTo("done".into())
+        );
+
+        assert_eq!(after_parent.node_execution_counts["fix"], 2);
+        assert_eq!(in_range_count(&after_parent), 0);
+        assert_eq!(
+            route(&after_parent),
+            RouteDecision::TransitionTo("fix".into())
         );
     }
 

--- a/src-tauri/src/adaptor/gateway/workflow/fanout_runtime.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/fanout_runtime.rs
@@ -366,6 +366,7 @@ mod tests {
             state: RuntimeExecutionState::Running,
             current_node_index: 0,
             node_execution_counts: HashMap::new(),
+            loop_guard_reset_baselines: Default::default(),
             node_history: Vec::new(),
             workflow_defaults: WorkflowDefaults {
                 backend_id: Some("backend-1".to_string()),

--- a/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR001_unknown-loop-guard-reset-node.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/fixtures/invalid/WFR001_unknown-loop-guard-reset-node.yml
@@ -1,0 +1,21 @@
+name: unknown-loop-guard-reset-node
+description: loop_guard.reset_on points to a missing node
+nodes:
+  - name: fix
+    session:
+      permission: edit
+      gate: auto
+      facets:
+        instruction: implement
+    rules:
+      - loop_guard:
+          max_iterations: 2
+          on_exhausted: done
+          reset_on: missing-boundary
+      - next: done
+  - name: done
+    session:
+      permission: edit
+      gate: auto
+      facets:
+        instruction: implement

--- a/src-tauri/src/adaptor/gateway/workflow/mapper.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/mapper.rs
@@ -148,9 +148,11 @@ fn domain_rule_to_schema(rule: domain::Rule) -> crate::adaptor::gateway::workflo
         domain::Rule::LoopGuard {
             max_iterations,
             on_exhausted,
+            reset_on,
         } => crate::adaptor::gateway::workflow::schema::Rule::LoopGuard {
             max_iterations,
             on_exhausted,
+            reset_on,
         },
         domain::Rule::Next(next) => crate::adaptor::gateway::workflow::schema::Rule::Next(next),
     }
@@ -435,6 +437,28 @@ mod tests {
                 .as_deref(),
             Some("inst")
         );
+    }
+
+    #[test]
+    fn workflow_mapping_round_trips_loop_guard_reset_on() {
+        let definition = domain::WorkflowDefinition {
+            name: "wf".to_string(),
+            nodes: vec![NodeDefinition {
+                name: "fix".to_string(),
+                rules: vec![domain::Rule::LoopGuard {
+                    max_iterations: 2,
+                    on_exhausted: "done".to_string(),
+                    reset_on: Some("round".to_string()),
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let schema = domain_workflow_to_schema(&definition).unwrap();
+        let mapped = schema_workflow_to_domain(schema).unwrap();
+
+        assert_eq!(mapped, definition);
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/output_submission.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/output_submission.rs
@@ -590,6 +590,7 @@ mod tests {
             state: RuntimeExecutionState::Running,
             current_node_index: 0,
             node_execution_counts: HashMap::from([("review".to_string(), 2)]),
+            loop_guard_reset_baselines: Default::default(),
             node_history: Vec::new(),
             workflow_defaults: WorkflowDefaults {
                 backend_id: None,

--- a/src-tauri/src/adaptor/gateway/workflow/resume_projection.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/resume_projection.rs
@@ -7,8 +7,9 @@
 use std::collections::HashMap;
 
 use crate::adaptor::gateway::workflow::event::WorkflowEvent;
-use crate::adaptor::gateway::workflow::event_projection::project_workflow_execution;
+use crate::adaptor::gateway::workflow::event_projection::project_retained_workflow_execution;
 use crate::adaptor::gateway::workflow::schema::WorkflowDefinitionYaml;
+use crate::domain::workflow::services::routing::LoopGuardResetBaselines;
 use crate::domain::workflow::{
     ExecutionOrigin, ExecutionStatus, NodeExecution, NodeExecutionStatus, TokenUsage,
 };
@@ -37,6 +38,7 @@ pub(crate) struct ResumeProjection {
     pub(crate) started_at: f64,
     pub(crate) resume_from_node: String,
     pub(crate) node_execution_counts: HashMap<String, u32>,
+    pub(crate) loop_guard_reset_baselines: LoopGuardResetBaselines,
     pub(crate) projected_node_executions: Vec<NodeExecution>,
     pub(crate) confirmed_top_level_nodes: Vec<NodeExecution>,
     pub(crate) confirmed_fanout_children: Vec<ConfirmedFanoutChild>,
@@ -46,8 +48,9 @@ pub(crate) fn project_resume_checkpoint(
     execution_id: &str,
     events: &[WorkflowEvent],
 ) -> Result<ResumeProjection, String> {
-    let execution = project_workflow_execution(execution_id, events)?
+    let projection = project_retained_workflow_execution(execution_id, events)?
         .ok_or_else(|| format!("execution {execution_id} has no execution_started event"))?;
+    let execution = projection.execution;
     if execution.status != ExecutionStatus::Interrupted {
         return Err(format!(
             "execution {execution_id} cannot resume from status {}",
@@ -87,14 +90,6 @@ pub(crate) fn project_resume_checkpoint(
             "execution {execution_id} must contain exactly one execution_started event"
         ));
     };
-
-    let mut node_execution_counts = HashMap::new();
-    for node in &execution.node_executions {
-        node_execution_counts
-            .entry(node.node_name.clone())
-            .and_modify(|attempt: &mut u32| *attempt = (*attempt).max(node.attempt))
-            .or_insert(node.attempt);
-    }
 
     let mut confirmed_top_level_nodes = execution
         .node_executions
@@ -216,7 +211,8 @@ pub(crate) fn project_resume_checkpoint(
         created_from: *created_from,
         started_at: *started_at,
         resume_from_node,
-        node_execution_counts,
+        node_execution_counts: projection.node_execution_counts,
+        loop_guard_reset_baselines: projection.loop_guard_reset_baselines,
         projected_node_executions: execution.node_executions,
         confirmed_top_level_nodes,
         confirmed_fanout_children,
@@ -230,9 +226,9 @@ mod tests {
         FanoutParentRef, TokenUsage as EventTokenUsage,
     };
     use crate::adaptor::gateway::workflow::schema::{
-        FanoutSpec, NodeDefinition, NodeKind, NodeKindName, SessionSpec,
+        FanoutSpec, NodeDefinition, NodeKind, NodeKindName, Rule, SessionSpec,
     };
-    use crate::domain::workflow::ExecutionInterruptionReason;
+    use crate::domain::workflow::{ExecutionInterruptionReason, NodeExecutionFailureKind};
 
     const EXECUTION_ID: &str = "00000000-0000-4000-8000-000000000133";
 
@@ -356,6 +352,179 @@ mod tests {
         assert_eq!(checkpoint.confirmed_top_level_nodes.len(), 1);
         assert_eq!(checkpoint.confirmed_top_level_nodes[0].node_name, "prepare");
         assert_eq!(checkpoint.node_execution_counts["fanout"], 1);
+    }
+
+    #[test]
+    fn restores_loop_guard_reset_baseline_from_event_order() {
+        let mut events = base_events();
+        let WorkflowEvent::ExecutionStarted { definition, .. } = &mut events[0] else {
+            unreachable!("base event must be ExecutionStarted");
+        };
+        definition.nodes = vec![
+            NodeDefinition {
+                name: "fix".to_string(),
+                rules: vec![Rule::LoopGuard {
+                    max_iterations: 2,
+                    on_exhausted: "done".to_string(),
+                    reset_on: Some("round".to_string()),
+                }],
+                ..Default::default()
+            },
+            NodeDefinition {
+                name: "round".to_string(),
+                ..Default::default()
+            },
+            NodeDefinition {
+                name: "done".to_string(),
+                ..Default::default()
+            },
+        ];
+        for (id, node_name, attempt, started_at, completed_at) in [
+            ("fix-1", "fix", 1, 2.0, 3.0),
+            ("fix-2", "fix", 2, 4.0, 5.0),
+            ("round-1", "round", 1, 6.0, 7.0),
+        ] {
+            events.push(WorkflowEvent::NodeStarted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: id.to_string(),
+                node_name: node_name.to_string(),
+                kind: NodeKindName::Session,
+                attempt,
+                fanout_parent: None,
+                timestamp: started_at,
+            });
+            events.push(WorkflowEvent::NodeCompleted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: id.to_string(),
+                node_name: node_name.to_string(),
+                attempt,
+                result_summary: None,
+                token_usage: None,
+                timestamp: completed_at,
+            });
+        }
+        events.extend([
+            WorkflowEvent::NodeStarted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "fix-3".to_string(),
+                node_name: "fix".to_string(),
+                kind: NodeKindName::Session,
+                attempt: 3,
+                fanout_parent: None,
+                timestamp: 8.0,
+            },
+            WorkflowEvent::ExecutionInterrupted {
+                execution_id: EXECUTION_ID.to_string(),
+                reason: ExecutionInterruptionReason::Crash,
+                timestamp: 9.0,
+            },
+        ]);
+
+        let checkpoint = project_resume_checkpoint(EXECUTION_ID, &events).unwrap();
+
+        assert_eq!(checkpoint.resume_from_node, "fix");
+        assert_eq!(checkpoint.node_execution_counts["fix"], 3);
+        assert_eq!(
+            checkpoint.loop_guard_reset_baselines.execution_count(
+                "fix",
+                checkpoint.node_execution_counts["fix"],
+                Some("round"),
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn failed_reset_node_does_not_advance_loop_guard_baseline() {
+        let mut events = base_events();
+        let WorkflowEvent::ExecutionStarted { definition, .. } = &mut events[0] else {
+            unreachable!("base event must be ExecutionStarted");
+        };
+        definition.nodes = vec![
+            NodeDefinition {
+                name: "fix".to_string(),
+                rules: vec![Rule::LoopGuard {
+                    max_iterations: 2,
+                    on_exhausted: "done".to_string(),
+                    reset_on: Some("round".to_string()),
+                }],
+                ..Default::default()
+            },
+            NodeDefinition {
+                name: "round".to_string(),
+                ..Default::default()
+            },
+            NodeDefinition {
+                name: "done".to_string(),
+                ..Default::default()
+            },
+        ];
+        events.extend([
+            WorkflowEvent::NodeStarted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "fix-1".to_string(),
+                node_name: "fix".to_string(),
+                kind: NodeKindName::Session,
+                attempt: 1,
+                fanout_parent: None,
+                timestamp: 2.0,
+            },
+            WorkflowEvent::NodeCompleted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "fix-1".to_string(),
+                node_name: "fix".to_string(),
+                attempt: 1,
+                result_summary: None,
+                token_usage: None,
+                timestamp: 3.0,
+            },
+            WorkflowEvent::NodeStarted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "round-1".to_string(),
+                node_name: "round".to_string(),
+                kind: NodeKindName::Session,
+                attempt: 1,
+                fanout_parent: None,
+                timestamp: 4.0,
+            },
+            WorkflowEvent::NodeFailed {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "round-1".to_string(),
+                node_name: "round".to_string(),
+                attempt: 1,
+                reason: "failed".to_string(),
+                failure_kind: NodeExecutionFailureKind::ValidationFailure,
+                retry_count: None,
+                timestamp: 5.0,
+            },
+            WorkflowEvent::NodeStarted {
+                execution_id: EXECUTION_ID.to_string(),
+                node_execution_id: "fix-2".to_string(),
+                node_name: "fix".to_string(),
+                kind: NodeKindName::Session,
+                attempt: 2,
+                fanout_parent: None,
+                timestamp: 6.0,
+            },
+            WorkflowEvent::ExecutionInterrupted {
+                execution_id: EXECUTION_ID.to_string(),
+                reason: ExecutionInterruptionReason::Crash,
+                timestamp: 7.0,
+            },
+        ]);
+
+        let checkpoint = project_resume_checkpoint(EXECUTION_ID, &events).unwrap();
+
+        assert_eq!(checkpoint.resume_from_node, "fix");
+        assert_eq!(checkpoint.node_execution_counts["fix"], 2);
+        assert_eq!(
+            checkpoint.loop_guard_reset_baselines.execution_count(
+                "fix",
+                checkpoint.node_execution_counts["fix"],
+                Some("round"),
+            ),
+            2
+        );
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl.rs
@@ -595,6 +595,18 @@ fn finalize_child_terminal_state(
     )
 }
 
+fn record_fanout_child_successful_completion(
+    execution: &mut WorkflowExecution,
+    child_node_name: &str,
+) {
+    let workflow = crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_domain(
+        &execution.workflow,
+    );
+    execution
+        .loop_guard_reset_baselines
+        .record_successful_completion(&workflow, child_node_name, &execution.node_execution_counts);
+}
+
 fn finalize_fanout_child_failure_state(
     exec: &mut WorkflowExecution,
     snapshot_before: WorkflowExecution,
@@ -976,6 +988,7 @@ impl WorkflowRuntimeService {
                 state,
                 current_node_index: 0,
                 node_execution_counts: HashMap::from([(current_node.clone(), 1)]),
+                loop_guard_reset_baselines: Default::default(),
                 node_history: Vec::new(),
                 workflow_defaults: WorkflowDefaults {
                     backend_id: None,
@@ -1156,6 +1169,7 @@ impl WorkflowRuntimeService {
             state: RuntimeExecutionState::Running,
             current_node_index: 0,
             node_execution_counts: HashMap::new(),
+            loop_guard_reset_baselines: Default::default(),
             node_history: Vec::new(),
             workflow_defaults,
             created_from,
@@ -2851,6 +2865,7 @@ impl WorkflowRuntimeService {
             node_execution.token_usage = Some(child_tokens.clone());
             node_execution.failure = None;
             node_execution.completed_at = Some(completed_at);
+            record_fanout_child_successful_completion(execution, expected_node_name);
             execution.updated_at = completed_at;
             let mut progress_events = vec![WorkflowEvent::ApprovalResolved {
                 execution_id: execution_id.to_string(),
@@ -3183,6 +3198,7 @@ impl WorkflowRuntimeService {
                 execution.failure = None;
                 execution.completed_at = Some(completed_at);
             }
+            record_fanout_child_successful_completion(exec, &child_name);
 
             // [08] child の RuntimeArtifact は CLI / Tauri 経由の SubmitOutput でのみ確定する。
             // ここでは artifacts slot に触れず、SubmitOutput 済みの値を保持したまま
@@ -4535,6 +4551,7 @@ impl WorkflowRuntimeService {
                 node_execution.failure = None;
                 node_execution.completed_at = Some(completed_at);
             }
+            record_fanout_child_successful_completion(execution, &input.node_name);
             let progress_events = vec![
                 WorkflowEvent::ArtifactProduced {
                     execution_id: input.execution_id.clone(),
@@ -5783,12 +5800,20 @@ impl WorkflowRuntimeService {
             let execution = find_by_worktree_mut(&mut executions, worktree_path)
                 .ok_or_else(|| WorkflowEngineError::ExecutionNotFound(worktree_path.to_string()))?;
             let snapshot_before = execution.clone();
-            let snapshot = workflow_fanout_runtime::apply_fanout_runtime_state(
+            workflow_fanout_runtime::apply_fanout_runtime_state(
                 execution,
                 &fanout_start,
                 &child_setups,
                 timestamp,
             )?;
+            for child in fanout_start
+                .children
+                .iter()
+                .filter(|child| child.reused.is_some())
+            {
+                record_fanout_child_successful_completion(execution, &child.node.name);
+            }
+            let snapshot = execution.to_commit_snapshot();
             (snapshot_before, snapshot)
         };
 
@@ -5830,6 +5855,11 @@ impl WorkflowRuntimeService {
                         timestamp,
                     });
                 }
+            }
+            // The live expansion installs every child NodeExecution before reused children are
+            // completed. Keep the durable fact order identical so replay sees the same execution
+            // counts at each reused child completion boundary.
+            for child in &fanout_start.children {
                 if let Some(reused) = child.reused.as_ref() {
                     if let Some(display_command) = reused.display_command.clone() {
                         started_events.push(WorkflowEvent::CommandPrepared {
@@ -6244,6 +6274,7 @@ impl WorkflowRuntimeService {
             state,
             current_node_index: 0,
             node_execution_counts: HashMap::from([("implementation_fix_policy".to_string(), 1)]),
+            loop_guard_reset_baselines: Default::default(),
             node_history: Vec::new(),
             started_at: 1000.0,
             updated_at: 1000.0,

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/resume_orchestration.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/resume_orchestration.rs
@@ -216,6 +216,7 @@ fn hydrate_resumed_execution(
             state: RuntimeExecutionState::Running,
             current_node_index,
             node_execution_counts,
+            loop_guard_reset_baselines: checkpoint.loop_guard_reset_baselines.clone(),
             node_history,
             workflow_defaults: WorkflowDefaults {
                 backend_id: None,

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_engine_impl/tests.rs
@@ -638,6 +638,7 @@ fn make_minimal_approval_exec(
         state: RuntimeExecutionState::WaitingApproval,
         current_node_index: 0,
         node_execution_counts: HashMap::from([(node_name.to_string(), 1)]),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -1337,6 +1338,7 @@ fn make_test_workflow() -> WorkflowDefinitionYaml {
                 Some(Rule::LoopGuard {
                     max_iterations: 3,
                     on_exhausted: "report".to_string(),
+                    reset_on: None,
                 }),
             ),
             make_test_node(
@@ -1359,6 +1361,7 @@ fn workflow_execution_to_commit_snapshot() {
         state: RuntimeExecutionState::Running,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -1398,6 +1401,7 @@ fn is_active_executionning() {
         state: RuntimeExecutionState::Running,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -1427,6 +1431,7 @@ fn is_active_waiting_approval() {
         state: RuntimeExecutionState::WaitingApproval,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -1456,6 +1461,7 @@ fn is_active_completed() {
         state: RuntimeExecutionState::Completed,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -1489,6 +1495,7 @@ fn is_active_failed() {
         },
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -1518,6 +1525,7 @@ fn is_active_aborted() {
         state: RuntimeExecutionState::Aborted,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -1550,6 +1558,7 @@ fn to_commit_snapshot_waiting_approval() {
         state: RuntimeExecutionState::WaitingApproval,
         current_node_index: 3,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1001.0,
@@ -1587,6 +1596,7 @@ fn to_commit_snapshot_failed() {
         },
         current_node_index: 1,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: vec![NodeHistoryEntry {
             node_name: "plan".to_string(),
             completed_at: 1000.5,
@@ -1638,6 +1648,7 @@ fn to_commit_snapshot_aborted() {
         state: RuntimeExecutionState::Aborted,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1001.0,
@@ -1669,6 +1680,7 @@ fn to_commit_snapshot_completed() {
         state: RuntimeExecutionState::Completed,
         current_node_index: 3,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1002.0,
@@ -1737,6 +1749,7 @@ fn make_exec(node_index: usize) -> WorkflowExecution {
         state: RuntimeExecutionState::Running,
         current_node_index: node_index,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         artifacts: HashMap::new(),
         node_executions: Vec::new(),
@@ -1764,6 +1777,7 @@ fn workflow_exec(workflow: WorkflowDefinitionYaml, node_index: usize) -> Workflo
         state: RuntimeExecutionState::Running,
         current_node_index: node_index,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         artifacts: HashMap::new(),
         node_executions: Vec::new(),
@@ -2354,6 +2368,68 @@ fn check_loop_guard_first_transition_no_count() {
         exec.check_loop_guard("review").unwrap(),
         LoopGuardResult::Allowed
     );
+}
+
+#[test]
+fn apply_advance_records_normal_node_reset_boundary_before_routing() {
+    let mut exec = make_exec(0);
+    let Rule::LoopGuard { reset_on, .. } = &mut exec.workflow.nodes[2].rules[1] else {
+        panic!("review must have loop_guard");
+    };
+    *reset_on = Some("plan".to_string());
+    exec.node_execution_counts.insert("review".to_string(), 3);
+    assert!(matches!(
+        exec.check_loop_guard("review").unwrap(),
+        LoopGuardResult::Exceeded { count: 3, .. }
+    ));
+
+    exec.apply_advance();
+
+    assert_eq!(
+        exec.check_loop_guard("review").unwrap(),
+        LoopGuardResult::Allowed
+    );
+}
+
+#[test]
+fn apply_advance_records_fanout_parent_reset_only_when_parent_completes() {
+    let workflow = WorkflowDefinitionYaml {
+        name: "fanout-reset".to_string(),
+        nodes: vec![
+            NodeDefinition {
+                name: "round".to_string(),
+                kind: NodeKind::Fanout(FanoutSpec {
+                    child: vec!["worker".to_string()],
+                    items: None,
+                }),
+                rules: vec![Rule::Next("fix".to_string())],
+                ..Default::default()
+            },
+            make_test_node("worker", TestKind::Session, "worker", vec![], None),
+            make_test_node(
+                "fix",
+                TestKind::Session,
+                "fix",
+                vec![],
+                Some(Rule::LoopGuard {
+                    max_iterations: 2,
+                    on_exhausted: "done".to_string(),
+                    reset_on: Some("round".to_string()),
+                }),
+            ),
+            make_test_node("done", TestKind::Session, "done", vec![], None),
+        ],
+        ..Default::default()
+    };
+    let mut exec = workflow_exec(workflow, 0);
+    exec.node_execution_counts.insert("round".to_string(), 1);
+    exec.node_execution_counts.insert("fix".to_string(), 2);
+
+    let outcome = exec.apply_advance();
+
+    assert!(matches!(outcome, NodeOutcome::TransitionAndStart(_)));
+    assert_eq!(exec.workflow.nodes[exec.current_node_index].name, "fix");
+    assert_eq!(exec.node_execution_counts["fix"], 3);
 }
 
 // ---- decide_turn_complete_action ----
@@ -3580,6 +3656,7 @@ fn insert_single_node_execution(
         state: RuntimeExecutionState::Running,
         current_node_index: 0,
         node_execution_counts: HashMap::from([(node_name.clone(), 1)]),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -4052,6 +4129,7 @@ fn make_approval_exec(state: RuntimeExecutionState, rules: Vec<Rule>) -> Workflo
         state,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: vec![],
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -4469,6 +4547,7 @@ fn apply_approval_application_records_approved_policy_and_advances_once() {
             m.insert("fix_policy".to_string(), 1);
             m
         },
+        loop_guard_reset_baselines: Default::default(),
         node_history: vec![],
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -4553,6 +4632,7 @@ fn auto_approve_persist_target_applies_latest_policy_and_advances_once() {
         state: RuntimeExecutionState::WaitingApproval,
         current_node_index: 0,
         node_execution_counts: HashMap::from([("implementation_fix_policy".to_string(), 1)]),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -4662,6 +4742,7 @@ async fn execute_outcome_auto_approve_persist_adopts_policy_and_starts_fix_once(
         state: RuntimeExecutionState::WaitingApproval,
         current_node_index: 1,
         node_execution_counts: HashMap::from([("implementation_fix_policy".to_string(), 1)]),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -4802,6 +4883,7 @@ fn make_normal_node_exec_with_stall_observation() -> WorkflowExecution {
         state: RuntimeExecutionState::Running,
         current_node_index: 0,
         node_execution_counts: HashMap::from([("plan".to_string(), 1)]),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -4860,6 +4942,7 @@ fn make_node_history_entry_saves_contract_result_to_node_output() {
             m.insert("plan".to_string(), 1);
             m
         },
+        loop_guard_reset_baselines: Default::default(),
         node_history: vec![],
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -4910,6 +4993,7 @@ fn make_node_history_entry_no_artifact_no_node_output() {
             m.insert("plan".to_string(), 1);
             m
         },
+        loop_guard_reset_baselines: Default::default(),
         node_history: vec![],
         started_at: 1000.0,
         updated_at: 1000.0,
@@ -4953,6 +5037,7 @@ fn make_on_exhausted_workflow() -> WorkflowDefinitionYaml {
                 Some(Rule::LoopGuard {
                     max_iterations: 2,
                     on_exhausted: "approval".to_string(),
+                    reset_on: None,
                 }),
             ),
             make_test_node(
@@ -4985,6 +5070,7 @@ fn on_exhausted_transitions_to_fallback_node() {
             m.insert("fix".to_string(), 2); // already at max
             m
         },
+        loop_guard_reset_baselines: Default::default(),
         node_history: vec![],
         artifacts: HashMap::new(),
         node_executions: Vec::new(),
@@ -5025,6 +5111,7 @@ fn check_loop_guard_exceeded_with_on_exhausted() {
             m.insert("fix".to_string(), 2);
             m
         },
+        loop_guard_reset_baselines: Default::default(),
         node_history: vec![],
         artifacts: HashMap::new(),
         node_executions: Vec::new(),
@@ -5080,6 +5167,7 @@ fn on_exhausted_chain_transitions() {
                 Some(Rule::LoopGuard {
                     max_iterations: 1,
                     on_exhausted: "node_b".to_string(),
+                    reset_on: None,
                 }),
             ),
             make_test_node(
@@ -5090,6 +5178,7 @@ fn on_exhausted_chain_transitions() {
                 Some(Rule::LoopGuard {
                     max_iterations: 1,
                     on_exhausted: "node_c".to_string(),
+                    reset_on: None,
                 }),
             ),
             make_test_node("node_c", TestKind::Session, "C", vec![], None),
@@ -5106,6 +5195,7 @@ fn on_exhausted_chain_transitions() {
             m.insert("node_b".to_string(), 1);
             m
         },
+        loop_guard_reset_baselines: Default::default(),
         node_history: vec![],
         artifacts: HashMap::new(),
         node_executions: Vec::new(),
@@ -5153,6 +5243,7 @@ fn make_on_exhausted_depth_exceeded_workflow() -> WorkflowDefinitionYaml {
                 Some(Rule::LoopGuard {
                     max_iterations: 1,
                     on_exhausted: "node_b".to_string(),
+                    reset_on: None,
                 }),
             ),
             make_test_node(
@@ -5163,6 +5254,7 @@ fn make_on_exhausted_depth_exceeded_workflow() -> WorkflowDefinitionYaml {
                 Some(Rule::LoopGuard {
                     max_iterations: 1,
                     on_exhausted: "node_a".to_string(),
+                    reset_on: None,
                 }),
             ),
         ],
@@ -5292,6 +5384,7 @@ fn apply_advance_to_fanout_clears_parent_output_without_child_map_entries() {
         state: RuntimeExecutionState::Running,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: vec![],
         artifacts: {
             let mut m = HashMap::new();
@@ -5586,6 +5679,7 @@ async fn engine_execution_id_consistency_across_execution_and_execution_store_me
         state: RuntimeExecutionState::Running,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 100.0,
         updated_at: 100.0,
@@ -5678,6 +5772,7 @@ async fn engine_validate_start_rejects_duplicate_active_execution_on_same_worktr
         state: RuntimeExecutionState::Running,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 100.0,
         updated_at: 100.0,
@@ -5927,6 +6022,7 @@ async fn handle_auto_complete_fixture_uses_execution_id_as_executions_key() {
         state: RuntimeExecutionState::Running,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 0.0,
         updated_at: 0.0,
@@ -5975,6 +6071,7 @@ fn make_exec_with(
         state,
         current_node_index: 0,
         node_execution_counts: HashMap::new(),
+        loop_guard_reset_baselines: Default::default(),
         node_history: Vec::new(),
         started_at: 100.0,
         updated_at: 110.0,
@@ -7131,6 +7228,7 @@ mod dispatch_boundary_tests {
             state: RuntimeExecutionState::WaitingApproval,
             current_node_index: 0,
             node_execution_counts: HashMap::from([(node_name.clone(), 1)]),
+            loop_guard_reset_baselines: Default::default(),
             node_history: Vec::new(),
             worktree_path: worktree_path.to_string(),
             created_from: ExecutionOrigin::Agent,
@@ -7834,6 +7932,7 @@ mod dispatch_boundary_tests {
                 ("prepare".to_string(), 1),
                 ("execute".to_string(), 1),
             ]),
+            loop_guard_reset_baselines: Default::default(),
             node_history: Vec::new(),
             worktree_path: worktree_path.to_string(),
             created_from: ExecutionOrigin::DesktopUi,
@@ -8082,6 +8181,226 @@ mod dispatch_boundary_tests {
             )
             .await;
         }
+    }
+
+    #[tokio::test]
+    async fn public_resume_preserves_reset_aware_routing_parity_with_uninterrupted_execution() {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_execution_store_data_dir(data_dir.clone()).await;
+        let (session_store, agent_runtime) = make_dispatch_deps(data_dir.clone());
+        let execution_id = uuid::Uuid::new_v4().to_string();
+        let worktree = TempDir::new().unwrap();
+        let workflow = WorkflowDefinitionYaml {
+            name: "reset-aware-public-resume".to_string(),
+            description: "resume with loop guard reset baseline".to_string(),
+            builtin: false,
+            schemas: Default::default(),
+            nodes: vec![
+                make_test_node(
+                    "fix",
+                    TestKind::Session,
+                    "review-summary",
+                    vec![Rule::Next("round".to_string())],
+                    Some(Rule::LoopGuard {
+                        max_iterations: 2,
+                        on_exhausted: "done".to_string(),
+                        reset_on: Some("round".to_string()),
+                    }),
+                ),
+                make_test_node(
+                    "round",
+                    TestKind::Session,
+                    "review-summary",
+                    vec![Rule::Next("route".to_string())],
+                    None,
+                ),
+                make_test_node(
+                    "route",
+                    TestKind::Session,
+                    "review-summary",
+                    vec![Rule::Next("fix".to_string())],
+                    None,
+                ),
+                make_test_node("done", TestKind::Session, "review-summary", vec![], None),
+            ],
+        };
+        let mut counts_at_reset = HashMap::from([("fix".to_string(), 2), ("round".to_string(), 1)]);
+        let domain_workflow =
+            crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_domain(
+                &workflow,
+            );
+        let mut reset_baselines =
+            crate::domain::workflow::services::routing::LoopGuardResetBaselines::default();
+        reset_baselines.record_successful_completion(&domain_workflow, "round", &counts_at_reset);
+        counts_at_reset.insert("fix".to_string(), 3);
+        counts_at_reset.insert("route".to_string(), 1);
+
+        let mut execution = WorkflowExecution {
+            id: execution_id.clone(),
+            workflow: workflow.clone(),
+            state: RuntimeExecutionState::Running,
+            current_node_index: 2,
+            node_execution_counts: counts_at_reset.clone(),
+            loop_guard_reset_baselines: reset_baselines.clone(),
+            node_history: Vec::new(),
+            worktree_path: worktree.path().to_string_lossy().into_owned(),
+            created_from: ExecutionOrigin::DesktopUi,
+            error_reason: None,
+            started_at: 1000.0,
+            updated_at: 1010.0,
+            current_session_id: Some("route-session-before-crash".to_string()),
+            current_node_token_usage: TokenUsage::default(),
+            artifacts: HashMap::new(),
+            node_executions: Vec::new(),
+            request: Some("continue reset-aware routing".to_string()),
+            fanout_runtime: None,
+            current_stall_observations: Vec::new(),
+            workflow_defaults: WorkflowDefaults {
+                backend_id: None,
+                permission_mode: PermissionMode::ASK.to_string(),
+            },
+        };
+        let mut events = vec![WorkflowEvent::ExecutionStarted {
+            execution_id: execution_id.clone(),
+            workflow_name: workflow.name.clone(),
+            worktree_path: execution.worktree_path.clone(),
+            created_from: execution.created_from,
+            request: execution.request.clone().unwrap(),
+            permission_mode: execution.workflow_defaults.permission_mode.clone(),
+            definition: workflow.clone(),
+            timestamp: 1000.0,
+        }];
+        for (node_name, attempt, started_at, completed_at) in [
+            ("fix", 1, 1001.0, 1002.0),
+            ("fix", 2, 1003.0, 1004.0),
+            ("round", 1, 1005.0, 1006.0),
+            ("fix", 3, 1007.0, 1008.0),
+        ] {
+            let node_execution_id = format!("{execution_id}-{node_name}-{attempt}");
+            let mut node_execution = node_execution_fixture(
+                &execution_id,
+                &node_execution_id,
+                node_name,
+                attempt,
+                NodeExecutionStatus::Succeeded,
+                None,
+                None,
+            );
+            node_execution.started_at = started_at;
+            node_execution.completed_at = Some(completed_at);
+            execution.node_executions.push(node_execution);
+            events.extend([
+                WorkflowEvent::NodeStarted {
+                    execution_id: execution_id.clone(),
+                    node_execution_id: node_execution_id.clone(),
+                    node_name: node_name.to_string(),
+                    kind: NodeKindName::Session,
+                    attempt,
+                    fanout_parent: None,
+                    timestamp: started_at,
+                },
+                WorkflowEvent::NodeCompleted {
+                    execution_id: execution_id.clone(),
+                    node_execution_id,
+                    node_name: node_name.to_string(),
+                    attempt,
+                    result_summary: None,
+                    token_usage: None,
+                    timestamp: completed_at,
+                },
+            ]);
+        }
+        let route_node_execution_id = format!("{execution_id}-route-1");
+        let mut route_execution = node_execution_fixture(
+            &execution_id,
+            &route_node_execution_id,
+            "route",
+            1,
+            NodeExecutionStatus::Running,
+            Some("route-session-before-crash"),
+            None,
+        );
+        route_execution.started_at = 1009.0;
+        execution.node_executions.push(route_execution);
+        events.extend([
+            WorkflowEvent::NodeStarted {
+                execution_id: execution_id.clone(),
+                node_execution_id: route_node_execution_id.clone(),
+                node_name: "route".to_string(),
+                kind: NodeKindName::Session,
+                attempt: 1,
+                fanout_parent: None,
+                timestamp: 1009.0,
+            },
+            WorkflowEvent::SessionAttached {
+                execution_id: execution_id.clone(),
+                node_execution_id: route_node_execution_id,
+                session_id: "route-session-before-crash".to_string(),
+                timestamp: 1009.0,
+            },
+        ]);
+        WorkflowEventLog::new(&data_dir)
+            .append_batch(&events)
+            .unwrap();
+        insert_execution_and_register_active(&engine, execution, ExecutionOrigin::DesktopUi).await;
+
+        assert!(engine
+            .interrupt_active_execution(
+                app.handle(),
+                &agent_runtime,
+                &execution_id,
+                ExecutionInterruptionReason::Crash,
+            )
+            .await
+            .unwrap());
+        engine
+            .resume_workflow_execution(app.handle(), &session_store, &agent_runtime, &execution_id)
+            .await
+            .unwrap();
+        let resumed_session_id = engine
+            .executions
+            .lock()
+            .await
+            .get(&execution_id)
+            .and_then(|execution| execution.current_session_id.clone())
+            .expect("resumed route session");
+
+        let mut uninterrupted = workflow_exec(workflow, 2);
+        uninterrupted.node_execution_counts = counts_at_reset;
+        uninterrupted.loop_guard_reset_baselines = reset_baselines;
+        uninterrupted.apply_advance();
+        let expected_node = uninterrupted.workflow.nodes[uninterrupted.current_node_index]
+            .name
+            .clone();
+        let expected_fix_count = uninterrupted.node_execution_counts["fix"];
+
+        engine
+            .on_turn_complete(
+                app.handle(),
+                &session_store,
+                &agent_runtime,
+                &resumed_session_id,
+                0,
+                None,
+                &[MessagePart::Text {
+                    content: "route after resume".to_string(),
+                    parent_tool_use_id: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let executions = engine.executions.lock().await;
+        let resumed = executions.get(&execution_id).expect("resumed execution");
+        assert_eq!(expected_node, "fix");
+        assert_eq!(
+            resumed.workflow.nodes[resumed.current_node_index].name,
+            expected_node
+        );
+        assert_eq!(resumed.node_execution_counts["fix"], expected_fix_count);
     }
 
     #[tokio::test]
@@ -13847,6 +14166,727 @@ mod dispatch_boundary_tests {
             completed_child.state,
             FanoutChildRuntimeState::Completed
         ));
+    }
+
+    async fn assert_fanout_reset_live_replay_parity(
+        reset_on: &str,
+        expected_count_after_first_child: u32,
+        expected_route_after_first_child: &str,
+    ) {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_execution_store_data_dir(data_dir.clone()).await;
+        let (session_store, handles) = make_dispatch_deps(data_dir.clone());
+
+        let execution_id = uuid::Uuid::new_v4().to_string();
+        let first_child_session_id = "fanout-reset-child-session-0";
+        let second_child_session_id = "fanout-reset-child-session-1";
+        let mut fanout = make_fanout_node("round", vec!["worker"]);
+        let NodeKind::Fanout(fanout_spec) = &mut fanout.kind else {
+            unreachable!("make_fanout_node must return a fanout")
+        };
+        fanout_spec.items = Some(ItemsSource::Literal(vec![
+            serde_json::json!({ "item": 0 }),
+            serde_json::json!({ "item": 1 }),
+        ]));
+        fanout.rules = vec![Rule::Next("fix".to_string())];
+        let workflow = WorkflowDefinitionYaml {
+            name: format!("fanout-{reset_on}-reset-parity"),
+            description: "test".to_string(),
+            builtin: false,
+            schemas: Default::default(),
+            nodes: vec![
+                fanout,
+                make_fanout_child("worker"),
+                make_approval_gated_session(
+                    "fix",
+                    "review-summary",
+                    vec![Rule::LoopGuard {
+                        max_iterations: 2,
+                        on_exhausted: "done".to_string(),
+                        reset_on: Some(reset_on.to_string()),
+                    }],
+                ),
+                make_approval_gated_session("done", "review-summary", vec![]),
+            ],
+        };
+        let mut execution = make_waiting_approval_execution_with_workflow(
+            &execution_id,
+            "/wt/fanout-reset-parity",
+            workflow,
+        );
+        execution.state = RuntimeExecutionState::Running;
+        execution.current_session_id = None;
+        execution.node_execution_counts = HashMap::from([
+            ("round".to_string(), 1),
+            ("worker".to_string(), 2),
+            ("fix".to_string(), 2),
+        ]);
+        let first_child = test_fanout_child(
+            "worker",
+            first_child_session_id,
+            FanoutChildRuntimeState::Running,
+            0,
+        );
+        let mut second_child = test_fanout_child(
+            "worker",
+            second_child_session_id,
+            FanoutChildRuntimeState::Running,
+            1,
+        );
+        second_child.attempt = 2;
+        install_test_fanout(&mut execution, vec![first_child, second_child]);
+        for (item_index, node_execution) in execution
+            .node_executions
+            .iter_mut()
+            .filter(|node_execution| node_execution.node_name == "worker")
+            .enumerate()
+        {
+            let parent = node_execution
+                .fanout_parent
+                .as_mut()
+                .expect("fanout child reference");
+            parent.item_index = Some(item_index);
+            parent.child_index = 0;
+        }
+        let mut historical_fix_executions = Vec::new();
+        for attempt in 1..=2 {
+            let node_execution_id = format!("{execution_id}-fix-{attempt}");
+            let mut fix_execution = node_execution_fixture(
+                &execution_id,
+                &node_execution_id,
+                "fix",
+                attempt,
+                NodeExecutionStatus::Succeeded,
+                None,
+                None,
+            );
+            fix_execution.completed_at = Some(1000.0 + f64::from(attempt));
+            historical_fix_executions.push(fix_execution);
+        }
+        execution
+            .node_executions
+            .splice(0..0, historical_fix_executions);
+        append_started_events_for_execution(&data_dir, &execution);
+        WorkflowEventLog::new(&data_dir)
+            .append_batch(
+                &(1..=2)
+                    .map(|attempt| WorkflowEvent::NodeCompleted {
+                        execution_id: execution_id.clone(),
+                        node_execution_id: format!("{execution_id}-fix-{attempt}"),
+                        node_name: "fix".to_string(),
+                        attempt,
+                        result_summary: None,
+                        token_usage: None,
+                        timestamp: 1000.0 + f64::from(attempt),
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+        insert_execution_and_register_active(&engine, execution, ExecutionOrigin::DesktopUi).await;
+        for session_id in [first_child_session_id, second_child_session_id] {
+            engine.session_workflow_refs.lock().await.insert(
+                session_id.to_string(),
+                SessionWorkflowRef {
+                    execution_id: execution_id.clone(),
+                },
+            );
+        }
+
+        engine
+            .on_turn_complete(
+                app.handle(),
+                &session_store,
+                &handles,
+                first_child_session_id,
+                0,
+                None,
+                &[MessagePart::Text {
+                    content: "first item complete".to_string(),
+                    parent_tool_use_id: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let (workflow, live_counts, live_baselines) = {
+            let executions = engine.executions.lock().await;
+            let execution = executions.get(&execution_id).expect("live execution");
+            assert_eq!(
+                execution.workflow.nodes[execution.current_node_index].name, "round",
+                "the fanout parent must remain active until every item completes"
+            );
+            (
+                execution.workflow.clone(),
+                execution.node_execution_counts.clone(),
+                execution.loop_guard_reset_baselines.clone(),
+            )
+        };
+        let mut interrupted_events = WorkflowEventLog::new(&data_dir)
+            .read_log(&execution_id)
+            .unwrap();
+        interrupted_events.push(WorkflowEvent::ExecutionInterrupted {
+            execution_id: execution_id.clone(),
+            reason: ExecutionInterruptionReason::Crash,
+            timestamp: current_timestamp() + 1.0,
+        });
+        let checkpoint = workflow_resume_projection::project_resume_checkpoint(
+            &execution_id,
+            &interrupted_events,
+        )
+        .unwrap();
+        let live_count = live_baselines.execution_count("fix", live_counts["fix"], Some(reset_on));
+        let replay_count = checkpoint.loop_guard_reset_baselines.execution_count(
+            "fix",
+            checkpoint.node_execution_counts["fix"],
+            Some(reset_on),
+        );
+        assert_eq!(live_count, expected_count_after_first_child);
+        assert_eq!(replay_count, live_count);
+        let domain_workflow =
+            crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_domain(
+                &workflow,
+            );
+        let live_route = crate::domain::workflow::services::routing::route_with_reset_baselines(
+            &domain_workflow,
+            0,
+            None,
+            &live_counts,
+            &live_baselines,
+        )
+        .unwrap();
+        let replay_route = crate::domain::workflow::services::routing::route_with_reset_baselines(
+            &domain_workflow,
+            0,
+            None,
+            &checkpoint.node_execution_counts,
+            &checkpoint.loop_guard_reset_baselines,
+        )
+        .unwrap();
+        assert_eq!(live_route, replay_route);
+        assert_eq!(
+            live_route,
+            crate::domain::workflow::services::routing::RouteDecision::TransitionTo(
+                expected_route_after_first_child.to_string()
+            )
+        );
+
+        engine
+            .on_turn_complete(
+                app.handle(),
+                &session_store,
+                &handles,
+                second_child_session_id,
+                0,
+                None,
+                &[MessagePart::Text {
+                    content: "second item complete".to_string(),
+                    parent_tool_use_id: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let (live_counts, live_baselines) = {
+            let executions = engine.executions.lock().await;
+            let execution = executions.get(&execution_id).expect("live execution");
+            assert_eq!(
+                execution.workflow.nodes[execution.current_node_index].name, "fix",
+                "the completed fanout must route using the reset-aware count"
+            );
+            (
+                execution.node_execution_counts.clone(),
+                execution.loop_guard_reset_baselines.clone(),
+            )
+        };
+        let mut interrupted_events = WorkflowEventLog::new(&data_dir)
+            .read_log(&execution_id)
+            .unwrap();
+        interrupted_events.push(WorkflowEvent::ExecutionInterrupted {
+            execution_id: execution_id.clone(),
+            reason: ExecutionInterruptionReason::Crash,
+            timestamp: current_timestamp() + 1.0,
+        });
+        let checkpoint = workflow_resume_projection::project_resume_checkpoint(
+            &execution_id,
+            &interrupted_events,
+        )
+        .unwrap();
+        assert_eq!(checkpoint.resume_from_node, "fix");
+        assert_eq!(checkpoint.node_execution_counts, live_counts);
+        assert_eq!(
+            checkpoint.loop_guard_reset_baselines.execution_count(
+                "fix",
+                checkpoint.node_execution_counts["fix"],
+                Some(reset_on),
+            ),
+            live_baselines.execution_count("fix", live_counts["fix"], Some(reset_on))
+        );
+        assert_eq!(
+            live_baselines.execution_count("fix", live_counts["fix"], Some(reset_on)),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn fanout_child_reset_baseline_matches_replay_for_multiple_items() {
+        assert_fanout_reset_live_replay_parity("worker", 0, "fix").await;
+    }
+
+    #[tokio::test]
+    async fn fanout_parent_reset_waits_for_parent_completion_in_live_and_replay() {
+        assert_fanout_reset_live_replay_parity("round", 2, "done").await;
+    }
+
+    fn fanout_child_completion_reset_workflow(
+        workflow_name: &str,
+        child: NodeDefinition,
+    ) -> WorkflowDefinitionYaml {
+        let mut fanout = make_fanout_node("round", vec!["worker"]);
+        let NodeKind::Fanout(fanout_spec) = &mut fanout.kind else {
+            unreachable!("make_fanout_node must return a fanout")
+        };
+        fanout_spec.items = Some(ItemsSource::Literal(vec![
+            serde_json::json!({ "item": 0 }),
+            serde_json::json!({ "item": 1 }),
+        ]));
+        fanout.rules = vec![Rule::Next("fix".to_string())];
+        WorkflowDefinitionYaml {
+            name: workflow_name.to_string(),
+            description: "test".to_string(),
+            builtin: false,
+            schemas: Default::default(),
+            nodes: vec![
+                fanout,
+                child,
+                make_approval_gated_session(
+                    "fix",
+                    "review-summary",
+                    vec![Rule::LoopGuard {
+                        max_iterations: 2,
+                        on_exhausted: "done".to_string(),
+                        reset_on: Some("worker".to_string()),
+                    }],
+                ),
+                make_approval_gated_session("done", "review-summary", vec![]),
+            ],
+        }
+    }
+
+    fn add_historical_guarded_node_completions(execution: &mut WorkflowExecution) {
+        let mut historical_fix_executions = Vec::new();
+        for attempt in 1..=2 {
+            let node_execution_id = format!("{}-fix-{attempt}", execution.id);
+            let mut fix_execution = node_execution_fixture(
+                &execution.id,
+                &node_execution_id,
+                "fix",
+                attempt,
+                NodeExecutionStatus::Succeeded,
+                None,
+                None,
+            );
+            fix_execution.completed_at = Some(1000.0 + f64::from(attempt));
+            historical_fix_executions.push(fix_execution);
+        }
+        execution
+            .node_executions
+            .splice(0..0, historical_fix_executions);
+    }
+
+    fn append_fanout_child_reset_seed_events(
+        data_dir: &std::path::Path,
+        execution: &WorkflowExecution,
+    ) {
+        append_started_events_for_execution(data_dir, execution);
+        WorkflowEventLog::new(data_dir)
+            .append_batch(
+                &(1..=2)
+                    .map(|attempt| WorkflowEvent::NodeCompleted {
+                        execution_id: execution.id.clone(),
+                        node_execution_id: format!("{}-fix-{attempt}", execution.id),
+                        node_name: "fix".to_string(),
+                        attempt,
+                        result_summary: None,
+                        token_usage: None,
+                        timestamp: 1000.0 + f64::from(attempt),
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+    }
+
+    async fn assert_fanout_child_completion_live_replay_parity(
+        engine: &WorkflowRuntimeService,
+        data_dir: &std::path::Path,
+        execution_id: &str,
+        expected_current_node: &str,
+        expected_range_count: u32,
+    ) {
+        let (workflow, live_counts, live_baselines) = {
+            let executions = engine.executions.lock().await;
+            let execution = executions.get(execution_id).expect("live execution");
+            assert_eq!(
+                execution.workflow.nodes[execution.current_node_index].name,
+                expected_current_node
+            );
+            (
+                execution.workflow.clone(),
+                execution.node_execution_counts.clone(),
+                execution.loop_guard_reset_baselines.clone(),
+            )
+        };
+        let mut interrupted_events = WorkflowEventLog::new(data_dir)
+            .read_log(execution_id)
+            .unwrap();
+        interrupted_events.push(WorkflowEvent::ExecutionInterrupted {
+            execution_id: execution_id.to_string(),
+            reason: ExecutionInterruptionReason::Crash,
+            timestamp: current_timestamp() + 1.0,
+        });
+        let checkpoint = workflow_resume_projection::project_resume_checkpoint(
+            execution_id,
+            &interrupted_events,
+        )
+        .unwrap();
+
+        assert_eq!(checkpoint.node_execution_counts, live_counts);
+        assert_eq!(checkpoint.loop_guard_reset_baselines, live_baselines);
+        assert_eq!(
+            live_baselines.execution_count("fix", live_counts["fix"], Some("worker")),
+            expected_range_count
+        );
+        let domain_workflow =
+            crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_domain(
+                &workflow,
+            );
+        let live_route = crate::domain::workflow::services::routing::route_with_reset_baselines(
+            &domain_workflow,
+            0,
+            None,
+            &live_counts,
+            &live_baselines,
+        )
+        .unwrap();
+        let replay_route = crate::domain::workflow::services::routing::route_with_reset_baselines(
+            &domain_workflow,
+            0,
+            None,
+            &checkpoint.node_execution_counts,
+            &checkpoint.loop_guard_reset_baselines,
+        )
+        .unwrap();
+        assert_eq!(live_route, replay_route);
+        assert_eq!(
+            live_route,
+            crate::domain::workflow::services::routing::RouteDecision::TransitionTo(
+                "fix".to_string()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn fanout_approval_child_reset_baseline_matches_replay_and_append_rollback() {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_execution_store_data_dir(data_dir.clone()).await;
+        let (session_store, agent_runtime) = make_dispatch_deps(data_dir.clone());
+        let execution_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/fanout-approval-reset-parity";
+        let first_session_id = "fanout-approval-reset-session-0";
+        let second_session_id = "fanout-approval-reset-session-1";
+        let workflow = fanout_child_completion_reset_workflow(
+            "fanout-approval-reset-parity",
+            make_approval_gated_session("worker", "review-summary", vec![]),
+        );
+        let mut execution =
+            make_waiting_approval_execution_with_workflow(&execution_id, worktree_path, workflow);
+        execution.state = RuntimeExecutionState::Running;
+        execution.current_session_id = None;
+        execution.node_execution_counts = HashMap::from([
+            ("round".to_string(), 1),
+            ("worker".to_string(), 2),
+            ("fix".to_string(), 2),
+        ]);
+        let first_child = test_fanout_child(
+            "worker",
+            first_session_id,
+            FanoutChildRuntimeState::Running,
+            0,
+        );
+        let mut second_child = test_fanout_child(
+            "worker",
+            second_session_id,
+            FanoutChildRuntimeState::Running,
+            1,
+        );
+        second_child.attempt = 2;
+        install_test_fanout(&mut execution, vec![first_child, second_child]);
+        for (item_index, node_execution) in execution
+            .node_executions
+            .iter_mut()
+            .filter(|node_execution| node_execution.node_name == "worker")
+            .enumerate()
+        {
+            node_execution
+                .fanout_parent
+                .as_mut()
+                .expect("fanout child reference")
+                .item_index = Some(item_index);
+        }
+        let first_node_execution_id = execution
+            .fanout_runtime
+            .as_ref()
+            .expect("fanout runtime")
+            .children[0]
+            .node_execution_id
+            .clone();
+        execution
+            .node_executions
+            .iter_mut()
+            .find(|node_execution| node_execution.id == first_node_execution_id)
+            .expect("first approval child")
+            .status = NodeExecutionStatus::WaitingApproval;
+        add_historical_guarded_node_completions(&mut execution);
+        append_fanout_child_reset_seed_events(&data_dir, &execution);
+        insert_execution_and_register_active(&engine, execution, ExecutionOrigin::DesktopUi).await;
+
+        engine.fail_next_required_event_append_for_test();
+        engine
+            .resolve_workflow_approval(
+                app.handle(),
+                &session_store,
+                &agent_runtime,
+                &execution_id,
+                None,
+                "worker",
+                Some(&first_node_execution_id),
+            )
+            .await
+            .expect_err("approval completion append failure must roll back");
+        {
+            let executions = engine.executions.lock().await;
+            let execution = executions
+                .get(&execution_id)
+                .expect("rolled back execution");
+            assert_eq!(execution.loop_guard_reset_baselines, Default::default());
+            assert_eq!(
+                execution
+                    .node_executions
+                    .iter()
+                    .find(|node_execution| node_execution.id == first_node_execution_id)
+                    .expect("rolled back approval child")
+                    .status,
+                NodeExecutionStatus::WaitingApproval
+            );
+        }
+
+        engine
+            .resolve_workflow_approval(
+                app.handle(),
+                &session_store,
+                &agent_runtime,
+                &execution_id,
+                None,
+                "worker",
+                Some(&first_node_execution_id),
+            )
+            .await
+            .unwrap();
+        assert_fanout_child_completion_live_replay_parity(
+            &engine,
+            &data_dir,
+            &execution_id,
+            "round",
+            0,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn fanout_command_child_reset_baseline_matches_replay_and_append_rollback() {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_execution_store_data_dir(data_dir.clone()).await;
+        let (session_store, agent_runtime) = make_dispatch_deps(data_dir.clone());
+        let execution_id = uuid::Uuid::new_v4().to_string();
+        let worktree_path = "/wt/fanout-command-reset-parity";
+        let workflow = fanout_child_completion_reset_workflow(
+            "fanout-command-reset-parity",
+            command_node("worker", "printf ok", vec![]),
+        );
+        let mut execution =
+            make_waiting_approval_execution_with_workflow(&execution_id, worktree_path, workflow);
+        execution.state = RuntimeExecutionState::Running;
+        execution.current_session_id = None;
+        execution.node_execution_counts = HashMap::from([
+            ("round".to_string(), 1),
+            ("worker".to_string(), 2),
+            ("fix".to_string(), 2),
+        ]);
+        let first_child = test_fanout_child("worker", "", FanoutChildRuntimeState::Running, 0);
+        let mut second_child = test_fanout_child("worker", "", FanoutChildRuntimeState::Running, 1);
+        second_child.attempt = 2;
+        install_test_fanout(&mut execution, vec![first_child, second_child]);
+        for (item_index, node_execution) in execution
+            .node_executions
+            .iter_mut()
+            .filter(|node_execution| node_execution.node_name == "worker")
+            .enumerate()
+        {
+            node_execution.kind = NodeKindName::Command;
+            node_execution
+                .fanout_parent
+                .as_mut()
+                .expect("fanout child reference")
+                .item_index = Some(item_index);
+        }
+        let first_child = &execution
+            .fanout_runtime
+            .as_ref()
+            .expect("fanout runtime")
+            .children[0];
+        let input = CommandExecutionInput {
+            execution_id: execution_id.clone(),
+            node_execution_id: first_child.node_execution_id.clone(),
+            node_name: first_child.node_name.clone(),
+            attempt: first_child.attempt,
+            worktree_path: worktree_path.to_string(),
+            raw_command: Some("printf ok".to_string()),
+            contract: None,
+            schemas: Default::default(),
+            fanout_parent: Some("round".to_string()),
+            session_id: None,
+        };
+        add_historical_guarded_node_completions(&mut execution);
+        append_fanout_child_reset_seed_events(&data_dir, &execution);
+        insert_execution_and_register_active(&engine, execution, ExecutionOrigin::DesktopUi).await;
+
+        engine.fail_next_required_event_append_for_test();
+        engine
+            .commit_fanout_command_output(
+                app.handle(),
+                &session_store,
+                &agent_runtime,
+                input.clone(),
+                command_output_for_test(0, "ok".to_string(), String::new()),
+            )
+            .await
+            .expect_err("command completion append failure must roll back");
+        {
+            let executions = engine.executions.lock().await;
+            let execution = executions
+                .get(&execution_id)
+                .expect("rolled back execution");
+            assert_eq!(execution.loop_guard_reset_baselines, Default::default());
+            assert_eq!(
+                execution
+                    .node_executions
+                    .iter()
+                    .find(|node_execution| node_execution.id == input.node_execution_id)
+                    .expect("rolled back command child")
+                    .status,
+                NodeExecutionStatus::Running
+            );
+        }
+
+        engine
+            .commit_fanout_command_output(
+                app.handle(),
+                &session_store,
+                &agent_runtime,
+                input,
+                command_output_for_test(0, "ok".to_string(), String::new()),
+            )
+            .await
+            .unwrap();
+        assert_fanout_child_completion_live_replay_parity(
+            &engine,
+            &data_dir,
+            &execution_id,
+            "round",
+            0,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn reused_fanout_children_reset_baseline_matches_replay_routing_and_append_rollback() {
+        let app = make_dispatch_app();
+        let engine = WorkflowRuntimeService::new_for_test();
+        let data_dir = dispatch_data_dir(app.handle());
+        engine.set_execution_store_data_dir(data_dir.clone()).await;
+        let (session_store, agent_runtime) = make_dispatch_deps(data_dir.clone());
+        let execution_id = uuid::Uuid::new_v4().to_string();
+        let worktree = TempDir::new().unwrap();
+        let worktree_path = worktree.path().to_string_lossy().into_owned();
+        let workflow = fanout_child_completion_reset_workflow(
+            "reused-fanout-child-reset-parity",
+            make_fanout_child("worker"),
+        );
+        let mut execution =
+            make_waiting_approval_execution_with_workflow(&execution_id, &worktree_path, workflow);
+        execution.state = RuntimeExecutionState::Running;
+        execution.current_session_id = None;
+        execution.node_execution_counts =
+            HashMap::from([("round".to_string(), 1), ("fix".to_string(), 2)]);
+        add_historical_guarded_node_completions(&mut execution);
+        append_fanout_child_reset_seed_events(&data_dir, &execution);
+        insert_execution_and_register_active(&engine, execution, ExecutionOrigin::DesktopUi).await;
+        engine.fanout_resume_checkpoints.lock().await.insert(
+            execution_id.clone(),
+            FanoutResumeCheckpoint {
+                parent_node_name: "round".to_string(),
+                children: (0..=1)
+                    .map(|item_index| FanoutResumeChild {
+                        node_name: "worker".to_string(),
+                        item_index: Some(item_index),
+                        child_index: 0,
+                        reusable: workflow_fanout_runtime::ReusableFanoutChild {
+                            result: Some(format!("reused item {item_index}")),
+                            display_command: None,
+                            artifact: None,
+                            contract: None,
+                            token_usage: None,
+                            completed_at: 1003.0 + item_index as f64,
+                        },
+                    })
+                    .collect(),
+            },
+        );
+
+        engine.fail_next_required_event_append_for_test();
+        engine
+            .start_fanout_children(app.handle(), &session_store, &agent_runtime, &worktree_path)
+            .await
+            .expect_err("reused child completion append failure must roll back");
+        {
+            let executions = engine.executions.lock().await;
+            let execution = executions
+                .get(&execution_id)
+                .expect("rolled back execution");
+            assert!(execution.fanout_runtime.is_none());
+            assert!(!execution.node_execution_counts.contains_key("worker"));
+            assert_eq!(execution.loop_guard_reset_baselines, Default::default());
+        }
+
+        engine
+            .start_fanout_children(app.handle(), &session_store, &agent_runtime, &worktree_path)
+            .await
+            .unwrap();
+        assert_fanout_child_completion_live_replay_parity(
+            &engine,
+            &data_dir,
+            &execution_id,
+            "fix",
+            1,
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_session.rs
@@ -948,6 +948,7 @@ mod tests {
             state: RuntimeExecutionState::Running,
             current_node_index: 0,
             node_execution_counts: HashMap::from([(node_name, 1)]),
+            loop_guard_reset_baselines: Default::default(),
             node_history: Vec::new(),
             workflow_defaults: WorkflowDefaults {
                 backend_id: None,

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_state.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_state.rs
@@ -37,6 +37,7 @@ pub(crate) struct WorkflowExecution {
     pub(crate) state: RuntimeExecutionState,
     pub(crate) current_node_index: usize,
     pub(crate) node_execution_counts: HashMap<String, u32>,
+    pub(crate) loop_guard_reset_baselines: workflow_routing::LoopGuardResetBaselines,
     pub(crate) node_history: Vec<NodeHistoryEntry>,
     /// node / 並列子 node 起動時の継承デフォルト（permission_mode / backend_id / selected_model）。
     /// `start_workflow` 時に capture し、以降は session_store を読み直さない（in-memory のみ）。
@@ -427,7 +428,15 @@ impl WorkflowExecution {
 
     /// ロック内で次ステップへの advance を適用する（純粋な状態変更）。
     pub(crate) fn apply_advance(&mut self) -> NodeOutcome {
-        let decision = self.decide_next_node();
+        let workflow = workflow_definition_to_domain(&self.workflow);
+        let completed_node_name = self.workflow.nodes[self.current_node_index].name.clone();
+        self.loop_guard_reset_baselines
+            .record_successful_completion(
+                &workflow,
+                &completed_node_name,
+                &self.node_execution_counts,
+            );
+        let decision = self.decide_next_node_with_workflow(&workflow);
         match decision {
             NextNodeDecision::Completed => {
                 self.state = RuntimeExecutionState::Completed;
@@ -500,13 +509,22 @@ impl WorkflowExecution {
     }
 
     /// 次のステップ遷移先を判定する（純粋関数）。
+    #[cfg(test)]
     pub(crate) fn decide_next_node(&self) -> NextNodeDecision {
         let workflow = workflow_definition_to_domain(&self.workflow);
-        match workflow_routing::route(
-            &workflow,
+        self.decide_next_node_with_workflow(&workflow)
+    }
+
+    fn decide_next_node_with_workflow(
+        &self,
+        workflow: &crate::domain::workflow::WorkflowDefinition,
+    ) -> NextNodeDecision {
+        match workflow_routing::route_with_reset_baselines(
+            workflow,
             self.current_node_index,
             self.current_node_artifact(),
             &self.node_execution_counts,
+            &self.loop_guard_reset_baselines,
         ) {
             Ok(workflow_routing::RouteDecision::Completed) => NextNodeDecision::Completed,
             Ok(workflow_routing::RouteDecision::TransitionTo(name)) => {
@@ -532,10 +550,11 @@ impl WorkflowExecution {
         target_node_name: &str,
     ) -> Result<LoopGuardResult, WorkflowEngineError> {
         let workflow = workflow_definition_to_domain(&self.workflow);
-        let decision = workflow_routing::guarded_target(
+        let decision = workflow_routing::guarded_target_with_reset_baselines(
             &workflow,
             target_node_name.to_string(),
             &self.node_execution_counts,
+            &self.loop_guard_reset_baselines,
         )
         .map_err(workflow_error_to_engine_error)?;
         if matches!(
@@ -553,14 +572,20 @@ impl WorkflowExecution {
                     "Node '{target_node_name}' not found in workflow"
                 ))
             })?;
-        let Some((max_iterations, on_exhausted)) = workflow_routing::loop_guard(node) else {
+        let Some((max_iterations, on_exhausted, reset_on)) = workflow_routing::loop_guard(node)
+        else {
             return Ok(LoopGuardResult::Allowed);
         };
-        let count = self
+        let cumulative_count = self
             .node_execution_counts
             .get(target_node_name)
             .copied()
             .unwrap_or(0);
+        let count = self.loop_guard_reset_baselines.execution_count(
+            target_node_name,
+            cumulative_count,
+            reset_on,
+        );
         Ok(LoopGuardResult::Exceeded {
             max_iterations,
             count,

--- a/src-tauri/src/adaptor/gateway/workflow/schema.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/schema.rs
@@ -416,6 +416,8 @@ pub struct SwitchRule {
 pub struct LoopGuardRule {
     pub max_iterations: u32,
     pub on_exhausted: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_on: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -433,6 +435,7 @@ pub enum Rule {
     LoopGuard {
         max_iterations: u32,
         on_exhausted: String,
+        reset_on: Option<String>,
     },
     Next(String),
 }
@@ -476,6 +479,7 @@ impl<'de> Deserialize<'de> for Rule {
             (None, None, Some(loop_guard), None) => Ok(Self::LoopGuard {
                 max_iterations: loop_guard.max_iterations,
                 on_exhausted: loop_guard.on_exhausted,
+                reset_on: loop_guard.reset_on,
             }),
             (None, None, None, Some(next)) => Ok(Self::Next(next)),
             (None, None, Some(_), Some(_)) => {
@@ -522,12 +526,14 @@ impl Serialize for Rule {
             Self::LoopGuard {
                 max_iterations,
                 on_exhausted,
+                reset_on,
             } => {
                 map.serialize_entry(
                     "loop_guard",
                     &LoopGuardRule {
                         max_iterations: *max_iterations,
                         on_exhausted: on_exhausted.clone(),
+                        reset_on: reset_on.clone(),
                     },
                 )?;
             }
@@ -842,7 +848,7 @@ nodes:
     rules:
       - when: { on: ok, then: done }
         next: fix
-      - loop_guard: { max_iterations: 3, on_exhausted: give_up }
+      - loop_guard: { max_iterations: 3, on_exhausted: give_up, reset_on: judge }
   - name: triage
     session:
       permission: edit
@@ -867,8 +873,9 @@ nodes:
             &wf.nodes[0].rules[1],
             Rule::LoopGuard {
                 max_iterations: 3,
-                on_exhausted
-            } if on_exhausted == "give_up"
+                on_exhausted,
+                reset_on: Some(reset_on),
+            } if on_exhausted == "give_up" && reset_on == "judge"
         ));
         assert!(matches!(
             &wf.nodes[1].rules[0],

--- a/src-tauri/src/domain/workflow/services/routing.rs
+++ b/src-tauri/src/domain/workflow/services/routing.rs
@@ -14,11 +14,61 @@ pub enum RouteDecision {
     TransitionTo(String),
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LoopGuardResetBaselines {
+    by_guarded_node: HashMap<String, u32>,
+}
+
+impl LoopGuardResetBaselines {
+    pub fn record_successful_completion(
+        &mut self,
+        workflow: &WorkflowDefinition,
+        completed_node_name: &str,
+        node_execution_counts: &HashMap<String, u32>,
+    ) {
+        for guarded_node in &workflow.nodes {
+            let Some((_, _, Some(reset_on))) = loop_guard(guarded_node) else {
+                continue;
+            };
+            if reset_on == completed_node_name {
+                let cumulative_count = node_execution_counts
+                    .get(&guarded_node.name)
+                    .copied()
+                    .unwrap_or(0);
+                self.by_guarded_node
+                    .insert(guarded_node.name.clone(), cumulative_count);
+            }
+        }
+    }
+
+    pub fn execution_count(
+        &self,
+        guarded_node_name: &str,
+        cumulative_count: u32,
+        reset_on: Option<&str>,
+    ) -> u32 {
+        if reset_on.is_some() {
+            cumulative_count.saturating_sub(
+                self.by_guarded_node
+                    .get(guarded_node_name)
+                    .copied()
+                    .unwrap_or(0),
+            )
+        } else {
+            cumulative_count
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RoutingValidationError {
     UnknownRuleTarget {
         node: String,
         target: String,
+    },
+    UnknownLoopGuardResetNode {
+        node: String,
+        reset_on: String,
     },
     MultipleDiscriminators {
         node: String,
@@ -97,11 +147,28 @@ pub fn validate_rules(workflow: &WorkflowDefinition) -> Vec<RoutingValidationErr
     errors
 }
 
+#[cfg(test)]
 pub fn route(
     workflow: &WorkflowDefinition,
     current_index: usize,
     artifact: Option<&Value>,
     node_execution_counts: &HashMap<String, u32>,
+) -> Result<RouteDecision, WorkflowError> {
+    route_with_reset_baselines(
+        workflow,
+        current_index,
+        artifact,
+        node_execution_counts,
+        &LoopGuardResetBaselines::default(),
+    )
+}
+
+pub fn route_with_reset_baselines(
+    workflow: &WorkflowDefinition,
+    current_index: usize,
+    artifact: Option<&Value>,
+    node_execution_counts: &HashMap<String, u32>,
+    loop_guard_reset_baselines: &LoopGuardResetBaselines,
 ) -> Result<RouteDecision, WorkflowError> {
     let node = workflow.nodes.get(current_index).ok_or_else(|| {
         WorkflowError::validation(format!("node index out of range: {current_index}"))
@@ -110,7 +177,12 @@ pub fn route(
     let Some(target) = raw_target(node, artifact)? else {
         return Ok(RouteDecision::Completed);
     };
-    guarded_target(workflow, target, node_execution_counts)
+    guarded_target_with_reset_baselines(
+        workflow,
+        target,
+        node_execution_counts,
+        loop_guard_reset_baselines,
+    )
 }
 
 pub fn rule_targets(rule: &Rule) -> Vec<&str> {
@@ -254,12 +326,13 @@ fn reachable_node_names(workflow: &WorkflowDefinition) -> BTreeSet<&str> {
     reachable_nodes_from_entry(workflow).into_iter().collect()
 }
 
-pub fn loop_guard(node: &NodeDefinition) -> Option<(u32, &str)> {
+pub fn loop_guard(node: &NodeDefinition) -> Option<(u32, &str, Option<&str>)> {
     node.rules.iter().find_map(|rule| match rule {
         Rule::LoopGuard {
             max_iterations,
             on_exhausted,
-        } => Some((*max_iterations, on_exhausted.as_str())),
+            reset_on,
+        } => Some((*max_iterations, on_exhausted.as_str(), reset_on.as_deref())),
         _ => None,
     })
 }
@@ -285,12 +358,24 @@ fn validate_node_rules(
         }
         match rule {
             Rule::When { .. } | Rule::Switch { .. } => discriminator_count += 1,
-            Rule::LoopGuard { max_iterations, .. } => {
+            Rule::LoopGuard {
+                max_iterations,
+                reset_on,
+                ..
+            } => {
                 loop_guard_count += 1;
                 if *max_iterations == 0 {
                     errors.push(RoutingValidationError::LoopGuardMaxIterations {
                         node: node.name.clone(),
                     });
+                }
+                if let Some(reset_on) = reset_on {
+                    if !node_names.contains(reset_on.as_str()) {
+                        errors.push(RoutingValidationError::UnknownLoopGuardResetNode {
+                            node: node.name.clone(),
+                            reset_on: reset_on.clone(),
+                        });
+                    }
                 }
             }
             Rule::Next(_) => next_count += 1,
@@ -489,10 +574,11 @@ fn raw_target(
     }
 }
 
-pub fn guarded_target(
+pub fn guarded_target_with_reset_baselines(
     workflow: &WorkflowDefinition,
     mut target: String,
     node_execution_counts: &HashMap<String, u32>,
+    loop_guard_reset_baselines: &LoopGuardResetBaselines,
 ) -> Result<RouteDecision, WorkflowError> {
     for _ in 0..workflow.nodes.len() {
         let target_node = workflow
@@ -500,10 +586,11 @@ pub fn guarded_target(
             .iter()
             .find(|node| node.name == target)
             .ok_or_else(|| WorkflowError::validation(format!("node not found: {target}")))?;
-        let Some((max_iterations, on_exhausted)) = loop_guard(target_node) else {
+        let Some((max_iterations, on_exhausted, reset_on)) = loop_guard(target_node) else {
             return Ok(RouteDecision::TransitionTo(target));
         };
-        let count = node_execution_counts.get(&target).copied().unwrap_or(0);
+        let cumulative_count = node_execution_counts.get(&target).copied().unwrap_or(0);
+        let count = loop_guard_reset_baselines.execution_count(&target, cumulative_count, reset_on);
         if count < max_iterations {
             return Ok(RouteDecision::TransitionTo(target));
         }
@@ -769,6 +856,7 @@ mod routing_tests {
             }
             RoutingValidationError::FanoutChildLeafViolation { reason, .. } => reason.clone(),
             RoutingValidationError::UnknownRuleTarget { .. }
+            | RoutingValidationError::UnknownLoopGuardResetNode { .. }
             | RoutingValidationError::UnreachableNode { .. } => String::new(),
         }
     }
@@ -1126,6 +1214,7 @@ mod routing_tests {
                         Rule::LoopGuard {
                             max_iterations: 2,
                             on_exhausted: "give_up".to_string(),
+                            reset_on: None,
                         },
                         Rule::Next("fix".to_string()),
                     ],
@@ -1139,6 +1228,89 @@ mod routing_tests {
             route(&wf, 0, None, &HashMap::from([("review".to_string(), 2)])).unwrap(),
             RouteDecision::TransitionTo("give_up".to_string())
         );
+    }
+
+    #[test]
+    fn test_loop_guard_reset_on正常完了ごとに新しいカウント範囲を開始する() {
+        let wf = workflow(
+            vec![
+                session_node("round", None, vec![Rule::Next("fix".to_string())]),
+                session_node(
+                    "fix",
+                    None,
+                    vec![
+                        Rule::LoopGuard {
+                            max_iterations: 2,
+                            on_exhausted: "give_up".to_string(),
+                            reset_on: Some("round".to_string()),
+                        },
+                        Rule::Next("round".to_string()),
+                    ],
+                ),
+                session_node("give_up", None, vec![]),
+            ],
+            BTreeMap::new(),
+        );
+        let mut counts = HashMap::from([("fix".to_string(), 2)]);
+        let mut baselines = LoopGuardResetBaselines::default();
+
+        assert_eq!(
+            guarded_target_with_reset_baselines(&wf, "fix".to_string(), &counts, &baselines,)
+                .unwrap(),
+            RouteDecision::TransitionTo("give_up".to_string()),
+            "reset_on が未到達なら Workflow 開始からの累計を使う"
+        );
+
+        baselines.record_successful_completion(&wf, "round", &counts);
+        assert_eq!(
+            guarded_target_with_reset_baselines(&wf, "fix".to_string(), &counts, &baselines,)
+                .unwrap(),
+            RouteDecision::TransitionTo("fix".to_string())
+        );
+
+        counts.insert("fix".to_string(), 3);
+        assert_eq!(
+            guarded_target_with_reset_baselines(&wf, "fix".to_string(), &counts, &baselines,)
+                .unwrap(),
+            RouteDecision::TransitionTo("fix".to_string())
+        );
+        counts.insert("fix".to_string(), 4);
+        assert_eq!(
+            guarded_target_with_reset_baselines(&wf, "fix".to_string(), &counts, &baselines,)
+                .unwrap(),
+            RouteDecision::TransitionTo("give_up".to_string())
+        );
+
+        baselines.record_successful_completion(&wf, "round", &counts);
+        assert_eq!(
+            guarded_target_with_reset_baselines(&wf, "fix".to_string(), &counts, &baselines,)
+                .unwrap(),
+            RouteDecision::TransitionTo("fix".to_string()),
+            "2 回目の正常完了でも新しい範囲を開始する"
+        );
+    }
+
+    #[test]
+    fn test_loop_guard_reset_onはcontrol_flow_edgeとして扱わない() {
+        let wf = workflow(
+            vec![
+                session_node("entry", None, vec![Rule::Next("fix".to_string())]),
+                session_node(
+                    "fix",
+                    None,
+                    vec![Rule::LoopGuard {
+                        max_iterations: 2,
+                        on_exhausted: "done".to_string(),
+                        reset_on: Some("boundary".to_string()),
+                    }],
+                ),
+                session_node("boundary", None, vec![]),
+                session_node("done", None, vec![]),
+            ],
+            BTreeMap::new(),
+        );
+
+        assert!(!reachable_node_names(&wf).contains("boundary"));
     }
 
     #[test]
@@ -1200,6 +1372,7 @@ mod routing_tests {
                 Rule::LoopGuard {
                     max_iterations: 3,
                     on_exhausted: "done".to_string(),
+                    reset_on: None,
                 },
             );
         }
@@ -1224,6 +1397,7 @@ mod routing_tests {
                     vec![Rule::LoopGuard {
                         max_iterations: 3,
                         on_exhausted: "done".to_string(),
+                        reset_on: None,
                     }],
                 ),
                 session_node("done", None, vec![]),

--- a/src-tauri/src/domain/workflow/services/validation.rs
+++ b/src-tauri/src/domain/workflow/services/validation.rs
@@ -88,6 +88,11 @@ pub enum ValidationError {
         node: String,
         target: String,
     },
+    /// loop_guard.reset_on が存在しない node を参照
+    UnknownLoopGuardResetNode {
+        node: String,
+        reset_on: String,
+    },
     /// rules の順序非依存性・網羅性・型付き参照・loop guard が不正
     InvalidRules {
         node: String,
@@ -233,6 +238,10 @@ impl fmt::Display for ValidationError {
             Self::UnknownRuleTarget { node, target } => write!(
                 f,
                 "node '{node}' のrulesが存在しないnode '{target}' を参照しています"
+            ),
+            Self::UnknownLoopGuardResetNode { node, reset_on } => write!(
+                f,
+                "node '{node}' のloop_guard.reset_onが存在しないnode '{reset_on}' を参照しています"
             ),
             Self::InvalidRules { node, reason, .. } => {
                 write!(f, "node '{node}' のrulesが不正です: {reason}")
@@ -422,6 +431,9 @@ fn routing_error_to_validation_error(error: routing::RoutingValidationError) -> 
     match error {
         routing::RoutingValidationError::UnknownRuleTarget { node, target } => {
             ValidationError::UnknownRuleTarget { node, target }
+        }
+        routing::RoutingValidationError::UnknownLoopGuardResetNode { node, reset_on } => {
+            ValidationError::UnknownLoopGuardResetNode { node, reset_on }
         }
         routing::RoutingValidationError::MultipleDiscriminators { node } => {
             ValidationError::InvalidRules {
@@ -1372,6 +1384,7 @@ mod tests {
                     Rule::LoopGuard {
                         max_iterations: 3,
                         on_exhausted: "plan".to_string(),
+                        reset_on: None,
                     },
                     Rule::Next("plan".to_string()),
                 ],
@@ -2038,6 +2051,7 @@ mod tests {
                     Rule::LoopGuard {
                         max_iterations: 2,
                         on_exhausted: "approval".to_string(),
+                        reset_on: None,
                     },
                     Rule::Next("approval".to_string()),
                 ],
@@ -2054,6 +2068,7 @@ mod tests {
             rules: vec![Rule::LoopGuard {
                 max_iterations: 2,
                 on_exhausted: "nonexistent".to_string(),
+                reset_on: None,
             }],
             ..make_node("fix", TestKind::Session, vec![])
         }]);
@@ -2062,6 +2077,32 @@ mod tests {
             err,
             ValidationError::UnknownRuleTarget { ref node, ref target }
                 if node == "fix" && target == "nonexistent"
+        ));
+    }
+
+    #[test]
+    fn loop_guard_unknown_reset_on_fails_with_referenced_node_name() {
+        let wf = make_workflow(vec![
+            NodeDefinition {
+                rules: vec![
+                    Rule::LoopGuard {
+                        max_iterations: 2,
+                        on_exhausted: "done".to_string(),
+                        reset_on: Some("missing-boundary".to_string()),
+                    },
+                    Rule::Next("done".to_string()),
+                ],
+                ..make_node("fix", TestKind::Session, vec![])
+            },
+            make_node("done", TestKind::Session, vec![]),
+        ]);
+
+        let err = validate(&wf).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ValidationError::UnknownLoopGuardResetNode { ref node, ref reset_on }
+                if node == "fix" && reset_on == "missing-boundary"
         ));
     }
 
@@ -2101,6 +2142,7 @@ mod tests {
                     Rule::LoopGuard {
                         max_iterations: 2,
                         on_exhausted: "done".to_string(),
+                        reset_on: None,
                     },
                     Rule::Next("node_a".to_string()),
                 ],

--- a/src-tauri/src/domain/workflow/value_objects/definition.rs
+++ b/src-tauri/src/domain/workflow/value_objects/definition.rs
@@ -203,6 +203,7 @@ pub enum Rule {
     LoopGuard {
         max_iterations: u32,
         on_exhausted: String,
+        reset_on: Option<String>,
     },
     Next(String),
 }

--- a/src-tauri/src/usecase/workflow/dto.rs
+++ b/src-tauri/src/usecase/workflow/dto.rs
@@ -105,6 +105,8 @@ pub(crate) enum RuleDto {
     LoopGuard {
         max_iterations: u32,
         on_exhausted: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reset_on: Option<String>,
     },
     Next {
         next: String,
@@ -326,9 +328,11 @@ fn rule_to_dto(rule: &domain::Rule) -> RuleDto {
         domain::Rule::LoopGuard {
             max_iterations,
             on_exhausted,
+            reset_on,
         } => RuleDto::LoopGuard {
             max_iterations: *max_iterations,
             on_exhausted: on_exhausted.clone(),
+            reset_on: reset_on.clone(),
         },
         domain::Rule::Next(next) => RuleDto::Next { next: next.clone() },
     }
@@ -463,6 +467,36 @@ mod tests {
         assert_eq!(
             serde_json::to_value(dto).unwrap()["nodes"][0]["session"]["facets"]["knowledge"],
             serde_json::json!(["knowledge-a", "knowledge-b"])
+        );
+    }
+
+    #[test]
+    fn workflow_to_dto_preserves_loop_guard_reset_on() {
+        let definition = domain::WorkflowDefinition {
+            name: "wf".to_string(),
+            description: String::new(),
+            nodes: vec![domain::NodeDefinition {
+                name: "fix".to_string(),
+                rules: vec![domain::Rule::LoopGuard {
+                    max_iterations: 2,
+                    on_exhausted: "done".to_string(),
+                    reset_on: Some("round".to_string()),
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let dto = workflow_to_dto(&definition);
+
+        assert_eq!(
+            serde_json::to_value(dto).unwrap()["nodes"][0]["rules"][0],
+            serde_json::json!({
+                "type": "loop_guard",
+                "max_iterations": 2,
+                "on_exhausted": "done",
+                "reset_on": "round"
+            })
         );
     }
 

--- a/src/components/panels/AutomationSection.test.tsx
+++ b/src/components/panels/AutomationSection.test.tsx
@@ -603,6 +603,7 @@ describe("AutomationSection", () => {
 								type: "loop_guard",
 								max_iterations: 3,
 								on_exhausted: "fallback-step",
+								reset_on: "review-round",
 							},
 						],
 					},
@@ -621,7 +622,9 @@ describe("AutomationSection", () => {
 		expect(screen.getByText("json-schema")).toBeInTheDocument();
 		expect(screen.getByText("Transition Rules")).toBeInTheDocument();
 		expect(
-			screen.getByText("loop_guard max 3 -> fallback-step"),
+			screen.getByText(
+				"loop_guard max 3 -> fallback-step, reset on review-round",
+			),
 		).toBeInTheDocument();
 		expect(screen.getByText(/^Inputs:/)).toBeInTheDocument();
 		expect(screen.getByText("step-0")).toBeInTheDocument();
@@ -630,6 +633,39 @@ describe("AutomationSection", () => {
 		expect(screen.getByText(/child-2/)).toBeInTheDocument();
 		expect(screen.getByText(/^Items:/)).toBeInTheDocument();
 		expect(screen.getByText("scan.items")).toBeInTheDocument();
+	});
+
+	it("workflow detail omits the reset suffix when loop_guard has no reset_on", async () => {
+		const user = userEvent.setup();
+		const automation = createMockAutomation({
+			selectedWorkflow: {
+				name: "loop-guard-without-reset",
+				description: "Loop guard without a reset boundary",
+				builtin: false,
+				nodes: [
+					{
+						name: "review",
+						kind: "session" as const,
+						rules: [
+							{
+								type: "loop_guard",
+								max_iterations: 3,
+								on_exhausted: "fallback-step",
+							},
+						],
+					},
+				],
+			},
+		});
+
+		render(<AutomationSection automation={automation} />);
+
+		await user.click(screen.getByText("review"));
+
+		expect(
+			screen.getByText("loop_guard max 3 -> fallback-step"),
+		).toBeInTheDocument();
+		expect(screen.queryByText(/, reset on/)).not.toBeInTheDocument();
 	});
 
 	it("workflow detail shows diagnostics", () => {

--- a/src/components/panels/automation/WorkflowDetail.tsx
+++ b/src/components/panels/automation/WorkflowDetail.tsx
@@ -465,7 +465,7 @@ function formatRule(rule: WorkflowRule): string {
 				: `switch ${rule.on}: ${cases}`;
 		}
 		case "loop_guard":
-			return `loop_guard max ${rule.max_iterations} -> ${rule.on_exhausted}`;
+			return `loop_guard max ${rule.max_iterations} -> ${rule.on_exhausted}${rule.reset_on ? `, reset on ${rule.reset_on}` : ""}`;
 		case "next":
 			return `next -> ${rule.next}`;
 	}
@@ -478,7 +478,7 @@ function ruleKey(rule: WorkflowRule): string {
 		case "switch":
 			return `switch:${rule.on}:${sortedCases(rule.cases)}:${rule.next ?? ""}`;
 		case "loop_guard":
-			return `loop_guard:${rule.max_iterations}:${rule.on_exhausted}`;
+			return `loop_guard:${rule.max_iterations}:${rule.on_exhausted}:${rule.reset_on ?? ""}`;
 		case "next":
 			return `next:${rule.next}`;
 	}

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -49,6 +49,7 @@ type Rule =
 			type: "loop_guard";
 			max_iterations: number;
 			on_exhausted: string;
+			reset_on?: string;
 	  }
 	| {
 			type: "next";


### PR DESCRIPTION
## 概要

loop_guard に任意の reset_on を追加し、指定 Node の正常完了ごとに guard 対象 Node の実行回数を数え直せるようにします。

Closes #1489

## 変更内容

- schema、domain、DTO、event、frontend 型で reset_on を保持
- Rust domain にカウント範囲の baseline と reset-aware routing を実装
- 通常 Node と fanout 親の正常完了をリセット境界として処理
- 中断・resume・イベント replay 後も同じ baseline と routing を復元
- 未知の reset_on 参照を WFR001 Diagnostic として報告
- Workflow 詳細表示と YAML 構文ドキュメントを更新
- Requirements と正常系・異常系・後方互換性テストを追加

## テスト

- [x] cargo fmt --check
- [x] cargo clippy --locked -- -D warnings
- [x] cargo test（2725 tests）
- [x] pnpm lint
- [x] pnpm test（1345 tests）
- [x] pnpm build
- [x] pnpm test:integration（22 tests）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `loop_guard` に `reset_on` を追加し、指定ノードの正常完了ごとに反復回数をリセットできるようになりました。
  * fanout、ワークフローの中断・再開時もリセット条件を正しく引き継ぎます。
  * ワークフロー詳細画面で `reset_on` の設定を確認できます。

* **バグ修正**
  * 存在しないノードを `reset_on` に指定した場合、対象箇所を示す診断メッセージを表示します。

* **ドキュメント**
  * YAML 構文と `loop_guard` のカウント、fanout時の挙動を更新しました。
  * `reset_on` 未指定時は従来の累計カウント動作を維持します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->