### PR TITLE
fix(event-store): 未使用テーブルを削除し起動時に物理サイズを回収する

### DIFF
--- a/specs/issues-1639/behavior.md
+++ b/specs/issues-1639/behavior.md
@@ -1,0 +1,57 @@
+## B-001: 旧schemaストアから未使用データを除去する
+
+GIVEN 対応対象の旧schemaバージョンのストアに`message_projection`、`terminal_records`、`stop_resolutions`、`idx_message_projection_ordinal`、および残存データが存在する
+WHEN 現行版がそのストアを開く
+THEN ストアは移行後のschemaで利用可能になる
+AND 3テーブル、`idx_message_projection_ordinal`、および残存データはストアに存在しない
+
+## B-002: 新規ストアに未使用テーブルを作成しない
+
+GIVEN local event storeがまだ存在しない
+WHEN 現行版がストアを新規作成する
+THEN 作成されたストアに`message_projection`、`terminal_records`、`stop_resolutions`、および`idx_message_projection_ordinal`は存在しない
+
+## B-003: 未使用テーブルを再作成しない
+
+GIVEN 移行または新規作成によって現行schemaになったストアが存在する
+WHEN 現行版がそのストアを再び開く
+THEN `message_projection`、`terminal_records`、`stop_resolutions`、および`idx_message_projection_ordinal`は再作成されない
+
+## B-004: 発火条件を満たす空き領域を起動時に回収する
+
+GIVEN ストアの`freelist_count / page_count`が25%以上であり、かつfreelistが64MB相当以上である
+WHEN 現行版がそのストアを開く
+THEN 起動時に空き領域がストア本体ファイルの物理サイズから回収される
+AND ストアは回収後のファイルで利用可能になる
+
+## B-005: 発火条件を満たさない起動では物理縮小を行わない
+
+GIVEN ストアの`freelist_count / page_count`が25%未満、またはfreelistが64MB相当未満である
+WHEN 現行版がそのストアを開く
+THEN ストア本体ファイルの物理縮小は実行されない
+AND 発火判定のためのデータベースファイル走査は発生しない
+
+## B-006: 物理縮小の失敗後も元のストアで起動する
+
+GIVEN 発火条件を満たすストアの物理縮小がディスク不足等により完了できない
+WHEN 現行版がそのストアを開く
+THEN 物理縮小用の一時ファイルは残らない
+AND 元のストアファイルのまま起動が継続し、ストアを利用できる
+
+## B-007: 物理縮小後も使用中データの整合性を維持する
+
+GIVEN 発火条件を満たすストアの使用中テーブルと`store_metadata`にデータが存在する
+WHEN 現行版が物理縮小とストア本体ファイルの差し替えを完了する
+THEN 使用中テーブルと`store_metadata`のデータは縮小前と同じ内容で利用できる
+AND 差し替え前の`-wal`または`-shm`ファイルに由来する不整合は観測されない
+
+## 要件IDとBehavior IDの対応表
+
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001 |
+| R-002 | B-002, B-003 |
+| R-003 | B-004 |
+| R-004 | B-005 |
+| R-005 | B-006 |
+| R-006 | B-007 |

