### PR TITLE
fix(workflow): Lua module 評価中の host 呼び出しが起こす二重借用 panic を解消する (#1690)

### DIFF
--- a/docs/specs/issues-1690/behavior.md
+++ b/docs/specs/issues-1690/behavior.md
@@ -1,0 +1,93 @@
+## B-001: module 本体の評価中に host API を呼ぶ module を参照する定義が有効な定義になる
+
+GIVEN workflows ディレクトリに Lua module があり、その module は本体の評価中に host API を呼んで Node を作り、その Node を返している
+AND 同じ workflows ディレクトリに、その module を `require` して返された Node を workflow の Node として参照する Lua workflow 定義がある
+WHEN その workflow 定義を取得する
+THEN 取得は成功する
+AND 取得した定義には、module が返した Node が workflow の Node として含まれる
+
+## B-002: 該当する定義が存在しても workflow 一覧が成功し当該定義が有効な定義として並ぶ
+
+GIVEN B-001 の Lua module と Lua workflow 定義が workflows ディレクトリにある
+AND 同じ workflows ディレクトリに他の workflow 定義がある
+WHEN workflow 一覧を取得する
+THEN 取得は成功し、workflow の配列が返る
+AND 当該 workflow は有効な定義として一覧に含まれる
+AND 他の workflow も通常どおり一覧に含まれる
+
+## B-003: 一覧取得の成功が Tauri command と local API の双方で成り立つ
+
+GIVEN B-002 の状態である
+WHEN Tauri command `list_workflows` と local API `GET /v1/workflows` のそれぞれで workflow 一覧を取得する
+THEN いずれの入口でも取得は成功し、workflow の配列が返る
+AND いずれの入口でも当該 workflow は有効な定義として一覧に含まれる
+
+## B-004: load に失敗する Lua 定義があっても一覧の取得は成功する
+
+GIVEN workflows ディレクトリに、load に失敗する Lua workflow 定義がある
+AND 同じ workflows ディレクトリに、正常に load できる workflow 定義が他にある
+WHEN workflow 一覧を取得する
+THEN 取得は成功し、workflow の配列が返る
+AND load に失敗した定義は不正な定義として一覧に含まれる
+AND その一覧上の扱いは、診断エラーを持つ YAML 定義が一覧に現れる扱いと同じである
+AND 他の workflow は通常どおり一覧に含まれる
+
+## B-005: 該当する定義が存在しても workflow diagnostics の取得は成功する
+
+GIVEN B-001 の Lua module と Lua workflow 定義が workflows ディレクトリにある
+AND 同じ workflows ディレクトリに他の workflow 定義がある
+WHEN workflow diagnostics を取得する
+THEN 取得は成功する
+AND 当該定義について、load の失敗を示す Diagnostic 項目は報告されない
+AND 他の定義の診断結果は通常どおり返る
+
+## B-006: load に失敗する定義があっても他の定義の診断結果が返る
+
+GIVEN workflows ディレクトリに、load に失敗する Lua workflow 定義がある
+AND 同じ workflows ディレクトリに、正常に load できる workflow 定義が他にある
+WHEN workflow diagnostics を取得する
+THEN 取得は成功する
+AND 失敗した定義について、失敗位置を示す Diagnostic 項目が報告される
+AND 他の定義の診断結果は通常どおり返る
+
+## B-007: diagnostics の取得が local API と CLI の双方で成り立つ
+
+GIVEN B-005 の Lua module と Lua workflow 定義が workflows ディレクトリにある
+AND 同じ workflows ディレクトリに、load に失敗する Lua workflow 定義がある
+WHEN local API `GET /v1/workflow/diagnostics` と CLI `releash workflow diagnostics` のそれぞれで診断を取得する
+THEN いずれの入口でも取得は成功する
+AND いずれの入口でも、B-005 の定義について load の失敗を示す Diagnostic 項目は報告されない
+AND いずれの入口でも、失敗した定義の Diagnostic 項目と他の定義の診断結果が同じ内容で得られる
+
+## B-008: 現在正常に load できる定義の結果が変わらない
+
+GIVEN workflows ディレクトリに、現在正常に load できる Lua workflow 定義と YAML workflow 定義がある
+WHEN workflow 一覧、各 workflow 定義、および workflow diagnostics を取得する
+THEN 一覧の内容は変更前と同じである
+AND 各 workflow 定義の内容は変更前と同じである
+AND 診断結果は変更前と同じである
+
+## B-009: require が workflows ディレクトリ配下だけを探索する
+
+GIVEN Lua workflow 定義が、workflows ディレクトリ配下にない module を `require` している
+WHEN workflow diagnostics を取得する
+THEN 当該定義は load に失敗する
+AND 探索範囲の逸脱を示す Diagnostic 項目が報告される
+
+## B-010: Lua 評価のメモリ上限と命令数上限が有効である
+
+GIVEN Lua workflow 定義の評価が、メモリ上限または命令数上限を超える
+WHEN workflow diagnostics を取得する
+THEN 当該定義は load に失敗する
+AND 上限の超過を示す Diagnostic 項目が報告される
+
+## 要件IDとBehavior IDの対応表
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001, B-002 |
+| R-002 | B-002 |
+| R-003 | B-003 |
+| R-004 | B-005, B-007 |
+| R-005 | B-008 |
+| R-006 | B-009, B-010 |
+| R-007 | B-002, B-004, B-006, B-007 |

--- a/docs/specs/issues-1690/design.md
+++ b/docs/specs/issues-1690/design.md
@@ -1,0 +1,99 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### host 借用を module lookup に閉じる
+
+この修正の責務 owner は `install_require`（`src-tauri/src/infrastructure/lua/evaluator.rs:340`）が組み立てる `require` callback である。gateway 以上の層は変更しない。
+
+現状の分岐は次の形をとる（`evaluator.rs:361`）。
+
+```rust
+let result = if let Some(module) = host.borrow().module(&module_name) {
+    module_to_lua(lua, module, Rc::clone(&host))
+} else {
+    load_file_module(lua, &base_dir, &module_name, location.clone())
+};
+```
+
+crate の edition は `2021`（`src-tauri/Cargo.toml:7`）であり、if-let の scrutinee が作る一時値は else 分岐を含む if-let 式全体の終端まで生存する。したがって `load_file_module`（`evaluator.rs:379`）が module 本体を評価している間、`host` の不変借用 guard が保持されたままになる。module 本体が host 関数を呼ぶと `module_to_lua`（`evaluator.rs:441`）が生成した closure が `borrow_mut()`（`evaluator.rs:458`）へ入り、二重借用で panic する。
+
+決定: lookup の結果を分岐前に束縛し、guard を lookup 文の終端で落とす。分岐は束縛済みの値に対して行う。
+
+```rust
+// borrow guard を分岐へ持ち込むと、file module の評価中に host 関数が
+// borrow_mut() へ入り二重借用になる。lookup 結果は必ず先に束縛する。
+let host_module = host.borrow().module(&module_name);
+let result = match host_module {
+    Some(module) => module_to_lua(lua, module, Rc::clone(&host)),
+    None => load_file_module(lua, &base_dir, &module_name, location.clone()),
+};
+```
+
+`LuaHost::module` は `&self` を取り所有値 `Option<LuaModule>` を返す（trait は `evaluator.rs:139`、実装は `adaptor/gateway/workflow/lua/mod.rs:491`）。lookup を先に完了させても戻り値の意味は変わらない。束縛を戻す refactor で同じ欠陥が再発するため、理由をコメントとして残す。
+
+修正後、module 本体からの host 呼び出しは通常の host call として arena へ Node を積む。R-001 / B-001 が要求する「module が返した Node が workflow の Node として含まれる」は、builder が node 名を木の構造から決める（`lua/mod.rs:1294` の `build` と `visit_node`）ため、Node が module 由来であることに依存せず成立する。
+
+#### 借用不変条件の適用範囲
+
+規則: host の借用 guard を、Lua へ制御が戻りうる処理をまたいで保持しない。
+
+現行コードでこの規則に反するのは上記の 1 箇所だけである。`module_to_lua` の call closure（`evaluator.rs:457`）と `HostUserData` の index metamethod（`evaluator.rs:213`）は、いずれも `let` 文で `borrow_mut()` の結果を受け取り、guard を落としてから `data_to_lua` を呼ぶ。`loading` と `cache` の借用は Lua 評価をまたがない。したがって変更対象は `install_require` の分岐だけであり、`LuaHost` trait の形状と他の借用点は変えない。
+
+#### 失敗経路と一覧・診断への波及
+
+決定: gateway、usecase、controller のいずれにも変更を入れない。
+
+修正後、module 本体の評価が失敗した場合は既存どおり `CallbackFailure` として `LuaFailure` に載り、`map_evaluation_error`（`adaptor/gateway/workflow/lua/mod.rs:148`）が `WFS009` / `WFS010` / `WFS011` / host category へ写す。
+
+- 一覧: `list_workflows_with_facets`（`storage.rs:373`）が `diagnose_workflow_file` の結果に error があれば当該 1 件だけを `Invalid workflow definition` の summary へ落とし、`list_file_summaries`（`storage.rs:311`）が他のファイルの走査を続ける。`source_format` はファイル拡張子から決まる（`storage.rs:510`）ため、診断エラーを持つ YAML 定義と同じ扱いになる。R-007 / B-004 はこの既存経路のまま成立する。R-002 / B-002 が要求する「当該定義が有効な定義として一覧に含まれる」は、借用修正により当該定義が診断エラーを持たなくなるため、同じ経路で成立する。
+- 診断: `diagnose_lua_workflow_source`（`diagnostics.rs:198`）が load 失敗を単一の Diagnostic 項目へ写し、`load_workflows_in_scope`（`diagnostics.rs:1683`）がファイル単位で `Err(diagnostics)` として蓄える。R-007 / B-006 も同様に成立する。R-004 / B-005 が要求する「当該定義に load 失敗の Diagnostic が報告されない」は、借用修正により当該定義の load が成功するため成立する。
+
+一覧が全体として失敗していたのは、panic が Diagnostic ではなく `spawn_blocking` の JoinError（`adaptor/controller/command/workflow/definition.rs:24`）として抜けていたためである。panic が消えれば入口側の整形に手を入れる必要はない。
+
+### Interface
+
+外部から観測できる契約は変更しない。
+
+- Tauri command `list_workflows`（`adaptor/controller/command/workflow/definition.rs:19`）、local API `GET /v1/workflows`（`adaptor/controller/api/workflow.rs:61`）、`GET /v1/workflow/diagnostics`、CLI `releash workflow diagnostics` の入出力を変えない。両一覧入口は同一の usecase `list_workflow_summaries`（`usecase/workflow/mod.rs:94`、呼び出しは `definition.rs:24` と `api/workflow.rs:110`）を通るため、R-003 / B-003 は入口ごとの分岐を設けずに成立する。
+- crate 内部の `LuaHost` trait、`evaluate` の signature、`LuaFailure` / `LuaFailureKind` / `LuaWorkflowError` も変えない。
+- Lua 側から観測できる契約（`require` の解決規則、`releash` / `facets` module の member）を変えない。
+
+### Data Model
+
+該当なし。追加・変更する record はない。
+
+### Database
+
+該当なし。
+
+### UI/UX
+
+該当なし。frontend に変更はない。
+
+### Algorithm
+
+該当なし。処理方式の選択は Architecture の借用範囲の決定に尽きる。
+
+### Infra
+
+該当なし。
+
+## Alternatives Considered
+
+- **load 経路を `catch_unwind` で包み、panic を Diagnostic へ写す**: 却下。panic の原因である借用範囲が残るため、当該定義は Diagnostic を伴う不正な定義のままになり、R-001 が要求する正常な load を満たさない。加えて Lua 評価中の任意の panic を Diagnostic へ変換することになり、Requirements が条件として定めていない範囲の外部挙動を設計で決めてしまう。
+- **module 本体の評価中の host 呼び出しを検出して拒否する（非対応化）**: 却下。R-001 が、当該 module を `require` する定義の正常な load と、module が返した Node の取り込みを要求している。加えて現行コードに「module 本体を評価中か」を判定できる点がなく、検出機構の新設を要する。
+- **crate の edition を 2024 へ上げ、if-let 一時値の drop 位置の変更で解消する**: 却下。同形の一時値の生存範囲が crate 全体で変わるため、影響が本件と無関係な箇所へ広がり、R-005（現在正常に load できる定義の結果を変えない）に対する risk が増える。
+- **`Rc<RefCell<H>>` を再入可能な所有形へ置き換える**: 却下。`LuaHost::call` / `index` は `&mut self` を要求し（`evaluator.rs:141`、`evaluator.rs:148`）、host は評価中に arena を伸ばす。置換の影響は host 実装全体へ及ぶ一方、本件の失敗は借用範囲だけで解消できる。
+
+## Cross-cutting concerns
+
+- セキュリティ: `require` の探索範囲（`resolve_module_path` の canonicalize と `starts_with(base_dir)` 判定、`evaluator.rs:410`）、`scrub_globals`（`evaluator.rs:279`）、`LuaLimits::default` のメモリ上限と命令数上限（`evaluator.rs:29`）のいずれにも触れない。R-006 / B-009 / B-010 は現行実装のまま成立する。
+- 失敗位置の観測: module 本体で失敗した場合、`caller_location` は `load_file_module` が `set_name` へ渡した module ファイルの絶対パスを source として返し、`lua_location_span`（`diagnostics.rs:286`）が workflows ディレクトリ相対へ正規化する。既存の `lua_component_error_uses_workflow_relative_source_and_line`（`diagnostics.rs:5264`）と同じ経路であり、B-006 の失敗位置はこの経路で得る。
+- 検証の置き場: 借用範囲そのものの回帰は `infrastructure/lua/evaluator.rs` の既存 test module へ置く。`TestHost` は `require('test')` で host module を返す（`evaluator.rs:689`）ため、`TempDir` に「トップレベルで `test.value(...)` を呼ぶ module」を書いて `evaluate` を通せば、修正前は panic、修正後は成功として区別できる。panic は `Result` に現れないため、host 呼び出しを含む module fixture が唯一の検出点になる。B-001 / B-002 / B-004 / B-005 / B-006 は必須レイヤーである `adaptor/gateway/`（`docs/architecture/TEST.md`）で、module ファイルを `TempDir` へ書いてから `load_lua_workflow` / `list_workflows_with_facets` / `diagnose_lua_workflow_source` を呼ぶ既存の書き方（`lua/mod.rs:2316`、`storage.rs:1227`、`diagnostics.rs:5264`）に合わせる。B-003 と B-007 は入口ごとに実装が分岐しない（一覧は同一 usecase、CLI diagnostics は local API 経由）ため、controller 層にテストを新設せず既存の `src-tauri/tests/workflow_diagnostics_cli_test.rs` の範囲を保つ。
+
+## Risks
+
+該当なし。

--- a/docs/specs/issues-1690/requirements.md
+++ b/docs/specs/issues-1690/requirements.md
@@ -1,0 +1,126 @@
+# Context
+
+## 入力文書
+
+- 正本: [Issue #1690](https://github.com/siro33950/releash/issues/1690) `[workflow engine] Lua module 評価中の host API 呼び出しが RefCell 二重借用で panic し、workflow 一覧まで壊れる`（labels: `bug` / state: OPEN / milestone: なし）
+- 配置先: `docs/specs/issues-1690`
+
+## 参照した既存実装・既存文書
+
+Issue が名指しした箇所、および調査で確認した関連箇所。いずれも実在を確認済み。
+
+| 参照先 | 内容 |
+| --- | --- |
+| `src-tauri/src/infrastructure/lua/evaluator.rs:340` | `install_require`。`require` の Lua 関数を組み立てる。 |
+| `src-tauri/src/infrastructure/lua/evaluator.rs:379` | `load_file_module`。workflows ディレクトリ配下の `.lua` を読み、その場で評価する。 |
+| `src-tauri/src/infrastructure/lua/evaluator.rs:441` | `module_to_lua`。host module の member を Lua 関数へ変換する。生成される関数は呼び出し時に host を `borrow_mut()` する。 |
+| `src-tauri/src/adaptor/gateway/workflow/lua/mod.rs` | Lua 定義の load。評価失敗を `WFS009` / `WFS010` / `WFS011` / host category へ写す。 |
+| `src-tauri/src/adaptor/gateway/workflow/diagnostics.rs:198` | `diagnose_lua_workflow_source`。load 失敗を Diagnostic 項目へ変換する。 |
+| `src-tauri/src/adaptor/gateway/workflow/storage.rs:373` | `list_workflows_with_facets`。診断でエラーを持つ定義を `Invalid workflow definition` として一覧に残す。 |
+| `src-tauri/src/adaptor/gateway/workflow/diagnostics.rs:1683` | `load_workflows_in_scope`。定義ファイルごとに結果を `Ok` / `Err(diagnostics)` として蓄える。 |
+| `src-tauri/src/adaptor/controller/api/workflow.rs:61` | `GET /v1/workflows` → `list_workflows`。 |
+| `src-tauri/src/adaptor/controller/command/workflow/definition.rs:19` | Tauri command `list_workflows`。 |
+| `docs/glossary/WORKFLOW.md:413` | 「部品は Sequence を返す関数として作り、再利用時は関数を再度呼んで独立した Node 群を得る」。文法正本における推奨形の記述。 |
+
+## 確定済みの前提
+
+- Lua workflow 定義の `require` は workflows ディレクトリ配下だけを探索する（`docs/glossary/WORKFLOW.md:413`）。
+- workflow 定義の入口は Tauri command、loopback HTTP local API、CLI の3つで、いずれも同じ usecase を共有する（`AGENTS.md`「構成で押さえる点」）。一覧は Tauri command `list_workflows` と `GET /v1/workflows` の双方が usecase の `list_workflow_summaries` を通る。
+- Lua の評価環境は外部 I/O を持たず、メモリ量と命令数に上限がある。この上限は緩めない（`AGENTS.md`「セキュリティ」）。
+- 一覧経路には、定義ファイル単位でエラーを Diagnostic として扱い当該定義だけを不正表示に落とす仕組みが既にある（`storage.rs:373` の `Invalid workflow definition`、`diagnostics.rs:1683` のファイル単位 `Err`）。この仕組みは Diagnostic として返る失敗にしか働かない。
+- 本 crate の Rust edition は `2021`（`src-tauri/Cargo.toml:7`）。
+- 現在 `workflows/` に `.lua` の定義ファイルは存在しない。再現には定義ファイルの追加が要る。
+
+# Outcome
+
+## 対象者
+
+- workflow 定義を Lua で書き、`require` で定義を複数ファイルに分割する開発者。
+- 同じ workflows ディレクトリを参照して workflow を観測・実行する Releash の全利用者（desktop UI、local API client、CLI）。
+
+## 現在の問題
+
+1. Lua module が module 本体の評価中（トップレベル）に host API を呼ぶと、その module を `require` する定義は load されず panic になる。定義が成立しないうえ、失敗が Diagnostic として返らないため、利用者は原因の位置も種類も分からない。
+2. その定義ファイルが workflows ディレクトリに存在する限り、workflow 一覧そのものが失敗する。他の正しい定義まで観測できなくなり、UI から復旧操作にたどり着けない。
+
+## 変更後に実現する状態
+
+1. module 評価中の host API 呼び出しが正当なパターンとして動作し、その module を `require` する定義は正常に load される。
+2. 1つの定義ファイルの load 失敗が、その定義の不正表示に閉じる。一覧および他の定義には波及しない。
+
+# Current Behavior
+
+## 再現手順
+
+`workflows/` に次の2ファイルを置く。
+
+```lua
+-- workflows/broken.lua
+local r = require("releash")
+local nodes = require("broken-parts.nodes")
+return r.workflow{ name = "broken", description = "x", main = nodes.main }
+```
+
+```lua
+-- workflows/broken-parts/nodes.lua
+local r = require("releash")
+return { main = r.command{ command = "true" } }
+```
+
+この状態で workflow 一覧を取得する（desktop UI の workflow 一覧表示、または `GET /v1/workflows`）。
+
+## 実際の出力
+
+- Issue に記載された観測結果: `task join error: task 262726 panicked with message "RefCell already borrowed"`。この文言は Tauri command `list_workflows` の join error 整形（`src-tauri/src/adaptor/controller/command/workflow/definition.rs:26`）と一致する。
+- Issue の記載: `GET /v1/workflows` も同じ load 経路で壊れ、一覧が配列でなくエラーを返す。
+
+## 経路の説明
+
+- `install_require`（`evaluator.rs:340`）は、host 提供 module と file module の分岐を `if let Some(module) = host.borrow().module(&module_name) { … } else { load_file_module(…) }` の形で書いている。
+- edition 2021 では if-let の scrutinee の一時値（`host.borrow()` が返す借用 guard）が、else 分岐を含む if-let 式全体の終わりまで生存する。したがって `load_file_module` が module を評価している間、host の不変借用が保持されたままになる。
+- `load_file_module`（`evaluator.rs:379`）は読み込んだ source をその場で評価する。module 本体が `r.command{…}` のような host 関数を呼ぶと、`module_to_lua`（`evaluator.rs:441`）が作った closure が host を `borrow_mut()` し、二重借用で panic する。
+- module が host を呼ばない値（純関数など）だけを返す形に書き換えると、評価中に `borrow_mut()` が起きないため発生しない。
+- 一覧経路の失敗の扱い: `list_workflows_with_facets`（`storage.rs:373`）は診断でエラーを持つ定義を `Invalid workflow definition` に落として一覧へ残す。しかし panic は Diagnostic として返らないため、この分岐に到達せず `spawn_blocking` の JoinError として一覧全体の失敗になる。
+- 上記の経路解析は、Issue 記載の見立てと本 spec 作成時のコード確認によるものであり、修正方針の確定ではない。
+
+## 影響範囲の確認結果
+
+- Tauri command `list_workflows`（`definition.rs:19`）と local API `GET /v1/workflows`（`api/workflow.rs:61`）は、ともに usecase の `list_workflow_summaries` を経由する。
+- workflow diagnostics（`GET /v1/workflow/diagnostics`、CLI `releash workflow diagnostics`）も `diagnose_workflow_file` を通り、同じ Lua 評価経路を使う。
+
+# Scope / Non-goals
+
+## 変更する対象
+
+- Lua module の評価中に host API が呼ばれた場合の扱い。
+- 1つの workflow 定義の load 失敗が、workflow 一覧および他の定義に波及しないこと。
+- 上記が Tauri command、local API、CLI のいずれの入口でも成り立つこと。
+
+## 変更しない対象
+
+- Lua 文法および host API（`r.session` / `r.command` / `r.input` 等）の仕様追加・削除。
+- `docs/glossary/WORKFLOW.md` が示す推奨形（部品は Sequence を返す関数として作る）そのものの変更。推奨は推奨のまま残す。
+- YAML 形式の workflow 定義の load・診断の挙動。
+- workflow の実行（execution）系の挙動。
+- Diagnostic code 体系（`WFS00x` の割り当て規則）の再設計。
+- Lua 評価環境の制限値（メモリ上限、命令数上限、`require` の探索範囲）の変更。
+
+# Requirements
+
+- R-001: workflows ディレクトリ配下の Lua module が module 本体の評価中に host API を呼び、その結果を module の返り値に含めて返したとき、その module を `require` する workflow 定義は正常に load される。module が返した Node は、当該 workflow の Node として定義に含まれる。
+- R-002: R-001 の形の定義ファイルが workflows ディレクトリに存在する状態でも、workflow 一覧の取得は成功する。一覧は定義の配列を返し、当該定義は有効な定義として一覧に含まれる。
+- R-003: R-002 の一覧取得の成功は、Tauri command `list_workflows` と local API `GET /v1/workflows` の双方で成り立つ。
+- R-004: R-001 の形の定義ファイルが存在する状態でも、workflow diagnostics の取得は成功する。当該定義について load の失敗を示す Diagnostic 項目は報告されず、他の定義の診断結果は通常どおり返る。これは local API `GET /v1/workflow/diagnostics` と CLI `releash workflow diagnostics` の双方で成り立つ。
+- R-005: 現在正常に load できる Lua 定義および YAML 定義の load 結果（一覧の内容、定義の内容、診断結果）は変わらない。
+- R-006: Lua 評価環境の制限は緩まない。`require` の探索範囲は workflows ディレクトリ配下のままであり、メモリ上限と命令数上限は現在の値のまま有効である。
+- R-007: workflow 定義 1 件の load 失敗は、当該定義が不正な定義として一覧に含まれることに閉じる。workflow 一覧の取得は成功し、他の定義の load 結果および診断結果には波及しない。当該定義の一覧上の扱いは、既存の不正な定義（診断エラーを持つ YAML 定義）と同じである。
+
+# Assumptions / Open Questions
+
+## Open Questions
+
+- なし。
+
+## Assumptions
+
+- なし。ユーザーが明示的に受け入れた仮定は存在しない。

--- a/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/diagnostics.rs
@@ -5261,6 +5261,149 @@ return r.workflow{
     }
 
     #[test]
+    fn test_workflow診断_module評価中にhostを呼ぶ定義と他定義を正常に診断する() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("module-host-parts");
+        fs::create_dir(&module_dir).unwrap();
+        fs::write(
+            module_dir.join("nodes.lua"),
+            r#"local r = require("releash")
+return { main = r.command{ command = "true" } }
+"#,
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("module-host.lua"),
+            r#"local r = require("releash")
+local nodes = require("module-host-parts.nodes")
+return r.workflow{
+  name = "module-host", description = "Module host workflow", main = nodes.main,
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("healthy.lua"),
+            r#"local r = require("releash")
+return r.workflow{
+  name = "healthy", description = "Healthy workflow",
+  main = r.command{ command = "printf healthy" },
+}
+"#,
+        )
+        .unwrap();
+
+        // When
+        let loaded = load_workflows_in_scope(
+            tmp.path(),
+            tmp.path(),
+            DiagnosticScope::ReachableFromDirectory,
+        );
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        for name in ["module-host", "healthy"] {
+            let (_, result) = loaded
+                .iter()
+                .find(|(workflow_name, _)| workflow_name == name)
+                .unwrap_or_else(|| panic!("{name} の診断 load 結果"));
+            let Ok((workflow, source_diagnostics)) = result else {
+                panic!("{name} は診断時に正常 load されるべき: {result:?}");
+            };
+            assert_eq!(workflow.name, name);
+            assert!(source_diagnostics.is_empty(), "{source_diagnostics:?}");
+            assert!(!report.items.iter().any(|item| {
+                item.workflow_name.as_deref() == Some(name) && item.severity == Severity::Error
+            }));
+        }
+
+        assert!(!report.items.iter().any(|item| {
+            item.workflow_name.as_deref() == Some("module-host")
+                && matches!(item.code.as_str(), "WFS009" | "WFS010" | "WFS011")
+        }));
+    }
+
+    #[test]
+    fn test_workflow診断_lua定義のload失敗を位置付きで報告して他定義へ波及させない() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("broken-parts");
+        fs::create_dir(&module_dir).unwrap();
+        fs::write(
+            module_dir.join("nodes.lua"),
+            "local r = require(\"releash\")\nreturn r.command{ command = }\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("broken.lua"),
+            r#"local r = require("releash")
+local nodes = require("broken-parts.nodes")
+return r.workflow{
+  name = "broken", description = "Broken workflow", main = nodes.main,
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("invalid-yaml.yml"),
+            r#"name: invalid-yaml
+description: Invalid YAML workflow
+nodes:
+  main:
+    artifact: something
+"#,
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("healthy.lua"),
+            r#"local r = require("releash")
+return r.workflow{
+  name = "healthy", description = "Healthy workflow",
+  main = r.command{ command = "printf healthy" },
+}
+"#,
+        )
+        .unwrap();
+
+        // When
+        let loaded = load_workflows_in_scope(
+            tmp.path(),
+            tmp.path(),
+            DiagnosticScope::ReachableFromDirectory,
+        );
+        let report = diagnose_directory(tmp.path());
+
+        // Then
+        let broken = report
+            .items
+            .iter()
+            .find(|item| item.workflow_name.as_deref() == Some("broken") && item.code == "WFS009")
+            .expect("broken module の syntax diagnostic");
+        let span = broken.span.as_ref().expect("broken module の失敗位置");
+        assert_eq!(span.source.as_deref(), Some("broken-parts/nodes.lua"));
+        assert_eq!(span.start_line, 2);
+
+        assert!(report.items.iter().any(|item| {
+            item.workflow_name.as_deref() == Some("invalid-yaml")
+                && item.severity == Severity::Error
+        }));
+
+        let (_, healthy_result) = loaded
+            .iter()
+            .find(|(name, _)| name == "healthy")
+            .expect("healthy の診断 load 結果");
+        let Ok((healthy, source_diagnostics)) = healthy_result else {
+            panic!("healthy は正常 load されるべき: {healthy_result:?}");
+        };
+        assert_eq!(healthy.name, "healthy");
+        assert!(source_diagnostics.is_empty(), "{source_diagnostics:?}");
+        assert!(!report.items.iter().any(|item| {
+            item.workflow_name.as_deref() == Some("healthy") && item.severity == Severity::Error
+        }));
+    }
+
+    #[test]
     fn lua_component_error_uses_workflow_relative_source_and_line() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(

--- a/src-tauri/src/adaptor/gateway/workflow/storage.rs
+++ b/src-tauri/src/adaptor/gateway/workflow/storage.rs
@@ -726,6 +726,82 @@ nodes:
     }
 
     #[test]
+    fn test_workflow一覧_lua定義のload失敗を当該定義だけの不正表示に隔離する() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("broken-parts");
+        fs::create_dir(&module_dir).unwrap();
+        fs::write(
+            module_dir.join("nodes.lua"),
+            "local r = require(\"releash\")\nreturn r.command{ command = }\n",
+        )
+        .unwrap();
+        let broken_path = tmp.path().join("broken.lua");
+        fs::write(
+            &broken_path,
+            r#"local r = require("releash")
+local nodes = require("broken-parts.nodes")
+return r.workflow{
+  name = "broken", description = "Broken workflow", main = nodes.main,
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("invalid-yaml.yml"),
+            r#"name: invalid-yaml
+description: Invalid YAML workflow
+nodes:
+  main:
+    artifact: something
+"#,
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("healthy.lua"),
+            r#"local r = require("releash")
+return r.workflow{
+  name = "healthy", description = "Healthy workflow",
+  main = r.command{ command = "printf healthy" },
+}
+"#,
+        )
+        .unwrap();
+
+        // When
+        let load_error = load_workflow(&broken_path, tmp.path()).unwrap_err();
+        let summaries = list_workflows(tmp.path()).unwrap();
+
+        // Then
+        let StorageError::Diagnostics(load_diagnostics) = load_error else {
+            panic!("Lua 定義の load 失敗は structured diagnostics であるべき");
+        };
+        assert!(load_diagnostics.iter().any(|item| item.code == "WFS009"));
+
+        let broken = summaries
+            .iter()
+            .find(|summary| summary.name == "broken")
+            .expect("broken summary");
+        let invalid_yaml = summaries
+            .iter()
+            .find(|summary| summary.name == "invalid-yaml")
+            .expect("invalid-yaml summary");
+        assert_eq!(broken.description, invalid_yaml.description);
+        assert_eq!(broken.description, "Invalid workflow definition");
+        assert_eq!(broken.builtin, invalid_yaml.builtin);
+        assert_eq!(broken.is_running, invalid_yaml.is_running);
+        assert_eq!(broken.source_format, WorkflowSourceFormat::Lua);
+        assert_eq!(invalid_yaml.source_format, WorkflowSourceFormat::Yaml);
+
+        let healthy = summaries
+            .iter()
+            .find(|summary| summary.name == "healthy")
+            .expect("healthy summary");
+        assert_eq!(healthy.description, "Healthy workflow");
+        assert_eq!(healthy.source_format, WorkflowSourceFormat::Lua);
+    }
+
+    #[test]
     fn list_workflows_collapses_same_name_across_formats() {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
@@ -1251,6 +1327,71 @@ return r.workflow{
                 .source_format,
             WorkflowSourceFormat::Lua
         );
+    }
+
+    #[test]
+    fn test_workflow一覧_module評価中のhost呼出で作ったnodeを有効な定義として扱う() {
+        // Given
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("module-host-parts");
+        std::fs::create_dir(&module_dir).unwrap();
+        std::fs::write(
+            module_dir.join("nodes.lua"),
+            r#"local r = require("releash")
+return { main = r.command{ command = "true" } }
+"#,
+        )
+        .unwrap();
+        let workflow_path = tmp.path().join("module-host.lua");
+        std::fs::write(
+            &workflow_path,
+            r#"local r = require("releash")
+local nodes = require("module-host-parts.nodes")
+return r.workflow{
+  name = "module-host", description = "Module host workflow", main = nodes.main,
+}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("healthy.lua"),
+            r#"local r = require("releash")
+return r.workflow{
+  name = "healthy", description = "Healthy workflow",
+  main = r.command{ command = "printf healthy" },
+}
+"#,
+        )
+        .unwrap();
+
+        // When
+        let workflow = load_workflow(&workflow_path, tmp.path()).unwrap();
+        let summaries = list_workflows(tmp.path()).unwrap();
+
+        // Then
+        let main = workflow
+            .nodes
+            .iter()
+            .find(|node| node.name == "main")
+            .expect("module が返した main node");
+        let NodeKind::Command(command) = &main.kind else {
+            panic!("module が返した node は command であるべき");
+        };
+        assert_eq!(command.command, "true");
+
+        let module_host = summaries
+            .iter()
+            .find(|summary| summary.name == "module-host")
+            .expect("module-host summary");
+        assert_eq!(module_host.description, "Module host workflow");
+        assert_eq!(module_host.source_format, WorkflowSourceFormat::Lua);
+
+        let healthy = summaries
+            .iter()
+            .find(|summary| summary.name == "healthy")
+            .expect("healthy summary");
+        assert_eq!(healthy.description, "Healthy workflow");
+        assert_eq!(healthy.source_format, WorkflowSourceFormat::Lua);
     }
 
     #[test]

--- a/src-tauri/src/infrastructure/lua/evaluator.rs
+++ b/src-tauri/src/infrastructure/lua/evaluator.rs
@@ -358,10 +358,12 @@ fn install_require<H: LuaHost + 'static>(
             ));
         }
 
