### PR TITLE
fix(shutdown): owned command非観測のquiesceを完了させreconciliation復旧を可能にする

### DIFF
--- a/src-tauri/src/adaptor/gateway/local_event_store/commit.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/commit.rs
@@ -28,13 +28,12 @@ use crate::domain::local_event::{
     validate_operation_record, CallerAttemptMutation, CommitBatchError, CommitBatchResult,
     CommitOperationKind, CommitResolution, CommittedBatch, CommittedStreamHead, IdempotencyBinding,
     LocalEventQueryError, LocalStateMutation, ObligationMutation, ObligationRecord,
-    ObligationStateRecord, OperationBindingMutation, OperationKind, OperationRecordMutation,
-    RecoveryActionMutation, RecoveryAttemptRecord, RecoveryResourceViewRecord,
-    RecoveryResultRecord, Revision, RevisionGuard, SafeOperationFailure,
-    SessionOperationFailureKind, SessionProjectionMutation, ShutdownDetailsCompactionMutation,
-    ShutdownLatestPointerMutation, ShutdownPlanMutation, ShutdownRecoverySnapshotMutation,
-    ShutdownTargetMutation, ShutdownTargetRecord, StreamId, StreamVersion,
-    WorkflowExecutionNodeProjectionMutation, WorkflowExecutionProjectionMutation,
+    OperationBindingMutation, OperationRecordMutation, RecoveryActionMutation,
+    RecoveryAttemptRecord, RecoveryResourceViewRecord, RecoveryResultRecord, Revision,
+    RevisionGuard, SafeOperationFailure, SessionOperationFailureKind, SessionProjectionMutation,
+    ShutdownDetailsCompactionMutation, ShutdownLatestPointerMutation, ShutdownPlanMutation,
+    ShutdownRecoverySnapshotMutation, ShutdownTargetMutation, ShutdownTargetRecord, StreamId,
+    StreamVersion, WorkflowExecutionNodeProjectionMutation, WorkflowExecutionProjectionMutation,
 };
 use crate::domain::workspace_tree::WorkspaceTree;
 
@@ -87,259 +86,6 @@ fn check_guard(existing: Option<i64>, guard: RevisionGuard) -> Result<(), Commit
         (Some(revision), _) => Err(conflict(revision)),
         (None, RevisionGuard::Expected(_)) => Err(conflict(0)),
     }
