### PR TITLE
fix(workflow): Context収集をFull Permissionで実行

### DIFF
--- a/specs/unified-node-model/examples/full-cycle-development.yml
+++ b/specs/unified-node-model/examples/full-cycle-development.yml
@@ -45,7 +45,7 @@ nodes:
   collect_inputs:
     session:
       model: gpt-5.6-sol
-      permission: edit
+      permission: full
       facets:
         policy: planning
         instruction: collect_inputs

--- a/src-tauri/src/adaptor/gateway/workflow/builtin.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin.rs
@@ -506,6 +506,28 @@ mod tests {
     use crate::adaptor::gateway::workflow::schema::SchemaDef;
 
     #[test]
+    fn context_collection_nodes_use_full_permission() {
+        for (source, node_name) in [
+            (BUILTIN_FULL_CYCLE_DEVELOPMENT, "collect_inputs"),
+            (BUILTIN_FULL_CYCLE_DEVELOPMENT_MANUAL, "collect_inputs"),
+            (BUILTIN_HANDLE_PR_REVIEW, "import_pr_review_comments"),
+            (BUILTIN_HANDLE_PR_REVIEW_MANUAL, "import_pr_review_comments"),
+        ] {
+            let workflow: WorkflowDefinitionYaml = serde_saphyr::from_str(source).unwrap();
+            let collection_node = workflow
+                .nodes
+                .iter()
+                .find(|node| node.name == node_name)
+                .unwrap();
+
+            assert_eq!(
+                collection_node.session().unwrap().permission.as_deref(),
+                Some("full")
+            );
+        }
+    }
+
+    #[test]
     fn full_cycle_implementation_check_requires_non_empty_results() {
         let workflow: WorkflowDefinitionYaml =
             serde_saphyr::from_str(BUILTIN_FULL_CYCLE_DEVELOPMENT).unwrap();

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/full-cycle-development-manual.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/full-cycle-development-manual.yml
@@ -204,7 +204,7 @@ nodes:
 - name: collect_inputs
   session:
     model: gpt-5.6-sol
-    permission: edit
+    permission: full
     gate: auto
     facets:
       policy: planning

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/full-cycle-development.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/full-cycle-development.yml
@@ -204,7 +204,7 @@ nodes:
 - name: collect_inputs
   session:
     model: gpt-5.6-sol
-    permission: edit
+    permission: full
     gate: auto
     facets:
       policy: planning


### PR DESCRIPTION
## 概要

- `full-cycle-development` の `collect_inputs` Permissionを `full` に変更
- manual版とunified node modelの仕様例も同じ設定に統一
- 関連WorkflowのContext収集ノードが `full` であることを保証する回帰テストを追加

## 検証

- `cargo fmt --check`
- `cargo test adaptor::gateway::workflow::builtin::tests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * フルサイクル開発ワークフローの入力収集ステップで、セッション権限を「編集」から「フル」に引き上げました。

* **テスト**
  * 組み込みワークフローの入力収集およびレビューコメント取り込みステップで、フル権限が設定されていることを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->