### PR TITLE
feat(observability): terminal spawn 失敗理由の保全とローカルログの導入

### DIFF
--- a/docs/specs/issues-1653/behavior.md
+++ b/docs/specs/issues-1653/behavior.md
@@ -1,0 +1,95 @@
+## B-001: per-worktree PTY cap到達の記録
+
+GIVEN AgentSessionのterminal spawnがper-worktree PTY cap到達によって失敗する
+WHEN 起動失敗の処理が完了する
+THEN 失敗後に参照できるReleashの記録から、失敗理由がper-worktree PTY cap到達であると区別できる
+AND その記録に対象のworktree pathが含まれる
+
+## B-002: PTY総数cap到達の記録
+
+GIVEN AgentSessionのterminal spawnがPTY総数cap到達によって失敗する
+WHEN 起動失敗の処理が完了する
+THEN 失敗後に参照できるReleashの記録から、失敗理由がPTY総数cap到達であると区別できる
+
+## B-003: owner衝突の記録
+
+GIVEN AgentSessionのterminal spawnがowner衝突によって失敗する
+WHEN 起動失敗の処理が完了する
+THEN 失敗後に参照できるReleashの記録から、失敗理由がowner衝突であると区別できる
+
+## B-004: PTYのopenまたはfork失敗の記録
+
+GIVEN AgentSessionのterminal spawnがPTYのopenまたはfork失敗によって失敗する
+WHEN 起動失敗の処理が完了する
+THEN 失敗後に参照できるReleashの記録から、失敗理由がPTYのopenまたはfork失敗であると区別できる
+AND その記録に発生源が返したエラー内容が含まれる
+
+## B-005: workflowのSession Node起動失敗の記録
+
+GIVEN workflowのSession Nodeのterminal spawnがper-worktree PTY cap到達、PTY総数cap到達、owner衝突、PTYのopenまたはfork失敗、またはこれら以外のspawn失敗によって失敗する
+WHEN そのNodeの失敗が記録される
+THEN Nodeの失敗理由として残る記録から、該当する失敗理由を区別できる
+AND per-worktree PTY cap到達の場合は対象のworktree pathが含まれる
+AND PTYのopenまたはfork失敗、またはこれら以外のspawn失敗の場合は発生源が返したエラー内容が含まれる
+
+## B-006: standalone起動失敗の記録
+
+GIVEN workflow外でstandalone AgentSessionのterminal spawnがper-worktree PTY cap到達、PTY総数cap到達、owner衝突、PTYのopenまたはfork失敗、またはこれら以外のspawn失敗によって失敗する
+WHEN standalone起動の失敗処理が完了する
+THEN 失敗後に参照できるReleashの記録から、該当する失敗理由を区別できる
+AND per-worktree PTY cap到達の場合は対象のworktree pathが含まれる
+AND PTYのopenまたはfork失敗、またはこれら以外のspawn失敗の場合は発生源が返したエラー内容が含まれる
+
+## B-007: history resume失敗の記録
+
+GIVEN workflow外でAgentSessionのhistory resumeに伴うterminal spawnがper-worktree PTY cap到達、PTY総数cap到達、owner衝突、PTYのopenまたはfork失敗、またはこれら以外のspawn失敗によって失敗する
+WHEN history resumeの結果が確定する
+THEN 失敗後に参照できるReleashの記録から、該当する失敗理由を区別できる
+AND per-worktree PTY cap到達の場合は対象のworktree pathが含まれる
+AND PTYのopenまたはfork失敗、またはこれら以外のspawn失敗の場合は発生源が返したエラー内容が含まれる
+
+## B-008: GUIプロセスの警告およびエラーログ
+
+GIVEN パッケージ版として配布されたReleashのGUIプロセスが起動している
+WHEN `log` crate経由で警告およびエラーが記録され、GUIプロセスが終了する
+THEN 警告およびエラーの内容がローカルのログファイルに書き出されている
+AND プロセス終了後もそのログファイルから内容を参照できる
+
+## B-009: ローカルログの増大上限
+
+GIVEN パッケージ版Releashがローカルのログファイルへ継続して警告またはエラーを書き出している
+WHEN ログの保持量が定められたサイズまたは世代の上限に達する
+THEN 保持されるローカルログはその上限を超えて増大しない
+
+## B-010: ローカルログの外部非送信
+
+GIVEN パッケージ版Releashが`log` crate経由の警告またはエラーをローカルのログファイルへ書き出す
+WHEN ログの記録が完了する
+THEN そのローカルログファイルの内容は、このログ記録機能によってReleashの外部へ送信されない
+
+## B-011: 上記以外のspawn失敗の記録
+
+GIVEN AgentSessionのterminal spawnがper-worktree PTY cap到達、PTY総数cap到達、owner衝突、PTYのopenまたはfork失敗のいずれでもない失敗によって失敗する
+WHEN 起動失敗の処理が完了する
+THEN 失敗後に参照できるReleashの記録から、失敗理由がこれら4分類以外のspawn失敗であると区別できる
+AND その記録に発生源が返したエラー内容が含まれる
+
+## B-012: CLIプロセスの警告およびエラーログ
+
+GIVEN パッケージ版として配布されたReleashのCLIプロセスが実行されている
+WHEN `log` crate経由で警告およびエラーが記録され、CLIプロセスが終了する
+THEN 警告およびエラーの内容がローカルのログファイルに書き出されている
+AND プロセス終了後もそのログファイルから内容を参照できる
+
+## 要件IDとBehavior IDの対応表
+
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001, B-002, B-003, B-004, B-011 |
+| R-002 | B-001, B-005, B-006, B-007 |
+| R-003 | B-004, B-005, B-006, B-007, B-011 |
+| R-004 | B-005 |
+| R-005 | B-006, B-007 |
+| R-006 | B-008, B-012 |
+| R-007 | B-009 |
+| R-008 | B-010 |

--- a/docs/specs/issues-1653/design.md
+++ b/docs/specs/issues-1653/design.md
@@ -24,7 +24,9 @@ terminal spawn失敗の分類は、既に発生源で区別されている`Termi
 
 ローカルファイルloggerの構築と`log` facadeへの登録は、新設する`src-tauri/src/infrastructure/local_log.rs`が所有する。ファイル出力、rotation、プロセス間の排他をOS資源として扱う責務であり、`docs/architecture/INFRASTRUCTURE.md`の境界に従う。
 
-loggerはTauriの`AppHandle`に依存しない形で構築する。`src-tauri/src/main.rs`は引数がある場合にTauri builderを構築せずCLIへ分岐するため、Tauri pluginとしてだけ登録するとCLIプロセスの出力先が無いままになる。GUIプロセスは`src-tauri/src/lib.rs`がcomposition rootとして既存のapplication setupより前に登録し、CLIプロセスは`src-tauri/src/cli/mod.rs`の`run`がsubcommand dispatchより前に登録する。これによりsetup内およびその後の既存`log::warn!`／`log::error!`と、CLI経路の同じ呼び出しが同じloggerを使う。各プロセスは自分が解決したdata dir配下へ書き、GUIは`PathAliases::from_runtime(None)`によるTauri側のdata dir、CLIは`RELEASH_DATA_DIR`を優先する`resolve_data_dir`の結果を使う。既定の起動経路では同じdata dirを解決して同一ファイルを共有するが、CLI起動時に任意の`RELEASH_DATA_DIR`を明示した場合は別の出力先になる。
+loggerはTauri pluginとして登録しない。`src-tauri/src/main.rs`は引数がある場合にTauri builderを構築せずCLIへ分岐するため、plugin登録だけではCLIプロセスの出力先が無いままになる。GUIプロセスは`src-tauri/src/lib.rs`がcomposition rootとしてapplication setupの冒頭で登録し、CLIプロセスは`src-tauri/src/cli/mod.rs`の`run`がsubcommand dispatchより前に登録する。これによりsetup内およびその後の既存`log::warn!`／`log::error!`と、CLI経路の同じ呼び出しが同じloggerを使う。
+
+出力先は各プロセスがそのプロセスのdata dirを解決する既存の経路に従う。GUIは`infrastructure/platform/app_data_dir.rs`の`resolve_data_dir`が返すTauri解決のdata dirを使い、event store、terminal checkpoint、子プロセスへ伝搬する`RELEASH_DATA_DIR`と同じ値になる。この解決は`AppHandle`を要するため、GUIのlogger登録はsetupより前へ移せない。CLIは`RELEASH_DATA_DIR`を優先する`cli/common.rs`の`resolve_data_dir`の結果を使う。GUIが子プロセスへ自分のdata dirを伝搬するため既定の起動経路では同一ファイルを共有するが、CLI起動時に任意の`RELEASH_DATA_DIR`を明示した場合は別の出力先になる。
 
 ### Interface
 
@@ -73,7 +75,7 @@ terminal spawn失敗時は、発生源のtyped errorをAgentSession側のspawn e
 - 同じdata dirを解決したGUIプロセスとCLIプロセスは同じファイルを共有する。各プロセスのbounded channelと専用writer threadがfile I/Oを所有し、`log::Log::log`はrecordを非ブロッキングでenqueueする。queue満杯時は新しいrecordを捨て、drain再開後のrecordに破棄件数を示す。`log::Log::flush`はそれ以前に受理したrecordのdrain完了を待ち、CLIは`run`の戻り際にflushする。data dirとlogsディレクトリの生成、書き込み、rotationはwriter threadで初回record処理時に行い、初期化時にはfile I/Oを行わない。
 - 同一ファイルに対する書き込みとrotationは、writer threadが`fs2`のblocking exclusive lockを取得してprocess間で直列化する。`local_event_store`はforegroundのopen処理で単一writer所有権の競合を即時に返す必要があるため`try_lock_exclusive`を使う一方、local loggerは呼び出し側から分離したwriter thread内で一時的なfile操作を順番に完了させるためblocking lockを使う。
 - rotationはrecordを書き込んだ後にactive fileが10 MiBを超えていた場合、次のrecordに備えて行う。1 recordを複数fileへ分割せずJSON行境界を保つため、1ファイルの最大サイズは10 MiBに直近record 1件分を加えた値となる。active fileを含む最大5ファイルの世代上限は厳密に守る。
-- loggerはGUIではTauri application setupより前、CLIではsubcommand dispatchより前に登録する。既存のOTLP trace／metrics／crash logs providerとは接続せず、`infrastructure/telemetry/`の送信条件と内容を変更しない。
+- loggerはGUIではTauri application setupの冒頭、CLIではsubcommand dispatchより前に登録する。既存のOTLP trace／metrics／crash logs providerとは接続せず、`infrastructure/telemetry/`の送信条件と内容を変更しない。
 
 デプロイ先、署名、Tauri capability、frontend packageは変更しない。
 

--- a/docs/specs/issues-1653/design.md
+++ b/docs/specs/issues-1653/design.md
@@ -1,0 +1,97 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### terminal spawn失敗理由の所有と伝播
+
+terminal spawn失敗の分類は、既に発生源で区別されている`TerminalSurfaceSpawnReservationError`と`TerminalSurfaceGatewayError`を正本とし、`src-tauri/src/usecase/terminal_surface/error.rs`および`src-tauri/src/usecase/terminal_surface/spawn_usecase.rs`で文字列へ潰さずに保持する。PTY runtime生成を呼ぶ箇所のエラーはPTYのopen／fork失敗として保持し、checkpoint読込、output reader開始、既存exited surfaceのdrain、runtime lifecycleによるmutation拒否など呼び出し元へ到達する残りの失敗は、発生源のmessageを保ったまま「上記以外のspawn失敗」として保持する。owner衝突として呼び出し元へ到達するのは`spawn_usecase.rs`のowner identity collision経路であり、これをowner衝突として保持する。`TerminalSurfaceSpawnReservationError::OwnerOccupied`は呼び出し元へ返らないため分類対象にしない。
+
+`src-tauri/src/domain/agent_session/provider_terminal_gateway.rs`では、`ProviderAgentTerminalGateway::spawn`だけがspawn固有のtyped errorを返すようにする。presence、stop、deleteなどの既存操作は従来の`ProviderAgentTerminalGatewayError`を使い続ける。`src-tauri/src/adaptor/gateway/agent_session/provider_agent_terminal_gateway.rs`はTerminal Surface側のtyped errorを、per-worktree cap、総数cap、owner衝突、PTY runtime生成失敗、およびそれ以外のspawn失敗の区別と必要なpayloadを保ったAgentSession側のerrorへ変換する。error messageの内容を再解析して分類しない。
+
+`src-tauri/src/usecase/agent_session/agent_session_launch.rs`の`AgentSessionLaunchUsecaseError`はterminal spawn失敗のtyped errorを保持する。新規起動の共通`spawn_prepared`経路とhistory resume経路は、失敗理由を取得した時点で記録し、その後に既存のrollback／cleanupを行う。これによりcleanupが別の失敗を返しても、最初のspawn失敗理由は失われない。既存のcap値、待機、retry、queue、AgentSession lifecycle遷移は変更しない。
+
+#### 経路ごとの記録owner
+
+- workflowのSession Nodeでterminal spawnを行うのは`activate_workflow_node`経路である。`src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs`の`activate_workflow_agent_session`でtyped errorの`Display`表現を`WorkflowRuntimeError::AgentSession`へ載せる。terminal spawnを行わない`prepare_workflow_agent_session`側のformattingは変更しない。既存の`workflow_host`の失敗収束から`WorkflowEvent::NodeFailed`、`ProcessExitedFact.failure_reason`へ至る経路をそのまま使い、event storeにNodeの失敗理由を永続化する。
+- standalone起動とhistory resumeは、`agent_session_launch.rs`がspawn失敗を`log::error!`で記録する。standaloneは呼び出し元へ既存の汎用エラーを返す前、history resumeは既存のPaused収束処理へ進む前に記録する。
+- workflow経路でも同じ`log::error!`記録を残す。workflowの判定材料となる正本はNodeの既存failure fact、プロセス横断の障害調査記録はローカルログとし、両者のownerを混同しない。
+
+根拠は、AgentSessionがTerminal ownershipを持ち、NodeExecutionはAgentSessionを参照するという`docs/architecture/README.md`および`docs/glossary/DOMAIN.md`の境界、domain portの外部エラーをgatewayで変換する`docs/architecture/GATEWAY.md`、業務手順とrollback順序をusecaseが所有する`docs/architecture/USECASE.md`である。
+
+#### ローカルloggerの責務
+
+ローカルファイルloggerの構築と`log` facadeへの登録は、新設する`src-tauri/src/infrastructure/local_log.rs`が所有する。ファイル出力、rotation、プロセス間の排他をOS資源として扱う責務であり、`docs/architecture/INFRASTRUCTURE.md`の境界に従う。
+
+loggerはTauriの`AppHandle`に依存しない形で構築する。`src-tauri/src/main.rs`は引数がある場合にTauri builderを構築せずCLIへ分岐するため、Tauri pluginとしてだけ登録するとCLIプロセスの出力先が無いままになる。GUIプロセスは`src-tauri/src/lib.rs`がcomposition rootとして既存のapplication setupより前に登録し、CLIプロセスは`src-tauri/src/cli/mod.rs`の`run`がsubcommand dispatchより前に登録する。これによりsetup内およびその後の既存`log::warn!`／`log::error!`と、CLI経路の同じ呼び出しが同じloggerを使う。各プロセスは自分が解決したdata dir配下へ書き、GUIは`PathAliases::from_runtime(None)`によるTauri側のdata dir、CLIは`RELEASH_DATA_DIR`を優先する`resolve_data_dir`の結果を使う。既定の起動経路では同じdata dirを解決して同一ファイルを共有するが、CLI起動時に任意の`RELEASH_DATA_DIR`を明示した場合は別の出力先になる。
+
+### Interface
+
+terminal spawn失敗の記録は、次の`kind`とpayloadで外部から区別できる表現に統一する。
+
+| 失敗 | 記録上のkind | 必須payload |
+| --- | --- | --- |
+| per-worktree PTY cap到達 | `per_worktree_cap` | `worktree_path` |
+| PTY総数cap到達 | `total_cap` | なし |
+| owner衝突 | `owner_conflict` | なし |
+| PTYのopen／process spawn失敗 | `pty_spawn` | 発生源のerror message |
+| 上記以外のspawn失敗 | `other_spawn_failure` | 発生源のerror message |
+
+ローカルログは`AgentSession terminal spawn failed`という事象名、AgentSession ID、上表のkindとpayloadを一つのerror recordに含める。workflowのNode失敗理由は`activate_workflow_agent_session`が組み立てる既存の`activate Workflow AgentSession '<agent_session_id>': ...`というcontextを維持し、その末尾に同じkindとpayloadを含むtyped errorの`Display`表現を置く。`workflow_host`が前置する`workflow runtime activation failed: `は既存表現のまま変更しない。`Debug`表現には依存しない。
+
+Tauri command `create_agent_session`と`resume_agent_session_history_candidate`の名前、引数、戻り値は変更しない。standalone起動が失敗したときのcode `AGENT_SESSION_TERMINAL_UNAVAILABLE`と利用者向けmessageも維持し、失敗理由をUI responseへ追加しない。local API、CLI、terminal protocolにも新しい公開契約を追加しない。
+
+sharedなTerminal Surface error型の変更後も、`src-tauri/src/adaptor/controller/command/terminal_surface/commands.rs`はper-worktree／total capを既存の`PTY_ERROR_CODE_CAP_REACHED`へ、それ以外を既存のgeneric codeへ変換する。AgentSessionのworkflow error formattingを変更するのはterminal spawn固有errorだけとし、その他の`AgentSessionLaunchUsecaseError`がNode失敗理由へ載る既存表現は維持する。
+
+### Data Model
+
+AgentSessionのterminal portにspawn専用errorを追加し、分類とR-002／R-003で必要なpayloadだけを保持する。これは一回のspawn試行結果を表す値であり、identity、lifecycle、独立した永続状態を持たない。`AgentSessionLaunchUsecaseError`はこの値をsourceとして保持し、standalone request registryで再利用できるよう`Clone`可能にするが、文字列化した複製は保持しない。
+
+ローカルログrecordはtimestamp、level、Rust target、message、および書き手がGUIプロセスとCLIプロセスのどちらかを判別できる値を持つ1行形式とする。AgentSession本文、PTY出力、workflow state全体はログへ保持しない。ログファイルにschema versionは導入しない。
+
+### Database
+
+新しいtable、event種別、migrationは追加しない。workflowの失敗理由は既存の`ProcessExitedFact.failure_reason`へ保存する。standalone／history resumeの記録はdata dir解決に従うローカルのローテーション対象ファイルであり、SQLite event storeへ複製しない。
+
+### UI/UX
+
+画面、操作フロー、表示文言は変更しない。失敗理由のアプリ内閲覧・検索・案内UIは追加せず、standalone起動失敗時は既存の汎用エラー表示を維持する。
+
+### Algorithm
+
+terminal spawn失敗時は、発生源のtyped errorをAgentSession側のspawn errorへ一度だけ変換する。新規起動では、同じerror値からローカルログと`AgentSessionLaunchUsecaseError`を生成し、一次原因を保持したまま既存rollbackを最後まで実行する。workflow境界はそのerrorを`Display`でNode失敗理由へ変換する。history resumeでは、同じerror値をローカルログへ書いた後に既存cleanupを実行し、cleanup成功時は従来どおりPausedを返す。
+
+分類にmessage prefix／substringの照合を使わない。worktree pathは`WorktreeCapReached`が保持する値を、PTY error messageは`spawn_runtime`が返した`TerminalSurfaceGatewayError`の内容をそのまま伝播させる。
+
+### Infra
+
+新しいlogging crateは追加せず、`local_log.rs`が標準のファイルI/Oと既存依存の`fs2`によるadvisory file lockでfile loggerを構成し、`src-tauri/src/infrastructure/mod.rs`から公開する。次を固定する。
+
+- level filterは`Warn`とし、要求対象のwarning／errorだけを記録する。
+- 出力先はdata dir解決配下のログディレクトリの単一ファイルとし、basenameは`releash`とする。OS固有の絶対pathはコードへ固定しない。stdout、stderr、Webview、network targetへは出力しない。
+- 同じdata dirを解決したGUIプロセスとCLIプロセスは同じファイルを共有する。各プロセスのbounded channelと専用writer threadがfile I/Oを所有し、`log::Log::log`はrecordを非ブロッキングでenqueueする。queue満杯時は新しいrecordを捨て、drain再開後のrecordに破棄件数を示す。`log::Log::flush`はそれ以前に受理したrecordのdrain完了を待ち、CLIは`run`の戻り際にflushする。data dirとlogsディレクトリの生成、書き込み、rotationはwriter threadで初回record処理時に行い、初期化時にはfile I/Oを行わない。
+- 同一ファイルに対する書き込みとrotationは、writer threadが`fs2`のblocking exclusive lockを取得してprocess間で直列化する。`local_event_store`はforegroundのopen処理で単一writer所有権の競合を即時に返す必要があるため`try_lock_exclusive`を使う一方、local loggerは呼び出し側から分離したwriter thread内で一時的なfile操作を順番に完了させるためblocking lockを使う。
+- rotationはrecordを書き込んだ後にactive fileが10 MiBを超えていた場合、次のrecordに備えて行う。1 recordを複数fileへ分割せずJSON行境界を保つため、1ファイルの最大サイズは10 MiBに直近record 1件分を加えた値となる。active fileを含む最大5ファイルの世代上限は厳密に守る。
+- loggerはGUIではTauri application setupより前、CLIではsubcommand dispatchより前に登録する。既存のOTLP trace／metrics／crash logs providerとは接続せず、`infrastructure/telemetry/`の送信条件と内容を変更しない。
+
+デプロイ先、署名、Tauri capability、frontend packageは変更しない。
+
+## Alternatives Considered
+
+- standalone／history resumeにも新しいlocal eventを追加する案は採らない。新しいevent schemaとprojection ownerが必要になる一方、本件で必要な障害調査記録は同時に導入するローカルloggerで満たせる。workflowだけは既存のNode failure factが判断材料の正本なので、その経路を維持する。
+- `log` facadeを既存のOTLP logs providerへbridgeする案は採らない。ローカルファイル内容を外部送信しないR-008と、既存telemetryの送信内容・条件を変えないNon-goalに反する。
+- `tauri-plugin-log`を使う案は採らない。plugin登録も`Builder::split`も`&AppHandle`を要求するのに対し、`main.rs`は引数ありの起動でTauri builderを通らずCLIへ分岐するため、CLIプロセスを構造的に覆えない。GUIだけpluginを使いCLIへ別実装を置く案も、rotation policyと出力先の所有者が二重になるため採らない。
+- Terminal Surface側のerror messageをAgentSession gatewayで解析する案は採らない。発生源の文言変更で分類が壊れ、R-001の区別を型で保証できないためである。
+
+## Cross-cutting concerns
+
+- セキュリティ: ローカルloggerはfile出力だけを持ち、OTLP、Webview、callbackへ転送しない。R-002で要求されたworktree pathとR-003で要求された発生源error以外のAgentSession内容やPTY出力を新たに記録しない。
+- 性能／保持量: warning／errorだけをbounded channel経由で専用writer threadのfile targetへ送り、呼び出し側をfile I/Oやprocess間lockの待機から分離する。active fileを含む最大5ファイルを保持し、各ファイルは10 MiBに直近record 1件分を加えたサイズまで許容する。同じdata dirを解決して同一ファイルを共有する場合に限り、保持量の上限はGUIとCLIの合計に対して効く。
+- 並行性: 同じdata dirを解決したGUIプロセスと複数のCLIプロセスが同じファイルへ書く場合は、writer threadによる書き込みとrotationをprocess間lockで直列化し、rotation中の書き込みで世代保持が壊れないようにする。process内queueが満杯の場合は新しいrecordを捨てるため、高頻度の警告／エラーが呼び出し側の処理速度をfile I/Oへ律速させない。
+- 互換性: Tauri commandのerror code／message、history resumeのPaused結果、workflow event schema、SQLite schema、既存OTLP設定を維持する。
+- 検証: `docs/architecture/TEST.md`に従い、Terminal Surface usecaseの分類保持、AgentSession gatewayの変換、AgentSession launchの一次原因保持を各レイヤーのRust testで検証する。workflowは既存のfailure factへの記録を複数レイヤー統合testで確認する。ローカルloggerはprocess-level integration testで、GUI経路とCLI経路それぞれのwarning／errorの終了後参照と、rotation後の保持ファイル数を確認する。B-010はloggerがfile出力だけを持ちOTLP bridgeを生成しないことを構成testで確認する。
+
+## Risks
+
+- process内queueが満杯になると新しいrecordを取りこぼす。呼び出し側をブロックしないことを優先し、drain再開後のrecordへ破棄件数を含めて欠落を判別可能にする。CLIはcommand dispatchから戻った時点、GUIはTauriの`RunEvent::Exit`受信時に`flush`して受理済みrecordをdrainし、プロセス終了時の記録欠落を防ぐ。

--- a/docs/specs/issues-1653/design.md
+++ b/docs/specs/issues-1653/design.md
@@ -40,7 +40,7 @@ terminal spawn失敗の記録は、次の`kind`とpayloadで外部から区別�
 | PTYのopen／process spawn失敗 | `pty_spawn` | 発生源のerror message |
 | 上記以外のspawn失敗 | `other_spawn_failure` | 発生源のerror message |
 
-ローカルログは`AgentSession terminal spawn failed`という事象名、AgentSession ID、上表のkindとpayloadを一つのerror recordに含める。workflowのNode失敗理由は`activate_workflow_agent_session`が組み立てる既存の`activate Workflow AgentSession '<agent_session_id>': ...`というcontextを維持し、その末尾に同じkindとpayloadを含むtyped errorの`Display`表現を置く。`workflow_host`が前置する`workflow runtime activation failed: `は既存表現のまま変更しない。`Debug`表現には依存しない。
+ローカルログは`AgentSession terminal spawn failed`という事象名、AgentSession ID、上表のkindとpayloadを一つのerror recordの`message`へ含める。これらを個別のJSON fieldへ分けず、workflowのNode失敗理由と同じ文字列表現を使って、同じ事実の表現を二つにしない。workflowのNode失敗理由は`activate_workflow_agent_session`が組み立てる既存の`activate Workflow AgentSession '<agent_session_id>': ...`というcontextを維持し、その末尾に同じkindとpayloadを含むtyped errorの`Display`表現を置く。`workflow_host`が前置する`workflow runtime activation failed: `は既存表現のまま変更しない。`Debug`表現には依存しない。
 
 Tauri command `create_agent_session`と`resume_agent_session_history_candidate`の名前、引数、戻り値は変更しない。standalone起動が失敗したときのcode `AGENT_SESSION_TERMINAL_UNAVAILABLE`と利用者向けmessageも維持し、失敗理由をUI responseへ追加しない。local API、CLI、terminal protocolにも新しい公開契約を追加しない。
 
@@ -50,7 +50,7 @@ sharedなTerminal Surface error型の変更後も、`src-tauri/src/adaptor/contr
 
 AgentSessionのterminal portにspawn専用errorを追加し、分類とR-002／R-003で必要なpayloadだけを保持する。これは一回のspawn試行結果を表す値であり、identity、lifecycle、独立した永続状態を持たない。`AgentSessionLaunchUsecaseError`はこの値をsourceとして保持し、standalone request registryで再利用できるよう`Clone`可能にするが、文字列化した複製は保持しない。
 