-}
-
-fn operation_progress_is_structurally_valid(mutations: &[LocalStateMutation]) -> bool {
-    let mut advances_existing_owner = false;
-    for mutation in mutations {
-        match mutation {
-            LocalStateMutation::OperationRecord(record) => {
-                if matches!(record.expected, RevisionGuard::Absent) {
-                    return false;
-                }
-                advances_existing_owner = true;
-            }
-            LocalStateMutation::Obligation(obligation) => {
-                if matches!(obligation.expected, RevisionGuard::Absent) {
-                    return false;
-                }
-                advances_existing_owner = true;
-            }
-            LocalStateMutation::RecoveryAction(action) => {
-                if matches!(action.expected, RevisionGuard::Absent) {
-                    return false;
-                }
-                advances_existing_owner = true;
-            }
-            LocalStateMutation::CallerAttempt(attempt) => {
-                if matches!(attempt.expected, RevisionGuard::Absent) {
-                    return false;
-                }
-                advances_existing_owner = true;
-            }
-            LocalStateMutation::SessionProjection(session) => {
-                if matches!(session.expected, RevisionGuard::Absent) {
-                    return false;
-                }
-            }
-            LocalStateMutation::WorkflowExecutionProjection(_)
-            | LocalStateMutation::WorkflowExecutionNodeProjection(_) => {}
-            LocalStateMutation::OperationBinding(_)
-            | LocalStateMutation::SessionProjectionRemoval(_)
-            | LocalStateMutation::AgentSessionRemoval(_)
-            | LocalStateMutation::ShutdownPlan(_)
-            | LocalStateMutation::ShutdownTarget(_)
-            | LocalStateMutation::ShutdownRecoverySnapshot(_)
-            | LocalStateMutation::ShutdownDetailsCompaction(_)
-            | LocalStateMutation::ShutdownLatestPointer(_) => return false,
-        }
-    }
-    advances_existing_owner
-}
-
-/// Workflow and projection commits may drain through an active shutdown only
-/// when the batch proves that it advances already-admitted work.  In
-/// particular, the internal lane label is not authority to mint a new caller
-/// operation, binding, obligation, or recovery action.
-fn internal_progress_is_anchored_to_existing_owner(prepared: &PreparedBatch) -> bool {
-    let mutations = &prepared.batch.state_mutations;
-    let mut advances_existing_owner = false;
-    for mutation in mutations {
-        match mutation {
-            LocalStateMutation::OperationBinding(_)
-            | LocalStateMutation::AgentSessionRemoval(_)
-            | LocalStateMutation::CallerAttempt(_)
-            | LocalStateMutation::ShutdownPlan(_)
-            | LocalStateMutation::ShutdownTarget(_)
-            | LocalStateMutation::ShutdownRecoverySnapshot(_)
-            | LocalStateMutation::ShutdownDetailsCompaction(_)
-            | LocalStateMutation::ShutdownLatestPointer(_) => return false,
-            LocalStateMutation::OperationRecord(operation) => {
-                if !guard_advances_existing(operation.expected, operation.revision) {
-                    return false;
-                }
-                advances_existing_owner = true;
-            }
-            LocalStateMutation::Obligation(obligation) => {
-                if !guard_advances_existing(obligation.expected, obligation.revision) {
-                    return false;
-                }
-                advances_existing_owner = true;
-            }
-            LocalStateMutation::RecoveryAction(action) => {
-                if !guard_advances_existing(action.expected, action.revision) {
-                    return false;
-                }
-                advances_existing_owner = true;
-            }
-            LocalStateMutation::SessionProjection(session) => {
-                if guard_advances_existing(session.expected, session.revision) {
-                    advances_existing_owner = true;
-                } else if !guard_inserts_revision_zero(session.expected, session.revision) {
-                    return false;
-                }
-            }
-            LocalStateMutation::SessionProjectionRemoval(removal) => {
-                if !matches!(removal.expected, RevisionGuard::Expected(_)) {
-                    return false;
-                }
-                advances_existing_owner = true;
-            }
-            LocalStateMutation::WorkflowExecutionProjection(workflow) => {
-                if !guard_advances_existing(workflow.expected, workflow.revision)
-                    && !guard_inserts_revision_zero(workflow.expected, workflow.revision)
-                {
-                    return false;
-                }
-            }
-            LocalStateMutation::WorkflowExecutionNodeProjection(nodes) => {
-                if !guard_advances_existing(nodes.expected, nodes.revision)
-                    && !guard_inserts_revision_zero(nodes.expected, nodes.revision)
-                {
-                    return false;
-                }
-            }
-        }
-    }
-    if !advances_existing_owner {
-        return false;
-    }
-    match prepared.batch.idempotency.operation_kind {
-        CommitOperationKind::Projection => false,
-        CommitOperationKind::Workflow => workflow_progress_has_one_execution_scope(prepared),
-        CommitOperationKind::ApplicationQuit
-        | CommitOperationKind::Recovery
-        | CommitOperationKind::UserMutation
-        | CommitOperationKind::OperationProgress => false,
-    }
-}
-
-fn guard_advances_existing(expected: RevisionGuard, revision: Revision) -> bool {
-    let RevisionGuard::Expected(current) = expected else {
-        return false;
-    };
-    current.next() == Some(revision)
-}
-
-fn guard_inserts_revision_zero(expected: RevisionGuard, revision: Revision) -> bool {
-    matches!(expected, RevisionGuard::Absent) && revision.value() == 0
-}
-
-fn workflow_progress_has_one_execution_scope(prepared: &PreparedBatch) -> bool {
-    let mut execution_id = None;
-    for mutation in &prepared.batch.state_mutations {
-        if let LocalStateMutation::Obligation(ObligationMutation {
-            record: ObligationRecord::WorkflowExecution { execution },
-            expected,
-            revision,
-            ..
-        }) = mutation
-        {
-            if !guard_advances_existing(*expected, *revision)
-                || execution_id
-                    .as_ref()
-                    .is_some_and(|stored| stored != &execution.execution_id)
-            {
-                return false;
-            }
-            execution_id = Some(execution.execution_id.clone());
-        }
-    }
-    let Some(execution_id) = execution_id else {
-        return false;
-    };
-    let expected_stream = match StreamId::workflow(&execution_id) {
-        Ok(stream) => stream,
-        Err(_) => return false,
-    };
-    if prepared
-        .batch
-        .expected_heads
-        .iter()
-        .any(|head| head.stream_id != expected_stream)
-        || prepared.batch.events.iter().any(|event| {
-            event.stream_id != expected_stream
-                || !matches!(
-                    &event.event,
-                    crate::domain::local_event::LocalDomainEvent::Workflow(workflow)
-                        if workflow.execution_id() == execution_id
-                )
-        })
-    {
-        return false;
-    }
-    prepared
-        .batch
-        .state_mutations
-        .iter()
-        .all(|mutation| match mutation {
-            LocalStateMutation::Obligation(ObligationMutation {
-                record: ObligationRecord::WorkflowExecution { execution },
-                ..
-            }) => execution.execution_id == execution_id,
-            LocalStateMutation::SessionProjection(projection) => match &projection.projection {
-                crate::domain::local_event::SessionProjectionRecord::WorkflowExecution(
-                    crate::domain::local_event::WorkflowExecutionProjectionRecord::Present(
-                        execution,
-                    ),
-                ) => {
-                    projection.session_id == format!("workflow:{execution_id}")
-                        && execution.execution_id == execution_id
-                }
-                crate::domain::local_event::SessionProjectionRecord::WorkflowExecution(
-                    crate::domain::local_event::WorkflowExecutionProjectionRecord::Deleted {
-                        execution_id: deleted,
-                    },
-                ) => {
-                    projection.session_id == format!("workflow:{execution_id}")
-                        && deleted == &execution_id
-                }
-                crate::domain::local_event::SessionProjectionRecord::WorkflowWorktreeOwner(
-                    owner,
-                ) => owner.execution_id == execution_id,
-                crate::domain::local_event::SessionProjectionRecord::AgentSession(_)
-                | crate::domain::local_event::SessionProjectionRecord::ProviderSessionOwnership(
-                    _,
-                )
-                | crate::domain::local_event::SessionProjectionRecord::ProviderHookHealth(_) => {
-                    false
-                }
-            },
-            LocalStateMutation::WorkflowExecutionProjection(projection) => {
-                prepared.batch.state_mutations.iter().any(|candidate| {
-                    matches!(
-                        candidate,
-                        LocalStateMutation::SessionProjection(source)
-                            if source.session_id == format!("workflow:{execution_id}")
-                                && source.expected == projection.expected
-                                && source.revision == projection.revision
-                    )
-                }) && match &projection.projection {
-                    crate::domain::local_event::WorkflowExecutionProjectionRecord::Present(
-                        execution,
-                    ) => execution.execution_id == execution_id,
-                    crate::domain::local_event::WorkflowExecutionProjectionRecord::Deleted {
-                        execution_id: deleted,
-                    } => deleted == &execution_id,
-                }
-            }
-            LocalStateMutation::WorkflowExecutionNodeProjection(nodes) => {
-                nodes.execution_id == execution_id
-                    && nodes
-                        .nodes
-                        .iter()
-                        .all(|node| node.execution_id.as_deref() == Some(execution_id.as_str()))
-                    && prepared.batch.state_mutations.iter().any(|candidate| {
-                        matches!(
-                            candidate,
-                            LocalStateMutation::WorkflowExecutionProjection(projection)
-                                if projection.expected == nodes.expected
-                                    && projection.revision == nodes.revision
-                        )
-                    })
-            }
-            _ => false,
-        })
 }
 
 fn recovery_result_targets_shutdown_target(
@@ -414,320 +160,91 @@ fn application_quit_progress_is_bound_to_current_plan(
     current_plan_summary: &str,
     prepared: &PreparedBatch,
 ) -> Result<bool, CommitBatchError> {
-    use crate::domain::local_event::{
-        ApplicationDomainEvent, OperationReceiptRecord, ShutdownPlanKey, ShutdownTargetKindRecord,
-        ShutdownTargetStateRecord,
-    };
+    use crate::domain::local_event::commit_admission::{self, QuitProgressFacts};
 
     let batch = &prepared.batch;
     let plan_summary =
         encoded_record(StoredShutdownPlanV1::decode(current_plan_summary))?.into_value();
-    let operation_id = plan_summary.operation_id.as_str();
-    if operation_id.is_empty() || batch.state_mutations.is_empty() {
-        return Ok(false);
-    }
 
-    // A caller joining the already accepted flight may add exactly one
-    // immutable binding to the current operation. It cannot smuggle any
-    // state or stream participant into that join commit.
-    if let [LocalStateMutation::OperationBinding(binding)] = batch.state_mutations.as_slice() {
-        return Ok(batch.expected_heads.is_empty()
-            && batch.events.is_empty()
-            && binding.key.kind == OperationKind::ApplicationQuit
-            && binding.key.installation_id == batch.idempotency.installation_id
-            && !binding.key.principal.is_empty()
-            && !binding.key.caller_request_id.is_empty()
-            && binding.operation_id == operation_id
-            && batch.idempotency.idempotency_key
-                == format!("{operation_id}.join.{}", binding.key.caller_request_id));
-    }
-
-    // The workflow executor's shutdown reservation is part of the fixed
-    // target effect. Its exact effect/session identity must already be in the
-    // current plan; an arbitrary obligation relabeled ApplicationQuit is not
-    // an admission capability.
+    // Facts for the single workflow-shutdown obligation batch: every target
+    // row of the current plan and the canonical obligation id derived from
+    // the batch obligation's effect identity.
+    let mut plan_targets: Vec<(ShutdownTargetRecord, i64)> = Vec::new();
+    let mut workflow_shutdown_obligation_id = None;
     if let [LocalStateMutation::Obligation(obligation)] = batch.state_mutations.as_slice() {
-        let ObligationRecord::WorkflowShutdown {
-            operation_id: stored_operation_id,
-            effect_identity,
-            owner_revision,
-            execution_id,
-            state,
+        if let ObligationRecord::WorkflowShutdown {
+            effect_identity, ..
         } = &obligation.record
-        else {
-            return Ok(false);
-        };
-        let mut target_matches = false;
-        let mut statement = connection
-            .prepare(
-                "SELECT detail, revision FROM shutdown_targets
-                 WHERE shutdown_id = ?1
-                 ORDER BY ordinal LIMIT 4097",
-            )
-            .map_err(|error| storage_unavailable(&error))?;
-        let rows = statement
-            .query_map(params![current_plan_id], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-            })
-            .map_err(|error| storage_unavailable(&error))?;
-        for row in rows {
-            let (raw, revision) = row.map_err(|error| storage_unavailable(&error))?;
-            let detail = encoded_record(StoredShutdownTargetV1::decode(&raw))?.into_value();
-            if matches!(
-                detail,
-                ShutdownTargetRecord::Target {
-                    target_id,
-                    kind: ShutdownTargetKindRecord::WorkflowExecution,
-                    state: ShutdownTargetStateRecord::EffectReserved,
-                    effect_identity: stored_effect,
-                    owner_operation_id: Some(owner),
-                    ..
-                } if target_id == *execution_id
-                    && stored_effect == *effect_identity
-                    && owner == operation_id
-                    && revision == *owner_revision
-            ) {
-                if target_matches {
-                    return Ok(false);
-                }
-                target_matches = true;
-            }
-        }
-        let digest = hex::encode(Sha256::digest(effect_identity.as_bytes()));
-        let expected_obligation_id = format!("workflow-shutdown-{}", &digest[..32]);
-        let guard_matches = match (obligation.expected, *state) {
-            (RevisionGuard::Absent, ObligationStateRecord::EffectReserved) => {
-                guard_inserts_revision_zero(obligation.expected, obligation.revision)
-                    && obligation.pending.as_ref().is_some_and(|pending| {
-                        pending.owner == *execution_id
-                            && pending.partition
-                                == crate::domain::local_event::PendingPartition::Owner
-                            && pending.shutdown_plan.is_none()
-                            && pending.ordered_key == format!("workflow-shutdown-{effect_identity}")
-                    })
-            }
-            (RevisionGuard::Expected(_), ObligationStateRecord::Completed) => {
-                guard_advances_existing(obligation.expected, obligation.revision)
-                    && obligation.pending.is_none()
-            }
-            _ => false,
-        };
-        return Ok(target_matches
-            && batch.expected_heads.is_empty()
-            && batch.events.is_empty()
-            && stored_operation_id == operation_id
-            && obligation.obligation_id == expected_obligation_id
-            && batch.idempotency.idempotency_key
-                == format!("{expected_obligation_id}.{}", obligation.revision.value())
-            && guard_matches);
-    }
-
-    let current_plan = ShutdownPlanKey {
-        shutdown_id: current_plan_id.to_string(),
-    };
-    let mut operation_revision = None;
-    let mut operation_status = None;
-    let mut plan_phase = None;
-    let mut target_transition = None;
-    let mut saw_plan = false;
-    let mut saw_pointer = false;
-    for mutation in &batch.state_mutations {
-        match mutation {
-            LocalStateMutation::OperationRecord(operation) => {
-                let OperationReceiptRecord::ApplicationQuit {
-                    operation_id: receipt_operation_id,
-                    plan,
-                    ..
-                } = &operation.receipt;
-                if operation_revision.replace(operation.revision).is_some()
-                    || operation.kind != OperationKind::ApplicationQuit
-                    || operation.operation_id != operation_id
-                    || receipt_operation_id != operation_id
-                    || plan != &current_plan
-                    || operation.latest_status.kind != OperationKind::ApplicationQuit
-                    || !guard_advances_existing(operation.expected, operation.revision)
-                {
-                    return Ok(false);
-                }
-                operation_status = Some(&operation.latest_status.value);
-            }
-            LocalStateMutation::ShutdownPlan(plan) => {
-                if saw_plan
-                    || plan.key != current_plan
-                    || plan.summary.operation_id != operation_id
-                    || !guard_advances_existing(plan.expected, plan.revision)
-                {
-                    return Ok(false);
-                }
-                saw_plan = true;
-                plan_phase = Some(plan.phase);
-            }
-            LocalStateMutation::ShutdownTarget(target) => {
-                if target_transition.replace(target).is_some()
-                    || target.key != current_plan
-                    || !guard_advances_existing(target.expected, target.revision)
-                {
-                    return Ok(false);
-                }
-                let existing: Option<(String, i64)> = connection
-                    .query_row(
-                        "SELECT detail, revision FROM shutdown_targets
-                         WHERE shutdown_id = ?1 AND ordinal = ?2",
-                        params![current_plan_id, target.ordinal],
-                        |row| Ok((row.get(0)?, row.get(1)?)),
-                    )
-                    .optional()
-                    .map_err(|error| storage_unavailable(&error))?;
-                let Some((raw, revision)) = existing else {
-                    return Ok(false);
-                };
-                let RevisionGuard::Expected(expected) = target.expected else {
-                    return Ok(false);
-                };
-                if expected.value() != revision {
-                    return Ok(false);
-                }
-                let existing = encoded_record(StoredShutdownTargetV1::decode(&raw))?.into_value();
-                let (
-                    ShutdownTargetRecord::Target {
-                        target_id: old_target_id,
-                        kind: old_kind,
-                        state: old_state,
-                        effect_identity: old_effect,
-                        owner_operation_id: old_owner,
-                        recovery_action: old_recovery,
-                        ..
-                    },
-                    ShutdownTargetRecord::Target {
-                        target_id,
-                        kind,
-                        state,
-                        effect_identity,
-                        owner_operation_id,
-                        failure,
-                        recovery_action,
-                    },
-                ) = (&existing, &target.detail)
-                else {
-                    return Ok(false);
-                };
-                let transition_matches = matches!(
-                    (*old_state, *state),
-                    (
-                        ShutdownTargetStateRecord::Prepared,
-                        ShutdownTargetStateRecord::EffectReserved
-                    ) | (
-                        ShutdownTargetStateRecord::EffectReserved,
-                        ShutdownTargetStateRecord::Completed
-                    ) | (
-                        ShutdownTargetStateRecord::EffectReserved,
-                        ShutdownTargetStateRecord::ReconciliationRequired
-                    )
-                );
-                if target_id != old_target_id
-                    || kind != old_kind
-                    || effect_identity != old_effect
-                    || old_owner
-                        .as_deref()
-                        .is_some_and(|owner| owner != operation_id)
-                    || owner_operation_id.as_deref() != Some(operation_id)
-                    || recovery_action != old_recovery
-                    || !transition_matches
-                    || (*state == ShutdownTargetStateRecord::ReconciliationRequired)
-                        != failure.is_some()
-                {
-                    return Ok(false);
-                }
-            }
-            LocalStateMutation::ShutdownLatestPointer(pointer) => {
-                if saw_pointer
-                    || pointer.expected.as_ref() != Some(&current_plan)
-                    || pointer.new.is_some()
-                {
-                    return Ok(false);
-                }
-                saw_pointer = true;
-            }
-            LocalStateMutation::OperationBinding(_)
-            | LocalStateMutation::CallerAttempt(_)
-            | LocalStateMutation::SessionProjection(_)
-            | LocalStateMutation::SessionProjectionRemoval(_)
-            | LocalStateMutation::AgentSessionRemoval(_)
-            | LocalStateMutation::Obligation(_)
-            | LocalStateMutation::RecoveryAction(_)
-            | LocalStateMutation::WorkflowExecutionProjection(_)
-            | LocalStateMutation::WorkflowExecutionNodeProjection(_)
-            | LocalStateMutation::ShutdownRecoverySnapshot(_)
-            | LocalStateMutation::ShutdownDetailsCompaction(_) => return Ok(false),
-        }
-    }
-
-    if let Some(target) = target_transition {
-        if batch.state_mutations.len() != 1
-            || !batch.expected_heads.is_empty()
-            || !batch.events.is_empty()
-            || batch.idempotency.idempotency_key
-                != format!(
-                    "{operation_id}.target.{}.{}",
-                    target.ordinal,
-                    target.revision.value()
-                )
         {
-            return Ok(false);
+            let mut statement = connection
+                .prepare(
+                    "SELECT detail, revision FROM shutdown_targets
+                     WHERE shutdown_id = ?1
+                     ORDER BY ordinal LIMIT 4097",
+                )
+                .map_err(|error| storage_unavailable(&error))?;
+            let rows = statement
+                .query_map(params![current_plan_id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                })
+                .map_err(|error| storage_unavailable(&error))?;
+            for row in rows {
+                let (raw, revision) = row.map_err(|error| storage_unavailable(&error))?;
+                let detail = encoded_record(StoredShutdownTargetV1::decode(&raw))?.into_value();
+                plan_targets.push((detail, revision));
+            }
+            let digest = hex::encode(Sha256::digest(effect_identity.as_bytes()));
+            workflow_shutdown_obligation_id = Some(format!("workflow-shutdown-{}", &digest[..32]));
         }
-        return Ok(true);
     }
-    let Some(operation_revision) = operation_revision else {
-        return Ok(false);
+
+    // Fact for the single shutdown-target transition batch: the stored row at
+    // the mutation's ordinal.
+    let target_ordinal = batch
+        .state_mutations
+        .iter()
+        .find_map(|mutation| match mutation {
+            LocalStateMutation::ShutdownTarget(target) => Some(target.ordinal),
+            _ => None,
+        });
+    let existing_target = match target_ordinal {
+        Some(ordinal) => fetch_shutdown_target_row(connection, current_plan_id, ordinal)?,
+        None => None,
     };
-    if !saw_plan
-        || batch.expected_heads.len() != 1
-        || batch.expected_heads[0].stream_id != StreamId::application()
-        || batch.events.len() != 1
-    {
-        return Ok(false);
-    }
-    let event = &batch.events[0];
-    let event_matches = event.stream_id == StreamId::application()
-        && matches!(
-            &event.event,
-            crate::domain::local_event::LocalDomainEvent::Application(
-                ApplicationDomainEvent::ShutdownPhaseAdvanced {
-                    shutdown_id,
-                    phase,
-                    ..
-                }
-            ) if shutdown_id == current_plan_id
-                && Some(*phase) == plan_phase
-        );
-    let activation = batch.idempotency.idempotency_key == format!("{operation_id}.activate")
-        && operation_status == Some(&crate::domain::local_event::OperationStatusValue::Activated)
-        && plan_phase == Some(crate::domain::local_event::ApplicationShutdownPhase::Activated)
-        && !saw_pointer
-        && batch.state_mutations.len() == 2;
-    let finish_identity = batch.idempotency.idempotency_key
-        == format!("{operation_id}.finish.{}", operation_revision.value());
-    let finish = finish_identity
-        && match (operation_status, plan_phase) {
-            (
-                Some(crate::domain::local_event::OperationStatusValue::Completed),
-                Some(crate::domain::local_event::ApplicationShutdownPhase::Completed),
-            ) => saw_pointer && batch.state_mutations.len() == 3,
-            (
-                Some(crate::domain::local_event::OperationStatusValue::FailedBeforeActivation {
-                    ..
-                }),
-                Some(crate::domain::local_event::ApplicationShutdownPhase::Failed),
-            )
-            | (
-                Some(crate::domain::local_event::OperationStatusValue::ReconciliationRequired {
-                    ..
-                }),
-                Some(crate::domain::local_event::ApplicationShutdownPhase::ReconciliationRequired),
-            ) => !saw_pointer && batch.state_mutations.len() == 2,
-            _ => false,
-        };
-    Ok(event_matches && (activation || finish))
+
+    Ok(
+        commit_admission::application_quit_progress_is_bound_to_current_plan(
+            batch,
+            &QuitProgressFacts {
+                plan_id: current_plan_id,
+                plan_summary: &plan_summary,
+                workflow_shutdown_obligation_id: workflow_shutdown_obligation_id.as_deref(),
+                plan_targets: &plan_targets,
+                existing_target: existing_target.as_ref(),
+            },
+        ),
+    )
+}
+
+fn fetch_shutdown_target_row(
+    connection: &Connection,
+    plan_id: &str,
+    ordinal: i64,
+) -> Result<Option<(ShutdownTargetRecord, i64)>, CommitBatchError> {
+    let existing: Option<(String, i64)> = connection
+        .query_row(
+            "SELECT detail, revision FROM shutdown_targets
+             WHERE shutdown_id = ?1 AND ordinal = ?2",
+            params![plan_id, ordinal],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .map_err(|error| storage_unavailable(&error))?;
+    let Some((raw, revision)) = existing else {
+        return Ok(None);
+    };
+    let detail = encoded_record(StoredShutdownTargetV1::decode(&raw))?.into_value();
+    Ok(Some((detail, revision)))
 }
 
 fn shutdown_target_recovery_is_bound_to_current_plan(
@@ -736,174 +253,48 @@ fn shutdown_target_recovery_is_bound_to_current_plan(
     current_plan_summary: &str,
     mutations: &[LocalStateMutation],
 ) -> Result<bool, CommitBatchError> {
+    use crate::domain::local_event::commit_admission::{
+        self, ExistingRecoveryAction, ShutdownRecoveryFacts,
+    };
+
     let plan_summary =
         encoded_record(StoredShutdownPlanV1::decode(current_plan_summary))?.into_value();
-    let mut recovery_action = None;
-    let mut shutdown_target = None;
-    let mut closure_operation = None;
-    let mut closure_plan = None;
-    let mut closure_pointer = None;
-    for mutation in mutations {
-        match mutation {
-            LocalStateMutation::RecoveryAction(action) => {
-                if recovery_action.replace(action).is_some() {
-                    return Ok(false);
-                }
-            }
-            LocalStateMutation::ShutdownTarget(target) => {
-                if shutdown_target.replace(target).is_some() {
-                    return Ok(false);
-                }
-            }
-            LocalStateMutation::OperationRecord(operation)
-                if operation.kind == OperationKind::ApplicationQuit =>
-            {
-                if closure_operation.replace(operation).is_some() {
-                    return Ok(false);
-                }
-            }
-            LocalStateMutation::ShutdownPlan(plan) => {
-                if closure_plan.replace(plan).is_some() {
-                    return Ok(false);
-                }
-            }
-            LocalStateMutation::ShutdownLatestPointer(pointer) => {
-                if closure_pointer.replace(pointer).is_some() {
-                    return Ok(false);
-                }
-            }
-            _ => return Ok(false),
-        }
-    }
-    let (Some(action), Some(target)) = (recovery_action, shutdown_target) else {
-        return Ok(false);
-    };
-    let has_plan_closure = match (closure_operation, closure_plan, closure_pointer) {
-        (None, None, None) => false,
-        (Some(operation), Some(plan), Some(pointer))
-            if operation.operation_id == plan_summary.operation_id
-                && matches!(operation.expected, RevisionGuard::Expected(_))
-                && plan.key.shutdown_id == current_plan_id
-                && plan.phase
-                    == crate::domain::local_event::ApplicationShutdownPhase::Completed
-                && plan.summary.operation_id == plan_summary.operation_id
-                && plan.summary.intent == plan_summary.intent
-                && matches!(plan.expected, RevisionGuard::Expected(_))
-                && pointer
-                    .expected
-                    .as_ref()
-                    .is_some_and(|key| key.shutdown_id == current_plan_id)
-                && pointer.new.is_none() =>
-        {
-            true
-        }
-        _ => return Ok(false),
-    };
-    if target.key.shutdown_id != current_plan_id || target.ordinal < 0 {
-        return Ok(false);
-    }
-    let RevisionGuard::Expected(expected_target_revision) = target.expected else {
-        // Shutdown recovery may only mutate a member of the plan's fixed
-        // target set. In particular, Recovery is never an insert path.
-        return Ok(false);
-    };
-    let existing_target: Option<(String, i64)> = connection
-        .query_row(
-            "SELECT detail, revision FROM shutdown_targets
-             WHERE shutdown_id = ?1 AND ordinal = ?2",
-            params![current_plan_id, target.ordinal],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        )
-        .optional()
-        .map_err(|error| storage_unavailable(&error))?;
-    let Some((existing_target, existing_target_revision)) = existing_target else {
-        return Ok(false);
-    };
-    if expected_target_revision.value() != existing_target_revision
-        || target.revision.value()
-            != match existing_target_revision.checked_add(1) {
-                Some(next) => next,
-                None => return Ok(false),
-            }
-    {
-        return Ok(false);
-    }
-    let existing_target =
-        encoded_record(StoredShutdownTargetV1::decode(&existing_target))?.into_value();
-    let (
-        ShutdownTargetRecord::Target {
-            target_id: existing_target_id,
-            kind: existing_kind,
-            state: existing_state,
-            effect_identity: existing_effect_identity,
-            owner_operation_id: existing_owner_operation_id,
-            failure: existing_failure,
-            recovery_action: existing_target_recovery,
-        },
-        ShutdownTargetRecord::Target {
-            target_id,
-            kind,
-            state,
-            effect_identity,
-            owner_operation_id,
-            failure,
-            recovery_action: Some(target_recovery),
-        },
-    ) = (&existing_target, &target.detail)
-    else {
-        return Ok(false);
-    };
-    if target_id != existing_target_id
-        || kind != existing_kind
-        || effect_identity != existing_effect_identity
-        || owner_operation_id != existing_owner_operation_id
-    {
-        // A recovery transition may change target state/failure, but never
-        // the executor-owned identity at the admitted ordinal.
-        return Ok(false);
-    }
+    let action = mutations.iter().find_map(|mutation| match mutation {
+        LocalStateMutation::RecoveryAction(action) => Some(action),
+        _ => None,
+    });
+    let target = mutations.iter().find_map(|mutation| match mutation {
+        LocalStateMutation::ShutdownTarget(target) => Some(target),
+        _ => None,
+    });
 
-    let RecoveryAttemptRecord::ShutdownTarget {
-        resource_ref,
-        plan,
-        ordinal,
-        target_key,
-        origin_revision,
-        action: attempted_action,
-        effect_identity_sha256,
-        intent,
-        state: attempt_state,
-        failure: attempt_failure,
-    } = &action.attempt;
-    let expected_resource_ref = format!(
-        "shutdown-target:{current_plan_id}:{}:{target_key}",
-        target.ordinal
-    );
-    if plan.shutdown_id != current_plan_id
-        || *ordinal != target.ordinal
-        || target_key != &shutdown_target_key(*existing_kind, existing_target_id)
-        || resource_ref != &expected_resource_ref
-        || target_recovery.action_id != action.action_id
-        || target_recovery.origin_revision != *origin_revision
-        || target_recovery.action != *attempted_action
-        || target_recovery.state != *attempt_state
-        || *effect_identity_sha256
-            != <[u8; 32]>::from(Sha256::digest(existing_effect_identity.as_bytes()))
-        || *intent != plan_summary.intent
-        || attempt_failure.is_some()
-    {
-        return Ok(false);
-    }
+    // Facts derived from the stored row at the batch target's ordinal: the
+    // decoded row plus the identity-authority values (canonical target key,
+    // effect-identity digest) the domain rule compares against.
+    let existing_target = match target {
+        Some(target) => fetch_shutdown_target_row(connection, current_plan_id, target.ordinal)?,
+        None => None,
+    };
+    let (existing_target_key, existing_effect_identity_sha256) = match existing_target.as_ref() {
+        Some((
+            ShutdownTargetRecord::Target {
+                target_id,
+                kind,
+                effect_identity,
+                ..
+            },
+            _,
+        )) => (
+            Some(shutdown_target_key(*kind, target_id)),
+            Some(<[u8; 32]>::from(Sha256::digest(effect_identity.as_bytes()))),
+        ),
+        _ => (None, None),
+    };
 
-    match action.expected {
-        RevisionGuard::Absent => Ok(action.revision.value() == 0
-            && action.completed.is_none()
-            && *origin_revision == existing_target_revision as u64
-            && *attempt_state == ObligationStateRecord::EffectReserved
-            && *state == *existing_state
-            && *failure == *existing_failure),
-        RevisionGuard::Expected(expected_action_revision) => {
-            let existing_action: Option<(String, Option<String>, i64)> = connection
+    // Fact for the finish path: the stored recovery action row.
+    let existing_action_row: Option<(RecoveryAttemptRecord, bool, i64)> = match action {
+        Some(action) if matches!(action.expected, RevisionGuard::Expected(_)) => {
+            let row: Option<(String, Option<String>, i64)> = connection
                 .query_row(
                     "SELECT attempt, completed, revision FROM recovery_action_attempts
                      WHERE action_id = ?1",
@@ -912,72 +303,60 @@ fn shutdown_target_recovery_is_bound_to_current_plan(
                 )
                 .optional()
                 .map_err(|error| storage_unavailable(&error))?;
-            let Some((existing_attempt, existing_completed, existing_action_revision)) =
-                existing_action
-            else {
-                return Ok(false);
-            };
-            if expected_action_revision.value() != existing_action_revision
-                || action.revision.value()
-                    != match existing_action_revision.checked_add(1) {
-                        Some(next) => next,
-                        None => return Ok(false),
-                    }
-                || existing_completed.is_some()
-            {
-                return Ok(false);
+            match row {
+                Some((raw_attempt, completed, revision)) => {
+                    let attempt =
+                        encoded_record(StoredRecoveryActionV1::decode(&raw_attempt))?.into_value();
+                    Some((attempt, completed.is_some(), revision))
+                }
+                None => None,
             }
-            let existing_attempt =
-                encoded_record(StoredRecoveryActionV1::decode(&existing_attempt))?.into_value();
-            let RecoveryAttemptRecord::ShutdownTarget {
-                resource_ref: existing_resource_ref,
-                plan: existing_plan,
-                ordinal: existing_ordinal,
-                target_key: existing_target_key,
-                origin_revision: existing_origin_revision,
-                action: existing_action_kind,
-                effect_identity_sha256: existing_effect_identity_sha256,
-                intent: existing_intent,
-                state: existing_attempt_state,
-                failure: existing_attempt_failure,
-            } = existing_attempt;
-            let Some(existing_target_recovery) = existing_target_recovery else {
-                return Ok(false);
-            };
-            if existing_resource_ref != *resource_ref
-                || existing_plan != *plan
-                || existing_ordinal != *ordinal
-                || existing_target_key != *target_key
-                || existing_origin_revision != *origin_revision
-                || existing_action_kind != *attempted_action
-                || existing_effect_identity_sha256 != *effect_identity_sha256
-                || existing_intent != *intent
-                || existing_attempt_state != ObligationStateRecord::EffectReserved
-                || existing_attempt_failure.is_some()
-                || existing_target_recovery.action_id != action.action_id
-                || existing_target_recovery.origin_revision != *origin_revision
-                || existing_target_recovery.action != *attempted_action
-                || existing_target_recovery.state != ObligationStateRecord::EffectReserved
-                || *attempt_state != ObligationStateRecord::Completed
-                || target_recovery.state != ObligationStateRecord::Completed
-            {
-                return Ok(false);
-            }
-            let Some(RecoveryResultRecord::Action(completed)) = action.completed.as_ref() else {
-                return Ok(false);
-            };
-            Ok((!has_plan_closure
-                || *state == crate::domain::local_event::ShutdownTargetStateRecord::Completed)
-                && completed.resource_revision == target.revision.value() as u64
-                && recovery_result_targets_shutdown_target(
+        }
+        _ => None,
+    };
+
+    // Fact for the finish path: the batch's completed recovery result must
+    // reference this exact target in its canonical result payload.
+    let completed_result_targets_target = match (action, target) {
+        (Some(action), Some(target)) => {
+            let RecoveryAttemptRecord::ShutdownTarget { target_key, .. } = &action.attempt;
+            match (&target.detail, action.completed.as_ref()) {
+                (
+                    ShutdownTargetRecord::Target { state, .. },
+                    Some(RecoveryResultRecord::Action(completed)),
+                ) => recovery_result_targets_shutdown_target(
                     &completed.resource_view,
                     current_plan_id,
                     target.ordinal,
                     target_key,
                     *state,
-                ))
+                ),
+                _ => false,
+            }
         }
-    }
+        _ => false,
+    };
+
+    Ok(
+        commit_admission::shutdown_target_recovery_is_bound_to_current_plan(
+            mutations,
+            &ShutdownRecoveryFacts {
+                plan_id: current_plan_id,
+                plan_summary: &plan_summary,
+                existing_target: existing_target.as_ref(),
+                existing_target_key: existing_target_key.as_deref(),
+                existing_effect_identity_sha256,
+                existing_action: existing_action_row.as_ref().map(
+                    |(attempt, has_completed_result, revision)| ExistingRecoveryAction {
+                        attempt,
+                        has_completed_result: *has_completed_result,
+                        revision: *revision,
+                    },
+                ),
+                completed_result_targets_target,
+            },
+        ),
+    )
 }
 
 fn encode_stream_heads(heads: &[CommittedStreamHead]) -> String {
@@ -1304,8 +683,13 @@ fn execute_in_transaction(
         current_shutdown_summary.as_deref(),
     ) {
         (None, None, None) => false,
-        (Some(_), Some("failed" | "cancelled" | "completed"), Some(_)) => false,
-        (Some(_), Some(_), Some(_)) => true,
+        // An undecodable stored phase keeps admission closed (fail closed).
+        (Some(_), Some(raw_phase), Some(_)) => {
+            !crate::adaptor::gateway::local_event_store::envelope::label_to_shutdown_phase(
+                raw_phase,
+            )
+            .is_some_and(crate::domain::local_event::ApplicationShutdownPhase::is_terminal)
+        }
         _ => return Err(corrupt("current shutdown pointer has no exact plan phase")),
     };
     let shutdown_target_recovery = if shutdown_admission_closed
@@ -1326,13 +710,17 @@ fn execute_in_transaction(
     };
     let operation_progress = batch.idempotency.operation_kind
         == CommitOperationKind::OperationProgress
-        && operation_progress_is_structurally_valid(&batch.state_mutations);
+        && crate::domain::local_event::commit_admission::operation_progress_is_structurally_valid(
+            &batch.state_mutations,
+        );
     let internal_progress = shutdown_admission_closed
         && matches!(
             batch.idempotency.operation_kind,
             CommitOperationKind::Workflow | CommitOperationKind::Projection
         )
-        && internal_progress_is_anchored_to_existing_owner(prepared);
+        && crate::domain::local_event::commit_admission::internal_progress_is_anchored_to_existing_owner(
+            batch,
+        );
     let application_quit_progress = if shutdown_admission_closed
         && batch.idempotency.operation_kind == CommitOperationKind::ApplicationQuit
     {
@@ -1367,16 +755,12 @@ fn execute_in_transaction(
         ));
     }
     if shutdown_admission_closed
-        && (matches!(
+        && crate::domain::local_event::commit_admission::closed_admission_rejects(
             batch.idempotency.operation_kind,
-            CommitOperationKind::UserMutation
-                | CommitOperationKind::Recovery
-                | CommitOperationKind::Workflow
-                | CommitOperationKind::Projection
-                | CommitOperationKind::ApplicationQuit
-        ) && !shutdown_target_recovery
-            && !internal_progress
-            && !application_quit_progress)
+            shutdown_target_recovery,
+            internal_progress,
+            application_quit_progress,
+        )
     {
         return Err(CommitBatchError::StorageUnavailable {
             failure: SafeOperationFailure::new(
@@ -1833,7 +1217,7 @@ fn validate_one_guard(
 }
 
 fn valid_projection_revision(expected: RevisionGuard, revision: Revision) -> bool {
-    guard_inserts_revision_zero(expected, revision) || guard_advances_existing(expected, revision)
+    expected.inserts_zero(revision) || expected.advances_to(revision)
 }
 
 fn validate_workflow_execution_projection(

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_command_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_command_gateway.rs
@@ -87,40 +87,6 @@ impl<R: tauri::Runtime> TauriWorkflowRuntimeCommandGateway<R> {
         }
     }
 
-    fn shutdown_record_for_readback(
-        lookup: Result<Option<crate::domain::local_event::ObligationView>, ()>,
-    ) -> Result<crate::domain::local_event::ObligationView, WorkflowShutdownEffectReadback> {
-        match lookup {
-            Ok(Some(record)) => Ok(record),
-            Ok(None) => Err(WorkflowShutdownEffectReadback::ConfirmedNotStarted),
-            Err(()) => Err(WorkflowShutdownEffectReadback::Ambiguous),
-        }
-    }
-
-    fn workflow_shutdown_record_matches(
-        record: &crate::domain::local_event::ObligationView,
-        operation_id: &str,
-        effect_identity: &str,
-        owner_revision: i64,
-        execution_id: &str,
-    ) -> Option<crate::domain::local_event::ObligationStateRecord> {
-        let crate::domain::local_event::ObligationRecord::WorkflowShutdown {
-            operation_id: stored_operation_id,
-            effect_identity: stored_effect_identity,
-            owner_revision: stored_owner_revision,
-            execution_id: stored_execution_id,
-            state,
-        } = &record.record
-        else {
-            return None;
-        };
-        (stored_operation_id == operation_id
-            && stored_effect_identity == effect_identity
-            && *stored_owner_revision == owner_revision
-            && stored_execution_id == execution_id)
-            .then_some(*state)
-    }
-
     async fn commit_workflow_shutdown_record(&self, record: WorkflowShutdownRecord<'_>) -> bool {
         use sha2::Digest;
         let WorkflowShutdownRecord {
@@ -504,54 +470,57 @@ impl<R: tauri::Runtime> WorkflowRuntimeShutdownGateway for TauriWorkflowRuntimeC
         owner_revision: i64,
         execution_id: &str,
     ) -> WorkflowShutdownEffectReadback {
-        match self.shutdown_effect_record(effect_identity).await {
-            Ok(Some(record)) => {
-                return match Self::workflow_shutdown_record_matches(
-                    &record,
-                    operation_id,
-                    effect_identity,
-                    owner_revision,
-                    execution_id,
-                ) {
-                    Some(crate::domain::local_event::ObligationStateRecord::Completed) => {
-                        WorkflowShutdownEffectReadback::Completed
-                    }
-                    Some(crate::domain::local_event::ObligationStateRecord::EffectReserved) => {
-                        WorkflowShutdownEffectReadback::Ambiguous
-                    }
-                    _ => WorkflowShutdownEffectReadback::Ambiguous,
-                };
-            }
-            Ok(None) => {}
-            Err(()) => return WorkflowShutdownEffectReadback::Ambiguous,
-        }
-        let zero = crate::domain::local_event::Revision::new(0).expect("zero revision");
-        if !self
-            .commit_workflow_shutdown_record(WorkflowShutdownRecord {
-                operation_id,
-                effect_identity,
-                owner_revision,
-                execution_id,
-                state: crate::domain::local_event::ObligationStateRecord::EffectReserved,
-                expected: crate::domain::local_event::RevisionGuard::Absent,
-                revision: zero,
-            })
-            .await
-        {
+        use crate::domain::local_event::workflow_shutdown::{
+            self, WorkflowShutdownReservationStep,
+        };
+        let Ok(record) = self.shutdown_effect_record(effect_identity).await else {
             return WorkflowShutdownEffectReadback::Ambiguous;
-        }
-        let observed_owned_command = self
-            .driver
+        };
+        let reservation = match workflow_shutdown::reservation_step(
+            record.as_ref(),
+            operation_id,
+            effect_identity,
+            execution_id,
+            owner_revision,
+        ) {
+            WorkflowShutdownReservationStep::AlreadyCompleted => {
+                return WorkflowShutdownEffectReadback::Completed
+            }
+            WorkflowShutdownReservationStep::ContinueOwn { reservation } => reservation,
+            WorkflowShutdownReservationStep::Reserve {
+                expected,
+                reservation,
+            } => {
+                if !self
+                    .commit_workflow_shutdown_record(WorkflowShutdownRecord {
+                        operation_id,
+                        effect_identity,
+                        owner_revision,
+                        execution_id,
+                        state: crate::domain::local_event::ObligationStateRecord::EffectReserved,
+                        expected,
+                        revision: reservation,
+                    })
+                    .await
+                {
+                    return WorkflowShutdownEffectReadback::Ambiguous;
+                }
+                reservation
+            }
+            WorkflowShutdownReservationStep::Reject => {
+                return WorkflowShutdownEffectReadback::Ambiguous
+            }
+        };
+        // An execution with no owned command has nothing left to quiesce in
+        // this process, so the effect is satisfied whether or not a command
+        // was observed. Commands a dead process left behind are crash
+        // recovery's responsibility, not this effect's.
+        self.driver
             .shutdown_active_commands_for_execution(execution_id)
             .await;
-        if !observed_owned_command {
-            // The durable reservation proves the effect may have started, but
-            // absence of an owned command cannot prove this effect completed;
-            // an unrelated terminal transition must not be adopted as its
-            // result.
+        let Some(completed) = reservation.next() else {
             return WorkflowShutdownEffectReadback::Ambiguous;
-        }
-        let one = crate::domain::local_event::Revision::new(1).expect("one revision");
+        };
         if self
             .commit_workflow_shutdown_record(WorkflowShutdownRecord {
                 operation_id,
@@ -559,8 +528,8 @@ impl<R: tauri::Runtime> WorkflowRuntimeShutdownGateway for TauriWorkflowRuntimeC
                 owner_revision,
                 execution_id,
                 state: crate::domain::local_event::ObligationStateRecord::Completed,
-                expected: crate::domain::local_event::RevisionGuard::Expected(zero),
-                revision: one,
+                expected: crate::domain::local_event::RevisionGuard::Expected(reservation),
+                revision: completed,
             })
             .await
         {
@@ -574,99 +543,31 @@ impl<R: tauri::Runtime> WorkflowRuntimeShutdownGateway for TauriWorkflowRuntimeC
         &self,
         operation_id: &str,
         effect_identity: &str,
-        owner_revision: i64,
+        _owner_revision: i64,
         execution_id: &str,
     ) -> WorkflowShutdownEffectReadback {
-        let record = match Self::shutdown_record_for_readback(
-            self.shutdown_effect_record(effect_identity).await,
-        ) {
-            Ok(record) => record,
-            Err(readback) => return readback,
+        use crate::domain::local_event::workflow_shutdown::{
+            self, WorkflowShutdownEffectResolution,
         };
-        match Self::workflow_shutdown_record_matches(
-            &record,
+        let Ok(record) = self.shutdown_effect_record(effect_identity).await else {
+            return WorkflowShutdownEffectReadback::Ambiguous;
+        };
+        match workflow_shutdown::read_resolution(
+            record.as_ref(),
             operation_id,
             effect_identity,
-            owner_revision,
             execution_id,
         ) {
-            Some(crate::domain::local_event::ObligationStateRecord::Completed) => {
+            WorkflowShutdownEffectResolution::Completed => {
                 WorkflowShutdownEffectReadback::Completed
             }
-            Some(crate::domain::local_event::ObligationStateRecord::EffectReserved) => {
+            WorkflowShutdownEffectResolution::NotStarted => {
+                WorkflowShutdownEffectReadback::ConfirmedNotStarted
+            }
+            WorkflowShutdownEffectResolution::Unresolved => {
                 WorkflowShutdownEffectReadback::Ambiguous
             }
-            _ => WorkflowShutdownEffectReadback::Ambiguous,
         }
-    }
-}
-
-#[cfg(test)]
-mod shutdown_effect_contract_tests {
-    use super::TauriWorkflowRuntimeCommandGateway;
-
-    #[test]
-    fn workflow_shutdown_read_failure_is_ambiguous_not_confirmed_not_started() {
-        use crate::usecase::workflow::ports::WorkflowShutdownEffectReadback;
-
-        assert_eq!(
-            TauriWorkflowRuntimeCommandGateway::<tauri::Wry>::shutdown_record_for_readback(Err(())),
-            Err(WorkflowShutdownEffectReadback::Ambiguous)
-        );
-        assert_eq!(
-            TauriWorkflowRuntimeCommandGateway::<tauri::Wry>::shutdown_record_for_readback(Ok(
-                None
-            )),
-            Err(WorkflowShutdownEffectReadback::ConfirmedNotStarted)
-        );
-    }
-
-    #[test]
-    fn workflow_shutdown_readback_is_bound_to_exact_effect_and_owner_revision() {
-        let record_value = crate::domain::local_event::ObligationRecord::WorkflowShutdown {
-            operation_id: "quit-operation".to_string(),
-            effect_identity: "quit-operation:0:workflow-1".to_string(),
-            owner_revision: 7,
-            execution_id: "workflow-1".to_string(),
-            state: crate::domain::local_event::ObligationStateRecord::Completed,
-        };
-        let record = crate::domain::local_event::ObligationView {
-            obligation_id: "workflow-shutdown-record".to_string(),
-            record: record_value,
-            record_sha256: [0; 32],
-            pending: None,
-            revision: crate::domain::local_event::Revision::new(1).unwrap(),
-        };
-        assert_eq!(
-            TauriWorkflowRuntimeCommandGateway::<tauri::Wry>::workflow_shutdown_record_matches(
-                &record,
-                "quit-operation",
-                "quit-operation:0:workflow-1",
-                7,
-                "workflow-1",
-            ),
-            Some(crate::domain::local_event::ObligationStateRecord::Completed)
-        );
-        assert!(
-            TauriWorkflowRuntimeCommandGateway::<tauri::Wry>::workflow_shutdown_record_matches(
-                &record,
-                "unrelated-terminal-operation",
-                "quit-operation:0:workflow-1",
-                7,
-                "workflow-1",
-            )
-            .is_none()
-        );
-        assert!(
-            TauriWorkflowRuntimeCommandGateway::<tauri::Wry>::workflow_shutdown_record_matches(
-                &record,
-                "quit-operation",
-                "quit-operation:0:workflow-1",
-                8,
-                "workflow-1",
-            )
-            .is_none()
-        );
     }
 }
 

--- a/src-tauri/src/domain/local_event/commit_admission.rs
+++ b/src-tauri/src/domain/local_event/commit_admission.rs
@@ -1,0 +1,789 @@
+//! Rules deciding which commits the store still admits while an application
+//! shutdown plan owns admission.
+//!
+//! The store fetches and decodes the durable rows a rule needs and passes
+//! them in as facts; every judgment on those facts lives here.
+
+use super::{
+    workflow_shutdown, ApplicationDomainEvent, ApplicationShutdownPhase, CommitOperationKind,
+    LocalAtomicBatch, LocalDomainEvent, LocalStateMutation, ObligationMutation, ObligationRecord,
+    ObligationStateRecord, OperationKind, OperationReceiptRecord, OperationStatusValue,
+    RecoveryAttemptRecord, RecoveryResultRecord, RevisionGuard, SessionProjectionRecord,
+    ShutdownPlanKey, ShutdownPlanRecord, ShutdownTargetRecord, ShutdownTargetStateRecord, StreamId,
+    WorkflowExecutionProjectionRecord,
+};
+
+/// Which commit lanes a closed shutdown admission rejects outright. The
+/// exempt lanes must each have proven their binding to the current plan.
+pub fn closed_admission_rejects(
+    kind: CommitOperationKind,
+    shutdown_target_recovery: bool,
+    internal_progress: bool,
+    application_quit_progress: bool,
+) -> bool {
+    matches!(
+        kind,
+        CommitOperationKind::UserMutation
+            | CommitOperationKind::Recovery
+            | CommitOperationKind::Workflow
+            | CommitOperationKind::Projection
+            | CommitOperationKind::ApplicationQuit
+    ) && !shutdown_target_recovery
+        && !internal_progress
+        && !application_quit_progress
+}
+
+pub fn operation_progress_is_structurally_valid(mutations: &[LocalStateMutation]) -> bool {
+    let mut advances_existing_owner = false;
+    for mutation in mutations {
+        match mutation {
+            LocalStateMutation::OperationRecord(record) => {
+                if matches!(record.expected, RevisionGuard::Absent) {
+                    return false;
+                }
+                advances_existing_owner = true;
+            }
+            LocalStateMutation::Obligation(obligation) => {
+                if matches!(obligation.expected, RevisionGuard::Absent) {
+                    return false;
+                }
+                advances_existing_owner = true;
+            }
+            LocalStateMutation::RecoveryAction(action) => {
+                if matches!(action.expected, RevisionGuard::Absent) {
+                    return false;
+                }
+                advances_existing_owner = true;
+            }
+            LocalStateMutation::CallerAttempt(attempt) => {
+                if matches!(attempt.expected, RevisionGuard::Absent) {
+                    return false;
+                }
+                advances_existing_owner = true;
+            }
+            LocalStateMutation::SessionProjection(session) => {
+                if matches!(session.expected, RevisionGuard::Absent) {
+                    return false;
+                }
+            }
+            LocalStateMutation::WorkflowExecutionProjection(_)
+            | LocalStateMutation::WorkflowExecutionNodeProjection(_) => {}
+            LocalStateMutation::OperationBinding(_)
+            | LocalStateMutation::SessionProjectionRemoval(_)
+            | LocalStateMutation::AgentSessionRemoval(_)
+            | LocalStateMutation::ShutdownPlan(_)
+            | LocalStateMutation::ShutdownTarget(_)
+            | LocalStateMutation::ShutdownRecoverySnapshot(_)
+            | LocalStateMutation::ShutdownDetailsCompaction(_)
+            | LocalStateMutation::ShutdownLatestPointer(_) => return false,
+        }
+    }
+    advances_existing_owner
+}
+
+/// Workflow and projection commits may drain through an active shutdown only
+/// when the batch proves that it advances already-admitted work.  In
+/// particular, the internal lane label is not authority to mint a new caller
+/// operation, binding, obligation, or recovery action.
+pub fn internal_progress_is_anchored_to_existing_owner(batch: &LocalAtomicBatch) -> bool {
+    let mutations = &batch.state_mutations;
+    let mut advances_existing_owner = false;
+    for mutation in mutations {
+        match mutation {
+            LocalStateMutation::OperationBinding(_)
+            | LocalStateMutation::AgentSessionRemoval(_)
+            | LocalStateMutation::CallerAttempt(_)
+            | LocalStateMutation::ShutdownPlan(_)
+            | LocalStateMutation::ShutdownTarget(_)
+            | LocalStateMutation::ShutdownRecoverySnapshot(_)
+            | LocalStateMutation::ShutdownDetailsCompaction(_)
+            | LocalStateMutation::ShutdownLatestPointer(_) => return false,
+            LocalStateMutation::OperationRecord(operation) => {
+                if !operation.expected.advances_to(operation.revision) {
+                    return false;
+                }
+                advances_existing_owner = true;
+            }
+            LocalStateMutation::Obligation(obligation) => {
+                if !obligation.expected.advances_to(obligation.revision) {
+                    return false;
+                }
+                advances_existing_owner = true;
+            }
+            LocalStateMutation::RecoveryAction(action) => {
+                if !action.expected.advances_to(action.revision) {
+                    return false;
+                }
+                advances_existing_owner = true;
+            }
+            LocalStateMutation::SessionProjection(session) => {
+                if session.expected.advances_to(session.revision) {
+                    advances_existing_owner = true;
+                } else if !session.expected.inserts_zero(session.revision) {
+                    return false;
+                }
+            }
+            LocalStateMutation::SessionProjectionRemoval(removal) => {
+                if !matches!(removal.expected, RevisionGuard::Expected(_)) {
+                    return false;
+                }
+                advances_existing_owner = true;
+            }
+            LocalStateMutation::WorkflowExecutionProjection(workflow) => {
+                if !workflow.expected.advances_to(workflow.revision)
+                    && !workflow.expected.inserts_zero(workflow.revision)
+                {
+                    return false;
+                }
+            }
+            LocalStateMutation::WorkflowExecutionNodeProjection(nodes) => {
+                if !nodes.expected.advances_to(nodes.revision)
+                    && !nodes.expected.inserts_zero(nodes.revision)
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    if !advances_existing_owner {
+        return false;
+    }
+    match batch.idempotency.operation_kind {
+        CommitOperationKind::Projection => false,
+        CommitOperationKind::Workflow => workflow_progress_has_one_execution_scope(batch),
+        CommitOperationKind::ApplicationQuit
+        | CommitOperationKind::Recovery
+        | CommitOperationKind::UserMutation
+        | CommitOperationKind::OperationProgress => false,
+    }
+}
+
+fn workflow_progress_has_one_execution_scope(batch: &LocalAtomicBatch) -> bool {
+    let mut execution_id = None;
+    for mutation in &batch.state_mutations {
+        if let LocalStateMutation::Obligation(ObligationMutation {
+            record: ObligationRecord::WorkflowExecution { execution },
+            expected,
+            revision,
+            ..
+        }) = mutation
+        {
+            if !expected.advances_to(*revision)
+                || execution_id
+                    .as_ref()
+                    .is_some_and(|stored| stored != &execution.execution_id)
+            {
+                return false;
+            }
+            execution_id = Some(execution.execution_id.clone());
+        }
+    }
+    let Some(execution_id) = execution_id else {
+        return false;
+    };
+    let expected_stream = match StreamId::workflow(&execution_id) {
+        Ok(stream) => stream,
+        Err(_) => return false,
+    };
+    if batch
+        .expected_heads
+        .iter()
+        .any(|head| head.stream_id != expected_stream)
+        || batch.events.iter().any(|event| {
+            event.stream_id != expected_stream
+                || !matches!(
+                    &event.event,
+                    LocalDomainEvent::Workflow(workflow)
+                        if workflow.execution_id() == execution_id
+                )
+        })
+    {
+        return false;
+    }
+    batch.state_mutations.iter().all(|mutation| match mutation {
+        LocalStateMutation::Obligation(ObligationMutation {
+            record: ObligationRecord::WorkflowExecution { execution },
+            ..
+        }) => execution.execution_id == execution_id,
+        LocalStateMutation::SessionProjection(projection) => match &projection.projection {
+            SessionProjectionRecord::WorkflowExecution(
+                WorkflowExecutionProjectionRecord::Present(execution),
+            ) => {
+                projection.session_id == format!("workflow:{execution_id}")
+                    && execution.execution_id == execution_id
+            }
+            SessionProjectionRecord::WorkflowExecution(
+                WorkflowExecutionProjectionRecord::Deleted {
+                    execution_id: deleted,
+                },
+            ) => {
+                projection.session_id == format!("workflow:{execution_id}")
+                    && deleted == &execution_id
+            }
+            SessionProjectionRecord::WorkflowWorktreeOwner(owner) => {
+                owner.execution_id == execution_id
+            }
+            SessionProjectionRecord::AgentSession(_)
+            | SessionProjectionRecord::ProviderSessionOwnership(_)
+            | SessionProjectionRecord::ProviderHookHealth(_) => false,
+        },
+        LocalStateMutation::WorkflowExecutionProjection(projection) => {
+            batch.state_mutations.iter().any(|candidate| {
+                matches!(
+                    candidate,
+                    LocalStateMutation::SessionProjection(source)
+                        if source.session_id == format!("workflow:{execution_id}")
+                            && source.expected == projection.expected
+                            && source.revision == projection.revision
+                )
+            }) && match &projection.projection {
+                WorkflowExecutionProjectionRecord::Present(execution) => {
+                    execution.execution_id == execution_id
+                }
+                WorkflowExecutionProjectionRecord::Deleted {
+                    execution_id: deleted,
+                } => deleted == &execution_id,
+            }
+        }
+        LocalStateMutation::WorkflowExecutionNodeProjection(nodes) => {
+            nodes.execution_id == execution_id
+                && nodes
+                    .nodes
+                    .iter()
+                    .all(|node| node.execution_id.as_deref() == Some(execution_id.as_str()))
+                && batch.state_mutations.iter().any(|candidate| {
+                    matches!(
+                        candidate,
+                        LocalStateMutation::WorkflowExecutionProjection(projection)
+                            if projection.expected == nodes.expected
+                                && projection.revision == nodes.revision
+                    )
+                })
+        }
+        _ => false,
+    })
+}
+
+/// Durable rows the store fetched and decoded for one ApplicationQuit-kind
+/// batch under closed admission.
+pub struct QuitProgressFacts<'a> {
+    pub plan_id: &'a str,
+    pub plan_summary: &'a ShutdownPlanRecord,
+    /// Canonical obligation id derived from the batch obligation's effect
+    /// identity (an identity-authority computation owned by the store).
+    pub workflow_shutdown_obligation_id: Option<&'a str>,
+    /// Every target row of the current plan: (detail, row revision). Fetched
+    /// when the batch is a single workflow-shutdown obligation commit.
+    pub plan_targets: &'a [(ShutdownTargetRecord, i64)],
+    /// The stored row at the ordinal of the batch's ShutdownTarget mutation:
+    /// (detail, row revision).
+    pub existing_target: Option<&'a (ShutdownTargetRecord, i64)>,
+}
+
+pub fn application_quit_progress_is_bound_to_current_plan(
+    batch: &LocalAtomicBatch,
+    facts: &QuitProgressFacts<'_>,
+) -> bool {
+    let operation_id = facts.plan_summary.operation_id.as_str();
+    if operation_id.is_empty() || batch.state_mutations.is_empty() {
+        return false;
+    }
+
+    // A caller joining the already accepted flight may add exactly one
+    // immutable binding to the current operation. It cannot smuggle any
+    // state or stream participant into that join commit.
+    if let [LocalStateMutation::OperationBinding(binding)] = batch.state_mutations.as_slice() {
+        return batch.expected_heads.is_empty()
+            && batch.events.is_empty()
+            && binding.key.kind == OperationKind::ApplicationQuit
+            && binding.key.installation_id == batch.idempotency.installation_id
+            && !binding.key.principal.is_empty()
+            && !binding.key.caller_request_id.is_empty()
+            && binding.operation_id == operation_id
+            && batch.idempotency.idempotency_key
+                == format!("{operation_id}.join.{}", binding.key.caller_request_id);
+    }
+
+    // The workflow executor's shutdown reservation is part of the fixed
+    // target effect. Its exact effect/session identity must already be in the
+    // current plan; an arbitrary obligation relabeled ApplicationQuit is not
+    // an admission capability.
+    if let [LocalStateMutation::Obligation(obligation)] = batch.state_mutations.as_slice() {
+        let ObligationRecord::WorkflowShutdown {
+            operation_id: stored_operation_id,
+            effect_identity,
+            owner_revision,
+            execution_id,
+            state,
+        } = &obligation.record
+        else {
+            return false;
+        };
+        let mut target_matches = false;
+        for (detail, revision) in facts.plan_targets {
+            if workflow_shutdown::obligation_anchor_matches(
+                detail,
+                *revision,
+                operation_id,
+                effect_identity,
+                execution_id,
+                *owner_revision,
+            ) {
+                if target_matches {
+                    return false;
+                }
+                target_matches = true;
+            }
+        }
+        let Some(expected_obligation_id) = facts.workflow_shutdown_obligation_id else {
+            return false;
+        };
+        let guard_matches = workflow_shutdown::obligation_guard_matches(
+            obligation,
+            *state,
+            effect_identity,
+            execution_id,
+        );
+        return target_matches
+            && batch.expected_heads.is_empty()
+            && batch.events.is_empty()
+            && stored_operation_id == operation_id
+            && obligation.obligation_id == expected_obligation_id
+            && batch.idempotency.idempotency_key
+                == format!("{expected_obligation_id}.{}", obligation.revision.value())
+            && guard_matches;
+    }
+
+    let current_plan = ShutdownPlanKey {
+        shutdown_id: facts.plan_id.to_string(),
+    };
+    let mut operation_revision = None;
+    let mut operation_status = None;
+    let mut plan_phase = None;
+    let mut target_transition = None;
+    let mut saw_plan = false;
+    let mut saw_pointer = false;
+    for mutation in &batch.state_mutations {
+        match mutation {
+            LocalStateMutation::OperationRecord(operation) => {
+                let OperationReceiptRecord::ApplicationQuit {
+                    operation_id: receipt_operation_id,
+                    plan,
+                    ..
+                } = &operation.receipt;
+                if operation_revision.replace(operation.revision).is_some()
+                    || operation.kind != OperationKind::ApplicationQuit
+                    || operation.operation_id != operation_id
+                    || receipt_operation_id != operation_id
+                    || plan != &current_plan
+                    || operation.latest_status.kind != OperationKind::ApplicationQuit
+                    || !operation.expected.advances_to(operation.revision)
+                {
+                    return false;
+                }
+                operation_status = Some(&operation.latest_status.value);
+            }
+            LocalStateMutation::ShutdownPlan(plan) => {
+                if saw_plan
+                    || plan.key != current_plan
+                    || plan.summary.operation_id != operation_id
+                    || !plan.expected.advances_to(plan.revision)
+                {
+                    return false;
+                }
+                saw_plan = true;
+                plan_phase = Some(plan.phase);
+            }
+            LocalStateMutation::ShutdownTarget(target) => {
+                if target_transition.replace(target).is_some()
+                    || target.key != current_plan
+                    || !target.expected.advances_to(target.revision)
+                {
+                    return false;
+                }
+                let Some((existing, revision)) = facts.existing_target else {
+                    return false;
+                };
+                let RevisionGuard::Expected(expected) = target.expected else {
+                    return false;
+                };
+                if expected.value() != *revision {
+                    return false;
+                }
+                let (
+                    ShutdownTargetRecord::Target {
+                        target_id: old_target_id,
+                        kind: old_kind,
+                        state: old_state,
+                        effect_identity: old_effect,
+                        owner_operation_id: old_owner,
+                        recovery_action: old_recovery,
+                        ..
+                    },
+                    ShutdownTargetRecord::Target {
+                        target_id,
+                        kind,
+                        state,
+                        effect_identity,
+                        owner_operation_id,
+                        failure,
+                        recovery_action,
+                    },
+                ) = (existing, &target.detail)
+                else {
+                    return false;
+                };
+                let transition_matches = matches!(
+                    (*old_state, *state),
+                    (
+                        ShutdownTargetStateRecord::Prepared,
+                        ShutdownTargetStateRecord::EffectReserved
+                    ) | (
+                        ShutdownTargetStateRecord::EffectReserved,
+                        ShutdownTargetStateRecord::Completed
+                    ) | (
+                        ShutdownTargetStateRecord::EffectReserved,
+                        ShutdownTargetStateRecord::ReconciliationRequired
+                    )
+                );
+                if target_id != old_target_id
+                    || kind != old_kind
+                    || effect_identity != old_effect
+                    || old_owner
+                        .as_deref()
+                        .is_some_and(|owner| owner != operation_id)
+                    || owner_operation_id.as_deref() != Some(operation_id)
+                    || recovery_action != old_recovery
+                    || !transition_matches
+                    || (*state == ShutdownTargetStateRecord::ReconciliationRequired)
+                        != failure.is_some()
+                {
+                    return false;
+                }
+            }
+            LocalStateMutation::ShutdownLatestPointer(pointer) => {
+                if saw_pointer
+                    || pointer.expected.as_ref() != Some(&current_plan)
+                    || pointer.new.is_some()
+                {
+                    return false;
+                }
+                saw_pointer = true;
+            }
+            LocalStateMutation::OperationBinding(_)
+            | LocalStateMutation::CallerAttempt(_)
+            | LocalStateMutation::SessionProjection(_)
+            | LocalStateMutation::SessionProjectionRemoval(_)
+            | LocalStateMutation::AgentSessionRemoval(_)
+            | LocalStateMutation::Obligation(_)
+            | LocalStateMutation::RecoveryAction(_)
+            | LocalStateMutation::WorkflowExecutionProjection(_)
+            | LocalStateMutation::WorkflowExecutionNodeProjection(_)
+            | LocalStateMutation::ShutdownRecoverySnapshot(_)
+            | LocalStateMutation::ShutdownDetailsCompaction(_) => return false,
+        }
+    }
+
+    if let Some(target) = target_transition {
+        if batch.state_mutations.len() != 1
+            || !batch.expected_heads.is_empty()
+            || !batch.events.is_empty()
+            || batch.idempotency.idempotency_key
+                != format!(
+                    "{operation_id}.target.{}.{}",
+                    target.ordinal,
+                    target.revision.value()
+                )
+        {
+            return false;
+        }
+        return true;
+    }
+    let Some(operation_revision) = operation_revision else {
+        return false;
+    };
+    if !saw_plan
+        || batch.expected_heads.len() != 1
+        || batch.expected_heads[0].stream_id != StreamId::application()
+        || batch.events.len() != 1
+    {
+        return false;
+    }
+    let event = &batch.events[0];
+    let event_matches = event.stream_id == StreamId::application()
+        && matches!(
+            &event.event,
+            LocalDomainEvent::Application(
+                ApplicationDomainEvent::ShutdownPhaseAdvanced {
+                    shutdown_id,
+                    phase,
+                    ..
+                }
+            ) if shutdown_id == facts.plan_id
+                && Some(*phase) == plan_phase
+        );
+    let activation = batch.idempotency.idempotency_key == format!("{operation_id}.activate")
+        && operation_status == Some(&OperationStatusValue::Activated)
+        && plan_phase == Some(ApplicationShutdownPhase::Activated)
+        && !saw_pointer
+        && batch.state_mutations.len() == 2;
+    let finish_identity = batch.idempotency.idempotency_key
+        == format!("{operation_id}.finish.{}", operation_revision.value());
+    let finish = finish_identity
+        && match (operation_status, plan_phase) {
+            (Some(OperationStatusValue::Completed), Some(ApplicationShutdownPhase::Completed)) => {
+                saw_pointer && batch.state_mutations.len() == 3
+            }
+            (
+                Some(OperationStatusValue::FailedBeforeActivation { .. }),
+                Some(ApplicationShutdownPhase::Failed),
+            )
+            | (
+                Some(OperationStatusValue::ReconciliationRequired { .. }),
+                Some(ApplicationShutdownPhase::ReconciliationRequired),
+            ) => !saw_pointer && batch.state_mutations.len() == 2,
+            _ => false,
+        };
+    event_matches && (activation || finish)
+}
+
+/// The stored recovery action row at the batch action's id.
+pub struct ExistingRecoveryAction<'a> {
+    pub attempt: &'a RecoveryAttemptRecord,
+    pub has_completed_result: bool,
+    pub revision: i64,
+}
+
+/// Durable rows the store fetched and decoded for one Recovery-kind batch
+/// under closed admission.
+pub struct ShutdownRecoveryFacts<'a> {
+    pub plan_id: &'a str,
+    pub plan_summary: &'a ShutdownPlanRecord,
+    /// The stored row at the batch target's (plan, ordinal): (detail, row
+    /// revision).
+    pub existing_target: Option<&'a (ShutdownTargetRecord, i64)>,
+    /// Canonical target key of the existing row's (kind, target id), an
+    /// identity-authority computation owned by the store.
+    pub existing_target_key: Option<&'a str>,
+    /// SHA-256 of the existing row's effect identity, computed by the store.
+    pub existing_effect_identity_sha256: Option<[u8; 32]>,
+    pub existing_action: Option<ExistingRecoveryAction<'a>>,
+    /// The batch's completed recovery result references this exact target,
+    /// validated against the canonical result payload by the store codec.
+    pub completed_result_targets_target: bool,
+}
+
+pub fn shutdown_target_recovery_is_bound_to_current_plan(
+    mutations: &[LocalStateMutation],
+    facts: &ShutdownRecoveryFacts<'_>,
+) -> bool {
+    let mut recovery_action = None;
+    let mut shutdown_target = None;
+    let mut closure_operation = None;
+    let mut closure_plan = None;
+    let mut closure_pointer = None;
+    for mutation in mutations {
+        match mutation {
+            LocalStateMutation::RecoveryAction(action) => {
+                if recovery_action.replace(action).is_some() {
+                    return false;
+                }
+            }
+            LocalStateMutation::ShutdownTarget(target) => {
+                if shutdown_target.replace(target).is_some() {
+                    return false;
+                }
+            }
+            LocalStateMutation::OperationRecord(operation)
+                if operation.kind == OperationKind::ApplicationQuit =>
+            {
+                if closure_operation.replace(operation).is_some() {
+                    return false;
+                }
+            }
+            LocalStateMutation::ShutdownPlan(plan) => {
+                if closure_plan.replace(plan).is_some() {
+                    return false;
+                }
+            }
+            LocalStateMutation::ShutdownLatestPointer(pointer) => {
+                if closure_pointer.replace(pointer).is_some() {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    let (Some(action), Some(target)) = (recovery_action, shutdown_target) else {
+        return false;
+    };
+    let has_plan_closure = match (closure_operation, closure_plan, closure_pointer) {
+        (None, None, None) => false,
+        (Some(operation), Some(plan), Some(pointer))
+            if operation.operation_id == facts.plan_summary.operation_id
+                && matches!(operation.expected, RevisionGuard::Expected(_))
+                && plan.key.shutdown_id == facts.plan_id
+                && plan.phase == ApplicationShutdownPhase::Completed
+                && plan.summary.operation_id == facts.plan_summary.operation_id
+                && plan.summary.intent == facts.plan_summary.intent
+                && matches!(plan.expected, RevisionGuard::Expected(_))
+                && pointer
+                    .expected
+                    .as_ref()
+                    .is_some_and(|key| key.shutdown_id == facts.plan_id)
+                && pointer.new.is_none() =>
+        {
+            true
+        }
+        _ => return false,
+    };
+    if target.key.shutdown_id != facts.plan_id || target.ordinal < 0 {
+        return false;
+    }
+    let RevisionGuard::Expected(expected_target_revision) = target.expected else {
+        // Shutdown recovery may only mutate a member of the plan's fixed
+        // target set. In particular, Recovery is never an insert path.
+        return false;
+    };
+    let Some((existing_target, existing_target_revision)) = facts.existing_target else {
+        return false;
+    };
+    if expected_target_revision.value() != *existing_target_revision
+        || target.revision.value()
+            != match existing_target_revision.checked_add(1) {
+                Some(next) => next,
+                None => return false,
+            }
+    {
+        return false;
+    }
+    let (
+        ShutdownTargetRecord::Target {
+            target_id: existing_target_id,
+            kind: existing_kind,
+            state: existing_state,
+            effect_identity: existing_effect_identity,
+            owner_operation_id: existing_owner_operation_id,
+            failure: existing_failure,
+            recovery_action: existing_target_recovery,
+        },
+        ShutdownTargetRecord::Target {
+            target_id,
+            kind,
+            state,
+            effect_identity,
+            owner_operation_id,
+            failure,
+            recovery_action: Some(target_recovery),
+        },
+    ) = (existing_target, &target.detail)
+    else {
+        return false;
+    };
+    if target_id != existing_target_id
+        || kind != existing_kind
+        || effect_identity != existing_effect_identity
+        || owner_operation_id != existing_owner_operation_id
+    {
+        // A recovery transition may change target state/failure, but never
+        // the executor-owned identity at the admitted ordinal.
+        return false;
+    }
+
+    let RecoveryAttemptRecord::ShutdownTarget {
+        resource_ref,
+        plan,
+        ordinal,
+        target_key,
+        origin_revision,
+        action: attempted_action,
+        effect_identity_sha256,
+        intent,
+        state: attempt_state,
+        failure: attempt_failure,
+    } = &action.attempt;
+    let expected_resource_ref = format!(
+        "shutdown-target:{}:{}:{target_key}",
+        facts.plan_id, target.ordinal
+    );
+    if plan.shutdown_id != facts.plan_id
+        || *ordinal != target.ordinal
+        || facts.existing_target_key != Some(target_key.as_str())
+        || resource_ref != &expected_resource_ref
+        || target_recovery.action_id != action.action_id
+        || target_recovery.origin_revision != *origin_revision
+        || target_recovery.action != *attempted_action
+        || target_recovery.state != *attempt_state
+        || facts.existing_effect_identity_sha256 != Some(*effect_identity_sha256)
+        || *intent != facts.plan_summary.intent
+        || attempt_failure.is_some()
+    {
+        return false;
+    }
+
+    match action.expected {
+        RevisionGuard::Absent => {
+            action.revision.value() == 0
+                && action.completed.is_none()
+                && *origin_revision == *existing_target_revision as u64
+                && *attempt_state == ObligationStateRecord::EffectReserved
+                && *state == *existing_state
+                && *failure == *existing_failure
+        }
+        RevisionGuard::Expected(expected_action_revision) => {
+            let Some(existing_action) = facts.existing_action.as_ref() else {
+                return false;
+            };
+            if expected_action_revision.value() != existing_action.revision
+                || action.revision.value()
+                    != match existing_action.revision.checked_add(1) {
+                        Some(next) => next,
+                        None => return false,
+                    }
+                || existing_action.has_completed_result
+            {
+                return false;
+            }
+            let RecoveryAttemptRecord::ShutdownTarget {
+                resource_ref: existing_resource_ref,
+                plan: existing_plan,
+                ordinal: existing_ordinal,
+                target_key: existing_target_key,
+                origin_revision: existing_origin_revision,
+                action: existing_action_kind,
+                effect_identity_sha256: existing_effect_identity_sha256,
+                intent: existing_intent,
+                state: existing_attempt_state,
+                failure: existing_attempt_failure,
+            } = existing_action.attempt;
+            let Some(existing_target_recovery) = existing_target_recovery else {
+                return false;
+            };
+            if existing_resource_ref != resource_ref
+                || existing_plan != plan
+                || existing_ordinal != ordinal
+                || existing_target_key != target_key
+                || existing_origin_revision != origin_revision
+                || existing_action_kind != attempted_action
+                || existing_effect_identity_sha256 != effect_identity_sha256
+                || existing_intent != intent
+                || *existing_attempt_state != ObligationStateRecord::EffectReserved
+                || existing_attempt_failure.is_some()
+                || existing_target_recovery.action_id != action.action_id
+                || existing_target_recovery.origin_revision != *origin_revision
+                || existing_target_recovery.action != *attempted_action
+                || existing_target_recovery.state != ObligationStateRecord::EffectReserved
+                || *attempt_state != ObligationStateRecord::Completed
+                || target_recovery.state != ObligationStateRecord::Completed
+            {
+                return false;
+            }
+            let Some(RecoveryResultRecord::Action(completed)) = action.completed.as_ref() else {
+                return false;
+            };
+            (!has_plan_closure || *state == ShutdownTargetStateRecord::Completed)
+                && completed.resource_revision == target.revision.value() as u64
+                && facts.completed_result_targets_target
+        }
+    }
+}

--- a/src-tauri/src/domain/local_event/events.rs
+++ b/src-tauri/src/domain/local_event/events.rs
@@ -31,6 +31,15 @@ pub enum ApplicationShutdownPhase {
     ReconciliationRequired,
 }
 
+impl ApplicationShutdownPhase {
+    /// A terminal plan no longer closes store admission.
+    /// `ReconciliationRequired` is not terminal: its plan still owns admission
+    /// until recovery drives it to a terminal phase.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
 /// Minimal application-stream event vocabulary owned by this module.
 /// The shutdown coordinator appends here; it must not invent a parallel
 /// event enum.

--- a/src-tauri/src/domain/local_event/mod.rs
+++ b/src-tauri/src/domain/local_event/mod.rs
@@ -7,6 +7,7 @@
 //! Tauri, or WebSocket dependency is allowed here.
 
 pub mod batch;
+pub mod commit_admission;
 pub mod events;
 pub mod failure;
 pub mod identifiers;
@@ -18,6 +19,7 @@ pub mod record;
 pub mod recovery;
 #[allow(clippy::module_inception)]
 pub mod repository;
+pub mod workflow_shutdown;
 
 pub use batch::{
     CommitBatchError, CommitBatchResult, CommitOperationKind, CommitResolution, CommittedBatch,

--- a/src-tauri/src/domain/local_event/mutation.rs
+++ b/src-tauri/src/domain/local_event/mutation.rs
@@ -44,6 +44,21 @@ pub enum RevisionGuard {
     Expected(Revision),
 }
 
+impl RevisionGuard {
+    /// The mutation advances an existing row by exactly one revision.
+    pub fn advances_to(self, revision: Revision) -> bool {
+        let Self::Expected(current) = self else {
+            return false;
+        };
+        current.next() == Some(revision)
+    }
+
+    /// The mutation inserts a new row at revision zero.
+    pub fn inserts_zero(self, revision: Revision) -> bool {
+        matches!(self, Self::Absent) && revision.value() == 0
+    }
+}
+
 /// Caller-scoped identity tuple `(principal, generation, kind, caller key)`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CallerOperationKey {

--- a/src-tauri/src/domain/local_event/workflow_shutdown.rs
+++ b/src-tauri/src/domain/local_event/workflow_shutdown.rs
@@ -1,0 +1,566 @@
+//! Rules for the workflow shutdown quiesce effect obligation.
+//!
+//! One durable obligation record exists per effect identity. The record's
+//! owner revision names the claimant that reserved the effect, but it is not
+//! part of the effect's identity: a later durable claimant of the same effect
+//! may adopt a completed result or take over a stale reservation.
+
+use super::{
+    ObligationMutation, ObligationRecord, ObligationStateRecord, ObligationView, PendingPartition,
+    Revision, RevisionGuard, ShutdownTargetKindRecord, ShutdownTargetRecord,
+    ShutdownTargetRecoveryRecord,
+};
+
+/// Durable resolution of one quiesce effect readback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowShutdownEffectResolution {
+    /// A durable record proves this effect completed, regardless of which
+    /// owner revision completed it.
+    Completed,
+    /// The effect has no completion record. A bare reservation also resolves
+    /// here: it cannot prove completion, and the effect is idempotent, so it
+    /// may be re-executed under the caller's owner revision.
+    NotStarted,
+    /// The stored record does not belong to this effect.
+    Unresolved,
+}
+
+/// How an executor may reserve the effect before running it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowShutdownReservationStep {
+    /// A durable record proves this effect completed; do not run it again.
+    AlreadyCompleted,
+    /// The caller already holds the reservation; continue from it.
+    ContinueOwn { reservation: Revision },
+    /// Commit a reservation under the caller's owner revision: fresh when no
+    /// record exists, a takeover when a stale owner's reservation remains.
+    Reserve {
+        expected: RevisionGuard,
+        reservation: Revision,
+    },
+    /// The record cannot be owned by this effect; do not start it.
+    Reject,
+}
+
+fn record_identity(
+    record: &ObligationView,
+    operation_id: &str,
+    effect_identity: &str,
+    execution_id: &str,
+) -> Option<(ObligationStateRecord, i64)> {
+    let ObligationRecord::WorkflowShutdown {
+        operation_id: stored_operation_id,
+        effect_identity: stored_effect_identity,
+        owner_revision: stored_owner_revision,
+        execution_id: stored_execution_id,
+        state,
+    } = &record.record
+    else {
+        return None;
+    };
+    (stored_operation_id == operation_id
+        && stored_effect_identity == effect_identity
+        && stored_execution_id == execution_id)
+        .then_some((*state, *stored_owner_revision))
+}
+
+pub fn read_resolution(
+    record: Option<&ObligationView>,
+    operation_id: &str,
+    effect_identity: &str,
+    execution_id: &str,
+) -> WorkflowShutdownEffectResolution {
+    let Some(record) = record else {
+        return WorkflowShutdownEffectResolution::NotStarted;
+    };
+    match record_identity(record, operation_id, effect_identity, execution_id) {
+        Some((ObligationStateRecord::Completed, _)) => WorkflowShutdownEffectResolution::Completed,
+        Some((ObligationStateRecord::EffectReserved, _)) => {
+            WorkflowShutdownEffectResolution::NotStarted
+        }
+        _ => WorkflowShutdownEffectResolution::Unresolved,
+    }
+}
+
+pub fn reservation_step(
+    record: Option<&ObligationView>,
+    operation_id: &str,
+    effect_identity: &str,
+    execution_id: &str,
+    owner_revision: i64,
+) -> WorkflowShutdownReservationStep {
+    let Some(record) = record else {
+        return WorkflowShutdownReservationStep::Reserve {
+            expected: RevisionGuard::Absent,
+            reservation: Revision::new(0).expect("zero revision"),
+        };
+    };
+    match record_identity(record, operation_id, effect_identity, execution_id) {
+        Some((ObligationStateRecord::Completed, _)) => {
+            WorkflowShutdownReservationStep::AlreadyCompleted
+        }
+        Some((ObligationStateRecord::EffectReserved, stored_owner_revision)) => {
+            if stored_owner_revision == owner_revision {
+                WorkflowShutdownReservationStep::ContinueOwn {
+                    reservation: record.revision,
+                }
+            } else {
+                match record.revision.next() {
+                    Some(reservation) => WorkflowShutdownReservationStep::Reserve {
+                        expected: RevisionGuard::Expected(record.revision),
+                        reservation,
+                    },
+                    None => WorkflowShutdownReservationStep::Reject,
+                }
+            }
+        }
+        _ => WorkflowShutdownReservationStep::Reject,
+    }
+}
+
+/// The durable anchor admitting a workflow shutdown obligation commit under
+/// closed admission: the target row at the obligation's owner revision either
+/// holds the plan's own effect reservation or a claimed recovery attempt
+/// re-owning the same effect.
+pub fn obligation_anchor_matches(
+    detail: &ShutdownTargetRecord,
+    revision: i64,
+    operation_id: &str,
+    effect_identity: &str,
+    execution_id: &str,
+    owner_revision: i64,
+) -> bool {
+    use super::ShutdownTargetStateRecord;
+    matches!(
+        detail,
+        ShutdownTargetRecord::Target {
+            target_id,
+            kind: ShutdownTargetKindRecord::WorkflowExecution,
+            state,
+            effect_identity: stored_effect,
+            owner_operation_id: Some(owner),
+            recovery_action,
+            ..
+        } if target_id.as_str() == execution_id
+            && stored_effect.as_str() == effect_identity
+            && owner.as_str() == operation_id
+            && revision == owner_revision
+            && (*state == ShutdownTargetStateRecord::EffectReserved
+                || matches!(
+                    recovery_action,
+                    Some(ShutdownTargetRecoveryRecord {
+                        state: ObligationStateRecord::EffectReserved,
+                        ..
+                    })
+                ))
+    )
+}
+
+pub fn obligation_guard_matches(
+    obligation: &ObligationMutation,
+    state: ObligationStateRecord,
+    effect_identity: &str,
+    execution_id: &str,
+) -> bool {
+    let reserved_pending_matches = || {
+        obligation.pending.as_ref().is_some_and(|pending| {
+            pending.owner == execution_id
+                && pending.partition == PendingPartition::Owner
+                && pending.shutdown_plan.is_none()
+                && pending.ordered_key == format!("workflow-shutdown-{effect_identity}")
+        })
+    };
+    match (obligation.expected, state) {
+        (RevisionGuard::Absent, ObligationStateRecord::EffectReserved) => {
+            obligation.expected.inserts_zero(obligation.revision) && reserved_pending_matches()
+        }
+        // A claimed retry takes over a stale reservation by advancing the
+        // same record under its new owner revision.
+        (RevisionGuard::Expected(_), ObligationStateRecord::EffectReserved) => {
+            obligation.expected.advances_to(obligation.revision) && reserved_pending_matches()
+        }
+        (RevisionGuard::Expected(_), ObligationStateRecord::Completed) => {
+            obligation.expected.advances_to(obligation.revision) && obligation.pending.is_none()
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{PendingIndexEntry, RecoveryActionKind, ShutdownTargetStateRecord};
+    use super::*;
+
+    fn record(state: ObligationStateRecord, owner_revision: i64) -> ObligationView {
+        ObligationView {
+            obligation_id: "workflow-shutdown-record".to_string(),
+            record: ObligationRecord::WorkflowShutdown {
+                operation_id: "quit-operation".to_string(),
+                effect_identity: "quit-operation:0:workflow-1".to_string(),
+                owner_revision,
+                execution_id: "workflow-1".to_string(),
+                state,
+            },
+            record_sha256: [0; 32],
+            pending: None,
+            revision: Revision::new(1).unwrap(),
+        }
+    }
+
+    fn resolution(record: Option<&ObligationView>) -> WorkflowShutdownEffectResolution {
+        read_resolution(
+            record,
+            "quit-operation",
+            "quit-operation:0:workflow-1",
+            "workflow-1",
+        )
+    }
+
+    #[test]
+    fn read_resolution_adopts_completion_and_reopens_stale_reservation() {
+        assert_eq!(
+            resolution(Some(&record(ObligationStateRecord::Completed, 7))),
+            WorkflowShutdownEffectResolution::Completed
+        );
+        assert_eq!(
+            resolution(Some(&record(ObligationStateRecord::EffectReserved, 7))),
+            WorkflowShutdownEffectResolution::NotStarted
+        );
+        assert_eq!(
+            resolution(Some(&record(
+                ObligationStateRecord::ReconciliationRequired,
+                7
+            ))),
+            WorkflowShutdownEffectResolution::Unresolved
+        );
+        assert_eq!(
+            resolution(None),
+            WorkflowShutdownEffectResolution::NotStarted
+        );
+    }
+
+    #[test]
+    fn read_resolution_is_bound_to_exact_effect_not_owner_revision() {
+        let stored = record(ObligationStateRecord::Completed, 7);
+        assert_eq!(
+            read_resolution(
+                Some(&stored),
+                "unrelated-terminal-operation",
+                "quit-operation:0:workflow-1",
+                "workflow-1",
+            ),
+            WorkflowShutdownEffectResolution::Unresolved
+        );
+        assert_eq!(
+            read_resolution(
+                Some(&stored),
+                "quit-operation",
+                "quit-operation:0:workflow-2",
+                "workflow-1",
+            ),
+            WorkflowShutdownEffectResolution::Unresolved
+        );
+        assert_eq!(
+            read_resolution(
+                Some(&stored),
+                "quit-operation",
+                "quit-operation:0:workflow-1",
+                "workflow-2",
+            ),
+            WorkflowShutdownEffectResolution::Unresolved
+        );
+    }
+
+    fn step(
+        record: Option<&ObligationView>,
+        owner_revision: i64,
+    ) -> WorkflowShutdownReservationStep {
+        reservation_step(
+            record,
+            "quit-operation",
+            "quit-operation:0:workflow-1",
+            "workflow-1",
+            owner_revision,
+        )
+    }
+
+    #[test]
+    fn reservation_step_continues_own_and_takes_over_stale_owner() {
+        assert_eq!(
+            step(None, 9),
+            WorkflowShutdownReservationStep::Reserve {
+                expected: RevisionGuard::Absent,
+                reservation: Revision::new(0).unwrap(),
+            }
+        );
+        assert_eq!(
+            step(Some(&record(ObligationStateRecord::Completed, 3)), 9),
+            WorkflowShutdownReservationStep::AlreadyCompleted
+        );
+        assert_eq!(
+            step(Some(&record(ObligationStateRecord::EffectReserved, 9)), 9),
+            WorkflowShutdownReservationStep::ContinueOwn {
+                reservation: Revision::new(1).unwrap(),
+            }
+        );
+        assert_eq!(
+            step(Some(&record(ObligationStateRecord::EffectReserved, 3)), 9),
+            WorkflowShutdownReservationStep::Reserve {
+                expected: RevisionGuard::Expected(Revision::new(1).unwrap()),
+                reservation: Revision::new(2).unwrap(),
+            }
+        );
+        let mut exhausted = record(ObligationStateRecord::EffectReserved, 3);
+        exhausted.revision = Revision::new(i64::MAX).unwrap();
+        assert_eq!(
+            step(Some(&exhausted), 9),
+            WorkflowShutdownReservationStep::Reject
+        );
+        assert_eq!(
+            step(
+                Some(&record(ObligationStateRecord::ReconciliationRequired, 9)),
+                9
+            ),
+            WorkflowShutdownReservationStep::Reject
+        );
+        assert_eq!(
+            reservation_step(
+                Some(&record(ObligationStateRecord::EffectReserved, 3)),
+                "unrelated-terminal-operation",
+                "quit-operation:0:workflow-1",
+                "workflow-1",
+                9,
+            ),
+            WorkflowShutdownReservationStep::Reject
+        );
+    }
+
+    fn target(
+        state: ShutdownTargetStateRecord,
+        recovery_state: Option<ObligationStateRecord>,
+    ) -> ShutdownTargetRecord {
+        ShutdownTargetRecord::Target {
+            target_id: "workflow-1".to_string(),
+            kind: ShutdownTargetKindRecord::WorkflowExecution,
+            state,
+            effect_identity: "quit-operation:0:workflow-1".to_string(),
+            owner_operation_id: Some("quit-operation".to_string()),
+            failure: None,
+            recovery_action: recovery_state.map(|state| ShutdownTargetRecoveryRecord {
+                action_id: "action-1".to_string(),
+                origin_revision: 4,
+                action: RecoveryActionKind::RetrySameEffect,
+                state,
+            }),
+        }
+    }
+
+    fn anchor_matches(detail: &ShutdownTargetRecord, revision: i64) -> bool {
+        obligation_anchor_matches(
+            detail,
+            revision,
+            "quit-operation",
+            "quit-operation:0:workflow-1",
+            "workflow-1",
+            5,
+        )
+    }
+
+    #[test]
+    fn obligation_anchor_accepts_reservation_and_claimed_recovery() {
+        assert!(anchor_matches(
+            &target(ShutdownTargetStateRecord::EffectReserved, None),
+            5
+        ));
+        assert!(anchor_matches(
+            &target(
+                ShutdownTargetStateRecord::ReconciliationRequired,
+                Some(ObligationStateRecord::EffectReserved),
+            ),
+            5,
+        ));
+        assert!(anchor_matches(
+            &target(
+                ShutdownTargetStateRecord::Prepared,
+                Some(ObligationStateRecord::EffectReserved),
+            ),
+            5,
+        ));
+        assert!(!anchor_matches(
+            &target(ShutdownTargetStateRecord::ReconciliationRequired, None),
+            5
+        ));
+        assert!(!anchor_matches(
+            &target(
+                ShutdownTargetStateRecord::ReconciliationRequired,
+                Some(ObligationStateRecord::Completed),
+            ),
+            5,
+        ));
+        assert!(!anchor_matches(
+            &target(ShutdownTargetStateRecord::EffectReserved, None),
+            6
+        ));
+    }
+
+    #[test]
+    fn obligation_anchor_is_bound_to_target_identity() {
+        let detail = target(ShutdownTargetStateRecord::EffectReserved, None);
+        assert!(!obligation_anchor_matches(
+            &detail,
+            5,
+            "unrelated-operation",
+            "quit-operation:0:workflow-1",
+            "workflow-1",
+            5,
+        ));
+        assert!(!obligation_anchor_matches(
+            &detail,
+            5,
+            "quit-operation",
+            "quit-operation:0:workflow-2",
+            "workflow-1",
+            5,
+        ));
+        assert!(!obligation_anchor_matches(
+            &detail,
+            5,
+            "quit-operation",
+            "quit-operation:0:workflow-1",
+            "workflow-2",
+            5,
+        ));
+    }
+
+    fn obligation(
+        state: ObligationStateRecord,
+        expected: RevisionGuard,
+        revision: i64,
+        pending: Option<PendingIndexEntry>,
+    ) -> ObligationMutation {
+        ObligationMutation {
+            obligation_id: "workflow-shutdown-abc".to_string(),
+            record: ObligationRecord::WorkflowShutdown {
+                operation_id: "quit-operation".to_string(),
+                effect_identity: "quit-operation:0:workflow-1".to_string(),
+                owner_revision: 5,
+                execution_id: "workflow-1".to_string(),
+                state,
+            },
+            pending,
+            expected,
+            revision: Revision::new(revision).unwrap(),
+        }
+    }
+
+    fn reserved_pending() -> PendingIndexEntry {
+        PendingIndexEntry {
+            ordered_key: "workflow-shutdown-quit-operation:0:workflow-1".to_string(),
+            owner: "workflow-1".to_string(),
+            partition: PendingPartition::Owner,
+            shutdown_plan: None,
+        }
+    }
+
+    fn guard_matches(obligation: &ObligationMutation, state: ObligationStateRecord) -> bool {
+        obligation_guard_matches(
+            obligation,
+            state,
+            "quit-operation:0:workflow-1",
+            "workflow-1",
+        )
+    }
+
+    #[test]
+    fn obligation_guard_admits_reservation_takeover_and_completion() {
+        let reservation = obligation(
+            ObligationStateRecord::EffectReserved,
+            RevisionGuard::Absent,
+            0,
+            Some(reserved_pending()),
+        );
+        assert!(guard_matches(
+            &reservation,
+            ObligationStateRecord::EffectReserved
+        ));
+
+        let takeover = obligation(
+            ObligationStateRecord::EffectReserved,
+            RevisionGuard::Expected(Revision::new(0).unwrap()),
+            1,
+            Some(reserved_pending()),
+        );
+        assert!(guard_matches(
+            &takeover,
+            ObligationStateRecord::EffectReserved
+        ));
+
+        let completion = obligation(
+            ObligationStateRecord::Completed,
+            RevisionGuard::Expected(Revision::new(1).unwrap()),
+            2,
+            None,
+        );
+        assert!(guard_matches(&completion, ObligationStateRecord::Completed));
+    }
+
+    #[test]
+    fn obligation_guard_rejects_malformed_shapes() {
+        let skipped_revision = obligation(
+            ObligationStateRecord::EffectReserved,
+            RevisionGuard::Expected(Revision::new(0).unwrap()),
+            2,
+            Some(reserved_pending()),
+        );
+        assert!(!guard_matches(
+            &skipped_revision,
+            ObligationStateRecord::EffectReserved
+        ));
+
+        let reservation_without_pending = obligation(
+            ObligationStateRecord::EffectReserved,
+            RevisionGuard::Expected(Revision::new(0).unwrap()),
+            1,
+            None,
+        );
+        assert!(!guard_matches(
+            &reservation_without_pending,
+            ObligationStateRecord::EffectReserved
+        ));
+
+        let completion_with_pending = obligation(
+            ObligationStateRecord::Completed,
+            RevisionGuard::Expected(Revision::new(1).unwrap()),
+            2,
+            Some(reserved_pending()),
+        );
+        assert!(!guard_matches(
+            &completion_with_pending,
+            ObligationStateRecord::Completed
+        ));
+
+        let inserted_completion = obligation(
+            ObligationStateRecord::Completed,
+            RevisionGuard::Absent,
+            0,
+            None,
+        );
+        assert!(!guard_matches(
+            &inserted_completion,
+            ObligationStateRecord::Completed
+        ));
+
+        let mut foreign_pending = reserved_pending();
+        foreign_pending.owner = "workflow-2".to_string();
+        let foreign_owner = obligation(
+            ObligationStateRecord::EffectReserved,
+            RevisionGuard::Expected(Revision::new(0).unwrap()),
+            1,
+            Some(foreign_pending),
+        );
+        assert!(!guard_matches(
+            &foreign_owner,
+            ObligationStateRecord::EffectReserved
+        ));
+    }
+}


### PR DESCRIPTION
Closes #1640

## 概要

active な workflow_execution が残った状態での quit で quiesce が必ず Ambiguous になり、`reconciliation_required` から復旧不能でストアが永久ロックする問題を修正する。

## 変更内容

### 層1: quiesce の意味論修正

- owned command を1つも観測できない execution の quiesce 効果を `Completed` として確定する（外部作用を要しない target の確定。spec issues-1499 準拠）
- Session node 実行中・approval 待ち等、command プロセスを持たない execution の quit が正常完了するようになる

### 層2: retry_same_effect の収束

- obligation record の照合から owner_revision を外し（identity = operation_id + effect_identity + execution_id）、`Completed` は所有者に関わらず採用、stale な `EffectReserved` は `ConfirmedNotStarted` として `execute_target` へ到達可能にする
- 初回試行が残した reservation を新 owner_revision へ CAS で引き継ぐ takeover を追加

### admission gate の拡張

- claim 済み recovery action（state=EffectReserved）を obligation commit の anchor として認める
- takeover 形状（`Expected → EffectReserved` の revision 前進 + pending 維持）を許可形状に追加

これにより、既に詰まった store も「Retry same effect」→ takeover → Completed → 全 target 完了 → plan closure → admission 開放、という既存の recovery ループで復旧できる。

### 判定規則の domain への移行

- `domain/local_event/workflow_shutdown.rs` 新設: effect の読み取り解決・reservation step・anchor/guard の受理判定
- `domain/local_event/commit_admission.rs` 新設: closed admission の全受理規則（operation progress / internal progress / quit progress / recovery の形状・遷移規則）
- `RevisionGuard::advances_to` / `inserts_zero`、`ApplicationShutdownPhase::is_terminal` を値オブジェクトのメソッド化
- gateway は SQL fetch・Stored*V1 デコード・hash 計算・port 型変換のみを担い、判定は domain 関数を呼ぶ

## 挙動に関する注記

facts 方式により行の fetch/decode が形状検査より先に走るため、「batch が形状不正 かつ 参照先の格納行が decode 不能（store 破損）」の組み合わせに限り、従来 admission 拒否（retryable）だったものが Corrupt エラーになり得る。正常な store では挙動差はない。

## テスト

- `cargo fmt --check` / `cargo clippy -- -D warnings` クリーン
- `cargo test` 1979件 + 受け入れテスト全通過
- domain の新規テスト: effect 解決・reservation step（takeover 含む）・anchor/guard 受理判定の正常系・拒否系 7件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * シャットダウン中のコミット受付判定を強化し、計画外・重複・不整合な操作を拒否するようになりました。
  * 未知のシャットダウン状態を安全側に扱い、誤った進行を防止します。
  * ワークフロー終了処理で、予約・実行・完了状態を正しく復元できるようになりました。
  * リビジョンや対象情報の整合性検証を強化しました。
* **テスト**
  * シャットダウン、復旧、予約状態、リビジョン整合性に関する検証を拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->