### PR TITLE
test(agent-tui): establish milestone 87 harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, feature/milestone/87]
   pull_request:
-    branches: [main]
+    branches: [main, feature/milestone/87]
 
 permissions:
   contents: read
@@ -157,6 +157,8 @@ jobs:
         with:
           workspaces: src-tauri
           key: rust-test
+      - name: Agent TUI harness self-test
+        run: cargo test --locked --test agent_tui_harness
       - run: cargo test --locked
 
   # ruleset の required status check が参照する名前を保つための集約ジョブ。
@@ -193,7 +195,7 @@ jobs:
   # カバレッジ計測は instrument 付きの追加ビルドを伴うため PR の待ち時間へ乗せない。
   # main への push でだけ測り、推移を Codecov で追う。
   coverage:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, feature/milestone/87]
   pull_request:
-    branches: [main]
+    branches: [main, feature/milestone/87]
   schedule:
     - cron: "0 6 * * 1"
 

--- a/docs/architecture/TEST.md
+++ b/docs/architecture/TEST.md
@@ -118,18 +118,3 @@ pub fn create_test_branch() -> Branch { /* ... */ }
 ## CI
 
 CI と同じコマンドをローカルでも使う。詳細はプロジェクト root の `CLAUDE.md` を参照。
-
-## Agent TUI test harness
-
-Agent TUI cutoverの外部保証とscenario ownerは[`specs/milestone-87-agent-tui-cutover/acceptance-contract.md`](../../specs/milestone-87-agent-tui-cutover/acceptance-contract.md)を正本とする。
-
-mock IPCとは別に、実PTYとout-of-band lifecycle signalを通るfixtureを次で実行する。
-
-```bash
-cd src-tauri
-cargo test --locked --test agent_tui_harness
-```
-
-この入口は実PTY入出力、backend readerの継続、resize、provider process終了、lifecycle signalの欠落・重複・逆順・遅延・scope混入・不正payloadと、integration branchのrelease境界をself-testする。これはproduct acceptanceではない。
-
-共通fixtureは`src-tauri/tests/support/agent_tui_fixture.rs`に置く。後続Issueはfixtureを利用したproduct acceptanceを別targetへ追加し、担当scenarioを実装前に失敗、実装後に成功させる。

--- a/docs/architecture/TEST.md
+++ b/docs/architecture/TEST.md
@@ -118,3 +118,18 @@ pub fn create_test_branch() -> Branch { /* ... */ }
 ## CI
 
 CI と同じコマンドをローカルでも使う。詳細はプロジェクト root の `CLAUDE.md` を参照。
+
+## Agent TUI test harness
+
+Agent TUI cutoverの外部保証とscenario ownerは[`specs/milestone-87-agent-tui-cutover/acceptance-contract.md`](../../specs/milestone-87-agent-tui-cutover/acceptance-contract.md)を正本とする。
+
+mock IPCとは別に、実PTYとout-of-band lifecycle signalを通るfixtureを次で実行する。
+
+```bash
+cd src-tauri
+cargo test --locked --test agent_tui_harness
+```
+
+この入口は実PTY入出力、backend readerの継続、resize、provider process終了、lifecycle signalの欠落・重複・逆順・遅延・scope混入・不正payloadと、integration branchのrelease境界をself-testする。これはproduct acceptanceではない。
+
+共通fixtureは`src-tauri/tests/support/agent_tui_fixture.rs`に置く。後続Issueはfixtureを利用したproduct acceptanceを別targetへ追加し、担当scenarioを実装前に失敗、実装後に成功させる。

