### PR TITLE
fix(workspace): ツリー行の状態を4分類へ統一し到達不能な interrupted を除去する

### DIFF
--- a/docs/specs/issues-1683/behavior.md
+++ b/docs/specs/issues-1683/behavior.md
@@ -1,0 +1,127 @@
+## B-001: 状態色の意味
+
+GIVEN Workspace ツリーの行または詳細ペインのノード状態アイコンが表示される
+WHEN ノードの4分類が色で表現される
+THEN 青は「実行中」を表す
+AND 黄は「介入が必要」を表す
+AND 赤は「失敗」を表す
+AND 緑は「動いていない」を表し、完了だけを意味しない
+
+## B-002: Recovery fence を持つ leaf
+
+GIVEN recovery fence を持つ leaf ノードが存在する
+WHEN Workspace ツリーが表示される
+THEN その leaf 行は赤で表示される
+AND 詳細な状態が `paused` であっても赤で表示される
+
+## B-003: 失敗した leaf
+
+GIVEN recovery fence を持たず、詳細な状態が `failed` の leaf ノードが存在する
+WHEN Workspace ツリーが表示される
+THEN その leaf 行は赤で表示される
+
+## B-004: Approval 待ちの leaf
+
+GIVEN recovery fence を持たず、詳細な状態が `failed` ではない approval 待ちの leaf ノードが存在する
+WHEN Workspace ツリーが表示される
+THEN その leaf 行は黄で表示される
+
+## B-005: Stop 信号だけを受領した実行中の leaf
+
+GIVEN recovery fence を持たず、詳細な状態が `failed` でも approval 待ちでもない leaf ノードが存在する
+AND その leaf ノードの詳細な状態は `running` である
+AND その leaf ノードは Stop 信号を受領し、Submit 信号を受領していない
+WHEN Workspace ツリーが表示される
+THEN その leaf 行は黄で表示される
+
+## B-006: 実行中の leaf
+
+GIVEN recovery fence、`failed`、approval 待ち、実行中の Stop 信号だけの受領のいずれにも該当しない leaf ノードが存在する
+AND その leaf ノードの詳細な状態は `running` である
+WHEN Workspace ツリーが表示される
+THEN その leaf 行は青で表示される
+
+## B-007: 動いていない leaf
+
+GIVEN より上位の分類条件に該当しない leaf ノードが存在する
+AND その leaf ノードの詳細な状態は `paused`、`completed`、`aborted` のいずれかである
+WHEN Workspace ツリーが表示される
+THEN その leaf 行は緑で表示される
+AND `paused` の leaf ノードが Stop 信号を受領していても緑で表示される
+
+## B-008: 親行の重大度集約
+
+GIVEN Sequence または Fanout の親行に、自分自身と配下の子の分類結果が存在する
+WHEN Workspace ツリーが表示される
+THEN 親行は赤、黄、青、緑の重大度順で最も重い分類の色で表示される
+AND 自分自身と配下の子の分類結果が同じ組み合わせなら、Sequence と Fanout の親行は同じ色で表示される
+
+## B-009: Workspace ツリー取得の状態表現
+
+GIVEN Workspace ツリー取得の外部インターフェースを利用する
+WHEN ツリー内のノードが返される
+THEN 各ノードの状態表現は「実行中」「介入が必要」「失敗」「動いていない」の4分類のいずれかである
+AND `running`、`paused`、`failed`、`waiting`、`aborted`、`completed` の詳細な状態値は返されない
+AND 呼び出し側が分類を導出する必要はない
+
+## B-010: Workspace ノード詳細取得の状態表現
+
+GIVEN Workspace ノード詳細取得の外部インターフェースを利用する
+WHEN ノード詳細が返される
+THEN ノードの詳細な状態と4分類の両方が返される
+AND 呼び出し側が詳細な状態から4分類を導出する必要はない
+
+## B-011: 詳細ペインの状態アイコン
+
+GIVEN Workspace ノードの詳細が表示される
+WHEN 詳細ペインにノード状態アイコンが表示される
+THEN アイコンの色はノードの4分類に従う
+AND `paused`、`completed`、`aborted` を含む詳細な状態の違いはアイコン形状で判別できる
+
+## B-012: interrupted の非公開化
+
+GIVEN Workspace ツリー取得または Workspace ノード詳細取得の外部インターフェースを利用する
+WHEN ノードの状態表現が返される
+THEN `interrupted` はツリーの状態にもノード詳細の状態にも現れない
+
+## B-013: ツリー行の状態アイコンの pulse
+
+GIVEN Workspace ツリーの行にノード状態アイコンが表示される
+WHEN ノードの4分類が青または黄である
+THEN アイコンは pulse する
+AND ノードの4分類が赤または緑である場合は pulse しない
+
+## B-014: 操作可否と resume 不能理由の維持
+
+GIVEN 同じ Workspace と workflow の状態が存在する
+WHEN 状態分類の変更前後で利用可能な操作と resume 不能理由を比較する
+THEN approve、retry、stop、resume、abort、archive の各操作可否は変わらない
+AND resume 不能理由の内容は変わらない
+
+## B-015: local API と CLI の応答維持
+
+GIVEN 同じ要求を local API または CLI へ送る
+WHEN 状態分類の変更前後で応答を比較する
+THEN local API の応答は変わらない
+AND CLI の応答は変わらない
+
+## B-016: 詳細ペインの状態アイコンの pulse
+
+GIVEN Workspace ノードの詳細が表示される
+WHEN 詳細ペインにノード状態アイコンが表示される
+THEN アイコンは4分類のいずれであっても pulse しない
+
+## 要件IDとBehavior IDの対応表
+
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001 |
+| R-002 | B-002, B-003, B-004, B-005, B-006, B-007 |
+| R-003 | B-008 |
+| R-004 | B-009 |
+| R-005 | B-010 |
+| R-006 | B-011 |
+| R-007 | B-012 |
+| R-008 | B-013, B-016 |
+| R-009 | B-014 |
+| R-010 | B-015 |

--- a/docs/specs/issues-1683/design.md
+++ b/docs/specs/issues-1683/design.md
@@ -1,0 +1,116 @@
+# Design
+
+Primary Spec: [requirements.md](requirements.md) / [behavior.md](behavior.md)
+
+## The actual design
+
+### Architecture
+
+Workspaceの状態分類はRustの`domain/workspace_tree`が所有する。分類の入力は`WorkspaceTreeNode`が既に持つ詳細状態、`completion_signals`、`recovery_owner_reason`であり、frontendやDTO変換で再判定しない。この責務配置は[DOMAIN.md](../../architecture/DOMAIN.md)の「規則はdomainが所有する」と、[USECASE.md](../../architecture/USECASE.md)および[GATEWAY.md](../../architecture/GATEWAY.md)のread model規約に従う。
+
+`WorkspaceTreeNode`の詳細状態と4分類を分離する。詳細状態はNodeイベント由来の状態として維持し、Sequence / Fanoutの子集約で上書きしない。4分類は詳細状態などから導出する別の値であり、Sequence / Fanoutだけが自分自身の分類と配下の分類を集約する。これにより、詳細状態を操作可否や詳細表示の正本として維持したまま、親行の表示分類をSequence / Fanoutで共通化する。
+
+主要な変更対象は次のとおり。
+
+| Path | 変更の要旨 |
+| --- | --- |
+| `src-tauri/src/domain/workspace_tree/value_objects/mod.rs` | 詳細状態から`Interrupted`を除き、4分類を表す`WorkspaceNodeStatusClassification`を追加する |
+| `src-tauri/src/domain/workspace_tree/entities/mod.rs` | leafの分類規則とSequence / Fanoutの重大度集約を所有し、詳細状態と親の分類集約を分離する |
+| `src-tauri/src/domain/workspace_tree/projection.rs` | runtime由来のcompletion signalとpaused状態を反映した後に分類を再計算する |
+| `src-tauri/src/usecase/workflow/workspace_tree.rs` | ツリーDTOの`status`を4分類へ変更し、詳細DTOへ`statusClassification`を追加する |
+| `src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs` | domainが確定した分類をツリーDTOと詳細DTOへ写像する |
+| `src/types/workspace-tree.ts` | ツリー用4分類型と詳細状態型を分離する |
+| `src/components/workspace/WorkflowNodeStatusIcon.tsx`、`WorkspaceBranchStatusIcon.tsx`、`WorkspaceList.tsx` | 色とpulseを4分類だけから選ぶ |
+| `src/components/panels/NodeContentView/NodeContentView.tsx` | 詳細状態で形状を、`statusClassification`で色を選ぶ |
+
+Workflow rootは引き続き`project_tree`で子へ平坦化し、表示対象にしない。現在の「最後の子からWorkflow rootの詳細状態を導出する」表示用分岐は廃止し、Workflow rootの実行状態とcapabilityは既存のexecution summaryおよびrecovery計算から維持する。
+
+approve / retry / stop / resume / abort / archiveの可否、`resume_unavailable_reason`、`preferred_node_id`は4分類を入力にしない。これらは既存の詳細状態、completion signal、recovery情報、execution summaryから算出し続ける。workflowドメインの`ExecutionStatus`とそのTauri / API / CLI表現は変更しない。test専用の`ExecutionStatus::Interrupted`からWorkspaceの詳細状態を生成・公開する経路だけを除き、`WorkspaceNodeStatus::Interrupted`へ操作可否を依存させない。
+
+#### 検証境界
+
+- domainでは、leafの分類優先順位、`paused`とStop信号の組み合わせ、recovery fenceの優先、Sequence / Fanoutの同一重大度集約を検証する。
+- gatewayでは、ツリーDTOが4分類だけを返すこと、詳細DTOが詳細状態と同じdomain分類を返すこと、capabilityとresume不能理由が変わらないことを検証する。
+- frontendでは、4分類の色、ツリー行のpulse、詳細状態ごとのアイコン形状、ツリー型と詳細型の分離を検証する。
+
+### Interface
+
+公開command名、引数、失敗形式は変更しない。変更対象となるTauri read contractは次の三つである。
+
+- `list_workspace_worktree_nodes`
+- `get_workspace_tree_selection_reconciliation`
+- `get_workspace_node_detail`
+
+ツリー内の`WorkspaceNodeDto`、`WorkspaceSequenceDto`、`WorkspaceFanoutDto`は既存の`status` fieldを維持し、値だけを次のclosed setへ置き換える。
+
+```text
+status = "active" | "attention" | "failure" | "idle"
+```
+
+4分類のpublic stringは詳細状態のどの値とも重ならない語彙にする。同じtokenが分類と詳細状態の二つの意味を持つと、`idle`が詳細状態の完了として読まれ、`paused`と`aborted`のノードが完了として扱われる。
+
+`WorkspaceNodeDetailDto`は詳細状態の`status`を維持し、4分類を`statusClassification`として追加する。
+
+```text
+status = "running" | "paused" | "failed" | "waiting" | "aborted" | "completed"
+statusClassification = "active" | "attention" | "failure" | "idle"
+```
+
+`interrupted`はツリーの`status`、詳細の`status`、詳細の`statusClassification`のいずれにも現れない。分類は全到達可能な詳細状態に対してtotalであり、新しい失敗分類やfallback値を公開しない。
+
+ツリーの`status`値変更はrendererと同時に切り替える互換性のないTauri response変更である。詳細の`statusClassification`は追加fieldだが、詳細`status`から`interrupted`を除く。local APIとCLIにはこのWorkspaceツリーread contractがないため、そのprotocolと応答は変更しない。
+
+### Data Model
+
+`WorkspaceNodeStatus`はNodeイベント由来の詳細状態を所有し、`Running | Paused | Failed | Waiting | Aborted | Completed`に閉じる。新しい`WorkspaceNodeStatusClassification`は`Active | Attention | Failure | Idle`に閉じ、public stringはそれぞれ`active | attention | failure | idle`とする。分類はvariant名でもpublic stringでも詳細状態と重ならず、型と語彙の双方で区別する。
+
+`WorkspaceTreeNode`は詳細状態を正本として保持し、分類はそこにcompletion signalとrecovery情報を加えて導出した一時的なread stateとして保持する。Sequence / Fanoutの分類だけは、自分自身の分類と子の分類から再計算した値を保持する。分類にidentity、version、永続recordは追加しない。
+
+ツリーDTOは分類だけを持ち、詳細状態、completion signal、recovery理由を重複して載せない。詳細DTOは詳細状態と分類の両方を持つ。既存の`submitReceived`、`stopReceived`、`waitingFor`、`recoveryReason`は詳細情報として維持する。
+
+### Database
+
+該当なし。分類は既存のcanonical event foldから復元した`WorkspaceTreeNode`上で導出し、SQLite schema、event、projection record、access pathを追加・変更しない。
+
+### UI/UX
+
+ツリー行は既存のBot / Terminal / ListTree / GitForkの形状を維持し、`status`の4分類だけで色を選ぶ。`active`は青、`attention`は黄、`failure`は赤、`idle`は緑に対応する。ツリー行の`title`と`aria-label`は現在と同じく行の`status`をそのまま含め、4分類だけを示す。詳細状態を行のテキストへ出さない。
+
+詳細ペインの`WorkflowNodeStatusIcon`は、`status`でLoader / Clock / AlertTriangle / Circle / Ban / CheckCircleの既存の形状差を維持し、`statusClassification`で色を選ぶ。これにより、たとえばrecovery fenceを持つ`paused`はpausedの形状のまま赤になり、通常の`paused`は同じ形状のまま緑になる。frontendは二つのfieldから分類を再導出しない。
+
+ツリー行のpulseは共有helperで4分類だけから決め、`active`と`attention`で有効、`failure`と`idle`で無効にする。詳細状態による形状選択とは独立させる。詳細ペインのアイコンはpulseさせず、`running`のspinを含む既存の形状表現を維持する。
+
+### Algorithm
+
+各ノードについて、まず自分自身の分類をR-002の順序どおり一つのordered matchで導出する。
+
+1. `recovery_owner_reason`がある場合は`Failure`。
+2. 詳細状態が`Failed`の場合は`Failure`。
+3. 詳細状態が`Waiting`の場合は`Attention`。
+4. 詳細状態が`Running`で、completion signalが`StopReceived`の場合は`Attention`。
+5. 詳細状態が`Running`の場合は`Active`。
+6. 詳細状態が`Paused | Completed | Aborted`の場合は`Idle`。
+
+その後、実行木をpost-orderで一度走査し、Sequence / Fanoutごとに自分自身と直接の子が持つ確定済み分類から`Failure > Attention > Active > Idle`の最上位を採る。子の分類には既にその配下が畳み込まれているため、親ごとに全subtreeを再走査しない。internal rule recordとretry historyは現在の親子集約と同様に通常の配下から除外し、過去attemptは各leaf自身の分類で表示する。
+
+`WorkspaceTree::restore`と`WorkspaceTreeProjector`の再計算に加え、`runtime_snapshot_nodes`がruntimeのcompletion signal、artifact、retry可否、paused状態を上書きした後にも同じ分類・親集約を実行する。これにより、ツリー全体のqueryと単独node detailのqueryが同じ最終入力から分類される。
+
+### Infra
+
+該当なし。
+
+## Alternatives Considered
+
+- frontendの色マップだけを差し替える案: recovery fenceとcompletion signalがツリーDTOに存在せず、分類規則もfrontendへ移るため不採用。
+- ツリーDTOへ詳細状態を残したまま4分類fieldを追加する案: ツリーが使わない詳細状態と表示用分類が並び、呼び出し側がどちらを正とするか選べるため不採用。ツリーの`status`は4分類へ置き換え、詳細状態は詳細DTOだけに残す。
+- SequenceとFanoutの既存集約を個別に修正する案: 同じ親行で異なる重大度規則が残るため不採用。domainの一つのpost-order集約を共有する。
+
+## Cross-cutting concerns
+
+- Performance: 分類と親集約は復元済みツリーに対する1回のpost-order処理とし、追加I/O、履歴全体の再読込、frontendでの再計算を増やさない。
+- Compatibility: Tauriのツリーresponseはbackendとrendererを同時更新する。Workspaceツリーを持たないlocal API / CLI、workflow execution status、操作commandのcontractは変更しない。
+- State ownership: 詳細状態、completion signal、recovery情報をsource of truthとし、4分類はdomainが導出するread stateに限定する。
+
+## Risks
+
+該当なし。

