### PR TITLE
fix(error): 表示文言の所有を Rust へ寄せ coded error の [object Object] を解消する

### DIFF
--- a/docs/specs/issues-1652/behavior.md
+++ b/docs/specs/issues-1652/behavior.md
@@ -1,0 +1,114 @@
+## B-001: coded error の表示文言
+
+GIVEN Tauri command が `code` と `message` を持つ coded error で reject する
+WHEN 利用者へそのエラーが表示される
+THEN 表示文言は backend が返した `message` と一致する
+AND `[object Object]` は表示されない
+
+## B-002: プレーン文字列 error の表示文言
+
+GIVEN Tauri command がプレーン文字列で reject する
+WHEN 利用者へそのエラーが表示される
+THEN 表示文言は reject された文字列と一致する
+
+## B-003: Terminal 上限到達時の初期化文言
+
+GIVEN Terminal 初期化が `CAP_REACHED` の coded error で失敗する
+WHEN 利用者が失敗文言を受け取る
+THEN 文言は backend が返した `message` と一致する
+AND 文言だけで Terminal の上限到達だと判別できる
+
+## B-004: Terminal 上限到達以外の初期化失敗文言
+
+GIVEN Terminal 初期化が `CAP_REACHED` 以外の backend error で失敗する
+WHEN 利用者が失敗文言を受け取る
+THEN 文言は backend が返した `message` と一致する
+AND 文言だけで Terminal 初期化失敗だと判別できる
+
+## B-005: 稼働中 Terminal の再同期失敗文言
+
+GIVEN 稼働中 Terminal の attachment を再同期する必要がある
+WHEN 再同期用の `attach_terminal_surface` が coded error で失敗する
+THEN 文言は backend が返した `message` と一致する
+AND 文言だけで初期化失敗ではなく再同期失敗だと判別できる
+
+## B-006: coded error の利用者向け文言
+
+GIVEN backend が coded error を返す
+WHEN その `message` が UI に表示される
+THEN 表示文言は既存 UI と同じ英語である
+AND 利用者が UI 上の対象と発生した事象を識別できる
+AND 回復可能な場合は利用者が取れる行動を識別できる
+AND 実装内部の語彙だけで構成された文言ではない
+
+## B-007: stale review group target からの回復
+
+GIVEN stage または unstage の対象が stale である
+WHEN Tauri command が `STALE_REVIEW_GROUP_TARGET` の coded error で reject する
+THEN reject 値の `code` は機械可読な値として利用できる
+AND frontend は snapshot を再取得する
+
+## B-008: coded error の telemetry 報告
+
+GIVEN frontend が backend 由来の coded error を telemetry として報告する
+WHEN telemetry の報告内容が backend へ送られる
+THEN 報告される `message` は coded error の `message` と一致する
+AND `[object Object]` は報告されない
+
+## B-009: backend 由来エラーを扱う全操作での一貫性
+
+GIVEN 利用者が Releash desktop で backend の処理を伴う操作を行う
+WHEN その操作が失敗し、利用者へエラーが表示されるか telemetry として報告される
+THEN coded error では backend が返した `message` と一致する文言が使われる
+AND プレーン文字列 error では reject された文字列と一致する文言が使われる
+AND `[object Object]` は表示も報告もされない
+
+## B-010: type tagged error の表示・報告文言
+
+GIVEN application lifecycle command が `type` と `message` を持つ tagged error で reject する
+WHEN そのエラーが利用者へ表示されるか telemetry として報告される
+THEN 使用される文言は backend が返した `message` と一致する
+AND `[object Object]` は表示も報告もされない
+AND `type` と variant 固有の既存フィールドは機械可読な値として維持される
+
+## B-011: Terminal WebSocket error の操作別文言
+
+GIVEN Terminal の attach、write、resize、または不正 request が WebSocket transport で失敗する
+WHEN 利用者が失敗文言を受け取る
+THEN 文言は Rust がその操作に対して返した固定 `message` と一致する
+AND frontend が接頭辞、接尾辞、または言い換えを付加しない
+AND attach、write、resize 失敗の文言は Tauri command transport と一致する
+
+## B-012: Terminal 失敗表示からの回復
+
+GIVEN Terminal の失敗文言が表示されている
+WHEN 同じ Terminal の後続の初期化・attach が完走するか、現行 attachment epoch の再同期が成功する
+THEN その失敗文言は表示されなくなる
+AND 古い attachment epoch の成功は現行の失敗文言を消さない
+
+## B-013: Terminal 入力不能 stream item の利用者向け文言
+
+GIVEN Terminal 入力が stale attachment、pending capacity 超過、または runtime write 失敗により受理できない
+WHEN `input_unavailable` stream item が Tauri Channel または local API WebSocket で利用者へ届く
+THEN `message` は Rust の protocol 境界が返した `Terminal input could not be sent. Try again.` と一致する
+AND 利用者が Terminal 入力を送信できなかった事象と再試行できることを識別できる
+AND attachment、reorder buffer、PTY writer などの内部原因は wire の `message` に含まれない
+AND transport によって `message` が変わらない
+
+## 要件 ID と Behavior ID の対応表
+
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001, B-009 |
+| R-002 | B-002, B-009 |
+| R-003 | B-001, B-002, B-003, B-004, B-005, B-009, B-010, B-011, B-013 |
+| R-004 | B-003, B-004 |
+| R-005 | B-005, B-006, B-010, B-011, B-013 |
+| R-006 | B-007 |
+| R-007 | B-008, B-009, B-010 |
+| R-008 | B-009, B-010, B-011, B-013 |
+| R-009 | —（内部可観測性のため behavior 対象外） |
+| R-010 | B-009, B-010 |
+| R-011 | B-005, B-011 |
+| R-012 | B-012 |
+| R-013 | B-013 |

--- a/docs/specs/issues-1652/design.md
+++ b/docs/specs/issues-1652/design.md
@@ -1,0 +1,299 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### 表示文言の owner
+
+利用者向けエラー文言は Rust の operation surface 境界が所有する。usecase error から `AppError::Coded` へ変換する `agent_session/provider_tui.rs` と `code/mod.rs`、`TerminalCommandError` および `write_terminal_surface` / `resize_terminal_surface` の文字列 error へ変換する `terminal_surface/commands.rs`、application lifecycle の tagged error を serialize する `application_operation_v1.rs`、Terminal WebSocket error を組み立てる `api/terminal.rs`、Terminal stream item を wire 型へ変換する `protocol/terminal.rs` が、type、code、操作、または内部原因分類に対応する英語の固定文言を選ぶ。
+
+同じ code が複数操作から返る場合、変換関数は操作 discriminator を受け取る。同一 code × 同一操作は必ず同じ文言になり、frontend は discriminator、code、error shape から文言を組み立てない。
+
+`AppError` の serialize 規則は変更しない。`Internal` はプレーン文字列、`Coded` は `{code, message}` のままとし、code の値も変更しない。application lifecycle の tagged error は手書き `Serialize` で `message` を additive に追加し、既存 `type` と variant 固有フィールドを維持する。`input_unavailable` の domain event と usecase stream item は内部原因だけを持ち、protocol 変換後の wire item だけが表示文言を持つ。表示専用文言を domain / usecase error に持ち込まず、`adaptor/controller/api/error.rs` の `ApiErrorBody` と CLI の契約も変更しない。
+
+#### frontend の共通抽出境界
+
+`src/lib/errorMessage.ts` の `getErrorMessage` を、`unknown` から表示・報告用文字列を得る唯一の共通関数とする。
+
+```ts
+export function getErrorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (
+		typeof error === "object" &&
+		error !== null &&
+		"message" in error &&
+		typeof error.message === "string"
+	) {
+		return error.message;
+	}
+	return String(error);
+}
+```
+
+この関数は code や type を読まず、文言の追加・置換を行わない。次の24ファイルが直接使用する。静的テストは production source から実際の利用ファイル集合を導出し、この一覧と完全一致させる。
+
+最後の `String(error)` は任意の frontend 値に対する汎用 fallback として維持するが、backend structured error の契約には含めない。backend の coded / tagged error は string `message` を必須とし、Terminal WebSocket の message 欠落は fallback に渡さず malformed frame として処理する。
+
+- `src/components/workspace/WorkspaceList.tsx`
+- `src/hooks/useProviderAvailabilitySettings.ts`
+- `src/components/panels/AgentSessionPanel/AgentSessionPanel.tsx`
+- `src/components/panels/MarkdownDiffViewer.tsx`
+- `src/hooks/useReviewFileView.ts`
+- `src/lib/telemetry.ts`
+- `src/hooks/useTerminal.ts`
+- `src/components/panels/NodeContentView/NodeContentView.tsx`
+- `src/hooks/useWorkspaceNodeDetail.ts`
+- `src/components/panels/automation/FacetEditor.tsx`
+- `src/components/panels/automation/NameInputDialog.tsx`
+- `src/lib/workflowExecutionActions.ts`
+- `src/hooks/useUpdateChecker.ts`
+- `src/components/panels/SettingsModal.tsx`
+- `src/hooks/useAutomation.ts`
+- `src/screens/useWorktreeGitActions.ts`
+- `src/hooks/useWorkflowConfig.ts`
+- `src/hooks/useAppSettings.ts`
+- `src/components/workspace/DeleteWorktreeDialog.tsx`
+- `src/components/panels/DiffToolbar.tsx`
+- `src/hooks/useWorkspaceTreeNodes.ts`
+- `src/contexts/ReviewThreadHandoffContext.tsx`
+- `src/hooks/useNotionSettings.ts`
+- `src/hooks/useApplicationShutdownSupervision.ts`
+
+`useDiffOperations.ts` の `STALE_REVIEW_GROUP_TARGET` 回復分岐と、`useApplicationShutdownSupervision.ts` の pending attempt cursor 回復分岐は、表示文言ではなく機械可読状態による回復判断なので維持する。shutdown は message 部分一致を使わず、非 null cursor を渡した `list_pending_application_attempts` が `type: "invalid_request"` を返した場合だけ cursor をリセットする。
+
+`terminalStreamSocket.ts` は `TerminalWsErrorV1.message` を直接 `useTerminal.ts` へ渡す。この経路は unknown 値からの抽出を行わないため `getErrorMessage` の24ファイル一覧には含めない。`useTerminal.ts` の `onTerminalError` は `AgentSessionPanel.tsx` と `RightSidebarBottom.tsx` に配線し、両画面の `role="alert"` へ同じ文言を渡す。
+
+#### Terminal の失敗・回復通知
+
+`useTerminal.ts` の `onTerminalError` は `(message: string | null) => void` である。Terminal の失敗時は表示する文言を渡し、初期化・attach が完走した時点と、再同期用 attach が成功した時点では `null` を渡す。exit 済み surface への attach も完走としてクリアし、`onTerminalReady` だけを稼働状態に限定する。再同期成功の通知は component が mount 済みで `attemptEpoch === attachmentEpoch` の場合だけ行い、古い attachment epoch の成功で現行の失敗表示を消さない。
+
+ack IPC 失敗、`input_unavailable`、WS stream error、stream item 適用失敗、Channel fallback の write 失敗は、失敗を観測した component が mount 済みで attachment epoch が現行の場合に `recoverAttachment()` を起動する。引数なしの回復要求は、`recoveringSinceEpoch === attachmentEpoch` の間は再入しない。WS の予期しない切断だけは失敗した epoch を渡し、snapshot 前に recovery socket 自体が切断した場合の既存再入を維持する。
+
+`AgentSessionPanel.tsx` は Terminal 専用の `terminalError` state をライフサイクル操作用の `error` state から分離する。`terminalError` は Terminal 分岐だけで描画し、paused / archived を含む他の分岐へ持ち越さない。`RightSidebarBottom.tsx` も Terminal 専用 state で同じ callback 契約を消費する。
+
+#### frontend 内部例外との分離
+
+- `ReviewThreadHandoffContext.tsx` は `build_review_thread_handoff` の reject と `navigator.clipboard.writeText` の例外を別の catch で扱う。前者は backend 文言のみ、後者は clipboard 操作の文脈を付ける。
+- `useTerminal.ts` は Terminal backend command の reject を `TerminalBackendCommandError` で識別し、その message を無加工で表示する。renderer 内部で発生した初期化例外には `Failed to initialize terminal: `、再同期例外には `Failed to resynchronize terminal: ` を付ける。再同期中の `detach_terminal_surface` も backend command 境界でラップする。
+- Channel fallback の `write_terminal_surface` reject は `getErrorMessage` で抽出した Rust 所有の message を無加工で表示し、WS stream error と同じ recovery を起動する。`resize_terminal_surface` の reject も同じ Rust 所有の message を持つが、renderer は size 同期の失敗を表示面へ出さず console にだけ記録する。WS stream error は受信済み message を無加工で表示し、stream item 適用失敗は renderer 内部例外として `Failed to apply terminal stream item: ` を付けた後、いずれも recovery を起動する。
+- `ack_terminal_surface_output` は業務エラーを返さないため、IPC 失敗には `Failed to acknowledge terminal output: ` を付ける。
+
+### Interface
+
+#### wire 契約
+
+- `AppError::Internal` と `Result<_, String>` の reject 値はプレーン文字列である。
+- `AppError::Coded` と `TerminalCommandError` の reject 値は `{code: string, message: string}` である。
+- application lifecycle の tagged error は `{type: string, message: string, ...variantFields}` である。
+- Terminal WebSocket の error response は `{status: "error", id, error: {code, message}}` である。
+- Terminal attachment stream の入力不能通知は `{type: "input_unavailable", session_key, message}` であり、内部原因分類を wire に含めない。
+- code は既存値を維持し、機械可読な回復分岐に使用できる。
+- type は既存値を維持し、shutdown cursor 回復などの機械可読分岐に使用できる。
+- message はそのまま表示できる英語の利用者向け文言である。
+- `attach_terminal_surface` は `recovery: bool` を受け取り、初回 attach と再同期の表示操作を Rust 側で区別する。成功時の応答と stream 契約は変更しない。
+
+#### application lifecycle tagged error の type と message
+
+| error type | type | message | 維持する variant field |
+| --- | --- | --- | --- |
+| `OperationApplicationErrorDtoV1` | `invalid_request` | `Releash could not access application operation history because the request is invalid.` | — |
+| `OperationApplicationErrorDtoV1` | `payload_conflict` | `The application operation request conflicts with an earlier request. Refresh and try again.` | — |
+| `OperationApplicationErrorDtoV1` | `shutdown_in_progress` | `Releash could not update application operation history while shutdown is in progress. Try again after Releash restarts.` | — |
+| `OperationApplicationErrorDtoV1` | `internal` | `Releash could not access application operation history. Try again.` | `correlation_id` |
+| `ApplicationQuitErrorDtoV1` | `invalid_request` | `Releash could not start the application quit because the request is invalid.` | — |
+| `ApplicationQuitErrorDtoV1` | `payload_conflict` | `The application quit request conflicts with an earlier request. Refresh and try again.` | — |
+| `ApplicationQuitErrorDtoV1` | `capacity_exceeded` | `Releash could not start another application quit. Wait for the current operation and try again.` | — |
+| `ApplicationQuitErrorDtoV1` | `internal` | `Releash could not complete the application quit. Try again.` | `correlation_id` |
+| `ApplicationQuitLookupErrorDtoV1` | `invalid_request` | `Releash could not check the application quit because the request is invalid.` | — |
+| `ApplicationQuitLookupErrorDtoV1` | `not_found` | `The application quit operation is no longer available.` | — |
+| `ApplicationQuitLookupErrorDtoV1` | `query_busy` | `Releash is still checking the application quit. Try again.` | — |
+| `ApplicationQuitLookupErrorDtoV1` | `deadline_exceeded` | `Checking the application quit took too long. Try again.` | — |
+| `ApplicationQuitLookupErrorDtoV1` | `storage_unavailable` | `Releash could not access the application quit operation. Try again.` | `failure` |
+| `ApplicationQuitLookupErrorDtoV1` | `internal` | `Releash could not check the application quit. Try again.` | `correlation_id` |
+| `CurrentShutdownErrorDtoV1` | `internal` | `Releash could not check the current application shutdown. Try again.` | `correlation_id` |
+| `ShutdownPlanQueryErrorDtoV1` | `invalid_request` | `Releash could not load the shutdown plan because the request is invalid.` | — |
+| `ShutdownPlanQueryErrorDtoV1` | `not_found` | `The shutdown plan is no longer available.` | — |
+| `ShutdownPlanQueryErrorDtoV1` | `details_compacted` | `The shutdown plan details are no longer available.` | — |
+| `ShutdownPlanQueryErrorDtoV1` | `cursor_mismatch` | `The shutdown plan changed while it was loading. Reload the plan and try again.` | — |
+| `ShutdownPlanQueryErrorDtoV1` | `cursor_expired` | `The shutdown plan page expired. Reload the plan and try again.` | — |
+| `ShutdownPlanQueryErrorDtoV1` | `query_busy` | `The shutdown plan is busy. Try again.` | — |
+| `ShutdownPlanQueryErrorDtoV1` | `deadline_exceeded` | `Loading the shutdown plan took too long. Try again.` | — |
+| `ShutdownPlanQueryErrorDtoV1` | `response_too_large` | `The shutdown plan is too large to load.` | — |
+| `ShutdownPlanQueryErrorDtoV1` | `storage_unavailable` | `Releash could not access the shutdown plan. Try again.` | `failure` |
+| `ShutdownPlanQueryErrorDtoV1` | `internal` | `Releash could not load the shutdown plan. Try again.` | `correlation_id` |
+| `ShutdownDetailsMutationErrorDtoV1` | `invalid_request` | `Releash could not compact the shutdown details because the request is invalid.` | — |
+| `ShutdownDetailsMutationErrorDtoV1` | `internal` | `Releash could not compact the shutdown details. Try again.` | `correlation_id` |
+| `RecoveryActionCommandErrorDtoV1` | `invalid_request` | `Releash could not resolve the shutdown target because the request is invalid.` | — |
+| `RecoveryActionCommandErrorDtoV1` | `not_found` | `The shutdown target action is no longer available. Reload the shutdown plan and try again.` | — |
+| `RecoveryActionCommandErrorDtoV1` | `storage_unavailable` | `Releash could not save the shutdown target action. Try again.` | `failure` |
+| `RecoveryActionCommandErrorDtoV1` | `internal` | `Releash could not resolve the shutdown target action. Try again.` | `correlation_id` |
+
+#### 操作に依存しない AppError の code と message
+
+| code | message |
+| --- | --- |
+| `PROVIDER_AVAILABILITY_INVALID_EXECUTABLE` | `Enter a Provider executable command name or path.` |
+| `PROVIDER_AVAILABILITY_CONFIG_UNAVAILABLE` | `Releash could not access the Provider executable setting. Try again.` |
+| `PROVIDER_AVAILABILITY_REFRESH_UNAVAILABLE` | `Releash could not refresh Provider CLI availability. Try again.` |
+| `PROVIDER_AVAILABILITY_CORRUPT` | `Releash could not read Provider CLI availability. Restart Releash and try again.` |
+| `AGENT_SESSION_PROVIDER_UNAVAILABLE` | `The selected Provider is unavailable. Check its executable and try again.` |
+| `AGENT_SESSION_STORAGE_UNAVAILABLE` | `Releash could not access saved AgentSession data. Try again.` |
+| `AGENT_SESSION_LAUNCH_UNAVAILABLE` | `Releash could not complete the Provider operation for this AgentSession. Try again.` |
+| `AGENT_SESSION_TERMINAL_UNAVAILABLE` | `Releash could not complete the Terminal operation for this AgentSession. Try again.` |
+| `AGENT_SESSION_CORRUPT` | `Releash could not continue because the AgentSession data is invalid.` |
+| `AGENT_SESSION_NOT_FOUND` | `The AgentSession is no longer available.` |
+| `AGENT_SESSION_INVALID_OPERATION` | `This operation is not available for the AgentSession in its current state. Refresh and try again.` |
+| `AGENT_SESSION_INVALID_REQUEST` | `Releash could not load the AgentSession because the request is invalid.` |
+| `AGENT_SESSION_HISTORY_INVALID_REQUEST` | `Releash could not load AgentSession history because the request is invalid.` |
+| `AGENT_SESSION_HISTORY_UNAVAILABLE` | `Releash could not load AgentSession history. Try again.` |
+| `AGENT_SESSION_HISTORY_CORRUPT` | `Releash could not load AgentSession history because its saved data is invalid.` |
+| `PROVIDER_HOOK_HEALTH_INVALID_REQUEST` | `Releash could not load Provider Hook health because the request is invalid.` |
+| `PROVIDER_HOOK_HEALTH_STORAGE_UNAVAILABLE` | `Releash could not load Provider Hook health. Try again.` |
+| `PROVIDER_HOOK_HEALTH_CORRUPT` | `Releash could not load Provider Hook health because its saved data is invalid.` |
+| `STALE_REVIEW_GROUP_TARGET` | `The review changed before the operation completed. Reload the review and try again.` |
+
+#### 操作に依存する AgentSession code と message
+
+| code | command / operation | message |
+| --- | --- | --- |
+| `AGENT_SESSION_INVALID_PROVIDER` | Provider executable の update / reset | `Select a valid Provider.` |
+| `AGENT_SESSION_INVALID_PROVIDER` | `create_agent_session` | `Select a Provider before starting the AgentSession.` |
+| `AGENT_SESSION_INVALID_PROVIDER` | `resume_agent_session_history_candidate` | `Select a Provider before resuming the AgentSession.` |
+| `AGENT_SESSION_INVALID_INPUT` | `create_agent_session` | `Releash could not start the AgentSession because the request is invalid.` |
+| `AGENT_SESSION_INVALID_INPUT` | `resume_agent_session_history_candidate` | `Releash could not resume the AgentSession because the request is invalid.` |
+| `AGENT_SESSION_CONFLICT` | `create_agent_session` | `The AgentSession could not be started because the request conflicts with current state or its Provider session is already in use. Refresh and try again.` |
+| `AGENT_SESSION_CONFLICT` | `resume_agent_session_history_candidate` | `The AgentSession could not be resumed because it changed or its Provider session is already in use. Refresh and try again.` |
+| `AGENT_SESSION_CONFLICT` | AgentSession lifecycle update | `The AgentSession could not be updated because it changed or its Provider session is already in use. Refresh and try again.` |
+
+#### TerminalCommandError の code、操作、message
+
+| code | command / operation | message |
+| --- | --- | --- |
+| `CAP_REACHED` | `get_or_spawn_terminal_surface` / 初期化 | `Terminal limit reached. Close an open Terminal and try again.` |
+| `PTY_ERROR` | `get_or_spawn_terminal_surface` / 初期化 | `Terminal initialization failed. Try again.` |
+| `INVALID_REQUEST` | `get_or_spawn_terminal_surface` / 初期化 | `Terminal initialization failed because the request is invalid.` |
+| `CAP_REACHED` | `get_terminal_surface` または `attach_terminal_surface(recovery=false)` / attach | `Terminal limit reached. Close an open Terminal and try again.` |
+| `PTY_ERROR` | `get_terminal_surface` または `attach_terminal_surface(recovery=false)` / attach | `Terminal attachment failed. Try again.` |
+| `INVALID_REQUEST` | `get_terminal_surface` または `attach_terminal_surface(recovery=false)` / attach | `Terminal attachment failed because the request is invalid.` |
+| `CAP_REACHED` | `attach_terminal_surface(recovery=true)` / 再同期 | `Terminal limit reached. Close an open Terminal and try again.` |
+| `PTY_ERROR` | `attach_terminal_surface(recovery=true)` / 再同期 | `Terminal resynchronization failed. Try again.` |
+| `INVALID_REQUEST` | `attach_terminal_surface(recovery=true)` / 再同期 | `Terminal resynchronization failed because the request is invalid.` |
+
+`write_terminal_surface` は既存の `Result<(), String>` を維持し、gateway failure では `Terminal input could not be sent. Try again.`、owner 変換失敗では `Terminal input could not be sent because the request is invalid.` を返す。`resize_terminal_surface` も既存の `Result<(), String>` を維持し、gateway failure では `Terminal resize failed. Try again.`、owner 変換失敗では `Terminal resize failed because the request is invalid.` を返す。
+
+#### TerminalWsErrorV1 の code、操作、message
+
+| code | WebSocket operation | message | 備考 |
+| --- | --- | --- | --- |
+| `PTY_ERROR` | attach | `Terminal attachment failed. Try again.` | Tauri の attach と同一 |
+| `INVALID_REQUEST` | attach | `Terminal attachment failed because the request is invalid.` | Tauri の attach と同一 |
+| `PTY_ERROR` | write | `Terminal input could not be sent. Try again.` | Tauri の write と同一 |
+| `INVALID_REQUEST` | write | `Terminal input could not be sent because the request is invalid.` | Tauri の write と同一 |
+| `PTY_ERROR` | resize | `Terminal resize failed. Try again.` | Tauri の resize と同一 |
+| `INVALID_REQUEST` | resize | `Terminal resize failed because the request is invalid.` | Tauri の resize と同一 |
+| `INVALID_REQUEST` | 不正 request | `Terminal request failed because the request is invalid.` | 接続前の JSON parse / frame kind / size と接続後の JSON parse / shape の不正を含む |
+| — | ack | error response を返さない | acknowledge は失敗を返さない既存契約 |
+| — | kill | WebSocket operation ではない | `kill_terminal_surface` Tauri command を使用する既存契約 |
+
+WebSocket attach は cap 系の `UsecaseError`（`PerWorktreeCap` / `TotalCap`）を返さないため、`CAP_REACHED` mapping を持たない。`terminalStreamSocket.ts` は表の message をそのまま渡す。message がない error frame は backend error として言い換えず malformed frame として console に記録し、socket を閉じて fallback / resync を開始する。
+
+#### `input_unavailable` の内部原因と message
+
+| domain event の原因分類 | protocol の message | wire に含めない内部原因 |
+| --- | --- | --- |
+| `StaleAttachment` | `Terminal input could not be sent. Try again.` | `Terminal input attachment is no longer active` |
+| `PendingCapacityExceeded` | `Terminal input could not be sent. Try again.` | `Terminal input reorder buffer is full` |
+| `RuntimeWriteFailed(String)` | `Terminal input could not be sent. Try again.` | runtime gateway error の文字列 |
+
+Tauri Channel と local API WebSocket はどちらも `TerminalSurfaceStreamItemV1::from` を通るため、同じ原因分類から同じ wire message を返す。変換時に内部原因を `operation=write_terminal_surface code=PTY_ERROR cause=...` として error log へ記録する。
+
+### Data Model
+
+新しい domain record、永続 record、identity、versioning は追加しない。`TerminalSurfaceInputUnavailableCause` は `StaleAttachment` / `PendingCapacityExceeded` / `RuntimeWriteFailed(String)` の3 variant を持ち、`internal_cause()` が内部原因文字列の唯一の定義元となる。runtime gateway は返却する `TerminalSurfaceGatewayError` もこの値から組み立てる。`TerminalSurfaceEvent::InputUnavailable` と `TerminalSurfaceStreamItem::InputUnavailable` は表示文言ではなくこの内部原因を保持し、`TerminalSurfaceStreamItemV1::InputUnavailable` は既存 wire shape の `message` を保持する。その他の既存 wire 型であるプレーン文字列と `{code, message}` を維持し、application lifecycle の `{type, ...variantFields}` には `message` だけを additive に追加する。frontend の共通関数は error 値、code、type を保持せず、呼び出し時に文字列だけを返す。
+
+### Database
+
+該当なし。
+
+### UI/UX
+
+AgentSession の Terminal と Workspace bottom Terminal は、Terminal surface の上に `role="alert"` / `text-destructive` の失敗表示面を持つ。他の既存エラー表示位置、レイアウト、重大度、再試行操作は変更しない。backend error の表示面は受け取った message をそのまま描画し、同じ Terminal の後続の初期化・attach または再同期が成功すると表示を消す。
+
+- Markdown diff、review file view、workflow action、Terminal backend reject にあった frontend 接頭辞を除去する。
+- Terminal 初期化・attach・再同期の区別は backend message で表す。
+- Terminal 初期化失敗は xterm へ重ねて書き込まず、`role="alert"` だけに表示する。
+- `AgentSessionPanel` の Terminal 失敗表示はライフサイクル操作の失敗表示と別の state で管理し、Terminal 分岐だけに表示する。
+- WS stream error、stream item 適用失敗、Channel write 失敗は自動的に attachment を再同期し、成功時に alert を消す。recovery 中の stream item 適用失敗は recovery を張り直さない。
+- frontend 内部例外の操作文脈は維持する。
+- telemetry は `Error` の stack を維持し、message の取得だけを `getErrorMessage` に委譲する。
+
+### Algorithm
+
+Terminal command の `UsecaseError` 変換は、error 分類から `TerminalCommandErrorCode` enum を決め、command operation と code の exhaustive match から固定 message を選ぶ。`attach_terminal_surface` は frontend が渡す `recovery` だけを操作 discriminator に使う。`write_terminal_surface` と `resize_terminal_surface` は構造化 error へ移行せず、gateway failure と owner 変換失敗をそれぞれの操作の固定文字列へ変換する。frontend は operation、code、error shape から文言を決めない。
+
+Terminal WebSocket は `TerminalWsError::Attach(code)` / `Write(code)` / `Resize(code)` / `InvalidRequest` の exhaustive match から固定 message を選び、内部 cause は response に含めない。`InvalidRequest` variant の code は常に `INVALID_REQUEST` であり、不正 request と `PTY_ERROR` の組み合わせは構築できない。
+
+runtime gateway は入力不能の発生点で3 variant の `TerminalSurfaceInputUnavailableCause` を構築する。usecase は原因を加工せず運び、protocol 変換が固定 message を設定して内部原因を log に残す。原因文字列の内容による分類は行わない。
+
+AgentSession の Provider parse と launch error 変換は、Provider 設定、session 作成、履歴再開、lifecycle 更新の operation を受け取り、operation-sensitive な3 code の message を選ぶ。Provider parse、launch、conflict にはそれぞれ専用 operation 型を使い、不可能な組み合わせを構築できない。他の code は operation に依存しない一つの mapping を再利用する。
+
+application lifecycle の7 error enum は variant 自体を変えず、手書き `Serialize` が private wire 構造体へ変換する。これにより既存 constructor と機械可読 field を維持しながら、全 variant に `message` を追加する。
+
+### Infra
+
+該当なし。
+
+## Alternatives Considered
+
+### frontend で code から表示文言を選ぶ
+
+採用しない。表示文言の owner が frontend にも生まれ、R-003 に反する。分類結果と操作は backend の message に反映し、frontend は構造抽出だけを行う。
+
+### code ごとに一つの message だけを持つ
+
+採用しない。Terminal の初期化と再同期、AgentSession の作成と履歴再開のように、同じ code でも発生した事象が異なる。operation discriminator を Rust の presentation mapping に渡し、同一 code × 同一操作を一意にする。
+
+### coded error をプレーン文字列へ serialize する
+
+採用しない。`STALE_REVIEW_GROUP_TARGET` を含む機械可読 code を失い、既存 serialize 契約も変わる。
+
+### application lifecycle error の全 constructor に message field を渡す
+
+採用しない。internally-tagged enum の unit variant に定数 field は追加できず、全 command / presenter の constructor に表示専用値を持ち回ることになる。enum の形を維持した手書き `Serialize` で command wire にだけ message を追加する。
+
+### 利用者向け文言を domain または usecase error に持たせる
+
+採用しない。文言は operation surface 向けの外部表現であり、domain / usecase のエラー分類へ表示都合を持ち込む。Tauri command、Terminal WebSocket、Terminal stream protocol の各 adaptor 境界に留め、`ApiErrorBody` と CLI は変更しない。
+
+### `input_unavailable` の原因文字列を protocol 境界で分類する
+
+採用しない。gateway 実装の文言変更が wire message の判断を暗黙に変え、未知の原因を分類できない。発生点で3 variant の domain enum に分類し、runtime write の詳細だけを variant の値として保持する。
+
+## Cross-cutting concerns
+
+### 互換性
+
+`AppError` と `TerminalCommandError` の wire shape、全 code 値、application lifecycle error の全 type 値と既存 variant field、`input_unavailable` の `{type, session_key, message}`、`ApiErrorBody`、CLI、`useDiffOperations.ts` の回復分岐を維持する。application lifecycle error と `TerminalWsErrorV1` の message は additive な変更である。`write_terminal_surface` と `resize_terminal_surface` の `Result<(), String>`、`attach_terminal_surface` の `recovery` 引数、成功時の応答、stream payload は維持する。
+
+### 可観測性と検証
+
+- `terminal_surface/commands.rs` は固定 message へ置き換える直前に、`operation`、`code`、内部原因を記録する。上限到達と owner 変換失敗は warn、gateway failure は error とする。
+- `api/terminal.rs` は WebSocket の固定 message へ置き換える直前に `operation`、`code`、内部原因を記録する。INVALID_REQUEST は warn、PTY_ERROR は error とする。
+- `protocol/terminal.rs` は `input_unavailable` の固定 message へ置き換える直前に、`operation=write_terminal_surface`、`code=PTY_ERROR`、内部原因を error で記録する。
+- `code/mod.rs` は stale review group の固定 message へ置き換える直前に、`STALE_REVIEW_GROUP_TARGET` と内部 `group_id` を warn で記録する。
+- `provider_tui_test.rs` は全AgentSession / Provider code と、操作依存 code の文言を検証する。
+- `terminal_surface/commands_test.rs` は3 code、初期化・attach・再同期の文言、write と resize の各2文言、`recovery` operation mapping、CAP_REACHED の4 operation を検証する。
+- `application_operation_v1_test.rs` は tagged error の全31 variant の type / message と既存 variant field を検証する。
+- `api/terminal_test.rs` は WebSocket で到達可能な7つの error operation / code の message と内部 cause の非露出を検証する。
+- `protocol/terminal_test.rs` は `input_unavailable` の3原因分類が固定 message へ変換され、内部原因が wire に載らないことを検証する。
+- `src/lib/errorMessage.test.ts` は coded error、プレーン文字列、`Error`、fallback を検証する。
+- `src/hooks/useTerminal.test.ts` は初期化中の失敗後の完走通知、再同期成功のクリア通知、古い epoch の成功によるクリア抑止、WS stream error と stream item 適用失敗の recovery、recovery 中の連続適用失敗による再入抑止、Channel write 失敗の通知と recovery、exit 済み attach のクリアを検証する。
+- `RightSidebarBottom.test.tsx` と `AgentSessionPanel.test.tsx` は Terminal alert が成功通知で消えることを検証し、後者は Terminal error が paused / archived 画面へ持ち越されないことも検証する。
+- その他の component / hook tests は代表的な object reject、frontend 内部例外、Terminal 初期化・ack・再同期、WebSocket message 透過、review handoff、shutdown cursor 回復、coded / tagged error telemetry を検証する。
+- `src/lib/errorMessageUsage.test.ts` は production source から共通関数の利用ファイル集合を導出して対象24ファイルと完全一致させ、`String(error)` / `String(cause)`、局所的な `Error.message` ternary、私的な同名 helper の再導入を検出する。
+
+### Risks
+
+- 新しい `getErrorMessage` 利用ファイルが対象24ファイルの一覧に追加されない可能性がある。production source から導出した利用ファイル集合との完全一致テストで検出する。
+- frontend と backend で `recovery` の意味がずれると Terminal の事象文言が誤る。初回 attach が `false`、回復 attach が `true` を渡す hook test と、Rust の operation mapping test で固定する。

