### PR TITLE
fix(agent-tui): provider TUIへbase branchを伝搬する

### DIFF
--- a/src-tauri/src/adaptor/gateway/agent_session/provider_agent_launch_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/provider_agent_launch_gateway.rs
@@ -35,6 +35,7 @@ impl ProviderAgentLaunchGateway for LocalProviderAgentLaunchGateway {
         armed: &ArmedProviderLifecycle,
         executable: ResolvedProviderExecutable,
         launch: ProviderSessionLaunch,
+        worktree_path: &str,
     ) -> Result<PreparedProviderLaunch, ProviderAgentLaunchGatewayError> {
         let session_directory = self.session_directory(armed.scope().agent_session_id());
         let resource_directory = session_directory.join(digest(armed.binding_id()));
@@ -77,6 +78,15 @@ impl ProviderAgentLaunchGateway for LocalProviderAgentLaunchGateway {
             "RELEASH_DATA_DIR".to_string(),
             self.data_dir.to_string_lossy().into_owned(),
         ));
+        if let Some(base_branch) =
+            crate::adaptor::gateway::repository::git_config::resolve_effective_base_branch(
+                worktree_path,
+            )
+            .ok()
+            .flatten()
+        {
+            environment.push(("RELEASH_BASE_BRANCH".to_string(), base_branch));
+        }
         environment.push((
             "RELEASH_PROVIDER_LIFECYCLE_HEALTH_FILE".to_string(),
             resource_directory

--- a/src-tauri/src/adaptor/gateway/agent_session/provider_agent_launch_gateway_test.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/provider_agent_launch_gateway_test.rs
@@ -32,6 +32,7 @@ fn test_provider_launch_gateway_claudeのpluginをlaunch単位で生成しcleanu
             &armed(ProviderKind::Claude),
             ResolvedProviderExecutable::new("/opt/bin/claude".into()).unwrap(),
             ProviderSessionLaunch::New,
+            data_dir.path().to_str().unwrap(),
         )
         .unwrap();
 
@@ -81,6 +82,7 @@ fn test_provider_launch_gateway_codexのresumeを同じroot_process契約で生�
             &armed(ProviderKind::Codex),
             ResolvedProviderExecutable::new("/opt/bin/codex".into()).unwrap(),
             ProviderSessionLaunch::resume("codex-session-1").unwrap(),
+            data_dir.path().to_str().unwrap(),
         )
         .unwrap();
 
@@ -121,6 +123,7 @@ fn test_provider_launch_gateway_両providerへhook実行環境を渡す() {
                 )
                 .unwrap(),
                 ProviderSessionLaunch::New,
+                data_dir.path().to_str().unwrap(),
             )
             .unwrap();
         let launch_directory = prepared.resource_directory().unwrap();
@@ -147,6 +150,77 @@ fn test_provider_launch_gateway_両providerへhook実行環境を渡す() {
     }
 }
 
+#[test]
+fn test_provider_launch_gateway_解決済みbase_branchを両providerへ渡す() {
+    let data_dir = tempdir().unwrap();
+    let (repo_dir, repo) = crate::test_support::git::create_test_repo();
+    crate::test_support::git::create_initial_commit(&repo);
+    let repo_path = repo_dir.path().to_str().unwrap();
+    let base_branch = repo.head().unwrap().shorthand().unwrap().to_string();
+    let base_commit = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.branch("feature", &base_commit, false).unwrap();
+    repo.set_head("refs/heads/feature").unwrap();
+    repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    crate::adaptor::gateway::repository::git_config::set_branch_base_override(
+        repo_path,
+        "feature",
+        Some(&base_branch),
+    )
+    .unwrap();
+    let gateway =
+        LocalProviderAgentLaunchGateway::new(data_dir.path().to_path_buf(), "releash".to_string());
+
+    for provider in [ProviderKind::Claude, ProviderKind::Codex] {
+        let prepared = gateway
+            .prepare(
+                &armed(provider),
+                ResolvedProviderExecutable::new(
+                    match provider {
+                        ProviderKind::Claude => "/opt/bin/claude",
+                        ProviderKind::Codex => "/opt/bin/codex",
+                    }
+                    .into(),
+                )
+                .unwrap(),
+                ProviderSessionLaunch::New,
+                repo_path,
+            )
+            .unwrap();
+
+        assert!(prepared
+            .process()
+            .environment()
+            .iter()
+            .any(|(key, value)| { key == "RELEASH_BASE_BRANCH" && value == &base_branch }));
+    }
+}
+
+#[test]
+fn test_provider_launch_gateway_base_branch未解決なら環境変数を渡さない() {
+    let data_dir = tempdir().unwrap();
+    let (repo_dir, repo) = crate::test_support::git::create_test_repo();
+    let head = crate::test_support::git::create_initial_commit(&repo);
+    repo.set_head_detached(head).unwrap();
+    let gateway =
+        LocalProviderAgentLaunchGateway::new(data_dir.path().to_path_buf(), "releash".to_string());
+
+    let prepared = gateway
+        .prepare(
+            &armed(ProviderKind::Claude),
+            ResolvedProviderExecutable::new("/opt/bin/claude".into()).unwrap(),
+            ProviderSessionLaunch::New,
+            repo_dir.path().to_str().unwrap(),
+        )
+        .unwrap();
+
+    assert!(prepared
+        .process()
+        .environment()
+        .iter()
+        .all(|(key, _)| key != "RELEASH_BASE_BRANCH"));
+}
+
 #[cfg(unix)]
 #[test]
 fn test_provider_launch_gateway_non_utf8実行pathをterminal_processまで保持する() {
@@ -164,6 +238,7 @@ fn test_provider_launch_gateway_non_utf8実行pathをterminal_processまで保�
             &armed(ProviderKind::Claude),
             ResolvedProviderExecutable::new(executable.clone()).unwrap(),
             ProviderSessionLaunch::New,
+            data_dir.path().to_str().unwrap(),
         )
         .unwrap();
 

