### PR TITLE
fix(workflow): session node 終端時に provider プロセスを停止し terminal 枠を解放する

### DIFF
--- a/docs/specs/issues-1654/behavior.md
+++ b/docs/specs/issues-1654/behavior.md
@@ -1,0 +1,110 @@
+## B-001: 成功したsession nodeのterminal枠を解放する
+
+GIVEN session node executionが`Running`で、そのnodeが起動したproviderプロセスがworktreeのterminal surface枠を占有し、プロセスの停止処理が成功する
+WHEN node executionが`Succeeded`へ遷移する
+THEN そのproviderプロセスは終了する
+AND 対応するterminal surfaceはworktreeの枠を占有しなくなる
+
+## B-002: 失敗したsession nodeのterminal枠を解放する
+
+GIVEN session node executionがactiveで、そのnodeが起動したproviderプロセスがworktreeのterminal surface枠を占有し、プロセスの停止処理が成功する
+WHEN node executionが`Failed`へ遷移する
+THEN そのproviderプロセスは終了する
+AND 対応するterminal surfaceはworktreeの枠を占有しなくなる
+
+## B-003: abortされたsession nodeのterminal枠を解放する
+
+GIVEN session node executionがactiveで、そのnodeが起動したproviderプロセスがworktreeのterminal surface枠を占有し、プロセスの停止処理が成功する
+WHEN node executionが`Aborted`へ遷移する
+THEN そのproviderプロセスは終了する
+AND 対応するterminal surfaceはworktreeの枠を占有しなくなる
+
+## B-004: 停止されたsessionの会話を引き継いで復帰する
+
+GIVEN 終端したsession nodeのproviderプロセスが停止され、停止前のterminal表示とproviderの会話が存在する
+WHEN 利用者が後からそのAgentSessionを開いて再開する
+THEN 停止前のterminal表示を確認できる
+AND providerとの会話を停止前の文脈から継続できる
+
+## B-005: Runningのsession nodeは停止しない
+
+GIVEN session node executionが`Running`で、そのnodeのproviderプロセスが動作している
+WHEN node executionが`Running`のまま処理を継続する
+THEN providerプロセスは停止されない
+AND 利用者はそのAgentSessionを引き続き操作できる
+
+## B-006: execution stop後にsession nodeを再開できる
+
+GIVEN `Running`のsession node executionと、そのnodeが起動したproviderプロセスが存在する
+WHEN 利用者がworkflow executionをstopしてnode executionが`Paused`になった後、workflow executionをresumeする
+THEN providerプロセスはnode executionが`Paused`の間も停止されない
+AND node executionは`Running`へ戻り、同じAgentSessionで処理を継続できる
+
+## B-007: 承認待ちのsession nodeへ再指示できる
+
+GIVEN session node executionが`WaitingApproval`で、そのnodeのproviderプロセスが動作している
+WHEN 利用者がそのAgentSessionへ追加の指示を送る
+THEN providerプロセスは停止されず、追加の指示を受け付ける
+AND providerとの会話を同じAgentSessionで継続できる
+
+## B-008: 終端済みnodeを重ねても新しいsession nodeを起動できる
+
+GIVEN 同一worktreeでsession nodeを含むworkflowを`per_worktree_cap`を超える回数繰り返し実行し、それらのnode executionがすべて終端している
+WHEN 新しいworkflowのsession nodeをactivateする
+THEN 終端済みnode executionのsessionは`per_worktree_cap`の使用数に含まれない
+AND `WorktreeCapReached`に起因する`TerminalUnavailable`にならず、session nodeを起動できる
+
+## B-009: 終端済みnodeを重ねても手動sessionを作成できる
+
+GIVEN 同一worktreeでsession nodeを含むworkflowを`per_worktree_cap`を超える回数繰り返し実行し、それらのnode executionがすべて終端している
+WHEN 利用者がそのworktreeに手動のAgentSessionを作成する
+THEN 終端済みnode executionのsessionは`per_worktree_cap`の使用数に含まれない
+AND `WorktreeCapReached`に起因する`TerminalUnavailable`にならず、AgentSessionを作成できる
+
+## B-010: 停止失敗でSubmitの確定結果を覆さない
+
+GIVEN Submitによって`Succeeded`へ遷移するsession node executionがあり、そのnodeのproviderプロセスの停止が失敗する
+WHEN 利用者がそのnodeの出力をSubmitする
+THEN Submitは成功として返る
+AND node executionは`Succeeded`のまま維持される
+
+## B-011: 停止失敗で承認の確定結果を覆さない
+
+GIVEN `WaitingApproval`のsession node executionがあり、そのnodeのproviderプロセスの停止が失敗する
+WHEN 利用者がそのnodeを承認する
+THEN 承認は成功として返る
+AND node executionは`Succeeded`のまま維持される
+
+## B-012: 停止失敗でabortの確定結果を覆さない
+
+GIVEN activeなsession node executionがあり、そのnodeのproviderプロセスの停止が失敗する
+WHEN 利用者がworkflow executionをabortする
+THEN abortは成功として返る
+AND node executionは`Aborted`のまま維持される
+
+## B-013: provider lifecycleの記録失敗で受理済みStopを覆さない
+
+GIVEN provider Stopによるnode executionの状態が確定し、同じStopに伴うprovider lifecycleの記録だけが失敗する
+WHEN provider Stopの受理結果を確認する
+THEN provider Stopは成功として扱われる
+AND node executionの確定した状態は維持される
+
+## B-014: provider session identity未確定の停止済みsessionはResumeできない
+
+GIVEN 終端したsession nodeのAgentSessionが`Paused`で保持されている
+AND provider session identityが確定していない
+WHEN 利用者がそのAgentSessionを開く
+THEN 停止中のAgentSessionとして表示される
+AND Resumeは提示されない
+
+## 要件IDとBehavior IDの対応表
+
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001, B-002, B-003 |
+| R-002 | B-004 |
+| R-003 | B-005, B-006, B-007 |
+| R-004 | B-008, B-009 |
+| R-005 | B-010, B-011, B-012 |
+| R-006 | B-013 |
+| R-007 | B-014 |

--- a/docs/specs/issues-1654/design.md
+++ b/docs/specs/issues-1654/design.md
@@ -1,0 +1,113 @@
+# Design
+
+対象: [requirements.md](requirements.md)（R-001〜R-007）/ [behavior.md](behavior.md)（B-001〜B-014）
+
+## The actual design
+
+### Architecture
+
+#### NodeExecution の終端差分を durable commit 後の AgentSession 停止効果にする
+
+`src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs` の `WorkflowExecution` が所有する NodeExecution status を正本とし、commit 前後の同一 NodeExecution を比較して、Session が active から `Succeeded` / `Failed` / `Aborted` へ初めて遷移した場合だけ停止対象を導出する。対象の identity は NodeExecution ID と、その NodeExecution が参照する AgentSession ID の組である。`current_session_id` や WorkflowExecution 全体の終端状態から対象を推定しないため、Sequence / Fanout、失敗処遇、承認を含む実行木の各 Session attempt を同じ規則で扱える。
+
+`src-tauri/src/usecase/workflow/runtime_driver.rs` の durable transaction 境界が、この差分を `WorkflowRuntimeEffect` の AgentSession 停止効果として保持する。効果は canonical workflow fact の永続化に成功するまで取り出せず、永続化失敗時には実行しない。`src-tauri/src/adaptor/gateway/workflow/workflow_host.rs` は durable transaction から解放された停止効果を、後続 Node の activation より先に実行する。これにより、終端した Session の枠を解放してから次の Session を起動する。
+
+abort は `src-tauri/src/adaptor/gateway/workflow/workflow_host/lifecycle_commands.rs` に独立した required-event commit 経路を持つため、同じ before/after 差分から停止効果を作り、`ExecutionAborted` の durable append 後に実行する。command runtime の shutdown は従来どおり別に行う。workflow execution の stop は NodeExecution を `Paused` に留めるため停止効果を生成せず、既存の Ctrl-C による interrupt と resume 経路を維持する。
+
+根拠は、workflow aggregate だけが NodeExecution の遷移を決め、NodeExecution は AgentSession を参照するが所有しないと定める [architecture/README.md](../../architecture/README.md)、[architecture/DOMAIN.md](../../architecture/DOMAIN.md)、[glossary/DOMAIN.md](../../glossary/DOMAIN.md) と、外部作用を durable commit 後に解放する `src-tauri/src/usecase/workflow/runtime_driver.rs` の既存 transaction 境界である。
+
+#### AgentSession が checkpoint 保持停止を所有する
+
+`src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs` の内部境界 `WorkflowAgentSessionPort` に、workflow-owned AgentSession の provider プロセスを terminal checkpoint 保持のまま停止する責務を追加する。`ProviderWorkflowAgentSessionPort` はこの操作を `src-tauri/src/usecase/agent_session/agent_session_lifecycle.rs` の `AgentSessionLifecycleUsecase` へ委譲する。
+
+AgentSession 側は既存の session operation lock の内側で対象を読み、`tree_parent` の NodeExecution ID が停止要求と一致する workflow-owned session だけを受理する。これにより、workflow に紐づかない手動 AgentSession の lifecycle は変更しない。停止には `ProviderAgentTerminalGateway::stop_preserving_checkpoint` を使い、`src-tauri/src/usecase/terminal_surface/lifecycle_usecase.rs` の既存処理によって runtime の停止、output drain、surface / runtime の registry からの除去を行う一方、terminal checkpoint は削除しない。AgentSession の `provider_session_id` と transcript reference は変更しないため、既存の open / resume 経路が provider CLI の resume 機能を使用できる。
+
+workflow 側は停止失敗を各効果の内側に閉じ、best-effort の warning を試みるだけで、Submit、承認、failure settlement、abort の結果には変換しない。warning の永続化や公開方法は追加せず、#1653 の可観測性改善を本件へ含めない。複数の停止対象がある場合も、一件の失敗で残りの停止を省略しない。NodeExecution の終端事実は既に durable であり、AgentSession 停止はその後の外部作用だからである。
+
+#### provider Stop の post-commit 失敗を受理結果から分離する
+
+provider Stop の transaction は、workflow の状態を確定する canonical workflow facts を先に append し、その後に provider lifecycle event を別 stream へ commit する。canonical facts の append が失敗した場合は Stop の受理自体を失敗として返す。一方、canonical facts が durable になった後の provider lifecycle commit 失敗は post-commit 失敗であり、確定済みの Stop を失敗へ戻さない。`src-tauri/src/adaptor/gateway/workflow/event_log_writer.rs` はこの状態を error ではなく専用 outcome として返し、`src-tauri/src/adaptor/gateway/workflow/workflow_host.rs` は warning を記録したうえで `record_provider_stop` を成功として完了する。
+
+provider lifecycle event はこの失敗時に欠落し得る。本変更では再配送を前提にせず、retry queue、起動時 reconciliation、診断情報の永続化を追加しない。
+
+#### 停止後の AgentSession lifecycle と workflow-owned session の除去権限
+
+停止は surface と runtime を registry から除去するため、`src-tauri/src/usecase/agent_session/agent_session_exit.rs` の exit 観測は停止済み session を対象として返さない。したがって停止操作自体が AgentSession の lifecycle settlement を所有する。`src-tauri/src/domain/agent_session/aggregates/agent_session.rs` の workflow 停止専用遷移が、対象 session を `Paused` へ遷移させ、意図的停止を異常終了として記録しない lifecycle event を同じ操作で生成する。usecase はその遷移を永続化した後、observed exit の非 GC 経路と同じ launch binding の解放と launch gateway の cleanup を行う。停止後の open は PTY 不在と `Paused` から停止前の terminal checkpoint を提示し、`provider_session_id` を持つ session は既存の resume 経路で provider CLI の再開機能を使う。
+
+`provider_session_id` が確定する前に終端した node execution の session も停止対象に含める。R-001 が終端状態を `Succeeded` / `Failed` / `Aborted` の三つとも対象にしており、provider hook が `provider_session_id` を関連付ける前に終端する経路があるためである。この session を既存の除去規則（PTY 不在かつ `provider_session_id` 未確定なら garbage）へ落とすと、open と `src-tauri/src/usecase/agent_session/agent_session_read.rs` の読み取り時 reconciliation が terminal checkpoint ごと AgentSession を削除し、R-007 を満たせない。そこで `src-tauri/src/domain/agent_session/aggregates/agent_session.rs` の除去判定で、`tree_parent` を持つ workflow-owned session を garbage collection の対象外とし、上記の lifecycle settlement も `provider_session_id` の有無で分岐させない。既存 aggregate が archive と delete を workflow-owned に対して拒否しているのと同じく、除去権限を workflow 側に残す。
+
+Resume の受理規則は AgentSession aggregate が所有し、`Paused` かつ `provider_session_id` が確定済みの場合だけ受理する。同じ判定から `AgentSessionOperations.can_resume` を作り、query service の read model へ透過させる。usecase と frontend は `provider_session_id` の有無から可否を再判定しない。
+
+主要な変更対象は次のとおり。
+
+| Path | 変更の要旨 |
+| --- | --- |
+| `src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs` | commit 前後から newly-terminal な Session と AgentSession 参照を導出する domain-owned 判定 |
+| `src-tauri/src/usecase/workflow/runtime_driver.rs` | AgentSession 停止効果を durable commit より前に秘匿し、成功後だけ解放する transaction material |
+| `src-tauri/src/adaptor/gateway/workflow/workflow_host.rs` | 通常の control-plane commit 後、後続 activation 前に停止効果を実行する共通境界 |
+| `src-tauri/src/adaptor/gateway/workflow/workflow_host/lifecycle_commands.rs` | abort の durable append 後に同じ停止効果を実行し、停止失敗を abort result へ返さない経路 |
+| `src-tauri/src/adaptor/gateway/workflow/event_log_writer.rs` | canonical workflow facts 確定後の provider lifecycle commit 失敗を post-commit outcome として返す境界 |
+| `src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs` | workflow 内部 port から AgentSession lifecycle の checkpoint 保持停止へ変換する境界 |
+| `src-tauri/src/domain/agent_session/aggregates/agent_session.rs` | workflow-owned session の停止遷移、Resume の受理規則、および workflow-owned session を garbage collection の対象外にする除去判定 |
+| `src-tauri/src/usecase/agent_session/agent_session_query.rs` | domain が判定した Resume 可否を含む AgentSession read model |
+| `src-tauri/src/adaptor/gateway/agent_session/agent_session_query_service.rs` | AgentSession の操作可否を read model へ透過する変換境界 |
+| `src-tauri/src/usecase/agent_session/agent_session_lifecycle.rs` | session operation lock、受理判定、checkpoint 保持停止、停止後の lifecycle settlement を順序付ける usecase |
+| `src-tauri/src/adaptor/gateway/workflow/runtime_command_gateway.rs` | 既存の AgentSession lifecycle usecase を workflow session port へ渡す composition |
+
+### Interface
+
+公開 Tauri command、local API、CLI、workflow definition、event schema の入出力は変更しない。Submit、承認、abort の成功・失敗表現も変更せず、post-commit の停止失敗を新しい公開 error にしない。
+
+内部境界 `WorkflowAgentSessionPort` は、NodeExecution ID と AgentSession ID で特定した workflow-owned session を checkpoint 保持のまま停止する責務を追加する。provider process、Terminal Surface、Provider lifecycle の具体型やエラーは workflow usecase へ漏らさず、既存の `WorkflowRuntimeError` 境界で閉じる。
+
+### Data Model
+
+永続 record は追加しない。停止効果は一回の workflow transaction に属する一時データであり、NodeExecution ID と AgentSession ID を identity とする。既に終端していた NodeExecution、Session 以外の Node kind、AgentSession 参照を持たない NodeExecution からは生成しない。
+
+AgentSession の既存 `provider_session_id`、transcript reference、`tree_parent`、Terminal Surface owner を再利用する。conversation 本文は保持せず、引き続き provider CLI / transcript を正本とする。terminal checkpoint の形式と保持先も変更しない。
+
+### Database
+
+該当なし。workflow fact、AgentSession lifecycle event、terminal checkpoint の schema は変更せず、停止効果の durable queue や起動時 reconciliation record は追加しない。
+
+### UI/UX
+
+AgentSession read model の `operations.canResume` が true の場合だけ、停止中の AgentSession に Resume を表示する。停止中の表示は provider プロセスが動作していないという事実だけを述べ、再開できない理由を frontend で断定しない。`canResume` が false になる状態は複数あり、read model はその理由を区別しないためである。frontend は lifecycle や provider identity から可否を再計算しない。
+
+### Algorithm
+
+停止対象の導出は、commit 前に active だった各 NodeExecution を ID で commit 後へ対応付け、commit 後が非 active、kind が Session、AgentSession ID が存在するものだけを選ぶ。同じ commit 内で新規に終端した対象だけを一度ずつ返す。active / terminal の分類は `RuntimeNodeExecutionStatus::is_active` を使い、状態集合を別実装へ複製しない。
+
+通常経路の順序は「aggregate 遷移 → canonical fact 永続化 → live aggregate 公開 → AgentSession 停止効果 → 後続 Node activation / state broadcast」とする。永続化前に停止しないため、commit failure で active のまま残った NodeExecution の provider processを失わない。後続 activation 前に停止するため、直前に終端した Session の枠を次の spawn が利用できる。
+
+abort 経路は activation cancellation を確定し、`ExecutionAborted` を durable append した後、active から `Aborted` になった全 Session の停止効果と command runtime shutdown を行ってから既存の terminal transition cleanup を続ける。停止効果の失敗は best-effort の warning 用に収集するが、処理を継続し、accepted abort を失敗へ戻さない。
+
+必要な検証は次の種別で行う。
+
+- workflow domain: `Running` / `Paused` / `WaitingApproval` から `Succeeded` / `Failed` / `Aborted` への Session 遷移だけが停止対象になり、active の維持、既終端、Command / composite は対象外になること。
+- workflow transaction / host: persistence failure では停止せず、durable commit 後は後続 activation より前に停止すること。Submit、承認、failure settlement、abort の各終端経路と、stop / resume / WaitingApproval の非停止経路を扱う。
+- AgentSession usecase / gateway: workflow ownershipを照合し、checkpoint を削除せず surface を枠から除外すること。停止後に既存 provider session identity で resume でき、手動 AgentSession には作用しないこと。`provider_session_id` が未確定のまま終端した session を停止しても、checkpoint と AgentSession が garbage collection されずに残り、read model が Resume 不可を返すこと。
+- frontend: read model が Resume 可の場合だけ停止中の AgentSession に Resume を表示すること。
+- workflow acceptance: 同一 worktree で終端済み Session を `per_worktree_cap` 以上累積させても、新しい workflow Session と手動 AgentSession が `WorktreeCapReached` にならないこと。停止失敗を注入しても Submit、承認、abort の確定結果が維持されること。
+
+### Infra
+
+該当なし。process 停止、Terminal output drain、checkpoint 保存には既存の Terminal Surface runtime と gateway を使い、新しい daemon、scheduler、background collector は追加しない。
+
+## Alternatives Considered
+
+- **execution 終端時または archive 時に一括停止する**: NodeExecution 終端から枠解放まで後続 Node や次の WorkflowExecution が起動でき、同一 execution 内でも cap を消費し続ける。R-001 の停止時点と Scope に一致しないため採らない。
+- **Ctrl-C の interrupt を停止として使う**: process と Terminal Surface が残り枠を解放しないことが現障害の原因であり、R-001 / R-004を満たさないため採らない。interrupt は active な `Paused` Session の resume を保つ workflow stop 専用として残す。
+- **Terminal Surface を delete / kill する**: process と枠は解放できるが checkpoint を破棄し、R-002 / B-004を満たさないため採らない。
+- **durable commit 前に provider process を停止する**: workflow fact の永続化失敗時に NodeExecution が active のまま provider process だけを失い、R-003に反するため採らない。
+- **後続 Node activation 後に停止する**: cap 境界では次の spawn が先に `WorktreeCapReached` となり、R-004を満たせないため採らない。
+- **cap 引き上げ、idle 回収、起動時 reconciliation**: 残留速度を変えるか別時点で回収する案であり、NodeExecution 終端時の所有責務を解決せず、明示された Non-goals にも含まれるため採らない。
+
+## Cross-cutting concerns
+
+該当なし。
+
+## Risks
+
+- post-commit の process 停止は workflow fact と原子的ではない。停止失敗時は R-005 に従って NodeExecution の終端を維持するため、その process が枠を占有し続ける可能性がある。本変更は durable retry や restart reconciliation を追加しない。
+- provider lifecycle commit は canonical workflow facts と原子的ではない。canonical facts 確定後の失敗は R-006 に従って Stop の受理を維持するため、provider lifecycle event が欠落し得る。本変更は retry や診断情報の永続化を追加しない。

