### PR TITLE
feat(workflow): Lua による workflow 定義

### DIFF
--- a/docs/specs/milestone-82/design.md
+++ b/docs/specs/milestone-82/design.md
@@ -200,6 +200,9 @@ pub struct Diagnostic {
 | WFS004 | kind に許可されない field（fanout への inputs 含む） |
 | WFS005 | 旧構文（type:, output_contract, parallel_children, aggregate, match:, cycle_guard, pass_output_from, variables 等） |
 | WFS006 | node 名重複 / 名前形式違反 |
+| WFS009 | Lua の構文エラー |
+| WFS010 | 評価の失敗、上限超過による打ち切り、chunk が `Workflow` を返さない |
+| WFS011 | `require` の解決失敗、workflows ディレクトリ外の参照、循環 require |
 | WFR001 | 未定義 node 参照（rules target / fanout child / inputs） |
 | WFR002 | 未定義 Contract 参照（artifact / input / items） |
 | WFR003 | 未定義または参照不能な Artifact path（artifact 無し session への参照、fanout child 名の参照を含む） |

--- a/docs/specs/milestone-82/design.md
+++ b/docs/specs/milestone-82/design.md
@@ -200,6 +200,8 @@ pub struct Diagnostic {
 | WFS004 | kind に許可されない field（fanout への inputs 含む） |
 | WFS005 | 旧構文（type:, output_contract, parallel_children, aggregate, match:, cycle_guard, pass_output_from, variables 等） |
 | WFS006 | node 名重複 / 名前形式違反 |
+| WFS007 | 配線 field の宣言位置違反（node に inputs / rules / on_failure。配線は合成子の children エントリが持つ） |
+| WFS008 | children エントリの形式違反、および sequence の artifact 宣言に対する output 欠落 |
 | WFS009 | Lua の構文エラー |
 | WFS010 | 評価の失敗、上限超過による打ち切り、chunk が `Workflow` を返さない |
 | WFS011 | `require` の解決失敗、workflows ディレクトリ外の参照、循環 require |
@@ -208,6 +210,9 @@ pub struct Diagnostic {
 | WFR003 | 未定義または参照不能な Artifact path（artifact 無し session への参照、fanout child 名の参照を含む） |
 | WFR004 | 予約名の誤用（request / item を node 名に、schemas に request 宣言） |
 | WFR005 | `item` の scope 外使用 |
+| WFR006 | root node（`main`）の欠落 |
+| WFR007 | 未解決の input 供給元（合成子のスコープ外、または存在しない供給元） |
+| WFR008 | 曖昧な input 供給元、および予約パラメータ名の使用 |
 | WFT001 | when.on が routing 可能 Boolean でない |
 | WFT002 | switch.on が routing 可能 enum でない / cases に enum 外の値 |
 | WFT003 | fanout items と child input の不整合（要素型不一致・items 無しで child が input 宣言・items 有りで child が input 未宣言） |
@@ -221,9 +226,15 @@ pub struct Diagnostic {
 | WFC004 | switch enum の被覆漏れ（next 無しの場合） |
 | WFC005 | 到達可能な loop_guard の無い cycle / loop_guard の max_iterations 不正 |
 | WFC006 | fanout child の leaf 違反（child への通常遷移 / entry / fanout の入れ子） |
+| WFC007 | children の重複参照、および fanout child エントリへの rules 宣言 |
+| WFC008 | 合成子の包含循環（children に自分自身が現れる） |
+| WFC009 | `on_failure: ignore` を宣言した子の Artifact に下流が依存している |
+| WFC010 | 合成子の子への `on_failure: retry` 宣言 |
 | WFR900 | facet 参照の解決失敗（未定義 facet） |
+| WFU002 | 未対応の `worktree` field 宣言（milestone #85 で解禁） |
+| WFI000 | ビルトイン定義の注記（Info） |
 
-なお WFR900（Resolve 段）/ WFT900（Typecheck 段）は facet・permission・model の参照/解決失敗を表す。stage は code 接頭辞（WFR→Resolve / WFT→Typecheck / WFC→ControlFlow / それ以外→ParseShape）で決まる。
+なお WFR900（Resolve 段）/ WFT900（Typecheck 段）は facet・permission・model の参照/解決失敗を表す。stage は code 接頭辞（WFR / WFU / FAC→Resolve / WFT→Typecheck / WFC→ControlFlow / それ以外→ParseShape）で決まる。
 
 ## 8. Runtime 実行経路
 

--- a/specs/issues-1591/behavior.md
+++ b/specs/issues-1591/behavior.md
@@ -1,0 +1,153 @@
+## B-001: Lua 定義と YAML 定義の同一性
+
+GIVEN ある workflow が Lua で定義されており、同じ内容の YAML 定義が存在する
+WHEN それぞれを実行する
+THEN 実行木の構造、Node の完了条件、辺の進行、事実ログ、read model は同一になる
+AND 定義が Lua で書かれたことを示す区別は実行木にも事実ログにも現れない
+
+## B-002: Lua の評価は load 時に限られる
+
+GIVEN Lua で定義された workflow が load されている
+WHEN その workflow を実行し、Node が起動・完了・再開する
+THEN 実行中に Lua は評価されない
+
+## B-003: require による合成は単一定義になる
+
+GIVEN Lua 定義が require で他のファイルの部品を取り込んでいる
+WHEN その定義を load する
+THEN engine は単一の workflow 定義を受け取る
+AND 部品は実行木に子 sequence として現れ、折り畳みと承認の単位になる
+
+## B-004: 部品の複数回利用
+
+GIVEN 部品が sequence を返す関数として書かれている
+WHEN 同一定義の中でその部品を複数回使う
+THEN 使用ごとに独立した Node 群が定義に現れる
+AND それぞれが別々の実行として実行木に並ぶ
+
+## B-005: 同一の値を複数の children へ置く記述
+
+GIVEN Lua 定義が同一の node の値を複数の children エントリへ置いている
+WHEN その定義を load する
+THEN その定義は拒否される
+
+## B-006: 存在しない参照
+
+GIVEN Lua 定義が、宣言されていない facet キー、artifact を宣言していない node の field、または schema に存在しない field を参照している
+WHEN その定義を load する
+THEN その定義は拒否される
+AND 拒否の理由は、その参照を書いた Lua のファイル名と行番号とともに報告される
+
+## B-007: スコープ外の値の参照
+
+GIVEN Lua 定義の合成子が、自分の children でも自分の input パラメータでもない値を配線の供給元にしている
+WHEN その定義を load する
+THEN その定義は拒否される
+AND 拒否の理由は、その配線を書いた Lua のファイル名と行番号とともに報告される
+
+## B-008: YAML と同じ誤りに対する診断
+
+GIVEN ある誤りを含む定義が Lua と YAML の両方で書かれている
+WHEN それぞれを検証する
+THEN 同じ診断コード、同じ段、同じ趣旨のメッセージが報告される
+
+## B-009: 編集支援
+
+GIVEN workflows ディレクトリを LuaLS が有効なエディタで開いている
+WHEN workflow 定義を編集する
+THEN ビルダーの引数、node の参照、facet キーに対して補完と型検査が働く
+AND node と facet の参照は定義元へジャンプでき、リネームが全参照へ追従する
+
+## B-010: facet 本文への到達
+
+GIVEN Lua 定義が facet を参照している
+WHEN その参照から定義元へジャンプする
+THEN その facet の本文である md ファイルへ到達できる
+
+## B-011: 生成物が欠けている、または古い場合
+
+GIVEN 型定義スタブまたは facet インデックスが存在しない、あるいは現在の facet と一致していない
+WHEN Lua 定義を load して実行する
+THEN load 結果と実行結果は、生成物が最新である場合と変わらない
+
+## B-012: 評価の決定性
+
+GIVEN 同じ Lua ファイル群が存在する
+WHEN 一覧表示、診断、実行開始など、異なる契機で繰り返し load する
+THEN 常に同じ workflow 定義が得られる
+AND 時刻、環境変数、外部ファイルの読み取りによって結果が変わらない
+
+## B-013: 終了しない定義
+
+GIVEN Lua 定義の評価が終了しない、または過大なメモリを要求する
+WHEN その定義を load する
+THEN 評価は打ち切られ、その定義は拒否される
+AND 打ち切られたことが診断として観測できる
+AND Releash の他の操作は継続できる
+
+## B-014: require の探索範囲
+
+GIVEN Lua 定義が workflows ディレクトリの外にあるファイルを require している
+WHEN その定義を load する
+THEN その定義は拒否される
+AND ディレクトリ外のファイルは読み込まれない
+
+## B-015: アプリ内での Lua 定義の扱い
+
+GIVEN Lua で定義された workflow が存在する
+WHEN 人間が Releash の Automation UI でその workflow を開く
+THEN 定義のソースは表示されない
+AND 定義を編集する手段は外部エディタでの起動だけである
+
+## B-016: Lua 定義の診断の提示
+
+GIVEN Lua で定義された workflow が検証で誤りを含む
+WHEN 人間が Releash の Automation UI を表示する
+THEN その workflow の誤りの件数が一覧で分かる
+AND 詳細では、各誤りがファイル名・行番号とともに一覧できる
+
+## B-017: 既存 YAML 定義の互換性
+
+GIVEN 既存の YAML で定義された workflow が存在する
+WHEN 一覧表示、取得、保存、診断、実行を行う
+THEN 変更前と同じ結果になる
+
+## B-018: builtin workflow の互換性
+
+GIVEN builtin workflow が存在する
+WHEN 一覧表示、取得、実行、編集、削除を試みる
+THEN 変更前と同じく一覧・取得・実行でき、編集と削除は拒否される
+
+## B-019: workflow 名の重複
+
+GIVEN 複数のファイルが同じ workflow 名を宣言している
+WHEN その名前で実行を開始しようとする
+THEN 開始は拒否される
+
+## B-020: ファイル名と workflow 名の不一致
+
+GIVEN Lua 定義が宣言する workflow 名がファイル名と一致しない
+WHEN その定義を load する
+THEN その定義は拒否される
+
+## 要件IDとBehavior IDの対応表
+
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001 |
+| R-002 | B-002 |
+| R-003 | B-003 |
+| R-004 | B-004, B-005 |
+| R-005 | B-006 |
+| R-006 | B-007 |
+| R-007 | B-008 |
+| R-008 | B-009, B-010 |
+| R-009 | B-011 |
+| R-010 | B-012 |
+| R-011 | B-013 |
+| R-012 | B-014 |
+| R-013 | B-015 |
+| R-014 | B-016 |
+| R-015 | B-017 |
+| R-016 | B-018 |
+| R-017 | B-019, B-020 |

--- a/specs/issues-1591/design.md
+++ b/specs/issues-1591/design.md
@@ -1,0 +1,217 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+本設計は [`specs/unified-node-model/decisions.md`](../unified-node-model/decisions.md) の「定義と展開」、[`specs/unified-node-model/syntax.md`](../unified-node-model/syntax.md)、`docs/architecture/DOMAIN.md`、`docs/architecture/GATEWAY.md`、`docs/architecture/INFRASTRUCTURE.md`、[`docs/specs/milestone-82/design.md`](../../docs/specs/milestone-82/design.md) §7（Diagnostic code 表）、および現行実装である `src-tauri/src/domain/workflow/value_objects/definition.rs`、`src-tauri/src/domain/workflow/services/validation.rs`、`src-tauri/src/adaptor/gateway/workflow/diagnostics.rs`、`src-tauri/src/adaptor/gateway/workflow/storage.rs` を根拠とする。
+
+#### 責務 owner
+
+定義言語の意味論（Node の種別・配線・完了・検証規則・名前空間）は workflow domain が所有し続ける。Lua は同じ `WorkflowDefinition` を組み立てる第二の入口であり、規則を持たない。Lua 経路が独自に判定してよいのは「Lua の値として書かれたものが定義の器に収まるか」までで、定義として正しいかは既存の検証層が判定する。
+
+Lua state の生成、標準ライブラリの選択、chunk の評価、メモリと命令の上限、`require` のファイル解決、評価失敗と位置情報の raw な受け渡しは infrastructure が所有する。mlua の型は infrastructure の外へ出さない。
+
+Lua の値と `WorkflowDefinition` の相互変換、Lua 位置と `DiagnosticSpan` の写像、`releash` モジュールと facet インデックスの実体、型スタブの生成は adaptor/gateway が所有する。
+
+名前空間の規則（node 名の一意性、無名エントリの合成内部名 `<合成子名>#<index>`、予約語の禁止）は domain が所有する。現在この規則は `deserialize_node_catalog` / `CatalogNormalizer`（`definition.rs:1104-1140`、`definition.rs:969-1102`）の内部にしか入口がなく serde に結合しているため、serde 非依存の関数として切り出し、YAML 経路（`deserialize_node_catalog`）と Lua 経路の双方がそれを呼ぶ。規則の二重実装を作らない。
+
+#### 主要な変更対象
+
+| Path | 変更の要旨 |
+| --- | --- |
+| `src-tauri/Cargo.toml` | mlua（`lua54` + `vendored` + `serde`）を追加する |
+| `src-tauri/src/infrastructure/lua/`（新規） | Lua state の生成と標準ライブラリの選択、chunk 評価、メモリ・命令上限、`require` のファイル解決、評価失敗と `(source, line)` の raw な返却 |
+| `src-tauri/src/domain/workflow/value_objects/definition.rs` | 名前空間規則を serde 非依存の関数へ切り出し、`deserialize_node_catalog` をその呼び出しへ組み替える |
+| `src-tauri/src/adaptor/gateway/workflow/lua/`（新規） | `releash` / facet インデックスモジュールの実装、ハンドルとその arena、ハンドルのグラフ → `WorkflowDefinition` 構築、node 名 → Lua 位置マップ、型スタブ生成 |
+| `src-tauri/src/adaptor/gateway/workflow/diagnostics.rs` | Lua ソース用の入口を追加し、定義レベル診断へ Lua 位置を付ける。`load_all_workflows`（`:1357`）を `.lua` へ拡張する |
+| `src-tauri/src/adaptor/gateway/workflow/storage.rs` | 定義ファイルの列挙・解決・load を「拡張子ごとの loader」へ一般化する（`:203` / `:246` / `:271` / `:379`）。保存経路は `.yml` のままにする |
+| `src-tauri/src/adaptor/gateway/workflow/runtime_resolver.rs` | name 解決の走査対象に `.lua` を含める（`:57`） |
+| `src-tauri/src/adaptor/gateway/workflow/definition_repository.rs` | `get` の解決を拡張し、`save` / `duplicate` は Lua 定義を対象外として拒否する |
+| `src-tauri/src/adaptor/gateway/workflow/editor_gateway.rs` | `.lua` を外部エディタで開けるようにする（`:72-83`） |
+| `src-tauri/src/usecase/workflow/dto.rs` / `query_service.rs` / `definition.rs` | summary / detail に定義形式を載せ、Lua 定義に対する保存・複製を拒否する |
+| `src-tauri/src/adaptor/controller/command/workflow/definition.rs` | 型スタブ再生成の契機（facet 変更時）を既存 command から呼ぶ |
+| `src/components/panels/automation/WorkflowList.tsx` / `WorkflowDetail.tsx` | 定義形式の表示、Lua のときの Monaco 非表示と診断一覧表示 |
+
+`domain/workflow/services/validation.rs` の検証規則、`routing.rs` の実行時評価、事実ログ、実行木 read model は変更しない。
+
+### Interface
+
+#### Lua 定義言語
+
+`releash` モジュールは次の関数と定数だけを公開する。引数は常に単一の table（`r.next` / `r.retry` / `r.input` / `r.schema` のプリミティブを除く）で、既知キー以外は呼び出し時点で拒否する。`?` は省略可能を表す。
+
+| 呼び出し | 返す型 | 備考 |
+| --- | --- | --- |
+| `r.command{ name?, command, artifact?, input?, completion? }` | `Node` | |
+| `r.session{ name?, provider, model?, permission?, facets?, artifact?, input?, completion? }` | `Node` | `model` / `permission` は provider CLI の語彙をそのまま渡す文字列 |
+| `r.fanout{ name?, children, items?, artifact?, input?, completion? }` | `Node` | |
+| `r.sequence{ name?, entry?, output?, children, artifact?, input?, completion? }` | `Node` | `entry` / `output` は自分の children に含まれる `Node` |
+| `r.child{ node, inputs?, rules?, on_failure? }` | `Child` | children の要素はすべてこの形 |
+| `r.next(node)` | `Rule` | |
+| `r.when{ on, on_true, next }` | `Rule` | `on_true` は `on` が true のときの遷移先（YAML の `then`）、`next` は false のときの遷移先 |
+| `r.switch{ on, cases, next? }` | `Rule` | `cases` は `<値> = Node` のマップ |
+| `r.loop_guard{ max_iterations, on_exhausted }` | `Rule` | `on_exhausted` は遷移先の `Node` |
+| `r.retry(n)` | `OnFailure` | |
+| `r.ignore` | `OnFailure` | 定数 |
+| `r.input(name, contract?)` | `Input` | `contract` は `Schema` |
+| `r.request` | `Source` | 予約供給元 |
+| `r.items` | `Source` | fanout の展開要素 |
+| `r.completion.approval` | `Completion` | 既定（auto）は省略で表す |
+| `r.provider.claude` / `r.provider.codex` | `Provider` | |
+| `r.schema.object{ name?, properties, required? }` | `Schema` | `properties` は `<名前> = Schema` |
+| `r.schema.array{ name?, items }` | `Schema` | `items` は `Schema` |
+| `r.schema.string{ enum? }` / `r.schema.boolean()` / `r.schema.integer()` / `r.schema.number()` | `Schema` | |
+| `r.workflow{ name, description, main }` | `Workflow` | chunk の戻り値がこれでなければ拒否 |
+
+参照の型:
+
+- `Node` は `Source` として使える（その node の Artifact 全体）。`node.<field>` は `Source`（Artifact の field）を返す。field は node が宣言した `artifact` の `Schema` に対して即座に検査される。
+- `Input` は `Source` として使える。
+- `inputs` は `<パラメータ名> = Source` のマップ。供給元に使えるのは、その合成子の children の `Node`、その合成子自身の `Input`、`r.request`、および fanout での `r.items` だけである。
+- `when.on` / `switch.on` / `fanout.items` は `Source`。`items` はリテラル配列（Lua の配列 table）も受ける。
+
+facet インデックスモジュールは `f.instruction.<key>` / `f.policy.<key>` / `f.knowledge.<key>` を公開し、それぞれ kind を持つ `Facet` を返す。`facets = { policy = <Facet>, knowledge = { <Facet>, ... }, instruction = <Facet> }` で、kind の合わない Facet は呼び出し時点で拒否する。`knowledge` は常に配列で書く（YAML の単数受けは Lua へ持ち込まない）。
+
+部品は `Node` を返す Lua 関数として書く。同じ `Node` の値を複数の `r.child{}` へ渡すことは拒否する（B-005）。再利用は関数を再度呼ぶことで行う。
+
+#### 生成物
+
+workflows ディレクトリへ次を出力する。いずれも編集を前提としない。
+
+| Path | 内容 |
+| --- | --- |
+| `.releash/releash.lua` | `---@meta`。`releash` モジュールの `@class` / `@param` / `@return` 型定義。静的なテンプレート |
+| `.releash/facets.lua` | `---@meta`。facet インデックスの型定義。各エントリの docstring に facet の説明と本文 md への `file://` リンクを含む |
+| `.luarc.json` | `workspace.library` に `.releash` を、`runtime.version` に `Lua 5.4` を設定する。**既に存在する場合は生成しない** |
+
+これらは補完のためだけに存在する。実行時に `require("releash")` / `require("facets")` が解決するのは Rust が提供するモジュールであり、生成物が欠けていても古くても load 結果と実行結果は変わらない（R-009、B-011）。
+
+#### Tauri command / DTO
+
+新しい Tauri command、WebSocket message、HTTP route は追加しない。既存 DTO を additive に拡張する。
+
+- `WorkflowSummaryDto` / `WorkflowDto` に `sourceFormat`（`"yaml"` | `"lua"`）を追加する。
+- `get_workflow_source` は Lua 定義に対して呼ばれない（frontend が呼ばない）。呼ばれた場合は Lua ソースをそのまま返す。
+- `save_workflow_source` / `duplicate_workflow` は Lua 定義を対象にしたとき、定義形式を理由に拒否する。判定は Rust 側で行い、frontend はボタンの表示可否に使うだけとする。
+- `open_workflow_in_editor` は `.lua` を解決できるようにする。builtin の拒否は変更しない。
+- `diagnose_all` の戻り形は変更しない。Lua 由来の `DiagnosticItem` も既存の `code` / `severity` / `stage` / `span` / `message` に載る。
+
+#### 内部境界
+
+| Interface | Responsibility |
+| --- | --- |
+| `WorkflowDefinitionLoader`（拡張子ごとの loader） | 定義ファイルのパスを受け、`WorkflowDefinition` と診断を返す。YAML 版と Lua 版が実装する |
+| `LuaEvaluator`（infrastructure） | chunk 名・ソース・workflows ディレクトリ・上限を受け、評価結果か、位置情報付きの失敗を返す |
+
+### Data Model
+
+Lua 側のハンドルはすべて mlua の UserData とし、実体は評価中だけ生きる arena（`Vec` と index）に置く。UserData が持つのは arena の index と種別だけで、定義そのものは持たない。これにより値の同一性（同じ `Node` を2回置いたか）が index の比較で判定でき、Lua 側から定義を書き換える経路も生まれない。
+
+| ハンドル | arena の実体 |
+| --- | --- |
+| `Node` | kind ごとの spec、`name`（明示分のみ）、`artifact`、`input`、`completion`、宣言位置 |
+| `Child` | 対象 `Node` の index、`inputs`、`rules`、`on_failure`、宣言位置 |
+| `Source` | 供給元の種別（node / node.field / input / request / items）と対象 index |
+| `Input` | パラメータ名、`Schema` の index |
+| `Schema` | `SchemaDef` 相当、`name`（明示分のみ） |
+| `Facet` | kind と key |
+| `Workflow` | `name`、`description`、root の `Node` index |
+
+評価が終わった時点で arena から `WorkflowDefinition` を構築し、arena と Lua state は破棄する。`WorkflowDefinition` に Lua 由来の情報は残さない（R-001、B-001）。診断のための `node 名 → (file, line)` マップは構築時に併せて作り、診断の生成が終わるまでだけ保持する。
+
+### Database
+
+該当なし。定義は実行開始時に `WorkflowDefinition` として engine へ渡り、事実ログ・read model・resume の扱いは YAML 由来と同一である。永続スキーマ、event 語彙、projection のいずれも変更しない。
+
+### UI/UX
+
+一覧（`WorkflowList.tsx`）は既存の builtin バッジと同じ位置に定義形式を表示し、診断件数バッジは現行のまま使う。
+
+詳細（`WorkflowDetail.tsx`）は `sourceFormat` で分岐する。`yaml` は現行のまま（Monaco・保存・複製）。`lua` では Monaco を描画せず、次だけを表示する。
+
+- 定義形式と、外部エディタで開くボタン。
+- 診断の一覧。各行は `<ファイル名>:<行番号>`、code、メッセージを持つ。ソース本文は表示しない。
+
+新しい編集手段・保存手段は追加しない。Monaco は Lua に対して一切使わない。
+
+### Algorithm
+
+#### load パイプライン
+
+Lua 定義の load は次の順で行い、いずれかの段でエラーが出たらそこで止める。
+
+1. **評価** — 標準ライブラリを絞った Lua state を作り、`releash` と facet インデックスを Rust のモジュールとして登録し、対象ファイルを chunk 名付きで評価する。chunk の戻り値が `Workflow` でなければ拒否する。
+2. **構築** — arena から `WorkflowDefinition` を組み立てる。node 名の決定と正規化は domain の名前空間規則を使う。
+3. **定義レベル検証** — 既存の `diagnose_workflow_definition(&workflow, None)` を呼び、返った診断に `node 名 → Lua 位置`マップで span を付ける。
+4. **facet 解決と template 参照検証** — 既存の `resolve_and_validate_workflow_facets` を YAML 経路と同じく呼ぶ。
+
+1 と 2 は Lua 経路固有、3 と 4 は YAML 経路と共有する。これにより「同じ誤りには同じ診断」が構造的に成立する（R-007、B-008）。
+
+#### 名前の決定と正規化
+
+- `r.workflow{ main = X }` に渡された `Node` はカタログ名 `main` を持つ。X に `name` が明示されていた場合は拒否する（規約名と別名の二重管理を作らない）。
+- `name` を明示した `Node` はその名前を持つ。予約語（`RESERVED_NODE_NAMES`）は拒否し、重複も拒否する。
+- `name` を持たない `Node` は、それを子に持つ合成子の名前と children 内の index から `<合成子名>#<index>` を得る。YAML の無名エントリと同一規則を同一関数から得る。
+- `Schema` も同じ規則で、明示名か自動生成名を持ち、`schemas` カタログへ登録される。
+
+構築は `main` から children をたどる走査で行い、到達した順にカタログへ並べる。到達しない `Node` はカタログに載せない（Lua では変数に束ねただけの node は定義に現れない）。
+
+#### 診断コードの割当
+
+§7 の code 表は「同系列で追番可、既存 code の意味変更は不可」であり、stage は接頭辞で決まる。Lua 固有の失敗にも新しい接頭辞は作らず、既存系列へ追番する。同じ意味を持つ既存 code は再利用する。
+
+| 事象 | code | 扱い |
+| --- | --- | --- |
+| Lua の構文エラー | `WFS009` | 新規（ParseShape） |
+| 評価の失敗、上限超過による打ち切り、chunk が `Workflow` を返さない | `WFS010` | 新規（ParseShape） |
+| `require` の解決失敗、workflows ディレクトリ外の参照、循環 require | `WFS011` | 新規（ParseShape） |
+| ビルダー引数の未知キー・型不一致・必須キー欠落 | `WFS002` | 既存（unknown field / unknown variant）を再利用 |
+| workflow 名がファイル名と一致しない、node 名の重複・予約語 | `WFS006` | 既存（名前重複 / 名前形式違反）を再利用 |
+| 同一 `Node` を複数の children へ置いた | `WFC007` | 既存（children の重複参照）を再利用 |
+| スコープ外の供給元を配線した | `WFR007` | 既存（未解決の input 供給元）を再利用 |
+| 存在しない facet、artifact 未宣言 node の field 参照、`main` 欠落 | `WFR900` / `WFR003` / `WFR006` | 既存をそのまま |
+
+`WFS009` / `WFS010` / `WFS011` の span は Lua の `(file, line)`、`WFS002` の span はビルダー呼び出し位置、既存 code の span は node の宣言位置とする。
+
+#### 評価の閉じ込めと有界化
+
+- 標準ライブラリは `table` / `string` / `math` のみを読み込む。`io` / `os` / `package` / `debug` は読み込まない。加えて base の `load` / `loadstring` / `dofile` / `loadfile` は評価前に `nil` を代入して落とす。これにより評価結果が時刻・環境変数・外部ファイルに依存しなくなる（R-010、B-012）。
+- `require` は Rust 実装をグローバルへ置く。モジュール名をドット区切りとして workflows ディレクトリ基準で `.lua` へ解決し、正規化した実パスがディレクトリ配下でなければ拒否する。同一評価内でモジュールを一度だけ評価してキャッシュし、循環 require は検出して拒否する（R-012、B-014）。
+- メモリ上限を 64 MiB、命令上限を 5,000 万とする。いずれも定義の評価を一度きり行う用途に対して十分に大きく、終了しない定義をアプリの寿命内で確実に打ち切る。超過は `WFS010` の診断として観測でき、他の workflow の load・実行は影響を受けない（R-011、B-013）。
+- 評価はすべて既存の `spawn_blocking` の内側で完結させ、Lua state を await をまたいで保持しない。
+
+#### 生成物の更新
+
+型スタブと facet インデックススタブは、アプリ起動時と、facet の作成・削除・リネームの成功時に再生成する。生成は冪等とし、既存ファイルと内容が一致する場合は書き込まない。生成に失敗しても load・実行・診断は継続する（生成物は補完のためだけに存在するため）。
+
+`.luarc.json` は存在しない場合だけ生成する。既存ファイルがあれば内容を検査も変更もしない。
+
+### Infra
+
+mlua を `lua54` + `vendored` + `serde` で追加する。`vendored` は Lua 5.4 のソースを同梱してビルドするため C コンパイラを要求するが、Tauri のビルドで既に満たされている。`send` feature は使わない（Lua state は `spawn_blocking` の内側で閉じるため `Send` を必要としない）。
+
+新しいプロセス・サービス・データベース・デプロイ構成は追加しない。
+
+## Alternatives Considered
+
+- **Lua の値を serde 経由で YAML 相当の中間表現へ落とし、既存の `Deserialize` に流す案**: 実装は薄いが、node の値参照（同一性）を中間表現で表現できず、エラー位置もビルダー呼び出し行にならない。確定した「値参照のみ」と「呼び出し時点での検証」を満たせないため採らない。
+- **文字列名による参照**: 実装は最も薄いが、LuaLS のリネーム・定義ジャンプ・未定義検出が効かず、ISSUE が掲げる目的（認知支援）を満たさないため採らない。
+- **`WFL` などの新しい code 接頭辞**: §7 の「同系列で追番可」と「stage は接頭辞で決まる」規約に反し、同じ誤りに YAML と Lua で別 code が付く。既存系列への追番と既存 code の再利用を採る。
+- **facet インデックスを実ファイルとして生成し `require` で読む案**: 生成物が実行時の正本の一部になり、生成物の欠落・陳腐化が load を壊す。R-009 に反するため採らない。
+- **`when` の true 側遷移先に `["then"]` を使う案**: YAML の遷移先キーと一致するが、Lua の予約語のため角括弧記法が必須になり、他のキーと書き方が揃わない。`on_true` を採る。
+- **アプリ内 Monaco での Lua 編集**: 補完・定義ジャンプが効かない場所で Lua を書かせることになり、Lua を採用した目的と衝突する。Releash では Monaco を使わない方針でもあるため採らない。
+- **children の要素に素の `Node` も許す案**: 直列の記述は短くなるが、子の書き方が2通りになる。「同じ意味に複数の書き方を作らない」方針により `r.child{}` の一形式に統一する。
+- **部品を table として返し複製 API を用意する案**: `require` のキャッシュにより同じ値が複数箇所に現れるため、暗黙または明示の複製という Lua にない概念が要る。関数として返す形は Lua の通常の書き方で同じ目的を満たすため採らない。
+
+## Cross-cutting concerns
+
+- **起動時コスト**: 起動時にスタブ生成と、既存の診断走査に `.lua` の評価が加わる。評価は定義ごとに一度きりで、上限により最悪時間も有界である。生成は内容一致時に書き込まない。
+- **命名の衝突**: 同じ workflow 名を複数ファイルが宣言した状態は、既存の `resolve_workflow_by_name` が `WFS006` で拒否する経路をそのまま使う（`.yml` と `.lua` の組み合わせを含む）。
+- **builtin**: builtin は YAML のまま同梱し、Lua 経路を通らない。builtin 名との重複拒否も現行のまま。
+
+## Risks
+
+- **自動生成名の可読性**: 名前を明示しない node は `<合成子名>#<index>` として実行木 UI と診断に現れる。YAML の無名エントリと同じ挙動だが、Lua では無名で書ける場面が増えるため、読みにくい名前が出やすくなる。型スタブの docstring で `name` の明示を促す以上の強制は行わない。
+- **定義ファイルの権限**: Lua 定義はアプリと同じプロセスで評価される。標準ライブラリの制限と `require` の閉じ込めで到達範囲は絞るが、Lua で任意の計算ができること自体は前提である（`command` node が任意のシェルを実行できるのと同じ地平にある）。
+- **ビルド要件**: `vendored` により C コンパイラがビルド要件に加わる。CI と開発環境では既に満たされているが、ビルド時間とバイナリサイズがわずかに増える。

--- a/specs/issues-1591/design.md
+++ b/specs/issues-1591/design.md
@@ -73,7 +73,7 @@ Lua の値と `WorkflowDefinition` の相互変換、Lua 位置と `DiagnosticSp
 
 facet インデックスモジュールは `f.instruction.<key>` / `f.policy.<key>` / `f.knowledge.<key>` を公開し、それぞれ kind を持つ `Facet` を返す。`facets = { policy = <Facet>, knowledge = { <Facet>, ... }, instruction = <Facet> }` で、kind の合わない Facet は呼び出し時点で拒否する。`knowledge` は常に配列で書く（YAML の単数受けは Lua へ持ち込まない）。
 
-部品は `Node` を返す Lua 関数として書く。同じ `Node` の値を複数の `r.child{}` へ渡すことは拒否する（B-005）。再利用は関数を再度呼ぶことで行う。
+部品は `sequence` を返す Lua 関数として書く。sequence を返すことで、実行木に子 sequence として現れ、折り畳みと `completion: approval` の単位になる（B-003）。engine から見れば部品も通常の node であり、部品由来かどうかを識別する情報は定義に残らないため、この規約は Lua 側の書き方として守る（葉を直接返す関数を engine が拒否することはできない）。同じ `Node` の値を複数の `r.child{}` へ渡すことは拒否する（B-005）。再利用は関数を再度呼ぶことで行う。
 
 #### 生成物
 

--- a/specs/issues-1591/requirements.md
+++ b/specs/issues-1591/requirements.md
@@ -1,0 +1,126 @@
+# Context
+
+- 要求の正本: [Issue #1591](https://github.com/siro33950/releash/issues/1591)「[統一 Node モデル] Lua による workflow 定義」（OPEN・milestone 86 の wave 4・comment なし）。
+- 設計の正本: [`specs/unified-node-model/decisions.md`](../unified-node-model/decisions.md) の §定義と展開、および [`specs/unified-node-model/syntax.md`](../unified-node-model/syntax.md)（Lua が組み立てる定義は、この構文が表すものと同一の `WorkflowDefinition` である）。
+- 補助資料:
+  - [milestone 86](https://github.com/siro33950/releash/milestone/86)「統一 Node モデル」— wave 順序（本 Issue は wave 4。#1465 / #1466 / #1467 とは依存なし、#1468 より前）。
+  - [#1463](https://github.com/siro33950/releash/issues/1463)（CLOSED・commit `09c27cbbc`）— sequence の再帰実行。部品を sequence として入れ子にできることが Lua 側の合成の土台であり、本 Issue の前提。
+  - [#1464](https://github.com/siro33950/releash/issues/1464)（CLOSED・不採用）— 定義を跨ぐ参照（`ref`）は持たない。部品化と再利用は定義言語の外で行う。
+  - [#1468](https://github.com/siro33950/releash/issues/1468)（OPEN・wave 8）— 文法の正本化。`docs/workflow-yaml-syntax.md` への Lua の記述追加は本 Issue ではなく #1468 が担う。
+  - [`docs/specs/milestone-82/design.md`](../../docs/specs/milestone-82/design.md) §7 — Diagnostic code 表。「この表が唯一の正。同系列で追番可、既存 code の意味変更は不可」であり、stage は code 接頭辞（WFS→ParseShape / WFR→Resolve / WFT→Typecheck / WFC→ControlFlow）で決まる。
+- 確定済みの背景と制約（後続の Behavior・Design が従う）:
+  - 型は厳密に定め、同じ意味に複数の書き方を作らない。冗長でも書き方が一つに定まることを優先する。
+  - `.lua` は load 時に一度だけ評価され、既存の `WorkflowDefinition` を返す。実行時に Lua は走らない。engine が受け取るものは YAML 由来と完全に同一である。
+  - 合成は `require` と sequence の入れ子で行う。engine には常に単一の `WorkflowDefinition` を渡し、合成子境界を engine に持ち込まない（loop_guard 検知・resume・diagnostics は単一定義内に閉じたままにする）。
+  - 目的は表現力の拡大ではなく、定義を書く・読むときの認知支援（型・補完・定義ジャンプ・リネーム）である。型検査の正本は既存の検証層のままで、Lua 側の型注釈は補完・定義ジャンプのためにある。
+  - node・facet・Artifact field の参照は値参照で書く。文字列名で参照する経路は設けない。
+  - 部品は sequence を返す関数として書く。同一の値を複数の children へ置く記述は拒否する。
+  - 部品の Interface（`input` パラメータ）と配線（`inputs`）は明示する。合成子のスコープ外の値を内側から参照する記述は拒否する（engine の配線規則は「供給元は合成子のスコープに閉じる」）。
+  - children エントリと rules はコンストラクタ関数で書く。
+  - facet は生成された定数テーブル経由で参照する。
+  - 実行時に使われるモジュール（`releash` と facet インデックス）は Rust が提供する。workflows ディレクトリへ出力する生成物は LuaLS 用の型スタブだけであり、実行時の正本にしない。
+  - Lua 定義は Releash のアプリ内でソース表示・編集の対象にしない。編集は外部エディタに委ねる（Releash では Monaco Editor を使わない）。
+  - builtin workflow は YAML のまま維持する。
+  - 品質ゲートは本リポジトリの既定（`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test`、`pnpm lint` / `pnpm test` / `pnpm build`、`pnpm test:integration`）。
+
+# Outcome
+
+- 対象者: Releash で workflow を定義・保守する開発者。
+- 現在の問題: 定義言語が YAML 単一で、定義を跨いだ部品化・再利用の手段が無い（`ref` は #1464 で不採用が確定している）。定義を書くときの支援も無く、node 名・facet キー・Contract 名・Artifact field はすべて生の文字列であるため、綴りの誤りや存在しない参照は書いている最中には分からず、保存・load 時の Diagnostic まで持ち越される。同じ手順を複数の workflow で使う手段が無いため、定義は肥大した単一ファイルとして重複する。
+- 変更後に実現する状態: workflow を `.lua` でも定義できる。部品は `require` で合成され、engine が受け取るのは YAML 由来と完全に同一の単一 `WorkflowDefinition` である。workflows ディレクトリを VSCode + LuaLS で開けば、ビルダー引数・node 参照・facet キーに対して補完・型検査・定義ジャンプ・リネームが効き、Releash 固有の誤りは load 時に Lua のファイル名・行番号付きで分かる。
+
+# Current Behavior
+
+commit `6e5c47022`（branch `feat/issues/1591`）で、以下をコード調査により確認した。調査範囲は workflow 定義の load・検証・保存・編集経路（`src-tauri/src/adaptor/gateway/workflow/`）、定義の値オブジェクトと検証規則（`src-tauri/src/domain/workflow/`）、定義を扱う frontend（`src/components/panels/automation/`）、および依存関係（`src-tauri/Cargo.toml`）である。
+
+## 定義の入口は `.yml` だけである
+
+workflow 定義を読む経路は5つあり、いずれも拡張子 `yml` を直接判定する。
+
+- 実行開始時の name 解決: `resolve_workflow_by_name` が workflows ディレクトリを走査し、`yml` のみを対象に全件 load してから `WorkflowDefinition.name` で一意解決する（`runtime_resolver.rs:57`）。複数ファイルが同じ name を宣言した状態は WFS006 で拒否される（`runtime_resolver.rs:33-38`）。
+- 一覧: `storage::list_workflows` → `list_yml_summaries` が `yml` のみを列挙する（`storage.rs:271`、`storage.rs:246`）。summary の name はファイル stem で上書きされる（`storage.rs:255-259`）。
+- 単体取得: `WorkflowDefinitionFileRepository::get` が `resolve_workflow_path`（`<name>.yml` の存在確認。`storage.rs:379`）→ `storage::load_workflow`（`storage.rs:203`）を呼び、見つからなければ builtin にフォールバックする（`definition_repository.rs:128-141`）。
+- 全体診断: `diagnostics::load_all_workflows` が `yml` のみを走査する（`diagnostics.rs:1357`、`diagnostics.rs:1366`）。
+- 外部エディタ起動: `resolve_workflow_editor_path` が `resolve_workflow_path` に委譲するため、`<name>.yml` しか開けない（`editor_gateway.rs:72-83`）。
+
+保存経路も `<name>.yml` への書き込みに固定されている（`storage.rs:118-137`、`storage.rs:172-194`）。
+
+## 定義レベルの検証は YAML に依存していない
+
+`diagnose_workflow_source` は3段で構成される（`diagnostics.rs:150-207`）。
+
+1. `YamlSpanMap::parse` で YAML の位置情報を作る（`span_map.rs`）。
+2. raw JSON 値に対する形の診断（`parse_shape_diagnostics`）。
+3. `serde_saphyr` で `WorkflowDefinition` へ deserialize し、`diagnose_workflow_definition(&workflow, Some(&span_map))` を呼ぶ。
+
+このうち 3 の `diagnose_workflow_definition` は `span_map: Option<&YamlSpanMap>` を取り（`diagnostics.rs:210-212`）、domain の検証規則（`domain/workflow/services/validation.rs`）を呼ぶ。すなわち定義レベルの検証（WFR / WFT / WFC 系）は YAML 表現に依存しておらず、位置情報は付加的である。facet 参照の解決と template 参照検証は `resolve_and_validate_workflow_facets` が別途行う（`storage.rs:336-352`）。
+
+## children 4形式の正規化は serde の Deserialize 実装に埋まっている
+
+インライン宣言・無名エントリをカタログへ登録し、無名を `<合成子名>#<index>` へ命名する正規化は `CatalogNormalizer` が担うが、その入口は `deserialize_node_catalog`（`definition.rs:1104-1140`）であり、`WorkflowDefinition` の `nodes` フィールドの `deserialize_with` としてのみ到達できる（`definition.rs:53-57`）。名前重複の検出（`definition.rs:1121-1126`、`definition.rs:1213-1220`）、kind ブロックがちょうど1つであることの検査（`definition.rs:1062-1068`）も同じ経路にある。
+
+## 定義を跨いだ部品化・再利用の手段が無い
+
+定義内での部品化は #1463 の sequence 再帰実行で可能になっている（`SequenceSpec` の children に sequence を置ける。`definition.rs:298-307`）。一方、別の `WorkflowDefinition` を参照する構文は存在せず、`ref` は #1464 で不採用が確定している。したがって、複数の workflow で同じ手順を使う手段は「定義をコピーする」以外に無い。
+
+## node・facet・Artifact field の参照はすべて生の文字列である
+
+- children エントリの参照名は `String`（`definition.rs:436-446`）、inputs の供給元は `InputSourceRef(String)`（`definition.rs:513-523`）で、`<node>.<field>` を `.` で分解して解釈する（`definition.rs:525-532`）。
+- rules の遷移先・`when.on` / `switch.on` / `switch.cases` の値もすべて `String`（`definition.rs:1274-1291`）。
+- facet 参照は `FacetRefs { policy: Option<String>, knowledge: Vec<String>, instruction: Option<String> }`（`definition.rs:216-236`）。未定義 facet は WFR900 で報告される。
+- これらの誤りは編集中には検出されず、保存・load・診断の実行時にはじめて Diagnostic になる。
+
+## 定義の編集はアプリ内の Monaco で行う
+
+`WorkflowDetail.tsx` が Monaco Editor に YAML ソースを載せ（`WorkflowDetail.tsx:137-157`、`:246-262`）、Diagnostic を marker として重ね（`:290-312`）、`save_workflow_source` で保存する。Monaco を使っているのは非テストコードではこの1ファイルだけである。
+
+## Lua ランタイムは存在しない
+
+`src-tauri/Cargo.toml` に Lua 関連の依存は無い。YAML の deserialize には `serde-saphyr` を使っている。
+
+# Scope / Non-goals
+
+## Scope
+
+- workflow 定義の入口として `.lua` を追加し、load 時の一度きりの評価で `WorkflowDefinition` を得ること。
+- `releash` モジュール（`session` / `command` / `fanout` / `sequence` / `workflow`、children・rules のコンストラクタ、schema ビルダー、input パラメータ）を Rust 関数として公開し、その呼び出し時点で引数を検証すること。
+- `require` と sequence の入れ子による合成、および部品を関数として再利用する規則。
+- Lua 由来の失敗を、Lua のファイル名・行番号付きで既存の Diagnostic 体系に載せること。
+- LuaLS 用の型定義スタブと facet インデックスの生成、および VSCode で補完・定義ジャンプ・リネームが効く状態にすること。
+- Lua workflow のアプリ内での扱い（一覧への表示、診断の提示、外部エディタでの起動）。
+- Lua 定義の評価の決定性・有界性・探索範囲の制限。
+
+## Non-goals
+
+- YAML 入口の廃止。YAML と Lua は併存する。
+- builtin workflow の Lua 化。
+- 文法ドキュメントの正本化（`docs/workflow-yaml-syntax.md` ほかへの Lua 記述の追加）。#1468 が所有する。
+- Monaco Editor の除去、および YAML 編集 UI の廃止。別 Issue が所有する。
+- `worktree: shared | isolated` の受理・解禁、および delegate（milestone #85）。
+- 実行時（load 後）の Lua 評価、および実行中の定義の再評価規則の変更。
+- 既存の Diagnostic code の意味変更、および YAML 経路の検証規則の変更。
+- 実行木 UI の変更。
+
+# Requirements
+
+- R-001: `.lua` で定義した workflow は、同等の YAML 定義と完全に同一に load・実行・観測・永続化・再開される。実行木・事実ログ・read model に「Lua 由来である」という区別が現れない。
+- R-002: `.lua` の評価は load 時の一度だけで、workflow の実行中に Lua は走らない。
+- R-003: 部品は `require` で合成でき、engine が受け取るのは常に単一の `WorkflowDefinition` である。定義を跨ぐ参照は存在しない。
+- R-004: 部品は関数として再利用でき、同じ部品を同一定義内で複数回使ったとき、それぞれが独立した node 群になる。同一の値を複数の children へ置く記述は拒否される。
+- R-005: node・facet・Artifact field の参照は値で書き、存在しない参照・型の合わない参照は、その記述を書いた Lua のファイル名と行番号付きで報告される。
+- R-006: 部品の Interface（`input`）と配線（`inputs`）は定義に明示され、合成子のスコープ外の値を内側から参照する記述は拒否される。
+- R-007: Lua 定義に対する検証結果は、同じ誤りを YAML で書いた場合と同じ Diagnostic（code・stage・message）になる。Lua 固有の失敗に与える code は既存の code 表の体系に従う。
+- R-008: workflows ディレクトリを VSCode + LuaLS で開くと、`releash` モジュールの補完と引数の型検査、facet キーの補完・定義ジャンプ・リネームが効く。facet の定義ジャンプの到達先から、その facet 本文の md へ到達できる。
+- R-009: 生成物（型スタブ・facet インデックス）は補完のためだけに存在し、生成物が欠けていても古くても、workflow の load 結果と実行結果は変わらない。
+- R-010: 同じ `.lua` ファイル群からは常に同じ `WorkflowDefinition` が得られる。評価結果が時刻・環境変数・外部 I/O・実行順に依存しない。
+- R-011: `.lua` の評価は有界であり、終了しない定義や過大なメモリを要求する定義がアプリの動作を止めない。打ち切りは Diagnostic として観測できる。
+- R-012: `require` の解決は workflows ディレクトリ配下に閉じ、その外のファイルは読み込めない。
+- R-013: Lua で定義された workflow は、Releash のアプリ内でソースの表示・編集の対象にならない。編集手段は外部エディタでの起動だけである。
+- R-014: Lua で定義された workflow の検証結果は、アプリ内で件数と、ファイル名・行番号付きのメッセージとして観測できる。
+- R-015: 互換性要件 — 既存の YAML 定義は、変更前と同じく一覧・取得・保存・診断・実行できる。
+- R-016: 互換性要件 — builtin workflow は変更前と同じく YAML として同梱され、編集不可・削除不可・名前の重複拒否の扱いも変わらない。
+- R-017: 互換性要件 — 同じ workflow name を複数のファイル（`.yml` と `.lua` を含む）が宣言した状態は、変更前と同じく拒否される。
+
+# Assumptions / Open Questions
+
+なし。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -507,6 +507,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +2768,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lua-src"
+version = "550.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c110c2fa33f34e0de05448e1f3eb2e0631e7a69e2d8ae1586cffc9fc9f9949"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.7.2+b925b3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "920cf654b23d217c550ceea57c32cd2a413ea27b6d47ed77b5ee0cf655adefa6"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,6 +2850,38 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mlua"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad72ffa037cf5970c9860674f32f703fda25d86cf217475fe7a79c5f9961bcaa"
+dependencies = [
+ "bstr",
+ "either",
+ "erased-serde",
+ "libc",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92136787b906d4e55cfe96cd6c62e010bb1a56889d0d6cf83eb016dbad07576b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3377,6 +3438,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -4027,6 +4097,7 @@ dependencies = [
  "hex",
  "libc",
  "log",
+ "mlua",
  "notify-debouncer-mini",
  "objc2",
  "objc2-app-kit",
@@ -4474,6 +4545,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -6319,6 +6400,15 @@ dependencies = [
  "thiserror 2.0.20",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "which"
+version = "8.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = "2"
 regex = "1"
 toml = "1.1"
 serde-saphyr = "1.0"
+mlua = { version = "0.12", features = ["lua54", "vendored", "serde"] }
 rand = "0.10"
 # issues-1499 T-02: bundled SQLite (>= 3.51.3) includes the WAL-reset
 # corruption fix required by the permanent local event store.

--- a/src-tauri/src/adaptor/controller/command/workflow/definition.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/definition.rs
@@ -1,5 +1,7 @@
 use crate::adaptor::controller::state::AppState;
-use crate::usecase::workflow::dto::{workflow_to_dto, WorkflowDto, WorkflowSummaryDto};
+use crate::usecase::workflow::dto::{
+    workflow_to_dto, workflow_to_dto_with_source_format, WorkflowDto, WorkflowSummaryDto,
+};
 use crate::usecase::workflow::ports::WorkflowSourceSaveError;
 use serde::Serialize;
 
@@ -35,7 +37,12 @@ pub async fn get_workflow(
             .get_workflow(&name)
             .map_err(|e| e.to_string())?
             .ok_or_else(|| format!("ワークフロー '{name}' が見つかりません"))
-            .map(|workflow| workflow_to_dto(&workflow))
+            .and_then(|workflow| {
+                query
+                    .get_workflow_source_format(&name)
+                    .map(|format| workflow_to_dto_with_source_format(&workflow, format))
+                    .map_err(|e| e.to_string())
+            })
     })
     .await
     .map_err(|e| format!("task join error: {e}"))?

--- a/src-tauri/src/adaptor/gateway/workflow/builtin.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin.rs
@@ -220,6 +220,7 @@ pub fn list_builtin_workflows() -> Vec<Summary> {
             description: e.description.to_string(),
             builtin: true,
             is_running: false,
+            source_format: crate::domain::workflow::WorkflowSourceFormat::Yaml,
         })
         .collect()
 }

--- a/src-tauri/src/adaptor/gateway/workflow/definition_repository.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/definition_repository.rs
@@ -82,11 +82,20 @@ fn validate_and_prepare_save(
                 "ビルトインワークフローは編集できません",
             ));
         }
+        if workflows_dir.join(format!("{original_name}.lua")).exists() {
+            return Err(WorkflowError::validation(
+                "Lua workflow は保存できません。外部エディタで編集してください",
+            ));
+        }
     }
 
     let is_new = original_name.is_none();
     let is_rename = original_name.is_some_and(|original_name| original_name != name);
-    if (is_new || is_rename) && workflows_dir.join(format!("{name}.yml")).exists() {
+    if (is_new || is_rename)
+        && ["yml", "lua"]
+            .iter()
+            .any(|extension| workflows_dir.join(format!("{name}.{extension}")).exists())
+    {
         return Err(WorkflowError::validation(format!(
             "ワークフロー '{name}' は既に存在します"
         )));
@@ -119,11 +128,12 @@ fn remove_renamed_workflow_file_after_success(
 
 impl WorkflowDefinitionRepository for WorkflowDefinitionFileRepository {
     fn list(&self, running_names: &[String]) -> Result<Vec<WorkflowSummary>, WorkflowError> {
-        let mut summaries: Vec<_> = storage::list_workflows(&self.workflows_dir)
-            .map_err(|e| WorkflowError::external(e.to_string()))?
-            .into_iter()
-            .map(mapper::schema_workflow_summary_to_domain)
-            .collect();
+        let mut summaries: Vec<_> =
+            storage::list_workflows_with_facets(&self.workflows_dir, &self.facets_base_dir)
+                .map_err(|e| WorkflowError::external(e.to_string()))?
+                .into_iter()
+                .map(mapper::schema_workflow_summary_to_domain)
+                .collect();
         for summary in &mut summaries {
             summary.is_running = running_names.contains(&summary.name);
         }
@@ -174,11 +184,29 @@ impl WorkflowDefinitionSourceGateway for WorkflowDefinitionFileSourceGateway {
         }
     }
 
+    fn source_format(
+        &self,
+        file_stem: &str,
+    ) -> Result<crate::domain::workflow::WorkflowSourceFormat, WorkflowError> {
+        match storage::resolve_workflow_path(&self.workflows_dir, file_stem) {
+            Ok(path) => storage::workflow_source_format(&path).ok_or_else(|| {
+                WorkflowError::external("workflow source has an unsupported extension")
+            }),
+            Err(storage::StorageError::NotFound { .. })
+                if builtin::is_builtin_workflow(file_stem) =>
+            {
+                Ok(crate::domain::workflow::WorkflowSourceFormat::Yaml)
+            }
+            Err(error) => Err(WorkflowError::external(error.to_string())),
+        }
+    }
+
     fn save_source(
         &self,
         source: &str,
         original_name: Option<&str>,
     ) -> Result<WorkflowDefinition, WorkflowError> {
+        reject_lua_source_save(self, original_name)?;
         let workflow = storage::parse_workflow_source(source, &self.facets_base_dir)
             .map_err(|e| WorkflowError::external(e.to_string()))?;
         let plan = validate_and_prepare_save(&self.workflows_dir, &workflow.name, original_name)?;
@@ -194,6 +222,7 @@ impl WorkflowDefinitionSourceGateway for WorkflowDefinitionFileSourceGateway {
         source: &str,
         original_name: Option<&str>,
     ) -> Result<WorkflowDefinition, WorkflowSourceSaveError> {
+        reject_lua_source_save(self, original_name).map_err(WorkflowSourceSaveError::Workflow)?;
         let workflow = storage::parse_workflow_source(source, &self.facets_base_dir)
             .map_err(storage_error_to_source_save_error)?;
         let plan = validate_and_prepare_save(&self.workflows_dir, &workflow.name, original_name)
@@ -205,6 +234,22 @@ impl WorkflowDefinitionSourceGateway for WorkflowDefinitionFileSourceGateway {
             .map_err(WorkflowSourceSaveError::Workflow)?;
         mapper::schema_workflow_to_domain(saved).map_err(WorkflowSourceSaveError::Workflow)
     }
+}
+
+fn reject_lua_source_save(
+    gateway: &WorkflowDefinitionFileSourceGateway,
+    original_name: Option<&str>,
+) -> Result<(), WorkflowError> {
+    if let Some(original_name) = original_name {
+        if gateway.source_format(original_name)?
+            == crate::domain::workflow::WorkflowSourceFormat::Lua
+        {
+            return Err(WorkflowError::validation(
+                "Lua workflow は保存できません。外部エディタで編集してください",
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn storage_error_to_source_save_error(error: storage::StorageError) -> WorkflowSourceSaveError {
@@ -441,5 +486,40 @@ nodes:
             .as_str()
             .is_some_and(|message| message.contains("missing-name")));
         assert!(!workflows.path().join("missing-knowledge.yml").exists());
+    }
+
+    #[test]
+    fn source_gateway_reads_lua_verbatim_and_rejects_save() {
+        let workflows = TempDir::new().unwrap();
+        let facets = TempDir::new().unwrap();
+        let gateway = WorkflowDefinitionFileSourceGateway::new(workflows.path(), facets.path());
+        let source = r#"
+local r = require("releash")
+return r.workflow{
+  name = "lua-source", description = "Lua",
+  main = r.command{ command = "true" },
+}
+"#;
+        fs::write(workflows.path().join("lua-source.lua"), source).unwrap();
+
+        assert_eq!(
+            gateway.get_source("lua-source").unwrap().as_deref(),
+            Some(source)
+        );
+        assert_eq!(
+            gateway.source_format("lua-source").unwrap(),
+            crate::domain::workflow::WorkflowSourceFormat::Lua
+        );
+        let error = gateway
+            .save_source(
+                "name: replacement\ndescription: replacement\nnodes: {}\n",
+                Some("lua-source"),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("Lua workflow"));
+        assert_eq!(
+            fs::read_to_string(workflows.path().join("lua-source.lua")).unwrap(),
+            source
+        );
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -1,6 +1,7 @@
 use crate::adaptor::gateway::workflow::builtin;
 use crate::adaptor::gateway::workflow::domain_mapping::workflow_definition_to_domain;
 use crate::adaptor::gateway::workflow::facet::{self, FacetKind};
+use crate::adaptor::gateway::workflow::lua;
 #[cfg(test)]
 use crate::adaptor::gateway::workflow::schema::NodeDefinition;
 use crate::adaptor::gateway::workflow::schema::{NodeKind, Rule, WorkflowDefinitionYaml};
@@ -217,6 +218,123 @@ pub(crate) fn diagnose_workflow_definition(
         items.push(validation_error_to_diagnostic(wf, &error, span_map));
     }
     items
+}
+
+pub(crate) fn diagnose_lua_workflow_source(
+    source_name: &str,
+    source: &str,
+    workflows_dir: &Path,
+    facets_base_dir: &Path,
+    workflow_name_hint: Option<&str>,
+) -> WorkflowSourceDiagnostics {
+    let catalog = match lua::facet_catalog(facets_base_dir) {
+        Ok(catalog) => catalog,
+        Err(error) => {
+            return WorkflowSourceDiagnostics {
+                workflow: None,
+                diagnostics: vec![DiagnosticItem::new(
+                    "WFS010",
+                    Severity::Error,
+                    DiagnosticStage::ParseShape,
+                    Some(lua_span(source_name, 1)),
+                    format!("facet index could not be loaded: {error}"),
+                )
+                .workflow(workflow_name_hint.unwrap_or("<unknown>"))],
+            };
+        }
+    };
+    let loaded = match lua::load_lua_workflow(source_name, source, workflows_dir, catalog) {
+        Ok(loaded) => loaded,
+        Err(error) => {
+            let stage = diagnostic_stage_for_code(&error.code);
+            let span = error
+                .location
+                .map(|location| lua_location_span(&location, workflows_dir));
+            return WorkflowSourceDiagnostics {
+                workflow: None,
+                diagnostics: vec![DiagnosticItem::new(
+                    error.code,
+                    Severity::Error,
+                    stage,
+                    span,
+                    error.message,
+                )
+                .workflow(workflow_name_hint.unwrap_or("<unknown>"))],
+            };
+        }
+    };
+    let mut diagnostics = diagnose_workflow_definition(&loaded.workflow, None);
+    for item in &mut diagnostics {
+        let location = item
+            .node_name
+            .as_ref()
+            .and_then(|node| loaded.node_locations.get(node))
+            .or_else(|| loaded.node_locations.get("main"));
+        if let Some(location) = location {
+            item.span = Some(lua_location_span(location, workflows_dir));
+        }
+    }
+    if workflow_name_hint.is_some_and(|name| name != loaded.workflow.name) {
+        let location = loaded.node_locations.get("main");
+        diagnostics.push(
+            DiagnosticItem::new(
+                "WFS006",
+                Severity::Error,
+                DiagnosticStage::ParseShape,
+                location.map(|location| lua_location_span(location, workflows_dir)),
+                format!(
+                    "Lua workflow name '{}' must match file name '{}'",
+                    loaded.workflow.name,
+                    workflow_name_hint.unwrap_or("<unknown>")
+                ),
+            )
+            .workflow(workflow_name_hint.unwrap_or("<unknown>"))
+            .field("name"),
+        );
+    }
+    WorkflowSourceDiagnostics {
+        workflow: Some(loaded.workflow),
+        diagnostics,
+    }
+}
+
+fn lua_span(source: &str, line: usize) -> DiagnosticSpan {
+    DiagnosticSpan {
+        source: Some(source.to_string()),
+        start_line: line,
+        start_col: 1,
+        end_line: line,
+        end_col: 2,
+    }
+}
+
+fn lua_location_span(
+    location: &crate::infrastructure::lua::LuaSourceLocation,
+    workflows_dir: &Path,
+) -> DiagnosticSpan {
+    let source = Path::new(&location.source);
+    let display_source = if source.is_absolute() {
+        std::fs::canonicalize(workflows_dir)
+            .ok()
+            .and_then(|base| source.strip_prefix(base).ok())
+            .map(|relative| relative.to_string_lossy().into_owned())
+            .unwrap_or_else(|| location.source.clone())
+    } else {
+        location.source.clone()
+    };
+    lua_span(&display_source, location.line)
+}
+
+fn diagnostic_stage_for_code(code: &str) -> DiagnosticStage {
+    if code.starts_with("WFR") || code.starts_with("FAC") {
+        DiagnosticStage::Resolve
+    } else if code.starts_with("WFT") {
+        DiagnosticStage::Typecheck
+    } else if code.starts_with("WFC") {
+        DiagnosticStage::ControlFlow
+    } else {
+        DiagnosticStage::ParseShape
+    }
 }
 
 fn normalize_invalid_source_workflow_name(
@@ -1363,12 +1481,17 @@ fn load_all_workflows(dir: &Path, facets_base_dir: &Path) -> Vec<NamedWorkflowDi
         if let Ok(entries) = std::fs::read_dir(dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("yml") {
+                if super::storage::workflow_source_format(&path).is_some() {
                     if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
                         let name = stem.to_string();
                         let result = match std::fs::read_to_string(&path) {
                             Ok(content) => {
-                                let diagnosis = diagnose_workflow_source(&content, Some(&name));
+                                let diagnosis = super::storage::diagnose_workflow_file(
+                                    &path,
+                                    &content,
+                                    dir,
+                                    facets_base_dir,
+                                );
                                 if let Some(workflow) = diagnosis.workflow {
                                     let _ =
                                         facet::resolve_workflow_facets(&workflow, facets_base_dir);
@@ -1767,6 +1890,7 @@ fn template_reference_span(content: &str, reference: &str) -> Option<DiagnosticS
             {
                 let end = close + 2;
                 return Some(DiagnosticSpan {
+                    source: None,
                     start_line: line_index + 1,
                     start_col: line[..open].chars().count() + 1,
                     end_line: line_index + 1,
@@ -3393,6 +3517,7 @@ nodes:
         assert_eq!(item.workflow_name.as_deref(), Some("dup-node"));
         let span = item
             .span
+            .as_ref()
             .expect("duplicate node key diagnostic must carry a span");
         assert_eq!(
             span.start_line, 6,
@@ -3668,5 +3793,111 @@ nodes:
                 diagnosis.diagnostics
             );
         }
+    }
+
+    #[test]
+    fn diagnose_all_reports_lua_syntax_file_and_line() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("broken.lua"),
+            "local r = require('releash')\nreturn )",
+        )
+        .unwrap();
+
+        let report = diagnose_all(tmp.path(), tmp.path());
+        let diagnostic = report
+            .items
+            .iter()
+            .find(|item| item.code == "WFS009")
+            .expect("Lua syntax diagnostic");
+        let span = diagnostic.span.as_ref().expect("Lua source span");
+
+        assert_eq!(span.source.as_deref(), Some("broken.lua"));
+        assert_eq!(span.start_line, 2);
+    }
+
+    #[test]
+    fn lua_and_yaml_domain_errors_keep_the_same_diagnostic_identity() {
+        let tmp = TempDir::new().unwrap();
+        let yaml = diagnose_workflow_source(
+            r#"
+name: review
+description: Review
+nodes:
+  main:
+    command: ""
+"#,
+            Some("review"),
+        );
+        let lua = diagnose_lua_workflow_source(
+            "review.lua",
+            r#"
+local r = require("releash")
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.command{ command = "" },
+}
+"#,
+            tmp.path(),
+            tmp.path(),
+            Some("review"),
+        );
+        let yaml_error = yaml
+            .diagnostics
+            .iter()
+            .find(|item| item.severity == Severity::Error)
+            .unwrap();
+        let lua_error = lua
+            .diagnostics
+            .iter()
+            .find(|item| item.severity == Severity::Error)
+            .unwrap();
+
+        assert_eq!(lua_error.code, yaml_error.code);
+        assert_eq!(lua_error.stage, yaml_error.stage);
+        assert_eq!(lua_error.message, yaml_error.message);
+        assert_eq!(
+            lua_error.span.as_ref().unwrap().source.as_deref(),
+            Some("review.lua")
+        );
+    }
+
+    #[test]
+    fn lua_component_error_uses_workflow_relative_source_and_line() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("component.lua"),
+            r#"
+local r = require("releash")
+return function()
+  local child = r.command{ command = "echo" }
+  local invalid = child.missing
+  return child
+end
+"#,
+        )
+        .unwrap();
+
+        let diagnosis = diagnose_lua_workflow_source(
+            "review.lua",
+            r#"
+local component = require("component")
+return require("releash").workflow{
+  name = "review", description = "Review", main = component(),
+}
+"#,
+            tmp.path(),
+            tmp.path(),
+            Some("review"),
+        );
+        let diagnostic = diagnosis
+            .diagnostics
+            .iter()
+            .find(|item| item.code == "WFR003")
+            .expect("component reference diagnostic");
+        let span = diagnostic.span.as_ref().expect("component source span");
+
+        assert_eq!(span.source.as_deref(), Some("component.lua"));
+        assert_eq!(span.start_line, 5);
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -246,7 +246,7 @@ pub(crate) fn diagnose_lua_workflow_source(
     let loaded = match lua::load_lua_workflow(source_name, source, workflows_dir, catalog) {
         Ok(loaded) => loaded,
         Err(error) => {
-            let stage = diagnostic_stage_for_code(&error.code);
+            let stage = stage_for_code(&error.code);
             let span = error
                 .location
                 .map(|location| lua_location_span(&location, workflows_dir));
@@ -323,18 +323,6 @@ fn lua_location_span(
         location.source.clone()
     };
     lua_span(&display_source, location.line)
-}
-
-fn diagnostic_stage_for_code(code: &str) -> DiagnosticStage {
-    if code.starts_with("WFR") || code.starts_with("FAC") {
-        DiagnosticStage::Resolve
-    } else if code.starts_with("WFT") {
-        DiagnosticStage::Typecheck
-    } else if code.starts_with("WFC") {
-        DiagnosticStage::ControlFlow
-    } else {
-        DiagnosticStage::ParseShape
-    }
 }
 
 fn normalize_invalid_source_workflow_name(
@@ -1079,8 +1067,9 @@ fn validation_error_code_stage(
     (code, stage_for_code(code))
 }
 
+/// Diagnostic code の接頭辞から段を決める。接頭辞と段の対応はこの関数だけが持つ。
 fn stage_for_code(code: &str) -> DiagnosticStage {
-    if code.starts_with("WFR") || code.starts_with("WFU") {
+    if code.starts_with("WFR") || code.starts_with("WFU") || code.starts_with("FAC") {
         DiagnosticStage::Resolve
     } else if code.starts_with("WFT") {
         DiagnosticStage::Typecheck

--- a/src-tauri/src/adaptor/gateway/workflow/editor_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/editor_gateway.rs
@@ -148,6 +148,16 @@ mod tests {
     }
 
     #[test]
+    fn workflow_editor_path_resolves_lua_file() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("custom-lua.lua"), "return nil").unwrap();
+
+        let path = resolve_workflow_editor_path(tmp.path(), "custom-lua").unwrap();
+
+        assert_eq!(path.file_name().unwrap(), "custom-lua.lua");
+    }
+
+    #[test]
     fn facet_editor_path_rejects_builtin_and_resolves_custom_file() {
         let tmp = TempDir::new().unwrap();
         facet::save_facet(facet::FacetKind::Instruction, "custom", "body", tmp.path()).unwrap();

--- a/src-tauri/src/adaptor/gateway/workflow/facet_repository.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/facet_repository.rs
@@ -60,7 +60,11 @@ impl FacetRepository for WorkflowFacetFileRepository {
             )));
         }
         gateway_facet::save_facet(gateway_kind, key, content, &self.base_dir)
-            .map_err(|e| WorkflowError::external(e.to_string()))
+            .map_err(|e| WorkflowError::external(e.to_string()))?;
+        if let Err(error) = super::lua::generate_editor_support(&self.base_dir) {
+            log::warn!("Lua editor support generation failed after facet save: {error}");
+        }
+        Ok(())
     }
 
     fn delete(&self, kind: FacetKind, key: &str) -> Result<(), WorkflowError> {
@@ -69,7 +73,11 @@ impl FacetRepository for WorkflowFacetFileRepository {
             key,
             &self.base_dir,
         )
-        .map_err(|e| WorkflowError::external(e.to_string()))
+        .map_err(|e| WorkflowError::external(e.to_string()))?;
+        if let Err(error) = super::lua::generate_editor_support(&self.base_dir) {
+            log::warn!("Lua editor support generation failed after facet delete: {error}");
+        }
+        Ok(())
     }
 
     fn list_summaries(&self, kind: FacetKind) -> Result<Vec<FacetSummary>, WorkflowError> {
@@ -89,6 +97,8 @@ impl FacetRepository for WorkflowFacetFileRepository {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::*;
     use tempfile::TempDir;
 
@@ -118,5 +128,35 @@ mod tests {
         assert!(summaries
             .iter()
             .any(|summary| summary.key == "impl" && summary.kind == "instruction"));
+    }
+
+    #[test]
+    fn save_and_delete_regenerate_facet_editor_stub() {
+        let tmp = TempDir::new().unwrap();
+        let repo = WorkflowFacetFileRepository::new(tmp.path());
+
+        repo.save(FacetKind::Instruction, "impl", "# Implement", true)
+            .unwrap();
+        let after_save = fs::read_to_string(tmp.path().join(".releash/facets.lua")).unwrap();
+        repo.delete(FacetKind::Instruction, "impl").unwrap();
+        let after_delete = fs::read_to_string(tmp.path().join(".releash/facets.lua")).unwrap();
+
+        assert!(after_save.contains("impl ReleashFacet Implement"));
+        assert!(!after_delete.contains("impl ReleashFacet Implement"));
+    }
+
+    #[test]
+    fn editor_stub_generation_failure_does_not_fail_facet_save() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".releash"), "blocks generated directory").unwrap();
+        let repo = WorkflowFacetFileRepository::new(tmp.path());
+
+        repo.save(FacetKind::Instruction, "impl", "body", true)
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("instructions/impl.md")).unwrap(),
+            "body"
+        );
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/lua/mod.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/lua/mod.rs
@@ -18,6 +18,10 @@ mod stubs;
 
 pub(crate) use stubs::generate_editor_support;
 
+/// 一度の評価で Lua 側から生成できる中間ハンドルの総数。Lua VM のメモリ上限は
+/// Rust 側の arena を数えないため、ここで別途有界にする。
+const MAX_HOST_ARENA_ENTRIES: usize = 100_000;
+
 const HANDLE_NODE: &str = "node";
 const HANDLE_CHILD: &str = "child";
 const HANDLE_RULE: &str = "rule";
@@ -436,6 +440,34 @@ impl WorkflowLuaHost {
         handle(HANDLE_SOURCE, index)
     }
 
+    /// arena に積まれた中間ハンドルの総数。
+    fn arena_entries(&self) -> usize {
+        self.nodes.len()
+            + self.children.len()
+            + self.rules.len()
+            + self.failures.len()
+            + self.inputs.len()
+            + self.sources.len()
+            + self.schemas.len()
+            + self.facets.len()
+            + self.workflows.len()
+    }
+
+    /// Lua VM のメモリ上限は Rust 側の arena を数えないため、ビルダー呼び出しの
+    /// 入口で総数を有界にする。`MAX_NODES_PER_WORKFLOW` に収まる定義は到達しない。
+    fn ensure_arena_budget(&self, location: &LuaSourceLocation) -> Result<(), LuaHostError> {
+        if self.arena_entries() >= MAX_HOST_ARENA_ENTRIES {
+            return Err(host_error(
+                "WFS010",
+                format!(
+                    "Lua definition exceeded the limit of {MAX_HOST_ARENA_ENTRIES} builder values"
+                ),
+                location.clone(),
+            ));
+        }
+        Ok(())
+    }
+
     fn build(self, workflow_index: usize) -> Result<LuaWorkflowDefinition, LuaWorkflowError> {
         WorkflowGraphBuilder::new(self).build(workflow_index)
     }
@@ -456,6 +488,7 @@ impl LuaHost for WorkflowLuaHost {
         arguments: Vec<LuaData>,
         location: LuaSourceLocation,
     ) -> Result<LuaData, LuaHostError> {
+        self.ensure_arena_budget(&location)?;
         match function {
             FN_COMMAND => self.call_command(arguments, location),
             FN_SESSION => self.call_session(arguments, location),
@@ -491,6 +524,7 @@ impl LuaHost for WorkflowLuaHost {
         key: &str,
         location: LuaSourceLocation,
     ) -> Result<LuaData, LuaHostError> {
+        self.ensure_arena_budget(&location)?;
         if handle.kind == HANDLE_FACET_INDEX {
             let kind = match handle.index {
                 0 => FacetKind::Instruction,
@@ -2674,6 +2708,31 @@ return r.workflow{
         .unwrap();
 
         assert_eq!(second.workflow, first.workflow);
+    }
+
+    #[test]
+    fn rejects_definitions_that_exhaust_the_host_arena_budget() {
+        let directory = TempDir::new().unwrap();
+
+        let error = load_lua_workflow(
+            "review.lua",
+            r#"
+local r = require("releash")
+for _ = 1, 200000 do
+  r.command{ command = "x" }
+end
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{ children = { r.child{ node = r.command{ command = "true" } } } },
+}
+"#,
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFS010");
+        assert!(error.message.contains("builder values"));
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/lua/mod.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/lua/mod.rs
@@ -1,0 +1,2723 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::Path;
+
+use serde_json::{Number, Value};
+
+use crate::domain::provider_lifecycle::ProviderKind;
+use crate::domain::workflow::value_objects::{
+    ChildEntry, CommandSpec, FacetRefs, FanoutSpec, InputParam, InputSourceRef, ItemsSource,
+    NodeCompletion, NodeDefinition, NodeKind, NodeNamespace, OnFailure, Rule, SchemaDef,
+    SequenceSpec, SessionSpec, WorkflowDefinition, MAIN_ENTRY_NODE_NAME,
+};
+use crate::infrastructure::lua::{
+    evaluate, LuaData, LuaEvaluationRequest, LuaFailure, LuaHost, LuaHostError, LuaHostHandle,
+    LuaLimits, LuaModule, LuaModuleValue, LuaSourceLocation, LuaTableData, LuaTableKey,
+};
+
+mod stubs;
+
+pub(crate) use stubs::generate_editor_support;
+
+const HANDLE_NODE: &str = "node";
+const HANDLE_CHILD: &str = "child";
+const HANDLE_RULE: &str = "rule";
+const HANDLE_FAILURE: &str = "on_failure";
+const HANDLE_INPUT: &str = "input";
+const HANDLE_SOURCE: &str = "source";
+const HANDLE_SCHEMA: &str = "schema";
+const HANDLE_FACET: &str = "facet";
+const HANDLE_FACET_INDEX: &str = "facet_index";
+const HANDLE_WORKFLOW: &str = "workflow";
+const HANDLE_PROVIDER: &str = "provider";
+const HANDLE_COMPLETION: &str = "completion";
+
+const FN_COMMAND: u32 = 1;
+const FN_SESSION: u32 = 2;
+const FN_FANOUT: u32 = 3;
+const FN_SEQUENCE: u32 = 4;
+const FN_CHILD: u32 = 5;
+const FN_NEXT: u32 = 6;
+const FN_WHEN: u32 = 7;
+const FN_SWITCH: u32 = 8;
+const FN_LOOP_GUARD: u32 = 9;
+const FN_RETRY: u32 = 10;
+const FN_INPUT: u32 = 11;
+const FN_SCHEMA_OBJECT: u32 = 12;
+const FN_SCHEMA_ARRAY: u32 = 13;
+const FN_SCHEMA_STRING: u32 = 14;
+const FN_SCHEMA_BOOLEAN: u32 = 15;
+const FN_SCHEMA_INTEGER: u32 = 16;
+const FN_SCHEMA_NUMBER: u32 = 17;
+const FN_WORKFLOW: u32 = 18;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LuaFacetCatalog {
+    pub(crate) instruction: Vec<String>,
+    pub(crate) policy: Vec<String>,
+    pub(crate) knowledge: Vec<String>,
+}
+
+pub(crate) fn facet_catalog(
+    base_dir: &Path,
+) -> Result<LuaFacetCatalog, crate::adaptor::gateway::workflow::facet::FacetError> {
+    use crate::adaptor::gateway::workflow::facet::{self, FacetKind};
+
+    Ok(LuaFacetCatalog {
+        instruction: facet::list_facets(FacetKind::Instruction, base_dir)?,
+        policy: facet::list_facets(FacetKind::Policy, base_dir)?,
+        knowledge: facet::list_facets(FacetKind::Knowledge, base_dir)?,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LuaWorkflowDefinition {
+    pub(crate) workflow: WorkflowDefinition,
+    pub(crate) node_locations: BTreeMap<String, LuaSourceLocation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LuaWorkflowError {
+    pub(crate) code: String,
+    pub(crate) message: String,
+    pub(crate) location: Option<LuaSourceLocation>,
+}
+
+impl std::fmt::Display for LuaWorkflowError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for LuaWorkflowError {}
+
+pub(crate) fn load_lua_workflow(
+    source_name: &str,
+    source: &str,
+    workflows_dir: &Path,
+    facets: LuaFacetCatalog,
+) -> Result<LuaWorkflowDefinition, LuaWorkflowError> {
+    load_lua_workflow_with_limits(
+        source_name,
+        source,
+        workflows_dir,
+        facets,
+        LuaLimits::default(),
+    )
+}
+
+fn load_lua_workflow_with_limits(
+    source_name: &str,
+    source: &str,
+    workflows_dir: &Path,
+    facets: LuaFacetCatalog,
+    limits: LuaLimits,
+) -> Result<LuaWorkflowDefinition, LuaWorkflowError> {
+    let host = WorkflowLuaHost::new(facets);
+    let evaluation = evaluate(
+        LuaEvaluationRequest {
+            source_name,
+            source,
+            workflows_dir,
+            limits,
+        },
+        host,
+    )
+    .map_err(map_evaluation_error)?;
+    let workflow_index =
+        expect_handle_data(&evaluation.value, HANDLE_WORKFLOW).map_err(|message| {
+            LuaWorkflowError {
+                code: "WFS010".to_string(),
+                message,
+                location: Some(LuaSourceLocation {
+                    source: source_name.to_string(),
+                    line: 1,
+                }),
+            }
+        })?;
+    evaluation.host.build(workflow_index)
+}
+
+fn map_evaluation_error(error: LuaFailure) -> LuaWorkflowError {
+    let code = match error.kind {
+        crate::infrastructure::lua::LuaFailureKind::Syntax => "WFS009",
+        crate::infrastructure::lua::LuaFailureKind::Require => "WFS011",
+        crate::infrastructure::lua::LuaFailureKind::Evaluation => "WFS010",
+        crate::infrastructure::lua::LuaFailureKind::Host => {
+            error.category.as_deref().unwrap_or("WFS002")
+        }
+    };
+    LuaWorkflowError {
+        code: code.to_string(),
+        message: error.message,
+        location: error.location,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NodeDraft {
+    name: Option<String>,
+    kind: NodeDraftKind,
+    artifact: Option<usize>,
+    input: Vec<usize>,
+    completion: NodeCompletion,
+    location: LuaSourceLocation,
+}
+
+#[derive(Debug, Clone)]
+enum NodeDraftKind {
+    Command(String),
+    Session {
+        provider: ProviderKind,
+        model: Option<String>,
+        permission: Option<String>,
+        facets: FacetRefs,
+    },
+    Fanout {
+        children: Vec<usize>,
+        items: Option<FanoutItemsDraft>,
+    },
+    Sequence {
+        children: Vec<usize>,
+        entry: Option<usize>,
+        output: Option<usize>,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum FanoutItemsDraft {
+    Literal(Vec<Value>),
+    Source(usize),
+}
+
+#[derive(Debug, Clone)]
+struct ChildDraft {
+    node: usize,
+    inputs: Vec<(String, usize)>,
+    rules: Option<Vec<usize>>,
+    on_failure: Option<OnFailure>,
+    location: LuaSourceLocation,
+}
+
+#[derive(Debug, Clone)]
+enum RuleDraft {
+    Next(usize),
+    When {
+        on: usize,
+        on_true: usize,
+        next: usize,
+    },
+    Switch {
+        on: usize,
+        cases: BTreeMap<String, usize>,
+        next: Option<usize>,
+    },
+    LoopGuard {
+        max_iterations: u32,
+        on_exhausted: usize,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct InputDraft {
+    name: String,
+    contract: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+enum SourceDraft {
+    Node { node: usize, fields: Vec<String> },
+    Input { input: usize, fields: Vec<String> },
+    Request,
+    Items,
+}
+
+#[derive(Debug, Clone)]
+struct SchemaDraft {
+    name: Option<String>,
+    kind: SchemaDraftKind,
+}
+
+#[derive(Debug, Clone)]
+enum SchemaDraftKind {
+    Object {
+        properties: BTreeMap<String, usize>,
+        required: BTreeSet<String>,
+    },
+    Array {
+        items: usize,
+    },
+    String {
+        values: Option<Vec<String>>,
+    },
+    Boolean,
+    Integer,
+    Number,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FacetKind {
+    Instruction,
+    Policy,
+    Knowledge,
+}
+
+#[derive(Debug, Clone)]
+struct FacetDraft {
+    kind: FacetKind,
+    key: String,
+}
+
+#[derive(Debug, Clone)]
+struct WorkflowDraft {
+    name: String,
+    description: String,
+    main: usize,
+}
+
+#[derive(Debug)]
+struct WorkflowLuaHost {
+    nodes: Vec<NodeDraft>,
+    children: Vec<ChildDraft>,
+    rules: Vec<RuleDraft>,
+    failures: Vec<OnFailure>,
+    inputs: Vec<InputDraft>,
+    sources: Vec<SourceDraft>,
+    schemas: Vec<SchemaDraft>,
+    facets: Vec<FacetDraft>,
+    workflows: Vec<WorkflowDraft>,
+    facet_module: LuaModule,
+    facet_keys: [BTreeSet<String>; 3],
+    request_source: usize,
+    items_source: usize,
+}
+
+impl WorkflowLuaHost {
+    fn new(catalog: LuaFacetCatalog) -> Self {
+        let mut host = Self {
+            nodes: Vec::new(),
+            children: Vec::new(),
+            rules: Vec::new(),
+            failures: vec![OnFailure::Ignore],
+            inputs: Vec::new(),
+            sources: vec![SourceDraft::Request, SourceDraft::Items],
+            schemas: Vec::new(),
+            facets: Vec::new(),
+            workflows: Vec::new(),
+            facet_module: LuaModule::default(),
+            facet_keys: [
+                catalog.instruction.into_iter().collect(),
+                catalog.policy.into_iter().collect(),
+                catalog.knowledge.into_iter().collect(),
+            ],
+            request_source: 0,
+            items_source: 1,
+        };
+        host.facet_module = host.make_facet_module();
+        host
+    }
+
+    fn make_facet_module(&self) -> LuaModule {
+        LuaModule {
+            members: BTreeMap::from([
+                (
+                    "instruction".to_string(),
+                    LuaModuleValue::Data(handle(HANDLE_FACET_INDEX, 0)),
+                ),
+                (
+                    "policy".to_string(),
+                    LuaModuleValue::Data(handle(HANDLE_FACET_INDEX, 1)),
+                ),
+                (
+                    "knowledge".to_string(),
+                    LuaModuleValue::Data(handle(HANDLE_FACET_INDEX, 2)),
+                ),
+            ]),
+        }
+    }
+
+    fn releash_module(&self) -> LuaModule {
+        let functions = [
+            ("command", FN_COMMAND),
+            ("session", FN_SESSION),
+            ("fanout", FN_FANOUT),
+            ("sequence", FN_SEQUENCE),
+            ("child", FN_CHILD),
+            ("next", FN_NEXT),
+            ("when", FN_WHEN),
+            ("switch", FN_SWITCH),
+            ("loop_guard", FN_LOOP_GUARD),
+            ("retry", FN_RETRY),
+            ("input", FN_INPUT),
+            ("workflow", FN_WORKFLOW),
+        ];
+        let mut members = BTreeMap::new();
+        for (name, function) in functions {
+            members.insert(name.to_string(), LuaModuleValue::Function(function));
+        }
+        members.insert(
+            "ignore".to_string(),
+            LuaModuleValue::Data(handle(HANDLE_FAILURE, 0)),
+        );
+        members.insert(
+            "request".to_string(),
+            LuaModuleValue::Data(handle(HANDLE_SOURCE, self.request_source)),
+        );
+        members.insert(
+            "items".to_string(),
+            LuaModuleValue::Data(handle(HANDLE_SOURCE, self.items_source)),
+        );
+        members.insert(
+            "completion".to_string(),
+            LuaModuleValue::Module(LuaModule {
+                members: BTreeMap::from([(
+                    "approval".to_string(),
+                    LuaModuleValue::Data(handle(HANDLE_COMPLETION, 0)),
+                )]),
+            }),
+        );
+        members.insert(
+            "provider".to_string(),
+            LuaModuleValue::Module(LuaModule {
+                members: BTreeMap::from([
+                    (
+                        "claude".to_string(),
+                        LuaModuleValue::Data(handle(HANDLE_PROVIDER, 0)),
+                    ),
+                    (
+                        "codex".to_string(),
+                        LuaModuleValue::Data(handle(HANDLE_PROVIDER, 1)),
+                    ),
+                ]),
+            }),
+        );
+        members.insert(
+            "schema".to_string(),
+            LuaModuleValue::Module(LuaModule {
+                members: BTreeMap::from([
+                    (
+                        "object".to_string(),
+                        LuaModuleValue::Function(FN_SCHEMA_OBJECT),
+                    ),
+                    (
+                        "array".to_string(),
+                        LuaModuleValue::Function(FN_SCHEMA_ARRAY),
+                    ),
+                    (
+                        "string".to_string(),
+                        LuaModuleValue::Function(FN_SCHEMA_STRING),
+                    ),
+                    (
+                        "boolean".to_string(),
+                        LuaModuleValue::Function(FN_SCHEMA_BOOLEAN),
+                    ),
+                    (
+                        "integer".to_string(),
+                        LuaModuleValue::Function(FN_SCHEMA_INTEGER),
+                    ),
+                    (
+                        "number".to_string(),
+                        LuaModuleValue::Function(FN_SCHEMA_NUMBER),
+                    ),
+                ]),
+            }),
+        );
+        LuaModule { members }
+    }
+
+    fn push_schema(&mut self, draft: SchemaDraft) -> LuaData {
+        let index = self.schemas.len();
+        self.schemas.push(draft);
+        handle(HANDLE_SCHEMA, index)
+    }
+
+    fn push_source(&mut self, draft: SourceDraft) -> LuaData {
+        let index = self.sources.len();
+        self.sources.push(draft);
+        handle(HANDLE_SOURCE, index)
+    }
+
+    fn build(self, workflow_index: usize) -> Result<LuaWorkflowDefinition, LuaWorkflowError> {
+        WorkflowGraphBuilder::new(self).build(workflow_index)
+    }
+}
+
+impl LuaHost for WorkflowLuaHost {
+    fn module(&self, name: &str) -> Option<LuaModule> {
+        match name {
+            "releash" => Some(self.releash_module()),
+            "facets" => Some(self.facet_module.clone()),
+            _ => None,
+        }
+    }
+
+    fn call(
+        &mut self,
+        function: u32,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        match function {
+            FN_COMMAND => self.call_command(arguments, location),
+            FN_SESSION => self.call_session(arguments, location),
+            FN_FANOUT => self.call_fanout(arguments, location),
+            FN_SEQUENCE => self.call_sequence(arguments, location),
+            FN_CHILD => self.call_child(arguments, location),
+            FN_NEXT => self.call_next(arguments, location),
+            FN_WHEN => self.call_when(arguments, location),
+            FN_SWITCH => self.call_switch(arguments, location),
+            FN_LOOP_GUARD => self.call_loop_guard(arguments, location),
+            FN_RETRY => self.call_retry(arguments, location),
+            FN_INPUT => self.call_input(arguments, location),
+            FN_SCHEMA_OBJECT => self.call_schema_object(arguments, location),
+            FN_SCHEMA_ARRAY => self.call_schema_array(arguments, location),
+            FN_SCHEMA_STRING => self.call_schema_string(arguments, location),
+            FN_SCHEMA_BOOLEAN => {
+                self.call_primitive_schema(arguments, location, SchemaDraftKind::Boolean)
+            }
+            FN_SCHEMA_INTEGER => {
+                self.call_primitive_schema(arguments, location, SchemaDraftKind::Integer)
+            }
+            FN_SCHEMA_NUMBER => {
+                self.call_primitive_schema(arguments, location, SchemaDraftKind::Number)
+            }
+            FN_WORKFLOW => self.call_workflow(arguments, location),
+            _ => Err(host_error("WFS002", "unknown builder function", location)),
+        }
+    }
+
+    fn index(
+        &mut self,
+        handle: &LuaHostHandle,
+        key: &str,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        if handle.kind == HANDLE_FACET_INDEX {
+            let kind = match handle.index {
+                0 => FacetKind::Instruction,
+                1 => FacetKind::Policy,
+                2 => FacetKind::Knowledge,
+                _ => return Err(host_error("WFS002", "invalid facet index", location)),
+            };
+            if !self.facet_keys[handle.index].contains(key) {
+                return Err(host_error(
+                    "WFR900",
+                    format!("facet '{key}' does not exist"),
+                    location,
+                ));
+            }
+            let index = self.facets.len();
+            self.facets.push(FacetDraft {
+                kind,
+                key: key.to_string(),
+            });
+            return Ok(LuaData::Handle(LuaHostHandle {
+                kind: HANDLE_FACET.to_string(),
+                index,
+            }));
+        }
+        let (node, mut fields) = match handle.kind.as_str() {
+            HANDLE_NODE => (handle.index, Vec::new()),
+            HANDLE_INPUT => {
+                return self.index_input(handle.index, Vec::new(), key, location);
+            }
+            HANDLE_SOURCE => match self.sources.get(handle.index) {
+                Some(SourceDraft::Input { input, fields }) => {
+                    return self.index_input(*input, fields.clone(), key, location);
+                }
+                Some(SourceDraft::Node { node, fields }) if fields.is_empty() => {
+                    (*node, fields.clone())
+                }
+                Some(SourceDraft::Node { .. }) => {
+                    return Err(host_error(
+                        "WFR003",
+                        "nested artifact field references are not supported",
+                        location,
+                    ));
+                }
+                _ => {
+                    return Err(host_error(
+                        "WFR003",
+                        "only a node or input source can be indexed",
+                        location,
+                    ));
+                }
+            },
+            _ => {
+                return Err(host_error(
+                    "WFR003",
+                    "only a node can be indexed as an artifact source",
+                    location,
+                ));
+            }
+        };
+        fields.push(key.to_string());
+        self.validate_artifact_path(node, &fields)
+            .map_err(|message| host_error("WFR003", message, location.clone()))?;
+        Ok(self.push_source(SourceDraft::Node { node, fields }))
+    }
+}
+
+impl WorkflowLuaHost {
+    fn call_command(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(
+            &table,
+            &["name", "command", "artifact", "input", "completion"],
+            &location,
+        )?;
+        let draft = NodeDraft {
+            name: optional_string(&table, "name", &location)?,
+            kind: NodeDraftKind::Command(required_string(&table, "command", &location)?),
+            artifact: optional_handle(&table, "artifact", HANDLE_SCHEMA, &location)?,
+            input: optional_handle_array(&table, "input", HANDLE_INPUT, &location)?
+                .unwrap_or_default(),
+            completion: parse_completion(&table, &location)?,
+            location,
+        };
+        Ok(push_node(&mut self.nodes, draft))
+    }
+
+    fn call_session(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(
+            &table,
+            &[
+                "name",
+                "provider",
+                "model",
+                "permission",
+                "facets",
+                "artifact",
+                "input",
+                "completion",
+            ],
+            &location,
+        )?;
+        let provider = match required_handle(&table, "provider", HANDLE_PROVIDER, &location)? {
+            0 => ProviderKind::Claude,
+            1 => ProviderKind::Codex,
+            _ => return Err(host_error("WFS002", "invalid provider", location)),
+        };
+        let facets = match table.get_string("facets") {
+            None | Some(LuaData::Nil) => FacetRefs::default(),
+            Some(LuaData::Table(table)) => self.parse_facets(table, &location)?,
+            Some(_) => return Err(type_error("facets", "table", &location)),
+        };
+        let draft = NodeDraft {
+            name: optional_string(&table, "name", &location)?,
+            kind: NodeDraftKind::Session {
+                provider,
+                model: optional_string(&table, "model", &location)?,
+                permission: optional_string(&table, "permission", &location)?,
+                facets,
+            },
+            artifact: optional_handle(&table, "artifact", HANDLE_SCHEMA, &location)?,
+            input: optional_handle_array(&table, "input", HANDLE_INPUT, &location)?
+                .unwrap_or_default(),
+            completion: parse_completion(&table, &location)?,
+            location,
+        };
+        Ok(push_node(&mut self.nodes, draft))
+    }
+
+    fn parse_facets(
+        &self,
+        table: &LuaTableData,
+        location: &LuaSourceLocation,
+    ) -> Result<FacetRefs, LuaHostError> {
+        reject_unknown(table, &["policy", "knowledge", "instruction"], location)?;
+        let policy = self.optional_facet(table, "policy", FacetKind::Policy, location)?;
+        let instruction =
+            self.optional_facet(table, "instruction", FacetKind::Instruction, location)?;
+        let knowledge = match table.get_string("knowledge") {
+            None | Some(LuaData::Nil) => Vec::new(),
+            Some(LuaData::Table(values)) => values
+                .as_array()
+                .ok_or_else(|| type_error("knowledge", "array", location))?
+                .into_iter()
+                .map(|value| self.facet_key(value, FacetKind::Knowledge, "knowledge", location))
+                .collect::<Result<Vec<_>, _>>()?,
+            Some(_) => return Err(type_error("knowledge", "array", location)),
+        };
+        Ok(FacetRefs {
+            policy,
+            knowledge,
+            instruction,
+        })
+    }
+
+    fn optional_facet(
+        &self,
+        table: &LuaTableData,
+        field: &str,
+        expected: FacetKind,
+        location: &LuaSourceLocation,
+    ) -> Result<Option<String>, LuaHostError> {
+        match table.get_string(field) {
+            None | Some(LuaData::Nil) => Ok(None),
+            Some(value) => self.facet_key(value, expected, field, location).map(Some),
+        }
+    }
+
+    fn facet_key(
+        &self,
+        value: &LuaData,
+        expected: FacetKind,
+        field: &str,
+        location: &LuaSourceLocation,
+    ) -> Result<String, LuaHostError> {
+        let index = expect_handle(value, HANDLE_FACET)
+            .map_err(|_| type_error(field, "matching Facet", location))?;
+        let facet = self
+            .facets
+            .get(index)
+            .ok_or_else(|| type_error(field, "matching Facet", location))?;
+        if facet.kind != expected {
+            return Err(type_error(field, "matching Facet", location));
+        }
+        Ok(facet.key.clone())
+    }
+
+    fn call_fanout(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(
+            &table,
+            &[
+                "name",
+                "children",
+                "items",
+                "artifact",
+                "input",
+                "completion",
+            ],
+            &location,
+        )?;
+        let items = match table.get_string("items") {
+            None | Some(LuaData::Nil) => None,
+            Some(value @ LuaData::Handle(_)) => {
+                let source = expect_handle(value, HANDLE_SOURCE)
+                    .or_else(|_| self.node_as_source_index(value))
+                    .map_err(|_| type_error("items", "Source or literal array", &location))?;
+                if !matches!(
+                    self.sources.get(source),
+                    Some(SourceDraft::Node { fields, .. }) if !fields.is_empty()
+                ) {
+                    return Err(host_error(
+                        "WFR003",
+                        "fanout items must reference an artifact field",
+                        location,
+                    ));
+                }
+                Some(FanoutItemsDraft::Source(source))
+            }
+            Some(LuaData::Table(values)) => Some(FanoutItemsDraft::Literal(lua_array_to_json(
+                values, &location,
+            )?)),
+            Some(_) => return Err(type_error("items", "Source or literal array", &location)),
+        };
+        let draft = NodeDraft {
+            name: optional_string(&table, "name", &location)?,
+            kind: NodeDraftKind::Fanout {
+                children: required_handle_array(&table, "children", HANDLE_CHILD, &location)?,
+                items,
+            },
+            artifact: optional_handle(&table, "artifact", HANDLE_SCHEMA, &location)?,
+            input: optional_handle_array(&table, "input", HANDLE_INPUT, &location)?
+                .unwrap_or_default(),
+            completion: parse_completion(&table, &location)?,
+            location,
+        };
+        Ok(push_node(&mut self.nodes, draft))
+    }
+
+    fn node_as_source_index(&mut self, value: &LuaData) -> Result<usize, ()> {
+        let node = expect_handle(value, HANDLE_NODE)?;
+        let index = self.sources.len();
+        self.sources.push(SourceDraft::Node {
+            node,
+            fields: Vec::new(),
+        });
+        Ok(index)
+    }
+
+    fn call_sequence(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(
+            &table,
+            &[
+                "name",
+                "entry",
+                "output",
+                "children",
+                "artifact",
+                "input",
+                "completion",
+            ],
+            &location,
+        )?;
+        let draft = NodeDraft {
+            name: optional_string(&table, "name", &location)?,
+            kind: NodeDraftKind::Sequence {
+                children: required_handle_array(&table, "children", HANDLE_CHILD, &location)?,
+                entry: optional_handle(&table, "entry", HANDLE_NODE, &location)?,
+                output: optional_handle(&table, "output", HANDLE_NODE, &location)?,
+            },
+            artifact: optional_handle(&table, "artifact", HANDLE_SCHEMA, &location)?,
+            input: optional_handle_array(&table, "input", HANDLE_INPUT, &location)?
+                .unwrap_or_default(),
+            completion: parse_completion(&table, &location)?,
+            location,
+        };
+        Ok(push_node(&mut self.nodes, draft))
+    }
+
+    fn call_child(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(
+            &table,
+            &["node", "inputs", "rules", "on_failure"],
+            &location,
+        )?;
+        let inputs = match table.get_string("inputs") {
+            None | Some(LuaData::Nil) => Vec::new(),
+            Some(LuaData::Table(values)) => {
+                let mut result = Vec::new();
+                for (key, value) in &values.entries {
+                    let LuaTableKey::String(key) = key else {
+                        return Err(type_error("inputs", "string-keyed table", &location));
+                    };
+                    let source = expect_handle(value, HANDLE_SOURCE)
+                        .or_else(|_| self.node_as_source_index(value))
+                        .or_else(|_| self.input_as_source_index(value))
+                        .map_err(|_| type_error("inputs", "Source values", &location))?;
+                    result.push((key.clone(), source));
+                }
+                result
+            }
+            Some(_) => return Err(type_error("inputs", "table", &location)),
+        };
+        let rules = optional_handle_array(&table, "rules", HANDLE_RULE, &location)?;
+        let on_failure = match table.get_string("on_failure") {
+            None | Some(LuaData::Nil) => None,
+            Some(value) => {
+                let index = expect_handle(value, HANDLE_FAILURE)
+                    .map_err(|_| type_error("on_failure", "OnFailure", &location))?;
+                Some(
+                    *self
+                        .failures
+                        .get(index)
+                        .ok_or_else(|| type_error("on_failure", "OnFailure", &location))?,
+                )
+            }
+        };
+        let index = self.children.len();
+        self.children.push(ChildDraft {
+            node: required_handle(&table, "node", HANDLE_NODE, &location)?,
+            inputs,
+            rules,
+            on_failure,
+            location,
+        });
+        Ok(handle(HANDLE_CHILD, index))
+    }
+
+    fn input_as_source_index(&mut self, value: &LuaData) -> Result<usize, ()> {
+        let input = expect_handle(value, HANDLE_INPUT)?;
+        let index = self.sources.len();
+        self.sources.push(SourceDraft::Input {
+            input,
+            fields: Vec::new(),
+        });
+        Ok(index)
+    }
+
+    fn call_next(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let node = one_handle(arguments, HANDLE_NODE, &location)?;
+        Ok(push_rule(&mut self.rules, RuleDraft::Next(node)))
+    }
+
+    fn call_when(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(&table, &["on", "on_true", "next"], &location)?;
+        let on = self.required_source(&table, "on", &location)?;
+        let draft = RuleDraft::When {
+            on,
+            on_true: required_handle(&table, "on_true", HANDLE_NODE, &location)?,
+            next: required_handle(&table, "next", HANDLE_NODE, &location)?,
+        };
+        Ok(push_rule(&mut self.rules, draft))
+    }
+
+    fn call_switch(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(&table, &["on", "cases", "next"], &location)?;
+        let cases = required_table(&table, "cases", &location)?;
+        let mut targets = BTreeMap::new();
+        for (key, value) in &cases.entries {
+            let key = lua_key_as_case(key)
+                .ok_or_else(|| type_error("cases", "scalar-keyed Node map", &location))?;
+            let target = expect_handle(value, HANDLE_NODE)
+                .map_err(|_| type_error("cases", "scalar-keyed Node map", &location))?;
+            targets.insert(key, target);
+        }
+        let draft = RuleDraft::Switch {
+            on: self.required_source(&table, "on", &location)?,
+            cases: targets,
+            next: optional_handle(&table, "next", HANDLE_NODE, &location)?,
+        };
+        Ok(push_rule(&mut self.rules, draft))
+    }
+
+    fn call_loop_guard(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(&table, &["max_iterations", "on_exhausted"], &location)?;
+        let max_iterations = required_u32(&table, "max_iterations", &location)?;
+        let draft = RuleDraft::LoopGuard {
+            max_iterations,
+            on_exhausted: required_handle(&table, "on_exhausted", HANDLE_NODE, &location)?,
+        };
+        Ok(push_rule(&mut self.rules, draft))
+    }
+
+    fn call_retry(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let count = one_u32(arguments, &location)?;
+        if count == 0 {
+            return Err(host_error(
+                "WFS002",
+                "retry count must be at least 1",
+                location,
+            ));
+        }
+        let index = self.failures.len();
+        self.failures.push(OnFailure::Retry(count));
+        Ok(handle(HANDLE_FAILURE, index))
+    }
+
+    fn call_input(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        if !(1..=2).contains(&arguments.len()) {
+            return Err(host_error(
+                "WFS002",
+                "input expects name and optional contract",
+                location,
+            ));
+        }
+        let name = match &arguments[0] {
+            LuaData::String(value) if !value.is_empty() => value.clone(),
+            _ => return Err(type_error("input name", "non-empty string", &location)),
+        };
+        let contract = arguments
+            .get(1)
+            .map(|value| expect_handle(value, HANDLE_SCHEMA))
+            .transpose()
+            .map_err(|_| type_error("input contract", "Schema", &location))?;
+        let index = self.inputs.len();
+        self.inputs.push(InputDraft { name, contract });
+        Ok(handle(HANDLE_INPUT, index))
+    }
+
+    fn call_schema_object(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(&table, &["name", "properties", "required"], &location)?;
+        let raw_properties = required_table(&table, "properties", &location)?;
+        let mut properties = BTreeMap::new();
+        for (key, value) in &raw_properties.entries {
+            let LuaTableKey::String(key) = key else {
+                return Err(type_error(
+                    "properties",
+                    "string-keyed Schema map",
+                    &location,
+                ));
+            };
+            let schema = expect_handle(value, HANDLE_SCHEMA)
+                .map_err(|_| type_error("properties", "string-keyed Schema map", &location))?;
+            properties.insert(key.clone(), schema);
+        }
+        let required = optional_string_array(&table, "required", &location)?
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        Ok(self.push_schema(SchemaDraft {
+            name: optional_string(&table, "name", &location)?,
+            kind: SchemaDraftKind::Object {
+                properties,
+                required,
+            },
+        }))
+    }
+
+    fn call_schema_array(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(&table, &["name", "items"], &location)?;
+        Ok(self.push_schema(SchemaDraft {
+            name: optional_string(&table, "name", &location)?,
+            kind: SchemaDraftKind::Array {
+                items: required_handle(&table, "items", HANDLE_SCHEMA, &location)?,
+            },
+        }))
+    }
+
+    fn call_schema_string(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(&table, &["enum"], &location)?;
+        Ok(self.push_schema(SchemaDraft {
+            name: None,
+            kind: SchemaDraftKind::String {
+                values: optional_string_array(&table, "enum", &location)?,
+            },
+        }))
+    }
+
+    fn call_primitive_schema(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+        kind: SchemaDraftKind,
+    ) -> Result<LuaData, LuaHostError> {
+        if !arguments.is_empty() {
+            return Err(host_error(
+                "WFS002",
+                "primitive schema expects no arguments",
+                location,
+            ));
+        }
+        Ok(self.push_schema(SchemaDraft { name: None, kind }))
+    }
+
+    fn call_workflow(
+        &mut self,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        let table = one_table(arguments, &location)?;
+        reject_unknown(&table, &["name", "description", "main"], &location)?;
+        let name = required_string(&table, "name", &location)?;
+        let description = required_string(&table, "description", &location)?;
+        let index = self.workflows.len();
+        let main = match table.get_string("main") {
+            None | Some(LuaData::Nil) => {
+                return Err(host_error(
+                    "WFR006",
+                    "workflow main node does not exist",
+                    location,
+                ));
+            }
+            Some(value) => expect_handle(value, HANDLE_NODE)
+                .map_err(|_| type_error("main", HANDLE_NODE, &location))?,
+        };
+        self.workflows.push(WorkflowDraft {
+            name,
+            description,
+            main,
+        });
+        Ok(handle(HANDLE_WORKFLOW, index))
+    }
+
+    fn required_source(
+        &mut self,
+        table: &LuaTableData,
+        field: &str,
+        location: &LuaSourceLocation,
+    ) -> Result<usize, LuaHostError> {
+        let value = table
+            .get_string(field)
+            .ok_or_else(|| missing_field(field, location))?;
+        expect_handle(value, HANDLE_SOURCE)
+            .or_else(|_| self.node_as_source_index(value))
+            .or_else(|_| self.input_as_source_index(value))
+            .map_err(|_| type_error(field, "Source", location))
+    }
+
+    fn validate_artifact_path(&self, node: usize, fields: &[String]) -> Result<(), String> {
+        let node = self
+            .nodes
+            .get(node)
+            .ok_or_else(|| "unknown node handle".to_string())?;
+        if matches!(node.kind, NodeDraftKind::Command(_))
+            && fields.len() == 1
+            && crate::domain::workflow::services::contract_schema::COMMAND_RESERVED_FIELDS
+                .contains(&fields[0].as_str())
+        {
+            return Ok(());
+        }
+        let schema = node
+            .artifact
+            .ok_or_else(|| "node does not declare an artifact".to_string())?;
+        self.validate_schema_path(schema, fields, "artifact")
+    }
+
+    fn index_input(
+        &mut self,
+        input: usize,
+        mut fields: Vec<String>,
+        key: &str,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError> {
+        if !fields.is_empty() {
+            return Err(host_error(
+                "WFR003",
+                "nested input field references are not supported",
+                location,
+            ));
+        }
+        fields.push(key.to_string());
+        let schema = self
+            .inputs
+            .get(input)
+            .and_then(|input| input.contract)
+            .ok_or_else(|| {
+                host_error(
+                    "WFR003",
+                    "input does not declare a contract",
+                    location.clone(),
+                )
+            })?;
+        self.validate_schema_path(schema, &fields, "input")
+            .map_err(|message| host_error("WFR003", message, location))?;
+        Ok(self.push_source(SourceDraft::Input { input, fields }))
+    }
+
+    fn validate_schema_path(
+        &self,
+        mut schema: usize,
+        fields: &[String],
+        source_kind: &str,
+    ) -> Result<(), String> {
+        for field in fields {
+            let draft = self
+                .schemas
+                .get(schema)
+                .ok_or_else(|| "unknown artifact schema".to_string())?;
+            let SchemaDraftKind::Object { properties, .. } = &draft.kind else {
+                return Err(format!(
+                    "{source_kind} field '{field}' cannot be read from a non-object schema"
+                ));
+            };
+            schema = *properties
+                .get(field)
+                .ok_or_else(|| format!("{source_kind} field '{field}' does not exist"))?;
+        }
+        Ok(())
+    }
+}
+
+struct WorkflowGraphBuilder {
+    host: WorkflowLuaHost,
+    namespace: NodeNamespace,
+    names: HashMap<usize, String>,
+    child_uses: HashSet<usize>,
+    nodes: Vec<NodeDefinition>,
+    locations: BTreeMap<String, LuaSourceLocation>,
+    schemas: BTreeMap<String, SchemaDef>,
+    schema_names: HashMap<usize, String>,
+}
+
+impl WorkflowGraphBuilder {
+    fn new(host: WorkflowLuaHost) -> Self {
+        Self {
+            host,
+            namespace: NodeNamespace::default(),
+            names: HashMap::new(),
+            child_uses: HashSet::new(),
+            nodes: Vec::new(),
+            locations: BTreeMap::new(),
+            schemas: BTreeMap::new(),
+            schema_names: HashMap::new(),
+        }
+    }
+
+    fn build(mut self, workflow_index: usize) -> Result<LuaWorkflowDefinition, LuaWorkflowError> {
+        let workflow = self
+            .host
+            .workflows
+            .get(workflow_index)
+            .cloned()
+            .ok_or_else(|| build_error("WFS010", "returned Workflow handle is invalid", None))?;
+        let main = self
+            .host
+            .nodes
+            .get(workflow.main)
+            .ok_or_else(|| build_error("WFR006", "workflow main node does not exist", None))?;
+        if main.name.is_some() {
+            return Err(build_error(
+                "WFS006",
+                "workflow main node must not declare a name",
+                Some(main.location.clone()),
+            ));
+        }
+        self.namespace
+            .register(MAIN_ENTRY_NODE_NAME)
+            .map_err(|error| {
+                build_error("WFS006", error.to_string(), Some(main.location.clone()))
+            })?;
+        self.names
+            .insert(workflow.main, MAIN_ENTRY_NODE_NAME.to_string());
+        self.child_uses.insert(workflow.main);
+        self.visit_node(workflow.main)?;
+        Ok(LuaWorkflowDefinition {
+            workflow: WorkflowDefinition {
+                name: workflow.name,
+                description: workflow.description,
+                builtin: false,
+                schemas: self.schemas,
+                nodes: self.nodes,
+                entry: MAIN_ENTRY_NODE_NAME.to_string(),
+            },
+            node_locations: self.locations,
+        })
+    }
+
+    fn visit_node(&mut self, index: usize) -> Result<(), LuaWorkflowError> {
+        if self
+            .nodes
+            .iter()
+            .any(|node| self.names.get(&index) == Some(&node.name))
+        {
+            return Ok(());
+        }
+        let draft = self
+            .host
+            .nodes
+            .get(index)
+            .cloned()
+            .ok_or_else(|| build_error("WFR001", "node handle does not exist", None))?;
+        let name = self.names.get(&index).cloned().ok_or_else(|| {
+            build_error(
+                "WFS006",
+                "node name was not assigned",
+                Some(draft.location.clone()),
+            )
+        })?;
+        let child_indices = match &draft.kind {
+            NodeDraftKind::Fanout { children, .. } | NodeDraftKind::Sequence { children, .. } => {
+                children.clone()
+            }
+            _ => Vec::new(),
+        };
+        for (position, child_index) in child_indices.iter().enumerate() {
+            let child = self.host.children.get(*child_index).ok_or_else(|| {
+                build_error(
+                    "WFR001",
+                    "child handle does not exist",
+                    Some(draft.location.clone()),
+                )
+            })?;
+            if !self.child_uses.insert(child.node) {
+                return Err(build_error(
+                    "WFC007",
+                    "the same Node value cannot be used by multiple children",
+                    Some(child.location.clone()),
+                ));
+            }
+            let child_node = self.host.nodes.get(child.node).ok_or_else(|| {
+                build_error(
+                    "WFR001",
+                    "child node does not exist",
+                    Some(child.location.clone()),
+                )
+            })?;
+            let child_name = match &child_node.name {
+                Some(explicit) => {
+                    self.namespace
+                        .register_explicit(explicit.clone())
+                        .map_err(|error| {
+                            build_error(
+                                "WFS006",
+                                error.to_string(),
+                                Some(child_node.location.clone()),
+                            )
+                        })?
+                }
+                None => self
+                    .namespace
+                    .register_synthesized(&name, position)
+                    .map_err(|error| {
+                        build_error(
+                            "WFS006",
+                            error.to_string(),
+                            Some(child_node.location.clone()),
+                        )
+                    })?,
+            };
+            self.names.insert(child.node, child_name);
+        }
+        let artifact = draft
+            .artifact
+            .map(|schema| self.register_schema(schema))
+            .transpose()?;
+        let input = draft
+            .input
+            .iter()
+            .map(|input| self.build_input(*input))
+            .collect::<Result<Vec<_>, _>>()?;
+        let kind = match draft.kind {
+            NodeDraftKind::Command(command) => NodeKind::Command(CommandSpec { command }),
+            NodeDraftKind::Session {
+                provider,
+                model,
+                permission,
+                facets,
+            } => NodeKind::Session(SessionSpec {
+                provider,
+                model,
+                permission,
+                facets,
+            }),
+            NodeDraftKind::Fanout { children, items } => NodeKind::Fanout(FanoutSpec {
+                children: self.build_children(index, &children, true)?,
+                items: items
+                    .map(|value| self.build_fanout_items(index, value))
+                    .transpose()?,
+            }),
+            NodeDraftKind::Sequence {
+                children,
+                entry,
+                output,
+            } => {
+                let child_nodes = children
+                    .iter()
+                    .map(|child| self.host.children[*child].node)
+                    .collect::<HashSet<_>>();
+                let entry =
+                    self.optional_child_name(entry, &child_nodes, &draft.location, "entry")?;
+                let output =
+                    self.optional_child_name(output, &child_nodes, &draft.location, "output")?;
+                NodeKind::Sequence(SequenceSpec {
+                    entry,
+                    output,
+                    children: self.build_children(index, &children, false)?,
+                })
+            }
+        };
+        self.locations.insert(name.clone(), draft.location);
+        self.nodes.push(NodeDefinition {
+            name,
+            kind,
+            artifact,
+            input,
+            completion: draft.completion,
+            worktree: None,
+        });
+        for child_index in &child_indices {
+            let node = self.host.children[*child_index].node;
+            self.visit_node(node)?;
+        }
+        Ok(())
+    }
+
+    fn build_input(&mut self, input_index: usize) -> Result<InputParam, LuaWorkflowError> {
+        let input = self
+            .host
+            .inputs
+            .get(input_index)
+            .cloned()
+            .ok_or_else(|| build_error("WFS002", "input handle does not exist", None))?;
+        let contract = input
+            .contract
+            .map(|schema| self.register_schema(schema))
+            .transpose()?;
+        Ok(InputParam {
+            name: input.name,
+            contract,
+        })
+    }
+
+    fn register_schema(&mut self, index: usize) -> Result<String, LuaWorkflowError> {
+        if let Some(name) = self.schema_names.get(&index) {
+            return Ok(name.clone());
+        }
+        let draft = self
+            .host
+            .schemas
+            .get(index)
+            .cloned()
+            .ok_or_else(|| build_error("WFS002", "schema handle does not exist", None))?;
+        let name = draft
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("schema-{index}"));
+        if self.schemas.contains_key(&name)
+            || self.schema_names.values().any(|value| value == &name)
+        {
+            return Err(build_error(
+                "WFS006",
+                format!("schema name '{name}' is duplicated"),
+                None,
+            ));
+        }
+        self.schema_names.insert(index, name.clone());
+        let definition = match draft.kind {
+            SchemaDraftKind::Object {
+                properties,
+                required,
+            } => {
+                let mut mapped = BTreeMap::new();
+                for (property, schema) in properties {
+                    mapped.insert(property, self.inline_schema(schema)?);
+                }
+                SchemaDef::Object {
+                    properties: mapped,
+                    required,
+                }
+            }
+            SchemaDraftKind::Array { items } => SchemaDef::Array {
+                items: self.register_schema(items)?,
+            },
+            SchemaDraftKind::String { values } => SchemaDef::String { r#enum: values },
+            SchemaDraftKind::Boolean => SchemaDef::Boolean,
+            SchemaDraftKind::Integer => SchemaDef::Integer,
+            SchemaDraftKind::Number => SchemaDef::Number,
+        };
+        self.schemas.insert(name.clone(), definition);
+        Ok(name)
+    }
+
+    fn inline_schema(&mut self, index: usize) -> Result<SchemaDef, LuaWorkflowError> {
+        let draft = self
+            .host
+            .schemas
+            .get(index)
+            .cloned()
+            .ok_or_else(|| build_error("WFS002", "schema handle does not exist", None))?;
+        if draft.name.is_some() {
+            let name = self.register_schema(index)?;
+            return Ok(self.schemas[&name].clone());
+        }
+        match draft.kind {
+            SchemaDraftKind::Object {
+                properties,
+                required,
+            } => {
+                let mut mapped = BTreeMap::new();
+                for (property, schema) in properties {
+                    mapped.insert(property, self.inline_schema(schema)?);
+                }
+                Ok(SchemaDef::Object {
+                    properties: mapped,
+                    required,
+                })
+            }
+            SchemaDraftKind::Array { .. } => {
+                let name = self.register_schema(index)?;
+                Ok(self.schemas[&name].clone())
+            }
+            SchemaDraftKind::String { values } => Ok(SchemaDef::String { r#enum: values }),
+            SchemaDraftKind::Boolean => Ok(SchemaDef::Boolean),
+            SchemaDraftKind::Integer => Ok(SchemaDef::Integer),
+            SchemaDraftKind::Number => Ok(SchemaDef::Number),
+        }
+    }
+
+    fn optional_child_name(
+        &self,
+        node: Option<usize>,
+        children: &HashSet<usize>,
+        location: &LuaSourceLocation,
+        field: &str,
+    ) -> Result<Option<String>, LuaWorkflowError> {
+        let Some(node) = node else {
+            return Ok(None);
+        };
+        if !children.contains(&node) {
+            return Err(build_error(
+                "WFR001",
+                format!("sequence {field} must be one of its children"),
+                Some(location.clone()),
+            ));
+        }
+        Ok(self.names.get(&node).cloned())
+    }
+
+    fn build_children(
+        &self,
+        owner: usize,
+        children: &[usize],
+        fanout: bool,
+    ) -> Result<Vec<ChildEntry>, LuaWorkflowError> {
+        let scope = children
+            .iter()
+            .map(|child| self.host.children[*child].node)
+            .collect::<HashSet<_>>();
+        let owner_inputs = self.host.nodes[owner]
+            .input
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        children
+            .iter()
+            .map(|child_index| {
+                let child = &self.host.children[*child_index];
+                let inputs = child
+                    .inputs
+                    .iter()
+                    .map(|(parameter, source)| {
+                        self.source_ref(*source, &scope, &owner_inputs, fanout, &child.location)
+                            .map(|source| (parameter.clone(), InputSourceRef::new(source)))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let rules = child
+                    .rules
+                    .as_ref()
+                    .map(|rules| {
+                        rules
+                            .iter()
+                            .map(|rule| self.build_rule(*rule, child.node, &scope, &child.location))
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?;
+                Ok(ChildEntry {
+                    name: self.names[&child.node].clone(),
+                    inputs,
+                    rules,
+                    on_failure: child.on_failure,
+                })
+            })
+            .collect()
+    }
+
+    fn source_ref(
+        &self,
+        source: usize,
+        scope: &HashSet<usize>,
+        owner_inputs: &HashSet<usize>,
+        fanout: bool,
+        location: &LuaSourceLocation,
+    ) -> Result<String, LuaWorkflowError> {
+        match self.host.sources.get(source) {
+            Some(SourceDraft::Node { node, fields }) if !fanout && scope.contains(node) => {
+                let mut raw = self.names[node].clone();
+                if !fields.is_empty() {
+                    raw.push('.');
+                    raw.push_str(&fields.join("."));
+                }
+                Ok(raw)
+            }
+            Some(SourceDraft::Input { input, fields }) if owner_inputs.contains(input) => {
+                let mut raw = self.host.inputs[*input].name.clone();
+                if !fields.is_empty() {
+                    raw.push('.');
+                    raw.push_str(&fields.join("."));
+                }
+                Ok(raw)
+            }
+            Some(SourceDraft::Request) => Ok("request".to_string()),
+            Some(SourceDraft::Items) if fanout => Ok("items".to_string()),
+            Some(_) => Err(build_error(
+                "WFR007",
+                "input source is outside the composite node scope",
+                Some(location.clone()),
+            )),
+            None => Err(build_error(
+                "WFR007",
+                "input source does not exist",
+                Some(location.clone()),
+            )),
+        }
+    }
+
+    fn build_rule(
+        &self,
+        rule: usize,
+        child_node: usize,
+        scope: &HashSet<usize>,
+        location: &LuaSourceLocation,
+    ) -> Result<Rule, LuaWorkflowError> {
+        let target = |node: &usize| {
+            if !scope.contains(node) {
+                return Err(build_error(
+                    "WFR001",
+                    "rule target must be a sibling child",
+                    Some(location.clone()),
+                ));
+            }
+            Ok(self.names[node].clone())
+        };
+        match self.host.rules.get(rule) {
+            Some(RuleDraft::Next(node)) => Ok(Rule::Next(target(node)?)),
+            Some(RuleDraft::When { on, on_true, next }) => Ok(Rule::When {
+                on: self.rule_field(*on, child_node, location)?,
+                then: target(on_true)?,
+                next: target(next)?,
+            }),
+            Some(RuleDraft::Switch { on, cases, next }) => Ok(Rule::Switch {
+                on: self.rule_field(*on, child_node, location)?,
+                cases: cases
+                    .iter()
+                    .map(|(value, node)| target(node).map(|name| (value.clone(), name)))
+                    .collect::<Result<_, _>>()?,
+                next: next.as_ref().map(target).transpose()?,
+            }),
+            Some(RuleDraft::LoopGuard {
+                max_iterations,
+                on_exhausted,
+            }) => Ok(Rule::LoopGuard {
+                max_iterations: *max_iterations,
+                on_exhausted: target(on_exhausted)?,
+            }),
+            None => Err(build_error(
+                "WFS002",
+                "rule handle does not exist",
+                Some(location.clone()),
+            )),
+        }
+    }
+
+    fn rule_field(
+        &self,
+        source: usize,
+        child_node: usize,
+        location: &LuaSourceLocation,
+    ) -> Result<String, LuaWorkflowError> {
+        match self.host.sources.get(source) {
+            Some(SourceDraft::Node { node, fields })
+                if *node == child_node && !fields.is_empty() =>
+            {
+                Ok(fields.join("."))
+            }
+            _ => Err(build_error(
+                "WFR003",
+                "rule discriminator must reference the current child artifact field",
+                Some(location.clone()),
+            )),
+        }
+    }
+
+    fn build_fanout_items(
+        &self,
+        owner: usize,
+        items: FanoutItemsDraft,
+    ) -> Result<ItemsSource, LuaWorkflowError> {
+        match items {
+            FanoutItemsDraft::Literal(values) => Ok(ItemsSource::Literal(values)),
+            FanoutItemsDraft::Source(source) => match self.host.sources.get(source) {
+                Some(SourceDraft::Node { node, fields }) if !fields.is_empty() => {
+                    Ok(ItemsSource::ArtifactField {
+                        node: self.names.get(node).cloned().unwrap_or_else(|| {
+                            self.host.nodes[*node].name.clone().unwrap_or_default()
+                        }),
+                        field: fields.join("."),
+                    })
+                }
+                Some(SourceDraft::Input { input, .. })
+                    if self.host.nodes[owner].input.contains(input) =>
+                {
+                    Err(build_error(
+                        "WFR003",
+                        "fanout items cannot use an input parameter directly",
+                        None,
+                    ))
+                }
+                _ => Err(build_error(
+                    "WFR003",
+                    "fanout items must reference an artifact field",
+                    None,
+                )),
+            },
+        }
+    }
+}
+
+fn handle(kind: &str, index: usize) -> LuaData {
+    LuaData::Handle(LuaHostHandle {
+        kind: kind.to_string(),
+        index,
+    })
+}
+
+fn push_node(nodes: &mut Vec<NodeDraft>, draft: NodeDraft) -> LuaData {
+    let index = nodes.len();
+    nodes.push(draft);
+    handle(HANDLE_NODE, index)
+}
+
+fn push_rule(rules: &mut Vec<RuleDraft>, draft: RuleDraft) -> LuaData {
+    let index = rules.len();
+    rules.push(draft);
+    handle(HANDLE_RULE, index)
+}
+
+fn expect_handle_data(value: &LuaData, kind: &str) -> Result<usize, String> {
+    expect_handle(value, kind).map_err(|_| format!("Lua chunk must return a {kind} value"))
+}
+
+fn expect_handle(value: &LuaData, kind: &str) -> Result<usize, ()> {
+    match value {
+        LuaData::Handle(handle) if handle.kind == kind => Ok(handle.index),
+        _ => Err(()),
+    }
+}
+
+fn one_table(
+    arguments: Vec<LuaData>,
+    location: &LuaSourceLocation,
+) -> Result<LuaTableData, LuaHostError> {
+    match arguments.as_slice() {
+        [LuaData::Table(table)] => Ok(table.clone()),
+        _ => Err(host_error(
+            "WFS002",
+            "builder expects exactly one table argument",
+            location.clone(),
+        )),
+    }
+}
+
+fn one_handle(
+    arguments: Vec<LuaData>,
+    kind: &str,
+    location: &LuaSourceLocation,
+) -> Result<usize, LuaHostError> {
+    match arguments.as_slice() {
+        [value] => expect_handle(value, kind).map_err(|_| type_error("argument", kind, location)),
+        _ => Err(host_error(
+            "WFS002",
+            "builder expects exactly one argument",
+            location.clone(),
+        )),
+    }
+}
+
+fn one_u32(arguments: Vec<LuaData>, location: &LuaSourceLocation) -> Result<u32, LuaHostError> {
+    match arguments.as_slice() {
+        [LuaData::Integer(value)] => {
+            u32::try_from(*value).map_err(|_| type_error("argument", "u32", location))
+        }
+        _ => Err(type_error("argument", "u32", location)),
+    }
+}
+
+fn reject_unknown(
+    table: &LuaTableData,
+    known: &[&str],
+    location: &LuaSourceLocation,
+) -> Result<(), LuaHostError> {
+    for key in table.string_keys() {
+        if !known.contains(&key) {
+            return Err(host_error(
+                "WFS002",
+                format!("unknown field '{key}'"),
+                location.clone(),
+            ));
+        }
+    }
+    if table
+        .entries
+        .keys()
+        .any(|key| !matches!(key, LuaTableKey::String(_)))
+    {
+        return Err(host_error(
+            "WFS002",
+            "builder table keys must be strings",
+            location.clone(),
+        ));
+    }
+    Ok(())
+}
+
+fn required_string(
+    table: &LuaTableData,
+    field: &str,
+    location: &LuaSourceLocation,
+) -> Result<String, LuaHostError> {
+    match table.get_string(field) {
+        Some(LuaData::String(value)) => Ok(value.clone()),
+        None | Some(LuaData::Nil) => Err(missing_field(field, location)),
+        Some(_) => Err(type_error(field, "string", location)),
+    }
+}
+
+fn optional_string(
+    table: &LuaTableData,
+    field: &str,
+    location: &LuaSourceLocation,
+) -> Result<Option<String>, LuaHostError> {
+    match table.get_string(field) {
+        None | Some(LuaData::Nil) => Ok(None),
+        Some(LuaData::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(type_error(field, "string", location)),
+    }
+}
+
+fn required_u32(
+    table: &LuaTableData,
+    field: &str,
+    location: &LuaSourceLocation,
+) -> Result<u32, LuaHostError> {
+    match table.get_string(field) {
+        Some(LuaData::Integer(value)) => {
+            u32::try_from(*value).map_err(|_| type_error(field, "u32", location))
+        }
+        None | Some(LuaData::Nil) => Err(missing_field(field, location)),
+        Some(_) => Err(type_error(field, "u32", location)),
+    }
+}
+
+fn required_table<'a>(
+    table: &'a LuaTableData,
+    field: &str,
+    location: &LuaSourceLocation,
+) -> Result<&'a LuaTableData, LuaHostError> {
+    match table.get_string(field) {
+        Some(LuaData::Table(value)) => Ok(value),
+        None | Some(LuaData::Nil) => Err(missing_field(field, location)),
+        Some(_) => Err(type_error(field, "table", location)),
+    }
+}
+
+fn required_handle(
+    table: &LuaTableData,
+    field: &str,
+    kind: &str,
+    location: &LuaSourceLocation,
+) -> Result<usize, LuaHostError> {
+    match table.get_string(field) {
+        Some(value) => expect_handle(value, kind).map_err(|_| type_error(field, kind, location)),
+        None => Err(missing_field(field, location)),
+    }
+}
+
+fn optional_handle(
+    table: &LuaTableData,
+    field: &str,
+    kind: &str,
+    location: &LuaSourceLocation,
+) -> Result<Option<usize>, LuaHostError> {
+    match table.get_string(field) {
+        None | Some(LuaData::Nil) => Ok(None),
+        Some(value) => expect_handle(value, kind)
+            .map(Some)
+            .map_err(|_| type_error(field, kind, location)),
+    }
+}
+
+fn required_handle_array(
+    table: &LuaTableData,
+    field: &str,
+    kind: &str,
+    location: &LuaSourceLocation,
+) -> Result<Vec<usize>, LuaHostError> {
+    optional_handle_array(table, field, kind, location)?
+        .ok_or_else(|| missing_field(field, location))
+}
+
+fn optional_handle_array(
+    table: &LuaTableData,
+    field: &str,
+    kind: &str,
+    location: &LuaSourceLocation,
+) -> Result<Option<Vec<usize>>, LuaHostError> {
+    match table.get_string(field) {
+        None | Some(LuaData::Nil) => Ok(None),
+        Some(LuaData::Table(values)) => values
+            .as_array()
+            .ok_or_else(|| type_error(field, "array", location))?
+            .into_iter()
+            .map(|value| expect_handle(value, kind).map_err(|_| type_error(field, kind, location)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some),
+        Some(_) => Err(type_error(field, "array", location)),
+    }
+}
+
+fn optional_string_array(
+    table: &LuaTableData,
+    field: &str,
+    location: &LuaSourceLocation,
+) -> Result<Option<Vec<String>>, LuaHostError> {
+    match table.get_string(field) {
+        None | Some(LuaData::Nil) => Ok(None),
+        Some(LuaData::Table(values)) => values
+            .as_array()
+            .ok_or_else(|| type_error(field, "string array", location))?
+            .into_iter()
+            .map(|value| match value {
+                LuaData::String(value) => Ok(value.clone()),
+                _ => Err(type_error(field, "string array", location)),
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some),
+        Some(_) => Err(type_error(field, "string array", location)),
+    }
+}
+
+fn parse_completion(
+    table: &LuaTableData,
+    location: &LuaSourceLocation,
+) -> Result<NodeCompletion, LuaHostError> {
+    match table.get_string("completion") {
+        None | Some(LuaData::Nil) => Ok(NodeCompletion::Auto),
+        Some(value) if expect_handle(value, HANDLE_COMPLETION) == Ok(0) => {
+            Ok(NodeCompletion::Approval)
+        }
+        Some(_) => Err(type_error("completion", "Completion", location)),
+    }
+}
+
+fn lua_array_to_json(
+    table: &LuaTableData,
+    location: &LuaSourceLocation,
+) -> Result<Vec<Value>, LuaHostError> {
+    table
+        .as_array()
+        .ok_or_else(|| type_error("items", "literal array", location))?
+        .into_iter()
+        .map(|value| lua_to_json(value, location))
+        .collect()
+}
+
+fn lua_to_json(value: &LuaData, location: &LuaSourceLocation) -> Result<Value, LuaHostError> {
+    match value {
+        LuaData::Nil => Ok(Value::Null),
+        LuaData::Boolean(value) => Ok(Value::Bool(*value)),
+        LuaData::Integer(value) => Ok(Value::Number((*value).into())),
+        LuaData::Number(value) => Number::from_f64(*value)
+            .map(Value::Number)
+            .ok_or_else(|| type_error("items", "finite JSON value", location)),
+        LuaData::String(value) => Ok(Value::String(value.clone())),
+        LuaData::Table(table) => {
+            if let Some(array) = table.as_array() {
+                return array
+                    .into_iter()
+                    .map(|value| lua_to_json(value, location))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(Value::Array);
+            }
+            let mut object = serde_json::Map::new();
+            for (key, value) in &table.entries {
+                let LuaTableKey::String(key) = key else {
+                    return Err(type_error("items", "JSON-compatible value", location));
+                };
+                object.insert(key.clone(), lua_to_json(value, location)?);
+            }
+            Ok(Value::Object(object))
+        }
+        LuaData::Handle(_) => Err(type_error("items", "JSON-compatible value", location)),
+    }
+}
+
+fn lua_key_as_case(key: &LuaTableKey) -> Option<String> {
+    match key {
+        LuaTableKey::Boolean(value) => Some(value.to_string()),
+        LuaTableKey::Integer(value) => Some(value.to_string()),
+        LuaTableKey::String(value) => Some(value.clone()),
+    }
+}
+
+fn missing_field(field: &str, location: &LuaSourceLocation) -> LuaHostError {
+    host_error(
+        "WFS002",
+        format!("missing required field '{field}'"),
+        location.clone(),
+    )
+}
+
+fn type_error(field: &str, expected: &str, location: &LuaSourceLocation) -> LuaHostError {
+    host_error(
+        "WFS002",
+        format!("field '{field}' must be {expected}"),
+        location.clone(),
+    )
+}
+
+fn host_error(code: &str, message: impl Into<String>, location: LuaSourceLocation) -> LuaHostError {
+    LuaHostError {
+        category: code.to_string(),
+        message: message.into(),
+        location: Some(location),
+    }
+}
+
+fn build_error(
+    code: &str,
+    message: impl Into<String>,
+    location: Option<LuaSourceLocation>,
+) -> LuaWorkflowError {
+    LuaWorkflowError {
+        code: code.to_string(),
+        message: message.into(),
+        location,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn load(source: &str) -> Result<LuaWorkflowDefinition, LuaWorkflowError> {
+        let directory = TempDir::new().unwrap();
+        load_lua_workflow(
+            "review.lua",
+            source,
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+    }
+
+    #[test]
+    fn builds_a_workflow_and_synthesizes_child_names() {
+        let loaded = load(
+            r#"
+local r = require("releash")
+local first = r.command{ command = "echo first" }
+local second = r.command{ command = "echo second" }
+return r.workflow{
+  name = "review",
+  description = "Review",
+  main = r.sequence{
+    children = {
+      r.child{ node = first },
+      r.child{ node = second },
+    },
+  },
+}
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(loaded.workflow.entry, "main");
+        assert_eq!(loaded.workflow.nodes[0].name, "main");
+        assert!(loaded.workflow.node_by_name("main#0").is_some());
+        assert!(loaded.workflow.node_by_name("main#1").is_some());
+    }
+
+    #[test]
+    fn rejects_same_node_value_in_multiple_children() {
+        let error = load(
+            r#"
+local r = require("releash")
+local child = r.command{ command = "echo" }
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{ children = {
+    r.child{ node = child }, r.child{ node = child },
+  } },
+}
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFC007");
+    }
+
+    #[test]
+    fn rejects_unknown_builder_field_at_call_line() {
+        let error = load(
+            r#"
+local r = require("releash")
+local child = r.command{ command = "echo", unknown = true }
+return r.workflow{ name = "review", description = "Review", main = child }
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFS002");
+        assert_eq!(error.location.unwrap().line, 3);
+    }
+
+    #[test]
+    fn maps_require_failures_and_non_workflow_returns_to_spec_codes() {
+        let directory = TempDir::new().unwrap();
+        let require_error = load_lua_workflow(
+            "review.lua",
+            "local value = require('../outside')\nreturn value",
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+        .unwrap_err();
+        let return_error = load_lua_workflow(
+            "review.lua",
+            "return {}",
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(require_error.code, "WFS011");
+        assert_eq!(require_error.location.unwrap().line, 1);
+        assert_eq!(return_error.code, "WFS010");
+        assert_eq!(return_error.location.unwrap().line, 1);
+    }
+
+    #[test]
+    fn rejects_unknown_artifact_field_at_index_line() {
+        let error = load(
+            r#"
+local r = require("releash")
+local child = r.command{
+  command = "echo",
+  artifact = r.schema.object{ properties = { ok = r.schema.boolean() } },
+}
+local invalid = child.missing
+return r.workflow{ name = "review", description = "Review", main = child }
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFR003");
+        let location = error.location.unwrap();
+        assert_eq!(location.source, "review.lua");
+        assert_eq!(location.line, 7);
+    }
+
+    #[test]
+    fn rejects_unknown_facet_at_reference_line() {
+        let directory = TempDir::new().unwrap();
+        let error = load_lua_workflow(
+            "review.lua",
+            r#"
+local r = require("releash")
+local f = require("facets")
+local child = r.session{
+  provider = r.provider.claude,
+  facets = { instruction = f.instruction.missing },
+}
+return r.workflow{ name = "review", description = "Review", main = child }
+"#,
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFR900");
+        let location = error.location.unwrap();
+        assert_eq!(location.source, "review.lua");
+        assert_eq!(location.line, 6);
+    }
+
+    #[test]
+    fn reports_reference_error_at_required_component_file_and_line() {
+        let directory = TempDir::new().unwrap();
+        let component = directory.path().join("component.lua");
+        fs::write(
+            &component,
+            r#"
+local r = require("releash")
+return function()
+  local child = r.command{ command = "echo" }
+  local invalid = child.missing
+  return child
+end
+"#,
+        )
+        .unwrap();
+
+        let error = load_lua_workflow(
+            "review.lua",
+            r#"
+local r = require("releash")
+local component = require("component")
+return r.workflow{ name = "review", description = "Review", main = component() }
+"#,
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+        .unwrap_err();
+        let location = error.location.unwrap();
+
+        assert_eq!(error.code, "WFR003");
+        assert_eq!(
+            location.source,
+            fs::canonicalize(component).unwrap().to_string_lossy()
+        );
+        assert_eq!(location.line, 5);
+    }
+
+    #[test]
+    fn require_component_function_creates_independent_nodes() {
+        let directory = TempDir::new().unwrap();
+        fs::write(
+            directory.path().join("component.lua"),
+            r#"
+local r = require("releash")
+return function(command)
+  local leaf = r.command{ command = command }
+  return r.sequence{
+    completion = r.completion.approval,
+    children = { r.child{ node = leaf } },
+  }
+end
+"#,
+        )
+        .unwrap();
+        let loaded = load_lua_workflow(
+            "review.lua",
+            r#"
+local r = require("releash")
+local component = require("component")
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{ children = {
+    r.child{ node = component("one") },
+    r.child{ node = component("two") },
+  } },
+}
+"#,
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+        .unwrap();
+
+        assert_eq!(loaded.workflow.nodes.len(), 5);
+        assert_eq!(
+            loaded
+                .workflow
+                .nodes
+                .iter()
+                .map(|node| node.name.as_str())
+                .collect::<Vec<_>>(),
+            ["main", "main#0", "main#0#0", "main#1", "main#1#0"]
+        );
+        assert_eq!(
+            loaded.workflow.node_by_name("main#0").unwrap().completion,
+            NodeCompletion::Approval
+        );
+        assert!(loaded
+            .workflow
+            .node_by_name("main#0")
+            .unwrap()
+            .is_sequence());
+    }
+
+    #[test]
+    fn builds_schema_fanout_items_and_scoped_item_wiring() {
+        let directory = TempDir::new().unwrap();
+        let loaded = load_lua_workflow(
+            "review.lua",
+            r#"
+local r = require("releash")
+local f = require("facets")
+local topic = r.schema.string{}
+local detail = r.schema.object{
+  name = "topic-detail",
+  properties = { label = r.schema.string{} },
+}
+local scan = r.command{
+  command = "scan",
+  artifact = r.schema.object{
+    properties = {
+      topics = r.schema.array{ items = topic },
+      detail = detail,
+    },
+    required = { "topics" },
+  },
+}
+local worker = r.session{
+  provider = r.provider.codex,
+  facets = { instruction = f.instruction.review },
+  input = { r.input("topic", topic) },
+}
+local spread = r.fanout{
+  items = scan.topics,
+  children = {
+    r.child{ node = worker, inputs = { topic = r.items } },
+  },
+}
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{ children = {
+    r.child{ node = scan },
+    r.child{ node = spread },
+  } },
+}
+"#,
+            directory.path(),
+            LuaFacetCatalog {
+                instruction: vec!["review".to_string()],
+                ..LuaFacetCatalog::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            loaded
+                .workflow
+                .nodes
+                .iter()
+                .map(|node| node.name.as_str())
+                .collect::<Vec<_>>(),
+            ["main", "main#0", "main#1", "main#1#0"]
+        );
+        let validation_errors = crate::domain::workflow::validation::validate_all(&loaded.workflow);
+        assert!(validation_errors.is_empty(), "{validation_errors:#?}");
+        assert!(loaded.workflow.schemas.contains_key("topic-detail"));
+    }
+
+    #[test]
+    fn rejects_input_source_from_outer_composite_scope() {
+        let error = load(
+            r#"
+local r = require("releash")
+local outer = r.input("outer")
+local leaf = r.command{ command = "echo", input = { r.input("value") } }
+local inner = r.sequence{
+  children = { r.child{ node = leaf, inputs = { value = outer } } },
+}
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{
+    input = { outer },
+    children = { r.child{ node = inner } },
+  },
+}
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFR007");
+        let location = error.location.unwrap();
+        assert_eq!(location.source, "review.lua");
+        assert_eq!(location.line, 6);
+    }
+
+    #[test]
+    fn accepts_field_reference_from_composite_input_contract() {
+        let loaded = load(
+            r#"
+local r = require("releash")
+local payload = r.input("payload", r.schema.object{
+  properties = { message = r.schema.string{} },
+  required = { "message" },
+})
+local leaf = r.command{ command = "echo", input = { r.input("value") } }
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{
+    input = { payload },
+    children = { r.child{ node = leaf, inputs = { value = payload.message } } },
+  },
+}
+"#,
+        )
+        .unwrap();
+
+        let sequence = loaded.workflow.entry_node().unwrap().sequence().unwrap();
+        assert_eq!(sequence.children[0].inputs[0].1.raw(), "payload.message");
+    }
+
+    #[test]
+    fn rejects_named_main_node() {
+        let error = load(
+            r#"
+local r = require("releash")
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.command{ name = "root", command = "true" },
+}
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFS006");
+        assert_eq!(error.location.unwrap().line, 5);
+    }
+
+    #[test]
+    fn rejects_missing_main_with_existing_resolve_diagnostic() {
+        let error = load(
+            r#"
+local r = require("releash")
+return r.workflow{ name = "review", description = "Review" }
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFR006");
+        let location = error.location.unwrap();
+        assert_eq!(location.source, "review.lua");
+        assert_eq!(location.line, 3);
+    }
+
+    #[test]
+    fn rejects_nested_field_reference_at_the_index_line() {
+        let error = load(
+            r#"
+local r = require("releash")
+local child = r.command{
+  command = "echo",
+  artifact = r.schema.object{ properties = {
+    nested = r.schema.object{ properties = { value = r.schema.string{} } },
+  } },
+}
+local invalid = child.nested.value
+return r.workflow{ name = "review", description = "Review", main = child }
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFR003");
+        assert_eq!(error.location.unwrap().line, 9);
+    }
+
+    #[test]
+    fn rejects_non_field_fanout_items_at_the_builder_line() {
+        let error = load(
+            r#"
+local r = require("releash")
+local source = r.command{ command = "source" }
+local child = r.command{ command = "child" }
+local spread = r.fanout{
+  items = source,
+  children = { r.child{ node = child } },
+}
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{ children = {
+    r.child{ node = source }, r.child{ node = spread },
+  } },
+}
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFR003");
+        assert_eq!(error.location.unwrap().line, 5);
+    }
+
+    #[test]
+    fn lua_definition_equals_the_same_yaml_definition_without_origin_metadata() {
+        let loaded = load(
+            r#"
+local r = require("releash")
+local result = r.schema.object{
+  name = "result",
+  properties = { message = r.schema.string{} },
+  required = { "message" },
+}
+local inspect = r.command{
+  name = "inspect",
+  command = "echo inspect",
+  artifact = result,
+  input = { r.input("request_text") },
+  completion = r.completion.approval,
+}
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{ children = {
+    r.child{ node = inspect, inputs = { request_text = r.request } },
+  } },
+}
+"#,
+        )
+        .unwrap();
+        let yaml: WorkflowDefinition = serde_saphyr::from_str(
+            r#"
+name: review
+description: Review
+schemas:
+  result:
+    type: object
+    properties:
+      message: string
+    required:
+      - message
+nodes:
+  main:
+    sequence:
+      children:
+        - inspect:
+            command: echo inspect
+            artifact: result
+            input:
+              - request_text
+            completion: approval
+            inputs:
+              request_text: request
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(loaded.workflow, yaml);
+
+        use crate::domain::workflow::entities::workflow_execution::{
+            WorkflowExecution, WorkflowExecutionRestore,
+        };
+        let mut lua_execution = WorkflowExecution::restore_runtime(WorkflowExecutionRestore {
+            id: "execution".to_string(),
+            workflow: loaded.workflow,
+            ..WorkflowExecutionRestore::default()
+        });
+        let mut yaml_execution = WorkflowExecution::restore_runtime(WorkflowExecutionRestore {
+            id: "execution".to_string(),
+            workflow: yaml,
+            ..WorkflowExecutionRestore::default()
+        });
+        let mut lua_index = 0_u32;
+        let mut yaml_index = 0_u32;
+        let lua_started = lua_execution
+            .start_root(
+                &mut || {
+                    lua_index += 1;
+                    format!("node-{lua_index}")
+                },
+                1.0,
+            )
+            .unwrap();
+        let yaml_started = yaml_execution
+            .start_root(
+                &mut || {
+                    yaml_index += 1;
+                    format!("node-{yaml_index}")
+                },
+                1.0,
+            )
+            .unwrap();
+
+        assert_eq!(lua_started, yaml_started);
+        assert_eq!(lua_execution, yaml_execution);
+    }
+
+    #[test]
+    fn builds_all_rule_completion_and_failure_variants() {
+        let loaded = load(
+            r#"
+local r = require("releash")
+local check = r.command{
+  command = "check",
+}
+local classify = r.command{
+  command = "classify",
+  completion = r.completion.approval,
+  artifact = r.schema.object{
+    properties = { status = r.schema.string{ enum = { "done", "retry" } } },
+    required = { "status" },
+  },
+}
+local retry = r.command{ command = "retry" }
+local done = r.command{ command = "done" }
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{ children = {
+    r.child{
+      node = check,
+      rules = { r.when{ on = check.ok, on_true = classify, next = retry } },
+      on_failure = r.retry(2),
+    },
+    r.child{
+      node = classify,
+      rules = { r.switch{ on = classify.status, cases = {
+        done = done,
+        retry = retry,
+      }, next = done } },
+    },
+    r.child{
+      node = retry,
+      rules = {
+        r.loop_guard{ max_iterations = 3, on_exhausted = done },
+        r.next(check),
+      },
+    },
+    r.child{ node = done, rules = {}, on_failure = r.ignore },
+  } },
+}
+"#,
+        )
+        .unwrap();
+
+        let main = loaded.workflow.root_sequence().unwrap();
+        assert!(matches!(
+            main.children[0].rules.as_deref(),
+            Some([Rule::When { .. }])
+        ));
+        assert_eq!(main.children[0].on_failure, Some(OnFailure::Retry(2)));
+        assert!(matches!(
+            main.children[1].rules.as_deref(),
+            Some([Rule::Switch { .. }])
+        ));
+        assert!(matches!(
+            main.children[2].rules.as_deref(),
+            Some([Rule::LoopGuard { .. }, Rule::Next(_)])
+        ));
+        assert_eq!(main.children[3].rules.as_deref(), Some(&[][..]));
+        assert_eq!(main.children[3].on_failure, Some(OnFailure::Ignore));
+        assert_eq!(
+            loaded.workflow.node_by_name("main#1").unwrap().completion,
+            NodeCompletion::Approval
+        );
+        let errors = crate::domain::workflow::validation::validate_all(&loaded.workflow);
+        assert!(errors.is_empty(), "{errors:#?}");
+    }
+
+    #[test]
+    fn runtime_modules_ignore_missing_or_stale_editor_stubs() {
+        let directory = TempDir::new().unwrap();
+        let source = r#"
+local r = require("releash")
+local f = require("facets")
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.session{
+    provider = r.provider.claude,
+    facets = { instruction = f.instruction.live },
+  },
+}
+"#;
+        let catalog = || LuaFacetCatalog {
+            instruction: vec!["live".to_string()],
+            ..LuaFacetCatalog::default()
+        };
+        let without_stubs =
+            load_lua_workflow("review.lua", source, directory.path(), catalog()).unwrap();
+        fs::create_dir_all(directory.path().join(".releash")).unwrap();
+        fs::write(
+            directory.path().join(".releash/releash.lua"),
+            "error('stale runtime stub must not run')",
+        )
+        .unwrap();
+        fs::write(
+            directory.path().join(".releash/facets.lua"),
+            "return { instruction = {} }",
+        )
+        .unwrap();
+
+        let with_stale_stubs =
+            load_lua_workflow("review.lua", source, directory.path(), catalog()).unwrap();
+
+        assert_eq!(with_stale_stubs.workflow, without_stubs.workflow);
+    }
+
+    #[test]
+    fn repeated_loads_of_the_same_file_group_are_deterministic() {
+        let directory = TempDir::new().unwrap();
+        fs::write(
+            directory.path().join("component.lua"),
+            r#"
+local r = require("releash")
+return function(label)
+  return r.command{ command = "echo " .. label }
+end
+"#,
+        )
+        .unwrap();
+        let source = r#"
+local r = require("releash")
+local component = require("component")
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{ children = {
+    r.child{ node = component("one") },
+    r.child{ node = component("two") },
+  } },
+}
+"#;
+
+        let first = load_lua_workflow(
+            "review.lua",
+            source,
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+        .unwrap();
+        let second = load_lua_workflow(
+            "review.lua",
+            source,
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+        .unwrap();
+
+        assert_eq!(second.workflow, first.workflow);
+    }
+
+    #[test]
+    fn resource_limits_are_reported_as_wfs010_without_poisoning_following_loads() {
+        let directory = TempDir::new().unwrap();
+        let infinite = load_lua_workflow_with_limits(
+            "infinite.lua",
+            "while true do end",
+            directory.path(),
+            LuaFacetCatalog::default(),
+            LuaLimits {
+                memory_bytes: 64 * 1024 * 1024,
+                instructions: 20_000,
+            },
+        )
+        .unwrap_err();
+        let oversized = load_lua_workflow_with_limits(
+            "oversized.lua",
+            "return string.rep('x', 16777216)",
+            directory.path(),
+            LuaFacetCatalog::default(),
+            LuaLimits {
+                memory_bytes: 4 * 1024 * 1024,
+                instructions: 50_000_000,
+            },
+        )
+        .unwrap_err();
+        let following = load_lua_workflow(
+            "review.lua",
+            r#"
+local r = require("releash")
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.command{ command = "true" },
+}
+"#,
+            directory.path(),
+            LuaFacetCatalog::default(),
+        );
+
+        assert_eq!(infinite.code, "WFS010");
+        assert!(infinite.message.contains("instruction limit"));
+        assert_eq!(oversized.code, "WFS010");
+        assert!(oversized.message.contains("memory limit"));
+        assert!(following.is_ok());
+    }
+}

--- a/src-tauri/src/adaptor/gateway/workflow/lua/mod.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/lua/mod.rs
@@ -837,6 +837,9 @@ impl WorkflowLuaHost {
             Some(LuaData::Table(values)) => {
                 let mut result = Vec::new();
                 for (key, value) in &values.entries {
+                    // inputs は 1 回の呼び出しで要素数ぶんの Source を積むため、
+                    // 呼び出し入口の検査だけでは上限を超えられる。要素ごとに見る。
+                    self.ensure_arena_budget(&location)?;
                     let LuaTableKey::String(key) = key else {
                         return Err(type_error("inputs", "string-keyed table", &location));
                     };
@@ -2724,6 +2727,37 @@ end
 return r.workflow{
   name = "review", description = "Review",
   main = r.sequence{ children = { r.child{ node = r.command{ command = "true" } } } },
+}
+"#,
+            directory.path(),
+            LuaFacetCatalog::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "WFS010");
+        assert!(error.message.contains("builder values"));
+    }
+
+    #[test]
+    fn rejects_a_single_child_whose_inputs_exhaust_the_arena_budget() {
+        let directory = TempDir::new().unwrap();
+
+        let error = load_lua_workflow(
+            "review.lua",
+            r#"
+local r = require("releash")
+local target = r.command{ command = "x" }
+-- arena を上限の手前まで埋めてから、1 回の r.child で残りを超える inputs を渡す。
+for _ = 1, 99000 do
+  r.command{ command = "x" }
+end
+local inputs = {}
+for i = 1, 5000 do
+  inputs["p" .. i] = target
+end
+return r.workflow{
+  name = "review", description = "Review",
+  main = r.sequence{ children = { r.child{ node = target, inputs = inputs } } },
 }
 "#,
             directory.path(),

--- a/src-tauri/src/adaptor/gateway/workflow/lua/stubs.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/lua/stubs.rs
@@ -1,10 +1,56 @@
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::adaptor::gateway::workflow::{
     builtin,
-    facet::{self, FacetKind},
+    facet::{self, FacetError, FacetKind},
 };
+
+/// 編集支援ファイルの生成で発生しうるエラー。I/O 失敗と facet カタログの失敗を
+/// 型で分ける。
+#[derive(Debug)]
+pub(crate) enum StubGenerationError {
+    Io(std::io::Error),
+    Facet(FacetError),
+    MissingBuiltinFacet { kind: FacetKind, key: String },
+}
+
+impl fmt::Display for StubGenerationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "I/Oエラー: {error}"),
+            Self::Facet(error) => write!(formatter, "facet一覧の取得に失敗: {error}"),
+            Self::MissingBuiltinFacet { kind, key } => write!(
+                formatter,
+                "ビルトインファセット '{key}' ({}) の本文が見つかりません",
+                kind.dir_name()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StubGenerationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Facet(error) => Some(error),
+            Self::MissingBuiltinFacet { .. } => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for StubGenerationError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<FacetError> for StubGenerationError {
+    fn from(error: FacetError) -> Self {
+        Self::Facet(error)
+    }
+}
 
 const RELEASH_STUB: &str = r#"---@meta
 
@@ -144,7 +190,7 @@ const LUARC: &str = r#"{
 }
 "#;
 
-pub(crate) fn generate_editor_support(workflows_dir: &Path) -> std::io::Result<()> {
+pub(crate) fn generate_editor_support(workflows_dir: &Path) -> Result<(), StubGenerationError> {
     fs::create_dir_all(workflows_dir)?;
     let generated_dir = workflows_dir.join(".releash");
     fs::create_dir_all(&generated_dir)?;
@@ -166,7 +212,7 @@ fn write_if_changed(path: &Path, content: &str) -> std::io::Result<()> {
     fs::write(path, content)
 }
 
-fn generate_facet_stub(base_dir: &Path) -> std::io::Result<String> {
+fn generate_facet_stub(base_dir: &Path) -> Result<String, StubGenerationError> {
     let mut output = String::from("---@meta\n\n---@class ReleashFacet\n\n");
     for kind in [
         FacetKind::Instruction,
@@ -179,15 +225,14 @@ fn generate_facet_stub(base_dir: &Path) -> std::io::Result<String> {
             FacetKind::Knowledge => "ReleashKnowledgeFacets",
         };
         output.push_str(&format!("---@class {class_name}\n"));
-        let summaries = facet::list_facet_summaries(kind, base_dir)
-            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        let summaries = facet::list_facet_summaries(kind, base_dir)?;
         for summary in summaries {
             let path = facet_document_path(base_dir, kind, &summary.key, summary.builtin);
             let description = summary.description.replace(['\r', '\n'], " ");
             let key = lua_doc_field(&summary.key);
             output.push_str(&format!(
-                "---@field {key} ReleashFacet {description} ([本文](file://{}))\n",
-                path.display()
+                "---@field {key} ReleashFacet {description} ([本文]({}))\n",
+                facet_document_url(&path)
             ));
         }
         output.push('\n');
@@ -198,7 +243,7 @@ fn generate_facet_stub(base_dir: &Path) -> std::io::Result<String> {
     Ok(output)
 }
 
-fn generate_builtin_facet_documents(base_dir: &Path) -> std::io::Result<()> {
+fn generate_builtin_facet_documents(base_dir: &Path) -> Result<(), StubGenerationError> {
     for kind in [
         FacetKind::Instruction,
         FacetKind::Policy,
@@ -208,15 +253,23 @@ fn generate_builtin_facet_documents(base_dir: &Path) -> std::io::Result<()> {
         fs::create_dir_all(&kind_dir)?;
         for key in builtin::list_builtin_facet_keys(kind) {
             let content = builtin::get_builtin_facet(kind, key).ok_or_else(|| {
-                std::io::Error::other(format!(
-                    "builtin facet content is missing: {}/{key}",
-                    kind.dir_name()
-                ))
+                StubGenerationError::MissingBuiltinFacet {
+                    kind,
+                    key: key.to_string(),
+                }
             })?;
             write_if_changed(&kind_dir.join(format!("{key}.md")), content)?;
         }
     }
     Ok(())
+}
+
+/// 生成する `file://` リンク。パス区切りの正規化と percent-encode を URL 側へ任せ、
+/// 空白を含むパス（macOS の `Application Support` 等）でも有効な URL にする。
+fn facet_document_url(path: &Path) -> String {
+    url::Url::from_file_path(path)
+        .map(|url| url.to_string())
+        .unwrap_or_else(|_| format!("file://{}", path.display()))
 }
 
 fn facet_document_path(
@@ -292,6 +345,32 @@ mod tests {
         assert!(releash.contains("---@field workflow fun(options: ReleashWorkflowOptions)"));
         assert!(releash.contains("---@field on_true ReleashNode"));
         assert!(!releash.contains("---@field equals ReleashNode"));
+    }
+
+    #[test]
+    fn facet_links_percent_encode_paths_with_spaces() {
+        let directory = TempDir::new().unwrap();
+        let base = directory.path().join("Application Support");
+        let instructions = base.join("instructions");
+        fs::create_dir_all(&instructions).unwrap();
+        fs::write(instructions.join("custom.md"), "# Custom facet\nBody").unwrap();
+
+        generate_editor_support(&base).unwrap();
+
+        let facets = fs::read_to_string(base.join(".releash/facets.lua")).unwrap();
+        assert!(facets.contains("Application%20Support"));
+        assert!(!facets.contains("Application Support"));
+    }
+
+    #[test]
+    fn lua_doc_field_quotes_keys_that_are_not_plain_identifiers() {
+        assert_eq!(lua_doc_field("coding"), "coding");
+        assert_eq!(lua_doc_field("_private"), "_private");
+        assert_eq!(
+            lua_doc_field("releash-thread-cli"),
+            "[\"releash-thread-cli\"]"
+        );
+        assert_eq!(lua_doc_field("with\"quote"), "[\"with\\\"quote\"]");
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/lua/stubs.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/lua/stubs.rs
@@ -1,0 +1,347 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::adaptor::gateway::workflow::{
+    builtin,
+    facet::{self, FacetKind},
+};
+
+const RELEASH_STUB: &str = r#"---@meta
+
+---@class ReleashSource
+---@class ReleashNode: ReleashSource
+---@class ReleashChild
+---@class ReleashRule
+---@class ReleashOnFailure
+---@class ReleashInput: ReleashSource
+---@class ReleashSchema
+---@class ReleashFacet
+---@class ReleashProvider
+---@class ReleashCompletion
+---@class ReleashWorkflow
+
+---@class ReleashCommandOptions
+---@field name? string
+---@field command string
+---@field artifact? ReleashSchema
+---@field input? ReleashInput[]
+---@field completion? ReleashCompletion
+
+---@class ReleashSessionFacets
+---@field policy? ReleashFacet
+---@field knowledge? ReleashFacet[]
+---@field instruction? ReleashFacet
+
+---@class ReleashSessionOptions
+---@field name? string
+---@field provider ReleashProvider
+---@field model? string
+---@field permission? string
+---@field facets? ReleashSessionFacets
+---@field artifact? ReleashSchema
+---@field input? ReleashInput[]
+---@field completion? ReleashCompletion
+
+---@class ReleashChildOptions
+---@field node ReleashNode
+---@field inputs? table<string, ReleashSource>
+---@field rules? ReleashRule[]
+---@field on_failure? ReleashOnFailure
+
+---@class ReleashFanoutOptions
+---@field name? string
+---@field children ReleashChild[]
+---@field items? ReleashSource|table
+---@field artifact? ReleashSchema
+---@field input? ReleashInput[]
+---@field completion? ReleashCompletion
+
+---@class ReleashSequenceOptions
+---@field name? string
+---@field entry? ReleashNode
+---@field output? ReleashNode
+---@field children ReleashChild[]
+---@field artifact? ReleashSchema
+---@field input? ReleashInput[]
+---@field completion? ReleashCompletion
+
+---@class ReleashWhenOptions
+---@field on ReleashSource
+---@field on_true ReleashNode
+---@field next ReleashNode
+
+---@class ReleashSwitchOptions
+---@field on ReleashSource
+---@field cases table<string|integer|boolean, ReleashNode>
+---@field next? ReleashNode
+
+---@class ReleashLoopGuardOptions
+---@field max_iterations integer
+---@field on_exhausted ReleashNode
+
+---@class ReleashObjectSchemaOptions
+---@field name? string
+---@field properties table<string, ReleashSchema>
+---@field required? string[]
+
+---@class ReleashArraySchemaOptions
+---@field name? string
+---@field items ReleashSchema
+
+---@class ReleashStringSchemaOptions
+---@field enum? string[]
+
+---@class ReleashWorkflowOptions
+---@field name string
+---@field description string
+---@field main ReleashNode
+
+---@class ReleashSchemaModule
+---@field object fun(options: ReleashObjectSchemaOptions): ReleashSchema
+---@field array fun(options: ReleashArraySchemaOptions): ReleashSchema
+---@field string fun(options: ReleashStringSchemaOptions): ReleashSchema
+---@field boolean fun(): ReleashSchema
+---@field integer fun(): ReleashSchema
+---@field number fun(): ReleashSchema
+
+---@class ReleashProviderModule
+---@field claude ReleashProvider
+---@field codex ReleashProvider
+
+---@class ReleashCompletionModule
+---@field approval ReleashCompletion
+
+---@class ReleashModule
+---@field command fun(options: ReleashCommandOptions): ReleashNode
+---@field session fun(options: ReleashSessionOptions): ReleashNode
+---@field fanout fun(options: ReleashFanoutOptions): ReleashNode
+---@field sequence fun(options: ReleashSequenceOptions): ReleashNode
+---@field child fun(options: ReleashChildOptions): ReleashChild
+---@field next fun(node: ReleashNode): ReleashRule
+---@field when fun(options: ReleashWhenOptions): ReleashRule
+---@field switch fun(options: ReleashSwitchOptions): ReleashRule
+---@field loop_guard fun(options: ReleashLoopGuardOptions): ReleashRule
+---@field retry fun(count: integer): ReleashOnFailure
+---@field ignore ReleashOnFailure
+---@field input fun(name: string, contract?: ReleashSchema): ReleashInput
+---@field request ReleashSource
+---@field items ReleashSource
+---@field completion ReleashCompletionModule
+---@field provider ReleashProviderModule
+---@field schema ReleashSchemaModule
+---@field workflow fun(options: ReleashWorkflowOptions): ReleashWorkflow
+
+---@type ReleashModule
+local releash = {}
+return releash
+"#;
+
+const LUARC: &str = r#"{
+  "runtime.version": "Lua 5.4",
+  "workspace.library": [
+    ".releash"
+  ]
+}
+"#;
+
+pub(crate) fn generate_editor_support(workflows_dir: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(workflows_dir)?;
+    let generated_dir = workflows_dir.join(".releash");
+    fs::create_dir_all(&generated_dir)?;
+    write_if_changed(&generated_dir.join("releash.lua"), RELEASH_STUB)?;
+    generate_builtin_facet_documents(workflows_dir)?;
+    let facets = generate_facet_stub(workflows_dir)?;
+    write_if_changed(&generated_dir.join("facets.lua"), &facets)?;
+    let luarc = workflows_dir.join(".luarc.json");
+    if !luarc.exists() {
+        fs::write(luarc, LUARC)?;
+    }
+    Ok(())
+}
+
+fn write_if_changed(path: &Path, content: &str) -> std::io::Result<()> {
+    if fs::read_to_string(path).ok().as_deref() == Some(content) {
+        return Ok(());
+    }
+    fs::write(path, content)
+}
+
+fn generate_facet_stub(base_dir: &Path) -> std::io::Result<String> {
+    let mut output = String::from("---@meta\n\n---@class ReleashFacet\n\n");
+    for kind in [
+        FacetKind::Instruction,
+        FacetKind::Policy,
+        FacetKind::Knowledge,
+    ] {
+        let class_name = match kind {
+            FacetKind::Instruction => "ReleashInstructionFacets",
+            FacetKind::Policy => "ReleashPolicyFacets",
+            FacetKind::Knowledge => "ReleashKnowledgeFacets",
+        };
+        output.push_str(&format!("---@class {class_name}\n"));
+        let summaries = facet::list_facet_summaries(kind, base_dir)
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        for summary in summaries {
+            let path = facet_document_path(base_dir, kind, &summary.key, summary.builtin);
+            let description = summary.description.replace(['\r', '\n'], " ");
+            let key = lua_doc_field(&summary.key);
+            output.push_str(&format!(
+                "---@field {key} ReleashFacet {description} ([本文](file://{}))\n",
+                path.display()
+            ));
+        }
+        output.push('\n');
+    }
+    output.push_str(
+        "---@class ReleashFacetModule\n---@field instruction ReleashInstructionFacets\n---@field policy ReleashPolicyFacets\n---@field knowledge ReleashKnowledgeFacets\n\n---@type ReleashFacetModule\nlocal facets = {}\nreturn facets\n",
+    );
+    Ok(output)
+}
+
+fn generate_builtin_facet_documents(base_dir: &Path) -> std::io::Result<()> {
+    for kind in [
+        FacetKind::Instruction,
+        FacetKind::Policy,
+        FacetKind::Knowledge,
+    ] {
+        let kind_dir = base_dir.join(".releash/facets").join(kind.dir_name());
+        fs::create_dir_all(&kind_dir)?;
+        for key in builtin::list_builtin_facet_keys(kind) {
+            let content = builtin::get_builtin_facet(kind, key).ok_or_else(|| {
+                std::io::Error::other(format!(
+                    "builtin facet content is missing: {}/{key}",
+                    kind.dir_name()
+                ))
+            })?;
+            write_if_changed(&kind_dir.join(format!("{key}.md")), content)?;
+        }
+    }
+    Ok(())
+}
+
+fn facet_document_path(
+    base_dir: &Path,
+    kind: FacetKind,
+    key: &str,
+    builtin_facet: bool,
+) -> PathBuf {
+    let custom = base_dir.join(kind.dir_name()).join(format!("{key}.md"));
+    if !builtin_facet || custom.exists() {
+        return custom;
+    }
+    base_dir
+        .join(".releash/facets")
+        .join(kind.dir_name())
+        .join(format!("{key}.md"))
+}
+
+fn lua_doc_field(key: &str) -> String {
+    let mut chars = key.chars();
+    if chars
+        .next()
+        .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    {
+        key.to_string()
+    } else {
+        format!("[\"{}\"]", key.replace('"', "\\\""))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn generates_idempotent_stubs_and_preserves_existing_luarc() {
+        let directory = TempDir::new().unwrap();
+        let instructions = directory.path().join("instructions");
+        fs::create_dir_all(&instructions).unwrap();
+        fs::write(instructions.join("custom.md"), "# Custom facet\nBody").unwrap();
+        fs::write(directory.path().join(".luarc.json"), "{\"custom\":true}").unwrap();
+
+        generate_editor_support(directory.path()).unwrap();
+        let first = fs::read_to_string(directory.path().join(".releash/facets.lua")).unwrap();
+        let builtin_path = directory.path().join(".releash/facets/policies/coding.md");
+        let first_builtin = fs::read_to_string(&builtin_path).unwrap();
+        generate_editor_support(directory.path()).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(directory.path().join(".luarc.json")).unwrap(),
+            "{\"custom\":true}"
+        );
+        assert_eq!(
+            fs::read_to_string(directory.path().join(".releash/facets.lua")).unwrap(),
+            first
+        );
+        assert_eq!(fs::read_to_string(&builtin_path).unwrap(), first_builtin);
+        assert_eq!(
+            first_builtin,
+            builtin::get_builtin_facet(FacetKind::Policy, "coding").unwrap()
+        );
+        assert!(first.contains("custom ReleashFacet Custom facet"));
+        assert!(first.contains(&format!(
+            "file://{}",
+            instructions.join("custom.md").display()
+        )));
+        assert!(first.contains(&format!("file://{}", builtin_path.display())));
+        let releash = fs::read_to_string(directory.path().join(".releash/releash.lua")).unwrap();
+        assert!(releash.contains("---@class ReleashNode: ReleashSource"));
+        assert!(releash.contains("---@field sequence fun(options: ReleashSequenceOptions)"));
+        assert!(releash.contains("---@field workflow fun(options: ReleashWorkflowOptions)"));
+        assert!(releash.contains("---@field on_true ReleashNode"));
+        assert!(!releash.contains("---@field equals ReleashNode"));
+    }
+
+    #[test]
+    fn custom_facet_with_builtin_key_links_to_custom_document() {
+        let directory = TempDir::new().unwrap();
+        let policies = directory.path().join("policies");
+        fs::create_dir_all(&policies).unwrap();
+        let custom_path = policies.join("coding.md");
+        fs::write(&custom_path, "# Custom coding\nBody").unwrap();
+
+        generate_editor_support(directory.path()).unwrap();
+
+        let facets = fs::read_to_string(directory.path().join(".releash/facets.lua")).unwrap();
+        let generated_builtin = directory.path().join(".releash/facets/policies/coding.md");
+        assert!(facets.contains("coding ReleashFacet Custom coding"));
+        assert!(facets.contains(&format!("file://{}", custom_path.display())));
+        assert!(!facets.contains(&format!("file://{}", generated_builtin.display())));
+    }
+
+    #[test]
+    fn generated_builtin_document_is_not_a_runtime_facet_source() {
+        let directory = TempDir::new().unwrap();
+        generate_editor_support(directory.path()).unwrap();
+        let generated_builtin = directory.path().join(".releash/facets/policies/coding.md");
+        let expected = builtin::get_builtin_facet(FacetKind::Policy, "coding")
+            .unwrap()
+            .to_string();
+
+        fs::write(&generated_builtin, "stale generated content").unwrap();
+        assert_eq!(
+            facet::load_facet(FacetKind::Policy, "coding", directory.path()).unwrap(),
+            expected
+        );
+
+        fs::remove_file(generated_builtin).unwrap();
+        assert_eq!(
+            facet::load_facet(FacetKind::Policy, "coding", directory.path()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn generates_luarc_only_when_absent() {
+        let directory = TempDir::new().unwrap();
+
+        generate_editor_support(directory.path()).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(directory.path().join(".luarc.json")).unwrap(),
+            LUARC
+        );
+    }
+}

--- a/src-tauri/src/adaptor/gateway/workflow/lua/stubs.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/lua/stubs.rs
@@ -14,6 +14,7 @@ pub(crate) enum StubGenerationError {
     Io(std::io::Error),
     Facet(FacetError),
     MissingBuiltinFacet { kind: FacetKind, key: String },
+    InvalidDocumentPath { path: PathBuf },
 }
 
 impl fmt::Display for StubGenerationError {
@@ -26,6 +27,11 @@ impl fmt::Display for StubGenerationError {
                 "ビルトインファセット '{key}' ({}) の本文が見つかりません",
                 kind.dir_name()
             ),
+            Self::InvalidDocumentPath { path } => write!(
+                formatter,
+                "ファセット本文のパスを file URL へ変換できません: {}",
+                path.display()
+            ),
         }
     }
 }
@@ -35,7 +41,7 @@ impl std::error::Error for StubGenerationError {
         match self {
             Self::Io(error) => Some(error),
             Self::Facet(error) => Some(error),
-            Self::MissingBuiltinFacet { .. } => None,
+            Self::MissingBuiltinFacet { .. } | Self::InvalidDocumentPath { .. } => None,
         }
     }
 }
@@ -232,7 +238,7 @@ fn generate_facet_stub(base_dir: &Path) -> Result<String, StubGenerationError> {
             let key = lua_doc_field(&summary.key);
             output.push_str(&format!(
                 "---@field {key} ReleashFacet {description} ([本文]({}))\n",
-                facet_document_url(&path)
+                facet_document_url(&path)?
             ));
         }
         output.push('\n');
@@ -266,10 +272,18 @@ fn generate_builtin_facet_documents(base_dir: &Path) -> Result<(), StubGeneratio
 
 /// 生成する `file://` リンク。パス区切りの正規化と percent-encode を URL 側へ任せ、
 /// 空白を含むパス（macOS の `Application Support` 等）でも有効な URL にする。
-fn facet_document_url(path: &Path) -> String {
-    url::Url::from_file_path(path)
+///
+/// `Url::from_file_path` は相対パスを受け付けないため、先に current_dir で絶対化する
+/// （`dirs::config_dir()` が解決できない環境では `workflows_dir()` が相対パスを返す）。
+fn facet_document_url(path: &Path) -> Result<String, StubGenerationError> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    url::Url::from_file_path(&absolute)
         .map(|url| url.to_string())
-        .unwrap_or_else(|_| format!("file://{}", path.display()))
+        .map_err(|_| StubGenerationError::InvalidDocumentPath { path: absolute })
 }
 
 fn facet_document_path(
@@ -360,6 +374,17 @@ mod tests {
         let facets = fs::read_to_string(base.join(".releash/facets.lua")).unwrap();
         assert!(facets.contains("Application%20Support"));
         assert!(!facets.contains("Application Support"));
+    }
+
+    #[test]
+    fn facet_document_url_absolutizes_relative_paths() {
+        let url = facet_document_url(Path::new("releash/workflows/policies/coding.md")).unwrap();
+
+        assert!(url.starts_with("file:///"), "{url}");
+        assert!(
+            url.ends_with("/releash/workflows/policies/coding.md"),
+            "{url}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/mapper.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/mapper.rs
@@ -155,6 +155,7 @@ pub(crate) fn schema_workflow_summary_to_domain(
         description: summary.description,
         builtin: summary.builtin,
         is_running: summary.is_running,
+        source_format: summary.source_format,
     }
 }
 
@@ -167,6 +168,7 @@ pub(crate) fn domain_workflow_summary_to_schema(
         description: summary.description,
         builtin: summary.builtin,
         is_running: summary.is_running,
+        source_format: summary.source_format,
     }
 }
 
@@ -315,6 +317,7 @@ mod tests {
             description: "desc".to_string(),
             builtin: false,
             is_running: true,
+            source_format: domain::WorkflowSourceFormat::Yaml,
         };
         let mapped = domain_workflow_summary_to_schema(domain.clone());
 
@@ -324,7 +327,8 @@ mod tests {
                 "name": "wf",
                 "description": "desc",
                 "builtin": false,
-                "is_running": true
+                "is_running": true,
+                "source_format": "yaml"
             })
         );
     }

--- a/src-tauri/src/adaptor/gateway/workflow/mod.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod fact_log;
 #[cfg(test)]
 pub(crate) mod failure_policy_config;
 pub(crate) mod failure_wire;
+pub(crate) mod lua;
 pub(crate) mod mapper;
 pub(crate) mod node_session_boundary;
 mod runtime_command_gateway;

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_resolver.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_resolver.rs
@@ -54,7 +54,9 @@ pub(crate) fn resolve_workflow_by_name(
         let mut paths = entries
             .filter_map(Result::ok)
             .map(|entry| entry.path())
-            .filter(|path| path.extension().and_then(|extension| extension.to_str()) == Some("yml"))
+            .filter(|path| {
+                crate::adaptor::gateway::workflow::storage::workflow_source_format(path).is_some()
+            })
             .collect::<Vec<_>>();
         paths.sort();
 
@@ -192,5 +194,48 @@ mod tests {
 
         assert!(error.to_string().contains("WFS006"));
         assert!(error.to_string().contains("duplicate-name"));
+    }
+
+    #[test]
+    fn resolves_lua_definition_by_declared_name() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("lua-runtime.lua"),
+            r#"
+local r = require("releash")
+return r.workflow{
+  name = "lua-runtime", description = "Lua runtime",
+  main = r.command{ command = "true" },
+}
+"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_workflow_by_name(tmp.path(), tmp.path(), "lua-runtime").unwrap();
+
+        assert_eq!(resolved.name, "lua-runtime");
+        assert_eq!(resolved.entry, "main");
+    }
+
+    #[test]
+    fn duplicate_name_across_yaml_and_lua_is_reported() {
+        let tmp = TempDir::new().unwrap();
+        storage::save_workflow(tmp.path(), &workflow("duplicate-cross-format")).unwrap();
+        std::fs::write(
+            tmp.path().join("duplicate-cross-format.lua"),
+            r#"
+local r = require("releash")
+return r.workflow{
+  name = "duplicate-cross-format", description = "Lua duplicate",
+  main = r.command{ command = "true" },
+}
+"#,
+        )
+        .unwrap();
+
+        let error =
+            resolve_workflow_by_name(tmp.path(), tmp.path(), "duplicate-cross-format").unwrap_err();
+
+        assert!(error.to_string().contains("WFS006"));
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/schema.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/schema.rs
@@ -19,6 +19,7 @@ pub struct Summary {
     pub builtin: bool,
     #[serde(default)]
     pub is_running: bool,
+    pub source_format: crate::domain::workflow::WorkflowSourceFormat,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]

--- a/src-tauri/src/adaptor/gateway/workflow/span_map.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/span_map.rs
@@ -3,8 +3,10 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 use serde_saphyr::granit_parser::{Event, Parser, ScanError, Span as ParserSpan};
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) struct DiagnosticSpan {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) source: Option<String>,
     pub(crate) start_line: usize,
     pub(crate) start_col: usize,
     pub(crate) end_line: usize,
@@ -16,6 +18,7 @@ impl DiagnosticSpan {
         let line = usize::try_from(location.line()).unwrap_or(usize::MAX);
         let col = usize::try_from(location.column()).unwrap_or(usize::MAX);
         Self {
+            source: None,
             start_line: line,
             start_col: col,
             end_line: line,
@@ -26,6 +29,7 @@ impl DiagnosticSpan {
     pub(crate) fn from_scan_error(error: &ScanError) -> Self {
         let marker = error.marker();
         Self {
+            source: None,
             start_line: marker.line(),
             start_col: marker.col() + 1,
             end_line: marker.line(),
@@ -70,11 +74,11 @@ impl YamlSpanMap {
     }
 
     pub(crate) fn value_span(&self, path: &str) -> Option<DiagnosticSpan> {
-        self.value_spans.get(path).copied()
+        self.value_spans.get(path).cloned()
     }
 
     pub(crate) fn key_span(&self, path: &str) -> Option<DiagnosticSpan> {
-        self.key_spans.get(path).copied()
+        self.key_spans.get(path).cloned()
     }
 
     pub(crate) fn nearest_span(&self, path: &str) -> Option<DiagnosticSpan> {
@@ -155,7 +159,7 @@ fn parse_mapping(
             Some((Event::Scalar(value, _, _, _), span)) => {
                 let span = diagnostic_span(&span).expect("parser spans always have coordinates");
                 let child = child_path(&path, &value);
-                map.key_spans.entry(child.clone()).or_insert(span);
+                map.key_spans.entry(child.clone()).or_insert(span.clone());
                 (child, span)
             }
             Some((_, _)) => continue,
@@ -223,6 +227,7 @@ fn parent_path(path: &str) -> Option<String> {
 
 fn diagnostic_span(span: &ParserSpan) -> Option<DiagnosticSpan> {
     Some(DiagnosticSpan {
+        source: None,
         start_line: span.start.line(),
         start_col: span.start.col() + 1,
         end_line: span.end.line(),
@@ -261,6 +266,7 @@ nodes:
         assert_eq!(
             map.field_span("name"),
             Some(DiagnosticSpan {
+                source: None,
                 start_line: 1,
                 start_col: 1,
                 end_line: 1,
@@ -270,6 +276,7 @@ nodes:
         assert_eq!(
             map.field_span("nodes.main.rules[0].when.on"),
             Some(DiagnosticSpan {
+                source: None,
                 start_line: 13,
                 start_col: 11,
                 end_line: 13,
@@ -285,6 +292,7 @@ nodes:
         assert_eq!(
             map.key_span("nodes.done"),
             Some(DiagnosticSpan {
+                source: None,
                 start_line: 16,
                 start_col: 3,
                 end_line: 16,
@@ -312,13 +320,14 @@ nodes:
         let source = "defaults: &defaults\n  provider: claude\nsession: *defaults\n";
         let map = YamlSpanMap::parse(source).unwrap();
         let alias_span = DiagnosticSpan {
+            source: None,
             start_line: 3,
             start_col: 10,
             end_line: 3,
             end_col: 19,
         };
 
-        assert_eq!(map.value_span("session"), Some(alias_span));
+        assert_eq!(map.value_span("session"), Some(alias_span.clone()));
         assert_eq!(map.nearest_span("session.provider"), Some(alias_span));
     }
 

--- a/src-tauri/src/adaptor/gateway/workflow/storage.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/storage.rs
@@ -102,6 +102,9 @@ impl Serialize for StorageError {
     }
 }
 
+/// 同じ名前を複数の形式が宣言した一覧エントリの説明。
+const DUPLICATE_NAME_DESCRIPTION: &str = "Duplicate workflow definition";
+
 pub fn workflows_dir() -> PathBuf {
     dirs::config_dir()
         .unwrap_or_else(|| PathBuf::from("."))
@@ -343,7 +346,22 @@ fn list_file_summaries<T, E: fmt::Display>(
     }
 
     summaries.sort_by(|a, b| a.name.cmp(&b.name));
-    Ok(summaries)
+    Ok(collapse_duplicate_names(summaries))
+}
+
+/// 同じ名前を複数の形式が宣言した状態は `resolve_workflow_path` が `WFS006` として
+/// 拒否する。一覧でも 1 件へ畳み込み、選べる行と実行できる定義を一致させる。
+fn collapse_duplicate_names(summaries: Vec<Summary>) -> Vec<Summary> {
+    let mut collapsed: Vec<Summary> = Vec::with_capacity(summaries.len());
+    for summary in summaries {
+        match collapsed.last_mut() {
+            Some(previous) if previous.name == summary.name => {
+                previous.description = DUPLICATE_NAME_DESCRIPTION.to_string();
+            }
+            _ => collapsed.push(summary),
+        }
+    }
+    collapsed
 }
 
 #[cfg(test)]
@@ -706,6 +724,34 @@ nodes:
 
         assert_eq!(disk_entry.description, "Invalid workflow definition");
         assert!(!disk_entry.builtin);
+    }
+
+    #[test]
+    fn list_workflows_collapses_same_name_across_formats() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        save_workflow(dir, &sample_workflow("duplicated", false)).unwrap();
+        fs::write(
+            dir.join("duplicated.lua"),
+            r#"
+local r = require("releash")
+return r.workflow{
+  name = "duplicated", description = "Lua duplicate",
+  main = r.command{ command = "true" },
+}
+"#,
+        )
+        .unwrap();
+
+        let list = list_workflows(dir).unwrap();
+        let matched = list
+            .iter()
+            .filter(|summary| summary.name == "duplicated")
+            .collect::<Vec<_>>();
+
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].description, DUPLICATE_NAME_DESCRIPTION);
+        assert!(resolve_workflow_path(dir, "duplicated").is_err());
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/storage.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/storage.rs
@@ -4,6 +4,7 @@ use super::domain_mapping::workflow_definition_to_domain;
 use super::facet;
 use super::schema::{Summary, WorkflowDefinitionYaml};
 use crate::domain::workflow::validation::{self, ValidationError};
+use crate::domain::workflow::WorkflowSourceFormat;
 use serde::Serialize;
 use std::fmt;
 use std::fs;
@@ -194,7 +195,81 @@ pub fn save_workflow_source(
     Ok(workflow)
 }
 
-/// YAML ファイルから `WorkflowDefinitionYaml` を読み込み、facet 参照を解決した上で validation する。
+trait WorkflowDefinitionLoader {
+    fn diagnose(
+        &self,
+        path: &Path,
+        content: &str,
+        workflows_dir: &Path,
+        facets_base_dir: &Path,
+    ) -> diagnostics::WorkflowSourceDiagnostics;
+}
+
+struct YamlWorkflowDefinitionLoader;
+
+impl WorkflowDefinitionLoader for YamlWorkflowDefinitionLoader {
+    fn diagnose(
+        &self,
+        path: &Path,
+        content: &str,
+        _workflows_dir: &Path,
+        _facets_base_dir: &Path,
+    ) -> diagnostics::WorkflowSourceDiagnostics {
+        diagnostics::diagnose_workflow_source(
+            content,
+            path.file_stem().and_then(|stem| stem.to_str()),
+        )
+    }
+}
+
+struct LuaWorkflowDefinitionLoader;
+
+impl WorkflowDefinitionLoader for LuaWorkflowDefinitionLoader {
+    fn diagnose(
+        &self,
+        path: &Path,
+        content: &str,
+        workflows_dir: &Path,
+        facets_base_dir: &Path,
+    ) -> diagnostics::WorkflowSourceDiagnostics {
+        diagnostics::diagnose_lua_workflow_source(
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("<unknown>.lua"),
+            content,
+            workflows_dir,
+            facets_base_dir,
+            path.file_stem().and_then(|stem| stem.to_str()),
+        )
+    }
+}
+
+pub(crate) fn diagnose_workflow_file(
+    path: &Path,
+    content: &str,
+    workflows_dir: &Path,
+    facets_base_dir: &Path,
+) -> diagnostics::WorkflowSourceDiagnostics {
+    let loader: &dyn WorkflowDefinitionLoader = match workflow_source_format(path) {
+        Some(WorkflowSourceFormat::Yaml) => &YamlWorkflowDefinitionLoader,
+        Some(WorkflowSourceFormat::Lua) => &LuaWorkflowDefinitionLoader,
+        None => {
+            return diagnostics::WorkflowSourceDiagnostics {
+                workflow: None,
+                diagnostics: vec![diagnostics::DiagnosticItem::new(
+                    "WFS002",
+                    diagnostics::Severity::Error,
+                    diagnostics::DiagnosticStage::ParseShape,
+                    None,
+                    format!("unsupported workflow source extension: {}", path.display()),
+                )],
+            };
+        }
+    };
+    loader.diagnose(path, content, workflows_dir, facets_base_dir)
+}
+
+/// workflow 定義ファイルを読み込み、facet 参照を解決した上で validation する。
 ///
 /// [02] schema 境界: load 経路で `facet.rs` を呼び、session / fanout child の
 /// gateway read model に解決済み内容を格納し、facet 本文の Artifact 参照も検証する。
@@ -205,9 +280,11 @@ pub fn load_workflow(
     facets_base_dir: &Path,
 ) -> Result<WorkflowDefinitionYaml, StorageError> {
     let content = fs::read_to_string(path)?;
-    let diagnosis = diagnostics::diagnose_workflow_source(
+    let diagnosis = diagnose_workflow_file(
+        path,
         &content,
-        path.file_stem().and_then(|stem| stem.to_str()),
+        path.parent().unwrap_or_else(|| Path::new(".")),
+        facets_base_dir,
     );
     if diagnosis.has_errors() {
         return Err(StorageError::Diagnostics(diagnosis.diagnostics));
@@ -227,7 +304,7 @@ pub fn load_workflow(
     Ok(workflow)
 }
 
-fn list_yml_summaries<T, E: fmt::Display>(
+fn list_file_summaries<T, E: fmt::Display>(
     dir: &Path,
     loader: impl Fn(&Path) -> Result<T, E>,
     to_summary: impl Fn(T) -> Summary,
@@ -243,7 +320,7 @@ fn list_yml_summaries<T, E: fmt::Display>(
     for entry in entries {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) == Some("yml") {
+        if workflow_source_format(&path).is_some() {
             let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
                 log::warn!(
                     "{label}読み込みスキップ: {}: 無効なファイル名",
@@ -255,6 +332,7 @@ fn list_yml_summaries<T, E: fmt::Display>(
                 Ok(item) => {
                     let mut summary = to_summary(item);
                     summary.name = stem.to_string();
+                    summary.source_format = workflow_source_format(&path).unwrap_or_default();
                     summaries.push(summary);
                 }
                 Err(e) => {
@@ -268,13 +346,21 @@ fn list_yml_summaries<T, E: fmt::Display>(
     Ok(summaries)
 }
 
+#[cfg(test)]
 pub fn list_workflows(dir: &Path) -> Result<Vec<Summary>, StorageError> {
+    list_workflows_with_facets(dir, dir)
+}
+
+pub(crate) fn list_workflows_with_facets(
+    dir: &Path,
+    facets_base_dir: &Path,
+) -> Result<Vec<Summary>, StorageError> {
     // list 用途では facet 未解決でも一覧表示に支障がないため、deserialize+validate のみを行う。
     // facet 解決が必要な実行系経路は明示的に `load_workflow` を呼ぶ。
     let load_for_listing = |path: &Path| -> Result<WorkflowDefinitionYaml, StorageError> {
         let content = fs::read_to_string(path)?;
         let stem = path.file_stem().and_then(|stem| stem.to_str());
-        let diagnosis = diagnostics::diagnose_workflow_source(&content, stem);
+        let diagnosis = diagnose_workflow_file(path, &content, dir, facets_base_dir);
         if diagnosis.has_errors() {
             return Ok(WorkflowDefinitionYaml {
                 name: stem.unwrap_or("invalid").to_string(),
@@ -297,7 +383,7 @@ pub fn list_workflows(dir: &Path) -> Result<Vec<Summary>, StorageError> {
         workflow.builtin = builtin::is_builtin_workflow(&workflow.name);
         Ok(workflow)
     };
-    let mut summaries = list_yml_summaries(
+    let mut summaries = list_file_summaries(
         dir,
         load_for_listing,
         |wf| Summary {
@@ -305,6 +391,7 @@ pub fn list_workflows(dir: &Path) -> Result<Vec<Summary>, StorageError> {
             description: wf.description,
             builtin: false, // name がファイル stem で上書きされた後に再計算する
             is_running: false,
+            source_format: WorkflowSourceFormat::Yaml,
         },
         "ワークフロー",
     )?;
@@ -378,21 +465,48 @@ fn validate_resolved_facet_references(
 
 pub fn resolve_workflow_path(dir: &Path, name: &str) -> Result<PathBuf, StorageError> {
     validation::validate_name(name)?;
-    let file_path = dir.join(format!("{name}.yml"));
-    if !file_path.exists() {
-        return Err(StorageError::NotFound {
+    let paths = [
+        dir.join(format!("{name}.yml")),
+        dir.join(format!("{name}.lua")),
+    ];
+    let existing = paths
+        .into_iter()
+        .filter(|path| path.exists())
+        .collect::<Vec<_>>();
+    match existing.as_slice() {
+        [] => Err(StorageError::NotFound {
             name: name.to_string(),
-        });
+        }),
+        [path] => Ok(path.clone()),
+        _ => Err(StorageError::Diagnostics(vec![
+            diagnostics::DiagnosticItem::new(
+                "WFS006",
+                diagnostics::Severity::Error,
+                diagnostics::DiagnosticStage::ParseShape,
+                None,
+                format!("workflow name '{name}' is duplicated"),
+            ),
+        ])),
     }
-    Ok(file_path)
+}
+
+pub(crate) fn workflow_source_format(path: &Path) -> Option<WorkflowSourceFormat> {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("yml") => Some(WorkflowSourceFormat::Yaml),
+        Some("lua") => Some(WorkflowSourceFormat::Lua),
+        _ => None,
+    }
 }
 
 pub fn delete_workflow(dir: &Path, name: &str) -> Result<(), StorageError> {
     validation::validate_name(name)?;
-    let file_path = dir.join(format!("{name}.yml"));
-    if file_path.exists() {
-        fs::remove_file(&file_path)?;
-        return Ok(());
+    match resolve_workflow_path(dir, name) {
+        Ok(file_path) => {
+            fs::remove_file(file_path)?;
+            return Ok(());
+        }
+        Err(StorageError::NotFound { .. }) => {}
+        Err(error) => return Err(error),
     }
     // builtin として認識できた場合（load 成功で Some）は削除を拒否する。
     // load 失敗（Err）の場合も「builtin として存在し得る」とみなし、安全側に倒して
@@ -1063,5 +1177,76 @@ nodes:
         std::fs::write(&file_path, yaml).unwrap();
         let wf = load_workflow(&file_path, dir).expect("load must succeed");
         assert_eq!(wf.nodes[0].name, "main");
+    }
+
+    #[test]
+    fn loads_and_lists_lua_workflow_with_source_format() {
+        let tmp = TempDir::new().unwrap();
+        let source = r#"
+local r = require("releash")
+return r.workflow{
+  name = "lua-workflow",
+  description = "Lua workflow",
+  main = r.command{ command = "true" },
+}
+"#;
+        let path = tmp.path().join("lua-workflow.lua");
+        std::fs::write(&path, source).unwrap();
+
+        let workflow = load_workflow(&path, tmp.path()).unwrap();
+        let summaries = list_workflows(tmp.path()).unwrap();
+
+        assert_eq!(workflow.name, "lua-workflow");
+        assert_eq!(workflow.nodes[0].name, "main");
+        assert_eq!(
+            summaries
+                .iter()
+                .find(|summary| summary.name == "lua-workflow")
+                .unwrap()
+                .source_format,
+            WorkflowSourceFormat::Lua
+        );
+    }
+
+    #[test]
+    fn rejects_lua_workflow_name_that_differs_from_file_stem() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("file-name.lua");
+        std::fs::write(
+            &path,
+            r#"
+local r = require("releash")
+return r.workflow{
+  name = "declared-name",
+  description = "Mismatch",
+  main = r.command{ command = "true" },
+}
+"#,
+        )
+        .unwrap();
+
+        let error = load_workflow(&path, tmp.path()).unwrap_err();
+        let StorageError::Diagnostics(items) = error else {
+            panic!("name mismatch must produce diagnostics");
+        };
+
+        let mismatch = items.iter().find(|item| item.code == "WFS006").unwrap();
+        let span = mismatch.span.as_ref().unwrap();
+        assert_eq!(span.source.as_deref(), Some("file-name.lua"));
+        assert_eq!(span.start_line, 6);
+    }
+
+    #[test]
+    fn rejects_ambiguous_yaml_and_lua_files_with_same_stem() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("duplicate.yml"), "name: duplicate").unwrap();
+        std::fs::write(tmp.path().join("duplicate.lua"), "return nil").unwrap();
+
+        let error = resolve_workflow_path(tmp.path(), "duplicate").unwrap_err();
+        let StorageError::Diagnostics(items) = error else {
+            panic!("duplicate source files must produce diagnostics");
+        };
+
+        assert!(items.iter().any(|item| item.code == "WFS006"));
     }
 }

--- a/src-tauri/src/domain/workflow/mod.rs
+++ b/src-tauri/src/domain/workflow/mod.rs
@@ -43,6 +43,7 @@ pub use value_objects::{
     StopReceivedFact, SubmitReceivedFact, SubmitRejectedFact, TimeoutKind, TokenUsage,
     TreeRootFact, WorkflowDefinition, WorkflowDefinitionName, WorkflowEvent, WorkflowExecution,
     WorkflowExecutionId, WorkflowExecutionSummary, WorkflowFacetContents, WorkflowPageRequest,
-    WorkflowRootFact, WorkflowRuntimeSnapshot, WorkflowSummary, WorkspaceWorktreePath,
-    WorktreeInventoryEntry, WorktreeManagementKind, NODE_STATUS_COMPLETED, NODE_STATUS_FAILED,
+    WorkflowRootFact, WorkflowRuntimeSnapshot, WorkflowSourceFormat, WorkflowSummary,
+    WorkspaceWorktreePath, WorktreeInventoryEntry, WorktreeManagementKind, NODE_STATUS_COMPLETED,
+    NODE_STATUS_FAILED,
 };

--- a/src-tauri/src/domain/workflow/value_objects/definition.rs
+++ b/src-tauri/src/domain/workflow/value_objects/definition.rs
@@ -37,6 +37,60 @@ pub fn is_reserved_node_name(name: &str) -> bool {
     RESERVED_NODE_NAMES.contains(&name)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeNamespaceError {
+    Duplicate(String),
+    Reserved(String),
+}
+
+impl std::fmt::Display for NodeNamespaceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Duplicate(name) => write!(formatter, "node name '{name}' is duplicated"),
+            Self::Reserved(name) => write!(formatter, "node name '{name}' is reserved"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NodeNamespace {
+    names: BTreeSet<String>,
+}
+
+impl NodeNamespace {
+    pub fn register(&mut self, name: impl Into<String>) -> Result<String, NodeNamespaceError> {
+        let name = name.into();
+        if !self.names.insert(name.clone()) {
+            return Err(NodeNamespaceError::Duplicate(name));
+        }
+        Ok(name)
+    }
+
+    pub fn register_explicit(
+        &mut self,
+        name: impl Into<String>,
+    ) -> Result<String, NodeNamespaceError> {
+        let name = name.into();
+        if is_reserved_node_name(&name) {
+            return Err(NodeNamespaceError::Reserved(name));
+        }
+        self.register(name)
+    }
+
+    pub fn register_synthesized(
+        &mut self,
+        owner: &str,
+        child_index: usize,
+    ) -> Result<String, NodeNamespaceError> {
+        self.register(format!("{owner}#{child_index}"))
+    }
+
+    #[cfg(test)]
+    pub fn contains(&self, name: &str) -> bool {
+        self.names.contains(name)
+    }
+}
+
 fn default_entry_node() -> String {
     MAIN_ENTRY_NODE_NAME.to_string()
 }
@@ -967,14 +1021,20 @@ impl<'de> Deserialize<'de> for RawChildElement {
 
 /// 正規化の作業状態。単一名前空間の登録簿と、カタログへ追記するインライン宣言。
 struct CatalogNormalizer {
-    names: BTreeSet<String>,
+    namespace: NodeNamespace,
     inline_nodes: Vec<NodeDefinition>,
 }
 
 impl CatalogNormalizer {
     fn new(top_level_names: BTreeSet<String>) -> Self {
+        let mut namespace = NodeNamespace::default();
+        for name in top_level_names {
+            namespace
+                .register(name)
+                .expect("top-level node names were already deduplicated");
+        }
         Self {
-            names: top_level_names,
+            namespace,
             inline_nodes: Vec::new(),
         }
     }
@@ -983,10 +1043,7 @@ impl CatalogNormalizer {
     where
         E: de::Error,
     {
-        if !self.names.insert(name.to_string()) {
-            return Err(E::custom(format!("node name '{name}' is duplicated")));
-        }
-        Ok(())
+        self.namespace.register(name).map(|_| ()).map_err(E::custom)
     }
 
     fn normalize_children<E>(
@@ -1034,8 +1091,10 @@ impl CatalogNormalizer {
                         }
                         // ④ 無名エントリ: 合成内部名を生成して登録。
                         (None, true) => {
-                            let synthesized = format!("{owner}#{index}");
-                            self.register(&synthesized)?;
+                            let synthesized = self
+                                .namespace
+                                .register_synthesized(owner, index)
+                                .map_err(E::custom)?;
                             let node_definition =
                                 self.raw_body_to_node(synthesized.clone(), node)?;
                             self.inline_nodes.push(node_definition);
@@ -1418,6 +1477,15 @@ pub struct WorkflowSummary {
     pub description: String,
     pub builtin: bool,
     pub is_running: bool,
+    pub source_format: WorkflowSourceFormat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkflowSourceFormat {
+    #[default]
+    Yaml,
+    Lua,
 }
 
 #[cfg(test)]
@@ -1609,5 +1677,30 @@ mod definition_tests {
             ..sequence
         };
         assert_eq!(explicit.entry_child_name(), Some("second"));
+    }
+
+    #[test]
+    fn test_node名前空間_明示名と自動生成名を同じ空間で一意にする() {
+        let mut namespace = NodeNamespace::default();
+
+        assert_eq!(namespace.register_explicit("prepare").unwrap(), "prepare");
+        assert_eq!(namespace.register_synthesized("main", 0).unwrap(), "main#0");
+        assert!(namespace.contains("prepare"));
+        assert!(namespace.contains("main#0"));
+        assert_eq!(
+            namespace.register("main#0"),
+            Err(NodeNamespaceError::Duplicate("main#0".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_node名前空間_明示名では予約語を拒否する() {
+        let mut namespace = NodeNamespace::default();
+
+        assert_eq!(
+            namespace.register_explicit("children"),
+            Err(NodeNamespaceError::Reserved("children".to_string()))
+        );
+        assert!(!namespace.contains("children"));
     }
 }

--- a/src-tauri/src/domain/workflow/value_objects/mod.rs
+++ b/src-tauri/src/domain/workflow/value_objects/mod.rs
@@ -13,12 +13,11 @@ mod state;
 mod worktree_origin;
 
 pub use contract::{ContractType, ContractValidationResult, ContractViolation};
-#[cfg(test)]
-pub use definition::InputSourceRef;
 pub use definition::{
     is_reserved_node_name, ChildEntry, CommandSpec, EffectiveRules, FacetRefs, FanoutSpec,
-    InputParam, ItemsSource, NodeCompletion, NodeDefinition, NodeKind, NodeKindName, OnFailure,
-    Rule, SchemaDef, SequenceSpec, SessionSpec, WorkflowDefinition, WorkflowSummary,
+    InputParam, InputSourceRef, ItemsSource, NodeCompletion, NodeDefinition, NodeKind,
+    NodeKindName, NodeNamespace, OnFailure, Rule, SchemaDef, SequenceSpec, SessionSpec,
+    WorkflowDefinition, WorkflowSourceFormat, WorkflowSummary, MAIN_ENTRY_NODE_NAME,
     MAX_FANOUT_CHILDREN, MAX_NODES_PER_WORKFLOW,
 };
 pub use execution::{

--- a/src-tauri/src/infrastructure/lua/evaluator.rs
+++ b/src-tauri/src/infrastructure/lua/evaluator.rs
@@ -12,6 +12,14 @@ use mlua::{
 
 const HOOK_INSTRUCTION_INTERVAL: u32 = 10_000;
 
+/// Lua table を `LuaData` へ変換するときの入れ子の上限。Rust 側の再帰変換が
+/// stack を使い切る前に打ち切る。
+const MAX_TABLE_DEPTH: usize = 64;
+
+/// 一度の変換で扱う table 要素数の上限。共有 table の展開が組み合わせ的に
+/// 増える経路を有界にする。
+const MAX_TABLE_ELEMENTS: usize = 100_000;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct LuaLimits {
     pub(crate) memory_bytes: usize,
@@ -457,39 +465,76 @@ fn module_to_lua<H: LuaHost + 'static>(
 }
 
 fn lua_to_data<H: LuaHost + 'static>(value: Value) -> mlua::Result<LuaData> {
-    match value {
-        Value::Nil => Ok(LuaData::Nil),
-        Value::Boolean(value) => Ok(LuaData::Boolean(value)),
-        Value::Integer(value) => Ok(LuaData::Integer(value)),
-        Value::Number(value) => Ok(LuaData::Number(value)),
-        Value::String(value) => Ok(LuaData::String(value.to_string_lossy())),
-        Value::Table(table) => {
-            let mut entries = BTreeMap::new();
-            for pair in table.pairs::<Value, Value>() {
-                let (key, value) = pair?;
-                let key = match key {
-                    Value::Boolean(key) => LuaTableKey::Boolean(key),
-                    Value::Integer(key) => LuaTableKey::Integer(key),
-                    Value::String(key) => LuaTableKey::String(key.to_string_lossy()),
-                    other => {
+    TableConversion::default().convert::<H>(value, 0)
+}
+
+/// 一度の `lua_to_data` 呼び出しで共有する変換状態。再帰パス上の table を
+/// identity で覚えて循環参照を拒否し、深さと要素数を有界にする。
+#[derive(Default)]
+struct TableConversion {
+    visiting: Vec<*const std::ffi::c_void>,
+    elements: usize,
+}
+
+impl TableConversion {
+    fn convert<H: LuaHost + 'static>(
+        &mut self,
+        value: Value,
+        depth: usize,
+    ) -> mlua::Result<LuaData> {
+        match value {
+            Value::Nil => Ok(LuaData::Nil),
+            Value::Boolean(value) => Ok(LuaData::Boolean(value)),
+            Value::Integer(value) => Ok(LuaData::Integer(value)),
+            Value::Number(value) => Ok(LuaData::Number(value)),
+            Value::String(value) => Ok(LuaData::String(value.to_string_lossy())),
+            Value::Table(table) => {
+                if depth >= MAX_TABLE_DEPTH {
+                    return Err(mlua::Error::runtime(format!(
+                        "Lua table nesting exceeded the limit of {MAX_TABLE_DEPTH}"
+                    )));
+                }
+                let pointer = table.to_pointer();
+                if self.visiting.contains(&pointer) {
+                    return Err(mlua::Error::runtime(
+                        "Lua table contains a recursive reference",
+                    ));
+                }
+                self.visiting.push(pointer);
+                let mut entries = BTreeMap::new();
+                for pair in table.pairs::<Value, Value>() {
+                    let (key, value) = pair?;
+                    self.elements += 1;
+                    if self.elements > MAX_TABLE_ELEMENTS {
                         return Err(mlua::Error::runtime(format!(
-                            "unsupported Lua table key type '{}'",
-                            other.type_name()
-                        )))
+                            "Lua table conversion exceeded the limit of {MAX_TABLE_ELEMENTS} entries"
+                        )));
                     }
-                };
-                entries.insert(key, lua_to_data::<H>(value)?);
+                    let key = match key {
+                        Value::Boolean(key) => LuaTableKey::Boolean(key),
+                        Value::Integer(key) => LuaTableKey::Integer(key),
+                        Value::String(key) => LuaTableKey::String(key.to_string_lossy()),
+                        other => {
+                            return Err(mlua::Error::runtime(format!(
+                                "unsupported Lua table key type '{}'",
+                                other.type_name()
+                            )))
+                        }
+                    };
+                    entries.insert(key, self.convert::<H>(value, depth + 1)?);
+                }
+                self.visiting.pop();
+                Ok(LuaData::Table(LuaTableData { entries }))
             }
-            Ok(LuaData::Table(LuaTableData { entries }))
+            Value::UserData(userdata) => {
+                let borrowed = userdata.borrow::<HostUserData<H>>()?;
+                Ok(LuaData::Handle(borrowed.handle.clone()))
+            }
+            other => Err(mlua::Error::runtime(format!(
+                "unsupported Lua value type '{}'",
+                other.type_name()
+            ))),
         }
-        Value::UserData(userdata) => {
-            let borrowed = userdata.borrow::<HostUserData<H>>()?;
-            Ok(LuaData::Handle(borrowed.handle.clone()))
-        }
-        other => Err(mlua::Error::runtime(format!(
-            "unsupported Lua value type '{}'",
-            other.type_name()
-        ))),
     }
 }
 
@@ -700,6 +745,48 @@ mod tests {
         };
 
         assert!(table.entries.is_empty());
+    }
+
+    #[test]
+    fn test_lua評価_循環参照するtableを拒否する() {
+        let dir = TempDir::new().unwrap();
+
+        let error = evaluate(
+            request(dir.path(), "local t = {}\nt.self = t\nreturn t"),
+            TestHost::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind, LuaFailureKind::Evaluation);
+        assert!(error.message.contains("recursive reference"));
+    }
+
+    #[test]
+    fn test_lua評価_table入れ子の上限を超えたら拒否する() {
+        let dir = TempDir::new().unwrap();
+        let source = format!(
+            "local t = {{}}\nfor _ = 1, {} do t = {{ inner = t }} end\nreturn t",
+            MAX_TABLE_DEPTH + 1
+        );
+
+        let error = evaluate(request(dir.path(), &source), TestHost::default()).unwrap_err();
+
+        assert_eq!(error.kind, LuaFailureKind::Evaluation);
+        assert!(error.message.contains("nesting exceeded"));
+    }
+
+    #[test]
+    fn test_lua評価_table要素数の上限を超えたら拒否する() {
+        let dir = TempDir::new().unwrap();
+        let source = format!(
+            "local t = {{}}\nfor i = 1, {} do t[i] = i end\nreturn t",
+            MAX_TABLE_ELEMENTS + 1
+        );
+
+        let error = evaluate(request(dir.path(), &source), TestHost::default()).unwrap_err();
+
+        assert_eq!(error.kind, LuaFailureKind::Evaluation);
+        assert!(error.message.contains("exceeded the limit"));
     }
 
     #[test]

--- a/src-tauri/src/infrastructure/lua/evaluator.rs
+++ b/src-tauri/src/infrastructure/lua/evaluator.rs
@@ -1,0 +1,847 @@
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use mlua::{
+    HookTriggers, Lua, LuaOptions, MetaMethod, MultiValue, RegistryKey, StdLib, UserData,
+    UserDataMethods, Value, VmState,
+};
+
+const HOOK_INSTRUCTION_INTERVAL: u32 = 10_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LuaLimits {
+    pub(crate) memory_bytes: usize,
+    pub(crate) instructions: u64,
+}
+
+impl Default for LuaLimits {
+    fn default() -> Self {
+        Self {
+            memory_bytes: 64 * 1024 * 1024,
+            instructions: 50_000_000,
+        }
+    }
+}
+
+pub(crate) struct LuaEvaluationRequest<'a> {
+    pub(crate) source_name: &'a str,
+    pub(crate) source: &'a str,
+    pub(crate) workflows_dir: &'a Path,
+    pub(crate) limits: LuaLimits,
+}
+
+#[derive(Debug)]
+pub(crate) struct LuaEvaluation<H> {
+    pub(crate) value: LuaData,
+    pub(crate) host: H,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LuaSourceLocation {
+    pub(crate) source: String,
+    pub(crate) line: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum LuaData {
+    Nil,
+    Boolean(bool),
+    Integer(i64),
+    Number(f64),
+    String(String),
+    Table(LuaTableData),
+    Handle(LuaHostHandle),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum LuaTableKey {
+    Boolean(bool),
+    Integer(i64),
+    String(String),
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct LuaTableData {
+    pub(crate) entries: BTreeMap<LuaTableKey, LuaData>,
+}
+
+impl LuaTableData {
+    pub(crate) fn get_string(&self, key: &str) -> Option<&LuaData> {
+        self.entries.get(&LuaTableKey::String(key.to_string()))
+    }
+
+    pub(crate) fn string_keys(&self) -> impl Iterator<Item = &str> {
+        self.entries.keys().filter_map(|key| match key {
+            LuaTableKey::String(key) => Some(key.as_str()),
+            _ => None,
+        })
+    }
+
+    pub(crate) fn as_array(&self) -> Option<Vec<&LuaData>> {
+        if self.entries.is_empty() {
+            return Some(Vec::new());
+        }
+        let mut values = Vec::with_capacity(self.entries.len());
+        for index in 1..=self.entries.len() {
+            values.push(self.entries.get(&LuaTableKey::Integer(index as i64))?);
+        }
+        (values.len() == self.entries.len()).then_some(values)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LuaHostHandle {
+    pub(crate) kind: String,
+    pub(crate) index: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct LuaModule {
+    pub(crate) members: BTreeMap<String, LuaModuleValue>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum LuaModuleValue {
+    Function(u32),
+    Module(LuaModule),
+    Data(LuaData),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LuaHostError {
+    pub(crate) category: String,
+    pub(crate) message: String,
+    pub(crate) location: Option<LuaSourceLocation>,
+}
+
+impl fmt::Display for LuaHostError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.category, self.message)
+    }
+}
+
+impl std::error::Error for LuaHostError {}
+
+pub(crate) trait LuaHost {
+    fn module(&self, name: &str) -> Option<LuaModule>;
+
+    fn call(
+        &mut self,
+        function: u32,
+        arguments: Vec<LuaData>,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError>;
+
+    fn index(
+        &mut self,
+        handle: &LuaHostHandle,
+        key: &str,
+        location: LuaSourceLocation,
+    ) -> Result<LuaData, LuaHostError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LuaFailureKind {
+    Syntax,
+    Evaluation,
+    Require,
+    Host,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LuaFailure {
+    pub(crate) kind: LuaFailureKind,
+    pub(crate) location: Option<LuaSourceLocation>,
+    pub(crate) category: Option<String>,
+    pub(crate) message: String,
+}
+
+impl fmt::Display for LuaFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(location) = &self.location {
+            write!(
+                formatter,
+                "{}:{}: {}",
+                location.source, location.line, self.message
+            )
+        } else {
+            formatter.write_str(&self.message)
+        }
+    }
+}
+
+impl std::error::Error for LuaFailure {}
+
+#[derive(Debug, Clone)]
+struct CallbackFailure(LuaFailure);
+
+impl fmt::Display for CallbackFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl std::error::Error for CallbackFailure {}
+
+struct HostUserData<H> {
+    handle: LuaHostHandle,
+    host: Rc<RefCell<H>>,
+}
+
+impl<H: LuaHost + 'static> UserData for HostUserData<H> {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_meta_method(
+            MetaMethod::Index,
+            |lua, this, key: String| -> mlua::Result<Value> {
+                let location = caller_location(lua);
+                let result = this
+                    .host
+                    .borrow_mut()
+                    .index(&this.handle, &key, location.clone())
+                    .map_err(|error| host_error_to_mlua(error, location))?;
+                data_to_lua(lua, result, Rc::clone(&this.host))
+            },
+        );
+    }
+}
+
+pub(crate) fn evaluate<H: LuaHost + 'static>(
+    request: LuaEvaluationRequest<'_>,
+    host: H,
+) -> Result<LuaEvaluation<H>, LuaFailure> {
+    let base_dir = canonical_workflows_dir(request.workflows_dir)?;
+    let lua = Lua::new_with(
+        StdLib::TABLE | StdLib::STRING | StdLib::MATH,
+        LuaOptions::default(),
+    )
+    .map_err(|error| map_mlua_error(error, request.source_name))?;
+    lua.set_memory_limit(request.limits.memory_bytes)
+        .map_err(|error| map_mlua_error(error, request.source_name))?;
+    scrub_globals(&lua).map_err(|error| map_mlua_error(error, request.source_name))?;
+    install_instruction_limit(&lua, request.limits.instructions)
+        .map_err(|error| map_mlua_error(error, request.source_name))?;
+
+    let host = Rc::new(RefCell::new(host));
+    install_require(&lua, &base_dir, Rc::clone(&host))
+        .map_err(|error| map_mlua_error(error, request.source_name))?;
+
+    let evaluated = lua
+        .load(request.source)
+        .set_name(request.source_name)
+        .eval::<Value>()
+        .map_err(|error| map_mlua_error(error, request.source_name))?;
+    let value =
+        lua_to_data::<H>(evaluated).map_err(|error| map_mlua_error(error, request.source_name))?;
+
+    drop(lua);
+    let host = Rc::try_unwrap(host)
+        .map_err(|_| LuaFailure {
+            kind: LuaFailureKind::Evaluation,
+            location: Some(LuaSourceLocation {
+                source: request.source_name.to_string(),
+                line: 1,
+            }),
+            category: None,
+            message: "Lua host state remained referenced after evaluation".to_string(),
+        })?
+        .into_inner();
+    Ok(LuaEvaluation { value, host })
+}
+
+fn canonical_workflows_dir(path: &Path) -> Result<PathBuf, LuaFailure> {
+    fs::canonicalize(path).map_err(|error| LuaFailure {
+        kind: LuaFailureKind::Evaluation,
+        location: None,
+        category: None,
+        message: format!(
+            "workflows directory '{}' could not be resolved: {error}",
+            path.display()
+        ),
+    })
+}
+
+fn scrub_globals(lua: &Lua) -> mlua::Result<()> {
+    let globals = lua.globals();
+    for name in [
+        "io",
+        "os",
+        "package",
+        "debug",
+        "coroutine",
+        "utf8",
+        "load",
+        "loadstring",
+        "dofile",
+        "loadfile",
+        "print",
+        "warn",
+        "pairs",
+        "next",
+        "collectgarbage",
+        "tostring",
+    ] {
+        globals.raw_set(name, Value::Nil)?;
+    }
+    if let Ok(math) = globals.raw_get::<mlua::Table>("math") {
+        math.raw_set("random", Value::Nil)?;
+        math.raw_set("randomseed", Value::Nil)?;
+    }
+    Ok(())
+}
+
+fn install_instruction_limit(lua: &Lua, limit: u64) -> mlua::Result<()> {
+    let executed = Rc::new(RefCell::new(0_u64));
+    lua.set_hook(
+        HookTriggers::new().every_nth_instruction(HOOK_INSTRUCTION_INTERVAL),
+        move |_lua, debug| {
+            let mut executed = executed.borrow_mut();
+            *executed = executed.saturating_add(u64::from(HOOK_INSTRUCTION_INTERVAL));
+            if *executed > limit {
+                let source = debug.source();
+                let location = LuaSourceLocation {
+                    source: normalize_source_name(
+                        source
+                            .source
+                            .as_deref()
+                            .or(source.short_src.as_deref())
+                            .unwrap_or("<lua>"),
+                    ),
+                    line: debug.current_line().unwrap_or(1),
+                };
+                return Err(mlua::Error::external(CallbackFailure(LuaFailure {
+                    kind: LuaFailureKind::Evaluation,
+                    location: Some(location),
+                    category: None,
+                    message: format!("Lua instruction limit of {limit} was exceeded"),
+                })));
+            }
+            Ok(VmState::Continue)
+        },
+    )
+}
+
+fn install_require<H: LuaHost + 'static>(
+    lua: &Lua,
+    base_dir: &Path,
+    host: Rc<RefCell<H>>,
+) -> mlua::Result<()> {
+    let base_dir = base_dir.to_path_buf();
+    let cache = Rc::new(RefCell::new(BTreeMap::<String, RegistryKey>::new()));
+    let loading = Rc::new(RefCell::new(BTreeSet::<String>::new()));
+    let require = lua.create_function(move |lua, module_name: String| {
+        if let Some(key) = cache.borrow().get(&module_name) {
+            return lua.registry_value::<Value>(key);
+        }
+        let location = caller_location(lua);
+        if !loading.borrow_mut().insert(module_name.clone()) {
+            return Err(callback_failure(
+                LuaFailureKind::Require,
+                Some(location),
+                format!("cyclic require detected for module '{module_name}'"),
+            ));
+        }
+
+        let result = if let Some(module) = host.borrow().module(&module_name) {
+            module_to_lua(lua, module, Rc::clone(&host))
+        } else {
+            load_file_module(lua, &base_dir, &module_name, location.clone())
+        };
+        loading.borrow_mut().remove(&module_name);
+
+        let mut value = result?;
+        if matches!(value, Value::Nil) {
+            value = Value::Boolean(true);
+        }
+        let key = lua.create_registry_value(value.clone())?;
+        cache.borrow_mut().insert(module_name, key);
+        Ok(value)
+    })?;
+    lua.globals().raw_set("require", require)
+}
+
+fn load_file_module(
+    lua: &Lua,
+    base_dir: &Path,
+    module_name: &str,
+    require_location: LuaSourceLocation,
+) -> mlua::Result<Value> {
+    let path = resolve_module_path(base_dir, module_name).map_err(|message| {
+        callback_failure(
+            LuaFailureKind::Require,
+            Some(require_location.clone()),
+            message,
+        )
+    })?;
+    let source = fs::read_to_string(&path).map_err(|error| {
+        callback_failure(
+            LuaFailureKind::Require,
+            Some(require_location),
+            format!("module '{}' could not be read: {error}", path.display()),
+        )
+    })?;
+    lua.load(&source)
+        .set_name(path.to_string_lossy().as_ref())
+        .eval::<Value>()
+        .map_err(|error| {
+            mlua::Error::external(CallbackFailure(map_mlua_error(
+                error,
+                path.to_string_lossy().as_ref(),
+            )))
+        })
+}
+
+fn resolve_module_path(base_dir: &Path, module_name: &str) -> Result<PathBuf, String> {
+    let components = module_name.split('.').collect::<Vec<_>>();
+    if components.is_empty()
+        || components.iter().any(|component| {
+            component.is_empty()
+                || !component.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+                })
+        })
+    {
+        return Err(format!("invalid require module name '{module_name}'"));
+    }
+    let mut candidate = base_dir.to_path_buf();
+    for component in components {
+        candidate.push(component);
+    }
+    candidate.set_extension("lua");
+    let canonical = fs::canonicalize(&candidate).map_err(|error| {
+        format!(
+            "module '{module_name}' could not be resolved as '{}': {error}",
+            candidate.display()
+        )
+    })?;
+    if !canonical.starts_with(base_dir) {
+        return Err(format!(
+            "module '{module_name}' resolves outside the workflows directory"
+        ));
+    }
+    Ok(canonical)
+}
+
+fn module_to_lua<H: LuaHost + 'static>(
+    lua: &Lua,
+    module: LuaModule,
+    host: Rc<RefCell<H>>,
+) -> mlua::Result<Value> {
+    let table = lua.create_table_with_capacity(0, module.members.len())?;
+    for (name, value) in module.members {
+        let value = match value {
+            LuaModuleValue::Function(function_id) => {
+                let callback_host = Rc::clone(&host);
+                Value::Function(lua.create_function(move |lua, arguments: MultiValue| {
+                    let location = caller_location(lua);
+                    let arguments = arguments
+                        .into_iter()
+                        .map(lua_to_data::<H>)
+                        .collect::<mlua::Result<Vec<_>>>()?;
+                    let result = callback_host
+                        .borrow_mut()
+                        .call(function_id, arguments, location.clone())
+                        .map_err(|error| host_error_to_mlua(error, location))?;
+                    data_to_lua(lua, result, Rc::clone(&callback_host))
+                })?)
+            }
+            LuaModuleValue::Module(module) => module_to_lua(lua, module, Rc::clone(&host))?,
+            LuaModuleValue::Data(data) => data_to_lua(lua, data, Rc::clone(&host))?,
+        };
+        table.raw_set(name, value)?;
+    }
+    Ok(Value::Table(table))
+}
+
+fn lua_to_data<H: LuaHost + 'static>(value: Value) -> mlua::Result<LuaData> {
+    match value {
+        Value::Nil => Ok(LuaData::Nil),
+        Value::Boolean(value) => Ok(LuaData::Boolean(value)),
+        Value::Integer(value) => Ok(LuaData::Integer(value)),
+        Value::Number(value) => Ok(LuaData::Number(value)),
+        Value::String(value) => Ok(LuaData::String(value.to_string_lossy())),
+        Value::Table(table) => {
+            let mut entries = BTreeMap::new();
+            for pair in table.pairs::<Value, Value>() {
+                let (key, value) = pair?;
+                let key = match key {
+                    Value::Boolean(key) => LuaTableKey::Boolean(key),
+                    Value::Integer(key) => LuaTableKey::Integer(key),
+                    Value::String(key) => LuaTableKey::String(key.to_string_lossy()),
+                    other => {
+                        return Err(mlua::Error::runtime(format!(
+                            "unsupported Lua table key type '{}'",
+                            other.type_name()
+                        )))
+                    }
+                };
+                entries.insert(key, lua_to_data::<H>(value)?);
+            }
+            Ok(LuaData::Table(LuaTableData { entries }))
+        }
+        Value::UserData(userdata) => {
+            let borrowed = userdata.borrow::<HostUserData<H>>()?;
+            Ok(LuaData::Handle(borrowed.handle.clone()))
+        }
+        other => Err(mlua::Error::runtime(format!(
+            "unsupported Lua value type '{}'",
+            other.type_name()
+        ))),
+    }
+}
+
+fn data_to_lua<H: LuaHost + 'static>(
+    lua: &Lua,
+    value: LuaData,
+    host: Rc<RefCell<H>>,
+) -> mlua::Result<Value> {
+    match value {
+        LuaData::Nil => Ok(Value::Nil),
+        LuaData::Boolean(value) => Ok(Value::Boolean(value)),
+        LuaData::Integer(value) => Ok(Value::Integer(value)),
+        LuaData::Number(value) => Ok(Value::Number(value)),
+        LuaData::String(value) => Ok(Value::String(lua.create_string(value)?)),
+        LuaData::Table(table_data) => {
+            let table = lua.create_table_with_capacity(0, table_data.entries.len())?;
+            for (key, value) in table_data.entries {
+                let key = match key {
+                    LuaTableKey::Boolean(value) => Value::Boolean(value),
+                    LuaTableKey::Integer(value) => Value::Integer(value),
+                    LuaTableKey::String(value) => Value::String(lua.create_string(value)?),
+                };
+                table.raw_set(key, data_to_lua(lua, value, Rc::clone(&host))?)?;
+            }
+            Ok(Value::Table(table))
+        }
+        LuaData::Handle(handle) => Ok(Value::UserData(
+            lua.create_userdata(HostUserData { handle, host })?,
+        )),
+    }
+}
+
+fn host_error_to_mlua(mut error: LuaHostError, fallback: LuaSourceLocation) -> mlua::Error {
+    if error.location.is_none() {
+        error.location = Some(fallback);
+    }
+    mlua::Error::external(CallbackFailure(LuaFailure {
+        kind: LuaFailureKind::Host,
+        location: error.location,
+        category: Some(error.category),
+        message: error.message,
+    }))
+}
+
+fn callback_failure(
+    kind: LuaFailureKind,
+    location: Option<LuaSourceLocation>,
+    message: impl Into<String>,
+) -> mlua::Error {
+    mlua::Error::external(CallbackFailure(LuaFailure {
+        kind,
+        location,
+        category: None,
+        message: message.into(),
+    }))
+}
+
+fn map_mlua_error(error: mlua::Error, fallback_source: &str) -> LuaFailure {
+    if let Some(callback) = error.downcast_ref::<CallbackFailure>() {
+        return callback.0.clone();
+    }
+    let display = error.to_string();
+    match error {
+        mlua::Error::SyntaxError { message, .. } => LuaFailure {
+            kind: LuaFailureKind::Syntax,
+            location: Some(LuaSourceLocation {
+                source: fallback_source.to_string(),
+                line: line_from_error_message(&message).unwrap_or(1),
+            }),
+            category: None,
+            message,
+        },
+        mlua::Error::MemoryError(message) => LuaFailure {
+            kind: LuaFailureKind::Evaluation,
+            location: Some(LuaSourceLocation {
+                source: fallback_source.to_string(),
+                line: line_from_error_message(&message).unwrap_or(1),
+            }),
+            category: None,
+            message: format!("Lua memory limit was exceeded: {message}"),
+        },
+        _ => LuaFailure {
+            kind: LuaFailureKind::Evaluation,
+            location: Some(LuaSourceLocation {
+                source: fallback_source.to_string(),
+                line: line_from_error_message(&display).unwrap_or(1),
+            }),
+            category: None,
+            message: display,
+        },
+    }
+}
+
+fn caller_location(lua: &Lua) -> LuaSourceLocation {
+    for level in 1..=8 {
+        let location = lua.inspect_stack(level, |debug| {
+            let source = debug.source();
+            (
+                source.source.map(|source| source.into_owned()),
+                debug.current_line(),
+            )
+        });
+        if let Some((Some(source), Some(line))) = location {
+            if source != "=[C]" {
+                return LuaSourceLocation {
+                    source: normalize_source_name(&source),
+                    line,
+                };
+            }
+        }
+    }
+    LuaSourceLocation {
+        source: "<lua>".to_string(),
+        line: 1,
+    }
+}
+
+fn normalize_source_name(source: &str) -> String {
+    source
+        .strip_prefix('@')
+        .or_else(|| source.strip_prefix('='))
+        .unwrap_or(source)
+        .to_string()
+}
+
+fn line_from_error_message(message: &str) -> Option<usize> {
+    message
+        .split(':')
+        .find_map(|part| part.trim().parse::<usize>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[derive(Debug, Default)]
+    struct TestHost {
+        calls: Vec<(u32, LuaSourceLocation)>,
+    }
+
+    impl LuaHost for TestHost {
+        fn module(&self, name: &str) -> Option<LuaModule> {
+            (name == "test").then(|| LuaModule {
+                members: BTreeMap::from([("value".to_string(), LuaModuleValue::Function(1))]),
+            })
+        }
+
+        fn call(
+            &mut self,
+            function: u32,
+            arguments: Vec<LuaData>,
+            location: LuaSourceLocation,
+        ) -> Result<LuaData, LuaHostError> {
+            self.calls.push((function, location));
+            Ok(arguments.into_iter().next().unwrap_or(LuaData::Nil))
+        }
+
+        fn index(
+            &mut self,
+            _handle: &LuaHostHandle,
+            key: &str,
+            location: LuaSourceLocation,
+        ) -> Result<LuaData, LuaHostError> {
+            Err(LuaHostError {
+                category: "test".to_string(),
+                message: format!("unknown field '{key}'"),
+                location: Some(location),
+            })
+        }
+    }
+
+    fn request<'a>(dir: &'a Path, source: &'a str) -> LuaEvaluationRequest<'a> {
+        LuaEvaluationRequest {
+            source_name: "main.lua",
+            source,
+            workflows_dir: dir,
+            limits: LuaLimits::default(),
+        }
+    }
+
+    #[test]
+    fn test_lua評価_許可moduleを呼び出して呼出位置を返す() {
+        let dir = TempDir::new().unwrap();
+
+        let result = evaluate(
+            request(
+                dir.path(),
+                "local test = require('test')\nreturn test.value('ok')",
+            ),
+            TestHost::default(),
+        )
+        .unwrap();
+
+        assert_eq!(result.value, LuaData::String("ok".to_string()));
+        assert_eq!(result.host.calls.len(), 1);
+        assert_eq!(result.host.calls[0].1.line, 2);
+    }
+
+    #[test]
+    fn test_lua評価_標準外部ioと動的loadを公開しない() {
+        let dir = TempDir::new().unwrap();
+        let source = "return { io = io, os = os, package = package, load = load, print = print, pairs = pairs, next = next, collectgarbage = collectgarbage, tostring = tostring, random = math.random }";
+
+        let result = evaluate(request(dir.path(), source), TestHost::default()).unwrap();
+        let LuaData::Table(table) = result.value else {
+            panic!("table expected");
+        };
+
+        assert!(table.entries.is_empty());
+    }
+
+    #[test]
+    fn test_lua評価_命令上限で終了しない定義を打ち切る() {
+        let dir = TempDir::new().unwrap();
+        let mut request = request(dir.path(), "while true do end");
+        request.limits.instructions = 20_000;
+
+        let error = evaluate(request, TestHost::default()).unwrap_err();
+
+        assert_eq!(error.kind, LuaFailureKind::Evaluation);
+        assert!(error.message.contains("instruction limit"));
+    }
+
+    #[test]
+    fn test_lua評価_メモリ上限で過大な定義だけを打ち切る() {
+        let dir = TempDir::new().unwrap();
+        let mut oversized = request(dir.path(), "return string.rep('x', 16777216)");
+        oversized.limits.memory_bytes = 4 * 1024 * 1024;
+
+        let error = evaluate(oversized, TestHost::default()).unwrap_err();
+        let following = evaluate(request(dir.path(), "return true"), TestHost::default()).unwrap();
+
+        assert_eq!(error.kind, LuaFailureKind::Evaluation);
+        assert!(error.message.contains("memory limit"));
+        assert_eq!(following.value, LuaData::Boolean(true));
+    }
+
+    #[test]
+    fn test_lua評価_requireはworkflow配下だけを解決して一度だけ評価する() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("part.lua"),
+            "return function() return 'part' end",
+        )
+        .unwrap();
+
+        let result = evaluate(
+            request(
+                dir.path(),
+                "local a = require('part')\nlocal b = require('part')\nreturn { a(), b(), a == b }",
+            ),
+            TestHost::default(),
+        )
+        .unwrap();
+        let LuaData::Table(table) = result.value else {
+            panic!("table expected");
+        };
+        assert_eq!(
+            table.as_array().unwrap(),
+            vec![
+                &LuaData::String("part".to_string()),
+                &LuaData::String("part".to_string()),
+                &LuaData::Boolean(true),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_lua評価_require循環を検出して拒否する() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("a.lua"), "return require('b')").unwrap();
+        fs::write(dir.path().join("b.lua"), "return require('a')").unwrap();
+
+        let error = evaluate(
+            request(dir.path(), "return require('a')"),
+            TestHost::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind, LuaFailureKind::Require);
+        assert!(error.message.contains("cyclic require"));
+        assert!(error.location.unwrap().source.ends_with("b.lua"));
+    }
+
+    #[test]
+    fn test_lua評価_requireのpath走査を拒否する() {
+        let dir = TempDir::new().unwrap();
+
+        let error = evaluate(
+            request(dir.path(), "return require('../outside')"),
+            TestHost::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind, LuaFailureKind::Require);
+        assert!(error.message.contains("invalid require module name"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_lua評価_requireのsymlinkによるdirectory外脱出を拒否する() {
+        use std::os::unix::fs::symlink;
+
+        let workflows = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_module = outside.path().join("outside.lua");
+        fs::write(&outside_module, "return 'outside'").unwrap();
+        symlink(&outside_module, workflows.path().join("escape.lua")).unwrap();
+
+        let error = evaluate(
+            request(workflows.path(), "return require('escape')"),
+            TestHost::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind, LuaFailureKind::Require);
+        assert!(error.message.contains("outside the workflows directory"));
+    }
+
+    #[test]
+    fn test_lua評価_構文エラーをsourceと行番号付きで返す() {
+        let dir = TempDir::new().unwrap();
+
+        let error = evaluate(
+            request(dir.path(), "local ok = true\nreturn )"),
+            TestHost::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind, LuaFailureKind::Syntax);
+        assert_eq!(error.location.unwrap().line, 2);
+    }
+
+    #[test]
+    fn test_lua評価_require先の構文エラーをmodule位置で返す() {
+        let dir = TempDir::new().unwrap();
+        let module = dir.path().join("broken.lua");
+        fs::write(&module, "local ok = true\nreturn )").unwrap();
+
+        let error = evaluate(
+            request(dir.path(), "return require('broken')"),
+            TestHost::default(),
+        )
+        .unwrap_err();
+        let location = error.location.unwrap();
+
+        assert_eq!(error.kind, LuaFailureKind::Syntax);
+        assert_eq!(
+            location.source,
+            fs::canonicalize(module).unwrap().to_string_lossy()
+        );
+        assert_eq!(location.line, 2);
+    }
+}

--- a/src-tauri/src/infrastructure/lua/mod.rs
+++ b/src-tauri/src/infrastructure/lua/mod.rs
@@ -1,0 +1,7 @@
+mod evaluator;
+
+pub(crate) use evaluator::{
+    evaluate, LuaData, LuaEvaluationRequest, LuaFailure, LuaFailureKind, LuaHost, LuaHostError,
+    LuaHostHandle, LuaLimits, LuaModule, LuaModuleValue, LuaSourceLocation, LuaTableData,
+    LuaTableKey,
+};

--- a/src-tauri/src/infrastructure/mod.rs
+++ b/src-tauri/src/infrastructure/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod comment;
 pub(crate) mod file_watcher;
 pub mod git;
 pub(crate) mod local_api;
+pub(crate) mod lua;
 pub(crate) mod platform;
 pub(crate) mod process;
 pub(crate) mod provider_history;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -907,6 +907,13 @@ pub fn run() {
                     repository_state.clone(),
                     code_usecase.clone(),
                 ));
+                let workflows_dir =
+                    adaptor::gateway::workflow::WorkflowDefinitionFileRepository::default_workflows_dir();
+                if let Err(error) =
+                    adaptor::gateway::workflow::lua::generate_editor_support(&workflows_dir)
+                {
+                    log::warn!("Lua editor support generation failed at startup: {error}");
+                }
                 let (workflow_usecase, workspace_query_service) =
                     adaptor::controller::wiring::build_workflow_services_with_repository_worktrees(
                         data_dir.clone(),

--- a/src-tauri/src/usecase/workflow/definition.rs
+++ b/src-tauri/src/usecase/workflow/definition.rs
@@ -47,6 +47,13 @@ impl WorkflowDefinitionUsecase {
         source_name: &str,
         new_name: &str,
     ) -> Result<(), WorkflowError> {
+        if self.definition_sources.source_format(source_name)?
+            == crate::domain::workflow::WorkflowSourceFormat::Lua
+        {
+            return Err(WorkflowError::validation(
+                "Lua workflow は複製できません。外部エディタで編集してください",
+            ));
+        }
         let mut definition = self.definitions.get(source_name)?.ok_or_else(|| {
             WorkflowError::NotFound(format!(
                 "ソースワークフロー '{source_name}' が見つかりません"
@@ -153,5 +160,40 @@ mod tests {
 
         assert!(definitions.get_saved("target").is_none());
         assert_eq!(definitions.deleted.lock().unwrap().as_slice(), ["target"]);
+    }
+
+    struct LuaDefinitionSourceGateway;
+
+    impl WorkflowDefinitionSourceGateway for LuaDefinitionSourceGateway {
+        fn get_source(&self, _file_stem: &str) -> Result<Option<String>, WorkflowError> {
+            Ok(None)
+        }
+
+        fn source_format(
+            &self,
+            _file_stem: &str,
+        ) -> Result<crate::domain::workflow::WorkflowSourceFormat, WorkflowError> {
+            Ok(crate::domain::workflow::WorkflowSourceFormat::Lua)
+        }
+
+        fn save_source(
+            &self,
+            _source: &str,
+            _original_name: Option<&str>,
+        ) -> Result<WorkflowDefinition, WorkflowError> {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn duplicate_workflow_rejects_lua_source() {
+        let definitions = Arc::new(FakeDefinitionRepository::default());
+        definitions.seed(definition("source", false));
+        let usecase =
+            WorkflowDefinitionUsecase::new(definitions, Arc::new(LuaDefinitionSourceGateway));
+
+        let error = usecase.duplicate_workflow("source", "copy").unwrap_err();
+
+        assert!(error.to_string().contains("Lua workflow"));
     }
 }

--- a/src-tauri/src/usecase/workflow/dto.rs
+++ b/src-tauri/src/usecase/workflow/dto.rs
@@ -11,6 +11,8 @@ pub(crate) struct WorkflowDto {
     pub description: String,
     #[serde(default)]
     pub builtin: bool,
+    #[serde(rename = "sourceFormat")]
+    pub source_format: domain::WorkflowSourceFormat,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub schemas: BTreeMap<String, serde_json::Value>,
     pub nodes: Vec<NodeDefinitionDto>,
@@ -159,6 +161,8 @@ pub(crate) struct WorkflowSummaryDto {
     pub builtin: bool,
     #[serde(default)]
     pub is_running: bool,
+    #[serde(rename = "sourceFormat")]
+    pub source_format: domain::WorkflowSourceFormat,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -228,10 +232,18 @@ pub(crate) struct WorkflowExecutionSummaryDto {
 }
 
 pub(crate) fn workflow_to_dto(definition: &domain::WorkflowDefinition) -> WorkflowDto {
+    workflow_to_dto_with_source_format(definition, domain::WorkflowSourceFormat::Yaml)
+}
+
+pub(crate) fn workflow_to_dto_with_source_format(
+    definition: &domain::WorkflowDefinition,
+    source_format: domain::WorkflowSourceFormat,
+) -> WorkflowDto {
     WorkflowDto {
         name: definition.name.clone(),
         description: definition.description.clone(),
         builtin: definition.builtin,
+        source_format,
         schemas: definition
             .schemas
             .iter()
@@ -252,6 +264,7 @@ pub(crate) fn workflow_summary_to_dto(summary: domain::WorkflowSummary) -> Workf
         description: summary.description,
         builtin: summary.builtin,
         is_running: summary.is_running,
+        source_format: summary.source_format,
     }
 }
 
@@ -460,6 +473,7 @@ mod tests {
             name: "wf".to_string(),
             description: "desc".to_string(),
             builtin: false,
+            source_format: domain::WorkflowSourceFormat::Yaml,
             schemas: [(
                 "plan".to_string(),
                 serde_json::json!({
@@ -497,6 +511,7 @@ mod tests {
                 "name": "wf",
                 "description": "desc",
                 "builtin": false,
+                "sourceFormat": "yaml",
                 "schemas": {
                     "plan": {
                         "type": "object",
@@ -519,6 +534,27 @@ mod tests {
                 }]
             })
         );
+    }
+
+    #[test]
+    fn workflow_dto_exposes_lua_only_as_definition_source_metadata() {
+        let workflow = domain::WorkflowDefinition {
+            name: "lua-workflow".to_string(),
+            description: "Lua".to_string(),
+            ..domain::WorkflowDefinition::default()
+        };
+
+        let value = serde_json::to_value(workflow_to_dto_with_source_format(
+            &workflow,
+            domain::WorkflowSourceFormat::Lua,
+        ))
+        .unwrap();
+
+        assert_eq!(value["sourceFormat"], "lua");
+        assert!(serde_json::to_value(workflow)
+            .unwrap()
+            .get("sourceFormat")
+            .is_none());
     }
 
     #[test]

--- a/src-tauri/src/usecase/workflow/mod.rs
+++ b/src-tauri/src/usecase/workflow/mod.rs
@@ -345,6 +345,13 @@ impl WorkflowUsecase {
         self.query.get_workflow_source(file_stem)
     }
 
+    pub fn get_workflow_source_format(
+        &self,
+        file_stem: &str,
+    ) -> Result<crate::domain::workflow::WorkflowSourceFormat, WorkflowError> {
+        self.query.get_workflow_source_format(file_stem)
+    }
+
     pub fn get_execution_log(
         &self,
         execution_id: &str,
@@ -738,6 +745,7 @@ mod tests {
                     description: definition.description.clone(),
                     builtin: definition.builtin,
                     is_running: running_names.contains(&definition.name),
+                    source_format: crate::domain::workflow::WorkflowSourceFormat::Yaml,
                 })
                 .collect::<Vec<_>>();
             summaries.sort_by(|left, right| left.name.cmp(&right.name));
@@ -1494,6 +1502,26 @@ mod tests {
         assert_no_forbidden_production_patterns(
             "usecase/repository_state",
             &external_dependency_patterns,
+        );
+    }
+
+    #[test]
+    fn workflow_execution_runtime_does_not_depend_on_lua_evaluation() {
+        let forbidden_patterns = [
+            concat!("infrastructure", "::", "lua"),
+            "mlua::",
+            "load_lua_workflow",
+        ];
+
+        assert_no_forbidden_production_patterns("domain/workflow", &forbidden_patterns);
+        assert_no_forbidden_production_patterns("usecase/workflow", &forbidden_patterns);
+        assert_no_forbidden_production_patterns(
+            "adaptor/gateway/workflow/workflow_host",
+            &forbidden_patterns,
+        );
+        assert_no_forbidden_production_patterns_in_file(
+            "adaptor/gateway/workflow/workflow_host.rs",
+            &forbidden_patterns,
         );
     }
 

--- a/src-tauri/src/usecase/workflow/ports.rs
+++ b/src-tauri/src/usecase/workflow/ports.rs
@@ -48,6 +48,12 @@ pub trait WorkflowExecutionProjectionRepository: Send + Sync {
 
 pub trait WorkflowDefinitionSourceGateway: Send + Sync {
     fn get_source(&self, file_stem: &str) -> Result<Option<String>, WorkflowError>;
+    fn source_format(
+        &self,
+        _file_stem: &str,
+    ) -> Result<crate::domain::workflow::WorkflowSourceFormat, WorkflowError> {
+        Ok(crate::domain::workflow::WorkflowSourceFormat::Yaml)
+    }
     fn save_source(
         &self,
         source: &str,

--- a/src-tauri/src/usecase/workflow/query_service.rs
+++ b/src-tauri/src/usecase/workflow/query_service.rs
@@ -79,6 +79,14 @@ impl WorkflowQueryService {
         self.definition_sources.get_source(name.as_str())
     }
 
+    pub fn get_workflow_source_format(
+        &self,
+        file_stem: &str,
+    ) -> Result<crate::domain::workflow::WorkflowSourceFormat, WorkflowError> {
+        let name = WorkflowDefinitionName::new(file_stem.to_string())?;
+        self.definition_sources.source_format(name.as_str())
+    }
+
     pub(in crate::usecase::workflow) fn read_events(
         &self,
         execution_id: &str,
@@ -235,6 +243,7 @@ mod tests {
                 description: self.workflow.description.clone(),
                 builtin: self.workflow.builtin,
                 is_running: running_names.contains(&self.workflow.name),
+                source_format: crate::domain::workflow::WorkflowSourceFormat::Yaml,
             }])
         }
 

--- a/src-tauri/src/usecase/workflow/query_service.rs
+++ b/src-tauri/src/usecase/workflow/query_service.rs
@@ -389,6 +389,75 @@ mod tests {
         }
     }
 
+    /// `source_format` の戻り値だけを制御する gateway。
+    struct FakeSourceFormatGateway {
+        format: Option<crate::domain::workflow::WorkflowSourceFormat>,
+    }
+
+    impl WorkflowDefinitionSourceGateway for FakeSourceFormatGateway {
+        fn get_source(&self, _file_stem: &str) -> Result<Option<String>, WorkflowError> {
+            Ok(None)
+        }
+
+        fn source_format(
+            &self,
+            _file_stem: &str,
+        ) -> Result<crate::domain::workflow::WorkflowSourceFormat, WorkflowError> {
+            self.format
+                .ok_or_else(|| WorkflowError::external("source format unavailable"))
+        }
+
+        fn save_source(
+            &self,
+            _source: &str,
+            _original_name: Option<&str>,
+        ) -> Result<WorkflowDefinition, WorkflowError> {
+            Err(WorkflowError::external("not used"))
+        }
+    }
+
+    fn service_with_source_format(
+        format: Option<crate::domain::workflow::WorkflowSourceFormat>,
+    ) -> WorkflowQueryService {
+        WorkflowQueryService::new(
+            Arc::new(FakeDefinitionRepository {
+                workflow: workflow(),
+            }),
+            Arc::new(FakeSourceFormatGateway { format }),
+            Arc::new(FakeFacetRepository::default()),
+            Arc::new(FakeEventRepository::default()),
+            Arc::new(FakeExecutionProjectionRepository::default()),
+        )
+    }
+
+    #[test]
+    fn get_workflow_source_format_returns_lua_from_gateway() {
+        let service =
+            service_with_source_format(Some(crate::domain::workflow::WorkflowSourceFormat::Lua));
+
+        assert_eq!(
+            service.get_workflow_source_format("wf").unwrap(),
+            crate::domain::workflow::WorkflowSourceFormat::Lua
+        );
+    }
+
+    #[test]
+    fn get_workflow_source_format_propagates_gateway_error() {
+        let service = service_with_source_format(None);
+
+        let error = service.get_workflow_source_format("wf").unwrap_err();
+
+        assert!(error.to_string().contains("source format unavailable"));
+    }
+
+    #[test]
+    fn get_workflow_source_format_rejects_invalid_file_stem() {
+        let service =
+            service_with_source_format(Some(crate::domain::workflow::WorkflowSourceFormat::Lua));
+
+        assert!(service.get_workflow_source_format("../escape").is_err());
+    }
+
     struct Fixture {
         service: WorkflowQueryService,
         facets: Arc<FakeFacetRepository>,

--- a/src/components/panels/AutomationSection.test.tsx
+++ b/src/components/panels/AutomationSection.test.tsx
@@ -124,12 +124,14 @@ describe("AutomationSection", () => {
 					description: "Built-in workflow",
 					builtin: true,
 					is_running: false,
+					sourceFormat: "yaml",
 				},
 				{
 					name: "my-custom",
 					description: "Custom workflow",
 					builtin: false,
 					is_running: false,
+					sourceFormat: "yaml",
 				},
 			],
 		});
@@ -147,6 +149,7 @@ describe("AutomationSection", () => {
 					description: "Built-in",
 					builtin: true,
 					is_running: false,
+					sourceFormat: "yaml",
 				},
 			],
 		});
@@ -164,6 +167,7 @@ describe("AutomationSection", () => {
 					description: "Custom",
 					builtin: false,
 					is_running: false,
+					sourceFormat: "yaml",
 				},
 			],
 		});
@@ -249,6 +253,7 @@ describe("AutomationSection", () => {
 					description: "Test",
 					builtin: false,
 					is_running: false,
+					sourceFormat: "yaml",
 				},
 			],
 			selectWorkflow,
@@ -265,6 +270,7 @@ describe("AutomationSection", () => {
 				name: "my-custom",
 				description: "A custom workflow",
 				builtin: false,
+				sourceFormat: "yaml",
 				nodes: [SESSION_NODE],
 			},
 		});
@@ -278,11 +284,48 @@ describe("AutomationSection", () => {
 				name: "builtin-workflow",
 				description: "Builtin",
 				builtin: true,
+				sourceFormat: "yaml",
 				nodes: [SESSION_NODE],
 			},
 		});
 		render(<AutomationSection automation={automation} />);
 		expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+	});
+
+	it("Lua workflow opens externally without rendering Monaco", async () => {
+		const user = userEvent.setup();
+		monacoMock.module.editor.create.mockClear();
+		const openWorkflowInEditor = vi.fn();
+		const automation = createMockAutomation({
+			workflows: [
+				{
+					name: "lua-workflow",
+					description: "Lua",
+					builtin: false,
+					is_running: false,
+					sourceFormat: "lua",
+				},
+			],
+			selectedWorkflow: {
+				name: "lua-workflow",
+				description: "Lua",
+				builtin: false,
+				sourceFormat: "lua",
+				nodes: [SESSION_NODE],
+			},
+			selectedWorkflowName: "lua-workflow",
+			selectedWorkflowSource: null,
+			openWorkflowInEditor,
+		});
+
+		render(<AutomationSection automation={automation} />);
+		await user.click(
+			screen.getByRole("button", { name: "Open in external editor" }),
+		);
+
+		expect(openWorkflowInEditor).toHaveBeenCalledWith("lua-workflow");
+		expect(monacoMock.module.editor.create).not.toHaveBeenCalled();
+		expect(screen.queryByText("YAML")).not.toBeInTheDocument();
 	});
 
 	it("facet list shows builtin/custom distinction", async () => {
@@ -323,6 +366,7 @@ describe("AutomationSection", () => {
 					description: "Running workflow",
 					builtin: false,
 					is_running: true,
+					sourceFormat: "yaml",
 				},
 			],
 			deleteWorkflow,
@@ -547,6 +591,7 @@ describe("AutomationSection", () => {
 				name: "test-wf",
 				description: "Test",
 				builtin: false,
+				sourceFormat: "yaml",
 				nodes: [SESSION_NODE],
 			},
 			selectedWorkflowName: "test-wf",
@@ -584,6 +629,7 @@ describe("AutomationSection", () => {
 				name: "detail-wf",
 				description: "Full details",
 				builtin: false,
+				sourceFormat: "yaml",
 				nodes: [
 					{
 						name: "complex-step",
@@ -642,6 +688,7 @@ describe("AutomationSection", () => {
 				name: "diag-wf",
 				description: "Workflow with diagnostics",
 				builtin: false,
+				sourceFormat: "yaml",
 				nodes: [SESSION_NODE],
 			},
 			report: {
@@ -765,7 +812,7 @@ describe("AutomationSection", () => {
 		).toBeInTheDocument();
 	});
 
-	it("workflow list shows diagnostic badge", () => {
+	it("Lua workflow list shows source format and diagnostic badge", () => {
 		const automation = createMockAutomation({
 			workflows: [
 				{
@@ -773,6 +820,7 @@ describe("AutomationSection", () => {
 					description: "Has errors",
 					builtin: false,
 					is_running: false,
+					sourceFormat: "lua",
 				},
 			],
 			report: {
@@ -786,6 +834,7 @@ describe("AutomationSection", () => {
 			},
 		});
 		render(<AutomationSection automation={automation} />);
+		expect(screen.getByText("lua")).toBeInTheDocument();
 		expect(screen.getByText("2")).toBeInTheDocument();
 		expect(screen.getByText("3")).toBeInTheDocument();
 	});

--- a/src/components/panels/AutomationSection.tsx
+++ b/src/components/panels/AutomationSection.tsx
@@ -45,6 +45,7 @@ export function AutomationSection({
 		saveWorkflowSource,
 		deleteWorkflow,
 		duplicateWorkflow,
+		openWorkflowInEditor,
 		selectFacet,
 		saveFacet,
 		deleteFacet,
@@ -207,6 +208,10 @@ export function AutomationSection({
 	}, [selectedFacetKey, facets]);
 
 	const isEditing = editingFacet || editingWorkflow;
+	const activeWorkflowSourceFormat = activeWorkflowName
+		? (workflows.find((workflow) => workflow.name === activeWorkflowName)
+				?.sourceFormat ?? "yaml")
+		: "yaml";
 
 	const handleReloadExternal = useCallback(() => {
 		clearExternalChange();
@@ -309,6 +314,13 @@ export function AutomationSection({
 									setDuplicateDialogOpen(true);
 								}}
 								onEdit={(name) => {
+									if (
+										workflows.find((workflow) => workflow.name === name)
+											?.sourceFormat === "lua"
+									) {
+										openWorkflowInEditor(name);
+										return;
+									}
 									setEditingWorkflow(true);
 									setWorkflowSaveDiagnostics(
 										report.items.filter((item) => item.workflow_name === name),
@@ -324,6 +336,7 @@ export function AutomationSection({
 						{/* Right: detail / editor */}
 						<div className="flex-1 min-w-0">
 							{editingWorkflow &&
+							activeWorkflowSourceFormat === "yaml" &&
 							activeWorkflowName &&
 							selectedWorkflowSource ? (
 								<WorkflowSourceEditor
@@ -348,14 +361,29 @@ export function AutomationSection({
 									workflow={selectedWorkflow}
 									report={report}
 									source={selectedWorkflowSource}
-									onEdit={handleEditWorkflow}
+									onEdit={() => {
+										if (selectedWorkflow.sourceFormat === "lua") {
+											openWorkflowInEditor(selectedWorkflow.name);
+										} else {
+											handleEditWorkflow();
+										}
+									}}
 								/>
-							) : activeWorkflowName && selectedWorkflowSource ? (
+							) : activeWorkflowName &&
+								(selectedWorkflowSource ||
+									activeWorkflowSourceFormat === "lua") ? (
 								<WorkflowSourceDiagnosticDetail
 									name={activeWorkflowName}
 									report={report}
-									source={selectedWorkflowSource}
-									onEdit={handleEditWorkflow}
+									source={selectedWorkflowSource ?? undefined}
+									sourceFormat={activeWorkflowSourceFormat}
+									onEdit={() => {
+										if (activeWorkflowSourceFormat === "lua") {
+											openWorkflowInEditor(activeWorkflowName);
+										} else {
+											handleEditWorkflow();
+										}
+									}}
 								/>
 							) : (
 								<p className="text-sm text-muted-foreground py-8 text-center">

--- a/src/components/panels/automation/DiagnosticBadge.tsx
+++ b/src/components/panels/automation/DiagnosticBadge.tsx
@@ -46,7 +46,7 @@ export function DiagnosticViewRow({ item }: { item: DiagnosticView }) {
 			<Info className="size-3 text-blue-500 shrink-0" />
 		);
 	const spanLabel = item.span
-		? `${item.span.start_line}:${item.span.start_col}`
+		? `${item.span.source ? `${item.span.source}:` : ""}${item.span.start_line}:${item.span.start_col}`
 		: null;
 
 	return (

--- a/src/components/panels/automation/WorkflowDetail.test.tsx
+++ b/src/components/panels/automation/WorkflowDetail.test.tsx
@@ -40,6 +40,7 @@ function makeWorkflow(overrides?: {
 		name: "wf",
 		description: "test workflow",
 		builtin: false,
+		sourceFormat: "yaml",
 		nodes: [
 			{
 				name: "implement",
@@ -241,5 +242,46 @@ describe("WorkflowDetail Monaco diagnostics", () => {
 				code: "WFR003",
 			},
 		]);
+	});
+
+	it("shows Lua diagnostics with source file and line without creating Monaco", () => {
+		vi.clearAllMocks();
+		const report: DiagnosticReport = {
+			items: [
+				{
+					code: "WFS009",
+					severity: "error",
+					stage: "parse_shape",
+					span: {
+						source: "component.lua",
+						start_line: 9,
+						start_col: 1,
+						end_line: 9,
+						end_col: 2,
+					},
+					message: "Lua syntax error",
+					workflow_name: "wf",
+				},
+			],
+			workflow_summaries: {},
+			facet_summaries: {},
+			facet_usage: {},
+		};
+
+		render(
+			<WorkflowSourceDiagnosticDetail
+				name="wf"
+				report={report}
+				sourceFormat="lua"
+				onEdit={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("component.lua:9:1")).toBeInTheDocument();
+		expect(screen.getByText("Lua syntax error")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Open in external editor" }),
+		).toBeInTheDocument();
+		expect(monacoMock.module.editor.create).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/panels/automation/WorkflowDetail.tsx
+++ b/src/components/panels/automation/WorkflowDetail.tsx
@@ -34,21 +34,30 @@ export function WorkflowDetail({
 		<div className="flex flex-col gap-4">
 			<div className="flex items-center justify-between">
 				<div>
-					<h4 className="text-sm font-medium">{workflow.name}</h4>
+					<div className="flex items-center gap-2">
+						<h4 className="text-sm font-medium">{workflow.name}</h4>
+						<span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
+							{workflow.sourceFormat}
+						</span>
+					</div>
 					<p className="text-xs text-muted-foreground">
 						{workflow.description}
 					</p>
 				</div>
 				{!workflow.builtin && (
 					<Button variant="outline" size="sm" onClick={onEdit}>
-						Edit
+						{workflow.sourceFormat === "lua"
+							? "Open in external editor"
+							: "Edit"}
 					</Button>
 				)}
 			</div>
 
 			<DiagnosticsPanel items={items} />
 
-			{source && <WorkflowSourcePane source={source} diagnostics={items} />}
+			{workflow.sourceFormat === "yaml" && source && (
+				<WorkflowSourcePane source={source} diagnostics={items} />
+			)}
 
 			<div className="flex flex-col gap-2">
 				<span className="text-xs font-medium text-muted-foreground">
@@ -66,11 +75,13 @@ export function WorkflowSourceDiagnosticDetail({
 	name,
 	report,
 	source,
+	sourceFormat = "yaml",
 	onEdit,
 }: {
 	name: string;
 	report: DiagnosticReport;
-	source: string;
+	source?: string;
+	sourceFormat?: "yaml" | "lua";
 	onEdit: () => void;
 }) {
 	const items = report.items.filter((i) => i.workflow_name === name);
@@ -79,19 +90,26 @@ export function WorkflowSourceDiagnosticDetail({
 		<div className="flex flex-col gap-4">
 			<div className="flex items-center justify-between">
 				<div>
-					<h4 className="text-sm font-medium">{name}</h4>
+					<div className="flex items-center gap-2">
+						<h4 className="text-sm font-medium">{name}</h4>
+						<span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
+							{sourceFormat}
+						</span>
+					</div>
 					<p className="text-xs text-muted-foreground">
 						Invalid workflow definition
 					</p>
 				</div>
 				<Button variant="outline" size="sm" onClick={onEdit}>
-					Edit
+					{sourceFormat === "lua" ? "Open in external editor" : "Edit"}
 				</Button>
 			</div>
 
 			<DiagnosticsPanel items={items} />
 
-			<WorkflowSourcePane source={source} diagnostics={items} />
+			{sourceFormat === "yaml" && source && (
+				<WorkflowSourcePane source={source} diagnostics={items} />
+			)}
 		</div>
 	);
 }

--- a/src/components/panels/automation/WorkflowList.tsx
+++ b/src/components/panels/automation/WorkflowList.tsx
@@ -70,6 +70,9 @@ export function WorkflowList({
 										builtin
 									</span>
 								)}
+								<span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground shrink-0">
+									{wf.sourceFormat}
+								</span>
 								<DiagnosticBadge summary={report.workflow_summaries[wf.name]} />
 							</div>
 							<span className="text-xs text-muted-foreground truncate">

--- a/src/hooks/useAutomation.test.ts
+++ b/src/hooks/useAutomation.test.ts
@@ -316,6 +316,54 @@ describe("useAutomation", () => {
 		);
 	});
 
+	it("selectWorkflow does not request Lua source", async () => {
+		const luaWorkflow = {
+			name: "lua-workflow",
+			description: "Lua",
+			builtin: false,
+			sourceFormat: "lua",
+			nodes: [],
+		};
+		mockInvoke.mockImplementation((cmd: string) => {
+			if (cmd === "list_workflows") {
+				return Promise.resolve([
+					{
+						name: "lua-workflow",
+						description: "Lua",
+						builtin: false,
+						is_running: false,
+						sourceFormat: "lua",
+					},
+				]);
+			}
+			if (cmd === "get_workflow") return Promise.resolve(luaWorkflow);
+			if (cmd === "diagnose_all_cmd") {
+				return Promise.resolve({
+					items: [],
+					workflow_summaries: {},
+					facet_summaries: {},
+					facet_usage: {},
+				});
+			}
+			return Promise.resolve(undefined);
+		});
+
+		const { result } = renderHook(() => useAutomation(true));
+		await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+
+		await act(async () => {
+			await result.current.selectWorkflow("lua-workflow");
+		});
+
+		expect(mockInvoke).toHaveBeenCalledWith("get_workflow", {
+			name: "lua-workflow",
+		});
+		expect(mockInvoke).not.toHaveBeenCalledWith("get_workflow_source", {
+			name: "lua-workflow",
+		});
+		expect(result.current.selectedWorkflowSource).toBeNull();
+	});
+
 	it("selectWorkflow keeps source when typed workflow load returns diagnostics", async () => {
 		mockInvoke.mockImplementation((cmd: string) => {
 			if (cmd === "get_workflow") {

--- a/src/hooks/useAutomation.ts
+++ b/src/hooks/useAutomation.ts
@@ -157,8 +157,15 @@ export function useAutomation(open: boolean) {
 			setSelectedWorkflowName(name);
 			setError(null);
 			try {
-				const source = await invoke<string>("get_workflow_source", { name });
-				setSelectedWorkflowSource(source);
+				const sourceFormat =
+					workflows.find((workflow) => workflow.name === name)?.sourceFormat ??
+					"yaml";
+				if (sourceFormat === "yaml") {
+					const source = await invoke<string>("get_workflow_source", { name });
+					setSelectedWorkflowSource(source);
+				} else {
+					setSelectedWorkflowSource(null);
+				}
 				try {
 					const wf = await invoke<WorkflowDefinition>("get_workflow", { name });
 					setSelectedWorkflow(wf);
@@ -173,7 +180,7 @@ export function useAutomation(open: boolean) {
 				setError(String(e));
 			}
 		},
-		[refreshDiagnostics],
+		[refreshDiagnostics, workflows],
 	);
 
 	const saveWorkflowSource = useCallback(

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -117,6 +117,7 @@ export interface WorkflowDefinition {
 	name: string;
 	description: string;
 	builtin: boolean;
+	sourceFormat: "yaml" | "lua";
 	schemas?: Record<string, SchemaDefView>;
 	nodes: NodeDefinition[];
 }
@@ -227,6 +228,7 @@ export type WorkflowDefinitionSummary = {
 	description: string;
 	builtin: boolean;
 	is_running: boolean;
+	sourceFormat: "yaml" | "lua";
 };
 
 export type FacetKind = "policy" | "knowledge" | "instruction";
@@ -242,6 +244,7 @@ type DiagnosticSeverity = "error" | "info";
 type DiagnosticStage = "parse_shape" | "resolve" | "typecheck" | "control_flow";
 
 interface DiagnosticSpan {
+	source?: string;
 	start_line: number;
 	start_col: number;
 	end_line: number;


### PR DESCRIPTION
## 概要

- `.lua` を workflow 定義の入口に追加。load 時に一度だけ評価して既存の `WorkflowDefinition` を組み立て、実行時に Lua は走らない
- `infrastructure/lua` に mlua ベースの評価器を新設。標準ライブラリを `table` / `string` / `math` に絞り、`require` は Rust 実装が workflows ディレクトリ配下へ閉じ込めて循環を検出。メモリ 64 MiB と命令 5,000 万で評価を有界化
- node 名の一意性と合成内部名 `<合成子名>#<index>` の生成を domain の `NodeNamespace` へ切り出し、YAML 経路（serde）と Lua 経路が同じ規則を呼ぶ
- `releash` モジュールを Rust 関数として公開。node・facet・Artifact field の参照は値参照で書き、ビルダー呼び出し時点で引数を検証して Lua のファイル名・行番号付きで報告
- 定義レベルの検証と facet 解決は YAML 経路と共有。診断コードは §7 の既存系列へ追番（`WFS009` / `WFS010` / `WFS011` を新設し、ビルダー引数は `WFS002`、スコープ外配線は `WFR007` などを再利用）
- 定義ファイルの列挙・解決・load を拡張子ごとの loader へ一般化し、実行時の name 解決・診断・外部エディタ起動を `.lua` へ拡張。保存と複製は Lua を対象外として拒否
- workflows ディレクトリへ LuaLS 用の型スタブと facet インデックスを冪等生成。実行時に使うモジュールは Rust が提供するため、生成物が欠けても古くても load 結果と実行結果は変わらない
- Lua 定義はアプリ内でソース表示・編集の対象にせず、一覧に定義形式を出し、診断をファイル名・行番号付きで提示して外部エディタへ委ねる

builtin workflow は YAML のまま維持し、YAML 入口の振る舞いは変更していない。

## 検証

- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- pnpm lint
- pnpm test
- pnpm build
- pnpm test:integration

Closes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Lua形式でワークフローを定義・読み込めるようになりました。
  * ワークフロー一覧と詳細画面で、YAML／Luaの形式を確認できます。
  * Lua編集用の外部エディター連携と、入力支援ファイルの自動生成に対応しました。
* **改善**
  * Luaの構文・参照・評価エラーを、ソースファイル名や行番号付きで表示します。
  * YAMLとLuaの同名定義を検出し、重複を防止します。
  * Luaワークフローの保存・複製・名前変更には対応していません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->