--- a/specs/milestone-87-agent-tui-cutover/acceptance-contract.md
+++ b/specs/milestone-87-agent-tui-cutover/acceptance-contract.md
@@ -1,0 +1,88 @@
+# Agent TUI cutover acceptance contract
+
+## 目的
+
+本書は、Agent GUIをprovider CLI TUIへ置き換える際に、利用者とworkflowから観測できる保証とrelease gateを定める。Rustの型、保存形式、providerごとのHook設定、terminal snapshot形式は後続Issueで決定する。
+
+## 状態の正本
+
+| 状態 | 正本 | Releashの責務 |
+|---|---|---|
+| conversation、thinking、tool表示、provider permission | provider CLIとprovider transcript | CLI TUIを改変せず表示し、独自Message modelへ複製しない |
+| live PTY、terminal checkpoint、bounded scrollback | Releash backend | frontendのmount状態から独立して保持し、同じ状態を各surfaceへ公開する |
+| NodeExecution、attempt、Submit、Artifact、Approval | Releash workflow | durableに記録し、providerの表示文言から推定しない |
+| provider session identity、Stop signal | provider lifecycle integrationを経由したReleashのledger | session、NodeExecution、attemptとの対応を検証する |
+
+frontendはbackend-owned stateのprojectionであり、workflow遷移またはterminal継続性の正本にならない。
+
+## 外部保証
+
+1. ClaudeとCodexのCLI TUIで対話、permission応答、再指示を行える。
+2. xtermのunmount / remount、tab・workspace切替、renderer reload後も同一live PTYへ欠落・重複なく再接続できる。
+3. App process restart後は最終画面とbounded scrollbackを復元できる。同一PTYまたはprocessの継続は保証しない。
+4. Submitとprovider Stopを別signalとして扱い、同じattemptの両方が揃った場合だけAutoまたはApprovalの次状態へ進む。
+5. ArtifactはSubmitへ任意で添付でき、Artifactなしでも完了意思を表明できる。
+6. signal欠落、重複、遅延、別attemptからの到着を、providerのterminal表示文言に依存せず判定する。
+7. Node完了後もAgentSessionとlive PTYを終了せず、Releashは自動入力または自動resumeを行わない。
+8. 旧AgentSessionデータを読み取り、変換、backfillしない。
+
+## Acceptance scenario
+
+| ID | 観測する境界 | 合格条件 | Owner |
+|---|---|---|---|
+| ATUI-000 | 実PTYとout-of-band lifecycle fixture | 実PTYのANSI / Unicode入出力と、Submit / Stopの欠落・重複を独立して再現できる | #1594 |
+| ATUI-010 | live terminal attach | remount、tab・workspace切替、renderer reload中の出力にgap、duplicate、順序逆転がない | #1595 |
+| ATUI-011 | terminal checkpoint | alternate screen、cursor、style、wide character、resize、bounded scrollback、終了画面を復元できる | #1595 |
+| ATUI-012 | App process restart | 最終画面とbounded scrollbackだけを復元し、同一process継続を成功扱いしない | #1595 |
+| ATUI-020 | provider lifecycle | Claude / Codexのsession、transcript参照、Stopを正しいAgentSessionとattemptへ関連付ける | #1596 |
+| ATUI-021 | lifecycle fault | signalの重複、遅延、欠落、別sessionからの混入をfail-closedで扱う | #1596 |
+| ATUI-030 | AgentSession vertical slice | 開始、対話、permission、reload、明示終了が旧Message projectionなしで成立する | #1597 |
+| ATUI-040 | Auto workflow | 同じattemptのSubmitとStopが揃った場合だけCompletedとなる | #1598 |
+| ATUI-041 | Approval workflow | 同じattemptのSubmitとStopが揃った場合だけWaitingApprovalとなり、Approve / Rejectできる | #1598 |
+| ATUI-042 | workflow fault | 片側signal、遅延signal、Retry、完了後の追加質問が定義済み状態へ収束する | #1598 |
+| ATUI-050 | atomic cutover | 旧runtime経路が削除され、Config、Hook、canonical docs、release buildが新契約だけを参照する | #1599 |
+
+ATUI-000は後続Issueが利用するfixture自体のself-testであり、ATUI-010以降のproduct保証を代替しない。各Owner Issueは該当scenarioをproduct境界へ接続してから完了する。
+
+## Harness self-test
+
+実行入口:
+
+```bash
+cd src-tauri
+cargo test --locked --test agent_tui_harness
+```
+
+fixtureは実PTY上でANSI / Unicodeを出力し、PTY入力を受け取る。Submit / Stopはterminal outputへ埋め込まず、別transportで構造化signalとして送る。表示文言を変更してもlifecycle判定が変わらないことをcontractとする。
+
+#1594では、後続Issueがproduct境界の失敗を再現できるように次のharness能力をself-testする。
+
+| Harness能力 | Self-testする内容 |
+|---|---|
+| 実PTY | ANSI、alternate screen、Unicode / wide character、入力、resize、任意exit code |
+| surface非接続 | renderer相当のconsumerが存在しなくてもbackend readerがPTYをdrainし、後からcaptureを観測できる |
+| lifecycle独立経路 | terminal表示と分離したSubmit / Stop、provider session、attempt、transcript参照 |
+| lifecycle fault注入 | 順序逆転、片側または両側欠落、Submit / Stop重複、遅延、別session / attempt、sequence異常、不正payload |
+| process境界 | provider process終了をStop signalとして扱わず、両者を独立して観測できる |
+| contract / release gate | 全scenario IDがcanonical contractに存在し、integration branchでCIを実行しつつrelease sourceにしない |
+
+PTYのOS bufferをrenderer向けretentionとして使わない。rendererが外れている間もbackend readerは停止せず、#1595で実装するbackend-owned terminal stateへ継続して取り込む。
+
+このコマンドは試験設備の自己テストであり、ATUI-010以降のproduct acceptance成功を表さない。fixtureの共通moduleは`src-tauri/tests/support/agent_tui_fixture.rs`とする。各Owner Issueは同moduleを利用するproduct acceptanceを追加し、自身のscenarioを実装前に失敗、実装後に成功させる。
+
+## Branchとrelease gate
+
+- integration branchは`feature/milestone/87`とする。
+- 各Issueの子branchは`feature/milestone/87`をbaseにし、同branchへ統合する。
+- `main`では現行製品のreleaseを継続する。
+- `feature/milestone/87`の途中状態からtagまたは製品releaseを作成しない。
+- #1599以外の変更で旧Agent GUIと新Agent TUIの混在状態を`main`へmergeしない。
+- #1599の最終PRは本表の全scenario、通常CI、package / release buildが成功してから`feature/milestone/87`を`main`へ一括統合する。
+
+## 保証外
+
+- App process restartを跨ぐ同一PTY / processの継続
+- provider resumeの成功とresume後のprovider挙動
+- Releash管理外へescapeしたbackground processの停止
+- 旧AgentSessionデータのmigration、互換reader、物理削除
+- provider表示文言の固定

