### PR TITLE
feat(workflow): CLI から UI と同一の workflow diagnostics を実行できるようにする

### DIFF
--- a/docs/specs/issues-1490/behavior.md
+++ b/docs/specs/issues-1490/behavior.md
@@ -1,0 +1,122 @@
+## B-001: 指定した directory に対する CLI 診断の実行
+
+GIVEN Releash アプリが起動している
+AND 利用者が指定する directory に workflow 定義が置かれている
+WHEN 利用者が CLI の workflow diagnostics command にその directory を指定して実行する
+THEN その directory を対象とした診断結果が出力される
+AND 対象 directory が repository 内の custom workflow directory であっても診断結果が出力される
+
+## B-002: 適用済み config directory に対する CLI 診断の実行
+
+GIVEN Releash アプリが起動している
+AND 適用済み Workflow の config directory に workflow 定義が置かれている
+WHEN 利用者が CLI の workflow diagnostics command で適用済み Workflow の config directory を診断対象として実行する
+THEN その config directory を対象とした診断結果が出力される
+
+## B-003: 指定 directory を workflow source と Facet base の双方として扱う
+
+GIVEN Releash アプリが起動している
+AND 指定した directory に workflow source が置かれ、同じ directory 配下に Facet が置かれている
+WHEN 利用者が CLI の workflow diagnostics command にその directory を指定して実行する
+THEN 診断結果には、その directory 上の workflow source に対する diagnostic が含まれる
+AND 診断結果には、その directory 配下の Facet に対する diagnostic が含まれる
+AND workflow 定義が参照する Facet key は、その directory 配下の Facet を対象として解決される
+
+## B-004: config directory へ未適用の workflow 定義の診断
+
+GIVEN Releash アプリが起動している
+AND 指定した directory 上の workflow 定義と Facet が、適用済み Workflow の config directory へ適用されていない
+WHEN 利用者が CLI の workflow diagnostics command にその directory を指定して実行する
+THEN 適用済み Workflow の config directory の内容ではなく、指定した directory 上の workflow 定義と Facet に対する診断結果が出力される
+
+## B-005: UI 経路と CLI 経路の診断結果の一致
+
+GIVEN Releash アプリが起動している
+AND 同一の対象 directory に workflow 定義と Facet が置かれている
+WHEN 同じ対象 directory に対して UI から診断を実行し、CLI からも診断を実行する
+THEN 双方の診断結果は、検出された diagnostic の code が一致する
+AND 双方の診断結果は、各 diagnostic の severity、message、発生位置（対象 source、開始行、開始列、終了行、終了列）が一致する
+AND 双方の診断結果は、diagnostic の並び順が一致する
+AND 双方の診断結果は、workflow ごとの集計、Facet ごとの集計、Facet の参照元情報が一致する
+
+## B-006: JSON 出力の内容
+
+GIVEN Releash アプリが起動している
+AND 診断対象 directory が指定されている
+WHEN 利用者が CLI の workflow diagnostics command を JSON 出力を選んで実行する
+THEN 出力される JSON は、UI が受け取る診断結果と同じ構造（診断項目の一覧、workflow ごとの集計、Facet ごとの集計、Facet の参照元情報）を持つ
+AND 各診断項目は UI が受け取るものと同じ field（code、severity、stage、発生位置、message、対象 workflow 名、対象 node 名、対象 Facet key、対象 Facet 種別、対象 field）を持つ
+AND CLI でのみ付与される field は追加されない
+AND UI が受け取る field の削除や入れ子構造の再構成は行われない
+
+## B-007: JSON 以外の出力形式
+
+GIVEN Releash アプリが起動している
+AND 診断対象 directory が指定されている
+WHEN 利用者が CLI の workflow diagnostics command を JSON 出力を選ばずに実行する
+THEN 診断結果が JSON ではない人間が読める形式で出力される
+AND 検出された diagnostic がその出力に含まれる
+
+## B-008: severity error を検出したときの終了コード
+
+GIVEN Releash アプリが起動している
+AND 診断対象 directory に、severity が error の diagnostic を 1 件以上生じさせる workflow 定義または Facet が置かれている
+WHEN 利用者が CLI の workflow diagnostics command をその directory に対して実行する
+THEN CLI process は non-zero の終了コードで終了する
+
+## B-009: severity error が無いときの終了コード
+
+GIVEN Releash アプリが起動している
+AND 診断対象 directory に対する診断で severity が error の diagnostic が 1 件も生じない（severity が info の diagnostic だけが生じる場合、および diagnostic が 1 件も生じない場合を含む）
+WHEN 利用者が CLI の workflow diagnostics command をその directory に対して実行する
+THEN CLI process は終了コード 0 で終了する
+
+## B-010: --help の記載内容
+
+GIVEN CLI に workflow diagnostics command が存在する
+WHEN 利用者がその command の `--help` を表示する
+THEN 診断対象 directory の指定方法が記載されている
+AND 終了コードの意味が記載されている
+AND 出力形式が記載されている
+
+## B-011: 既存 diagnostic 規則と UI 経路の結果の維持
+
+GIVEN 本変更の前に、ある対象 directory に対して UI 経路で得られていた診断結果がある
+WHEN 本変更の後に、同じ対象 directory に対して UI から診断を実行する
+THEN 検出される diagnostic の code、severity、message は本変更の前と同一である
+AND UI が受け取る診断結果の構造と field は本変更の前と同一である
+
+## B-012: Releash アプリが起動していないときの CLI 診断
+
+GIVEN Releash アプリが起動しておらず local API へ到達できない
+WHEN 利用者が CLI の workflow diagnostics command を実行する
+THEN 診断結果は出力されない
+AND local API の起動を要する既存 CLI command と同じ失敗表示になる
+AND local API の起動を要する既存 CLI command の失敗時と同じ終了コードで終了する
+
+## B-013: 指定 directory を対象にしたときの診断範囲
+
+GIVEN Releash アプリが起動している
+AND 指定した directory 配下に workflow 定義が置かれている
+WHEN 利用者が CLI の workflow diagnostics command にその directory を指定して実行する
+THEN 診断結果には、指定した directory 配下の workflow 定義に対する diagnostic が含まれる
+AND 指定した directory 配下の workflow が参照する Facet は、その実体が指定 directory 配下に無くても判定対象に含まれる
+AND 指定した directory 配下の workflow から参照されない workflow および Facet について diagnostic は出ない
+AND 終了コードは、この判定範囲で生じた diagnostic だけで決まる
+
+## 要件IDとBehavior IDの対応表
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001 |
+| R-002 | B-001, B-002 |
+| R-003 | B-003 |
+| R-004 | B-003, B-004 |
+| R-005 | B-005 |
+| R-006 | B-005 |
+| R-007 | B-006 |
+| R-008 | B-007 |
+| R-009 | B-008, B-009 |
+| R-010 | B-010 |
+| R-011 | B-011 |
+| R-012 | B-012 |
+| R-013 | B-013 |

--- a/docs/specs/issues-1490/design.md
+++ b/docs/specs/issues-1490/design.md
@@ -1,0 +1,191 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### 診断の実行 owner を `WorkflowReadUsecase` へ移す
+
+`diagnose_all` は現在 `WorkflowUsecase`（`src-tauri/src/usecase/workflow/mod.rs:461-463`）が持ち、`WorkflowDiagnosticsGateway` も `WorkflowUsecase` の field である（同 `:191`）。一方、CLI が経由する local API は `WorkflowUsecase` を持たない。`LocalApiState` が保持するのは `WorkflowReadUsecase` と `WorkflowRuntimeUsecase` だけである（`src-tauri/src/adaptor/controller/api/mod.rs:19-23`）。
+
+Diagnostic は WorkflowDefinition の検証結果であり状態遷移を伴わない読み取りである（`docs/glossary/DOMAIN.md:144-146`）。よって `WorkflowDiagnosticsGateway` の保持と `diagnose_all` を `WorkflowReadUsecase` へ移し、`WorkflowUsecase::diagnose_all()` は `self.read` へ委譲する。
+
+これで UI（Tauri command）と local API（CLI の経路）が同一の usecase メソッドと同一の gateway 実装を通る（R-006）。
+
+#### CLI の経路は local API のみとする
+
+`src-tauri/src/cli/mod.rs:1-4` は「workflow command/query は localhost local API を正とする。アプリ未起動時は read-only query だけ backend-owned read model の file-direct fallback を許可する」と定めている。fallback は許可であって義務ではない。診断は local API 経由だけで実行し、file-direct fallback を持たない（Scope、Non-goals）。経路が 1 本なので、経路差による diagnostic の増減は生じない（B-005）。
+
+未起動時の観測結果は既存と同一にする（R-012、B-012）。`api_client::mutation`（`src-tauri/src/cli/api_client.rs:126-134`）は local API へ到達できないとき `app_must_be_running_error()`（同 `:148-150`）を返し、`CliError::Other` として終了コード `1` になる。診断もこの失敗をそのまま共有し、診断専用の失敗表現を作らない。
+
+既存の `api_client` には「read-only かつ fallback を持たない」呼び出し口が無い。`read_with_fallback`（同 `:111-123`）は fallback を要求し、`mutation` は責務が状態遷移を指す。よって local API 呼び出しの分類（`request_classified`）と、`ApiRequestError::Unavailable` を `app_must_be_running_error()` へ写す処理（`require_running`）を read / mutation いずれにも属さない内部関数として置き、その上に `mutation` と read 用の `read_without_fallback` を並べる。`mutation` を流用せず入口を 2 つに保つのは、`file_direct.rs` の冒頭が定める read / mutation の区別を CLI 側で崩さないためである。
+
+#### 診断対象は port の引数で渡す
+
+`WorkflowDiagnosticsGateway::diagnose_all` は現在引数を取らず、対象 directory は gateway 構築時に固定される（`src-tauri/src/adaptor/gateway/workflow/diagnostics_gateway.rs:14-23`、`wiring.rs:334-335,358-361`）。実行時指定（R-002）を満たすため、対象を port の引数へ移す。
+
+usecase 層に対象を表す型を置き、次の 2 つだけを表現する。
+
+- 適用済み Workflow の config directory を対象とする（gateway が構築時に保持している `workflows_dir` / `facets_base_dir` をそのまま使う）。
+- 呼び出し時に指定された directory を対象とする。
+
+指定 directory は workflow source directory として使う。Facet base は `facet.rs` を単一 owner とする解決規則により、`<dir>/facets` が directory として存在すればそこを使い、存在しなければ従来 layout の `<dir>` を使う（R-003）。
+
+適用済み config directory の path 所有者は gateway 側（`storage::workflows_dir()`、`src-tauri/src/adaptor/gateway/workflow/storage.rs:108-113`）に残る。CLI と local API handler はこの path を再計算しない。
+
+#### 指定 directory の診断範囲は起点からの到達集合とする
+
+現在の `diagnose_all`（`src-tauri/src/adaptor/gateway/workflow/diagnostics.rs:1442-1551`）は「その環境で使える全件」を列挙する。`load_all_workflows`（同 `:1649-1726`）は disk 上の定義に加えディスクと名前が衝突しない builtin workflow を必ず足し、`facet::list_facet_summaries`（`src-tauri/src/adaptor/gateway/workflow/facet.rs:215-`）は builtin facet を必ず足す。適用済み config directory を対象にする場合、builtin は実体が無くても `include_str!` で使えるためこの列挙は正しい。
+
+指定 directory を対象にする場合は起点が異なる。診断が答えるのは「指定 directory の workflow が動くか」であり、判定範囲は指定 directory 配下の workflow 定義を起点として、そこから到達する Facet までである（R-013、B-013）。起点から到達しない workflow と Facet は結果に出さない。Facet 側の列挙には全件列挙ではなく既存の `collect_referenced_facet_keys`（`diagnostics.rs:1570-`）と同じ到達集合を使う。
+
+到達判定と解決規則は変えない。`facet::facet_exists`（`facet.rs:133-`）は builtin facet を常に true とし、`facet::load_facet`（同 `:118-131`）は base_dir に実体が無ければ builtin へフォールバックする。指定 directory の workflow が builtin facet を参照していれば実行時に解決されるので、診断でも解決成功として扱い、その Facet 本文も判定範囲に入る。ここを変えると、実行できる workflow を診断が error にする。
+
+切り替えるのは診断対象の列挙だけで、各対象へ適用する診断規則、diagnostic code、severity、message は変えない（R-011、B-011）。適用済み config directory を対象にする経路の結果は本変更の前後で同一である。
+
+到達集合に入った Facet は、diagnostic が 1 件も出なくても `facet_summaries` に 0 件の entry を持つ。呼び出し側が「判定対象に入った Facet」と「起点から到達せず判定対象外だった Facet」を区別できる必要があるためである（B-013）。適用済み config directory を対象にする場合はこの entry を作らない。そちらは全件列挙なので判定対象と非対象の区別が生じず、entry を足すと既存の出力が変わる（R-011）。
+
+disk 上の workflow を読み込む経路に置かない処理がひとつある。`facet::resolve_workflow_facets` の呼び出しは戻り値を捨てており、解決結果は診断のどの判定にも使われない。Facet 参照の検査は `facet_exists` を通る到達集合の側が行う。
+
+#### 主要な変更対象
+
+| path | 変更の要旨 |
+| --- | --- |
+| `src-tauri/src/usecase/workflow/ports.rs` | `WorkflowDiagnosticsGateway` に対象引数を追加し、対象を表す型を定義する |
+| `src-tauri/src/usecase/workflow/mod.rs` | `WorkflowReadUsecase` が diagnostics gateway を保持し `diagnose_all(target)` を持つ。`WorkflowUsecase::diagnose_all()` は委譲に変わる |
+| `src-tauri/src/adaptor/gateway/workflow/diagnostics_gateway.rs` | 対象から `workflows_dir` / `facets_base_dir` を解決する |
+| `src-tauri/src/adaptor/protocol/workflow.rs` | 診断 DTO（`DiagnosticReport` / `DiagnosticItem` / `DiagnosticSpan` / `DiagnosticSummary` / `FacetUsageEntry` / `Severity` / `DiagnosticStage`）を wire model として置く |
+| `src-tauri/src/adaptor/gateway/workflow/diagnostics.rs`、`span_map.rs` | 診断 DTO の構築を所有する。対象種別に応じて診断対象の列挙を全件と到達集合で切り替える |
+| `src-tauri/src/adaptor/controller/wiring.rs` | `WorkflowReadUsecase` の構築（`build_canonical_workflow_read_usecase` を含む）へ diagnostics gateway を配線する |
+| `src-tauri/src/adaptor/controller/command/workflow/diagnostics.rs` | `diagnose_all_cmd` へ optional な対象 directory 引数を足す |
+| `src-tauri/src/adaptor/controller/api/workflow.rs` | 診断 endpoint を追加する |
+| `src-tauri/src/cli/workflow.rs`、新設 `src-tauri/src/cli/diagnostics.rs` | subcommand 定義と、対象解決・出力整形・終了コード導出 |
+| `src-tauri/src/cli/api_client.rs` | 診断 endpoint の client と、fallback を持たない read 用の呼び出し口を足す |
+| `src-tauri/src/cli/common.rs`、`src-tauri/src/cli/mod.rs` | CLI の成功値に終了コードを載せる |
+| `src-tauri/src/infrastructure/local_api/client.rs` | query が空のとき URL へ `?` を付けない |
+| `src-tauri/src/adaptor/controller/wiring.rs`、新設 `src-tauri/src/workflow_diagnostics_acceptance.rs` | 両経路を実 HTTP で突き合わせる acceptance harness と、その composition 入口 |
+
+### Interface
+
+#### CLI
+
+```
+releash workflow diagnostics [--dir <PATH>] [--json]
+```
+
+- `--dir` は診断対象の workflow source directory。Facet base は `<dir>/facets` が directory として存在すればそこを使い、存在しなければ `<dir>` を使う。省略時は適用済み Workflow の config directory を対象にする（B-002）。省略可能である必要があるため位置引数ではなく named flag にする。
+- `--json` は既存 subcommand と同じ bool flag。
+- 終了コード: `0`（severity error が 0 件）、`3`（severity error が 1 件以上）、および既存の `1` / `2` / `4`（command 自体の失敗）。
+
+#### Tauri command
+
+`diagnose_all_cmd` へ対象 directory を表す optional 引数を足す。省略時は適用済み Workflow の config directory を対象にし、戻り値の JSON shape は変えない。引数なしの既存呼び出し（`src/hooks/useAutomation.ts:58,82`）が返す結果は本変更の前後で同一である（R-011、B-011）。
+
+UI 経路と CLI 経路の双方が対象 directory を受け取るため（R-002）、B-005 / B-011 を両経路の入口から観測して判定できる。
+
+#### local API
+
+```
+GET /v1/workflow/diagnostics?dir=<absolute path>
+```
+
+- `dir` は省略可能。省略時は適用済み config directory を対象にする。
+- response body は `DiagnosticReport` の JSON をそのまま返す。envelope で包まない（既存 read endpoint が DTO を直接返す形と同じ）。
+- `dir` が空文字列または相対 path の場合は `ApiError::invalid_request`。query 型は既存 router と同じく `deny_unknown_fields` にする。
+- `dir` が存在しない場合は `404 not_found`、directory ではない場合または列挙できない場合は既存の `WorkflowError::External` mapping により `500 workflow_error` とする。対象検査は gateway の Directory 分岐で共有する。
+
+#### 内部境界
+
+- `WorkflowDiagnosticsGateway` — 指定された対象 directory に対する診断結果 JSON を返す port。対象の解決規則（適用済み config directory がどこか）は実装側が所有する。
+- `WorkflowReadUsecase::diagnose_all(target)` — UI（Tauri command）と local API が共有する唯一の診断呼び出し口。戻り値型は既存どおり `Result<serde_json::Value, WorkflowError>` を保つ（R-007、R-011）。
+
+### Data Model
+
+- 新しい永続 record はない。`DiagnosticReport` / `DiagnosticItem` / `DiagnosticSummary` / `FacetUsageEntry` / `DiagnosticSpan` の field 構成、serde 属性、serialize 結果は変更しない（R-011、B-006、B-011）。
+- 診断 DTO は `adaptor/protocol/` に置く。CLI と Tauri command の双方が同じ型で読むためであり、複数の入口が共有する view 型の置き場所は `docs/architecture/CONTROLLER.md` が protocol と定めている。DTO の構築（`serde_saphyr` の位置情報から span を作る、`DiagnosticItem` を組み立てる）は外部世界を診断語彙へ写す変換なので gateway が所有し、protocol へは持ち込まない。
+- CLI の human-readable 描画と error 件数の集計を型の上で行うため、上記 DTO へ `Deserialize` を追加する。`skip_serializing_if = "Option::is_none"` が付いている field には `serde(default)` を対にする必要がある。追加は逆方向の変換だけで、serialize 側の出力には影響しない。
+- `--json` 出力は、経路から受け取った `serde_json::Value` を無加工でそのまま出す。描画のために typed へ戻した値を再 serialize しない（R-007、B-006）。
+- 診断対象を表す型は usecase 層に置く値であり、永続化も versioning も持たない。
+
+### Database
+
+該当なし。
+
+### UI/UX
+
+#### human-readable 出力
+
+`--json` を付けない場合、次を出す（B-007）。
+
+- diagnostic 1 件につき 1 行。severity、code、発生位置、message、対象（workflow 名、または facet 種別と key）を含める。`span` を持たない item は位置欄を省く。
+- 末尾に severity 別の件数（error 件数と info 件数）を出す。
+
+#### `--help` の記載
+
+`releash workflow diagnostics --help` に次を書く（R-010、B-010）。
+
+- `--dir` の意味。指定 directory を workflow source として扱い、Facet base は `<dir>/facets` が directory として存在すればそこを、存在しなければ `<dir>` を使うこと。省略時は適用済み config directory が対象になること。
+- 出力形式。既定は human-readable、`--json` で `DiagnosticReport` の JSON を出すこと。
+- 終了コードの意味。`0` / `3` と、既存の失敗コードの区別。
+
+#### UI 側
+
+Settings の Automation セクションと `useAutomation` は変更しない（Non-goals）。`diagnose_all_cmd` の対象 directory 引数は省略可能であり、引数なしの既存 invoke は適用済み config directory を対象にし続ける。
+
+### Algorithm
+
+#### 終了コードの導出
+
+report の `items` を走査し、severity が error の item が 1 件以上あれば `3`、それ以外（info のみ、および 0 件）は `0` とする（B-008、B-009）。
+
+`workflow_summaries` / `facet_summaries` の `error_count` を合算しない。`add_diagnostic_to_workflow_and_facet`（`src-tauri/src/adaptor/gateway/workflow/diagnostics.rs:2093-2104`）が 1 件の item を workflow 側と facet 側の両方の summary へ計上するため、summary の合算では二重計上になり件数が実体と一致しない。
+
+#### 成功したまま非 zero で終える経路
+
+現在の CLI は `Result<String, CliError>` を `cli_result_exit_code`（`src-tauri/src/cli/common.rs:3-29`）へ渡し、`Ok` は必ず `0` になる。「command は成功したが診断 error があった」を表現できないため、CLI の成功値を stdout と終了コードの組に変え、`cli_result_exit_code` の入力型をそれに合わせる。既存 subcommand は終了コード `0` を持つ成功値へ写像し、`1` / `2` / `4` の対応表は変えない。
+
+診断 error の検出には未使用の `3` を割り当てる。`1`（`Other`）を再利用すると、I/O 失敗や serialize 失敗と「定義に error がある」が同じコードになり区別できなくなる。
+
+#### `--dir` の解決と検証
+
+CLI 入口で、`--dir` の値を process の cwd 基準で絶対 path へ解決し、存在しなければ `CliError::NotFound` として弾く。gateway は Directory target を診断する直前に `read_dir` を 1 回行い、directory の type と列挙可否を検証する。
+
+- R-013 により指定 directory の診断は配下の workflow 定義を起点とするため、存在しない directory を渡すと起点が 0 件になり「診断対象なし・error 0 件」として終了コード `0` になる。typo と正常終了が区別できないので入口で弾く。`ensure_existing_data_dir`（`src-tauri/src/cli/common.rs:74-82`）が同じ理由で既に置かれており、その扱いに揃える。
+- 絶対化は CLI 入口で行う。local API へは絶対 path だけを渡すため、診断対象が local API を提供するアプリ process の cwd に依存しない。
+- gateway の `read_dir` が `NotFound` を返した場合は `WorkflowError::NotFound`、それ以外の I/O error（regular file の指定、権限不足など）は `WorkflowError::External` へ写す。CLI ではそれぞれ終了コード `4` と `1` になる。
+- 入口検証は local API への到達より先に効く。アプリが起動しておらず、かつ `--dir` が存在しない場合の終了コードは `4` であって `1` ではない。R-012 が求めるのは「診断のために新しい失敗表現を作らないこと」であり、入力そのものが不正な場合まで未起動の失敗へ寄せることではない。到達可否より先に入力を弾くことで、アプリの起動状態によって同じ typo の観測結果が変わらない。
+
+### Infra
+
+該当なし。
+
+## Alternatives Considered
+
+- **port の signature を変えず、対象ごとに gateway を新規構築する**: local API handler と CLI がリクエストごとに `WorkflowDiagnosticsFileGateway` を組み立てることになり、composition root の責務（`docs/architecture/CONTROLLER.md`）が handler へ散る。加えて、適用済み config directory の path を CLI 側が再計算する必要が生じ、path の所有者が二重化する。採らない。
+- **CLI を local API 経由にせず、常に in-process で診断する**: `src-tauri/src/cli/mod.rs:1-4` の「workflow command/query は local API を正とする」に反する。適用済み config directory を対象にする場合、その directory の所有者は起動中のアプリである。採らない。
+- **local API を一次経路にしつつ read-only の file-direct fallback を併設する**: `cli/mod.rs:1-4` は read-only query への fallback を許可しているため実装は可能だが、Scope が local API 経由の対応だけに限定されている。fallback を持つと未起動時に診断結果が返り、R-012 の「既存 CLI command と同じ失敗」を満たせない。採らない。
+- **usecase port の戻り値を typed な `DiagnosticReport` にする**: `DiagnosticReport` は adaptor 層の型であり、usecase 層の port から名指しできない。既存どおり `serde_json::Value` を保つ。
+- **診断 error の検出に既存の終了コード `1` を再利用する**: command 自体の失敗と診断結果が同じコードになり、CI から両者を区別できない。採らない。
+
+## Cross-cutting concerns
+
+### 任意 directory を読む read endpoint を local API へ足すことの扱い
+
+新設 endpoint は、呼び出し元が指定した directory 配下の workflow source と Facet を読み、その内容に由来する message を返す。到達できるのは master token を持つ呼び出し元だけであり、master token は renderer JS へ渡さない既存構成を変えない（terminal router だけが別 token を受理する、`src-tauri/src/adaptor/controller/api/mod.rs:45-56`）。master token を持つのは同一ユーザーの local process（CLI）であり、その process は元から同じ file 権限を持つため、権限の拡大は生じない。
+
+### 検証手段が自明でない受入条件
+
+- B-005（UI 経路と CLI 経路の一致）: 同一の一時 directory を対象 directory として UI 経路（`diagnose_all_cmd`）と CLI 経路の双方へ渡し、返る診断結果を比較する。両経路が対象 directory を引数で受けるため、内部 usecase を直接呼ばずに経路の入口から比較できる。
+- B-008 / B-009（終了コード）: 終了コード導出を report 値からの純粋関数として分離し、error あり / info のみ / 0 件の 3 入力で確認する。
+- local API 経由の経路（実 HTTP 通信）は `src-tauri/tests/` の統合テストで確認する（`docs/architecture/TEST.md` 統合テスト）。harness は `#[cfg(debug_assertions)]` の acceptance module に置き、`wiring::build_workflow_services_with_gateways` へ harness 用の gateway を渡して UI 経路の usecase を組む。test 専用の fake gateway を debug ビルドへ広げない。既存の `workflow_control_plane_acceptance` / `provider_lifecycle_acceptance` と同じ作法である。
+- B-012（未起動時）: local API の discovery file が無い状態で診断 command を実行し、local API の起動を要する既存 CLI command と同じ失敗表示および同じ終了コードになることを確認する。
+
+### 互換境界
+
+- Tauri command（`diagnose_all_cmd`）の名前、引数、戻り値の JSON shape は変えない。
+- 既存 local API endpoint と既存 CLI subcommand の入出力および終了コードは変えない。
+- `WorkflowDiagnosticsGateway` は crate 内部の port であり、外部契約ではないため移行手段は要らない。
+
+## Risks
+
+- `DiagnosticReport.items` の並びは `load_all_workflows` の `read_dir` 列挙順に依存しており（`diagnostics.rs:1657`）、実装は順序を明示的に固定していない。B-005 は「diagnostic の並び順が一致する」を求めるが、順序を固定する変更は UI 経路の出力順も変えるため R-011 / B-011 と衝突しうる。同一 directory を同一 filesystem 状態で読む限り両経路の順序は一致するという前提で設計しており、この前提が成立しない場合は順序固定の可否を Requirements 側の判断として確認する必要がある。

