### PR TITLE
feat(workspace): Sequence 行のアイコンを Waypoints に変更

### DIFF
--- a/docs/specs/issues-1721/behavior.md
+++ b/docs/specs/issues-1721/behavior.md
@@ -1,0 +1,34 @@
+## B-001: トップレベルの Sequence 行
+
+GIVEN Workspace ツリーにトップレベルの Sequence 行が存在する
+WHEN Workspace ツリーが表示される
+THEN すべてのトップレベルの Sequence 行は Node 種別アイコンとして `Waypoints` を表示する
+
+## B-002: 入れ子の Sequence 行
+
+GIVEN Workspace ツリーに別の合成 Node の配下へ入れ子になった Sequence 行が存在する
+WHEN Workspace ツリーが表示される
+THEN すべての入れ子の Sequence 行は Node 種別アイコンとして `Waypoints` を表示する
+
+## B-003: Sequence 行のアイコン表示規則
+
+GIVEN Workspace ツリーに `active`、`attention`、`failure`、`idle` のいずれかに分類された Sequence 行が存在する
+WHEN Sequence 行の `Waypoints` が表示される
+THEN `Waypoints` は14pxで表示される
+AND `active` は青、`attention` は黄、`failure` は赤、`idle` は緑で表示される
+AND `active` と `attention` では pulse する
+AND `failure` と `idle` では pulse しない
+
+## B-004: Fanout 行のアイコン維持
+
+GIVEN Workspace ツリーに Fanout 行が存在する
+WHEN Workspace ツリーが表示される
+THEN Fanout 行は Node 種別アイコンとして既存の `GitFork` を表示する
+
+## 要件IDとBehavior IDの対応表
+
+| Requirement ID | Behavior ID |
+| --- | --- |
+| R-001 | B-001, B-002 |
+| R-002 | B-003 |
+| R-003 | B-004 |

--- a/docs/specs/issues-1721/design.md
+++ b/docs/specs/issues-1721/design.md
@@ -1,0 +1,60 @@
+# Design
+
+## The actual design
+
+### Architecture
+
+#### Workspace tree branch 行のアイコン選択
+
+`src/components/workspace/WorkspaceList.tsx` の `WorkspaceBranchRow` が、`WorkspaceTreeItem.kind` に基づく合成 Node のアイコン選択を引き続き所有する。`fanout` 分岐は既存の `FanoutRowStatusIcon` を使用し、Sequence 分岐だけが `WorkspaceBranchStatusIcon` へ渡す Lucide アイコンを `ListTree` から `Waypoints` へ変更する。新しい component や Node 種別判定は追加しない。
+
+`WorkspaceTreeItemRow` はトップレベルの項目にも各合成 Node の `children` にも再帰的に使われ、すべての Sequence を同じ `WorkspaceBranchRow` へ渡している。この既存経路を維持することで、一箇所のアイコン選択がトップレベルと入れ子の Sequence の双方へ適用される。根拠は `src/types/workspace-tree.ts` の `WorkspaceTreeItem` discriminated union と、`src/components/workspace/WorkspaceList.tsx` の `WorkspaceTreeItemRow` / `WorkspaceBranchRow` である。
+
+主要な変更対象は次のとおり。
+
+| Path | 変更の要旨 |
+| --- | --- |
+| `src/components/workspace/WorkspaceList.tsx` | `lucide-react` の import と Sequence 分岐の icon prop を `Waypoints` へ置き換える |
+| `src/components/workspace/WorkspaceList.test.tsx` | Sequence の形状に関する既存観測を `Waypoints` へ更新し、トップレベル・入れ子・4状態分類・Fanout 維持を Behavior に対応づけて検証する |
+
+状態分類の決定、色の対応、pulse の決定は変更しない。これらは Issue #1683 の設計どおり backend-owned classification と既存の `WorkspaceBranchStatusIcon` / `WorkflowNodeStatusIcon` が担い、本件は Node 種別を表す形状だけを変更する。
+
+### Interface
+
+公開 Tauri command、local API、CLI、DTO、TypeScript の公開型、component props は変更しない。`WorkspaceBranchStatusIcon` の内部 interface も維持し、既存の `LucideIcon` 型の icon prop に `Waypoints` を渡す。互換性のない契約変更はない。
+
+### Data Model
+
+該当なし。`WorkspaceSequence`、`WorkspaceFanout`、`WorkspaceTreeItem` および状態分類の保持方法を変更しない。
+
+### Database
+
+該当なし。永続化する事実、projection、SQLite schema、access path を変更しない。
+
+### UI/UX
+
+Sequence 行は `Waypoints` を `WorkspaceBranchStatusIcon` 経由で表示する。同 component の既定 `size-3.5` を使うため14pxを維持し、`workflowNodeIconClasses` による青・黄・赤・緑と、`isWorkspaceNodePulseStatus` による `active` / `attention` のみの pulse をそのまま適用する。
+
+Fanout 行は既存の `FanoutRowStatusIcon` 経由で `GitFork` を表示し続ける。行の階層、インデント、展開・折り畳み、ラベル、操作領域は変更しない。
+
+検証は既存の component test を拡張し、トップレベルと入れ子で共有される Sequence のアイコン選択、Sequence の既存表示規則、Fanout のアイコン維持を観測する。共有される色・pulse 規則については、既存の関連 component test を回帰検証として維持する。
+
+### Algorithm
+
+該当なし。
+
+### Infra
+
+該当なし。
+
+## Alternatives Considered
+
+該当なし。`Waypoints` は R-001 で確定済みであり、代替アイコンの再選定は Non-goal である。
+
+## Cross-cutting concerns
+
+該当なし。
+
+## Risks
+
+該当なし。

