### PR TITLE
fix(event-store): 事実行 append の tokio ランタイム構築を撤去し fd 枯渇による追記失敗を解消する (#1679)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,6 @@ Rust テストの配置、命名、レイヤー別の必須／柔軟、モック
 - `git2` の `UnbornBranch`: `repo.head()` が `ErrorCode::UnbornBranch` を返す場合の分岐が要る。
 - `git apply --cached`: パッチのベースはステージング状態にする。HEAD ベースだとコンテキストが一致しない。
 - worktree をリポジトリルート内に作らない。Biome が nested config で失敗する。
-- `docs/specs` は `.gitignore` に入っているが、既存のファイルは tracked のまま残っている。新規に作った spec だけが ignore される。
 
 ## レビュー観点
 

--- a/docs/specs/issues-1679/behavior.md
+++ b/docs/specs/issues-1679/behavior.md
@@ -1,0 +1,74 @@
+## B-001: 事実行の追記が file descriptor を増やさない
+
+GIVEN プロセスの open fd 数が観測できる
+WHEN node の事実行を1行追記する
+THEN 事実行が記録される
+AND 追記の実行中および完了後の open fd 数が、追記を理由として追記前より増えない
+
+## B-002: 同時多重の追記でも file descriptor が増えない
+
+GIVEN 複数の workflow が並列に実行され、事実行の追記が同時に発生する
+WHEN それらの追記が並行して行われる
+THEN すべての事実行が記録される
+AND 同時に実行される追記の数が増えても、追記を理由とする open fd 数の増加が起きない
+
+## B-003: fd 上限の直下でも事実行を追記できる
+
+GIVEN プロセスの open fd 数が fd soft limit の直下にある
+WHEN node の activation が session_attached の事実行を追記する
+THEN 事実行が記録される
+AND `failed to create fact append runtime: Too many open files (os error 24)` は発生しない
+AND activation は file descriptor を確保できないことを理由に失敗しない
+
+## B-004: 同期文脈からの追記
+
+GIVEN 同期文脈から事実行の追記が行われる
+WHEN 事実行を追記する
+THEN 事実行が記録される
+AND 追記の結果が呼び出し元へ返り、実行が停止しない
+
+## B-005: async 文脈（provider Stop の受理）からの追記
+
+GIVEN provider の Stop を受理する async 経路が事実行の追記を行う
+WHEN その事実行を追記する
+THEN 事実行が記録される
+AND 受理処理が継続し、panic、deadlock、実行の停止が起きない
+
+## B-006: async 文脈（node activation）からの追記
+
+GIVEN node の activation が async 経路で事実行の追記を行う
+WHEN その事実行を追記する
+THEN 事実行が記録される
+AND activation が継続し、panic、deadlock、実行の停止が起きない
+
+## B-007: 事実行の内容と追記順序の維持
+
+GIVEN 同一 node に対して複数の事実が順に発生する
+WHEN それらを追記する
+THEN 記録された各事実行の内容が変更前と一致する
+AND 同一 node の事実行の並びが、事実の発生順と一致する
+
+## B-008: 追記が途中で失敗したときの記録の単位
+
+GIVEN 複数の事実行を続けて追記する
+WHEN その途中で、ある事実行の追記が失敗する
+THEN 失敗した事実行より前に追記された事実行は記録されたまま残る
+AND 失敗した事実行は記録されない
+AND 追記の失敗が呼び出し元へ返る
+
+## B-009: 追記先に起因する失敗の扱い
+
+GIVEN 追記先の SQLite に起因して事実行の追記が失敗する
+WHEN node の処理がその事実行の追記を行う
+THEN 追記の失敗が呼び出し元へ伝わる
+AND その node は失敗として扱われる
+AND 追記できなかった事実は、記録されたものとして扱われない
+
+## 要件IDとBehavior IDの対応表
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001, B-002 |
+| R-002 | B-003, B-009 |
+| R-003 | B-004, B-005, B-006 |
+| R-004 | B-007, B-008 |
+| R-005 | B-008, B-009 |

--- a/docs/specs/issues-1679/design.md
+++ b/docs/specs/issues-1679/design.md
@@ -1,0 +1,80 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### 事実行 append の同期ポートを writer thread への blocking 委譲で満たす
+
+事実行 append は呼び出し側から見て同期の port である。usecase の `PreparedWorkflowTransaction::persist` は同期の `FnOnce(&[WorkflowEvent]) -> Result<(), E>` を受け取り（`src-tauri/src/usecase/workflow/runtime_driver.rs:163-169`）、domain の `IsolatedWorktreeLedgerRepository::append` も同期 trait method である（`src-tauri/src/domain/workflow/repository.rs:21-26`）。この 2 つの契約が同期であることが、gateway 側に「tokio runtime を要さない同期 append」を用意する理由になる。
+
+決定は次のとおり。
+
+- `LocalEventStore` に node_events 単一行 append の blocking 入口を置く。writer thread への request 投入は現在と同じ `WriteQueue::admit` で行い、応答の受け取りだけを同期化する。
+- `fact_log::append_pending_rows_blocking` は OS thread の spawn と tokio runtime の構築をやめ、呼び出し元の thread でこの blocking 入口を行ごとに呼ぶ。
+
+この形が成立する根拠は既存実装にある。writer は tokio task ではなく独立した OS thread であり（`src-tauri/src/adaptor/gateway/local_event_store/store.rs:735-745` の `local-event-store-writer`）、呼び出し元が block しても応答側は前進する。読み出し側は同じ store に対して既に同一の形を採っており（`store.rs:1005` の `submit_indexed_query_blocking` → `local_event_store/reader.rs:1899`）、`append_facts_for_events` は同じ関数の中で runtime を作らずにその読み出しを呼んでいる（`adaptor/gateway/workflow/fact_log.rs:389-424`）。append 経路だけが runtime を必要としていたのは、reply channel が async 専用だったことによる。
+
+#### reply channel を std の同期チャネルにする
+
+`NodeEventAppendRequest.reply` は現在 `tokio::sync::oneshot::Sender` であり（`local_event_store/writer.rs:62`）、その blocking 受信は tokio runtime context の内側で panic する。事実行 append の async 呼び出し元はまさに runtime worker 上にある（`adaptor/gateway/workflow/event_log_writer.rs:39-45` の provider Stop 受理、`adaptor/gateway/workflow/workflow_host.rs:2119-2160` の commit）ため、oneshot のまま blocking 受信へ切り替えると R-003 を満たせない。
+
+reply を reader pool と同じ std の同期チャネル（容量 1）へ変更する。std の受信は runtime context を判定せず panic しないため、同期文脈と async 文脈のどちらからでも同じ 1 つの入口が使える。送信側が drop された場合の受信失敗は、現在の oneshot 受信失敗と同じく `NodeEventWriteError::OutcomeUnknown` へ写す。
+
+`WriteRequest::Commit` 側の reply は変更しない。`commit_batch_with_node_events` は async の production 呼び出し元を持つため（`adaptor/gateway/agent_session/agent_session_repository.rs:260`）、そのまま async として残す。
+
+#### append の入口を blocking の 1 つに統一する
+
+`LocalEventStore::append_node_event`（async、`store.rs:978`）の production 呼び出し元は `append_pending_rows_blocking` だけである。blocking 入口を追加したうえで async 版を残すと、同じ意味の append が 2 通りになる。async 版は削除し、既存の呼び出し（いずれもテスト）を blocking 入口へ寄せる。
+
+#### panic 境界を再構築しない
+
+現在は `std::thread::scope` の `join()` が append worker の panic を `node fact append worker panicked` という失敗へ畳んでいる。thread を作らなくなるとこの境界は消える。唯一の panic 源は store の write queue / reader pool 内部の mutex poisoning であり、同じ関数が呼ぶ読み出し経路には元から境界がない。`catch_unwind` を新設せず、読み出し経路と同じ扱いに揃える。
+
+### Interface
+
+- `LocalEventStore` の node_events append: 同期 method 1 つ。入出力は既存 async 版と同型（`NewNodeEventRow` と発生時刻の `Option<i64>` を受け、`Result<i64, NodeEventWriteError>` を返す）。async 版は削除する。
+- `writer::NodeEventAppendRequest` は `reply` field の型だけを変更する。他の field と `WriteRequest` の variant 構成は変えない。
+- `fact_log::append_facts_for_events` / `append_single_fact` / `append_pending_rows_blocking` のシグネチャは変えない。したがって呼び出し元（`workflow_host` の commit 経路、`event_log_writer`、`worktree_ledger_repository`、起動時 reconciliation）に変更は要らない。
+- Tauri command、local API、CLI の外部契約は変更しない。
+
+### Data Model
+
+該当なし。`NewNodeEventRow` の field、`seq` と `timestamp_ms` の与え方、記録される事実の種類は変えない。
+
+### Database
+
+該当なし。同一 writer connection 上の同一の単一行 INSERT を実行する。access path の追加も schema 変更もない。
+
+### UI/UX
+
+該当なし。
+
+### Algorithm
+
+維持する不変条件と、それが本設計で成り立つ根拠だけを示す。
+
+- 同一 node の事実行の並び（R-004 / B-007）: rows は 1 行ずつ順に投入し、応答を得てから次を投入する。writer は単一 thread で request を直列に処理するため、helper thread を挟まなくなっても同一 node の到着順は変わらない。
+- 失敗時の記録単位（R-005 / B-008）: 途中の行が失敗した時点で残りを投入せず、呼び出し元へ失敗を返す。原子性は 1 行を超えない（`store.rs:973-977`）。
+- 失敗分類: append 失敗は `NodeEventWriteError` のまま gateway 境界で文字列へ写し、`workflow_host` 側の `append_error_context` 合成（`workflow_host.rs:1497` ほか）と `settle_runtime_failure_for_node` の扱いは変えない。runtime 構築起因の文言（`failed to create fact append runtime: ...`）と worker panic 文言は発生源が消えるため無くなる。B-003 の「その文言が発生しない」はこの消滅で満たす。
+
+### Infra
+
+該当なし。プロセス起動時の fd soft limit は Non-goals であり、追加・変更・撤去する構成要素はない。
+
+## Alternatives Considered
+
+- 既存の tokio runtime handle を共有して `Handle::block_on` する（Issue が挙げた対応案の 1 つ）。`Handle::block_on` は runtime worker thread 上で panic する。事実行 append の async 呼び出し元（`event_log_writer.rs:45`、`workflow_host.rs:2157`）はまさにその位置にあるため R-003 を満たせない。`workflow_host.rs:1719` に同種の呼び出しがあるが、あれは `spawn_blocking` の内側で blocking region に入っており条件が異なる。
+- append 経路全体を async にする。usecase の `persist` が同期 `FnOnce`、domain の `IsolatedWorktreeLedgerRepository::append` が同期 trait method であるため、usecase と domain の契約変更を伴う。さらに `workflow_host.rs:2119` は「同期 append を跨いで executions mutex を保持する」ことを明示した設計であり、その境界も作り直しになる。Requirements にない変更範囲へ広がる。
+- reply を tokio oneshot のまま保ち、外部 executor の `block_on` で待つ。`futures-executor` を直接依存へ追加することになり、同じ store の読み出し経路（`adaptor/gateway/local_event_store/reader.rs:1904` の `mpsc::sync_channel(1)`）と別パターンになる。得られるのは reply field の型を変えずに済むことだけで、割に合わない。
+
+## Cross-cutting concerns
+
+- 性能: append 1 回あたりの OS thread spawn と runtime 構築が無くなる。呼び出し元が block する区間は writer の応答待ちだけになり、block する thread の本数は変わらない（現行も呼び出し元 thread が `join()` で block していた）。
+- 可観測性: append 失敗の文言が `node fact append failed: {error}` に収束する。writer 側の `node event append failed [{correlation}]` ログ（`store.rs:771`）は変えない。
+- 検証: B-001 と B-002 の「fd が増えない」は、隔離した子プロセス内で writer を INSERT 直前に停止し、呼び出し元が応答待ちに入った append 実行中の open fd 数を追記前と比較して確認する。単発は writer の停止位置への到達通知、並行はその到達通知と write queue に残り N-1 本が滞留したことの双方により、全 append が in-flight であることを確定する。完了後の open fd 数も追記前と比較する。数え方は `/dev/fd` の列挙で、macOS と CI の Linux（`/proc/self/fd` への symlink）の双方で同じ経路が使える。B-003 は同じ子プロセス隔離下で store を open して warm-up append を済ませ、現在の open fd 数に 2 個の余裕だけを残す値まで `RLIMIT_NOFILE` の soft limit を下げて確認する。limit を下げた後は `/dev/fd` を列挙せず、`session_attached` の append が成功して既存 reader から同じ事実行を読めることを確認する。rlimit の変更は親プロセスおよび他テストへ波及しない。B-005 と B-006 は、async runtime 上（`#[tokio::test]`）から append を呼んで panic せず結果が返ることで確認する。
+
+## Risks
+
+- blocking 受信が前進する根拠は「writer が独立した OS thread であり、その応答が tokio task の進行に依存しない」ことに尽きる。実装で node_events append の応答経路に tokio task を挟むと、current-thread runtime や worker を塞いだ状態で deadlock し、B-004 から B-006 を満たせなくなる。
+- fd 数の観測を行う子プロセスには対象テストだけを指定し、テスト thread 数も 1 に固定する。writer の停止中に到達通知と queue 滞留数で in-flight を確定してから計数するため、他テストの fd 増減や append 完了タイミングには依存しない。

--- a/docs/specs/issues-1679/requirements.md
+++ b/docs/specs/issues-1679/requirements.md
@@ -1,0 +1,156 @@
+# Context
+
+## 入力文書
+
+- 要求の正本: [Issue #1679](https://github.com/siro33950/releash/issues/1679)「[event store] 事実行の append ごとに tokio ランタイムを構築しており fd 上限 256 を踏む」（state: OPEN、label: bug、milestone なし、comment なし）
+- 補助資料（本 Issue の要求ではない。境界の確認にのみ使う）
+  - [Issue #1678](https://github.com/siro33950/releash/issues/1678) — 起動に失敗した Session node が resume も retry も受け付けず復旧不能になる（OPEN）。本 Issue の EMFILE がその発端の 1 つ。
+  - [Issue #1677](https://github.com/siro33950/releash/issues/1677) — セッション同時上限（`per_worktree_cap: 32` / `max_panes_total: 64`）の値と機構（OPEN）。同じく並列度を上げたときに踏む上限。
+- 調査で参照した実装
+  - `src-tauri/src/adaptor/gateway/workflow/fact_log.rs:427-450` — `append_pending_rows_blocking`（事実行 append の唯一の集約点。OS thread の spawn と tokio ランタイムの新規構築）
+  - `src-tauri/src/adaptor/gateway/workflow/fact_log.rs:389-424` — `append_facts_for_events`（事実列を行へ写像して `:423` で上記へ渡す）
+  - `src-tauri/src/adaptor/gateway/workflow/fact_log.rs:652-659` — `append_single_fact`（単独の事実を `:658` で上記へ渡す）
+  - `src-tauri/src/adaptor/gateway/workflow/fact_log.rs:453-540` — `append_fact_batch_for_seed`（`#[cfg(test)]`。`:528` に 2 つ目のランタイム構築があるが test 専用）
+  - `src-tauri/src/adaptor/gateway/local_event_store/store.rs:972-997` — `append_node_event`（async。writer thread へ request を渡して oneshot を await する。行単位 INSERT で原子性は 1 行を超えない）
+  - `src-tauri/src/adaptor/gateway/local_event_store/store.rs:1005-1013` — `submit_indexed_query_blocking`（reader pool 上の同期読み出し。ランタイムを要さない）
+  - `src-tauri/src/adaptor/gateway/workflow/workflow_host.rs:1497` / `:2266` / `:687` — 失敗文言の合成箇所と、起動時 reconciliation の木ごとループ
+  - `src-tauri/src/adaptor/gateway/workflow/event_log_writer.rs:22-30` / `:39-45` — 事実行 append の入口（後者は async fn から同期 append を呼ぶ）
+  - `src-tauri/src/adaptor/gateway/workflow/worktree_ledger_repository.rs:124` — isolated worktree ledger からの事実行 append
+  - `src-tauri/src/lib.rs:619-621` — アプリケーション全体の tokio ランタイム構築と Tauri async runtime への設定
+  - `src-tauri/src/cli/common.rs:138-139` — CLI 側の事実行 append 呼び出しを含む `test_support` module が `#[cfg(test)]` であること
+- 規約: `AGENTS.md`「構成で押さえる点」「アーキテクチャ原則」「セキュリティ」、`docs/glossary/DOMAIN.md`「使用禁止語」
+
+## 確定済みの背景と制約
+
+- 永続化は event store であり、事実を追記して読み側で projection を導出する。full-recompute 経路を増やさない（`AGENTS.md`）。
+- node_events への追記は 1 行単位で、原子性が 1 行を超えることはない（`store.rs:972-976` のコメントが明示）。
+- 事実行 append の入口は `append_facts_for_events` と `append_single_fact` の 2 つで、どちらも `append_pending_rows_blocking` へ集約される。この関数は同期関数であり、内部で OS thread を spawn し、その thread 内で `enable_all()` 付きの current-thread tokio ランタイムを新規構築し、`runtime.block_on` で async の `append_node_event` を呼ぶ。
+- 事実行 append の production 呼び出し元は GUI プロセスに限られる。workflow host の activation / commit 経路、`event_log_writer`、`worktree_ledger_repository`、および起動時 reconciliation（`workflow_host.rs:687` の木ごとループから `fact_log.rs:857`）である。`cli/common.rs` の append 呼び出しは `#[cfg(test)]` の `test_support` 配下だけで、CLI プロセスは production では事実行を書かない。
+- 事実行 append は同期文脈と async 文脈の両方から呼ばれる。async 文脈からの呼び出しは `event_log_writer.rs:45`（provider Stop 受理）と workflow host の activation 経路にある。現在は専用の OS thread を挟むことで、async 文脈からの `block_on` が成立している。
+- アプリケーション全体の tokio ランタイムは `lib.rs:619` に 1 つ存在し、Tauri の async runtime として設定されている。事実行 append 経路だけがこれを共有していない。
+- `src-tauri/` に `setrlimit` / `RLIMIT_NOFILE` の記述はない（grep により確認）。起動時に fd soft limit を引き上げる処理は存在しない。
+- 対応プラットフォームは macOS（`AGENTS.md`）。macOS の GUI アプリは launchd から起動されるため、その soft limit を継承する。
+- `docs/glossary/DOMAIN.md` の使用禁止語により、記録された事実を指すときに `WorkflowEvent` を用いない。本文書では「事実」「事実行」と呼ぶ。
+
+# Outcome
+
+- 対象者: Releash で workflow を実行する開発者。特に fanout や複数 worktree で workflow を並列に走らせる利用者。
+- 現在の問題: node の事実行を 1 回 append するたびに、その append 専用の tokio ランタイムを新規構築する。ランタイム構築は I/O driver のために file descriptor を確保するので、事実の追記が SQLite への書き込みとは別に fd を要求する。GUI プロセスの fd soft limit は 256 のまま引き上げられていないため、並列実行で fd 使用量が上限に近づくと、事実行の append が EMFILE で失敗する。事実ログの append が失敗するということは workflow の実行状態そのものを記録できないということであり、失敗した append が `session_attached` だった場合、node は AgentSession を持たないまま停止する。
+- 変更後に実現する状態: 事実行の追記が、追記の回数や同時数に応じた file descriptor を要求しない。事実を書けるかどうかは書き込み先の状態だけで決まり、追記処理自身が確保する OS リソースが失敗要因にならない。
+
+# Current Behavior
+
+## 実障害（Issue の報告、2026-08-23）
+
+11:41:57、feat-issues-1652 worktree の `02_implement-existing-spec`（execution `1182b833`）で `create_detailed_design` attempt 2 の activation が次の理由で失敗した。
+
+```
+workflow runtime activation failed: session attachment event append failed:
+failed to create fact append runtime: Too many open files (os error 24)
+```
+
+`session_attached` の事実を 1 行 append しようとして OS の fd 上限（EMFILE）に達し、node execution は `sessionId` を持たないまま `paused` で残った。Issue 起票時点の実測は、workflow 4 本が走っている状態で fd 168 / 上限 256。
+
+この障害は Issue の報告であり、本文書の作成にあたって再実行はしていない。以下はコードと作業環境に対して確認した内容である。
+
+## 失敗文言がどこで作られるか
+
+| 文言 | 生成箇所 |
+|---|---|
+| `failed to create fact append runtime: {error}` | `fact_log.rs:439` |
+| `session attachment event append failed` | `workflow_host.rs:1497`（commit 経路の `append_error_context`） |
+| `workflow runtime activation failed: {error}` | `workflow_host.rs:2266`（`settle_runtime_failure_for_node`） |
+
+EMFILE は SQLite への書き込み時ではなく、append 用ランタイムの構築時に起きている。
+
+## append ごとに fd を要求している箇所
+
+`fact_log.rs:427-450`。
+
+```rust
+pub(crate) fn append_pending_rows_blocking(
+    store: &Arc<LocalEventStore>,
+    rows: Vec<PendingFactRow>,
+) -> Result<(), String> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let store = Arc::clone(store);
+    std::thread::scope(|scope| {
+        scope
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|error| format!("failed to create fact append runtime: {error}"))?;
+                for pending in rows {
+                    runtime
+                        .block_on(store.append_node_event(pending.row, Some(pending.timestamp_ms)))
+                        .map_err(|error| format!("node fact append failed: {error}"))?;
+                }
+                Ok::<(), String>(())
+            })
+            .join()
+            .map_err(|_| "node fact append worker panicked".to_string())?
+    })
+}
+```
+
+- 呼び出しごとに OS thread を spawn し、その中でランタイムを新規構築する。`enable_all()` は I/O driver を有効にするため、構築時に kqueue とその起床用 descriptor を確保する。ファイルを開く処理ではないのに fd を要求するのはこのためである。
+- ランタイムは関数の終了時に drop されるので、確保した fd は解放される。したがって蓄積し続ける leak ではなく、append の実行中にだけ増える一時的な使用量である。並列に走る append の数だけこの一時使用が重なり、ピークが上限を越える。
+- 同じ file の読み出し側（`submit_indexed_query_blocking`、`store.rs:1005`）は store の reader pool 上で同期実行され、ランタイムを構築しない。ランタイムを構築しているのは append 経路だけである。
+
+## append が起きる頻度
+
+node の事実は node 開始・session attach・artifact 産出・完了ごとに書かれるため、workflow の実行中は継続的に発生する。加えてアプリ起動時の reconciliation が木ごとに走り（`workflow_host.rs:687`）、前進した分の事実を追記する（`fact_log.rs:857`）ため、起動直後にも集中する。
+
+## fd soft limit
+
+作業環境（macOS Darwin 25.5.0）で実測した値は次のとおりで、Issue の記載と一致する。
+
+```
+launchctl limit maxfiles:  soft 256 / hard unlimited
+kern.maxfilesperproc:      245760
+```
+
+プロセスに効いているのは soft limit の 256 であり、`kern.maxfilesperproc` の 245760 ではない。hard limit が unlimited なので `setrlimit(RLIMIT_NOFILE, ...)` でプロセス自身が引き上げられる状態にあるが、`src-tauri/` にその記述はない。
+
+セッション 1 本あたり PTY の master/slave、provider プロセスとのパイプ、terminal journal のファイルハンドルが積み上がり、そこに SQLite（本体 + WAL + shm）と、上記の一時ランタイムが乗る。
+
+## 再現条件
+
+GUI プロセスの fd soft limit が 256 の状態で、workflow を並列に実行して fd 使用量を上限付近まで押し上げ、その状態で node の activation（`session_attached` の追記）を行う。append 用ランタイムの構築が EMFILE で失敗し、上記の文言で activation が失敗する。fd 使用量が上限から十分離れていれば同じ append は成功する。
+
+# Scope / Non-goals
+
+## 変更する
+
+- 事実行 append 経路（`fact_log` の `append_pending_rows_blocking` と、そこへ集約される `append_facts_for_events` / `append_single_fact`）が 1 回の追記のために確保する OS リソース。
+- 上記の変更に伴って必要になる、呼び出し元（workflow host、`event_log_writer`、`worktree_ledger_repository`、起動時 reconciliation）からの呼び出し形。
+
+## 変更しない
+
+- 記録される事実の種類と内容、node_events の行構造、追記の原子性の単位（1 行）。純粋事実ログ（追記のみ、読み側で projection を導出する）という永続化の形。
+- 起動に失敗した Session node の resume / retry / restart の責務分担（#1678）。本変更は append が fd を理由に失敗しないようにするものであり、既に `sessionId` を持たないまま `paused` で残った node の復旧手段は扱わない。
+- セッション同時上限（`per_worktree_cap` / `max_panes_total`）の値と、上限到達時に拒否するか回収するかの機構（#1677）。
+- プロセス起動時の fd soft limit。`setrlimit(RLIMIT_NOFILE, ...)` による引き上げは行わず、起動元から継承した値のまま動作する。
+- PTY、provider プロセス、terminal journal、SQLite 本体が使う fd の量そのもの。fd 使用量の内訳のうち、事実行 append 以外の削減は扱わない。
+- fd 使用量を観測・通知する仕組みの追加。
+
+# Requirements
+
+- R-001: 事実行の append が、その append のためだけの file descriptor を確保しない。事実行を追記している間も含めて、追記そのものを理由にプロセスの open fd 数が増えない。
+- R-002: 事実行の append が、file descriptor を確保できないことを理由に失敗しない。現在この失敗として表面化している `failed to create fact append runtime: Too many open files (os error 24)` が発生しない。追記先である SQLite 自体に起因する失敗はこの限りでない。
+- R-003: 事実行の append を、同期文脈と async 文脈のどちらからも呼び出せる。現在 async 文脈から呼ばれている経路（provider Stop の受理、node activation 時の事実追記）が、panic、deadlock、実行の停止を起こさずに動作する。
+- R-004: 記録される事実行の内容と、同一 node に対する追記順序が変更前と一致する。追記の原子性の単位を 1 行から変えない。
+- R-005: 事実行の append が失敗した場合に、その失敗が呼び出し元へ伝わり、node の失敗として扱われる現在の性質を変えない。追記できなかった事実を、追記できたものとして扱わない。追記先の store が内部状態の破壊により利用不能になっている場合は、事実行の読み出しと同じ扱いとし、この要件の対象に含めない。
+
+# Assumptions / Open Questions
+
+## Assumptions
+
+- なし。
+
+## Open Questions
+
+- なし。

--- a/src-tauri/src/adaptor/gateway/local_event_store/fault.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/fault.rs
@@ -6,7 +6,69 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(test)]
-use std::sync::Mutex;
+use std::sync::{Arc, Condvar, Mutex};
+#[cfg(test)]
+use std::time::Duration;
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct NodeEventAppendStallState {
+    armed: bool,
+    arrived: bool,
+    released: bool,
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct NodeEventAppendStall {
+    state: Mutex<NodeEventAppendStallState>,
+    arrived: Condvar,
+    released: Condvar,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct NodeEventAppendStallGuard {
+    stall: Arc<NodeEventAppendStall>,
+}
+
+#[cfg(test)]
+impl NodeEventAppendStallGuard {
+    pub(crate) fn wait_until_arrived(&self) {
+        let state = self
+            .stall
+            .state
+            .lock()
+            .expect("node event append stall poisoned");
+        let (state, _) = self
+            .stall
+            .arrived
+            .wait_timeout_while(state, Duration::from_secs(10), |state| !state.arrived)
+            .expect("node event append stall poisoned");
+        assert!(
+            state.arrived,
+            "writer did not reach the node event append stall"
+        );
+    }
+
+    pub(crate) fn release(&self) {
+        let mut state = self
+            .stall
+            .state
+            .lock()
+            .expect("node event append stall poisoned");
+        state.released = true;
+        drop(state);
+        self.stall.released.notify_all();
+    }
+}
+
+#[cfg(test)]
+impl Drop for NodeEventAppendStallGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InitialCreateFaultPoint {
@@ -48,6 +110,8 @@ pub struct FaultInjector {
     schema_fail_before_readback: AtomicUsize,
     initial_create_fault_point: AtomicUsize,
     maintenance_fault_point: AtomicUsize,
+    #[cfg(test)]
+    node_event_append_stall: Arc<NodeEventAppendStall>,
     #[cfg(test)]
     initial_create_process_crash_point: AtomicUsize,
     #[cfg(test)]
@@ -110,6 +174,55 @@ impl FaultInjector {
     pub fn take_drop_reply(&self) -> bool {
         Self::take(&self.drop_reply)
     }
+
+    #[cfg(test)]
+    pub fn arm_drop_reply(&self) {
+        self.drop_reply.fetch_add(1, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn arm_node_event_append_stall(&self) -> NodeEventAppendStallGuard {
+        let mut state = self
+            .node_event_append_stall
+            .state
+            .lock()
+            .expect("node event append stall poisoned");
+        assert!(!state.armed, "node event append stall is already armed");
+        *state = NodeEventAppendStallState {
+            armed: true,
+            arrived: false,
+            released: false,
+        };
+        drop(state);
+        NodeEventAppendStallGuard {
+            stall: Arc::clone(&self.node_event_append_stall),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn wait_before_node_event_append_if_armed(&self) {
+        let mut state = self
+            .node_event_append_stall
+            .state
+            .lock()
+            .expect("node event append stall poisoned");
+        if !state.armed {
+            return;
+        }
+        state.arrived = true;
+        self.node_event_append_stall.arrived.notify_all();
+        while !state.released {
+            state = self
+                .node_event_append_stall
+                .released
+                .wait(state)
+                .expect("node event append stall poisoned");
+        }
+        *state = NodeEventAppendStallState::default();
+    }
+
+    #[cfg(not(test))]
+    pub(crate) fn wait_before_node_event_append_if_armed(&self) {}
 
     pub fn take_schema_fail_before_begin(&self) -> bool {
         Self::take(&self.schema_fail_before_begin)

--- a/src-tauri/src/adaptor/gateway/local_event_store/node_events_test.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/node_events_test.rs
@@ -143,10 +143,11 @@ mod store_round_trip_tests {
     use crate::adaptor::gateway::local_event_store::store::{
         LocalEventStore, LocalEventStoreConfig,
     };
+    use crate::adaptor::gateway::local_event_store::writer::NodeEventWriteError;
     use crate::domain::local_event::LocalEventQueryError;
 
-    #[tokio::test]
-    async fn test_store経由の追記_writerスレッドでseqが払い出され読み出せる() {
+    #[test]
+    fn test_store事実追記_同期文脈で記録され結果が返る() {
         // Given: file-backed store
         let root = tempfile::TempDir::new().unwrap();
         let store =
@@ -155,12 +156,10 @@ mod store_round_trip_tests {
 
         // When: store API で2行 append する（1行目は明示時刻・2行目は clock）
         let first = store
-            .append_node_event(row("tree-1", "root", None), Some(1_000))
-            .await
+            .append_node_event_blocking(row("tree-1", "root", None), Some(1_000))
             .unwrap();
         let second = store
-            .append_node_event(row("tree-1", "child", Some("root")), None)
-            .await
+            .append_node_event_blocking(row("tree-1", "child", Some("root")), None)
             .unwrap();
 
         // Then: seq が直列に払い出され、reader pool から読み出せる
@@ -172,6 +171,115 @@ mod store_round_trip_tests {
             .unwrap();
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].node_execution_id, "root");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_store事実追記_async_runtime上でpanicせず記録され結果が返る() {
+        // Given: current-thread tokio runtime 上で利用する file-backed store
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+
+        // When: runtime worker 上から同期 append を呼ぶ
+        let seq = store
+            .append_node_event_blocking(row("tree-async", "root", None), Some(1_000))
+            .unwrap();
+
+        // Then: 呼び出しが停止せず結果が返り、事実行を読み出せる
+        assert_eq!(seq, 1);
+        let rows = store
+            .submit_indexed_query_blocking(|connection| {
+                read_tree(connection, "tree-async")
+                    .map_err(|_| LocalEventQueryError::InvalidRequest)
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].node_execution_id, "root");
+    }
+
+    #[test]
+    fn test_store事実追記_閉じたwrite_queueはoutcome_unknownを返す() {
+        // Given: write queue が閉じた file-backed store
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        store.close_write_queue_for_tests();
+
+        // When: 事実行を追記する
+        let error = store
+            .append_node_event_blocking(row("tree-closed", "root", None), Some(1_000))
+            .unwrap_err();
+
+        // Then: admission の Closed が OutcomeUnknown として返る
+        assert_eq!(error, NodeEventWriteError::OutcomeUnknown);
+    }
+
+    #[test]
+    fn test_store事実追記_reply喪失はoutcome_unknownを返す() {
+        // Given: 次の writer reply を失う file-backed store
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        store.fault_injector().arm_drop_reply();
+
+        // When: 事実行を追記する
+        let error = store
+            .append_node_event_blocking(row("tree-reply-loss", "root", None), Some(1_000))
+            .unwrap_err();
+
+        // Then: receiver の切断が OutcomeUnknown として返り、writer は処理済みである
+        assert_eq!(error, NodeEventWriteError::OutcomeUnknown);
+        let rows = store
+            .submit_indexed_query_blocking(|connection| {
+                read_tree(connection, "tree-reply-loss")
+                    .map_err(|_| LocalEventQueryError::InvalidRequest)
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn test_store事実追記_writer内のsqlite失敗を返して後続追記を継続する() {
+        // Given: node_events.kind の CHECK 制約に違反する行
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        let invalid = NewNodeEventRow {
+            tree_id: "tree-sqlite-failure".to_string(),
+            node_execution_id: "invalid".to_string(),
+            parent_id: None,
+            node_name: "main".to_string(),
+            kind: "invalid-kind".to_string(),
+            attempt: 1,
+            event_type: "started".to_string(),
+            session_id: None,
+            detail: "{}".to_string(),
+        };
+
+        // When: admission 後の writer thread で INSERT が失敗する
+        let error = store
+            .append_node_event_blocking(invalid, Some(1_000))
+            .unwrap_err();
+
+        // Then: SQLite 失敗が返り、失敗行は記録されていない
+        assert_eq!(error, NodeEventWriteError::StorageUnavailable);
+        let rows = store
+            .submit_indexed_query_blocking(|connection| {
+                read_tree(connection, "tree-sqlite-failure")
+                    .map_err(|_| LocalEventQueryError::InvalidRequest)
+            })
+            .unwrap();
+        assert!(rows.is_empty());
+
+        // And: writer は停止せず、後続の正常行に seq 1 を払い出す
+        let seq = store
+            .append_node_event_blocking(row("tree-sqlite-failure", "valid", None), Some(2_000))
+            .unwrap();
+        assert_eq!(seq, 1);
     }
 }
 

--- a/src-tauri/src/adaptor/gateway/local_event_store/store.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/store.rs
@@ -6,7 +6,7 @@
 //! exchange messages with those threads.
 
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{mpsc, Arc};
 
 use sha2::{Digest, Sha256};
 use tokio::sync::oneshot;
@@ -756,6 +756,7 @@ impl LocalEventStore {
                                 }
                             }
                             WriteRequest::NodeEventAppend(request) => {
+                                fault.wait_before_node_event_append_if_armed();
                                 let timestamp_ms = request
                                     .timestamp_ms
                                     .unwrap_or_else(|| clock.now_ms())
@@ -772,7 +773,11 @@ impl LocalEventStore {
                                     );
                                     NodeEventWriteError::StorageUnavailable
                                 });
-                                let _ = request.reply.send(result);
+                                if fault.take_drop_reply() {
+                                    drop(request.reply);
+                                } else {
+                                    let _ = request.reply.send(result);
+                                }
                             }
                         },
                         QueuePop::Idle => {}
@@ -834,6 +839,16 @@ impl LocalEventStore {
     #[cfg(test)]
     pub fn fault_injector(&self) -> &Arc<FaultInjector> {
         &self.fault
+    }
+
+    #[cfg(test)]
+    pub(crate) fn close_write_queue_for_tests(&self) {
+        self.queue.close();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_write_request_count(&self) -> usize {
+        self.queue.pending_request_count()
     }
 
     /// Validate and encode a batch before queue admission (design step 1).
@@ -975,12 +990,12 @@ impl LocalEventStore {
     /// spans more than this one row.
     ///
     /// `timestamp_ms` は事実の発生時刻。None なら store の clock で刻む。
-    pub(crate) async fn append_node_event(
+    pub(crate) fn append_node_event_blocking(
         &self,
         row: NewNodeEventRow,
         timestamp_ms: Option<i64>,
     ) -> Result<i64, NodeEventWriteError> {
-        let (reply, receiver) = oneshot::channel();
+        let (reply, receiver) = mpsc::sync_channel(1);
         match self
             .queue
             .admit(WriteRequest::NodeEventAppend(NodeEventAppendRequest {
@@ -993,7 +1008,7 @@ impl LocalEventStore {
             Err(AdmitRejection::Closed) => return Err(NodeEventWriteError::OutcomeUnknown),
         }
         receiver
-            .await
+            .recv()
             .map_err(|_| NodeEventWriteError::OutcomeUnknown)?
     }
 

--- a/src-tauri/src/adaptor/gateway/local_event_store/writer.rs
+++ b/src-tauri/src/adaptor/gateway/local_event_store/writer.rs
@@ -6,7 +6,7 @@
 //! are enforced at admission time, before the writer sees the request.
 
 use std::collections::VecDeque;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::time::Duration;
 
 use tokio::sync::oneshot;
@@ -59,7 +59,7 @@ pub struct NodeEventAppendRequest {
     pub row: NewNodeEventRow,
     /// 事実の発生時刻。None なら store の clock で刻む。
     pub timestamp_ms: Option<i64>,
-    pub reply: oneshot::Sender<Result<i64, NodeEventWriteError>>,
+    pub reply: mpsc::SyncSender<Result<i64, NodeEventWriteError>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
@@ -164,6 +164,12 @@ impl WriteQueue {
         drop(state);
         self.available.notify_one();
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_request_count(&self) -> usize {
+        let state = self.state.lock().expect("write queue poisoned");
+        state.normal.queue.len() + state.critical.queue.len()
     }
 
     /// Pop the next request, critical lane first. `None` when closed and

--- a/src-tauri/src/adaptor/gateway/workflow/fact_log.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/fact_log.rs
@@ -431,24 +431,12 @@ pub(crate) fn append_pending_rows_blocking(
     if rows.is_empty() {
         return Ok(());
     }
-    let store = Arc::clone(store);
-    std::thread::scope(|scope| {
-        scope
-            .spawn(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|error| format!("failed to create fact append runtime: {error}"))?;
-                for pending in rows {
-                    runtime
-                        .block_on(store.append_node_event(pending.row, Some(pending.timestamp_ms)))
-                        .map_err(|error| format!("node fact append failed: {error}"))?;
-                }
-                Ok::<(), String>(())
-            })
-            .join()
-            .map_err(|_| "node fact append worker panicked".to_string())?
-    })
+    for pending in rows {
+        store
+            .append_node_event_blocking(pending.row, Some(pending.timestamp_ms))
+            .map_err(|error| format!("node fact append failed: {error}"))?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/adaptor/gateway/workflow/fact_log_test.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/fact_log_test.rs
@@ -87,6 +87,403 @@ fn no_lookup(_: &str) -> Result<Option<FactRowMeta>, String> {
     Ok(None)
 }
 
+fn open_fd_count() -> usize {
+    std::fs::read_dir("/dev/fd").unwrap().count()
+}
+
+fn test_fact_meta(tree_id: &str, node_execution_id: &str) -> NodeFactMeta {
+    NodeFactMeta {
+        tree_id: tree_id.to_string(),
+        node_execution_id: node_execution_id.to_string(),
+        parent_id: None,
+        node_name: "main".to_string(),
+        kind: NodeKindName::Session,
+        attempt: 1,
+    }
+}
+
+mod fd_invariance_tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::time::{Duration, Instant};
+
+    const FD_TEST_CHILD: &str = "RELEASH_FACT_LOG_FD_TEST_CHILD";
+
+    #[cfg(unix)]
+    struct NoFileSoftLimitGuard {
+        original: libc::rlimit,
+    }
+
+    #[cfg(unix)]
+    impl NoFileSoftLimitGuard {
+        fn lower_to(soft_limit: usize) -> Self {
+            let mut original = std::mem::MaybeUninit::<libc::rlimit>::uninit();
+            // SAFETY: getrlimit writes one rlimit value to the valid out pointer.
+            let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, original.as_mut_ptr()) };
+            assert_eq!(result, 0, "failed to read RLIMIT_NOFILE");
+            // SAFETY: getrlimit succeeded and initialized the value.
+            let original = unsafe { original.assume_init() };
+            let soft_limit = soft_limit as libc::rlim_t;
+            assert!(
+                soft_limit < original.rlim_cur,
+                "RLIMIT_NOFILE soft limit is too low to create the test condition"
+            );
+            let lowered = libc::rlimit {
+                rlim_cur: soft_limit,
+                rlim_max: original.rlim_max,
+            };
+            // SAFETY: lowered preserves the inherited hard limit and only lowers the soft limit.
+            let result = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &lowered) };
+            assert_eq!(result, 0, "failed to lower RLIMIT_NOFILE");
+            Self { original }
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for NoFileSoftLimitGuard {
+        fn drop(&mut self) {
+            // SAFETY: restores the rlimit value read successfully by lower_to.
+            let result = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &self.original) };
+            assert_eq!(result, 0, "failed to restore RLIMIT_NOFILE");
+        }
+    }
+
+    fn run_in_isolated_process(child_name: &str, test_filter: &str) -> bool {
+        if std::env::var(FD_TEST_CHILD).as_deref() == Ok(child_name) {
+            return false;
+        }
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .env(FD_TEST_CHILD, child_name)
+            .arg(test_filter)
+            .arg("--test-threads=1")
+            .status()
+            .unwrap();
+        assert!(status.success());
+        true
+    }
+
+    fn wait_until_pending_request_count(store: &LocalEventStore, expected: usize) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let actual = store.pending_write_request_count();
+            if actual == expected {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "write queue did not reach {expected} pending requests; actual: {actual}"
+            );
+            std::thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn test_事実行追記_単発追記中と完了後にopen_fd数が変わらない() {
+        if run_in_isolated_process(
+            "single",
+            "fd_invariance_tests::test_事実行追記_単発追記中と完了後にopen_fd数が変わらない",
+        ) {
+            return;
+        }
+
+        // Given: INSERT 直前で writer を停止する store と追記前の open fd 数
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        let stall = store.fault_injector().arm_node_event_append_stall();
+        let meta = test_fact_meta("fd-single-tree", "fd-single-node");
+        let before = open_fd_count();
+
+        // When: caller が writer の応答待ちに入った状態で open fd 数を測る
+        let worker_store = Arc::clone(&store);
+        let worker = std::thread::spawn(move || {
+            append_single_fact(&worker_store, &meta, &NodeFact::RetryRequested, 1_000)
+        });
+        stall.wait_until_arrived();
+        let in_flight = open_fd_count();
+        stall.release();
+        worker.join().unwrap().unwrap();
+        let after = open_fd_count();
+
+        // Then: 追記中・完了後とも fd 数が増えず、事実行が記録される
+        assert_eq!(in_flight, before);
+        assert_eq!(after, before);
+        let records = read_tree_records(&store, "fd-single-tree").unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].meta.node_execution_id, "fd-single-node");
+        assert_eq!(records[0].fact, NodeFact::RetryRequested);
+    }
+
+    #[test]
+    fn test_事実行追記_全追記が並行実行中でもopen_fd数が変わらず全行を記録する() {
+        const APPEND_COUNT: usize = 16;
+
+        if run_in_isolated_process(
+            "parallel",
+            "fd_invariance_tests::test_事実行追記_全追記が並行実行中でもopen_fd数が変わらず全行を記録する",
+        ) {
+            return;
+        }
+
+        // Given: 1本目を INSERT 直前で停止し、同時開始を待つ追記 worker
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        let stall = store.fault_injector().arm_node_event_append_stall();
+        let barrier = Arc::new(Barrier::new(APPEND_COUNT + 1));
+        let workers = (0..APPEND_COUNT)
+            .map(|index| {
+                let store = Arc::clone(&store);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let meta = test_fact_meta("fd-parallel-tree", &format!("node-{index}"));
+                    barrier.wait();
+                    append_single_fact(&store, &meta, &NodeFact::RetryRequested, index as i64)
+                })
+            })
+            .collect::<Vec<_>>();
+        let before = open_fd_count();
+
+        // When: 1本が writer に到達し、残りすべてが queue に滞留した状態で測る
+        barrier.wait();
+        stall.wait_until_arrived();
+        wait_until_pending_request_count(&store, APPEND_COUNT - 1);
+        let in_flight = open_fd_count();
+        stall.release();
+        for worker in workers {
+            worker.join().unwrap().unwrap();
+        }
+        let after = open_fd_count();
+
+        // Then: 全 append の実行中・完了後とも fd 数が増えず、全行が記録される
+        assert_eq!(in_flight, before);
+        assert_eq!(after, before);
+        let records = read_tree_records(&store, "fd-parallel-tree").unwrap();
+        assert_eq!(records.len(), APPEND_COUNT);
+        let mut node_execution_ids = records
+            .iter()
+            .map(|record| record.meta.node_execution_id.as_str())
+            .collect::<Vec<_>>();
+        node_execution_ids.sort_unstable();
+        let mut expected = (0..APPEND_COUNT)
+            .map(|index| format!("node-{index}"))
+            .collect::<Vec<_>>();
+        expected.sort_unstable();
+        assert_eq!(node_execution_ids, expected);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_事実行追記_fd_soft_limit直下でもsession_attachedを記録する() {
+        if run_in_isolated_process(
+            "soft-limit",
+            "fd_invariance_tests::test_事実行追記_fd_soft_limit直下でもsession_attachedを記録する",
+        ) {
+            return;
+        }
+
+        // Given: store の fd を確保済みで、soft limit に2個だけ余裕がある子プロセス
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        let warm_up_meta = test_fact_meta("fd-warm-up-tree", "fd-warm-up-node");
+        append_single_fact(&store, &warm_up_meta, &NodeFact::RetryRequested, 1_000).unwrap();
+        let current_open_fd_count = open_fd_count();
+        let _soft_limit = NoFileSoftLimitGuard::lower_to(current_open_fd_count + 2);
+        let meta = test_fact_meta("fd-soft-limit-tree", "fd-soft-limit-node");
+        let fact = NodeFact::SessionAttached(SessionAttachedFact {
+            session_id: "fd-soft-limit-session".to_string(),
+            provider_session_id: Some("fd-soft-limit-provider-session".to_string()),
+            transcript_ref: Some("fd-soft-limit-transcript".to_string()),
+            initial_instruction_admitted: true,
+        });
+
+        // When: fd soft limit 直下で session_attached を追記する
+        append_single_fact(&store, &meta, &fact, 2_000).unwrap();
+
+        // Then: fd を追加取得せず追記でき、同じ事実行を既存 reader から読める
+        let records = read_tree_records(&store, "fd-soft-limit-tree").unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].meta.node_execution_id, "fd-soft-limit-node");
+        assert_eq!(records[0].fact, fact);
+    }
+}
+
+mod append_contract_tests {
+    use super::*;
+    use crate::adaptor::gateway::local_event_store::writer::NORMAL_LANE_MAX_BYTES;
+
+    fn read_raw_rows(
+        store: &Arc<LocalEventStore>,
+        tree_id: &str,
+    ) -> Vec<crate::adaptor::gateway::local_event_store::node_events::NodeEventRow> {
+        let tree_id = tree_id.to_string();
+        store
+            .submit_indexed_query_blocking(move |connection| {
+                node_events::read_tree(connection, &tree_id)
+                    .map_err(|_| LocalEventQueryError::InvalidRequest)
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn test_事実行追記_同期文脈で記録され結果が返る() {
+        // Given: 同期文脈で利用する file-backed store と単独の事実
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        let meta = test_fact_meta("sync-context-tree", "sync-context-node");
+
+        // When: 事実行を追記する
+        let result = append_single_fact(&store, &meta, &NodeFact::RetryRequested, 1_000);
+
+        // Then: 結果が返り、事実行が記録される
+        assert_eq!(result, Ok(()));
+        let records = read_tree_records(&store, "sync-context-tree").unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].fact, NodeFact::RetryRequested);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_事実行追記_async_runtime上でpanicせず記録され結果が返る() {
+        // Given: current-thread tokio runtime 上で利用する file-backed store と単独の事実
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        let meta = test_fact_meta("async-context-tree", "async-context-node");
+
+        // When: runtime worker 上から同期 append を呼ぶ
+        let result = append_single_fact(&store, &meta, &NodeFact::ResumeRequested, 2_000);
+
+        // Then: 呼び出しが停止せず結果が返り、事実行が記録される
+        assert_eq!(result, Ok(()));
+        let records = read_tree_records(&store, "async-context-tree").unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].fact, NodeFact::ResumeRequested);
+    }
+
+    #[test]
+    fn test_事実行追記_同一nodeの内容とseqが入力順に記録される() {
+        // Given: 同一 node に順に発生した、全 field を同定できる3つの事実行
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        let meta = NodeFactMeta {
+            tree_id: "ordering-tree".to_string(),
+            node_execution_id: "ordering-node".to_string(),
+            parent_id: Some("ordering-parent".to_string()),
+            node_name: "worker".to_string(),
+            kind: NodeKindName::Session,
+            attempt: 2,
+        };
+        let facts = [
+            NodeFact::SessionAttached(SessionAttachedFact {
+                session_id: "session-1".to_string(),
+                provider_session_id: Some("provider-session-1".to_string()),
+                transcript_ref: Some("transcript-1".to_string()),
+                initial_instruction_admitted: true,
+            }),
+            NodeFact::RetryRequested,
+            NodeFact::ResumeRequested,
+        ];
+        let rows = facts
+            .iter()
+            .enumerate()
+            .map(|(index, fact)| pending_single_fact(&meta, fact, 1_000 + index as i64))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let expected = rows.clone();
+
+        // When: 3行を1行ずつ同期 append する
+        append_pending_rows_blocking(&store, rows).unwrap();
+
+        // Then: NewNodeEventRow の全 field・timestamp・払い出し seq が入力順と一致する
+        let stored = read_raw_rows(&store, "ordering-tree");
+        assert_eq!(stored.len(), expected.len());
+        for (index, (stored, expected)) in stored.iter().zip(expected.iter()).enumerate() {
+            assert_eq!(stored.tree_id, expected.row.tree_id);
+            assert_eq!(stored.seq, index as i64 + 1);
+            assert_eq!(stored.node_execution_id, expected.row.node_execution_id);
+            assert_eq!(stored.parent_id, expected.row.parent_id);
+            assert_eq!(stored.node_name, expected.row.node_name);
+            assert_eq!(stored.kind, expected.row.kind);
+            assert_eq!(stored.attempt, expected.row.attempt);
+            assert_eq!(stored.event_type, expected.row.event_type);
+            assert_eq!(stored.session_id, expected.row.session_id);
+            assert_eq!(stored.detail, expected.row.detail);
+            assert_eq!(stored.timestamp_ms, expected.timestamp_ms);
+        }
+    }
+
+    #[test]
+    fn test_事実行追記_利用不能な追記先の失敗が呼び出し元へ返る() {
+        // Given: write queue が閉じた store
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        store.close_write_queue_for_tests();
+        let meta = test_fact_meta("unavailable-tree", "unavailable-node");
+
+        // When: 事実行を追記する
+        let error =
+            append_single_fact(&store, &meta, &NodeFact::AbortRequested, 1_000).unwrap_err();
+
+        // Then: 失敗が握りつぶされず呼び出し元へ返り、行は記録されない
+        assert_eq!(
+            error,
+            "node fact append failed: node event write outcome is unknown"
+        );
+        assert!(read_raw_rows(&store, "unavailable-tree").is_empty());
+    }
+
+    #[test]
+    fn test_事実行追記_複数行の途中失敗で前の行だけが記録される() {
+        // Given: 正常行、queue 容量を超える行、未投入で終わる正常行の順の入力
+        let root = tempfile::TempDir::new().unwrap();
+        let store =
+            LocalEventStore::open(LocalEventStoreConfig::production(root.path().to_path_buf()))
+                .unwrap();
+        let before_meta = test_fact_meta("partial-tree", "before-failure");
+        let after_meta = test_fact_meta("partial-tree", "after-failure");
+        let before = pending_single_fact(&before_meta, &NodeFact::RetryRequested, 1_000).unwrap();
+        let failed = PendingFactRow {
+            row: NewNodeEventRow {
+                tree_id: "partial-tree".to_string(),
+                node_execution_id: "failed-row".to_string(),
+                parent_id: None,
+                node_name: "main".to_string(),
+                kind: "session".to_string(),
+                attempt: 1,
+                event_type: "retry_requested".to_string(),
+                session_id: None,
+                detail: "x".repeat(NORMAL_LANE_MAX_BYTES),
+            },
+            timestamp_ms: 2_000,
+        };
+        let after = pending_single_fact(&after_meta, &NodeFact::ResumeRequested, 3_000).unwrap();
+
+        // When: 3行を順に追記する
+        let error = append_pending_rows_blocking(&store, vec![before, failed, after]).unwrap_err();
+
+        // Then: 容量拒否が返り、成功済みの1行だけが durable のまま残る
+        assert_eq!(
+            error,
+            "node fact append failed: node event storage is unavailable"
+        );
+        let stored = read_raw_rows(&store, "partial-tree");
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].seq, 1);
+        assert_eq!(stored[0].node_execution_id, "before-failure");
+    }
+}
+
 mod mapping_tests {
     use super::*;
 

--- a/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/workflow_host.rs
@@ -4611,7 +4611,7 @@ nodes:
             )
             .unwrap();
             store
-                .append_node_event(
+                .append_node_event_blocking(
                     NewNodeEventRow {
                         tree_id: CORRUPT_TREE_ID.to_string(),
                         node_execution_id: CORRUPT_TREE_ID.to_string(),
@@ -4625,7 +4625,6 @@ nodes:
                     },
                     Some(4),
                 )
-                .await
                 .unwrap();
             append_started_session_tree(&store, VALID_TREE_ID, "/repo/valid", 5);
             let corrupt_count =
@@ -4718,7 +4717,7 @@ nodes:
                 r#""permission":"bypassPermissions""#,
             );
             store
-                .append_node_event(
+                .append_node_event_blocking(
                     NewNodeEventRow {
                         tree_id: TREE_ID.to_string(),
                         node_execution_id: TREE_ID.to_string(),
@@ -4732,7 +4731,6 @@ nodes:
                     },
                     Some(1),
                 )
-                .await
                 .unwrap();
 
             let history_error = workflow_fact_log::read_tree_records(&store, TREE_ID).unwrap_err();


### PR DESCRIPTION
Closes #1679

## 原因

node の事実行を append する唯一の集約点 `append_pending_rows_blocking`（`adaptor/gateway/workflow/fact_log.rs`）が、呼び出しごとに OS thread を spawn し、その中で `enable_all()` 付きの current-thread tokio ランタイムを新規構築していた。`enable_all()` は I/O driver を有効にするため、構築時に kqueue とその起床用 descriptor を確保する。ファイルを開く処理ではないのに fd を要求するのはこの経路である。

ランタイムは関数の終了時に drop されるので蓄積する leak ではなく、append の実行中にだけ増える一時的な使用量である。並列に走る append の数だけこの一時使用が重なり、ピークが上限を越える。macOS の GUI プロセスは launchd から soft limit 256 を継承し、セッション 1 本あたりの PTY master/slave、provider プロセスとのパイプ、terminal journal、そこに SQLite（本体 + WAL + shm）が積み上がった上にこの一時使用が乗る。

結果として `session_attached` の 1 行 append が EMFILE で失敗し、node execution は `sessionId` を持たないまま `paused` で残った。事実行の append が失敗するということは、workflow の実行状態そのものを記録できないということである。

append 経路だけがランタイムを必要としていた理由は、writer への reply channel が `tokio::sync::oneshot` で async 専用だったことにある。同じ store の読み出し側（`local_event_store/store.rs` の `submit_indexed_query_blocking`）は reader pool 上で同期実行され、ランタイムを構築しない。`append_facts_for_events` は同じ関数の中で、ランタイムを作らずにその読み出しを呼んでいた。

## 修正

Issue が挙げた 2 つの決定に対する結論は「既存ランタイムの共有でも append 経路の async 化でもなく、reply を同期化してランタイムを要さない同期 append にする」「fd soft limit は引き上げない」である。append がそもそも fd を要求しなくなるため、この失敗要因は soft limit の値に依らず消える。

- **reply channel を std の同期チャネルにする**: `NodeEventAppendRequest.reply` を `tokio::sync::oneshot::Sender` から `std::sync::mpsc::SyncSender`（容量 1）へ変更する。std の受信は runtime context を判定せず panic しないため、同期文脈と async runtime worker 上の双方から同じ 1 つの入口が使える。既存ランタイムを `Handle::block_on` で共有する案は、worker thread 上で panic するため採らない。事実行 append の async 呼び出し元（`event_log_writer` の provider Stop 受理、`workflow_host` の commit）はまさにその位置にある
- **append の入口を blocking の 1 つに統一する**: `LocalEventStore::append_node_event`(async) を削除し、入出力が同型の `append_node_event_blocking` へ置き換える。async 版の production 呼び出し元は append 経路だけであり、同じ意味の append を 2 通り残さない
- **helper thread とランタイム構築を撤去する**: `append_pending_rows_blocking` は呼び出し元の thread で 1 行ずつ blocking 入口を呼ぶ。この形が成立する根拠は、writer が tokio task ではなく独立した OS thread（`local-event-store-writer`）であり、呼び出し元が block しても応答側が前進することにある。読み出し側は同じ store に対して既に同型を採っている
- **Commit 側の reply は変えない**: `commit_batch_with_node_events` は async の production 呼び出し元（`agent_session_repository`）を持つため、`WriteRequest::Commit` の reply は oneshot のまま残す
- **panic 境界を再構築しない**: `std::thread::scope` の `join()` が畳んでいた `node fact append worker panicked` は発生源ごと消える。唯一の panic 源は write queue / reader pool 内部の mutex poisoning であり、同じ関数が呼ぶ読み出し経路には元から境界がない。`catch_unwind` を新設せず、読み出し経路と同じ扱いに揃える

維持する不変条件: 同一 node の事実行の並びは、rows を 1 行ずつ順に投入し応答を得てから次を投入することで保つ（writer は単一 thread で request を直列に処理するため、helper thread を挟まなくなっても到着順は変わらない）。途中の行が失敗した時点で残りを投入せず呼び出し元へ失敗を返し、原子性は 1 行を超えない。

変えない契約: `append_facts_for_events` / `append_single_fact` / `append_pending_rows_blocking` のシグネチャ、`NewNodeEventRow` の field、`seq` と `timestamp_ms` の与え方、記録される事実の種類、Tauri command / local API / CLI の外部契約。呼び出し元（workflow host の commit 経路、`event_log_writer`、`worktree_ledger_repository`、起動時 reconciliation）に変更はない。schema 変更も access path の追加もない。append 失敗の文言は `node fact append failed: {error}` に収束し、`failed to create fact append runtime: ...` は発生源が消える。

あわせて、`.gitignore` から `docs/specs` のエントリが削除され新規 spec も追跡対象になっているため、AGENTS.md の「落とし穴」に残っていた記述を削除した。

## テスト

- **fd を要求しないこと（B-001 / B-002）**: fault injector に writer を INSERT 直前で停止する stall を追加し、子プロセス隔離かつテスト thread 1 本で、caller が応答待ちに入った in-flight 状態の open fd 数を追記前と比較する。並行版は「1 本が writer へ到達 + 残り N-1 本が write queue に滞留」の双方で全 append が in-flight であることを確定してから計数する。完了後の fd 数も比較する。数え方は `/dev/fd` の列挙で、macOS と CI の Linux の双方で同じ経路が使える
- **fd soft limit 直下（B-003）**: 同じ子プロセス隔離下で store を open して warm-up append を済ませ、現在の open fd 数に 2 個の余裕だけを残す値まで `RLIMIT_NOFILE` の soft limit を下げ、`session_attached` の append が成功して既存 reader から同じ事実行を読めることを確認する。rlimit の変更は子プロセス内に閉じる
- **同期文脈と async 文脈（B-004 / B-005 / B-006）**: `#[tokio::test]` の runtime worker 上から同期 append を呼び、panic も停止もせず結果が返って事実行を読めること
- **内容と順序（B-007）**: `NewNodeEventRow` の全 field・timestamp・払い出し `seq` が入力順と一致すること
- **失敗の扱い（B-008 / B-009）**: 途中失敗で成功済みの行だけが durable に残り失敗が呼び出し元へ返ること、write queue closed と reply 喪失が `OutcomeUnknown` になること、writer 内の SQLite 失敗が返り writer が停止せず後続に `seq` を払い出すこと
- 検証: `cargo fmt --check` / `cargo clippy --locked -- -D warnings` / `cargo test --locked` すべて pass（failures 0）。frontend への変更はない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcQsg3EStWvgHkXeeuPKp8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 事実ログの追記時にファイルディスクリプタが増加する問題を修正しました。
  * ファイルディスクリプタの上限に近い環境でも、事実ログを正常に記録できるようになりました。
  * 同期処理や非同期処理からの追記、同時追記時の内容・順序を安定させました。
  * 追記先の障害や途中失敗時に、結果と保存済みデータを適切に扱うよう改善しました。

* **ドキュメント**
  * 事実ログ追記に関する要件、仕様、設計を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->