--- a/src-tauri/tests/agent_tui_harness.rs
+++ b/src-tauri/tests/agent_tui_harness.rs
@@ -1,0 +1,305 @@
+#[path = "support/agent_tui_fixture.rs"]
+mod agent_tui_fixture;
+
+use agent_tui_fixture::{
+    parsed_signals, run_fixture, signal_events, CapturedLifecyclePayload, FixtureLifecycleEmission,
+    FixtureLifecyclePayload, FixtureLifecycleSignal, FixturePlan, FixtureRunOptions,
+    FIXTURE_ATTEMPT_KEY, FIXTURE_SESSION_KEY, FIXTURE_TRANSCRIPT_REF,
+};
+use portable_pty::PtySize;
+use std::time::Duration;
+
+#[test]
+fn atui_000_real_pty_io_and_lifecycle_use_independent_channels() {
+    let run = run_fixture(
+        FixturePlan::new(
+            "arbitrary-visible-provider-wording",
+            vec![
+                FixtureLifecycleEmission::signal("submit", 1),
+                FixtureLifecycleEmission::signal("stop", 2),
+            ],
+        ),
+        FixtureRunOptions::default(),
+    );
+
+    assert_eq!(run.exit_code, 0);
+    assert!(run.terminal_output.contains("\x1b[?1049h"));
+    assert!(run.terminal_output.contains("\x1b[1;32m"));
+    assert!(run.terminal_output.contains("日本語🙂"));
+    assert!(run.terminal_output.contains("operator-input"));
+    assert!(!run.terminal_output.contains("\"event\":\"stop\""));
+    assert_eq!(signal_events(&run), vec!["submit", "stop"]);
+    assert!(parsed_signals(&run).iter().all(|signal| {
+        signal.session_key == FIXTURE_SESSION_KEY
+            && signal.attempt_key == FIXTURE_ATTEMPT_KEY
+            && signal.transcript_ref.as_deref() == Some(FIXTURE_TRANSCRIPT_REF)
+    }));
+}
+
+#[test]
+fn atui_000_backend_capture_continues_without_surface_consumer() {
+    let run = run_fixture(
+        FixturePlan {
+            input_lines: 2,
+            ..FixturePlan::new("output-without-surface-consumer", vec![])
+        },
+        FixtureRunOptions {
+            input_lines: vec!["first-input".to_string(), "second-input".to_string()],
+            ..FixtureRunOptions::default()
+        },
+    );
+
+    assert_eq!(run.exit_code, 0);
+    assert!(run
+        .terminal_output
+        .contains("output-without-surface-consumer"));
+    assert!(run.terminal_output.contains("received-0:first-input"));
+    assert!(run.terminal_output.contains("received-1:second-input"));
+}
+
+#[cfg(unix)]
+#[test]
+fn atui_000_real_pty_resize_is_visible_to_provider() {
+    let run = run_fixture(
+        FixturePlan {
+            report_terminal_size: true,
+            ..FixturePlan::new("resize-provider", vec![])
+        },
+        FixtureRunOptions {
+            resize_to: Some(PtySize {
+                rows: 37,
+                cols: 111,
+                pixel_width: 0,
+                pixel_height: 0,
+            }),
+            ..FixtureRunOptions::default()
+        },
+    );
+
+    assert!(run.terminal_output.contains("terminal-size:37x111"));
+}
+
+#[test]
+fn atui_000_provider_process_exit_is_not_a_stop_signal() {
+    let run = run_fixture(
+        FixturePlan {
+            exit_code: 23,
+            ..FixturePlan::new("provider-exits-without-stop", vec![])
+        },
+        FixtureRunOptions::default(),
+    );
+
+    assert_eq!(run.exit_code, 23);
+    assert!(run.lifecycle.is_empty());
+}
+
+#[test]
+fn atui_000_submit_and_stop_order_can_be_reversed() {
+    let submit_then_stop = run_fixture(
+        FixturePlan::new(
+            "same-visible-output",
+            vec![
+                FixtureLifecycleEmission::signal("submit", 1),
+                FixtureLifecycleEmission::signal("stop", 2),
+            ],
+        ),
+        FixtureRunOptions::default(),
+    );
+    let stop_then_submit = run_fixture(
+        FixturePlan::new(
+            "same-visible-output",
+            vec![
+                FixtureLifecycleEmission::signal("stop", 1),
+                FixtureLifecycleEmission::signal("submit", 2),
+            ],
+        ),
+        FixtureRunOptions::default(),
+    );
+
+    assert_eq!(signal_events(&submit_then_stop), vec!["submit", "stop"]);
+    assert_eq!(signal_events(&stop_then_submit), vec!["stop", "submit"]);
+}
+
+#[test]
+fn atui_000_each_lifecycle_signal_can_be_missing() {
+    let submit_only = run_fixture(
+        FixturePlan::new(
+            "same-visible-output",
+            vec![FixtureLifecycleEmission::signal("submit", 1)],
+        ),
+        FixtureRunOptions::default(),
+    );
+    let stop_only = run_fixture(
+        FixturePlan::new(
+            "same-visible-output",
+            vec![FixtureLifecycleEmission::signal("stop", 1)],
+        ),
+        FixtureRunOptions::default(),
+    );
+    let neither = run_fixture(
+        FixturePlan::new("same-visible-output", vec![]),
+        FixtureRunOptions::default(),
+    );
+
+    assert_eq!(signal_events(&submit_only), vec!["submit"]);
+    assert_eq!(signal_events(&stop_only), vec!["stop"]);
+    assert!(neither.lifecycle.is_empty());
+}
+
+#[test]
+fn atui_000_each_lifecycle_signal_can_be_duplicated() {
+    let run = run_fixture(
+        FixturePlan::new(
+            "duplicate-independent-output",
+            vec![
+                FixtureLifecycleEmission::signal("submit", 1),
+                FixtureLifecycleEmission::signal("submit", 2),
+                FixtureLifecycleEmission::signal("stop", 3),
+                FixtureLifecycleEmission::signal("stop", 4),
+            ],
+        ),
+        FixtureRunOptions::default(),
+    );
+
+    assert_eq!(
+        signal_events(&run),
+        vec!["submit", "submit", "stop", "stop"]
+    );
+}
+
+#[test]
+fn atui_000_lifecycle_signal_can_be_delayed() {
+    let run = run_fixture(
+        FixturePlan::new(
+            "delayed-signal-output",
+            vec![
+                FixtureLifecycleEmission::signal("submit", 1),
+                FixtureLifecycleEmission::delayed_signal("stop", 2, 100),
+            ],
+        ),
+        FixtureRunOptions::default(),
+    );
+
+    assert_eq!(signal_events(&run), vec!["submit", "stop"]);
+    let gap = run.lifecycle[1]
+        .received_after
+        .saturating_sub(run.lifecycle[0].received_after);
+    assert!(gap >= Duration::from_millis(75), "observed gap: {gap:?}");
+}
+
+#[test]
+fn atui_000_lifecycle_scope_can_reference_another_session_or_attempt() {
+    let mut wrong_session = FixtureLifecycleSignal::new("stop", 1);
+    wrong_session.session_key = "other-session".to_string();
+    let mut wrong_attempt = FixtureLifecycleSignal::new("stop", 2);
+    wrong_attempt.attempt_key = "other-attempt".to_string();
+    let run = run_fixture(
+        FixturePlan::new(
+            "cross-scope-signal-output",
+            vec![
+                FixtureLifecycleEmission {
+                    delay_before_ms: 0,
+                    payload: FixtureLifecyclePayload::Signal {
+                        signal: wrong_session,
+                    },
+                },
+                FixtureLifecycleEmission {
+                    delay_before_ms: 0,
+                    payload: FixtureLifecyclePayload::Signal {
+                        signal: wrong_attempt,
+                    },
+                },
+            ],
+        ),
+        FixtureRunOptions::default(),
+    );
+
+    let signals = parsed_signals(&run);
+    assert_eq!(signals[0].session_key, "other-session");
+    assert_eq!(signals[1].attempt_key, "other-attempt");
+}
+
+#[test]
+fn atui_000_lifecycle_sequence_gap_and_reversal_are_preserved() {
+    let run = run_fixture(
+        FixturePlan::new(
+            "sequence-fault-output",
+            vec![
+                FixtureLifecycleEmission::signal("submit", 3),
+                FixtureLifecycleEmission::signal("stop", 1),
+            ],
+        ),
+        FixtureRunOptions::default(),
+    );
+
+    let sequences: Vec<_> = parsed_signals(&run)
+        .into_iter()
+        .map(|signal| signal.sequence)
+        .collect();
+    assert_eq!(sequences, vec![3, 1]);
+}
+
+#[test]
+fn atui_000_malformed_lifecycle_payload_is_observable_without_terminal_parsing() {
+    let run = run_fixture(
+        FixturePlan::new(
+            "malformed-signal-output",
+            vec![FixtureLifecycleEmission::raw("{not-valid-json")],
+        ),
+        FixtureRunOptions::default(),
+    );
+
+    assert_eq!(run.lifecycle.len(), 1);
+    match &run.lifecycle[0].payload {
+        CapturedLifecyclePayload::Invalid(payload) => assert_eq!(payload, "{not-valid-json"),
+        CapturedLifecyclePayload::Signal(signal) => {
+            panic!("expected invalid payload, got {signal:?}")
+        }
+    }
+    assert!(!run.terminal_output.contains("not-valid-json"));
+}
+
+#[test]
+fn harness_contract_lists_every_milestone_scenario_once() {
+    const CONTRACT: &str =
+        include_str!("../../specs/milestone-87-agent-tui-cutover/acceptance-contract.md");
+    const SCENARIOS: &[&str] = &[
+        "ATUI-000", "ATUI-010", "ATUI-011", "ATUI-012", "ATUI-020", "ATUI-021", "ATUI-030",
+        "ATUI-040", "ATUI-041", "ATUI-042", "ATUI-050",
+    ];
+
+    for scenario in SCENARIOS {
+        assert_eq!(
+            CONTRACT
+                .lines()
+                .filter(|line| line.starts_with(&format!("| {scenario} |")))
+                .count(),
+            1,
+            "{scenario} must have exactly one canonical contract row"
+        );
+    }
+}
+
+#[test]
+fn integration_branch_runs_ci_without_becoming_a_release_source() {
+    const CI: &str = include_str!("../../.github/workflows/ci.yml");
+    const CODEQL: &str = include_str!("../../.github/workflows/codeql.yml");
+    const AUTO_TAG: &str = include_str!("../../.github/workflows/auto-tag.yml");
+    const RELEASE: &str = include_str!("../../.github/workflows/release.yml");
+
+    assert_eq!(
+        CI.matches("branches: [main, feature/milestone/87]").count(),
+        2
+    );
+    assert_eq!(
+        CODEQL
+            .matches("branches: [main, feature/milestone/87]")
+            .count(),
+        2
+    );
+    assert!(CI.contains("cargo test --locked --test agent_tui_harness"));
+    assert!(AUTO_TAG.contains("branches: [main]"));
+    assert!(!AUTO_TAG.contains("feature/milestone/87"));
+    assert!(RELEASE.contains("tags: ['v*']"));
+    assert!(!RELEASE.contains("feature/milestone/87"));
+}

