### PR TITLE
fix(workflow): 終端 session 停止 effect を commit call stack から切り離し provider Stop 受理の deadlock を解消する (#1695)

### DIFF
--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
@@ -1078,7 +1078,7 @@ impl WorkflowRuntimeHost {
         };
         let effects = durable.into_effects();
         drop(executions);
-        self.execute_committed_runtime_effects(effects).await;
+        self.spawn_committed_runtime_effects(effects);
         if let Err(error) = self.sync_state_after_required_event_commit(&snapshot).await {
             log::warn!(
                 "workflow {execution_id}: derived execution projection refresh failed after control-plane commit: {error}"
@@ -1087,7 +1087,34 @@ impl WorkflowRuntimeHost {
         Ok(snapshot)
     }
 
-    async fn execute_committed_runtime_effects(&self, effects: Vec<WorkflowRuntimeEffect>) {
+    /// durable commit 済みの runtime effect を detached task で実行する。
+    ///
+    /// provider Stop 受理経路は同一 AgentSession の operation lock と provider
+    /// lifecycle slot lock を保持したまま commit するため、Session 停止 effect を
+    /// 同じ call stack で実行すると lock を再取得して deadlock する。
+    fn spawn_committed_runtime_effects(&self, effects: Vec<WorkflowRuntimeEffect>) {
+        let stops: Vec<WorkflowRuntimeEffect> = effects
+            .into_iter()
+            .filter(|effect| {
+                matches!(
+                    effect,
+                    WorkflowRuntimeEffect::StopWorkflowAgentSession { .. }
+                )
+            })
+            .collect();
+        if stops.is_empty() {
+            return;
+        }
+        let sessions = self.workflow_agent_sessions.clone();
+        tokio::spawn(async move {
+            Self::run_committed_runtime_effects(sessions, stops).await;
+        });
+    }
+
+    async fn run_committed_runtime_effects(
+        sessions: Arc<dyn WorkflowAgentSessionPort>,
+        effects: Vec<WorkflowRuntimeEffect>,
+    ) {
         for effect in effects {
             let WorkflowRuntimeEffect::StopWorkflowAgentSession {
                 node_execution_id,
@@ -1096,8 +1123,7 @@ impl WorkflowRuntimeHost {
             else {
                 continue;
             };
-            if let Err(error) = self
-                .workflow_agent_sessions
+            if let Err(error) = sessions
                 .stop_workflow_agent_session_preserving_checkpoint(
                     &agent_session_id,
                     &node_execution_id,
@@ -2061,7 +2087,7 @@ impl WorkflowRuntimeHost {
             }
         };
 
-        self.execute_committed_runtime_effects(effects).await;
+        self.spawn_committed_runtime_effects(effects);
 
         if let Err(e) = self
             .sync_state_after_required_event_commit(snapshot_for_commit)
@@ -2839,6 +2865,76 @@ nodes:
             }
         }
 
+        struct NeverResolvingStopWorkflowAgentSessions;
+
+        #[async_trait::async_trait]
+        impl WorkflowAgentSessionPort for NeverResolvingStopWorkflowAgentSessions {
+            fn is_provider_available(&self, _provider: ProviderKind) -> bool {
+                true
+            }
+
+            async fn prepare_workflow_agent_session(
+                &self,
+                _worktree_path: &str,
+                _config: WorkflowSessionLaunchConfig,
+                _workflow_execution_id: &str,
+                _node_execution_id: &str,
+                _initial_instruction: &str,
+            ) -> Result<NodeSessionInfo, WorkflowRuntimeError> {
+                Ok(NodeSessionInfo {
+                    id: EFFECT_AGENT_SESSION_ID.to_string(),
+                })
+            }
+
+            async fn activate_workflow_agent_session(
+                &self,
+                _node_session_id: &str,
+                _node_execution_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn confirm_workflow_agent_session_attachment(
+                &self,
+                _node_session_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn dispatch_initial_instruction(
+                &self,
+                _node_session_id: &str,
+                _node_execution_id: &str,
+                _instruction: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn interrupt_workflow_agent_session(
+                &self,
+                _node_session_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+
+            async fn stop_workflow_agent_session_preserving_checkpoint(
+                &self,
+                _node_session_id: &str,
+                _node_execution_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                std::future::pending::<()>().await;
+                unreachable!()
+            }
+
+            async fn rollback_workflow_agent_session(
+                &self,
+                _node_session_id: &str,
+                _node_execution_id: &str,
+            ) -> Result<(), WorkflowRuntimeError> {
+                Ok(())
+            }
+        }
+
         struct RuntimeEffectFixture {
             app: tauri::App<tauri::test::MockRuntime>,
             store: Arc<LocalEventStore>,
@@ -2866,6 +2962,24 @@ nodes:
             completion: NodeCompletion,
             stop_fails: bool,
         ) -> RuntimeEffectFixture {
+            let stop_calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let sessions: Arc<dyn WorkflowAgentSessionPort> =
+                Arc::new(RecordingWorkflowAgentSessions {
+                    stop_calls: stop_calls.clone(),
+                    failing_agent_session_id: if stop_fails {
+                        EFFECT_AGENT_SESSION_ID.to_string()
+                    } else {
+                        String::new()
+                    },
+                });
+            runtime_effect_fixture_with_sessions(completion, sessions, stop_calls).await
+        }
+
+        async fn runtime_effect_fixture_with_sessions(
+            completion: NodeCompletion,
+            sessions: Arc<dyn WorkflowAgentSessionPort>,
+            stop_calls: Arc<std::sync::Mutex<Vec<(String, String)>>>,
+        ) -> RuntimeEffectFixture {
             let directory = tempfile::tempdir().unwrap();
             let fault = Arc::new(FaultInjector::new());
             let mut config = LocalEventStoreConfig::production(directory.path().to_path_buf());
@@ -2878,19 +2992,11 @@ nodes:
             app.manage(crate::infrastructure::platform::app_data_dir::TestDataDir(
                 directory.path().to_path_buf(),
             ));
-            let stop_calls = Arc::new(std::sync::Mutex::new(Vec::new()));
             let host = Arc::new(WorkflowRuntimeHost::with_execution_store(
             Arc::new(UnusedWorkflowResolver),
             Arc::new(AcceptingWorktreeResolver),
             Arc::new(ExecutionStore::new_in_memory_for_tests()),
-            Arc::new(RecordingWorkflowAgentSessions {
-                stop_calls: stop_calls.clone(),
-                failing_agent_session_id: if stop_fails {
-                    EFFECT_AGENT_SESSION_ID.to_string()
-                } else {
-                    String::new()
-                },
-            }),
+            sessions,
             Arc::new(
                 crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
                     store.clone(),
@@ -3103,7 +3209,20 @@ nodes:
                 .status
         }
 
-        fn assert_single_terminal_stop(fixture: &RuntimeEffectFixture) {
+        async fn wait_for_single_terminal_stop(fixture: &RuntimeEffectFixture) {
+            let observed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    if !fixture.stop_calls.lock().unwrap().is_empty() {
+                        return;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                }
+            })
+            .await;
+            assert!(
+                observed.is_ok(),
+                "terminal stop effect must run after durable commit"
+            );
             assert_eq!(
                 fixture.stop_calls.lock().unwrap().as_slice(),
                 &[(
@@ -3144,7 +3263,7 @@ nodes:
                 persisted_node_status(&fixture),
                 NodeExecutionStatus::Succeeded
             );
-            assert_single_terminal_stop(&fixture);
+            wait_for_single_terminal_stop(&fixture).await;
             let page = fixture
                 .store
                 .load_stream(LoadStreamRequest {
@@ -3182,11 +3301,11 @@ nodes:
                 persisted_node_status(&fixture),
                 NodeExecutionStatus::Succeeded
             );
-            assert_single_terminal_stop(&fixture);
+            wait_for_single_terminal_stop(&fixture).await;
         }
 
         #[tokio::test]
-        async fn test_session終端_停止後に後続sessionをactivateする() {
+        async fn test_session終端_後続activateを停止完了に依存させず両方を実行する() {
             // Given
             let fixture = sequential_runtime_effect_fixture().await;
             fixture.calls.lock().unwrap().clear();
@@ -3227,18 +3346,67 @@ nodes:
                 .find(|node| node.node_name == "agent-two")
                 .unwrap();
             assert_eq!(second.status, NodeExecutionStatus::Running);
+            let activate = RuntimeEffectCall::Activate {
+                node_execution_id: second.id.clone(),
+                agent_session_id: second.session_id.clone().unwrap(),
+            };
+            assert!(
+                fixture.calls.lock().unwrap().contains(&activate),
+                "Submit acceptance must activate the next Session without waiting for the stop effect"
+            );
+            let expected_stop = RuntimeEffectCall::Stop {
+                node_execution_id: fixture.first_node_execution_id.clone(),
+                agent_session_id: fixture.first_agent_session_id.clone(),
+            };
+            let observed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    if fixture.calls.lock().unwrap().contains(&expected_stop) {
+                        return;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                }
+            })
+            .await;
+            assert!(
+                observed.is_ok(),
+                "terminal stop effect must run after durable commit"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_provider_stop受理_停止effect未完了でもcommitと後続処理が完了する() {
+            // Given
+            let fixture = runtime_effect_fixture_with_sessions(
+                NodeCompletion::Auto,
+                Arc::new(NeverResolvingStopWorkflowAgentSessions),
+                Arc::new(std::sync::Mutex::new(Vec::new())),
+            )
+            .await;
+            fixture
+                .control_plane
+                .submit_output(SubmitOutputCommand {
+                    node_execution_id: fixture.node_execution_id.clone(),
+                    artifact: None,
+                })
+                .await
+                .unwrap();
+
+            // When
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                fixture
+                    .control_plane
+                    .record_provider_stop(provider_stop_command(&fixture), Vec::new()),
+            )
+            .await;
+
+            // Then
+            let result =
+                result.expect("provider Stop acceptance must not block on the session stop effect");
+            assert!(result.is_ok(), "unexpected provider Stop error: {result:?}");
             assert_eq!(
-                fixture.calls.lock().unwrap().as_slice(),
-                &[
-                    RuntimeEffectCall::Stop {
-                        node_execution_id: fixture.first_node_execution_id.clone(),
-                        agent_session_id: fixture.first_agent_session_id.clone(),
-                    },
-                    RuntimeEffectCall::Activate {
-                        node_execution_id: second.id.clone(),
-                        agent_session_id: second.session_id.clone().unwrap(),
-                    },
-                ]
+                persisted_node_status(&fixture),
+                NodeExecutionStatus::Succeeded
             );
         }
 
@@ -3263,7 +3431,7 @@ nodes:
                 persisted_node_status(&fixture),
                 NodeExecutionStatus::Succeeded
             );
-            assert_single_terminal_stop(&fixture);
+            wait_for_single_terminal_stop(&fixture).await;
 
             // When
             let result = fixture
@@ -3277,7 +3445,7 @@ nodes:
                 persisted_node_status(&fixture),
                 NodeExecutionStatus::Succeeded
             );
-            assert_single_terminal_stop(&fixture);
+            wait_for_single_terminal_stop(&fixture).await;
         }
 
         #[tokio::test]
@@ -3329,7 +3497,7 @@ nodes:
                 persisted_node_status(&fixture),
                 NodeExecutionStatus::Succeeded
             );
-            assert_single_terminal_stop(&fixture);
+            wait_for_single_terminal_stop(&fixture).await;
         }
 
         #[tokio::test]
@@ -3369,7 +3537,7 @@ nodes:
                     .status,
                 NodeExecutionStatus::Failed
             );
-            assert_single_terminal_stop(&fixture);
+            wait_for_single_terminal_stop(&fixture).await;
         }
 
         #[tokio::test]
@@ -3389,44 +3557,32 @@ nodes:
                 persisted_node_status(&fixture),
                 NodeExecutionStatus::Aborted
             );
-            assert_single_terminal_stop(&fixture);
+            wait_for_single_terminal_stop(&fixture).await;
         }
 
         #[tokio::test]
         async fn test_committed_runtime_effects_停止失敗後も残りのagent_sessionを停止する() {
-            let directory = tempfile::tempdir().unwrap();
-            let store = LocalEventStore::open(LocalEventStoreConfig::production(
-                directory.path().to_path_buf(),
-            ))
-            .unwrap();
             let stop_calls = Arc::new(std::sync::Mutex::new(Vec::new()));
-            let host = WorkflowRuntimeHost::with_execution_store(
-            Arc::new(UnusedWorkflowResolver),
-            Arc::new(UnusedWorktreeResolver),
-            Arc::new(ExecutionStore::new_in_memory_for_tests()),
-            Arc::new(RecordingWorkflowAgentSessions {
-                stop_calls: stop_calls.clone(),
-                failing_agent_session_id: "agent-session-1".to_string(),
-            }),
-            Arc::new(
-                crate::adaptor::gateway::workflow::NodeEventIsolatedWorktreeLedgerRepository::new(
-                    store,
-                ),
-            ),
-            Arc::new(MissingRepoWorktreeInventory),
-        );
+            let sessions: Arc<dyn WorkflowAgentSessionPort> =
+                Arc::new(RecordingWorkflowAgentSessions {
+                    stop_calls: stop_calls.clone(),
+                    failing_agent_session_id: "agent-session-1".to_string(),
+                });
 
-            host.execute_committed_runtime_effects(vec![
-                WorkflowRuntimeEffect::BroadcastState,
-                WorkflowRuntimeEffect::StopWorkflowAgentSession {
-                    node_execution_id: "node-1".to_string(),
-                    agent_session_id: "agent-session-1".to_string(),
-                },
-                WorkflowRuntimeEffect::StopWorkflowAgentSession {
-                    node_execution_id: "node-2".to_string(),
-                    agent_session_id: "agent-session-2".to_string(),
-                },
-            ])
+            WorkflowRuntimeHost::run_committed_runtime_effects(
+                sessions,
+                vec![
+                    WorkflowRuntimeEffect::BroadcastState,
+                    WorkflowRuntimeEffect::StopWorkflowAgentSession {
+                        node_execution_id: "node-1".to_string(),
+                        agent_session_id: "agent-session-1".to_string(),
+                    },
+                    WorkflowRuntimeEffect::StopWorkflowAgentSession {
+                        node_execution_id: "node-2".to_string(),
+                        agent_session_id: "agent-session-2".to_string(),
+                    },
+                ],
+            )
             .await;
 
             assert_eq!(

--- a/src-tauri/tests/workflow_control_plane_acceptance_test.rs
+++ b/src-tauri/tests/workflow_control_plane_acceptance_test.rs
@@ -137,9 +137,15 @@ fn owner(worktree_path: &str, session_id: &str) -> TerminalSurfaceOwnerV1 {
 }
 
 async fn receive_until(attachment: &mut TerminalSurfaceWireAttachment, needle: &str) {
-    tokio::time::timeout(Duration::from_secs(10), async {
-        let mut output = String::new();
-        while !output.contains(needle) {
+    receive_until_all(attachment, &[needle]).await;
+}
+
+/// 1 つの accumulator で全 needle を待つ。複数の期待出力が同じ Snapshot や
+/// 同じ出力 batch に載って届いても取りこぼさない。
+async fn receive_until_all(attachment: &mut TerminalSurfaceWireAttachment, needles: &[&str]) {
+    let mut output = String::new();
+    let result = tokio::time::timeout(Duration::from_secs(10), async {
+        while !needles.iter().all(|needle| output.contains(needle)) {
             match attachment.next().await.expect("Terminal Surface stream") {
                 TerminalSurfaceStreamItemV1::Snapshot { surface } => {
                     output.push_str(&surface.terminal_surface.replay)
@@ -149,8 +155,10 @@ async fn receive_until(attachment: &mut TerminalSurfaceWireAttachment, needle: &
             }
         }
     })
-    .await
-    .unwrap_or_else(|_| panic!("timed out waiting for {needle:?}"));
+    .await;
+    if result.is_err() {
+        panic!("timed out waiting for {needles:?}; received: {output:?}");
+    }
 }
 
 async fn send_hook(
@@ -165,7 +173,23 @@ async fn send_hook(
             &format!("releash-fixture-hook-json:{payload}\r"),
         )
         .unwrap();
-    receive_until(terminal, "releash-fixture-lifecycle-command-result:").await;
+    // node を終端させる Stop では、commit 後の停止 effect が結果行の出力より先に
+    // PTY を閉じることがある。stream 終了は commit 完了の証拠なので同期完了として扱う。
+    tokio::time::timeout(Duration::from_secs(10), async {
+        let mut output = String::new();
+        while !output.contains("releash-fixture-lifecycle-command-result:") {
+            match terminal.next().await {
+                Some(TerminalSurfaceStreamItemV1::Snapshot { surface }) => {
+                    output.push_str(&surface.terminal_surface.replay)
+                }
+                Some(TerminalSurfaceStreamItemV1::Output { data, .. }) => output.push_str(&data),
+                Some(_) => {}
+                None => return,
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for the lifecycle command result"));
 }
 
 async fn wait_for_execution_status(
@@ -286,6 +310,33 @@ fn leaf_nodes(execution: &AcceptanceWorkflowExecution) -> Vec<AcceptanceNodeExec
         })
         .cloned()
         .collect()
+}
+
+async fn wait_for_leaf_session_attachment(
+    host: &WorkflowControlPlaneAcceptanceHost<tauri::test::MockRuntime>,
+    execution_id: &str,
+    leaf_index: usize,
+) -> String {
+    let result = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let execution = host.execution(execution_id).await.unwrap().unwrap();
+            if let Some(agent_session_id) = leaf_nodes(&execution)
+                .get(leaf_index)
+                .and_then(|leaf| leaf.agent_session_id.clone())
+            {
+                return agent_session_id;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    match result {
+        Ok(agent_session_id) => agent_session_id,
+        Err(_) => panic!(
+            "Leaf {leaf_index} must attach an AgentSession: {:?}",
+            host.execution(execution_id).await
+        ),
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -462,10 +513,14 @@ async fn test_atui_040_autoは両signal順序と重複に依存せず後続を�
             advanced_leaves[1].status,
             AcceptanceNodeExecutionStatus::Running
         );
-        assert_ne!(
-            advanced_leaves[0].agent_session_id,
-            advanced_leaves[1].agent_session_id
-        );
+        let next_session_id = wait_for_leaf_session_attachment(&host, &execution_id, 1).await;
+        assert_ne!(next_session_id, first_session_id);
+        wait_for_agent_session_lifecycle(
+            &host,
+            &first_session_id,
+            AcceptanceAgentSessionLifecycle::Paused,
+        )
+        .await;
 
         assert!(host.submit(&first.id).await.is_err());
         let after_duplicates = host.execution(&execution_id).await.unwrap().unwrap();
@@ -1189,12 +1244,20 @@ async fn test_issue_1654_workflow完了時にproviderを停止しcheckpointか�
             terminal_owner.clone(),
         )
         .unwrap();
-    receive_until(&mut resumed_terminal, "releash-fixture-input-complete-0").await;
-
+    // 復元画面の replay は resumed fixture の起動出力で上書きされ得るため、
+    // 同期は「resumed fixture が実際に入力を消費すること」で取る。echo と marker は
+    // 同じ Snapshot / 出力 batch に載って届き得るため 1 回の accumulator で両方待つ。
     host.terminal()
         .write(terminal_owner.clone(), "follow-up-after-completion\r")
         .unwrap();
-    receive_until(&mut resumed_terminal, "follow-up-after-completion").await;
+    receive_until_all(
+        &mut resumed_terminal,
+        &[
+            "follow-up-after-completion",
+            "releash-fixture-input-complete-0",
+        ],
+    )
+    .await;
     send_hook(
         &host,
         &mut resumed_terminal,


### PR DESCRIPTION
Closes #1695

## 原因

provider Stop 受理（`ProviderLifecycleIngressUsecase::receive`）は、同一 AgentSession の operation lock と provider lifecycle slot lock を保持したまま workflow control plane を commit する。commit 末尾で同期実行される `StopWorkflowAgentSession` effect の実体 `stop_workflow_owned_preserving_checkpoint` は、先頭で同じ session の operation lock を、`release_launch_binding` で同じ slot lock を再取得するため永久待ちに入る（lock は二重に絡んでおり、片方の解消だけでは直らない）。

commit が返らないため `finish_control_plane_commit` → `start_leaves` に到達せず、Submit+Stop の auto 完了で Stop hook が completion を発火する遷移すべてで node 前進が止まり、「running のまま無 session」になっていた。

## 修正

- 停止 effect を durable commit 後に detached task で実行し（`spawn_committed_runtime_effects`）、commit を effect の完了に blocking させない。「effect は durable persist 後にのみ解放」という不変条件は維持
- 外形の変更は「旧 session 停止 → 後続 activate」の同期順序保証が落ちる一点のみ。停止は応答後ミリ秒オーダーで着火し、terminal cap（per-worktree 32 / total 64）に対して一時重なりは高々 1 のため実害はない

## テスト

- **acceptance 回帰**: `test_atui_040_auto...` に「次 node の `agent_session_id` が Some になる」「完了 session が `Paused` に到達する」を追加。従来の assertion は deadlock 前に durable になる fact projection のみを読んでおり、この deadlock に対して盲目だった（修正前 fail / 修正後 pass を確認）
- **unit 回帰**: stop port が永遠に解決しなくても Stop 受理 commit が完了することを timeout 付きで検証
- deadlock 解消で suite が 10 秒 → 5.2 秒に高速化した結果顕在化した、テスト同期の脆弱性を修正:
  - 完了 Stop では停止 effect が fixture の結果行より先に PTY を閉じ得るため、`send_hook` は stream 終了も commit 完了の証拠として同期完了扱いにする
  - resume 後の echo と入力消費 marker は同一 Snapshot / 出力 batch に載って届き得るため、`receive_until_all` で単一 accumulator により両方を待つ
- 検証: acceptance suite 20/20 連続 pass、`cargo test --locked` 全体 green、`cargo clippy -D warnings` / `cargo fmt --check` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DThbc5mkygVmpK9jQ4vYBA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ワークフロー停止処理を非同期化し、停止完了を待たずにコミットや後続セッションの開始を進められるようにしました。
  * 停止処理が失敗した場合も警告を記録して処理を継続するよう改善しました。
  * ワークフロー出力の待機精度とタイムアウト時のエラー情報を改善しました。
  * ストリーム終了やセッション接続を適切に検知できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->