### PR TITLE
fix(workflow): active Attemptの再SubmitでArtifactを差し替える

### DIFF
--- a/specs/milestone-87-agent-tui-cutover/issue-1598-workflow-control-plane.md
+++ b/specs/milestone-87-agent-tui-cutover/issue-1598-workflow-control-plane.md
@@ -125,6 +125,8 @@ ReleashはWorkflow ledgerを正本として、signalの受信、Artifact、Appro
 - Node名だけ、Provider session IDだけ、Terminal表示、現在選択中UIからAttemptを推定しない。
 - 同一signalの再送は冪等とし、Node遷移、Artifact、Approval、後続起動を重複させない。
 
+Issue #1626 は、上記の「同一signalの再送」に含まれる重複Submitの解釈を上書きする。SubmitReceivedからReadyまでのsignal遷移と二signal合流は一度きりのまま維持する一方、同一AttemptがRunning、Paused、WaitingApprovalの間は、Artifact付き再Submitを毎回検証してArtifactを差し替え、ArtifactProducedを再記録する。WaitingApprovalは差し替え後も維持する。Artifactなしの重複Submitは従来どおり冪等なno-opとし、終端AttemptへのSubmitは受理しない。
+
 ## 6. Domain model方針
 
 ### 6.1 WorkflowExecution aggregate

--- a/src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs
+++ b/src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs
@@ -1524,6 +1524,12 @@ impl WorkflowExecution {
         else {
             return TransitionOutcome::NotApplicable;
         };
+        if !self.runtime.node_executions[execution_index]
+            .status
+            .is_active()
+        {
+            return TransitionOutcome::NotApplicable;
+        }
         let fanout_child = self.runtime.node_executions[execution_index]
             .fanout_parent
             .is_some();
@@ -3375,6 +3381,62 @@ mod tests {
         assert_eq!(
             resumed.completion_signals,
             NodeCompletionSignalState::SubmitReceived
+        );
+    }
+
+    #[test]
+    fn paused_attempt_accepts_artifact_replacement_without_changing_status() {
+        let mut execution = restored_execution(RuntimeExecutionState::Running);
+        let node_execution_id = execution
+            .begin_node_attempt(
+                "implement".to_string(),
+                NodeKindName::Session,
+                1,
+                None,
+                "node-execution-1".to_string(),
+                10.0,
+            )
+            .unwrap();
+        assert_eq!(
+            execution.record_node_completion_signal(
+                &node_execution_id,
+                NodeCompletionSignal::Submit,
+                11.0,
+            ),
+            TransitionOutcome::Applied
+        );
+        assert_eq!(
+            execution.pause_node_execution(&node_execution_id, 12.0),
+            TransitionOutcome::Applied
+        );
+        assert!(execution.admit_node_submit(&node_execution_id).is_ok());
+        assert_eq!(
+            execution.record_node_completion_signal(
+                &node_execution_id,
+                NodeCompletionSignal::Submit,
+                13.0,
+            ),
+            TransitionOutcome::AlreadyApplied
+        );
+        assert_eq!(
+            execution.apply_submitted_output(
+                "implement".to_string(),
+                &node_execution_id,
+                1,
+                None,
+                "result".to_string(),
+                serde_json::json!({"result": "replacement"}),
+                None,
+                14.0,
+            ),
+            TransitionOutcome::Applied
+        );
+
+        let paused = &execution.node_executions()[0];
+        assert_eq!(paused.status, RuntimeNodeExecutionStatus::Paused);
+        assert_eq!(
+            paused.artifact.as_ref(),
+            Some(&serde_json::json!({"result": "replacement"}))
         );
     }
 

--- a/src-tauri/src/usecase/workflow/control_plane.rs
+++ b/src-tauri/src/usecase/workflow/control_plane.rs
@@ -275,27 +275,31 @@ impl WorkflowControlPlaneUsecase {
         };
         let timestamp = self.runtime.current_timestamp();
         let mut candidate = current.clone();
-        match candidate.record_node_completion_signal(
+        let submit_signal_applied = match candidate.record_node_completion_signal(
             &command.node_execution_id,
             NodeCompletionSignal::Submit,
             timestamp,
         ) {
-            crate::domain::workflow::entities::workflow_execution::TransitionOutcome::Applied => {}
-            crate::domain::workflow::entities::workflow_execution::TransitionOutcome::AlreadyApplied => {
-                return Ok(())
-            }
+            TransitionOutcome::Applied => true,
+            TransitionOutcome::AlreadyApplied => false,
             _ => {
                 return Err(WorkflowError::invalid_state(format!(
                     "node execution '{}' cannot accept Submit",
                     command.node_execution_id
                 )))
             }
+        };
+        if !submit_signal_applied && validated_artifact.is_none() {
+            return Ok(());
         }
-        let mut events = vec![WorkflowEvent::NodeSubmitReceived {
-            execution_id: execution_id.clone(),
-            node_execution_id: command.node_execution_id.clone(),
-            timestamp,
-        }];
+        let mut events = Vec::new();
+        if submit_signal_applied {
+            events.push(WorkflowEvent::NodeSubmitReceived {
+                execution_id: execution_id.clone(),
+                node_execution_id: command.node_execution_id.clone(),
+                timestamp,
+            });
+        }
         if let Some((contract, validated)) = validated_artifact {
             if candidate.apply_submitted_output(
                 target.node_name.clone(),
@@ -325,13 +329,18 @@ impl WorkflowControlPlaneUsecase {
                 timestamp,
             ));
         }
-        let (outcome, handshake_events) = apply_completion_handshake(
-            &mut candidate,
-            &command.node_execution_id,
-            self.runtime.new_node_execution_id(),
-            timestamp,
-        )?;
-        events.extend(handshake_events);
+        let outcome = if submit_signal_applied {
+            let (outcome, handshake_events) = apply_completion_handshake(
+                &mut candidate,
+                &command.node_execution_id,
+                self.runtime.new_node_execution_id(),
+                timestamp,
+            )?;
+            events.extend(handshake_events);
+            outcome
+        } else {
+            None
+        };
         let worktree_path = current.worktree_path.clone();
         let snapshot = self
             .runtime

--- a/src-tauri/src/usecase/workflow/control_plane.rs
+++ b/src-tauri/src/usecase/workflow/control_plane.rs
@@ -223,38 +223,23 @@ impl WorkflowControlPlaneUsecase {
                 ))
             })?;
 