--- a/docs/specs/issues-1490/requirements.md
+++ b/docs/specs/issues-1490/requirements.md
@@ -1,0 +1,132 @@
+# Context
+
+- 要求の正本は GitHub Issue #1490「CLIからUIと同一のworkflow diagnosticsを実行できるようにする」（https://github.com/siro33950/releash/issues/1490 、state: OPEN、label なし、milestone なし、comment なし）。Issue 本文以外の URL、添付、関連 Issue の参照はない。追加の自由文指示もない。
+- Spec の配置先は `docs/specs/issues-1490`。
+- workflow 診断の実体は `diagnostics::diagnose_all(workflows_dir, facets_base_dir)`（`src-tauri/src/adaptor/gateway/workflow/diagnostics.rs:1442`）である。workflow source の parse と shape 検査、`ValidationError` 由来の resolve / typecheck / control-flow 検査、Facet 解決、facet 本文の template 検査、diagnostic code への mapping を、この一箇所がまとめて行う。
+- 診断結果 DTO は `DiagnosticReport`（`src-tauri/src/adaptor/gateway/workflow/diagnostics.rs:118-126`）で、`items` / `workflow_summaries` / `facet_summaries` / `facet_usage` を持つ。`DiagnosticSummary` は同 `:112-115`、`FacetUsageEntry` は同 `:129-133`。`DiagnosticItem`（同 `:34-56`）は `code`、`severity`（同 `:28-31` の `error` / `info`）、`stage`（同 `:60-64`）、`span`（`src-tauri/src/adaptor/gateway/workflow/span_map.rs:7-14` の `source` / `start_line` / `start_col` / `end_line` / `end_col`）、`message`、`workflow_name`、`node_name`、`facet_key`、`facet_kind`、`field` を持つ。frontend は同じ形を `DiagnosticReport`（`src/types/workflow.ts:278-283`）として受ける。
+- `AGENTS.md` の「アーキテクチャ原則」により、アプリケーションロジックは Rust が所有する。入口は Tauri command（`adaptor/controller/command/`）、loopback HTTP local API（`adaptor/controller/api/`）、CLI（`cli/`）の 3 つで、同じ usecase を共有する。
+- `src-tauri/src/cli/mod.rs:1-4` は CLI の経路規約として「workflow command/query は localhost local API を正とする。アプリ未起動時は read-only query だけ backend-owned read model の file-direct fallback を許可する」と定めている。fallback 実装は `src-tauri/src/cli/file_direct.rs`。
+- `docs/glossary/DOMAIN.md:144-146` は Diagnostic を「WorkflowDefinition の parse、shape、resolve、typecheck、control-flow の検証結果であり、実行木や NodeExecution の lifecycle state ではない」と定めている。
+- 現在状態の確認は、worktree 内コードの読解と `releash workflow --help` の実行によって行った。Releash アプリを起動しての UI 動作確認は行っていない。UI 経路の出力形は、`diagnose_all_cmd` が素通しする `diagnostics::diagnose_all` の既存テストで確認した。
+
+# Outcome
+
+対象者は、repository 内で workflow 定義（`workflows/*.yml` と `workflows/facets/{instructions,policies,knowledge}/*.md`）を書く開発者、および同じ定義を扱う agent である。
+
+現在、workflow 定義の正式な診断は Releash の UI からしか実行できない。診断対象は適用済みの config directory に固定されているため、repository 内で書いた custom workflow を検証するには、いったん config directory へ適用したうえでアプリを起動し、Settings を開く必要がある。適用前に手元で行えるのは `yq` などによる YAML 構文 parse までで、WFS002 のような workflow shape error、schema 宣言と参照の不整合、Facet 参照の欠落、template 変数と input 宣言の不一致は検出できない。
+
+変更後は、CLI から診断対象 directory を指定して、UI と同一の診断を実行できる。同じ入力に対して UI と CLI は同じ diagnostic code、severity、message、location、順序を返し、CLI は診断 error の有無を終了コードで表す。開発者と agent は、config directory へ適用する前に、repository 内の workflow directory をそのまま正式検証できる。
+
+CLI の診断は Releash アプリが公開する local API を経由して実行するため、アプリの起動を要する。アプリが起動していない場合の観測結果は、local API の起動を要する既存 CLI command と同じにする。
+
+# Current Behavior
+
+## UI 経路
+
+Settings の Automation セクションが `useAutomation` を通じて `diagnose_all_cmd` を invoke する（`src/hooks/useAutomation.ts:58`、`:82`、表示は `src/components/panels/AutomationSection.tsx`）。呼び出しの連鎖は次のとおりである。
+
+1. `diagnose_all_cmd`（`src-tauri/src/adaptor/controller/command/workflow/diagnostics.rs:5-14`、登録は `src-tauri/src/adaptor/controller/command/workflow/mod.rs:52,98`）が `spawn_blocking` 内で
+2. `WorkflowUsecase::diagnose_all`（`src-tauri/src/usecase/workflow/mod.rs:461-463`）を呼び、
+3. `WorkflowDiagnosticsGateway::diagnose_all`（`src-tauri/src/usecase/workflow/ports.rs:83-85`）へ委譲し、
+4. `WorkflowDiagnosticsFileGateway`（`src-tauri/src/adaptor/gateway/workflow/diagnostics_gateway.rs:9-33`）が `diagnostics::diagnose_all` を呼び、`DiagnosticReport` を `serde_json::to_value` で serialize して返す。
+
+usecase の戻り値は `serde_json::Value` であり、DTO の serialize は gateway 境界で完了している。Tauri command はその値を素通しする。
+
+## 診断対象 directory が config directory に固定されている
+
+`WorkflowDiagnosticsFileGateway` は `workflows_dir` と `facets_base_dir` を construction 時に受け取り（`src-tauri/src/adaptor/gateway/workflow/diagnostics_gateway.rs:14-23`）、`diagnose_all` は引数を取らない（`src-tauri/src/usecase/workflow/ports.rs:84`）。composition は両方に `WorkflowDefinitionFileRepository::default_workflows_dir()` を渡している（`src-tauri/src/adaptor/controller/wiring.rs:334-335,358-361`）。その値は `storage::workflows_dir()`（`src-tauri/src/adaptor/gateway/workflow/storage.rs:108-113`）が返す `<config_dir>/releash/workflows` である。
+
+診断対象を実行時に切り替える入口はない。repository 内の `workflows/` を対象に診断する経路も存在しない。
+
+## 診断内容
+
+`diagnose_all`（`src-tauri/src/adaptor/gateway/workflow/diagnostics.rs:1442-1551`）は次を行う。
+
+- `facets_base_dir` から `policies` / `knowledge` / `instructions` の全 Facet key を収集する。
+- `workflows_dir` 上の workflow source を全件走査して診断し、ディスク上の定義と名前が衝突しない builtin workflow を追加で診断対象にする（`load_all_workflows`、同 `:1649-1726`）。
+- 各 Facet について key 命名規則（FAC001）、builtin である旨の info（FAC000）、template 変数、workflow 側 input 宣言との突合を検査する。
+
+diagnostic code は parse / shape 系（WFS001、WFS002、WFS006、WFS008 など）、resolve 系（WFR001 など）、typecheck 系（WFT001 など）、control-flow 系（WFC004 など）、Facet 系（FAC000、FAC001）に分かれる。`ValidationError` から code への mapping も同ファイルが持つ（同 `:1180-1240`）。schema 宣言の不正は `InvalidSchemaKind::InvalidDeclaration` を経由して WFS002 になる（同 `:1218`、判定は `src-tauri/src/domain/workflow/services/validation.rs:1370-1470`）。
+
+## CLI に診断入口がない
+
+CLI の top command は Workflow / Review / Hook の 3 つで（`src-tauri/src/cli/mod.rs:32-49`）、`releash workflow` の subcommand は `status` と `output`（`submit` / `get`）だけである（`src-tauri/src/cli/workflow.rs:12-25`、dispatch は `src-tauri/src/cli/mod.rs:120-145`）。`src-tauri/src/cli/` 配下に diagnostics を呼ぶコードはない。
+
+Issue 本文は既存の確認手段として `releash workflow list` を挙げているが、`workflow list` subcommand は現在の CLI に存在しない。
+
+## local API に診断 endpoint がない
+
+local API の workflow router（`src-tauri/src/adaptor/controller/api/workflow.rs:50-93`）が公開しているのは、workflow 一覧、execution の一覧・作成・取得・log・approve・abort・stop・resume・retry、node execution の submit、artifact の validate・get である。diagnostics の endpoint はない。
+
+## CLI の終了コード規則
+
+`cli_result_exit_code`（`src-tauri/src/cli/common.rs:3-29`）は、成功で 0、`CliError::InvalidInput` で 2、`CliError::NotFound` で 4、`CliError::Other` で 1 を返す。処理そのものは成功したうえで、結果の内容（診断 error の有無など）に応じて終了コードを変える経路はない。
+
+## 再現手順
+
+1. repository 内の `workflows/` に、schema 宣言が不正な workflow 定義（例: `properties` 配下に不正な宣言を置いたもの）を追加する。
+2. `releash workflow --help` を実行する。実際の出力は次のとおりで、診断を実行する subcommand はない。
+
+```
+workflow command / query サブコマンド。
+
+Usage: releash workflow <COMMAND>
+
+Commands:
+  status  指定 execution の現在 read model を表示する。
+  output  node の Artifact に対する typed CLI 入口。
+
+Options:
+  -h, --help  Print help
+```
+
+3. そのため手元で行えるのは `yq` などによる YAML 構文 parse までで、WFS002 は検出されない。
+4. 同じ定義を `<config_dir>/releash/workflows` へ配置し、Releash を起動して Settings の Automation を開くと、`diagnose_all_cmd` の結果として WFS002 が表示される。`diagnose_all_cmd` は `diagnostics::diagnose_all` の結果を serialize して素通しするため、この項目に付く値は既存テスト `test_診断_yamlとluaの不正permissionは同じwfs002でfield位置を示す`（`src-tauri/src/adaptor/gateway/workflow/diagnostics.rs:2304-2332`）で確認できる。同テストは不正な宣言に対し `code = "WFS002"`、`stage = ParseShape`、`field = Some("permission")`、`span.start_line = 7` を assert している。
+
+# Scope / Non-goals
+
+## Scope
+
+- CLI から workflow diagnostics を実行する入口の追加。
+- local API への workflow diagnostics endpoint の追加。CLI はこの endpoint を経由して診断する。
+- 診断対象 directory を実行時に指定できるようにすること（workflow source と Facet base の双方）。
+- CLI の診断結果出力（human-readable および JSON）と終了コード。
+- CLI の `--help` 記載内容。
+- UI と CLI が同じ usecase、同じ `WorkflowDiagnosticsGateway`、同じ診断実装を共有する構成。
+
+## Non-goals
+
+- workflow diagnostics の既存規則、diagnostic code、severity、message、span の変更。
+- UI 専用または CLI 専用の診断規則の追加。
+- CLI の file-direct fallback（`src-tauri/src/cli/file_direct.rs`）へ診断を追加すること。診断はアプリ起動中の local API 経由だけで実行する。
+- CLI による診断結果の自動修正。
+- UI 側の診断表示（`AutomationSection` / `SettingsModal`）の変更。
+- diagnostics 以外の CLI subcommand の変更。
+- workflow 定義構文そのものの変更。
+- 診断以外の workflow 操作（適用、実行、保存）を CLI へ追加すること。
+
+# Requirements
+
+- R-001: CLI から workflow diagnostics を実行できる command を提供する。
+- R-002: UI 経路と CLI 経路の双方が、診断対象として、適用済み Workflow の config directory と、利用者が指定した directory の双方を扱える。指定できる directory には repository 内の custom workflow directory を含む。
+- R-003: 指定した directory を workflow source directory として扱う。Facet base は `<dir>/facets` が directory として存在すればそこを使い、存在しなければ `<dir>` を使う。
+- R-004: 指定した directory 配下の Facet を含めて診断する。対象 workflow が config directory へ適用されていない状態でも診断できる。
+- R-005: 同一の対象 directory に対して、CLI が返す診断結果は UI が受け取る `DiagnosticReport` と、diagnostic code、severity、message、location（span）、`items` の順序、workflow summary、facet summary、facet usage のすべてにおいて一致する。
+- R-006: UI と CLI は同じ Rust usecase と同じ `WorkflowDiagnosticsGateway` を経由して診断を実行する。parse、schema 検証、routing 検証、Facet 解決、template 検証、diagnostic mapping を CLI 側へ再実装しない。CLI 経路に診断規則の分岐や複製を持たない。
+- R-007: JSON 出力を選んだ場合、CLI は UI が受け取るものと同じ `DiagnosticReport` DTO をそのまま serialize した JSON を出力する。CLI 固有の field 追加や再構成を行わない。
+- R-008: JSON 出力を選ばない場合、CLI は human-readable な形式で診断結果を出力する。
+- R-009: 診断を実行できたとき、severity が `error` の diagnostic が 1 件以上あれば CLI process は non-zero の終了コードで終了し、`error` が 0 件であれば 0 で終了する。
+- R-010: CLI の `--help` に、診断対象 directory の指定方法、終了コードの意味、出力形式を記載する。
+- R-011: 既存の diagnostic 規則、diagnostic code、severity、message、および `DiagnosticReport` の wire shape を変更しない。UI 経路（`diagnose_all_cmd`）が返す結果は、本変更の前後で同一である。
+- R-012: Releash アプリが起動しておらず local API へ到達できないとき、CLI の診断 command は診断結果を出力せず、local API の起動を要する既存 CLI command と同じ失敗表示および同じ終了コードで終了する。本変更で新しい失敗表現を追加しない。
+- R-013: 指定した directory を対象にする場合、診断は指定 directory 配下の workflow 定義を起点とし、そこから実行時と同じ解決規則で到達する Facet を含めて判定する。起点から到達しない workflow および Facet について diagnostic を出さない。適用済み Workflow の config directory を対象にする場合の診断範囲は変更しない。
+
+# Assumptions / Open Questions
+
+## Assumptions
+
+なし。
+
+## Open Questions
+
+なし。

--- a/src-tauri/src/adaptor/controller/api/workflow.rs
+++ b/src-tauri/src/adaptor/controller/api/workflow.rs
@@ -14,6 +14,7 @@ use crate::usecase::workflow::command::{
     StartExecutionCommand, StopExecutionCommand, SubmitOutputArtifact, SubmitOutputCommand,
 };
 use crate::usecase::workflow::dto::{WorkflowExecutionSummaryDto, WorkflowSummaryDto};