-ローカルログrecordはtimestamp、level、Rust target、message、および書き手がGUIプロセスとCLIプロセスのどちらかを判別できる値を持つ1行形式とする。AgentSession本文、PTY出力、workflow state全体はログへ保持しない。ログファイルにschema versionは導入しない。
+ローカルログrecordはtimestamp、level、Rust target、message、および書き手がGUIプロセスとCLIプロセスのどちらかを判別できる値を持つ1行形式とする。terminal spawn失敗の事象名、AgentSession ID、kind、payloadは`message`の内容であり、独立したfieldにしない。AgentSession本文、PTY出力、workflow state全体はログへ保持しない。ログファイルにschema versionは導入しない。
 
 ### Database
 
@@ -73,7 +73,7 @@ terminal spawn失敗時は、発生源のtyped errorをAgentSession側のspawn e
 - level filterは`Warn`とし、要求対象のwarning／errorだけを記録する。
 - 出力先はdata dir解決配下のログディレクトリの単一ファイルとし、basenameは`releash`とする。OS固有の絶対pathはコードへ固定しない。stdout、stderr、Webview、network targetへは出力しない。
 - 同じdata dirを解決したGUIプロセスとCLIプロセスは同じファイルを共有する。各プロセスのbounded channelと専用writer threadがfile I/Oを所有し、`log::Log::log`はrecordを非ブロッキングでenqueueする。queue満杯時は新しいrecordを捨て、drain再開後のrecordに破棄件数を示す。`log::Log::flush`はそれ以前に受理したrecordのdrain完了を待ち、CLIは`run`の戻り際にflushする。data dirとlogsディレクトリの生成、書き込み、rotationはwriter threadで初回record処理時に行い、初期化時にはfile I/Oを行わない。
-- 同一ファイルに対する書き込みとrotationは、writer threadが`fs2`のblocking exclusive lockを取得してprocess間で直列化する。`local_event_store`はforegroundのopen処理で単一writer所有権の競合を即時に返す必要があるため`try_lock_exclusive`を使う一方、local loggerは呼び出し側から分離したwriter thread内で一時的なfile操作を順番に完了させるためblocking lockを使う。
+- process間の排他対象はログディレクトリ内の専用lock file `releash.lock` に固定し、active fileと世代fileをlock対象にしない。writer threadはこのlockを`fs2`のblocking exclusive lockで取得し、保持したままactive fileのopen、書き込み、サイズ確認、rotation、世代削除、rotation後のactive file再openまでを完了させる。`local_event_store`はforegroundのopen処理で単一writer所有権の競合を即時に返す必要があるため`try_lock_exclusive`を使う一方、local loggerは呼び出し側から分離したwriter thread内で一時的なfile操作を順番に完了させるためblocking lockを使う。
 - rotationはrecordを書き込んだ後にactive fileが10 MiBを超えていた場合、次のrecordに備えて行う。1 recordを複数fileへ分割せずJSON行境界を保つため、1ファイルの最大サイズは10 MiBに直近record 1件分を加えた値となる。active fileを含む最大5ファイルの世代上限は厳密に守る。
 - loggerはGUIではTauri application setupの冒頭、CLIではsubcommand dispatchより前に登録する。既存のOTLP trace／metrics／crash logs providerとは接続せず、`infrastructure/telemetry/`の送信条件と内容を変更しない。
 
@@ -92,7 +92,7 @@ terminal spawn失敗時は、発生源のtyped errorをAgentSession側のspawn e
 - 性能／保持量: warning／errorだけをbounded channel経由で専用writer threadのfile targetへ送り、呼び出し側をfile I/Oやprocess間lockの待機から分離する。active fileを含む最大5ファイルを保持し、各ファイルは10 MiBに直近record 1件分を加えたサイズまで許容する。同じdata dirを解決して同一ファイルを共有する場合に限り、保持量の上限はGUIとCLIの合計に対して効く。
 - 並行性: 同じdata dirを解決したGUIプロセスと複数のCLIプロセスが同じファイルへ書く場合は、writer threadによる書き込みとrotationをprocess間lockで直列化し、rotation中の書き込みで世代保持が壊れないようにする。process内queueが満杯の場合は新しいrecordを捨てるため、高頻度の警告／エラーが呼び出し側の処理速度をfile I/Oへ律速させない。
 - 互換性: Tauri commandのerror code／message、history resumeのPaused結果、workflow event schema、SQLite schema、既存OTLP設定を維持する。
-- 検証: `docs/architecture/TEST.md`に従い、Terminal Surface usecaseの分類保持、AgentSession gatewayの変換、AgentSession launchの一次原因保持を各レイヤーのRust testで検証する。workflowは既存のfailure factへの記録を複数レイヤー統合testで確認する。ローカルloggerはprocess-level integration testで、GUI経路とCLI経路それぞれのwarning／errorの終了後参照と、rotation後の保持ファイル数を確認する。B-010はloggerがfile出力だけを持ちOTLP bridgeを生成しないことを構成testで確認する。
+- 検証: `docs/architecture/TEST.md`に従い、Terminal Surface usecaseの分類保持、AgentSession gatewayの変換、AgentSession launchの一次原因保持を各レイヤーのRust testで検証する。workflowは既存のfailure factへの記録を複数レイヤー統合testで確認する。ローカルloggerはprocess-level integration testで、GUI経路とCLI経路それぞれのwarning／errorの終了後参照と、rotation後の保持ファイル数を確認する。同じdata dirを共有する複数プロセスの同時書き込みと同時rotationも同じtestに含め、recordが混線せず世代上限が保たれることを確認する。B-010はloggerがfile出力だけを持ちOTLP bridgeを生成しないことを構成testで確認する。
 
 ## Risks
 