-        let active = self.runtime.load_active_execution(&execution_id).await?;
-        let persisted_events = if active.is_none() {
-            Some(self.runtime.load_persisted_events(&execution_id).await?)
-        } else {
-            None
-        };
+        let current = self
+            .runtime
+            .load_active_execution(&execution_id)
+            .await?
+            .ok_or_else(|| {
+                WorkflowError::NotFound(format!(
+                    "Active node execution not found: {}",
+                    command.node_execution_id
+                ))
+            })?;
 
-        let Some(current) = active else {
-            let events = persisted_events.unwrap_or_default();
-            if submit_was_persisted(&events, &command.node_execution_id) {
-                return Ok(());
-            }
-            return Err(WorkflowError::NotFound(format!(
-                "Active node execution not found: {}",
-                command.node_execution_id
-            )));
-        };
-
-        let target = match submission::validate_submit_target_context(
+        let target = submission::validate_submit_target_context(
             &current,
             &execution_id,
             &command.node_execution_id,
-        ) {
-            Ok(target) => target,
-            Err(error) => {
-                let events = self.runtime.load_persisted_events(&execution_id).await?;
-                if submit_was_persisted(&events, &command.node_execution_id) {
-                    return Ok(());
-                }
-                return Err(runtime_error_to_workflow_error(error));
-            }
-        };
+        )
+        .map_err(runtime_error_to_workflow_error)?;
         let validated_artifact = if let Some(artifact) = command.artifact {
             submission::validate_artifact_contract_for_workflow(
                 &current.workflow,
@@ -771,18 +756,6 @@ fn apply_fanout_approval(
     *outcome.snapshot_mut() = RuntimeCommitSnapshot::from_execution(execution)
         .map_err(runtime_error_to_workflow_error)?;
     Ok((outcome, events))
-}
-
-fn submit_was_persisted(events: &[WorkflowEvent], expected_node_execution_id: &str) -> bool {
-    events.iter().any(|event| {
-        matches!(
-            event,
-            WorkflowEvent::NodeSubmitReceived {
-                node_execution_id,
-                ..
-            } if node_execution_id == expected_node_execution_id
-        )
-    })
 }
 
 fn apply_completion_handshake(

--- a/src-tauri/src/workflow_control_plane_acceptance.rs
+++ b/src-tauri/src/workflow_control_plane_acceptance.rs
@@ -40,6 +40,8 @@ const APPROVAL_FANOUT_CLAUDE_WORKFLOW: &str = "acceptance-approval-fanout-claude
 const APPROVAL_FANOUT_CODEX_WORKFLOW: &str = "acceptance-approval-fanout-codex";
 const ARTIFACT_CLAUDE_WORKFLOW: &str = "acceptance-artifact-claude";
 const ARTIFACT_CODEX_WORKFLOW: &str = "acceptance-artifact-codex";
+const APPROVAL_ARTIFACT_CLAUDE_WORKFLOW: &str = "acceptance-approval-artifact-claude";
+const APPROVAL_ARTIFACT_CODEX_WORKFLOW: &str = "acceptance-approval-artifact-codex";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AcceptanceWorkflowExecutionStatus {
@@ -72,6 +74,7 @@ pub struct AcceptanceNodeExecution {
     pub can_approve: bool,
     pub can_retry: bool,
     pub has_artifact: bool,
+    pub artifact: Option<serde_json::Value>,
     pub failure_reason: Option<String>,
 }
 
@@ -118,7 +121,13 @@ struct NodeExecutionResponse {
     can_approve: bool,
     can_retry: bool,
     has_artifact: bool,
+    artifact: Option<ArtifactResponse>,
     failure: Option<NodeExecutionFailureResponse>,
+}
+
+#[derive(Deserialize)]
+struct ArtifactResponse {
+    value: serde_json::Value,
 }
 
 #[derive(Deserialize)]
@@ -212,13 +221,22 @@ impl WorkflowDefinitionResolver for AcceptanceWorkflowDefinitionResolver {
             });
         }
         let artifact_provider = match workflow_name {
-            ARTIFACT_CLAUDE_WORKFLOW => Some(ProviderKind::Claude),
-            ARTIFACT_CODEX_WORKFLOW => Some(ProviderKind::Codex),
+            ARTIFACT_CLAUDE_WORKFLOW | APPROVAL_ARTIFACT_CLAUDE_WORKFLOW => {
+                Some(ProviderKind::Claude)
+            }
+            ARTIFACT_CODEX_WORKFLOW | APPROVAL_ARTIFACT_CODEX_WORKFLOW => Some(ProviderKind::Codex),
             _ => None,
         };
         if let Some(provider) = artifact_provider {
-            let mut node =
-                acceptance_session_node("agent", provider, SessionGate::Auto, Vec::new());
+            let gate = if matches!(
+                workflow_name,
+                APPROVAL_ARTIFACT_CLAUDE_WORKFLOW | APPROVAL_ARTIFACT_CODEX_WORKFLOW
+            ) {
+                SessionGate::Approval
+            } else {
+                SessionGate::Auto
+            };
+            let mut node = acceptance_session_node("agent", provider, gate, Vec::new());
             node.artifact = Some("acceptance-result".to_string());
             return Ok(WorkflowDefinition {
                 name: workflow_name.to_string(),
@@ -481,6 +499,19 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
             .await
     }
 
+    pub async fn start_approval_artifact_workflow(
+        &self,
+        worktree_path: &str,
+        provider: AcceptanceProvider,
+    ) -> Result<String, String> {
+        let workflow_name = match provider {
+            AcceptanceProvider::Claude => APPROVAL_ARTIFACT_CLAUDE_WORKFLOW,
+            AcceptanceProvider::Codex => APPROVAL_ARTIFACT_CODEX_WORKFLOW,
+        };
+        self.start_named_workflow(worktree_path, workflow_name)
+            .await
+    }
+
     async fn start_named_workflow(
         &self,
         worktree_path: &str,
@@ -519,6 +550,11 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
             .recover_startup()
             .await
             .map_err(|error| error.to_string())
+    }
+
+    pub async fn workflow_log(&self, execution_id: &str) -> Result<Vec<serde_json::Value>, String> {
+        self.get(&format!("/v1/workflow/executions/{execution_id}/log"))
+            .await
     }
 
     pub async fn submit(&self, node_execution_id: &str) -> Result<(), String> {
@@ -739,6 +775,7 @@ impl From<NodeExecutionResponse> for AcceptanceNodeExecution {
             can_approve: value.can_approve,
             can_retry: value.can_retry,
             has_artifact: value.has_artifact,
+            artifact: value.artifact.map(|artifact| artifact.value),
             failure_reason: value.failure.map(|failure| failure.reason),
         }
     }

--- a/src-tauri/tests/workflow_control_plane_acceptance_test.rs
+++ b/src-tauri/tests/workflow_control_plane_acceptance_test.rs
@@ -361,7 +361,7 @@ async fn test_atui_040_autoは両signal順序と重複に依存せず後続を�
             advanced.node_executions[1].agent_session_id
         );
 
-        host.submit(&first.id).await.unwrap();
+        assert!(host.submit(&first.id).await.is_err());
         emit_provider_stop(
             &host,
             &mut first_terminal,
@@ -951,13 +951,14 @@ async fn test_issue_1626_active_attemptへの再submitはartifactを差し替え
         3
     );
 
-    host.submit_artifact(
-        &node.id,
-        "acceptance-result",
-        serde_json::json!({"result": "terminal replacement"}),
-    )
-    .await
-    .unwrap();
+    assert!(host
+        .submit_artifact(
+            &node.id,
+            "acceptance-result",
+            serde_json::json!({"result": "terminal replacement"}),
+        )
+        .await
+        .is_err());
     let after_terminal_submit = host.execution(&execution_id).await.unwrap().unwrap();
     assert_eq!(
         after_terminal_submit.node_executions[0].artifact.as_ref(),

--- a/src-tauri/tests/workflow_control_plane_acceptance_test.rs
+++ b/src-tauri/tests/workflow_control_plane_acceptance_test.rs
@@ -816,6 +816,166 @@ async fn test_atui_042_別bindingのstopを拒否しinvalid_artifactはsubmitご
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_issue_1626_active_attemptへの再submitはartifactを差し替える() {
+    let root = tempfile::TempDir::new().unwrap();
+    let worktree = root.path().join("resubmit-artifact-worktree");
+    std::fs::create_dir_all(&worktree).unwrap();
+    let worktree = worktree.to_string_lossy().into_owned();
+    let host = host(root.path(), 8);
+    let execution_id = host
+        .start_approval_artifact_workflow(&worktree, AcceptanceProvider::Claude)
+        .await
+        .unwrap();
+    let initial = wait_for_node_count(&host, &execution_id, 1).await;
+    let node = initial.node_executions[0].clone();
+    let terminal_owner = owner(&worktree, node.agent_session_id.as_deref().unwrap());
+    let mut terminal = host
+        .terminal()
+        .attach("issue-1626-resubmit".to_string(), terminal_owner.clone())
+        .unwrap();
+    receive_until(&mut terminal, "releash-fixture-input-complete-0").await;
+    associate_provider_session(&host, &mut terminal, &terminal_owner, "provider-resubmit").await;
+
+    host.submit_artifact(
+        &node.id,
+        "acceptance-result",
+        serde_json::json!({"result": "first"}),
+    )
+    .await
+    .unwrap();
+    host.submit_artifact(
+        &node.id,
+        "acceptance-result",
+        serde_json::json!({"result": "running replacement"}),
+    )
+    .await
+    .unwrap();
+
+    let after_running_replacement = host.execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(
+        after_running_replacement.node_executions[0].status,
+        AcceptanceNodeExecutionStatus::Running
+    );
+    assert_eq!(
+        after_running_replacement.node_executions[0]
+            .artifact
+            .as_ref(),
+        Some(&serde_json::json!({"result": "running replacement"}))
+    );
+    let after_running_log = host.workflow_log(&execution_id).await.unwrap();
+    assert_eq!(
+        after_running_log
+            .iter()
+            .filter(|event| event["event"] == "node_submit_received")
+            .count(),
+        1
+    );
+    assert_eq!(
+        after_running_log
+            .iter()
+            .filter(|event| event["event"] == "artifact_produced")
+            .count(),
+        2
+    );
+
+    assert!(host
+        .submit_artifact(
+            &node.id,
+            "acceptance-result",
+            serde_json::json!({"unexpected": "invalid replacement"}),
+        )
+        .await
+        .is_err());
+    let after_invalid = host.execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(
+        after_invalid.node_executions[0].artifact.as_ref(),
+        Some(&serde_json::json!({"result": "running replacement"}))
+    );
+    assert_eq!(
+        host.workflow_log(&execution_id)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|event| event["event"] == "artifact_produced")
+            .count(),
+        2
+    );
+
+    emit_provider_stop(&host, &mut terminal, &terminal_owner, "provider-resubmit").await;
+    let waiting = host.execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(
+        waiting.node_executions[0].status,
+        AcceptanceNodeExecutionStatus::WaitingApproval
+    );
+
+    host.submit_artifact(
+        &node.id,
+        "acceptance-result",
+        serde_json::json!({"result": "waiting replacement"}),
+    )
+    .await
+    .unwrap();
+    let after_waiting_replacement = host.execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(
+        after_waiting_replacement.node_executions[0].status,
+        AcceptanceNodeExecutionStatus::WaitingApproval
+    );
+    assert_eq!(
+        after_waiting_replacement.node_executions[0]
+            .artifact
+            .as_ref(),
+        Some(&serde_json::json!({"result": "waiting replacement"}))
+    );
+
+    host.approve(&execution_id, &node.node_name, &node.id)
+        .await
+        .unwrap();
+    wait_for_execution_status(
+        &host,
+        &execution_id,
+        AcceptanceWorkflowExecutionStatus::Completed,
+    )
+    .await;
+    let completed = host.execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(
+        completed.node_executions[0].artifact.as_ref(),
+        Some(&serde_json::json!({"result": "waiting replacement"}))
+    );
+    assert_eq!(
+        host.workflow_log(&execution_id)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|event| event["event"] == "artifact_produced")
+            .count(),
+        3
+    );
+
+    host.submit_artifact(
+        &node.id,
+        "acceptance-result",
+        serde_json::json!({"result": "terminal replacement"}),
+    )
+    .await
+    .unwrap();
+    let after_terminal_submit = host.execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(
+        after_terminal_submit.node_executions[0].artifact.as_ref(),
+        Some(&serde_json::json!({"result": "waiting replacement"}))
+    );
+    assert_eq!(
+        host.workflow_log(&execution_id)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|event| event["event"] == "artifact_produced")
+            .count(),
+        3
+    );
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_atui_042_workflow完了後もagent_sessionとptyを維持し追加stopで再進行しない() {
     let root = tempfile::TempDir::new().unwrap();
     let worktree = root.path().join("worktree");


### PR DESCRIPTION
## 概要

- Running / Paused / WaitingApproval の同一Attemptへの再Submitで、検証済みArtifactを差し替える
- Submit信号の一度きり遷移とArtifact更新を分離し、WaitingApprovalとcompletion handshakeを維持する
- invalid Artifact、終端Attempt、MS87の重複Submit仕様を受け入れテストと仕様文書で固定する

## テスト

- cargo fmt --check
- cargo clippy --locked -- -D warnings
- cargo test --locked

Closes #1626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 承認付きアーティファクトワークフローを追加しました。
  - 実行結果としてアーティファクトを確認・取得できるようになりました。
  - ワークフローの実行ログを取得できるようになりました。

- **バグ修正**
  - 実行中または承認待ちの処理では、有効なアーティファクトの再送信で成果物を更新できるようになりました。
  - 無効な再送信や完了後の再送信は、既存の状態や成果物を変更せず適切に処理されます。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->