--- a/docs/specs/issues-1654/requirements.md
+++ b/docs/specs/issues-1654/requirements.md
@@ -1,0 +1,116 @@
+# Context
+
+要求の正本は Issue #1654（https://github.com/siro33950/releash/issues/1654 、`[terminal surface] workflow node session の provider プロセスが完了後も残留し per_worktree_cap を食い潰してセッション起動不能になる`、OPEN、label: `bug`）。
+
+Issue が「関連」として挙げる #1652（`[object Object]` 表示）と #1653（spawn 失敗理由の破棄・ロガー未初期化）は別 Issue であり、本変更の要求には含めない。
+
+根拠となる既存実装:
+
+- `src-tauri/src/domain/terminal_surface/value_objects/terminal_surface_lifecycle_config.rs`
+- `src-tauri/src/domain/terminal_surface/entities/terminal_surface_registry.rs`
+- `src-tauri/src/usecase/terminal_surface/lifecycle_usecase.rs`
+- `src-tauri/src/adaptor/gateway/agent_session/provider_agent_terminal_gateway.rs`
+- `src-tauri/src/usecase/agent_session/agent_session_launch.rs`
+- `src-tauri/src/usecase/agent_session/agent_session_lifecycle.rs`
+- `src-tauri/src/usecase/agent_session/agent_session_interrupt.rs`
+- `src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs`
+- `src-tauri/src/adaptor/gateway/workflow/workflow_host/lifecycle_commands.rs`
+- `src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs`
+
+確定済みの背景と制約:
+
+- terminal surface には worktree ごとの上限がある。`TerminalSurfaceLifecycleConfig::default()` は `per_worktree_cap: 32` / `max_panes_total: 64`。
+- 上限判定は「プロセスが exited でない surface の数 + 予約数」で行う。プロセスが生きている限り枠は解放されない。
+- 既存の停止操作は意味が異なる3種類がある。`interrupt` は PTY へ Ctrl-C を書くだけでプロセスも枠も残る。`stop_preserving_checkpoint` はプロセスを終了し terminal checkpoint を残したまま枠を解放する。`delete` / `kill` はプロセス終了に加えて checkpoint も破棄する。
+- AgentSession は `provider_session_id` を持つ場合、プロセス終了後に provider CLI 自身の再開機能（Claude は `claude --resume <provider_session_id>`、Codex は `codex resume <provider_session_id>`）で復帰できる。`provider_session_id` は provider hook 経由で取得される。
+- node execution の状態は `Running` / `Paused` / `WaitingApproval` が active、`Succeeded` / `Failed` / `Aborted` が終端。
+- execution の abort は active な node execution を `Aborted` へ遷移させる。execution の stop は node を `Paused` に留め、resume 可能な状態として残す。
+
+停止の定義（provider プロセスを終了して terminal surface の枠を解放し、terminal checkpoint と `provider_session_id` は保持する）と、停止の時点（node execution の終端時点）は、本 spec 作成時に利用者が本 Session 内で明示的に指示した確定事項である。Issue の「対応」節が対応方針を未定としているのはこの指示より前の記述であり、R-001 と Scope / Non-goals はこの指示に従う。
+
+# Outcome
+
+対象は、同一 worktree で workflow を繰り返し実行する Releash 利用者。
+
+現在の問題は、workflow の session node が起動した provider プロセスが node 終了後も終了されず、worktree ごとの terminal surface 上限を残留プロセスが埋めていくことである。上限に達すると、その worktree では workflow の node activation も手動の session 作成もすべて失敗し、UI 上は当該 worktree に実行中のものが何も表示されていないのに新規実行が一切できなくなる。利用者から残留プロセスは見えず、復旧手段は Releash の外から残留プロセスを手動で kill することしかない。
+
+変更後は、session node execution が終端した時点でその node の provider プロセスが終了し、terminal surface の枠が解放される。同一 worktree で workflow を何度実行しても終端済み node の分が枠を占有せず、上限到達による起動不能が発生しない。停止された session は破棄されず、後から開けば provider の会話を引き継いで復帰できる。
+
+# Current Behavior
+
+## 上限と失敗の経路
+
+- `TerminalSurfaceLifecycleConfig::default()` が `per_worktree_cap: 32` / `max_panes_total: 64` を返す（`terminal_surface_lifecycle_config.rs:9-12`）。
+- `TerminalSurfaceRegistry::reserve_spawn_slot` は、対象 worktree の「exited でない surface 数 + 予約数」が `per_worktree_cap` 以上のとき `WorktreeCapReached` を返す（`terminal_surface_registry.rs:165-173`）。
+- `WorktreeCapReached` は `ProviderAgentTerminalGatewayError::Unavailable` に丸められ（`provider_agent_terminal_gateway.rs:31`）、`AgentSessionLaunchUsecaseError::TerminalUnavailable` として workflow へ伝わる。workflow 側では `activate Workflow AgentSession '<id>': TerminalUnavailable` の形になる（`node_session_boundary.rs:146-153`）。
+
+## provider プロセスが終了しない箇所
+
+- node 完了（Submit）経路 `WorkflowControlPlane::submit_output_once`（`usecase/workflow/control_plane.rs:205-338`）には、terminal surface / provider プロセスを停止する処理が無い。
+- workflow の stop / abort 経路は `interrupt_workflow_agent_session` を呼ぶだけで（`lifecycle_commands.rs:234-236`、`:686-689`）、その実体は PTY への Ctrl-C 書き込みである（`agent_session_interrupt.rs:40-44`）。プロセスは終了せず、枠も解放されない。`lifecycle_commands.rs:708` には「AgentSession と PTY は Workflow 終端後もユーザー操作のため保持する」と明記されている。
+- execution のアーカイブは実行木の枝を表示から隠すだけで（`domain/workspace_tree/services.rs:66-84`）、プロセスや surface には作用しない。
+- 時間経過や idle に基づく terminal surface の回収は存在しない。
+
+## 枠が解放される既存の経路
+
+- provider プロセスが実際に終了し、Releash がそれを検知したとき（`agent_session.rs:386-397` で AgentSession が `Paused` になる）。
+- 利用者が session を archive / delete したとき（`agent_session_lifecycle.rs:272-274`、`:536-538`）。ただし workflow node session は execution をアーカイブすると実行木から見えなくなるため、この操作に到達できない。
+- workflow node の launch rollback（`agent_session_launch.rs:514-517`）。
+- worktree 自体を削除したときの `kill_by_worktree`（`usecase/repository_usecase.rs:243`）。
+
+## 実障害での観測（2026-08-19、PJT-2308 worktree）
+
+再現手順は「同一 worktree で session node を含む workflow を繰り返し実行する」。当日は 02:23 / 02:43 / 08:38 / 08:46 / 10:39 / 10:53 の実行が該当した。
+
+観測された事実:
+
+- 障害時点で、Releash の直接子プロセスのうち cwd が当該 worktree のものがちょうど 32 個残留していた（claude 14、codex/node 17、zsh 1）。
+- 11:46:59 / 11:47:22 に `05_review-fix`（execution `e47d4ec8`）の `create_fix_plan` attempt 2 / 3 が次の出力で失敗した。
+
+  ```
+  workflow runtime activation failed: activate Workflow AgentSession '...': TerminalUnavailable
+  ```
+
+- 11:47:26 に `execution_aborted`。
+- 11:48:25 / 11:48:29 / 11:48:35 の手動 session 新規作成 3 回（claude 2、codex 1）が即時失敗し rollback した（`binding_armed` → `binding_expired` → `tombstoned`、`launch_observed` なし）。
+- 同時刻に別 worktree（11:48:46、11:48:55）では成功した。
+- UI 上は当該 worktree に「No sessions or workflows」と表示されていた。
+- 残留プロセス 32 個を手動 kill した結果、Releash が exit を検知して 13:23:02 に該当 session 群が `paused` へ遷移し、枠が解放されて復旧した。
+
+# Scope / Non-goals
+
+変更する対象:
+
+- workflow の session node が起動した AgentSession について、node execution が終端した時点で provider プロセスを終了し terminal surface の枠を解放する責務。
+- 停止した workflow node session を後から復帰できる状態に保つこと。
+- 停止した AgentSession の resume 可否を、provider session identity の確定状態を含めて利用者へ示すこと。
+- provider Stop の canonical workflow facts 確定後に発生する provider lifecycle commit 失敗を、受理済みの Stop を覆さない post-commit 失敗として扱うこと。
+
+変更しない対象:
+
+- `per_worktree_cap` / `max_panes_total` の値。
+- workflow に紐づかない手動作成 session のライフサイクル。
+- execution が終端した時点、および execution をアーカイブした時点での追加の停止責務。
+- 本変更より前に既に残留しているプロセスの回収、および起動時 reconciliation による回収。
+- 上限到達時の失敗理由の保持と表示（#1653）、`[object Object]` 表示（#1652）。
+- command node が起動するプロセスのライフサイクル。
+- canonical workflow facts 確定後に失敗した provider lifecycle commit の retry、および診断情報の永続化。
+
+# Requirements
+
+- R-001: session node execution が終端状態（`Succeeded` / `Failed` / `Aborted`）へ遷移した時点で、その node execution が起動した provider プロセスは終了し、対応する terminal surface は worktree の枠を占有しなくなる。
+- R-002: R-001 で停止され、`provider_session_id` が確定している AgentSession は、利用者が後から開いたときに provider の会話を引き継いで復帰できる。terminal checkpoint と `provider_session_id` は破棄されない。
+- R-003: node execution が active（`Running` / `Paused` / `WaitingApproval`）である間は、その node の provider プロセスを停止しない。execution stop 後の resume と、承認待ちからの再指示は現行どおり行える。
+- R-004: 同一 worktree で session node を含む workflow を繰り返し実行しても、終端済み node execution の session が `per_worktree_cap` を占有せず、`WorktreeCapReached` に起因する `TerminalUnavailable` で node activation および手動 session 作成が失敗しない。
+- R-005: R-001 の停止に失敗しても、node execution の終端という確定済みの事実は覆らない。停止失敗を理由に Submit / 承認 / abort が失敗として利用者へ返らない。
+- R-006: provider Stop の canonical workflow facts が確定した後に provider lifecycle の記録が失敗しても、その失敗は post-commit 失敗として扱い、Stop の受理を覆してはならない。
+- R-007: 停止された AgentSession が `Paused` でも `provider_session_id` が未確定なら、利用者に Resume を提示してはならない。AgentSession と terminal checkpoint は保持し、停止状態は確認できなければならない。
+
+# Assumptions / Open Questions
+
+Assumptions（利用者が明示的に受け入れた前提）:
+
+- 本文書における「停止」は、provider プロセスを終了して terminal surface を registry から解放し、terminal checkpoint と `provider_session_id` は保持することを指す。プロセスの凍結と復元ではなく、復帰は provider CLI の再開機能によるプロセス再起動である。
+- 停止の時点は node execution の終端時点とする。execution の終端時点およびアーカイブ時点は採用しない。
+
+Open Questions: なし。

--- a/src-tauri/src/adaptor/gateway/agent_session/agent_session_query_service.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/agent_session_query_service.rs
@@ -4,9 +4,7 @@ use super::agent_session_repository::{derive_session, locate_session};
 use crate::adaptor::gateway::local_event_store::read_only::LocalEventReadStore;
 use crate::adaptor::gateway::local_event_store::LocalEventStore;
 use crate::adaptor::gateway::workflow::fact_log::{self, FactLogReadBackend};