--- a/docs/specs/issues-1652/requirements.md
+++ b/docs/specs/issues-1652/requirements.md
@@ -1,0 +1,139 @@
+# Context
+
+- 変更要求の正本: [#1652 [frontend] Coded AppError がエラー表示で [object Object] になる](https://github.com/siro33950/releash/issues/1652)（label: bug / milestone なし）
+- 実障害: 2026-08-19、PJT-2308 worktree で AgentSession 起動が `AGENT_SESSION_TERMINAL_UNAVAILABLE` で失敗し、WorkspaceList のエラーボックスに `[object Object]` だけが表示された。
+- 表示文言の決定は Rust が所有する。frontend は backend が返した文言の構造抽出と表示だけを担い、`code` や error shape から表示文言を決めない。
+- `docs/architecture/CONTROLLER.md` は Tauri command の戻り値を `Result<_, AppError>` に統一する方針を定めているが、現時点では `Result<_, String>` の command が77個残る。この移行は本変更に含めない。
+
+# Outcome
+
+- backend が返した利用者向け文言が、coded error でも `[object Object]` に失われず、そのまま表示・報告される。
+- 利用者が Terminal の初期化、既存 Terminal への attach、稼働中 Terminal の再同期を文言だけで区別できる。
+- Terminal の失敗表示は、同じ Terminal の後続の初期化・attach または再同期が成功すると消える。
+- 同じ code でも発生した操作が異なる場合は、Rust の command 境界が操作に対応する固定文言を選ぶ。
+- 利用者向け固定文言へ置き換えた内部原因は、code と対応づけて backend log から追跡できる。
+- Terminal の入力不能通知は transport に依存しない固定文言を返し、内部原因を利用者向け wire へ露出しない。
+
+# Current Behavior
+
+## backend が返すエラーの形
+
+- `AppError::Internal(String)` はプレーン文字列として serialize される。
+- `AppError::Coded { code, message }` は `{code, message}` のオブジェクトとして serialize される。
+- Terminal の3 command は `TerminalCommandError` を返す。wire shape は `{code, message}` で、code は `CAP_REACHED` / `PTY_ERROR` / `INVALID_REQUEST` である。
+- `write_terminal_surface` と `resize_terminal_surface` は `Result<(), String>` を維持し、失敗時は Rust の command 境界で操作に対応する固定文言へ変換する。
+- Terminal WebSocket の error response は `{status: "error", error: {code, message}}` で、message は操作ごとの固定した利用者向け文言である。
+- Terminal attachment stream の `input_unavailable` は `{type: "input_unavailable", session_key, message}` を維持し、domain の内部原因を protocol 境界で固定した利用者向け `message` へ変換する。
+- workflow、app config、review handoff、workspace tree などには `Result<_, String>` の command が残る。
+- application lifecycle command は `type` discriminator と利用者向け `message` を持つ専用の tagged error を返す。`correlation_id` / `failure` など variant 固有の既存フィールドも維持する。
+- `src-tauri/src/other/error.rs` の serialize 契約、code と type の値、`adaptor/controller/api/error.rs` の `ApiErrorBody`、CLI の契約は変更対象ではない。
+
+## frontend の受け取り経路
+
+Tauri IPC または frontend library が reject した値を利用者へ表示、上位へ返却、または telemetry として報告する共通抽出境界は次の24ファイルである。静的テストは production source から `getErrorMessage` の利用ファイル集合を導出し、この一覧との完全一致を検証する。
+
+| ファイル | 現在受け取り得る backend error |
+| --- | --- |
+| `src/components/workspace/WorkspaceList.tsx` | AgentSession / Provider の `AppError`、workflow の `String` |
+| `src/hooks/useProviderAvailabilitySettings.ts` | `AppError` |
+| `src/components/panels/AgentSessionPanel/AgentSessionPanel.tsx` | `AppError` |
+| `src/components/panels/MarkdownDiffViewer.tsx` | `AppError` |
+| `src/hooks/useReviewFileView.ts` | `AppError` |
+| `src/lib/telemetry.ts` | unhandled error / rejection の任意の shape |
+| `src/hooks/useTerminal.ts` | `TerminalCommandError`、`String`、frontend 内部例外 |
+| `src/components/panels/NodeContentView/NodeContentView.tsx` | `String` |
+| `src/hooks/useWorkspaceNodeDetail.ts` | `String` |
+| `src/components/panels/automation/FacetEditor.tsx` | `String` |
+| `src/components/panels/automation/NameInputDialog.tsx` | `String` |
+| `src/lib/workflowExecutionActions.ts` | `String` |
+| `src/hooks/useUpdateChecker.ts` | plugin 由来の error |
+| `src/components/panels/SettingsModal.tsx` | repository の `AppError`、app config / editor の `String` |
+| `src/hooks/useAutomation.ts` | `String` |
+| `src/screens/useWorktreeGitActions.ts` | `AppError` |
+| `src/hooks/useWorkflowConfig.ts` | `String` |
+| `src/hooks/useAppSettings.ts` | app config の `String`、autostart plugin の error |
+| `src/components/workspace/DeleteWorktreeDialog.tsx` | `AppError` |
+| `src/components/panels/DiffToolbar.tsx` | `String` |
+| `src/hooks/useWorkspaceTreeNodes.ts` | `String` |
+| `src/contexts/ReviewThreadHandoffContext.tsx` | review handoff の `String`、clipboard の frontend 例外 |
+| `src/hooks/useNotionSettings.ts` | `String` |
+| `src/hooks/useApplicationShutdownSupervision.ts` | application lifecycle の tagged error |
+
+これらの経路で `String(error)` または `error instanceof Error ? error.message : String(error)` を局所的に使うと、Tauri が reject した `{code, message}` や `{type, message}` が `[object Object]` になる。24ファイルは共通の `getErrorMessage` を使用し、production source 全体で同目的の局所抽出を再導入しない。
+
+Terminal error は次の直接伝播経路も通る。ここでは frontend が文言を抽出・加工せず、Rust が返した message をそのまま callback と alert へ渡す。
+
+| ファイル | 責務 |
+| --- | --- |
+| `src/lib/terminalStreamSocket.ts` | `TerminalWsErrorV1.message` を接頭辞なしで `useTerminal` へ渡す |
+| `src/hooks/useTerminal.ts` | command / WebSocket / attachment stream の backend message を `onTerminalError` へ渡す。Channel fallback の write reject も `getErrorMessage` で抽出した文言を無加工で渡す。初期化・attach 完走時と現行 epoch の再同期成功時は `null` を渡す |
+| `src/components/panels/AgentSessionPanel/AgentSessionPanel.tsx` | AgentSession の Terminal error をライフサイクル error と分離した state で保持し、`role="alert"` で表示・クリアする |
+| `src/components/panels/RightSidebarBottom.tsx` | Workspace の Terminal error を専用 state で保持し、`role="alert"` で表示・クリアする |
+
+## frontend が文脈を付加する経路
+
+- backend が表示文言を所有する reject には、frontend の接頭辞・接尾辞を付けない。
+- Channel fallback の `write_terminal_surface` reject は backend が表示文言を所有するため、frontend は `getErrorMessage` による抽出だけを行い、操作文脈を付加しない。
+- `ack_terminal_surface_output` の IPC 失敗、Terminal renderer 内部の初期化・再同期・stream 適用失敗、clipboard 書き込み失敗など、backend が利用者向け文言を所有しない frontend 側の失敗には操作文脈を維持する。
+- `ReviewThreadHandoffContext.tsx` は `build_review_thread_handoff` の reject と clipboard 例外を別々に扱う。
+
+## 既存の機械可読分岐
+
+- `src/components/panels/useDiffOperations.ts` は `STALE_REVIEW_GROUP_TARGET` を検出して snapshot を再取得する。この回復挙動は表示文言の選択ではないため維持する。
+- `src/hooks/useApplicationShutdownSupervision.ts` は pending attempt の非 null cursor に対する `type: "invalid_request"` だけを cursor 回復条件として扱う。message 文字列の部分一致は行わない。
+
+# Scope / Non-goals
+
+## Scope
+
+- 上表の24ファイルを `src/lib/errorMessage.ts` の `getErrorMessage` へ統一し、production source から導出した利用ファイル集合と機械照合する。
+- production source 全体から同目的の `String(error)` と `instanceof Error` による局所抽出を除去し、静的テストで再導入を検出する。
+- backend 由来の表示文言に frontend が付けている接頭辞・接尾辞を除去する。
+- frontend 内部例外と backend command reject が同じ catch に入る経路を分離する。
+- 既存25 code の利用者向け英語文言を Rust の command 境界で確定する。
+- application lifecycle の tagged error 全 variant に、既存 type と variant 固有フィールドを維持した利用者向け message を追加する。
+- Terminal と AgentSession の操作依存 code は、code を変えずに操作ごとの固定文言を返す。
+- Terminal WebSocket の attach / write / resize / 不正 request に、Rust が所有する操作別の固定文言を設定する。
+- Tauri Channel fallback の write 失敗を Rust command 境界の固定文言として通知し、WebSocket write と同じ文言・回復処理にする。`resize_terminal_surface` も同じ command 境界で WebSocket resize と同じ固定文言を返す。
+- `input_unavailable` の3内部原因を domain event で分類し、protocol 境界で transport 非依存の利用者向け固定文言へ変換する。
+- Terminal の初期化・attach 完走または現行 epoch の再同期成功を表示面へ通知し、同じ Terminal の失敗表示をクリアする。
+- 利用者向け固定文言への変換で失われる Terminal command の owner 変換原因、Terminal WebSocket と `input_unavailable` の内部原因、stale review group ID を、code とともに backend log へ記録する。
+- backend 文言、frontend 抽出、操作別文言、回復分岐、静的検証をテストで固定する。
+
+## Non-goals
+
+- `Result<_, String>` を返す Tauri command 77個の `Result<_, AppError>` への移行。
+- `AppError` の serialize 表現の変更。`Internal` はプレーン文字列、`Coded` は `{code, message}` を維持する。
+- code の値・命名・粒度の変更、および coded error の追加・削除。
+- `adaptor/controller/api/error.rs` の `ApiErrorBody` と CLI のエラー契約の変更。
+- `useDiffOperations.ts` の `STALE_REVIEW_GROUP_TARGET` 回復挙動の変更。
+- frontend 内部エラーの文言を Rust へ移管すること。
+- Terminal の `role="alert"` 表示面以外のエラー UI のレイアウト・配置・重大度表現の変更。
+- UI 文言の多言語化。
+- `src/App.tsx` が `catch {}` で処理する `quit_after_startup_failure` の表示・telemetry 経路の変更。
+
+# Requirements
+
+- R-001: Tauri command が `{code, message}` 形式の coded error で reject したとき、利用者に表示される文言は backend が返した `message` と一致し、`[object Object]` は表示されない。
+- R-002: Tauri command がプレーン文字列で reject したとき、利用者に表示される文言は reject された文字列と一致し、frontend が付加した接頭辞・接尾辞を含まない。
+- R-003: frontend は backend 由来のエラーに対して、code や error shape を用いた文言選択、接頭辞・接尾辞の付加、言い換えを行わない。
+- R-004: Terminal 初期化の `CAP_REACHED` とそれ以外の失敗は、backend が返す文言だけで区別できる。
+- R-005: backend structured error の message は、利用者が対象、発生した事象、回復可能な場合の行動を識別できる英語の文言である。同じ code でも操作が異なる場合は、同一 code × 同一操作で一意な文言を返す。
+- R-006: code は機械可読な回復分岐に引き続き利用でき、`STALE_REVIEW_GROUP_TARGET` の snapshot 再取得は変わらない。
+- R-007: frontend が coded error または tagged error を telemetry として backend へ報告するとき、報告される `message` は backend が返した `message` と一致する。
+- R-008: R-001、R-002、R-007 は上表の24ファイルと Terminal の直接伝播経路で成立し、production source に同目的の局所抽出が残らない。
+- R-009: 利用者向け固定文言への変換で表示から除かれた Terminal command の owner 変換原因、Terminal WebSocket の内部原因、`input_unavailable` の内部原因は `operation` / `code` / `cause` として、その他の内部原因は code と原因を識別できる文脈とともに backend log に記録され、利用者向け error と内部原因を突き合わせられる。
+- R-010: application lifecycle command の tagged error は全 variant が利用者向け `message` を持ち、既存の `type` と variant 固有フィールドを維持し、表示・報告で `[object Object]` にならない。
+- R-011: Terminal WebSocket error は操作に対応する Rust 所有の固定 message を返し、Tauri command と同じ attach、write、resize の失敗は transport に依存せず同じ message になる。
+- R-012: Terminal の失敗文言が表示されているとき、同じ Terminal の後続の初期化・attach 完走または現行 attachment epoch の再同期成功により失敗表示はクリアされ、古い epoch の成功は現行の失敗表示をクリアしない。
+- R-013: `input_unavailable` は stale attachment、pending capacity 超過、runtime write 失敗を domain event で分類し、protocol 境界で利用者向け固定 message へ変換する。wire に内部原因を含めず、Tauri Channel と local API WebSocket で同じ message を返す。
+
+# Assumptions / Open Questions
+
+## Assumptions
+
+なし。
+
+## Open Questions
+
+なし。

--- a/src-tauri/src/adaptor/controller/api/terminal.rs
+++ b/src-tauri/src/adaptor/controller/api/terminal.rs
@@ -17,6 +17,67 @@ use super::LocalApiState;
 
 const MAX_TERMINAL_REQUEST_BYTES: usize = 64 * 1024;
 
+#[derive(Clone, Copy)]
+enum TerminalWsError {
+    Attach(TerminalWsErrorCode),
+    Write(TerminalWsErrorCode),
+    Resize(TerminalWsErrorCode),
+    InvalidRequest,
+}
+
+impl TerminalWsError {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Attach(_) => "attach_terminal_surface",
+            Self::Write(_) => "write_terminal_surface",
+            Self::Resize(_) => "resize_terminal_surface",
+            Self::InvalidRequest => "terminal_websocket_request",
+        }
+    }
+
+    fn code(self) -> TerminalWsErrorCode {
+        match self {
+            Self::Attach(code) | Self::Write(code) | Self::Resize(code) => code,
+            Self::InvalidRequest => TerminalWsErrorCode::InvalidRequest,
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::Attach(TerminalWsErrorCode::PtyError) => "Terminal attachment failed. Try again.",
+            Self::Attach(TerminalWsErrorCode::InvalidRequest) => {
+                "Terminal attachment failed because the request is invalid."
+            }
+            Self::Write(TerminalWsErrorCode::PtyError) => {
+                "Terminal input could not be sent. Try again."
+            }
+            Self::Write(TerminalWsErrorCode::InvalidRequest) => {
+                "Terminal input could not be sent because the request is invalid."
+            }
+            Self::Resize(TerminalWsErrorCode::PtyError) => "Terminal resize failed. Try again.",
+            Self::Resize(TerminalWsErrorCode::InvalidRequest) => {
+                "Terminal resize failed because the request is invalid."
+            }
+            Self::InvalidRequest => "Terminal request failed because the request is invalid.",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TerminalWsErrorCode {
+    InvalidRequest,
+    PtyError,
+}
+
+impl TerminalWsErrorCode {
+    fn code(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "INVALID_REQUEST",
+            Self::PtyError => "PTY_ERROR",
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct TerminalApiDeps {
     application: Arc<TerminalSurfaceApplication>,
@@ -127,16 +188,14 @@ async fn serve_attachment(
 ) {
     let owner = match owner.try_into() {
         Ok(owner) => owner,
-        Err(message) => {
+        Err(cause) => {
             let _ = send_response(
                 sink,
-                &TerminalWsResponseV1::Error {
+                &terminal_ws_error(
                     id,
-                    error: TerminalWsErrorV1 {
-                        code: "INVALID_REQUEST",
-                        message,
-                    },
-                },
+                    TerminalWsError::Attach(TerminalWsErrorCode::InvalidRequest),
+                    cause,
+                ),
             )
             .await;
             return;
@@ -145,16 +204,14 @@ async fn serve_attachment(
     let attachment_id = attachment_id.unwrap_or_else(|| format!("ws-{}", uuid::Uuid::new_v4()));
     let mut attachment = match deps.application.attach(&attachment_id, &owner) {
         Ok(attachment) => attachment,
-        Err(error) => {
+        Err(cause) => {
             let _ = send_response(
                 sink,
-                &TerminalWsResponseV1::Error {
+                &terminal_ws_error(
                     id,
-                    error: TerminalWsErrorV1 {
-                        code: "PTY_ERROR",
-                        message: error.to_string(),
-                    },
-                },
+                    TerminalWsError::Attach(TerminalWsErrorCode::PtyError),
+                    cause.to_string(),
+                ),
             )
             .await;
             return;
@@ -220,24 +277,6 @@ fn handle_attached_request(deps: &TerminalApiDeps, text: &str) -> Option<Termina
         Ok(request) => request,
         Err(error) => return Some(invalid_request(error.to_string())),
     };
-    let error = |operation: &'static str, message: String| {
-        Some(TerminalWsResponseV1::Error {
-            id: operation.to_string(),
-            error: TerminalWsErrorV1 {
-                code: "PTY_ERROR",
-                message,
-            },
-        })
-    };
-    let invalid_owner = |operation: &'static str, message: String| {
-        Some(TerminalWsResponseV1::Error {
-            id: operation.to_string(),
-            error: TerminalWsErrorV1 {
-                code: "INVALID_REQUEST",
-                message,
-            },
-        })
-    };
     match request {
         TerminalWsAttachedRequestV1::Write {
             owner,
@@ -248,7 +287,13 @@ fn handle_attached_request(deps: &TerminalApiDeps, text: &str) -> Option<Termina
         } => {
             let owner = match owner.try_into() {
                 Ok(owner) => owner,
-                Err(message) => return invalid_owner("write", message),
+                Err(cause) => {
+                    return Some(terminal_ws_error(
+                        "write".to_string(),
+                        TerminalWsError::Write(TerminalWsErrorCode::InvalidRequest),
+                        cause,
+                    ));
+                }
             };
             match deps.application.write_attached(
                 &owner,
@@ -258,7 +303,11 @@ fn handle_attached_request(deps: &TerminalApiDeps, text: &str) -> Option<Termina
                 &data,
             ) {
                 Ok(()) => None,
-                Err(cause) => error("write", cause.to_string()),
+                Err(cause) => Some(terminal_ws_error(
+                    "write".to_string(),
+                    TerminalWsError::Write(TerminalWsErrorCode::PtyError),
+                    cause.to_string(),
+                )),
             }
         }
         TerminalWsAttachedRequestV1::Ack {
@@ -272,24 +321,57 @@ fn handle_attached_request(deps: &TerminalApiDeps, text: &str) -> Option<Termina
         TerminalWsAttachedRequestV1::Resize { owner, rows, cols } => {
             let owner = match owner.try_into() {
                 Ok(owner) => owner,
-                Err(message) => return invalid_owner("resize", message),
+                Err(cause) => {
+                    return Some(terminal_ws_error(
+                        "resize".to_string(),
+                        TerminalWsError::Resize(TerminalWsErrorCode::InvalidRequest),
+                        cause,
+                    ));
+                }
             };
             match deps.application.resize(&owner, rows, cols) {
                 Ok(()) => None,
-                Err(cause) => error("resize", cause.to_string()),
+                Err(cause) => Some(terminal_ws_error(
+                    "resize".to_string(),
+                    TerminalWsError::Resize(TerminalWsErrorCode::PtyError),
+                    cause.to_string(),
+                )),
             }
         }
     }
 }
 
-fn invalid_request(message: String) -> TerminalWsResponseV1 {
+fn terminal_ws_error(id: String, error: TerminalWsError, cause: String) -> TerminalWsResponseV1 {
+    let code = error.code();
+    match code {
+        TerminalWsErrorCode::InvalidRequest => log::warn!(
+            "Terminal WebSocket request failed: operation={} code={} cause={}",
+            error.name(),
+            code.code(),
+            cause
+        ),
+        TerminalWsErrorCode::PtyError => log::error!(
+            "Terminal WebSocket request failed: operation={} code={} cause={}",
+            error.name(),
+            code.code(),
+            cause
+        ),
+    }
     TerminalWsResponseV1::Error {
-        id: "invalid".to_string(),
+        id,
         error: TerminalWsErrorV1 {
-            code: "INVALID_REQUEST",
-            message,
+            code: code.code(),
+            message: error.message().to_string(),
         },
     }
+}
+
+fn invalid_request(cause: String) -> TerminalWsResponseV1 {
+    terminal_ws_error(
+        "invalid".to_string(),
+        TerminalWsError::InvalidRequest,
+        cause,
+    )
 }
 
 #[cfg(test)]

--- a/src-tauri/src/adaptor/controller/api/terminal_test.rs
+++ b/src-tauri/src/adaptor/controller/api/terminal_test.rs
@@ -440,7 +440,69 @@ async fn test_ターミナル画面接続_不正json_frameにinvalid_requestエ�
     let response = next_json(&mut socket).await;
     assert_eq!(response["status"], "error");
     assert_eq!(response["error"]["code"], "INVALID_REQUEST");
+    assert_eq!(
+        response["error"]["message"],
+        "Terminal request failed because the request is invalid."
+    );
     fixture.server.abort();
+}
+
+#[test]
+fn test_ターミナル画面接続_全エラー操作が固定した利用者向け文言を返す() {
+    // Given
+    let cases = [
+        (
+            TerminalWsError::Attach(TerminalWsErrorCode::PtyError),
+            "PTY_ERROR",
+            "Terminal attachment failed. Try again.",
+        ),
+        (
+            TerminalWsError::Attach(TerminalWsErrorCode::InvalidRequest),
+            "INVALID_REQUEST",
+            "Terminal attachment failed because the request is invalid.",
+        ),
+        (
+            TerminalWsError::Write(TerminalWsErrorCode::PtyError),
+            "PTY_ERROR",
+            "Terminal input could not be sent. Try again.",
+        ),
+        (
+            TerminalWsError::Write(TerminalWsErrorCode::InvalidRequest),
+            "INVALID_REQUEST",
+            "Terminal input could not be sent because the request is invalid.",
+        ),
+        (
+            TerminalWsError::Resize(TerminalWsErrorCode::PtyError),
+            "PTY_ERROR",
+            "Terminal resize failed. Try again.",
+        ),
+        (
+            TerminalWsError::Resize(TerminalWsErrorCode::InvalidRequest),
+            "INVALID_REQUEST",
+            "Terminal resize failed because the request is invalid.",
+        ),
+        (
+            TerminalWsError::InvalidRequest,
+            "INVALID_REQUEST",
+            "Terminal request failed because the request is invalid.",
+        ),
+    ];
+
+    // When / Then
+    for (error, expected_code, expected_message) in cases {
+        let wire = serde_json::to_value(terminal_ws_error(
+            "test".to_string(),
+            error,
+            "internal cause that must not be displayed".to_string(),
+        ))
+        .unwrap();
+        assert_eq!(wire["error"]["code"], expected_code);
+        assert_eq!(wire["error"]["message"], expected_message);
+        assert!(!wire["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("internal cause"));
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src-tauri/src/adaptor/controller/command/agent_session/provider_tui.rs
+++ b/src-tauri/src/adaptor/controller/command/agent_session/provider_tui.rs
@@ -67,7 +67,7 @@ pub async fn update_provider_executable(
     provider: String,
     executable: String,
 ) -> Result<ProviderAvailabilitySnapshotResponse, AppError> {
-    let provider = parse_provider(&provider)?;
+    let provider = parse_provider(&provider, ProviderParseOperation::ConfigureProvider)?;
     let availability = Arc::clone(availability.inner());
     run_provider_availability_blocking(move || {
         availability.update_configured_executable(provider, &executable)
@@ -81,7 +81,7 @@ pub async fn reset_provider_executable(
     availability: State<'_, Arc<ProviderAvailabilityUsecase>>,
     provider: String,
 ) -> Result<ProviderAvailabilitySnapshotResponse, AppError> {
-    let provider = parse_provider(&provider)?;
+    let provider = parse_provider(&provider, ProviderParseOperation::ConfigureProvider)?;
     let availability = Arc::clone(availability.inner());
     run_provider_availability_blocking(move || availability.reset_configured_executable(provider))
         .await
@@ -99,24 +99,179 @@ where
         .map_err(provider_availability_error)
 }
 
+#[derive(Clone, Copy)]
+enum ProviderParseOperation {
+    ConfigureProvider,
+    Start,
+    ResumeHistory,
+}
+
+#[derive(Clone, Copy)]
+enum AgentSessionLaunchOperation {
+    Start,
+    ResumeHistory,
+}
+
+#[derive(Clone, Copy)]
+enum AgentSessionConflictOperation {
+    Start,
+    ResumeHistory,
+    Update,
+}
+
+enum ProviderTuiCodedError {
+    ProviderAvailabilityInvalidExecutable,
+    ProviderAvailabilityConfigUnavailable,
+    ProviderAvailabilityRefreshUnavailable,
+    ProviderAvailabilityCorrupt,
+    AgentSessionInvalidProvider(ProviderParseOperation),
+    AgentSessionProviderUnavailable,
+    AgentSessionInvalidInput(AgentSessionLaunchOperation),
+    AgentSessionConflict(AgentSessionConflictOperation),
+    AgentSessionStorageUnavailable,
+    AgentSessionLaunchUnavailable,
+    AgentSessionTerminalUnavailable,
+    AgentSessionCorrupt,
+    AgentSessionNotFound,
+    AgentSessionInvalidOperation,
+    AgentSessionInvalidRequest,
+    AgentSessionHistoryInvalidRequest,
+    AgentSessionHistoryUnavailable,
+    AgentSessionHistoryCorrupt,
+    ProviderHookHealthInvalidRequest,
+    ProviderHookHealthStorageUnavailable,
+    ProviderHookHealthCorrupt,
+}
+
+fn provider_tui_coded_error(error: ProviderTuiCodedError) -> AppError {
+    let (code, message) = match error {
+        ProviderTuiCodedError::ProviderAvailabilityInvalidExecutable => (
+            "PROVIDER_AVAILABILITY_INVALID_EXECUTABLE",
+            "Enter a Provider executable command name or path.",
+        ),
+        ProviderTuiCodedError::ProviderAvailabilityConfigUnavailable => (
+            "PROVIDER_AVAILABILITY_CONFIG_UNAVAILABLE",
+            "Releash could not access the Provider executable setting. Try again.",
+        ),
+        ProviderTuiCodedError::ProviderAvailabilityRefreshUnavailable => (
+            "PROVIDER_AVAILABILITY_REFRESH_UNAVAILABLE",
+            "Releash could not refresh Provider CLI availability. Try again.",
+        ),
+        ProviderTuiCodedError::ProviderAvailabilityCorrupt => (
+            "PROVIDER_AVAILABILITY_CORRUPT",
+            "Releash could not read Provider CLI availability. Restart Releash and try again.",
+        ),
+        ProviderTuiCodedError::AgentSessionInvalidProvider(operation) => match operation {
+            ProviderParseOperation::ConfigureProvider => {
+                ("AGENT_SESSION_INVALID_PROVIDER", "Select a valid Provider.")
+            }
+            ProviderParseOperation::Start => (
+                "AGENT_SESSION_INVALID_PROVIDER",
+                "Select a Provider before starting the AgentSession.",
+            ),
+            ProviderParseOperation::ResumeHistory => (
+                "AGENT_SESSION_INVALID_PROVIDER",
+                "Select a Provider before resuming the AgentSession.",
+            ),
+        },
+        ProviderTuiCodedError::AgentSessionProviderUnavailable => (
+            "AGENT_SESSION_PROVIDER_UNAVAILABLE",
+            "The selected Provider is unavailable. Check its executable and try again.",
+        ),
+        ProviderTuiCodedError::AgentSessionInvalidInput(operation) => match operation {
+            AgentSessionLaunchOperation::Start => (
+                "AGENT_SESSION_INVALID_INPUT",
+                "Releash could not start the AgentSession because the request is invalid.",
+            ),
+            AgentSessionLaunchOperation::ResumeHistory => (
+                "AGENT_SESSION_INVALID_INPUT",
+                "Releash could not resume the AgentSession because the request is invalid.",
+            ),
+        },
+        ProviderTuiCodedError::AgentSessionConflict(operation) => match operation {
+            AgentSessionConflictOperation::Start => (
+                "AGENT_SESSION_CONFLICT",
+                "The AgentSession could not be started because the request conflicts with current state or its Provider session is already in use. Refresh and try again.",
+            ),
+            AgentSessionConflictOperation::ResumeHistory => (
+                "AGENT_SESSION_CONFLICT",
+                "The AgentSession could not be resumed because it changed or its Provider session is already in use. Refresh and try again.",
+            ),
+            AgentSessionConflictOperation::Update => (
+                "AGENT_SESSION_CONFLICT",
+                "The AgentSession could not be updated because it changed or its Provider session is already in use. Refresh and try again.",
+            ),
+        },
+        ProviderTuiCodedError::AgentSessionStorageUnavailable => (
+            "AGENT_SESSION_STORAGE_UNAVAILABLE",
+            "Releash could not access saved AgentSession data. Try again.",
+        ),
+        ProviderTuiCodedError::AgentSessionLaunchUnavailable => (
+            "AGENT_SESSION_LAUNCH_UNAVAILABLE",
+            "Releash could not complete the Provider operation for this AgentSession. Try again.",
+        ),
+        ProviderTuiCodedError::AgentSessionTerminalUnavailable => (
+            "AGENT_SESSION_TERMINAL_UNAVAILABLE",
+            "Releash could not complete the Terminal operation for this AgentSession. Try again.",
+        ),
+        ProviderTuiCodedError::AgentSessionCorrupt => (
+            "AGENT_SESSION_CORRUPT",
+            "Releash could not continue because the AgentSession data is invalid.",
+        ),
+        ProviderTuiCodedError::AgentSessionNotFound => (
+            "AGENT_SESSION_NOT_FOUND",
+            "The AgentSession is no longer available.",
+        ),
+        ProviderTuiCodedError::AgentSessionInvalidOperation => (
+            "AGENT_SESSION_INVALID_OPERATION",
+            "This operation is not available for the AgentSession in its current state. Refresh and try again.",
+        ),
+        ProviderTuiCodedError::AgentSessionInvalidRequest => (
+            "AGENT_SESSION_INVALID_REQUEST",
+            "Releash could not load the AgentSession because the request is invalid.",
+        ),
+        ProviderTuiCodedError::AgentSessionHistoryInvalidRequest => (
+            "AGENT_SESSION_HISTORY_INVALID_REQUEST",
+            "Releash could not load AgentSession history because the request is invalid.",
+        ),
+        ProviderTuiCodedError::AgentSessionHistoryUnavailable => (
+            "AGENT_SESSION_HISTORY_UNAVAILABLE",
+            "Releash could not load AgentSession history. Try again.",
+        ),
+        ProviderTuiCodedError::AgentSessionHistoryCorrupt => (
+            "AGENT_SESSION_HISTORY_CORRUPT",
+            "Releash could not load AgentSession history because its saved data is invalid.",
+        ),
+        ProviderTuiCodedError::ProviderHookHealthInvalidRequest => (
+            "PROVIDER_HOOK_HEALTH_INVALID_REQUEST",
+            "Releash could not load Provider Hook health because the request is invalid.",
+        ),
+        ProviderTuiCodedError::ProviderHookHealthStorageUnavailable => (
+            "PROVIDER_HOOK_HEALTH_STORAGE_UNAVAILABLE",
+            "Releash could not load Provider Hook health. Try again.",
+        ),
+        ProviderTuiCodedError::ProviderHookHealthCorrupt => (
+            "PROVIDER_HOOK_HEALTH_CORRUPT",
+            "Releash could not load Provider Hook health because its saved data is invalid.",
+        ),
+    };
+    AppError::coded(code, message)
+}
+
 fn provider_availability_error(error: ProviderAvailabilityUsecaseError) -> AppError {
     match error {
-        ProviderAvailabilityUsecaseError::InvalidInput => AppError::coded(
-            "PROVIDER_AVAILABILITY_INVALID_EXECUTABLE",
-            "Provider executable must be a non-empty command name or path",
-        ),
-        ProviderAvailabilityUsecaseError::ConfigUnavailable => AppError::coded(
-            "PROVIDER_AVAILABILITY_CONFIG_UNAVAILABLE",
-            "Provider executable Config is unavailable",
-        ),
-        ProviderAvailabilityUsecaseError::RefreshUnavailable => AppError::coded(
-            "PROVIDER_AVAILABILITY_REFRESH_UNAVAILABLE",
-            "Provider executable search environment refresh failed",
-        ),
-        ProviderAvailabilityUsecaseError::Corrupt => AppError::coded(
-            "PROVIDER_AVAILABILITY_CORRUPT",
-            "Provider availability registry is unavailable",
-        ),
+        ProviderAvailabilityUsecaseError::InvalidInput => {
+            provider_tui_coded_error(ProviderTuiCodedError::ProviderAvailabilityInvalidExecutable)
+        }
+        ProviderAvailabilityUsecaseError::ConfigUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::ProviderAvailabilityConfigUnavailable)
+        }
+        ProviderAvailabilityUsecaseError::RefreshUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::ProviderAvailabilityRefreshUnavailable)
+        }
+        ProviderAvailabilityUsecaseError::Corrupt => {
+            provider_tui_coded_error(ProviderTuiCodedError::ProviderAvailabilityCorrupt)
+        }
     }
 }
 
@@ -131,7 +286,7 @@ pub async fn create_agent_session(
     caller_request_id: String,
 ) -> Result<String, AppError> {
     let command_ingress = Instant::now();
-    let provider = parse_provider(&provider)?;
+    let provider = parse_provider(&provider, ProviderParseOperation::Start)?;
     crate::other::telemetry::record_terminal_launch(
         crate::other::telemetry::TerminalLaunch::CommandIngress,
         command_ingress.elapsed(),
@@ -146,7 +301,7 @@ pub async fn create_agent_session(
             caller_request_id,
         })
         .await
-        .map_err(launch_error)
+        .map_err(|error| launch_error(error, AgentSessionLaunchOperation::Start))
 }
 
 #[tauri::command]
@@ -161,7 +316,7 @@ pub async fn resume_agent_session_history_candidate(
     cols: u16,
     caller_request_id: String,
 ) -> Result<String, AppError> {
-    let provider = parse_provider(&provider)?;
+    let provider = parse_provider(&provider, ProviderParseOperation::ResumeHistory)?;
     let outcome = launch
         .resume_history(AgentSessionHistoryResumeRequest {
             workspace: WorkspaceIdentity::new(workspace_identity),
@@ -173,7 +328,7 @@ pub async fn resume_agent_session_history_candidate(
             caller_request_id,
         })
         .await
-        .map_err(launch_error)?;
+        .map_err(|error| launch_error(error, AgentSessionLaunchOperation::ResumeHistory))?;
     Ok(match outcome {
         crate::usecase::agent_session::AgentSessionHistoryResumeOutcome::Open(session)
         | crate::usecase::agent_session::AgentSessionHistoryResumeOutcome::Paused(session) => {
@@ -182,13 +337,15 @@ pub async fn resume_agent_session_history_candidate(
     })
 }
 
-fn parse_provider(value: &str) -> Result<ProviderKind, AppError> {
+fn parse_provider(
+    value: &str,
+    operation: ProviderParseOperation,
+) -> Result<ProviderKind, AppError> {
     match value {
         "claude" => Ok(ProviderKind::Claude),
         "codex" => Ok(ProviderKind::Codex),
-        _ => Err(AppError::coded(
-            "AGENT_SESSION_INVALID_PROVIDER",
-            "Provider must be selected explicitly",
+        _ => Err(provider_tui_coded_error(
+            ProviderTuiCodedError::AgentSessionInvalidProvider(operation),
         )),
     }
 }
@@ -359,35 +516,38 @@ impl From<ProviderHookHealthWarning> for ProviderHookHealthWarningResponse {
     }
 }
 
-fn launch_error(error: AgentSessionLaunchUsecaseError) -> AppError {
+fn launch_error(
+    error: AgentSessionLaunchUsecaseError,
+    operation: AgentSessionLaunchOperation,
+) -> AppError {
     match error {
-        AgentSessionLaunchUsecaseError::ProviderUnavailable => AppError::coded(
-            "AGENT_SESSION_PROVIDER_UNAVAILABLE",
-            "Selected Provider is unavailable",
-        ),
-        AgentSessionLaunchUsecaseError::InvalidInput => AppError::coded(
-            "AGENT_SESSION_INVALID_INPUT",
-            "AgentSession launch input is invalid",
-        ),
-        AgentSessionLaunchUsecaseError::Conflict => AppError::coded(
-            "AGENT_SESSION_CONFLICT",
-            "AgentSession conflicts with current state",
-        ),
-        AgentSessionLaunchUsecaseError::StorageUnavailable => AppError::coded(
-            "AGENT_SESSION_STORAGE_UNAVAILABLE",
-            "AgentSession persistence is unavailable",
-        ),
-        AgentSessionLaunchUsecaseError::LaunchUnavailable => AppError::coded(
-            "AGENT_SESSION_LAUNCH_UNAVAILABLE",
-            "Provider launch preparation is unavailable",
-        ),
+        AgentSessionLaunchUsecaseError::ProviderUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionProviderUnavailable)
+        }
+        AgentSessionLaunchUsecaseError::InvalidInput => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionInvalidInput(operation))
+        }
+        AgentSessionLaunchUsecaseError::Conflict => {
+            let operation = match operation {
+                AgentSessionLaunchOperation::Start => AgentSessionConflictOperation::Start,
+                AgentSessionLaunchOperation::ResumeHistory => {
+                    AgentSessionConflictOperation::ResumeHistory
+                }
+            };
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionConflict(operation))
+        }
+        AgentSessionLaunchUsecaseError::StorageUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionStorageUnavailable)
+        }
+        AgentSessionLaunchUsecaseError::LaunchUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionLaunchUnavailable)
+        }
         AgentSessionLaunchUsecaseError::TerminalUnavailable
-        | AgentSessionLaunchUsecaseError::TerminalSpawn(_) => AppError::coded(
-            "AGENT_SESSION_TERMINAL_UNAVAILABLE",
-            "AgentSession Terminal Surface is unavailable",
-        ),
+        | AgentSessionLaunchUsecaseError::TerminalSpawn(_) => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionTerminalUnavailable)
+        }
         AgentSessionLaunchUsecaseError::Corrupt => {
-            AppError::coded("AGENT_SESSION_CORRUPT", "AgentSession state is corrupt")
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionCorrupt)
         }
     }
 }
@@ -395,85 +555,71 @@ fn launch_error(error: AgentSessionLaunchUsecaseError) -> AppError {
 fn lifecycle_error(error: AgentSessionLifecycleUsecaseError) -> AppError {
     match error {
         AgentSessionLifecycleUsecaseError::NotFound => {
-            AppError::coded("AGENT_SESSION_NOT_FOUND", "AgentSession was not found")
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionNotFound)
         }
-        AgentSessionLifecycleUsecaseError::InvalidOperation => AppError::coded(
-            "AGENT_SESSION_INVALID_OPERATION",
-            "AgentSession operation is not allowed in the current state",
+        AgentSessionLifecycleUsecaseError::InvalidOperation => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionInvalidOperation)
+        }
+        AgentSessionLifecycleUsecaseError::Conflict => provider_tui_coded_error(
+            ProviderTuiCodedError::AgentSessionConflict(AgentSessionConflictOperation::Update),
         ),
-        AgentSessionLifecycleUsecaseError::Conflict => AppError::coded(
-            "AGENT_SESSION_CONFLICT",
-            "AgentSession conflicts with current state",
-        ),
-        AgentSessionLifecycleUsecaseError::StorageUnavailable => AppError::coded(
-            "AGENT_SESSION_STORAGE_UNAVAILABLE",
-            "AgentSession persistence is unavailable",
-        ),
-        AgentSessionLifecycleUsecaseError::LaunchUnavailable => AppError::coded(
-            "AGENT_SESSION_LAUNCH_UNAVAILABLE",
-            "Provider launch preparation is unavailable",
-        ),
-        AgentSessionLifecycleUsecaseError::TerminalUnavailable => AppError::coded(
-            "AGENT_SESSION_TERMINAL_UNAVAILABLE",
-            "AgentSession Terminal Surface is unavailable",
-        ),
+        AgentSessionLifecycleUsecaseError::StorageUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionStorageUnavailable)
+        }
+        AgentSessionLifecycleUsecaseError::LaunchUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionLaunchUnavailable)
+        }
+        AgentSessionLifecycleUsecaseError::TerminalUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionTerminalUnavailable)
+        }
         AgentSessionLifecycleUsecaseError::Corrupt => {
-            AppError::coded("AGENT_SESSION_CORRUPT", "AgentSession state is corrupt")
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionCorrupt)
         }
     }
 }
 
 fn read_error(error: AgentSessionReadUsecaseError) -> AppError {
     match error {
-        AgentSessionReadUsecaseError::InvalidRequest => AppError::coded(
-            "AGENT_SESSION_INVALID_REQUEST",
-            "AgentSession read request is invalid",
-        ),
-        AgentSessionReadUsecaseError::StorageUnavailable => AppError::coded(
-            "AGENT_SESSION_STORAGE_UNAVAILABLE",
-            "AgentSession persistence is unavailable",
-        ),
-        AgentSessionReadUsecaseError::TerminalUnavailable => AppError::coded(
-            "AGENT_SESSION_TERMINAL_UNAVAILABLE",
-            "AgentSession Terminal Surface is unavailable",
-        ),
+        AgentSessionReadUsecaseError::InvalidRequest => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionInvalidRequest)
+        }
+        AgentSessionReadUsecaseError::StorageUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionStorageUnavailable)
+        }
+        AgentSessionReadUsecaseError::TerminalUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionTerminalUnavailable)
+        }
         AgentSessionReadUsecaseError::Corrupt => {
-            AppError::coded("AGENT_SESSION_CORRUPT", "AgentSession state is corrupt")
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionCorrupt)
         }
     }
 }
 
 fn history_error(error: AgentSessionHistoryQueryError) -> AppError {
     match error {
-        AgentSessionHistoryQueryError::InvalidRequest => AppError::coded(
-            "AGENT_SESSION_HISTORY_INVALID_REQUEST",
-            "AgentSession history request is invalid",
-        ),
-        AgentSessionHistoryQueryError::Unavailable => AppError::coded(
-            "AGENT_SESSION_HISTORY_UNAVAILABLE",
-            "AgentSession history is unavailable",
-        ),
-        AgentSessionHistoryQueryError::Corrupt => AppError::coded(
-            "AGENT_SESSION_HISTORY_CORRUPT",
-            "AgentSession history is corrupt",
-        ),
+        AgentSessionHistoryQueryError::InvalidRequest => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionHistoryInvalidRequest)
+        }
+        AgentSessionHistoryQueryError::Unavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionHistoryUnavailable)
+        }
+        AgentSessionHistoryQueryError::Corrupt => {
+            provider_tui_coded_error(ProviderTuiCodedError::AgentSessionHistoryCorrupt)
+        }
     }
 }
 
 fn hook_health_error(error: ProviderHookHealthUsecaseError) -> AppError {
     match error {
-        ProviderHookHealthUsecaseError::InvalidInput => AppError::coded(
-            "PROVIDER_HOOK_HEALTH_INVALID_REQUEST",
-            "Provider Hook health request is invalid",
-        ),
-        ProviderHookHealthUsecaseError::StorageUnavailable => AppError::coded(
-            "PROVIDER_HOOK_HEALTH_STORAGE_UNAVAILABLE",
-            "Provider Hook health persistence is unavailable",
-        ),
-        ProviderHookHealthUsecaseError::Corrupt => AppError::coded(
-            "PROVIDER_HOOK_HEALTH_CORRUPT",
-            "Provider Hook health state is corrupt",
-        ),
+        ProviderHookHealthUsecaseError::InvalidInput => {
+            provider_tui_coded_error(ProviderTuiCodedError::ProviderHookHealthInvalidRequest)
+        }
+        ProviderHookHealthUsecaseError::StorageUnavailable => {
+            provider_tui_coded_error(ProviderTuiCodedError::ProviderHookHealthStorageUnavailable)
+        }
+        ProviderHookHealthUsecaseError::Corrupt => {
+            provider_tui_coded_error(ProviderTuiCodedError::ProviderHookHealthCorrupt)
+        }
     }
 }
 