--- a/specs/issues-1639/design.md
+++ b/specs/issues-1639/design.md
@@ -1,0 +1,113 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### 責務 owner と変更対象
+
+本変更は Rust backend の `LocalEventStore` が所有する。schema shape と version evolution は既存どおり `src-tauri/src/adaptor/gateway/local_event_store/schema.rs`、writer lock 取得から reader pool 構築までの起動順序は `src-tauri/src/adaptor/gateway/local_event_store/store.rs` を正本とする。SQLite の物理回収と固定 database path の差し替えは、新設する `src-tauri/src/adaptor/gateway/local_event_store/maintenance.rs` に閉じ込め、`store.rs` は起動順序への組み込みだけを担う。
+
+この owner は、Issue #1639 の確定方針、既存の単一 writer／固定 SQLite authority、[src-tauri/AGENTS.md](../../src-tauri/AGENTS.md)、[Gateway 規約](../../docs/architecture/GATEWAY.md)、[Infrastructure 規約](../../docs/architecture/INFRASTRUCTURE.md) に基づく。既存 app data GC、usecase、controller、frontend は変更しない。
+
+主要な変更対象は次のとおり。
+
+| Path | 変更の要旨 |
+| --- | --- |
+| `src-tauri/src/adaptor/gateway/local_event_store/schema.rs` | schema v5、未使用 schema object の削除、supported schema からの移行、現行 schema の不在検証を所有する。 |
+| `src-tauri/src/adaptor/gateway/local_event_store/store.rs` | schema evolution と既存の checkpoint／sync 後、reader connection と worker の生成前に起動時保守を呼び出す。 |
+| `src-tauri/src/adaptor/gateway/local_event_store/maintenance.rs` | 発火判定、`VACUUM INTO`、出力検証、固定 path の差し替え、失敗時 cleanup を所有する。 |
+| `src-tauri/src/adaptor/gateway/local_event_store/layout.rs` | 保守用一時 database と、その SQLite sidecar の固定 path 導出を追加する。app data の列挙は行わない。 |
+| `src-tauri/src/adaptor/gateway/local_event_store/fault.rs` | 物理回収失敗と差し替え境界を in-process で検証する fault point を追加する。production では従来どおり no-op とする。 |
+
+schema evolution は store の正当性を確立する必須処理であり、失敗時は既存の `SchemaEvolutionFailed` で起動を止める。物理回収は正当性確立後の保守であり、失敗しても canonical database を変更せず、利用可能な writer connection を返して起動を続ける。この境界により R-001／R-002 と R-005 の失敗意味を混在させない。
+
+| 上流契約 | 対応する設計判断 |
+| --- | --- |
+| R-001、R-002／B-001、B-002、B-003 | schema v5 の原子的移行と現行 schema の不在 invariant |
+| R-003、R-004／B-004、B-005 | header-backed PRAGMA による AND 判定と起動時保守 |
+| R-005、R-006／B-006、B-007 | 元 database を変更しない出力生成、検証後の原子的差し替え、sidecar 分離 |
+
+#### 起動順序と原子性境界
+
+`LocalEventStore::open` は writer lock file の排他保持中に、既存 database の分類、writer connection の open、必要な schema evolution、現行 schema 検証、metadata 更新、`wal_checkpoint(TRUNCATE)`、database sync を完了する。その後に起動時保守を実行し、保守が返した canonical writer connection から metadata を読み、reader pool と writer／reader worker を生成する。
+
+物理差し替えの原子性境界は、同一 app data directory 内の保守用一時 database から固定 database path への platform 対応 replace とする。replace 前は元 database だけが authority、replace 成功後は検証・sync 済みの縮小 database だけが authority であり、pointer file、generation directory、backup authority は追加しない。writer lock は判定から reader pool 構築まで継続保持する。
+
+#### 必要な検証
+
+- B-001〜B-003 は、supported schema v1〜v4 の file-backed SQLite と新規 store の schema object を検査し、移行後と再起動後に対象 3 テーブル／index が存在しないことを検証する。
+- B-004／B-005 は、発火判定を純粋な整数計算として境界値検証し、file-backed SQLite では発火時だけ固定 database の物理サイズと file identity が更新されることを検証する。非発火経路は保守用 fault point が到達しないことにより、`VACUUM INTO` が実行されないことを確認する。
+- B-006 は `VACUUM INTO` と replace の前後へ fault を注入し、元 database の identity／内容で再 open でき、一時 database とその sidecar が残らないことを検証する。
+- B-007 は縮小前後の使用中テーブルと `store_metadata` の内容、現行 schema 検証、再 open 後の read／write、および旧 `-wal`／`-shm` が差し替え後の authority に再利用されないことを file-backed SQLite で検証する。
+
+検証コードは [Test 規約](../../docs/architecture/TEST.md) に従い対象 module 内へ置き、外部 process は起動しない。
+
+### Interface
+
+公開 command、Tauri／WebSocket protocol、domain trait は変更しない。既存の `LocalEventStore::open(LocalEventStoreConfig)` が唯一の入口であり、成功時は schema v5 かつ保守判定済みの store を返す。
+
+内部境界として `maintenance.rs` の起動時保守は `StoreLayout` と唯一の writer connection の ownership を受け取り、元の connection または差し替え後に再 open した connection を返す。新しい trait や runtime command は追加しない。
+
+schema evolution の公開失敗分類は既存の `SchemaEvolutionFailed` を維持する。物理回収の失敗分類は外部 interface に追加せず、保守内部で元 store への継続に収束させる。これにより既存 caller は物理回収の有無を条件にせず、従来と同じ open contract を利用できる。
+
+### Data Model
+
+永続 record は追加しない。`store_metadata.schema_version` と `PRAGMA user_version` を 5 に更新するが、`installation_id`、HMAC key、`process_instance_id`、各使用中 record の identity と内容は移行・縮小を通じて保持する。
+
+保守用一時 database は `local-event-store.vacuum.sqlite3` という固定名で canonical database と同じ directory に置く。一時 database とその `-wal`／`-shm` は authority、履歴、再開 token として保持せず、起動時保守の入口と失敗出口で cleanup 対象にする。保守実行履歴、最終実行時刻、freelist の snapshot は永続化せず、発火条件は毎起動時の SQLite header 値から導出する。
+
+### Database
+
+schema v5 では `message_projection`、`terminal_records`、`stop_resolutions` と `idx_message_projection_ordinal` を現行 DDL から除去する。v4→v5 を追加し、既存の v1／v2／v3 移行も同じ最終 v5 transaction に収束させる。各経路は対象 object の削除、`store_metadata.schema_version = 5`、`PRAGMA user_version = 5` を同じ schema evolution transaction で確定し、commit 後に現行 schema を再検証する。
+
+既存 database の分類は v4 を supported schema として受け入れる。`validate_current_schema` は対象 3 テーブルと index の不在を必須 invariant とし、index の存在要求から `idx_message_projection_ordinal` を外す。v1 入力の形を確認する `validate_supported_schema_v1` にある `terminal_records` の検証は、移行前 schema の識別根拠なので維持する。
+
+物理回収の access path は、writer connection に対する `PRAGMA page_count`、`PRAGMA freelist_count`、`PRAGMA page_size` と `VACUUM INTO` に限定する。`page_count` と `freelist_count` は [SQLite PRAGMA](https://www.sqlite.org/pragma.html) が提供する page 数を使用し、テーブル走査や `dbstat` を発火判定へ使用しない。
+
+### UI/UX
+
+該当なし。
+
+### Algorithm
+
+#### 発火判定
+
+page 数と page size は非負整数へ検証してから計算する。`page_count == 0` は非発火とし、それ以外では次の二条件をともに満たした場合だけ縮小する。
+
+- `freelist_count * 4 >= page_count`
+- `freelist_count * page_size >= 64 MiB`
+
+浮動小数点除算を使わず cross multiplication と checked integer arithmetic を使うことで、25% 境界と 64 MiB 境界を丸めずに判定する。どちらか一方でも満たさない場合は同じ writer connection をそのまま返し、`VACUUM INTO`、一時 database の作成、database file の差し替えを行わない。
+
+#### 物理回収と差し替え
+
+保守の入口で前回中断に由来する固定一時 database とその sidecar を cleanup する。発火時は元 writer connection の `synchronous=FULL` を維持したまま `VACUUM INTO` で一時 database を生成する。[SQLite の VACUUM 仕様](https://www.sqlite.org/lang_vacuum.html) が保証する元 database と同じ logical content の consistent snapshot を利用し、完了後に一時 database の現行 schema／integrity、owner-only permission、file sync を確認する。検証が終わるまで元 database は変更しない。
+
+一時 database の準備成功後に元 writer connection を閉じる。事前に完了した `wal_checkpoint(TRUNCATE)` と正常 close により committed WAL を本体へ反映した状態で、旧 canonical path の `-wal`／`-shm` を除去する。これは WAL が database の persistent state の一部であるという [SQLite WAL 仕様](https://www.sqlite.org/wal.html) に従い、open 中または checkpoint 前の WAL を単独で削除しないための順序制約である。
+
+同一 directory 内で一時 database を canonical path へ原子的に replace し、directory を sync する。Unix では同一 filesystem の rename、Windows では repository で採用済みの `ReplaceFileW`／`MoveFileExW` write-through 方式を用いる。replace した database は既存の `open_existing_writer` から再 open し、そこで `journal_mode=WAL` と `synchronous=FULL` を再確立する。したがって `VACUUM INTO` 出力の journal mode を canonical mode と仮定せず、旧名の sidecar を新しい本体へ組み合わせない。
+
+`VACUUM INTO`、一時 database の検証・sync・permission 設定、sidecar cleanup、replace のいずれかが replace 成功前に失敗した場合は、一時 artifact を cleanup し、canonical path の元 database をそのまま使用する。元 connection を閉じた後の失敗では、変更されていない canonical path を `open_existing_writer` で再 open する。失敗は correlation を付けた warning として記録するが、schema validation 成功済みの元 store の起動は継続する。
+
+### Infra
+
+新しい service、daemon、background task、dependency、deployment 設定は追加しない。保守は `LocalEventStore::open` を同期でブロックし、writer／reader worker が起動した後には実行しない。既存 app data GC の構成と実行時刻は変更しない。
+
+## Alternatives Considered
+
+- schema v5 の migration 内だけで物理回収する案は採用しない。schema 移行後に空き領域が再び閾値へ達した場合に回収経路がなくなり、R-003 を継続して満たせないためである。
+- 既存 app data GC から回収する案は採用しない。GC 実行時には reader pool と writer worker が既に動作しており、安全な固定 path 差し替え境界を所有しないためである。
+- canonical database に通常の `VACUUM` を直接実行する案は採用しない。失敗時にも元 file を不変で保持する R-005 の境界を、出力検証後の原子的差し替えとして構成できないためである。
+- auto-vacuum を有効化する案は採用しない。既存 store の常設回収方式と schema／file 再構築の扱いを変更し、確定した `VACUUM INTO` と閾値発火の契約から外れるためである。
+
+## Cross-cutting concerns
+
+- 耐久性: 一時 database file、atomic replace、app data directory の順に sync し、replace 前の中断では元 database、replace 後の中断では検証済み database のどちらかだけを canonical path とする。
+- 性能: 非発火起動では header-backed PRAGMA と整数計算だけを追加する。発火時の全 database 再構築は reader／worker 起動前に一度だけ同期実行する。
+- セキュリティ: 一時 database にも canonical database と同じ owner-only permission を設定し、削除済み page の内容を一時 artifact として残さない。
+- 可観測性: skip、成功、失敗を既存 logging 経路へ記録し、database 内容はログへ含めない。物理回収の成否を新しい public state や永続 record にはしない。
+
+## Risks
+
+該当なし。

--- a/specs/issues-1639/requirements.md
+++ b/specs/issues-1639/requirements.md
@@ -1,0 +1,62 @@
+# Context
+
+- 入力: [Issue #1639](https://github.com/siro33950/releash/issues/1639) — [event store] 旧message projectionの残存データ7.2GBでストアが8.7GBに肥大化している（クリーンアップ経路がない）（OPEN）。要求の正本。本文（現状・経緯・影響）と 2026-08-13 の「対応方針（確定）」コメントからなる。
+- 補助資料:
+  - [Issue #1640](https://github.com/siro33950/releash/issues/1640) — shutdown reconciliation からの復旧不能問題。2026-08-13 のフリーズ障害の隣接 Issue であり、本変更の対象外境界を定める参照。
+  - [PR #1621](https://github.com/siro33950/releash/pull/1621) — MS87 Agent TUI 移行の一括統合（MERGED、v0.4.0）。残存データの書き込み元だった旧 message projection 実装を削除した変更。
+- 確定済みの背景:
+  - local event store は `~/Library/Application Support/com.releash.app/local-event-store.sqlite3`。SQLite（WAL モード）で、書き込みはプロセスが writer lock file を排他保持する。
+  - 旧 message projection 実装は PR #1621 で削除済み。現行コードは `message_projection` を読みも書きもしない。残存データへの最終書き込みは 2026-08-12 00:00 で既に停止している。
+  - SQLite は行を削除してもファイルサイズが自動では縮まない。物理サイズの回収には VACUUM 等の操作が別途必要である。
+  - 前例として 2026-07-27 に WAL が 18GB まで肥大化してストアが破損し手動再構築した経緯があり、再構築後 126MB のストアが 2.5 週間で 8.7GB へ再肥大化した。掃除経路がない限り肥大化は繰り返し発生する。
+- 確定済みの制約（Issue #1639 確定コメント）:
+  - 対応は 3 層に分ける。未使用テーブルの削除は schema バージョン移行（一回きり）、物理サイズの回収は store 自身が所有する起動時保守パス（常設）、ファイルシステム層の既存 app data GC は変更しない。
+  - 物理サイズ回収を既存 app data GC に置くことは不成立と確定済み（責務がファイルシステム GC と異なる・ストア開放後の background 実行では差し替えが成立しない・通常 VACUUM は writer を長時間占有する、の 3 理由）。
+  - 物理縮小の発火条件は `freelist_count / page_count >= 25%` かつ freelist が 64MB 相当以上の AND と確定済み。
+  - 縮小はストアの正当性の要件ではなく、失敗時は best-effort で旧ファイルのまま起動を継続する。
+
+# Outcome
+
+- 対象者: Releash を継続運用する利用者（現段階では開発者自身を含む全利用者）。
+- 現在の問題: ストア 8.7GB のうち 7.2GB が現行コードの誰も読み書きしない死蔵データであり、毎起動のスキーマ検証がその全ページを読むため、起動コストの大半が不要データに費やされている。さらに残存データを掃除する経路も、ファイルの物理サイズを回収する経路も存在せず、削除しても縮まないまま放置され、再肥大化しても回収できない。
+- 変更後に実現する状態: 未使用テーブルとその残存データがストアから削除され、肥大化した既存ストアは起動時に物理サイズが回収される。以後空き領域が再肥大化した場合も、常設の保守経路が起動時に自動で回収する。
+
+# Current Behavior
+
+2026-08-13 時点、branch `feat/issues/1639` で確認。コード参照は `src-tauri/src/` からの相対。
+
+- 実測（Issue #1639、dbstat、2026-08-13 時点）: ストア全体 8.7GB。内訳は `message_projection` 7,227MB（31,787 行）、`events` 476MB、`session_projection` 380MB（892 行）、`logical_commits` 124MB（355,348 行）。`message_projection` の中身は旧実装が書いたメッセージ行ごとの累積全文スナップショット（ordinal 1 が 32KB、ordinal 4,599 で 505KB と O(n²) で蓄積。最大セッションは 1 セッションで 4,599 行・1.2GB）。
+- `adaptor/gateway/local_event_store/schema.rs` に `message_projection`（:114）、`terminal_records`（:125）、`stop_resolutions`（:135）の DDL と `idx_message_projection_ordinal`（:210）が残る。`CURRENT_SCHEMA_VERSION` は 4（:10）。
+- `src-tauri/src` 全体でこの 3 テーブルへの参照は `schema.rs` の DDL とスキーマ検証だけであり（grep で確認）、実 SQL（`FROM` / `INTO` / `UPDATE` / `DELETE`）は 0 件、対応する domain 型も存在しない。`src-tauri/tests/agent_session_tui_acceptance.rs` の atui_050 テスト群が、旧 message projection 境界を現行コードが使えないことを検証している。
+- `VACUUM` および freelist を扱うコードは `src-tauri/src` に存在しない（grep 0 件）。ストアの物理サイズを回収する経路はどこにもない。
+- store open シーケンスのスキーマ検証（`schema.rs:1003` / `:1126` の `PRAGMA integrity_check` は DB ファイル全ページを読み、`require_foreign_key_integrity`（`:1178`）の `PRAGMA foreign_key_check` は全 FK 行を走査する）が毎起動実行され、死蔵データも毎回その対象になる。一方この検証は open シーケンス内に限られ、運転中には走らない。
+- 再現手順: 旧実装（v0.4.0 未満）で workflow Command gate のターミナル出力を伴う運用をしたストアを現行版で開く。実際の出力: 3 テーブルと残存データは削除されず、ファイルサイズも維持されたまま、毎起動の全ページ検証が走り続ける。
+
+# Scope / Non-goals
+
+## Scope
+
+- 未使用 3 テーブル（`message_projection` / `terminal_records` / `stop_resolutions`）と付随 index の schema からの削除。schema バージョン移行として行い、既存ストア上の残存データの削除を含む。
+- store 起動時の物理サイズ回収経路（store 自身が所有する保守パス）の新設。
+
+## Non-goals
+
+- 2026-08-13 のアプリフリーズの原因調査・修正。本 Issue の残存データは運転中フリーズの説明にならないことが確定済みで、スコープ外として別途調査する（#1640 / #1641）。
+- shutdown reconciliation からの復旧不能問題（#1640）。
+- 既存 app data GC（ファイルシステム GC）の変更。
+- 未使用 3 テーブル以外の 15 テーブルおよび `store_metadata` のスキーマ・データの変更。
+- 起動後（運転中）の物理サイズ回収の実行。
+
+# Requirements
+
+- R-001: 旧 schema バージョンの既存ストアを現行版で開いたとき、未使用 3 テーブル（`message_projection` / `terminal_records` / `stop_resolutions`）とその index、および残存データがストアから削除されている。
+- R-002: 移行後および新規作成のストアに未使用 3 テーブルが存在せず、以後の起動で再作成されない。
+- R-003: 空き領域が発火条件（`freelist_count / page_count >= 25%` かつ freelist 64MB 相当以上の AND）を満たすストアを開いたとき、起動時にファイルの物理サイズが回収される。
+- R-004: 発火条件を満たさないストアの起動では縮小処理が実行されず、発火判定がファイル走査を伴わない（性能）。
+- R-005: 物理縮小が失敗した場合（ディスク不足等）、一時ファイルの残骸を片付けた上で、旧ファイルのまま起動が継続する（安全性）。
+- R-006: 縮小・差し替えの前後で、使用中テーブルと `store_metadata` のデータが保持され、差し替え後に旧 `-wal` / `-shm` ファイルに由来する不整合が生じない（互換性・安全性）。
+
+# Assumptions / Open Questions
+
+- Assumption: 物理サイズ回収は store open を同期でブロックする。差し替えが安全に成立する区間が open シーケンス中に限られるため非同期化の選択肢はないことが、Issue #1639 確定コメントで受け入れ済みである。
+- Open Questions: なし。

--- a/src-tauri/src/adaptor/gateway/comment/mod.rs
+++ b/src-tauri/src/adaptor/gateway/comment/mod.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 use crate::domain::comment::{
     ReviewActor, ReviewActorKind, ReviewError, ReviewEvent, ReviewTarget,
 };
+use crate::infrastructure::platform::file_replace;
 use crate::usecase::comment::{
     ReviewClock, ReviewEventMutation, ReviewEventStore, ReviewIdGenerator,
 };
@@ -395,7 +396,7 @@ impl FileReviewEventStore {
             file.write_all(json.as_bytes()).map_err(io_error)?;
             file.sync_all().map_err(io_error)?;
         }
-        replace_file(&tmp_path, &file_path)?;
+        file_replace::replace_file(&tmp_path, &file_path).map_err(io_error)?;
         Ok(())
     }
 }
@@ -474,60 +475,6 @@ fn acquire_worktree_file_lock(
             Err(e) => return Err(ReviewError::Io(e.to_string())),
         }
     }
-}
-
-fn replace_file(tmp_path: &Path, file_path: &Path) -> Result<(), ReviewError> {
-    #[cfg(windows)]
-    {
-        replace_file_windows(tmp_path, file_path)
-    }
-    #[cfg(not(windows))]
-    {
-        std::fs::rename(tmp_path, file_path).map_err(io_error)
-    }
-}
-
-#[cfg(windows)]
-fn replace_file_windows(tmp_path: &Path, file_path: &Path) -> Result<(), ReviewError> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::{
-        MoveFileExW, ReplaceFileW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
-        REPLACEFILE_WRITE_THROUGH,
-    };
-
-    fn wide(path: &Path) -> Vec<u16> {
-        path.as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect()
-    }
-
-    let tmp = wide(tmp_path);
-    let dest = wide(file_path);
-    let ok = if file_path.exists() {
-        unsafe {
-            ReplaceFileW(
-                dest.as_ptr(),
-                tmp.as_ptr(),
-                std::ptr::null(),
-                REPLACEFILE_WRITE_THROUGH,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-            )
-        }
-    } else {
-        unsafe {
-            MoveFileExW(
-                tmp.as_ptr(),
-                dest.as_ptr(),
-                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-            )
-        }
-    };
-    if ok == 0 {
-        return Err(ReviewError::Io(std::io::Error::last_os_error().to_string()));
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/adaptor/gateway/local_event_store/fault.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/fault.rs
@@ -22,6 +22,17 @@ pub enum InitialCreateFaultPoint {
     AfterEvidenceUnlink = 10,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaintenanceFaultPoint {
+    BeforeVacuumInto = 1,
+    BeforeOutputValidation = 2,
+    BeforeOutputPermission = 3,
+    BeforeOutputSync = 4,
+    BeforeCanonicalSidecarCleanup = 5,
+    BeforeReplace = 6,
+    AfterReplace = 7,
+}
+
 #[derive(Debug, Default)]
 pub struct FaultInjector {
     fail_before_begin: AtomicUsize,
@@ -36,6 +47,7 @@ pub struct FaultInjector {
     schema_commit_reply_loss: AtomicUsize,
     schema_fail_before_readback: AtomicUsize,
     initial_create_fault_point: AtomicUsize,
+    maintenance_fault_point: AtomicUsize,
     #[cfg(test)]
     initial_create_process_crash_point: AtomicUsize,
     #[cfg(test)]
@@ -101,6 +113,12 @@ impl FaultInjector {
         Self::take(&self.schema_fail_before_commit)
     }
 
+    #[cfg(test)]
+    pub fn arm_schema_fail_before_commit(&self) {
+        self.schema_fail_before_commit
+            .fetch_add(1, Ordering::SeqCst);
+    }
+
     pub fn take_schema_commit_reply_loss(&self) -> bool {
         Self::take(&self.schema_commit_reply_loss)
     }
@@ -113,6 +131,18 @@ impl FaultInjector {
         self.initial_create_fault_point
             .compare_exchange(point as usize, 0, Ordering::SeqCst, Ordering::SeqCst)
             .is_ok()
+    }
+
+    pub fn take_maintenance_fault(&self, point: MaintenanceFaultPoint) -> bool {
+        self.maintenance_fault_point
+            .compare_exchange(point as usize, 0, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    #[cfg(test)]
+    pub fn arm_maintenance_fault(&self, point: MaintenanceFaultPoint) {
+        self.maintenance_fault_point
+            .store(point as usize, Ordering::SeqCst);
     }
 
     /// Terminate the subprocess without unwinding after the production fault

--- a/src-tauri/src/adaptor/gateway/local_event_store/layout.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/layout.rs
@@ -1,8 +1,8 @@
 //! Fixed production layout and initial-create evidence for the local event store.
 //!
-//! The layout deliberately derives exactly three application-owned paths from
-//! app-data. It never enumerates app-data and has no pointer, generation, or
-//! legacy-source concept.
+//! The layout derives only fixed application-owned paths from app-data. It
+//! never enumerates app-data and has no pointer, generation, or legacy-source
+//! concept.
 
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -20,6 +20,7 @@ pub use crate::infrastructure::app_data_path::{
 };
 
 pub const DATABASE_FILE: &str = "local-event-store.sqlite3";
+pub const VACUUM_DATABASE_FILE: &str = "local-event-store.vacuum.sqlite3";
 pub const WRITER_LOCK_FILE: &str = "local-event-store.lock";
 pub const INITIAL_CREATE_EVIDENCE_FILE: &str = "local-event-store.initial-create";
 
@@ -54,6 +55,18 @@ impl StoreLayout {
         self.app_data_root.join(DATABASE_FILE)
     }
 
+    pub fn vacuum_database_path(&self) -> PathBuf {
+        self.app_data_root.join(VACUUM_DATABASE_FILE)
+    }
+
+    pub fn database_sidecar_paths(&self) -> [PathBuf; 2] {
+        sqlite_sidecar_paths(&self.database_path())
+    }
+
+    pub fn vacuum_database_sidecar_paths(&self) -> [PathBuf; 2] {
+        sqlite_sidecar_paths(&self.vacuum_database_path())
+    }
+
     pub fn writer_lock_path(&self) -> PathBuf {
         self.app_data_root.join(WRITER_LOCK_FILE)
     }
@@ -78,6 +91,13 @@ impl StoreLayout {
     pub fn observe(&self, operation: StorePathOperation, path: &Path) {
         self.observer.observe(operation, path);
     }
+}
+
+pub(super) fn sqlite_sidecar_paths(database_path: &Path) -> [PathBuf; 2] {
+    [
+        PathBuf::from(format!("{}-wal", database_path.display())),
+        PathBuf::from(format!("{}-shm", database_path.display())),
+    ]
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src-tauri/src/adaptor/gateway/local_event_store/maintenance.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/maintenance.rs
@@ -1,0 +1,1018 @@
+//! Startup-only physical maintenance for the fixed SQLite authority.
+
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use super::connection::{
+    open_existing_writer, open_reader, set_owner_only_permissions, ConnectionError,
+};
+use super::fault::{FaultInjector, MaintenanceFaultPoint};
+use super::layout::{StoreLayout, StorePathOperation};
+use super::schema::validate_current_schema;
+use crate::infrastructure::platform::file_replace;
+
+const MINIMUM_RECLAIM_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FreelistStats {
+    page_count: u64,
+    freelist_count: u64,
+    page_size: u64,
+}
+
+#[derive(Debug)]
+enum MaintenanceFailure {
+    Sqlite(rusqlite::Error),
+    Connection(ConnectionError),
+    Io(std::io::Error),
+    InvalidPragmaValue,
+    InvalidPathEncoding,
+    ArithmeticOverflow,
+    Injected(MaintenanceFaultPoint),
+}
+
+impl std::fmt::Display for MaintenanceFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sqlite(error) => write!(formatter, "sqlite error: {error}"),
+            Self::Connection(error) => write!(formatter, "connection error: {error}"),
+            Self::Io(error) => write!(formatter, "filesystem error: {error}"),
+            Self::InvalidPragmaValue => formatter.write_str("invalid SQLite page statistic"),
+            Self::InvalidPathEncoding => {
+                formatter.write_str("vacuum database path is not valid UTF-8")
+            }
+            Self::ArithmeticOverflow => {
+                formatter.write_str("SQLite page statistic arithmetic overflow")
+            }
+            Self::Injected(point) => write!(formatter, "injected fault at {point:?}"),
+        }
+    }
+}
+
+impl From<rusqlite::Error> for MaintenanceFailure {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Sqlite(error)
+    }
+}
+
+impl From<ConnectionError> for MaintenanceFailure {
+    fn from(error: ConnectionError) -> Self {
+        Self::Connection(error)
+    }
+}
+
+impl From<std::io::Error> for MaintenanceFailure {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+#[derive(Debug)]
+pub enum StartupMaintenanceError {
+    Connection(ConnectionError),
+}
+
+impl std::fmt::Display for StartupMaintenanceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connection(error) => write!(formatter, "connection error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for StartupMaintenanceError {}
+
+pub fn run_startup_maintenance(
+    layout: &StoreLayout,
+    connection: Connection,
+    fault: &FaultInjector,
+) -> Result<Connection, StartupMaintenanceError> {
+    if let Err(error) = cleanup_vacuum_artifacts(layout) {
+        log_failure("stale artifact cleanup", &error);
+        return Ok(connection);
+    }
+
+    let stats = match read_freelist_stats(&connection) {
+        Ok(stats) => stats,
+        Err(error) => {
+            log_failure("freelist inspection", &error);
+            return Ok(connection);
+        }
+    };
+    let should_reclaim = match should_reclaim(stats) {
+        Ok(should_reclaim) => should_reclaim,
+        Err(error) => {
+            log_failure("freelist threshold calculation", &error);
+            return Ok(connection);
+        }
+    };
+    if !should_reclaim {
+        log::debug!(
+            "local event store startup maintenance skipped: page_count={}, freelist_count={}, page_size={}",
+            stats.page_count,
+            stats.freelist_count,
+            stats.page_size
+        );
+        return Ok(connection);
+    }
+
+    if let Err(error) = prepare_vacuum_database(layout, &connection, fault) {
+        log_failure("vacuum output preparation", &error);
+        cleanup_after_failure(layout);
+        return Ok(connection);
+    }
+
+    drop(connection);
+    match replace_canonical_database(layout, fault) {
+        Ok(()) => {}
+        Err(CanonicalReplacementFailure::PreReplace(error)) => {
+            log_failure("canonical database replacement", &error);
+            cleanup_after_failure(layout);
+            return reopen_canonical(layout);
+        }
+        Err(CanonicalReplacementFailure::PostReplace(error)) => {
+            log_failure(
+                "canonical database replacement applied but directory durability failed",
+                &error,
+            );
+            cleanup_after_failure(layout);
+            return reopen_canonical(layout);
+        }
+    }
+
+    if let Err(error) = cleanup_vacuum_artifacts(layout) {
+        log_failure("post-replacement artifact cleanup", &error);
+    }
+    let reopened = reopen_canonical(layout)?;
+    log::info!(
+        "local event store startup maintenance reclaimed free pages: page_count={}, freelist_count={}, page_size={}",
+        stats.page_count,
+        stats.freelist_count,
+        stats.page_size
+    );
+    Ok(reopened)
+}
+
+fn read_freelist_stats(connection: &Connection) -> Result<FreelistStats, MaintenanceFailure> {
+    fn non_negative(value: i64) -> Result<u64, MaintenanceFailure> {
+        u64::try_from(value).map_err(|_| MaintenanceFailure::InvalidPragmaValue)
+    }
+
+    let page_count = connection.pragma_query_value(None, "page_count", |row| row.get(0))?;
+    let freelist_count = connection.pragma_query_value(None, "freelist_count", |row| row.get(0))?;
+    let page_size = connection.pragma_query_value(None, "page_size", |row| row.get(0))?;
+    Ok(FreelistStats {
+        page_count: non_negative(page_count)?,
+        freelist_count: non_negative(freelist_count)?,
+        page_size: non_negative(page_size)?,
+    })
+}
+
+fn should_reclaim(stats: FreelistStats) -> Result<bool, MaintenanceFailure> {
+    if stats.page_count == 0 {
+        return Ok(false);
+    }
+    let ratio_numerator = stats
+        .freelist_count
+        .checked_mul(4)
+        .ok_or(MaintenanceFailure::ArithmeticOverflow)?;
+    let freelist_bytes = stats
+        .freelist_count
+        .checked_mul(stats.page_size)
+        .ok_or(MaintenanceFailure::ArithmeticOverflow)?;
+    Ok(ratio_numerator >= stats.page_count && freelist_bytes >= MINIMUM_RECLAIM_BYTES)
+}
+
+fn prepare_vacuum_database(
+    layout: &StoreLayout,
+    connection: &Connection,
+    fault: &FaultInjector,
+) -> Result<(), MaintenanceFailure> {
+    let vacuum_path = layout.vacuum_database_path();
+    let vacuum_path_text = vacuum_path
+        .to_str()
+        .ok_or(MaintenanceFailure::InvalidPathEncoding)?;
+    create_empty_vacuum_database(layout, &vacuum_path)?;
+    inject(fault, MaintenanceFaultPoint::BeforeVacuumInto)?;
+    layout.observe(StorePathOperation::Write, &vacuum_path);
+    connection.execute("VACUUM INTO ?1", [vacuum_path_text])?;
+
+    inject(fault, MaintenanceFaultPoint::BeforeOutputValidation)?;
+    layout.observe(StorePathOperation::Open, &vacuum_path);
+    layout.observe(StorePathOperation::Read, &vacuum_path);
+    let output = open_reader(&vacuum_path)?;
+    validate_current_schema(&output)?;
+    drop(output);
+
+    inject(fault, MaintenanceFaultPoint::BeforeOutputPermission)?;
+    layout.observe(StorePathOperation::Metadata, &vacuum_path);
+    set_owner_only_permissions(&vacuum_path)?;
+    verify_owner_only_permissions(&vacuum_path)?;
+
+    inject(fault, MaintenanceFaultPoint::BeforeOutputSync)?;
+    layout.observe(StorePathOperation::Open, &vacuum_path);
+    layout.observe(StorePathOperation::Sync, &vacuum_path);
+    std::fs::File::open(&vacuum_path)?.sync_all()?;
+    remove_paths(layout, &layout.vacuum_database_sidecar_paths())?;
+    Ok(())
+}
+
+fn create_empty_vacuum_database(
+    layout: &StoreLayout,
+    vacuum_path: &Path,
+) -> Result<(), MaintenanceFailure> {
+    layout.observe(StorePathOperation::Write, vacuum_path);
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options.open(vacuum_path)?;
+    layout.observe(StorePathOperation::Metadata, vacuum_path);
+    set_owner_only_permissions(vacuum_path)?;
+    verify_owner_only_permissions(vacuum_path)?;
+    drop(file);
+    Ok(())
+}
+
+#[derive(Debug)]
+enum CanonicalReplacementFailure {
+    PreReplace(MaintenanceFailure),
+    PostReplace(MaintenanceFailure),
+}
+
+fn replace_canonical_database(
+    layout: &StoreLayout,
+    fault: &FaultInjector,
+) -> Result<(), CanonicalReplacementFailure> {
+    inject(fault, MaintenanceFaultPoint::BeforeCanonicalSidecarCleanup)
+        .map_err(CanonicalReplacementFailure::PreReplace)?;
+    remove_paths(layout, &layout.database_sidecar_paths())
+        .map_err(MaintenanceFailure::from)
+        .map_err(CanonicalReplacementFailure::PreReplace)?;
+    inject(fault, MaintenanceFaultPoint::BeforeReplace)
+        .map_err(CanonicalReplacementFailure::PreReplace)?;
+
+    let vacuum_path = layout.vacuum_database_path();
+    let database_path = layout.database_path();
+    layout.observe(StorePathOperation::Write, &vacuum_path);
+    layout.observe(StorePathOperation::Write, &database_path);
+    file_replace::replace_file(&vacuum_path, &database_path)
+        .map_err(MaintenanceFailure::from)
+        .map_err(CanonicalReplacementFailure::PreReplace)?;
+    inject(fault, MaintenanceFaultPoint::AfterReplace)
+        .map_err(CanonicalReplacementFailure::PostReplace)?;
+    layout
+        .sync_app_data_root()
+        .map_err(MaintenanceFailure::from)
+        .map_err(CanonicalReplacementFailure::PostReplace)?;
+    Ok(())
+}
+
+fn reopen_canonical(layout: &StoreLayout) -> Result<Connection, StartupMaintenanceError> {
+    let database_path = layout.database_path();
+    layout.observe(StorePathOperation::Open, &database_path);
+    layout.observe(StorePathOperation::Write, &database_path);
+    open_existing_writer(&database_path).map_err(StartupMaintenanceError::Connection)
+}
+
+fn cleanup_vacuum_artifacts(layout: &StoreLayout) -> Result<(), std::io::Error> {
+    let mut paths = Vec::with_capacity(3);
+    paths.push(layout.vacuum_database_path());
+    paths.extend(layout.vacuum_database_sidecar_paths());
+    remove_paths(layout, &paths)
+}
+
+fn cleanup_after_failure(layout: &StoreLayout) {
+    if let Err(error) = cleanup_vacuum_artifacts(layout) {
+        log_failure("failure-exit artifact cleanup", &error);
+    }
+}
+
+fn remove_paths(layout: &StoreLayout, paths: &[std::path::PathBuf]) -> Result<(), std::io::Error> {
+    let mut first_error = None;
+    for path in paths {
+        layout.observe(StorePathOperation::Remove, path);
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            }
+        }
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
+fn verify_owner_only_permissions(path: &Path) -> Result<(), std::io::Error> {
+    let metadata = std::fs::metadata(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o777 != 0o600 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "vacuum database permissions are not owner-only",
+            ));
+        }
+    }
+    #[cfg(not(unix))]
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "vacuum database is not a regular file",
+        ));
+    }
+    Ok(())
+}
+
+fn inject(fault: &FaultInjector, point: MaintenanceFaultPoint) -> Result<(), MaintenanceFailure> {
+    if fault.take_maintenance_fault(point) {
+        return Err(MaintenanceFailure::Injected(point));
+    }
+    Ok(())
+}
+
+fn log_failure(stage: &str, error: &dyn std::fmt::Display) {
+    let correlation_id = uuid::Uuid::new_v4();
+    log::warn!(
+        "local event store startup maintenance failed at {stage} [{correlation_id}]: {error}"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::adaptor::gateway::local_event_store::store::{
+        LocalEventStore, LocalEventStoreConfig,
+    };
+    use crate::domain::local_event::{
+        CommitIdentity, CommitOperationKind, IdempotencyBinding, LocalAtomicBatch,
+        LocalEventTransactionRepository,
+    };
+    use crate::infrastructure::app_data_path::{AppDataPathObserver, AppDataPathOperation};
+
+    #[derive(Default)]
+    struct RecordingObserver {
+        operations: Mutex<Vec<(AppDataPathOperation, PathBuf)>>,
+    }
+
+    impl AppDataPathObserver for RecordingObserver {
+        fn observe(&self, operation: AppDataPathOperation, path: &Path) {
+            self.operations
+                .lock()
+                .expect("maintenance observer")
+                .push((operation, path.to_path_buf()));
+        }
+    }
+
+    impl RecordingObserver {
+        fn observed(&self, operation: AppDataPathOperation, path: &Path) -> bool {
+            self.operations
+                .lock()
+                .expect("maintenance observer")
+                .iter()
+                .any(|observed| observed == &(operation, path.to_path_buf()))
+        }
+    }
+
+    fn open_store(root: &Path) -> Arc<LocalEventStore> {
+        LocalEventStore::open(LocalEventStoreConfig::production(root.to_path_buf()))
+            .expect("file-backed local event store")
+    }
+
+    fn open_store_with_fault(
+        root: &Path,
+        fault: Arc<FaultInjector>,
+        observer: Arc<dyn AppDataPathObserver>,
+    ) -> Arc<LocalEventStore> {
+        let mut config = LocalEventStoreConfig::production(root.to_path_buf());
+        config.fault = fault;
+        config.path_observer = observer;
+        LocalEventStore::open(config).expect("file-backed local event store with maintenance fault")
+    }
+
+    fn database_path(root: &Path) -> PathBuf {
+        StoreLayout::new(root).database_path()
+    }
+
+    fn create_fragmented_store(root: &Path) -> (u64, String) {
+        let store = open_store(root);
+        let installation_id = store.installation_id().to_string();
+        drop(store);
+        let path = database_path(root);
+        let connection = open_existing_writer(&path).unwrap();
+        connection
+            .execute_batch("PRAGMA secure_delete = OFF;")
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO logical_commits (
+                     commit_id, installation_id, operation_kind, idempotency_key,
+                     payload_hash, state, first_global_sequence, last_global_sequence,
+                     event_count, mutation_count, stream_heads_json, result_hash,
+                     committed_at_ms
+                 ) VALUES (
+                     'maintenance-preserved', ?1, 'projection', 'maintenance-preserved',
+                     zeroblob(32), 'sealed', NULL, NULL, 0, 0, '{}', NULL, 1
+                 )",
+                [&installation_id],
+            )
+            .unwrap();
+        connection
+            .execute_batch(
+                "INSERT INTO stream_heads (stream_id, head, updated_commit_id)
+                     VALUES ('maintenance-stream', 1, 'maintenance-preserved');
+                 INSERT INTO events (
+                     global_sequence, event_id, commit_id, stream_id, stream_sequence,
+                     event_type, payload_version, occurred_at, payload, payload_sha256
+                 ) VALUES (
+                     1, 'maintenance-event', 'maintenance-preserved', 'maintenance-stream', 1,
+                     'maintenance.event', 1, '2026-01-01T00:00:00Z', X'01', zeroblob(32)
+                 );
+                 INSERT INTO operation_bindings (
+                     principal, installation_id, kind, caller_request_id, scope_id,
+                     operation_id, binding_hmac, commit_id
+                 ) VALUES (
+                     'maintenance-principal',
+                     (SELECT installation_id FROM store_metadata WHERE id = 1),
+                     'send', 'maintenance-request', 'maintenance-scope',
+                     'maintenance-operation', zeroblob(32), 'maintenance-preserved'
+                 );
+                 INSERT INTO caller_attempts (
+                     principal, installation_id, kind, caller_request_id, scope_id,
+                     command_hash, sealed_command, resolution, revision, commit_id
+                 ) VALUES (
+                     'maintenance-principal',
+                     (SELECT installation_id FROM store_metadata WHERE id = 1),
+                     'send', 'maintenance-request', 'maintenance-scope',
+                     zeroblob(32), X'01', 'accepted', 1, 'maintenance-preserved'
+                 );
+                 INSERT INTO operation_records (
+                     kind, operation_id, receipt, latest_status, revision, commit_id
+                 ) VALUES (
+                     'send', 'maintenance-operation', '{}', '{}', 1,
+                     'maintenance-preserved'
+                 );
+                 INSERT INTO session_projection (
+                     session_id, projection, revision, commit_id
+                 ) VALUES (
+                     'maintenance-session', '{}', 1, 'maintenance-preserved'
+                 );
+                 INSERT INTO obligations (
+                     obligation_id, record, pending, revision, commit_id
+                 ) VALUES (
+                     'maintenance-obligation', '{}', 1, 1, 'maintenance-preserved'
+                 );
+                 INSERT INTO pending_obligations (
+                     ordered_key, obligation_id, owner, partition, shutdown_id, commit_id
+                 ) VALUES (
+                     'maintenance-ordered', 'maintenance-obligation', 'maintenance-owner',
+                     'owner', NULL, 'maintenance-preserved'
+                 );
+                 INSERT INTO recovery_action_attempts (
+                     action_id, binding_hash, attempt, completed, revision, commit_id
+                 ) VALUES (
+                     'maintenance-action', zeroblob(32), '{}', '{}', 1,
+                     'maintenance-preserved'
+                 );
+                 INSERT INTO shutdown_plans (
+                     shutdown_id, phase, summary, details_state, revision, commit_id
+                 ) VALUES (
+                     'maintenance-shutdown', 'prepared', 'maintenance', 'available', 1,
+                     'maintenance-preserved'
+                 );
+                 UPDATE pending_obligations
+                    SET shutdown_id = 'maintenance-shutdown'
+                  WHERE ordered_key = 'maintenance-ordered';
+                 INSERT INTO shutdown_targets (
+                     shutdown_id, ordinal, detail, revision, commit_id
+                 ) VALUES (
+                     'maintenance-shutdown', 0, '{}', 1, 'maintenance-preserved'
+                 );
+                 INSERT INTO shutdown_recovery_snapshots (
+                     shutdown_id, partition, ordinal, detail, commit_id
+                 ) VALUES (
+                     'maintenance-shutdown', 'owner', 0, '{}', 'maintenance-preserved'
+                 );
+                 INSERT INTO workflow_executions (
+                     execution_id, workspace_identity, status, list_kind, sort_at_bits,
+                     record_schema, record, source_revision, commit_id
+                 ) VALUES (
+                     'maintenance-execution', 'maintenance-workspace', 'running', 'active', 1,
+                     'workflow_execution_record_v1', '{}', 1, 'maintenance-preserved'
+                 );
+                 INSERT INTO workflow_execution_nodes (
+                     execution_id, node_id, parent_id, sibling_order, session_id,
+                     node_execution_id, record_schema, tree_record, detail_record,
+                     source_revision, commit_id
+                 ) VALUES (
+                     'maintenance-execution', 'maintenance-node', NULL, 0,
+                     'maintenance-session', 'maintenance-node-execution',
+                     'workflow_execution_node_record_v1', '{}', '{}', 1,
+                     'maintenance-preserved'
+                 );
+                 UPDATE store_metadata
+                    SET next_global_sequence = 2,
+                        shutdown_pointer_revision = 1
+                  WHERE id = 1;",
+            )
+            .unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE startup_maintenance_free_space (payload BLOB NOT NULL);
+                 INSERT INTO startup_maintenance_free_space (payload)
+                     VALUES (zeroblob(71303168));
+                 DROP TABLE startup_maintenance_free_space;
+                 PRAGMA wal_checkpoint(TRUNCATE);",
+            )
+            .unwrap();
+        let stats = read_freelist_stats(&connection).unwrap();
+        assert!(
+            should_reclaim(stats).unwrap(),
+            "fixture must cross both thresholds"
+        );
+        drop(connection);
+        (std::fs::metadata(path).unwrap().len(), installation_id)
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct StoreSnapshot {
+        tables: Vec<(&'static str, Vec<Vec<rusqlite::types::Value>>)>,
+        metadata: Vec<rusqlite::types::Value>,
+    }
+
+    fn snapshot_store(connection: &Connection) -> StoreSnapshot {
+        const TABLES: [&str; 15] = [
+            "logical_commits",
+            "stream_heads",
+            "events",
+            "operation_bindings",
+            "caller_attempts",
+            "operation_records",
+            "session_projection",
+            "obligations",
+            "pending_obligations",
+            "recovery_action_attempts",
+            "shutdown_plans",
+            "shutdown_targets",
+            "shutdown_recovery_snapshots",
+            "workflow_executions",
+            "workflow_execution_nodes",
+        ];
+
+        let tables = TABLES
+            .into_iter()
+            .map(|table| {
+                let mut statement = connection
+                    .prepare(&format!("SELECT * FROM {table} ORDER BY 1"))
+                    .unwrap();
+                let column_count = statement.column_count();
+                let rows = statement
+                    .query_map([], |row| {
+                        (0..column_count)
+                            .map(|index| row.get(index))
+                            .collect::<Result<Vec<rusqlite::types::Value>, _>>()
+                    })
+                    .unwrap()
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap();
+                (table, rows)
+            })
+            .collect();
+        let metadata = connection
+            .query_row(
+                "SELECT id, schema_version, installation_id, created_at_ms,
+                        cursor_hmac_key, operation_binding_hmac_key,
+                        next_global_sequence, health, current_shutdown_id,
+                        shutdown_pointer_revision
+                 FROM store_metadata WHERE id = 1",
+                [],
+                |row| {
+                    (0..10)
+                        .map(|index| row.get(index))
+                        .collect::<Result<Vec<rusqlite::types::Value>, _>>()
+                },
+            )
+            .unwrap();
+        StoreSnapshot { tables, metadata }
+    }
+
+    fn snapshot_store_path(root: &Path) -> StoreSnapshot {
+        let connection = open_existing_writer(&database_path(root)).unwrap();
+        snapshot_store(&connection)
+    }
+
+    fn assert_preserved_content(root: &Path, installation_id: &str) {
+        let connection = open_existing_writer(&database_path(root)).unwrap();
+        let stored_installation_id: String = connection
+            .query_row(
+                "SELECT installation_id FROM store_metadata WHERE id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_installation_id, installation_id);
+        let commit_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM logical_commits
+                 WHERE commit_id = 'maintenance-preserved'
+                   AND idempotency_key = 'maintenance-preserved'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(commit_count, 1);
+        super::super::schema::validate_current_schema(&connection).unwrap();
+    }
+
+    #[test]
+    fn test_物理回収判定_二つの閾値をともに満たす場合だけ発火する() {
+        let page_size = 4096;
+        let minimum_pages = MINIMUM_RECLAIM_BYTES / page_size;
+
+        assert!(should_reclaim(FreelistStats {
+            page_count: minimum_pages * 4,
+            freelist_count: minimum_pages,
+            page_size,
+        })
+        .unwrap());
+        assert!(!should_reclaim(FreelistStats {
+            page_count: minimum_pages * 4 + 1,
+            freelist_count: minimum_pages,
+            page_size,
+        })
+        .unwrap());
+        assert!(!should_reclaim(FreelistStats {
+            page_count: (minimum_pages - 1) * 4,
+            freelist_count: minimum_pages - 1,
+            page_size,
+        })
+        .unwrap());
+        assert!(!should_reclaim(FreelistStats {
+            page_count: 0,
+            freelist_count: 0,
+            page_size,
+        })
+        .unwrap());
+    }
+
+    #[test]
+    fn test_物理回収判定_整数演算のoverflowを発火扱いにしない() {
+        assert!(matches!(
+            should_reclaim(FreelistStats {
+                page_count: u64::MAX,
+                freelist_count: u64::MAX,
+                page_size: u64::MAX,
+            }),
+            Err(MaintenanceFailure::ArithmeticOverflow)
+        ));
+    }
+
+    #[test]
+    fn test_起動時保守_非発火storeではvacuumと差し替えへ進まない() {
+        let root = tempfile::TempDir::new().unwrap();
+        let fault = Arc::new(FaultInjector::new());
+        fault.arm_maintenance_fault(MaintenanceFaultPoint::BeforeVacuumInto);
+        let observer = Arc::new(RecordingObserver::default());
+        let store = open_store_with_fault(root.path(), fault.clone(), observer.clone());
+        let layout = StoreLayout::new(root.path());
+
+        assert!(fault.take_maintenance_fault(MaintenanceFaultPoint::BeforeVacuumInto));
+        assert!(!observer.observed(AppDataPathOperation::Write, &layout.vacuum_database_path()));
+        assert!(!layout.vacuum_database_path().exists());
+        drop(store);
+    }
+
+    #[tokio::test]
+    async fn test_起動時保守_発火storeを縮小してデータ保持と再writeを可能にする() {
+        let root = tempfile::TempDir::new().unwrap();
+        let (size_before, installation_id) = create_fragmented_store(root.path());
+        let expected_snapshot = snapshot_store_path(root.path());
+        let observer = Arc::new(RecordingObserver::default());
+
+        let store = open_store_with_fault(
+            root.path(),
+            Arc::new(FaultInjector::new()),
+            observer.clone(),
+        );
+        let size_after = std::fs::metadata(database_path(root.path())).unwrap().len();
+        assert!(size_after < size_before);
+        assert_eq!(store.installation_id(), installation_id);
+        drop(store);
+        assert_eq!(snapshot_store_path(root.path()), expected_snapshot);
+
+        let store = open_store(root.path());
+        let commit_id = CommitIdentity::parse("maintenance-new-write").unwrap();
+        store
+            .commit_batch(LocalAtomicBatch {
+                commit_id: commit_id.clone(),
+                idempotency: IdempotencyBinding {
+                    installation_id: installation_id.clone(),
+                    operation_kind: CommitOperationKind::Projection,
+                    idempotency_key: "maintenance-new-write".to_string(),
+                    payload_hash: [7; 32],
+                },
+                expected_heads: Vec::new(),
+                events: Vec::new(),
+                state_mutations: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let layout = StoreLayout::new(root.path());
+        for sidecar in layout.database_sidecar_paths() {
+            assert!(observer.observed(AppDataPathOperation::Remove, &sidecar));
+        }
+        drop(store);
+
+        assert_preserved_content(root.path(), &installation_id);
+        let connection = open_existing_writer(&database_path(root.path())).unwrap();
+        let new_commit_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM logical_commits
+                 WHERE commit_id = 'maintenance-new-write'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(new_commit_count, 1);
+    }
+
+    #[test]
+    fn test_起動時保守_replace成功前の各faultで元storeを維持して一時artifactを除去する() {
+        let seed = tempfile::TempDir::new().unwrap();
+        let (seed_size, installation_id) = create_fragmented_store(seed.path());
+        let seed_database = database_path(seed.path());
+        for point in [
+            MaintenanceFaultPoint::BeforeVacuumInto,
+            MaintenanceFaultPoint::BeforeOutputValidation,
+            MaintenanceFaultPoint::BeforeOutputPermission,
+            MaintenanceFaultPoint::BeforeOutputSync,
+            MaintenanceFaultPoint::BeforeCanonicalSidecarCleanup,
+            MaintenanceFaultPoint::BeforeReplace,
+        ] {
+            let root = tempfile::TempDir::new().unwrap();
+            let layout = StoreLayout::new(root.path());
+            std::fs::copy(&seed_database, layout.database_path()).unwrap();
+            let fault = Arc::new(FaultInjector::new());
+            fault.arm_maintenance_fault(point);
+
+            drop(open_store_with_fault(
+                root.path(),
+                fault,
+                Arc::new(RecordingObserver::default()),
+            ));
+
+            assert_eq!(
+                std::fs::metadata(layout.database_path()).unwrap().len(),
+                seed_size
+            );
+            assert_preserved_content(root.path(), &installation_id);
+            assert!(!layout.vacuum_database_path().exists());
+            for sidecar in layout.vacuum_database_sidecar_paths() {
+                assert!(!sidecar.exists(), "fault point {point:?}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_起動時保守_replace直後のfault境界から新canonicalを次回openする() {
+        let root = tempfile::TempDir::new().unwrap();
+        let (size_before, installation_id) = create_fragmented_store(root.path());
+        let expected_snapshot = snapshot_store_path(root.path());
+        let layout = StoreLayout::new(root.path());
+        let fault = Arc::new(FaultInjector::new());
+        fault.arm_maintenance_fault(MaintenanceFaultPoint::AfterReplace);
+        let connection = open_existing_writer(&database_path(root.path())).unwrap();
+        prepare_vacuum_database(&layout, &connection, fault.as_ref()).unwrap();
+        drop(connection);
+
+        assert!(matches!(
+            replace_canonical_database(&layout, fault.as_ref()),
+            Err(CanonicalReplacementFailure::PostReplace(
+                MaintenanceFailure::Injected(MaintenanceFaultPoint::AfterReplace)
+            ))
+        ));
+
+        assert!(std::fs::metadata(database_path(root.path())).unwrap().len() < size_before);
+        assert!(!layout.vacuum_database_path().exists());
+        for sidecar in layout.database_sidecar_paths() {
+            assert!(!sidecar.exists());
+        }
+        for sidecar in layout.vacuum_database_sidecar_paths() {
+            assert!(!sidecar.exists());
+        }
+
+        let store = open_store(root.path());
+        assert_eq!(store.installation_id(), installation_id);
+        drop(store);
+        assert_eq!(snapshot_store_path(root.path()), expected_snapshot);
+
+        let store = open_store(root.path());
+        let commit_id = CommitIdentity::parse("post-replace-new-write").unwrap();
+        store
+            .commit_batch(LocalAtomicBatch {
+                commit_id,
+                idempotency: IdempotencyBinding {
+                    installation_id,
+                    operation_kind: CommitOperationKind::Projection,
+                    idempotency_key: "post-replace-new-write".to_string(),
+                    payload_hash: [9; 32],
+                },
+                expected_heads: Vec::new(),
+                events: Vec::new(),
+                state_mutations: Vec::new(),
+            })
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn test_起動時保守_vacuum書込み前からowner_only権限を持つ() {
+        let root = tempfile::TempDir::new().unwrap();
+        create_fragmented_store(root.path());
+        let layout = StoreLayout::new(root.path());
+        let connection = open_existing_writer(&database_path(root.path())).unwrap();
+        let fault = FaultInjector::new();
+        fault.arm_maintenance_fault(MaintenanceFaultPoint::BeforeVacuumInto);
+
+        assert!(matches!(
+            prepare_vacuum_database(&layout, &connection, &fault),
+            Err(MaintenanceFailure::Injected(
+                MaintenanceFaultPoint::BeforeVacuumInto
+            ))
+        ));
+        let vacuum_path = layout.vacuum_database_path();
+        assert_eq!(std::fs::metadata(&vacuum_path).unwrap().len(), 0);
+        verify_owner_only_permissions(&vacuum_path).unwrap();
+        cleanup_vacuum_artifacts(&layout).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_起動時保守_非utf8一時path失敗を区別して元storeを継続する() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = tempfile::TempDir::new().unwrap();
+        let (_, installation_id) = create_fragmented_store(root.path());
+        let connection = open_existing_writer(&database_path(root.path())).unwrap();
+        let invalid_root =
+            std::path::PathBuf::from(std::ffi::OsString::from_vec(b"non-utf8-\xff".to_vec()));
+        let layout = StoreLayout::new(&invalid_root);
+
+        let error = prepare_vacuum_database(&layout, &connection, &FaultInjector::new())
+            .expect_err("non-UTF-8 vacuum path must be rejected");
+        let stored_installation_id: String = connection
+            .query_row(
+                "SELECT installation_id FROM store_metadata WHERE id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_installation_id, installation_id);
+        assert_eq!(error.to_string(), "vacuum database path is not valid UTF-8");
+        assert!(matches!(error, MaintenanceFailure::InvalidPathEncoding));
+        assert_ne!(
+            error.to_string(),
+            MaintenanceFailure::InvalidPragmaValue.to_string()
+        );
+        assert!(!layout.vacuum_database_path().exists());
+    }
+
+    fn write_stale_vacuum_artifacts(layout: &StoreLayout) {
+        std::fs::write(layout.vacuum_database_path(), b"stale-database").unwrap();
+        for (index, sidecar) in layout
+            .vacuum_database_sidecar_paths()
+            .into_iter()
+            .enumerate()
+        {
+            std::fs::write(sidecar, format!("stale-sidecar-{index}")).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_起動時保守_非発火時は前回のstale一時artifactだけを除去する() {
+        let root = tempfile::TempDir::new().unwrap();
+        let installation_id = open_store(root.path()).installation_id().to_string();
+        let layout = StoreLayout::new(root.path());
+        write_stale_vacuum_artifacts(&layout);
+        let fault = Arc::new(FaultInjector::new());
+        fault.arm_maintenance_fault(MaintenanceFaultPoint::BeforeVacuumInto);
+        let observer = Arc::new(RecordingObserver::default());
+
+        let store = open_store_with_fault(root.path(), fault.clone(), observer.clone());
+
+        assert_eq!(store.installation_id(), installation_id);
+        assert!(fault.take_maintenance_fault(MaintenanceFaultPoint::BeforeVacuumInto));
+        assert!(!observer.observed(AppDataPathOperation::Write, &layout.vacuum_database_path()));
+        assert!(!layout.vacuum_database_path().exists());
+        for sidecar in layout.vacuum_database_sidecar_paths() {
+            assert!(!sidecar.exists());
+        }
+    }
+
+    #[test]
+    fn test_起動時保守_発火時はstale一時artifactを除去して回収を完了する() {
+        let root = tempfile::TempDir::new().unwrap();
+        let (size_before, installation_id) = create_fragmented_store(root.path());
+        let expected_snapshot = snapshot_store_path(root.path());
+        let layout = StoreLayout::new(root.path());
+        write_stale_vacuum_artifacts(&layout);
+
+        let store = open_store(root.path());
+
+        assert_eq!(store.installation_id(), installation_id);
+        assert!(std::fs::metadata(database_path(root.path())).unwrap().len() < size_before);
+        assert!(!layout.vacuum_database_path().exists());
+        for sidecar in layout.vacuum_database_sidecar_paths() {
+            assert!(!sidecar.exists());
+        }
+        drop(store);
+        assert_eq!(snapshot_store_path(root.path()), expected_snapshot);
+    }
+
+    #[test]
+    fn test_起動時保守_checkpoint_busyではwalを保持して保守をskipする() {
+        let root = tempfile::TempDir::new().unwrap();
+        let store = open_store(root.path());
+        let installation_id = store.installation_id().to_string();
+        drop(store);
+        let layout = StoreLayout::new(root.path());
+        let database_path = layout.database_path();
+        let reader = open_reader(&database_path).unwrap();
+        reader.execute_batch("BEGIN;").unwrap();
+        reader
+            .query_row("SELECT COUNT(*) FROM store_metadata", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap();
+        let writer = open_existing_writer(&database_path).unwrap();
+        writer
+            .execute(
+                "INSERT INTO logical_commits (
+                     commit_id, installation_id, operation_kind, idempotency_key,
+                     payload_hash, state, first_global_sequence, last_global_sequence,
+                     event_count, mutation_count, stream_heads_json, result_hash,
+                     committed_at_ms
+                 ) VALUES (
+                     'checkpoint-busy', ?1, 'projection', 'checkpoint-busy',
+                     zeroblob(32), 'sealed', NULL, NULL, 0, 0, '{}', NULL, 2
+                 )",
+                [&installation_id],
+            )
+            .unwrap();
+        drop(writer);
+        let fault = Arc::new(FaultInjector::new());
+        fault.arm_maintenance_fault(MaintenanceFaultPoint::BeforeVacuumInto);
+        let observer = Arc::new(RecordingObserver::default());
+
+        let store = open_store_with_fault(root.path(), fault.clone(), observer.clone());
+
+        assert!(fault.take_maintenance_fault(MaintenanceFaultPoint::BeforeVacuumInto));
+        assert!(!observer.observed(AppDataPathOperation::Write, &layout.vacuum_database_path()));
+        for sidecar in layout.database_sidecar_paths() {
+            assert!(sidecar.exists());
+            assert!(!observer.observed(AppDataPathOperation::Remove, &sidecar));
+        }
+        let main_only_path = root.path().join("main-only.sqlite3");
+        std::fs::copy(&database_path, &main_only_path).unwrap();
+        let mut main_only_uri = url::Url::from_file_path(&main_only_path).unwrap();
+        main_only_uri
+            .query_pairs_mut()
+            .append_pair("immutable", "1");
+        let main_only = Connection::open_with_flags(
+            main_only_uri.as_str(),
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
+                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+        )
+        .unwrap();
+        let main_only_count: i64 = main_only
+            .query_row(
+                "SELECT COUNT(*) FROM logical_commits WHERE commit_id = 'checkpoint-busy'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(main_only_count, 0);
+        let verification = open_reader(&database_path).unwrap();
+        let retained: i64 = verification
+            .query_row(
+                "SELECT COUNT(*) FROM logical_commits WHERE commit_id = 'checkpoint-busy'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, 1);
+        drop(store);
+        reader.execute_batch("ROLLBACK;").unwrap();
+    }
+}

--- a/src-tauri/src/adaptor/gateway/local_event_store/mod.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod fault;
 pub(crate) mod hmac_sha256;
 pub(crate) mod indexed_projection_codec;
 pub(crate) mod layout;
+pub(crate) mod maintenance;
 pub(crate) mod projection_record_codec;
 pub(crate) mod provider_hook_health_codec;
 pub(crate) mod provider_lifecycle_codec;

--- a/src-tauri/src/adaptor/gateway/local_event_store/schema.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/schema.rs
@@ -4,10 +4,14 @@ use rusqlite::Connection;
 
 use super::fault::{FaultInjector, InitialCreateFaultPoint};
 
+#[cfg(test)]
+#[path = "schema_test.rs"]
+mod schema_test;
+
 /// Minimum SQLite version containing the WAL-reset corruption fix.
 pub const MIN_SQLITE_VERSION_NUMBER: i32 = 3_051_003;
 pub const APPLICATION_ID: i32 = 0x524C_5348;
-pub const CURRENT_SCHEMA_VERSION: i64 = 4;
+pub const CURRENT_SCHEMA_VERSION: i64 = 5;
 
 pub const CURRENT_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS logical_commits (
@@ -111,34 +115,6 @@ CREATE TABLE IF NOT EXISTS session_projection (
     )
 );
 
-CREATE TABLE IF NOT EXISTS message_projection (
-    session_id TEXT NOT NULL,
-    message_id TEXT NOT NULL,
-    message_ordinal INTEGER NOT NULL CHECK (message_ordinal > 0),
-    projection TEXT NOT NULL,
-    revision INTEGER NOT NULL CHECK (revision >= 0),
-    commit_id TEXT NOT NULL REFERENCES logical_commits (commit_id),
-    PRIMARY KEY (session_id, message_id),
-    UNIQUE (session_id, message_ordinal)
-);
-
-CREATE TABLE IF NOT EXISTS terminal_records (
-    session_id TEXT NOT NULL,
-    turn_id TEXT NOT NULL,
-    terminal_identity TEXT NOT NULL,
-    result TEXT NOT NULL,
-    participant_digest BLOB NOT NULL CHECK (length(participant_digest) = 32),
-    commit_id TEXT NOT NULL REFERENCES logical_commits (commit_id),
-    PRIMARY KEY (session_id, turn_id)
-);
-
-CREATE TABLE IF NOT EXISTS stop_resolutions (
-    stop_operation_id TEXT PRIMARY KEY,
-    resolution TEXT NOT NULL CHECK (resolution IN ('succeeded', 'superseded')),
-    detail TEXT NOT NULL,
-    commit_id TEXT NOT NULL REFERENCES logical_commits (commit_id)
-);
-
 CREATE TABLE IF NOT EXISTS obligations (
     obligation_id TEXT PRIMARY KEY,
     record TEXT NOT NULL,
@@ -207,8 +183,6 @@ CREATE INDEX IF NOT EXISTS idx_pending_obligations_shutdown
     ON pending_obligations (shutdown_id, ordered_key);
 CREATE INDEX IF NOT EXISTS idx_shutdown_plans_details_state
     ON shutdown_plans (details_state);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_message_projection_ordinal
-    ON message_projection (session_id, message_ordinal);
 CREATE INDEX IF NOT EXISTS idx_caller_attempts_scope
     ON caller_attempts (principal, installation_id, scope_id, kind, caller_request_id);
 CREATE INDEX IF NOT EXISTS idx_caller_attempts_pending_kind
@@ -320,7 +294,7 @@ fn create_store_metadata(
 ) -> Result<(), rusqlite::Error> {
     if !matches!(table_name, "store_metadata" | "store_metadata_v2")
         || !matches!(shutdown_plans_table, "shutdown_plans" | "shutdown_plans_v2")
-        || !matches!(schema_version, 2..=4)
+        || !matches!(schema_version, 2..=5)
     {
         return Err(rusqlite::Error::InvalidQuery);
     }
@@ -363,7 +337,7 @@ pub fn initialize_schema(
     if let Err(error) = (|| {
         connection.execute_batch(CURRENT_SCHEMA)?;
         connection.execute_batch(SESSION_PROJECTION_TABLE_V3)?;
-        create_store_metadata(connection, "store_metadata", "shutdown_plans", 4)?;
+        create_store_metadata(connection, "store_metadata", "shutdown_plans", 5)?;
         connection.execute_batch(WORKSPACE_QUERY_RECORDS_V3)?;
         connection.execute_batch(NODE_EXECUTION_IDENTITY_V4)?;
         connection.execute(
@@ -372,7 +346,7 @@ pub fn initialize_schema(
                 cursor_hmac_key, operation_binding_hmac_key, process_instance_id,
                 next_global_sequence, health, current_shutdown_id,
                 shutdown_pointer_revision
-             ) VALUES (1, 4, ?1, ?2, ?3, ?4, ?5, 1, 'ok',
+             ) VALUES (1, 5, ?1, ?2, ?3, ?4, ?5, 1, 'ok',
                        NULL, 0)",
             rusqlite::params![
                 metadata.installation_id,
@@ -409,6 +383,74 @@ pub fn initialize_schema(
     finish_schema_admission(connection)
 }
 
+#[derive(Debug, Clone, Copy)]
+enum SupportedMetadataVersion {
+    V2,
+    V3,
+    V4,
+}
+
+fn carry_forward_store_metadata_v5(
+    connection: &Connection,
+    source_version: SupportedMetadataVersion,
+) -> Result<(), rusqlite::Error> {
+    let source_table = match source_version {
+        SupportedMetadataVersion::V2 => "store_metadata_v2",
+        SupportedMetadataVersion::V3 => "store_metadata_v3",
+        SupportedMetadataVersion::V4 => "store_metadata_v4",
+    };
+    connection.execute_batch(&format!(
+        "ALTER TABLE store_metadata RENAME TO {source_table};"
+    ))?;
+    create_store_metadata(connection, "store_metadata", "shutdown_plans", 5)?;
+    connection.execute_batch(&format!(
+        "INSERT INTO store_metadata (
+             id, schema_version, installation_id, created_at_ms,
+             cursor_hmac_key, operation_binding_hmac_key,
+             process_instance_id, next_global_sequence, health,
+             current_shutdown_id, shutdown_pointer_revision
+         )
+         SELECT id, 5, installation_id, created_at_ms,
+                cursor_hmac_key, operation_binding_hmac_key,
+                process_instance_id, next_global_sequence, health,
+                current_shutdown_id, shutdown_pointer_revision
+         FROM {source_table};
+         DROP TABLE {source_table};"
+    ))
+}
+
+fn evolve_schema_transaction(
+    connection: &Connection,
+    fault: &FaultInjector,
+    evolution: impl FnOnce(&Connection) -> Result<(), rusqlite::Error>,
+) -> Result<bool, rusqlite::Error> {
+    if fault.take_schema_fail_before_begin() {
+        return Err(rusqlite::Error::InvalidQuery);
+    }
+    connection.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
+    let result = evolution(connection).and_then(|()| {
+        connection.pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION)?;
+        if fault.take_schema_fail_before_commit() {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+        Ok(())
+    });
+    if let Err(error) = result {
+        let _ = connection.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
+        return Err(error);
+    }
+    connection.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
+    if fault.take_schema_commit_reply_loss() {
+        return Err(rusqlite::Error::InvalidQuery);
+    }
+    if fault.take_schema_fail_before_readback() {
+        return Err(rusqlite::Error::InvalidQuery);
+    }
+    validate_current_schema(connection)?;
+    finish_schema_admission(connection)?;
+    Ok(true)
+}
+
 pub fn evolve_schema(
     connection: &Connection,
     fault: &FaultInjector,
@@ -431,6 +473,20 @@ pub fn evolve_schema(
         return Ok(false);
     }
 
+    let is_supported_v4 = application_id == i64::from(APPLICATION_ID)
+        && user_version == 4
+        && metadata_columns
+            .iter()
+            .any(|column| column == "installation_id")
+        && !metadata_columns.iter().any(|column| column == "store_id");
+    if is_supported_v4 {
+        return evolve_schema_transaction(connection, fault, |connection| {
+            carry_forward_store_metadata_v5(connection, SupportedMetadataVersion::V4)?;
+            drop_retired_schema_v5(connection)?;
+            Ok(())
+        });
+    }
+
     let is_supported_v3 = application_id == i64::from(APPLICATION_ID)
         && user_version == 3
         && metadata_columns
@@ -438,48 +494,12 @@ pub fn evolve_schema(
             .any(|column| column == "installation_id")
         && !metadata_columns.iter().any(|column| column == "store_id");
     if is_supported_v3 {
-        if fault.take_schema_fail_before_begin() {
-            return Err(rusqlite::Error::InvalidQuery);
-        }
-        connection.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
-        let evolution = (|| {
-            connection.execute_batch("ALTER TABLE store_metadata RENAME TO store_metadata_v3;")?;
-            create_store_metadata(connection, "store_metadata", "shutdown_plans", 4)?;
-            connection.execute_batch(
-                "INSERT INTO store_metadata (
-                     id, schema_version, installation_id, created_at_ms,
-                     cursor_hmac_key, operation_binding_hmac_key,
-                     process_instance_id, next_global_sequence, health,
-                     current_shutdown_id, shutdown_pointer_revision
-                 )
-                 SELECT id, 4, installation_id, created_at_ms,
-                        cursor_hmac_key, operation_binding_hmac_key,
-                        process_instance_id, next_global_sequence, health,
-                        current_shutdown_id, shutdown_pointer_revision
-                 FROM store_metadata_v3;
-                 DROP TABLE store_metadata_v3;",
-            )?;
+        return evolve_schema_transaction(connection, fault, |connection| {
+            carry_forward_store_metadata_v5(connection, SupportedMetadataVersion::V3)?;
             connection.execute_batch(NODE_EXECUTION_IDENTITY_V4)?;
-            connection.pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION)?;
-            if fault.take_schema_fail_before_commit() {
-                return Err(rusqlite::Error::InvalidQuery);
-            }
-            Ok::<(), rusqlite::Error>(())
-        })();
-        if let Err(error) = evolution {
-            let _ = connection.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
-            return Err(error);
-        }
-        connection.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
-        if fault.take_schema_commit_reply_loss() {
-            return Err(rusqlite::Error::InvalidQuery);
-        }
-        if fault.take_schema_fail_before_readback() {
-            return Err(rusqlite::Error::InvalidQuery);
-        }
-        validate_current_schema(connection)?;
-        finish_schema_admission(connection)?;
-        return Ok(true);
+            drop_retired_schema_v5(connection)?;
+            Ok(())
+        });
     }
 
     let is_supported_v2 = application_id == i64::from(APPLICATION_ID)
@@ -489,51 +509,15 @@ pub fn evolve_schema(
             .any(|column| column == "installation_id")
         && !metadata_columns.iter().any(|column| column == "store_id");
     if is_supported_v2 {
-        if fault.take_schema_fail_before_begin() {
-            return Err(rusqlite::Error::InvalidQuery);
-        }
-        connection.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
-        let evolution = (|| {
-            connection.execute_batch("ALTER TABLE store_metadata RENAME TO store_metadata_v2;")?;
-            create_store_metadata(connection, "store_metadata", "shutdown_plans", 4)?;
-            connection.execute_batch(
-                "INSERT INTO store_metadata (
-                     id, schema_version, installation_id, created_at_ms,
-                     cursor_hmac_key, operation_binding_hmac_key,
-                     process_instance_id, next_global_sequence, health,
-                     current_shutdown_id, shutdown_pointer_revision
-                 )
-                 SELECT id, 4, installation_id, created_at_ms,
-                        cursor_hmac_key, operation_binding_hmac_key,
-                        process_instance_id, next_global_sequence, health,
-                        current_shutdown_id, shutdown_pointer_revision
-                 FROM store_metadata_v2;
-                 DROP TABLE store_metadata_v2;",
-            )?;
+        return evolve_schema_transaction(connection, fault, |connection| {
+            carry_forward_store_metadata_v5(connection, SupportedMetadataVersion::V2)?;
             evolve_session_projection_v3(connection)?;
             connection.execute_batch(WORKSPACE_QUERY_RECORDS_V3)?;
             super::workspace_query_migration::rebuild_workspace_query_records(connection)?;
             connection.execute_batch(NODE_EXECUTION_IDENTITY_V4)?;
-            connection.pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION)?;
-            if fault.take_schema_fail_before_commit() {
-                return Err(rusqlite::Error::InvalidQuery);
-            }
-            Ok::<(), rusqlite::Error>(())
-        })();
-        if let Err(error) = evolution {
-            let _ = connection.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
-            return Err(error);
-        }
-        connection.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
-        if fault.take_schema_commit_reply_loss() {
-            return Err(rusqlite::Error::InvalidQuery);
-        }
-        if fault.take_schema_fail_before_readback() {
-            return Err(rusqlite::Error::InvalidQuery);
-        }
-        validate_current_schema(connection)?;
-        finish_schema_admission(connection)?;
-        return Ok(true);
+            drop_retired_schema_v5(connection)?;
+            Ok(())
+        });
     }
 
     let is_supported_v1 = metadata_columns.iter().any(|column| column == "store_id")
@@ -545,11 +529,7 @@ pub fn evolve_schema(
         return Err(rusqlite::Error::InvalidQuery);
     }
 
-    if fault.take_schema_fail_before_begin() {
-        return Err(rusqlite::Error::InvalidQuery);
-    }
-    connection.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
-    let evolution = (|| {
+    evolve_schema_transaction(connection, fault, |connection| {
         // In v1, `generation_id` was the authority embedded in logical
         // idempotency keys, operation lookup keys, binding-HMAC preimages,
         // and caller-attempt seal contexts.
@@ -729,7 +709,7 @@ pub fn evolve_schema(
                  ON shutdown_plans (details_state);
              PRAGMA application_id = 0x524C5348;",
         )?;
-        create_store_metadata(connection, "store_metadata", "shutdown_plans", 4)?;
+        create_store_metadata(connection, "store_metadata", "shutdown_plans", 5)?;
         connection.execute_batch(
             "INSERT INTO store_metadata (
                  id, schema_version, installation_id, created_at_ms,
@@ -737,7 +717,7 @@ pub fn evolve_schema(
                  next_global_sequence, health, current_shutdown_id,
                  shutdown_pointer_revision
              )
-             SELECT id, 4, generation_id, created_at_ms,
+             SELECT id, 5, generation_id, created_at_ms,
                     cursor_hmac_key, operation_binding_hmac_key, boot_id,
                     next_global_sequence, 'ok', current_shutdown_plan_id,
                     shutdown_pointer_revision
@@ -748,26 +728,18 @@ pub fn evolve_schema(
         connection.execute_batch(WORKSPACE_QUERY_RECORDS_V3)?;
         super::workspace_query_migration::rebuild_workspace_query_records(connection)?;
         connection.execute_batch(NODE_EXECUTION_IDENTITY_V4)?;
-        connection.pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION)?;
-        if fault.take_schema_fail_before_commit() {
-            return Err(rusqlite::Error::InvalidQuery);
-        }
-        Ok::<(), rusqlite::Error>(())
-    })();
-    if let Err(error) = evolution {
-        let _ = connection.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
-        return Err(error);
-    }
-    connection.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
-    if fault.take_schema_commit_reply_loss() {
-        return Err(rusqlite::Error::InvalidQuery);
-    }
-    if fault.take_schema_fail_before_readback() {
-        return Err(rusqlite::Error::InvalidQuery);
-    }
-    validate_current_schema(connection)?;
-    finish_schema_admission(connection)?;
-    Ok(true)
+        drop_retired_schema_v5(connection)?;
+        Ok(())
+    })
+}
+
+fn drop_retired_schema_v5(connection: &Connection) -> Result<(), rusqlite::Error> {
+    connection.execute_batch(
+        "DROP INDEX IF EXISTS idx_message_projection_ordinal;
+         DROP TABLE IF EXISTS message_projection;
+         DROP TABLE IF EXISTS terminal_records;
+         DROP TABLE IF EXISTS stop_resolutions;",
+    )
 }
 
 fn finish_schema_admission(connection: &Connection) -> Result<(), rusqlite::Error> {
@@ -968,7 +940,6 @@ pub fn validate_current_schema(connection: &Connection) -> Result<(), rusqlite::
         "idx_pending_obligations_owner",
         "idx_pending_obligations_shutdown",
         "idx_shutdown_plans_details_state",
-        "idx_message_projection_ordinal",
         "idx_caller_attempts_scope",
         "idx_caller_attempts_pending_kind",
         "idx_operation_bindings_operation",
@@ -983,6 +954,10 @@ pub fn validate_current_schema(connection: &Connection) -> Result<(), rusqlite::
     ] {
         require_index(connection, index)?;
     }
+    for table in ["message_projection", "terminal_records", "stop_resolutions"] {
+        require_schema_object_absent(connection, "table", table)?;
+    }
+    require_schema_object_absent(connection, "index", "idx_message_projection_ordinal")?;
     for table in ["logical_commits", "operation_bindings", "caller_attempts"] {
         let divergent_identity_count: i64 = connection.query_row(
             &format!(
@@ -1170,6 +1145,22 @@ fn require_index(connection: &Connection, index: &str) -> Result<(), rusqlite::E
         |row| row.get(0),
     )?;
     if exists != 1 {
+        return Err(rusqlite::Error::InvalidQuery);
+    }
+    Ok(())
+}
+
+fn require_schema_object_absent(
+    connection: &Connection,
+    object_type: &str,
+    name: &str,
+) -> Result<(), rusqlite::Error> {
+    let count: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM sqlite_schema WHERE type = ?1 AND name = ?2",
+        rusqlite::params![object_type, name],
+        |row| row.get(0),
+    )?;
+    if count != 0 {
         return Err(rusqlite::Error::InvalidQuery);
     }
     Ok(())

--- a/src-tauri/src/adaptor/gateway/local_event_store/schema_test.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/schema_test.rs
@@ -1,0 +1,345 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rusqlite::Connection;
+
+use super::CURRENT_SCHEMA_VERSION;
+use crate::adaptor::gateway::local_event_store::connection::open_existing_writer;
+use crate::adaptor::gateway::local_event_store::fault::FaultInjector;
+use crate::adaptor::gateway::local_event_store::layout::StoreLayout;
+use crate::adaptor::gateway::local_event_store::store::{
+    LocalEventStore, LocalEventStoreConfig, LocalEventStoreOpenError,
+};
+
+fn open_store(root: &Path) -> Arc<LocalEventStore> {
+    LocalEventStore::open(LocalEventStoreConfig::production(root.to_path_buf()))
+        .expect("file-backed local event store")
+}
+
+fn database_path(root: &Path) -> PathBuf {
+    StoreLayout::new(root).database_path()
+}
+
+fn add_retired_schema_and_data(connection: &Connection, identity_column: &str) {
+    connection
+        .execute_batch(
+            "CREATE TABLE message_projection (
+                 session_id TEXT NOT NULL,
+                 message_id TEXT NOT NULL,
+                 message_ordinal INTEGER NOT NULL CHECK (message_ordinal > 0),
+                 projection TEXT NOT NULL,
+                 revision INTEGER NOT NULL CHECK (revision >= 0),
+                 commit_id TEXT NOT NULL REFERENCES logical_commits (commit_id),
+                 PRIMARY KEY (session_id, message_id),
+                 UNIQUE (session_id, message_ordinal)
+             );
+             CREATE TABLE terminal_records (
+                 session_id TEXT NOT NULL,
+                 turn_id TEXT NOT NULL,
+                 terminal_identity TEXT NOT NULL,
+                 result TEXT NOT NULL,
+                 participant_digest BLOB NOT NULL CHECK (length(participant_digest) = 32),
+                 commit_id TEXT NOT NULL REFERENCES logical_commits (commit_id),
+                 PRIMARY KEY (session_id, turn_id)
+             );
+             CREATE TABLE stop_resolutions (
+                 stop_operation_id TEXT PRIMARY KEY,
+                 resolution TEXT NOT NULL CHECK (resolution IN ('succeeded', 'superseded')),
+                 detail TEXT NOT NULL,
+                 commit_id TEXT NOT NULL REFERENCES logical_commits (commit_id)
+             );
+             CREATE UNIQUE INDEX idx_message_projection_ordinal
+                 ON message_projection (session_id, message_ordinal);",
+        )
+        .unwrap();
+    connection
+        .execute(
+            &format!(
+                "INSERT INTO logical_commits (
+                     commit_id, {identity_column}, operation_kind, idempotency_key,
+                     payload_hash, state, first_global_sequence, last_global_sequence,
+                     event_count, mutation_count, stream_heads_json, result_hash,
+                     committed_at_ms
+                 ) VALUES (
+                     'retired-schema-commit',
+                     (SELECT {identity_column} FROM store_metadata WHERE id = 1),
+                     'projection', 'retired-schema', zeroblob(32), 'sealed',
+                     NULL, NULL, 0, 0, '{{}}', NULL, 1
+                 )"
+            ),
+            [],
+        )
+        .unwrap();
+    connection
+        .execute_batch(
+            "INSERT INTO message_projection (
+                 session_id, message_id, message_ordinal, projection, revision, commit_id
+             ) VALUES ('retired-session', 'retired-message', 1, 'retired', 1,
+                       'retired-schema-commit');
+             INSERT INTO terminal_records (
+                 session_id, turn_id, terminal_identity, result,
+                 participant_digest, commit_id
+             ) VALUES ('retired-session', 'retired-turn', 'retired-terminal', 'retired',
+                       zeroblob(32), 'retired-schema-commit');
+             INSERT INTO stop_resolutions (
+                 stop_operation_id, resolution, detail, commit_id
+             ) VALUES ('retired-stop', 'succeeded', 'retired', 'retired-schema-commit');",
+        )
+        .unwrap();
+}
+
+fn rewrite_metadata_version(connection: &Connection, version: i64) {
+    connection
+        .execute_batch(&format!(
+            "PRAGMA foreign_keys = OFF;
+             BEGIN IMMEDIATE;
+             ALTER TABLE store_metadata RENAME TO store_metadata_v5;
+             CREATE TABLE store_metadata (
+                 id INTEGER PRIMARY KEY CHECK (id = 1),
+                 schema_version INTEGER NOT NULL CHECK (schema_version = {version}),
+                 installation_id TEXT NOT NULL,
+                 created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+                 cursor_hmac_key BLOB NOT NULL CHECK (length(cursor_hmac_key) = 32),
+                 operation_binding_hmac_key BLOB NOT NULL
+                     CHECK (length(operation_binding_hmac_key) = 32),
+                 process_instance_id TEXT NOT NULL,
+                 next_global_sequence INTEGER NOT NULL CHECK (next_global_sequence >= 1),
+                 health TEXT NOT NULL CHECK (health = 'ok'),
+                 current_shutdown_id TEXT,
+                 shutdown_pointer_revision INTEGER NOT NULL
+                     CHECK (shutdown_pointer_revision >= 0),
+                 FOREIGN KEY (current_shutdown_id)
+                     REFERENCES shutdown_plans (shutdown_id)
+                     DEFERRABLE INITIALLY DEFERRED
+             );
+             INSERT INTO store_metadata (
+                 id, schema_version, installation_id, created_at_ms,
+                 cursor_hmac_key, operation_binding_hmac_key,
+                 process_instance_id, next_global_sequence, health,
+                 current_shutdown_id, shutdown_pointer_revision
+             )
+             SELECT id, {version}, installation_id, created_at_ms,
+                    cursor_hmac_key, operation_binding_hmac_key,
+                    process_instance_id, next_global_sequence, health,
+                    current_shutdown_id, shutdown_pointer_revision
+             FROM store_metadata_v5;
+             DROP TABLE store_metadata_v5;
+             PRAGMA user_version = {version};
+             COMMIT;
+             PRAGMA foreign_keys = ON;"
+        ))
+        .unwrap();
+}
+
+fn rewrite_as_supported_v1(connection: &Connection) {
+    connection
+        .execute_batch(
+            "PRAGMA foreign_keys = OFF;
+             BEGIN IMMEDIATE;
+             DROP INDEX idx_caller_attempts_scope;
+             DROP INDEX idx_caller_attempts_pending_kind;
+             DROP INDEX idx_operation_bindings_operation;
+             DROP INDEX idx_pending_obligations_partition;
+             DROP INDEX idx_pending_obligations_owner;
+             DROP INDEX idx_pending_obligations_shutdown;
+             DROP INDEX idx_shutdown_plans_details_state;
+             DROP INDEX idx_workflow_execution_nodes_node_execution;
+             ALTER TABLE logical_commits
+                 RENAME COLUMN installation_id TO generation_id;
+             ALTER TABLE operation_bindings
+                 RENAME COLUMN installation_id TO generation_id;
+             ALTER TABLE caller_attempts
+                 RENAME COLUMN installation_id TO generation_id;
+             ALTER TABLE pending_obligations
+                 RENAME COLUMN shutdown_id TO shutdown_plan_id;
+             ALTER TABLE shutdown_plans RENAME COLUMN shutdown_id TO plan_id;
+             ALTER TABLE shutdown_plans ADD COLUMN epoch INTEGER NOT NULL DEFAULT 0;
+             ALTER TABLE shutdown_targets RENAME COLUMN shutdown_id TO plan_id;
+             ALTER TABLE shutdown_targets ADD COLUMN epoch INTEGER NOT NULL DEFAULT 0;
+             ALTER TABLE shutdown_recovery_snapshots
+                 RENAME COLUMN shutdown_id TO plan_id;
+             ALTER TABLE shutdown_recovery_snapshots
+                 ADD COLUMN epoch INTEGER NOT NULL DEFAULT 0;
+             ALTER TABLE store_metadata RENAME TO store_metadata_v5;
+             CREATE TABLE store_metadata (
+                 id INTEGER PRIMARY KEY CHECK (id = 1),
+                 schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+                 store_id TEXT NOT NULL,
+                 generation_id TEXT NOT NULL,
+                 created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+                 cursor_hmac_key BLOB NOT NULL CHECK (length(cursor_hmac_key) = 32),
+                 operation_binding_hmac_key BLOB NOT NULL
+                     CHECK (length(operation_binding_hmac_key) = 32),
+                 boot_id TEXT NOT NULL,
+                 next_global_sequence INTEGER NOT NULL CHECK (next_global_sequence >= 1),
+                 current_shutdown_plan_id TEXT,
+                 shutdown_pointer_revision INTEGER NOT NULL
+                     CHECK (shutdown_pointer_revision >= 0),
+                 FOREIGN KEY (current_shutdown_plan_id)
+                     REFERENCES shutdown_plans (plan_id)
+                     DEFERRABLE INITIALLY DEFERRED
+             );
+             INSERT INTO store_metadata (
+                 id, schema_version, store_id, generation_id, created_at_ms,
+                 cursor_hmac_key, operation_binding_hmac_key, boot_id,
+                 next_global_sequence, current_shutdown_plan_id,
+                 shutdown_pointer_revision
+             )
+             SELECT id, 1, installation_id, installation_id, created_at_ms,
+                    cursor_hmac_key, operation_binding_hmac_key,
+                    process_instance_id, next_global_sequence,
+                    current_shutdown_id, shutdown_pointer_revision
+             FROM store_metadata_v5;
+             DROP TABLE store_metadata_v5;
+             ALTER TABLE session_projection RENAME TO session_projection_v5;
+             CREATE TABLE session_projection (
+                 session_id TEXT PRIMARY KEY,
+                 projection TEXT NOT NULL,
+                 revision INTEGER NOT NULL CHECK (revision >= 0),
+                 commit_id TEXT NOT NULL REFERENCES logical_commits (commit_id)
+             );
+             INSERT INTO session_projection (
+                 session_id, projection, revision, commit_id
+             )
+             SELECT session_id, projection, revision, commit_id
+             FROM session_projection_v5;
+             DROP TABLE session_projection_v5;
+             DROP TABLE workflow_execution_nodes;
+             DROP TABLE workflow_executions;
+             PRAGMA user_version = 1;
+             COMMIT;
+             PRAGMA foreign_keys = ON;",
+        )
+        .unwrap();
+}
+
+fn create_supported_store(root: &Path, version: i64) {
+    drop(open_store(root));
+    let connection = open_existing_writer(&database_path(root)).unwrap();
+    if version == 1 {
+        rewrite_as_supported_v1(&connection);
+        add_retired_schema_and_data(&connection, "generation_id");
+    } else {
+        if version <= 3 {
+            connection
+                .execute_batch("DROP INDEX idx_workflow_execution_nodes_node_execution;")
+                .unwrap();
+        }
+        rewrite_metadata_version(&connection, version);
+        add_retired_schema_and_data(&connection, "installation_id");
+    }
+    connection
+        .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+        .unwrap();
+}
+
+fn assert_retired_schema_absent(connection: &Connection) {
+    let count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_schema
+             WHERE name IN (
+                 'message_projection', 'terminal_records', 'stop_resolutions',
+                 'idx_message_projection_ordinal'
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 0);
+    let version: i64 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, CURRENT_SCHEMA_VERSION);
+    let metadata_version: i64 = connection
+        .query_row(
+            "SELECT schema_version FROM store_metadata WHERE id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(metadata_version, CURRENT_SCHEMA_VERSION);
+}
+
+#[test]
+fn test_schema_v5_新規作成と再起動で廃止schemaを作成しない() {
+    let root = tempfile::TempDir::new().unwrap();
+
+    drop(open_store(root.path()));
+    let connection = open_existing_writer(&database_path(root.path())).unwrap();
+    assert_retired_schema_absent(&connection);
+    drop(connection);
+
+    drop(open_store(root.path()));
+    let connection = open_existing_writer(&database_path(root.path())).unwrap();
+    assert_retired_schema_absent(&connection);
+}
+
+#[test]
+fn test_schema_v5_supported_schema_v1からv4を開くと廃止schemaを削除する() {
+    for version in 1..=4 {
+        let root = tempfile::TempDir::new().unwrap();
+        create_supported_store(root.path(), version);
+
+        drop(open_store(root.path()));
+        let connection = open_existing_writer(&database_path(root.path())).unwrap();
+        assert_retired_schema_absent(&connection);
+        let retained_commit_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM logical_commits
+                 WHERE commit_id = 'retired-schema-commit'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained_commit_count, 1, "supported schema v{version}");
+        drop(connection);
+
+        drop(open_store(root.path()));
+        let connection = open_existing_writer(&database_path(root.path())).unwrap();
+        assert_retired_schema_absent(&connection);
+    }
+}
+
+#[test]
+fn test_schema_v5_移行commit前の失敗ではv4と廃止dataを原子的に維持する() {
+    let root = tempfile::TempDir::new().unwrap();
+    create_supported_store(root.path(), 4);
+    let fault = Arc::new(FaultInjector::new());
+    fault.arm_schema_fail_before_commit();
+    let mut config = LocalEventStoreConfig::production(root.path().to_path_buf());
+    config.fault = fault;
+
+    let error = match LocalEventStore::open(config) {
+        Ok(_) => panic!("schema evolution fault must fail store open"),
+        Err(error) => error,
+    };
+    assert_eq!(error, LocalEventStoreOpenError::SchemaEvolutionFailed);
+    let connection = open_existing_writer(&database_path(root.path())).unwrap();
+    let version: i64 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, 4);
+    let retired_object_count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_schema
+             WHERE name IN (
+                 'message_projection', 'terminal_records', 'stop_resolutions',
+                 'idx_message_projection_ordinal'
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(retired_object_count, 4);
+    let retired_data_count: i64 = connection
+        .query_row(
+            "SELECT
+                 (SELECT COUNT(*) FROM message_projection)
+               + (SELECT COUNT(*) FROM terminal_records)
+               + (SELECT COUNT(*) FROM stop_resolutions)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(retired_data_count, 3);
+}

--- a/src-tauri/src/adaptor/gateway/local_event_store/store.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/store.rs
@@ -23,8 +23,11 @@ use crate::adaptor::gateway::local_event_store::fault::InitialCreateFaultPoint;
 use crate::adaptor::gateway::local_event_store::layout::{
     create_initial_create_evidence_with_fault, inspect_initial_create_evidence,
     remove_initial_create_evidence, replace_invalid_evidence_for_absent_database_with_fault,
-    InitialCreateEvidenceState, NoopStorePathObserver, StoreLayout, StorePathObserver,
-    StorePathOperation,
+    sqlite_sidecar_paths, InitialCreateEvidenceState, NoopStorePathObserver, StoreLayout,
+    StorePathObserver, StorePathOperation,
+};
+use crate::adaptor::gateway::local_event_store::maintenance::{
+    run_startup_maintenance, StartupMaintenanceError,
 };
 use crate::adaptor::gateway::local_event_store::projection_record_codec::canonical_mutation_identity_v1 as canonical_projection_mutation_identity_v1;
 use crate::adaptor::gateway::local_event_store::reader::{
@@ -99,6 +102,33 @@ fn classify_connection_error(
     }
 }
 
+fn classify_startup_maintenance_error(error: &StartupMaintenanceError) -> LocalEventStoreOpenError {
+    match error {
+        StartupMaintenanceError::Connection(error) => {
+            classify_connection_error(error, LocalEventStoreOpenError::StoreValidationFailed)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WalCheckpointResult {
+    busy: bool,
+    log_frames: i64,
+    checkpointed_frames: i64,
+}
+
+fn truncate_wal_checkpoint(
+    connection: &rusqlite::Connection,
+) -> Result<WalCheckpointResult, rusqlite::Error> {
+    connection.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+        Ok(WalCheckpointResult {
+            busy: row.get::<_, i64>(0)? != 0,
+            log_frames: row.get(1)?,
+            checkpointed_frames: row.get(2)?,
+        })
+    })
+}
+
 fn classify_writer_lock_error(error: &std::io::Error) -> LocalEventStoreOpenError {
     if error.kind() == std::io::ErrorKind::WouldBlock {
         LocalEventStoreOpenError::WriterLockHeld
@@ -146,12 +176,9 @@ fn open_schema_inspection(
     // not claim a read-mark or change a sidecar byte. `immutable=1` is never
     // used when a non-empty WAL exists because it could ignore committed
     // frames. No create flag is permitted at this boundary.
-    let wal_path = std::path::PathBuf::from(format!("{}-wal", path.display()));
+    let [wal_path, shm_path] = sqlite_sidecar_paths(path);
     let mut wal_has_bytes = false;
-    for sidecar in [
-        wal_path.clone(),
-        std::path::PathBuf::from(format!("{}-shm", path.display())),
-    ] {
+    for sidecar in [wal_path.clone(), shm_path] {
         layout.observe(StorePathOperation::Metadata, &sidecar);
         match std::fs::metadata(&sidecar) {
             Ok(metadata) => {
@@ -227,11 +254,8 @@ fn is_proven_initial_create_residue(
 
 fn remove_initial_create_database(layout: &StoreLayout) -> Result<(), LocalEventStoreOpenError> {
     let database = layout.database_path();
-    for path in [
-        database.clone(),
-        std::path::PathBuf::from(format!("{}-wal", database.display())),
-        std::path::PathBuf::from(format!("{}-shm", database.display())),
-    ] {
+    let [wal_path, shm_path] = layout.database_sidecar_paths();
+    for path in [database, wal_path, shm_path] {
         layout.observe(StorePathOperation::Remove, &path);
         match std::fs::remove_file(path) {
             Ok(()) => {}
@@ -250,6 +274,7 @@ enum ExistingDatabaseKind {
     SupportedV1,
     SupportedV2,
     SupportedV3,
+    SupportedV4,
 }
 
 fn classify_existing_database(
@@ -314,14 +339,15 @@ fn classify_existing_database(
         return Ok(ExistingDatabaseKind::SupportedV1);
     }
     if application_id == i64::from(APPLICATION_ID) {
-        if matches!(user_version, 2 | 3)
+        if matches!(user_version, 2..=4)
             && columns.iter().any(|column| column == "installation_id")
             && !columns.iter().any(|column| column == "store_id")
         {
-            return Ok(if user_version == 2 {
-                ExistingDatabaseKind::SupportedV2
-            } else {
-                ExistingDatabaseKind::SupportedV3
+            return Ok(match user_version {
+                2 => ExistingDatabaseKind::SupportedV2,
+                3 => ExistingDatabaseKind::SupportedV3,
+                4 => ExistingDatabaseKind::SupportedV4,
+                _ => unreachable!("supported schema version was matched above"),
             });
         }
         if user_version != CURRENT_SCHEMA_VERSION {
@@ -567,6 +593,7 @@ impl LocalEventStore {
                     ExistingDatabaseKind::SupportedV1
                         | ExistingDatabaseKind::SupportedV2
                         | ExistingDatabaseKind::SupportedV3
+                        | ExistingDatabaseKind::SupportedV4
                 ) {
                     evolve_schema(&connection, config.fault.as_ref()).map_err(|error| {
                         classify_sqlite_error(
@@ -590,25 +617,31 @@ impl LocalEventStore {
             .map_err(|error| {
                 classify_sqlite_error(&error, LocalEventStoreOpenError::StoreValidationFailed)
             })?;
-        writer_connection
-            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
-            .map_err(|error| {
-                classify_sqlite_error(&error, LocalEventStoreOpenError::StoreValidationFailed)
-            })?;
-        layout.observe(StorePathOperation::Open, &database_path);
-        layout.observe(StorePathOperation::Sync, &database_path);
-        std::fs::File::open(&database_path)
-            .and_then(|file| file.sync_all())
-            .map_err(|_| LocalEventStoreOpenError::StorageUnavailable)?;
-        if config
-            .fault
-            .take_initial_create_fault(InitialCreateFaultPoint::AfterDatabaseSync)
-        {
-            #[cfg(test)]
-            config
+        let checkpoint = truncate_wal_checkpoint(&writer_connection).map_err(|error| {
+            classify_sqlite_error(&error, LocalEventStoreOpenError::StoreValidationFailed)
+        })?;
+        if checkpoint.busy {
+            log::warn!(
+                "local event store startup maintenance skipped because WAL checkpoint is busy: log_frames={}, checkpointed_frames={}",
+                checkpoint.log_frames,
+                checkpoint.checkpointed_frames
+            );
+        } else {
+            layout.observe(StorePathOperation::Open, &database_path);
+            layout.observe(StorePathOperation::Sync, &database_path);
+            std::fs::File::open(&database_path)
+                .and_then(|file| file.sync_all())
+                .map_err(|_| LocalEventStoreOpenError::StorageUnavailable)?;
+            if config
                 .fault
-                .crash_initial_create_process_if_armed(InitialCreateFaultPoint::AfterDatabaseSync);
-            return Err(LocalEventStoreOpenError::StorageUnavailable);
+                .take_initial_create_fault(InitialCreateFaultPoint::AfterDatabaseSync)
+            {
+                #[cfg(test)]
+                config.fault.crash_initial_create_process_if_armed(
+                    InitialCreateFaultPoint::AfterDatabaseSync,
+                );
+                return Err(LocalEventStoreOpenError::StorageUnavailable);
+            }
         }
         if config
             .fault
@@ -632,6 +665,20 @@ impl LocalEventStore {
             );
             return Err(LocalEventStoreOpenError::StorageUnavailable);
         }
+
+        let writer_connection = if checkpoint.busy {
+            writer_connection
+        } else {
+            run_startup_maintenance(&layout, writer_connection, config.fault.as_ref()).map_err(
+                |error| {
+                    let correlation = correlation_id();
+                    log::error!(
+                        "local event store could not reopen after startup maintenance [{correlation}]: {error}"
+                    );
+                    classify_startup_maintenance_error(&error)
+                },
+            )?
+        };
 
         let (installation_id, cursor_key, operation_binding_key): (String, Vec<u8>, Vec<u8>) =
             writer_connection
@@ -1120,6 +1167,22 @@ mod startup_error_classification_tests {
                 &ConnectionError::SqliteTooOld { version_number: 0 },
                 LocalEventStoreOpenError::StorageUnavailable,
             ),
+            LocalEventStoreOpenError::UnsupportedRuntime
+        );
+    }
+
+    #[test]
+    fn startup_maintenance_reopen_failures_use_the_connection_classifier() {
+        assert_eq!(
+            classify_startup_maintenance_error(&StartupMaintenanceError::Connection(
+                ConnectionError::Sqlite(sqlite_failure(rusqlite::ffi::SQLITE_IOERR)),
+            )),
+            LocalEventStoreOpenError::StorageUnavailable
+        );
+        assert_eq!(
+            classify_startup_maintenance_error(&StartupMaintenanceError::Connection(
+                ConnectionError::SqliteTooOld { version_number: 0 },
+            )),
             LocalEventStoreOpenError::UnsupportedRuntime
         );
     }

--- a/src-tauri/src/adaptor/gateway/local_event_store/store.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/store.rs
@@ -626,22 +626,21 @@ impl LocalEventStore {
                 checkpoint.log_frames,
                 checkpoint.checkpointed_frames
             );
-        } else {
-            layout.observe(StorePathOperation::Open, &database_path);
-            layout.observe(StorePathOperation::Sync, &database_path);
-            std::fs::File::open(&database_path)
-                .and_then(|file| file.sync_all())
-                .map_err(|_| LocalEventStoreOpenError::StorageUnavailable)?;
-            if config
+        }
+        layout.observe(StorePathOperation::Open, &database_path);
+        layout.observe(StorePathOperation::Sync, &database_path);
+        std::fs::File::open(&database_path)
+            .and_then(|file| file.sync_all())
+            .map_err(|_| LocalEventStoreOpenError::StorageUnavailable)?;
+        if config
+            .fault
+            .take_initial_create_fault(InitialCreateFaultPoint::AfterDatabaseSync)
+        {
+            #[cfg(test)]
+            config
                 .fault
-                .take_initial_create_fault(InitialCreateFaultPoint::AfterDatabaseSync)
-            {
-                #[cfg(test)]
-                config.fault.crash_initial_create_process_if_armed(
-                    InitialCreateFaultPoint::AfterDatabaseSync,
-                );
-                return Err(LocalEventStoreOpenError::StorageUnavailable);
-            }
+                .crash_initial_create_process_if_armed(InitialCreateFaultPoint::AfterDatabaseSync);
+            return Err(LocalEventStoreOpenError::StorageUnavailable);
         }
         if config
             .fault

--- a/src-tauri/src/infrastructure/platform/file_replace.rs
+++ b/src-tauri/src/infrastructure/platform/file_replace.rs
@@ -1,0 +1,56 @@
+use std::path::Path;
+
+pub(crate) fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        replace_file_windows(source, destination)
+    }
+    #[cfg(not(windows))]
+    {
+        std::fs::rename(source, destination)
+    }
+}
+
+#[cfg(windows)]
+fn replace_file_windows(source: &Path, destination: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, ReplaceFileW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        REPLACEFILE_WRITE_THROUGH,
+    };
+
+    fn wide(path: &Path) -> Vec<u16> {
+        path.as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    let destination_exists = destination.exists();
+    let source = wide(source);
+    let destination = wide(destination);
+    let replaced = if destination_exists {
+        unsafe {
+            ReplaceFileW(
+                destination.as_ptr(),
+                source.as_ptr(),
+                std::ptr::null(),
+                REPLACEFILE_WRITE_THROUGH,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        }
+    } else {
+        unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                destination.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        }
+    };
+    if replaced == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/src-tauri/src/infrastructure/platform/mod.rs
+++ b/src-tauri/src/infrastructure/platform/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod app_data_dir;
 pub(crate) mod cli_install;
+pub(crate) mod file_replace;
 pub(crate) mod menu;
 pub(crate) mod native_drop;
 pub(crate) mod path_aliases;


### PR DESCRIPTION
## 背景

旧 message projection の残存データにより local event store が 8.7GB まで肥大化していた（うち 7.2GB が現行コードの誰も読み書きしない死蔵データ）。書き込み元の実装は PR #1621 で削除済みだが、残存データを掃除する経路も、SQLite のファイル物理サイズを回収する経路も存在しなかった。

## 変更内容

- **未使用テーブルの削除（schema バージョン移行・一回きり）**: `message_projection` / `terminal_records` / `stop_resolutions` と付随 index を schema から削除し、既存ストア上の残存データを回収する。移行後および新規作成のストアでは再作成されない。
- **起動時保守パスの新設（常設）**: store 自身が所有する保守経路を追加。`freelist_count / page_count >= 25%` かつ freelist 64MB 相当以上を満たすときに `VACUUM INTO` + ファイル差し替えで物理サイズを回収する。発火判定はファイル走査を伴わない。
- **best-effort の安全性**: 縮小失敗時は一時ファイルの残骸を片付けた上で、旧ファイルのまま起動を継続する。差し替え前後で使用中テーブルと `store_metadata` のデータを保持し、旧 `-wal` / `-shm` に由来する不整合を生じさせない。
- **ファイル差し替えの共通化**: Windows 対応を含むアトミックなファイル差し替えを comment gateway から `infrastructure/platform/file_replace` へ切り出して共有する。
- 保守経路の各境界に fault injection point を追加し、`schema_test.rs` / `maintenance.rs` にテストを追加。

## 検証

`cargo test --locked` で本変更対象の LocalEventStore テストを含む 1,977 件が成功。

以下は実行環境（sandbox の loopback listener 権限・Node バージョン）の制約により**判定に到達できなかった**もので、本変更の成否は未確認：

- `pnpm test` — 実行環境が Node v20.20.0 で Vitest が起動前に停止
- `pnpm test:integration` — webServer の `::1:1420` listen が `EPERM`
- `cargo deny --locked check` — advisory DB の lock 取得が read-only path で失敗
- `cargo test --locked --test agent_tui_harness` — 失敗 11 件はすべて未変更の fixture の bind `EPERM`
- `cargo test --locked` 全体 — 未変更の local API / hook test 8 件が loopback listener bind の `EPERM` で失敗

CI での再確認が必要。

Closes #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 起動時にデータベースの空き領域を自動回収し、ファイルサイズを最適化します。
  * 使用率と回収量が一定条件を満たす場合のみ処理を実行します。
* **改善**
  * 旧バージョンの不要なテーブルやインデックスを安全に削除します。
  * 回収処理に失敗しても一時ファイルを残さず、既存データで起動を継続します。
  * データやメタデータの整合性を維持し、保存内容を保護します。
* **テスト**
  * スキーマ移行、障害発生時、権限やファイル状態などの検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->