-use crate::domain::agent_session::aggregates::{
-    AgentSession, AgentSessionLifecycle, AgentSessionOperations,
-};
+use crate::domain::agent_session::aggregates::{AgentSession, AgentSessionLifecycle};
 use crate::domain::provider_lifecycle::ProviderKind;
 use crate::domain::workflow::{NodeFact, TreeRootFact};
 use crate::usecase::agent_session::{
@@ -122,7 +120,7 @@ pub(crate) fn workspace_session_items(
 }
 
 pub(crate) fn agent_session_item(session: &AgentSession) -> AgentSessionItemDto {
-    let operations = AgentSessionOperations::for_state(session.tree_parent(), session.lifecycle());
+    let operations = session.operations();
     AgentSessionItemDto {
         id: session.id().to_string(),
         workspace_identity: session.workspace().as_str().to_string(),
@@ -148,6 +146,7 @@ pub(crate) fn agent_session_item(session: &AgentSession) -> AgentSessionItemDto 
             can_archive: operations.can_archive,
             can_restore: operations.can_restore,
             can_delete: operations.can_delete,
+            can_resume: operations.can_resume,
         },
         activity: AgentSessionActivityDto::Idle,
         last_exit_abnormal: session.last_exit_abnormal(),

--- a/src-tauri/src/adaptor/gateway/agent_session/agent_session_repository_test.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/agent_session_repository_test.rs
@@ -7,6 +7,9 @@ use super::agent_session_repository::map_commit_batch_error;
 use super::{workspace_session_items, LocalAgentSessionQueryService, LocalAgentSessionRepository};
 use crate::adaptor::gateway::local_event_store::{LocalEventStore, LocalEventStoreConfig};
 use crate::adaptor::gateway::workflow::fact_log;
+use crate::adaptor::gateway::workflow::test_support::{
+    seed_workflow_session_facts, WorkflowSessionFactSeed,
+};
 use crate::domain::agent_session::aggregates::{
     AgentSession, AgentSessionLifecycle, AgentSessionTreeParent,
 };
@@ -1004,6 +1007,78 @@ async fn test_agent_session_query_service_idで一件の表示モデルを返す
     assert!(detail.operations.can_archive);
     assert!(!detail.operations.can_restore);
     assert!(!detail.operations.can_delete);
+    assert!(!detail.operations.can_resume);
+}
+
+#[tokio::test]
+async fn test_agent_session_query_service_resume可否をprovider参照の有無から返す() {
+    let directory = TempDir::new().unwrap();
+    let store = open_store(&directory);
+    let repository = new_repository(&store);
+
+    for (execution_id, node_execution_id, session_id, provider_session_id) in [
+        ("workflow-unknown", "node-unknown", "session-unknown", None),
+        (
+            "workflow-known",
+            "node-known",
+            "session-known",
+            Some("provider-known"),
+        ),
+    ] {
+        seed_workflow_session_facts(
+            &store,
+            WorkflowSessionFactSeed {
+                workflow_name: "workflow",
+                request: "test",
+                worktree_path: "/repo/worktree",
+                provider: ProviderKind::Codex,
+                workflow_execution_id: execution_id,
+                node_execution_id,
+                session_id,
+                initial_instruction_admitted: true,
+            },
+        )
+        .unwrap();
+        let mut saved = repository
+            .create(
+                AgentSession::create(
+                    session_id,
+                    WorkspaceIdentity::new("/repo"),
+                    "/repo/worktree",
+                    ProviderKind::Codex,
+                    Some(AgentSessionTreeParent::new(execution_id, node_execution_id).unwrap()),
+                )
+                .unwrap(),
+                &format!("create-{session_id}"),
+            )
+            .await
+            .unwrap();
+        if let Some(provider_session_id) = provider_session_id {
+            saved
+                .session_mut()
+                .associate_provider_session(provider_session_id, None)
+                .unwrap();
+            saved = repository
+                .save(saved, &format!("associate-{session_id}"))
+                .await
+                .unwrap();
+        }
+        saved
+            .session_mut()
+            .stop_workflow_owned(node_execution_id)
+            .unwrap();
+        repository
+            .save(saved, &format!("stop-{session_id}"))
+            .await
+            .unwrap();
+    }
+
+    let query_service = LocalAgentSessionQueryService::new(store);
+    let unknown = query_service.get("session-unknown").await.unwrap().unwrap();
+    let known = query_service.get("session-known").await.unwrap().unwrap();
+
+    assert!(!unknown.operations.can_resume);
+    assert!(known.operations.can_resume);
 }
 
 #[tokio::test]
@@ -1045,6 +1120,7 @@ async fn test_workspace共通read_modelは全lifecycleを返す() {
     assert!(!archived.operations.can_archive);
     assert!(archived.operations.can_restore);
     assert!(archived.operations.can_delete);
+    assert!(!archived.operations.can_resume);
 }
 
 #[tokio::test]

--- a/src-tauri/src/adaptor/gateway/workflow/event_log_writer.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/event_log_writer.rs
@@ -2,6 +2,11 @@ use tauri::Manager;
 
 use crate::adaptor::gateway::workflow::event::WorkflowEvent;
 
+pub(crate) enum ProviderStopCommitOutcome {
+    Committed,
+    CanonicalFactsCommittedWithProviderLifecycleFailure(String),
+}
+
 fn managed_store<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> Result<std::sync::Arc<crate::adaptor::gateway::local_event_store::LocalEventStore>, String> {
@@ -28,24 +33,33 @@ pub(crate) fn append_required_events_for_app<R: tauri::Runtime>(
 /// provider Stop の受理: 事実（stop_received 等）を先に追記し、provider lifecycle
 /// event を provider ストリームへ commit する。
 ///
-/// 事実が先である理由: 途中で落ちた場合、事実側が残れば node は完了し（利用者の
-/// 観測として正しい）、provider 側の再配送は同じ事実の重複 append（fold で無害）に
-/// 収束する。逆順は「provider は止まったが node が完了しない」窓を作る。
+/// canonical facts の追記後に provider lifecycle commit が失敗した場合は post-commit
+/// outcome として返す。呼び出し側は warning を記録するが、確定済みの Stop 受理は
+/// 失敗へ戻さない。retry と診断情報の永続化はこの境界では行わない。
 pub(crate) async fn append_provider_stop_for_app<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     events: &[WorkflowEvent],
     provider_events: Vec<crate::domain::provider_lifecycle::ScopedProviderLifecycleEvent>,
-) -> Result<(), String> {
+) -> Result<ProviderStopCommitOutcome, String> {
     let store = managed_store(app)?;
     crate::adaptor::gateway::workflow::fact_log::append_facts_for_events(&store, events)?;
     if provider_events.is_empty() {
-        return Ok(());
+        return Ok(ProviderStopCommitOutcome::Committed);
     }
     let repository: std::sync::Arc<
         dyn crate::domain::local_event::LocalEventTransactionRepository,
     > = store.clone();
     let installation_id = store.installation_id().to_string();
-    commit_provider_lifecycle_events(repository, installation_id, provider_events).await
+    Ok(
+        match commit_provider_lifecycle_events(repository, installation_id, provider_events).await {
+            Ok(()) => ProviderStopCommitOutcome::Committed,
+            Err(error) => {
+                ProviderStopCommitOutcome::CanonicalFactsCommittedWithProviderLifecycleFailure(
+                    error,
+                )
+            }
+        },
+    )
 }
 
 async fn commit_provider_lifecycle_events(

--- a/src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs
@@ -5,7 +5,7 @@ use crate::domain::provider_lifecycle::ProviderKind;
 use crate::domain::workspace_tree::WorkspaceIdentity;
 use crate::usecase::agent_session::{
     AgentSessionInitialInstructionUsecase, AgentSessionInterruptUsecase, AgentSessionLaunchUsecase,
-    WorkflowAgentSessionLaunchRequest,
+    AgentSessionLifecycleUsecase, WorkflowAgentSessionLaunchRequest,
 };
 use crate::usecase::workflow::runtime_error::WorkflowRuntimeError;
 
@@ -67,6 +67,12 @@ pub(crate) trait WorkflowAgentSessionPort: Send + Sync {
         node_session_id: &str,
     ) -> Result<(), WorkflowRuntimeError>;
 
+    async fn stop_workflow_agent_session_preserving_checkpoint(
+        &self,
+        node_session_id: &str,
+        node_execution_id: &str,
+    ) -> Result<(), WorkflowRuntimeError>;
+
     async fn rollback_workflow_agent_session(
         &self,
         node_session_id: &str,
@@ -78,6 +84,7 @@ pub(crate) struct ProviderWorkflowAgentSessionPort {
     launch: Arc<AgentSessionLaunchUsecase>,
     initial_instruction: Arc<AgentSessionInitialInstructionUsecase>,
     interrupt: Arc<AgentSessionInterruptUsecase>,
+    lifecycle: Arc<AgentSessionLifecycleUsecase>,
     availability: Arc<dyn ProviderAvailabilityReader>,
 }
 
@@ -86,12 +93,14 @@ impl ProviderWorkflowAgentSessionPort {
         launch: Arc<AgentSessionLaunchUsecase>,
         initial_instruction: Arc<AgentSessionInitialInstructionUsecase>,
         interrupt: Arc<AgentSessionInterruptUsecase>,
+        lifecycle: Arc<AgentSessionLifecycleUsecase>,
         availability: Arc<dyn ProviderAvailabilityReader>,
     ) -> Self {
         Self {
             launch,
             initial_instruction,
             interrupt,
+            lifecycle,
             availability,
         }
     }
@@ -198,6 +207,25 @@ impl WorkflowAgentSessionPort for ProviderWorkflowAgentSessionPort {
             .map_err(|error| {
                 WorkflowRuntimeError::AgentSession(format!(
                     "interrupt Workflow AgentSession '{node_session_id}': {error:?}"
+                ))
+            })
+    }
+
+    async fn stop_workflow_agent_session_preserving_checkpoint(
+        &self,
+        node_session_id: &str,
+        node_execution_id: &str,
+    ) -> Result<(), WorkflowRuntimeError> {
+        self.lifecycle
+            .stop_workflow_owned_preserving_checkpoint(
+                node_session_id,
+                node_execution_id,
+                &format!("workflow-node-terminal-stop-{node_execution_id}"),
+            )
+            .await
+            .map_err(|error| {
+                WorkflowRuntimeError::AgentSession(format!(
+                    "stop Workflow AgentSession '{node_session_id}' for NodeExecution '{node_execution_id}': {error:?}"
                 ))
             })
     }

--- a/src-tauri/src/adaptor/gateway/workflow/runtime_command_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/runtime_command_gateway.rs
@@ -46,6 +46,8 @@ pub(crate) struct TauriWorkflowRuntimeCommandGatewayDeps {
         Arc<crate::usecase::agent_session::AgentSessionInitialInstructionUsecase>,
     pub(crate) agent_session_interrupt:
         Arc<crate::usecase::agent_session::AgentSessionInterruptUsecase>,
+    pub(crate) agent_session_lifecycle:
+        Arc<crate::usecase::agent_session::AgentSessionLifecycleUsecase>,
     pub(crate) provider_availability:
         Arc<dyn crate::domain::agent_session::ProviderAvailabilityReader>,
     pub(crate) worktree_ledger: Arc<dyn crate::domain::workflow::IsolatedWorktreeLedgerRepository>,
@@ -176,6 +178,7 @@ impl<R: tauri::Runtime> TauriWorkflowRuntimeCommandGateway<R> {
             agent_session_launch,
             agent_session_initial_instruction,
             agent_session_interrupt,
+            agent_session_lifecycle,
             provider_availability,
             worktree_ledger,
             worktree_inventory,
@@ -191,6 +194,7 @@ impl<R: tauri::Runtime> TauriWorkflowRuntimeCommandGateway<R> {
             agent_session_launch,
             agent_session_initial_instruction,
             agent_session_interrupt,
+            agent_session_lifecycle,
             provider_availability,
             worktree_ledger,
             worktree_inventory,

--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
@@ -55,6 +55,7 @@ use crate::infrastructure::process::command_runner::{
 };
 use crate::usecase::agent_session::{
     AgentSessionInitialInstructionUsecase, AgentSessionInterruptUsecase, AgentSessionLaunchUsecase,
+    AgentSessionLifecycleUsecase,
 };
 use crate::usecase::workflow::runtime_driver::{
     self as workflow_runtime_driver, NodeOutcome, PreparedWorkflowTransaction,
@@ -330,6 +331,7 @@ impl WorkflowRuntimeHost {
         agent_session_launch: Arc<AgentSessionLaunchUsecase>,
         agent_session_initial_instruction: Arc<AgentSessionInitialInstructionUsecase>,
         agent_session_interrupt: Arc<AgentSessionInterruptUsecase>,
+        agent_session_lifecycle: Arc<AgentSessionLifecycleUsecase>,
         provider_availability: Arc<dyn crate::domain::agent_session::ProviderAvailabilityReader>,
         worktree_ledger: Arc<dyn crate::domain::workflow::IsolatedWorktreeLedgerRepository>,
         worktree_inventory: Arc<dyn crate::domain::workflow::WorktreeInventoryGateway>,
@@ -342,6 +344,7 @@ impl WorkflowRuntimeHost {
                 agent_session_launch,
                 agent_session_initial_instruction,
                 agent_session_interrupt,
+                agent_session_lifecycle,
                 provider_availability,
             )),
             worktree_ledger,
@@ -1001,12 +1004,21 @@ impl WorkflowRuntimeHost {
                 if provider_events.is_empty() {
                     workflow_event_log_writer::append_required_events_for_app(app, &events)
                 } else {
-                    workflow_event_log_writer::append_provider_stop_for_app(
+                    match workflow_event_log_writer::append_provider_stop_for_app(
                         app,
                         &events,
                         provider_events,
                     )
-                    .await
+                    .await?
+                    {
+                        workflow_event_log_writer::ProviderStopCommitOutcome::Committed => {}
+                        workflow_event_log_writer::ProviderStopCommitOutcome::CanonicalFactsCommittedWithProviderLifecycleFailure(error) => {
+                            log::warn!(
+                                "workflow provider Stop facts were committed but provider lifecycle commit failed: {error}"
+                            );
+                        }
+                    }
+                    Ok(())
                 }
             })
             .await;
@@ -1060,17 +1072,39 @@ impl WorkflowRuntimeHost {
                 return Err(WorkflowRuntimeError::SessionStore(error));
             }
         };
-        debug_assert_eq!(
-            durable.into_effects(),
-            vec![WorkflowRuntimeEffect::BroadcastState]
-        );
+        let effects = durable.into_effects();
         drop(executions);
+        self.execute_committed_runtime_effects(effects).await;
         if let Err(error) = self.sync_state_after_required_event_commit(&snapshot).await {
             log::warn!(
                 "workflow {execution_id}: derived execution projection refresh failed after control-plane commit: {error}"
             );
         }
         Ok(snapshot)
+    }
+
+    async fn execute_committed_runtime_effects(&self, effects: Vec<WorkflowRuntimeEffect>) {
+        for effect in effects {
+            let WorkflowRuntimeEffect::StopWorkflowAgentSession {
+                node_execution_id,
+                agent_session_id,
+            } = effect
+            else {
+                continue;
+            };
+            if let Err(error) = self
+                .workflow_agent_sessions
+                .stop_workflow_agent_session_preserving_checkpoint(
+                    &agent_session_id,
+                    &node_execution_id,
+                )
+                .await
+            {
+                log::warn!(
+                    "workflow NodeExecution '{node_execution_id}': failed to stop AgentSession '{agent_session_id}' after durable terminal transition: {error}"
+                );
+            }
+        }
     }
 
     async fn finish_control_plane_commit<R: tauri::Runtime>(
@@ -1977,12 +2011,7 @@ impl WorkflowRuntimeHost {
             *current = snapshot_before;
             transaction
                 .persist(current, |events| self.write_log_required_batch(app, events))
-                .map(|durable| {
-                    debug_assert_eq!(
-                        durable.into_effects(),
-                        vec![WorkflowRuntimeEffect::BroadcastState]
-                    );
-                })
+                .map(|durable| durable.into_effects())
                 .map_err(|error| match error {
                     WorkflowTransactionCommitError::StaleCandidate => {
                         "workflow transaction candidate became stale".to_string()
@@ -1990,16 +2019,21 @@ impl WorkflowRuntimeHost {
                     WorkflowTransactionCommitError::Persistence(error) => error,
                 })
         };
-        if let Err(e) = append_result {
-            let _ = workflow_runtime_commit::restore_execution_store_active_snapshot(
-                &self.execution_store,
-                execution_store_snapshot_before,
-            )
-            .await;
-            return Err(RequiredEventCommitFailure::BeforeDurableAppend(
-                WorkflowRuntimeError::SessionStore(format!("{append_error_context}: {e}")),
-            ));
-        }
+        let effects = match append_result {
+            Ok(effects) => effects,
+            Err(e) => {
+                let _ = workflow_runtime_commit::restore_execution_store_active_snapshot(
+                    &self.execution_store,
+                    execution_store_snapshot_before,
+                )
+                .await;
+                return Err(RequiredEventCommitFailure::BeforeDurableAppend(
+                    WorkflowRuntimeError::SessionStore(format!("{append_error_context}: {e}")),
+                ));
+            }
+        };
+
+        self.execute_committed_runtime_effects(effects).await;
 
         if let Err(e) = self
             .sync_state_after_required_event_commit(snapshot_for_commit)
@@ -2301,20 +2335,34 @@ impl WorkflowRuntimeHost {
 }
 
 #[cfg(test)]
-mod startup_recovery_tests {
+mod workflow_host_tests {
     use super::*;
+    use crate::adaptor::gateway::local_event_store::fault::FaultInjector;
     use crate::adaptor::gateway::local_event_store::node_events::NewNodeEventRow;
     use crate::adaptor::gateway::local_event_store::{LocalEventStore, LocalEventStoreConfig};
     use crate::adaptor::gateway::workflow::node_session_boundary::NodeSessionInfo;
-    use crate::domain::provider_lifecycle::ProviderKind;
-    use crate::domain::workflow::{
-        ChildEntry, ExecutionParentRef, NodeDefinition, NodeFact, NodeFactMeta, NodeKind,
-        SequenceSpec, SessionPermission, SessionRootFact, SessionSpec, StartedFact, TreeRootFact,
-        WorkflowRootFact,
+    use crate::adaptor::gateway::workflow::TauriWorkflowRuntimeCommandGateway;
+    use crate::domain::local_event::{
+        LoadStreamRequest, LocalEventTransactionRepository, StreamId,
     };
+    use crate::domain::provider_lifecycle::{
+        ProviderKind, ProviderLifecycleEvent, ProviderLifecycleScope, ScopedProviderLifecycleEvent,
+    };
+    use crate::domain::workflow::{
+        ChildEntry, ExecutionParentRef, FacetRefs, NodeCompletion, NodeDefinition, NodeFact,
+        NodeFactMeta, NodeKind, SequenceSpec, SessionPermission, SessionRootFact, SessionSpec,
+        StartedFact, TreeRootFact, WorkflowRootFact,
+    };
+    use crate::usecase::provider_lifecycle::ProviderWorkflowStopCommand;
+    use crate::usecase::workflow::command::{ApprovalCommand, SubmitOutputCommand};
+    use crate::usecase::workflow::control_plane::WorkflowControlPlaneUsecase;
     use crate::usecase::workflow::runtime_resolver::{
         ManagedWorktreeResolverError, WorkflowDefinitionResolverError,
     };
+
+    const EFFECT_WORKTREE_PATH: &str = "/repo/effect-test";
+    const EFFECT_NODE_NAME: &str = "agent";
+    const EFFECT_AGENT_SESSION_ID: &str = "agent-session-effect-test";
 
     struct UnusedWorkflowResolver;
 
@@ -2357,6 +2405,11 @@ mod startup_recovery_tests {
     }
 
     struct FailingWorkflowAgentSessions;
+
+    struct RecordingWorkflowAgentSessions {
+        stop_calls: Arc<std::sync::Mutex<Vec<(String, String)>>>,
+        failing_agent_session_id: String,
+    }
 
     struct MissingRepoWorktreeInventory;
 
@@ -2423,6 +2476,14 @@ mod startup_recovery_tests {
             unreachable!()
         }
 
+        async fn stop_workflow_agent_session_preserving_checkpoint(
+            &self,
+            _node_session_id: &str,
+            _node_execution_id: &str,
+        ) -> Result<(), WorkflowRuntimeError> {
+            unreachable!()
+        }
+
         async fn rollback_workflow_agent_session(
             &self,
             _node_session_id: &str,
@@ -2432,353 +2493,1132 @@ mod startup_recovery_tests {
         }
     }
 
-    fn append_started_session_tree(
-        store: &Arc<LocalEventStore>,
-        tree_id: &str,
-        worktree_path: &str,
-        timestamp_ms: i64,
-    ) {
-        let definition = WorkflowDefinition {
-            name: format!("workflow-{tree_id}"),
-            description: String::new(),
-            builtin: false,
-            schemas: Default::default(),
-            nodes: vec![
-                NodeDefinition {
-                    name: "main".to_string(),
-                    kind: NodeKind::Sequence(SequenceSpec {
-                        entry: None,
-                        output: None,
-                        children: vec![ChildEntry::reference("impl")],
-                    }),
-                    artifact: None,
-                    input: Vec::new(),
-                    completion: crate::domain::workflow::NodeCompletion::Auto,
-                    worktree: None,
+    mod runtime_effect_tests {
+        use super::*;
+
+        #[async_trait::async_trait]
+        impl WorkflowAgentSessionPort for RecordingWorkflowAgentSessions {
+            fn is_provider_available(&self, _provider: ProviderKind) -> bool {
+                true
+            }
+
+            async fn prepare_workflow_agent_session(
+                &self,
+                _worktree_path: &str,
+                _config: WorkflowSessionLaunchConfig,
+                _workflow_execution_id: &str,
+                _node_execution_id: &str,
+                _initial_instruction: &str,
+            ) -> Result<NodeSessionInfo, WorkflowRuntimeError> {
+                Ok(NodeSessionInfo {
+                    id: EFFECT_AGENT_SESSION_ID.to_string(),
+                })
+            }
+
+            async fn activate_workflow_agent_session(
+                &self,
+                _node_session_id: &str,
+                _node_execution_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn confirm_workflow_agent_session_attachment(
+                &self,
+                _node_session_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn dispatch_initial_instruction(
+                &self,
+                _node_session_id: &str,
+                _node_execution_id: &str,
+                _instruction: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn interrupt_workflow_agent_session(
+                &self,
+                _node_session_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn stop_workflow_agent_session_preserving_checkpoint(
+                &self,
+                node_session_id: &str,
+                node_execution_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                self.stop_calls
+                    .lock()
+                    .unwrap()
+                    .push((node_execution_id.to_string(), node_session_id.to_string()));
+                if node_session_id == self.failing_agent_session_id {
+                    return Err(WorkflowRuntimeError::AgentSession(
+                        "intentional stop failure".to_string(),
+                    ));
+                }
+                Ok(())
+            }
+
+            async fn rollback_workflow_agent_session(
+                &self,
+                _node_session_id: &str,
+                _node_execution_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+        }
+
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        enum RuntimeEffectCall {
+            Activate {
+                node_execution_id: String,
+                agent_session_id: String,
+            },
+            Stop {
+                node_execution_id: String,
+                agent_session_id: String,
+            },
+        }
+
+        struct OrderedWorkflowAgentSessions {
+            calls: Arc<std::sync::Mutex<Vec<RuntimeEffectCall>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl WorkflowAgentSessionPort for OrderedWorkflowAgentSessions {
+            fn is_provider_available(&self, _provider: ProviderKind) -> bool {
+                true
+            }
+
+            async fn prepare_workflow_agent_session(
+                &self,
+                _worktree_path: &str,
+                _config: WorkflowSessionLaunchConfig,
+                _workflow_execution_id: &str,
+                node_execution_id: &str,
+                _initial_instruction: &str,
+            ) -> Result<NodeSessionInfo, WorkflowRuntimeError> {
+                Ok(NodeSessionInfo {
+                    id: format!("agent-session-{node_execution_id}"),
+                })
+            }
+
+            async fn activate_workflow_agent_session(
+                &self,
+                node_session_id: &str,
+                node_execution_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push(RuntimeEffectCall::Activate {
+                        node_execution_id: node_execution_id.to_string(),
+                        agent_session_id: node_session_id.to_string(),
+                    });
+                Ok(())
+            }
+
+            async fn confirm_workflow_agent_session_attachment(
+                &self,
+                _node_session_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn dispatch_initial_instruction(
+                &self,
+                _node_session_id: &str,
+                _node_execution_id: &str,
+                _instruction: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn interrupt_workflow_agent_session(
+                &self,
+                _node_session_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn stop_workflow_agent_session_preserving_checkpoint(
+                &self,
+                node_session_id: &str,
+                node_execution_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                self.calls.lock().unwrap().push(RuntimeEffectCall::Stop {
+                    node_execution_id: node_execution_id.to_string(),
+                    agent_session_id: node_session_id.to_string(),
+                });
+                Ok(())
+            }
+
+            async fn rollback_workflow_agent_session(
+                &self,
+                _node_session_id: &str,
+                _node_execution_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+        }
+
+        struct RuntimeEffectFixture {
+            app: tauri::App<tauri::test::MockRuntime>,
+            store: Arc<LocalEventStore>,
+            fault: Arc<FaultInjector>,
+            host: Arc<WorkflowRuntimeHost>,
+            control_plane: WorkflowControlPlaneUsecase,
+            stop_calls: Arc<std::sync::Mutex<Vec<(String, String)>>>,
+            execution_id: String,
+            node_execution_id: String,
+            _directory: tempfile::TempDir,
+        }
+
+        struct SequentialRuntimeEffectFixture {
+            _app: tauri::App<tauri::test::MockRuntime>,
+            host: Arc<WorkflowRuntimeHost>,
+            control_plane: WorkflowControlPlaneUsecase,
+            calls: Arc<std::sync::Mutex<Vec<RuntimeEffectCall>>>,
+            execution_id: String,
+            first_node_execution_id: String,
+            first_agent_session_id: String,
+            _directory: tempfile::TempDir,
+        }
+
+        async fn runtime_effect_fixture(
+            completion: NodeCompletion,
+            stop_fails: bool,
+        ) -> RuntimeEffectFixture {
+            let directory = tempfile::tempdir().unwrap();
+            let fault = Arc::new(FaultInjector::new());
+            let mut config = LocalEventStoreConfig::production(directory.path().to_path_buf());
+            config.fault = fault.clone();
+            let store = LocalEventStore::open(config).unwrap();
+            let app = tauri::test::mock_builder()
+                .build(tauri::test::mock_context(tauri::test::noop_assets()))
+                .unwrap();
+            app.manage(store.clone());
+            app.manage(crate::infrastructure::platform::app_data_dir::TestDataDir(
+                directory.path().to_path_buf(),
+            ));
+            let stop_calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let host = Arc::new(WorkflowRuntimeHost::with_execution_store(
+            Arc::new(UnusedWorkflowResolver),
+            Arc::new(AcceptingWorktreeResolver),
+            Arc::new(ExecutionStore::new_in_memory_for_tests()),
+            Arc::new(RecordingWorkflowAgentSessions {
+                stop_calls: stop_calls.clone(),
+                failing_agent_session_id: if stop_fails {
+                    EFFECT_AGENT_SESSION_ID.to_string()
+                } else {
+                    String::new()
                 },
-                NodeDefinition {
-                    name: "impl".to_string(),
+            }),
+            Arc::new(
+                crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
+                    store.clone(),
+                ),
+            ),
+            Arc::new(MissingRepoWorktreeInventory),
+        ));
+            let workflow = WorkflowDefinition {
+                name: "runtime-effect-test".to_string(),
+                description: String::new(),
+                builtin: false,
+                schemas: Default::default(),
+                nodes: vec![NodeDefinition {
+                    name: EFFECT_NODE_NAME.to_string(),
                     kind: NodeKind::Session(SessionSpec {
                         provider: ProviderKind::Codex,
                         model: None,
                         permission: None,
-                        facets: Default::default(),
+                        facets: FacetRefs {
+                            instruction: Some("policy-confirmation".to_string()),
+                            ..FacetRefs::default()
+                        },
                     }),
                     artifact: None,
                     input: Vec::new(),
-                    completion: crate::domain::workflow::NodeCompletion::Auto,
+                    completion,
                     worktree: None,
+                }],
+                entry: EFFECT_NODE_NAME.to_string(),
+            };
+            let execution_id = host
+                .start_resolved_workflow(
+                    app.handle(),
+                    workflow,
+                    EFFECT_WORKTREE_PATH.to_string(),
+                    None,
+                    ExecutionOrigin::DesktopUi,
+                )
+                .await
+                .unwrap();
+            let snapshot = host.get_state_by_execution_id(&execution_id).await.unwrap();
+            let node_execution_id = snapshot
+                .node_executions
+                .iter()
+                .find(|node| node.node_name == EFFECT_NODE_NAME)
+                .unwrap()
+                .id
+                .clone();
+            let node = snapshot
+                .node_executions
+                .iter()
+                .find(|node| node.id == node_execution_id)
+                .unwrap();
+            assert_eq!(
+                node.status,
+                NodeExecutionStatus::Running,
+                "unexpected activation failure: {:?}",
+                node.failure
+            );
+            assert_eq!(node.session_id.as_deref(), Some(EFFECT_AGENT_SESSION_ID));
+            let repository: Arc<dyn LocalEventTransactionRepository> = store.clone();
+            let gateway = Arc::new(TauriWorkflowRuntimeCommandGateway::new_with_driver(
+                app.handle().clone(),
+                host.clone(),
+                repository,
+                store.installation_id().to_string(),
+            ));
+            let control_plane = WorkflowControlPlaneUsecase::new(gateway);
+            RuntimeEffectFixture {
+                app,
+                store,
+                fault,
+                host,
+                control_plane,
+                stop_calls,
+                execution_id,
+                node_execution_id,
+                _directory: directory,
+            }
+        }
+
+        async fn sequential_runtime_effect_fixture() -> SequentialRuntimeEffectFixture {
+            let directory = tempfile::tempdir().unwrap();
+            let store = LocalEventStore::open(LocalEventStoreConfig::production(
+                directory.path().to_path_buf(),
+            ))
+            .unwrap();
+            let app = tauri::test::mock_builder()
+                .build(tauri::test::mock_context(tauri::test::noop_assets()))
+                .unwrap();
+            app.manage(store.clone());
+            app.manage(crate::infrastructure::platform::app_data_dir::TestDataDir(
+                directory.path().to_path_buf(),
+            ));
+            let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let host = Arc::new(WorkflowRuntimeHost::with_execution_store(
+                Arc::new(UnusedWorkflowResolver),
+                Arc::new(AcceptingWorktreeResolver),
+                Arc::new(ExecutionStore::new_in_memory_for_tests()),
+                Arc::new(OrderedWorkflowAgentSessions {
+                    calls: calls.clone(),
+                }),
+                Arc::new(
+                    crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
+                        store.clone(),
+                    ),
+                ),
+                Arc::new(MissingRepoWorktreeInventory),
+            ));
+            let session_node = |name: &str| NodeDefinition {
+                name: name.to_string(),
+                kind: NodeKind::Session(SessionSpec {
+                    provider: ProviderKind::Codex,
+                    model: None,
+                    permission: None,
+                    facets: FacetRefs {
+                        instruction: Some("policy-confirmation".to_string()),
+                        ..FacetRefs::default()
+                    },
+                }),
+                artifact: None,
+                input: Vec::new(),
+                completion: NodeCompletion::Auto,
+                worktree: None,
+            };
+            let workflow = WorkflowDefinition {
+                name: "runtime-effect-order-test".to_string(),
+                description: String::new(),
+                builtin: false,
+                schemas: Default::default(),
+                nodes: vec![
+                    NodeDefinition {
+                        name: "main".to_string(),
+                        kind: NodeKind::Sequence(SequenceSpec {
+                            entry: None,
+                            output: None,
+                            children: vec![
+                                ChildEntry::reference("agent-one"),
+                                ChildEntry::reference("agent-two"),
+                            ],
+                        }),
+                        artifact: None,
+                        input: Vec::new(),
+                        completion: NodeCompletion::Auto,
+                        worktree: None,
+                    },
+                    session_node("agent-one"),
+                    session_node("agent-two"),
+                ],
+                entry: "main".to_string(),
+            };
+            let execution_id = host
+                .start_resolved_workflow(
+                    app.handle(),
+                    workflow,
+                    EFFECT_WORKTREE_PATH.to_string(),
+                    None,
+                    ExecutionOrigin::DesktopUi,
+                )
+                .await
+                .unwrap();
+            let snapshot = host.get_state_by_execution_id(&execution_id).await.unwrap();
+            let first = snapshot
+                .node_executions
+                .iter()
+                .find(|node| node.node_name == "agent-one")
+                .unwrap();
+            assert_eq!(first.status, NodeExecutionStatus::Running);
+            let first_node_execution_id = first.id.clone();
+            let first_agent_session_id = first.session_id.clone().unwrap();
+            let repository: Arc<dyn LocalEventTransactionRepository> = store.clone();
+            let gateway = Arc::new(TauriWorkflowRuntimeCommandGateway::new_with_driver(
+                app.handle().clone(),
+                host.clone(),
+                repository,
+                store.installation_id().to_string(),
+            ));
+            let control_plane = WorkflowControlPlaneUsecase::new(gateway);
+            SequentialRuntimeEffectFixture {
+                _app: app,
+                host,
+                control_plane,
+                calls,
+                execution_id,
+                first_node_execution_id,
+                first_agent_session_id,
+                _directory: directory,
+            }
+        }
+
+        fn provider_stop_command(fixture: &RuntimeEffectFixture) -> ProviderWorkflowStopCommand {
+            ProviderWorkflowStopCommand {
+                agent_session_id: EFFECT_AGENT_SESSION_ID.to_string(),
+                workflow_execution_id: fixture.execution_id.clone(),
+                node_execution_id: fixture.node_execution_id.clone(),
+                binding_id: "binding-effect-test".to_string(),
+            }
+        }
+
+        fn persisted_node_status(fixture: &RuntimeEffectFixture) -> NodeExecutionStatus {
+            let backend = workflow_fact_log::FactLogReadBackend::Live(fixture.store.clone());
+            workflow_fact_log::fold_tree_from(&backend, &fixture.execution_id)
+                .unwrap()
+                .unwrap()
+                .aggregate
+                .node_executions
+                .iter()
+                .find(|node| node.id == fixture.node_execution_id)
+                .unwrap()
+                .status
+        }
+
+        fn assert_single_terminal_stop(fixture: &RuntimeEffectFixture) {
+            assert_eq!(
+                fixture.stop_calls.lock().unwrap().as_slice(),
+                &[(
+                    fixture.node_execution_id.clone(),
+                    EFFECT_AGENT_SESSION_ID.to_string(),
+                )]
+            );
+        }
+
+        #[tokio::test]
+        async fn test_provider_stop_provider_lifecycle_commit失敗後も停止effectを実行する() {
+            // Given
+            let fixture = runtime_effect_fixture(NodeCompletion::Auto, false).await;
+            fixture
+                .control_plane
+                .submit_output(SubmitOutputCommand {
+                    node_execution_id: fixture.node_execution_id.clone(),
+                    artifact: None,
+                })
+                .await
+                .unwrap();
+            fixture.fault.arm_fail_before_commit();
+            let scope = ProviderLifecycleScope::new(EFFECT_AGENT_SESSION_ID).unwrap();
+            let lifecycle_events = vec![ScopedProviderLifecycleEvent::new(
+                scope,
+                ProviderLifecycleEvent::stop_observed("binding-effect-test").unwrap(),
+            )];
+
+            // When
+            let result = fixture
+                .control_plane
+                .record_provider_stop(provider_stop_command(&fixture), lifecycle_events)
+                .await;
+
+            // Then
+            assert!(result.is_ok(), "unexpected provider Stop error: {result:?}");
+            assert_eq!(
+                persisted_node_status(&fixture),
+                NodeExecutionStatus::Succeeded
+            );
+            assert_single_terminal_stop(&fixture);
+            let page = fixture
+                .store
+                .load_stream(LoadStreamRequest {
+                    stream_id: StreamId::provider_lifecycle(EFFECT_AGENT_SESSION_ID).unwrap(),
+                    after: None,
+                    limit: 10,
+                })
+                .await
+                .unwrap();
+            assert!(page.events.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_submit_agent_session停止失敗でも成功とsucceededを維持する() {
+            // Given
+            let fixture = runtime_effect_fixture(NodeCompletion::Auto, true).await;
+            fixture
+                .control_plane
+                .record_provider_stop(provider_stop_command(&fixture), Vec::new())
+                .await
+                .unwrap();
+
+            // When
+            let result = fixture
+                .control_plane
+                .submit_output(SubmitOutputCommand {
+                    node_execution_id: fixture.node_execution_id.clone(),
+                    artifact: None,
+                })
+                .await;
+
+            // Then
+            assert!(result.is_ok(), "unexpected Submit error: {result:?}");
+            assert_eq!(
+                persisted_node_status(&fixture),
+                NodeExecutionStatus::Succeeded
+            );
+            assert_single_terminal_stop(&fixture);
+        }
+
+        #[tokio::test]
+        async fn test_session終端_停止後に後続sessionをactivateする() {
+            // Given
+            let fixture = sequential_runtime_effect_fixture().await;
+            fixture.calls.lock().unwrap().clear();
+            fixture
+                .control_plane
+                .record_provider_stop(
+                    ProviderWorkflowStopCommand {
+                        agent_session_id: fixture.first_agent_session_id.clone(),
+                        workflow_execution_id: fixture.execution_id.clone(),
+                        node_execution_id: fixture.first_node_execution_id.clone(),
+                        binding_id: "binding-order-test".to_string(),
+                    },
+                    Vec::new(),
+                )
+                .await
+                .unwrap();
+            assert!(fixture.calls.lock().unwrap().is_empty());
+
+            // When
+            fixture
+                .control_plane
+                .submit_output(SubmitOutputCommand {
+                    node_execution_id: fixture.first_node_execution_id.clone(),
+                    artifact: None,
+                })
+                .await
+                .unwrap();
+
+            // Then
+            let snapshot = fixture
+                .host
+                .get_state_by_execution_id(&fixture.execution_id)
+                .await
+                .unwrap();
+            let second = snapshot
+                .node_executions
+                .iter()
+                .find(|node| node.node_name == "agent-two")
+                .unwrap();
+            assert_eq!(second.status, NodeExecutionStatus::Running);
+            assert_eq!(
+                fixture.calls.lock().unwrap().as_slice(),
+                &[
+                    RuntimeEffectCall::Stop {
+                        node_execution_id: fixture.first_node_execution_id.clone(),
+                        agent_session_id: fixture.first_agent_session_id.clone(),
+                    },
+                    RuntimeEffectCall::Activate {
+                        node_execution_id: second.id.clone(),
+                        agent_session_id: second.session_id.clone().unwrap(),
+                    },
+                ]
+            );
+        }
+
+        #[tokio::test]
+        async fn test_終端済みsessionへの再stop_確定状態と停止回数を変えない() {
+            // Given
+            let fixture = runtime_effect_fixture(NodeCompletion::Auto, false).await;
+            fixture
+                .control_plane
+                .record_provider_stop(provider_stop_command(&fixture), Vec::new())
+                .await
+                .unwrap();
+            fixture
+                .control_plane
+                .submit_output(SubmitOutputCommand {
+                    node_execution_id: fixture.node_execution_id.clone(),
+                    artifact: None,
+                })
+                .await
+                .unwrap();
+            assert_eq!(
+                persisted_node_status(&fixture),
+                NodeExecutionStatus::Succeeded
+            );
+            assert_single_terminal_stop(&fixture);
+
+            // When
+            let result = fixture
+                .control_plane
+                .record_provider_stop(provider_stop_command(&fixture), Vec::new())
+                .await;
+
+            // Then
+            assert!(result.is_ok(), "unexpected repeated Stop error: {result:?}");
+            assert_eq!(
+                persisted_node_status(&fixture),
+                NodeExecutionStatus::Succeeded
+            );
+            assert_single_terminal_stop(&fixture);
+        }
+
+        #[tokio::test]
+        async fn test_承認_agent_session停止失敗でも成功とsucceededを維持する() {
+            // Given
+            let fixture = runtime_effect_fixture(NodeCompletion::Approval, true).await;
+            fixture
+                .control_plane
+                .submit_output(SubmitOutputCommand {
+                    node_execution_id: fixture.node_execution_id.clone(),
+                    artifact: None,
+                })
+                .await
+                .unwrap();
+            fixture
+                .control_plane
+                .record_provider_stop(provider_stop_command(&fixture), Vec::new())
+                .await
+                .unwrap();
+            let waiting = fixture
+                .host
+                .get_state_by_execution_id(&fixture.execution_id)
+                .await
+                .unwrap();
+            assert_eq!(
+                waiting
+                    .node_executions
+                    .iter()
+                    .find(|node| node.id == fixture.node_execution_id)
+                    .unwrap()
+                    .status,
+                NodeExecutionStatus::WaitingApproval
+            );
+
+            // When
+            let result = fixture
+                .control_plane
+                .resolve_approval(ApprovalCommand {
+                    execution_id: fixture.execution_id.clone(),
+                    node_name: EFFECT_NODE_NAME.to_string(),
+                    node_execution_id: Some(fixture.node_execution_id.clone()),
+                    comment: None,
+                })
+                .await;
+
+            // Then
+            assert!(result.is_ok(), "unexpected approval error: {result:?}");
+            assert_eq!(
+                persisted_node_status(&fixture),
+                NodeExecutionStatus::Succeeded
+            );
+            assert_single_terminal_stop(&fixture);
+        }
+
+        #[tokio::test]
+        async fn test_failure_settlement_agent_session停止失敗でも成功とfailedを維持する() {
+            // Given
+            let fixture = runtime_effect_fixture(NodeCompletion::Auto, true).await;
+            let runtime_error = WorkflowRuntimeError::AgentSession("runtime failed".to_string());
+
+            // When
+            let result = fixture
+                .host
+                .settle_runtime_failure_for_node(
+                    fixture.app.handle(),
+                    EFFECT_WORKTREE_PATH,
+                    &fixture.execution_id,
+                    &fixture.node_execution_id,
+                    &runtime_error,
+                )
+                .await;
+
+            // Then
+            assert!(
+                result.is_ok(),
+                "unexpected failure settlement error: {result:?}"
+            );
+            let settled = fixture
+                .host
+                .get_state_by_execution_id(&fixture.execution_id)
+                .await
+                .unwrap();
+            assert_eq!(
+                settled
+                    .node_executions
+                    .iter()
+                    .find(|node| node.id == fixture.node_execution_id)
+                    .unwrap()
+                    .status,
+                NodeExecutionStatus::Failed
+            );
+            assert_single_terminal_stop(&fixture);
+        }
+
+        #[tokio::test]
+        async fn test_abort_agent_session停止失敗でも成功とabortedを維持する() {
+            // Given
+            let fixture = runtime_effect_fixture(NodeCompletion::Auto, true).await;
+
+            // When
+            let result = fixture
+                .host
+                .abort_workflow_execution(fixture.app.handle(), &fixture.execution_id, None)
+                .await;
+
+            // Then
+            assert!(result.is_ok(), "unexpected abort error: {result:?}");
+            assert_eq!(
+                persisted_node_status(&fixture),
+                NodeExecutionStatus::Aborted
+            );
+            assert_single_terminal_stop(&fixture);
+        }
+
+        #[tokio::test]
+        async fn test_committed_runtime_effects_停止失敗後も残りのagent_sessionを停止する() {
+            let directory = tempfile::tempdir().unwrap();
+            let store = LocalEventStore::open(LocalEventStoreConfig::production(
+                directory.path().to_path_buf(),
+            ))
+            .unwrap();
+            let stop_calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let host = WorkflowRuntimeHost::with_execution_store(
+            Arc::new(UnusedWorkflowResolver),
+            Arc::new(UnusedWorktreeResolver),
+            Arc::new(ExecutionStore::new_in_memory_for_tests()),
+            Arc::new(RecordingWorkflowAgentSessions {
+                stop_calls: stop_calls.clone(),
+                failing_agent_session_id: "agent-session-1".to_string(),
+            }),
+            Arc::new(
+                crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
+                    store,
+                ),
+            ),
+            Arc::new(MissingRepoWorktreeInventory),
+        );
+
+            host.execute_committed_runtime_effects(vec![
+                WorkflowRuntimeEffect::BroadcastState,
+                WorkflowRuntimeEffect::StopWorkflowAgentSession {
+                    node_execution_id: "node-1".to_string(),
+                    agent_session_id: "agent-session-1".to_string(),
                 },
-            ],
-            entry: "main".to_string(),
-        };
-        let root_meta = NodeFactMeta {
-            tree_id: tree_id.to_string(),
-            node_execution_id: tree_id.to_string(),
-            parent_id: None,
-            node_name: "main".to_string(),
-            kind: NodeKindName::Sequence,
-            attempt: 1,
-        };
-        workflow_fact_log::append_single_fact(
-            store,
-            &root_meta,
-            &NodeFact::Started(StartedFact {
-                parent: None,
-                root: Some(TreeRootFact::Workflow(WorkflowRootFact {
-                    workflow_name: definition.name.clone(),
-                    worktree_path: worktree_path.to_string(),
-                    created_from: ExecutionOrigin::DesktopUi,
-                    request: String::new(),
-                    definition,
-                })),
-            }),
-            timestamp_ms,
-        )
-        .unwrap();
-        let child_meta = NodeFactMeta {
-            tree_id: tree_id.to_string(),
-            node_execution_id: format!("{tree_id}-session"),
-            parent_id: Some(tree_id.to_string()),
-            node_name: "impl".to_string(),
-            kind: NodeKindName::Session,
-            attempt: 1,
-        };
-        workflow_fact_log::append_single_fact(
-            store,
-            &child_meta,
-            &NodeFact::Started(StartedFact {
-                parent: Some(ExecutionParentRef::sequence_child(tree_id)),
-                root: None,
-            }),
-            timestamp_ms + 1,
-        )
-        .unwrap();
+                WorkflowRuntimeEffect::StopWorkflowAgentSession {
+                    node_execution_id: "node-2".to_string(),
+                    agent_session_id: "agent-session-2".to_string(),
+                },
+            ])
+            .await;
+
+            assert_eq!(
+                stop_calls.lock().unwrap().as_slice(),
+                &[
+                    ("node-1".to_string(), "agent-session-1".to_string()),
+                    ("node-2".to_string(), "agent-session-2".to_string()),
+                ]
+            );
+        }
     }
 
-    #[tokio::test]
-    async fn test_startup_reconciliation_壊れたtreeの後続treeも処理する() {
-        const CORRUPT_TREE_ID: &str = "00000000-0000-4000-8000-000000000001";
-        const VALID_TREE_ID: &str = "00000000-0000-4000-8000-000000000002";
+    mod startup_recovery_tests {
+        use super::*;
 
-        let directory = tempfile::tempdir().unwrap();
-        let store = LocalEventStore::open(LocalEventStoreConfig::production(
-            directory.path().to_path_buf(),
-        ))
-        .unwrap();
-        append_started_session_tree(&store, CORRUPT_TREE_ID, "/repo/corrupt", 1);
-        let corrupt_child_meta = NodeFactMeta {
-            tree_id: CORRUPT_TREE_ID.to_string(),
-            node_execution_id: format!("{CORRUPT_TREE_ID}-session"),
-            parent_id: Some(CORRUPT_TREE_ID.to_string()),
-            node_name: "impl".to_string(),
-            kind: NodeKindName::Session,
-            attempt: 1,
-        };
-        workflow_fact_log::append_single_fact(
-            &store,
-            &corrupt_child_meta,
-            &NodeFact::IsolatedWorktreeCreated(
-                crate::domain::workflow::value_objects::IsolatedWorktreeCreatedFact {
+        fn append_started_session_tree(
+            store: &Arc<LocalEventStore>,
+            tree_id: &str,
+            worktree_path: &str,
+            timestamp_ms: i64,
+        ) {
+            let definition = WorkflowDefinition {
+                name: format!("workflow-{tree_id}"),
+                description: String::new(),
+                builtin: false,
+                schemas: Default::default(),
+                nodes: vec![
+                    NodeDefinition {
+                        name: "main".to_string(),
+                        kind: NodeKind::Sequence(SequenceSpec {
+                            entry: None,
+                            output: None,
+                            children: vec![ChildEntry::reference("impl")],
+                        }),
+                        artifact: None,
+                        input: Vec::new(),
+                        completion: crate::domain::workflow::NodeCompletion::Auto,
+                        worktree: None,
+                    },
+                    NodeDefinition {
+                        name: "impl".to_string(),
+                        kind: NodeKind::Session(SessionSpec {
+                            provider: ProviderKind::Codex,
+                            model: None,
+                            permission: None,
+                            facets: Default::default(),
+                        }),
+                        artifact: None,
+                        input: Vec::new(),
+                        completion: crate::domain::workflow::NodeCompletion::Auto,
+                        worktree: None,
+                    },
+                ],
+                entry: "main".to_string(),
+            };
+            let root_meta = NodeFactMeta {
+                tree_id: tree_id.to_string(),
+                node_execution_id: tree_id.to_string(),
+                parent_id: None,
+                node_name: "main".to_string(),
+                kind: NodeKindName::Sequence,
+                attempt: 1,
+            };
+            workflow_fact_log::append_single_fact(
+                store,
+                &root_meta,
+                &NodeFact::Started(StartedFact {
+                    parent: None,
+                    root: Some(TreeRootFact::Workflow(WorkflowRootFact {
+                        workflow_name: definition.name.clone(),
+                        worktree_path: worktree_path.to_string(),
+                        created_from: ExecutionOrigin::DesktopUi,
+                        request: String::new(),
+                        definition,
+                    })),
+                }),
+                timestamp_ms,
+            )
+            .unwrap();
+            let child_meta = NodeFactMeta {
+                tree_id: tree_id.to_string(),
+                node_execution_id: format!("{tree_id}-session"),
+                parent_id: Some(tree_id.to_string()),
+                node_name: "impl".to_string(),
+                kind: NodeKindName::Session,
+                attempt: 1,
+            };
+            workflow_fact_log::append_single_fact(
+                store,
+                &child_meta,
+                &NodeFact::Started(StartedFact {
+                    parent: Some(ExecutionParentRef::sequence_child(tree_id)),
+                    root: None,
+                }),
+                timestamp_ms + 1,
+            )
+            .unwrap();
+        }
+
+        #[tokio::test]
+        async fn test_startup_reconciliation_壊れたtreeの後続treeも処理する() {
+            const CORRUPT_TREE_ID: &str = "00000000-0000-4000-8000-000000000001";
+            const VALID_TREE_ID: &str = "00000000-0000-4000-8000-000000000002";
+
+            let directory = tempfile::tempdir().unwrap();
+            let store = LocalEventStore::open(LocalEventStoreConfig::production(
+                directory.path().to_path_buf(),
+            ))
+            .unwrap();
+            append_started_session_tree(&store, CORRUPT_TREE_ID, "/repo/corrupt", 1);
+            let corrupt_child_meta = NodeFactMeta {
+                tree_id: CORRUPT_TREE_ID.to_string(),
+                node_execution_id: format!("{CORRUPT_TREE_ID}-session"),
+                parent_id: Some(CORRUPT_TREE_ID.to_string()),
+                node_name: "impl".to_string(),
+                kind: NodeKindName::Session,
+                attempt: 1,
+            };
+            workflow_fact_log::append_single_fact(
+                &store,
+                &corrupt_child_meta,
+                &NodeFact::IsolatedWorktreeCreated(
+                    crate::domain::workflow::value_objects::IsolatedWorktreeCreatedFact {
+                        repository_root: "/repo".to_string(),
+                        worktree_path: format!(
+                            "/repo-worktrees/.releash-isolated/{CORRUPT_TREE_ID}-session-a1"
+                        ),
+                        branch: format!("releash/isolated/{CORRUPT_TREE_ID}-session-a1"),
+                    },
+                ),
+                3,
+            )
+            .unwrap();
+            store
+                .append_node_event(
+                    NewNodeEventRow {
+                        tree_id: CORRUPT_TREE_ID.to_string(),
+                        node_execution_id: CORRUPT_TREE_ID.to_string(),
+                        parent_id: None,
+                        node_name: "main".to_string(),
+                        kind: "session".to_string(),
+                        attempt: 1,
+                        event_type: "submit_received".to_string(),
+                        session_id: None,
+                        detail: "{".to_string(),
+                    },
+                    Some(4),
+                )
+                .await
+                .unwrap();
+            append_started_session_tree(&store, VALID_TREE_ID, "/repo/valid", 5);
+            let corrupt_count =
+                workflow_fact_log::read_tree_records(&store, CORRUPT_TREE_ID).unwrap_err();
+            assert!(corrupt_count.contains("decode"));
+            let valid_count = workflow_fact_log::read_tree_records(&store, VALID_TREE_ID)
+                .unwrap()
+                .len();
+
+            let app = tauri::test::mock_builder()
+                .build(tauri::test::mock_context(tauri::test::noop_assets()))
+                .unwrap();
+            let worktree_ledger = Arc::new(
+                crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
+                    store.clone(),
+                ),
+            );
+            app.manage(store.clone());
+            let host = WorkflowRuntimeHost::with_execution_store(
+                Arc::new(UnusedWorkflowResolver),
+                Arc::new(UnusedWorktreeResolver),
+                Arc::new(ExecutionStore::new_in_memory_for_tests()),
+                Arc::new(FailingWorkflowAgentSessions),
+                worktree_ledger,
+                Arc::new(MissingRepoWorktreeInventory),
+            );
+
+            let error = host.reconcile_startup(app.handle()).await.unwrap_err();
+
+            assert!(matches!(error, WorkflowRuntimeError::SessionStore(_)));
+            assert!(host
+                .execution_store
+                .list_active()
+                .await
+                .unwrap()
+                .iter()
+                .any(|execution| execution.execution_id == VALID_TREE_ID));
+            assert_eq!(
+                workflow_fact_log::read_tree_records(&store, VALID_TREE_ID)
+                    .unwrap()
+                    .len(),
+                valid_count
+            );
+            assert!(!workflow_fact_log::read_tree_records(&store, VALID_TREE_ID)
+                .unwrap()
+                .iter()
+                .any(|record| matches!(record.fact, NodeFact::IsolatedWorktreeLost)));
+            let corrupt_lost_count = store
+                .submit_indexed_query_blocking(move |connection| {
+                    crate::adaptor::gateway::local_event_store::node_events::read_tree(
+                        connection,
+                        CORRUPT_TREE_ID,
+                    )
+                    .map(|rows| {
+                        rows.into_iter()
+                            .filter(|row| row.event_type == "isolated_worktree_lost")
+                            .count()
+                    })
+                    .map_err(|_| crate::domain::local_event::LocalEventQueryError::InvalidRequest)
+                })
+                .unwrap();
+            assert_eq!(corrupt_lost_count, 0);
+        }
+
+        #[tokio::test]
+        async fn test_startup_reconciliation_provider固有permissionのstarted_factをsession_store_errorにする(
+        ) {
+            const TREE_ID: &str = "00000000-0000-4000-8000-000000000004";
+            let directory = tempfile::tempdir().unwrap();
+            let store = LocalEventStore::open(LocalEventStoreConfig::production(
+                directory.path().to_path_buf(),
+            ))
+            .unwrap();
+            let fact = NodeFact::Started(StartedFact {
+                parent: None,
+                root: Some(TreeRootFact::Session(SessionRootFact {
+                    workspace_identity: "/repo".to_string(),
+                    worktree_path: "/repo".to_string(),
+                    session: SessionSpec {
+                        provider: ProviderKind::Claude,
+                        model: None,
+                        permission: Some(SessionPermission::Auto),
+                        facets: Default::default(),
+                    },
+                    created_from: ExecutionOrigin::DesktopUi,
+                })),
+            });
+            let legacy_detail = fact.encode_detail().unwrap().replace(
+                r#""permission":"auto""#,
+                r#""permission":"bypassPermissions""#,
+            );
+            store
+                .append_node_event(
+                    NewNodeEventRow {
+                        tree_id: TREE_ID.to_string(),
+                        node_execution_id: TREE_ID.to_string(),
+                        parent_id: None,
+                        node_name: "main".to_string(),
+                        kind: "session".to_string(),
+                        attempt: 1,
+                        event_type: "started".to_string(),
+                        session_id: None,
+                        detail: legacy_detail,
+                    },
+                    Some(1),
+                )
+                .await
+                .unwrap();
+
+            let history_error = workflow_fact_log::read_tree_records(&store, TREE_ID).unwrap_err();
+            assert!(history_error.contains("node fact decode failed"));
+            assert!(history_error.contains("bypassPermissions"));
+
+            let app = tauri::test::mock_builder()
+                .build(tauri::test::mock_context(tauri::test::noop_assets()))
+                .unwrap();
+            let worktree_ledger = Arc::new(
+                crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
+                    store.clone(),
+                ),
+            );
+            app.manage(store);
+            let host = WorkflowRuntimeHost::with_execution_store(
+                Arc::new(UnusedWorkflowResolver),
+                Arc::new(UnusedWorktreeResolver),
+                Arc::new(ExecutionStore::new_in_memory_for_tests()),
+                Arc::new(FailingWorkflowAgentSessions),
+                worktree_ledger,
+                Arc::new(MissingRepoWorktreeInventory),
+            );
+
+            let error = host.reconcile_startup(app.handle()).await.unwrap_err();
+
+            assert!(
+                matches!(error, WorkflowRuntimeError::SessionStore(message) if
+                message.contains("bypassPermissions"))
+            );
+        }
+
+        #[tokio::test]
+        async fn test_隔離worktree喪失後のresumeは事実を追記せず拒否する() {
+            use crate::domain::workflow::value_objects::IsolatedWorktreeCreatedFact;
+
+            const TREE_ID: &str = "00000000-0000-4000-8000-000000000003";
+            let directory = tempfile::tempdir().unwrap();
+            let store = LocalEventStore::open(LocalEventStoreConfig::production(
+                directory.path().to_path_buf(),
+            ))
+            .unwrap();
+            append_started_session_tree(&store, TREE_ID, "/repo", 1);
+            let child_meta = NodeFactMeta {
+                tree_id: TREE_ID.to_string(),
+                node_execution_id: format!("{TREE_ID}-session"),
+                parent_id: Some(TREE_ID.to_string()),
+                node_name: "impl".to_string(),
+                kind: NodeKindName::Session,
+                attempt: 1,
+            };
+            workflow_fact_log::append_single_fact(
+                &store,
+                &child_meta,
+                &NodeFact::IsolatedWorktreeCreated(IsolatedWorktreeCreatedFact {
                     repository_root: "/repo".to_string(),
                     worktree_path: format!(
-                        "/repo-worktrees/.releash-isolated/{CORRUPT_TREE_ID}-session-a1"
+                        "/repo-worktrees/.releash-isolated/{TREE_ID}-session-a1"
                     ),
-                    branch: format!("releash/isolated/{CORRUPT_TREE_ID}-session-a1"),
-                },
-            ),
-            3,
-        )
-        .unwrap();
-        store
-            .append_node_event(
-                NewNodeEventRow {
-                    tree_id: CORRUPT_TREE_ID.to_string(),
-                    node_execution_id: CORRUPT_TREE_ID.to_string(),
-                    parent_id: None,
-                    node_name: "main".to_string(),
-                    kind: "session".to_string(),
-                    attempt: 1,
-                    event_type: "submit_received".to_string(),
-                    session_id: None,
-                    detail: "{".to_string(),
-                },
-                Some(4),
+                    branch: format!("releash/isolated/{TREE_ID}-session-a1"),
+                }),
+                3,
             )
-            .await
             .unwrap();
-        append_started_session_tree(&store, VALID_TREE_ID, "/repo/valid", 5);
-        let corrupt_count =
-            workflow_fact_log::read_tree_records(&store, CORRUPT_TREE_ID).unwrap_err();
-        assert!(corrupt_count.contains("decode"));
-        let valid_count = workflow_fact_log::read_tree_records(&store, VALID_TREE_ID)
-            .unwrap()
-            .len();
 
-        let app = tauri::test::mock_builder()
-            .build(tauri::test::mock_context(tauri::test::noop_assets()))
-            .unwrap();
-        let worktree_ledger = Arc::new(
-            crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
-                store.clone(),
-            ),
-        );
-        app.manage(store.clone());
-        let host = WorkflowRuntimeHost::with_execution_store(
-            Arc::new(UnusedWorkflowResolver),
-            Arc::new(UnusedWorktreeResolver),
-            Arc::new(ExecutionStore::new_in_memory_for_tests()),
-            Arc::new(FailingWorkflowAgentSessions),
-            worktree_ledger,
-            Arc::new(MissingRepoWorktreeInventory),
-        );
-
-        let error = host.reconcile_startup(app.handle()).await.unwrap_err();
-
-        assert!(matches!(error, WorkflowRuntimeError::SessionStore(_)));
-        assert!(host
-            .execution_store
-            .list_active()
-            .await
-            .unwrap()
-            .iter()
-            .any(|execution| execution.execution_id == VALID_TREE_ID));
-        assert_eq!(
-            workflow_fact_log::read_tree_records(&store, VALID_TREE_ID)
+            let app = tauri::test::mock_builder()
+                .build(tauri::test::mock_context(tauri::test::noop_assets()))
+                .unwrap();
+            let worktree_ledger = Arc::new(
+                crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
+                    store.clone(),
+                ),
+            );
+            app.manage(store.clone());
+            let host = WorkflowRuntimeHost::with_execution_store(
+                Arc::new(UnusedWorkflowResolver),
+                Arc::new(AcceptingWorktreeResolver),
+                Arc::new(ExecutionStore::new_in_memory_for_tests()),
+                Arc::new(FailingWorkflowAgentSessions),
+                worktree_ledger,
+                Arc::new(MissingRepoWorktreeInventory),
+            );
+            host.reconcile_startup(app.handle()).await.unwrap();
+            let before = workflow_fact_log::read_tree_records(&store, TREE_ID)
                 .unwrap()
-                .len(),
-            valid_count
-        );
-        assert!(!workflow_fact_log::read_tree_records(&store, VALID_TREE_ID)
-            .unwrap()
-            .iter()
-            .any(|record| matches!(record.fact, NodeFact::IsolatedWorktreeLost)));
-        let corrupt_lost_count = store
-            .submit_indexed_query_blocking(move |connection| {
-                crate::adaptor::gateway::local_event_store::node_events::read_tree(
-                    connection,
-                    CORRUPT_TREE_ID,
-                )
-                .map(|rows| {
-                    rows.into_iter()
-                        .filter(|row| row.event_type == "isolated_worktree_lost")
-                        .count()
-                })
-                .map_err(|_| crate::domain::local_event::LocalEventQueryError::InvalidRequest)
-            })
-            .unwrap();
-        assert_eq!(corrupt_lost_count, 0);
-    }
+                .len();
 
-    #[tokio::test]
-    async fn test_startup_reconciliation_provider固有permissionのstarted_factをsession_store_errorにする(
-    ) {
-        const TREE_ID: &str = "00000000-0000-4000-8000-000000000004";
-        let directory = tempfile::tempdir().unwrap();
-        let store = LocalEventStore::open(LocalEventStoreConfig::production(
-            directory.path().to_path_buf(),
-        ))
-        .unwrap();
-        let fact = NodeFact::Started(StartedFact {
-            parent: None,
-            root: Some(TreeRootFact::Session(SessionRootFact {
-                workspace_identity: "/repo".to_string(),
-                worktree_path: "/repo".to_string(),
-                session: SessionSpec {
-                    provider: ProviderKind::Claude,
-                    model: None,
-                    permission: Some(SessionPermission::Auto),
-                    facets: Default::default(),
-                },
-                created_from: ExecutionOrigin::DesktopUi,
-            })),
-        });
-        let legacy_detail = fact.encode_detail().unwrap().replace(
-            r#""permission":"auto""#,
-            r#""permission":"bypassPermissions""#,
-        );
-        store
-            .append_node_event(
-                NewNodeEventRow {
-                    tree_id: TREE_ID.to_string(),
-                    node_execution_id: TREE_ID.to_string(),
-                    parent_id: None,
-                    node_name: "main".to_string(),
-                    kind: "session".to_string(),
-                    attempt: 1,
-                    event_type: "started".to_string(),
-                    session_id: None,
-                    detail: legacy_detail,
-                },
-                Some(1),
-            )
-            .await
-            .unwrap();
+            let error = host
+                .resume_workflow_execution(app.handle(), TREE_ID)
+                .await
+                .unwrap_err();
 
-        let history_error = workflow_fact_log::read_tree_records(&store, TREE_ID).unwrap_err();
-        assert!(history_error.contains("node fact decode failed"));
-        assert!(history_error.contains("bypassPermissions"));
-
-        let app = tauri::test::mock_builder()
-            .build(tauri::test::mock_context(tauri::test::noop_assets()))
-            .unwrap();
-        let worktree_ledger = Arc::new(
-            crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
-                store.clone(),
-            ),
-        );
-        app.manage(store);
-        let host = WorkflowRuntimeHost::with_execution_store(
-            Arc::new(UnusedWorkflowResolver),
-            Arc::new(UnusedWorktreeResolver),
-            Arc::new(ExecutionStore::new_in_memory_for_tests()),
-            Arc::new(FailingWorkflowAgentSessions),
-            worktree_ledger,
-            Arc::new(MissingRepoWorktreeInventory),
-        );
-
-        let error = host.reconcile_startup(app.handle()).await.unwrap_err();
-
-        assert!(
-            matches!(error, WorkflowRuntimeError::SessionStore(message) if
-            message.contains("bypassPermissions"))
-        );
-    }
-
-    #[tokio::test]
-    async fn test_隔離worktree喪失後のresumeは事実を追記せず拒否する() {
-        use crate::domain::workflow::value_objects::IsolatedWorktreeCreatedFact;
-
-        const TREE_ID: &str = "00000000-0000-4000-8000-000000000003";
-        let directory = tempfile::tempdir().unwrap();
-        let store = LocalEventStore::open(LocalEventStoreConfig::production(
-            directory.path().to_path_buf(),
-        ))
-        .unwrap();
-        append_started_session_tree(&store, TREE_ID, "/repo", 1);
-        let child_meta = NodeFactMeta {
-            tree_id: TREE_ID.to_string(),
-            node_execution_id: format!("{TREE_ID}-session"),
-            parent_id: Some(TREE_ID.to_string()),
-            node_name: "impl".to_string(),
-            kind: NodeKindName::Session,
-            attempt: 1,
-        };
-        workflow_fact_log::append_single_fact(
-            &store,
-            &child_meta,
-            &NodeFact::IsolatedWorktreeCreated(IsolatedWorktreeCreatedFact {
-                repository_root: "/repo".to_string(),
-                worktree_path: format!("/repo-worktrees/.releash-isolated/{TREE_ID}-session-a1"),
-                branch: format!("releash/isolated/{TREE_ID}-session-a1"),
-            }),
-            3,
-        )
-        .unwrap();
-
-        let app = tauri::test::mock_builder()
-            .build(tauri::test::mock_context(tauri::test::noop_assets()))
-            .unwrap();
-        let worktree_ledger = Arc::new(
-            crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
-                store.clone(),
-            ),
-        );
-        app.manage(store.clone());
-        let host = WorkflowRuntimeHost::with_execution_store(
-            Arc::new(UnusedWorkflowResolver),
-            Arc::new(AcceptingWorktreeResolver),
-            Arc::new(ExecutionStore::new_in_memory_for_tests()),
-            Arc::new(FailingWorkflowAgentSessions),
-            worktree_ledger,
-            Arc::new(MissingRepoWorktreeInventory),
-        );
-        host.reconcile_startup(app.handle()).await.unwrap();
-        let before = workflow_fact_log::read_tree_records(&store, TREE_ID)
-            .unwrap()
-            .len();
-
-        let error = host
-            .resume_workflow_execution(app.handle(), TREE_ID)
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(
-                &error,
-                WorkflowRuntimeError::InvalidState(reason)
-                    if reason
-                        == &format!(
-                            "isolated worktree is missing: /repo-worktrees/.releash-isolated/{TREE_ID}-session-a1"
-                        )
-            ),
-            "unexpected error: {error}"
-        );
-        let records = workflow_fact_log::read_tree_records(&store, TREE_ID).unwrap();
-        assert_eq!(records.len(), before);
-        assert!(!records
-            .iter()
-            .any(|record| matches!(record.fact, NodeFact::ResumeRequested)));
+            assert!(
+                matches!(
+                    &error,
+                    WorkflowRuntimeError::InvalidState(reason)
+                        if reason
+                            == &format!(
+                                "isolated worktree is missing: /repo-worktrees/.releash-isolated/{TREE_ID}-session-a1"
+                            )
+                ),
+                "unexpected error: {error}"
+            );
+            let records = workflow_fact_log::read_tree_records(&store, TREE_ID).unwrap();
+            assert_eq!(records.len(), before);
+            assert!(!records
+                .iter()
+                .any(|record| matches!(record.fact, NodeFact::ResumeRequested)));
+        }
     }
 }
 

--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host/lifecycle_commands.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host/lifecycle_commands.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 enum AbortCommit {
-    Aborted { session_ids: Vec<String> },
+    Aborted,
     NotFound,
     AlreadyTerminal,
 }
@@ -78,15 +78,13 @@ impl WorkflowRuntimeHost {
             .commit_abort_workflow_by_execution_id(app, execution_id, expected_node_name)
             .await;
         match abort_result {
-            Ok(AbortCommit::Aborted { session_ids }) => {
+            Ok(AbortCommit::Aborted) => {
                 if activation_was_paused {
                     activation_gate.commit_cancel();
                     activation_guard = Some(activation_gate.lock.lock().await);
                 }
                 let _activation_guard = activation_guard;
-                let terminal_cleanup_result = self
-                    .finish_committed_abort(app, execution_id, &session_ids)
-                    .await;
+                self.finish_committed_abort(app, execution_id).await;
                 self.execution_store
                     .finish_active_interruption(interruption_reservation)
                     .await
@@ -95,7 +93,6 @@ impl WorkflowRuntimeHost {
                             "ExecutionStore abort reservation cleanup failed: {error}"
                         ))
                     })?;
-                terminal_cleanup_result?;
                 abort_outcome_to_command_result(AbortOutcome::Aborted, execution_id)
             }
             Ok(AbortCommit::NotFound) => {
@@ -563,22 +560,15 @@ impl WorkflowRuntimeHost {
         // 1. 対象 execution の存在 + active 性を判定。
         //    非受理経路 (NotFound / AlreadyTerminal) ではどんな外部副作用も発生させない。
         let lookup = self.abort_target_lookup(execution_id).await?;
-        let (current_node_session_id, active_node_session_ids) = match lookup {
+        match lookup {
             AbortTargetLookup::NotFound => {
                 return Ok(AbortCommit::NotFound);
             }
             AbortTargetLookup::AlreadyTerminal => {
                 return Ok(AbortCommit::AlreadyTerminal);
             }
-            AbortTargetLookup::Active {
-                current_node_session_id,
-                active_node_session_ids,
-            } => (current_node_session_id, active_node_session_ids),
-        };
-        let mut session_ids = current_node_session_id.into_iter().collect::<Vec<_>>();
-        session_ids.extend(active_node_session_ids.into_iter().flatten());
-        session_ids.sort();
-        session_ids.dedup();
+            AbortTargetLookup::Active => {}
+        }
         // 2. [04] pre-commit (rollback 可能): mutation 直前 snapshot を取得し、
         //    state を Aborted に遷移させる。競合で terminal 化していた場合は
         //    AlreadyTerminal で返す。
@@ -617,6 +607,7 @@ impl WorkflowRuntimeHost {
             exec.record_aborted_history_for_active_leaves(timestamp);
 
             let _ = exec.transition_aborted();
+            exec.abort_active_node_executions(timestamp);
             exec.clear_node_stalls(timestamp);
             let snapshot_state = RuntimeCommitSnapshot::from_execution(exec)?;
             (snapshot_before, snapshot_state, aborted_node_for_event)
@@ -668,44 +659,27 @@ impl WorkflowRuntimeHost {
             None,
         );
 
-        Ok(AbortCommit::Aborted { session_ids })
+        Ok(AbortCommit::Aborted)
     }
 
     async fn finish_committed_abort<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
         execution_id: &str,
-        session_ids: &[String],
-    ) -> Result<(), WorkflowRuntimeError> {
+    ) {
         // ExecutionAborted is durable before this method is called. Runtime activation must be
         // quiesced before entering this terminal cleanup so it cannot recreate a closed runtime.
         self.shutdown_active_commands_for_execution(execution_id)
             .await;
-        let mut interrupt_failures = Vec::new();
-        for session_id in session_ids {
-            if let Err(error) = self
-                .workflow_agent_sessions
-                .interrupt_workflow_agent_session(session_id)
-                .await
-            {
-                interrupt_failures.push(error.to_string());
-            }
-        }
         self.finalize_terminal_transition_after_required_append(app, execution_id)
             .await;
-        if interrupt_failures.is_empty() {
-            Ok(())
-        } else {
-            Err(WorkflowRuntimeError::AgentSession(
-                interrupt_failures.join("; "),
-            ))
-        }
     }
 
     /// `abort_workflow_by_execution_id` の post-commit 区間。state は呼出し前に Aborted に
     /// 遷移済みで、`ExecutionAborted` event は必須 append 済み、かつ Execution Store sync も
     /// 完了済みである前提。Workflow refs cleanup / broadcast / in-memory runtime releaseを
-    /// 実行する。AgentSessionとPTYはWorkflow終端後もユーザー操作のため保持する。
+    /// 実行する。終端した Session の AgentSession は required append 後の effect で
+    /// checkpoint を保持したまま停止済みである。
     ///
     /// [04] post-commit 失敗は warn ログのみで command 結果に伝播させない。観測可能な
     /// 事実は既に ExecutionAborted で確定しており、ここでの副作用失敗を command failure に
@@ -747,18 +721,7 @@ impl WorkflowRuntimeHost {
                 if !exec.is_active() {
                     return Ok(AbortTargetLookup::AlreadyTerminal);
                 }
-                let current_node_session_id = exec.current_session_id.clone();
-                let active_node_session_ids = Some(
-                    exec.node_executions
-                        .iter()
-                        .filter(|node| node.status.is_active())
-                        .filter_map(|node| node.session_id.clone())
-                        .collect::<Vec<_>>(),
-                );
-                return Ok(AbortTargetLookup::Active {
-                    current_node_session_id,
-                    active_node_session_ids,
-                });
+                return Ok(AbortTargetLookup::Active);
             }
         }
         if self.has_terminal_execution_record(execution_id).await? {

--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host/runtime_commit.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host/runtime_commit.rs
@@ -17,10 +17,7 @@ use crate::usecase::workflow::runtime_snapshot::RuntimeCommitSnapshot;
 pub(crate) enum AbortTargetLookup {
     NotFound,
     AlreadyTerminal,
-    Active {
-        current_node_session_id: Option<String>,
-        active_node_session_ids: Option<Vec<String>>,
-    },
+    Active,
 }
 
 /// `abort_workflow_by_execution_id` の typed outcome。

--- a/src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs
+++ b/src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs
@@ -643,6 +643,7 @@ mod tests {
                 can_archive: true,
                 can_restore: false,
                 can_delete: false,
+                can_resume: false,
             },
             activity: AgentSessionActivityDto::Idle,
             last_exit_abnormal: false,

--- a/src-tauri/src/agent_session_tui_acceptance.rs
+++ b/src-tauri/src/agent_session_tui_acceptance.rs
@@ -216,6 +216,7 @@ impl<R: tauri::Runtime> AgentSessionTuiAcceptanceHost<R> {
                 composition.launch.clone(),
                 composition.initial_instruction.clone(),
                 composition.interrupt.clone(),
+                composition.lifecycle.clone(),
                 composition.availability_reader.clone(),
             ));
         terminal.bind_agent_session_activity(composition.activity.clone());

--- a/src-tauri/src/cli/review.rs
+++ b/src-tauri/src/cli/review.rs
@@ -531,6 +531,7 @@ mod tests {
                     can_archive: false,
                     can_restore: false,
                     can_delete: false,
+                    can_resume: false,
                 },
                 activity: crate::usecase::agent_session::AgentSessionActivityDto::Idle,
                 last_exit_abnormal: false,

--- a/src-tauri/src/domain/agent_session/aggregates/agent_session.rs
+++ b/src-tauri/src/domain/agent_session/aggregates/agent_session.rs
@@ -132,6 +132,13 @@ pub(crate) enum AgentSessionArchiveError {
 pub(crate) enum AgentSessionRecoveryError {
     NotArchived,
     NotPaused,
+    ProviderSessionUnknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AgentSessionWorkflowStopError {
+    NotWorkflowOwned,
+    NodeExecutionMismatch,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -164,20 +171,7 @@ pub(crate) struct AgentSessionOperations {
     pub(crate) can_archive: bool,
     pub(crate) can_restore: bool,
     pub(crate) can_delete: bool,
-}
-
-impl AgentSessionOperations {
-    pub(crate) fn for_state(
-        tree_parent: Option<&AgentSessionTreeParent>,
-        lifecycle: AgentSessionLifecycle,
-    ) -> Self {
-        let tree_root = tree_parent.is_none();
-        Self {
-            can_archive: tree_root && lifecycle != AgentSessionLifecycle::Archived,
-            can_restore: tree_root && lifecycle == AgentSessionLifecycle::Archived,
-            can_delete: tree_root && lifecycle == AgentSessionLifecycle::Archived,
-        }
-    }
+    pub(crate) can_resume: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -285,6 +279,16 @@ impl AgentSession {
         self.lifecycle
     }
 
+    pub(crate) fn operations(&self) -> AgentSessionOperations {
+        let tree_root = self.tree_parent.is_none();
+        AgentSessionOperations {
+            can_archive: tree_root && self.lifecycle != AgentSessionLifecycle::Archived,
+            can_restore: tree_root && self.lifecycle == AgentSessionLifecycle::Archived,
+            can_delete: tree_root && self.lifecycle == AgentSessionLifecycle::Archived,
+            can_resume: self.authorize_resume().is_ok(),
+        }
+    }
+
     pub(crate) fn uncommitted_events(&self) -> &[AgentSessionLifecycleEvent] {
         &self.uncommitted_events
     }
@@ -368,6 +372,9 @@ impl AgentSession {
                 AgentSessionLifecycle::Open if self.provider_session_id.is_some() => {
                     AgentSessionOpenAction::Resume
                 }
+                AgentSessionLifecycle::Open if self.tree_parent.is_some() => {
+                    AgentSessionOpenAction::RemainPaused
+                }
                 AgentSessionLifecycle::Open => AgentSessionOpenAction::GarbageCollect,
             },
         }
@@ -380,7 +387,7 @@ impl AgentSession {
         if self.lifecycle == AgentSessionLifecycle::Archived {
             return AgentSessionProcessExitOutcome::AlreadyArchived;
         }
-        if self.provider_session_id.is_none() {
+        if self.provider_session_id.is_none() && self.tree_parent.is_none() {
             return AgentSessionProcessExitOutcome::GcRequired;
         }
         if self.lifecycle == AgentSessionLifecycle::Paused {
@@ -471,7 +478,15 @@ impl AgentSession {
         if self.lifecycle != AgentSessionLifecycle::Paused {
             return Err(AgentSessionRecoveryError::NotPaused);
         }
-        Ok(())
+        self.provider_session_id_for_recovery().map(|_| ())
+    }
+
+    pub(crate) fn provider_session_id_for_recovery(
+        &self,
+    ) -> Result<&str, AgentSessionRecoveryError> {
+        self.provider_session_id
+            .as_deref()
+            .ok_or(AgentSessionRecoveryError::ProviderSessionUnknown)
     }
 
     pub(crate) fn admit_initial_instruction(
@@ -520,10 +535,46 @@ impl AgentSession {
         if pty_presence != ManagedPtyPresence::ConfirmedAbsent {
             return Err(AgentSessionRemovalError::PtyNotConfirmedAbsent);
         }
+        if self.tree_parent.is_some() {
+            return Err(AgentSessionRemovalError::WorkflowOwned);
+        }
         if self.provider_session_id.is_some() {
             return Err(AgentSessionRemovalError::ProviderSessionKnown);
         }
         Ok(AgentSessionRemovalAuthorization::GarbageCollection)
+    }
+
+    pub(crate) fn authorize_workflow_stop(
+        &self,
+        node_execution_id: &str,
+    ) -> Result<(), AgentSessionWorkflowStopError> {
+        let parent = self
+            .tree_parent
+            .as_ref()
+            .ok_or(AgentSessionWorkflowStopError::NotWorkflowOwned)?;
+        if parent.node_execution_id != node_execution_id {
+            return Err(AgentSessionWorkflowStopError::NodeExecutionMismatch);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn stop_workflow_owned(
+        &mut self,
+        node_execution_id: &str,
+    ) -> Result<AgentSessionMutationOutcome, AgentSessionWorkflowStopError> {
+        self.authorize_workflow_stop(node_execution_id)?;
+        if self.lifecycle != AgentSessionLifecycle::Open {
+            return Ok(AgentSessionMutationOutcome::AlreadyApplied);
+        }
+        self.lifecycle = AgentSessionLifecycle::Paused;
+        self.last_exit_abnormal = false;
+        self.last_exit_code = None;
+        self.uncommitted_events
+            .push(AgentSessionLifecycleEvent::LifecycleChanged {
+                lifecycle: AgentSessionLifecycle::Paused,
+                last_exit_abnormal: false,
+            });
+        Ok(AgentSessionMutationOutcome::Applied)
     }
 
     pub(crate) fn authorize_workflow_launch_rollback(

--- a/src-tauri/src/domain/agent_session/aggregates/agent_session_test.rs
+++ b/src-tauri/src/domain/agent_session/aggregates/agent_session_test.rs
@@ -2,6 +2,7 @@ use super::agent_session::{
     AgentSessionArchiveError, AgentSessionAssociationError, AgentSessionCreationError,
     AgentSessionInitialInstructionError, AgentSessionRecoveryError,
     AgentSessionRemovalAuthorization, AgentSessionRemovalError, AgentSessionTreeParentError,
+    AgentSessionWorkflowStopError,
 };
 use super::{
     AgentSession, AgentSessionArchiveOutcome, AgentSessionInitialInstructionOutcome,
@@ -656,6 +657,62 @@ fn test_agent_session_gc_provider_session_id既知なら拒否する() {
 }
 
 #[test]
+fn test_agent_session_gc_workflow所有ならprovider_session_id未確定でも拒否する() {
+    let session = AgentSession::create(
+        "agent-session-1",
+        WorkspaceIdentity::new("/repo"),
+        "/repo/.worktrees/feature",
+        ProviderKind::Codex,
+        Some(AgentSessionTreeParent::new("workflow-1", "node-1").unwrap()),
+    )
+    .unwrap();
+
+    let error = session
+        .authorize_gc(ManagedPtyPresence::ConfirmedAbsent)
+        .unwrap_err();
+
+    assert_eq!(error, AgentSessionRemovalError::WorkflowOwned);
+    assert_eq!(
+        session.open_action(ManagedPtyPresence::ConfirmedAbsent),
+        AgentSessionOpenAction::RemainPaused
+    );
+}
+
+#[test]
+fn test_agent_session_workflow停止_所有node_executionとの一致だけを許可する() {
+    let workflow_session = AgentSession::create(
+        "agent-session-1",
+        WorkspaceIdentity::new("/repo"),
+        "/repo/.worktrees/feature",
+        ProviderKind::Claude,
+        Some(AgentSessionTreeParent::new("workflow-1", "node-1").unwrap()),
+    )
+    .unwrap();
+    let standalone_session = AgentSession::create(
+        "agent-session-2",
+        WorkspaceIdentity::new("/repo"),
+        "/repo/.worktrees/feature",
+        ProviderKind::Claude,
+        None,
+    )
+    .unwrap();
+
+    assert!(workflow_session.authorize_workflow_stop("node-1").is_ok());
+    assert_eq!(
+        workflow_session
+            .authorize_workflow_stop("different-node")
+            .unwrap_err(),
+        AgentSessionWorkflowStopError::NodeExecutionMismatch
+    );
+    assert_eq!(
+        standalone_session
+            .authorize_workflow_stop("node-1")
+            .unwrap_err(),
+        AgentSessionWorkflowStopError::NotWorkflowOwned
+    );
+}
+
+#[test]
 fn test_agent_session生成_実行木上の親を固定する() {
     let tree_parent =
         AgentSessionTreeParent::new("workflow-execution-1", "node-execution-1").unwrap();
@@ -906,6 +963,34 @@ fn test_agent_session_process終了_provider_session_id不明ならgcを要求�
 }
 
 #[test]
+fn test_agent_session_workflow停止_provider未確定でも異常終了にせずpausedへ遷移する() {
+    let mut session = AgentSession::create(
+        "agent-session-1",
+        WorkspaceIdentity::new("/repo"),
+        "/repo/.worktrees/feature",
+        ProviderKind::Codex,
+        Some(AgentSessionTreeParent::new("workflow-1", "node-1").unwrap()),
+    )
+    .unwrap();
+    session.take_uncommitted_events();
+
+    let outcome = session.stop_workflow_owned("node-1").unwrap();
+
+    assert_eq!(outcome, AgentSessionMutationOutcome::Applied);
+    assert_eq!(session.lifecycle(), AgentSessionLifecycle::Paused);
+    assert_eq!(session.provider_session_id(), None);
+    assert_eq!(session.transcript_ref(), None);
+    assert!(!session.last_exit_abnormal());
+    assert_eq!(
+        session.uncommitted_events(),
+        &[AgentSessionLifecycleEvent::LifecycleChanged {
+            lifecycle: AgentSessionLifecycle::Paused,
+            last_exit_abnormal: false,
+        }]
+    );
+}
+
+#[test]
 fn test_agent_session関連付け_異なるprovider_session_idへの差し替えを拒否する() {
     let mut session = AgentSession::create(
         "agent-session-1",
@@ -1113,32 +1198,66 @@ fn test_agent_session_open判断_pty状態とlifecycleから唯一の操作を�
 }
 
 #[test]
-fn test_agent_session操作表示_tree_parentとlifecycleの規則をdomainだけが決める() {
+fn test_agent_session操作表示_resume可否を含む規則をdomainだけが決める() {
+    let mut standalone = AgentSession::create(
+        "agent-session-1",
+        WorkspaceIdentity::new("/repo"),
+        "/repo/.worktrees/feature",
+        ProviderKind::Codex,
+        None,
+    )
+    .unwrap();
     assert_eq!(
-        AgentSessionOperations::for_state(None, AgentSessionLifecycle::Open),
+        standalone.operations(),
         AgentSessionOperations {
             can_archive: true,
             can_restore: false,
             can_delete: false,
+            can_resume: false,
         }
     );
+
+    standalone
+        .associate_provider_session("provider-session-1", None)
+        .unwrap();
+    standalone.observe_provider_process_exit(Some(0));
     assert_eq!(
-        AgentSessionOperations::for_state(None, AgentSessionLifecycle::Archived),
+        standalone.operations(),
+        AgentSessionOperations {
+            can_archive: true,
+            can_restore: false,
+            can_delete: false,
+            can_resume: true,
+        }
+    );
+
+    standalone.archive().unwrap();
+    assert_eq!(
+        standalone.operations(),
         AgentSessionOperations {
             can_archive: false,
             can_restore: true,
             can_delete: true,
+            can_resume: false,
         }
     );
+
+    let mut workflow_session = AgentSession::create(
+        "workflow-session",
+        WorkspaceIdentity::new("/repo"),
+        "/repo/.worktrees/feature",
+        ProviderKind::Codex,
+        Some(AgentSessionTreeParent::new("workflow-1", "node-1").unwrap()),
+    )
+    .unwrap();
+    workflow_session.stop_workflow_owned("node-1").unwrap();
     assert_eq!(
-        AgentSessionOperations::for_state(
-            Some(&AgentSessionTreeParent::new("workflow-1", "node-1").unwrap()),
-            AgentSessionLifecycle::Open,
-        ),
+        workflow_session.operations(),
         AgentSessionOperations {
             can_archive: false,
             can_restore: false,
             can_delete: false,
+            can_resume: false,
         }
     );
 }
@@ -1168,6 +1287,20 @@ fn test_agent_session復帰開始_resumeとrestoreの受理状態をdomainが判
 
     session.observe_provider_process_exit(Some(0));
     assert!(session.authorize_resume().is_ok());
+
+    let mut unknown_provider = AgentSession::create(
+        "workflow-session",
+        WorkspaceIdentity::new("/repo"),
+        "/repo/.worktrees/feature",
+        ProviderKind::Codex,
+        Some(AgentSessionTreeParent::new("workflow-1", "node-1").unwrap()),
+    )
+    .unwrap();
+    unknown_provider.stop_workflow_owned("node-1").unwrap();
+    assert_eq!(
+        unknown_provider.authorize_resume().unwrap_err(),
+        AgentSessionRecoveryError::ProviderSessionUnknown
+    );
 
     session
         .complete_resume(AgentSessionRecoveryResult::Succeeded)

--- a/src-tauri/src/domain/agent_session/aggregates/mod.rs
+++ b/src-tauri/src/domain/agent_session/aggregates/mod.rs
@@ -7,12 +7,13 @@ mod provider_registry;
 #[path = "provider_registry_test.rs"]
 mod provider_registry_tests;
 
+#[cfg(test)]
+pub(crate) use agent_session::AgentSessionOperations;
 pub(crate) use agent_session::{
     AgentSession, AgentSessionArchiveOutcome, AgentSessionInitialInstructionOutcome,
     AgentSessionLifecycle, AgentSessionLifecycleEvent, AgentSessionMutationOutcome,
-    AgentSessionOpenAction, AgentSessionOperations, AgentSessionProcessExitOutcome,
-    AgentSessionRecoveryResult, AgentSessionRemovalAuthorization, AgentSessionTreeParent,
-    ManagedPtyPresence,
+    AgentSessionOpenAction, AgentSessionProcessExitOutcome, AgentSessionRecoveryResult,
+    AgentSessionRemovalAuthorization, AgentSessionTreeParent, ManagedPtyPresence,
 };
 #[cfg(test)]
 pub(crate) use provider_registry::ProviderRegistryError;

--- a/src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs
+++ b/src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs
@@ -151,6 +151,12 @@ pub struct RuntimeNodeExecutionFailure {
     pub kind: NodeExecutionFailureKind,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewlyTerminalSession {
+    pub node_execution_id: String,
+    pub agent_session_id: String,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ApprovalAttemptTarget {
     pub node_execution_id: String,
@@ -743,6 +749,31 @@ impl WorkflowExecution {
             .node_executions
             .iter()
             .find(|execution| execution.id == node_execution_id)
+    }
+
+    pub fn newly_terminal_sessions_since(
+        &self,
+        before: &WorkflowExecution,
+    ) -> Vec<NewlyTerminalSession> {
+        if self.id != before.id {
+            return Vec::new();
+        }
+        before
+            .runtime
+            .node_executions
+            .iter()
+            .filter(|node| node.kind == NodeKindName::Session && node.status.is_active())
+            .filter_map(|previous| {
+                let current = self.node_execution(&previous.id)?;
+                if current.status.is_active() {
+                    return None;
+                }
+                Some(NewlyTerminalSession {
+                    node_execution_id: current.id.clone(),
+                    agent_session_id: current.session_id.clone()?,
+                })
+            })
+            .collect()
     }
 
     /// node の親スコープ id（root インスタンスなら None）。
@@ -3991,6 +4022,115 @@ mod tests {
             lifecycle: WorkflowExecution::lifecycle_from_state(state),
             ..WorkflowExecutionRestore::default()
         })
+    }
+
+    #[test]
+    fn newly_terminal_sessions_activeから終端への初回遷移だけを導出する() {
+        for active in [
+            RuntimeNodeExecutionStatus::Running,
+            RuntimeNodeExecutionStatus::Paused,
+            RuntimeNodeExecutionStatus::WaitingApproval,
+        ] {
+            for terminal in [
+                RuntimeNodeExecutionStatus::Succeeded,
+                RuntimeNodeExecutionStatus::Failed,
+                RuntimeNodeExecutionStatus::Aborted,
+            ] {
+                let mut before = restored_execution(RuntimeExecutionState::Running);
+                before
+                    .begin_node_attempt(
+                        "implement".to_string(),
+                        NodeKindName::Session,
+                        1,
+                        None,
+                        "node-execution-1".to_string(),
+                        10.0,
+                    )
+                    .unwrap();
+                before.attach_node_session("node-execution-1", "agent-session-1".to_string(), 11.0);
+                before.node_executions[0].status = active;
+                let mut after = before.clone();
+                after.node_executions[0].status = terminal;
+
+                assert_eq!(
+                    after.newly_terminal_sessions_since(&before),
+                    vec![NewlyTerminalSession {
+                        node_execution_id: "node-execution-1".to_string(),
+                        agent_session_id: "agent-session-1".to_string(),
+                    }],
+                    "{active:?} -> {terminal:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn newly_terminal_sessions_active維持と既終端と非sessionと参照なしを除外する() {
+        let mut before = restored_execution(RuntimeExecutionState::Running);
+        for (id, kind, session_id, status) in [
+            (
+                "running",
+                NodeKindName::Session,
+                Some("running-session"),
+                RuntimeNodeExecutionStatus::Running,
+            ),
+            (
+                "paused",
+                NodeKindName::Session,
+                Some("paused-session"),
+                RuntimeNodeExecutionStatus::Paused,
+            ),
+            (
+                "waiting-approval",
+                NodeKindName::Session,
+                Some("waiting-approval-session"),
+                RuntimeNodeExecutionStatus::WaitingApproval,
+            ),
+            (
+                "terminal",
+                NodeKindName::Session,
+                Some("terminal-session"),
+                RuntimeNodeExecutionStatus::Succeeded,
+            ),
+            (
+                "command",
+                NodeKindName::Command,
+                Some("command-session"),
+                RuntimeNodeExecutionStatus::Running,
+            ),
+            (
+                "unattached",
+                NodeKindName::Session,
+                None,
+                RuntimeNodeExecutionStatus::Running,
+            ),
+        ] {
+            before
+                .begin_node_attempt("implement".to_string(), kind, 1, None, id.to_string(), 10.0)
+                .unwrap();
+            if let Some(session_id) = session_id {
+                before.attach_node_session(id, session_id.to_string(), 11.0);
+            }
+            before
+                .node_executions
+                .iter_mut()
+                .find(|node| node.id == id)
+                .unwrap()
+                .status = status;
+        }
+        let mut after = before.clone();
+        for id in ["terminal", "command", "unattached"] {
+            after
+                .node_executions
+                .iter_mut()
+                .find(|node| node.id == id)
+                .unwrap()
+                .status = RuntimeNodeExecutionStatus::Aborted;
+        }
+
+        assert!(after.newly_terminal_sessions_since(&before).is_empty());
+        after.id = "different-execution".to_string();
+        assert!(after.newly_terminal_sessions_since(&before).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -759,6 +759,7 @@ pub fn run() {
             let agent_session_launch = agent_sessions.launch.clone();
             let agent_session_initial_instruction = agent_sessions.initial_instruction.clone();
             let agent_session_interrupt = agent_sessions.interrupt.clone();
+            let agent_session_lifecycle = agent_sessions.lifecycle.clone();
             let agent_session_exit = agent_sessions.exit.clone();
             let provider_availability = agent_sessions.availability_reader.clone();
             let provider_lifecycle_ingress = agent_sessions.lifecycle_ingress.clone();
@@ -782,7 +783,7 @@ pub fn run() {
             app.manage(agent_sessions.hook_health);
             app.manage(agent_sessions.hook_health_read);
             app.manage(agent_sessions.lifecycle_ingress);
-            app.manage(agent_sessions.lifecycle);
+            app.manage(agent_session_lifecycle.clone());
             app.manage(agent_sessions.read);
             app.manage(agent_session_exit);
             app.manage(agent_sessions.provider_availability);
@@ -969,6 +970,7 @@ pub fn run() {
                         agent_session_initial_instruction: agent_session_initial_instruction
                             .clone(),
                         agent_session_interrupt: agent_session_interrupt.clone(),
+                        agent_session_lifecycle: agent_session_lifecycle.clone(),
                         provider_availability: provider_availability.clone(),
                         worktree_ledger: worktree_ledger_repository.clone(),
                         worktree_inventory: worktree_inventory_gateway.clone(),

--- a/src-tauri/src/usecase/agent_session/agent_session_lifecycle.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_lifecycle.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use crate::domain::agent_session::aggregates::{
-    AgentSessionArchiveOutcome, AgentSessionOpenAction, AgentSessionProcessExitOutcome,
-    AgentSessionRecoveryResult, ManagedPtyPresence,
+    AgentSessionArchiveOutcome, AgentSessionMutationOutcome, AgentSessionOpenAction,
+    AgentSessionProcessExitOutcome, AgentSessionRecoveryResult, ManagedPtyPresence,
 };
 use crate::domain::agent_session::{
     ProviderAgentLaunchGateway, ProviderAgentTerminalGateway, ProviderAvailabilityReader,
@@ -282,6 +282,40 @@ impl AgentSessionLifecycleUsecase {
             .map_err(map_session_error)
     }
 
+    pub(crate) async fn stop_workflow_owned_preserving_checkpoint(
+        &self,
+        agent_session_id: &str,
+        node_execution_id: &str,
+        caller_request_id: &str,
+    ) -> Result<(), AgentSessionLifecycleUsecaseError> {
+        let _operation = self
+            .sessions
+            .lock_operation(agent_session_id)
+            .await
+            .map_err(map_session_error)?;
+        let session = self.required(agent_session_id).await?;
+        session
+            .session()
+            .authorize_workflow_stop(node_execution_id)
+            .map_err(|_| AgentSessionLifecycleUsecaseError::InvalidOperation)?;
+        self.terminal
+            .stop_preserving_checkpoint(&session.session().terminal_surface_owner())
+            .map_err(|_| AgentSessionLifecycleUsecaseError::TerminalUnavailable)?;
+        let outcome = self
+            .sessions
+            .stop_workflow_owned(agent_session_id, node_execution_id, caller_request_id)
+            .await
+            .map_err(map_session_error)?;
+        if outcome == AgentSessionMutationOutcome::Applied {
+            self.change_notifier
+                .agent_session_changed(session.session().worktree_path());
+        }
+        self.release_launch_binding(agent_session_id).await?;
+        self.launch_gateway
+            .cleanup(agent_session_id)
+            .map_err(|_| AgentSessionLifecycleUsecaseError::LaunchUnavailable)
+    }
+
     pub(crate) async fn delete(
         &self,
         agent_session_id: &str,
@@ -445,8 +479,8 @@ impl AgentSessionLifecycleUsecase {
         let session = self.required(agent_session_id).await?;
         let provider_session_id = session
             .session()
-            .provider_session_id()
-            .ok_or(AgentSessionLifecycleUsecaseError::InvalidOperation)?;
+            .provider_session_id_for_recovery()
+            .map_err(|_| AgentSessionLifecycleUsecaseError::InvalidOperation)?;
         let executable = self
             .availability
             .resolved_executable(session.session().provider())

--- a/src-tauri/src/usecase/agent_session/agent_session_lifecycle_test.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_lifecycle_test.rs
@@ -5,8 +5,11 @@ use super::{AgentSessionLifecycleUsecase, AgentSessionOpenOutcome, AgentSessionU
 use crate::adaptor::gateway::agent_session::LocalAgentSessionRepository;
 use crate::adaptor::gateway::local_event_store::{LocalEventStore, LocalEventStoreConfig};
 use crate::adaptor::gateway::provider_lifecycle::LocalProviderLifecycleCredentialGateway;
+use crate::adaptor::gateway::workflow::test_support::{
+    seed_workflow_session_facts, WorkflowSessionFactSeed,
+};
 use crate::domain::agent_session::aggregates::{
-    AgentSessionArchiveOutcome, AgentSessionLifecycle, ManagedPtyPresence,
+    AgentSessionArchiveOutcome, AgentSessionLifecycle, AgentSessionTreeParent, ManagedPtyPresence,
     ResolvedProviderExecutable,
 };
 use crate::domain::agent_session::repository::{
@@ -150,6 +153,7 @@ struct LifecycleTerminal {
     presence: Mutex<ManagedPtyPresence>,
     runtime_generation: Mutex<u64>,
     fail_spawn: Mutex<bool>,
+    fail_stop: Mutex<bool>,
     spawn_count: Mutex<usize>,
     first_spawn_entered: Mutex<Option<mpsc::Sender<()>>>,
     first_spawn_release: Mutex<Option<mpsc::Receiver<()>>>,
@@ -217,6 +221,7 @@ impl LifecycleTerminal {
             presence: Mutex::new(presence),
             runtime_generation: Mutex::new(1),
             fail_spawn: Mutex::new(false),
+            fail_stop: Mutex::new(false),
             spawn_count: Mutex::new(0),
             first_spawn_entered: Mutex::new(None),
             first_spawn_release: Mutex::new(None),
@@ -270,6 +275,9 @@ impl ProviderAgentTerminalGateway for LifecycleTerminal {
         owner: &TerminalSurfaceOwner,
     ) -> Result<(), ProviderAgentTerminalGatewayError> {
         self.stops.lock().unwrap().push(owner.clone());
+        if *self.fail_stop.lock().unwrap() {
+            return Err(ProviderAgentTerminalGatewayError::Unavailable);
+        }
         *self.presence.lock().unwrap() = ManagedPtyPresence::ConfirmedAbsent;
         Ok(())
     }
@@ -300,6 +308,7 @@ impl ProviderAgentTerminalGateway for LifecycleTerminal {
 
 struct LifecycleTestContext {
     _directory: tempfile::TempDir,
+    store: Arc<LocalEventStore>,
     sessions: Arc<AgentSessionUsecase>,
     lifecycle: AgentSessionLifecycleUsecase,
     launches: Arc<RecordingResumeLaunches>,
@@ -339,6 +348,7 @@ fn setup() -> LifecycleTestContext {
     );
     LifecycleTestContext {
         _directory: directory,
+        store,
         sessions,
         lifecycle: usecase,
         launches,
@@ -347,6 +357,292 @@ fn setup() -> LifecycleTestContext {
         hook_health,
         change_notifier,
     }
+}
+
+#[tokio::test]
+async fn test_workflow所有agent_session停止_checkpointとprovider参照を保持してresumeできる() {
+    let LifecycleTestContext {
+        _directory,
+        store,
+        sessions,
+        lifecycle,
+        launches,
+        terminal,
+        provider_lifecycle,
+        ..
+    } = setup();
+    seed_workflow_session_facts(
+        &store,
+        WorkflowSessionFactSeed {
+            workflow_name: "workflow",
+            request: "test",
+            worktree_path: "/repo/worktree",
+            provider: ProviderKind::Claude,
+            workflow_execution_id: "workflow-1",
+            node_execution_id: "node-1",
+            session_id: "workflow-agent",
+            initial_instruction_admitted: true,
+        },
+    )
+    .unwrap();
+    sessions
+        .create(
+            "workflow-agent",
+            WorkspaceIdentity::new("/repo"),
+            "/repo/worktree",
+            ProviderKind::Claude,
+            Some(AgentSessionTreeParent::new("workflow-1", "node-1").unwrap()),
+            "create-workflow-agent",
+        )
+        .await
+        .unwrap();
+    sessions
+        .associate_provider_session(
+            "workflow-agent",
+            "provider-1",
+            Some("provider://transcript/1"),
+            "associate-workflow-agent",
+        )
+        .await
+        .unwrap();
+    let scope = ProviderLifecycleScope::new("workflow-agent").unwrap();
+    provider_lifecycle
+        .arm(
+            ProviderLifecycleSlotId::new("workflow-agent-slot").unwrap(),
+            ProviderKind::Claude,
+            scope.clone(),
+        )
+        .await
+        .unwrap();
+
+    lifecycle
+        .stop_workflow_owned_preserving_checkpoint(
+            "workflow-agent",
+            "node-1",
+            "stop-workflow-agent",
+        )
+        .await
+        .unwrap();
+
+    let stopped = sessions.find("workflow-agent").await.unwrap().unwrap();
+    assert_eq!(stopped.session().lifecycle(), AgentSessionLifecycle::Paused);
+    assert!(!stopped.session().last_exit_abnormal());
+    assert_eq!(stopped.session().provider_session_id(), Some("provider-1"));
+    assert_eq!(
+        stopped.session().transcript_ref(),
+        Some("provider://transcript/1")
+    );
+    assert_eq!(
+        *terminal.presence.lock().unwrap(),
+        ManagedPtyPresence::ConfirmedAbsent
+    );
+    assert_eq!(terminal.stops.lock().unwrap().len(), 1);
+    assert!(terminal.deletes.lock().unwrap().is_empty());
+    assert_eq!(
+        launches.cleanups.lock().unwrap().as_slice(),
+        &["workflow-agent"]
+    );
+    assert!(provider_lifecycle
+        .active_launch_id(ProviderKind::Claude, &scope)
+        .await
+        .unwrap()
+        .is_none());
+
+    assert_eq!(
+        lifecycle
+            .resume("workflow-agent", 24, 80, "resume-workflow-agent")
+            .await
+            .unwrap(),
+        AgentSessionOpenOutcome::Resumed
+    );
+    assert_eq!(
+        launches.launches.lock().unwrap().as_slice(),
+        &[ProviderSessionLaunch::resume("provider-1").unwrap()]
+    );
+    assert_eq!(
+        sessions
+            .find("workflow-agent")
+            .await
+            .unwrap()
+            .unwrap()
+            .session()
+            .lifecycle(),
+        AgentSessionLifecycle::Open
+    );
+}
+
+#[tokio::test]
+async fn test_workflow所有agent_session停止_provider未確定でもgcせずpausedで保持する() {
+    let LifecycleTestContext {
+        _directory,
+        store,
+        sessions,
+        lifecycle,
+        terminal,
+        ..
+    } = setup();
+    seed_workflow_session_facts(
+        &store,
+        WorkflowSessionFactSeed {
+            workflow_name: "workflow",
+            request: "test",
+            worktree_path: "/repo/worktree",
+            provider: ProviderKind::Codex,
+            workflow_execution_id: "workflow-1",
+            node_execution_id: "node-1",
+            session_id: "workflow-agent-unknown",
+            initial_instruction_admitted: true,
+        },
+    )
+    .unwrap();
+    sessions
+        .create(
+            "workflow-agent-unknown",
+            WorkspaceIdentity::new("/repo"),
+            "/repo/worktree",
+            ProviderKind::Codex,
+            Some(AgentSessionTreeParent::new("workflow-1", "node-1").unwrap()),
+            "create-workflow-agent-unknown",
+        )
+        .await
+        .unwrap();
+
+    lifecycle
+        .stop_workflow_owned_preserving_checkpoint(
+            "workflow-agent-unknown",
+            "node-1",
+            "stop-workflow-agent-unknown",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        lifecycle
+            .open(
+                "workflow-agent-unknown",
+                24,
+                80,
+                "open-workflow-agent-unknown"
+            )
+            .await
+            .unwrap(),
+        AgentSessionOpenOutcome::Paused
+    );
+    assert_eq!(
+        lifecycle
+            .reconcile_garbage_collection(
+                "workflow-agent-unknown",
+                "reconcile-workflow-agent-unknown",
+            )
+            .await
+            .unwrap(),
+        super::AgentSessionGarbageCollectionOutcome::Retained
+    );
+    let retained = sessions
+        .find("workflow-agent-unknown")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        retained.session().lifecycle(),
+        AgentSessionLifecycle::Paused
+    );
+    assert!(!retained.session().last_exit_abnormal());
+    assert_eq!(retained.session().provider_session_id(), None);
+    assert!(terminal.deletes.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_workflow所有agent_session停止_ownership不一致と停止失敗ではsettleしない() {
+    let LifecycleTestContext {
+        _directory,
+        store,
+        sessions,
+        lifecycle,
+        launches,
+        terminal,
+        ..
+    } = setup();
+    seed_workflow_session_facts(
+        &store,
+        WorkflowSessionFactSeed {
+            workflow_name: "workflow",
+            request: "test",
+            worktree_path: "/repo/worktree",
+            provider: ProviderKind::Claude,
+            workflow_execution_id: "workflow-1",
+            node_execution_id: "node-1",
+            session_id: "workflow-agent",
+            initial_instruction_admitted: true,
+        },
+    )
+    .unwrap();
+    sessions
+        .create(
+            "workflow-agent",
+            WorkspaceIdentity::new("/repo"),
+            "/repo/worktree",
+            ProviderKind::Claude,
+            Some(AgentSessionTreeParent::new("workflow-1", "node-1").unwrap()),
+            "create-workflow-agent",
+        )
+        .await
+        .unwrap();
+    sessions
+        .create(
+            "manual-agent",
+            WorkspaceIdentity::new("/repo"),
+            "/repo/worktree",
+            ProviderKind::Claude,
+            None,
+            "create-manual-agent",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        lifecycle
+            .stop_workflow_owned_preserving_checkpoint(
+                "workflow-agent",
+                "different-node",
+                "stop-wrong-node",
+            )
+            .await
+            .unwrap_err(),
+        super::AgentSessionLifecycleUsecaseError::InvalidOperation
+    );
+    assert_eq!(
+        lifecycle
+            .stop_workflow_owned_preserving_checkpoint(
+                "manual-agent",
+                "node-1",
+                "stop-manual-agent",
+            )
+            .await
+            .unwrap_err(),
+        super::AgentSessionLifecycleUsecaseError::InvalidOperation
+    );
+    assert!(terminal.stops.lock().unwrap().is_empty());
+
+    *terminal.fail_stop.lock().unwrap() = true;
+    assert_eq!(
+        lifecycle
+            .stop_workflow_owned_preserving_checkpoint("workflow-agent", "node-1", "stop-failure",)
+            .await
+            .unwrap_err(),
+        super::AgentSessionLifecycleUsecaseError::TerminalUnavailable
+    );
+    assert_eq!(
+        sessions
+            .find("workflow-agent")
+            .await
+            .unwrap()
+            .unwrap()
+            .session()
+            .lifecycle(),
+        AgentSessionLifecycle::Open
+    );
+    assert!(launches.cleanups.lock().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/src-tauri/src/usecase/agent_session/agent_session_query.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_query.rs
@@ -36,6 +36,7 @@ pub(crate) struct AgentSessionOperationsDto {
     pub can_archive: bool,
     pub can_restore: bool,
     pub can_delete: bool,
+    pub can_resume: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src-tauri/src/usecase/agent_session/agent_session_read_test.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_read_test.rs
@@ -112,6 +112,7 @@ fn item(id: &str) -> AgentSessionItemDto {
             can_archive: true,
             can_restore: false,
             can_delete: false,
+            can_resume: false,
         },
         activity: AgentSessionActivityDto::Idle,
         last_exit_abnormal: false,

--- a/src-tauri/src/usecase/agent_session/usecase.rs
+++ b/src-tauri/src/usecase/agent_session/usecase.rs
@@ -188,6 +188,21 @@ impl AgentSessionUsecase {
         Ok(outcome)
     }
 
+    pub(crate) async fn stop_workflow_owned(
+        &self,
+        agent_session_id: &str,
+        node_execution_id: &str,
+        caller_request_id: &str,
+    ) -> Result<AgentSessionMutationOutcome, AgentSessionUsecaseError> {
+        let mut session = self.required(agent_session_id).await?;
+        let outcome = session
+            .session_mut()
+            .stop_workflow_owned(node_execution_id)
+            .map_err(|_| AgentSessionUsecaseError::InvalidOperation)?;
+        self.save_if_changed(session, caller_request_id).await?;
+        Ok(outcome)
+    }
+
     pub(crate) async fn complete_resume(
         &self,
         agent_session_id: &str,

--- a/src-tauri/src/usecase/workflow/runtime_driver.rs
+++ b/src-tauri/src/usecase/workflow/runtime_driver.rs
@@ -47,6 +47,10 @@ pub(crate) fn node_outcome_from_advance(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum WorkflowRuntimeEffect {
     BroadcastState,
+    StopWorkflowAgentSession {
+        node_execution_id: String,
+        agent_session_id: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -126,7 +130,7 @@ impl PreparedWorkflowTransaction {
     fn from_candidate(
         before: WorkflowExecution,
         after: WorkflowExecution,
-        decision: WorkflowRuntimeDecision,
+        mut decision: WorkflowRuntimeDecision,
     ) -> Result<Self, WorkflowTransactionPreparationError> {
         if before == after
             && decision.outcome == TransitionOutcome::Applied
@@ -134,6 +138,15 @@ impl PreparedWorkflowTransaction {
         {
             return Err(WorkflowTransactionPreparationError::EventWithoutStateChange);
         }
+        decision.effects.extend(
+            after
+                .newly_terminal_sessions_since(&before)
+                .into_iter()
+                .map(|target| WorkflowRuntimeEffect::StopWorkflowAgentSession {
+                    node_execution_id: target.node_execution_id,
+                    agent_session_id: target.agent_session_id,
+                }),
+        );
         Ok(Self {
             before,
             after,
@@ -213,7 +226,25 @@ impl DurableWorkflowTransaction {
 mod tests {
     use super::*;
     use crate::domain::workflow::entities::workflow_execution::TransitionRejection;
-    use crate::domain::workflow::{ExecutionInterruptionReason, RuntimeExecutionState};
+    use crate::domain::workflow::{
+        ExecutionInterruptionReason, NodeExecutionFailureKind, NodeKindName, RuntimeExecutionState,
+    };
+
+    fn execution_with_attached_session() -> WorkflowExecution {
+        let mut execution = WorkflowExecution::restore(RuntimeExecutionState::Running, None);
+        execution
+            .begin_node_attempt(
+                "session".to_string(),
+                NodeKindName::Session,
+                1,
+                None,
+                "node-execution".to_string(),
+                1.0,
+            )
+            .unwrap();
+        execution.attach_node_session("node-execution", "agent-session".to_string(), 1.0);
+        execution
+    }
 
     fn interrupted_event() -> WorkflowEvent {
         WorkflowEvent::ExecutionInterrupted {
@@ -265,6 +296,69 @@ mod tests {
             vec![WorkflowRuntimeEffect::BroadcastState]
         );
         assert_eq!(live.state(), &RuntimeExecutionState::Interrupted);
+    }
+
+    #[test]
+    fn newly_terminal_session_stop_effect_becomes_available_after_persistence() {
+        let mut live = execution_with_attached_session();
+        let prepared = PreparedWorkflowTransaction::observe(&live, |candidate| {
+            let outcome = candidate.fail_node_execution(
+                "node-execution",
+                "provider failed".to_string(),
+                NodeExecutionFailureKind::InfrastructureCrash,
+                2.0,
+            );
+            Ok(WorkflowRuntimeDecision {
+                outcome,
+                events: vec![interrupted_event()],
+                effects: vec![WorkflowRuntimeEffect::BroadcastState],
+            })
+        })
+        .unwrap();
+
+        let durable = prepared.persist(&mut live, |_| Ok::<_, ()>(())).unwrap();
+
+        assert_eq!(
+            durable.into_effects(),
+            vec![
+                WorkflowRuntimeEffect::BroadcastState,
+                WorkflowRuntimeEffect::StopWorkflowAgentSession {
+                    node_execution_id: "node-execution".to_string(),
+                    agent_session_id: "agent-session".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn newly_terminal_session_persistence_failure_keeps_active_aggregate() {
+        let mut live = execution_with_attached_session();
+        let prepared = PreparedWorkflowTransaction::observe(&live, |candidate| {
+            let outcome = candidate.fail_node_execution(
+                "node-execution",
+                "provider failed".to_string(),
+                NodeExecutionFailureKind::InfrastructureCrash,
+                2.0,
+            );
+            Ok(WorkflowRuntimeDecision {
+                outcome,
+                events: vec![interrupted_event()],
+                effects: vec![WorkflowRuntimeEffect::BroadcastState],
+            })
+        })
+        .unwrap();
+
+        let result = prepared.persist(&mut live, |_| Err("disk"));
+
+        assert!(matches!(
+            result,
+            Err(WorkflowTransactionCommitError::Persistence("disk"))
+        ));
+        assert!(live
+            .node_execution("node-execution")
+            .unwrap()
+            .status
+            .is_active());
     }
 
     #[test]

--- a/src-tauri/src/workflow_control_plane_acceptance.rs
+++ b/src-tauri/src/workflow_control_plane_acceptance.rs
@@ -18,9 +18,13 @@ use crate::domain::workflow::{
     RepositoryWorktreeInventory, SchemaDef, SequenceSpec, SessionSpec, WorkflowDefinition,
     WorkflowError, WorktreeInventoryGateway,
 };
+use crate::domain::workspace_tree::WorkspaceIdentity;
 use crate::infrastructure::local_api::{LocalApiServer, LocalApiServerBinding};
 use crate::terminal_surface::TerminalSurfaceRuntime;
-use crate::usecase::agent_session::AgentSessionUsecase;
+use crate::usecase::agent_session::{
+    AgentSessionLaunchRequest, AgentSessionLaunchUsecase, AgentSessionLifecycleUsecase,
+    AgentSessionUsecase,
+};
 use crate::usecase::workflow::runtime_resolver::{
     ManagedWorktreeResolver, ManagedWorktreeResolverError, WorkflowDefinitionResolver,
     WorkflowDefinitionResolverError,
@@ -345,6 +349,8 @@ pub struct WorkflowControlPlaneAcceptanceHost<R: tauri::Runtime> {
     exit_observer_cancellation:
         Arc<dyn crate::domain::terminal_surface::gateway::TerminalSurfaceEventCancellation>,
     provider_sessions: Arc<AgentSessionUsecase>,
+    provider_launch: Arc<AgentSessionLaunchUsecase>,
+    provider_lifecycle: Arc<AgentSessionLifecycleUsecase>,
     _runtime: Arc<WorkflowRuntimeUsecase>,
     local_api: Arc<LocalApiServer>,
     local_api_base_url: String,
@@ -419,6 +425,7 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
             composition.launch.clone(),
             composition.initial_instruction.clone(),
             composition.interrupt.clone(),
+            composition.lifecycle.clone(),
             composition.availability_reader.clone(),
             Arc::new(
                 crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
@@ -475,6 +482,8 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
             exit_observer,
             exit_observer_cancellation,
             provider_sessions: composition.sessions,
+            provider_launch: composition.launch,
+            provider_lifecycle: composition.lifecycle,
             _runtime: runtime,
             local_api,
             local_api_base_url: format!("http://127.0.0.1:{port}"),
@@ -682,6 +691,81 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
             .ok_or_else(|| "Retry response was not successful".to_string())
     }
 
+    pub async fn abort(&self, execution_id: &str) -> Result<(), String> {
+        let response: MutationResponse = self
+            .post(
+                &format!("/v1/workflow/executions/{execution_id}/abort"),
+                &serde_json::json!({}),
+            )
+            .await?;
+        response
+            .ok
+            .then_some(())
+            .ok_or_else(|| "Abort response was not successful".to_string())
+    }
+
+    pub async fn stop(&self, execution_id: &str) -> Result<(), String> {
+        let response: MutationResponse = self
+            .post(
+                &format!("/v1/workflow/executions/{execution_id}/stop"),
+                &serde_json::json!({}),
+            )
+            .await?;
+        response
+            .ok
+            .then_some(())
+            .ok_or_else(|| "Stop response was not successful".to_string())
+    }
+
+    pub async fn resume(&self, execution_id: &str) -> Result<(), String> {
+        let response: MutationResponse = self
+            .post(
+                &format!("/v1/workflow/executions/{execution_id}/resume"),
+                &serde_json::json!({}),
+            )
+            .await?;
+        response
+            .ok
+            .then_some(())
+            .ok_or_else(|| "Resume response was not successful".to_string())
+    }
+
+    pub async fn launch_manual_agent_session(
+        &self,
+        worktree_path: &str,
+        provider: AcceptanceProvider,
+        caller_request_id: &str,
+    ) -> Result<String, String> {
+        self.provider_launch
+            .launch_standalone(AgentSessionLaunchRequest {
+                workspace: WorkspaceIdentity::new(worktree_path),
+                worktree_path: worktree_path.to_string(),
+                provider: match provider {
+                    AcceptanceProvider::Claude => ProviderKind::Claude,
+                    AcceptanceProvider::Codex => ProviderKind::Codex,
+                },
+                rows: 24,
+                cols: 80,
+                caller_request_id: caller_request_id.to_string(),
+            })
+            .await
+            .map(|session| session.session().id().to_string())
+            .map_err(|error| format!("{error:?}"))
+    }
+
+    pub async fn resume_agent_session(&self, agent_session_id: &str) -> Result<(), String> {
+        self.provider_lifecycle
+            .resume(
+                agent_session_id,
+                24,
+                80,
+                &format!("acceptance-resume-{agent_session_id}"),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| format!("{error:?}"))
+    }
+
     pub async fn agent_session_lifecycle(
         &self,
         agent_session_id: &str,
@@ -749,6 +833,8 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
             exit_observer,
             exit_observer_cancellation,
             provider_sessions,
+            provider_launch,
+            provider_lifecycle,
             _runtime,
             local_api,
             local_api_base_url: _,
@@ -764,7 +850,15 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
             .await
             .map_err(|error| format!("join local API server: {error}"))?;
         _app.unmanage::<Arc<LocalEventStore>>();
-        drop((local_api, _runtime, provider_sessions, terminal, _app));
+        drop((
+            local_api,
+            _runtime,
+            provider_sessions,
+            provider_launch,
+            provider_lifecycle,
+            terminal,
+            _app,
+        ));
         tokio::time::timeout(std::time::Duration::from_secs(10), async {
             loop {
                 let writer_lock = std::fs::OpenOptions::new()

--- a/src-tauri/tests/workflow_control_plane_acceptance_test.rs
+++ b/src-tauri/tests/workflow_control_plane_acceptance_test.rs
@@ -54,7 +54,7 @@ fn install_fixture_executable(
     std::fs::write(
         &executable,
         format!(
-            "#!/bin/sh\ninitial_instruction=\n{initial_instruction_argument}\nif [ -n \"$initial_instruction\" ]; then\n  {{ printf '\\033[200~%s\\033[201~\\n' \"$initial_instruction\"; cat; }} | {command}\nelse\n  {command}\nfi\n"
+            "#!/bin/sh\ntrap '' INT\ninitial_instruction=\n{initial_instruction_argument}\nif [ -n \"$initial_instruction\" ]; then\n  {{ printf '\\033[200~%s\\033[201~\\n' \"$initial_instruction\"; cat; }} | {command}\nelse\n  {command}\nfi\n"
         ),
     )
     .unwrap();
@@ -163,6 +163,28 @@ async fn wait_for_execution_status(
     })
     .await
     .expect("Workflow execution must reach the expected status");
+}
+
+async fn wait_for_agent_session_lifecycle(
+    host: &WorkflowControlPlaneAcceptanceHost<tauri::test::MockRuntime>,
+    agent_session_id: &str,
+    lifecycle: AcceptanceAgentSessionLifecycle,
+) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if host
+                .agent_session_lifecycle(agent_session_id)
+                .await
+                .unwrap()
+                == Some(lifecycle)
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("AgentSession must reach the expected lifecycle");
 }
 
 async fn associate_provider_session(
@@ -380,13 +402,6 @@ async fn test_atui_040_autoは両signal順序と重複に依存せず後続を�
         );
 
         assert!(host.submit(&first.id).await.is_err());
-        emit_provider_stop(
-            &host,
-            &mut first_terminal,
-            &first_owner,
-            &format!("provider-auto-{index}"),
-        )
-        .await;
         let after_duplicates = host.execution(&execution_id).await.unwrap().unwrap();
         let after_duplicate_leaves = leaf_nodes(&after_duplicates);
         assert_eq!(after_duplicate_leaves.len(), 2);
@@ -468,6 +483,21 @@ async fn test_atui_041_approvalは両signal成立後だけ対象nodeを承認で
             AcceptanceNodeExecutionStatus::WaitingApproval
         );
         assert!(waiting.node_executions[0].can_approve);
+        assert_eq!(
+            host.agent_session_lifecycle(&session_id).await.unwrap(),
+            Some(AcceptanceAgentSessionLifecycle::Open)
+        );
+        host.terminal()
+            .write(
+                terminal_owner.clone(),
+                &format!("waiting-approval-follow-up-{index}\r"),
+            )
+            .unwrap();
+        receive_until(
+            &mut terminal,
+            &format!("waiting-approval-follow-up-{index}"),
+        )
+        .await;
         assert!(host
             .approve(&execution_id, "other-node", &node.id)
             .await
@@ -689,7 +719,7 @@ async fn test_atui_042_片側signalは再起動後も同じattemptへ復元さ�
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_atui_042_retryは新attemptと新sessionを作り旧stopを混入させない() {
+async fn test_atui_042_retryは旧attemptを停止し新attemptのterminalを維持する() {
     let root = tempfile::TempDir::new().unwrap();
     let worktree = root.path().join("retry-worktree");
     std::fs::create_dir_all(&worktree).unwrap();
@@ -714,6 +744,12 @@ async fn test_atui_042_retryは新attemptと新sessionを作り旧stopを混入�
     assert!(retryable.node_executions[0].can_retry);
 
     host.retry(&execution_id, &old_attempt.id).await.unwrap();
+    wait_for_agent_session_lifecycle(
+        &host,
+        &old_session_id,
+        AcceptanceAgentSessionLifecycle::Paused,
+    )
+    .await;
     let retried = wait_for_node_count(&host, &execution_id, 2).await;
     let old_history = retried
         .node_executions
@@ -730,37 +766,44 @@ async fn test_atui_042_retryは新attemptと新sessionを作り旧stopを混入�
     assert_eq!(old_history.status, AcceptanceNodeExecutionStatus::Aborted);
     assert!(old_history.submit_received);
     assert!(!old_history.stop_received);
+    assert_eq!(
+        host.agent_session_lifecycle(&old_session_id).await.unwrap(),
+        Some(AcceptanceAgentSessionLifecycle::Paused)
+    );
+    assert!(host.terminal().get(old_owner).is_err());
+
     assert_eq!(new_attempt.attempt, 2);
     assert_eq!(new_attempt.status, AcceptanceNodeExecutionStatus::Running);
     assert!(!new_attempt.submit_received);
     assert!(!new_attempt.stop_received);
     assert_ne!(new_attempt.agent_session_id, old_attempt.agent_session_id);
 
-    emit_provider_stop(&host, &mut old_terminal, &old_owner, "provider-retry-old").await;
-    let after_old_stop = host.execution(&execution_id).await.unwrap().unwrap();
-    let current = after_old_stop
-        .node_executions
-        .iter()
-        .find(|node| node.id == new_attempt.id)
-        .unwrap();
-    assert!(!current.submit_received);
-    assert!(!current.stop_received);
-
-    let new_owner = owner(&worktree, new_attempt.agent_session_id.as_deref().unwrap());
+    let new_session_id = new_attempt.agent_session_id.as_deref().unwrap();
+    assert_eq!(
+        host.agent_session_lifecycle(new_session_id).await.unwrap(),
+        Some(AcceptanceAgentSessionLifecycle::Open)
+    );
+    let new_owner = owner(&worktree, new_session_id);
     let mut new_terminal = host
         .terminal()
         .attach("atui-042-retry-new".to_string(), new_owner.clone())
         .unwrap();
     receive_until(&mut new_terminal, "releash-fixture-input-complete-0").await;
-    associate_provider_session(&host, &mut new_terminal, &new_owner, "provider-retry-new").await;
-    host.submit(&new_attempt.id).await.unwrap();
-    emit_provider_stop(&host, &mut new_terminal, &new_owner, "provider-retry-new").await;
-    wait_for_execution_status(
-        &host,
-        &execution_id,
-        AcceptanceWorkflowExecutionStatus::Completed,
-    )
-    .await;
+    host.terminal()
+        .write(new_owner.clone(), "follow-up-after-retry\r")
+        .unwrap();
+    receive_until(&mut new_terminal, "follow-up-after-retry").await;
+    assert!(!host.terminal().get(new_owner).unwrap().is_exited);
+
+    let after_terminal_input = host.execution(&execution_id).await.unwrap().unwrap();
+    let current = after_terminal_input
+        .node_executions
+        .iter()
+        .find(|node| node.id == new_attempt.id)
+        .unwrap();
+    assert_eq!(current.status, AcceptanceNodeExecutionStatus::Running);
+    assert!(!current.submit_received);
+    assert!(!current.stop_received);
     host.shutdown().await.unwrap();
 }
 
@@ -1001,7 +1044,7 @@ async fn test_issue_1626_active_attemptへの再submitはartifactを差し替え
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_atui_042_workflow完了後もagent_sessionとptyを維持し追加stopで再進行しない() {
+async fn test_issue_1654_workflow完了時にproviderを停止しcheckpointからresumeできる() {
     let root = tempfile::TempDir::new().unwrap();
     let worktree = root.path().join("worktree");
     std::fs::create_dir_all(&worktree).unwrap();
@@ -1041,7 +1084,6 @@ async fn test_atui_042_workflow完了後もagent_sessionとptyを維持し追加
         }),
     )
     .await;
-    host.submit(&node.id).await.unwrap();
     send_hook(
         &host,
         &mut terminal,
@@ -1053,48 +1095,43 @@ async fn test_atui_042_workflow完了後もagent_sessionとptyを維持し追加
         }),
     )
     .await;
+    host.submit(&node.id).await.unwrap();
     wait_for_execution_status(
         &host,
         &execution_id,
         AcceptanceWorkflowExecutionStatus::Completed,
     )
     .await;
+    wait_for_agent_session_lifecycle(&host, &session_id, AcceptanceAgentSessionLifecycle::Paused)
+        .await;
 
-    let sequence_after_completion = host
-        .terminal()
-        .get(terminal_owner.clone())
-        .unwrap()
-        .terminal_surface
-        .sequence;
-    tokio::task::yield_now().await;
     assert_eq!(
-        host.terminal()
-            .get(terminal_owner.clone())
-            .unwrap()
-            .terminal_surface
-            .sequence,
-        sequence_after_completion,
-        "Workflow completion must not inject another Provider input",
+        host.agent_session_lifecycle(&session_id).await.unwrap(),
+        Some(AcceptanceAgentSessionLifecycle::Paused),
     );
+    assert!(host.terminal().get(terminal_owner.clone()).is_err());
+
+    host.resume_agent_session(&session_id).await.unwrap();
     assert_eq!(
         host.agent_session_lifecycle(&session_id).await.unwrap(),
         Some(AcceptanceAgentSessionLifecycle::Open),
     );
-    assert!(
-        !host
-            .terminal()
-            .get(terminal_owner.clone())
-            .unwrap()
-            .is_exited
-    );
+    let mut resumed_terminal = host
+        .terminal()
+        .attach(
+            "workflow-completion-resume".to_string(),
+            terminal_owner.clone(),
+        )
+        .unwrap();
+    receive_until(&mut resumed_terminal, "releash-fixture-input-complete-0").await;
 
     host.terminal()
         .write(terminal_owner.clone(), "follow-up-after-completion\r")
         .unwrap();
-    receive_until(&mut terminal, "follow-up-after-completion").await;
+    receive_until(&mut resumed_terminal, "follow-up-after-completion").await;
     send_hook(
         &host,
-        &mut terminal,
+        &mut resumed_terminal,
         &terminal_owner,
         serde_json::json!({
             "session_id": "provider-session-1",
@@ -1115,5 +1152,145 @@ async fn test_atui_042_workflow完了後もagent_sessionとptyを維持し追加
         AcceptanceNodeExecutionStatus::Succeeded
     );
     assert!(!host.terminal().get(terminal_owner).unwrap().is_exited);
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_issue_1654_execution_stop中はproviderを残して同じagent_sessionでresumeする() {
+    let root = tempfile::TempDir::new().unwrap();
+    let worktree = root.path().join("stop-resume-worktree");
+    std::fs::create_dir_all(&worktree).unwrap();
+    let worktree = worktree.to_string_lossy().into_owned();
+    let host = host(root.path(), 4);
+    let execution_id = host
+        .start_auto_workflow(&worktree, AcceptanceProvider::Claude)
+        .await
+        .unwrap();
+    let running = wait_for_node_count(&host, &execution_id, 1).await;
+    let node = running.node_executions[0].clone();
+    let session_id = node.agent_session_id.clone().unwrap();
+    let terminal_owner = owner(&worktree, &session_id);
+    let mut terminal = host
+        .terminal()
+        .attach("issue-1654-stop-resume".to_string(), terminal_owner.clone())
+        .unwrap();
+    receive_until(&mut terminal, "releash-fixture-input-complete-0").await;
+
+    host.stop(&execution_id).await.unwrap();
+    let stopped = host.execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(stopped.status, AcceptanceWorkflowExecutionStatus::Running);
+    assert_eq!(
+        stopped.node_executions[0].agent_session_id.as_deref(),
+        Some(session_id.as_str())
+    );
+    assert_eq!(
+        host.agent_session_lifecycle(&session_id).await.unwrap(),
+        Some(AcceptanceAgentSessionLifecycle::Open)
+    );
+    assert!(
+        !host
+            .terminal()
+            .get(terminal_owner.clone())
+            .unwrap()
+            .is_exited
+    );
+
+    host.resume(&execution_id).await.unwrap();
+    let resumed = host.execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(
+        resumed.node_executions[0].status,
+        AcceptanceNodeExecutionStatus::Running
+    );
+    assert_eq!(
+        resumed.node_executions[0].agent_session_id.as_deref(),
+        Some(session_id.as_str())
+    );
+    host.terminal()
+        .write(terminal_owner.clone(), "follow-up-after-workflow-resume\r")
+        .unwrap();
+    receive_until(&mut terminal, "follow-up-after-workflow-resume").await;
+
+    host.abort(&execution_id).await.unwrap();
+    wait_for_execution_status(
+        &host,
+        &execution_id,
+        AcceptanceWorkflowExecutionStatus::Aborted,
+    )
+    .await;
+    wait_for_agent_session_lifecycle(&host, &session_id, AcceptanceAgentSessionLifecycle::Paused)
+        .await;
+    let aborted = host.execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(
+        aborted.node_executions[0].status,
+        AcceptanceNodeExecutionStatus::Aborted
+    );
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_issue_1654_cap超過回数の終端後もworkflowと手動sessionを起動できる() {
+    let root = tempfile::TempDir::new().unwrap();
+    let worktree = root.path().join("cap-worktree");
+    std::fs::create_dir_all(&worktree).unwrap();
+    let worktree = worktree.to_string_lossy().into_owned();
+    let host = host(root.path(), 1);
+
+    for index in 0..33 {
+        let execution_id = host
+            .start_auto_workflow(&worktree, AcceptanceProvider::Claude)
+            .await
+            .unwrap_or_else(|error| panic!("workflow {index} failed to start: {error}"));
+        let running = wait_for_node_count(&host, &execution_id, 1).await;
+        let node = running.node_executions[0].clone();
+        let session_id = node.agent_session_id.clone().unwrap();
+        host.abort(&execution_id).await.unwrap();
+        wait_for_execution_status(
+            &host,
+            &execution_id,
+            AcceptanceWorkflowExecutionStatus::Aborted,
+        )
+        .await;
+        wait_for_agent_session_lifecycle(
+            &host,
+            &session_id,
+            AcceptanceAgentSessionLifecycle::Paused,
+        )
+        .await;
+        assert_eq!(
+            host.execution(&execution_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .node_executions[0]
+                .status,
+            AcceptanceNodeExecutionStatus::Aborted
+        );
+    }
+
+    let next_execution_id = host
+        .start_auto_workflow(&worktree, AcceptanceProvider::Claude)
+        .await
+        .unwrap();
+    let next = wait_for_node_count(&host, &next_execution_id, 1).await;
+    assert_eq!(
+        next.node_executions[0].status,
+        AcceptanceNodeExecutionStatus::Running
+    );
+    let manual_session_id = host
+        .launch_manual_agent_session(
+            &worktree,
+            AcceptanceProvider::Codex,
+            "issue-1654-manual-after-cap",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        host.agent_session_lifecycle(&manual_session_id)
+            .await
+            .unwrap(),
+        Some(AcceptanceAgentSessionLifecycle::Open)
+    );
+
+    host.abort(&next_execution_id).await.unwrap();
     host.shutdown().await.unwrap();
 }

--- a/src/components/panels/AgentSessionPanel/AgentSessionPanel.test.tsx
+++ b/src/components/panels/AgentSessionPanel/AgentSessionPanel.test.tsx
@@ -29,6 +29,7 @@ const session = {
 		canArchive: true,
 		canRestore: false,
 		canDelete: false,
+		canResume: false,
 	},
 };
 
@@ -63,7 +64,15 @@ describe("AgentSessionPanel", () => {
 	it("Pausedは明示Resumeが成功するまでTerminalをattachしない", async () => {
 		mockInvoke.mockResolvedValueOnce("paused").mockResolvedValueOnce("resumed");
 
-		render(<AgentSessionPanel session={{ ...session, lifecycle: "paused" }} />);
+		render(
+			<AgentSessionPanel
+				session={{
+					...session,
+					lifecycle: "paused",
+					operations: { ...session.operations, canResume: true },
+				}}
+			/>,
+		);
 
 		const resume = await screen.findByRole("button", { name: "Resume" });
 		expect(screen.queryByTestId("provider-terminal")).not.toBeInTheDocument();
@@ -81,14 +90,29 @@ describe("AgentSessionPanel", () => {
 	});
 
 	it("自動resume失敗後はPausedとerrorを表示して明示Resumeを待つ", async () => {
+		const onRefresh = vi.fn();
 		mockInvoke
 			.mockResolvedValueOnce("paused")
 			.mockRejectedValueOnce(new Error("resume failed"));
 
-		render(<AgentSessionPanel session={session} />);
+		const { rerender } = render(
+			<AgentSessionPanel session={session} onRefresh={onRefresh} />,
+		);
 
 		expect(await screen.findByRole("alert")).toHaveTextContent(
 			"Provider session is not running",
+		);
+		expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
+		expect(onRefresh).toHaveBeenCalledOnce();
+		rerender(
+			<AgentSessionPanel
+				session={{
+					...session,
+					lifecycle: "paused",
+					operations: { ...session.operations, canResume: true },
+				}}
+				onRefresh={onRefresh}
+			/>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Resume" }));
 		expect(await screen.findByRole("alert")).toHaveTextContent("resume failed");
@@ -103,7 +127,12 @@ describe("AgentSessionPanel", () => {
 
 		rerender(
 			<AgentSessionPanel
-				session={{ ...session, lifecycle: "paused", lastExitAbnormal: true }}
+				session={{
+					...session,
+					lifecycle: "paused",
+					lastExitAbnormal: true,
+					operations: { ...session.operations, canResume: true },
+				}}
 			/>,
 		);
 
@@ -111,6 +140,17 @@ describe("AgentSessionPanel", () => {
 			"Provider session is not running",
 		);
 		expect(screen.getByRole("button", { name: "Resume" })).toBeVisible();
+	});
+
+	it("provider session identity未確定のPausedではResumeを表示しない", async () => {
+		mockInvoke.mockResolvedValueOnce("paused");
+
+		render(<AgentSessionPanel session={{ ...session, lifecycle: "paused" }} />);
+
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"Provider session is not running",
+		);
+		expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
 	});
 
 	it("StandaloneでもTerminal表示の上にArchive操作を置かない", async () => {
@@ -137,6 +177,7 @@ describe("AgentSessionPanel", () => {
 						canArchive: false,
 						canRestore: false,
 						canDelete: false,
+						canResume: false,
 					},
 				}}
 			/>,
@@ -161,6 +202,7 @@ describe("AgentSessionPanel", () => {
 						canArchive: false,
 						canRestore: true,
 						canDelete: true,
+						canResume: false,
 					},
 				}}
 			/>,
@@ -261,6 +303,7 @@ describe("AgentSessionRoute", () => {
 				canArchive: false,
 				canRestore: true,
 				canDelete: true,
+				canResume: false,
 			},
 		};
 		let getReads = 0;
@@ -299,6 +342,7 @@ describe("AgentSessionRoute", () => {
 				canArchive: false,
 				canRestore: true,
 				canDelete: true,
+				canResume: false,
 			},
 		};
 		let getReads = 0;

--- a/src/components/panels/AgentSessionPanel/AgentSessionPanel.tsx
+++ b/src/components/panels/AgentSessionPanel/AgentSessionPanel.tsx
@@ -60,6 +60,10 @@ export function AgentSessionPanel({
 	const workspaceIdentity =
 		session?.workspaceIdentity ?? initialAttachment?.workspaceIdentity ?? "";
 	const provider = session?.provider ?? initialAttachment?.provider ?? "";
+	const canResume = session?.operations.canResume ?? false;
+	const pausedMessage = canResume
+		? "Provider session is not running. Resume to retry."
+		: "Provider session is not running.";
 	const [state, setState] = useState<PanelState>(
 		initiallyAttached ? "terminal" : "loading",
 	);
@@ -89,7 +93,8 @@ export function AgentSessionPanel({
 					setState("terminal");
 					return;
 				case "paused":
-					setError("Provider session is not running. Resume to retry.");
+					onRefresh?.();
+					setError(pausedMessage);
 					setState("paused");
 					return;
 				case "indeterminate":
@@ -100,7 +105,7 @@ export function AgentSessionPanel({
 					return;
 			}
 		},
-		[onRefresh, worktreePath],
+		[onRefresh, pausedMessage, worktreePath],
 	);
 
 	const runLifecycleOperation = useCallback(
@@ -196,19 +201,21 @@ export function AgentSessionPanel({
 			)}
 			{state === "paused" && !error && (
 				<div role="alert" className="text-destructive">
-					Provider session is not running. Resume to retry.
+					{pausedMessage}
 				</div>
 			)}
 			{state === "loading" && <div>Opening AgentSession...</div>}
 			{state === "paused" && (
 				<>
 					<div className="text-muted-foreground">AgentSession is paused.</div>
-					<Button
-						type="button"
-						onClick={() => void runLifecycleOperation("resume_agent_session")}
-					>
-						Resume
-					</Button>
+					{canResume && (
+						<Button
+							type="button"
+							onClick={() => void runLifecycleOperation("resume_agent_session")}
+						>
+							Resume
+						</Button>
+					)}
 				</>
 			)}
 			{state === "archived" && (

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -449,6 +449,7 @@ describe("WorkspaceList", () => {
 						canArchive: false,
 						canRestore: true,
 						canDelete: true,
+						canResume: false,
 					},
 				},
 			],

--- a/src/types/agent-session.ts
+++ b/src/types/agent-session.ts
@@ -14,6 +14,7 @@ export interface AgentSessionItem {
 		canArchive: boolean;
 		canRestore: boolean;
 		canDelete: boolean;
+		canResume: boolean;
 	};
 }
 


### PR DESCRIPTION
Closes #1654

## 背景

session node execution が `Succeeded` / `Failed` / `Aborted` へ遷移しても provider プロセスが終了せず、worktree ごとの terminal surface 上限（`per_worktree_cap: 32`）を残留プロセスが埋めていた。上限に達すると、その worktree では workflow の node activation も手動の session 作成も `WorktreeCapReached` に起因する `TerminalUnavailable` で失敗する。UI 上は当該 worktree に実行中のものが何も表示されないため、利用者から残留プロセスは見えず、復旧手段は Releash の外から手動で kill することしかなかった。

spec: `docs/specs/issues-1654/`

## 変更

**終端した session node の provider プロセスを停止する**

`WorkflowExecution` が commit 前後の同一 NodeExecution を比較し、Session が active から終端へ初めて遷移したものだけを停止対象として導出する。durable transaction 境界がこれを効果として保持し、canonical fact の永続化に成功した後、かつ後続 Node の activation より前に実行する。永続化に失敗した場合は停止しないため、active のまま残った NodeExecution の provider プロセスを失わない。

停止は terminal checkpoint と `provider_session_id` を保持するので、後から AgentSession を開けば provider CLI の再開機能で会話を引き継いで復帰できる。workflow execution の stop は NodeExecution を `Paused` に留めるため停止効果を生成せず、既存の interrupt と resume 経路は変わらない。

**AgentSession が checkpoint 保持停止を所有する**

AgentSession 集約に workflow 停止専用の遷移を追加し、意図的な停止を異常終了として事実ログへ記録しない。停止は `tree_parent` の NodeExecution ID が要求と一致する workflow-owned session だけを受理するため、手動作成 session のライフサイクルは変わらない。

`provider_session_id` が確定する前に終端した session も停止対象に含めるため、workflow-owned session を garbage collection の対象外にし、checkpoint ごと削除されないようにした。あわせて Resume の受理規則（`Paused` かつ provider session identity 確定済み）を集約が所有し、read model の `operations.canResume` 経由で UI の出し分けに使う。frontend は lifecycle や provider identity から可否を再計算しない。

**provider Stop の post-commit 失敗を受理結果から分離する**

canonical workflow facts が durable になった後の provider lifecycle commit 失敗は post-commit 失敗として扱い、確定済みの Stop を失敗へ戻さない。

**停止失敗の扱い**

停止失敗は各効果の内側に閉じ、warning に留める。Submit、承認、failure settlement、abort の確定結果へは変換しない。複数の停止対象がある場合も、一件の失敗で残りの停止を省略しない。

## 検証

- workflow domain: active から終端への Session 遷移だけが停止対象になり、active 維持・既終端・Command / composite・AgentSession 参照なしは対象外になること
- workflow transaction / host: 永続化失敗では停止せず、durable commit 後は後続 activation より前に停止すること。Submit / 承認 / failure settlement / abort の各終端経路と、終端後の再 Stop
- AgentSession usecase / gateway: ownership の照合、checkpoint を消さずに枠から除外すること、停止後に既存 provider session identity で resume できること、`provider_session_id` 未確定のまま終端した session が GC されず read model が Resume 不可を返すこと
- frontend: read model が Resume 可の場合だけ停止中の AgentSession に Resume を表示すること
- acceptance: 同一 worktree で `per_worktree_cap` を超える 33 回の終端を積んでも、新しい workflow session と手動 AgentSession が起動できること。停止失敗を注入しても確定結果が維持されること

CI と同じコマンド（`cargo fmt --check` / `cargo clippy --locked -- -D warnings` / `cargo deny --locked check` / `cargo test --locked` / `pnpm lint` / `pnpm test` / `pnpm build` / `pnpm test:integration`）をローカルで実行し、すべて通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwhtDXuVGob1h6pvAoi3nB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ワークフロー完了・失敗・中断時に、関連するプロバイダープロセスを停止し、ターミナル枠を解放します。
  * 停止後もチェックポイントを保持し、条件を満たすセッションを再開できるようになりました。
  * セッション画面に再開可否を表示し、再開できない場合はResume操作を表示しません。
  * 終端済みセッションを上限数の計算から除外し、新しいセッションを作成しやすくしました。

* **改善**
  * StopやAbortの確定結果が、後続のクリーンアップ失敗によって覆らないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->