--- a/src-tauri/src/adaptor/controller/command/agent_session/provider_tui_test.rs
+++ b/src-tauri/src/adaptor/controller/command/agent_session/provider_tui_test.rs
@@ -37,32 +37,319 @@ fn test_agent_session_controller_domain結果をwire語彙へ変換する() {
 #[test]
 fn test_agent_session_controller_provider未選択と未知値を起動前に拒否する() {
     assert_eq!(
-        parse_provider("claude").unwrap(),
+        parse_provider("claude", ProviderParseOperation::Start).unwrap(),
         crate::domain::provider_lifecycle::ProviderKind::Claude
     );
     assert_eq!(
-        parse_provider("codex").unwrap(),
+        parse_provider("codex", ProviderParseOperation::Start).unwrap(),
         crate::domain::provider_lifecycle::ProviderKind::Codex
     );
-    let missing = serde_json::to_value(parse_provider("").unwrap_err()).unwrap();
-    let unknown = serde_json::to_value(parse_provider("unknown").unwrap_err()).unwrap();
+    let missing =
+        serde_json::to_value(parse_provider("", ProviderParseOperation::Start).unwrap_err())
+            .unwrap();
+    let unknown =
+        serde_json::to_value(parse_provider("unknown", ProviderParseOperation::Start).unwrap_err())
+            .unwrap();
     assert_eq!(missing["code"], "AGENT_SESSION_INVALID_PROVIDER");
     assert_eq!(unknown["code"], "AGENT_SESSION_INVALID_PROVIDER");
 }
 
 #[test]
 fn test_agent_session_controller_terminal_spawn詳細を既存の利用者向けerrorへ変換する() {
-    let error = launch_error(AgentSessionLaunchUsecaseError::TerminalSpawn(
-        crate::domain::agent_session::ProviderAgentTerminalSpawnError::PerWorktreeCap {
-            worktree_path: "/repo/worktree".to_string(),
-        },
-    ));
-    let value = serde_json::to_value(error).unwrap();
+    // Given
+    let internal_worktree_path = "/repo/worktree";
 
+    // When
+    let error = launch_error(
+        AgentSessionLaunchUsecaseError::TerminalSpawn(
+            crate::domain::agent_session::ProviderAgentTerminalSpawnError::PerWorktreeCap {
+                worktree_path: internal_worktree_path.to_string(),
+            },
+        ),
+        AgentSessionLaunchOperation::Start,
+    );
+
+    // Then
+    let value = serde_json::to_value(error).unwrap();
     assert_eq!(value["code"], "AGENT_SESSION_TERMINAL_UNAVAILABLE");
     assert_eq!(
         value["message"],
-        "AgentSession Terminal Surface is unavailable"
+        "Releash could not complete the Terminal operation for this AgentSession. Try again."
     );
-    assert!(!value.to_string().contains("/repo/worktree"));
+    assert!(!value.to_string().contains(internal_worktree_path));
+}
+
+#[test]
+fn test_agent_session_controller_対象21codeを利用者向け英語文言へ変換する() {
+    // Given
+    let cases = [
+        (
+            provider_availability_error(ProviderAvailabilityUsecaseError::InvalidInput),
+            "PROVIDER_AVAILABILITY_INVALID_EXECUTABLE",
+            "Enter a Provider executable command name or path.",
+        ),
+        (
+            provider_availability_error(ProviderAvailabilityUsecaseError::ConfigUnavailable),
+            "PROVIDER_AVAILABILITY_CONFIG_UNAVAILABLE",
+            "Releash could not access the Provider executable setting. Try again.",
+        ),
+        (
+            provider_availability_error(ProviderAvailabilityUsecaseError::RefreshUnavailable),
+            "PROVIDER_AVAILABILITY_REFRESH_UNAVAILABLE",
+            "Releash could not refresh Provider CLI availability. Try again.",
+        ),
+        (
+            provider_availability_error(ProviderAvailabilityUsecaseError::Corrupt),
+            "PROVIDER_AVAILABILITY_CORRUPT",
+            "Releash could not read Provider CLI availability. Restart Releash and try again.",
+        ),
+        (
+            parse_provider("unknown", ProviderParseOperation::Start).unwrap_err(),
+            "AGENT_SESSION_INVALID_PROVIDER",
+            "Select a Provider before starting the AgentSession.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::ProviderUnavailable,
+                AgentSessionLaunchOperation::Start,
+            ),
+            "AGENT_SESSION_PROVIDER_UNAVAILABLE",
+            "The selected Provider is unavailable. Check its executable and try again.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::InvalidInput,
+                AgentSessionLaunchOperation::Start,
+            ),
+            "AGENT_SESSION_INVALID_INPUT",
+            "Releash could not start the AgentSession because the request is invalid.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::Conflict,
+                AgentSessionLaunchOperation::Start,
+            ),
+            "AGENT_SESSION_CONFLICT",
+            "The AgentSession could not be started because the request conflicts with current state or its Provider session is already in use. Refresh and try again.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::StorageUnavailable,
+                AgentSessionLaunchOperation::Start,
+            ),
+            "AGENT_SESSION_STORAGE_UNAVAILABLE",
+            "Releash could not access saved AgentSession data. Try again.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::LaunchUnavailable,
+                AgentSessionLaunchOperation::Start,
+            ),
+            "AGENT_SESSION_LAUNCH_UNAVAILABLE",
+            "Releash could not complete the Provider operation for this AgentSession. Try again.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::TerminalUnavailable,
+                AgentSessionLaunchOperation::Start,
+            ),
+            "AGENT_SESSION_TERMINAL_UNAVAILABLE",
+            "Releash could not complete the Terminal operation for this AgentSession. Try again.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::Corrupt,
+                AgentSessionLaunchOperation::Start,
+            ),
+            "AGENT_SESSION_CORRUPT",
+            "Releash could not continue because the AgentSession data is invalid.",
+        ),
+        (
+            lifecycle_error(AgentSessionLifecycleUsecaseError::NotFound),
+            "AGENT_SESSION_NOT_FOUND",
+            "The AgentSession is no longer available.",
+        ),
+        (
+            lifecycle_error(AgentSessionLifecycleUsecaseError::InvalidOperation),
+            "AGENT_SESSION_INVALID_OPERATION",
+            "This operation is not available for the AgentSession in its current state. Refresh and try again.",
+        ),
+        (
+            read_error(AgentSessionReadUsecaseError::InvalidRequest),
+            "AGENT_SESSION_INVALID_REQUEST",
+            "Releash could not load the AgentSession because the request is invalid.",
+        ),
+        (
+            history_error(AgentSessionHistoryQueryError::InvalidRequest),
+            "AGENT_SESSION_HISTORY_INVALID_REQUEST",
+            "Releash could not load AgentSession history because the request is invalid.",
+        ),
+        (
+            history_error(AgentSessionHistoryQueryError::Unavailable),
+            "AGENT_SESSION_HISTORY_UNAVAILABLE",
+            "Releash could not load AgentSession history. Try again.",
+        ),
+        (
+            history_error(AgentSessionHistoryQueryError::Corrupt),
+            "AGENT_SESSION_HISTORY_CORRUPT",
+            "Releash could not load AgentSession history because its saved data is invalid.",
+        ),
+        (
+            hook_health_error(ProviderHookHealthUsecaseError::InvalidInput),
+            "PROVIDER_HOOK_HEALTH_INVALID_REQUEST",
+            "Releash could not load Provider Hook health because the request is invalid.",
+        ),
+        (
+            hook_health_error(ProviderHookHealthUsecaseError::StorageUnavailable),
+            "PROVIDER_HOOK_HEALTH_STORAGE_UNAVAILABLE",
+            "Releash could not load Provider Hook health. Try again.",
+        ),
+        (
+            hook_health_error(ProviderHookHealthUsecaseError::Corrupt),
+            "PROVIDER_HOOK_HEALTH_CORRUPT",
+            "Releash could not load Provider Hook health because its saved data is invalid.",
+        ),
+    ];
+
+    // When / Then
+    for (error, expected_code, expected_message) in cases {
+        assert_coded_error(error, expected_code, expected_message);
+    }
+}
+
+#[test]
+fn test_agent_session_controller_操作依存codeを操作ごとの固定文言へ変換する() {
+    // Given
+    let cases = [
+        (
+            parse_provider("unknown", ProviderParseOperation::ConfigureProvider)
+                .unwrap_err(),
+            "AGENT_SESSION_INVALID_PROVIDER",
+            "Select a valid Provider.",
+        ),
+        (
+            parse_provider("unknown", ProviderParseOperation::Start).unwrap_err(),
+            "AGENT_SESSION_INVALID_PROVIDER",
+            "Select a Provider before starting the AgentSession.",
+        ),
+        (
+            parse_provider("unknown", ProviderParseOperation::ResumeHistory).unwrap_err(),
+            "AGENT_SESSION_INVALID_PROVIDER",
+            "Select a Provider before resuming the AgentSession.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::InvalidInput,
+                AgentSessionLaunchOperation::Start,
+            ),
+            "AGENT_SESSION_INVALID_INPUT",
+            "Releash could not start the AgentSession because the request is invalid.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::InvalidInput,
+                AgentSessionLaunchOperation::ResumeHistory,
+            ),
+            "AGENT_SESSION_INVALID_INPUT",
+            "Releash could not resume the AgentSession because the request is invalid.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::Conflict,
+                AgentSessionLaunchOperation::Start,
+            ),
+            "AGENT_SESSION_CONFLICT",
+            "The AgentSession could not be started because the request conflicts with current state or its Provider session is already in use. Refresh and try again.",
+        ),
+        (
+            launch_error(
+                AgentSessionLaunchUsecaseError::Conflict,
+                AgentSessionLaunchOperation::ResumeHistory,
+            ),
+            "AGENT_SESSION_CONFLICT",
+            "The AgentSession could not be resumed because it changed or its Provider session is already in use. Refresh and try again.",
+        ),
+        (
+            lifecycle_error(AgentSessionLifecycleUsecaseError::Conflict),
+            "AGENT_SESSION_CONFLICT",
+            "The AgentSession could not be updated because it changed or its Provider session is already in use. Refresh and try again.",
+        ),
+    ];
+
+    // When / Then
+    for (error, expected_code, expected_message) in cases {
+        assert_coded_error(error, expected_code, expected_message);
+    }
+}
+
+#[test]
+fn test_agent_session_controller_共有codeは全usecase_error経路で同じ文言になる() {
+    // Given / When / Then
+    assert_coded_errors(
+        [
+            launch_error(
+                AgentSessionLaunchUsecaseError::StorageUnavailable,
+                AgentSessionLaunchOperation::Start,
+            ),
+            lifecycle_error(AgentSessionLifecycleUsecaseError::StorageUnavailable),
+            read_error(AgentSessionReadUsecaseError::StorageUnavailable),
+        ],
+        "AGENT_SESSION_STORAGE_UNAVAILABLE",
+        "Releash could not access saved AgentSession data. Try again.",
+    );
+    assert_coded_errors(
+        [
+            launch_error(
+                AgentSessionLaunchUsecaseError::LaunchUnavailable,
+                AgentSessionLaunchOperation::Start,
+            ),
+            lifecycle_error(AgentSessionLifecycleUsecaseError::LaunchUnavailable),
+        ],
+        "AGENT_SESSION_LAUNCH_UNAVAILABLE",
+        "Releash could not complete the Provider operation for this AgentSession. Try again.",
+    );
+    assert_coded_errors(
+        [
+            launch_error(
+                AgentSessionLaunchUsecaseError::TerminalUnavailable,
+                AgentSessionLaunchOperation::Start,
+            ),
+            lifecycle_error(AgentSessionLifecycleUsecaseError::TerminalUnavailable),
+            read_error(AgentSessionReadUsecaseError::TerminalUnavailable),
+        ],
+        "AGENT_SESSION_TERMINAL_UNAVAILABLE",
+        "Releash could not complete the Terminal operation for this AgentSession. Try again.",
+    );
+    assert_coded_errors(
+        [
+            launch_error(
+                AgentSessionLaunchUsecaseError::Corrupt,
+                AgentSessionLaunchOperation::Start,
+            ),
+            lifecycle_error(AgentSessionLifecycleUsecaseError::Corrupt),
+            read_error(AgentSessionReadUsecaseError::Corrupt),
+        ],
+        "AGENT_SESSION_CORRUPT",
+        "Releash could not continue because the AgentSession data is invalid.",
+    );
+}
+
+fn assert_coded_errors<const N: usize>(
+    errors: [AppError; N],
+    expected_code: &str,
+    expected_message: &str,
+) {
+    for error in errors {
+        assert_coded_error(error, expected_code, expected_message);
+    }
+}
+
+fn assert_coded_error(error: AppError, expected_code: &str, expected_message: &str) {
+    assert_eq!(
+        serde_json::to_value(error).unwrap(),
+        serde_json::json!({
+            "code": expected_code,
+            "message": expected_message,
+        })
+    );
 }

