### PR TITLE
fix(workflow): builtin の human checkpoint を Opus 5 / edit 権限へ統一

### DIFF
--- a/src-tauri/src/adaptor/gateway/workflow/builtin/01_author-spec.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/01_author-spec.yml
@@ -300,7 +300,7 @@ nodes:
 - name: requirements_consider
   session:
     model: gpt-5.6-sol
-    permission: ask
+    permission: edit
     gate: auto
     facets:
       policy: author-spec-governance
@@ -386,7 +386,7 @@ nodes:
 - name: behavior_validate
   session:
     model: gpt-5.6-sol
-    permission: ask
+    permission: edit
     gate: auto
     facets:
       policy: author-spec-governance
@@ -408,7 +408,7 @@ nodes:
 - name: behavior_consider
   session:
     model: gpt-5.6-sol
-    permission: ask
+    permission: edit
     gate: auto
     facets:
       policy: author-spec-governance
@@ -501,7 +501,7 @@ nodes:
 - name: design_validate
   session:
     model: gpt-5.6-sol
-    permission: ask
+    permission: edit
     gate: auto
     facets:
       policy: author-spec-governance
@@ -526,7 +526,7 @@ nodes:
 - name: design_consider
   session:
     model: gpt-5.6-sol
-    permission: ask
+    permission: edit
     gate: auto
     facets:
       policy: author-spec-governance
@@ -613,7 +613,7 @@ nodes:
 - name: full_spec_consider
   session:
     model: gpt-5.6-sol
-    permission: ask
+    permission: edit
     gate: auto
     facets:
       policy: author-spec-governance
@@ -640,8 +640,8 @@ nodes:
 # HumanDecisionSequence: 文書レビューではなく、自動判断不能な一点だけを解決する。
 - name: human_decision
   session:
-    model: gpt-5.6-sol
-    permission: ask
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: author-spec-governance
@@ -678,8 +678,8 @@ nodes:
 # FinalReviewSequence: 通常経路で唯一の人間による文書レビュー。
 - name: final_review
   session:
-    model: gpt-5.6-sol
-    permission: ask
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: author-spec-governance

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement-existing-spec.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/02_implement-existing-spec.yml
@@ -157,8 +157,8 @@ nodes:
     next: create_detailed_design
 - name: implementation_confirmation
   session:
-    model: gpt-5.6-sol
-    permission: full
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: reporting

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/03_full-review.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/03_full-review.yml
@@ -245,8 +245,8 @@ nodes:
   - next: review_confirmation
 - name: review_confirmation
   session:
-    model: gpt-5.6-sol
-    permission: full
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: reporting

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/04_review-fix-policy-manual.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/04_review-fix-policy-manual.yml
@@ -108,8 +108,8 @@ nodes:
   - next: check_fix_policy_consistency
 - name: decide_fix_policy_manual
   session:
-    model: gpt-5.6-sol
-    permission: full
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: triage
@@ -155,8 +155,8 @@ nodes:
   - next: check_fix_policy_consistency
 - name: correct_fix_policy_manual
   session:
-    model: gpt-5.6-sol
-    permission: full
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: triage
@@ -171,8 +171,8 @@ nodes:
   - resolve_request
 - name: policy_confirmation
   session:
-    model: gpt-5.6-sol
-    permission: full
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: reporting

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/04_review-fix-policy.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/04_review-fix-policy.yml
@@ -171,8 +171,8 @@ nodes:
   - resolve_request
 - name: policy_confirmation
   session:
-    model: gpt-5.6-sol
-    permission: full
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: reporting

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/05_review-fix.yml
@@ -172,8 +172,8 @@ nodes:
     next: implement_fix_plan
 - name: fix_confirmation
   session:
-    model: gpt-5.6-sol
-    permission: full
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: reporting

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/06_handle-pr-review-manual.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/06_handle-pr-review-manual.yml
@@ -165,8 +165,8 @@ nodes:
 
 - name: decide_pr_review_fix_policy_manual
   session:
-    model: gpt-5.6-sol
-    permission: full
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: triage
@@ -203,8 +203,8 @@ nodes:
 
 - name: correct_pr_review_fix_policy_manual
   session:
-    model: gpt-5.6-sol
-    permission: full
+    model: claude-opus-5
+    permission: edit
     gate: approval
     facets:
       policy: triage
@@ -265,7 +265,7 @@ nodes:
 
 - name: pr_review_confirmation
   session:
-    model: gpt-5.6-sol
+    model: claude-opus-5
     permission: edit
     gate: approval
     facets:

--- a/src-tauri/src/adaptor/gateway/workflow/builtin/06_handle-pr-review.yml
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin/06_handle-pr-review.yml
@@ -265,7 +265,7 @@ nodes:
 
 - name: pr_review_confirmation
   session:
-    model: gpt-5.6-sol
+    model: claude-opus-5
     permission: edit
     gate: approval
     facets:


### PR DESCRIPTION
## 概要

builtin workflow のうち、人間と対話するノード（`gate: approval`）のモデルを Claude Opus 5 に統一し、あわせて権限設定を `edit` へ揃えた。

## 変更内容

### 1. human checkpoint 13ノードを `claude-opus-5` へ

instruction 本文を確認し、実際に人間と対話するのは `gate: approval` の13ノードであることを確認したうえで `gpt-5.6-sol` から変更した。

| ファイル | ノード |
|---|---|
| 01_author-spec | human_decision, final_review |
| 02_implement-existing-spec | implementation_confirmation |
| 03_full-review | review_confirmation |
| 04_review-fix-policy-manual | decide_fix_policy_manual, correct_fix_policy_manual, policy_confirmation |
| 04_review-fix-policy | policy_confirmation |
| 05_review-fix | fix_confirmation |
| 06_handle-pr-review-manual | decide_pr_review_fix_policy_manual, correct_pr_review_fix_policy_manual, pr_review_confirmation |
| 06_handle-pr-review | pr_review_confirmation |

`gate: auto` 側は対象外とした。`author-spec-write-*` は HumanDecision Artifact を読むだけ、`finalize_pr_review` は確認済み内容の実行のみ、`full-review-verify-and-classify` は `MANUAL_JUDGMENT` の分類のみで、いずれも人間と対話しない。

### 2. `permission: ask` を `edit` へ（8件）

`01_author-spec.yml` のみに存在。requirements_consider / behavior_validate / behavior_consider / design_validate / design_consider / full_spec_consider / human_decision / final_review。

### 3. `claude-opus-5` かつ `permission: full` を `edit` へ（9件）

上記1で Opus 5 化したノードを中心に、opus × full の組み合わせを解消した。

## 確認

- `cargo test workflow` 1133 件パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * 各種ビルトインワークフローの確認・レビュー・修正ステップで、利用するAIモデルを `claude-opus-5` に変更しました。
  * 対象ステップの実行権限を、確認を求める設定または完全実行から、編集可能な設定へ見直しました。
  * これにより、仕様作成、実装確認、レビュー対応、修正判断などの処理で、モデル選択と操作権限が統一されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->