+use crate::usecase::workflow::ports::WorkflowDiagnosticsTarget;
 
 use super::error::ApiError;
 use super::protocol::{
@@ -37,6 +38,13 @@ struct ExecutionListQuery {
     limit: Option<u64>,
     #[serde(default)]
     offset: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DiagnosticsQuery {
+    #[serde(default)]
+    dir: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -92,6 +100,7 @@ pub(super) fn router() -> Router<LocalApiState> {
             "/v1/workflow/executions/{execution_id}/artifacts/{node}",
             get(get_artifact),
         )
+        .route("/v1/workflow/diagnostics", get(diagnose_workflows))
 }
 
 async fn list_workflows(
@@ -100,6 +109,17 @@ async fn list_workflows(
     let workflow = state.workflow;
     let summaries = blocking(move || workflow.list_workflow_summaries()).await?;
     Ok(Json(summaries))
+}
+
+async fn diagnose_workflows(
+    State(state): State<LocalApiState>,
+    query: Result<Query<DiagnosticsQuery>, QueryRejection>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let Query(query) = query.map_err(|error| ApiError::invalid_request(error.body_text()))?;
+    let target = WorkflowDiagnosticsTarget::from_optional_directory(query.dir)?;
+    let workflow = state.workflow;
+    let report = blocking(move || workflow.diagnose_all(target)).await?;
+    Ok(Json(report))
 }
 
 async fn list_executions(
@@ -328,6 +348,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::adaptor::controller::api::test_support::{get_json, test_router};
 
     #[test]
     fn parses_public_filter_and_origin_vocabulary() {
@@ -356,5 +381,133 @@ mod tests {
         );
         assert!(parse_page(Some(0), None).is_err());
         assert!(parse_page(Some(MAX_PAGE_LIMIT + 1), None).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_診断api_queryを検証して共通reportを返す() {
+        // Given
+        let data = tempfile::tempdir().unwrap();
+        let workflows = tempfile::tempdir().unwrap();
+        std::fs::write(workflows.path().join("custom.yml"), "name: [").unwrap();
+        let (router, _, _) = test_router(data.path(), "secret");
+
+        // When
+        let applied = get_json(&router, "/v1/workflow/diagnostics").await;
+
+        // Then
+        assert_eq!(applied.0, StatusCode::OK);
+        assert!(applied.1["items"].is_array());
+        for field in ["workflow_summaries", "facet_summaries", "facet_usage"] {
+            assert!(applied.1[field].is_object());
+        }
+
+        let encoded_dir: String =
+            url::form_urlencoded::byte_serialize(workflows.path().as_os_str().as_encoded_bytes())
+                .collect();
+        let specified = get_json(
+            &router,
+            &format!("/v1/workflow/diagnostics?dir={encoded_dir}"),
+        )
+        .await;
+        assert_eq!(specified.0, StatusCode::OK);
+        assert!(specified.1["workflow_summaries"]["custom"].is_object());
+
+        for uri in [
+            "/v1/workflow/diagnostics?dir=",
+            "/v1/workflow/diagnostics?dir=relative/path",
+            "/v1/workflow/diagnostics?unknown=1",
+        ] {
+            let response = get_json(&router, uri).await;
+            assert_eq!(response.0, StatusCode::BAD_REQUEST, "uri: {uri}");
+        }
+
+        let unauthorized = router
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/workflow/diagnostics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_診断api_存在しない指定directoryをnot_foundにする() {
+        // Given
+        let data = tempfile::tempdir().unwrap();
+        let missing = data.path().join("missing");
+        let (router, _, _) = test_router(data.path(), "secret");
+        let encoded_dir: String =
+            url::form_urlencoded::byte_serialize(missing.as_os_str().as_encoded_bytes()).collect();
+
+        // When
+        let response = get_json(
+            &router,
+            &format!("/v1/workflow/diagnostics?dir={encoded_dir}"),
+        )
+        .await;
+
+        // Then
+        assert_eq!(response.0, StatusCode::NOT_FOUND);
+        assert_eq!(response.1["code"], "not_found");
+        assert_eq!(
+            response.1["message"],
+            format!("directory does not exist: {}", missing.display())
+        );
+        assert!(response.1.get("items").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_診断api_通常fileの指定をinternal_errorにする() {
+        // Given
+        let data = tempfile::tempdir().unwrap();
+        let file = data.path().join("workflow.yml");
+        std::fs::write(&file, "name: workflow").unwrap();
+        let (router, _, _) = test_router(data.path(), "secret");
+        let encoded_dir: String =
+            url::form_urlencoded::byte_serialize(file.as_os_str().as_encoded_bytes()).collect();
+
+        // When
+        let response = get_json(
+            &router,
+            &format!("/v1/workflow/diagnostics?dir={encoded_dir}"),
+        )
+        .await;
+
+        // Then
+        assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.1["code"], "workflow_error");
+        assert!(response.1.get("items").is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_診断api_列挙不能な指定directoryをinternal_errorにする() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Given
+        let data = tempfile::tempdir().unwrap();
+        let unreadable = data.path().join("unreadable");
+        std::fs::create_dir(&unreadable).unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let (router, _, _) = test_router(data.path(), "secret");
+        let encoded_dir: String =
+            url::form_urlencoded::byte_serialize(unreadable.as_os_str().as_encoded_bytes())
+                .collect();
+
+        // When
+        let response = get_json(
+            &router,
+            &format!("/v1/workflow/diagnostics?dir={encoded_dir}"),
+        )
+        .await;
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        // Then
+        assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.1["code"], "workflow_error");
+        assert!(response.1.get("items").is_none());
     }
 }

--- a/src-tauri/src/adaptor/controller/api/workflow.rs
+++ b/src-tauri/src/adaptor/controller/api/workflow.rs
@@ -492,6 +492,13 @@ mod tests {
         let unreadable = data.path().join("unreadable");
         std::fs::create_dir(&unreadable).unwrap();
         std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::read_dir(&unreadable).is_ok() {
+            std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+            eprintln!(
+                "skipping unreadable directory test because this process can read mode 0o000"
+            );
+            return;
+        }
         let (router, _, _) = test_router(data.path(), "secret");
         let encoded_dir: String =
             url::form_urlencoded::byte_serialize(unreadable.as_os_str().as_encoded_bytes())

--- a/src-tauri/src/adaptor/controller/command/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/controller/command/workflow/diagnostics.rs
@@ -1,13 +1,26 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::adaptor::controller::state::AppState;
 
 #[tauri::command]
 pub async fn diagnose_all_cmd(
     state: tauri::State<'_, AppState>,
+    dir: Option<String>,
 ) -> Result<serde_json::Value, String> {
-    let usecase = state.workflow_usecase.clone();
-    tokio::task::spawn_blocking(move || usecase.diagnose_all().map_err(|e| e.to_string()))
+    diagnose_all_impl(&state.workflow_usecase, dir).await
+}
+
+/// 内部経路。Tauri command 側は injected state を受け取り本関数に委譲する。
+pub(crate) async fn diagnose_all_impl(
+    usecase: &Arc<crate::usecase::workflow::WorkflowUsecase>,
+    dir: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let target =
+        crate::usecase::workflow::ports::WorkflowDiagnosticsTarget::from_optional_directory(dir)
+            .map_err(|e| e.to_string())?;
+    let usecase = usecase.clone();
+    tokio::task::spawn_blocking(move || usecase.diagnose_all(target).map_err(|e| e.to_string()))
         .await
         .map_err(|e| format!("task join error: {e}"))?
 }

--- a/src-tauri/src/adaptor/controller/wiring.rs
+++ b/src-tauri/src/adaptor/controller/wiring.rs
@@ -296,6 +296,10 @@ pub(crate) fn build_canonical_workflow_read_usecase(
         workflows_dir.clone(),
         workflows_dir.clone(),
     ));
+    let diagnostics = Arc::new(WorkflowDiagnosticsFileGateway::new(
+        workflows_dir.clone(),
+        workflows_dir.clone(),
+    ));
     let facets = Arc::new(WorkflowFacetFileRepository::new(workflows_dir));
     let events = Arc::new(WorkflowEventLogRepository::with_read_store(
         local_event_store.clone(),
@@ -320,10 +324,13 @@ pub(crate) fn build_canonical_workflow_read_usecase(
         worktrees,
         secrets,
         workspace_query,
+        diagnostics,
     ))
 }
 
-fn build_workflow_services_with_gateways(
+/// gateway を呼び出し側から差し替えられる workflow composition。production 配線と
+/// acceptance harness の双方がこの一箇所を通る。
+pub(crate) fn build_workflow_services_with_gateways(
     data_dir: impl Into<std::path::PathBuf>,
     worktrees: Arc<dyn ManagedWorktreeGateway>,
     editors: Arc<dyn ExternalEditorGateway>,
@@ -421,6 +428,32 @@ pub(crate) fn spawn_startup_app_data_gc(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_診断read_usecase_適用済みdirectoryを診断する() {
+        // Given
+        let data = tempfile::tempdir().unwrap();
+        let workflows = tempfile::tempdir().unwrap();
+        let _store =
+            LocalEventStore::open(LocalEventStoreConfig::production(data.path().to_path_buf()))
+                .unwrap();
+        std::fs::write(workflows.path().join("configured.yml"), "name: [").unwrap();
+        let read = build_canonical_workflow_read_usecase(
+            data.path(),
+            Some(workflows.path().to_path_buf()),
+        )
+        .unwrap();
+
+        // When
+        let report = read
+            .diagnose_all(
+                crate::usecase::workflow::ports::WorkflowDiagnosticsTarget::AppliedConfigDirectory,
+            )
+            .unwrap();
+
+        // Then
+        assert!(report["workflow_summaries"]["configured"].is_object());
+    }
 
     async fn seed_b006_execution(store: &Arc<LocalEventStore>, workspace: &str) {
         use crate::domain::workflow::{ExecutionOrigin, ExecutionStatus};

--- a/src-tauri/src/adaptor/gateway/workflow/builtin.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/builtin.rs
@@ -5,6 +5,7 @@ use super::domain_mapping::workflow_definition_to_domain;
 use super::facet::{self, FacetError, FacetKind};
 use super::schema::{Summary, WorkflowDefinitionYaml};
 use super::storage;
+use crate::adaptor::protocol::workflow::DiagnosticItem;
 use crate::domain::workflow::validation::{self, ValidationError};
 
 const BUILTIN_01_AUTHOR_SPEC: &str = include_str!("../../../../../workflows/01_author-spec.yml");
@@ -87,7 +88,7 @@ pub enum BuiltinError {
     },
     Diagnostics {
         filename: &'static str,
-        diagnostics: Vec<diagnostics::DiagnosticItem>,
+        diagnostics: Vec<DiagnosticItem>,
     },
     Validation {
         filename: &'static str,

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -5,16 +5,20 @@ use crate::adaptor::gateway::workflow::lua;
 #[cfg(test)]
 use crate::adaptor::gateway::workflow::schema::NodeDefinition;
 use crate::adaptor::gateway::workflow::schema::{NodeKind, Rule, WorkflowDefinitionYaml};
-use crate::adaptor::gateway::workflow::span_map::{DiagnosticSpan, YamlSpanMap};
+use crate::adaptor::gateway::workflow::span_map::YamlSpanMap;
 use crate::adaptor::gateway::workflow::workflow_host::prompt_rendering;
+use crate::adaptor::protocol::workflow::{
+    DiagnosticItem, DiagnosticReport, DiagnosticSpan, DiagnosticStage, DiagnosticSummary,
+    FacetUsageEntry, Severity,
+};
 use crate::domain::workflow::validation;
 use crate::domain::workflow::validation::{
     InvalidArtifactReferenceKind, InvalidEnvironmentReferenceKind, InvalidRuleKind,
     InvalidSchemaKind,
 };
 use crate::domain::workflow::SessionPermission;
-use serde::Serialize;
 use std::collections::{HashMap, HashSet};
+use std::convert::Infallible;
 use std::path::Path;
 
 const ALL_FACET_KINDS: [FacetKind; 3] = [
@@ -23,47 +27,32 @@ const ALL_FACET_KINDS: [FacetKind; 3] = [
     FacetKind::Instruction,
 ];
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum Severity {
-    Error,
-    Info,
-}
+/// 診断 DTO の構築は、外部世界（YAML parser / validation error）を診断語彙へ写す
+/// gateway の責務であり、wire model 側には置かない。
+impl DiagnosticSpan {
+    pub(crate) fn from_location(location: serde_saphyr::Location) -> Self {
+        let line = usize::try_from(location.line()).unwrap_or(usize::MAX);
+        let col = usize::try_from(location.column()).unwrap_or(usize::MAX);
+        Self {
+            source: None,
+            start_line: line,
+            start_col: col,
+            end_line: line,
+            end_col: col.saturating_add(1),
+        }
+    }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct DiagnosticItem {
-    pub code: String,
-    pub severity: Severity,
-    pub stage: DiagnosticStage,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub span: Option<DiagnosticSpan>,
-    pub message: String,
-    /// 対象の workflow 名（ファセット診断の場合は None）
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workflow_name: Option<String>,
-    /// 対象の node 名
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub node_name: Option<String>,
-    /// 対象のファセットキー（ファセット診断の場合）
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub facet_key: Option<String>,
-    /// 対象のファセット種別
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub facet_kind: Option<String>,
-    /// 対象フィールド
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub field: Option<String>,
+    pub(crate) fn from_scan_error(error: &serde_saphyr::granit_parser::ScanError) -> Self {
+        let marker = error.marker();
+        Self {
+            source: None,
+            start_line: marker.line(),
+            start_col: marker.col() + 1,
+            end_line: marker.line(),
+            end_col: marker.col() + 2,
+        }
+    }
 }
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum DiagnosticStage {
-    ParseShape,
-    Resolve,
-    Typecheck,
-    ControlFlow,
-}
-
 impl DiagnosticItem {
     pub(crate) fn new(
         code: impl Into<String>,
@@ -86,50 +75,34 @@ impl DiagnosticItem {
         }
     }
 
-    fn workflow(mut self, name: impl Into<String>) -> Self {
+    pub(crate) fn workflow(mut self, name: impl Into<String>) -> Self {
         self.workflow_name = Some(name.into());
         self
     }
 
-    fn node(mut self, name: impl Into<String>) -> Self {
+    pub(crate) fn node(mut self, name: impl Into<String>) -> Self {
         self.node_name = Some(name.into());
         self
     }
 
-    fn facet(mut self, key: impl Into<String>, kind: impl Into<String>) -> Self {
+    pub(crate) fn facet(mut self, key: impl Into<String>, kind: impl Into<String>) -> Self {
         self.facet_key = Some(key.into());
         self.facet_kind = Some(kind.into());
         self
     }
 
-    fn field(mut self, field: impl Into<String>) -> Self {
+    pub(crate) fn field(mut self, field: impl Into<String>) -> Self {
         self.field = Some(field.into());
         self
     }
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
-pub struct DiagnosticSummary {
-    pub error_count: usize,
-    pub info_count: usize,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct DiagnosticReport {
-    pub items: Vec<DiagnosticItem>,
-    /// workflow名 → そのworkflowの診断サマリ
-    pub workflow_summaries: HashMap<String, DiagnosticSummary>,
-    /// "kind/key" → そのファセットの診断サマリ
-    pub facet_summaries: HashMap<String, DiagnosticSummary>,
-    /// ファセットキー → 参照元 workflow/node 情報のリスト
-    pub facet_usage: HashMap<String, Vec<FacetUsageEntry>>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct FacetUsageEntry {
-    pub workflow_name: String,
-    pub node_name: String,
-    pub slot: String,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiagnosticScope {
+    /// 適用済み config directory 用。disk + builtin の全 workflow / 全 Facet を列挙する。
+    AllAvailable,
+    /// 指定 directory 用。directory 配下の workflow を起点に、到達する Facet だけを列挙する。
+    ReachableFromDirectory,
 }
 
 type LoadedWorkflowDiagnostics =
@@ -1440,16 +1413,47 @@ fn node_field_path(wf: &WorkflowDefinitionYaml, node_name: &str, field: &str) ->
 
 /// 全ワークフロー・全ファセットを走査し診断結果を返す
 pub fn diagnose_all(workflows_dir: &Path, facets_base_dir: &Path) -> DiagnosticReport {
+    diagnose_with_scope(
+        workflows_dir,
+        facets_base_dir,
+        DiagnosticScope::AllAvailable,
+    )
+}
+
+/// 指定 directory を workflow source directory として扱い、正本 layout から解決した
+/// Facet base に対して workflow から到達する範囲だけを診断する。
+pub fn diagnose_directory(dir: &Path) -> DiagnosticReport {
+    let facets_base_dir = facet::resolve_facets_base_dir(dir);
+    diagnose_with_scope(
+        dir,
+        &facets_base_dir,
+        DiagnosticScope::ReachableFromDirectory,
+    )
+}
+
+fn diagnose_with_scope(
+    workflows_dir: &Path,
+    facets_base_dir: &Path,
+    scope: DiagnosticScope,
+) -> DiagnosticReport {
     let mut items = Vec::new();
     let mut workflow_summaries: HashMap<String, DiagnosticSummary> = HashMap::new();
     let mut facet_summaries: HashMap<String, DiagnosticSummary> = HashMap::new();
     let mut facet_usage: HashMap<String, Vec<FacetUsageEntry>> = HashMap::new();
 
+    let workflows = load_workflows_in_scope(workflows_dir, facets_base_dir, scope);
+
     // --- 全ファセットキーのセットを構築（参照存在チェック用） ---
-    let all_facet_keys = collect_all_facet_keys(facets_base_dir);
+    let all_facet_keys = match scope {
+        DiagnosticScope::AllAvailable => collect_all_facet_keys(facets_base_dir),
+        DiagnosticScope::ReachableFromDirectory => workflows
+            .iter()
+            .filter_map(|(_, result)| result.as_ref().ok())
+            .flat_map(|(workflow, _)| collect_reachable_facet_keys(workflow, facets_base_dir))
+            .collect(),
+    };
 
     // --- ワークフロー診断 ---
-    let workflows = load_all_workflows(workflows_dir, facets_base_dir);
     for (name, wf_result) in &workflows {
         match wf_result {
             Err(diagnostics) => {
@@ -1486,6 +1490,14 @@ pub fn diagnose_all(workflows_dir: &Path, facets_base_dir: &Path) -> DiagnosticR
         let summaries = facet::list_facet_summaries(*kind, facets_base_dir).unwrap_or_default();
         for summary in &summaries {
             let facet_id = format!("{}/{}", kind.canonical_name(), summary.key);
+            if scope == DiagnosticScope::ReachableFromDirectory
+                && !all_facet_keys.contains(&facet_id)
+            {
+                continue;
+            }
+            if scope == DiagnosticScope::ReachableFromDirectory {
+                facet_summaries.entry(facet_id.clone()).or_default();
+            }
 
             // ファセットキー命名規則チェック
             if facet::validate_facet_key(&summary.key).is_err() {
@@ -1573,39 +1585,52 @@ fn collect_referenced_facet_keys(
 ) -> Result<HashSet<String>, facet::FacetError> {
     let mut checked = HashSet::new();
     let mut existing = HashSet::new();
+    try_for_each_workflow_facet_ref(workflow, |kind, key| {
+        collect_existing_facet_key(&mut checked, &mut existing, kind, key, base_dir)
+    })?;
+    Ok(existing)
+}
+
+fn collect_reachable_facet_keys(
+    workflow: &WorkflowDefinitionYaml,
+    base_dir: &Path,
+) -> HashSet<String> {
+    let mut checked = HashSet::new();
+    let mut existing = HashSet::new();
+    let result = try_for_each_workflow_facet_ref(workflow, |kind, key| {
+        let facet_id = format!("{}/{}", kind.canonical_name(), key);
+        if checked.insert(facet_id.clone())
+            && matches!(facet::facet_exists(kind, key, base_dir), Ok(true))
+        {
+            existing.insert(facet_id);
+        }
+        Ok::<(), Infallible>(())
+    });
+    match result {
+        Ok(()) => existing,
+        Err(never) => match never {},
+    }
+}
+
+fn try_for_each_workflow_facet_ref<E>(
+    workflow: &WorkflowDefinitionYaml,
+    mut visit: impl FnMut(FacetKind, &str) -> Result<(), E>,
+) -> Result<(), E> {
     for node in &workflow.nodes {
         let Some(session) = node.session() else {
             continue;
         };
         if let Some(key) = session.facets.policy.as_deref() {
-            collect_existing_facet_key(
-                &mut checked,
-                &mut existing,
-                FacetKind::Policy,
-                key,
-                base_dir,
-            )?;
+            visit(FacetKind::Policy, key)?;
         }
         for key in &session.facets.knowledge {
-            collect_existing_facet_key(
-                &mut checked,
-                &mut existing,
-                FacetKind::Knowledge,
-                key,
-                base_dir,
-            )?;
+            visit(FacetKind::Knowledge, key)?;
         }
         if let Some(key) = session.facets.instruction.as_deref() {
-            collect_existing_facet_key(
-                &mut checked,
-                &mut existing,
-                FacetKind::Instruction,
-                key,
-                base_dir,
-            )?;
+            visit(FacetKind::Instruction, key)?;
         }
     }
-    Ok(existing)
+    Ok(())
 }
 
 fn collect_existing_facet_key(
@@ -1645,8 +1670,14 @@ pub(crate) fn diagnose_workflow_facet_references(
     Ok(items)
 }
 
-/// ディスク + builtin のワークフロー一覧を読み込み
-fn load_all_workflows(dir: &Path, facets_base_dir: &Path) -> Vec<NamedWorkflowDiagnostics> {
+/// scope に応じたワークフロー一覧を読み込む。
+/// `DiagnosticScope::AllAvailable` の場合だけ、ディスク上の定義と名前が衝突しない
+/// builtin workflow を追加する。
+fn load_workflows_in_scope(
+    dir: &Path,
+    facets_base_dir: &Path,
+    scope: DiagnosticScope,
+) -> Vec<NamedWorkflowDiagnostics> {
     let mut results = Vec::new();
 
     // ディスク上のカスタムワークフロー（validate() をスキップし全件走査）
@@ -1667,8 +1698,6 @@ fn load_all_workflows(dir: &Path, facets_base_dir: &Path) -> Vec<NamedWorkflowDi
                                     facets_base_dir,
                                 );
                                 if let Some(workflow) = diagnosis.workflow {
-                                    let _ =
-                                        facet::resolve_workflow_facets(&workflow, facets_base_dir);
                                     Ok((workflow, diagnosis.diagnostics))
                                 } else {
                                     Err(diagnosis.diagnostics)
@@ -1691,36 +1720,38 @@ fn load_all_workflows(dir: &Path, facets_base_dir: &Path) -> Vec<NamedWorkflowDi
         }
     }
 
-    // ビルトインワークフロー
-    for summary in builtin::list_builtin_workflows() {
-        if !seen.contains(&summary.name) {
-            match builtin::load_builtin_workflow_resolved(&summary.name) {
-                Ok(Some(wf)) => results.push((summary.name, Ok((wf, Vec::new())))),
-                Ok(None) => results.push((
-                    summary.name.clone(),
-                    Err(vec![DiagnosticItem::new(
-                        "WFS001",
-                        Severity::Error,
-                        DiagnosticStage::ParseShape,
-                        None,
-                        format!("ビルトインワークフロー '{}' の読み込みに失敗", summary.name),
-                    )
-                    .workflow(summary.name.clone())]),
-                )),
-                Err(err) => results.push((
-                    summary.name.clone(),
-                    Err(vec![DiagnosticItem::new(
-                        "WFS001",
-                        Severity::Error,
-                        DiagnosticStage::ParseShape,
-                        None,
-                        format!(
-                            "ビルトインワークフロー '{}' の読み込みに失敗: {err}",
-                            summary.name
-                        ),
-                    )
-                    .workflow(summary.name.clone())]),
-                )),
+    if scope == DiagnosticScope::AllAvailable {
+        // ビルトインワークフロー
+        for summary in builtin::list_builtin_workflows() {
+            if !seen.contains(&summary.name) {
+                match builtin::load_builtin_workflow_resolved(&summary.name) {
+                    Ok(Some(wf)) => results.push((summary.name, Ok((wf, Vec::new())))),
+                    Ok(None) => results.push((
+                        summary.name.clone(),
+                        Err(vec![DiagnosticItem::new(
+                            "WFS001",
+                            Severity::Error,
+                            DiagnosticStage::ParseShape,
+                            None,
+                            format!("ビルトインワークフロー '{}' の読み込みに失敗", summary.name),
+                        )
+                        .workflow(summary.name.clone())]),
+                    )),
+                    Err(err) => results.push((
+                        summary.name.clone(),
+                        Err(vec![DiagnosticItem::new(
+                            "WFS001",
+                            Severity::Error,
+                            DiagnosticStage::ParseShape,
+                            None,
+                            format!(
+                                "ビルトインワークフロー '{}' の読み込みに失敗: {err}",
+                                summary.name
+                            ),
+                        )
+                        .workflow(summary.name.clone())]),
+                    )),
+                }
             }
         }
     }
@@ -2141,6 +2172,26 @@ mod tests {
         }
     }
 
+    fn make_session_node(
+        name: &str,
+        policy: Option<&str>,
+        knowledge: &[&str],
+        instruction: Option<&str>,
+    ) -> NodeDefinition {
+        NodeDefinition {
+            name: name.to_string(),
+            kind: NodeKind::Session(SessionSpec {
+                facets: FacetRefs {
+                    policy: policy.map(str::to_string),
+                    knowledge: knowledge.iter().map(|key| (*key).to_string()).collect(),
+                    instruction: instruction.map(str::to_string),
+                },
+                ..Default::default()
+            }),
+            ..NodeDefinition::default()
+        }
+    }
+
     fn make_child(name: &str, instruction: Option<&str>) -> NodeDefinition {
         NodeDefinition {
             name: name.to_string(),
@@ -2184,6 +2235,69 @@ mod tests {
         let facet_dir = dir.join(kind);
         fs::create_dir_all(&facet_dir).unwrap();
         fs::write(facet_dir.join(format!("{key}.md")), content).unwrap();
+    }
+
+    #[test]
+    fn test_診断reportはserializeとdeserializeをround_tripできる() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("round-trip.yml"),
+            r#"name: round-trip
+description: round trip
+nodes:
+  main:
+    command: printf ok
+"#,
+        )
+        .unwrap();
+
+        // When
+        let report = diagnose_all(tmp.path(), tmp.path());
+        let value = serde_json::to_value(report).unwrap();
+        let decoded = serde_json::from_value::<DiagnosticReport>(value.clone()).unwrap();
+
+        // Then
+        assert_eq!(serde_json::to_value(decoded).unwrap(), value);
+    }
+
+    #[test]
+    fn test_診断itemは省略されたoptional_fieldをnoneとしてdeserializeする() {
+        // Given
+        let value = serde_json::json!({
+            "code": "X",
+            "severity": "error",
+            "stage": "parse_shape",
+            "message": "m"
+        });
+
+        // When
+        let item = serde_json::from_value::<DiagnosticItem>(value).unwrap();
+
+        // Then
+        assert!(item.span.is_none());
+        assert!(item.workflow_name.is_none());
+        assert!(item.node_name.is_none());
+        assert!(item.facet_key.is_none());
+        assert!(item.facet_kind.is_none());
+        assert!(item.field.is_none());
+    }
+
+    #[test]
+    fn test_診断spanは省略されたsourceをnoneとしてdeserializeする() {
+        // Given
+        let value = serde_json::json!({
+            "start_line": 7,
+            "start_col": 5,
+            "end_line": 7,
+            "end_col": 6
+        });
+
+        // When
+        let span = serde_json::from_value::<DiagnosticSpan>(value).unwrap();
+
+        // Then
+        assert!(span.source.is_none());
     }
 
     fn permission_yaml(permission: &str) -> String {
@@ -2410,6 +2524,573 @@ return r.workflow{{
         fs::create_dir_all(dir).unwrap();
         let content = serde_saphyr::to_string(wf).unwrap();
         fs::write(dir.join(format!("{}.yml", wf.name)), content).unwrap();
+    }
+
+    #[test]
+    fn test_診断_指定directory経路はbuiltin_workflowを列挙しない() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("custom.yml"),
+            r#"name: custom
+description: custom workflow
+nodes:
+  main:
+    command: printf ok
+"#,
+        )
+        .unwrap();
+        let builtin_names: HashSet<_> = builtin::list_builtin_workflows()
+            .into_iter()
+            .map(|summary| summary.name)
+            .collect();
+
+        // When
+        let directory_report = diagnose_directory(tmp.path());
+        let all_report = diagnose_all(tmp.path(), tmp.path());
+
+        // Then
+        assert!(directory_report
+            .workflow_summaries
+            .keys()
+            .all(|name| !builtin_names.contains(name)));
+        assert!(directory_report.items.iter().all(|item| item
+            .workflow_name
+            .as_ref()
+            .is_none_or(|name| !builtin_names.contains(name))));
+
+        assert!(all_report
+            .workflow_summaries
+            .keys()
+            .any(|name| builtin_names.contains(name)));
+        assert!(all_report.items.iter().any(|item| item
+            .workflow_name
+            .as_ref()
+            .is_some_and(|name| builtin_names.contains(name))));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路は参照されないfacetを列挙しない() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        setup_facet(tmp.path(), "policies", "unused", "unused policy");
+        fs::write(
+            tmp.path().join("custom.yml"),
+            r#"name: custom
+description: custom workflow
+nodes:
+  main:
+    command: printf ok
+"#,
+        )
+        .unwrap();
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(!report.facet_summaries.contains_key("policy/unused"));
+        assert!(report
+            .items
+            .iter()
+            .all(|item| item.facet_key.as_deref() != Some("unused")));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路はfacets配下の参照済みcustom_facetを判定対象に含める() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        setup_facet(
+            &tmp.path().join("facets"),
+            "instructions",
+            "custom-instruction",
+            "custom instruction",
+        );
+        let workflow = WorkflowDefinitionYaml {
+            name: "canonical-custom-facet".to_string(),
+            description: "canonical custom facet diagnostic".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_node("main", Some("custom-instruction"))],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(!report.items.iter().any(|item| {
+            item.code == "FAC002" && item.facet_key.as_deref() == Some("custom-instruction")
+        }));
+        assert!(report
+            .facet_summaries
+            .contains_key("instruction/custom-instruction"));
+        assert!(report
+            .facet_usage
+            .contains_key("instruction/custom-instruction"));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路はfacets配下のdisk本文をbuiltinより優先する() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        let builtin_instruction =
+            builtin::list_builtin_facet_keys(FacetKind::Instruction)[0].to_string();
+        setup_facet(
+            &tmp.path().join("facets"),
+            "instructions",
+            &builtin_instruction,
+            "{{ bad ref }}",
+        );
+        let workflow = WorkflowDefinitionYaml {
+            name: "builtin-override".to_string(),
+            description: "disk facet overrides builtin".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_node("main", Some(&builtin_instruction))],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(report.items.iter().any(|item| {
+            item.code == "FAC003" && item.facet_key.as_deref() == Some(&builtin_instruction)
+        }));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路は不正参照があっても他のcustomとbuiltin_facetを保持する() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        setup_facet(
+            &tmp.path().join("facets"),
+            "instructions",
+            "custom-instruction",
+            "{{ bad ref }}",
+        );
+        let builtin_knowledge =
+            builtin::list_builtin_facet_keys(FacetKind::Knowledge)[0].to_string();
+        let workflow = WorkflowDefinitionYaml {
+            name: "mixed-references".to_string(),
+            description: "mixed valid and invalid references".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_session_node(
+                "main",
+                Some("Bad.Key"),
+                &[&builtin_knowledge],
+                Some("custom-instruction"),
+            )],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(report
+            .items
+            .iter()
+            .any(|item| { item.code == "FAC002" && item.facet_key.as_deref() == Some("Bad.Key") }));
+        for valid_key in [&builtin_knowledge, "custom-instruction"] {
+            assert!(!report.items.iter().any(|item| {
+                item.code == "FAC002" && item.facet_key.as_deref() == Some(valid_key)
+            }));
+        }
+        assert!(report
+            .facet_summaries
+            .contains_key("instruction/custom-instruction"));
+        assert!(report
+            .facet_usage
+            .contains_key("instruction/custom-instruction"));
+        assert!(report.items.iter().any(|item| {
+            item.code == "FAC003" && item.facet_key.as_deref() == Some("custom-instruction")
+        }));
+        assert!(report.items.iter().any(|item| {
+            item.code == "FAC000" && item.facet_key.as_deref() == Some(&builtin_knowledge)
+        }));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路は一部inventoryのio失敗時も健全なkindを保持する() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        let facets_dir = tmp.path().join("facets");
+        fs::create_dir_all(&facets_dir).unwrap();
+        fs::write(facets_dir.join("policies"), "not a directory").unwrap();
+        setup_facet(&facets_dir, "knowledge", "known", "{{ bad ref }}");
+        let workflow = WorkflowDefinitionYaml {
+            name: "broken-inventory".to_string(),
+            description: "one broken facet inventory".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_session_node(
+                "main",
+                Some("custom-policy"),
+                &["known"],
+                None,
+            )],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(!report
+            .items
+            .iter()
+            .any(|item| { item.code == "FAC002" && item.facet_key.as_deref() == Some("known") }));
+        assert!(report.facet_summaries.contains_key("knowledge/known"));
+        assert!(report.facet_usage.contains_key("knowledge/known"));
+        assert!(report
+            .items
+            .iter()
+            .any(|item| { item.code == "FAC003" && item.facet_key.as_deref() == Some("known") }));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路は不正keyと同居するknowledge_facetを保持する() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        setup_facet(tmp.path(), "knowledge", "team-guide", "{{ bad ref }}");
+        let workflow = WorkflowDefinitionYaml {
+            name: "mixed-knowledge".to_string(),
+            description: "valid knowledge and invalid instruction".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_session_node(
+                "main",
+                None,
+                &["team-guide"],
+                Some("setup.v2"),
+            )],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        let missing_refs = report
+            .items
+            .iter()
+            .filter(|item| item.code == "FAC002")
+            .collect::<Vec<_>>();
+        assert_eq!(missing_refs.len(), 1);
+        assert_eq!(missing_refs[0].facet_key.as_deref(), Some("setup.v2"));
+        assert!(report.facet_summaries.contains_key("knowledge/team-guide"));
+        assert!(report.facet_usage.contains_key("knowledge/team-guide"));
+        assert!(report.items.iter().any(|item| {
+            item.code == "FAC003" && item.facet_key.as_deref() == Some("team-guide")
+        }));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路のfac002集合はall_available経路と一致する() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        setup_facet(
+            tmp.path(),
+            "instructions",
+            "real-instruction",
+            "{{ bad ref }}",
+        );
+        let workflow = WorkflowDefinitionYaml {
+            name: "scope-parity".to_string(),
+            description: "facet reference parity".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_session_node(
+                "main",
+                Some("-bad"),
+                &[],
+                Some("real-instruction"),
+            )],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let directory_report = diagnose_directory(tmp.path());
+        let all_available_report = diagnose_all(tmp.path(), tmp.path());
+        let fac002_keys = |report: &DiagnosticReport| {
+            report
+                .items
+                .iter()
+                .filter(|item| item.code == "FAC002")
+                .filter_map(|item| item.facet_key.clone())
+                .collect::<HashSet<_>>()
+        };
+
+        // Then
+        assert_eq!(
+            fac002_keys(&directory_report),
+            fac002_keys(&all_available_report)
+        );
+        assert_eq!(
+            fac002_keys(&directory_report),
+            HashSet::from(["-bad".to_string()])
+        );
+        assert!(directory_report
+            .facet_summaries
+            .contains_key("instruction/real-instruction"));
+        assert!(directory_report
+            .facet_usage
+            .contains_key("instruction/real-instruction"));
+        assert!(directory_report.items.iter().any(|item| {
+            item.code == "FAC003" && item.facet_key.as_deref() == Some("real-instruction")
+        }));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路は直下inventory破損時も他kindの本文診断を保持する() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("policies"), "not a directory").unwrap();
+        setup_facet(tmp.path(), "knowledge", "known", "{{ bad ref }}");
+        let workflow = WorkflowDefinitionYaml {
+            name: "cross-kind-degrade".to_string(),
+            description: "broken policy inventory and healthy knowledge".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_session_node(
+                "main",
+                Some("custom-policy"),
+                &["known"],
+                None,
+            )],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(!report
+            .items
+            .iter()
+            .any(|item| { item.code == "FAC002" && item.facet_key.as_deref() == Some("known") }));
+        assert!(report.facet_summaries.contains_key("knowledge/known"));
+        assert!(report.facet_usage.contains_key("knowledge/known"));
+        assert!(report
+            .items
+            .iter()
+            .any(|item| { item.code == "FAC003" && item.facet_key.as_deref() == Some("known") }));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路で実体のない参照facetをfac002にする() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        let workflow = WorkflowDefinitionYaml {
+            name: "missing-facet".to_string(),
+            description: "missing facet reference".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_session_node("main", Some("missing-policy"), &[], None)],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+        let item = report
+            .items
+            .iter()
+            .find(|item| {
+                item.code == "FAC002" && item.facet_key.as_deref() == Some("missing-policy")
+            })
+            .expect("missing Facet reference must produce FAC002");
+
+        // Then
+        assert_eq!(item.severity, Severity::Error);
+        assert_eq!(item.stage, DiagnosticStage::Resolve);
+        assert_eq!(item.workflow_name.as_deref(), Some("missing-facet"));
+        assert_eq!(item.node_name.as_deref(), Some("main"));
+        assert_eq!(item.facet_key.as_deref(), Some("missing-policy"));
+        assert_eq!(item.facet_kind.as_deref(), Some("policy"));
+        assert_eq!(item.field.as_deref(), Some("policy"));
+        assert!(item.message.contains("missing-policy"));
+        let usage = report.facet_usage.get("policy/missing-policy").unwrap();
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].workflow_name, "missing-facet");
+        assert_eq!(usage[0].node_name, "main");
+        assert_eq!(usage[0].slot, "policy");
+    }
+
+    #[test]
+    fn test_診断_指定directory経路はfacet本文の不正template構文をfac003にする() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        setup_facet(
+            &tmp.path().join("facets"),
+            "instructions",
+            "invalid-template",
+            "{{ bad ref }}",
+        );
+        let workflow = WorkflowDefinitionYaml {
+            name: "facet-syntax".to_string(),
+            description: "invalid Facet template syntax".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_node("main", Some("invalid-template"))],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(report.items.iter().any(|item| {
+            item.code == "FAC003" && item.facet_key.as_deref() == Some("invalid-template")
+        }));
+        assert!(
+            report
+                .facet_summaries
+                .get("instruction/invalid-template")
+                .unwrap()
+                .error_count
+                > 0
+        );
+    }
+
+    #[test]
+    fn test_診断_指定directory経路はworkflow文脈と不整合なfacet本文をwfr003にする() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        setup_facet(
+            &tmp.path().join("facets"),
+            "instructions",
+            "invalid-reference",
+            "Use {{ missing_node }}",
+        );
+        let workflow = WorkflowDefinitionYaml {
+            name: "facet-reference".to_string(),
+            description: "invalid Facet template reference".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_node("main", Some("invalid-reference"))],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(report.items.iter().any(|item| {
+            item.code == "WFR003"
+                && item.workflow_name.as_deref() == Some("facet-reference")
+                && item.node_name.as_deref() == Some("main")
+                && item.facet_key.as_deref() == Some("invalid-reference")
+        }));
+        assert!(
+            report
+                .facet_summaries
+                .get("instruction/invalid-reference")
+                .unwrap()
+                .error_count
+                > 0
+        );
+    }
+
+    #[test]
+    fn test_診断_指定directory経路は直下の参照済みcustom_facetを判定対象に含める() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        setup_facet(
+            tmp.path(),
+            "instructions",
+            "custom-instruction",
+            "custom instruction",
+        );
+        let workflow = WorkflowDefinitionYaml {
+            name: "custom-facet".to_string(),
+            description: "custom facet diagnostic".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_node("main", Some("custom-instruction"))],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(!report.items.iter().any(|item| {
+            item.code == "FAC002" && item.facet_key.as_deref() == Some("custom-instruction")
+        }));
+        assert!(report
+            .facet_summaries
+            .contains_key("instruction/custom-instruction"));
+        assert!(report
+            .facet_usage
+            .contains_key("instruction/custom-instruction"));
+    }
+
+    #[test]
+    fn test_診断_指定directory経路は参照済みbuiltin_facetを判定対象に含める() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        let builtin_instruction =
+            builtin::list_builtin_facet_keys(FacetKind::Instruction)[0].to_string();
+        let workflow = WorkflowDefinitionYaml {
+            name: "builtin-facet".to_string(),
+            description: "builtin facet diagnostic".to_string(),
+            builtin: false,
+            entry: "main".to_string(),
+            schemas: Default::default(),
+            nodes: vec![make_node("main", Some(&builtin_instruction))],
+        };
+        save_workflow_yaml(tmp.path(), &workflow);
+
+        // When
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        assert!(!report.items.iter().any(|item| {
+            item.code == "FAC002" && item.facet_key.as_deref() == Some(&builtin_instruction)
+        }));
+        assert!(report.items.iter().any(|item| {
+            item.code == "FAC000"
+                && item.facet_kind.as_deref() == Some("instruction")
+                && item.facet_key.as_deref() == Some(&builtin_instruction)
+        }));
+    }
+
+    #[test]
+    fn test_診断_指定directoryで不正permission宣言がwfs002になる() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("permission.yml"),
+            permission_yaml("unknown"),
+        )
+        .unwrap();
+
+        // When
+        let report = diagnose_directory(tmp.path());
+        let item = report
+            .items
+            .iter()
+            .find(|item| item.code == "WFS002")
+            .expect("WFS002 diagnostic");
+
+        // Then
+        assert_eq!(item.stage, DiagnosticStage::ParseShape);
+        assert_eq!(item.field.as_deref(), Some("permission"));
+        assert_eq!(item.span.as_ref().unwrap().start_line, 7);
     }
 
     #[test]

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -1490,12 +1490,11 @@ fn diagnose_with_scope(
         let summaries = facet::list_facet_summaries(*kind, facets_base_dir).unwrap_or_default();
         for summary in &summaries {
             let facet_id = format!("{}/{}", kind.canonical_name(), summary.key);
-            if scope == DiagnosticScope::ReachableFromDirectory
-                && !all_facet_keys.contains(&facet_id)
-            {
-                continue;
-            }
             if scope == DiagnosticScope::ReachableFromDirectory {
+                if !all_facet_keys.contains(&facet_id) {
+                    continue;
+                }
+                // 到達した Facet は diagnostic が 0 件でも判定対象だったことを summary に残す。
                 facet_summaries.entry(facet_id.clone()).or_default();
             }
 
@@ -1597,19 +1596,27 @@ fn collect_reachable_facet_keys(
 ) -> HashSet<String> {
     let mut checked = HashSet::new();
     let mut existing = HashSet::new();
-    let result = try_for_each_workflow_facet_ref(workflow, |kind, key| {
+    for_each_workflow_facet_ref(workflow, |kind, key| {
         let facet_id = format!("{}/{}", kind.canonical_name(), key);
         if checked.insert(facet_id.clone())
             && matches!(facet::facet_exists(kind, key, base_dir), Ok(true))
         {
             existing.insert(facet_id);
         }
-        Ok::<(), Infallible>(())
     });
-    match result {
-        Ok(()) => existing,
-        Err(never) => match never {},
-    }
+    existing
+}
+
+/// 失敗しない走査。`try_for_each_workflow_facet_ref` と同じ順序で参照を訪れる。
+fn for_each_workflow_facet_ref(
+    workflow: &WorkflowDefinitionYaml,
+    mut visit: impl FnMut(FacetKind, &str),
+) {
+    try_for_each_workflow_facet_ref(workflow, |kind, key| {
+        visit(kind, key);
+        Ok::<(), Infallible>(())
+    })
+    .unwrap();
 }
 
 fn try_for_each_workflow_facet_ref<E>(

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics_gateway.rs
@@ -158,6 +158,13 @@ mod tests {
         let unreadable = configured.path().join("unreadable");
         std::fs::create_dir(&unreadable).unwrap();
         std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::read_dir(&unreadable).is_ok() {
+            std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+            eprintln!(
+                "skipping unreadable directory test because this process can read mode 0o000"
+            );
+            return;
+        }
 
         // When
         let result = WorkflowDiagnosticsFileGateway::new(configured.path(), configured.path())

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics_gateway.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics_gateway.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::domain::workflow::WorkflowError;
-use crate::usecase::workflow::ports::WorkflowDiagnosticsGateway;
+use crate::usecase::workflow::ports::{WorkflowDiagnosticsGateway, WorkflowDiagnosticsTarget};
 
 use super::diagnostics;
 
@@ -24,8 +24,30 @@ impl WorkflowDiagnosticsFileGateway {
 }
 
 impl WorkflowDiagnosticsGateway for WorkflowDiagnosticsFileGateway {
-    fn diagnose_all(&self) -> Result<serde_json::Value, WorkflowError> {
-        let report = diagnostics::diagnose_all(&self.workflows_dir, &self.facets_base_dir);
+    fn diagnose_all(
+        &self,
+        target: WorkflowDiagnosticsTarget,
+    ) -> Result<serde_json::Value, WorkflowError> {
+        let report = match target {
+            WorkflowDiagnosticsTarget::AppliedConfigDirectory => {
+                diagnostics::diagnose_all(&self.workflows_dir, &self.facets_base_dir)
+            }
+            WorkflowDiagnosticsTarget::Directory(dir) => {
+                if let Err(error) = std::fs::read_dir(&dir) {
+                    if error.kind() == std::io::ErrorKind::NotFound {
+                        return Err(WorkflowError::NotFound(format!(
+                            "directory does not exist: {}",
+                            dir.display()
+                        )));
+                    }
+                    return Err(WorkflowError::external(format!(
+                        "failed to read diagnostics target directory '{}': {error}",
+                        dir.display()
+                    )));
+                }
+                diagnostics::diagnose_directory(&dir)
+            }
+        };
         serde_json::to_value(report)
             .map_err(|e| WorkflowError::external(format!("serialize workflow diagnostics: {e}")))
     }
@@ -42,12 +64,108 @@ mod tests {
         let facets = TempDir::new().unwrap();
 
         let report = WorkflowDiagnosticsFileGateway::new(workflows.path(), facets.path())
-            .diagnose_all()
+            .diagnose_all(WorkflowDiagnosticsTarget::AppliedConfigDirectory)
             .unwrap();
 
         assert!(report["items"].is_array());
         assert!(report["workflow_summaries"].is_object());
         assert!(report["facet_summaries"].is_object());
         assert!(report["facet_usage"].is_object());
+    }
+
+    #[test]
+    fn test_診断gateway_指定directoryを使う() {
+        // Given
+        let configured = TempDir::new().unwrap();
+        let requested = TempDir::new().unwrap();
+        std::fs::write(requested.path().join("broken.yml"), "name: [").unwrap();
+
+        // When
+        let report = WorkflowDiagnosticsFileGateway::new(configured.path(), configured.path())
+            .diagnose_all(WorkflowDiagnosticsTarget::Directory(
+                requested.path().to_path_buf(),
+            ))
+            .unwrap();
+
+        // Then
+        assert!(report["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| { item["code"] == "WFS001" && item["workflow_name"] == "broken" }));
+    }
+
+    #[test]
+    fn test_診断gateway_適用済みreportを保持する() {
+        // Given
+        let workflows = TempDir::new().unwrap();
+        let facets = TempDir::new().unwrap();
+        let expected =
+            serde_json::to_value(diagnostics::diagnose_all(workflows.path(), facets.path()))
+                .unwrap();
+
+        // When
+        let actual = WorkflowDiagnosticsFileGateway::new(workflows.path(), facets.path())
+            .diagnose_all(WorkflowDiagnosticsTarget::AppliedConfigDirectory)
+            .unwrap();
+
+        // Then
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_診断gateway_存在しない指定directoryをnot_foundにする() {
+        // Given
+        let configured = TempDir::new().unwrap();
+        let missing = configured.path().join("missing");
+
+        // When
+        let error = WorkflowDiagnosticsFileGateway::new(configured.path(), configured.path())
+            .diagnose_all(WorkflowDiagnosticsTarget::Directory(missing.clone()))
+            .unwrap_err();
+
+        // Then
+        assert!(matches!(
+            error,
+            WorkflowError::NotFound(message)
+                if message == format!("directory does not exist: {}", missing.display())
+        ));
+    }
+
+    #[test]
+    fn test_診断gateway_通常fileの指定をexternal_errorにする() {
+        // Given
+        let configured = TempDir::new().unwrap();
+        let file = configured.path().join("workflow.yml");
+        std::fs::write(&file, "name: workflow").unwrap();
+
+        // When
+        let error = WorkflowDiagnosticsFileGateway::new(configured.path(), configured.path())
+            .diagnose_all(WorkflowDiagnosticsTarget::Directory(file))
+            .unwrap_err();
+
+        // Then
+        assert!(matches!(error, WorkflowError::External(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_診断gateway_列挙不能な指定directoryをexternal_errorにする() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Given
+        let configured = TempDir::new().unwrap();
+        let unreadable = configured.path().join("unreadable");
+        std::fs::create_dir(&unreadable).unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // When
+        let result = WorkflowDiagnosticsFileGateway::new(configured.path(), configured.path())
+            .diagnose_all(WorkflowDiagnosticsTarget::Directory(unreadable.clone()));
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let error = result.unwrap_err();
+
+        // Then
+        assert!(matches!(error, WorkflowError::External(_)));
     }
 }

--- a/src-tauri/src/adaptor/gateway/workflow/facet.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/facet.rs
@@ -15,6 +15,17 @@ pub fn facets_base_dir() -> PathBuf {
     storage::workflows_dir()
 }
 
+/// workflow source directory から authoring layout の Facet base を解決する。
+/// `<dir>/facets` が directory ならそれを使い、無ければ従来 layout の `<dir>` を使う。
+pub(crate) fn resolve_facets_base_dir(workflow_source_dir: &Path) -> PathBuf {
+    let canonical_dir = workflow_source_dir.join("facets");
+    if canonical_dir.is_dir() {
+        canonical_dir
+    } else {
+        workflow_source_dir.to_path_buf()
+    }
+}
+
 #[derive(Debug)]
 pub enum FacetError {
     InvalidKey { key: String },

--- a/src-tauri/src/adaptor/gateway/workflow/span_map.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/span_map.rs
@@ -1,42 +1,8 @@
 use std::collections::BTreeMap;
 
-use serde::Serialize;
 use serde_saphyr::granit_parser::{Event, Parser, ScanError, Span as ParserSpan};
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub(crate) struct DiagnosticSpan {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) source: Option<String>,
-    pub(crate) start_line: usize,
-    pub(crate) start_col: usize,
-    pub(crate) end_line: usize,
-    pub(crate) end_col: usize,
-}
-
-impl DiagnosticSpan {
-    pub(crate) fn from_location(location: serde_saphyr::Location) -> Self {
-        let line = usize::try_from(location.line()).unwrap_or(usize::MAX);
-        let col = usize::try_from(location.column()).unwrap_or(usize::MAX);
-        Self {
-            source: None,
-            start_line: line,
-            start_col: col,
-            end_line: line,
-            end_col: col.saturating_add(1),
-        }
-    }
-
-    pub(crate) fn from_scan_error(error: &ScanError) -> Self {
-        let marker = error.marker();
-        Self {
-            source: None,
-            start_line: marker.line(),
-            start_col: marker.col() + 1,
-            end_line: marker.line(),
-            end_col: marker.col() + 2,
-        }
-    }
-}
+use crate::adaptor::protocol::workflow::DiagnosticSpan;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct YamlSpanMap {

--- a/src-tauri/src/adaptor/gateway/workflow/storage.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/storage.rs
@@ -3,6 +3,7 @@ use super::diagnostics;
 use super::domain_mapping::workflow_definition_to_domain;
 use super::facet;
 use super::schema::{Summary, WorkflowDefinitionYaml};
+use crate::adaptor::protocol::workflow::{DiagnosticItem, DiagnosticStage, Severity};
 use crate::domain::workflow::validation::{self, ValidationError};
 use crate::domain::workflow::WorkflowSourceFormat;
 use serde::Serialize;
@@ -15,7 +16,7 @@ pub enum StorageError {
     Io(std::io::Error),
     YamlDeserialize(serde_saphyr::Error),
     YamlSerialize(serde_saphyr::ser::Error),
-    Diagnostics(Vec<diagnostics::DiagnosticItem>),
+    Diagnostics(Vec<DiagnosticItem>),
     Validation(ValidationError),
     FacetResolution(facet::FacetError),
     NotFound { name: String },
@@ -155,10 +156,10 @@ pub fn parse_workflow_source(
         return Err(StorageError::Diagnostics(diagnosis.diagnostics));
     }
     let mut workflow = diagnosis.workflow.ok_or_else(|| {
-        StorageError::Diagnostics(vec![diagnostics::DiagnosticItem::new(
+        StorageError::Diagnostics(vec![DiagnosticItem::new(
             "WFS001",
-            diagnostics::Severity::Error,
-            diagnostics::DiagnosticStage::ParseShape,
+            Severity::Error,
+            DiagnosticStage::ParseShape,
             None,
             "workflow source could not be parsed",
         )])
@@ -259,10 +260,10 @@ pub(crate) fn diagnose_workflow_file(
         None => {
             return diagnostics::WorkflowSourceDiagnostics {
                 workflow: None,
-                diagnostics: vec![diagnostics::DiagnosticItem::new(
+                diagnostics: vec![DiagnosticItem::new(
                     "WFS002",
-                    diagnostics::Severity::Error,
-                    diagnostics::DiagnosticStage::ParseShape,
+                    Severity::Error,
+                    DiagnosticStage::ParseShape,
                     None,
                     format!("unsupported workflow source extension: {}", path.display()),
                 )],
@@ -293,10 +294,10 @@ pub fn load_workflow(
         return Err(StorageError::Diagnostics(diagnosis.diagnostics));
     }
     let mut workflow = diagnosis.workflow.ok_or_else(|| {
-        StorageError::Diagnostics(vec![diagnostics::DiagnosticItem::new(
+        StorageError::Diagnostics(vec![DiagnosticItem::new(
             "WFS001",
-            diagnostics::Severity::Error,
-            diagnostics::DiagnosticStage::ParseShape,
+            Severity::Error,
+            DiagnosticStage::ParseShape,
             None,
             "workflow source could not be parsed",
         )])
@@ -390,10 +391,10 @@ pub(crate) fn list_workflows_with_facets(
             });
         }
         let mut workflow = diagnosis.workflow.ok_or_else(|| {
-            StorageError::Diagnostics(vec![diagnostics::DiagnosticItem::new(
+            StorageError::Diagnostics(vec![DiagnosticItem::new(
                 "WFS001",
-                diagnostics::Severity::Error,
-                diagnostics::DiagnosticStage::ParseShape,
+                Severity::Error,
+                DiagnosticStage::ParseShape,
                 None,
                 "workflow source could not be parsed",
             )])
@@ -430,7 +431,7 @@ fn validate_workflow_definition(workflow: &WorkflowDefinitionYaml) -> Result<(),
     let diagnostics = diagnostics::diagnose_workflow_definition(workflow, None);
     if diagnostics
         .iter()
-        .any(|item| item.severity == diagnostics::Severity::Error)
+        .any(|item| item.severity == Severity::Error)
     {
         return Err(StorageError::Diagnostics(diagnostics));
     }
@@ -445,7 +446,7 @@ pub(crate) fn resolve_and_validate_workflow_facets(
         diagnostics::diagnose_workflow_facet_references(workflow, facets_base_dir)?;
     if reference_diagnostics
         .iter()
-        .any(|item| item.severity == diagnostics::Severity::Error)
+        .any(|item| item.severity == Severity::Error)
     {
         return Err(StorageError::Diagnostics(reference_diagnostics));
     }
@@ -496,15 +497,13 @@ pub fn resolve_workflow_path(dir: &Path, name: &str) -> Result<PathBuf, StorageE
             name: name.to_string(),
         }),
         [path] => Ok(path.clone()),
-        _ => Err(StorageError::Diagnostics(vec![
-            diagnostics::DiagnosticItem::new(
-                "WFS006",
-                diagnostics::Severity::Error,
-                diagnostics::DiagnosticStage::ParseShape,
-                None,
-                format!("workflow name '{name}' is duplicated"),
-            ),
-        ])),
+        _ => Err(StorageError::Diagnostics(vec![DiagnosticItem::new(
+            "WFS006",
+            Severity::Error,
+            DiagnosticStage::ParseShape,
+            None,
+            format!("workflow name '{name}' is duplicated"),
+        )])),
     }
 }
 

--- a/src-tauri/src/adaptor/protocol/workflow.rs
+++ b/src-tauri/src/adaptor/protocol/workflow.rs
@@ -1,6 +1,82 @@
 //! Public workflow execution wire model.
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Info,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticStage {
+    ParseShape,
+    Resolve,
+    Typecheck,
+    ControlFlow,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DiagnosticSpan {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    pub start_line: usize,
+    pub start_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DiagnosticItem {
+    pub code: String,
+    pub severity: Severity,
+    pub stage: DiagnosticStage,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span: Option<DiagnosticSpan>,
+    pub message: String,
+    /// 対象の workflow 名（ファセット診断の場合は None）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_name: Option<String>,
+    /// 対象の node 名
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_name: Option<String>,
+    /// 対象のファセットキー（ファセット診断の場合）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub facet_key: Option<String>,
+    /// 対象のファセット種別
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub facet_kind: Option<String>,
+    /// 対象フィールド
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct DiagnosticSummary {
+    pub error_count: usize,
+    pub info_count: usize,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DiagnosticReport {
+    pub items: Vec<DiagnosticItem>,
+    /// workflow名 → そのworkflowの診断サマリ
+    pub workflow_summaries: HashMap<String, DiagnosticSummary>,
+    /// "kind/key" → そのファセットの診断サマリ
+    pub facet_summaries: HashMap<String, DiagnosticSummary>,
+    /// ファセットキー → 参照元 workflow/node 情報のリスト
+    pub facet_usage: HashMap<String, Vec<FacetUsageEntry>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FacetUsageEntry {
+    pub workflow_name: String,
+    pub node_name: String,
+    pub slot: String,
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src-tauri/src/cli/api_client.rs
+++ b/src-tauri/src/cli/api_client.rs
@@ -98,6 +98,17 @@ impl LocalApiClient {
         Ok(response.into())
     }
 
+    /// workflow diagnostics を local API 経由で取得する。診断結果 DTO をそのまま返す。
+    pub(super) fn workflow_diagnostics(
+        &self,
+        dir: Option<&str>,
+    ) -> Result<serde_json::Value, ApiRequestError> {
+        let query: Vec<(&str, &str)> = dir.into_iter().map(|dir| ("dir", dir)).collect();
+        self.transport
+            .get_json(&["v1", "workflow", "diagnostics"], &query)
+            .map_err(ApiRequestError::from)
+    }
+
     pub(super) fn receive_provider_lifecycle(
         &self,
         request: &ProviderLifecycleReceiveRequest,
@@ -123,18 +134,34 @@ pub(super) fn read_with_fallback<T>(
     }
 }
 
+/// アプリ起動を要する mutation。local API へ到達できない場合は
+/// 「アプリ起動が必要」失敗になる。
 pub(super) fn mutation<T>(
     data_dir: &Path,
     api_request: impl FnOnce(&LocalApiClient) -> Result<T, ApiRequestError>,
 ) -> Result<T, CliError> {
-    match mutation_classified(data_dir, api_request) {
+    require_running(request_classified(data_dir, api_request))
+}
+
+/// アプリ起動を要する read-only query。fallback を持たず、失敗表現は
+/// mutation と同じにする。read と mutation を別入口に保つのは、file_direct が
+/// 定める「read だけが fallback を持てる」区別を呼び出し側で崩さないためである。
+pub(super) fn read_without_fallback<T>(
+    data_dir: &Path,
+    api_request: impl FnOnce(&LocalApiClient) -> Result<T, ApiRequestError>,
+) -> Result<T, CliError> {
+    require_running(request_classified(data_dir, api_request))
+}
+
+fn require_running<T>(result: Result<T, ApiRequestError>) -> Result<T, CliError> {
+    match result {
         Ok(value) => Ok(value),
         Err(ApiRequestError::Unavailable) => Err(app_must_be_running_error()),
         Err(ApiRequestError::Cli(error)) => Err(error),
     }
 }
 
-pub(super) fn mutation_classified<T>(
+pub(super) fn request_classified<T>(
     data_dir: &Path,
     api_request: impl FnOnce(&LocalApiClient) -> Result<T, ApiRequestError>,
 ) -> Result<T, ApiRequestError> {

--- a/src-tauri/src/cli/api_client_test.rs
+++ b/src-tauri/src/cli/api_client_test.rs
@@ -1,14 +1,14 @@
 use std::io::{Read, Write};
-use std::sync::Arc;
 
 use tempfile::TempDir;
 
 use super::*;
-use crate::adaptor::controller::api::{self, test_support as api_test_support};
+use crate::adaptor::controller::api::test_support as api_test_support;
 use crate::adaptor::gateway::workflow::schema::{
     CommandSpec, NodeDefinition, NodeKind, WorkflowDefinitionYaml,
 };
 use crate::adaptor::gateway::workflow::storage;
+use crate::cli::test_helpers::try_start_local_api_test_host;
 use crate::cli::{output, workflow};
 use crate::infrastructure::local_api::{local_api_discovery_path, process_start_time};
 
@@ -41,6 +41,53 @@ fn write_live_discovery(data_dir: &Path, token: &str) -> std::thread::JoinHandle
     })
 }
 
+fn write_diagnostics_server(data_dir: &Path, expected_target: &str) -> std::thread::JoinHandle<()> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let pid = std::process::id();
+    std::fs::write(
+        local_api_discovery_path(data_dir),
+        serde_json::json!({
+            "port": port,
+            "token": "secret",
+            "instance_id": "test-instance",
+            "pid": pid,
+            "process_started_at": process_start_time(pid).unwrap(),
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let expected_target = expected_target.to_string();
+    std::thread::spawn(move || {
+        let (mut identity_stream, _) = listener.accept().unwrap();
+        let mut identity_request = [0_u8; 4096];
+        let read = identity_stream.read(&mut identity_request).unwrap();
+        let identity_request = String::from_utf8_lossy(&identity_request[..read]);
+        assert!(identity_request
+            .starts_with("GET /.well-known/releash-local-api/test-instance HTTP/1.1"));
+        identity_stream
+            .write_all(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
+            .unwrap();
+
+        let (mut diagnostics_stream, _) = listener.accept().unwrap();
+        let mut diagnostics_request = [0_u8; 4096];
+        let read = diagnostics_stream.read(&mut diagnostics_request).unwrap();
+        let diagnostics_request = String::from_utf8_lossy(&diagnostics_request[..read]);
+        assert!(
+            diagnostics_request.starts_with(&format!("GET {expected_target} HTTP/1.1")),
+            "unexpected diagnostics request: {diagnostics_request}"
+        );
+        assert!(diagnostics_request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer secret"));
+        diagnostics_stream
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}",
+            )
+            .unwrap();
+    })
+}
+
 fn command_workflow(name: &str) -> WorkflowDefinitionYaml {
     WorkflowDefinitionYaml {
         name: name.to_string(),
@@ -67,40 +114,15 @@ fn test_保持対象cli_discoveryとlive_httpを通る() {
     storage::save_workflow(workflows.path(), &command_workflow("review")).unwrap();
     api_test_support::seed_query_execution(query_data.path(), execution_id);
     api_test_support::seed_submitted_output(query_data.path(), execution_id);
-    let (_workflow_usecase, runtime, gateway) = api_test_support::usecases(query_data.path());
-    gateway.resolve_workflows_from(
-        workflows.path().to_path_buf(),
-        workflows.path().to_path_buf(),
-    );
-    let binding = match crate::infrastructure::local_api::LocalApiServerBinding::bind(
-        client_data.path().to_path_buf(),
-    ) {
-        Ok(binding) => binding,
-        Err(error)
-            if error.to_string().contains("Operation not permitted")
-                || error.to_string().contains("Permission denied") =>
-        {
-            eprintln!("skipping loopback test because bind is forbidden: {error}");
-            return;
-        }
-        Err(error) => panic!("the local API must bind to loopback: {error}"),
+    let Some(host) =
+        try_start_local_api_test_host(client_data.path(), query_data.path(), workflows.path())
+    else {
+        return;
     };
-    let router = api::build_router(
-        Arc::new(
-            crate::adaptor::controller::wiring::build_canonical_workflow_read_usecase(
-                query_data.path().to_path_buf(),
-                Some(workflows.path().to_path_buf()),
-            )
-            .unwrap(),
-        ),
-        runtime,
-        binding.bearer_token(),
-        binding.terminal_bearer_token(),
-        None,
-        None,
+    host.gateway.resolve_workflows_from(
+        workflows.path().to_path_buf(),
+        workflows.path().to_path_buf(),
     );
-    let server_runtime = tokio::runtime::Runtime::new().unwrap();
-    let server = binding.start(router, server_runtime.handle());
 
     let status: serde_json::Value = serde_json::from_str(
         &workflow::cmd_status(client_data.path(), execution_id, true).unwrap(),
@@ -108,7 +130,8 @@ fn test_保持対象cli_discoveryとlive_httpを通る() {
     .unwrap();
     assert_eq!(status["id"], execution_id);
 
-    gateway.bind_node_execution("00000000-0000-4000-8000-000000000456", execution_id);
+    host.gateway
+        .bind_node_execution("00000000-0000-4000-8000-000000000456", execution_id);
 
     output::cmd_output_submit(
         client_data.path(),
@@ -125,7 +148,7 @@ fn test_保持対象cli_discoveryとlive_httpを通る() {
     assert_eq!(output["status"], "submitted");
     assert_eq!(output["contract"], "review-result");
 
-    let commands = gateway.commands.lock().unwrap();
+    let commands = host.gateway.commands.lock().unwrap();
     assert_eq!(commands.outputs.len(), 1);
     assert_eq!(
         commands.outputs[0].node_execution_id,
@@ -133,7 +156,7 @@ fn test_保持対象cli_discoveryとlive_httpを通る() {
     );
     drop(commands);
 
-    server.shutdown();
+    drop(host);
     assert!(!local_api_discovery_path(client_data.path()).exists());
 }
 
@@ -151,6 +174,65 @@ fn test_local_api更新_discovery欠落時に日本語で拒否する() {
     assert!(
         matches!(result, Err(CliError::Other(message)) if message.contains("アプリの起動が必要"))
     );
+}
+
+#[test]
+fn test_local_api_fallback無し読取_discovery欠落時は更新と同じ失敗になる() {
+    // Given
+    let temp = TempDir::new().unwrap();
+
+    // When
+    let read: Result<(), CliError> = read_without_fallback(temp.path(), |_| unreachable!());
+    let mutation: Result<(), CliError> = mutation(temp.path(), |_| unreachable!());
+
+    // Then
+    assert_eq!(read, mutation);
+    assert_eq!(
+        read,
+        Err(CliError::Other(
+            "この操作には Releash アプリの起動が必要です".to_string()
+        ))
+    );
+}
+
+#[test]
+fn test_workflow_diagnosticsはdirectory有無をqueryへ写す() {
+    // Given
+    let cases = [
+        (None, "/v1/workflow/diagnostics"),
+        (Some("/tmp/x"), "/v1/workflow/diagnostics?dir=%2Ftmp%2Fx"),
+    ];
+
+    for (dir, expected_target) in cases {
+        let temp = TempDir::new().unwrap();
+        let server = write_diagnostics_server(temp.path(), expected_target);
+
+        // When
+        let value =
+            read_without_fallback(temp.path(), |client| client.workflow_diagnostics(dir)).unwrap();
+
+        // Then
+        assert_eq!(value, serde_json::json!({}));
+        server.join().unwrap();
+    }
+}
+
+#[test]
+fn test_local_api_status_errorのcli分類を維持する() {
+    // Given
+    let invalid_statuses = [400, 409, 422];
+
+    // When
+    let not_found = api_error(404, Some("missing"));
+    let invalid = invalid_statuses.map(|status| api_error(status, Some("invalid")));
+    let unauthorized = api_error(401, Some("unauthorized"));
+
+    // Then
+    assert!(matches!(not_found, CliError::NotFound(_)));
+    assert!(invalid
+        .into_iter()
+        .all(|error| matches!(error, CliError::InvalidInput(_))));
+    assert!(matches!(unauthorized, CliError::Other(_)));
 }
 
 #[test]

--- a/src-tauri/src/cli/cli_test.rs
+++ b/src-tauri/src/cli/cli_test.rs
@@ -5,6 +5,7 @@ fn test_cli長文help_対応中のagent向けcommandだけを表示する() {
     let help = render_long_help();
     for command in [
         "$ releash workflow --help",
+        "$ releash workflow diagnostics --help",
         "$ releash workflow status --help",
         "$ releash workflow output submit --help",
         "$ releash workflow output get --help",
@@ -22,6 +23,15 @@ fn test_cli長文help_対応中のagent向けcommandだけを表示する() {
 fn test_clicommand整理_保持対象workflowとreview_commandを受理する() {
     let execution_id = "550e8400-e29b-41d4-a716-446655440000";
     for argv in [
+        vec!["releash", "workflow", "diagnostics"],
+        vec![
+            "releash",
+            "workflow",
+            "diagnostics",
+            "--dir",
+            "/tmp/x",
+            "--json",
+        ],
         vec!["releash", "workflow", "status", execution_id],
         vec![
             "releash",
@@ -49,6 +59,39 @@ fn test_clicommand整理_保持対象workflowとreview_commandを受理する() 
         assert!(
             Cli::try_parse_from(argv.clone()).is_ok(),
             "supported command failed to parse: {argv:?}"
+        );
+    }
+}
+
+#[test]
+fn test_診断cli_helpに対象と出力と終了コードを記載する() {
+    // Given
+    let mut command = Cli::command();
+
+    // When
+    let help = command
+        .find_subcommand_mut("workflow")
+        .unwrap()
+        .find_subcommand_mut("diagnostics")
+        .unwrap()
+        .render_long_help()
+        .to_string();
+
+    // Then
+    for expected in [
+        "--dir",
+        "--json",
+        "適用済み Workflow の config directory",
+        "終了コード",
+        "0  severity error の診断が 0 件",
+        "3  severity error の診断が 1 件以上",
+        "1  command 自体の失敗",
+        "2  引数が不正",
+        "4  対象 directory が存在しない",
+    ] {
+        assert!(
+            help.contains(expected),
+            "missing diagnostics help: {expected}"
         );
     }
 }

--- a/src-tauri/src/cli/common.rs
+++ b/src-tauri/src/cli/common.rs
@@ -1,10 +1,36 @@
 use std::path::{Path, PathBuf};
 
-pub(super) fn cli_result_exit_code(result: Result<String, CliError>) -> i32 {
+/// 診断 error が 1 件以上検出されたことを表す終了コード。
+/// command 自体の失敗（1 = Other / 2 = InvalidInput / 4 = NotFound）と区別する。
+pub(super) const DIAGNOSTIC_ERRORS_EXIT_CODE: i32 = 3;
+
+/// CLI の成功結果。stdout と、その結果が表す終了コードの組。
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct CliSuccess {
+    pub(super) stdout: String,
+    pub(super) exit_code: i32,
+}
+
+impl CliSuccess {
+    /// 終了コード 0 の成功。
+    pub(super) fn ok(stdout: String) -> Self {
+        Self {
+            stdout,
+            exit_code: 0,
+        }
+    }
+
+    /// 処理は成功したが、結果の内容が非 zero 終了を表す場合。
+    pub(super) fn with_exit_code(stdout: String, exit_code: i32) -> Self {
+        Self { stdout, exit_code }
+    }
+}
+
+pub(super) fn cli_result_exit_code(result: Result<CliSuccess, CliError>) -> i32 {
     match result {
-        Ok(stdout) => {
-            print!("{stdout}");
-            0
+        Ok(success) => {
+            print!("{}", success.stdout);
+            success.exit_code
         }
         Err(error) => {
             eprintln!("{}", cli_error_stderr(&error));
@@ -388,7 +414,14 @@ mod tests {
 
     #[test]
     fn exit_code_mapping_is_stable() {
-        assert_eq!(cli_result_exit_code(Ok(String::new())), 0);
+        assert_eq!(cli_result_exit_code(Ok(CliSuccess::ok(String::new()))), 0);
+        assert_eq!(
+            cli_result_exit_code(Ok(CliSuccess::with_exit_code(
+                String::new(),
+                DIAGNOSTIC_ERRORS_EXIT_CODE,
+            ))),
+            3
+        );
         assert_eq!(
             cli_error_exit_code(&CliError::InvalidInput("bad".to_string())),
             2

--- a/src-tauri/src/cli/diagnostics.rs
+++ b/src-tauri/src/cli/diagnostics.rs
@@ -1,0 +1,139 @@
+use std::path::{Path, PathBuf};
+
+use super::api_client;
+use serde::Deserialize;
+
+use super::common::{self, CliError, CliSuccess};
+use crate::adaptor::protocol::workflow::{DiagnosticReport, Severity};
+
+pub(super) fn cmd_diagnostics(
+    data_dir: &Path,
+    dir: Option<PathBuf>,
+    json: bool,
+) -> Result<CliSuccess, CliError> {
+    let dir = dir
+        .map(|dir| -> Result<PathBuf, CliError> {
+            let cwd = std::env::current_dir()
+                .map_err(|error| CliError::Other(format!("resolve current directory: {error}")))?;
+            let dir = absolutize(dir, &cwd);
+            ensure_existing_target_dir(&dir)?;
+            Ok(dir)
+        })
+        .transpose()?;
+    let dir = dir.as_deref().map(target_dir_str).transpose()?;
+    let value =
+        api_client::read_without_fallback(data_dir, |client| client.workflow_diagnostics(dir))?;
+    let report = DiagnosticReport::deserialize(&value)
+        .map_err(|error| CliError::Other(format!("decode workflow diagnostics: {error}")))?;
+    let exit_code = diagnostics_exit_code(&report);
+    let stdout = if json {
+        format_json(&value)?
+    } else {
+        format_human_readable(&report)
+    };
+    Ok(CliSuccess::with_exit_code(stdout, exit_code))
+}
+
+/// `--dir` を process の cwd 基準で絶対 path へ解決する。local API へは絶対 path
+/// だけを渡すため、診断対象がアプリ process の cwd に依存しない。
+fn absolutize(dir: PathBuf, cwd: &Path) -> PathBuf {
+    if dir.is_absolute() {
+        dir
+    } else {
+        cwd.join(dir)
+    }
+}
+
+fn ensure_existing_target_dir(path: &Path) -> Result<(), CliError> {
+    if !path.exists() {
+        return Err(CliError::NotFound(format!(
+            "directory does not exist: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn target_dir_str(path: &Path) -> Result<&str, CliError> {
+    path.to_str().ok_or_else(|| {
+        CliError::InvalidInput(format!(
+            "diagnostics target directory must be valid UTF-8: {}",
+            path.display()
+        ))
+    })
+}
+
+/// severity error の item が 1 件以上あれば非 zero。
+/// workflow_summaries / facet_summaries の error_count は合算しない。
+/// add_diagnostic_to_workflow_and_facet が 1 件の item を workflow 側と facet 側の両方の
+/// summary へ計上するため、合算すると二重計上になる。
+fn diagnostics_exit_code(report: &DiagnosticReport) -> i32 {
+    if report
+        .items
+        .iter()
+        .any(|item| item.severity == Severity::Error)
+    {
+        common::DIAGNOSTIC_ERRORS_EXIT_CODE
+    } else {
+        0
+    }
+}
+
+fn format_json(value: &serde_json::Value) -> Result<String, CliError> {
+    let text = serde_json::to_string_pretty(value)
+        .map_err(|error| CliError::Other(format!("serialize workflow diagnostics: {error}")))?;
+    Ok(format!("{text}\n"))
+}
+
+fn format_human_readable(report: &DiagnosticReport) -> String {
+    let mut output = String::new();
+    let mut error_count = 0;
+    let mut info_count = 0;
+    for item in &report.items {
+        let severity = match item.severity {
+            Severity::Error => {
+                error_count += 1;
+                "error"
+            }
+            Severity::Info => {
+                info_count += 1;
+                "info"
+            }
+        };
+        let location = item.span.as_ref().map_or_else(String::new, |span| {
+            span.source.as_ref().map_or_else(
+                || format!(" {}:{}", span.start_line, span.start_col),
+                |source| format!(" {source}:{}:{}", span.start_line, span.start_col),
+            )
+        });
+        let mut targets = Vec::new();
+        if let Some(workflow_name) = &item.workflow_name {
+            targets.push(format!("workflow={workflow_name}"));
+        }
+        if let Some(node_name) = &item.node_name {
+            targets.push(format!("node={node_name}"));
+        }
+        if let (Some(facet_kind), Some(facet_key)) = (&item.facet_kind, &item.facet_key) {
+            targets.push(format!("facet={facet_kind}/{facet_key}"));
+        }
+        if let Some(field) = &item.field {
+            targets.push(format!("field={field}"));
+        }
+        let target = if targets.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", targets.join(", "))
+        };
+        output.push_str(&format!(
+            "{severity} {}{location}{target}: {}\n",
+            item.code, item.message
+        ));
+    }
+    output.push('\n');
+    output.push_str(&format!("{error_count} error, {info_count} info\n"));
+    output
+}
+
+#[cfg(test)]
+#[path = "diagnostics_test.rs"]
+mod diagnostics_tests;

--- a/src-tauri/src/cli/diagnostics_test.rs
+++ b/src-tauri/src/cli/diagnostics_test.rs
@@ -1,0 +1,304 @@
+use super::*;
+
+use crate::adaptor::controller::command::workflow::diagnostics::diagnose_all_impl;
+use crate::cli::test_helpers::start_local_api_test_host as start_host;
+
+const VALID_WORKFLOW: &str = r#"name: valid-fixture
+description: valid diagnostics fixture
+nodes:
+  main:
+    session:
+      provider: claude
+      facets:
+        instruction: fixture-instruction
+"#;
+fn write_valid_fixture(directory: &Path) {
+    std::fs::create_dir_all(directory.join("instructions")).unwrap();
+    std::fs::write(directory.join("valid-fixture.yml"), VALID_WORKFLOW).unwrap();
+    std::fs::write(
+        directory
+            .join("instructions")
+            .join("fixture-instruction.md"),
+        "# Fixture instruction\n",
+    )
+    .unwrap();
+}
+
+fn json_stdout(success: &CliSuccess) -> serde_json::Value {
+    serde_json::from_str(&success.stdout).unwrap_or_else(|error| {
+        panic!(
+            "diagnostics stdout must be JSON: {error}; stdout={}",
+            success.stdout
+        )
+    })
+}
+
+fn report(value: serde_json::Value) -> DiagnosticReport {
+    serde_json::from_value(value).unwrap()
+}
+
+#[test]
+fn test_診断_相対pathだけをcwd基準の絶対pathへ解決する() {
+    // Given
+    let cwd = Path::new("/tmp/repository");
+
+    // When
+    let relative = absolutize(PathBuf::from("workflows"), cwd);
+    let absolute = absolutize(PathBuf::from("/tmp/workflows"), cwd);
+
+    // Then
+    assert_eq!(relative, cwd.join("workflows"));
+    assert_eq!(absolute, PathBuf::from("/tmp/workflows"),);
+}
+
+#[test]
+fn test_診断_存在しない対象directoryをnot_foundにする() {
+    // Given
+    let existing = tempfile::tempdir().unwrap();
+    let missing = existing.path().join("missing");
+
+    // When
+    let existing_result = ensure_existing_target_dir(existing.path());
+    let missing_error = ensure_existing_target_dir(&missing).unwrap_err();
+
+    // Then
+    assert_eq!(existing_result, Ok(()));
+    assert_eq!(
+        missing_error,
+        CliError::NotFound(format!("directory does not exist: {}", missing.display()))
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_診断_utf8ではない対象directoryをinvalid_inputにする() {
+    use std::os::unix::ffi::OsStringExt;
+
+    // Given
+    let path = PathBuf::from(std::ffi::OsString::from_vec(vec![0xff]));
+
+    // When
+    let result = target_dir_str(&path);
+
+    // Then
+    assert!(matches!(result, Err(CliError::InvalidInput(_))));
+}
+
+#[test]
+fn test_診断_error_itemがある場合だけ終了コード3にする() {
+    // Given
+    let error = report(serde_json::json!({
+        "items": [{"code":"E1","severity":"error","stage":"parse_shape","message":"m"}],
+        "workflow_summaries": {},
+        "facet_summaries": {},
+        "facet_usage": {}
+    }));
+    let info = report(serde_json::json!({
+        "items": [{"code":"I1","severity":"info","stage":"resolve","message":"m"}],
+        "workflow_summaries": {},
+        "facet_summaries": {},
+        "facet_usage": {}
+    }));
+    let empty = report(serde_json::json!({
+        "items": [],
+        "workflow_summaries": {},
+        "facet_summaries": {},
+        "facet_usage": {}
+    }));
+
+    // When
+    let error_exit = diagnostics_exit_code(&error);
+    let info_exit = diagnostics_exit_code(&info);
+    let empty_exit = diagnostics_exit_code(&empty);
+
+    // Then
+    assert_eq!(error_exit, 3);
+    assert_eq!(info_exit, 0);
+    assert_eq!(empty_exit, 0);
+}
+
+#[test]
+fn test_診断_human_readable出力がitem順と位置と対象を保持する() {
+    // Given
+    let report = report(serde_json::json!({
+        "items": [
+            {
+                "code":"E1","severity":"error","stage":"parse_shape","message":"first",
+                "span":{"source":"workflow.yml","start_line":2,"start_col":3,"end_line":2,"end_col":4},
+                "workflow_name":"alpha","node_name":"main","field":"permission"
+            },
+            {"code":"I1","severity":"info","stage":"resolve","message":"second"},
+            {"code":"I2","severity":"info","stage":"resolve","message":"third","workflow_name":"beta"},
+            {
+                "code":"I3","severity":"info","stage":"resolve","message":"fourth",
+                "span":{"start_line":4,"start_col":5,"end_line":4,"end_col":6},
+                "facet_kind":"policy","facet_key":"coding"
+            }
+        ],
+        "workflow_summaries": {},
+        "facet_summaries": {},
+        "facet_usage": {}
+    }));
+
+    // When
+    let output = format_human_readable(&report);
+
+    // Then
+    assert_eq!(output.lines().count(), 6);
+    assert_eq!(
+        output,
+        "error E1 workflow.yml:2:3 [workflow=alpha, node=main, field=permission]: first\n\
+info I1: second\n\
+info I2 [workflow=beta]: third\n\
+info I3 4:5 [facet=policy/coding]: fourth\n\
+\n\
+1 error, 3 info\n"
+    );
+}
+
+#[test]
+fn test_診断_json出力が受信valueを再構成しない() {
+    // Given
+    let value = serde_json::json!({
+        "items": [],
+        "workflow_summaries": {},
+        "facet_summaries": {},
+        "facet_usage": {},
+        "future_field": {"kept": true}
+    });
+
+    // When
+    let output = format_json(&value).unwrap();
+
+    // Then
+    assert_eq!(
+        output,
+        format!("{}\n", serde_json::to_string_pretty(&value).unwrap())
+    );
+}
+
+#[test]
+fn test_診断_cli_sourceにdiagnostic_code_literalを持たない() {
+    // Given
+    let sources = [
+        ("mod.rs", include_str!("mod.rs")),
+        ("diagnostics.rs", include_str!("diagnostics.rs")),
+        ("api_client.rs", include_str!("api_client.rs")),
+        ("workflow.rs", include_str!("workflow.rs")),
+        ("common.rs", include_str!("common.rs")),
+    ];
+
+    for (file, source) in sources {
+        // When / Then
+        for prefix in ["\"WF", "\"FAC"] {
+            assert!(
+                !source.contains(prefix),
+                "diagnostic code prefix '{prefix}' must not appear in {file}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_診断_ui経路は存在しない指定directoryをerrorにする() {
+    // Given
+    let client_data = tempfile::tempdir().unwrap();
+    let query_data = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let missing = query_data.path().join("missing");
+    let host = start_host(
+        client_data.path(),
+        query_data.path(),
+        applied_directory.path(),
+    );
+
+    // When
+    let error = host
+        .server_runtime
+        .block_on(diagnose_all_impl(
+            &host.workflow,
+            Some(missing.to_string_lossy().into_owned()),
+        ))
+        .unwrap_err();
+
+    // Then
+    assert_eq!(
+        error,
+        format!("not_found: directory does not exist: {}", missing.display())
+    );
+}
+
+#[test]
+fn test_診断_cli経路は前後空白を含む実在directoryを同じpathでgatewayへ渡す() {
+    // Given
+    let client_data = tempfile::tempdir().unwrap();
+    let query_data = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_parent = tempfile::tempdir().unwrap();
+    let fixture_directory = fixture_parent.path().join(" workflows ");
+    std::fs::create_dir(&fixture_directory).unwrap();
+    write_valid_fixture(&fixture_directory);
+    let _host = start_host(
+        client_data.path(),
+        query_data.path(),
+        applied_directory.path(),
+    );
+
+    // When
+    let success = cmd_diagnostics(client_data.path(), Some(fixture_directory), true).unwrap();
+    let report = json_stdout(&success);
+
+    // Then
+    assert_eq!(success.exit_code, 0);
+    assert!(report["facet_usage"]["instruction/fixture-instruction"].is_array());
+}
+
+#[test]
+fn test_診断_cli経路は通常fileの指定をcommand失敗にする() {
+    // Given
+    let client_data = tempfile::tempdir().unwrap();
+    let query_data = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let target_parent = tempfile::tempdir().unwrap();
+    let file = target_parent.path().join("workflow.yml");
+    std::fs::write(&file, "name: workflow").unwrap();
+    let _host = start_host(
+        client_data.path(),
+        query_data.path(),
+        applied_directory.path(),
+    );
+
+    // When
+    let error = cmd_diagnostics(client_data.path(), Some(file), true).unwrap_err();
+
+    // Then
+    assert_eq!(common::cli_result_exit_code(Err(error)), 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_診断_cli経路は列挙不能なdirectoryの指定をcommand失敗にする() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Given
+    let client_data = tempfile::tempdir().unwrap();
+    let query_data = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let target_parent = tempfile::tempdir().unwrap();
+    let unreadable = target_parent.path().join("unreadable");
+    std::fs::create_dir(&unreadable).unwrap();
+    std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let _host = start_host(
+        client_data.path(),
+        query_data.path(),
+        applied_directory.path(),
+    );
+
+    // When
+    let result = cmd_diagnostics(client_data.path(), Some(unreadable.clone()), true);
+    std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let error = result.unwrap_err();
+
+    // Then
+    assert_eq!(common::cli_result_exit_code(Err(error)), 1);
+}

--- a/src-tauri/src/cli/diagnostics_test.rs
+++ b/src-tauri/src/cli/diagnostics_test.rs
@@ -288,6 +288,11 @@ fn test_診断_cli経路は列挙不能なdirectoryの指定をcommand失敗に�
     let unreadable = target_parent.path().join("unreadable");
     std::fs::create_dir(&unreadable).unwrap();
     std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+    if std::fs::read_dir(&unreadable).is_ok() {
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+        eprintln!("skipping unreadable directory test because this process can read mode 0o000");
+        return;
+    }
     let _host = start_host(
         client_data.path(),
         query_data.path(),

--- a/src-tauri/src/cli/hook.rs
+++ b/src-tauri/src/cli/hook.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 
-use super::api_client::{mutation_classified, ApiRequestError};
+use super::api_client::{request_classified, ApiRequestError};
 use super::common::{cli_error_stderr, resolve_data_dir, CliError};
 use super::HookProvider;
 use crate::adaptor::gateway::provider_lifecycle::{
@@ -93,7 +93,7 @@ fn receive_from(_reader: impl Read, provider: HookProvider) -> Result<String, Cl
         signal,
     };
     let data_dir = resolve_data_dir().map_err(CliError::Other)?;
-    let response = mutation_classified(&data_dir, |client| {
+    let response = request_classified(&data_dir, |client| {
         client.receive_provider_lifecycle(&request)
     })
     .map_err(|error| {

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -5,17 +5,22 @@
 
 mod api_client;
 mod common;
+mod diagnostics;
 mod file_direct;
 mod hook;
 mod output;
 mod review;
+#[cfg(test)]
+mod test_helpers;
 mod workflow;
 
 use std::sync::OnceLock;
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 
-use common::{cli_result_exit_code, resolve_data_dir, resolve_existing_data_dir, CliError};
+use common::{
+    cli_result_exit_code, resolve_data_dir, resolve_existing_data_dir, CliError, CliSuccess,
+};
 use output::OutputSubcommand;
 use review::ReviewSubcommand;
 use workflow::WorkflowSubcommand;
@@ -115,13 +120,16 @@ pub fn run() -> i32 {
             eprintln!("{error}");
         }
     }
-    let result =
-        match cli.command {
-            TopCommand::Workflow { command } => resolve_data_dir()
+    let result = match cli.command {
+        TopCommand::Workflow { command } => {
+            resolve_data_dir()
                 .map_err(CliError::Other)
                 .and_then(|data_dir| match command {
+                    WorkflowSubcommand::Diagnostics { dir, json } => {
+                        diagnostics::cmd_diagnostics(&data_dir, dir, json)
+                    }
                     WorkflowSubcommand::Status { execution_id, json } => {
-                        workflow::cmd_status(&data_dir, &execution_id, json)
+                        workflow::cmd_status(&data_dir, &execution_id, json).map(CliSuccess::ok)
                     }
                     WorkflowSubcommand::Output { command } => match command {
                         OutputSubcommand::Submit {
@@ -135,20 +143,23 @@ pub fn run() -> i32 {
                             contract.as_deref(),
                             json,
                             file,
-                        ),
+                        )
+                        .map(CliSuccess::ok),
                         OutputSubcommand::Get {
                             execution_id,
                             node,
                             json,
-                        } => output::cmd_output_get(&data_dir, &execution_id, &node, json),
+                        } => output::cmd_output_get(&data_dir, &execution_id, &node, json)
+                            .map(CliSuccess::ok),
                     },
-                }),
-            TopCommand::Review { command } => resolve_existing_data_dir()
-                .and_then(|data_dir| review::cmd_review(&data_dir, command)),
-            TopCommand::Hook { command } => match command {
-                HookSubcommand::Receive { provider } => hook::cmd_receive(provider),
-            },
-        };
+                })
+        }
+        TopCommand::Review { command } => resolve_existing_data_dir()
+            .and_then(|data_dir| review::cmd_review(&data_dir, command).map(CliSuccess::ok)),
+        TopCommand::Hook { command } => match command {
+            HookSubcommand::Receive { provider } => hook::cmd_receive(provider).map(CliSuccess::ok),
+        },
+    };
     let exit_code = cli_result_exit_code(result);
     log::logger().flush();
     exit_code

--- a/src-tauri/src/cli/test_helpers.rs
+++ b/src-tauri/src/cli/test_helpers.rs
@@ -1,0 +1,79 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::adaptor::controller::api::{self, test_support as api_test_support};
+use crate::infrastructure::local_api::{LocalApiServer, LocalApiServerBinding};
+use crate::usecase::workflow::WorkflowUsecase;
+
+pub(crate) struct LocalApiTestHost {
+    pub(crate) workflow: Arc<WorkflowUsecase>,
+    pub(crate) gateway: Arc<api_test_support::RecordingRuntimeGateway>,
+    server: Arc<LocalApiServer>,
+    pub(crate) server_runtime: tokio::runtime::Runtime,
+}
+
+impl Drop for LocalApiTestHost {
+    fn drop(&mut self) {
+        self.server.shutdown();
+    }
+}
+
+pub(crate) fn start_local_api_test_host(
+    client_data: &Path,
+    query_data: &Path,
+    applied_directory: &Path,
+) -> LocalApiTestHost {
+    start_local_api_test_host_with_policy(client_data, query_data, applied_directory, false)
+        .expect("strict local API test host must not be skipped")
+}
+
+pub(crate) fn try_start_local_api_test_host(
+    client_data: &Path,
+    query_data: &Path,
+    applied_directory: &Path,
+) -> Option<LocalApiTestHost> {
+    start_local_api_test_host_with_policy(client_data, query_data, applied_directory, true)
+}
+
+fn start_local_api_test_host_with_policy(
+    client_data: &Path,
+    query_data: &Path,
+    applied_directory: &Path,
+    skip_forbidden_bind: bool,
+) -> Option<LocalApiTestHost> {
+    let (workflow, runtime, gateway) = api_test_support::usecases(query_data);
+    let binding = match LocalApiServerBinding::bind(client_data.to_path_buf()) {
+        Ok(binding) => binding,
+        Err(error)
+            if skip_forbidden_bind
+                && (error.to_string().contains("Operation not permitted")
+                    || error.to_string().contains("Permission denied")) =>
+        {
+            eprintln!("skipping loopback test because bind is forbidden: {error}");
+            return None;
+        }
+        Err(error) => panic!("the local API must bind to loopback: {error}"),
+    };
+    let router = api::build_router(
+        Arc::new(
+            crate::adaptor::controller::wiring::build_canonical_workflow_read_usecase(
+                query_data.to_path_buf(),
+                Some(applied_directory.to_path_buf()),
+            )
+            .unwrap(),
+        ),
+        runtime,
+        binding.bearer_token(),
+        binding.terminal_bearer_token(),
+        None,
+        None,
+    );
+    let server_runtime = tokio::runtime::Runtime::new().unwrap();
+    let server = binding.start(router, server_runtime.handle());
+    Some(LocalApiTestHost {
+        workflow,
+        gateway,
+        server,
+        server_runtime,
+    })
+}

--- a/src-tauri/src/cli/workflow.rs
+++ b/src-tauri/src/cli/workflow.rs
@@ -11,6 +11,31 @@ use crate::adaptor::protocol::workflow::{ExecutionStatusView, WorkflowExecutionV
 /// `releash workflow` の Agent-facing command / query 集合。
 #[derive(Subcommand, Debug)]
 pub(super) enum WorkflowSubcommand {
+    /// workflow 定義と Facet を診断する。
+    #[command(long_about = "workflow 定義と Facet を診断する。\n\n\
+対象 directory:\n\
+  --dir <PATH> で指定した directory を workflow source directory として扱う。\n\
+  Facet base は <PATH>/facets が directory ならそこを使い、無ければ <PATH> を使う。\n\
+  指定 directory 配下の workflow 定義を起点に、参照される Facet までを判定範囲とする。\n\
+  --dir を省略した場合は、適用済み Workflow の config directory を対象にする。\n\n\
+出力形式:\n\
+  既定は 1 診断 1 行の human-readable 形式で、末尾に severity 別の件数を出す。\n\
+  --json を付けると、UI が受け取るものと同じ診断結果 JSON をそのまま出力する。\n\n\
+終了コード:\n\
+  0  severity error の診断が 0 件\n\
+  3  severity error の診断が 1 件以上\n\
+  1  command 自体の失敗（Releash アプリ未起動、I/O 失敗、serialize 失敗）\n\
+  2  引数が不正\n\
+  4  対象 directory が存在しない\n\n\
+この command は Releash アプリの起動を必要とする。")]
+    Diagnostics {
+        /// 診断対象 directory。Facet base は facets/ があればそこを、無ければこの directory を使う。省略時は適用済み config directory。
+        #[arg(long, value_name = "PATH")]
+        dir: Option<std::path::PathBuf>,
+        /// 診断結果 JSON をそのまま出力する。
+        #[arg(long)]
+        json: bool,
+    },
     /// 指定 execution の現在 read model を表示する。
     Status {
         execution_id: String,

--- a/src-tauri/src/infrastructure/local_api/client.rs
+++ b/src-tauri/src/infrastructure/local_api/client.rs
@@ -109,7 +109,9 @@ impl LocalApiHttpClient {
         query: &[(&str, &str)],
     ) -> Result<T, LocalApiClientError> {
         let mut url = self.endpoint(segments)?;
-        url.query_pairs_mut().extend_pairs(query.iter().copied());
+        if !query.is_empty() {
+            url.query_pairs_mut().extend_pairs(query.iter().copied());
+        }
         self.send(self.client.get(url))
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,8 @@ mod other;
 pub mod provider_lifecycle_acceptance;
 #[cfg(debug_assertions)]
 pub mod workflow_control_plane_acceptance;
+#[cfg(debug_assertions)]
+pub mod workflow_diagnostics_acceptance;
 pub mod terminal_surface {
     pub use crate::adaptor::controller::terminal_surface_runtime::{
         TerminalSurfaceEventFault, TerminalSurfaceEventFaultController, TerminalSurfaceRuntime,

--- a/src-tauri/src/usecase/workflow/mod.rs
+++ b/src-tauri/src/usecase/workflow/mod.rs
@@ -35,7 +35,7 @@ use crate::domain::workflow::{
 };
 use crate::usecase::workflow::ports::{
     ExternalEditorGateway, WorkflowConfigPathGateway, WorkflowDefinitionSourceGateway,
-    WorkflowDiagnosticsGateway, WorkflowSourceSaveError,
+    WorkflowDiagnosticsGateway, WorkflowDiagnosticsTarget, WorkflowSourceSaveError,
 };
 
 use definition::WorkflowDefinitionUsecase;
@@ -63,6 +63,7 @@ pub(crate) struct WorkflowReadUsecase {
     workspace_query: std::sync::Arc<dyn crate::usecase::workspace_tree::WorkspaceQueryService>,
     output: WorkflowOutputUsecase,
     worktrees: std::sync::Arc<dyn ManagedWorktreeGateway>,
+    diagnostics: std::sync::Arc<dyn WorkflowDiagnosticsGateway>,
 }
 
 impl WorkflowReadUsecase {
@@ -71,13 +72,22 @@ impl WorkflowReadUsecase {
         worktrees: std::sync::Arc<dyn ManagedWorktreeGateway>,
         secrets: std::sync::Arc<dyn SecretSourceGateway>,
         workspace_query: std::sync::Arc<dyn crate::usecase::workspace_tree::WorkspaceQueryService>,
+        diagnostics: std::sync::Arc<dyn WorkflowDiagnosticsGateway>,
     ) -> Self {
         Self {
             output: WorkflowOutputUsecase::new(query.clone(), secrets),
             query,
             worktrees,
             workspace_query,
+            diagnostics,
         }
+    }
+
+    pub(crate) fn diagnose_all(
+        &self,
+        target: WorkflowDiagnosticsTarget,
+    ) -> Result<serde_json::Value, WorkflowError> {
+        self.diagnostics.diagnose_all(target)
     }
 
     pub(crate) fn list_workflow_summaries(
@@ -177,7 +187,6 @@ pub struct WorkflowUsecase {
     output: WorkflowOutputUsecase,
     worktrees: std::sync::Arc<dyn ManagedWorktreeGateway>,
     editors: std::sync::Arc<dyn ExternalEditorGateway>,
-    diagnostics: std::sync::Arc<dyn WorkflowDiagnosticsGateway>,
     config_paths: std::sync::Arc<dyn WorkflowConfigPathGateway>,
     execution_archives: std::sync::Arc<dyn WorkflowExecutionArchiveRepository>,
     workspace_nodes: std::sync::Arc<dyn crate::domain::workspace_tree::WorkspaceTreeRepository>,
@@ -209,6 +218,7 @@ impl WorkflowUsecase {
             output: output.clone(),
             worktrees: worktrees.clone(),
             workspace_query: workspace_query.clone(),
+            diagnostics,
         };
         Self {
             query,
@@ -217,7 +227,6 @@ impl WorkflowUsecase {
             output,
             worktrees,
             editors,
-            diagnostics,
             config_paths,
             execution_archives,
             workspace_nodes,
@@ -458,8 +467,11 @@ impl WorkflowUsecase {
         self.editors.open_facet(kind.dir_name(), key)
     }
 
-    pub fn diagnose_all(&self) -> Result<serde_json::Value, WorkflowError> {
-        self.diagnostics.diagnose_all()
+    pub fn diagnose_all(
+        &self,
+        target: WorkflowDiagnosticsTarget,
+    ) -> Result<serde_json::Value, WorkflowError> {
+        self.read.diagnose_all(target)
     }
 
     pub fn automation_config_dir(&self) -> Result<String, WorkflowError> {
@@ -503,7 +515,8 @@ mod tests {
     };
     use crate::usecase::workflow::ports::{
         ExternalEditorGateway, WorkflowConfigPathGateway, WorkflowDiagnosticsGateway,
-        WorkflowEventDraft, WorkflowEventRepository, WorkflowExecutionProjectionRepository,
+        WorkflowDiagnosticsTarget, WorkflowEventDraft, WorkflowEventRepository,
+        WorkflowExecutionProjectionRepository,
     };
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -767,10 +780,23 @@ mod tests {
         }
     }
 
-    struct FakeDiagnosticsGateway;
+    #[derive(Default)]
+    struct FakeDiagnosticsGateway {
+        targets: Mutex<Vec<WorkflowDiagnosticsTarget>>,
+    }
+
+    impl FakeDiagnosticsGateway {
+        fn targets(&self) -> Vec<WorkflowDiagnosticsTarget> {
+            self.targets.lock().unwrap().clone()
+        }
+    }
 
     impl WorkflowDiagnosticsGateway for FakeDiagnosticsGateway {
-        fn diagnose_all(&self) -> Result<serde_json::Value, WorkflowError> {
+        fn diagnose_all(
+            &self,
+            target: WorkflowDiagnosticsTarget,
+        ) -> Result<serde_json::Value, WorkflowError> {
+            self.targets.lock().unwrap().push(target);
             Ok(serde_json::json!({"items": [], "workflowSummaries": {}}))
         }
     }
@@ -796,6 +822,7 @@ mod tests {
         editors: Arc<FakeExternalEditorGateway>,
         definitions: Arc<FakeDefinitionRepository>,
         definition_sources: Arc<FakeDefinitionSourceGateway>,
+        diagnostics: Arc<FakeDiagnosticsGateway>,
         workspace_nodes: Arc<FakeWorkspaceTreeRepository>,
         _workspace_root: tempfile::TempDir,
     }
@@ -873,6 +900,7 @@ mod tests {
             let facets = Arc::new(FakeFacetRepository::default());
             let events = Arc::new(FakeEventRepository::default());
             let editors = Arc::new(FakeExternalEditorGateway::default());
+            let diagnostics = Arc::new(FakeDiagnosticsGateway::default());
             let workspace_nodes = Arc::new(FakeWorkspaceTreeRepository::default());
             let workspace_root = tempfile::tempdir().unwrap();
             let workspace_query =
@@ -891,7 +919,7 @@ mod tests {
                 facets.clone(),
                 Arc::new(FakeManagedWorktreeGateway),
                 editors.clone(),
-                Arc::new(FakeDiagnosticsGateway),
+                diagnostics.clone(),
                 Arc::new(FakeConfigPathGateway),
                 Arc::new(FakeSecretSourceGateway),
                 Arc::new(NoopArchiveRepository),
@@ -903,6 +931,7 @@ mod tests {
                 editors,
                 definitions,
                 definition_sources,
+                diagnostics,
                 workspace_nodes,
                 _workspace_root: workspace_root,
             }
@@ -1226,11 +1255,48 @@ mod tests {
     }
 
     #[test]
-    fn diagnose_and_config_path_delegate_to_gateways() {
+    fn test_診断usecase_指定directoryをgatewayへ渡す() {
+        // Given
+        let fixture = Fixture::new();
+        let path = std::path::PathBuf::from("/tmp/custom-workflows");
+
+        // When
+        let report = fixture
+            .usecase
+            .diagnose_all(WorkflowDiagnosticsTarget::Directory(path.clone()))
+            .unwrap();
+
+        // Then
+        assert_eq!(report["items"].as_array().unwrap().len(), 0);
+        assert_eq!(
+            fixture.diagnostics.targets(),
+            vec![WorkflowDiagnosticsTarget::Directory(path)]
+        );
+    }
+
+    #[test]
+    fn test_診断usecase_適用済みdirectoryをgatewayへ渡す() {
+        // Given
         let fixture = Fixture::new();
 
-        let report = fixture.usecase.diagnose_all().unwrap();
+        // When
+        let report = fixture
+            .usecase
+            .diagnose_all(WorkflowDiagnosticsTarget::AppliedConfigDirectory)
+            .unwrap();
+
+        // Then
         assert_eq!(report["items"].as_array().unwrap().len(), 0);
+        assert_eq!(
+            fixture.diagnostics.targets(),
+            vec![WorkflowDiagnosticsTarget::AppliedConfigDirectory]
+        );
+    }
+
+    #[test]
+    fn config_path_delegates_to_gateway() {
+        let fixture = Fixture::new();
+
         assert_eq!(
             fixture.usecase.automation_config_dir().unwrap(),
             "/automation"

--- a/src-tauri/src/usecase/workflow/ports.rs
+++ b/src-tauri/src/usecase/workflow/ports.rs
@@ -80,8 +80,40 @@ pub trait ExternalEditorGateway: Send + Sync {
     fn open_facet(&self, kind: &str, key: &str) -> Result<(), WorkflowError>;
 }
 
+/// workflow diagnostics の診断対象。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkflowDiagnosticsTarget {
+    /// 適用済み Workflow の config directory。実際の path は gateway 実装が所有する。
+    AppliedConfigDirectory,
+    /// 呼び出し時に指定された workflow source directory。Facet base は gateway が解決する。
+    Directory(std::path::PathBuf),
+}
+
+impl WorkflowDiagnosticsTarget {
+    /// 入口（Tauri command / local API）が受け取る optional な directory 文字列を対象へ写す。
+    /// 絶対 path であることだけを検証する。空文字列と空白のみの文字列も相対 path として
+    /// 弾かれる。前後の空白は path の一部として保持する（空白を含む directory 名は正当で
+    /// あり、trim すると実在する対象を診断できなくなる）。対象 directory の実在検査は
+    /// filesystem I/O を所有する gateway が行う。
+    pub fn from_optional_directory(dir: Option<String>) -> Result<Self, WorkflowError> {
+        let Some(dir) = dir else {
+            return Ok(Self::AppliedConfigDirectory);
+        };
+        let path = std::path::PathBuf::from(&dir);
+        if !path.is_absolute() {
+            return Err(WorkflowError::Validation(format!(
+                "diagnostics target directory must be an absolute path: {dir}"
+            )));
+        }
+        Ok(Self::Directory(path))
+    }
+}
+
 pub trait WorkflowDiagnosticsGateway: Send + Sync {
-    fn diagnose_all(&self) -> Result<serde_json::Value, WorkflowError>;
+    fn diagnose_all(
+        &self,
+        target: WorkflowDiagnosticsTarget,
+    ) -> Result<serde_json::Value, WorkflowError>;
 }
 
 pub trait WorkflowConfigPathGateway: Send + Sync {
@@ -194,4 +226,91 @@ impl<T> WorkflowRuntimeCommandGateway for T where
         + WorkflowRuntimeStateGateway
         + WorkflowRuntimeShutdownGateway
 {
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_診断対象_directory省略時は適用済みconfigになる() {
+        // Given
+        let directory = None;
+
+        // When
+        let target = WorkflowDiagnosticsTarget::from_optional_directory(directory).unwrap();
+
+        // Then
+        assert_eq!(target, WorkflowDiagnosticsTarget::AppliedConfigDirectory);
+    }
+
+    #[test]
+    fn test_診断対象_空directoryを拒否する() {
+        // Given
+        let directories = [String::new(), "   ".to_string()];
+
+        // When
+        let targets = directories
+            .map(|directory| WorkflowDiagnosticsTarget::from_optional_directory(Some(directory)));
+
+        // Then
+        assert!(targets
+            .into_iter()
+            .all(|target| matches!(target, Err(WorkflowError::Validation(_)))));
+    }
+
+    #[test]
+    fn test_診断対象_相対directoryを拒否する() {
+        // Given
+        let directory = "workflows".to_string();
+
+        // When
+        let target = WorkflowDiagnosticsTarget::from_optional_directory(Some(directory));
+
+        // Then
+        assert!(matches!(target, Err(WorkflowError::Validation(_))));
+    }
+
+    #[test]
+    fn test_診断対象_先頭空白付き相対directoryを拒否する() {
+        // Given
+        let directory = " workflows".to_string();
+
+        // When
+        let target = WorkflowDiagnosticsTarget::from_optional_directory(Some(directory));
+
+        // Then
+        assert!(matches!(target, Err(WorkflowError::Validation(_))));
+    }
+
+    #[test]
+    fn test_診断対象_絶対directoryを受理する() {
+        // Given
+        let directory = "/tmp/x".to_string();
+
+        // When
+        let target = WorkflowDiagnosticsTarget::from_optional_directory(Some(directory)).unwrap();
+
+        // Then
+        assert_eq!(
+            target,
+            WorkflowDiagnosticsTarget::Directory(PathBuf::from("/tmp/x"))
+        );
+    }
+
+    #[test]
+    fn test_診断対象_絶対directoryの末尾空白を保持する() {
+        // Given
+        let directory = "/tmp/workflows ".to_string();
+
+        // When
+        let target = WorkflowDiagnosticsTarget::from_optional_directory(Some(directory)).unwrap();
+
+        // Then
+        assert_eq!(
+            target,
+            WorkflowDiagnosticsTarget::Directory(PathBuf::from("/tmp/workflows "))
+        );
+    }
 }

--- a/src-tauri/src/workflow_diagnostics_acceptance.rs
+++ b/src-tauri/src/workflow_diagnostics_acceptance.rs
@@ -1,0 +1,307 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::adaptor::gateway::local_event_store::{LocalEventStore, LocalEventStoreConfig};
+use crate::domain::workflow::entities::workflow_execution::WorkflowExecution;
+use crate::domain::workflow::{ManagedWorktreeGateway, SecretSourceGateway, WorkflowError};
+use crate::infrastructure::local_api::{LocalApiServer, LocalApiServerBinding};
+use crate::usecase::workflow::command::{
+    AbortExecutionCommand, ResolvedStartExecutionCommand, ResumeExecutionCommand,
+    StopExecutionCommand,
+};
+use crate::usecase::workflow::control_plane::{
+    WorkflowControlPlaneCommit, WorkflowControlPlaneGateway,
+};
+use crate::usecase::workflow::ports::ExternalEditorGateway;
+use crate::usecase::workflow::ports::{
+    WorkflowAbortExecutionGateway, WorkflowResumeExecutionGateway, WorkflowRuntimeShutdownGateway,
+    WorkflowRuntimeStateGateway, WorkflowStartExecutionGateway, WorkflowStopExecutionGateway,
+};
+use crate::usecase::workflow::runtime_driver::NodeOutcome;
+use crate::usecase::workflow::runtime_snapshot::RuntimeCommitSnapshot;
+use crate::usecase::workflow::WorkflowRuntimeUsecase;
+
+/// diagnostics harness は診断の read 経路だけを通す。worktree / editor / secret は
+/// この経路から呼ばれないため、呼ばれた場合に harness の想定外だと分かる実装にする。
+struct DiagnosticsAcceptanceWorktreeGateway;
+
+impl ManagedWorktreeGateway for DiagnosticsAcceptanceWorktreeGateway {
+    fn resolve(&self, _worktree_path: &str) -> Result<String, WorkflowError> {
+        Err(unsupported_diagnostics_operation("worktree resolve"))
+    }
+}
+
+struct DiagnosticsAcceptanceExternalEditorGateway;
+
+impl ExternalEditorGateway for DiagnosticsAcceptanceExternalEditorGateway {
+    fn open_workflow(&self, _name: &str) -> Result<(), WorkflowError> {
+        Err(unsupported_diagnostics_operation("open workflow"))
+    }
+
+    fn open_facet(&self, _kind: &str, _key: &str) -> Result<(), WorkflowError> {
+        Err(unsupported_diagnostics_operation("open facet"))
+    }
+}
+
+struct DiagnosticsAcceptanceSecretSourceGateway;
+
+impl SecretSourceGateway for DiagnosticsAcceptanceSecretSourceGateway {
+    fn configured_secret_values(&self) -> Result<Vec<String>, WorkflowError> {
+        Err(unsupported_diagnostics_operation(
+            "configured secret values",
+        ))
+    }
+}
+
+fn unsupported_diagnostics_operation(operation: &str) -> WorkflowError {
+    WorkflowError::external(format!(
+        "{operation} is unavailable in diagnostics acceptance harness"
+    ))
+}
+
+struct DiagnosticsAcceptanceRuntimeGateway;
+
+fn unsupported_runtime_operation() -> WorkflowError {
+    WorkflowError::external("workflow runtime is unavailable in diagnostics acceptance harness")
+}
+
+#[async_trait::async_trait]
+impl WorkflowStartExecutionGateway for DiagnosticsAcceptanceRuntimeGateway {
+    async fn resolve_start_execution_worktree(
+        &self,
+        _worktree_path: String,
+    ) -> Result<String, WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+
+    async fn resolve_start_execution_workflow(
+        &self,
+        _workflow_name: &str,
+    ) -> Result<crate::domain::workflow::WorkflowDefinition, WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+
+    async fn start_resolved_execution(
+        &self,
+        _command: ResolvedStartExecutionCommand,
+    ) -> Result<String, WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowAbortExecutionGateway for DiagnosticsAcceptanceRuntimeGateway {
+    async fn abort_execution(&self, _command: AbortExecutionCommand) -> Result<(), WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowStopExecutionGateway for DiagnosticsAcceptanceRuntimeGateway {
+    async fn stop_execution(&self, _command: StopExecutionCommand) -> Result<(), WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowResumeExecutionGateway for DiagnosticsAcceptanceRuntimeGateway {
+    async fn resume_execution(
+        &self,
+        _command: ResumeExecutionCommand,
+    ) -> Result<(), WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowRuntimeStateGateway for DiagnosticsAcceptanceRuntimeGateway {
+    async fn recover_startup(&self) -> Result<(), WorkflowError> {
+        Ok(())
+    }
+
+    #[cfg(test)]
+    async fn get_state_by_execution_id(
+        &self,
+        _execution_id: &str,
+    ) -> Result<Option<crate::domain::workflow::WorkflowRuntimeSnapshot>, WorkflowError> {
+        Ok(None)
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowRuntimeShutdownGateway for DiagnosticsAcceptanceRuntimeGateway {
+    async fn shutdown_active_commands(&self) {}
+
+    async fn application_shutdown_target_execution_ids(&self) -> Result<Vec<String>, String> {
+        Ok(Vec::new())
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowControlPlaneGateway for DiagnosticsAcceptanceRuntimeGateway {
+    fn current_timestamp(&self) -> f64 {
+        0.0
+    }
+
+    fn new_node_execution_id(&self) -> String {
+        String::new()
+    }
+
+    fn ensure_node_recovery_available(
+        &self,
+        _execution_id: &str,
+        _node_execution_id: &str,
+    ) -> Result<(), WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+
+    async fn resolve_workflow_execution_id(
+        &self,
+        _node_execution_id: &str,
+    ) -> Result<Option<String>, WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+
+    async fn load_active_execution(
+        &self,
+        _execution_id: &str,
+    ) -> Result<Option<WorkflowExecution>, WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+
+    async fn recover_active_executions(&self) -> Result<(), WorkflowError> {
+        Ok(())
+    }
+
+    async fn approval_persisted(
+        &self,
+        _execution_id: &str,
+        _node_name: &str,
+        _node_execution_id: Option<&str>,
+    ) -> Result<bool, WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+
+    fn configured_secret_values(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    async fn commit_control_plane(
+        &self,
+        _commit: WorkflowControlPlaneCommit,
+    ) -> Result<RuntimeCommitSnapshot, WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+
+    async fn finish_control_plane_commit(
+        &self,
+        _worktree_path: &str,
+        _snapshot: &RuntimeCommitSnapshot,
+        _outcome: Option<NodeOutcome>,
+    ) -> Result<(), WorkflowError> {
+        Err(unsupported_runtime_operation())
+    }
+}
+
+pub struct WorkflowDiagnosticsAcceptanceHost {
+    ui_usecase: Arc<crate::usecase::workflow::WorkflowUsecase>,
+    _store: Arc<LocalEventStore>,
+    local_api: Arc<LocalApiServer>,
+    base_url: String,
+    token: String,
+}
+
+impl WorkflowDiagnosticsAcceptanceHost {
+    pub fn start(data_dir: PathBuf, applied_directory: PathBuf) -> Result<Self, String> {
+        let store = LocalEventStore::open(LocalEventStoreConfig::production(data_dir.clone()))
+            .map_err(|error| error.to_string())?;
+        let ui_usecase = crate::adaptor::controller::wiring::build_workflow_services_with_gateways(
+            data_dir.clone(),
+            Arc::new(DiagnosticsAcceptanceWorktreeGateway),
+            Arc::new(DiagnosticsAcceptanceExternalEditorGateway),
+            Arc::new(DiagnosticsAcceptanceSecretSourceGateway),
+            store.clone(),
+        )
+        .0;
+        let workflow = Arc::new(
+            crate::adaptor::controller::wiring::build_canonical_workflow_read_usecase(
+                data_dir.clone(),
+                Some(applied_directory),
+            )
+            .map_err(|error| error.to_string())?,
+        );
+        let runtime = Arc::new(WorkflowRuntimeUsecase::new(Arc::new(
+            DiagnosticsAcceptanceRuntimeGateway,
+        )));
+        let binding = LocalApiServerBinding::bind(data_dir).map_err(|error| error.to_string())?;
+        let port = binding.port();
+        let token = binding.bearer_token();
+        let router = crate::adaptor::controller::api::build_router(
+            workflow,
+            runtime,
+            token.clone(),
+            binding.terminal_bearer_token(),
+            None,
+            None,
+        );
+        let local_api = binding.start(router, &tokio::runtime::Handle::current());
+        Ok(Self {
+            ui_usecase: Arc::new(ui_usecase),
+            _store: store,
+            local_api,
+            base_url: format!("http://127.0.0.1:{port}"),
+            token: token.to_string(),
+        })
+    }
+
+    pub async fn diagnose_via_ui_entry(
+        &self,
+        directory: &Path,
+    ) -> Result<serde_json::Value, String> {
+        let directory = directory
+            .to_str()
+            .ok_or_else(|| "diagnostics directory must be valid UTF-8".to_string())?;
+        crate::adaptor::controller::command::workflow::diagnostics::diagnose_all_impl(
+            &self.ui_usecase,
+            Some(directory.to_string()),
+        )
+        .await
+    }
+
+    pub async fn diagnose(&self, directory: Option<&Path>) -> Result<serde_json::Value, String> {
+        let mut url = reqwest::Url::parse(&format!("{}/v1/workflow/diagnostics", self.base_url))
+            .map_err(|error| error.to_string())?;
+        if let Some(directory) = directory {
+            let directory = directory
+                .to_str()
+                .ok_or_else(|| "diagnostics directory must be valid UTF-8".to_string())?;
+            url.query_pairs_mut().append_pair("dir", directory);
+        }
+        let response = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .map_err(|error| error.to_string())?
+            .get(url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|error| error.to_string())?;
+        let status = response.status();
+        let bytes = response.bytes().await.map_err(|error| error.to_string())?;
+        if !status.is_success() {
+            return Err(format!(
+                "HTTP {}: {}",
+                status.as_u16(),
+                String::from_utf8_lossy(&bytes)
+            ));
+        }
+        serde_json::from_slice(&bytes).map_err(|error| error.to_string())
+    }
+
+    pub async fn shutdown(self) -> Result<(), String> {
+        self.local_api
+            .shutdown_and_wait()
+            .await
+            .map_err(|error| error.to_string())
+    }
+}

--- a/src-tauri/src/workflow_diagnostics_acceptance.rs
+++ b/src-tauri/src/workflow_diagnostics_acceptance.rs
@@ -279,6 +279,8 @@ impl WorkflowDiagnosticsAcceptanceHost {
         }
         let response = reqwest::Client::builder()
             .no_proxy()
+            .connect_timeout(std::time::Duration::from_secs(1))
+            .timeout(std::time::Duration::from_secs(5))
             .build()
             .map_err(|error| error.to_string())?
             .get(url)

--- a/src-tauri/tests/workflow_diagnostics_cli_test.rs
+++ b/src-tauri/tests/workflow_diagnostics_cli_test.rs
@@ -1,0 +1,558 @@
+use std::process::Command;
+
+const RELEASH_CLI_PATH: &str = env!("CARGO_BIN_EXE_releash");
+
+const VALID_WORKFLOW: &str = r#"name: valid-fixture
+description: valid diagnostics fixture
+nodes:
+  main:
+    session:
+      provider: claude
+      facets:
+        instruction: fixture-instruction
+"#;
+
+const INVALID_WORKFLOW: &str = r#"name: invalid-fixture
+description: invalid permission fixture
+nodes:
+  main:
+    session:
+      provider: claude
+      permission: unknown
+"#;
+
+const BOOLEAN_SCALAR_SCHEMA_WORKFLOW: &str = r#"name: boolean-scalar-schema
+description: boolean scalar schema fixture
+schemas:
+  payload:
+    type: object
+    properties:
+      foo: boolean
+nodes:
+  main:
+    command: printf ok
+"#;
+
+const NESTED_SCHEMA_REFERENCE_WORKFLOW: &str = r#"name: nested-schema-reference
+description: nested schema reference fixture
+schemas:
+  payload:
+    type: object
+    properties:
+      nested:
+        type: object
+        properties:
+          child: result
+  result:
+    type: object
+    properties:
+      value: string
+nodes:
+  main:
+    command: printf ok
+"#;
+
+const INVALID_NESTED_ARRAY_SCHEMA_WORKFLOW: &str = r#"name: invalid-nested-array-schema
+description: invalid nested array schema fixture
+schemas:
+  payload:
+    type: object
+    properties:
+      values:
+        type: array
+        items: bad.reference
+nodes:
+  main:
+    command: printf ok
+"#;
+
+fn write_valid_fixture(directory: &std::path::Path) {
+    let facet_directory = directory.join("facets").join("instructions");
+    std::fs::create_dir_all(&facet_directory).unwrap();
+    std::fs::write(directory.join("valid-fixture.yml"), VALID_WORKFLOW).unwrap();
+    std::fs::write(
+        facet_directory.join("fixture-instruction.md"),
+        "# Fixture instruction\n",
+    )
+    .unwrap();
+}
+
+fn write_invalid_fixture(directory: &std::path::Path) {
+    std::fs::write(directory.join("invalid-fixture.yml"), INVALID_WORKFLOW).unwrap();
+}
+
+fn write_scalar_schema_fixture(directory: &std::path::Path) {
+    std::fs::write(
+        directory.join("boolean-scalar-schema.yml"),
+        BOOLEAN_SCALAR_SCHEMA_WORKFLOW,
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("nested-schema-reference.yml"),
+        NESTED_SCHEMA_REFERENCE_WORKFLOW,
+    )
+    .unwrap();
+}
+
+fn write_invalid_nested_array_schema_fixture(directory: &std::path::Path) {
+    std::fs::write(
+        directory.join("invalid-nested-array-schema.yml"),
+        INVALID_NESTED_ARRAY_SCHEMA_WORKFLOW,
+    )
+    .unwrap();
+}
+
+fn write_applied_fixture(directory: &std::path::Path) {
+    std::fs::write(directory.join("applied-only.yml"), "name: [").unwrap();
+}
+
+fn run_diagnostics_cli(
+    data_directory: &std::path::Path,
+    target_directory: Option<&std::path::Path>,
+    json: bool,
+) -> std::process::Output {
+    let mut command = Command::new(RELEASH_CLI_PATH);
+    command.args(["workflow", "diagnostics"]);
+    if let Some(target_directory) = target_directory {
+        command.arg("--dir").arg(target_directory);
+    }
+    if json {
+        command.arg("--json");
+    }
+    command
+        .env("RELEASH_DATA_DIR", data_directory)
+        .output()
+        .unwrap()
+}
+
+fn json_stdout(output: &std::process::Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "diagnostics stdout must be JSON: {error}; stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
+}
+
+#[test]
+fn test_診断cli_アプリ未起動時は既存commandと同じ失敗になる() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+
+    // When
+    let diagnostics = Command::new(RELEASH_CLI_PATH)
+        .args(["workflow", "diagnostics", "--dir"])
+        .arg(fixture_directory.path())
+        .env("RELEASH_DATA_DIR", data_directory.path())
+        .output()
+        .unwrap();
+    let existing_command = Command::new(RELEASH_CLI_PATH)
+        .args([
+            "workflow",
+            "output",
+            "submit",
+            "--node-execution",
+            "00000000-0000-4000-8000-000000000456",
+        ])
+        .env("RELEASH_DATA_DIR", data_directory.path())
+        .output()
+        .unwrap();
+
+    // Then
+    assert_eq!(diagnostics.status.code(), Some(1));
+    assert!(diagnostics.stdout.is_empty());
+    assert_eq!(diagnostics.status.code(), existing_command.status.code());
+    assert_eq!(diagnostics.stderr, existing_command.stderr);
+    assert_eq!(
+        String::from_utf8(diagnostics.stderr).unwrap().trim(),
+        "error: この操作には Releash アプリの起動が必要です"
+    );
+}
+
+#[test]
+fn test_診断cli_helpに対象directoryと終了コードと出力形式が載る() {
+    // Given
+    let arguments = ["workflow", "diagnostics", "--help"];
+
+    // When
+    let output = Command::new(RELEASH_CLI_PATH)
+        .args(arguments)
+        .output()
+        .unwrap();
+
+    // Then
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    for expected in [
+        "--dir",
+        "--json",
+        "適用済み",
+        "Facet base",
+        "出力形式",
+        "終了コード",
+        "0  severity error",
+        "3  severity error",
+        "1  command 自体の失敗",
+        "2  引数が不正",
+        "4  対象 directory が存在しない",
+    ] {
+        assert!(stdout.contains(expected), "missing help text: {expected}");
+    }
+}
+
+#[test]
+fn test_診断cli_存在しないdirはnot_foundで終わる() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let fixture_parent = tempfile::tempdir().unwrap();
+    let missing_directory = fixture_parent.path().join("missing");
+
+    // When
+    let output = Command::new(RELEASH_CLI_PATH)
+        .args(["workflow", "diagnostics", "--dir"])
+        .arg(&missing_directory)
+        .env("RELEASH_DATA_DIR", data_directory.path())
+        .output()
+        .unwrap();
+
+    // Then
+    assert_eq!(output.status.code(), Some(4));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8(output.stderr).unwrap().trim(),
+        format!("directory does not exist: {}", missing_directory.display())
+    );
+}
+
+#[tokio::test]
+async fn test_診断local_api_実http経由で指定directoryのreportを返す() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    std::fs::write(fixture_directory.path().join("custom.yml"), "name: [").unwrap();
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+    // When
+    let report = host.diagnose(Some(fixture_directory.path())).await.unwrap();
+
+    // Then
+    assert!(report["workflow_summaries"]["custom"].is_object());
+    assert!(report["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["workflow_name"] == "custom"));
+    assert!(report["facet_summaries"].is_object());
+    assert!(report["facet_usage"].is_object());
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_診断_ui経路とcli経路が同じvalid_fixtureで同一reportを返す() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    write_valid_fixture(fixture_directory.path());
+    write_applied_fixture(applied_directory.path());
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+    // When
+    let ui_report = host
+        .diagnose_via_ui_entry(fixture_directory.path())
+        .await
+        .unwrap();
+    let cli_output =
+        run_diagnostics_cli(data_directory.path(), Some(fixture_directory.path()), true);
+    let cli_report = json_stdout(&cli_output);
+
+    // Then
+    assert_eq!(cli_output.status.code(), Some(0));
+    assert_eq!(cli_report, ui_report);
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_診断_ui経路とcli経路が同じinvalid_fixtureで同一reportを返す() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    write_invalid_fixture(fixture_directory.path());
+    write_applied_fixture(applied_directory.path());
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+
+    // When
+    let ui_report = host
+        .diagnose_via_ui_entry(fixture_directory.path())
+        .await
+        .unwrap();
+    let cli_output =
+        run_diagnostics_cli(data_directory.path(), Some(fixture_directory.path()), true);
+    let cli_report = json_stdout(&cli_output);
+
+    // Then
+    assert_eq!(cli_output.status.code(), Some(3));
+    assert_eq!(cli_report, ui_report);
+    let item = cli_report["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["code"] == "WFS002")
+        .expect("WFS002 diagnostic");
+    assert_eq!(item["severity"], "error");
+    assert_eq!(item["stage"], "parse_shape");
+    assert_eq!(item["field"], "permission");
+    assert_eq!(item["span"]["start_line"], 7);
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_診断_ui経路とcli経路がscalar_schema宣言のwfs002で同一reportを返す() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    write_scalar_schema_fixture(fixture_directory.path());
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+
+    // When
+    let ui_report = host
+        .diagnose_via_ui_entry(fixture_directory.path())
+        .await
+        .unwrap();
+    let cli_output =
+        run_diagnostics_cli(data_directory.path(), Some(fixture_directory.path()), true);
+    let cli_report = json_stdout(&cli_output);
+
+    // Then
+    assert_eq!(cli_output.status.code(), Some(3));
+    assert_eq!(cli_report, ui_report);
+    let items = cli_report["items"].as_array().unwrap();
+    for (workflow_name, message_fragment) in [
+        (
+            "boolean-scalar-schema",
+            "properties.foo: scalar schema supports only 'string', got 'boolean'",
+        ),
+        (
+            "nested-schema-reference",
+            "properties.nested: properties.child: scalar schema supports only 'string', got 'result'",
+        ),
+    ] {
+        let item = items
+            .iter()
+            .find(|item| item["code"] == "WFS002" && item["workflow_name"] == workflow_name)
+            .unwrap_or_else(|| panic!("{workflow_name} must produce WFS002"));
+        assert_eq!(item["severity"], "error");
+        assert_eq!(item["stage"], "parse_shape");
+        let message = item["message"].as_str().unwrap();
+        assert!(message.starts_with("workflow shape error: error:"));
+        assert!(message.contains(message_fragment), "unexpected WFS002 item: {item:?}");
+        assert!(item["span"]["start_line"].as_u64().is_some());
+    }
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_診断_ui経路とcli経路がnested_schema_validationのwfs002で同一reportを返す() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    write_invalid_nested_array_schema_fixture(fixture_directory.path());
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+
+    // When
+    let ui_report = host
+        .diagnose_via_ui_entry(fixture_directory.path())
+        .await
+        .unwrap();
+    let cli_output =
+        run_diagnostics_cli(data_directory.path(), Some(fixture_directory.path()), true);
+    let cli_report = json_stdout(&cli_output);
+
+    // Then
+    assert_eq!(cli_output.status.code(), Some(3));
+    assert_eq!(cli_report, ui_report);
+    let item = cli_report["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["code"] == "WFS002")
+        .expect("nested schema declaration must produce WFS002");
+    assert_eq!(item["severity"], "error");
+    assert_eq!(item["stage"], "parse_shape");
+    assert!(item["message"]
+        .as_str()
+        .unwrap()
+        .contains("must start with an ASCII alphanumeric"));
+    assert_eq!(item["span"]["start_line"], 7);
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_診断_cli経路は指定directory配下のfacetを含めて適用前に診断する() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    write_valid_fixture(fixture_directory.path());
+    write_applied_fixture(applied_directory.path());
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+
+    // When
+    let output = run_diagnostics_cli(data_directory.path(), Some(fixture_directory.path()), true);
+    let report = json_stdout(&output);
+
+    // Then
+    assert_eq!(output.status.code(), Some(0));
+    assert!(!report["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| { item["code"] == "FAC002" && item["facet_key"] == "fixture-instruction" }));
+    assert!(!report["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| { item["code"] == "FAC000" && item["facet_key"] == "fixture-instruction" }));
+    assert!(report["facet_usage"]["instruction/fixture-instruction"].is_array());
+    assert_eq!(
+        report["facet_summaries"]["instruction/fixture-instruction"],
+        serde_json::json!({ "error_count": 0, "info_count": 0 })
+    );
+    assert!(report["workflow_summaries"].get("applied-only").is_none());
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_診断_error検出時に終了コード3を返す() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    write_invalid_fixture(fixture_directory.path());
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+
+    // When
+    let output = run_diagnostics_cli(data_directory.path(), Some(fixture_directory.path()), true);
+
+    // Then
+    assert_eq!(output.status.code(), Some(3));
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_診断_error無しなら終了コード0を返す() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    write_valid_fixture(fixture_directory.path());
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+
+    // When
+    let output = run_diagnostics_cli(data_directory.path(), Some(fixture_directory.path()), true);
+    let report = json_stdout(&output);
+
+    // Then
+    assert_eq!(output.status.code(), Some(0));
+    assert!(report["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|item| item["severity"] != "error"));
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_診断_dir省略時は適用済みconfig_directoryを対象にする() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    write_valid_fixture(fixture_directory.path());
+    write_applied_fixture(applied_directory.path());
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+
+    // When
+    let output = run_diagnostics_cli(data_directory.path(), None, true);
+    let report = json_stdout(&output);
+
+    // Then
+    assert_eq!(output.status.code(), Some(3));
+    assert!(report["workflow_summaries"]["applied-only"].is_object());
+    assert!(report["workflow_summaries"].get("valid-fixture").is_none());
+    host.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_診断_human_readable出力に検出したdiagnosticが含まれる() {
+    // Given
+    let data_directory = tempfile::tempdir().unwrap();
+    let applied_directory = tempfile::tempdir().unwrap();
+    let fixture_directory = tempfile::tempdir().unwrap();
+    write_invalid_fixture(fixture_directory.path());
+    let host =
+        releash_lib::workflow_diagnostics_acceptance::WorkflowDiagnosticsAcceptanceHost::start(
+            data_directory.path().to_path_buf(),
+            applied_directory.path().to_path_buf(),
+        )
+        .unwrap();
+
+    // When
+    let output = run_diagnostics_cli(data_directory.path(), Some(fixture_directory.path()), false);
+
+    // Then
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(serde_json::from_str::<serde_json::Value>(&stdout).is_err());
+    assert!(stdout.lines().any(|line| line.contains("WFS002")));
+    assert!(stdout.lines().any(|line| line.starts_with("1 error, ")));
+    host.shutdown().await.unwrap();
+}


### PR DESCRIPTION
## 背景

workflow 定義の正式な診断は UI からしか実行できない。診断対象は適用済みの config directory に固定されているため、repository 内で書いた custom workflow を検証するには、いったん config directory へ適用したうえでアプリを起動し、Settings を開く必要がある。

適用前に手元で行えるのは `yq` などによる YAML 構文 parse までで、WFS002 のような workflow shape error、schema 宣言と参照の不整合、Facet 参照の欠落、template 変数と input 宣言の不一致は検出できない。

spec: `docs/specs/issues-1490/`

## 変更

### 診断の実行 owner を `WorkflowReadUsecase` へ移す

Diagnostic は WorkflowDefinition の検証結果であり状態遷移を伴わない読み取りである（`docs/glossary/DOMAIN.md`）。`WorkflowDiagnosticsGateway` の保持と `diagnose_all` を `WorkflowReadUsecase` へ移し、`WorkflowUsecase::diagnose_all()` は委譲にした。

local API が保持するのは `WorkflowReadUsecase` なので、これで UI（Tauri command）と CLI（local API）が同一 usecase メソッドと同一 gateway 実装を通る。CLI 側に parse、schema 検証、routing 検証、Facet 解決、template 検証、diagnostic mapping を複製しない。

### 診断対象を port の引数で渡す

対象 directory は gateway 構築時に固定されていた。実行時に指定できるよう、対象を表す型を usecase 層に置き、port の引数へ移した。

- 適用済み Workflow の config directory（gateway が構築時に保持している path をそのまま使う）
- 呼び出し時に指定された directory

指定 directory は workflow source directory として扱う。Facet base は `facet.rs` を単一 owner とする解決規則により、`<dir>/facets` が directory として存在すればそこを、無ければ従来 layout の `<dir>` を使う。適用済み config directory の path 所有者は gateway 側に残り、CLI と local API handler はこの path を再計算しない。

### 指定 directory の診断範囲は起点からの到達集合とする

適用済み config directory を対象にする場合は「その環境で使える全件」を列挙する。builtin は実体が無くても `include_str!` で使えるため、この列挙が正しい。

指定 directory を対象にする場合は起点が異なる。判定範囲は配下の workflow 定義を起点とし、そこから到達する Facet までとする。到達判定と解決規則は変えないので、builtin facet を参照していれば実行時と同じく解決成功として扱い、その本文も判定範囲に入る。

切り替えるのは対象の列挙だけで、各対象へ適用する診断規則、diagnostic code、severity、message は変えない。

### CLI

```
releash workflow diagnostics [--dir <PATH>] [--json]
```

`--dir` を省略すると適用済み config directory が対象になる。既定は 1 診断 1 行の human-readable 形式で、末尾に severity 別の件数を出す。`--json` は経路から受け取った値を無加工でそのまま出す。

終了コードは severity error の item が 1 件以上あれば `3`、それ以外は `0`。command 自体の失敗（`1` / `2` / `4`）と区別するために未使用の `3` を割り当てた。`workflow_summaries` / `facet_summaries` の `error_count` は 1 件の item を workflow 側と facet 側の両方へ計上するため、合算せず `items` から導出する。

`--help` に対象 directory の指定方法、出力形式、終了コードの意味を記載した。

診断は local API 経由だけで実行し、file-direct fallback を持たない。アプリ未起動時の失敗表示と終了コードは、local API の起動を要する既存 CLI command と同一である。

### local API

```
GET /v1/workflow/diagnostics?dir=<absolute path>
```

`dir` は省略可能。response body は `DiagnosticReport` の JSON をそのまま返し、envelope で包まない。`dir` が相対 path（空文字列を含む）なら `400 invalid_request`、存在しなければ `404 not_found`、directory でない場合や列挙できない場合は `500 workflow_error`。

到達できるのは master token を持つ呼び出し元だけであり、それは同一ユーザーの local process なので、元から同じ file 権限を持つ。権限の拡大は生じない。

### 互換性

既存の diagnostic 規則、diagnostic code、severity、message、`DiagnosticReport` の wire shape は変えない。`diagnose_all_cmd` へ足した対象 directory 引数は optional で、引数なしの既存 invoke（`useAutomation.ts`）は適用済み config directory を対象にし続ける。UI 側の診断表示は変更していない。

診断 DTO は CLI と Tauri command の双方が同じ型で読むため `adaptor/protocol/` へ置いた。DTO の構築（YAML の位置情報から span を作る、item を組み立てる）は外部世界を診断語彙へ写す変換なので gateway が所有する。serde 属性は `Deserialize` の追加だけで、serialize 出力は変わらない。

## 検証

| ゲート | 結果 |
| --- | --- |
| `cargo fmt --check` | pass |
| `cargo clippy --locked --all-targets -- -D warnings` | pass |
| `cargo test --locked` | 2175 + 統合テスト全通過 |
| `qlty check --no-progress --all` | No issues |

frontend の変更が無いため `pnpm` 系のゲートはローカルで実行していない。CI の結果で確認する。

UI 経路と CLI 経路の一致は、同一の一時 directory を両経路の入口へ渡して比較している。CLI は実プロセスとして起動し、UI 経路は `#[cfg(debug_assertions)]` の acceptance harness が実 HTTP で並走させる。valid fixture、invalid permission、scalar schema 宣言、nested schema 宣言の 4 つで、返る JSON 全体の一致と終了コードを確認する。

CLI 経路に診断規則の複製が無いことは、CLI の source に diagnostic code の literal が現れないことをテストで固定している。

Closes #1490

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KabNDUhBayxwEVLuAbfjo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `workflow diagnostics` CLIコマンドを追加しました。
  * 対象ディレクトリを指定してワークフロー診断を実行できます。
  * 人間向け出力とJSON出力に対応しました。
  * 診断結果にエラーが含まれる場合は、専用の終了コードを返します。
  * UIとCLIで共通の診断結果・JSON形式を利用します。

* **改善**
  * `--help` に対象範囲、出力形式、終了コードの説明を追加しました。
  * 不存在のディレクトリやアプリ未起動時のエラーを明確にしました。
  * 指定ディレクトリから到達可能なワークフローとFacetのみを診断します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->