### PR TITLE
fix(workflow): artifact宣言なしAgent NodeにSubmit指示を注入する

### DIFF
--- a/docs/workflow-engine-evolution-plan.md
+++ b/docs/workflow-engine-evolution-plan.md
@@ -122,11 +122,11 @@ CLI の更新操作は Tauri アプリ内の token-authenticated localhost API �
 
 ```sh
 releash workflow status <execution-id>
-releash workflow output submit <execution-id> --node <node-name> [--node-execution <id>] --type <contract> --json '<json>'
+releash workflow output submit --node-execution <id> --type <contract> --json '<json>'
 releash workflow output get <execution-id> --node <node-name>
 ```
 
-fanout で同名 NodeExecution が複数 active な場合は `node_execution_id` が必要。session 内の CLI は engine が注入する実行 ID を既定値に使う。
+Submitは通常Nodeとfanout childを区別せず、`node_execution_id`だけで対象を識別する。
 
 ## UI 方針
 

--- a/specs/milestone-87-agent-tui-cutover/issue-1598-workflow-control-plane.md
+++ b/specs/milestone-87-agent-tui-cutover/issue-1598-workflow-control-plane.md
@@ -117,7 +117,7 @@ ReleashはWorkflow ledgerを正本として、signalの受信、Artifact、Appro
 
 ## 5. Signal correlation
 
-- SubmitはWorkflowExecution ID、Node名、NodeExecution IDを必須入力として対象を特定する。
+- SubmitはNodeExecution IDだけを必須入力として対象を特定し、WorkflowExecution IDとNode名はbackendが永続化投影から解決する。
 - SubmitのNodeExecution IDは現在対象となるAttemptと一致しなければならない。
 - Provider Stopは検証済みAgentSession IDからAgentSession originを読み、WorkflowExecution IDとNodeExecution IDを解決する。
 - Standalone AgentSessionのStopはProvider lifecycle ledgerだけへ保存し、Workflowへ適用しない。
@@ -225,33 +225,31 @@ Provider lifecycle ledgerだけにStopが残りWorkflowへ適用されない中�
 Artifactなし:
 
 ```bash
-releash workflow output submit EXECUTION_ID \
-  --node NODE_NAME \
+releash workflow output submit \
   --node-execution NODE_EXECUTION_ID
 ```
 
 Artifactあり:
 
 ```bash
-releash workflow output submit EXECUTION_ID \
-  --node NODE_NAME \
+releash workflow output submit \
   --node-execution NODE_EXECUTION_ID \
   --type CONTRACT \
   --json JSON_VALUE
 ```
 
-- `--node-execution`は必須とする。
+- `--node-execution`はSubmit対象を一意に識別する唯一の必須identityとする。
 - Artifact指定時は`--type`と`--json`または`--file`を全て要求する。
 - Artifact未指定時は`--type`、`--json`、`--file`を要求しない。
 - `workflow output get`はArtifact取得のまま維持する。
 
 ### 8.2 Local API
 
-Local API requestはArtifact提出ではなくNode Submitを表す。requestは必須NodeExecution IDとoptional Artifactを持つ。ControllerはprotocolをUsecase commandへ変換するだけとし、signal合流、validation結果による遷移、current Attempt判定を行わない。
+Local API requestはArtifact提出ではなくNode Submitを表す。NodeExecution IDはpathで必須とし、request bodyはoptional Artifactだけを持つ。ControllerはprotocolをUsecase commandへ変換するだけとし、signal合流、validation結果による遷移、current Attempt判定を行わない。
 
 ### 8.3 Initial instruction
 
-通常Agent NodeとFanout Agent Nodeの両方へ、WorkflowExecution ID、Node名、NodeExecution IDを含む正確なSubmit commandを初回指示として渡す。Artifact contractがないNodeにもArtifactなしSubmitの指示を渡す。
+通常Agent NodeとFanout Agent Nodeの両方へ、NodeExecution IDだけで対象を識別する正確なSubmit commandを初回指示として渡す。Artifact contractがないNodeにもArtifactなしSubmitの指示を渡す。
 
 ## 9. Read model / TUI
 

--- a/src-tauri/src/adaptor/controller/api/mod.rs
+++ b/src-tauri/src/adaptor/controller/api/mod.rs
@@ -65,6 +65,7 @@ fn authenticated_with_tokens(router: Router, tokens: auth::AcceptedBearerTokens)
 
 #[cfg(test)]
 pub(crate) mod test_support {
+    use std::collections::HashMap;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::{Arc, Mutex};
@@ -125,6 +126,7 @@ pub(crate) mod test_support {
     #[derive(Default)]
     pub(crate) struct RecordingRuntimeGateway {
         pub(crate) commands: Mutex<RecordedRuntimeCommands>,
+        node_execution_owners: Mutex<HashMap<String, String>>,
         workflow_resolution: Mutex<Option<(PathBuf, PathBuf)>>,
         output_persistence_data_dir: Mutex<Option<PathBuf>>,
         errors: Mutex<RecordedRuntimeErrors>,
@@ -137,6 +139,13 @@ pub(crate) mod test_support {
             facets_base_dir: PathBuf,
         ) {
             *self.workflow_resolution.lock().unwrap() = Some((workflows_dir, facets_base_dir));
+        }
+
+        pub(crate) fn bind_node_execution(&self, node_execution_id: &str, execution_id: &str) {
+            self.node_execution_owners
+                .lock()
+                .unwrap()
+                .insert(node_execution_id.to_string(), execution_id.to_string());
         }
 
         fn persist_submitted_outputs_to(&self, data_dir: PathBuf) {
@@ -348,6 +357,18 @@ pub(crate) mod test_support {
             "node-execution-next".to_string()
         }
 
+        async fn resolve_workflow_execution_id(
+            &self,
+            node_execution_id: &str,
+        ) -> Result<Option<String>, WorkflowError> {
+            Ok(self
+                .node_execution_owners
+                .lock()
+                .unwrap()
+                .get(node_execution_id)
+                .cloned())
+        }
+
         async fn load_active_execution(
             &self,
             execution_id: &str,
@@ -441,16 +462,18 @@ pub(crate) mod test_support {
                         }
                         _ => None,
                     });
-                    Some(SubmitOutputCommand {
-                        execution_id: execution_id.clone(),
+                    Some((
+                        SubmitOutputCommand {
+                            node_execution_id: node_execution_id.clone(),
+                            artifact,
+                        },
+                        execution_id.clone(),
                         node_name,
-                        node_execution_id: node_execution_id.clone(),
-                        artifact,
-                    })
+                    ))
                 }
                 _ => None,
             });