--- a/docs/specs/issues-1683/requirements.md
+++ b/docs/specs/issues-1683/requirements.md
@@ -1,0 +1,108 @@
+# Context
+
+- 要求の正本は GitHub Issue #1683「[workspace tree] ノードの状態がアイコンの色から判別できず、実態とも一致しない」（https://github.com/siro33950/releash/issues/1683 、state: OPEN、label: bug、milestone なし、comment なし）。追加の自由文指示はない。
+- Workspace ツリーは Tauri command 経路でだけ提供される。local API と CLI は Workspace ツリーを返していない。
+- ツリー行のアイコン形状は行の種類で固定されており、状態は色にしか出ない。leaf 行は `contentKind` に応じて Bot / Terminal（`src/components/workspace/WorkspaceList.tsx:183`）、Sequence 行は ListTree（`src/components/workspace/WorkspaceList.tsx:406`）、Fanout 行は GitFork（`src/components/workspace/FanoutRowStatusIcon.tsx:12`）。
+- アプリケーションロジックは Rust が所有し、frontend に許すのは表示とレイアウト制御である（`AGENTS.md` アーキテクチャ原則）。ノード状態の分類規則を frontend に置くことはできない。
+- 現在状態の確認は、リポジトリ内コードの読解によって行った。アプリを起動しての画面確認は行っていない。
+
+# Outcome
+
+Releash の Workspace ツリーを見る開発者が対象である。
+
+現在、ツリー行の色はノードの状態を判別する用をなしていない。production で一度も出ない色があり、意味の異なる状態が同じ色になり、介入が必要な状態や復元できない状態が「実行中」と同じ色で表示される。親行の集約規則も Sequence / Fanout / Workflow root で 3 種類に割れている。そのため、開発者はツリーを見ても、どのノードが自分の介入を待っているのか、どのノードが失敗して止まっているのかを判断できず、詳細ペインを一つずつ開くまで実態が分からない。
+
+変更後は、ツリー行の色が「実行中」「介入が必要」「失敗」「動いていない」の 4 つの意味だけを表す。どの行についても色が一意に決まり、その色が実際のノードの状態と一致する。親行の色は配下を含めた最も重い状態を表し、Sequence と Fanout で規則が変わらない。開発者はツリーを見るだけで、介入が必要な箇所と失敗している箇所を特定できる。
+
+# Current Behavior
+
+## ツリー行の状態表示
+
+ツリー行の状態色は `workflowNodeIconClasses`（`src/components/workspace/WorkflowNodeStatusIcon.tsx:12-20`）が状態値ごとに定める 7 色である。branch 行も同じ色マップを共有する（`src/components/workspace/WorkspaceBranchStatusIcon.tsx:23-24`）。`running` / `waiting` のときだけアイコンが pulse する（`src/components/workspace/WorkflowNodeStatusIcon.tsx:22-27`）。pulse を適用しているのはツリー行だけで、leaf 行は `src/components/workspace/WorkspaceList.tsx:184-185`、branch 行は `src/components/workspace/WorkspaceBranchStatusIcon.tsx:25-26` である。詳細ペインのノード状態アイコンは pulse せず、`running` は Loader2 の spin で表す（`src/components/panels/NodeContentView/NodeContentView.tsx:152-153`、`src/components/workspace/WorkflowNodeStatusIcon.tsx:36-58`）。
+
+状態値は `WorkspaceNodeStatus`（`src-tauri/src/domain/workspace_tree/value_objects/mod.rs:35-43`）の `running` / `paused` / `failed` / `waiting` / `interrupted` / `aborted` / `completed` の 7 値で、`status` として文字列のままツリー DTO に載る（`src-tauri/src/usecase/workflow/workspace_tree.rs:54`、`src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs:318,391,403`）。frontend 側の型も同じ 7 値である（`src/types/workspace-tree.ts:22-29`）。
+
+## 到達不能な色がある
+
+`interrupted`（オレンジ、`src/components/workspace/WorkflowNodeStatusIcon.tsx:17`）を設定するのは `workflow_status()`（`src-tauri/src/domain/workspace_tree/entities/mod.rs:1004-1014`）だけで、その分岐は `#[cfg(test)]` である。元になる `ExecutionStatus::Interrupted` 自体が `#[cfg(test)]` であり（`src-tauri/src/domain/workflow/value_objects/execution.rs:11-12`）、この variant を生成する経路（`src-tauri/src/adaptor/gateway/workflow/state_notification_gateway.rs:68`、`src-tauri/src/adaptor/gateway/workflow/execution_store.rs:206`）もすべて `#[cfg(test)]` で閉じている。production ビルドでこの色は一度も出ない。
+
+加えて `workflow_status()` が付く Workflow ノードは DTO 化されず子へ平坦化されるため（`src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs:383-385`）、Workflow root の status は表示に一切使われない。
+
+`WorkspaceNodeStatus::Interrupted` は表示以外に、resume 可否と recovery 理由を算出する `recompute_workflow_recovery_capabilities()` の条件にも読まれている（`src-tauri/src/domain/workspace_tree/entities/mod.rs:629,659`）。到達不能なため、この条件は production では常に false である。
+
+## 意味の異なる状態が同色になる
+
+`paused` と `aborted` はどちらも `text-muted-foreground` である（`src/components/workspace/WorkflowNodeStatusIcon.tsx:14,18`）。`paused` はユーザーが Stop した再開可能なノードで、`stop_workflow_execution` が実行中の Node Attempt を pause する経路で付く（`src-tauri/src/adaptor/gateway/workflow/workflow_host/lifecycle_commands.rs:152`、`src-tauri/src/domain/workspace_tree/projection.rs:189-191`）。`aborted` は中止されて終わったノードで、`NodeFailed` の `failure_kind` が `UserAbort` のときに付き `can_retry` は false になる（`src-tauri/src/domain/workspace_tree/entities/mod.rs:856-881`）。再開できるものとできないものが同じ見た目になる。`text-muted-foreground` は行の既定テキスト色と同じなので、状態が付いていないようにしか見えない。
+
+## 状態に載っていない情報がある
+
+- crash 後の recovery fence は `RecoveryFenceProjected` により `recovery_owner_reason` へ入るだけで（`src-tauri/src/domain/workspace_tree/projection.rs:58-61`）、ノードの `status` は変わらない。ツリー DTO（`src-tauri/src/usecase/workflow/workspace_tree.rs:51-66` の `WorkspaceNodeDto`）に recovery 情報がないため、復元できないノードが `running` として青 + pulse で「実行中」に見える。詳細ペイン（`src/components/panels/NodeContentView/NodeContentView.tsx:173-177`）を開かない限り分からない。
+- submit / stop の片方だけを受け取った状態（`NodeCompletionSignalState::SubmitReceived` / `StopReceived`、`src-tauri/src/domain/workflow/value_objects/node_execution.rs:4-10`）も `status` に出ず、`running` と同じ青になる。Stop だけ来て Submit がないノードは人が retry を判断するしかないが（`can_retry()` が partial signal を条件に含む、`src-tauri/src/domain/workflow/entities/workflow_execution/mod.rs:201-207`）、ツリーでは通常の実行中と区別できない。
+
+これらの詳細は detail 側にだけ載っている。`WorkspaceNodeDetailDto` は `submit_received` / `stop_received` / `recovery_reason` を持つ（`src-tauri/src/usecase/workflow/workspace_tree.rs:125-126,133`、`src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs:469`）。
+
+## 親行の集約規則が 3 種に割れている
+
+- Fanout: `aggregate_status()`（`src-tauri/src/domain/workspace_tree/entities/mod.rs:1016-1034`）で子と自分の最小ランクを採る。ランクは `running`=1 が最優先で、子が失敗していても `running` の子が 1 つあれば親は `running` になる。ランクには欠番 4 が残っている。
+- Sequence: 子から集約せず自分の Node イベントだけを正とする（`src-tauri/src/domain/workspace_tree/entities/mod.rs:537-539`）。子からは `updated_at` だけを伝播する。
+- Workflow root: 最後の子から導出するロジックがあるが（`src-tauri/src/domain/workspace_tree/entities/mod.rs:542-550`）、平坦化されて表示されないため効かない。
+
+## 再現手順
+
+1. Workflow を実行し、実行中のノードを含むツリーを表示する。
+2. 実行中の Workflow を Stop する。ツリー行は `text-muted-foreground` になる（`paused`）。
+3. 別の Workflow のノードを abort する。ツリー行は同じ `text-muted-foreground` になる（`aborted`）。
+4. どちらの行も既定テキスト色と同じ灰色で表示され、再開できるノードと終わったノードを見分けられない。
+
+# Scope / Non-goals
+
+## Scope
+
+- Workspace ツリーの行が表す状態色の意味と、その色を決める分類規則。
+- 親行（Sequence / Fanout）の状態集約規則。
+- Workspace ツリー取得および Workspace ノード詳細取得の外部インターフェースが返す状態表現。
+- 詳細ペインのノード状態アイコンの色と形状。
+- 到達不能な `interrupted` 状態の除去。
+
+## Non-goals
+
+- ツリー行のアイコン形状（Bot / Terminal / ListTree / GitFork）の変更。
+- local API と CLI の応答。Workspace ツリーを返していないため対象外である。
+- Workflow 実行そのものの状態遷移規則の変更。`ExecutionStatus` および Node Attempt の実行状態は対象外である。
+- recovery fence および completion signal の生成規則の変更。
+- approve / retry / stop / resume / abort / archive の操作可否判定の変更。
+- Workflow root ノードをツリーへ表示すること。引き続き子へ平坦化する。
+- 過去 attempt 履歴（`pastAttempts`）の表示規則の変更。
+
+# Requirements
+
+- R-001: Workspace ツリーの行が表すノード状態の色は 4 つとし、それぞれの意味を次に固定する。緑は完了ではなく「動いていない」を表す。
+
+  | 色 | 意味 |
+  |---|---|
+  | 青 | 実行中 |
+  | 黄 | 介入が必要 |
+  | 赤 | 失敗 |
+  | 緑 | 動いていない |
+
+- R-002: leaf ノードの分類は次の順で評価し、最初に当てはまったものを採る。
+  1. recovery fence を持つ → 赤
+  2. 状態が `failed` → 赤
+  3. approval 待ち → 黄
+  4. 状態が `running` かつ Stop 信号だけを受領（Submit 未受領）→ 黄
+  5. 状態が `running` → 青
+  6. 状態が `paused` / `completed` / `aborted` → 緑
+
+  `paused` かつ Stop 信号受領は 4 に当たらず 6 で緑になる。`paused` かつ recovery fence ありは 1 で赤になる。
+- R-003: 親行（Sequence / Fanout）は、自分自身の分類結果と配下の子の分類結果を合わせ、赤 > 黄 > 青 > 緑 の重大度順で最も重いものを採る。Sequence と Fanout で規則を分けない。
+- R-004: Workspace ツリー取得の外部インターフェースが返すノード状態は R-001 の 4 分類だけとし、`running` / `paused` / `failed` / `waiting` / `aborted` / `completed` といった詳細な状態値をツリーに返さない。分類の判定は呼び出し側に委ねない。
+- R-005: Workspace ノード詳細取得の外部インターフェースは、詳細な状態と R-001 の 4 分類の両方を返す。詳細ペインが 4 分類を自分で導出する必要がない。
+- R-006: 詳細ペインのノード状態アイコンは、色を R-001 の 4 分類に従わせ、`paused` / `completed` / `aborted` などの詳細はアイコン形状で区別できるようにする。
+- R-007: `interrupted` は Workspace ツリーおよび Workspace ノード詳細のいずれの状態表現にも現れない。
+- R-008: Workspace ツリー行のアイコンを pulse させる対象は、現在 pulse している状態（`running` / `waiting`）を新しい分類へ移した結果として、青と黄の 2 分類とする。赤と緑は pulse しない。詳細ペインのノード状態アイコンは、現在どおり pulse させない。
+- R-009: approve / retry / stop / resume / abort / archive の操作可否、および resume 不能理由の内容は、この変更の前後で変わらない。
+- R-010: local API と CLI の応答は、この変更の前後で変わらない。
+
+# Assumptions / Open Questions
+
+なし。