--- a/docs/specs/issues-1653/requirements.md
+++ b/docs/specs/issues-1653/requirements.md
@@ -1,0 +1,103 @@
+# Context
+
+- Issue: https://github.com/siro33950/releash/issues/1653 （`[observability] terminal spawn 失敗理由が変換で破棄され、ロガー未初期化でパッケージ版にログが一切残らない`、label: bug）
+- 契機となった実障害: 2026-08-19、PJT-2308 worktree で AgentSession 起動が連続失敗した。切り分けにイベントストアの直接照会（sqlite3）と OS レベルのプロセス列挙（lsof / pgrep）が必要だった。アプリ内のどこにも失敗理由が記録されていなかったため。
+- 本 Spec は Issue が挙げる 2 つの原因の両方を対象にする。Issue 本文は原因2（logger 未初期化）について「別途議論して決める」としているが、2026-08-23 に人間が両方を Scope に含めると確定した。この確定が Issue 本文の記述に優先する。
+- ログの出力先は 2026-08-23 に人間が「ローカルファイル（ローテーション付き、外部送信なし）」と確定した。
+- 対象コード:
+  - `src-tauri/src/usecase/agent_session/agent_session_launch.rs`
+  - `src-tauri/src/adaptor/gateway/agent_session/provider_agent_terminal_gateway.rs`
+  - `src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs`
+  - `src-tauri/src/usecase/terminal_surface/error.rs`
+  - `src-tauri/src/domain/terminal_surface/entities/terminal_surface_registry.rs`
+  - `src-tauri/src/infrastructure/telemetry/`
+- 既存の観測基盤: OpenTelemetry (OTLP) の trace / metrics / logs パイプラインが `src-tauri/src/infrastructure/telemetry/mod.rs` にある。logs signal は `SdkLoggerProvider` として構築されるが、利用者は `crash::report_error`（panic hook と frontend からのエラー報告）だけである。
+
+# Outcome
+
+対象者は、Releash の terminal / AgentSession 起動が失敗したときに原因を特定する開発者および利用者である。
+
+現在は、起動失敗が起きてもアプリが残す記録に失敗理由が含まれない。per-worktree PTY cap 到達も、PTY の open / fork 失敗も、同じ `TerminalUnavailable` としてしか残らない。さらに `log::warn!` / `log::error!` の呼び出しは 145 箇所あるが logger が初期化されていないため、どの経路の警告・エラーも出力先を持たない。結果として、障害のたびにイベントストアの直接照会と OS レベル調査が必要になる。
+
+変更後は、terminal spawn 失敗の具体的な理由が Releash 自身の記録から判別でき、`log` マクロ経由の警告・エラーがパッケージ版でもローカルのログファイルに残る。障害の一次切り分けが、外部ツールによる forensics なしに完了する。
+
+# Current Behavior
+
+## 原因1: spawn 失敗理由がエラー変換で破棄される
+
+失敗理由は発生源では区別されているが、AgentSession 起動経路の 2 段階の変換で失われる。
+
+理由が保持されている段階:
+
+- `domain/terminal_surface/entities/terminal_surface_registry.rs:157-178` の `reserve_spawn` は、`TerminalSurfaceSpawnReservationError` として `OwnerOccupied(session_key)` / `WorktreeCapReached(worktree_path)` / `TotalCapReached` を区別して返す。cap の既定値は `domain/terminal_surface/value_objects/terminal_surface_lifecycle_config.rs:10-11` で `per_worktree_cap: 32` / `max_panes_total: 64`。
+- `usecase/terminal_surface/error.rs:24-38` は cap 到達をメッセージ付きの `UsecaseError::CapReached("PTY cap reached for worktree {worktree_path}")` / `UsecaseError::CapReached("PTY total cap reached")` へ変換する。PTY の open / fork 失敗は `TerminalSurfaceGatewayError`（`domain/terminal_surface/gateway.rs:22-24`、メッセージ文字列を保持する）から `UsecaseError::Gateway(String)` になる。
+- owner 衝突として呼び出し元へ到達するのは、`usecase/terminal_surface/spawn_usecase.rs:232-237,258-263` の `UsecaseError::Gateway("Terminal Surface owner identity collision")` である。`TerminalSurfaceSpawnReservationError::OwnerOccupied` は `spawn_usecase.rs:255-271` で呼び出し元へ返されず、`wait_for_spawn_resolution` の後に再試行へ戻るため、`error.rs:27-29` の `"Terminal Surface owner is already being created: {session_key}"` へは到達しない。
+- 上記4分類のいずれにも当たらない失敗も、AgentSession が呼ぶ `usecase/terminal_surface/application.rs:385-404` の `get_or_spawn_process` から `UsecaseError` として返る。runtime lifecycle による mutation 拒否（`application.rs:194-196,212-223`）、checkpoint 読込失敗（`spawn_usecase.rs:277-283`）、output reader 開始失敗（`spawn_usecase.rs:70-74`）、既存の exited surface に対する drain 失敗（`spawn_usecase.rs:238-244`）がこれに当たり、いずれも発生源のメッセージを保持している。
+
+理由が失われる段階:
+
+- `adaptor/gateway/agent_session/provider_agent_terminal_gateway.rs:22-31` の `spawn` が `get_or_spawn_process` の結果を `.map_err(|_| ProviderAgentTerminalGatewayError::Unavailable)` で潰す。`ProviderAgentTerminalGatewayError` は `domain/agent_session/provider_terminal_gateway.rs:7-9` で `Unavailable` の単一 variant である。
+- `usecase/agent_session/agent_session_launch.rs:599-613`（新規起動 `spawn_prepared`）は `self.terminal.spawn(...).is_err()` だけを見て `AgentSessionLaunchUsecaseError::TerminalUnavailable` を返す。
+- `usecase/agent_session/agent_session_launch.rs:707-721`（`resume_history`）も同様に `.is_err()` だけを見て、失敗を Paused 結果へ落とす。
+
+その結果として残る記録:
+
+- workflow 経路: workflow の Session Node で terminal spawn を行うのは、`usecase/agent_session/agent_session_launch.rs:345-399` の `activate_workflow_node` から呼ばれる `spawn_prepared` である。`prepare_workflow_node`（同 301-343）は `terminal.spawn` を呼ばない。失敗は `adaptor/gateway/workflow/node_session_boundary.rs:141-155` が `WorkflowRuntimeError::AgentSession(format!("activate Workflow AgentSession '{node_session_id}': {error:?}"))` として組み立て、`adaptor/gateway/workflow/workflow_host.rs:1284-1317` が `settle_runtime_failure_for_node` へ渡し、同 2081-2119 が `format!("workflow runtime activation failed: {error}")` を `WorkflowEvent::NodeFailed { reason }`（`domain/workflow/value_objects/runtime_event.rs:105-115`）の reason にする。`WorkflowRuntimeError::AgentSession` の `Display` はメッセージをそのまま出力し（`usecase/workflow/runtime_error.rs:51`）、`AgentSessionLaunchUsecaseError` は `agent_session_launch.rs:70-79` の fieldless enum なので `{error:?}` は variant 名だけになる。実際に残る文字列は `workflow runtime activation failed: activate Workflow AgentSession '<agent_session_id>': TerminalUnavailable` であり、含まれる識別子は AgentSession の id で、失敗理由も NodeExecution id も含まれない。この reason が `adaptor/gateway/workflow/fact_log.rs:299-315` で `ProcessExitedFact.failure_reason` としてイベントストアへ永続化される。
+- standalone 経路: `adaptor/controller/command/agent_session/provider_tui.rs:384-387` が `AppError::coded("AGENT_SESSION_TERMINAL_UNAVAILABLE", "AgentSession Terminal Surface is unavailable")` を frontend へ返すだけで、永続化される記録はない。
+
+対比: terminal surface を直接扱う command 経路 `adaptor/controller/command/terminal_surface/commands.rs:122` は `UsecaseError::CapReached(_) => PTY_ERROR_CODE_CAP_REACHED` として cap 到達を区別している。AgentSession 起動経路だけが区別を落としている。
+
+再現手順: 同一 worktree で AgentSession を `per_worktree_cap`（既定 32）まで起動した状態で、さらに 1 つ起動する。workflow の Session Node から起動した場合はイベントストアに `workflow runtime activation failed: activate Workflow AgentSession '<agent_session_id>': TerminalUnavailable` が残り、standalone の場合は code `AGENT_SESSION_TERMINAL_UNAVAILABLE` が frontend へ返る。いずれにも cap 到達である事実、どちらの cap か、対象 worktree path は残らない。2026-08-19 の実障害（per-worktree cap 到達）でも、イベント上は `TerminalUnavailable` としか残らなかった。
+
+## 原因2: logger が初期化されておらず log マクロの出力先がない
+
+- `src-tauri/Cargo.toml:56` に `log = "0.4"` があり、`src-tauri/src/` 配下に `log::warn!` / `log::error!` / `log::info!` / `log::debug!` / `log::trace!` の呼び出しが 145 箇所ある。
+- logger 実装の登録は存在しない。`src-tauri/` 全体に対する調査で、`log::set_logger` / `log::set_boxed_logger` / `impl log::Log` / `log::set_max_level` / `LevelFilter` / `env_logger` / `tracing-subscriber` / `simple_logger` / `fern` のいずれも見つからない。`tauri-plugin-log` は `Cargo.toml` に無く、`src/lib.rs:622-634` の plugin 登録にも無い。
+- `log` crate は logger 未登録時にすべてのマクロを no-op として扱う。したがって開発ビルドでもパッケージ版でも、これら 145 箇所の出力はどこにも残らない。macOS 統合ログにも残らない。
+- CLI プロセスも同じ状態にある。`src-tauri/src/main.rs:13-18` は引数がある場合に Tauri builder を構築せず `releash_lib::cli::run()`（`src/cli/mod.rs:102`）へ分岐するため、GUI 側の起動処理を通らない。`src/cli/hook.rs:116,144` など CLI から通る経路にも `log::warn!` の呼び出しがある。
+- OTLP の logs signal は存在するが `log` facade とは接続されていない。`infrastructure/telemetry/mod.rs:104-112` が構築した `SdkLoggerProvider` は `crash::init_crash_reporting` へ渡され、`infrastructure/telemetry/crash.rs:40-70` の `report_error` だけが使う。`report_error` は panic hook（`crash.rs:72` 以降）と frontend からのエラー報告（`adaptor/controller/command/telemetry/commands.rs:13`）の 2 経路からしか呼ばれず、かつ crash reporting 無効時と OTLP 未設定時は早期 return する。`log` マクロを OTLP logs へ橋渡しする appender は導入されていない。
+- 具体的な影響例: `usecase/agent_session/agent_session_launch.rs:794-796` の `rollback_failed_new_launch_preserving_cause` は、起動失敗のロールバックに失敗した事実を `log::warn!` で記録しているが、この警告は実際にはどこにも出ていない。同様に `adaptor/gateway/terminal_surface/runtime_gateway_impl.rs:274,318,322` の terminal 出力収集・終了検出・永続化の失敗も残らない。
+
+再現手順: パッケージ版（`.app`）として配布した Releash を起動し、`log::warn!` を通る経路（例: AgentSession 起動失敗後のロールバック失敗）を発生させる。アプリのログファイルは存在せず、`log show --predicate 'process == "releash"'` にも該当レコードが出ない。
+
+# Scope / Non-goals
+
+## Scope
+
+- AgentSession 起動経路（新規起動および history resume）における terminal spawn 失敗理由の保全。理由の区別（per-worktree cap 到達 / 総数 cap 到達 / owner 衝突 / PTY の open・fork 失敗 / これら以外の spawn 失敗）が失敗後に参照できる記録へ残るようにする。
+- workflow の Session Node 起動失敗として残る失敗理由への、上記区別の反映。
+- workflow 外（standalone 起動、history resume）の AgentSession 起動失敗に対する、失敗理由の記録の追加。
+- logger の初期化の導入。`log` crate 経由の警告・エラーがローカルのログファイルへ書き出されるようにする。対象は GUI プロセスと CLI プロセス（`releash workflow` / `releash review` / `releash hook`）の両方とする。
+
+## Non-goals
+
+- terminal spawn 失敗そのものを減らすこと。cap の既定値の変更、cap 到達時の待機・再試行・キューイングの導入は行わない。
+- 既存の OTLP telemetry（trace / metrics）および crash reporting の送信内容・送信条件の変更。
+- ログを閲覧・検索する UI をアプリ内に追加すること。
+- 既存 `log` マクロ呼び出し箇所の網羅的な見直し（レベルの是正、文言の統一、呼び出しの追加・削除）。本 Spec は既存の呼び出しに出力先を与えることに限る。
+- AgentSession 以外のドメイン（review、repository、workflow 定義評価など）の観測性の改善。
+- 失敗理由を利用者向けに UI で案内すること（cap 到達時の誘導表示など）。
+
+# Requirements
+
+- R-001: AgentSession の terminal spawn が失敗したとき、その失敗が「per-worktree PTY cap 到達」「PTY 総数 cap 到達」「owner 衝突」「PTY の open / fork 失敗」「これら以外の spawn 失敗」のいずれであるかを、失敗後に参照できる Releash の記録から区別できる。
+- R-002: 失敗が per-worktree PTY cap 到達である場合、R-001 の記録に対象の worktree path が含まれる。
+- R-003: 失敗が PTY の open / fork 失敗、または R-001 の「これら以外の spawn 失敗」である場合、R-001 の記録に発生源が返したエラー内容が含まれる。
+- R-004: workflow の Session Node が terminal spawn 失敗によって失敗したとき、その Node の失敗理由として残る記録に R-001 から R-003 の内容が含まれる。
+- R-005: workflow 外の AgentSession 起動（standalone 起動および history resume）が terminal spawn 失敗で終わったときも、R-001 から R-003 の内容が失敗後に参照できる記録として残る。
+- R-006: パッケージ版として配布した Releash の GUI プロセスおよび CLI プロセス（`releash workflow` / `releash review` / `releash hook`）が `log` crate 経由で記録した警告およびエラーがローカルのログファイルへ書き出され、プロセス終了後にそのファイルから参照できる。
+- R-007: R-006 のログファイルは無制限に増大せず、サイズまたは世代の上限を持つ。
+- R-008: R-006 のログファイルの内容は Releash から外部へ送信されない。
+
+# Assumptions / Open Questions
+
+## Assumptions
+
+- 本 Spec の Scope に Issue #1653 の原因1 と原因2 の両方を含めることは、2026-08-23 に人間が確定した。Issue 本文の「logger 初期化の導入を別途議論して決める」という記述より、この確定が優先する。
+- `log` マクロの出力先をローカルファイル（ローテーション付き、外部送信なし）とすることは、2026-08-23 に人間が確定した。
+- terminal spawn 失敗の記録対象を Issue 本文が挙げる4分類に限らず、呼び出し元へ到達する spawn 失敗すべてとすることは、2026-08-23 に人間が確定した。
+- logger の対象に GUI プロセスと CLI プロセスの両方を含めることは、2026-08-23 に人間が確定した。
+
+## Open Questions
+
+なし。

--- a/src-tauri/src/adaptor/controller/command/agent_session/provider_tui.rs
+++ b/src-tauri/src/adaptor/controller/command/agent_session/provider_tui.rs
@@ -381,7 +381,8 @@ fn launch_error(error: AgentSessionLaunchUsecaseError) -> AppError {
             "AGENT_SESSION_LAUNCH_UNAVAILABLE",
             "Provider launch preparation is unavailable",
         ),
-        AgentSessionLaunchUsecaseError::TerminalUnavailable => AppError::coded(
+        AgentSessionLaunchUsecaseError::TerminalUnavailable
+        | AgentSessionLaunchUsecaseError::TerminalSpawn(_) => AppError::coded(
             "AGENT_SESSION_TERMINAL_UNAVAILABLE",
             "AgentSession Terminal Surface is unavailable",
         ),

--- a/src-tauri/src/adaptor/controller/command/agent_session/provider_tui_test.rs
+++ b/src-tauri/src/adaptor/controller/command/agent_session/provider_tui_test.rs
@@ -49,3 +49,20 @@ fn test_agent_session_controller_provider未選択と未知値を起動前に拒
     assert_eq!(missing["code"], "AGENT_SESSION_INVALID_PROVIDER");
     assert_eq!(unknown["code"], "AGENT_SESSION_INVALID_PROVIDER");
 }
+
+#[test]
+fn test_agent_session_controller_terminal_spawn詳細を既存の利用者向けerrorへ変換する() {
+    let error = launch_error(AgentSessionLaunchUsecaseError::TerminalSpawn(
+        crate::domain::agent_session::ProviderAgentTerminalSpawnError::PerWorktreeCap {
+            worktree_path: "/repo/worktree".to_string(),
+        },
+    ));
+    let value = serde_json::to_value(error).unwrap();
+
+    assert_eq!(value["code"], "AGENT_SESSION_TERMINAL_UNAVAILABLE");
+    assert_eq!(
+        value["message"],
+        "AgentSession Terminal Surface is unavailable"
+    );
+    assert!(!value.to_string().contains("/repo/worktree"));
+}

