### PR TITLE
fix(watcher): FSEventsストリーム破棄をメインスレッドとロック外へ隔離する

### DIFF
--- a/src-tauri/src/adaptor/controller/command/watcher/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/watcher/mod.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Emitter, Manager};
 
 use crate::adaptor::controller::state::AppState;
 use crate::adaptor::gateway::repository::watch::{
@@ -20,12 +20,17 @@ pub(crate) fn invoke_handler(
     tauri::generate_handler![start_watching, start_git_dir_watching, stop_watching]
 }
 
+// watcher の生成・破棄は FSEvents ストリームの停止待ちでブロックし得るため、
+// メインスレッドで実行せず spawn_blocking へ逃がす（#1641）
+
 #[tauri::command]
-pub fn start_watching(
-    app: AppHandle,
-    state: State<'_, FileWatcherManager>,
-    path: String,
-) -> Result<u64, String> {
+pub async fn start_watching(app: AppHandle, path: String) -> Result<u64, String> {
+    tauri::async_runtime::spawn_blocking(move || start_watching_blocking(app, path))
+        .await
+        .map_err(|err| err.to_string())?
+}
+
+fn start_watching_blocking(app: AppHandle, path: String) -> Result<u64, String> {
     if let Some(app_state) = app.try_state::<AppState>() {
         match app_state
             .repository_state
@@ -39,30 +44,33 @@ pub fn start_watching(
 
     let watcher_id = generate_watcher_id();
     let app_clone = app.clone();
-    state.start_watching(watcher_id, path, move |event| {
-        let event = file_change_event_from_path(watcher_id, &event.path);
-        let _ = app_clone.emit("file-change", event);
+    app.state::<FileWatcherManager>()
+        .start_watching(watcher_id, path, move |event| {
+            let event = file_change_event_from_path(watcher_id, &event.path);
+            let _ = app_clone.emit("file-change", event);
+        })
+}
+
+#[tauri::command]
+pub async fn start_git_dir_watching(app: AppHandle, repo_path: String) -> Result<u64, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        app.state::<AppState>()
+            .repository_state
+            .start_git_dir_watching(&repo_path)
+            .map_err(|err| err.to_string())
     })
+    .await
+    .map_err(|err| err.to_string())?
 }
 
 #[tauri::command]
-pub fn start_git_dir_watching(
-    app: AppHandle,
-    _state: State<'_, FileWatcherManager>,
-    repo_path: String,
-) -> Result<u64, String> {
-    app.state::<AppState>()
-        .repository_state
-        .start_git_dir_watching(&repo_path)
-        .map_err(|err| err.to_string())
+pub async fn stop_watching(app: AppHandle, watcher_id: u64) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || stop_watching_blocking(app, watcher_id))
+        .await
+        .map_err(|err| err.to_string())?
 }
 
-#[tauri::command]
-pub fn stop_watching(
-    app: AppHandle,
-    state: State<'_, FileWatcherManager>,
-    watcher_id: u64,
-) -> Result<(), String> {
+fn stop_watching_blocking(app: AppHandle, watcher_id: u64) -> Result<(), String> {
     if let Some(app_state) = app.try_state::<AppState>() {
         match app_state.repository_state.stop_watching(watcher_id) {
             Ok(true) => return Ok(()),
@@ -71,7 +79,7 @@ pub fn stop_watching(
         }
     }
 
-    state.stop_watching(watcher_id)
+    app.state::<FileWatcherManager>().stop_watching(watcher_id)
 }
 
 fn file_change_event_from_path(watcher_id: u64, path: &Path) -> FileChangeEvent {

--- a/src-tauri/src/adaptor/gateway/repository/state.rs
+++ b/src-tauri/src/adaptor/gateway/repository/state.rs
@@ -47,8 +47,19 @@ impl RepositoryStateRepository for RepositoryStateRepositoryGateway {
 }
 
 struct RepositoryStateWatcherHandles {
-    _file_debouncer: RecommendedDebouncer,
-    _git_debouncer: RecommendedDebouncer,
+    file_debouncer: Option<RecommendedDebouncer>,
+    git_debouncer: Option<RecommendedDebouncer>,
+}
+
+impl Drop for RepositoryStateWatcherHandles {
+    fn drop(&mut self) {
+        // FsEventWatcher の drop は run loop の停止待ちでブロックし得るため、
+        // 呼び出し元スレッドでは実行しない（#1641）
+        crate::other::dispose::dispose_in_background(
+            "repository-watcher-dispose",
+            (self.file_debouncer.take(), self.git_debouncer.take()),
+        );
+    }
 }
 
 pub struct NotifyRepositoryStateWatcher {
@@ -73,8 +84,8 @@ impl RepositoryStateWatcher for NotifyRepositoryStateWatcher {
         let file_debouncer = start_file_watcher(state.clone(), &self.repository)?;
         let git_debouncer = start_git_watcher(state, &self.repository)?;
         Ok(Box::new(RepositoryStateWatcherHandles {
-            _file_debouncer: file_debouncer,
-            _git_debouncer: git_debouncer,
+            file_debouncer: Some(file_debouncer),
+            git_debouncer: Some(git_debouncer),
         }))
     }
 }

--- a/src-tauri/src/infrastructure/file_watcher/mod.rs
+++ b/src-tauri/src/infrastructure/file_watcher/mod.rs
@@ -70,10 +70,31 @@ impl FileWatcherManager {
     }
 
     pub(crate) fn stop_watching(&self, watcher_id: u64) -> Result<(), String> {
-        let mut sessions = self.sessions.lock();
-        sessions
+        let session = self
+            .sessions
+            .lock()
             .remove(&watcher_id)
             .ok_or_else(|| format!("Watcher {} not found", watcher_id))?;
+        // debouncer の drop はブロックし得るため sessions ロックの外・別スレッドで行う（#1641）
+        crate::other::dispose::dispose_in_background("file-watcher-dispose", session);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stop_watching_removes_session_and_errors_on_unknown_id() {
+        let manager = FileWatcherManager::default();
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+
+        let id = manager.start_watching(1, path, |_| {}).unwrap();
+        assert_eq!(id, 1);
+
+        manager.stop_watching(1).unwrap();
+        assert!(manager.stop_watching(1).is_err());
     }
 }

--- a/src-tauri/src/other/dispose.rs
+++ b/src-tauri/src/other/dispose.rs
@@ -1,0 +1,40 @@
+//! ブロッキングし得る資源破棄を呼び出し元スレッドから隔離するユーティリティ。
+
+/// `value` の drop を使い捨てスレッドで実行する。
+///
+/// FSEvents watcher の drop は run loop の停止待ちで長時間（最悪無期限に）ブロック
+/// し得るため、メインスレッドや async worker 上では実行しない（#1641）。
+/// スレッド生成に失敗した場合のみ、その場で drop する。
+pub fn dispose_in_background<T: Send + 'static>(thread_name: &str, value: T) {
+    let _ = std::thread::Builder::new()
+        .name(thread_name.to_string())
+        .spawn(move || drop(value));
+}
+
+#[cfg(test)]
+mod dispose_tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_dispose_はdropを別スレッドで実行する() {
+        struct Probe {
+            tx: std::sync::mpsc::Sender<std::thread::ThreadId>,
+        }
+
+        impl Drop for Probe {
+            fn drop(&mut self) {
+                let _ = self.tx.send(std::thread::current().id());
+            }
+        }
+
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        dispose_in_background("test-dispose", Probe { tx });
+
+        let drop_thread = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("drop が実行されること");
+        assert_ne!(drop_thread, std::thread::current().id());
+    }
+}

--- a/src-tauri/src/other/mod.rs
+++ b/src-tauri/src/other/mod.rs
@@ -1,3 +1,4 @@
+pub mod dispose;
 pub mod error;
 pub(crate) mod id;
 pub mod performance_switches;

--- a/src-tauri/src/usecase/repository_state/runtime.rs
+++ b/src-tauri/src/usecase/repository_state/runtime.rs
@@ -107,6 +107,40 @@ pub(crate) mod tests_support {
         }
     }
 
+    /// tokio ランタイム外（std スレッド）から `WorktreeState::new` を呼ぶテスト用。
+    /// worker を spawn しないため snapshot は更新されない。
+    pub(crate) struct NoSpawnRepositoryStateWorkerRuntime;
+
+    #[async_trait::async_trait]
+    impl RepositoryStateWorkerRuntime for NoSpawnRepositoryStateWorkerRuntime {
+        fn invalidation_channel(
+            &self,
+        ) -> (
+            Box<dyn RepositoryStateInvalidationSender>,
+            Box<dyn RepositoryStateInvalidationReceiver>,
+        ) {
+            let (tx, rx) = mpsc::unbounded_channel();
+            (
+                Box::new(TokioInvalidationSender(tx)),
+                Box::new(TokioInvalidationReceiver(rx)),
+            )
+        }
+
+        fn spawn_worker(&self, _future: RepositoryStateWorkerFuture) {}
+
+        async fn sleep(&self, _duration: Duration) {}
+
+        async fn scan(
+            &self,
+            _scanner: Arc<dyn RepositoryScanner>,
+            repo_path: String,
+        ) -> Result<RepositorySnapshotParts, RepositoryStateError> {
+            Err(RepositoryStateError::Watcher(format!(
+                "no-spawn runtime does not scan {repo_path}"
+            )))
+        }
+    }
+
     pub(crate) struct IdentityWorktreePathNormalizer;
 
     impl WorktreePathNormalizer for IdentityWorktreePathNormalizer {

--- a/src-tauri/src/usecase/repository_state/service.rs
+++ b/src-tauri/src/usecase/repository_state/service.rs
@@ -176,24 +176,31 @@ impl RepositoryStateService {
     }
 
     pub fn stop_watching(&self, watcher_id: u64) -> Result<bool, RepositoryStateError> {
-        let mut worktrees = self.worktrees.write();
-        let mut empty_key = None;
         let mut found = false;
+        let mut removed = None;
 
-        for (key, state) in worktrees.iter() {
-            if state.release_subscription(watcher_id) {
-                found = true;
-                if state.subscriber_count() == 0 {
-                    empty_key = Some(key.clone());
+        {
+            let mut worktrees = self.worktrees.write();
+            let mut empty_key = None;
+
+            for (key, state) in worktrees.iter() {
+                if state.release_subscription(watcher_id) {
+                    found = true;
+                    if state.subscriber_count() == 0 {
+                        empty_key = Some(key.clone());
+                    }
+                    break;
                 }
-                break;
+            }
+
+            if let Some(key) = empty_key {
+                removed = worktrees.remove(&key);
             }
         }
 
-        if let Some(key) = empty_key {
-            if let Some(state) = worktrees.remove(&key) {
-                state.shutdown();
-            }
+        // watcher の破棄はブロックし得るため worktrees ロックの外で行う（#1641）
+        if let Some(state) = removed {
+            state.shutdown();
         }
 
         Ok(found)
@@ -230,14 +237,9 @@ impl RepositoryStateService {
             return Ok(existing.clone());
         }
 
-        let mut worktrees = self.worktrees.write();
-        if let Some(existing) = worktrees.get(&key) {
-            if let Some((id, kind)) = subscription {
-                existing.add_subscription(id, kind, worktree_path.to_string());
-            }
-            return Ok(existing.clone());
-        }
-
+        // watcher の生成は watch ごとに FSEvents ストリームの破棄・再作成を伴い
+        // ブロックし得るため worktrees ロックの外で行う（#1641）。生成が競合した
+        // 場合は先に登録された state を採用し、負けた側の watcher は破棄する。
         let canonical_path = key.to_string_lossy().to_string();
         let state = WorktreeState::new(
             canonical_path,
@@ -246,12 +248,23 @@ impl RepositoryStateService {
             self.runtime.clone(),
             self.debounce,
         );
-        if let Some((id, kind)) = subscription {
-            state.add_subscription(id, kind, worktree_path.to_string());
-        }
         if let Err(err) = state.start_watchers(self.watcher.as_ref()) {
             state.shutdown();
             return Err(err);
+        }
+
+        let mut worktrees = self.worktrees.write();
+        if let Some(existing) = worktrees.get(&key) {
+            if let Some((id, kind)) = subscription {
+                existing.add_subscription(id, kind, worktree_path.to_string());
+            }
+            let existing = existing.clone();
+            drop(worktrees);
+            state.shutdown();
+            return Ok(existing);
+        }
+        if let Some((id, kind)) = subscription {
+            state.add_subscription(id, kind, worktree_path.to_string());
         }
         worktrees.insert(key, state.clone());
         Ok(state)
@@ -294,7 +307,7 @@ mod tests {
     use crate::usecase::repository_dto::{BranchCardDto, FileDiffStatDto, FileStatusDto};
     use crate::usecase::repository_state::runtime::tests_support::{
         CanonicalWorktreePathNormalizer, IdentityWorktreePathNormalizer,
-        TestRepositoryStateWorkerRuntime,
+        NoSpawnRepositoryStateWorkerRuntime, TestRepositoryStateWorkerRuntime,
     };
     use crate::usecase::repository_state::snapshot::RepositorySnapshotParts;
     use crate::usecase::repository_state::worker::InvalidateReason;
@@ -948,5 +961,228 @@ mod tests {
         let ignored = service.get_status("/repo", true).unwrap();
         assert_eq!(ignored[0].worktree_status, "ignored");
         assert_eq!(scanner.ignored_calls.load(Ordering::SeqCst), 1);
+    }
+
+    struct GateWatchSession {
+        drop_entered: Arc<std::sync::atomic::AtomicBool>,
+        release: Arc<std::sync::Barrier>,
+    }
+
+    impl Drop for GateWatchSession {
+        fn drop(&mut self) {
+            self.drop_entered.store(true, Ordering::SeqCst);
+            self.release.wait();
+        }
+    }
+
+    struct GateWatcher {
+        next_id: AtomicU64,
+        drop_entered: Arc<std::sync::atomic::AtomicBool>,
+        release: Arc<std::sync::Barrier>,
+    }
+
+    impl RepositoryStateWatcher for GateWatcher {
+        fn next_watcher_id(&self) -> u64 {
+            self.next_id.fetch_add(1, Ordering::SeqCst) + 1
+        }
+
+        fn start_watchers(
+            &self,
+            _state: Arc<WorktreeState>,
+        ) -> Result<
+            Box<dyn crate::usecase::repository_state::worktree::RepositoryStateWatchSession>,
+            RepositoryStateError,
+        > {
+            Ok(Box::new(GateWatchSession {
+                drop_entered: self.drop_entered.clone(),
+                release: self.release.clone(),
+            }))
+        }
+    }
+
+    struct BlockingStartWatcher {
+        next_id: AtomicU64,
+        start_entered: Arc<AtomicUsize>,
+        release: Arc<std::sync::Barrier>,
+    }
+
+    impl RepositoryStateWatcher for BlockingStartWatcher {
+        fn next_watcher_id(&self) -> u64 {
+            self.next_id.fetch_add(1, Ordering::SeqCst) + 1
+        }
+
+        fn start_watchers(
+            &self,
+            _state: Arc<WorktreeState>,
+        ) -> Result<
+            Box<dyn crate::usecase::repository_state::worktree::RepositoryStateWatchSession>,
+            RepositoryStateError,
+        > {
+            self.start_entered.fetch_add(1, Ordering::SeqCst);
+            self.release.wait();
+            Ok(Box::new(()))
+        }
+    }
+
+    fn no_spawn_service(watcher: Arc<dyn RepositoryStateWatcher>) -> Arc<RepositoryStateService> {
+        Arc::new(RepositoryStateService::new_with_scanner(
+            Arc::new(TestRepositoryStateRepository),
+            Arc::new(CountingScanner::default()),
+            Arc::new(NoopRepositoryStateNotifier),
+            watcher,
+            Arc::new(NoSpawnRepositoryStateWorkerRuntime),
+            Arc::new(IdentityWorktreePathNormalizer),
+            Duration::ZERO,
+        ))
+    }
+
+    #[test]
+    fn stop_watching_releases_worktrees_lock_before_watch_session_drop() {
+        let drop_entered = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let release = Arc::new(std::sync::Barrier::new(2));
+        let service = no_spawn_service(Arc::new(GateWatcher {
+            next_id: AtomicU64::new(0),
+            drop_entered: drop_entered.clone(),
+            release: release.clone(),
+        }));
+        let id = service
+            .subscribe("/repo", WatchSubscriptionKind::File)
+            .unwrap();
+
+        let stopper = {
+            let service = service.clone();
+            std::thread::spawn(move || service.stop_watching(id).unwrap())
+        };
+        while !drop_entered.load(Ordering::SeqCst) {
+            std::thread::yield_now();
+        }
+
+        let (probe_tx, probe_rx) = std::sync::mpsc::channel();
+        {
+            let service = service.clone();
+            std::thread::spawn(move || {
+                let _ = probe_tx.send(service.get_snapshot("/repo").is_ok());
+            });
+        }
+        let probe = probe_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("watch session の drop 中も worktrees ロックが解放されていること");
+
+        release.wait();
+        assert!(probe);
+        assert!(stopper.join().unwrap());
+        assert_eq!(service.worktree_count(), 0);
+    }
+
+    #[test]
+    fn subscribe_starts_watchers_outside_worktrees_lock() {
+        let start_entered = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(std::sync::Barrier::new(2));
+        let service = no_spawn_service(Arc::new(BlockingStartWatcher {
+            next_id: AtomicU64::new(0),
+            start_entered: start_entered.clone(),
+            release: release.clone(),
+        }));
+
+        let subscriber = {
+            let service = service.clone();
+            std::thread::spawn(move || {
+                service
+                    .subscribe("/blocked", WatchSubscriptionKind::File)
+                    .unwrap()
+            })
+        };
+        while start_entered.load(Ordering::SeqCst) == 0 {
+            std::thread::yield_now();
+        }
+
+        let (probe_tx, probe_rx) = std::sync::mpsc::channel();
+        {
+            let service = service.clone();
+            std::thread::spawn(move || {
+                let _ = probe_tx.send(service.get_snapshot("/other").is_ok());
+            });
+        }
+        let probe = probe_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("start_watchers 中も worktrees ロックが解放されていること");
+
+        release.wait();
+        assert!(probe);
+        subscriber.join().unwrap();
+        assert_eq!(service.worktree_count(), 1);
+    }
+
+    #[test]
+    fn concurrent_subscribe_for_same_worktree_converges_to_single_state() {
+        let start_entered = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(std::sync::Barrier::new(3));
+        let service = no_spawn_service(Arc::new(BlockingStartWatcher {
+            next_id: AtomicU64::new(0),
+            start_entered: start_entered.clone(),
+            release: release.clone(),
+        }));
+
+        let first = {
+            let service = service.clone();
+            std::thread::spawn(move || {
+                service
+                    .subscribe("/repo", WatchSubscriptionKind::File)
+                    .unwrap()
+            })
+        };
+        let second = {
+            let service = service.clone();
+            std::thread::spawn(move || {
+                service
+                    .subscribe("/repo", WatchSubscriptionKind::Git)
+                    .unwrap()
+            })
+        };
+        while start_entered.load(Ordering::SeqCst) < 2 {
+            std::thread::yield_now();
+        }
+        release.wait();
+
+        let first_id = first.join().unwrap();
+        let second_id = second.join().unwrap();
+
+        assert_eq!(service.worktree_count(), 1);
+        assert!(service.stop_watching(first_id).unwrap());
+        assert_eq!(service.worktree_count(), 1);
+        assert!(service.stop_watching(second_id).unwrap());
+        assert_eq!(service.worktree_count(), 0);
+    }
+
+    #[test]
+    fn subscribe_failure_does_not_register_worktree() {
+        struct FailingWatcher {
+            next_id: AtomicU64,
+        }
+
+        impl RepositoryStateWatcher for FailingWatcher {
+            fn next_watcher_id(&self) -> u64 {
+                self.next_id.fetch_add(1, Ordering::SeqCst) + 1
+            }
+
+            fn start_watchers(
+                &self,
+                _state: Arc<WorktreeState>,
+            ) -> Result<
+                Box<dyn crate::usecase::repository_state::worktree::RepositoryStateWatchSession>,
+                RepositoryStateError,
+            > {
+                Err(RepositoryStateError::Watcher("start failed".to_string()))
+            }
+        }
+
+        let service = no_spawn_service(Arc::new(FailingWatcher {
+            next_id: AtomicU64::new(0),
+        }));
+
+        assert!(service
+            .subscribe("/repo", WatchSubscriptionKind::File)
+            .is_err());
+        assert_eq!(service.worktree_count(), 0);
     }
 }


### PR DESCRIPTION
## 概要

Closes #1641

FSEvents ストリームの破棄（notify の run loop 停止待ちスピン + join）がメインスレッド上で `worktrees` write ロックを保持したまま直列実行され、UI が応答不能になる構造を解消する。対応方針は https://github.com/siro33950/releash/issues/1641#issuecomment-5299472639 のとおり。

## 変更内容

**1. 破棄をメインスレッドから外す**
- `start_watching` / `start_git_dir_watching` / `stop_watching` コマンドを async 化し、本体を `tauri::async_runtime::spawn_blocking` へ逃がす。IPC の引数・戻り値は不変（フロントエンド変更なし）。

**2. ロック保持中の生成・破棄をやめる**
- `RepositoryStateService::stop_watching`: write ロック内は map からの `remove` までとし、ロック解放後に `shutdown()` を実行。
- `ensure_watching_with_subscription`: `WorktreeState` 生成と `start_watchers`（watch ごとに FSEvents ストリーム破棄・再作成を伴う）をロック外へ移動。生成競合時は先に登録された state を採用し、負けた側の watcher は破棄（map 内の state は常に watcher 起動済み、の不変条件を維持）。
- `FileWatcherManager::stop_watching`: `sessions` ロック解放後に破棄。

**3. drop を使い捨てスレッドへ隔離**
- `other/dispose.rs` に `dispose_in_background` を新設。
- gateway の `RepositoryStateWatcherHandles` に `Drop` を実装し debouncer 破棄を `repository-watcher-dispose` スレッドへ、`FileWatcherManager` のセッション破棄を `file-watcher-dispose` スレッドへ隔離。最悪ケース（notify 側の無限スピン）でもリークはスレッド1本に閉じ、UI と他経路は停止しない。

## テスト

- drop ブロック中に `worktrees` ロックが解放されていることの回帰テスト（旧実装ではタイムアウトで fail する構造）
- `start_watchers` ブロック中のロック解放の検証
- 同一 worktree への並行 subscribe が単一 state に収束することの検証
- 生成失敗時に map へ登録されないことの検証
- `dispose_in_background` が別スレッドで drop することの検証
- `FileWatcherManager` の stop / 未知 id エラーの検証

## 品質チェック

- `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`（1974件 + 受け入れテスト）すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ファイル監視の開始・停止処理を非同期化し、アプリの応答性を改善しました。
  * 監視停止時の待機処理を最適化し、画面操作の遅延を軽減しました。
  * リポジトリ監視の同時実行時に重複登録や不完全な終了が発生する問題を修正しました。
  * 監視の開始に失敗した場合も、関連リソースが適切に解放されるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->