--- a/src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs
+++ b/src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs
@@ -315,7 +315,7 @@ fn project_tree(
         WorkspaceNodeDto {
             id: public_id,
             title: node.title.clone(),
-            status: node.status.as_public_str().to_string(),
+            status: node.status_classification.as_public_str().to_string(),
             error_reason: node.error_reason.clone(),
             content_kind: if node.kind == WorkspaceNodeKind::WorkflowCommand {
                 "command"
@@ -388,7 +388,7 @@ fn project_tree(
                     vec![WorkspaceTreeItemDto::Fanout(WorkspaceFanoutDto {
                         id: root.map_or_else(|| node.id.clone(), |root| root.public_id.clone()),
                         title: node.title.clone(),
-                        status: node.status.as_public_str().to_string(),
+                        status: node.status_classification.as_public_str().to_string(),
                         workflow_capabilities: root
                             .and_then(|root| root.workflow_capabilities.clone()),
                         children: branch(Some(&node.id), children, hidden, by_id, root_projections),
@@ -400,7 +400,7 @@ fn project_tree(
                     vec![WorkspaceTreeItemDto::Sequence(WorkspaceSequenceDto {
                         id: root.map_or_else(|| node.id.clone(), |root| root.public_id.clone()),
                         title: node.title.clone(),
-                        status: node.status.as_public_str().to_string(),
+                        status: node.status_classification.as_public_str().to_string(),
                         workflow_capabilities: root
                             .and_then(|root| root.workflow_capabilities.clone()),
                         children: branch(Some(&node.id), children, hidden, by_id, root_projections),
@@ -461,6 +461,7 @@ fn node_detail(node: WorkspaceTreeNode) -> WorkspaceNodeDetailDto {
         id: node.id,
         title: node.title,
         status: node.status.as_public_str().to_string(),
+        status_classification: node.status_classification.as_public_str().to_string(),
         submit_received,
         stop_received,
         waiting_for,
@@ -553,7 +554,9 @@ mod tests {
     use super::*;
     use crate::domain::local_event::WorkflowExecutionMetadataRecord;
     use crate::domain::workflow::{ExecutionOrigin, ExecutionStatus, TokenUsage};
-    use crate::domain::workspace_tree::{WorkspaceNodeStatus, WorkspaceTreeNode};
+    use crate::domain::workspace_tree::{
+        WorkspaceNodeStatus, WorkspaceNodeStatusClassification, WorkspaceTreeNode,
+    };
     use crate::usecase::agent_session::{
         AgentSessionActivityDto, AgentSessionOperationsDto, AgentSessionProviderDto,
     };
@@ -566,6 +569,7 @@ mod tests {
             kind: WorkspaceNodeKind::WorkflowSession,
             title: "Review".to_string(),
             status: WorkspaceNodeStatus::Waiting,
+            status_classification: WorkspaceNodeStatusClassification::Attention,
             error_reason: None,
             updated_at_bits: 1.0f64.to_bits(),
             execution_id: None,
@@ -687,9 +691,12 @@ mod tests {
 
         assert_eq!(json[0]["kind"], "sequence");
         assert_eq!(json[0]["id"], execution_id);
+        assert_eq!(json[0]["status"], "active");
         assert_eq!(json[0]["workflowCapabilities"]["canStop"], true);
         assert_eq!(json[0]["children"][0]["kind"], "fanout");
+        assert_eq!(json[0]["children"][0]["status"], "active");
         assert_eq!(json[0]["children"][0]["children"][0]["kind"], "node");
+        assert_eq!(json[0]["children"][0]["children"][0]["status"], "active");
     }
 
     #[test]
@@ -785,6 +792,264 @@ mod tests {
         assert_eq!(detail["waitingFor"], "submit");
         assert_eq!(detail["hasArtifact"], false);
         assert_eq!(detail["capabilities"]["canRetry"], true);
+    }
+
+    #[test]
+    fn test_workspaceツリー契約_nodeとsequenceとfanoutは4分類だけを返す() {
+        // Given
+        let execution_id = "workflow-execution";
+        let owner = tree_owner(execution_id);
+        let sequence = child_node(
+            "sequence",
+            execution_id,
+            execution_id,
+            WorkspaceNodeKind::Sequence,
+            "main",
+        );
+        let fanout = child_node(
+            "fanout",
+            "sequence",
+            execution_id,
+            WorkspaceNodeKind::Fanout,
+            "reviews",
+        );
+        let mut failed = child_node(
+            "failed",
+            "fanout",
+            execution_id,
+            WorkspaceNodeKind::WorkflowCommand,
+            "lint",
+        );
+        failed.status = WorkspaceNodeStatus::Failed;
+        let tree = WorkspaceTree::restore("/repo", vec![owner, sequence, fanout, failed]).unwrap();
+
+        // When
+        let json = serde_json::to_value(project_tree(
+            &tree,
+            &HashSet::new(),
+            &HashSet::from([execution_id.to_string()]),
+            &[],
+        ))
+        .unwrap();
+
+        // Then
+        for status in [
+            &json[0]["status"],
+            &json[0]["children"][0]["status"],
+            &json[0]["children"][0]["children"][0]["status"],
+        ] {
+            assert_eq!(status, "failure");
+            assert!(![
+                "running",
+                "paused",
+                "failed",
+                "waiting",
+                "aborted",
+                "completed",
+                "interrupted",
+            ]
+            .contains(&status.as_str().unwrap()));
+        }
+    }
+
+    #[test]
+    fn test_workspaceノード詳細契約_詳細状態と4分類を同時に返す() {
+        // Given
+        let cases = [
+            (
+                WorkspaceNodeStatus::Running,
+                WorkspaceNodeStatusClassification::Active,
+                "running",
+                "active",
+            ),
+            (
+                WorkspaceNodeStatus::Paused,
+                WorkspaceNodeStatusClassification::Idle,
+                "paused",
+                "idle",
+            ),
+            (
+                WorkspaceNodeStatus::Failed,
+                WorkspaceNodeStatusClassification::Failure,
+                "failed",
+                "failure",
+            ),
+            (
+                WorkspaceNodeStatus::Waiting,
+                WorkspaceNodeStatusClassification::Attention,
+                "waiting",
+                "attention",
+            ),
+            (
+                WorkspaceNodeStatus::Aborted,
+                WorkspaceNodeStatusClassification::Idle,
+                "aborted",
+                "idle",
+            ),
+            (
+                WorkspaceNodeStatus::Completed,
+                WorkspaceNodeStatusClassification::Idle,
+                "completed",
+                "idle",
+            ),
+        ];
+
+        // When / Then
+        for (status, classification, expected_status, expected_classification) in cases {
+            let mut current = node();
+            current.status = status;
+            current.status_classification = classification;
+            let detail = serde_json::to_value(node_detail(current)).unwrap();
+            assert_eq!(detail["status"], expected_status);
+            assert_eq!(detail["statusClassification"], expected_classification);
+            assert_ne!(detail["status"], "interrupted");
+            assert_ne!(detail["statusClassification"], "interrupted");
+        }
+    }
+
+    #[test]
+    fn test_workspaceツリー契約_recovery_fenceありでも操作capabilityとresume不能理由を維持する() {
+        // Given
+        let execution_id = "workflow-execution";
+        let owner = tree_owner(execution_id);
+        let mut sequence = child_node(
+            "sequence",
+            execution_id,
+            execution_id,
+            WorkspaceNodeKind::Sequence,
+            "main",
+        );
+        sequence.status = WorkspaceNodeStatus::Completed;
+        let mut approval = child_node(
+            "approval",
+            "sequence",
+            execution_id,
+            WorkspaceNodeKind::WorkflowSession,
+            "approval",
+        );
+        approval.status = WorkspaceNodeStatus::Waiting;
+        approval.can_approve = true;
+        let mut failed = child_node(
+            "failed",
+            "sequence",
+            execution_id,
+            WorkspaceNodeKind::WorkflowCommand,
+            "failed",
+        );
+        failed.sibling_order = 1;
+        failed.status = WorkspaceNodeStatus::Failed;
+        failed.can_retry = true;
+        let mut running = child_node(
+            "running",
+            "sequence",
+            execution_id,
+            WorkspaceNodeKind::WorkflowCommand,
+            "running",
+        );
+        running.sibling_order = 2;
+        let mut fenced_paused = child_node(
+            "fenced-paused",
+            "sequence",
+            execution_id,
+            WorkspaceNodeKind::WorkflowSession,
+            "fenced-paused",
+        );
+        fenced_paused.sibling_order = 3;
+        fenced_paused.status = WorkspaceNodeStatus::Paused;
+        fenced_paused.recovery_owner_reason = Some("recovery fence".to_string());
+        let tree = WorkspaceTree::restore(
+            "/repo",
+            vec![owner, sequence, approval, failed, running, fenced_paused],
+        )
+        .unwrap();
+
+        // When
+        let json = serde_json::to_value(project_tree(
+            &tree,
+            &HashSet::new(),
+            &HashSet::from([execution_id.to_string()]),
+            &[],
+        ))
+        .unwrap();
+
+        // Then
+        assert_eq!(json[0]["workflowCapabilities"]["canStop"], true);
+        assert_eq!(json[0]["workflowCapabilities"]["canResume"], false);
+        assert_eq!(
+            json[0]["workflowCapabilities"]["resumeUnavailableReason"],
+            "recovery fence"
+        );
+        assert_eq!(json[0]["workflowCapabilities"]["canAbort"], true);
+        assert_eq!(json[0]["workflowCapabilities"]["canArchive"], false);
+        assert_eq!(json[0]["children"][0]["capabilities"]["canApprove"], true);
+        assert_eq!(json[0]["children"][1]["capabilities"]["canRetry"], true);
+    }
+
+    #[test]
+    fn test_workspaceツリー契約_pausedでもresume可否とresume不能理由を維持する() {
+        // Given
+        let execution_id = "paused-workflow-execution";
+        let owner = tree_owner(execution_id);
+        let mut paused = child_node(
+            "paused",
+            execution_id,
+            execution_id,
+            WorkspaceNodeKind::WorkflowSession,
+            "paused",
+        );
+        paused.status = WorkspaceNodeStatus::Paused;
+        let tree = WorkspaceTree::restore("/repo", vec![owner, paused]).unwrap();
+
+        // When
+        let json = serde_json::to_value(project_tree(
+            &tree,
+            &HashSet::new(),
+            &HashSet::from([execution_id.to_string()]),
+            &[],
+        ))
+        .unwrap();
+
+        // Then
+        assert_eq!(json[0]["status"], "idle");
+        assert_eq!(json[0]["workflowCapabilities"]["canStop"], false);
+        assert_eq!(json[0]["workflowCapabilities"]["canResume"], true);
+        assert!(json[0]["workflowCapabilities"]["resumeUnavailableReason"].is_null());
+    }
+
+    #[test]
+    fn test_workspaceツリー契約_completedでも終了時capabilityを維持する() {
+        // Given
+        let execution_id = "completed-workflow-execution";
+        let mut owner = tree_owner(execution_id);
+        owner.status = WorkspaceNodeStatus::Completed;
+        owner.can_stop = false;
+        owner.can_abort = false;
+        owner.can_archive = true;
+        let mut completed = child_node(
+            "completed",
+            execution_id,
+            execution_id,
+            WorkspaceNodeKind::WorkflowCommand,
+            "completed",
+        );
+        completed.status = WorkspaceNodeStatus::Completed;
+        let tree = WorkspaceTree::restore("/repo", vec![owner, completed]).unwrap();
+
+        // When
+        let json = serde_json::to_value(project_tree(
+            &tree,
+            &HashSet::new(),
+            &HashSet::from([execution_id.to_string()]),
+            &[],
+        ))
+        .unwrap();
+
+        // Then
+        assert_eq!(json[0]["status"], "idle");
+        assert_eq!(json[0]["workflowCapabilities"]["canStop"], false);
+        assert_eq!(json[0]["workflowCapabilities"]["canResume"], false);
+        assert_eq!(json[0]["workflowCapabilities"]["canAbort"], false);
+        assert_eq!(json[0]["workflowCapabilities"]["canArchive"], true);
     }
 
     #[test]

--- a/src-tauri/src/domain/workspace_tree/entities/mod.rs
+++ b/src-tauri/src/domain/workspace_tree/entities/mod.rs
@@ -12,6 +12,7 @@ use super::value_objects::{
     WorkspaceIdentity, WorkspaceNodeKind, WorkspaceNodeStatus, WorkspaceStructureFact,
     WorkspaceTreeError, WorkspaceTreeNode, INTERNAL_SIBLING_ORDER,
 };
+use super::WorkspaceNodeStatusClassification;
 use crate::domain::workflow::{
     ExecutionParentRef, ExecutionStatus, ItemsSource, NodeCompletionSignalState,
     NodeExecutionFailureKind, NodeKindName, WorkflowDefinition,
@@ -270,13 +271,21 @@ impl WorkspaceTree {
             })
             .collect::<HashSet<_>>();
         let sibling_order = self.next_sibling_order(None);
+        let status = WorkspaceNodeStatus::Running;
+        let completion_signals = NodeCompletionSignalState::default();
+        let recovery_owner_reason = None;
         self.nodes.push(WorkspaceTreeNode {
             id: execution_id.clone(),
             parent_id: None,
             sibling_order,
             kind: WorkspaceNodeKind::Workflow,
             title: non_empty_or(workflow_name, DEFAULT_WORKFLOW_TITLE),
-            status: WorkspaceNodeStatus::Running,
+            status,
+            status_classification: WorkspaceTreeNode::classify_own_status(
+                status,
+                completion_signals,
+                recovery_owner_reason.is_some(),
+            ),
             error_reason: None,
             updated_at_bits: timestamp.to_bits(),
             execution_id: Some(execution_id.clone()),
@@ -286,7 +295,7 @@ impl WorkspaceTree {
             retry_predecessor_id: None,
             past_attempt_ids: Vec::new(),
             is_retry_history: false,
-            completion_signals: Default::default(),
+            completion_signals,
             has_artifact: false,
             session_id: None,
             can_approve: false,
@@ -294,7 +303,7 @@ impl WorkspaceTree {
             can_close: false,
             can_stop: true,
             can_resume: false,
-            recovery_owner_reason: None,
+            recovery_owner_reason,
             resume_unavailable_reason: None,
             can_abort: true,
             can_archive: false,
@@ -306,13 +315,21 @@ impl WorkspaceTree {
         // They preserve dynamic/static fanout identity across later commits
         // without retaining the full Workflow definition.
         for name in dynamic_fanout_names {
+            let status = WorkspaceNodeStatus::Waiting;
+            let completion_signals = NodeCompletionSignalState::default();
+            let recovery_owner_reason = None;
             self.nodes.push(WorkspaceTreeNode {
                 id: dynamic_fanout_sentinel_id(&execution_id, &name),
                 parent_id: Some(execution_id.clone()),
                 sibling_order: INTERNAL_SIBLING_ORDER,
                 kind: WorkspaceNodeKind::Fanout,
                 title: name,
-                status: WorkspaceNodeStatus::Waiting,
+                status,
+                status_classification: WorkspaceTreeNode::classify_own_status(
+                    status,
+                    completion_signals,
+                    recovery_owner_reason.is_some(),
+                ),
                 error_reason: None,
                 updated_at_bits: timestamp.to_bits(),
                 execution_id: Some(execution_id.clone()),
@@ -322,7 +339,7 @@ impl WorkspaceTree {
                 retry_predecessor_id: None,
                 past_attempt_ids: Vec::new(),
                 is_retry_history: false,
-                completion_signals: Default::default(),
+                completion_signals,
                 has_artifact: false,
                 session_id: None,
                 can_approve: false,
@@ -330,7 +347,7 @@ impl WorkspaceTree {
                 can_close: false,
                 can_stop: false,
                 can_resume: false,
-                recovery_owner_reason: None,
+                recovery_owner_reason,
                 resume_unavailable_reason: None,
                 can_abort: false,
                 can_archive: false,
@@ -454,6 +471,9 @@ impl WorkspaceTree {
                 }
             }
         };
+        let status = WorkspaceNodeStatus::Running;
+        let completion_signals = NodeCompletionSignalState::default();
+        let recovery_owner_reason = None;
         self.nodes.push(WorkspaceTreeNode {
             id,
             parent_id: Some(parent_id),
@@ -465,7 +485,12 @@ impl WorkspaceTree {
                 NodeKindName::Sequence => WorkspaceNodeKind::Sequence,
             },
             title: node_name.clone(),
-            status: WorkspaceNodeStatus::Running,
+            status,
+            status_classification: WorkspaceTreeNode::classify_own_status(
+                status,
+                completion_signals,
+                recovery_owner_reason.is_some(),
+            ),
             error_reason: None,
             updated_at_bits: timestamp.to_bits(),
             execution_id: Some(execution_id),
@@ -475,7 +500,7 @@ impl WorkspaceTree {
             retry_predecessor_id: None,
             past_attempt_ids: Vec::new(),
             is_retry_history: false,
-            completion_signals: Default::default(),
+            completion_signals,
             has_artifact: false,
             session_id: None,
             can_approve: false,
@@ -483,7 +508,7 @@ impl WorkspaceTree {
             can_close: false,
             can_stop: false,
             can_resume: false,
-            recovery_owner_reason: None,
+            recovery_owner_reason,
             resume_unavailable_reason: None,
             can_abort: false,
             can_archive: false,
@@ -521,39 +546,36 @@ impl WorkspaceTree {
             let Some(children) = by_parent.get(&branch_id) else {
                 continue;
             };
-            let child_status = children
-                .iter()
-                .map(|index| self.nodes[*index].status)
-                .collect::<Vec<_>>();
             let child_updated = children
                 .iter()
                 .map(|index| self.nodes[*index].updated_at_bits)
                 .max_by(|left, right| f64::from_bits(*left).total_cmp(&f64::from_bits(*right)));
-            let current_child_status = children
-                .iter()
-                .max_by_key(|index| self.nodes[**index].sibling_order)
-                .map(|index| self.nodes[*index].status);
             if let Some(branch) = self.nodes.iter_mut().find(|node| node.id == branch_id) {
-                // Sequence branch の status は合成子インスタンス自身の Node イベント
-                // （NodeCompleted / NodeFailed / ApprovalRequested）が正であり、
-                // ここでは子の updated_at 伝播だけを行う。
-                if branch.kind == WorkspaceNodeKind::Fanout {
-                    branch.status = aggregate_status(&child_status, branch.status);
-                } else if branch.kind == WorkspaceNodeKind::Workflow
-                    && !branch.can_archive
-                    && branch.status != WorkspaceNodeStatus::Interrupted
-                {
-                    branch.status = match current_child_status {
-                        Some(WorkspaceNodeStatus::Completed) | None => WorkspaceNodeStatus::Running,
-                        Some(status) => status,
-                    };
-                }
                 if let Some(updated) = child_updated {
                     branch.updated_at_bits = max_f64_bits(branch.updated_at_bits, updated);
                 }
             }
         }
+        self.recompute_status_classifications();
         self.recompute_workflow_recovery_capabilities();
+    }
+
+    pub(super) fn recompute_status_classifications(&mut self) {
+        for node in &mut self.nodes {
+            node.status_classification = node.own_status_classification();
+        }
+        let mut by_parent = BTreeMap::<String, Vec<usize>>::new();
+        for (index, node) in self.nodes.iter().enumerate() {
+            if !node.is_internal_rule_record() && !node.is_retry_history {
+                if let Some(parent) = &node.parent_id {
+                    by_parent.entry(parent.clone()).or_default().push(index);
+                }
+            }
+        }
+        let mut visit_state = vec![0_u8; self.nodes.len()];
+        for index in 0..self.nodes.len() {
+            aggregate_status_classification(index, &mut self.nodes, &by_parent, &mut visit_state);
+        }
     }
 
     fn recompute_retry_histories(&mut self) {
@@ -626,7 +648,6 @@ impl WorkspaceTree {
             let Some(workflow) = self.workflow_node(&execution_id) else {
                 continue;
             };
-            let interrupted = workflow.status == WorkspaceNodeStatus::Interrupted;
             let execution_reason = workflow.recovery_owner_reason.clone();
             let waiting_approval = self.nodes.iter().any(|node| {
                 node.execution_id.as_deref() == Some(execution_id.as_str()) && node.can_approve
@@ -656,7 +677,7 @@ impl WorkspaceTree {
                     && node.status == WorkspaceNodeStatus::Paused
             });
             let recovery_fenced = execution_reason.is_some() || !owner_reasons.is_empty();
-            let reason = (interrupted || paused || recovery_fenced)
+            let reason = (paused || recovery_fenced)
                 .then(|| {
                     owner_reasons
                         .into_iter()
@@ -674,9 +695,8 @@ impl WorkspaceTree {
             if let Some(workflow) = self.workflow_node_mut(&execution_id) {
                 workflow.resume_unavailable_reason = reason;
                 workflow.can_stop = can_stop;
-                workflow.can_resume = (interrupted || paused)
-                    && !waiting_approval
-                    && workflow.resume_unavailable_reason.is_none();
+                workflow.can_resume =
+                    paused && !waiting_approval && workflow.resume_unavailable_reason.is_none();
             }
         }
     }
@@ -1007,30 +1027,39 @@ pub(super) fn workflow_status(status: ExecutionStatus) -> WorkspaceNodeStatus {
         #[cfg(test)]
         ExecutionStatus::WaitingApproval => WorkspaceNodeStatus::Waiting,
         #[cfg(test)]
-        ExecutionStatus::Interrupted => WorkspaceNodeStatus::Interrupted,
+        ExecutionStatus::Interrupted => WorkspaceNodeStatus::Paused,
         ExecutionStatus::Completed => WorkspaceNodeStatus::Completed,
         ExecutionStatus::Aborted => WorkspaceNodeStatus::Aborted,
     }
 }
 
-fn aggregate_status(
-    children: &[WorkspaceNodeStatus],
-    parent: WorkspaceNodeStatus,
-) -> WorkspaceNodeStatus {
-    children
-        .iter()
-        .copied()
-        .chain(std::iter::once(parent))
-        .min_by_key(|status| match status {
-            WorkspaceNodeStatus::Running => 1,
-            WorkspaceNodeStatus::Paused => 2,
-            WorkspaceNodeStatus::Failed => 3,
-            WorkspaceNodeStatus::Waiting => 5,
-            WorkspaceNodeStatus::Interrupted => 6,
-            WorkspaceNodeStatus::Aborted => 7,
-            WorkspaceNodeStatus::Completed => 8,
-        })
-        .unwrap_or(parent)
+fn aggregate_status_classification(
+    index: usize,
+    nodes: &mut [WorkspaceTreeNode],
+    by_parent: &BTreeMap<String, Vec<usize>>,
+    visit_state: &mut [u8],
+) -> WorkspaceNodeStatusClassification {
+    if visit_state[index] != 0 {
+        // A visiting node keeps its own classification until validate() rejects the parent cycle.
+        return nodes[index].status_classification;
+    }
+    visit_state[index] = 1;
+    let node_id = nodes[index].id.clone();
+    let aggregate_children = matches!(
+        nodes[index].kind,
+        WorkspaceNodeKind::Sequence | WorkspaceNodeKind::Fanout
+    );
+    let mut classification = nodes[index].status_classification;
+    for child_index in by_parent.get(&node_id).into_iter().flatten().copied() {
+        let child_classification =
+            aggregate_status_classification(child_index, nodes, by_parent, visit_state);
+        if aggregate_children {
+            classification = classification.most_severe(child_classification);
+        }
+    }
+    nodes[index].status_classification = classification;
+    visit_state[index] = 2;
+    classification
 }
 
 pub(super) fn non_empty_or(value: String, fallback: &str) -> String {
@@ -1225,6 +1254,226 @@ mod tests {
                 worktree: None,
             }],
             entry: "plan".to_string(),
+        }
+    }
+
+    fn parent_ref(kind: NodeKindName, parent_id: &str, child_index: usize) -> ExecutionParentRef {
+        if kind == NodeKindName::Fanout {
+            ExecutionParentRef::fanout_child(parent_id, None, child_index)
+        } else {
+            ExecutionParentRef::sequence_child(parent_id)
+        }
+    }
+
+    fn status_fact(
+        execution_id: &str,
+        node_execution_id: &str,
+        status: WorkspaceNodeStatus,
+        timestamp: f64,
+    ) -> Option<WorkspaceStructureFact> {
+        match status {
+            WorkspaceNodeStatus::Running => None,
+            WorkspaceNodeStatus::Completed => Some(WorkspaceStructureFact::NodeCompleted {
+                execution_id: execution_id.to_string(),
+                node_execution_id: node_execution_id.to_string(),
+                timestamp,
+            }),
+            WorkspaceNodeStatus::Waiting => Some(WorkspaceStructureFact::NodeApprovalRequested {
+                execution_id: execution_id.to_string(),
+                node_execution_id: node_execution_id.to_string(),
+                timestamp,
+            }),
+            WorkspaceNodeStatus::Failed | WorkspaceNodeStatus::Aborted => {
+                Some(WorkspaceStructureFact::NodeFailed {
+                    execution_id: execution_id.to_string(),
+                    node_execution_id: node_execution_id.to_string(),
+                    reason: "test failure".to_string(),
+                    failure_kind: if status == WorkspaceNodeStatus::Aborted {
+                        NodeExecutionFailureKind::UserAbort
+                    } else {
+                        NodeExecutionFailureKind::ValidationFailure
+                    },
+                    timestamp,
+                })
+            }
+            WorkspaceNodeStatus::Paused => None,
+        }
+    }
+
+    fn branch_classification(
+        kind: NodeKindName,
+        parent_status: WorkspaceNodeStatus,
+        child_statuses: &[WorkspaceNodeStatus],
+    ) -> WorkspaceNodeStatusClassification {
+        let execution_id = "00000000-0000-4000-8000-0000000000d1";
+        let mut facts = vec![
+            WorkspaceStructureFact::WorkflowStarted {
+                execution_id: execution_id.to_string(),
+                workflow_name: "classification".to_string(),
+                worktree_path: "/repo".to_string(),
+                definition: definition(),
+                timestamp: 1.0,
+            },
+            WorkspaceStructureFact::NodeStarted {
+                execution_id: execution_id.to_string(),
+                node_execution_id: "branch".to_string(),
+                node_name: "branch".to_string(),
+                kind,
+                attempt: 1,
+                parent: None,
+                timestamp: 2.0,
+            },
+        ];
+        for (index, status) in child_statuses.iter().copied().enumerate() {
+            let node_execution_id = format!("child-{index}");
+            facts.push(WorkspaceStructureFact::NodeStarted {
+                execution_id: execution_id.to_string(),
+                node_execution_id: node_execution_id.clone(),
+                node_name: node_execution_id.clone(),
+                kind: NodeKindName::Command,
+                attempt: 1,
+                parent: Some(parent_ref(kind, "branch", index)),
+                timestamp: 3.0 + index as f64,
+            });
+            if let Some(fact) = status_fact(
+                execution_id,
+                &node_execution_id,
+                status,
+                10.0 + index as f64,
+            ) {
+                facts.push(fact);
+            }
+        }
+        if let Some(fact) = status_fact(execution_id, "branch", parent_status, 20.0) {
+            facts.push(fact);
+        }
+        let mut tree = WorkspaceTree::empty("/repo");
+        WorkspaceTreeProjector::project(&mut tree, facts).unwrap();
+        tree.nodes()
+            .iter()
+            .find(|node| node.node_execution_id.as_deref() == Some("branch"))
+            .unwrap()
+            .status_classification
+    }
+
+    #[test]
+    fn test_親分類集約_sequenceとfanoutが同じ重大度順を使う() {
+        // Given
+        let cases: [(
+            WorkspaceNodeStatus,
+            &[WorkspaceNodeStatus],
+            WorkspaceNodeStatusClassification,
+        ); 4] = [
+            (
+                WorkspaceNodeStatus::Completed,
+                &[WorkspaceNodeStatus::Completed],
+                WorkspaceNodeStatusClassification::Idle,
+            ),
+            (
+                WorkspaceNodeStatus::Running,
+                &[WorkspaceNodeStatus::Completed],
+                WorkspaceNodeStatusClassification::Active,
+            ),
+            (
+                WorkspaceNodeStatus::Completed,
+                &[WorkspaceNodeStatus::Running, WorkspaceNodeStatus::Waiting],
+                WorkspaceNodeStatusClassification::Attention,
+            ),
+            (
+                WorkspaceNodeStatus::Completed,
+                &[
+                    WorkspaceNodeStatus::Running,
+                    WorkspaceNodeStatus::Waiting,
+                    WorkspaceNodeStatus::Failed,
+                ],
+                WorkspaceNodeStatusClassification::Failure,
+            ),
+        ];
+
+        // When / Then
+        for (parent_status, child_statuses, expected) in cases {
+            for kind in [NodeKindName::Sequence, NodeKindName::Fanout] {
+                assert_eq!(
+                    branch_classification(kind, parent_status, child_statuses),
+                    expected,
+                    "{kind:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_親分類集約_子孫のfailureをsequenceとfanoutの祖先まで反映する() {
+        // Given
+        let execution_id = "00000000-0000-4000-8000-0000000000d2";
+        let mut tree = WorkspaceTree::empty("/repo");
+        let facts = [
+            WorkspaceStructureFact::WorkflowStarted {
+                execution_id: execution_id.to_string(),
+                workflow_name: "classification".to_string(),
+                worktree_path: "/repo".to_string(),
+                definition: definition(),
+                timestamp: 1.0,
+            },
+            WorkspaceStructureFact::NodeStarted {
+                execution_id: execution_id.to_string(),
+                node_execution_id: "outer-sequence".to_string(),
+                node_name: "outer".to_string(),
+                kind: NodeKindName::Sequence,
+                attempt: 1,
+                parent: None,
+                timestamp: 2.0,
+            },
+            WorkspaceStructureFact::NodeStarted {
+                execution_id: execution_id.to_string(),
+                node_execution_id: "inner-fanout".to_string(),
+                node_name: "inner".to_string(),
+                kind: NodeKindName::Fanout,
+                attempt: 1,
+                parent: Some(ExecutionParentRef::sequence_child("outer-sequence")),
+                timestamp: 3.0,
+            },
+            WorkspaceStructureFact::NodeStarted {
+                execution_id: execution_id.to_string(),
+                node_execution_id: "failed-leaf".to_string(),
+                node_name: "leaf".to_string(),
+                kind: NodeKindName::Command,
+                attempt: 1,
+                parent: Some(ExecutionParentRef::fanout_child("inner-fanout", None, 0)),
+                timestamp: 4.0,
+            },
+            WorkspaceStructureFact::NodeFailed {
+                execution_id: execution_id.to_string(),
+                node_execution_id: "failed-leaf".to_string(),
+                reason: "test failure".to_string(),
+                failure_kind: NodeExecutionFailureKind::ValidationFailure,
+                timestamp: 5.0,
+            },
+            WorkspaceStructureFact::NodeCompleted {
+                execution_id: execution_id.to_string(),
+                node_execution_id: "inner-fanout".to_string(),
+                timestamp: 6.0,
+            },
+            WorkspaceStructureFact::NodeCompleted {
+                execution_id: execution_id.to_string(),
+                node_execution_id: "outer-sequence".to_string(),
+                timestamp: 7.0,
+            },
+        ];
+
+        // When
+        WorkspaceTreeProjector::project(&mut tree, facts).unwrap();
+
+        // Then
+        for node_execution_id in ["inner-fanout", "outer-sequence"] {
+            assert_eq!(
+                tree.nodes()
+                    .iter()
+                    .find(|node| { node.node_execution_id.as_deref() == Some(node_execution_id) })
+                    .unwrap()
+                    .status_classification,
+                WorkspaceNodeStatusClassification::Failure
+            );
         }
     }
 
@@ -2144,7 +2393,11 @@ mod tests {
         .unwrap();
 
         let workflow = tree.workflow_node(execution_id).unwrap();
-        assert_eq!(workflow.status, WorkspaceNodeStatus::Failed);
+        assert_eq!(workflow.status, WorkspaceNodeStatus::Waiting);
+        assert_eq!(
+            workflow.status_classification,
+            WorkspaceNodeStatusClassification::Attention
+        );
         assert!(!workflow.can_stop);
         assert!(!workflow.can_resume);
         assert!(workflow.can_abort);
@@ -2158,13 +2411,21 @@ mod tests {
             .iter()
             .find(|node| node.node_execution_id.as_deref() == Some("checks"))
             .unwrap();
-        assert_eq!(fanout.status, WorkspaceNodeStatus::Failed);
+        assert_eq!(fanout.status, WorkspaceNodeStatus::Completed);
+        assert_eq!(
+            fanout.status_classification,
+            WorkspaceNodeStatusClassification::Failure
+        );
         let waiting = tree
             .nodes()
             .iter()
             .find(|node| node.node_execution_id.as_deref() == Some("test"))
             .unwrap();
         assert_eq!(waiting.status, WorkspaceNodeStatus::Waiting);
+        assert_eq!(
+            waiting.status_classification,
+            WorkspaceNodeStatusClassification::Attention
+        );
         assert!(waiting.can_approve);
     }
 

--- a/src-tauri/src/domain/workspace_tree/mod.rs
+++ b/src-tauri/src/domain/workspace_tree/mod.rs
@@ -15,5 +15,5 @@ pub use repository::WorkspaceTreeRepository;
 pub use services::{WorkspacePublicRoot, WorkspaceTreeVisibilityPolicy};
 pub use value_objects::{
     WorkspaceCommandResult, WorkspaceIdentity, WorkspaceNodeKind, WorkspaceNodeStatus,
-    WorkspaceStructureFact, WorkspaceTreeNode,
+    WorkspaceNodeStatusClassification, WorkspaceStructureFact, WorkspaceTreeNode,
 };

--- a/src-tauri/src/domain/workspace_tree/projection.rs
+++ b/src-tauri/src/domain/workspace_tree/projection.rs
@@ -163,20 +163,11 @@ pub fn runtime_snapshot_nodes(
     });
     let mut tree = WorkspaceTree::empty(workspace_identity);
     WorkspaceTreeProjector::project(&mut tree, facts).map_err(|error| error.to_string())?;
-    let mut projected = tree
-        .nodes()
+    for runtime in node_executions
         .iter()
-        .filter(|node| node.execution_id.as_deref() == Some(execution_id))
-        .cloned()
-        .collect::<Vec<_>>();
-    for node in &mut projected {
-        let Some(node_execution_id) = node.node_execution_id.as_deref() else {
-            continue;
-        };
-        let Some(runtime) = node_executions
-            .iter()
-            .find(|runtime| runtime.id == node_execution_id)
-        else {
+        .filter(|runtime| runtime.execution_id == execution_id)
+    {
+        let Some(node) = tree.execution_node_mut(execution_id, &runtime.id) else {
             continue;
         };
         node.completion_signals = runtime.completion_signals;
@@ -190,7 +181,14 @@ pub fn runtime_snapshot_nodes(
             node.status = crate::domain::workspace_tree::WorkspaceNodeStatus::Paused;
         }
     }
-    Ok(projected)
+    // Runtime overlays refresh classification without changing projected recovery capabilities.
+    tree.recompute_status_classifications();
+    Ok(tree
+        .nodes()
+        .iter()
+        .filter(|node| node.execution_id.as_deref() == Some(execution_id))
+        .cloned()
+        .collect())
 }
 
 fn same_retry_target(
@@ -211,7 +209,9 @@ mod tests {
         ExecutionOrigin, ExecutionStatus, NodeCompletionSignalState, NodeDefinition,
         NodeExecutionFailureKind, NodeKindName, TokenUsage, WorkflowDefinition,
     };
-    use crate::domain::workspace_tree::WorkspaceNodeStatus;
+    use crate::domain::workspace_tree::{
+        WorkspaceNodeStatus, WorkspaceNodeStatusClassification, WorkspaceTreeNode,
+    };
 
     const EXECUTION_ID: &str = "00000000-0000-4000-8000-000000000901";
     const OTHER_EXECUTION_ID: &str = "00000000-0000-4000-8000-000000000902";
@@ -257,6 +257,20 @@ mod tests {
             resume_from_node: None,
             total_token_usage: TokenUsage::default(),
         }
+    }
+
+    fn capability_state(
+        node: &WorkspaceTreeNode,
+    ) -> (bool, bool, bool, bool, bool, bool, Option<&str>) {
+        (
+            node.can_approve,
+            node.can_retry,
+            node.can_stop,
+            node.can_resume,
+            node.can_abort,
+            node.can_archive,
+            node.resume_unavailable_reason.as_deref(),
+        )
     }
 
     #[test]
@@ -599,5 +613,199 @@ mod tests {
             .find(|node| node.node_execution_id.is_none())
             .unwrap();
         assert_eq!(root.resume_unavailable_reason.as_deref(), Some(reason));
+    }
+
+    #[test]
+    fn test_runtime_snapshot分類_runningのstop_receivedをattentionにしてcapabilityを維持する() {
+        // Given
+        let mut sequence = node(
+            "sequence",
+            EXECUTION_ID,
+            RuntimeNodeExecutionStatus::Succeeded,
+        );
+        sequence.node_name = "sequence".to_string();
+        sequence.kind = NodeKindName::Sequence;
+        sequence.display_command = None;
+        sequence.completed_at = Some(4.0);
+        let mut stopped_child = node(
+            "stopped-child",
+            EXECUTION_ID,
+            RuntimeNodeExecutionStatus::Running,
+        );
+        stopped_child.node_name = "stopped-child".to_string();
+        stopped_child.kind = NodeKindName::Session;
+        stopped_child.display_command = None;
+        stopped_child.parent = Some(crate::domain::workflow::ExecutionParentRef::sequence_child(
+            "sequence",
+        ));
+        stopped_child.completion_signals = NodeCompletionSignalState::StopReceived;
+        let execution = execution();
+        let runtime_nodes = [sequence, stopped_child];
+
+        // When
+        let nodes = runtime_snapshot_nodes(RuntimeSnapshotNodeProjection {
+            execution_id: EXECUTION_ID,
+            workflow_name: "workflow",
+            workspace_identity: "/repo",
+            workflow_definition: &WorkflowDefinition::default(),
+            node_executions: &runtime_nodes,
+            retry_predecessors: &std::collections::HashMap::new(),
+            standalone_session_id: None,
+            started_at: 1.0,
+            updated_at: 10.0,
+            execution: &execution,
+            recovery_owner_reason: None,
+            node_recovery_reasons: &[],
+        })
+        .unwrap();
+        let by_execution_id = nodes
+            .iter()
+            .filter_map(|node| node.node_execution_id.as_deref().map(|id| (id, node)))
+            .collect::<std::collections::HashMap<_, _>>();
+        let workflow = nodes
+            .iter()
+            .find(|node| node.node_execution_id.is_none())
+            .unwrap();
+
+        // Then
+        assert_eq!(
+            by_execution_id["stopped-child"].status_classification,
+            WorkspaceNodeStatusClassification::Attention
+        );
+        assert_eq!(
+            by_execution_id["sequence"].status_classification,
+            WorkspaceNodeStatusClassification::Attention
+        );
+        assert_eq!(
+            capability_state(by_execution_id["stopped-child"]),
+            (false, true, false, false, false, false, None)
+        );
+        assert_eq!(
+            capability_state(workflow),
+            (false, false, true, false, true, false, None)
+        );
+    }
+
+    #[test]
+    fn test_runtime_snapshot分類_pausedのstop_receivedをidleにしてcapabilityを維持する() {
+        // Given
+        let mut paused = node("paused", EXECUTION_ID, RuntimeNodeExecutionStatus::Paused);
+        paused.node_name = "paused".to_string();
+        paused.kind = NodeKindName::Session;
+        paused.display_command = None;
+        paused.completion_signals = NodeCompletionSignalState::StopReceived;
+        let execution = execution();
+
+        // When
+        let nodes = runtime_snapshot_nodes(RuntimeSnapshotNodeProjection {
+            execution_id: EXECUTION_ID,
+            workflow_name: "workflow",
+            workspace_identity: "/repo",
+            workflow_definition: &WorkflowDefinition::default(),
+            node_executions: &[paused],
+            retry_predecessors: &std::collections::HashMap::new(),
+            standalone_session_id: None,
+            started_at: 1.0,
+            updated_at: 10.0,
+            execution: &execution,
+            recovery_owner_reason: None,
+            node_recovery_reasons: &[],
+        })
+        .unwrap();
+        let paused = nodes
+            .iter()
+            .find(|node| node.node_execution_id.as_deref() == Some("paused"))
+            .unwrap();
+        let workflow = nodes
+            .iter()
+            .find(|node| node.node_execution_id.is_none())
+            .unwrap();
+
+        // Then
+        assert_eq!(
+            paused.status_classification,
+            WorkspaceNodeStatusClassification::Idle
+        );
+        assert_eq!(
+            capability_state(paused),
+            (false, true, false, false, false, false, None)
+        );
+        assert_eq!(
+            capability_state(workflow),
+            (false, false, true, false, true, false, None)
+        );
+    }
+
+    #[test]
+    fn test_runtime_snapshot分類_recovery_fenceをfailureにしてcapabilityを維持する() {
+        // Given
+        let mut fanout = node(
+            "fanout",
+            EXECUTION_ID,
+            RuntimeNodeExecutionStatus::Succeeded,
+        );
+        fanout.node_name = "fanout".to_string();
+        fanout.kind = NodeKindName::Fanout;
+        fanout.display_command = None;
+        fanout.completed_at = Some(4.0);
+        let mut recovery = node("recovery", EXECUTION_ID, RuntimeNodeExecutionStatus::Paused);
+        recovery.node_name = "recovery".to_string();
+        recovery.parent = Some(crate::domain::workflow::ExecutionParentRef::fanout_child(
+            "fanout", None, 0,
+        ));
+        let execution = execution();
+        let runtime_nodes = [fanout, recovery];
+        let recovery_reason = "recovery fence";
+
+        // When
+        let nodes = runtime_snapshot_nodes(RuntimeSnapshotNodeProjection {
+            execution_id: EXECUTION_ID,
+            workflow_name: "workflow",
+            workspace_identity: "/repo",
+            workflow_definition: &WorkflowDefinition::default(),
+            node_executions: &runtime_nodes,
+            retry_predecessors: &std::collections::HashMap::new(),
+            standalone_session_id: None,
+            started_at: 1.0,
+            updated_at: 10.0,
+            execution: &execution,
+            recovery_owner_reason: None,
+            node_recovery_reasons: &[("recovery".to_string(), recovery_reason.to_string())],
+        })
+        .unwrap();
+        let by_execution_id = nodes
+            .iter()
+            .filter_map(|node| node.node_execution_id.as_deref().map(|id| (id, node)))
+            .collect::<std::collections::HashMap<_, _>>();
+        let workflow = nodes
+            .iter()
+            .find(|node| node.node_execution_id.is_none())
+            .unwrap();
+
+        // Then
+        assert_eq!(
+            by_execution_id["recovery"].status_classification,
+            WorkspaceNodeStatusClassification::Failure
+        );
+        assert_eq!(
+            by_execution_id["fanout"].status_classification,
+            WorkspaceNodeStatusClassification::Failure
+        );
+        assert_eq!(
+            capability_state(by_execution_id["recovery"]),
+            (false, false, false, false, false, false, None)
+        );
+        assert_eq!(
+            capability_state(workflow),
+            (
+                false,
+                false,
+                true,
+                false,
+                true,
+                false,
+                Some(recovery_reason)
+            )
+        );
     }
 }

--- a/src-tauri/src/domain/workspace_tree/services.rs
+++ b/src-tauri/src/domain/workspace_tree/services.rs
@@ -88,7 +88,7 @@ impl WorkspaceTreeVisibilityPolicy {
 mod tests {
     use super::*;
     use crate::domain::workflow::NodeCompletionSignalState;
-    use crate::domain::workspace_tree::WorkspaceNodeStatus;
+    use crate::domain::workspace_tree::{WorkspaceNodeStatus, WorkspaceNodeStatusClassification};
 
     fn node(
         id: &str,
@@ -104,6 +104,7 @@ mod tests {
             kind,
             title: id.to_string(),
             status: WorkspaceNodeStatus::Running,
+            status_classification: WorkspaceNodeStatusClassification::Active,
             error_reason: None,
             updated_at_bits: 0.0_f64.to_bits(),
             execution_id: execution_id.map(str::to_string),

--- a/src-tauri/src/domain/workspace_tree/value_objects/mod.rs
+++ b/src-tauri/src/domain/workspace_tree/value_objects/mod.rs
@@ -37,7 +37,6 @@ pub enum WorkspaceNodeStatus {
     Paused,
     Failed,
     Waiting,
-    Interrupted,
     Aborted,
     Completed,
 }
@@ -49,9 +48,44 @@ impl WorkspaceNodeStatus {
             Self::Paused => "paused",
             Self::Failed => "failed",
             Self::Waiting => "waiting",
-            Self::Interrupted => "interrupted",
             Self::Aborted => "aborted",
             Self::Completed => "completed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceNodeStatusClassification {
+    Active,
+    Attention,
+    Failure,
+    Idle,
+}
+
+impl WorkspaceNodeStatusClassification {
+    pub fn as_public_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Attention => "attention",
+            Self::Failure => "failure",
+            Self::Idle => "idle",
+        }
+    }
+
+    pub(super) fn most_severe(self, other: Self) -> Self {
+        if self.severity() >= other.severity() {
+            self
+        } else {
+            other
+        }
+    }
+
+    fn severity(self) -> u8 {
+        match self {
+            Self::Failure => 3,
+            Self::Attention => 2,
+            Self::Active => 1,
+            Self::Idle => 0,
         }
     }
 }
@@ -72,6 +106,7 @@ pub struct WorkspaceTreeNode {
     pub kind: WorkspaceNodeKind,
     pub title: String,
     pub status: WorkspaceNodeStatus,
+    pub status_classification: WorkspaceNodeStatusClassification,
     pub error_reason: Option<String>,
     pub updated_at_bits: u64,
     pub execution_id: Option<String>,
@@ -119,6 +154,33 @@ impl WorkspaceTreeNode {
         self.kind == WorkspaceNodeKind::Fanout
             && self.sibling_order == INTERNAL_SIBLING_ORDER
             && self.node_execution_id.is_none()
+    }
+
+    pub(super) fn classify_own_status(
+        status: WorkspaceNodeStatus,
+        completion_signals: NodeCompletionSignalState,
+        recovery_fenced: bool,
+    ) -> WorkspaceNodeStatusClassification {
+        if recovery_fenced || status == WorkspaceNodeStatus::Failed {
+            WorkspaceNodeStatusClassification::Failure
+        } else if status == WorkspaceNodeStatus::Waiting
+            || (status == WorkspaceNodeStatus::Running
+                && completion_signals == NodeCompletionSignalState::StopReceived)
+        {
+            WorkspaceNodeStatusClassification::Attention
+        } else if status == WorkspaceNodeStatus::Running {
+            WorkspaceNodeStatusClassification::Active
+        } else {
+            WorkspaceNodeStatusClassification::Idle
+        }
+    }
+
+    pub(super) fn own_status_classification(&self) -> WorkspaceNodeStatusClassification {
+        Self::classify_own_status(
+            self.status,
+            self.completion_signals,
+            self.recovery_owner_reason.is_some(),
+        )
     }
 }
 
@@ -234,3 +296,127 @@ impl std::fmt::Display for WorkspaceTreeError {
 }
 
 impl std::error::Error for WorkspaceTreeError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(
+        status: WorkspaceNodeStatus,
+        completion_signals: NodeCompletionSignalState,
+        recovery_owner_reason: Option<&str>,
+    ) -> WorkspaceTreeNode {
+        WorkspaceTreeNode {
+            id: "node".to_string(),
+            parent_id: Some("workflow".to_string()),
+            sibling_order: 0,
+            kind: WorkspaceNodeKind::WorkflowSession,
+            title: "node".to_string(),
+            status,
+            status_classification: WorkspaceNodeStatusClassification::Idle,
+            error_reason: None,
+            updated_at_bits: 1.0_f64.to_bits(),
+            execution_id: Some("workflow".to_string()),
+            node_execution_id: Some("node-execution".to_string()),
+            node_name: Some("node".to_string()),
+            attempt: Some(1),
+            retry_predecessor_id: None,
+            past_attempt_ids: Vec::new(),
+            is_retry_history: false,
+            completion_signals,
+            has_artifact: false,
+            session_id: None,
+            can_approve: false,
+            can_retry: false,
+            can_close: false,
+            can_stop: false,
+            can_resume: false,
+            recovery_owner_reason: recovery_owner_reason.map(str::to_string),
+            resume_unavailable_reason: None,
+            can_abort: false,
+            can_archive: false,
+            display_command: None,
+            command_result: None,
+            dynamic_fanout: false,
+        }
+    }
+
+    #[test]
+    fn test_詳細状態分類_優先順位と境界の組み合わせを4分類へ写像する() {
+        // Given
+        let cases = [
+            (
+                WorkspaceNodeStatus::Running,
+                NodeCompletionSignalState::Pending,
+                None,
+                WorkspaceNodeStatusClassification::Active,
+            ),
+            (
+                WorkspaceNodeStatus::Running,
+                NodeCompletionSignalState::StopReceived,
+                None,
+                WorkspaceNodeStatusClassification::Attention,
+            ),
+            (
+                WorkspaceNodeStatus::Waiting,
+                NodeCompletionSignalState::Pending,
+                None,
+                WorkspaceNodeStatusClassification::Attention,
+            ),
+            (
+                WorkspaceNodeStatus::Failed,
+                NodeCompletionSignalState::Pending,
+                None,
+                WorkspaceNodeStatusClassification::Failure,
+            ),
+            (
+                WorkspaceNodeStatus::Paused,
+                NodeCompletionSignalState::StopReceived,
+                None,
+                WorkspaceNodeStatusClassification::Idle,
+            ),
+            (
+                WorkspaceNodeStatus::Completed,
+                NodeCompletionSignalState::Ready,
+                None,
+                WorkspaceNodeStatusClassification::Idle,
+            ),
+            (
+                WorkspaceNodeStatus::Aborted,
+                NodeCompletionSignalState::Pending,
+                None,
+                WorkspaceNodeStatusClassification::Idle,
+            ),
+            (
+                WorkspaceNodeStatus::Paused,
+                NodeCompletionSignalState::StopReceived,
+                Some("recovery fence"),
+                WorkspaceNodeStatusClassification::Failure,
+            ),
+        ];
+
+        // When / Then
+        for (status, signals, recovery_reason, expected) in cases {
+            assert_eq!(
+                node(status, signals, recovery_reason).own_status_classification(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_状態分類の公開値_4分類だけを返す() {
+        // Given
+        let cases = [
+            (WorkspaceNodeStatusClassification::Active, "active"),
+            (WorkspaceNodeStatusClassification::Attention, "attention"),
+            (WorkspaceNodeStatusClassification::Failure, "failure"),
+            (WorkspaceNodeStatusClassification::Idle, "idle"),
+        ];
+
+        // When / Then
+        for (classification, expected) in cases {
+            assert_eq!(classification.as_public_str(), expected);
+        }
+    }
+}

--- a/src-tauri/src/usecase/workflow/mod.rs
+++ b/src-tauri/src/usecase/workflow/mod.rs
@@ -920,6 +920,8 @@ mod tests {
             kind: crate::domain::workspace_tree::WorkspaceNodeKind::WorkflowSession,
             title: "node".to_string(),
             status: crate::domain::workspace_tree::WorkspaceNodeStatus::Running,
+            status_classification:
+                crate::domain::workspace_tree::WorkspaceNodeStatusClassification::Active,
             error_reason: None,
             updated_at_bits: 1.0_f64.to_bits(),
             execution_id: execution_id.map(str::to_string),

--- a/src-tauri/src/usecase/workflow/workspace_tree.rs
+++ b/src-tauri/src/usecase/workflow/workspace_tree.rs
@@ -122,6 +122,7 @@ pub(crate) struct WorkspaceNodeDetailDto {
     pub id: String,
     pub title: String,
     pub status: String,
+    pub status_classification: String,
     pub submit_received: bool,
     pub stop_received: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -369,7 +370,7 @@ mod tests {
             nodes: vec![WorkspaceTreeItemDto::Sequence(WorkspaceSequenceDto {
                 id: "workflow".to_string(),
                 title: "main".to_string(),
-                status: "running".to_string(),
+                status: "active".to_string(),
                 workflow_capabilities: Some(WorkspaceWorkflowCapabilitiesDto {
                     can_stop: true,
                     can_resume: false,
@@ -380,12 +381,12 @@ mod tests {
                 children: vec![WorkspaceTreeItemDto::Fanout(WorkspaceFanoutDto {
                     id: "fanout".to_string(),
                     title: "Fanout".to_string(),
-                    status: "running".to_string(),
+                    status: "active".to_string(),
                     workflow_capabilities: None,
                     children: vec![WorkspaceTreeItemDto::Node(WorkspaceNodeDto {
                         id: "selected-node".to_string(),
                         title: "Child".to_string(),
-                        status: "running".to_string(),
+                        status: "active".to_string(),
                         error_reason: None,
                         content_kind: "session",
                         capabilities: WorkspaceNodeCapabilitiesDto {
@@ -428,5 +429,36 @@ mod tests {
             reconciliation.snapshot.preferred_node_id.as_deref(),
             Some("selected-node")
         );
+    }
+
+    #[test]
+    fn test_選択整合契約_返却snapshotの全行が4分類だけを持つ() {
+        fn assert_classifications(items: &[WorkspaceTreeItemDto]) {
+            for item in items {
+                let (status, children) = match item {
+                    WorkspaceTreeItemDto::Node(node) => (node.status.as_str(), None),
+                    WorkspaceTreeItemDto::Sequence(sequence) => {
+                        (sequence.status.as_str(), Some(sequence.children.as_slice()))
+                    }
+                    WorkspaceTreeItemDto::Fanout(fanout) => {
+                        (fanout.status.as_str(), Some(fanout.children.as_slice()))
+                    }
+                };
+                assert!(["active", "attention", "failure", "idle"].contains(&status));
+                assert_ne!(status, "interrupted");
+                if let Some(children) = children {
+                    assert_classifications(children);
+                }
+            }
+        }
+
+        // Given
+        let snapshot = nested_snapshot();
+
+        // When
+        let reconciliation = reconcile_workspace_tree_selection(snapshot, "selected-node");
+
+        // Then
+        assert_classifications(&reconciliation.snapshot.nodes);
     }
 }

--- a/src/App.workspace-archive.test.tsx
+++ b/src/App.workspace-archive.test.tsx
@@ -135,7 +135,7 @@ const initialSnapshot: WorkspaceTreeSnapshot = {
 			kind: "node",
 			id: FALLBACK_NODE_ID,
 			title: "Fallback session",
-			status: "running",
+			status: "active",
 			contentKind: "session",
 			capabilities: { canApprove: false, canRetry: false, canClose: true },
 			pastAttempts: [],
@@ -146,7 +146,7 @@ const initialSnapshot: WorkspaceTreeSnapshot = {
 			kind: "sequence",
 			id: "archivable-workflow",
 			title: "Archivable workflow",
-			status: "completed",
+			status: "idle",
 			workflowCapabilities: {
 				canStop: false,
 				canResume: false,
@@ -158,7 +158,7 @@ const initialSnapshot: WorkspaceTreeSnapshot = {
 					kind: "node",
 					id: SELECTED_NODE_ID,
 					title: "Selected workflow Node",
-					status: "completed",
+					status: "idle",
 					contentKind: "session",
 					capabilities: { canApprove: false, canRetry: false, canClose: false },
 					pastAttempts: [],
@@ -179,7 +179,7 @@ const fallbackSnapshot: WorkspaceTreeSnapshot = {
 			kind: "node",
 			id: FALLBACK_NODE_ID,
 			title: "Fallback session",
-			status: "running",
+			status: "active",
 			contentKind: "session",
 			capabilities: { canApprove: false, canRetry: false, canClose: true },
 			pastAttempts: [],
@@ -441,7 +441,7 @@ describe("App Workspace Archive selection reconciliation", () => {
 		);
 
 		await user.click(
-			screen.getByRole("button", { name: "Fallback session, running" }),
+			screen.getByRole("button", { name: "Fallback session, active" }),
 		);
 		await waitFor(() =>
 			expect(screen.getByTestId("center-node")).toHaveTextContent(

--- a/src/components/panels/NodeContentView/NodeContentView.test.tsx
+++ b/src/components/panels/NodeContentView/NodeContentView.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { WorkspaceNodeDetail } from "@/types/workspace-tree";
+import type {
+	WorkspaceNodeDetail,
+	WorkspaceNodeStatus,
+	WorkspaceNodeStatusClassification,
+} from "@/types/workspace-tree";
 import { NodeContentView } from "./NodeContentView";
 
 const mocks = vi.hoisted(() => ({
@@ -43,6 +47,7 @@ function sessionDetail(
 		id,
 		title: `Session ${id}`,
 		status: "running",
+		statusClassification: "active",
 		submitReceived: false,
 		stopReceived: false,
 		hasArtifact: false,
@@ -216,6 +221,7 @@ describe("NodeContentView", () => {
 		mocks.detailState.detail = {
 			...sessionDetail("missing", null),
 			status: "failed",
+			statusClassification: "failure",
 		};
 		renderView("missing");
 
@@ -228,6 +234,7 @@ describe("NodeContentView", () => {
 			id: "command-node",
 			title: "Run checks",
 			status: "failed",
+			statusClassification: "failure",
 			submitReceived: false,
 			stopReceived: false,
 			hasArtifact: false,
@@ -288,6 +295,7 @@ describe("NodeContentView", () => {
 		mocks.detailState.detail = {
 			...sessionDetail("failed-session"),
 			status: "failed",
+			statusClassification: "failure",
 			errorReason: "Agent process exited unexpectedly",
 		};
 		renderView("failed-session");
@@ -306,10 +314,89 @@ describe("NodeContentView", () => {
 		expect(screen.getByTitle("running")).toBeVisible();
 	});
 
+	it.each<[WorkspaceNodeStatus, WorkspaceNodeStatusClassification, string]>([
+		["running", "active", "lucide-loader-circle"],
+		["waiting", "attention", "lucide-clock"],
+		["failed", "failure", "lucide-triangle-alert"],
+		["paused", "idle", "lucide-circle"],
+		["completed", "idle", "lucide-circle-check"],
+		["aborted", "idle", "lucide-ban"],
+	])(
+		"uses the existing %s shape and never pulses in the detail pane",
+		(status, statusClassification, expectedShapeClass) => {
+			mocks.detailState.detail = {
+				...sessionDetail(`${status}-shape`),
+				status,
+				statusClassification,
+			};
+
+			renderView(`${status}-shape`);
+
+			const icon = screen.getByTitle(status).querySelector("svg");
+			expect(icon).toHaveClass(expectedShapeClass);
+			expect(icon).not.toHaveClass("animate-pulse");
+		},
+	);
+
+	it.each<
+		[
+			WorkspaceNodeStatus,
+			WorkspaceNodeStatusClassification,
+			string,
+			string,
+			string,
+		]
+	>([
+		[
+			"running",
+			"active",
+			"lucide-loader-circle",
+			"text-blue-600",
+			"dark:text-blue-300",
+		],
+		[
+			"waiting",
+			"attention",
+			"lucide-clock",
+			"text-yellow-600",
+			"dark:text-yellow-300",
+		],
+		[
+			"failed",
+			"failure",
+			"lucide-triangle-alert",
+			"text-red-600",
+			"dark:text-red-300",
+		],
+		[
+			"paused",
+			"idle",
+			"lucide-circle",
+			"text-green-600",
+			"dark:text-green-300",
+		],
+	])(
+		"colors the %s detail shape from the %s classification without pulsing",
+		(status, statusClassification, shapeClass, lightClass, darkClass) => {
+			mocks.detailState.detail = {
+				...sessionDetail(`${statusClassification}-color`),
+				status,
+				statusClassification,
+			};
+
+			renderView(`${statusClassification}-color`);
+
+			const icon = screen.getByTitle(status).querySelector("svg");
+			expect(icon).toHaveClass(shapeClass, lightClass, darkClass);
+			expect(icon).not.toHaveClass("animate-pulse");
+		},
+	);
+
 	it("shows backend-owned error and recovery reasons without deriving them in the TUI", () => {
 		mocks.detailState.detail = {
 			...sessionDetail("paused-session"),
 			status: "paused",
+			statusClassification: "failure",
 			errorReason: "Node activation failed",
 			recoveryReason: "Provider session must be recovered",
 		};

--- a/src/components/panels/NodeContentView/NodeContentView.tsx
+++ b/src/components/panels/NodeContentView/NodeContentView.tsx
@@ -150,7 +150,10 @@ function NodeHeader({
 	return (
 		<div className="flex min-w-0 items-center gap-2 pl-2">
 			<span title={detail.status}>
-				<WorkflowNodeStatusIcon status={detail.status} />
+				<WorkflowNodeStatusIcon
+					status={detail.status}
+					statusClassification={detail.statusClassification}
+				/>
 			</span>
 			<span className="min-w-0 flex-1 truncate text-sm font-medium">
 				{detail.title}

--- a/src/components/workspace/FanoutRowStatusIcon.test.tsx
+++ b/src/components/workspace/FanoutRowStatusIcon.test.tsx
@@ -1,37 +1,37 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { WorkspaceNodeStatus } from "@/types/workspace-tree";
+import type { WorkspaceNodeStatusClassification } from "@/types/workspace-tree";
 import { FanoutRowStatusIcon } from "./FanoutRowStatusIcon";
 import { workflowNodeIconClasses } from "./WorkflowNodeStatusIcon";
 
-const statuses: WorkspaceNodeStatus[] = [
-	"running",
-	"paused",
-	"failed",
-	"waiting",
-	"interrupted",
-	"aborted",
-	"completed",
+const classifications: WorkspaceNodeStatusClassification[] = [
+	"active",
+	"attention",
+	"failure",
+	"idle",
 ];
 
 describe("FanoutRowStatusIcon", () => {
-	it.each(statuses)("keeps the GitFork icon shape for %s", (status) => {
-		const { container } = render(<FanoutRowStatusIcon status={status} />);
-		const icon = container.querySelector("svg.lucide-git-fork");
+	it.each(classifications)(
+		"keeps the GitFork icon shape and classification color for %s",
+		(status) => {
+			const { container } = render(<FanoutRowStatusIcon status={status} />);
+			const icon = container.querySelector("svg.lucide-git-fork");
 
-		expect(container.querySelectorAll("svg")).toHaveLength(1);
-		expect(icon).toBeInTheDocument();
-		expect(icon).toHaveClass(...workflowNodeIconClasses[status].split(" "));
-	});
+			expect(container.querySelectorAll("svg")).toHaveLength(1);
+			expect(icon).toBeInTheDocument();
+			expect(icon).toHaveClass(...workflowNodeIconClasses[status].split(" "));
+		},
+	);
 
-	it("pulses only running and waiting statuses", () => {
-		for (const status of statuses) {
+	it("pulses only active and attention classifications", () => {
+		for (const status of classifications) {
 			const { container, unmount } = render(
 				<FanoutRowStatusIcon status={status} />,
 			);
 			const icon = container.querySelector("svg.lucide-git-fork");
 
-			if (status === "running" || status === "waiting") {
+			if (status === "active" || status === "attention") {
 				expect(icon).toHaveClass("animate-pulse");
 			} else {
 				expect(icon).not.toHaveClass("animate-pulse");
@@ -41,8 +41,8 @@ describe("FanoutRowStatusIcon", () => {
 	});
 
 	it("exposes the backend status as the title", () => {
-		render(<FanoutRowStatusIcon status="interrupted" />);
+		render(<FanoutRowStatusIcon status="attention" />);
 
-		expect(screen.getByTitle("interrupted")).toBeInTheDocument();
+		expect(screen.getByTitle("attention")).toBeInTheDocument();
 	});
 });

--- a/src/components/workspace/FanoutRowStatusIcon.tsx
+++ b/src/components/workspace/FanoutRowStatusIcon.tsx
@@ -1,9 +1,9 @@
 import { GitFork } from "lucide-react";
-import type { WorkspaceNodeStatus } from "@/types/workspace-tree";
+import type { WorkspaceNodeStatusClassification } from "@/types/workspace-tree";
 import { WorkspaceBranchStatusIcon } from "./WorkspaceBranchStatusIcon";
 
 interface FanoutRowStatusIconProps {
-	status: WorkspaceNodeStatus;
+	status: WorkspaceNodeStatusClassification;
 	containerClassName?: string;
 	iconClassName?: string;
 }

--- a/src/components/workspace/WorkflowNodeStatusIcon.test.ts
+++ b/src/components/workspace/WorkflowNodeStatusIcon.test.ts
@@ -1,35 +1,34 @@
 import { describe, expect, it } from "vitest";
-import type { WorkspaceNodeStatus } from "@/types/workspace-tree";
+import type { WorkspaceNodeStatusClassification } from "@/types/workspace-tree";
 import {
 	isWorkspaceNodePulseStatus,
 	workflowNodeIconClasses,
 } from "./WorkflowNodeStatusIcon";
 
-const statuses: WorkspaceNodeStatus[] = [
-	"running",
-	"paused",
-	"failed",
-	"waiting",
-	"interrupted",
-	"aborted",
-	"completed",
+const classifications: WorkspaceNodeStatusClassification[] = [
+	"active",
+	"attention",
+	"failure",
+	"idle",
 ];
 
 describe("Workspace Node status presentation", () => {
-	it("covers exactly the backend-owned public statuses", () => {
+	it("maps exactly the backend-owned classifications to their colors", () => {
 		expect(Object.keys(workflowNodeIconClasses).sort()).toEqual(
-			[...statuses].sort(),
+			[...classifications].sort(),
 		);
+		expect(workflowNodeIconClasses).toEqual({
+			active: "text-blue-600 dark:text-blue-300",
+			attention: "text-yellow-600 dark:text-yellow-300",
+			failure: "text-red-600 dark:text-red-300",
+			idle: "text-green-600 dark:text-green-300",
+		});
 	});
 
-	it.each(statuses)("defines a color for %s", (status) => {
-		expect(workflowNodeIconClasses[status]).toBeTruthy();
-	});
-
-	it("pulses only running and waiting", () => {
-		for (const status of statuses) {
-			expect(isWorkspaceNodePulseStatus(status)).toBe(
-				status === "running" || status === "waiting",
+	it("pulses only active and attention", () => {
+		for (const classification of classifications) {
+			expect(isWorkspaceNodePulseStatus(classification)).toBe(
+				classification === "active" || classification === "attention",
 			);
 		}
 	});

--- a/src/components/workspace/WorkflowNodeStatusIcon.tsx
+++ b/src/components/workspace/WorkflowNodeStatusIcon.tsx
@@ -7,27 +7,30 @@ import {
 	Loader2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { WorkspaceNodeStatus } from "@/types/workspace-tree";
+import type {
+	WorkspaceNodeStatus,
+	WorkspaceNodeStatusClassification,
+} from "@/types/workspace-tree";
 
-export const workflowNodeIconClasses: Record<WorkspaceNodeStatus, string> = {
-	running: "text-blue-600 dark:text-blue-300",
-	paused: "text-muted-foreground",
-	failed: "text-red-600 dark:text-red-300",
-	waiting: "text-yellow-600 dark:text-yellow-300",
-	interrupted: "text-orange-600 dark:text-orange-300",
-	aborted: "text-muted-foreground",
-	completed: "text-green-600 dark:text-green-300",
+export const workflowNodeIconClasses: Record<
+	WorkspaceNodeStatusClassification,
+	string
+> = {
+	active: "text-blue-600 dark:text-blue-300",
+	attention: "text-yellow-600 dark:text-yellow-300",
+	failure: "text-red-600 dark:text-red-300",
+	idle: "text-green-600 dark:text-green-300",
 };
 
-/** running / waiting のときにアイコンを pulse させるかの判定。 */
 export function isWorkspaceNodePulseStatus(
-	status: WorkspaceNodeStatus,
+	status: WorkspaceNodeStatusClassification,
 ): boolean {
-	return status === "running" || status === "waiting";
+	return status === "active" || status === "attention";
 }
 
 interface WorkflowNodeStatusIconProps {
 	status: WorkspaceNodeStatus;
+	statusClassification: WorkspaceNodeStatusClassification;
 	containerClassName?: string;
 	iconClassName?: string;
 	circleClassName?: string;
@@ -35,11 +38,12 @@ interface WorkflowNodeStatusIconProps {
 
 export function WorkflowNodeStatusIcon({
 	status,
+	statusClassification,
 	containerClassName,
 	iconClassName = "size-3.5 shrink-0",
 	circleClassName = "size-2.5 shrink-0",
 }: WorkflowNodeStatusIconProps) {
-	const colorClassName = workflowNodeIconClasses[status];
+	const colorClassName = workflowNodeIconClasses[statusClassification];
 	const inheritedColor = containerClassName ? undefined : colorClassName;
 	const baseIconClassName = cn(iconClassName, inheritedColor);
 	const icon =

--- a/src/components/workspace/WorkspaceBranchStatusIcon.tsx
+++ b/src/components/workspace/WorkspaceBranchStatusIcon.tsx
@@ -1,13 +1,13 @@
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { WorkspaceNodeStatus } from "@/types/workspace-tree";
+import type { WorkspaceNodeStatusClassification } from "@/types/workspace-tree";
 import {
 	isWorkspaceNodePulseStatus,
 	workflowNodeIconClasses,
 } from "./WorkflowNodeStatusIcon";
 
 interface WorkspaceBranchStatusIconProps {
-	status: WorkspaceNodeStatus;
+	status: WorkspaceNodeStatusClassification;
 	icon: LucideIcon;
 	containerClassName?: string;
 	iconClassName?: string;
@@ -20,8 +20,7 @@ export function WorkspaceBranchStatusIcon({
 	containerClassName,
 	iconClassName = "size-3.5 shrink-0",
 }: WorkspaceBranchStatusIconProps) {
-	const colorClassName =
-		workflowNodeIconClasses[status] ?? "text-muted-foreground";
+	const colorClassName = workflowNodeIconClasses[status];
 	const pulseClassName = isWorkspaceNodePulseStatus(status)
 		? "animate-pulse"
 		: undefined;

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -119,7 +119,7 @@ const directNode: WorkspaceTreeItem = {
 	kind: "node",
 	id: "4f168b74-f9cf-4d51-9970-81ea281bc983",
 	title: "Direct session",
-	status: "running",
+	status: "active",
 	contentKind: "session",
 	capabilities: { canApprove: false, canRetry: false, canClose: true },
 	pastAttempts: [],
@@ -130,7 +130,7 @@ const directNode: WorkspaceTreeItem = {
 function standaloneSessionNode({
 	id,
 	title,
-	status = "running",
+	status = "active",
 	canArchive = true,
 	canDelete = false,
 	sessionRef = id,
@@ -166,7 +166,7 @@ const recursiveTree: WorkspaceTreeItem[] = [
 		kind: "sequence",
 		id: "workflow-internal-uuid",
 		title: "Release workflow",
-		status: "running",
+		status: "active",
 		workflowCapabilities: {
 			canStop: true,
 			canResume: false,
@@ -179,7 +179,7 @@ const recursiveTree: WorkspaceTreeItem[] = [
 				kind: "node",
 				id: "workflow-session-internal-uuid",
 				title: "Prepare",
-				status: "completed",
+				status: "idle",
 				contentKind: "session",
 				capabilities: { canApprove: false, canRetry: false, canClose: false },
 				pastAttempts: [],
@@ -190,7 +190,7 @@ const recursiveTree: WorkspaceTreeItem[] = [
 				kind: "fanout",
 				id: "fanout-internal-uuid",
 				title: "Review all",
-				status: "running",
+				status: "active",
 				workflowCapabilities: null,
 				updatedAt: 4,
 				children: [
@@ -198,7 +198,7 @@ const recursiveTree: WorkspaceTreeItem[] = [
 						kind: "node",
 						id: "fanout-child-internal-uuid",
 						title: "Architecture review",
-						status: "running",
+						status: "active",
 						contentKind: "command",
 						capabilities: {
 							canApprove: false,
@@ -402,6 +402,61 @@ describe("WorkspaceList", () => {
 		expect(container.querySelectorAll("svg.lucide-git-fork")).toHaveLength(1);
 	});
 
+	it("uses the four classification colors and pulse rules for Sequence rows", () => {
+		const cases = [
+			{
+				title: "Active sequence",
+				status: "active",
+				colorClasses: ["text-blue-600", "dark:text-blue-300"],
+				pulses: true,
+			},
+			{
+				title: "Attention sequence",
+				status: "attention",
+				colorClasses: ["text-yellow-600", "dark:text-yellow-300"],
+				pulses: true,
+			},
+			{
+				title: "Failure sequence",
+				status: "failure",
+				colorClasses: ["text-red-600", "dark:text-red-300"],
+				pulses: false,
+			},
+			{
+				title: "Idle sequence",
+				status: "idle",
+				colorClasses: ["text-green-600", "dark:text-green-300"],
+				pulses: false,
+			},
+		] as const;
+		const nodes: WorkspaceTreeItem[] = cases.map(
+			({ title, status }, index) => ({
+				kind: "sequence",
+				id: `sequence-${index}`,
+				title,
+				status,
+				children: [],
+				updatedAt: index,
+			}),
+		);
+		mocks.treeStateOverrides.set("/repo/wt", { nodes });
+
+		renderWorkspaceList();
+
+		for (const { title, colorClasses, pulses } of cases) {
+			const icon = screen
+				.getByRole("button", { name: title })
+				.querySelector("svg.lucide-list-tree");
+			expect(icon).toBeInTheDocument();
+			expect(icon).toHaveClass(...colorClasses);
+			if (pulses) {
+				expect(icon).toHaveClass("animate-pulse");
+			} else {
+				expect(icon).not.toHaveClass("animate-pulse");
+			}
+		}
+	});
+
 	it("backendが絞り込んだStandalone Session Nodeを選択できる", async () => {
 		mocks.treeStateOverrides.set("/repo/wt", {
 			nodes: [
@@ -417,7 +472,7 @@ describe("WorkspaceList", () => {
 
 		await user.click(
 			screen.getByRole("button", {
-				name: "Claude AgentSession, running",
+				name: "Claude AgentSession, active",
 			}),
 		);
 
@@ -516,63 +571,70 @@ describe("WorkspaceList", () => {
 		});
 	});
 
-	it("Standalone Session Nodeの実行状態はテキストでなくアイコン色で表現する", () => {
+	it("Standalone Session Nodeの4分類は色とpulseで表現する", () => {
 		mocks.treeStateOverrides.set("/repo/wt", {
 			nodes: [
 				standaloneSessionNode({
-					id: "provider-agent-running",
-					title: "Running Session",
-					status: "running",
+					id: "provider-agent-active",
+					title: "Active Session",
+					status: "active",
 				}),
 				standaloneSessionNode({
-					id: "provider-agent-completed",
-					title: "Completed Session",
-					status: "completed",
+					id: "provider-agent-attention",
+					title: "Attention Session",
+					status: "attention",
 				}),
 				standaloneSessionNode({
-					id: "provider-agent-failed",
-					title: "Failed Session",
-					status: "failed",
+					id: "provider-agent-failure",
+					title: "Failure Session",
+					status: "failure",
 				}),
 				standaloneSessionNode({
-					id: "provider-agent-paused",
-					title: "Paused Session",
-					status: "paused",
+					id: "provider-agent-idle",
+					title: "Idle Session",
+					status: "idle",
 				}),
 			],
 			archivedSessions: [],
 		});
 		renderWorkspaceList();
 
-		const runningRow = screen.getByRole("button", {
-			name: "Running Session, running",
+		const activeRow = screen.getByRole("button", {
+			name: "Active Session, active",
 		});
-		const completedRow = screen.getByRole("button", {
-			name: "Completed Session, completed",
+		const attentionRow = screen.getByRole("button", {
+			name: "Attention Session, attention",
 		});
-		const failedRow = screen.getByRole("button", {
-			name: "Failed Session, failed",
+		const failureRow = screen.getByRole("button", {
+			name: "Failure Session, failure",
 		});
-		const pausedRow = screen.getByRole("button", {
-			name: "Paused Session, paused",
+		const idleRow = screen.getByRole("button", {
+			name: "Idle Session, idle",
 		});
 
-		expect(within(runningRow).queryByText("running")).toBeNull();
-		expect(within(completedRow).queryByText("completed")).toBeNull();
-		expect(within(failedRow).queryByText("failed")).toBeNull();
-		expect(within(pausedRow).queryByText("paused")).toBeNull();
+		expect(within(activeRow).queryByText("active")).toBeNull();
+		expect(within(attentionRow).queryByText("attention")).toBeNull();
+		expect(within(failureRow).queryByText("failure")).toBeNull();
+		expect(within(idleRow).queryByText("idle")).toBeNull();
 		expect(
-			within(runningRow).getByTitle("session, running").firstChild,
+			within(activeRow).getByTitle("session, active").firstChild,
 		).toHaveClass("text-blue-600", "dark:text-blue-300", "animate-pulse");
 		expect(
-			within(completedRow).getByTitle("session, completed").firstChild,
-		).toHaveClass("text-green-600", "dark:text-green-300");
+			within(attentionRow).getByTitle("session, attention").firstChild,
+		).toHaveClass("text-yellow-600", "dark:text-yellow-300", "animate-pulse");
 		expect(
-			within(failedRow).getByTitle("session, failed").firstChild,
+			within(failureRow).getByTitle("session, failure").firstChild,
 		).toHaveClass("text-red-600", "dark:text-red-300");
+		expect(within(idleRow).getByTitle("session, idle").firstChild).toHaveClass(
+			"text-green-600",
+			"dark:text-green-300",
+		);
 		expect(
-			within(pausedRow).getByTitle("session, paused").firstChild,
-		).toHaveClass("text-muted-foreground");
+			within(failureRow).getByTitle("session, failure").firstChild,
+		).not.toHaveClass("animate-pulse");
+		expect(
+			within(idleRow).getByTitle("session, idle").firstChild,
+		).not.toHaveClass("animate-pulse");
 	});
 
 	it("Standalone AgentSessionのXはArchiveしID不明時はDelete確認を要求する", async () => {
@@ -674,7 +736,7 @@ describe("WorkspaceList", () => {
 
 		expect(
 			screen.getByRole("button", {
-				name: "Codex AgentSession, running",
+				name: "Codex AgentSession, active",
 			}),
 		).toBeVisible();
 		expect(screen.getByText("Claude AgentSession")).toBeVisible();
@@ -687,7 +749,7 @@ describe("WorkspaceList", () => {
 					kind: "sequence",
 					id: "empty-workflow",
 					title: "Empty workflow",
-					status: "running",
+					status: "active",
 					workflowCapabilities: {
 						canStop: true,
 						canResume: false,
@@ -711,11 +773,11 @@ describe("WorkspaceList", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("keeps one familiar content icon per Node and styles it from backend status", () => {
+	it("keeps one familiar content icon per Node and styles it from backend classification", () => {
 		renderWorkspaceList();
 
 		const sessionRow = screen.getByRole("button", {
-			name: "Direct session, running",
+			name: "Direct session, active",
 		});
 		const sessionIcons = sessionRow.querySelectorAll("svg");
 		expect(sessionIcons).toHaveLength(1);
@@ -726,7 +788,7 @@ describe("WorkspaceList", () => {
 		);
 
 		const commandRow = screen.getByRole("button", {
-			name: "Architecture review, running",
+			name: "Architecture review, active",
 		});
 		const commandIcons = commandRow.querySelectorAll("svg");
 		expect(commandIcons).toHaveLength(1);
@@ -737,12 +799,12 @@ describe("WorkspaceList", () => {
 		);
 	});
 
-	it("shows the backend failed status on a failed session badge", () => {
+	it("shows the backend failure classification on a failed session badge", () => {
 		mocks.treeStateOverrides.set("/repo/wt", {
 			nodes: [
 				{
 					...directNode,
-					status: "failed",
+					status: "failure",
 					errorReason: "app server stopped",
 				},
 			],
@@ -750,7 +812,7 @@ describe("WorkspaceList", () => {
 
 		renderWorkspaceList();
 
-		expect(screen.getByTitle("session, failed")).toBeInTheDocument();
+		expect(screen.getByTitle("session, failure")).toBeInTheDocument();
 	});
 
 	it("toggles Workflow and Fanout branches without changing selection", async () => {
@@ -1053,7 +1115,7 @@ describe("WorkspaceList", () => {
 			kind: "node",
 			id: "occurrence-a-1",
 			title: "A",
-			status: "completed",
+			status: "idle",
 			contentKind: "session",
 			capabilities: { canApprove: false, canRetry: false, canClose: false },
 			pastAttempts: [],
@@ -1075,14 +1137,14 @@ describe("WorkspaceList", () => {
 			...occurrenceA1,
 			id: "occurrence-c-1",
 			title: "C",
-			status: "running",
+			status: "active",
 			updatedAt: 4,
 		};
 		const workflow = (children: WorkspaceTreeItem[]): WorkspaceTreeItem => ({
 			kind: "sequence",
 			id: "loop-workflow",
 			title: "Loop workflow",
-			status: "running",
+			status: "active",
 			workflowCapabilities: {
 				canStop: true,
 				canResume: false,
@@ -1123,13 +1185,13 @@ describe("WorkspaceList", () => {
 			.map((button) => button.getAttribute("aria-label"))
 			.filter((label) => label?.match(/^[ABC],/));
 		expect(executionLabels).toEqual([
-			"A, completed",
-			"B, completed",
-			"A, completed",
-			"C, running",
+			"A, idle",
+			"B, idle",
+			"A, idle",
+			"C, active",
 		]);
 		const [firstA, secondA] = screen.getAllByRole("button", {
-			name: /^A, completed$/,
+			name: /^A, idle$/,
 		});
 		expect(firstA).toHaveAttribute("aria-current", "page");
 		expect(secondA).not.toHaveAttribute("aria-current");
@@ -1152,20 +1214,20 @@ describe("WorkspaceList", () => {
 		const first = standaloneSessionNode({
 			id: "retry-attempt-first",
 			title: "Review",
-			status: "failed",
+			status: "failure",
 			canArchive: false,
 		});
 		const second = standaloneSessionNode({
 			id: "retry-attempt-second",
 			title: "Review",
-			status: "completed",
+			status: "idle",
 			canArchive: false,
 		});
 		const latest: WorkspaceNode = {
 			...standaloneSessionNode({
 				id: "retry-attempt-latest",
 				title: "Review",
-				status: "running",
+				status: "active",
 				canArchive: false,
 			}),
 			pastAttempts: [first, second],
@@ -1187,9 +1249,9 @@ describe("WorkspaceList", () => {
 
 		const executions = screen.getAllByRole("button", { name: /^Review,/ });
 		expect(executions.map((row) => row.getAttribute("aria-label"))).toEqual([
-			"Review, failed",
-			"Review, completed",
-			"Review, running",
+			"Review, failure",
+			"Review, idle",
+			"Review, active",
 		]);
 		await user.click(executions[0]);
 		expect(onSelectWorktree).toHaveBeenLastCalledWith(
@@ -1381,7 +1443,7 @@ describe("WorkspaceList", () => {
 			item.kind === "sequence" && item.workflowCapabilities
 				? {
 						...item,
-						status: "completed" as const,
+						status: "idle" as const,
 						workflowCapabilities: {
 							...item.workflowCapabilities,
 							canArchive: true,
@@ -1451,7 +1513,7 @@ describe("WorkspaceList", () => {
 			item.kind === "sequence" && item.workflowCapabilities
 				? {
 						...item,
-						status: "completed" as const,
+						status: "idle" as const,
 						workflowCapabilities: {
 							...item.workflowCapabilities,
 							canArchive: true,

--- a/src/hooks/useWorkspaceNodeDetail.test.ts
+++ b/src/hooks/useWorkspaceNodeDetail.test.ts
@@ -24,6 +24,7 @@ function detail(id: string, title = id): WorkspaceNodeDetail {
 		id,
 		title,
 		status: "running",
+		statusClassification: "active",
 		submitReceived: false,
 		stopReceived: false,
 		hasArtifact: false,

--- a/src/hooks/useWorkspaceTreeNodes.test.ts
+++ b/src/hooks/useWorkspaceTreeNodes.test.ts
@@ -25,7 +25,7 @@ function makeNode(id: string): WorkspaceTreeItem {
 		kind: "node",
 		id,
 		title: id,
-		status: "running",
+		status: "active",
 		contentKind: "session",
 		capabilities: { canApprove: false, canRetry: false, canClose: true },
 		pastAttempts: [],
@@ -377,7 +377,7 @@ describe("useWorkspaceTreeNodes", () => {
 			kind: "sequence",
 			id: "empty-workflow",
 			title: "Empty workflow",
-			status: "running",
+			status: "active",
 			workflowCapabilities: {
 				canStop: true,
 				canResume: false,

--- a/src/types/workspace-tree.ts
+++ b/src/types/workspace-tree.ts
@@ -24,9 +24,14 @@ export type WorkspaceNodeStatus =
 	| "paused"
 	| "failed"
 	| "waiting"
-	| "interrupted"
 	| "aborted"
 	| "completed";
+
+export type WorkspaceNodeStatusClassification =
+	| "active"
+	| "attention"
+	| "failure"
+	| "idle";
 
 export interface WorkspaceNodeCapabilities {
 	canApprove: boolean;
@@ -52,7 +57,7 @@ export interface WorkspaceNode {
 	kind: "node";
 	id: string;
 	title: string;
-	status: WorkspaceNodeStatus;
+	status: WorkspaceNodeStatusClassification;
 	errorReason?: string | null;
 	contentKind: "session" | "command";
 	capabilities: WorkspaceNodeCapabilities;
@@ -67,7 +72,7 @@ export interface WorkspaceSequence {
 	kind: "sequence";
 	id: string;
 	title: string;
-	status: WorkspaceNodeStatus;
+	status: WorkspaceNodeStatusClassification;
 	workflowCapabilities?: WorkspaceWorkflowCapabilities | null;
 	children: WorkspaceTreeItem[];
 	updatedAt: number;
@@ -77,7 +82,7 @@ export interface WorkspaceFanout {
 	kind: "fanout";
 	id: string;
 	title: string;
-	status: WorkspaceNodeStatus;
+	status: WorkspaceNodeStatusClassification;
 	workflowCapabilities?: WorkspaceWorkflowCapabilities | null;
 	children: WorkspaceTreeItem[];
 	updatedAt: number;
@@ -129,6 +134,7 @@ export interface WorkspaceNodeDetail {
 	id: string;
 	title: string;
 	status: WorkspaceNodeStatus;
+	statusClassification: WorkspaceNodeStatusClassification;
 	submitReceived: boolean;
 	stopReceived: boolean;
 	waitingFor?: "submit" | "stop";


### PR DESCRIPTION
## 背景

Workspace ツリーの行は `WorkspaceNodeStatus` の 7 値をそのまま色へ写しており、ノードの状態を判別する用をなしていなかった。

- `interrupted`（オレンジ）を生成する経路が `#[cfg(test)]` で閉じており、production で一度も出ない。
- `paused`（再開できる）と `aborted`（終わっている）がどちらも `text-muted-foreground` で、行の既定テキスト色と区別が付かない。
- recovery fence と completion signal がツリー DTO に無く、復元できないノードや Stop 信号だけを受領したノードが実行中と同じ青 + pulse で表示される。
- 親行の集約規則が Fanout（最小ランク）/ Sequence（集約しない）/ Workflow root（最後の子から導出）の 3 種類に割れている。

spec: `docs/specs/issues-1683/`

## 変更

### 4分類を domain が所有する

`WorkspaceNodeStatusClassification`（`active` / `attention` / `failure` / `idle`）を追加し、leaf の分類を次の順で決める。規則は `WorkspaceTreeNode::classify_own_status` が単独で所有し、ノード生成時の初期値もこの関数を通す。

| 順 | 条件 | 分類 |
| --- | --- | --- |
| 1 | recovery fence を持つ | `failure` |
| 2 | `failed` | `failure` |
| 3 | `waiting` | `attention` |
| 4 | `running` かつ Stop 信号のみ受領 | `attention` |
| 5 | `running` | `active` |
| 6 | `paused` / `completed` / `aborted` | `idle` |

色の意味は 青 = 実行中、黄 = 介入が必要、赤 = 失敗、緑 = 動いていない。緑は完了ではなく「動いていない」を表す。

### 親行の集約を Sequence / Fanout で統一する

復元済みツリーを post-order で 1 度走査し、自分自身と直接の子の確定済み分類から `failure > attention > active > idle` の最上位を採る。詳細状態の子集約と、Workflow root の詳細状態を最後の子から導出する分岐は廃止した。internal rule record と retry history は従来どおり配下から除外する。runtime snapshot は completion signal と paused を反映した後に分類だけを再計算し、projection 由来の操作可否は変更しない。

### read contract

| 対象 | 変更 |
| --- | --- |
| ツリーの `WorkspaceNodeDto` / `WorkspaceSequenceDto` / `WorkspaceFanoutDto` | `status` を 4 分類へ置き換え、詳細状態を返さない |
| `WorkspaceNodeDetailDto` | 詳細 `status` を維持し `statusClassification` を追加 |

`list_workspace_worktree_nodes` / `get_workspace_tree_selection_reconciliation` / `get_workspace_node_detail` の command 名、引数、失敗形式は変更しない。local API と CLI は Workspace ツリーを返していないため応答は変わらない。

### interrupted の除去

`WorkspaceNodeStatus::Interrupted` を削除し、これに依存していた到達不能な resume 条件も除去した。resume 可否と resume 不能理由は leaf の `paused` と recovery fence だけで決まる。`ExecutionStatus` と Node Attempt の実行状態は変更しない。

### 表示

ツリー行は Bot / Terminal / ListTree / GitFork の形状を維持し、色と pulse を 4 分類だけから選ぶ。pulse は `active` と `attention` のみ。詳細ペインは形状を詳細状態から、色を `statusClassification` から選び、pulse させない。recovery fence を持つ `paused` は paused の形状のまま赤になる。

## 検証

| ゲート | 結果 |
| --- | --- |
| `cargo fmt --check` | pass |
| `cargo clippy --locked --all-targets -- -D warnings` | pass |
| `cargo test --locked` | 2101 + 56 passed |
| `pnpm lint` | pass |
| `pnpm test` | 959 passed / 90 files |
| `pnpm build` | pass |
| `pnpm test:integration` | 25 passed |
| `qlty check --no-progress --all` | No issues |

Closes #1683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oh1TncP5sosXwSb6o7QY3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ワークスペースツリーの状態表示を「実行中」「要対応」「失敗」「停止中」の4分類に統一しました。
  - 詳細画面では、状態の分類と詳細情報を併せて確認できます。
  - 状態に応じてアイコンの色と形状を表示します。

- **改善**
  - 実行中・要対応のアイコンのみ脈動表示します。
  - 中断状態を公開表示から除外し、操作可否や再開条件は従来どおり維持します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->