--- a/src-tauri/src/adaptor/controller/command/terminal_surface/commands.rs
+++ b/src-tauri/src/adaptor/controller/command/terminal_surface/commands.rs
@@ -119,8 +119,13 @@ pub struct TerminalCommandError {
 impl From<UsecaseError> for TerminalCommandError {
     fn from(error: UsecaseError) -> Self {
         let code = match error {
-            UsecaseError::CapReached(_) => PTY_ERROR_CODE_CAP_REACHED,
-            UsecaseError::Gateway(_) => PTY_ERROR_CODE_GENERIC,
+            UsecaseError::PerWorktreeCap { .. } | UsecaseError::TotalCap => {
+                PTY_ERROR_CODE_CAP_REACHED
+            }
+            UsecaseError::Gateway(_)
+            | UsecaseError::OwnerConflict
+            | UsecaseError::PtySpawn { .. }
+            | UsecaseError::OtherSpawnFailure { .. } => PTY_ERROR_CODE_GENERIC,
         };
         Self {
             code: code.to_string(),

--- a/src-tauri/src/adaptor/controller/command/terminal_surface/commands_test.rs
+++ b/src-tauri/src/adaptor/controller/command/terminal_surface/commands_test.rs
@@ -32,6 +32,26 @@ fn test_ターミナル画面生成_上限到達を安定したコマンドコ�
 }
 
 #[test]
+fn test_ターミナル画面生成_上限以外のspawn失敗を従来の汎用コードへ変換する() {
+    let errors = [
+        UsecaseError::OwnerConflict,
+        UsecaseError::PtySpawn {
+            error: "openpty failed".to_string(),
+        },
+        UsecaseError::OtherSpawnFailure {
+            error: "checkpoint failed".to_string(),
+        },
+    ];
+
+    for error in errors {
+        assert_eq!(
+            TerminalCommandError::from(error).code,
+            PTY_ERROR_CODE_GENERIC
+        );
+    }
+}
+
+#[test]
 fn test_ターミナル起動性能計測_commandは匿名phaseとdurationだけを返してdrainする() {
     let _guard = crate::other::telemetry::lock_test_telemetry();
     crate::other::telemetry::reset_test_metrics();

--- a/src-tauri/src/adaptor/controller/terminal_surface_runtime.rs
+++ b/src-tauri/src/adaptor/controller/terminal_surface_runtime.rs
@@ -8,6 +8,7 @@ use crate::adaptor::protocol::terminal::{
     TerminalSurfaceStreamItemV1, TerminalSurfaceV1,
 };
 use crate::domain::terminal_surface::gateway::TerminalSurfaceEventSink;
+use crate::domain::terminal_surface::TerminalSurfaceLifecycleConfig;
 
 pub struct TerminalSurfaceRuntime {
     application: Arc<crate::usecase::terminal_surface::application::TerminalSurfaceApplication>,
@@ -51,6 +52,30 @@ impl TerminalSurfaceRuntime {
     }
 
     #[doc(hidden)]
+    pub fn new_with_data_dir_and_lifecycle_limits<R: tauri::Runtime>(
+        app: tauri::AppHandle<R>,
+        data_dir: PathBuf,
+        per_worktree_cap: usize,
+        max_panes_total: usize,
+    ) -> Self {
+        if app
+            .try_state::<crate::infrastructure::platform::app_data_dir::TestDataDir>()
+            .is_none()
+        {
+            app.manage(crate::infrastructure::platform::app_data_dir::TestDataDir(
+                data_dir,
+            ));
+        }
+        Self::compose_with_lifecycle_config(
+            app,
+            TerminalSurfaceLifecycleConfig {
+                per_worktree_cap,
+                max_panes_total,
+            },
+        )
+    }
+
+    #[doc(hidden)]
     pub fn new_with_data_dir_and_event_faults<R: tauri::Runtime>(
         app: tauri::AppHandle<R>,
         data_dir: PathBuf,
@@ -69,7 +94,7 @@ impl TerminalSurfaceRuntime {
         let event_target: Arc<dyn TerminalSurfaceEventSink> = event_hub.clone();
         let (event_sink, faults) = crate::adaptor::gateway::terminal_surface::event_fault_relay::fault_injecting_event_sink(event_target);
         (
-            Self::compose_with_event_transport(app, event_hub, event_sink),
+            Self::compose_with_event_transport(app, event_hub, event_sink, None),
             faults,
         )
     }
@@ -79,7 +104,18 @@ impl TerminalSurfaceRuntime {
             crate::adaptor::gateway::terminal_surface::event_hub::TerminalSurfaceEventHub::new(),
         );
         let event_sink: Arc<dyn TerminalSurfaceEventSink> = event_hub.clone();
-        Self::compose_with_event_transport(app, event_hub, event_sink)
+        Self::compose_with_event_transport(app, event_hub, event_sink, None)
+    }
+
+    fn compose_with_lifecycle_config<R: tauri::Runtime>(
+        app: tauri::AppHandle<R>,
+        lifecycle_config: TerminalSurfaceLifecycleConfig,
+    ) -> Self {
+        let event_hub = Arc::new(
+            crate::adaptor::gateway::terminal_surface::event_hub::TerminalSurfaceEventHub::new(),
+        );
+        let event_sink: Arc<dyn TerminalSurfaceEventSink> = event_hub.clone();
+        Self::compose_with_event_transport(app, event_hub, event_sink, Some(lifecycle_config))
     }
 
     fn compose_with_event_transport<R: tauri::Runtime>(
@@ -88,6 +124,7 @@ impl TerminalSurfaceRuntime {
             crate::adaptor::gateway::terminal_surface::event_hub::TerminalSurfaceEventHub,
         >,
         event_sink: Arc<dyn TerminalSurfaceEventSink>,
+        lifecycle_config: Option<TerminalSurfaceLifecycleConfig>,
     ) -> Self {
         let journal_enabled = !crate::other::performance_switches::terminal_performance_switches()
             .disable_terminal_journal;
@@ -96,13 +133,19 @@ impl TerminalSurfaceRuntime {
                 event_sink,
             ),
         );
-        let gateway = Arc::new(
-            crate::adaptor::gateway::terminal_surface::runtime_gateway_impl::TerminalSurfaceRuntimeGatewayFor::new_with_event_sink(
-                app,
-                activity_tap.clone(),
-                journal_enabled,
-            ),
-        );
+        let gateway = Arc::new(match lifecycle_config {
+            Some(lifecycle_config) => crate::adaptor::gateway::terminal_surface::runtime_gateway_impl::TerminalSurfaceRuntimeGatewayFor::new_with_event_sink_and_lifecycle_config(
+                    app,
+                    activity_tap.clone(),
+                    journal_enabled,
+                    lifecycle_config,
+                ),
+            None => crate::adaptor::gateway::terminal_surface::runtime_gateway_impl::TerminalSurfaceRuntimeGatewayFor::new_with_event_sink(
+                    app,
+                    activity_tap.clone(),
+                    journal_enabled,
+                ),
+        });
         Self {
             application: Arc::new(
                 crate::usecase::terminal_surface::application::TerminalSurfaceApplication::new(

--- a/src-tauri/src/adaptor/gateway/agent_session/provider_agent_terminal_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/provider_agent_terminal_gateway.rs
@@ -2,6 +2,7 @@ use crate::domain::agent_session::aggregates::ManagedPtyPresence;
 use crate::domain::agent_session::{
     ProviderAgentTerminalGateway, ProviderAgentTerminalGatewayError,
     ProviderAgentTerminalInputGateway, ProviderAgentTerminalObservationGateway,
+    ProviderAgentTerminalSpawnError,
 };
 use crate::domain::terminal_surface::{
     TerminalActivity, TerminalProcessLaunch, TerminalSurfaceOwner,
@@ -9,6 +10,21 @@ use crate::domain::terminal_surface::{
 use crate::usecase::terminal_surface::application::{
     OwnedTerminalSummaryLookup, TerminalSurfaceApplication,
 };
+use crate::usecase::terminal_surface::error::UsecaseError;
+
+fn map_spawn_error(error: UsecaseError) -> ProviderAgentTerminalSpawnError {
+    match error {
+        UsecaseError::PerWorktreeCap { worktree_path } => {
+            ProviderAgentTerminalSpawnError::PerWorktreeCap { worktree_path }
+        }
+        UsecaseError::TotalCap => ProviderAgentTerminalSpawnError::TotalCap,
+        UsecaseError::OwnerConflict => ProviderAgentTerminalSpawnError::OwnerConflict,
+        UsecaseError::PtySpawn { error } => ProviderAgentTerminalSpawnError::PtySpawn { error },
+        UsecaseError::Gateway(error) | UsecaseError::OtherSpawnFailure { error } => {
+            ProviderAgentTerminalSpawnError::OtherSpawnFailure { error }
+        }
+    }
+}
 
 impl ProviderAgentTerminalGateway for TerminalSurfaceApplication {
     fn spawn(
@@ -18,7 +34,7 @@ impl ProviderAgentTerminalGateway for TerminalSurfaceApplication {
         process: TerminalProcessLaunch,
         rows: u16,
         cols: u16,
-    ) -> Result<(), ProviderAgentTerminalGatewayError> {
+    ) -> Result<(), ProviderAgentTerminalSpawnError> {
         self.get_or_spawn_process(
             rows,
             cols,
@@ -28,7 +44,7 @@ impl ProviderAgentTerminalGateway for TerminalSurfaceApplication {
             process,
         )
         .map(|_| ())
-        .map_err(|_| ProviderAgentTerminalGatewayError::Unavailable)
+        .map_err(map_spawn_error)
     }
 
     fn presence(

--- a/src-tauri/src/adaptor/gateway/agent_session/provider_agent_terminal_gateway_test.rs
+++ b/src-tauri/src/adaptor/gateway/agent_session/provider_agent_terminal_gateway_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::adaptor::gateway::terminal_surface::event_hub::TerminalSurfaceEventHub;
 use crate::domain::agent_session::aggregates::ManagedPtyPresence;
 use crate::domain::agent_session::ProviderAgentTerminalGateway;
+use crate::domain::agent_session::ProviderAgentTerminalSpawnError;
 use crate::domain::terminal_surface::entities::TerminalSurface;
 use crate::domain::terminal_surface::gateway::TerminalSurfaceGateway;
 use crate::domain::terminal_surface::{
@@ -39,6 +40,56 @@ fn application_with(surface: Option<TerminalSurface>) -> TerminalSurfaceApplicat
         gateway.insert_surface(surface);
     }
     TerminalSurfaceApplication::new(gateway, Arc::new(TerminalSurfaceEventHub::new()))
+}
+
+#[test]
+fn test_provider_agent_terminal_spawn_error_5分類とpayloadを保持する() {
+    let cases = [
+        (
+            crate::usecase::terminal_surface::error::UsecaseError::PerWorktreeCap {
+                worktree_path: "/repo/worktree".to_string(),
+            },
+            ProviderAgentTerminalSpawnError::PerWorktreeCap {
+                worktree_path: "/repo/worktree".to_string(),
+            },
+        ),
+        (
+            crate::usecase::terminal_surface::error::UsecaseError::TotalCap,
+            ProviderAgentTerminalSpawnError::TotalCap,
+        ),
+        (
+            crate::usecase::terminal_surface::error::UsecaseError::OwnerConflict,
+            ProviderAgentTerminalSpawnError::OwnerConflict,
+        ),
+        (
+            crate::usecase::terminal_surface::error::UsecaseError::PtySpawn {
+                error: "openpty failed".to_string(),
+            },
+            ProviderAgentTerminalSpawnError::PtySpawn {
+                error: "openpty failed".to_string(),
+            },
+        ),
+        (
+            crate::usecase::terminal_surface::error::UsecaseError::OtherSpawnFailure {
+                error: "checkpoint failed".to_string(),
+            },
+            ProviderAgentTerminalSpawnError::OtherSpawnFailure {
+                error: "checkpoint failed".to_string(),
+            },
+        ),
+        (
+            crate::usecase::terminal_surface::error::UsecaseError::Gateway(
+                "runtime is shutting down".to_string(),
+            ),
+            ProviderAgentTerminalSpawnError::OtherSpawnFailure {
+                error: "runtime is shutting down".to_string(),
+            },
+        ),
+    ];
+
+    for (source, expected) in cases {
+        assert_eq!(super::map_spawn_error(source), expected);
+    }
 }
 
 #[test]

--- a/src-tauri/src/adaptor/gateway/terminal_surface/runtime_gateway_impl.rs
+++ b/src-tauri/src/adaptor/gateway/terminal_surface/runtime_gateway_impl.rs
@@ -18,7 +18,8 @@ use crate::domain::terminal_surface::gateway::{
     TerminalSurfaceGateway, TerminalSurfaceGatewayError, TerminalSurfaceRepository,
 };
 use crate::domain::terminal_surface::{
-    TerminalSurfaceCheckpoint as DomainTerminalCheckpoint, TERMINAL_SURFACE_SCROLLBACK_ROWS,
+    TerminalSurfaceCheckpoint as DomainTerminalCheckpoint, TerminalSurfaceLifecycleConfig,
+    TERMINAL_SURFACE_SCROLLBACK_ROWS,
 };
 use crate::infrastructure::terminal::checkpoint_journal::IncrementalCheckpointJournal;
 use crate::infrastructure::terminal::checkpoint_scheduler::DirtyCheckpointScheduler;
@@ -474,10 +475,26 @@ impl<R: Runtime> TerminalSurfaceRuntimeGatewayFor<R> {
         event_sink: Arc<dyn TerminalSurfaceEventSink>,
         journal_enabled: bool,
     ) -> Self {
+        Self::new_with_event_sink_and_lifecycle_config(
+            app,
+            event_sink,
+            journal_enabled,
+            TerminalSurfaceLifecycleConfig::default(),
+        )
+    }
+
+    pub(crate) fn new_with_event_sink_and_lifecycle_config(
+        app: AppHandle<R>,
+        event_sink: Arc<dyn TerminalSurfaceEventSink>,
+        journal_enabled: bool,
+        lifecycle_config: TerminalSurfaceLifecycleConfig,
+    ) -> Self {
         Self {
             app: Some(app),
             event_sink: Some(event_sink),
-            registry: Arc::new(Mutex::new(TerminalSurfaceRegistry::default())),
+            registry: Arc::new(Mutex::new(TerminalSurfaceRegistry::with_config(
+                lifecycle_config,
+            ))),
             input_ingress: Mutex::new(TerminalSurfaceInputIngressRegistry::default()),
             spawn_resolved: Condvar::new(),
             runtimes: Mutex::new(HashMap::new()),

--- a/src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/node_session_boundary.rs
@@ -5,7 +5,8 @@ use crate::domain::provider_lifecycle::ProviderKind;
 use crate::domain::workspace_tree::WorkspaceIdentity;
 use crate::usecase::agent_session::{
     AgentSessionInitialInstructionUsecase, AgentSessionInterruptUsecase, AgentSessionLaunchUsecase,
-    AgentSessionLifecycleUsecase, WorkflowAgentSessionLaunchRequest,
+    AgentSessionLaunchUsecaseError, AgentSessionLifecycleUsecase,
+    WorkflowAgentSessionLaunchRequest,
 };
 use crate::usecase::workflow::runtime_error::WorkflowRuntimeError;
 
@@ -88,6 +89,15 @@ pub(crate) struct ProviderWorkflowAgentSessionPort {
     availability: Arc<dyn ProviderAvailabilityReader>,
 }
 
+fn activation_error(
+    node_session_id: &str,
+    error: AgentSessionLaunchUsecaseError,
+) -> WorkflowRuntimeError {
+    WorkflowRuntimeError::AgentSession(format!(
+        "activate Workflow AgentSession '{node_session_id}': {error}"
+    ))
+}
+
 impl ProviderWorkflowAgentSessionPort {
     pub(crate) fn new(
         launch: Arc<AgentSessionLaunchUsecase>,
@@ -154,11 +164,7 @@ impl WorkflowAgentSessionPort for ProviderWorkflowAgentSessionPort {
         self.launch
             .activate_workflow_node(node_session_id)
             .await
-            .map_err(|error| {
-                WorkflowRuntimeError::AgentSession(format!(
-                    "activate Workflow AgentSession '{node_session_id}': {error:?}"
-                ))
-            })?;
+            .map_err(|error| activation_error(node_session_id, error))?;
         Ok(())
     }
 
@@ -246,5 +252,41 @@ impl WorkflowAgentSessionPort for ProviderWorkflowAgentSessionPort {
                     "rollback unattached Workflow AgentSession '{node_session_id}': {error:?}"
                 ))
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::agent_session::ProviderAgentTerminalSpawnError;
+
+    #[test]
+    fn test_workflow_agent_session_activation_terminal_spawn分類をcontext付きで保持する() {
+        let error = activation_error(
+            "agent-session-1",
+            AgentSessionLaunchUsecaseError::TerminalSpawn(
+                ProviderAgentTerminalSpawnError::PtySpawn {
+                    error: "openpty failed".to_string(),
+                },
+            ),
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "activate Workflow AgentSession 'agent-session-1': kind=pty_spawn error=openpty failed"
+        );
+    }
+
+    #[test]
+    fn test_workflow_agent_session_activation_terminal以外の既存表現を維持する() {
+        let error = activation_error(
+            "agent-session-1",
+            AgentSessionLaunchUsecaseError::LaunchUnavailable,
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "activate Workflow AgentSession 'agent-session-1': LaunchUnavailable"
+        );
     }
 }

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -108,10 +108,12 @@ pub fn run() -> i32 {
         }
     };
     if let Ok(data_dir) = resolve_data_dir() {
-        let _ = crate::infrastructure::local_log::init(
+        if let Err(error) = crate::infrastructure::local_log::init(
             &data_dir,
             crate::infrastructure::local_log::LocalLogProcess::Cli,
-        );
+        ) {
+            eprintln!("{error}");
+        }
     }
     let result =
         match cli.command {

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -107,6 +107,12 @@ pub fn run() -> i32 {
             return error.exit_code();
         }
     };
+    if let Ok(data_dir) = resolve_data_dir() {
+        let _ = crate::infrastructure::local_log::init(
+            &data_dir,
+            crate::infrastructure::local_log::LocalLogProcess::Cli,
+        );
+    }
     let result =
         match cli.command {
             TopCommand::Workflow { command } => resolve_data_dir()
@@ -141,7 +147,9 @@ pub fn run() -> i32 {
                 HookSubcommand::Receive { provider } => hook::cmd_receive(provider),
             },
         };
-    cli_result_exit_code(result)
+    let exit_code = cli_result_exit_code(result);
+    log::logger().flush();
+    exit_code
 }
 
 #[cfg(test)]

--- a/src-tauri/src/domain/agent_session/mod.rs
+++ b/src-tauri/src/domain/agent_session/mod.rs
@@ -31,4 +31,5 @@ pub(crate) use provider_session_ownership::{
 pub(crate) use provider_terminal_gateway::{
     ProviderAgentTerminalGateway, ProviderAgentTerminalGatewayError,
     ProviderAgentTerminalInputGateway, ProviderAgentTerminalObservationGateway,
+    ProviderAgentTerminalSpawnError,
 };

--- a/src-tauri/src/domain/agent_session/provider_terminal_gateway.rs
+++ b/src-tauri/src/domain/agent_session/provider_terminal_gateway.rs
@@ -8,6 +8,36 @@ pub(crate) enum ProviderAgentTerminalGatewayError {
     Unavailable,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProviderAgentTerminalSpawnError {
+    PerWorktreeCap { worktree_path: String },
+    TotalCap,
+    OwnerConflict,
+    PtySpawn { error: String },
+    OtherSpawnFailure { error: String },
+}
+
+impl std::fmt::Display for ProviderAgentTerminalSpawnError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PerWorktreeCap { worktree_path } => {
+                write!(
+                    formatter,
+                    "kind=per_worktree_cap worktree_path={worktree_path}"
+                )
+            }
+            Self::TotalCap => formatter.write_str("kind=total_cap"),
+            Self::OwnerConflict => formatter.write_str("kind=owner_conflict"),
+            Self::PtySpawn { error } => write!(formatter, "kind=pty_spawn error={error}"),
+            Self::OtherSpawnFailure { error } => {
+                write!(formatter, "kind=other_spawn_failure error={error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProviderAgentTerminalSpawnError {}
+
 pub(crate) trait ProviderAgentTerminalGateway: Send + Sync {
     fn spawn(
         &self,
@@ -16,7 +46,7 @@ pub(crate) trait ProviderAgentTerminalGateway: Send + Sync {
         process: TerminalProcessLaunch,
         rows: u16,
         cols: u16,
-    ) -> Result<(), ProviderAgentTerminalGatewayError>;
+    ) -> Result<(), ProviderAgentTerminalSpawnError>;
 
     fn presence(
         &self,

--- a/src-tauri/src/domain/terminal_surface/entities/terminal_surface_registry.rs
+++ b/src-tauri/src/domain/terminal_surface/entities/terminal_surface_registry.rs
@@ -39,7 +39,6 @@ impl Default for TerminalSurfaceRegistry {
 }
 
 impl TerminalSurfaceRegistry {
-    #[cfg(test)]
     pub fn with_config(config: TerminalSurfaceLifecycleConfig) -> Self {
         Self {
             config,

--- a/src-tauri/src/infrastructure/local_log.rs
+++ b/src-tauri/src/infrastructure/local_log.rs
@@ -1,0 +1,351 @@
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const LOG_DIRECTORY_NAME: &str = "logs";
+const ACTIVE_FILE_NAME: &str = "releash.log";
+const LOCK_FILE_NAME: &str = "releash.lock";
+const MAX_FILE_BYTES: u64 = 10 * 1024 * 1024;
+const MAX_FILE_COUNT: usize = 5;
+const QUEUE_CAPACITY: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalLogProcess {
+    Gui,
+    Cli,
+}
+
+impl LocalLogProcess {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Gui => "gui",
+            Self::Cli => "cli",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum LocalLogInitError {
+    Io(io::Error),
+    AlreadyInitialized,
+}
+
+impl std::fmt::Display for LocalLogInitError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "local log initialization failed: {error}"),
+            Self::AlreadyInitialized => formatter.write_str("local logger is already initialized"),
+        }
+    }
+}
+
+impl std::error::Error for LocalLogInitError {}
+
+impl From<io::Error> for LocalLogInitError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+pub(crate) fn init(data_dir: &Path, process: LocalLogProcess) -> Result<(), LocalLogInitError> {
+    init_with_limits(data_dir, process, MAX_FILE_BYTES, MAX_FILE_COUNT)
+}
+
+fn init_with_limits(
+    data_dir: &Path,
+    process: LocalLogProcess,
+    max_file_bytes: u64,
+    max_file_count: usize,
+) -> Result<(), LocalLogInitError> {
+    let logger = LocalFileLogger::new(data_dir, process, max_file_bytes, max_file_count)?;
+    let logger = Box::leak(Box::new(logger));
+    log::set_logger(logger).map_err(|_| LocalLogInitError::AlreadyInitialized)?;
+    log::set_max_level(log::LevelFilter::Warn);
+    Ok(())
+}
+
+struct PendingLogRecord {
+    timestamp_unix_ms: u64,
+    level: log::Level,
+    target: String,
+    message: String,
+    dropped_records_before: u64,
+}
+
+impl PendingLogRecord {
+    fn new(level: log::Level, target: &str, message: String) -> Self {
+        Self {
+            timestamp_unix_ms: timestamp_unix_ms(),
+            level,
+            target: target.to_string(),
+            message,
+            dropped_records_before: 0,
+        }
+    }
+
+    fn dropped_notice(dropped_records: u64) -> Self {
+        Self {
+            timestamp_unix_ms: timestamp_unix_ms(),
+            level: log::Level::Warn,
+            target: module_path!().to_string(),
+            message: format!("Local log records dropped: count={dropped_records}"),
+            dropped_records_before: dropped_records,
+        }
+    }
+}
+
+fn timestamp_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| {
+            u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+        })
+}
+
+enum WriterCommand {
+    Record(PendingLogRecord),
+    Flush(SyncSender<()>),
+}
+
+struct LocalFileLogger {
+    sender: SyncSender<WriterCommand>,
+    dropped_records: AtomicU64,
+}
+
+impl LocalFileLogger {
+    fn new(
+        data_dir: &Path,
+        process: LocalLogProcess,
+        max_file_bytes: u64,
+        max_file_count: usize,
+    ) -> Result<Self, io::Error> {
+        Self::new_with_queue_capacity(
+            data_dir,
+            process,
+            max_file_bytes,
+            max_file_count,
+            QUEUE_CAPACITY,
+        )
+    }
+
+    fn new_with_queue_capacity(
+        data_dir: &Path,
+        process: LocalLogProcess,
+        max_file_bytes: u64,
+        max_file_count: usize,
+        queue_capacity: usize,
+    ) -> Result<Self, io::Error> {
+        let (sender, receiver) = mpsc::sync_channel(queue_capacity);
+        let writer = LocalLogWriter::new(data_dir, process, max_file_bytes, max_file_count);
+        std::thread::Builder::new()
+            .name("releash-local-log-writer".to_string())
+            .spawn(move || writer.run(receiver))?;
+        Ok(Self {
+            sender,
+            dropped_records: AtomicU64::new(0),
+        })
+    }
+
+    fn enqueue(&self, mut record: PendingLogRecord) {
+        record.dropped_records_before = self.dropped_records.swap(0, Ordering::Relaxed);
+        match self.sender.try_send(WriterCommand::Record(record)) {
+            Ok(()) => {}
+            Err(TrySendError::Full(WriterCommand::Record(record)))
+            | Err(TrySendError::Disconnected(WriterCommand::Record(record))) => {
+                self.add_dropped(record.dropped_records_before.saturating_add(1));
+            }
+            Err(TrySendError::Full(WriterCommand::Flush(_)))
+            | Err(TrySendError::Disconnected(WriterCommand::Flush(_))) => unreachable!(),
+        }
+    }
+
+    fn add_dropped(&self, count: u64) {
+        let _ =
+            self.dropped_records
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                    Some(current.saturating_add(count))
+                });
+    }
+
+    fn drain_dropped_notice(&self) -> bool {
+        let dropped_records = self.dropped_records.swap(0, Ordering::Relaxed);
+        if dropped_records == 0 {
+            return true;
+        }
+        if self
+            .sender
+            .send(WriterCommand::Record(PendingLogRecord::dropped_notice(
+                dropped_records,
+            )))
+            .is_err()
+        {
+            self.add_dropped(dropped_records);
+            return false;
+        }
+        true
+    }
+}
+
+impl log::Log for LocalFileLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.level() <= log::Level::Warn
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if self.enabled(record.metadata()) {
+            self.enqueue(PendingLogRecord::new(
+                record.level(),
+                record.target(),
+                record.args().to_string(),
+            ));
+        }
+    }
+
+    fn flush(&self) {
+        if !self.drain_dropped_notice() {
+            return;
+        }
+        let (completed, completion) = mpsc::sync_channel(0);
+        if self.sender.send(WriterCommand::Flush(completed)).is_ok() {
+            let _ = completion.recv();
+        }
+    }
+}
+
+struct LocalLogWriter {
+    directory: PathBuf,
+    directory_initialized: bool,
+    process: LocalLogProcess,
+    max_file_bytes: u64,
+    max_file_count: usize,
+}
+
+impl LocalLogWriter {
+    fn new(
+        data_dir: &Path,
+        process: LocalLogProcess,
+        max_file_bytes: u64,
+        max_file_count: usize,
+    ) -> Self {
+        Self {
+            directory: data_dir.join(LOG_DIRECTORY_NAME),
+            directory_initialized: false,
+            process,
+            max_file_bytes,
+            max_file_count: max_file_count.max(1),
+        }
+    }
+
+    fn run(mut self, receiver: Receiver<WriterCommand>) {
+        while let Ok(command) = receiver.recv() {
+            match command {
+                WriterCommand::Record(record) => {
+                    let _ = self.append(&record);
+                }
+                WriterCommand::Flush(completed) => {
+                    let _ = completed.send(());
+                }
+            }
+        }
+    }
+
+    fn active_path(&self) -> PathBuf {
+        self.directory.join(ACTIVE_FILE_NAME)
+    }
+
+    fn generation_path(&self, generation: usize) -> PathBuf {
+        self.directory.join(format!("releash.{generation}.log"))
+    }
+
+    fn lock_path(&self) -> PathBuf {
+        self.directory.join(LOCK_FILE_NAME)
+    }
+
+    fn append(&mut self, record: &PendingLogRecord) -> Result<(), io::Error> {
+        let record = self.serialize(record)?;
+        if !self.directory_initialized {
+            fs::create_dir_all(&self.directory)?;
+            self.directory_initialized = true;
+        }
+        let lock = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(self.lock_path())?;
+        fs2::FileExt::lock_exclusive(&lock)?;
+        let write_result = self.append_locked(&record);
+        let unlock_result = fs2::FileExt::unlock(&lock);
+        write_result.and(unlock_result)
+    }
+
+    fn serialize(&self, record: &PendingLogRecord) -> Result<Vec<u8>, io::Error> {
+        let mut serialized = serde_json::json!({
+            "timestamp_unix_ms": record.timestamp_unix_ms,
+            "level": record.level.as_str(),
+            "target": record.target,
+            "message": record.message,
+            "process": self.process.as_str(),
+        });
+        if record.dropped_records_before > 0 {
+            serialized["dropped_records_before"] =
+                serde_json::Value::from(record.dropped_records_before);
+        }
+        let mut serialized = serde_json::to_vec(&serialized).map_err(io::Error::other)?;
+        serialized.push(b'\n');
+        Ok(serialized)
+    }
+
+    fn append_locked(&self, record: &[u8]) -> Result<(), io::Error> {
+        let active_path = self.active_path();
+        if self.max_file_count == 1
+            && fs::metadata(&active_path).is_ok_and(|metadata| metadata.len() > self.max_file_bytes)
+        {
+            fs::remove_file(&active_path)?;
+        }
+
+        let mut active = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&active_path)?;
+        active.write_all(record)?;
+        active.flush()?;
+        let active_length = active.metadata()?.len();
+        drop(active);
+
+        if self.max_file_count > 1 && active_length > self.max_file_bytes {
+            self.rotate_locked()?;
+        }
+        Ok(())
+    }
+
+    fn rotate_locked(&self) -> Result<(), io::Error> {
+        let active_path = self.active_path();
+        for generation in (1..self.max_file_count).rev() {
+            let source = if generation == 1 {
+                active_path.clone()
+            } else {
+                self.generation_path(generation - 1)
+            };
+            let destination = self.generation_path(generation);
+            match fs::remove_file(&destination) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            match fs::rename(source, destination) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "local_log_test.rs"]
+mod local_log_tests;

--- a/src-tauri/src/infrastructure/local_log_test.rs
+++ b/src-tauri/src/infrastructure/local_log_test.rs
@@ -1,0 +1,472 @@
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+use opentelemetry::logs::AnyValue;
+use opentelemetry_sdk::logs::{InMemoryLogExporter, SdkLogRecord, SdkLoggerProvider};
+
+use super::*;
+
+const CHILD_TEST_NAME: &str =
+    "infrastructure::local_log::local_log_tests::test_local_log_child_writer";
+const CONFIGURATION_CHILD_TEST_NAME: &str =
+    "infrastructure::local_log::local_log_tests::test_local_log_file_only構成_child";
+const CONFIGURATION_CHILD_SUCCESS_MARKER: &str = "releash-local-log-configuration-test-passed";
+const TEST_MAX_FILE_BYTES: u64 = 256;
+
+fn serialized_record_with_size(size: usize) -> Vec<u8> {
+    let serialize = |message: &str| {
+        let mut record = serde_json::to_vec(&serde_json::json!({
+            "timestamp_unix_ms": 0,
+            "level": "WARN",
+            "target": "local_log_test",
+            "message": message,
+            "process": "gui",
+        }))
+        .unwrap();
+        record.push(b'\n');
+        record
+    };
+    let empty_record_size = serialize("").len();
+    assert!(size >= empty_record_size);
+    let record = serialize(&"x".repeat(size - empty_record_size));
+    assert_eq!(record.len(), size);
+    record
+}
+
+fn log_files(data_dir: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = fs::read_dir(data_dir.join(LOG_DIRECTORY_NAME))
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name == ACTIVE_FILE_NAME
+                        || (name.starts_with("releash.") && name.ends_with(".log"))
+                })
+        })
+        .collect();
+    files.sort();
+    files
+}
+
+fn assert_log_file_count_bound(data_dir: &Path) -> Vec<PathBuf> {
+    let files = log_files(data_dir);
+    assert!(!files.is_empty());
+    assert!(files.len() <= MAX_FILE_COUNT);
+    files
+}
+
+fn records(data_dir: &Path) -> Vec<serde_json::Value> {
+    log_files(data_dir)
+        .into_iter()
+        .flat_map(|path| {
+            fs::read_to_string(path)
+                .unwrap()
+                .lines()
+                .map(|line| serde_json::from_str(line).unwrap())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn writer(data_dir: &Path) -> LocalLogWriter {
+    fs::create_dir_all(data_dir.join(LOG_DIRECTORY_NAME)).unwrap();
+    LocalLogWriter::new(
+        data_dir,
+        LocalLogProcess::Gui,
+        TEST_MAX_FILE_BYTES,
+        MAX_FILE_COUNT,
+    )
+}
+
+fn child_writer(
+    data_dir: &Path,
+    process: LocalLogProcess,
+    writer: &str,
+    count: usize,
+    max_file_bytes: u64,
+) -> Child {
+    Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg(CHILD_TEST_NAME)
+        .arg("--ignored")
+        .env("RELEASH_LOCAL_LOG_TEST_DIR", data_dir)
+        .env("RELEASH_LOCAL_LOG_TEST_PROCESS", process.as_str())
+        .env("RELEASH_LOCAL_LOG_TEST_WRITER", writer)
+        .env("RELEASH_LOCAL_LOG_TEST_COUNT", count.to_string())
+        .env(
+            "RELEASH_LOCAL_LOG_TEST_MAX_BYTES",
+            max_file_bytes.to_string(),
+        )
+        .spawn()
+        .unwrap()
+}
+
+fn exported_body(record: &SdkLogRecord) -> Option<String> {
+    record.body().map(|value| match value {
+        AnyValue::String(value) => value.to_string(),
+        _ => format!("{value:?}"),
+    })
+}
+
+#[test]
+#[ignore]
+fn test_local_log_child_writer() {
+    let Some(data_dir) = std::env::var_os("RELEASH_LOCAL_LOG_TEST_DIR") else {
+        return;
+    };
+    let process = match std::env::var("RELEASH_LOCAL_LOG_TEST_PROCESS")
+        .unwrap()
+        .as_str()
+    {
+        "gui" => LocalLogProcess::Gui,
+        "cli" => LocalLogProcess::Cli,
+        value => panic!("unexpected process kind: {value}"),
+    };
+    let writer = std::env::var("RELEASH_LOCAL_LOG_TEST_WRITER").unwrap();
+    let count = std::env::var("RELEASH_LOCAL_LOG_TEST_COUNT")
+        .unwrap()
+        .parse::<usize>()
+        .unwrap();
+    let max_file_bytes = std::env::var("RELEASH_LOCAL_LOG_TEST_MAX_BYTES")
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
+    init_with_limits(
+        Path::new(&data_dir),
+        process,
+        max_file_bytes,
+        MAX_FILE_COUNT,
+    )
+    .unwrap();
+
+    log::info!(target: "local_log_test", "writer={writer} info must not be written");
+    for index in 0..count {
+        log::warn!(
+            target: "local_log_test",
+            "writer={writer} index={index} payload=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        );
+    }
+    log::error!(target: "local_log_test", "writer={writer} terminal error");
+    log::logger().flush();
+}
+
+#[test]
+#[ignore]
+fn test_local_log_file_only構成_child() {
+    let Some(data_dir) = std::env::var_os("RELEASH_LOCAL_LOG_CONFIGURATION_TEST_DIR") else {
+        return;
+    };
+    let exporter = InMemoryLogExporter::default();
+    let provider = SdkLoggerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    crate::infrastructure::telemetry::crash::init_crash_reporting(
+        Some(provider.clone()),
+        true,
+        true,
+    );
+    init_with_limits(
+        Path::new(&data_dir),
+        LocalLogProcess::Gui,
+        1_024 * 1_024,
+        MAX_FILE_COUNT,
+    )
+    .unwrap();
+
+    log::warn!(target: "local_log_configuration_test", "local-file-only-marker");
+    crate::infrastructure::telemetry::crash::report_error(
+        "rust",
+        "local-log-configuration-test",
+        "crash-otlp-only-marker",
+        None,
+    );
+    log::logger().flush();
+    provider.force_flush().unwrap();
+
+    let local_records = records(Path::new(&data_dir));
+    assert!(local_records
+        .iter()
+        .any(|record| record["message"] == "local-file-only-marker"));
+    assert!(!local_records
+        .iter()
+        .any(|record| record["message"] == "crash-otlp-only-marker"));
+    let exported_bodies: Vec<String> = exporter
+        .get_emitted_logs()
+        .unwrap()
+        .iter()
+        .filter_map(|log| exported_body(&log.record))
+        .collect();
+    assert!(exported_bodies
+        .iter()
+        .any(|body| body == "crash-otlp-only-marker"));
+    assert!(!exported_bodies
+        .iter()
+        .any(|body| body == "local-file-only-marker"));
+    println!("{CONFIGURATION_CHILD_SUCCESS_MARKER}");
+}
+
+#[test]
+fn test_local_log_file_only構成では通常logをfileだけへ送りcrash_logだけをotlpへ送る() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+
+    // When
+    let output = Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg(CONFIGURATION_CHILD_TEST_NAME)
+        .arg("--ignored")
+        .arg("--nocapture")
+        .env("RELEASH_LOCAL_LOG_CONFIGURATION_TEST_DIR", directory.path())
+        .output()
+        .unwrap();
+
+    // Then
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "configuration child failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line == CONFIGURATION_CHILD_SUCCESS_MARKER),
+        "configuration child success marker is missing\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn test_local_log_初期化とflushだけではdata_dirを作らない() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let missing_data_dir = directory.path().join("missing");
+
+    // When
+    let logger = LocalFileLogger::new(
+        &missing_data_dir,
+        LocalLogProcess::Cli,
+        TEST_MAX_FILE_BYTES,
+        MAX_FILE_COUNT,
+    )
+    .unwrap();
+    log::Log::flush(&logger);
+
+    // Then
+    assert!(!missing_data_dir.exists());
+}
+
+#[test]
+fn test_local_log_process間lock保持中もlog呼び出しをブロックせず破棄件数を残す() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let logs_directory = directory.path().join(LOG_DIRECTORY_NAME);
+    fs::create_dir_all(&logs_directory).unwrap();
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(logs_directory.join(LOCK_FILE_NAME))
+        .unwrap();
+    fs2::FileExt::lock_exclusive(&lock).unwrap();
+    let logger = Arc::new(
+        LocalFileLogger::new_with_queue_capacity(
+            directory.path(),
+            LocalLogProcess::Gui,
+            1_024 * 1_024,
+            MAX_FILE_COUNT,
+            1,
+        )
+        .unwrap(),
+    );
+    let caller = Arc::clone(&logger);
+    let (completed, completion) = mpsc::sync_channel(0);
+
+    // When
+    std::thread::spawn(move || {
+        let record = log::Record::builder()
+            .args(format_args!("writer lock is held"))
+            .level(log::Level::Error)
+            .target("local_log_test")
+            .build();
+        log::Log::log(caller.as_ref(), &record);
+        completed.send(()).unwrap();
+    });
+
+    // Then
+    completion
+        .recv_timeout(Duration::from_secs(1))
+        .expect("log caller must not wait for the process lock");
+    for _ in 0..10_000 {
+        let record = log::Record::builder()
+            .args(format_args!("queue pressure"))
+            .level(log::Level::Warn)
+            .target("local_log_test")
+            .build();
+        log::Log::log(logger.as_ref(), &record);
+    }
+    assert!(logger.dropped_records.load(Ordering::Relaxed) > 0);
+
+    fs2::FileExt::unlock(&lock).unwrap();
+    log::Log::flush(logger.as_ref());
+    assert!(records(directory.path()).iter().any(|record| {
+        record["dropped_records_before"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    }));
+}
+
+#[test]
+fn test_local_log_guiとcliのwarningとerrorをprocess終了後も共通fileから参照できる() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+
+    // When
+    let mut gui = child_writer(
+        directory.path(),
+        LocalLogProcess::Gui,
+        "gui",
+        1,
+        1_024 * 1_024,
+    );
+    assert!(gui.wait().unwrap().success());
+    let mut cli = child_writer(
+        directory.path(),
+        LocalLogProcess::Cli,
+        "cli",
+        1,
+        1_024 * 1_024,
+    );
+    assert!(cli.wait().unwrap().success());
+
+    // Then
+    let records = records(directory.path());
+    assert_eq!(records.len(), 4);
+    for record in &records {
+        assert!(record["timestamp_unix_ms"].as_u64().is_some());
+        assert!(matches!(record["level"].as_str(), Some("WARN" | "ERROR")));
+        assert_eq!(record["target"], "local_log_test");
+        assert!(record["message"].as_str().unwrap().contains("writer="));
+        assert!(matches!(record["process"].as_str(), Some("gui" | "cli")));
+    }
+    assert!(records.iter().any(|record| record["process"] == "gui"));
+    assert!(records.iter().any(|record| record["process"] == "cli"));
+    assert!(!records.iter().any(|record| record["message"]
+        .as_str()
+        .unwrap()
+        .contains("info must not")));
+}
+
+#[test]
+fn test_local_log_guiと複数cliの同時rotationでrecordを混線させず最大5fileを保持する() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let mut children = vec![
+        child_writer(directory.path(), LocalLogProcess::Gui, "gui", 80, 512),
+        child_writer(directory.path(), LocalLogProcess::Cli, "cli-1", 80, 512),
+        child_writer(directory.path(), LocalLogProcess::Cli, "cli-2", 80, 512),
+    ];
+
+    // When
+    for child in &mut children {
+        assert!(child.wait().unwrap().success());
+    }
+
+    // Then
+    let files = assert_log_file_count_bound(directory.path());
+    assert!(files.len() >= MAX_FILE_COUNT - 1);
+    for record in records(directory.path()) {
+        assert_eq!(record["target"], "local_log_test");
+        let message = record["message"].as_str().unwrap();
+        assert!(message.starts_with("writer="));
+        assert!(message.contains(" index=") || message.ends_with(" terminal error"));
+        assert!(matches!(record["process"].as_str(), Some("gui" | "cli")));
+    }
+}
+
+#[test]
+fn test_local_log_空activeへ上限ちょうどのrecordを書いてrotateしない() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let writer = writer(directory.path());
+    let record = serialized_record_with_size(usize::try_from(TEST_MAX_FILE_BYTES).unwrap());
+
+    // When
+    writer.append_locked(&record).unwrap();
+
+    // Then
+    let files = assert_log_file_count_bound(directory.path());
+    assert_eq!(files, vec![writer.active_path()]);
+    assert_eq!(fs::metadata(&files[0]).unwrap().len(), TEST_MAX_FILE_BYTES);
+    assert_eq!(records(directory.path()).len(), 1);
+}
+
+#[test]
+fn test_local_log_空activeへの上限超過recordを分割せず1つのjson行として保持する() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let writer = writer(directory.path());
+    let record_size = usize::try_from(TEST_MAX_FILE_BYTES).unwrap() * (MAX_FILE_COUNT + 2) + 1;
+    let record = serialized_record_with_size(record_size);
+
+    // When
+    writer.append_locked(&record).unwrap();
+
+    // Then
+    let files = assert_log_file_count_bound(directory.path());
+    assert_eq!(files, vec![writer.generation_path(1)]);
+    assert_eq!(fs::metadata(&files[0]).unwrap().len(), record_size as u64);
+    assert_eq!(records(directory.path()).len(), 1);
+}
+
+#[test]
+fn test_local_log_既存record後の上限ちょうどのrecordを同じfileへ書いてからrotateする() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let writer = writer(directory.path());
+    let existing_record = serialized_record_with_size(128);
+    writer.append_locked(&existing_record).unwrap();
+    let record = serialized_record_with_size(usize::try_from(TEST_MAX_FILE_BYTES).unwrap());
+
+    // When
+    writer.append_locked(&record).unwrap();
+
+    // Then
+    let files = assert_log_file_count_bound(directory.path());
+    assert_eq!(files, vec![writer.generation_path(1)]);
+    assert_eq!(
+        fs::metadata(&files[0]).unwrap().len(),
+        128 + TEST_MAX_FILE_BYTES
+    );
+    assert_eq!(records(directory.path()).len(), 2);
+}
+
+#[test]
+fn test_local_log_既存record後の上限超過recordも分割せず世代上限を守る() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let writer = writer(directory.path());
+    writer
+        .append_locked(&serialized_record_with_size(128))
+        .unwrap();
+    let record_size = usize::try_from(TEST_MAX_FILE_BYTES).unwrap() * (MAX_FILE_COUNT + 2) + 1;
+    let record = serialized_record_with_size(record_size);
+
+    // When
+    writer.append_locked(&record).unwrap();
+
+    // Then
+    let files = assert_log_file_count_bound(directory.path());
+    assert_eq!(files, vec![writer.generation_path(1)]);
+    assert_eq!(
+        fs::metadata(&files[0]).unwrap().len(),
+        128 + record_size as u64
+    );
+    assert_eq!(records(directory.path()).len(), 2);
+}

--- a/src-tauri/src/infrastructure/mod.rs
+++ b/src-tauri/src/infrastructure/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod comment;
 pub(crate) mod file_watcher;
 pub mod git;
 pub(crate) mod local_api;
+pub(crate) mod local_log;
 pub(crate) mod lua;
 pub(crate) mod platform;
 pub(crate) mod process;

--- a/src-tauri/src/infrastructure/platform/window_lifecycle.rs
+++ b/src-tauri/src/infrastructure/platform/window_lifecycle.rs
@@ -98,7 +98,14 @@ fn show_and_focus_active_surface(
     true
 }
 
+fn flush_local_log_on_exit(event: &tauri::RunEvent, flush: impl FnOnce()) {
+    if matches!(event, tauri::RunEvent::Exit) {
+        flush();
+    }
+}
+
 pub fn handle_run_event(app_handle: &tauri::AppHandle, event: tauri::RunEvent) {
+    flush_local_log_on_exit(&event, || log::logger().flush());
     match event {
         tauri::RunEvent::WindowEvent {
             event: tauri::WindowEvent::CloseRequested { api, .. },
@@ -158,12 +165,26 @@ pub fn handle_run_event(app_handle: &tauri::AppHandle, event: tauri::RunEvent) {
 #[cfg(test)]
 mod native_exit_tests {
     use super::{
-        active_window_label, handle_native_exit_requested, native_exit_intent, NativeExitRoute,
-        NORMAL_WINDOW_LABEL, STARTUP_FAILURE_WINDOW_LABEL,
+        active_window_label, flush_local_log_on_exit, handle_native_exit_requested,
+        native_exit_intent, NativeExitRoute, NORMAL_WINDOW_LABEL, STARTUP_FAILURE_WINDOW_LABEL,
     };
     use crate::usecase::shutdown_coordinator::ApplicationQuitIntent;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+
+    #[test]
+    fn exit_event_flushes_local_log_only_at_process_exit() {
+        let flushes = AtomicUsize::new(0);
+        flush_local_log_on_exit(&tauri::RunEvent::Ready, || {
+            flushes.fetch_add(1, Ordering::SeqCst);
+        });
+        assert_eq!(flushes.load(Ordering::SeqCst), 0);
+
+        flush_local_log_on_exit(&tauri::RunEvent::Exit, || {
+            flushes.fetch_add(1, Ordering::SeqCst);
+        });
+        assert_eq!(flushes.load(Ordering::SeqCst), 1);
+    }
 
     #[test]
     fn native_exit_preserves_signed_code() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -602,12 +602,6 @@ where
 pub fn run() {
     let startup_started = Instant::now();
     other::telemetry::set_startup_origin(startup_started);
-    if let Ok(aliases) = infrastructure::platform::path_aliases::PathAliases::from_runtime(None) {
-        let _ = infrastructure::local_log::init(
-            &aliases.releash().data_dir,
-            infrastructure::local_log::LocalLogProcess::Gui,
-        );
-    }
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     let provider_initial_search_path =
@@ -639,6 +633,15 @@ pub fn run() {
         .plugin(tauri_plugin_wdio::init())
         .plugin(tauri_plugin_wdio_webdriver::init());
     let builder = builder.setup(move |app| {
+            // data dir 解決を Tauri 側の 1 経路へ統一する。AppHandle を要するため setup 冒頭で登録する。
+            if let Ok(data_dir) =
+                infrastructure::platform::app_data_dir::resolve_data_dir(app.handle())
+            {
+                let _ = infrastructure::local_log::init(
+                    &data_dir,
+                    infrastructure::local_log::LocalLogProcess::Gui,
+                );
+            }
             let failure_exit: Arc<
                 dyn usecase::application_startup::ProcessLocalExitPort,
             > = Arc::new(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -602,6 +602,12 @@ where
 pub fn run() {
     let startup_started = Instant::now();
     other::telemetry::set_startup_origin(startup_started);
+    if let Ok(aliases) = infrastructure::platform::path_aliases::PathAliases::from_runtime(None) {
+        let _ = infrastructure::local_log::init(
+            &aliases.releash().data_dir,
+            infrastructure::local_log::LocalLogProcess::Gui,
+        );
+    }
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     let provider_initial_search_path =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -637,10 +637,12 @@ pub fn run() {
             if let Ok(data_dir) =
                 infrastructure::platform::app_data_dir::resolve_data_dir(app.handle())
             {
-                let _ = infrastructure::local_log::init(
+                if let Err(error) = infrastructure::local_log::init(
                     &data_dir,
                     infrastructure::local_log::LocalLogProcess::Gui,
-                );
+                ) {
+                    eprintln!("{error}");
+                }
             }
             let failure_exit: Arc<
                 dyn usecase::application_startup::ProcessLocalExitPort,

--- a/src-tauri/src/usecase/agent_session/agent_session_launch.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_launch.rs
@@ -10,8 +10,8 @@ use crate::domain::agent_session::aggregates::{
 use crate::domain::agent_session::repository::VersionedAgentSession;
 use crate::domain::agent_session::{
     AgentSessionHistoryGateway, AgentSessionHistoryGatewayError, ProviderAgentLaunchGateway,
-    ProviderAgentLaunchGatewayError, ProviderAgentTerminalGateway, ProviderAvailabilityReader,
-    ProviderSessionLaunch,
+    ProviderAgentLaunchGatewayError, ProviderAgentTerminalGateway, ProviderAgentTerminalSpawnError,
+    ProviderAvailabilityReader, ProviderSessionLaunch,
 };
 use crate::domain::provider_lifecycle::{
     ArmedProviderLifecycle, ProviderKind, ProviderLifecycleScope, ProviderLifecycleSlotId,
@@ -67,7 +67,7 @@ pub(crate) enum AgentSessionHistoryResumeOutcome {
     Paused(VersionedAgentSession),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AgentSessionLaunchUsecaseError {
     ProviderUnavailable,
     InvalidInput,
@@ -75,8 +75,20 @@ pub(crate) enum AgentSessionLaunchUsecaseError {
     StorageUnavailable,
     LaunchUnavailable,
     TerminalUnavailable,
+    TerminalSpawn(ProviderAgentTerminalSpawnError),
     Corrupt,
 }
+
+impl std::fmt::Display for AgentSessionLaunchUsecaseError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TerminalSpawn(error) => error.fmt(formatter),
+            _ => write!(formatter, "{self:?}"),
+        }
+    }
+}
+
+impl std::error::Error for AgentSessionLaunchUsecaseError {}
 
 impl From<ProviderLifecycleUsecaseError> for AgentSessionLaunchUsecaseError {
     fn from(error: ProviderLifecycleUsecaseError) -> Self {
@@ -596,20 +608,17 @@ impl AgentSessionLaunchUsecase {
             executable: _,
         } = durable;
         let initial_hook_warning = prepared.initial_hook_warning();
-        if self
-            .terminal
-            .spawn(
-                created.session().terminal_surface_owner(),
-                created.session().worktree_path(),
-                prepared.into_process(),
-                rows,
-                cols,
-            )
-            .is_err()
-        {
+        if let Err(error) = self.terminal.spawn(
+            created.session().terminal_surface_owner(),
+            created.session().worktree_path(),
+            prepared.into_process(),
+            rows,
+            cols,
+        ) {
+            record_terminal_spawn_failure(created.session().id(), &error);
             self.rollback_failed_new_launch_preserving_cause(&created, &armed, &caller_request_id)
                 .await;
-            return Err(AgentSessionLaunchUsecaseError::TerminalUnavailable);
+            return Err(AgentSessionLaunchUsecaseError::TerminalSpawn(error));
         }
         self.record_hook_launch(
             created.session().provider(),
@@ -704,17 +713,14 @@ impl AgentSessionLaunchUsecase {
             }
         };
         let initial_hook_warning = prepared.initial_hook_warning();
-        if self
-            .terminal
-            .spawn(
-                associated.session().terminal_surface_owner(),
-                associated.session().worktree_path(),
-                prepared.into_process(),
-                request.rows,
-                request.cols,
-            )
-            .is_err()
-        {
+        if let Err(error) = self.terminal.spawn(
+            associated.session().terminal_surface_owner(),
+            associated.session().worktree_path(),
+            prepared.into_process(),
+            request.rows,
+            request.cols,
+        ) {
+            record_terminal_spawn_failure(&agent_session_id, &error);
             self.cleanup_failed_history_resume(&request, &agent_session_id, &armed)
                 .await?;
             return self.pause_history_resume(&request, &agent_session_id).await;
@@ -879,6 +885,10 @@ impl AgentSessionLaunchUsecase {
         tasks.retain(|task| !task.is_finished());
         tasks.push(task);
     }
+}
+
+fn record_terminal_spawn_failure(agent_session_id: &str, error: &ProviderAgentTerminalSpawnError) {
+    log::error!("AgentSession terminal spawn failed agent_session_id={agent_session_id} {error}");
 }
 
 async fn wait_for_activation(mut completion: watch::Receiver<bool>) -> bool {

--- a/src-tauri/src/usecase/agent_session/agent_session_lifecycle_test.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_lifecycle_test.rs
@@ -17,8 +17,8 @@ use crate::domain::agent_session::repository::{
 };
 use crate::domain::agent_session::{
     PreparedProviderLaunch, ProviderAgentLaunchGateway, ProviderAgentLaunchGatewayError,
-    ProviderAgentTerminalGateway, ProviderAgentTerminalGatewayError, ProviderAvailabilityReader,
-    ProviderSessionLaunch,
+    ProviderAgentTerminalGateway, ProviderAgentTerminalGatewayError,
+    ProviderAgentTerminalSpawnError, ProviderAvailabilityReader, ProviderSessionLaunch,
 };
 use crate::domain::provider_lifecycle::{
     ArmedProviderLifecycle, ProviderHookHealth, ProviderHookHealthRepository,
@@ -241,7 +241,7 @@ impl ProviderAgentTerminalGateway for LifecycleTerminal {
         _process: TerminalProcessLaunch,
         _rows: u16,
         _cols: u16,
-    ) -> Result<(), ProviderAgentTerminalGatewayError> {
+    ) -> Result<(), ProviderAgentTerminalSpawnError> {
         let should_block = {
             let mut spawn_count = self.spawn_count.lock().unwrap();
             *spawn_count += 1;
@@ -256,7 +256,9 @@ impl ProviderAgentTerminalGateway for LifecycleTerminal {
             }
         }
         if *self.fail_spawn.lock().unwrap() {
-            return Err(ProviderAgentTerminalGatewayError::Unavailable);
+            return Err(ProviderAgentTerminalSpawnError::OtherSpawnFailure {
+                error: "test terminal spawn failure".to_string(),
+            });
         }
         *self.runtime_generation.lock().unwrap() += 1;
         *self.presence.lock().unwrap() = ManagedPtyPresence::Live;

--- a/src-tauri/src/usecase/agent_session/agent_session_test.rs
+++ b/src-tauri/src/usecase/agent_session/agent_session_test.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex, Once};
 use std::time::Duration;
 
 use super::{
@@ -18,8 +18,8 @@ use crate::domain::agent_session::repository::{
 use crate::domain::agent_session::{
     AgentSessionHistoryGateway, AgentSessionHistoryGatewayError, AgentSessionHistoryMetadata,
     PreparedProviderLaunch, ProviderAgentLaunchGateway, ProviderAgentLaunchGatewayError,
-    ProviderAgentTerminalGateway, ProviderAgentTerminalGatewayError, ProviderAvailabilityReader,
-    ProviderSessionLaunch,
+    ProviderAgentTerminalGateway, ProviderAgentTerminalGatewayError,
+    ProviderAgentTerminalSpawnError, ProviderAvailabilityReader, ProviderSessionLaunch,
 };
 use crate::domain::provider_lifecycle::{
     ArmedProviderLifecycle, ProviderHookHealth, ProviderHookHealthRepository,
@@ -36,6 +36,86 @@ struct FailingSaveRepository {
     create_calls: AtomicUsize,
     atomic_create_calls: AtomicUsize,
     launch_lifecycle_events: Mutex<Vec<ScopedProviderLifecycleEvent>>,
+}
+
+struct CapturingLogger {
+    messages: Mutex<Vec<String>>,
+}
+
+impl log::Log for CapturingLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.level() <= log::Level::Error
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if self.enabled(record.metadata()) {
+            self.messages
+                .lock()
+                .unwrap()
+                .push(record.args().to_string());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static CAPTURING_LOGGER: CapturingLogger = CapturingLogger {
+    messages: Mutex::new(Vec::new()),
+};
+static CAPTURING_LOGGER_INIT: Once = Once::new();
+
+fn install_capturing_logger() {
+    CAPTURING_LOGGER_INIT.call_once(|| {
+        log::set_logger(&CAPTURING_LOGGER).unwrap();
+        log::set_max_level(log::LevelFilter::Trace);
+    });
+}
+
+fn captured_terminal_spawn_failure(agent_session_id: &str) -> Option<String> {
+    CAPTURING_LOGGER
+        .messages
+        .lock()
+        .unwrap()
+        .iter()
+        .rev()
+        .find(|message| {
+            message.contains("AgentSession terminal spawn failed")
+                && message.contains(agent_session_id)
+        })
+        .cloned()
+}
+
+#[test]
+fn test_agent_session_terminal_spawn_error_記録用kindとpayloadを表示する() {
+    let cases = [
+        (
+            ProviderAgentTerminalSpawnError::PerWorktreeCap {
+                worktree_path: "/repo/worktree".to_string(),
+            },
+            "kind=per_worktree_cap worktree_path=/repo/worktree",
+        ),
+        (ProviderAgentTerminalSpawnError::TotalCap, "kind=total_cap"),
+        (
+            ProviderAgentTerminalSpawnError::OwnerConflict,
+            "kind=owner_conflict",
+        ),
+        (
+            ProviderAgentTerminalSpawnError::PtySpawn {
+                error: "openpty failed".to_string(),
+            },
+            "kind=pty_spawn error=openpty failed",
+        ),
+        (
+            ProviderAgentTerminalSpawnError::OtherSpawnFailure {
+                error: "checkpoint failed".to_string(),
+            },
+            "kind=other_spawn_failure error=checkpoint failed",
+        ),
+    ];
+
+    for (error, expected) in cases {
+        assert_eq!(error.to_string(), expected);
+    }
 }
 
 impl FailingSaveRepository {
@@ -388,7 +468,7 @@ struct RecordedTerminalSpawn {
 #[derive(Default)]
 struct RecordingTerminal {
     spawns: Mutex<Vec<RecordedTerminalSpawn>>,
-    fail_spawn: Mutex<bool>,
+    spawn_error: Mutex<Option<ProviderAgentTerminalSpawnError>>,
     fail_delete: Mutex<bool>,
     deletes: Mutex<usize>,
 }
@@ -409,7 +489,7 @@ impl ProviderAgentTerminalGateway for BlockingLaunchTerminal {
         _process: TerminalProcessLaunch,
         _rows: u16,
         _cols: u16,
-    ) -> Result<(), ProviderAgentTerminalGatewayError> {
+    ) -> Result<(), ProviderAgentTerminalSpawnError> {
         self.spawns.fetch_add(1, Ordering::SeqCst);
         let entered = self.spawn_entered.lock().unwrap().take();
         if let Some(entered) = entered {
@@ -467,9 +547,9 @@ impl ProviderAgentTerminalGateway for RecordingTerminal {
         process: TerminalProcessLaunch,
         rows: u16,
         cols: u16,
-    ) -> Result<(), ProviderAgentTerminalGatewayError> {
-        if *self.fail_spawn.lock().unwrap() {
-            return Err(ProviderAgentTerminalGatewayError::Unavailable);
+    ) -> Result<(), ProviderAgentTerminalSpawnError> {
+        if let Some(error) = self.spawn_error.lock().unwrap().clone() {
+            return Err(error);
         }
         self.spawns.lock().unwrap().push(RecordedTerminalSpawn {
             owner,
@@ -1135,6 +1215,7 @@ async fn test_agent_session_launch_pty起動中のsessionをgcしない() {
 
 #[tokio::test]
 async fn test_agent_session_history_resumeは新しいsessionを作り失敗時もidを保持する() {
+    install_capturing_logger();
     let directory = tempfile::tempdir().unwrap();
     let store = crate::adaptor::gateway::local_event_store::LocalEventStore::open(
         crate::adaptor::gateway::local_event_store::LocalEventStoreConfig::production(
@@ -1157,7 +1238,10 @@ async fn test_agent_session_history_resumeは新しいsessionを作り失敗時�
     });
     let launch_gateway = Arc::new(RecordingLaunchGateway::default());
     let terminal = Arc::new(RecordingTerminal::default());
-    *terminal.fail_spawn.lock().unwrap() = true;
+    *terminal.spawn_error.lock().unwrap() =
+        Some(ProviderAgentTerminalSpawnError::OtherSpawnFailure {
+            error: "checkpoint restore failed".to_string(),
+        });
     let hook_health = hook_health_usecase();
     let usecase = AgentSessionLaunchUsecase::new(
         sessions.clone(),
@@ -1205,8 +1289,11 @@ async fn test_agent_session_history_resumeは新しいsessionを作り失敗時�
     );
     assert_eq!(
         launch_gateway.cleanups.lock().unwrap().as_slice(),
-        &[expected_id]
+        std::slice::from_ref(&expected_id)
     );
+    let record = captured_terminal_spawn_failure(&expected_id).unwrap();
+    assert!(record.contains("kind=other_spawn_failure"));
+    assert!(record.contains("error=checkpoint restore failed"));
 }
 
 #[tokio::test]
@@ -1699,6 +1786,7 @@ async fn test_provider_agent_workflow_session_launch_activate後のrollbackで�
 
 #[tokio::test]
 async fn test_agent_session_launch_spawn失敗時はsessionとlaunch資源をrollbackする() {
+    install_capturing_logger();
     let directory = tempfile::tempdir().unwrap();
     let store = crate::adaptor::gateway::local_event_store::LocalEventStore::open(
         crate::adaptor::gateway::local_event_store::LocalEventStoreConfig::production(
@@ -1711,7 +1799,9 @@ async fn test_agent_session_launch_spawn失敗時はsessionとlaunch資源をrol
     )));
     let launch_gateway = Arc::new(RecordingLaunchGateway::default());
     let terminal = Arc::new(RecordingTerminal::default());
-    *terminal.fail_spawn.lock().unwrap() = true;
+    *terminal.spawn_error.lock().unwrap() = Some(ProviderAgentTerminalSpawnError::PerWorktreeCap {
+        worktree_path: "/repo/worktree".to_string(),
+    });
     let hook_health = hook_health_usecase();
     let usecase = AgentSessionLaunchUsecase::new(
         sessions.clone(),
@@ -1744,18 +1834,26 @@ async fn test_agent_session_launch_spawn失敗時はsessionとlaunch資源をrol
 
     assert_eq!(
         result.unwrap_err(),
-        AgentSessionLaunchUsecaseError::TerminalUnavailable
+        AgentSessionLaunchUsecaseError::TerminalSpawn(
+            ProviderAgentTerminalSpawnError::PerWorktreeCap {
+                worktree_path: "/repo/worktree".to_string()
+            }
+        )
     );
     let expected_id = launch_gateway.cleanups.lock().unwrap()[0].clone();
     assert!(sessions.find(&expected_id).await.unwrap().is_none());
     assert_eq!(
         launch_gateway.cleanups.lock().unwrap().as_slice(),
-        &[expected_id]
+        std::slice::from_ref(&expected_id)
     );
+    let record = captured_terminal_spawn_failure(&expected_id).unwrap();
+    assert!(record.contains("kind=per_worktree_cap"));
+    assert!(record.contains("worktree_path=/repo/worktree"));
 }
 
 #[tokio::test]
-async fn test_agent_session_launch_rollbackのterminal削除失敗でも後続cleanupが走り一次原因を返す() {
+async fn test_agent_session_launch_prepare失敗時のrollbackのterminal削除失敗でも後続cleanupが走り一次原因を返す(
+) {
     let directory = tempfile::tempdir().unwrap();
     let store = crate::adaptor::gateway::local_event_store::LocalEventStore::open(
         crate::adaptor::gateway::local_event_store::LocalEventStoreConfig::production(
@@ -1804,6 +1902,71 @@ async fn test_agent_session_launch_rollbackのterminal削除失敗でも後続cl
     assert_eq!(
         result.unwrap_err(),
         AgentSessionLaunchUsecaseError::LaunchUnavailable
+    );
+    assert_eq!(*terminal.deletes.lock().unwrap(), 1);
+    let expected_id = launch_gateway.cleanups.lock().unwrap()[0].clone();
+    assert_eq!(
+        launch_gateway.cleanups.lock().unwrap().as_slice(),
+        std::slice::from_ref(&expected_id)
+    );
+    assert!(sessions.find(&expected_id).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_agent_session_launch_spawn失敗時のrollbackのterminal削除失敗でも後続cleanupが走り一次原因を返す(
+) {
+    let directory = tempfile::tempdir().unwrap();
+    let store = crate::adaptor::gateway::local_event_store::LocalEventStore::open(
+        crate::adaptor::gateway::local_event_store::LocalEventStoreConfig::production(
+            directory.path().to_path_buf(),
+        ),
+    )
+    .unwrap();
+    let sessions = Arc::new(AgentSessionUsecase::new(Arc::new(
+        crate::adaptor::gateway::agent_session::LocalAgentSessionRepository::new(store.clone()),
+    )));
+    let launch_gateway = Arc::new(RecordingLaunchGateway::default());
+    let terminal = Arc::new(RecordingTerminal::default());
+    *terminal.spawn_error.lock().unwrap() = Some(ProviderAgentTerminalSpawnError::PtySpawn {
+        error: "openpty failed".to_string(),
+    });
+    *terminal.fail_delete.lock().unwrap() = true;
+    let usecase = AgentSessionLaunchUsecase::new(
+        sessions.clone(),
+        Arc::new(ProviderLifecycleUsecase::new(
+            Arc::new(
+                crate::adaptor::gateway::provider_lifecycle::LocalProviderLifecycleCredentialGateway,
+            ),
+            Arc::new(RecordingLifecycleEvents::default()),
+        )),
+        Arc::new(FixedAvailability {
+            available: true,
+            checks: Mutex::new(Vec::new()),
+        }),
+        launch_gateway.clone(),
+        terminal.clone(),
+        Arc::new(FixedHistory {
+            entries: Vec::new(),
+        }),
+        hook_health_usecase(),
+    );
+
+    let result = usecase
+        .launch_standalone(AgentSessionLaunchRequest {
+            workspace: WorkspaceIdentity::new("/repo"),
+            worktree_path: "/repo/worktree".to_string(),
+            provider: ProviderKind::Codex,
+            rows: 24,
+            cols: 80,
+            caller_request_id: "rollback-spawn-delete-failure-1".to_string(),
+        })
+        .await;
+
+    assert_eq!(
+        result.unwrap_err(),
+        AgentSessionLaunchUsecaseError::TerminalSpawn(ProviderAgentTerminalSpawnError::PtySpawn {
+            error: "openpty failed".to_string()
+        })
     );
     assert_eq!(*terminal.deletes.lock().unwrap(), 1);
     let expected_id = launch_gateway.cleanups.lock().unwrap()[0].clone();

--- a/src-tauri/src/usecase/terminal_surface/error.rs
+++ b/src-tauri/src/usecase/terminal_surface/error.rs
@@ -1,12 +1,20 @@
 use crate::domain::terminal_surface::entities::TerminalSurfaceSpawnReservationError;
 use crate::domain::terminal_surface::gateway::TerminalSurfaceGatewayError;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum UsecaseError {
     #[error("{0}")]
     Gateway(String),
-    #[error("{0}")]
-    CapReached(String),
+    #[error("PTY cap reached for worktree {worktree_path}")]
+    PerWorktreeCap { worktree_path: String },
+    #[error("PTY total cap reached")]
+    TotalCap,
+    #[error("Terminal Surface owner identity collision")]
+    OwnerConflict,
+    #[error("{error}")]
+    PtySpawn { error: String },
+    #[error("{error}")]
+    OtherSpawnFailure { error: String },
 }
 
 impl From<String> for UsecaseError {
@@ -24,15 +32,11 @@ impl From<TerminalSurfaceGatewayError> for UsecaseError {
 impl From<TerminalSurfaceSpawnReservationError> for UsecaseError {
     fn from(value: TerminalSurfaceSpawnReservationError) -> Self {
         match value {
-            TerminalSurfaceSpawnReservationError::OwnerOccupied(session_key) => Self::Gateway(
-                format!("Terminal Surface owner is already being created: {session_key}"),
-            ),
+            TerminalSurfaceSpawnReservationError::OwnerOccupied(_) => Self::OwnerConflict,
             TerminalSurfaceSpawnReservationError::WorktreeCapReached(worktree_path) => {
-                Self::CapReached(format!("PTY cap reached for worktree {worktree_path}"))
+                Self::PerWorktreeCap { worktree_path }
             }
-            TerminalSurfaceSpawnReservationError::TotalCapReached => {
-                Self::CapReached("PTY total cap reached".to_string())
-            }
+            TerminalSurfaceSpawnReservationError::TotalCapReached => Self::TotalCap,
         }
     }
 }

--- a/src-tauri/src/usecase/terminal_surface/spawn_usecase.rs
+++ b/src-tauri/src/usecase/terminal_surface/spawn_usecase.rs
@@ -57,7 +57,9 @@ fn spawn_reserved<G: TerminalSurfaceGateway + ?Sized>(
         initial_terminal_surface,
     }) {
         manager.rollback_spawn_slot(&reservation);
-        return Err(error.into());
+        return Err(UsecaseError::PtySpawn {
+            error: error.message().to_string(),
+        });
     }
 
     let surface =
@@ -70,14 +72,18 @@ fn spawn_reserved<G: TerminalSurfaceGateway + ?Sized>(
     if let Err(error) = manager.start_output_reader(runtime_generation) {
         cleanup_failed_spawn(manager, runtime_generation);
         manager.rollback_spawn_slot(&reservation);
-        return Err(error.into());
+        return Err(UsecaseError::OtherSpawnFailure {
+            error: error.message().to_string(),
+        });
     }
     output_reader_ready.finish();
     if let Some(startup_input) = startup_input {
         if let Err(error) = manager.write(&session_key, &startup_input) {
             cleanup_failed_spawn(manager, runtime_generation);
             manager.rollback_spawn_slot(&reservation);
-            return Err(error.into());
+            return Err(UsecaseError::OtherSpawnFailure {
+                error: error.message().to_string(),
+            });
         }
     }
 
@@ -151,9 +157,7 @@ pub fn get_or_spawn_with_startup<G: TerminalSurfaceGateway + ?Sized>(
     loop {
         if let Some(surface) = manager.find_summary_by_session_key(&session_key) {
             if surface.owner != owner {
-                return Err(UsecaseError::Gateway(
-                    "Terminal Surface owner identity collision".to_string(),
-                ));
+                return Err(UsecaseError::OwnerConflict);
             }
             return Ok(GetOrSpawnTerminalOutcome {
                 surface,
@@ -170,9 +174,7 @@ pub fn get_or_spawn_with_startup<G: TerminalSurfaceGateway + ?Sized>(
             ) => {
                 if let Some(surface) = manager.wait_for_spawn_resolution(&session_key) {
                     if surface.owner != owner {
-                        return Err(UsecaseError::Gateway(
-                            "Terminal Surface owner identity collision".to_string(),
-                        ));
+                        return Err(UsecaseError::OwnerConflict);
                     }
                     return Ok(GetOrSpawnTerminalOutcome {
                         surface,
@@ -191,7 +193,9 @@ pub fn get_or_spawn_with_startup<G: TerminalSurfaceGateway + ?Sized>(
             Ok(checkpoint) => checkpoint,
             Err(error) => {
                 manager.rollback_spawn_slot(&reservation);
-                return Err(error.into());
+                return Err(UsecaseError::OtherSpawnFailure {
+                    error: error.message().to_string(),
+                });
             }
         };
         checkpoint_lookup.finish();
@@ -231,13 +235,15 @@ pub fn get_or_spawn_with_process<G: TerminalSurfaceGateway + ?Sized>(
     loop {
         if let Some(surface) = manager.find_summary_by_session_key(&session_key) {
             if surface.owner != owner {
-                return Err(UsecaseError::Gateway(
-                    "Terminal Surface owner identity collision".to_string(),
-                ));
+                return Err(UsecaseError::OwnerConflict);
             }
             if surface.process_state.is_exited() {
                 let runtime_generation = surface.runtime_generation.value();
-                manager.wait_runtime_output_drain(runtime_generation)?;
+                manager
+                    .wait_runtime_output_drain(runtime_generation)
+                    .map_err(|error| UsecaseError::OtherSpawnFailure {
+                        error: error.message().to_string(),
+                    })?;
                 manager.remove_surface(runtime_generation);
                 manager.remove_runtime(runtime_generation);
                 continue;
@@ -257,9 +263,7 @@ pub fn get_or_spawn_with_process<G: TerminalSurfaceGateway + ?Sized>(
             ) => {
                 if let Some(surface) = manager.wait_for_spawn_resolution(&session_key) {
                     if surface.owner != owner {
-                        return Err(UsecaseError::Gateway(
-                            "Terminal Surface owner identity collision".to_string(),
-                        ));
+                        return Err(UsecaseError::OwnerConflict);
                     }
                     return Ok(GetOrSpawnTerminalOutcome {
                         surface,
@@ -278,7 +282,9 @@ pub fn get_or_spawn_with_process<G: TerminalSurfaceGateway + ?Sized>(
             Ok(checkpoint) => checkpoint,
             Err(error) => {
                 manager.rollback_spawn_slot(&reservation);
-                return Err(error.into());
+                return Err(UsecaseError::OtherSpawnFailure {
+                    error: error.message().to_string(),
+                });
             }
         };
         checkpoint_lookup.finish();

--- a/src-tauri/src/usecase/terminal_surface/spawn_usecase_test.rs
+++ b/src-tauri/src/usecase/terminal_surface/spawn_usecase_test.rs
@@ -82,6 +82,13 @@ fn workspace_owner(path: &str) -> TerminalSurfaceOwner {
     TerminalSurfaceOwner::workspace(WorkspaceIdentity::new(path)).unwrap()
 }
 
+fn unwrap_spawn_error(result: Result<GetOrSpawnTerminalOutcome, UsecaseError>) -> UsecaseError {
+    match result {
+        Ok(_) => panic!("expected terminal spawn error"),
+        Err(error) => error,
+    }
+}
+
 impl TerminalSurfaceRepository for MockGateway {
     fn find_summary_by_session_key(&self, session_key: &str) -> Option<TerminalSurfaceSummary> {
         self.registry
@@ -487,11 +494,68 @@ fn test_ターミナル画面取得または生成_上限到達時は既存画�
         None,
     );
 
-    assert!(matches!(result, Err(UsecaseError::CapReached(_))));
+    assert_eq!(
+        unwrap_spawn_error(result),
+        UsecaseError::PerWorktreeCap {
+            worktree_path: "/repo".to_string()
+        }
+    );
     assert_eq!(*gateway.spawn_count.lock().unwrap(), 0);
     assert!(gateway.killed.lock().unwrap().is_empty());
     assert!(gateway.snapshot(first).is_some());
     assert!(gateway.snapshot(second).is_some());
+}
+
+#[test]
+fn test_ターミナル画面取得または生成_総数上限到達を分類する() {
+    let gateway = MockGateway::new();
+    gateway.insert_session("key-1", "/repo-1");
+    gateway.insert_session("key-2", "/repo-2");
+    gateway.insert_session("key-3", "/repo-3");
+
+    let result = get_or_spawn(
+        &gateway,
+        24,
+        80,
+        Some("/repo-4".to_string()),
+        workspace_owner("/repo-4"),
+        None,
+    );
+
+    assert_eq!(unwrap_spawn_error(result), UsecaseError::TotalCap);
+}
+
+#[test]
+fn test_ターミナル画面取得または生成_owner衝突を分類する() {
+    let gateway = MockGateway::new();
+    let requested =
+        TerminalSurfaceOwner::session(WorkspaceIdentity::new("/repo"), "session-1").unwrap();
+    let registered =
+        TerminalSurfaceOwner::session(WorkspaceIdentity::new("/other"), "session-1").unwrap();
+    let runtime_generation = gateway.next_runtime_generation();
+    gateway.registry.lock().unwrap().insert(TerminalSurface {
+        session_key: requested.stable_key(),
+        owner: registered,
+        worktree_path: Some("/repo".to_string()),
+        label: None,
+        runtime_generation: runtime_generation.into(),
+        process_state: crate::domain::terminal_surface::TerminalProcessState::Running,
+        checkpoint: TerminalSurfaceCheckpoint::empty(80, 24),
+        latest_sequence: 0,
+        last_output_at: None,
+    });
+
+    let result = get_or_spawn_with_process(
+        &gateway,
+        24,
+        80,
+        Some("/repo".to_string()),
+        requested,
+        None,
+        TerminalProcessLaunch::new("provider", Vec::new(), Vec::new()).unwrap(),
+    );
+
+    assert_eq!(unwrap_spawn_error(result), UsecaseError::OwnerConflict);
 }
 
 #[test]
@@ -508,7 +572,12 @@ fn test_ターミナル画面生成_実行環境生成失敗時に予約を解�
         None,
     );
 
-    assert!(matches!(result, Err(UsecaseError::Gateway(_))));
+    assert_eq!(
+        unwrap_spawn_error(result),
+        UsecaseError::PtySpawn {
+            error: "spawn failed".to_string()
+        }
+    );
     gateway.fail_spawn.store(false, Ordering::SeqCst);
 
     let retry = get_or_spawn(
@@ -541,7 +610,7 @@ fn test_ターミナル画面生成_復元点読込失敗時に予約を解除�
 
     assert!(matches!(
         result,
-        Err(UsecaseError::Gateway(message)) if message == "checkpoint load failed"
+        Err(UsecaseError::OtherSpawnFailure { error }) if error == "checkpoint load failed"
     ));
     assert!(!gateway
         .registry
@@ -578,7 +647,12 @@ fn test_ターミナル画面生成_出力読取開始失敗時に新規画面�
         None,
     );
 
-    assert!(matches!(result, Err(UsecaseError::Gateway(_))));
+    assert_eq!(
+        unwrap_spawn_error(result),
+        UsecaseError::OtherSpawnFailure {
+            error: "reader failed".to_string()
+        }
+    );
     assert_eq!(*gateway.spawn_count.lock().unwrap(), 1);
     assert_eq!(*gateway.killed.lock().unwrap(), vec![1]);
     assert!(gateway.snapshot(1).is_none());
@@ -677,7 +751,7 @@ fn test_ターミナル画面生成_後始末終了失敗時は明示再試行�
 
     assert!(matches!(
         result,
-        Err(UsecaseError::Gateway(message)) if message == "reader failed"
+        Err(UsecaseError::OtherSpawnFailure { error }) if error == "reader failed"
     ));
     assert_eq!(*gateway.spawn_count.lock().unwrap(), 1);
     assert_eq!(*gateway.killed.lock().unwrap(), vec![1]);

--- a/src-tauri/src/workflow_control_plane_acceptance.rs
+++ b/src-tauri/src/workflow_control_plane_acceptance.rs
@@ -362,6 +362,28 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
         config: AgentSessionTuiAcceptanceConfig,
         app: tauri::App<R>,
     ) -> Result<Self, String> {
+        Self::start_with_terminal_lifecycle_limits(config, app, None)
+    }
+
+    #[doc(hidden)]
+    pub fn start_with_terminal_caps(
+        config: AgentSessionTuiAcceptanceConfig,
+        app: tauri::App<R>,
+        per_worktree_cap: usize,
+        max_panes_total: usize,
+    ) -> Result<Self, String> {
+        Self::start_with_terminal_lifecycle_limits(
+            config,
+            app,
+            Some((per_worktree_cap, max_panes_total)),
+        )
+    }
+
+    fn start_with_terminal_lifecycle_limits(
+        config: AgentSessionTuiAcceptanceConfig,
+        app: tauri::App<R>,
+        terminal_caps: Option<(usize, usize)>,
+    ) -> Result<Self, String> {
         std::fs::create_dir_all(&config.data_dir).map_err(|error| error.to_string())?;
         let store =
             LocalEventStore::open(LocalEventStoreConfig::production(config.data_dir.clone()))
@@ -373,10 +395,20 @@ impl<R: tauri::Runtime> WorkflowControlPlaneAcceptanceHost<R> {
             config.data_dir.clone(),
         ));
 
-        let terminal = TerminalSurfaceRuntime::new_with_data_dir(
-            app.handle().clone(),
-            config.data_dir.clone(),
-        );
+        let terminal = match terminal_caps {
+            Some((per_worktree_cap, max_panes_total)) => {
+                TerminalSurfaceRuntime::new_with_data_dir_and_lifecycle_limits(
+                    app.handle().clone(),
+                    config.data_dir.clone(),
+                    per_worktree_cap,
+                    max_panes_total,
+                )
+            }
+            None => TerminalSurfaceRuntime::new_with_data_dir(
+                app.handle().clone(),
+                config.data_dir.clone(),
+            ),
+        };
         let composition = compose_agent_sessions(AgentSessionCompositionInput {
 			store: store.clone(),
 			data_dir: config.data_dir.clone(),

--- a/src-tauri/tests/local_log_cli_regression_test.rs
+++ b/src-tauri/tests/local_log_cli_regression_test.rs
@@ -1,0 +1,28 @@
+use std::process::Command;
+
+const RELEASH_CLI_PATH: &str = env!("CARGO_BIN_EXE_releash");
+
+#[test]
+fn test_review_cli_存在しないdata_dirをlogger初期化で作らずnot_foundを返す() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let missing_data_dir = directory.path().join("missing");
+
+    // When
+    let output = Command::new(RELEASH_CLI_PATH)
+        .args(["review", "list", "--session-id", "abc"])
+        .env("RELEASH_DATA_DIR", &missing_data_dir)
+        .output()
+        .unwrap();
+
+    // Then
+    assert_eq!(output.status.code(), Some(4));
+    assert_eq!(
+        String::from_utf8(output.stderr).unwrap().trim(),
+        format!(
+            "data directory does not exist: {}",
+            missing_data_dir.display()
+        )
+    );
+    assert!(!missing_data_dir.exists());
+}

--- a/src-tauri/tests/workflow_control_plane_acceptance_test.rs
+++ b/src-tauri/tests/workflow_control_plane_acceptance_test.rs
@@ -72,6 +72,23 @@ fn host(
     root: &Path,
     input_lines: usize,
 ) -> WorkflowControlPlaneAcceptanceHost<tauri::test::MockRuntime> {
+    configured_host(root, input_lines, None)
+}
+
+fn host_with_terminal_caps(
+    root: &Path,
+    input_lines: usize,
+    per_worktree_cap: usize,
+    max_panes_total: usize,
+) -> WorkflowControlPlaneAcceptanceHost<tauri::test::MockRuntime> {
+    configured_host(root, input_lines, Some((per_worktree_cap, max_panes_total)))
+}
+
+fn configured_host(
+    root: &Path,
+    input_lines: usize,
+    terminal_caps: Option<(usize, usize)>,
+) -> WorkflowControlPlaneAcceptanceHost<tauri::test::MockRuntime> {
     let bin = root.join("bin");
     std::fs::create_dir_all(&bin).unwrap();
     let claude = install_fixture_executable(
@@ -89,18 +106,26 @@ fn host(
     let app = tauri::test::mock_builder()
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .unwrap();
-    WorkflowControlPlaneAcceptanceHost::start(
-        AgentSessionTuiAcceptanceConfig {
-            data_dir: root.join("releash-data"),
-            claude_executable: Some(claude),
-            codex_executable: Some(codex),
-            provider_search_path: None,
-            provider_refresh_search_path: None,
-            claude_config_dir: root.join("claude-home"),
-            codex_home: root.join("codex-home"),
-        },
-        app,
-    )
+    let config = AgentSessionTuiAcceptanceConfig {
+        data_dir: root.join("releash-data"),
+        claude_executable: Some(claude),
+        codex_executable: Some(codex),
+        provider_search_path: None,
+        provider_refresh_search_path: None,
+        claude_config_dir: root.join("claude-home"),
+        codex_home: root.join("codex-home"),
+    };
+    match terminal_caps {
+        Some((per_worktree_cap, max_panes_total)) => {
+            WorkflowControlPlaneAcceptanceHost::start_with_terminal_caps(
+                config,
+                app,
+                per_worktree_cap,
+                max_panes_total,
+            )
+        }
+        None => WorkflowControlPlaneAcceptanceHost::start(config, app),
+    }
     .unwrap()
 }
 
@@ -267,6 +292,47 @@ fn leaf_nodes(execution: &AcceptanceWorkflowExecution) -> Vec<AcceptanceNodeExec
 enum SignalOrder {
     SubmitThenStop,
     StopThenSubmit,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_workflow_terminal_spawn失敗を実行収束経路からprocess_exited_failure_reasonへ保存する()
+{
+    // Given
+    let root = tempfile::TempDir::new().unwrap();
+    let worktree = root.path().join("terminal-spawn-failure-worktree");
+    std::fs::create_dir_all(&worktree).unwrap();
+    let worktree = worktree.to_string_lossy().into_owned();
+    let host = host_with_terminal_caps(root.path(), 1, 0, 64);
+
+    // When
+    let execution_id = host
+        .start_auto_workflow(&worktree, AcceptanceProvider::Claude)
+        .await
+        .unwrap();
+    let process_exited = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let events = host.workflow_log(&execution_id).await.unwrap();
+            if let Some(event) = events
+                .into_iter()
+                .find(|event| event["event"] == "process_exited")
+            {
+                return event;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("ProcessExitedFact must be appended");
+
+    // Then
+    assert_eq!(process_exited["kind"], "session");
+    let failure_reason = process_exited["failureReason"].as_str().unwrap();
+    assert!(failure_reason.contains("workflow runtime activation failed"));
+    assert!(failure_reason.contains("activate Workflow AgentSession 'agent-session-"));
+    assert!(failure_reason.contains("kind=per_worktree_cap"));
+    assert!(failure_reason.contains(&format!("worktree_path={worktree}")));
+
+    host.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Closes #1653

## 背景

terminal spawn の失敗理由は発生源では区別されているが、AgentSession 起動経路の 2 段階の変換で失われていた。`adaptor/gateway/agent_session/provider_agent_terminal_gateway.rs` が `get_or_spawn_process` のエラーを `.map_err(|_| Unavailable)` で潰し、`usecase/agent_session/agent_session_launch.rs` が `.is_err()` だけを見て `TerminalUnavailable` を返すため、per-worktree cap 到達も PTY の open / fork 失敗も同じ結果にしか残らない。workflow の Node 失敗理由には variant 名だけが載り、standalone 起動では永続化される記録がなかった。

あわせて `log` crate の logger がどこにも登録されていないため、`log::warn!` / `log::error!` の呼び出し 145 箇所はすべて no-op になっていた。パッケージ版でもアプリのログファイルは存在せず、macOS 統合ログにも残らない。結果として、障害のたびにイベントストアの直接照会と OS レベルのプロセス調査が必要になっていた。

spec: `docs/specs/issues-1653/`

## 変更

**terminal spawn 失敗を型で保全する**

発生源の `TerminalSurfaceSpawnReservationError` と `TerminalSurfaceGatewayError` を正本とし、`usecase/terminal_surface/` で文字列へ潰さず保持する。domain port は `ProviderAgentTerminalGateway::spawn` だけが spawn 専用の typed error を返し、gateway が分類と payload を保ったまま変換する。error message の再解析による分類は行わない。

記録上の表現は次に統一した。

| 失敗 | kind | payload |
| --- | --- | --- |
| per-worktree PTY cap 到達 | `per_worktree_cap` | `worktree_path` |
| PTY 総数 cap 到達 | `total_cap` | なし |
| owner 衝突 | `owner_conflict` | なし |
| PTY の open / process spawn 失敗 | `pty_spawn` | 発生源の error message |
| 上記以外の spawn 失敗 | `other_spawn_failure` | 発生源の error message |

`AgentSessionLaunchUsecaseError::TerminalSpawn` がこの値を保持する。新規起動と history resume のいずれも、失敗理由を取得した時点で記録してから既存の rollback / cleanup を行うため、cleanup が別の失敗を返しても一次原因は失われない。cap 値、待機、retry、AgentSession の lifecycle 遷移は変えていない。

**経路ごとの記録**

workflow の Session Node は `activate_workflow_agent_session` が typed error の `Display` を `WorkflowRuntimeError::AgentSession` へ載せ、既存の `NodeFailed` から `ProcessExitedFact.failure_reason` へ至る経路でイベントストアへ永続化する。standalone 起動と history resume は `log::error!` でローカルログへ記録する。

Tauri command の名前・引数・戻り値、`AGENT_SESSION_TERMINAL_UNAVAILABLE` の code と利用者向け message、history resume の Paused 結果、terminal command の cap / generic error code はいずれも従来どおりで、失敗理由を UI response へは足していない。

**ローカル logger の導入**

`infrastructure/local_log.rs` を新設し、`log` facade へ登録する。GUI は Tauri application setup より前、CLI は subcommand dispatch より前に初期化するため、`main.rs` が CLI へ分岐する経路も覆う。

- `Warn` 以上を data dir 配下 `logs/releash.log` へ JSON 1 行形式で書き出す。timestamp、level、target、message、GUI / CLI の判別値を持つ。外部への送信経路は持たない。
- bounded channel と専用 writer thread が file I/O を所有する。`log::Log::log` は非ブロッキングで enqueue し、queue 満杯時は破棄して次のレコードへ破棄件数を載せる。呼び出し側が file I/O やプロセス間 lock の待機に律速されない。
- CLI は `run` の戻り際、GUI は `RunEvent::Exit` 受信時に flush し、プロセス終了後もファイルから参照できるようにする。
- 書き込みと rotation は `fs2` の exclusive lock でプロセス間直列化する。10 MiB を超えたら rotate し、1 レコードは分割しないので 1 ファイルは 10 MiB に直近レコード 1 件分を加えたサイズまで、世代は active を含む最大 5 ファイル。

新しい logging crate も新しい event / table / migration も追加していない。既存の OTLP trace / metrics / crash reporting の送信内容と送信条件も変えていない。

## 検証

- terminal_surface usecase: 5 分類それぞれが予約解除・cleanup を伴っても保持されること
- AgentSession gateway: Terminal Surface の各エラーが payload ごと spawn error へ変換されること
- AgentSession launch: rollback の terminal 削除が失敗しても一次原因を返すこと（prepare 失敗と spawn 失敗の双方）、ローカルログに kind と payload が残ること
- controller: cap 到達は既存の cap code、それ以外は既存の generic code へ落ちること。standalone の UI response に worktree path が漏れないこと
- workflow acceptance: `per_worktree_cap` を 0 にして実際に workflow を起動し、`settle_runtime_failure_for_node` を通って永続化された `ProcessExitedFact.failureReason` に `kind=per_worktree_cap` と対象 worktree path が載ること
- local logger: GUI / CLI 双方の warning・error がプロセス終了後に共通ファイルから参照できること、GUI と複数 CLI の同時 rotation でレコードが混線せず世代上限を守ること、プロセス間 lock 保持中も呼び出し側がブロックせず破棄件数が残ること、上限超過レコードを分割せず 1 行として保持すること、通常ログは file だけ・crash log は OTLP だけへ送られること、初期化と flush だけでは data dir を作らないこと（`releash review` の data dir 実在チェックを壊さないこと）

CI と同じコマンド（`cargo fmt --check` / `cargo clippy --locked -- -D warnings` / `cargo deny --locked check` / `cargo build --locked` / `cargo test --locked`）と `qlty check --no-progress --all` をすべて実行し、通過している。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ターミナル起動失敗を、上限超過・所有者競合・PTY起動失敗などの具体的な理由として表示・記録できるようになりました。
  - ワークフロー、単独起動、履歴再開で失敗理由を確認できます。
  - GUIとCLIの警告・エラーログをローカル保存し、サイズ・世代数を制限して管理します。ログは外部送信されません。

- **バグ修正**
  - ターミナル起動失敗時も、利用者向けエラーコードと詳細情報が適切に保持されるよう改善しました。

- **ドキュメント**
  - ターミナル起動失敗の要件、動作、ログ保存仕様を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->