### PR TITLE
feat(terminal): Shift+Enter / Cmd+Enter を ESC+CR としてTUIへ送る

### DIFF
--- a/specs/issues-1637/behavior.md
+++ b/specs/issues-1637/behavior.md
@@ -1,0 +1,50 @@
+## B-001: Shift+Enterによる改行挿入入力
+
+GIVEN workspaceターミナルまたはAgent sessionのTUIのターミナルsurfaceにフォーカスがある
+WHEN 利用者がShift+Enterを押す
+THEN PTY入力へ`\x1b\r`（ESC + CRの2バイト）が送られる
+AND `\r`は重複して送られない
+
+## B-002: Cmd+Enterによる改行挿入入力
+
+GIVEN workspaceターミナルまたはAgent sessionのTUIのターミナルsurfaceにフォーカスがある
+WHEN 利用者がCmd+Enterを押す
+THEN PTY入力へ`\x1b\r`（ESC + CRの2バイト）が送られる
+AND `\r`は重複して送られない
+
+## B-003: 修飾キーなしのEnter入力の維持
+
+GIVEN workspaceターミナルまたはAgent sessionのTUIのターミナルsurfaceにフォーカスがある
+WHEN 利用者が修飾キーなしのEnterを押す
+THEN PTY入力へ`\r`が送られる
+
+## B-004: IME変換中のEnter入力の維持
+
+GIVEN workspaceターミナルまたはAgent sessionのTUIのターミナルsurfaceにフォーカスがあり、IMEによる未確定文字列がある
+WHEN 利用者がEnterを押す（修飾キーなし、Shift、Cmd、Ctrl、Altのいずれを伴う場合も含む）
+THEN PTY入力へ`\x1b\r`は送られない
+AND PTY入力へEnter由来の`\r`も送られない
+AND IMEが確定した文字列がPTY入力へ送られる
+
+## B-005: その他のキー入力の維持
+
+GIVEN workspaceターミナルまたはAgent sessionのTUIのターミナルsurfaceにフォーカスがある
+WHEN 利用者がShift+Enter、Cmd+Enter、IME変換中のEnter、または既存のペイン操作ショートカット以外のキー入力を行う
+THEN PTY入力へ送られる内容は本変更前と同じである
+
+## B-006: ペイン操作ショートカットの入力抑止の維持
+
+GIVEN workspaceターミナルまたはAgent sessionのTUIのターミナルsurfaceにフォーカスがある
+WHEN 利用者がCmd+D、Cmd+Shift+D、またはCmd+Option+矢印を押す
+THEN そのキー入力はPTY入力へ送られない
+
+## 要件IDとBehavior IDの対応表
+
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001 |
+| R-002 | B-002 |
+| R-003 | B-003 |
+| R-004 | B-004 |
+| R-005 | B-003, B-005, B-006 |
+| R-006 | B-001, B-002, B-003, B-004, B-005, B-006 |

