### PR TITLE
fix(local-api): discovery 受理判定を domain へ移し接続不能と陳腐化を区別する (#1704)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -44,7 +44,7 @@ infrastructure ← adaptor（controller / gateway / presenter）→ usecase → 
 - Provider lifecycleとProvider availabilityは別の境界である。
 - 旧Agent GUI specは現行正本ではない。
 
-## ドメイン一覧（15個）
+## ドメイン一覧（16個）
 
 | ドメイン | 含まれる責務 |
 |---|---|
@@ -52,6 +52,7 @@ infrastructure ← adaptor（controller / gateway / presenter）→ usecase → 
 | `repository` | branch、commit、log、worktree、status、repo_paths、git_config |
 | `workflow` | 定義、実行木、Artifact、Contract、facet、completion と承認、Diagnostic |
 | `local_event` | 永続 local event store の語彙。store identity、atomic batch、state mutation、query、transaction port |
+| `local_api_discovery` | local API discovery の内容、プロセス観測、接続先観測に基づく受理・拒否判定 |
 | `workspace_tree` | Workspace / Session の bounded な query 集約。canonical な execution / node / session record から復元する |
 | `comment` | diff_comment_store、diff_comment_sender |
 | `agent_session` | AgentSession identity、lifecycle、Provider、Terminal ownership |

--- a/docs/specs/issues-1704/behavior.md
+++ b/docs/specs/issues-1704/behavior.md
@@ -1,0 +1,67 @@
+## B-001: 接続先を確認できなかった場合の失敗表示
+
+GIVEN discovery file が存在し、その内容の検査を通過する
+AND 実行環境が discovery の接続先への接続を許可しない
+WHEN local API を使う CLI command を実行する
+THEN 失敗表示は、接続先を確認できなかったこと（接続不能または環境による遮断）を失敗の理由として示す
+AND 失敗表示は、discovery file が不正または古いことを失敗の理由として示さない
+
+## B-002: 接続先が別インスタンスを指す場合の失敗表示
+
+GIVEN discovery file が存在し、その内容の検査を通過する
+AND discovery の接続先へ到達できる
+AND その接続先が discovery の instance_id を持つ local API ではない
+WHEN local API を使う CLI command を実行する
+THEN 失敗表示は、discovery が別のインスタンスを指すか陳腐化していることを失敗の理由として示す
+AND 失敗表示は、接続先を確認できなかったことを失敗の理由として示さない
+
+## B-003: discovery が指すプロセスが存在しない場合の接続拒否
+
+GIVEN 実行環境が discovery の pid に対するプロセス情報を参照できる
+AND discovery が指す pid のプロセスが存在しない
+WHEN local API を使う CLI command を実行する
+THEN その discovery を用いた local API への接続は拒否される
+AND command は失敗する
+
+## B-004: discovery の開始時刻が一致しない場合の接続拒否
+
+GIVEN 実行環境が discovery の pid に対するプロセス情報を参照できる
+AND discovery が指す pid のプロセスの開始時刻が discovery の process_started_at と一致しない
+WHEN local API を使う CLI command を実行する
+THEN その discovery を用いた local API への接続は拒否される
+AND command は失敗する
+
+## B-005: 接続先の確認が成立しない場合の token 非送信
+
+GIVEN discovery file が存在し、その内容の検査を通過する
+AND 接続先が discovery の instance_id を持つ local API であることを確認できない
+WHEN local API を使う CLI command を実行する
+THEN 接続先へ discovery の token を含む request は送信されない
+AND command は失敗する
+
+## B-006: local API が起動していない場合の失敗表示と終了コード
+
+GIVEN discovery file が存在しない
+WHEN `releash workflow output submit` を実行する
+THEN stderr へ `error: この操作には Releash アプリの起動が必要です` が出力される
+AND 終了コードは 1 である
+
+## B-007: プロセス情報を参照できない場合の専用失敗
+
+GIVEN discovery file が存在し、その内容の検査を通過する
+AND 実行環境からプロセス情報を参照できない
+WHEN local API を使う CLI command を実行する
+THEN discovery は不正・陳腐化とは区別した専用の失敗として拒否される
+AND 失敗表示はプロセス情報を参照できないため接続先を確認できなかったことを示す
+AND 失敗表示は discovery file の path、token、「不正」「古い」の語を含まない
+AND identity GET を含む接続先への request は送信されない
+AND command は file fallback へ進まず終了コード 1 で失敗する
+
+## 要件IDとBehavior IDの対応表
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001, B-002 |
+| R-002 | B-003, B-004 |
+| R-003 | B-005 |
+| R-004 | B-006 |
+| R-005 | B-007 |

--- a/docs/specs/issues-1704/design.md
+++ b/docs/specs/issues-1704/design.md
@@ -1,0 +1,186 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### 判定規則を domain が所有し、gateway が外部信号を調停する
+
+`src-tauri/src/domain/local_api_discovery/` を discovery 受理判定のドメイン境界とする。ここに discovery の内容を表す `DiscoveryContent`、プロセス観測の三値を表す `ProcessObservation`、接続先観測の三値を表す `ConnectionObservation`、受理・拒否と失敗種別を決める純粋な `DiscoveryAdmissionService` を置く。domain は reqwest、sysinfo、filesystem の型を受け取らず、transport error の実体も受け取らない。
+
+`src-tauri/src/infrastructure/local_api/` は discovery file の読み込みと decode、sysinfo から得た開始時刻とプロセス一覧の有無、identity endpoint の応答 status または transport error、認証済み request の transport だけを扱う。これらの生信号を受理可否へ分類しない。
+
+infrastructure の local API 用 reqwest client は redirect を追従しない。identity GET と以降の認証済み request の接続先を discovery が指す `127.0.0.1:<port>` に固定する。identity GET が 3xx を返した場合、gateway はその status を生の応答として domain へ渡し、domain は「応答はあるが 204 でない」接続先観測として `InstanceMismatch` に分類する。
+
+`src-tauri/src/adaptor/gateway/local_api.rs` の `LocalApiClientGateway::discover` が生信号を集め、domain の値へ変換して `DiscoveryAdmissionService` に判定を委ねる。拒否理由を `LocalApiClientError` へ写し、CLI へ出す失敗文言を生成する。プロセス観測を受理した場合だけ identity GET 用の client を組み立て、接続先観測も受理した場合だけ呼び出し元へ返す。CLI 側（`src-tauri/src/cli/api_client.rs`）は gateway の入口を使い、discovery 失敗を既存の catch-all で `CliError::Other` へ落とす。
+
+所有者を CLI 側へ移す設計（`ApiRequestError` に失敗種別を足す）は採らない。`ApiRequestError` の `Unavailable` は「local API へ到達できないので fallback してよい／アプリ起動を促す」という意味を持ち、R-004（`Unavailable` に対応する既存文言）と B-005（確認不成立時は command が失敗する）を同時に満たせなくなるためである。詳細は Alternatives Considered。
+
+#### discovery 検証を内容・プロセス・接続先の順で行う
+
+gateway は次の順で観測し、domain の判定へ渡す。
+
+1. discovery file の読み込みと decode
+2. 内容の検査（`port` / `token` / `instance_id` / `pid` / `process_started_at` の空・0 検査と PID 照合）
+3. 接続先の確認（`/.well-known/releash-local-api/<instance_id>` への無認証 GET が 204 か）
+
+接続先観測は次の三値とする。
+
+- **確認できた（204）** — 接続を許可する。
+- **確認した上で不成立（応答は得られたが 204 でない）** — `DiscoveryInstanceMismatch`。
+- **確認できなかった（transport error）** — `DiscoveryUnreachable`。
+
+「応答を得られたか」で分ける。connect 拒否、環境による遮断、timeout、protocol error はすべて「確認できなかった」に属する。B-001 の GIVEN は接続拒否だが、timeout も「確認できなかった」であり、同じ側へ寄せる。
+
+2 段目では、内容の空・0検査とPID照合を分離する。内容の検査が不成立なら従来どおり `InvalidDiscovery` とする。PID照合は infrastructure の生信号から domain が構築する `ProcessObservation` の三値で分岐する。
+
+- **プロセス情報を参照できない** — 不正・陳腐化とは区別した `ProcessInformationUnavailable` として拒否し、接続先確認へ進まない。
+- **参照できたが対象プロセスが不在、または開始時刻が0** — 従来どおり `InvalidDiscovery` とする。
+- **開始時刻を取得できた** — discoveryの `process_started_at` と一致すれば接続先確認へ進み、不一致なら従来どおり `InvalidDiscovery` とする。
+
+`lookup_process_start_time` はまず対象PIDだけを参照する。開始時刻を取得できなかった場合に限り全プロセスを参照し、開始時刻の有無とプロセス一覧の有無を生値のまま gateway へ返す。参照不能か対象不在かの分類は `ProcessObservation::from_raw` が行う。`process_start_time` の既存 `Option<u64>` interface はlocal API起動処理のために残すため、起動時に自プロセスの開始時刻を解決できなければ失敗する既存動作は変わらない。
+
+#### 受入条件の検証手段
+
+- 内容、プロセス観測、接続先観測の判定規則は `domain/local_api_discovery/local_api_discovery_test.rs` の純粋な単体テストで検証する。
+- discovery file、sysinfo、HTTP status の生信号取得は `infrastructure/local_api/{client,discovery}_test.rs` で検証する。
+- B-001 の「接続不能」は、応答を得られない接続先を与える gateway 単体テストで検証する。「環境による遮断」は自動テストで再現せず、同じ「応答なし」へ変換される transport error で代表させる。
+- B-002 は、identity path が 204 以外を返す偽サーバを用いた gateway 単体テストで検証する。
+- B-003 / B-004 は既存の単体テストが維持対象として残る。
+- B-005 の「token を含む request を送信しない」は、偽サーバが受信した request を検査する単体テストで検証する。
+- B-006 は既存経路（discovery file 不在 → `Ok(None)` → `ApiRequestError::Unavailable` → `app_must_be_running_error`）の変更なしで満たす。
+- B-007 は、gateway へプロセス参照の生信号を注入し、専用失敗が返ることと、偽サーバが接続を1件も受理しないことを検証する。三値の分類規則は domain の単体テストで個別に検証する。
+
+### Interface
+
+外部から観測できる契約は CLI の stderr 表示と終了コードである。追加するのは次の 3 分類で、いずれも `CliError::Other` として `error: <message>` 形式・終了コード 1 で出る（`cli/common.rs` の既存整形）。
+
+- 接続先を確認できなかった場合:
+  `local API の接続先 (127.0.0.1:<port>) へ接続できず、接続先を確認できませんでした。接続が拒否されたか、実行環境が loopback 接続を許可していません: <transport error>`
+  discovery file のパスも「不正」「古い」という語も含めない（B-001）。
+- 接続先が別インスタンスを指す場合:
+  `local API discovery が別のインスタンスを指しているか、古くなっています (<discovery file path>)`
+  「接続できなかった」という語を含めない（B-002）。
+- プロセス情報を参照できない場合:
+  `プロセス情報を参照できないため、local API の接続先を確認できませんでした`
+  discovery file のパス、token、「不正」「古い」という語を含めず、接続先へ request を送信しない（B-007）。
+
+変えない契約:
+
+- discovery file 不在時の `この操作には Releash アプリの起動が必要です` と終了コード 1（R-004 / B-006）。
+- 内容の検査、およびプロセス情報を参照できる場合のプロセス不在・開始時刻不一致時の `local API discovery file が不正または古いです (<path>)`。
+- local API の wire 契約（`/.well-known/releash-local-api/<instance_id>` への無認証 GET と 204、以降の Bearer 認証）。server 側は変更しない。
+- gateway の `LocalApiClientGateway::discover` は `Result<Option<Self>, LocalApiClientError>` を返し、`Ok(None)` は discovery file 不在のみを意味する。
+
+内部境界として、infrastructure は `ProcessStartTimeLookup`（開始時刻とプロセス一覧の有無）および identity GET の status / transport error を返す。gateway はそれぞれを domain の `ProcessObservation` と `ConnectionObservation` へ変換する。
+
+gateway の `LocalApiClientError` に `ProcessInformationUnavailable`、`DiscoveryUnreachable`（port と transport error を保持）、`DiscoveryInstanceMismatch`（discovery file path を保持）を追加する。`Unavailable` は従来どおり「確認済みの接続先に対する本 request の connect 失敗」に限って使い、意味を変えない。
+
+### Data Model
+
+discovery file のスキーマ（`LocalApiDiscovery` の `port` / `token` / `instance_id` / `pid` / `process_started_at`）は変更しない。追加も削除もないため versioning は不要で、旧版アプリが書いた discovery file を新版 CLI が読む組み合わせ、およびその逆も従来どおり成立する。
+
+新たに永続化する record はない。
+
+### Database
+
+該当なし。
+
+### UI/UX
+
+該当なし。CLI の失敗表示は Interface に記載した。
+
+### Algorithm
+
+該当なし。
+
+### Infra
+
+該当なし。
+
+## Alternatives Considered
+
+- **接続不能を `ApiRequestError::Unavailable` へ分類する案。** 既存の「到達できない」分類に寄せれば CLI 側の変更が不要になる。採らない。`Unavailable` は `mutation` で `この操作には Releash アプリの起動が必要です` に落ちるため、R-004 が固定する discovery file 不在時の表示と同じ文言になり、B-001 の「接続先を確認できなかったことを理由として示す」を満たせない。加えて `read_with_fallback` が file fallback へ進んで command が成功してしまい、B-005 の「command は失敗する」に反する。
+- **`Unavailable` に理由を持たせて `require_running` で文言を分ける案。** 上記の文言問題だけは解けるが、`read_with_fallback` の fallback 判定が `Unavailable` 全体に掛かるため B-005 を満たせない。
+- **PID 照合を撤廃して接続先確認だけに一本化する案。** R-002（B-003 / B-004）を満たせない。
+
+## Cross-cutting concerns
+
+- **token の非送信順序（R-003 / B-005）。** gateway はプロセス観測を受理した後にだけ identity GET を送り、接続先確認が成立した後にだけ認証済み request を送る。`ProcessInformationUnavailable` は identity GET より前に、`DiscoveryUnreachable` / `DiscoveryInstanceMismatch` は認証済み request より前に返る。接続先確認そのものは従来どおり無認証 GET のままにする。
+- **失敗表示に秘密を含めない。** 新しい 3 分類の文言には discovery の `token` を含めない。`ProcessInformationUnavailable` は固定文言だけを持ち、`DiscoveryUnreachable` が保持するのは port と transport error であり、identity 確認 URL に token は現れない。
+
+## Risks
+
+- **実 sandbox 下の挙動を自動テストで再現できない。** B-001 の実環境成立は cargo test では確認できず、手動検証に依存する。手動検証の環境が requirements の計測条件（codex-cli 0.149.1、macOS Darwin 25.5.0、`sandbox_mode = "workspace-write"`、network access 無効）から外れると、確認したことにならない。
+- **プロセス一覧が空であることを参照不能の判定に使う。** 対応プラットフォームのmacOSでは正常な一覧が空になることはないという前提に立つ。参照不能と判定した場合は専用失敗として接続前に拒否するため、判定が安全側を外れても接続先への情報送信には進まない。
+
+## 接続先確認の失敗分類に対する既存の手動検証
+
+以下はPID参照不能分岐を追加する前に、B-001とB-006を2026-08-27に確認した記録である。記載するworktree diffとbinaryのSHA-256はその時点の検証対象を識別するものであり、現在の domain / gateway 境界とPID参照不能分岐を含むファイルを指すものではない。B-007は「受入条件の検証手段」に記載した注入可能な単体テストで検証する。
+
+- codex-cli 0.149.1
+- macOS 26.5.2（Darwin 25.5.0、arm64）
+- `~/.codex/config.toml` の `sandbox_mode = "workspace-write"`
+- codex-cli 0.149.1 の組み込み permission profile `:workspace` と `--sandbox-state-disable-network` を明示
+- worktree: `/Volumes/siro33950_SSD_1/workspace/releash-worktrees/feat-issues-1704`
+- Git HEAD: `092d3fb09109ff8147291d43cba86a293c370fa9`
+- `client.rs` と `client_test.rs` の worktree diff SHA-256: `6014a76938c5d391561071ab4c16d29755c065c320dd7e12bb1f9b08ab812eae`
+- 検証 binary: `src-tauri/target/debug/releash`
+- binary SHA-256: `74084adcb0b7b204a69ff4aaac51f9eded0636669b48a81971df9d4120f379ea`
+- binary mtime: `2026-08-27T19:22:12+0900`
+
+`pnpm tauri:dev` がこの worktree の `releash v0.4.7` をコンパイルして上記 binary を起動したログを確認した。Releash (Dev) の local API は `/Users/siro33950/Library/Application Support/com.releash.app.dev/local-api.json` に discovery file を作成し、検証時は PID 65820、port 54400 で稼働していた。token は表示・記録していない。
+
+### sandbox 内
+
+実行 command:
+
+```bash
+codex sandbox \
+  -P :workspace \
+  --sandbox-state-disable-network \
+  -C /Volumes/siro33950_SSD_1/workspace/releash-worktrees/feat-issues-1704 \
+  -- env \
+  RELEASH_DATA_DIR='/Users/siro33950/Library/Application Support/com.releash.app.dev' \
+  /Volumes/siro33950_SSD_1/workspace/releash-worktrees/feat-issues-1704/src-tauri/target/debug/releash \
+  workflow diagnostics
+```
+
+stdout は空。stderr 全文:
+
+```text
+error: local API の接続先 (127.0.0.1:54400) へ接続できず、接続先を確認できませんでした。接続が拒否されたか、実行環境が loopback 接続を許可していません: error sending request for url (http://127.0.0.1:54400/.well-known/releash-local-api/74f6fd2fb4eb4bbf9de6f24407ba0ba8)
+```
+
+終了コードは 1。stderr に `local API discovery file が不正または古いです` は含まれなかった。
+
+### sandbox 外
+
+同じ Releash (Dev) が稼働している間に、同じ binary と data directory で実行した。
+
+```bash
+RELEASH_DATA_DIR='/Users/siro33950/Library/Application Support/com.releash.app.dev' \
+  /Volumes/siro33950_SSD_1/workspace/releash-worktrees/feat-issues-1704/src-tauri/target/debug/releash \
+  workflow diagnostics
+```
+
+stdout は `info WFI000 [workflow=01_author-spec]: ビルトインワークフロー '01_author-spec'` から始まる診断結果を出力し、末尾は `0 error, 58 info` だった。stderr は空。終了コードは 0。
+
+### アプリ停止時
+
+Releash (Dev) の PID 65820 が停止したことを確認した。discovery file 不在の条件を明示するため、新規の空 data directory `/tmp/releash-1704-stopped-data.oJJgZG` を使った。
+
+```bash
+RELEASH_DATA_DIR=/tmp/releash-1704-stopped-data.oJJgZG \
+  /Volumes/siro33950_SSD_1/workspace/releash-worktrees/feat-issues-1704/src-tauri/target/debug/releash \
+  workflow output submit \
+  --node-execution 00000000-0000-0000-0000-000000000000
+```
+
+stdout は空。stderr 全文:
+
+```text
+error: この操作には Releash アプリの起動が必要です
+```
+
+終了コードは 1。

--- a/docs/specs/issues-1704/requirements.md
+++ b/docs/specs/issues-1704/requirements.md
@@ -1,0 +1,103 @@
+# Context
+
+## 入力文書
+
+- 要求の正本: [Issue #1704](https://github.com/siro33950/releash/issues/1704)「fix(local-api): sandbox 内の provider session から submit できない — discovery の PID 照合が seatbelt で成立せず InvalidDiscovery に誤診される」（state: OPEN、label なし、milestone なし、2026-08-27 作成）
+- 調査で参照した実装
+  - `src-tauri/src/infrastructure/local_api/client.rs:59-88` — discovery の読み込みと検証（`discover`）、失敗種別（`LocalApiClientError`）
+  - `src-tauri/src/infrastructure/local_api/client.rs:135-143` — `matches_server_instance`（`/.well-known/releash-local-api/<instance_id>` への無認証 GET が 204 を返すかの確認）
+  - `src-tauri/src/infrastructure/local_api/discovery.rs:26-38` — `process_start_time`（sysinfo 経由の他プロセス参照）
+  - `src-tauri/src/infrastructure/local_api/server.rs:25-137` — discovery file の書き出しと identity endpoint の登録
+  - `src-tauri/src/cli/api_client.rs` — CLI から local API を呼ぶ入口と失敗の分類（`discover` の Err は `CliError::Other` へ落ちる）
+  - `src-tauri/src/cli/common.rs:50-53` — CLI の stderr 表示形式（`error: <message>`）
+  - `src-tauri/src/adaptor/gateway/provider_lifecycle/launch_spec.rs:182-206` — provider session 起動時の permission と sandbox flag の対応
+- 規約: `AGENTS.md`「構成で押さえる点」「セキュリティ」
+
+## 確定済みの背景と制約
+
+- local API は 127.0.0.1 のみに bind し、`{data_dir}/local-api.json`（0600）へ port、token、instance_id、pid、process_started_at を書き出す。CLI はこの file から接続先と token を得る。
+- CLI が local API へ接続する前の検査は 2 段ある。(1) discovery file の内容検査（port / token / instance_id / process_started_at の空・0 検査と、`process_start_time(pid)` が `process_started_at` と一致するかの照合）。(2) token を送る前に、接続先が discovery の instance_id を名乗る local API であることを無認証 GET で確認する。どちらが不成立でも `InvalidDiscovery` になる。
+- Releash は provider session を codex の workspace-write sandbox 下で起動する（Manual は `--sandbox workspace-write`、Auto は `--approve-for-me`。後者は `codex --help` に「using the workspace-write sandbox」と明記されている）。permission 未指定時も codex の設定既定（`sandbox_mode = "workspace-write"`）で同じ sandbox になる。
+- codex 0.149.1 に埋め込まれた seatbelt policy の base policy は `(deny default)` であり、loopback 通信の許可規則を持たない。実機計測では、sandbox 内から loopback への connect は既定設定でも `sandbox_workspace_write.network_access` を有効にしても拒否される。sandbox 下の provider session から local API へ到達する手段はない。
+- CLI の失敗は stderr へ `error: <message>` の形で出る。
+
+# Outcome
+
+- 対象者: Releash の workflow で provider session に作業させ、その成果物を artifact として提出させる開発者。
+- 現在の問題: sandbox 内の provider session から local API を使う CLI command が失敗するとき、失敗表示が原因を「discovery file が不正または古い」と断定する。実際の原因は loopback 接続の遮断であり discovery file は正常であるため、agent は discovery の再取得やアプリ再起動といった無関係な復旧を試み、session が空転する（Issue 記載の実例: 提出 4 回失敗のあと `open -a Releash` の実行に至った）。
+- 変更後に実現する状態: 失敗表示が「接続先を確認できなかった」ことと「discovery が古い／別インスタンスを指す」ことを区別して示し、無関係な復旧へ誘導しない。
+
+# Current Behavior
+
+## 再現手順
+
+1. Releash アプリを起動する（local API が稼働し discovery file が存在する状態にする）。
+2. provider session と同じ sandbox 下で CLI を実行する。最小手順は `codex sandbox -- /Applications/Releash.app/Contents/MacOS/releash workflow diagnostics`（codex-cli 0.149.1、macOS Darwin 25.5.0、`sandbox_mode = "workspace-write"`、network access 無効）。
+3. 同じ command を sandbox 外で実行して比較する。
+
+## 実際の出力
+
+- sandbox 内（終了コード 1）:
+
+  ```
+  error: local API discovery file が不正または古いです (/Users/siro33950/Library/Application Support/com.releash.app/local-api.json)
+  ```
+
+- sandbox 外: 診断結果（`info WFI000 [workflow=01_author-spec]: ビルトインワークフロー '01_author-spec'` 以下）を出力し、終了コード 0。
+- Issue が報告する `workflow output submit` でも同じ文言で失敗し、同時刻の sandbox 外実行では discovery 検証を通過してサーバへ到達する（偽の node-execution に対し `Node execution not found`）。
+
+## どの検査が失敗しているか
+
+稼働中の Releash（pid 80733、port 56242）を対象に、上と同じ sandbox 内で各検査を個別に計測した。
+
+| 検査 | sandbox 内の結果 |
+|---|---|
+| discovery file の読み込みと decode | 成功 |
+| `proc_listallpids` | 成功（888 プロセスが可視） |
+| `proc_pidinfo`（PROC_PIDTBSDINFO） | 成功（`start_tvsec` が discovery の `process_started_at` と一致） |
+| `sysctl kern.procargs2` | 成功 |
+| `proc_pidpath` | 成功 |
+| `connect(127.0.0.1:56242)` | `EPERM`（Operation not permitted）で拒否 |
+| AF_UNIX socket への `connect` | `EPERM` で拒否（socket 許可の明示指定なしの場合） |
+
+- `process_start_time` が使う sysinfo 0.39.6 の macOS 経路は `proc_listallpids` → `proc_pidinfo` →（`sysctl kern.procargs2` または `proc_pidpath`）であり、いずれも sandbox 内で成功する。したがって PID 照合は sandbox 内でも成立する。
+- 実際に失敗しているのは instance_id の照合であり、その原因は照合結果の不一致ではなく、loopback 接続そのものが sandbox に拒否されることである。`matches_server_instance` は送信失敗と instance 不一致を同じ `false` に潰し、`discover` はそれを `InvalidDiscovery` として返す。このため「接続できない」が「discovery file が不正または古い」と表示される。
+- Issue が sandbox の遮断根拠として挙げた `pgrep` の失敗は、pgrep が使う sysmond への mach-lookup が禁じられていることによるもので、`process_start_time` が使う経路とは別である。
+
+## 影響範囲
+
+- discovery 検証は local API を使う CLI command で共有されるため、失敗は submit に限らない（上の再現は `workflow diagnostics`）。
+- file fallback を持つ read 系 command も、discovery 検証が Err を返した時点で fallback へ進まずそのまま失敗する。
+- loopback 接続が拒否される以上、discovery 検証を通過させても、続く request 自体が同じ理由で失敗する。
+
+# Scope / Non-goals
+
+## 変更する
+
+- CLI が local API へ接続する際の discovery 検証の判定規則と、失敗の分類および表示。
+
+## 変更しない
+
+- sandbox 内の provider session から local API へ到達する経路の確保。sandbox は loopback 接続を拒否するため、本変更で提出が成立するようにはならない。到達手段の確保は別途扱う。
+- local API の loopback 限定 bind、Bearer token 認証、terminal 用 token の分離、discovery file の 0600 権限という既存のセキュリティ前提。
+- workflow の実行モデル、artifact 提出の意味論、`workflow output submit` の入力仕様。
+- provider（codex / claude）の承認運用そのもの（escalation の禁止、承認 policy の変更など）。
+- 各 CLI command に固有の振る舞い。discovery 検証は共有されるため変更の効果は他 command にも同じ規則で及ぶが、command 固有の要求は本変更に含めない。
+
+# Requirements
+
+- R-001: local API の接続先を確認できなかった場合に、その失敗を「discovery file が不正または古い」と断定しない。失敗表示は、確認できなかったこと（接続不能・環境による遮断）と、確認した上で不成立だったこと（別インスタンスを指す・陳腐化している）を区別して示す。
+- R-002: プロセス情報を参照できる環境では、discovery が指すプロセスが存在しない場合、および開始時刻が discovery の値と一致しない場合に、従来どおり接続を拒否する。
+- R-003: discovery の token を送信する前に、接続先が discovery の instance_id を持つ local API であることを確認する、という現在の保証を弱めない。
+- R-004: local API が起動しておらず discovery file が存在しない場合の失敗表示と終了コードを変えない。
+- R-005: プロセス情報を参照できない環境では、discovery を不正・陳腐化と断定せず、プロセス情報を参照できないため接続先を確認できないことを示す専用の失敗として拒否する。この場合は identity GET を含む接続先への request を送信しない。
+
+# Assumptions / Open Questions
+
+## Assumptions
+
+- なし。
+
+## Open Questions
+
+- なし。

--- a/src-tauri/src/adaptor/gateway/local_api.rs
+++ b/src-tauri/src/adaptor/gateway/local_api.rs
@@ -1,0 +1,202 @@
+use std::path::{Path, PathBuf};
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::domain::local_api_discovery::{
+    ConnectionObservation, DiscoveryAdmissionService, DiscoveryContent, DiscoveryRejection,
+    ProcessObservation,
+};
+use crate::infrastructure::local_api::{
+    local_api_discovery_path, lookup_process_start_time, read_local_api_discovery,
+    LocalApiDiscoveryReadError, LocalApiHttpClient, LocalApiIdentityRequestError,
+    LocalApiTransportError, ProcessStartTimeLookup,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum LocalApiClientError {
+    #[error("local API discovery file の読み込みに失敗しました ({}): {source}", path.display())]
+    DiscoveryRead {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("local API discovery file が不正です ({}): {source}", path.display())]
+    DiscoveryDecode {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("local API discovery file が不正または古いです ({})", path.display())]
+    InvalidDiscovery { path: PathBuf },
+    #[error("プロセス情報を参照できないため、local API の接続先を確認できませんでした")]
+    ProcessInformationUnavailable,
+    #[error(
+		"local API の接続先 (127.0.0.1:{port}) へ接続できず、接続先を確認できませんでした。接続が拒否されたか、実行環境が loopback 接続を許可していません: {source}"
+	)]
+    DiscoveryUnreachable {
+        port: u16,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("local API discovery が別のインスタンスを指しているか、古くなっています ({})", path.display())]
+    DiscoveryInstanceMismatch { path: PathBuf },
+    #[error("local API URL が不正です: {0}")]
+    InvalidUrl(#[source] url::ParseError),
+    #[error("local API client の初期化に失敗しました: {0}")]
+    ClientInitialization(#[source] reqwest::Error),
+    #[error("local API URL を構築できません")]
+    InvalidEndpoint,
+    #[error("local API is unavailable: {0}")]
+    Unavailable(#[source] reqwest::Error),
+    #[error("local API request に失敗しました: {0}")]
+    Request(#[source] reqwest::Error),
+    #[error("local API error ({status})")]
+    HttpStatus {
+        status: u16,
+        message: Option<String>,
+    },
+    #[error("local API response が不正です: {0}")]
+    Decode(#[source] serde_json::Error),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LocalApiClientGateway {
+    client: LocalApiHttpClient,
+}
+
+impl LocalApiClientGateway {
+    pub(crate) fn discover(data_dir: &Path) -> Result<Option<Self>, LocalApiClientError> {
+        Self::discover_with_process_lookup(data_dir, lookup_process_start_time)
+    }
+
+    fn discover_with_process_lookup(
+        data_dir: &Path,
+        lookup_process: impl FnOnce(u32) -> ProcessStartTimeLookup,
+    ) -> Result<Option<Self>, LocalApiClientError> {
+        let Some(discovery) =
+            read_local_api_discovery(data_dir).map_err(map_discovery_read_error)?
+        else {
+            return Ok(None);
+        };
+        let path = local_api_discovery_path(data_dir);
+        let content = DiscoveryContent::new(
+            discovery.port,
+            discovery.token.clone(),
+            discovery.instance_id.clone(),
+            discovery.pid,
+            discovery.process_started_at,
+        );
+        let process_lookup = lookup_process(discovery.pid);
+        let process_observation = ProcessObservation::from_raw(
+            process_lookup.process_list_available,
+            process_lookup.start_time,
+        );
+        DiscoveryAdmissionService::assess_process(&content, process_observation)
+            .map_err(|rejection| map_process_rejection(rejection, path.clone()))?;
+
+        let port = discovery.port;
+        let instance_id = discovery.instance_id.clone();
+        let client = LocalApiHttpClient::new(discovery).map_err(map_transport_error)?;
+        let (connection_observation, request_error) = match client.identity_status(&instance_id) {
+            Ok(status) => (
+                ConnectionObservation::from_response_status(Some(status)),
+                None,
+            ),
+            Err(LocalApiIdentityRequestError::InvalidEndpoint) => {
+                return Err(LocalApiClientError::InvalidEndpoint);
+            }
+            Err(LocalApiIdentityRequestError::Request(source)) => (
+                ConnectionObservation::from_response_status(None),
+                Some(source),
+            ),
+        };
+        DiscoveryAdmissionService::assess_connection(connection_observation)
+            .map_err(|rejection| map_connection_rejection(rejection, path, port, request_error))?;
+        Ok(Some(Self { client }))
+    }
+
+    pub(crate) fn get_json<T: DeserializeOwned>(
+        &self,
+        segments: &[&str],
+        query: &[(&str, &str)],
+    ) -> Result<T, LocalApiClientError> {
+        self.client
+            .get_json(segments, query)
+            .map_err(map_transport_error)
+    }
+
+    pub(crate) fn post_json<B: Serialize + ?Sized, T: DeserializeOwned>(
+        &self,
+        segments: &[&str],
+        body: &B,
+    ) -> Result<T, LocalApiClientError> {
+        self.client
+            .post_json(segments, body)
+            .map_err(map_transport_error)
+    }
+}
+
+fn map_discovery_read_error(error: LocalApiDiscoveryReadError) -> LocalApiClientError {
+    match error {
+        LocalApiDiscoveryReadError::Read { path, source } => {
+            LocalApiClientError::DiscoveryRead { path, source }
+        }
+        LocalApiDiscoveryReadError::Decode { path, source } => {
+            LocalApiClientError::DiscoveryDecode { path, source }
+        }
+    }
+}
+
+fn map_process_rejection(rejection: DiscoveryRejection, path: PathBuf) -> LocalApiClientError {
+    match rejection {
+        DiscoveryRejection::InvalidOrStale => LocalApiClientError::InvalidDiscovery { path },
+        DiscoveryRejection::ProcessInformationUnavailable => {
+            LocalApiClientError::ProcessInformationUnavailable
+        }
+        DiscoveryRejection::InstanceMismatch | DiscoveryRejection::ConnectionUnreachable => {
+            unreachable!("process assessment cannot return a connection rejection")
+        }
+    }
+}
+
+fn map_connection_rejection(
+    rejection: DiscoveryRejection,
+    path: PathBuf,
+    port: u16,
+    request_error: Option<reqwest::Error>,
+) -> LocalApiClientError {
+    match rejection {
+        DiscoveryRejection::InstanceMismatch => {
+            LocalApiClientError::DiscoveryInstanceMismatch { path }
+        }
+        DiscoveryRejection::ConnectionUnreachable => LocalApiClientError::DiscoveryUnreachable {
+            port,
+            source: request_error
+                .expect("a connection without a response must retain its transport error"),
+        },
+        DiscoveryRejection::InvalidOrStale | DiscoveryRejection::ProcessInformationUnavailable => {
+            unreachable!("connection assessment cannot return a process rejection")
+        }
+    }
+}
+
+fn map_transport_error(error: LocalApiTransportError) -> LocalApiClientError {
+    match error {
+        LocalApiTransportError::InvalidUrl(source) => LocalApiClientError::InvalidUrl(source),
+        LocalApiTransportError::ClientInitialization(source) => {
+            LocalApiClientError::ClientInitialization(source)
+        }
+        LocalApiTransportError::InvalidEndpoint => LocalApiClientError::InvalidEndpoint,
+        LocalApiTransportError::Unavailable(source) => LocalApiClientError::Unavailable(source),
+        LocalApiTransportError::Request(source) => LocalApiClientError::Request(source),
+        LocalApiTransportError::HttpStatus { status, message } => {
+            LocalApiClientError::HttpStatus { status, message }
+        }
+        LocalApiTransportError::Decode(source) => LocalApiClientError::Decode(source),
+    }
+}
+
+#[cfg(test)]
+#[path = "local_api_test.rs"]
+mod local_api_tests;

--- a/src-tauri/src/adaptor/gateway/local_api_test.rs
+++ b/src-tauri/src/adaptor/gateway/local_api_test.rs
@@ -1,0 +1,475 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+use super::*;
+use crate::infrastructure::local_api::process_start_time;
+use crate::test_support::{EnvVarGuard, TEST_ENV_LOCK};
+
+fn write_discovery(data_dir: &Path, port: u16, token: &str) {
+    let pid = std::process::id();
+    write_discovery_value(
+        data_dir,
+        serde_json::json!({
+            "port": port,
+            "token": token,
+            "instance_id": "test-instance",
+            "pid": pid,
+            "process_started_at": process_start_time(pid).unwrap(),
+        }),
+    );
+}
+
+fn write_discovery_value(data_dir: &Path, discovery: serde_json::Value) {
+    std::fs::write(local_api_discovery_path(data_dir), discovery.to_string()).unwrap();
+}
+
+fn found_process(start_time: u64) -> ProcessStartTimeLookup {
+    ProcessStartTimeLookup {
+        process_list_available: true,
+        start_time: Some(start_time),
+    }
+}
+
+#[test]
+fn test_local_api接続先確認_204応答をtoken送信前に受理する() {
+    // Given
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).unwrap();
+        stream
+            .write_all(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
+            .unwrap();
+        String::from_utf8_lossy(&request[..read]).into_owned()
+    });
+    let temp = TempDir::new().unwrap();
+    let token = "identity-secret";
+    write_discovery(temp.path(), port, token);
+
+    // When
+    let client = LocalApiClientGateway::discover(temp.path()).unwrap();
+    let request = server.join().unwrap();
+
+    // Then
+    assert!(client.is_some());
+    assert!(request.starts_with("GET /.well-known/releash-local-api/test-instance HTTP/1.1"));
+    assert!(!request.to_ascii_lowercase().contains("authorization:"));
+    assert!(!request.contains(token));
+}
+
+#[test]
+fn test_local_api接続_proxy環境変数を無視してloopbackへ直接接続する() {
+    // Given
+    let _lock = TEST_ENV_LOCK.lock();
+    let target = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let proxy = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    proxy.set_nonblocking(true).unwrap();
+    let proxy_url = format!("http://{}", proxy.local_addr().unwrap());
+    let _http_proxy = EnvVarGuard::set_value("HTTP_PROXY", &proxy_url);
+    let _http_proxy_lower = EnvVarGuard::set_value("http_proxy", &proxy_url);
+    let _all_proxy = EnvVarGuard::set_value("ALL_PROXY", &proxy_url);
+    let _all_proxy_lower = EnvVarGuard::set_value("all_proxy", &proxy_url);
+    let _no_proxy = EnvVarGuard::set_value("NO_PROXY", "");
+    let _no_proxy_lower = EnvVarGuard::set_value("no_proxy", "");
+    let target_port = target.local_addr().unwrap().port();
+    let received = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let received_for_server = received.clone();
+    let server = std::thread::spawn(move || {
+        let (mut identity_stream, _) = target.accept().unwrap();
+        let mut identity_request = [0_u8; 4096];
+        let identity_read = identity_stream.read(&mut identity_request).unwrap();
+        let identity_request = String::from_utf8_lossy(&identity_request[..identity_read]);
+        assert!(identity_request
+            .starts_with("GET /.well-known/releash-local-api/test-instance HTTP/1.1"));
+        assert!(!identity_request
+            .to_ascii_lowercase()
+            .contains("authorization:"));
+        identity_stream
+            .write_all(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
+            .unwrap();
+
+        let (mut stream, _) = target.accept().unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        loop {
+            match stream.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(read) => {
+                    request.extend_from_slice(&buffer[..read]);
+                    if request
+                        .windows(b"proxy-secret-marker".len())
+                        .any(|window| window == b"proxy-secret-marker")
+                    {
+                        break;
+                    }
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    break;
+                }
+                Err(error) => panic!("failed to read direct request: {error}"),
+            }
+        }
+        *received_for_server.lock().unwrap() = request;
+        stream
+			.write_all(
+				b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"ok\":true}",
+			)
+			.unwrap();
+    });
+    let temp = TempDir::new().unwrap();
+    write_discovery(temp.path(), target_port, "proxy-secret-token");
+
+    // When
+    let client = LocalApiClientGateway::discover(temp.path())
+        .unwrap()
+        .unwrap();
+    let response: serde_json::Value = client
+        .post_json(
+            &["v1", "test"],
+            &serde_json::json!({"marker": "proxy-secret-marker"}),
+        )
+        .unwrap();
+
+    // Then
+    assert_eq!(response, serde_json::json!({"ok": true}));
+    server.join().unwrap();
+    let direct_request = String::from_utf8_lossy(&received.lock().unwrap()).into_owned();
+    assert!(direct_request
+        .to_ascii_lowercase()
+        .contains("authorization: bearer proxy-secret-token"));
+    assert!(direct_request.contains("proxy-secret-marker"));
+    assert!(matches!(
+        proxy.accept(),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
+    ));
+}
+
+#[test]
+fn test_local_api接続先確認_process情報参照不能を専用失敗として返す() {
+    // Given
+    let temp = TempDir::new().unwrap();
+    let token = "unavailable-process-secret";
+    write_discovery_value(
+        temp.path(),
+        serde_json::json!({
+            "port": 43123,
+            "token": token,
+            "instance_id": "test-instance",
+            "pid": 42,
+            "process_started_at": 123,
+        }),
+    );
+
+    // When
+    let error = LocalApiClientGateway::discover_with_process_lookup(temp.path(), |_| {
+        ProcessStartTimeLookup {
+            process_list_available: false,
+            start_time: None,
+        }
+    })
+    .unwrap_err();
+
+    // Then
+    assert!(matches!(
+        error,
+        LocalApiClientError::ProcessInformationUnavailable
+    ));
+    let message = error.to_string();
+    assert_eq!(
+        message,
+        "プロセス情報を参照できないため、local API の接続先を確認できませんでした"
+    );
+    assert!(!message.contains("不正"));
+    assert!(!message.contains("古い"));
+    assert!(!message.contains(token));
+    assert!(!message.contains(&local_api_discovery_path(temp.path()).display().to_string()));
+}
+
+#[test]
+fn test_local_api接続先確認_process情報参照不能なら接続を試みない() {
+    // Given
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let temp = TempDir::new().unwrap();
+    write_discovery_value(
+        temp.path(),
+        serde_json::json!({
+            "port": port,
+            "token": "secret",
+            "instance_id": "test-instance",
+            "pid": 42,
+            "process_started_at": 123,
+        }),
+    );
+
+    // When
+    let result = LocalApiClientGateway::discover_with_process_lookup(temp.path(), |_| {
+        ProcessStartTimeLookup {
+            process_list_available: false,
+            start_time: None,
+        }
+    });
+
+    // Then
+    assert!(matches!(
+        result,
+        Err(LocalApiClientError::ProcessInformationUnavailable)
+    ));
+    assert!(matches!(
+        listener.accept(),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
+    ));
+}
+
+#[test]
+fn test_local_api接続先確認_接続不能を確認不能として返す() {
+    // Given
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let temp = TempDir::new().unwrap();
+    write_discovery_value(
+        temp.path(),
+        serde_json::json!({
+            "port": port,
+            "token": "unreachable-secret",
+            "instance_id": "test-instance",
+            "pid": 42,
+            "process_started_at": 123,
+        }),
+    );
+
+    // When
+    let error =
+        LocalApiClientGateway::discover_with_process_lookup(temp.path(), |_| found_process(123))
+            .unwrap_err();
+
+    // Then
+    let expected_message = match &error {
+        LocalApiClientError::DiscoveryUnreachable {
+            port: error_port,
+            source,
+        } => {
+            assert_eq!(*error_port, port);
+            format!(
+				"local API の接続先 (127.0.0.1:{port}) へ接続できず、接続先を確認できませんでした。接続が拒否されたか、実行環境が loopback 接続を許可していません: {source}"
+			)
+        }
+        error => panic!("expected DiscoveryUnreachable, got {error:?}"),
+    };
+    assert_eq!(error.to_string(), expected_message);
+}
+
+#[test]
+fn test_local_api接続先確認_別instance応答をtoken送信せず不一致として返す() {
+    // Given
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).unwrap();
+        stream
+            .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .unwrap();
+        String::from_utf8_lossy(&request[..read]).into_owned()
+    });
+    let temp = TempDir::new().unwrap();
+    let token = "mismatch-secret";
+    write_discovery(temp.path(), port, token);
+    let discovery_path = local_api_discovery_path(temp.path());
+
+    // When
+    let error = LocalApiClientGateway::discover(temp.path()).unwrap_err();
+    let request = server.join().unwrap();
+
+    // Then
+    assert!(matches!(
+        &error,
+        LocalApiClientError::DiscoveryInstanceMismatch { path } if path == &discovery_path
+    ));
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "local API discovery が別のインスタンスを指しているか、古くなっています ({})",
+            discovery_path.display()
+        )
+    );
+    assert!(request.starts_with("GET /.well-known/releash-local-api/test-instance HTTP/1.1"));
+    assert!(!request.to_ascii_lowercase().contains("authorization:"));
+    assert!(!request.contains(token));
+}
+
+#[test]
+fn test_local_api接続先確認_redirectを追従せずtoken送信前に不一致として返す() {
+    // Given
+    let redirect_target = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    redirect_target.set_nonblocking(true).unwrap();
+    let redirect_target_port = redirect_target.local_addr().unwrap().port();
+    let discovery_target = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let discovery_port = discovery_target.local_addr().unwrap().port();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = discovery_target.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).unwrap();
+        let response = format!(
+			"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{redirect_target_port}/identity\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+		);
+        stream.write_all(response.as_bytes()).unwrap();
+        String::from_utf8_lossy(&request[..read]).into_owned()
+    });
+    let temp = TempDir::new().unwrap();
+    let token = "redirect-secret";
+    write_discovery(temp.path(), discovery_port, token);
+    let discovery_path = local_api_discovery_path(temp.path());
+
+    // When
+    let error = LocalApiClientGateway::discover(temp.path()).unwrap_err();
+    let request = server.join().unwrap();
+
+    // Then
+    assert!(matches!(
+        &error,
+        LocalApiClientError::DiscoveryInstanceMismatch { path } if path == &discovery_path
+    ));
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "local API discovery が別のインスタンスを指しているか、古くなっています ({})",
+            discovery_path.display()
+        )
+    );
+    assert!(request.starts_with("GET /.well-known/releash-local-api/test-instance HTTP/1.1"));
+    assert!(!request.to_ascii_lowercase().contains("authorization:"));
+    assert!(!request.contains(token));
+    assert!(matches!(
+        redirect_target.accept(),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
+    ));
+}
+
+#[test]
+fn test_local_api_discovery_終了済みprocessを従来の表示で拒否する() {
+    // Given
+    let temp = TempDir::new().unwrap();
+    let path = local_api_discovery_path(temp.path());
+    write_discovery_value(
+        temp.path(),
+        serde_json::json!({
+            "port": 43123,
+            "token": "stale-secret",
+            "instance_id": "stale-instance",
+            "pid": 42,
+            "process_started_at": 123,
+        }),
+    );
+
+    // When
+    let error = LocalApiClientGateway::discover_with_process_lookup(temp.path(), |_| {
+        ProcessStartTimeLookup {
+            process_list_available: true,
+            start_time: None,
+        }
+    })
+    .unwrap_err();
+
+    // Then
+    assert!(matches!(
+        &error,
+        LocalApiClientError::InvalidDiscovery { path: error_path } if error_path == &path
+    ));
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "local API discovery file が不正または古いです ({})",
+            path.display()
+        )
+    );
+}
+
+#[test]
+fn test_local_api_discovery_pid再利用で開始時刻が異なる接続先を拒否する() {
+    // Given
+    let temp = TempDir::new().unwrap();
+    write_discovery_value(
+        temp.path(),
+        serde_json::json!({
+            "port": 43123,
+            "token": "stale-secret",
+            "instance_id": "stale-instance",
+            "pid": 42,
+            "process_started_at": 123,
+        }),
+    );
+
+    // When
+    let result =
+        LocalApiClientGateway::discover_with_process_lookup(temp.path(), |_| found_process(124));
+
+    // Then
+    assert!(matches!(
+        result,
+        Err(LocalApiClientError::InvalidDiscovery { .. })
+    ));
+}
+
+#[test]
+fn test_local_api_discovery_空または0の内容を従来の表示で拒否する() {
+    // Given
+    let temp = TempDir::new().unwrap();
+    let path = local_api_discovery_path(temp.path());
+    let cases = [
+        ("port", serde_json::json!(0)),
+        ("token", serde_json::json!("")),
+        ("instance_id", serde_json::json!("")),
+        ("pid", serde_json::json!(0)),
+        ("process_started_at", serde_json::json!(0)),
+    ];
+
+    for (field, value) in cases {
+        let mut discovery = serde_json::json!({
+            "port": 43123,
+            "token": "secret",
+            "instance_id": "test-instance",
+            "pid": 42,
+            "process_started_at": 123,
+        });
+        discovery[field] = value;
+        write_discovery_value(temp.path(), discovery);
+
+        // When
+        let error = LocalApiClientGateway::discover_with_process_lookup(temp.path(), |_| {
+            found_process(123)
+        })
+        .unwrap_err();
+
+        // Then
+        assert!(matches!(
+            &error,
+            LocalApiClientError::InvalidDiscovery { path: error_path } if error_path == &path
+        ));
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "local API discovery file が不正または古いです ({})",
+                path.display()
+            ),
+            "field: {field}"
+        );
+    }
+}