--- a/src-tauri/tests/support/agent_tui_fixture.rs
+++ b/src-tauri/tests/support/agent_tui_fixture.rs
@@ -1,0 +1,365 @@
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const FIXTURE_PLAN_ENV: &str = "RELEASH_AGENT_TUI_FIXTURE_PLAN";
+pub const FIXTURE_SESSION_KEY: &str = "fixture-session";
+pub const FIXTURE_ATTEMPT_KEY: &str = "fixture-attempt";
+pub const FIXTURE_TRANSCRIPT_REF: &str = "provider://fixture/transcript";
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct FixtureLifecycleSignal {
+    pub session_key: String,
+    pub attempt_key: String,
+    pub transcript_ref: Option<String>,
+    pub event: String,
+    pub sequence: u64,
+}
+
+impl FixtureLifecycleSignal {
+    pub fn new(event: &str, sequence: u64) -> Self {
+        Self {
+            session_key: FIXTURE_SESSION_KEY.to_string(),
+            attempt_key: FIXTURE_ATTEMPT_KEY.to_string(),
+            transcript_ref: Some(FIXTURE_TRANSCRIPT_REF.to_string()),
+            event: event.to_string(),
+            sequence,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FixtureLifecyclePayload {
+    Signal { signal: FixtureLifecycleSignal },
+    Raw { value: String },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct FixtureLifecycleEmission {
+    pub delay_before_ms: u64,
+    pub payload: FixtureLifecyclePayload,
+}
+
+impl FixtureLifecycleEmission {
+    pub fn signal(event: &str, sequence: u64) -> Self {
+        Self {
+            delay_before_ms: 0,
+            payload: FixtureLifecyclePayload::Signal {
+                signal: FixtureLifecycleSignal::new(event, sequence),
+            },
+        }
+    }
+
+    pub fn delayed_signal(event: &str, sequence: u64, delay_before_ms: u64) -> Self {
+        Self {
+            delay_before_ms,
+            payload: FixtureLifecyclePayload::Signal {
+                signal: FixtureLifecycleSignal::new(event, sequence),
+            },
+        }
+    }
+
+    pub fn raw(value: &str) -> Self {
+        Self {
+            delay_before_ms: 0,
+            payload: FixtureLifecyclePayload::Raw {
+                value: value.to_string(),
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct FixturePlan {
+    pub label: String,
+    pub input_lines: usize,
+    pub report_terminal_size: bool,
+    pub(crate) lifecycle_endpoint: String,
+    pub lifecycle: Vec<FixtureLifecycleEmission>,
+    pub exit_code: u8,
+}
+
+impl FixturePlan {
+    pub fn new(label: &str, lifecycle: Vec<FixtureLifecycleEmission>) -> Self {
+        Self {
+            label: label.to_string(),
+            input_lines: 1,
+            report_terminal_size: false,
+            lifecycle_endpoint: String::new(),
+            lifecycle,
+            exit_code: 0,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum CapturedLifecyclePayload {
+    Signal(FixtureLifecycleSignal),
+    Invalid(String),
+}
+
+#[derive(Debug)]
+pub struct CapturedLifecycleFrame {
+    pub received_after: Duration,
+    pub payload: CapturedLifecyclePayload,
+}
+
+pub struct FixtureRun {
+    pub exit_code: u32,
+    pub terminal_output: String,
+    pub lifecycle: Vec<CapturedLifecycleFrame>,
+}
+
+pub struct FixtureRunOptions {
+    pub input_lines: Vec<String>,
+    pub resize_to: Option<PtySize>,
+}
+
+impl Default for FixtureRunOptions {
+    fn default() -> Self {
+        Self {
+            input_lines: vec!["operator-input".to_string()],
+            resize_to: None,
+        }
+    }
+}
+
+#[test]
+fn agent_tui_fixture_process() {
+    let Ok(plan_json) = env::var(FIXTURE_PLAN_ENV) else {
+        return;
+    };
+    let plan: FixturePlan = serde_json::from_str(&plan_json).expect("parse Agent TUI fixture plan");
+
+    print!("\x1b[?1049h\x1b[2J\x1b[H{} 日本語🙂\r\n", plan.label);
+    std::io::stdout().flush().expect("flush fixture header");
+
+    for index in 0..plan.input_lines {
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .expect("read fixture PTY input");
+        print!("\x1b[1;32mreceived-{index}:{}\x1b[0m\r\n", input.trim());
+        std::io::stdout().flush().expect("flush fixture response");
+    }
+
+    if plan.report_terminal_size {
+        let (rows, cols) = current_terminal_size().expect("read fixture terminal size");
+        print!("terminal-size:{rows}x{cols}\r\n");
+        std::io::stdout()
+            .flush()
+            .expect("flush fixture terminal size");
+    }
+
+    for emission in &plan.lifecycle {
+        thread::sleep(Duration::from_millis(emission.delay_before_ms));
+        send_fixture_payload(&plan.lifecycle_endpoint, &emission.payload);
+    }
+
+    print!("\x1b[?1049l");
+    std::io::stdout().flush().expect("flush fixture footer");
+    if plan.exit_code != 0 {
+        std::process::exit(i32::from(plan.exit_code));
+    }
+}
+
+#[cfg(unix)]
+fn current_terminal_size() -> Option<(u16, u16)> {
+    let mut size = std::mem::MaybeUninit::<libc::winsize>::zeroed();
+    let result = unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, size.as_mut_ptr()) };
+    if result == 0 {
+        let size = unsafe { size.assume_init() };
+        Some((size.ws_row, size.ws_col))
+    } else {
+        None
+    }
+}
+
+#[cfg(not(unix))]
+fn current_terminal_size() -> Option<(u16, u16)> {
+    None
+}
+
+fn send_fixture_payload(endpoint: &str, payload: &FixtureLifecyclePayload) {
+    let mut stream = TcpStream::connect(endpoint).expect("connect lifecycle fixture transport");
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .expect("set lifecycle write timeout");
+    match payload {
+        FixtureLifecyclePayload::Signal { signal } => {
+            serde_json::to_writer(&mut stream, signal).expect("serialize lifecycle fixture signal");
+        }
+        FixtureLifecyclePayload::Raw { value } => stream
+            .write_all(value.as_bytes())
+            .expect("write raw lifecycle fixture payload"),
+    }
+    stream
+        .write_all(b"\n")
+        .expect("terminate lifecycle fixture payload");
+    stream.flush().expect("flush lifecycle fixture payload");
+}
+
+pub fn run_fixture(mut plan: FixturePlan, options: FixtureRunOptions) -> FixtureRun {
+    assert_eq!(plan.input_lines, options.input_lines.len());
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind lifecycle fixture transport");
+    listener
+        .set_nonblocking(true)
+        .expect("set lifecycle listener nonblocking");
+    plan.lifecycle_endpoint = listener
+        .local_addr()
+        .expect("read lifecycle fixture address")
+        .to_string();
+
+    let expected_lifecycle_count = plan.lifecycle.len();
+    let started_at = Instant::now();
+    let capture_thread = thread::spawn(move || {
+        collect_fixture_lifecycle(listener, expected_lifecycle_count, started_at)
+    });
+
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("open real PTY for Agent TUI fixture");
+    let mut command = CommandBuilder::new(env::current_exe().expect("resolve test executable"));
+    command.arg("--exact");
+    command.arg("agent_tui_fixture::agent_tui_fixture_process");
+    command.arg("--nocapture");
+    command.arg("--test-threads=1");
+    command.env(
+        FIXTURE_PLAN_ENV,
+        serde_json::to_string(&plan).expect("serialize Agent TUI fixture plan"),
+    );
+
+    let mut child = pair
+        .slave
+        .spawn_command(command)
+        .expect("spawn Agent TUI fixture in real PTY");
+    drop(pair.slave);
+
+    if let Some(size) = options.resize_to {
+        pair.master
+            .resize(size)
+            .expect("resize Agent TUI fixture PTY");
+    }
+
+    let mut writer = pair
+        .master
+        .take_writer()
+        .expect("take Agent TUI fixture PTY writer");
+    let mut reader = pair
+        .master
+        .try_clone_reader()
+        .expect("clone Agent TUI fixture PTY reader");
+    let output_thread = thread::spawn(move || read_pty_to_end(&mut reader));
+
+    for input in &options.input_lines {
+        writer
+            .write_all(format!("{input}\r").as_bytes())
+            .expect("write Agent TUI fixture PTY input");
+        writer.flush().expect("flush Agent TUI fixture PTY input");
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let exit_code = loop {
+        if let Some(status) = child.try_wait().expect("poll Agent TUI fixture") {
+            break status.exit_code();
+        }
+        if Instant::now() >= deadline {
+            child.kill().expect("kill timed out Agent TUI fixture");
+            panic!("Agent TUI fixture did not exit within five seconds");
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    drop(writer);
+
+    let terminal_bytes = output_thread.join().expect("join Agent TUI PTY reader");
+    let lifecycle = capture_thread
+        .join()
+        .expect("join Agent TUI lifecycle capture");
+
+    FixtureRun {
+        exit_code,
+        terminal_output: String::from_utf8_lossy(&terminal_bytes).into_owned(),
+        lifecycle,
+    }
+}
+
+fn read_pty_to_end(reader: &mut impl Read) -> Vec<u8> {
+    let mut output = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => output.extend_from_slice(&buffer[..read]),
+            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+            Err(error) if error.raw_os_error() == Some(5) => break,
+            Err(error) => panic!("read Agent TUI fixture PTY: {error}"),
+        }
+    }
+    output
+}
+
+fn collect_fixture_lifecycle(
+    listener: TcpListener,
+    expected_count: usize,
+    started_at: Instant,
+) -> Vec<CapturedLifecycleFrame> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut captured = Vec::new();
+    while captured.len() < expected_count {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                stream
+                    .set_nonblocking(false)
+                    .expect("set lifecycle fixture stream blocking");
+                let mut payload = String::new();
+                stream
+                    .read_to_string(&mut payload)
+                    .expect("read lifecycle fixture payload");
+                let payload = payload.trim_end().to_string();
+                let parsed = match serde_json::from_str(&payload) {
+                    Ok(signal) => CapturedLifecyclePayload::Signal(signal),
+                    Err(_) => CapturedLifecyclePayload::Invalid(payload),
+                };
+                captured.push(CapturedLifecycleFrame {
+                    received_after: started_at.elapsed(),
+                    payload: parsed,
+                });
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(error) => panic!("accept lifecycle fixture payload: {error}"),
+        }
+    }
+    captured
+}
+
+pub fn parsed_signals(run: &FixtureRun) -> Vec<&FixtureLifecycleSignal> {
+    run.lifecycle
+        .iter()
+        .filter_map(|frame| match &frame.payload {
+            CapturedLifecyclePayload::Signal(signal) => Some(signal),
+            CapturedLifecyclePayload::Invalid(_) => None,
+        })
+        .collect()
+}
+
+pub fn signal_events(run: &FixtureRun) -> Vec<&str> {
+    parsed_signals(run)
+        .into_iter()
+        .map(|signal| signal.event.as_str())
+        .collect()
+}


### PR DESCRIPTION
## 概要

- Agent TUI cutoverの外部契約とscenario ownerを固定
- 実PTYとout-of-band lifecycle signalを使う共通fixtureを追加
- fixture自己テストをproduct acceptanceと明確に分離
- feature/milestone/87へのpush/PRでCIとCodeQLを実行
- integration branchをrelease sourceにしないgateを検証

## 検証

- cargo fmt --check
- cargo clippy --locked -- -D warnings
- cargo test --locked --quiet
- cargo test --locked --test agent_tui_harness -- --test-threads=1
- qlty check --no-progress --all

Tracks #1594