### PR TITLE
fix(workspace): 実行木のルート行に Node 名ではなく workflow 名を表示する (#1662)

### DIFF
--- a/docs/specs/issues-1662/behavior.md
+++ b/docs/specs/issues-1662/behavior.md
@@ -1,0 +1,62 @@
+## B-001: workflow 実行ルート行の表示名
+
+GIVEN workflow 定義から起動された workflow 実行が Workspace ツリーに存在する
+WHEN 利用者が Workspace ツリーを表示する
+THEN その実行を表すルート行の表示名は、その実行の workflow 名である
+
+## B-002: ルート行の Node 種別に依らない表示名
+
+GIVEN workflow 実行のルート行にあたる Node の種別が Sequence、Fanout、Session、Command のいずれかである
+WHEN 利用者が Workspace ツリーを表示する
+THEN Node の種別に依らず、ルート行の表示名はその実行の workflow 名である
+
+## B-003: 並存する複数実行の判別
+
+GIVEN 同一 workspace に workflow 名の異なる複数の workflow 実行が同時に存在する
+WHEN 利用者が Workspace ツリーを表示する
+THEN 各ルート行の表示名は、それぞれの実行の workflow 名である
+AND 各ルート行の表示名は互いに異なり、行ごとにどの workflow の実行かを判別できる
+
+## B-004: 実行中の表示名とアーカイブ済み履歴の名前の一致
+
+GIVEN workflow 実行がルート行として Workspace ツリーに表示されている
+WHEN その実行がアーカイブされ、利用者がアーカイブ済み workflow 履歴を表示する
+THEN 履歴に表示されるその実行の名前は、アーカイブ前に同じ実行のルート行へ表示されていた名前と一致する
+
+## B-005: 単独 AgentSession のルート行表示名の維持
+
+GIVEN workflow を介さずに起動された単独 AgentSession の実行木が Workspace ツリーに存在する
+WHEN 利用者が Workspace ツリーを表示する
+THEN その実行木のルート行の表示名は、本変更の前と同じである
+
+## B-006: ルート行以外の行の表示名の維持
+
+GIVEN workflow 実行の実行木に、ルート行以外の行（子 Sequence、Fanout、Session Node、Command Node）が存在する
+WHEN 利用者が Workspace ツリーを表示する
+THEN ルート行以外の各行の表示名は、本変更の前と同じである
+
+## B-007: Node 詳細に表示される名前の維持
+
+GIVEN workflow 実行の実行木の行が Workspace ツリーに表示されている
+WHEN 利用者がルート行または他の行を選択して Node 詳細を表示する
+THEN Node 詳細に表示される名前は、本変更の前と同じである
+
+## B-008: ルート行の識別子、状態表示、workflow 操作可否の維持
+
+GIVEN workflow 実行のルート行が Workspace ツリーに表示されている
+WHEN 利用者がルート行を参照し、workflow 操作を行う
+THEN ルート行の識別子は、本変更の前と同じである
+AND ルート行の状態表示は、本変更の前と同じである
+AND 停止、中止、再開、アーカイブの各 workflow 操作の可否は、本変更の前と同じである
+
+## 要件IDとBehavior IDの対応表
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001 |
+| R-002 | B-002 |
+| R-003 | B-003 |
+| R-004 | B-004 |
+| R-005 | B-005 |
+| R-006 | B-006 |
+| R-007 | B-007 |
+| R-008 | B-008 |

--- a/docs/specs/issues-1662/design.md
+++ b/docs/specs/issues-1662/design.md
@@ -1,0 +1,78 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### ルート行の表示名を決める規則の所有者
+
+`WorkspacePublicRoot`（`src-tauri/src/domain/workspace_tree/services.rs`）が「public root 行が外へ見せる名前は owner（Workflow node）の表示名である」という規則を所有する。gateway は写像だけを行い、どの名前を出すかを選ばない。
+
+この struct は既に同型の規則を持つ。行が外へ見せる識別子は public root Node の id ではなく owner の execution_id である（`services.rs:41-47` の `public_id`）。表示名も同じく「行が代表する実行の属性を見せる」規則であり、識別子と表示名で所有者を分けない。`docs/architecture/DOMAIN.md`「規則は domain が所有する。形は概念による」（状態を持たない概念は値オブジェクトとドメインサービスが規則を所有する）および「一つの概念に一つの表現」、`docs/architecture/GATEWAY.md`「業務判断を gateway に沈めない」に従う。
+
+owner の表示名を名前の出所にする。owner の title は `WorkflowSummaryProjected` の適用で `WorkflowExecutionMetadataRecord.workflow_name` から入り（`src-tauri/src/adaptor/gateway/workspace_tree/repository.rs:214-221`、`src-tauri/src/domain/workspace_tree/entities/mod.rs:747`）、アーカイブ済み履歴の名前は同じ record の同じ field から入る（`src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs:239`, `:504`）。R-004 は両者が同一の事実を読むことで成立する。workflow 名を read model 側で別途組み立て直す経路は作らない。
+
+#### 変更対象は投影であって Node の表示名ではない
+
+`WorkspaceTreeNode.title` は変更しない。差し替えるのは Workspace ツリー read model の投影（`query_service.rs` の `project_tree`）で組み立てるルート行の表示名だけである。
+
+Node の表示名は Node 詳細の経路でも使われる。`load_node` はルート行の要求に対して public root Node を clone して id だけ execution_id へ差し替えたものを返し（`repository.rs:145-155`）、`node_detail` がそこから詳細 DTO を作る。Node の title を書き換えると詳細側の名前も同時に変わり、R-007 を満たせない。
+
+#### ルート行の Node 種別に依らない単一の写像
+
+`project_tree` 内の `RootProjection` に表示名を持たせ、Fanout / Sequence / それ以外（Session・Command）の 3 つの分岐すべてが `RootProjection` から表示名を取る。`root_projections` に載らない行（ルート行以外）は従来どおり Node の title を使う。
+
+現状は 3 つの分岐がそれぞれ独立に `node.title` を読んでいる（`query_service.rs:385-412`）。ここに個別の差し替えを足すと種別ごとの漏れが起きる。`public_id` と `workflow_capabilities` は既に `RootProjection` 経由で 3 分岐へ配られているため、表示名を同じ経路に載せることで R-002 が構造で保証される。
+
+#### 単独 AgentSession を launch 種別で分岐しない
+
+表示名の差し替えは public root へ一律に適用し、`workflow_execution_ids`（launch 種別）による分岐を入れない。
+
+規則は「行はそれが代表する実行の名前を見せる」の一つである。単独 AgentSession の合成定義は definition の `name` と唯一の Node 名がともに `session` であるため（`src-tauri/src/domain/workflow/value_objects/node_fact.rs:155-192`）、一律適用でも表示名は変わらず R-005 は満たされる。launch 種別で分岐すると、domain が表現していない区別に基づく表示規則が gateway 側に生まれ、規則の所有者が二つに割れる。
+
+#### 検証の置き場所
+
+B-001 / B-002 / B-003 / B-006 は `project_tree` の単体テスト（gateway 層、`query_service_test.rs` に in-memory の `WorkspaceTree` を組む既存ヘルパーがある）で判定できる。手段が自明でないのは次の 2 点である。
+
+- B-004: 実行中の行の名前とアーカイブ済み履歴の名前が同一の事実から来ることを確かめるには、ツリー投影と履歴投影の両方を同じ fold から作って比較する必要がある。gateway 層のテストで両投影を同時に取る。
+- B-005: 単独 AgentSession の表示名が変わらないことは、別 module の合成定義（`node_fact.rs`）の名前の一致に依存する。gateway 層の回帰テストで、単独 session の実行木のルート行の表示名を固定する。
+
+### Interface
+
+外部から観測できる契約は変更しない。`WorkspaceNodeDto` / `WorkspaceSequenceDto` / `WorkspaceFanoutDto` の field 構成、`id`、`status`、`workflowCapabilities` は現状のままで、ルート行の `title` の値だけが変わる（R-008）。Tauri command の追加・削除・signature 変更はない。frontend は受け取った `title` をそのまま描画しており（`src/components/workspace/WorkspaceList.tsx:408`）、型定義（`src/types/workspace-tree.ts`）と描画の変更は不要である。
+
+内部境界として `WorkspacePublicRoot` に「行が外へ見せる表示名」を返す公開アクセサを一つ追加する。`public_id` と同じく借用を返し、他の domain port / trait は変更しない。
+
+### Data Model
+
+追加・変更する永続 record はない。`project_tree` のローカル構造体 `RootProjection` に表示名の field を一つ追加する。所有者は投影関数であり、identity は現状どおり public root Node の id をキーとする map で引く。versioning は不要（永続化されない投影中の値である）。
+
+### Database
+
+該当なし。新しい access path は追加せず、既存の fold 経路のみを使う。
+
+### UI/UX
+
+Workspace ツリーの workflow 実行ルート行のラベルが Node 名から workflow 名に変わる。行の並び、階層、状態表示、操作 UI、選択挙動は変更しない。frontend の変更はない。
+
+### Algorithm
+
+該当なし。
+
+### Infra
+
+該当なし。
+
+## Alternatives Considered
+
+- **`WorkspaceTreeNode.title` を owner 名で生成または上書きする**: 採らない。`load_node` 経由の Node 詳細の名前も同時に変わり、R-007 を満たせない。
+- **gateway が `WorkspacePublicRoot::owner()` の title を直接読み、domain へアクセサを足さない**: 採らない。行の公開表現を決める規則が、識別子は domain、表示名は gateway と二か所に分かれる。`docs/architecture/DOMAIN.md`「一つの概念に一つの表現」に反する。
+- **`workflow_execution_ids` で分岐し、workflow として起動された実行のルート行にだけ差し替えを適用する**: 採らない。R-005 は合成定義の名前の一致で既に満たされ、分岐は domain が表現していない区別を gateway に持ち込むだけになる。
+
+## Cross-cutting concerns
+
+Workspace ツリー read model は現在 2 つの Tauri command 経路（`list_workspace_worktree_nodes`、`get_workspace_tree_selection_reconciliation`）から出ており、いずれも `project_tree` を通る。表示名の差し替えを投影に置くことで両経路が同じ名前を返し、将来 local API や別 client surface が同じ query service を使う場合も追加の対応が要らない（`AGENTS.md`「同じ backend-owned state を Tauri、local API、将来の client surface で再利用できるか」）。
+
+## Risks
+
+R-005 の成立は、単独 AgentSession の合成定義における definition の `name` と Node 名がともに `session` であるという、`node_fact.rs` 側の一致に依存する。この一致が将来崩れると単独 AgentSession のルート行の表示名が変わる。B-005 の回帰テストでこの表示名を固定し、崩れた場合にテストで検知できるようにする。

--- a/docs/specs/issues-1662/requirements.md
+++ b/docs/specs/issues-1662/requirements.md
@@ -1,0 +1,93 @@
+# Context
+
+## 入力文書
+
+- 正本: GitHub Issue #1662「[workspace tree] workflow 実行木のルート行が常に node 名 main で表示され workflow 名が出ない」 <https://github.com/siro33950/releash/issues/1662>（label: `bug`、state: OPEN）
+- 参照した規約: `docs/glossary/WORKFLOW.md`、`AGENTS.md`
+- 参照した実装: `src-tauri/src/domain/workspace_tree/`（`entities/mod.rs`、`services.rs`、`projection.rs`）、`src-tauri/src/adaptor/gateway/workspace_tree/`（`query_service.rs`、`repository.rs`）、`src-tauri/src/domain/workflow/value_objects/node_fact.rs`、`src-tauri/src/adaptor/controller/command/workspace_tree.rs`、`src/components/workspace/WorkspaceList.tsx`、`src/types/workspace-tree.ts`、`workflows/*.yml`
+- 配置先: `docs/specs/issues-1662`
+
+## 確定済みの背景
+
+- workflow 定義の root Node 名は定義構文の規約で `main` に固定されている（`docs/glossary/WORKFLOW.md:40`「root は `nodes.main` という規約で決まる」）。リポジトリ同梱の builtin workflow 8本はすべて `nodes.main` を持つ（`workflows/01_author-spec.yml:112` ほか）。したがって workflow 実行の実行木の root Node 名は常に `main` である。
+- workflow 名は Workflow ノード（実行木の owner）が保持する。値は workflow 定義の `name` であり（`src-tauri/src/adaptor/gateway/workspace_tree/repository.rs:103`）、Workspace ツリーへは owner の表示名として入る（生成 `src-tauri/src/domain/workspace_tree/entities/mod.rs:282`、更新 `同:747`）。
+- 実行木の子ノードの表示名は Node 名である（`src-tauri/src/domain/workspace_tree/entities/mod.rs:475`）。root Sequence の表示名はここで `main` になる。
+- UI に「workflow 実行の行」として現れるのは Workflow ノードそのものではなく public root、すなわち owner の最初の可視直下子である（`src-tauri/src/domain/workspace_tree/services.rs:49` の `from_owner`）。read model の投影で Workflow ノードは自身を DTO 化せず子を展開するだけであり（`src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs:380`）、workflow 名を持つノードは UI に届かない。
+- public root の行には execution 単位の識別子（execution_id）と workflow 操作の可否（停止 / 中止 / 再開 / アーカイブ）が付与される（`src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs:342-365`）。行の実体は execution 単位である。
+- 単独 AgentSession も同じ実行木として表現される。その合成 workflow 定義は `name` と唯一の Node 名がともに `session` である（`src-tauri/src/domain/workflow/value_objects/node_fact.rs:155-192`）。owner の表示名と public root の表示名はどちらも `session` で一致する。
+- frontend は read model から受け取った表示名をそのまま描画する。加工は行わない（`src/components/workspace/WorkspaceList.tsx:408`、型定義 `src/types/workspace-tree.ts`）。
+- `AGENTS.md`「Rust がロジックを所有する」により、frontend に許されるのは表示とレイアウト制御、入力受付、`invoke` 呼び出し、表示用フォーマットのみである。表示名の決定はアプリケーションロジックであり Rust が持つ。
+- Workspace ツリーの read model は現状 Tauri command `list_workspace_worktree_nodes` と `get_workspace_tree_selection_reconciliation`（`src-tauri/src/adaptor/controller/command/workspace_tree.rs`）からのみ公開されている。loopback local API には Workspace ツリーの route が存在しない。
+
+## Issue 記載と現行コードの差異
+
+Issue が根拠として挙げる `domain/workflow/services/fact_replay.rs:203` の `standalone_session_definition` は、現行の main（`8e7612f83`）に存在しない。単独 AgentSession の合成定義に相当する現行の実装位置は `src-tauri/src/domain/workflow/value_objects/node_fact.rs:155-192` である。Issue 中の他の行番号も現行コードとは数行ずれている。本文書では現行コードで確認した位置を記載する。Issue が述べる事実関係そのもの（root Node 名が `main` 固定であること、public root が UI 上の workflow 行であること、単独 AgentSession では workflow 名と Node 名が一致すること）は現行コードでも成立している。
+
+# Outcome
+
+- 対象者: Releash で workflow を実行し、Workspace ツリーで実行状況を観測・操作する開発者。
+- 現在の問題: どの workflow を起動しても実行木のルート行が `main` と表示され、行から workflow を判別できない。さらに、同じ実行がアーカイブ済み履歴では workflow 名で表示されるため、実行中と履歴で同じ実行の名前が食い違う。
+- 変更後に実現する状態: Workspace ツリーの workflow 実行ルート行に、その実行の workflow 名が表示される。同一 workspace で複数の workflow を走らせても行から実行中の workflow を判別でき、実行中の表示名とアーカイブ済み履歴の表示名が一致する。
+
+# Current Behavior
+
+## 再現手順
+
+1. Releash を起動し、任意の worktree を選択する。
+2. builtin workflow `01_author-spec` を起動する。
+3. 同じ worktree で builtin workflow `03_full-review` を起動する。
+4. Workspace パネルの実行木を見る。
+5. 手順 2 で起動した実行を停止し、アーカイブする。
+6. workflow 履歴の表示を見る。
+
+## 実際の出力
+
+- 手順 4: 実行木のルート行が 2行とも `main` と表示される。どちらの行がどの workflow の実行かを行の表示名から判別できない。
+- 手順 6: 履歴には `01_author-spec` と表示される。手順 4 で同じ実行が `main` と表示されていたものと食い違う。
+
+## 確認方法と根拠
+
+上記は実行木の投影経路をコード上で追って確認した。
+
+- ルート行の表示名: public root は owner の最初の可視直下子（`domain/workspace_tree/services.rs:49`）であり、workflow 実行ではこれが root Sequence `main` になる。その表示名は Node 名（`domain/workspace_tree/entities/mod.rs:475`）であり、read model の投影は public root の表示名を差し替えない（`adaptor/gateway/workspace_tree/query_service.rs:395-406`）。frontend は受け取った値をそのまま描画する（`src/components/workspace/WorkspaceList.tsx:408`）。
+- 履歴行の表示名: `adaptor/gateway/workspace_tree/query_service.rs:239` が workflow 名を使う。
+- 表示名の差異は表示名だけに閉じており、行の識別子（execution_id）と workflow 操作の可否は public root に正しく付与されている（`adaptor/gateway/workspace_tree/query_service.rs:342-365`）。
+
+単独 AgentSession については、合成定義の `name` と唯一の Node 名がともに `session` であるため（`domain/workflow/value_objects/node_fact.rs:155-192`）、owner の表示名と public root の表示名はいずれも `session` で一致している。
+
+# Scope / Non-goals
+
+## 変更するもの
+
+- Workspace ツリーの read model が返す、workflow 実行ルート行（public root）の表示名。
+
+## 変更しないもの
+
+- 実行木の Node が保持する表示名そのもの。Node 詳細など、Node の表示名を使う他の経路の表示は変えない。
+- ルート行以外の行（子 Sequence、Fanout、Session / Command Node）の表示名。
+- 単独 AgentSession の実行木の表示名。
+- ルート行の識別子、状態表示、workflow 操作（停止 / 中止 / 再開 / アーカイブ）の可否。
+- アーカイブ済み workflow 履歴の表示名。既に workflow 名である。
+- workflow 定義構文。root Node 名を `main` に固定する規約は変えない。
+- 表示名の決定を frontend に置くことは、`AGENTS.md` の「全てのアプリケーションロジックは Rust に置く」により選択肢に含めない。
+
+# Requirements
+
+- R-001: Workspace ツリー上で workflow 実行を表すルート行の表示名が、その実行の workflow 名になる。
+- R-002: R-001 は、ルート行にあたる Node の種別（Sequence / Fanout / Session / Command）に依らず成り立つ。
+- R-003: 同一 workspace で複数の workflow 実行が同時に並ぶとき、各ルート行の表示名からどの workflow の実行かを判別できる。
+- R-004: 同一の実行について、実行中に表示されるルート行の表示名と、アーカイブ済み workflow 履歴に表示される名前が一致する。
+- R-005: 単独 AgentSession の実行木のルート行の表示名は、本変更の前後で変わらない。
+- R-006: ルート行以外の行の表示名は、本変更の前後で変わらない。
+- R-007: Node 詳細に表示される名前は、本変更の前後で変わらない。
+- R-008: ルート行の識別子、状態表示、および workflow 操作（停止 / 中止 / 再開 / アーカイブ）の可否は、本変更の前後で変わらない。
+
+# Assumptions / Open Questions
+
+## Assumptions
+
+なし。
+
+## Open Questions
+
+なし。

--- a/src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs
+++ b/src-tauri/src/adaptor/gateway/workspace_tree/query_service.rs
@@ -299,6 +299,7 @@ fn project_tree(
     fn node_dto(
         node: &WorkspaceTreeNode,
         public_id: String,
+        public_title: String,
         workflow_capabilities: Option<WorkspaceWorkflowCapabilitiesDto>,
         session_capabilities: Option<WorkspaceSessionCapabilitiesDto>,
         by_id: &HashMap<&str, &WorkspaceTreeNode>,
@@ -307,11 +308,11 @@ fn project_tree(
             .past_attempt_ids
             .iter()
             .filter_map(|id| by_id.get(id.as_str()).copied())
-            .map(|past| node_dto(past, past.id.clone(), None, None, by_id))
+            .map(|past| node_dto(past, past.id.clone(), past.title.clone(), None, None, by_id))
             .collect::<Vec<_>>();
         WorkspaceNodeDto {
             id: public_id,
-            title: node.title.clone(),
+            title: public_title,
             status: node.status_classification.as_public_str().to_string(),
             error_reason: node.error_reason.clone(),
             content_kind: if node.kind == WorkspaceNodeKind::WorkflowCommand {
@@ -335,6 +336,7 @@ fn project_tree(
     #[derive(Clone)]
     struct RootProjection {
         public_id: String,
+        public_title: String,
         workflow_capabilities: Option<WorkspaceWorkflowCapabilitiesDto>,
         session_capabilities: Option<WorkspaceSessionCapabilitiesDto>,
     }
@@ -351,6 +353,7 @@ fn project_tree(
                 root.node().id.as_str(),
                 RootProjection {
                     public_id: root.public_id().to_string(),
+                    public_title: root.public_title().to_string(),
                     workflow_capabilities: is_workflow.then(|| workflow_capabilities(root.owner())),
                     session_capabilities: root_session.map(|session| {
                         WorkspaceSessionCapabilitiesDto {
@@ -384,7 +387,8 @@ fn project_tree(
                     let root = root_projections.get(node.id.as_str());
                     vec![WorkspaceTreeItemDto::Fanout(WorkspaceFanoutDto {
                         id: root.map_or_else(|| node.id.clone(), |root| root.public_id.clone()),
-                        title: node.title.clone(),
+                        title: root
+                            .map_or_else(|| node.title.clone(), |root| root.public_title.clone()),
                         status: node.status_classification.as_public_str().to_string(),
                         workflow_capabilities: root
                             .and_then(|root| root.workflow_capabilities.clone()),
@@ -396,7 +400,8 @@ fn project_tree(
                     let root = root_projections.get(node.id.as_str());
                     vec![WorkspaceTreeItemDto::Sequence(WorkspaceSequenceDto {
                         id: root.map_or_else(|| node.id.clone(), |root| root.public_id.clone()),
-                        title: node.title.clone(),
+                        title: root
+                            .map_or_else(|| node.title.clone(), |root| root.public_title.clone()),
                         status: node.status_classification.as_public_str().to_string(),
                         workflow_capabilities: root
                             .and_then(|root| root.workflow_capabilities.clone()),
@@ -409,6 +414,7 @@ fn project_tree(
                     vec![WorkspaceTreeItemDto::Node(node_dto(
                         node,
                         root.map_or_else(|| node.id.clone(), |root| root.public_id.clone()),
+                        root.map_or_else(|| node.title.clone(), |root| root.public_title.clone()),
                         root.and_then(|root| root.workflow_capabilities.clone()),
                         root.and_then(|root| root.session_capabilities.clone()),
                         by_id,

--- a/src-tauri/src/adaptor/gateway/workspace_tree/query_service_test.rs
+++ b/src-tauri/src/adaptor/gateway/workspace_tree/query_service_test.rs
@@ -10,7 +10,7 @@ use crate::domain::local_event::WorkflowExecutionMetadataRecord;
 use crate::domain::provider_lifecycle::ProviderKind;
 use crate::domain::workflow::{
     ExecutionOrigin, ExecutionStatus, TokenUsage, WorkflowExecutionArchiveSnapshot,
-    WorkflowExecutionId,
+    WorkflowExecutionId, WorkflowExecutionManualArchiveRecord,
 };
 use crate::domain::workspace_tree::{
     WorkspaceNodeStatus, WorkspaceNodeStatusClassification, WorkspaceTreeNode,
@@ -45,6 +45,44 @@ impl WorkflowExecutionArchiveRepository for EmptyArchives {
         Ok(WorkflowExecutionArchiveSnapshot {
             records: Vec::new(),
         })
+    }
+}
+
+struct ArchivedExecution {
+    execution_id: String,
+    archived_at: f64,
+}
+
+impl WorkflowExecutionArchiveRepository for ArchivedExecution {
+    fn archive_manual(
+        &self,
+        _execution_id: &WorkflowExecutionId,
+        _archived_at: f64,
+    ) -> Result<(), WorkflowError> {
+        Ok(())
+    }
+
+    fn restore_manual(
+        &self,
+        _execution_id: &WorkflowExecutionId,
+        _restored_at: f64,
+    ) -> Result<(), WorkflowError> {
+        Ok(())
+    }
+
+    fn manual_archive_snapshot_for(
+        &self,
+        execution_ids: &[String],
+    ) -> Result<WorkflowExecutionArchiveSnapshot, WorkflowError> {
+        let records = execution_ids
+            .contains(&self.execution_id)
+            .then(|| WorkflowExecutionManualArchiveRecord {
+                execution_id: self.execution_id.clone(),
+                archived_at: self.archived_at,
+            })
+            .into_iter()
+            .collect();
+        Ok(WorkflowExecutionArchiveSnapshot { records })
     }
 }
 
@@ -164,6 +202,153 @@ async fn test_workspace_tree_query_workspace同定子がworktreeと異なるsess
         WorkspaceTreeItemDto::Node(node) if node.id == "standalone-session"
     ));
 }
+
+#[test]
+fn test_workspaceツリー投影_同じfoldのworkflow履歴と表示名が一致する() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let store = LocalEventStore::open(LocalEventStoreConfig::production(
+        directory.path().to_path_buf(),
+    ))
+    .unwrap();
+    let execution_id = "00000000-0000-4000-8000-000000001662";
+    seed_workflow_session_facts(
+        &store,
+        WorkflowSessionFactSeed {
+            workflow_name: "01_author-spec",
+            request: "test",
+            worktree_path: "/repo",
+            provider: ProviderKind::Codex,
+            workflow_execution_id: execution_id,
+            node_execution_id: "workflow-node",
+            session_id: "workflow-session",
+            initial_instruction_admitted: true,
+        },
+    )
+    .unwrap();
+    let repository = SqliteWorkspaceTreeRepository::new(store);
+    let tree_query =
+        SqliteWorkspaceQueryService::with_repository(repository.clone(), Arc::new(EmptyArchives));
+    let history_query = SqliteWorkspaceQueryService::with_repository(
+        repository,
+        Arc::new(ArchivedExecution {
+            execution_id: execution_id.to_string(),
+            archived_at: 10.0,
+        }),
+    );
+
+    // When
+    let snapshot = tree_query
+        .workspace_tree(&WorkspaceIdentity::new("/repo"))
+        .unwrap();
+    let history = history_query
+        .workflow_history(&WorkspaceIdentity::new("/repo"))
+        .unwrap();
+    let tree_json = serde_json::to_value(snapshot.nodes).unwrap();
+    let tree_title = tree_json[0]["title"].as_str().unwrap();
+
+    // Then
+    assert_eq!(tree_title, "01_author-spec");
+    assert_ne!(tree_title, "main");
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].execution_id, execution_id);
+    assert_eq!(history[0].title, tree_title);
+}
+
+#[tokio::test]
+async fn test_workspaceツリー投影_単独agent_sessionのpublic_root表示名はsessionを保つ() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let store = LocalEventStore::open(LocalEventStoreConfig::production(
+        directory.path().to_path_buf(),
+    ))
+    .unwrap();
+    let workspace = WorkspaceIdentity::new("/repo");
+    let execution_id = "standalone-session";
+    LocalAgentSessionRepository::new(store.clone())
+        .create(
+            AgentSession::create(
+                execution_id,
+                workspace.clone(),
+                workspace.as_str(),
+                ProviderKind::Codex,
+                AgentSessionTreeLocation::session_tree_root(execution_id).unwrap(),
+            )
+            .unwrap(),
+            "standalone-create",
+        )
+        .await
+        .unwrap();
+    let repository = SqliteWorkspaceTreeRepository::new(store);
+    let query = SqliteWorkspaceQueryService::with_repository(repository, Arc::new(EmptyArchives));
+
+    // When
+    let snapshot = query.workspace_tree(&workspace).unwrap();
+    let detail = query
+        .node_detail(&workspace, execution_id)
+        .unwrap()
+        .unwrap();
+    let tree_json = serde_json::to_value(snapshot.nodes).unwrap();
+
+    // Then
+    assert_eq!(tree_json[0]["title"], "session");
+    assert_eq!(detail.title, "session");
+}
+
+#[test]
+fn test_workspaceノード詳細_public_rootと子nodeの名前はnodeのtitleを保つ() {
+    // Given
+    let directory = tempfile::tempdir().unwrap();
+    let store = LocalEventStore::open(LocalEventStoreConfig::production(
+        directory.path().to_path_buf(),
+    ))
+    .unwrap();
+    let workspace = WorkspaceIdentity::new("/repo");
+    let execution_id = "00000000-0000-4000-8000-000000001663";
+    let child_execution_id = "workflow-node";
+    seed_workflow_session_facts(
+        &store,
+        WorkflowSessionFactSeed {
+            workflow_name: "01_author-spec",
+            request: "test",
+            worktree_path: workspace.as_str(),
+            provider: ProviderKind::Codex,
+            workflow_execution_id: execution_id,
+            node_execution_id: child_execution_id,
+            session_id: "workflow-session",
+            initial_instruction_admitted: true,
+        },
+    )
+    .unwrap();
+    let repository = SqliteWorkspaceTreeRepository::new(store);
+    let query =
+        SqliteWorkspaceQueryService::with_repository(repository.clone(), Arc::new(EmptyArchives));
+    let root_node = repository
+        .load_node(&workspace, execution_id)
+        .unwrap()
+        .unwrap();
+    let child_node = repository
+        .load_node_by_node_execution_id(child_execution_id)
+        .unwrap()
+        .unwrap();
+
+    // When
+    let root_detail = query
+        .node_detail(&workspace, execution_id)
+        .unwrap()
+        .unwrap();
+    let child_detail = query
+        .node_detail(&workspace, &child_node.id)
+        .unwrap()
+        .unwrap();
+
+    // Then
+    assert_eq!(root_node.title, "main");
+    assert_eq!(root_detail.title, root_node.title);
+    assert_eq!(child_node.title, "impl");
+    assert_eq!(child_detail.title, child_node.title);
+}
+
 fn node() -> WorkspaceTreeNode {
     WorkspaceTreeNode {
         id: "node".to_string(),
@@ -213,6 +398,12 @@ fn tree_owner(execution_id: &str) -> WorkspaceTreeNode {
     owner.can_approve = false;
     owner.can_stop = true;
     owner.can_abort = true;
+    owner
+}
+
+fn tree_owner_with_title(execution_id: &str, title: &str) -> WorkspaceTreeNode {
+    let mut owner = tree_owner(execution_id);
+    owner.title = title.to_string();
     owner
 }
 
@@ -332,6 +523,7 @@ fn standalone_session_is_a_public_node_root_with_backend_lifecycle_capabilities(
     assert_eq!(json[0]["contentKind"], "session");
     assert_eq!(json[0]["sessionCapabilities"]["sessionRef"], "session-ref");
     assert_eq!(json[0]["sessionCapabilities"]["canArchive"], true);
+    assert_eq!(json[0]["sessionCapabilities"]["canDelete"], false);
     assert!(json[0]["workflowCapabilities"].is_null());
 }
 
@@ -359,6 +551,170 @@ fn leaf_workflow_root_keeps_workflow_capabilities_on_the_node() {
     assert_eq!(json[0]["kind"], "node");
     assert_eq!(json[0]["id"], execution_id);
     assert_eq!(json[0]["workflowCapabilities"]["canStop"], true);
+}
+
+fn assert_public_root_title(kind: WorkspaceNodeKind) {
+    // Given
+    let execution_id = "workflow-execution";
+    let owner = tree_owner_with_title(execution_id, "01_author-spec");
+    let public_root = child_node("root", execution_id, execution_id, kind, "main");
+    let tree = WorkspaceTree::restore("/repo", vec![owner, public_root]).unwrap();
+
+    // When
+    let json = serde_json::to_value(project_tree(
+        &tree,
+        &HashSet::new(),
+        &HashSet::from([execution_id.to_string()]),
+        &[],
+    ))
+    .unwrap();
+
+    // Then
+    assert_eq!(json[0]["title"], "01_author-spec");
+    assert_ne!(json[0]["title"], "main");
+}
+
+#[test]
+fn test_workspaceツリー投影_sequenceのpublic_root表示名にworkflow名を返す() {
+    assert_public_root_title(WorkspaceNodeKind::Sequence);
+}
+
+#[test]
+fn test_workspaceツリー投影_fanoutのpublic_root表示名にworkflow名を返す() {
+    assert_public_root_title(WorkspaceNodeKind::Fanout);
+}
+
+#[test]
+fn test_workspaceツリー投影_sessionのpublic_root表示名にworkflow名を返す() {
+    assert_public_root_title(WorkspaceNodeKind::WorkflowSession);
+}
+
+#[test]
+fn test_workspaceツリー投影_commandのpublic_root表示名にworkflow名を返す() {
+    assert_public_root_title(WorkspaceNodeKind::WorkflowCommand);
+}
+
+#[test]
+fn test_workspaceツリー投影_異なるworkflow名の複数実行を表示名で判別できる() {
+    // Given
+    let execution_a = "execution-a";
+    let execution_b = "execution-b";
+    let owner_a = tree_owner_with_title(execution_a, "01_author-spec");
+    let owner_b = tree_owner_with_title(execution_b, "03_full-review");
+    let root_a = child_node(
+        "root-a",
+        execution_a,
+        execution_a,
+        WorkspaceNodeKind::Sequence,
+        "main",
+    );
+    let root_b = child_node(
+        "root-b",
+        execution_b,
+        execution_b,
+        WorkspaceNodeKind::Sequence,
+        "main",
+    );
+    let tree = WorkspaceTree::restore("/repo", vec![owner_a, root_a, owner_b, root_b]).unwrap();
+
+    // When
+    let json = serde_json::to_value(project_tree(
+        &tree,
+        &HashSet::new(),
+        &HashSet::from([execution_a.to_string(), execution_b.to_string()]),
+        &[],
+    ))
+    .unwrap();
+
+    // Then
+    let row_a = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["id"] == execution_a)
+        .unwrap();
+    let row_b = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["id"] == execution_b)
+        .unwrap();
+    assert_eq!(row_a["title"], "01_author-spec");
+    assert_eq!(row_b["title"], "03_full-review");
+    assert_ne!(row_a["title"], row_b["title"]);
+}
+
+#[test]
+fn test_workspaceツリー投影_public_root以外はnode名を表示名に保つ() {
+    // Given
+    let execution_id = "workflow-execution";
+    let owner = tree_owner_with_title(execution_id, "01_author-spec");
+    let public_root = child_node(
+        "root",
+        execution_id,
+        execution_id,
+        WorkspaceNodeKind::Sequence,
+        "main",
+    );
+    let child_sequence = child_node(
+        "child-sequence",
+        "root",
+        execution_id,
+        WorkspaceNodeKind::Sequence,
+        "prepare",
+    );
+    let mut child_fanout = child_node(
+        "child-fanout",
+        "root",
+        execution_id,
+        WorkspaceNodeKind::Fanout,
+        "reviews",
+    );
+    child_fanout.sibling_order = 1;
+    let mut child_session = child_node(
+        "child-session",
+        "root",
+        execution_id,
+        WorkspaceNodeKind::WorkflowSession,
+        "author",
+    );
+    child_session.sibling_order = 2;
+    let mut child_command = child_node(
+        "child-command",
+        "root",
+        execution_id,
+        WorkspaceNodeKind::WorkflowCommand,
+        "lint",
+    );
+    child_command.sibling_order = 3;
+    let tree = WorkspaceTree::restore(
+        "/repo",
+        vec![
+            owner,
+            public_root,
+            child_sequence,
+            child_fanout,
+            child_session,
+            child_command,
+        ],
+    )
+    .unwrap();
+
+    // When
+    let json = serde_json::to_value(project_tree(
+        &tree,
+        &HashSet::new(),
+        &HashSet::from([execution_id.to_string()]),
+        &[],
+    ))
+    .unwrap();
+
+    // Then
+    assert_eq!(json[0]["title"], "01_author-spec");
+    assert_eq!(json[0]["children"][0]["title"], "prepare");
+    assert_eq!(json[0]["children"][1]["title"], "reviews");
+    assert_eq!(json[0]["children"][2]["title"], "author");
+    assert_eq!(json[0]["children"][3]["title"], "lint");
 }
 
 #[test]

--- a/src-tauri/src/domain/workspace_tree/services.rs
+++ b/src-tauri/src/domain/workspace_tree/services.rs
@@ -46,6 +46,10 @@ impl<'a> WorkspacePublicRoot<'a> {
             .expect("a Workflow root owner must have an execution id")
     }
 
+    pub fn public_title(&self) -> &'a str {
+        self.owner.title.as_str()
+    }
+
     fn from_owner(nodes: &'a [WorkspaceTreeNode], owner: &'a WorkspaceTreeNode) -> Option<Self> {
         owner.execution_id.as_ref()?;
         let node = nodes
@@ -222,5 +226,33 @@ mod tests {
 
         assert_eq!(by_execution, by_node);
         assert!(WorkspacePublicRoot::for_node(&nodes, "child").is_none());
+    }
+
+    #[test]
+    fn test_public_root表示名_public_root_nodeではなくownerのtitleを返す() {
+        // Given
+        let mut owner = node(
+            "owner",
+            None,
+            0,
+            WorkspaceNodeKind::Workflow,
+            Some("execution"),
+        );
+        owner.title = "01_author-spec".to_string();
+        let mut public_root = node(
+            "root",
+            Some("owner"),
+            0,
+            WorkspaceNodeKind::Sequence,
+            Some("execution"),
+        );
+        public_root.title = "main".to_string();
+        let nodes = vec![owner, public_root];
+
+        // When
+        let public_root = WorkspacePublicRoot::for_execution(&nodes, "execution").unwrap();
+
+        // Then
+        assert_eq!(public_root.public_title(), "01_author-spec");
     }
 }


### PR DESCRIPTION
Closes #1662

## 原因

Workspace ツリーで「workflow 実行の行」として見えているのは Workflow node 自身ではなく、その最初の可視直下子である public root（`domain/workspace_tree/services.rs` の `WorkspacePublicRoot`）である。read model の投影は Workflow node を DTO 化せず子を展開するだけなので（`adaptor/gateway/workspace_tree/query_service.rs`）、workflow 名を持つ node は UI に届かない。

一方で実行木の root Node 名は定義構文の規約で `main` に固定されている（`docs/glossary/WORKFLOW.md`「root は `nodes.main` という規約で決まる」。builtin workflow 8 本はすべて `nodes.main` を持つ）。ルート行の表示名は Node 名をそのまま使っていたため、どの workflow を起動しても行は常に `main` と表示され、同一 workspace で複数の実行を走らせても行から判別できない。

さらにアーカイブ済み workflow 履歴は `WorkflowExecutionMetadataRecord.workflow_name` を使う（`query_service.rs:239`）ため、同じ実行が実行中は `main`、履歴では `01_author-spec` と食い違って表示されていた。

なお Issue が根拠に挙げた `domain/workflow/services/fact_replay.rs` の `standalone_session_definition` は現行の main に存在しない。単独 AgentSession の合成定義に相当する現行の位置は `domain/workflow/value_objects/node_fact.rs` である。Issue が述べる事実関係そのもの（root Node 名が `main` 固定であること、public root が UI 上の workflow 行であること、単独 AgentSession では workflow 名と Node 名が一致すること）は現行コードでも成立している。

## 修正

- **表示名を決める規則を domain が所有する**: `WorkspacePublicRoot` に `public_title()` を追加し、「public root 行が外へ見せる名前は owner（Workflow node）の表示名である」を domain に置く。この struct は既に同型の規則（行が外へ見せる識別子は public root Node の id ではなく owner の execution_id）を `public_id()` で持っており、識別子と表示名で所有者を分けない
- **ルート行の Node 種別に依らない単一の写像**: `project_tree` の `RootProjection` に表示名を載せ、Fanout / Sequence / それ以外（Session・Command）の 3 分岐がすべてそこから取る。分岐ごとに `node.title` を読む形をやめ、種別ごとの漏れが構造で起きないようにする
- **Node の title は変更しない**: 差し替えるのはツリー投影が組み立てるルート行の表示名だけ。`load_node` 経由の Node 詳細と、ルート行以外の行（子 Sequence、Fanout、Session / Command Node）は従来どおり Node の title を使う
- **launch 種別で分岐しない**: 単独 AgentSession の合成定義は definition の `name` と唯一の Node 名がともに `session` であるため、public root へ一律適用しても表示名は変わらない。`workflow_execution_ids` で分岐すると、domain が表現していない区別に基づく表示規則が gateway 側に生まれる

owner の title は履歴の名前と同じ `WorkflowExecutionMetadataRecord.workflow_name` から入るため、実行中のルート行と履歴が同一の事実を読む形になり、両者の表示名が一致する。workflow 名を read model 側で組み立て直す経路は作らない。

変えない契約: `WorkspaceNodeDto` / `WorkspaceSequenceDto` / `WorkspaceFanoutDto` の field 構成、ルート行の `id`（execution_id）・`status`・`workflowCapabilities`、Tauri command の signature。frontend は受け取った `title` をそのまま描画しており、型定義と描画の変更はない。

## テスト

- **domain**: public root の表示名が public root Node ではなく owner の title を返すこと
- **gateway**: ルート行が Sequence / Fanout / Session / Command のいずれでも workflow 名になること（B-001 / B-002）、workflow 名の異なる複数実行を表示名で判別できること（B-003）、同じ fold から作ったツリー投影と履歴投影の名前が一致すること（B-004）、単独 AgentSession のルート行が `session` を保つこと（B-005）、public root 以外の行が Node 名を保つこと（B-006）、Node 詳細の名前が Node の title を保つこと（B-007）
- 検証: `cargo fmt --check` / `cargo clippy --locked -- -D warnings` / `cargo test --locked`（lib 2254 + 各 acceptance すべて green）すべて pass。frontend への変更はない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019S6UWDZhBbNmNaQG6oEUNE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ワークフロー実行ツリーのルート行に、常に対応するワークフロー名が表示されるようになりました。
  * Sequence、Fanout、Session、Command などの実行種別にかかわらず、ルート行の表示が統一されます。
  * 複数の実行やアーカイブ済み履歴を、ワークフロー名で正しく識別できるようになりました。
  * AgentSession、子ノードの表示名や識別子、実行操作の可否は従来どおりです。

* **ドキュメント**
  * ルート行の表示仕様、要件、設計を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->