--- a/src-tauri/src/adaptor/gateway/mod.rs
+++ b/src-tauri/src/adaptor/gateway/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod code;
 pub(crate) mod comment;
 pub(crate) mod external_editor;
 pub(crate) mod git_host;
+pub(crate) mod local_api;
 pub(crate) mod local_event_store;
 pub(crate) mod notion;
 pub(crate) mod provider_lifecycle;

--- a/src-tauri/src/cli/api_client.rs
+++ b/src-tauri/src/cli/api_client.rs
@@ -4,10 +4,10 @@ use super::common::CliError;
 use crate::adaptor::controller::api::protocol::{
     GetArtifactResponse, MutationResponse, SubmitOutputRequest,
 };
+use crate::adaptor::gateway::local_api::{LocalApiClientError, LocalApiClientGateway};
 use crate::adaptor::protocol::provider_lifecycle::{
     ProviderLifecycleReceiveRequest, ProviderLifecycleReceiveResponse,
 };
-use crate::infrastructure::local_api::{LocalApiClientError, LocalApiHttpClient};
 use crate::usecase::workflow::WorkflowGetOutputResult;
 
 #[derive(Debug)]
@@ -36,14 +36,14 @@ impl From<LocalApiClientError> for ApiRequestError {
 
 #[derive(Debug, Clone)]
 pub(super) struct LocalApiClient {
-    transport: LocalApiHttpClient,
+    transport: LocalApiClientGateway,
 }
 
 impl LocalApiClient {
     fn discover(data_dir: &Path) -> Result<Option<Self>, CliError> {
-        LocalApiHttpClient::discover(data_dir)
+        LocalApiClientGateway::discover(data_dir)
             .map(|client| client.map(|transport| Self { transport }))
-            .map_err(|error| CliError::Other(error.to_string()))
+            .map_err(discovery_error)
     }
 
     pub(super) fn execution_status(
@@ -117,6 +117,10 @@ impl LocalApiClient {
             .post_json(&["v1", "provider-lifecycle", "signals"], request)
             .map_err(ApiRequestError::from)
     }
+}
+
+fn discovery_error(error: LocalApiClientError) -> CliError {
+    CliError::Other(error.to_string())
 }
 
 pub(super) fn read_with_fallback<T>(

--- a/src-tauri/src/cli/api_client_test.rs
+++ b/src-tauri/src/cli/api_client_test.rs
@@ -8,6 +8,7 @@ use crate::adaptor::gateway::workflow::schema::{
     CommandSpec, NodeDefinition, NodeKind, WorkflowDefinitionYaml,
 };
 use crate::adaptor::gateway::workflow::storage;
+use crate::cli::common::{cli_error_exit_code, cli_error_stderr};
 use crate::cli::test_helpers::try_start_local_api_test_host;
 use crate::cli::{output, workflow};
 use crate::infrastructure::local_api::{local_api_discovery_path, process_start_time};
@@ -273,5 +274,24 @@ fn test_local_api読取_不正discoveryでfallbackしない() {
     );
     assert!(
         matches!(result, Err(CliError::Other(message)) if message.contains("discovery file が不正"))
+    );
+}
+
+#[test]
+fn test_local_api_discovery_process情報参照不能をcatch_allで終了コード1にする() {
+    // Given / When
+    let error = discovery_error(LocalApiClientError::ProcessInformationUnavailable);
+
+    // Then
+    assert_eq!(
+        error,
+        CliError::Other(
+            "プロセス情報を参照できないため、local API の接続先を確認できませんでした".to_string()
+        )
+    );
+    assert_eq!(cli_error_exit_code(&error), 1);
+    assert_eq!(
+        cli_error_stderr(&error),
+        "error: プロセス情報を参照できないため、local API の接続先を確認できませんでした"
     );
 }

--- a/src-tauri/src/domain/local_api_discovery/local_api_discovery_test.rs
+++ b/src-tauri/src/domain/local_api_discovery/local_api_discovery_test.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+fn valid_content() -> DiscoveryContent {
+    DiscoveryContent::new(
+        43123,
+        "secret".to_string(),
+        "instance-1".to_string(),
+        42,
+        123,
+    )
+}
+
+#[test]
+fn test_discovery内容判定_空または0の値を拒否する() {
+    // Given
+    let cases = [
+        DiscoveryContent::new(0, "secret".to_string(), "instance-1".to_string(), 42, 123),
+        DiscoveryContent::new(43123, " ".to_string(), "instance-1".to_string(), 42, 123),
+        DiscoveryContent::new(43123, "secret".to_string(), " ".to_string(), 42, 123),
+        DiscoveryContent::new(
+            43123,
+            "secret".to_string(),
+            "instance-1".to_string(),
+            0,
+            123,
+        ),
+        DiscoveryContent::new(43123, "secret".to_string(), "instance-1".to_string(), 42, 0),
+    ];
+
+    // When / Then
+    for content in cases {
+        assert_eq!(
+            DiscoveryAdmissionService::assess_process(&content, ProcessObservation::StartedAt(123),),
+            Err(DiscoveryRejection::InvalidOrStale)
+        );
+    }
+}
+
+#[test]
+fn test_process観測_参照不能と対象不在と開始時刻を区別する() {
+    // Given / When
+    let unavailable = ProcessObservation::from_raw(false, None);
+    let missing = ProcessObservation::from_raw(true, None);
+    let zero = ProcessObservation::from_raw(true, Some(0));
+    let found = ProcessObservation::from_raw(true, Some(123));
+
+    // Then
+    assert_eq!(unavailable, ProcessObservation::Unavailable);
+    assert_eq!(missing, ProcessObservation::ProcessNotFound);
+    assert_eq!(zero, ProcessObservation::ProcessNotFound);
+    assert_eq!(found, ProcessObservation::StartedAt(123));
+}
+
+#[test]
+fn test_discovery_process判定_参照不能を専用失敗として拒否する() {
+    // Given / When
+    let result = DiscoveryAdmissionService::assess_process(
+        &valid_content(),
+        ProcessObservation::Unavailable,
+    );
+
+    // Then
+    assert_eq!(
+        result,
+        Err(DiscoveryRejection::ProcessInformationUnavailable)
+    );
+}
+
+#[test]
+fn test_discovery_process判定_対象不在と開始時刻不一致を陳腐化として拒否する() {
+    // Given
+    let content = valid_content();
+
+    // When / Then
+    assert_eq!(
+        DiscoveryAdmissionService::assess_process(&content, ProcessObservation::ProcessNotFound,),
+        Err(DiscoveryRejection::InvalidOrStale)
+    );
+    assert_eq!(
+        DiscoveryAdmissionService::assess_process(&content, ProcessObservation::StartedAt(124),),
+        Err(DiscoveryRejection::InvalidOrStale)
+    );
+}
+
+#[test]
+fn test_discovery_process判定_開始時刻一致を受理する() {
+    // Given / When
+    let result = DiscoveryAdmissionService::assess_process(
+        &valid_content(),
+        ProcessObservation::StartedAt(123),
+    );
+
+    // Then
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn test_接続先観測_status204とその他と応答なしを区別する() {
+    // Given / When
+    let verified = ConnectionObservation::from_response_status(Some(204));
+    let mismatch = ConnectionObservation::from_response_status(Some(404));
+    let unreachable = ConnectionObservation::from_response_status(None);
+
+    // Then
+    assert_eq!(verified, ConnectionObservation::IdentityVerified);
+    assert_eq!(mismatch, ConnectionObservation::UnexpectedResponse);
+    assert_eq!(unreachable, ConnectionObservation::NoResponse);
+}
+
+#[test]
+fn test_discovery接続先判定_観測結果を受理または専用失敗へ分類する() {
+    // Given / When / Then
+    assert_eq!(
+        DiscoveryAdmissionService::assess_connection(ConnectionObservation::IdentityVerified,),
+        Ok(())
+    );
+    assert_eq!(
+        DiscoveryAdmissionService::assess_connection(ConnectionObservation::UnexpectedResponse,),
+        Err(DiscoveryRejection::InstanceMismatch)
+    );
+    assert_eq!(
+        DiscoveryAdmissionService::assess_connection(ConnectionObservation::NoResponse),
+        Err(DiscoveryRejection::ConnectionUnreachable)
+    );
+}

--- a/src-tauri/src/domain/local_api_discovery/mod.rs
+++ b/src-tauri/src/domain/local_api_discovery/mod.rs
@@ -1,0 +1,121 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiscoveryContent {
+    port: u16,
+    token: String,
+    instance_id: String,
+    pid: u32,
+    process_started_at: u64,
+}
+
+impl DiscoveryContent {
+    pub(crate) fn new(
+        port: u16,
+        token: String,
+        instance_id: String,
+        pid: u32,
+        process_started_at: u64,
+    ) -> Self {
+        Self {
+            port,
+            token,
+            instance_id,
+            pid,
+            process_started_at,
+        }
+    }
+
+    pub(crate) fn is_acceptable(&self) -> bool {
+        self.port != 0
+            && !self.token.trim().is_empty()
+            && !self.instance_id.trim().is_empty()
+            && self.pid != 0
+            && self.process_started_at != 0
+    }
+
+    pub(crate) fn process_started_at(&self) -> u64 {
+        self.process_started_at
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProcessObservation {
+    Unavailable,
+    ProcessNotFound,
+    StartedAt(u64),
+}
+
+impl ProcessObservation {
+    pub(crate) fn from_raw(process_list_available: bool, start_time: Option<u64>) -> Self {
+        if !process_list_available {
+            return Self::Unavailable;
+        }
+        match start_time {
+            Some(start_time) if start_time != 0 => Self::StartedAt(start_time),
+            Some(_) | None => Self::ProcessNotFound,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConnectionObservation {
+    IdentityVerified,
+    UnexpectedResponse,
+    NoResponse,
+}
+
+impl ConnectionObservation {
+    pub(crate) fn from_response_status(status: Option<u16>) -> Self {
+        match status {
+            Some(204) => Self::IdentityVerified,
+            Some(_) => Self::UnexpectedResponse,
+            None => Self::NoResponse,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiscoveryRejection {
+    InvalidOrStale,
+    ProcessInformationUnavailable,
+    InstanceMismatch,
+    ConnectionUnreachable,
+}
+
+pub(crate) struct DiscoveryAdmissionService;
+
+impl DiscoveryAdmissionService {
+    pub(crate) fn assess_process(
+        content: &DiscoveryContent,
+        observation: ProcessObservation,
+    ) -> Result<(), DiscoveryRejection> {
+        if !content.is_acceptable() {
+            return Err(DiscoveryRejection::InvalidOrStale);
+        }
+        match observation {
+            ProcessObservation::Unavailable => {
+                Err(DiscoveryRejection::ProcessInformationUnavailable)
+            }
+            ProcessObservation::ProcessNotFound => Err(DiscoveryRejection::InvalidOrStale),
+            ProcessObservation::StartedAt(start_time)
+                if start_time != content.process_started_at() =>
+            {
+                Err(DiscoveryRejection::InvalidOrStale)
+            }
+            ProcessObservation::StartedAt(_) => Ok(()),
+        }
+    }
+
+    pub(crate) fn assess_connection(
+        observation: ConnectionObservation,
+    ) -> Result<(), DiscoveryRejection> {
+        match observation {
+            ConnectionObservation::IdentityVerified => Ok(()),
+            ConnectionObservation::UnexpectedResponse => Err(DiscoveryRejection::InstanceMismatch),
+            ConnectionObservation::NoResponse => Err(DiscoveryRejection::ConnectionUnreachable),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "local_api_discovery_test.rs"]
+mod local_api_discovery_tests;

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod code;
 pub(crate) mod comment;
 pub(crate) mod external_editor;
 pub(crate) mod git_host;
+pub(crate) mod local_api_discovery;
 pub(crate) mod local_event;
 pub(crate) mod notion;
 pub(crate) mod path;

--- a/src-tauri/src/infrastructure/local_api/client.rs
+++ b/src-tauri/src/infrastructure/local_api/client.rs
@@ -6,46 +6,57 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use super::{local_api_discovery_path, process_start_time, LocalApiDiscovery};
+use super::{local_api_discovery_path, LocalApiDiscovery};
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum LocalApiClientError {
-    #[error("local API discovery file の読み込みに失敗しました ({}): {source}", path.display())]
-    DiscoveryRead {
+#[derive(Debug)]
+pub(crate) enum LocalApiDiscoveryReadError {
+    Read {
         path: PathBuf,
-        #[source]
         source: std::io::Error,
     },
-    #[error("local API discovery file が不正です ({}): {source}", path.display())]
-    DiscoveryDecode {
+    Decode {
         path: PathBuf,
-        #[source]
         source: serde_json::Error,
     },
-    #[error("local API discovery file が不正または古いです ({})", path.display())]
-    InvalidDiscovery { path: PathBuf },
-    #[error("local API URL が不正です: {0}")]
-    InvalidUrl(#[source] url::ParseError),
-    #[error("local API client の初期化に失敗しました: {0}")]
-    ClientInitialization(#[source] reqwest::Error),
-    #[error("local API URL を構築できません")]
+}
+
+#[derive(Debug)]
+pub(crate) enum LocalApiIdentityRequestError {
     InvalidEndpoint,
-    #[error("local API is unavailable: {0}")]
-    Unavailable(#[source] reqwest::Error),
-    #[error("local API request に失敗しました: {0}")]
-    Request(#[source] reqwest::Error),
-    #[error("local API error ({status})")]
+    Request(reqwest::Error),
+}
+
+#[derive(Debug)]
+pub(crate) enum LocalApiTransportError {
+    InvalidUrl(url::ParseError),
+    ClientInitialization(reqwest::Error),
+    InvalidEndpoint,
+    Unavailable(reqwest::Error),
+    Request(reqwest::Error),
     HttpStatus {
         status: u16,
         message: Option<String>,
     },
-    #[error("local API response が不正です: {0}")]
-    Decode(#[source] serde_json::Error),
+    Decode(serde_json::Error),
 }
 
 #[derive(Debug, Deserialize)]
 struct ErrorResponse {
     message: String,
+}
+
+pub(crate) fn read_local_api_discovery(
+    data_dir: &Path,
+) -> Result<Option<LocalApiDiscovery>, LocalApiDiscoveryReadError> {
+    let path = local_api_discovery_path(data_dir);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(LocalApiDiscoveryReadError::Read { path, source }),
+    };
+    serde_json::from_str(&contents)
+        .map(Some)
+        .map_err(|source| LocalApiDiscoveryReadError::Decode { path, source })
 }
 
 #[derive(Debug, Clone)]
@@ -56,46 +67,16 @@ pub(crate) struct LocalApiHttpClient {
 }
 
 impl LocalApiHttpClient {
-    pub(crate) fn discover(data_dir: &Path) -> Result<Option<Self>, LocalApiClientError> {
-        let path = local_api_discovery_path(data_dir);
-        let contents = match std::fs::read_to_string(&path) {
-            Ok(contents) => contents,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(source) => {
-                return Err(LocalApiClientError::DiscoveryRead { path, source });
-            }
-        };
-        let discovery = serde_json::from_str::<LocalApiDiscovery>(&contents).map_err(|source| {
-            LocalApiClientError::DiscoveryDecode {
-                path: path.clone(),
-                source,
-            }
-        })?;
-        if discovery.port == 0
-            || discovery.token.trim().is_empty()
-            || discovery.instance_id.trim().is_empty()
-            || discovery.process_started_at == 0
-            || process_start_time(discovery.pid) != Some(discovery.process_started_at)
-        {
-            return Err(LocalApiClientError::InvalidDiscovery { path });
-        }
-        let instance_id = discovery.instance_id.clone();
-        let client = Self::new(discovery)?;
-        if !client.matches_server_instance(&instance_id) {
-            return Err(LocalApiClientError::InvalidDiscovery { path });
-        }
-        Ok(Some(client))
-    }
-
-    fn new(discovery: LocalApiDiscovery) -> Result<Self, LocalApiClientError> {
+    pub(crate) fn new(discovery: LocalApiDiscovery) -> Result<Self, LocalApiTransportError> {
         let base_url = Url::parse(&format!("http://127.0.0.1:{}/", discovery.port))
-            .map_err(LocalApiClientError::InvalidUrl)?;
+            .map_err(LocalApiTransportError::InvalidUrl)?;
         let client = Client::builder()
             .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
             .connect_timeout(Duration::from_secs(1))
             .timeout(Duration::from_secs(5))
             .build()
-            .map_err(LocalApiClientError::ClientInitialization)?;
+            .map_err(LocalApiTransportError::ClientInitialization)?;
         Ok(Self {
             base_url,
             token: discovery.token,
@@ -107,7 +88,7 @@ impl LocalApiHttpClient {
         &self,
         segments: &[&str],
         query: &[(&str, &str)],
-    ) -> Result<T, LocalApiClientError> {
+    ) -> Result<T, LocalApiTransportError> {
         let mut url = self.endpoint(segments)?;
         if !query.is_empty() {
             url.query_pairs_mut().extend_pairs(query.iter().copied());
@@ -119,30 +100,42 @@ impl LocalApiHttpClient {
         &self,
         segments: &[&str],
         body: &B,
-    ) -> Result<T, LocalApiClientError> {
+    ) -> Result<T, LocalApiTransportError> {
         let url = self.endpoint(segments)?;
         self.send(self.client.post(url).json(body))
     }
 
-    fn endpoint(&self, segments: &[&str]) -> Result<Url, LocalApiClientError> {
+    pub(crate) fn identity_status(
+        &self,
+        instance_id: &str,
+    ) -> Result<u16, LocalApiIdentityRequestError> {
+        let url = self
+            .endpoint(&[".well-known", "releash-local-api", instance_id])
+            .map_err(|error| match error {
+                LocalApiTransportError::InvalidEndpoint => {
+                    LocalApiIdentityRequestError::InvalidEndpoint
+                }
+                _ => unreachable!("endpoint only returns InvalidEndpoint"),
+            })?;
+        self.client
+            .get(url)
+            .send()
+            .map(|response| response.status().as_u16())
+            .map_err(LocalApiIdentityRequestError::Request)
+    }
+
+    fn endpoint(&self, segments: &[&str]) -> Result<Url, LocalApiTransportError> {
         let mut url = self.base_url.clone();
         url.path_segments_mut()
-            .map_err(|_| LocalApiClientError::InvalidEndpoint)?
+            .map_err(|_| LocalApiTransportError::InvalidEndpoint)?
             .extend(segments);
         Ok(url)
     }
 
-    fn matches_server_instance(&self, instance_id: &str) -> bool {
-        let Ok(url) = self.endpoint(&[".well-known", "releash-local-api", instance_id]) else {
-            return false;
-        };
-        self.client
-            .get(url)
-            .send()
-            .is_ok_and(|response| response.status() == reqwest::StatusCode::NO_CONTENT)
-    }
-
-    fn send<T: DeserializeOwned>(&self, request: RequestBuilder) -> Result<T, LocalApiClientError> {
+    fn send<T: DeserializeOwned>(
+        &self,
+        request: RequestBuilder,
+    ) -> Result<T, LocalApiTransportError> {
         let response = self
             .authenticated(request)
             .send()
@@ -154,12 +147,12 @@ impl LocalApiHttpClient {
                 .ok()
                 .map(|error| error.message)
                 .filter(|message| !message.trim().is_empty());
-            return Err(LocalApiClientError::HttpStatus {
+            return Err(LocalApiTransportError::HttpStatus {
                 status: status.as_u16(),
                 message,
             });
         }
-        serde_json::from_slice(&bytes).map_err(LocalApiClientError::Decode)
+        serde_json::from_slice(&bytes).map_err(LocalApiTransportError::Decode)
     }
 
     fn authenticated(&self, request: RequestBuilder) -> RequestBuilder {
@@ -167,11 +160,11 @@ impl LocalApiHttpClient {
     }
 }
 
-fn classify_transport_error(error: reqwest::Error) -> LocalApiClientError {
+fn classify_transport_error(error: reqwest::Error) -> LocalApiTransportError {
     if error.is_connect() {
-        LocalApiClientError::Unavailable(error)
+        LocalApiTransportError::Unavailable(error)
     } else {
-        LocalApiClientError::Request(error)
+        LocalApiTransportError::Request(error)
     }
 }
 

--- a/src-tauri/src/infrastructure/local_api/client_test.rs
+++ b/src-tauri/src/infrastructure/local_api/client_test.rs
@@ -1,40 +1,79 @@
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::Arc;
 
 use tempfile::TempDir;
 
 use super::*;
-use crate::test_support::{EnvVarGuard, TEST_ENV_LOCK};
 
-fn write_discovery(data_dir: &Path, port: u16, token: &str) {
-    let pid = std::process::id();
+fn discovery(port: u16, token: &str) -> LocalApiDiscovery {
+    LocalApiDiscovery {
+        port,
+        token: token.to_string(),
+        instance_id: "test-instance".to_string(),
+        pid: 42,
+        process_started_at: 123,
+    }
+}
+
+#[test]
+fn test_local_api_discovery読取_file不在をnoneとして返す() {
+    // Given
+    let temp = TempDir::new().unwrap();
+
+    // When
+    let result = read_local_api_discovery(temp.path()).unwrap();
+
+    // Then
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_local_api_discovery読取_jsonの生値を返す() {
+    // Given
+    let temp = TempDir::new().unwrap();
+    let expected = discovery(43123, "secret");
     std::fs::write(
-        local_api_discovery_path(data_dir),
-        serde_json::json!({
-            "port": port,
-            "token": token,
-            "instance_id": "test-instance",
-            "pid": pid,
-            "process_started_at": process_start_time(pid).unwrap(),
-        })
-        .to_string(),
+        local_api_discovery_path(temp.path()),
+        serde_json::to_vec(&expected).unwrap(),
     )
     .unwrap();
+
+    // When
+    let result = read_local_api_discovery(temp.path()).unwrap();
+
+    // Then
+    assert_eq!(result, Some(expected));
+}
+
+#[test]
+fn test_local_api_discovery読取_不正jsonをdecode_errorとして返す() {
+    // Given
+    let temp = TempDir::new().unwrap();
+    let path = local_api_discovery_path(temp.path());
+    std::fs::write(&path, "not-json").unwrap();
+
+    // When
+    let error = read_local_api_discovery(temp.path()).unwrap_err();
+
+    // Then
+    assert!(matches!(
+        error,
+        LocalApiDiscoveryReadError::Decode { path: error_path, .. } if error_path == path
+    ));
 }
 
 #[test]
 fn test_local_api認証_discoveryのbearer_tokenをrequestへ設定する() {
-    let client = LocalApiHttpClient {
-        base_url: Url::parse("http://127.0.0.1:43123/").unwrap(),
-        token: "secret".to_string(),
-        client: Client::builder().no_proxy().build().unwrap(),
-    };
+    // Given
+    let client = LocalApiHttpClient::new(discovery(43123, "secret")).unwrap();
+
+    // When
     let request = client
         .authenticated(client.client.get(client.base_url.clone()))
         .build()
         .unwrap();
 
+    // Then
     assert_eq!(
         request
             .headers()
@@ -45,94 +84,35 @@ fn test_local_api認証_discoveryのbearer_tokenをrequestへ設定する() {
 }
 
 #[test]
-fn test_local_api接続_proxy環境変数を無視してloopbackへ直接接続する() {
-    let _lock = TEST_ENV_LOCK.lock();
-    let target = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-    let proxy = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-    proxy.set_nonblocking(true).unwrap();
-    let proxy_url = format!("http://{}", proxy.local_addr().unwrap());
-    let _http_proxy = EnvVarGuard::set_value("HTTP_PROXY", &proxy_url);
-    let _http_proxy_lower = EnvVarGuard::set_value("http_proxy", &proxy_url);
-    let _all_proxy = EnvVarGuard::set_value("ALL_PROXY", &proxy_url);
-    let _all_proxy_lower = EnvVarGuard::set_value("all_proxy", &proxy_url);
-    let _no_proxy = EnvVarGuard::set_value("NO_PROXY", "");
-    let _no_proxy_lower = EnvVarGuard::set_value("no_proxy", "");
-    let target_port = target.local_addr().unwrap().port();
-    let received = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let received_for_server = received.clone();
+fn test_local_api接続先観測_http_statusの生値を返す() {
+    // Given
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = std::thread::spawn(move || {
-        let (mut identity_stream, _) = target.accept().unwrap();
-        let mut identity_request = [0_u8; 4096];
-        let identity_read = identity_stream.read(&mut identity_request).unwrap();
-        let identity_request = String::from_utf8_lossy(&identity_request[..identity_read]);
-        assert!(identity_request
-            .starts_with("GET /.well-known/releash-local-api/test-instance HTTP/1.1"));
-        assert!(!identity_request
-            .to_ascii_lowercase()
-            .contains("authorization:"));
-        identity_stream
-            .write_all(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
-            .unwrap();
-
-        let (mut stream, _) = target.accept().unwrap();
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).unwrap();
         stream
-            .set_read_timeout(Some(Duration::from_secs(1)))
+            .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
             .unwrap();
-        let mut request = Vec::new();
-        let mut buffer = [0_u8; 4096];
-        loop {
-            match stream.read(&mut buffer) {
-                Ok(0) => break,
-                Ok(read) => {
-                    request.extend_from_slice(&buffer[..read]);
-                    if request
-                        .windows(b"proxy-secret-marker".len())
-                        .any(|window| window == b"proxy-secret-marker")
-                    {
-                        break;
-                    }
-                }
-                Err(error)
-                    if matches!(
-                        error.kind(),
-                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
-                    ) =>
-                {
-                    break;
-                }
-                Err(error) => panic!("failed to read direct request: {error}"),
-            }
-        }
-        *received_for_server.lock().unwrap() = request;
-        stream
-            .write_all(
-                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"ok\":true}",
-            )
-            .unwrap();
+        String::from_utf8_lossy(&request[..read]).into_owned()
     });
-    let temp = TempDir::new().unwrap();
-    write_discovery(temp.path(), target_port, "proxy-secret-token");
-    let client = LocalApiHttpClient::discover(temp.path()).unwrap().unwrap();
+    let client = LocalApiHttpClient::new(discovery(port, "raw-secret")).unwrap();
 
-    let response: serde_json::Value = client
-        .post_json(
-            &["v1", "test"],
-            &serde_json::json!({"marker": "proxy-secret-marker"}),
-        )
-        .unwrap();
+    // When
+    let status = client.identity_status("test-instance").unwrap();
+    let request = server.join().unwrap();
 
-    assert_eq!(response, serde_json::json!({"ok": true}));
-    server.join().unwrap();
-    let direct_request = String::from_utf8_lossy(&received.lock().unwrap()).into_owned();
-    assert!(direct_request
-        .to_ascii_lowercase()
-        .contains("authorization: bearer proxy-secret-token"));
-    assert!(direct_request.contains("proxy-secret-marker"));
-    assert!(matches!(proxy.accept(), Err(error) if error.kind() == std::io::ErrorKind::WouldBlock));
+    // Then
+    assert_eq!(status, 404);
+    assert!(request.starts_with("GET /.well-known/releash-local-api/test-instance HTTP/1.1"));
+    assert!(!request.to_ascii_lowercase().contains("authorization:"));
+    assert!(!request.contains("raw-secret"));
 }
 
 #[test]
 fn test_local_api応答_body_timeoutをrequest_errorとして返す() {
+    // Given
     let target = TcpListener::bind(("127.0.0.1", 0)).unwrap();
     let target_port = target.local_addr().unwrap().port();
     let server = std::thread::spawn(move || {
@@ -157,60 +137,12 @@ fn test_local_api応答_body_timeoutをrequest_errorとして返す() {
             .unwrap(),
     };
 
+    // When
     let error = client
         .get_json::<serde_json::Value>(&["v1", "test"], &[])
         .unwrap_err();
 
-    assert!(matches!(error, LocalApiClientError::Request(_)));
+    // Then
+    assert!(matches!(error, LocalApiTransportError::Request(_)));
     server.join().unwrap();
-}
-
-#[test]
-fn test_local_api_discovery_終了済みprocessの接続先を拒否する() {
-    let temp = TempDir::new().unwrap();
-    std::fs::write(
-        local_api_discovery_path(temp.path()),
-        serde_json::json!({
-            "port": 43123,
-            "token": "stale-secret",
-            "instance_id": "stale-instance",
-            "pid": i32::MAX as u32,
-            "process_started_at": 1,
-        })
-        .to_string(),
-    )
-    .unwrap();
-
-    let result = LocalApiHttpClient::discover(temp.path());
-
-    assert!(matches!(
-        result,
-        Err(LocalApiClientError::InvalidDiscovery { .. })
-    ));
-}
-
-#[test]
-fn test_local_api_discovery_pid再利用で開始時刻が異なる接続先を拒否する() {
-    let temp = TempDir::new().unwrap();
-    let pid = std::process::id();
-    let current_started_at = process_start_time(pid).unwrap();
-    std::fs::write(
-        local_api_discovery_path(temp.path()),
-        serde_json::json!({
-            "port": 43123,
-            "token": "stale-secret",
-            "instance_id": "stale-instance",
-            "pid": pid,
-            "process_started_at": current_started_at.saturating_add(1),
-        })
-        .to_string(),
-    )
-    .unwrap();
-
-    let result = LocalApiHttpClient::discover(temp.path());
-
-    assert!(matches!(
-        result,
-        Err(LocalApiClientError::InvalidDiscovery { .. })
-    ));
 }

--- a/src-tauri/src/infrastructure/local_api/discovery.rs
+++ b/src-tauri/src/infrastructure/local_api/discovery.rs
@@ -23,7 +23,19 @@ pub(crate) struct LocalApiDiscovery {
     pub(crate) process_started_at: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProcessStartTimeLookup {
+    pub(crate) process_list_available: bool,
+    pub(crate) start_time: Option<u64>,
+}
+
 pub(crate) fn process_start_time(pid: u32) -> Option<u64> {
+    lookup_process_start_time(pid)
+        .start_time
+        .filter(|start_time| *start_time != 0)
+}
+
+pub(crate) fn lookup_process_start_time(pid: u32) -> ProcessStartTimeLookup {
     let pid = Pid::from_u32(pid);
     let mut system = System::new();
     system.refresh_processes_specifics(
@@ -31,10 +43,19 @@ pub(crate) fn process_start_time(pid: u32) -> Option<u64> {
         true,
         ProcessRefreshKind::nothing(),
     );
-    system
-        .process(pid)
-        .map(|process| process.start_time())
-        .filter(|started_at| *started_at > 0)
+    let start_time = system.process(pid).map(|process| process.start_time());
+    if start_time.is_some_and(|start_time| start_time != 0) {
+        return ProcessStartTimeLookup {
+            process_list_available: true,
+            start_time,
+        };
+    }
+
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, ProcessRefreshKind::nothing());
+    ProcessStartTimeLookup {
+        process_list_available: !system.processes().is_empty(),
+        start_time: system.process(pid).map(|process| process.start_time()),
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/infrastructure/local_api/discovery_test.rs
+++ b/src-tauri/src/infrastructure/local_api/discovery_test.rs
@@ -1,6 +1,30 @@
 use super::*;
 
 #[test]
+fn test_process開始時刻参照_現在processの生値を返す() {
+    // Given
+    let pid = std::process::id();
+
+    // When
+    let result = lookup_process_start_time(pid);
+
+    // Then
+    assert!(result.process_list_available);
+    assert!(result.start_time.is_some_and(|start_time| start_time != 0));
+    assert_eq!(process_start_time(pid), result.start_time);
+}
+
+#[test]
+fn test_process開始時刻参照_対象不在でもprocess一覧の参照結果を返す() {
+    // Given / When
+    let result = lookup_process_start_time(u32::MAX);
+
+    // Then
+    assert!(result.process_list_available);
+    assert_eq!(result.start_time, None);
+}
+
+#[test]
 fn test_local_api_discovery_所有fileを非公開権限で作成して削除する() {
     let directory = tempfile::tempdir().unwrap();
     let discovery = LocalApiDiscovery {

--- a/src-tauri/src/infrastructure/local_api/mod.rs
+++ b/src-tauri/src/infrastructure/local_api/mod.rs
@@ -2,9 +2,13 @@ mod client;
 mod discovery;
 mod server;
 
-pub(crate) use client::{LocalApiClientError, LocalApiHttpClient};
+pub(crate) use client::{
+    read_local_api_discovery, LocalApiDiscoveryReadError, LocalApiHttpClient,
+    LocalApiIdentityRequestError, LocalApiTransportError,
+};
 pub(crate) use discovery::{
-    local_api_discovery_path, process_start_time, LocalApiDiscovery, LocalApiDiscoveryFile,
+    local_api_discovery_path, lookup_process_start_time, process_start_time, LocalApiDiscovery,
+    LocalApiDiscoveryFile, ProcessStartTimeLookup,
 };
 #[cfg(debug_assertions)]
 pub(crate) use server::LocalApiServer;

--- a/src-tauri/src/provider_lifecycle_acceptance.rs
+++ b/src-tauri/src/provider_lifecycle_acceptance.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use crate::adaptor::gateway::local_api::LocalApiClientGateway;
 use crate::adaptor::gateway::local_event_store::provider_lifecycle_codec::PROVIDER_LIFECYCLE_EVENT_TYPE;
 use crate::adaptor::gateway::local_event_store::{LocalEventStore, LocalEventStoreConfig};
 use crate::adaptor::gateway::provider_lifecycle::{
@@ -21,7 +22,7 @@ use crate::domain::provider_lifecycle::{
     ProviderLifecycleUnavailableReason,
 };
 use crate::domain::workflow::{WorkflowDefinition, WorkflowError};
-use crate::infrastructure::local_api::{LocalApiHttpClient, LocalApiServer, LocalApiServerBinding};
+use crate::infrastructure::local_api::{LocalApiServer, LocalApiServerBinding};
 use crate::usecase::provider_lifecycle::ProviderLifecycleUsecase;
 use crate::usecase::workflow::command::{
     AbortExecutionCommand, ResolvedStartExecutionCommand, ResumeExecutionCommand,
@@ -481,7 +482,7 @@ impl ProviderLifecycleAcceptanceHost {
             reason: protocol_unavailable_reason(reason),
         };
         let response = tokio::task::spawn_blocking(move || {
-            let client = LocalApiHttpClient::discover(&data_dir)
+            let client = LocalApiClientGateway::discover(&data_dir)
                 .map_err(|error| error.to_string())?
                 .ok_or_else(|| "local API discovery is unavailable".to_string())?;
             client

--- a/src-tauri/tests/provider_lifecycle_acceptance_test.rs
+++ b/src-tauri/tests/provider_lifecycle_acceptance_test.rs
@@ -950,7 +950,7 @@ async fn test_providerライフサイクル受入_stale_discoveryから古い接
             None,
             before,
             &run,
-            "不正または古い",
+            "別のインスタンスを指しているか、古くなっています",
         )
         .await;
         let stale_request = stale_request.join().unwrap();


### PR DESCRIPTION
Closes #1704

## 原因

CLI が local API へ接続する前の検査は 2 段ある。(1) discovery file の内容検査と PID 照合、(2) token を送る前に接続先が discovery の `instance_id` を名乗る local API かを無認証 GET で確認する。`matches_server_instance` は 2 段目で **送信失敗と instance 不一致を同じ `false` へ潰し**、`discover` はそれを `InvalidDiscovery` として返していた。

このため sandbox 内から loopback 接続が拒否されると、discovery file が正常でも `local API discovery file が不正または古いです (<path>)` と表示される。agent は discovery の再取得やアプリ再起動という無関係な復旧を試み、session が空転する（Issue の実例: 提出 4 回失敗のあと `open -a Releash` に至る）。

Issue が疑った PID 照合は原因ではなかった。稼働中の Releash を対象に sandbox 内で各検査を個別計測したところ、`proc_listallpids` / `proc_pidinfo` / `sysctl kern.procargs2` / `proc_pidpath` はいずれも成功し、`start_tvsec` は discovery の `process_started_at` と一致した。実際に失敗するのは `connect(127.0.0.1:<port>)` で `EPERM` になる 2 段目だけである。Issue が根拠に挙げた `pgrep` の失敗は sysmond への mach-lookup が禁じられていることによるもので、`process_start_time` が使う経路とは別である。

なお seatbelt は loopback 接続を拒否するため、本変更で sandbox 内からの提出が成立するようにはならない。誤診をやめ、失敗の理由を区別して示すまでが本 PR の範囲である。

## 修正

- **判定規則を domain が所有する**: `domain/local_api_discovery/` を新設し、discovery 内容 `DiscoveryContent`、プロセス観測の三値 `ProcessObservation`、接続先観測の三値 `ConnectionObservation`、受理・拒否を決める純粋な `DiscoveryAdmissionService` を置く。domain は reqwest / sysinfo / filesystem の型も transport error の実体も受け取らない
- **接続先観測を「応答を得られたか」で三値に分ける**: 204 は受理、応答はあるが 204 でない場合は `DiscoveryInstanceMismatch`、transport error は `DiscoveryUnreachable`。connect 拒否・環境による遮断・timeout・protocol error はすべて「確認できなかった」側へ寄せる
- **プロセス観測も三値に分ける**: `lookup_process_start_time` はまず対象 PID だけを参照し、取得できなかった場合に限り全プロセスを参照して、開始時刻の有無とプロセス一覧の有無を生値のまま返す。参照不能なら `ProcessInformationUnavailable` として拒否し、identity GET を含む request を接続先へ送らない。プロセスが不在・開始時刻が不一致の場合は従来どおり `InvalidDiscovery` を維持する
- **gateway が外部信号を調停する**: `adaptor/gateway/local_api.rs` の `LocalApiClientGateway::discover` が生信号を集めて domain の値へ変換し、判定を委ね、拒否理由を `LocalApiClientError` と失敗文言へ写す。`infrastructure/local_api/` は discovery file の読み書き、sysinfo の生値、identity GET の status、認証済み request の transport だけを扱い、受理可否を分類しない
- **接続先を discovery の指す宛先へ固定する**: local API 用 reqwest client を `redirect::Policy::none()` にする。identity GET が 3xx を返した場合は「応答はあるが 204 でない」として `InstanceMismatch` に分類し、token 送信前に拒否する

CLI の失敗表示に増えるのは次の 3 分類で、いずれも `error: <message>` 形式・終了コード 1（`cli/common.rs` の既存整形）。

- 接続先を確認できなかった場合: `local API の接続先 (127.0.0.1:<port>) へ接続できず、接続先を確認できませんでした。接続が拒否されたか、実行環境が loopback 接続を許可していません: <transport error>`
- 別インスタンスを指す場合: `local API discovery が別のインスタンスを指しているか、古くなっています (<path>)`
- プロセス情報を参照できない場合: `プロセス情報を参照できないため、local API の接続先を確認できませんでした`

変えない契約: discovery file 不在時の `この操作には Releash アプリの起動が必要です` と終了コード 1、内容検査およびプロセス不在・開始時刻不一致時の従来文言、local API の wire 契約（`/.well-known/releash-local-api/<instance_id>` への無認証 GET と 204、以降の Bearer 認証）、discovery file のスキーマ。server 側は変更しない。

## テスト

- **domain**: 内容の空・0 検査、プロセス観測の三値分類（参照不能 / 対象不在・開始時刻不一致 / 一致）、接続先観測の三値分類（204 / その他 status / 応答なし）を純粋な単体テストで検証（B-001〜B-005 / B-007 の判定規則）
- **gateway**: 応答を返さない接続先で「確認不能」になること（B-001）、偽サーバが 204 以外や 3xx を返す場合に token を送らず不一致とすること（B-002 / B-005）、プロセス参照の生信号を注入して専用失敗になり偽サーバが接続を 1 件も受理しないこと（B-007）、終了済み process / 内容不正が従来の表示で拒否されること（B-003 / B-004）、proxy 環境変数を無視して loopback へ直接接続すること
- **infrastructure**: discovery file 読み取りの生値・不在・不正 JSON、identity GET の status 生値、`ProcessStartTimeLookup` が対象不在でもプロセス一覧の参照結果を返すこと
- **cli**: `ProcessInformationUnavailable` が catch-all で終了コード 1 になること、discovery 欠落時に fallback すること、不正 discovery で fallback しないこと（B-006）
- **acceptance**: `test_providerライフサイクル受入_stale_discoveryから古い接続先へ送信しない` を新しい文言へ更新
- **手動検証**（2026-08-27、codex-cli 0.149.1 / Darwin 25.5.0 / `sandbox_mode = "workspace-write"` / network 無効）: sandbox 内で `workflow diagnostics` が新しい接続不能の文言と終了コード 1 になり、`不正または古い` を含まないこと、同じ binary が sandbox 外では終了コード 0 で診断結果を返すこと、アプリ停止時は `この操作には Releash アプリの起動が必要です` になることを確認（記録は `docs/specs/issues-1704/design.md`）
- 検証: `cargo fmt --check` / `cargo clippy --locked -- -D warnings` / `cargo deny --locked check` / `cargo test --locked`（lib 2244 + 各 acceptance すべて green）/ `cargo test --locked --test agent_tui_harness`（13）すべて pass。frontend への変更はない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191b8DozpyApqFLQzKpL6Qp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ローカル API の接続先・プロセス・インスタンスを確認し、安全に接続できる場合のみ利用するようになりました。
  * 接続不能、別インスタンス、プロセス情報の取得不可などを区別して表示します。
  * 各エラーは終了コード 1 で終了します。

* **ドキュメント**
  * ローカル API discovery の要件、動作仕様、設計資料を追加しました。
  * ドメイン一覧に local API discovery を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->