--- a/docs/specs/issues-1721/requirements.md
+++ b/docs/specs/issues-1721/requirements.md
@@ -1,0 +1,57 @@
+# Context
+
+- Primary source は GitHub Issue #1721「[workspace tree] sequence 行のアイコンが Node 種別を表しておらず fanout と対比しない」（https://github.com/siro33950/releash/issues/1721 、state: OPEN、label: enhancement、comment なし）である。
+- 追加資料は GitHub Issue #1683（https://github.com/siro33950/releash/issues/1683 ）、`docs/specs/issues-1683/requirements.md`、`docs/specs/issues-1683/behavior.md`、`docs/specs/issues-1683/design.md`、`src/components/workspace/WorkspaceList.tsx`、`src/components/workspace/FanoutRowStatusIcon.tsx`、`src/types/workspace-tree.ts` である。
+- Sequence は children を時系列に束ね、辺を所有する合成 Node、Fanout は children を並列に束ねる合成 Node である（`docs/glossary/DOMAIN.md`、`docs/glossary/WORKFLOW.md`）。
+- Issue #1683 とその Spec により、Workspace ツリー行の色は Node 種別ではなく状態分類を表す。Issue #1683 の変更ではアイコン形状が Non-goal とされ、commit `59bb632fa` で状態色と pulse の規則が現行実装へ反映された。
+- Sequence 行の `ListTree` は、Sequence が公開 DTO に追加された commit `efc76d0ce` で導入された。Issue #1721 に対応済みの commit および `docs/specs/issues-1721` の既存文書は確認できなかった。
+- 現在状態の確認は Issue、既存 Spec、用語集、現行コード、既存テスト、Git 履歴の読解によって行った。アプリを起動しての画面確認は行っていない。
+
+# Outcome
+
+Releash の Workspace ツリーで workflow の実行木を確認する開発者が対象である。
+
+現在、Sequence 行の `ListTree` はツリーそのものと同じ形を重ねて表示し、枝分かれする形にも見える。そのため、14px のアイコン形状だけでは、children を時系列に束ねる Sequence と、children を並列に束ねる Fanout を判別しにくい。色は Node の状態分類を表すため、Node 種別の判別には使えない。
+
+変更後は、Sequence 行が複数の点を分岐なしの経路で結ぶ `Waypoints` で表示される。Fanout 行の `GitFork` との形状差により、開発者は状態色に頼らず Sequence と Fanout を判別できる。
+
+# Current Behavior
+
+`src/types/workspace-tree.ts` は、Workspace ツリーの合成 Node を `kind: "sequence"` と `kind: "fanout"` に分けている。トップレベルおよび入れ子の Sequence は、どちらも同じ Sequence 行として表示される。
+
+`src/components/workspace/WorkspaceList.tsx:403-406` は、Fanout 行を `FanoutRowStatusIcon`、それ以外の合成 Node である Sequence 行を `WorkspaceBranchStatusIcon` で描画する。Sequence 行には `ListTree` が渡されている。`src/components/workspace/FanoutRowStatusIcon.tsx:12` は Fanout 行に `GitFork` を渡す。
+
+両方のアイコンは `WorkspaceBranchStatusIcon` により `size-3.5`（14px）で表示され、同じ状態分類に基づく色と pulse を受ける。既存の `src/components/workspace/WorkspaceList.test.tsx` も、Sequence 行に `lucide-list-tree`、Fanout 行に `lucide-git-fork` が表示されることを確認している。
+
+最小の再現手順と実際の出力は次のとおりである。
+
+1. Sequence と Fanout を含む workflow の Workspace ツリーを表示する。
+2. Sequence 行と Fanout 行の左端にある Node 種別アイコンを比較する。
+3. Sequence 行には枝分かれしたツリー形状の `ListTree`、Fanout 行には分岐形状の `GitFork` が、いずれも14pxかつ状態分類に応じた同じ色規則で表示される。
+
+# Scope / Non-goals
+
+## Scope
+
+- Workspace ツリーに表示されるすべての Sequence 行について、Node 種別を表すアイコン形状を `ListTree` から `Waypoints` へ変更する。
+- トップレベルと入れ子のどちらの Sequence 行にも同じ変更を適用する。
+- Sequence 行の既存の表示サイズ、状態色、pulse の規則を維持する。
+
+## Non-goals
+
+- Fanout 行の `GitFork` の変更。
+- Workspace ツリーの状態分類、色、pulse の規則の変更。
+- Session / Command の leaf 行アイコンの変更。
+- ツリーの階層、レイアウト、展開・折り畳み操作の変更。
+- Sequence / Fanout の workflow 上の意味、実行規則、backend の型および外部インターフェースの変更。
+- Sequence の代替アイコン候補を再選定すること。
+
+# Requirements
+
+- R-001: Workspace ツリーのトップレベルおよび入れ子のすべての Sequence 行は、Node 種別アイコンとして `Waypoints` を表示する。
+- R-002: Sequence 行の `Waypoints` は14pxで表示され、既存の状態分類に基づく色と pulse の規則をそのまま反映する。
+- R-003: Fanout 行は、Node 種別アイコンとして既存の `GitFork` を引き続き表示する。
+
+# Assumptions / Open Questions
+
+なし。