--- a/src-tauri/src/adaptor/controller/command/code/mod.rs
+++ b/src-tauri/src/adaptor/controller/command/code/mod.rs
@@ -45,6 +45,8 @@ pub(super) const COMMAND_NAMES: &[&str] = &[
 ];
 
 const STALE_REVIEW_GROUP_TARGET_ERROR_CODE: &str = "STALE_REVIEW_GROUP_TARGET";
+const STALE_REVIEW_GROUP_TARGET_ERROR_MESSAGE: &str =
+    "The review changed before the operation completed. Reload the review and try again.";
 
 pub(crate) fn register(router: &mut super::CommandRouter) {
     router.register_domain(COMMAND_NAMES, Box::new(invoke_handler()));
@@ -88,8 +90,16 @@ impl From<CodeUsecaseError> for AppError {
     fn from(e: CodeUsecaseError) -> Self {
         let message = e.to_string();
         match &e {
-            CodeUsecaseError::Code(CodeError::StaleReviewGroupTarget { .. }) => {
-                AppError::coded(STALE_REVIEW_GROUP_TARGET_ERROR_CODE, message)
+            CodeUsecaseError::Code(CodeError::StaleReviewGroupTarget { group_id }) => {
+                log::warn!(
+                    "code command failed: code={} group_id={}",
+                    STALE_REVIEW_GROUP_TARGET_ERROR_CODE,
+                    group_id
+                );
+                AppError::coded(
+                    STALE_REVIEW_GROUP_TARGET_ERROR_CODE,
+                    STALE_REVIEW_GROUP_TARGET_ERROR_MESSAGE,
+                )
             }
             _ => AppError::Internal(message),
         }
@@ -136,19 +146,26 @@ mod tests {
     }
 
     #[test]
-    fn stale_review_group_targetは機械可読codeを持つerrorとして返す() {
+    fn test_review_group操作_staleな対象はcodeと利用者向けmessageを持つerrorとして返す() {
+        // Given
+        let internal_group_id = "g:old:0";
         let usecase_err = CodeUsecaseError::Code(CodeError::StaleReviewGroupTarget {
-            group_id: "g:old:0".to_string(),
+            group_id: internal_group_id.to_string(),
         });
+
+        // When
         let app_err = AppError::from(usecase_err);
 
-        assert_eq!(app_err.to_string(), "review group target stale: g:old:0");
+        // Then
+        assert_eq!(app_err.to_string(), STALE_REVIEW_GROUP_TARGET_ERROR_MESSAGE);
         assert_eq!(
             serde_json::to_value(&app_err).unwrap(),
             serde_json::json!({
                 "code": STALE_REVIEW_GROUP_TARGET_ERROR_CODE,
-                "message": "review group target stale: g:old:0"
+                "message": STALE_REVIEW_GROUP_TARGET_ERROR_MESSAGE
             })
         );
+        assert!(!app_err.to_string().contains(internal_group_id));
+        assert!(!app_err.to_string().contains("review group target stale"));
     }
 }

--- a/src-tauri/src/adaptor/controller/command/terminal_surface/commands.rs
+++ b/src-tauri/src/adaptor/controller/command/terminal_surface/commands.rs
@@ -13,15 +13,70 @@ use crate::usecase::terminal_surface::application::{
 };
 use crate::usecase::terminal_surface::error::UsecaseError;
 
-const PTY_ERROR_CODE_CAP_REACHED: &str = "CAP_REACHED";
-const PTY_ERROR_CODE_GENERIC: &str = "PTY_ERROR";
-const PTY_ERROR_CODE_INVALID_REQUEST: &str = "INVALID_REQUEST";
+#[derive(Clone, Copy)]
+enum TerminalCommandErrorCode {
+    CapReached,
+    PtyError,
+    InvalidRequest,
+}
 
-fn invalid_owner_error(message: String) -> TerminalCommandError {
-    TerminalCommandError {
-        code: PTY_ERROR_CODE_INVALID_REQUEST.to_string(),
-        message,
+impl TerminalCommandErrorCode {
+    fn code(self) -> &'static str {
+        match self {
+            Self::CapReached => "CAP_REACHED",
+            Self::PtyError => "PTY_ERROR",
+            Self::InvalidRequest => "INVALID_REQUEST",
+        }
     }
+}
+
+fn invalid_owner_error(
+    operation: TerminalCommandOperation,
+    internal_cause: String,
+) -> TerminalCommandError {
+    let code = TerminalCommandErrorCode::InvalidRequest;
+    log::warn!(
+        "Terminal command failed: operation={} code={} cause={}",
+        operation.name(),
+        code.code(),
+        internal_cause
+    );
+    TerminalCommandError {
+        code: code.code().to_string(),
+        message: operation.message(code).to_string(),
+    }
+}
+
+fn invalid_terminal_write_owner_error(internal_cause: String) -> String {
+    log::warn!(
+        "Terminal command failed: operation=write_terminal_surface code=INVALID_REQUEST cause={}",
+        internal_cause
+    );
+    "Terminal input could not be sent because the request is invalid.".to_string()
+}
+
+fn terminal_write_error(error: UsecaseError) -> String {
+    log::error!(
+        "Terminal command failed: operation=write_terminal_surface code=PTY_ERROR cause={}",
+        error
+    );
+    "Terminal input could not be sent. Try again.".to_string()
+}
+
+fn invalid_terminal_resize_owner_error(internal_cause: String) -> String {
+    log::warn!(
+        "Terminal command failed: operation=resize_terminal_surface code=INVALID_REQUEST cause={}",
+        internal_cause
+    );
+    "Terminal resize failed because the request is invalid.".to_string()
+}
+
+fn terminal_resize_error(error: UsecaseError) -> String {
+    log::error!(
+        "Terminal command failed: operation=resize_terminal_surface code=PTY_ERROR cause={}",
+        error
+    );
+    "Terminal resize failed. Try again.".to_string()
 }
 
 #[tauri::command(async)]
@@ -116,20 +171,90 @@ pub struct TerminalCommandError {
     pub message: String,
 }
 
-impl From<UsecaseError> for TerminalCommandError {
-    fn from(error: UsecaseError) -> Self {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TerminalCommandOperation {
+    Initialize,
+    GetExisting,
+    Attach,
+    Resynchronize,
+}
+
+impl TerminalCommandOperation {
+    fn attachment(recovery: bool) -> Self {
+        if recovery {
+            Self::Resynchronize
+        } else {
+            Self::Attach
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Initialize => "get_or_spawn_terminal_surface",
+            Self::GetExisting => "get_terminal_surface",
+            Self::Attach => "attach_terminal_surface",
+            Self::Resynchronize => "attach_terminal_surface_recovery",
+        }
+    }
+
+    fn message(self, code: TerminalCommandErrorCode) -> &'static str {
+        match (self, code) {
+            (_, TerminalCommandErrorCode::CapReached) => {
+                "Terminal limit reached. Close an open Terminal and try again."
+            }
+            (Self::Initialize, TerminalCommandErrorCode::PtyError) => {
+                "Terminal initialization failed. Try again."
+            }
+            (Self::Initialize, TerminalCommandErrorCode::InvalidRequest) => {
+                "Terminal initialization failed because the request is invalid."
+            }
+            (Self::GetExisting | Self::Attach, TerminalCommandErrorCode::PtyError) => {
+                "Terminal attachment failed. Try again."
+            }
+            (Self::GetExisting | Self::Attach, TerminalCommandErrorCode::InvalidRequest) => {
+                "Terminal attachment failed because the request is invalid."
+            }
+            (Self::Resynchronize, TerminalCommandErrorCode::PtyError) => {
+                "Terminal resynchronization failed. Try again."
+            }
+            (Self::Resynchronize, TerminalCommandErrorCode::InvalidRequest) => {
+                "Terminal resynchronization failed because the request is invalid."
+            }
+        }
+    }
+}
+
+impl TerminalCommandError {
+    fn from_usecase(error: UsecaseError, operation: TerminalCommandOperation) -> Self {
+        let internal_cause = error.to_string();
         let code = match error {
             UsecaseError::PerWorktreeCap { .. } | UsecaseError::TotalCap => {
-                PTY_ERROR_CODE_CAP_REACHED
+                TerminalCommandErrorCode::CapReached
             }
             UsecaseError::Gateway(_)
             | UsecaseError::OwnerConflict
             | UsecaseError::PtySpawn { .. }
-            | UsecaseError::OtherSpawnFailure { .. } => PTY_ERROR_CODE_GENERIC,
+            | UsecaseError::OtherSpawnFailure { .. } => TerminalCommandErrorCode::PtyError,
         };
+        match code {
+            TerminalCommandErrorCode::CapReached => log::warn!(
+                "Terminal command failed: operation={} code={} cause={}",
+                operation.name(),
+                code.code(),
+                internal_cause
+            ),
+            TerminalCommandErrorCode::PtyError | TerminalCommandErrorCode::InvalidRequest => {
+                log::error!(
+                    "Terminal command failed: operation={} code={} cause={}",
+                    operation.name(),
+                    code.code(),
+                    internal_cause
+                )
+            }
+        }
         Self {
-            code: code.to_string(),
-            message: error.to_string(),
+            code: code.code().to_string(),
+            message: operation.message(code).to_string(),
         }
     }
 }
@@ -143,7 +268,9 @@ pub fn write_terminal_surface(
     client_started_at_unix_ms: Option<f64>,
     data: String,
 ) -> Result<(), String> {
-    let owner = owner.try_into()?;
+    let owner = owner
+        .try_into()
+        .map_err(invalid_terminal_write_owner_error)?;
     state
         .terminal_surface
         .write_attached(
@@ -153,7 +280,7 @@ pub fn write_terminal_surface(
             client_started_at_unix_ms,
             &data,
         )
-        .map_err(|error| error.to_string())
+        .map_err(terminal_write_error)
 }
 
 #[tauri::command(async)]
@@ -176,11 +303,13 @@ pub fn resize_terminal_surface(
     rows: u16,
     cols: u16,
 ) -> Result<(), String> {
-    let owner = owner.try_into()?;
+    let owner = owner
+        .try_into()
+        .map_err(invalid_terminal_resize_owner_error)?;
     state
         .terminal_surface
         .resize(&owner, rows, cols)
-        .map_err(|error| error.to_string())
+        .map_err(terminal_resize_error)
 }
 
 #[tauri::command(async)]
@@ -188,12 +317,16 @@ pub fn get_terminal_surface(
     state: State<'_, AppState>,
     owner: TerminalSurfaceOwnerV1,
 ) -> Result<TerminalSurfaceSummaryV1, TerminalCommandError> {
-    let owner = owner.try_into().map_err(invalid_owner_error)?;
+    let owner = owner
+        .try_into()
+        .map_err(|cause| invalid_owner_error(TerminalCommandOperation::GetExisting, cause))?;
     state
         .terminal_surface
         .get_summary(&owner)
         .map(Into::into)
-        .map_err(TerminalCommandError::from)
+        .map_err(|error| {
+            TerminalCommandError::from_usecase(error, TerminalCommandOperation::GetExisting)
+        })
 }
 
 pub(crate) async fn forward_terminal_surface_attachment<F>(
@@ -217,13 +350,17 @@ pub fn attach_terminal_surface(
     state: State<'_, AppState>,
     attachment_id: String,
     owner: TerminalSurfaceOwnerV1,
+    recovery: bool,
     on_event: Channel<TerminalSurfaceStreamItemV1>,
 ) -> Result<(), TerminalCommandError> {
-    let owner = owner.try_into().map_err(invalid_owner_error)?;
+    let operation = TerminalCommandOperation::attachment(recovery);
+    let owner = owner
+        .try_into()
+        .map_err(|cause| invalid_owner_error(operation, cause))?;
     let application = state.terminal_surface.clone();
     let attachment = application
         .attach(&attachment_id, &owner)
-        .map_err(TerminalCommandError::from)?;
+        .map_err(|error| TerminalCommandError::from_usecase(error, operation))?;
     tauri::async_runtime::spawn(forward_terminal_surface_attachment(
         application,
         attachment_id,
@@ -272,12 +409,16 @@ pub fn get_or_spawn_terminal_surface(
     label: Option<String>,
     startup_command: Option<String>,
 ) -> Result<GetOrSpawnTerminalV1, TerminalCommandError> {
-    let owner = owner.try_into().map_err(invalid_owner_error)?;
+    let owner = owner
+        .try_into()
+        .map_err(|cause| invalid_owner_error(TerminalCommandOperation::Initialize, cause))?;
     state
         .terminal_surface
         .get_or_spawn(rows, cols, cwd, owner, label, startup_command)
         .map(Into::into)
-        .map_err(TerminalCommandError::from)
+        .map_err(|error| {
+            TerminalCommandError::from_usecase(error, TerminalCommandOperation::Initialize)
+        })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/adaptor/controller/command/terminal_surface/commands_test.rs
+++ b/src-tauri/src/adaptor/controller/command/terminal_surface/commands_test.rs
@@ -15,24 +15,175 @@ use crate::domain::workspace_tree::WorkspaceIdentity;
 use crate::usecase::terminal_surface::application::TerminalSurfaceApplication;
 
 #[test]
-fn test_ターミナル画面生成_上限到達を安定したコマンドコードへ変換する() {
-    let worktree_error = UsecaseError::from(
-        TerminalSurfaceSpawnReservationError::WorktreeCapReached("/repo".to_string()),
-    );
-    let total_error = UsecaseError::from(TerminalSurfaceSpawnReservationError::TotalCapReached);
+fn test_ターミナル画面生成_上限到達を固定したコマンドエラーへ変換する() {
+    // Given
+    let operations = [
+        TerminalCommandOperation::Initialize,
+        TerminalCommandOperation::GetExisting,
+        TerminalCommandOperation::Attach,
+        TerminalCommandOperation::Resynchronize,
+    ];
 
-    assert_eq!(
-        TerminalCommandError::from(worktree_error).code,
-        PTY_ERROR_CODE_CAP_REACHED
+    // When / Then
+    for operation in operations {
+        let command_error = TerminalCommandError::from_usecase(
+            UsecaseError::from(TerminalSurfaceSpawnReservationError::WorktreeCapReached(
+                "/repo".to_string(),
+            )),
+            operation,
+        );
+        assert_eq!(
+            serde_json::to_value(command_error).unwrap(),
+            serde_json::json!({
+                "code": "CAP_REACHED",
+                "message": "Terminal limit reached. Close an open Terminal and try again.",
+            })
+        );
+    }
+    let total_command_error = TerminalCommandError::from_usecase(
+        UsecaseError::from(TerminalSurfaceSpawnReservationError::TotalCapReached),
+        TerminalCommandOperation::Initialize,
     );
     assert_eq!(
-        TerminalCommandError::from(total_error).code,
-        PTY_ERROR_CODE_CAP_REACHED
+        serde_json::to_value(total_command_error).unwrap(),
+        serde_json::json!({
+            "code": "CAP_REACHED",
+            "message": "Terminal limit reached. Close an open Terminal and try again.",
+        })
     );
 }
 
 #[test]
-fn test_ターミナル画面生成_上限以外のspawn失敗を従来の汎用コードへ変換する() {
+fn test_ターミナル接続_recovery指定を初回接続と再同期へ対応づける() {
+    // Given / When / Then
+    assert_eq!(
+        TerminalCommandOperation::attachment(false),
+        TerminalCommandOperation::Attach
+    );
+    assert_eq!(
+        TerminalCommandOperation::attachment(true),
+        TerminalCommandOperation::Resynchronize
+    );
+}
+
+#[test]
+fn test_ターミナル操作_gateway失敗を操作ごとの固定文言へ変換する() {
+    // Given
+    let cases = [
+        (
+            TerminalCommandOperation::Initialize,
+            "Terminal initialization failed. Try again.",
+        ),
+        (
+            TerminalCommandOperation::GetExisting,
+            "Terminal attachment failed. Try again.",
+        ),
+        (
+            TerminalCommandOperation::Attach,
+            "Terminal attachment failed. Try again.",
+        ),
+        (
+            TerminalCommandOperation::Resynchronize,
+            "Terminal resynchronization failed. Try again.",
+        ),
+    ];
+
+    // When / Then
+    for (operation, expected_message) in cases {
+        let command_error = TerminalCommandError::from_usecase(
+            UsecaseError::Gateway("internal PTY failure".to_string()),
+            operation,
+        );
+        assert_eq!(
+            serde_json::to_value(command_error).unwrap(),
+            serde_json::json!({
+                "code": "PTY_ERROR",
+                "message": expected_message,
+            })
+        );
+    }
+}
+
+#[test]
+fn test_ターミナル操作_不正なownerを操作ごとの固定文言へ変換する() {
+    // Given
+    let cases = [
+        (
+            TerminalCommandOperation::Initialize,
+            "Terminal initialization failed because the request is invalid.",
+        ),
+        (
+            TerminalCommandOperation::GetExisting,
+            "Terminal attachment failed because the request is invalid.",
+        ),
+        (
+            TerminalCommandOperation::Attach,
+            "Terminal attachment failed because the request is invalid.",
+        ),
+        (
+            TerminalCommandOperation::Resynchronize,
+            "Terminal resynchronization failed because the request is invalid.",
+        ),
+    ];
+
+    // When / Then
+    for (operation, expected_message) in cases {
+        let command_error = invalid_owner_error(
+            operation,
+            "invalid Terminal Surface owner: empty workspace path".to_string(),
+        );
+        assert_eq!(
+            serde_json::to_value(command_error).unwrap(),
+            serde_json::json!({
+                "code": "INVALID_REQUEST",
+                "message": expected_message,
+            })
+        );
+    }
+}
+
+#[test]
+fn test_ターミナル入力_write失敗をtransport共通の固定文言へ変換する() {
+    // Given / When
+    let gateway_error = terminal_write_error(UsecaseError::Gateway(
+        "Terminal input reorder buffer is full".to_string(),
+    ));
+    let invalid_owner_error = invalid_terminal_write_owner_error(
+        "invalid Terminal Surface owner: empty workspace path".to_string(),
+    );
+
+    // Then
+    assert_eq!(
+        gateway_error,
+        "Terminal input could not be sent. Try again."
+    );
+    assert_eq!(
+        invalid_owner_error,
+        "Terminal input could not be sent because the request is invalid."
+    );
+}
+
+#[test]
+fn test_ターミナル画面変形_resize失敗をtransport共通の固定文言へ変換する() {
+    // Given / When
+    let gateway_error = terminal_resize_error(UsecaseError::Gateway(
+        "Terminal runtime host is not bound".to_string(),
+    ));
+    let invalid_owner_error = invalid_terminal_resize_owner_error(
+        "invalid Terminal Surface owner: empty workspace path".to_string(),
+    );
+
+    // Then
+    assert_eq!(gateway_error, "Terminal resize failed. Try again.");
+    assert_eq!(
+        invalid_owner_error,
+        "Terminal resize failed because the request is invalid."
+    );
+}
+
+#[test]
+fn test_ターミナル画面生成_上限以外のspawn失敗を汎用codeと固定文言へ変換する() {
+    // Given
     let errors = [
         UsecaseError::OwnerConflict,
         UsecaseError::PtySpawn {
@@ -43,11 +194,21 @@ fn test_ターミナル画面生成_上限以外のspawn失敗を従来の汎用
         },
     ];
 
+    // When / Then
     for error in errors {
+        let internal_cause = error.to_string();
+        let command_error =
+            TerminalCommandError::from_usecase(error, TerminalCommandOperation::Initialize);
+        let wire = serde_json::to_value(command_error).unwrap();
+
         assert_eq!(
-            TerminalCommandError::from(error).code,
-            PTY_ERROR_CODE_GENERIC
+            wire,
+            serde_json::json!({
+                "code": "PTY_ERROR",
+                "message": "Terminal initialization failed. Try again.",
+            })
         );
+        assert!(!wire.to_string().contains(&internal_cause));
     }
 }
 

--- a/src-tauri/src/adaptor/gateway/terminal_surface/event_hub_test.rs
+++ b/src-tauri/src/adaptor/gateway/terminal_surface/event_hub_test.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use crate::domain::terminal_surface::gateway::{
     TerminalSurfaceEvent, TerminalSurfaceEventSink, TerminalSurfaceEventSource,
+    TerminalSurfaceInputUnavailableCause,
 };
 
 use super::TerminalSurfaceEventHub;
@@ -29,7 +30,7 @@ fn test_global_broadcastへはexitだけが流れoutputやresizeは流れない(
     });
     hub.publish(TerminalSurfaceEvent::InputUnavailable {
         session_key: "session".to_string(),
-        message: "unavailable".to_string(),
+        cause: TerminalSurfaceInputUnavailableCause::StaleAttachment,
     });
     assert!(matches!(
         global.try_recv(),

--- a/src-tauri/src/adaptor/gateway/terminal_surface/runtime_gateway_impl.rs
+++ b/src-tauri/src/adaptor/gateway/terminal_surface/runtime_gateway_impl.rs
@@ -15,7 +15,8 @@ use crate::domain::terminal_surface::entities::{
 };
 use crate::domain::terminal_surface::gateway::{
     TerminalRuntimeSpawnRequest, TerminalSurfaceEvent, TerminalSurfaceEventSink,
-    TerminalSurfaceGateway, TerminalSurfaceGatewayError, TerminalSurfaceRepository,
+    TerminalSurfaceGateway, TerminalSurfaceGatewayError, TerminalSurfaceInputUnavailableCause,
+    TerminalSurfaceRepository,
 };
 use crate::domain::terminal_surface::{
     TerminalSurfaceCheckpoint as DomainTerminalCheckpoint, TerminalSurfaceLifecycleConfig,
@@ -525,11 +526,15 @@ impl<R: Runtime> TerminalSurfaceRuntimeGatewayFor<R> {
             .map(|surface| surface.runtime_generation.value())
     }
 
-    fn publish_input_unavailable(&self, session_key: &str, error: &TerminalSurfaceGatewayError) {
+    fn publish_input_unavailable(
+        &self,
+        session_key: &str,
+        cause: TerminalSurfaceInputUnavailableCause,
+    ) {
         if let Some(event_sink) = &self.event_sink {
             event_sink.publish(TerminalSurfaceEvent::InputUnavailable {
                 session_key: session_key.to_string(),
-                message: format!("Failed to write to terminal: {error}"),
+                cause,
             });
         }
     }
@@ -914,20 +919,19 @@ impl<R: Runtime> TerminalSurfaceGateway for TerminalSurfaceRuntimeGatewayFor<R> 
         {
             Ok(ready) => ready,
             Err(TerminalSurfaceInputIngressError::StaleAttachment) => {
-                let error = TerminalSurfaceGatewayError::new(
-                    "Terminal input attachment is no longer active",
-                );
+                let cause = TerminalSurfaceInputUnavailableCause::StaleAttachment;
+                let error = TerminalSurfaceGatewayError::new(cause.internal_cause());
                 drop(ingress);
-                self.publish_input_unavailable(session_key, &error);
+                self.publish_input_unavailable(session_key, cause);
                 return Err(error);
             }
             Err(TerminalSurfaceInputIngressError::PendingCapacityExceeded) => {
-                let error =
-                    TerminalSurfaceGatewayError::new("Terminal input reorder buffer is full");
+                let cause = TerminalSurfaceInputUnavailableCause::PendingCapacityExceeded;
+                let error = TerminalSurfaceGatewayError::new(cause.internal_cause());
                 let should_publish = ingress.record_failure(session_key, attachment_id);
                 drop(ingress);
                 if should_publish {
-                    self.publish_input_unavailable(session_key, &error);
+                    self.publish_input_unavailable(session_key, cause);
                 }
                 return Err(error);
             }
@@ -947,7 +951,12 @@ impl<R: Runtime> TerminalSurfaceGateway for TerminalSurfaceRuntimeGatewayFor<R> 
                 let should_publish = ingress.record_failure(session_key, attachment_id);
                 drop(ingress);
                 if should_publish {
-                    self.publish_input_unavailable(session_key, &error);
+                    self.publish_input_unavailable(
+                        session_key,
+                        TerminalSurfaceInputUnavailableCause::RuntimeWriteFailed(
+                            error.message().to_string(),
+                        ),
+                    );
                 }
                 return Err(error);
             }

--- a/src-tauri/src/adaptor/gateway/terminal_surface/runtime_gateway_impl_test.rs
+++ b/src-tauri/src/adaptor/gateway/terminal_surface/runtime_gateway_impl_test.rs
@@ -555,8 +555,7 @@ fn test_ターミナル画面入力_連続する入力不能をattachment_stream
         recorded.events.lock().unwrap().as_slice(),
         &[TerminalSurfaceEvent::InputUnavailable {
             session_key: "key".to_string(),
-            message: "Failed to write to terminal: Terminal input reorder buffer is full"
-                .to_string(),
+            cause: TerminalSurfaceInputUnavailableCause::PendingCapacityExceeded,
         }]
     );
 }
@@ -580,8 +579,7 @@ fn test_ターミナル画面入力_失効attachmentのwrite失敗はinput_unava
         recorded.events.lock().unwrap().as_slice(),
         &[TerminalSurfaceEvent::InputUnavailable {
             session_key: "key".to_string(),
-            message: "Failed to write to terminal: Terminal input attachment is no longer active"
-                .to_string(),
+            cause: TerminalSurfaceInputUnavailableCause::StaleAttachment,
         }]
     );
 }

--- a/src-tauri/src/adaptor/protocol/application_operation_v1.rs
+++ b/src-tauri/src/adaptor/protocol/application_operation_v1.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 pub(crate) fn decode_nonnegative_i64_decimal(raw: &str) -> Option<i64> {
     if raw.is_empty()
@@ -81,8 +81,39 @@ impl From<crate::domain::local_event::SafeOperationFailure> for SafeOperationFai
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[derive(Serialize)]
+struct ApplicationCommandErrorWire<'a> {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    correlation_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failure: Option<&'a SafeOperationFailureDtoV1>,
+}
+
+impl<'a> ApplicationCommandErrorWire<'a> {
+    fn new(error_type: &'static str, message: &'static str) -> Self {
+        Self {
+            error_type,
+            message,
+            correlation_id: None,
+            failure: None,
+        }
+    }
+
+    fn with_correlation_id(mut self, correlation_id: &'a str) -> Self {
+        self.correlation_id = Some(correlation_id);
+        self
+    }
+
+    fn with_failure(mut self, failure: &'a SafeOperationFailureDtoV1) -> Self {
+        self.failure = Some(failure);
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum OperationApplicationErrorDtoV1 {
     InvalidRequest,
     PayloadConflict,
@@ -90,8 +121,35 @@ pub(crate) enum OperationApplicationErrorDtoV1 {
     Internal { correlation_id: String },
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+impl Serialize for OperationApplicationErrorDtoV1 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let wire = match self {
+            Self::InvalidRequest => ApplicationCommandErrorWire::new(
+                "invalid_request",
+                "Releash could not access application operation history because the request is invalid.",
+            ),
+            Self::PayloadConflict => ApplicationCommandErrorWire::new(
+                "payload_conflict",
+                "The application operation request conflicts with an earlier request. Refresh and try again.",
+            ),
+            Self::ShutdownInProgress => ApplicationCommandErrorWire::new(
+                "shutdown_in_progress",
+                "Releash could not update application operation history while shutdown is in progress. Try again after Releash restarts.",
+            ),
+            Self::Internal { correlation_id } => ApplicationCommandErrorWire::new(
+                "internal",
+                "Releash could not access application operation history. Try again.",
+            )
+            .with_correlation_id(correlation_id),
+        };
+        wire.serialize(serializer)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum ApplicationQuitErrorDtoV1 {
     InvalidRequest,
     PayloadConflict,
@@ -99,8 +157,35 @@ pub(crate) enum ApplicationQuitErrorDtoV1 {
     Internal { correlation_id: String },
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+impl Serialize for ApplicationQuitErrorDtoV1 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let wire = match self {
+            Self::InvalidRequest => ApplicationCommandErrorWire::new(
+                "invalid_request",
+                "Releash could not start the application quit because the request is invalid.",
+            ),
+            Self::PayloadConflict => ApplicationCommandErrorWire::new(
+                "payload_conflict",
+                "The application quit request conflicts with an earlier request. Refresh and try again.",
+            ),
+            Self::CapacityExceeded => ApplicationCommandErrorWire::new(
+                "capacity_exceeded",
+                "Releash could not start another application quit. Wait for the current operation and try again.",
+            ),
+            Self::Internal { correlation_id } => ApplicationCommandErrorWire::new(
+                "internal",
+                "Releash could not complete the application quit. Try again.",
+            )
+            .with_correlation_id(correlation_id),
+        };
+        wire.serialize(serializer)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum ApplicationQuitLookupErrorDtoV1 {
     InvalidRequest,
     NotFound,
@@ -110,14 +195,64 @@ pub(crate) enum ApplicationQuitLookupErrorDtoV1 {
     Internal { correlation_id: String },
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+impl Serialize for ApplicationQuitLookupErrorDtoV1 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let wire = match self {
+            Self::InvalidRequest => ApplicationCommandErrorWire::new(
+                "invalid_request",
+                "Releash could not check the application quit because the request is invalid.",
+            ),
+            Self::NotFound => ApplicationCommandErrorWire::new(
+                "not_found",
+                "The application quit operation is no longer available.",
+            ),
+            Self::QueryBusy => ApplicationCommandErrorWire::new(
+                "query_busy",
+                "Releash is still checking the application quit. Try again.",
+            ),
+            Self::DeadlineExceeded => ApplicationCommandErrorWire::new(
+                "deadline_exceeded",
+                "Checking the application quit took too long. Try again.",
+            ),
+            Self::StorageUnavailable { failure } => ApplicationCommandErrorWire::new(
+                "storage_unavailable",
+                "Releash could not access the application quit operation. Try again.",
+            )
+            .with_failure(failure),
+            Self::Internal { correlation_id } => ApplicationCommandErrorWire::new(
+                "internal",
+                "Releash could not check the application quit. Try again.",
+            )
+            .with_correlation_id(correlation_id),
+        };
+        wire.serialize(serializer)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum CurrentShutdownErrorDtoV1 {
     Internal { correlation_id: String },
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+impl Serialize for CurrentShutdownErrorDtoV1 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let Self::Internal { correlation_id } = self;
+        ApplicationCommandErrorWire::new(
+            "internal",
+            "Releash could not check the current application shutdown. Try again.",
+        )
+        .with_correlation_id(correlation_id)
+        .serialize(serializer)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum ShutdownPlanQueryErrorDtoV1 {
     InvalidRequest,
     NotFound,
@@ -131,20 +266,120 @@ pub(crate) enum ShutdownPlanQueryErrorDtoV1 {
     Internal { correlation_id: String },
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+impl Serialize for ShutdownPlanQueryErrorDtoV1 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let wire = match self {
+            Self::InvalidRequest => ApplicationCommandErrorWire::new(
+                "invalid_request",
+                "Releash could not load the shutdown plan because the request is invalid.",
+            ),
+            Self::NotFound => ApplicationCommandErrorWire::new(
+                "not_found",
+                "The shutdown plan is no longer available.",
+            ),
+            Self::DetailsCompacted => ApplicationCommandErrorWire::new(
+                "details_compacted",
+                "The shutdown plan details are no longer available.",
+            ),
+            Self::CursorMismatch => ApplicationCommandErrorWire::new(
+                "cursor_mismatch",
+                "The shutdown plan changed while it was loading. Reload the plan and try again.",
+            ),
+            Self::CursorExpired => ApplicationCommandErrorWire::new(
+                "cursor_expired",
+                "The shutdown plan page expired. Reload the plan and try again.",
+            ),
+            Self::QueryBusy => ApplicationCommandErrorWire::new(
+                "query_busy",
+                "The shutdown plan is busy. Try again.",
+            ),
+            Self::DeadlineExceeded => ApplicationCommandErrorWire::new(
+                "deadline_exceeded",
+                "Loading the shutdown plan took too long. Try again.",
+            ),
+            Self::ResponseTooLarge => ApplicationCommandErrorWire::new(
+                "response_too_large",
+                "The shutdown plan is too large to load.",
+            ),
+            Self::StorageUnavailable { failure } => ApplicationCommandErrorWire::new(
+                "storage_unavailable",
+                "Releash could not access the shutdown plan. Try again.",
+            )
+            .with_failure(failure),
+            Self::Internal { correlation_id } => ApplicationCommandErrorWire::new(
+                "internal",
+                "Releash could not load the shutdown plan. Try again.",
+            )
+            .with_correlation_id(correlation_id),
+        };
+        wire.serialize(serializer)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum ShutdownDetailsMutationErrorDtoV1 {
     InvalidRequest,
     Internal { correlation_id: String },
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+impl Serialize for ShutdownDetailsMutationErrorDtoV1 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let wire = match self {
+            Self::InvalidRequest => ApplicationCommandErrorWire::new(
+                "invalid_request",
+                "Releash could not compact the shutdown details because the request is invalid.",
+            ),
+            Self::Internal { correlation_id } => ApplicationCommandErrorWire::new(
+                "internal",
+                "Releash could not compact the shutdown details. Try again.",
+            )
+            .with_correlation_id(correlation_id),
+        };
+        wire.serialize(serializer)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum RecoveryActionCommandErrorDtoV1 {
     InvalidRequest,
     NotFound,
     StorageUnavailable { failure: SafeOperationFailureDtoV1 },
     Internal { correlation_id: String },
+}
+
+impl Serialize for RecoveryActionCommandErrorDtoV1 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let wire = match self {
+            Self::InvalidRequest => ApplicationCommandErrorWire::new(
+                "invalid_request",
+                "Releash could not resolve the shutdown target because the request is invalid.",
+            ),
+            Self::NotFound => ApplicationCommandErrorWire::new(
+                "not_found",
+                "The shutdown target action is no longer available. Reload the shutdown plan and try again.",
+            ),
+            Self::StorageUnavailable { failure } => ApplicationCommandErrorWire::new(
+                "storage_unavailable",
+                "Releash could not save the shutdown target action. Try again.",
+            )
+            .with_failure(failure),
+            Self::Internal { correlation_id } => ApplicationCommandErrorWire::new(
+                "internal",
+                "Releash could not resolve the shutdown target action. Try again.",
+            )
+            .with_correlation_id(correlation_id),
+        };
+        wire.serialize(serializer)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -323,3 +558,7 @@ fn recovery_classification_label(
         C::Unchanged => "unchanged",
     }
 }
+
+#[cfg(test)]
+#[path = "application_operation_v1_test.rs"]
+mod application_operation_v1_tests;

--- a/src-tauri/src/adaptor/protocol/application_operation_v1_test.rs
+++ b/src-tauri/src/adaptor/protocol/application_operation_v1_test.rs
@@ -1,0 +1,231 @@
+use super::*;
+
+fn failure() -> SafeOperationFailureDtoV1 {
+    SafeOperationFailureDtoV1 {
+        kind: "storage_unavailable".to_string(),
+        retryable: true,
+        label: "Storage unavailable".to_string(),
+        detail: Some("internal detail".to_string()),
+        correlation_id: "failure-correlation".to_string(),
+    }
+}
+
+#[test]
+fn test_アプリケーション操作エラー_全variantがtypeと利用者向けmessageを直列化する() {
+    // Given
+    let cases = vec![
+        (
+            serde_json::to_value(OperationApplicationErrorDtoV1::InvalidRequest).unwrap(),
+            "invalid_request",
+            "Releash could not access application operation history because the request is invalid.",
+        ),
+        (
+            serde_json::to_value(OperationApplicationErrorDtoV1::PayloadConflict).unwrap(),
+            "payload_conflict",
+            "The application operation request conflicts with an earlier request. Refresh and try again.",
+        ),
+        (
+            serde_json::to_value(OperationApplicationErrorDtoV1::ShutdownInProgress).unwrap(),
+            "shutdown_in_progress",
+            "Releash could not update application operation history while shutdown is in progress. Try again after Releash restarts.",
+        ),
+        (
+            serde_json::to_value(OperationApplicationErrorDtoV1::Internal {
+                correlation_id: "operation-correlation".to_string(),
+            })
+            .unwrap(),
+            "internal",
+            "Releash could not access application operation history. Try again.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitErrorDtoV1::InvalidRequest).unwrap(),
+            "invalid_request",
+            "Releash could not start the application quit because the request is invalid.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitErrorDtoV1::PayloadConflict).unwrap(),
+            "payload_conflict",
+            "The application quit request conflicts with an earlier request. Refresh and try again.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitErrorDtoV1::CapacityExceeded).unwrap(),
+            "capacity_exceeded",
+            "Releash could not start another application quit. Wait for the current operation and try again.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitErrorDtoV1::Internal {
+                correlation_id: "quit-correlation".to_string(),
+            })
+            .unwrap(),
+            "internal",
+            "Releash could not complete the application quit. Try again.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitLookupErrorDtoV1::InvalidRequest).unwrap(),
+            "invalid_request",
+            "Releash could not check the application quit because the request is invalid.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitLookupErrorDtoV1::NotFound).unwrap(),
+            "not_found",
+            "The application quit operation is no longer available.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitLookupErrorDtoV1::QueryBusy).unwrap(),
+            "query_busy",
+            "Releash is still checking the application quit. Try again.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitLookupErrorDtoV1::DeadlineExceeded).unwrap(),
+            "deadline_exceeded",
+            "Checking the application quit took too long. Try again.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitLookupErrorDtoV1::StorageUnavailable {
+                failure: failure(),
+            })
+            .unwrap(),
+            "storage_unavailable",
+            "Releash could not access the application quit operation. Try again.",
+        ),
+        (
+            serde_json::to_value(ApplicationQuitLookupErrorDtoV1::Internal {
+                correlation_id: "lookup-correlation".to_string(),
+            })
+            .unwrap(),
+            "internal",
+            "Releash could not check the application quit. Try again.",
+        ),
+        (
+            serde_json::to_value(CurrentShutdownErrorDtoV1::Internal {
+                correlation_id: "shutdown-correlation".to_string(),
+            })
+            .unwrap(),
+            "internal",
+            "Releash could not check the current application shutdown. Try again.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::InvalidRequest).unwrap(),
+            "invalid_request",
+            "Releash could not load the shutdown plan because the request is invalid.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::NotFound).unwrap(),
+            "not_found",
+            "The shutdown plan is no longer available.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::DetailsCompacted).unwrap(),
+            "details_compacted",
+            "The shutdown plan details are no longer available.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::CursorMismatch).unwrap(),
+            "cursor_mismatch",
+            "The shutdown plan changed while it was loading. Reload the plan and try again.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::CursorExpired).unwrap(),
+            "cursor_expired",
+            "The shutdown plan page expired. Reload the plan and try again.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::QueryBusy).unwrap(),
+            "query_busy",
+            "The shutdown plan is busy. Try again.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::DeadlineExceeded).unwrap(),
+            "deadline_exceeded",
+            "Loading the shutdown plan took too long. Try again.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::ResponseTooLarge).unwrap(),
+            "response_too_large",
+            "The shutdown plan is too large to load.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::StorageUnavailable {
+                failure: failure(),
+            })
+            .unwrap(),
+            "storage_unavailable",
+            "Releash could not access the shutdown plan. Try again.",
+        ),
+        (
+            serde_json::to_value(ShutdownPlanQueryErrorDtoV1::Internal {
+                correlation_id: "plan-correlation".to_string(),
+            })
+            .unwrap(),
+            "internal",
+            "Releash could not load the shutdown plan. Try again.",
+        ),
+        (
+            serde_json::to_value(ShutdownDetailsMutationErrorDtoV1::InvalidRequest).unwrap(),
+            "invalid_request",
+            "Releash could not compact the shutdown details because the request is invalid.",
+        ),
+        (
+            serde_json::to_value(ShutdownDetailsMutationErrorDtoV1::Internal {
+                correlation_id: "details-correlation".to_string(),
+            })
+            .unwrap(),
+            "internal",
+            "Releash could not compact the shutdown details. Try again.",
+        ),
+        (
+            serde_json::to_value(RecoveryActionCommandErrorDtoV1::InvalidRequest).unwrap(),
+            "invalid_request",
+            "Releash could not resolve the shutdown target because the request is invalid.",
+        ),
+        (
+            serde_json::to_value(RecoveryActionCommandErrorDtoV1::NotFound).unwrap(),
+            "not_found",
+            "The shutdown target action is no longer available. Reload the shutdown plan and try again.",
+        ),
+        (
+            serde_json::to_value(RecoveryActionCommandErrorDtoV1::StorageUnavailable {
+                failure: failure(),
+            })
+            .unwrap(),
+            "storage_unavailable",
+            "Releash could not save the shutdown target action. Try again.",
+        ),
+        (
+            serde_json::to_value(RecoveryActionCommandErrorDtoV1::Internal {
+                correlation_id: "recovery-correlation".to_string(),
+            })
+            .unwrap(),
+            "internal",
+            "Releash could not resolve the shutdown target action. Try again.",
+        ),
+    ];
+
+    // When / Then
+    for (wire, expected_type, expected_message) in cases {
+        assert_eq!(wire["type"], expected_type);
+        assert_eq!(wire["message"], expected_message);
+        assert_ne!(wire["message"], "[object Object]");
+    }
+}
+
+#[test]
+fn test_アプリケーション操作エラー_既存の付加fieldを維持する() {
+    // Given / When
+    let internal = serde_json::to_value(ApplicationQuitErrorDtoV1::Internal {
+        correlation_id: "quit-correlation".to_string(),
+    })
+    .unwrap();
+    let storage = serde_json::to_value(ShutdownPlanQueryErrorDtoV1::StorageUnavailable {
+        failure: failure(),
+    })
+    .unwrap();
+
+    // Then
+    assert_eq!(internal["type"], "internal");
+    assert_eq!(internal["correlation_id"], "quit-correlation");
+    assert_eq!(internal.as_object().unwrap().len(), 3);
+    assert_eq!(storage["type"], "storage_unavailable");
+    assert_eq!(storage["failure"]["correlation_id"], "failure-correlation");
+    assert_eq!(storage.as_object().unwrap().len(), 3);
+}

--- a/src-tauri/src/adaptor/protocol/terminal.rs
+++ b/src-tauri/src/adaptor/protocol/terminal.rs
@@ -223,13 +223,16 @@ impl From<TerminalSurfaceStreamItem> for TerminalSurfaceStreamItemV1 {
                 exit_code,
                 sequence,
             },
-            TerminalSurfaceStreamItem::InputUnavailable {
-                session_key,
-                message,
-            } => Self::InputUnavailable {
-                session_key,
-                message,
-            },
+            TerminalSurfaceStreamItem::InputUnavailable { session_key, cause } => {
+                log::error!(
+                    "Terminal input unavailable: operation=write_terminal_surface code=PTY_ERROR cause={}",
+                    cause.internal_cause()
+                );
+                Self::InputUnavailable {
+                    session_key,
+                    message: "Terminal input could not be sent. Try again.".to_string(),
+                }
+            }
         }
     }
 }

--- a/src-tauri/src/adaptor/protocol/terminal_test.rs
+++ b/src-tauri/src/adaptor/protocol/terminal_test.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::domain::terminal_surface::entities::TerminalSurface;
+use crate::domain::terminal_surface::gateway::TerminalSurfaceInputUnavailableCause;
+use crate::usecase::terminal_surface::application::TerminalSurfaceStreamItem;
 use crate::usecase::terminal_surface::spawn_usecase::GetOrSpawnTerminalOutcome;
 
 #[test]
@@ -57,4 +59,36 @@ fn test_ターミナル画面取得または生成_応答で接続前の復元�
     let json = serde_json::to_value(response).unwrap();
     assert!(json.get("terminal_surface").is_none());
     assert_eq!(json["session_key"], "workspace:5:/repo");
+}
+
+#[test]
+fn test_ターミナル入力不能_全内部原因を固定文言へ変換しwireから除外する() {
+    // Given
+    let causes = [
+        TerminalSurfaceInputUnavailableCause::StaleAttachment,
+        TerminalSurfaceInputUnavailableCause::PendingCapacityExceeded,
+        TerminalSurfaceInputUnavailableCause::RuntimeWriteFailed(
+            "PTY writer disconnected".to_string(),
+        ),
+    ];
+
+    // When / Then
+    for cause in causes {
+        let internal_cause = cause.internal_cause().to_string();
+        let item = TerminalSurfaceStreamItemV1::from(TerminalSurfaceStreamItem::InputUnavailable {
+            session_key: "terminal-1".to_string(),
+            cause,
+        });
+        let json = serde_json::to_value(item).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "type": "input_unavailable",
+                "session_key": "terminal-1",
+                "message": "Terminal input could not be sent. Try again.",
+            })
+        );
+        assert!(!json.to_string().contains(&internal_cause));
+    }
 }

--- a/src-tauri/src/domain/terminal_surface/gateway.rs
+++ b/src-tauri/src/domain/terminal_surface/gateway.rs
@@ -45,6 +45,23 @@ impl fmt::Display for TerminalSurfaceGatewayError {
 impl std::error::Error for TerminalSurfaceGatewayError {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TerminalSurfaceInputUnavailableCause {
+    StaleAttachment,
+    PendingCapacityExceeded,
+    RuntimeWriteFailed(String),
+}
+
+impl TerminalSurfaceInputUnavailableCause {
+    pub fn internal_cause(&self) -> &str {
+        match self {
+            Self::StaleAttachment => "Terminal input attachment is no longer active",
+            Self::PendingCapacityExceeded => "Terminal input reorder buffer is full",
+            Self::RuntimeWriteFailed(cause) => cause,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TerminalSurfaceEvent {
     Output {
         session_key: String,
@@ -65,7 +82,7 @@ pub enum TerminalSurfaceEvent {
     },
     InputUnavailable {
         session_key: String,
-        message: String,
+        cause: TerminalSurfaceInputUnavailableCause,
     },
 }
 

--- a/src-tauri/src/usecase/terminal_surface/application.rs
+++ b/src-tauri/src/usecase/terminal_surface/application.rs
@@ -8,6 +8,7 @@ use crate::domain::terminal_surface::entities::{
 use crate::domain::terminal_surface::gateway::{
     TerminalSurfaceEvent, TerminalSurfaceEventCancellation, TerminalSurfaceEventReceiveError,
     TerminalSurfaceEventSource, TerminalSurfaceEventSubscription, TerminalSurfaceGateway,
+    TerminalSurfaceInputUnavailableCause,
 };
 use crate::domain::terminal_surface::{TerminalProcessLaunch, TerminalSurfaceOwner};
 use crate::usecase::terminal_surface::error::UsecaseError;
@@ -63,7 +64,7 @@ pub(crate) enum TerminalSurfaceStreamItem {
     },
     InputUnavailable {
         session_key: String,
-        message: String,
+        cause: TerminalSurfaceInputUnavailableCause,
     },
 }
 
@@ -168,13 +169,12 @@ impl TerminalSurfaceAttachmentStream {
                         TerminalSurfaceSequenceDecision::Closed => return None,
                     }
                 }
-                Ok(TerminalSurfaceEvent::InputUnavailable {
-                    session_key,
-                    message,
-                }) if session_key == self.session_key => {
+                Ok(TerminalSurfaceEvent::InputUnavailable { session_key, cause })
+                    if session_key == self.session_key =>
+                {
                     return Some(TerminalSurfaceStreamItem::InputUnavailable {
                         session_key,
-                        message,
+                        cause,
                     });
                 }
                 Ok(_) => {}

--- a/src/components/panels/AgentSessionPanel/AgentSessionPanel.test.tsx
+++ b/src/components/panels/AgentSessionPanel/AgentSessionPanel.test.tsx
@@ -99,7 +99,7 @@ describe("AgentSessionPanel", () => {
 	});
 
 	it.each([
-		["paused", "Provider session is not running. Resume to retry."],
+		["paused", "Provider session is not running."],
 		["archived", null],
 	] as const)(
 		"Terminalの失敗文言を%s画面へ持ち越さない",

--- a/src/components/panels/AgentSessionPanel/AgentSessionPanel.test.tsx
+++ b/src/components/panels/AgentSessionPanel/AgentSessionPanel.test.tsx
@@ -6,14 +6,31 @@ import { AgentSessionPanel, AgentSessionRoute } from "./AgentSessionPanel";
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
 vi.mock("@/components/panels/TerminalPanel", () => ({
-	TerminalPanel: (props: Record<string, unknown>) => (
-		<div
-			data-testid="provider-terminal"
-			data-initialization={String(props.initialization)}
-			data-auto-focus={String(props.autoFocus)}
-			data-owner={JSON.stringify(props.owner)}
-		/>
-	),
+	TerminalPanel: (props: Record<string, unknown>) => {
+		const onTerminalError = props.onTerminalError as
+			| ((message: string | null) => void)
+			| undefined;
+		return (
+			<div
+				data-testid="provider-terminal"
+				data-initialization={String(props.initialization)}
+				data-auto-focus={String(props.autoFocus)}
+				data-owner={JSON.stringify(props.owner)}
+			>
+				<button
+					type="button"
+					onClick={() =>
+						onTerminalError?.("Terminal resynchronization failed. Try again.")
+					}
+				>
+					Report terminal error
+				</button>
+				<button type="button" onClick={() => onTerminalError?.(null)}>
+					Complete terminal recovery
+				</button>
+			</div>
+		);
+	},
 }));
 
 const mockInvoke = vi.mocked(invoke);
@@ -60,6 +77,56 @@ describe("AgentSessionPanel", () => {
 			sessionId: "agent-session-1",
 		});
 	});
+
+	it("Terminalの失敗文言をalertへ表示し回復成功時に消す", async () => {
+		mockInvoke.mockResolvedValueOnce("attached");
+
+		render(<AgentSessionPanel session={session} />);
+		fireEvent.click(
+			await screen.findByRole("button", { name: "Report terminal error" }),
+		);
+
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"Terminal resynchronization failed. Try again.",
+		);
+		expect(screen.getByTestId("provider-terminal")).toBeVisible();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "Complete terminal recovery" }),
+		);
+
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it.each([
+		["paused", "Provider session is not running. Resume to retry."],
+		["archived", null],
+	] as const)(
+		"Terminalの失敗文言を%s画面へ持ち越さない",
+		async (lifecycle, expectedAlert) => {
+			mockInvoke.mockResolvedValueOnce("attached");
+			const { rerender } = render(<AgentSessionPanel session={session} />);
+			fireEvent.click(
+				await screen.findByRole("button", { name: "Report terminal error" }),
+			);
+			expect(await screen.findByRole("alert")).toHaveTextContent(
+				"Terminal resynchronization failed. Try again.",
+			);
+
+			rerender(<AgentSessionPanel session={{ ...session, lifecycle }} />);
+
+			await waitFor(() => {
+				expect(
+					screen.queryByText("Terminal resynchronization failed. Try again."),
+				).not.toBeInTheDocument();
+			});
+			if (expectedAlert) {
+				expect(screen.getByRole("alert")).toHaveTextContent(expectedAlert);
+			} else {
+				expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+			}
+		},
+	);
 
 	it("Pausedは明示Resumeが成功するまでTerminalをattachしない", async () => {
 		mockInvoke.mockResolvedValueOnce("paused").mockResolvedValueOnce("resumed");
@@ -119,6 +186,26 @@ describe("AgentSessionPanel", () => {
 		expect(screen.getByRole("button", { name: "Resume" })).toBeVisible();
 		expect(screen.queryByTestId("provider-terminal")).toBeNull();
 	});
+
+	it.each([
+		[
+			{
+				code: "AGENT_SESSION_LAUNCH_UNAVAILABLE",
+				message: "backend open failed",
+			},
+			"backend open failed",
+		],
+		["plain open failed", "plain open failed"],
+	])(
+		"open失敗からbackendのmessageだけを表示する",
+		async (rejection, expected) => {
+			mockInvoke.mockRejectedValueOnce(rejection);
+
+			render(<AgentSessionPanel session={session} />);
+
+			expect((await screen.findByRole("alert")).textContent).toBe(expected);
+		},
+	);
 
 	it("Provider CLI終了でbackendがPausedへ更新した場合もerrorとResumeを表示する", async () => {
 		mockInvoke.mockResolvedValueOnce("attached");

--- a/src/components/panels/AgentSessionPanel/AgentSessionPanel.tsx
+++ b/src/components/panels/AgentSessionPanel/AgentSessionPanel.tsx
@@ -6,6 +6,7 @@ import {
 	notifyAgentSessionChanged,
 	subscribeAgentSessionChanged,
 } from "@/lib/agentSessionEvents";
+import { getErrorMessage } from "@/lib/errorMessage";
 import type {
 	AgentSessionItem,
 	AgentSessionLaunchAttachment,
@@ -68,6 +69,7 @@ export function AgentSessionPanel({
 		initiallyAttached ? "terminal" : "loading",
 	);
 	const [error, setError] = useState<string | null>(null);
+	const [terminalError, setTerminalError] = useState<string | null>(null);
 	const [actionPending, setActionPending] = useState(false);
 	const openedSessionIdRef = useRef<string | null>(
 		initiallyAttached ? agentSessionId : null,
@@ -127,7 +129,7 @@ export function AgentSessionPanel({
 				});
 				applyOutcome(outcome);
 			} catch (cause) {
-				setError(cause instanceof Error ? cause.message : String(cause));
+				setError(getErrorMessage(cause));
 				setState(
 					command === "restore_agent_session" ||
 						(command === "open_agent_session" && session.operations.canRestore)
@@ -153,7 +155,7 @@ export function AgentSessionPanel({
 			setState("gone");
 			notifyAgentSessionChanged(session.worktreePath);
 		} catch (cause) {
-			setError(cause instanceof Error ? cause.message : String(cause));
+			setError(getErrorMessage(cause));
 		} finally {
 			setActionPending(false);
 		}
@@ -177,18 +179,31 @@ export function AgentSessionPanel({
 
 	if (state === "terminal") {
 		return (
-			<TerminalPanel
-				cwd={worktreePath}
-				theme={theme}
-				owner={{
-					kind: "session",
-					workspacePath: workspaceIdentity,
-					sessionId: agentSessionId,
-				}}
-				label={`${provider} AgentSession`}
-				initialization="attach-existing"
-				autoFocus
-			/>
+			<div className="flex h-full flex-col bg-background">
+				{terminalError && (
+					<div
+						role="alert"
+						className="shrink-0 px-3 py-2 text-sm text-destructive"
+					>
+						{terminalError}
+					</div>
+				)}
+				<div className="min-h-0 flex-1">
+					<TerminalPanel
+						cwd={worktreePath}
+						theme={theme}
+						owner={{
+							kind: "session",
+							workspacePath: workspaceIdentity,
+							sessionId: agentSessionId,
+						}}
+						label={`${provider} AgentSession`}
+						onTerminalError={setTerminalError}
+						initialization="attach-existing"
+						autoFocus
+					/>
+				</div>
+			</div>
 		);
 	}
 
@@ -314,7 +329,7 @@ export function AgentSessionRoute({
 			})
 			.catch((cause) => {
 				if (active) {
-					setError(cause instanceof Error ? cause.message : String(cause));
+					setError(getErrorMessage(cause));
 				}
 			});
 		return () => {

--- a/src/components/panels/DiffToolbar.tsx
+++ b/src/components/panels/DiffToolbar.tsx
@@ -16,6 +16,7 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { FileNavigationResult } from "@/hooks/useFileNavigation";
+import { getErrorMessage } from "@/lib/errorMessage";
 import { cn } from "@/lib/utils";
 import type { DiffMode } from "@/types/settings";
 
@@ -61,7 +62,7 @@ export function DiffToolbar({
 		setEditorError(null);
 		invoke("open_in_editor", { filePath }).catch((e) => {
 			console.error("Failed to open in editor:", e);
-			setEditorError(String(e));
+			setEditorError(getErrorMessage(e));
 			if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
 			errorTimerRef.current = setTimeout(() => setEditorError(null), 5000);
 		});

--- a/src/components/panels/MarkdownDiffViewer.tsx
+++ b/src/components/panels/MarkdownDiffViewer.tsx
@@ -9,6 +9,7 @@ import {
 import Markdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
+import { getErrorMessage } from "@/lib/errorMessage";
 import { rehypeSourceLines } from "@/lib/rehypeSourceLines";
 import type { DiffRange, InlineChunk, SplitRow } from "@/types/markdown-diff";
 import type { DiffMode } from "@/types/settings";
@@ -59,10 +60,6 @@ export interface MarkdownDiffViewerProps {
 }
 
 const remarkPlugins = [remarkGfm];
-
-function readModelErrorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
-}
 
 function readModelInputKeyFromArgs(args: ReadModelArgs): ReadModelInputKey {
 	return {
@@ -121,7 +118,7 @@ function useReadModel<T>(
 					setState((prev) => ({
 						status: "error",
 						result: currentReadModelResult(prev.result, inputKey),
-						error: readModelErrorMessage(error),
+						error: getErrorMessage(error),
 					}));
 				}
 			});
@@ -148,7 +145,7 @@ function ReadModelErrorNotice({ message }: { message: string }) {
 			role="alert"
 			className="m-4 rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
 		>
-			Failed to load markdown diff: {message}
+			{message}
 		</div>
 	);
 }

--- a/src/components/panels/NodeContentView/NodeContentView.tsx
+++ b/src/components/panels/NodeContentView/NodeContentView.tsx
@@ -10,6 +10,7 @@ import {
 	retryWorkspaceNode,
 	useWorkspaceNodeDetail,
 } from "@/hooks/useWorkspaceNodeDetail";
+import { getErrorMessage } from "@/lib/errorMessage";
 import type { AgentSessionLaunchAttachment } from "@/types/agent-session";
 import type { Theme } from "@/types/settings";
 import type {
@@ -116,7 +117,7 @@ function NodeHeader({
 			await approveWorkspaceNode({ worktreePath, nodeId: detail.id });
 			setActionError(null);
 		} catch (error) {
-			setActionError(error instanceof Error ? error.message : String(error));
+			setActionError(getErrorMessage(error));
 		} finally {
 			setApproving(false);
 		}
@@ -129,7 +130,7 @@ function NodeHeader({
 			await retryWorkspaceNode({ worktreePath, nodeId: detail.id });
 			setActionError(null);
 		} catch (error) {
-			setActionError(error instanceof Error ? error.message : String(error));
+			setActionError(getErrorMessage(error));
 		} finally {
 			setRetrying(false);
 		}

--- a/src/components/panels/RightSidebarBottom.test.tsx
+++ b/src/components/panels/RightSidebarBottom.test.tsx
@@ -20,7 +20,25 @@ vi.mock("react-resizable-panels", () => ({
 }));
 
 vi.mock("@/components/panels/TerminalPanel", () => ({
-	TerminalPanel: () => <div data-testid="terminal-panel" />,
+	TerminalPanel: ({
+		onTerminalError,
+	}: {
+		onTerminalError?: (message: string | null) => void;
+	}) => (
+		<div data-testid="terminal-panel">
+			<button
+				type="button"
+				onClick={() =>
+					onTerminalError?.("Terminal resynchronization failed. Try again.")
+				}
+			>
+				Report terminal error
+			</button>
+			<button type="button" onClick={() => onTerminalError?.(null)}>
+				Complete terminal recovery
+			</button>
+		</div>
+	),
 }));
 
 vi.mock("@/hooks/useDiffComments", () => ({
@@ -48,6 +66,26 @@ describe("RightSidebarBottom", () => {
 
 		expect(screen.getByTestId("panel-terminal")).toBeInTheDocument();
 		expect(screen.getByTestId("resizable-group")).toBeInTheDocument();
+	});
+
+	it("Terminalの失敗文言をalertへ表示し回復成功時に消す", async () => {
+		const user = userEvent.setup();
+		render(<RightSidebarBottom {...defaultProps} />);
+
+		await user.click(
+			screen.getByRole("button", { name: "Report terminal error" }),
+		);
+
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"Terminal resynchronization failed. Try again.",
+		);
+		expect(screen.getByTestId("terminal-panel")).toBeVisible();
+
+		await user.click(
+			screen.getByRole("button", { name: "Complete terminal recovery" }),
+		);
+
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 	});
 
 	it("should render collapse button with correct aria-label when expanded", () => {

--- a/src/components/panels/RightSidebarBottom.tsx
+++ b/src/components/panels/RightSidebarBottom.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, ChevronUp } from "lucide-react";
+import { useState } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { DiffCommentList } from "@/components/panels/DiffCommentList";
 import { TerminalPanel } from "@/components/panels/TerminalPanel";
@@ -24,6 +25,7 @@ export function RightSidebarBottom({
 	collapsed,
 }: RightSidebarBottomProps) {
 	const { comments, deleteThread } = useDiffComments({ worktreeName });
+	const [terminalError, setTerminalError] = useState<string | null>(null);
 
 	return (
 		<div className="flex flex-col h-full">
@@ -46,12 +48,23 @@ export function RightSidebarBottom({
 			<div className="flex-1 overflow-hidden">
 				<Group orientation="horizontal">
 					<Panel id="terminal" defaultSize="50%" minSize="20%">
-						<div className="h-full overflow-hidden border-r border-border">
-							<TerminalPanel
-								cwd={rootPath}
-								owner={{ kind: "workspace", workspacePath: rootPath }}
-								theme={theme}
-							/>
+						<div className="flex h-full flex-col overflow-hidden border-r border-border">
+							{terminalError && (
+								<div
+									role="alert"
+									className="shrink-0 px-3 py-2 text-sm text-destructive"
+								>
+									{terminalError}
+								</div>
+							)}
+							<div className="min-h-0 flex-1">
+								<TerminalPanel
+									cwd={rootPath}
+									owner={{ kind: "workspace", workspacePath: rootPath }}
+									theme={theme}
+									onTerminalError={setTerminalError}
+								/>
+							</div>
 						</div>
 					</Panel>
 					<Separator />

--- a/src/components/panels/SettingsModal.tsx
+++ b/src/components/panels/SettingsModal.tsx
@@ -35,6 +35,7 @@ import { useBackgroundConfig } from "@/hooks/useAppSettings";
 import { useAutomation } from "@/hooks/useAutomation";
 import { useNotionSettings } from "@/hooks/useNotionSettings";
 import { useProviderAvailabilitySettings } from "@/hooks/useProviderAvailabilitySettings";
+import { getErrorMessage } from "@/lib/errorMessage";
 import { setPerformanceTelemetryEnabled, trackEvent } from "@/lib/telemetry";
 import { cn } from "@/lib/utils";
 import type { BranchInfo } from "@/types/git";
@@ -72,7 +73,7 @@ function useWorkflowSettings(open: boolean) {
 				setDraft(normalized);
 			})
 			.catch((e) => {
-				if (!cancelled) setError(String(e));
+				if (!cancelled) setError(getErrorMessage(e));
 			})
 			.finally(() => {
 				if (!cancelled) setLoading(false);
@@ -91,7 +92,7 @@ function useWorkflowSettings(open: boolean) {
 			await invoke("update_workflow_config", { workflow: draft });
 			setConfig({ ...draft });
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 			throw e;
 		} finally {
 			setSaving(false);
@@ -206,7 +207,7 @@ function useExternalEditorConfig(open: boolean) {
 				setEditors(detected);
 			})
 			.catch((e) => {
-				if (!cancelled) setError(String(e));
+				if (!cancelled) setError(getErrorMessage(e));
 			})
 			.finally(() => {
 				if (!cancelled) setLoading(false);
@@ -224,7 +225,7 @@ function useExternalEditorConfig(open: boolean) {
 			await invoke("update_external_editor", { editor });
 			setInitialEditor(editor);
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 			throw e;
 		}
 	}, [editor]);
@@ -379,7 +380,7 @@ function RepoBaseBranchItem({
 				setInitialBase(base);
 			})
 			.catch((e) => {
-				setError(String(e));
+				setError(getErrorMessage(e));
 			})
 			.finally(() => {
 				setLoading(false);
@@ -485,7 +486,7 @@ function useRepoChanges() {
 				revision: prev.revision + 1,
 			}));
 		} catch (e) {
-			setState((prev) => ({ ...prev, error: String(e) }));
+			setState((prev) => ({ ...prev, error: getErrorMessage(e) }));
 			throw e;
 		}
 	}, [state.pendingBases]);

--- a/src/components/panels/TerminalPanel.tsx
+++ b/src/components/panels/TerminalPanel.tsx
@@ -37,7 +37,7 @@ export interface TerminalPanelProps {
 	owner?: TerminalSurfaceOwner;
 	label?: string;
 	onTerminalReady?: (sessionKey: string) => void;
-	onTerminalError?: (message: string) => void;
+	onTerminalError?: (message: string | null) => void;
 	shouldKillPendingTerminal?: () => boolean;
 	initialization?: TerminalInitializationMode;
 	autoFocus?: boolean;

--- a/src/components/panels/__tests__/MarkdownDiffViewer.test.tsx
+++ b/src/components/panels/__tests__/MarkdownDiffViewer.test.tsx
@@ -37,11 +37,11 @@ function mockReadModel({
 	rows?: SplitRow[];
 	chunks?: InlineChunk[];
 	visibleBlocks?: unknown[];
-	rejectCommands?: Record<string, string>;
+	rejectCommands?: Record<string, unknown>;
 } = {}) {
 	mockInvoke.mockImplementation((command: string) => {
 		if (rejectCommands[command]) {
-			return Promise.reject(new Error(rejectCommands[command]));
+			return Promise.reject(rejectCommands[command]);
 		}
 
 		switch (command) {
@@ -160,11 +160,30 @@ describe("MarkdownDiffViewer", () => {
 			);
 
 			const alert = await screen.findByRole("alert");
-			expect(alert).toHaveTextContent(
-				"Failed to load markdown diff: backend failed",
-			);
+			expect(alert.textContent).toBe("backend failed");
 		},
 	);
+
+	it("shows coded backend read model message without decoration", async () => {
+		mockReadModel({
+			rejectCommands: {
+				compute_markdown_diff_ranges: {
+					code: "MARKDOWN_DIFF_UNAVAILABLE",
+					message: "coded backend failed",
+				},
+			},
+		});
+		render(
+			<MarkdownDiffViewer
+				originalContent="old text"
+				modifiedContent="new text"
+			/>,
+		);
+
+		expect((await screen.findByRole("alert")).textContent).toBe(
+			"coded backend failed",
+		);
+	});
 
 	describe("split mode", () => {
 		it("renders grid container with separator", async () => {
@@ -318,9 +337,7 @@ describe("MarkdownDiffViewer", () => {
 				await failedRows.promise.catch(() => {});
 			});
 
-			expect(await screen.findByRole("alert")).toHaveTextContent(
-				"Failed to load markdown diff: B failed",
-			);
+			expect((await screen.findByRole("alert")).textContent).toBe("B failed");
 			expect(screen.queryByText("old A")).not.toBeInTheDocument();
 			expect(screen.queryByText("new A")).not.toBeInTheDocument();
 			expect(
@@ -509,9 +526,7 @@ describe("MarkdownDiffViewer", () => {
 			);
 
 			const alert = await screen.findByRole("alert");
-			expect(alert).toHaveTextContent(
-				"Failed to load markdown diff: visible blocks failed",
-			);
+			expect(alert.textContent).toBe("visible blocks failed");
 			expect(screen.queryByText("No changes")).not.toBeInTheDocument();
 		});
 	});

--- a/src/components/panels/automation/FacetEditor.tsx
+++ b/src/components/panels/automation/FacetEditor.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { getErrorMessage } from "@/lib/errorMessage";
 import { extractTemplateVariables } from "./utils";
 
 export function FacetEditor({
@@ -34,7 +35,7 @@ export function FacetEditor({
 			const rendered = await renderPreview(content, sampleValues);
 			setPreview(rendered);
 		} catch (e) {
-			setError(e instanceof Error ? e.message : String(e));
+			setError(getErrorMessage(e));
 		}
 	}, [content, sampleValues, renderPreview]);
 
@@ -47,7 +48,7 @@ export function FacetEditor({
 				setError(result.error ?? "Save failed");
 			}
 		} catch (e) {
-			setError(e instanceof Error ? e.message : String(e));
+			setError(getErrorMessage(e));
 		} finally {
 			setSaving(false);
 		}

--- a/src/components/panels/automation/NameInputDialog.tsx
+++ b/src/components/panels/automation/NameInputDialog.tsx
@@ -10,6 +10,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 export function NameInputDialog({
 	open,
@@ -51,7 +52,7 @@ export function NameInputDialog({
 				setError(result.error ?? "Unknown error");
 			}
 		} catch (e) {
-			setError(e instanceof Error ? e.message : String(e));
+			setError(getErrorMessage(e));
 		} finally {
 			setSaving(false);
 		}

--- a/src/components/workspace/DeleteWorktreeDialog.test.tsx
+++ b/src/components/workspace/DeleteWorktreeDialog.test.tsx
@@ -178,7 +178,7 @@ describe("DeleteWorktreeDialog", () => {
 		await user.click(deleteButton);
 
 		await waitFor(() => {
-			expect(screen.getByText("Error: Delete failed")).toBeInTheDocument();
+			expect(screen.getByText("Delete failed")).toBeInTheDocument();
 		});
 
 		// Spinner should be gone, button should be re-enabled

--- a/src/components/workspace/DeleteWorktreeDialog.tsx
+++ b/src/components/workspace/DeleteWorktreeDialog.tsx
@@ -10,6 +10,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { getErrorMessage } from "@/lib/errorMessage";
 import type { WorktreeBranch } from "@/types/git";
 
 interface DeleteWorktreeDialogProps {
@@ -40,7 +41,7 @@ export function DeleteWorktreeDialog({
 			try {
 				await onConfirm(branch, force);
 			} catch (e) {
-				setError(String(e));
+				setError(getErrorMessage(e));
 			} finally {
 				setDeleting(false);
 				deletingRef.current = false;

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -271,7 +271,7 @@ function renderWorkspaceList(
 function mockDeferredProviderCreate() {
 	const deferred: {
 		resolve?: (agentSessionId: string) => void;
-		reject?: (error: Error) => void;
+		reject?: (error: unknown) => void;
 	} = {};
 	mocks.invoke.mockImplementation((command: string) => {
 		if (command === "list_workspace_worktree_nodes") {
@@ -1312,11 +1312,16 @@ describe("WorkspaceList", () => {
 		});
 
 		await act(async () => {
-			createCall.reject?.(new Error("spawn failed"));
+			createCall.reject?.({
+				code: "AGENT_SESSION_LAUNCH_UNAVAILABLE",
+				message: "backend launch failed",
+			});
 		});
 
 		expect(onSelectWorktree).not.toHaveBeenCalled();
-		expect(await screen.findByRole("alert")).toHaveTextContent("spawn failed");
+		expect((await screen.findByRole("alert")).textContent).toBe(
+			"backend launch failed",
+		);
 	});
 
 	it("選択が起動中表示のまま作成が失敗した場合は同一launchTokenのエラー表示を再選択する", async () => {
@@ -1332,7 +1337,7 @@ describe("WorkspaceList", () => {
 		>;
 
 		await act(async () => {
-			createCall.reject?.(new Error("spawn failed"));
+			createCall.reject?.("plain launch failed");
 		});
 
 		expect(onSelectWorktree).toHaveBeenLastCalledWith(
@@ -1344,7 +1349,7 @@ describe("WorkspaceList", () => {
 				worktreePath: "/repo/wt",
 				provider: "codex",
 				launchToken: launching.launchToken,
-				error: "spawn failed",
+				error: "plain launch failed",
 			},
 		);
 	});

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -49,6 +49,7 @@ import { useWorkflowConfig } from "@/hooks/useWorkflowConfig";
 import { useWorkspaceTreeNodes } from "@/hooks/useWorkspaceTreeNodes";
 import { useWorktreeList } from "@/hooks/useWorktreeList";
 import { notifyAgentSessionChanged } from "@/lib/agentSessionEvents";
+import { getErrorMessage } from "@/lib/errorMessage";
 import { trackEvent } from "@/lib/telemetry";
 import {
 	executeWorkflowAction,
@@ -721,9 +722,7 @@ function WorktreeTreeItem({
 					onSelectWorktree(branch.worktree_path, branch.name, repoName);
 				}
 			} catch (error) {
-				setProviderActionError(
-					error instanceof Error ? error.message : String(error),
-				);
+				setProviderActionError(getErrorMessage(error));
 			}
 		},
 		[
@@ -769,9 +768,7 @@ function WorktreeTreeItem({
 					onSelectWorktree(branch.worktree_path, branch.name, repoName);
 				}
 			} catch (error) {
-				setProviderActionError(
-					error instanceof Error ? error.message : String(error),
-				);
+				setProviderActionError(getErrorMessage(error));
 			}
 		},
 		[
@@ -816,9 +813,7 @@ function WorktreeTreeItem({
 					},
 				});
 			} catch (error) {
-				setProviderActionError(
-					error instanceof Error ? error.message : String(error),
-				);
+				setProviderActionError(getErrorMessage(error));
 			}
 		},
 		[branch.worktree_path, refreshAgentSessions, selectCenter],
@@ -840,9 +835,7 @@ function WorktreeTreeItem({
 		} catch (error) {
 			setProviderHistory([]);
 			setProviderHistoryNextAfter(null);
-			setProviderActionError(
-				error instanceof Error ? error.message : String(error),
-			);
+			setProviderActionError(getErrorMessage(error));
 		} finally {
 			setProviderHistoryLoading(false);
 		}
@@ -864,9 +857,7 @@ function WorktreeTreeItem({
 			setProviderHistoryNextAfter(page?.nextAfter ?? null);
 			setProviderActionError(null);
 		} catch (error) {
-			setProviderActionError(
-				error instanceof Error ? error.message : String(error),
-			);
+			setProviderActionError(getErrorMessage(error));
 		} finally {
 			setProviderHistoryLoading(false);
 		}
@@ -910,9 +901,7 @@ function WorktreeTreeItem({
 					},
 				});
 			} catch (error) {
-				setProviderActionError(
-					error instanceof Error ? error.message : String(error),
-				);
+				setProviderActionError(getErrorMessage(error));
 			}
 		},
 		[branch.worktree_path, refreshAgentSessions, selectCenter],
@@ -945,7 +934,7 @@ function WorktreeTreeItem({
 					await refreshTree();
 				}
 			} catch (e) {
-				setWorkflowActionError(`Archive workflow failed: ${String(e)}`);
+				setWorkflowActionError(getErrorMessage(e));
 			}
 		},
 		[
@@ -963,9 +952,7 @@ function WorktreeTreeItem({
 				await executeWorkflowAction(action, workflow.id);
 				await refreshTree();
 			} catch (error) {
-				setWorkflowActionError(
-					error instanceof Error ? error.message : String(error),
-				);
+				setWorkflowActionError(getErrorMessage(error));
 			}
 		},
 		[refreshTree],
@@ -982,9 +969,7 @@ function WorktreeTreeItem({
 			setAvailableProviders(providers ?? []);
 		} catch (error) {
 			setAvailableProviders([]);
-			setProviderActionError(
-				error instanceof Error ? error.message : String(error),
-			);
+			setProviderActionError(getErrorMessage(error));
 		} finally {
 			setProviderMenuLoading(false);
 		}
@@ -1046,7 +1031,7 @@ function WorktreeTreeItem({
 				}
 				void refreshAgentSessions();
 			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
+				const message = getErrorMessage(error);
 				setProviderActionError(message);
 				if (isLaunchSelectionCurrent()) {
 					selectCenter({
@@ -1092,7 +1077,7 @@ function WorktreeTreeItem({
 			setWorkflowRequestInput("");
 			await refreshTree();
 		} catch (e) {
-			setWorkflowStartError(String(e));
+			setWorkflowStartError(getErrorMessage(e));
 		} finally {
 			setWorkflowStarting(false);
 		}
@@ -1127,9 +1112,7 @@ function WorktreeTreeItem({
 				);
 				await refreshTree();
 			} catch (error) {
-				setWorkflowActionError(
-					error instanceof Error ? error.message : String(error),
-				);
+				setWorkflowActionError(getErrorMessage(error));
 			}
 		},
 		[branch.worktree_path, refreshTree],

--- a/src/contexts/ReviewThreadHandoffContext.test.tsx
+++ b/src/contexts/ReviewThreadHandoffContext.test.tsx
@@ -81,7 +81,22 @@ describe("ReviewThreadHandoffProvider", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Copy for Agent" }));
 
 		expect(await screen.findByRole("alert")).toHaveTextContent(
-			"Failed to copy Agent instruction: Error: clipboard unavailable",
+			"Failed to copy Agent instruction: clipboard unavailable",
 		);
+	});
+
+	it("handoff生成失敗はbackend文言だけを表示してclipboardを呼ばない", async () => {
+		mocks.invoke.mockRejectedValueOnce({
+			code: "REVIEW_HANDOFF_UNAVAILABLE",
+			message: "Review handoff is unavailable. Try again.",
+		});
+		renderHandoff();
+
+		fireEvent.click(screen.getByRole("button", { name: "Copy for Agent" }));
+
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"Review handoff is unavailable. Try again.",
+		);
+		expect(mocks.writeText).not.toHaveBeenCalled();
 	});
 });

--- a/src/contexts/ReviewThreadHandoffContext.tsx
+++ b/src/contexts/ReviewThreadHandoffContext.tsx
@@ -6,6 +6,7 @@ import {
 	useMemo,
 	useState,
 } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 export interface ReviewThreadHandoffFeedback {
 	threadId: string;
@@ -63,11 +64,22 @@ export function ReviewThreadHandoffProvider({
 	);
 	const copyThreadForAgent = useCallback(
 		async (threadId: string) => {
+			let content: string;
 			try {
-				const content = await invoke<string>("build_review_thread_handoff", {
+				content = await invoke<string>("build_review_thread_handoff", {
 					worktreeName,
 					threadId,
 				});
+			} catch (error) {
+				setFeedback({
+					threadId,
+					kind: "error",
+					message: getErrorMessage(error),
+				});
+				return;
+			}
+
+			try {
 				await navigator.clipboard.writeText(content);
 				setFeedback({
 					threadId,
@@ -78,7 +90,7 @@ export function ReviewThreadHandoffProvider({
 				setFeedback({
 					threadId,
 					kind: "error",
-					message: `Failed to copy Agent instruction: ${String(error)}`,
+					message: `Failed to copy Agent instruction: ${getErrorMessage(error)}`,
 				});
 			}
 		},

--- a/src/hooks/useAppSettings.ts
+++ b/src/hooks/useAppSettings.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { useCallback, useEffect, useState } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 export interface BackgroundConfig {
 	close_to_tray: boolean;
@@ -42,7 +43,7 @@ export function useBackgroundConfig() {
 				setDraft(cfg);
 			})
 			.catch((e) => {
-				setError(String(e));
+				setError(getErrorMessage(e));
 			})
 			.finally(() => {
 				setLoading(false);
@@ -73,7 +74,7 @@ export function useBackgroundConfig() {
 
 			setConfig({ ...draft });
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 			throw e;
 		} finally {
 			setSaving(false);

--- a/src/hooks/useApplicationShutdownSupervision.test.ts
+++ b/src/hooks/useApplicationShutdownSupervision.test.ts
@@ -188,4 +188,40 @@ describe("useApplicationShutdownSupervision", () => {
 		expect(calls[1][1].request.request_id).toBe(snapshot.requestId);
 		unmount();
 	});
+
+	it("pending attemptの無効なcursor errorだけをtypeで判定して次回は先頭から読む", async () => {
+		let attemptCalls = 0;
+		mockInvoke.mockImplementation((command: string) => {
+			if (command === "list_pending_application_attempts") {
+				attemptCalls += 1;
+				if (attemptCalls === 1) {
+					return Promise.resolve({ entries: [], next_cursor: "stale-cursor" });
+				}
+				if (attemptCalls === 2) {
+					return Promise.reject({ type: "invalid_request" });
+				}
+				return Promise.resolve({ entries: [], next_cursor: null });
+			}
+			if (command === "get_application_shutdown") {
+				return Promise.resolve({ type: "current", plan: null });
+			}
+			return defaultInvoke(command);
+		});
+		const { result, unmount } = renderHook(() =>
+			useApplicationShutdownSupervision(),
+		);
+
+		await waitFor(() => expect(attemptCalls).toBe(2));
+		await act(async () => result.current.refresh());
+
+		const attemptInvocations = mockInvoke.mock.calls.filter(
+			([command]) => command === "list_pending_application_attempts",
+		);
+		expect(attemptInvocations[1][1]).toEqual({
+			limit: 32,
+			cursor: "stale-cursor",
+		});
+		expect(attemptInvocations[2][1]).toEqual({ limit: 32, cursor: null });
+		unmount();
+	});
 });

--- a/src/hooks/useApplicationShutdownSupervision.ts
+++ b/src/hooks/useApplicationShutdownSupervision.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 interface PendingApplicationAttempt {
 	kind: "application_quit";
@@ -92,6 +93,19 @@ function sameState(
 	return JSON.stringify(current) === JSON.stringify(next) ? current : next;
 }
 
+function isInvalidPendingAttemptCursor(
+	error: unknown,
+	cursor: string | null,
+): boolean {
+	return (
+		cursor !== null &&
+		typeof error === "object" &&
+		error !== null &&
+		"type" in error &&
+		error.type === "invalid_request"
+	);
+}
+
 function loadQuitAttempt(): QuitAttemptSnapshot | null {
 	const saved = globalThis.localStorage.getItem(QUIT_ATTEMPT_STORAGE_KEY);
 	if (!saved) return null;
@@ -111,14 +125,23 @@ function loadQuitAttempt(): QuitAttemptSnapshot | null {
 	}
 }
 
-async function loadAttempts(initialCursor: string | null) {
+async function loadAttempts(
+	initialCursor: string | null,
+	onInvalidCursor: () => void,
+) {
 	const entries: PendingApplicationAttempt[] = [];
 	let cursor = initialCursor;
 	for (let page = 0; page < MAX_ATTEMPT_PAGES; page += 1) {
-		const result = await invoke<PendingApplicationAttemptPage>(
-			"list_pending_application_attempts",
-			{ limit: 32, cursor },
-		);
+		let result: PendingApplicationAttemptPage;
+		try {
+			result = await invoke<PendingApplicationAttemptPage>(
+				"list_pending_application_attempts",
+				{ limit: 32, cursor },
+			);
+		} catch (error) {
+			if (isInvalidPendingAttemptCursor(error, cursor)) onInvalidCursor();
+			throw error;
+		}
 		entries.push(...result.entries);
 		cursor = result.next_cursor;
 		if (cursor === null || entries.length >= MAX_ATTEMPTS) break;
@@ -168,8 +191,11 @@ export function useApplicationShutdownSupervision() {
 
 	const refresh = useCallback(async () => {
 		try {
+			const attemptPagePromise = loadAttempts(attemptCursor.current, () => {
+				attemptCursor.current = null;
+			});
 			const [attemptPage, shutdownResult] = await Promise.all([
-				loadAttempts(attemptCursor.current),
+				attemptPagePromise,
 				invoke<CurrentShutdownResult>("get_application_shutdown"),
 			]);
 			attemptCursor.current = attemptPage.nextCursor;
@@ -204,9 +230,8 @@ export function useApplicationShutdownSupervision() {
 				}),
 			);
 		} catch (error) {
-			if (String(error).includes("cursor")) attemptCursor.current = null;
 			setState((current) =>
-				sameState(current, { ...current, error: String(error) }),
+				sameState(current, { ...current, error: getErrorMessage(error) }),
 			);
 		}
 	}, []);

--- a/src/hooks/useAutomation.ts
+++ b/src/hooks/useAutomation.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 import type {
 	DiagnosticReport,
 	FacetKind,
@@ -59,7 +60,7 @@ export function useAutomation(open: boolean) {
 			setWorkflows(wfList);
 			setReport(diagReport);
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 		} finally {
 			setLoading(false);
 		}
@@ -72,7 +73,7 @@ export function useAutomation(open: boolean) {
 			});
 			setFacets(list);
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 		}
 	}, []);
 
@@ -81,7 +82,7 @@ export function useAutomation(open: boolean) {
 			const diagReport = await invoke<DiagnosticReport>("diagnose_all_cmd");
 			setReport(diagReport);
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 		}
 	}, []);
 
@@ -171,13 +172,13 @@ export function useAutomation(open: boolean) {
 					setSelectedWorkflow(wf);
 				} catch (e) {
 					setSelectedWorkflow(null);
-					setError(String(e));
+					setError(getErrorMessage(e));
 					await refreshDiagnostics();
 				}
 			} catch (e) {
 				setSelectedWorkflow(null);
 				setSelectedWorkflowSource(null);
-				setError(String(e));
+				setError(getErrorMessage(e));
 			}
 		},
 		[refreshDiagnostics, workflows],
@@ -208,7 +209,7 @@ export function useAutomation(open: boolean) {
 				return { ok: true as const, workflow };
 			} catch (e) {
 				await refreshDiagnostics();
-				return { ok: false as const, error: String(e) };
+				return { ok: false as const, error: getErrorMessage(e) };
 			}
 		},
 		[fetchAll, refreshDiagnostics],
@@ -225,7 +226,7 @@ export function useAutomation(open: boolean) {
 				}
 				await fetchAll();
 			} catch (e) {
-				setError(String(e));
+				setError(getErrorMessage(e));
 			}
 		},
 		[fetchAll, selectedWorkflow, selectedWorkflowName],
@@ -241,7 +242,7 @@ export function useAutomation(open: boolean) {
 				await fetchAll();
 				return { ok: true as const };
 			} catch (e) {
-				return { ok: false as const, error: String(e) };
+				return { ok: false as const, error: getErrorMessage(e) };
 			}
 		},
 		[fetchAll],
@@ -251,7 +252,7 @@ export function useAutomation(open: boolean) {
 		try {
 			await invoke("open_workflow_in_editor", { name });
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 		}
 	}, []);
 
@@ -264,7 +265,7 @@ export function useAutomation(open: boolean) {
 			setSelectedFacetKey(key);
 			setSelectedFacetKind(kind);
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 		}
 	}, []);
 
@@ -280,7 +281,7 @@ export function useAutomation(open: boolean) {
 				await Promise.all([fetchFacets(kind), refreshDiagnostics()]);
 				return { ok: true as const };
 			} catch (e) {
-				return { ok: false as const, error: String(e) };
+				return { ok: false as const, error: getErrorMessage(e) };
 			}
 		},
 		[fetchFacets, refreshDiagnostics],
@@ -297,7 +298,7 @@ export function useAutomation(open: boolean) {
 				}
 				await Promise.all([fetchFacets(kind), refreshDiagnostics()]);
 			} catch (e) {
-				setError(String(e));
+				setError(getErrorMessage(e));
 			}
 		},
 		[fetchFacets, refreshDiagnostics, selectedFacetKey, selectedFacetKind],
@@ -314,7 +315,7 @@ export function useAutomation(open: boolean) {
 				await Promise.all([fetchFacets(kind), refreshDiagnostics()]);
 				return { ok: true as const };
 			} catch (e) {
-				return { ok: false as const, error: String(e) };
+				return { ok: false as const, error: getErrorMessage(e) };
 			}
 		},
 		[fetchFacets, refreshDiagnostics],
@@ -325,7 +326,7 @@ export function useAutomation(open: boolean) {
 			try {
 				await invoke("open_facet_in_editor", { kind, key });
 			} catch (e) {
-				setError(String(e));
+				setError(getErrorMessage(e));
 			}
 		},
 		[],
@@ -340,7 +341,7 @@ export function useAutomation(open: boolean) {
 				});
 				return rendered;
 			} catch (e) {
-				setError(String(e));
+				setError(getErrorMessage(e));
 				return content;
 			}
 		},

--- a/src/hooks/useNotionSettings.ts
+++ b/src/hooks/useNotionSettings.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 import type {
 	NotionPropertyInfo,
 	NotionRepoConfig,
@@ -184,7 +185,7 @@ export function useNotionSettings(
 				updateDraft(repoPath, (d) => ({
 					...d,
 					validating: false,
-					validationStatus: String(e),
+					validationStatus: getErrorMessage(e),
 				}));
 			}
 		},

--- a/src/hooks/useProviderAvailabilitySettings.test.ts
+++ b/src/hooks/useProviderAvailabilitySettings.test.ts
@@ -1,0 +1,35 @@
+import { invoke } from "@tauri-apps/api/core";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useProviderAvailabilitySettings } from "./useProviderAvailabilitySettings";
+
+const mockInvoke = vi.mocked(invoke);
+
+describe("useProviderAvailabilitySettings", () => {
+	beforeEach(() => {
+		mockInvoke.mockReset();
+	});
+
+	it.each([
+		[
+			{ code: "PROVIDER_AVAILABILITY_CORRUPT", message: "backend message" },
+			"backend message",
+		],
+		["plain message", "plain message"],
+	])(
+		"Provider executable設定の取得失敗からmessageだけを保持する",
+		async (rejection, expected) => {
+			mockInvoke.mockRejectedValueOnce(rejection);
+
+			const { result } = renderHook(() =>
+				useProviderAvailabilitySettings(true),
+			);
+
+			await waitFor(() => {
+				expect(mockInvoke).toHaveBeenCalledWith("get_provider_availability");
+				expect(result.current.loading).toBe(false);
+				expect(result.current.error).toBe(expected);
+			});
+		},
+	);
+});

--- a/src/hooks/useProviderAvailabilitySettings.ts
+++ b/src/hooks/useProviderAvailabilitySettings.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 export interface ProviderAvailabilityItem {
 	provider: string;
@@ -71,7 +72,7 @@ export function useProviderAvailabilitySettings(open: boolean) {
 				if (!cancelled) acceptSnapshot(next);
 			})
 			.catch((cause) => {
-				if (!cancelled) setError(String(cause));
+				if (!cancelled) setError(getErrorMessage(cause));
 			})
 			.finally(() => {
 				if (!cancelled) setLoading(false);
@@ -111,7 +112,7 @@ export function useProviderAvailabilitySettings(open: boolean) {
 			}
 			acceptSnapshot(latest);
 		} catch (cause) {
-			setError(String(cause));
+			setError(getErrorMessage(cause));
 			throw cause;
 		} finally {
 			setSaving(false);
@@ -131,7 +132,7 @@ export function useProviderAvailabilitySettings(open: boolean) {
 				setSnapshot(next);
 				setDrafts(draftsAfterReset(provider, drafts, snapshot, next));
 			} catch (cause) {
-				setError(String(cause));
+				setError(getErrorMessage(cause));
 			} finally {
 				setSaving(false);
 			}
@@ -149,7 +150,7 @@ export function useProviderAvailabilitySettings(open: boolean) {
 				),
 			);
 		} catch (cause) {
-			setError(String(cause));
+			setError(getErrorMessage(cause));
 		} finally {
 			setRefreshing(false);
 		}

--- a/src/hooks/useReviewFileView.test.ts
+++ b/src/hooks/useReviewFileView.test.ts
@@ -87,21 +87,31 @@ describe("useReviewFileView", () => {
 		expect(result.current.error).toBeNull();
 	});
 
-	it("exposes command failures as an explicit error state", async () => {
-		mockInvoke.mockRejectedValue("review target is not in snapshot");
+	it.each([
+		[
+			{
+				code: "REVIEW_FILE_VIEW_UNAVAILABLE",
+				message: "coded review failure",
+			},
+			"coded review failure",
+		],
+		["plain review failure", "plain review failure"],
+	])(
+		"exposes backend message as an explicit error state",
+		async (rejection, expected) => {
+			mockInvoke.mockRejectedValue(rejection);
 
-		const { result } = renderHook(() =>
-			useReviewFileView("/repo", "missing.ts", "head", "changes", 0, 17),
-		);
-
-		await waitFor(() => {
-			expect(result.current.loading).toBe(false);
-			expect(result.current.error).toBe(
-				"Failed to load diff: review target is not in snapshot",
+			const { result } = renderHook(() =>
+				useReviewFileView("/repo", "missing.ts", "head", "changes", 0, 17),
 			);
-		});
 
-		expect(result.current.view).toBeNull();
-		expect(result.current.hunks).toBeNull();
-	});
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+				expect(result.current.error).toBe(expected);
+			});
+
+			expect(result.current.view).toBeNull();
+			expect(result.current.hunks).toBeNull();
+		},
+	);
 });

--- a/src/hooks/useReviewFileView.ts
+++ b/src/hooks/useReviewFileView.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useRef, useState } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 import type { ReviewFileView, ReviewViewport } from "@/types/review";
 import type { DiffBase, DiffSection } from "@/types/settings";
 
@@ -47,7 +48,7 @@ export function useReviewFileView(
 			.catch((reason: unknown) => {
 				if (requestId !== requestIdRef.current) return;
 				setView(null);
-				setError(`Failed to load diff: ${formatReviewFileViewError(reason)}`);
+				setError(getErrorMessage(reason));
 				setLoading(false);
 			});
 
@@ -84,10 +85,4 @@ export function useReviewFileView(
 		loading,
 		error,
 	};
-}
-
-function formatReviewFileViewError(error: unknown): string {
-	if (error instanceof Error) return error.message;
-	if (typeof error === "string") return error;
-	return String(error);
 }

--- a/src/hooks/useTerminal.test.ts
+++ b/src/hooks/useTerminal.test.ts
@@ -967,11 +967,11 @@ describe("useTerminal", () => {
 		mockChannels[mockChannels.length - 1]?.onmessage({
 			type: "input_unavailable",
 			session_key: "test-uuid-1234",
-			message: "Failed to write to terminal: PTY input queue is full",
+			message: "Terminal input could not be sent. Try again.",
 		});
 		await waitFor(() => {
 			expect(onTerminalError).toHaveBeenCalledWith(
-				"Failed to write to terminal: PTY input queue is full",
+				"Terminal input could not be sent. Try again.",
 			);
 		});
 	});
@@ -998,7 +998,7 @@ describe("useTerminal", () => {
 		mockChannels[0].onmessage({
 			type: "input_unavailable",
 			session_key: "test-uuid-1234",
-			message: "Failed to write to terminal: stale attachment",
+			message: "Terminal input could not be sent. Try again.",
 		});
 
 		await waitFor(() => {
@@ -1009,7 +1009,7 @@ describe("useTerminal", () => {
 			).toHaveLength(2);
 		});
 		expect(onTerminalError).toHaveBeenCalledWith(
-			"Failed to write to terminal: stale attachment",
+			"Terminal input could not be sent. Try again.",
 		);
 		const attachCalls = mockInvoke.mock.calls.filter(
 			([command]) => command === "attach_terminal_surface",
@@ -1022,7 +1022,7 @@ describe("useTerminal", () => {
 			expect.objectContaining({ recovery: true }),
 		);
 		expect(onTerminalError.mock.calls).toEqual([
-			["Failed to write to terminal: stale attachment"],
+			["Terminal input could not be sent. Try again."],
 			[null],
 		]);
 		const secondAttachmentId = (attachCalls[1][1] as { attachmentId: string })

--- a/src/hooks/useTerminal.test.ts
+++ b/src/hooks/useTerminal.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalOutputScheduler } from "@/lib/terminalOutputScheduler";
 import { resetTerminalPerformanceSwitchesCache } from "@/lib/terminalPerformanceSwitches";
 import { resetTerminalStreamEndpointCache } from "@/lib/terminalStreamEndpoint";
 import { useTerminal } from "./useTerminal";
@@ -82,6 +83,7 @@ const REPO_WORKSPACE_OWNER = {
 const mockInvoke = vi.fn();
 const mockListen = vi.fn();
 const mockChannels: Array<{ onmessage: (message: unknown) => void }> = [];
+let mockChannelConstructionError: Error | null = null;
 let mockOnDataCallback: (data: string) => void = () => {};
 let mockTerminalConstructorOptions: Record<string, unknown> = {};
 let mockTerminalInstance: {
@@ -108,6 +110,9 @@ vi.mock("@tauri-apps/api/core", () => ({
 		onmessage = (_message: unknown) => {};
 
 		constructor() {
+			if (mockChannelConstructionError) {
+				throw mockChannelConstructionError;
+			}
 			mockChannels.push(this);
 		}
 	},
@@ -275,6 +280,7 @@ describe("useTerminal", () => {
 		mockInvoke.mockReset();
 		mockListen.mockReset();
 		mockChannels.length = 0;
+		mockChannelConstructionError = null;
 		mockTerminalConstructorOptions = {};
 		mockWebglAddonInstances.length = 0;
 		MockWebSocket.instances.length = 0;
@@ -417,6 +423,7 @@ describe("useTerminal", () => {
 			expect(mockInvoke).toHaveBeenCalledWith("attach_terminal_surface", {
 				owner: { kind: "workspace", workspacePath: "" },
 				attachmentId: expect.any(String),
+				recovery: false,
 				onEvent: mockChannels[0],
 			});
 		});
@@ -768,13 +775,14 @@ describe("useTerminal", () => {
 		});
 	});
 
-	it("PTY初期化失敗を表示して呼び出し元へ通知する", async () => {
+	it("CAP_REACHEDのbackend messageをalert用callbackだけへ通知する", async () => {
 		const onTerminalError = vi.fn();
 		mockInvoke.mockImplementation((cmd: string) => {
 			if (cmd === "get_or_spawn_terminal_surface") {
 				return Promise.reject({
 					code: "CAP_REACHED",
-					message: "PTY limit unavailable for worktree /repo",
+					message:
+						"Terminal limit reached. Close an open Terminal and try again.",
 				});
 			}
 			return Promise.resolve();
@@ -786,11 +794,11 @@ describe("useTerminal", () => {
 
 		await waitFor(() => {
 			expect(onTerminalError).toHaveBeenCalledWith(
-				"Terminal limit reached: PTY limit unavailable for worktree /repo",
+				"Terminal limit reached. Close an open Terminal and try again.",
 			);
 		});
-		expect(mockTerminalInstance.write).toHaveBeenCalledWith(
-			"\r\n\x1b[31mTerminal limit reached: PTY limit unavailable for worktree /repo\x1b[0m\r\n",
+		expect(mockTerminalInstance.write).not.toHaveBeenCalledWith(
+			"\r\n\x1b[31mTerminal limit reached. Close an open Terminal and try again.\x1b[0m\r\n",
 		);
 		expect(mockInvoke).not.toHaveBeenCalledWith(
 			"register_active_terminal",
@@ -798,11 +806,11 @@ describe("useTerminal", () => {
 		);
 	});
 
-	it("安定codeのない上限風messageは一般初期化失敗として扱う", async () => {
+	it("プレーン文字列の初期化失敗をそのまま通知する", async () => {
 		const onTerminalError = vi.fn();
 		mockInvoke.mockImplementation((cmd: string) => {
 			if (cmd === "get_or_spawn_terminal_surface") {
-				return Promise.reject("PTY cap reached for worktree /repo");
+				return Promise.reject("Terminal initialization failed. Try again.");
 			}
 			return Promise.resolve();
 		});
@@ -813,9 +821,32 @@ describe("useTerminal", () => {
 
 		await waitFor(() => {
 			expect(onTerminalError).toHaveBeenCalledWith(
-				"Failed to initialize terminal: PTY cap reached for worktree /repo",
+				"Terminal initialization failed. Try again.",
 			);
 		});
+	});
+
+	it("frontend内部の初期化失敗には操作文脈を付けて通知する", async () => {
+		const onTerminalError = vi.fn();
+		const schedulerSetup = vi
+			.spyOn(TerminalOutputScheduler.prototype, "setMaxWritesInFlight")
+			.mockImplementationOnce(() => {
+				throw new Error("renderer attachment setup failed");
+			});
+
+		try {
+			renderHook(() =>
+				useTerminal(containerRef, { cwd: "/repo", onTerminalError }),
+			);
+
+			await waitFor(() => {
+				expect(onTerminalError).toHaveBeenCalledWith(
+					"Failed to initialize terminal: renderer attachment setup failed",
+				);
+			});
+		} finally {
+			schedulerSetup.mockRestore();
+		}
 	});
 
 	it("ユーザー入力時に write_terminal_surface が呼び出される", async () => {
@@ -844,6 +875,42 @@ describe("useTerminal", () => {
 				sequence: 0,
 				data: "test input",
 			});
+		});
+	});
+
+	it("Channel write失敗を無加工で通知し新attachmentへ自動resyncする", async () => {
+		const onTerminalError = vi.fn();
+		const onTerminalReady = vi.fn();
+		const baseImplementation = mockInvoke.getMockImplementation();
+		mockInvoke.mockImplementation(
+			(cmd: string, args?: Record<string, unknown>) => {
+				if (cmd === "write_terminal_surface") {
+					return Promise.reject("Terminal input could not be sent. Try again.");
+				}
+				return baseImplementation?.(cmd, args);
+			},
+		);
+
+		renderHook(() =>
+			useTerminal(containerRef, { onTerminalError, onTerminalReady }),
+		);
+		await waitFor(() => {
+			expect(onTerminalReady).toHaveBeenCalledWith("test-uuid-1234");
+		});
+		onTerminalError.mockClear();
+
+		mockOnDataCallback("test input");
+
+		await waitFor(() => {
+			expect(onTerminalError.mock.calls).toEqual([
+				["Terminal input could not be sent. Try again."],
+				[null],
+			]);
+			expect(
+				mockInvoke.mock.calls.filter(
+					([command]) => command === "attach_terminal_surface",
+				),
+			).toHaveLength(2);
 		});
 	});
 
@@ -911,11 +978,15 @@ describe("useTerminal", () => {
 
 	it("input_unavailable受信時は新attachmentへ一度だけ自動resyncする", async () => {
 		const onTerminalError = vi.fn();
-		renderHook(() => useTerminal(containerRef, { onTerminalError }));
+		const onTerminalReady = vi.fn();
+		renderHook(() =>
+			useTerminal(containerRef, { onTerminalError, onTerminalReady }),
+		);
 
 		await waitFor(() => {
-			expect(mockChannels).toHaveLength(1);
+			expect(onTerminalReady).toHaveBeenCalledWith("test-uuid-1234");
 		});
+		onTerminalError.mockClear();
 		const firstAttachCall = mockInvoke.mock.calls.find(
 			([command]) => command === "attach_terminal_surface",
 		);
@@ -944,23 +1015,64 @@ describe("useTerminal", () => {
 			([command]) => command === "attach_terminal_surface",
 		);
 		expect(attachCalls).toHaveLength(2);
+		expect(attachCalls[0][1]).toEqual(
+			expect.objectContaining({ recovery: false }),
+		);
+		expect(attachCalls[1][1]).toEqual(
+			expect.objectContaining({ recovery: true }),
+		);
+		expect(onTerminalError.mock.calls).toEqual([
+			["Failed to write to terminal: stale attachment"],
+			[null],
+		]);
 		const secondAttachmentId = (attachCalls[1][1] as { attachmentId: string })
 			.attachmentId;
 		expect(secondAttachmentId).not.toBe(firstAttachmentId);
 	});
 
-	it("stream itemのapply失敗を通知し以後のitemを処理し続ける", async () => {
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	it("resync commandのプレーン文字列rejectを接頭辞なしで通知する", async () => {
 		const onTerminalError = vi.fn();
+		let attachCalls = 0;
+		const baseImplementation = mockInvoke.getMockImplementation();
+		mockInvoke.mockImplementation(
+			(cmd: string, args?: Record<string, unknown>) => {
+				if (cmd === "attach_terminal_surface") {
+					attachCalls += 1;
+					if (attachCalls === 2) {
+						return Promise.reject("backend resync failed");
+					}
+				}
+				return baseImplementation?.(cmd, args);
+			},
+		);
 		renderHook(() => useTerminal(containerRef, { onTerminalError }));
 
 		await waitFor(() => {
 			expect(mockChannels).toHaveLength(1);
-			expect(mockInvoke).toHaveBeenCalledWith(
-				"resize_terminal_surface",
-				expect.objectContaining({ rows: 24, cols: 80 }),
-			);
 		});
+		mockChannels[0].onmessage({
+			type: "input_unavailable",
+			session_key: "test-uuid-1234",
+			message: "stale attachment",
+		});
+
+		await waitFor(() => {
+			expect(onTerminalError).toHaveBeenCalledWith("backend resync failed");
+		});
+	});
+
+	it("stream itemのapply失敗を通知し新attachmentへのresync成功でクリアする", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const onTerminalError = vi.fn();
+		const onTerminalReady = vi.fn();
+		renderHook(() =>
+			useTerminal(containerRef, { onTerminalError, onTerminalReady }),
+		);
+
+		await waitFor(() => {
+			expect(onTerminalReady).toHaveBeenCalledWith("test-uuid-1234");
+		});
+		onTerminalError.mockClear();
 		mockTerminalInstance.resize.mockImplementationOnce(() => {
 			throw new Error("resize boom");
 		});
@@ -972,25 +1084,98 @@ describe("useTerminal", () => {
 			rows: 40,
 			sequence: 1,
 		});
-		mockChannels[0].onmessage({
-			type: "output",
-			session_key: "test-uuid-1234",
-			data: "after-failure",
-			sequence: 2,
-		});
-
 		await waitFor(() => {
-			expect(onTerminalError).toHaveBeenCalledWith(
-				"Failed to apply terminal stream item: resize boom",
-			);
-			expect(mockTerminalInstance.write).toHaveBeenCalledWith(
-				"after-failure",
-				expect.any(Function),
-			);
+			expect(onTerminalError.mock.calls).toEqual([
+				["Failed to apply terminal stream item: resize boom"],
+				[null],
+			]);
+			expect(mockChannels).toHaveLength(2);
 		});
 		expect(errorSpy).toHaveBeenCalledWith(
 			"Failed to apply terminal stream item: resize boom",
 		);
+		errorSpy.mockRestore();
+	});
+
+	it("recovery中にstream itemのapply失敗が連続してもresyncを張り直さない", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const attachResolvers: Array<() => void> = [];
+		let attachCalls = 0;
+		const baseImplementation = mockInvoke.getMockImplementation();
+		mockInvoke.mockImplementation(
+			(cmd: string, args?: Record<string, unknown>) => {
+				if (cmd === "attach_terminal_surface") {
+					attachCalls += 1;
+					if (attachCalls === 1) {
+						const channel = args?.onEvent as {
+							onmessage: (message: unknown) => void;
+						};
+						queueMicrotask(() => {
+							channel.onmessage({
+								type: "snapshot",
+								surface: {
+									session_key: "test-uuid-1234",
+									terminal_surface: {
+										replay: "",
+										sequence: 0,
+										cols: 80,
+										rows: 24,
+									},
+									is_exited: false,
+									exit_code: null,
+								},
+							});
+						});
+						return Promise.resolve();
+					}
+					return new Promise<void>((resolve) => {
+						attachResolvers.push(resolve);
+					});
+				}
+				return baseImplementation?.(cmd, args);
+			},
+		);
+
+		const onTerminalReady = vi.fn();
+		renderHook(() => useTerminal(containerRef, { onTerminalReady }));
+		await waitFor(() => {
+			expect(onTerminalReady).toHaveBeenCalledWith("test-uuid-1234");
+		});
+		mockTerminalInstance.resize.mockImplementation(() => {
+			throw new Error("resize boom");
+		});
+
+		mockChannels[0].onmessage({
+			type: "resize",
+			session_key: "test-uuid-1234",
+			cols: 120,
+			rows: 40,
+			sequence: 1,
+		});
+		await waitFor(() => {
+			expect(mockChannels).toHaveLength(2);
+			expect(attachResolvers).toHaveLength(1);
+		});
+		mockChannels[1].onmessage({
+			type: "resize",
+			session_key: "test-uuid-1234",
+			cols: 121,
+			rows: 41,
+			sequence: 2,
+		});
+		mockChannels[1].onmessage({
+			type: "resize",
+			session_key: "test-uuid-1234",
+			cols: 122,
+			rows: 42,
+			sequence: 3,
+		});
+
+		await waitFor(() => {
+			expect(errorSpy).toHaveBeenCalledTimes(3);
+		});
+		expect(attachCalls).toBe(2);
+		attachResolvers[0]();
 		errorSpy.mockRestore();
 	});
 
@@ -1034,6 +1219,58 @@ describe("useTerminal", () => {
 			expect(mockInvoke).toHaveBeenCalledWith("detach_terminal_surface", {
 				attachmentId: attachmentIds[1],
 			});
+		});
+	});
+
+	it("resync中のfrontend内部例外には操作文脈を付けて通知する", async () => {
+		const onTerminalError = vi.fn();
+		renderHook(() => useTerminal(containerRef, { onTerminalError }));
+		await waitFor(() => {
+			expect(mockChannels).toHaveLength(1);
+		});
+		mockChannelConstructionError = new Error("renderer recovery setup failed");
+		mockChannels[0].onmessage({
+			type: "input_unavailable",
+			session_key: "test-uuid-1234",
+			message: "stale attachment",
+		});
+
+		await waitFor(() => {
+			expect(onTerminalError).toHaveBeenCalledWith(
+				"Failed to resynchronize terminal: renderer recovery setup failed",
+			);
+		});
+	});
+
+	it("resync中のdetach command rejectを接頭辞なしで通知する", async () => {
+		const onTerminalError = vi.fn();
+		const baseImplementation = mockInvoke.getMockImplementation();
+		mockInvoke.mockImplementation(
+			(cmd: string, args?: Record<string, unknown>) => {
+				if (cmd === "detach_terminal_surface") {
+					return Promise.reject({
+						code: "PTY_ERROR",
+						message: "Terminal detachment failed. Try again.",
+					});
+				}
+				return baseImplementation?.(cmd, args);
+			},
+		);
+		renderHook(() => useTerminal(containerRef, { onTerminalError }));
+
+		await waitFor(() => {
+			expect(mockChannels).toHaveLength(1);
+		});
+		mockChannels[0].onmessage({
+			type: "input_unavailable",
+			session_key: "test-uuid-1234",
+			message: "stale attachment",
+		});
+
+		await waitFor(() => {
+			expect(onTerminalError).toHaveBeenCalledWith(
+				"Terminal detachment failed. Try again.",
+			);
 		});
 	});
 
@@ -1812,6 +2049,36 @@ describe("useTerminal", () => {
 				attachmentId,
 				sequence: 7,
 			});
+		});
+	});
+
+	it("ack commandのIPC失敗へ操作文脈を付けて通知する", async () => {
+		const onTerminalError = vi.fn();
+		const baseImplementation = mockInvoke.getMockImplementation();
+		mockInvoke.mockImplementation(
+			(cmd: string, args?: Record<string, unknown>) => {
+				if (cmd === "ack_terminal_surface_output") {
+					return Promise.reject("IPC bridge unavailable");
+				}
+				return baseImplementation?.(cmd, args);
+			},
+		);
+		renderHook(() => useTerminal(containerRef, { onTerminalError }));
+
+		await waitFor(() => {
+			expect(mockChannels).toHaveLength(1);
+		});
+		mockChannels[0].onmessage({
+			type: "output",
+			session_key: "test-uuid-1234",
+			data: "provider output",
+			sequence: 7,
+		});
+
+		await waitFor(() => {
+			expect(onTerminalError).toHaveBeenCalledWith(
+				"Failed to acknowledge terminal output: IPC bridge unavailable",
+			);
 		});
 	});
 
@@ -2817,6 +3084,113 @@ describe("useTerminal", () => {
 			);
 		};
 
+		it("初期化中のWS stream errorをresyncし初期化完走時にクリアする", async () => {
+			mockStreamEndpoint();
+			const onTerminalError = vi.fn();
+			const onTerminalReady = vi.fn();
+
+			renderHook(() =>
+				useTerminal(containerRef, { onTerminalError, onTerminalReady }),
+			);
+			await waitFor(() => {
+				expect(MockWebSocket.instances).toHaveLength(1);
+			});
+			const socket = MockWebSocket.instances[0];
+			socket.open();
+			await waitFor(() => {
+				expect(socket.sent).toHaveLength(1);
+			});
+			socket.acceptAttach();
+			socket.receive({
+				status: "error",
+				error: {
+					code: "PTY_ERROR",
+					message: "Terminal input could not be sent. Try again.",
+				},
+			});
+
+			expect(onTerminalError).toHaveBeenCalledWith(
+				"Terminal input could not be sent. Try again.",
+			);
+			await waitFor(() => {
+				expect(MockWebSocket.instances).toHaveLength(2);
+			});
+			const recoverySocket = MockWebSocket.instances[1];
+			recoverySocket.open();
+			await waitFor(() => {
+				expect(recoverySocket.sent).toHaveLength(1);
+			});
+			recoverySocket.acceptAttach();
+			recoverySocket.receive(wsSnapshot);
+
+			await waitFor(() => {
+				expect(onTerminalReady).toHaveBeenCalledWith("test-uuid-1234");
+			});
+			expect(onTerminalError).toHaveBeenCalledWith(null);
+		});
+
+		it("古いepochの再同期成功では新しい再同期失敗をクリアしない", async () => {
+			mockStreamEndpoint();
+			const onTerminalError = vi.fn();
+			const onTerminalReady = vi.fn();
+
+			renderHook(() =>
+				useTerminal(containerRef, { onTerminalError, onTerminalReady }),
+			);
+			await waitFor(() => {
+				expect(MockWebSocket.instances).toHaveLength(1);
+			});
+			const first = MockWebSocket.instances[0];
+			first.open();
+			await waitFor(() => {
+				expect(first.sent).toHaveLength(1);
+			});
+			first.acceptAttach();
+			first.receive(wsSnapshot);
+			await waitFor(() => {
+				expect(onTerminalReady).toHaveBeenCalledWith("test-uuid-1234");
+			});
+			onTerminalError.mockClear();
+
+			first.receive({
+				status: "event",
+				item: {
+					type: "input_unavailable",
+					session_key: "test-uuid-1234",
+					message: "stale attachment",
+				},
+			});
+			await waitFor(() => {
+				expect(MockWebSocket.instances).toHaveLength(2);
+			});
+			const second = MockWebSocket.instances[1];
+			second.open();
+			await waitFor(() => {
+				expect(second.sent).toHaveLength(1);
+			});
+			mockChannelConstructionError = new Error(
+				"renderer recovery setup failed",
+			);
+			const closeFirst = first.close.bind(first);
+			first.close = () => {
+				closeFirst();
+				second.close();
+			};
+
+			second.acceptAttach();
+
+			await waitFor(() => {
+				expect(onTerminalError).toHaveBeenCalledWith(
+					"Failed to resynchronize terminal: renderer recovery setup failed",
+				);
+			});
+			await Promise.resolve();
+			expect(onTerminalError).not.toHaveBeenCalledWith(null);
+			expect(onTerminalError).toHaveBeenLastCalledWith(
+				"Failed to resynchronize terminal: renderer recovery setup failed",
+			);
+		});
+
 		it("snapshot後の予期しないWS切断はChannelへ単発resyncし以後の入力はinvoke経路になる", async () => {
 			mockStreamEndpoint();
 
@@ -2877,6 +3251,96 @@ describe("useTerminal", () => {
 					([command]) => command === "attach_terminal_surface",
 				),
 			).toHaveLength(1);
+		});
+
+		it("WS stream errorはbackend messageを無加工で通知しresync成功でクリアする", async () => {
+			mockStreamEndpoint();
+			const onTerminalError = vi.fn();
+			const onTerminalReady = vi.fn();
+
+			renderHook(() =>
+				useTerminal(containerRef, { onTerminalError, onTerminalReady }),
+			);
+			await waitFor(() => {
+				expect(MockWebSocket.instances).toHaveLength(1);
+			});
+			const socket = MockWebSocket.instances[0];
+			socket.open();
+			await waitFor(() => {
+				expect(socket.sent).toHaveLength(1);
+			});
+			socket.acceptAttach();
+			socket.receive(wsSnapshot);
+			await waitFor(() => {
+				expect(onTerminalReady).toHaveBeenCalledWith("test-uuid-1234");
+			});
+			onTerminalError.mockClear();
+			socket.receive({
+				status: "error",
+				error: {
+					code: "PTY_ERROR",
+					message: "Terminal input could not be sent. Try again.",
+				},
+			});
+
+			await waitFor(() => {
+				expect(MockWebSocket.instances).toHaveLength(2);
+			});
+			const recoverySocket = MockWebSocket.instances[1];
+			recoverySocket.open();
+			await waitFor(() => {
+				expect(recoverySocket.sent).toHaveLength(1);
+			});
+			recoverySocket.acceptAttach();
+			recoverySocket.receive(wsSnapshot);
+
+			await waitFor(() => {
+				expect(onTerminalError.mock.calls).toEqual([
+					["Terminal input could not be sent. Try again."],
+					[null],
+				]);
+			});
+			expect(onTerminalError).not.toHaveBeenCalledWith(
+				expect.stringContaining("Terminal stream error:"),
+			);
+		});
+
+		it("messageのないWS error frameは表示せずsocketを閉じてresyncする", async () => {
+			mockStreamEndpoint();
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const onTerminalError = vi.fn();
+
+			try {
+				renderHook(() => useTerminal(containerRef, { onTerminalError }));
+				await waitFor(() => {
+					expect(MockWebSocket.instances).toHaveLength(1);
+				});
+				const socket = MockWebSocket.instances[0];
+				socket.open();
+				await waitFor(() => {
+					expect(socket.sent).toHaveLength(1);
+				});
+				socket.acceptAttach();
+				socket.receive(wsSnapshot);
+				socket.receive({ status: "error", error: { code: "PTY_ERROR" } });
+
+				await waitFor(() => {
+					expect(socket.readyState).toBe(MockWebSocket.CLOSED);
+					expect(
+						mockInvoke.mock.calls.filter(
+							([command]) => command === "attach_terminal_surface",
+						),
+					).toHaveLength(1);
+				});
+				expect(
+					onTerminalError.mock.calls.filter(([message]) => message !== null),
+				).toEqual([]);
+				expect(warnSpy).toHaveBeenCalledWith(
+					"Closing terminal stream after an error frame without a backend message",
+				);
+			} finally {
+				warnSpy.mockRestore();
+			}
 		});
 
 		it("recovery中のWSがsnapshot前に切断されてもepoch単位で再入し回復する", async () => {
@@ -3388,7 +3852,11 @@ describe("useTerminal", () => {
 				},
 			);
 
-			renderHook(() => useTerminal(containerRef));
+			const onTerminalError = vi.fn();
+			const onTerminalReady = vi.fn();
+			renderHook(() =>
+				useTerminal(containerRef, { onTerminalError, onTerminalReady }),
+			);
 			await waitFor(() => {
 				expect(mockChannels).toHaveLength(1);
 			});
@@ -3418,6 +3886,8 @@ describe("useTerminal", () => {
 				"write_terminal_surface",
 				expect.anything(),
 			);
+			expect(onTerminalError).toHaveBeenCalledWith(null);
+			expect(onTerminalReady).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -2,6 +2,7 @@ import { Channel, invoke } from "@tauri-apps/api/core";
 import { FitAddon } from "@xterm/addon-fit";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import { type RefObject, useCallback, useEffect, useMemo, useRef } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 import {
 	reportMountedXtermMounted,
 	reportMountedXtermUnmounted,
@@ -37,47 +38,17 @@ interface GetOrSpawnTerminalResult {
 	exit_code: number | null;
 }
 
-interface TauriCommandError {
-	code?: unknown;
-	message?: unknown;
-}
+class TerminalBackendCommandError extends Error {}
 
-const TERMINAL_CAP_REACHED_CODE = "CAP_REACHED";
-
-function isObject(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
-function getCommandError(error: unknown): TauriCommandError | null {
-	if (!isObject(error)) return null;
-	return error;
-}
-
-function getErrorMessage(error: unknown): string {
-	const commandError = getCommandError(error);
-	if (typeof commandError?.message === "string") {
-		return commandError.message;
+async function invokeTerminalBackendCommand<T>(
+	command: string,
+	args: Record<string, unknown>,
+): Promise<T> {
+	try {
+		return await invoke<T>(command, args);
+	} catch (error) {
+		throw new TerminalBackendCommandError(getErrorMessage(error));
 	}
-	if (error instanceof Error) {
-		return error.message;
-	}
-	return String(error);
-}
-
-function getErrorCode(error: unknown): string | null {
-	const commandError = getCommandError(error);
-	if (typeof commandError?.code === "string") {
-		return commandError.code;
-	}
-	return null;
-}
-
-function formatTerminalInitError(error: unknown): string {
-	const message = getErrorMessage(error);
-	if (getErrorCode(error) === TERMINAL_CAP_REACHED_CODE) {
-		return `Terminal limit reached: ${message}`;
-	}
-	return `Failed to initialize terminal: ${message}`;
 }
 
 const terminalDarkTheme: ITheme = {
@@ -137,7 +108,7 @@ export interface UseTerminalOptions {
 	owner?: TerminalSurfaceOwner;
 	label?: string;
 	onTerminalReady?: (sessionKey: string) => void;
-	onTerminalError?: (message: string) => void;
+	onTerminalError?: (message: string | null) => void;
 	shouldKillPendingTerminal?: () => boolean;
 	initialization?: TerminalInitializationMode;
 	autoFocus?: boolean;
@@ -306,6 +277,7 @@ export function useTerminal(
 			});
 		};
 		let recoverAttachment: ((failedEpoch?: number) => void) | null = null;
+		let attachmentEpoch = 0;
 		let performanceRequestStartedAt: number | null = null;
 		let firstXtermParsed = false;
 		const performanceProbeActive = isTerminalPerformanceProbeActive();
@@ -370,10 +342,13 @@ export function useTerminal(
 			performanceRequestStartedAt = launchOrigin ?? requestStartedAt;
 			const result =
 				initialization === "attach-existing"
-					? await invoke<GetOrSpawnTerminalResult>("get_terminal_surface", {
-							owner: terminalOwner,
-						})
-					: await invoke<GetOrSpawnTerminalResult>(
+					? await invokeTerminalBackendCommand<GetOrSpawnTerminalResult>(
+							"get_terminal_surface",
+							{
+								owner: terminalOwner,
+							},
+						)
+					: await invokeTerminalBackendCommand<GetOrSpawnTerminalResult>(
 							"get_or_spawn_terminal_surface",
 							{
 								rows,
@@ -437,7 +412,6 @@ export function useTerminal(
 			let hasSnapshot = false;
 			let streamSessionKey = result.session_key;
 			let streamProcessing = Promise.resolve();
-			let attachmentEpoch = 0;
 			let recoveringSinceEpoch: number | null = null;
 			let firstChannelReceived = false;
 			const attachStream = async (recovery: boolean) => {
@@ -466,9 +440,10 @@ export function useTerminal(
 						sequence,
 					}).catch((error) => {
 						if (!isMounted || epoch !== attachmentEpoch) return;
-						const message = `Failed to acknowledge terminal output: ${getErrorMessage(error)}`;
-						console.error(message);
-						onTerminalErrorRef.current?.(message);
+						const message = getErrorMessage(error);
+						const contextualMessage = `Failed to acknowledge terminal output: ${message}`;
+						console.error(contextualMessage);
+						onTerminalErrorRef.current?.(contextualMessage);
 						recoverAttachment?.();
 					});
 				};
@@ -535,9 +510,11 @@ export function useTerminal(
 					}
 					streamProcessing = streamProcessing.then(() =>
 						applyTerminalStreamItem(item, applyContext).catch((error) => {
+							if (!isMounted || epoch !== attachmentEpoch) return;
 							const message = `Failed to apply terminal stream item: ${getErrorMessage(error)}`;
 							console.error(message);
 							onTerminalErrorRef.current?.(message);
+							recoverAttachment?.();
 						}),
 					);
 				};
@@ -561,8 +538,10 @@ export function useTerminal(
 								},
 								onStreamItem: handleStreamItem,
 								onStreamError: (message) => {
+									if (!isMounted || epoch !== attachmentEpoch) return;
 									console.error(message);
 									onTerminalErrorRef.current?.(message);
+									recoverAttachment?.();
 								},
 							},
 						);
@@ -577,9 +556,10 @@ export function useTerminal(
 				if (!nextSocket) {
 					const nextChannel = new Channel<TerminalSurfaceStreamItem>();
 					nextChannel.onmessage = handleStreamItem;
-					await invoke("attach_terminal_surface", {
+					await invokeTerminalBackendCommand("attach_terminal_surface", {
 						owner: terminalOwner,
 						attachmentId: nextAttachmentId,
+						recovery,
 						onEvent: nextChannel,
 					});
 				}
@@ -595,7 +575,7 @@ export function useTerminal(
 					socketsClosedByUs.add(previousSocket);
 					previousSocket.close();
 				} else if (previousAttachmentId) {
-					await invoke("detach_terminal_surface", {
+					await invokeTerminalBackendCommand("detach_terminal_surface", {
 						attachmentId: previousAttachmentId,
 					});
 				}
@@ -614,14 +594,22 @@ export function useTerminal(
 				recoveringSinceEpoch = attemptEpoch;
 				void attempt.then(
 					() => {
-						if (!isMounted) releaseCurrentAttachment();
+						if (!isMounted) {
+							releaseCurrentAttachment();
+							return;
+						}
+						if (attemptEpoch !== attachmentEpoch) return;
+						onTerminalErrorRef.current?.(null);
 					},
 					(error) => {
 						if (recoveringSinceEpoch === attemptEpoch) {
 							recoveringSinceEpoch = null;
 						}
 						if (!isMounted) return;
-						const message = `Failed to resynchronize terminal: ${getErrorMessage(error)}`;
+						const message =
+							error instanceof TerminalBackendCommandError
+								? error.message
+								: `Failed to resynchronize terminal: ${getErrorMessage(error)}`;
 						console.error(message);
 						onTerminalErrorRef.current?.(message);
 					},
@@ -638,7 +626,9 @@ export function useTerminal(
 			]);
 			if (!initialized) return;
 			if (autoFocus) terminal.focus();
-			if (!isMounted || !isRunningRef.current) return;
+			if (!isMounted) return;
+			onTerminalErrorRef.current?.(null);
+			if (!isRunningRef.current) return;
 			onTerminalReadyRef.current?.(streamSessionKey);
 
 			// 初回fit()が不正確だった場合のセーフティネット:
@@ -654,14 +644,17 @@ export function useTerminal(
 		initTerminal().catch((error) => {
 			console.error("Failed to initialize PTY:", error);
 			if (!isMounted) return;
-			const message = formatTerminalInitError(error);
-			terminal.write(`\r\n\x1b[31m${message}\x1b[0m\r\n`);
+			const message =
+				error instanceof TerminalBackendCommandError
+					? error.message
+					: `Failed to initialize terminal: ${getErrorMessage(error)}`;
 			onTerminalErrorRef.current?.(message);
 		});
 
 		deliverInput = (data: string) => {
 			const activeAttachmentId = attachmentId;
 			if (!activeAttachmentId) return;
+			const writeEpoch = attachmentEpoch;
 			const sequence = inputSequence;
 			inputSequence += 1;
 			const clientStartedAtUnixMs = performanceProbeActive
@@ -695,7 +688,11 @@ export function useTerminal(
 					? {}
 					: { clientStartedAtUnixMs }),
 			}).catch((error) => {
+				if (!isMounted || writeEpoch !== attachmentEpoch) return;
+				const message = getErrorMessage(error);
 				console.error("Failed to dispatch terminal input:", error);
+				onTerminalErrorRef.current?.(message);
+				recoverAttachment?.();
 			});
 		};
 		const dispatchInput = (data: string) => {

--- a/src/hooks/useUpdateChecker.ts
+++ b/src/hooks/useUpdateChecker.ts
@@ -1,6 +1,7 @@
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 type UpdateStatus = "idle" | "checking" | "available" | "downloading" | "error";
 
@@ -78,7 +79,7 @@ export function useUpdateChecker(enabled: boolean): UpdateCheckResult {
 				});
 				await relaunch();
 			} catch (e) {
-				setError(e instanceof Error ? e.message : String(e));
+				setError(getErrorMessage(e));
 				setStatus("error");
 			}
 		})();

--- a/src/hooks/useWorkflowConfig.ts
+++ b/src/hooks/useWorkflowConfig.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useState } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 import type { WorkflowDefinitionSummary } from "@/types/workflow";
 
 export function useWorkflowConfig(open: boolean) {
@@ -14,7 +15,7 @@ export function useWorkflowConfig(open: boolean) {
 			const list = await invoke<WorkflowDefinitionSummary[]>("list_workflows");
 			setWorkflows(list);
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 		} finally {
 			setLoading(false);
 		}
@@ -33,7 +34,7 @@ export function useWorkflowConfig(open: boolean) {
 				await invoke("delete_workflow", { name });
 				await fetchWorkflows();
 			} catch (e) {
-				setError(String(e));
+				setError(getErrorMessage(e));
 			}
 		},
 		[fetchWorkflows],
@@ -44,7 +45,7 @@ export function useWorkflowConfig(open: boolean) {
 		try {
 			await invoke("open_workflow_in_editor", { name });
 		} catch (e) {
-			setError(String(e));
+			setError(getErrorMessage(e));
 		}
 	}, []);
 

--- a/src/hooks/useWorkspaceNodeDetail.ts
+++ b/src/hooks/useWorkspaceNodeDetail.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useEffect, useRef, useState } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 import type { WorkflowExecutionChangedPayload } from "@/types/workflow";
 import type { WorkspaceNodeDetail } from "@/types/workspace-tree";
 
@@ -84,8 +85,7 @@ export function useWorkspaceNodeDetail({
 				})
 				.catch((error) => {
 					if (cancelled || loadSeq !== loadSeqRef.current) return;
-					const message =
-						error instanceof Error ? error.message : String(error);
+					const message = getErrorMessage(error);
 					if (preserveDetail && detailRef.current != null) {
 						setState({
 							detail: detailRef.current,

--- a/src/hooks/useWorkspaceTreeNodes.ts
+++ b/src/hooks/useWorkspaceTreeNodes.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { subscribeAgentSessionChanged } from "@/lib/agentSessionEvents";
+import { getErrorMessage } from "@/lib/errorMessage";
 import type { WorkflowExecutionChangedPayload } from "@/types/workflow";
 import type {
 	WorkspaceTreeItem,
@@ -197,7 +198,7 @@ export function useWorkspaceTreeNodes(
 				}));
 			}
 			errorWorktreePathRef.current = worktreePath;
-			setError(String(e));
+			setError(getErrorMessage(e));
 			return null;
 		} finally {
 			if (seq === refreshSeqRef.current) {

--- a/src/lib/__tests__/telemetry.test.ts
+++ b/src/lib/__tests__/telemetry.test.ts
@@ -73,13 +73,26 @@ describe("telemetry", () => {
 
 	it("frontend error をRustへ送る", () => {
 		const error = new Error("boom");
+		error.stack = "error stack";
 		reportFrontendError(error, "react_error", "component stack");
 		expect(invoke).toHaveBeenCalledWith("report_frontend_error", {
 			payload: expect.objectContaining({
 				errorType: "react_error",
 				message: "boom",
-				stack: expect.stringContaining("component stack"),
+				stack: "error stack\ncomponent stack",
 			}),
+		});
+	});
+
+	it("プレーン文字列のfrontend errorをそのままRustへ送る", () => {
+		reportFrontendError("plain failure");
+
+		expect(invoke).toHaveBeenCalledWith("report_frontend_error", {
+			payload: {
+				errorType: "frontend_error",
+				message: "plain failure",
+				stack: undefined,
+			},
 		});
 	});
 
@@ -103,13 +116,36 @@ describe("telemetry", () => {
 		installFrontendErrorHandlers();
 		const event = new Event("unhandledrejection") as PromiseRejectionEvent;
 		Object.defineProperty(event, "reason", {
-			value: new Error("promise boom"),
+			value: {
+				code: "AGENT_SESSION_LAUNCH_UNAVAILABLE",
+				message: "coded promise failure",
+			},
 		});
 		window.dispatchEvent(event);
 		expect(invoke).toHaveBeenCalledWith("report_frontend_error", {
 			payload: expect.objectContaining({
 				errorType: "unhandled_rejection",
-				message: "promise boom",
+				message: "coded promise failure",
+			}),
+		});
+	});
+
+	it("type tagged errorのmessageをunhandledrejectionからRustへ送る", () => {
+		installFrontendErrorHandlers();
+		const event = new Event("unhandledrejection") as PromiseRejectionEvent;
+		Object.defineProperty(event, "reason", {
+			value: {
+				type: "invalid_request",
+				message:
+					"Releash could not start the application quit because the request is invalid.",
+			},
+		});
+		window.dispatchEvent(event);
+		expect(invoke).toHaveBeenCalledWith("report_frontend_error", {
+			payload: expect.objectContaining({
+				errorType: "unhandled_rejection",
+				message:
+					"Releash could not start the application quit because the request is invalid.",
 			}),
 		});
 	});

--- a/src/lib/errorMessage.test.ts
+++ b/src/lib/errorMessage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { getErrorMessage } from "./errorMessage";
+
+describe("getErrorMessage", () => {
+	it("Errorのmessageを返す", () => {
+		expect(getErrorMessage(new Error("error message"))).toBe("error message");
+	});
+
+	it("messageを持つobjectから文字列を返す", () => {
+		expect(
+			getErrorMessage({ code: "CODED_ERROR", message: "backend message" }),
+		).toBe("backend message");
+	});
+
+	it("プレーン文字列をそのまま返す", () => {
+		expect(getErrorMessage("plain message")).toBe("plain message");
+	});
+
+	it.each([
+		[42, "42"],
+		[null, "null"],
+		[undefined, "undefined"],
+		[{ message: 42 }, "[object Object]"],
+	])("その他の値%jはStringで変換する", (error, expected) => {
+		expect(getErrorMessage(error)).toBe(expected);
+	});
+});

--- a/src/lib/errorMessage.ts
+++ b/src/lib/errorMessage.ts
@@ -1,0 +1,12 @@
+export function getErrorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (
+		typeof error === "object" &&
+		error !== null &&
+		"message" in error &&
+		typeof error.message === "string"
+	) {
+		return error.message;
+	}
+	return String(error);
+}

--- a/src/lib/errorMessageUsage.test.ts
+++ b/src/lib/errorMessageUsage.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+const TYPESCRIPT_SOURCES = import.meta.glob(
+	["./**/*.{ts,tsx}", "../**/*.{ts,tsx}"],
+	{
+		query: "?raw",
+		import: "default",
+		eager: true,
+	},
+);
+
+const TARGET_FILES = [
+	"src/components/workspace/WorkspaceList.tsx",
+	"src/hooks/useProviderAvailabilitySettings.ts",
+	"src/components/panels/AgentSessionPanel/AgentSessionPanel.tsx",
+	"src/components/panels/MarkdownDiffViewer.tsx",
+	"src/hooks/useReviewFileView.ts",
+	"src/lib/telemetry.ts",
+	"src/hooks/useTerminal.ts",
+	"src/components/panels/NodeContentView/NodeContentView.tsx",
+	"src/hooks/useWorkspaceNodeDetail.ts",
+	"src/components/panels/automation/FacetEditor.tsx",
+	"src/components/panels/automation/NameInputDialog.tsx",
+	"src/lib/workflowExecutionActions.ts",
+	"src/hooks/useUpdateChecker.ts",
+	"src/components/panels/SettingsModal.tsx",
+	"src/hooks/useAutomation.ts",
+	"src/screens/useWorktreeGitActions.ts",
+	"src/hooks/useWorkflowConfig.ts",
+	"src/hooks/useAppSettings.ts",
+	"src/components/workspace/DeleteWorktreeDialog.tsx",
+	"src/components/panels/DiffToolbar.tsx",
+	"src/hooks/useWorkspaceTreeNodes.ts",
+	"src/contexts/ReviewThreadHandoffContext.tsx",
+	"src/hooks/useNotionSettings.ts",
+	"src/hooks/useApplicationShutdownSupervision.ts",
+] as const;
+
+const LOCAL_STRING_EXTRACTION =
+	/\bString\s*\(\s*(?:e|err|error|reason|cause|exception|caught)\s*\)/;
+const LOCAL_ERROR_MESSAGE_TERNARY =
+	/instanceof\s+Error\s*\?[\s\S]{0,120}?\.message\b/;
+const LOCAL_HELPER_DECLARATION =
+	/(?:function|const|let|var)\s+getErrorMessage\b/;
+const GET_ERROR_MESSAGE_CALL = /\bgetErrorMessage\s*\(/;
+
+function sourceFor(targetFile: string): string | undefined {
+	const relativePath = targetFile.startsWith("src/lib/")
+		? targetFile.replace(/^src\/lib\//, "./")
+		: targetFile.replace(/^src\//, "../");
+	return TYPESCRIPT_SOURCES[relativePath];
+}
+
+function targetFileFor(relativePath: string): string {
+	return relativePath.startsWith("./")
+		? `src/lib/${relativePath.slice(2)}`
+		: `src/${relativePath.slice(3)}`;
+}
+
+describe("backend error message extraction", () => {
+	it("対象ファイル一覧がproductionの共通抽出関数利用箇所と一致する", () => {
+		const actualTargetFiles = Object.entries(TYPESCRIPT_SOURCES)
+			.filter(
+				([file, source]) =>
+					!file.includes(".test.") &&
+					!file.endsWith("/errorMessage.ts") &&
+					GET_ERROR_MESSAGE_CALL.test(source),
+			)
+			.map(([file]) => targetFileFor(file))
+			.sort();
+		expect(actualTargetFiles).toEqual([...TARGET_FILES].sort());
+
+		for (const file of TARGET_FILES) {
+			const source = sourceFor(file);
+			expect(
+				source,
+				`${file} must be part of the source inventory`,
+			).toBeDefined();
+			if (source === undefined) continue;
+
+			expect(source, `${file} must import getErrorMessage`).toContain(
+				'from "@/lib/errorMessage"',
+			);
+			expect(source, `${file} must call getErrorMessage`).toMatch(
+				/\bgetErrorMessage\s*\(/,
+			);
+			expect(source, `${file} must not use String(error)`).not.toMatch(
+				LOCAL_STRING_EXTRACTION,
+			);
+			expect(
+				source,
+				`${file} must not extract Error.message locally`,
+			).not.toMatch(LOCAL_ERROR_MESSAGE_TERNARY);
+			expect(source, `${file} must not declare a local helper`).not.toMatch(
+				LOCAL_HELPER_DECLARATION,
+			);
+		}
+	});
+
+	it("production sourceへ局所抽出を再導入しない", () => {
+		for (const [file, source] of Object.entries(TYPESCRIPT_SOURCES)) {
+			if (file.includes(".test.") || file.endsWith("/errorMessage.ts")) {
+				continue;
+			}
+
+			expect(source, `${file} must not use String(error)`).not.toMatch(
+				LOCAL_STRING_EXTRACTION,
+			);
+			expect(
+				source,
+				`${file} must not extract Error.message locally`,
+			).not.toMatch(LOCAL_ERROR_MESSAGE_TERNARY);
+			expect(source, `${file} must not declare a local helper`).not.toMatch(
+				LOCAL_HELPER_DECLARATION,
+			);
+		}
+	});
+});

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 let mountedXtermCount = 0;
 let errorHandlersInstalled = false;
@@ -35,13 +36,8 @@ export function reportMountedXtermUnmounted(): void {
 }
 
 function normalizeError(error: unknown): { message: string; stack?: string } {
-	if (error instanceof Error) {
-		return { message: error.message, stack: error.stack };
-	}
-	if (typeof error === "string") {
-		return { message: error };
-	}
-	return { message: String(error) };
+	const stack = error instanceof Error ? error.stack : undefined;
+	return { message: getErrorMessage(error), stack };
 }
 
 export function reportFrontendError(

--- a/src/lib/terminalStreamSocket.ts
+++ b/src/lib/terminalStreamSocket.ts
@@ -81,7 +81,14 @@ export function openTerminalStreamSocket(
 				return;
 			}
 			if (payload.status === "error") {
-				const message = `Terminal stream error: ${payload.error?.message ?? "unknown"}`;
+				const message = payload.error?.message;
+				if (typeof message !== "string") {
+					console.warn(
+						"Closing terminal stream after an error frame without a backend message",
+					);
+					socket.close();
+					return;
+				}
 				if (!settled) {
 					settled = true;
 					reject(new Error(message));

--- a/src/lib/workflowExecutionActions.test.ts
+++ b/src/lib/workflowExecutionActions.test.ts
@@ -31,11 +31,18 @@ describe("executeWorkflowAction", () => {
 		},
 	);
 
-	it("normalizes command errors", async () => {
-		invokeMock.mockRejectedValueOnce("denied");
+	it.each([
+		[{ code: "WORKFLOW_UNAVAILABLE", message: "coded denial" }, "coded denial"],
+		["plain denial", "plain denial"],
+	])("normalizes command errors", async (rejection, expected) => {
+		invokeMock.mockRejectedValueOnce(rejection);
 
-		await expect(
-			executeWorkflowAction("resume", "execution-1"),
-		).rejects.toThrow("Resume workflow failed: denied");
+		try {
+			await executeWorkflowAction("resume", "execution-1");
+			expect.unreachable("workflow action should reject");
+		} catch (error) {
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toBe(expected);
+		}
 	});
 });

--- a/src/lib/workflowExecutionActions.ts
+++ b/src/lib/workflowExecutionActions.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 export type WorkflowExecutionAction = "stop" | "resume" | "abort";
 
@@ -11,12 +12,6 @@ const actionCommand: Record<
 	abort: "abort_workflow",
 };
 
-const actionLabel: Record<WorkflowExecutionAction, string> = {
-	stop: "Stop",
-	resume: "Resume",
-	abort: "Abort",
-};
-
 export async function executeWorkflowAction(
 	action: WorkflowExecutionAction,
 	executionId: string,
@@ -24,6 +19,6 @@ export async function executeWorkflowAction(
 	try {
 		await invoke(actionCommand[action], { executionId });
 	} catch (error) {
-		throw new Error(`${actionLabel[action]} workflow failed: ${String(error)}`);
+		throw new Error(getErrorMessage(error));
 	}
 }

--- a/src/screens/useWorktreeGitActions.ts
+++ b/src/screens/useWorktreeGitActions.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 // Re-export reducer types used by this hook
 export type GitAction =
@@ -83,7 +84,7 @@ export function useWorktreeGitActions({
 			await stage(rootPath, []);
 			refreshGit();
 		} catch (e) {
-			dispatchGit({ type: "SET_GIT_ERROR", error: String(e) });
+			dispatchGit({ type: "SET_GIT_ERROR", error: getErrorMessage(e) });
 		}
 	}, [rootPath, stage, refreshGit, dispatchGit]);
 
@@ -92,7 +93,7 @@ export function useWorktreeGitActions({
 			await unstage(rootPath, []);
 			refreshGit();
 		} catch (e) {
-			dispatchGit({ type: "SET_GIT_ERROR", error: String(e) });
+			dispatchGit({ type: "SET_GIT_ERROR", error: getErrorMessage(e) });
 		}
 	}, [rootPath, unstage, refreshGit, dispatchGit]);
 
@@ -108,7 +109,7 @@ export function useWorktreeGitActions({
 			dispatchUI({ type: "CLOSE_CREATE_BRANCH" });
 			refreshGit();
 		} catch (e) {
-			dispatchGit({ type: "SET_GIT_ERROR", error: String(e) });
+			dispatchGit({ type: "SET_GIT_ERROR", error: getErrorMessage(e) });
 		}
 	}, [
 		rootPath,


### PR DESCRIPTION
## 背景

Tauri の reject 値が `{code, message}` のとき、frontend の `String(error)` / `error instanceof Error ? error.message : String(error)` が値を潰して **`[object Object]`** を表示・報告していた。回復可能性を機械可読にするために `code` を持たせた設計意図が、表示層で完全に失われていた。

表示文言の決定を Rust の operation surface 境界へ集約し、frontend は構造抽出だけを行う形にする。

spec: `docs/specs/issues-1652/`

## 変更

### frontend の抽出境界を一本化

- `src/lib/errorMessage.ts` の `getErrorMessage` を、`unknown` から表示・報告用文字列を得る唯一の関数とする。24ファイル71箇所の局所抽出を置換した。
- `src/lib/errorMessageUsage.test.ts` が production source から `getErrorMessage` の利用ファイル集合を導出して一覧と機械照合し、`String(error)` などの局所抽出の再導入を検出する。
- backend 由来の文言に付いていた接頭辞（`Failed to load diff: ` / `Failed to load markdown diff: ` / `Archive workflow failed: ` 等）を除去した。frontend 内部例外の操作文脈は維持する。

### 利用者向け文言を Rust が所有する

| 対象 | 件数 | 変換位置 |
| --- | --- | --- |
| `AppError::Coded` | 25 code | `agent_session/provider_tui.rs`、`code/mod.rs` |
| application lifecycle tagged error | 7 DTO / 31 variant | `protocol/application_operation_v1.rs` |
| `TerminalCommandError` | 3 code × 4 operation | `terminal_surface/commands.rs` |
| Terminal WebSocket error | 7 operation / code | `api/terminal.rs` |
| `input_unavailable` stream item | 3 原因分類 | `protocol/terminal.rs` |

- `code` と `type` の値、および全ての wire shape は変更しない。tagged error の `message` は手書き `Serialize` で additive に追加する。
- 同じ code / 原因分類でも操作が異なる場合は operation discriminator を変換関数へ渡し、同一 code × 同一操作を一意にする。`attach_terminal_surface` は `recovery` 引数で初回 attach と再同期を区別する。
- `write` と `resize` は Tauri command と WebSocket で同じ固定文言を返す。
- `input_unavailable` は domain event で内部原因を分類し、protocol 境界で transport 非依存の文言へ変換する。

### 内部原因の可観測性

固定文言へ置き換える際に表示から除かれる内部原因を、`operation` / `code` とともに backend log へ記録する。owner 変換失敗、Terminal WebSocket の失敗、`input_unavailable` の原因、stale review group ID が対象。

### Terminal 失敗表示

- `AgentSessionPanel` と `RightSidebarBottom` の Terminal 上に `role="alert"` の失敗表示面を持たせ、`onTerminalError` を配線した。`AgentSessionPanel` はライフサイクル操作の error と別 state で管理する。
- 初期化・attach の完走、または現行 attachment epoch の再同期成功で表示をクリアする。古い epoch の成功では消さない。
- WS stream error、stream 適用失敗、Channel fallback の write 失敗も recovery を起動し、同じクリア条件へ収束させる。

## 検証

| ゲート | 結果 |
| --- | --- |
| `cargo fmt --check` | pass |
| `cargo clippy --locked -- -D warnings` | pass |
| `cargo test --locked` | 2069 + 49 passed |
| `pnpm lint` | pass |
| `pnpm test` | 958 passed / 90 files |
| `pnpm build` | pass |
| `pnpm test:integration` | 25 passed |
| `qlty check --no-progress --all` | No issues |

`design.md` の対応表と Rust 実装の利用者向け message 集合（70件）が双方向で完全一致することを機械照合で確認している。

Closes #1652

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYXjQYZUmLY1qLdNi4vhtQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 構造化エラーやプレーン文字列を正しく表示し、「[object Object]」や不要な接頭辞を排除。
  * 端末の接続・入力・再同期など、操作に応じた分かりやすいエラーを表示。
  * 端末の復旧成功時にエラー表示を自動消去し、古い状態による誤表示を防止。
  * 内部エラー情報を画面やエラー報告に公開せず、利用者向けメッセージを維持。

* **ドキュメント**
  * エラー表示、端末操作、復旧動作に関する要件・設計・検証仕様を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->