-            if let Some(command) = submit {
+            if let Some((command, execution_id, node_name)) = submit {
                 if let (Some(data_dir), Some(artifact)) = (
                     self.output_persistence_data_dir.lock().unwrap().clone(),
                     command.artifact.as_ref(),
@@ -458,12 +481,12 @@ pub(crate) mod test_support {
                     append_canonical_workflow_drafts(
                         &data_dir,
                         &[WorkflowEventDraft {
-                            execution_id: command.execution_id.clone(),
+                            execution_id,
                             event_kind: "artifact_produced".to_string(),
                             timestamp: 110.0,
                             payload: serde_json::json!({
                                 "node_execution_id": command.node_execution_id,
-                                "node_name": command.node_name,
+                                "node_name": node_name,
                                 "contract": artifact.contract,
                                 "value": artifact.value,
                                 "submitted_at": 109.0,
@@ -916,7 +939,7 @@ pub(crate) mod test_support {
             ),
             (
                 Method::POST,
-                format!("/v1/workflow/executions/{execution_id}/submit"),
+                "/v1/workflow/node-executions/ne-review-2/submit".to_string(),
             ),
             (
                 Method::POST,
@@ -954,6 +977,7 @@ pub(crate) mod test_support {
         let directory = tempfile::tempdir().unwrap();
         let (router, _, gateway) = test_router(directory.path(), "secret");
         let execution_id = "00000000-0000-4000-8000-000000000123";
+        gateway.bind_node_execution("ne-review-2", execution_id);
         let start = send_json(
             &router,
             "/v1/workflow/executions",
@@ -1039,10 +1063,8 @@ pub(crate) mod test_support {
 
         let submit = send_json(
             &router,
-            &format!("/v1/workflow/executions/{execution_id}/submit"),
+            "/v1/workflow/node-executions/ne-review-2/submit",
             serde_json::json!({
-                "node": "review",
-                "node_execution_id": "ne-review-2",
                 "artifact": {
                     "contract": "review-result",
                     "value": {"status": "approved"}
@@ -1089,8 +1111,6 @@ pub(crate) mod test_support {
         assert_eq!(commands.retries[0].node_execution_id, "ne-review-2");
 
         assert_eq!(commands.outputs.len(), 1);
-        assert_eq!(commands.outputs[0].execution_id, execution_id);
-        assert_eq!(commands.outputs[0].node_name, "review");
         assert_eq!(commands.outputs[0].node_execution_id, "ne-review-2");
         let artifact = commands.outputs[0].artifact.as_ref().unwrap();
         assert_eq!(artifact.contract, "review-result");
@@ -1165,12 +1185,11 @@ pub(crate) mod test_support {
 
         gateway.errors.lock().unwrap().output =
             Some(WorkflowError::NotFound("execution not found".to_string()));
+        gateway.bind_node_execution("ne-review-1", execution_id);
         let output = send_json(
             &router,
-            &format!("/v1/workflow/executions/{execution_id}/submit"),
+            "/v1/workflow/node-executions/ne-review-1/submit",
             serde_json::json!({
-                "node": "review",
-                "node_execution_id": "ne-review-1",
                 "artifact": {
                     "contract": "review-result",
                     "value": {"status": "approved"}
@@ -1187,14 +1206,23 @@ pub(crate) mod test_support {
         let directory = tempfile::tempdir().unwrap();
         let (router, _, gateway) = test_router(directory.path(), "secret");
         let execution_id = "00000000-0000-4000-8000-000000000123";
+        gateway.bind_node_execution("ne-review-2", execution_id);
 
-        let response = send_json(
+        let legacy_identity_fields = send_json(
             &router,
-            &format!("/v1/workflow/executions/{execution_id}/submit"),
+            "/v1/workflow/node-executions/ne-review-2/submit",
             serde_json::json!({
                 "node": "review",
                 "node_execution_id": "ne-review-2"
             }),
+        )
+        .await;
+        assert_eq!(legacy_identity_fields.0, StatusCode::BAD_REQUEST);
+
+        let response = send_json(
+            &router,
+            "/v1/workflow/node-executions/ne-review-2/submit",
+            serde_json::json!({}),
         )
         .await;
 
@@ -1318,13 +1346,12 @@ pub(crate) mod test_support {
         .unwrap();
         let (router, _, gateway) = test_router(directory.path(), "secret");
         gateway.persist_submitted_outputs_to(directory.path().to_path_buf());
+        gateway.bind_node_execution("ne-review-2", execution_id);
 
         let submit = send_json(
             &router,
-            &format!("/v1/workflow/executions/{execution_id}/submit"),
+            "/v1/workflow/node-executions/ne-review-2/submit",
             serde_json::json!({
-                "node": "review",
-                "node_execution_id": "ne-review-2",
                 "artifact": {
                     "contract": "review-result",
                     "value": {"status": "approved"}

--- a/src-tauri/src/adaptor/controller/api/protocol.rs
+++ b/src-tauri/src/adaptor/controller/api/protocol.rs
@@ -37,8 +37,6 @@ pub(crate) struct SubmitOutputArtifactRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct SubmitOutputRequest {
-    pub(crate) node: String,
-    pub(crate) node_execution_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) artifact: Option<SubmitOutputArtifactRequest>,
 }

--- a/src-tauri/src/adaptor/controller/api/workflow.rs
+++ b/src-tauri/src/adaptor/controller/api/workflow.rs
@@ -81,7 +81,7 @@ pub(super) fn router() -> Router<LocalApiState> {
             post(retry_node),
         )
         .route(
-            "/v1/workflow/executions/{execution_id}/submit",
+            "/v1/workflow/node-executions/{node_execution_id}/submit",
             post(submit_output),
         )
         .route(
@@ -233,16 +233,14 @@ async fn retry_node(
 
 async fn submit_output(
     State(state): State<LocalApiState>,
-    Path(execution_id): Path<String>,
+    Path(node_execution_id): Path<String>,
     payload: Result<Json<SubmitOutputRequest>, JsonRejection>,
 ) -> Result<Json<MutationResponse>, ApiError> {
     let Json(payload) = payload.map_err(|error| ApiError::invalid_request(error.body_text()))?;
     state
         .runtime
         .submit_output(SubmitOutputCommand {
-            execution_id,
-            node_name: payload.node,
-            node_execution_id: payload.node_execution_id,
+            node_execution_id,
             artifact: payload.artifact.map(|artifact| SubmitOutputArtifact {
                 contract: artifact.contract,
                 value: artifact.value,

--- a/src-tauri/src/adaptor/controller/command/workflow/output.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/output.rs
@@ -30,29 +30,44 @@ async fn authorize_output_execution_access(
     .map_err(|e| format!("task join error: {e}"))?
 }
 
-/// [08] Tauri command 経路: node に対する構造化出力を typed 提出する。
+async fn authorize_output_node_execution_access(
+    query: &Arc<crate::usecase::workflow::WorkflowUsecase>,
+    worktree_path: String,
+    node_execution_id: &str,
+) -> Result<(), String> {
+    let query = query.clone();
+    let node_execution_id = node_execution_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        query
+            .authorize_node_execution_access_for_worktree(&node_execution_id, &worktree_path)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))?
+}
+
+/// Tauri command 経路: NodeExecutionにSubmit signalとoptional Artifactを提出する。
 ///
 /// in-process caller (UI / API / 外部 Tauri caller) は workflow runtime usecase
 /// を経由して、CLI 経路と同一の state mutation 境界に合流する（spec [08] L169）。
 /// worktree-scoped 認可境界（spec [08] が依拠する [05] 観測経路の認可境界）を通過しない caller には
 /// 「該当 execution なし」と同表現で拒否を返し、存在情報を漏らさない。
 #[tauri::command]
-#[allow(clippy::too_many_arguments)]
 pub async fn workflow_submit_output(
     state: tauri::State<'_, AppState>,
     runtime: tauri::State<'_, Arc<WorkflowRuntimeUsecase>>,
     worktree_path: String,
-    execution_id: String,
-    node_name: String,
     node_execution_id: String,
     artifact: Option<WorkflowSubmitArtifactInput>,
 ) -> Result<(), String> {
-    authorize_output_execution_access(&state.workflow_usecase, worktree_path, &execution_id)
-        .await?;
+    authorize_output_node_execution_access(
+        &state.workflow_usecase,
+        worktree_path,
+        &node_execution_id,
+    )
+    .await?;
     runtime
         .submit_output(SubmitOutputCommand {
-            execution_id,
-            node_name,
             node_execution_id,
             artifact: artifact.map(|artifact| SubmitOutputArtifact {
                 contract: artifact.contract,

--- a/src-tauri/src/adaptor/gateway/local_event_store/reader.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/reader.rs
@@ -329,6 +329,11 @@ pub(crate) fn run_query_in_recovery_snapshot(
                 session_projection_by_identity(connection, session_id)?,
             ))
         }
+        LocalEventQuery::WorkflowExecutionByNodeExecution { node_execution_id } => {
+            Ok(LocalEventQueryResult::WorkflowExecutionByNodeExecution(
+                workflow_execution_by_node_execution(connection, node_execution_id)?,
+            ))
+        }
         LocalEventQuery::AgentSessionProjectionPage {
             workspace_identity,
             lifecycle,
@@ -427,6 +432,24 @@ pub(crate) fn run_query_in_recovery_snapshot(
             cursor.as_ref(),
         )?)),
     }
+}
+
+fn workflow_execution_by_node_execution(
+    connection: &Connection,
+    node_execution_id: &str,
+) -> Result<Option<String>, LocalEventQueryError> {
+    if node_execution_id.trim().is_empty() {
+        return Err(LocalEventQueryError::InvalidRequest);
+    }
+    connection
+        .query_row(
+            "SELECT execution_id FROM workflow_execution_nodes
+             WHERE node_execution_id = ?1",
+            params![node_execution_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| storage_unavailable(&error))
 }
 
 fn operation_binding_by_identity(
@@ -2445,6 +2468,35 @@ mod canonical_runtime_owner_snapshot_tests {
         assert_eq!(
             canonical_runtime_owner_snapshot(&connection, 1),
             Err(LocalEventQueryError::ResponseTooLarge)
+        );
+    }
+
+    #[test]
+    fn node_execution_identity_resolves_its_workflow_execution() {
+        let connection = Connection::open_in_memory().expect("in-memory SQLite");
+        connection
+            .execute_batch(
+                "CREATE TABLE workflow_execution_nodes (
+                     execution_id TEXT NOT NULL,
+                     node_execution_id TEXT UNIQUE
+                 );
+                 INSERT INTO workflow_execution_nodes
+                     (execution_id, node_execution_id)
+                 VALUES ('execution-1', 'node-execution-1');",
+            )
+            .unwrap();
+
+        assert_eq!(
+            workflow_execution_by_node_execution(&connection, "node-execution-1").unwrap(),
+            Some("execution-1".to_string())
+        );
+        assert_eq!(
+            workflow_execution_by_node_execution(&connection, "missing").unwrap(),
+            None
+        );
+        assert_eq!(
+            workflow_execution_by_node_execution(&connection, ""),
+            Err(LocalEventQueryError::InvalidRequest)
         );
     }
 }

--- a/src-tauri/src/adaptor/gateway/local_event_store/schema.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/schema.rs
@@ -7,7 +7,7 @@ use super::fault::{FaultInjector, InitialCreateFaultPoint};
 /// Minimum SQLite version containing the WAL-reset corruption fix.
 pub const MIN_SQLITE_VERSION_NUMBER: i32 = 3_051_003;
 pub const APPLICATION_ID: i32 = 0x524C_5348;
-pub const CURRENT_SCHEMA_VERSION: i64 = 3;
+pub const CURRENT_SCHEMA_VERSION: i64 = 4;
 
 pub const CURRENT_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS logical_commits (
@@ -270,6 +270,12 @@ CREATE INDEX IF NOT EXISTS idx_session_projection_public_node
     WHERE public_summary IS NOT NULL;
 "#;
 
+const NODE_EXECUTION_IDENTITY_V4: &str = r#"
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_execution_nodes_node_execution
+    ON workflow_execution_nodes (node_execution_id)
+    WHERE node_execution_id IS NOT NULL;
+"#;
+
 const SESSION_PROJECTION_TABLE_V3: &str = r#"
 CREATE TABLE IF NOT EXISTS session_projection (
     session_id TEXT PRIMARY KEY,
@@ -314,7 +320,7 @@ fn create_store_metadata(
 ) -> Result<(), rusqlite::Error> {
     if !matches!(table_name, "store_metadata" | "store_metadata_v2")
         || !matches!(shutdown_plans_table, "shutdown_plans" | "shutdown_plans_v2")
-        || !matches!(schema_version, 2 | 3)
+        || !matches!(schema_version, 2..=4)
     {
         return Err(rusqlite::Error::InvalidQuery);
     }
@@ -357,15 +363,16 @@ pub fn initialize_schema(
     if let Err(error) = (|| {
         connection.execute_batch(CURRENT_SCHEMA)?;
         connection.execute_batch(SESSION_PROJECTION_TABLE_V3)?;
-        create_store_metadata(connection, "store_metadata", "shutdown_plans", 3)?;
+        create_store_metadata(connection, "store_metadata", "shutdown_plans", 4)?;
         connection.execute_batch(WORKSPACE_QUERY_RECORDS_V3)?;
+        connection.execute_batch(NODE_EXECUTION_IDENTITY_V4)?;
         connection.execute(
             "INSERT INTO store_metadata (
                 id, schema_version, installation_id, created_at_ms,
                 cursor_hmac_key, operation_binding_hmac_key, process_instance_id,
                 next_global_sequence, health, current_shutdown_id,
                 shutdown_pointer_revision
-             ) VALUES (1, 3, ?1, ?2, ?3, ?4, ?5, 1, 'ok',
+             ) VALUES (1, 4, ?1, ?2, ?3, ?4, ?5, 1, 'ok',
                        NULL, 0)",
             rusqlite::params![
                 metadata.installation_id,
@@ -424,6 +431,57 @@ pub fn evolve_schema(
         return Ok(false);
     }
 
+    let is_supported_v3 = application_id == i64::from(APPLICATION_ID)
+        && user_version == 3
+        && metadata_columns
+            .iter()
+            .any(|column| column == "installation_id")
+        && !metadata_columns.iter().any(|column| column == "store_id");
+    if is_supported_v3 {
+        if fault.take_schema_fail_before_begin() {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+        connection.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
+        let evolution = (|| {
+            connection.execute_batch("ALTER TABLE store_metadata RENAME TO store_metadata_v3;")?;
+            create_store_metadata(connection, "store_metadata", "shutdown_plans", 4)?;
+            connection.execute_batch(
+                "INSERT INTO store_metadata (
+                     id, schema_version, installation_id, created_at_ms,
+                     cursor_hmac_key, operation_binding_hmac_key,
+                     process_instance_id, next_global_sequence, health,
+                     current_shutdown_id, shutdown_pointer_revision
+                 )
+                 SELECT id, 4, installation_id, created_at_ms,
+                        cursor_hmac_key, operation_binding_hmac_key,
+                        process_instance_id, next_global_sequence, health,
+                        current_shutdown_id, shutdown_pointer_revision
+                 FROM store_metadata_v3;
+                 DROP TABLE store_metadata_v3;",
+            )?;
+            connection.execute_batch(NODE_EXECUTION_IDENTITY_V4)?;
+            connection.pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION)?;
+            if fault.take_schema_fail_before_commit() {
+                return Err(rusqlite::Error::InvalidQuery);
+            }
+            Ok::<(), rusqlite::Error>(())
+        })();
+        if let Err(error) = evolution {
+            let _ = connection.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
+            return Err(error);
+        }
+        connection.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
+        if fault.take_schema_commit_reply_loss() {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+        if fault.take_schema_fail_before_readback() {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+        validate_current_schema(connection)?;
+        finish_schema_admission(connection)?;
+        return Ok(true);
+    }
+
     let is_supported_v2 = application_id == i64::from(APPLICATION_ID)
         && user_version == 2
         && metadata_columns
@@ -437,7 +495,7 @@ pub fn evolve_schema(
         connection.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
         let evolution = (|| {
             connection.execute_batch("ALTER TABLE store_metadata RENAME TO store_metadata_v2;")?;
-            create_store_metadata(connection, "store_metadata", "shutdown_plans", 3)?;
+            create_store_metadata(connection, "store_metadata", "shutdown_plans", 4)?;
             connection.execute_batch(
                 "INSERT INTO store_metadata (
                      id, schema_version, installation_id, created_at_ms,
@@ -445,7 +503,7 @@ pub fn evolve_schema(
                      process_instance_id, next_global_sequence, health,
                      current_shutdown_id, shutdown_pointer_revision
                  )
-                 SELECT id, 3, installation_id, created_at_ms,
+                 SELECT id, 4, installation_id, created_at_ms,
                         cursor_hmac_key, operation_binding_hmac_key,
                         process_instance_id, next_global_sequence, health,
                         current_shutdown_id, shutdown_pointer_revision
@@ -455,6 +513,7 @@ pub fn evolve_schema(
             evolve_session_projection_v3(connection)?;
             connection.execute_batch(WORKSPACE_QUERY_RECORDS_V3)?;
             super::workspace_query_migration::rebuild_workspace_query_records(connection)?;
+            connection.execute_batch(NODE_EXECUTION_IDENTITY_V4)?;
             connection.pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION)?;
             if fault.take_schema_fail_before_commit() {
                 return Err(rusqlite::Error::InvalidQuery);
@@ -670,7 +729,7 @@ pub fn evolve_schema(
                  ON shutdown_plans (details_state);
              PRAGMA application_id = 0x524C5348;",
         )?;
-        create_store_metadata(connection, "store_metadata", "shutdown_plans", 3)?;
+        create_store_metadata(connection, "store_metadata", "shutdown_plans", 4)?;
         connection.execute_batch(
             "INSERT INTO store_metadata (
                  id, schema_version, installation_id, created_at_ms,
@@ -678,7 +737,7 @@ pub fn evolve_schema(
                  next_global_sequence, health, current_shutdown_id,
                  shutdown_pointer_revision
              )
-             SELECT id, 3, generation_id, created_at_ms,
+             SELECT id, 4, generation_id, created_at_ms,
                     cursor_hmac_key, operation_binding_hmac_key, boot_id,
                     next_global_sequence, 'ok', current_shutdown_plan_id,
                     shutdown_pointer_revision
@@ -688,6 +747,7 @@ pub fn evolve_schema(
         evolve_session_projection_v3(connection)?;
         connection.execute_batch(WORKSPACE_QUERY_RECORDS_V3)?;
         super::workspace_query_migration::rebuild_workspace_query_records(connection)?;
+        connection.execute_batch(NODE_EXECUTION_IDENTITY_V4)?;
         connection.pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION)?;
         if fault.take_schema_fail_before_commit() {
             return Err(rusqlite::Error::InvalidQuery);
@@ -916,6 +976,7 @@ pub fn validate_current_schema(connection: &Connection) -> Result<(), rusqlite::
         "idx_workflow_executions_global_list",
         "idx_workflow_execution_nodes_node",
         "idx_workflow_execution_nodes_occurrence",
+        "idx_workflow_execution_nodes_node_execution",
         "idx_workflow_execution_nodes_session",
         "idx_session_projection_public_list",
         "idx_session_projection_public_node",
@@ -1128,4 +1189,102 @@ fn table_columns(connection: &Connection, table: &str) -> Result<Vec<String>, ru
         .query_map([], |row| row.get::<_, String>(1))?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(columns)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata() -> InitialStoreMetadata<'static> {
+        InitialStoreMetadata {
+            installation_id: "00000000-0000-4000-8000-000000000001",
+            cursor_hmac_key: &[1; 32],
+            operation_binding_hmac_key: &[2; 32],
+            process_instance_id: "00000000-0000-4000-8000-000000000002",
+            created_at_ms: 1,
+        }
+    }
+
+    fn initialize(connection: &Connection) {
+        initialize_schema(connection, &metadata(), &FaultInjector::new()).unwrap();
+    }
+
+    #[test]
+    fn schema_v3_evolves_to_global_node_execution_identity() {
+        let connection = Connection::open_in_memory().unwrap();
+        initialize(&connection);
+        connection
+            .execute_batch(
+                "BEGIN IMMEDIATE;
+                 DROP INDEX idx_workflow_execution_nodes_node_execution;
+                 ALTER TABLE store_metadata RENAME TO store_metadata_v4;",
+            )
+            .unwrap();
+        create_store_metadata(&connection, "store_metadata", "shutdown_plans", 3).unwrap();
+        connection
+            .execute_batch(
+                "INSERT INTO store_metadata (
+                     id, schema_version, installation_id, created_at_ms,
+                     cursor_hmac_key, operation_binding_hmac_key,
+                     process_instance_id, next_global_sequence, health,
+                     current_shutdown_id, shutdown_pointer_revision
+                 )
+                 SELECT id, 3, installation_id, created_at_ms,
+                        cursor_hmac_key, operation_binding_hmac_key,
+                        process_instance_id, next_global_sequence, health,
+                        current_shutdown_id, shutdown_pointer_revision
+                 FROM store_metadata_v4;
+                 DROP TABLE store_metadata_v4;
+                 PRAGMA user_version = 3;
+                 COMMIT;",
+            )
+            .unwrap();
+
+        assert!(evolve_schema(&connection, &FaultInjector::new()).unwrap());
+        validate_current_schema(&connection).unwrap();
+        require_index(&connection, "idx_workflow_execution_nodes_node_execution").unwrap();
+    }
+
+    #[test]
+    fn node_execution_identity_is_unique_across_workflow_executions() {
+        let connection = Connection::open_in_memory().unwrap();
+        initialize(&connection);
+        connection
+            .execute_batch("PRAGMA foreign_keys = OFF;")
+            .unwrap();
+        for execution_id in ["execution-1", "execution-2"] {
+            connection
+                .execute(
+                    "INSERT INTO workflow_executions (
+                         execution_id, workspace_identity, status, list_kind,
+                         sort_at_bits, record_schema, record, source_revision, commit_id
+                     ) VALUES (?1, ?2, 'running', 'active', 0,
+                               'workflow_execution_record_v1', '{}', 0, 'commit')",
+                    rusqlite::params![execution_id, format!("/{execution_id}")],
+                )
+                .unwrap();
+        }
+        connection
+            .execute(
+                "INSERT INTO workflow_execution_nodes (
+                     execution_id, node_id, parent_id, sibling_order, session_id,
+                     node_execution_id, record_schema, tree_record, detail_record,
+                     source_revision, commit_id
+                 ) VALUES ('execution-1', 'node-1', NULL, 0, NULL, 'node-execution-1',
+                           'workflow_execution_node_record_v1', '{}', '{}', 0, 'commit')",
+                [],
+            )
+            .unwrap();
+
+        let duplicate = connection.execute(
+            "INSERT INTO workflow_execution_nodes (
+                 execution_id, node_id, parent_id, sibling_order, session_id,
+                 node_execution_id, record_schema, tree_record, detail_record,
+                 source_revision, commit_id
+             ) VALUES ('execution-2', 'node-2', NULL, 0, NULL, 'node-execution-1',
+                       'workflow_execution_node_record_v1', '{}', '{}', 0, 'commit')",
+            [],
+        );
+        assert!(duplicate.is_err());
+    }
 }

--- a/src-tauri/src/adaptor/gateway/local_event_store/store.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/store.rs
@@ -249,6 +249,7 @@ enum ExistingDatabaseKind {
     Current,
     SupportedV1,
     SupportedV2,
+    SupportedV3,
 }
 
 fn classify_existing_database(
@@ -313,11 +314,15 @@ fn classify_existing_database(
         return Ok(ExistingDatabaseKind::SupportedV1);
     }
     if application_id == i64::from(APPLICATION_ID) {
-        if user_version == 2
+        if matches!(user_version, 2 | 3)
             && columns.iter().any(|column| column == "installation_id")
             && !columns.iter().any(|column| column == "store_id")
         {
-            return Ok(ExistingDatabaseKind::SupportedV2);
+            return Ok(if user_version == 2 {
+                ExistingDatabaseKind::SupportedV2
+            } else {
+                ExistingDatabaseKind::SupportedV3
+            });
         }
         if user_version != CURRENT_SCHEMA_VERSION {
             return Err(LocalEventStoreOpenError::UnsupportedStoreVersion);
@@ -559,7 +564,9 @@ impl LocalEventStore {
                 })?;
                 if matches!(
                     kind,
-                    ExistingDatabaseKind::SupportedV1 | ExistingDatabaseKind::SupportedV2
+                    ExistingDatabaseKind::SupportedV1
+                        | ExistingDatabaseKind::SupportedV2
+                        | ExistingDatabaseKind::SupportedV3
                 ) {
                     evolve_schema(&connection, config.fault.as_ref()).map_err(|error| {
                         classify_sqlite_error(

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_command_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_command_gateway.rs
@@ -358,6 +358,29 @@ impl<R: tauri::Runtime> WorkflowControlPlaneGateway for TauriWorkflowRuntimeComm
         uuid::Uuid::new_v4().to_string()
     }
 
+    async fn resolve_workflow_execution_id(
+        &self,
+        node_execution_id: &str,
+    ) -> Result<Option<String>, WorkflowError> {
+        let result = self
+            .local_event_repository
+            .query(
+                crate::domain::local_event::LocalEventQuery::WorkflowExecutionByNodeExecution {
+                    node_execution_id: node_execution_id.to_string(),
+                },
+            )
+            .await
+            .map_err(|error| WorkflowError::external(error.to_string()))?;
+        match result {
+            crate::domain::local_event::LocalEventQueryResult::WorkflowExecutionByNodeExecution(
+                execution_id,
+            ) => Ok(execution_id),
+            _ => Err(WorkflowError::external(
+                "unexpected node execution lookup result",
+            )),
+        }
+    }
+
     async fn load_active_execution(
         &self,
         execution_id: &str,

--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
@@ -2213,6 +2213,7 @@ impl WorkflowRuntimeHost {
             &node_clone,
             node_facet_contents,
             &execution_id_for_ref,
+            &node_execution_id,
             task_clone.as_deref(),
             &artifacts_clone,
             &workflow_clone.schemas,

--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
@@ -2212,7 +2212,6 @@ impl WorkflowRuntimeHost {
         let (system_prompt, prompt) = workflow_prompt::build_node_prompt(
             &node_clone,
             node_facet_contents,
-            &execution_id_for_ref,
             &node_execution_id,
             task_clone.as_deref(),
             &artifacts_clone,

--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host/prompt_rendering.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host/prompt_rendering.rs
@@ -145,8 +145,6 @@ pub(crate) fn append_completion_action(
     prompt: &mut String,
     artifact: Option<&str>,
     schemas: &BTreeMap<String, SchemaDef>,
-    execution_id: &str,
-    node_name: &str,
     node_execution_id: &str,
 ) {
     let (schema_guidance, action) = match artifact {
@@ -154,21 +152,13 @@ pub(crate) fn append_completion_action(
             let domain_schemas = schemas.clone();
             let schema_guidance =
                 workflow_contract::render_contract_prompt_guidance(&domain_schemas, contract);
-            let action = prompt_composition::artifact_completion_action(
-                contract,
-                execution_id,
-                node_name,
-                Some(node_execution_id),
-            );
+            let action =
+                prompt_composition::artifact_completion_action(contract, node_execution_id);
             (schema_guidance, action)
         }
         None => (
             None,
-            prompt_composition::artifactless_completion_action(
-                execution_id,
-                node_name,
-                node_execution_id,
-            ),
+            prompt_composition::artifactless_completion_action(node_execution_id),
         ),
     };
     if !prompt.is_empty() {
@@ -184,7 +174,6 @@ pub(crate) fn append_completion_action(
 pub(crate) fn build_node_prompt(
     node: &NodeDefinition,
     facet_contents: Option<&FacetContents>,
-    execution_id: &str,
     node_execution_id: &str,
     request: Option<&str>,
     artifacts: &HashMap<String, RuntimeArtifact>,
@@ -215,8 +204,6 @@ pub(crate) fn build_node_prompt(
         &mut prompt,
         node.artifact.as_deref(),
         schemas,
-        execution_id,
-        &node.name,
         node_execution_id,
     );
     Ok((system_prompt, prompt))
@@ -240,7 +227,6 @@ impl<'a> FanoutChildPromptContext<'a> {
 pub(crate) fn build_fanout_child_prompt(
     node: &NodeDefinition,
     facet_contents: Option<&FacetContents>,
-    execution_id: &str,
     request: Option<&str>,
     artifacts: &HashMap<String, RuntimeArtifact>,
     context: FanoutChildPromptContext<'_>,
@@ -265,8 +251,6 @@ pub(crate) fn build_fanout_child_prompt(
         &mut user_message,
         node.artifact.as_deref(),
         schemas,
-        execution_id,
-        &node.name,
         context.node_execution_id,
     );
 
@@ -322,7 +306,6 @@ mod tests {
         let error = build_node_prompt(
             &node,
             None,
-            "execution-1",
             "node-execution-1",
             None,
             &HashMap::new(),
@@ -359,7 +342,6 @@ mod tests {
         let (_system, prompt) = build_node_prompt(
             &node,
             Some(&resolved),
-            "execution-1",
             "node-execution-1",
             Some("ship"),
             &outputs,
@@ -395,7 +377,6 @@ mod tests {
         let (_system, prompt) = build_node_prompt(
             &node,
             Some(&resolved),
-            "execution-1",
             "node-execution-1",
             Some(""),
             &outputs,
@@ -416,7 +397,6 @@ mod tests {
         let (_system, prompt) = build_fanout_child_prompt(
             &node,
             Some(&resolved),
-            "execution-1",
             None,
             &HashMap::new(),
             FanoutChildPromptContext::new(Some(&item), "node-execution-1"),
@@ -453,7 +433,6 @@ mod tests {
         let (_system, prompt) = build_fanout_child_prompt(
             &node,
             Some(&resolved),
-            "execution-1",
             Some("ship"),
             &outputs,
             FanoutChildPromptContext::new(Some(&item), "node-execution-1"),
@@ -478,7 +457,6 @@ mod tests {
         let (_system, prompt) = build_node_prompt(
             &node,
             Some(&resolved),
-            "execution-1",
             "node-execution-1",
             None,
             &HashMap::new(),
@@ -486,8 +464,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(prompt.contains("releash workflow output submit execution-1"));
-        assert!(prompt.contains("--node review"));
+        assert!(prompt.contains("releash workflow output submit"));
+        assert!(!prompt.contains("--node review"));
         assert!(prompt.contains("--node-execution node-execution-1"));
         assert!(!prompt.contains("--type"));
         assert!(!prompt.contains("--json"));
@@ -512,7 +490,6 @@ mod tests {
         let (_system, prompt) = build_node_prompt(
             &node,
             Some(&resolved),
-            "execution-1",
             "node-execution-1",
             None,
             &HashMap::new(),
@@ -523,8 +500,8 @@ mod tests {
         assert!(prompt.contains("## Artifact contract"));
         assert!(prompt.contains("\"verdict\": \"string\""));
         assert!(prompt.contains("Fields not listed in `properties` are accepted"));
-        assert!(prompt.contains("releash workflow output submit execution-1"));
-        assert!(prompt.contains("--node review"));
+        assert!(prompt.contains("releash workflow output submit"));
+        assert!(!prompt.contains("--node review"));
         assert!(prompt.contains("--node-execution node-execution-1"));
         assert!(prompt.contains("--type review-result"));
         let deprecated_step_flag = ["--", "step"].concat();
@@ -539,7 +516,6 @@ mod tests {
         let (_system, prompt) = build_fanout_child_prompt(
             &node,
             Some(&resolved),
-            "execution-1",
             None,
             &HashMap::new(),
             FanoutChildPromptContext::new(None, "node-execution-1"),
@@ -547,8 +523,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(prompt.contains("releash workflow output submit execution-1"));
-        assert!(prompt.contains("--node review"));
+        assert!(prompt.contains("releash workflow output submit"));
+        assert!(!prompt.contains("--node review"));
         assert!(prompt.contains("--node-execution node-execution-1"));
         assert!(!prompt.contains("--type"));
         assert!(!prompt.contains("--json"));
@@ -565,7 +541,6 @@ mod tests {
         let (_system, prompt) = build_fanout_child_prompt(
             &node,
             Some(&resolved),
-            "execution-1",
             None,
             &HashMap::new(),
             FanoutChildPromptContext::new(Some(&item), "node-execution-1"),
@@ -573,8 +548,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(prompt.contains("releash workflow output submit execution-1"));
-        assert!(prompt.contains("--node review"));
+        assert!(prompt.contains("releash workflow output submit"));
+        assert!(!prompt.contains("--node review"));
         assert!(prompt.contains("--node-execution node-execution-1"));
         assert!(prompt.contains("--type review-result"));
     }

--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host/prompt_rendering.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host/prompt_rendering.rs
@@ -141,26 +141,36 @@ fn replace_template_refs(content: &str, mut resolve: impl FnMut(&str) -> Option<
     result
 }
 
-pub(crate) fn append_artifact_completion_action(
+pub(crate) fn append_completion_action(
     prompt: &mut String,
     artifact: Option<&str>,
     schemas: &BTreeMap<String, SchemaDef>,
     execution_id: &str,
     node_name: &str,
-    node_execution_id: Option<&str>,
+    node_execution_id: &str,
 ) {
-    let Some(contract) = artifact else {
-        return;
+    let (schema_guidance, action) = match artifact {
+        Some(contract) => {
+            let domain_schemas = schemas.clone();
+            let schema_guidance =
+                workflow_contract::render_contract_prompt_guidance(&domain_schemas, contract);
+            let action = prompt_composition::artifact_completion_action(
+                contract,
+                execution_id,
+                node_name,
+                Some(node_execution_id),
+            );
+            (schema_guidance, action)
+        }
+        None => (
+            None,
+            prompt_composition::artifactless_completion_action(
+                execution_id,
+                node_name,
+                node_execution_id,
+            ),
+        ),
     };
-    let domain_schemas = schemas.clone();
-    let schema_guidance =
-        workflow_contract::render_contract_prompt_guidance(&domain_schemas, contract);
-    let action = prompt_composition::artifact_completion_action(
-        contract,
-        execution_id,
-        node_name,
-        node_execution_id,
-    );
     if !prompt.is_empty() {
         prompt.push_str("\n\n");
     }
@@ -175,6 +185,7 @@ pub(crate) fn build_node_prompt(
     node: &NodeDefinition,
     facet_contents: Option<&FacetContents>,
     execution_id: &str,
+    node_execution_id: &str,
     request: Option<&str>,
     artifacts: &HashMap<String, RuntimeArtifact>,
     schemas: &BTreeMap<String, SchemaDef>,
@@ -200,13 +211,13 @@ pub(crate) fn build_node_prompt(
         .map(|content| render_prompt_content(&content, &artifacts, None));
     let rendered_user = render_prompt_content(&composed.user_message, &artifacts, None);
     let mut prompt = inject_input_artifacts(&rendered_user, &node.inputs, &artifacts);
-    append_artifact_completion_action(
+    append_completion_action(
         &mut prompt,
         node.artifact.as_deref(),
         schemas,
         execution_id,
         &node.name,
-        None,
+        node_execution_id,
     );
     Ok((system_prompt, prompt))
 }
@@ -250,13 +261,13 @@ pub(crate) fn build_fanout_child_prompt(
     let rendered_user = render_prompt_content(&composed.user_message, &artifacts, context.item);
     let rendered_user = inject_input_artifacts(&rendered_user, &node.inputs, &artifacts);
     let mut user_message = inject_fanout_item(&rendered_user, node.input.as_deref(), context.item);
-    append_artifact_completion_action(
+    append_completion_action(
         &mut user_message,
         node.artifact.as_deref(),
         schemas,
         execution_id,
         &node.name,
-        Some(context.node_execution_id),
+        context.node_execution_id,
     );
 
     Ok((system_prompt, user_message))
@@ -312,6 +323,7 @@ mod tests {
             &node,
             None,
             "execution-1",
+            "node-execution-1",
             None,
             &HashMap::new(),
             &BTreeMap::new(),
@@ -348,6 +360,7 @@ mod tests {
             &node,
             Some(&resolved),
             "execution-1",
+            "node-execution-1",
             Some("ship"),
             &outputs,
             &BTreeMap::new(),
@@ -383,6 +396,7 @@ mod tests {
             &node,
             Some(&resolved),
             "execution-1",
+            "node-execution-1",
             Some(""),
             &outputs,
             &BTreeMap::new(),
@@ -457,6 +471,29 @@ mod tests {
     }
 
     #[test]
+    fn build_node_prompt_appends_artifactless_output_submit_action() {
+        let node = make_test_node("review", "Review the change.");
+        let resolved = instruction_contents("Review the change.");
+
+        let (_system, prompt) = build_node_prompt(
+            &node,
+            Some(&resolved),
+            "execution-1",
+            "node-execution-1",
+            None,
+            &HashMap::new(),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert!(prompt.contains("releash workflow output submit execution-1"));
+        assert!(prompt.contains("--node review"));
+        assert!(prompt.contains("--node-execution node-execution-1"));
+        assert!(!prompt.contains("--type"));
+        assert!(!prompt.contains("--json"));
+    }
+
+    #[test]
     fn build_node_prompt_appends_canonical_output_submit_action() {
         let mut node = make_test_node("review", "Review the change.");
         node.artifact = Some("review-result".to_string());
@@ -476,6 +513,7 @@ mod tests {
             &node,
             Some(&resolved),
             "execution-1",
+            "node-execution-1",
             None,
             &HashMap::new(),
             &schemas,
@@ -487,10 +525,33 @@ mod tests {
         assert!(prompt.contains("Fields not listed in `properties` are accepted"));
         assert!(prompt.contains("releash workflow output submit execution-1"));
         assert!(prompt.contains("--node review"));
+        assert!(prompt.contains("--node-execution node-execution-1"));
         assert!(prompt.contains("--type review-result"));
-        assert!(!prompt.contains("--node-execution"));
         let deprecated_step_flag = ["--", "step"].concat();
         assert!(!prompt.contains(&deprecated_step_flag));
+    }
+
+    #[test]
+    fn build_fanout_child_prompt_appends_artifactless_output_submit_action() {
+        let node = make_test_node("review", "Review the change.");
+        let resolved = instruction_contents("Review the change.");
+
+        let (_system, prompt) = build_fanout_child_prompt(
+            &node,
+            Some(&resolved),
+            "execution-1",
+            None,
+            &HashMap::new(),
+            FanoutChildPromptContext::new(None, "node-execution-1"),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert!(prompt.contains("releash workflow output submit execution-1"));
+        assert!(prompt.contains("--node review"));
+        assert!(prompt.contains("--node-execution node-execution-1"));
+        assert!(!prompt.contains("--type"));
+        assert!(!prompt.contains("--json"));
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host/runtime_session.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host/runtime_session.rs
@@ -110,7 +110,6 @@ fn prepare_fanout_child_prompt_plans(
             let (system_prompt, user_message) = workflow_prompt::build_fanout_child_prompt(
                 &child.node,
                 facet_contents.for_node(&child.node.name),
-                &fanout_start.execution_id,
                 fanout_start.request.as_deref(),
                 &prompt_inputs.artifacts,
                 workflow_prompt::FanoutChildPromptContext::new(

--- a/src-tauri/src/adaptor/gateway/workspace_tree/repository.rs
+++ b/src-tauri/src/adaptor/gateway/workspace_tree/repository.rs
@@ -28,6 +28,9 @@ pub(crate) const SQL_WORKFLOW_NODE_DETAIL: &str = "SELECT node.tree_record, node
      JOIN workflow_executions AS execution
        ON execution.execution_id = node.execution_id
      WHERE node.node_id = ?1 AND execution.workspace_identity = ?2";
+pub(crate) const SQL_WORKFLOW_NODE_BY_NODE_EXECUTION: &str =
+    "SELECT tree_record, detail_record FROM workflow_execution_nodes
+     WHERE node_execution_id = ?1";
 pub(crate) const SQL_WORKFLOW_NODE_ID_FOR_SESSION: &str = "SELECT node.node_id
      FROM workflow_execution_nodes AS node
      JOIN workflow_executions AS execution
@@ -141,6 +144,29 @@ impl WorkspaceTreeRepository for SqliteWorkspaceTreeRepository {
         }
 
         Ok(None)
+    }
+
+    fn load_node_by_node_execution_id(
+        &self,
+        node_execution_id: &str,
+    ) -> Result<Option<WorkspaceTreeNode>, LocalEventQueryError> {
+        let requested = node_execution_id.to_string();
+        let workflow_node = self.run_indexed(move |connection| {
+            connection
+                .query_row(
+                    SQL_WORKFLOW_NODE_BY_NODE_EXECUTION,
+                    params![requested],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()
+                .map_err(sql_query_error)
+        })?;
+        workflow_node
+            .map(|(tree_record, detail_record)| {
+                decode_workflow_execution_node_detail_v1(&tree_record, &detail_record)
+                    .map_err(codec_query_error)
+            })
+            .transpose()
     }
 
     fn node_id_for_session(

--- a/src-tauri/src/cli/api_client.rs
+++ b/src-tauri/src/cli/api_client.rs
@@ -57,13 +57,19 @@ impl LocalApiClient {
 
     pub(super) fn submit_output(
         &self,
-        execution_id: &str,
+        node_execution_id: &str,
         request: &SubmitOutputRequest,
     ) -> Result<(), ApiRequestError> {
         let response: MutationResponse = self
             .transport
             .post_json(
-                &["v1", "workflow", "executions", execution_id, "submit"],
+                &[
+                    "v1",
+                    "workflow",
+                    "node-executions",
+                    node_execution_id,
+                    "submit",
+                ],
                 request,
             )
             .map_err(ApiRequestError::from)?;

--- a/src-tauri/src/cli/api_client_test.rs
+++ b/src-tauri/src/cli/api_client_test.rs
@@ -107,10 +107,10 @@ fn test_保持対象cli_discoveryとlive_httpを通る() {
     .unwrap();
     assert_eq!(status["id"], execution_id);
 
+    gateway.bind_node_execution("00000000-0000-4000-8000-000000000456", execution_id);
+
     output::cmd_output_submit(
         client_data.path(),
-        execution_id,
-        "review",
         "00000000-0000-4000-8000-000000000456".to_string(),
         Some("review-result"),
         Some(r#"{"status":"approved"}"#.to_string()),
@@ -126,7 +126,6 @@ fn test_保持対象cli_discoveryとlive_httpを通る() {
 
     let commands = gateway.commands.lock().unwrap();
     assert_eq!(commands.outputs.len(), 1);
-    assert_eq!(commands.outputs[0].execution_id, execution_id);
     assert_eq!(
         commands.outputs[0].node_execution_id,
         "00000000-0000-4000-8000-000000000456"

--- a/src-tauri/src/cli/cli_test.rs
+++ b/src-tauri/src/cli/cli_test.rs
@@ -82,9 +82,6 @@ fn test_clicommand整理_保持対象workflowとreview_commandを受理する() 
             "workflow",
             "output",
             "submit",
-            execution_id,
-            "--node",
-            "review",
             "--node-execution",
             "550e8400-e29b-41d4-a716-446655440001",
             "--type",
@@ -116,7 +113,7 @@ fn test_clicommand整理_一次owner文書が実装済みsurfaceだけを列挙�
 
     for retained in [
         "releash workflow status <execution-id>",
-        "releash workflow output submit <execution-id>",
+        "releash workflow output submit --node-execution <id>",
         "releash workflow output get <execution-id>",
     ] {
         assert!(

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -117,16 +117,12 @@ pub fn run() -> i32 {
                     }
                     WorkflowSubcommand::Output { command } => match command {
                         OutputSubcommand::Submit {
-                            execution_id,
-                            node,
                             node_execution,
                             contract,
                             json,
                             file,
                         } => output::cmd_output_submit(
                             &data_dir,
-                            &execution_id,
-                            &node,
                             node_execution,
                             contract.as_deref(),
                             json,

--- a/src-tauri/src/cli/output.rs
+++ b/src-tauri/src/cli/output.rs
@@ -17,9 +17,6 @@ pub(super) enum OutputSubcommand {
             .multiple(false)
     ))]
     Submit {
-        execution_id: String,
-        #[arg(long, value_name = "NODE_NAME")]
-        node: String,
         #[arg(long = "node-execution", value_name = "NODE_EXECUTION_ID")]
         node_execution: String,
         #[arg(long = "type", value_name = "CONTRACT", requires = "artifact_value")]
@@ -51,15 +48,16 @@ pub(super) enum OutputSubcommand {
 
 pub(super) fn cmd_output_submit(
     data_dir: &Path,
-    execution_id: &str,
-    node: &str,
     node_execution: String,
     contract: Option<&str>,
     json_arg: Option<String>,
     file_arg: Option<PathBuf>,
 ) -> Result<String, CliError> {
-    validate_execution_id(execution_id)?;
-    validate_node(node)?;
+    if node_execution.trim().is_empty() {
+        return Err(CliError::InvalidInput(
+            "--node-execution must not be empty".to_string(),
+        ));
+    }
     let artifact = match contract {
         Some(contract) => {
             validate_contract_argument(contract)?;
@@ -76,19 +74,15 @@ pub(super) fn cmd_output_submit(
             ));
         }
     };
-    let request = SubmitOutputRequest {
-        node: node.to_string(),
-        node_execution_id: node_execution,
-        artifact,
-    };
+    let request = SubmitOutputRequest { artifact };
     api_client::mutation(data_dir, |client| {
-        client.submit_output(execution_id, &request)
+        client.submit_output(&node_execution, &request)
     })?;
     Ok(match contract {
         Some(contract) => {
-            format!("submitted: execution_id={execution_id} node={node} type={contract}\n")
+            format!("submitted: node_execution_id={node_execution} type={contract}\n")
         }
-        None => format!("submitted: execution_id={execution_id} node={node}\n"),
+        None => format!("submitted: node_execution_id={node_execution}\n"),
     })
 }
 

--- a/src-tauri/src/cli/output_test.rs
+++ b/src-tauri/src/cli/output_test.rs
@@ -149,6 +149,16 @@ fn test_workflow_output_submit_requires_attempt_identity_and_accepts_optional_ar
 }
 
 #[test]
+fn test_workflow_output_submit_rejects_blank_node_execution_id() {
+    let temp = TempDir::new().unwrap();
+
+    assert_eq!(
+        cmd_output_submit(temp.path(), "   ".to_string(), None, None, None).unwrap_err(),
+        CliError::InvalidInput("--node-execution must not be empty".to_string())
+    );
+}
+
+#[test]
 fn test_workflow_output_submit_実行中アプリを要求する() {
     let temp = TempDir::new().unwrap();
     let execution_id = test_uuid(10);

--- a/src-tauri/src/cli/output_test.rs
+++ b/src-tauri/src/cli/output_test.rs
@@ -62,9 +62,6 @@ fn test_workflow_output_cli_保持対象commandだけを正規語彙でparseす�
             "workflow",
             "output",
             "submit",
-            execution_id,
-            "--node",
-            "review",
             "--node-execution",
             "550e8400-e29b-41d4-a716-446655440001",
             "--type",
@@ -114,7 +111,6 @@ fn test_workflow_output_cli_保持対象commandだけを正規語彙でparseす�
 
 #[test]
 fn test_workflow_output_submit_requires_attempt_identity_and_accepts_optional_artifact() {
-    let execution_id = "550e8400-e29b-41d4-a716-446655440000";
     let node_execution_id = "550e8400-e29b-41d4-a716-446655440001";
 
     assert!(Cli::try_parse_from([
@@ -122,9 +118,6 @@ fn test_workflow_output_submit_requires_attempt_identity_and_accepts_optional_ar
         "workflow",
         "output",
         "submit",
-        execution_id,
-        "--node",
-        "review",
         "--node-execution",
         node_execution_id,
     ])
@@ -134,13 +127,23 @@ fn test_workflow_output_submit_requires_attempt_identity_and_accepts_optional_ar
         "workflow",
         "output",
         "submit",
-        execution_id,
-        "--node",
-        "review",
         "--node-execution",
         node_execution_id,
         "--type",
         "review-verdict",
+    ])
+    .is_err());
+    assert!(Cli::try_parse_from(["releash", "workflow", "output", "submit"]).is_err());
+    assert!(Cli::try_parse_from([
+        "releash",
+        "workflow",
+        "output",
+        "submit",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--node",
+        "review",
+        "--node-execution",
+        node_execution_id,
     ])
     .is_err());
 }
@@ -153,8 +156,6 @@ fn test_workflow_output_submit_実行中アプリを要求する() {
 
     let error = cmd_output_submit(
         temp.path(),
-        &execution_id,
-        "review",
         "550e8400-e29b-41d4-a716-446655440001".to_string(),
         Some("review-verdict"),
         Some(r#"{"verdict":"LGTM"}"#.to_string()),

--- a/src-tauri/src/domain/local_event/query.rs
+++ b/src-tauri/src/domain/local_event/query.rs
@@ -86,6 +86,9 @@ pub enum LocalEventQuery {
     SessionProjectionByIdentity {
         session_id: String,
     },
+    WorkflowExecutionByNodeExecution {
+        node_execution_id: String,
+    },
     AgentSessionProjectionPage {
         workspace_identity: String,
         lifecycle: Option<AgentSessionLifecycleRecord>,
@@ -322,6 +325,7 @@ pub enum LocalEventQueryResult {
     CallerAttemptPage(Vec<CallerAttemptView>),
     ObligationByIdentity(Option<ObligationView>),
     SessionProjectionByIdentity(Option<SessionProjectionView>),
+    WorkflowExecutionByNodeExecution(Option<String>),
     AgentSessionProjectionPage(AgentSessionProjectionPageView),
     CanonicalRuntimeOwnerSnapshot(Vec<CanonicalRuntimeOwnerView>),
     PendingRecoveryPage(PendingRecoveryPageView),

--- a/src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs
+++ b/src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs
@@ -482,6 +482,7 @@ pub struct AppliedNodeCompletionHandshake {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeSubmitTarget {
+    pub node_name: String,
     pub session_id: Option<String>,
     pub attempt: u32,
 }
@@ -501,7 +502,7 @@ pub struct RestartedNodeAttempt {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeSubmitRejection {
     ExecutionNotActive,
-    NodeNotFound,
+    NodeExecutionNotFound,
     AttemptNotCurrent,
 }
 
@@ -1845,20 +1846,18 @@ impl WorkflowExecution {
 
     pub fn admit_node_submit(
         &self,
-        node_name: &str,
         node_execution_id: &str,
     ) -> Result<NodeSubmitTarget, NodeSubmitRejection> {
         if !self.is_active() {
             return Err(NodeSubmitRejection::ExecutionNotActive);
         }
-        if !self
+        let requested = self
             .runtime
             .node_executions
             .iter()
-            .any(|execution| execution.node_name == node_name)
-        {
-            return Err(NodeSubmitRejection::NodeNotFound);
-        }
+            .find(|execution| execution.id == node_execution_id)
+            .ok_or(NodeSubmitRejection::NodeExecutionNotFound)?;
+        let node_name = requested.node_name.as_str();
         let current_node = self
             .runtime
             .workflow
@@ -1892,6 +1891,7 @@ impl WorkflowExecution {
             })
             .ok_or(NodeSubmitRejection::AttemptNotCurrent)?;
         Ok(NodeSubmitTarget {
+            node_name: execution.node_name.clone(),
             session_id: execution.session_id.clone(),
             attempt: execution.attempt,
         })
@@ -3059,6 +3059,29 @@ mod tests {
             lifecycle: WorkflowExecution::lifecycle_from_state(state),
             ..WorkflowExecutionRestore::default()
         })
+    }
+
+    #[test]
+    fn node_submit_target_is_derived_from_node_execution_identity() {
+        let mut execution = restored_execution(RuntimeExecutionState::Running);
+        execution
+            .begin_node_attempt(
+                "implement".to_string(),
+                NodeKindName::Session,
+                1,
+                None,
+                "node-execution-1".to_string(),
+                10.0,
+            )
+            .unwrap();
+
+        let target = execution.admit_node_submit("node-execution-1").unwrap();
+        assert_eq!(target.node_name, "implement");
+        assert_eq!(target.attempt, 1);
+        assert_eq!(
+            execution.admit_node_submit("missing"),
+            Err(NodeSubmitRejection::NodeExecutionNotFound)
+        );
     }
 
     #[test]

--- a/src-tauri/src/domain/workflow/services/prompt_composition.rs
+++ b/src-tauri/src/domain/workflow/services/prompt_composition.rs
@@ -40,19 +40,9 @@ pub fn provider_tui_initial_instruction(system_prompt: Option<&str>, user_messag
     }
 }
 
-pub fn artifact_completion_action(
-    key: &str,
-    execution_id: &str,
-    node_name: &str,
-    node_execution_id: Option<&str>,
-) -> String {
+pub fn artifact_completion_action(key: &str, node_execution_id: &str) -> String {
     let quoted_key = crate::domain::shell::quote_path_for_shell(key);
-    let quoted_execution_id = crate::domain::shell::quote_path_for_shell(execution_id);
-    let quoted_node_name = crate::domain::shell::quote_path_for_shell(node_name);
-    let node_execution_arg = node_execution_id
-        .map(crate::domain::shell::quote_path_for_shell)
-        .map(|id| format!("  --node-execution {id} \\\n"))
-        .unwrap_or_default();
+    let quoted_node_execution_id = crate::domain::shell::quote_path_for_shell(node_execution_id);
     format!(
         "## 完了時の必須アクション\n\n\
 提出値が確定した時点で、次の assistant action は最終応答ではなく CLI 実行でなければならない。\n\
@@ -60,22 +50,14 @@ pub fn artifact_completion_action(
 このコマンドが成功するまで node は完了していない。\n\
 成功したら追加の調査やtool実行を行わず、そのturnを終了すること。\n\n\
 ```sh\n\
-releash workflow output submit {execution_id} \\\n  --node {node_name} \\\n{node_execution_arg}  --type {key} \\\n  --json '{{...}}'\n\
+releash workflow output submit \\\n  --node-execution {node_execution_id} \\\n  --type {key} \\\n  --json '{{...}}'\n\
 ```",
-        execution_id = quoted_execution_id,
-        node_name = quoted_node_name,
-        node_execution_arg = node_execution_arg,
+        node_execution_id = quoted_node_execution_id,
         key = quoted_key
     )
 }
 
-pub fn artifactless_completion_action(
-    execution_id: &str,
-    node_name: &str,
-    node_execution_id: &str,
-) -> String {
-    let quoted_execution_id = crate::domain::shell::quote_path_for_shell(execution_id);
-    let quoted_node_name = crate::domain::shell::quote_path_for_shell(node_name);
+pub fn artifactless_completion_action(node_execution_id: &str) -> String {
     let quoted_node_execution_id = crate::domain::shell::quote_path_for_shell(node_execution_id);
     format!(
         "## 完了時の必須アクション\n\n\
@@ -84,10 +66,8 @@ pub fn artifactless_completion_action(
 このコマンドが成功するまで node は完了していない。\n\
 成功したら追加の調査やtool実行を行わず、そのturnを終了すること。\n\n\
 ```sh\n\
-releash workflow output submit {execution_id} \\\n  --node {node_name} \\\n  --node-execution {node_execution_id}\n\
+releash workflow output submit \\\n  --node-execution {node_execution_id}\n\
 ```",
-        execution_id = quoted_execution_id,
-        node_name = quoted_node_name,
         node_execution_id = quoted_node_execution_id,
     )
 }

--- a/src-tauri/src/domain/workflow/services/prompt_composition.rs
+++ b/src-tauri/src/domain/workflow/services/prompt_composition.rs
@@ -69,6 +69,29 @@ releash workflow output submit {execution_id} \\\n  --node {node_name} \\\n{node
     )
 }
 
+pub fn artifactless_completion_action(
+    execution_id: &str,
+    node_name: &str,
+    node_execution_id: &str,
+) -> String {
+    let quoted_execution_id = crate::domain::shell::quote_path_for_shell(execution_id);
+    let quoted_node_name = crate::domain::shell::quote_path_for_shell(node_name);
+    let quoted_node_execution_id = crate::domain::shell::quote_path_for_shell(node_execution_id);
+    format!(
+        "## 完了時の必須アクション\n\n\
+作業が完了した時点で、次の assistant action は最終応答ではなく CLI 実行でなければならない。\n\
+チャット本文に完了報告を書いても提出とは扱われない。必ず次のコマンドで完了を提出すること。\n\
+このコマンドが成功するまで node は完了していない。\n\
+成功したら追加の調査やtool実行を行わず、そのturnを終了すること。\n\n\
+```sh\n\
+releash workflow output submit {execution_id} \\\n  --node {node_name} \\\n  --node-execution {node_execution_id}\n\
+```",
+        execution_id = quoted_execution_id,
+        node_name = quoted_node_name,
+        node_execution_id = quoted_node_execution_id,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/domain/workspace_tree/repository.rs
+++ b/src-tauri/src/domain/workspace_tree/repository.rs
@@ -14,6 +14,11 @@ pub trait WorkspaceTreeRepository: Send + Sync {
         node_id: &str,
     ) -> Result<Option<WorkspaceTreeNode>, crate::domain::local_event::LocalEventQueryError>;
 
+    fn load_node_by_node_execution_id(
+        &self,
+        node_execution_id: &str,
+    ) -> Result<Option<WorkspaceTreeNode>, crate::domain::local_event::LocalEventQueryError>;
+
     fn node_id_for_session(
         &self,
         workspace_identity: &WorkspaceIdentity,

--- a/src-tauri/src/provider_lifecycle_acceptance.rs
+++ b/src-tauri/src/provider_lifecycle_acceptance.rs
@@ -229,6 +229,14 @@ impl WorkflowControlPlaneGateway for AcceptanceWorkflowRuntimeGateway {
         "node-execution-test".to_string()
     }
 
+    async fn resolve_workflow_execution_id(
+        &self,
+        _node_execution_id: &str,
+    ) -> Result<Option<String>, WorkflowError> {
+        self.record_command();
+        Err(unavailable_workflow_runtime())
+    }
+
     async fn load_active_execution(
         &self,
         _execution_id: &str,

--- a/src-tauri/src/usecase/workflow/command/mod.rs
+++ b/src-tauri/src/usecase/workflow/command/mod.rs
@@ -130,6 +130,15 @@ mod tests {
             "node-execution-test".to_string()
         }
 
+        async fn resolve_workflow_execution_id(
+            &self,
+            _node_execution_id: &str,
+        ) -> Result<Option<String>, WorkflowError> {
+            Err(WorkflowError::external(
+                "control plane is not used by this test",
+            ))
+        }
+
         async fn load_active_execution(
             &self,
             _execution_id: &str,
@@ -307,8 +316,6 @@ mod tests {
             .is_err());
         assert!(WorkflowSubmitOutputUsecase::new(gateway.clone())
             .execute(SubmitOutputCommand {
-                execution_id: valid_execution_id(),
-                node_name: "review".to_string(),
                 node_execution_id: "node-execution-1".to_string(),
                 artifact: Some(SubmitOutputArtifact {
                     contract: " ".to_string(),

--- a/src-tauri/src/usecase/workflow/command/preflight.rs
+++ b/src-tauri/src/usecase/workflow/command/preflight.rs
@@ -59,8 +59,6 @@ impl WorkflowRuntimeCommandPreflight {
         &self,
         command: &SubmitOutputCommand,
     ) -> Result<(), WorkflowError> {
-        WorkflowExecutionId::new(command.execution_id.clone())?;
-        NodeDefinitionName::new(command.node_name.clone())?;
         if command.node_execution_id.trim().is_empty() {
             return Err(WorkflowError::validation(
                 "node_execution_id must not be empty",

--- a/src-tauri/src/usecase/workflow/command/submit_output.rs
+++ b/src-tauri/src/usecase/workflow/command/submit_output.rs
@@ -15,8 +15,6 @@ pub struct SubmitOutputArtifact {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubmitOutputCommand {
-    pub execution_id: String,
-    pub node_name: String,
     pub node_execution_id: String,
     pub artifact: Option<SubmitOutputArtifact>,
 }

--- a/src-tauri/src/usecase/workflow/control_plane.rs
+++ b/src-tauri/src/usecase/workflow/control_plane.rs
@@ -36,6 +36,11 @@ pub(crate) trait WorkflowControlPlaneGateway: Send + Sync {
 
     fn new_node_execution_id(&self) -> String;
 
+    async fn resolve_workflow_execution_id(
+        &self,
+        node_execution_id: &str,
+    ) -> Result<Option<String>, WorkflowError>;
+
     async fn load_active_execution(
         &self,
         execution_id: &str,
@@ -204,53 +209,61 @@ impl WorkflowControlPlaneUsecase {
     }
 
     async fn submit_output_once(&self, command: SubmitOutputCommand) -> Result<(), WorkflowError> {
-        submission::validate_submit_output_request(
-            &command.execution_id,
-            &command.node_name,
-            &command.node_execution_id,
-        )
-        .map_err(runtime_error_to_workflow_error)?;
+        submission::validate_submit_output_request(&command.node_execution_id)
+            .map_err(runtime_error_to_workflow_error)?;
 
-        let active = self
+        let execution_id = self
             .runtime
-            .load_active_execution(&command.execution_id)
-            .await?;
+            .resolve_workflow_execution_id(&command.node_execution_id)
+            .await?
+            .ok_or_else(|| {
+                WorkflowError::NotFound(format!(
+                    "Node execution not found: {}",
+                    command.node_execution_id
+                ))
+            })?;
+
+        let active = self.runtime.load_active_execution(&execution_id).await?;
         let persisted_events = if active.is_none() {
-            Some(
-                self.runtime
-                    .load_persisted_events(&command.execution_id)
-                    .await?,
-            )
+            Some(self.runtime.load_persisted_events(&execution_id).await?)
         } else {
             None
         };
-        let workflow = active
-            .as_ref()
-            .map(|execution| &execution.workflow)
-            .or_else(|| {
-                persisted_events
-                    .as_ref()?
-                    .iter()
-                    .find_map(|event| match event {
-                        WorkflowEvent::ExecutionStarted { definition, .. } => Some(definition),
-                        _ => None,
-                    })
-            });
+
+        let Some(current) = active else {
+            let events = persisted_events.unwrap_or_default();
+            if submit_was_persisted(&events, &command.node_execution_id) {
+                return Ok(());
+            }
+            return Err(WorkflowError::NotFound(format!(
+                "Active node execution not found: {}",
+                command.node_execution_id
+            )));
+        };
+
+        let target = match submission::validate_submit_target_context(
+            &current,
+            &execution_id,
+            &command.node_execution_id,
+        ) {
+            Ok(target) => target,
+            Err(error) => {
+                let events = self.runtime.load_persisted_events(&execution_id).await?;
+                if submit_was_persisted(&events, &command.node_execution_id) {
+                    return Ok(());
+                }
+                return Err(runtime_error_to_workflow_error(error));
+            }
+        };
         let validated_artifact = if let Some(artifact) = command.artifact {
-            let workflow = workflow.ok_or_else(|| {
-                WorkflowError::NotFound(format!(
-                    "Workflow execution not found: {}",
-                    command.execution_id
-                ))
-            })?;
             submission::validate_artifact_contract_for_workflow(
-                workflow,
-                &command.node_name,
+                &current.workflow,
+                &target.node_name,
                 &artifact.contract,
             )
             .map_err(runtime_error_to_workflow_error)?;
             let validated = submission::validate_submission_output_with_secrets(
-                workflow,
+                &current.workflow,
                 &artifact.contract,
                 artifact.value,
                 &self.runtime.configured_secret_values(),
@@ -259,36 +272,6 @@ impl WorkflowControlPlaneUsecase {
             Some((artifact.contract, validated))
         } else {
             None
-        };
-
-        let Some(current) = active else {
-            let events = persisted_events.unwrap_or_default();
-            if submit_was_persisted(&events, &command.node_name, &command.node_execution_id) {
-                return Ok(());
-            }
-            return Err(WorkflowError::NotFound(format!(
-                "Workflow execution not found: {}",
-                command.execution_id
-            )));
-        };
-
-        let target = match submission::validate_submit_target_context(
-            &current,
-            &command.execution_id,
-            &command.node_name,
-            &command.node_execution_id,
-        ) {
-            Ok(target) => target,
-            Err(error) => {
-                let events = self
-                    .runtime
-                    .load_persisted_events(&command.execution_id)
-                    .await?;
-                if submit_was_persisted(&events, &command.node_name, &command.node_execution_id) {
-                    return Ok(());
-                }
-                return Err(runtime_error_to_workflow_error(error));
-            }
         };
         let timestamp = self.runtime.current_timestamp();
         let mut candidate = current.clone();
@@ -309,13 +292,13 @@ impl WorkflowControlPlaneUsecase {
             }
         }
         let mut events = vec![WorkflowEvent::NodeSubmitReceived {
-            execution_id: command.execution_id.clone(),
+            execution_id: execution_id.clone(),
             node_execution_id: command.node_execution_id.clone(),
             timestamp,
         }];
         if let Some((contract, validated)) = validated_artifact {
             if candidate.apply_submitted_output(
-                command.node_name.clone(),
+                target.node_name.clone(),
                 &command.node_execution_id,
                 target.attempt,
                 target.session_id,
@@ -332,9 +315,9 @@ impl WorkflowControlPlaneUsecase {
                 )));
             }
             events.push(submission::artifact_produced_event(
-                &command.execution_id,
+                &execution_id,
                 &command.node_execution_id,
-                &command.node_name,
+                &target.node_name,
                 contract,
                 validated.artifact,
                 None,
@@ -354,7 +337,7 @@ impl WorkflowControlPlaneUsecase {
             .runtime
             .commit_control_plane(WorkflowControlPlaneCommit {
                 operation_kind: CommitOperationKind::UserMutation,
-                execution_id: command.execution_id,
+                execution_id,
                 before: current,
                 after: candidate,
                 workflow_events: events,
@@ -781,32 +764,16 @@ fn apply_fanout_approval(
     Ok((outcome, events))
 }
 
-fn submit_was_persisted(
-    events: &[WorkflowEvent],
-    expected_node_name: &str,
-    expected_node_execution_id: &str,
-) -> bool {
-    let matching_node = events.iter().any(|event| {
+fn submit_was_persisted(events: &[WorkflowEvent], expected_node_execution_id: &str) -> bool {
+    events.iter().any(|event| {
         matches!(
             event,
-            WorkflowEvent::NodeStarted {
+            WorkflowEvent::NodeSubmitReceived {
                 node_execution_id,
-                node_name,
                 ..
             } if node_execution_id == expected_node_execution_id
-                && node_name == expected_node_name
         )
-    });
-    matching_node
-        && events.iter().any(|event| {
-            matches!(
-                event,
-                WorkflowEvent::NodeSubmitReceived {
-                    node_execution_id,
-                    ..
-                } if node_execution_id == expected_node_execution_id
-            )
-        })
+    })
 }
 
 fn apply_completion_handshake(

--- a/src-tauri/src/usecase/workflow/mod.rs
+++ b/src-tauri/src/usecase/workflow/mod.rs
@@ -299,6 +299,29 @@ impl WorkflowUsecase {
         }
     }
 
+    pub fn authorize_node_execution_access_for_worktree(
+        &self,
+        node_execution_id: &str,
+        worktree_path: &str,
+    ) -> Result<(), WorkflowError> {
+        if node_execution_id.trim().is_empty() {
+            return Err(WorkflowError::validation(
+                "node_execution_id must not be empty",
+            ));
+        }
+        let node = self
+            .workspace_nodes
+            .load_node_by_node_execution_id(node_execution_id)
+            .map_err(|error| WorkflowError::external(error.to_string()))?
+            .ok_or_else(|| {
+                WorkflowError::external(format!("Node execution not found: {node_execution_id}"))
+            })?;
+        let execution_id = node.execution_id.ok_or_else(|| {
+            WorkflowError::external(format!("Node execution not found: {node_execution_id}"))
+        })?;
+        self.authorize_execution_access_for_worktree(&execution_id, worktree_path)
+    }
+
     pub fn resolve_worktree_by_execution(
         &self,
         execution_id: &str,
@@ -1003,6 +1026,16 @@ mod tests {
             &self,
             _workspace_identity: &crate::domain::workspace_tree::WorkspaceIdentity,
             _node_id: &str,
+        ) -> Result<
+            Option<crate::domain::workspace_tree::WorkspaceTreeNode>,
+            crate::domain::local_event::LocalEventQueryError,
+        > {
+            Ok(None)
+        }
+
+        fn load_node_by_node_execution_id(
+            &self,
+            _node_execution_id: &str,
         ) -> Result<
             Option<crate::domain::workspace_tree::WorkspaceTreeNode>,
             crate::domain::local_event::LocalEventQueryError,

--- a/src-tauri/src/usecase/workflow/mod.rs
+++ b/src-tauri/src/usecase/workflow/mod.rs
@@ -1006,12 +1006,29 @@ mod tests {
         editors: Arc<FakeExternalEditorGateway>,
         definitions: Arc<FakeDefinitionRepository>,
         definition_sources: Arc<FakeDefinitionSourceGateway>,
+        workspace_nodes: Arc<FakeWorkspaceTreeRepository>,
         _workspace_root: tempfile::TempDir,
     }
 
-    struct EmptyWorkspaceTreeRepository;
+    #[derive(Default)]
+    struct FakeWorkspaceTreeRepository {
+        nodes: Mutex<HashMap<String, crate::domain::workspace_tree::WorkspaceTreeNode>>,
+    }
 
-    impl crate::domain::workspace_tree::WorkspaceTreeRepository for EmptyWorkspaceTreeRepository {
+    impl FakeWorkspaceTreeRepository {
+        fn insert(
+            &self,
+            node_execution_id: &str,
+            node: crate::domain::workspace_tree::WorkspaceTreeNode,
+        ) {
+            self.nodes
+                .lock()
+                .unwrap()
+                .insert(node_execution_id.to_string(), node);
+        }
+    }
+
+    impl crate::domain::workspace_tree::WorkspaceTreeRepository for FakeWorkspaceTreeRepository {
         fn load(
             &self,
             _workspace_identity: &crate::domain::workspace_tree::WorkspaceIdentity,
@@ -1035,12 +1052,12 @@ mod tests {
 
         fn load_node_by_node_execution_id(
             &self,
-            _node_execution_id: &str,
+            node_execution_id: &str,
         ) -> Result<
             Option<crate::domain::workspace_tree::WorkspaceTreeNode>,
             crate::domain::local_event::LocalEventQueryError,
         > {
-            Ok(None)
+            Ok(self.nodes.lock().unwrap().get(node_execution_id).cloned())
         }
 
         fn node_id_for_session(
@@ -1076,6 +1093,7 @@ mod tests {
             let facets = Arc::new(FakeFacetRepository::default());
             let events = Arc::new(FakeEventRepository::default());
             let editors = Arc::new(FakeExternalEditorGateway::default());
+            let workspace_nodes = Arc::new(FakeWorkspaceTreeRepository::default());
             let workspace_root = tempfile::tempdir().unwrap();
             let workspace_query =
                 crate::usecase::workspace_tree::TestWorkspaceQueryService::new(executions);
@@ -1097,7 +1115,7 @@ mod tests {
                 Arc::new(FakeConfigPathGateway),
                 Arc::new(FakeSecretSourceGateway),
                 Arc::new(NoopArchiveRepository),
-                Arc::new(EmptyWorkspaceTreeRepository),
+                workspace_nodes.clone(),
                 workspace_query,
             );
             Self {
@@ -1105,8 +1123,44 @@ mod tests {
                 editors,
                 definitions,
                 definition_sources,
+                workspace_nodes,
                 _workspace_root: workspace_root,
             }
+        }
+    }
+
+    fn workspace_node(
+        node_execution_id: &str,
+        execution_id: Option<&str>,
+    ) -> crate::domain::workspace_tree::WorkspaceTreeNode {
+        crate::domain::workspace_tree::WorkspaceTreeNode {
+            id: format!("node:{node_execution_id}"),
+            parent_id: execution_id.map(str::to_string),
+            sibling_order: 0,
+            kind: crate::domain::workspace_tree::WorkspaceNodeKind::WorkflowSession,
+            title: "node".to_string(),
+            status: crate::domain::workspace_tree::WorkspaceNodeStatus::Running,
+            error_reason: None,
+            updated_at_bits: 1.0_f64.to_bits(),
+            execution_id: execution_id.map(str::to_string),
+            node_execution_id: Some(node_execution_id.to_string()),
+            node_name: Some("node".to_string()),
+            attempt: Some(1),
+            completion_signals: Default::default(),
+            has_artifact: false,
+            session_id: None,
+            can_approve: false,
+            can_retry: false,
+            can_close: false,
+            can_stop: false,
+            can_resume: false,
+            recovery_owner_reason: None,
+            resume_unavailable_reason: None,
+            can_abort: false,
+            can_archive: false,
+            display_command: None,
+            command_result: None,
+            dynamic_fanout: false,
         }
     }
 
@@ -1316,6 +1370,51 @@ mod tests {
                 .authorize_execution_access_for_worktree("invalid", "repo"),
             Err(WorkflowError::Validation(_))
         ));
+    }
+
+    #[test]
+    fn authorize_node_execution_access_for_worktree_checks_identity_and_execution_ownership() {
+        let execution_id = "00000000-0000-0000-0000-000000000011";
+        let fixture = Fixture::with_executions(vec![execution_summary(
+            execution_id,
+            "/canonical/repo",
+            ExecutionStatus::Running,
+        )]);
+        fixture.workspace_nodes.insert(
+            "node-execution-1",
+            workspace_node("node-execution-1", Some(execution_id)),
+        );
+        fixture.workspace_nodes.insert(
+            "node-execution-without-owner",
+            workspace_node("node-execution-without-owner", None),
+        );
+
+        fixture
+            .usecase
+            .authorize_node_execution_access_for_worktree("node-execution-1", "repo")
+            .unwrap();
+        assert!(matches!(
+            fixture
+                .usecase
+                .authorize_node_execution_access_for_worktree("   ", "repo"),
+            Err(WorkflowError::Validation(_))
+        ));
+        for node_execution_id in ["missing", "node-execution-without-owner"] {
+            assert_eq!(
+                fixture
+                    .usecase
+                    .authorize_node_execution_access_for_worktree(node_execution_id, "repo")
+                    .unwrap_err(),
+                WorkflowError::external(format!("Node execution not found: {node_execution_id}"))
+            );
+        }
+        assert_eq!(
+            fixture
+                .usecase
+                .authorize_node_execution_access_for_worktree("node-execution-1", "other")
+                .unwrap_err(),
+            WorkflowError::external(format!("Workflow execution not found: {execution_id}"))
+        );
     }
 
     #[test]

--- a/src-tauri/src/usecase/workflow/output_submission.rs
+++ b/src-tauri/src/usecase/workflow/output_submission.rs
@@ -7,7 +7,7 @@ use crate::domain::workflow::services::{contract as workflow_contract, secret_ma
 use crate::domain::workflow::RuntimeArtifact;
 use crate::domain::workflow::WorkflowDefinition;
 use crate::domain::workflow::WorkflowEvent;
-use crate::domain::workflow::{ContractType, ContractValidationResult, NodeDefinitionName};
+use crate::domain::workflow::{ContractType, ContractValidationResult};
 use crate::usecase::workflow::runtime_error::WorkflowRuntimeError;
 
 #[derive(Debug)]
@@ -18,21 +18,14 @@ pub(crate) struct ValidatedSubmissionOutput {
 
 #[derive(Debug)]
 pub(crate) struct SubmissionTargetContext {
+    pub(crate) node_name: String,
     pub(crate) session_id: Option<String>,
     pub(crate) attempt: u32,
 }
 
 pub(crate) fn validate_submit_output_request(
-    execution_id: &str,
-    node_name: &str,
     node_execution_id: &str,
 ) -> Result<(), WorkflowRuntimeError> {
-    uuid::Uuid::parse_str(execution_id).map_err(|_| {
-        WorkflowRuntimeError::ValidationError("execution_id must be UUID".to_string())
-    })?;
-    NodeDefinitionName::new(node_name).map_err(|_| {
-        WorkflowRuntimeError::ValidationError("node_name must not be empty".to_string())
-    })?;
     if node_execution_id.trim().is_empty() {
         return Err(WorkflowRuntimeError::ValidationError(
             "node_execution_id must not be empty".to_string(),
@@ -44,26 +37,30 @@ pub(crate) fn validate_submit_output_request(
 pub(crate) fn validate_submit_target_context(
     exec: &DomainWorkflowExecution,
     execution_id: &str,
-    node_name: &str,
     node_execution_id: &str,
 ) -> Result<SubmissionTargetContext, WorkflowRuntimeError> {
     use crate::domain::workflow::entities::workflow_execution::NodeSubmitRejection;
 
-    let target = exec
-        .admit_node_submit(node_name, node_execution_id)
-        .map_err(|rejection| match rejection {
-            NodeSubmitRejection::ExecutionNotActive => WorkflowRuntimeError::InvalidState(format!(
-                "execution {execution_id} is not accepting node submit (state: {})",
-                exec.state().as_str()
-            )),
-            NodeSubmitRejection::NodeNotFound => WorkflowRuntimeError::ValidationError(format!(
-                "node '{node_name}' was not found in execution '{execution_id}'"
-            )),
-            NodeSubmitRejection::AttemptNotCurrent => WorkflowRuntimeError::InvalidState(format!(
-                "active node execution '{node_execution_id}' for node '{node_name}' was not found"
-            )),
-        })?;
+    let target =
+        exec.admit_node_submit(node_execution_id)
+            .map_err(|rejection| match rejection {
+                NodeSubmitRejection::ExecutionNotActive => {
+                    WorkflowRuntimeError::InvalidState(format!(
+                        "execution {execution_id} is not accepting node submit (state: {})",
+                        exec.state().as_str()
+                    ))
+                }
+                NodeSubmitRejection::NodeExecutionNotFound => {
+                    WorkflowRuntimeError::ValidationError(format!(
+                "node execution '{node_execution_id}' was not found in execution '{execution_id}'"
+            ))
+                }
+                NodeSubmitRejection::AttemptNotCurrent => WorkflowRuntimeError::InvalidState(
+                    format!("active node execution '{node_execution_id}' was not found"),
+                ),
+            })?;
     Ok(SubmissionTargetContext {
+        node_name: target.node_name,
         session_id: target.session_id,
         attempt: target.attempt,
     })
@@ -189,30 +186,13 @@ mod tests {
     }
 
     #[test]
-    fn validate_submit_output_request_rejects_invalid_identity_fields() {
+    fn validate_submit_output_request_requires_node_execution_identity() {
         assert!(matches!(
-            validate_submit_output_request("not-a-uuid", "review", "node-execution-1"),
-            Err(WorkflowRuntimeError::ValidationError(message))
-                if message == "execution_id must be UUID"
-        ));
-        assert!(matches!(
-            validate_submit_output_request(
-                "00000000-0000-0000-0000-000000000001",
-                " ",
-                "node-execution-1"
-            ),
-            Err(WorkflowRuntimeError::ValidationError(message))
-                if message == "node_name must not be empty"
-        ));
-        assert!(matches!(
-            validate_submit_output_request(
-                "00000000-0000-0000-0000-000000000001",
-                "review",
-                ""
-            ),
+            validate_submit_output_request(""),
             Err(WorkflowRuntimeError::ValidationError(message))
                 if message == "node_execution_id must not be empty"
         ));
+        assert!(validate_submit_output_request("node-execution-1").is_ok());
     }
 
     #[test]

--- a/src-tauri/src/usecase/workflow/runtime_command.rs
+++ b/src-tauri/src/usecase/workflow/runtime_command.rs
@@ -273,6 +273,15 @@ mod tests {
             "node-execution-test".to_string()
         }
 
+        async fn resolve_workflow_execution_id(
+            &self,
+            _node_execution_id: &str,
+        ) -> Result<Option<String>, WorkflowError> {
+            Err(WorkflowError::external(
+                "control plane is not used by this test",
+            ))
+        }
+
         async fn load_active_execution(
             &self,
             _execution_id: &str,
@@ -486,8 +495,6 @@ mod tests {
 
         let submit_err = usecase
             .submit_output(SubmitOutputCommand {
-                execution_id: "00000000-0000-0000-0000-000000000001".to_string(),
-                node_name: "review".to_string(),
                 node_execution_id: "node-execution-1".to_string(),
                 artifact: Some(crate::usecase::workflow::command::SubmitOutputArtifact {
                     contract: " ".to_string(),

--- a/src-tauri/src/workflow_control_plane_acceptance.rs
+++ b/src-tauri/src/workflow_control_plane_acceptance.rs
@@ -521,19 +521,11 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
             .map_err(|error| error.to_string())
     }
 
-    pub async fn submit(
-        &self,
-        execution_id: &str,
-        node_name: &str,
-        node_execution_id: &str,
-    ) -> Result<(), String> {
+    pub async fn submit(&self, node_execution_id: &str) -> Result<(), String> {
         let response: MutationResponse = self
             .post(
-                &format!("/v1/workflow/executions/{execution_id}/submit"),
-                &serde_json::json!({
-                    "node": node_name,
-                    "node_execution_id": node_execution_id,
-                }),
+                &format!("/v1/workflow/node-executions/{node_execution_id}/submit"),
+                &serde_json::json!({}),
             )
             .await?;
         response
@@ -544,18 +536,14 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
 
     pub async fn submit_artifact(
         &self,
-        execution_id: &str,
-        node_name: &str,
         node_execution_id: &str,
         contract: &str,
         value: serde_json::Value,
     ) -> Result<(), String> {
         let response: MutationResponse = self
             .post(
-                &format!("/v1/workflow/executions/{execution_id}/submit"),
+                &format!("/v1/workflow/node-executions/{node_execution_id}/submit"),
                 &serde_json::json!({
-                    "node": node_name,
-                    "node_execution_id": node_execution_id,
                     "artifact": {
                         "contract": contract,
                         "value": value,

--- a/src-tauri/tests/workflow_control_plane_acceptance_test.rs
+++ b/src-tauri/tests/workflow_control_plane_acceptance_test.rs
@@ -249,7 +249,7 @@ async fn test_atui_040_同時submit_stopは競合を利用者へ返さず一度�
     associate_provider_session(&host, &mut terminal, &terminal_owner, "provider-concurrent").await;
 
     let (submit, ()) = tokio::join!(
-        host.submit(&execution_id, &first.node_name, &first.id),
+        host.submit(&first.id),
         emit_provider_stop(&host, &mut terminal, &terminal_owner, "provider-concurrent",),
     );
     submit.unwrap();
@@ -300,12 +300,8 @@ async fn test_atui_040_autoは両signal順序と重複に依存せず後続を�
 
         match order {
             SignalOrder::SubmitThenStop => {
-                host.submit(&execution_id, &first.node_name, &first.id)
-                    .await
-                    .unwrap();
-                host.submit(&execution_id, &first.node_name, &first.id)
-                    .await
-                    .unwrap();
+                host.submit(&first.id).await.unwrap();
+                host.submit(&first.id).await.unwrap();
             }
             SignalOrder::StopThenSubmit => {
                 emit_provider_stop(
@@ -347,9 +343,7 @@ async fn test_atui_040_autoは両signal順序と重複に依存せず後続を�
                 .await;
             }
             SignalOrder::StopThenSubmit => {
-                host.submit(&execution_id, &first.node_name, &first.id)
-                    .await
-                    .unwrap();
+                host.submit(&first.id).await.unwrap();
             }
         }
 
@@ -367,9 +361,7 @@ async fn test_atui_040_autoは両signal順序と重複に依存せず後続を�
             advanced.node_executions[1].agent_session_id
         );
 
-        host.submit(&execution_id, &first.node_name, &first.id)
-            .await
-            .unwrap();
+        host.submit(&first.id).await.unwrap();
         emit_provider_stop(
             &host,
             &mut first_terminal,
@@ -421,9 +413,7 @@ async fn test_atui_041_approvalは両signal成立後だけ対象nodeを承認で
 
         match order {
             SignalOrder::SubmitThenStop => {
-                host.submit(&execution_id, &node.node_name, &node.id)
-                    .await
-                    .unwrap();
+                host.submit(&node.id).await.unwrap();
             }
             SignalOrder::StopThenSubmit => {
                 emit_provider_stop(
@@ -453,9 +443,7 @@ async fn test_atui_041_approvalは両signal成立後だけ対象nodeを承認で
                 .await;
             }
             SignalOrder::StopThenSubmit => {
-                host.submit(&execution_id, &node.node_name, &node.id)
-                    .await
-                    .unwrap();
+                host.submit(&node.id).await.unwrap();
             }
         }
         let waiting = host.execution(&execution_id).await.unwrap().unwrap();
@@ -529,9 +517,7 @@ async fn test_atui_041_fanout兄弟は独立し全子成功時だけ一度完了
     )
     .await;
 
-    host.submit(&execution_id, &first.node_name, &first.id)
-        .await
-        .unwrap();
+    host.submit(&first.id).await.unwrap();
     emit_provider_stop(
         &host,
         &mut first_terminal,
@@ -576,9 +562,7 @@ async fn test_atui_041_fanout兄弟は独立し全子成功時だけ一度完了
         AcceptanceWorkflowExecutionStatus::Completed
     );
 
-    host.submit(&execution_id, &second.node_name, &second.id)
-        .await
-        .unwrap();
+    host.submit(&second.id).await.unwrap();
     emit_provider_stop(
         &host,
         &mut second_terminal,
@@ -638,10 +622,7 @@ async fn test_atui_042_片側signalは再起動後も同じattemptへ復元さ�
         )
         .await;
         match signal {
-            SignalOrder::SubmitThenStop => host_before
-                .submit(&execution_id, &node.node_name, &node.id)
-                .await
-                .unwrap(),
+            SignalOrder::SubmitThenStop => host_before.submit(&node.id).await.unwrap(),
             SignalOrder::StopThenSubmit => {
                 emit_provider_stop(
                     &host_before,
@@ -704,9 +685,7 @@ async fn test_atui_042_retryは新attemptと新sessionを作り旧stopを混入�
         .unwrap();
     receive_until(&mut old_terminal, "releash-fixture-input-complete-0").await;
     associate_provider_session(&host, &mut old_terminal, &old_owner, "provider-retry-old").await;
-    host.submit(&execution_id, &old_attempt.node_name, &old_attempt.id)
-        .await
-        .unwrap();
+    host.submit(&old_attempt.id).await.unwrap();
     let retryable = host.execution(&execution_id).await.unwrap().unwrap();
     assert!(retryable.node_executions[0].can_retry);
 
@@ -750,9 +729,7 @@ async fn test_atui_042_retryは新attemptと新sessionを作り旧stopを混入�
         .unwrap();
     receive_until(&mut new_terminal, "releash-fixture-input-complete-0").await;
     associate_provider_session(&host, &mut new_terminal, &new_owner, "provider-retry-new").await;
-    host.submit(&execution_id, &new_attempt.node_name, &new_attempt.id)
-        .await
-        .unwrap();
+    host.submit(&new_attempt.id).await.unwrap();
     emit_provider_stop(&host, &mut new_terminal, &new_owner, "provider-retry-new").await;
     wait_for_execution_status(
         &host,
@@ -802,8 +779,6 @@ async fn test_atui_042_別bindingのstopを拒否しinvalid_artifactはsubmitご
 
     assert!(host
         .submit_artifact(
-            &execution_id,
-            &node.node_name,
             &node.id,
             "acceptance-result",
             serde_json::json!({"unexpected": "value"}),
@@ -815,8 +790,6 @@ async fn test_atui_042_別bindingのstopを拒否しinvalid_artifactはsubmitご
     assert!(!after_invalid.node_executions[0].has_artifact);
 
     host.submit_artifact(
-        &execution_id,
-        &node.node_name,
         &node.id,
         "acceptance-result",
         serde_json::json!({"result": "ok"}),
@@ -883,9 +856,7 @@ async fn test_atui_042_workflow完了後もagent_sessionとptyを維持し追加
         }),
     )
     .await;
-    host.submit(&execution_id, &node.node_name, &node.id)
-        .await
-        .unwrap();
+    host.submit(&node.id).await.unwrap();
     send_hook(
         &host,
         &mut terminal,


### PR DESCRIPTION
## 概要

- artifact宣言なしAgent NodeへArtifactなしSubmitコマンドを初回指示として注入
- 通常NodeのNodeExecution IDをプロンプト生成境界へ渡し、必須のnode-execution引数を付与
- fanout childにもArtifactなしSubmitを注入し、artifactあり経路のcontract guidanceを維持

## テスト

- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test

Closes #1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 成果物がないノードでも、ワークフロー完了時の出力送信アクションが提示されるようになりました。
  * 成果物がある場合は、必要な形式や実行情報を含む完了アクションが生成されます。
* **改善**
  * 出力送信の対象指定がノード実行IDに統一され、CLIおよびAPIの操作が簡潔になりました。
  * 通常ノードと分岐ノードで、完了処理の追跡性と実行情報の正確性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->