--- a/src/components/workspace/WorkspaceList.test.tsx
+++ b/src/components/workspace/WorkspaceList.test.tsx
@@ -195,19 +195,28 @@ const recursiveTree: WorkspaceTreeItem[] = [
 				updatedAt: 4,
 				children: [
 					{
-						kind: "node",
-						id: "fanout-child-internal-uuid",
-						title: "Architecture review",
-						status: "active",
-						contentKind: "command",
-						capabilities: {
-							canApprove: false,
-							canRetry: false,
-							canClose: false,
-						},
-						pastAttempts: [],
-						pastAttemptsCollapsed: false,
+						kind: "sequence",
+						id: "review-sequence-internal-uuid",
+						title: "Review sequence",
+						status: "attention",
 						updatedAt: 5,
+						children: [
+							{
+								kind: "node",
+								id: "fanout-child-internal-uuid",
+								title: "Architecture review",
+								status: "active",
+								contentKind: "command",
+								capabilities: {
+									canApprove: false,
+									canRetry: false,
+									canClose: false,
+								},
+								pastAttempts: [],
+								pastAttemptsCollapsed: false,
+								updatedAt: 6,
+							},
+						],
 					},
 				],
 			},
@@ -383,22 +392,30 @@ describe("WorkspaceList", () => {
 		expect(within(section).queryByRole("button")).not.toBeInTheDocument();
 	});
 
