### PR TITLE
fix(local-store): SQLite の WAL-reset 破損バグを予防し recovery snapshot を最終ページで解放する

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1156,7 +1156,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash 0.2.0",
+ "foldhash",
  "html5ever",
  "precomputed-hash",
  "selectors",
@@ -1437,12 +1437,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1938,11 +1932,11 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -1953,11 +1947,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2636,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4050,10 +4044,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.37.0"
+name = "rsqlite-vfs"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.13.1",
  "fallible-iterator",
@@ -4061,6 +4065,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -4691,6 +4696,18 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,8 +47,9 @@ tree-sitter-go = "0.25"
 toml = "1.1"
 serde-saphyr = "0.0"
 rand = "0.10"
-# issues-1499 T-02: bundled SQLite (>= 3.45) for the permanent local event store.
-rusqlite = { version = "0.37", features = ["bundled"] }
+# issues-1499 T-02: bundled SQLite (>= 3.51.3) includes the WAL-reset
+# corruption fix required by the permanent local event store.
+rusqlite = { version = "0.39", features = ["bundled"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "time", "macros", "io-util", "process"] }
 sha2 = "0.11"
 ring = "0.17"

--- a/src-tauri/src/adaptor/gateway/local_event_store/connection.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/connection.rs
@@ -42,13 +42,24 @@ pub fn check_sqlite_version() -> Result<(), ConnectionError> {
     Ok(())
 }
 
-fn configure(connection: &Connection) -> Result<(), ConnectionError> {
+fn configure_common(connection: &Connection) -> Result<(), ConnectionError> {
     connection.busy_timeout(Duration::from_secs(2))?;
-    connection.pragma_update(None, "journal_mode", "WAL")?;
-    connection.pragma_update(None, "synchronous", "FULL")?;
     connection.pragma_update(None, "foreign_keys", "ON")?;
     connection.pragma_update(None, "trusted_schema", "OFF")?;
     Ok(())
+}
+
+fn configure_writer(connection: &Connection) -> Result<(), ConnectionError> {
+    configure_common(connection)?;
+    connection.pragma_update(None, "journal_mode", "WAL")?;
+    connection.pragma_update(None, "synchronous", "FULL")?;
+    Ok(())
+}
+
+fn configure_reader(connection: &Connection) -> Result<(), ConnectionError> {
+    // A reader must not participate in persistent journal configuration or
+    // checkpoint ownership. Those effects belong to the single writer.
+    configure_common(connection)
 }
 
 /// Open the single writer connection.
@@ -60,7 +71,7 @@ pub fn open_writer(path: &Path) -> Result<Connection, ConnectionError> {
             | OpenFlags::SQLITE_OPEN_CREATE
             | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
-    configure(&connection)?;
+    configure_writer(&connection)?;
     Ok(connection)
 }
 
@@ -71,7 +82,7 @@ pub fn open_existing_writer(path: &Path) -> Result<Connection, ConnectionError> 
         path,
         OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
-    configure(&connection)?;
+    configure_writer(&connection)?;
     Ok(connection)
 }
 
@@ -82,7 +93,7 @@ pub fn open_reader(path: &Path) -> Result<Connection, ConnectionError> {
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
-    configure(&connection)?;
+    configure_reader(&connection)?;
     Ok(connection)
 }
 

--- a/src-tauri/src/adaptor/gateway/local_event_store/reader.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/reader.rs
@@ -59,7 +59,16 @@ pub const MAX_PENDING_RECOVERY_PAGE: usize = 200;
 /// The public 4 MiB bound is enforced after semantic decoding and DTO
 /// expansion. This separate cap bounds one internal SQLite fetch without
 /// confusing opaque record bytes with encoded public response bytes.