-        let result = if let Some(module) = host.borrow().module(&module_name) {
-            module_to_lua(lua, module, Rc::clone(&host))
-        } else {
-            load_file_module(lua, &base_dir, &module_name, location.clone())
+        // 借用 guard を分岐へ持ち込むと、file module の評価中に host 関数が
+        // borrow_mut() へ入り二重借用になる。lookup 結果は必ず先に束縛する。
+        let host_module = host.borrow().module(&module_name);
+        let result = match host_module {
+            Some(module) => module_to_lua(lua, module, Rc::clone(&host)),
+            None => load_file_module(lua, &base_dir, &module_name, location.clone()),
         };
         loading.borrow_mut().remove(&module_name);
 
@@ -854,6 +856,38 @@ mod tests {
                 &LuaData::Boolean(true),
             ]
         );
+    }
+
+    #[test]
+    fn test_lua評価_require先moduleの評価中にhost関数を呼べる() {
+        // Given
+        let dir = TempDir::new().unwrap();
+        let module = dir.path().join("parts.lua");
+        fs::write(
+            &module,
+            "local test = require('test')\nreturn { made = test.value('ok') }",
+        )
+        .unwrap();
+
+        // When
+        let result = evaluate(
+            request(
+                dir.path(),
+                "local parts = require('parts')\nreturn parts.made",
+            ),
+            TestHost::default(),
+        )
+        .unwrap();
+
+        // Then
+        assert_eq!(result.value, LuaData::String("ok".to_string()));
+        assert_eq!(result.host.calls.len(), 1);
+        assert_eq!(result.host.calls[0].0, 1);
+        assert_eq!(
+            result.host.calls[0].1.source,
+            fs::canonicalize(module).unwrap().to_string_lossy()
+        );
+        assert_eq!(result.host.calls[0].1.line, 2);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1690

## 原因

`install_require`（`src-tauri/src/infrastructure/lua/evaluator.rs`）が host module の lookup を if-let の scrutinee に置いていた。

```rust
let result = if let Some(module) = host.borrow().module(&module_name) {
    module_to_lua(lua, module, Rc::clone(&host))
} else {
    load_file_module(lua, &base_dir, &module_name, location.clone())
};
```

edition 2021（本 crate の設定）では scrutinee の一時値、つまり `host.borrow()` が返す借用 guard が **else 分岐を含む if-let 式全体の終端まで生存**する。そのため `load_file_module` が file module の本体を評価している間ずっと host の不変借用が保持される。module 本体が `r.command{...}` のような host 関数を呼ぶと、`module_to_lua` が生成した closure が `borrow_mut()` へ入り、二重借用で panic する。module が host を呼ばない値だけを返す形（`return function(r) ... end`）では評価中に `borrow_mut()` が起きないため発生しない。

波及が大きいのは、この失敗が Diagnostic として返らないためである。一覧には定義ファイル単位でエラーを `Invalid workflow definition` へ落として一覧に残す仕組み（`storage.rs` の `list_workflows_with_facets`）が既にあるが、これは Diagnostic として返る失敗にしか働かない。panic は `spawn_blocking` の JoinError として抜けるため、この分岐へ到達せず一覧全体の失敗になる。該当ファイルが workflows ディレクトリにある限り、他の正しい定義まで観測できなくなっていた。

## 修正

- **借用 guard を module lookup に閉じる**: lookup 結果を分岐前に束縛し、guard を lookup 文の終端で落とす。`LuaHost::module` は `&self` を取って所有値 `Option<LuaModule>` を返すため、lookup を先に完了させても戻り値の意味は変わらない。束縛を戻す refactor で同じ欠陥が再発するため、理由をコメントとして残す

```rust
// 借用 guard を分岐へ持ち込むと、file module の評価中に host 関数が
// borrow_mut() へ入り二重借用になる。lookup 結果は必ず先に束縛する。
let host_module = host.borrow().module(&module_name);
let result = match host_module {
    Some(module) => module_to_lua(lua, module, Rc::clone(&host)),
    None => load_file_module(lua, &base_dir, &module_name, location.clone()),
};
```

- **規則として置くのは「host の借用 guard を、Lua へ制御が戻りうる処理をまたいで保持しない」**。現行コードでこれに反するのは上記 1 箇所だけである。`module_to_lua` の call closure と `HostUserData` の index metamethod はいずれも `let` 文で `borrow_mut()` の結果を受け取り、guard を落としてから `data_to_lua` を呼ぶ。`loading` と `cache` の借用は Lua 評価をまたがない
- **gateway より上の層は変更しない**。panic が消えれば module 本体の評価失敗は既存どおり `CallbackFailure` として `LuaFailure` に載り、`map_evaluation_error` が `WFS009` / `WFS010` / `WFS011` / host category へ写す。一覧は既存の `Invalid workflow definition` 経路で当該 1 件だけを落とし、診断は `load_workflows_in_scope` がファイル単位で `Err(diagnostics)` として蓄える。`LuaHost` trait、`evaluate` の signature、`LuaFailure` / `LuaFailureKind` / `LuaWorkflowError` も変えない
- **Lua 側から観測できる契約を変えない**。`require` の解決規則、`releash` / `facets` module の member、`resolve_module_path` の探索範囲（canonicalize と `starts_with(base_dir)` 判定）、`scrub_globals`、`LuaLimits::default` のメモリ上限と命令数上限のいずれにも触れない
- 入出力の契約も変えない。Tauri command `list_workflows`、local API `GET /v1/workflows`、`GET /v1/workflow/diagnostics`、CLI `releash workflow diagnostics` はそのままである。両一覧入口は同一 usecase `list_workflow_summaries` を通るため、入口ごとの分岐は設けない

Issue が候補に挙げた「load 経路の panic を Diagnostic へ隔離する防御」は採らなかった。`catch_unwind` で包む案は panic の原因である借用範囲が残るため、当該定義が Diagnostic を伴う不正な定義のままになり、Issue の期待する「module 評価中の host API 呼び出しが正当なパターンとして動作する」を満たさない。加えて Lua 評価中の任意の panic を Diagnostic へ変換することになり、条件として定めていない範囲の外部挙動まで決めてしまう。「1 定義の load 失敗が一覧へ波及しない」という要求は、panic が消えたあとは既存の隔離経路がそのまま満たす（下記テストで固定した）。他に検討して却下した案は edition 2024 化（同形の一時値の生存範囲が crate 全体で変わる）と `Rc<RefCell<H>>` の再入可能な所有形への置換（`LuaHost::call` / `index` が `&mut self` を要求し、影響が host 実装全体へ及ぶ）。

## テスト

- **infrastructure/lua**: 借用範囲そのものの回帰。`TempDir` にトップレベルで host 関数を呼ぶ module を書いて `evaluate` を通し、返り値・host call 回数・呼び出し位置（module ファイルの絶対パスと行）を検証する。panic は `Result` に現れないため、host 呼び出しを含む module fixture が唯一の検出点になる
- **adaptor/gateway（一覧）**: ① module 評価中の host 呼び出しで作った Node が `main` の Command node として定義に含まれ、当該 workflow が有効な定義として一覧に並ぶこと ② Lua 定義の load 失敗が `WFS009` の structured diagnostics として返り、一覧上は description / builtin / is_running が不正な YAML 定義と同一の `Invalid workflow definition` に落ちる（`source_format` は拡張子どおり Lua / Yaml で分かれる）こと、他の定義が通常どおり並ぶこと
- **adaptor/gateway（診断）**: ① 該当定義に load 失敗の Diagnostic（`WFS009` / `WFS010` / `WFS011`）が報告されず、他の定義の診断結果が通常どおり返ること ② 失敗する定義について `broken-parts/nodes.lua` の 2 行目という workflows 相対の位置付きで Diagnostic が報告され、同ディレクトリの不正 YAML と正常定義の診断結果に波及しないこと
- 入口ごとに実装が分岐しない（一覧は同一 usecase、CLI diagnostics は local API 経由）ため、controller 層にテストは新設せず既存の `src-tauri/tests/workflow_diagnostics_cli_test.rs` の範囲を保つ
- 検証: `cargo fmt --check` / `cargo clippy --locked -- -D warnings` / `cargo deny --locked check`（advisories / bans / licenses / sources すべて ok）/ `cargo test --locked`（lib 2271 passed・2 ignored、acceptance 各 suite green、`workflow_diagnostics_cli_test` 13）/ `cargo test --locked --test agent_tui_harness`（13）すべて pass。frontend への変更はない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD2qKjrZKZiT6aRbbjUKyk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Lua モジュールの評価中にホスト機能を呼び出しても、ワークフローの読み込みが正常に完了するようになりました。
  * 一部の Lua 定義が読み込みに失敗した場合でも、他の定義の一覧表示や診断結果に影響しなくなりました。

* **ドキュメント**
  * Lua ワークフロー評価、診断、一覧取得、各種 API、CLI の動作仕様を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->