### PR TITLE
feat(workspace): 実行開始済みNodeだけをWorkspace treeへ表示する (#1512)

### DIFF
--- a/docs/specs/issues-1512/behavior.md
+++ b/docs/specs/issues-1512/behavior.md
@@ -1,0 +1,120 @@
+# Behavior — issues-1512 Workspace treeには実行開始済みNodeだけを表示する
+
+対象Requirements: `docs/specs/issues-1512/requirements.md`
+
+## B-001: Node未開始のWorkflow branchは空childrenで表示される
+
+GIVEN Workflow定義に複数のNodeを持つWorkflow executionが存在し、`NodeStarted`イベントが一件も記録されていない
+WHEN Workspace treeのsnapshotを取得する
+THEN そのWorkflow executionのbranch行は表示される
+AND branchのchildrenは空である
+AND 定義上のNodeはleaf行として一件も表示されない
+
+最小再現入力: 実行イベント0件のWorkflow execution（既存テスト`declaration_order_and_queued_nodes_come_from_execution_snapshot`と同じ入力）。現在の実際の結果は、全定義Nodeが`queued`としてdeclaration orderで並ぶ（2026-07-19に`cargo test -p releash --lib usecase::workflow::workspace_tree::tests`で確認、21 passed）。
+
+## B-002: 実行済みoccurrenceだけがevent順で表示され、未実行定義Nodeは表示されない
+
+GIVEN Workflow定義が`[A, B, C, D]`のWorkflow executionが存在し、`NodeStarted`が`A → B → A → C`の順に記録されている
+WHEN Workspace treeのsnapshotを取得する
+THEN Workflow branchのchildrenは`A, B, A, C`の4 occurrenceだけが`NodeStarted`のevent順で並ぶ
+AND `D`のleaf行は表示されない
+AND `A`の2つのoccurrenceは別行であり、相互に異なるopaque IDを持つ
+
+最小再現入力: 既存テスト`execution_occurrences_follow_event_order_and_unstarted_nodes_remain_queued`と同じ入力。現在の実際の結果は、4 occurrenceの後に未実行`D`が`queued`で並ぶ。
+
+## B-003: 条件分岐で未選択のNodeはWorkflow完了後も表示されない
+
+GIVEN 条件分岐により一部の定義Nodeが一度も開始されないままWorkflow executionが完了状態（Completed / Failed / Aborted のいずれか）に達している
+WHEN Workspace treeのsnapshotを取得する
+THEN 開始されなかった定義NodeのleafおよびbranchはWorkspace treeに表示されない
+AND 開始済みNodeのoccurrence行は表示され続ける
+
+## B-004: 未開始fanoutはbranchごと表示されない
+
+GIVEN Workflow定義にfanout Nodeが含まれ、そのfanoutに対応する`NodeExecution`が存在しないWorkflow executionが存在する
+WHEN Workspace treeのsnapshotを取得する
+THEN そのfanoutのbranch行はWorkspace treeに表示されない
+AND fanout childのplaceholder行も表示されない
+
+## B-005: 開始済みfanoutは実在するchild NodeExecutionだけを表示する（literal items）
+
+GIVEN literal itemsを持つfanoutが開始済みで、一部のitem×childの組だけがchild `NodeExecution`として開始されている
+WHEN Workspace treeのsnapshotを取得する
+THEN fanout branchのchildrenは実在するchild `NodeExecution`の行だけである
+AND 未開始のitem×childの組に対するplaceholder行は合成されない
+
+最小再現入力: 既存テスト`artifact_item_fanout_keeps_queued_child_id_for_its_first_occurrence`が固定する「queued placeholderのopaque IDが最初の実行childと一致する」仕様は本契約で廃止され、placeholder自体が公開されない。
+
+## B-006: 開始済みfanoutは実在するchild NodeExecutionだけを表示する（artifact items未確定）
+
+GIVEN ArtifactField itemsを持つfanoutが開始済みで、itemsが未確定のためchild `NodeExecution`が一件も存在しない
+WHEN Workspace treeのsnapshotを取得する
+THEN fanout branchは表示され、childrenは空である
+AND childごとのplaceholder行は合成されない
+
+## B-007: 開始済みNodeは全statusで表示され続ける
+
+GIVEN `Running / WaitingApproval / Succeeded / Failed / Aborted`の各statusを持つ開始済み`NodeExecution`がWorkflow executionに存在する
+WHEN Workspace treeのsnapshotを取得する
+THEN 5つのstatusすべての`NodeExecution`がleaf行として表示される
+AND 各行のstatus表示は従来と同じstatusを示す
+
+## B-008: Node開始時のlive反映とreload後の一致
+
+GIVEN Workflow executionが実行中で、あるNodeがまだ開始されていない
+WHEN そのNodeが実際に開始される（durableな`NodeStarted`が記録される）
+THEN live snapshotにそのNodeのleaf行が追加される
+AND アプリreload後に取得したWorkspace treeにも同じ行が表示される
+AND live更新後のtreeとreload後のtreeは一致する
+
+## B-009: preferredNodeIdは表示対象の実在Nodeだけを指す
+
+GIVEN Workspace treeのsnapshotが存在する
+WHEN `preferredNodeId`を取得する
+THEN `preferredNodeId`は表示対象のleaf行に存在するNode IDである
+AND 表示対象のleaf行が一件もない場合（Node未開始のWorkflowのみ等）、`preferredNodeId`は`null`である
+
+## B-010: Node detail / session lookupは未実行Nodeを返さない
+
+GIVEN 定義にのみ存在し`NodeExecution`を持たないNodeがあるWorkflow executionが存在する
+WHEN Node detailおよびsession lookupを照会する
+THEN 未実行Nodeに対応するdetail recordは登録されておらず、参照・返却されない
+AND 開始済みNodeのdetailは従来どおり取得できる
+
+## B-011: stale selectionはpreferredNodeIdへfallbackする
+
+GIVEN frontendが保持中の選択Node IDを持ち、新しく取得したsnapshotの表示対象にそのIDが存在しない
+WHEN snapshotが更新される
+THEN 選択はsnapshotの`preferredNodeId`が指すNodeへfallbackする
+AND `preferredNodeId`が`null`（表示対象なし）の場合、選択は未選択状態になる
+
+## B-012: frontendはbackend snapshotのmirrorに徹する
+
+GIVEN backendがchildrenが空のWorkflow branchを含むsnapshotを返す
+WHEN frontend（`useWorkspaceTreeNodes` / `WorkspaceList`）がsnapshotを描画する
+THEN frontendはsnapshotの内容を加工せずそのまま描画し、空childrenのWorkflow branchを正常な状態として表示する
+AND frontendに`status === "queued"`等のstatus値やWorkflow定義・分岐結果に基づく表示可否の除外判定は存在しない
+
+## B-013: 正本文書が本契約へ更新されている
+
+GIVEN `docs/specs/milestone-82/design.md` §13と`docs/specs/milestone-82/goal-14-issue-1454.md`に「未開始Nodeはqueued」の記載が存在する
+WHEN 本変更を適用する
+THEN 両文書の該当記載が「実行開始済みNode限定」の本契約へ更新されている
+AND 更新後の記載は`specs/unified-node-model/decisions.md`の「実際に起きたことだけが実行木に載る」を受け入れ根拠として参照している
+
+## 要件IDと検証方法の対応表
+
+| Requirement ID | Behavior ID | Verification Method |
+| --- | --- | --- |
+| R-001 | B-001 | 実行イベント0件のWorkflow executionを入力に`src-tauri/`で`cargo test -p releash --lib usecase::workflow::workspace_tree::tests`を実行し、projectionの出力でWorkflow branch行が存在しchildrenが空配列であること、定義Nodeのleaf行が0件であることを確認する。 |
+| R-002 | B-002, B-003 | 定義`[A,B,C,D]`・実行`A→B→A→C`のsnapshotをprojectionテストで検証し、childrenが4 occurrence（event順）のみで`D`の行がないことを確認する。条件分岐で未開始のNodeを持つ完了済み（Completed / Failed / Aborted）executionでも、未開始Nodeの行がないことをテストで確認する。 |
+| R-003 | B-004 | fanout定義があり対応する`NodeExecution`がないexecutionのprojection出力に、fanout branch行およびそのchild行が0件であることをテストで確認する。 |
+| R-004 | B-005, B-006 | literal items fanoutで一部childのみ開始したsnapshot、およびArtifactField items未確定で開始済みのfanoutのsnapshotをprojectionテストで検証し、childrenが実在するchild `NodeExecution`の行だけであり、placeholder行が合成されないことを確認する。 |
+| R-005 | B-007 | `Running / WaitingApproval / Succeeded / Failed / Aborted`の`NodeExecution`を各1件持つexecutionのprojection出力に、5行すべてが従来のstatus表示で存在することをテストで確認する。 |
+| R-006 | B-002 | `A→B→A→C`のsnapshotで`A`の2 occurrenceが別行・event順・相互に異なるopaque IDであることをテストで確認する。併せて、queued placeholderとの同一ID仕様を固定していた既存テスト（`artifact_item_fanout_keeps_queued_child_id_for_its_first_occurrence`等3件）が新契約のテストへ置き換えられていることを確認する。 |
+| R-007 | B-008 | 実行中のexecutionで`NodeStarted`を追記した前後のlive snapshot、およびイベントストアからの再構築（reload相当）snapshotを比較し、新Nodeの行が両方に存在しtreeが一致することをテストで確認する。 |
+| R-008 | B-009 | 開始済みNodeを持つsnapshotで`preferredNodeId`が表示対象leafのIDであること、Node未開始のWorkflowのみのsnapshotで`preferredNodeId`が`None`であることをprojectionテストで確認する。 |
+| R-009 | B-010 | 未実行Nodeを含むexecutionでNode detail index / session lookupを照会し、未実行Nodeのrecordが存在しないこと、開始済みNodeのdetailが取得できることをテストで確認する。 |
+| R-010 | B-011 | 保持中の選択Node IDが含まれないsnapshotへ更新するfrontendテストで、選択が`preferredNodeId`のNodeへ遷移すること、`preferredNodeId`が`null`のとき未選択状態になることを確認する。 |
+| R-011 | B-012 | 空childrenのWorkflow branchを含むsnapshotを入力とする`useWorkspaceTreeNodes` / `WorkspaceList`のテストでsnapshotが無加工で描画されることを確認し、frontend（`src/`）に`queued`比較やWorkflow定義・分岐結果による表示可否判定が追加されていないことをコード確認する。 |
+| R-012 | B-013 | `docs/specs/milestone-82/design.md` §13と`docs/specs/milestone-82/goal-14-issue-1454.md`を読み、「未開始Nodeはqueued」記載が実行開始済みNode限定の契約へ更新され、`specs/unified-node-model/decisions.md`への参照があることを確認する。 |

--- a/docs/specs/issues-1512/design.md
+++ b/docs/specs/issues-1512/design.md
@@ -1,0 +1,113 @@
+# Design
+
+対象: `docs/specs/issues-1512/requirements.md`（R-001〜R-012）/ `docs/specs/issues-1512/behavior.md`（B-001〜B-013）
+
+## The actual design
+
+### Architecture
+
+#### 表示可否の決定はRust projectionの1箇所に閉じる
+
+表示契約の変更は`src-tauri/src/usecase/workflow/workspace_tree.rs`のprojection関数群だけで行う。queued行を生成している経路は次の3つであり、すべて削除する（R-002 / R-003 / R-004 / R-011、B-001〜B-006）。
+
+1. `project_workflow_children`の定義Node追記ブロック（現行789–819行）: `NodeExecution`が存在しない定義Nodeをdeclaration orderで末尾へ追加している。削除により、childrenは`node_executions`（`fanout_parent`なし）の`NodeStarted` append順の投影だけになる。定義由来のフィルタ用`child_names`集合と`executed_node_names`集合も不要になる。
+2. `project_fanout`の`keep_queued_slots`ブロック（現行897–938行）と`expected_fanout_slots`（現行969–993行）: 定義・items（Literal / ArtifactField）から期待slotを合成している。両方削除し、childrenは`actual_children`（実在するchild `NodeExecution`）の投影だけにする。
+3. 定義-onlyのfanout branch投影: 1.の削除に伴い、`project_fanout`が`parent: None`で呼ばれる経路が消える。未開始fanoutはbranchごと投影されない（B-004）。
+
+frontend（`useWorkspaceTreeNodes` / `WorkspaceList`）はbackend snapshotのmirrorを維持し、表示可否判定を追加しない（R-011、B-012）。`WorkspaceBranchRow`は既に`item.children.map(...)`で空配列を正常に描画するため、空children表示のための描画変更は不要であり、テストで固定するだけにする。
+
+#### projection関数のシグネチャ整理
+
+definition-only経路の削除により、次のOptionを外す。
+
+- `project_workflow_node`の`node_execution: Option<&NodeExecution>` → `&NodeExecution`。`RepresentativeStatus::Queued`へのfallback（現行1012行）と`summary.started_at`への`updated_at` fallback（現行1022行）は到達不能になるため削除する。
+- `project_fanout`の`parent: Option<&NodeExecution>` → `&NodeExecution`。status集約の`unwrap_or(RepresentativeStatus::Queued)`（現行944行）はparent statusが常に供給されるため到達不能になる。
+
+`project_workflow_children`が`definition`を参照する残りの用途は、fanout childのkind解決等の表示補助に限られる。definitionは「何を表示するか」の決定には使わない。この原則は#1468で追加されるSequence / Refの再帰projectionにも適用する: definition childやexpected child slotから未開始Nodeの行を再生成しない（R-003）。
+
+#### stale selectionはArchive専用のbackend-owned reconciliationで判定する
+
+Archive済みWorkflowのNode detail / session lookupは参照可能なままなので、detail lookupのmissingだけでは「detailは有効だが新snapshotには表示されない」選択を検出できない。Archive成功後だけ、専用`WorkspaceTreeQueryService`がmanaged worktree、workspace session、archive record、`WorkflowQueryService`のread依存を用い、`WorkspaceProjectionTarget::Snapshot`を一度生成する。同じprojectionからsnapshot membershipを判定し、`{ snapshot, reconciliation: { selectionInSnapshot } }`を返す（R-010 / R-011、B-011 / B-012）。Command側`WorkflowUsecase`はこのreadを公開せず、Archive / Restore mutationだけを所有する。
+
+frontendで選択IDを常時loaderへ渡したり、snapshotのleafを走査したりしない。`useWorkspaceTreeNodes`がArchive成功時だけ`{ worktreePath, selectedNodeId, reconciliationGeneration }`をrequest contextとして登録し、combined reconciliation readを直ちに試す。通常の初期load、event / websocket、dropdown、Archive以外のactionによるrefreshは`list_workspace_worktree_nodes`を使う。最初のcombined readが失敗した場合は既存snapshot・選択・request contextを保持し、次に既存契機でrefreshされたとき、同じcontextが有効な場合だけcombined readを再試行する。自動retry timerは追加しない。
+
+各refreshには既存の単調増加`refreshSeq`を割り当てる。最新sequenceで、現在のgeneration・worktree・selectionと一致するresponseだけを受理し、snapshotと`{ refreshSeq, requestContext, selectionInSnapshot }`をhookの一つのstate commitで公開する。成功、選択変更、worktree変更で必要contextを解除するため、遅延response、後続refreshに追い越されたresponse、選択のA→B→Aで旧generationに属するresponseはno-opになる。
+
+`selectionInSnapshot=false`の受理eventは、同じcommitで適用された`snapshot.preferredNodeId`を唯一のfallback候補として扱う。`WorkspaceList`は現在contextとの一致をeffect直前に再確認し、`refreshSeq`ごとに一度だけAppへ当該Nodeの失効を通知する。Appはcallback到着時にもfunctional updateで現在選択が同じNode IDか確認して`awaitingInitial`へ戻す。既存auto-select effectが同snapshotの`preferredNodeId`を選び、`null`なら未選択を維持する。`selectionInSnapshot=true`なら通知せず現在選択を維持する。Archive以外のdetail-missingは、従来どおり`NodeContentView`の`onNodeMissing`から同じ`awaitingInitial` / auto-select経路へ入る。
+
+#### 正本文書の更新
+
+R-012 / B-013として次を更新する。
+
+- `docs/specs/milestone-82/design.md` §13（現行385行）:「未開始Nodeはqueuedで表示する」を、実行開始済み（durableな`NodeStarted`に由来する`NodeExecution`が存在する）Nodeだけを表示する契約へ書き換える。
+- `docs/specs/milestone-82/goal-14-issue-1454.md`（現行20行「未開始Nodeはqueued」・43行「queued Node」）: 同様に本契約へ書き換える。
+
+両更新とも、受け入れ根拠として`specs/unified-node-model/decisions.md` §実行木の「WorkflowDefinitionはテンプレートであり木ではない。実行木には展開結果（実際に起きたこと）だけが載る」を参照する。
+
+### Interface
+
+- 通常refreshは既存`list_workspace_worktree_nodes(worktreePath) -> WorkspaceTreeSnapshotDto`を使う。`children: Vec<WorkspaceTreeItemDto>`が空になりうることは既に型上許容されている（R-001、B-001 / B-006）。
+- Archive後の必要contextが有効な間だけ、Tauri command `get_workspace_tree_selection_reconciliation(worktreePath, selectedNodeId) -> WorkspaceTreeSelectionSnapshotDto`を使う。controllerは独立した`State<Arc<WorkspaceTreeQueryService>>`を呼ぶ。
+- responseは`{ snapshot: WorkspaceTreeSnapshotDto, reconciliation: { selectionInSnapshot: boolean } }`である。`selectedNodeId`はrequestとfrontend request contextだけ、`preferredNodeId`は同梱snapshotだけを正とし、responseのreconciliationへ複製しない。membershipとfallback候補は必ず同じprojectionに対応する。
+- `get_workspace_node_detail` / `get_workspace_session_node_id`等の既存command、およびWebSocket protocolの型・シグネチャは変更しない。
+- opaque ID規則は変更しない: `workflow_node_occurrence_key` / `fanout_branch_occurrence_key` / `fanout_child_occurrence_key` / `fanout_dynamic_child_occurrence_key` / `opaque_workflow_node_id`は現行のまま。実行済みoccurrenceのID・event順の既存保証はこれで維持される（R-006、B-002）。queued placeholderとの同一ID仕様はplaceholder自体が公開されなくなることで消滅する。`fanout_dynamic_child_occurrence_key`のplaceholder前提コメント（現行1153–1155行）は実態に合わせて更新する。
+- `preferred_node_id`（現行1315–1323行）はコード変更しない。queued行が投影されなくなることで、走査対象が表示対象の実在leafだけになり、leafが皆無なら`None`を返す既存実装がそのままR-008 / B-009を満たす。
+
+### Data Model
+
+- `WorkspaceProjectionIndex`（`records` / `session_node_ids`）の構造は変更しない。登録はすべて`project_workflow_node`内で行われるため、definition-only行の投影廃止により、未実行Nodeのdetail record / session lookup entryは自然に登録されなくなる（R-009、B-010）。
+- `WorkspaceSelectionReconciliationDto`が持つ独立したread factは`selection_in_snapshot`だけである。fallbackは同梱`WorkspaceTreeSnapshotDto.preferred_node_id`から得る。
+- frontendのArchive再調停状態は世代付きrequest contextだけを保持し、server requestのechoやsnapshot preferred値の複製を持たない。受理eventは同じstate commitのsnapshotと`refreshSeq`で相関する。
+- domain（`NodeExecutionStatus`等）は変更しない（Non-goal）。
+
+### Database
+
+該当なし（イベントストア・永続化スキーマの変更はない。live snapshotとreload後のsnapshotは同一のprojection関数がイベントストア由来の同一stateから導出するため、一致はprojectionの純粋性で保証される。R-007、B-008）。
+
+### UI/UX
+
+- Workspace tree: 未開始Node・未開始fanout・fanout placeholderの行が表示されなくなる。Node未開始のWorkflowはbranch行のみ（children空）で表示される。開始済みNodeは`Running / WaitingApproval / Succeeded / Failed / Aborted`の全statusで従来どおり表示される（R-005、B-007）。
+- 選択中のNodeが新snapshotの表示対象から消えた場合、選択は`preferredNodeId`のNodeへ移り、表示対象がなければ中央は未選択状態（"Select a Node from the Workspace tree."）になる（B-011）。
+- Archive後のreconciliation readが一時失敗した間は、古いsnapshotと選択を表示したままにする。次の既存refreshで成功したauthoritative snapshotを受理してからfallbackする。
+- `NodeContentView`の`status === "queued"`分岐（現行89–91行）は変更しない。workflow nodeのdetailは常に実行済みstatusを持つため到達しなくなるが、`queued`語彙の一括削除はNon-goalであり、frontend変更のScopeは`useWorkspaceTreeNodes` / `WorkspaceList`に限る。
+
+### Algorithm
+
+- `project_workflow_children`（変更後）: `node_executions`のうち`fanout_parent`なしのものを`NodeStarted` append順に走査し、occurrence番号を採番して`project_fanout` / `project_workflow_node`へ投影するだけになる。ソート・定義追記は行わない。
+- `project_fanout`（変更後）: `actual_children`だけをsemantic key採番（現行851–895行のまま）で投影する。branch statusは`aggregate_representative_statuses(children ∪ parent status)`で、childrenが空でもparent statusが常に供給される。`updated_at`はchildren / parentのmaxで、既存ロジックのまま。
+- frontend refresh: Archive再調停contextがなければlist commandを呼ぶ。contextがあればcombined commandを呼び、失敗時はcontextを保持する。最新`refreshSeq`かつ現在のgeneration / worktree / selectionに一致する成功だけがsnapshotとreconciliation eventを同時にcommitし、contextを解除する。選択またはworktree変更もgenerationを進めて解除する。
+- frontend notification: commit後のeffectでeventのsequence / generation / worktree / selectionを再確認する。`selectionInSnapshot=false`かつ未通知の`refreshSeq`だけをAppへ通知し、fallback値はcommit済みsnapshotの`preferredNodeId`だけを使う。
+- テスト設計（検証対応表に従う。Rust側は`workspace_tree.rs`の`#[cfg(test)] mod tests`、frontend側は対象ファイル隣の`*.test.ts(x)`）:
+  - 廃止仕様を固定する既存テスト3件（`declaration_order_and_queued_nodes_come_from_execution_snapshot` / `execution_occurrences_follow_event_order_and_unstarted_nodes_remain_queued` / `artifact_item_fanout_keeps_queued_child_id_for_its_first_occurrence`）を新契約のテストへ置き換える（B-001 / B-002 / B-005相当）。
+  - 追加: 条件分岐で未開始Nodeを持つ完了済みexecution（B-003）、未開始fanout非表示（B-004）、ArtifactField items未確定の開始済みfanout空children（B-006）、5 status全表示（B-007）、`NodeStarted`追記前後のsnapshot比較（B-008）、`preferredNodeId`の実在leaf限定と`None`（B-009）、detail / session lookupの未実行Node不在（B-010）。
+  - 既存テストのうちqueued slot前提の箇所（`literal_fanout_items_expand_to_distinct_leaf_nodes_in_item_then_child_order`等、置き換え対象3件以外）も新契約の期待値へ更新する。
+  - frontend: stale selection→`preferredNodeId` fallbackと`null`時の未選択（B-011）、空childrenのWorkflow branchを含むsnapshotの無加工描画（B-012）。
+  - frontend競合: Archive直後read失敗→次refresh成功、`selectionInSnapshot=true`、選択移動、worktree変更、後続refresh、A→B→A、重複render、Appへの遅延旧Node通知を固定する。通常選択変更とoccurrence更新がreconciliation / closed sessions / workflow historyのfull refetchを起こさないことも計数する。
+
+### Infra
+
+該当なし。
+
+## Alternatives Considered
+
+- **`NotStarted` / `Skipped` statusのdomain追加**: 未実行Nodeをstatus付きで表現する案。requirementsのNon-goalであり、未実行Nodeは`NodeExecution`不在というdefinition-only stateとして判別できるため採らない。
+- **frontendでのqueued行フィルタリング**: backendはqueued行を返し続け、frontendで除外する案。表示可否の所有者がfrontendへ移りR-011に反するため採らない。
+- **stale selection fallbackでのfrontend snapshot走査**: `WorkspaceList`がleaf集合に選択IDが含まれるか自前で走査する案。表示可否・membershipの所有者がfrontendへ移りR-011に反するため採らない。採用案は専用QueryServiceが同じbackend projectionからmembershipを導出する。
+- **選択中の全refreshでreconciliation commandを使う案**: Archiveと無関係なrefreshでもmembershipを再計算し、Node選択だけでtree / closed sessions / historyのfull refetchを起こすため採らない。Archive後の未完了contextがある期間だけcombined commandを使う。
+- **Archive handler内の一回だけのread**: 単純だが一時失敗後にB-011を完了できないため採らない。必要contextを成功まで保持し、次の既存refreshで再試行する。
+- **responseへ`selectedNodeId` / `preferredNodeId`を複製する案**: request echoとsnapshot cloneであり、不一致という不正状態を表現できるため採らない。request contextと同梱snapshotを唯一値にする。
+- **`preferredNodeId`をAppへ渡して直接選択する案**: Appへsnapshot値を別配管すると相関対象が増えるため採らない。Appには失効したNode IDだけを通知し、同じsnapshotを表示するWorkspaceListの既存auto-select経路を再利用する。
+
+## Cross-cutting concerns
+
+- **性能**: queued行・expected slotの合成と、そのdetail index登録が削除されるため、projectionの計算量・snapshotサイズは縮小方向。reconciliation projectionはArchive後の未完了contextだけで実行し、通常refreshや選択変更には追加しない。
+- **互換性**: 実行済みoccurrenceのopaque ID・event順・status表示・detail取得は既存規則のまま維持する（R-005 / R-006）。CLI / Local API / event logの語彙・識別規則は変更しない。
+- **アーキテクチャ**: 表示契約とmembershipはRust projectionに閉じる。新規read modelは専用`WorkspaceTreeQueryService`が所有し、controllerは独立したTauri Stateを読む。Command側`WorkflowUsecase`はArchive / Restore mutationを維持する。frontendはsnapshotのmirrorと世代付きrequest相関だけを担い、WebSocket protocol・domain・永続化は変更しない。
+
+## Risks
+
+- queued placeholderを前提にしたテスト・補助関数の残存: 置き換え対象として指定された3件以外にも、fanout系テストがexpected slotを前提にしている（`literal_fanout_items_expand_to_distinct_leaf_nodes_in_item_then_child_order`等）。テスト更新範囲は3件に限らないことを実装時に前提とする。
+- 一時read failure: Archive成功後も必要contextを解除せず、次の既存refreshでだけ再試行する。timer retryを追加しないため、外部refreshが来るまで古いsnapshot / selectionを維持する。
+- 非同期競合: 遅延responseや選択のABAが現在選択を失効させる危険がある。`refreshSeq`、generation、worktree、selected Node IDをすべて照合し、通知済みsequenceを記録する。Appもcallback到着時に現在Node IDを再確認する。
+- fallback後の再選択タイミング: `awaitingInitial`復帰方式では、表示対象が皆無で未選択になった後、新たにNodeが開始されると初回auto-selectと同じ経路で選択される。これは初回表示時の既存挙動と同一経路の再利用である。
+- `NodeContentView`のqueued分岐・`RepresentativeStatus::Queued`・frontend status語彙の`"queued"`は本変更でworkflow node経路から到達しなくなるが、削除はNon-goal（`queued`語彙の一括削除をしない）のため残す。dead code整理は別Issueの候補として実装時に報告する。

--- a/docs/specs/issues-1512/requirements.md
+++ b/docs/specs/issues-1512/requirements.md
@@ -1,0 +1,90 @@
+# Context
+
+- 変更要求の正本: [#1512 Workspace treeには実行開始済みNodeだけを表示する](https://github.com/siro33950/releash/issues/1512)（milestone [統一 Node モデル](https://github.com/siro33950/releash/milestone/86)）
+- 入力文書:
+  - [#1454](https://github.com/siro33950/releash/issues/1454) Workspace UIをNode中心の再帰ツリーに統一（closed。現行のqueued表示を意図的に導入した先行実装）
+  - [#1468](https://github.com/siro33950/releash/issues/1468) 実行木UIの統一と文法正本化・最終cleanup（後続。詳細設計にqueued placeholder前提の記述が残る）
+  - [#1329](https://github.com/siro33950/releash/issues/1329) / [#1331](https://github.com/siro33950/releash/issues/1331) / [#1461](https://github.com/siro33950/releash/issues/1461)（closed。fanout・read model・新構文の器の先行移行）
+  - milestone [#82 Workflow Engine 新モデル移行](https://github.com/siro33950/releash/milestone/82)（closed）/ milestone #85（Session delegate + worktree隔離。入力の`issues/85`はこのmilestoneを指すとユーザー確認済み）
+  - `specs/unified-node-model/decisions.md` / `syntax.md` / `examples/`（統一Nodeモデルの正本）
+  - `docs/specs/milestone-82/design.md` / `goal-14-issue-1454.md` / `goal-common.md` / `plan.md`
+  - `docs/workflow-yaml-syntax.md` / `docs/workflow-engine-evolution-plan.md` / `docs/workflow-engine-model-boundary.md` / `docs/architecture/` / `docs/domain-model/current-state.md` / `docs/examples/`
+  - 既存実装: `src-tauri/src/usecase/workflow/workspace_tree.rs` ほか（詳細はCurrent Behavior）
+- 確定済みの背景:
+  - `specs/unified-node-model/decisions.md` §実行木は「WorkflowDefinitionはテンプレートであり木ではない。実行木には展開結果（実際に起きたこと）だけが載る」と定義している。本変更はWorkspace projectionをこの正本へ合わせる契約変更である。
+  - 現行の「未開始Nodeはqueued表示」は#1454で意図的に導入され、`docs/specs/milestone-82/design.md` §13（行385）と`goal-14-issue-1454.md`（行20・行42）に正本として記載されている。本変更はこの正本記載の更新を含む。
+  - #1468の詳細設計（queued rows / queued composite subtree等）は本契約確定前の記述であり、#1512の契約が優先する。#1468の再帰実行木projection（Sequence / Ref）でも本契約（definition child / expected child slotから未開始Nodeを再生成しない）を維持する。
+  - 現行domainの`NodeExecutionStatus`は`Running / WaitingApproval / Succeeded / Failed / Aborted`のみで、`NotStarted` / `Skipped`は存在しない。未実行Nodeは、durableな`NodeStarted`イベントと`NodeExecution`が存在しないdefinition-only stateとして判別できる。
+  - 表示可否の決定はRust-owned projectionが所有する（プロジェクト方針: ロジックはRustに置き、frontendはmirrorに徹する）。
+
+# Outcome
+
+- 対象者: Workspace treeでworkflow実行を監視する開発者。
+- 現在の問題: 一度も実行されていないWorkflow Node（条件分岐で使われない候補、未開始のfanout expected slotを含む）が`queued`としてWorkspaceへ並ぶため、実際に発生した作業とWorkflow定義上の候補が混在し、実行中・確認待ち・完了済みのNodeを監視しにくい。
+- 変更後の状態: Workspace treeは実行開始済み（durableな`NodeStarted`に由来する実在の`NodeExecution`を持つ）Nodeだけを表示し、Workspaceが「実際に発生した作業状態を扱うsurface」になる。Workflow定義のpreviewではなくなる。
+
+# Current Behavior
+
+- `src-tauri/src/usecase/workflow/workspace_tree.rs::project_workflow_children`（行702–822）: 実行済みNodeをevent順に投影した後、`NodeExecution`が一件も存在しない定義Nodeをdeclaration orderで末尾へ追加し（行789–819）、`node_execution = None`として`project_workflow_node`が`queued`表示へ変換する（行1012）。
+- 同`project_fanout`（行832–967）+ `expected_fanout_slots`（行969–993）: 親fanoutがactiveな間、定義とitemsから期待slotを合成し、未実行slotを`queued` placeholderとして表示する（行897–938）。ArtifactField itemsが未確定の場合はchildごとに1つのplaceholderを合成する。
+- queued placeholderと最初の実行occurrenceは同一のopaque IDを持つ仕様であり、テストで固定されている。
+- definition-only Nodeも`project_workflow_node`（行1054–1098）でNode detail indexへ登録され、選択すると`get_workspace_node_detail`がqueued detailを返す。`NodeContentView.tsx`（行89–91）は`status === "queued"`で「This session has not started yet.」を表示する。
+- `src/hooks/useWorkspaceTreeNodes.ts`はbackend snapshotを無加工で保持し、`src/components/workspace/WorkspaceList.tsx`は渡されたchildrenを無条件に描画する（frontend独自の表示可否判定はない）。
+- `preferred_node_id`（行1315–1323）は全leaf（queued含む）から`running / waiting`を優先して選び、なければ先頭leafを返す。表示対象が皆無なら`None`。
+- Node選択状態はfrontendのメモリ上（`src/App.tsx`の`centerStateByWorktree`、行44–63）のみで保持され、永続化されていない。選択Nodeがdetailから消えると`onNodeMissing`経由で未選択（`resolvedEmpty`）へ落とす（行242–259）。
+- 再現手順と実際の出力: `src-tauri/`で次を実行すると、現在のqueued挙動を固定する既存テスト3件を含む21件が全て成功する（2026-07-19確認: `21 passed; 0 failed`）。
+
+  ```bash
+  cargo test -p releash --lib usecase::workflow::workspace_tree::tests
+  ```
+
+  - `declaration_order_and_queued_nodes_come_from_execution_snapshot`: 実行イベント0件のworkflowで全定義Nodeが`queued`としてdeclaration orderで並ぶこと。
+  - `execution_occurrences_follow_event_order_and_unstarted_nodes_remain_queued`: 定義`[A,B,C,D]`・実行`A→B→A→C`で、4 occurrenceの後に未実行`D`が`queued`で並ぶこと。
+  - `artifact_item_fanout_keeps_queued_child_id_for_its_first_occurrence`: queued placeholderのopaque IDが最初の実行childと一致すること。
+
+# Scope / Non-goals
+
+## Scope（変更するもの）
+
+- Rust Workspace projection（`workspace_tree.rs`）の表示契約: definition-only Nodeの`queued`追加、fanout expected slotからのplaceholder合成、definition-only recordのdetail / session lookup indexへの登録を廃止し、実在するexecution occurrenceだけからstatus・updated time・children集約・`preferredNodeId`を導出する。
+- queued placeholderと最初の実行occurrenceで同一IDを維持するという既存仕様・テストの廃止（placeholder自体を外部へ公開しない）。
+- 保持中の選択Node IDが新snapshotの表示対象に存在しない場合のfallback挙動。
+- frontend（`useWorkspaceTreeNodes` / `WorkspaceList`）: backend snapshotのmirrorを維持し、childrenが空のWorkflow branchを正常な状態として表示できるようにする。
+- 正本文書の更新: `docs/specs/milestone-82/design.md` §13と`goal-14-issue-1454.md`の「未開始Nodeはqueued」要件を、実行開始済みNode限定の本契約へ更新する（`specs/unified-node-model/decisions.md`「実際に起きたことだけが実行木に載る」を受け入れ根拠として参照する）。
+- 本Issueが指定する既存テスト3件の新契約への置き換えと、新契約（条件分岐未選択の非表示・空childrenのWorkflow・開始済みfanoutのactual child限定・stale selection fallback）の固定。
+
+## Non-goals（変更しないもの）
+
+- `NodeExecutionStatus`やWorkflow domainへの`NotStarted` / `Skipped`の追加。
+- Workflow定義全体を閲覧・編集する新しいUI（実行前定義の確認機能はWorkspace treeの責務に含めない）。
+- `queued` status語彙の他用途からの一括削除。
+- 実行済み・完了済み・失敗・中断NodeのWorkspace履歴からの削除。
+- 未実行Nodeを例外的に表示するpin等の新概念の追加。
+- 選択Node IDの永続化機構の新設（fallback要求は保持中の選択に対するもの。ユーザー確認済み）。
+- CLI / Local API / event logのWorkflowExecution / NodeExecution語彙・識別規則の変更。
+
+# Requirements
+
+- R-001: Workflow executionのbranch行は、Workflow executionが存在する間は表示される。Nodeが一件も開始されていない場合、branchは表示されchildrenは空である。
+- R-002: Node leaf行は、durableな`NodeStarted`に由来する実在の`NodeExecution`が存在する場合だけ表示される。定義にのみ存在するNode（未実行・条件分岐で未選択・到達しなかったNode）は、実行中もWorkflow完了後も表示されない。
+- R-003: fanout等の合成子branchは、対応する実在の`NodeExecution`がある場合だけ表示される。未開始fanoutはbranchごと表示されない。#1468で追加されるSequence / Refも同じ契約に従う。
+- R-004: fanout childは実在するchild `NodeExecution`だけが表示され、定義・expected slot・items（literal / artifactのどちらでも）からplaceholderは合成されない。
+- R-005: 開始済みNodeは`Running / WaitingApproval / Succeeded / Failed / Aborted`のいずれの状態でも従来どおり表示され続ける（互換性要件）。
+- R-006: retry / loopで同じ定義Nodeが複数回開始された場合は、従来どおり実行occurrenceごとに別行となり、`NodeStarted`のevent順を維持し、相互に異なるopaque IDを持つ。実行済みoccurrenceのopaque ID・event順という既存保証は維持する（互換性要件）。一方、queued placeholderと最初の実行occurrenceで同一IDを維持する既存仕様は廃止する。
+- R-007: Nodeが実際に開始された時点でlive snapshotへ行が追加され、reload後も同じ行が表示される。live更新とreload後のWorkspace treeは一致する。
+- R-008: `preferredNodeId`は表示対象の実在Nodeだけを指す。表示対象がなければ`null`になる。
+- R-009: Node detail / session lookupは未実行Node（definition-only record）を参照・返却しない。
+- R-010: 保持中の選択Node IDが新snapshotに存在しない場合、表示対象の`preferredNodeId`へ安全にfallbackし、表示対象がなければ未選択になる。
+- R-011: 表示対象の決定はRust projectionが所有する。frontendに`status === "queued"`等を使った除外判定やWorkflow定義・分岐結果を使った表示可否ロジックを追加しない（安全性・アーキテクチャ要件）。
+- R-012: `docs/specs/milestone-82/design.md` §13と`docs/specs/milestone-82/goal-14-issue-1454.md`の「未開始Nodeはqueued」記載が、本契約（実行開始済みNode限定）へ更新されている。
+
+# Assumptions / Open Questions
+
+## Assumptions
+
+- 入力documentsの`https://github.com/siro33950/releash/issues/85`はmilestone #85（Session delegate + worktree隔離）を指す参照であり、GitHub Issue(PR) #85（セキュリティ修正）は本件と無関係（ユーザー確認済み 2026-07-19）。
+- R-010のfallback要求は保持中の選択Node IDに対するものであり、選択の永続化機構の新設は含まない（ユーザー確認済み 2026-07-19）。
+
+## Open Questions
+
+なし。

--- a/docs/specs/milestone-82/design.md
+++ b/docs/specs/milestone-82/design.md
@@ -382,15 +382,15 @@ enum WorkspaceNodeContentDto {
 - `Node`は`id / title / status / content_kind / capabilities / updated_at`を持ち、childrenを持たない。
 - `Workflow`は`id / title / status / capabilities / children / updated_at`を持ち、contentを持たない。
 - `Fanout`は`id / title / status / children / updated_at`を持ち、contentと独自actionを持たない。
-- 実行済みNodeはevent projectionが復元した実行順を保つ。同じ定義Nodeが反復された場合も実行occurrenceごとに別行を作り、`A → B → A → C`をその順で表示する。未開始Nodeはqueuedで表示する。
+- Workspace treeにはdurableな`NodeStarted`に由来する実在の`NodeExecution`だけを表示し、未開始の定義Nodeやfanout expected slotから行を合成しない。実行開始済みNodeはevent projectionが復元した実行順を保ち、同じ定義Nodeが反復された場合も実行occurrenceごとに別行を作り、`A → B → A → C`をその順で表示する。これは[`specs/unified-node-model/decisions.md` §実行木](../../../specs/unified-node-model/decisions.md#実行木)の「実行木には展開結果（実際に起きたこと）だけが載る」という決定に従う。
 - fanout親の各実行occurrenceはFanout branch、対応するchildの各実行occurrenceはそのbranch配下のNodeとして実行順に投影する。fanout childをWorkflow直下へ重複表示しない。
 - `fanout_parent`は階層構築だけに使う。execution ID、NodeExecution ID、attempt、fanout parent attempt、item/child index、raw kindをheader/treeへ表示しない。
 - tree summaryにSession本文、Command output、Artifact本文を含めない。汎用`get_workspace_node_detail(worktree_path, node_id)`で選択Nodeだけを取得する。
 - 実行occurrenceごとに異なるopaque Node IDを返す。frontendはIDを解析せず、後続occurrenceの追加後も既存IDを維持する。detailは選択IDが指す実行occurrenceのSessionまたはCommandを返す。
 - `CenterSelection`は`{ kind: "node", worktreePath, nodeId }`へ統一する。NewSessionは選択variantではなく作成操作とし、作成後のNodeを表示する。
 - Workflow action（stop/resume/abort/archive）とNode action（approve、単独Sessionのclose）はRustが返すcapabilityに従う。
-- 初回表示用`preferred_node_id`はrunning/waiting Nodeを優先するが、更新時に表示中Nodeを勝手に切り替えない。retry/loopで新しいoccurrenceが追加されても、選択中の過去occurrenceを維持する。
-- frontendはWorktreeごとに`awaiting_initial | selected | resolved_empty`だけを保持する。空snapshotでは初回選択資格を維持し、backend detailが`None`になった選択だけをempty stateへ遷移させる。tree非表示でもdetailが残るarchive済みNodeは選択を維持する。
+- frontendはWorktreeごとに`awaiting_initial | selected`だけを保持する。`selected`のNode IDが新snapshotの表示対象に残る間は選択を維持するため、retry/loopで新しいoccurrenceが追加されても選択中の過去occurrenceを切り替えない。表示対象から消えた場合は`awaiting_initial`へ戻り、同じsnapshotの`preferred_node_id`を初回表示と同じ経路で適用する。
+- `preferred_node_id`はrunning/waiting Nodeを優先する。`awaiting_initial`で`preferred_node_id`が`null`の間は未選択のまま初回選択資格を維持し、後続snapshotで表示対象Nodeが現れたときに適用する。
 - 単独SessionのCloseはopaque Node IDを受けるRust commandで解決する。NewSessionはApp-owned request UUIDをRustへ渡し、同UUIDをSession IDとして永続化するcheck-and-saveによりWorktree切り替え、並行呼び出し、再起動後retryでも冪等にする。
 
 ## 14. 削除一覧（旧 → 処置）

--- a/docs/specs/milestone-82/goal-14-issue-1454.md
+++ b/docs/specs/milestone-82/goal-14-issue-1454.md
@@ -17,15 +17,15 @@
 ## 実装内容
 
 1. **再帰Workspace read model**: `WorkspaceTreeNodeDto::Session | Workflow { node_executions }`を`Node | Workflow | Fanout`の再帰enumへ置き換える。Nodeにchildrenを持たせず、Workflow/Fanoutにcontentを持たせない。tree summaryはtitle/status/content kind/capability/updated timeだけを返し、Session本文・Command output・Artifact本文を含めない。
-2. **Rust projection**: 非Workflow Sessionを単独Nodeへ、通常Session/Commandの各実行occurrenceをNodeへ、fanout親の各実行occurrenceをFanout branchへ投影する。実行済みNodeはevent projectionが復元した実行順を保ち、同じ定義Nodeが反復された場合も`A → B → A → C`のように実行ごとに別行を作る。fanout childは対応するFanout branch配下へ実行順に投影し、Workflow直下へ重複表示しない。未開始Nodeはqueued。status/capability/title/order/fanout階層化をfrontendへ置かない。
+2. **Rust projection**: 非Workflow Sessionを単独Nodeへ、通常Session/Commandの各実行occurrenceをNodeへ、fanout親の各実行occurrenceをFanout branchへ投影する。Workspace treeにはdurableな`NodeStarted`に由来する実在の`NodeExecution`だけを表示し、未開始の定義Nodeやfanout expected slotから行を合成しない。実行開始済みNodeはevent projectionが復元した実行順を保ち、同じ定義Nodeが反復された場合も`A → B → A → C`のように実行ごとに別行を作る。fanout childは対応するFanout branch配下へ実行順に投影し、Workflow直下へ重複表示しない。この表示契約は[`specs/unified-node-model/decisions.md` §実行木](../../../specs/unified-node-model/decisions.md#実行木)の「実行木には展開結果（実際に起きたこと）だけが載る」という決定に従う。status/capability/title/order/fanout階層化をfrontendへ置かない。
 3. **汎用Node detail**: `get_workspace_workflow_node_detail`を`get_workspace_node_detail(worktree_path, node_id)`へ置き換える。contentは`Session { session_id? } | Command { display_command?, result? }`。実行occurrenceごとに異なるNode IDを返し、frontendが解析しないopaque IDとする。各IDは後続occurrenceが追加されても変えず、detailはそのIDが指す実行occurrenceのcontentを返す。
 4. **Session表示の統一**: 単独SessionとWorkflow Sessionの両方を同じ`BoundSessionChat`で表示する。`workflowNodeSession`による中央表示除外を削除し、会話本文、入力、live更新、permission応答を利用可能にする。
 5. **中央表示の一本化**: `MainLayout`の`AgentChatPanel | WorkflowView`分岐と`WorkflowView`を削除し、常に`ViewToolbar + NodeContentView`を表示する。Workflow/Fanout行はtreeの展開・折り畳みだけを行い、中央表示を変更しない。
 6. **Command snapshot**: Artifact参照展開後のCommandをsecret maskして`CommandPrepared` eventへ保存し、event projectionでNodeExecutionの`display_command`へ復元する。raw Commandは永続化しない。event commit成功後にprocessをspawnする。Command detailはdisplay command/status/exit code/duration/stdout/stderrを表示する。
-7. **選択と操作**: `CenterSelection`を`{ kind: "node", worktreePath, nodeId }`へ統一する。NewSessionは選択variantではなく作成操作とする。初回はbackendの`preferred_node_id`を使うが、更新時に表示中Nodeを勝手に変更しない。Workflow actionとNode actionはbackend capabilityだけに従う。
+7. **選択と操作**: `CenterSelection`を`{ kind: "node", worktreePath, nodeId }`へ統一する。NewSessionは選択variantではなく作成操作とする。初回はbackendの`preferred_node_id`を使い、更新時は選択IDが新snapshotの表示対象に残る間だけ表示中Nodeを維持する。Workflow actionとNode actionはbackend capabilityだけに従う。
 8. **内部metadataを非表示化**: execution ID、NodeExecution ID、attempt、fanout parent attempt、item/child index、raw Node kind、resume checkpointをtree row/Node headerへ表示しない。
 9. **旧Agent command hostの廃止**: Session tabに依存していたcommand palette、New/Search/Previous/Next thread command、Agent shortcut設定と公開Tauri commandを削除する。Session localなFind、Raw scrollback、Copyは`ChatSessionView`のtoolbarと固定shortcutで提供する。
-10. **選択Nodeの消滅**: AppはWorktreeごとに`awaiting_initial | selected | resolved_empty`のUI lifecycleを持つ。空の初回snapshotは`preferred_node_id`の適用資格を消費しない。選択Nodeのdetailがbackendから`None`になった場合だけ`resolved_empty`へ遷移してempty stateを表示し、別Nodeへ自動fallbackしない。treeから消えてもdetailが残るarchive済みWorkflow Nodeは選択を維持する。単独SessionのCloseは`close_workspace_node(worktree_path, node_id)`でopaque IDの解決をRustへ委ねる。
+10. **選択Nodeの消滅**: AppはWorktreeごとに`awaiting_initial | selected`のUI lifecycleを持つ。選択IDが新snapshotの表示対象に残る間は選択を維持し、表示対象から消えた場合は`awaiting_initial`へ戻って同じsnapshotの`preferred_node_id`を初回表示と同じ経路で適用する。`preferred_node_id`が`null`の間は未選択のまま初回選択資格を維持する。単独SessionのCloseは`close_workspace_node(worktree_path, node_id)`でopaque IDの解決をRustへ委ねる。
 11. **NewSessionの冪等作成**: AppがWorktreeごとの作成requestを所有し、Worktree切り替えをcancelとして扱わない。Rustの`create_workspace_session`はrequest UUIDを永続Session IDとしてcheck-and-saveを直列化し、同一requestの再送・並行実行・再起動後retryで同じSessionを返す。作成commit後は保存済みSessionをcanonical resultとし、retry時のpermission/backend/model変更に左右されない。異なるWorktreeまたは単独Session以外とのID衝突は拒否する。frontendは同一attemptのtaskをMainLayoutで共有し、失敗時だけ同じrequest UUIDの新attemptとして明示retryする。
 
 ## 削除対象
@@ -40,13 +40,13 @@
 
 ## テスト
 
-- Rust projection: 単独Session、通常Workflow、queued Node、Fanout、item展開、retry/loopの実行occurrence順（`A → B → A → C`）、missing Session、occurrenceごとのstatus/capability。
+- Rust projection: 単独Session、通常Workflow、未開始Node非表示と空のWorkflow branch、実行開始済みFanoutのactual child限定、item展開、retry/loopの実行occurrence順（`A → B → A → C`）、missing Session、occurrenceごとのstatus/capability。
 - event replay: `CommandPrepared`からmasked実行Commandを復元し、raw secretを保存・表示しない。
 - frontend: recursive tree、branch toggle、Node選択、単独/Workflow共通Session表示、Command表示、内部metadata非表示。
 - frontend: Settingsに旧Agent shortcut設定を表示せず、Session local toolbarと固定shortcutは利用できる。
-- frontend: detailのauthoritativeな`None`でstale中央表示を破棄し、取得errorでは現在detailを維持する。空snapshotから最初の`preferred_node_id`が出現した場合だけ自動選択し、選択消滅後は自動fallbackしない。
+- frontend: detailのauthoritativeな`None`でstale中央表示を破棄し、取得errorでは現在detailを維持する。新snapshotの表示対象に選択IDが残る場合は現在選択を維持し、消えた場合は同じsnapshotの`preferred_node_id`へfallbackする。`preferred_node_id`が`null`なら未選択のまま初回選択資格を維持する。
 - Rust: opaque Node Close、同一NewSession requestの逐次・並行・再起動後retry、payload不一致拒否、保存失敗後retry。
-- integration: NewSession、選択中単独SessionのClose、空Worktreeの最初のWorkflow Node自動選択、Workflow Session、Workflow Command、Fanout、retry/loopで追加された各occurrence、過去occurrenceの選択維持。
+- integration: NewSession、選択中単独SessionのClose後のsnapshot membershipに基づくfallbackまたは未選択、空Worktreeの最初のWorkflow Node自動選択、Workflow Session、Workflow Command、Fanout、retry/loopで追加された各occurrence、snapshotに残る過去occurrenceの選択維持。
 
 ## 受け入れ基準
 
@@ -60,8 +60,8 @@
 - tree summaryにSession本文、Command output、Artifact本文を含めない。
 - Tauri/WebSocketから同じWorkspace tree/detail read modelを再利用できる。
 - 旧Agent command palette/shortcut commandは公開せず、Session localなFind/Raw scrollback/Copyは維持される。
-- 選択中の単独SessionをCloseすると中央はempty stateになり、archive済みWorkflow Nodeの選択は維持される。
-- 空Worktreeで最初のWorkflow Nodeが追加されると一度だけ自動選択され、その後のrefreshやNode消滅では別Nodeへ勝手に移動しない。
+- 選択中NodeのIDが新snapshotの表示対象から消えると、同じsnapshotの`preferred_node_id`へfallbackし、`preferred_node_id`が`null`なら未選択になる。
+- 空Worktreeでは初回選択資格を維持し、最初のWorkflow Nodeが追加されると自動選択される。refresh後も選択IDがsnapshotに残る間は現在選択を維持し、retry/loopで追加された別occurrenceへ勝手に移動しない。
 - NewSession作成中にWorktreeを切り替えて戻っても同じrequestからSessionを重複作成せず、非表示Worktreeで完了した結果が現在表示中の別Worktreeを奪わない。
 
 ## 対象外

--- a/src-tauri/src/adaptor/controller/command/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/mod.rs
@@ -267,6 +267,7 @@ mod tests {
             "get_workspace_status",
             "get_workspace_node_detail",
             "get_workspace_session_node_id",
+            "get_workspace_tree_selection_reconciliation",
             "get_worktree_dirty_count",
             "git_create_branch",
             "git_stage",

--- a/src-tauri/src/adaptor/controller/command/workflow/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/mod.rs
@@ -481,6 +481,7 @@ mod tests {
         "close_workspace_node",
         "get_workspace_node_detail",
         "get_workspace_session_node_id",
+        "get_workspace_tree_selection_reconciliation",
         "restore_workspace_workflow_execution",
     ];
 

--- a/src-tauri/src/adaptor/controller/command/workspace_tree.rs
+++ b/src-tauri/src/adaptor/controller/command/workspace_tree.rs
@@ -5,11 +5,13 @@ use tauri::State;
 use crate::adaptor::controller::state::AppState;
 use crate::usecase::workflow::{
     CloseWorkspaceNodeCommand, WorkflowRuntimeUsecase, WorkspaceNodeCommandUsecase,
-    WorkspaceNodeDetailDto, WorkspaceTreeSnapshotDto, WorkspaceWorkflowHistoryItemDto,
+    WorkspaceNodeDetailDto, WorkspaceTreeQueryService, WorkspaceTreeSelectionSnapshotDto,
+    WorkspaceTreeSnapshotDto, WorkspaceWorkflowHistoryItemDto,
 };
 
 pub(super) const COMMAND_NAMES: &[&str] = &[
     "list_workspace_worktree_nodes",
+    "get_workspace_tree_selection_reconciliation",
     "list_workspace_workflow_history",
     "get_workspace_node_detail",
     "get_workspace_session_node_id",
@@ -27,6 +29,7 @@ pub(crate) fn invoke_handler(
 ) -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Sync + 'static {
     tauri::generate_handler![
         list_workspace_worktree_nodes,
+        get_workspace_tree_selection_reconciliation,
         list_workspace_workflow_history,
         get_workspace_node_detail,
         get_workspace_session_node_id,
@@ -54,6 +57,22 @@ pub async fn list_workspace_worktree_nodes(
     .await
     .map_err(|e| format!("task join error: {e}"))??;
     Ok(nodes)
+}
+
+#[tauri::command]
+pub async fn get_workspace_tree_selection_reconciliation(
+    query_service: State<'_, Arc<WorkspaceTreeQueryService>>,
+    worktree_path: String,
+    selected_node_id: String,
+) -> Result<WorkspaceTreeSelectionSnapshotDto, String> {
+    let query_service = query_service.inner().clone();
+    tokio::task::spawn_blocking(move || {
+        query_service
+            .get_workspace_tree_selection_reconciliation(&worktree_path, &selected_node_id)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/adaptor/controller/wiring.rs
+++ b/src-tauri/src/adaptor/controller/wiring.rs
@@ -78,6 +78,7 @@ use crate::usecase::workflow::query_service::WorkflowQueryService;
 use crate::usecase::workflow::{
     NodeExecutionLifecycleUsecase, WorkflowReadUsecase, WorkflowRuntimeUsecase, WorkflowUsecase,
     WorkspaceNodeActionResolver, WorkspaceNodeCommandUsecase, WorkspaceSessionGateway,
+    WorkspaceTreeQueryService,
 };
 
 pub(crate) fn build_agent_backend_registry(
@@ -284,6 +285,7 @@ impl WorkspaceSessionGateway for EmptyWorkspaceSessionGateway {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_workflow_usecase_with_repository_worktrees<R: tauri::Runtime + 'static>(
     data_dir: impl Into<std::path::PathBuf>,
     repository_usecase: Arc<RepositoryUsecase>,
@@ -292,12 +294,31 @@ pub(crate) fn build_workflow_usecase_with_repository_worktrees<R: tauri::Runtime
     session_store: Arc<SessionStore>,
     app: tauri::AppHandle<R>,
 ) -> WorkflowUsecase {
+    build_workflow_services_with_repository_worktrees(
+        data_dir,
+        repository_usecase,
+        app_config,
+        config_secrets,
+        session_store,
+        app,
+    )
+    .0
+}
+
+pub(crate) fn build_workflow_services_with_repository_worktrees<R: tauri::Runtime + 'static>(
+    data_dir: impl Into<std::path::PathBuf>,
+    repository_usecase: Arc<RepositoryUsecase>,
+    app_config: Arc<dyn ConfigRepository>,
+    config_secrets: Arc<dyn ConfigSecretRepository>,
+    session_store: Arc<SessionStore>,
+    app: tauri::AppHandle<R>,
+) -> (WorkflowUsecase, WorkspaceTreeQueryService) {
     let data_dir = data_dir.into();
     let sessions = Arc::new(StoredWorkspaceSessionGateway::new(
         session_store,
         data_dir.clone(),
     ));
-    build_workflow_usecase_with_gateways(
+    build_workflow_services_with_gateways(
         data_dir,
         Arc::new(RepositoryManagedWorktreeGateway::new(
             repository_usecase,
@@ -353,6 +374,7 @@ pub(crate) fn build_file_direct_workflow_read_usecase(
     Ok(WorkflowReadUsecase::new(query, worktrees, secrets))
 }
 
+#[cfg(test)]
 fn build_workflow_usecase_with_gateways(
     data_dir: impl Into<std::path::PathBuf>,
     worktrees: Arc<dyn ManagedWorktreeGateway>,
@@ -360,6 +382,16 @@ fn build_workflow_usecase_with_gateways(
     secrets: Arc<dyn SecretSourceGateway>,
     sessions: Arc<dyn WorkspaceSessionGateway>,
 ) -> WorkflowUsecase {
+    build_workflow_services_with_gateways(data_dir, worktrees, editors, secrets, sessions).0
+}
+
+fn build_workflow_services_with_gateways(
+    data_dir: impl Into<std::path::PathBuf>,
+    worktrees: Arc<dyn ManagedWorktreeGateway>,
+    editors: Arc<dyn ExternalEditorGateway>,
+    secrets: Arc<dyn SecretSourceGateway>,
+    sessions: Arc<dyn WorkspaceSessionGateway>,
+) -> (WorkflowUsecase, WorkspaceTreeQueryService) {
     let data_dir = data_dir.into();
     let workflows_dir = WorkflowDefinitionFileRepository::default_workflows_dir();
     let facets_base_dir = workflows_dir.clone();
@@ -391,19 +423,22 @@ fn build_workflow_usecase_with_gateways(
         events,
         execution_projection,
     );
-    WorkflowUsecase::new(
-        query,
+    let workflow_usecase = WorkflowUsecase::new(
+        query.clone(),
         definitions,
         definition_sources,
         facets,
-        worktrees,
+        worktrees.clone(),
         editors,
         diagnostics,
         config_paths,
         secrets,
-        sessions,
-        execution_archives,
-    )
+        sessions.clone(),
+        execution_archives.clone(),
+    );
+    let workspace_tree_query_service =
+        WorkspaceTreeQueryService::new(query, worktrees, sessions, execution_archives);
+    (workflow_usecase, workspace_tree_query_service)
 }
 
 pub(crate) fn build_workflow_runtime_usecase(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,16 +238,17 @@ pub fn run() {
                     .state::<Arc<usecase::agent_session::session::SessionStore>>()
                     .inner()
                     .clone();
-                let workflow_usecase = Arc::new(
-                    adaptor::controller::wiring::build_workflow_usecase_with_repository_worktrees(
+                let (workflow_usecase, workspace_tree_query_service) =
+                    adaptor::controller::wiring::build_workflow_services_with_repository_worktrees(
                         data_dir.clone(),
                         repository_usecase.clone(),
                         config_repository.clone(),
                         config_secret_repository.clone(),
                         session_store_state,
                         app.handle().clone(),
-                    ),
-                );
+                    );
+                let workflow_usecase = Arc::new(workflow_usecase);
+                app.manage(Arc::new(workspace_tree_query_service));
                 let notion_usecase = Arc::new(usecase::notion::usecase::NotionUsecase::new(
                     notion_config_repository.clone(),
                     notion_api_gateway.clone(),

--- a/src-tauri/src/usecase/workflow/mod.rs
+++ b/src-tauri/src/usecase/workflow/mod.rs
@@ -47,7 +47,8 @@ pub(crate) use workspace_node_command::{
 };
 pub(crate) use workspace_tree::{
     WorkspaceNodeDetailDto, WorkspaceSessionGateway, WorkspaceSessionInput, WorkspaceSessionState,
-    WorkspaceTreeSnapshotDto, WorkspaceWorkflowHistoryItemDto,
+    WorkspaceTreeQueryService, WorkspaceTreeSelectionSnapshotDto, WorkspaceTreeSnapshotDto,
+    WorkspaceWorkflowHistoryItemDto,
 };
 
 #[derive(Clone)]

--- a/src-tauri/src/usecase/workflow/workspace_tree.rs
+++ b/src-tauri/src/usecase/workflow/workspace_tree.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Write as _;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
@@ -19,9 +20,9 @@ use crate::domain::workflow::status_aggregation::{
 };
 use crate::domain::workflow::{
     ExecutionListFilter, ExecutionStatus, FanoutSpec, ItemsSource, NodeDefinition, NodeExecution,
-    NodeExecutionStatus, NodeKind, NodeKindName, WorkflowDefinition, WorkflowError,
-    WorkflowExecution, WorkflowExecutionId, WorkflowExecutionManualArchiveRecord,
-    WorkflowExecutionSummary, WORKFLOW_ARCHIVE_REASON_MANUAL,
+    NodeExecutionStatus, NodeKindName, WorkflowDefinition, WorkflowError, WorkflowExecution,
+    WorkflowExecutionId, WorkflowExecutionManualArchiveRecord, WorkflowExecutionSummary,
+    WORKFLOW_ARCHIVE_REASON_MANUAL,
 };
 
 const DEFAULT_SESSION_TITLE: &str = "NewSession";
@@ -79,6 +80,19 @@ pub(crate) struct WorkspaceTreeSnapshotDto {
     pub nodes: Vec<WorkspaceTreeItemDto>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preferred_node_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkspaceTreeSelectionSnapshotDto {
+    pub snapshot: WorkspaceTreeSnapshotDto,
+    pub reconciliation: WorkspaceSelectionReconciliationDto,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkspaceSelectionReconciliationDto {
+    pub selection_in_snapshot: bool,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -240,6 +254,56 @@ struct WorkspaceProjectionIndex {
 struct WorkspaceProjection {
     snapshot: WorkspaceTreeSnapshotDto,
     index: WorkspaceProjectionIndex,
+}
+
+#[derive(Clone)]
+pub(crate) struct WorkspaceTreeQueryService {
+    query: WorkflowQueryService,
+    worktrees: Arc<dyn crate::domain::workflow::ManagedWorktreeGateway>,
+    sessions: Arc<dyn WorkspaceSessionGateway>,
+    execution_archives: Arc<dyn crate::domain::workflow::WorkflowExecutionArchiveRepository>,
+}
+
+impl WorkspaceTreeQueryService {
+    pub(crate) fn new(
+        query: WorkflowQueryService,
+        worktrees: Arc<dyn crate::domain::workflow::ManagedWorktreeGateway>,
+        sessions: Arc<dyn WorkspaceSessionGateway>,
+        execution_archives: Arc<dyn crate::domain::workflow::WorkflowExecutionArchiveRepository>,
+    ) -> Self {
+        Self {
+            query,
+            worktrees,
+            sessions,
+            execution_archives,
+        }
+    }
+
+    pub(crate) fn get_workspace_tree_selection_reconciliation(
+        &self,
+        worktree_path: &str,
+        selected_node_id: &str,
+    ) -> Result<WorkspaceTreeSelectionSnapshotDto, WorkflowError> {
+        let worktree_path = self.worktrees.resolve(worktree_path)?;
+        let mut sessions = self.sessions.list_active_sessions(&worktree_path)?;
+        sessions.extend(
+            self.sessions
+                .list_closed_sessions(&worktree_path)?
+                .into_iter()
+                .filter(|session| session.workflow_node_session),
+        );
+        let archives = self.execution_archives.manual_archive_records()?;
+        self.query
+            .project_workspace(
+                &worktree_path,
+                sessions,
+                &archives,
+                WorkspaceProjectionTarget::Snapshot,
+            )
+            .map(|projection| {
+                reconcile_workspace_tree_selection(projection.snapshot, selected_node_id)
+            })
+    }
 }
 
 impl WorkflowUsecase {
@@ -561,6 +625,31 @@ fn project_workspace_tree(
     }
 }
 
+fn reconcile_workspace_tree_selection(
+    snapshot: WorkspaceTreeSnapshotDto,
+    selected_node_id: &str,
+) -> WorkspaceTreeSelectionSnapshotDto {
+    let selection_in_snapshot = workspace_tree_contains_node(&snapshot.nodes, selected_node_id);
+    WorkspaceTreeSelectionSnapshotDto {
+        snapshot,
+        reconciliation: WorkspaceSelectionReconciliationDto {
+            selection_in_snapshot,
+        },
+    }
+}
+
+fn workspace_tree_contains_node(nodes: &[WorkspaceTreeItemDto], node_id: &str) -> bool {
+    nodes.iter().any(|item| match item {
+        WorkspaceTreeItemDto::Node(node) => node.id == node_id,
+        WorkspaceTreeItemDto::Workflow(workflow) => {
+            workspace_tree_contains_node(&workflow.children, node_id)
+        }
+        WorkspaceTreeItemDto::Fanout(fanout) => {
+            workspace_tree_contains_node(&fanout.children, node_id)
+        }
+    })
+}
+
 fn restrict_summaries_to_projection_target(
     summaries: &mut Vec<WorkflowExecutionSummary>,
     sessions: &[WorkspaceSessionInput],
@@ -664,7 +753,7 @@ fn project_workflow(
         .map(|projection| {
             project_workflow_children(
                 &summary,
-                Some(&projection.execution),
+                &projection.execution,
                 projection.definition.as_ref(),
                 sessions,
                 target,
@@ -701,21 +790,13 @@ fn project_workflow(
 
 fn project_workflow_children(
     summary: &WorkflowExecutionSummary,
-    execution: Option<&WorkflowExecution>,
+    execution: &WorkflowExecution,
     definition: Option<&WorkflowDefinition>,
     sessions: &HashMap<String, WorkspaceSessionInput>,
     target: &WorkspaceProjectionTarget,
     index: &mut WorkspaceProjectionIndex,
 ) -> Vec<WorkspaceTreeItemDto> {
-    let child_names = definition
-        .into_iter()
-        .flat_map(|definition| definition.nodes.iter())
-        .filter_map(|node| node.fanout())
-        .flat_map(|fanout| fanout.child.iter().cloned())
-        .collect::<HashSet<_>>();
-    let node_executions = execution
-        .map(|execution| execution.node_executions.as_slice())
-        .unwrap_or_default();
+    let node_executions = execution.node_executions.as_slice();
     let mut fanout_children = HashMap::<(String, u32), Vec<&NodeExecution>>::new();
     for node_execution in node_executions {
         let Some(parent) = node_execution.fanout_parent.as_ref() else {
@@ -731,7 +812,6 @@ fn project_workflow_children(
     // timestamps: a fanout batch can legitimately give several occurrences the
     // same timestamp. Repeated definitions therefore remain repeated UI rows.
     let mut occurrence_counts = HashMap::<String, usize>::new();
-    let mut executed_node_names = HashSet::<String>::new();
     let mut children = Vec::new();
     for node_execution in node_executions
         .iter()
@@ -742,26 +822,26 @@ fn project_workflow_children(
             .or_default();
         let current_occurrence = *occurrence_index;
         *occurrence_index += 1;
-        executed_node_names.insert(node_execution.node_name.clone());
 
-        let node_definition = definition.and_then(|definition| {
-            definition
-                .nodes
-                .iter()
-                .find(|node| node.name == node_execution.node_name)
-        });
         let item = match node_execution.kind {
             NodeKindName::Fanout => {
+                let fanout_spec = definition
+                    .and_then(|definition| {
+                        definition
+                            .nodes
+                            .iter()
+                            .find(|node| node.name == node_execution.node_name)
+                    })
+                    .and_then(NodeDefinition::fanout);
                 let actual_children = fanout_children
                     .get(&(node_execution.node_name.clone(), node_execution.attempt))
                     .map(Vec::as_slice)
                     .unwrap_or_default();
                 project_fanout(
                     summary,
-                    definition,
                     &node_execution.node_name,
-                    node_definition.and_then(NodeDefinition::fanout),
-                    Some(node_execution),
+                    fanout_spec,
+                    node_execution,
                     current_occurrence,
                     actual_children,
                     sessions,
@@ -772,50 +852,13 @@ fn project_workflow_children(
             NodeKindName::Session | NodeKindName::Command => project_workflow_node(
                 summary,
                 &workflow_node_occurrence_key(&node_execution.node_name, current_occurrence),
-                &node_execution.node_name,
-                node_execution.kind,
-                Some(node_execution),
+                node_execution,
                 sessions,
                 target,
                 index,
             ),
         };
         children.push(item);
-    }
-
-    // Definitions which have never started remain available as queued rows.
-    // They follow the executed prefix in declaration order; fanout children stay
-    // nested under their parent and never appear directly under the Workflow.
-    if let Some(definition) = definition {
-        for node in definition.nodes.iter().filter(|node| {
-            !child_names.contains(&node.name) && !executed_node_names.contains(&node.name)
-        }) {
-            let item = match &node.kind {
-                NodeKind::Fanout(spec) => project_fanout(
-                    summary,
-                    Some(definition),
-                    &node.name,
-                    Some(spec),
-                    None,
-                    0,
-                    &[],
-                    sessions,
-                    target,
-                    index,
-                ),
-                NodeKind::Session(_) | NodeKind::Command(_) => project_workflow_node(
-                    summary,
-                    &workflow_node_occurrence_key(&node.name, 0),
-                    &node.name,
-                    node.kind_name(),
-                    None,
-                    sessions,
-                    target,
-                    index,
-                ),
-            };
-            children.push(item);
-        }
     }
 
     children
@@ -831,10 +874,9 @@ struct FanoutSlot {
 #[allow(clippy::too_many_arguments)]
 fn project_fanout(
     summary: &WorkflowExecutionSummary,
-    definition: Option<&WorkflowDefinition>,
     fanout_name: &str,
     spec: Option<&FanoutSpec>,
-    parent: Option<&NodeExecution>,
+    parent: &NodeExecution,
     parent_occurrence: usize,
     actual_children: &[&NodeExecution],
     sessions: &HashMap<String, WorkspaceSessionInput>,
@@ -843,7 +885,6 @@ fn project_fanout(
 ) -> WorkspaceTreeItemDto {
     let mut slot_occurrences = BTreeMap::<FanoutSlot, usize>::new();
     let mut dynamic_child_occurrences = BTreeMap::<(usize, String), usize>::new();
-    let mut actual_slots = HashSet::<FanoutSlot>::new();
     let mut children = Vec::new();
     let dynamic_items =
         spec.is_some_and(|spec| matches!(spec.items, Some(ItemsSource::ArtifactField { .. })));
@@ -858,7 +899,6 @@ fn project_fanout(
             child_index: reference.child_index,
             child_name: node_execution.node_name.clone(),
         };
-        actual_slots.insert(slot.clone());
         let semantic_key = if dynamic_items {
             let dynamic_key = (reference.child_index, node_execution.node_name.clone());
             let occurrence = dynamic_child_occurrences.entry(dynamic_key).or_default();
@@ -885,73 +925,24 @@ fn project_fanout(
         children.push(project_workflow_node(
             summary,
             &semantic_key,
-            &node_execution.node_name,
-            node_execution.kind,
-            Some(node_execution),
+            node_execution,
             sessions,
             target,
             index,
         ));
     }
 
-    let keep_queued_slots = parent
-        .map(|parent| parent.status.is_active())
-        .unwrap_or(true);
-    if keep_queued_slots {
-        for slot in spec
-            .map(|spec| expected_fanout_slots(spec, actual_children.is_empty()))
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|slot| !actual_slots.contains(slot))
-        {
-            let kind = definition
-                .and_then(|definition| {
-                    definition
-                        .nodes
-                        .iter()
-                        .find(|node| node.name == slot.child_name)
-                })
-                .map(NodeDefinition::kind_name)
-                .unwrap_or(NodeKindName::Session);
-            let semantic_key = if dynamic_items {
-                fanout_dynamic_child_occurrence_key(
-                    fanout_name,
-                    parent_occurrence,
-                    slot.child_index,
-                    &slot.child_name,
-                    0,
-                )
-            } else {
-                fanout_child_occurrence_key(fanout_name, parent_occurrence, &slot, 0)
-            };
-            children.push(project_workflow_node(
-                summary,
-                &semantic_key,
-                &slot.child_name,
-                kind,
-                None,
-                sessions,
-                target,
-                index,
-            ));
-        }
-    }
-
     let child_statuses = children.iter().filter_map(tree_item_status);
-    let parent_status =
-        parent.map(|node_execution| representative_status(node_execution.status.as_str()));
-    let status = aggregate_representative_statuses(child_statuses.chain(parent_status))
-        .unwrap_or(RepresentativeStatus::Queued);
+    let parent_status = representative_status(parent.status.as_str());
+    let status =
+        aggregate_representative_statuses(child_statuses.chain(std::iter::once(parent_status)))
+            .expect("fanout status aggregation always includes its execution");
     let child_updated = children.iter().map(tree_item_updated_at);
-    let parent_updated = parent.into_iter().map(|node_execution| {
-        node_execution
-            .completed_at
-            .unwrap_or(node_execution.started_at)
-    });
+    let parent_updated = parent.completed_at.unwrap_or(parent.started_at);
     let updated_at = child_updated
-        .chain(parent_updated)
+        .chain(std::iter::once(parent_updated))
         .max_by(f64::total_cmp)
-        .unwrap_or(summary.started_at);
+        .expect("fanout updated time aggregation always includes its execution");
 
     WorkspaceTreeItemDto::Fanout(WorkspaceFanoutDto {
         id: opaque_branch_id(&fanout_branch_occurrence_key(
@@ -966,74 +957,38 @@ fn project_fanout(
     })
 }
 
-fn expected_fanout_slots(spec: &FanoutSpec, no_actual_children: bool) -> Vec<FanoutSlot> {
-    let item_indices = match &spec.items {
-        Some(ItemsSource::Literal(items)) => items
-            .iter()
-            .enumerate()
-            .map(|(index, _)| Some(index))
-            .collect::<Vec<_>>(),
-        Some(ItemsSource::ArtifactField { .. }) if no_actual_children => vec![None],
-        Some(ItemsSource::ArtifactField { .. }) => Vec::new(),
-        None => vec![None],
-    };
-    item_indices
-        .into_iter()
-        .flat_map(|item_index| {
-            spec.child
-                .iter()
-                .enumerate()
-                .map(move |(child_index, child_name)| FanoutSlot {
-                    item_index,
-                    child_index,
-                    child_name: child_name.clone(),
-                })
-        })
-        .collect()
-}
-
-#[allow(clippy::too_many_arguments)]
 fn project_workflow_node(
     summary: &WorkflowExecutionSummary,
     semantic_key: &str,
-    title: &str,
-    kind: NodeKindName,
-    node_execution: Option<&NodeExecution>,
+    node_execution: &NodeExecution,
     sessions: &HashMap<String, WorkspaceSessionInput>,
     target: &WorkspaceProjectionTarget,
     index: &mut WorkspaceProjectionIndex,
 ) -> WorkspaceTreeItemDto {
     let id = opaque_workflow_node_id(&summary.execution_id, semantic_key);
     let session = node_execution
-        .and_then(|node_execution| node_execution.session_id.as_ref())
+        .session_id
+        .as_ref()
         .and_then(|session_id| sessions.get(session_id));
-    let status = node_execution
-        .map(|node_execution| workflow_node_status(node_execution, session))
-        .unwrap_or(RepresentativeStatus::Queued);
-    let updated_at = node_execution
-        .map(|node_execution| {
-            let execution_updated = node_execution
-                .completed_at
-                .unwrap_or(node_execution.started_at);
-            session
-                .map(|session| session.updated_at.max(execution_updated))
-                .unwrap_or(execution_updated)
-        })
-        .unwrap_or(summary.started_at);
+    let status = workflow_node_status(node_execution, session);
+    let execution_updated = node_execution
+        .completed_at
+        .unwrap_or(node_execution.started_at);
+    let updated_at = session
+        .map(|session| session.updated_at.max(execution_updated))
+        .unwrap_or(execution_updated);
     let capabilities = WorkspaceNodeCapabilitiesDto {
-        can_approve: node_execution.is_some_and(|node_execution| {
-            node_execution.status == NodeExecutionStatus::WaitingApproval
-        }),
+        can_approve: node_execution.status == NodeExecutionStatus::WaitingApproval,
         can_close: false,
     };
     let status_value = status.as_str().to_string();
-    let content_kind = match kind {
+    let content_kind = match node_execution.kind {
         NodeKindName::Command => "command",
         NodeKindName::Session | NodeKindName::Fanout => "session",
     };
     let node = WorkspaceNodeDto {
         id: id.clone(),
-        title: title.to_string(),
+        title: node_execution.node_name.clone(),
         status: status_value.clone(),
         error_reason: session.and_then(|session| session.error_reason.clone()),
         content_kind,
@@ -1042,10 +997,9 @@ fn project_workflow_node(
     };
 
     if let WorkspaceProjectionTarget::Session(session_id) = target {
-        if node_execution.is_some_and(|node_execution| {
-            node_execution.session_id.as_deref() == Some(session_id.as_str())
-                && sessions.contains_key(session_id)
-        }) {
+        if node_execution.session_id.as_deref() == Some(session_id.as_str())
+            && sessions.contains_key(session_id)
+        {
             index
                 .session_node_ids
                 .insert(session_id.clone(), id.clone());
@@ -1054,12 +1008,11 @@ fn project_workflow_node(
     if target.matches_node(&id) {
         // Content can retain command output, so it is materialized only for the
         // one explicitly selected leaf. Snapshot/Session projections never clone it.
-        let content = match kind {
+        let content = match node_execution.kind {
             NodeKindName::Command => {
                 WorkspaceNodeContentDto::Command(WorkspaceCommandNodeContentDto {
-                    display_command: node_execution
-                        .and_then(|node_execution| node_execution.display_command.clone()),
-                    result: node_execution.and_then(command_result),
+                    display_command: node_execution.display_command.clone(),
+                    result: command_result(node_execution),
                 })
             }
             NodeKindName::Session | NodeKindName::Fanout => {
@@ -1070,21 +1023,19 @@ fn project_workflow_node(
                 })
             }
         };
-        let approval = node_execution.and_then(|node_execution| {
-            (node_execution.status == NodeExecutionStatus::WaitingApproval).then(|| {
-                WorkspaceNodeApprovalTarget {
-                    execution_id: node_execution.execution_id.clone(),
-                    node_name: node_execution.node_name.clone(),
-                    node_execution_id: node_execution.id.clone(),
-                }
-            })
+        let approval = (node_execution.status == NodeExecutionStatus::WaitingApproval).then(|| {
+            WorkspaceNodeApprovalTarget {
+                execution_id: node_execution.execution_id.clone(),
+                node_name: node_execution.node_name.clone(),
+                node_execution_id: node_execution.id.clone(),
+            }
         });
         index.records.insert(
             id.clone(),
             WorkspaceNodeRecord {
                 detail: WorkspaceNodeDetailDto {
                     id,
-                    title: title.to_string(),
+                    title: node_execution.node_name.clone(),
                     status: status_value,
                     error_reason: session.and_then(|session| session.error_reason.clone()),
                     capabilities,
@@ -1150,9 +1101,8 @@ fn fanout_dynamic_child_occurrence_key(
     child_name: &str,
     occurrence: usize,
 ) -> String {
-    // Before ArtifactField items are known, the queued placeholder has no item
-    // coordinate. Keep that same semantic ID for the first concrete child and
-    // then number later concrete occurrences in their NodeStarted order.
+    // ArtifactField items are discovered only through concrete child executions.
+    // Number those children in their NodeStarted order without exposing item coordinates.
     fanout_child_occurrence_key(
         fanout_name,
         parent_occurrence,
@@ -1383,7 +1333,7 @@ mod tests {
     use super::*;
     use crate::domain::workflow::{
         Artifact, CommandSpec, ExecutionOrigin, NodeExecutionFailure, NodeExecutionFailureKind,
-        TokenUsage,
+        NodeKind, TokenUsage,
     };
 
     fn summary() -> WorkflowExecutionSummary {
@@ -1722,7 +1672,7 @@ mod tests {
     }
 
     #[test]
-    fn declaration_order_and_queued_nodes_come_from_execution_snapshot() {
+    fn workflow_without_started_nodes_has_an_empty_branch_and_no_preferred_node() {
         let definition = definition(vec![
             command_definition("build"),
             session_definition("review"),
@@ -1738,43 +1688,20 @@ mod tests {
         let WorkspaceTreeItemDto::Workflow(workflow) = &projected.snapshot.nodes[0] else {
             panic!("expected workflow")
         };
-        let titles = workflow
-            .children
-            .iter()
-            .map(|item| match item {
-                WorkspaceTreeItemDto::Node(node) => node.title.as_str(),
-                _ => panic!("expected leaf"),
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(titles, vec!["build", "review"]);
-        assert!(workflow.children.iter().all(|item| {
-            matches!(item, WorkspaceTreeItemDto::Node(node) if node.status == "queued")
-        }));
+        assert!(workflow.children.is_empty());
+        assert_eq!(projected.snapshot.preferred_node_id, None);
+        assert!(projected.index.records.is_empty());
+        assert!(projected.index.session_node_ids.is_empty());
     }
 
     #[test]
-    fn execution_occurrences_follow_event_order_and_unstarted_nodes_remain_queued() {
+    fn execution_occurrences_follow_event_order_without_unstarted_definitions() {
         let workflow_definition = definition(vec![
             session_definition("A"),
             command_definition("B"),
             command_definition("C"),
             session_definition("D"),
         ]);
-        let queued = project_workspace_tree(
-            "/repo",
-            Vec::new(),
-            vec![summary()],
-            projection(workflow_definition.clone(), execution(Vec::new())),
-            &[],
-            &WorkspaceProjectionTarget::Snapshot,
-        );
-        let WorkspaceTreeItemDto::Workflow(queued_workflow) = &queued.snapshot.nodes[0] else {
-            panic!("expected workflow")
-        };
-        let WorkspaceTreeItemDto::Node(queued_a) = &queued_workflow.children[0] else {
-            panic!("expected queued A")
-        };
-
         let mut occurrences = vec![
             node(
                 "a-first-internal",
@@ -1833,10 +1760,8 @@ mod tests {
                 .iter()
                 .map(|node| node.title.as_str())
                 .collect::<Vec<_>>(),
-            vec!["A", "B", "A", "C", "D"]
+            vec!["A", "B", "A", "C"]
         );
-        assert_eq!(leaves.last().unwrap().status, "queued");
-        assert_eq!(leaves[0].id, queued_a.id);
         assert_ne!(leaves[0].id, leaves[2].id);
         assert_eq!(
             leaves
@@ -1856,6 +1781,281 @@ mod tests {
             assert!(!serialized.contains(internal_id));
         }
         assert!(!serialized.contains("attempt"));
+        assert_eq!(
+            projected.snapshot.preferred_node_id,
+            Some(leaves[3].id.clone())
+        );
+    }
+
+    #[test]
+    fn terminal_workflows_hide_every_unstarted_leaf_and_branch() {
+        let fanout = NodeDefinition {
+            name: "unstarted-fanout".to_string(),
+            kind: NodeKind::Fanout(FanoutSpec {
+                child: vec!["fanout-child".to_string()],
+                items: None,
+            }),
+            ..Default::default()
+        };
+        let workflow_definition = definition(vec![
+            session_definition("started"),
+            session_definition("unstarted-leaf"),
+            fanout,
+            session_definition("fanout-child"),
+        ]);
+        let started = node(
+            "started-execution",
+            "started",
+            NodeKindName::Session,
+            1,
+            NodeExecutionStatus::Succeeded,
+        );
+
+        for status in [
+            ExecutionStatus::Completed,
+            ExecutionStatus::Failed,
+            ExecutionStatus::Aborted,
+        ] {
+            let mut workflow_summary = summary();
+            workflow_summary.status = status;
+            let mut runtime = execution(vec![started.clone()]);
+            runtime.status = status;
+            let projected = project_workspace_tree(
+                "/repo",
+                Vec::new(),
+                vec![workflow_summary],
+                projection(workflow_definition.clone(), runtime),
+                &[],
+                &WorkspaceProjectionTarget::Snapshot,
+            );
+            let WorkspaceTreeItemDto::Workflow(workflow) = &projected.snapshot.nodes[0] else {
+                panic!("expected workflow")
+            };
+            assert_eq!(workflow.children.len(), 1);
+            assert!(matches!(
+                &workflow.children[0],
+                WorkspaceTreeItemDto::Node(node) if node.title == "started"
+            ));
+        }
+    }
+
+    #[test]
+    fn started_nodes_keep_every_execution_status() {
+        let statuses = [
+            (NodeExecutionStatus::Running, "running"),
+            (NodeExecutionStatus::WaitingApproval, "waiting"),
+            (NodeExecutionStatus::Succeeded, "completed"),
+            (NodeExecutionStatus::Failed, "failed"),
+            (NodeExecutionStatus::Aborted, "aborted"),
+        ];
+        let definitions = statuses
+            .iter()
+            .enumerate()
+            .map(|(index, _)| session_definition(&format!("node-{index}")))
+            .collect::<Vec<_>>();
+        let executions = statuses
+            .iter()
+            .enumerate()
+            .map(|(index, (status, _))| {
+                node(
+                    &format!("execution-{index}"),
+                    &format!("node-{index}"),
+                    NodeKindName::Session,
+                    index as u32 + 1,
+                    *status,
+                )
+            })
+            .collect::<Vec<_>>();
+        let projected = project_workspace_tree(
+            "/repo",
+            Vec::new(),
+            vec![summary()],
+            projection(definition(definitions), execution(executions)),
+            &[],
+            &WorkspaceProjectionTarget::Snapshot,
+        );
+        let WorkspaceTreeItemDto::Workflow(workflow) = &projected.snapshot.nodes[0] else {
+            panic!("expected workflow")
+        };
+        let projected_statuses = workflow
+            .children
+            .iter()
+            .map(|item| match item {
+                WorkspaceTreeItemDto::Node(node) => node.status.as_str(),
+                _ => panic!("expected leaf"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            projected_statuses,
+            statuses
+                .iter()
+                .map(|(_, expected)| *expected)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn node_started_is_identical_in_live_and_reloaded_workspace_trees() {
+        let workflow_definition = definition(vec![session_definition("plan")]);
+        let mut live_execution = execution(Vec::new());
+        let before = project_workspace_tree(
+            "/repo",
+            Vec::new(),
+            vec![summary()],
+            projection(workflow_definition.clone(), live_execution.clone()),
+            &[],
+            &WorkspaceProjectionTarget::Snapshot,
+        );
+        let WorkspaceTreeItemDto::Workflow(before_workflow) = &before.snapshot.nodes[0] else {
+            panic!("expected workflow")
+        };
+        assert!(before_workflow.children.is_empty());
+
+        let mut started = node(
+            "plan-execution",
+            "plan",
+            NodeKindName::Session,
+            1,
+            NodeExecutionStatus::Running,
+        );
+        started.started_at = 2.0;
+        live_execution.node_executions.push(started);
+        live_execution.updated_at = 2.0;
+        live_execution.current_node = Some("plan".to_string());
+        let live = project_workspace_tree(
+            "/repo",
+            Vec::new(),
+            vec![summary()],
+            projection(workflow_definition.clone(), live_execution),
+            &[],
+            &WorkspaceProjectionTarget::Snapshot,
+        );
+
+        // Event replay lives outside the usecase layer. Model reload with an
+        // independently reconstructed domain read model at this projection boundary.
+        let mut reloaded_node = node(
+            "plan-execution",
+            "plan",
+            NodeKindName::Session,
+            1,
+            NodeExecutionStatus::Running,
+        );
+        reloaded_node.started_at = 2.0;
+        let mut reloaded_execution = execution(vec![reloaded_node]);
+        reloaded_execution.updated_at = 2.0;
+        reloaded_execution.current_node = Some("plan".to_string());
+        let reloaded = project_workspace_tree(
+            "/repo",
+            Vec::new(),
+            vec![summary()],
+            projection(workflow_definition, reloaded_execution),
+            &[],
+            &WorkspaceProjectionTarget::Snapshot,
+        );
+
+        let WorkspaceTreeItemDto::Workflow(live_workflow) = &live.snapshot.nodes[0] else {
+            panic!("expected live workflow")
+        };
+        assert_eq!(live_workflow.children.len(), 1);
+        assert_eq!(live.snapshot, reloaded.snapshot);
+    }
+
+    #[test]
+    fn definition_only_nodes_never_populate_tree_detail_or_session_indexes() {
+        let fanout = NodeDefinition {
+            name: "matrix".to_string(),
+            kind: NodeKind::Fanout(FanoutSpec {
+                child: vec!["review".to_string()],
+                items: Some(ItemsSource::Literal(vec![serde_json::json!("item")])),
+            }),
+            ..Default::default()
+        };
+        let expanded_definition = definition(vec![
+            session_definition("plan"),
+            fanout,
+            session_definition("review"),
+        ]);
+        let stored_session = WorkspaceSessionInput {
+            id: "stored-session".to_string(),
+            worktree_path: "/repo".to_string(),
+            state: WorkspaceSessionState::Active,
+            error_reason: None,
+            updated_at: 4.0,
+            first_message: String::new(),
+            workflow_node_session: true,
+            workflow_execution_id: Some(summary().execution_id),
+        };
+        let empty = project_workspace_tree(
+            "/repo",
+            vec![stored_session.clone()],
+            vec![summary()],
+            projection(definition(Vec::new()), execution(Vec::new())),
+            &[],
+            &WorkspaceProjectionTarget::Snapshot,
+        );
+        let definition_only = project_workspace_tree(
+            "/repo",
+            vec![stored_session.clone()],
+            vec![summary()],
+            projection(expanded_definition.clone(), execution(Vec::new())),
+            &[],
+            &WorkspaceProjectionTarget::Snapshot,
+        );
+        assert_eq!(empty.snapshot, definition_only.snapshot);
+
+        let detail_target = workflow_node_target("plan");
+        let missing_detail = project_workspace_tree(
+            "/repo",
+            vec![stored_session.clone()],
+            vec![summary()],
+            projection(expanded_definition.clone(), execution(Vec::new())),
+            &[],
+            &detail_target,
+        );
+        assert!(missing_detail.index.records.is_empty());
+        let missing_session = project_workspace_tree(
+            "/repo",
+            vec![stored_session.clone()],
+            vec![summary()],
+            projection(expanded_definition.clone(), execution(Vec::new())),
+            &[],
+            &WorkspaceProjectionTarget::Session("stored-session".to_string()),
+        );
+        assert!(missing_session.index.session_node_ids.is_empty());
+
+        let mut started = node(
+            "plan-execution",
+            "plan",
+            NodeKindName::Session,
+            1,
+            NodeExecutionStatus::Running,
+        );
+        started.session_id = Some("stored-session".to_string());
+        let runtime = execution(vec![started]);
+        let detail = project_workspace_tree(
+            "/repo",
+            vec![stored_session.clone()],
+            vec![summary()],
+            projection(expanded_definition.clone(), runtime.clone()),
+            &[],
+            &detail_target,
+        );
+        let WorkspaceProjectionTarget::Node(node_id) = detail_target else {
+            unreachable!()
+        };
+        assert!(detail.index.records.contains_key(&node_id));
+        let lookup = project_workspace_tree(
+            "/repo",
+            vec![stored_session],
+            vec![summary()],
+            projection(expanded_definition, runtime),
+            &[],
+            &WorkspaceProjectionTarget::Session("stored-session".to_string()),
+        );
+        assert_eq!(
+            lookup.index.session_node_ids.get("stored-session"),
+            Some(&node_id)
+        );
     }
 
     #[test]
@@ -1981,7 +2181,7 @@ mod tests {
     }
 
     #[test]
-    fn literal_fanout_items_expand_to_distinct_leaf_nodes_in_item_then_child_order() {
+    fn literal_fanout_projects_only_started_children_in_event_order() {
         let fanout = NodeDefinition {
             name: "matrix".to_string(),
             kind: NodeKind::Fanout(FanoutSpec {
@@ -1993,16 +2193,15 @@ mod tests {
             }),
             ..Default::default()
         };
-        let mut parent = node(
+        let parent = node(
             "matrix-parent",
             "matrix",
             NodeKindName::Fanout,
             1,
-            NodeExecutionStatus::Succeeded,
+            NodeExecutionStatus::Running,
         );
-        parent.completed_at = Some(4.0);
         let mut executions = vec![parent];
-        for (item_index, child_name) in [(0, "lint"), (0, "test"), (1, "lint"), (1, "test")] {
+        for (item_index, child_name) in [(0, "lint"), (1, "test")] {
             let child_index = usize::from(child_name == "test");
             let mut child = node(
                 &format!("{child_name}-{item_index}"),
@@ -2050,7 +2249,7 @@ mod tests {
                 _ => panic!("expected leaf"),
             })
             .collect::<Vec<_>>();
-        assert_eq!(titles, vec!["lint", "test", "lint", "test"]);
+        assert_eq!(titles, vec!["lint", "test"]);
         let ids = fanout
             .children
             .iter()
@@ -2059,11 +2258,11 @@ mod tests {
                 _ => panic!("expected leaf"),
             })
             .collect::<HashSet<_>>();
-        assert_eq!(ids.len(), 4);
+        assert_eq!(ids.len(), 2);
     }
 
     #[test]
-    fn artifact_item_fanout_keeps_queued_child_id_for_its_first_occurrence() {
+    fn artifact_item_fanout_without_started_children_has_an_empty_branch() {
         let fanout = NodeDefinition {
             name: "matrix".to_string(),
             kind: NodeKind::Fanout(FanoutSpec {
@@ -2083,7 +2282,7 @@ mod tests {
             NodeExecutionStatus::Running,
         );
         let workflow_definition = definition(vec![fanout, session_definition("review")]);
-        let queued = project_workspace_tree(
+        let empty = project_workspace_tree(
             "/repo",
             Vec::new(),
             vec![summary()],
@@ -2091,20 +2290,16 @@ mod tests {
             &[],
             &WorkspaceProjectionTarget::Snapshot,
         );
-        let fanout_child = |projection: &WorkspaceProjection, index: usize| {
+        let fanout_branch = |projection: &WorkspaceProjection| {
             let WorkspaceTreeItemDto::Workflow(workflow) = &projection.snapshot.nodes[0] else {
                 panic!("expected workflow")
             };
             let WorkspaceTreeItemDto::Fanout(fanout) = &workflow.children[0] else {
                 panic!("expected fanout")
             };
-            let WorkspaceTreeItemDto::Node(node) = &fanout.children[index] else {
-                panic!("expected fanout child")
-            };
-            node.clone()
+            fanout.clone()
         };
-        let queued_id = fanout_child(&queued, 0).id.clone();
-        assert_eq!(fanout_child(&queued, 0).status, "queued");
+        assert!(fanout_branch(&empty).children.is_empty());
 
         let dynamic_child = |id: &str, item_index: usize| {
             let mut child = node(
@@ -2138,9 +2333,17 @@ mod tests {
             &WorkspaceProjectionTarget::Snapshot,
         );
 
-        assert_eq!(fanout_child(&expanded, 0).id, queued_id);
-        assert_eq!(fanout_child(&expanded, 0).status, "running");
-        assert_ne!(fanout_child(&expanded, 0).id, fanout_child(&expanded, 1).id);
+        let children = &fanout_branch(&expanded).children;
+        assert_eq!(children.len(), 2);
+        let WorkspaceTreeItemDto::Node(first) = &children[0] else {
+            panic!("expected first concrete child")
+        };
+        let WorkspaceTreeItemDto::Node(second) = &children[1] else {
+            panic!("expected second concrete child")
+        };
+        assert_eq!(first.status, "running");
+        assert_eq!(second.status, "running");
+        assert_ne!(first.id, second.id);
     }
 
     #[test]
@@ -2715,6 +2918,100 @@ mod tests {
     }
 
     #[test]
+    fn selection_reconciliation_keeps_a_leaf_that_remains_in_the_snapshot() {
+        let started = node(
+            "session-node",
+            "plan",
+            NodeKindName::Session,
+            1,
+            NodeExecutionStatus::Running,
+        );
+        let selected_node_id = match workflow_node_target("plan") {
+            WorkspaceProjectionTarget::Node(node_id) => node_id,
+            _ => unreachable!(),
+        };
+        let projected = project_workspace_tree(
+            "/repo",
+            Vec::new(),
+            vec![summary()],
+            projection(
+                definition(vec![session_definition("plan")]),
+                execution(vec![started]),
+            ),
+            &[],
+            &WorkspaceProjectionTarget::Snapshot,
+        );
+
+        let response = reconcile_workspace_tree_selection(projected.snapshot, &selected_node_id);
+
+        assert!(response.reconciliation.selection_in_snapshot);
+        assert_eq!(response.snapshot.preferred_node_id, Some(selected_node_id));
+        assert_eq!(
+            serde_json::to_value(&response).unwrap()["reconciliation"],
+            serde_json::json!({ "selectionInSnapshot": true })
+        );
+    }
+
+    #[test]
+    fn archived_selection_reconciliation_uses_the_same_snapshot_preferred_leaf_or_null() {
+        let started = node(
+            "session-node",
+            "plan",
+            NodeKindName::Session,
+            1,
+            NodeExecutionStatus::Running,
+        );
+        let selected_node_id = match workflow_node_target("plan") {
+            WorkspaceProjectionTarget::Node(node_id) => node_id,
+            _ => unreachable!(),
+        };
+        let archives = vec![WorkflowExecutionManualArchiveRecord {
+            execution_id: summary().execution_id,
+            archived_at: 5.0,
+        }];
+        let direct_session = WorkspaceSessionInput {
+            id: "direct-session".to_string(),
+            worktree_path: "/repo".to_string(),
+            state: WorkspaceSessionState::Active,
+            error_reason: None,
+            updated_at: 6.0,
+            first_message: "fallback".to_string(),
+            workflow_node_session: false,
+            workflow_execution_id: None,
+        };
+        let project_snapshot = |sessions| {
+            project_workspace_tree(
+                "/repo",
+                sessions,
+                vec![summary()],
+                projection(
+                    definition(vec![session_definition("plan")]),
+                    execution(vec![started.clone()]),
+                ),
+                &archives,
+                &WorkspaceProjectionTarget::Snapshot,
+            )
+            .snapshot
+        };
+
+        let with_fallback = reconcile_workspace_tree_selection(
+            project_snapshot(vec![direct_session]),
+            &selected_node_id,
+        );
+        assert!(!with_fallback.reconciliation.selection_in_snapshot);
+        assert!(with_fallback.snapshot.preferred_node_id.is_some());
+
+        let without_fallback =
+            reconcile_workspace_tree_selection(project_snapshot(Vec::new()), &selected_node_id);
+        assert!(!without_fallback.reconciliation.selection_in_snapshot);
+        assert_eq!(without_fallback.snapshot.preferred_node_id, None);
+        assert_eq!(
+            serde_json::to_value(&without_fallback).unwrap()["reconciliation"],
+            serde_json::json!({ "selectionInSnapshot": false })
+        );
+    }
+
+    #[test]
     fn archived_workflow_is_hidden_from_tree_but_selected_session_detail_remains_available() {
         let mut running = node(
             "session-node",
@@ -2761,11 +3058,11 @@ mod tests {
         };
         let detail = project_workspace_tree(
             "/repo",
-            vec![stored_session],
+            vec![stored_session.clone()],
             vec![summary()],
             projection(
                 definition(vec![session_definition("plan")]),
-                execution(vec![running]),
+                execution(vec![running.clone()]),
             ),
             &archives,
             &target,
@@ -2778,6 +3075,22 @@ mod tests {
         assert_eq!(content.session_id.as_deref(), Some("stored-session"));
         assert!(!detail.index.records[node_id].detail.capabilities.can_close);
         assert!(detail.index.records[node_id].close.is_none());
+
+        let lookup = project_workspace_tree(
+            "/repo",
+            vec![stored_session],
+            vec![summary()],
+            projection(
+                definition(vec![session_definition("plan")]),
+                execution(vec![running]),
+            ),
+            &archives,
+            &WorkspaceProjectionTarget::Session("stored-session".to_string()),
+        );
+        assert_eq!(
+            lookup.index.session_node_ids.get("stored-session"),
+            Some(node_id)
+        );
     }
 
     #[test]

--- a/src/App.new-session.test.tsx
+++ b/src/App.new-session.test.tsx
@@ -10,6 +10,7 @@ interface TestRequest {
 const mocks = vi.hoisted(() => ({
 	openWorktreeTab: vi.fn(),
 	selectedWorktreeId: "wt-a",
+	preferredNodeId: "preferred-a" as string | null,
 	lastRequests: new Map<string, TestRequest>(),
 }));
 
@@ -109,10 +110,11 @@ vi.mock("@/components/workspace/WorkspaceList", () => ({
 				type="button"
 				onClick={() =>
 					autoSelectPreferredNode &&
+					mocks.preferredNodeId &&
 					onSelectWorktree("/wt-a", undefined, undefined, {
 						kind: "node",
 						worktreePath: "/wt-a",
-						nodeId: "preferred-a",
+						nodeId: mocks.preferredNodeId,
 					})
 				}
 			>
@@ -225,6 +227,7 @@ const { default: App } = await import("./App");
 beforeEach(() => {
 	vi.clearAllMocks();
 	mocks.selectedWorktreeId = "wt-a";
+	mocks.preferredNodeId = "preferred-a";
 	mocks.lastRequests.clear();
 });
 
@@ -238,14 +241,30 @@ describe("App Workspace selection lifecycle", () => {
 		expect(screen.getByTestId("auto-select")).toHaveTextContent("settled");
 	});
 
-	it("shows empty after authoritative removal and does not auto-fallback", () => {
+	it("falls back to the new preferred Node after authoritative removal", () => {
 		render(<App />);
 		fireEvent.click(screen.getByRole("button", { name: "Select A" }));
 		expect(screen.getByTestId("center-node")).toHaveTextContent("node-a");
 
+		mocks.preferredNodeId = "replacement-a";
 		fireEvent.click(screen.getByRole("button", { name: "Invalidate center" }));
 		expect(screen.getByTestId("center-node")).toHaveTextContent("none");
+		expect(screen.getByTestId("auto-select")).toHaveTextContent("awaiting");
+		fireEvent.click(screen.getByRole("button", { name: "Apply preferred A" }));
+		expect(screen.getByTestId("center-node")).toHaveTextContent(
+			"replacement-a",
+		);
 		expect(screen.getByTestId("auto-select")).toHaveTextContent("settled");
+	});
+
+	it("stays unselected when authoritative removal has no preferred Node", () => {
+		render(<App />);
+		fireEvent.click(screen.getByRole("button", { name: "Select A" }));
+		mocks.preferredNodeId = null;
+
+		fireEvent.click(screen.getByRole("button", { name: "Invalidate center" }));
+		expect(screen.getByTestId("center-node")).toHaveTextContent("none");
+		expect(screen.getByTestId("auto-select")).toHaveTextContent("awaiting");
 		fireEvent.click(screen.getByRole("button", { name: "Apply preferred A" }));
 		expect(screen.getByTestId("center-node")).toHaveTextContent("none");
 	});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,7 @@ import type {
 
 type WorktreeCenterState =
 	| { phase: "awaitingInitial" }
-	| { phase: "selected"; selection: CenterSelection }
-	| { phase: "resolvedEmpty" };
+	| { phase: "selected"; selection: CenterSelection };
 
 interface NewSessionCreationState {
 	request: NewSessionCreationRequest;
@@ -251,7 +250,25 @@ function App() {
 				}
 				return {
 					...current,
-					[worktreePath]: { phase: "resolvedEmpty" },
+					[worktreePath]: { phase: "awaitingInitial" },
+				};
+			});
+		},
+		[],
+	);
+	const handleWorkspaceSelectionInvalidated = useCallback(
+		(worktreePath: string, nodeId: string) => {
+			setCenterStateByWorktree((current) => {
+				const active = current[worktreePath];
+				if (
+					active?.phase !== "selected" ||
+					active.selection.nodeId !== nodeId
+				) {
+					return current;
+				}
+				return {
+					...current,
+					[worktreePath]: { phase: "awaitingInitial" },
 				};
 			});
 		},
@@ -288,6 +305,7 @@ function App() {
 				newSessionCreationStatusByWorktree={newSessionCreationStatusByWorktree}
 				onSelectWorktree={handleSelectWorktree}
 				onCreateSession={handleCreateSession}
+				onWorkspaceSelectionInvalidated={handleWorkspaceSelectionInvalidated}
 				onAddRepo={handleAddRepo}
 				onShowSettings={() => setShowAppSettings(true)}
 			/>
@@ -300,6 +318,7 @@ function App() {
 			newSessionCreationStatusByWorktree,
 			handleSelectWorktree,
 			handleCreateSession,
+			handleWorkspaceSelectionInvalidated,
 			handleAddRepo,
 		],
 	);

--- a/src/App.workspace-archive.test.tsx
+++ b/src/App.workspace-archive.test.tsx
@@ -1,0 +1,439 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+	WorkspaceTreeSelectionSnapshot,
+	WorkspaceTreeSnapshot,
+} from "@/types/workspace-tree";
+
+const SELECTED_NODE_ID = "selected-workflow-node";
+const FALLBACK_NODE_ID = "fallback-session-node";
+
+const mocks = vi.hoisted(() => ({
+	invoke: vi.fn(),
+	listen: vi.fn().mockResolvedValue(vi.fn()),
+	emit: vi.fn().mockResolvedValue(undefined),
+	openWorktreeTab: vi.fn(),
+	initFromCwd: vi.fn(),
+	addRepo: vi.fn(),
+	removeRepo: vi.fn(),
+	updateSettings: vi.fn(),
+	updateTheme: vi.fn(),
+	refreshWorktrees: vi.fn().mockResolvedValue(undefined),
+	archiveCommitted: false,
+	postArchiveSnapshot: null as unknown,
+	reconciliationFailuresRemaining: 0,
+	workspaceSelectionInvalidated: null as
+		| ((worktreePath: string, nodeId: string) => void)
+		| null,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+vi.mock("@tauri-apps/api/event", () => ({
+	emit: mocks.emit,
+	listen: mocks.listen,
+}));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/plugin-opener", () => ({
+	openUrl: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/hooks/useSettings", () => ({
+	useSettings: () => ({
+		settings: { autoUpdate: false, theme: "dark" },
+		updateSettings: mocks.updateSettings,
+		updateTheme: mocks.updateTheme,
+	}),
+}));
+vi.mock("@/hooks/useUpdateChecker", () => ({
+	useUpdateChecker: () => null,
+}));
+vi.mock("@/hooks/useWorkspaceNavigation", () => ({
+	useWorkspaceNavigation: () => ({
+		worktrees: [{ id: "wt", rootPath: "/repo/wt" }],
+		selectedWorktreeId: "wt",
+		openWorktreeTab: mocks.openWorktreeTab,
+	}),
+}));
+vi.mock("@/hooks/useRepoList", () => ({
+	useRepoList: () => ({
+		repoPaths: ["/repo"],
+		addRepo: mocks.addRepo,
+		removeRepo: mocks.removeRepo,
+		initFromCwd: mocks.initFromCwd,
+	}),
+}));
+vi.mock("@/hooks/useMenuEvents", () => ({ useMenuEvents: vi.fn() }));
+vi.mock("@/hooks/useSessionStore", () => ({
+	archiveSession: vi.fn().mockResolvedValue(undefined),
+	getAgentSessionNotice: vi.fn().mockResolvedValue({
+		sessionId: "closed-session",
+		revision: 1,
+		notice: null,
+	}),
+	listClosedSessions: vi.fn().mockResolvedValue([]),
+	restoreSession: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/hooks/useWorkflowConfig", () => ({
+	useWorkflowConfig: () => ({ workflows: [], loading: false, error: null }),
+}));
+vi.mock("@/hooks/useWorktreeList", () => ({
+	useWorktreeList: () => ({
+		branches: [
+			{
+				name: "feature",
+				is_main_worktree: false,
+				worktree_path: "/repo/wt",
+				dirty_count: 0,
+				is_merged: false,
+				ahead: 0,
+				behind: 0,
+				has_upstream: false,
+				base_ahead: 0,
+			},
+		],
+		loading: false,
+		refresh: mocks.refreshWorktrees,
+	}),
+}));
+vi.mock("@/components/UpdateDialog", () => ({ UpdateDialog: () => null }));
+vi.mock("@/components/panels/SettingsModal", () => ({
+	SettingsModal: () => null,
+}));
+vi.mock("@/screens/MainLayout", () => ({
+	MainLayout: ({
+		leftNav,
+		centerSelection,
+	}: {
+		leftNav: React.ReactNode;
+		centerSelection?: { nodeId: string } | null;
+	}) => {
+		mocks.workspaceSelectionInvalidated = (
+			leftNav as React.ReactElement<{
+				onWorkspaceSelectionInvalidated: (
+					worktreePath: string,
+					nodeId: string,
+				) => void;
+			}>
+		).props.onWorkspaceSelectionInvalidated;
+		return (
+			<div>
+				{leftNav}
+				<div data-testid="center-node">{centerSelection?.nodeId ?? "none"}</div>
+			</div>
+		);
+	},
+}));
+
+const initialSnapshot: WorkspaceTreeSnapshot = {
+	nodes: [
+		{
+			kind: "node",
+			id: FALLBACK_NODE_ID,
+			title: "Fallback session",
+			status: "running",
+			contentKind: "session",
+			capabilities: { canApprove: false, canClose: true },
+			updatedAt: 1,
+		},
+		{
+			kind: "workflow",
+			id: "archivable-workflow",
+			title: "Archivable workflow",
+			status: "completed",
+			capabilities: {
+				canStop: false,
+				canResume: false,
+				canAbort: false,
+				canArchive: true,
+			},
+			children: [
+				{
+					kind: "node",
+					id: SELECTED_NODE_ID,
+					title: "Selected workflow Node",
+					status: "completed",
+					contentKind: "session",
+					capabilities: { canApprove: false, canClose: false },
+					updatedAt: 2,
+				},
+			],
+			updatedAt: 2,
+		},
+	],
+	preferredNodeId: SELECTED_NODE_ID,
+};
+
+const fallbackSnapshot: WorkspaceTreeSnapshot = {
+	nodes: [
+		{
+			kind: "node",
+			id: FALLBACK_NODE_ID,
+			title: "Fallback session",
+			status: "running",
+			contentKind: "session",
+			capabilities: { canApprove: false, canClose: true },
+			updatedAt: 3,
+		},
+	],
+	preferredNodeId: FALLBACK_NODE_ID,
+};
+
+function reconciliation(
+	snapshot: WorkspaceTreeSnapshot,
+	selectionInSnapshot: boolean,
+): WorkspaceTreeSelectionSnapshot {
+	return {
+		snapshot,
+		reconciliation: { selectionInSnapshot },
+	};
+}
+
+function snapshotContainsNode(
+	nodes: WorkspaceTreeSnapshot["nodes"],
+	selectedNodeId: string,
+): boolean {
+	return nodes.some((item) => {
+		if (item.kind === "node") return item.id === selectedNodeId;
+		return snapshotContainsNode(item.children, selectedNodeId);
+	});
+}
+
+const { default: App } = await import("./App");
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.archiveCommitted = false;
+	mocks.postArchiveSnapshot = fallbackSnapshot;
+	mocks.reconciliationFailuresRemaining = 0;
+	mocks.workspaceSelectionInvalidated = null;
+	mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+		if (command === "get_cwd" || command === "get_main_repo_path") {
+			return Promise.resolve("/repo");
+		}
+		if (command === "list_worktrees") return Promise.resolve([]);
+		if (command === "list_workspace_worktree_nodes") {
+			return Promise.resolve(
+				mocks.archiveCommitted
+					? (mocks.postArchiveSnapshot as WorkspaceTreeSnapshot)
+					: initialSnapshot,
+			);
+		}
+		if (command === "get_workspace_tree_selection_reconciliation") {
+			if (mocks.reconciliationFailuresRemaining > 0) {
+				mocks.reconciliationFailuresRemaining -= 1;
+				return Promise.reject(new Error("temporary reconciliation failure"));
+			}
+			const snapshot = mocks.archiveCommitted
+				? (mocks.postArchiveSnapshot as WorkspaceTreeSnapshot)
+				: initialSnapshot;
+			const selectedNodeId = (args as { selectedNodeId: string })
+				.selectedNodeId;
+			return Promise.resolve(
+				reconciliation(
+					snapshot,
+					snapshotContainsNode(snapshot.nodes, selectedNodeId),
+				),
+			);
+		}
+		if (command === "list_workspace_workflow_history") {
+			return Promise.resolve([]);
+		}
+		if (command === "archive_workspace_workflow_execution") {
+			mocks.archiveCommitted = true;
+			return Promise.resolve(null);
+		}
+		return Promise.resolve(null);
+	});
+});
+
+describe("App Workspace Archive selection reconciliation", () => {
+	it("retries a failed Archive read on the next refresh and falls back to the snapshot preferred Node", async () => {
+		const user = userEvent.setup();
+		mocks.reconciliationFailuresRemaining = 1;
+		render(<App />);
+		await waitFor(() =>
+			expect(screen.getByTestId("center-node")).toHaveTextContent(
+				SELECTED_NODE_ID,
+			),
+		);
+		expect(
+			mocks.invoke.mock.calls.filter(
+				([command]) =>
+					command === "get_workspace_tree_selection_reconciliation",
+			),
+		).toHaveLength(0);
+
+		await user.click(
+			screen.getByRole("button", { name: "Archive Archivable workflow" }),
+		);
+		await waitFor(() =>
+			expect(
+				mocks.invoke.mock.calls.filter(
+					([command]) =>
+						command === "get_workspace_tree_selection_reconciliation",
+				),
+			).toHaveLength(1),
+		);
+		expect(screen.getByTestId("center-node")).toHaveTextContent(
+			SELECTED_NODE_ID,
+		);
+
+		act(() => {
+			window.dispatchEvent(
+				new CustomEvent("workspace-tree-refresh", {
+					detail: { worktreePath: "/repo/wt" },
+				}),
+			);
+		});
+
+		await waitFor(() =>
+			expect(screen.getByTestId("center-node")).toHaveTextContent(
+				FALLBACK_NODE_ID,
+			),
+		);
+		expect(mocks.invoke).toHaveBeenCalledWith(
+			"archive_workspace_workflow_execution",
+			{ worktreePath: "/repo/wt", executionId: "archivable-workflow" },
+		);
+		const archiveCallIndex = mocks.invoke.mock.calls.findIndex(
+			([command]) => command === "archive_workspace_workflow_execution",
+		);
+		expect(
+			mocks.invoke.mock.calls
+				.slice(archiveCallIndex + 1)
+				.some(
+					([command, args]) =>
+						command === "get_workspace_tree_selection_reconciliation" &&
+						(args as { selectedNodeId?: string }).selectedNodeId ===
+							SELECTED_NODE_ID,
+				),
+		).toBe(true);
+		expect(
+			mocks.invoke.mock.calls.filter(
+				([command]) =>
+					command === "get_workspace_tree_selection_reconciliation",
+			),
+		).toHaveLength(2);
+
+		const listCallsAfterSuccess = mocks.invoke.mock.calls.filter(
+			([command]) => command === "list_workspace_worktree_nodes",
+		).length;
+		act(() => {
+			window.dispatchEvent(
+				new CustomEvent("workspace-tree-refresh", {
+					detail: { worktreePath: "/repo/wt" },
+				}),
+			);
+		});
+		await waitFor(() =>
+			expect(
+				mocks.invoke.mock.calls.filter(
+					([command]) => command === "list_workspace_worktree_nodes",
+				).length,
+			).toBeGreaterThan(listCallsAfterSuccess),
+		);
+		expect(
+			mocks.invoke.mock.calls.filter(
+				([command]) =>
+					command === "get_workspace_tree_selection_reconciliation",
+			),
+		).toHaveLength(2);
+		expect(mocks.archiveCommitted).toBe(true);
+	});
+
+	it("retries a failed Archive read and becomes unselected when the snapshot has no preferred Node", async () => {
+		const user = userEvent.setup();
+		mocks.postArchiveSnapshot = { nodes: [], preferredNodeId: null };
+		mocks.reconciliationFailuresRemaining = 1;
+		render(<App />);
+		await waitFor(() =>
+			expect(screen.getByTestId("center-node")).toHaveTextContent(
+				SELECTED_NODE_ID,
+			),
+		);
+		await user.click(
+			screen.getByRole("button", { name: "Archive Archivable workflow" }),
+		);
+		await waitFor(() =>
+			expect(
+				mocks.invoke.mock.calls.filter(
+					([command]) =>
+						command === "get_workspace_tree_selection_reconciliation",
+				),
+			).toHaveLength(1),
+		);
+		expect(screen.getByTestId("center-node")).toHaveTextContent(
+			SELECTED_NODE_ID,
+		);
+		act(() => {
+			window.dispatchEvent(
+				new CustomEvent("workspace-tree-refresh", {
+					detail: { worktreePath: "/repo/wt" },
+				}),
+			);
+		});
+
+		await waitFor(() =>
+			expect(screen.getByTestId("center-node")).toHaveTextContent("none"),
+		);
+		expect(
+			mocks.invoke.mock.calls.filter(
+				([command]) =>
+					command === "get_workspace_tree_selection_reconciliation",
+			),
+		).toHaveLength(2);
+		expect(mocks.archiveCommitted).toBe(true);
+	});
+
+	it("keeps the selection when it remains in the accepted Archive snapshot", async () => {
+		const user = userEvent.setup();
+		mocks.postArchiveSnapshot = initialSnapshot;
+		render(<App />);
+		await waitFor(() =>
+			expect(screen.getByTestId("center-node")).toHaveTextContent(
+				SELECTED_NODE_ID,
+			),
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: "Archive Archivable workflow" }),
+		);
+		await waitFor(() =>
+			expect(
+				mocks.invoke.mock.calls.filter(
+					([command]) =>
+						command === "get_workspace_tree_selection_reconciliation",
+				),
+			).toHaveLength(1),
+		);
+		expect(screen.getByTestId("center-node")).toHaveTextContent(
+			SELECTED_NODE_ID,
+		);
+	});
+
+	it("ignores a delayed invalidation callback for a Node that is no longer selected", async () => {
+		const user = userEvent.setup();
+		render(<App />);
+		await waitFor(() =>
+			expect(screen.getByTestId("center-node")).toHaveTextContent(
+				SELECTED_NODE_ID,
+			),
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: "Fallback session, running" }),
+		);
+		await waitFor(() =>
+			expect(screen.getByTestId("center-node")).toHaveTextContent(
+				FALLBACK_NODE_ID,
+			),
+		);
+		act(() => {
+			mocks.workspaceSelectionInvalidated?.("/repo/wt", SELECTED_NODE_ID);
+		});
+
+		expect(screen.getByTestId("center-node")).toHaveTextContent(
+			FALLBACK_NODE_ID,
+		);
+	});
+});

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceTreeReconciliationEvent } from "@/hooks/useWorkspaceTreeNodes";
 import type { WorktreeBranch } from "@/types/git";
 import type {
 	WorkspaceSessionHistoryItem,
@@ -20,6 +21,7 @@ type MockWorkspaceTreeState = {
 	preferredNodeId?: string | null;
 	closedSessions?: WorkspaceSessionHistoryItem[];
 	workflowHistory?: WorkspaceWorkflowHistoryItem[];
+	reconciliationEvent?: WorkspaceTreeReconciliationEvent | null;
 	loading?: boolean;
 	error?: string | null;
 };
@@ -36,8 +38,12 @@ const mocks = vi.hoisted(() => ({
 		notice: null,
 	}),
 	refreshTree: vi.fn().mockResolvedValue(undefined),
+	beginArchiveReconciliation: vi.fn().mockResolvedValue(undefined),
+	synchronizeSelectedNodeId: vi.fn(),
+	isReconciliationEventCurrent: vi.fn().mockReturnValue(true),
 	refreshWorktrees: vi.fn().mockResolvedValue(undefined),
 	treeStateOverrides: new Map<string, MockWorkspaceTreeState>(),
+	selectedNodeIds: new Map<string, string | null>(),
 	worktreeBranches: [] as WorktreeBranch[],
 }));
 
@@ -75,9 +81,16 @@ vi.mock("@/hooks/useWorkspaceTreeNodes", () => ({
 			preferredNodeId: state.preferredNodeId ?? null,
 			closedSessions: state.closedSessions ?? [],
 			workflowHistory: state.workflowHistory ?? [],
+			reconciliationEvent: state.reconciliationEvent ?? null,
 			loading: state.loading ?? false,
 			error: state.error ?? null,
 			refresh: mocks.refreshTree,
+			beginArchiveReconciliation: mocks.beginArchiveReconciliation,
+			synchronizeSelectedNodeId: (selectedNodeId: string | null) => {
+				mocks.selectedNodeIds.set(worktreePath, selectedNodeId);
+				mocks.synchronizeSelectedNodeId(selectedNodeId);
+			},
+			isReconciliationEventCurrent: mocks.isReconciliationEventCurrent,
 		};
 	},
 }));
@@ -187,7 +200,29 @@ function renderWorkspaceList(
 			{...overrides}
 		/>,
 	);
-	return { ...result, onSelectWorktree, onCreateSession };
+	const rerenderWorkspaceList = (
+		nextOverrides: Partial<React.ComponentProps<typeof WorkspaceList>> = {},
+	) => {
+		result.rerender(
+			<WorkspaceList
+				repoPaths={["/repo"]}
+				selectedRootPath="/repo/wt"
+				centerSelection={null}
+				onSelectWorktree={onSelectWorktree}
+				onCreateSession={onCreateSession}
+				onAddRepo={vi.fn()}
+				onShowSettings={vi.fn()}
+				{...overrides}
+				{...nextOverrides}
+			/>,
+		);
+	};
+	return {
+		...result,
+		onSelectWorktree,
+		onCreateSession,
+		rerenderWorkspaceList,
+	};
 }
 
 beforeEach(() => {
@@ -198,8 +233,16 @@ beforeEach(() => {
 	}
 	mocks.worktreeBranches = [makeBranch()];
 	mocks.treeStateOverrides.clear();
+	mocks.selectedNodeIds.clear();
 	mocks.treeStateOverrides.set("/repo/wt", { nodes: recursiveTree });
 	mocks.invoke.mockResolvedValue(null);
+	mocks.refreshTree.mockResolvedValue(undefined);
+	mocks.beginArchiveReconciliation.mockResolvedValue(undefined);
+	mocks.isReconciliationEventCurrent.mockImplementation(
+		(event: WorkspaceTreeReconciliationEvent, selectedNodeId: string | null) =>
+			event.requestContext.worktreePath === "/repo/wt" &&
+			event.requestContext.selectedNodeId === selectedNodeId,
+	);
 });
 
 describe("WorkspaceList", () => {
@@ -220,6 +263,37 @@ describe("WorkspaceList", () => {
 				.querySelector("svg.lucide-git-fork"),
 		).toBeInTheDocument();
 		expect(container.querySelectorAll("svg.lucide-git-fork")).toHaveLength(1);
+	});
+
+	it("renders an empty backend-owned Workflow branch without Node leaves", () => {
+		mocks.treeStateOverrides.set("/repo/wt", {
+			nodes: [
+				{
+					kind: "workflow",
+					id: "empty-workflow",
+					title: "Empty workflow",
+					status: "running",
+					capabilities: {
+						canStop: true,
+						canResume: false,
+						canAbort: true,
+						canArchive: false,
+					},
+					children: [],
+					updatedAt: 1,
+				},
+			],
+			preferredNodeId: null,
+		});
+
+		renderWorkspaceList();
+
+		expect(
+			screen.getByRole("button", { name: "Empty workflow" }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /Direct session/ }),
+		).not.toBeInTheDocument();
 	});
 
 	it("keeps one familiar content icon per Node and styles it from backend status", () => {
@@ -353,6 +427,66 @@ describe("WorkspaceList", () => {
 		expect(onSelectWorktree).toHaveBeenCalledTimes(1);
 	});
 
+	it("re-arms preferred selection after auto selection is disabled", async () => {
+		mocks.treeStateOverrides.set("/repo/wt", {
+			nodes: recursiveTree,
+			preferredNodeId: directNode.id,
+		});
+		const { onSelectWorktree, onCreateSession, rerender } = renderWorkspaceList(
+			{
+				autoSelectPreferredNode: true,
+			},
+		);
+		await waitFor(() => expect(onSelectWorktree).toHaveBeenCalledTimes(1));
+
+		mocks.treeStateOverrides.set("/repo/wt", {
+			nodes: recursiveTree,
+			preferredNodeId: "fanout-child-internal-uuid",
+		});
+		rerender(
+			<WorkspaceList
+				repoPaths={["/repo"]}
+				selectedRootPath="/repo/wt"
+				centerSelection={{
+					kind: "node",
+					worktreePath: "/repo/wt",
+					nodeId: directNode.id,
+				}}
+				autoSelectPreferredNode={false}
+				onSelectWorktree={onSelectWorktree}
+				onCreateSession={onCreateSession}
+				onAddRepo={vi.fn()}
+				onShowSettings={vi.fn()}
+			/>,
+		);
+		expect(onSelectWorktree).toHaveBeenCalledTimes(1);
+
+		rerender(
+			<WorkspaceList
+				repoPaths={["/repo"]}
+				selectedRootPath="/repo/wt"
+				centerSelection={null}
+				autoSelectPreferredNode={true}
+				onSelectWorktree={onSelectWorktree}
+				onCreateSession={onCreateSession}
+				onAddRepo={vi.fn()}
+				onShowSettings={vi.fn()}
+			/>,
+		);
+
+		await waitFor(() => expect(onSelectWorktree).toHaveBeenCalledTimes(2));
+		expect(onSelectWorktree).toHaveBeenLastCalledWith(
+			"/repo/wt",
+			"feature",
+			"repo",
+			{
+				kind: "node",
+				worktreePath: "/repo/wt",
+				nodeId: "fanout-child-internal-uuid",
+			},
+		);
+	});
+
 	it("keeps initial selection eligible while an empty snapshot has no preferred Node", async () => {
 		mocks.treeStateOverrides.set("/repo/wt", {
 			nodes: [],
@@ -451,7 +585,7 @@ describe("WorkspaceList", () => {
 		);
 	});
 
-	it("does not apply a later preferred Node after selection was resolved empty", async () => {
+	it("does not apply a preferred Node while auto selection is disabled", async () => {
 		mocks.treeStateOverrides.set("/repo/wt", {
 			nodes: recursiveTree,
 			preferredNodeId: directNode.id,
@@ -493,6 +627,18 @@ describe("WorkspaceList", () => {
 		expect(
 			screen.getByRole("button", { name: /Architecture review/ }),
 		).toHaveAttribute("aria-current", "page");
+	});
+
+	it("passes only the Worktree-scoped selected opaque ID to the tree read", () => {
+		renderWorkspaceList({
+			centerSelection: {
+				kind: "node",
+				worktreePath: "/other",
+				nodeId: "foreign-node",
+			},
+		});
+
+		expect(mocks.selectedNodeIds.get("/repo/wt")).toBeNull();
 	});
 
 	it("keeps occurrence order and the selected past occurrence when later executions append", async () => {
@@ -623,6 +769,159 @@ describe("WorkspaceList", () => {
 		expect(mocks.refreshTree).toHaveBeenCalledOnce();
 		expect(detailRefresh).toHaveBeenCalledOnce();
 		window.removeEventListener("workspace-tree-refresh", detailRefresh);
+	});
+
+	it("notifies App after Archive refresh says the current selection left the snapshot", async () => {
+		const user = userEvent.setup();
+		const selectedNodeId = "workflow-session-internal-uuid";
+		const archivableTree = recursiveTree.map((item) =>
+			item.kind === "workflow"
+				? {
+						...item,
+						status: "completed" as const,
+						capabilities: { ...item.capabilities, canArchive: true },
+					}
+				: item,
+		);
+		mocks.treeStateOverrides.set("/repo/wt", {
+			nodes: archivableTree,
+		});
+		const onWorkspaceSelectionInvalidated = vi.fn();
+		const { rerenderWorkspaceList } = renderWorkspaceList({
+			centerSelection: {
+				kind: "node",
+				worktreePath: "/repo/wt",
+				nodeId: selectedNodeId,
+			},
+			onWorkspaceSelectionInvalidated,
+		});
+
+		await user.click(
+			screen.getByRole("button", { name: "Archive Release workflow" }),
+		);
+		await waitFor(() =>
+			expect(mocks.beginArchiveReconciliation).toHaveBeenCalledWith(
+				selectedNodeId,
+			),
+		);
+		mocks.treeStateOverrides.set("/repo/wt", {
+			nodes: [directNode],
+			preferredNodeId: directNode.id,
+			reconciliationEvent: {
+				refreshSeq: 2,
+				requestContext: {
+					worktreePath: "/repo/wt",
+					selectedNodeId,
+					reconciliationGeneration: 2,
+				},
+				selectionInSnapshot: false,
+			},
+		});
+		rerenderWorkspaceList();
+
+		await waitFor(() =>
+			expect(onWorkspaceSelectionInvalidated).toHaveBeenCalledWith(
+				"/repo/wt",
+				selectedNodeId,
+			),
+		);
+		expect(mocks.invoke).toHaveBeenCalledWith(
+			"archive_workspace_workflow_execution",
+			{
+				worktreePath: "/repo/wt",
+				executionId: "workflow-internal-uuid",
+			},
+		);
+		rerenderWorkspaceList();
+		expect(onWorkspaceSelectionInvalidated).toHaveBeenCalledOnce();
+		expect(mocks.refreshTree).not.toHaveBeenCalled();
+		expect(mocks.selectedNodeIds.get("/repo/wt")).toBe(selectedNodeId);
+	});
+
+	it("keeps the current selection when Archive reconciliation says it remains displayed", async () => {
+		const user = userEvent.setup();
+		const selectedNodeId = "workflow-session-internal-uuid";
+		const archivableTree = recursiveTree.map((item) =>
+			item.kind === "workflow"
+				? {
+						...item,
+						status: "completed" as const,
+						capabilities: { ...item.capabilities, canArchive: true },
+					}
+				: item,
+		);
+		mocks.treeStateOverrides.set("/repo/wt", { nodes: archivableTree });
+		const onWorkspaceSelectionInvalidated = vi.fn();
+		const { rerenderWorkspaceList } = renderWorkspaceList({
+			centerSelection: {
+				kind: "node",
+				worktreePath: "/repo/wt",
+				nodeId: selectedNodeId,
+			},
+			onWorkspaceSelectionInvalidated,
+		});
+
+		await user.click(
+			screen.getByRole("button", { name: "Archive Release workflow" }),
+		);
+		await waitFor(() =>
+			expect(mocks.beginArchiveReconciliation).toHaveBeenCalledWith(
+				selectedNodeId,
+			),
+		);
+		mocks.treeStateOverrides.set("/repo/wt", {
+			nodes: archivableTree,
+			preferredNodeId: selectedNodeId,
+			reconciliationEvent: {
+				refreshSeq: 2,
+				requestContext: {
+					worktreePath: "/repo/wt",
+					selectedNodeId,
+					reconciliationGeneration: 2,
+				},
+				selectionInSnapshot: true,
+			},
+		});
+		rerenderWorkspaceList();
+
+		expect(onWorkspaceSelectionInvalidated).not.toHaveBeenCalled();
+	});
+
+	it("does not deliver an accepted invalidation after the selection moves", async () => {
+		const selectedNodeId = "workflow-session-internal-uuid";
+		const onWorkspaceSelectionInvalidated = vi.fn();
+		const { rerenderWorkspaceList } = renderWorkspaceList({
+			centerSelection: {
+				kind: "node",
+				worktreePath: "/repo/wt",
+				nodeId: selectedNodeId,
+			},
+			onWorkspaceSelectionInvalidated,
+		});
+		mocks.treeStateOverrides.set("/repo/wt", {
+			nodes: [directNode],
+			preferredNodeId: directNode.id,
+			reconciliationEvent: {
+				refreshSeq: 4,
+				requestContext: {
+					worktreePath: "/repo/wt",
+					selectedNodeId,
+					reconciliationGeneration: 3,
+				},
+				selectionInSnapshot: false,
+			},
+		});
+
+		rerenderWorkspaceList({
+			centerSelection: {
+				kind: "node",
+				worktreePath: "/repo/wt",
+				nodeId: directNode.id,
+			},
+		});
+
+		expect(onWorkspaceSelectionInvalidated).not.toHaveBeenCalled();
+		expect(mocks.selectedNodeIds.get("/repo/wt")).toBe(directNode.id);
 	});
 
 	it("routes SessionHistory restore and archive through stored lifecycle commands", async () => {

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -94,6 +94,10 @@ interface WorkspaceListProps {
 		branchName?: string,
 		repoName?: string,
 	) => void;
+	onWorkspaceSelectionInvalidated?: (
+		worktreePath: string,
+		nodeId: string,
+	) => void;
 	onAddRepo: () => void;
 	onShowSettings: () => void;
 }
@@ -420,6 +424,7 @@ function WorktreeTreeItem({
 	newSessionCreationStatus,
 	onSelectWorktree,
 	onCreateSession,
+	onWorkspaceSelectionInvalidated,
 	onDelete,
 }: {
 	branch: WorktreeBranch;
@@ -430,6 +435,7 @@ function WorktreeTreeItem({
 	newSessionCreationStatus?: NewSessionCreationStatus;
 	onSelectWorktree: WorkspaceListProps["onSelectWorktree"];
 	onCreateSession: WorkspaceListProps["onCreateSession"];
+	onWorkspaceSelectionInvalidated: WorkspaceListProps["onWorkspaceSelectionInvalidated"];
 	onDelete: (branch: WorktreeBranch) => void;
 }) {
 	const [expanded, setExpanded] = useState(true);
@@ -449,6 +455,7 @@ function WorktreeTreeItem({
 		Record<string, string>
 	>({});
 	const [workflowStarting, setWorkflowStarting] = useState(false);
+	const notifiedReconciliationSeqRef = useRef<number | null>(null);
 	const preferredSelectionRequestRef = useRef<{
 		worktreePath: string | null;
 		requested: boolean;
@@ -478,9 +485,13 @@ function WorktreeTreeItem({
 		preferredNodeId,
 		closedSessions,
 		workflowHistory,
+		reconciliationEvent,
 		loading: treeLoading,
 		error: treeError,
 		refresh: refreshTree,
+		beginArchiveReconciliation,
+		synchronizeSelectedNodeId,
+		isReconciliationEventCurrent,
 	} = useWorkspaceTreeNodes(branch.worktree_path);
 	const {
 		workflows,
@@ -501,7 +512,14 @@ function WorktreeTreeItem({
 	);
 
 	useEffect(() => {
-		if (!autoSelectPreferredNode) return;
+		synchronizeSelectedNodeId(scopedCenterSelection?.nodeId ?? null);
+	}, [scopedCenterSelection?.nodeId, synchronizeSelectedNodeId]);
+
+	useEffect(() => {
+		if (!autoSelectPreferredNode) {
+			preferredSelectionRequestRef.current.requested = false;
+			return;
+		}
 		if (preferredSelectionRequestRef.current.requested) return;
 		if (!branch.worktree_path) return;
 		if (branch.worktree_path !== selectedRootPath) return;
@@ -522,6 +540,29 @@ function WorktreeTreeItem({
 		selectedRootPath,
 		treeError,
 		treeLoading,
+	]);
+
+	useEffect(() => {
+		if (!reconciliationEvent || reconciliationEvent.selectionInSnapshot) return;
+		if (
+			notifiedReconciliationSeqRef.current === reconciliationEvent.refreshSeq ||
+			!isReconciliationEventCurrent(
+				reconciliationEvent,
+				scopedCenterSelection?.nodeId ?? null,
+			)
+		) {
+			return;
+		}
+		notifiedReconciliationSeqRef.current = reconciliationEvent.refreshSeq;
+		onWorkspaceSelectionInvalidated?.(
+			reconciliationEvent.requestContext.worktreePath,
+			reconciliationEvent.requestContext.selectedNodeId,
+		);
+	}, [
+		isReconciliationEventCurrent,
+		onWorkspaceSelectionInvalidated,
+		reconciliationEvent,
+		scopedCenterSelection?.nodeId,
 	]);
 
 	const handleSelectNode = useCallback(
@@ -557,12 +598,21 @@ function WorktreeTreeItem({
 					worktreePath: branch.worktree_path,
 					executionId: workflow.id,
 				});
-				await refreshTree();
+				if (scopedCenterSelection?.nodeId) {
+					await beginArchiveReconciliation(scopedCenterSelection.nodeId);
+				} else {
+					await refreshTree();
+				}
 			} catch (e) {
 				setWorkflowActionError(`Archive workflow failed: ${String(e)}`);
 			}
 		},
-		[branch.worktree_path, refreshTree],
+		[
+			beginArchiveReconciliation,
+			branch.worktree_path,
+			refreshTree,
+			scopedCenterSelection?.nodeId,
+		],
 	);
 
 	const handleWorkflowExecutionAction = useCallback(
@@ -1081,6 +1131,7 @@ function RepoTreeSectionView({
 	newSessionCreationStatusByWorktree,
 	onSelectWorktree,
 	onCreateSession,
+	onWorkspaceSelectionInvalidated,
 }: {
 	repoPath: string;
 	branches: WorktreeBranch[];
@@ -1092,6 +1143,7 @@ function RepoTreeSectionView({
 	newSessionCreationStatusByWorktree?: Record<string, NewSessionCreationStatus>;
 	onSelectWorktree: WorkspaceListProps["onSelectWorktree"];
 	onCreateSession: WorkspaceListProps["onCreateSession"];
+	onWorkspaceSelectionInvalidated: WorkspaceListProps["onWorkspaceSelectionInvalidated"];
 }) {
 	const [collapsed, setCollapsed] = useState(false);
 	const [refreshing, setRefreshing] = useState(false);
@@ -1189,6 +1241,9 @@ function RepoTreeSectionView({
 								}
 								onSelectWorktree={onSelectWorktree}
 								onCreateSession={onCreateSession}
+								onWorkspaceSelectionInvalidated={
+									onWorkspaceSelectionInvalidated
+								}
 								onDelete={setDeletingBranch}
 							/>
 						))
@@ -1213,6 +1268,7 @@ function RepoTreeSection({
 	newSessionCreationStatusByWorktree,
 	onSelectWorktree,
 	onCreateSession,
+	onWorkspaceSelectionInvalidated,
 }: {
 	repoPath: string;
 	selectedRootPath: string | null;
@@ -1221,6 +1277,7 @@ function RepoTreeSection({
 	newSessionCreationStatusByWorktree?: Record<string, NewSessionCreationStatus>;
 	onSelectWorktree: WorkspaceListProps["onSelectWorktree"];
 	onCreateSession: WorkspaceListProps["onCreateSession"];
+	onWorkspaceSelectionInvalidated: WorkspaceListProps["onWorkspaceSelectionInvalidated"];
 }) {
 	const { branches, loading, refresh } = useWorktreeList(repoPath);
 	return (
@@ -1235,6 +1292,7 @@ function RepoTreeSection({
 			newSessionCreationStatusByWorktree={newSessionCreationStatusByWorktree}
 			onSelectWorktree={onSelectWorktree}
 			onCreateSession={onCreateSession}
+			onWorkspaceSelectionInvalidated={onWorkspaceSelectionInvalidated}
 		/>
 	);
 }
@@ -1247,6 +1305,7 @@ export function WorkspaceList({
 	newSessionCreationStatusByWorktree,
 	onSelectWorktree,
 	onCreateSession,
+	onWorkspaceSelectionInvalidated,
 	onAddRepo,
 	onShowSettings,
 }: WorkspaceListProps) {
@@ -1285,6 +1344,7 @@ export function WorkspaceList({
 						}
 						onSelectWorktree={onSelectWorktree}
 						onCreateSession={onCreateSession}
+						onWorkspaceSelectionInvalidated={onWorkspaceSelectionInvalidated}
 					/>
 				))}
 				{repoPaths.length === 0 && (

--- a/src/hooks/useWorkspaceTreeNodes.test.ts
+++ b/src/hooks/useWorkspaceTreeNodes.test.ts
@@ -4,6 +4,7 @@ import type { SessionStatus, SessionSummary } from "@/types/session";
 import type { WorkflowExecutionChangedPayload } from "@/types/workflow";
 import type {
 	WorkspaceTreeItem,
+	WorkspaceTreeSelectionSnapshot,
 	WorkspaceTreeSnapshot,
 } from "@/types/workspace-tree";
 import { useWorkspaceTreeNodes } from "./useWorkspaceTreeNodes";
@@ -43,6 +44,16 @@ function makeSnapshot(
 	return { nodes, preferredNodeId };
 }
 
+function makeSelectionSnapshot(
+	snapshot: WorkspaceTreeSnapshot,
+	selectionInSnapshot: boolean,
+): WorkspaceTreeSelectionSnapshot {
+	return {
+		snapshot,
+		reconciliation: { selectionInSnapshot },
+	};
+}
+
 function makeStatus(overrides: Partial<SessionStatus> = {}): SessionStatus {
 	return {
 		chat_session_id: "session-1",
@@ -68,10 +79,8 @@ function deferred<T>() {
 	return { promise, resolve, reject };
 }
 
-function countTreeFetches(): number {
-	return mockInvoke.mock.calls.filter(
-		([command]) => command === "list_workspace_worktree_nodes",
-	).length;
+function countInvocations(command: string): number {
+	return mockInvoke.mock.calls.filter(([called]) => called === command).length;
 }
 
 async function waitForScheduledRefresh() {
@@ -83,11 +92,15 @@ describe("useWorkspaceTreeNodes", () => {
 	let treeResponses: Array<
 		WorkspaceTreeSnapshot | Promise<WorkspaceTreeSnapshot>
 	>;
+	let selectionResponses: Array<
+		WorkspaceTreeSelectionSnapshot | Promise<WorkspaceTreeSelectionSnapshot>
+	>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		listeners = {};
 		treeResponses = [];
+		selectionResponses = [];
 		mockListClosedSessions.mockResolvedValue([]);
 		mockListen.mockImplementation(
 			(event: string, listener: (event: { payload: never }) => void) => {
@@ -98,6 +111,12 @@ describe("useWorkspaceTreeNodes", () => {
 		mockInvoke.mockImplementation((command: string) => {
 			if (command === "list_workspace_worktree_nodes") {
 				return Promise.resolve(treeResponses.shift() ?? makeSnapshot([], null));
+			}
+			if (command === "get_workspace_tree_selection_reconciliation") {
+				return Promise.resolve(
+					selectionResponses.shift() ??
+						makeSelectionSnapshot(makeSnapshot([], null), false),
+				);
 			}
 			if (command === "list_workspace_workflow_history") {
 				return Promise.resolve([]);
@@ -114,6 +133,278 @@ describe("useWorkspaceTreeNodes", () => {
 		await waitFor(() => expect(result.current.loading).toBe(false));
 		expect(result.current.nodes).toEqual([makeNode("node-1")]);
 		expect(result.current.preferredNodeId).toBe("node-1");
+		expect(countInvocations("list_workspace_worktree_nodes")).toBe(1);
+		expect(
+			countInvocations("get_workspace_tree_selection_reconciliation"),
+		).toBe(0);
+	});
+
+	it("does not refetch tree, closed sessions, or history when only selection changes", async () => {
+		treeResponses.push(makeSnapshot([makeNode("node-a")], "node-a"));
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		act(() => result.current.synchronizeSelectedNodeId("node-a"));
+		act(() => result.current.synchronizeSelectedNodeId("node-b"));
+		act(() => result.current.synchronizeSelectedNodeId("node-a"));
+
+		expect(countInvocations("list_workspace_worktree_nodes")).toBe(1);
+		expect(
+			countInvocations("get_workspace_tree_selection_reconciliation"),
+		).toBe(0);
+		expect(countInvocations("list_workspace_workflow_history")).toBe(1);
+		expect(mockListClosedSessions).toHaveBeenCalledOnce();
+	});
+
+	it("starts Archive reconciliation explicitly and commits snapshot and membership together", async () => {
+		treeResponses.push(makeSnapshot([makeNode("selected")], "selected"));
+		selectionResponses.push(
+			makeSelectionSnapshot(
+				makeSnapshot([makeNode("replacement")], "replacement"),
+				false,
+			),
+		);
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		act(() => result.current.synchronizeSelectedNodeId("selected"));
+
+		await act(async () => {
+			await result.current.beginArchiveReconciliation("selected");
+		});
+
+		expect(mockInvoke).toHaveBeenCalledWith(
+			"get_workspace_tree_selection_reconciliation",
+			{ worktreePath: "/repo", selectedNodeId: "selected" },
+		);
+		expect(result.current.nodes).toEqual([makeNode("replacement")]);
+		expect(result.current.preferredNodeId).toBe("replacement");
+		expect(result.current.reconciliationEvent).toEqual({
+			refreshSeq: expect.any(Number),
+			requestContext: {
+				worktreePath: "/repo",
+				selectedNodeId: "selected",
+				reconciliationGeneration: expect.any(Number),
+			},
+			selectionInSnapshot: false,
+		});
+		const event = result.current.reconciliationEvent;
+		expect(event).not.toBeNull();
+		if (!event) throw new Error("expected an accepted reconciliation event");
+		expect(result.current.isReconciliationEventCurrent(event, "selected")).toBe(
+			true,
+		);
+	});
+
+	it("retains the old snapshot after a failed Archive read and retries on the next refresh", async () => {
+		treeResponses.push(
+			makeSnapshot([makeNode("selected")], "selected"),
+			makeSnapshot([makeNode("later")], "later"),
+		);
+		const failed = deferred<WorkspaceTreeSelectionSnapshot>();
+		selectionResponses.push(failed.promise);
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		act(() => result.current.synchronizeSelectedNodeId("selected"));
+
+		let firstAttempt!: Promise<unknown>;
+		act(() => {
+			firstAttempt = result.current.beginArchiveReconciliation("selected");
+		});
+		await act(async () => {
+			failed.reject(new Error("temporary read failure"));
+			await firstAttempt;
+		});
+		expect(result.current.nodes).toEqual([makeNode("selected")]);
+		expect(result.current.preferredNodeId).toBe("selected");
+		expect(result.current.reconciliationEvent).toBeNull();
+
+		selectionResponses.push(
+			makeSelectionSnapshot(
+				makeSnapshot([makeNode("fallback")], "fallback"),
+				false,
+			),
+		);
+		await act(async () => {
+			await result.current.refresh();
+		});
+		expect(
+			countInvocations("get_workspace_tree_selection_reconciliation"),
+		).toBe(2);
+		expect(result.current.nodes).toEqual([makeNode("fallback")]);
+		expect(result.current.reconciliationEvent?.selectionInSnapshot).toBe(false);
+
+		await act(async () => {
+			await result.current.refresh();
+		});
+		expect(
+			countInvocations("get_workspace_tree_selection_reconciliation"),
+		).toBe(2);
+		expect(countInvocations("list_workspace_worktree_nodes")).toBe(2);
+		expect(result.current.nodes).toEqual([makeNode("later")]);
+	});
+
+	it("keeps a selected Node when the successful Archive snapshot still contains it", async () => {
+		treeResponses.push(makeSnapshot([makeNode("selected")], "selected"));
+		selectionResponses.push(
+			makeSelectionSnapshot(
+				makeSnapshot([makeNode("selected")], "selected"),
+				true,
+			),
+		);
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		act(() => result.current.synchronizeSelectedNodeId("selected"));
+
+		await act(async () => {
+			await result.current.beginArchiveReconciliation("selected");
+		});
+
+		expect(result.current.reconciliationEvent?.selectionInSnapshot).toBe(true);
+		expect(result.current.nodes).toEqual([makeNode("selected")]);
+	});
+
+	it("invalidates an in-flight Archive response after selection moves, including ABA", async () => {
+		treeResponses.push(makeSnapshot([makeNode("selected")], "selected"));
+		const oldResponse = deferred<WorkspaceTreeSelectionSnapshot>();
+		selectionResponses.push(oldResponse.promise);
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		act(() => result.current.synchronizeSelectedNodeId("selected"));
+
+		let pending!: Promise<unknown>;
+		act(() => {
+			pending = result.current.beginArchiveReconciliation("selected");
+		});
+		act(() => result.current.synchronizeSelectedNodeId("other"));
+		act(() => result.current.synchronizeSelectedNodeId("selected"));
+		await act(async () => {
+			oldResponse.resolve(
+				makeSelectionSnapshot(
+					makeSnapshot([makeNode("stale")], "stale"),
+					false,
+				),
+			);
+			await pending;
+		});
+
+		expect(result.current.nodes).toEqual([makeNode("selected")]);
+		expect(result.current.reconciliationEvent).toBeNull();
+	});
+
+	it("invalidates an in-flight Archive response after the Worktree changes", async () => {
+		treeResponses.push(
+			makeSnapshot([makeNode("old-selected")], "old-selected"),
+			makeSnapshot([makeNode("new-worktree")], "new-worktree"),
+		);
+		const oldResponse = deferred<WorkspaceTreeSelectionSnapshot>();
+		selectionResponses.push(oldResponse.promise);
+		const { result, rerender } = renderHook(
+			({ path }) => useWorkspaceTreeNodes(path),
+			{ initialProps: { path: "/old" as string | null } },
+		);
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		act(() => result.current.synchronizeSelectedNodeId("old-selected"));
+
+		let pending!: Promise<unknown>;
+		act(() => {
+			pending = result.current.beginArchiveReconciliation("old-selected");
+		});
+		rerender({ path: "/new" });
+		await waitFor(() =>
+			expect(result.current.nodes).toEqual([makeNode("new-worktree")]),
+		);
+		await act(async () => {
+			oldResponse.resolve(
+				makeSelectionSnapshot(
+					makeSnapshot([makeNode("stale-old")], "stale-old"),
+					false,
+				),
+			);
+			await pending;
+		});
+
+		expect(result.current.nodes).toEqual([makeNode("new-worktree")]);
+		expect(result.current.reconciliationEvent).toBeNull();
+	});
+
+	it("discards an older reconciliation response after a later refresh starts", async () => {
+		treeResponses.push(makeSnapshot([makeNode("selected")], "selected"));
+		const oldResponse = deferred<WorkspaceTreeSelectionSnapshot>();
+		selectionResponses.push(
+			oldResponse.promise,
+			makeSelectionSnapshot(
+				makeSnapshot([makeNode("latest")], "latest"),
+				false,
+			),
+		);
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		act(() => result.current.synchronizeSelectedNodeId("selected"));
+
+		let older!: Promise<unknown>;
+		act(() => {
+			older = result.current.beginArchiveReconciliation("selected");
+		});
+		await act(async () => {
+			await result.current.refresh();
+		});
+		expect(result.current.nodes).toEqual([makeNode("latest")]);
+		const latestEvent = result.current.reconciliationEvent;
+
+		await act(async () => {
+			oldResponse.resolve(
+				makeSelectionSnapshot(
+					makeSnapshot([makeNode("stale")], "stale"),
+					false,
+				),
+			);
+			await older;
+		});
+		expect(result.current.nodes).toEqual([makeNode("latest")]);
+		expect(result.current.reconciliationEvent).toBe(latestEvent);
+	});
+
+	it("ignores an older Worktree response after the path changes", async () => {
+		const oldResponse = deferred<WorkspaceTreeSnapshot>();
+		treeResponses.push(oldResponse.promise, makeSnapshot([makeNode("new")]));
+		const { result, rerender } = renderHook(
+			({ path }) => useWorkspaceTreeNodes(path),
+			{ initialProps: { path: "/old" as string | null } },
+		);
+
+		rerender({ path: "/new" });
+		await waitFor(() =>
+			expect(result.current.nodes).toEqual([makeNode("new")]),
+		);
+		await act(async () => {
+			oldResponse.resolve(makeSnapshot([makeNode("old")]));
+			await oldResponse.promise;
+		});
+		expect(result.current.nodes).toEqual([makeNode("new")]);
+	});
+
+	it("keeps an empty Workflow branch from the backend snapshot unchanged", async () => {
+		const emptyWorkflow: WorkspaceTreeItem = {
+			kind: "workflow",
+			id: "empty-workflow",
+			title: "Empty workflow",
+			status: "running",
+			capabilities: {
+				canStop: true,
+				canResume: false,
+				canAbort: true,
+				canArchive: false,
+			},
+			children: [],
+			updatedAt: 1,
+		};
+		treeResponses.push(makeSnapshot([emptyWorkflow], null));
+
+		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.nodes).toEqual([emptyWorkflow]);
+		expect(result.current.preferredNodeId).toBeNull();
 	});
 
 	it("keeps the previous snapshot visible during a background refresh", async () => {
@@ -148,7 +439,9 @@ describe("useWorkspaceTreeNodes", () => {
 			makeSnapshot([]),
 		);
 		renderHook(() => useWorkspaceTreeNodes("/repo"));
-		await waitFor(() => expect(countTreeFetches()).toBe(1));
+		await waitFor(() =>
+			expect(countInvocations("list_workspace_worktree_nodes")).toBe(1),
+		);
 		await waitFor(() =>
 			expect(listeners["session-status-changed"]?.length).toBe(1),
 		);
@@ -161,13 +454,15 @@ describe("useWorkspaceTreeNodes", () => {
 			});
 		});
 		await waitForScheduledRefresh();
-		expect(countTreeFetches()).toBe(2);
+		expect(countInvocations("list_workspace_worktree_nodes")).toBe(2);
 	});
 
 	it("ignores session and workflow events for another Worktree", async () => {
 		treeResponses.push(makeSnapshot([]));
 		renderHook(() => useWorkspaceTreeNodes("/repo"));
-		await waitFor(() => expect(countTreeFetches()).toBe(1));
+		await waitFor(() =>
+			expect(countInvocations("list_workspace_worktree_nodes")).toBe(1),
+		);
 		await waitFor(() =>
 			expect(listeners["workflow-execution-changed"]?.length).toBe(1),
 		);
@@ -183,7 +478,7 @@ describe("useWorkspaceTreeNodes", () => {
 			});
 		});
 		await waitForScheduledRefresh();
-		expect(countTreeFetches()).toBe(1);
+		expect(countInvocations("list_workspace_worktree_nodes")).toBe(1);
 	});
 
 	it("does not filter closed sessions by workflow metadata in frontend", async () => {
@@ -203,24 +498,5 @@ describe("useWorkspaceTreeNodes", () => {
 		const { result } = renderHook(() => useWorkspaceTreeNodes("/repo"));
 		await waitFor(() => expect(result.current.loading).toBe(false));
 		expect(result.current.closedSessions).toEqual([closed]);
-	});
-
-	it("ignores an older Worktree response after the path changes", async () => {
-		const oldResponse = deferred<WorkspaceTreeSnapshot>();
-		treeResponses.push(oldResponse.promise, makeSnapshot([makeNode("new")]));
-		const { result, rerender } = renderHook(
-			({ path }) => useWorkspaceTreeNodes(path),
-			{ initialProps: { path: "/old" as string | null } },
-		);
-
-		rerender({ path: "/new" });
-		await waitFor(() =>
-			expect(result.current.nodes).toEqual([makeNode("new")]),
-		);
-		await act(async () => {
-			oldResponse.resolve(makeSnapshot([makeNode("old")]));
-			await oldResponse.promise;
-		});
-		expect(result.current.nodes).toEqual([makeNode("new")]);
 	});
 });

--- a/src/hooks/useWorkspaceTreeNodes.ts
+++ b/src/hooks/useWorkspaceTreeNodes.ts
@@ -7,45 +7,95 @@ import type { WorkflowExecutionChangedPayload } from "@/types/workflow";
 import type {
 	WorkspaceSessionHistoryItem,
 	WorkspaceTreeItem,
+	WorkspaceTreeSelectionSnapshot,
 	WorkspaceTreeSnapshot,
 	WorkspaceWorkflowHistoryItem,
 } from "@/types/workspace-tree";
+
+export interface WorkspaceReconciliationRequestContext {
+	worktreePath: string;
+	selectedNodeId: string;
+	reconciliationGeneration: number;
+}
+
+export interface WorkspaceTreeReconciliationEvent {
+	refreshSeq: number;
+	requestContext: WorkspaceReconciliationRequestContext;
+	selectionInSnapshot: boolean;
+}
+
+export interface WorkspaceTreeRefreshResult {
+	snapshot: WorkspaceTreeSnapshot;
+	reconciliationEvent: WorkspaceTreeReconciliationEvent | null;
+}
+
+interface WorkspaceTreeState {
+	snapshot: WorkspaceTreeSnapshot;
+	closedSessions: WorkspaceSessionHistoryItem[];
+	workflowHistory: WorkspaceWorkflowHistoryItem[];
+	reconciliationEvent: WorkspaceTreeReconciliationEvent | null;
+}
 
 interface UseWorkspaceTreeNodesResult {
 	nodes: WorkspaceTreeItem[];
 	preferredNodeId: string | null;
 	closedSessions: WorkspaceSessionHistoryItem[];
 	workflowHistory: WorkspaceWorkflowHistoryItem[];
+	reconciliationEvent: WorkspaceTreeReconciliationEvent | null;
 	loading: boolean;
 	error: string | null;
-	refresh: () => Promise<void>;
+	refresh: () => Promise<WorkspaceTreeRefreshResult | null>;
+	beginArchiveReconciliation: (
+		selectedNodeId: string,
+	) => Promise<WorkspaceTreeRefreshResult | null>;
+	synchronizeSelectedNodeId: (selectedNodeId: string | null) => void;
+	isReconciliationEventCurrent: (
+		event: WorkspaceTreeReconciliationEvent,
+		selectedNodeId: string | null,
+	) => boolean;
 }
 
 interface WorkspaceTreeRefreshDetail {
 	worktreePath?: string;
 }
 
+const EMPTY_SNAPSHOT: WorkspaceTreeSnapshot = {
+	nodes: [],
+	preferredNodeId: null,
+};
+
+function sameReconciliationContext(
+	left: WorkspaceReconciliationRequestContext | null,
+	right: WorkspaceReconciliationRequestContext,
+): boolean {
+	return (
+		left?.worktreePath === right.worktreePath &&
+		left.selectedNodeId === right.selectedNodeId &&
+		left.reconciliationGeneration === right.reconciliationGeneration
+	);
+}
+
 export function useWorkspaceTreeNodes(
 	worktreePath: string | null | undefined,
 ): UseWorkspaceTreeNodesResult {
-	const [nodes, setNodes] = useState<WorkspaceTreeItem[]>([]);
-	const [preferredNodeId, setPreferredNodeId] = useState<string | null>(null);
-	const [closedSessions, setClosedSessions] = useState<
-		WorkspaceSessionHistoryItem[]
-	>([]);
-	const [workflowHistory, setWorkflowHistory] = useState<
-		WorkspaceWorkflowHistoryItem[]
-	>([]);
+	const [treeState, setTreeState] = useState<WorkspaceTreeState>({
+		snapshot: EMPTY_SNAPSHOT,
+		closedSessions: [],
+		workflowHistory: [],
+		reconciliationEvent: null,
+	});
 	const [loading, setLoading] = useState(() => Boolean(worktreePath));
 	const [error, setError] = useState<string | null>(null);
 	const refreshTimerRef = useRef<number | null>(null);
 	const refreshSeqRef = useRef(0);
 	const loadedWorktreePathRef = useRef<string | null>(null);
 	const errorWorktreePathRef = useRef<string | null>(null);
-
-	const updateNodes = useCallback((nextNodes: WorkspaceTreeItem[]) => {
-		setNodes(nextNodes);
-	}, []);
+	const worktreePathRef = useRef(worktreePath);
+	const reconciliationGenerationRef = useRef(0);
+	const reconciliationContextRef =
+		useRef<WorkspaceReconciliationRequestContext | null>(null);
+	const observedSelectedNodeIdRef = useRef<string | null>(null);
+	const acceptedReconciliationSeqRef = useRef<number | null>(null);
 
 	const hasLoadedCurrentWorktree = useCallback(
 		() => loadedWorktreePathRef.current === worktreePath,
@@ -57,55 +107,165 @@ export function useWorkspaceTreeNodes(
 			refreshSeqRef.current += 1;
 			loadedWorktreePathRef.current = null;
 			errorWorktreePathRef.current = null;
-			setNodes([]);
-			setPreferredNodeId(null);
-			setClosedSessions([]);
-			setWorkflowHistory([]);
+			reconciliationContextRef.current = null;
+			acceptedReconciliationSeqRef.current = null;
+			setTreeState({
+				snapshot: EMPTY_SNAPSHOT,
+				closedSessions: [],
+				workflowHistory: [],
+				reconciliationEvent: null,
+			});
 			setLoading(false);
 			setError(null);
-			return;
+			return null;
 		}
 		const seq = ++refreshSeqRef.current;
+		const requestContext = reconciliationContextRef.current;
+		const activeRequestContext =
+			requestContext?.worktreePath === worktreePath &&
+			requestContext.selectedNodeId === observedSelectedNodeIdRef.current
+				? requestContext
+				: null;
 		const showLoading = !hasLoadedCurrentWorktree();
 		if (showLoading) {
 			setLoading(true);
 		}
 		try {
-			const [snapshot, nextClosedSessions, nextWorkflowHistory] =
-				await Promise.all([
-					invoke<WorkspaceTreeSnapshot>("list_workspace_worktree_nodes", {
+			const snapshotRequest = activeRequestContext
+				? invoke<WorkspaceTreeSelectionSnapshot>(
+						"get_workspace_tree_selection_reconciliation",
+						{
+							worktreePath,
+							selectedNodeId: activeRequestContext.selectedNodeId,
+						},
+					)
+				: invoke<WorkspaceTreeSnapshot>("list_workspace_worktree_nodes", {
 						worktreePath,
-					}),
+					});
+			const [treeResult, nextClosedSessions, nextWorkflowHistory] =
+				await Promise.all([
+					snapshotRequest,
 					listClosedSessions(worktreePath),
 					invoke<WorkspaceWorkflowHistoryItem[]>(
 						"list_workspace_workflow_history",
 						{ worktreePath },
 					),
 				]);
-			if (seq !== refreshSeqRef.current) return;
+			if (seq !== refreshSeqRef.current) return null;
+
+			let snapshot: WorkspaceTreeSnapshot;
+			let reconciliationEvent: WorkspaceTreeReconciliationEvent | null = null;
+			if (activeRequestContext) {
+				if (
+					!sameReconciliationContext(
+						reconciliationContextRef.current,
+						activeRequestContext,
+					) ||
+					worktreePathRef.current !== activeRequestContext.worktreePath ||
+					observedSelectedNodeIdRef.current !==
+						activeRequestContext.selectedNodeId ||
+					reconciliationGenerationRef.current !==
+						activeRequestContext.reconciliationGeneration
+				) {
+					return null;
+				}
+				const selectionResult = treeResult as WorkspaceTreeSelectionSnapshot;
+				snapshot = selectionResult.snapshot;
+				reconciliationContextRef.current = null;
+				acceptedReconciliationSeqRef.current = seq;
+				reconciliationEvent = {
+					refreshSeq: seq,
+					requestContext: activeRequestContext,
+					selectionInSnapshot:
+						selectionResult.reconciliation.selectionInSnapshot,
+				};
+			} else {
+				snapshot = treeResult as WorkspaceTreeSnapshot;
+				acceptedReconciliationSeqRef.current = null;
+			}
+
 			loadedWorktreePathRef.current = worktreePath;
 			errorWorktreePathRef.current = null;
-			updateNodes(snapshot.nodes);
-			setPreferredNodeId(snapshot.preferredNodeId ?? null);
-			setClosedSessions(nextClosedSessions);
-			setWorkflowHistory(nextWorkflowHistory);
+			setTreeState({
+				snapshot,
+				closedSessions: nextClosedSessions,
+				workflowHistory: nextWorkflowHistory,
+				reconciliationEvent,
+			});
 			setError(null);
+			return { snapshot, reconciliationEvent };
 		} catch (e) {
-			if (seq !== refreshSeqRef.current) return;
+			if (seq !== refreshSeqRef.current) return null;
 			if (!hasLoadedCurrentWorktree()) {
-				updateNodes([]);
-				setPreferredNodeId(null);
-				setClosedSessions([]);
-				setWorkflowHistory([]);
+				setTreeState((current) => ({
+					...current,
+					snapshot: EMPTY_SNAPSHOT,
+					closedSessions: [],
+					workflowHistory: [],
+				}));
 			}
 			errorWorktreePathRef.current = worktreePath;
 			setError(String(e));
+			return null;
 		} finally {
 			if (seq === refreshSeqRef.current) {
 				setLoading(false);
 			}
 		}
-	}, [hasLoadedCurrentWorktree, updateNodes, worktreePath]);
+	}, [hasLoadedCurrentWorktree, worktreePath]);
+
+	const beginArchiveReconciliation = useCallback(
+		(selectedNodeId: string) => {
+			if (!worktreePath) return Promise.resolve(null);
+			if (observedSelectedNodeIdRef.current !== selectedNodeId) {
+				observedSelectedNodeIdRef.current = selectedNodeId;
+				reconciliationGenerationRef.current += 1;
+			}
+			const requestContext = {
+				worktreePath,
+				selectedNodeId,
+				reconciliationGeneration: ++reconciliationGenerationRef.current,
+			};
+			reconciliationContextRef.current = requestContext;
+			acceptedReconciliationSeqRef.current = null;
+			setTreeState((current) =>
+				current.reconciliationEvent
+					? { ...current, reconciliationEvent: null }
+					: current,
+			);
+			return refresh();
+		},
+		[refresh, worktreePath],
+	);
+
+	const synchronizeSelectedNodeId = useCallback(
+		(selectedNodeId: string | null) => {
+			if (observedSelectedNodeIdRef.current === selectedNodeId) return;
+			observedSelectedNodeIdRef.current = selectedNodeId;
+			reconciliationGenerationRef.current += 1;
+			reconciliationContextRef.current = null;
+			acceptedReconciliationSeqRef.current = null;
+			setTreeState((current) =>
+				current.reconciliationEvent
+					? { ...current, reconciliationEvent: null }
+					: current,
+			);
+		},
+		[],
+	);
+
+	const isReconciliationEventCurrent = useCallback(
+		(event: WorkspaceTreeReconciliationEvent, selectedNodeId: string | null) =>
+			event.refreshSeq === refreshSeqRef.current &&
+			event.refreshSeq === acceptedReconciliationSeqRef.current &&
+			event.requestContext.worktreePath === worktreePathRef.current &&
+			event.requestContext.selectedNodeId === selectedNodeId &&
+			event.requestContext.selectedNodeId ===
+				observedSelectedNodeIdRef.current &&
+			event.requestContext.reconciliationGeneration ===
+				reconciliationGenerationRef.current,
+		[],
+	);
 
 	const scheduleRefresh = useCallback(() => {
 		if (refreshTimerRef.current != null) {
@@ -116,6 +276,16 @@ export function useWorkspaceTreeNodes(
 			void refresh();
 		}, 80);
 	}, [refresh]);
+
+	useEffect(() => {
+		if (worktreePathRef.current === worktreePath) return;
+		worktreePathRef.current = worktreePath;
+		refreshSeqRef.current += 1;
+		reconciliationGenerationRef.current += 1;
+		reconciliationContextRef.current = null;
+		acceptedReconciliationSeqRef.current = null;
+		observedSelectedNodeIdRef.current = null;
+	}, [worktreePath]);
 
 	useEffect(() => {
 		void refresh();
@@ -197,12 +367,16 @@ export function useWorkspaceTreeNodes(
 		);
 
 	return {
-		nodes,
-		preferredNodeId,
-		closedSessions,
-		workflowHistory,
+		nodes: treeState.snapshot.nodes,
+		preferredNodeId: treeState.snapshot.preferredNodeId ?? null,
+		closedSessions: treeState.closedSessions,
+		workflowHistory: treeState.workflowHistory,
+		reconciliationEvent: treeState.reconciliationEvent,
 		loading: currentLoading,
 		error: currentError,
 		refresh,
+		beginArchiveReconciliation,
+		synchronizeSelectedNodeId,
+		isReconciliationEventCurrent,
 	};
 }

--- a/src/types/workspace-tree.ts
+++ b/src/types/workspace-tree.ts
@@ -80,6 +80,15 @@ export interface WorkspaceTreeSnapshot {
 	preferredNodeId?: string | null;
 }
 
+export interface WorkspaceSelectionReconciliation {
+	selectionInSnapshot: boolean;
+}
+
+export interface WorkspaceTreeSelectionSnapshot {
+	snapshot: WorkspaceTreeSnapshot;
+	reconciliation: WorkspaceSelectionReconciliation;
+}
+
 export interface WorkspaceSessionNodeContent {
 	kind: "session";
 	sessionId?: string | null;

--- a/tests/helpers/tauri-mock.ts
+++ b/tests/helpers/tauri-mock.ts
@@ -8,6 +8,10 @@ export interface MockConfig {
 	ipcHandler: Record<string, unknown>;
 }
 
+export function workspaceTreeReconciliation(snapshot: unknown): unknown {
+	return { __workspaceTreeReconciliationSnapshot: snapshot };
+}
+
 interface TauriMockInternals {
 	invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
 	transformCallback: (cb: (data: unknown) => void, once?: boolean) => number;
@@ -82,6 +86,19 @@ export async function setupTauriMock(page: Page, config: MockConfig) {
 			args: Record<string, unknown>;
 		}> = [];
 
+		function workspaceTreeContainsNode(
+			nodes: unknown,
+			selectedNodeId: string,
+		): boolean {
+			if (!Array.isArray(nodes)) return false;
+			return nodes.some((item) => {
+				if (!item || typeof item !== "object") return false;
+				const record = item as Record<string, unknown>;
+				if (record.kind === "node") return record.id === selectedNodeId;
+				return workspaceTreeContainsNode(record.children, selectedNodeId);
+			});
+		}
+
 		async function invoke(
 			cmd: string,
 			args: Record<string, unknown> = {},
@@ -126,6 +143,27 @@ export async function setupTauriMock(page: Page, config: MockConfig) {
 			// ユーザー定義コマンド
 			if (cmd in cfg.ipcHandler) {
 				let value = cfg.ipcHandler[cmd];
+				if (
+					cmd === "get_workspace_tree_selection_reconciliation" &&
+					value &&
+					typeof value === "object" &&
+					"__workspaceTreeReconciliationSnapshot" in
+						(value as Record<string, unknown>)
+				) {
+					const snapshot = (
+						value as { __workspaceTreeReconciliationSnapshot: unknown }
+					).__workspaceTreeReconciliationSnapshot as Record<string, unknown>;
+					const selectedNodeId = args.selectedNodeId as string;
+					return {
+						snapshot,
+						reconciliation: {
+							selectionInSnapshot: workspaceTreeContainsNode(
+								snapshot.nodes,
+								selectedNodeId,
+							),
+						},
+					};
+				}
 				if (
 					value &&
 					typeof value === "object" &&

--- a/tests/workspace-manager.spec.ts
+++ b/tests/workspace-manager.spec.ts
@@ -4,7 +4,11 @@ import {
 	buildMockConfig,
 	kanbanBranches,
 } from "./helpers/fixtures";
-import { emitTauriEvent, setupTauriMock } from "./helpers/tauri-mock";
+import {
+	emitTauriEvent,
+	setupTauriMock,
+	workspaceTreeReconciliation,
+} from "./helpers/tauri-mock";
 import { waitForApp } from "./helpers/utils";
 
 async function waitForAnimations(locator: Locator) {
@@ -787,6 +791,110 @@ test.describe("Workspace Manager", () => {
 		await expect(page.getByText(/attempt 4/i)).not.toBeVisible();
 	});
 
+	test("Archive reconciliation derives membership from its opt-in response snapshot", async ({
+		page,
+	}) => {
+		const worktreePath = "/test/repo-worktrees/feat-wip";
+		const selectedNodeId = "archive-selected-node";
+		const fallbackNodeId = "archive-fallback-node";
+		const initialSnapshot = {
+			nodes: [
+				{
+					kind: "node",
+					id: fallbackNodeId,
+					title: "Archive fallback",
+					status: "running",
+					contentKind: "session",
+					capabilities: { canApprove: false, canClose: true },
+					updatedAt: 1000,
+				},
+				{
+					kind: "workflow",
+					id: "archivable-workflow",
+					title: "Archivable integration workflow",
+					status: "completed",
+					capabilities: {
+						canStop: false,
+						canResume: false,
+						canAbort: false,
+						canArchive: true,
+					},
+					updatedAt: 2000,
+					children: [
+						{
+							kind: "node",
+							id: selectedNodeId,
+							title: "Archive selected",
+							status: "completed",
+							contentKind: "session",
+							capabilities: { canApprove: false, canClose: false },
+							updatedAt: 2000,
+						},
+					],
+				},
+			],
+			preferredNodeId: null,
+		};
+		const reconciledSnapshot = {
+			nodes: [initialSnapshot.nodes[0]],
+			preferredNodeId: fallbackNodeId,
+		};
+		const config = buildMockConfig({
+			list_branches_with_status: kanbanBranches.filter(
+				(branch) => branch.name === "feat/wip",
+			),
+			list_workspace_worktree_nodes: initialSnapshot,
+			get_workspace_tree_selection_reconciliation:
+				workspaceTreeReconciliation(reconciledSnapshot),
+			archive_workspace_workflow_execution: null,
+			get_workspace_node_detail: {
+				id: selectedNodeId,
+				title: "Archive selected",
+				status: "completed",
+				capabilities: { canApprove: false, canClose: false },
+				updatedAt: 2000,
+				content: { kind: "session", sessionId: "archive-selected-session" },
+			},
+			get_session: rawSession(
+				"archive-selected-session",
+				worktreePath,
+				"Archive selected body",
+			),
+		});
+		await setupTauriMock(page, config);
+		await waitForApp(page);
+
+		await page
+			.getByRole("button", { name: "Archive selected, completed" })
+			.click();
+		await expect(
+			page.getByRole("button", { name: "Archive selected, completed" }),
+		).toHaveAttribute("aria-current", "page");
+		await page
+			.getByRole("button", { name: "Archivable integration workflow" })
+			.hover();
+		await page
+			.getByRole("button", { name: "Archive Archivable integration workflow" })
+			.click();
+
+		await expect(
+			page.getByRole("button", { name: "Archive fallback, running" }),
+		).toHaveAttribute("aria-current", "page");
+		const reconciliationInvocations = await page.evaluate(
+			() =>
+				window.__TAURI_INTERNALS__?.invocations.filter(
+					(entry) =>
+						entry.cmd === "get_workspace_tree_selection_reconciliation",
+				) ?? [],
+		);
+		expect(reconciliationInvocations).toEqual([
+			{
+				cmd: "get_workspace_tree_selection_reconciliation",
+				args: { worktreePath, selectedNodeId },
+			},
+		]);
+	});
+
 	test("a later occurrence appends without replacing the selected past occurrence", async ({
 		page,
 	}) => {
@@ -846,6 +954,15 @@ test.describe("Workspace Manager", () => {
 		await expect(
 			page.getByText("First occurrence body", { exact: true }),
 		).toBeVisible();
+		const refreshInvocations = await page.evaluate(
+			() => window.__TAURI_INTERNALS__?.invocations ?? [],
+		);
+		expect(
+			refreshInvocations.filter(
+				(entry) =>
+					entry.cmd === "get_workspace_tree_selection_reconciliation",
+			),
+		).toHaveLength(0);
 		await expect(firstRow).toHaveAttribute("aria-current", "page");
 
 		await page.evaluate(
@@ -903,6 +1020,15 @@ test.describe("Workspace Manager", () => {
 		await expect(
 			page.getByText("First occurrence body", { exact: true }),
 		).toBeVisible();
+		const updateInvocations = await page.evaluate(
+			() => window.__TAURI_INTERNALS__?.invocations ?? [],
+		);
+		expect(
+			updateInvocations.filter(
+				(entry) =>
+					entry.cmd === "get_workspace_tree_selection_reconciliation",
+			),
+		).toHaveLength(0);
 
 		await page.evaluate(
 			({ worktreePath }) => {


### PR DESCRIPTION
## 概要

Workspace tree を Workflow 定義の preview から、実際に発生した作業状態を扱う surface へ変更する。未実行の definition-only Node（条件分岐で使われない候補・未開始の fanout expected slot）を `queued` placeholder として投影する経路を廃止し、durable な `NodeStarted` に由来する実在の `NodeExecution` を持つ Node だけを表示する。

`specs/unified-node-model/decisions.md` の「実行木には展開結果（実際に起きたこと）だけが載る」定義へ Workspace projection を合わせる契約変更。

Closes #1512

## 主な変更

- **Rust projection** (`usecase/workflow/workspace_tree.rs`): `NodeExecution` を持たない definition Node / 未実行 fanout slot を投影しない。表示可否の決定は Rust-owned projection が所有。
- **frontend** (`hooks/useWorkspaceTreeNodes.ts`, `components/workspace/WorkspaceList.tsx`, `App.tsx`): backend projection の mirror として追従。
- **spec 正本の更新**: `docs/specs/milestone-82/design.md` §13 / `goal-14-issue-1454.md` の queued 表示記載を更新。
- **テスト**: Rust usecase・hook・component・integration の各層を追加。

## テスト

- [ ] `cargo test` (src-tauri)
- [ ] `pnpm test`
- [ ] `pnpm test:integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Workspace treeに、実行開始済みのNodeのみを表示する仕様を追加しました。
  * 未開始Nodeやfanoutの未実行プレースホルダーを表示しないようにしました。
  * アーカイブ後に選択Nodeが表示対象外となった場合、適切なNodeへ自動的にフォールバックします。
  * 選択状態とツリー表示の再同期処理を追加しました。

* **ドキュメント**
  * Workspace treeの表示条件、選択状態、再同期に関する仕様を更新しました。

* **テスト**
  * 未開始Node、fanout、選択のフォールバック、再同期、競合ケースを検証するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->