-pub const PENDING_RECOVERY_INTERNAL_PAGE_MAX_BYTES: usize = 16 * 1024 * 1024;
+///
+/// The internal cap stays an eighth of the public bound so that DTO expansion
+/// keeps a whole internal page inside the public response. That matters beyond
+/// response size: a page that survives to the public layer intact never needs
+/// the public truncation path, and only an untruncated page lets a snapshot be
+/// released as soon as its internal cursor is exhausted. Expansion is not
+/// bounded in theory — an owner repeated across the entry and its target, or a
+/// control character escaped as `\u00XX`, still multiplies bytes — so the
+/// public truncation remains as a safety valve.
+pub const PENDING_RECOVERY_INTERNAL_PAGE_MAX_BYTES: usize = 512 * 1024;
 pub const MAX_ACTIVE_RECOVERY_SNAPSHOTS: usize = 8;
 pub const MAX_SHUTDOWN_PAGE: usize = 128;
 pub const SHUTDOWN_PAGE_MAX_BYTES: usize = 1024 * 1024;
@@ -2341,11 +2350,13 @@ impl RecoverySnapshotPager {
     }
 
     fn remove(&self, snapshot_id: &str) {
-        self.state
-            .lock()
-            .expect("recovery snapshot pager poisoned")
-            .active
-            .remove(snapshot_id);
+        let mut state = self.state.lock().expect("recovery snapshot pager poisoned");
+        Self::forget(&mut state, snapshot_id);
+    }
+
+    fn forget(state: &mut RecoverySnapshotState, snapshot_id: &str) {
+        state.active.remove(snapshot_id);
+        state.issue_order.retain(|id| id != snapshot_id);
     }
 
     fn reserve(
@@ -2366,7 +2377,7 @@ impl RecoverySnapshotPager {
             .map(|(id, _)| id.clone())
             .collect::<Vec<_>>();
         for id in expired {
-            state.active.remove(&id);
+            Self::forget(&mut state, &id);
         }
         while state.active.len() >= MAX_ACTIVE_RECOVERY_SNAPSHOTS {
             let Some(oldest) = state.issue_order.pop_front() else {
@@ -2389,9 +2400,9 @@ impl RecoverySnapshotPager {
 
     fn should_retain(result: &Result<LocalEventQueryResult, LocalEventQueryError>) -> bool {
         match result {
-            Ok(LocalEventQueryResult::PendingRecoveryPage(page)) => !page.entries.is_empty(),
+            Ok(LocalEventQueryResult::PendingRecoveryPage(page)) => page.next_cursor.is_some(),
             Ok(LocalEventQueryResult::PendingRecoverySnapshotPage(page)) => {
-                !page.entries.is_empty()
+                page.next_cursor.is_some()
             }
             _ => false,
         }
@@ -2499,6 +2510,25 @@ impl RecoverySnapshotPager {
             .expect("recovery snapshot worker list poisoned")
             .push(worker);
         self.dispatch(&snapshot_id, &sender, query).await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn issue_order_len_for_test(&self) -> usize {
+        self.state
+            .lock()
+            .expect("recovery snapshot pager poisoned")
+            .issue_order
+            .len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn running_worker_count_for_test(&self) -> usize {
+        self.workers
+            .lock()
+            .expect("recovery snapshot worker list poisoned")
+            .iter()
+            .filter(|worker| !worker.is_finished())
+            .count()
     }
 
     pub fn close(&self) {

--- a/src-tauri/src/adaptor/gateway/local_event_store/schema.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/schema.rs
@@ -4,8 +4,8 @@ use rusqlite::Connection;
 
 use super::fault::{FaultInjector, InitialCreateFaultPoint};
 
-/// Minimum SQLite library version required at compile / startup.
-pub const MIN_SQLITE_VERSION_NUMBER: i32 = 3_045_000;
+/// Minimum SQLite version containing the WAL-reset corruption fix.
+pub const MIN_SQLITE_VERSION_NUMBER: i32 = 3_051_003;
 pub const APPLICATION_ID: i32 = 0x524C_5348;
 pub const CURRENT_SCHEMA_VERSION: i64 = 2;
 

--- a/src-tauri/src/adaptor/gateway/local_event_store/store.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/store.rs
@@ -757,6 +757,16 @@ impl LocalEventStore {
         Arc::clone(&self.readers)
     }
 
+    #[cfg(test)]
+    pub(crate) fn recovery_snapshot_worker_count_for_test(&self) -> usize {
+        self.recovery_snapshots.running_worker_count_for_test()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn recovery_snapshot_issue_order_len_for_test(&self) -> usize {
+        self.recovery_snapshots.issue_order_len_for_test()
+    }
+
     /// Validate and encode a batch before queue admission (design step 1).
     fn prepare(&self, batch: LocalAtomicBatch) -> Result<PreparedBatch, CommitBatchError> {
         if batch.idempotency.installation_id != self.installation_id {

--- a/src-tauri/src/adaptor/gateway/local_event_store/tests.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/tests.rs
@@ -22,8 +22,9 @@ use crate::adaptor::gateway::local_event_store::envelope::{
 use crate::adaptor::gateway::local_event_store::fault::FaultInjector;
 use crate::adaptor::gateway::local_event_store::layout::StoreLayout;
 use crate::adaptor::gateway::local_event_store::reader::{
-    read_envelope, READ_QUEUE_MAX_DEPTH, SQL_OPERATION_LOOKUP, SQL_PENDING_FIRST_PAGE,
-    SQL_PENDING_FIRST_PAGE_PARTITION, SQL_PENDING_FIRST_PAGE_PREFIX, SQL_TERMINAL_LOOKUP,
+    read_envelope, MAX_ACTIVE_RECOVERY_SNAPSHOTS, READ_QUEUE_MAX_DEPTH, SQL_OPERATION_LOOKUP,
+    SQL_PENDING_FIRST_PAGE, SQL_PENDING_FIRST_PAGE_PARTITION, SQL_PENDING_FIRST_PAGE_PREFIX,
+    SQL_TERMINAL_LOOKUP,
 };
 use crate::adaptor::gateway::local_event_store::state_record_codec::{
     canonicalize_recovery_result_record, StoredObligationV1, StoredOperationReceiptV1,
@@ -3665,6 +3666,188 @@ async fn pending_recovery_cursor_pages_and_rejects_tampering() {
             .await,
         Err(LocalEventQueryError::InvalidRequest)
     ));
+}
+
+#[tokio::test]
+async fn recovery_snapshot_workers_close_after_the_final_page() {
+    let harness = Harness::open();
+    harness
+        .store
+        .commit_batch(batch(
+            "commit-snapshot-worker-expiry",
+            "key-snapshot-worker-expiry",
+            [41; 32],
+            vec![],
+            vec![],
+            vec![
+                obligation_mutation("snapshot-worker-1", true),
+                obligation_mutation("snapshot-worker-2", true),
+            ],
+        ))
+        .await
+        .expect("seed recovery snapshot worker fixtures");
+
+    let LocalEventQueryResult::PendingRecoveryPage(completed) = harness
+        .store
+        .query(LocalEventQuery::PendingRecoveryPage {
+            limit: 2,
+            partition: None,
+            owner: None,
+            ordered_key_prefix: None,
+            shutdown_plan: None,
+            cursor: None,
+        })
+        .await
+        .expect("complete recovery page")
+    else {
+        panic!("unexpected complete recovery page result");
+    };
+    assert!(completed.next_cursor.is_none());
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    while harness.store.recovery_snapshot_worker_count_for_test() != 0
+        && std::time::Instant::now() < deadline
+    {
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        harness.store.recovery_snapshot_worker_count_for_test(),
+        0,
+        "a completed page must not retain a SQLite read transaction"
+    );
+
+    let LocalEventQueryResult::PendingRecoveryPage(first) = harness
+        .store
+        .query(LocalEventQuery::PendingRecoveryPage {
+            limit: 1,
+            partition: None,
+            owner: None,
+            ordered_key_prefix: None,
+            shutdown_plan: None,
+            cursor: None,
+        })
+        .await
+        .expect("first incomplete recovery page")
+    else {
+        panic!("unexpected incomplete recovery page result");
+    };
+    assert!(first.next_cursor.is_some());
+    assert_eq!(
+        harness.store.recovery_snapshot_worker_count_for_test(),
+        1,
+        "an incomplete page must retain its SQLite snapshot"
+    );
+}
+
+#[tokio::test]
+async fn recovery_snapshot_issue_order_does_not_grow_for_completed_pages() {
+    let harness = Harness::open();
+    harness
+        .store
+        .commit_batch(batch(
+            "commit-snapshot-issue-order",
+            "key-snapshot-issue-order",
+            [43; 32],
+            vec![],
+            vec![],
+            vec![obligation_mutation("snapshot-issue-order-1", true)],
+        ))
+        .await
+        .expect("seed recovery snapshot issue order fixture");
+
+    for _ in 0..(MAX_ACTIVE_RECOVERY_SNAPSHOTS * 4) {
+        let LocalEventQueryResult::PendingRecoveryPage(page) = harness
+            .store
+            .query(LocalEventQuery::PendingRecoveryPage {
+                limit: 2,
+                partition: None,
+                owner: None,
+                ordered_key_prefix: None,
+                shutdown_plan: None,
+                cursor: None,
+            })
+            .await
+            .expect("complete recovery page")
+        else {
+            panic!("unexpected complete recovery page result");
+        };
+        assert!(page.next_cursor.is_none());
+    }
+
+    assert_eq!(
+        harness.store.recovery_snapshot_issue_order_len_for_test(),
+        0,
+        "a completed page must drop its snapshot id from the eviction queue"
+    );
+}
+
+/// A page released at its internal cursor must also be complete for the public
+/// caller. If DTO expansion pushed the page past the public bound, the public
+/// layer would truncate and hand back a continuation cursor for a snapshot the
+/// gateway already released, so the next request would fail as `CursorExpired`.
+#[tokio::test]
+async fn an_internal_pending_page_survives_dto_expansion_within_the_public_bound() {
+    let harness = Harness::open();
+    let owner = "o".repeat(12 * 1024);
+    let mutations = (0..200)
+        .map(|ordinal| {
+            let mut mutation = obligation_mutation(&format!("public-bound-{ordinal:03}"), true);
+            let LocalStateMutation::Obligation(ref mut obligation) = mutation else {
+                unreachable!("obligation helper always returns an obligation mutation");
+            };
+            obligation.pending.as_mut().expect("pending entry").owner = owner.clone();
+            mutation
+        })
+        .collect::<Vec<_>>();
+    harness
+        .store
+        .commit_batch(batch(
+            "commit-public-bound",
+            "key-public-bound",
+            [47; 32],
+            vec![],
+            vec![],
+            mutations,
+        ))
+        .await
+        .expect("seed pending obligations with expanding owners");
+
+    let repository: Arc<dyn LocalEventTransactionRepository> = harness.store.clone();
+    let authority: Arc<dyn crate::usecase::agent_session::operation::OperationBindingAuthority> =
+        harness.store.clone();
+    let usecase = crate::usecase::agent_session::operation::RecoveryActionUsecase::new(
+        repository,
+        authority,
+        Arc::new(PerformanceRecoveryExecutor),
+        harness.store.installation_id().to_string(),
+    );
+    let query =
+        |cursor: Option<String>| crate::usecase::agent_session::operation::PendingRecoveryQuery {
+            limit: 200,
+            partition: None,
+            owner: None,
+            shutdown_plan: None,
+            cursor,
+        };
+
+    let page = usecase
+        .pending(query(None))
+        .await
+        .expect("first pending recovery page");
+    let internal_next_cursor = page.next_cursor.clone();
+    let public = crate::adaptor::protocol::agent_session_v1::checked_pending_recovery_page(page)
+        .expect("bounded public pending page");
+    assert_eq!(
+        public.next_cursor, internal_next_cursor,
+        "the public layer must not truncate an internal page and invent a continuation"
+    );
+
+    let continuation = public
+        .next_cursor
+        .expect("the internal byte bound must close the first page before the count bound");
+    usecase
+        .pending(query(Some(continuation)))
+        .await
+        .expect("the continuation must resolve inside the retained snapshot");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Scope

WAL 肥大 (#1555) の主因は **message_projection の write amplification** であり、本 PR では扱わない。別途対応する。

主因の内訳:

- assistant メッセージ 1 件 = 1 行で、その 1 行が MB 級に育つ
- ストリーミング更新のたびに `projection_record_codec.rs:277` の `merge_additive_payload` が行全体を parse -> merge -> serialize して丸ごと書き戻す
- SQLite の WAL はページ単位なので、末尾追記でも overflow page チェーン全体が WAL へ流れる
- 実測 `sum(length(projection) * revision)` = 44.0 GB。三角数近似で約 22 GB。実測 WAL 23.9 GB とほぼ一致
- 最大寄与は session `9bd0dc8c` の 1 行で 1.4 MB × revision 10,900 = 14.3 GB

**この PR は SQLite 側の WAL-reset 破損バグの予防と、recovery snapshot を最終ページで解放することに絞る。**

## Changes

### 1. bundled SQLite を 3.51.3 へ (`b232174f8`)

rusqlite 0.37 -> 0.39 で bundled SQLite が 3.51.3 になる。SQLite の changelog にある "Fix the WAL-reset database corruption bug." は 3.53.0 (2026-04-09) と 3.51.3 (2026-03-13) に入っており、従来の 3.45 系は該当する。`MIN_SQLITE_VERSION_NUMBER` も 3_051_003 へ上げ、破損修正を含まない SQLite では起動時に弾く。

### 2. reader を永続 journal 設定から切り離す (`9eb8b5b1c`)

`configure` を `configure_common` / `configure_writer` / `configure_reader` へ分割し、`journal_mode` と `synchronous` を writer だけが設定する。`journal_mode` は DB に永続する設定であり read-only 接続が触る必然性がなく、rollback journal の DB に対しては `SQLITE_READONLY` で失敗し得る経路でもあった。

### 3. recovery snapshot を最終ページで解放する (`989fe76be`)

- `should_retain` を `!page.entries.is_empty()` から `page.next_cursor.is_some()` へ。従来は最終ページでも entries があれば worker を保持し、SQLite の read transaction を `CURSOR_TTL_MS` (5分) 抱えていた
- `issue_order` のリーク修正。`remove()` が `active` からしか消さないため、単一ページで完結するクエリを繰り返すと `issue_order` に stale な ID が無制限に溜まっていた (`active` が上限に達しないと eviction ループが動かず回収されない)。両方を同時に更新する `forget()` を導入
- `PENDING_RECOVERY_INTERNAL_PAGE_MAX_BYTES` を 16 MiB -> 512 KiB。内部ページが公開上限 4 MiB を超えると `checked_pending_recovery_page` がエントリを切り詰め、内部 `next_cursor` が `None` でも継続カーソルを公開する。最終ページで snapshot を解放する以上その継続要求は `CursorExpired` になるため、内部ページ 1 枚が DTO 展開後も公開レスポンスに収まるようにした。展開率は理論上無界なので公開側の切り詰めは安全弁として残している

## Not included

当初この PR に入れていたが、主因が別と判明したため外したもの:

- `wal_autocheckpoint = 1000` — SQLite の既定値の再宣言でしかない
- `journal_size_limit = 64MB` — WAL ファイルサイズは有界になるが、書き込み総量 22 GB と fsync 回数は変わらない。むしろ checkpoint/truncate が高頻度化して I/O は増える。主因を直せば発動しない
- worker の TTL ポーリング (`StoreClock::deadline_poll_interval_ms`) — `FakeStoreClock` というテスト都合が production の trait に漏れていた

## Validation

`src-tauri/` にて:

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib local_event_store` — 162 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ローカルイベントストアの復旧処理を改善し、完了したページやカーソルが不要に保持されないようにしました。
  * SQLiteのWAL処理に関する破損リスクを低減し、データの安定性を向上しました。
  * 復旧ページの取得中に、続きのデータが正しく保持・取得されるよう改善しました。

* **改善**
  * SQLite接続設定を読み取り・書き込み用途に適切に分離し、ローカルイベント処理の信頼性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->