-	it("renders the backend-owned recursive Workflow and Fanout hierarchy", () => {
+	it("renders Waypoints for top-level and nested Sequence rows while keeping GitFork for Fanout", () => {
 		const { container } = renderWorkspaceList();
 
 		expect(screen.getByText("Release workflow")).toBeInTheDocument();
 		expect(screen.getByText("Review all")).toBeInTheDocument();
+		expect(screen.getByText("Review sequence")).toBeInTheDocument();
 		expect(screen.getByText("Architecture review")).toBeInTheDocument();
 		expect(
 			screen
 				.getByRole("button", { name: "Release workflow" })
-				.querySelector("svg.lucide-list-tree"),
+				.querySelector("svg.lucide-waypoints"),
+		).toBeInTheDocument();
+		expect(
+			screen
+				.getByRole("button", { name: "Review sequence" })
+				.querySelector("svg.lucide-waypoints"),
 		).toBeInTheDocument();
 		expect(
 			screen
 				.getByRole("button", { name: "Review all" })
 				.querySelector("svg.lucide-git-fork"),
 		).toBeInTheDocument();
+		expect(container.querySelectorAll("svg.lucide-waypoints")).toHaveLength(2);
+		expect(container.querySelectorAll("svg.lucide-list-tree")).toHaveLength(0);
 		expect(container.querySelectorAll("svg.lucide-git-fork")).toHaveLength(1);
 	});
 
@@ -441,13 +458,14 @@ describe("WorkspaceList", () => {
 		);
 		mocks.treeStateOverrides.set("/repo/wt", { nodes });
 
-		renderWorkspaceList();
+		const { container } = renderWorkspaceList();
 
 		for (const { title, colorClasses, pulses } of cases) {
 			const icon = screen
 				.getByRole("button", { name: title })
-				.querySelector("svg.lucide-list-tree");
+				.querySelector("svg.lucide-waypoints");
 			expect(icon).toBeInTheDocument();
+			expect(icon).toHaveClass("size-3.5");
 			expect(icon).toHaveClass(...colorClasses);
 			if (pulses) {
 				expect(icon).toHaveClass("animate-pulse");
@@ -455,6 +473,7 @@ describe("WorkspaceList", () => {
 				expect(icon).not.toHaveClass("animate-pulse");
 			}
 		}
+		expect(container.querySelectorAll("svg.lucide-list-tree")).toHaveLength(0);
 	});
 
 	it("backendが絞り込んだStandalone Session Nodeを選択できる", async () => {

--- a/src/components/workspace/WorkspaceList.tsx
+++ b/src/components/workspace/WorkspaceList.tsx
@@ -10,7 +10,6 @@ import {
 	GitBranch,
 	GitPullRequest,
 	Home,
-	ListTree,
 	Loader2,
 	MessageSquare,
 	MoreHorizontal,
@@ -21,6 +20,7 @@ import {
 	Square,
 	Terminal,
 	Trash2,
+	Waypoints,
 	Workflow,
 	X,
 } from "lucide-react";
@@ -403,7 +403,7 @@ function WorkspaceBranchRow({
 					{item.kind === "fanout" ? (
 						<FanoutRowStatusIcon status={item.status} />
 					) : (
-						<WorkspaceBranchStatusIcon status={item.status} icon={ListTree} />
+						<WorkspaceBranchStatusIcon status={item.status} icon={Waypoints} />
 					)}
 					<span className="min-w-0 truncate">{item.title}</span>
 					{expanded ? (


### PR DESCRIPTION
## 概要

Workspace ツリーの Sequence 行で、ツリー自体と形状が重複し Fanout と判別しにくかった `ListTree` アイコンを、分岐なしの経路を表す `Waypoints` に変更します。

## 変更内容

- トップレベルと入れ子の Sequence 行に `Waypoints` を表示
- 既存の14pxサイズ、状態色、pulse の規則を維持
- Fanout 行の `GitFork` が維持されることを回帰テストで確認
- Issue #1721 の要件、Behavior、設計を Spec に記録

## 検証

- `pnpm test -- src/components/workspace/WorkspaceList.test.tsx`（90 files・962 tests passed）
- `pnpm lint`（243 files passed）

Closes #1721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Workspace ツリーの Sequence 行アイコンを、より適切な「Waypoints」に変更しました。
  - トップレベルおよび入れ子の Sequence 行に適用されます。
  - Fanout 行の「GitFork」アイコンは従来どおり維持されます。
  - アイコンのサイズや状態に応じた色・アニメーション表示は変更ありません。

- **ドキュメント**
  - Sequence 行の表示仕様と設計内容を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->