--- a/specs/issues-1637/design.md
+++ b/specs/issues-1637/design.md
@@ -1,0 +1,74 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### キー入力変換の責務
+
+`src/hooks/useTerminal.ts` の xterm 入力アダプタが、DOM `KeyboardEvent` の Shift+Enter と Cmd（meta）+Enter を `\x1b\r` へ変換する責務を持つ。修飾キーと IME composition は browser の keyboard event としてのみ確定できるため、この責務は `AGENTS.md` が frontend に認める入力受付に該当する。Issue #1637 も変更対象として `src/hooks/useTerminal.ts` の `attachCustomKeyEventHandler` を名指ししている。新しい domain decision や terminal state は frontend に持たせない。
+
+変換後の入力は xterm 6.0.0 の公開 `Terminal.input` から既存の `Terminal.onData` へ戻し、`dispatchInput`、startup input buffer、attachment ごとの sequence、WebSocket または Tauri command、Rust の Terminal Surface input ingress という現在の経路をそのまま通す。入力の順序、実行中判定、attachment、retry/recovery、および PTY 書き込みの owner は引き続き backend の `terminal_surface` とする。根拠は `src/hooks/useTerminal.ts` の既存入力経路、`src-tauri/src/domain/terminal_surface/entities/terminal_surface_input_ingress.rs`、および `docs/architecture/README.md` の Terminal Surface ownership である。
+
+主要な変更対象は次のとおり。
+
+| Path | 変更の要旨 |
+| --- | --- |
+| `src/hooks/useTerminal.ts` | 既存の `attachCustomKeyEventHandler` に、対象 Enter chord の IME 除外、`\x1b\r` 投入、xterm 既定エンコード抑止を追加し、`Terminal.onData` の受け口で IME 変換中の Enter 由来バイトを抑止する |
+| `src/hooks/useTerminal.test.ts` | B-001 から B-006 の PTY 入力契約を hook unit test で自動検証する |
+
+### Interface
+
+利用者向け契約は、ターミナル surface にフォーカスがあるとき、Shift+Enter または Cmd（meta）+Enter が PTY 入力 `\x1b\r` を一度だけ生成することである。新しい設定、UI、Tauri command、WebSocket message、protocol version は追加しない。
+
+内部境界には xterm 6.0.0 の公開 `attachCustomKeyEventHandler` と `Terminal.input(data, true)` を使用する。後者が発火する既存 `onData` を唯一の送出入口とし、custom key handler から `write_terminal_surface` や WebSocket を直接呼ばない。既存の Tauri `write_terminal_surface` と WebSocket `write` frame の `data: string` 契約は変更せず、変換済みの 2 文字を従来と同じ一つの入力単位として渡す。
+
+互換境界は非破壊とする。修飾キーなしの Enter、Ctrl+Enter、Alt（Option）+Enter、追加修飾キーを伴う Enter、その他のキー、および既存ペイン操作 chord は従来どおり xterm または既存抑止処理へ委譲する。
+
+### Data Model
+
+新しい record、frontend state、backend state、永続データは追加しない。`\x1b\r` は既存 terminal input の `data` としてその場で送出し、保持や versioning の対象にしない。
+
+### Database
+
+該当なし。
+
+### UI/UX
+
+ターミナル surface 上の Shift+Enter と Cmd+Enter のキー操作だけを変更する。表示、設定項目、操作フローは追加しない。
+
+### Algorithm
+
+custom key handler の Enter 変換分岐は `key === "Enter"` に限定する。この分岐内で最初に `isComposing === true` または `keyCode === 229` を判定し、該当時は変換せず xterm の composition 処理へ委譲する。Enter 以外はこの分岐へ入れず、既存のペイン操作 chord 判定をそのまま適用する。
+
+IME 変換中の Enter は、委譲だけでは R-004 を満たさない。xterm 6.0.0 の `CompositionHelper.keydown` は `keyCode === 229` の Enter に対しては `false` を返してキーエンコードへ到達させないが、`isComposing` かつ `keyCode === 13` の Enter（WebKit 系が発火させる形。macOS の Tauri WebView はこちら）に対しては `_finalizeComposition(false)` で確定文字列を送出したのち `true` を返し、Enter を通常どおりエンコードする。そのため後者では確定文字列に続けて Enter 由来の `\r`（Alt 併用時は `\x1b\r`）が `onData` へ届く。
+
+この差を吸収するため、custom key handler は `isComposing` かつ `keyCode === 13` の Enter keydown を検出したときに、直後に届く Enter 由来バイトの抑止フラグを立てる。`onData` の受け口はフラグが立っている間に届いた `\r` または `\x1b\r` を一度だけ捨て、フラグを下ろす。フラグは `queueMicrotask` でも解除する。xterm がこの keydown に対して発火させるデータイベントは同一 task 内で同期的に完了するため、次の microtask まで残ったフラグは対象イベントが発生しなかったことを意味し、後続の入力へ波及させない。`keyCode === 229` の Enter ではフラグを立てない。この経路では Enter 由来バイトが発生せず、確定文字列を誤って捨てうるためである。フラグの判定は `Terminal.onData` の受け口に閉じ、`inputDispatchRef` 経由の非キー入力経路には影響させない。
+
+この抑止は修飾キーの有無を問わない。IME 変換中の Shift+Enter、Cmd+Enter、Ctrl+Enter、Alt+Enter のいずれでも、PTY 入力へ届くのは IME が確定した文字列だけになる。
+
+composition 中ではない Enter のうち、変換対象は次のいずれかを満たす入力に限定する。
+
+- Shift のみが押され、meta、Ctrl、Alt は押されていない。
+- meta のみが押され、Shift、Ctrl、Alt は押されていない。
+
+対象 chord の `keydown` では browser の既定処理を `preventDefault` し、`Terminal.input("\x1b\r", true)` を一度呼ぶ。対象 chord の keydown、keypress、keyup はすべて handler から `false` を返して xterm のキーエンコーダへ渡さず、投入は keydown に限定する。これにより custom handler が複数の keyboard event 種別で呼ばれても `\x1b\r` は一度だけ `onData` へ到達し、xterm 由来の追加 `\r` は発生しない。IME 変換中と対象外のキーは `true` を返し、既存エンコードを維持する。この event 順序と入力 API は xterm 6.0.0 の [`CoreBrowserTerminal.ts`](https://github.com/xtermjs/xterm.js/blob/6.0.0/src/browser/CoreBrowserTerminal.ts) と[公開 typings](https://github.com/xtermjs/xterm.js/blob/6.0.0/typings/xterm.d.ts)を根拠とする。
+
+B-001 から B-006 のうち検証手段が自明でないのは、キー入力に対して PTY 入力へ渡る内容である。これは `src/hooks/useTerminal.test.ts` の hook unit test で、送出された `data` と送出回数を観測して検証する。workspace owner と Agent session owner の双方も同じ種別の検証で固定する。実 provider process は起動しない。
+
+### Infra
+
+該当なし。
+
+## Alternatives Considered
+
+- custom key handler から既存 `inputDispatchRef` または backend transport を直接呼ぶ案: PTY へ同じ bytes は送れるが、xterm の公開 user-input 経路と既存 `onData` 入口を迂回し、入力時の xterm 処理と Releash の dispatch 経路を分岐させるため採用しない。
+- browser key event を新しい backend command へ渡して Rust で変換する案: custom handler は xterm の同期処理前に受理可否を返す必要があり、DOM event のためだけに新しい同期境界と protocol を追加することになる。Requirements が確定した入力フォーマット以上の domain decision はなく、既存の Terminal Surface 入力契約も変更するため採用しない。
+
+## Cross-cutting concerns
+
+- 可観測性: 既存 dispatch を通すことで terminal input performance probe の `on_data` 計測点も通常入力と同じ位置に維持する。新しい telemetry event は追加しない。
+
+## Risks
+
+該当なし。

--- a/specs/issues-1637/requirements.md
+++ b/specs/issues-1637/requirements.md
@@ -1,0 +1,68 @@
+# Context
+
+- 要求の正本: [Issue #1637](https://github.com/siro33950/releash/issues/1637) 「[Agent TUI] Shift+Enter / Cmd+Enter を改行挿入（ESC+CR）としてTUIへ送る」（OPEN、2026-08-12、comment なし）。
+- 補助資料（本書作成時に参照して事実を確認したもの）:
+  - `src/hooks/useTerminal.ts` — Releash のターミナル surface の入力経路。現行のキー処理と PTY への送出はここを通る。
+  - xterm.js upstream `src/common/input/Keyboard.ts` — Enter（keyCode 13）のエンコード規則。
+  - xterm.js upstream `src/browser/CoreBrowserTerminal.ts` — `attachCustomKeyEventHandler` と IME composition 処理の関係。
+  - [codex-rs/tui/src/keymap.rs](https://github.com/openai/codex/blob/main/codex-rs/tui/src/keymap.rs) — Codex の default keymap。`insert_newline` に `plain(KeyCode::Enter)` / `shift(KeyCode::Enter)` / `alt(KeyCode::Enter)` がバインドされていることを確認済み。
+  - 先行事例（同方式の実装）: [superset](https://github.com/superset-sh/superset/blob/main/apps/desktop/src/renderer/lib/terminal/line-edit-translations.ts)（Electron）、[nezha](https://github.com/hanshuaikang/nezha/blob/main/src/shortcuts.ts)（Tauri 2、IME composing 除外あり）、[tessera](https://github.com/horang-labs/tessera/blob/main/src/lib/terminal/terminal-key-input.ts)（Electron）。
+- 要求元が確定済みとして提示した背景:
+  - 送出するバイト列は ESC + CR（`\x1b\r`）である。Claude Code（Ink の parse-keypress が meta+return として解釈。`/terminal-setup` が VS Code / Alacritty / Zed に書き込む実体も同じ 2 バイト、v2.1.228 バイナリで確認済み）と Codex（crossterm が ESC プレフィクスを Alt 修飾へ変換し、default keymap の `alt(KeyCode::Enter)` が `insert_newline`）の双方が「改行挿入」と解釈する。
+  - この方式は kitty keyboard protocol のネゴシエーションに依存しない。したがって kitty 未対応の xterm.js 6.0.0 のままで機能する。
+  - IME 変換中の判定条件として `isComposing` / `keyCode === 229` を挙げている。
+- 完了条件に関する制約: Issue は「対象キー入力に対して PTY 入力へ送られる内容を自動検証できること」を完了条件としている。実機の手動確認のみでは完了条件を満たさない。
+- 完了条件が挙げる「IME 確定の Enter では従来通り `\r` が送られる」は、未確定文字列がない状態（変換が確定した後）の Enter を指すものとして解釈し、修飾キーなしの Enter と同じ扱いとする（R-003 が担う）。
+- 未確定文字列がある状態の Enter 押下では、Enter 由来のバイトを PTY へ送らず、IME が確定した文字列だけを送る（R-004）。これは修飾キーの有無を問わない確定判断である。xterm.js 6.0.0 は `keyCode === 229` の Enter では Enter 由来のバイトを送らないが、`isComposing` かつ `keyCode === 13` の Enter（WebKit 系が発火させる形）では composition を確定させたうえで Enter をエンコードする（根拠は Current Behavior）。この差を Releash 側で吸収し、どちらの経路でも同じ結果にする。
+- 適用範囲に関する事実: Releash の workspace ターミナルと Agent session の TUI（`AgentSessionPanel` → `TerminalPanel`）は同一のターミナル surface 実装を共有しており、キー入力から PTY までの経路も共通である。
+
+# Outcome
+
+- 対象者: Releash のターミナル surface 上で TUI（Claude Code / Codex）を操作する開発者。
+- 現在の問題: TUI のプロンプトに改行を挿入する手段がない。Shift+Enter も Cmd+Enter も素の Enter と同じ「送信」として扱われるため、複数行の指示を書くには Releash の外で本文を組み立てて貼り付けるしかない。
+- 変更後に実現する状態: ターミナル上の TUI で Shift+Enter / Cmd+Enter が改行挿入として働き、素の Enter は従来どおり送信のままである。IME で日本語を変換中の Enter がこの変換に巻き込まれない。
+
+# Current Behavior
+
+Issue #1637 が報告する挙動を、2026-08-13 時点の worktree（branch `feat/issues/1637`、`55410de53` 系）の現行実装と xterm.js upstream のソースで裏付けた。
+
+- 再現手順: worktree でターミナル（または Agent session の TUI）を開き、Claude Code または Codex を起動する。プロンプトへ文字を入力した状態で Shift+Enter または Cmd+Enter を押す。
+- 実際の出力: 改行は挿入されず、その時点の入力が送信される。素の Enter を押した場合と区別がつかない。
+- 経路上の根拠:
+  - xterm.js（`@xterm/xterm` ^6.0.0）の Enter エンコードは `result.key = ev.altKey ? C0.ESC + C0.CR : C0.CR` であり、`shiftKey` と `metaKey` は特別扱いされない。Shift+Enter も Cmd+Enter も `\r` 1 バイトになる。ESC+CR になるのは Alt（Option）+Enter のときだけである。
+  - `src/hooks/useTerminal.ts:217` のカスタムキーハンドラは、ペイン操作キー（Cmd+D / Cmd+Shift+D / Cmd+Option+矢印）だけを xterm に処理させず、それ以外は素通しする。Enter 系の分岐は存在しない。
+  - そのため Shift+Enter / Cmd+Enter は xterm のエンコード結果 `\r` として `terminal.onData` に届き、既存の入力 dispatch 経路を通って PTY へ送られる。
+  - カスタムキーハンドラは xterm の composition 処理（`_compositionHelper.keydown`）より前に呼ばれる。IME 変換中の keydown（`isComposing === true` または `keyCode === 229`）もカスタムキーハンドラへ到達する。
+  - IME 変換中の Enter 押下の扱いは、`CompositionHelper.keydown`（`src/browser/input/CompositionHelper.ts`）で 2 経路に分かれる。`keyCode === 229` の Enter は `false` が返り、`CoreBrowserTerminal._keyDown` がキーエンコード（`evaluateKeyboardEvent` と `triggerDataEvent`）へ到達しないため Enter 由来のバイトは送られない。`isComposing` かつ `keyCode === 13` の Enter は `_finalizeComposition(false)` で composition を確定させたのち `true` が返るため、確定文字列に続けて Enter のエンコード結果（Alt なしなら `\r`、Alt ありなら `\x1b\r`）が PTY へ送られる。
+  - IME が確定した文字列は composition 完了時に `triggerDataEvent` から送られ、通常の入力と同じ `onData` 経路を通って PTY へ届く。
+- 既存テスト: `src/hooks/useTerminal.test.ts` にキー入力ごとの PTY 送出内容（Shift+Enter / Cmd+Enter / 素の Enter の区別）を検証するテストはない。
+
+# Scope / Non-goals
+
+## Scope
+
+- ターミナル surface でのキー入力から PTY 入力までの経路における、Shift+Enter と Cmd+Enter の送出内容。
+- IME 変換中の Enter 押下をこの変換の対象から除外すること。
+- 上記の送出内容を自動テストで検証できるようにすること。
+
+## Non-goals
+
+- IME 変換中でない状態での、素の Enter、Ctrl+Enter、Alt（Option）+Enter の送出内容の変更。
+- ペイン操作ショートカット（Cmd+D / Cmd+Shift+D / Cmd+Option+矢印）の扱いの変更。
+- kitty keyboard protocol への対応、および xterm.js のバージョン更新。
+- provider 側（Claude Code / Codex）の keybinding 設定や TUI 実装の変更。
+- 改行挿入に割り当てるキーのユーザー設定化。
+- ターミナル surface 以外の入力欄（チャット入力欄、ダイアログ等）のキー挙動。
+
+# Requirements
+
+- R-001: ターミナル surface にフォーカスがある状態で Shift+Enter を押すと、PTY 入力へ `\x1b\r`（ESC + CR の 2 バイト）が送られる。`\r` は重複して送られない。
+- R-002: ターミナル surface にフォーカスがある状態で Cmd（meta）+Enter を押すと、PTY 入力へ `\x1b\r`（ESC + CR の 2 バイト）が送られる。`\r` は重複して送られない。
+- R-003: 修飾キーなしの Enter を押したときに PTY 入力へ送られる内容は本変更前と変わらず、`\r` のままである。
+- R-004: IME による変換中（未確定文字列がある状態）の Enter 押下では、PTY 入力へ `\x1b\r` も Enter 由来の `\r` も送られない。この Enter 押下によって PTY 入力へ送られるのは、IME が確定した文字列だけである。修飾キーの有無と種類（Shift、Cmd、Ctrl、Alt）を問わず同じである。
+- R-005: 互換性要件 — Shift+Enter、Cmd+Enter、および IME 変換中の Enter 以外のキー入力について、PTY 入力へ送られる内容は本変更前と変わらない。既存のペイン操作ショートカットが xterm に処理されない扱いも維持される。
+- R-006: R-001 から R-005 は、workspace ターミナルと Agent session の TUI のどちらのターミナル surface でも同じように成り立つ。
+
+# Assumptions / Open Questions
+
+なし。

--- a/src/hooks/useTerminal.test.ts
+++ b/src/hooks/useTerminal.test.ts
@@ -90,6 +90,9 @@ let mockTerminalInstance: {
 	focus: ReturnType<typeof vi.fn>;
 	write: ReturnType<typeof vi.fn>;
 	resize: ReturnType<typeof vi.fn>;
+	input: ReturnType<
+		typeof vi.fn<(data: string, wasUserInput?: boolean) => void>
+	>;
 	onData: ReturnType<typeof vi.fn>;
 	attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
 	dispose: ReturnType<typeof vi.fn>;
@@ -125,6 +128,7 @@ vi.mock("@xterm/xterm", () => {
 				this.cols = cols;
 				this.rows = rows;
 			});
+			input = vi.fn((data: string) => mockOnDataCallback(data));
 			onData = vi
 				.fn()
 				.mockImplementation((callback: (data: string) => void) => {
@@ -145,6 +149,92 @@ vi.mock("@xterm/xterm", () => {
 		},
 	};
 });
+
+interface KeyboardSequenceInit {
+	key: string;
+	keyCode: number;
+	shiftKey?: boolean;
+	metaKey?: boolean;
+	ctrlKey?: boolean;
+	altKey?: boolean;
+	isComposing?: boolean;
+}
+
+function dispatchKeyboardSequence(
+	init: KeyboardSequenceInit,
+	xtermEncodedData: string | null,
+) {
+	const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock
+		.calls[0][0] as (event: KeyboardEvent) => boolean;
+	const events = (["keydown", "keypress", "keyup"] as const).map(
+		(type) =>
+			({
+				type,
+				key: init.key,
+				keyCode: init.keyCode,
+				shiftKey: init.shiftKey ?? false,
+				metaKey: init.metaKey ?? false,
+				ctrlKey: init.ctrlKey ?? false,
+				altKey: init.altKey ?? false,
+				isComposing: init.isComposing ?? false,
+				preventDefault: vi.fn(),
+				stopPropagation: vi.fn(),
+			}) as unknown as KeyboardEvent,
+	);
+	const delegated = events.map((event) => handler(event));
+	if (
+		delegated[0] &&
+		xtermEncodedData !== null &&
+		!events[0].isComposing &&
+		events[0].keyCode !== 229
+	) {
+		mockTerminalInstance.input(xtermEncodedData, true);
+	}
+	return { delegated, events };
+}
+
+function dispatchXtermCompositionEnter(
+	init: KeyboardSequenceInit,
+	compositionData: string,
+) {
+	const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock
+		.calls[0][0] as (event: KeyboardEvent) => boolean;
+	const event = {
+		type: "keydown",
+		key: init.key,
+		keyCode: init.keyCode,
+		shiftKey: init.shiftKey ?? false,
+		metaKey: init.metaKey ?? false,
+		ctrlKey: init.ctrlKey ?? false,
+		altKey: init.altKey ?? false,
+		isComposing: init.isComposing ?? false,
+		preventDefault: vi.fn(),
+		stopPropagation: vi.fn(),
+	} as unknown as KeyboardEvent;
+	const delegated = handler(event);
+	if (delegated) {
+		if (event.keyCode === 229) {
+			mockOnDataCallback(compositionData);
+		} else {
+			mockOnDataCallback(compositionData);
+			mockOnDataCallback(event.altKey ? "\x1b\r" : "\r");
+		}
+	}
+	return { delegated, event };
+}
+
+function terminalInputWrites() {
+	return mockInvoke.mock.calls
+		.filter(([command]) => command === "write_terminal_surface")
+		.map(
+			([, args]) =>
+				args as {
+					owner: unknown;
+					sequence: number;
+					data: string;
+				},
+		);
+}
 
 let mockFitAddonInstance: { fit: ReturnType<typeof vi.fn> };
 
@@ -2200,66 +2290,267 @@ describe("useTerminal", () => {
 	});
 
 	describe("attachCustomKeyEventHandler", () => {
-		it("ペイン操作キーを抑止する", () => {
-			renderHook(() => useTerminal(containerRef));
+		const agentSessionOwner = {
+			kind: "session",
+			workspacePath: "/repo",
+			sessionId: "agent-session-1",
+		} as const;
+		const surfaces = [
+			{
+				label: "workspace",
+				owner: REPO_WORKSPACE_OWNER,
+				options: { cwd: "/repo", owner: REPO_WORKSPACE_OWNER },
+			},
+			{
+				label: "Agent session",
+				owner: agentSessionOwner,
+				options: {
+					cwd: "/repo",
+					owner: agentSessionOwner,
+					initialization: "attach-existing" as const,
+				},
+			},
+		];
 
-			expect(
-				mockTerminalInstance.attachCustomKeyEventHandler,
-			).toHaveBeenCalledTimes(1);
-			const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock
-				.calls[0][0] as (event: Partial<KeyboardEvent>) => boolean;
+		describe.each(surfaces)("$label terminal surface", (surface) => {
+			async function renderRunningSurface() {
+				const hook = renderHook(() =>
+					useTerminal(containerRef, surface.options),
+				);
+				await waitFor(() => {
+					expect(hook.result.current.isRunningRef.current).toBe(true);
+				});
+				mockInvoke.mockClear();
+				return hook;
+			}
 
-			// Cmd+D → false (垂直分割)
-			expect(
-				handler({ metaKey: true, ctrlKey: false, altKey: false, key: "d" }),
-			).toBe(false);
-			// Cmd+Shift+D → false (水平分割)
-			expect(
-				handler({ metaKey: true, ctrlKey: false, altKey: false, key: "D" }),
-			).toBe(false);
-			// Cmd+Option+ArrowRight → false (フォーカス移動)
-			expect(
-				handler({
-					metaKey: true,
-					ctrlKey: false,
-					altKey: true,
-					key: "ArrowRight",
-				}),
-			).toBe(false);
-			// Cmd+Option+ArrowLeft → false
-			expect(
-				handler({
-					metaKey: true,
-					ctrlKey: false,
-					altKey: true,
-					key: "ArrowLeft",
-				}),
-			).toBe(false);
-		});
+			it.each([
+				{
+					label: "Shift+Enter",
+					modifiers: { shiftKey: true },
+				},
+				{
+					label: "Cmd+Enter",
+					modifiers: { metaKey: true },
+				},
+			])("$labelをESC+CRとして一度だけ送る", async ({ modifiers }) => {
+				await renderRunningSurface();
 
-		it("通常キーは抑止しない", () => {
-			renderHook(() => useTerminal(containerRef));
+				const { delegated, events } = dispatchKeyboardSequence(
+					{ key: "Enter", keyCode: 13, ...modifiers },
+					"\r",
+				);
 
-			const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock
-				.calls[0][0] as (event: Partial<KeyboardEvent>) => boolean;
+				expect(delegated).toEqual([false, false, false]);
+				expect(events[0].preventDefault).toHaveBeenCalledTimes(1);
+				expect(events[1].preventDefault).not.toHaveBeenCalled();
+				expect(events[2].preventDefault).not.toHaveBeenCalled();
+				expect(mockTerminalInstance.input).toHaveBeenCalledTimes(1);
+				expect(mockTerminalInstance.input).toHaveBeenCalledWith("\x1b\r", true);
+				expect(terminalInputWrites()).toEqual([
+					expect.objectContaining({
+						owner: surface.owner,
+						sequence: 0,
+						data: "\x1b\r",
+					}),
+				]);
+			});
 
-			// 通常の文字入力 → true
-			expect(
-				handler({ metaKey: false, ctrlKey: false, altKey: false, key: "a" }),
-			).toBe(true);
-			// Cmd+C (コピー) → true
-			expect(
-				handler({ metaKey: true, ctrlKey: false, altKey: false, key: "c" }),
-			).toBe(true);
-			// 矢印キー（修飾なし） → true
-			expect(
-				handler({
-					metaKey: false,
-					ctrlKey: false,
-					altKey: false,
-					key: "ArrowRight",
-				}),
-			).toBe(true);
+			it("修飾キーなしのEnterをCRのまま送る", async () => {
+				await renderRunningSurface();
+
+				const { delegated } = dispatchKeyboardSequence(
+					{ key: "Enter", keyCode: 13 },
+					"\r",
+				);
+
+				expect(delegated).toEqual([true, true, true]);
+				expect(terminalInputWrites()).toEqual([
+					expect.objectContaining({
+						owner: surface.owner,
+						sequence: 0,
+						data: "\r",
+					}),
+				]);
+			});
+
+			it.each([
+				{
+					label: "isComposingかつkeyCode 13の修飾キーなし",
+					event: { keyCode: 13, isComposing: true },
+				},
+				{
+					label: "isComposingかつkeyCode 13のShift",
+					event: { keyCode: 13, isComposing: true, shiftKey: true },
+				},
+				{
+					label: "isComposingかつkeyCode 13のCmd",
+					event: { keyCode: 13, isComposing: true, metaKey: true },
+				},
+				{
+					label: "isComposingかつkeyCode 13のCtrl",
+					event: { keyCode: 13, isComposing: true, ctrlKey: true },
+				},
+				{
+					label: "isComposingかつkeyCode 13のAlt",
+					event: { keyCode: 13, isComposing: true, altKey: true },
+				},
+				{
+					label: "keyCode 229かつ修飾キーなし",
+					event: { keyCode: 229 },
+				},
+				{
+					label: "keyCode 229かつShift",
+					event: { keyCode: 229, shiftKey: true },
+				},
+				{
+					label: "keyCode 229かつCmd",
+					event: { keyCode: 229, metaKey: true },
+				},
+				{
+					label: "keyCode 229かつCtrl",
+					event: { keyCode: 229, ctrlKey: true },
+				},
+				{
+					label: "keyCode 229かつAlt",
+					event: { keyCode: 229, altKey: true },
+				},
+			])("$labelのEnterで確定文字列だけを一度送る", async ({ event }) => {
+				await renderRunningSurface();
+
+				const { delegated, event: keydown } = dispatchXtermCompositionEnter(
+					{ key: "Enter", ...event },
+					"確定文字列",
+				);
+
+				expect(delegated).toBe(true);
+				expect(keydown.preventDefault).not.toHaveBeenCalled();
+				expect(mockTerminalInstance.input).not.toHaveBeenCalled();
+				expect(terminalInputWrites()).toEqual([
+					expect.objectContaining({
+						owner: surface.owner,
+						sequence: 0,
+						data: "確定文字列",
+					}),
+				]);
+			});
+
+			it.each([
+				{
+					label: "Ctrl+Enter",
+					event: { key: "Enter", keyCode: 13, ctrlKey: true },
+					encoded: "\r",
+				},
+				{
+					label: "Alt+Enter",
+					event: { key: "Enter", keyCode: 13, altKey: true },
+					encoded: "\x1b\r",
+				},
+				{
+					label: "Shift+Ctrl+Enter",
+					event: {
+						key: "Enter",
+						keyCode: 13,
+						shiftKey: true,
+						ctrlKey: true,
+					},
+					encoded: "\r",
+				},
+				{
+					label: "Shift+Alt+Enter",
+					event: {
+						key: "Enter",
+						keyCode: 13,
+						shiftKey: true,
+						altKey: true,
+					},
+					encoded: "\x1b\r",
+				},
+				{
+					label: "Cmd+Ctrl+Enter",
+					event: {
+						key: "Enter",
+						keyCode: 13,
+						metaKey: true,
+						ctrlKey: true,
+					},
+					encoded: "\r",
+				},
+				{
+					label: "Cmd+Alt+Enter",
+					event: {
+						key: "Enter",
+						keyCode: 13,
+						metaKey: true,
+						altKey: true,
+					},
+					encoded: "\x1b\r",
+				},
+				{
+					label: "Shift+Cmd+Enter",
+					event: {
+						key: "Enter",
+						keyCode: 13,
+						shiftKey: true,
+						metaKey: true,
+					},
+					encoded: "\r",
+				},
+				{
+					label: "文字キー",
+					event: { key: "a", keyCode: 65 },
+					encoded: "a",
+				},
+				{
+					label: "矢印キー",
+					event: { key: "ArrowRight", keyCode: 39 },
+					encoded: "\x1b[C",
+				},
+			])("$labelをxtermの既存入力へ委譲する", async ({ event, encoded }) => {
+				await renderRunningSurface();
+
+				const { delegated, events } = dispatchKeyboardSequence(event, encoded);
+
+				expect(delegated).toEqual([true, true, true]);
+				expect(events[0].preventDefault).not.toHaveBeenCalled();
+				expect(terminalInputWrites()).toEqual([
+					expect.objectContaining({
+						owner: surface.owner,
+						sequence: 0,
+						data: encoded,
+					}),
+				]);
+			});
+
+			it.each([
+				{
+					label: "Cmd+D",
+					event: { key: "d", keyCode: 68, metaKey: true },
+				},
+				{
+					label: "Cmd+Shift+D",
+					event: {
+						key: "D",
+						keyCode: 68,
+						metaKey: true,
+						shiftKey: true,
+					},
+				},
+				...(["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"] as const).map(
+					(key) => ({
+						label: `Cmd+Option+${key}`,
+						event: { key, keyCode: 0, metaKey: true, altKey: true },
+					}),
+				),
+			])("$labelをPTY入力へ送らない", async ({ event }) => {
+				await renderRunningSurface();
+
+				const { delegated } = dispatchKeyboardSequence(event, null);
+
+				expect(delegated).toEqual([false, false, false]);
+				expect(mockTerminalInstance.input).not.toHaveBeenCalled();
+				expect(terminalInputWrites()).toEqual([]);
+			});
 		});
 	});
 

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -213,8 +213,39 @@ export function useTerminal(
 			}
 		});
 
-		// ペイン操作に使うキーをxtermに処理させない
+		// IME変換中のEnterで xterm が送るEnter由来バイトを捨てるためのフラグ
+		let suppressImeEnterData = false;
+
+		// キー変換とペイン操作キーの入力抑止
 		terminal.attachCustomKeyEventHandler((event) => {
+			if (
+				event.key === "Enter" &&
+				(event.isComposing || event.keyCode === 229)
+			) {
+				// keyCode 229 では xterm がEnterをエンコードしないため抑止しない。
+				// keyCode 13 (WebKit系) では composition確定後にEnterがエンコードされるので抑止する。
+				// xtermの送出は同じtask内で同期的に終わるため、残ったフラグはmicrotaskで下ろす。
+				if (event.type === "keydown" && event.keyCode === 13) {
+					suppressImeEnterData = true;
+					queueMicrotask(() => {
+						suppressImeEnterData = false;
+					});
+				}
+				return true;
+			}
+			if (event.key === "Enter") {
+				const isShiftOnly =
+					event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey;
+				const isMetaOnly =
+					event.metaKey && !event.shiftKey && !event.ctrlKey && !event.altKey;
+				if (isShiftOnly || isMetaOnly) {
+					if (event.type === "keydown") {
+						event.preventDefault();
+						terminal.input("\x1b\r", true);
+					}
+					return false;
+				}
+			}
 			const mod = event.metaKey || event.ctrlKey;
 			// Cmd+D (垂直分割) / Cmd+Shift+D (水平分割)
 			if (mod && event.key === "d") return false;
@@ -677,7 +708,13 @@ export function useTerminal(
 			deliverInput(data);
 		};
 		inputDispatchRef.current = dispatchInput;
-		terminal.onData(dispatchInput);
+		terminal.onData((data) => {
+			if (suppressImeEnterData && (data === "\r" || data === "\x1b\r")) {
+				suppressImeEnterData = false;
+				return;
+			}
+			dispatchInput(data);
+		});
 
 		const RESIZE_DEBOUNCE_MS = 100;
 		let resizeTimer: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
Closes #1637

## 概要

ターミナル surface（workspace ターミナル / Agent session の TUI）で Shift+Enter と Cmd+Enter を改行挿入として扱えるようにする。PTY 入力へ `\x1b\r`（ESC + CR）を送ることで、Claude Code（Ink の meta+return）と Codex（crossterm の `alt(KeyCode::Enter)`）の双方が改行挿入と解釈する。kitty keyboard protocol のネゴシエーションには依存しない。

## 変更内容

- `useTerminal` の custom key handler で Shift のみ / meta のみを伴う Enter を `Terminal.input("\x1b\r", true)` へ変換し、keydown / keypress / keyup すべてを xterm のキーエンコーダへ渡さないことで `\r` の重複送出を防ぐ。
- IME 変換中の Enter は修飾キーの有無と種類を問わず Enter 由来バイトを送らず、確定文字列だけを PTY へ送る。xterm 6.0.0 は `keyCode === 229` の Enter では Enter をエンコードしないが、`isComposing` かつ `keyCode === 13` の Enter（WebKit 系、macOS の Tauri WebView はこちら）では `_finalizeComposition` 後に Enter をエンコードするため、`onData` の受け口でこの差を吸収する。
- 素の Enter、Ctrl+Enter、Alt+Enter、その他のキー、既存のペイン操作ショートカット（Cmd+D / Cmd+Shift+D / Cmd+Option+矢印）の扱いは変更しない。
- キー入力ごとの PTY 送出内容（内容と回数）を検証する hook unit test を追加。workspace owner と Agent session owner の双方で同じ検証を回す。
- `specs/issues-1637/` に要求・振る舞い定義・実装仕様を記録。

## 検証

- `pnpm lint` 通過
- `pnpm test` 90 files / 939 tests 全通過（`useTerminal.test.ts` は 118 tests）
- `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Shift+EnterおよびCmd+Enterで、端末にエスケープ付き改行を送信できるようになりました。
  * 通常のEnterは従来どおり改行として処理されます。
  * IME変換中のEnterによる不要な改行送信を抑止し、確定した文字列のみを送信します。

* **バグ修正**
  * ワークスペース端末とAgent session端末で、キー入力やペイン操作ショートカットの処理を改善しました。

* **テスト**
  * 各種修飾キー、IME入力、通常入力の動作検証を拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->