--- a/src-tauri/src/adaptor/gateway/repository/git_config.rs
+++ b/src-tauri/src/adaptor/gateway/repository/git_config.rs
@@ -142,6 +142,45 @@ fn resolve_base_ref_oid(repo: &git2::Repository, base_name: &str) -> Option<git2
         .or_else(|| peel(&format!("refs/remotes/origin/{base_name}")))
 }
 
+/// Provider TUI の `RELEASH_BASE_BRANCH` に渡す現在ブランチの実効 base 名を返す。
+/// detached / unborn / ref 不在 / merge-base 不成立は `None`。
+pub(crate) fn resolve_effective_base_branch(
+    repo_path: &str,
+) -> Result<Option<String>, RepositoryError> {
+    let repo = match client::open(repo_path) {
+        Ok(repo) => repo,
+        Err(_) => return Ok(None),
+    };
+    let head = match repo.head() {
+        Ok(head) => head,
+        Err(_) => return Ok(None),
+    };
+    if !head.is_branch() {
+        return Ok(None);
+    }
+    let current_oid = match head.target() {
+        Some(oid) => oid,
+        None => return Ok(None),
+    };
+    let branch_name = match head.shorthand() {
+        Ok(branch_name) => branch_name.to_string(),
+        Err(_) => return Ok(None),
+    };
+    let config = repo.config().ok();
+    let base_name = match resolve_branch_base(&repo, config.as_ref(), &branch_name) {
+        Some(base_name) => base_name,
+        None => return Ok(None),
+    };
+    let base_oid = match resolve_base_ref_oid(&repo, &base_name) {
+        Some(base_oid) => base_oid,
+        None => return Ok(None),
+    };
+    if repo.merge_base(current_oid, base_oid).is_err() {
+        return Ok(None);
+    }
+    Ok(Some(base_name))
+}
+
 pub(crate) fn resolve_base_commit_oid(
     path_hint: &str,
     base_name: &str,
@@ -303,6 +342,46 @@ mod git_config_gateway_tests {
 
         let result = resolve_current_base_branch(dir.path().to_str().unwrap()).unwrap();
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_実効base_ref実在ならsome_ref不在ならnone() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        let repo_path = dir.path().to_str().unwrap();
+        let default_branch = repo.head().unwrap().shorthand().unwrap().to_string();
+
+        checkout_feature_branch(&repo);
+        set_branch_base_override(repo_path, "feature", Some(&default_branch)).unwrap();
+        assert_eq!(
+            resolve_effective_base_branch(repo_path).unwrap(),
+            Some(default_branch)
+        );
+
+        set_branch_base_override(repo_path, "feature", Some("no-such-branch")).unwrap();
+        assert_eq!(resolve_effective_base_branch(repo_path).unwrap(), None);
+    }
+
+    #[test]
+    fn test_実効base_merge_base不成立ならnone() {
+        let (dir, repo) = create_test_repo();
+        create_initial_commit(&repo);
+        let repo_path = dir.path().to_str().unwrap();
+        let default_branch = repo.head().unwrap().shorthand().unwrap().to_string();
+        let signature = repo.signature().unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let orphan = repo
+            .commit(None, &signature, &signature, "orphan root", &tree, &[])
+            .unwrap();
+        repo.reference("refs/heads/feature", orphan, true, "orphan")
+            .unwrap();
+        repo.set_head("refs/heads/feature").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+        set_branch_base_override(repo_path, "feature", Some(&default_branch)).unwrap();
+
+        assert_eq!(resolve_effective_base_branch(repo_path).unwrap(), None);
     }
 
     #[test]

--- a/src-tauri/src/domain/agent_session/provider_launch_gateway.rs
+++ b/src-tauri/src/domain/agent_session/provider_launch_gateway.rs
@@ -60,6 +60,7 @@ pub(crate) trait ProviderAgentLaunchGateway: Send + Sync {
         armed: &ArmedProviderLifecycle,
         executable: ResolvedProviderExecutable,
         launch: ProviderSessionLaunch,
+        worktree_path: &str,
     ) -> Result<PreparedProviderLaunch, ProviderAgentLaunchGatewayError>;
 
     fn cleanup(&self, agent_session_id: &str) -> Result<(), ProviderAgentLaunchGatewayError>;

--- a/src-tauri/src/usecase/agent_session/agent_session_launch.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_launch.rs
@@ -434,7 +434,12 @@ impl AgentSessionLaunchUsecase {
         );
         let prepared = match self
             .launch_gateway
-            .prepare(&durable.armed, durable.executable.clone(), launch)
+            .prepare(
+                &durable.armed,
+                durable.executable.clone(),
+                launch,
+                durable.created.session().worktree_path(),
+            )
             .map_err(map_launch_error)
         {
             Ok(prepared) => prepared,
@@ -575,6 +580,7 @@ impl AgentSessionLaunchUsecase {
             executable,
             ProviderSessionLaunch::resume(&request.provider_session_id)
                 .map_err(|_| AgentSessionLaunchUsecaseError::Corrupt)?,
+            associated.session().worktree_path(),
         ) {
             Ok(prepared) => prepared,
             Err(_) => {

--- a/src-tauri/src/usecase/agent_session/agent_session_lifecycle.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_lifecycle.rs
@@ -469,6 +469,7 @@ impl AgentSessionLifecycleUsecase {
             executable,
             ProviderSessionLaunch::resume(provider_session_id)
                 .map_err(|_| AgentSessionLifecycleUsecaseError::Corrupt)?,
+            session.session().worktree_path(),
         ) {
             Ok(prepared) => prepared,
             Err(_) => {

--- a/src-tauri/src/usecase/agent_session/agent_session_lifecycle_test.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_lifecycle_test.rs
@@ -70,6 +70,7 @@ impl ProviderAgentLaunchGateway for RecordingResumeLaunches {
         armed: &ArmedProviderLifecycle,
         _executable: ResolvedProviderExecutable,
         launch: ProviderSessionLaunch,
+        _worktree_path: &str,
     ) -> Result<PreparedProviderLaunch, ProviderAgentLaunchGatewayError> {
         self.armed.lock().unwrap().push(armed.clone());
         self.launches.lock().unwrap().push(launch);

--- a/src-tauri/src/usecase/agent_session/agent_session_test.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_test.rs
@@ -254,6 +254,7 @@ impl ProviderAgentLaunchGateway for RecordingLaunchGateway {
         armed: &ArmedProviderLifecycle,
         executable: ResolvedProviderExecutable,
         launch: ProviderSessionLaunch,
+        _worktree_path: &str,
     ) -> Result<PreparedProviderLaunch, ProviderAgentLaunchGatewayError> {
         if *self.fail_prepare.lock().unwrap() {
             return Err(ProviderAgentLaunchGatewayError::Unavailable);


### PR DESCRIPTION
## 概要
- Provider TUI session起動時にworktreeの実効base branchを解決する
- 解決できた場合のみRELEASH_BASE_BRANCHをprocess環境へ追加する
- detached、unborn、ref不在、merge-base不成立では環境変数を追加しない
- 新規起動、履歴再開、停止後再開の全経路でworktree pathを渡す

## テスト
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test

Closes #1633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * エージェント起動時に、作業ツリーに対応する有効なベースブランチ情報を自動的に引き渡すようになりました。
  * スタンドアロン起動とセッション再開の両方で、適切なブランチ情報が利用されます。

* **バグ修正**
  * ベースブランチを解決できない場合に、不正な情報を起動プロセスへ渡さないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->